### PR TITLE
fix(network): force all upstream connections over IPv4

### DIFF
--- a/internal/auth/claude/utls_transport.go
+++ b/internal/auth/claude/utls_transport.go
@@ -103,7 +103,7 @@ func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.Clie
 
 // createConnection creates a new HTTP/2 connection with Firefox TLS fingerprint
 func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientConn, error) {
-	conn, err := t.dialer.Dial("tcp", addr)
+	conn, err := t.dialer.Dial("tcp4", addr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/proxy.go
+++ b/internal/util/proxy.go
@@ -35,7 +35,7 @@ func NewHTTPClient(timeout time.Duration) *http.Client {
 func NewDefaultTransport() *http.Transport {
 	return &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           (&net.Dialer{Timeout: DefaultHTTPDialTimeout, KeepAlive: 30 * time.Second}).DialContext,
+		DialContext:           (&net.Dialer{Timeout: DefaultHTTPDialTimeout, KeepAlive: 30 * time.Second, LocalAddr: &net.TCPAddr{IP: net.IPv4zero}}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       DefaultHTTPIdleConnTimeout,


### PR DESCRIPTION
## 问题

BWG VPS 的 IPv6 通过 SIT 隧道（ipv6net@NONE）提供，不是原生 IPv6。导致：
- 到 IPv6 网关的第 1 跳延迟 5-14ms（IPv4 仅 0.6ms）
- 隧道有额外封装开销和稳定性风险
- CliRelay 向上游 API（Gemini、Anthropic 等）的连接部分走了 IPv6

## 改动

- `internal/util/proxy.go`: `net.Dialer` 绑定 `LocalAddr` 到 `0.0.0.0`，强制只使用 IPv4
- `internal/auth/claude/utls_transport.go`: uTLS Dial 使用 `tcp4` 替代 `tcp`

## 验证

- [x] `go build ./cmd/server/` 编译通过