### PR TITLE
fix: ignore canceled requests in usage logs

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -539,6 +539,10 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			}
 		}
 		if errScan := scanner.Err(); errScan != nil {
+			if shouldSuppressUsageFailure(errScan, "") {
+				out <- cliproxyexecutor.StreamChunk{Err: errScan}
+				return
+			}
 			recordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.publishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}

--- a/internal/runtime/executor/usage_helpers.go
+++ b/internal/runtime/executor/usage_helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -122,6 +123,9 @@ func (r *usageReporter) publishFailureWithContent(ctx context.Context, inputCont
 	if r == nil {
 		return
 	}
+	if shouldSuppressUsageFailure(nil, outputContent) {
+		return
+	}
 	r.contentMu.Lock()
 	r.inputContent = inputContent
 	r.outputContent = outputContent
@@ -134,6 +138,9 @@ func (r *usageReporter) trackFailure(ctx context.Context, errPtr *error) {
 		return
 	}
 	if *errPtr != nil {
+		if shouldSuppressUsageFailure(*errPtr, "") {
+			return
+		}
 		r.contentMu.Lock()
 		if r.outputContent == "" && r.outputBuilder.Len() == 0 && r.outputFile == nil {
 			r.outputContent = structuredUpstreamErrorJSON(*errPtr)
@@ -141,6 +148,13 @@ func (r *usageReporter) trackFailure(ctx context.Context, errPtr *error) {
 		r.contentMu.Unlock()
 		r.publishFailure(ctx)
 	}
+}
+
+func shouldSuppressUsageFailure(err error, outputContent string) bool {
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(outputContent), "context canceled")
 }
 
 type upstreamBodyError interface {

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -80,6 +81,34 @@ func TestUsageReporterSpillsLargeStreamingOutputToTempFile(t *testing.T) {
 	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
 		t.Fatalf("expected temp file to be removed, stat err=%v", err)
 	}
+}
+
+func TestShouldSuppressUsageFailureForContextCanceled(t *testing.T) {
+	if !shouldSuppressUsageFailure(context.Canceled, "") {
+		t.Fatal("context.Canceled should not be published as a failed usage record")
+	}
+	wrapped := &urlErrorForTest{err: context.Canceled}
+	if !shouldSuppressUsageFailure(wrapped, "") {
+		t.Fatal("wrapped context.Canceled should not be published as a failed usage record")
+	}
+	if !shouldSuppressUsageFailure(nil, `Post "https://chatgpt.com/backend-api/codex/responses": context canceled`) {
+		t.Fatal("context canceled output text should not be published as a failed usage record")
+	}
+	if shouldSuppressUsageFailure(errors.New("upstream 500"), "") {
+		t.Fatal("ordinary upstream errors should still be published as failed usage records")
+	}
+}
+
+type urlErrorForTest struct {
+	err error
+}
+
+func (e *urlErrorForTest) Error() string {
+	return `Post "https://chatgpt.com/backend-api/codex/responses": ` + e.err.Error()
+}
+
+func (e *urlErrorForTest) Unwrap() error {
+	return e.err
 }
 
 func TestRequestDetailsCaptureUpstreamLogsWhenOnlyContentStorageEnabled(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat user-canceled upstream requests (`context.Canceled` / `context canceled`) as non-error usage outcomes
- Skip publishing failed usage records for canceled Codex stream scanner errors
- Add regression coverage for canceled request suppression

## Tests
- `go test ./internal/runtime/executor -run TestShouldSuppressUsageFailureForContextCanceled`
- `go test ./internal/runtime/executor`
- `go test ./sdk/api/handlers/openai`
- `go test ./...`