### PR TITLE
fix: stop backend deploy from publishing panel assets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,18 +48,6 @@ jobs:
           target: "/opt/clirelay2/"
           overwrite: true
 
-      - name: Upload panel assets
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          port: ${{ secrets.SERVER_PORT }}
-          username: root
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "manage.html,management.html,assets"
-          target: "/tmp/clirelay-panel-${{ github.sha }}/"
-          overwrite: true
-          rm: true
-
       - name: Stop, swap, and restart
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -79,24 +67,10 @@ jobs:
             SERVICE_DIR="$(dirname "$SERVICE_BIN")"
             SERVICE_NAME="$(basename "$SERVICE_BIN")"
             TEMP_BIN="/opt/clirelay2/cli-proxy-api-new"
-            PANEL_SRC="/tmp/clirelay-panel-${{ github.sha }}"
-            PANEL_DIR="/home/web/html/relay-panel"
-            PANEL_NEXT="${PANEL_DIR}.new"
             if [ ! -f "$TEMP_BIN" ]; then
               echo "uploaded temp binary not found: $TEMP_BIN"
               exit 1
             fi
-            if [ ! -f "$PANEL_SRC/manage.html" ] || [ ! -d "$PANEL_SRC/assets" ]; then
-              echo "uploaded panel assets not found under: $PANEL_SRC"
-              exit 1
-            fi
-            rm -rf "$PANEL_NEXT"
-            mkdir -p "$(dirname "$PANEL_DIR")"
-            mkdir -p "$PANEL_NEXT"
-            cp -a "$PANEL_SRC"/. "$PANEL_NEXT"/
-            chown -R root:root "$PANEL_NEXT"
-            find "$PANEL_NEXT" -type d -exec chmod 755 {} \;
-            find "$PANEL_NEXT" -type f -exec chmod 644 {} \;
             cd "$SERVICE_DIR"
             echo "Service binary: $SERVICE_BIN"
             # Stop via systemd
@@ -115,13 +89,6 @@ jobs:
             # Swap in new binary
             mv "$TEMP_BIN" "$SERVICE_NAME"
             chmod +x "$SERVICE_NAME"
-            # Atomically publish the management panel used by Nginx.
-            if [ -d "$PANEL_DIR" ]; then
-              mv "$PANEL_DIR" "${PANEL_DIR}.bak.$(date +%Y%m%d_%H%M%S)"
-            fi
-            mv "$PANEL_NEXT" "$PANEL_DIR"
-            rm -rf "$PANEL_SRC"
-            ls -1dt "${PANEL_DIR}.bak."* 2>/dev/null | tail -n +4 | xargs -r rm -rf
             # Clean up old backups, keep last 3
             ls -1t "${SERVICE_NAME}.bak."* 2>/dev/null | tail -n +4 | xargs -r rm -f
             # Start service

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestDeployWorkflowPublishesNginxPanelAssets(t *testing.T) {
+func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/deploy.yml")
 	if err != nil {
 		t.Fatalf("read deploy workflow: %v", err)
@@ -14,15 +14,25 @@ func TestDeployWorkflowPublishesNginxPanelAssets(t *testing.T) {
 	content := string(data)
 
 	for _, want := range []string{
-		`Upload panel assets`,
-		`source: "manage.html,management.html,assets"`,
-		`PANEL_SRC="/tmp/clirelay-panel-${{ github.sha }}"`,
-		`PANEL_DIR="/home/web/html/relay-panel"`,
-		`cp -a "$PANEL_SRC"/. "$PANEL_NEXT"/`,
-		`mv "$PANEL_NEXT" "$PANEL_DIR"`,
+		`Upload binary (as temp name)`,
+		`source: "cli-proxy-api-new"`,
+		`target: "/opt/clirelay2/"`,
 	} {
 		if !strings.Contains(content, want) {
-			t.Fatalf("deploy workflow does not publish Nginx panel assets, missing %q", want)
+			t.Fatalf("deploy workflow missing backend binary deployment marker %q", want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		`Upload panel assets`,
+		`source: "manage.html,management.html,assets"`,
+		`PANEL_SRC=`,
+		`PANEL_DIR=`,
+		`relay-panel`,
+		`/home/web/html`,
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("backend deploy workflow must not publish frontend panel assets, found %q", forbidden)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- remove backend workflow upload of `manage.html`, `management.html`, and `assets`
- remove the SSH script that atomically replaces `/home/web/html/relay-panel`
- keep backend binary deployment unchanged
- update regression test so backend deploy cannot publish frontend panel assets again

## Context
The frontend panel is deployed from the separate `kittors/codeProxy` project. Publishing the backend repository static artifacts from `CliRelay` can overwrite the newer frontend build with stale bundled assets.

## Verification
- go test ./deployment_workflow_test.go
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "yaml ok"'\n- git diff --check\n\nNot merged automatically: merging to `dev` would trigger the backend deploy workflow, so this PR is left for manual review/approval.