### PR TITLE
Fix Claude OAuth user model registration

### DIFF
--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -873,6 +873,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 				excluded = entry.ExcludedModels
 			}
 		}
+		models = appendOAuthUserDefinedModelConfigs(models, provider, authKind)
 		models = applyExcludedModels(models, excluded)
 	case "bedrock":
 		models = registry.GetBedrockModels()
@@ -1457,6 +1458,86 @@ func buildClaudeConfigModels(entry *config.ClaudeKey) []*ModelInfo {
 		return nil
 	}
 	return buildConfigModels(entry.Models, "anthropic", "claude")
+}
+
+func appendOAuthUserDefinedModelConfigs(models []*ModelInfo, provider, authKind string) []*ModelInfo {
+	if !strings.EqualFold(strings.TrimSpace(authKind), "oauth") {
+		return models
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return models
+	}
+	owners := modelConfigOwnerAliases(provider)
+	if len(owners) == 0 {
+		return models
+	}
+
+	out := append([]*ModelInfo(nil), models...)
+	seen := make(map[string]struct{}, len(out))
+	for _, model := range out {
+		if model == nil {
+			continue
+		}
+		id := strings.ToLower(strings.TrimSpace(model.ID))
+		if id != "" {
+			seen[id] = struct{}{}
+		}
+	}
+
+	now := time.Now().Unix()
+	for _, row := range internalusage.ListModelConfigs() {
+		modelID := strings.TrimSpace(row.ModelID)
+		if modelID == "" || !row.Enabled || !strings.EqualFold(strings.TrimSpace(row.Source), "user") {
+			continue
+		}
+		if _, ok := owners[normalizeModelConfigOwner(row.OwnedBy)]; !ok {
+			continue
+		}
+		key := strings.ToLower(modelID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, &ModelInfo{
+			ID:          modelID,
+			Object:      "model",
+			Created:     now,
+			OwnedBy:     strings.TrimSpace(row.OwnedBy),
+			Type:        provider,
+			DisplayName: strings.TrimSpace(row.Description),
+			Description: strings.TrimSpace(row.Description),
+			UserDefined: true,
+		})
+	}
+	return out
+}
+
+func modelConfigOwnerAliases(provider string) map[string]struct{} {
+	provider = normalizeModelConfigOwner(provider)
+	if provider == "" {
+		return nil
+	}
+	values := []string{provider}
+	switch provider {
+	case "claude":
+		values = append(values, "anthropic")
+	case "gemini", "gemini-cli", "vertex":
+		values = append(values, "google")
+	case "codex":
+		values = append(values, "openai")
+	}
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = normalizeModelConfigOwner(value); value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func normalizeModelConfigOwner(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), "-"))
 }
 
 func buildBedrockConfigModels(entry *config.BedrockKey) []*ModelInfo {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -1,12 +1,14 @@
 package cliproxy
 
-import "context"
-
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
@@ -121,5 +123,49 @@ func TestRegisterModelsForAuth_UsesPreMergedExcludedModelsAttribute(t *testing.T
 	}
 	if !seenGlobalExcluded {
 		t.Fatal("expected global excluded model to be present when attribute override is set")
+	}
+}
+
+func TestRegisterModelsForAuth_AddsUserModelConfigsForOAuthProvider(t *testing.T) {
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     "claude-opus-4-7",
+		OwnedBy:     "claude",
+		Description: "User-defined Claude OAuth model",
+		Enabled:     true,
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "claude-oauth-user-models",
+		Provider: "claude",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+		Metadata: map[string]any{
+			"email": "claude@example.com",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	if !hasModelID(registry.GetAvailableModelsByProvider("claude"), "claude-opus-4-7") {
+		t.Fatal("expected user-defined Claude model config to be registered for Claude OAuth auth")
 	}
 }


### PR DESCRIPTION
## Summary
- register enabled user-defined Claude model configs for Claude OAuth auths
- keep model-config additions scoped to OAuth so API-key configs do not gain unintended models
- add regression coverage for claude-opus-4-7 style user-defined OAuth models

## Tests
- go test ./...