### PR TITLE
feat: expose auth subscription expiry

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -41,7 +41,18 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-var lastRefreshKeys = []string{"last_refresh", "lastRefresh", "last_refreshed_at", "lastRefreshedAt"}
+var (
+	lastRefreshKeys               = []string{"last_refresh", "lastRefresh", "last_refreshed_at", "lastRefreshedAt"}
+	subscriptionExpirationKeys    = []string{"subscription_expires_at", "subscriptionExpiresAt"}
+	subscriptionExpirationLayouts = []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02T15:04",
+	}
+)
 
 const (
 	anthropicCallbackPort                     = 54545
@@ -121,6 +132,84 @@ func parseLastRefreshValue(v any) (time.Time, bool) {
 		}
 	}
 	return time.Time{}, false
+}
+
+func extractSubscriptionExpirationTimestamp(meta map[string]any) (time.Time, bool) {
+	if len(meta) == 0 {
+		return time.Time{}, false
+	}
+	for _, key := range subscriptionExpirationKeys {
+		if val, ok := meta[key]; ok {
+			if ts, okParse := parseSubscriptionExpirationValue(val); okParse && !ts.IsZero() {
+				return ts.UTC(), true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+func parseSubscriptionExpirationValue(v any) (time.Time, bool) {
+	switch val := v.(type) {
+	case string:
+		s := strings.TrimSpace(val)
+		if s == "" {
+			return time.Time{}, false
+		}
+		for _, layout := range subscriptionExpirationLayouts {
+			if ts, err := time.Parse(layout, s); err == nil {
+				return ts.UTC(), true
+			}
+		}
+		if unix, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return normalizeSubscriptionUnix(unix), true
+		}
+	case float64:
+		return normalizeSubscriptionUnix(int64(val)), true
+	case int64:
+		return normalizeSubscriptionUnix(val), true
+	case int:
+		return normalizeSubscriptionUnix(int64(val)), true
+	case json.Number:
+		if i, err := val.Int64(); err == nil {
+			return normalizeSubscriptionUnix(i), true
+		}
+		if f, err := val.Float64(); err == nil {
+			return normalizeSubscriptionUnix(int64(f)), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func normalizeSubscriptionUnix(raw int64) time.Time {
+	if raw <= 0 {
+		return time.Time{}
+	}
+	if raw > 1_000_000_000_000 {
+		return time.UnixMilli(raw).UTC()
+	}
+	return time.Unix(raw, 0).UTC()
+}
+
+func subscriptionRemainingMinutes(now, expiresAt time.Time) int64 {
+	diff := expiresAt.Sub(now)
+	if diff == 0 {
+		return 0
+	}
+	if diff > 0 {
+		return int64((diff + time.Minute - time.Nanosecond) / time.Minute)
+	}
+	return -int64((-diff + time.Minute - time.Nanosecond) / time.Minute)
+}
+
+func addSubscriptionExpirationFields(entry gin.H, meta map[string]any, now time.Time) {
+	expiresAt, ok := extractSubscriptionExpirationTimestamp(meta)
+	if !ok {
+		return
+	}
+	entry["subscription_expires_at"] = expiresAt.Format(time.RFC3339)
+	entry["subscription_expires_at_ms"] = expiresAt.UnixMilli()
+	entry["subscription_remaining_minutes"] = subscriptionRemainingMinutes(now, expiresAt)
+	entry["subscription_expired"] = !now.Before(expiresAt)
 }
 
 func isWebUIRequest(c *gin.Context) bool {
@@ -356,6 +445,10 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 				emailValue := gjson.GetBytes(data, "email").String()
 				fileData["type"] = typeValue
 				fileData["email"] = emailValue
+				metadata := make(map[string]any)
+				if errJSON := json.Unmarshal(data, &metadata); errJSON == nil {
+					addSubscriptionExpirationFields(fileData, metadata, time.Now())
+				}
 			}
 
 			files = append(files, fileData)
@@ -407,6 +500,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 			entry["account"] = account
 		}
 	}
+	addSubscriptionExpirationFields(entry, auth.Metadata, time.Now())
 	if !auth.CreatedAt.IsZero() {
 		entry["created_at"] = auth.CreatedAt
 	}
@@ -864,12 +958,13 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	}
 
 	var req struct {
-		Name     string  `json:"name"`
-		Label    *string `json:"label"`
-		Prefix   *string `json:"prefix"`
-		ProxyURL *string `json:"proxy_url"`
-		ProxyID  *string `json:"proxy_id"`
-		Priority *int    `json:"priority"`
+		Name                  string  `json:"name"`
+		Label                 *string `json:"label"`
+		Prefix                *string `json:"prefix"`
+		ProxyURL              *string `json:"proxy_url"`
+		ProxyID               *string `json:"proxy_id"`
+		Priority              *int    `json:"priority"`
+		SubscriptionExpiresAt *string `json:"subscription_expires_at"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -958,6 +1053,25 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			delete(targetAuth.Metadata, "priority")
 		} else {
 			targetAuth.Metadata["priority"] = *req.Priority
+		}
+		changed = true
+	}
+	if req.SubscriptionExpiresAt != nil {
+		value := strings.TrimSpace(*req.SubscriptionExpiresAt)
+		if targetAuth.Metadata == nil {
+			targetAuth.Metadata = make(map[string]any)
+		}
+		if value == "" {
+			delete(targetAuth.Metadata, "subscription_expires_at")
+			delete(targetAuth.Metadata, "subscriptionExpiresAt")
+		} else {
+			ts, ok := parseSubscriptionExpirationValue(value)
+			if !ok || ts.IsZero() {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "subscription_expires_at must be a valid time"})
+				return
+			}
+			targetAuth.Metadata["subscription_expires_at"] = ts.UTC().Format(time.RFC3339)
+			delete(targetAuth.Metadata, "subscriptionExpiresAt")
 		}
 		changed = true
 	}

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -93,6 +93,139 @@ func TestPatchAuthFileFieldsUpdatesOAuthChannelLabel(t *testing.T) {
 	}
 }
 
+func TestBuildAuthFileEntryIncludesSubscriptionExpiration(t *testing.T) {
+	expiresAt := time.Now().UTC().Add(90 * time.Minute).Truncate(time.Minute)
+	auth := &coreauth.Auth{
+		ID:       "codex-subscription",
+		FileName: "codex-subscription.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "codex-subscription.json",
+		},
+		Metadata: map[string]any{
+			"subscription_expires_at": expiresAt.Format(time.RFC3339),
+		},
+	}
+
+	entry := (&Handler{}).buildAuthFileEntry(auth)
+	if entry == nil {
+		t.Fatal("expected auth file entry")
+	}
+	if got, _ := entry["subscription_expires_at"].(string); got != expiresAt.Format(time.RFC3339) {
+		t.Fatalf("subscription_expires_at = %q, want %q", got, expiresAt.Format(time.RFC3339))
+	}
+	if got, ok := entry["subscription_expires_at_ms"].(int64); !ok || got != expiresAt.UnixMilli() {
+		t.Fatalf("subscription_expires_at_ms = %#v, want %d", entry["subscription_expires_at_ms"], expiresAt.UnixMilli())
+	}
+	if got, ok := entry["subscription_remaining_minutes"].(int64); !ok || got < 89 || got > 90 {
+		t.Fatalf("subscription_remaining_minutes = %#v, want around 90", entry["subscription_remaining_minutes"])
+	}
+	if expired, _ := entry["subscription_expired"].(bool); expired {
+		t.Fatal("subscription_expired = true, want false")
+	}
+}
+
+func TestPatchAuthFileFieldsUpdatesSubscriptionExpiration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	_, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "oauth-subscription",
+		FileName: "oauth-subscription.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"email": "subscriber@example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"name":                    "oauth-subscription.json",
+		"subscription_expires_at": "2027-01-02T03:04:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/auth-files/fields", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchAuthFileFields(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("oauth-subscription")
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if got, _ := updated.Metadata["subscription_expires_at"].(string); got != "2027-01-02T03:04:00Z" {
+		t.Fatalf("subscription_expires_at = %q, want %q", got, "2027-01-02T03:04:00Z")
+	}
+}
+
+func TestPatchAuthFileFieldsClearsSubscriptionExpiration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	_, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "oauth-subscription-clear",
+		FileName: "oauth-subscription-clear.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"email":                   "subscriber@example.com",
+			"subscription_expires_at": "2027-01-02T03:04:00Z",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"name":                    "oauth-subscription-clear.json",
+		"subscription_expires_at": "",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/auth-files/fields", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchAuthFileFields(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("oauth-subscription-clear")
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if _, exists := updated.Metadata["subscription_expires_at"]; exists {
+		t.Fatalf("subscription_expires_at should be cleared, got %v", updated.Metadata["subscription_expires_at"])
+	}
+}
+
 func TestPatchAuthFileFieldsRenamesRoutingChannelReferences(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary
- add subscription expiration metadata to auth file listing
- validate and persist custom subscription_expires_at values through auth file field updates
- cover parsing and patch behavior with management handler tests

## Test Plan
- go test ./...