### PR TITLE
fix: accept arbitrary gpt image dimensions

### DIFF
--- a/internal/runtime/executor/codex_executor_image_test.go
+++ b/internal/runtime/executor/codex_executor_image_test.go
@@ -955,6 +955,32 @@ func TestParseCodexImageRequestAcceptsExtendedGenerationOptions(t *testing.T) {
 	}
 }
 
+func TestParseCodexImageRequestAcceptsArbitraryPositiveDimensions(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		size     string
+		wantSize string
+	}{
+		{name: "small square", size: "128x128", wantSize: "128x128"},
+		{name: "uppercase separator", size: "128X256", wantSize: "128x256"},
+		{name: "custom widescreen", size: "3000x1200", wantSize: "3000x1200"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseCodexImageRequest([]byte(`{
+				"model":"gpt-image-2",
+				"prompt":"draw a fox",
+				"size":"` + tc.size + `"
+			}`))
+			if err != nil {
+				t.Fatalf("parseCodexImageRequest(size=%s) error = %v", tc.size, err)
+			}
+			if parsed.Size != tc.wantSize {
+				t.Fatalf("size = %q, want %q", parsed.Size, tc.wantSize)
+			}
+		})
+	}
+}
+
 func TestParseCodexImageRequestAcceptsImageEditsPayload(t *testing.T) {
 	parsed, err := parseCodexImageRequest([]byte(`{
 		"model":"gpt-image-2",

--- a/internal/runtime/executor/codex_image_executor.go
+++ b/internal/runtime/executor/codex_image_executor.go
@@ -45,6 +45,7 @@ const (
 var codexImageChatGPTBaseURL = "https://chatgpt.com"
 var codexImagePollTimeout = codexImageConversationTimout
 var codexImagePollInterval = 3 * time.Second
+var codexImageSizePattern = regexp.MustCompile(`^[1-9][0-9]*x[1-9][0-9]*$`)
 
 type codexImageRequest struct {
 	Model             string
@@ -354,8 +355,8 @@ func parseCodexImageRequest(body []byte) (*codexImageRequest, error) {
 		return nil, fmt.Errorf("only response_format=b64_json is supported for Codex OAuth image generation")
 	}
 	parsed.Size = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "size").String()))
-	if parsed.Size != "" && !isSupportedCodexImageSize(parsed.Size) {
-		return nil, fmt.Errorf("size must be one of 1024x1024, 1792x1024, 1024x1792, 2560x1440, 2160x3840")
+	if parsed.Size != "" && !isValidCodexImageSize(parsed.Size) {
+		return nil, fmt.Errorf("size must be WIDTHxHEIGHT using positive integers")
 	}
 	parsed.Quality = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "quality").String()))
 	if parsed.Quality != "" && !isSupportedCodexImageQuality(parsed.Quality) {
@@ -480,13 +481,8 @@ func parseCodexImageUpload(item gjson.Result, defaultFileName string) (*codexIma
 	return upload, nil
 }
 
-func isSupportedCodexImageSize(size string) bool {
-	switch strings.ToLower(strings.TrimSpace(size)) {
-	case "1024x1024", "1792x1024", "1024x1792", "2560x1440", "2160x3840":
-		return true
-	default:
-		return false
-	}
+func isValidCodexImageSize(size string) bool {
+	return codexImageSizePattern.MatchString(strings.ToLower(strings.TrimSpace(size)))
 }
 
 func isSupportedCodexImageQuality(quality string) bool {


### PR DESCRIPTION
## Summary
- Replace the fixed gpt-image-2 size allowlist with WIDTHxHEIGHT positive-integer format validation.
- Keep size normalization to lowercase so values like 128X256 are accepted as 128x256.
- Add regression coverage for arbitrary valid dimensions.

## Tests
- go test ./internal/runtime/executor -run 'TestParseCodexImageRequestAcceptsArbitraryPositiveDimensions|TestParseCodexImageRequestAcceptsExtendedGenerationOptions'
- go test ./internal/runtime/executor
- go test ./internal/runtime/executor ./internal/api/handlers/management ./sdk/api/handlers/openai
- go test ./...