### PR TITLE
fix: sync OpenRouter Claude dated aliases

### DIFF
--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -105,10 +105,10 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			if err := UpsertModelConfig(existing); err != nil {
 				return result, fmt.Errorf("sync openrouter model pricing %s: %w", modelID, err)
 			}
-			if err := openRouterDeleteLegacyOpenRouterRows(legacyModelIDs); err != nil {
+			if err := openRouterDeleteLegacyOpenRouterRows(modelID, legacyModelIDs); err != nil {
 				return result, err
 			}
-			if err := openRouterSyncExistingAliasRows(model, owner, legacyModelIDs); err != nil {
+			if err := openRouterSyncExistingAliasRows(modelID, model, owner, legacyModelIDs); err != nil {
 				return result, err
 			}
 			result.Updated++
@@ -119,7 +119,7 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			return result, err
 		}
 		if migrated {
-			if err := openRouterSyncExistingAliasRows(model, owner, legacyModelIDs); err != nil {
+			if err := openRouterSyncExistingAliasRows(modelID, model, owner, legacyModelIDs); err != nil {
 				return result, err
 			}
 			result.Updated++
@@ -140,7 +140,7 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 		if err := UpsertModelConfig(row); err != nil {
 			return result, fmt.Errorf("sync openrouter model %s: %w", modelID, err)
 		}
-		if err := openRouterSyncExistingAliasRows(model, owner, legacyModelIDs); err != nil {
+		if err := openRouterSyncExistingAliasRows(modelID, model, owner, legacyModelIDs); err != nil {
 			return result, err
 		}
 		result.Added++
@@ -459,8 +459,30 @@ func openRouterLegacyLocalModelIDs(remoteModelID, owner, modelID string) []strin
 	add(providerless)
 	if normalizeModelOwnerValue(owner) == "anthropic" {
 		add(strings.ReplaceAll(providerless, ".", "-"))
+		for _, aliasID := range openRouterExistingAnthropicReleaseDateAliasIDs(modelID) {
+			add(aliasID)
+		}
 	}
 	return ids
+}
+
+func openRouterExistingAnthropicReleaseDateAliasIDs(modelID string) []string {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return nil
+	}
+	prefix := modelID + "-"
+	var aliases []string
+	for _, row := range ListModelConfigs() {
+		aliasID := strings.TrimSpace(row.ModelID)
+		if aliasID == modelID || !strings.HasPrefix(aliasID, prefix) {
+			continue
+		}
+		if openRouterStripAnthropicReleaseDate(aliasID) == modelID {
+			aliases = append(aliases, aliasID)
+		}
+	}
+	return aliases
 }
 
 func openRouterApplyModelSync(row *ModelConfigRow, model OpenRouterRemoteModel, owner string) {
@@ -494,6 +516,9 @@ func openRouterShouldSyncDescription(row ModelConfigRow) bool {
 
 func openRouterMigrateLegacyOpenRouterRow(modelID, owner string, model OpenRouterRemoteModel, legacyModelIDs []string) (bool, error) {
 	for _, legacyModelID := range legacyModelIDs {
+		if openRouterIsAnthropicReleaseDateAlias(legacyModelID, modelID) {
+			continue
+		}
 		existing, exists := GetModelConfig(legacyModelID)
 		if !exists || existing.Source != openRouterModelSource {
 			continue
@@ -503,7 +528,7 @@ func openRouterMigrateLegacyOpenRouterRow(modelID, owner string, model OpenRoute
 		if err := UpsertModelConfig(existing); err != nil {
 			return false, fmt.Errorf("migrate openrouter model %s to %s: %w", legacyModelID, modelID, err)
 		}
-		if err := openRouterDeleteLegacyOpenRouterRows(legacyModelIDs); err != nil {
+		if err := openRouterDeleteLegacyOpenRouterRows(modelID, legacyModelIDs); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -511,8 +536,11 @@ func openRouterMigrateLegacyOpenRouterRow(modelID, owner string, model OpenRoute
 	return false, nil
 }
 
-func openRouterDeleteLegacyOpenRouterRows(modelIDs []string) error {
+func openRouterDeleteLegacyOpenRouterRows(baseModelID string, modelIDs []string) error {
 	for _, modelID := range modelIDs {
+		if openRouterIsAnthropicReleaseDateAlias(modelID, baseModelID) {
+			continue
+		}
 		existing, exists := GetModelConfig(modelID)
 		if !exists || existing.Source != openRouterModelSource {
 			continue
@@ -524,10 +552,13 @@ func openRouterDeleteLegacyOpenRouterRows(modelIDs []string) error {
 	return nil
 }
 
-func openRouterSyncExistingAliasRows(model OpenRouterRemoteModel, owner string, modelIDs []string) error {
+func openRouterSyncExistingAliasRows(baseModelID string, model OpenRouterRemoteModel, owner string, modelIDs []string) error {
 	for _, modelID := range modelIDs {
 		existing, exists := GetModelConfig(modelID)
-		if !exists || existing.Source == openRouterModelSource {
+		if !exists {
+			continue
+		}
+		if existing.Source == openRouterModelSource && !openRouterIsAnthropicReleaseDateAlias(modelID, baseModelID) {
 			continue
 		}
 		openRouterApplyModelSync(&existing, model, owner)
@@ -536,6 +567,12 @@ func openRouterSyncExistingAliasRows(model OpenRouterRemoteModel, owner string, 
 		}
 	}
 	return nil
+}
+
+func openRouterIsAnthropicReleaseDateAlias(modelID, baseModelID string) bool {
+	modelID = strings.TrimSpace(modelID)
+	baseModelID = strings.TrimSpace(baseModelID)
+	return modelID != "" && baseModelID != "" && modelID != baseModelID && openRouterStripAnthropicReleaseDate(modelID) == baseModelID
 }
 
 func ownerMatchesOpenRouterAliasPrefix(owner, cleanOwner string) bool {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -286,6 +286,93 @@ func TestSyncOpenRouterModelsUsesAnthropicDateSuffixBaseModelID(t *testing.T) {
 	}
 }
 
+func TestSyncOpenRouterModelsUpdatesAnthropicDatedAliasFromBaseRemoteID(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "anthropic/claude-3.5-haiku",
+			Description: "Fast Claude Haiku model from OpenRouter",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.0000008",
+				Completion:     "0.000004",
+				InputCacheRead: "0.00000008",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 1 || result.Updated != 0 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	baseModel, ok := GetModelConfig("claude-3-5-haiku")
+	if !ok {
+		t.Fatal("expected base Claude model to be imported")
+	}
+	if baseModel.InputPricePerMillion != 0.8 || baseModel.OutputPricePerMillion != 4 || baseModel.CachedPricePerMillion != 0.08 {
+		t.Fatalf("unexpected base Claude pricing: %+v", baseModel)
+	}
+
+	datedModel, ok := GetModelConfig("claude-3-5-haiku-20241022")
+	if !ok {
+		t.Fatal("expected seeded dated Claude alias to remain available")
+	}
+	if datedModel.InputPricePerMillion != 0.8 || datedModel.OutputPricePerMillion != 4 || datedModel.CachedPricePerMillion != 0.08 {
+		t.Fatalf("dated Claude alias should reuse base remote pricing: %+v", datedModel)
+	}
+	if datedModel.Description != "Fast Claude Haiku model from OpenRouter" {
+		t.Fatalf("dated Claude alias should reuse base remote description, got %q", datedModel.Description)
+	}
+}
+
+func TestSyncOpenRouterModelsPreservesExistingOpenRouterDatedAliasFromBaseRemoteID(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "claude-3-5-haiku-20241022",
+		OwnedBy:               "anthropic",
+		Description:           "Old OpenRouter dated alias",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0,
+		OutputPricePerMillion: 0,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "anthropic/claude-3.5-haiku",
+			Description: "Fast Claude Haiku model from OpenRouter",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.0000008",
+				Completion:     "0.000004",
+				InputCacheRead: "0.00000008",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 1 || result.Updated != 0 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	datedModel, ok := GetModelConfig("claude-3-5-haiku-20241022")
+	if !ok {
+		t.Fatal("expected existing OpenRouter dated alias to remain available")
+	}
+	if datedModel.Source != "openrouter" || datedModel.Description != "Fast Claude Haiku model from OpenRouter" {
+		t.Fatalf("dated OpenRouter alias metadata should be refreshed: %+v", datedModel)
+	}
+	if datedModel.InputPricePerMillion != 0.8 || datedModel.OutputPricePerMillion != 4 || datedModel.CachedPricePerMillion != 0.08 {
+		t.Fatalf("dated OpenRouter alias should reuse base remote pricing: %+v", datedModel)
+	}
+}
+
 func TestSyncOpenRouterModelsMigratesExistingOpenRouterPrefixedRows(t *testing.T) {
 	initModelConfigTestDB(t)
 


### PR DESCRIPTION
## Summary
- update existing Claude release-date aliases when OpenRouter only returns the base Claude model id
- preserve older OpenRouter-sourced dated aliases and refresh their pricing/description instead of migrating them away
- add regression coverage for claude-3.5-haiku syncing claude-3-5-haiku-20241022

## Tests
- go test ./internal/usage -run 'TestSyncOpenRouterModels|TestOpenRouterPricePerMillionRoundsFloatArtifacts'
- go test ./internal/api/handlers/management ./internal/usage
- go test ./...
- git diff --check