### PR TITLE
fix(network): fallback to prefer-ipv4 aware transport for direct connections

### DIFF
--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -58,5 +58,9 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		httpClient.Transport = rt
 	}
 
+	if httpClient.Transport == nil {
+		httpClient.Transport = util.NewDefaultTransport(cfg != nil && cfg.PreferIPv4)
+	}
+
 	return httpClient
 }


### PR DESCRIPTION
## 问题

开启 `prefer-ipv4` 后，Codex 请求仍走 IPv6：
```
Post "https://chatgpt.com/backend-api/codex/responses": read tcp
[2607:8700:5500:8131::2]:32772->[2a06:98c1:3100::6812:202f]:443:
read: connection reset by peer
```

PR #163 修复了 `BuildProxyTransport` 的 `false` 硬编码问题，但遗漏了**没有 proxy 时的路径**。

## 根因

当 `newProxyAwareHTTPClient` 中：
1. 没有配置 proxy URL（大多数情况）
2. context 中没有 RoundTripper（`ContextKeyRoundTripper` 目前无注入方）

→ `httpClient.Transport` 为 nil → Go 使用 `http.DefaultTransport` → 不受 `prefer-ipv4` 控制 → IPv6

## 修复

在函数返回前增加兜底：当 Transport 仍为 nil 时，使用 `util.NewDefaultTransport(cfg.PreferIPv4)` 确保 `prefer-ipv4` 配置生效。