### PR TITLE
fix(management): gracefully return nil to honor environment proxies

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -660,13 +660,7 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 		}
 	}
 
-	transport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok || transport == nil {
-		return &http.Transport{Proxy: nil}
-	}
-	clone := transport.Clone()
-	clone.Proxy = nil
-	return clone
+	return nil
 }
 
 func buildProxyTransport(proxyStr string) *http.Transport {


### PR DESCRIPTION
### Background
When calling the management API probe via `/v0/management/api-call`, the outbound HTTP requests fall into a 30-second TCP SYN timeout blackhole if the host relies on `HTTP_PROXY` environment variables for outbound access (e.g. in GFW environments).

### Cause
The legacy code was deeply cloning and explicitly overriding the transport proxy property with `clone.Proxy = nil`. By stripping out Go's native proxy handlers, requests are forced to bypass configured transparent sidecar proxies, dropping connections.

### Fix
If no custom proxy configurations are provided globally or per auth, `apiCallTransport` now simply returns `nil`. This idiomatically delegates Transport directly down to Go's `http.DefaultTransport`, which handles standard system variables (`HTTP_PROXY`, `NO_PROXY`, SOCKS5 variants) flawlessly out-of-the-box and guarantees deep keep-alive connection pool reuse.