### PR TITLE
Fix Anthropic OAuth callback fallback

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1479,9 +1479,28 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	// Initialize Claude auth service
 	anthropicAuth := claude.NewClaudeAuth(h.cfg)
 
-	// Generate authorization URL (then override redirect_uri to reuse server port)
-	authURL, state, err := anthropicAuth.GenerateAuthURL(state, pkceCodes)
+	isWebUI := isWebUIRequest(c)
+	redirectURI := claude.RedirectURI
+	var forwarder *callbackForwarder
+	if isWebUI {
+		if targetURL, errTarget := h.managementCallbackURL("/anthropic/callback"); errTarget != nil {
+			log.WithError(errTarget).Warn("failed to compute anthropic callback target, falling back to Claude platform callback")
+			redirectURI = claude.PlatformRedirectURI
+		} else {
+			var errStart error
+			if forwarder, errStart = startCallbackForwarder(anthropicCallbackPort, "anthropic", targetURL); errStart != nil {
+				log.WithError(errStart).Warn("failed to start anthropic callback forwarder, falling back to Claude platform callback")
+				redirectURI = claude.PlatformRedirectURI
+			}
+		}
+	}
+
+	// Generate authorization URL after choosing the redirect URI; the same value must be used for token exchange.
+	authURL, state, err := anthropicAuth.GenerateAuthURLWithRedirectURI(state, pkceCodes, redirectURI)
 	if err != nil {
+		if forwarder != nil {
+			stopCallbackForwarderInstance(ctx, anthropicCallbackPort, forwarder)
+		}
 		log.Errorf("Failed to generate authorization URL: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
 		return
@@ -1489,25 +1508,8 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 
 	RegisterOAuthSession(state, "anthropic")
 
-	isWebUI := isWebUIRequest(c)
-	var forwarder *callbackForwarder
-	if isWebUI {
-		targetURL, errTarget := h.managementCallbackURL("/anthropic/callback")
-		if errTarget != nil {
-			log.WithError(errTarget).Error("failed to compute anthropic callback target")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
-			return
-		}
-		var errStart error
-		if forwarder, errStart = startCallbackForwarder(anthropicCallbackPort, "anthropic", targetURL); errStart != nil {
-			log.WithError(errStart).Error("failed to start anthropic callback forwarder")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
-			return
-		}
-	}
-
 	go func() {
-		if isWebUI {
+		if forwarder != nil {
 			defer stopCallbackForwarderInstance(ctx, anthropicCallbackPort, forwarder)
 		}
 
@@ -1563,7 +1565,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		code := strings.Split(rawCode, "#")[0]
 
 		// Exchange code for tokens using internal auth service
-		bundle, errExchange := anthropicAuth.ExchangeCodeForTokens(ctx, code, state, pkceCodes)
+		bundle, errExchange := anthropicAuth.ExchangeCodeForTokensWithRedirectURI(ctx, code, state, pkceCodes, redirectURI)
 		if errExchange != nil {
 			authErr := claude.NewAuthenticationError(claude.ErrCodeExchangeFailed, errExchange)
 			log.Errorf("Failed to exchange authorization code for tokens: %v", authErr)

--- a/internal/api/handlers/management/oauth_callback_forwarder_test.go
+++ b/internal/api/handlers/management/oauth_callback_forwarder_test.go
@@ -2,11 +2,18 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 )
 
 func TestStartCallbackForwarderOnAvailablePortFallsBackWhenPreferredBusy(t *testing.T) {
@@ -47,4 +54,52 @@ func TestStartCallbackForwarderOnAvailablePortFallsBackWhenPreferredBusy(t *test
 		_ = resp.Body.Close()
 		t.Fatalf("unexpected redirect location: %q", location)
 	}
+}
+
+func TestRequestAnthropicTokenFallsBackToPlatformCallbackWhenLocalPortBusy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	busy, err := net.Listen("tcp", "127.0.0.1:54545")
+	if err != nil {
+		t.Skipf("anthropic callback port already unavailable: %v", err)
+	}
+	defer func() { _ = busy.Close() }()
+
+	previousStore := oauthSessions
+	oauthSessions = newOAuthSessionStore(oauthCallbackWaitTimeout)
+	t.Cleanup(func() {
+		oauthSessions = previousStore
+	})
+
+	h := &Handler{
+		cfg: &config.Config{
+			AuthDir: t.TempDir(),
+			Port:    8317,
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "/anthropic-auth-url?is_webui=true", nil)
+	c.Request = req
+
+	h.RequestAnthropicToken(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload struct {
+		URL   string `json:"url"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload.State == "" {
+		t.Fatalf("expected state in response")
+	}
+	if !strings.Contains(payload.URL, url.QueryEscape(claude.PlatformRedirectURI)) {
+		t.Fatalf("auth URL should use platform callback fallback, got %s", payload.URL)
+	}
+	SetOAuthSessionError(payload.State, "test shutdown")
 }

--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -19,10 +19,12 @@ import (
 
 // OAuth configuration constants for Claude/Anthropic
 const (
-	AuthURL     = "https://claude.ai/oauth/authorize"
-	TokenURL    = "https://api.anthropic.com/v1/oauth/token"
-	ClientID    = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-	RedirectURI = "http://localhost:54545/callback"
+	AuthURL             = "https://claude.ai/oauth/authorize"
+	TokenURL            = "https://api.anthropic.com/v1/oauth/token"
+	ClientID            = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+	LocalRedirectURI    = "http://localhost:54545/callback"
+	PlatformRedirectURI = "https://platform.claude.com/oauth/code/callback"
+	RedirectURI         = LocalRedirectURI
 )
 
 // tokenResponse represents the response structure from Anthropic's OAuth token endpoint.
@@ -79,15 +81,21 @@ func NewClaudeAuth(cfg *config.Config) *ClaudeAuth {
 //   - string: The state parameter for verification
 //   - error: An error if PKCE codes are missing or URL generation fails
 func (o *ClaudeAuth) GenerateAuthURL(state string, pkceCodes *PKCECodes) (string, string, error) {
+	return o.GenerateAuthURLWithRedirectURI(state, pkceCodes, RedirectURI)
+}
+
+// GenerateAuthURLWithRedirectURI creates the OAuth authorization URL with a caller-selected redirect URI.
+func (o *ClaudeAuth) GenerateAuthURLWithRedirectURI(state string, pkceCodes *PKCECodes, redirectURI string) (string, string, error) {
 	if pkceCodes == nil {
 		return "", "", fmt.Errorf("PKCE codes are required")
 	}
+	redirectURI = normalizeRedirectURI(redirectURI)
 
 	params := url.Values{
 		"code":                  {"true"},
 		"client_id":             {ClientID},
 		"response_type":         {"code"},
-		"redirect_uri":          {RedirectURI},
+		"redirect_uri":          {redirectURI},
 		"scope":                 {"org:create_api_key user:profile user:inference"},
 		"code_challenge":        {pkceCodes.CodeChallenge},
 		"code_challenge_method": {"S256"},
@@ -130,9 +138,15 @@ func (c *ClaudeAuth) parseCodeAndState(code string) (parsedCode, parsedState str
 //   - *ClaudeAuthBundle: The complete authentication bundle with tokens
 //   - error: An error if token exchange fails
 func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state string, pkceCodes *PKCECodes) (*ClaudeAuthBundle, error) {
+	return o.ExchangeCodeForTokensWithRedirectURI(ctx, code, state, pkceCodes, RedirectURI)
+}
+
+// ExchangeCodeForTokensWithRedirectURI exchanges an authorization code using the redirect URI from the auth request.
+func (o *ClaudeAuth) ExchangeCodeForTokensWithRedirectURI(ctx context.Context, code, state string, pkceCodes *PKCECodes, redirectURI string) (*ClaudeAuthBundle, error) {
 	if pkceCodes == nil {
 		return nil, fmt.Errorf("PKCE codes are required for token exchange")
 	}
+	redirectURI = normalizeRedirectURI(redirectURI)
 	newCode, newState := o.parseCodeAndState(code)
 
 	// Prepare token exchange request
@@ -141,7 +155,7 @@ func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state stri
 		"state":         state,
 		"grant_type":    "authorization_code",
 		"client_id":     ClientID,
-		"redirect_uri":  RedirectURI,
+		"redirect_uri":  redirectURI,
 		"code_verifier": pkceCodes.CodeVerifier,
 	}
 
@@ -205,6 +219,14 @@ func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state stri
 	}
 
 	return bundle, nil
+}
+
+func normalizeRedirectURI(redirectURI string) string {
+	redirectURI = strings.TrimSpace(redirectURI)
+	if redirectURI == "" {
+		return RedirectURI
+	}
+	return redirectURI
 }
 
 // RefreshTokens refreshes the access token using the refresh token.

--- a/internal/auth/claude/anthropic_auth_test.go
+++ b/internal/auth/claude/anthropic_auth_test.go
@@ -1,0 +1,87 @@
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestGenerateAuthURLWithRedirectURIUsesProvidedRedirect(t *testing.T) {
+	auth := &ClaudeAuth{}
+	pkceCodes := &PKCECodes{
+		CodeVerifier:  "verifier",
+		CodeChallenge: "challenge",
+	}
+
+	authURL, state, err := auth.GenerateAuthURLWithRedirectURI("state-123", pkceCodes, PlatformRedirectURI)
+	if err != nil {
+		t.Fatalf("GenerateAuthURLWithRedirectURI returned error: %v", err)
+	}
+	if state != "state-123" {
+		t.Fatalf("state = %q, want %q", state, "state-123")
+	}
+
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+	if got := parsed.Query().Get("redirect_uri"); got != PlatformRedirectURI {
+		t.Fatalf("redirect_uri = %q, want %q", got, PlatformRedirectURI)
+	}
+}
+
+func TestExchangeCodeForTokensWithRedirectURIUsesProvidedRedirect(t *testing.T) {
+	var requestBody map[string]any
+	auth := &ClaudeAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.String() != TokenURL {
+					t.Fatalf("request URL = %q, want %q", req.URL.String(), TokenURL)
+				}
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("read request body: %v", err)
+				}
+				if err := json.Unmarshal(body, &requestBody); err != nil {
+					t.Fatalf("unmarshal request body: %v", err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body: io.NopCloser(strings.NewReader(`{
+						"access_token":"access-token",
+						"refresh_token":"refresh-token",
+						"token_type":"Bearer",
+						"expires_in":3600,
+						"account":{"email_address":"user@example.com"}
+					}`)),
+					Request: req,
+				}, nil
+			}),
+		},
+	}
+
+	bundle, err := auth.ExchangeCodeForTokensWithRedirectURI(context.Background(), "code-123", "state-123", &PKCECodes{
+		CodeVerifier:  "verifier",
+		CodeChallenge: "challenge",
+	}, PlatformRedirectURI)
+	if err != nil {
+		t.Fatalf("ExchangeCodeForTokensWithRedirectURI returned error: %v", err)
+	}
+	if bundle.TokenData.Email != "user@example.com" {
+		t.Fatalf("email = %q, want %q", bundle.TokenData.Email, "user@example.com")
+	}
+	if got := requestBody["redirect_uri"]; got != PlatformRedirectURI {
+		t.Fatalf("redirect_uri = %v, want %q", got, PlatformRedirectURI)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
## Summary
- add Claude OAuth redirect URI variants for local and platform callback flows
- fall back to Claude platform callback when the WebUI local callback forwarder cannot start
- keep token exchange using the same redirect_uri selected for authorization
- add regression tests for the busy Anthropic callback port and redirect URI propagation

## Tests
- go test ./internal/api/handlers/management -run 'TestRequestAnthropicTokenFallsBackToPlatformCallbackWhenLocalPortBusy|TestStartCallbackForwarderOnAvailablePortFallsBackWhenPreferredBusy' -count=1
- go test ./internal/auth/claude -count=1
- go test ./internal/api/handlers/management -count=1
- node --check assets/AuthFilesPage-8ofG866A.js
- go test ./... -count=1