### PR TITLE
fix: tolerate duplicate oauth email aliases

### DIFF
--- a/internal/api/handlers/management/channel_names.go
+++ b/internal/api/handlers/management/channel_names.go
@@ -168,8 +168,28 @@ func collectKnownChannelsWithPolicy(cfg *config.Config, auths []*coreauth.Auth, 
 			continue
 		}
 		canonical := auth.ChannelName()
+		if err := addKnownChannelWithPolicy(known, canonical, canonical, "OAuth auth file", failOnConflict); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		if excludeAuthID != "" && strings.EqualFold(strings.TrimSpace(auth.ID), strings.TrimSpace(excludeAuthID)) {
+			continue
+		}
+		accountType, _ := auth.AccountInfo()
+		if !strings.EqualFold(accountType, "oauth") {
+			continue
+		}
+		canonical := strings.TrimSpace(auth.ChannelName())
 		for _, identifier := range auth.ChannelIdentifiers() {
-			if err := addKnownChannelWithPolicy(known, identifier, canonical, "OAuth auth file", failOnConflict); err != nil {
+			if strings.EqualFold(strings.TrimSpace(identifier), canonical) {
+				continue
+			}
+			if err := addKnownChannelWithPolicy(known, identifier, canonical, "OAuth auth file", false); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/api/handlers/management/provider_oauth_channel_conflict_test.go
+++ b/internal/api/handlers/management/provider_oauth_channel_conflict_test.go
@@ -84,3 +84,48 @@ func TestPutOpenCodeGoKeysIgnoresStaleEmptyClaudeRowsDuringChannelValidation(t *
 		t.Fatalf("OpenCodeGoKey = %+v", h.cfg.OpenCodeGoKey)
 	}
 }
+
+func TestPutOpenCodeGoKeysIgnoresDuplicateOAuthEmailAliases(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	for _, auth := range []*coreauth.Auth{
+		{
+			ID:       "codex-yuan.json",
+			FileName: "codex-yuan.json",
+			Provider: "codex",
+			Label:    "GptPlus4",
+			Metadata: map[string]any{
+				"email": "yuan364299311@gmail.com",
+			},
+		},
+		{
+			ID:       "gemini-yuan.json",
+			FileName: "gemini-yuan.json",
+			Provider: "gemini-cli",
+			Metadata: map[string]any{
+				"email": "yuan364299311@gmail.com",
+			},
+		},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register oauth auth %s: %v", auth.ID, err)
+		}
+	}
+	h := &Handler{cfg: &config.Config{}, configFilePath: configPath, authManager: manager}
+
+	body := []byte(`[{"name":"opencode-go","api-key":" go-api-key "}]`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/opencode-go-api-key", bytes.NewReader(body))
+
+	h.PutOpenCodeGoKeys(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- register OAuth channel labels separately from legacy email aliases
- skip conflicting secondary OAuth email aliases instead of blocking unrelated provider saves
- add regression coverage for the production shape where Codex and Gemini OAuth files share yuan364299311@gmail.com

## Investigation
- production clirelay2 is running /opt/clirelay2/clirelay2 on port 8318
- runtime settings only contain two real Claude API-key rows
- auth files include codex-yuan364299311@gmail.com-plus.json with label GptPlus4 and gemini-yuan364299311@gmail.com... with the same email

## Tests
- go test ./internal/api/handlers/management ./internal/config ./internal/watcher/synthesizer -count=1
- go test ./...
