### PR TITLE
ci: fix GHCR image namespace for fork publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: kittors/clirelay
+  IMAGE_NAME: zuohuadong/clirelay
 
 jobs:
   build-and-push:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,71 @@
+name: Sync upstream
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '7 2 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  UPSTREAM_REPOSITORY: router-for-me/CLIProxyAPI
+  UPSTREAM_BRANCH: main
+  BASE_BRANCH: dev
+  SYNC_BRANCH: chore/sync-upstream-main-to-dev
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream "https://github.com/${UPSTREAM_REPOSITORY}.git"
+          git fetch origin "${BASE_BRANCH}"
+          git fetch upstream "${UPSTREAM_BRANCH}"
+
+      - name: Merge upstream
+        id: merge
+        run: |
+          set -euo pipefail
+          git checkout -B "${SYNC_BRANCH}" "origin/${BASE_BRANCH}"
+          base_sha="$(git rev-parse HEAD)"
+          git merge --no-edit "upstream/${UPSTREAM_BRANCH}"
+          head_sha="$(git rev-parse HEAD)"
+          if [ "${base_sha}" = "${head_sha}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push sync branch
+        if: steps.merge.outputs.changed == 'true'
+        run: git push --force-with-lease origin "${SYNC_BRANCH}"
+
+      - name: Create or update pull request
+        if: steps.merge.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          title="chore: sync upstream ${UPSTREAM_BRANCH} into ${BASE_BRANCH}"
+          body="Automated upstream sync from ${UPSTREAM_REPOSITORY}:${UPSTREAM_BRANCH} into ${BASE_BRANCH}."
+          existing_pr="$(gh pr list --base "${BASE_BRANCH}" --head "${SYNC_BRANCH}" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "${existing_pr}" ]; then
+            gh pr edit "${existing_pr}" --title "${title}" --body "${body}"
+          else
+            gh pr create --base "${BASE_BRANCH}" --head "${SYNC_BRANCH}" --title "${title}" --body "${body}"
+          fi


### PR DESCRIPTION
## Summary
- update Docker publish workflow image name to ghcr.io/zuohuadong/clirelay
- add upstream sync workflow from upstream main into dev

## Verification
- git diff --check origin/dev..HEAD

## Notes
This fixes the GHCR push failure where the workflow attempted to push ghcr.io/kittors/clirelay without write permission.