### PR TITLE
fix: allow auth channel rename with alias conflicts

### DIFF
--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -496,6 +496,72 @@ func TestPatchAuthFileFieldsRejectsDuplicateOAuthChannelLabel(t *testing.T) {
 	}
 }
 
+func TestPatchAuthFileFieldsAllowsRenameWhenUnrelatedOAuthAliasesConflict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	for _, auth := range []*coreauth.Auth{
+		{
+			ID:       "oauth-alias-a",
+			FileName: "oauth-alias-a.json",
+			Provider: "codex",
+			Label:    "Team A",
+			Metadata: map[string]any{"email": "shared@example.com"},
+		},
+		{
+			ID:       "oauth-alias-b",
+			FileName: "oauth-alias-b.json",
+			Provider: "codex",
+			Label:    "Team B",
+			Metadata: map[string]any{"email": "shared@example.com"},
+		},
+		{
+			ID:       "oauth-auth-rename",
+			FileName: "oauth-auth-rename.json",
+			Provider: "claude",
+			Label:    "Original Channel",
+			Metadata: map[string]any{"email": "rename@example.com"},
+		},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register auth %s: %v", auth.ID, err)
+		}
+	}
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"name":  "oauth-auth-rename.json",
+		"label": "Renamed Channel",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/auth-files/fields", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchAuthFileFields(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("oauth-auth-rename")
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if updated.Label != "Renamed Channel" {
+		t.Fatalf("label = %q, want %q", updated.Label, "Renamed Channel")
+	}
+}
+
 func TestPatchAuthFileFieldsReturnsErrorWhenPersistenceFails(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/handlers/management/channel_names.go
+++ b/internal/api/handlers/management/channel_names.go
@@ -82,6 +82,10 @@ func uniqueChannelGroups(values []string) []string {
 }
 
 func addKnownChannel(known map[string]knownChannel, rawName, canonicalName, source string) error {
+	return addKnownChannelWithPolicy(known, rawName, canonicalName, source, true)
+}
+
+func addKnownChannelWithPolicy(known map[string]knownChannel, rawName, canonicalName, source string, failOnConflict bool) error {
 	name := strings.TrimSpace(rawName)
 	canonicalName = strings.TrimSpace(canonicalName)
 	if name == "" || canonicalName == "" {
@@ -89,6 +93,9 @@ func addKnownChannel(known map[string]knownChannel, rawName, canonicalName, sour
 	}
 	key := strings.ToLower(name)
 	if existing, exists := known[key]; exists && !strings.EqualFold(existing.Canonical, canonicalName) {
+		if !failOnConflict {
+			return nil
+		}
 		return fmt.Errorf("channel name %q is already used by %s", name, existing.Source)
 	}
 	known[key] = knownChannel{Canonical: canonicalName, Source: source}
@@ -96,25 +103,34 @@ func addKnownChannel(known map[string]knownChannel, rawName, canonicalName, sour
 }
 
 func collectKnownChannels(cfg *config.Config, auths []*coreauth.Auth, excludeAuthID string) (map[string]knownChannel, error) {
+	return collectKnownChannelsWithPolicy(cfg, auths, excludeAuthID, true)
+}
+
+func collectKnownChannelsForAuthRename(cfg *config.Config, auths []*coreauth.Auth, excludeAuthID string) map[string]knownChannel {
+	known, _ := collectKnownChannelsWithPolicy(cfg, auths, excludeAuthID, false)
+	return known
+}
+
+func collectKnownChannelsWithPolicy(cfg *config.Config, auths []*coreauth.Auth, excludeAuthID string, failOnConflict bool) (map[string]knownChannel, error) {
 	known := make(map[string]knownChannel)
 	if cfg != nil {
 		for _, entry := range cfg.GeminiKey {
-			if err := addKnownChannel(known, entry.Name, entry.Name, "Gemini API key config"); err != nil {
+			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "Gemini API key config", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
 		for _, entry := range cfg.ClaudeKey {
-			if err := addKnownChannel(known, entry.Name, entry.Name, "Claude API key config"); err != nil {
+			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "Claude API key config", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
 		for _, entry := range cfg.CodexKey {
-			if err := addKnownChannel(known, entry.Name, entry.Name, "Codex API key config"); err != nil {
+			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "Codex API key config", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
 		for _, entry := range cfg.OpenAICompatibility {
-			if err := addKnownChannel(known, entry.Name, entry.Name, "OpenAI compatibility config"); err != nil {
+			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "OpenAI compatibility config", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
@@ -133,7 +149,7 @@ func collectKnownChannels(cfg *config.Config, auths []*coreauth.Auth, excludeAut
 		}
 		canonical := auth.ChannelName()
 		for _, identifier := range auth.ChannelIdentifiers() {
-			if err := addKnownChannel(known, identifier, canonical, "OAuth auth file"); err != nil {
+			if err := addKnownChannelWithPolicy(known, identifier, canonical, "OAuth auth file", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
@@ -292,10 +308,7 @@ func (h *Handler) validateAuthChannelName(name, excludeAuthID string) (string, e
 	if h != nil && h.authManager != nil {
 		auths = h.authManager.List()
 	}
-	known, err := collectKnownChannels(h.cfg, auths, excludeAuthID)
-	if err != nil {
-		return "", err
-	}
+	known := collectKnownChannelsForAuthRename(h.cfg, auths, excludeAuthID)
 	key := strings.ToLower(trimmed)
 	if existing, exists := known[key]; exists {
 		return "", fmt.Errorf("channel name %q is already used by %s", trimmed, existing.Source)


### PR DESCRIPTION
## Summary
- allow auth-file channel rename validation to ignore unrelated pre-existing OAuth alias conflicts
- keep direct duplicate channel-name rejection intact
- add regression coverage for repeated auth channel rename when shared legacy email aliases exist

## Test Plan
- go test ./internal/api/handlers/management -run 'TestPatchAuthFileFields(AllowsRenameWhenUnrelatedOAuthAliasesConflict|RejectsDuplicateOAuthChannelLabel|UpdatesOAuthChannelLabel|RenamesRoutingChannelReferences)' -count=1\n- git diff --check\n- go test ./...