### PR TITLE
fix(codex): use loop to delete defer_loading from each tool

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -172,7 +172,10 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 		// Claude Code may set defer_loading on tools when tool schemas are deferred.
 		// The Codex endpoint we proxy to rejects defer_loading without tool_search, so strip the flag.
 		if toolsResult.Get("#(defer_loading=true)").Exists() {
-			rawJSON, _ = sjson.DeleteBytes(rawJSON, "tools.#.defer_loading")
+			toolsResult.ForEach(func(i, _ gjson.Result) bool {
+				rawJSON, _ = sjson.DeleteBytes(rawJSON, fmt.Sprintf("tools.%d.defer_loading", i.Int()))
+				return true
+			})
 			rootResult = gjson.ParseBytes(rawJSON)
 			toolsResult = rootResult.Get("tools")
 		}

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -1,0 +1,32 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertClaudeRequestToCodex_StripsDeferLoading(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [
+			{"name": "WebSearch", "description": "search", "input_schema": {"type": "object"}, "defer_loading": true},
+			{"name": "Read", "description": "read", "input_schema": {"type": "object"}}
+		]
+	}`)
+
+	out := ConvertClaudeRequestToCodex("gpt-5.2", input, true)
+
+	// Ensure defer_loading is removed from all tools in the output
+	tools := gjson.GetBytes(out, "tools")
+	if !tools.IsArray() {
+		t.Fatal("expected tools to be an array")
+	}
+	tools.ForEach(func(i, tool gjson.Result) bool {
+		if tool.Get("defer_loading").Exists() {
+			t.Fatalf("tool %d still has defer_loading: %s", i.Int(), tool.Raw)
+		}
+		return true
+	})
+}


### PR DESCRIPTION
## Summary\n- Fix incorrect sjson.Delete path: tools.#.defer_loading does not actually delete anything.\n- Use gjson.ForEach + explicit index-based sjson.Delete to strip defer_loading from each tool.\n- Add unit test verifying defer_loading is removed.\n\n## Test plan\n- [x] go test ./internal/translator/codex/claude -v\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)