### PR TITLE
fix: prevent oauth display rows from blocking provider saves

### DIFF
--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -459,7 +459,7 @@ func TestPatchAuthFileFieldsRejectsDuplicateOAuthChannelLabel(t *testing.T) {
 	h := &Handler{
 		cfg: &config.Config{
 			ClaudeKey: []config.ClaudeKey{
-				{Name: "Shared Channel"},
+				{Name: "Shared Channel", APIKey: "claude-api-key"},
 			},
 		},
 		authManager: manager,

--- a/internal/api/handlers/management/channel_names.go
+++ b/internal/api/handlers/management/channel_names.go
@@ -115,26 +115,41 @@ func collectKnownChannelsWithPolicy(cfg *config.Config, auths []*coreauth.Auth, 
 	known := make(map[string]knownChannel)
 	if cfg != nil {
 		for _, entry := range cfg.GeminiKey {
+			if strings.TrimSpace(entry.APIKey) == "" {
+				continue
+			}
 			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "Gemini API key config", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
 		for _, entry := range cfg.ClaudeKey {
+			if strings.TrimSpace(entry.APIKey) == "" {
+				continue
+			}
 			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "Claude API key config", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
 		for _, entry := range cfg.CodexKey {
+			if strings.TrimSpace(entry.APIKey) == "" {
+				continue
+			}
 			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "Codex API key config", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
 		for _, entry := range cfg.OpenCodeGoKey {
+			if strings.TrimSpace(entry.APIKey) == "" {
+				continue
+			}
 			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "OpenCode Go API key config", failOnConflict); err != nil {
 				return nil, err
 			}
 		}
 		for _, entry := range cfg.OpenAICompatibility {
+			if strings.TrimSpace(entry.BaseURL) == "" {
+				continue
+			}
 			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "OpenAI compatibility config", failOnConflict); err != nil {
 				return nil, err
 			}

--- a/internal/api/handlers/management/provider_oauth_channel_conflict_test.go
+++ b/internal/api/handlers/management/provider_oauth_channel_conflict_test.go
@@ -1,0 +1,86 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func newProviderConfigConflictHandler(t *testing.T, cfg *config.Config) *Handler {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	_, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "claude-oauth.json",
+		FileName: "claude-oauth.json",
+		Provider: "claude",
+		Label:    "claude-oauth",
+		Metadata: map[string]any{
+			"email": "yuan364299311@gmail.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register oauth auth: %v", err)
+	}
+	return &Handler{cfg: cfg, configFilePath: configPath, authManager: manager}
+}
+
+func TestPutClaudeKeysDropsOAuthDisplayRowsBeforeChannelValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newProviderConfigConflictHandler(t, &config.Config{})
+
+	body := []byte(`[
+		{"name":"yuan364299311@gmail.com","api-key":"","account_type":"oauth","runtime_only":true},
+		{"name":"opusclaw1","api-key":" claude-api-key "}
+	]`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/claude-api-key", bytes.NewReader(body))
+
+	h.PutClaudeKeys(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(h.cfg.ClaudeKey) != 1 {
+		t.Fatalf("ClaudeKey length = %d, want 1: %+v", len(h.cfg.ClaudeKey), h.cfg.ClaudeKey)
+	}
+	if h.cfg.ClaudeKey[0].Name != "opusclaw1" || h.cfg.ClaudeKey[0].APIKey != "claude-api-key" {
+		t.Fatalf("ClaudeKey[0] = %+v", h.cfg.ClaudeKey[0])
+	}
+}
+
+func TestPutOpenCodeGoKeysIgnoresStaleEmptyClaudeRowsDuringChannelValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newProviderConfigConflictHandler(t, &config.Config{
+		ClaudeKey: []config.ClaudeKey{
+			{Name: "yuan364299311@gmail.com"},
+		},
+	})
+
+	body := []byte(`[{"name":"opencode-go","api-key":" go-api-key "}]`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/opencode-go-api-key", bytes.NewReader(body))
+
+	h.PutOpenCodeGoKeys(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-api-key" {
+		t.Fatalf("OpenCodeGoKey = %+v", h.cfg.OpenCodeGoKey)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1062,19 +1062,28 @@ func (cfg *Config) SanitizeCodexKeys() {
 	cfg.CodexKey = out
 }
 
-// SanitizeClaudeKeys normalizes headers for Claude credentials.
+// SanitizeClaudeKeys removes empty Claude API-key rows and normalizes headers.
 func (cfg *Config) SanitizeClaudeKeys() {
 	if cfg == nil || len(cfg.ClaudeKey) == 0 {
 		return
 	}
+	out := make([]ClaudeKey, 0, len(cfg.ClaudeKey))
 	for i := range cfg.ClaudeKey {
-		entry := &cfg.ClaudeKey[i]
+		entry := cfg.ClaudeKey[i]
+		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		if entry.APIKey == "" {
+			continue
+		}
+		entry.Name = strings.TrimSpace(entry.Name)
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		out = append(out, entry)
 	}
+	cfg.ClaudeKey = out
 }
 
 // SanitizeOpenCodeGoKeys deduplicates and normalizes OpenCode Go credentials.


### PR DESCRIPTION
## Summary
- drop empty Claude API-key display rows during sanitization
- ignore inactive provider config rows during channel-name conflict checks
- add regression coverage for Claude and OpenCode Go saves with OAuth auth files present

## Tests
- go test ./...
