### PR TITLE
fix: preserve auth routing metadata for quota checks

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -268,6 +268,23 @@ func normalizeSubscriptionUnix(raw int64) time.Time {
 	return time.Unix(raw, 0).UTC()
 }
 
+func routingMetadataString(metadata map[string]any, keys ...string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if raw, ok := metadata[key].(string); ok {
+			if value := strings.TrimSpace(raw); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
 func subscriptionExpirationFromStart(startedAt time.Time, period string) time.Time {
 	if strings.EqualFold(period, "yearly") {
 		return startedAt.AddDate(1, 0, 0).UTC()
@@ -1041,6 +1058,9 @@ func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []
 	auth := &coreauth.Auth{
 		ID:         authID,
 		Provider:   provider,
+		Prefix:     routingMetadataString(metadata, "prefix"),
+		ProxyURL:   routingMetadataString(metadata, "proxy_url", "proxy-url", "proxyUrl"),
+		ProxyID:    routingMetadataString(metadata, "proxy_id", "proxy-id", "proxyId"),
 		FileName:   filepath.Base(path),
 		Label:      label,
 		Status:     coreauth.StatusActive,
@@ -1210,11 +1230,29 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		changed = true
 	}
 	if req.Prefix != nil {
-		targetAuth.Prefix = *req.Prefix
+		targetAuth.Prefix = strings.TrimSpace(*req.Prefix)
+		if targetAuth.Metadata == nil {
+			targetAuth.Metadata = make(map[string]any)
+		}
+		if targetAuth.Prefix == "" {
+			delete(targetAuth.Metadata, "prefix")
+		} else {
+			targetAuth.Metadata["prefix"] = targetAuth.Prefix
+		}
 		changed = true
 	}
 	if req.ProxyURL != nil {
-		targetAuth.ProxyURL = *req.ProxyURL
+		targetAuth.ProxyURL = strings.TrimSpace(*req.ProxyURL)
+		if targetAuth.Metadata == nil {
+			targetAuth.Metadata = make(map[string]any)
+		}
+		if targetAuth.ProxyURL == "" {
+			delete(targetAuth.Metadata, "proxy_url")
+			delete(targetAuth.Metadata, "proxy-url")
+			delete(targetAuth.Metadata, "proxyUrl")
+		} else {
+			targetAuth.Metadata["proxy_url"] = targetAuth.ProxyURL
+		}
 		changed = true
 	}
 	if req.ProxyID != nil {

--- a/internal/api/handlers/management/auth_files_upload_test.go
+++ b/internal/api/handlers/management/auth_files_upload_test.go
@@ -113,6 +113,45 @@ func TestUploadAuthFilePersistsUploadedJSONThroughStorePersister(t *testing.T) {
 	}
 }
 
+func TestRegisterAuthFromFileAppliesRoutingMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	h := &Handler{
+		cfg: &config.Config{
+			AuthDir: authDir,
+		},
+		authManager: manager,
+	}
+
+	fileName := "claude-pro.json"
+	absPath := filepath.Join(authDir, fileName)
+	data := []byte(`{"type":"claude","email":"pro@example.com","prefix":"team-a","proxy_url":"http://auth-proxy.local:8080","proxy_id":"premium-egress"}`)
+	if err := os.WriteFile(absPath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := h.registerAuthFromFile(context.Background(), absPath, data); err != nil {
+		t.Fatalf("registerAuthFromFile: %v", err)
+	}
+
+	auth, ok := manager.GetByID(fileName)
+	if !ok || auth == nil {
+		t.Fatalf("registered auth not found")
+	}
+	if auth.Prefix != "team-a" {
+		t.Fatalf("Prefix = %q, want team-a", auth.Prefix)
+	}
+	if auth.ProxyURL != "http://auth-proxy.local:8080" {
+		t.Fatalf("ProxyURL = %q, want auth proxy", auth.ProxyURL)
+	}
+	if auth.ProxyID != "premium-egress" {
+		t.Fatalf("ProxyID = %q, want premium-egress", auth.ProxyID)
+	}
+}
+
 func TestImportVertexCredentialRejectsOversizedMultipart(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -64,6 +64,7 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("auth filestore: create dir failed: %w", err)
 	}
+	syncRoutingMetadata(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -233,6 +234,9 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 	auth := &cliproxyauth.Auth{
 		ID:               id,
 		Provider:         provider,
+		Prefix:           metadataString(metadata, "prefix"),
+		ProxyURL:         metadataString(metadata, "proxy_url", "proxy-url", "proxyUrl"),
+		ProxyID:          metadataString(metadata, "proxy_id", "proxy-id", "proxyId"),
 		FileName:         id,
 		Label:            s.labelFor(metadata),
 		Status:           status,
@@ -248,6 +252,47 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		auth.Attributes["email"] = email
 	}
 	return auth, nil
+}
+
+func metadataString(metadata map[string]any, keys ...string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if raw, ok := metadata[key].(string); ok {
+			if value := strings.TrimSpace(raw); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func syncRoutingMetadata(auth *cliproxyauth.Auth) {
+	if auth == nil {
+		return
+	}
+	prefix := strings.TrimSpace(auth.Prefix)
+	proxyURL := strings.TrimSpace(auth.ProxyURL)
+	proxyID := strings.TrimSpace(auth.ProxyID)
+	if prefix == "" && proxyURL == "" && proxyID == "" {
+		return
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	if prefix != "" {
+		auth.Metadata["prefix"] = prefix
+	}
+	if proxyURL != "" {
+		auth.Metadata["proxy_url"] = proxyURL
+	}
+	if proxyID != "" {
+		auth.Metadata["proxy_id"] = proxyID
+	}
 }
 
 func (s *FileTokenStore) idFor(path, baseDir string) string {

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -1,6 +1,14 @@
 package auth
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
 
 func TestExtractAccessToken(t *testing.T) {
 	t.Parallel()
@@ -76,5 +84,75 @@ func TestExtractAccessToken(t *testing.T) {
 				t.Errorf("extractAccessToken() = %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestFileTokenStoreListAppliesRoutingMetadata(t *testing.T) {
+	dir := t.TempDir()
+	fileName := "claude-max.json"
+	data := []byte(`{"type":"claude","email":"max@example.com","prefix":"team-b","proxy_url":"http://auth-proxy.local:8080","proxy_id":"premium-egress"}`)
+	if err := os.WriteFile(filepath.Join(dir, fileName), data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	auth := auths[0]
+	if auth.Prefix != "team-b" {
+		t.Fatalf("Prefix = %q, want team-b", auth.Prefix)
+	}
+	if auth.ProxyURL != "http://auth-proxy.local:8080" {
+		t.Fatalf("ProxyURL = %q, want auth proxy", auth.ProxyURL)
+	}
+	if auth.ProxyID != "premium-egress" {
+		t.Fatalf("ProxyID = %q, want premium-egress", auth.ProxyID)
+	}
+}
+
+func TestFileTokenStoreSavePersistsRoutingMetadata(t *testing.T) {
+	dir := t.TempDir()
+	fileName := "claude-pro.json"
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+
+	_, err := store.Save(context.Background(), &cliproxyauth.Auth{
+		ID:       fileName,
+		FileName: fileName,
+		Provider: "claude",
+		Prefix:   "team-c",
+		ProxyURL: "http://auth-proxy.local:8080",
+		ProxyID:  "premium-egress",
+		Metadata: map[string]any{
+			"type":  "claude",
+			"email": "pro@example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, fileName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if metadata["prefix"] != "team-c" {
+		t.Fatalf("prefix = %#v, want team-c", metadata["prefix"])
+	}
+	if metadata["proxy_url"] != "http://auth-proxy.local:8080" {
+		t.Fatalf("proxy_url = %#v, want auth proxy", metadata["proxy_url"])
+	}
+	if metadata["proxy_id"] != "premium-egress" {
+		t.Fatalf("proxy_id = %#v, want premium-egress", metadata["proxy_id"])
 	}
 }


### PR DESCRIPTION
## Summary
- hydrate auth prefix, proxy_url, and proxy_id from OAuth auth JSON during upload/register and file-store loading
- persist runtime routing metadata back into auth JSON on save
- keep management field edits in sync with stored metadata so quota calls keep using auth-specific proxy settings after reimport/restart

## Tests
- go test ./internal/api/handlers/management
- go test ./sdk/auth
- node --check assets/AuthFilesPage-8ofG866A.js
- go test ./...

No production deployment or restart performed.