### PR TITLE
fix: add default antigravity oauth client

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,8 +3,8 @@
 host: ""
 
 # OAuth client credentials for provider login flows.
-# Gemini CLI / Code Assist OAuth uses the official Gemini CLI OAuth client by default.
-# Set Gemini credentials only when you intentionally want to override that client.
+# Gemini CLI / Code Assist and Antigravity OAuth use their official OAuth clients by default.
+# Set credentials only when you intentionally want to override those clients.
 # You can set overrides either in config.yaml or via environment variables:
 #   - Gemini:      CLIRELAY_GEMINI_OAUTH_CLIENT_ID / CLIRELAY_GEMINI_OAUTH_CLIENT_SECRET
 #   - Antigravity: CLIRELAY_ANTIGRAVITY_OAUTH_CLIENT_ID / CLIRELAY_ANTIGRAVITY_OAUTH_CLIENT_SECRET

--- a/internal/auth/antigravity/auth_test.go
+++ b/internal/auth/antigravity/auth_test.go
@@ -1,0 +1,31 @@
+package antigravity
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestBuildAuthURLUsesDefaultAntigravityClient(t *testing.T) {
+	t.Setenv(config.EnvAntigravityOAuthClientID, "")
+	t.Setenv(config.EnvAntigravityOAuthClientSecret, "")
+
+	auth := NewAntigravityAuth(&config.Config{}, nil)
+
+	authURL := auth.BuildAuthURL("state-value", "http://localhost:51121/oauth-callback")
+	if authURL == "" {
+		t.Fatal("authURL is empty, want URL with default Antigravity client")
+	}
+
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse authURL: %v", err)
+	}
+	if got := parsed.Query().Get("client_id"); got != config.AntigravityOAuthClientID {
+		t.Fatalf("client_id = %q, want default Antigravity client", got)
+	}
+	if got := parsed.Query().Get("state"); got != "state-value" {
+		t.Fatalf("state = %q, want state-value", got)
+	}
+}

--- a/internal/config/oauth_clients.go
+++ b/internal/config/oauth_clients.go
@@ -14,6 +14,11 @@ const (
 	GeminiCLIOAuthClientID     = "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
 	GeminiCLIOAuthClientSecret = "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"
 
+	// AntigravityOAuthClientID and AntigravityOAuthClientSecret are the OAuth
+	// client credentials used by Antigravity for Google Code Assist login.
+	AntigravityOAuthClientID     = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+	AntigravityOAuthClientSecret = "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"
+
 	EnvGeminiOAuthClientID     = "CLIRELAY_GEMINI_OAUTH_CLIENT_ID"
 	EnvGeminiOAuthClientSecret = "CLIRELAY_GEMINI_OAUTH_CLIENT_SECRET"
 
@@ -69,6 +74,14 @@ func (cfg *Config) OAuthClientCredentials(kind string) (clientID, clientSecret s
 		}
 		if clientSecret == "" && clientID == GeminiCLIOAuthClientID {
 			clientSecret = GeminiCLIOAuthClientSecret
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(kind), OAuthClientAntigravity) {
+		if clientID == "" {
+			clientID = AntigravityOAuthClientID
+		}
+		if clientSecret == "" && clientID == AntigravityOAuthClientID {
+			clientSecret = AntigravityOAuthClientSecret
 		}
 	}
 

--- a/internal/config/oauth_clients_test.go
+++ b/internal/config/oauth_clients_test.go
@@ -41,7 +41,7 @@ func TestGeminiOAuthClientCredentialsKeepsExplicitConfig(t *testing.T) {
 	}
 }
 
-func TestAntigravityOAuthClientCredentialsDoNotUseGeminiCLIDefault(t *testing.T) {
+func TestAntigravityOAuthClientCredentialsDefaultsToAntigravityClient(t *testing.T) {
 	t.Setenv(EnvAntigravityOAuthClientID, "")
 	t.Setenv(EnvAntigravityOAuthClientSecret, "")
 
@@ -49,10 +49,10 @@ func TestAntigravityOAuthClientCredentialsDoNotUseGeminiCLIDefault(t *testing.T)
 
 	clientID, clientSecret := cfg.OAuthClientCredentials(OAuthClientAntigravity)
 
-	if clientID != "" {
-		t.Fatalf("clientID = %q, want empty antigravity client ID", clientID)
+	if clientID != AntigravityOAuthClientID {
+		t.Fatalf("clientID = %q, want official Antigravity OAuth client", clientID)
 	}
-	if clientSecret != "" {
-		t.Fatalf("clientSecret = %q, want empty antigravity client secret", clientSecret)
+	if clientSecret != AntigravityOAuthClientSecret {
+		t.Fatalf("clientSecret = %q, want official Antigravity OAuth client secret", clientSecret)
 	}
 }


### PR DESCRIPTION
## Summary
- add built-in Antigravity OAuth client credentials as the default for provider login flows
- keep config/env overrides for Antigravity credentials
- add regression coverage for config resolution and Antigravity auth URL generation

## Test Plan
- go test ./internal/config
- go test ./internal/auth/antigravity
- go test ./internal/api/handlers/management
- go test ./...