### PR TITLE
fix: default Gemini CLI OAuth client

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,7 +3,9 @@
 host: ""
 
 # OAuth client credentials for provider login flows.
-# You can set these either in config.yaml or via environment variables:
+# Gemini CLI / Code Assist OAuth uses the official Gemini CLI OAuth client by default.
+# Set Gemini credentials only when you intentionally want to override that client.
+# You can set overrides either in config.yaml or via environment variables:
 #   - Gemini:      CLIRELAY_GEMINI_OAUTH_CLIENT_ID / CLIRELAY_GEMINI_OAUTH_CLIENT_SECRET
 #   - Antigravity: CLIRELAY_ANTIGRAVITY_OAUTH_CLIENT_ID / CLIRELAY_ANTIGRAVITY_OAUTH_CLIENT_SECRET
 oauth-clients:

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -314,7 +315,7 @@ func (h *Handler) refreshGeminiOAuthAccessToken(ctx context.Context, auth *corea
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
-	clientID, clientSecret := cfg.OAuthClientCredentials(config.OAuthClientGemini)
+	clientID, clientSecret := geminiAuth.ResolveOAuthClientCredentials(cfg, base, metadata)
 	if strings.TrimSpace(clientID) == "" {
 		return "", fmt.Errorf("gemini oauth client-id missing (set config oauth-clients.gemini.client-id or env %s)", config.EnvGeminiOAuthClientID)
 	}

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1696,10 +1696,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			return
 		}
 
-		ifToken["token_uri"] = "https://oauth2.googleapis.com/token"
-		ifToken["client_id"] = strings.TrimSpace(conf.ClientID)
-		ifToken["scopes"] = geminiAuth.Scopes
-		ifToken["universe_domain"] = "googleapis.com"
+		ifToken = geminiAuth.EnrichOAuthTokenMap(ifToken, conf)
 
 		ts := geminiAuth.GeminiTokenStorage{
 			Token:     ifToken,

--- a/internal/auth/gemini/gemini_auth.go
+++ b/internal/auth/gemini/gemini_auth.go
@@ -41,6 +41,72 @@ var Scopes = []string{
 	"https://www.googleapis.com/auth/userinfo.profile",
 }
 
+func EnrichOAuthTokenMap(tokenMap map[string]any, oauthConfig *oauth2.Config) map[string]any {
+	if tokenMap == nil {
+		tokenMap = make(map[string]any)
+	}
+	tokenMap["token_uri"] = "https://oauth2.googleapis.com/token"
+	if oauthConfig != nil {
+		if strings.TrimSpace(oauthConfig.ClientID) != "" {
+			tokenMap["client_id"] = strings.TrimSpace(oauthConfig.ClientID)
+		}
+		if strings.TrimSpace(oauthConfig.ClientSecret) != "" {
+			tokenMap["client_secret"] = strings.TrimSpace(oauthConfig.ClientSecret)
+		}
+		if len(oauthConfig.Scopes) > 0 {
+			tokenMap["scopes"] = append([]string(nil), oauthConfig.Scopes...)
+		} else {
+			tokenMap["scopes"] = append([]string(nil), Scopes...)
+		}
+	} else {
+		tokenMap["scopes"] = append([]string(nil), Scopes...)
+	}
+	tokenMap["universe_domain"] = "googleapis.com"
+	return tokenMap
+}
+
+func ResolveOAuthClientCredentials(appConfig *config.Config, tokenData, metadata map[string]any) (string, string) {
+	clientID := strings.TrimSpace(stringFromMap(tokenData, "client_id"))
+	clientSecret := strings.TrimSpace(stringFromMap(tokenData, "client_secret"))
+	if clientID == "" {
+		clientID = strings.TrimSpace(stringFromMap(metadata, "client_id"))
+	}
+	if clientSecret == "" {
+		clientSecret = strings.TrimSpace(stringFromMap(metadata, "client_secret"))
+	}
+	if clientID != "" {
+		if clientSecret == "" && appConfig != nil {
+			cfgClientID, cfgClientSecret := appConfig.OAuthClientCredentials(config.OAuthClientGemini)
+			if strings.TrimSpace(cfgClientID) == clientID {
+				clientSecret = strings.TrimSpace(cfgClientSecret)
+			}
+		}
+		if clientSecret == "" && clientID == config.GeminiCLIOAuthClientID {
+			clientSecret = config.GeminiCLIOAuthClientSecret
+		}
+		return clientID, clientSecret
+	}
+	if appConfig == nil {
+		appConfig = &config.Config{}
+	}
+	return appConfig.OAuthClientCredentials(config.OAuthClientGemini)
+}
+
+func stringFromMap(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key]; ok {
+		switch typed := v.(type) {
+		case string:
+			return typed
+		case fmt.Stringer:
+			return typed.String()
+		}
+	}
+	return ""
+}
+
 // GeminiAuth provides methods for handling the Gemini OAuth2 authentication flow.
 // It encapsulates the logic for obtaining, storing, and refreshing authentication tokens
 // for Google's Gemini AI services.
@@ -201,10 +267,7 @@ func (g *GeminiAuth) createTokenStorage(ctx context.Context, config *oauth2.Conf
 		return nil, fmt.Errorf("failed to unmarshal token: %w", err)
 	}
 
-	ifToken["token_uri"] = "https://oauth2.googleapis.com/token"
-	ifToken["client_id"] = strings.TrimSpace(config.ClientID)
-	ifToken["scopes"] = Scopes
-	ifToken["universe_domain"] = "googleapis.com"
+	ifToken = EnrichOAuthTokenMap(ifToken, config)
 
 	ts := GeminiTokenStorage{
 		Token:     ifToken,

--- a/internal/auth/gemini/gemini_auth_test.go
+++ b/internal/auth/gemini/gemini_auth_test.go
@@ -1,0 +1,52 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"golang.org/x/oauth2"
+)
+
+func TestEnrichOAuthTokenMapStoresClientSecret(t *testing.T) {
+	tokenMap := map[string]any{
+		"access_token": "access-token",
+	}
+	conf := &oauth2.Config{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scopes:       Scopes,
+	}
+
+	enriched := EnrichOAuthTokenMap(tokenMap, conf)
+
+	if enriched["client_id"] != "client-id" {
+		t.Fatalf("client_id = %v, want client-id", enriched["client_id"])
+	}
+	if enriched["client_secret"] != "client-secret" {
+		t.Fatalf("client_secret = %v, want client-secret", enriched["client_secret"])
+	}
+	if enriched["token_uri"] != "https://oauth2.googleapis.com/token" {
+		t.Fatalf("token_uri = %v, want oauth2 token endpoint", enriched["token_uri"])
+	}
+}
+
+func TestResolveOAuthClientCredentialsUsesStoredTokenClient(t *testing.T) {
+	clientID, clientSecret := ResolveOAuthClientCredentials(&config.Config{
+		OAuthClients: config.OAuthClients{
+			Gemini: config.OAuthClient{
+				ClientID:     "configured-client-id",
+				ClientSecret: "configured-client-secret",
+			},
+		},
+	}, map[string]any{
+		"client_id":     "stored-client-id",
+		"client_secret": "stored-client-secret",
+	}, nil)
+
+	if clientID != "stored-client-id" {
+		t.Fatalf("clientID = %q, want stored-client-id", clientID)
+	}
+	if clientSecret != "stored-client-secret" {
+		t.Fatalf("clientSecret = %q, want stored-client-secret", clientSecret)
+	}
+}

--- a/internal/config/oauth_clients.go
+++ b/internal/config/oauth_clients.go
@@ -9,6 +9,11 @@ const (
 	OAuthClientGemini      = "gemini"
 	OAuthClientAntigravity = "antigravity"
 
+	// GeminiCLIOAuthClientID and GeminiCLIOAuthClientSecret are the OAuth
+	// client credentials published by Google's Gemini CLI for Code Assist login.
+	GeminiCLIOAuthClientID     = "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
+	GeminiCLIOAuthClientSecret = "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"
+
 	EnvGeminiOAuthClientID     = "CLIRELAY_GEMINI_OAUTH_CLIENT_ID"
 	EnvGeminiOAuthClientSecret = "CLIRELAY_GEMINI_OAUTH_CLIENT_SECRET"
 
@@ -55,6 +60,15 @@ func (cfg *Config) OAuthClientCredentials(kind string) (clientID, clientSecret s
 		}
 		if clientSecret == "" {
 			clientSecret = strings.TrimSpace(os.Getenv(EnvAntigravityOAuthClientSecret))
+		}
+	}
+
+	if strings.EqualFold(strings.TrimSpace(kind), OAuthClientGemini) {
+		if clientID == "" {
+			clientID = GeminiCLIOAuthClientID
+		}
+		if clientSecret == "" && clientID == GeminiCLIOAuthClientID {
+			clientSecret = GeminiCLIOAuthClientSecret
 		}
 	}
 

--- a/internal/config/oauth_clients_test.go
+++ b/internal/config/oauth_clients_test.go
@@ -1,0 +1,58 @@
+package config
+
+import "testing"
+
+func TestGeminiOAuthClientCredentialsDefaultsToGeminiCLIClient(t *testing.T) {
+	t.Setenv(EnvGeminiOAuthClientID, "")
+	t.Setenv(EnvGeminiOAuthClientSecret, "")
+
+	cfg := &Config{}
+
+	clientID, clientSecret := cfg.OAuthClientCredentials(OAuthClientGemini)
+
+	if clientID != "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com" {
+		t.Fatalf("clientID = %q, want official Gemini CLI OAuth client", clientID)
+	}
+	if clientSecret == "" {
+		t.Fatalf("clientSecret is empty, want official Gemini CLI OAuth client secret")
+	}
+}
+
+func TestGeminiOAuthClientCredentialsKeepsExplicitConfig(t *testing.T) {
+	t.Setenv(EnvGeminiOAuthClientID, "")
+	t.Setenv(EnvGeminiOAuthClientSecret, "")
+
+	cfg := &Config{
+		OAuthClients: OAuthClients{
+			Gemini: OAuthClient{
+				ClientID:     "custom-client-id",
+				ClientSecret: "custom-client-secret",
+			},
+		},
+	}
+
+	clientID, clientSecret := cfg.OAuthClientCredentials(OAuthClientGemini)
+
+	if clientID != "custom-client-id" {
+		t.Fatalf("clientID = %q, want custom-client-id", clientID)
+	}
+	if clientSecret != "custom-client-secret" {
+		t.Fatalf("clientSecret = %q, want custom-client-secret", clientSecret)
+	}
+}
+
+func TestAntigravityOAuthClientCredentialsDoNotUseGeminiCLIDefault(t *testing.T) {
+	t.Setenv(EnvAntigravityOAuthClientID, "")
+	t.Setenv(EnvAntigravityOAuthClientSecret, "")
+
+	cfg := &Config{}
+
+	clientID, clientSecret := cfg.OAuthClientCredentials(OAuthClientAntigravity)
+
+	if clientID != "" {
+		t.Fatalf("clientID = %q, want empty antigravity client ID", clientID)
+	}
+	if clientSecret != "" {
+		t.Fatalf("clientSecret = %q, want empty antigravity client secret", clientSecret)
+	}
+}

--- a/internal/runtime/executor/gemini_cli_executor.go
+++ b/internal/runtime/executor/gemini_cli_executor.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
@@ -659,7 +660,7 @@ func prepareGeminiCLITokenSource(ctx context.Context, cfg *config.Config, auth *
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
-	clientID, clientSecret := cfg.OAuthClientCredentials(config.OAuthClientGemini)
+	clientID, clientSecret := resolveGeminiCLITokenOAuthClient(cfg, base, metadata)
 	if strings.TrimSpace(clientID) == "" {
 		return nil, nil, fmt.Errorf("gemini-cli oauth client-id missing (set config oauth-clients.gemini.client-id or env %s)", config.EnvGeminiOAuthClientID)
 	}
@@ -678,6 +679,10 @@ func prepareGeminiCLITokenSource(ctx context.Context, cfg *config.Config, auth *
 	}
 	updateGeminiCLITokenMetadata(auth, base, currentToken)
 	return oauth2.ReuseTokenSource(currentToken, src), base, nil
+}
+
+func resolveGeminiCLITokenOAuthClient(cfg *config.Config, tokenData, metadata map[string]any) (string, string) {
+	return geminiAuth.ResolveOAuthClientCredentials(cfg, tokenData, metadata)
 }
 
 func updateGeminiCLITokenMetadata(auth *cliproxyauth.Auth, base map[string]any, tok *oauth2.Token) {

--- a/internal/runtime/executor/gemini_cli_executor_test.go
+++ b/internal/runtime/executor/gemini_cli_executor_test.go
@@ -1,0 +1,100 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestPrepareGeminiCLITokenSourceUsesStoredOAuthClientCredentials(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Metadata: map[string]any{
+			"token": map[string]any{
+				"access_token":  "expired-access-token",
+				"refresh_token": "stored-refresh-token",
+				"token_type":    "Bearer",
+				"expiry":        time.Now().Add(-time.Hour).Format(time.RFC3339),
+				"client_id":     "stored-client-id",
+				"client_secret": "stored-client-secret",
+			},
+		},
+	}
+	cfg := &config.Config{
+		OAuthClients: config.OAuthClients{
+			Gemini: config.OAuthClient{
+				ClientID:     "configured-client-id",
+				ClientSecret: "configured-client-secret",
+			},
+		},
+	}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if err := req.ParseForm(); err != nil {
+			t.Fatalf("ParseForm returned error: %v", err)
+		}
+		if got := req.Form.Get("client_id"); got != "stored-client-id" {
+			t.Fatalf("refresh client_id = %q, want stored-client-id", got)
+		}
+		if got := req.Form.Get("client_secret"); got != "stored-client-secret" {
+			t.Fatalf("refresh client_secret = %q, want stored-client-secret", got)
+		}
+		if got := req.Form.Get("refresh_token"); got != "stored-refresh-token" {
+			t.Fatalf("refresh_token = %q, want stored-refresh-token", got)
+		}
+
+		body, _ := json.Marshal(map[string]any{
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       ioNopCloser{Reader: strings.NewReader(string(body))},
+			Request:    req,
+		}, nil
+	}))
+
+	_, _, err := prepareGeminiCLITokenSource(ctx, cfg, auth)
+	if err != nil {
+		t.Fatalf("prepareGeminiCLITokenSource returned error: %v", err)
+	}
+}
+
+func TestResolveGeminiCLITokenOAuthClientUsesConfiguredSecretForMatchingStoredClientID(t *testing.T) {
+	cfg := &config.Config{
+		OAuthClients: config.OAuthClients{
+			Gemini: config.OAuthClient{
+				ClientID:     "custom-client-id",
+				ClientSecret: "custom-client-secret",
+			},
+		},
+	}
+
+	clientID, clientSecret := resolveGeminiCLITokenOAuthClient(cfg, map[string]any{
+		"client_id": "custom-client-id",
+	}, nil)
+
+	if clientID != "custom-client-id" {
+		t.Fatalf("clientID = %q, want custom-client-id", clientID)
+	}
+	if clientSecret != "custom-client-secret" {
+		t.Fatalf("clientSecret = %q, want custom-client-secret", clientSecret)
+	}
+}
+
+type ioNopCloser struct {
+	*strings.Reader
+}
+
+func (c ioNopCloser) Close() error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- default Gemini OAuth config to the official Gemini CLI Code Assist OAuth client
- preserve effective client metadata in generated Gemini auth files
- prefer stored OAuth client credentials when refreshing Gemini CLI tokens

## Test Plan
- go test ./internal/config ./internal/auth/gemini ./internal/runtime/executor ./internal/api/handlers/management
- go test ./...