### PR TITLE
fix: reconcile Codex plan tags from usage

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -223,6 +223,9 @@ func (h *Handler) APICall(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read response"})
 		return
 	}
+	if errReconcile := h.reconcileCodexWhamUsagePlan(c.Request.Context(), auth, parsedURL, resp.StatusCode, respBody); errReconcile != nil {
+		log.WithError(errReconcile).Warn("failed to reconcile codex usage plan type")
+	}
 
 	c.JSON(http.StatusOK, apiCallResponse{
 		StatusCode: resp.StatusCode,
@@ -241,6 +244,94 @@ func firstNonEmptyString(values ...*string) string {
 		}
 	}
 	return ""
+}
+
+func (h *Handler) reconcileCodexWhamUsagePlan(ctx context.Context, auth *coreauth.Auth, parsedURL *url.URL, statusCode int, respBody []byte) error {
+	if h == nil || h.authManager == nil || auth == nil {
+		return nil
+	}
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return nil
+	}
+	if !isCodexWhamUsageURL(parsedURL) {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return nil
+	}
+
+	var payload struct {
+		PlanType string `json:"plan_type"`
+	}
+	if err := json.Unmarshal(respBody, &payload); err != nil {
+		return nil
+	}
+	planType := normalizeTagValue(payload.PlanType)
+	if planType == "" {
+		return nil
+	}
+
+	if auth.Metadata == nil {
+		return nil
+	}
+	changed := false
+	if currentType, _ := auth.Metadata["type"].(string); strings.TrimSpace(currentType) == "" {
+		auth.Metadata["type"] = "codex"
+		changed = true
+	}
+	currentPlanType := normalizeTagValue(metadataString(auth.Metadata, "plan_type", "planType"))
+	if currentPlanType != planType {
+		auth.Metadata["plan_type"] = planType
+		delete(auth.Metadata, "planType")
+		changed = true
+	}
+	if reconcileAuthExplicitDisplayTags(auth) {
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+
+	now := time.Now()
+	auth.UpdatedAt = now
+	_, err := h.authManager.Update(ctx, auth)
+	return err
+}
+
+func isCodexWhamUsageURL(parsedURL *url.URL) bool {
+	if parsedURL == nil {
+		return false
+	}
+	path := strings.TrimRight(parsedURL.EscapedPath(), "/")
+	return path == "/backend-api/wham/usage"
+}
+
+func reconcileAuthExplicitDisplayTags(auth *coreauth.Auth) bool {
+	if auth == nil || auth.Metadata == nil {
+		return false
+	}
+	currentTags, ok := metadataStringSliceWithPresence(auth.Metadata, "display_tags")
+	if !ok {
+		return false
+	}
+	reconciledTags := buildAuthTagPayload(auth).DisplayTags
+	if normalizedStringSlicesEqual(currentTags, reconciledTags) {
+		return false
+	}
+	auth.Metadata["display_tags"] = reconciledTags
+	return true
+}
+
+func normalizedStringSlicesEqual(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if normalizeTagValue(a[i]) != normalizeTagValue(b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func tokenValueForAuth(auth *coreauth.Auth) string {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -383,6 +383,90 @@ func TestResolveTokenForAuth_Claude_SkipsRefreshWhenTokenValid(t *testing.T) {
 	}
 }
 
+func TestAPICallReconcilesCodexWhamUsagePlanType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/backend-api/wham/usage" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+			t.Fatalf("unexpected authorization header: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"email":     "aleckmason123@gmail.com",
+			"plan_type": "free",
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "codex-plan.json",
+		FileName: "codex-plan.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"type":         "codex",
+			"access_token": "access-token",
+			"email":        "aleckmason123@gmail.com",
+			"plan_type":    "plus",
+			"display_tags": []string{"codex", "plus"},
+		},
+	}
+	registered, err := manager.Register(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registered.EnsureIndex()
+
+	requestBody, err := json.Marshal(map[string]any{
+		"authIndex": registered.Index,
+		"method":    "GET",
+		"url":       upstream.URL + "/backend-api/wham/usage",
+		"header": map[string]string{
+			"Authorization": "Bearer $TOKEN$",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+
+	h := &Handler{cfg: &config.Config{}, authManager: manager}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/api-call", bytes.NewReader(requestBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.APICall(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if got, _ := updated.Metadata["plan_type"].(string); got != "free" {
+		t.Fatalf("plan_type = %q, want free", got)
+	}
+	displayTags, ok := updated.Metadata["display_tags"].([]string)
+	if !ok {
+		t.Fatalf("display_tags type = %T, want []string", updated.Metadata["display_tags"])
+	}
+	if len(displayTags) != 2 || displayTags[0] != "codex" || displayTags[1] != "free" {
+		t.Fatalf("display_tags = %#v, want [codex free]", displayTags)
+	}
+	saved := store.items[auth.ID]
+	if saved == nil {
+		t.Fatal("expected auth store to persist reconciled auth")
+	}
+	if got, _ := saved.Metadata["plan_type"].(string); got != "free" {
+		t.Fatalf("saved plan_type = %q, want free", got)
+	}
+}
+
 func TestAPICallRejectsOversizedUpstreamResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -696,6 +696,9 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	entry["custom_tags"] = tags.CustomTags
 	entry["hidden_default_tags"] = tags.HiddenDefaultTags
 	entry["display_tags"] = tags.DisplayTags
+	if planType := normalizeTagValue(metadataString(auth.Metadata, "plan_type", "planType")); planType != "" {
+		entry["plan_type"] = planType
+	}
 	addSubscriptionFields(entry, auth.Metadata, time.Now())
 	if !auth.CreatedAt.IsZero() {
 		entry["created_at"] = auth.CreatedAt

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -317,6 +318,88 @@ func TestBuildAuthFileEntryHonorsExplicitEmptyDisplayTags(t *testing.T) {
 	if len(displayTags) != 0 {
 		t.Fatalf("display_tags = %#v, want empty list", displayTags)
 	}
+}
+
+func TestBuildAuthFileEntryReplacesStaleExplicitPlanDisplayTag(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-downgraded-tags",
+		FileName: "codex-downgraded-tags.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "codex-downgraded-tags.json",
+		},
+		Metadata: map[string]any{
+			"plan_type":    "free",
+			"display_tags": []string{"codex", "plus"},
+		},
+	}
+
+	entry := (&Handler{}).buildAuthFileEntry(auth)
+	if entry == nil {
+		t.Fatal("expected auth file entry")
+	}
+	defaultTags, ok := entry["default_tags"].([]string)
+	if !ok {
+		t.Fatalf("default_tags type = %T, want []string", entry["default_tags"])
+	}
+	if len(defaultTags) != 2 || defaultTags[0] != "codex" || defaultTags[1] != "free" {
+		t.Fatalf("default_tags = %#v, want [codex free]", defaultTags)
+	}
+	displayTags, ok := entry["display_tags"].([]string)
+	if !ok {
+		t.Fatalf("display_tags type = %T, want []string", entry["display_tags"])
+	}
+	if len(displayTags) != 2 || displayTags[0] != "codex" || displayTags[1] != "free" {
+		t.Fatalf("display_tags = %#v, want [codex free]", displayTags)
+	}
+}
+
+func TestBuildAuthFileEntryExposesMetadataPlanTypeBeforeIDTokenClaim(t *testing.T) {
+	idToken := makeManagementJWTForTest(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_plan_type":  "plus",
+			"chatgpt_account_id": "acct_123",
+		},
+	})
+	auth := &coreauth.Auth{
+		ID:       "codex-stale-id-token",
+		FileName: "codex-stale-id-token.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "codex-stale-id-token.json",
+		},
+		Metadata: map[string]any{
+			"plan_type": "free",
+			"id_token":  idToken,
+		},
+	}
+
+	entry := (&Handler{}).buildAuthFileEntry(auth)
+	if entry == nil {
+		t.Fatal("expected auth file entry")
+	}
+	if got, _ := entry["plan_type"].(string); got != "free" {
+		t.Fatalf("plan_type = %q, want free", got)
+	}
+	claims, ok := entry["id_token"].(gin.H)
+	if !ok {
+		t.Fatalf("id_token type = %T, want gin.H", entry["id_token"])
+	}
+	if got, _ := claims["plan_type"].(string); got != "plus" {
+		t.Fatalf("id_token.plan_type = %q, want plus", got)
+	}
+}
+
+func makeManagementJWTForTest(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	encode := func(v any) string {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal jwt part: %v", err)
+		}
+		return base64.RawURLEncoding.EncodeToString(raw)
+	}
+	return encode(map[string]any{"alg": "none", "typ": "JWT"}) + "." + encode(claims) + ".sig"
 }
 
 func TestBuildAuthFileEntryIncludesActiveRestrictions(t *testing.T) {

--- a/internal/api/handlers/management/auth_tags.go
+++ b/internal/api/handlers/management/auth_tags.go
@@ -10,6 +10,16 @@ import (
 
 const maxCustomAuthTags = 3
 
+var codexPlanDisplayTags = map[string]struct{}{
+	"business":   {},
+	"edu":        {},
+	"enterprise": {},
+	"free":       {},
+	"plus":       {},
+	"pro":        {},
+	"team":       {},
+}
+
 type authTagPayload struct {
 	DefaultTags       []string
 	CustomTags        []string
@@ -60,6 +70,14 @@ func buildAuthTagPayloadFromValues(provider string, metadata map[string]any) aut
 			}
 			displayTags = append(displayTags, tag)
 		}
+	} else {
+		displayTags = reconcileExplicitDisplayTags(
+			provider,
+			metadata,
+			defaultTags,
+			customTags,
+			explicitDisplayTags,
+		)
 	}
 
 	return authTagPayload{
@@ -68,6 +86,56 @@ func buildAuthTagPayloadFromValues(provider string, metadata map[string]any) aut
 		HiddenDefaultTags: append([]string{}, hiddenDefaultTags...),
 		DisplayTags:       append([]string{}, displayTags...),
 	}
+}
+
+func reconcileExplicitDisplayTags(provider string, metadata map[string]any, defaultTags []string, customTags []string, explicitDisplayTags []string) []string {
+	if len(explicitDisplayTags) == 0 {
+		return []string{}
+	}
+	allowed := make(map[string]struct{}, len(defaultTags)+len(customTags))
+	for _, tag := range defaultTags {
+		if normalized := normalizeTagValue(tag); normalized != "" {
+			allowed[normalized] = struct{}{}
+		}
+	}
+	for _, tag := range customTags {
+		if normalized := normalizeTagValue(tag); normalized != "" {
+			allowed[normalized] = struct{}{}
+		}
+	}
+
+	providerTag := normalizeTagValue(provider)
+	currentPlan := normalizeTagValue(metadataString(metadata, "plan_type", "planType"))
+	out := make([]string, 0, len(explicitDisplayTags))
+	for _, tag := range explicitDisplayTags {
+		normalized := normalizeTagValue(tag)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := allowed[normalized]; ok {
+			if !containsNormalizedTag(out, normalized) {
+				out = append(out, normalized)
+			}
+			continue
+		}
+		if isStaleCodexPlanDisplayTag(providerTag, currentPlan, normalized) {
+			if _, ok := allowed[currentPlan]; ok && !containsNormalizedTag(out, currentPlan) {
+				out = append(out, currentPlan)
+			}
+		}
+	}
+	return out
+}
+
+func isStaleCodexPlanDisplayTag(providerTag string, currentPlan string, tag string) bool {
+	if providerTag != "codex" || currentPlan == "" || tag == currentPlan {
+		return false
+	}
+	if _, ok := codexPlanDisplayTags[currentPlan]; !ok {
+		return false
+	}
+	_, ok := codexPlanDisplayTags[tag]
+	return ok
 }
 
 func defaultAuthTags(provider string, metadata map[string]any) []string {


### PR DESCRIPTION
## Summary
- Reconcile Codex `plan_type` from management `/api-call` responses for `wham/usage`
- Return metadata `plan_type` at the auth-files top level so stale JWT claims do not drive UI badges
- Replace stale explicit Codex plan display tags like `plus` with the current plan tag

## Test Plan
- `go test ./internal/api/handlers/management -count=1`
- `go test ./...`