### PR TITLE
fix: guard proxy pool handler lock

### DIFF
--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -31,9 +31,9 @@ func (h *Handler) GetProxyPool(c *gin.Context) {
 	var entries []config.ProxyPoolEntry
 	if usage.ProxyPoolStoreAvailable() {
 		entries = usage.ListProxyPool()
-	} else {
+	} else if h != nil {
 		h.mu.Lock()
-		if h != nil && h.cfg != nil {
+		if h.cfg != nil {
 			entries = append(entries, h.cfg.ProxyPool...)
 		}
 		h.mu.Unlock()


### PR DESCRIPTION
## Summary
- guard proxy pool handler mutex access when the handler receiver is nil
- keep existing proxy pool response behavior unchanged

## Test Plan
- gofmt -l .
- secret smoke scan
- go vet ./...
- go test ./...
- golangci-lint run --config .golangci.yml
- go build -o test-output ./cmd/server