### PR TITLE
fix: record forwarded client IP in request details

### DIFF
--- a/internal/runtime/executor/usage_helpers.go
+++ b/internal/runtime/executor/usage_helpers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -363,10 +364,12 @@ func buildRequestDetailContent(ctx context.Context) string {
 	req := ginCtx.Request
 	apiRequest, _ := ginCtx.Get(apiRequestKey)
 	apiResponse, _ := ginCtx.Get(apiResponseKey)
+	clientIP, clientIPSource := requestLogClientIP(ginCtx, req)
 
 	detail := map[string]any{
 		"client": map[string]any{
-			"ip":                  ginCtx.ClientIP(),
+			"ip":                  clientIP,
+			"ip_source":           clientIPSource,
 			"remote_addr":         req.RemoteAddr,
 			"method":              req.Method,
 			"url":                 req.URL.String(),
@@ -390,6 +393,103 @@ func buildRequestDetailContent(ctx context.Context) string {
 		return ""
 	}
 	return string(data)
+}
+
+func requestLogClientIP(ginCtx *gin.Context, req *http.Request) (string, string) {
+	if ip, source := forwardedClientIP(req); ip != "" {
+		return ip, source
+	}
+	if ginCtx != nil {
+		if ip := strings.TrimSpace(ginCtx.ClientIP()); ip != "" {
+			return ip, "client_ip"
+		}
+	}
+	if req != nil {
+		if ip := remoteAddrIP(req.RemoteAddr); ip != "" {
+			return ip, "remote_addr"
+		}
+	}
+	return "", ""
+}
+
+func forwardedClientIP(req *http.Request) (string, string) {
+	if req == nil || req.Header == nil {
+		return "", ""
+	}
+	headerPriority := []string{
+		"CF-Connecting-IP",
+		"True-Client-IP",
+		"X-Real-IP",
+		"X-Forwarded-For",
+	}
+	for _, header := range headerPriority {
+		if ip := firstHeaderIP(req.Header, header); ip != "" {
+			return ip, header
+		}
+	}
+	if ip := forwardedHeaderIP(req.Header); ip != "" {
+		return ip, "Forwarded"
+	}
+	return "", ""
+}
+
+func firstHeaderIP(headers http.Header, header string) string {
+	for _, value := range headers.Values(header) {
+		for _, candidate := range strings.Split(value, ",") {
+			if ip := normalizeIPCandidate(candidate); ip != "" {
+				return ip
+			}
+		}
+	}
+	return ""
+}
+
+func forwardedHeaderIP(headers http.Header) string {
+	for _, value := range headers.Values("Forwarded") {
+		for _, entry := range strings.Split(value, ",") {
+			for _, part := range strings.Split(entry, ";") {
+				key, rawValue, ok := strings.Cut(part, "=")
+				if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {
+					continue
+				}
+				if ip := normalizeIPCandidate(rawValue); ip != "" {
+					return ip
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func remoteAddrIP(remoteAddr string) string {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if remoteAddr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return normalizeIPCandidate(host)
+	}
+	return normalizeIPCandidate(remoteAddr)
+}
+
+func normalizeIPCandidate(candidate string) string {
+	candidate = strings.TrimSpace(candidate)
+	candidate = strings.Trim(candidate, `"`)
+	if candidate == "" || strings.EqualFold(candidate, "unknown") {
+		return ""
+	}
+	if strings.HasPrefix(candidate, "[") {
+		if end := strings.Index(candidate, "]"); end > 0 {
+			candidate = candidate[1:end]
+		}
+	} else if host, _, err := net.SplitHostPort(candidate); err == nil {
+		candidate = host
+	}
+	ip := net.ParseIP(strings.TrimSpace(candidate))
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
 }
 
 func bytesToString(value any) string {

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -154,6 +154,35 @@ func TestRequestDetailsCaptureUpstreamLogsWhenOnlyContentStorageEnabled(t *testi
 	}
 }
 
+func TestRequestDetailsPreferForwardedClientIPForCDNRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, engine := gin.CreateTestContext(httptest.NewRecorder())
+	if err := engine.SetTrustedProxies(nil); err != nil {
+		t.Fatalf("SetTrustedProxies(nil): %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"input":"hi"}`))
+	req.RemoteAddr = "198.51.100.10:45678"
+	req.Header.Set("X-Forwarded-For", "203.0.113.24, 198.51.100.10")
+	ginCtx.Request = req
+	ctx := context.WithValue(req.Context(), util.ContextKeyGin, ginCtx)
+
+	var detail struct {
+		Client struct {
+			IP         string `json:"ip"`
+			RemoteAddr string `json:"remote_addr"`
+		} `json:"client"`
+	}
+	if err := json.Unmarshal([]byte(buildRequestDetailContent(ctx)), &detail); err != nil {
+		t.Fatalf("unmarshal request details: %v", err)
+	}
+	if detail.Client.IP != "203.0.113.24" {
+		t.Fatalf("client.ip = %q, want real forwarded client IP", detail.Client.IP)
+	}
+	if detail.Client.RemoteAddr != "198.51.100.10:45678" {
+		t.Fatalf("client.remote_addr = %q, want CDN connection address preserved", detail.Client.RemoteAddr)
+	}
+}
+
 func TestFirstTokenLatencyMsFromContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ginCtx, _ := gin.CreateTestContext(nil)


### PR DESCRIPTION
## Summary
- Resolve request log detail client IP from CDN/proxy headers before falling back to Gin ClientIP/RemoteAddr.
- Preserve the actual connection address in client.remote_addr and record client.ip_source for audit clarity.
- Add regression coverage for CDN-style X-Forwarded-For with trusted proxies disabled.

Fixes #69

## Test Plan
- PASS: go test ./internal/runtime/executor -count=1
- PASS: go test ./internal/api -run TestManagementRemoteRestrictionIgnoresForgedForwardedFor -count=1
- PASS: go test ./...