### PR TITLE
fix: add missing config.yaml mount for clirelay-updater

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,4 +56,5 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker-compose.yml:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/docker-compose.yml:ro
       - ./.env:${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/.env
+      - ${CLI_PROXY_CONFIG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/config.yaml}:/CLIProxyAPI/config.yaml
     restart: unless-stopped


### PR DESCRIPTION
## Problem
The `clirelay-updater` service fails to start because it cannot read `/CLIProxyAPI/config.yaml`.  
The container enters an infinite `Restarting(0)` loop.

## Root Cause
The `docker-compose.yml` mounts `config.yaml` for `cli-proxy-api` but forgets to mount it for `clirelay-updater`.

## Fix
Add the same volume mount to `clirelay-updater`:
`- ${CLI_PROXY_CONFIG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/config.yaml}:/CLIProxyAPI/config.yaml`

## Testing
- Verified locally: after adding mount, both services start and stay `Up`.
- Without mount, updater constantly restarts with `open /CLIProxyAPI/config.yaml: no such file or directory`.