### PR TITLE
fix: bucket auth file trend days by local timezone

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -772,7 +772,7 @@ func fillDailyCountPoints(points []usage.DailyCountPoint, days int) []usage.Dail
 	start := usage.CutoffStartUTC(days)
 	result := make([]usage.DailyCountPoint, 0, days)
 	for i := 0; i < days; i++ {
-		date := start.AddDate(0, 0, i).Format("2006-01-02")
+		date := usage.LocalDayKeyAt(start.AddDate(0, 0, i))
 		result = append(result, usage.DailyCountPoint{Date: date, Requests: byDate[date]})
 	}
 	return result

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -992,6 +993,11 @@ func localDayKeyAt(t time.Time) string {
 	return t.In(loc).Format("2006-01-02")
 }
 
+// LocalDayKeyAt returns the YYYY-MM-DD day key in the project-configured timezone.
+func LocalDayKeyAt(t time.Time) string {
+	return localDayKeyAt(t)
+}
+
 func cutoffDayKey(days int) string {
 	return localDayKeyAt(CutoffStartUTC(days))
 }
@@ -1626,11 +1632,10 @@ func QueryDailyCallsByAuthIndexes(authIndexes []string, days int) ([]DailyCountP
 	}
 
 	q := fmt.Sprintf(`
-		SELECT substr(timestamp, 1, 10) AS day_key, COUNT(*)
+		SELECT timestamp
 		FROM request_logs
 		WHERE timestamp >= ? AND auth_index IN (%s)
-		GROUP BY day_key
-		ORDER BY day_key ASC
+		ORDER BY timestamp ASC
 	`, placeholders)
 
 	rows, err := db.Query(q, args...)
@@ -1639,15 +1644,31 @@ func QueryDailyCallsByAuthIndexes(authIndexes []string, days int) ([]DailyCountP
 	}
 	defer rows.Close()
 
-	result := make([]DailyCountPoint, 0, days)
+	byDate := make(map[string]int64, days)
 	for rows.Next() {
-		var point DailyCountPoint
-		if err := rows.Scan(&point.Date, &point.Requests); err != nil {
+		var ts string
+		if err := rows.Scan(&ts); err != nil {
 			return nil, fmt.Errorf("usage: daily calls by auth indexes scan: %w", err)
 		}
+		parsed, ok := parseStoredTime(ts)
+		if !ok {
+			continue
+		}
+		byDate[localDayKeyAt(parsed)]++
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	result := make([]DailyCountPoint, 0, len(byDate))
+	for date, requests := range byDate {
+		point := DailyCountPoint{Date: date, Requests: requests}
 		result = append(result, point)
 	}
-	return result, rows.Err()
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Date < result[j].Date
+	})
+	return result, nil
 }
 
 func QueryHourlyCallsByAuthIndex(authIndex string, hours int) ([]HourlyCountPoint, error) {

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -55,6 +55,36 @@ func TestCutoffStartUTCAtUsesProjectTimezoneForDayBoundaries(t *testing.T) {
 	}
 }
 
+func TestQueryDailyCallsByAuthIndexesBucketsByProjectTimezone(t *testing.T) {
+	CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	loc := time.FixedZone("UTC+14", 14*3600)
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{StoreContent: false}, loc); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	stopRequestLogMaintenance()
+	t.Cleanup(CloseDB)
+
+	nowLocal := time.Now().In(loc)
+	localToday := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 30, 0, 0, loc)
+	InsertLog("", "", "gpt-5.4", "codex", "Codex", "auth-local-day", false, localToday, 1, 1, TokenStats{TotalTokens: 1}, "", "")
+
+	points, err := QueryDailyCallsByAuthIndexes([]string{"auth-local-day"}, 1)
+	if err != nil {
+		t.Fatalf("QueryDailyCallsByAuthIndexes() error = %v", err)
+	}
+	if len(points) != 1 {
+		t.Fatalf("points len = %d, want 1: %+v", len(points), points)
+	}
+	wantDate := localToday.Format("2006-01-02")
+	if points[0].Date != wantDate {
+		t.Fatalf("point date = %q, want local day %q", points[0].Date, wantDate)
+	}
+	if points[0].Requests != 1 {
+		t.Fatalf("point requests = %d, want 1", points[0].Requests)
+	}
+}
+
 func TestQuotaSnapshotPointsKeepFineGrainedSeries(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 


### PR DESCRIPTION
## Summary
- aggregate auth-file daily request counts by the configured project timezone
- align filled trend dates with the same local day keys
- add regression coverage for requests that fall on the previous UTC date

## Verification
- go test ./internal/usage -run TestQueryDailyCallsByAuthIndexesBucketsByProjectTimezone -count=1
- go test ./internal/api/handlers/management -run 'TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal|TestGetAuthFileGroupTrendAggregatesByProvider' -count=1
- go test ./internal/usage ./internal/api/handlers/management -count=1
- go test ./...