### PR TITLE
feat: enforce channel group model scopes

### DIFF
--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -19,13 +19,14 @@ type channelDescriptor struct {
 }
 
 type channelGroupItem struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Priority    int      `json:"priority,omitempty"`
-	Implicit    bool     `json:"implicit"`
-	Prefixes    []string `json:"prefixes,omitempty"`
-	Channels    []string `json:"channels,omitempty"`
-	PathRoutes  []string `json:"path-routes,omitempty"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description,omitempty"`
+	Priority      int      `json:"priority,omitempty"`
+	Implicit      bool     `json:"implicit"`
+	Prefixes      []string `json:"prefixes,omitempty"`
+	Channels      []string `json:"channels,omitempty"`
+	AllowedModels []string `json:"allowed-models,omitempty"`
+	PathRoutes    []string `json:"path-routes,omitempty"`
 }
 
 func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []channelDescriptor {
@@ -114,6 +115,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 		}
 		item.Description = group.Description
 		item.Priority = group.Priority
+		item.AllowedModels = append(item.AllowedModels, group.AllowedModels...)
 		item.Prefixes = append(item.Prefixes, group.Match.Prefixes...)
 		configuredChannelsByGroup[item.Name] = append(configuredChannelsByGroup[item.Name], group.Match.Channels...)
 	}

--- a/internal/config/routing_groups.go
+++ b/internal/config/routing_groups.go
@@ -19,6 +19,7 @@ type RoutingChannelGroup struct {
 	Match             ChannelGroupMatch `yaml:"match,omitempty" json:"match,omitempty"`
 	Priority          int               `yaml:"priority,omitempty" json:"priority,omitempty"`
 	ChannelPriorities map[string]int    `yaml:"channel-priorities,omitempty" json:"channel-priorities,omitempty"`
+	AllowedModels     []string          `yaml:"allowed-models,omitempty" json:"allowed-models,omitempty"`
 }
 
 // RoutingPathRoute maps a URL namespace path to a channel group.
@@ -98,6 +99,9 @@ func (cfg *Config) SanitizeRouting() {
 			return strings.TrimSpace(value)
 		})
 		group.ChannelPriorities = normalizeChannelPriorities(group.ChannelPriorities)
+		group.AllowedModels = normalizeStringList(group.AllowedModels, func(value string) string {
+			return strings.TrimSpace(value)
+		})
 		if group.Name == "" {
 			continue
 		}

--- a/sdk/cliproxy/auth/routing_groups.go
+++ b/sdk/cliproxy/auth/routing_groups.go
@@ -238,13 +238,16 @@ func candidateSupportsModel(cfg *internalconfig.Config, registryRef *registry.Mo
 	if auth == nil || modelID == "" {
 		return false
 	}
+	groups := authGroups(cfg, auth)
+	if !modelAllowedByRoutingGroupScopes(cfg, modelID, groups, routeGroup, allowedGroups) {
+		return false
+	}
 	if registryRef == nil {
 		return true
 	}
 	if registryRef.ClientSupportsModel(auth.ID, modelID) {
 		return true
 	}
-	groups := authGroups(cfg, auth)
 	if len(groups) == 0 {
 		return false
 	}
@@ -271,6 +274,71 @@ func candidateSupportsModel(cfg *internalconfig.Config, registryRef *registry.Mo
 			continue
 		}
 		if registryRef.ClientSupportsModel(auth.ID, group+"/"+modelID) {
+			return true
+		}
+	}
+	return false
+}
+
+func modelAllowedByRoutingGroupScopes(cfg *internalconfig.Config, modelID string, candidateGroups map[string]struct{}, routeGroup string, allowedGroups map[string]struct{}) bool {
+	modelID = strings.TrimSpace(modelID)
+	if cfg == nil || modelID == "" || len(candidateGroups) == 0 {
+		return true
+	}
+
+	scopedGroups := make(map[string]struct{})
+	if routeGroup != "" {
+		normalized := internalrouting.NormalizeGroupName(routeGroup)
+		if _, ok := candidateGroups[normalized]; ok {
+			scopedGroups[normalized] = struct{}{}
+		}
+	}
+	if len(allowedGroups) > 0 {
+		for group := range candidateGroups {
+			if _, ok := allowedGroups[group]; ok {
+				scopedGroups[group] = struct{}{}
+			}
+		}
+	}
+	if len(scopedGroups) == 0 {
+		return true
+	}
+
+	foundRestrictedGroup := false
+	for _, group := range cfg.Routing.ChannelGroups {
+		groupName := internalrouting.NormalizeGroupName(group.Name)
+		if _, ok := scopedGroups[groupName]; !ok {
+			continue
+		}
+		if len(group.AllowedModels) == 0 {
+			return true
+		}
+		foundRestrictedGroup = true
+		if routingGroupAllowsModel(groupName, group.AllowedModels, modelID) {
+			return true
+		}
+	}
+	return !foundRestrictedGroup
+}
+
+func routingGroupAllowsModel(groupName string, allowedModels []string, modelID string) bool {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return false
+	}
+	unprefixed := modelID
+	if groupName != "" {
+		prefix := groupName + "/"
+		if strings.HasPrefix(strings.ToLower(modelID), strings.ToLower(prefix)) {
+			unprefixed = modelID[len(prefix):]
+		}
+	}
+	for _, allowed := range allowedModels {
+		allowed = strings.TrimSpace(allowed)
+		if allowed == "" {
+			continue
+		}
+		if strings.EqualFold(allowed, modelID) || strings.EqualFold(allowed, unprefixed) {
 			return true
 		}
 	}

--- a/sdk/cliproxy/auth/routing_groups_test.go
+++ b/sdk/cliproxy/auth/routing_groups_test.go
@@ -55,6 +55,46 @@ func TestCanServeModelWithScopesSupportsAllowedGroupPrefixedModels(t *testing.T)
 	}
 }
 
+func TestCanServeModelWithScopesHonorsGroupAllowedModels(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.GetGlobalRegistry()
+	now := time.Now().Unix()
+	reg.RegisterClient("team-auth", "openai", []*registry.ModelInfo{
+		{ID: "team/gpt-5", Created: now},
+		{ID: "team/claude-opus", Created: now},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient("team-auth")
+	})
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{
+					Name:          "team",
+					AllowedModels: []string{"gpt-5"},
+				},
+			},
+		},
+	})
+	if _, err := manager.Register(context.Background(), &Auth{
+		ID:       "team-auth",
+		Provider: "openai",
+		Prefix:   "team",
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	if !manager.CanServeModelWithScopes("gpt-5", nil, nil, "team") {
+		t.Fatal("expected allowed model to be available through route group")
+	}
+	if manager.CanServeModelWithScopes("claude-opus", nil, nil, "team") {
+		t.Fatal("expected model outside routing group allowed-models to be unavailable")
+	}
+}
+
 func TestAuthGroupsMatchesLegacyOAuthEmailAfterRename(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add allowed-models to routing channel group config
- expose group model scopes in management channel group metadata
- enforce group model scopes during scoped routing/model availability checks

## Verification
- go test ./internal/config ./internal/usage ./internal/api/handlers/management ./sdk/cliproxy/auth
- go test ./...