### PR TITLE
fix(management): apply config changes without restart

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -49,6 +49,7 @@ type Handler struct {
 	envSecret           string
 	logDir              string
 	postAuthHook        coreauth.PostAuthHook
+	onConfigMutated     func(*config.Config)
 	startTime           time.Time
 	attemptCleanupStop  chan struct{}
 	attemptCleanupOnce  sync.Once
@@ -142,6 +143,8 @@ func (h *Handler) SetConfig(cfg *config.Config) { h.cfg = cfg }
 
 // SetAuthManager updates the auth manager reference used by management endpoints.
 func (h *Handler) SetAuthManager(manager *coreauth.Manager) { h.authManager = manager }
+
+func (h *Handler) SetConfigMutatedHook(fn func(*config.Config)) { h.onConfigMutated = fn }
 
 // SetAccessManager wires the request authentication access manager so management writes
 // (such as API key channel/model restrictions) can be applied immediately at runtime.
@@ -319,19 +322,25 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 // persist saves the current in-memory config to disk.
 func (h *Handler) persist(c *gin.Context) bool {
 	h.mu.Lock()
-	defer h.mu.Unlock()
+	cfg := h.cfg
+	mutated := h.onConfigMutated
 	if usage.ConfigStoreAvailable() {
-		usage.PersistRuntimeSettingsFromConfig(h.cfg)
+		usage.PersistRuntimeSettingsFromConfig(cfg)
 	}
 	// Preserve comments when writing
-	if err := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); err != nil {
+	if err := config.SaveConfigPreserveComments(h.configFilePath, cfg); err != nil {
+		h.mu.Unlock()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save config: %v", err)})
 		return false
 	}
 	if usage.ConfigStoreAvailable() {
 		usage.CleanDBBackedConfigFromYAML(h.configFilePath)
 	}
+	h.mu.Unlock()
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	if mutated != nil {
+		mutated(cfg)
+	}
 	return true
 }
 
@@ -346,10 +355,14 @@ func (h *Handler) persistRuntimeSetting(c *gin.Context, key string, value any) b
 	if strings.TrimSpace(h.configFilePath) != "" {
 		usage.CleanDBBackedConfigFromYAML(h.configFilePath)
 	}
+	cfg := h.cfg
 	if h != nil && h.authManager != nil {
-		h.authManager.SetConfig(h.cfg)
+		h.authManager.SetConfig(cfg)
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	if h != nil && h.onConfigMutated != nil {
+		h.onConfigMutated(cfg)
+	}
 	return true
 }
 

--- a/internal/api/handlers/management/routing_config.go
+++ b/internal/api/handlers/management/routing_config.go
@@ -83,4 +83,7 @@ func (h *Handler) PutRoutingConfig(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	if h != nil && h.onConfigMutated != nil {
+		h.onConfigMutated(cfgRef)
+	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -295,6 +295,21 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	// Initialize management handler
 	s.mgmt = managementHandlers.NewHandler(cfg, configFilePath, authManager)
 	s.mgmt.SetAccessManager(accessManager)
+	s.mgmt.SetConfigMutatedHook(func(updated *config.Config) {
+		if updated == nil {
+			updated = cfg
+		}
+		if updated == nil {
+			return
+		}
+		usage.MigrateRoutingConfigFromConfig(updated, configFilePath)
+		usage.ApplyStoredRoutingConfig(updated)
+		usage.MigrateProxyPoolFromConfig(updated, configFilePath)
+		usage.ApplyStoredProxyPool(updated)
+		usage.MigrateRuntimeSettingsFromConfig(updated, configFilePath)
+		usage.ApplyStoredRuntimeSettings(updated)
+		s.UpdateClients(updated)
+	})
 	if optionState.localPassword != "" {
 		s.mgmt.SetLocalPassword(optionState.localPassword)
 	}


### PR DESCRIPTION
## Summary
- 让 management 写入（DB-backed / YAML）后立即触发运行时刷新，不再依赖 config.yaml hash 变更 watcher。
- 解决禁用/启用渠道配置必须重启才生效的问题（Issue #152）。

## Test plan
- [x] go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)