### PR TITLE
test: keep dev merge verification green

### DIFF
--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -88,7 +88,7 @@ func TestQueryDailyCallsByAuthIndexesBucketsByProjectTimezone(t *testing.T) {
 func TestQuotaSnapshotPointsKeepFineGrainedSeries(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 
-	recordedAt := time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC)
+	recordedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
 	resetAt := recordedAt.Add(5 * time.Hour)
 	remaining := 100.0
 


### PR DESCRIPTION
Updates the quota snapshot fixture so it stays within retention during local verification before merging dev to main.