### PR TITLE
Fix log query when file logging is disabled

### DIFF
--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -34,7 +34,12 @@ func (h *Handler) GetLogs(c *gin.Context) {
 		return
 	}
 	if !h.cfg.LoggingToFile {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "logging to file disabled"})
+		cutoff := parseCutoff(c.Query("after"))
+		c.JSON(http.StatusOK, gin.H{
+			"lines":            []string{},
+			"line-count":       0,
+			"latest-timestamp": cutoff,
+		})
 		return
 	}
 

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -1,0 +1,46 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestGetLogsReturnsEmptySnapshotWhenFileLoggingDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewHandler(&config.Config{LoggingToFile: false}, "", nil)
+	defer h.Close()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/logs?limit=50000&after=1714567890", nil)
+
+	h.GetLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Lines           []string `json:"lines"`
+		LineCount       int      `json:"line-count"`
+		LatestTimestamp int64    `json:"latest-timestamp"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Lines) != 0 {
+		t.Fatalf("lines = %v, want empty", payload.Lines)
+	}
+	if payload.LineCount != 0 {
+		t.Fatalf("line-count = %d, want 0", payload.LineCount)
+	}
+	if payload.LatestTimestamp != 1714567890 {
+		t.Fatalf("latest-timestamp = %d, want 1714567890", payload.LatestTimestamp)
+	}
+}

--- a/internal/usage/config_yaml_cleanup.go
+++ b/internal/usage/config_yaml_cleanup.go
@@ -2,9 +2,12 @@ package usage
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -153,6 +156,10 @@ func cleanConfigKeysFromYAML(configFilePath string, keysToRemove map[string]bool
 }
 
 func writeYAMLNodeAtomic(configFilePath string, root *yaml.Node) error {
+	return writeYAMLNodeAtomicWithRename(configFilePath, root, os.Rename)
+}
+
+func writeYAMLNodeAtomicWithRename(configFilePath string, root *yaml.Node, renameFile func(string, string) error) error {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
@@ -193,5 +200,37 @@ func writeYAMLNodeAtomic(configFilePath string, root *yaml.Node) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmpPath, configFilePath)
+	if renameFile == nil {
+		renameFile = os.Rename
+	}
+	if err := renameFile(tmpPath, configFilePath); err != nil {
+		if isAtomicYAMLReplaceUnsupported(err) {
+			if errFallback := writeYAMLFileInPlace(configFilePath, buf.Bytes(), mode); errFallback != nil {
+				return fmt.Errorf("atomic replace failed: %w; in-place write failed: %w", err, errFallback)
+			}
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func isAtomicYAMLReplaceUnsupported(err error) bool {
+	return errors.Is(err, syscall.EBUSY) || errors.Is(err, syscall.EXDEV)
+}
+
+func writeYAMLFileInPlace(path string, data []byte, mode os.FileMode) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }

--- a/internal/usage/config_yaml_cleanup_test.go
+++ b/internal/usage/config_yaml_cleanup_test.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"gopkg.in/yaml.v3"
 	_ "modernc.org/sqlite"
 )
 
@@ -135,6 +137,51 @@ func TestCleanDBBackedConfigFromYAMLCleansPersistedSections(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o640 {
 		t.Fatalf("cleaned config mode = %o, want 640", got)
+	}
+}
+
+func TestWriteYAMLNodeAtomicFallsBackWhenRenameTargetBusy(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("routing:\n  strategy: round-robin\n"), 0o640); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte("port: 8318\nlogging-to-file: true\n"), &root); err != nil {
+		t.Fatalf("parse yaml: %v", err)
+	}
+
+	renameCalled := false
+	err := writeYAMLNodeAtomicWithRename(configPath, &root, func(oldPath, newPath string) error {
+		renameCalled = true
+		if filepath.Dir(oldPath) != filepath.Dir(configPath) {
+			t.Fatalf("temp file dir = %s, want %s", filepath.Dir(oldPath), filepath.Dir(configPath))
+		}
+		if newPath != configPath {
+			t.Fatalf("rename target = %s, want %s", newPath, configPath)
+		}
+		return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: syscall.EBUSY}
+	})
+	if err != nil {
+		t.Fatalf("writeYAMLNodeAtomicWithRename returned error: %v", err)
+	}
+	if !renameCalled {
+		t.Fatal("rename was not attempted")
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if got := string(data); strings.Contains(got, "routing:") || !strings.Contains(got, "logging-to-file: true") {
+		t.Fatalf("config was not rewritten in place:\n%s", got)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("config mode = %o, want 640", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Return an empty logs snapshot from the management logs API when `logging-to-file` is disabled instead of surfacing a 400 error to the panel.
- Fall back to in-place YAML writes when atomic config cleanup rename fails with bind-mounted config files.
- Add regression tests for both issue #130 symptoms.

## Test Plan
- `go test ./internal/api/handlers/management -run TestGetLogsReturnsEmptySnapshotWhenFileLoggingDisabled -count=1`
- `go test ./internal/usage -run TestWriteYAMLNodeAtomicFallsBackWhenRenameTargetBusy -count=1`
- `go test ./internal/api/handlers/management -run 'TestGetLogsReturnsEmptySnapshotWhenFileLoggingDisabled|TestGetUsageLogs' -count=1`
- `go test ./internal/usage -run 'TestWriteYAMLNodeAtomicFallsBackWhenRenameTargetBusy|TestCleanDBBackedConfigFromYAMLCleansPersistedSections|TestMigrateRoutingConfigFromConfigCleansYAML' -count=1`
- `go test ./...`

Fixes #130.
