### PR TITLE
fix(auth): keep credentials after refresh failure

### DIFF
--- a/internal/runtime/executor/codex_executor_image_test.go
+++ b/internal/runtime/executor/codex_executor_image_test.go
@@ -684,6 +684,7 @@ func TestCodexExecutorExecuteImageGenerationReturnsResponsesFailedRateLimit(t *t
 }
 
 func TestUsageReporterTrackFailureStoresErrorContent(t *testing.T) {
+	const model = "gpt-image-failure-content"
 	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
 	cliproxyusage.RegisterPlugin(usagePlugin)
 
@@ -692,8 +693,8 @@ func TestUsageReporterTrackFailureStoresErrorContent(t *testing.T) {
 		Provider: "codex",
 		Status:   cliproxyauth.StatusActive,
 	}
-	reporter := newUsageReporter(context.Background(), "codex", "gpt-image-2", auth)
-	reporter.setInputContent(`{"model":"gpt-image-2","prompt":"draw a fox"}`)
+	reporter := newUsageReporter(context.Background(), "codex", model, auth)
+	reporter.setInputContent(`{"model":"` + model + `","prompt":"draw a fox"}`)
 	errValue := fmt.Errorf("openai image conversation returned no downloadable images")
 
 	reporter.trackFailure(context.Background(), &errValue)
@@ -702,7 +703,7 @@ func TestUsageReporterTrackFailureStoresErrorContent(t *testing.T) {
 	for {
 		select {
 		case record := <-usagePlugin.records:
-			if record.Model != "gpt-image-2" {
+			if record.Model != model {
 				continue
 			}
 			if !record.Failed {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -68,9 +68,9 @@ const (
 	quotaBackoffMax       = 30 * time.Minute
 )
 
-// PermanentAuthError indicates an unrecoverable authentication failure.
-// When an executor's Refresh method returns this error, the conductor
-// will automatically remove the credential from memory and disk.
+// PermanentAuthError indicates a refresh failure that should be surfaced as
+// unavailable instead of retried immediately. It is not proof that the user
+// intentionally removed the credential.
 type PermanentAuthError struct {
 	Reason string
 	Cause  error
@@ -2533,19 +2533,18 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	log.Debugf("refreshed %s, %s, %v", auth.Provider, auth.ID, err)
 	now := time.Now()
 	if err != nil {
-		// If the error is permanent (e.g. invalid_grant, refresh_token_reused),
-		// remove the credential from memory and disk.
 		if IsPermanentAuthError(err) {
-			log.Warnf("permanent refresh failure for %s (%s): %v — removing credential", auth.ID, auth.Provider, err)
+			log.Warnf("permanent refresh failure for %s (%s): %v", auth.ID, auth.Provider, err)
 			m.mu.Lock()
-			delete(m.auths, id)
-			delete(m.quotaProbeAfter, id)
-			m.mu.Unlock()
-			if m.store != nil {
-				if delErr := m.store.Delete(ctx, id); delErr != nil {
-					log.Errorf("failed to delete invalid auth file %s: %v", id, delErr)
-				}
+			if current := m.auths[id]; current != nil {
+				current.NextRefreshAfter = now.Add(refreshFailureBackoff)
+				current.LastError = &Error{Message: err.Error()}
+				current.Status = StatusError
+				current.StatusMessage = err.Error()
+				current.UpdatedAt = now
+				m.auths[id] = current
 			}
+			m.mu.Unlock()
 			return
 		}
 		m.mu.Lock()

--- a/sdk/cliproxy/auth/refresh_cleanup_test.go
+++ b/sdk/cliproxy/auth/refresh_cleanup_test.go
@@ -63,7 +63,7 @@ func (e *stubExecutor) HttpRequest(_ context.Context, _ *Auth, _ *http.Request) 
 
 // --- tests ---
 
-func TestRefreshAuth_PermanentError_RemovesCredential(t *testing.T) {
+func TestRefreshAuth_PermanentError_MarksCredentialUnavailable(t *testing.T) {
 	store := &trackingStore{}
 	mgr := NewManager(store, nil, nil)
 
@@ -88,17 +88,27 @@ func TestRefreshAuth_PermanentError_RemovesCredential(t *testing.T) {
 	// Trigger refresh.
 	mgr.refreshAuth(context.Background(), "test-auth-1")
 
-	// Auth should be removed from memory.
-	if _, ok := mgr.GetByID("test-auth-1"); ok {
-		t.Fatal("expected auth to be removed from memory after permanent error")
+	current, ok := mgr.GetByID("test-auth-1")
+	if !ok {
+		t.Fatal("expected auth to remain in memory after permanent error")
+	}
+	if current.NextRefreshAfter.IsZero() {
+		t.Fatal("expected NextRefreshAfter to be set after permanent error")
+	}
+	if current.LastError == nil || current.LastError.Message == "" {
+		t.Fatal("expected LastError to be set after permanent error")
+	}
+	if current.Status != StatusError {
+		t.Fatalf("expected StatusError after permanent error, got %q", current.Status)
+	}
+	if current.StatusMessage == "" {
+		t.Fatal("expected StatusMessage to be set after permanent error")
 	}
 
-	// Store.Delete should have been called.
-	if got := store.deleteCount.Load(); got != 1 {
-		t.Fatalf("expected 1 Delete call, got %d", got)
-	}
-	if store.lastDeleted != "test-auth-1" {
-		t.Fatalf("expected Delete for 'test-auth-1', got '%s'", store.lastDeleted)
+	// Store.Delete should NOT have been called: refresh failures are not proof
+	// that the user intentionally removed the account.
+	if got := store.deleteCount.Load(); got != 0 {
+		t.Fatalf("expected 0 Delete calls, got %d", got)
 	}
 }
 


### PR DESCRIPTION
修复自动刷新遇到 PermanentAuthError 时误删账号认证文件的问题。

这次调整让刷新失败只标记账号为 error 并进入刷新冷却，不再从内存和存储中删除凭证。新增回归测试覆盖 permanent refresh error 不调用 Store.Delete 的行为。

同时修复一个 CI 中暴露的 usage reporter 测试串台问题：失败内容测试使用唯一 model，避免读取到其它图片测试遗留的全局 usage 记录。

验证：
- go test ./sdk/cliproxy/auth ./internal/auth/codex -count=1
- go test ./sdk/cliproxy/... ./internal/auth/codex -count=1
- go test ./sdk/cliproxy/auth ./internal/auth/codex ./internal/runtime/executor -count=1
- go test ./...
- git diff --check