### PR TITLE
feat: add public API key usage query endpoint and /manage/ route

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ docker compose up -d
 
 Set your AI tool's API base to `http://localhost:8317` and start coding!
 
+**Example: OpenAI Codex (`~/.codex/config.toml`)**
+```toml
+[model_providers.tabcode]
+name = "openai"
+base_url = "http://localhost:8317/v1"
+requires_openai_auth = true
+```
+
 > 📖 **Full setup guides →** [help.router-for.me](https://help.router-for.me/)
 
 ## 🖥️ Management Panel

--- a/README_CN.md
+++ b/README_CN.md
@@ -84,6 +84,14 @@ docker compose up -d
 
 将 AI 工具的 API 地址设为 `http://localhost:8317`，开始编码！
 
+**示例：OpenAI Codex (`~/.codex/config.toml`)**
+```toml
+[model_providers.tabcode]
+name = "openai"
+base_url = "http://localhost:8317/v1"
+requires_openai_auth = true
+```
+
 > 📖 **完整教程 →** [help.router-for.me](https://help.router-for.me/cn/)
 
 ## 🖥️ 管理面板

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -3,6 +3,7 @@ package management
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -42,6 +43,47 @@ func (h *Handler) ExportUsageStatistics(c *gin.Context) {
 		Version:    1,
 		ExportedAt: time.Now().UTC(),
 		Usage:      snapshot,
+	})
+}
+
+// GetPublicUsageByAPIKey returns usage statistics for a specific API key.
+// This endpoint is designed for public access (no management key required).
+func (h *Handler) GetPublicUsageByAPIKey(c *gin.Context) {
+	apiKey := strings.TrimSpace(c.Query("api_key"))
+	if apiKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+		return
+	}
+
+	var snapshot usage.StatisticsSnapshot
+	if h != nil && h.usageStats != nil {
+		snapshot = h.usageStats.Snapshot()
+	}
+
+	// Find the matching API key entry
+	apiData, found := snapshot.APIs[apiKey]
+	if !found {
+		c.JSON(http.StatusOK, gin.H{
+			"usage": usage.StatisticsSnapshot{
+				APIs: map[string]usage.APISnapshot{},
+			},
+			"api_key": apiKey,
+			"found":   false,
+		})
+		return
+	}
+
+	// Return only the matched API key's data
+	filteredSnapshot := usage.StatisticsSnapshot{
+		APIs: map[string]usage.APISnapshot{
+			apiKey: apiData,
+		},
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"usage":   filteredSnapshot,
+		"api_key": apiKey,
+		"found":   true,
 	})
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -323,6 +323,8 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 // It defines the endpoints and associates them with their respective handlers.
 func (s *Server) setupRoutes() {
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
+	s.engine.GET("/manage", s.serveManagementControlPanel)
+	s.engine.GET("/manage/*filepath", s.serveManagementControlPanel)
 	openaiHandlers := openai.NewOpenAIAPIHandler(s.handlers)
 	geminiHandlers := gemini.NewGeminiAPIHandler(s.handlers)
 	geminiCLIHandlers := gemini.NewGeminiCLIAPIHandler(s.handlers)
@@ -652,6 +654,13 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.POST("/iflow-auth-url", s.mgmt.RequestIFlowCookieToken)
 		mgmt.POST("/oauth-callback", s.mgmt.PostOAuthCallback)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)
+	}
+
+	// Public endpoints - no management key required
+	pub := s.engine.Group("/v0/management/public")
+	pub.Use(s.managementAvailabilityMiddleware())
+	{
+		pub.GET("/usage", s.mgmt.GetPublicUsageByAPIKey)
 	}
 }
 


### PR DESCRIPTION
## Changes

- Add `GetPublicUsageByAPIKey` handler for public API key usage data query
- Add `/v0/management/public/usage?api_key=xxx` endpoint (no admin auth required)
- Add `/manage/*` route to serve management control panel (cleaner URL)
- Users can query their own API key usage statistics without admin login

## Endpoints Added

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/v0/management/public/usage?api_key=xxx` | None | Query usage stats for a specific API key |
| GET | `/manage/*` | None | Serve management panel (clean URL) |