### PR TITLE
fix: hot reload provider toggle

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -59,15 +59,16 @@ const (
 )
 
 type serverOptionConfig struct {
-	extraMiddleware      []gin.HandlerFunc
-	engineConfigurator   func(*gin.Engine)
-	routerConfigurator   func(*gin.Engine, *handlers.BaseAPIHandler, *config.Config)
-	requestLoggerFactory func(*config.Config, string) logging.RequestLogger
-	localPassword        string
-	keepAliveEnabled     bool
-	keepAliveTimeout     time.Duration
-	keepAliveOnTimeout   func()
-	postAuthHook         auth.PostAuthHook
+	extraMiddleware       []gin.HandlerFunc
+	engineConfigurator    func(*gin.Engine)
+	routerConfigurator    func(*gin.Engine, *handlers.BaseAPIHandler, *config.Config)
+	requestLoggerFactory  func(*config.Config, string) logging.RequestLogger
+	localPassword         string
+	keepAliveEnabled      bool
+	keepAliveTimeout      time.Duration
+	keepAliveOnTimeout    func()
+	postAuthHook          auth.PostAuthHook
+	configMutatedCallback func(*config.Config)
 }
 
 // ServerOption customises HTTP server construction.
@@ -132,6 +133,12 @@ func WithRequestLoggerFactory(factory func(*config.Config, string) logging.Reque
 func WithPostAuthHook(hook auth.PostAuthHook) ServerOption {
 	return func(cfg *serverOptionConfig) {
 		cfg.postAuthHook = hook
+	}
+}
+
+func WithConfigMutatedCallback(fn func(*config.Config)) ServerOption {
+	return func(cfg *serverOptionConfig) {
+		cfg.configMutatedCallback = fn
 	}
 }
 
@@ -296,21 +303,25 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	// Initialize management handler
 	s.mgmt = managementHandlers.NewHandler(cfg, configFilePath, authManager)
 	s.mgmt.SetAccessManager(accessManager)
-	s.mgmt.SetConfigMutatedHook(func(updated *config.Config) {
-		if updated == nil {
-			updated = cfg
-		}
-		if updated == nil {
-			return
-		}
-		usage.MigrateRoutingConfigFromConfig(updated, configFilePath)
-		usage.ApplyStoredRoutingConfig(updated)
-		usage.MigrateProxyPoolFromConfig(updated, configFilePath)
-		usage.ApplyStoredProxyPool(updated)
-		usage.MigrateRuntimeSettingsFromConfig(updated, configFilePath)
-		usage.ApplyStoredRuntimeSettings(updated)
-		s.UpdateClients(updated)
-	})
+	if optionState.configMutatedCallback != nil {
+		s.mgmt.SetConfigMutatedHook(optionState.configMutatedCallback)
+	} else {
+		s.mgmt.SetConfigMutatedHook(func(updated *config.Config) {
+			if updated == nil {
+				updated = cfg
+			}
+			if updated == nil {
+				return
+			}
+			usage.MigrateRoutingConfigFromConfig(updated, configFilePath)
+			usage.ApplyStoredRoutingConfig(updated)
+			usage.MigrateProxyPoolFromConfig(updated, configFilePath)
+			usage.ApplyStoredProxyPool(updated)
+			usage.MigrateRuntimeSettingsFromConfig(updated, configFilePath)
+			usage.ApplyStoredRuntimeSettings(updated)
+			s.UpdateClients(updated)
+		})
+	}
 	if optionState.localPassword != "" {
 		s.mgmt.SetLocalPassword(optionState.localPassword)
 	}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -353,6 +353,69 @@ func (s *Service) applyRetryConfig(cfg *config.Config) {
 	s.coreManager.SetRetryConfig(cfg.RequestRetry, maxInterval)
 }
 
+func (s *Service) applyConfigReload(newCfg *config.Config, refreshRegisteredModels bool) {
+	if s == nil {
+		return
+	}
+	previousStrategy := ""
+	s.cfgMu.RLock()
+	if s.cfg != nil {
+		previousStrategy = strings.ToLower(strings.TrimSpace(s.cfg.Routing.Strategy))
+	}
+	s.cfgMu.RUnlock()
+
+	if newCfg == nil {
+		s.cfgMu.RLock()
+		newCfg = s.cfg
+		s.cfgMu.RUnlock()
+	}
+	if newCfg == nil {
+		return
+	}
+	internalusage.MigrateRoutingConfigFromConfig(newCfg, s.configPath)
+	internalusage.ApplyStoredRoutingConfig(newCfg)
+	internalusage.MigrateProxyPoolFromConfig(newCfg, s.configPath)
+	internalusage.ApplyStoredProxyPool(newCfg)
+	internalusage.MigrateRuntimeSettingsFromConfig(newCfg, s.configPath)
+	internalusage.ApplyStoredRuntimeSettings(newCfg)
+
+	nextStrategy := strings.ToLower(strings.TrimSpace(newCfg.Routing.Strategy))
+	previousStrategy = config.NormalizeRoutingStrategy(previousStrategy)
+	nextStrategy = config.NormalizeRoutingStrategy(nextStrategy)
+	if s.coreManager != nil && previousStrategy != nextStrategy {
+		var selector coreauth.Selector
+		switch nextStrategy {
+		case "fill-first":
+			selector = &coreauth.FillFirstSelector{}
+		default:
+			selector = &coreauth.RoundRobinSelector{}
+		}
+		s.coreManager.SetSelector(selector)
+	}
+
+	s.applyRetryConfig(newCfg)
+	s.applyPprofConfig(newCfg)
+	if s.server != nil {
+		s.server.UpdateClients(newCfg)
+	}
+	s.cfgMu.Lock()
+	s.cfg = newCfg
+	s.cfgMu.Unlock()
+	if s.watcher != nil {
+		s.watcher.SetConfig(newCfg)
+	}
+	if s.coreManager != nil {
+		s.coreManager.SetConfig(newCfg)
+		s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
+	}
+	s.rebindExecutors()
+	if refreshRegisteredModels && s.coreManager != nil {
+		for _, auth := range s.coreManager.List() {
+			s.registerModelsForAuth(context.Background(), auth)
+		}
+	}
+}
+
 func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName string, ok bool) {
 	if a == nil {
 		return "", "", false
@@ -524,7 +587,11 @@ func (s *Service) Run(ctx context.Context) error {
 	// legacy clients removed; no caches to refresh
 
 	// handlers no longer depend on legacy clients; pass nil slice initially
-	s.server = api.NewServer(s.cfg, s.coreManager, s.accessManager, s.configPath, s.serverOptions...)
+	serverOptions := append([]api.ServerOption(nil), s.serverOptions...)
+	serverOptions = append(serverOptions, api.WithConfigMutatedCallback(func(updated *config.Config) {
+		s.applyConfigReload(updated, true)
+	}))
+	s.server = api.NewServer(s.cfg, s.coreManager, s.accessManager, s.configPath, serverOptions...)
 
 	if s.authManager == nil {
 		s.authManager = newDefaultAuthManager()
@@ -579,55 +646,7 @@ func (s *Service) Run(ctx context.Context) error {
 
 	var watcherWrapper *WatcherWrapper
 	reloadCallback := func(newCfg *config.Config) {
-		previousStrategy := ""
-		s.cfgMu.RLock()
-		if s.cfg != nil {
-			previousStrategy = strings.ToLower(strings.TrimSpace(s.cfg.Routing.Strategy))
-		}
-		s.cfgMu.RUnlock()
-
-		if newCfg == nil {
-			s.cfgMu.RLock()
-			newCfg = s.cfg
-			s.cfgMu.RUnlock()
-		}
-		if newCfg == nil {
-			return
-		}
-		internalusage.MigrateRoutingConfigFromConfig(newCfg, s.configPath)
-		internalusage.ApplyStoredRoutingConfig(newCfg)
-		internalusage.MigrateProxyPoolFromConfig(newCfg, s.configPath)
-		internalusage.ApplyStoredProxyPool(newCfg)
-		internalusage.MigrateRuntimeSettingsFromConfig(newCfg, s.configPath)
-		internalusage.ApplyStoredRuntimeSettings(newCfg)
-
-		nextStrategy := strings.ToLower(strings.TrimSpace(newCfg.Routing.Strategy))
-		previousStrategy = config.NormalizeRoutingStrategy(previousStrategy)
-		nextStrategy = config.NormalizeRoutingStrategy(nextStrategy)
-		if s.coreManager != nil && previousStrategy != nextStrategy {
-			var selector coreauth.Selector
-			switch nextStrategy {
-			case "fill-first":
-				selector = &coreauth.FillFirstSelector{}
-			default:
-				selector = &coreauth.RoundRobinSelector{}
-			}
-			s.coreManager.SetSelector(selector)
-		}
-
-		s.applyRetryConfig(newCfg)
-		s.applyPprofConfig(newCfg)
-		if s.server != nil {
-			s.server.UpdateClients(newCfg)
-		}
-		s.cfgMu.Lock()
-		s.cfg = newCfg
-		s.cfgMu.Unlock()
-		if s.coreManager != nil {
-			s.coreManager.SetConfig(newCfg)
-			s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
-		}
-		s.rebindExecutors()
+		s.applyConfigReload(newCfg, false)
 	}
 
 	watcherWrapper, err = s.watcherFactory(s.configPath, s.cfg.AuthDir, reloadCallback)

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -6,9 +6,67 @@ import (
 	"strings"
 	"testing"
 
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
+
+func TestApplyConfigReloadRefreshesModelRegistryForConfigAuths(t *testing.T) {
+	cfg := &config.Config{
+		GeminiKey: []config.GeminiKey{{
+			APIKey: "gemini-hot-reload-key",
+			Models: []internalconfig.GeminiModel{{Name: "models/gemini-hot-reload-model", Alias: "gemini-hot-reload-model"}},
+		}},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: cfg, coreManager: manager}
+	auth := &coreauth.Auth{
+		ID:       "gemini-hot-reload-auth",
+		Provider: "gemini",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":   "gemini-hot-reload-key",
+			"auth_kind": "apikey",
+			"source":    "config:gemini[test]",
+		},
+	}
+	ctx := context.Background()
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(ctx, auth)
+	if !hasModelID(registry.GetAvailableModelsByProvider("gemini"), "gemini-hot-reload-model") {
+		t.Fatal("expected model to be registered before config reload")
+	}
+
+	next := *cfg
+	next.GeminiKey = []config.GeminiKey{{
+		APIKey:         "gemini-hot-reload-key",
+		Models:         []internalconfig.GeminiModel{{Name: "models/gemini-hot-reload-model", Alias: "gemini-hot-reload-model"}},
+		ExcludedModels: []string{"*"},
+	}}
+	service.applyConfigReload(&next, true)
+
+	if hasModelID(registry.GetAvailableModelsByProvider("gemini"), "gemini-hot-reload-model") {
+		t.Fatal("expected model registry to drop disabled provider models after config reload")
+	}
+}
+
+func hasModelID(models []*ModelInfo, id string) bool {
+	for _, model := range models {
+		if model != nil && strings.EqualFold(strings.TrimSpace(model.ID), id) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestRegisterModelsForAuth_UsesPreMergedExcludedModelsAttribute(t *testing.T) {
 	service := &Service{


### PR DESCRIPTION
## Summary

  - 修复 AI 供应商启用/禁用开关热更新不生效的问题。这个 bug的根因是：管理端保存供应商配置后，只调用了 API Server 层的`UpdateClients`，它会更新配置引用和派生 auth，但不会触发 Service层完整运行时刷新；因此 `coreManager`、provider executor 和 `GlobalModelRegistry`仍然保留旧状态。前端把供应商禁用保存成 `excluded-models: ["*"]`后，新的配置虽然已经写入并同步到部分 auth 状态，但旧的模型注册没有被注销，所以`/models` 等运行时路径仍然能看到该供应商模型，直到容器重启或文件 watcher 完整 reload才会重新构建模型 registry。
  - 将 management mutation hook 接回 Service 层配置刷新链路，复用原本 watcher热更新时使用的配置应用逻辑，确保管理端保存配置后同步刷新 runtime settings、APIServer、Service 配置、`coreManager` 配置、OAuth model alias 和 provider executor。
  - 在管理端配置变更后主动刷新已注册 auth 的模型 registry，让 `excluded-models: ["*"]`这类禁用操作立即注销对应供应商模型，避免运行时继续使用旧模型列表。

## Verification

 - `go test ./...`

## Branch Checklist

- [x] PR targets `dev`, not `main`
- [x] Branch is based on the latest `origin/dev`
- [x] Only files related to this change are included
