### PR TITLE
feat(network): make prefer-ipv4 configurable via config.yaml

### DIFF
--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -150,7 +150,7 @@ func (h *Handler) PostProxyPoolCheck(c *gin.Context) {
 }
 
 func checkProxyConnectivity(ctx context.Context, proxyURL string, testURL string) (int, error) {
-	transport := util.BuildProxyTransport(proxyURL)
+	transport := util.BuildProxyTransport(proxyURL, false)
 	if transport == nil {
 		return 0, fmt.Errorf("failed to build proxy transport")
 	}

--- a/internal/auth/claude/utls_transport.go
+++ b/internal/auth/claude/utls_transport.go
@@ -27,6 +27,8 @@ type utlsRoundTripper struct {
 	pending map[string]*sync.Cond
 	// dialer is used to create network connections, supporting proxies
 	dialer proxy.Dialer
+	// preferIPv4 forces IPv4-only dialing when true
+	preferIPv4 bool
 }
 
 // newUtlsRoundTripper creates a new utls-based round tripper with optional proxy support
@@ -50,6 +52,7 @@ func newUtlsRoundTripper(cfg *config.SDKConfig) *utlsRoundTripper {
 		connections: make(map[string]*http2.ClientConn),
 		pending:     make(map[string]*sync.Cond),
 		dialer:      dialer,
+		preferIPv4:  cfg != nil && cfg.PreferIPv4,
 	}
 }
 
@@ -103,7 +106,11 @@ func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.Clie
 
 // createConnection creates a new HTTP/2 connection with Firefox TLS fingerprint
 func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientConn, error) {
-	conn, err := t.dialer.Dial("tcp4", addr)
+	network := "tcp"
+	if t.preferIPv4 {
+		network = "tcp4"
+	}
+	conn, err := t.dialer.Dial(network, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -9,6 +9,11 @@ type SDKConfig struct {
 	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
 	ProxyURL string `yaml:"proxy-url" json:"proxy-url"`
 
+	// PreferIPv4 forces all outbound upstream connections to use IPv4 only.
+	// When true, the dialer binds to 0.0.0.0 and skips IPv6 resolution.
+	// Useful when the server's IPv6 route quality is poor (e.g. SIT tunnel).
+	PreferIPv4 bool `yaml:"prefer-ipv4" json:"prefer-ipv4"`
+
 	// ForceModelPrefix requires explicit model prefixes (e.g., "teamA/gemini-3-pro-preview")
 	// to target prefixed credentials. When false, unprefixed model requests may use prefixed
 	// credentials as well.

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -44,7 +44,7 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 
 	// If we have a proxy URL configured, set up the transport
 	if proxyURL != "" {
-		transport := util.BuildProxyTransport(proxyURL)
+		transport := util.BuildProxyTransport(proxyURL, false)
 		if transport != nil {
 			httpClient.Transport = transport
 			return httpClient

--- a/internal/util/proxy.go
+++ b/internal/util/proxy.go
@@ -32,10 +32,14 @@ func NewHTTPClient(timeout time.Duration) *http.Client {
 	return client
 }
 
-func NewDefaultTransport() *http.Transport {
+func NewDefaultTransport(preferIPv4 bool) *http.Transport {
+	dialer := &net.Dialer{Timeout: DefaultHTTPDialTimeout, KeepAlive: 30 * time.Second}
+	if preferIPv4 {
+		dialer.LocalAddr = &net.TCPAddr{IP: net.IPv4zero}
+	}
 	return &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           (&net.Dialer{Timeout: DefaultHTTPDialTimeout, KeepAlive: 30 * time.Second, LocalAddr: &net.TCPAddr{IP: net.IPv4zero}}).DialContext,
+		DialContext:           dialer.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       DefaultHTTPIdleConnTimeout,
@@ -46,7 +50,7 @@ func NewDefaultTransport() *http.Transport {
 	}
 }
 
-func BuildProxyTransport(proxyURL string) *http.Transport {
+func BuildProxyTransport(proxyURL string, preferIPv4 bool) *http.Transport {
 	proxyURL = strings.TrimSpace(proxyURL)
 	if proxyURL == "" {
 		return nil
@@ -58,7 +62,7 @@ func BuildProxyTransport(proxyURL string) *http.Transport {
 		return nil
 	}
 
-	transport := NewDefaultTransport()
+	transport := NewDefaultTransport(preferIPv4)
 	switch parsedURL.Scheme {
 	case "socks5":
 		var proxyAuth *proxy.Auth
@@ -74,6 +78,9 @@ func BuildProxyTransport(proxyURL string) *http.Transport {
 		}
 		transport.Proxy = nil
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if preferIPv4 {
+				network = "tcp4"
+			}
 			return dialer.Dial(network, addr)
 		}
 	case "http", "https":
@@ -95,14 +102,14 @@ func SetProxy(cfg *config.SDKConfig, httpClient *http.Client) *http.Client {
 	}
 	if cfg == nil {
 		if httpClient.Transport == nil {
-			httpClient.Transport = NewDefaultTransport()
+			httpClient.Transport = NewDefaultTransport(false)
 		}
 		return httpClient
 	}
 	if httpClient.Transport == nil {
-		httpClient.Transport = NewDefaultTransport()
+		httpClient.Transport = NewDefaultTransport(cfg.PreferIPv4)
 	}
-	if transport := BuildProxyTransport(cfg.ProxyURL); transport != nil {
+	if transport := BuildProxyTransport(cfg.ProxyURL, cfg.PreferIPv4); transport != nil {
 		httpClient.Transport = transport
 	}
 	return httpClient


### PR DESCRIPTION
## 问题

BWG VPS 的 IPv6 通过 SIT 隧道提供，回程质量较差（到网关第 1 跳 5-14ms vs IPv4 的 0.6ms）。之前 PR #161 将 IPv4 强制写死，缺乏灵活性。

## 改动

将 IPv4 优先改为可配置项 `prefer-ipv4`，通过 `config.yaml` 或管理面板可视化编辑器控制。

- `sdk_config.go`: 新增 `PreferIPv4 bool` 字段
- `proxy.go`: `NewDefaultTransport` / `BuildProxyTransport` 接收 `preferIPv4` 参数
- `utls_transport.go`: Anthropic 连接也遵循配置
- `proxy_pool.go`, `proxy_helpers.go`: 更新调用签名

## 验证

- [x] `go build ./cmd/server/` 编译通过