### PR TITLE
feat: persist CC Switch presets in sqlite

### DIFF
--- a/internal/api/handlers/management/ccswitch_import_configs.go
+++ b/internal/api/handlers/management/ccswitch_import_configs.go
@@ -1,0 +1,84 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func (h *Handler) GetCcSwitchImportConfigs(c *gin.Context) {
+	items := usage.ListCcSwitchImportConfigs()
+	if items == nil {
+		items = []usage.CcSwitchImportConfigRow{}
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"ccswitch-import-configs": items,
+		"items":                   items,
+	})
+}
+
+func (h *Handler) PutCcSwitchImportConfigs(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+		return
+	}
+
+	var items []usage.CcSwitchImportConfigRow
+	if err = json.Unmarshal(data, &items); err != nil {
+		var body struct {
+			Items []usage.CcSwitchImportConfigRow `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &body); err2 != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+			return
+		}
+		items = body.Items
+	}
+
+	for idx := range items {
+		items[idx] = usage.CcSwitchImportConfigRow{
+			ID:                   strings.TrimSpace(items[idx].ID),
+			ClientType:           strings.ToLower(strings.TrimSpace(items[idx].ClientType)),
+			ProviderName:         strings.TrimSpace(items[idx].ProviderName),
+			Note:                 strings.TrimSpace(items[idx].Note),
+			DefaultModel:         strings.TrimSpace(items[idx].DefaultModel),
+			AllowedChannelGroups: items[idx].AllowedChannelGroups,
+			EndpointPath:         items[idx].EndpointPath,
+			UsageAutoInterval:    items[idx].UsageAutoInterval,
+			APIKeyField:          strings.TrimSpace(items[idx].APIKeyField),
+			CreatedAt:            strings.TrimSpace(items[idx].CreatedAt),
+			UpdatedAt:            strings.TrimSpace(items[idx].UpdatedAt),
+		}
+
+		switch items[idx].ClientType {
+		case "claude", "codex", "gemini":
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "client-type must be one of claude, codex, gemini"})
+			return
+		}
+
+		if items[idx].ID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+			return
+		}
+		if items[idx].ProviderName == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "provider-name is required"})
+			return
+		}
+		if items[idx].DefaultModel == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "default-model is required"})
+			return
+		}
+	}
+
+	if err := usage.ReplaceAllCcSwitchImportConfigs(items); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/internal/api/handlers/management/ccswitch_import_configs_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_test.go
@@ -1,0 +1,109 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestCcSwitchImportConfigsManagementHandlersUseDatabase(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	h := NewHandler(&config.Config{}, "", nil)
+
+	getEmptyRec := httptest.NewRecorder()
+	getEmptyCtx, _ := gin.CreateTestContext(getEmptyRec)
+	getEmptyCtx.Request = httptest.NewRequest(http.MethodGet, "/ccswitch-import-configs", nil)
+
+	h.GetCcSwitchImportConfigs(getEmptyCtx)
+	if getEmptyRec.Code != http.StatusOK {
+		t.Fatalf("empty GET status = %d, want %d; body=%s", getEmptyRec.Code, http.StatusOK, getEmptyRec.Body.String())
+	}
+
+	var emptyPayload struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(getEmptyRec.Body.Bytes(), &emptyPayload); err != nil {
+		t.Fatalf("unmarshal empty GET response: %v", err)
+	}
+	if len(emptyPayload.Items) != 0 {
+		t.Fatalf("empty GET returned %d item(s), want 0", len(emptyPayload.Items))
+	}
+
+	body := []byte(`[
+  {
+    "id": "cfg-claude",
+    "client-type": "claude",
+    "provider-name": "Relay Claude",
+    "note": "Team preset",
+    "default-model": "claude-sonnet-4-5",
+    "allowed-channel-groups": ["team-a", "team-b"],
+    "endpoint-path": "/anthropic",
+    "usage-auto-interval": 45,
+    "api-key-field": "ANTHROPIC_AUTH_TOKEN"
+  }
+]`)
+
+	putRec := httptest.NewRecorder()
+	putCtx, _ := gin.CreateTestContext(putRec)
+	putCtx.Request = httptest.NewRequest(http.MethodPut, "/ccswitch-import-configs", bytes.NewReader(body))
+
+	h.PutCcSwitchImportConfigs(putCtx)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d; body=%s", putRec.Code, http.StatusOK, putRec.Body.String())
+	}
+
+	getRec := httptest.NewRecorder()
+	getCtx, _ := gin.CreateTestContext(getRec)
+	getCtx.Request = httptest.NewRequest(http.MethodGet, "/ccswitch-import-configs", nil)
+
+	h.GetCcSwitchImportConfigs(getCtx)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d; body=%s", getRec.Code, http.StatusOK, getRec.Body.String())
+	}
+
+	var got struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal GET response: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(got.Items))
+	}
+	if got.Items[0]["client-type"] != "claude" {
+		t.Fatalf("client-type = %#v, want claude", got.Items[0]["client-type"])
+	}
+	if got.Items[0]["provider-name"] != "Relay Claude" {
+		t.Fatalf("provider-name = %#v, want Relay Claude", got.Items[0]["provider-name"])
+	}
+	if got.Items[0]["api-key-field"] != "ANTHROPIC_AUTH_TOKEN" {
+		t.Fatalf("api-key-field = %#v, want ANTHROPIC_AUTH_TOKEN", got.Items[0]["api-key-field"])
+	}
+}
+
+func TestPutCcSwitchImportConfigsRejectsInvalidClientType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(
+		http.MethodPut,
+		"/ccswitch-import-configs",
+		bytes.NewReader([]byte(`[{"id":"cfg-1","client-type":"unknown","provider-name":"Relay","default-model":"gpt-5.5"}]`)),
+	)
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.PutCcSwitchImportConfigs(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -629,6 +629,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PUT("/model-openrouter-sync", s.mgmt.PutOpenRouterModelSync)
 		mgmt.POST("/model-openrouter-sync/run", s.mgmt.PostOpenRouterModelSyncRun)
 		mgmt.GET("/channel-groups", s.mgmt.GetChannelGroups)
+		mgmt.GET("/ccswitch-import-configs", s.mgmt.GetCcSwitchImportConfigs)
+		mgmt.PUT("/ccswitch-import-configs", s.mgmt.PutCcSwitchImportConfigs)
 		mgmt.GET("/routing-config", s.mgmt.GetRoutingConfig)
 		mgmt.PUT("/routing-config", s.mgmt.PutRoutingConfig)
 		mgmt.GET("/identity-fingerprint", s.mgmt.GetIdentityFingerprint)

--- a/internal/usage/ccswitch_import_configs_db.go
+++ b/internal/usage/ccswitch_import_configs_db.go
@@ -1,0 +1,230 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type CcSwitchImportConfigRow struct {
+	ID                   string   `json:"id"`
+	ClientType           string   `json:"client-type"`
+	ProviderName         string   `json:"provider-name"`
+	Note                 string   `json:"note"`
+	DefaultModel         string   `json:"default-model"`
+	AllowedChannelGroups []string `json:"allowed-channel-groups"`
+	EndpointPath         string   `json:"endpoint-path"`
+	UsageAutoInterval    int      `json:"usage-auto-interval"`
+	APIKeyField          string   `json:"api-key-field,omitempty"`
+	CreatedAt            string   `json:"created-at,omitempty"`
+	UpdatedAt            string   `json:"updated-at,omitempty"`
+}
+
+const createCcSwitchImportConfigsTableSQL = `
+CREATE TABLE IF NOT EXISTS ccswitch_import_configs (
+  id                     TEXT PRIMARY KEY NOT NULL,
+  client_type            TEXT NOT NULL,
+  provider_name          TEXT NOT NULL DEFAULT '',
+  note                   TEXT NOT NULL DEFAULT '',
+  default_model          TEXT NOT NULL DEFAULT '',
+  allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+  endpoint_path          TEXT NOT NULL DEFAULT '',
+  usage_auto_interval    INTEGER NOT NULL DEFAULT 30,
+  api_key_field          TEXT NOT NULL DEFAULT '',
+  created_at             TEXT NOT NULL DEFAULT '',
+  updated_at             TEXT NOT NULL DEFAULT ''
+);
+`
+
+func initCcSwitchImportConfigsTable(db *sql.DB) {
+	if _, err := db.Exec(createCcSwitchImportConfigsTableSQL); err != nil {
+		log.Errorf("usage: create ccswitch_import_configs table: %v", err)
+	}
+}
+
+func ListCcSwitchImportConfigs() []CcSwitchImportConfigRow {
+	db := getDB()
+	if db == nil {
+		return nil
+	}
+
+	rows, err := db.Query(`SELECT id, client_type, provider_name, note, default_model,
+		allowed_channel_groups, endpoint_path, usage_auto_interval, api_key_field, created_at, updated_at
+		FROM ccswitch_import_configs ORDER BY created_at ASC, id ASC`)
+	if err != nil {
+		log.Errorf("usage: list ccswitch_import_configs: %v", err)
+		return nil
+	}
+	defer rows.Close()
+
+	var result []CcSwitchImportConfigRow
+	for rows.Next() {
+		row := scanCcSwitchImportConfigFromRow(rows)
+		if row != nil {
+			result = append(result, *row)
+		}
+	}
+	return result
+}
+
+func ReplaceAllCcSwitchImportConfigs(configs []CcSwitchImportConfigRow) error {
+	db := getDB()
+	if db == nil {
+		return fmt.Errorf("database not initialised")
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec("DELETE FROM ccswitch_import_configs"); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	stmt, err := tx.Prepare(`INSERT INTO ccswitch_import_configs
+		(id, client_type, provider_name, note, default_model, allowed_channel_groups,
+		 endpoint_path, usage_auto_interval, api_key_field, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	seen := make(map[string]struct{}, len(configs))
+	for _, row := range configs {
+		row = normalizeCcSwitchImportConfigRow(row)
+		if row.ID == "" {
+			_ = tx.Rollback()
+			return fmt.Errorf("id is required")
+		}
+		if row.ClientType == "" {
+			_ = tx.Rollback()
+			return fmt.Errorf("client-type is required")
+		}
+		if row.ProviderName == "" {
+			_ = tx.Rollback()
+			return fmt.Errorf("provider-name is required")
+		}
+		if row.DefaultModel == "" {
+			_ = tx.Rollback()
+			return fmt.Errorf("default-model is required")
+		}
+		if _, exists := seen[row.ID]; exists {
+			_ = tx.Rollback()
+			return fmt.Errorf("duplicate id %q", row.ID)
+		}
+		seen[row.ID] = struct{}{}
+		if row.CreatedAt == "" {
+			row.CreatedAt = now
+		}
+		row.UpdatedAt = now
+
+		if _, err := stmt.Exec(
+			row.ID,
+			row.ClientType,
+			row.ProviderName,
+			row.Note,
+			row.DefaultModel,
+			mustJSONStringList(row.AllowedChannelGroups),
+			row.EndpointPath,
+			row.UsageAutoInterval,
+			row.APIKeyField,
+			row.CreatedAt,
+			row.UpdatedAt,
+		); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func normalizeCcSwitchImportConfigRow(row CcSwitchImportConfigRow) CcSwitchImportConfigRow {
+	row.ID = strings.TrimSpace(row.ID)
+	row.ClientType = strings.ToLower(strings.TrimSpace(row.ClientType))
+	row.ProviderName = strings.TrimSpace(row.ProviderName)
+	row.Note = strings.TrimSpace(row.Note)
+	row.DefaultModel = strings.TrimSpace(row.DefaultModel)
+	row.AllowedChannelGroups = normalizeLowerStringSlice(row.AllowedChannelGroups)
+	row.EndpointPath = normalizeCcSwitchEndpointPath(row.EndpointPath)
+	if row.UsageAutoInterval <= 0 {
+		row.UsageAutoInterval = 30
+	}
+	if row.ClientType == "claude" {
+		row.APIKeyField = normalizeCcSwitchAPIKeyField(row.APIKeyField)
+	} else {
+		row.APIKeyField = ""
+	}
+	return row
+}
+
+func normalizeLowerStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.ToLower(strings.TrimSpace(value))
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		result = append(result, trimmed)
+	}
+	if result == nil {
+		return []string{}
+	}
+	return result
+}
+
+func normalizeCcSwitchEndpointPath(value string) string {
+	raw := strings.TrimSpace(value)
+	if raw == "" || raw == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(raw, "/") {
+		raw = "/" + raw
+	}
+	return strings.TrimRight(raw, "/")
+}
+
+func normalizeCcSwitchAPIKeyField(value string) string {
+	if strings.EqualFold(strings.TrimSpace(value), "ANTHROPIC_AUTH_TOKEN") {
+		return "ANTHROPIC_AUTH_TOKEN"
+	}
+	return "ANTHROPIC_API_KEY"
+}
+
+func scanCcSwitchImportConfigFromRow(row scannable) *CcSwitchImportConfigRow {
+	var result CcSwitchImportConfigRow
+	var allowedChannelGroupsJSON string
+	if err := row.Scan(
+		&result.ID,
+		&result.ClientType,
+		&result.ProviderName,
+		&result.Note,
+		&result.DefaultModel,
+		&allowedChannelGroupsJSON,
+		&result.EndpointPath,
+		&result.UsageAutoInterval,
+		&result.APIKeyField,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	); err != nil {
+		return nil
+	}
+	result.AllowedChannelGroups = decodeJSONStringList(allowedChannelGroupsJSON)
+	return &result
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -320,6 +320,8 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	initAPIKeysTable(db)
 	log.Debugf("usage: initializing api_key_permission_profiles table")
 	initAPIKeyPermissionProfilesTable(db)
+	log.Debugf("usage: initializing ccswitch_import_configs table")
+	initCcSwitchImportConfigsTable(db)
 	log.Debugf("usage: initializing routing_config table")
 	initRoutingConfigTable(db)
 	log.Debugf("usage: initializing proxy_pool table")


### PR DESCRIPTION
## Summary
- add SQLite storage for CC Switch import presets
- expose management API endpoints for listing and replacing presets
- cover the new handlers with database-backed tests
