### PR TITLE
fix: avoid auth outage from token count failures

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -737,19 +737,10 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		execReq.Model = m.applyOAuthModelAlias(auth, execReq.Model)
 		execReq.Model = m.applyAPIKeyModelAlias(auth, execReq.Model)
 		resp, errExec := executor.CountTokens(execCtx, auth, execReq, opts)
-		result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: errExec == nil}
 		if errExec != nil {
 			if errCtx := execCtx.Err(); errCtx != nil {
 				return cliproxyexecutor.Response{}, errCtx
 			}
-			result.Error = &Error{Message: errExec.Error()}
-			if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
-				result.Error.HTTPStatus = se.StatusCode()
-			}
-			if ra := retryAfterFromError(errExec); ra != nil {
-				result.RetryAfter = ra
-			}
-			m.MarkResult(execCtx, result)
 			if isRequestInvalidError(errExec) {
 				return cliproxyexecutor.Response{}, errExec
 			}
@@ -759,7 +750,6 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			lastErr = errExec
 			continue
 		}
-		m.MarkResult(execCtx, result)
 		return resp, nil
 	}
 }

--- a/sdk/cliproxy/auth/conductor_count_tokens_test.go
+++ b/sdk/cliproxy/auth/conductor_count_tokens_test.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+type countTokensFailureExecutor struct{}
+
+func (e *countTokensFailureExecutor) Identifier() string { return "claude" }
+
+func (e *countTokensFailureExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+}
+
+func (e *countTokensFailureExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{Code: "not_implemented", Message: "ExecuteStream not implemented"}
+}
+
+func (e *countTokensFailureExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *countTokensFailureExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{
+		Code:       "unsupported_count_tokens",
+		Message:    "count_tokens is not supported by this upstream",
+		HTTPStatus: http.StatusNotFound,
+	}
+}
+
+func (e *countTokensFailureExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{Code: "not_implemented", Message: "HttpRequest not implemented", HTTPStatus: http.StatusNotImplemented}
+}
+
+func TestExecuteCountFailureDoesNotPoisonMessageAvailability(t *testing.T) {
+	t.Parallel()
+
+	const (
+		authID = "count-token-failure-auth"
+		model  = "mimo-v2.5-pro"
+	)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model, Created: time.Now().Unix()}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(&countTokensFailureExecutor{})
+	if _, err := manager.Register(context.Background(), &Auth{
+		ID:       authID,
+		Provider: "claude",
+		Status:   StatusActive,
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, err := manager.ExecuteCount(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("expected count_tokens error")
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() after count_tokens failure error = %v", err)
+	}
+	if string(resp.Payload) != `{"ok":true}` {
+		t.Fatalf("Execute() payload = %q", string(resp.Payload))
+	}
+}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -54,11 +54,28 @@ type modelCooldownError struct {
 	provider string
 }
 
+type modelUnavailableError struct {
+	model    string
+	resetIn  time.Duration
+	provider string
+}
+
 func newModelCooldownError(model, provider string, resetIn time.Duration) *modelCooldownError {
 	if resetIn < 0 {
 		resetIn = 0
 	}
 	return &modelCooldownError{
+		model:    model,
+		provider: provider,
+		resetIn:  resetIn,
+	}
+}
+
+func newModelUnavailableError(model, provider string, resetIn time.Duration) *modelUnavailableError {
+	if resetIn < 0 {
+		resetIn = 0
+	}
+	return &modelUnavailableError{
 		model:    model,
 		provider: provider,
 		resetIn:  resetIn,
@@ -107,6 +124,58 @@ func (e *modelCooldownError) StatusCode() int {
 }
 
 func (e *modelCooldownError) Headers() http.Header {
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	resetSeconds := int(math.Ceil(e.resetIn.Seconds()))
+	if resetSeconds < 0 {
+		resetSeconds = 0
+	}
+	headers.Set("Retry-After", strconv.Itoa(resetSeconds))
+	return headers
+}
+
+func (e *modelUnavailableError) Error() string {
+	modelName := e.model
+	if modelName == "" {
+		modelName = "requested model"
+	}
+	message := fmt.Sprintf("All credentials for model %s are temporarily unavailable", modelName)
+	if e.provider != "" {
+		message = fmt.Sprintf("%s via provider %s", message, e.provider)
+	}
+	resetSeconds := int(math.Ceil(e.resetIn.Seconds()))
+	if resetSeconds < 0 {
+		resetSeconds = 0
+	}
+	displayDuration := e.resetIn
+	if displayDuration > 0 && displayDuration < time.Second {
+		displayDuration = time.Second
+	} else {
+		displayDuration = displayDuration.Round(time.Second)
+	}
+	errorBody := map[string]any{
+		"code":          "model_unavailable",
+		"message":       message,
+		"model":         e.model,
+		"reset_time":    displayDuration.String(),
+		"reset_seconds": resetSeconds,
+	}
+	if e.provider != "" {
+		errorBody["provider"] = e.provider
+	}
+	payload := map[string]any{"error": errorBody}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Sprintf(`{"error":{"code":"model_unavailable","message":"%s"}}`, message)
+	}
+	return string(data)
+}
+
+func (e *modelUnavailableError) StatusCode() int {
+	return http.StatusServiceUnavailable
+}
+
+func (e *modelUnavailableError) Headers() http.Header {
 	headers := make(http.Header)
 	headers.Set("Content-Type", "application/json")
 	resetSeconds := int(math.Ceil(e.resetIn.Seconds()))
@@ -209,7 +278,7 @@ func preferCodexWebsocketAuths(ctx context.Context, provider string, available [
 	return available
 }
 
-func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount int, earliest time.Time) {
+func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount int, cooldownEarliest time.Time, temporaryCount int, temporaryEarliest time.Time) {
 	available = make(map[int][]*Auth)
 	for i := 0; i < len(auths); i++ {
 		candidate := auths[i]
@@ -221,12 +290,20 @@ func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (ava
 		}
 		if reason == blockReasonCooldown {
 			cooldownCount++
-			if !next.IsZero() && (earliest.IsZero() || next.Before(earliest)) {
-				earliest = next
+			if !next.IsZero() && (cooldownEarliest.IsZero() || next.Before(cooldownEarliest)) {
+				cooldownEarliest = next
+			}
+		}
+		if reason == blockReasonCooldown || reason == blockReasonOther {
+			if !next.IsZero() {
+				temporaryCount++
+				if temporaryEarliest.IsZero() || next.Before(temporaryEarliest) {
+					temporaryEarliest = next
+				}
 			}
 		}
 	}
-	return available, cooldownCount, earliest
+	return available, cooldownCount, cooldownEarliest, temporaryCount, temporaryEarliest
 }
 
 func routeGroupSelectionScope(meta map[string]any) string {
@@ -318,7 +395,7 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time, inc
 		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
 	}
 
-	availableByPriority, cooldownCount, earliest := collectAvailableByPriority(auths, model, now)
+	availableByPriority, cooldownCount, earliest, temporaryCount, temporaryEarliest := collectAvailableByPriority(auths, model, now)
 	if len(availableByPriority) == 0 {
 		if cooldownCount == len(auths) && !earliest.IsZero() {
 			providerForError := provider
@@ -330,6 +407,17 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time, inc
 				resetIn = 0
 			}
 			return nil, newModelCooldownError(model, providerForError, resetIn)
+		}
+		if temporaryCount == len(auths) && !temporaryEarliest.IsZero() {
+			providerForError := provider
+			if providerForError == "mixed" {
+				providerForError = ""
+			}
+			resetIn := temporaryEarliest.Sub(now)
+			if resetIn < 0 {
+				resetIn = 0
+			}
+			return nil, newModelUnavailableError(model, providerForError, resetIn)
 		}
 		return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
 	}

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -451,6 +452,53 @@ func TestSelectorPick_AllCooldownReturnsModelCooldownError(t *testing.T) {
 			t.Fatalf("Error().error.provider = %q, want %q", got, "gemini")
 		}
 	})
+}
+
+func TestSelectorPick_AllTemporaryFailuresReturnsModelUnavailableError(t *testing.T) {
+	t.Parallel()
+
+	model := "test-model"
+	now := time.Now()
+	next := now.Add(60 * time.Second)
+	auths := []*Auth{
+		{
+			ID: "a",
+			ModelStates: map[string]*ModelState{
+				model: {
+					Status:         StatusError,
+					Unavailable:    true,
+					NextRetryAfter: next,
+				},
+			},
+		},
+		{
+			ID: "b",
+			ModelStates: map[string]*ModelState{
+				model: {
+					Status:         StatusError,
+					Unavailable:    true,
+					NextRetryAfter: next,
+				},
+			},
+		},
+	}
+
+	selector := &FillFirstSelector{}
+	_, err := selector.Pick(context.Background(), "claude", model, cliproxyexecutor.Options{}, auths)
+	if err == nil {
+		t.Fatal("Pick() error = nil")
+	}
+
+	statusErr, ok := err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("Pick() error = %T, want status error", err)
+	}
+	if got := statusErr.StatusCode(); got != http.StatusServiceUnavailable {
+		t.Fatalf("StatusCode() = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+	if strings.Contains(err.Error(), "auth_unavailable") {
+		t.Fatalf("Error() = %q, should not report auth_unavailable", err.Error())
+	}
 }
 
 func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsNotBlocked(t *testing.T) {


### PR DESCRIPTION
## Summary
- stop count_tokens failures from marking the generation model unavailable
- return a 503 model_unavailable response for temporary all-auth cooldowns instead of a misleading auth_unavailable 500
- add regression tests for issue #75 style failures

## Tests
- go test ./sdk/cliproxy/auth
- go test ./...

Fixes #75