### PR TITLE
fix: enforce auth-level cooldown on 429 quota

### DIFF
--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -675,6 +675,24 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
 	}
+
+	// Quota exceeded is an auth-level cooldown signal. Once we know an auth is cooling down,
+	// we should block *all* model requests for that auth until recovery, even if per-model
+	// state hasn't been initialized yet. This prevents clients from burning extra upstream
+	// requests by switching models during the same quota window.
+	if auth.Quota.Exceeded {
+		next := auth.Quota.NextRecoverAt
+		if !next.IsZero() && next.After(now) {
+			if auth.NextRetryAfter.After(now) && (next.IsZero() || auth.NextRetryAfter.Before(next)) {
+				next = auth.NextRetryAfter
+			}
+			if next.Before(now) {
+				next = now
+			}
+			return true, blockReasonCooldown, next
+		}
+	}
+
 	if model != "" {
 		if len(auth.ModelStates) > 0 {
 			state, ok := auth.ModelStates[model]

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -577,6 +577,35 @@ func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsNotBlocked(t *testin
 	}
 }
 
+func TestIsAuthBlockedForModel_AuthQuotaCooldownBlocksAllModels(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	next := now.Add(15 * time.Minute)
+
+	auth := &Auth{
+		ID: "a",
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: next,
+		},
+		NextRetryAfter: next,
+	}
+
+	// Even if the requested model has no per-model state yet, auth-level cooldown should block it.
+	blocked, reason, gotNext := isAuthBlockedForModel(auth, "some-new-model", now)
+	if !blocked {
+		t.Fatalf("blocked = false, want true")
+	}
+	if reason != blockReasonCooldown {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonCooldown)
+	}
+	if gotNext.IsZero() || gotNext.Sub(next) > time.Second || next.Sub(gotNext) > time.Second {
+		t.Fatalf("next = %v, want around %v", gotNext, next)
+	}
+}
+
 func TestFillFirstSelectorPick_ThinkingSuffixFallsBackToBaseModelState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When an auth is in quota cooldown (auth.Quota.Exceeded + NextRecoverAt), block *all* model requests for that auth until recovery. This prevents repeated upstream 429s when clients switch models after hitting usage_limit_reached. Includes selector unit test.