### PR TITLE
Docs: clarify management panel frontend repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,11 @@
 <INSTRUCTIONS>
 所有通过 `spawn_agent` 调用的子代理必须显式指定 `model: "gpt-5.3-codex"`；不要再使用 `gpt-5.1-codex-mini`。轻量子任务可通过降低 `reasoning_effort`（例如 `low`）控制成本。
 
+重要：管理面板前后端分离（避免改错仓库）
+- Go 服务端仓库（本仓库）只负责 `/manage` 的托管与“运行时拉取面板资源”的同步链路（见 `internal/managementasset/*`）。
+- 面板源码在独立前端仓库维护，运行时会从 `remote-management.panel-github-repository` 指定的 GitHub 仓库拉取 release 资源；默认指向 `https://github.com/kittors/codeProxy`。
+- 所以：要改“manage 页面 UI/交互/文案/组件”，应该去 `codeProxy` 仓库改并走它的构建/发版流程；不要在本仓库里直接改已打包的静态 assets 来期待上线生效。
+
 严禁轻易部署、重启、替换远端服务或修改生产环境。除非用户明确要求“部署”“重启”“上线”“替换远端二进制”“发布到服务器”等生产操作，否则只能在本地修改、测试、构建和说明，不得主动执行远端部署。
 
 开始任何项目/任务前，必须先确保本地 `dev` 和 `main` 分支已同步到远端最新代码；建议先 `git fetch origin`，再分别更新 `dev` 与 `main`（优先使用 fast-forward 更新，避免无意产生合并提交）。若工作区存在未提交改动，先确认改动归属，避免覆盖用户或其它任务的变更。

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ http://localhost:8317/manage
 - Docker Compose deployments expose the panel at `/manage`.
 - The server can serve a bundled SPA directory or auto-fetch panel assets when needed.
 - This repository contains the hosting/update path for `/manage`; the standalone web panel source is maintained separately from the Go server code.
+- Make UI/interaction/copy changes in the panel source repository (default: `kittors/codeProxy`) and ship them via its release artifacts for the server to fetch.
 - Terminal-first management is also available through `docker compose exec cli-proxy-api ./cli-proxy-api -tui`.
 - If you want to customize the panel asset source, set `remote-management.panel-github-repository`.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -295,6 +295,7 @@ http://localhost:8317/manage
 - Docker Compose 部署会在 `/manage` 暴露控制面板。
 - 服务端既支持托管打包后的 SPA 目录，也支持在需要时自动拉取面板资源。
 - 当前仓库只包含 `/manage` 的托管和同步链路，独立 Web 面板源码与 Go 服务端代码分仓维护。
+- 面板的 UI/交互/文案 等改动请到面板源码仓库（默认 `kittors/codeProxy`）提交，并通过其发布产物（GitHub Release）供服务端拉取。
 - 如果你偏向终端运维，也可以使用 `docker compose exec cli-proxy-api ./cli-proxy-api -tui`。
 - 如果你希望自定义面板资源来源，可设置 `remote-management.panel-github-repository`。
 


### PR DESCRIPTION
- Explicitly document that /manage panel frontend is maintained in the separate codeProxy repo\n- Point to remote-management.panel-github-repository default (kittors/codeProxy)\n\n(no runtime behavior changes)