### PR TITLE
fix: avoid updater .env bind directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,5 @@ services:
       CLIRELAY_TARGET_SERVICE: ${CLIRELAY_TARGET_SERVICE:-cli-proxy-api}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./docker-compose.yml:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/docker-compose.yml:ro
-      - ./.env:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/.env
+      - ${CLIRELAY_PROJECT_DIR:-${PWD:-.}}:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}
     restart: unless-stopped

--- a/docker_compose_test.go
+++ b/docker_compose_test.go
@@ -49,8 +49,7 @@ func TestRepositoryComposeMirrorsDeploymentFilesAtProjectDirInUpdater(t *testing
 		"CLIRELAY_PROJECT_DIR: ${CLIRELAY_PROJECT_DIR:-${PWD:-.}}",
 		"CLIRELAY_COMPOSE_FILE: ${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/docker-compose.yml",
 		"CLIRELAY_ENV_FILE: ${CLIRELAY_ENV_FILE:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/.env}",
-		"./docker-compose.yml:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/docker-compose.yml:ro",
-		"./.env:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/.env",
+		"${CLIRELAY_PROJECT_DIR:-${PWD:-.}}:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("docker-compose.yml updater config missing %q", want)
@@ -63,6 +62,22 @@ func TestRepositoryComposeMirrorsDeploymentFilesAtProjectDirInUpdater(t *testing
 	} {
 		if strings.Contains(content, forbidden) {
 			t.Fatalf("docker-compose.yml still contains updater /workspace path %q", forbidden)
+		}
+	}
+}
+
+func TestRepositoryComposeDoesNotCreateEnvDirectoryForUpdater(t *testing.T) {
+	data, err := os.ReadFile("docker-compose.yml")
+	if err != nil {
+		t.Fatalf("read docker-compose.yml: %v", err)
+	}
+	content := string(data)
+
+	for _, forbidden := range []string{
+		"./.env:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/.env",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("docker-compose.yml should not default updater to missing .env bind %q", forbidden)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- replace the updater sidecar's separate docker-compose.yml/.env file binds in the repository compose with a project-directory bind
- keep CLIRELAY_ENV_FILE available so the updater can create or update a normal .env file inside the mounted project directory
- add a regression test to prevent reintroducing the ./.env bind that can become an .env directory when missing

## Verification
- go test .
- go test ./cmd/updater
- docker compose -f docker-compose.yml config
- go test ./...