### PR TITLE
fix: prevent management IP ban lockouts

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -45,6 +45,13 @@ tls:
 #   - "http://localhost:5173"
 cors-allow-origins: []
 
+# Reverse proxies whose X-Forwarded-For / X-Real-IP headers may be trusted.
+# Leave empty for direct exposure. For Docker bridge + Nginx, trust only the
+# proxy/container subnet, for example:
+# trusted-proxies:
+#   - "172.18.0.0/16"
+trusted-proxies: []
+
 # Management API settings
 remote-management:
   # Whether to allow remote (non-localhost) management access.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -206,27 +206,28 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		envSecret := h.envSecret
 
 		fail := func() {}
+		isBanned := func() (time.Duration, bool) { return 0, false }
+		clearFailures := func() {}
 		if !localClient {
-			h.attemptsMu.Lock()
-			ai := h.failedAttempts[clientIP]
-			if ai != nil {
-				if !ai.blockedUntil.IsZero() {
-					if time.Now().Before(ai.blockedUntil) {
-						remaining := time.Until(ai.blockedUntil).Round(time.Second)
-						h.attemptsMu.Unlock()
-						c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)})
-						return
-					}
-					// Ban expired, reset state
-					ai.blockedUntil = time.Time{}
-					ai.count = 0
-				}
-			}
-			h.attemptsMu.Unlock()
-
 			if !allowRemote {
 				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "remote management disabled"})
 				return
+			}
+
+			isBanned = func() (time.Duration, bool) {
+				h.attemptsMu.Lock()
+				defer h.attemptsMu.Unlock()
+				ai := h.failedAttempts[clientIP]
+				if ai == nil || ai.blockedUntil.IsZero() {
+					return 0, false
+				}
+				if time.Now().Before(ai.blockedUntil) {
+					return time.Until(ai.blockedUntil).Round(time.Second), true
+				}
+				// Ban expired, reset state.
+				ai.blockedUntil = time.Time{}
+				ai.count = 0
+				return 0, false
 			}
 
 			fail = func() {
@@ -241,6 +242,15 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 				if aip.count >= maxFailures {
 					aip.blockedUntil = time.Now().Add(banDuration)
 					aip.count = 0
+				}
+				h.attemptsMu.Unlock()
+			}
+
+			clearFailures = func() {
+				h.attemptsMu.Lock()
+				if ai := h.failedAttempts[clientIP]; ai != nil {
+					ai.count = 0
+					ai.blockedUntil = time.Time{}
 				}
 				h.attemptsMu.Unlock()
 			}
@@ -270,6 +280,10 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 
 		if provided == "" {
 			if !localClient {
+				if remaining, banned := isBanned(); banned {
+					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)})
+					return
+				}
 				fail()
 			}
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing management key"})
@@ -286,34 +300,24 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		}
 
 		if envSecret != "" && subtle.ConstantTimeCompare([]byte(provided), []byte(envSecret)) == 1 {
-			if !localClient {
-				h.attemptsMu.Lock()
-				if ai := h.failedAttempts[clientIP]; ai != nil {
-					ai.count = 0
-					ai.blockedUntil = time.Time{}
-				}
-				h.attemptsMu.Unlock()
-			}
+			clearFailures()
 			c.Next()
 			return
 		}
 
 		if secretHash == "" || bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) != nil {
 			if !localClient {
+				if remaining, banned := isBanned(); banned {
+					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)})
+					return
+				}
 				fail()
 			}
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid management key"})
 			return
 		}
 
-		if !localClient {
-			h.attemptsMu.Lock()
-			if ai := h.failedAttempts[clientIP]; ai != nil {
-				ai.count = 0
-				ai.blockedUntil = time.Time{}
-			}
-			h.attemptsMu.Unlock()
-		}
+		clearFailures()
 
 		c.Next()
 	}

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -1,9 +1,80 @@
 package management
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"golang.org/x/crypto/bcrypt"
+)
 
 func TestHandlerCloseIsIdempotent(t *testing.T) {
 	h := NewHandlerWithoutConfigFilePath(nil, nil)
 	h.Close()
 	h.Close()
+}
+
+func TestMiddlewareAllowsValidKeyAfterRemoteIPIsBanned(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const managementKey = "correct-management-key"
+	hashed, err := bcrypt.GenerateFromPassword([]byte(managementKey), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash test management key: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		RemoteManagement: config.RemoteManagement{
+			AllowRemote: true,
+			SecretKey:   string(hashed),
+		},
+	}, nil)
+	defer h.Close()
+
+	router := gin.New()
+	router.Use(h.Middleware())
+	router.GET("/v0/management/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	for i := 0; i < 5; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+		req.RemoteAddr = "203.0.113.10:4321"
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("missing-key attempt %d status = %d, want %d; body=%s", i+1, rr.Code, http.StatusUnauthorized, rr.Body.String())
+		}
+	}
+
+	rrBanned := httptest.NewRecorder()
+	reqBanned := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+	reqBanned.RemoteAddr = "203.0.113.10:4321"
+	router.ServeHTTP(rrBanned, reqBanned)
+	if rrBanned.Code != http.StatusForbidden {
+		t.Fatalf("banned missing-key status = %d, want %d; body=%s", rrBanned.Code, http.StatusForbidden, rrBanned.Body.String())
+	}
+	if !strings.Contains(rrBanned.Body.String(), "IP banned") {
+		t.Fatalf("expected IP banned response, got %s", rrBanned.Body.String())
+	}
+
+	rrValid := httptest.NewRecorder()
+	reqValid := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+	reqValid.RemoteAddr = "203.0.113.10:4321"
+	reqValid.Header.Set("Authorization", "Bearer "+managementKey)
+	router.ServeHTTP(rrValid, reqValid)
+	if rrValid.Code != http.StatusOK {
+		t.Fatalf("valid-key status after ban = %d, want %d; body=%s", rrValid.Code, http.StatusOK, rrValid.Body.String())
+	}
+
+	rrAfterClear := httptest.NewRecorder()
+	reqAfterClear := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+	reqAfterClear.RemoteAddr = "203.0.113.10:4321"
+	router.ServeHTTP(rrAfterClear, reqAfterClear)
+	if rrAfterClear.Code != http.StatusUnauthorized {
+		t.Fatalf("missing-key status after valid key cleared ban = %d, want %d; body=%s", rrAfterClear.Code, http.StatusUnauthorized, rrAfterClear.Body.String())
+	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -231,9 +231,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 
 	// Create gin engine
 	engine := gin.New()
-	if err := engine.SetTrustedProxies(nil); err != nil {
-		log.Warnf("failed to disable trusted proxies: %v", err)
-	}
+	configureTrustedProxies(engine, cfg.TrustedProxies)
 	if optionState.engineConfigurator != nil {
 		optionState.engineConfigurator(engine)
 	}
@@ -571,6 +569,33 @@ func (s *Server) setupRoutes() {
 	})
 
 	// Management routes are registered lazily by registerManagementRoutes when a secret is configured.
+}
+
+func configureTrustedProxies(engine *gin.Engine, trustedProxies []string) {
+	if engine == nil {
+		return
+	}
+
+	proxies := make([]string, 0, len(trustedProxies))
+	for _, proxy := range trustedProxies {
+		if trimmed := strings.TrimSpace(proxy); trimmed != "" {
+			proxies = append(proxies, trimmed)
+		}
+	}
+
+	if len(proxies) == 0 {
+		if err := engine.SetTrustedProxies(nil); err != nil {
+			log.Warnf("failed to disable trusted proxies: %v", err)
+		}
+		return
+	}
+
+	if err := engine.SetTrustedProxies(proxies); err != nil {
+		log.Warnf("failed to configure trusted proxies %v: %v; forwarded client IP headers will be ignored", proxies, err)
+		if fallbackErr := engine.SetTrustedProxies(nil); fallbackErr != nil {
+			log.Warnf("failed to disable trusted proxies after configuration error: %v", fallbackErr)
+		}
+	}
 }
 
 // AttachWebsocketRoute registers a websocket upgrade handler on the primary Gin engine.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -617,3 +617,27 @@ func TestManagementRemoteRestrictionIgnoresForgedForwardedFor(t *testing.T) {
 		t.Fatalf("expected remote management disabled response, got %s", rr.Body.String())
 	}
 }
+
+func TestServerTrustedProxiesAllowConfiguredReverseProxyClientIP(t *testing.T) {
+	server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
+		cfg.TrustedProxies = []string{"172.18.0.0/16"}
+	})
+	server.engine.GET("/test-client-ip", func(c *gin.Context) {
+		c.String(http.StatusOK, c.ClientIP())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test-client-ip", nil)
+	req.RemoteAddr = "172.18.0.1:4321"
+	req.Header.Set("X-Forwarded-For", "203.0.113.55")
+	req.Header.Set("X-Real-IP", "198.51.100.23")
+
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != "203.0.113.55" {
+		t.Fatalf("ClientIP() = %q, want forwarded client IP", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	// Leave empty to disable cross-origin browser access by default.
 	CORSAllowOrigins []string `yaml:"cors-allow-origins" json:"cors-allow-origins"`
 
+	// TrustedProxies lists reverse proxy IPs or CIDRs whose forwarding headers may be trusted.
+	// Leave empty to ignore X-Forwarded-For/X-Real-IP and use the direct peer address.
+	TrustedProxies []string `yaml:"trusted-proxies,omitempty" json:"trusted-proxies,omitempty"`
+
 	// RemoteManagement nests management-related options under 'remote-management'.
 	RemoteManagement RemoteManagement `yaml:"remote-management" json:"-"`
 


### PR DESCRIPTION
## Summary

Fixes the management IP ban lockout reported in issue #183.

- Allows a valid management key to pass even when the client IP has an active failed-attempt ban, then clears that failed state.
- Adds `trusted-proxies` startup config so Docker/Nginx deployments can opt in to trusting only known reverse proxy CIDRs for `X-Forwarded-For` / `X-Real-IP`.
- Keeps the secure default of trusting no proxy headers unless explicitly configured.

## Tests

- `go test ./internal/api/handlers/management ./internal/api`
- `go test ./...`
