### PR TITLE
feat: persist provider credentials in sqlite

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -320,6 +320,9 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 func (h *Handler) persist(c *gin.Context) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if usage.ConfigStoreAvailable() {
+		usage.PersistRuntimeSettingsFromConfig(h.cfg)
+	}
 	// Preserve comments when writing
 	if err := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save config: %v", err)})

--- a/internal/api/handlers/management/runtime_settings_test.go
+++ b/internal/api/handlers/management/runtime_settings_test.go
@@ -18,7 +18,7 @@ func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
 	if err := os.WriteFile(configPath, []byte("identity-fingerprint:\n  codex:\n    enabled: false\nlogging-to-file: true\n"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	h := NewHandler(&config.Config{}, configPath, nil)
+	h := NewHandler(&config.Config{LoggingToFile: true}, configPath, nil)
 
 	rec := performModelsRequest(http.MethodPut, "/identity-fingerprint", []byte(`{
 		"codex": {
@@ -59,7 +59,7 @@ func TestPutOAuthModelAliasPersistsToSQLite(t *testing.T) {
 	if err := os.WriteFile(configPath, []byte("oauth-model-alias:\n  codex:\n    - name: old\n      alias: stale\nlogging-to-file: true\n"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	h := NewHandler(&config.Config{}, configPath, nil)
+	h := NewHandler(&config.Config{LoggingToFile: true}, configPath, nil)
 
 	rec := performModelsRequest(http.MethodPut, "/oauth-model-alias", []byte(`{
 		"codex": [
@@ -85,6 +85,53 @@ func TestPutOAuthModelAliasPersistsToSQLite(t *testing.T) {
 	}
 	if strings.Contains(string(data), "oauth-model-alias:") {
 		t.Fatalf("oauth-model-alias should be removed from YAML after DB write:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "logging-to-file: true") {
+		t.Fatalf("ordinary config should remain in YAML:\n%s", string(data))
+	}
+}
+
+func TestPutProviderCredentialsPersistToSQLite(t *testing.T) {
+	initManagementModelsTestDB(t)
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("codex-api-key:\n  - api-key: old-codex\n    base-url: https://old.example.com\nclaude-api-key:\n  - api-key: old-claude\n    base-url: https://old.example.com\nlogging-to-file: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	h := NewHandler(&config.Config{LoggingToFile: true}, configPath, nil)
+
+	codexRec := performModelsRequest(http.MethodPut, "/codex-api-key", []byte(`[
+		{"api-key": "sk-codex-db", "base-url": "https://codex.example.com"}
+	]`), h.PutCodexKeys)
+	if codexRec.Code != http.StatusOK {
+		t.Fatalf("PutCodexKeys status = %d body = %s", codexRec.Code, codexRec.Body.String())
+	}
+	claudeRec := performModelsRequest(http.MethodPut, "/claude-api-key", []byte(`[
+		{"api-key": "sk-claude-db", "name": "claude-db", "base-url": "https://claude.example.com"}
+	]`), h.PutClaudeKeys)
+	if claudeRec.Code != http.StatusOK {
+		t.Fatalf("PutClaudeKeys status = %d body = %s", claudeRec.Code, claudeRec.Body.String())
+	}
+
+	var stored config.Config
+	if !usage.ApplyStoredRuntimeSettings(&stored) {
+		t.Fatal("ApplyStoredRuntimeSettings returned false")
+	}
+	if len(stored.CodexKey) != 1 || stored.CodexKey[0].APIKey != "sk-codex-db" || stored.CodexKey[0].BaseURL != "https://codex.example.com" {
+		t.Fatalf("stored codex keys = %#v", stored.CodexKey)
+	}
+	if len(stored.ClaudeKey) != 1 || stored.ClaudeKey[0].APIKey != "sk-claude-db" || stored.ClaudeKey[0].Name != "claude-db" {
+		t.Fatalf("stored claude keys = %#v", stored.ClaudeKey)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	for _, forbidden := range []string{"codex-api-key:", "claude-api-key:"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("%s should be removed from YAML after DB write:\n%s", forbidden, string(data))
+		}
 	}
 	if !strings.Contains(string(data), "logging-to-file: true") {
 		t.Fatalf("ordinary config should remain in YAML:\n%s", string(data))

--- a/internal/usage/config_yaml_cleanup.go
+++ b/internal/usage/config_yaml_cleanup.go
@@ -22,6 +22,13 @@ var dbBackedConfigYAMLKeys = map[string]bool{
 	"api-key-entries":        true,
 	"routing":                true,
 	"proxy-pool":             true,
+	"gemini-api-key":         true,
+	"codex-api-key":          true,
+	"claude-api-key":         true,
+	"bedrock-api-key":        true,
+	"opencode-go-api-key":    true,
+	"openai-compatibility":   true,
+	"vertex-api-key":         true,
 	"claude-header-defaults": true,
 	"kimi-header-defaults":   true,
 	"identity-fingerprint":   true,
@@ -83,6 +90,13 @@ func cleanRoutingConfigFromYAML(configFilePath string) {
 
 func cleanRuntimeSettingsFromYAML(configFilePath string) {
 	cleanConfigKeysFromYAML(configFilePath, map[string]bool{
+		"gemini-api-key":         true,
+		"codex-api-key":          true,
+		"claude-api-key":         true,
+		"bedrock-api-key":        true,
+		"opencode-go-api-key":    true,
+		"openai-compatibility":   true,
+		"vertex-api-key":         true,
 		"claude-header-defaults": true,
 		"kimi-header-defaults":   true,
 		"identity-fingerprint":   true,

--- a/internal/usage/config_yaml_cleanup_test.go
+++ b/internal/usage/config_yaml_cleanup_test.go
@@ -108,20 +108,20 @@ func TestMigrateRoutingConfigFromConfigKeepsYAMLWhenDBUnavailable(t *testing.T) 
 
 func TestCleanDBBackedConfigFromYAMLCleansPersistedSections(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
-	content := []byte("port: 8318\napi-keys:\n  - sk-test\napi-key-entries:\n  - key: sk-entry\nrouting:\n  strategy: round-robin\nproxy-pool:\n  - id: hk\n    url: http://127.0.0.1:7890\nclaude-header-defaults:\n  user-agent: ClaudeCLI/1.0\nkimi-header-defaults:\n  user-agent: KimiCLI/1.24.0\nidentity-fingerprint:\n  codex:\n    enabled: true\noauth-excluded-models:\n  codex:\n    - gpt-4\noauth-model-alias:\n  codex:\n    - name: gpt-5\n      alias: codex-gpt5\npayload:\n  default:\n    - models:\n        - name: gpt-5\n      params:\n        temperature: 0.2\nlogging-to-file: true\n")
+	content := []byte("port: 8318\napi-keys:\n  - sk-test\napi-key-entries:\n  - key: sk-entry\nrouting:\n  strategy: round-robin\nproxy-pool:\n  - id: hk\n    url: http://127.0.0.1:7890\ngemini-api-key:\n  - api-key: sk-gemini\ncodex-api-key:\n  - api-key: sk-codex\n    base-url: https://codex.example.com\nclaude-api-key:\n  - api-key: sk-claude\n    base-url: https://claude.example.com\nbedrock-api-key:\n  - name: bedrock\nopencode-go-api-key:\n  - api-key: sk-opencode\nopenai-compatibility:\n  - name: compat\n    base-url: https://compat.example.com\nvertex-api-key:\n  - api-key: sk-vertex\n    base-url: https://vertex.example.com\nclaude-header-defaults:\n  user-agent: ClaudeCLI/1.0\nkimi-header-defaults:\n  user-agent: KimiCLI/1.24.0\nidentity-fingerprint:\n  codex:\n    enabled: true\noauth-excluded-models:\n  codex:\n    - gpt-4\noauth-model-alias:\n  codex:\n    - name: gpt-5\n      alias: codex-gpt5\npayload:\n  default:\n    - models:\n        - name: gpt-5\n      params:\n        temperature: 0.2\nlogging-to-file: true\n")
 	if err := os.WriteFile(configPath, content, 0o640); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
-	if removed := CleanDBBackedConfigFromYAML(configPath); removed != 10 {
-		t.Fatalf("CleanDBBackedConfigFromYAML removed %d sections, want 10", removed)
+	if removed := CleanDBBackedConfigFromYAML(configPath); removed != 17 {
+		t.Fatalf("CleanDBBackedConfigFromYAML removed %d sections, want 17", removed)
 	}
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}
-	for _, forbidden := range []string{"api-keys:", "api-key-entries:", "routing:", "proxy-pool:", "claude-header-defaults:", "kimi-header-defaults:", "identity-fingerprint:", "oauth-excluded-models:", "oauth-model-alias:", "payload:"} {
+	for _, forbidden := range []string{"api-keys:", "api-key-entries:", "routing:", "proxy-pool:", "gemini-api-key:", "codex-api-key:", "claude-api-key:", "bedrock-api-key:", "opencode-go-api-key:", "openai-compatibility:", "vertex-api-key:", "claude-header-defaults:", "kimi-header-defaults:", "identity-fingerprint:", "oauth-excluded-models:", "oauth-model-alias:", "payload:"} {
 		if strings.Contains(string(data), forbidden) {
 			t.Fatalf("%s should be removed from YAML:\n%s", forbidden, string(data))
 		}

--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -11,6 +11,13 @@ import (
 )
 
 const (
+	RuntimeSettingGeminiKeys           = "gemini-api-key"
+	RuntimeSettingCodexKeys            = "codex-api-key"
+	RuntimeSettingClaudeKeys           = "claude-api-key"
+	RuntimeSettingBedrockKeys          = "bedrock-api-key"
+	RuntimeSettingOpenCodeGoKeys       = "opencode-go-api-key"
+	RuntimeSettingOpenAICompatibility  = "openai-compatibility"
+	RuntimeSettingVertexCompatKeys     = "vertex-api-key"
 	RuntimeSettingClaudeHeaderDefaults = "claude-header-defaults"
 	RuntimeSettingKimiHeaderDefaults   = "kimi-header-defaults"
 	RuntimeSettingIdentityFingerprint  = "identity-fingerprint"
@@ -45,6 +52,160 @@ type runtimeSettingSpec struct {
 
 func runtimeSettingSpecs() []runtimeSettingSpec {
 	return []runtimeSettingSpec{
+		{
+			key: RuntimeSettingGeminiKeys,
+			meaningful: func(cfg *config.Config) bool {
+				return len(cfg.GeminiKey) > 0
+			},
+			value: func(cfg *config.Config) any {
+				holder := &config.Config{GeminiKey: append([]config.GeminiKey(nil), cfg.GeminiKey...)}
+				holder.SanitizeGeminiKeys()
+				return holder.GeminiKey
+			},
+			apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.GeminiKey
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("usage: decode %s: %v", RuntimeSettingGeminiKeys, err)
+					return false
+				}
+				holder := &config.Config{GeminiKey: value}
+				holder.SanitizeGeminiKeys()
+				cfg.GeminiKey = holder.GeminiKey
+				return true
+			},
+		},
+		{
+			key: RuntimeSettingCodexKeys,
+			meaningful: func(cfg *config.Config) bool {
+				return len(cfg.CodexKey) > 0
+			},
+			value: func(cfg *config.Config) any {
+				holder := &config.Config{CodexKey: append([]config.CodexKey(nil), cfg.CodexKey...)}
+				holder.SanitizeCodexKeys()
+				return holder.CodexKey
+			},
+			apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.CodexKey
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("usage: decode %s: %v", RuntimeSettingCodexKeys, err)
+					return false
+				}
+				holder := &config.Config{CodexKey: value}
+				holder.SanitizeCodexKeys()
+				cfg.CodexKey = holder.CodexKey
+				return true
+			},
+		},
+		{
+			key: RuntimeSettingClaudeKeys,
+			meaningful: func(cfg *config.Config) bool {
+				return len(cfg.ClaudeKey) > 0
+			},
+			value: func(cfg *config.Config) any {
+				holder := &config.Config{ClaudeKey: append([]config.ClaudeKey(nil), cfg.ClaudeKey...)}
+				holder.SanitizeClaudeKeys()
+				return holder.ClaudeKey
+			},
+			apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.ClaudeKey
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("usage: decode %s: %v", RuntimeSettingClaudeKeys, err)
+					return false
+				}
+				holder := &config.Config{ClaudeKey: value}
+				holder.SanitizeClaudeKeys()
+				cfg.ClaudeKey = holder.ClaudeKey
+				return true
+			},
+		},
+		{
+			key: RuntimeSettingBedrockKeys,
+			meaningful: func(cfg *config.Config) bool {
+				return len(cfg.BedrockKey) > 0
+			},
+			value: func(cfg *config.Config) any {
+				holder := &config.Config{BedrockKey: append([]config.BedrockKey(nil), cfg.BedrockKey...)}
+				holder.SanitizeBedrockKeys()
+				return holder.BedrockKey
+			},
+			apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.BedrockKey
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("usage: decode %s: %v", RuntimeSettingBedrockKeys, err)
+					return false
+				}
+				holder := &config.Config{BedrockKey: value}
+				holder.SanitizeBedrockKeys()
+				cfg.BedrockKey = holder.BedrockKey
+				return true
+			},
+		},
+		{
+			key: RuntimeSettingOpenCodeGoKeys,
+			meaningful: func(cfg *config.Config) bool {
+				return len(cfg.OpenCodeGoKey) > 0
+			},
+			value: func(cfg *config.Config) any {
+				holder := &config.Config{OpenCodeGoKey: append([]config.OpenCodeGoKey(nil), cfg.OpenCodeGoKey...)}
+				holder.SanitizeOpenCodeGoKeys()
+				return holder.OpenCodeGoKey
+			},
+			apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.OpenCodeGoKey
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("usage: decode %s: %v", RuntimeSettingOpenCodeGoKeys, err)
+					return false
+				}
+				holder := &config.Config{OpenCodeGoKey: value}
+				holder.SanitizeOpenCodeGoKeys()
+				cfg.OpenCodeGoKey = holder.OpenCodeGoKey
+				return true
+			},
+		},
+		{
+			key: RuntimeSettingOpenAICompatibility,
+			meaningful: func(cfg *config.Config) bool {
+				return len(cfg.OpenAICompatibility) > 0
+			},
+			value: func(cfg *config.Config) any {
+				holder := &config.Config{OpenAICompatibility: append([]config.OpenAICompatibility(nil), cfg.OpenAICompatibility...)}
+				holder.SanitizeOpenAICompatibility()
+				return holder.OpenAICompatibility
+			},
+			apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.OpenAICompatibility
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("usage: decode %s: %v", RuntimeSettingOpenAICompatibility, err)
+					return false
+				}
+				holder := &config.Config{OpenAICompatibility: value}
+				holder.SanitizeOpenAICompatibility()
+				cfg.OpenAICompatibility = holder.OpenAICompatibility
+				return true
+			},
+		},
+		{
+			key: RuntimeSettingVertexCompatKeys,
+			meaningful: func(cfg *config.Config) bool {
+				return len(cfg.VertexCompatAPIKey) > 0
+			},
+			value: func(cfg *config.Config) any {
+				holder := &config.Config{VertexCompatAPIKey: append([]config.VertexCompatKey(nil), cfg.VertexCompatAPIKey...)}
+				holder.SanitizeVertexCompatKeys()
+				return holder.VertexCompatAPIKey
+			},
+			apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.VertexCompatKey
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("usage: decode %s: %v", RuntimeSettingVertexCompatKeys, err)
+					return false
+				}
+				holder := &config.Config{VertexCompatAPIKey: value}
+				holder.SanitizeVertexCompatKeys()
+				cfg.VertexCompatAPIKey = holder.VertexCompatAPIKey
+				return true
+			},
+		},
 		{
 			key: RuntimeSettingClaudeHeaderDefaults,
 			meaningful: func(cfg *config.Config) bool {
@@ -263,6 +424,24 @@ func UpsertRuntimeSetting(key string, value any) error {
 		time.Now().UTC().Format(time.RFC3339),
 	)
 	return err
+}
+
+func PersistRuntimeSettingsFromConfig(cfg *config.Config) int {
+	if cfg == nil || !ConfigStoreAvailable() {
+		return 0
+	}
+	persisted := 0
+	for _, spec := range runtimeSettingSpecs() {
+		if !spec.meaningful(cfg) && !runtimeSettingExists(spec.key) {
+			continue
+		}
+		if err := UpsertRuntimeSetting(spec.key, spec.value(cfg)); err != nil {
+			log.Errorf("usage: persist runtime setting %s: %v", spec.key, err)
+			continue
+		}
+		persisted++
+	}
+	return persisted
 }
 
 func ApplyStoredRuntimeSettings(cfg *config.Config) bool {

--- a/internal/usage/runtime_settings_db_test.go
+++ b/internal/usage/runtime_settings_db_test.go
@@ -75,6 +75,63 @@ debug: true
 	assertMigrationBackupMode(t, configPath+".pre-runtime-settings-sqlite-migration", 0o600)
 }
 
+func TestRuntimeSettingsMigrationMovesProviderCredentialsIntoSQLite(t *testing.T) {
+	cleanup := setupConfigMigrationTestDB(t)
+	defer cleanup()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `port: 8318
+codex-api-key:
+  - api-key: sk-codex-test
+    base-url: https://codex.example.com
+claude-api-key:
+  - api-key: sk-claude-test
+    name: claude-primary
+    base-url: https://claude.example.com
+debug: true
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := &config.Config{
+		CodexKey: []config.CodexKey{
+			{APIKey: "sk-codex-test", BaseURL: "https://codex.example.com"},
+		},
+		ClaudeKey: []config.ClaudeKey{
+			{APIKey: "sk-claude-test", Name: "claude-primary", BaseURL: "https://claude.example.com"},
+		},
+	}
+
+	if migrated := MigrateRuntimeSettingsFromConfig(cfg, configPath); migrated != 2 {
+		t.Fatalf("MigrateRuntimeSettingsFromConfig = %d, want 2", migrated)
+	}
+
+	cfg.CodexKey = nil
+	cfg.ClaudeKey = nil
+	if !ApplyStoredRuntimeSettings(cfg) {
+		t.Fatal("ApplyStoredRuntimeSettings returned false")
+	}
+	if len(cfg.CodexKey) != 1 || cfg.CodexKey[0].APIKey != "sk-codex-test" || cfg.CodexKey[0].BaseURL != "https://codex.example.com" {
+		t.Fatalf("CodexKey after DB apply = %#v", cfg.CodexKey)
+	}
+	if len(cfg.ClaudeKey) != 1 || cfg.ClaudeKey[0].APIKey != "sk-claude-test" || cfg.ClaudeKey[0].Name != "claude-primary" {
+		t.Fatalf("ClaudeKey after DB apply = %#v", cfg.ClaudeKey)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	for _, forbidden := range []string{"codex-api-key:", "claude-api-key:"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("%s should be removed from YAML after migration:\n%s", forbidden, string(data))
+		}
+	}
+	if !strings.Contains(string(data), "port: 8318") || !strings.Contains(string(data), "debug: true") {
+		t.Fatalf("ordinary config should remain in YAML:\n%s", string(data))
+	}
+}
+
 func TestRuntimeSettingsSQLiteWinsOverStaleYAML(t *testing.T) {
 	cleanup := setupConfigMigrationTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- migrate provider credential config sections into runtime_settings SQLite storage
- make DB-backed cleanup remove provider key sections from config.yaml
- persist provider credential management writes before YAML cleanup

## Tests
- go test ./...
