### PR TITLE
feat: add request log database cleanup endpoint

### DIFF
--- a/docs/superpowers/plans/2026-05-08-request-log-database-cleanup.md
+++ b/docs/superpowers/plans/2026-05-08-request-log-database-cleanup.md
@@ -1,0 +1,314 @@
+# Request Log Database Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a safe one-click cleanup action on the Request Logs page that deletes only SQLite request-log history and message bodies.
+
+**Architecture:** Extend the existing management usage-log API with a `DELETE /usage/logs` endpoint backed by a usage-layer table cleanup helper, then surface that endpoint from the Request Logs page with an explicit danger confirmation modal and immediate refresh.
+
+**Tech Stack:** Go, Gin, SQLite (`modernc.org/sqlite`), React, TypeScript, Vitest
+
+---
+
+### Task 1: Backend usage-layer cleanup primitive
+
+**Files:**
+- Modify: `internal/usage/usage_db.go`
+- Test: `internal/usage/usage_db_test.go`
+
+- [ ] **Step 1: Write the failing usage-layer test**
+
+```go
+func TestClearAllRequestLogsRemovesRequestLogTablesOnly(t *testing.T) {
+	dbPath := t.TempDir() + "/usage.db"
+	if err := InitDB(dbPath); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer CloseDB()
+
+	entry := LogEntry{
+		Timestamp:   time.Now().UTC(),
+		APIKey:      "sk-test",
+		Model:       "gpt-5",
+		TotalTokens: 12,
+	}
+	logID, err := InsertLog(entry)
+	if err != nil {
+		t.Fatalf("InsertLog() error = %v", err)
+	}
+	if _, err := getDB().Exec(
+		`INSERT INTO request_log_content (log_id, timestamp, compression, input_content, output_content)
+		 VALUES (?, ?, 'none', X'01', X'02')`,
+		logID,
+		time.Now().UTC().Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("seed request_log_content error = %v", err)
+	}
+
+	result, err := ClearAllRequestLogs()
+	if err != nil {
+		t.Fatalf("ClearAllRequestLogs() error = %v", err)
+	}
+	if result.DeletedLogs != 1 || result.DeletedContents != 1 {
+		t.Fatalf("unexpected cleanup result: %#v", result)
+	}
+
+	var logsCount, contentCount int
+	if err := getDB().QueryRow("SELECT COUNT(*) FROM request_logs").Scan(&logsCount); err != nil {
+		t.Fatalf("count request_logs error = %v", err)
+	}
+	if err := getDB().QueryRow("SELECT COUNT(*) FROM request_log_content").Scan(&contentCount); err != nil {
+		t.Fatalf("count request_log_content error = %v", err)
+	}
+	if logsCount != 0 || contentCount != 0 {
+		t.Fatalf("expected empty request log tables, got logs=%d content=%d", logsCount, contentCount)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/usage -run TestClearAllRequestLogsRemovesRequestLogTablesOnly -count=1`
+Expected: FAIL because `ClearAllRequestLogs` does not exist yet.
+
+- [ ] **Step 3: Write the minimal cleanup implementation**
+
+```go
+type ClearRequestLogsResult struct {
+	DeletedLogs     int64 `json:"deleted_logs"`
+	DeletedContents int64 `json:"deleted_contents"`
+}
+
+func ClearAllRequestLogs() (ClearRequestLogsResult, error) {
+	db := getDB()
+	if db == nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: database not initialised")
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: begin clear request logs: %w", err)
+	}
+	defer rollbackTx(tx)
+
+	contentResult, err := tx.Exec("DELETE FROM request_log_content")
+	if err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_log_content: %w", err)
+	}
+	logResult, err := tx.Exec("DELETE FROM request_logs")
+	if err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_logs: %w", err)
+	}
+
+	deletedContents, _ := contentResult.RowsAffected()
+	deletedLogs, _ := logResult.RowsAffected()
+
+	if err := tx.Commit(); err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: commit clear request logs: %w", err)
+	}
+
+	if _, err := db.Exec("VACUUM"); err != nil {
+		log.Warnf("usage: vacuum after request log cleanup failed: %v", err)
+	}
+
+	return ClearRequestLogsResult{
+		DeletedLogs:     deletedLogs,
+		DeletedContents: deletedContents,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/usage -run TestClearAllRequestLogsRemovesRequestLogTablesOnly -count=1`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/usage/usage_db.go internal/usage/usage_db_test.go
+git commit -m "feat: add request log database cleanup helper"
+```
+
+### Task 2: Management API endpoint for request-log cleanup
+
+**Files:**
+- Modify: `internal/api/handlers/management/usage_logs_handler.go`
+- Modify: `internal/api/server.go`
+- Test: `internal/api/handlers/management/usage_logs_handler_test.go`
+
+- [ ] **Step 1: Write the failing handler test**
+
+```go
+func TestDeleteUsageLogsClearsRequestLogDatabase(t *testing.T) {
+	h := newTestManagementHandler(t)
+	seedUsageLog(t)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/usage/logs", nil)
+
+	h.DeleteUsageLogs(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), `"deleted_logs":1`) {
+		t.Fatalf("body = %s, want deleted count", w.Body.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/api/handlers/management -run TestDeleteUsageLogsClearsRequestLogDatabase -count=1`
+Expected: FAIL because the handler and route do not exist yet.
+
+- [ ] **Step 3: Add the minimal handler and route**
+
+```go
+func (h *Handler) DeleteUsageLogs(c *gin.Context) {
+	result, err := usage.ClearAllRequestLogs()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+```
+
+```go
+mgmt.DELETE("/usage/logs", s.mgmt.DeleteUsageLogs)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/api/handlers/management -run TestDeleteUsageLogsClearsRequestLogDatabase -count=1`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/handlers/management/usage_logs_handler.go internal/api/handlers/management/usage_logs_handler_test.go internal/api/server.go
+git commit -m "feat: expose request log cleanup management endpoint"
+```
+
+### Task 3: Frontend API client and request logs page action
+
+**Files:**
+- Modify: `src/lib/http/apis/usage.ts`
+- Modify: `src/modules/monitor/RequestLogsPage.tsx`
+- Modify: `src/i18n/locales/en.json`
+- Modify: `src/i18n/locales/zh-CN.json`
+- Test: `src/modules/monitor/__tests__/RequestLogsPage.test.tsx`
+
+- [ ] **Step 1: Write the failing page test**
+
+```tsx
+test("clears request-log database after confirmation", async () => {
+  const user = userEvent.setup();
+  mocks.getUsageLogs
+    .mockResolvedValueOnce({
+      items: [seedRow],
+      total: 1,
+      page: 1,
+      size: 50,
+      filters: { api_keys: [], api_key_names: {}, models: [], channels: [] },
+      stats: { total: 1, success_rate: 100, total_tokens: 30, total_cost: 0.01 },
+    })
+    .mockResolvedValueOnce({
+      items: [],
+      total: 0,
+      page: 1,
+      size: 50,
+      filters: { api_keys: [], api_key_names: {}, models: [], channels: [] },
+      stats: { total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 },
+    });
+  mocks.clearUsageLogs.mockResolvedValue({ deleted_logs: 1, deleted_contents: 1 });
+
+  renderRequestLogsPage();
+  await user.click(await screen.findByRole("button", { name: /Clear Database Logs/i }));
+  await user.click(await screen.findByRole("button", { name: /Clear/i }));
+
+  await waitFor(() => expect(mocks.clearUsageLogs).toHaveBeenCalledTimes(1));
+  expect(await screen.findByText("No Data")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun vitest run src/modules/monitor/__tests__/RequestLogsPage.test.tsx`
+Expected: FAIL because the page has no cleanup button or API method yet.
+
+- [ ] **Step 3: Add the minimal frontend implementation**
+
+```ts
+async clearUsageLogs(): Promise<{ deleted_logs: number; deleted_contents: number }> {
+  return apiClient.delete("/usage/logs");
+}
+```
+
+```tsx
+<Button variant="danger" onClick={() => setConfirmClearOpen(true)}>
+  {t("request_logs.clear_database_logs")}
+</Button>
+<ConfirmModal
+  open={confirmClearOpen}
+  title={t("request_logs.clear_database_logs")}
+  description={t("request_logs.clear_database_logs_confirm")}
+  confirmText={t("request_logs.clear_database_logs_confirm_button")}
+  onClose={() => setConfirmClearOpen(false)}
+  onConfirm={() => {
+    setConfirmClearOpen(false);
+    void handleClearDatabaseLogs();
+  }}
+/>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun vitest run src/modules/monitor/__tests__/RequestLogsPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/http/apis/usage.ts src/modules/monitor/RequestLogsPage.tsx src/modules/monitor/__tests__/RequestLogsPage.test.tsx src/i18n/locales/en.json src/i18n/locales/zh-CN.json
+git commit -m "feat: add request log database cleanup action"
+```
+
+### Task 4: Final verification and integration
+
+**Files:**
+- Verify only the files above plus docs in `docs/superpowers/...`
+
+- [ ] **Step 1: Run backend verification**
+
+Run: `go test ./internal/usage ./internal/api/handlers/management -count=1`
+Expected: PASS
+
+- [ ] **Step 2: Run frontend verification**
+
+Run: `bun vitest run src/modules/monitor/__tests__/RequestLogsPage.test.tsx src/modules/logs/__tests__/LogsPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 3: Run repo status checks**
+
+Run: `git status --short`
+Expected: no unrelated changes included in either feature branch
+
+- [ ] **Step 4: Merge feature branches into local dev after verification**
+
+```bash
+git checkout dev
+git merge --ff-only feature/issue-159-clear-request-log-db
+git push origin dev
+```
+
+- [ ] **Step 5: Repeat merge flow for the second repo**
+
+```bash
+git checkout dev
+git merge --ff-only feature/issue-159-clear-request-log-db
+git push origin dev
+```

--- a/docs/superpowers/specs/2026-05-08-request-log-database-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-08-request-log-database-cleanup-design.md
@@ -1,0 +1,98 @@
+# Request Log Database Cleanup Design
+
+**Problem**
+
+Issue [#159](https://github.com/kittors/CliRelay/issues/159) asks for a simple way to clear the growing SQLite request-log data shown in the management panel. The current panel already exposes:
+
+- `请求日志 / Request Logs` for SQLite-backed request history and message content.
+- `日志查询 / Logs` for file-based live logs and error log downloads.
+
+Those are different storage systems, so the cleanup entry must make the scope obvious and avoid implying that API keys, model configs, routing data, or other database-backed management records will be deleted.
+
+**Decision**
+
+Add a dangerous action entry to the `Request Logs` page, not to `Logs` or `System Monitor`.
+
+Why this is the best fit:
+
+- The page already represents `request_logs` and `request_log_content`, so the cleanup target matches the user’s mental model.
+- It avoids mixing SQLite request history cleanup with file log cleanup.
+- It keeps the blast radius narrow: only request-log history is cleared, while management configuration stored in SQLite remains untouched.
+
+**Scope**
+
+Add a one-click management action that:
+
+- Deletes all rows from `request_logs`.
+- Deletes all rows from `request_log_content`.
+- Optionally runs a SQLite `VACUUM`/checkpoint style reclaim step in the same backend operation when safe.
+- Refreshes the `Request Logs` page so totals, filters, rows, and storage indicators immediately drop to zero/empty.
+
+Out of scope:
+
+- Deleting API keys, model configs, channel groups, provider settings, permission templates, or any other business data tables.
+- Clearing file-based runtime logs under the log directory.
+- Adding new YAML config knobs.
+
+**Backend Design**
+
+Add a management endpoint under the existing usage-log namespace:
+
+- `DELETE /v0/management/usage/logs`
+
+Behavior:
+
+- Call a new usage-layer helper to clear only request-log tables.
+- Return JSON with deleted counts so the UI can show an informative success toast.
+- Keep the handler behind the existing management auth middleware.
+
+Usage-layer helper:
+
+- Add `ClearAllRequestLogs() (ClearRequestLogsResult, error)` in `internal/usage/usage_db.go`.
+- Execute the delete inside a transaction.
+- Delete `request_log_content` explicitly, then `request_logs`.
+- Run a `VACUUM` only after the transaction commits, using the same database handle.
+- Log the number of removed rows for auditability.
+
+Suggested response shape:
+
+```json
+{
+  "deleted_logs": 12345,
+  "deleted_contents": 12345
+}
+```
+
+**Frontend Design**
+
+Add the entry to the title action area of `src/modules/monitor/RequestLogsPage.tsx`.
+
+UI behavior:
+
+- Render a danger-style button such as `Clear Database Logs`.
+- Open a `ConfirmModal` with explicit copy:
+  - This clears SQLite request-log history and message bodies.
+  - This does not delete API keys or other management configuration.
+  - This action cannot be undone.
+- On confirm, call the new `usageApi.clearUsageLogs()` method.
+- Clear current table state and refetch page 1 so the table, stats, and filters match the backend.
+- Show a success toast with the deleted count when available.
+
+**Testing Strategy**
+
+Backend:
+
+- Add a usage-layer test proving `ClearAllRequestLogs()` removes both tables while leaving unrelated DB-backed data intact.
+- Add a handler test proving `DELETE /usage/logs` returns `200` with counts and empties subsequent log queries.
+
+Frontend:
+
+- Add a `RequestLogsPage` test that opens the modal, confirms the action, calls the API, and shows the updated empty state.
+- Keep `LogsPage` behavior unchanged to guard against storage-scope confusion.
+
+**Risk Controls**
+
+- The button lives only on `Request Logs`, not globally.
+- Confirmation copy states the exact deletion scope.
+- Backend helper is limited to request-log tables.
+- No production deployment or restart is performed as part of this task.

--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -197,6 +197,15 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 	})
 }
 
+func (h *Handler) DeleteUsageLogs(c *gin.Context) {
+	result, err := usage.ClearAllRequestLogs()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
 // buildNameMaps builds three maps from the current config/auth store:
 //  1. keyNameMap:          user-facing api_key → display name
 //  2. channelNameMap:      source/api_key/email → channel name

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -786,3 +786,62 @@ func TestGetPublicUsageLogs_RejectsOversizedPOSTBody(t *testing.T) {
 		t.Fatalf("expected oversized body rejection, body=%s", rec.Body.String())
 	}
 }
+
+func TestDeleteUsageLogsClearsRequestLogDatabase(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	now := time.Now().UTC()
+	usage.InsertLog("sk-target", "", "gpt-5.4", "codex", "Codex", "auth-1", false, now, 123, 45, usage.TokenStats{
+		InputTokens: 1, OutputTokens: 2, TotalTokens: 3,
+	}, `{"messages":[{"role":"user","content":"hello"}]}`, `{"id":"resp_1"}`)
+
+	h := &Handler{cfg: &config.Config{}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/usage/logs", nil)
+
+	h.DeleteUsageLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		DeletedLogs     int64 `json:"deleted_logs"`
+		DeletedContents int64 `json:"deleted_contents"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload.DeletedLogs != 1 {
+		t.Fatalf("DeletedLogs = %d, want 1", payload.DeletedLogs)
+	}
+	if payload.DeletedContents != 1 {
+		t.Fatalf("DeletedContents = %d, want 1", payload.DeletedContents)
+	}
+
+	result, err := usage.QueryLogs(usage.LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() after delete error = %v", err)
+	}
+	if len(result.Items) != 0 {
+		t.Fatalf("expected 0 request logs after delete, got %d", len(result.Items))
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -641,6 +641,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/usage/export", s.mgmt.ExportUsageStatistics)
 		mgmt.POST("/usage/import", s.mgmt.ImportUsageStatistics)
 		mgmt.GET("/usage/logs", s.mgmt.GetUsageLogs)
+		mgmt.DELETE("/usage/logs", s.mgmt.DeleteUsageLogs)
 		mgmt.GET("/usage/logs/:id/content", s.mgmt.GetLogContent)
 		mgmt.GET("/usage/auth-file-group-trend", s.mgmt.GetAuthFileGroupTrend)
 		mgmt.GET("/usage/auth-file-trend", s.mgmt.GetAuthFileTrend)

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -72,6 +72,11 @@ type LogStats struct {
 	TotalCost   float64 `json:"total_cost"`
 }
 
+type ClearRequestLogsResult struct {
+	DeletedLogs     int64 `json:"deleted_logs"`
+	DeletedContents int64 `json:"deleted_contents"`
+}
+
 type DailyCountPoint struct {
 	Date     string `json:"date"`
 	Requests int64  `json:"requests"`
@@ -618,6 +623,63 @@ func DeleteLogsByAPIKey(apiKey string) (int64, error) {
 		log.Infof("usage: deleted %d request log(s) for api_key=%s", deleted, apiKey)
 	}
 	return deleted, nil
+}
+
+// ClearAllRequestLogs removes all request_logs and request_log_content rows
+// while leaving other SQLite-backed management data untouched.
+func ClearAllRequestLogs() (ClearRequestLogsResult, error) {
+	db := getDB()
+	if db == nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: database not initialised")
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: begin clear request logs: %w", err)
+	}
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	contentResult, err := tx.Exec("DELETE FROM request_log_content")
+	if err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_log_content: %w", err)
+	}
+	logResult, err := tx.Exec("DELETE FROM request_logs")
+	if err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_logs: %w", err)
+	}
+
+	deletedContents, err := contentResult.RowsAffected()
+	if err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: content affected rows: %w", err)
+	}
+	deletedLogs, err := logResult.RowsAffected()
+	if err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: log affected rows: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return ClearRequestLogsResult{}, fmt.Errorf("usage: commit clear request logs: %w", err)
+	}
+	committed = true
+
+	if _, err := db.Exec("VACUUM"); err != nil {
+		log.Warnf("usage: vacuum after request log cleanup failed: %v", err)
+	}
+
+	if deletedLogs > 0 || deletedContents > 0 {
+		log.Infof("usage: cleared request logs (logs=%d contents=%d)", deletedLogs, deletedContents)
+	}
+
+	return ClearRequestLogsResult{
+		DeletedLogs:     deletedLogs,
+		DeletedContents: deletedContents,
+	}, nil
 }
 
 // DashboardKPI holds the aggregated KPI data needed by the dashboard page.

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -961,3 +961,72 @@ func TestDeleteLogsByAPIKeyRemovesLogsAndContent(t *testing.T) {
 		t.Fatalf("expected 1 content row (sk-other only), got %d", contentCount)
 	}
 }
+
+func TestClearAllRequestLogsRemovesRequestLogTablesOnly(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	if err := UpsertAPIKey(APIKeyRow{
+		Key:       "sk-config-keep",
+		Name:      "Config Keep",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey() error = %v", err)
+	}
+
+	timestamp := time.Now().UTC()
+	input := `{"messages":[{"role":"user","content":"hello"}]}`
+	output := `{"id":"resp_1","output":"done"}`
+
+	InsertLog("sk-target", "", "gpt-test", "source", "channel", "auth-1", false, timestamp, 100, 10, TokenStats{
+		InputTokens: 10, OutputTokens: 20, TotalTokens: 30,
+	}, input, output)
+	InsertLog("sk-other", "", "gpt-test", "source", "channel", "auth-2", false, timestamp, 200, 20, TokenStats{
+		InputTokens: 5, OutputTokens: 10, TotalTokens: 15,
+	}, input, output)
+
+	result, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() error = %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("expected 2 log rows before cleanup, got %d", len(result.Items))
+	}
+
+	cleared, err := ClearAllRequestLogs()
+	if err != nil {
+		t.Fatalf("ClearAllRequestLogs() error = %v", err)
+	}
+	if cleared.DeletedLogs != 2 {
+		t.Fatalf("DeletedLogs = %d, want 2", cleared.DeletedLogs)
+	}
+	if cleared.DeletedContents != 2 {
+		t.Fatalf("DeletedContents = %d, want 2", cleared.DeletedContents)
+	}
+
+	result, err = QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() after cleanup error = %v", err)
+	}
+	if len(result.Items) != 0 {
+		t.Fatalf("expected 0 log rows after cleanup, got %d", len(result.Items))
+	}
+
+	db := getDB()
+	var contentCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM request_log_content").Scan(&contentCount); err != nil {
+		t.Fatalf("count content rows: %v", err)
+	}
+	if contentCount != 0 {
+		t.Fatalf("expected 0 content rows after cleanup, got %d", contentCount)
+	}
+
+	keys := ListAPIKeys()
+	if len(keys) != 1 || keys[0].Key != "sk-config-keep" {
+		t.Fatalf("ListAPIKeys() = %#v, want preserved api key row", keys)
+	}
+}


### PR DESCRIPTION
## Summary
- add a management endpoint to clear only request log tables from SQLite
- add regression tests for the usage helper and management handler
- document the design and implementation plan for issue #159

## Verification
- go test ./internal/usage ./internal/api/handlers/management -count=1