### PR TITLE
feat: add selective request log cleanup

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -32,6 +32,12 @@ type authFileTrendResponse struct {
 	QuotaSeries       []usage.QuotaSnapshotSeries `json:"quota_series"`
 }
 
+type deleteUsageLogsRequest struct {
+	ClearBodyContent    bool `json:"clear_body_content"`
+	ClearDetailContent  bool `json:"clear_detail_content"`
+	ClearRequestRecords bool `json:"clear_request_records"`
+}
+
 // GetUsageLogs returns paginated, filterable request log entries from SQLite.
 // It enriches each log item with resolved api_key_name and channel_name
 // from the in-memory config, eliminating the need for multiple frontend API calls.
@@ -198,8 +204,32 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 }
 
 func (h *Handler) DeleteUsageLogs(c *gin.Context) {
-	result, err := usage.ClearAllRequestLogs()
+	if c.Request.ContentLength == 0 {
+		result, err := usage.ClearAllRequestLogs()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, result)
+		return
+	}
+
+	var req deleteUsageLogsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	result, err := usage.ClearRequestLogs(usage.ClearRequestLogsOptions{
+		ClearBodyContent:    req.ClearBodyContent,
+		ClearDetailContent:  req.ClearDetailContent,
+		ClearRequestRecords: req.ClearRequestRecords,
+	})
 	if err != nil {
+		if strings.Contains(err.Error(), "at least one cleanup option") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -845,3 +845,52 @@ func TestDeleteUsageLogsClearsRequestLogDatabase(t *testing.T) {
 		t.Fatalf("expected 0 request logs after delete, got %d", len(result.Items))
 	}
 }
+
+func TestDeleteUsageLogsSupportsSelectiveBodyCleanup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	now := time.Now().UTC()
+	usage.InsertLogWithDetails("sk-target", "Primary", "gpt-5.4", "codex", "Codex", "auth-1", false, now, 123, 45, usage.TokenStats{
+		InputTokens: 1, OutputTokens: 2, TotalTokens: 3,
+	}, `{"messages":[{"role":"user","content":"hello"}]}`, `{"id":"resp_1"}`, `{"request_id":"req-1"}`)
+
+	h := &Handler{cfg: &config.Config{}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/usage/logs", strings.NewReader(`{"clear_body_content":true,"clear_detail_content":true}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.DeleteUsageLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	result, err := usage.QueryLogs(usage.LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() after selective delete error = %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 request log after selective cleanup, got %d", len(result.Items))
+	}
+	if result.Items[0].HasContent {
+		t.Fatalf("HasContent = true, want false after selective cleanup")
+	}
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -73,8 +73,17 @@ type LogStats struct {
 }
 
 type ClearRequestLogsResult struct {
-	DeletedLogs     int64 `json:"deleted_logs"`
-	DeletedContents int64 `json:"deleted_contents"`
+	DeletedLogs       int64 `json:"deleted_logs"`
+	DeletedContents   int64 `json:"deleted_contents"`
+	ClearedBodyRows   int64 `json:"cleared_body_rows"`
+	ClearedDetailRows int64 `json:"cleared_detail_rows"`
+	ClearedLegacyRows int64 `json:"cleared_legacy_rows"`
+}
+
+type ClearRequestLogsOptions struct {
+	ClearBodyContent    bool `json:"clear_body_content"`
+	ClearDetailContent  bool `json:"clear_detail_content"`
+	ClearRequestRecords bool `json:"clear_request_records"`
 }
 
 type DailyCountPoint struct {
@@ -625,12 +634,37 @@ func DeleteLogsByAPIKey(apiKey string) (int64, error) {
 	return deleted, nil
 }
 
-// ClearAllRequestLogs removes all request_logs and request_log_content rows
-// while leaving other SQLite-backed management data untouched.
-func ClearAllRequestLogs() (ClearRequestLogsResult, error) {
+func rowsAffected(result sql.Result) (int64, error) {
+	if result == nil {
+		return 0, nil
+	}
+	value, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func normalizeClearRequestLogsOptions(options ClearRequestLogsOptions) (ClearRequestLogsOptions, error) {
+	if options.ClearRequestRecords {
+		options.ClearBodyContent = true
+		options.ClearDetailContent = true
+	}
+	if !options.ClearBodyContent && !options.ClearDetailContent && !options.ClearRequestRecords {
+		return ClearRequestLogsOptions{}, fmt.Errorf("usage: at least one cleanup option must be selected")
+	}
+	return options, nil
+}
+
+// ClearRequestLogs selectively clears request log bodies, details, and/or full request records.
+func ClearRequestLogs(options ClearRequestLogsOptions) (ClearRequestLogsResult, error) {
 	db := getDB()
 	if db == nil {
 		return ClearRequestLogsResult{}, fmt.Errorf("usage: database not initialised")
+	}
+	options, err := normalizeClearRequestLogsOptions(options)
+	if err != nil {
+		return ClearRequestLogsResult{}, err
 	}
 
 	tx, err := db.Begin()
@@ -645,22 +679,74 @@ func ClearAllRequestLogs() (ClearRequestLogsResult, error) {
 		}
 	}()
 
-	contentResult, err := tx.Exec("DELETE FROM request_log_content")
-	if err != nil {
-		return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_log_content: %w", err)
-	}
-	logResult, err := tx.Exec("DELETE FROM request_logs")
-	if err != nil {
-		return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_logs: %w", err)
-	}
+	var result ClearRequestLogsResult
 
-	deletedContents, err := contentResult.RowsAffected()
-	if err != nil {
-		return ClearRequestLogsResult{}, fmt.Errorf("usage: content affected rows: %w", err)
-	}
-	deletedLogs, err := logResult.RowsAffected()
-	if err != nil {
-		return ClearRequestLogsResult{}, fmt.Errorf("usage: log affected rows: %w", err)
+	if options.ClearRequestRecords {
+		contentResult, err := tx.Exec("DELETE FROM request_log_content")
+		if err != nil {
+			return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_log_content: %w", err)
+		}
+		logResult, err := tx.Exec("DELETE FROM request_logs")
+		if err != nil {
+			return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_logs: %w", err)
+		}
+
+		result.DeletedContents, err = rowsAffected(contentResult)
+		if err != nil {
+			return ClearRequestLogsResult{}, fmt.Errorf("usage: content affected rows: %w", err)
+		}
+		result.DeletedLogs, err = rowsAffected(logResult)
+		if err != nil {
+			return ClearRequestLogsResult{}, fmt.Errorf("usage: log affected rows: %w", err)
+		}
+	} else {
+		if options.ClearBodyContent {
+			contentResult, err := tx.Exec(
+				"UPDATE request_log_content SET input_content = X'', output_content = X'' WHERE length(input_content) > 0 OR length(output_content) > 0",
+			)
+			if err != nil {
+				return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_log_content bodies: %w", err)
+			}
+			result.ClearedBodyRows, err = rowsAffected(contentResult)
+			if err != nil {
+				return ClearRequestLogsResult{}, fmt.Errorf("usage: body affected rows: %w", err)
+			}
+
+			legacyResult, err := tx.Exec(
+				"UPDATE request_logs SET input_content = '', output_content = '' WHERE length(input_content) > 0 OR length(output_content) > 0",
+			)
+			if err != nil {
+				return ClearRequestLogsResult{}, fmt.Errorf("usage: clear legacy request log bodies: %w", err)
+			}
+			result.ClearedLegacyRows, err = rowsAffected(legacyResult)
+			if err != nil {
+				return ClearRequestLogsResult{}, fmt.Errorf("usage: legacy affected rows: %w", err)
+			}
+		}
+
+		if options.ClearDetailContent {
+			detailResult, err := tx.Exec(
+				"UPDATE request_log_content SET detail_content = X'' WHERE length(detail_content) > 0",
+			)
+			if err != nil {
+				return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_log_content details: %w", err)
+			}
+			result.ClearedDetailRows, err = rowsAffected(detailResult)
+			if err != nil {
+				return ClearRequestLogsResult{}, fmt.Errorf("usage: detail affected rows: %w", err)
+			}
+		}
+
+		deleteEmptyRowsResult, err := tx.Exec(
+			"DELETE FROM request_log_content WHERE length(input_content) = 0 AND length(output_content) = 0 AND length(detail_content) = 0",
+		)
+		if err != nil {
+			return ClearRequestLogsResult{}, fmt.Errorf("usage: delete empty request_log_content rows: %w", err)
+		}
+		result.DeletedContents, err = rowsAffected(deleteEmptyRowsResult)
+		if err != nil {
+			return ClearRequestLogsResult{}, fmt.Errorf("usage: deleted empty content rows: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -672,14 +758,24 @@ func ClearAllRequestLogs() (ClearRequestLogsResult, error) {
 		log.Warnf("usage: vacuum after request log cleanup failed: %v", err)
 	}
 
-	if deletedLogs > 0 || deletedContents > 0 {
-		log.Infof("usage: cleared request logs (logs=%d contents=%d)", deletedLogs, deletedContents)
+	if result.DeletedLogs > 0 || result.DeletedContents > 0 || result.ClearedBodyRows > 0 || result.ClearedDetailRows > 0 || result.ClearedLegacyRows > 0 {
+		log.Infof(
+			"usage: cleared request logs (logs=%d contents=%d body_rows=%d detail_rows=%d legacy_rows=%d)",
+			result.DeletedLogs,
+			result.DeletedContents,
+			result.ClearedBodyRows,
+			result.ClearedDetailRows,
+			result.ClearedLegacyRows,
+		)
 	}
 
-	return ClearRequestLogsResult{
-		DeletedLogs:     deletedLogs,
-		DeletedContents: deletedContents,
-	}, nil
+	return result, nil
+}
+
+// ClearAllRequestLogs removes all request_logs and request_log_content rows
+// while leaving other SQLite-backed management data untouched.
+func ClearAllRequestLogs() (ClearRequestLogsResult, error) {
+	return ClearRequestLogs(ClearRequestLogsOptions{ClearRequestRecords: true})
 }
 
 // DashboardKPI holds the aggregated KPI data needed by the dashboard page.

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1030,3 +1030,71 @@ func TestClearAllRequestLogsRemovesRequestLogTablesOnly(t *testing.T) {
 		t.Fatalf("ListAPIKeys() = %#v, want preserved api key row", keys)
 	}
 }
+
+func TestClearRequestLogsClearsBodiesButKeepsRequestRows(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	now := time.Now().UTC()
+	details := `{"request_id":"req-1","provider":"codex"}`
+	InsertLogWithDetails("sk-target", "Primary", "gpt-5.4", "codex", "Codex", "auth-1", false, now, 123, 45, TokenStats{
+		InputTokens: 11, OutputTokens: 22, TotalTokens: 33,
+	}, `{"messages":[{"role":"user","content":"hello"}]}`, `{"id":"resp_1"}`, details)
+
+	before, err := GetRequestLogStorageBytes()
+	if err != nil {
+		t.Fatalf("GetRequestLogStorageBytes() before error = %v", err)
+	}
+	if before <= 0 {
+		t.Fatalf("expected request log storage bytes before cleanup, got %d", before)
+	}
+
+	result, err := ClearRequestLogs(ClearRequestLogsOptions{
+		ClearBodyContent:   true,
+		ClearDetailContent: true,
+	})
+	if err != nil {
+		t.Fatalf("ClearRequestLogs() error = %v", err)
+	}
+	if result.DeletedLogs != 0 {
+		t.Fatalf("DeletedLogs = %d, want 0", result.DeletedLogs)
+	}
+
+	rows, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() after cleanup error = %v", err)
+	}
+	if len(rows.Items) != 1 {
+		t.Fatalf("expected 1 request log row after cleanup, got %d", len(rows.Items))
+	}
+	if rows.Items[0].HasContent {
+		t.Fatalf("HasContent = true, want false after content cleanup")
+	}
+
+	content, err := QueryLogContent(rows.Items[0].ID)
+	if err != nil {
+		t.Fatalf("QueryLogContent() after cleanup error = %v", err)
+	}
+	if content.InputContent != "" || content.OutputContent != "" {
+		t.Fatalf("expected empty input/output content after cleanup, got input=%q output=%q", content.InputContent, content.OutputContent)
+	}
+
+	part, err := QueryLogContentPart(rows.Items[0].ID, "details")
+	if err != nil {
+		t.Fatalf("QueryLogContentPart(details) after cleanup error = %v", err)
+	}
+	if part.Content != "" {
+		t.Fatalf("expected empty details content after cleanup, got %q", part.Content)
+	}
+
+	after, err := GetRequestLogStorageBytes()
+	if err != nil {
+		t.Fatalf("GetRequestLogStorageBytes() after error = %v", err)
+	}
+	if after != 0 {
+		t.Fatalf("expected request log storage bytes to be 0 after cleanup, got %d", after)
+	}
+}


### PR DESCRIPTION
## Summary
- add selective request log cleanup options to the management usage API
- preserve request rows and stats by default while clearing bulky stored bodies/details
- cover selective cleanup and legacy compatibility with tests

## Test Plan
- go test ./internal/usage ./internal/api/handlers/management -count=1
