### PR TITLE
fix: sync OpenRouter model descriptions

### DIFF
--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -99,48 +99,31 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			result.Skipped++
 			continue
 		}
+		legacyModelIDs := openRouterLegacyLocalModelIDs(remoteModelID, owner, modelID)
 		if existing, exists := GetModelConfig(modelID); exists {
-			if ownerMatchesOpenRouterAliasPrefix(existing.OwnedBy, owner) {
-				existing.OwnedBy = owner
-			}
-			existing.PricingMode = "token"
-			existing.InputPricePerMillion = openRouterPricePerMillion(model.Pricing.Prompt)
-			existing.OutputPricePerMillion = openRouterPricePerMillion(model.Pricing.Completion)
-			existing.CachedPricePerMillion = openRouterPricePerMillion(model.Pricing.InputCacheRead)
-			existing.PricePerCall = 0
+			openRouterApplyModelSync(&existing, model, owner)
 			if err := UpsertModelConfig(existing); err != nil {
 				return result, fmt.Errorf("sync openrouter model pricing %s: %w", modelID, err)
 			}
-			if remoteModelID != modelID {
-				if prefixed, ok := GetModelConfig(remoteModelID); ok && prefixed.Source == openRouterModelSource {
-					if err := DeleteModelConfig(remoteModelID); err != nil {
-						return result, fmt.Errorf("delete old openrouter model %s: %w", remoteModelID, err)
-					}
-				}
+			if err := openRouterDeleteLegacyOpenRouterRows(legacyModelIDs); err != nil {
+				return result, err
+			}
+			if err := openRouterSyncExistingAliasRows(model, owner, legacyModelIDs); err != nil {
+				return result, err
 			}
 			result.Updated++
 			continue
 		}
-		if remoteModelID != modelID {
-			if existing, exists := GetModelConfig(remoteModelID); exists && existing.Source == openRouterModelSource {
-				existing.ModelID = modelID
-				if ownerMatchesOpenRouterAliasPrefix(existing.OwnedBy, owner) || existing.OwnedBy == "" {
-					existing.OwnedBy = owner
-				}
-				existing.PricingMode = "token"
-				existing.InputPricePerMillion = openRouterPricePerMillion(model.Pricing.Prompt)
-				existing.OutputPricePerMillion = openRouterPricePerMillion(model.Pricing.Completion)
-				existing.CachedPricePerMillion = openRouterPricePerMillion(model.Pricing.InputCacheRead)
-				existing.PricePerCall = 0
-				if err := UpsertModelConfig(existing); err != nil {
-					return result, fmt.Errorf("migrate openrouter model %s to %s: %w", remoteModelID, modelID, err)
-				}
-				if err := DeleteModelConfig(remoteModelID); err != nil {
-					return result, fmt.Errorf("delete old openrouter model %s: %w", remoteModelID, err)
-				}
-				result.Updated++
-				continue
+		migrated, err := openRouterMigrateLegacyOpenRouterRow(modelID, owner, model, legacyModelIDs)
+		if err != nil {
+			return result, err
+		}
+		if migrated {
+			if err := openRouterSyncExistingAliasRows(model, owner, legacyModelIDs); err != nil {
+				return result, err
 			}
+			result.Updated++
+			continue
 		}
 
 		row := ModelConfigRow{
@@ -156,6 +139,9 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 		}
 		if err := UpsertModelConfig(row); err != nil {
 			return result, fmt.Errorf("sync openrouter model %s: %w", modelID, err)
+		}
+		if err := openRouterSyncExistingAliasRows(model, owner, legacyModelIDs); err != nil {
+			return result, err
 		}
 		result.Added++
 	}
@@ -420,14 +406,136 @@ func openRouterOwnerFromModelID(modelID string) string {
 }
 
 func openRouterLocalModelID(remoteModelID, owner string) string {
-	modelID := strings.TrimSpace(remoteModelID)
-	if _, suffix, found := strings.Cut(modelID, "/"); found {
-		modelID = strings.TrimSpace(suffix)
-	}
+	modelID := openRouterProviderlessModelID(remoteModelID)
 	if normalizeModelOwnerValue(owner) == "anthropic" {
 		modelID = strings.ReplaceAll(modelID, ".", "-")
+		modelID = openRouterStripAnthropicReleaseDate(modelID)
 	}
 	return modelID
+}
+
+func openRouterProviderlessModelID(remoteModelID string) string {
+	modelID := strings.TrimSpace(remoteModelID)
+	if _, suffix, found := strings.Cut(modelID, "/"); found {
+		return strings.TrimSpace(suffix)
+	}
+	return modelID
+}
+
+func openRouterStripAnthropicReleaseDate(modelID string) string {
+	modelID = strings.TrimSpace(modelID)
+	if !strings.HasPrefix(modelID, "claude-") || len(modelID) <= 9 {
+		return modelID
+	}
+	dateStart := len(modelID) - 8
+	if modelID[dateStart-1] != '-' {
+		return modelID
+	}
+	for _, ch := range modelID[dateStart:] {
+		if ch < '0' || ch > '9' {
+			return modelID
+		}
+	}
+	return modelID[:dateStart-1]
+}
+
+func openRouterLegacyLocalModelIDs(remoteModelID, owner, modelID string) []string {
+	var ids []string
+	seen := map[string]struct{}{}
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" || id == modelID {
+			return
+		}
+		if _, exists := seen[id]; exists {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	add(remoteModelID)
+	providerless := openRouterProviderlessModelID(remoteModelID)
+	add(providerless)
+	if normalizeModelOwnerValue(owner) == "anthropic" {
+		add(strings.ReplaceAll(providerless, ".", "-"))
+	}
+	return ids
+}
+
+func openRouterApplyModelSync(row *ModelConfigRow, model OpenRouterRemoteModel, owner string) {
+	if row == nil {
+		return
+	}
+	if row.OwnedBy == "" || ownerMatchesOpenRouterAliasPrefix(row.OwnedBy, owner) {
+		row.OwnedBy = owner
+	}
+	if description := openRouterModelDescription(model); description != "" && openRouterShouldSyncDescription(*row) {
+		row.Description = description
+	}
+	row.PricingMode = "token"
+	row.InputPricePerMillion = openRouterPricePerMillion(model.Pricing.Prompt)
+	row.OutputPricePerMillion = openRouterPricePerMillion(model.Pricing.Completion)
+	row.CachedPricePerMillion = openRouterPricePerMillion(model.Pricing.InputCacheRead)
+	row.PricePerCall = 0
+}
+
+func openRouterShouldSyncDescription(row ModelConfigRow) bool {
+	if strings.TrimSpace(row.Description) == "" {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(row.Source)) {
+	case openRouterModelSource, "seed":
+		return true
+	default:
+		return false
+	}
+}
+
+func openRouterMigrateLegacyOpenRouterRow(modelID, owner string, model OpenRouterRemoteModel, legacyModelIDs []string) (bool, error) {
+	for _, legacyModelID := range legacyModelIDs {
+		existing, exists := GetModelConfig(legacyModelID)
+		if !exists || existing.Source != openRouterModelSource {
+			continue
+		}
+		existing.ModelID = modelID
+		openRouterApplyModelSync(&existing, model, owner)
+		if err := UpsertModelConfig(existing); err != nil {
+			return false, fmt.Errorf("migrate openrouter model %s to %s: %w", legacyModelID, modelID, err)
+		}
+		if err := openRouterDeleteLegacyOpenRouterRows(legacyModelIDs); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func openRouterDeleteLegacyOpenRouterRows(modelIDs []string) error {
+	for _, modelID := range modelIDs {
+		existing, exists := GetModelConfig(modelID)
+		if !exists || existing.Source != openRouterModelSource {
+			continue
+		}
+		if err := DeleteModelConfig(modelID); err != nil {
+			return fmt.Errorf("delete old openrouter model %s: %w", modelID, err)
+		}
+	}
+	return nil
+}
+
+func openRouterSyncExistingAliasRows(model OpenRouterRemoteModel, owner string, modelIDs []string) error {
+	for _, modelID := range modelIDs {
+		existing, exists := GetModelConfig(modelID)
+		if !exists || existing.Source == openRouterModelSource {
+			continue
+		}
+		openRouterApplyModelSync(&existing, model, owner)
+		if err := UpsertModelConfig(existing); err != nil {
+			return fmt.Errorf("sync openrouter model alias %s: %w", modelID, err)
+		}
+	}
+	return nil
 }
 
 func ownerMatchesOpenRouterAliasPrefix(owner, cleanOwner string) bool {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -91,6 +91,90 @@ func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 	}
 }
 
+func TestSyncOpenRouterModelsUpdatesExistingOpenRouterDescription(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "gpt-openrouter-test",
+		OwnedBy:               "openai",
+		Description:           "Old OpenRouter description",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  9,
+		OutputPricePerMillion: 18,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "openai/gpt-openrouter-test",
+			Description: "Fresh remote description",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.00000175",
+				Completion: "0.000014",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 0 || result.Updated != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	model, ok := GetModelConfig("gpt-openrouter-test")
+	if !ok {
+		t.Fatal("expected existing OpenRouter model config")
+	}
+	if model.Description != "Fresh remote description" {
+		t.Fatalf("existing OpenRouter description should be refreshed, got %q", model.Description)
+	}
+}
+
+func TestSyncOpenRouterModelsFillsEmptyUserDescription(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "gpt-openrouter-test",
+		OwnedBy:               "custom-owner",
+		Description:           "",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  9,
+		OutputPricePerMillion: 18,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "openai/gpt-openrouter-test",
+			Description: "Remote description",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.00000175",
+				Completion: "0.000014",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 0 || result.Updated != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	model, ok := GetModelConfig("gpt-openrouter-test")
+	if !ok {
+		t.Fatal("expected existing model config")
+	}
+	if model.Description != "Remote description" || model.Source != "user" {
+		t.Fatalf("empty user description should be filled without changing source: %+v", model)
+	}
+}
+
 func TestSyncOpenRouterModelsStripsProviderPrefixAndTildeFromImportedModelID(t *testing.T) {
 	initModelConfigTestDB(t)
 
@@ -158,6 +242,50 @@ func TestSyncOpenRouterModelsNormalizesAnthropicVersionDots(t *testing.T) {
 	}
 }
 
+func TestSyncOpenRouterModelsUsesAnthropicDateSuffixBaseModelID(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "anthropic/claude-3-5-haiku-20241022",
+			Description: "Fast Claude Haiku model from OpenRouter",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.0000008",
+				Completion:     "0.000004",
+				InputCacheRead: "0.00000008",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 1 || result.Updated != 0 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	baseModel, ok := GetModelConfig("claude-3-5-haiku")
+	if !ok {
+		t.Fatal("expected Anthropic dated OpenRouter id to sync into the base Claude id")
+	}
+	if baseModel.OwnedBy != "anthropic" || baseModel.Description != "Fast Claude Haiku model from OpenRouter" {
+		t.Fatalf("unexpected base Claude metadata: %+v", baseModel)
+	}
+	if baseModel.InputPricePerMillion != 0.8 || baseModel.OutputPricePerMillion != 4 || baseModel.CachedPricePerMillion != 0.08 {
+		t.Fatalf("unexpected base Claude pricing: %+v", baseModel)
+	}
+
+	datedModel, ok := GetModelConfig("claude-3-5-haiku-20241022")
+	if !ok {
+		t.Fatal("expected seeded dated Claude id to remain available")
+	}
+	if datedModel.InputPricePerMillion != 0.8 || datedModel.OutputPricePerMillion != 4 || datedModel.CachedPricePerMillion != 0.08 {
+		t.Fatalf("dated Claude alias should reuse base pricing: %+v", datedModel)
+	}
+	if datedModel.Description != "Fast Claude Haiku model from OpenRouter" {
+		t.Fatalf("dated Claude alias should reuse base description, got %q", datedModel.Description)
+	}
+}
+
 func TestSyncOpenRouterModelsMigratesExistingOpenRouterPrefixedRows(t *testing.T) {
 	initModelConfigTestDB(t)
 
@@ -198,8 +326,8 @@ func TestSyncOpenRouterModelsMigratesExistingOpenRouterPrefixedRows(t *testing.T
 	if _, ok := GetModelConfig("openai/gpt-openrouter-legacy"); ok {
 		t.Fatal("did not expect old prefixed OpenRouter row to remain")
 	}
-	if model.Description != "Existing prefixed import" || model.Source != "openrouter" || model.OwnedBy != "openai" {
-		t.Fatalf("existing OpenRouter metadata should otherwise stay unchanged: %+v", model)
+	if model.Description != "Remote description" || model.Source != "openrouter" || model.OwnedBy != "openai" {
+		t.Fatalf("existing OpenRouter metadata should be refreshed during migration: %+v", model)
 	}
 	if model.InputPricePerMillion != 2 || model.OutputPricePerMillion != 8 {
 		t.Fatalf("existing OpenRouter pricing should be synced: %+v", model)


### PR DESCRIPTION
## Summary
- refresh OpenRouter/seed model descriptions during sync while preserving non-empty user descriptions
- normalize Anthropic Claude release-date IDs to base IDs such as claude-3-5-haiku
- keep existing dated aliases priced/described from the synced OpenRouter data

## Tests
- go test ./internal/usage -run 'TestSyncOpenRouterModels|TestOpenRouterPricePerMillionRoundsFloatArtifacts'
- go test ./internal/api/handlers/management ./internal/usage
- go test ./...
- git diff --check