### PR TITLE
fix: deploy panel to nginx host mount

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
             SERVICE_NAME="$(basename "$SERVICE_BIN")"
             TEMP_BIN="/opt/clirelay2/cli-proxy-api-new"
             PANEL_SRC="/tmp/clirelay-panel-${{ github.sha }}"
-            PANEL_DIR="/var/www/html/relay-panel"
+            PANEL_DIR="/home/web/html/relay-panel"
             PANEL_NEXT="${PANEL_DIR}.new"
             if [ ! -f "$TEMP_BIN" ]; then
               echo "uploaded temp binary not found: $TEMP_BIN"

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -17,7 +17,7 @@ func TestDeployWorkflowPublishesNginxPanelAssets(t *testing.T) {
 		`Upload panel assets`,
 		`source: "manage.html,management.html,assets"`,
 		`PANEL_SRC="/tmp/clirelay-panel-${{ github.sha }}"`,
-		`PANEL_DIR="/var/www/html/relay-panel"`,
+		`PANEL_DIR="/home/web/html/relay-panel"`,
 		`cp -a "$PANEL_SRC"/. "$PANEL_NEXT"/`,
 		`mv "$PANEL_NEXT" "$PANEL_DIR"`,
 	} {


### PR DESCRIPTION
## Summary
- publish the management panel to /home/web/html/relay-panel, the host path mounted into the nginx container as /var/www/html/relay-panel
- update the deploy workflow regression test to guard the actual host mount path

## Root Cause
PR #94 made the deploy workflow upload panel assets, but used the container path /var/www/html/relay-panel on the host. The nginx container bind-mounts /home/web/html to /var/www/html, so the public site still served stale files from /home/web/html/relay-panel.

## Verification
- go test ./deployment_workflow_test.go
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'
- go test ./deployment_workflow_test.go ./auth_files_quota_asset_test.go ./management_asset_navigation_test.go
- git diff --check
- go test ./...