### PR TITLE
fix: keep refreshing tokens for disabled auths

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2176,7 +2176,7 @@ func (m *Manager) snapshotAuths() []*Auth {
 }
 
 func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
-	if a == nil || a.Disabled {
+	if a == nil {
 		return false
 	}
 	if !a.NextRefreshAfter.IsZero() && now.Before(a.NextRefreshAfter) {
@@ -2384,7 +2384,7 @@ func (m *Manager) markRefreshPending(id string, now time.Time) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	auth, ok := m.auths[id]
-	if !ok || auth == nil || auth.Disabled {
+	if !ok || auth == nil {
 		return false
 	}
 	if !auth.NextRefreshAfter.IsZero() && now.Before(auth.NextRefreshAfter) {


### PR DESCRIPTION
## Summary

- Disabled auths should not be used for API requests, but their tokens still need periodic refresh so they remain valid when re-enabled
- Fix removes `a.Disabled` check from `shouldRefresh()` and `markRefreshPending()` in the auth manager
- Auth selection for requests (candidate.Disabled) is unchanged — disabled auths still won't be used for API calls

## Changes

- `sdk/cliproxy/auth/conductor.go`: 2 lines changed (removed disabled checks from refresh logic)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./sdk/cliproxy/auth/...` passes
- [x] `go vet ./sdk/cliproxy/auth/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)