### PR TITLE
fix: fallback antigravity webui oauth callback port

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2066,17 +2066,9 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 		return
 	}
 
-	redirectURI := fmt.Sprintf("http://localhost:%d/oauth-callback", antigravity.CallbackPort)
-	authURL := authSvc.BuildAuthURL(state, redirectURI)
-	if strings.TrimSpace(authURL) == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "antigravity oauth client-id not configured"})
-		return
-	}
-
-	RegisterOAuthSession(state, "antigravity")
-
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
+	callbackPort := antigravity.CallbackPort
 	if isWebUI {
 		targetURL, errTarget := h.managementCallbackURL("/antigravity/callback")
 		if errTarget != nil {
@@ -2085,16 +2077,28 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			return
 		}
 		var errStart error
-		if forwarder, errStart = startCallbackForwarder(antigravity.CallbackPort, "antigravity", targetURL); errStart != nil {
+		if forwarder, callbackPort, errStart = startCallbackForwarderOnAvailablePort(antigravity.CallbackPort, "antigravity", targetURL); errStart != nil {
 			log.WithError(errStart).Error("failed to start antigravity callback forwarder")
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
 			return
 		}
 	}
 
+	redirectURI := fmt.Sprintf("http://localhost:%d/oauth-callback", callbackPort)
+	authURL := authSvc.BuildAuthURL(state, redirectURI)
+	if strings.TrimSpace(authURL) == "" {
+		if isWebUI {
+			stopCallbackForwarderInstance(ctx, callbackPort, forwarder)
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": "antigravity oauth client-id not configured"})
+		return
+	}
+
+	RegisterOAuthSession(state, "antigravity")
+
 	go func() {
 		if isWebUI {
-			defer stopCallbackForwarderInstance(ctx, antigravity.CallbackPort, forwarder)
+			defer stopCallbackForwarderInstance(ctx, callbackPort, forwarder)
 		}
 
 		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-antigravity-%s.oauth", state))

--- a/internal/api/handlers/management/oauth_callback_forwarder_test.go
+++ b/internal/api/handlers/management/oauth_callback_forwarder_test.go
@@ -120,3 +120,70 @@ func TestRequestAnthropicTokenUsesAvailableLocalCallbackWhenPreferredPortBusy(t 
 	}
 	SetOAuthSessionError(payload.State, "test shutdown")
 }
+
+func TestRequestAntigravityTokenUsesAvailableLocalCallbackWhenPreferredPortBusy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	busy, err := net.Listen("tcp", "127.0.0.1:51121")
+	if err != nil {
+		t.Skipf("antigravity callback port already unavailable: %v", err)
+	}
+	defer func() { _ = busy.Close() }()
+
+	previousStore := oauthSessions
+	oauthSessions = newOAuthSessionStore(oauthCallbackWaitTimeout)
+	t.Cleanup(func() {
+		oauthSessions = previousStore
+	})
+
+	h := &Handler{
+		cfg: &config.Config{
+			AuthDir: t.TempDir(),
+			Port:    8317,
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "/antigravity-auth-url?is_webui=true", nil)
+	c.Request = req
+
+	h.RequestAntigravityToken(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload struct {
+		URL   string `json:"url"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload.State == "" {
+		t.Fatalf("expected state in response")
+	}
+	authURL, err := url.Parse(payload.URL)
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+	redirectURI := authURL.Query().Get("redirect_uri")
+	if strings.TrimSpace(redirectURI) == "" {
+		t.Fatalf("auth URL missing redirect_uri: %s", payload.URL)
+	}
+	callbackURL, err := url.Parse(redirectURI)
+	if err != nil {
+		t.Fatalf("parse redirect_uri: %v", err)
+	}
+	if callbackURL.Scheme != "http" || callbackURL.Hostname() != "localhost" || callbackURL.Path != "/oauth-callback" {
+		t.Fatalf("redirect_uri = %q, want local antigravity callback URL", redirectURI)
+	}
+	if callbackURL.Port() == "51121" {
+		t.Fatalf("redirect_uri should use a free callback port when 51121 is busy, got %q", redirectURI)
+	}
+	if callbackURL.Port() == "" {
+		t.Fatalf("redirect_uri missing callback port: %q", redirectURI)
+	}
+
+	SetOAuthSessionError(payload.State, "test shutdown")
+}


### PR DESCRIPTION
## Summary
- let Antigravity WebUI OAuth use an available localhost callback port when 51121 is busy
- build the Antigravity redirect_uri from the actual callback forwarder port
- add a regression test for the busy 51121 production case

## Tests
- go test ./internal/api/handlers/management -run TestRequestAntigravityTokenUsesAvailableLocalCallbackWhenPreferredPortBusy -count=1
- go test ./internal/api/handlers/management
- go test ./internal/auth/antigravity ./internal/config
- go test ./...