### PR TITLE
fix(network): propagate prefer-ipv4 to all executor HTTP clients

### DIFF
--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -150,7 +150,7 @@ func (h *Handler) PostProxyPoolCheck(c *gin.Context) {
 }
 
 func checkProxyConnectivity(ctx context.Context, proxyURL string, testURL string) (int, error) {
-	transport := util.BuildProxyTransport(proxyURL)
+	transport := util.BuildProxyTransport(proxyURL, false)
 	if transport == nil {
 		return 0, fmt.Errorf("failed to build proxy transport")
 	}

--- a/internal/auth/claude/utls_transport.go
+++ b/internal/auth/claude/utls_transport.go
@@ -27,6 +27,8 @@ type utlsRoundTripper struct {
 	pending map[string]*sync.Cond
 	// dialer is used to create network connections, supporting proxies
 	dialer proxy.Dialer
+	// preferIPv4 forces IPv4-only dialing when true
+	preferIPv4 bool
 }
 
 // newUtlsRoundTripper creates a new utls-based round tripper with optional proxy support
@@ -50,6 +52,7 @@ func newUtlsRoundTripper(cfg *config.SDKConfig) *utlsRoundTripper {
 		connections: make(map[string]*http2.ClientConn),
 		pending:     make(map[string]*sync.Cond),
 		dialer:      dialer,
+		preferIPv4:  cfg != nil && cfg.PreferIPv4,
 	}
 }
 
@@ -103,7 +106,11 @@ func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.Clie
 
 // createConnection creates a new HTTP/2 connection with Firefox TLS fingerprint
 func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientConn, error) {
-	conn, err := t.dialer.Dial("tcp4", addr)
+	network := "tcp"
+	if t.preferIPv4 {
+		network = "tcp4"
+	}
+	conn, err := t.dialer.Dial(network, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -9,6 +9,11 @@ type SDKConfig struct {
 	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
 	ProxyURL string `yaml:"proxy-url" json:"proxy-url"`
 
+	// PreferIPv4 forces all outbound upstream connections to use IPv4 only.
+	// When true, the dialer binds to 0.0.0.0 and skips IPv6 resolution.
+	// Useful when the server's IPv6 route quality is poor (e.g. SIT tunnel).
+	PreferIPv4 bool `yaml:"prefer-ipv4" json:"prefer-ipv4"`
+
 	// ForceModelPrefix requires explicit model prefixes (e.g., "teamA/gemini-3-pro-preview")
 	// to target prefixed credentials. When false, unprefixed model requests may use prefixed
 	// credentials as well.

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -44,7 +44,7 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 
 	// If we have a proxy URL configured, set up the transport
 	if proxyURL != "" {
-		transport := util.BuildProxyTransport(proxyURL)
+		transport := util.BuildProxyTransport(proxyURL, false)
 		if transport != nil {
 			httpClient.Transport = transport
 			return httpClient

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -42,9 +42,11 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		proxyURL = strings.TrimSpace(auth.ProxyURL)
 	}
 
+	preferIPv4 := cfg != nil && cfg.PreferIPv4
+
 	// If we have a proxy URL configured, set up the transport
 	if proxyURL != "" {
-		transport := util.BuildProxyTransport(proxyURL, false)
+		transport := util.BuildProxyTransport(proxyURL, preferIPv4)
 		if transport != nil {
 			httpClient.Transport = transport
 			return httpClient
@@ -56,6 +58,11 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	// Priority 4: Use RoundTripper from context (typically from RoundTripperFor)
 	if rt, ok := ctx.Value(util.ContextKeyRoundTripper).(http.RoundTripper); ok && rt != nil {
 		httpClient.Transport = rt
+	}
+
+	// If no transport was configured, apply the default one (which respects prefer-ipv4)
+	if httpClient.Transport == nil {
+		httpClient.Transport = util.NewDefaultTransport(preferIPv4)
 	}
 
 	return httpClient

--- a/internal/util/proxy.go
+++ b/internal/util/proxy.go
@@ -32,10 +32,14 @@ func NewHTTPClient(timeout time.Duration) *http.Client {
 	return client
 }
 
-func NewDefaultTransport() *http.Transport {
+func NewDefaultTransport(preferIPv4 bool) *http.Transport {
+	dialer := &net.Dialer{Timeout: DefaultHTTPDialTimeout, KeepAlive: 30 * time.Second}
+	if preferIPv4 {
+		dialer.LocalAddr = &net.TCPAddr{IP: net.IPv4zero}
+	}
 	return &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           (&net.Dialer{Timeout: DefaultHTTPDialTimeout, KeepAlive: 30 * time.Second, LocalAddr: &net.TCPAddr{IP: net.IPv4zero}}).DialContext,
+		DialContext:           dialer.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       DefaultHTTPIdleConnTimeout,
@@ -46,7 +50,7 @@ func NewDefaultTransport() *http.Transport {
 	}
 }
 
-func BuildProxyTransport(proxyURL string) *http.Transport {
+func BuildProxyTransport(proxyURL string, preferIPv4 bool) *http.Transport {
 	proxyURL = strings.TrimSpace(proxyURL)
 	if proxyURL == "" {
 		return nil
@@ -58,7 +62,7 @@ func BuildProxyTransport(proxyURL string) *http.Transport {
 		return nil
 	}
 
-	transport := NewDefaultTransport()
+	transport := NewDefaultTransport(preferIPv4)
 	switch parsedURL.Scheme {
 	case "socks5":
 		var proxyAuth *proxy.Auth
@@ -74,6 +78,9 @@ func BuildProxyTransport(proxyURL string) *http.Transport {
 		}
 		transport.Proxy = nil
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if preferIPv4 {
+				network = "tcp4"
+			}
 			return dialer.Dial(network, addr)
 		}
 	case "http", "https":
@@ -95,14 +102,14 @@ func SetProxy(cfg *config.SDKConfig, httpClient *http.Client) *http.Client {
 	}
 	if cfg == nil {
 		if httpClient.Transport == nil {
-			httpClient.Transport = NewDefaultTransport()
+			httpClient.Transport = NewDefaultTransport(false)
 		}
 		return httpClient
 	}
 	if httpClient.Transport == nil {
-		httpClient.Transport = NewDefaultTransport()
+		httpClient.Transport = NewDefaultTransport(cfg.PreferIPv4)
 	}
-	if transport := BuildProxyTransport(cfg.ProxyURL); transport != nil {
+	if transport := BuildProxyTransport(cfg.ProxyURL, cfg.PreferIPv4); transport != nil {
 		httpClient.Transport = transport
 	}
 	return httpClient


### PR DESCRIPTION
## 问题

开启 `prefer-ipv4` 后，Codex 请求仍然走 IPv6：
```
Post "https://chatgpt.com/backend-api/codex/responses": read tcp [2607:8700:5500:8131::2]:32772->[2a06:98c1:3100::6812:202f]:443: read: connection reset by peer
```

## 根因

`newProxyAwareHTTPClient`（所有 executor 的 HTTP Client 工厂函数）有两个遗漏：

1. **`BuildProxyTransport(proxyURL, false)` 硬编码了 `false`**，没有传 `cfg.PreferIPv4`
2. **当没有 proxy 且没有 context RoundTripper 时**，`Transport` 为 nil → Go 使用 `http.DefaultTransport` → 完全不受 `prefer-ipv4` 控制

## 修复

- 提取 `preferIPv4 := cfg != nil && cfg.PreferIPv4` 并传入 `BuildProxyTransport`
- 当 `httpClient.Transport` 仍为 nil 时，使用 `util.NewDefaultTransport(preferIPv4)` 作为兜底