### PR TITLE
fix: avoid responses websocket cooldown stalls

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -51,9 +51,7 @@ import (
 )
 
 const (
-	oauthCallbackSuccessHTML = `<html><head><meta charset="utf-8"><title>Authentication successful</title><script>setTimeout(function(){window.close();},5000);</script></head><body><h1>Authentication successful!</h1><p>You can close this window.</p><p>This window will close automatically in 5 seconds.</p></body></html>`
-	// Main API requests can legitimately spend several minutes waiting on upstream model execution.
-	// Long-lived SSE and websocket routes explicitly clear this deadline before streaming/upgrading.
+	oauthCallbackSuccessHTML  = `<html><head><meta charset="utf-8"><title>Authentication successful</title><script>setTimeout(function(){window.close();},5000);</script></head><body><h1>Authentication successful!</h1><p>You can close this window.</p><p>This window will close automatically in 5 seconds.</p></body></html>`
 	mainAPIServerWriteTimeout = 10 * time.Minute
 )
 
@@ -342,7 +340,6 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 		Addr:              fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
 		Handler:           engine,
 		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      mainAPIServerWriteTimeout,
 		IdleTimeout:       2 * time.Minute,
 		MaxHeaderBytes:    1 << 20,

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -905,45 +905,93 @@ func parseCodexQuotaProbe(body []byte) *cliproxyauth.QuotaProbeResult {
 
 	allowed := rateLimit.Get("allowed")
 	limitReached := rateLimit.Get("limit_reached")
-	if allowed.Exists() && allowed.Bool() && (!limitReached.Exists() || !limitReached.Bool()) {
-		return &cliproxyauth.QuotaProbeResult{Recovered: true}
+	if allowed.Exists() && !allowed.Bool() {
+		return codexQuotaProbeBlocked(rateLimit)
+	}
+	if limitReached.Exists() && limitReached.Bool() {
+		return codexQuotaProbeBlocked(rateLimit)
 	}
 
-	nextRecoverAt := time.Time{}
-	for _, path := range []string{"primary_window", "secondary_window"} {
+	seenWindow := false
+	for _, path := range codexQuotaWindowPaths() {
 		window := rateLimit.Get(path)
 		if !window.Exists() {
 			continue
 		}
-		usedPercent := window.Get("used_percent")
-		if usedPercent.Exists() && usedPercent.Float() < 100 {
-			return &cliproxyauth.QuotaProbeResult{Recovered: true}
+		seenWindow = true
+		if codexQuotaWindowExceeded(window) {
+			return codexQuotaProbeBlocked(rateLimit)
 		}
-		if resetAt := codexQuotaWindowResetAt(window, time.Now()); !resetAt.IsZero() {
+	}
+	if seenWindow || (allowed.Exists() && allowed.Bool()) {
+		return &cliproxyauth.QuotaProbeResult{Recovered: true}
+	}
+
+	return codexQuotaProbeBlocked(rateLimit)
+}
+
+func codexQuotaProbeBlocked(rateLimit gjson.Result) *cliproxyauth.QuotaProbeResult {
+	return &cliproxyauth.QuotaProbeResult{
+		Recovered:     false,
+		NextRecoverAt: codexQuotaNextRecoverAt(rateLimit, time.Now()),
+	}
+}
+
+func codexQuotaWindowPaths() []string {
+	return []string{"primary_window", "secondary_window", "weekly_window", "week_window", "long_window"}
+}
+
+func codexQuotaNextRecoverAt(rateLimit gjson.Result, now time.Time) time.Time {
+	nextRecoverAt := time.Time{}
+	for _, path := range codexQuotaWindowPaths() {
+		window := rateLimit.Get(path)
+		if !window.Exists() || !codexQuotaWindowExceeded(window) {
+			continue
+		}
+		if resetAt := codexQuotaWindowResetAt(window, now); !resetAt.IsZero() {
 			if nextRecoverAt.IsZero() || resetAt.Before(nextRecoverAt) {
 				nextRecoverAt = resetAt
 			}
 		}
 	}
+	return nextRecoverAt
+}
 
-	return &cliproxyauth.QuotaProbeResult{
-		Recovered:     false,
-		NextRecoverAt: nextRecoverAt,
+func codexQuotaWindowExceeded(window gjson.Result) bool {
+	if !window.Exists() {
+		return false
 	}
+	if limitReached := window.Get("limit_reached"); limitReached.Exists() {
+		return limitReached.Bool()
+	}
+	if usedPercent := window.Get("used_percent"); usedPercent.Exists() {
+		return usedPercent.Float() >= 100
+	}
+	if remaining := window.Get("remaining"); remaining.Exists() {
+		return remaining.Float() <= 0
+	}
+	if available := window.Get("available"); available.Exists() {
+		return !available.Bool()
+	}
+	return false
 }
 
 func codexQuotaWindowResetAt(window gjson.Result, now time.Time) time.Time {
 	if !window.Exists() {
 		return time.Time{}
 	}
-	if resetAt := window.Get("reset_at").Int(); resetAt > 0 {
-		resetAtTime := time.Unix(resetAt, 0)
-		if resetAtTime.After(now) {
-			return resetAtTime
+	for _, path := range []string{"reset_at", "resets_at"} {
+		if resetAt := window.Get(path).Int(); resetAt > 0 {
+			resetAtTime := time.Unix(resetAt, 0)
+			if resetAtTime.After(now) {
+				return resetAtTime
+			}
 		}
 	}
-	if afterSeconds := window.Get("reset_after_seconds").Int(); afterSeconds > 0 {
-		return now.Add(time.Duration(afterSeconds) * time.Second)
+	for _, path := range []string{"reset_after_seconds", "resets_in_seconds"} {
+		if afterSeconds := window.Get(path).Int(); afterSeconds > 0 {
+			return now.Add(time.Duration(afterSeconds) * time.Second)
+		}
 	}
 	return time.Time{}
 }

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -60,6 +60,61 @@ func TestParseCodexRetryAfter(t *testing.T) {
 	})
 }
 
+func TestParseCodexQuotaProbe(t *testing.T) {
+	now := time.Now()
+	resetAt := now.Add(2 * time.Hour).Unix()
+
+	t.Run("keeps blocked when weekly window is exhausted", func(t *testing.T) {
+		body := []byte(`{"rate_limit":{"allowed":false,"limit_reached":true,"primary_window":{"used_percent":25,"reset_at":` + itoa(now.Add(5*time.Hour).Unix()) + `},"secondary_window":{"used_percent":100,"reset_at":` + itoa(resetAt) + `}}}`)
+		result := parseCodexQuotaProbe(body)
+		if result == nil {
+			t.Fatalf("expected quota probe result")
+		}
+		if result.Recovered {
+			t.Fatalf("expected blocked result when weekly window is exhausted")
+		}
+		if result.NextRecoverAt.IsZero() || result.NextRecoverAt.Unix() != resetAt {
+			t.Fatalf("NextRecoverAt = %v, want unix %d", result.NextRecoverAt, resetAt)
+		}
+	})
+
+	t.Run("keeps blocked when any window is exhausted", func(t *testing.T) {
+		body := []byte(`{"rate_limit":{"allowed":true,"limit_reached":false,"primary_window":{"used_percent":20},"secondary_window":{"used_percent":100,"reset_at":` + itoa(resetAt) + `}}}`)
+		result := parseCodexQuotaProbe(body)
+		if result == nil {
+			t.Fatalf("expected quota probe result")
+		}
+		if result.Recovered {
+			t.Fatalf("expected blocked result when one quota window is exhausted")
+		}
+	})
+
+	t.Run("recovers when all windows have capacity", func(t *testing.T) {
+		body := []byte(`{"rate_limit":{"allowed":true,"limit_reached":false,"primary_window":{"used_percent":20},"secondary_window":{"used_percent":80}}}`)
+		result := parseCodexQuotaProbe(body)
+		if result == nil {
+			t.Fatalf("expected quota probe result")
+		}
+		if !result.Recovered {
+			t.Fatalf("expected recovered result when all quota windows have capacity")
+		}
+	})
+
+	t.Run("recognizes explicit weekly window", func(t *testing.T) {
+		body := []byte(`{"rate_limit":{"allowed":true,"limit_reached":false,"primary_window":{"used_percent":20},"weekly_window":{"used_percent":100,"reset_after_seconds":3600}}}`)
+		result := parseCodexQuotaProbe(body)
+		if result == nil {
+			t.Fatalf("expected quota probe result")
+		}
+		if result.Recovered {
+			t.Fatalf("expected blocked result when weekly_window is exhausted")
+		}
+		if result.NextRecoverAt.IsZero() {
+			t.Fatalf("expected NextRecoverAt from weekly_window reset_after_seconds")
+		}
+	})
+}
+
 func itoa(v int64) string {
 	return strconv.FormatInt(v, 10)
 }

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -32,7 +32,7 @@ import (
 const (
 	// Keep aligned with upstream CLIProxyAPI (codex-tui).
 	codexResponsesWebsocketBetaHeaderValue = "responses_websockets=2026-02-06"
-	codexResponsesWebsocketIdleTimeout     = 5 * time.Minute
+	codexResponsesWebsocketIdleTimeout     = 20 * time.Minute
 	codexResponsesWebsocketHandshakeTO     = 30 * time.Second
 )
 

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -60,6 +60,7 @@ const (
 type pinnedAuthContextKey struct{}
 type selectedAuthCallbackContextKey struct{}
 type executionSessionContextKey struct{}
+type cooldownWaitDisabledContextKey struct{}
 
 // ReadJSONRequestBody applies the shared request-body limit and writes a standard API error response.
 func ReadJSONRequestBody(c *gin.Context) ([]byte, bool) {
@@ -124,6 +125,13 @@ func WithExecutionSessionID(ctx context.Context, sessionID string) context.Conte
 		ctx = context.Background()
 	}
 	return context.WithValue(ctx, executionSessionContextKey{}, sessionID)
+}
+
+func WithCooldownWaitDisabled(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, cooldownWaitDisabledContextKey{}, true)
 }
 
 // BuildErrorResponseBody builds an OpenAI-compatible JSON error response body.
@@ -285,6 +293,9 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	if executionSessionID := executionSessionIDFromContext(ctx); executionSessionID != "" {
 		meta[coreexecutor.ExecutionSessionMetadataKey] = executionSessionID
 	}
+	if cooldownWaitDisabledFromContext(ctx) {
+		meta[coreexecutor.DisableCooldownWaitMetadataKey] = true
+	}
 	return meta
 }
 
@@ -341,6 +352,14 @@ func executionSessionIDFromContext(ctx context.Context) string {
 	default:
 		return ""
 	}
+}
+
+func cooldownWaitDisabledFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	enabled, _ := ctx.Value(cooldownWaitDisabledContextKey{}).(bool)
+	return enabled
 }
 
 // BaseAPIHandler contains the handlers for API endpoints.

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -23,21 +23,53 @@ import (
 )
 
 const (
-	wsRequestTypeCreate  = "response.create"
-	wsRequestTypeAppend  = "response.append"
-	wsEventTypeError     = "error"
-	wsEventTypeCompleted = "response.completed"
-	wsEventTypeDone      = "response.done"
-	wsDoneMarker         = "[DONE]"
-	wsTurnStateHeader    = "x-codex-turn-state"
-	wsRequestBodyKey     = "REQUEST_BODY_OVERRIDE"
-	wsPayloadLogMaxSize  = 2048
+	wsRequestTypeCreate                   = "response.create"
+	wsRequestTypeAppend                   = "response.append"
+	wsEventTypeError                      = "error"
+	wsEventTypeCompleted                  = "response.completed"
+	wsEventTypeDone                       = "response.done"
+	wsDoneMarker                          = "[DONE]"
+	wsTurnStateHeader                     = "x-codex-turn-state"
+	wsRequestBodyKey                      = "REQUEST_BODY_OVERRIDE"
+	wsPayloadLogMaxSize                   = 2048
+	responsesWebsocketHeartbeatInterval   = 30 * time.Second
+	responsesWebsocketHeartbeatWriteLimit = 10 * time.Second
 )
 
 var responsesWebsocketUpgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
 	CheckOrigin:     util.WebsocketOriginAllowed,
+}
+
+func startResponsesWebsocketHeartbeat(conn *websocket.Conn, sessionID string) func() {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(responsesWebsocketHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if err := conn.WriteControl(websocket.PingMessage, []byte("ping"), time.Now().Add(responsesWebsocketHeartbeatWriteLimit)); err != nil {
+					log.Debugf("responses websocket: heartbeat failed id=%s error=%v", sessionID, err)
+					return
+				}
+			}
+		}
+	}()
+	return func() {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		close(stop)
+		<-done
+	}
 }
 
 // ResponsesWebsocket handles websocket requests for /v1/responses.
@@ -54,6 +86,8 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		clientRemoteAddr = strings.TrimSpace(c.Request.RemoteAddr)
 	}
 	log.Infof("responses websocket: client connected id=%s remote=%s", passthroughSessionID, clientRemoteAddr)
+	stopHeartbeat := startResponsesWebsocketHeartbeat(conn, passthroughSessionID)
+	defer stopHeartbeat()
 	var wsTerminateErr error
 	var wsBodyLog strings.Builder
 	defer func() {

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -205,6 +205,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 				pinnedAuthID = strings.TrimSpace(authID)
 			})
 		}
+		cliCtx = handlers.WithCooldownWaitDisabled(cliCtx)
 		dataChan, _, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 
 		completedOutput, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsBodyLog, passthroughSessionID)

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -23,17 +23,18 @@ import (
 )
 
 const (
-	wsRequestTypeCreate                   = "response.create"
-	wsRequestTypeAppend                   = "response.append"
-	wsEventTypeError                      = "error"
-	wsEventTypeCompleted                  = "response.completed"
-	wsEventTypeDone                       = "response.done"
-	wsDoneMarker                          = "[DONE]"
-	wsTurnStateHeader                     = "x-codex-turn-state"
-	wsRequestBodyKey                      = "REQUEST_BODY_OVERRIDE"
-	wsPayloadLogMaxSize                   = 2048
-	responsesWebsocketHeartbeatInterval   = 30 * time.Second
-	responsesWebsocketHeartbeatWriteLimit = 10 * time.Second
+	wsRequestTypeCreate                          = "response.create"
+	wsRequestTypeAppend                          = "response.append"
+	wsEventTypeError                             = "error"
+	wsEventTypeCompleted                         = "response.completed"
+	wsEventTypeDone                              = "response.done"
+	wsDoneMarker                                 = "[DONE]"
+	wsTurnStateHeader                            = "x-codex-turn-state"
+	wsRequestBodyKey                             = "REQUEST_BODY_OVERRIDE"
+	wsPayloadLogMaxSize                          = 2048
+	responsesWebsocketHeartbeatInterval          = 30 * time.Second
+	responsesWebsocketHeartbeatWriteLimit        = 10 * time.Second
+	responsesWebsocketApplicationKeepAlivePeriod = 30 * time.Second
 )
 
 var responsesWebsocketUpgrader = websocket.Upgrader{
@@ -432,6 +433,21 @@ func normalizeJSONArrayRaw(raw []byte) string {
 	return "[]"
 }
 
+func responsesWebsocketKeepAlivePayload(sessionID string) []byte {
+	responseID := "resp_keepalive_" + strings.ReplaceAll(sessionID, "-", "")
+	payload, err := json.Marshal(map[string]any{
+		"type": "response.in_progress",
+		"response": map[string]any{
+			"id":     responseID,
+			"status": "in_progress",
+		},
+	})
+	if err != nil {
+		return []byte(`{"type":"response.in_progress","response":{"status":"in_progress"}}`)
+	}
+	return payload
+}
+
 func responsesWebsocketPrewarmPayloads(requestJSON []byte) ([][]byte, bool) {
 	if !gjson.GetBytes(requestJSON, "generate").Exists() || gjson.GetBytes(requestJSON, "generate").Bool() {
 		return nil, false
@@ -454,12 +470,23 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 ) ([]byte, error) {
 	completed := false
 	completedOutput := []byte("[]")
+	keepAlive := time.NewTicker(responsesWebsocketApplicationKeepAlivePeriod)
+	defer keepAlive.Stop()
 
 	for {
 		select {
 		case <-c.Request.Context().Done():
 			cancel(c.Request.Context().Err())
 			return completedOutput, c.Request.Context().Err()
+		case <-keepAlive.C:
+			payload := responsesWebsocketKeepAlivePayload(sessionID)
+			markAPIResponseTimestamp(c)
+			appendWebsocketEvent(wsBodyLog, "response", payload)
+			if errWrite := conn.WriteMessage(websocket.TextMessage, payload); errWrite != nil {
+				log.Warnf("responses websocket: keepalive write failed id=%s event=%s error=%v", sessionID, websocketPayloadEventType(payload), errWrite)
+				cancel(errWrite)
+				return completedOutput, errWrite
+			}
 		case errMsg, ok := <-errs:
 			if !ok {
 				errs = nil

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -556,6 +556,9 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 	}
 
 	_, maxWait := m.retrySettings()
+	if cooldownWaitDisabled(opts.Metadata) {
+		maxWait = 0
+	}
 
 	var lastErr error
 	for attempt := 0; ; attempt++ {
@@ -618,6 +621,9 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	}
 
 	_, maxWait := m.retrySettings()
+	if cooldownWaitDisabled(opts.Metadata) {
+		maxWait = 0
+	}
 
 	var lastErr error
 	for attempt := 0; ; attempt++ {
@@ -898,6 +904,18 @@ func isSinglePickRouteRequest(meta map[string]any) bool {
 		return false
 	}
 	raw, ok := meta[cliproxyexecutor.SinglePickMetadataKey]
+	if !ok || raw == nil {
+		return false
+	}
+	enabled, ok := parseBoolAny(raw)
+	return ok && enabled
+}
+
+func cooldownWaitDisabled(meta map[string]any) bool {
+	if len(meta) == 0 {
+		return false
+	}
+	raw, ok := meta[cliproxyexecutor.DisableCooldownWaitMetadataKey]
 	if !ok || raw == nil {
 		return false
 	}
@@ -1292,6 +1310,9 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 		return 0, false
 	}
 	if isSinglePickRouteRequest(meta) {
+		return 0, false
+	}
+	if cooldownWaitDisabled(meta) {
 		return 0, false
 	}
 	if status := statusCodeFromError(err); status == http.StatusOK {

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -120,6 +120,38 @@ func TestManager_ShouldRetryAfterError_DisablesInternalRetryForSinglePick(t *tes
 	}
 }
 
+func TestManager_ShouldRetryAfterError_DisablesInternalRetryForCooldownWaitDisabled(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(3, 30*time.Second)
+
+	model := "test-model"
+	next := time.Now().Add(5 * time.Second)
+	auth := &Auth{
+		ID:       "auth-1",
+		Provider: "codex",
+		ModelStates: map[string]*ModelState{
+			model: {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: next,
+			},
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	_, maxWait := m.retrySettings()
+	meta := map[string]any{"disable_cooldown_wait": true}
+	wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: 500, Message: "boom"}, 0, []string{"codex"}, model, maxWait, meta)
+	if shouldRetry {
+		t.Fatalf("expected shouldRetry=false when cooldown wait is disabled, got true (wait=%v)", wait)
+	}
+	if wait != 0 {
+		t.Fatalf("expected wait=0 when cooldown wait is disabled, got %v", wait)
+	}
+}
+
 func TestManager_MarkResult_RespectsAuthDisableCoolingOverride(t *testing.T) {
 	prev := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -26,6 +26,8 @@ const (
 	SelectedAuthCallbackMetadataKey = "selected_auth_callback"
 	// ExecutionSessionMetadataKey identifies a long-lived downstream execution session.
 	ExecutionSessionMetadataKey = "execution_session_id"
+	// DisableCooldownWaitMetadataKey skips manager-level cooldown waiting for latency-sensitive requests.
+	DisableCooldownWaitMetadataKey = "disable_cooldown_wait"
 )
 
 // Request encapsulates the translated payload that will be sent to a provider executor.


### PR DESCRIPTION
This PR includes the responses websocket stability fixes on top of latest dev:\n\n- add downstream websocket heartbeat for /v1/responses\n- extend Codex upstream websocket idle timeout\n- avoid manager-level cooldown waits for latency-sensitive responses websocket requests\n- keep quota recovery and request body read timeout fixes in this branch\n\nValidation:\n- go test ./sdk/cliproxy/auth ./sdk/api/handlers/openai ./internal/runtime/executor ./internal/api ./...\n- built linux amd64 binary and hot-replaced the Podman container on the server\n- verified local/external health 200 after restart