### PR TITLE
Support CC Switch route model mappings

### DIFF
--- a/internal/api/handlers/management/ccswitch_import_configs.go
+++ b/internal/api/handlers/management/ccswitch_import_configs.go
@@ -48,6 +48,7 @@ func (h *Handler) PutCcSwitchImportConfigs(c *gin.Context) {
 			DefaultModel:         strings.TrimSpace(items[idx].DefaultModel),
 			ModelMappings:        items[idx].ModelMappings,
 			AllowedChannelGroups: items[idx].AllowedChannelGroups,
+			RoutePath:            items[idx].RoutePath,
 			EndpointPath:         items[idx].EndpointPath,
 			UsageAutoInterval:    items[idx].UsageAutoInterval,
 			APIKeyField:          strings.TrimSpace(items[idx].APIKeyField),

--- a/internal/api/path_routing.go
+++ b/internal/api/path_routing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -28,6 +29,21 @@ func resolvePathRouteContext(cfg *config.Config, authManager *cliproxyauth.Manag
 	routePath := internalrouting.NormalizeNamespacePath(group)
 	if routePath == "" {
 		return nil, false
+	}
+	if row, ok := usage.FindCcSwitchImportConfigByRoutePath(routePath); ok {
+		group := ""
+		if len(row.AllowedChannelGroups) > 0 {
+			group = internalrouting.NormalizeGroupName(row.AllowedChannelGroups[0])
+		}
+		if group == "" {
+			return nil, false
+		}
+		return &internalrouting.PathRouteContext{
+			RoutePath: row.RoutePath,
+			Group:     group,
+			Fallback:  "none",
+			CcSwitch:  ccSwitchRouteContextFromImportConfig(row),
+		}, true
 	}
 	if cfg != nil {
 		for i := range cfg.Routing.PathRoutes {
@@ -51,6 +67,25 @@ func resolvePathRouteContext(cfg *config.Config, authManager *cliproxyauth.Manag
 		}
 	}
 	return nil, false
+}
+
+func ccSwitchRouteContextFromImportConfig(row usage.CcSwitchImportConfigRow) *internalrouting.CcSwitchRouteContext {
+	mappings := make([]internalrouting.CcSwitchModelMapping, 0, len(row.ModelMappings))
+	for _, mapping := range row.ModelMappings {
+		mappings = append(mappings, internalrouting.CcSwitchModelMapping{
+			Role:         strings.TrimSpace(mapping.Role),
+			RequestModel: strings.TrimSpace(mapping.RequestModel),
+			TargetModel:  strings.TrimSpace(mapping.TargetModel),
+		})
+	}
+	return &internalrouting.CcSwitchRouteContext{
+		ConfigID:             strings.TrimSpace(row.ID),
+		ClientType:           strings.ToLower(strings.TrimSpace(row.ClientType)),
+		RoutePath:            row.RoutePath,
+		EndpointPath:         row.EndpointPath,
+		AllowedChannelGroups: append([]string(nil), row.AllowedChannelGroups...),
+		ModelMappings:        mappings,
+	}
 }
 
 func groupRoutingMiddleware(resolve func(string) (*internalrouting.PathRouteContext, bool)) gin.HandlerFunc {

--- a/internal/api/path_routing_test.go
+++ b/internal/api/path_routing_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestResolvePathRouteContextUsesCcSwitchEndpointPath(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, nil); err != nil {
+		t.Fatalf("usage.InitDB() error = %v", err)
+	}
+	defer usage.CloseDB()
+
+	if err := usage.ReplaceAllCcSwitchImportConfigs([]usage.CcSwitchImportConfigRow{
+		{
+			ID:                   "cfg-kimi-opus",
+			ClientType:           "claude",
+			ProviderName:         "Kimi Opus",
+			DefaultModel:         "kimi-k2.6",
+			AllowedChannelGroups: []string{"kimicode"},
+			RoutePath:            "/kimicode/cs_opus",
+			EndpointPath:         "",
+			UsageAutoInterval:    30,
+			ModelMappings: []usage.CcSwitchModelMappingRow{
+				{Role: "opus", RequestModel: "claude-opus-4-7", TargetModel: "kimi-k2.6"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllCcSwitchImportConfigs() error = %v", err)
+	}
+
+	authManager := cliproxyauth.NewManager(nil, nil, nil)
+	authManager.SetConfig(&config.Config{
+		Routing: config.RoutingConfig{
+			ChannelGroups: []config.RoutingChannelGroup{{Name: "kimicode"}},
+		},
+	})
+
+	route, ok := resolvePathRouteContext(&config.Config{}, authManager, "/kimicode/cs_opus")
+	if !ok || route == nil {
+		t.Fatal("resolvePathRouteContext() did not resolve CC Switch route")
+	}
+	if route.Group != "kimicode" {
+		t.Fatalf("route.Group = %q, want kimicode", route.Group)
+	}
+	if route.RoutePath != "/kimicode/cs_opus" {
+		t.Fatalf("route.RoutePath = %q, want /kimicode/cs_opus", route.RoutePath)
+	}
+	if route.CcSwitch == nil {
+		t.Fatal("route.CcSwitch = nil, want config metadata")
+	}
+	if route.CcSwitch.ConfigID != "cfg-kimi-opus" {
+		t.Fatalf("route.CcSwitch.ConfigID = %q, want cfg-kimi-opus", route.CcSwitch.ConfigID)
+	}
+	if len(route.CcSwitch.ModelMappings) != 1 ||
+		route.CcSwitch.ModelMappings[0].RequestModel != "claude-opus-4-7" ||
+		route.CcSwitch.ModelMappings[0].TargetModel != "kimi-k2.6" {
+		t.Fatalf("route.CcSwitch.ModelMappings = %#v", route.CcSwitch.ModelMappings)
+	}
+
+	legacyRoute, ok := resolvePathRouteContext(&config.Config{}, authManager, "/kimicode")
+	if !ok || legacyRoute == nil {
+		t.Fatal("resolvePathRouteContext() did not resolve legacy channel group route")
+	}
+	if legacyRoute.CcSwitch != nil {
+		t.Fatalf("legacy route CcSwitch = %#v, want nil", legacyRoute.CcSwitch)
+	}
+}

--- a/internal/routing/scope.go
+++ b/internal/routing/scope.go
@@ -17,6 +17,22 @@ type PathRouteContext struct {
 	RoutePath string
 	Group     string
 	Fallback  string
+	CcSwitch  *CcSwitchRouteContext
+}
+
+type CcSwitchRouteContext struct {
+	ConfigID             string
+	ClientType           string
+	RoutePath            string
+	EndpointPath         string
+	AllowedChannelGroups []string
+	ModelMappings        []CcSwitchModelMapping
+}
+
+type CcSwitchModelMapping struct {
+	Role         string
+	RequestModel string
+	TargetModel  string
 }
 
 type pathRouteContextKey struct{}
@@ -29,8 +45,7 @@ func WithPathRouteContext(ctx context.Context, route *PathRouteContext) context.
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cloned := *route
-	return context.WithValue(ctx, pathRouteContextKey{}, &cloned)
+	return context.WithValue(ctx, pathRouteContextKey{}, clonePathRouteContext(route))
 }
 
 // PathRouteContextFromContext extracts the resolved path-route scope from context.
@@ -43,7 +58,24 @@ func PathRouteContextFromContext(ctx context.Context) *PathRouteContext {
 	if route == nil {
 		return nil
 	}
+	return clonePathRouteContext(route)
+}
+
+func clonePathRouteContext(route *PathRouteContext) *PathRouteContext {
+	if route == nil {
+		return nil
+	}
 	cloned := *route
+	if route.CcSwitch != nil {
+		ccSwitch := *route.CcSwitch
+		if route.CcSwitch.AllowedChannelGroups != nil {
+			ccSwitch.AllowedChannelGroups = append([]string(nil), route.CcSwitch.AllowedChannelGroups...)
+		}
+		if route.CcSwitch.ModelMappings != nil {
+			ccSwitch.ModelMappings = append([]CcSwitchModelMapping(nil), route.CcSwitch.ModelMappings...)
+		}
+		cloned.CcSwitch = &ccSwitch
+	}
 	return &cloned
 }
 

--- a/internal/usage/ccswitch_import_configs_db.go
+++ b/internal/usage/ccswitch_import_configs_db.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -24,6 +25,7 @@ type CcSwitchImportConfigRow struct {
 	DefaultModel         string                    `json:"default-model"`
 	ModelMappings        []CcSwitchModelMappingRow `json:"model-mappings"`
 	AllowedChannelGroups []string                  `json:"allowed-channel-groups"`
+	RoutePath            string                    `json:"route-path,omitempty"`
 	EndpointPath         string                    `json:"endpoint-path"`
 	UsageAutoInterval    int                       `json:"usage-auto-interval"`
 	APIKeyField          string                    `json:"api-key-field,omitempty"`
@@ -40,6 +42,7 @@ CREATE TABLE IF NOT EXISTS ccswitch_import_configs (
   default_model          TEXT NOT NULL DEFAULT '',
   model_mappings         TEXT NOT NULL DEFAULT '[]',
   allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+  route_path             TEXT NOT NULL DEFAULT '',
   endpoint_path          TEXT NOT NULL DEFAULT '',
   usage_auto_interval    INTEGER NOT NULL DEFAULT 30,
   api_key_field          TEXT NOT NULL DEFAULT '',
@@ -57,6 +60,15 @@ func initCcSwitchImportConfigsTable(db *sql.DB) {
 			log.Errorf("usage: migrate ccswitch_import_configs.model_mappings: %v", err)
 		}
 	}
+	if _, err := db.Exec(`ALTER TABLE ccswitch_import_configs ADD COLUMN route_path TEXT NOT NULL DEFAULT ''`); err != nil {
+		if !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+			log.Errorf("usage: migrate ccswitch_import_configs.route_path: %v", err)
+		}
+	}
+	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_ccswitch_import_configs_route_path
+		ON ccswitch_import_configs(route_path) WHERE route_path <> ''`); err != nil {
+		log.Errorf("usage: create ccswitch_import_configs.route_path index: %v", err)
+	}
 }
 
 func ListCcSwitchImportConfigs() []CcSwitchImportConfigRow {
@@ -66,7 +78,7 @@ func ListCcSwitchImportConfigs() []CcSwitchImportConfigRow {
 	}
 
 	rows, err := db.Query(`SELECT id, client_type, provider_name, note, default_model, model_mappings,
-		allowed_channel_groups, endpoint_path, usage_auto_interval, api_key_field, created_at, updated_at
+		allowed_channel_groups, route_path, endpoint_path, usage_auto_interval, api_key_field, created_at, updated_at
 		FROM ccswitch_import_configs ORDER BY created_at ASC, id ASC`)
 	if err != nil {
 		log.Errorf("usage: list ccswitch_import_configs: %v", err)
@@ -82,6 +94,26 @@ func ListCcSwitchImportConfigs() []CcSwitchImportConfigRow {
 		}
 	}
 	return result
+}
+
+func FindCcSwitchImportConfigByRoutePath(routePath string) (CcSwitchImportConfigRow, bool) {
+	db := getDB()
+	if db == nil {
+		return CcSwitchImportConfigRow{}, false
+	}
+	normalizedRoutePath := normalizeCcSwitchRoutePath(routePath)
+	if normalizedRoutePath == "" {
+		return CcSwitchImportConfigRow{}, false
+	}
+
+	row := db.QueryRow(`SELECT id, client_type, provider_name, note, default_model, model_mappings,
+		allowed_channel_groups, route_path, endpoint_path, usage_auto_interval, api_key_field, created_at, updated_at
+		FROM ccswitch_import_configs WHERE route_path = ? LIMIT 1`, normalizedRoutePath)
+	result := scanCcSwitchImportConfigFromRow(row)
+	if result == nil {
+		return CcSwitchImportConfigRow{}, false
+	}
+	return *result, true
 }
 
 func ReplaceAllCcSwitchImportConfigs(configs []CcSwitchImportConfigRow) error {
@@ -102,8 +134,8 @@ func ReplaceAllCcSwitchImportConfigs(configs []CcSwitchImportConfigRow) error {
 
 	stmt, err := tx.Prepare(`INSERT INTO ccswitch_import_configs
 		(id, client_type, provider_name, note, default_model, model_mappings, allowed_channel_groups,
-		 endpoint_path, usage_auto_interval, api_key_field, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		 route_path, endpoint_path, usage_auto_interval, api_key_field, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -112,6 +144,7 @@ func ReplaceAllCcSwitchImportConfigs(configs []CcSwitchImportConfigRow) error {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	seen := make(map[string]struct{}, len(configs))
+	seenRoutePaths := make(map[string]struct{}, len(configs))
 	for _, row := range configs {
 		row = normalizeCcSwitchImportConfigRow(row)
 		if row.ID == "" {
@@ -135,6 +168,13 @@ func ReplaceAllCcSwitchImportConfigs(configs []CcSwitchImportConfigRow) error {
 			return fmt.Errorf("duplicate id %q", row.ID)
 		}
 		seen[row.ID] = struct{}{}
+		if row.RoutePath != "" {
+			if _, exists := seenRoutePaths[row.RoutePath]; exists {
+				_ = tx.Rollback()
+				return fmt.Errorf("duplicate route-path %q", row.RoutePath)
+			}
+			seenRoutePaths[row.RoutePath] = struct{}{}
+		}
 		if row.CreatedAt == "" {
 			row.CreatedAt = now
 		}
@@ -148,6 +188,7 @@ func ReplaceAllCcSwitchImportConfigs(configs []CcSwitchImportConfigRow) error {
 			row.DefaultModel,
 			mustJSONModelMappings(row.ModelMappings),
 			mustJSONStringList(row.AllowedChannelGroups),
+			row.RoutePath,
 			row.EndpointPath,
 			row.UsageAutoInterval,
 			row.APIKeyField,
@@ -170,6 +211,7 @@ func normalizeCcSwitchImportConfigRow(row CcSwitchImportConfigRow) CcSwitchImpor
 	row.DefaultModel = strings.TrimSpace(row.DefaultModel)
 	row.ModelMappings = normalizeCcSwitchModelMappings(row.ModelMappings)
 	row.AllowedChannelGroups = normalizeLowerStringSlice(row.AllowedChannelGroups)
+	row.RoutePath = normalizeCcSwitchRoutePath(row.RoutePath)
 	row.EndpointPath = normalizeCcSwitchEndpointPath(row.EndpointPath)
 	if row.UsageAutoInterval <= 0 {
 		row.UsageAutoInterval = 30
@@ -214,6 +256,10 @@ func normalizeCcSwitchEndpointPath(value string) string {
 		raw = "/" + raw
 	}
 	return strings.TrimRight(raw, "/")
+}
+
+func normalizeCcSwitchRoutePath(value string) string {
+	return internalrouting.NormalizeNamespacePath(value)
 }
 
 func normalizeCcSwitchAPIKeyField(value string) string {
@@ -296,6 +342,7 @@ func scanCcSwitchImportConfigFromRow(row scannable) *CcSwitchImportConfigRow {
 		&result.DefaultModel,
 		&modelMappingsJSON,
 		&allowedChannelGroupsJSON,
+		&result.RoutePath,
 		&result.EndpointPath,
 		&result.UsageAutoInterval,
 		&result.APIKeyField,

--- a/internal/usage/ccswitch_import_configs_db_test.go
+++ b/internal/usage/ccswitch_import_configs_db_test.go
@@ -46,3 +46,85 @@ func TestReplaceAllCcSwitchImportConfigsPersistsModelMappings(t *testing.T) {
 		t.Fatalf("model mapping not preserved: %#v", rows[0].ModelMappings[1])
 	}
 }
+
+func TestReplaceAllCcSwitchImportConfigsRejectsDuplicateRoutePaths(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+	usageDBMu.Lock()
+	db := usageDB
+	usageDBMu.Unlock()
+	if db == nil {
+		t.Fatal("expected test db")
+	}
+	initCcSwitchImportConfigsTable(db)
+
+	err := ReplaceAllCcSwitchImportConfigs([]CcSwitchImportConfigRow{
+		{
+			ID:                   "cfg-kimi-a",
+			ClientType:           "claude",
+			ProviderName:         "Kimi A",
+			DefaultModel:         "kimi-k2.6",
+			AllowedChannelGroups: []string{"kimicode"},
+			RoutePath:            "/kimicode/cs_same",
+			EndpointPath:         "",
+			UsageAutoInterval:    30,
+		},
+		{
+			ID:                   "cfg-kimi-b",
+			ClientType:           "claude",
+			ProviderName:         "Kimi B",
+			DefaultModel:         "kimi-k2.6",
+			AllowedChannelGroups: []string{"kimicode"},
+			RoutePath:            "kimicode/cs_same/",
+			EndpointPath:         "",
+			UsageAutoInterval:    30,
+		},
+	})
+	if err == nil {
+		t.Fatal("ReplaceAllCcSwitchImportConfigs() error = nil, want duplicate route-path error")
+	}
+}
+
+func TestFindCcSwitchImportConfigByRoutePath(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+	usageDBMu.Lock()
+	db := usageDB
+	usageDBMu.Unlock()
+	if db == nil {
+		t.Fatal("expected test db")
+	}
+	initCcSwitchImportConfigsTable(db)
+
+	if err := ReplaceAllCcSwitchImportConfigs([]CcSwitchImportConfigRow{
+		{
+			ID:                   "cfg-kimi-route",
+			ClientType:           "claude",
+			ProviderName:         "Kimi route",
+			DefaultModel:         "kimi-k2.6",
+			AllowedChannelGroups: []string{"kimicode"},
+			RoutePath:            "/kimicode/cs_abcd1234",
+			EndpointPath:         "",
+			UsageAutoInterval:    30,
+			ModelMappings: []CcSwitchModelMappingRow{
+				{Role: "opus", RequestModel: "claude-opus-4-7", TargetModel: "kimi-k2.6"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllCcSwitchImportConfigs() error = %v", err)
+	}
+
+	row, ok := FindCcSwitchImportConfigByRoutePath("https://relay.example.com/kimicode/cs_abcd1234/")
+	if !ok {
+		t.Fatal("FindCcSwitchImportConfigByRoutePath() ok = false, want true")
+	}
+	if row.ID != "cfg-kimi-route" {
+		t.Fatalf("row.ID = %q, want %q", row.ID, "cfg-kimi-route")
+	}
+	if row.RoutePath != "/kimicode/cs_abcd1234" {
+		t.Fatalf("row.RoutePath = %q, want normalized route path", row.RoutePath)
+	}
+	if len(row.ModelMappings) != 1 || row.ModelMappings[0].TargetModel != "kimi-k2.6" {
+		t.Fatalf("row.ModelMappings = %#v, want kimi-k2.6 mapping", row.ModelMappings)
+	}
+}

--- a/sdk/api/handlers/claude/ccswitch_model_mapping.go
+++ b/sdk/api/handlers/claude/ccswitch_model_mapping.go
@@ -1,0 +1,52 @@
+package claude
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func routeContextFromGin(c *gin.Context) *internalrouting.PathRouteContext {
+	if c == nil {
+		return nil
+	}
+	if raw, exists := c.Get(internalrouting.GinPathRouteContextKey); exists {
+		route, _ := raw.(*internalrouting.PathRouteContext)
+		if route != nil {
+			return route
+		}
+	}
+	if c.Request != nil {
+		return internalrouting.PathRouteContextFromContext(c.Request.Context())
+	}
+	return nil
+}
+
+func rewriteCcSwitchClaudeRequestModel(rawJSON []byte, route *internalrouting.PathRouteContext) ([]byte, string, bool) {
+	modelName := strings.TrimSpace(gjson.GetBytes(rawJSON, "model").String())
+	if modelName == "" || route == nil || route.CcSwitch == nil {
+		return rawJSON, modelName, false
+	}
+	if !strings.EqualFold(strings.TrimSpace(route.CcSwitch.ClientType), "claude") {
+		return rawJSON, modelName, false
+	}
+	for _, mapping := range route.CcSwitch.ModelMappings {
+		requestModel := strings.TrimSpace(mapping.RequestModel)
+		targetModel := strings.TrimSpace(mapping.TargetModel)
+		if requestModel == "" || targetModel == "" {
+			continue
+		}
+		if !strings.EqualFold(requestModel, modelName) {
+			continue
+		}
+		rewritten, err := sjson.SetBytes(rawJSON, "model", targetModel)
+		if err != nil {
+			return rawJSON, modelName, false
+		}
+		return rewritten, targetModel, true
+	}
+	return rawJSON, modelName, false
+}

--- a/sdk/api/handlers/claude/ccswitch_model_mapping_test.go
+++ b/sdk/api/handlers/claude/ccswitch_model_mapping_test.go
@@ -1,0 +1,63 @@
+package claude
+
+import (
+	"testing"
+
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/tidwall/gjson"
+)
+
+func TestRewriteCcSwitchClaudeRequestModelMapsConfiguredRequestModel(t *testing.T) {
+	rawJSON := []byte(`{"model":"claude-opus-4-7","max_tokens":32,"messages":[{"role":"user","content":"ok"}]}`)
+	route := &internalrouting.PathRouteContext{
+		RoutePath: "/kimicode/cs_opus",
+		Group:     "kimicode",
+		CcSwitch: &internalrouting.CcSwitchRouteContext{
+			ConfigID:   "cfg-kimi-opus",
+			ClientType: "claude",
+			ModelMappings: []internalrouting.CcSwitchModelMapping{
+				{Role: "opus", RequestModel: "claude-opus-4-7", TargetModel: "kimi-k2.6"},
+			},
+		},
+	}
+
+	rewritten, modelName, mapped := rewriteCcSwitchClaudeRequestModel(rawJSON, route)
+	if !mapped {
+		t.Fatal("mapped = false, want true")
+	}
+	if modelName != "kimi-k2.6" {
+		t.Fatalf("modelName = %q, want kimi-k2.6", modelName)
+	}
+	if got := gjson.GetBytes(rewritten, "model").String(); got != "kimi-k2.6" {
+		t.Fatalf("rewritten model = %q, want kimi-k2.6", got)
+	}
+	if got := gjson.GetBytes(rawJSON, "model").String(); got != "claude-opus-4-7" {
+		t.Fatalf("input rawJSON mutated, model = %q", got)
+	}
+}
+
+func TestRewriteCcSwitchClaudeRequestModelLeavesUnmappedModelUnchanged(t *testing.T) {
+	rawJSON := []byte(`{"model":"claude-sonnet-4-5","max_tokens":32}`)
+	route := &internalrouting.PathRouteContext{
+		RoutePath: "/kimicode/cs_opus",
+		Group:     "kimicode",
+		CcSwitch: &internalrouting.CcSwitchRouteContext{
+			ConfigID:   "cfg-kimi-opus",
+			ClientType: "claude",
+			ModelMappings: []internalrouting.CcSwitchModelMapping{
+				{Role: "opus", RequestModel: "claude-opus-4-7", TargetModel: "kimi-k2.6"},
+			},
+		},
+	}
+
+	rewritten, modelName, mapped := rewriteCcSwitchClaudeRequestModel(rawJSON, route)
+	if mapped {
+		t.Fatal("mapped = true, want false")
+	}
+	if modelName != "claude-sonnet-4-5" {
+		t.Fatalf("modelName = %q, want original model", modelName)
+	}
+	if string(rewritten) != string(rawJSON) {
+		t.Fatalf("rewritten JSON changed: %s", rewritten)
+	}
+}

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -66,6 +66,7 @@ func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 	if !ok {
 		return
 	}
+	rawJSON, _, _ = rewriteCcSwitchClaudeRequestModel(rawJSON, routeContextFromGin(c))
 
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
@@ -87,6 +88,7 @@ func (h *ClaudeCodeAPIHandler) ClaudeCountTokens(c *gin.Context) {
 	if !ok {
 		return
 	}
+	rawJSON, _, _ = rewriteCcSwitchClaudeRequestModel(rawJSON, routeContextFromGin(c))
 
 	c.Header("Content-Type", "application/json")
 


### PR DESCRIPTION
## Summary
- add database-backed CC Switch route paths with duplicate protection
- resolve route-isolated CC Switch namespaces to their channel group
- rewrite Claude request models from configured request model to target model on CC Switch routes

## Test Plan
- go test -count=1 ./...
- go test ./...
