### PR TITLE
fix(auth): recover oauth refresh token races

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2533,24 +2533,27 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	log.Debugf("refreshed %s, %s, %v", auth.Provider, auth.ID, err)
 	now := time.Now()
 	if err != nil {
-		if IsPermanentAuthError(err) {
+		permanent := IsPermanentAuthError(err)
+		if permanent {
 			log.Warnf("permanent refresh failure for %s (%s): %v", auth.ID, auth.Provider, err)
-			m.mu.Lock()
-			if current := m.auths[id]; current != nil {
-				current.NextRefreshAfter = now.Add(refreshFailureBackoff)
-				current.LastError = &Error{Message: err.Error()}
-				current.Status = StatusError
-				current.StatusMessage = err.Error()
-				current.UpdatedAt = now
-				m.auths[id] = current
+			if supportsRefreshTokenRaceRecovery(cloned) && m.recoverRotatedRefreshToken(ctx, id, cloned, now, err) {
+				return
 			}
-			m.mu.Unlock()
-			return
 		}
 		m.mu.Lock()
 		if current := m.auths[id]; current != nil {
 			current.NextRefreshAfter = now.Add(refreshFailureBackoff)
 			current.LastError = &Error{Message: err.Error()}
+			if permanent {
+				if supportsRefreshTokenRaceRecovery(current) && canKeepRefreshFailureActive(current, now) {
+					current.Status = StatusActive
+					current.StatusMessage = ""
+				} else {
+					current.Status = StatusError
+					current.StatusMessage = err.Error()
+				}
+			}
+			current.UpdatedAt = now
 			m.auths[id] = current
 		}
 		m.mu.Unlock()
@@ -2569,6 +2572,211 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	updated.LastError = nil
 	updated.UpdatedAt = now
 	_, _ = m.Update(ctx, updated)
+}
+
+func (m *Manager) recoverRotatedRefreshToken(ctx context.Context, id string, used *Auth, now time.Time, refreshErr error) bool {
+	usedRefreshToken := authRefreshToken(used)
+	if usedRefreshToken == "" {
+		return false
+	}
+
+	latest := m.findAuthWithDifferentRefreshToken(id, usedRefreshToken)
+	if latest == nil && m.store != nil {
+		if items, err := m.store.List(ctx); err == nil {
+			for _, item := range items {
+				if item == nil || item.ID != id {
+					continue
+				}
+				if latestRefreshToken := authRefreshToken(item); latestRefreshToken != "" && latestRefreshToken != usedRefreshToken {
+					latest = item.Clone()
+				}
+				break
+			}
+		} else {
+			log.Debugf("failed to re-read auth store after refresh failure for %s: %v", id, err)
+		}
+	}
+	if latest == nil {
+		return false
+	}
+
+	m.mu.Lock()
+	if current := m.auths[id]; current != nil {
+		if currentRefreshToken := authRefreshToken(current); currentRefreshToken != "" && currentRefreshToken != usedRefreshToken {
+			latest = current.Clone()
+		} else {
+			preserveRuntimeFields(latest, current)
+		}
+	} else {
+		m.mu.Unlock()
+		return false
+	}
+	applyRecoveredRefreshState(latest, now, refreshErr)
+	latest.UpdatedAt = now
+	latest.EnsureIndex()
+	m.auths[id] = latest.Clone()
+	m.mu.Unlock()
+
+	log.Infof("recovered refresh failure for %s by loading rotated refresh token", id)
+	m.hook.OnAuthUpdated(ctx, latest.Clone())
+	return true
+}
+
+func applyRecoveredRefreshState(auth *Auth, now time.Time, refreshErr error) {
+	if auth == nil {
+		return
+	}
+	if canKeepRefreshFailureActive(auth, now) {
+		auth.NextRefreshAfter = time.Time{}
+		auth.LastError = nil
+		auth.Status = StatusActive
+		auth.StatusMessage = ""
+		return
+	}
+	if auth.Disabled || auth.Status == StatusDisabled || auth.Unavailable || auth.Quota.Exceeded {
+		return
+	}
+	auth.NextRefreshAfter = now.Add(refreshFailureBackoff)
+	auth.LastError = &Error{Message: refreshErrorMessage(refreshErr)}
+	auth.Status = StatusError
+	auth.StatusMessage = auth.LastError.Message
+}
+
+func refreshErrorMessage(err error) string {
+	if err == nil {
+		return "refresh token recovered but access token is not usable"
+	}
+	return err.Error()
+}
+
+func supportsRefreshTokenRaceRecovery(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if providerSupportsRefreshTokenRaceRecovery(provider) {
+		return true
+	}
+	if auth.Metadata != nil {
+		if typ, _ := auth.Metadata["type"].(string); providerSupportsRefreshTokenRaceRecovery(typ) {
+			return true
+		}
+	}
+	return false
+}
+
+func providerSupportsRefreshTokenRaceRecovery(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "codex", "claude":
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Manager) findAuthWithDifferentRefreshToken(id string, usedRefreshToken string) *Auth {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	current := m.auths[id]
+	if current == nil {
+		return nil
+	}
+	currentRefreshToken := authRefreshToken(current)
+	if currentRefreshToken == "" || currentRefreshToken == usedRefreshToken {
+		return nil
+	}
+	return current.Clone()
+}
+
+func preserveRuntimeFields(dst *Auth, src *Auth) {
+	if dst == nil || src == nil {
+		return
+	}
+	if dst.Runtime == nil {
+		dst.Runtime = src.Runtime
+	}
+	if dst.Storage == nil {
+		dst.Storage = src.Storage
+	}
+	if dst.Index == "" {
+		dst.Index = src.Index
+		dst.indexAssigned = src.indexAssigned
+	}
+	if dst.FileName == "" {
+		dst.FileName = src.FileName
+	}
+}
+
+func canKeepRefreshFailureActive(auth *Auth, now time.Time) bool {
+	if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+		return false
+	}
+	if auth.Unavailable || auth.Quota.Exceeded {
+		return false
+	}
+	if !authAccessTokenUsable(auth, now) {
+		return false
+	}
+	return auth.Status == "" || auth.Status == StatusUnknown || auth.Status == StatusActive || auth.Status == StatusError
+}
+
+func authAccessTokenUsable(auth *Auth, now time.Time) bool {
+	if authTokenValue(auth, "access_token", "accessToken") == "" {
+		return false
+	}
+	expiry, hasExpiry := auth.ExpirationTime()
+	return !hasExpiry || expiry.After(now)
+}
+
+func authRefreshToken(auth *Auth) string {
+	return authTokenValue(auth, "refresh_token", "refreshToken")
+}
+
+func authTokenValue(auth *Auth, keys ...string) string {
+	if auth == nil {
+		return ""
+	}
+	if val := tokenValueFromMap(auth.Metadata, keys...); val != "" {
+		return val
+	}
+	for _, nestedKey := range []string{"token", "Token"} {
+		nested, ok := auth.Metadata[nestedKey]
+		if !ok {
+			continue
+		}
+		switch typed := nested.(type) {
+		case map[string]any:
+			if val := tokenValueFromMap(typed, keys...); val != "" {
+				return val
+			}
+		case map[string]string:
+			for _, key := range keys {
+				if val := strings.TrimSpace(typed[key]); val != "" {
+					return val
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func tokenValueFromMap(meta map[string]any, keys ...string) string {
+	if len(meta) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		switch raw := meta[key].(type) {
+		case string:
+			if val := strings.TrimSpace(raw); val != "" {
+				return val
+			}
+		case []byte:
+			if val := strings.TrimSpace(string(raw)); val != "" {
+				return val
+			}
+		}
+	}
+	return ""
 }
 
 func (m *Manager) executorFor(provider string) ProviderExecutor {

--- a/sdk/cliproxy/auth/refresh_cleanup_test.go
+++ b/sdk/cliproxy/auth/refresh_cleanup_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,9 +20,22 @@ type trackingStore struct {
 	saveCount   atomic.Int32
 	deleteCount atomic.Int32
 	lastDeleted string
+	listItems   []*Auth
+	listHook    func()
 }
 
-func (s *trackingStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+func (s *trackingStore) List(context.Context) ([]*Auth, error) {
+	out := make([]*Auth, 0, len(s.listItems))
+	for _, auth := range s.listItems {
+		if auth != nil {
+			out = append(out, auth.Clone())
+		}
+	}
+	if s.listHook != nil {
+		s.listHook()
+	}
+	return out, nil
+}
 func (s *trackingStore) Save(_ context.Context, _ *Auth) (string, error) {
 	s.saveCount.Add(1)
 	return "", nil
@@ -34,11 +48,18 @@ func (s *trackingStore) Delete(_ context.Context, id string) error {
 
 // stubExecutor is a minimal executor whose Refresh result can be controlled.
 type stubExecutor struct {
+	id         string
 	refreshErr error
 	refreshOut *Auth
+	onRefresh  func()
 }
 
-func (e *stubExecutor) Identifier() string { return "test-provider" }
+func (e *stubExecutor) Identifier() string {
+	if e.id != "" {
+		return e.id
+	}
+	return "test-provider"
+}
 func (e *stubExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	return cliproxyexecutor.Response{}, nil
 }
@@ -46,6 +67,9 @@ func (e *stubExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Re
 	return nil, nil
 }
 func (e *stubExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	if e.onRefresh != nil {
+		e.onRefresh()
+	}
 	if e.refreshErr != nil {
 		return nil, e.refreshErr
 	}
@@ -109,6 +133,473 @@ func TestRefreshAuth_PermanentError_MarksCredentialUnavailable(t *testing.T) {
 	// that the user intentionally removed the account.
 	if got := store.deleteCount.Load(); got != 0 {
 		t.Fatalf("expected 0 Delete calls, got %d", got)
+	}
+}
+
+func TestRefreshAuth_PermanentError_KeepsUsableAccessTokenActive(t *testing.T) {
+	store := &trackingStore{}
+	mgr := NewManager(store, nil, nil)
+
+	auth := &Auth{
+		ID:       "test-auth-usable-token",
+		Provider: "test-provider",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "still-usable-access-token",
+			"refresh_token": "stale-refresh-token",
+			"expired":       time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	ctx := WithSkipPersist(context.Background())
+	if _, err := mgr.Register(ctx, auth); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	mgr.RegisterExecutor(&stubExecutor{
+		refreshErr: &PermanentAuthError{
+			Reason: "refresh token reused",
+			Cause:  fmt.Errorf("refresh_token_reused"),
+		},
+	})
+
+	mgr.refreshAuth(context.Background(), auth.ID)
+
+	current, ok := mgr.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth to remain in memory after permanent error")
+	}
+	if current.Status != StatusActive {
+		t.Fatalf("expected usable access token to remain active, got %q", current.Status)
+	}
+	if current.StatusMessage != "" {
+		t.Fatalf("expected empty StatusMessage, got %q", current.StatusMessage)
+	}
+	if current.LastError == nil || current.LastError.Message == "" {
+		t.Fatal("expected LastError to retain refresh failure diagnostics")
+	}
+	if current.NextRefreshAfter.IsZero() {
+		t.Fatal("expected NextRefreshAfter to be set after permanent error")
+	}
+	if got := store.deleteCount.Load(); got != 0 {
+		t.Fatalf("expected 0 Delete calls, got %d", got)
+	}
+}
+
+func TestRefreshAuth_PermanentError_RecoversRotatedRefreshTokenFromStore(t *testing.T) {
+	stored := &Auth{
+		ID:       "test-auth-rotated-token",
+		Provider: "test-provider",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"expired":       time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+	store := &trackingStore{listItems: []*Auth{stored}}
+	mgr := NewManager(store, nil, nil)
+
+	auth := &Auth{
+		ID:       stored.ID,
+		Provider: stored.Provider,
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "old-access-token",
+			"refresh_token": "old-refresh-token",
+			"expired":       time.Now().Add(-time.Minute).Format(time.RFC3339),
+		},
+	}
+
+	ctx := WithSkipPersist(context.Background())
+	if _, err := mgr.Register(ctx, auth); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	mgr.RegisterExecutor(&stubExecutor{
+		refreshErr: &PermanentAuthError{
+			Reason: "credential revoked",
+			Cause:  fmt.Errorf("invalid_grant"),
+		},
+	})
+
+	mgr.refreshAuth(context.Background(), auth.ID)
+
+	current, ok := mgr.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth to remain in memory after permanent error")
+	}
+	if got, _ := current.Metadata["refresh_token"].(string); got != "new-refresh-token" {
+		t.Fatalf("refresh_token = %q, want new-refresh-token", got)
+	}
+	if got, _ := current.Metadata["access_token"].(string); got != "new-access-token" {
+		t.Fatalf("access_token = %q, want new-access-token", got)
+	}
+	if current.Status != StatusActive {
+		t.Fatalf("expected recovered auth to remain active, got %q", current.Status)
+	}
+	if current.LastError != nil {
+		t.Fatalf("expected recovered auth LastError to be nil, got %+v", current.LastError)
+	}
+	if !current.NextRefreshAfter.IsZero() {
+		t.Fatalf("expected recovered auth NextRefreshAfter to be cleared, got %s", current.NextRefreshAfter)
+	}
+	if got := store.deleteCount.Load(); got != 0 {
+		t.Fatalf("expected 0 Delete calls, got %d", got)
+	}
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("expected recovery to avoid overwriting store, got %d Save calls", got)
+	}
+}
+
+func TestRefreshAuth_PermanentError_RecoversRotatedRefreshTokenFromMemory(t *testing.T) {
+	store := &trackingStore{}
+	mgr := NewManager(store, nil, nil)
+
+	auth := &Auth{
+		ID:       "test-auth-memory-rotated-token",
+		Provider: "test-provider",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "old-access-token",
+			"refresh_token": "old-refresh-token",
+			"expired":       time.Now().Add(-time.Minute).Format(time.RFC3339),
+		},
+	}
+
+	ctx := WithSkipPersist(context.Background())
+	if _, err := mgr.Register(ctx, auth); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	mgr.RegisterExecutor(&stubExecutor{
+		refreshErr: &PermanentAuthError{
+			Reason: "credential revoked",
+			Cause:  fmt.Errorf("invalid_grant"),
+		},
+		onRefresh: func() {
+			mgr.mu.Lock()
+			latest := auth.Clone()
+			latest.Metadata["access_token"] = "memory-access-token"
+			latest.Metadata["refresh_token"] = "memory-refresh-token"
+			latest.Metadata["expired"] = time.Now().Add(time.Hour).Format(time.RFC3339)
+			mgr.auths[auth.ID] = latest
+			mgr.mu.Unlock()
+		},
+	})
+
+	mgr.refreshAuth(context.Background(), auth.ID)
+
+	current, ok := mgr.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth to remain in memory after recovery")
+	}
+	if got, _ := current.Metadata["refresh_token"].(string); got != "memory-refresh-token" {
+		t.Fatalf("refresh_token = %q, want memory-refresh-token", got)
+	}
+	if current.Status != StatusActive {
+		t.Fatalf("expected recovered auth to remain active, got %q", current.Status)
+	}
+	if current.LastError != nil {
+		t.Fatalf("expected recovered auth LastError to be nil, got %+v", current.LastError)
+	}
+	if !current.NextRefreshAfter.IsZero() {
+		t.Fatalf("expected recovered auth NextRefreshAfter to be cleared, got %s", current.NextRefreshAfter)
+	}
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("expected recovery to avoid overwriting store, got %d Save calls", got)
+	}
+}
+
+func TestRefreshAuth_PermanentError_DoesNotReviveRemovedAuth(t *testing.T) {
+	stored := &Auth{
+		ID:       "test-auth-removed-before-recovery",
+		Provider: "test-provider",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"expired":       time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+	store := &trackingStore{listItems: []*Auth{stored}}
+	mgr := NewManager(store, nil, nil)
+
+	used := &Auth{
+		ID:       stored.ID,
+		Provider: stored.Provider,
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "old-access-token",
+			"refresh_token": "old-refresh-token",
+			"expired":       time.Now().Add(-time.Minute).Format(time.RFC3339),
+		},
+	}
+
+	mgr.mu.Lock()
+	mgr.auths[used.ID] = used.Clone()
+	mgr.mu.Unlock()
+
+	store.listHook = func() {
+		mgr.mu.Lock()
+		delete(mgr.auths, used.ID)
+		mgr.mu.Unlock()
+	}
+
+	if mgr.recoverRotatedRefreshToken(context.Background(), used.ID, used, time.Now(), fmt.Errorf("invalid_grant")) {
+		t.Fatal("expected recovery to fail after auth was removed")
+	}
+	if _, ok := mgr.GetByID(used.ID); ok {
+		t.Fatal("expected removed auth not to be revived")
+	}
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("expected no Save calls, got %d", got)
+	}
+}
+
+func TestRefreshAuth_PermanentError_RecoveryMarksUnusableAccessTokenError(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]any
+	}{
+		{
+			name: "missing access token",
+			metadata: map[string]any{
+				"type":          "codex",
+				"refresh_token": "new-refresh-token",
+				"expired":       time.Now().Add(time.Hour).Format(time.RFC3339),
+			},
+		},
+		{
+			name: "expired access token",
+			metadata: map[string]any{
+				"type":          "codex",
+				"access_token":  "expired-access-token",
+				"refresh_token": "new-refresh-token",
+				"expired":       time.Now().Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := &Auth{
+				ID:       "test-auth-unusable-recovery-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Provider: "test-provider",
+				Status:   StatusActive,
+				Metadata: tt.metadata,
+			}
+			store := &trackingStore{listItems: []*Auth{stored}}
+			mgr := NewManager(store, nil, nil)
+
+			auth := &Auth{
+				ID:       stored.ID,
+				Provider: stored.Provider,
+				Status:   StatusActive,
+				Metadata: map[string]any{
+					"type":          "codex",
+					"access_token":  "old-access-token",
+					"refresh_token": "old-refresh-token",
+					"expired":       time.Now().Add(-time.Minute).Format(time.RFC3339),
+				},
+			}
+
+			ctx := WithSkipPersist(context.Background())
+			if _, err := mgr.Register(ctx, auth); err != nil {
+				t.Fatalf("Register failed: %v", err)
+			}
+			mgr.RegisterExecutor(&stubExecutor{
+				refreshErr: &PermanentAuthError{
+					Reason: "credential revoked",
+					Cause:  fmt.Errorf("invalid_grant"),
+				},
+			})
+
+			mgr.refreshAuth(context.Background(), auth.ID)
+
+			current, ok := mgr.GetByID(auth.ID)
+			if !ok {
+				t.Fatal("expected auth to remain in memory after recovery")
+			}
+			if got := authRefreshToken(current); got != "new-refresh-token" {
+				t.Fatalf("refresh_token = %q, want new-refresh-token", got)
+			}
+			if current.Status != StatusError {
+				t.Fatalf("expected unusable recovered token to be marked error, got %q", current.Status)
+			}
+			if current.StatusMessage == "" {
+				t.Fatal("expected StatusMessage to retain refresh failure diagnostics")
+			}
+			if current.LastError == nil || current.LastError.Message == "" {
+				t.Fatal("expected LastError to retain refresh failure diagnostics")
+			}
+			if current.NextRefreshAfter.IsZero() {
+				t.Fatal("expected NextRefreshAfter to be set for unusable recovered token")
+			}
+			if got := store.saveCount.Load(); got != 0 {
+				t.Fatalf("expected recovery to avoid overwriting store, got %d Save calls", got)
+			}
+		})
+	}
+}
+
+func TestRefreshAuth_PermanentError_DoesNotKeepGenericProviderActive(t *testing.T) {
+	store := &trackingStore{}
+	mgr := NewManager(store, nil, nil)
+
+	auth := &Auth{
+		ID:       "test-auth-generic-provider",
+		Provider: "test-provider",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "test-provider",
+			"access_token":  "still-usable-access-token",
+			"refresh_token": "stale-refresh-token",
+			"expired":       time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	ctx := WithSkipPersist(context.Background())
+	if _, err := mgr.Register(ctx, auth); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	mgr.RegisterExecutor(&stubExecutor{
+		refreshErr: &PermanentAuthError{
+			Reason: "generic permanent failure",
+			Cause:  fmt.Errorf("generic_permanent_failure"),
+		},
+	})
+
+	mgr.refreshAuth(context.Background(), auth.ID)
+
+	current, ok := mgr.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth to remain in memory after permanent error")
+	}
+	if current.Status != StatusError {
+		t.Fatalf("expected generic provider to preserve permanent-error semantics, got %q", current.Status)
+	}
+	if current.StatusMessage == "" {
+		t.Fatal("expected StatusMessage to be set after generic permanent error")
+	}
+}
+
+func TestRefreshAuth_PermanentError_RecoveryPreservesDisabledState(t *testing.T) {
+	stored := &Auth{
+		ID:       "test-auth-disabled-recovery",
+		Provider: "test-provider",
+		Status:   StatusDisabled,
+		Disabled: true,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"expired":       time.Now().Add(time.Hour).Format(time.RFC3339),
+			"disabled":      true,
+		},
+	}
+	store := &trackingStore{listItems: []*Auth{stored}}
+	mgr := NewManager(store, nil, nil)
+
+	auth := &Auth{
+		ID:       stored.ID,
+		Provider: stored.Provider,
+		Status:   StatusDisabled,
+		Disabled: true,
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "old-access-token",
+			"refresh_token": "old-refresh-token",
+			"expired":       time.Now().Add(-time.Minute).Format(time.RFC3339),
+			"disabled":      true,
+		},
+	}
+
+	ctx := WithSkipPersist(context.Background())
+	if _, err := mgr.Register(ctx, auth); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	mgr.RegisterExecutor(&stubExecutor{
+		refreshErr: &PermanentAuthError{
+			Reason: "credential revoked",
+			Cause:  fmt.Errorf("invalid_grant"),
+		},
+	})
+
+	mgr.refreshAuth(context.Background(), auth.ID)
+
+	current, ok := mgr.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth to remain in memory after recovery")
+	}
+	if !current.Disabled {
+		t.Fatal("expected recovered auth to remain disabled")
+	}
+	if current.Status != StatusDisabled {
+		t.Fatalf("expected recovered auth to keep disabled status, got %q", current.Status)
+	}
+	if got, _ := current.Metadata["refresh_token"].(string); got != "new-refresh-token" {
+		t.Fatalf("refresh_token = %q, want new-refresh-token", got)
+	}
+}
+
+func TestRefreshAuth_PermanentError_RecoveryPreservesQuotaExceededState(t *testing.T) {
+	stored := &Auth{
+		ID:       "test-auth-quota-recovery",
+		Provider: "test-provider",
+		Status:   StatusError,
+		Quota:    QuotaState{Exceeded: true},
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"expired":       time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+	store := &trackingStore{listItems: []*Auth{stored}}
+	mgr := NewManager(store, nil, nil)
+
+	auth := &Auth{
+		ID:       stored.ID,
+		Provider: stored.Provider,
+		Status:   StatusError,
+		Quota:    QuotaState{Exceeded: true},
+		Metadata: map[string]any{
+			"type":          "codex",
+			"access_token":  "old-access-token",
+			"refresh_token": "old-refresh-token",
+			"expired":       time.Now().Add(-time.Minute).Format(time.RFC3339),
+		},
+	}
+
+	ctx := WithSkipPersist(context.Background())
+	if _, err := mgr.Register(ctx, auth); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	mgr.RegisterExecutor(&stubExecutor{
+		refreshErr: &PermanentAuthError{
+			Reason: "credential revoked",
+			Cause:  fmt.Errorf("invalid_grant"),
+		},
+	})
+
+	mgr.refreshAuth(context.Background(), auth.ID)
+
+	current, ok := mgr.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth to remain in memory after recovery")
+	}
+	if !current.Quota.Exceeded {
+		t.Fatal("expected recovered auth to preserve quota exceeded state")
+	}
+	if current.Status != StatusError {
+		t.Fatalf("expected recovered auth to keep quota status, got %q", current.Status)
+	}
+	if got, _ := current.Metadata["refresh_token"].(string); got != "new-refresh-token" {
+		t.Fatalf("refresh_token = %q, want new-refresh-token", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

修复 OAuth refresh_token 旋转/并发刷新导致认证异常的链路：

- permanent refresh failure 不再删除认证文件，也不会把旧 refresh_token 覆盖回存储。
- Codex/Claude OAuth 刷新失败时，如果发现内存或 store 中已有旋转后的 refresh_token，会恢复到新版凭据。
- 只有 access_token 仍可用时才保持 active；缺失/过期时保留 LastError 和 NextRefreshAfter，避免把不可用账号伪装成可用。
- 防止 TOCTOU 场景下恢复逻辑复活已经被删除/移除的 auth。
- 保持 disabled、quota exceeded、generic provider PermanentAuthError 原有语义。

## Verification

- go test ./sdk/cliproxy/auth ./internal/auth/codex ./internal/runtime/executor -count=1
- go test -race ./sdk/cliproxy/auth -run 'TestRefreshAuth_PermanentError' -count=1\n- go test ./...\n- git diff --check\n- 第二轮子代理 code review：无 Critical/High/Medium/Low findings\n