### PR TITLE
fix: include Claude Opus 4.7 in routing models

### DIFF
--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -52,6 +52,18 @@ func GetClaudeModels() []*ModelInfo {
 			Thinking:            &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: false},
 		},
 		{
+			ID:                  "claude-opus-4-7",
+			Object:              "model",
+			Created:             1776297600, // 2026-04-15
+			OwnedBy:             "anthropic",
+			Type:                "claude",
+			DisplayName:         "Claude Opus 4.7",
+			Description:         "Premium model combining maximum intelligence with practical performance",
+			ContextLength:       1000000,
+			MaxCompletionTokens: 128000,
+			Thinking:            &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: false, Levels: []string{"low", "medium", "high", "xhigh", "max"}},
+		},
+		{
 			ID:                  "claude-opus-4-5-20251101",
 			Object:              "model",
 			Created:             1761955200, // 2025-11-01

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -27,3 +27,22 @@ func TestCodexStaticModelsIncludeCurrentCodexModels(t *testing.T) {
 		t.Fatalf("expected LookupStaticModelInfo to exclude removed Cherry alias gptimage-2")
 	}
 }
+
+func TestClaudeStaticModelsIncludeCurrentMaxModels(t *testing.T) {
+	models := GetStaticModelDefinitionsByChannel("claude")
+	modelIDs := make(map[string]bool, len(models))
+	for _, model := range models {
+		if model != nil {
+			modelIDs[model.ID] = true
+		}
+	}
+
+	for _, id := range []string{"claude-opus-4-6", "claude-opus-4-7"} {
+		if !modelIDs[id] {
+			t.Fatalf("expected claude static models to include %q", id)
+		}
+		if LookupStaticModelInfo(id) == nil {
+			t.Fatalf("expected LookupStaticModelInfo to find %q", id)
+		}
+	}
+}

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -9,6 +9,7 @@ import (
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
@@ -168,6 +169,41 @@ func TestRegisterModelsForAuth_AddsUserModelConfigsForOAuthProvider(t *testing.T
 	if !hasModelID(registry.GetAvailableModelsByProvider("claude"), "claude-opus-4-7") {
 		t.Fatal("expected user-defined Claude model config to be registered for Claude OAuth auth")
 	}
+}
+
+func TestRegisterModelsForAuth_ClaudeOAuthStaticMaxModelIsRouteableWithoutModelConfig(t *testing.T) {
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "claude-oauth-static-max-models",
+		Provider: "claude",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{
+			"email": "claude@example.com",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	providers := util.GetProviderName("claude-opus-4-7")
+	for _, provider := range providers {
+		if provider == "claude" {
+			return
+		}
+	}
+	t.Fatalf("expected claude-opus-4-7 to route to claude after Claude OAuth registration, got providers %v", providers)
 }
 
 func TestRegisterModelsForAuth_AddsUserModelConfigsForOAuthProviderInferredFromAccountInfo(t *testing.T) {


### PR DESCRIPTION
## Summary
- add claude-opus-4-7 to backend static Claude model definitions
- add regression coverage for static Claude Max model metadata
- add routing regression showing Claude OAuth registration makes claude-opus-4-7 provider-resolvable without relying on model-config rows

## Tests
- go test ./internal/registry -run TestClaudeStaticModelsIncludeCurrentMaxModels -count=1
- go test ./sdk/cliproxy -run TestRegisterModelsForAuth_ClaudeOAuthStaticMaxModelIsRouteableWithoutModelConfig -count=1
- go test ./...