### PR TITLE
feat: add claude oauth identity fingerprint

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -25,10 +25,12 @@ func (h *Handler) GetIdentityFingerprint(c *gin.Context) {
 	h.mu.Unlock()
 
 	current.Codex = config.NormalizeCodexIdentityFingerprint(current.Codex)
+	current.Claude = config.NormalizeClaudeIdentityFingerprint(current.Claude)
 	c.JSON(http.StatusOK, identityFingerprintResponse{
 		IdentityFingerprint: current,
 		Defaults: config.IdentityFingerprintConfig{
-			Codex: config.DefaultCodexIdentityFingerprint(),
+			Codex:  config.DefaultCodexIdentityFingerprint(),
+			Claude: config.DefaultClaudeIdentityFingerprint(),
 		},
 	})
 }
@@ -41,12 +43,20 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 	}
 
 	body.Codex = config.NormalizeCodexIdentityFingerprint(body.Codex)
+	body.Claude = config.NormalizeClaudeIdentityFingerprint(body.Claude)
 	if err := validateCodexIdentityFingerprint(body.Codex); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := validateClaudeIdentityFingerprint(body.Claude); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	if body.Codex.Enabled && body.Codex.SessionMode == "fixed" && strings.TrimSpace(body.Codex.SessionID) == "" {
 		body.Codex.SessionID = uuid.NewString()
+	}
+	if body.Claude.Enabled && body.Claude.SessionMode == "fixed" && strings.TrimSpace(body.Claude.SessionID) == "" {
+		body.Claude.SessionID = uuid.NewString()
 	}
 
 	h.mu.Lock()
@@ -84,6 +94,33 @@ func validateCodexIdentityFingerprint(fp config.CodexIdentityFingerprintConfig) 
 	return nil
 }
 
+func validateClaudeIdentityFingerprint(fp config.ClaudeIdentityFingerprintConfig) error {
+	if containsHeaderLineBreak(fp.UserAgent) || containsHeaderLineBreak(fp.CLIVersion) ||
+		containsHeaderLineBreak(fp.Entrypoint) || containsHeaderLineBreak(fp.AnthropicBeta) ||
+		containsHeaderLineBreak(fp.StainlessPackageVersion) || containsHeaderLineBreak(fp.StainlessRuntimeVersion) ||
+		containsHeaderLineBreak(fp.StainlessTimeout) || containsHeaderLineBreak(fp.SessionID) ||
+		containsHeaderLineBreak(fp.DeviceID) {
+		return fmt.Errorf("identity fingerprint fields must not contain line breaks")
+	}
+	for key, value := range fp.CustomHeaders {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return fmt.Errorf("custom header name cannot be empty")
+		}
+		if !isHTTPHeaderToken(key) {
+			return fmt.Errorf("invalid custom header name: %s", key)
+		}
+		if isIdentityFingerprintBlockedHeader(key) || isClaudeIdentityFingerprintBlockedHeader(key) {
+			return fmt.Errorf("custom header %s is managed by the system", key)
+		}
+		if containsHeaderLineBreak(value) {
+			return fmt.Errorf("custom header %s must not contain line breaks", key)
+		}
+	}
+	return nil
+}
+
 func containsHeaderLineBreak(value string) bool {
 	return strings.ContainsAny(value, "\r\n")
 }
@@ -92,6 +129,20 @@ func isIdentityFingerprintBlockedHeader(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
 	case "authorization", "content-type", "accept", "connection", "chatgpt-account-id",
 		"user-agent", "version", "session_id", "session-id", "originator", "openai-beta":
+		return true
+	default:
+		return false
+	}
+}
+
+func isClaudeIdentityFingerprintBlockedHeader(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	if strings.HasPrefix(key, "x-stainless-") {
+		return true
+	}
+	switch key {
+	case "x-api-key", "anthropic-beta", "anthropic-version", "anthropic-dangerous-direct-browser-access",
+		"x-app", "x-client-request-id", "x-claude-code-session-id":
 		return true
 	default:
 		return false

--- a/internal/api/handlers/management/runtime_settings_test.go
+++ b/internal/api/handlers/management/runtime_settings_test.go
@@ -26,6 +26,12 @@ func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
 			"user-agent": "codex_cli_rs/0.125.0",
 			"originator": "codex_cli_rs",
 			"session-mode": "per-request"
+		},
+		"claude": {
+			"enabled": true,
+			"cli-version": "2.1.88",
+			"entrypoint": "cli",
+			"session-mode": "server-stable"
 		}
 	}`), h.PutIdentityFingerprint)
 	if rec.Code != http.StatusOK {
@@ -38,6 +44,10 @@ func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
 	}
 	if !stored.IdentityFingerprint.Codex.Enabled || stored.IdentityFingerprint.Codex.UserAgent != "codex_cli_rs/0.125.0" {
 		t.Fatalf("stored identity fingerprint = %#v", stored.IdentityFingerprint.Codex)
+	}
+	if !stored.IdentityFingerprint.Claude.Enabled || stored.IdentityFingerprint.Claude.UserAgent != "claude-cli/2.1.88 (external, cli)" ||
+		stored.IdentityFingerprint.Claude.SessionMode != "server-stable" {
+		t.Fatalf("stored claude identity fingerprint = %#v", stored.IdentityFingerprint.Claude)
 	}
 
 	data, err := os.ReadFile(configPath)

--- a/internal/auth/claude/anthropic.go
+++ b/internal/auth/claude/anthropic.go
@@ -17,6 +17,8 @@ type ClaudeTokenData struct {
 	RefreshToken string `json:"refresh_token"`
 	// Email is the Anthropic account email
 	Email string `json:"email"`
+	// AccountUUID is the Anthropic OAuth account UUID returned by the token endpoint.
+	AccountUUID string `json:"account_uuid"`
 	// Expire is the timestamp of the token expire
 	Expire string `json:"expired"`
 }

--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -209,6 +209,7 @@ func (o *ClaudeAuth) ExchangeCodeForTokensWithRedirectURI(ctx context.Context, c
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
 		Email:        tokenResp.Account.EmailAddress,
+		AccountUUID:  tokenResp.Account.UUID,
 		Expire:       time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339),
 	}
 
@@ -293,6 +294,7 @@ func (o *ClaudeAuth) RefreshTokens(ctx context.Context, refreshToken string) (*C
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
 		Email:        tokenResp.Account.EmailAddress,
+		AccountUUID:  tokenResp.Account.UUID,
 		Expire:       time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339),
 	}, nil
 }
@@ -312,6 +314,7 @@ func (o *ClaudeAuth) CreateTokenStorage(bundle *ClaudeAuthBundle) *ClaudeTokenSt
 		RefreshToken: bundle.TokenData.RefreshToken,
 		LastRefresh:  bundle.LastRefresh,
 		Email:        bundle.TokenData.Email,
+		AccountUUID:  bundle.TokenData.AccountUUID,
 		Expire:       bundle.TokenData.Expire,
 	}
 

--- a/internal/auth/claude/anthropic_auth_test.go
+++ b/internal/auth/claude/anthropic_auth_test.go
@@ -57,7 +57,7 @@ func TestExchangeCodeForTokensWithRedirectURIUsesProvidedRedirect(t *testing.T) 
 						"refresh_token":"refresh-token",
 						"token_type":"Bearer",
 						"expires_in":3600,
-						"account":{"email_address":"user@example.com"}
+						"account":{"uuid":"account-uuid-123","email_address":"user@example.com"}
 					}`)),
 					Request: req,
 				}, nil
@@ -74,6 +74,9 @@ func TestExchangeCodeForTokensWithRedirectURIUsesProvidedRedirect(t *testing.T) 
 	}
 	if bundle.TokenData.Email != "user@example.com" {
 		t.Fatalf("email = %q, want %q", bundle.TokenData.Email, "user@example.com")
+	}
+	if bundle.TokenData.AccountUUID != "account-uuid-123" {
+		t.Fatalf("account uuid = %q, want %q", bundle.TokenData.AccountUUID, "account-uuid-123")
 	}
 	if got := requestBody["redirect_uri"]; got != PlatformRedirectURI {
 		t.Fatalf("redirect_uri = %v, want %q", got, PlatformRedirectURI)

--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -31,6 +31,9 @@ type ClaudeTokenStorage struct {
 	// Email is the Anthropic account email address associated with this token.
 	Email string `json:"email"`
 
+	// AccountUUID is the Anthropic OAuth account UUID associated with this token.
+	AccountUUID string `json:"account_uuid,omitempty"`
+
 	// Type indicates the authentication provider type, always "claude" for this storage.
 	Type string `json:"type"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,11 +194,20 @@ const (
 	DefaultCodexFingerprintOriginator    = "codex-tui"
 	DefaultCodexFingerprintWebsocketBeta = "responses_websockets=2026-02-06"
 	DefaultCodexFingerprintSessionMode   = "per-request"
+
+	DefaultClaudeFingerprintCLIVersion              = "2.1.88"
+	DefaultClaudeFingerprintEntrypoint              = "cli"
+	DefaultClaudeFingerprintAnthropicBeta           = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20,effort-2025-11-24"
+	DefaultClaudeFingerprintStainlessPackageVersion = "0.74.0"
+	DefaultClaudeFingerprintStainlessRuntimeVersion = "v22.13.0"
+	DefaultClaudeFingerprintStainlessTimeout        = "600"
+	DefaultClaudeFingerprintSessionMode             = "per-request"
 )
 
 // IdentityFingerprintConfig groups provider-specific upstream identity settings.
 type IdentityFingerprintConfig struct {
-	Codex CodexIdentityFingerprintConfig `yaml:"codex,omitempty" json:"codex,omitempty"`
+	Codex  CodexIdentityFingerprintConfig  `yaml:"codex,omitempty" json:"codex,omitempty"`
+	Claude ClaudeIdentityFingerprintConfig `yaml:"claude,omitempty" json:"claude,omitempty"`
 }
 
 // CodexIdentityFingerprintConfig configures Codex upstream identity headers.
@@ -223,6 +232,40 @@ func DefaultCodexIdentityFingerprint() CodexIdentityFingerprintConfig {
 		WebsocketBeta: DefaultCodexFingerprintWebsocketBeta,
 		SessionMode:   DefaultCodexFingerprintSessionMode,
 		CustomHeaders: map[string]string{},
+	}
+}
+
+// ClaudeIdentityFingerprintConfig configures Claude Code-style Anthropic OAuth identity.
+type ClaudeIdentityFingerprintConfig struct {
+	Enabled                 bool              `yaml:"enabled" json:"enabled"`
+	CLIVersion              string            `yaml:"cli-version,omitempty" json:"cli-version,omitempty"`
+	Entrypoint              string            `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	UserAgent               string            `yaml:"user-agent,omitempty" json:"user-agent,omitempty"`
+	AnthropicBeta           string            `yaml:"anthropic-beta,omitempty" json:"anthropic-beta,omitempty"`
+	StainlessPackageVersion string            `yaml:"stainless-package-version,omitempty" json:"stainless-package-version,omitempty"`
+	StainlessRuntimeVersion string            `yaml:"stainless-runtime-version,omitempty" json:"stainless-runtime-version,omitempty"`
+	StainlessTimeout        string            `yaml:"stainless-timeout,omitempty" json:"stainless-timeout,omitempty"`
+	SessionMode             string            `yaml:"session-mode,omitempty" json:"session-mode,omitempty"`
+	SessionID               string            `yaml:"session-id,omitempty" json:"session-id,omitempty"`
+	DeviceID                string            `yaml:"device-id,omitempty" json:"device-id,omitempty"`
+	CustomHeaders           map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+}
+
+// DefaultClaudeIdentityFingerprint returns the recommended Claude Code identity template.
+func DefaultClaudeIdentityFingerprint() ClaudeIdentityFingerprintConfig {
+	cliVersion := DefaultClaudeFingerprintCLIVersion
+	entrypoint := DefaultClaudeFingerprintEntrypoint
+	return ClaudeIdentityFingerprintConfig{
+		Enabled:                 false,
+		CLIVersion:              cliVersion,
+		Entrypoint:              entrypoint,
+		UserAgent:               BuildClaudeFingerprintUserAgent(cliVersion, entrypoint),
+		AnthropicBeta:           DefaultClaudeFingerprintAnthropicBeta,
+		StainlessPackageVersion: DefaultClaudeFingerprintStainlessPackageVersion,
+		StainlessRuntimeVersion: DefaultClaudeFingerprintStainlessRuntimeVersion,
+		StainlessTimeout:        DefaultClaudeFingerprintStainlessTimeout,
+		SessionMode:             DefaultClaudeFingerprintSessionMode,
+		CustomHeaders:           map[string]string{},
 	}
 }
 

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -8,6 +8,7 @@ func (cfg *Config) SanitizeIdentityFingerprint() {
 		return
 	}
 	cfg.IdentityFingerprint.Codex = NormalizeCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex)
+	cfg.IdentityFingerprint.Claude = NormalizeClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude)
 }
 
 // NormalizeCodexIdentityFingerprint trims user input and applies safe defaults
@@ -38,6 +39,80 @@ func NormalizeCodexIdentityFingerprint(in CodexIdentityFingerprintConfig) CodexI
 	}
 	if out.SessionMode != "server-stable" && out.SessionMode != "fixed" && out.SessionMode != "per-request" {
 		out.SessionMode = DefaultCodexFingerprintSessionMode
+	}
+
+	if len(out.CustomHeaders) > 0 {
+		cleaned := make(map[string]string, len(out.CustomHeaders))
+		for key, value := range out.CustomHeaders {
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			if key == "" || value == "" {
+				continue
+			}
+			cleaned[key] = value
+		}
+		out.CustomHeaders = cleaned
+	} else {
+		out.CustomHeaders = map[string]string{}
+	}
+	return out
+}
+
+// BuildClaudeFingerprintUserAgent builds the Claude Code User-Agent value from
+// the CLI version and entrypoint dimensions.
+func BuildClaudeFingerprintUserAgent(cliVersion, entrypoint string) string {
+	cliVersion = strings.TrimSpace(cliVersion)
+	entrypoint = strings.TrimSpace(entrypoint)
+	if cliVersion == "" {
+		cliVersion = DefaultClaudeFingerprintCLIVersion
+	}
+	if entrypoint == "" {
+		entrypoint = DefaultClaudeFingerprintEntrypoint
+	}
+	return "claude-cli/" + cliVersion + " (external, " + entrypoint + ")"
+}
+
+// NormalizeClaudeIdentityFingerprint trims user input and applies safe defaults
+// for fields that participate in Claude Code-style Anthropic OAuth identity.
+func NormalizeClaudeIdentityFingerprint(in ClaudeIdentityFingerprintConfig) ClaudeIdentityFingerprintConfig {
+	out := in
+	out.CLIVersion = strings.TrimSpace(out.CLIVersion)
+	out.Entrypoint = strings.TrimSpace(out.Entrypoint)
+	out.UserAgent = strings.TrimSpace(out.UserAgent)
+	out.AnthropicBeta = strings.TrimSpace(out.AnthropicBeta)
+	out.StainlessPackageVersion = strings.TrimSpace(out.StainlessPackageVersion)
+	out.StainlessRuntimeVersion = strings.TrimSpace(out.StainlessRuntimeVersion)
+	out.StainlessTimeout = strings.TrimSpace(out.StainlessTimeout)
+	out.SessionMode = strings.TrimSpace(strings.ToLower(out.SessionMode))
+	out.SessionID = strings.TrimSpace(out.SessionID)
+	out.DeviceID = strings.TrimSpace(out.DeviceID)
+
+	if out.CLIVersion == "" {
+		out.CLIVersion = DefaultClaudeFingerprintCLIVersion
+	}
+	if out.Entrypoint == "" {
+		out.Entrypoint = DefaultClaudeFingerprintEntrypoint
+	}
+	if out.UserAgent == "" {
+		out.UserAgent = BuildClaudeFingerprintUserAgent(out.CLIVersion, out.Entrypoint)
+	}
+	if out.AnthropicBeta == "" {
+		out.AnthropicBeta = DefaultClaudeFingerprintAnthropicBeta
+	}
+	if out.StainlessPackageVersion == "" {
+		out.StainlessPackageVersion = DefaultClaudeFingerprintStainlessPackageVersion
+	}
+	if out.StainlessRuntimeVersion == "" {
+		out.StainlessRuntimeVersion = DefaultClaudeFingerprintStainlessRuntimeVersion
+	}
+	if out.StainlessTimeout == "" {
+		out.StainlessTimeout = DefaultClaudeFingerprintStainlessTimeout
+	}
+	if out.SessionMode == "" {
+		out.SessionMode = DefaultClaudeFingerprintSessionMode
+	}
+	if out.SessionMode != "server-stable" && out.SessionMode != "fixed" && out.SessionMode != "per-request" {
+		out.SessionMode = DefaultClaudeFingerprintSessionMode
 	}
 
 	if len(out.CustomHeaders) > 0 {

--- a/internal/config/identity_fingerprint_test.go
+++ b/internal/config/identity_fingerprint_test.go
@@ -36,3 +36,66 @@ func TestNormalizeCodexIdentityFingerprintAppliesCurrentDefaults(t *testing.T) {
 		t.Fatalf("SessionMode = %q, want per-request", got.SessionMode)
 	}
 }
+
+func TestDefaultClaudeIdentityFingerprintMirrorsClaudeCode(t *testing.T) {
+	t.Parallel()
+
+	got := DefaultClaudeIdentityFingerprint()
+
+	if got.Enabled {
+		t.Fatalf("Enabled = true, want false by default")
+	}
+	if got.CLIVersion != "2.1.88" {
+		t.Fatalf("CLIVersion = %q, want 2.1.88", got.CLIVersion)
+	}
+	if got.Entrypoint != "cli" {
+		t.Fatalf("Entrypoint = %q, want cli", got.Entrypoint)
+	}
+	if got.UserAgent != "claude-cli/2.1.88 (external, cli)" {
+		t.Fatalf("UserAgent = %q, want Claude Code user agent", got.UserAgent)
+	}
+	if got.StainlessPackageVersion != "0.74.0" {
+		t.Fatalf("StainlessPackageVersion = %q, want 0.74.0", got.StainlessPackageVersion)
+	}
+	if got.StainlessRuntimeVersion != "v22.13.0" {
+		t.Fatalf("StainlessRuntimeVersion = %q, want v22.13.0", got.StainlessRuntimeVersion)
+	}
+	if got.SessionMode != "per-request" {
+		t.Fatalf("SessionMode = %q, want per-request", got.SessionMode)
+	}
+}
+
+func TestNormalizeClaudeIdentityFingerprintBuildsUserAgentFromVersionAndEntrypoint(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeClaudeIdentityFingerprint(ClaudeIdentityFingerprintConfig{
+		Enabled:     true,
+		CLIVersion:  " 2.2.0 ",
+		Entrypoint:  " sdk-cli ",
+		SessionMode: "INVALID",
+		CustomHeaders: map[string]string{
+			" X-Test ": " value ",
+			"":         "discard",
+			"X-Blank":  " ",
+		},
+	})
+
+	if !got.Enabled {
+		t.Fatal("Enabled = false, want true")
+	}
+	if got.CLIVersion != "2.2.0" {
+		t.Fatalf("CLIVersion = %q, want 2.2.0", got.CLIVersion)
+	}
+	if got.Entrypoint != "sdk-cli" {
+		t.Fatalf("Entrypoint = %q, want sdk-cli", got.Entrypoint)
+	}
+	if got.UserAgent != "claude-cli/2.2.0 (external, sdk-cli)" {
+		t.Fatalf("UserAgent = %q, want derived Claude Code user agent", got.UserAgent)
+	}
+	if got.SessionMode != "per-request" {
+		t.Fatalf("SessionMode = %q, want per-request fallback", got.SessionMode)
+	}
+	if got.CustomHeaders["X-Test"] != "value" || len(got.CustomHeaders) != 1 {
+		t.Fatalf("CustomHeaders = %#v, want trimmed non-empty header only", got.CustomHeaders)
+	}
+}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -116,11 +116,18 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, err
 	}
 
+	claudeFP, claudeFPEnabled := claudeIdentityFingerprint(e.cfg)
+	claudeFPSessionID := ""
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	// Skipped when skip_anthropic_processing is enabled (third-party Claude-compatible APIs).
 	if !skipAnthropic {
-		body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
+		if claudeFPEnabled {
+			claudeFPSessionID = claudeFingerprintSessionID(claudeFP)
+			body = applyClaudeIdentityFingerprintPayload(auth, body, claudeFP, claudeFPSessionID)
+		} else {
+			body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
+		}
 	}
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
@@ -150,7 +157,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if err != nil {
 		return resp, err
 	}
-	applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg)
+	applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, claudeFP, claudeFPEnabled, claudeFPSessionID)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -265,11 +272,18 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, err
 	}
 
+	claudeFP, claudeFPEnabled := claudeIdentityFingerprint(e.cfg)
+	claudeFPSessionID := ""
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	// Skipped when skip_anthropic_processing is enabled (third-party Claude-compatible APIs).
 	if !skipAnthropic {
-		body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
+		if claudeFPEnabled {
+			claudeFPSessionID = claudeFingerprintSessionID(claudeFP)
+			body = applyClaudeIdentityFingerprintPayload(auth, body, claudeFP, claudeFPSessionID)
+		} else {
+			body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
+		}
 	}
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
@@ -299,7 +313,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return nil, err
 	}
-	applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, e.cfg)
+	applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, e.cfg, claudeFP, claudeFPEnabled, claudeFPSessionID)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -451,7 +465,12 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
-	applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg)
+	claudeFP, claudeFPEnabled := claudeIdentityFingerprint(e.cfg)
+	claudeFPSessionID := ""
+	if claudeFPEnabled {
+		claudeFPSessionID = claudeFingerprintSessionID(claudeFP)
+	}
+	applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, claudeFP, claudeFPEnabled, claudeFPSessionID)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -687,7 +706,7 @@ func mapStainlessArch() string {
 	}
 }
 
-func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, cfg *config.Config) {
+func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, cfg *config.Config, claudeFP config.ClaudeIdentityFingerprintConfig, claudeFPEnabled bool, claudeFPSessionID string) {
 	hdrDefault := func(cfgVal, fallback string) string {
 		if cfgVal != "" {
 			return cfgVal
@@ -709,6 +728,18 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 		r.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 	r.Header.Set("Content-Type", "application/json")
+
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	if claudeFPEnabled {
+		util.ApplyCustomHeadersFromAttrs(r, attrs)
+		applyClaudeIdentityFingerprintHeaders(r.Header, claudeFP, stream, extraBetas, claudeFPSessionID)
+		r.Header.Set("Connection", "keep-alive")
+		r.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
+		return
+	}
 
 	var ginHeaders http.Header
 	if ginCtx, ok := r.Context().Value(util.ContextKeyGin).(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
@@ -766,10 +797,6 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	}
 	// Keep OS/Arch mapping dynamic (not configurable).
 	// They intentionally continue to derive from runtime.GOOS/runtime.GOARCH.
-	var attrs map[string]string
-	if auth != nil {
-		attrs = auth.Attributes
-	}
 	util.ApplyCustomHeadersFromAttrs(r, attrs)
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -3,9 +3,11 @@ package executor
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -318,6 +320,100 @@ func TestClaudeExecutor_GeneratesNewUserIDByDefault(t *testing.T) {
 	}
 	if !isValidUserID(userIDs[0]) || !isValidUserID(userIDs[1]) {
 		t.Fatalf("user_ids should be valid, got %q and %q", userIDs[0], userIDs[1])
+	}
+}
+
+func TestClaudeExecutorAppliesClaudeIdentityFingerprint(t *testing.T) {
+	var gotHeaders http.Header
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-4-5","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{
+		IdentityFingerprint: config.IdentityFingerprintConfig{
+			Claude: config.ClaudeIdentityFingerprintConfig{
+				Enabled:     true,
+				CLIVersion:  "2.1.88",
+				Entrypoint:  "cli",
+				SessionMode: "fixed",
+				SessionID:   "session-fixed-123",
+				DeviceID:    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			},
+		},
+	})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":  "oauth-access-token",
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"type":         "claude",
+			"account_uuid": "account-uuid-123",
+		},
+	}
+	payload := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":[{"type":"text","text":"hello from user message"}]}]}`)
+
+	if _, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-4-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	}); err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if got := gotHeaders.Get("User-Agent"); got != "claude-cli/2.1.88 (external, cli)" {
+		t.Fatalf("User-Agent = %q, want Claude Code fingerprint", got)
+	}
+	if got := gotHeaders.Get("Anthropic-Beta"); !strings.Contains(got, "redact-thinking-2026-02-12") ||
+		!strings.Contains(got, "oauth-2025-04-20") {
+		t.Fatalf("Anthropic-Beta = %q, want Claude Code OAuth betas", got)
+	}
+	if got := gotHeaders.Get("X-Stainless-Package-Version"); got != "0.74.0" {
+		t.Fatalf("X-Stainless-Package-Version = %q, want 0.74.0", got)
+	}
+	if got := gotHeaders.Get("X-Stainless-Runtime-Version"); got != "v22.13.0" {
+		t.Fatalf("X-Stainless-Runtime-Version = %q, want v22.13.0", got)
+	}
+	if got := gotHeaders.Get("X-Claude-Code-Session-Id"); got != "session-fixed-123" {
+		t.Fatalf("X-Claude-Code-Session-Id = %q, want fixed session", got)
+	}
+	if got := gotHeaders.Get("X-App"); got != "cli" {
+		t.Fatalf("X-App = %q, want cli", got)
+	}
+	if got := gotHeaders.Get("X-Client-Request-Id"); got == "" {
+		t.Fatal("X-Client-Request-Id is empty")
+	}
+
+	billing := gjson.GetBytes(gotBody, "system.0.text").String()
+	if !strings.Contains(billing, "x-anthropic-billing-header: cc_version=2.1.88.") ||
+		!strings.Contains(billing, "cc_entrypoint=cli") {
+		t.Fatalf("billing header block = %q, want Claude Code billing fingerprint", billing)
+	}
+	if got := gjson.GetBytes(gotBody, "system.1.text").String(); got != "You are Claude Code, Anthropic's official CLI for Claude." {
+		t.Fatalf("system.1.text = %q, want Claude Code prefix", got)
+	}
+
+	var userID struct {
+		DeviceID    string `json:"device_id"`
+		AccountUUID string `json:"account_uuid"`
+		SessionID   string `json:"session_id"`
+	}
+	if err := json.Unmarshal([]byte(gjson.GetBytes(gotBody, "metadata.user_id").String()), &userID); err != nil {
+		t.Fatalf("metadata.user_id is not JSON: %v; body=%s", err, string(gotBody))
+	}
+	if userID.DeviceID != "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" ||
+		userID.AccountUUID != "account-uuid-123" || userID.SessionID != "session-fixed-123" {
+		t.Fatalf("metadata.user_id = %#v, want device/account/session fingerprint", userID)
 	}
 }
 

--- a/internal/runtime/executor/claude_identity_fingerprint.go
+++ b/internal/runtime/executor/claude_identity_fingerprint.go
@@ -1,0 +1,283 @@
+package executor
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const claudeFingerprintSalt = "59cf53e54c78"
+
+var (
+	claudeServerSessionOnce sync.Once
+	claudeServerSessionID   string
+)
+
+type claudeFingerprintUserID struct {
+	DeviceID    string `json:"device_id"`
+	AccountUUID string `json:"account_uuid"`
+	SessionID   string `json:"session_id"`
+}
+
+func claudeIdentityFingerprint(cfg *config.Config) (config.ClaudeIdentityFingerprintConfig, bool) {
+	if cfg == nil || !cfg.IdentityFingerprint.Claude.Enabled {
+		return config.ClaudeIdentityFingerprintConfig{}, false
+	}
+	return config.NormalizeClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude), true
+}
+
+func claudeServerStableSessionID() string {
+	claudeServerSessionOnce.Do(func() {
+		claudeServerSessionID = uuid.NewString()
+	})
+	return claudeServerSessionID
+}
+
+func claudeFingerprintSessionID(fp config.ClaudeIdentityFingerprintConfig) string {
+	switch strings.TrimSpace(strings.ToLower(fp.SessionMode)) {
+	case "fixed":
+		if strings.TrimSpace(fp.SessionID) != "" {
+			return strings.TrimSpace(fp.SessionID)
+		}
+		return claudeServerStableSessionID()
+	case "server-stable":
+		return claudeServerStableSessionID()
+	default:
+		return uuid.NewString()
+	}
+}
+
+func applyClaudeIdentityFingerprintHeaders(headers http.Header, fp config.ClaudeIdentityFingerprintConfig, stream bool, extraBetas []string, sessionID string) {
+	if headers == nil {
+		return
+	}
+	headers.Set("Anthropic-Beta", mergeClaudeBetaHeader(fp.AnthropicBeta, extraBetas))
+	headers.Set("Anthropic-Version", "2023-06-01")
+	headers.Set("Anthropic-Dangerous-Direct-Browser-Access", "true")
+	headers.Set("User-Agent", fp.UserAgent)
+	headers.Set("X-App", fp.Entrypoint)
+	headers.Set("X-Claude-Code-Session-Id", sessionID)
+	headers.Set("X-Client-Request-Id", uuid.NewString())
+	headers.Set("X-Stainless-Helper-Method", "stream")
+	headers.Set("X-Stainless-Retry-Count", "0")
+	headers.Set("X-Stainless-Runtime-Version", fp.StainlessRuntimeVersion)
+	headers.Set("X-Stainless-Package-Version", fp.StainlessPackageVersion)
+	headers.Set("X-Stainless-Runtime", "node")
+	headers.Set("X-Stainless-Lang", "js")
+	headers.Set("X-Stainless-Arch", mapStainlessArch())
+	headers.Set("X-Stainless-Os", mapStainlessOS())
+	headers.Set("X-Stainless-Timeout", fp.StainlessTimeout)
+	if stream {
+		headers.Set("Accept", "text/event-stream")
+	} else {
+		headers.Set("Accept", "application/json")
+	}
+	for key, value := range fp.CustomHeaders {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key != "" && value != "" && !isClaudeFingerprintRuntimeBlockedHeader(key) {
+			headers.Set(key, value)
+		}
+	}
+}
+
+func mergeClaudeBetaHeader(base string, extraBetas []string) string {
+	seen := make(map[string]bool)
+	var out []string
+	add := func(raw string) {
+		for _, part := range strings.Split(raw, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" && !seen[part] {
+				seen[part] = true
+				out = append(out, part)
+			}
+		}
+	}
+	add(base)
+	for _, beta := range extraBetas {
+		add(beta)
+	}
+	if !seen["oauth-2025-04-20"] {
+		out = append([]string{"oauth-2025-04-20"}, out...)
+	}
+	return strings.Join(out, ",")
+}
+
+func applyClaudeIdentityFingerprintPayload(auth *cliproxyauth.Auth, payload []byte, fp config.ClaudeIdentityFingerprintConfig, sessionID string) []byte {
+	payload = applyClaudeFingerprintSystem(payload, fp)
+	userID, err := json.Marshal(claudeFingerprintUserID{
+		DeviceID:    claudeFingerprintDeviceID(auth, fp),
+		AccountUUID: claudeFingerprintAccountUUID(auth),
+		SessionID:   sessionID,
+	})
+	if err == nil {
+		payload, _ = sjson.SetBytes(payload, "metadata.user_id", string(userID))
+	}
+	return payload
+}
+
+func applyClaudeFingerprintSystem(payload []byte, fp config.ClaudeIdentityFingerprintConfig) []byte {
+	system := gjson.GetBytes(payload, "system")
+	remaining := make([]map[string]any, 0)
+	appendText := func(text string, cache bool) {
+		text = strings.TrimSpace(text)
+		if text == "" || isClaudeFingerprintBillingText(text) || isClaudeFingerprintPrefixText(text) {
+			return
+		}
+		block := map[string]any{"type": "text", "text": text}
+		if cache {
+			block["cache_control"] = map[string]string{"type": "ephemeral"}
+		}
+		remaining = append(remaining, block)
+	}
+	if system.IsArray() {
+		for _, item := range system.Array() {
+			text := item.Get("text").String()
+			if isClaudeFingerprintBillingText(text) || isClaudeFingerprintPrefixText(text) {
+				continue
+			}
+			var block map[string]any
+			if err := json.Unmarshal([]byte(item.Raw), &block); err == nil {
+				remaining = append(remaining, block)
+			}
+		}
+	} else if system.Type == gjson.String {
+		appendText(system.String(), false)
+	}
+
+	next := []map[string]any{
+		{"type": "text", "text": buildClaudeBillingHeader(payload, fp)},
+		{
+			"type":          "text",
+			"text":          "You are Claude Code, Anthropic's official CLI for Claude.",
+			"cache_control": map[string]string{"type": "ephemeral"},
+		},
+	}
+	next = append(next, remaining...)
+	raw, err := json.Marshal(next)
+	if err != nil {
+		return payload
+	}
+	payload, _ = sjson.SetRawBytes(payload, "system", raw)
+	return payload
+}
+
+func buildClaudeBillingHeader(payload []byte, fp config.ClaudeIdentityFingerprintConfig) string {
+	fingerprint := computeClaudeBillingFingerprint(firstClaudeUserMessageText(payload), fp.CLIVersion)
+	return fmt.Sprintf("x-anthropic-billing-header: cc_version=%s.%s; cc_entrypoint=%s;", fp.CLIVersion, fingerprint, fp.Entrypoint)
+}
+
+func firstClaudeUserMessageText(payload []byte) string {
+	messages := gjson.GetBytes(payload, "messages")
+	for _, msg := range messages.Array() {
+		if msg.Get("role").String() != "user" {
+			continue
+		}
+		content := msg.Get("content")
+		if content.Type == gjson.String {
+			return content.String()
+		}
+		if content.IsArray() {
+			for _, block := range content.Array() {
+				if block.Get("type").String() == "text" {
+					return block.Get("text").String()
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func computeClaudeBillingFingerprint(messageText, version string) string {
+	chars := []rune(messageText)
+	pick := func(index int) rune {
+		if index >= 0 && index < len(chars) {
+			return chars[index]
+		}
+		return '0'
+	}
+	input := fmt.Sprintf("%s%c%c%c%s", claudeFingerprintSalt, pick(4), pick(7), pick(20), version)
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])[:3]
+}
+
+func claudeFingerprintDeviceID(auth *cliproxyauth.Auth, fp config.ClaudeIdentityFingerprintConfig) string {
+	if isClaudeFingerprintDeviceID(fp.DeviceID) {
+		return strings.ToLower(fp.DeviceID)
+	}
+	seed := claudeFingerprintAccountUUID(auth)
+	if seed == "" && auth != nil {
+		seed = auth.ID
+	}
+	if seed == "" {
+		seed = "claude-oauth"
+	}
+	sum := sha256.Sum256([]byte("claude-device:" + seed))
+	return hex.EncodeToString(sum[:])
+}
+
+func claudeFingerprintAccountUUID(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	for _, key := range []string{"account_uuid", "account_id", "uuid"} {
+		if auth.Metadata != nil {
+			if value, ok := auth.Metadata[key].(string); ok && strings.TrimSpace(value) != "" {
+				return strings.TrimSpace(value)
+			}
+		}
+		if auth.Attributes != nil {
+			if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+				return value
+			}
+		}
+	}
+	return auth.ID
+}
+
+func isClaudeFingerprintDeviceID(value string) bool {
+	value = strings.TrimSpace(value)
+	if len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if r >= '0' && r <= '9' || r >= 'a' && r <= 'f' || r >= 'A' && r <= 'F' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func isClaudeFingerprintBillingText(text string) bool {
+	return strings.Contains(text, "x-anthropic-billing-header")
+}
+
+func isClaudeFingerprintPrefixText(text string) bool {
+	return strings.Contains(text, "You are Claude Code")
+}
+
+func isClaudeFingerprintRuntimeBlockedHeader(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	if strings.HasPrefix(key, "x-stainless-") {
+		return true
+	}
+	switch key {
+	case "authorization", "content-type", "accept", "connection", "x-api-key",
+		"anthropic-beta", "anthropic-version", "anthropic-dangerous-direct-browser-access",
+		"user-agent", "x-app", "x-client-request-id", "x-claude-code-session-id":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -266,11 +266,13 @@ func runtimeSettingSpecs() []runtimeSettingSpec {
 		{
 			key: RuntimeSettingIdentityFingerprint,
 			meaningful: func(cfg *config.Config) bool {
-				return codexIdentityFingerprintMeaningful(cfg.IdentityFingerprint.Codex)
+				return codexIdentityFingerprintMeaningful(cfg.IdentityFingerprint.Codex) ||
+					claudeIdentityFingerprintMeaningful(cfg.IdentityFingerprint.Claude)
 			},
 			value: func(cfg *config.Config) any {
 				return config.IdentityFingerprintConfig{
-					Codex: config.NormalizeCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex),
+					Codex:  config.NormalizeCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex),
+					Claude: config.NormalizeClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude),
 				}
 			},
 			apply: func(cfg *config.Config, raw json.RawMessage) bool {
@@ -280,6 +282,7 @@ func runtimeSettingSpecs() []runtimeSettingSpec {
 					return false
 				}
 				value.Codex = config.NormalizeCodexIdentityFingerprint(value.Codex)
+				value.Claude = config.NormalizeClaudeIdentityFingerprint(value.Claude)
 				cfg.IdentityFingerprint = value
 				return true
 			},
@@ -355,6 +358,23 @@ func codexIdentityFingerprintMeaningful(fp config.CodexIdentityFingerprintConfig
 		normalized.Version != defaults.Version ||
 		normalized.Originator != defaults.Originator ||
 		normalized.WebsocketBeta != defaults.WebsocketBeta ||
+		normalized.SessionMode != defaults.SessionMode
+}
+
+func claudeIdentityFingerprintMeaningful(fp config.ClaudeIdentityFingerprintConfig) bool {
+	normalized := config.NormalizeClaudeIdentityFingerprint(fp)
+	defaults := config.DefaultClaudeIdentityFingerprint()
+	if normalized.Enabled || strings.TrimSpace(normalized.SessionID) != "" ||
+		strings.TrimSpace(normalized.DeviceID) != "" || len(normalized.CustomHeaders) > 0 {
+		return true
+	}
+	return normalized.CLIVersion != defaults.CLIVersion ||
+		normalized.Entrypoint != defaults.Entrypoint ||
+		normalized.UserAgent != defaults.UserAgent ||
+		normalized.AnthropicBeta != defaults.AnthropicBeta ||
+		normalized.StainlessPackageVersion != defaults.StainlessPackageVersion ||
+		normalized.StainlessRuntimeVersion != defaults.StainlessRuntimeVersion ||
+		normalized.StainlessTimeout != defaults.StainlessTimeout ||
 		normalized.SessionMode != defaults.SessionMode
 }
 

--- a/internal/usage/runtime_settings_db_test.go
+++ b/internal/usage/runtime_settings_db_test.go
@@ -21,6 +21,10 @@ identity-fingerprint:
   codex:
     enabled: true
     user-agent: codex_cli_rs/0.125.0
+  claude:
+    enabled: true
+    cli-version: 2.1.88
+    entrypoint: cli
 oauth-model-alias:
   antigravity:
     - name: rev19-uic3-1p
@@ -34,6 +38,11 @@ debug: true
 		KimiHeaderDefaults: config.KimiHeaderDefaults{UserAgent: "KimiCLI/1.24.0"},
 		IdentityFingerprint: config.IdentityFingerprintConfig{
 			Codex: config.CodexIdentityFingerprintConfig{Enabled: true, UserAgent: "codex_cli_rs/0.125.0"},
+			Claude: config.ClaudeIdentityFingerprintConfig{
+				Enabled:    true,
+				CLIVersion: "2.1.88",
+				Entrypoint: "cli",
+			},
 		},
 		OAuthModelAlias: map[string][]config.OAuthModelAlias{
 			"antigravity": {{Name: "rev19-uic3-1p", Alias: "gemini-2.5-computer-use-preview-10-2025"}},
@@ -55,6 +64,9 @@ debug: true
 	}
 	if !cfg.IdentityFingerprint.Codex.Enabled || cfg.IdentityFingerprint.Codex.UserAgent != "codex_cli_rs/0.125.0" {
 		t.Fatalf("IdentityFingerprint.Codex = %#v", cfg.IdentityFingerprint.Codex)
+	}
+	if !cfg.IdentityFingerprint.Claude.Enabled || cfg.IdentityFingerprint.Claude.UserAgent != "claude-cli/2.1.88 (external, cli)" {
+		t.Fatalf("IdentityFingerprint.Claude = %#v", cfg.IdentityFingerprint.Claude)
 	}
 	if got := cfg.OAuthModelAlias["antigravity"]; len(got) != 1 || got[0].Alias != "gemini-2.5-computer-use-preview-10-2025" {
 		t.Fatalf("OAuthModelAlias = %#v", cfg.OAuthModelAlias)


### PR DESCRIPTION
## Summary
- add Claude OAuth identity fingerprint configuration and persistence
- apply Claude Code-style request headers, system metadata, billing marker, and account/session/device identity
- preserve Anthropic OAuth account UUID across token exchange and refresh

## Tests
- go test ./...