### PR TITLE
fix: refresh Claude OAuth token for quota checks

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	claudeauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
 	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
@@ -37,6 +38,17 @@ var geminiOAuthScopes = []string{
 }
 
 var antigravityOAuthTokenURL = "https://oauth2.googleapis.com/token"
+
+type claudeOAuthRefresher interface {
+	RefreshTokens(ctx context.Context, refreshToken string) (*claudeauth.ClaudeTokenData, error)
+}
+
+var newClaudeOAuthRefresher = func(cfg *config.Config) claudeOAuthRefresher {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	return claudeauth.NewClaudeAuth(cfg)
+}
 
 type apiCallRequest struct {
 	AuthIndexSnake  *string           `json:"auth_index"`
@@ -262,8 +274,74 @@ func (h *Handler) resolveTokenForAuth(ctx context.Context, auth *coreauth.Auth) 
 		token, errToken := h.refreshAntigravityOAuthAccessToken(ctx, auth)
 		return token, errToken
 	}
+	if provider == "claude" || provider == "anthropic" {
+		token, errToken := h.refreshClaudeOAuthAccessToken(ctx, auth)
+		return token, errToken
+	}
 
 	return tokenValueForAuth(auth), nil
+}
+
+func (h *Handler) refreshClaudeOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if auth == nil {
+		return "", nil
+	}
+
+	metadata := auth.Metadata
+	if len(metadata) == 0 {
+		return "", fmt.Errorf("claude oauth metadata missing")
+	}
+
+	current := strings.TrimSpace(tokenValueFromMetadata(metadata))
+	if current != "" && !claudeTokenNeedsRefresh(metadata) {
+		return current, nil
+	}
+
+	refreshToken := stringValue(metadata, "refresh_token")
+	if refreshToken == "" {
+		return "", fmt.Errorf("claude refresh token missing")
+	}
+
+	var cfg *config.Config
+	if h != nil {
+		cfg = h.cfg
+	}
+	refresher := newClaudeOAuthRefresher(cfg)
+	tokenData, errRefresh := refresher.RefreshTokens(ctx, refreshToken)
+	if errRefresh != nil {
+		return "", errRefresh
+	}
+	if tokenData == nil || strings.TrimSpace(tokenData.AccessToken) == "" {
+		return "", fmt.Errorf("claude oauth token refresh returned empty access_token")
+	}
+
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["access_token"] = strings.TrimSpace(tokenData.AccessToken)
+	if strings.TrimSpace(tokenData.RefreshToken) != "" {
+		auth.Metadata["refresh_token"] = strings.TrimSpace(tokenData.RefreshToken)
+	}
+	if strings.TrimSpace(tokenData.Email) != "" {
+		auth.Metadata["email"] = strings.TrimSpace(tokenData.Email)
+	}
+	if strings.TrimSpace(tokenData.Expire) != "" {
+		auth.Metadata["expired"] = strings.TrimSpace(tokenData.Expire)
+	}
+	auth.Metadata["type"] = "claude"
+	now := time.Now()
+	auth.Metadata["last_refresh"] = now.Format(time.RFC3339)
+
+	if h != nil && h.authManager != nil {
+		auth.LastRefreshedAt = now
+		auth.UpdatedAt = now
+		_, _ = h.authManager.Update(ctx, auth)
+	}
+
+	return strings.TrimSpace(tokenData.AccessToken), nil
 }
 
 func (h *Handler) refreshGeminiOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {
@@ -472,6 +550,23 @@ func antigravityTokenNeedsRefresh(metadata map[string]any) bool {
 		return !exp.After(time.Now().Add(skew))
 	}
 	return true
+}
+
+func claudeTokenNeedsRefresh(metadata map[string]any) bool {
+	// Refresh a bit early to avoid requests racing token expiry.
+	const skew = 30 * time.Second
+
+	if metadata == nil {
+		return true
+	}
+	for _, key := range []string{"expired", "expiry", "expires_at", "expiresAt"} {
+		if expStr, ok := metadata[key].(string); ok {
+			if ts, errParse := time.Parse(time.RFC3339, strings.TrimSpace(expStr)); errParse == nil {
+				return !ts.After(time.Now().Add(skew))
+			}
+		}
+	}
+	return false
 }
 
 func int64Value(raw any) int64 {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	claudeauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -182,6 +183,119 @@ func TestResolveTokenForAuth_Antigravity_SkipsRefreshWhenTokenValid(t *testing.T
 	}
 	if callCount != 0 {
 		t.Fatalf("expected no refresh calls, got %d", callCount)
+	}
+}
+
+type fakeClaudeOAuthRefresher struct {
+	tokenData *claudeauth.ClaudeTokenData
+	err       error
+	calls     int
+	gotRT     string
+}
+
+func (f *fakeClaudeOAuthRefresher) RefreshTokens(ctx context.Context, refreshToken string) (*claudeauth.ClaudeTokenData, error) {
+	_ = ctx
+	f.calls++
+	f.gotRT = refreshToken
+	return f.tokenData, f.err
+}
+
+func TestResolveTokenForAuth_Claude_RefreshesExpiredToken(t *testing.T) {
+	refresher := &fakeClaudeOAuthRefresher{
+		tokenData: &claudeauth.ClaudeTokenData{
+			AccessToken:  "new-claude-token",
+			RefreshToken: "new-claude-refresh",
+			Email:        "claude@example.com",
+			Expire:       time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+	originalFactory := newClaudeOAuthRefresher
+	newClaudeOAuthRefresher = func(cfg *config.Config) claudeOAuthRefresher {
+		_ = cfg
+		return refresher
+	}
+	t.Cleanup(func() { newClaudeOAuthRefresher = originalFactory })
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+
+	auth := &coreauth.Auth{
+		ID:       "claude-test.json",
+		FileName: "claude-test.json",
+		Provider: "claude",
+		Metadata: map[string]any{
+			"type":          "claude",
+			"access_token":  "old-claude-token",
+			"refresh_token": "old-claude-refresh",
+			"expired":       time.Now().Add(-time.Hour).Format(time.RFC3339),
+			"email":         "old@example.com",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{cfg: &config.Config{}, authManager: manager}
+	token, err := h.resolveTokenForAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("resolveTokenForAuth: %v", err)
+	}
+	if token != "new-claude-token" {
+		t.Fatalf("expected refreshed token, got %q", token)
+	}
+	if refresher.calls != 1 {
+		t.Fatalf("expected 1 refresh call, got %d", refresher.calls)
+	}
+	if refresher.gotRT != "old-claude-refresh" {
+		t.Fatalf("unexpected refresh token: %q", refresher.gotRT)
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth in manager after update")
+	}
+	if got := tokenValueFromMetadata(updated.Metadata); got != "new-claude-token" {
+		t.Fatalf("expected manager metadata updated, got %q", got)
+	}
+	if got, _ := updated.Metadata["refresh_token"].(string); got != "new-claude-refresh" {
+		t.Fatalf("expected refresh_token updated, got %q", got)
+	}
+	if got, _ := updated.Metadata["email"].(string); got != "claude@example.com" {
+		t.Fatalf("expected email updated, got %q", got)
+	}
+}
+
+func TestResolveTokenForAuth_Claude_SkipsRefreshWhenTokenValid(t *testing.T) {
+	refresher := &fakeClaudeOAuthRefresher{
+		tokenData: &claudeauth.ClaudeTokenData{AccessToken: "should-not-be-used"},
+	}
+	originalFactory := newClaudeOAuthRefresher
+	newClaudeOAuthRefresher = func(cfg *config.Config) claudeOAuthRefresher {
+		_ = cfg
+		return refresher
+	}
+	t.Cleanup(func() { newClaudeOAuthRefresher = originalFactory })
+
+	auth := &coreauth.Auth{
+		ID:       "claude-valid.json",
+		FileName: "claude-valid.json",
+		Provider: "claude",
+		Metadata: map[string]any{
+			"type":         "claude",
+			"access_token": "ok-claude-token",
+			"expired":      time.Now().Add(30 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	h := &Handler{cfg: &config.Config{}}
+	token, err := h.resolveTokenForAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("resolveTokenForAuth: %v", err)
+	}
+	if token != "ok-claude-token" {
+		t.Fatalf("expected existing token, got %q", token)
+	}
+	if refresher.calls != 0 {
+		t.Fatalf("expected no refresh calls, got %d", refresher.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- refresh expired Claude OAuth access tokens when management /api-call injects $TOKEN$
- persist refreshed Claude token metadata back through the auth manager
- add regression coverage for expired and still-valid Claude OAuth tokens

## Test Plan
- go test ./internal/api/handlers/management -run 'TestResolveTokenForAuth_Claude|TestResolveTokenForAuth_Antigravity'\n- go test ./internal/api/handlers/management\n- node --check assets/AuthFilesPage-8ofG866A.js\n- go test ./...