### PR TITLE
fix: register Claude OAuth model library entries

### DIFF
--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -793,6 +793,8 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	if authKind == "" {
 		if kind, _ := a.AccountInfo(); strings.EqualFold(kind, "api_key") {
 			authKind = "apikey"
+		} else if strings.EqualFold(kind, "oauth") {
+			authKind = "oauth"
 		}
 	}
 	if a.Attributes != nil {
@@ -873,7 +875,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 				excluded = entry.ExcludedModels
 			}
 		}
-		models = appendOAuthUserDefinedModelConfigs(models, provider, authKind)
+		models = appendOAuthProviderModelConfigs(models, provider, authKind)
 		models = applyExcludedModels(models, excluded)
 	case "bedrock":
 		models = registry.GetBedrockModels()
@@ -1460,7 +1462,7 @@ func buildClaudeConfigModels(entry *config.ClaudeKey) []*ModelInfo {
 	return buildConfigModels(entry.Models, "anthropic", "claude")
 }
 
-func appendOAuthUserDefinedModelConfigs(models []*ModelInfo, provider, authKind string) []*ModelInfo {
+func appendOAuthProviderModelConfigs(models []*ModelInfo, provider, authKind string) []*ModelInfo {
 	if !strings.EqualFold(strings.TrimSpace(authKind), "oauth") {
 		return models
 	}
@@ -1488,7 +1490,7 @@ func appendOAuthUserDefinedModelConfigs(models []*ModelInfo, provider, authKind 
 	now := time.Now().Unix()
 	for _, row := range internalusage.ListModelConfigs() {
 		modelID := strings.TrimSpace(row.ModelID)
-		if modelID == "" || !row.Enabled || !strings.EqualFold(strings.TrimSpace(row.Source), "user") {
+		if modelID == "" || !row.Enabled || !oauthProviderModelConfigSourceAllowed(row.Source) {
 			continue
 		}
 		if _, ok := owners[normalizeModelConfigOwner(row.OwnedBy)]; !ok {
@@ -1511,6 +1513,15 @@ func appendOAuthUserDefinedModelConfigs(models []*ModelInfo, provider, authKind 
 		})
 	}
 	return out
+}
+
+func oauthProviderModelConfigSourceAllowed(source string) bool {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "user", "seed", "openrouter":
+		return true
+	default:
+		return false
+	}
 }
 
 func modelConfigOwnerAliases(provider string) map[string]struct{} {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -169,3 +169,88 @@ func TestRegisterModelsForAuth_AddsUserModelConfigsForOAuthProvider(t *testing.T
 		t.Fatal("expected user-defined Claude model config to be registered for Claude OAuth auth")
 	}
 }
+
+func TestRegisterModelsForAuth_AddsUserModelConfigsForOAuthProviderInferredFromAccountInfo(t *testing.T) {
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     "claude-opus-4-7",
+		OwnedBy:     "anthropic",
+		Description: "User-defined Claude OAuth model",
+		Enabled:     true,
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "claude-oauth-account-info-models",
+		Provider: "claude",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{
+			"email": "claude@example.com",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	if !hasModelID(registry.GetAvailableModelsByProvider("claude"), "claude-opus-4-7") {
+		t.Fatal("expected Claude OAuth model config to be registered when oauth is inferred from account info")
+	}
+}
+
+func TestRegisterModelsForAuth_AddsOpenRouterAnthropicModelConfigsForOAuthProvider(t *testing.T) {
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     "claude-opus-4-7",
+		OwnedBy:     "anthropic",
+		Description: "OpenRouter-synced Claude model",
+		Enabled:     true,
+		Source:      "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "claude-oauth-openrouter-models",
+		Provider: "claude",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+		Metadata: map[string]any{
+			"email": "claude@example.com",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	if !hasModelID(registry.GetAvailableModelsByProvider("claude"), "claude-opus-4-7") {
+		t.Fatal("expected OpenRouter-synced Anthropic model config to be registered for Claude OAuth auth")
+	}
+}


### PR DESCRIPTION
## Summary
- Register enabled DB model-config rows for Claude OAuth when their owner matches Claude/Anthropic, including user, seed, and OpenRouter library sources.
- Infer OAuth auth kind from AccountInfo when an auth store does not set attributes.auth_kind.
- Add regressions for account-info-inferred OAuth and OpenRouter-synced Anthropic model configs.

## Test Plan
- go test ./sdk/cliproxy -run 'TestRegisterModelsForAuth_Adds(UserModelConfigsForOAuthProvider(InferredFromAccountInfo)?|OpenRouterAnthropicModelConfigsForOAuthProvider)$' -count=1\n- go test ./...\n\nRefs #177