### PR TITLE
fix: calculate cached token costs accurately

### DIFF
--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -149,6 +149,20 @@ func DeleteModelPricing(modelID string) error {
 	return nil
 }
 
+func calculateTokenCost(inputTokens, outputTokens, cachedTokens int64, inputPrice, outputPrice, cachedPrice float64) float64 {
+	billableInputTokens := inputTokens
+	if cachedTokens > 0 && inputTokens >= cachedTokens {
+		// OpenAI-compatible usage reports cached tokens as a subset of input tokens.
+		billableInputTokens = inputTokens - cachedTokens
+	}
+	if cachedPrice <= 0 {
+		cachedPrice = inputPrice
+	}
+	return float64(billableInputTokens)/1_000_000*inputPrice +
+		float64(outputTokens)/1_000_000*outputPrice +
+		float64(cachedTokens)/1_000_000*cachedPrice
+}
+
 // CalculateCost computes the cost for a request based on the model's pricing.
 // Returns 0 if no pricing is configured for the model.
 func CalculateCost(modelID string, inputTokens, outputTokens, cachedTokens int64) float64 {
@@ -161,9 +175,14 @@ func CalculateCost(modelID string, inputTokens, outputTokens, cachedTokens int64
 		if normalizePricingMode(row.PricingMode) == "call" {
 			return row.PricePerCall
 		}
-		return float64(inputTokens)/1_000_000*row.InputPricePerMillion +
-			float64(outputTokens)/1_000_000*row.OutputPricePerMillion +
-			float64(cachedTokens)/1_000_000*row.CachedPricePerMillion
+		return calculateTokenCost(
+			inputTokens,
+			outputTokens,
+			cachedTokens,
+			row.InputPricePerMillion,
+			row.OutputPricePerMillion,
+			row.CachedPricePerMillion,
+		)
 	}
 	modelConfigCacheMu.RUnlock()
 
@@ -173,10 +192,14 @@ func CalculateCost(modelID string, inputTokens, outputTokens, cachedTokens int64
 	if !ok {
 		return 0
 	}
-	cost := float64(inputTokens)/1_000_000*row.InputPricePerMillion +
-		float64(outputTokens)/1_000_000*row.OutputPricePerMillion +
-		float64(cachedTokens)/1_000_000*row.CachedPricePerMillion
-	return cost
+	return calculateTokenCost(
+		inputTokens,
+		outputTokens,
+		cachedTokens,
+		row.InputPricePerMillion,
+		row.OutputPricePerMillion,
+		row.CachedPricePerMillion,
+	)
 }
 
 // QueryTotalCostByKey returns the total accumulated cost for a given API key.

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -1,0 +1,65 @@
+package usage
+
+import "testing"
+
+func TestCalculateCostDiscountsCachedInputSubset(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "cache-aware-model",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  10,
+		OutputPricePerMillion: 20,
+		CachedPricePerMillion: 1,
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	cost := CalculateCost("cache-aware-model", 1000, 500, 800)
+	want := (float64(200)*10 + float64(500)*20 + float64(800)*1) / 1_000_000
+	if cost != want {
+		t.Fatalf("cost = %.10f, want %.10f", cost, want)
+	}
+}
+
+func TestCalculateCostKeepsSeparateCacheTokensFromInput(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "separate-cache-model",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  3,
+		OutputPricePerMillion: 15,
+		CachedPricePerMillion: 0.3,
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	cost := CalculateCost("separate-cache-model", 21, 393, 188086)
+	want := (float64(21)*3 + float64(393)*15 + float64(188086)*0.3) / 1_000_000
+	if cost != want {
+		t.Fatalf("cost = %.10f, want %.10f", cost, want)
+	}
+}
+
+func TestCalculateCostFallsBackToInputPriceWhenCachedPriceMissing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "missing-cache-price-model",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  10,
+		OutputPricePerMillion: 20,
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	cost := CalculateCost("missing-cache-price-model", 1000, 500, 800)
+	want := (float64(1000)*10 + float64(500)*20) / 1_000_000
+	if cost != want {
+		t.Fatalf("cost = %.10f, want %.10f", cost, want)
+	}
+}


### PR DESCRIPTION
## Summary
- subtract cached input tokens from billable input when cached tokens are reported as an input subset
- fall back to input pricing when cached pricing is missing
- add regression tests for cached input subset, separate cache tokens, and missing cached price

## Tests
- go test ./...
