### PR TITLE
Fix Kimi log channel alias resolution

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -44,7 +44,7 @@ type deleteUsageLogsRequest struct {
 func (h *Handler) GetUsageLogs(c *gin.Context) {
 	// Build name maps from config and auth store first so channel filtering can resolve
 	// to stable auth_index values (and reflect renamed OAuth channels).
-	keyNameMap, channelNameMap, authIndexChannelMap := h.buildNameMaps()
+	keyNameMap, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap := h.buildNameMaps()
 
 	channelFilterRaw := strings.TrimSpace(c.Query("channel"))
 	if channelFilterRaw == "" {
@@ -65,6 +65,7 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 	}
 	var authIndexes []string
 	var channelNames []string
+	authIndexChannelNames := make(map[string][]string)
 	if len(selectedChannelKeys) > 0 {
 		for key := range selectedChannelKeys {
 			channelNames = append(channelNames, key)
@@ -85,6 +86,9 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 			}
 			if _, ok := selectedChannelKeys[key]; ok {
 				authIndexes = append(authIndexes, idx)
+				if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
+					authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
+				}
 			}
 		}
 		// No matches should yield an empty result set rather than "no filter".
@@ -94,14 +98,15 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 	}
 
 	params := usage.LogQueryParams{
-		Page:         intQueryDefault(c, "page", 1),
-		Size:         intQueryDefault(c, "size", 50),
-		Days:         intQueryDefault(c, "days", 7),
-		APIKey:       strings.TrimSpace(c.Query("api_key")),
-		Model:        strings.TrimSpace(c.Query("model")),
-		Status:       strings.TrimSpace(c.Query("status")),
-		AuthIndexes:  authIndexes,
-		ChannelNames: channelNames,
+		Page:                  intQueryDefault(c, "page", 1),
+		Size:                  intQueryDefault(c, "size", 50),
+		Days:                  intQueryDefault(c, "days", 7),
+		APIKey:                strings.TrimSpace(c.Query("api_key")),
+		Model:                 strings.TrimSpace(c.Query("model")),
+		Status:                strings.TrimSpace(c.Query("status")),
+		AuthIndexes:           authIndexes,
+		ChannelNames:          channelNames,
+		AuthIndexChannelNames: authIndexChannelNames,
 	}
 
 	result, err := usage.QueryLogs(params)
@@ -133,6 +138,12 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 		// Keep the channel captured at request time. Only translate legacy
 		// source identifiers (email/API key) into display names.
 		if item.ChannelName != "" {
+			if name, ok := authIndexChannelMap[item.AuthIndex]; ok && strings.TrimSpace(name) != "" {
+				if _, legacy := channelNameMap[item.ChannelName]; legacy || containsFold(ambiguousAuthIndexChannelMap[item.AuthIndex], item.ChannelName) {
+					item.ChannelName = name
+					continue
+				}
+			}
 			if name, ok := channelNameMap[item.ChannelName]; ok && strings.TrimSpace(name) != "" {
 				item.ChannelName = name
 			}
@@ -240,10 +251,11 @@ func (h *Handler) DeleteUsageLogs(c *gin.Context) {
 //  1. keyNameMap:          user-facing api_key → display name
 //  2. channelNameMap:      source/api_key/email → channel name
 //  3. authIndexChannelMap: auth_index → current channel name
-func (h *Handler) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelMap map[string]string) {
+func (h *Handler) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelMap map[string]string, ambiguousAuthIndexChannelMap map[string][]string) {
 	keyNameMap = make(map[string]string)
 	channelNameMap = make(map[string]string)
 	authIndexChannelMap = make(map[string]string)
+	ambiguousAuthIndexChannelMap = make(map[string][]string)
 
 	// User-facing API key names from SQLite
 	for _, row := range usage.ListAPIKeys() {
@@ -284,6 +296,13 @@ func (h *Handler) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelM
 		}
 	}
 
+	type legacyChannelCandidate struct {
+		key       string
+		channel   string
+		authIndex string
+	}
+	var legacyCandidates []legacyChannelCandidate
+
 	if h.authManager != nil {
 		for _, auth := range h.authManager.List() {
 			if auth == nil {
@@ -299,16 +318,63 @@ func (h *Handler) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelM
 			}
 			if accountType, account := auth.AccountInfo(); strings.EqualFold(accountType, "oauth") {
 				if source := strings.TrimSpace(account); source != "" {
-					channelNameMap[source] = channel
+					legacyCandidates = append(legacyCandidates, legacyChannelCandidate{
+						key:       source,
+						channel:   channel,
+						authIndex: strings.TrimSpace(auth.Index),
+					})
 				}
 			}
 			if email := strings.TrimSpace(authEmail(auth)); email != "" {
-				channelNameMap[email] = channel
+				legacyCandidates = append(legacyCandidates, legacyChannelCandidate{
+					key:       email,
+					channel:   channel,
+					authIndex: strings.TrimSpace(auth.Index),
+				})
 			}
 		}
 	}
 
+	legacyChannelsByKey := make(map[string]map[string]struct{})
+	for _, candidate := range legacyCandidates {
+		key := strings.TrimSpace(candidate.key)
+		channel := strings.TrimSpace(candidate.channel)
+		if key == "" || channel == "" {
+			continue
+		}
+		if legacyChannelsByKey[key] == nil {
+			legacyChannelsByKey[key] = make(map[string]struct{})
+		}
+		legacyChannelsByKey[key][strings.ToLower(channel)] = struct{}{}
+	}
+	for _, candidate := range legacyCandidates {
+		key := strings.TrimSpace(candidate.key)
+		if key == "" {
+			continue
+		}
+		if len(legacyChannelsByKey[key]) > 1 {
+			if candidate.authIndex != "" {
+				ambiguousAuthIndexChannelMap[candidate.authIndex] = append(ambiguousAuthIndexChannelMap[candidate.authIndex], key)
+			}
+			continue
+		}
+		channelNameMap[key] = strings.TrimSpace(candidate.channel)
+	}
+
 	return
+}
+
+func containsFold(values []string, needle string) bool {
+	needle = strings.TrimSpace(needle)
+	if needle == "" {
+		return false
+	}
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func intQueryDefault(c *gin.Context, key string, def int) int {
@@ -644,7 +710,7 @@ func (h *Handler) GetUsageChartData(c *gin.Context) {
 		}
 		// Fallback: for older logs where api_key_name was not yet stored,
 		// enrich with display names from the current config.
-		keyNameMap, _, _ := h.buildNameMaps()
+		keyNameMap, _, _, _ := h.buildNameMaps()
 		for i := range apikeyDist {
 			if apikeyDist[i].Name == "" {
 				if name, ok := keyNameMap[apikeyDist[i].APIKey]; ok {

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -196,6 +196,120 @@ func TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers(t *testing
 	}
 }
 
+func TestGetUsageLogsResolvesGenericKimiChannelByAuthIndex(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	authA, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "kimi-auth-a",
+		FileName: "kimi-a.json",
+		Provider: "kimi",
+		Label:    "kimi-a",
+		Metadata: map[string]any{
+			"label":         "kimi-a",
+			"refresh_token": "refresh-a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth A: %v", err)
+	}
+	authB, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "kimi-auth-b",
+		FileName: "kimi-b.json",
+		Provider: "kimi",
+		Label:    "kimi-b",
+		Metadata: map[string]any{
+			"label":         "kimi-b",
+			"refresh_token": "refresh-b",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth B: %v", err)
+	}
+
+	now := time.Now().UTC()
+	usage.InsertLog(
+		"", "", "kimi-k2.6", "kimi", "kimi", authA.Index,
+		false, now.Add(-time.Minute), 123, 45,
+		usage.TokenStats{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+		"", "",
+	)
+	usage.InsertLog(
+		"", "", "kimi-k2.6", "kimi", "kimi", authB.Index,
+		false, now, 123, 45,
+		usage.TokenStats{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+		"", "",
+	)
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50", nil)
+
+	h.GetUsageLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Items []struct {
+			ChannelName string `json:"channel_name"`
+			AuthIndex   string `json:"auth_index"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(payload.Items))
+	}
+	gotByIndex := make(map[string]string, len(payload.Items))
+	for _, item := range payload.Items {
+		gotByIndex[item.AuthIndex] = item.ChannelName
+	}
+	if gotByIndex[authA.Index] != "kimi-a" {
+		t.Fatalf("channel_name for auth A = %q, want kimi-a", gotByIndex[authA.Index])
+	}
+	if gotByIndex[authB.Index] != "kimi-b" {
+		t.Fatalf("channel_name for auth B = %q, want kimi-b", gotByIndex[authB.Index])
+	}
+
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50&channel=kimi-b", nil)
+	h.GetUsageLogs(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("filtered expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal filtered response: %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("filtered item count = %d, want 1", len(payload.Items))
+	}
+	if payload.Items[0].AuthIndex != authB.Index || payload.Items[0].ChannelName != "kimi-b" {
+		t.Fatalf("filtered item = %+v, want auth B kimi-b", payload.Items[0])
+	}
+}
+
 func TestGetUsageLogs_EmptyDB_DoesNotReturnNullSlices(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -46,6 +46,9 @@ type LogQueryParams struct {
 	Status       string   // "success", "failed", or "" (all)
 	AuthIndexes  []string // optional auth_index IN (...) filter
 	ChannelNames []string // optional channel_name IN (...) filter
+	// Optional precise legacy matches for renamed auth channels whose stored
+	// channel_name was a shared provider/source value.
+	AuthIndexChannelNames map[string][]string
 }
 
 // LogQueryResult holds the paginated query result.
@@ -1227,6 +1230,29 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 		}
 		if len(authPlaceholders) > 0 {
 			filterConditions = append(filterConditions, "(auth_index IN ("+strings.Join(authPlaceholders, ",")+") AND trim(coalesce(channel_name, '')) = '')")
+		}
+
+		for idx, names := range params.AuthIndexChannelNames {
+			trimmedIndex := strings.TrimSpace(idx)
+			if trimmedIndex == "" {
+				continue
+			}
+			pairPlaceholders := make([]string, 0, len(names))
+			pairArgs := make([]any, 0, len(names)+1)
+			pairArgs = append(pairArgs, trimmedIndex)
+			for _, name := range names {
+				trimmedName := strings.ToLower(strings.TrimSpace(name))
+				if trimmedName == "" {
+					continue
+				}
+				pairPlaceholders = append(pairPlaceholders, "?")
+				pairArgs = append(pairArgs, trimmedName)
+			}
+			if len(pairPlaceholders) == 0 {
+				continue
+			}
+			filterConditions = append(filterConditions, "(auth_index = ? AND lower(trim(channel_name)) IN ("+strings.Join(pairPlaceholders, ",")+"))")
+			args = append(args, pairArgs...)
 		}
 
 		channelPlaceholders := make([]string, 0, len(params.ChannelNames))


### PR DESCRIPTION
## Summary
- resolve ambiguous legacy Kimi request logs by auth_index so renamed auth files show distinct channel aliases
- keep existing explicit stored channel names unchanged
- support precise channel filtering for ambiguous legacy auth channel names

## Tests
- go test ./internal/api/handlers/management -run 'TestGetUsageLogsResolvesGenericKimiChannelByAuthIndex|TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers|TestGetUsageLogsResolvesLegacySourceChannelName' -count=1
- go test ./internal/api/handlers/management ./internal/usage
- go test ./...