### PR TITLE
feat: clean DB-backed config during migration

### DIFF
--- a/internal/api/handlers/management/channel_rename.go
+++ b/internal/api/handlers/management/channel_rename.go
@@ -42,6 +42,9 @@ func (h *Handler) renameChannelReferences(oldNames []string, newName string) err
 		if err := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); err != nil {
 			return fmt.Errorf("failed to save config: %w", err)
 		}
+		if usage.ConfigStoreAvailable() {
+			usage.CleanDBBackedConfigFromYAML(h.configFilePath)
+		}
 	}
 	if configChanged && h.authManager != nil {
 		h.authManager.SetConfig(h.cfg)

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -325,6 +325,9 @@ func (h *Handler) persist(c *gin.Context) bool {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save config: %v", err)})
 		return false
 	}
+	if usage.ConfigStoreAvailable() {
+		usage.CleanDBBackedConfigFromYAML(h.configFilePath)
+	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	return true
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -57,7 +57,7 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 		log.Errorf("usage: failed to initialize SQLite: %v", err)
 	}
 	usage.MigrateAPIKeysFromConfig(cfg, configPath)
-	usage.MigrateRoutingConfigFromConfig(cfg)
+	usage.MigrateRoutingConfigFromConfig(cfg, configPath)
 	usage.ApplyStoredRoutingConfig(cfg)
 	usage.MigrateProxyPoolFromConfig(cfg, configPath)
 	usage.ApplyStoredProxyPool(cfg)
@@ -126,7 +126,7 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 		log.Errorf("usage: failed to initialize SQLite: %v", err)
 	}
 	usage.MigrateAPIKeysFromConfig(cfg, configPath)
-	usage.MigrateRoutingConfigFromConfig(cfg)
+	usage.MigrateRoutingConfigFromConfig(cfg, configPath)
 	usage.ApplyStoredRoutingConfig(cfg)
 	usage.MigrateProxyPoolFromConfig(cfg, configPath)
 	usage.ApplyStoredProxyPool(cfg)

--- a/internal/usage/apikey_db.go
+++ b/internal/usage/apikey_db.go
@@ -4,13 +4,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 )
 
 // APIKeyRow mirrors config.APIKeyEntry and is used for SQLite persistence.
@@ -315,16 +313,9 @@ func MigrateAPIKeysFromConfig(cfg *config.Config, configFilePath string) int {
 
 	// Auto-clean the config file to remove stale api-keys/api-key-entries
 	if configFilePath != "" {
-		// Backup first
-		backupPath := configFilePath + ".pre-sqlite-migration"
-		if data, err := os.ReadFile(configFilePath); err == nil {
-			if err := os.WriteFile(backupPath, data, 0644); err != nil {
-				log.Warnf("usage: failed to backup config before cleanup: %v", err)
-			} else {
-				log.Infof("usage: backed up config.yaml to %s", backupPath)
-			}
+		if backupConfigForMigration(configFilePath, apiKeysMigrationBackupSuffix) {
+			cleanAPIKeysFromYAML(configFilePath)
 		}
-		cleanAPIKeysFromYAML(configFilePath)
 	}
 
 	return imported
@@ -572,64 +563,4 @@ func scanSingleAPIKeyRow(row *sql.Row) *APIKeyRow {
 		_ = json.Unmarshal([]byte(channelGroupsJSON), &r.AllowedChannelGroups)
 	}
 	return &r
-}
-
-// cleanAPIKeysFromYAML directly removes api-keys and api-key-entries from the YAML file
-// by manipulating the YAML node tree. This is more reliable than SaveConfigPreserveComments
-// which uses a merge that doesn't delete existing keys.
-func cleanAPIKeysFromYAML(configFilePath string) {
-	data, err := os.ReadFile(configFilePath)
-	if err != nil {
-		log.Warnf("usage: failed to read config for cleanup: %v", err)
-		return
-	}
-
-	var root yaml.Node
-	if err := yaml.Unmarshal(data, &root); err != nil {
-		log.Warnf("usage: failed to parse config YAML: %v", err)
-		return
-	}
-	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
-		return
-	}
-	mapNode := root.Content[0]
-	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
-		return
-	}
-
-	// Remove api-keys and api-key-entries from the root mapping
-	keysToRemove := map[string]bool{"api-keys": true, "api-key-entries": true}
-	filtered := make([]*yaml.Node, 0, len(mapNode.Content))
-	removed := 0
-	for i := 0; i+1 < len(mapNode.Content); i += 2 {
-		keyNode := mapNode.Content[i]
-		if keyNode != nil && keysToRemove[keyNode.Value] {
-			removed++
-			continue
-		}
-		filtered = append(filtered, mapNode.Content[i], mapNode.Content[i+1])
-	}
-
-	if removed == 0 {
-		return // nothing to clean
-	}
-
-	mapNode.Content = filtered
-
-	// Write back
-	f, err := os.Create(configFilePath)
-	if err != nil {
-		log.Warnf("usage: failed to create config for cleanup: %v", err)
-		return
-	}
-	defer f.Close()
-
-	enc := yaml.NewEncoder(f)
-	enc.SetIndent(2)
-	if err := enc.Encode(&root); err != nil {
-		log.Warnf("usage: failed to write cleaned config: %v", err)
-		return
-	}
-	_ = enc.Close()
-	log.Infof("usage: removed api-keys and api-key-entries from config.yaml (%d sections removed)", removed)
 }

--- a/internal/usage/config_yaml_cleanup.go
+++ b/internal/usage/config_yaml_cleanup.go
@@ -1,0 +1,165 @@
+package usage
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	apiKeysMigrationBackupSuffix   = ".pre-sqlite-migration"
+	proxyPoolMigrationBackupSuffix = ".pre-proxy-pool-sqlite-migration"
+	routingMigrationBackupSuffix   = ".pre-routing-sqlite-migration"
+)
+
+var dbBackedConfigYAMLKeys = map[string]bool{
+	"api-keys":        true,
+	"api-key-entries": true,
+	"routing":         true,
+	"proxy-pool":      true,
+}
+
+// ConfigStoreAvailable reports whether the SQLite store that owns DB-backed
+// config sections is ready. Callers must not remove YAML fallbacks when this is
+// false.
+func ConfigStoreAvailable() bool {
+	return getDB() != nil
+}
+
+// CleanDBBackedConfigFromYAML removes config sections now owned by SQLite from
+// config.yaml. It is safe to call repeatedly after management saves, because it
+// only rewrites the file when one of the target root keys exists.
+func CleanDBBackedConfigFromYAML(configFilePath string) int {
+	return cleanConfigKeysFromYAML(configFilePath, dbBackedConfigYAMLKeys, "DB-backed config")
+}
+
+func backupConfigForMigration(configFilePath string, suffix string) bool {
+	if strings.TrimSpace(configFilePath) == "" || strings.TrimSpace(suffix) == "" {
+		return false
+	}
+	data, err := os.ReadFile(configFilePath)
+	if err != nil {
+		log.Warnf("usage: failed to read config before migration backup: %v", err)
+		return false
+	}
+	backupPath := configFilePath + suffix
+	if err := os.WriteFile(backupPath, data, 0o600); err != nil {
+		log.Warnf("usage: failed to backup config before cleanup: %v", err)
+		return false
+	}
+	log.Infof("usage: backed up config.yaml to %s", backupPath)
+	return true
+}
+
+func cleanAPIKeysFromYAML(configFilePath string) {
+	cleanConfigKeysFromYAML(configFilePath, map[string]bool{
+		"api-keys":        true,
+		"api-key-entries": true,
+	}, "api_keys")
+}
+
+func cleanProxyPoolFromYAML(configFilePath string) {
+	cleanConfigKeysFromYAML(configFilePath, map[string]bool{
+		"proxy-pool": true,
+	}, "proxy_pool")
+}
+
+func cleanRoutingConfigFromYAML(configFilePath string) {
+	cleanConfigKeysFromYAML(configFilePath, map[string]bool{
+		"routing": true,
+	}, "routing_config")
+}
+
+func cleanConfigKeysFromYAML(configFilePath string, keysToRemove map[string]bool, label string) int {
+	if strings.TrimSpace(configFilePath) == "" || len(keysToRemove) == 0 {
+		return 0
+	}
+	data, err := os.ReadFile(configFilePath)
+	if err != nil {
+		log.Warnf("usage: failed to read config for %s cleanup: %v", label, err)
+		return 0
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		log.Warnf("usage: failed to parse config YAML for %s cleanup: %v", label, err)
+		return 0
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return 0
+	}
+	mapNode := root.Content[0]
+	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
+		return 0
+	}
+
+	filtered := make([]*yaml.Node, 0, len(mapNode.Content))
+	removed := 0
+	for i := 0; i+1 < len(mapNode.Content); i += 2 {
+		keyNode := mapNode.Content[i]
+		if keyNode != nil && keysToRemove[keyNode.Value] {
+			removed++
+			continue
+		}
+		filtered = append(filtered, mapNode.Content[i], mapNode.Content[i+1])
+	}
+	if removed == 0 {
+		return 0
+	}
+
+	mapNode.Content = filtered
+	if err := writeYAMLNodeAtomic(configFilePath, &root); err != nil {
+		log.Warnf("usage: failed to write cleaned %s config: %v", label, err)
+		return 0
+	}
+	log.Infof("usage: removed %d %s section(s) from config.yaml", removed, label)
+	return removed
+}
+
+func writeYAMLNodeAtomic(configFilePath string, root *yaml.Node) error {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		_ = enc.Close()
+		return err
+	}
+	if err := enc.Close(); err != nil {
+		return err
+	}
+
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(configFilePath); err == nil {
+		mode = info.Mode().Perm()
+	}
+
+	dir := filepath.Dir(configFilePath)
+	base := filepath.Base(configFilePath)
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(buf.Bytes()); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, configFilePath)
+}

--- a/internal/usage/config_yaml_cleanup_test.go
+++ b/internal/usage/config_yaml_cleanup_test.go
@@ -1,0 +1,166 @@
+package usage
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "modernc.org/sqlite"
+)
+
+func setupConfigMigrationTestDB(t *testing.T) func() {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	if _, err := db.Exec(createTableSQL); err != nil {
+		_ = db.Close()
+		t.Fatalf("create request_logs table: %v", err)
+	}
+	initAPIKeysTable(db)
+	initRoutingConfigTable(db)
+	initProxyPoolTable(db)
+
+	usageDBMu.Lock()
+	usageDB = db
+	usageDBPath = dbPath
+	usageDBMu.Unlock()
+
+	return func() {
+		usageDBMu.Lock()
+		if usageDB != nil {
+			_ = usageDB.Close()
+			usageDB = nil
+		}
+		usageDBPath = ""
+		usageDBMu.Unlock()
+	}
+}
+
+func TestMigrateRoutingConfigFromConfigCleansYAML(t *testing.T) {
+	cleanup := setupConfigMigrationTestDB(t)
+	defer cleanup()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8318\nrouting:\n  strategy: round-robin\n  channel-groups:\n    - name: chatgpt-pro\n      match:\n        channels:\n          - GptPro1\ndebug: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			Strategy: "round-robin",
+			ChannelGroups: []config.RoutingChannelGroup{
+				{Name: "chatgpt-pro", Match: config.ChannelGroupMatch{Channels: []string{"GptPro1"}}},
+			},
+			IncludeDefaultGroup: true,
+		},
+	}
+
+	if !MigrateRoutingConfigFromConfig(cfg, configPath) {
+		t.Fatal("MigrateRoutingConfigFromConfig returned false")
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(data), "routing:") {
+		t.Fatalf("routing should be removed from YAML after migration:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "port: 8318") || !strings.Contains(string(data), "debug: true") {
+		t.Fatalf("non-DB-backed config should remain in YAML:\n%s", string(data))
+	}
+	assertMigrationBackupMode(t, configPath+".pre-routing-sqlite-migration", 0o600)
+}
+
+func TestMigrateRoutingConfigFromConfigKeepsYAMLWhenDBUnavailable(t *testing.T) {
+	usageDBMu.Lock()
+	usageDB = nil
+	usageDBPath = ""
+	usageDBMu.Unlock()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("routing:\n  strategy: round-robin\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := &config.Config{Routing: config.RoutingConfig{Strategy: "round-robin", IncludeDefaultGroup: true}}
+
+	if MigrateRoutingConfigFromConfig(cfg, configPath) {
+		t.Fatal("MigrateRoutingConfigFromConfig returned true without a DB")
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(data), "routing:") {
+		t.Fatalf("routing should remain when DB is unavailable:\n%s", string(data))
+	}
+}
+
+func TestCleanDBBackedConfigFromYAMLCleansPersistedSections(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte("port: 8318\napi-keys:\n  - sk-test\napi-key-entries:\n  - key: sk-entry\nrouting:\n  strategy: round-robin\nproxy-pool:\n  - id: hk\n    url: http://127.0.0.1:7890\nlogging-to-file: true\n")
+	if err := os.WriteFile(configPath, content, 0o640); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if removed := CleanDBBackedConfigFromYAML(configPath); removed != 4 {
+		t.Fatalf("CleanDBBackedConfigFromYAML removed %d sections, want 4", removed)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	for _, forbidden := range []string{"api-keys:", "api-key-entries:", "routing:", "proxy-pool:"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("%s should be removed from YAML:\n%s", forbidden, string(data))
+		}
+	}
+	if !strings.Contains(string(data), "port: 8318") || !strings.Contains(string(data), "logging-to-file: true") {
+		t.Fatalf("ordinary config should remain in YAML:\n%s", string(data))
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("cleaned config mode = %o, want 640", got)
+	}
+}
+
+func TestAPIKeyMigrationBackupUsesPrivatePermissions(t *testing.T) {
+	cleanup := setupConfigMigrationTestDB(t)
+	defer cleanup()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("api-keys:\n  - sk-test\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := &config.Config{SDKConfig: config.SDKConfig{APIKeys: []string{"sk-test"}}}
+
+	if migrated := MigrateAPIKeysFromConfig(cfg, configPath); migrated != 1 {
+		t.Fatalf("MigrateAPIKeysFromConfig = %d, want 1", migrated)
+	}
+	assertMigrationBackupMode(t, configPath+".pre-sqlite-migration", 0o600)
+}
+
+func assertMigrationBackupMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected migration backup %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("backup mode for %s = %o, want %o", path, got, want)
+	}
+}

--- a/internal/usage/proxy_pool_db.go
+++ b/internal/usage/proxy_pool_db.go
@@ -3,14 +3,12 @@ package usage
 import (
 	"database/sql"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 	"unicode"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 )
 
 const createProxyPoolTableSQL = `
@@ -139,14 +137,24 @@ func ApplyStoredProxyPool(cfg *config.Config) bool {
 
 // MigrateProxyPoolFromConfig moves legacy YAML proxy-pool entries into SQLite.
 func MigrateProxyPoolFromConfig(cfg *config.Config, configFilePath string) int {
-	if cfg == nil || !ProxyPoolStoreAvailable() || len(cfg.ProxyPool) == 0 || len(ListProxyPool()) > 0 {
+	if cfg == nil || !ProxyPoolStoreAvailable() {
+		return 0
+	}
+	if len(ListProxyPool()) > 0 {
+		cfg.ProxyPool = nil
+		cleanProxyPoolFromYAML(configFilePath)
+		return 0
+	}
+	if len(cfg.ProxyPool) == 0 {
 		return 0
 	}
 
 	normalized := config.NormalizeProxyPool(cfg.ProxyPool)
 	if len(normalized) == 0 {
 		cfg.ProxyPool = nil
-		cleanProxyPoolFromYAML(configFilePath)
+		if backupConfigForMigration(configFilePath, proxyPoolMigrationBackupSuffix) {
+			cleanProxyPoolFromYAML(configFilePath)
+		}
 		return 0
 	}
 
@@ -156,13 +164,9 @@ func MigrateProxyPoolFromConfig(cfg *config.Config, configFilePath string) int {
 	}
 	cfg.ProxyPool = nil
 	if configFilePath != "" {
-		backupPath := configFilePath + ".pre-proxy-pool-sqlite-migration"
-		if data, err := os.ReadFile(configFilePath); err == nil {
-			if err := os.WriteFile(backupPath, data, 0o644); err != nil {
-				log.Warnf("usage: failed to backup config before proxy_pool cleanup: %v", err)
-			}
+		if backupConfigForMigration(configFilePath, proxyPoolMigrationBackupSuffix) {
+			cleanProxyPoolFromYAML(configFilePath)
 		}
-		cleanProxyPoolFromYAML(configFilePath)
 	}
 	log.Infof("usage: migrated %d proxy_pool entries from config to SQLite", len(normalized))
 	return len(normalized)
@@ -204,57 +208,4 @@ func normalizeProxyPoolEntryID(raw string) string {
 		}
 	}
 	return strings.Trim(b.String(), "-")
-}
-
-func cleanProxyPoolFromYAML(configFilePath string) {
-	if strings.TrimSpace(configFilePath) == "" {
-		return
-	}
-	data, err := os.ReadFile(configFilePath)
-	if err != nil {
-		log.Warnf("usage: failed to read config for proxy_pool cleanup: %v", err)
-		return
-	}
-
-	var root yaml.Node
-	if err := yaml.Unmarshal(data, &root); err != nil {
-		log.Warnf("usage: failed to parse config YAML for proxy_pool cleanup: %v", err)
-		return
-	}
-	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
-		return
-	}
-	mapNode := root.Content[0]
-	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
-		return
-	}
-
-	filtered := make([]*yaml.Node, 0, len(mapNode.Content))
-	removed := 0
-	for i := 0; i+1 < len(mapNode.Content); i += 2 {
-		keyNode := mapNode.Content[i]
-		if keyNode != nil && keyNode.Value == "proxy-pool" {
-			removed++
-			continue
-		}
-		filtered = append(filtered, mapNode.Content[i], mapNode.Content[i+1])
-	}
-	if removed == 0 {
-		return
-	}
-
-	mapNode.Content = filtered
-	f, err := os.Create(configFilePath)
-	if err != nil {
-		log.Warnf("usage: failed to create config for proxy_pool cleanup: %v", err)
-		return
-	}
-	defer f.Close()
-
-	enc := yaml.NewEncoder(f)
-	enc.SetIndent(2)
-	if err := enc.Encode(&root); err != nil {
-		log.Warnf("usage: failed to write cleaned proxy_pool config: %v", err)
-	}
-	_ = enc.Close()
 }

--- a/internal/usage/proxy_pool_db_test.go
+++ b/internal/usage/proxy_pool_db_test.go
@@ -107,7 +107,43 @@ func TestProxyPoolMigrationMovesConfigEntriesIntoSQLite(t *testing.T) {
 	if strings.Contains(string(data), "proxy-pool:") {
 		t.Fatalf("proxy-pool should be removed from YAML after migration:\n%s", string(data))
 	}
-	if _, err := os.Stat(configPath + ".pre-proxy-pool-sqlite-migration"); err != nil {
-		t.Fatalf("expected migration backup: %v", err)
+	assertMigrationBackupMode(t, configPath+".pre-proxy-pool-sqlite-migration", 0o600)
+}
+
+func TestProxyPoolMigrationCleansYAMLWhenSQLiteAlreadyHasEntries(t *testing.T) {
+	cleanup := setupProxyPoolTestDB(t)
+	defer cleanup()
+
+	if err := ReplaceProxyPool([]config.ProxyPoolEntry{
+		{ID: "db-proxy", Name: "DB Proxy", URL: "http://127.0.0.1:7890", Enabled: true},
+	}); err != nil {
+		t.Fatalf("ReplaceProxyPool: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("proxy-pool:\n  - id: yaml-proxy\n    url: http://127.0.0.1:7891\nlogging-to-file: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := &config.Config{
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "yaml-proxy", URL: "http://127.0.0.1:7891", Enabled: true},
+		},
+	}
+
+	if migrated := MigrateProxyPoolFromConfig(cfg, configPath); migrated != 0 {
+		t.Fatalf("MigrateProxyPoolFromConfig = %d, want 0 when DB already has entries", migrated)
+	}
+	if len(cfg.ProxyPool) != 0 {
+		t.Fatalf("cfg.ProxyPool after cleanup = %#v, want empty before DB apply", cfg.ProxyPool)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(data), "proxy-pool:") {
+		t.Fatalf("stale proxy-pool should be removed from YAML:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "logging-to-file: true") {
+		t.Fatalf("ordinary config should remain in YAML:\n%s", string(data))
 	}
 }

--- a/internal/usage/routing_config_db.go
+++ b/internal/usage/routing_config_db.go
@@ -38,7 +38,7 @@ func routingConfigMeaningful(cfg config.RoutingConfig) bool {
 }
 
 func ApplyStoredRoutingConfig(cfg *config.Config) bool {
-	if cfg == nil {
+	if cfg == nil || !ConfigStoreAvailable() {
 		return false
 	}
 	stored := GetRoutingConfig()
@@ -49,13 +49,25 @@ func ApplyStoredRoutingConfig(cfg *config.Config) bool {
 	return true
 }
 
-func MigrateRoutingConfigFromConfig(cfg *config.Config) bool {
-	if cfg == nil || !routingConfigMeaningful(cfg.Routing) || GetRoutingConfig() != nil {
+func MigrateRoutingConfigFromConfig(cfg *config.Config, configFilePath string) bool {
+	if cfg == nil || !ConfigStoreAvailable() {
+		return false
+	}
+	if GetRoutingConfig() != nil {
+		cleanRoutingConfigFromYAML(configFilePath)
+		return false
+	}
+	if !routingConfigMeaningful(cfg.Routing) {
 		return false
 	}
 	if err := UpsertRoutingConfig(cfg.Routing); err != nil {
 		log.Errorf("usage: migrate routing config: %v", err)
 		return false
+	}
+	if strings.TrimSpace(configFilePath) != "" {
+		if backupConfigForMigration(configFilePath, routingMigrationBackupSuffix) {
+			cleanRoutingConfigFromYAML(configFilePath)
+		}
 	}
 	return true
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -585,6 +585,7 @@ func (s *Service) Run(ctx context.Context) error {
 		if newCfg == nil {
 			return
 		}
+		internalusage.MigrateRoutingConfigFromConfig(newCfg, s.configPath)
 		internalusage.ApplyStoredRoutingConfig(newCfg)
 		internalusage.MigrateProxyPoolFromConfig(newCfg, s.configPath)
 		internalusage.ApplyStoredProxyPool(newCfg)


### PR DESCRIPTION
## Summary
- add shared YAML cleanup helpers for DB-backed config sections
- migrate routing config into SQLite and clean stale routing/proxy/API-key YAML sections after successful migration
- make migration backups private and YAML rewrites atomic

## Tests
- go test ./...
