### PR TITLE
fix: use auth proxy for Claude quota token refresh

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -305,11 +305,7 @@ func (h *Handler) refreshClaudeOAuthAccessToken(ctx context.Context, auth *corea
 		return "", fmt.Errorf("claude refresh token missing")
 	}
 
-	var cfg *config.Config
-	if h != nil {
-		cfg = h.cfg
-	}
-	refresher := newClaudeOAuthRefresher(cfg)
+	refresher := newClaudeOAuthRefresher(h.claudeOAuthRefreshConfig(auth))
 	tokenData, errRefresh := refresher.RefreshTokens(ctx, refreshToken)
 	if errRefresh != nil {
 		return "", errRefresh
@@ -342,6 +338,27 @@ func (h *Handler) refreshClaudeOAuthAccessToken(ctx context.Context, auth *corea
 	}
 
 	return strings.TrimSpace(tokenData.AccessToken), nil
+}
+
+func (h *Handler) claudeOAuthRefreshConfig(auth *coreauth.Auth) *config.Config {
+	var cfgCopy config.Config
+	if h != nil && h.cfg != nil {
+		cfgCopy = *h.cfg
+	}
+	if auth == nil {
+		return &cfgCopy
+	}
+
+	var proxyURL string
+	if h != nil && h.cfg != nil {
+		proxyURL = h.cfg.ResolveProxyURL(auth.ProxyID, auth.ProxyURL)
+	} else {
+		proxyURL = auth.ProxyURL
+	}
+	if trimmed := strings.TrimSpace(proxyURL); trimmed != "" {
+		cfgCopy.ProxyURL = trimmed
+	}
+	return &cfgCopy
 }
 
 func (h *Handler) refreshGeminiOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -265,6 +265,90 @@ func TestResolveTokenForAuth_Claude_RefreshesExpiredToken(t *testing.T) {
 	}
 }
 
+func TestResolveTokenForAuth_Claude_RefreshUsesAuthProxyURL(t *testing.T) {
+	refresher := &fakeClaudeOAuthRefresher{
+		tokenData: &claudeauth.ClaudeTokenData{
+			AccessToken: "new-claude-token",
+			Expire:      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+	var gotProxyURL string
+	originalFactory := newClaudeOAuthRefresher
+	newClaudeOAuthRefresher = func(cfg *config.Config) claudeOAuthRefresher {
+		if cfg != nil {
+			gotProxyURL = cfg.ProxyURL
+		}
+		return refresher
+	}
+	t.Cleanup(func() { newClaudeOAuthRefresher = originalFactory })
+
+	auth := &coreauth.Auth{
+		ID:       "claude-proxy.json",
+		FileName: "claude-proxy.json",
+		Provider: "claude",
+		ProxyURL: "http://auth-proxy.local:8080",
+		Metadata: map[string]any{
+			"type":          "claude",
+			"access_token":  "old-claude-token",
+			"refresh_token": "old-claude-refresh",
+			"expired":       time.Now().Add(-time.Hour).Format(time.RFC3339),
+		},
+	}
+	h := &Handler{cfg: &config.Config{SDKConfig: config.SDKConfig{ProxyURL: "http://global-proxy.local:8080"}}}
+
+	if _, err := h.resolveTokenForAuth(context.Background(), auth); err != nil {
+		t.Fatalf("resolveTokenForAuth: %v", err)
+	}
+	if gotProxyURL != "http://auth-proxy.local:8080" {
+		t.Fatalf("expected Claude refresh to use auth proxy URL, got %q", gotProxyURL)
+	}
+}
+
+func TestResolveTokenForAuth_Claude_RefreshUsesProxyIDBeforeProxyURL(t *testing.T) {
+	refresher := &fakeClaudeOAuthRefresher{
+		tokenData: &claudeauth.ClaudeTokenData{
+			AccessToken: "new-claude-token",
+			Expire:      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+	var gotProxyURL string
+	originalFactory := newClaudeOAuthRefresher
+	newClaudeOAuthRefresher = func(cfg *config.Config) claudeOAuthRefresher {
+		if cfg != nil {
+			gotProxyURL = cfg.ProxyURL
+		}
+		return refresher
+	}
+	t.Cleanup(func() { newClaudeOAuthRefresher = originalFactory })
+
+	auth := &coreauth.Auth{
+		ID:       "claude-proxy-id.json",
+		FileName: "claude-proxy-id.json",
+		Provider: "claude",
+		ProxyID:  "premium-egress",
+		ProxyURL: "http://legacy-proxy.local:8080",
+		Metadata: map[string]any{
+			"type":          "claude",
+			"access_token":  "old-claude-token",
+			"refresh_token": "old-claude-refresh",
+			"expired":       time.Now().Add(-time.Hour).Format(time.RFC3339),
+		},
+	}
+	h := &Handler{cfg: &config.Config{
+		SDKConfig: config.SDKConfig{ProxyURL: "http://global-proxy.local:8080"},
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "premium-egress", URL: "http://pool-proxy.local:8080", Enabled: true},
+		},
+	}}
+
+	if _, err := h.resolveTokenForAuth(context.Background(), auth); err != nil {
+		t.Fatalf("resolveTokenForAuth: %v", err)
+	}
+	if gotProxyURL != "http://pool-proxy.local:8080" {
+		t.Fatalf("expected Claude refresh to use proxy-id URL, got %q", gotProxyURL)
+	}
+}
+
 func TestResolveTokenForAuth_Claude_SkipsRefreshWhenTokenValid(t *testing.T) {
 	refresher := &fakeClaudeOAuthRefresher{
 		tokenData: &claudeauth.ClaudeTokenData{AccessToken: "should-not-be-used"},


### PR DESCRIPTION
## Summary
- make Claude OAuth token refresh for quota checks use the same auth-level proxy resolution as /api-call
- prefer proxy-id entries over legacy per-auth proxy-url, preserving global proxy fallback
- add regression coverage for Claude quota refresh proxy selection

## Test Plan
- go test ./internal/api/handlers/management -run 'TestResolveTokenForAuth_Claude_RefreshUses'\n- go test ./internal/api/handlers/management\n- node --check assets/AuthFilesPage-8ofG866A.js\n- go test ./...