### PR TITLE
ci: fix deploy workflow heredoc indentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,9 +96,9 @@ jobs:
               BODY_SIZE_CONF="/etc/nginx/conf.d/90-clirelay-body-size.conf"
               mkdir -p "$(dirname "$BODY_SIZE_CONF")"
               cat > "$BODY_SIZE_CONF" <<'EOF'
-# Managed by CliRelay GitHub Actions deploy workflow
-client_max_body_size 2000m;
-EOF
+            # Managed by CliRelay GitHub Actions deploy workflow
+            client_max_body_size 2000m;
+            EOF
               if command -v nginx >/dev/null 2>&1; then
                 nginx -t
                 nginx -s reload || systemctl reload nginx || systemctl restart nginx


### PR DESCRIPTION
## Summary
- Indent the nginx body size heredoc inside the deploy workflow YAML block.
- Keeps the rendered remote shell script EOF marker at column 1 after YAML parsing.

## Test Plan
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/deploy.yml
- parsed deploy script confirms EOF at column 1
- git diff --check