### PR TITLE
fix(management): allow empty channel groups in validation

### DIFF
--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -246,7 +246,6 @@ func validateRoutingAndAPIKeyRestrictions(cfg *config.Config, auths []*coreauth.
 	apiKeyEntries := canonicalizeAPIKeyEntriesChannels(cfg.APIKeyEntries, known)
 
 	groups := buildChannelGroupItems(cfg, auths)
-	descriptors := collectChannelDescriptors(cfg, auths)
 	knownGroups := make(map[string]channelGroupItem, len(groups))
 	for _, group := range groups {
 		knownGroups[group.Name] = group
@@ -262,7 +261,7 @@ func validateRoutingAndAPIKeyRestrictions(cfg *config.Config, auths []*coreauth.
 			return fmt.Errorf("duplicate channel group %q", group.Name)
 		}
 		seenGroupNames[name] = struct{}{}
-		if _, exists := knownGroups[name]; !exists || (name != "default" && !channelGroupMatchesAnyDescriptor(group, descriptors)) {
+		if _, exists := knownGroups[name]; !exists {
 			return fmt.Errorf("channel group %q does not match any known channel", group.Name)
 		}
 	}

--- a/internal/api/handlers/management/channel_groups_test.go
+++ b/internal/api/handlers/management/channel_groups_test.go
@@ -136,14 +136,14 @@ func TestValidateRoutingAndAPIKeyRestrictions(t *testing.T) {
 			wantMessage: `duplicate channel group "PRO"`,
 		},
 		{
-			name: "group must match known channel",
+			name: "empty group is allowed",
 			mutate: func(cfg *config.Config) {
 				cfg.Routing.ChannelGroups = append(cfg.Routing.ChannelGroups, config.RoutingChannelGroup{
 					Name:  "ghost",
 					Match: config.ChannelGroupMatch{Prefixes: []string{"ghost"}},
 				})
 			},
-			wantMessage: `channel group "ghost" does not match any known channel`,
+			wantMessage: "",
 		},
 		{
 			name: "duplicate path routes are rejected",
@@ -198,6 +198,12 @@ func TestValidateRoutingAndAPIKeyRestrictions(t *testing.T) {
 			tc.mutate(cfg)
 
 			err := validateRoutingAndAPIKeyRestrictions(cfg, nil)
+			if tc.wantMessage == "" {
+				if err != nil {
+					t.Fatalf("expected no validation error, got: %v", err)
+				}
+				return
+			}
 			if err == nil {
 				t.Fatalf("expected validation error containing %q", tc.wantMessage)
 			}


### PR DESCRIPTION
## 修复内容

移除 `validateRoutingAndAPIKeyRestrictions` 中对 `channelGroupMatchesAnyDescriptor` 的强制检查，允许引用已删除/禁用渠道的空渠道分组存在。

## 问题描述

当某个渠道分组的所有关联渠道被删除后，该分组变成"空"的，但验证函数会拒绝任何涉及路由配置的保存操作，导致：
- 渠道分组页面任何操作都报错
- API Keys 页面保存失败
- YAML 配置保存失败

## 修复后行为

- 空分组不再触发验证错误
- 前端已优雅处理异常状态显示（\"异常 N个已删除渠道\"标签）
- 其他验证（重复分组名、路径路由引用、API Key 引用）仍然有效

## 修改文件

| 文件 | 改动 |
|------|------|
| `internal/api/handlers/management/channel_groups.go` | 移除 `channelGroupMatchesAnyDescriptor` 强制检查 |
| `internal/api/handlers/management/channel_groups_test.go` | 更新测试用例反映新行为 |