### PR TITLE
feat: persist auth file tags

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -691,6 +691,11 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 			entry["account"] = account
 		}
 	}
+	tags := buildAuthTagPayload(auth)
+	entry["default_tags"] = tags.DefaultTags
+	entry["custom_tags"] = tags.CustomTags
+	entry["hidden_default_tags"] = tags.HiddenDefaultTags
+	entry["display_tags"] = tags.DisplayTags
 	addSubscriptionFields(entry, auth.Metadata, time.Now())
 	if !auth.CreatedAt.IsZero() {
 		entry["created_at"] = auth.CreatedAt
@@ -1160,15 +1165,17 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	}
 
 	var req struct {
-		Name                  string  `json:"name"`
-		Label                 *string `json:"label"`
-		Prefix                *string `json:"prefix"`
-		ProxyURL              *string `json:"proxy_url"`
-		ProxyID               *string `json:"proxy_id"`
-		Priority              *int    `json:"priority"`
-		SubscriptionStartedAt *string `json:"subscription_started_at"`
-		SubscriptionPeriod    *string `json:"subscription_period"`
-		SubscriptionExpiresAt *string `json:"subscription_expires_at"`
+		Name                  string    `json:"name"`
+		Label                 *string   `json:"label"`
+		CustomTags            *[]string `json:"custom_tags"`
+		HiddenDefaultTags     *[]string `json:"hidden_default_tags"`
+		Prefix                *string   `json:"prefix"`
+		ProxyURL              *string   `json:"proxy_url"`
+		ProxyID               *string   `json:"proxy_id"`
+		Priority              *int      `json:"priority"`
+		SubscriptionStartedAt *string   `json:"subscription_started_at"`
+		SubscriptionPeriod    *string   `json:"subscription_period"`
+		SubscriptionExpiresAt *string   `json:"subscription_expires_at"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -1238,6 +1245,34 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			delete(targetAuth.Metadata, "prefix")
 		} else {
 			targetAuth.Metadata["prefix"] = targetAuth.Prefix
+		}
+		changed = true
+	}
+	if req.CustomTags != nil {
+		tags, errNormalize := normalizeEditableTags(*req.CustomTags, maxCustomAuthTags)
+		if errNormalize != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": errNormalize.Error()})
+			return
+		}
+		if targetAuth.Metadata == nil {
+			targetAuth.Metadata = make(map[string]any)
+		}
+		if len(tags) == 0 {
+			delete(targetAuth.Metadata, "custom_tags")
+		} else {
+			targetAuth.Metadata["custom_tags"] = tags
+		}
+		changed = true
+	}
+	if req.HiddenDefaultTags != nil {
+		tags := normalizeTagList(*req.HiddenDefaultTags)
+		if targetAuth.Metadata == nil {
+			targetAuth.Metadata = make(map[string]any)
+		}
+		if len(tags) == 0 {
+			delete(targetAuth.Metadata, "hidden_default_tags")
+		} else {
+			targetAuth.Metadata["hidden_default_tags"] = tags
 		}
 		changed = true
 	}

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -94,6 +94,147 @@ func TestPatchAuthFileFieldsUpdatesOAuthChannelLabel(t *testing.T) {
 	}
 }
 
+func TestPatchAuthFileFieldsUpdatesCustomTagsAndHiddenDefaultTags(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	_, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "oauth-auth-tags",
+		FileName: "oauth-auth-tags.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"email":     "tags@example.com",
+			"plan_type": "pro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"name":                "oauth-auth-tags.json",
+		"custom_tags":         []string{" Team ", "priority", "team"},
+		"hidden_default_tags": []string{"pro", " codex "},
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/auth-files/fields", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchAuthFileFields(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("oauth-auth-tags")
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	customTags, ok := updated.Metadata["custom_tags"].([]string)
+	if !ok {
+		t.Fatalf("custom_tags type = %T, want []string", updated.Metadata["custom_tags"])
+	}
+	if len(customTags) != 2 || customTags[0] != "team" || customTags[1] != "priority" {
+		t.Fatalf("custom_tags = %#v, want [team priority]", customTags)
+	}
+	hiddenTags, ok := updated.Metadata["hidden_default_tags"].([]string)
+	if !ok {
+		t.Fatalf("hidden_default_tags type = %T, want []string", updated.Metadata["hidden_default_tags"])
+	}
+	if len(hiddenTags) != 2 || hiddenTags[0] != "pro" || hiddenTags[1] != "codex" {
+		t.Fatalf("hidden_default_tags = %#v, want [pro codex]", hiddenTags)
+	}
+}
+
+func TestPatchAuthFileFieldsRejectsMoreThanThreeCustomTags(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	_, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "oauth-auth-too-many-tags",
+		FileName: "oauth-auth-too-many-tags.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"email": "tags@example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"name":        "oauth-auth-too-many-tags.json",
+		"custom_tags": []string{"one", "two", "three", "four"},
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/auth-files/fields", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchAuthFileFields(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+}
+
+func TestBuildAuthFileEntryIncludesDefaultAndDisplayTags(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-tagged-auth",
+		FileName: "codex-tagged-auth.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "codex-tagged-auth.json",
+		},
+		Metadata: map[string]any{
+			"email":               "tagged@example.com",
+			"plan_type":           "pro",
+			"custom_tags":         []string{"team-a"},
+			"hidden_default_tags": []string{"pro"},
+		},
+	}
+
+	entry := (&Handler{}).buildAuthFileEntry(auth)
+	if entry == nil {
+		t.Fatal("expected auth file entry")
+	}
+	defaultTags, ok := entry["default_tags"].([]string)
+	if !ok {
+		t.Fatalf("default_tags type = %T, want []string", entry["default_tags"])
+	}
+	if len(defaultTags) != 2 || defaultTags[0] != "codex" || defaultTags[1] != "pro" {
+		t.Fatalf("default_tags = %#v, want [codex pro]", defaultTags)
+	}
+	displayTags, ok := entry["display_tags"].([]string)
+	if !ok {
+		t.Fatalf("display_tags type = %T, want []string", entry["display_tags"])
+	}
+	if len(displayTags) != 2 || displayTags[0] != "codex" || displayTags[1] != "team-a" {
+		t.Fatalf("display_tags = %#v, want [codex team-a]", displayTags)
+	}
+}
+
 func TestBuildAuthFileEntryIncludesSubscriptionExpiration(t *testing.T) {
 	expiresAt := time.Now().UTC().Add(90 * time.Minute).Truncate(time.Minute)
 	auth := &coreauth.Auth{

--- a/internal/api/handlers/management/auth_tags.go
+++ b/internal/api/handlers/management/auth_tags.go
@@ -1,0 +1,223 @@
+package management
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const maxCustomAuthTags = 3
+
+type authTagPayload struct {
+	DefaultTags       []string
+	CustomTags        []string
+	HiddenDefaultTags []string
+	DisplayTags       []string
+}
+
+func buildAuthTagPayload(auth *coreauth.Auth) authTagPayload {
+	if auth == nil {
+		return authTagPayload{
+			DefaultTags:       []string{},
+			CustomTags:        []string{},
+			HiddenDefaultTags: []string{},
+			DisplayTags:       []string{},
+		}
+	}
+	return buildAuthTagPayloadFromValues(strings.TrimSpace(auth.Provider), auth.Metadata)
+}
+
+func buildAuthTagPayloadFromValues(provider string, metadata map[string]any) authTagPayload {
+	defaultTags := defaultAuthTags(provider, metadata)
+	customTags := metadataStringSlice(metadata, "custom_tags")
+	hiddenDefaultTags := metadataStringSlice(metadata, "hidden_default_tags")
+	hiddenSet := make(map[string]struct{}, len(hiddenDefaultTags))
+	for _, tag := range hiddenDefaultTags {
+		hiddenSet[tag] = struct{}{}
+	}
+
+	displayTags := make([]string, 0, len(defaultTags)+len(customTags))
+	for _, tag := range defaultTags {
+		if _, hidden := hiddenSet[tag]; hidden {
+			continue
+		}
+		displayTags = append(displayTags, tag)
+	}
+	for _, tag := range customTags {
+		if _, exists := hiddenSet[tag]; exists {
+			continue
+		}
+		if containsNormalizedTag(displayTags, tag) {
+			continue
+		}
+		displayTags = append(displayTags, tag)
+	}
+
+	return authTagPayload{
+		DefaultTags:       append([]string{}, defaultTags...),
+		CustomTags:        append([]string{}, customTags...),
+		HiddenDefaultTags: append([]string{}, hiddenDefaultTags...),
+		DisplayTags:       append([]string{}, displayTags...),
+	}
+}
+
+func defaultAuthTags(provider string, metadata map[string]any) []string {
+	tags := make([]string, 0, 2)
+	if normalizedProvider := normalizeTagValue(provider); normalizedProvider != "" && normalizedProvider != "unknown" {
+		tags = append(tags, normalizedProvider)
+	}
+	if metadata != nil {
+		if planType := normalizeTagValue(metadataString(metadata, "plan_type", "planType")); planType != "" {
+			if !containsNormalizedTag(tags, planType) {
+				tags = append(tags, planType)
+			}
+		}
+	}
+	return tags
+}
+
+func normalizeEditableTags(values []string, max int) ([]string, error) {
+	normalized := normalizeTagList(values)
+	if max > 0 && len(normalized) > max {
+		return nil, fmt.Errorf("custom_tags supports at most %d items", max)
+	}
+	return normalized, nil
+}
+
+func normalizeTagList(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		tag := normalizeTagValue(value)
+		if tag == "" {
+			continue
+		}
+		if _, exists := seen[tag]; exists {
+			continue
+		}
+		seen[tag] = struct{}{}
+		out = append(out, tag)
+	}
+	return out
+}
+
+func normalizeTagValue(value string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	if trimmed == "" {
+		return ""
+	}
+	return strings.Join(strings.Fields(trimmed), "-")
+}
+
+func containsNormalizedTag(values []string, target string) bool {
+	normalizedTarget := normalizeTagValue(target)
+	for _, value := range values {
+		if normalizeTagValue(value) == normalizedTarget {
+			return true
+		}
+	}
+	return false
+}
+
+func metadataStringSlice(metadata map[string]any, key string) []string {
+	if len(metadata) == 0 {
+		return []string{}
+	}
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return []string{}
+	}
+	switch typed := raw.(type) {
+	case []string:
+		return normalizeTagList(typed)
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text, ok := item.(string); ok {
+				values = append(values, text)
+			}
+		}
+		return normalizeTagList(values)
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return []string{}
+		}
+		return normalizeTagList(strings.Split(typed, ","))
+	default:
+		return []string{}
+	}
+}
+
+func metadataString(metadata map[string]any, keys ...string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		if raw, ok := metadata[key].(string); ok {
+			if trimmed := strings.TrimSpace(raw); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+type channelGroupChannelDetail struct {
+	Name              string   `json:"name"`
+	Source            string   `json:"source,omitempty"`
+	DefaultTags       []string `json:"default_tags"`
+	CustomTags        []string `json:"custom_tags"`
+	HiddenDefaultTags []string `json:"hidden_default_tags"`
+	DisplayTags       []string `json:"display_tags"`
+}
+
+func uniqueSortedChannelDetails(values []channelGroupChannelDetail) []channelGroupChannelDetail {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]channelGroupChannelDetail, len(values))
+	for _, value := range values {
+		name := strings.TrimSpace(value.Name)
+		if name == "" {
+			continue
+		}
+		value.Name = name
+		if value.DefaultTags == nil {
+			value.DefaultTags = []string{}
+		}
+		if value.CustomTags == nil {
+			value.CustomTags = []string{}
+		}
+		if value.HiddenDefaultTags == nil {
+			value.HiddenDefaultTags = []string{}
+		}
+		if value.DisplayTags == nil {
+			value.DisplayTags = []string{}
+		}
+		key := strings.ToLower(name)
+		existing, ok := seen[key]
+		if !ok || tagPayloadScore(value) >= tagPayloadScore(existing) {
+			seen[key] = value
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]channelGroupChannelDetail, 0, len(seen))
+	for _, value := range seen {
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out
+}
+
+func tagPayloadScore(value channelGroupChannelDetail) int {
+	return len(value.DisplayTags)*100 + len(value.DefaultTags)*10 + len(value.CustomTags)
+}

--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -13,48 +13,61 @@ import (
 )
 
 type channelDescriptor struct {
-	Name   string
-	Prefix string
-	Source string
+	Name              string
+	Prefix            string
+	Source            string
+	DefaultTags       []string
+	CustomTags        []string
+	HiddenDefaultTags []string
+	DisplayTags       []string
 }
 
 type channelGroupItem struct {
-	Name          string   `json:"name"`
-	Description   string   `json:"description,omitempty"`
-	Priority      int      `json:"priority,omitempty"`
-	Implicit      bool     `json:"implicit"`
-	Prefixes      []string `json:"prefixes,omitempty"`
-	Channels      []string `json:"channels,omitempty"`
-	AllowedModels []string `json:"allowed-models,omitempty"`
-	PathRoutes    []string `json:"path-routes,omitempty"`
+	Name           string                      `json:"name"`
+	Description    string                      `json:"description,omitempty"`
+	Priority       int                         `json:"priority,omitempty"`
+	Implicit       bool                        `json:"implicit"`
+	Prefixes       []string                    `json:"prefixes,omitempty"`
+	Channels       []string                    `json:"channels,omitempty"`
+	ChannelDetails []channelGroupChannelDetail `json:"channel-details,omitempty"`
+	AllowedModels  []string                    `json:"allowed-models,omitempty"`
+	PathRoutes     []string                    `json:"path-routes,omitempty"`
 }
 
 func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []channelDescriptor {
 	items := make([]channelDescriptor, 0)
-	push := func(name, prefix, source string) {
+	push := func(name, prefix, source string, tags authTagPayload) {
 		name = strings.TrimSpace(name)
 		prefix = internalrouting.NormalizeGroupName(prefix)
 		if name == "" && prefix == "" {
 			return
 		}
-		items = append(items, channelDescriptor{Name: name, Prefix: prefix, Source: source})
+		items = append(items, channelDescriptor{
+			Name:              name,
+			Prefix:            prefix,
+			Source:            source,
+			DefaultTags:       append([]string{}, tags.DefaultTags...),
+			CustomTags:        append([]string{}, tags.CustomTags...),
+			HiddenDefaultTags: append([]string{}, tags.HiddenDefaultTags...),
+			DisplayTags:       append([]string{}, tags.DisplayTags...),
+		})
 	}
 
 	if cfg != nil {
 		for _, entry := range cfg.GeminiKey {
-			push(entry.Name, entry.Prefix, "gemini")
+			push(entry.Name, entry.Prefix, "gemini", buildAuthTagPayloadFromValues("gemini", nil))
 		}
 		for _, entry := range cfg.ClaudeKey {
-			push(entry.Name, entry.Prefix, "claude")
+			push(entry.Name, entry.Prefix, "claude", buildAuthTagPayloadFromValues("claude", nil))
 		}
 		for _, entry := range cfg.CodexKey {
-			push(entry.Name, entry.Prefix, "codex")
+			push(entry.Name, entry.Prefix, "codex", buildAuthTagPayloadFromValues("codex", nil))
 		}
 		for _, entry := range cfg.VertexCompatAPIKey {
-			push("", entry.Prefix, "vertex")
+			push("", entry.Prefix, "vertex", buildAuthTagPayloadFromValues("vertex", nil))
 		}
 		for _, entry := range cfg.OpenAICompatibility {
-			push(entry.Name, entry.Prefix, "openai")
+			push(entry.Name, entry.Prefix, "openai", buildAuthTagPayloadFromValues("openai", nil))
 		}
 	}
 
@@ -62,7 +75,7 @@ func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []cha
 		if !includeAuthInChannelGroups(auth) {
 			continue
 		}
-		push(auth.ChannelName(), auth.Prefix, auth.Provider)
+		push(auth.ChannelName(), auth.Prefix, auth.Provider, buildAuthTagPayload(auth))
 	}
 
 	return items
@@ -161,6 +174,14 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 			}
 			if matched && channelName != "" {
 				group.Channels = append(group.Channels, channelName)
+				group.ChannelDetails = append(group.ChannelDetails, channelGroupChannelDetail{
+					Name:              channelName,
+					Source:            channel.Source,
+					DefaultTags:       append([]string{}, channel.DefaultTags...),
+					CustomTags:        append([]string{}, channel.CustomTags...),
+					HiddenDefaultTags: append([]string{}, channel.HiddenDefaultTags...),
+					DisplayTags:       append([]string{}, channel.DisplayTags...),
+				})
 			}
 		}
 	}
@@ -170,6 +191,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 		item.Name = name
 		item.Prefixes = uniqueSortedStrings(item.Prefixes, internalrouting.NormalizeGroupName)
 		item.Channels = uniqueSortedStrings(item.Channels, func(value string) string { return strings.TrimSpace(value) })
+		item.ChannelDetails = uniqueSortedChannelDetails(item.ChannelDetails)
 		item.PathRoutes = uniqueSortedStrings(knownPaths[name], internalrouting.NormalizeNamespacePath)
 		out = append(out, *item)
 	}

--- a/internal/api/handlers/management/channel_groups_test.go
+++ b/internal/api/handlers/management/channel_groups_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -236,6 +237,90 @@ func TestGetChannelGroupsReturnsGroupMetadata(t *testing.T) {
 	}
 	if len(body.Items) < 3 {
 		t.Fatalf("expected at least 3 group items, got %d", len(body.Items))
+	}
+}
+
+func TestGetChannelGroupsReturnsChannelDetailsWithTags(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	manager := coreauth.NewManager(&memoryAuthStore{}, nil, nil)
+	_, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "oauth-auth-tags",
+		FileName: "oauth-auth-tags.json",
+		Provider: "codex",
+		Label:    "A_GptPro",
+		Prefix:   "team-a",
+		Metadata: map[string]any{
+			"email":               "tags@example.com",
+			"plan_type":           "pro",
+			"custom_tags":         []string{"vip"},
+			"hidden_default_tags": []string{"pro"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/channel-groups", nil)
+
+	h := &Handler{
+		cfg:         testRoutingConfig(),
+		authManager: manager,
+	}
+	h.GetChannelGroups(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Items []struct {
+			Name           string `json:"name"`
+			ChannelDetails []struct {
+				Name        string   `json:"name"`
+				DefaultTags []string `json:"default_tags"`
+				DisplayTags []string `json:"display_tags"`
+			} `json:"channel-details"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	var matched *struct {
+		Name           string `json:"name"`
+		ChannelDetails []struct {
+			Name        string   `json:"name"`
+			DefaultTags []string `json:"default_tags"`
+			DisplayTags []string `json:"display_tags"`
+		} `json:"channel-details"`
+	}
+	for i := range body.Items {
+		if body.Items[i].Name == "team-a" {
+			matched = &body.Items[i]
+			break
+		}
+	}
+	if matched == nil {
+		t.Fatal("expected team-a group")
+	}
+	if len(matched.ChannelDetails) == 0 {
+		t.Fatal("expected channel details for team-a group")
+	}
+	if matched.ChannelDetails[0].Name != "A_GptPro" {
+		t.Fatalf("channel detail name = %q, want A_GptPro", matched.ChannelDetails[0].Name)
+	}
+	if len(matched.ChannelDetails[0].DefaultTags) != 2 ||
+		matched.ChannelDetails[0].DefaultTags[0] != "codex" ||
+		matched.ChannelDetails[0].DefaultTags[1] != "pro" {
+		t.Fatalf("default_tags = %#v, want [codex pro]", matched.ChannelDetails[0].DefaultTags)
+	}
+	if len(matched.ChannelDetails[0].DisplayTags) != 2 ||
+		matched.ChannelDetails[0].DisplayTags[0] != "codex" ||
+		matched.ChannelDetails[0].DisplayTags[1] != "vip" {
+		t.Fatalf("display_tags = %#v, want [codex vip]", matched.ChannelDetails[0].DisplayTags)
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist auth-file tag preferences in auth metadata
- return default/custom/hidden/display tag sets from auth-files and channel-groups management APIs
- cover the new contract with management handler tests

## Verification
- go test ./internal/api/handlers/management -run 'Test(PatchAuthFileFieldsUpdatesCustomTagsAndHiddenDefaultTags|PatchAuthFileFieldsRejectsMoreThanThreeCustomTags|BuildAuthFileEntryIncludesDefaultAndDisplayTags|GetChannelGroupsReturnsChannelDetailsWithTags)$'