### PR TITLE
fix(management): hot apply config auth removals

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -37,6 +37,7 @@ import (
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher/synthesizer"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/claude"
@@ -1536,6 +1537,7 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	// Save YAML snapshot for next comparison
 	s.oldConfigYaml, _ = yaml.Marshal(cfg)
 
+	s.syncConfigDerivedAuths(cfg)
 	s.handlers.UpdateClients(&cfg.SDKConfig)
 
 	if s.mgmt != nil {
@@ -1585,6 +1587,78 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 		vertexAICompatCount,
 		openAICompatCount,
 	)
+}
+
+func (s *Server) syncConfigDerivedAuths(cfg *config.Config) {
+	if s == nil || s.handlers == nil || s.handlers.AuthManager == nil || cfg == nil {
+		return
+	}
+
+	ctx := auth.WithSkipPersist(context.Background())
+	synth := synthesizer.NewConfigSynthesizer()
+	auths, err := synth.Synthesize(&synthesizer.SynthesisContext{
+		Config:      cfg,
+		AuthDir:     cfg.AuthDir,
+		Now:         time.Now(),
+		IDGenerator: synthesizer.NewStableIDGenerator(),
+	})
+	if err != nil {
+		log.WithError(err).Warn("failed to synthesize config auths during client update")
+		return
+	}
+
+	manager := s.handlers.AuthManager
+	desiredIDs := make(map[string]struct{}, len(auths))
+	for _, next := range auths {
+		if next == nil || strings.TrimSpace(next.ID) == "" {
+			continue
+		}
+		desiredIDs[next.ID] = struct{}{}
+		if existing, ok := manager.GetByID(next.ID); ok && existing != nil {
+			next.CreatedAt = existing.CreatedAt
+			next.LastRefreshedAt = existing.LastRefreshedAt
+			next.NextRefreshAfter = existing.NextRefreshAfter
+			_, err = manager.Update(ctx, next)
+		} else {
+			_, err = manager.Register(ctx, next)
+		}
+		if err != nil {
+			log.WithError(err).Warnf("failed to apply config auth %s", next.ID)
+		}
+	}
+
+	for _, existing := range manager.List() {
+		if existing == nil || strings.TrimSpace(existing.ID) == "" {
+			continue
+		}
+		if !isConfigDerivedAuth(existing) {
+			continue
+		}
+		if _, stillConfigured := desiredIDs[existing.ID]; stillConfigured {
+			continue
+		}
+		if existing.Disabled && existing.Status == auth.StatusDisabled {
+			continue
+		}
+		disabled := existing.Clone()
+		disabled.Disabled = true
+		disabled.Status = auth.StatusDisabled
+		disabled.StatusMessage = "removed via config update"
+		disabled.UpdatedAt = time.Now()
+		if _, err := manager.Update(ctx, disabled); err != nil {
+			log.WithError(err).Warnf("failed to disable removed config auth %s", disabled.ID)
+		}
+	}
+}
+
+func isConfigDerivedAuth(authState *auth.Auth) bool {
+	if authState == nil {
+		return false
+	}
+	if authState.Attributes == nil {
+		return false
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(authState.Attributes["source"])), "config:")
 }
 
 func (s *Server) SetWebsocketAuthChangeHandler(fn func(bool, bool)) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -206,6 +206,55 @@ func TestGroupedNestedV1RouteConfigured(t *testing.T) {
 	}
 }
 
+func TestUpdateClientsDisablesRemovedConfigAuths(t *testing.T) {
+	server := newTestServer(t)
+	manager := server.handlers.AuthManager
+	ctx := context.Background()
+
+	for _, seed := range []*auth.Auth{
+		{
+			ID:       "claude-config-auth",
+			Provider: "claude",
+			Label:    "Claude API key",
+			Status:   auth.StatusActive,
+			Attributes: map[string]string{
+				"source":  "config:claude[old]",
+				"api_key": "sk-claude-old",
+			},
+		},
+		{
+			ID:       "kimi-config-auth",
+			Provider: "kimi",
+			Label:    "Kimi API key",
+			Status:   auth.StatusActive,
+			Attributes: map[string]string{
+				"source":       "config:kimi[old]",
+				"api_key":      "sk-kimi-old",
+				"compat_name":  "Kimi",
+				"provider_key": "kimi",
+			},
+		},
+	} {
+		if _, err := manager.Register(ctx, seed); err != nil {
+			t.Fatalf("register auth %s: %v", seed.ID, err)
+		}
+	}
+
+	next := *server.cfg
+	next.ClaudeKey = nil
+	server.UpdateClients(&next)
+
+	for _, id := range []string{"claude-config-auth", "kimi-config-auth"} {
+		updated, ok := manager.GetByID(id)
+		if !ok {
+			t.Fatalf("expected existing auth %s to remain as disabled runtime state", id)
+		}
+		if !updated.Disabled || updated.Status != auth.StatusDisabled {
+			t.Fatalf("%s should be disabled after removal, got disabled=%t status=%s", id, updated.Disabled, updated.Status)
+		}
+	}
+}
+
 func TestGroupedV1RouteForbiddenByAPIKeyGroups(t *testing.T) {
 	server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
 		cfg.SDKConfig.APIKeys = nil


### PR DESCRIPTION
## Summary
- sync config-derived runtime auth entries during server client updates
- immediately disable removed/disabled config auths such as Claude API keys and OpenAI-compatible Kimi entries
- add regression coverage for Claude and Kimi config auths remaining active after management saves

## Test plan
- go test ./internal/api -run TestUpdateClientsDisablesRemovedConfigAuths -count=1
- go test ./internal/api -count=1
- go test ./... -count=1