### PR TITLE
fix: persist auth file display tags

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1169,6 +1169,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		Label                 *string   `json:"label"`
 		CustomTags            *[]string `json:"custom_tags"`
 		HiddenDefaultTags     *[]string `json:"hidden_default_tags"`
+		DisplayTags           *[]string `json:"display_tags"`
 		Prefix                *string   `json:"prefix"`
 		ProxyURL              *string   `json:"proxy_url"`
 		ProxyID               *string   `json:"proxy_id"`
@@ -1274,6 +1275,14 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		} else {
 			targetAuth.Metadata["hidden_default_tags"] = tags
 		}
+		changed = true
+	}
+	if req.DisplayTags != nil {
+		tags := normalizeTagList(*req.DisplayTags)
+		if targetAuth.Metadata == nil {
+			targetAuth.Metadata = make(map[string]any)
+		}
+		targetAuth.Metadata["display_tags"] = tags
 		changed = true
 	}
 	if req.ProxyURL != nil {

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -157,6 +157,62 @@ func TestPatchAuthFileFieldsUpdatesCustomTagsAndHiddenDefaultTags(t *testing.T) 
 	}
 }
 
+func TestPatchAuthFileFieldsUpdatesDisplayTags(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	_, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "oauth-auth-display-tags",
+		FileName: "oauth-auth-display-tags.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"email":     "display-tags@example.com",
+			"plan_type": "pro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"name":         "oauth-auth-display-tags.json",
+		"custom_tags":  []string{"vip"},
+		"display_tags": []string{"codex", "vip"},
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/auth-files/fields", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchAuthFileFields(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("oauth-auth-display-tags")
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	displayTags, ok := updated.Metadata["display_tags"].([]string)
+	if !ok {
+		t.Fatalf("display_tags type = %T, want []string", updated.Metadata["display_tags"])
+	}
+	if len(displayTags) != 2 || displayTags[0] != "codex" || displayTags[1] != "vip" {
+		t.Fatalf("display_tags = %#v, want [codex vip]", displayTags)
+	}
+}
+
 func TestPatchAuthFileFieldsRejectsMoreThanThreeCustomTags(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -232,6 +288,34 @@ func TestBuildAuthFileEntryIncludesDefaultAndDisplayTags(t *testing.T) {
 	}
 	if len(displayTags) != 2 || displayTags[0] != "codex" || displayTags[1] != "team-a" {
 		t.Fatalf("display_tags = %#v, want [codex team-a]", displayTags)
+	}
+}
+
+func TestBuildAuthFileEntryHonorsExplicitEmptyDisplayTags(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-hidden-tags",
+		FileName: "codex-hidden-tags.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "codex-hidden-tags.json",
+		},
+		Metadata: map[string]any{
+			"plan_type":    "pro",
+			"custom_tags":  []string{"vip"},
+			"display_tags": []string{},
+		},
+	}
+
+	entry := (&Handler{}).buildAuthFileEntry(auth)
+	if entry == nil {
+		t.Fatal("expected auth file entry")
+	}
+	displayTags, ok := entry["display_tags"].([]string)
+	if !ok {
+		t.Fatalf("display_tags type = %T, want []string", entry["display_tags"])
+	}
+	if len(displayTags) != 0 {
+		t.Fatalf("display_tags = %#v, want empty list", displayTags)
 	}
 }
 

--- a/internal/api/handlers/management/auth_tags.go
+++ b/internal/api/handlers/management/auth_tags.go
@@ -33,26 +33,33 @@ func buildAuthTagPayloadFromValues(provider string, metadata map[string]any) aut
 	defaultTags := defaultAuthTags(provider, metadata)
 	customTags := metadataStringSlice(metadata, "custom_tags")
 	hiddenDefaultTags := metadataStringSlice(metadata, "hidden_default_tags")
+	explicitDisplayTags, hasExplicitDisplayTags := metadataStringSliceWithPresence(
+		metadata,
+		"display_tags",
+	)
 	hiddenSet := make(map[string]struct{}, len(hiddenDefaultTags))
 	for _, tag := range hiddenDefaultTags {
 		hiddenSet[tag] = struct{}{}
 	}
 
-	displayTags := make([]string, 0, len(defaultTags)+len(customTags))
-	for _, tag := range defaultTags {
-		if _, hidden := hiddenSet[tag]; hidden {
-			continue
+	displayTags := explicitDisplayTags
+	if !hasExplicitDisplayTags {
+		displayTags = make([]string, 0, len(defaultTags)+len(customTags))
+		for _, tag := range defaultTags {
+			if _, hidden := hiddenSet[tag]; hidden {
+				continue
+			}
+			displayTags = append(displayTags, tag)
 		}
-		displayTags = append(displayTags, tag)
-	}
-	for _, tag := range customTags {
-		if _, exists := hiddenSet[tag]; exists {
-			continue
+		for _, tag := range customTags {
+			if _, exists := hiddenSet[tag]; exists {
+				continue
+			}
+			if containsNormalizedTag(displayTags, tag) {
+				continue
+			}
+			displayTags = append(displayTags, tag)
 		}
-		if containsNormalizedTag(displayTags, tag) {
-			continue
-		}
-		displayTags = append(displayTags, tag)
 	}
 
 	return authTagPayload{
@@ -125,16 +132,21 @@ func containsNormalizedTag(values []string, target string) bool {
 }
 
 func metadataStringSlice(metadata map[string]any, key string) []string {
+	values, _ := metadataStringSliceWithPresence(metadata, key)
+	return values
+}
+
+func metadataStringSliceWithPresence(metadata map[string]any, key string) ([]string, bool) {
 	if len(metadata) == 0 {
-		return []string{}
+		return []string{}, false
 	}
 	raw, ok := metadata[key]
 	if !ok || raw == nil {
-		return []string{}
+		return []string{}, ok
 	}
 	switch typed := raw.(type) {
 	case []string:
-		return normalizeTagList(typed)
+		return normalizeTagList(typed), true
 	case []any:
 		values := make([]string, 0, len(typed))
 		for _, item := range typed {
@@ -142,14 +154,14 @@ func metadataStringSlice(metadata map[string]any, key string) []string {
 				values = append(values, text)
 			}
 		}
-		return normalizeTagList(values)
+		return normalizeTagList(values), true
 	case string:
 		if strings.TrimSpace(typed) == "" {
-			return []string{}
+			return []string{}, true
 		}
-		return normalizeTagList(strings.Split(typed, ","))
+		return normalizeTagList(strings.Split(typed, ",")), true
 	default:
-		return []string{}
+		return []string{}, true
 	}
 }
 


### PR DESCRIPTION
## Summary
- Persist display_tags through /auth-files/fields.
- Treat explicit display_tags, including an empty array, as authoritative over computed tag display.
- Add tests for display tag persistence and explicit empty visibility.

## Test Plan
- go test ./...
- git diff --check