### PR TITLE
fix(network): honor prefer ipv4 for proxy-aware transports

### DIFF
--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -44,7 +44,7 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 
 	// If we have a proxy URL configured, set up the transport
 	if proxyURL != "" {
-		transport := util.BuildProxyTransport(proxyURL, false)
+		transport := util.BuildProxyTransport(proxyURL, cfg != nil && cfg.PreferIPv4)
 		if transport != nil {
 			httpClient.Transport = transport
 			return httpClient

--- a/internal/runtime/executor/proxy_helpers_test.go
+++ b/internal/runtime/executor/proxy_helpers_test.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -73,4 +75,45 @@ func TestNewProxyAwareHTTPClientFallsBackWhenProxyIDMissing(t *testing.T) {
 		t.Fatalf("client.Get returned error: %v", err)
 	}
 	_ = resp.Body.Close()
+}
+
+func TestNewProxyAwareHTTPClientHonorsPreferIPv4ForHTTPProxy(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("ipv6 loopback unavailable: %v", err)
+	}
+
+	proxyHits := 0
+	proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHits++
+		if r.URL.String() != "http://target.example/check" {
+			t.Fatalf("proxy received URL %q", r.URL.String())
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	proxyServer.Listener = listener
+	proxyServer.Start()
+	defer proxyServer.Close()
+
+	cfg := &config.Config{}
+	cfg.PreferIPv4 = true
+	auth := &cliproxyauth.Auth{
+		ProxyURL: fmt.Sprintf("http://%s", listener.Addr().String()),
+	}
+	client := newProxyAwareHTTPClient(context.Background(), cfg, auth, 0)
+
+	req, err := http.NewRequest(http.MethodGet, "http://target.example/check", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("client.Do unexpectedly succeeded via IPv6 proxy while preferIPv4 is enabled")
+	}
+	if proxyHits != 0 {
+		t.Fatalf("proxy hits = %d, want 0 when preferIPv4 blocks IPv6-only proxy", proxyHits)
+	}
 }

--- a/internal/util/proxy.go
+++ b/internal/util/proxy.go
@@ -34,12 +34,16 @@ func NewHTTPClient(timeout time.Duration) *http.Client {
 
 func NewDefaultTransport(preferIPv4 bool) *http.Transport {
 	dialer := &net.Dialer{Timeout: DefaultHTTPDialTimeout, KeepAlive: 30 * time.Second}
+	dialContext := dialer.DialContext
 	if preferIPv4 {
 		dialer.LocalAddr = &net.TCPAddr{IP: net.IPv4zero}
+		dialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp4", addr)
+		}
 	}
 	return &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           dialer.DialContext,
+		DialContext:           dialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       DefaultHTTPIdleConnTimeout,


### PR DESCRIPTION
## Summary
- honor `PreferIPv4` in proxy-aware executor HTTP clients
- force the default transport dialer to use `tcp4` when the flag is enabled
- add a regression test covering an IPv6-only HTTP proxy path

## Verification
- go test ./internal/runtime/executor -run TestNewProxyAwareHTTPClientHonorsPreferIPv4ForHTTPProxy -count=1
- go test ./internal/runtime/executor ./internal/util -count=1
- go test ./... -count=1