### PR TITLE
fix: treat kimi token auth as oauth channels

### DIFF
--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -95,6 +95,62 @@ func TestPatchAuthFileFieldsUpdatesOAuthChannelLabel(t *testing.T) {
 	}
 }
 
+func TestPatchAuthFileFieldsUpdatesKimiOAuthChannelLabel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	_, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "kimi-auth-1",
+		FileName: "kimi-auth-1.json",
+		Provider: "kimi",
+		Label:    "Kimi User",
+		Metadata: map[string]any{
+			"type":          "kimi",
+			"access_token":  "kimi-access-token",
+			"refresh_token": "kimi-refresh-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"name":  "kimi-auth-1.json",
+		"label": "Kimi Team A",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/auth-files/fields", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchAuthFileFields(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("kimi-auth-1")
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if updated.Label != "Kimi Team A" {
+		t.Fatalf("label = %q, want %q", updated.Label, "Kimi Team A")
+	}
+	if got, _ := updated.Metadata["label"].(string); got != "Kimi Team A" {
+		t.Fatalf("metadata label = %q, want %q", got, "Kimi Team A")
+	}
+}
+
 func TestPatchAuthFileFieldsUpdatesCustomTagsAndHiddenDefaultTags(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/handlers/management/channel_groups_test.go
+++ b/internal/api/handlers/management/channel_groups_test.go
@@ -332,6 +332,45 @@ func TestGetChannelGroupsReturnsChannelDetailsWithTags(t *testing.T) {
 	}
 }
 
+func TestBuildChannelGroupItemsKeepsRenamedKimiOAuthChannelsSeparate(t *testing.T) {
+	auths := []*coreauth.Auth{
+		{
+			ID:       "kimi-team-a",
+			Label:    "Kimi Team A",
+			Provider: "kimi",
+			Metadata: map[string]any{
+				"type":          "kimi",
+				"refresh_token": "kimi-refresh-a",
+			},
+		},
+		{
+			ID:       "kimi-team-b",
+			Label:    "Kimi Team B",
+			Provider: "kimi",
+			Metadata: map[string]any{
+				"type":          "kimi",
+				"refresh_token": "kimi-refresh-b",
+			},
+		},
+	}
+
+	items := buildChannelGroupItems(&config.Config{
+		Routing: config.RoutingConfig{IncludeDefaultGroup: true},
+	}, auths)
+	if len(items) != 1 {
+		t.Fatalf("expected default group, got %d groups: %#v", len(items), items)
+	}
+	if !containsString(items[0].Channels, "Kimi Team A") {
+		t.Fatalf("channels = %v, want Kimi Team A", items[0].Channels)
+	}
+	if !containsString(items[0].Channels, "Kimi Team B") {
+		t.Fatalf("channels = %v, want Kimi Team B", items[0].Channels)
+	}
+	if len(items[0].ChannelDetails) != 2 {
+		t.Fatalf("channel details = %#v, want two distinct Kimi entries", items[0].ChannelDetails)
+	}
+}
+
 func TestBuildChannelGroupItemsCanonicalizesRenamedOAuthChannel(t *testing.T) {
 	cfg := &config.Config{
 		Routing: config.RoutingConfig{

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -390,6 +390,9 @@ func (a *Auth) AccountInfo() (string, string) {
 			}
 		}
 	}
+	if strings.EqualFold(strings.TrimSpace(a.Provider), "kimi") && hasKimiOAuthTokenMetadata(a.Metadata) {
+		return "oauth", "kimi"
+	}
 	// Fall back to API key (API-key auth)
 	if a.Attributes != nil {
 		if v := a.Attributes["api_key"]; v != "" {
@@ -397,6 +400,18 @@ func (a *Auth) AccountInfo() (string, string) {
 		}
 	}
 	return "", ""
+}
+
+func hasKimiOAuthTokenMetadata(metadata map[string]any) bool {
+	if metadata == nil {
+		return false
+	}
+	for _, key := range []string{"refresh_token", "access_token"} {
+		if value, ok := metadata[key].(string); ok && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // ChannelName returns the user-facing channel label used by management UI and routing restrictions.

--- a/sdk/cliproxy/auth/types_test.go
+++ b/sdk/cliproxy/auth/types_test.go
@@ -33,3 +33,22 @@ func TestToolPrefixDisabled(t *testing.T) {
 		t.Error("should return false when set to false")
 	}
 }
+
+func TestKimiTokenAuthReportsOAuthAccountInfo(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{
+		Provider: "kimi",
+		Metadata: map[string]any{
+			"refresh_token": "kimi-refresh-token",
+		},
+	}
+
+	accountType, account := auth.AccountInfo()
+	if accountType != "oauth" {
+		t.Fatalf("accountType = %q, want oauth", accountType)
+	}
+	if account != "kimi" {
+		t.Fatalf("account = %q, want kimi", account)
+	}
+}


### PR DESCRIPTION
修复 Kimi token 认证文件不能设置渠道别名、不能作为可重命名 OAuth 渠道参与路由的问题。

变更：
- Kimi 认证文件只要包含 access_token 或 refresh_token，就按 OAuth 认证文件报告 account_type。
- 复用现有 label 校验、重复渠道名校验、路由引用重命名逻辑。
- 增加测试覆盖 Kimi label PATCH 和两个已命名 Kimi 渠道在 channel-groups 中保持独立。

验证：
- go test ./sdk/cliproxy/auth ./internal/api/handlers/management
- go test ./...
