### PR TITLE
fix: preserve logged channel names

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -58,7 +58,20 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 		}
 	}
 	var authIndexes []string
+	var channelNames []string
 	if len(selectedChannelKeys) > 0 {
+		for key := range selectedChannelKeys {
+			channelNames = append(channelNames, key)
+		}
+		for raw, name := range channelNameMap {
+			key := strings.ToLower(strings.TrimSpace(name))
+			if key == "" {
+				continue
+			}
+			if _, ok := selectedChannelKeys[key]; ok {
+				channelNames = append(channelNames, raw)
+			}
+		}
 		for idx, name := range authIndexChannelMap {
 			key := strings.ToLower(strings.TrimSpace(name))
 			if key == "" {
@@ -69,19 +82,20 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 			}
 		}
 		// No matches should yield an empty result set rather than "no filter".
-		if len(authIndexes) == 0 {
+		if len(authIndexes) == 0 && len(channelNames) == 0 {
 			authIndexes = []string{""}
 		}
 	}
 
 	params := usage.LogQueryParams{
-		Page:        intQueryDefault(c, "page", 1),
-		Size:        intQueryDefault(c, "size", 50),
-		Days:        intQueryDefault(c, "days", 7),
-		APIKey:      strings.TrimSpace(c.Query("api_key")),
-		Model:       strings.TrimSpace(c.Query("model")),
-		Status:      strings.TrimSpace(c.Query("status")),
-		AuthIndexes: authIndexes,
+		Page:         intQueryDefault(c, "page", 1),
+		Size:         intQueryDefault(c, "size", 50),
+		Days:         intQueryDefault(c, "days", 7),
+		APIKey:       strings.TrimSpace(c.Query("api_key")),
+		Model:        strings.TrimSpace(c.Query("model")),
+		Status:       strings.TrimSpace(c.Query("status")),
+		AuthIndexes:  authIndexes,
+		ChannelNames: channelNames,
 	}
 
 	result, err := usage.QueryLogs(params)
@@ -110,17 +124,20 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 				item.APIKeyName = name
 			}
 		}
-		// Prefer the current auth-index derived channel name so renamed OAuth
-		// channels are reflected in logs immediately without rewriting history.
+		// Keep the channel captured at request time. Only translate legacy
+		// source identifiers (email/API key) into display names.
+		if item.ChannelName != "" {
+			if name, ok := channelNameMap[item.ChannelName]; ok && strings.TrimSpace(name) != "" {
+				item.ChannelName = name
+			}
+			continue
+		}
 		if name, ok := authIndexChannelMap[item.AuthIndex]; ok && strings.TrimSpace(name) != "" {
 			item.ChannelName = name
 			continue
 		}
-		// Fall back to source-based mapping when the stored log channel is empty.
-		if item.ChannelName == "" {
-			if name, ok := channelNameMap[item.Source]; ok {
-				item.ChannelName = name
-			}
+		if name, ok := channelNameMap[item.Source]; ok {
+			item.ChannelName = name
 		}
 	}
 
@@ -131,12 +148,14 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 			filters.APIKeyNames[key] = name
 		}
 	}
-	// Add channel filter options from current auth snapshot.
-	if len(authIndexChannelMap) > 0 {
+	if len(filters.Channels) > 0 {
 		seen := make(map[string]struct{})
-		channels := make([]string, 0, len(authIndexChannelMap))
-		for _, name := range authIndexChannelMap {
-			trimmed := strings.TrimSpace(name)
+		channels := make([]string, 0, len(filters.Channels))
+		for _, value := range filters.Channels {
+			trimmed := strings.TrimSpace(value)
+			if name, ok := channelNameMap[trimmed]; ok && strings.TrimSpace(name) != "" {
+				trimmed = strings.TrimSpace(name)
+			}
 			key := strings.ToLower(trimmed)
 			if key == "" {
 				continue

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -19,7 +19,7 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
-func TestGetUsageLogsPrefersCurrentAuthChannelNameByAuthIndex(t *testing.T) {
+func TestGetUsageLogsResolvesLegacySourceChannelName(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tmpDir := t.TempDir()
@@ -93,6 +93,106 @@ func TestGetUsageLogsPrefersCurrentAuthChannelNameByAuthIndex(t *testing.T) {
 	}
 	if payload.Items[0].FirstTokenMs != 45 {
 		t.Fatalf("first_token_ms = %d, want %d", payload.Items[0].FirstTokenMs, 45)
+	}
+}
+
+func TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "tabcode-auth",
+		FileName: "tabcode.json",
+		Provider: "codex",
+		Label:    "tabcode-pro",
+		Metadata: map[string]any{"label": "tabcode-pro"},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	usage.InsertLog(
+		"", "", "gpt-5.4", "tabcode-plus", "tabcode-plus", auth.Index,
+		false, time.Now().UTC(), 123, 45,
+		usage.TokenStats{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+		"", "",
+	)
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50", nil)
+
+	h.GetUsageLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Items []struct {
+			ChannelName string `json:"channel_name"`
+		} `json:"items"`
+		Filters struct {
+			Channels []string `json:"channels"`
+		} `json:"filters"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(payload.Items))
+	}
+	if payload.Items[0].ChannelName != "tabcode-plus" {
+		t.Fatalf("channel_name = %q, want %q", payload.Items[0].ChannelName, "tabcode-plus")
+	}
+	if len(payload.Filters.Channels) != 1 || payload.Filters.Channels[0] != "tabcode-plus" {
+		t.Fatalf("filters.channels = %#v, want [tabcode-plus]", payload.Filters.Channels)
+	}
+
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50&channel=tabcode-plus", nil)
+	h.GetUsageLogs(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("filtered expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal filtered response: %v", err)
+	}
+	if len(payload.Items) != 1 || payload.Items[0].ChannelName != "tabcode-plus" {
+		t.Fatalf("filtered items = %#v, want one tabcode-plus item", payload.Items)
+	}
+
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50&channel=tabcode-pro", nil)
+	h.GetUsageLogs(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mismatched filtered expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal mismatched filtered response: %v", err)
+	}
+	if len(payload.Items) != 0 {
+		t.Fatalf("mismatched filtered items = %#v, want none", payload.Items)
 	}
 }
 

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -38,13 +38,14 @@ type LogRow struct {
 
 // LogQueryParams holds filter/pagination parameters for QueryLogs.
 type LogQueryParams struct {
-	Page        int      // 1-based
-	Size        int      // rows per page
-	Days        int      // time range in days
-	APIKey      string   // exact match filter
-	Model       string   // exact match filter
-	Status      string   // "success", "failed", or "" (all)
-	AuthIndexes []string // optional auth_index IN (...) filter
+	Page         int      // 1-based
+	Size         int      // rows per page
+	Days         int      // time range in days
+	APIKey       string   // exact match filter
+	Model        string   // exact match filter
+	Status       string   // "success", "failed", or "" (all)
+	AuthIndexes  []string // optional auth_index IN (...) filter
+	ChannelNames []string // optional channel_name IN (...) filter
 }
 
 // LogQueryResult holds the paginated query result.
@@ -538,12 +539,16 @@ func QueryFilters(days int) (FilterOptions, error) {
 	if err != nil {
 		return FilterOptions{}, err
 	}
+	channels, err := queryDistinct(db, "channel_name", cutoff)
+	if err != nil {
+		return FilterOptions{}, err
+	}
 
 	return FilterOptions{
 		APIKeys:     keys,
 		APIKeyNames: make(map[string]string),
 		Models:      models,
-		Channels:    make([]string, 0),
+		Channels:    channels,
 	}, nil
 }
 
@@ -1045,20 +1050,39 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 	} else if params.Status == "failed" {
 		conditions = append(conditions, "failed = 1")
 	}
-	if len(params.AuthIndexes) > 0 {
-		placeholders := make([]string, 0, len(params.AuthIndexes))
+	if len(params.AuthIndexes) > 0 || len(params.ChannelNames) > 0 {
+		filterConditions := make([]string, 0, 2)
+
+		authPlaceholders := make([]string, 0, len(params.AuthIndexes))
 		for _, idx := range params.AuthIndexes {
 			trimmed := strings.TrimSpace(idx)
 			if trimmed == "" {
 				continue
 			}
-			placeholders = append(placeholders, "?")
+			authPlaceholders = append(authPlaceholders, "?")
 			args = append(args, trimmed)
 		}
-		if len(placeholders) > 0 {
-			conditions = append(conditions, "auth_index IN ("+strings.Join(placeholders, ",")+")")
+		if len(authPlaceholders) > 0 {
+			filterConditions = append(filterConditions, "(auth_index IN ("+strings.Join(authPlaceholders, ",")+") AND trim(coalesce(channel_name, '')) = '')")
+		}
+
+		channelPlaceholders := make([]string, 0, len(params.ChannelNames))
+		for _, name := range params.ChannelNames {
+			trimmed := strings.ToLower(strings.TrimSpace(name))
+			if trimmed == "" {
+				continue
+			}
+			channelPlaceholders = append(channelPlaceholders, "?")
+			args = append(args, trimmed)
+		}
+		if len(channelPlaceholders) > 0 {
+			filterConditions = append(filterConditions, "lower(trim(channel_name)) IN ("+strings.Join(channelPlaceholders, ",")+")")
+		}
+
+		if len(filterConditions) > 0 {
+			conditions = append(conditions, "("+strings.Join(filterConditions, " OR ")+")")
 		} else {
-			// If caller attempted to filter but provided no usable auth indexes, match nothing.
+			// If caller attempted to filter but provided no usable channel selectors, match nothing.
 			conditions = append(conditions, "1 = 0")
 		}
 	}


### PR DESCRIPTION
## Summary
- keep stored request log channel names instead of overwriting them from the current auth snapshot
- derive channel filter options from logged channel names
- support channel filtering by stored channel names while preserving legacy empty-channel fallback

## Tests
- go test ./internal/api/handlers/management -run 'TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers|TestGetUsageLogsResolvesLegacySourceChannelName|TestGetUsageLogs_EmptyDB_DoesNotReturnNullSlices' -count=1
- go test ./internal/usage -count=1
- go test ./internal/api/handlers/management -run 'TestGetUsageLogs|TestGetPublicUsageLogs|TestGetLogContent|TestGetPublicLogContent' -count=1
- git diff --check

Full go test ./... still has the pre-existing unrelated failure: internal/api/handlers/management TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal returns request_total=1, want 3.