### PR TITLE
fix: handle websocket generate=false prewarm locally

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -141,6 +141,25 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		lastRequest = updatedLastRequest
 
+		if prewarmPayloads, ok := responsesWebsocketPrewarmPayloads(requestJSON); ok {
+			for _, prewarmPayload := range prewarmPayloads {
+				markAPIResponseTimestamp(c)
+				appendWebsocketEvent(&wsBodyLog, "response", prewarmPayload)
+				if errWrite := conn.WriteMessage(websocket.TextMessage, prewarmPayload); errWrite != nil {
+					log.Warnf(
+						"responses websocket: prewarm write failed id=%s event=%s error=%v",
+						passthroughSessionID,
+						websocketPayloadEventType(prewarmPayload),
+						errWrite,
+					)
+					wsTerminateErr = errWrite
+					return
+				}
+			}
+			lastResponseOutput = []byte("[]")
+			continue
+		}
+
 		modelName := gjson.GetBytes(requestJSON, "model").String()
 		cliCtx, cliCancel := h.GetContextWithCancel(h, c, c.Request.Context())
 		cliCtx = cliproxyexecutor.WithDownstreamWebsocket(cliCtx)
@@ -376,6 +395,17 @@ func normalizeJSONArrayRaw(raw []byte) string {
 		return trimmed
 	}
 	return "[]"
+}
+
+func responsesWebsocketPrewarmPayloads(requestJSON []byte) ([][]byte, bool) {
+	if !gjson.GetBytes(requestJSON, "generate").Exists() || gjson.GetBytes(requestJSON, "generate").Bool() {
+		return nil, false
+	}
+
+	syntheticID := "resp_prewarm_" + uuid.NewString()
+	created := []byte(fmt.Sprintf(`{"type":"response.created","response":{"id":%q}}`, syntheticID))
+	done := []byte(fmt.Sprintf(`{"type":"response.done","response":{"id":%q,"output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`, syntheticID))
+	return [][]byte{created, done}, true
 }
 
 func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -32,6 +32,49 @@ func TestNormalizeResponsesWebsocketRequestCreate(t *testing.T) {
 	}
 }
 
+func TestResponsesWebsocketPrewarmPayloads(t *testing.T) {
+	requestJSON := []byte(`{"model":"test-model","generate":false,"stream":true,"input":[]}`)
+
+	payloads, ok := responsesWebsocketPrewarmPayloads(requestJSON)
+	if !ok {
+		t.Fatalf("expected prewarm payloads")
+	}
+	if len(payloads) != 2 {
+		t.Fatalf("payload len = %d, want 2", len(payloads))
+	}
+	if gjson.GetBytes(payloads[0], "type").String() != "response.created" {
+		t.Fatalf("unexpected created payload type: %s", gjson.GetBytes(payloads[0], "type").String())
+	}
+	if gjson.GetBytes(payloads[1], "type").String() != "response.done" {
+		t.Fatalf("unexpected done payload type: %s", gjson.GetBytes(payloads[1], "type").String())
+	}
+	responseID := gjson.GetBytes(payloads[0], "response.id").String()
+	if responseID == "" {
+		t.Fatalf("created payload missing response id")
+	}
+	if gjson.GetBytes(payloads[1], "response.id").String() != responseID {
+		t.Fatalf("done payload response id mismatch")
+	}
+	if len(gjson.GetBytes(payloads[1], "response.output").Array()) != 0 {
+		t.Fatalf("done payload output must be empty")
+	}
+	if gjson.GetBytes(payloads[1], "response.usage.total_tokens").Int() != 0 {
+		t.Fatalf("done payload total_tokens must be 0")
+	}
+}
+
+func TestResponsesWebsocketPrewarmPayloadsDisabledForGenerateTrue(t *testing.T) {
+	requestJSON := []byte(`{"model":"test-model","generate":true,"stream":true,"input":[]}`)
+
+	payloads, ok := responsesWebsocketPrewarmPayloads(requestJSON)
+	if ok {
+		t.Fatalf("generate=true must not be treated as prewarm")
+	}
+	if payloads != nil {
+		t.Fatalf("expected nil payloads when generate=true")
+	}
+}
+
 func TestNormalizeResponsesWebsocketRequestCreateWithHistory(t *testing.T) {
 	lastRequest := []byte(`{"model":"test-model","stream":true,"input":[{"type":"message","id":"msg-1"}]}`)
 	lastResponseOutput := []byte(`[


### PR DESCRIPTION
## Summary
- handle websocket `generate: false` prewarm requests locally instead of forwarding them upstream
- synthesize `response.created` and `response.done` events with a response id so follow-up requests can reuse session state
- add unit coverage for prewarm payload generation

## Testing
- `go test -run 'Test(Response|Normalize|Websocket|Append|Set)' ./sdk/api/handlers/openai`
