### PR TITLE
fix: avoid request body read timeout

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -51,9 +51,7 @@ import (
 )
 
 const (
-	oauthCallbackSuccessHTML = `<html><head><meta charset="utf-8"><title>Authentication successful</title><script>setTimeout(function(){window.close();},5000);</script></head><body><h1>Authentication successful!</h1><p>You can close this window.</p><p>This window will close automatically in 5 seconds.</p></body></html>`
-	// Main API requests can legitimately spend several minutes waiting on upstream model execution.
-	// Long-lived SSE and websocket routes explicitly clear this deadline before streaming/upgrading.
+	oauthCallbackSuccessHTML  = `<html><head><meta charset="utf-8"><title>Authentication successful</title><script>setTimeout(function(){window.close();},5000);</script></head><body><h1>Authentication successful!</h1><p>You can close this window.</p><p>This window will close automatically in 5 seconds.</p></body></html>`
 	mainAPIServerWriteTimeout = 10 * time.Minute
 )
 
@@ -342,7 +340,6 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 		Addr:              fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
 		Handler:           engine,
 		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      mainAPIServerWriteTimeout,
 		IdleTimeout:       2 * time.Minute,
 		MaxHeaderBytes:    1 << 20,


### PR DESCRIPTION
## Summary
- remove the API server-wide 30s ReadTimeout so large or slow request bodies are not interrupted while being read
- keep ReadHeaderTimeout and the existing long WriteTimeout for API execution

## Root cause
The server wrapped request body read failures as `Invalid request`. With ReadTimeout set to 30s, Go net/http can abort body reads for larger or slower client uploads, producing errors like `read tcp ... i/o timeout`.

## Tests
- go test ./internal/api
- go test ./...