### PR TITLE
fix: handle codex image response failures

### DIFF
--- a/internal/runtime/executor/codex_executor_image_test.go
+++ b/internal/runtime/executor/codex_executor_image_test.go
@@ -554,6 +554,135 @@ func TestCodexExecutorExecuteImageGenerationViaResponsesToolChoice(t *testing.T)
 	}
 }
 
+func TestCodexExecutorExecuteImageGenerationRetriesResponsesFailedRateLimit(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/backend-api/codex/responses" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		if attempts.Add(1) == 1 {
+			_, _ = w.Write([]byte(
+				"data: {\"type\":\"response.created\",\"response\":{\"created_at\":1710000002}}\n\n" +
+					"data: {\"type\":\"error\",\"error\":{\"type\":\"input-images\",\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit reached for gpt-image-2. Please try again in 1ms.\"}}\n\n" +
+					"data: {\"type\":\"response.failed\",\"response\":{\"created_at\":1710000002,\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit reached for gpt-image-2. Please try again in 1ms.\"}}}\n\n" +
+					"data: [DONE]\n\n",
+			))
+			return
+		}
+		_, _ = w.Write([]byte(
+			"data: {\"type\":\"response.created\",\"response\":{\"created_at\":1710000003}}\n\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000003,\"output\":[{\"type\":\"image_generation_call\",\"result\":\"Z2VuZXJhdGVk\",\"revised_prompt\":\"retried image\"}]}}\n\n" +
+				"data: [DONE]\n\n",
+		))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "codex-auth-generation-retry",
+		Provider: "codex",
+		Status:   cliproxyauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url": server.URL + "/backend-api/codex",
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"account_id":   "account-1",
+		},
+	}
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-image-2",
+		Payload: []byte(`{"model":"gpt-image-2","prompt":"给我绘制一个 springboot 的系统架构图"}`),
+		Format:  sdktranslator.FromString("openai"),
+	}, cliproxyexecutor.Options{
+		Alt:          "images/generations",
+		SourceFormat: sdktranslator.FromString("openai"),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts.Load())
+	}
+
+	var payload struct {
+		Data []struct {
+			B64JSON       string `json:"b64_json"`
+			RevisedPrompt string `json:"revised_prompt"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Payload, &payload); err != nil {
+		t.Fatalf("Unmarshal payload: %v", err)
+	}
+	if len(payload.Data) != 1 {
+		t.Fatalf("data length = %d, want 1", len(payload.Data))
+	}
+	if payload.Data[0].B64JSON != "Z2VuZXJhdGVk" {
+		t.Fatalf("b64_json = %q, want generated image", payload.Data[0].B64JSON)
+	}
+	if payload.Data[0].RevisedPrompt != "retried image" {
+		t.Fatalf("revised_prompt = %q, want retried image", payload.Data[0].RevisedPrompt)
+	}
+}
+
+func TestCodexExecutorExecuteImageGenerationReturnsResponsesFailedRateLimit(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/backend-api/codex/responses" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(
+			"data: {\"type\":\"response.created\",\"response\":{\"created_at\":1710000002}}\n\n" +
+				"data: {\"type\":\"response.failed\",\"response\":{\"created_at\":1710000002,\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit reached for gpt-image-2. Please try again in 1ms.\"}}}\n\n" +
+				"data: [DONE]\n\n",
+		))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "codex-auth-generation-rate-limit",
+		Provider: "codex",
+		Status:   cliproxyauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url": server.URL + "/backend-api/codex",
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"account_id":   "account-1",
+		},
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-image-2",
+		Payload: []byte(`{"model":"gpt-image-2","prompt":"draw a fox"}`),
+		Format:  sdktranslator.FromString("openai"),
+	}, cliproxyexecutor.Options{
+		Alt:          "images/generations",
+		SourceFormat: sdktranslator.FromString("openai"),
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want rate limit error")
+	}
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("Execute() error type = %T, want statusErr", err)
+	}
+	if status.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("StatusCode() = %d, want 429", status.StatusCode())
+	}
+	if !strings.Contains(status.Error(), "rate_limit_exceeded") || strings.Contains(status.Error(), "stream disconnected") {
+		t.Fatalf("error = %q, want upstream rate limit without disconnected message", status.Error())
+	}
+	if attempts.Load() != 3 {
+		t.Fatalf("attempts = %d, want 3 retries including initial attempt", attempts.Load())
+	}
+}
+
 func TestUsageReporterTrackFailureStoresErrorContent(t *testing.T) {
 	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
 	cliproxyusage.RegisterPlugin(usagePlugin)

--- a/internal/runtime/executor/codex_image_executor.go
+++ b/internal/runtime/executor/codex_image_executor.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,8 @@ const (
 	codexImageConversationTimout = 5 * time.Minute
 	codexImageMaxN               = 4
 	codexImageMaxUploads         = 5
+	codexImageResponsesMaxTries  = 3
+	codexImageResponsesMaxRetry  = 2 * time.Second
 )
 
 var codexImageChatGPTBaseURL = "https://chatgpt.com"
@@ -977,68 +980,80 @@ func (e *CodexExecutor) executeCodexImageViaResponses(
 		return nil, nil, statusErr{code: http.StatusBadRequest, msg: err.Error()}
 	}
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, nil, err
-	}
-	applyCodexHeaders(httpReq, e.cfg, auth, apiKey, true)
-
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
 		authLabel = auth.Label
 		authType, authValue = auth.AccountInfo()
 	}
-	recordAPIRequest(ctx, e.cfg, upstreamRequestLog{
-		URL:       url,
-		Method:    http.MethodPost,
-		Headers:   httpReq.Header.Clone(),
-		Body:      body,
-		Provider:  e.Identifier(),
-		AuthID:    authID,
-		AuthLabel: authLabel,
-		AuthType:  authType,
-		AuthValue: authValue,
-	})
 
 	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpResp, err := httpClient.Do(httpReq)
-	if err != nil {
-		recordAPIResponseError(ctx, e.cfg, err)
-		return nil, nil, err
-	}
-	defer func() {
-		if httpResp != nil && httpResp.Body != nil {
-			_ = httpResp.Body.Close()
+	var lastErr error
+	for attempt := 1; attempt <= codexImageResponsesMaxTries; attempt++ {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, nil, err
 		}
-	}()
-	recordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
-		upstreamBody := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
-		appendAPIResponseChunk(ctx, e.cfg, upstreamBody)
-		return nil, nil, newCodexStatusErr(httpResp.StatusCode, upstreamBody)
-	}
+		applyCodexHeaders(httpReq, e.cfg, auth, apiKey, true)
+		recordAPIRequest(ctx, e.cfg, upstreamRequestLog{
+			URL:       url,
+			Method:    http.MethodPost,
+			Headers:   httpReq.Header.Clone(),
+			Body:      body,
+			Provider:  e.Identifier(),
+			AuthID:    authID,
+			AuthLabel: authLabel,
+			AuthType:  authType,
+			AuthValue: authValue,
+		})
 
-	rawBody, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
-	if err != nil {
-		recordAPIResponseError(ctx, e.cfg, err)
-		return nil, nil, err
-	}
-	appendAPIResponseChunk(ctx, e.cfg, rawBody)
+		httpResp, err := httpClient.Do(httpReq)
+		if err != nil {
+			recordAPIResponseError(ctx, e.cfg, err)
+			return nil, nil, err
+		}
+		recordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+		if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+			upstreamBody := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+			_ = httpResp.Body.Close()
+			appendAPIResponseChunk(ctx, e.cfg, upstreamBody)
+			return nil, nil, newCodexStatusErr(httpResp.StatusCode, upstreamBody)
+		}
 
-	results, createdAt, err := collectCodexImagesFromResponsesBody(rawBody)
-	if err != nil {
-		return nil, nil, err
+		rawBody, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
+		responseHeaders := httpResp.Header.Clone()
+		_ = httpResp.Body.Close()
+		if err != nil {
+			recordAPIResponseError(ctx, e.cfg, err)
+			return nil, nil, err
+		}
+		appendAPIResponseChunk(ctx, e.cfg, rawBody)
+
+		results, createdAt, err := collectCodexImagesFromResponsesBody(rawBody)
+		if err != nil {
+			lastErr = err
+			if retryDelay, ok := codexImageResponsesRetryDelay(err, attempt); ok {
+				if waitErr := waitCodexImageResponsesRetry(ctx, retryDelay); waitErr != nil {
+					return nil, nil, waitErr
+				}
+				continue
+			}
+			return nil, nil, err
+		}
+		if len(results) == 0 {
+			return nil, nil, statusErr{code: http.StatusBadGateway, msg: "responses image request returned no generated images"}
+		}
+		payload, err := buildCodexImageOpenAIResponseFromResults(results, createdAt)
+		if err != nil {
+			return nil, nil, err
+		}
+		_ = originalPayload
+		return payload, responseHeaders, nil
 	}
-	if len(results) == 0 {
-		return nil, nil, statusErr{code: http.StatusBadGateway, msg: "responses image request returned no generated images"}
+	if lastErr != nil {
+		return nil, nil, lastErr
 	}
-	payload, err := buildCodexImageOpenAIResponseFromResults(results, createdAt)
-	if err != nil {
-		return nil, nil, err
-	}
-	_ = originalPayload
-	return payload, httpResp.Header.Clone(), nil
+	return nil, nil, statusErr{code: http.StatusBadGateway, msg: "responses image request failed"}
 }
 
 func buildCodexImageResponsesRequest(parsed *codexImageRequest, toolModel string) ([]byte, error) {
@@ -1139,6 +1154,7 @@ func collectCodexImagesFromResponsesBody(body []byte) ([]codexResponsesImageResu
 		fallbackSeen    = make(map[string]struct{})
 		createdAt       int64
 		foundFinal      bool
+		streamErr       error
 	)
 	for _, line := range bytes.Split(body, []byte("\n")) {
 		line = bytes.TrimRight(line, "\r")
@@ -1152,6 +1168,8 @@ func collectCodexImagesFromResponsesBody(body []byte) ([]codexResponsesImageResu
 		}
 		eventType := gjson.GetBytes(payload, "type").String()
 		switch eventType {
+		case "error":
+			streamErr = codexResponsesFailedStatusErr(payload)
 		case "response.output_item.done":
 			result, itemID, ok := extractCodexImageFromResponsesOutputItemDone(payload)
 			if !ok {
@@ -1175,6 +1193,8 @@ func collectCodexImagesFromResponsesBody(body []byte) ([]codexResponsesImageResu
 				return results, createdAt, nil
 			}
 			foundFinal = true
+		case "response.failed":
+			return nil, createdAt, codexResponsesFailedStatusErr(payload)
 		case "response.created":
 			if createdAt == 0 {
 				createdAt = gjson.GetBytes(payload, "response.created_at").Int()
@@ -1187,10 +1207,113 @@ func collectCodexImagesFromResponsesBody(body []byte) ([]codexResponsesImageResu
 	if len(fallbackResults) > 0 {
 		return fallbackResults, createdAt, nil
 	}
+	if streamErr != nil {
+		return nil, createdAt, streamErr
+	}
 	if foundFinal {
 		return nil, createdAt, nil
 	}
 	return nil, createdAt, fmt.Errorf("stream disconnected before response.completed")
+}
+
+func codexResponsesFailedStatusErr(payload []byte) statusErr {
+	message := strings.TrimSpace(gjson.GetBytes(payload, "response.error.message").String())
+	if message == "" {
+		message = strings.TrimSpace(gjson.GetBytes(payload, "error.message").String())
+	}
+	code := strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String())
+	if code == "" {
+		code = strings.TrimSpace(gjson.GetBytes(payload, "error.code").String())
+	}
+	errType := strings.TrimSpace(gjson.GetBytes(payload, "response.error.type").String())
+	if errType == "" {
+		errType = strings.TrimSpace(gjson.GetBytes(payload, "error.type").String())
+	}
+	statusCode := http.StatusBadGateway
+	if strings.Contains(code, "rate_limit") || strings.Contains(errType, "rate_limit") {
+		statusCode = http.StatusTooManyRequests
+		errType = "rate_limit_error"
+	}
+	if message == "" {
+		message = "responses image request failed"
+	}
+	if errType == "" {
+		errType = "upstream_error"
+	}
+	body, _ := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    errType,
+			"code":    code,
+		},
+	})
+	err := statusErr{code: statusCode, msg: string(body), upstreamBody: body}
+	if retryAfter := codexImageResponsesRetryAfter(message); retryAfter > 0 {
+		err.retryAfter = &retryAfter
+	}
+	return err
+}
+
+func codexImageResponsesRetryDelay(err error, attempt int) (time.Duration, bool) {
+	if attempt >= codexImageResponsesMaxTries {
+		return 0, false
+	}
+	status, ok := err.(statusErr)
+	if !ok || status.code != http.StatusTooManyRequests || status.retryAfter == nil {
+		return 0, false
+	}
+	if *status.retryAfter <= 0 || *status.retryAfter > codexImageResponsesMaxRetry {
+		return 0, false
+	}
+	return *status.retryAfter, true
+}
+
+func waitCodexImageResponsesRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+var codexImageRetryAfterPattern = regexp.MustCompile(`(?i)try again in\s+([0-9]+(?:\.[0-9]+)?\s*(?:ms|s|sec|secs|second|seconds|m|min|mins|minute|minutes))`)
+
+func codexImageResponsesRetryAfter(message string) time.Duration {
+	match := codexImageRetryAfterPattern.FindStringSubmatch(message)
+	if len(match) < 2 {
+		return 0
+	}
+	value := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(match[1]), " ", ""))
+	replacements := []struct {
+		suffix string
+		with   string
+	}{
+		{suffix: "seconds", with: "s"},
+		{suffix: "second", with: "s"},
+		{suffix: "secs", with: "s"},
+		{suffix: "sec", with: "s"},
+		{suffix: "minutes", with: "m"},
+		{suffix: "minute", with: "m"},
+		{suffix: "mins", with: "m"},
+		{suffix: "min", with: "m"},
+	}
+	for _, replacement := range replacements {
+		if strings.HasSuffix(value, replacement.suffix) {
+			value = strings.TrimSuffix(value, replacement.suffix) + replacement.with
+			break
+		}
+	}
+	delay, err := time.ParseDuration(value)
+	if err != nil {
+		return 0
+	}
+	return delay
 }
 
 func extractCodexImagesFromResponsesCompleted(payload []byte) ([]codexResponsesImageResult, int64, error) {


### PR DESCRIPTION
## Summary
- Treat Codex Responses `response.failed` and `error` events as terminal upstream errors instead of disconnected streams.
- Retry short `rate_limit_exceeded` image failures when upstream asks to retry shortly.
- Add regression coverage for transient and exhausted gpt-image-2 rate-limit failed events.

## Test Plan
- go test ./internal/runtime/executor -run 'TestCodexExecutorExecuteImageGenerationRetriesResponsesFailedRateLimit|TestCodexExecutorExecuteImageGenerationReturnsResponsesFailedRateLimit' -count=1\n- go test ./internal/runtime/executor -count=1\n- go test ./sdk/api/handlers/openai -count=1\n- go test ./... -count=1\n- go vet ./...\n- gofmt check\n- git diff --check\n- golangci-lint run --config .golangci.yml