### PR TITLE
fix(codex): strip defer_loading tools flag

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -168,6 +168,15 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	// Convert tools declarations to the expected format for the Codex API.
 	toolsResult := rootResult.Get("tools")
 	if toolsResult.IsArray() {
+		// Codex validates deferred tools strictly: defer_loading requires tools.tool_search.
+		// Claude Code may set defer_loading on tools when tool schemas are deferred.
+		// The Codex endpoint we proxy to rejects defer_loading without tool_search, so strip the flag.
+		if toolsResult.Get("#(defer_loading=true)").Exists() {
+			rawJSON, _ = sjson.DeleteBytes(rawJSON, "tools.#.defer_loading")
+			rootResult = gjson.ParseBytes(rawJSON)
+			toolsResult = rootResult.Get("tools")
+		}
+
 		template, _ = sjson.SetRaw(template, "tools", `[]`)
 		template, _ = sjson.Set(template, "tool_choice", `auto`)
 		toolResults := toolsResult.Array()


### PR DESCRIPTION
## Summary\n- Fix Codex upstream 400 when Claude Code uses deferred tool schemas (tools.defer_loading).\n- Strip tools[].defer_loading in Claude->Codex request translation because Codex rejects it without tools.tool_search.\n\n## Test plan\n- [x] go test ./...\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)