### PR TITLE
feat: add AWS Bedrock provider support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/internal/api/handlers/management/bedrock_config_test.go
+++ b/internal/api/handlers/management/bedrock_config_test.go
@@ -1,0 +1,92 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func performBedrockConfigRequest(method string, path string, body []byte, handler gin.HandlerFunc) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	if body == nil {
+		c.Request = httptest.NewRequest(method, path, nil)
+	} else {
+		c.Request = httptest.NewRequest(method, path, bytes.NewReader(body))
+	}
+	handler(c)
+	return rec
+}
+
+func TestBedrockKeyManagementHandlers(t *testing.T) {
+	cfg := &config.Config{}
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8317\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	h := NewHandler(cfg, configPath, nil)
+	t.Cleanup(h.Close)
+
+	payload := []byte(`[
+		{
+			"name":"aws api",
+			"auth-mode":"api-key",
+			"api-key":"br-key",
+			"region":"eu-west-1",
+			"force-global":true,
+			"models":[{"name":"claude-sonnet-4-5","alias":"aws-sonnet"}]
+		},
+		{
+			"name":"aws sigv4",
+			"auth-mode":"sigv4",
+			"access-key-id":"AKIA",
+			"secret-access-key":"SECRET",
+			"region":"us-east-1"
+		}
+	]`)
+
+	putRec := performBedrockConfigRequest(http.MethodPut, "/bedrock-api-key", payload, h.PutBedrockKeys)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d body=%s", putRec.Code, putRec.Body.String())
+	}
+	if len(cfg.BedrockKey) != 2 {
+		t.Fatalf("expected 2 bedrock keys, got %d", len(cfg.BedrockKey))
+	}
+
+	patchPayload := []byte(`{"index":1,"value":{"name":"renamed sigv4","region":"ap-southeast-2","session-token":"SESSION"}}`)
+	patchRec := performBedrockConfigRequest(http.MethodPatch, "/bedrock-api-key", patchPayload, h.PatchBedrockKey)
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d body=%s", patchRec.Code, patchRec.Body.String())
+	}
+	if cfg.BedrockKey[1].Name != "renamed sigv4" || cfg.BedrockKey[1].Region != "ap-southeast-2" || cfg.BedrockKey[1].SessionToken != "SESSION" {
+		t.Fatalf("unexpected patched key: %+v", cfg.BedrockKey[1])
+	}
+
+	getRec := performBedrockConfigRequest(http.MethodGet, "/bedrock-api-key", nil, h.GetBedrockKeys)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d body=%s", getRec.Code, getRec.Body.String())
+	}
+	var got map[string][]config.BedrockKey
+	if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode GET body: %v", err)
+	}
+	if len(got["bedrock-api-key"]) != 2 {
+		t.Fatalf("expected 2 keys from GET, got %+v", got)
+	}
+
+	deleteRec := performBedrockConfigRequest(http.MethodDelete, "/bedrock-api-key?index=0", nil, h.DeleteBedrockKey)
+	if deleteRec.Code != http.StatusOK {
+		t.Fatalf("DELETE status = %d body=%s", deleteRec.Code, deleteRec.Body.String())
+	}
+	if len(cfg.BedrockKey) != 1 || cfg.BedrockKey[0].Name != "renamed sigv4" {
+		t.Fatalf("unexpected keys after delete: %+v", cfg.BedrockKey)
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -744,6 +744,211 @@ func (h *Handler) DeleteClaudeKey(c *gin.Context) {
 	c.JSON(400, gin.H{"error": "missing api-key or index"})
 }
 
+// bedrock-api-key: []BedrockKey
+func (h *Handler) GetBedrockKeys(c *gin.Context) {
+	c.JSON(200, gin.H{"bedrock-api-key": h.cfg.BedrockKey})
+}
+
+func (h *Handler) PutBedrockKeys(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var arr []config.BedrockKey
+	if err = json.Unmarshal(data, &arr); err != nil {
+		var obj struct {
+			Items []config.BedrockKey `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		arr = obj.Items
+	}
+	for i := range arr {
+		normalizeBedrockKey(&arr[i])
+	}
+	prev := append([]config.BedrockKey(nil), h.cfg.BedrockKey...)
+	h.cfg.BedrockKey = arr
+	h.cfg.SanitizeBedrockKeys()
+	if err := h.validateChannelNames(); err != nil {
+		h.cfg.BedrockKey = prev
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	h.persist(c)
+}
+
+func (h *Handler) PatchBedrockKey(c *gin.Context) {
+	type bedrockKeyPatch struct {
+		Name            *string                `json:"name"`
+		Priority        *int                   `json:"priority"`
+		Prefix          *string                `json:"prefix"`
+		AuthMode        *string                `json:"auth-mode"`
+		APIKey          *string                `json:"api-key"`
+		AccessKeyID     *string                `json:"access-key-id"`
+		SecretAccessKey *string                `json:"secret-access-key"`
+		SessionToken    *string                `json:"session-token"`
+		Region          *string                `json:"region"`
+		ForceGlobal     *bool                  `json:"force-global"`
+		BaseURL         *string                `json:"base-url"`
+		ProxyURL        *string                `json:"proxy-url"`
+		ProxyID         *string                `json:"proxy-id"`
+		Models          *[]config.BedrockModel `json:"models"`
+		Headers         *map[string]string     `json:"headers"`
+		ExcludedModels  *[]string              `json:"excluded-models"`
+	}
+	var body struct {
+		Index *int             `json:"index"`
+		Match *string          `json:"match"`
+		Value *bedrockKeyPatch `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	targetIndex := -1
+	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.BedrockKey) {
+		targetIndex = *body.Index
+	}
+	if targetIndex == -1 && body.Match != nil {
+		match := strings.TrimSpace(*body.Match)
+		for i := range h.cfg.BedrockKey {
+			entry := h.cfg.BedrockKey[i]
+			if entry.APIKey == match || entry.AccessKeyID == match || entry.Name == match {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 {
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+
+	entry := h.cfg.BedrockKey[targetIndex]
+	if body.Value.Name != nil {
+		entry.Name = strings.TrimSpace(*body.Value.Name)
+	}
+	if body.Value.Priority != nil {
+		entry.Priority = *body.Value.Priority
+	}
+	if body.Value.Prefix != nil {
+		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+	}
+	if body.Value.AuthMode != nil {
+		entry.AuthMode = strings.TrimSpace(*body.Value.AuthMode)
+	}
+	if body.Value.APIKey != nil {
+		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.AccessKeyID != nil {
+		entry.AccessKeyID = strings.TrimSpace(*body.Value.AccessKeyID)
+	}
+	if body.Value.SecretAccessKey != nil {
+		entry.SecretAccessKey = strings.TrimSpace(*body.Value.SecretAccessKey)
+	}
+	if body.Value.SessionToken != nil {
+		entry.SessionToken = strings.TrimSpace(*body.Value.SessionToken)
+	}
+	if body.Value.Region != nil {
+		entry.Region = strings.TrimSpace(*body.Value.Region)
+	}
+	if body.Value.ForceGlobal != nil {
+		entry.ForceGlobal = *body.Value.ForceGlobal
+	}
+	if body.Value.BaseURL != nil {
+		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
+	}
+	if body.Value.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
+	}
+	if body.Value.ProxyID != nil {
+		entry.ProxyID = strings.TrimSpace(*body.Value.ProxyID)
+	}
+	if body.Value.Models != nil {
+		entry.Models = append([]config.BedrockModel(nil), (*body.Value.Models)...)
+	}
+	if body.Value.Headers != nil {
+		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
+	}
+	if body.Value.ExcludedModels != nil {
+		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+	}
+	normalizeBedrockKey(&entry)
+	prev := append([]config.BedrockKey(nil), h.cfg.BedrockKey...)
+	h.cfg.BedrockKey[targetIndex] = entry
+	h.cfg.SanitizeBedrockKeys()
+	if err := h.validateChannelNames(); err != nil {
+		h.cfg.BedrockKey = prev
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	h.persist(c)
+}
+
+func (h *Handler) DeleteBedrockKey(c *gin.Context) {
+	if val := strings.TrimSpace(c.Query("api-key")); val != "" {
+		out := make([]config.BedrockKey, 0, len(h.cfg.BedrockKey))
+		for _, v := range h.cfg.BedrockKey {
+			if v.APIKey != val {
+				out = append(out, v)
+			}
+		}
+		if len(out) != len(h.cfg.BedrockKey) {
+			h.cfg.BedrockKey = out
+			h.cfg.SanitizeBedrockKeys()
+			h.persist(c)
+			return
+		}
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+	if val := strings.TrimSpace(c.Query("access-key-id")); val != "" {
+		out := make([]config.BedrockKey, 0, len(h.cfg.BedrockKey))
+		for _, v := range h.cfg.BedrockKey {
+			if v.AccessKeyID != val {
+				out = append(out, v)
+			}
+		}
+		if len(out) != len(h.cfg.BedrockKey) {
+			h.cfg.BedrockKey = out
+			h.cfg.SanitizeBedrockKeys()
+			h.persist(c)
+			return
+		}
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+	if val := strings.TrimSpace(c.Query("name")); val != "" {
+		out := make([]config.BedrockKey, 0, len(h.cfg.BedrockKey))
+		for _, v := range h.cfg.BedrockKey {
+			if v.Name != val {
+				out = append(out, v)
+			}
+		}
+		if len(out) != len(h.cfg.BedrockKey) {
+			h.cfg.BedrockKey = out
+			h.cfg.SanitizeBedrockKeys()
+			h.persist(c)
+			return
+		}
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+	if idxStr := c.Query("index"); idxStr != "" {
+		var idx int
+		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && idx >= 0 && idx < len(h.cfg.BedrockKey) {
+			h.cfg.BedrockKey = append(h.cfg.BedrockKey[:idx], h.cfg.BedrockKey[idx+1:]...)
+			h.cfg.SanitizeBedrockKeys()
+			h.persist(c)
+			return
+		}
+	}
+	c.JSON(400, gin.H{"error": "missing api-key, access-key-id, name, or index"})
+}
+
 // openai-compatibility: []OpenAICompatibility
 func (h *Handler) GetOpenAICompat(c *gin.Context) {
 	c.JSON(200, gin.H{"openai-compatibility": normalizedOpenAICompatibilityEntries(h.cfg.OpenAICompatibility)})
@@ -1398,6 +1603,39 @@ func normalizeClaudeKey(entry *config.ClaudeKey) {
 		return
 	}
 	normalized := make([]config.ClaudeModel, 0, len(entry.Models))
+	for i := range entry.Models {
+		model := entry.Models[i]
+		model.Name = strings.TrimSpace(model.Name)
+		model.Alias = strings.TrimSpace(model.Alias)
+		if model.Name == "" && model.Alias == "" {
+			continue
+		}
+		normalized = append(normalized, model)
+	}
+	entry.Models = normalized
+}
+
+func normalizeBedrockKey(entry *config.BedrockKey) {
+	if entry == nil {
+		return
+	}
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.AuthMode = strings.TrimSpace(entry.AuthMode)
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.AccessKeyID = strings.TrimSpace(entry.AccessKeyID)
+	entry.SecretAccessKey = strings.TrimSpace(entry.SecretAccessKey)
+	entry.SessionToken = strings.TrimSpace(entry.SessionToken)
+	entry.Region = strings.TrimSpace(entry.Region)
+	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	if len(entry.Models) == 0 {
+		return
+	}
+	normalized := make([]config.BedrockModel, 0, len(entry.Models))
 	for i := range entry.Models {
 		model := entry.Models[i]
 		model.Name = strings.TrimSpace(model.Name)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -754,6 +754,11 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/claude-api-key", s.mgmt.PatchClaudeKey)
 		mgmt.DELETE("/claude-api-key", s.mgmt.DeleteClaudeKey)
 
+		mgmt.GET("/bedrock-api-key", s.mgmt.GetBedrockKeys)
+		mgmt.PUT("/bedrock-api-key", s.mgmt.PutBedrockKeys)
+		mgmt.PATCH("/bedrock-api-key", s.mgmt.PatchBedrockKey)
+		mgmt.DELETE("/bedrock-api-key", s.mgmt.DeleteBedrockKey)
+
 		mgmt.GET("/codex-api-key", s.mgmt.GetCodexKeys)
 		mgmt.PUT("/codex-api-key", s.mgmt.PutCodexKeys)
 		mgmt.PATCH("/codex-api-key", s.mgmt.PatchCodexKey)

--- a/internal/config/bedrock.go
+++ b/internal/config/bedrock.go
@@ -1,0 +1,170 @@
+package config
+
+import "strings"
+
+const (
+	DefaultBedrockRegion  = "us-east-1"
+	BedrockAuthModeSigV4  = "sigv4"
+	BedrockAuthModeAPIKey = "api-key"
+)
+
+// BedrockKey represents an AWS Bedrock Runtime credential.
+// It supports both AWS SigV4 credentials and Bedrock API key bearer auth.
+type BedrockKey struct {
+	// Name is a human-readable label for this channel.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
+	// Priority controls selection preference when multiple credentials match.
+	// Higher values are preferred; defaults to 0.
+	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Prefix optionally namespaces model aliases for this credential.
+	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// AuthMode selects credential handling: "sigv4" (default) or "api-key".
+	AuthMode string `yaml:"auth-mode,omitempty" json:"auth-mode,omitempty"`
+
+	// APIKey is used when AuthMode is "api-key" and maps to Authorization: Bearer.
+	APIKey string `yaml:"api-key,omitempty" json:"api-key,omitempty"`
+
+	// AccessKeyID is the AWS access key id used for SigV4 signing.
+	AccessKeyID string `yaml:"access-key-id,omitempty" json:"access-key-id,omitempty"`
+
+	// SecretAccessKey is the AWS secret access key used for SigV4 signing.
+	SecretAccessKey string `yaml:"secret-access-key,omitempty" json:"secret-access-key,omitempty"`
+
+	// SessionToken is an optional AWS session token for temporary credentials.
+	SessionToken string `yaml:"session-token,omitempty" json:"session-token,omitempty"`
+
+	// Region is the Bedrock Runtime region. Empty defaults to us-east-1.
+	Region string `yaml:"region,omitempty" json:"region,omitempty"`
+
+	// ForceGlobal maps supported Claude aliases to the global Bedrock prefix.
+	ForceGlobal bool `yaml:"force-global,omitempty" json:"force-global,omitempty"`
+
+	// BaseURL optionally overrides the Bedrock Runtime endpoint.
+	BaseURL string `yaml:"base-url,omitempty" json:"base-url,omitempty"`
+
+	// ProxyURL overrides the global proxy setting for this credential.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+
+	// ProxyID references a reusable proxy-pool entry. When valid, it takes precedence over ProxyURL.
+	ProxyID string `yaml:"proxy-id,omitempty" json:"proxy-id,omitempty"`
+
+	// Models defines upstream model names and aliases for request routing.
+	Models []BedrockModel `yaml:"models,omitempty" json:"models,omitempty"`
+
+	// Headers optionally adds extra HTTP headers for requests sent with this credential.
+	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+
+	// ExcludedModels lists model IDs that should be excluded for this credential.
+	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+}
+
+func (k BedrockKey) GetAPIKey() string {
+	if strings.EqualFold(strings.TrimSpace(k.AuthMode), BedrockAuthModeAPIKey) {
+		return k.APIKey
+	}
+	if strings.TrimSpace(k.APIKey) != "" {
+		return k.APIKey
+	}
+	return k.AccessKeyID
+}
+
+func (k BedrockKey) GetBaseURL() string { return k.BaseURL }
+
+// BedrockModel describes an upstream Bedrock/Claude model and a client-facing alias.
+type BedrockModel struct {
+	// Name is the upstream model or Claude alias used by the executor.
+	Name string `yaml:"name" json:"name"`
+
+	// Alias is the client-facing model name.
+	Alias string `yaml:"alias" json:"alias"`
+}
+
+func (m BedrockModel) GetName() string  { return m.Name }
+func (m BedrockModel) GetAlias() string { return m.Alias }
+
+// SanitizeBedrockKeys deduplicates and normalizes AWS Bedrock credentials.
+func (cfg *Config) SanitizeBedrockKeys() {
+	if cfg == nil {
+		return
+	}
+
+	seen := make(map[string]struct{}, len(cfg.BedrockKey))
+	out := cfg.BedrockKey[:0]
+	for i := range cfg.BedrockKey {
+		entry := cfg.BedrockKey[i]
+		entry.Name = strings.TrimSpace(entry.Name)
+		entry.Priority = entry.Priority
+		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.AuthMode = normalizeBedrockAuthMode(entry.AuthMode)
+		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		entry.AccessKeyID = strings.TrimSpace(entry.AccessKeyID)
+		entry.SecretAccessKey = strings.TrimSpace(entry.SecretAccessKey)
+		entry.SessionToken = strings.TrimSpace(entry.SessionToken)
+		entry.Region = strings.TrimSpace(entry.Region)
+		if entry.Region == "" {
+			entry.Region = DefaultBedrockRegion
+		}
+		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+		entry.Headers = NormalizeHeaders(entry.Headers)
+		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		entry.Models = sanitizeBedrockModels(entry.Models)
+
+		var credentialKey string
+		if entry.AuthMode == BedrockAuthModeAPIKey {
+			if entry.APIKey == "" {
+				continue
+			}
+			credentialKey = strings.Join([]string{entry.AuthMode, entry.APIKey, entry.Region, entry.BaseURL}, "|")
+		} else {
+			if entry.AccessKeyID == "" || entry.SecretAccessKey == "" {
+				continue
+			}
+			credentialKey = strings.Join([]string{entry.AuthMode, entry.AccessKeyID, entry.SecretAccessKey, entry.SessionToken, entry.Region, entry.BaseURL}, "|")
+		}
+		if _, exists := seen[credentialKey]; exists {
+			continue
+		}
+		seen[credentialKey] = struct{}{}
+		out = append(out, entry)
+	}
+	cfg.BedrockKey = out
+}
+
+func normalizeBedrockAuthMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "apikey", "api_key", BedrockAuthModeAPIKey:
+		return BedrockAuthModeAPIKey
+	default:
+		return BedrockAuthModeSigV4
+	}
+}
+
+func sanitizeBedrockModels(models []BedrockModel) []BedrockModel {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]BedrockModel, 0, len(models))
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		model.Name = strings.TrimSpace(model.Name)
+		model.Alias = strings.TrimSpace(model.Alias)
+		if model.Name == "" && model.Alias == "" {
+			continue
+		}
+		key := strings.ToLower(model.Name) + "|" + strings.ToLower(model.Alias)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, model)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/config/bedrock_test.go
+++ b/internal/config/bedrock_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigReadsBedrockKeys(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`port: 8317
+bedrock-api-key:
+  - name: bedrock bearer
+    auth-mode: api-key
+    api-key: br-key
+    region: eu-west-1
+    force-global: true
+    base-url: https://bedrock.local
+    prefix: aws
+    proxy-url: http://proxy.local:8080
+    proxy-id: hk
+    headers:
+      X-Test: yes
+    models:
+      - name: claude-sonnet-4-5
+        alias: aws-sonnet
+    excluded-models:
+      - claude-opus-*
+  - name: bedrock sigv4
+    auth-mode: sigv4
+    access-key-id: AKIATEST
+    secret-access-key: SECRET
+    session-token: SESSION
+    region: us-east-1
+`)
+	if err := os.WriteFile(configPath, content, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if len(cfg.BedrockKey) != 2 {
+		t.Fatalf("expected 2 bedrock keys, got %d", len(cfg.BedrockKey))
+	}
+	first := cfg.BedrockKey[0]
+	if first.AuthMode != "api-key" {
+		t.Fatalf("first auth-mode = %q, want api-key", first.AuthMode)
+	}
+	if first.APIKey != "br-key" || first.Region != "eu-west-1" || !first.ForceGlobal {
+		t.Fatalf("unexpected first credential: %+v", first)
+	}
+	if first.Headers["X-Test"] != "yes" {
+		t.Fatalf("expected header to survive normalization, got %+v", first.Headers)
+	}
+	if len(first.Models) != 1 || first.Models[0].Alias != "aws-sonnet" {
+		t.Fatalf("unexpected models: %+v", first.Models)
+	}
+	second := cfg.BedrockKey[1]
+	if second.AuthMode != "sigv4" {
+		t.Fatalf("second auth-mode = %q, want sigv4", second.AuthMode)
+	}
+	if second.AccessKeyID != "AKIATEST" || second.SecretAccessKey != "SECRET" || second.SessionToken != "SESSION" {
+		t.Fatalf("unexpected sigv4 credential: %+v", second)
+	}
+}
+
+func TestSanitizeBedrockKeys(t *testing.T) {
+	cfg := &Config{
+		BedrockKey: []BedrockKey{
+			{
+				Name:            " sig ",
+				AuthMode:        " ",
+				AccessKeyID:     " AKIA ",
+				SecretAccessKey: " SECRET ",
+				Region:          " ",
+				Prefix:          "/team/",
+				Headers:         map[string]string{" x-test ": " ok "},
+				Models: []BedrockModel{
+					{Name: " claude-sonnet-4-5 ", Alias: " sonnet "},
+					{Name: " ", Alias: " "},
+				},
+				ExcludedModels: []string{" claude-opus-* ", ""},
+			},
+			{AuthMode: "sigv4", AccessKeyID: "AKIA", SecretAccessKey: "SECRET"},
+			{AuthMode: "api-key", APIKey: " br-key ", Region: " ap-southeast-2 "},
+			{AuthMode: "api-key", APIKey: " "},
+			{AuthMode: "sigv4", AccessKeyID: "missing-secret"},
+		},
+	}
+
+	cfg.SanitizeBedrockKeys()
+
+	if len(cfg.BedrockKey) != 2 {
+		t.Fatalf("expected 2 sanitized bedrock keys, got %d: %+v", len(cfg.BedrockKey), cfg.BedrockKey)
+	}
+	sig := cfg.BedrockKey[0]
+	if sig.AuthMode != "sigv4" || sig.Region != "us-east-1" || sig.Prefix != "team" {
+		t.Fatalf("unexpected sigv4 normalized fields: %+v", sig)
+	}
+	if sig.AccessKeyID != "AKIA" || sig.SecretAccessKey != "SECRET" {
+		t.Fatalf("unexpected sigv4 credentials: %+v", sig)
+	}
+	if sig.Headers["x-test"] != "ok" {
+		t.Fatalf("expected normalized header, got %+v", sig.Headers)
+	}
+	if len(sig.Models) != 1 || sig.Models[0].Name != "claude-sonnet-4-5" || sig.Models[0].Alias != "sonnet" {
+		t.Fatalf("unexpected sanitized models: %+v", sig.Models)
+	}
+	if len(sig.ExcludedModels) != 1 || sig.ExcludedModels[0] != "claude-opus-*" {
+		t.Fatalf("unexpected excluded models: %+v", sig.ExcludedModels)
+	}
+	apiKey := cfg.BedrockKey[1]
+	if apiKey.AuthMode != "api-key" || apiKey.APIKey != "br-key" || apiKey.Region != "ap-southeast-2" {
+		t.Fatalf("unexpected api-key normalized fields: %+v", apiKey)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,9 @@ type Config struct {
 	// ClaudeKey defines a list of Claude API key configurations as specified in the YAML configuration file.
 	ClaudeKey []ClaudeKey `yaml:"claude-api-key" json:"claude-api-key"`
 
+	// BedrockKey defines AWS Bedrock Runtime credential configurations.
+	BedrockKey []BedrockKey `yaml:"bedrock-api-key" json:"bedrock-api-key"`
+
 	// ClaudeHeaderDefaults configures default header values for Claude API requests.
 	// These are used as fallbacks when the client does not send its own headers.
 	ClaudeHeaderDefaults ClaudeHeaderDefaults `yaml:"claude-header-defaults" json:"claude-header-defaults"`
@@ -792,6 +795,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// Sanitize Claude key headers
 	cfg.SanitizeClaudeKeys()
+
+	// Sanitize AWS Bedrock Runtime credentials.
+	cfg.SanitizeBedrockKeys()
 
 	// Normalize provider identity fingerprints.
 	cfg.SanitizeIdentityFingerprint()

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -16,6 +16,7 @@ import (
 //   - vertex
 //   - gemini-cli
 //   - aistudio
+//   - bedrock
 //   - codex
 //   - qwen
 //   - iflow
@@ -26,6 +27,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	switch key {
 	case "claude":
 		return GetClaudeModels()
+	case "bedrock":
+		return GetBedrockModels()
 	case "gemini":
 		return GetGeminiModels()
 	case "vertex":
@@ -79,6 +82,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 
 	allModels := [][]*ModelInfo{
 		GetClaudeModels(),
+		GetBedrockModels(),
 		GetGeminiModels(),
 		GetGeminiVertexModels(),
 		GetGeminiCLIModels(),
@@ -106,4 +110,23 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 	}
 
 	return nil
+}
+
+// GetBedrockModels returns the Claude-family model definitions exposed through AWS Bedrock.
+func GetBedrockModels() []*ModelInfo {
+	claudeModels := GetClaudeModels()
+	if len(claudeModels) == 0 {
+		return nil
+	}
+	out := make([]*ModelInfo, 0, len(claudeModels))
+	for _, model := range claudeModels {
+		if model == nil {
+			continue
+		}
+		clone := *model
+		clone.OwnedBy = "aws"
+		clone.Type = "bedrock"
+		out = append(out, &clone)
+	}
+	return out
 }

--- a/internal/runtime/executor/bedrock_executor.go
+++ b/internal/runtime/executor/bedrock_executor.go
@@ -1,0 +1,817 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	defaultBedrockRegion  = "us-east-1"
+	bedrockAuthModeAPIKey = "api-key"
+)
+
+var bedrockCrossRegionPrefixes = []string{"us.", "eu.", "apac.", "jp.", "au.", "us-gov.", "global."}
+
+var defaultBedrockModelMapping = map[string]string{
+	"claude-opus-4-7":            "us.anthropic.claude-opus-4-7-v1",
+	"claude-opus-4-6-thinking":   "us.anthropic.claude-opus-4-6-v1",
+	"claude-opus-4-6":            "us.anthropic.claude-opus-4-6-v1",
+	"claude-opus-4-5-thinking":   "us.anthropic.claude-opus-4-5-20251101-v1:0",
+	"claude-opus-4-5-20251101":   "us.anthropic.claude-opus-4-5-20251101-v1:0",
+	"claude-opus-4-1":            "us.anthropic.claude-opus-4-1-20250805-v1:0",
+	"claude-opus-4-20250514":     "us.anthropic.claude-opus-4-20250514-v1:0",
+	"claude-sonnet-4-6-thinking": "us.anthropic.claude-sonnet-4-6",
+	"claude-sonnet-4-6":          "us.anthropic.claude-sonnet-4-6",
+	"claude-sonnet-4-5":          "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+	"claude-sonnet-4-5-thinking": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+	"claude-sonnet-4-5-20250929": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+	"claude-sonnet-4-20250514":   "us.anthropic.claude-sonnet-4-20250514-v1:0",
+	"claude-haiku-4-5":           "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+	"claude-haiku-4-5-20251001":  "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+}
+
+// BedrockExecutor executes Anthropic Claude payloads through AWS Bedrock Runtime.
+type BedrockExecutor struct {
+	cfg *config.Config
+}
+
+func NewBedrockExecutor(cfg *config.Config) *BedrockExecutor { return &BedrockExecutor{cfg: cfg} }
+
+func (e *BedrockExecutor) Identifier() string { return "bedrock" }
+
+func (e *BedrockExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
+	if req == nil {
+		return nil
+	}
+	body, err := readAndResetRequestBody(req)
+	if err != nil {
+		return err
+	}
+	return e.prepareBedrockHTTPRequest(req.Context(), req, auth, body)
+}
+
+func (e *BedrockExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("bedrock executor: request is nil")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	body, err := readAndResetRequestBody(req)
+	if err != nil {
+		return nil, err
+	}
+	httpReq := req.WithContext(ctx)
+	if err := e.prepareBedrockHTTPRequest(ctx, httpReq, auth, body); err != nil {
+		return nil, err
+	}
+	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	return httpClient.Do(httpReq)
+}
+
+func (e *BedrockExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if opts.Alt == "responses/compact" {
+		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	}
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	mappedModel, ok := resolveBedrockModelID(auth, baseModel)
+	if !ok {
+		err = statusErr{code: http.StatusBadRequest, msg: "unsupported bedrock model: " + baseModel}
+		return resp, err
+	}
+
+	reporter := newUsageReporter(ctx, e.Identifier(), baseModel, auth)
+	defer reporter.trackFailure(ctx, &err)
+
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("claude")
+	translatorStreamMode := from != to
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayloadSource, translatorStreamMode)
+	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, translatorStreamMode)
+	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return resp, err
+	}
+	requestedModel := payloadRequestedModel(opts, req.Model)
+	body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	body = disableThinkingIfToolChoiceForced(body)
+	betaTokens := resolveBedrockBetaTokens(opts.Headers.Get("anthropic-beta"), body, mappedModel)
+	bodyForTranslation := body
+	body, err = prepareBedrockRequestBody(body, mappedModel, betaTokens)
+	if err != nil {
+		return resp, err
+	}
+
+	httpResp, err := e.doBedrockRequest(ctx, auth, mappedModel, false, body)
+	if err != nil {
+		recordAPIResponseError(ctx, e.cfg, err)
+		reporter.publishFailureWithContent(ctx, string(req.Payload), err.Error())
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("bedrock executor: close response body error: %v", errClose)
+		}
+	}()
+	recordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+		appendAPIResponseChunk(ctx, e.cfg, b)
+		reporter.publishFailureWithContent(ctx, string(req.Payload), string(b))
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return resp, err
+	}
+	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
+	if err != nil {
+		recordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	data = transformBedrockInvocationMetrics(data)
+	appendAPIResponseChunk(ctx, e.cfg, data)
+	reporter.publishWithContent(ctx, parseClaudeUsage(data), string(req.Payload), string(data))
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, bodyForTranslation, data, &param)
+	resp = cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}
+	return resp, nil
+}
+
+func (e *BedrockExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	if opts.Alt == "responses/compact" {
+		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	}
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	mappedModel, ok := resolveBedrockModelID(auth, baseModel)
+	if !ok {
+		err = statusErr{code: http.StatusBadRequest, msg: "unsupported bedrock model: " + baseModel}
+		return nil, err
+	}
+
+	reporter := newUsageReporter(ctx, e.Identifier(), baseModel, auth)
+	defer reporter.trackFailure(ctx, &err)
+
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("claude")
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayloadSource, true)
+	bodyForTranslation := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	bodyForTranslation, _ = sjson.SetBytes(bodyForTranslation, "model", baseModel)
+	bodyForTranslation, err = thinking.ApplyThinking(bodyForTranslation, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, err
+	}
+	requestedModel := payloadRequestedModel(opts, req.Model)
+	bodyForTranslation = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", bodyForTranslation, originalTranslated, requestedModel)
+	bodyForTranslation = disableThinkingIfToolChoiceForced(bodyForTranslation)
+	betaTokens := resolveBedrockBetaTokens(opts.Headers.Get("anthropic-beta"), bodyForTranslation, mappedModel)
+	body, err := prepareBedrockRequestBody(bodyForTranslation, mappedModel, betaTokens)
+	if err != nil {
+		return nil, err
+	}
+
+	httpResp, err := e.doBedrockRequest(ctx, auth, mappedModel, true, body)
+	if err != nil {
+		recordAPIResponseError(ctx, e.cfg, err)
+		reporter.publishFailureWithContent(ctx, string(req.Payload), err.Error())
+		return nil, err
+	}
+	recordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+		appendAPIResponseChunk(ctx, e.cfg, b)
+		reporter.publishFailureWithContent(ctx, string(req.Payload), string(b))
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("bedrock executor: close response body error: %v", errClose)
+		}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, err
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	reporter.setInputContent(string(req.Payload))
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("bedrock executor: close response body error: %v", errClose)
+			}
+		}()
+
+		decoder := newBedrockEventStreamDecoder(httpResp.Body)
+		var param any
+		for {
+			payload, errDecode := decoder.Decode()
+			if errDecode != nil {
+				if errors.Is(errDecode, io.EOF) {
+					reporter.ensurePublished(ctx)
+					return
+				}
+				recordAPIResponseError(ctx, e.cfg, errDecode)
+				reporter.publishFailure(ctx)
+				out <- cliproxyexecutor.StreamChunk{Err: errDecode}
+				return
+			}
+			appendAPIResponseChunk(ctx, e.cfg, payload)
+			sseData := extractBedrockChunkData(payload)
+			if len(sseData) == 0 {
+				continue
+			}
+			sseData = transformBedrockInvocationMetrics(sseData)
+			line := []byte("data: " + string(sseData))
+			reporter.appendOutputChunk(line)
+			if detail, ok := parseClaudeStreamUsage(line); ok {
+				reporter.publish(ctx, detail)
+			}
+			if from == to {
+				eventType := gjson.GetBytes(sseData, "type").String()
+				if eventType != "" {
+					out <- cliproxyexecutor.StreamChunk{Payload: []byte("event: " + eventType + "\n")}
+				}
+				out <- cliproxyexecutor.StreamChunk{Payload: append(line, '\n', '\n')}
+				continue
+			}
+			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, bodyForTranslation, line, &param)
+			for i := range chunks {
+				out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
+			}
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func (e *BedrockExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	_ = ctx
+	_ = auth
+	_ = req
+	_ = opts
+	return cliproxyexecutor.Response{}, statusErr{code: http.StatusNotImplemented, msg: "bedrock count_tokens is not supported"}
+}
+
+func (e *BedrockExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	_ = ctx
+	if auth == nil {
+		return nil, fmt.Errorf("bedrock executor: auth is nil")
+	}
+	return auth, nil
+}
+
+func (e *BedrockExecutor) doBedrockRequest(ctx context.Context, auth *cliproxyauth.Auth, modelID string, stream bool, body []byte) (*http.Response, error) {
+	region := bedrockRegion(auth)
+	targetURL := buildBedrockURL(bedrockAttr(auth, "base_url"), region, modelID, stream)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", "cli-proxy-bedrock")
+	if err := e.prepareBedrockHTTPRequest(ctx, httpReq, auth, body); err != nil {
+		return nil, err
+	}
+
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	recordAPIRequest(ctx, e.cfg, upstreamRequestLog{
+		URL:       targetURL,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	return httpClient.Do(httpReq)
+}
+
+func (e *BedrockExecutor) prepareBedrockHTTPRequest(ctx context.Context, req *http.Request, auth *cliproxyauth.Auth, body []byte) error {
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	if bedrockAuthMode(auth) == bedrockAuthModeAPIKey {
+		apiKey := bedrockAttr(auth, "api_key")
+		if apiKey == "" {
+			return fmt.Errorf("bedrock executor: missing api key")
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		util.ApplyCustomHeadersFromAttrs(req, attrs)
+		return nil
+	}
+	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	signer, err := newBedrockSignerFromAuth(auth)
+	if err != nil {
+		return err
+	}
+	return signer.signRequest(ctx, req, body)
+}
+
+type bedrockSigner struct {
+	credentials aws.Credentials
+	region      string
+	signer      *v4.Signer
+}
+
+func newBedrockSignerFromAuth(auth *cliproxyauth.Auth) (*bedrockSigner, error) {
+	accessKeyID := bedrockAttr(auth, "access_key_id")
+	if accessKeyID == "" {
+		accessKeyID = bedrockAttr(auth, "aws_access_key_id")
+	}
+	if accessKeyID == "" {
+		return nil, fmt.Errorf("bedrock executor: missing aws access key id")
+	}
+	secretAccessKey := bedrockAttr(auth, "secret_access_key")
+	if secretAccessKey == "" {
+		secretAccessKey = bedrockAttr(auth, "aws_secret_access_key")
+	}
+	if secretAccessKey == "" {
+		return nil, fmt.Errorf("bedrock executor: missing aws secret access key")
+	}
+	return &bedrockSigner{
+		credentials: aws.Credentials{
+			AccessKeyID:     accessKeyID,
+			SecretAccessKey: secretAccessKey,
+			SessionToken:    firstNonEmpty(bedrockAttr(auth, "session_token"), bedrockAttr(auth, "aws_session_token")),
+		},
+		region: bedrockRegion(auth),
+		signer: v4.NewSigner(),
+	}, nil
+}
+
+func (s *bedrockSigner) signRequest(ctx context.Context, req *http.Request, body []byte) error {
+	payloadHash := sha256.Sum256(body)
+	return s.signer.SignHTTP(ctx, s.credentials, req, hex.EncodeToString(payloadHash[:]), "bedrock", s.region, time.Now())
+}
+
+func resolveBedrockModelID(auth *cliproxyauth.Auth, requestedModel string) (string, bool) {
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return "", false
+	}
+	if mapped := resolveBedrockCustomModelMapping(auth, requestedModel); mapped != "" {
+		requestedModel = mapped
+	}
+	modelID, shouldAdjust, ok := normalizeBedrockModelID(requestedModel)
+	if !ok {
+		return "", false
+	}
+	if shouldAdjust {
+		region := bedrockRegion(auth)
+		if bedrockForceGlobal(auth) {
+			region = "global"
+		}
+		modelID = adjustBedrockModelRegionPrefix(modelID, region)
+	}
+	return modelID, true
+}
+
+func resolveBedrockCustomModelMapping(auth *cliproxyauth.Auth, requestedModel string) string {
+	raw := bedrockAttr(auth, "model_mapping")
+	if strings.TrimSpace(raw) == "" {
+		return requestedModel
+	}
+	mapped := gjson.Get(raw, requestedModel).String()
+	if strings.TrimSpace(mapped) == "" {
+		return requestedModel
+	}
+	return mapped
+}
+
+func normalizeBedrockModelID(modelID string) (string, bool, bool) {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return "", false, false
+	}
+	if mapped, exists := defaultBedrockModelMapping[modelID]; exists {
+		return mapped, true, true
+	}
+	if isRegionalBedrockModelID(modelID) {
+		return modelID, true, true
+	}
+	if isLikelyBedrockModelID(modelID) {
+		return modelID, false, true
+	}
+	return "", false, false
+}
+
+func isRegionalBedrockModelID(modelID string) bool {
+	lower := strings.ToLower(strings.TrimSpace(modelID))
+	for _, prefix := range bedrockCrossRegionPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLikelyBedrockModelID(modelID string) bool {
+	lower := strings.ToLower(strings.TrimSpace(modelID))
+	if strings.HasPrefix(lower, "arn:") {
+		return true
+	}
+	for _, prefix := range []string{"anthropic.", "amazon.", "meta.", "mistral.", "cohere.", "ai21.", "deepseek.", "stability.", "writer.", "nova."} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func adjustBedrockModelRegionPrefix(modelID, region string) string {
+	targetPrefix := bedrockCrossRegionPrefix(region)
+	if strings.EqualFold(strings.TrimSpace(region), "global") {
+		targetPrefix = "global"
+	}
+	for _, prefix := range bedrockCrossRegionPrefixes {
+		if strings.HasPrefix(modelID, prefix) {
+			if prefix == targetPrefix+"." {
+				return modelID
+			}
+			return targetPrefix + "." + modelID[len(prefix):]
+		}
+	}
+	return modelID
+}
+
+func bedrockCrossRegionPrefix(region string) string {
+	region = strings.ToLower(strings.TrimSpace(region))
+	switch {
+	case strings.HasPrefix(region, "us-gov"):
+		return "us-gov"
+	case strings.HasPrefix(region, "us-"):
+		return "us"
+	case strings.HasPrefix(region, "eu-"):
+		return "eu"
+	case region == "ap-northeast-1":
+		return "jp"
+	case region == "ap-southeast-2":
+		return "au"
+	case strings.HasPrefix(region, "ap-"):
+		return "apac"
+	case strings.HasPrefix(region, "ca-"), strings.HasPrefix(region, "sa-"):
+		return "us"
+	default:
+		return "us"
+	}
+}
+
+func buildBedrockURL(baseURL, region, modelID string, stream bool) string {
+	if region == "" {
+		region = defaultBedrockRegion
+	}
+	encodedModelID := url.PathEscape(modelID)
+	encodedModelID = strings.ReplaceAll(encodedModelID, ":", "%3A")
+	endpoint := "invoke"
+	if stream {
+		endpoint = "invoke-with-response-stream"
+	}
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com", region)
+	}
+	return fmt.Sprintf("%s/model/%s/%s", baseURL, encodedModelID, endpoint)
+}
+
+func prepareBedrockRequestBody(body []byte, modelID string, betaTokens []string) ([]byte, error) {
+	var err error
+	body, err = sjson.SetBytes(body, "anthropic_version", "bedrock-2023-05-31")
+	if err != nil {
+		return nil, fmt.Errorf("inject anthropic_version: %w", err)
+	}
+	if len(betaTokens) > 0 {
+		body, err = sjson.SetBytes(body, "anthropic_beta", betaTokens)
+		if err != nil {
+			return nil, fmt.Errorf("inject anthropic_beta: %w", err)
+		}
+	}
+	for _, path := range []string{"model", "stream", "output_config"} {
+		body, err = sjson.DeleteBytes(body, path)
+		if err != nil {
+			return nil, fmt.Errorf("remove %s: %w", path, err)
+		}
+	}
+	body = removeBedrockToolCustomFields(body)
+	body = sanitizeBedrockCacheControl(body, modelID)
+	return body, nil
+}
+
+func resolveBedrockBetaTokens(betaHeader string, body []byte, modelID string) []string {
+	tokens := make([]string, 0)
+	for _, part := range strings.Split(betaHeader, ",") {
+		if token := strings.TrimSpace(part); token != "" {
+			tokens = append(tokens, token)
+		}
+	}
+	if gjson.GetBytes(body, "betas").IsArray() {
+		gjson.GetBytes(body, "betas").ForEach(func(_, value gjson.Result) bool {
+			if token := strings.TrimSpace(value.String()); token != "" {
+				tokens = append(tokens, token)
+			}
+			return true
+		})
+	}
+	if len(tokens) == 0 {
+		return nil
+	}
+	_ = modelID
+	allowed := map[string]bool{
+		"fine-grained-tool-streaming-2025-05-14": true,
+		"interleaved-thinking-2025-05-14":        true,
+		"token-efficient-tools-2025-02-19":       true,
+		"tool-search-tool-2025-10-19":            true,
+	}
+	seen := make(map[string]struct{}, len(tokens))
+	out := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		switch token {
+		case "advanced-tool-use-2025-11-20":
+			token = "tool-search-tool-2025-10-19"
+		}
+		if !allowed[token] {
+			continue
+		}
+		if _, exists := seen[token]; exists {
+			continue
+		}
+		seen[token] = struct{}{}
+		out = append(out, token)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func removeBedrockToolCustomFields(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return body
+	}
+	tools.ForEach(func(key, _ gjson.Result) bool {
+		body, _ = sjson.DeleteBytes(body, fmt.Sprintf("tools.%d.custom", key.Int()))
+		return true
+	})
+	return body
+}
+
+func sanitizeBedrockCacheControl(body []byte, modelID string) []byte {
+	_ = modelID
+	paths := make([]string, 0)
+	collectCacheControlPaths(gjson.GetBytes(body, "system"), "system", &paths)
+	collectCacheControlPaths(gjson.GetBytes(body, "messages"), "messages", &paths)
+	for _, path := range paths {
+		body, _ = sjson.DeleteBytes(body, path+".scope")
+		body, _ = sjson.DeleteBytes(body, path+".ttl")
+	}
+	return body
+}
+
+func collectCacheControlPaths(result gjson.Result, base string, paths *[]string) {
+	if !result.Exists() {
+		return
+	}
+	if result.IsObject() {
+		if result.Get("cache_control").Exists() {
+			*paths = append(*paths, base+".cache_control")
+		}
+		for key, value := range result.Map() {
+			collectCacheControlPaths(value, base+"."+escapeGJSONPathSegment(key), paths)
+		}
+		return
+	}
+	if result.IsArray() {
+		result.ForEach(func(key, value gjson.Result) bool {
+			collectCacheControlPaths(value, fmt.Sprintf("%s.%d", base, key.Int()), paths)
+			return true
+		})
+	}
+}
+
+func escapeGJSONPathSegment(segment string) string {
+	if strings.ContainsAny(segment, ".#|") {
+		return strings.ReplaceAll(segment, ".", "\\.")
+	}
+	return segment
+}
+
+func extractBedrockChunkData(payload []byte) []byte {
+	b64 := gjson.GetBytes(payload, "bytes").String()
+	if b64 == "" {
+		return nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil
+	}
+	return decoded
+}
+
+func transformBedrockInvocationMetrics(data []byte) []byte {
+	metrics := gjson.GetBytes(data, "amazon-bedrock-invocationMetrics")
+	if !metrics.Exists() || !metrics.IsObject() {
+		return data
+	}
+	data, _ = sjson.DeleteBytes(data, "amazon-bedrock-invocationMetrics")
+	if gjson.GetBytes(data, "usage").Exists() {
+		return data
+	}
+	if inputTokens := metrics.Get("inputTokenCount"); inputTokens.Exists() {
+		data, _ = sjson.SetBytes(data, "usage.input_tokens", inputTokens.Int())
+	}
+	if outputTokens := metrics.Get("outputTokenCount"); outputTokens.Exists() {
+		data, _ = sjson.SetBytes(data, "usage.output_tokens", outputTokens.Int())
+	}
+	return data
+}
+
+type bedrockEventStreamDecoder struct {
+	reader io.Reader
+}
+
+func newBedrockEventStreamDecoder(r io.Reader) *bedrockEventStreamDecoder {
+	return &bedrockEventStreamDecoder{reader: r}
+}
+
+func (d *bedrockEventStreamDecoder) Decode() ([]byte, error) {
+	for {
+		prelude := make([]byte, 12)
+		if _, err := io.ReadFull(d.reader, prelude); err != nil {
+			return nil, err
+		}
+		expectedPreludeCRC := binary.BigEndian.Uint32(prelude[8:12])
+		if crc32.ChecksumIEEE(prelude[:8]) != expectedPreludeCRC {
+			return nil, fmt.Errorf("bedrock eventstream: invalid prelude crc")
+		}
+		totalLen := binary.BigEndian.Uint32(prelude[0:4])
+		headersLen := binary.BigEndian.Uint32(prelude[4:8])
+		if totalLen < 16 || headersLen > totalLen-16 {
+			return nil, fmt.Errorf("bedrock eventstream: invalid frame length")
+		}
+		rest := make([]byte, int(totalLen)-12)
+		if _, err := io.ReadFull(d.reader, rest); err != nil {
+			return nil, err
+		}
+		frameWithoutMessageCRC := append(bytes.Clone(prelude), rest[:len(rest)-4]...)
+		expectedMessageCRC := binary.BigEndian.Uint32(rest[len(rest)-4:])
+		if crc32.ChecksumIEEE(frameWithoutMessageCRC) != expectedMessageCRC {
+			return nil, fmt.Errorf("bedrock eventstream: invalid message crc")
+		}
+		headers := rest[:headersLen]
+		payload := rest[headersLen : len(rest)-4]
+		eventHeaders := parseBedrockEventStreamHeaders(headers)
+		if eventHeaders.eventType == "chunk" {
+			return payload, nil
+		}
+		if err := bedrockEventStreamException(eventHeaders, payload); err != nil {
+			return nil, err
+		}
+	}
+}
+
+type bedrockEventStreamHeaders struct {
+	eventType     string
+	messageType   string
+	exceptionType string
+}
+
+func parseBedrockEventStreamHeaders(headers []byte) bedrockEventStreamHeaders {
+	out := bedrockEventStreamHeaders{}
+	for len(headers) > 0 {
+		nameLen := int(headers[0])
+		headers = headers[1:]
+		if len(headers) < nameLen+3 {
+			return out
+		}
+		name := string(headers[:nameLen])
+		headers = headers[nameLen:]
+		valueType := headers[0]
+		headers = headers[1:]
+		if valueType != 7 || len(headers) < 2 {
+			return out
+		}
+		valueLen := int(binary.BigEndian.Uint16(headers[:2]))
+		headers = headers[2:]
+		if len(headers) < valueLen {
+			return out
+		}
+		value := string(headers[:valueLen])
+		headers = headers[valueLen:]
+		switch name {
+		case ":event-type":
+			out.eventType = value
+		case ":message-type":
+			out.messageType = value
+		case ":exception-type":
+			out.exceptionType = value
+		}
+	}
+	return out
+}
+
+func bedrockEventStreamException(headers bedrockEventStreamHeaders, payload []byte) error {
+	eventType := strings.TrimSpace(headers.eventType)
+	exceptionType := strings.TrimSpace(headers.exceptionType)
+	messageType := strings.TrimSpace(headers.messageType)
+	lowerEvent := strings.ToLower(eventType)
+	isException := strings.EqualFold(messageType, "exception") ||
+		exceptionType != "" ||
+		strings.Contains(lowerEvent, "exception") ||
+		strings.Contains(lowerEvent, "error")
+	if !isException {
+		return nil
+	}
+	errorType := firstNonEmpty(exceptionType, eventType, messageType, "exception")
+	message := firstNonEmpty(gjson.GetBytes(payload, "message").String(), gjson.GetBytes(payload, "Message").String(), string(payload))
+	return fmt.Errorf("bedrock eventstream %s: %s", errorType, message)
+}
+
+func bedrockAuthMode(auth *cliproxyauth.Auth) string {
+	mode := strings.ToLower(strings.TrimSpace(bedrockAttr(auth, "auth_mode")))
+	switch mode {
+	case "apikey", "api_key", "api-key":
+		return bedrockAuthModeAPIKey
+	default:
+		return "sigv4"
+	}
+}
+
+func bedrockRegion(auth *cliproxyauth.Auth) string {
+	region := firstNonEmpty(bedrockAttr(auth, "region"), bedrockAttr(auth, "aws_region"))
+	if region == "" {
+		return defaultBedrockRegion
+	}
+	return region
+}
+
+func bedrockForceGlobal(auth *cliproxyauth.Auth) bool {
+	return strings.EqualFold(bedrockAttr(auth, "force_global"), "true") ||
+		strings.EqualFold(bedrockAttr(auth, "aws_force_global"), "true")
+}
+
+func bedrockAttr(auth *cliproxyauth.Auth, key string) string {
+	if auth == nil || auth.Attributes == nil {
+		return ""
+	}
+	return strings.TrimSpace(auth.Attributes[key])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func readAndResetRequestBody(req *http.Request) ([]byte, error) {
+	if req == nil || req.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if errClose := req.Body.Close(); errClose != nil {
+		return nil, errClose
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	return body, nil
+}

--- a/internal/runtime/executor/bedrock_executor_test.go
+++ b/internal/runtime/executor/bedrock_executor_test.go
@@ -1,0 +1,274 @@
+package executor
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestResolveBedrockModelID_UsesDefaultMappingAndRegionPrefix(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"region": "eu-west-1",
+		},
+	}
+
+	got, ok := resolveBedrockModelID(auth, "claude-sonnet-4-5")
+
+	if !ok {
+		t.Fatal("expected model mapping to resolve")
+	}
+	want := "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+	if got != want {
+		t.Fatalf("resolveBedrockModelID() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveBedrockModelID_ForceGlobal(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"region":       "us-east-1",
+			"force_global": "true",
+		},
+	}
+
+	got, ok := resolveBedrockModelID(auth, "claude-opus-4-5-thinking")
+
+	if !ok {
+		t.Fatal("expected model mapping to resolve")
+	}
+	want := "global.anthropic.claude-opus-4-5-20251101-v1:0"
+	if got != want {
+		t.Fatalf("resolveBedrockModelID() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildBedrockURL_EncodesModelIDAndChoosesEndpoint(t *testing.T) {
+	got := buildBedrockURL("", "us-east-1", "us.anthropic.claude-sonnet-4-5-20250929-v1:0", true)
+	want := "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/invoke-with-response-stream"
+	if got != want {
+		t.Fatalf("buildBedrockURL(stream) = %q, want %q", got, want)
+	}
+
+	got = buildBedrockURL("https://bedrock.test/base", "us-east-1", "anthropic.claude-3-5-haiku", false)
+	want = "https://bedrock.test/base/model/anthropic.claude-3-5-haiku/invoke"
+	if got != want {
+		t.Fatalf("buildBedrockURL(base-url) = %q, want %q", got, want)
+	}
+}
+
+func TestPrepareBedrockRequestBody_AdaptsClaudePayload(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-5",
+		"stream": true,
+		"system": [{"type":"text","text":"hello","cache_control":{"type":"ephemeral","ttl":"5m","scope":"global"}}],
+		"tools": [{"name":"Read","custom":{"defer_loading":true},"input_schema":{"type":"object"}}],
+		"messages": [{"role":"user","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral","scope":"global"}}]}],
+		"output_config": {"enabled": true}
+	}`)
+
+	got, err := prepareBedrockRequestBody(input, "us.anthropic.claude-sonnet-4-5-20250929-v1:0", []string{"fine-grained-tool-streaming-2025-05-14"})
+	if err != nil {
+		t.Fatalf("prepareBedrockRequestBody() error = %v", err)
+	}
+
+	if v := gjson.GetBytes(got, "anthropic_version").String(); v != "bedrock-2023-05-31" {
+		t.Fatalf("anthropic_version = %q", v)
+	}
+	if !gjson.GetBytes(got, "anthropic_beta.0").Exists() {
+		t.Fatal("expected anthropic_beta to be injected")
+	}
+	for _, path := range []string{
+		"model",
+		"stream",
+		"output_config",
+		"tools.0.custom",
+		"system.0.cache_control.ttl",
+		"system.0.cache_control.scope",
+		"messages.0.content.0.cache_control.scope",
+	} {
+		if gjson.GetBytes(got, path).Exists() {
+			t.Fatalf("expected %s to be removed from body: %s", path, got)
+		}
+	}
+}
+
+func TestTransformBedrockInvocationMetrics(t *testing.T) {
+	input := []byte(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"amazon-bedrock-invocationMetrics":{"inputTokenCount":150,"outputTokenCount":42}}`)
+
+	got := transformBedrockInvocationMetrics(input)
+
+	if gjson.GetBytes(got, "amazon-bedrock-invocationMetrics").Exists() {
+		t.Fatalf("amazon-bedrock-invocationMetrics should be removed: %s", got)
+	}
+	if inputTokens := gjson.GetBytes(got, "usage.input_tokens").Int(); inputTokens != 150 {
+		t.Fatalf("usage.input_tokens = %d, want 150", inputTokens)
+	}
+	if outputTokens := gjson.GetBytes(got, "usage.output_tokens").Int(); outputTokens != 42 {
+		t.Fatalf("usage.output_tokens = %d, want 42", outputTokens)
+	}
+}
+
+func TestBedrockEventStreamDecoder_DecodesChunkPayload(t *testing.T) {
+	payload := []byte(`{"bytes":"` + base64.StdEncoding.EncodeToString([]byte(`{"type":"message_start"}`)) + `"}`)
+	frame := buildBedrockTestEventStreamFrame(t, ":event-type", "chunk", payload)
+
+	decoded, err := newBedrockEventStreamDecoder(strings.NewReader(string(frame))).Decode()
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if string(decoded) != string(payload) {
+		t.Fatalf("Decode() = %s, want %s", decoded, payload)
+	}
+}
+
+func TestBedrockEventStreamDecoder_ReturnsExceptionPayload(t *testing.T) {
+	payload := []byte(`{"message":"model stream failed"}`)
+	frame := buildBedrockTestEventStreamFrameWithHeaders(t, map[string]string{
+		":message-type":   "exception",
+		":exception-type": "modelStreamErrorException",
+	}, payload)
+
+	_, err := newBedrockEventStreamDecoder(strings.NewReader(string(frame))).Decode()
+
+	if err == nil {
+		t.Fatal("expected exception frame to return an error")
+	}
+	if !strings.Contains(err.Error(), "modelStreamErrorException") || !strings.Contains(err.Error(), "model stream failed") {
+		t.Fatalf("exception error = %q, want type and message", err.Error())
+	}
+}
+
+func TestBedrockPrepareRequest_SignsSigV4AndAppliesCustomHeaders(t *testing.T) {
+	exec := NewBedrockExecutor(&config.Config{})
+	req, err := http.NewRequest(http.MethodPost, "https://bedrock-runtime.us-east-1.amazonaws.com/model/test/invoke", strings.NewReader(`{"ok":true}`))
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	auth := &cliproxyauth.Auth{
+		Provider: "bedrock",
+		Attributes: map[string]string{
+			"auth_mode":         "sigv4",
+			"access_key_id":     "AKIATEST",
+			"secret_access_key": "SECRET",
+			"session_token":     "SESSION",
+			"region":            "us-east-1",
+			"header:X-Test":     "yes",
+		},
+	}
+
+	if err := exec.PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+
+	if got := req.Header.Get("X-Test"); got != "yes" {
+		t.Fatalf("custom header = %q, want yes", got)
+	}
+	if got := req.Header.Get("X-Amz-Security-Token"); got != "SESSION" {
+		t.Fatalf("session token header = %q, want SESSION", got)
+	}
+	if got := req.Header.Get("Authorization"); !strings.HasPrefix(got, "AWS4-HMAC-SHA256 ") {
+		t.Fatalf("Authorization = %q, want SigV4 header", got)
+	}
+	body, _ := io.ReadAll(req.Body)
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("request body after signing = %q, want original body", body)
+	}
+}
+
+func TestBedrockExecutorExecute_APIKeyModeSendsInvokeRequest(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotAuth = r.Header.Get("Authorization")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("x-amzn-requestid", "aws-req-1")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	exec := NewBedrockExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "bedrock-api-key",
+		Provider: "bedrock",
+		Label:    "bedrock",
+		Attributes: map[string]string{
+			"auth_mode": "api-key",
+			"api_key":   "bedrock-test-key",
+			"region":    "us-east-1",
+			"base_url":  server.URL,
+		},
+	}
+	req := cliproxyexecutor.Request{
+		Model:   "claude-sonnet-4-5",
+		Payload: []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"stream":false}`),
+	}
+
+	resp, err := exec.Execute(context.Background(), auth, req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if gotAuth != "Bearer bedrock-test-key" {
+		t.Fatalf("Authorization = %q, want bearer API key", gotAuth)
+	}
+	wantPath := "/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/invoke"
+	if gotPath != wantPath {
+		t.Fatalf("path = %q, want %q", gotPath, wantPath)
+	}
+	if gjson.GetBytes(gotBody, "model").Exists() || gjson.GetBytes(gotBody, "stream").Exists() {
+		t.Fatalf("Bedrock body should not contain model/stream: %s", gotBody)
+	}
+	if v := gjson.GetBytes(gotBody, "anthropic_version").String(); v != "bedrock-2023-05-31" {
+		t.Fatalf("anthropic_version = %q", v)
+	}
+	if reqID := resp.Headers.Get("x-amzn-requestid"); reqID != "aws-req-1" {
+		t.Fatalf("response request id header = %q", reqID)
+	}
+}
+
+func buildBedrockTestEventStreamFrame(t *testing.T, headerName, headerValue string, payload []byte) []byte {
+	t.Helper()
+	return buildBedrockTestEventStreamFrameWithHeaders(t, map[string]string{headerName: headerValue}, payload)
+}
+
+func buildBedrockTestEventStreamFrameWithHeaders(t *testing.T, headerValues map[string]string, payload []byte) []byte {
+	t.Helper()
+	headers := make([]byte, 0)
+	for headerName, headerValue := range headerValues {
+		headers = append(headers, byte(len(headerName)))
+		headers = append(headers, []byte(headerName)...)
+		headers = append(headers, 7) // string header value
+		valueLen := make([]byte, 2)
+		binary.BigEndian.PutUint16(valueLen, uint16(len(headerValue)))
+		headers = append(headers, valueLen...)
+		headers = append(headers, []byte(headerValue)...)
+	}
+	totalLen := uint32(12 + len(headers) + len(payload) + 4)
+	prelude := make([]byte, 12)
+	binary.BigEndian.PutUint32(prelude[0:4], totalLen)
+	binary.BigEndian.PutUint32(prelude[4:8], uint32(len(headers)))
+	binary.BigEndian.PutUint32(prelude[8:12], crc32.ChecksumIEEE(prelude[0:8]))
+
+	frame := append(prelude, headers...)
+	frame = append(frame, payload...)
+	messageCRC := make([]byte, 4)
+	binary.BigEndian.PutUint32(messageCRC, crc32.ChecksumIEEE(frame))
+	frame = append(frame, messageCRC...)
+	return frame
+}

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -55,8 +55,8 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.clientsMutex.Unlock()
 	}
 
-	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount := BuildAPIKeyClients(cfg)
-	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + openAICompatCount
+	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, bedrockAPIKeyCount, openAICompatCount := BuildAPIKeyClients(cfg)
+	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + bedrockAPIKeyCount + openAICompatCount
 	log.Debugf("loaded %d API key clients", totalAPIKeyClients)
 
 	var authFileCount int
@@ -100,7 +100,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.clientsMutex.Unlock()
 	}
 
-	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + openAICompatCount
+	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + bedrockAPIKeyCount + openAICompatCount
 
 	if w.reloadCallback != nil {
 		log.Debugf("triggering server update callback before auth refresh")
@@ -109,13 +109,14 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 
 	w.refreshAuthState(forceAuthRefresh)
 
-	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d OpenAI-compat)",
+	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d Bedrock keys + %d OpenAI-compat)",
 		totalNewClients,
 		authFileCount,
 		geminiAPIKeyCount,
 		vertexCompatAPIKeyCount,
 		claudeAPIKeyCount,
 		codexAPIKeyCount,
+		bedrockAPIKeyCount,
 		openAICompatCount,
 	)
 }
@@ -242,13 +243,17 @@ func (w *Watcher) loadFileClients(cfg *config.Config) int {
 	return authFileCount
 }
 
-func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int) {
+func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int) {
 	geminiAPIKeyCount := 0
 	vertexCompatAPIKeyCount := 0
 	claudeAPIKeyCount := 0
 	codexAPIKeyCount := 0
+	bedrockAPIKeyCount := 0
 	openAICompatCount := 0
 
+	if cfg == nil {
+		return 0, 0, 0, 0, 0, 0
+	}
 	if len(cfg.GeminiKey) > 0 {
 		geminiAPIKeyCount += len(cfg.GeminiKey)
 	}
@@ -261,12 +266,15 @@ func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int) {
 	if len(cfg.CodexKey) > 0 {
 		codexAPIKeyCount += len(cfg.CodexKey)
 	}
+	if len(cfg.BedrockKey) > 0 {
+		bedrockAPIKeyCount += len(cfg.BedrockKey)
+	}
 	if len(cfg.OpenAICompatibility) > 0 {
 		for _, compatConfig := range cfg.OpenAICompatibility {
 			openAICompatCount += len(compatConfig.APIKeyEntries)
 		}
 	}
-	return geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount
+	return geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, bedrockAPIKeyCount, openAICompatCount
 }
 
 func (w *Watcher) persistConfigAsync() {

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -56,6 +56,21 @@ func ComputeClaudeModelsHash(models []config.ClaudeModel) string {
 	return hashJoined(keys)
 }
 
+// ComputeBedrockModelsHash returns a stable hash for AWS Bedrock model aliases.
+func ComputeBedrockModelsHash(models []config.BedrockModel) string {
+	keys := normalizeModelPairs(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+		}
+	})
+	return hashJoined(keys)
+}
+
 // ComputeCodexModelsHash returns a stable hash for Codex model aliases.
 func ComputeCodexModelsHash(models []config.CodexModel) string {
 	keys := normalizeModelPairs(func(out func(key string)) {

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ConfigSynthesizer generates Auth entries from configuration API keys.
-// It handles Gemini, Claude, Codex, OpenAI-compat, and Vertex-compat providers.
+// It handles Gemini, Claude, Bedrock, Codex, OpenAI-compat, and Vertex-compat providers.
 type ConfigSynthesizer struct{}
 
 // NewConfigSynthesizer creates a new ConfigSynthesizer instance.
@@ -29,6 +29,8 @@ func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth,
 	out = append(out, s.synthesizeGeminiKeys(ctx)...)
 	// Claude API Keys
 	out = append(out, s.synthesizeClaudeKeys(ctx)...)
+	// AWS Bedrock Runtime credentials
+	out = append(out, s.synthesizeBedrockKeys(ctx)...)
 	// Codex API Keys
 	out = append(out, s.synthesizeCodexKeys(ctx)...)
 	// OpenAI-compat
@@ -145,6 +147,96 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, ck.ExcludedModels, "apikey")
+		out = append(out, a)
+	}
+	return out
+}
+
+// synthesizeBedrockKeys creates Auth entries for AWS Bedrock Runtime credentials.
+func (s *ConfigSynthesizer) synthesizeBedrockKeys(ctx *SynthesisContext) []*coreauth.Auth {
+	cfg := ctx.Config
+	now := ctx.Now
+	idGen := ctx.IDGenerator
+
+	out := make([]*coreauth.Auth, 0, len(cfg.BedrockKey))
+	for i := range cfg.BedrockKey {
+		entry := cfg.BedrockKey[i]
+		authMode := strings.ToLower(strings.TrimSpace(entry.AuthMode))
+		switch authMode {
+		case "apikey", "api_key", "api-key":
+			authMode = "api-key"
+		default:
+			authMode = "sigv4"
+		}
+
+		region := strings.TrimSpace(entry.Region)
+		if region == "" {
+			region = "us-east-1"
+		}
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		proxyID := strings.TrimSpace(entry.ProxyID)
+		prefix := strings.TrimSpace(entry.Prefix)
+
+		attrs := map[string]string{
+			"auth_mode": authMode,
+			"region":    region,
+		}
+		idParts := []string{authMode, region, base, proxyURL}
+		switch authMode {
+		case "api-key":
+			key := strings.TrimSpace(entry.APIKey)
+			if key == "" {
+				continue
+			}
+			attrs["api_key"] = key
+			idParts = append(idParts, key)
+		default:
+			accessKeyID := strings.TrimSpace(entry.AccessKeyID)
+			secretAccessKey := strings.TrimSpace(entry.SecretAccessKey)
+			if accessKeyID == "" || secretAccessKey == "" {
+				continue
+			}
+			attrs["api_key"] = accessKeyID
+			attrs["access_key_id"] = accessKeyID
+			attrs["secret_access_key"] = secretAccessKey
+			if sessionToken := strings.TrimSpace(entry.SessionToken); sessionToken != "" {
+				attrs["session_token"] = sessionToken
+			}
+			idParts = append(idParts, accessKeyID, secretAccessKey, strings.TrimSpace(entry.SessionToken))
+		}
+		if entry.Priority != 0 {
+			attrs["priority"] = strconv.Itoa(entry.Priority)
+		}
+		if base != "" {
+			attrs["base_url"] = base
+		}
+		if entry.ForceGlobal {
+			attrs["force_global"] = "true"
+		}
+		if hash := diff.ComputeBedrockModelsHash(entry.Models); hash != "" {
+			attrs["models_hash"] = hash
+		}
+		addConfigHeadersToAttrs(entry.Headers, attrs)
+		id, token := idGen.Next("bedrock:apikey", idParts...)
+		attrs["source"] = fmt.Sprintf("config:bedrock[%s]", token)
+		label := strings.TrimSpace(entry.Name)
+		if label == "" {
+			label = "bedrock-apikey"
+		}
+		a := &coreauth.Auth{
+			ID:         id,
+			Provider:   "bedrock",
+			Label:      label,
+			Prefix:     prefix,
+			Status:     coreauth.StatusActive,
+			ProxyURL:   proxyURL,
+			ProxyID:    proxyID,
+			Attributes: attrs,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
 		out = append(out, a)
 	}
 	return out

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -546,6 +546,87 @@ func TestConfigSynthesizer_VertexCompat_WithModels(t *testing.T) {
 	}
 }
 
+func TestConfigSynthesizer_BedrockKeys(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			BedrockKey: []config.BedrockKey{
+				{
+					Name:        "aws api",
+					AuthMode:    "api-key",
+					APIKey:      "br-key",
+					Region:      "eu-west-1",
+					ForceGlobal: true,
+					BaseURL:     "https://bedrock.local",
+					Prefix:      "aws",
+					ProxyURL:    "http://proxy.local",
+					ProxyID:     "hk",
+					Headers:     map[string]string{"X-Bedrock": "test"},
+					Models: []config.BedrockModel{
+						{Name: "claude-sonnet-4-5", Alias: "aws-sonnet"},
+					},
+					ExcludedModels: []string{"claude-opus-*"},
+				},
+				{
+					Name:            "aws sigv4",
+					AuthMode:        "sigv4",
+					AccessKeyID:     "AKIATEST",
+					SecretAccessKey: "SECRET",
+					SessionToken:    "SESSION",
+					Region:          "us-east-1",
+				},
+			},
+		},
+		Now:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 bedrock auths, got %d", len(auths))
+	}
+
+	apiAuth := auths[0]
+	if apiAuth.Provider != "bedrock" || apiAuth.Label != "aws api" || apiAuth.Prefix != "aws" {
+		t.Fatalf("unexpected api auth identity: %+v", apiAuth)
+	}
+	if apiAuth.Attributes["auth_mode"] != "api-key" || apiAuth.Attributes["api_key"] != "br-key" {
+		t.Fatalf("unexpected api auth attributes: %+v", apiAuth.Attributes)
+	}
+	if apiAuth.Attributes["region"] != "eu-west-1" || apiAuth.Attributes["force_global"] != "true" {
+		t.Fatalf("unexpected region attrs: %+v", apiAuth.Attributes)
+	}
+	if apiAuth.Attributes["base_url"] != "https://bedrock.local" || apiAuth.Attributes["header:X-Bedrock"] != "test" {
+		t.Fatalf("unexpected base/header attrs: %+v", apiAuth.Attributes)
+	}
+	if _, ok := apiAuth.Attributes["models_hash"]; !ok {
+		t.Fatal("expected models_hash for bedrock models")
+	}
+	if apiAuth.ProxyURL != "http://proxy.local" || apiAuth.ProxyID != "hk" {
+		t.Fatalf("unexpected proxy settings: proxy=%q proxyID=%q", apiAuth.ProxyURL, apiAuth.ProxyID)
+	}
+	if apiAuth.Attributes["excluded_models_hash"] == "" || apiAuth.Attributes["auth_kind"] != "apikey" {
+		t.Fatalf("expected API key exclusion metadata, got %+v", apiAuth.Attributes)
+	}
+
+	sigAuth := auths[1]
+	if sigAuth.Provider != "bedrock" || sigAuth.Label != "aws sigv4" {
+		t.Fatalf("unexpected sigv4 auth identity: %+v", sigAuth)
+	}
+	if sigAuth.Attributes["auth_mode"] != "sigv4" {
+		t.Fatalf("auth_mode = %q, want sigv4", sigAuth.Attributes["auth_mode"])
+	}
+	if sigAuth.Attributes["access_key_id"] != "AKIATEST" || sigAuth.Attributes["secret_access_key"] != "SECRET" || sigAuth.Attributes["session_token"] != "SESSION" {
+		t.Fatalf("unexpected sigv4 attrs: %+v", sigAuth.Attributes)
+	}
+	if sigAuth.Attributes["api_key"] != "AKIATEST" {
+		t.Fatalf("expected api_key identifier to use access key id for alias/account handling, got %+v", sigAuth.Attributes)
+	}
+}
+
 func TestConfigSynthesizer_IDStability(t *testing.T) {
 	cfg := &config.Config{
 		GeminiKey: []config.GeminiKey{
@@ -594,6 +675,9 @@ func TestConfigSynthesizer_AllProviders(t *testing.T) {
 			VertexCompatAPIKey: []config.VertexCompatKey{
 				{APIKey: "vertex-key", BaseURL: "https://vertex.api"},
 			},
+			BedrockKey: []config.BedrockKey{
+				{AuthMode: "api-key", APIKey: "bedrock-key"},
+			},
 		},
 		Now:         time.Now(),
 		IDGenerator: NewStableIDGenerator(),
@@ -603,8 +687,8 @@ func TestConfigSynthesizer_AllProviders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(auths) != 5 {
-		t.Fatalf("expected 5 auths, got %d", len(auths))
+	if len(auths) != 6 {
+		t.Fatalf("expected 6 auths, got %d", len(auths))
 	}
 
 	providers := make(map[string]bool)
@@ -612,7 +696,7 @@ func TestConfigSynthesizer_AllProviders(t *testing.T) {
 		providers[a.Provider] = true
 	}
 
-	expected := []string{"gemini", "claude", "codex", "compat", "vertex"}
+	expected := []string{"gemini", "claude", "codex", "compat", "vertex", "bedrock"}
 	for _, p := range expected {
 		if !providers[p] {
 			t.Errorf("expected provider %s not found", p)

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -68,14 +68,18 @@ func TestBuildAPIKeyClientsCounts(t *testing.T) {
 		},
 		ClaudeKey: []config.ClaudeKey{{APIKey: "c1"}},
 		CodexKey:  []config.CodexKey{{APIKey: "x1"}, {APIKey: "x2"}},
+		BedrockKey: []config.BedrockKey{
+			{AuthMode: "api-key", APIKey: "b1"},
+			{AuthMode: "sigv4", AccessKeyID: "AKIA", SecretAccessKey: "SECRET"},
+		},
 		OpenAICompatibility: []config.OpenAICompatibility{
 			{APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "o1"}, {APIKey: "o2"}}},
 		},
 	}
 
-	gemini, vertex, claude, codex, compat := BuildAPIKeyClients(cfg)
-	if gemini != 2 || vertex != 1 || claude != 1 || codex != 2 || compat != 2 {
-		t.Fatalf("unexpected counts: %d %d %d %d %d", gemini, vertex, claude, codex, compat)
+	gemini, vertex, claude, codex, bedrock, compat := BuildAPIKeyClients(cfg)
+	if gemini != 2 || vertex != 1 || claude != 1 || codex != 2 || bedrock != 2 || compat != 2 {
+		t.Fatalf("unexpected counts: %d %d %d %d %d %d", gemini, vertex, claude, codex, bedrock, compat)
 	}
 }
 

--- a/sdk/cliproxy/auth/api_key_model_alias_test.go
+++ b/sdk/cliproxy/auth/api_key_model_alias_test.go
@@ -108,6 +108,9 @@ func TestAPIKeyModelAlias_MultipleProviders(t *testing.T) {
 		GeminiKey: []internalconfig.GeminiKey{{APIKey: "gemini-key", Models: []internalconfig.GeminiModel{{Name: "gemini-2.5-pro", Alias: "gp"}}}},
 		ClaudeKey: []internalconfig.ClaudeKey{{APIKey: "claude-key", Models: []internalconfig.ClaudeModel{{Name: "claude-sonnet-4", Alias: "cs4"}}}},
 		CodexKey:  []internalconfig.CodexKey{{APIKey: "codex-key", Models: []internalconfig.CodexModel{{Name: "o3", Alias: "o"}}}},
+		BedrockKey: []internalconfig.BedrockKey{
+			{AuthMode: "sigv4", AccessKeyID: "AKIA", SecretAccessKey: "SECRET", Models: []internalconfig.BedrockModel{{Name: "claude-sonnet-4-5", Alias: "aws-sonnet"}}},
+		},
 	}
 
 	mgr := NewManager(nil, nil, nil)
@@ -117,6 +120,7 @@ func TestAPIKeyModelAlias_MultipleProviders(t *testing.T) {
 	_, _ = mgr.Register(ctx, &Auth{ID: "gemini-auth", Provider: "gemini", Attributes: map[string]string{"api_key": "gemini-key"}})
 	_, _ = mgr.Register(ctx, &Auth{ID: "claude-auth", Provider: "claude", Attributes: map[string]string{"api_key": "claude-key"}})
 	_, _ = mgr.Register(ctx, &Auth{ID: "codex-auth", Provider: "codex", Attributes: map[string]string{"api_key": "codex-key"}})
+	_, _ = mgr.Register(ctx, &Auth{ID: "bedrock-auth", Provider: "bedrock", Attributes: map[string]string{"auth_mode": "sigv4", "api_key": "AKIA", "access_key_id": "AKIA"}})
 
 	tests := []struct {
 		authID, input, want string
@@ -124,6 +128,7 @@ func TestAPIKeyModelAlias_MultipleProviders(t *testing.T) {
 		{"gemini-auth", "gp", "gemini-2.5-pro"},
 		{"claude-auth", "cs4", "claude-sonnet-4"},
 		{"codex-auth", "o", "o3"},
+		{"bedrock-auth", "aws-sonnet", "claude-sonnet-4-5"},
 	}
 
 	for _, tt := range tests {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -338,6 +338,10 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 			if entry := resolveCodexAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
 			}
+		case "bedrock":
+			if entry := resolveBedrockAPIKeyConfig(cfg, auth); entry != nil {
+				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+			}
 		case "vertex":
 			if entry := resolveVertexAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
@@ -1024,6 +1028,8 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 		upstreamModel = resolveUpstreamModelForClaudeAPIKey(cfg, auth, requestedModel)
 	case "codex":
 		upstreamModel = resolveUpstreamModelForCodexAPIKey(cfg, auth, requestedModel)
+	case "bedrock":
+		upstreamModel = resolveUpstreamModelForBedrockAPIKey(cfg, auth, requestedModel)
 	case "vertex":
 		upstreamModel = resolveUpstreamModelForVertexAPIKey(cfg, auth, requestedModel)
 	default:
@@ -1103,6 +1109,65 @@ func resolveCodexAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalc
 	return resolveAPIKeyConfig(cfg.CodexKey, auth)
 }
 
+func resolveBedrockAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalconfig.BedrockKey {
+	if cfg == nil || auth == nil {
+		return nil
+	}
+	attrKey := ""
+	attrAccessKeyID := ""
+	attrBase := ""
+	attrRegion := ""
+	attrMode := ""
+	if auth.Attributes != nil {
+		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
+		attrAccessKeyID = strings.TrimSpace(auth.Attributes["access_key_id"])
+		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrRegion = strings.TrimSpace(auth.Attributes["region"])
+		attrMode = strings.ToLower(strings.TrimSpace(auth.Attributes["auth_mode"]))
+	}
+	if attrMode == "apikey" || attrMode == "api_key" {
+		attrMode = "api-key"
+	}
+	for i := range cfg.BedrockKey {
+		entry := &cfg.BedrockKey[i]
+		cfgMode := strings.ToLower(strings.TrimSpace(entry.AuthMode))
+		if cfgMode == "" {
+			cfgMode = "sigv4"
+		}
+		if cfgMode == "apikey" || cfgMode == "api_key" {
+			cfgMode = "api-key"
+		}
+		if attrMode != "" && cfgMode != attrMode {
+			continue
+		}
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if attrBase != "" && !strings.EqualFold(cfgBase, attrBase) {
+			continue
+		}
+		cfgRegion := strings.TrimSpace(entry.Region)
+		if cfgRegion == "" {
+			cfgRegion = internalconfig.DefaultBedrockRegion
+		}
+		if attrRegion != "" && !strings.EqualFold(cfgRegion, attrRegion) {
+			continue
+		}
+		if cfgMode == "api-key" {
+			if attrKey != "" && strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) {
+				return entry
+			}
+			continue
+		}
+		cfgAccessKeyID := strings.TrimSpace(entry.AccessKeyID)
+		if attrAccessKeyID != "" && strings.EqualFold(cfgAccessKeyID, attrAccessKeyID) {
+			return entry
+		}
+		if attrKey != "" && strings.EqualFold(cfgAccessKeyID, attrKey) {
+			return entry
+		}
+	}
+	return nil
+}
+
 func resolveVertexAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalconfig.VertexCompatKey {
 	if cfg == nil {
 		return nil
@@ -1128,6 +1193,14 @@ func resolveUpstreamModelForClaudeAPIKey(cfg *internalconfig.Config, auth *Auth,
 
 func resolveUpstreamModelForCodexAPIKey(cfg *internalconfig.Config, auth *Auth, requestedModel string) string {
 	entry := resolveCodexAPIKeyConfig(cfg, auth)
+	if entry == nil {
+		return ""
+	}
+	return resolveModelAliasFromConfigModels(requestedModel, asModelAliasEntries(entry.Models))
+}
+
+func resolveUpstreamModelForBedrockAPIKey(cfg *internalconfig.Config, auth *Auth, requestedModel string) string {
+	entry := resolveBedrockAPIKeyConfig(cfg, auth)
 	if entry == nil {
 		return ""
 	}

--- a/sdk/cliproxy/providers.go
+++ b/sdk/cliproxy/providers.go
@@ -29,7 +29,7 @@ func NewAPIKeyClientProvider() APIKeyClientProvider {
 type apiKeyClientProvider struct{}
 
 func (p *apiKeyClientProvider) Load(ctx context.Context, cfg *config.Config) (*APIKeyClientResult, error) {
-	geminiCount, vertexCompatCount, claudeCount, codexCount, openAICompat := watcher.BuildAPIKeyClients(cfg)
+	geminiCount, vertexCompatCount, claudeCount, codexCount, bedrockCount, openAICompat := watcher.BuildAPIKeyClients(cfg)
 	if ctx != nil {
 		select {
 		case <-ctx.Done():
@@ -42,6 +42,7 @@ func (p *apiKeyClientProvider) Load(ctx context.Context, cfg *config.Config) (*A
 		VertexCompatKeyCount: vertexCompatCount,
 		ClaudeKeyCount:       claudeCount,
 		CodexKeyCount:        codexCount,
+		BedrockKeyCount:      bedrockCount,
 		OpenAICompatCount:    openAICompat,
 	}, nil
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -426,6 +426,8 @@ func (s *Service) ensureExecutorsForAuthWithMode(a *coreauth.Auth, forceReplace 
 		s.coreManager.RegisterExecutor(executor.NewAntigravityExecutor(s.cfg))
 	case "claude":
 		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(s.cfg))
+	case "bedrock":
+		s.coreManager.RegisterExecutor(executor.NewBedrockExecutor(s.cfg))
 	case "qwen":
 		s.coreManager.RegisterExecutor(executor.NewQwenExecutor(s.cfg))
 	case "iflow":
@@ -849,6 +851,17 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 			}
 		}
 		models = applyExcludedModels(models, excluded)
+	case "bedrock":
+		models = registry.GetBedrockModels()
+		if entry := s.resolveConfigBedrockKey(a); entry != nil {
+			if len(entry.Models) > 0 {
+				models = buildBedrockConfigModels(entry)
+			}
+			if authKind == "apikey" {
+				excluded = entry.ExcludedModels
+			}
+		}
+		models = applyExcludedModels(models, excluded)
 	case "codex":
 		models = registry.GetOpenAIModels()
 		if entry := s.resolveConfigCodexKey(a); entry != nil {
@@ -1024,6 +1037,61 @@ func (s *Service) resolveConfigGeminiKey(auth *coreauth.Auth) *config.GeminiKey 
 			continue
 		}
 		if attrKey == "" && attrBase != "" && strings.EqualFold(cfgBase, attrBase) {
+			return entry
+		}
+	}
+	return nil
+}
+
+func (s *Service) resolveConfigBedrockKey(auth *coreauth.Auth) *config.BedrockKey {
+	if auth == nil || s.cfg == nil {
+		return nil
+	}
+	var attrKey, attrAccessKeyID, attrBase, attrRegion, attrMode string
+	if auth.Attributes != nil {
+		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
+		attrAccessKeyID = strings.TrimSpace(auth.Attributes["access_key_id"])
+		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrRegion = strings.TrimSpace(auth.Attributes["region"])
+		attrMode = strings.ToLower(strings.TrimSpace(auth.Attributes["auth_mode"]))
+	}
+	if attrMode == "apikey" || attrMode == "api_key" {
+		attrMode = "api-key"
+	}
+	for i := range s.cfg.BedrockKey {
+		entry := &s.cfg.BedrockKey[i]
+		cfgMode := strings.ToLower(strings.TrimSpace(entry.AuthMode))
+		if cfgMode == "" {
+			cfgMode = "sigv4"
+		}
+		if cfgMode == "apikey" || cfgMode == "api_key" {
+			cfgMode = "api-key"
+		}
+		if attrMode != "" && cfgMode != attrMode {
+			continue
+		}
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if attrBase != "" && !strings.EqualFold(cfgBase, attrBase) {
+			continue
+		}
+		cfgRegion := strings.TrimSpace(entry.Region)
+		if cfgRegion == "" {
+			cfgRegion = config.DefaultBedrockRegion
+		}
+		if attrRegion != "" && !strings.EqualFold(cfgRegion, attrRegion) {
+			continue
+		}
+		if cfgMode == "api-key" {
+			if attrKey != "" && strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) {
+				return entry
+			}
+			continue
+		}
+		cfgAccessKeyID := strings.TrimSpace(entry.AccessKeyID)
+		if attrAccessKeyID != "" && strings.EqualFold(cfgAccessKeyID, attrAccessKeyID) {
+			return entry
+		}
+		if attrKey != "" && strings.EqualFold(cfgAccessKeyID, attrKey) {
 			return entry
 		}
 	}
@@ -1343,6 +1411,13 @@ func buildClaudeConfigModels(entry *config.ClaudeKey) []*ModelInfo {
 		return nil
 	}
 	return buildConfigModels(entry.Models, "anthropic", "claude")
+}
+
+func buildBedrockConfigModels(entry *config.BedrockKey) []*ModelInfo {
+	if entry == nil {
+		return nil
+	}
+	return buildConfigModels(entry.Models, "aws", "bedrock")
 }
 
 func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {

--- a/sdk/cliproxy/service_bedrock_test.go
+++ b/sdk/cliproxy/service_bedrock_test.go
@@ -1,0 +1,77 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+func TestEnsureExecutorsForAuth_BedrockBindsBedrockExecutor(t *testing.T) {
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: coreauth.NewManager(nil, nil, nil),
+	}
+	auth := &coreauth.Auth{
+		ID:       "bedrock-auth",
+		Provider: "bedrock",
+		Status:   coreauth.StatusActive,
+	}
+
+	service.ensureExecutorsForAuth(auth)
+
+	exec, ok := service.coreManager.Executor("bedrock")
+	if !ok || exec == nil {
+		t.Fatal("expected bedrock executor after bind")
+	}
+	if exec.Identifier() != "bedrock" {
+		t.Fatalf("executor identifier = %q, want bedrock", exec.Identifier())
+	}
+}
+
+func TestRegisterModelsForAuth_BedrockConfigModels(t *testing.T) {
+	service := &Service{
+		cfg: &config.Config{
+			BedrockKey: []config.BedrockKey{
+				{
+					AuthMode: "api-key",
+					APIKey:   "br-key",
+					Models: []config.BedrockModel{
+						{Name: "claude-sonnet-4-5", Alias: "aws-sonnet"},
+						{Name: "claude-opus-4-5", Alias: "aws-opus"},
+					},
+					ExcludedModels: []string{"aws-opus"},
+				},
+			},
+		},
+	}
+	auth := &coreauth.Auth{
+		ID:       "bedrock-auth-models",
+		Provider: "bedrock",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "br-key",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := registry.GetAvailableModelsByProvider("bedrock")
+	if len(models) != 1 {
+		t.Fatalf("expected 1 registered bedrock model after exclusion, got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "aws-sonnet" {
+		t.Fatalf("registered model id = %q, want aws-sonnet", models[0].ID)
+	}
+	if models[0].OwnedBy != "aws" || models[0].Type != "bedrock" {
+		t.Fatalf("unexpected model ownership/type: %+v", models[0])
+	}
+}

--- a/sdk/cliproxy/types.go
+++ b/sdk/cliproxy/types.go
@@ -63,6 +63,9 @@ type APIKeyClientResult struct {
 	// CodexKeyCount is the number of Codex API keys loaded
 	CodexKeyCount int
 
+	// BedrockKeyCount is the number of AWS Bedrock credentials loaded
+	BedrockKeyCount int
+
 	// OpenAICompatCount is the number of OpenAI compatibility API keys loaded
 	OpenAICompatCount int
 }

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -28,6 +28,8 @@ type PayloadModelRule = internalconfig.PayloadModelRule
 type GeminiKey = internalconfig.GeminiKey
 type CodexKey = internalconfig.CodexKey
 type ClaudeKey = internalconfig.ClaudeKey
+type BedrockKey = internalconfig.BedrockKey
+type BedrockModel = internalconfig.BedrockModel
 type VertexCompatKey = internalconfig.VertexCompatKey
 type VertexCompatModel = internalconfig.VertexCompatModel
 type OpenAICompatibility = internalconfig.OpenAICompatibility
@@ -38,6 +40,7 @@ type TLS = internalconfig.TLSConfig
 
 const (
 	DefaultPanelGitHubRepository = internalconfig.DefaultPanelGitHubRepository
+	DefaultBedrockRegion         = internalconfig.DefaultBedrockRegion
 )
 
 func LoadConfig(configFile string) (*Config, error) { return internalconfig.LoadConfig(configFile) }


### PR DESCRIPTION
Adds AWS Bedrock Runtime support with SigV4/API-key credentials, model mapping, config management routes, and tests.\n\nVerification:\n- go test ./...