### PR TITLE
fix: register Kimi K2.6 for Kimi auth

### DIFF
--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -1073,6 +1073,18 @@ func GetKimiModels() []*ModelInfo {
 			MaxCompletionTokens: 32768,
 			Thinking:            &ThinkingSupport{Min: 1024, Max: 32000, ZeroAllowed: true, DynamicAllowed: true},
 		},
+		{
+			ID:                  "kimi-k2.6",
+			Object:              "model",
+			Created:             1776038400, // 2026-04-13
+			OwnedBy:             "moonshot",
+			Type:                "kimi",
+			DisplayName:         "Kimi K2.6",
+			Description:         "Kimi K2.6 - Latest Moonshot AI coding model with improved capabilities",
+			ContextLength:       131072,
+			MaxCompletionTokens: 32768,
+			Thinking:            &ThinkingSupport{Min: 1024, Max: 32000, ZeroAllowed: true, DynamicAllowed: true},
+		},
 	}
 }
 

--- a/sdk/cliproxy/service_kimi_test.go
+++ b/sdk/cliproxy/service_kimi_test.go
@@ -1,0 +1,33 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+func TestRegisterModelsForAuth_KimiRegistersK2Dot6(t *testing.T) {
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "kimi-auth-models",
+		Provider: "kimi",
+		Status:   coreauth.StatusActive,
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	if !registry.ClientSupportsModel(auth.ID, "kimi-k2.6") {
+		t.Fatalf("expected Kimi auth to register kimi-k2.6 support")
+	}
+	if !hasModelID(registry.GetAvailableModelsByProvider("kimi"), "kimi-k2.6") {
+		t.Fatalf("expected kimi-k2.6 in available Kimi provider models")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `kimi-k2.6` to the Kimi static model catalog so Kimi OAuth auths register support for it.
- Add a regression test proving Kimi auth registration includes `kimi-k2.6`.

## Test Plan
- `go test ./sdk/cliproxy -run TestRegisterModelsForAuth_KimiRegistersK2Dot6 -count=1`
- `go test ./sdk/cliproxy ./sdk/api/handlers ./sdk/api/handlers/claude ./internal/registry ./internal/runtime/executor ./internal/api ./internal/routing ./internal/usage -count=1`
- `go test ./... -count=1`
- `go build ./cmd/server`