### PR TITLE
test: make auth file trend cycle test date relative

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -474,7 +474,7 @@ func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 		t.Fatalf("register auth: %v", err)
 	}
 
-	now := time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC)
+	now := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
 	resetAt := now.Add(4 * 24 * time.Hour)
 	cycleStart := resetAt.Add(-7 * 24 * time.Hour)
 


### PR DESCRIPTION
## Summary
- Make the auth-file weekly reset cycle test use a current relative timestamp instead of a fixed April 2026 date.
- Keeps the same cycle assertions while avoiding failures once the fixed date falls outside the default 7-day trend window.

## Test Plan
- PASS: go test ./internal/api/handlers/management -run TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal -count=1
- PASS: go test ./...