### PR TITLE
fix(management): satisfy staticcheck for handler nil check

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -356,11 +356,11 @@ func (h *Handler) persistRuntimeSetting(c *gin.Context, key string, value any) b
 		usage.CleanDBBackedConfigFromYAML(h.configFilePath)
 	}
 	cfg := h.cfg
-	if h != nil && h.authManager != nil {
+	if h.authManager != nil {
 		h.authManager.SetConfig(cfg)
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
-	if h != nil && h.onConfigMutated != nil {
+	if h.onConfigMutated != nil {
 		h.onConfigMutated(cfg)
 	}
 	return true


### PR DESCRIPTION
## Summary
- 修复 golangci-lint/staticcheck (SA5011) 对 h 可能为 nil 的误判：在方法接收者内去掉冗余的 `h != nil` 分支。

## Test plan
- [x] go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)