### PR TITLE
feat: add insecure-skip-verify and ca-cert TLS config options

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -137,6 +137,15 @@ request-log-storage:
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 proxy-url: ""
 
+# When true, disables TLS certificate verification for all upstream HTTPS connections.
+# Use only when upstream APIs use self-signed certificates or in trusted internal networks.
+# Default is false (verification enabled).
+insecure-skip-verify: false
+
+# Path to a PEM-encoded CA certificate file for verifying upstream server certificates.
+# When empty, the system default root CA pool is used.
+ca-cert: ""
+
 # When true, unprefixed model requests only use credentials without a prefix (except when prefix == model name).
 force-model-prefix: false
 

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -987,8 +987,12 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 		}
 	}
 
+	var sdkCfg *config.SDKConfig
+	if h != nil && h.cfg != nil {
+		sdkCfg = &h.cfg.SDKConfig
+	}
 	for _, proxyStr := range proxyCandidates {
-		if transport := buildProxyTransport(proxyStr); transport != nil {
+		if transport := buildProxyTransport(proxyStr, sdkCfg); transport != nil {
 			return transport
 		}
 	}
@@ -996,7 +1000,7 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 	return nil
 }
 
-func buildProxyTransport(proxyStr string) *http.Transport {
+func buildProxyTransport(proxyStr string, sdkCfg *config.SDKConfig) *http.Transport {
 	proxyStr = strings.TrimSpace(proxyStr)
 	if proxyStr == "" {
 		return nil
@@ -1033,7 +1037,9 @@ func buildProxyTransport(proxyStr string) *http.Transport {
 	}
 
 	if proxyURL.Scheme == "http" || proxyURL.Scheme == "https" {
-		return &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+		transport := &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+		util.ApplyTLSConfig(transport, sdkCfg)
+		return transport
 	}
 
 	log.Debugf("unsupported proxy scheme: %s", proxyURL.Scheme)

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -211,6 +211,10 @@ func (h *Handler) GetLatestVersion(c *gin.Context) {
 	}
 	if proxyURL != "" {
 		sdkCfg := &sdkconfig.SDKConfig{ProxyURL: proxyURL}
+		if h != nil && h.cfg != nil {
+			sdkCfg.InsecureSkipVerify = h.cfg.InsecureSkipVerify
+			sdkCfg.CACert = h.cfg.CACert
+		}
 		util.SetProxy(sdkCfg, client)
 	}
 

--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -128,8 +128,12 @@ func (h *Handler) PostProxyPoolCheck(c *gin.Context) {
 		return
 	}
 
+	var sdkCfg *config.SDKConfig
+	if h != nil && h.cfg != nil {
+		sdkCfg = &h.cfg.SDKConfig
+	}
 	started := time.Now()
-	statusCode, err := checkProxyConnectivity(c.Request.Context(), proxyURL, testURL)
+	statusCode, err := checkProxyConnectivity(c.Request.Context(), proxyURL, testURL, sdkCfg)
 	latencyMs := time.Since(started).Milliseconds()
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
@@ -149,11 +153,12 @@ func (h *Handler) PostProxyPoolCheck(c *gin.Context) {
 	})
 }
 
-func checkProxyConnectivity(ctx context.Context, proxyURL string, testURL string) (int, error) {
+func checkProxyConnectivity(ctx context.Context, proxyURL string, testURL string, sdkCfg *config.SDKConfig) (int, error) {
 	transport := util.BuildProxyTransport(proxyURL, false)
 	if transport == nil {
 		return 0, fmt.Errorf("failed to build proxy transport")
 	}
+	util.ApplyTLSConfig(transport, sdkCfg)
 	client := &http.Client{Timeout: defaultProxyCheckTimeout, Transport: transport}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, testURL, nil)
 	if err != nil {

--- a/internal/api/handlers/management/update.go
+++ b/internal/api/handlers/management/update.go
@@ -360,7 +360,11 @@ func (h *Handler) githubClient() *http.Client {
 	if h != nil && h.cfg != nil {
 		proxyURL := strings.TrimSpace(h.cfg.ProxyURL)
 		if proxyURL != "" {
-			util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: proxyURL}, client)
+			util.SetProxy(&sdkconfig.SDKConfig{
+				ProxyURL:           proxyURL,
+				InsecureSkipVerify: h.cfg.InsecureSkipVerify,
+				CACert:             h.cfg.CACert,
+			}, client)
 		}
 	}
 	return client

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -47,6 +47,15 @@ type SDKConfig struct {
 	// NonStreamKeepAliveInterval controls how often blank lines are emitted for non-streaming responses.
 	// <= 0 disables keep-alives. Value is in seconds.
 	NonStreamKeepAliveInterval int `yaml:"nonstream-keepalive-interval,omitempty" json:"nonstream-keepalive-interval,omitempty"`
+
+	// InsecureSkipVerify disables TLS certificate verification for upstream HTTPS connections.
+	// When true, the proxy will accept any certificate presented by upstream servers.
+	// This is insecure and should only be used in testing or trusted internal networks.
+	InsecureSkipVerify bool `yaml:"insecure-skip-verify" json:"insecure-skip-verify"`
+
+	// CACert is the path to a PEM-encoded CA certificate file used to verify upstream server certificates.
+	// When empty, the system default root CA pool is used.
+	CACert string `yaml:"ca-cert" json:"ca-cert"`
 }
 
 // RequestLogStorageConfig controls retention and cleanup of full request/response bodies.

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -47,6 +47,9 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		transport := util.BuildProxyTransport(proxyURL, cfg != nil && cfg.PreferIPv4)
 		if transport != nil {
 			httpClient.Transport = transport
+			if sdkCfg := cfgToSDKCfg(cfg); sdkCfg != nil {
+				util.ApplyTLSConfig(transport, sdkCfg)
+			}
 			return httpClient
 		}
 		// If proxy setup failed, log and fall through to context RoundTripper
@@ -59,8 +62,20 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	}
 
 	if httpClient.Transport == nil {
-		httpClient.Transport = util.NewDefaultTransport(cfg != nil && cfg.PreferIPv4)
+		transport := util.NewDefaultTransport(cfg != nil && cfg.PreferIPv4)
+		httpClient.Transport = transport
+		if sdkCfg := cfgToSDKCfg(cfg); sdkCfg != nil {
+			util.ApplyTLSConfig(transport, sdkCfg)
+		}
 	}
 
 	return httpClient
+}
+
+// cfgToSDKCfg extracts the embedded SDKConfig from Config for TLS settings.
+func cfgToSDKCfg(cfg *config.Config) *config.SDKConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &cfg.SDKConfig
 }

--- a/internal/util/proxy.go
+++ b/internal/util/proxy.go
@@ -116,5 +116,8 @@ func SetProxy(cfg *config.SDKConfig, httpClient *http.Client) *http.Client {
 	if transport := BuildProxyTransport(cfg.ProxyURL, cfg.PreferIPv4); transport != nil {
 		httpClient.Transport = transport
 	}
+	if t, ok := httpClient.Transport.(*http.Transport); ok {
+		ApplyTLSConfig(t, cfg)
+	}
 	return httpClient
 }

--- a/internal/util/tls.go
+++ b/internal/util/tls.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"os"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	log "github.com/sirupsen/logrus"
+)
+
+// ApplyTLSConfig applies TLS settings from SDKConfig to the given HTTP transport.
+// It configures InsecureSkipVerify and custom CA certificates when specified.
+// This function is safe to call with nil transport or nil sdkCfg.
+func ApplyTLSConfig(transport *http.Transport, sdkCfg *config.SDKConfig) {
+	if transport == nil {
+		return
+	}
+
+	tlsConfig := &tls.Config{}
+	hasCustom := false
+
+	if sdkCfg != nil && sdkCfg.CACert != "" {
+		caCert, err := os.ReadFile(sdkCfg.CACert)
+		if err != nil {
+			log.Errorf("failed to read CA cert file %s: %v", sdkCfg.CACert, err)
+		} else {
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM(caCert) {
+				log.Errorf("failed to parse CA cert from %s", sdkCfg.CACert)
+			} else {
+				tlsConfig.RootCAs = caCertPool
+				hasCustom = true
+			}
+		}
+	}
+
+	if sdkCfg != nil && sdkCfg.InsecureSkipVerify {
+		tlsConfig.InsecureSkipVerify = true
+		hasCustom = true
+		log.Warn("TLS certificate verification is disabled for upstream connections. This is insecure and should only be used in testing or trusted internal networks.")
+	}
+
+	if hasCustom {
+		transport.TLSClientConfig = tlsConfig
+	}
+}


### PR DESCRIPTION
## Summary

Add two global configuration options to handle upstream SSL certificate verification failures that occur in certain deployment environments (especially Docker with incomplete CA bundles or upstream APIs using self-signed certificates).

## Changes

- **`insecure-skip-verify`** (default: `false`): Disables TLS certificate verification for all upstream HTTPS connections.
- **`ca-cert`** (default: `""`): Path to a PEM-encoded custom CA certificate file for verifying upstream server certificates.

These settings are applied to all outbound HTTP transports:
- Provider HTTP clients (Codex, Claude, Gemini, Kimi, iFlow, Qwen, Antigravity)
- Runtime proxy-aware HTTP clients
- Proxy pool connectivity checks
- API tool transports
- GitHub release/update check clients

## Usage

```yaml
# In config.yaml
insecure-skip-verify: true
ca-cert: "/path/to/custom-ca.pem"
```

⚠️ **Security note**: `insecure-skip-verify` should only be used in testing or trusted internal networks.