### PR TITLE
fix: sync OpenRouter pricing for existing models

### DIFF
--- a/internal/usage/model_config_db.go
+++ b/internal/usage/model_config_db.go
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS model_openrouter_sync_state (
   last_error       TEXT NOT NULL DEFAULT '',
   last_seen        INTEGER NOT NULL DEFAULT 0,
   last_added       INTEGER NOT NULL DEFAULT 0,
+  last_updated     INTEGER NOT NULL DEFAULT 0,
   last_skipped     INTEGER NOT NULL DEFAULT 0,
   updated_at       DATETIME NOT NULL
 );
@@ -108,6 +109,7 @@ func initModelConfigTables(db *sql.DB) {
 		log.Errorf("usage: create model config tables: %v", err)
 		return
 	}
+	ensureOpenRouterModelSyncStateSchema(db)
 	seedDefaultModelConfigRows(db)
 	mergeLegacyPricingIntoModelConfigs(db)
 	reloadModelConfigCache(db)

--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,6 +36,7 @@ type OpenRouterRemoteModel struct {
 type OpenRouterModelSyncResult struct {
 	Seen    int `json:"seen"`
 	Added   int `json:"added"`
+	Updated int `json:"updated"`
 	Skipped int `json:"skipped"`
 }
 
@@ -46,6 +48,7 @@ type OpenRouterModelSyncState struct {
 	LastError       string `json:"last_error"`
 	LastSeen        int    `json:"last_seen"`
 	LastAdded       int    `json:"last_added"`
+	LastUpdated     int    `json:"last_updated"`
 	LastSkipped     int    `json:"last_skipped"`
 	UpdatedAt       string `json:"updated_at"`
 	Running         bool   `json:"running"`
@@ -89,8 +92,20 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			result.Skipped++
 			continue
 		}
-		if _, exists := GetModelConfig(modelID); exists {
-			result.Skipped++
+		if existing, exists := GetModelConfig(modelID); exists {
+			cleanOwner := openRouterOwnerFromModelID(modelID)
+			if ownerMatchesOpenRouterAliasPrefix(existing.OwnedBy, cleanOwner) {
+				existing.OwnedBy = cleanOwner
+			}
+			existing.PricingMode = "token"
+			existing.InputPricePerMillion = openRouterPricePerMillion(model.Pricing.Prompt)
+			existing.OutputPricePerMillion = openRouterPricePerMillion(model.Pricing.Completion)
+			existing.CachedPricePerMillion = openRouterPricePerMillion(model.Pricing.InputCacheRead)
+			existing.PricePerCall = 0
+			if err := UpsertModelConfig(existing); err != nil {
+				return result, fmt.Errorf("sync openrouter model pricing %s: %w", modelID, err)
+			}
+			result.Updated++
 			continue
 		}
 
@@ -125,7 +140,7 @@ func GetOpenRouterModelSyncState() OpenRouterModelSyncState {
 	ensureOpenRouterModelSyncStateRow()
 	var enabled int
 	if err := db.QueryRow(
-		`SELECT enabled, interval_minutes, last_sync_at, last_success_at, last_error, last_seen, last_added, last_skipped, updated_at
+		`SELECT enabled, interval_minutes, last_sync_at, last_success_at, last_error, last_seen, last_added, last_updated, last_skipped, updated_at
 		 FROM model_openrouter_sync_state WHERE id = 1`,
 	).Scan(
 		&enabled,
@@ -135,6 +150,7 @@ func GetOpenRouterModelSyncState() OpenRouterModelSyncState {
 		&state.LastError,
 		&state.LastSeen,
 		&state.LastAdded,
+		&state.LastUpdated,
 		&state.LastSkipped,
 		&state.UpdatedAt,
 	); err != nil {
@@ -262,13 +278,47 @@ func ensureOpenRouterModelSyncStateRow() {
 	if db == nil {
 		return
 	}
+	ensureOpenRouterModelSyncStateSchema(db)
 	_, _ = db.Exec(
 		`INSERT OR IGNORE INTO model_openrouter_sync_state
-		 (id, enabled, interval_minutes, last_sync_at, last_success_at, last_error, last_seen, last_added, last_skipped, updated_at)
-		 VALUES (1, 0, ?, '', '', '', 0, 0, 0, ?)`,
+		 (id, enabled, interval_minutes, last_sync_at, last_success_at, last_error, last_seen, last_added, last_updated, last_skipped, updated_at)
+		 VALUES (1, 0, ?, '', '', '', 0, 0, 0, 0, ?)`,
 		defaultOpenRouterModelSyncIntervalMinutes,
 		nowRFC3339(),
 	)
+}
+
+func ensureOpenRouterModelSyncStateSchema(db *sql.DB) {
+	if db == nil || sqliteColumnExists(db, "model_openrouter_sync_state", "last_updated") {
+		return
+	}
+	if _, err := db.Exec("ALTER TABLE model_openrouter_sync_state ADD COLUMN last_updated INTEGER NOT NULL DEFAULT 0"); err != nil {
+		log.Warnf("usage: add openrouter sync last_updated column: %v", err)
+	}
+}
+
+func sqliteColumnExists(db *sql.DB, tableName, columnName string) bool {
+	rows, err := db.Query("PRAGMA table_info(" + tableName + ")")
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name string
+		var columnType string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			continue
+		}
+		if name == columnName {
+			return true
+		}
+	}
+	return false
 }
 
 func recordOpenRouterModelSyncResult(result OpenRouterModelSyncResult, syncErr error) OpenRouterModelSyncState {
@@ -288,13 +338,14 @@ func recordOpenRouterModelSyncResult(result OpenRouterModelSyncResult, syncErr e
 	}
 	_, _ = db.Exec(
 		`UPDATE model_openrouter_sync_state
-		 SET last_sync_at = ?, last_success_at = ?, last_error = ?, last_seen = ?, last_added = ?, last_skipped = ?, updated_at = ?
+		 SET last_sync_at = ?, last_success_at = ?, last_error = ?, last_seen = ?, last_added = ?, last_updated = ?, last_skipped = ?, updated_at = ?
 		 WHERE id = 1`,
 		now,
 		lastSuccessAt,
 		lastError,
 		result.Seen,
 		result.Added,
+		result.Updated,
 		result.Skipped,
 		now,
 	)
@@ -327,7 +378,20 @@ func openRouterOwnerFromModelID(modelID string) string {
 	if !found {
 		return openRouterModelSource
 	}
+	prefix = strings.TrimLeft(prefix, "~～")
+	if strings.TrimSpace(prefix) == "" {
+		return openRouterModelSource
+	}
 	return normalizeModelOwnerValue(prefix)
+}
+
+func ownerMatchesOpenRouterAliasPrefix(owner, cleanOwner string) bool {
+	owner = normalizeModelOwnerValue(owner)
+	cleanOwner = normalizeModelOwnerValue(cleanOwner)
+	if owner == "" || cleanOwner == "" {
+		return false
+	}
+	return (strings.HasPrefix(owner, "~") || strings.HasPrefix(owner, "～")) && strings.TrimLeft(owner, "~～") == cleanOwner
 }
 
 func openRouterModelDescription(model OpenRouterRemoteModel) string {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -42,7 +42,7 @@ func TestSyncOpenRouterModelsAddsNewModelsWithPricingAndOwner(t *testing.T) {
 	}
 }
 
-func TestSyncOpenRouterModelsSkipsExistingUserModels(t *testing.T) {
+func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	if err := UpsertModelConfig(ModelConfigRow{
@@ -63,15 +63,16 @@ func TestSyncOpenRouterModelsSkipsExistingUserModels(t *testing.T) {
 			ID:          "openai/gpt-5.3-codex",
 			Description: "Remote description",
 			Pricing: OpenRouterRemotePricing{
-				Prompt:     "0.00000175",
-				Completion: "0.000014",
+				Prompt:         "0.00000175",
+				Completion:     "0.000014",
+				InputCacheRead: "0.000000175",
 			},
 		},
 	})
 	if err != nil {
 		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
 	}
-	if result.Seen != 1 || result.Added != 0 || result.Skipped != 1 {
+	if result.Seen != 1 || result.Added != 0 || result.Updated != 1 || result.Skipped != 0 {
 		t.Fatalf("unexpected sync result: %+v", result)
 	}
 
@@ -79,7 +80,90 @@ func TestSyncOpenRouterModelsSkipsExistingUserModels(t *testing.T) {
 	if !ok {
 		t.Fatal("expected existing model config")
 	}
-	if model.OwnedBy != "custom-owner" || model.Description != "Local override" || model.InputPricePerMillion != 9 || model.Source != "user" {
-		t.Fatalf("existing user model should not be overwritten: %+v", model)
+	if model.OwnedBy != "custom-owner" || model.Description != "Local override" || model.Source != "user" {
+		t.Fatalf("existing user metadata should not be overwritten: %+v", model)
+	}
+	if model.InputPricePerMillion != 1.75 || model.OutputPricePerMillion != 14 || model.CachedPricePerMillion != 0.175 {
+		t.Fatalf("existing user model pricing should be synced: %+v", model)
+	}
+}
+
+func TestSyncOpenRouterModelsStripsTildeFromOwnerPrefix(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "~moonshotai/kimi-latest",
+			Description: "Moonshot latest alias",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.0000007448",
+				Completion: "0.000004655",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 1 || result.Updated != 0 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	model, ok := GetModelConfig("~moonshotai/kimi-latest")
+	if !ok {
+		t.Fatal("expected OpenRouter alias model to be imported with its original id")
+	}
+	if model.ModelID != "~moonshotai/kimi-latest" {
+		t.Fatalf("model id should remain the OpenRouter id, got %q", model.ModelID)
+	}
+	if model.OwnedBy != "moonshotai" {
+		t.Fatalf("owner should not keep OpenRouter alias marker, got %q", model.OwnedBy)
+	}
+}
+
+func TestSyncOpenRouterModelsCleansExistingTildeOwnerWhenUpdatingPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "~moonshotai/kimi-latest",
+		OwnedBy:               "～moonshotai",
+		Description:           "Existing imported alias",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  9,
+		OutputPricePerMillion: 18,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "~moonshotai/kimi-latest",
+			Description: "Remote description",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.0000007448",
+				Completion: "0.000004655",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 0 || result.Updated != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	model, ok := GetModelConfig("~moonshotai/kimi-latest")
+	if !ok {
+		t.Fatal("expected existing model config")
+	}
+	if model.OwnedBy != "moonshotai" {
+		t.Fatalf("existing OpenRouter owner should be cleaned, got %q", model.OwnedBy)
+	}
+	if model.Description != "Existing imported alias" || model.Source != "openrouter" {
+		t.Fatalf("existing OpenRouter metadata should otherwise stay unchanged: %+v", model)
+	}
+	if model.InputPricePerMillion != 0.7448 || model.OutputPricePerMillion != 4.655 {
+		t.Fatalf("existing OpenRouter pricing should be synced: %+v", model)
 	}
 }


### PR DESCRIPTION
## Summary\n- Update existing matching model IDs with OpenRouter pricing while preserving manual metadata\n- Track updated counts in OpenRouter sync state\n- Strip OpenRouter alias marker from owner prefixes while preserving the model ID\n\n## Tests\n- go test ./...