### PR TITLE
feat: add auth file quota trend api

### DIFF
--- a/internal/api/handlers/management/quota.go
+++ b/internal/api/handlers/management/quota.go
@@ -3,6 +3,7 @@ package management
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -60,11 +61,27 @@ func (h *Handler) PostQuotaReconcile(c *gin.Context) {
 }
 
 type quotaSnapshotRequest struct {
-	AuthIndexSnake  *string             `json:"auth_index"`
-	AuthIndexCamel  *string             `json:"authIndex"`
-	AuthIndexPascal *string             `json:"AuthIndex"`
-	Provider        string              `json:"provider"`
-	Quotas          map[string]*float64 `json:"quotas"`
+	AuthIndexSnake   *string                     `json:"auth_index"`
+	AuthIndexCamel   *string                     `json:"authIndex"`
+	AuthIndexPascal  *string                     `json:"AuthIndex"`
+	Provider         string                      `json:"provider"`
+	Quotas           map[string]*float64         `json:"quotas"`
+	QuotaPoints      []quotaSnapshotPointRequest `json:"quota_points"`
+	QuotaPointsCamel []quotaSnapshotPointRequest `json:"quotaPoints"`
+}
+
+type quotaSnapshotPointRequest struct {
+	RecordedAtSnake    *time.Time `json:"recorded_at"`
+	RecordedAtCamel    *time.Time `json:"recordedAt"`
+	QuotaKeySnake      string     `json:"quota_key"`
+	QuotaKeyCamel      string     `json:"quotaKey"`
+	QuotaLabelSnake    string     `json:"quota_label"`
+	QuotaLabelCamel    string     `json:"quotaLabel"`
+	Percent            *float64   `json:"percent"`
+	ResetAtSnake       *time.Time `json:"reset_at"`
+	ResetAtCamel       *time.Time `json:"resetAt"`
+	WindowSecondsSnake int64      `json:"window_seconds"`
+	WindowSecondsCamel int64      `json:"windowSeconds"`
 }
 
 func (h *Handler) PostAuthFileQuotaSnapshot(c *gin.Context) {
@@ -84,8 +101,12 @@ func (h *Handler) PostAuthFileQuotaSnapshot(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index is required"})
 		return
 	}
-	if len(body.Quotas) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "quotas is required"})
+	quotaPoints := body.QuotaPoints
+	if len(quotaPoints) == 0 && len(body.QuotaPointsCamel) > 0 {
+		quotaPoints = body.QuotaPointsCamel
+	}
+	if len(body.Quotas) == 0 && len(quotaPoints) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "quotas or quota_points is required"})
 		return
 	}
 
@@ -101,10 +122,60 @@ func (h *Handler) PostAuthFileQuotaSnapshot(c *gin.Context) {
 		}
 	}
 
-	if err := usage.RecordDailyQuotaSnapshot(authIndex, provider, body.Quotas); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
+	if len(body.Quotas) > 0 {
+		if err := usage.RecordDailyQuotaSnapshot(authIndex, provider, body.Quotas); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	if len(quotaPoints) > 0 {
+		points := make([]usage.QuotaSnapshotPoint, 0, len(quotaPoints))
+		for _, point := range quotaPoints {
+			quotaKey := strings.TrimSpace(firstNonEmptyValue(point.QuotaKeySnake, point.QuotaKeyCamel))
+			if quotaKey == "" {
+				continue
+			}
+			recordedAt := time.Time{}
+			if point.RecordedAtSnake != nil {
+				recordedAt = point.RecordedAtSnake.UTC()
+			} else if point.RecordedAtCamel != nil {
+				recordedAt = point.RecordedAtCamel.UTC()
+			}
+			var resetAt *time.Time
+			if point.ResetAtSnake != nil {
+				value := point.ResetAtSnake.UTC()
+				resetAt = &value
+			} else if point.ResetAtCamel != nil {
+				value := point.ResetAtCamel.UTC()
+				resetAt = &value
+			}
+			windowSeconds := point.WindowSecondsSnake
+			if windowSeconds == 0 {
+				windowSeconds = point.WindowSecondsCamel
+			}
+			points = append(points, usage.QuotaSnapshotPoint{
+				RecordedAt:    recordedAt,
+				QuotaKey:      quotaKey,
+				QuotaLabel:    firstNonEmptyValue(point.QuotaLabelSnake, point.QuotaLabelCamel),
+				Percent:       point.Percent,
+				ResetAt:       resetAt,
+				WindowSeconds: windowSeconds,
+			})
+		}
+		if err := usage.RecordQuotaSnapshotPoints(authIndex, provider, points); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 	}
 	h.clearTrendCache()
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func firstNonEmptyValue(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }

--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -20,6 +20,18 @@ type authFileGroupTrendResponse struct {
 	QuotaPoints []usage.DailyQuotaPoint `json:"quota_points"`
 }
 
+type authFileTrendResponse struct {
+	AuthIndex         string                      `json:"auth_index"`
+	Days              int                         `json:"days"`
+	Hours             int                         `json:"hours"`
+	RequestTotal      int64                       `json:"request_total"`
+	CycleRequestTotal int64                       `json:"cycle_request_total"`
+	CycleStart        string                      `json:"cycle_start"`
+	DailyUsage        []usage.DailyCountPoint     `json:"daily_usage"`
+	HourlyUsage       []usage.HourlyCountPoint    `json:"hourly_usage"`
+	QuotaSeries       []usage.QuotaSnapshotSeries `json:"quota_series"`
+}
+
 // GetUsageLogs returns paginated, filterable request log entries from SQLite.
 // It enriches each log item with resolved api_key_name and channel_name
 // from the in-memory config, eliminating the need for multiple frontend API calls.
@@ -661,6 +673,134 @@ func (h *Handler) GetAuthFileGroupTrend(c *gin.Context) {
 	payload := authFileGroupTrendResponse{Days: days, Group: group, Points: points, QuotaPoints: quotaPoints}
 	h.setTrendCache(cacheKey, payload)
 	c.JSON(http.StatusOK, payload)
+}
+
+func (h *Handler) GetAuthFileTrend(c *gin.Context) {
+	authIndex := strings.TrimSpace(c.Query("auth_index"))
+	if authIndex == "" {
+		authIndex = strings.TrimSpace(c.Query("authIndex"))
+	}
+	if authIndex == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index is required"})
+		return
+	}
+	if h != nil && h.authManager != nil && h.authByIndex(authIndex) == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "auth not found"})
+		return
+	}
+
+	days := intQueryDefault(c, "days", 7)
+	if days < 1 {
+		days = 7
+	}
+	if days > 7 {
+		days = 7
+	}
+	hours := intQueryDefault(c, "hours", 5)
+	if hours < 1 {
+		hours = 5
+	}
+	if hours > 24 {
+		hours = 24
+	}
+
+	dailyRaw, err := usage.QueryDailyCallsByAuthIndexes([]string{authIndex}, days)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	daily := fillDailyCountPoints(dailyRaw, days)
+
+	hourly, err := usage.QueryHourlyCallsByAuthIndex(authIndex, hours)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if hourly == nil {
+		hourly = []usage.HourlyCountPoint{}
+	}
+
+	cutoff := usage.CutoffStartUTC(days)
+	requestTotal, err := usage.QueryRequestCountByAuthIndexSince(authIndex, cutoff)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	trendStart := time.Now().AddDate(0, 0, -7)
+	trendEnd := time.Now().Add(time.Minute)
+	series, err := usage.QueryQuotaSnapshotSeries(authIndex, trendStart, trendEnd)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if series == nil {
+		series = []usage.QuotaSnapshotSeries{}
+	}
+
+	cycleStart := cutoff
+	if weeklyCycleStart, ok := latestWeeklyQuotaCycleStart(series); ok && weeklyCycleStart.After(cutoff) {
+		cycleStart = weeklyCycleStart
+	}
+	cycleRequestTotal, err := usage.QueryRequestCountByAuthIndexSince(authIndex, cycleStart)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, authFileTrendResponse{
+		AuthIndex:         authIndex,
+		Days:              days,
+		Hours:             hours,
+		RequestTotal:      requestTotal,
+		CycleRequestTotal: cycleRequestTotal,
+		CycleStart:        cycleStart.UTC().Format(time.RFC3339),
+		DailyUsage:        daily,
+		HourlyUsage:       hourly,
+		QuotaSeries:       series,
+	})
+}
+
+func fillDailyCountPoints(points []usage.DailyCountPoint, days int) []usage.DailyCountPoint {
+	if days < 1 {
+		days = 7
+	}
+	byDate := make(map[string]int64, len(points))
+	for _, point := range points {
+		byDate[point.Date] += point.Requests
+	}
+	start := usage.CutoffStartUTC(days)
+	result := make([]usage.DailyCountPoint, 0, days)
+	for i := 0; i < days; i++ {
+		date := start.AddDate(0, 0, i).Format("2006-01-02")
+		result = append(result, usage.DailyCountPoint{Date: date, Requests: byDate[date]})
+	}
+	return result
+}
+
+func latestWeeklyQuotaCycleStart(series []usage.QuotaSnapshotSeries) (time.Time, bool) {
+	var latestPoint *usage.QuotaSnapshotSeriesPoint
+	var latestWindow int64
+	for i := range series {
+		if series[i].WindowSeconds < 604800 {
+			continue
+		}
+		windowSeconds := series[i].WindowSeconds
+		for j := range series[i].Points {
+			point := &series[i].Points[j]
+			if point.ResetAt == nil || point.ResetAt.IsZero() {
+				continue
+			}
+			if latestPoint == nil || point.Timestamp.After(latestPoint.Timestamp) {
+				latestPoint = point
+				latestWindow = windowSeconds
+			}
+		}
+	}
+	if latestPoint == nil || latestWindow <= 0 {
+		return time.Time{}, false
+	}
+	return latestPoint.ResetAt.Add(-time.Duration(latestWindow) * time.Second).UTC(), true
 }
 
 func (h *Handler) authIndexesForProviderGroup(group string) []string {

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -347,6 +347,175 @@ func TestGetAuthFileGroupTrendAggregatesByProvider(t *testing.T) {
 	}
 }
 
+func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex-auth-file-trend",
+		FileName: "codex.json",
+		Provider: "codex",
+		Label:    "GptPro2",
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	now := time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC)
+	resetAt := now.Add(4 * 24 * time.Hour)
+	cycleStart := resetAt.Add(-7 * 24 * time.Hour)
+
+	usage.InsertLog("", "", "gpt-5.4", "codex", "GptPro2", auth.Index, false, cycleStart.Add(-time.Hour), 1, 1, usage.TokenStats{TotalTokens: 1}, "", "")
+	usage.InsertLog("", "", "gpt-5.4", "codex", "GptPro2", auth.Index, false, cycleStart.Add(time.Hour), 1, 1, usage.TokenStats{TotalTokens: 1}, "", "")
+	usage.InsertLog("", "", "gpt-5.4", "codex", "GptPro2", auth.Index, false, now.Add(-time.Hour), 1, 1, usage.TokenStats{TotalTokens: 1}, "", "")
+
+	weeklyRemaining := 93.0
+	if err := usage.RecordQuotaSnapshotPoints(auth.Index, "codex", []usage.QuotaSnapshotPoint{
+		{
+			RecordedAt:    now,
+			QuotaKey:      "code_week",
+			QuotaLabel:    "m_quota.code_weekly",
+			Percent:       &weeklyRemaining,
+			ResetAt:       &resetAt,
+			WindowSeconds: 604800,
+		},
+	}); err != nil {
+		t.Fatalf("record quota snapshot point: %v", err)
+	}
+
+	h := &Handler{cfg: &config.Config{}, authManager: manager}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/auth-file-trend?auth_index="+auth.Index+"&days=7&hours=5", nil)
+
+	h.GetAuthFileTrend(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		AuthIndex         string `json:"auth_index"`
+		RequestTotal      int64  `json:"request_total"`
+		CycleRequestTotal int64  `json:"cycle_request_total"`
+		CycleStart        string `json:"cycle_start"`
+		DailyUsage        []struct {
+			Date     string `json:"date"`
+			Requests int64  `json:"requests"`
+		} `json:"daily_usage"`
+		QuotaSeries []struct {
+			QuotaKey      string `json:"quota_key"`
+			QuotaLabel    string `json:"quota_label"`
+			WindowSeconds int64  `json:"window_seconds"`
+			Points        []struct {
+				Timestamp string   `json:"timestamp"`
+				Percent   *float64 `json:"percent"`
+				ResetAt   string   `json:"reset_at"`
+			} `json:"points"`
+		} `json:"quota_series"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload.AuthIndex != auth.Index {
+		t.Fatalf("auth_index = %q, want %q", payload.AuthIndex, auth.Index)
+	}
+	if payload.RequestTotal != 3 {
+		t.Fatalf("request_total = %d, want 3", payload.RequestTotal)
+	}
+	if payload.CycleRequestTotal != 2 {
+		t.Fatalf("cycle_request_total = %d, want 2", payload.CycleRequestTotal)
+	}
+	if payload.CycleStart != cycleStart.Format(time.RFC3339) {
+		t.Fatalf("cycle_start = %q, want %q", payload.CycleStart, cycleStart.Format(time.RFC3339))
+	}
+	if len(payload.DailyUsage) != 7 {
+		t.Fatalf("daily_usage len = %d, want 7", len(payload.DailyUsage))
+	}
+	if len(payload.QuotaSeries) != 1 {
+		t.Fatalf("quota_series len = %d, want 1", len(payload.QuotaSeries))
+	}
+	if payload.QuotaSeries[0].QuotaKey != "code_week" {
+		t.Fatalf("quota key = %q, want code_week", payload.QuotaSeries[0].QuotaKey)
+	}
+	if payload.QuotaSeries[0].WindowSeconds != 604800 {
+		t.Fatalf("window seconds = %d, want 604800", payload.QuotaSeries[0].WindowSeconds)
+	}
+	if len(payload.QuotaSeries[0].Points) != 1 || payload.QuotaSeries[0].Points[0].Percent == nil || *payload.QuotaSeries[0].Points[0].Percent != 93 {
+		t.Fatalf("quota point = %+v, want one 93%% point", payload.QuotaSeries[0].Points)
+	}
+}
+
+func TestPostAuthFileQuotaSnapshotStoresFineGrainedPoints(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	body := []byte(`{
+		"auth_index":"auth-1",
+		"provider":"codex",
+		"quotas":{"code_week":93},
+		"quota_points":[
+			{
+				"quota_key":"additional:codex_bengalfox:5h",
+				"quota_label":"GPT-5.3-Codex-Spark: 5h",
+				"percent":100,
+				"reset_at":"2026-04-30T21:00:00Z",
+				"window_seconds":18000
+			}
+		]
+	}`)
+
+	h := &Handler{cfg: &config.Config{}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/usage/auth-file-quota-snapshot", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PostAuthFileQuotaSnapshot(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	points, err := usage.QueryQuotaSnapshotPoints("auth-1", time.Now().Add(-time.Minute), time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatalf("QueryQuotaSnapshotPoints() error = %v", err)
+	}
+	if len(points) != 1 {
+		t.Fatalf("points = %d, want 1", len(points))
+	}
+	if points[0].QuotaKey != "additional:codex_bengalfox:5h" {
+		t.Fatalf("quota key = %q", points[0].QuotaKey)
+	}
+	if points[0].ResetAt == nil || points[0].ResetAt.Format(time.RFC3339) != "2026-04-30T21:00:00Z" {
+		t.Fatalf("reset_at = %v", points[0].ResetAt)
+	}
+}
+
 func TestGetPublicUsageLogs_EmptyDB_DoesNotReturnNullModels(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -626,6 +626,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/usage/logs", s.mgmt.GetUsageLogs)
 		mgmt.GET("/usage/logs/:id/content", s.mgmt.GetLogContent)
 		mgmt.GET("/usage/auth-file-group-trend", s.mgmt.GetAuthFileGroupTrend)
+		mgmt.GET("/usage/auth-file-trend", s.mgmt.GetAuthFileTrend)
 		mgmt.POST("/usage/auth-file-quota-snapshot", s.mgmt.PostAuthFileQuotaSnapshot)
 		mgmt.GET("/usage/chart-data", s.mgmt.GetUsageChartData)
 		mgmt.GET("/usage/entity-stats", s.mgmt.GetEntityUsageStats)

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -81,6 +81,35 @@ type DailyQuotaPoint struct {
 	Samples int64    `json:"samples"`
 }
 
+type HourlyCountPoint struct {
+	Hour     string `json:"hour"`
+	Requests int64  `json:"requests"`
+}
+
+type QuotaSnapshotPoint struct {
+	RecordedAt    time.Time  `json:"recorded_at"`
+	AuthIndex     string     `json:"auth_index"`
+	Provider      string     `json:"provider"`
+	QuotaKey      string     `json:"quota_key"`
+	QuotaLabel    string     `json:"quota_label"`
+	Percent       *float64   `json:"percent"`
+	ResetAt       *time.Time `json:"reset_at,omitempty"`
+	WindowSeconds int64      `json:"window_seconds"`
+}
+
+type QuotaSnapshotSeriesPoint struct {
+	Timestamp time.Time  `json:"timestamp"`
+	Percent   *float64   `json:"percent"`
+	ResetAt   *time.Time `json:"reset_at,omitempty"`
+}
+
+type QuotaSnapshotSeries struct {
+	QuotaKey      string                     `json:"quota_key"`
+	QuotaLabel    string                     `json:"quota_label"`
+	WindowSeconds int64                      `json:"window_seconds"`
+	Points        []QuotaSnapshotSeriesPoint `json:"points"`
+}
+
 const systemRequestLogFilterValue = "__system__"
 
 var (
@@ -140,6 +169,21 @@ CREATE TABLE IF NOT EXISTS auth_file_quota_snapshots (
 
 CREATE INDEX IF NOT EXISTS idx_quota_snapshots_date ON auth_file_quota_snapshots(date_key);
 CREATE INDEX IF NOT EXISTS idx_quota_snapshots_auth ON auth_file_quota_snapshots(auth_index);
+
+CREATE TABLE IF NOT EXISTS auth_file_quota_snapshot_points (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  recorded_at    DATETIME NOT NULL,
+  auth_index     TEXT NOT NULL,
+  provider       TEXT NOT NULL DEFAULT '',
+  quota_key      TEXT NOT NULL,
+  quota_label    TEXT NOT NULL DEFAULT '',
+  percent        REAL,
+  reset_at       DATETIME,
+  window_seconds INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_quota_snapshot_points_auth_time ON auth_file_quota_snapshot_points(auth_index, recorded_at);
+CREATE INDEX IF NOT EXISTS idx_quota_snapshot_points_auth_key_time ON auth_file_quota_snapshot_points(auth_index, quota_key, recorded_at);
 `
 
 // migrateContentColumns adds input_content/output_content columns to an
@@ -898,6 +942,19 @@ func MigrateFromSnapshot(snapshot StatisticsSnapshot) (int64, error) {
 
 // --- internal helpers ---
 
+func parseStoredTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
 func getDB() *sql.DB {
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()
@@ -1593,6 +1650,81 @@ func QueryDailyCallsByAuthIndexes(authIndexes []string, days int) ([]DailyCountP
 	return result, rows.Err()
 }
 
+func QueryHourlyCallsByAuthIndex(authIndex string, hours int) ([]HourlyCountPoint, error) {
+	db := getDB()
+	if db == nil {
+		return []HourlyCountPoint{}, nil
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return []HourlyCountPoint{}, nil
+	}
+	if hours < 1 {
+		hours = 5
+	}
+	if hours > 24 {
+		hours = 24
+	}
+
+	loc := getUsageLocation()
+	now := time.Now().In(loc).Truncate(time.Hour)
+	start := now.Add(-time.Duration(hours-1) * time.Hour)
+	buckets := make([]HourlyCountPoint, 0, hours)
+	byKey := make(map[string]*HourlyCountPoint, hours)
+	for i := 0; i < hours; i++ {
+		key := start.Add(time.Duration(i) * time.Hour).Format("2006-01-02 15:00")
+		buckets = append(buckets, HourlyCountPoint{Hour: key, Requests: 0})
+		byKey[key] = &buckets[len(buckets)-1]
+	}
+
+	rows, err := db.Query(`
+		SELECT timestamp
+		FROM request_logs
+		WHERE timestamp >= ? AND auth_index = ?
+	`, start.UTC().Format(time.RFC3339), authIndex)
+	if err != nil {
+		return nil, fmt.Errorf("usage: hourly calls by auth index query: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var ts string
+		if err := rows.Scan(&ts); err != nil {
+			return nil, fmt.Errorf("usage: hourly calls by auth index scan: %w", err)
+		}
+		parsed, ok := parseStoredTime(ts)
+		if !ok {
+			continue
+		}
+		key := parsed.In(loc).Truncate(time.Hour).Format("2006-01-02 15:00")
+		if bucket := byKey[key]; bucket != nil {
+			bucket.Requests++
+		}
+	}
+	return buckets, rows.Err()
+}
+
+func QueryRequestCountByAuthIndexSince(authIndex string, since time.Time) (int64, error) {
+	db := getDB()
+	if db == nil {
+		return 0, nil
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return 0, nil
+	}
+	var count int64
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM request_logs
+		WHERE timestamp >= ? AND auth_index = ?
+	`, since.UTC().Format(time.RFC3339), authIndex).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("usage: request count by auth index query: %w", err)
+	}
+	return count, nil
+}
+
 func RecordDailyQuotaSnapshot(authIndex, provider string, quotas map[string]*float64) error {
 	db := getDB()
 	if db == nil {
@@ -1665,6 +1797,98 @@ func RecordDailyQuotaSnapshot(authIndex, provider string, quotas map[string]*flo
 	return nil
 }
 
+func RecordQuotaSnapshotPoints(authIndex, provider string, points []QuotaSnapshotPoint) error {
+	db := getDB()
+	if db == nil {
+		return nil
+	}
+
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" || len(points) == 0 {
+		return nil
+	}
+	provider = strings.TrimSpace(provider)
+	now := time.Now()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: quota snapshot points begin: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO auth_file_quota_snapshot_points
+			(recorded_at, auth_index, provider, quota_key, quota_label, percent, reset_at, window_seconds)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return fmt.Errorf("usage: quota snapshot points prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, point := range points {
+		quotaKey := strings.TrimSpace(point.QuotaKey)
+		if quotaKey == "" {
+			continue
+		}
+		quotaLabel := strings.TrimSpace(point.QuotaLabel)
+		if quotaLabel == "" {
+			quotaLabel = quotaKey
+		}
+		recordedAt := point.RecordedAt
+		if recordedAt.IsZero() {
+			recordedAt = now
+		}
+		pointProvider := strings.TrimSpace(point.Provider)
+		if pointProvider == "" {
+			pointProvider = provider
+		}
+		var value any
+		if point.Percent == nil {
+			value = nil
+		} else {
+			percent := *point.Percent
+			if percent < 0 {
+				percent = 0
+			}
+			if percent > 100 {
+				percent = 100
+			}
+			value = percent
+		}
+		var resetValue any
+		if point.ResetAt != nil && !point.ResetAt.IsZero() {
+			resetValue = point.ResetAt.UTC().Format(time.RFC3339Nano)
+		}
+		if _, err = stmt.Exec(
+			recordedAt.UTC().Format(time.RFC3339Nano),
+			authIndex,
+			pointProvider,
+			quotaKey,
+			quotaLabel,
+			value,
+			resetValue,
+			point.WindowSeconds,
+		); err != nil {
+			return fmt.Errorf("usage: quota snapshot points insert: %w", err)
+		}
+	}
+
+	retentionCutoff := now.AddDate(0, 0, -8).UTC().Format(time.RFC3339Nano)
+	if _, err = tx.Exec(`DELETE FROM auth_file_quota_snapshot_points WHERE recorded_at < ?`, retentionCutoff); err != nil {
+		return fmt.Errorf("usage: quota snapshot points prune: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("usage: quota snapshot points commit: %w", err)
+	}
+	return nil
+}
+
 func QueryDailyQuotaByAuthIndexes(authIndexes []string, quotaKey string, days int) ([]DailyQuotaPoint, error) {
 	db := getDB()
 	if db == nil {
@@ -1733,6 +1957,97 @@ func QueryDailyQuotaByAuthIndexes(authIndexes []string, quotaKey string, days in
 		result = append(result, point)
 	}
 	return result, rows.Err()
+}
+
+func QueryQuotaSnapshotPoints(authIndex string, start, end time.Time) ([]QuotaSnapshotPoint, error) {
+	db := getDB()
+	if db == nil {
+		return []QuotaSnapshotPoint{}, nil
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return []QuotaSnapshotPoint{}, nil
+	}
+	if start.IsZero() {
+		start = time.Now().AddDate(0, 0, -7)
+	}
+	if end.IsZero() {
+		end = time.Now()
+	}
+
+	rows, err := db.Query(`
+		SELECT recorded_at, auth_index, provider, quota_key, quota_label, percent, reset_at, window_seconds
+		FROM auth_file_quota_snapshot_points
+		WHERE auth_index = ? AND recorded_at >= ? AND recorded_at <= ?
+		ORDER BY recorded_at ASC, quota_key ASC
+	`, authIndex, start.UTC().Format(time.RFC3339Nano), end.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return nil, fmt.Errorf("usage: quota snapshot points query: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]QuotaSnapshotPoint, 0)
+	for rows.Next() {
+		var point QuotaSnapshotPoint
+		var recordedAt string
+		var resetAt sql.NullString
+		var percent sql.NullFloat64
+		if err := rows.Scan(
+			&recordedAt,
+			&point.AuthIndex,
+			&point.Provider,
+			&point.QuotaKey,
+			&point.QuotaLabel,
+			&percent,
+			&resetAt,
+			&point.WindowSeconds,
+		); err != nil {
+			return nil, fmt.Errorf("usage: quota snapshot points scan: %w", err)
+		}
+		if parsed, ok := parseStoredTime(recordedAt); ok {
+			point.RecordedAt = parsed
+		}
+		if percent.Valid {
+			v := percent.Float64
+			point.Percent = &v
+		}
+		if resetAt.Valid {
+			if parsed, ok := parseStoredTime(resetAt.String); ok {
+				point.ResetAt = &parsed
+			}
+		}
+		result = append(result, point)
+	}
+	return result, rows.Err()
+}
+
+func QueryQuotaSnapshotSeries(authIndex string, start, end time.Time) ([]QuotaSnapshotSeries, error) {
+	points, err := QueryQuotaSnapshotPoints(authIndex, start, end)
+	if err != nil {
+		return nil, err
+	}
+	series := make([]QuotaSnapshotSeries, 0)
+	indexByKey := make(map[string]int)
+	for _, point := range points {
+		seriesKey := fmt.Sprintf("%s\x00%d", point.QuotaKey, point.WindowSeconds)
+		idx, ok := indexByKey[seriesKey]
+		if !ok {
+			idx = len(series)
+			indexByKey[seriesKey] = idx
+			series = append(series, QuotaSnapshotSeries{
+				QuotaKey:      point.QuotaKey,
+				QuotaLabel:    point.QuotaLabel,
+				WindowSeconds: point.WindowSeconds,
+				Points:        []QuotaSnapshotSeriesPoint{},
+			})
+		}
+		series[idx].Points = append(series[idx].Points, QuotaSnapshotSeriesPoint{
+			Timestamp: point.RecordedAt,
+			Percent:   point.Percent,
+			ResetAt:   point.ResetAt,
+		})
+	}
+	return series, nil
 }
 
 // GetRequestLogStorageBytes returns the approximate bytes currently occupied by

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -55,6 +55,55 @@ func TestCutoffStartUTCAtUsesProjectTimezoneForDayBoundaries(t *testing.T) {
 	}
 }
 
+func TestQuotaSnapshotPointsKeepFineGrainedSeries(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	recordedAt := time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC)
+	resetAt := recordedAt.Add(5 * time.Hour)
+	remaining := 100.0
+
+	err := RecordQuotaSnapshotPoints("auth-1", "codex", []QuotaSnapshotPoint{
+		{
+			RecordedAt:    recordedAt,
+			QuotaKey:      "additional:codex_bengalfox:5h",
+			QuotaLabel:    "GPT-5.3-Codex-Spark: 5h",
+			Percent:       &remaining,
+			ResetAt:       &resetAt,
+			WindowSeconds: 18000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RecordQuotaSnapshotPoints() error = %v", err)
+	}
+
+	points, err := QueryQuotaSnapshotPoints("auth-1", recordedAt.Add(-time.Minute), recordedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("QueryQuotaSnapshotPoints() error = %v", err)
+	}
+	if len(points) != 1 {
+		t.Fatalf("points = %d, want 1", len(points))
+	}
+	point := points[0]
+	if point.Provider != "codex" {
+		t.Fatalf("Provider = %q, want codex", point.Provider)
+	}
+	if point.QuotaKey != "additional:codex_bengalfox:5h" {
+		t.Fatalf("QuotaKey = %q", point.QuotaKey)
+	}
+	if point.QuotaLabel != "GPT-5.3-Codex-Spark: 5h" {
+		t.Fatalf("QuotaLabel = %q", point.QuotaLabel)
+	}
+	if point.Percent == nil || *point.Percent != 100 {
+		t.Fatalf("Percent = %v, want 100", point.Percent)
+	}
+	if point.ResetAt == nil || !point.ResetAt.Equal(resetAt) {
+		t.Fatalf("ResetAt = %v, want %v", point.ResetAt, resetAt)
+	}
+	if point.WindowSeconds != 18000 {
+		t.Fatalf("WindowSeconds = %d, want 18000", point.WindowSeconds)
+	}
+}
+
 func TestQueryLogsSupportsSystemRequestLogFilterValue(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 


### PR DESCRIPTION
## Summary
- add fine-grained auth-file quota snapshot persistence
- add single auth-file trend endpoint with daily/hourly usage and quota series
- compute weekly-cycle request totals from latest weekly quota reset window

## Test Plan
- go test ./internal/usage -run TestQuotaSnapshotPointsKeepFineGrainedSeries -count=1
- go test ./internal/api/handlers/management -run 'Test(GetAuthFileTrendUsesWeeklyResetCycleForRequestTotal|PostAuthFileQuotaSnapshotStoresFineGrainedPoints)' -count=1
- go test ./...