### PR TITLE
fix: reset request log content counter after cleanup

### DIFF
--- a/internal/usage/log_content_store.go
+++ b/internal/usage/log_content_store.go
@@ -241,6 +241,14 @@ func runRequestLogMaintenancePass(db *sql.DB) {
 	compactLogContentStorageInternal(db, true)
 }
 
+func refreshRequestLogContentBytes(q logContentQuerier) {
+	if total, err := queryStoredContentBytes(q); err == nil {
+		requestLogContentBytes.Store(total)
+	} else {
+		requestLogContentBytes.Store(-1)
+	}
+}
+
 func insertLogContentTx(tx *sql.Tx, logID int64, timestamp time.Time, inputContent, outputContent, detailContent string) error {
 	if tx == nil || logID < 1 || (!requestLogStorage.StoreContent) {
 		return nil

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -753,6 +753,7 @@ func ClearRequestLogs(options ClearRequestLogsOptions) (ClearRequestLogsResult, 
 		return ClearRequestLogsResult{}, fmt.Errorf("usage: commit clear request logs: %w", err)
 	}
 	committed = true
+	refreshRequestLogContentBytes(db)
 
 	if _, err := db.Exec("VACUUM"); err != nil {
 		log.Warnf("usage: vacuum after request log cleanup failed: %v", err)

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1098,3 +1098,62 @@ func TestClearRequestLogsClearsBodiesButKeepsRequestRows(t *testing.T) {
 		t.Fatalf("expected request log storage bytes to be 0 after cleanup, got %d", after)
 	}
 }
+
+func TestClearRequestLogsAllowsNewContentAfterSizeCapCleanup(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+		MaxTotalSizeMB:         1,
+	})
+
+	maxBytes := maxLogContentBytes()
+	if maxBytes <= 0 {
+		t.Fatalf("maxLogContentBytes() = %d, want positive cap", maxBytes)
+	}
+
+	now := time.Now().UTC()
+	firstBody := makePseudoRandomText(650 * 1024)
+	InsertLogWithDetails("sk-target", "Primary", "gpt-5.4", "codex", "Codex", "auth-1", false, now, 123, 45, TokenStats{
+		InputTokens: 11, OutputTokens: 22, TotalTokens: 33,
+	}, firstBody, `{"id":"first"}`, `{"request_id":"req-first"}`)
+
+	before, err := GetRequestLogStorageBytes()
+	if err != nil {
+		t.Fatalf("GetRequestLogStorageBytes() before error = %v", err)
+	}
+	if before <= 0 || before >= maxBytes {
+		t.Fatalf("expected first stored body to be below cap, got before=%d max=%d", before, maxBytes)
+	}
+
+	if _, err := ClearRequestLogs(ClearRequestLogsOptions{
+		ClearBodyContent:   true,
+		ClearDetailContent: true,
+	}); err != nil {
+		t.Fatalf("ClearRequestLogs() error = %v", err)
+	}
+
+	after, err := GetRequestLogStorageBytes()
+	if err != nil {
+		t.Fatalf("GetRequestLogStorageBytes() after cleanup error = %v", err)
+	}
+	if after != 0 {
+		t.Fatalf("expected stored bytes to be 0 after cleanup, got %d", after)
+	}
+
+	secondBody := makePseudoRandomText(650 * 1024)
+	InsertLogWithDetails("sk-target", "Primary", "gpt-5.4", "codex", "Codex", "auth-1", false, now.Add(time.Second), 123, 45, TokenStats{
+		InputTokens: 11, OutputTokens: 22, TotalTokens: 33,
+	}, secondBody, `{"id":"second"}`, `{"request_id":"req-second"}`)
+
+	rows, err := QueryLogs(LogQueryParams{Page: 1, Size: 1, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() after reinserting content error = %v", err)
+	}
+	if len(rows.Items) != 1 {
+		t.Fatalf("expected latest request log row, got %d", len(rows.Items))
+	}
+	if !rows.Items[0].HasContent {
+		t.Fatalf("HasContent = false for new log after cleanup, want true")
+	}
+}


### PR DESCRIPTION
## Summary

- refresh the in-memory request log content byte counter after clearing request log content
- add a regression test proving new content can be stored after cleanup under the size cap

## Verification

- go test ./internal/usage -run TestClearRequestLogsAllowsNewContentAfterSizeCapCleanup -count=1
- go test ./internal/usage
- go test ./internal/api/handlers/management
- go test ./...
