### PR TITLE
fix: normalize OpenRouter model ids

### DIFF
--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -239,8 +239,8 @@ func TestOpenRouterModelSyncHandlersConfigureAndRun(t *testing.T) {
 	restoreFetcher := usage.SetOpenRouterModelFetcherForTest(func(_ context.Context) ([]usage.OpenRouterRemoteModel, error) {
 		return []usage.OpenRouterRemoteModel{
 			{
-				ID:          "openai/gpt-5.3-codex",
-				Name:        "OpenAI: GPT-5.3-Codex",
+				ID:          "openai/gpt-openrouter-handler-test",
+				Name:        "OpenAI: GPT OpenRouter Handler Test",
 				Description: "Agentic coding model",
 				Pricing: usage.OpenRouterRemotePricing{
 					Prompt:         "0.00000175",
@@ -293,8 +293,11 @@ func TestOpenRouterModelSyncHandlersConfigureAndRun(t *testing.T) {
 	if runPayload.State.LastAdded != 1 || runPayload.State.LastSkipped != 0 || runPayload.State.LastError != "" {
 		t.Fatalf("unexpected sync run state: %+v", runPayload.State)
 	}
-	if _, ok := usage.GetModelConfig("openai/gpt-5.3-codex"); !ok {
-		t.Fatal("expected openai/gpt-5.3-codex to be imported")
+	if _, ok := usage.GetModelConfig("gpt-openrouter-handler-test"); !ok {
+		t.Fatal("expected gpt-openrouter-handler-test to be imported")
+	}
+	if _, ok := usage.GetModelConfig("openai/gpt-openrouter-handler-test"); ok {
+		t.Fatal("did not expect OpenRouter provider prefix to be stored in model id")
 	}
 
 	getRec := performModelsRequest(http.MethodGet, "/model-openrouter-sync", nil, h.GetOpenRouterModelSync)

--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -87,15 +88,20 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			return result, err
 		}
 
-		modelID := strings.TrimSpace(model.ID)
+		remoteModelID := strings.TrimSpace(model.ID)
+		if remoteModelID == "" {
+			result.Skipped++
+			continue
+		}
+		owner := openRouterOwnerFromModelID(remoteModelID)
+		modelID := openRouterLocalModelID(remoteModelID, owner)
 		if modelID == "" {
 			result.Skipped++
 			continue
 		}
 		if existing, exists := GetModelConfig(modelID); exists {
-			cleanOwner := openRouterOwnerFromModelID(modelID)
-			if ownerMatchesOpenRouterAliasPrefix(existing.OwnedBy, cleanOwner) {
-				existing.OwnedBy = cleanOwner
+			if ownerMatchesOpenRouterAliasPrefix(existing.OwnedBy, owner) {
+				existing.OwnedBy = owner
 			}
 			existing.PricingMode = "token"
 			existing.InputPricePerMillion = openRouterPricePerMillion(model.Pricing.Prompt)
@@ -105,13 +111,41 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			if err := UpsertModelConfig(existing); err != nil {
 				return result, fmt.Errorf("sync openrouter model pricing %s: %w", modelID, err)
 			}
+			if remoteModelID != modelID {
+				if prefixed, ok := GetModelConfig(remoteModelID); ok && prefixed.Source == openRouterModelSource {
+					if err := DeleteModelConfig(remoteModelID); err != nil {
+						return result, fmt.Errorf("delete old openrouter model %s: %w", remoteModelID, err)
+					}
+				}
+			}
 			result.Updated++
 			continue
+		}
+		if remoteModelID != modelID {
+			if existing, exists := GetModelConfig(remoteModelID); exists && existing.Source == openRouterModelSource {
+				existing.ModelID = modelID
+				if ownerMatchesOpenRouterAliasPrefix(existing.OwnedBy, owner) || existing.OwnedBy == "" {
+					existing.OwnedBy = owner
+				}
+				existing.PricingMode = "token"
+				existing.InputPricePerMillion = openRouterPricePerMillion(model.Pricing.Prompt)
+				existing.OutputPricePerMillion = openRouterPricePerMillion(model.Pricing.Completion)
+				existing.CachedPricePerMillion = openRouterPricePerMillion(model.Pricing.InputCacheRead)
+				existing.PricePerCall = 0
+				if err := UpsertModelConfig(existing); err != nil {
+					return result, fmt.Errorf("migrate openrouter model %s to %s: %w", remoteModelID, modelID, err)
+				}
+				if err := DeleteModelConfig(remoteModelID); err != nil {
+					return result, fmt.Errorf("delete old openrouter model %s: %w", remoteModelID, err)
+				}
+				result.Updated++
+				continue
+			}
 		}
 
 		row := ModelConfigRow{
 			ModelID:               modelID,
-			OwnedBy:               openRouterOwnerFromModelID(modelID),
+			OwnedBy:               owner,
 			Description:           openRouterModelDescription(model),
 			Enabled:               true,
 			PricingMode:           "token",
@@ -385,6 +419,17 @@ func openRouterOwnerFromModelID(modelID string) string {
 	return normalizeModelOwnerValue(prefix)
 }
 
+func openRouterLocalModelID(remoteModelID, owner string) string {
+	modelID := strings.TrimSpace(remoteModelID)
+	if _, suffix, found := strings.Cut(modelID, "/"); found {
+		modelID = strings.TrimSpace(suffix)
+	}
+	if normalizeModelOwnerValue(owner) == "anthropic" {
+		modelID = strings.ReplaceAll(modelID, ".", "-")
+	}
+	return modelID
+}
+
 func ownerMatchesOpenRouterAliasPrefix(owner, cleanOwner string) bool {
 	owner = normalizeModelOwnerValue(owner)
 	cleanOwner = normalizeModelOwnerValue(cleanOwner)
@@ -406,5 +451,5 @@ func openRouterPricePerMillion(value string) float64 {
 	if err != nil || price <= 0 {
 		return 0
 	}
-	return price * 1_000_000
+	return math.Round(price*1_000_000*1_000_000_000_000) / 1_000_000_000_000
 }

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 )
 
-func TestSyncOpenRouterModelsAddsNewModelsWithPricingAndOwner(t *testing.T) {
+func TestSyncOpenRouterModelsAddsNewModelsWithLocalModelIDPricingAndOwner(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
 		{
-			ID:          "openai/gpt-5.3-codex",
-			Name:        "OpenAI: GPT-5.3-Codex",
-			Description: "Agentic coding model",
+			ID:          "openai/gpt-openrouter-test",
+			Name:        "OpenAI: GPT OpenRouter Test",
+			Description: "Agentic test model",
 			Pricing: OpenRouterRemotePricing{
 				Prompt:         "0.00000175",
 				Completion:     "0.000014",
@@ -27,11 +27,14 @@ func TestSyncOpenRouterModelsAddsNewModelsWithPricingAndOwner(t *testing.T) {
 		t.Fatalf("unexpected sync result: %+v", result)
 	}
 
-	model, ok := GetModelConfig("openai/gpt-5.3-codex")
+	model, ok := GetModelConfig("gpt-openrouter-test")
 	if !ok {
-		t.Fatal("expected openai/gpt-5.3-codex to be imported")
+		t.Fatal("expected gpt-openrouter-test to be imported")
 	}
-	if model.OwnedBy != "openai" || model.Source != "openrouter" || model.Description != "Agentic coding model" {
+	if _, ok := GetModelConfig("openai/gpt-openrouter-test"); ok {
+		t.Fatal("did not expect OpenRouter provider prefix to be stored in model id")
+	}
+	if model.OwnedBy != "openai" || model.Source != "openrouter" || model.Description != "Agentic test model" {
 		t.Fatalf("unexpected imported model metadata: %+v", model)
 	}
 	if model.InputPricePerMillion != 1.75 || model.OutputPricePerMillion != 14 || model.CachedPricePerMillion != 0.175 {
@@ -46,7 +49,7 @@ func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	if err := UpsertModelConfig(ModelConfigRow{
-		ModelID:               "openai/gpt-5.3-codex",
+		ModelID:               "gpt-openrouter-test",
 		OwnedBy:               "custom-owner",
 		Description:           "Local override",
 		Enabled:               true,
@@ -60,7 +63,7 @@ func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 
 	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
 		{
-			ID:          "openai/gpt-5.3-codex",
+			ID:          "openai/gpt-openrouter-test",
 			Description: "Remote description",
 			Pricing: OpenRouterRemotePricing{
 				Prompt:         "0.00000175",
@@ -76,7 +79,7 @@ func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 		t.Fatalf("unexpected sync result: %+v", result)
 	}
 
-	model, ok := GetModelConfig("openai/gpt-5.3-codex")
+	model, ok := GetModelConfig("gpt-openrouter-test")
 	if !ok {
 		t.Fatal("expected existing model config")
 	}
@@ -88,7 +91,7 @@ func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 	}
 }
 
-func TestSyncOpenRouterModelsStripsTildeFromOwnerPrefix(t *testing.T) {
+func TestSyncOpenRouterModelsStripsProviderPrefixAndTildeFromImportedModelID(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
@@ -108,25 +111,60 @@ func TestSyncOpenRouterModelsStripsTildeFromOwnerPrefix(t *testing.T) {
 		t.Fatalf("unexpected sync result: %+v", result)
 	}
 
-	model, ok := GetModelConfig("~moonshotai/kimi-latest")
+	model, ok := GetModelConfig("kimi-latest")
 	if !ok {
-		t.Fatal("expected OpenRouter alias model to be imported with its original id")
+		t.Fatal("expected OpenRouter alias model to be imported with a local model id")
 	}
-	if model.ModelID != "~moonshotai/kimi-latest" {
-		t.Fatalf("model id should remain the OpenRouter id, got %q", model.ModelID)
+	if model.ModelID != "kimi-latest" {
+		t.Fatalf("model id should strip OpenRouter provider prefix, got %q", model.ModelID)
+	}
+	if _, ok := GetModelConfig("~moonshotai/kimi-latest"); ok {
+		t.Fatal("did not expect OpenRouter alias marker to be stored in model id")
 	}
 	if model.OwnedBy != "moonshotai" {
 		t.Fatalf("owner should not keep OpenRouter alias marker, got %q", model.OwnedBy)
 	}
 }
 
-func TestSyncOpenRouterModelsCleansExistingTildeOwnerWhenUpdatingPricing(t *testing.T) {
+func TestSyncOpenRouterModelsNormalizesAnthropicVersionDots(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "anthropic/claude-sonnet-4.6",
+			Description: "Claude Sonnet 4.6",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000003",
+				Completion: "0.000015",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 0 || result.Updated != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	model, ok := GetModelConfig("claude-sonnet-4-6")
+	if !ok {
+		t.Fatal("expected anthropic model to use the local Claude id")
+	}
+	if model.OwnedBy != "anthropic" || model.InputPricePerMillion != 3 || model.OutputPricePerMillion != 15 {
+		t.Fatalf("unexpected normalized anthropic model: %+v", model)
+	}
+	if _, ok := GetModelConfig("claude-sonnet-4.6"); ok {
+		t.Fatal("did not expect dotted Anthropic version id to be stored")
+	}
+}
+
+func TestSyncOpenRouterModelsMigratesExistingOpenRouterPrefixedRows(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	if err := UpsertModelConfig(ModelConfigRow{
-		ModelID:               "~moonshotai/kimi-latest",
-		OwnedBy:               "～moonshotai",
-		Description:           "Existing imported alias",
+		ModelID:               "openai/gpt-openrouter-legacy",
+		OwnedBy:               "openai",
+		Description:           "Existing prefixed import",
 		Enabled:               true,
 		PricingMode:           "token",
 		InputPricePerMillion:  9,
@@ -138,11 +176,11 @@ func TestSyncOpenRouterModelsCleansExistingTildeOwnerWhenUpdatingPricing(t *test
 
 	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
 		{
-			ID:          "~moonshotai/kimi-latest",
+			ID:          "openai/gpt-openrouter-legacy",
 			Description: "Remote description",
 			Pricing: OpenRouterRemotePricing{
-				Prompt:     "0.0000007448",
-				Completion: "0.000004655",
+				Prompt:     "0.000002",
+				Completion: "0.000008",
 			},
 		},
 	})
@@ -153,17 +191,23 @@ func TestSyncOpenRouterModelsCleansExistingTildeOwnerWhenUpdatingPricing(t *test
 		t.Fatalf("unexpected sync result: %+v", result)
 	}
 
-	model, ok := GetModelConfig("~moonshotai/kimi-latest")
+	model, ok := GetModelConfig("gpt-openrouter-legacy")
 	if !ok {
-		t.Fatal("expected existing model config")
+		t.Fatal("expected existing OpenRouter row to be migrated to local model id")
 	}
-	if model.OwnedBy != "moonshotai" {
-		t.Fatalf("existing OpenRouter owner should be cleaned, got %q", model.OwnedBy)
+	if _, ok := GetModelConfig("openai/gpt-openrouter-legacy"); ok {
+		t.Fatal("did not expect old prefixed OpenRouter row to remain")
 	}
-	if model.Description != "Existing imported alias" || model.Source != "openrouter" {
+	if model.Description != "Existing prefixed import" || model.Source != "openrouter" || model.OwnedBy != "openai" {
 		t.Fatalf("existing OpenRouter metadata should otherwise stay unchanged: %+v", model)
 	}
-	if model.InputPricePerMillion != 0.7448 || model.OutputPricePerMillion != 4.655 {
+	if model.InputPricePerMillion != 2 || model.OutputPricePerMillion != 8 {
 		t.Fatalf("existing OpenRouter pricing should be synced: %+v", model)
+	}
+}
+
+func TestOpenRouterPricePerMillionRoundsFloatArtifacts(t *testing.T) {
+	if got := openRouterPricePerMillion("0.0000002"); got != 0.2 {
+		t.Fatalf("expected clean per-million price, got %.17g", got)
 	}
 }


### PR DESCRIPTION
## Summary
- strip OpenRouter provider prefixes before storing synced model ids
- normalize Anthropic dotted version ids to local hyphenated ids
- sync pricing onto matching local/user rows and round per-million prices to avoid float artifacts

## Verification
- go test ./...