### PR TITLE
fix: honor disabled OpenAI compatible key entries

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -674,6 +674,9 @@ type OpenAICompatibilityAPIKey struct {
 	// APIKey is the authentication key for accessing the external API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// Disabled marks this API key entry as inactive while preserving the config.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// ProxyURL overrides the global proxy setting for this API key if provided.
 	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
 

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -364,9 +364,12 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 		base := strings.TrimSpace(compat.BaseURL)
 
 		// Handle new APIKeyEntries format (preferred)
-		createdEntries := 0
+		hasAPIKeyEntries := len(compat.APIKeyEntries) > 0
 		for j := range compat.APIKeyEntries {
 			entry := &compat.APIKeyEntries[j]
+			if entry.Disabled {
+				continue
+			}
 			key := strings.TrimSpace(entry.APIKey)
 			proxyURL := strings.TrimSpace(entry.ProxyURL)
 			proxyID := strings.TrimSpace(entry.ProxyID)
@@ -401,10 +404,9 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				UpdatedAt:  now,
 			}
 			out = append(out, a)
-			createdEntries++
 		}
 		// Fallback: create entry without API key if no APIKeyEntries
-		if createdEntries == 0 {
+		if !hasAPIKeyEntries {
 			idKind := fmt.Sprintf("openai-compatibility:%s", providerName)
 			id, token := idGen.Next(idKind, base)
 			attrs := map[string]string{

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -359,6 +359,33 @@ func TestConfigSynthesizer_OpenAICompat(t *testing.T) {
 			wantLen: 2,
 		},
 		{
+			name: "skips disabled APIKeyEntries without fallback",
+			compat: []config.OpenAICompatibility{
+				{
+					Name:    "CustomProvider",
+					BaseURL: "https://custom.api.com",
+					APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+						{APIKey: "key-enabled"},
+						{APIKey: "key-disabled", Disabled: true},
+					},
+				},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "all disabled APIKeyEntries do not create fallback auth",
+			compat: []config.OpenAICompatibility{
+				{
+					Name:    "CustomProvider",
+					BaseURL: "https://custom.api.com",
+					APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+						{APIKey: "key-disabled", Disabled: true},
+					},
+				},
+			},
+			wantLen: 0,
+		},
+		{
 			name: "empty APIKeyEntries included (legacy)",
 			compat: []config.OpenAICompatibility{
 				{


### PR DESCRIPTION
## Summary
- add a disabled flag to OpenAI Compatible api-key-entries
- skip disabled OpenAI Compatible key entries during runtime auth synthesis
- avoid creating a no-key fallback auth when all configured entries are disabled

## Validation
- go test ./internal/watcher/synthesizer -run TestConfigSynthesizer_OpenAICompat -count=1
- go test ./internal/watcher/synthesizer ./internal/config ./internal/api/handlers/management

## Notes
- go test ./... currently fails in unrelated internal/usage TestQuotaSnapshotPointsKeepFineGrainedSeries (points = 0, want 1); this package is not touched by this PR.