### PR TITLE
fix: enforce default route model restrictions

### DIFF
--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -233,6 +233,34 @@ func (h *Handler) modelPathRouteScopedModels(models []map[string]any, routeGroup
 	return filtered
 }
 
+func (h *Handler) modelRootRouteScopedModels(models []map[string]any) []map[string]any {
+	if h == nil || h.authManager == nil || h.cfg == nil || !h.cfg.Routing.IncludeDefaultGroup {
+		return models
+	}
+	restricted := false
+	for _, group := range h.cfg.Routing.ChannelGroups {
+		if internalrouting.NormalizeGroupName(group.Name) == "default" && len(group.AllowedModels) > 0 {
+			restricted = true
+			break
+		}
+	}
+	if !restricted {
+		return models
+	}
+	allowedGroups := map[string]struct{}{"default": {}}
+	filtered := make([]map[string]any, 0, len(models))
+	for _, model := range models {
+		id := strings.TrimSpace(modelPathStringValue(model["id"]))
+		if id == "" {
+			continue
+		}
+		if h.authManager.CanServeModelWithScopes(id, nil, allowedGroups, "") {
+			filtered = append(filtered, model)
+		}
+	}
+	return filtered
+}
+
 func modelConfigScope(c *gin.Context) string {
 	scope := strings.ToLower(strings.TrimSpace(c.Query("scope")))
 	switch scope {
@@ -410,8 +438,8 @@ func (h *Handler) GetModelPathAvailability(c *gin.Context) {
 
 	rootOpenAICapabilities := openAIV1Capabilities("/")
 	rootGeminiCapabilities := geminiV1BetaCapabilities("/")
-	appendModelPaths(items, modelRegistry.GetAvailableModels("openai"), "/", rootOpenAICapabilities)
-	appendModelPaths(items, modelRegistry.GetAvailableModels("gemini"), "/", rootGeminiCapabilities)
+	appendModelPaths(items, h.modelRootRouteScopedModels(modelRegistry.GetAvailableModels("openai")), "/", rootOpenAICapabilities)
+	appendModelPaths(items, h.modelRootRouteScopedModels(modelRegistry.GetAvailableModels("gemini")), "/", rootGeminiCapabilities)
 
 	routes := []modelPathRouteResponse{
 		{

--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -413,6 +413,80 @@ func TestGetModelPathAvailabilityFiltersConfiguredPathByRouteGroup(t *testing.T)
 	}
 }
 
+func TestGetModelPathAvailabilityFiltersRootByDefaultAllowedModels(t *testing.T) {
+	allowedModelID := "model-path-availability-default-allowed"
+	blockedModelID := "model-path-availability-default-blocked"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("model-path-availability-default-auth", "openai", []*registry.ModelInfo{
+		{ID: allowedModelID, Object: "model", OwnedBy: "openai", Type: "openai"},
+		{ID: blockedModelID, Object: "model", OwnedBy: "openai", Type: "openai"},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient("model-path-availability-default-auth")
+	})
+
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:          "default",
+					AllowedModels: []string{allowedModelID},
+				},
+			},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "model-path-availability-default-auth",
+		Provider: "openai",
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	h := NewHandler(cfg, "", manager)
+	rec := performModelsRequest(http.MethodGet, "/model-path-availability", nil, h.GetModelPathAvailability)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GetModelPathAvailability status = %d body = %s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Data []struct {
+			ID    string `json:"id"`
+			Paths []struct {
+				Method string `json:"method"`
+				Path   string `json:"path"`
+			} `json:"paths"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	hasRootPath := func(modelID string) bool {
+		t.Helper()
+		for _, item := range payload.Data {
+			if item.ID != modelID {
+				continue
+			}
+			for _, path := range item.Paths {
+				if path.Method == http.MethodGet && path.Path == "/v1/models" {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	if !hasRootPath(allowedModelID) {
+		t.Fatalf("expected %q to have root /v1/models path", allowedModelID)
+	}
+	if hasRootPath(blockedModelID) {
+		t.Fatalf("did not expect %q to have root /v1/models path", blockedModelID)
+	}
+}
+
 func TestGetModelPathAvailabilityIncludesCcSwitchRoutePaths(t *testing.T) {
 	initManagementModelsTestDB(t)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1184,8 +1184,10 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 			}
 		}
 
+		scopedRoutingRestricted := s.hasScopedRoutingModelRestriction(routeGroup, allowedChannelGroups)
+
 		// If no restriction, just call the handler directly
-		if allowedModels == nil && allowedChannels == nil && allowedChannelGroups == nil && routeGroup == "" {
+		if allowedModels == nil && allowedChannels == nil && allowedChannelGroups == nil && routeGroup == "" && !scopedRoutingRestricted {
 			userAgent := c.GetHeader("User-Agent")
 			if strings.HasPrefix(userAgent, "claude-cli") {
 				claudeHandler.ClaudeModels(c)
@@ -1234,6 +1236,9 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 					if s.handlers == nil || s.handlers.AuthManager == nil || !s.handlers.AuthManager.CanServeModelWithScopes(id, allowedChannels, allowedChannelGroups, routeGroup) {
 						continue
 					}
+				}
+				if scopedRoutingRestricted && !s.modelAllowedByScopedRoutingGroups(id, routeGroup, allowedChannelGroups) {
+					continue
 				}
 				filtered = append(filtered, model)
 			}
@@ -1877,6 +1882,11 @@ func (s *Server) scopedRoutingAllowedModels(routeGroup string, allowedGroups map
 			if normalized := internalrouting.NormalizeGroupName(group); normalized != "" {
 				scopedGroups[normalized] = struct{}{}
 			}
+		}
+	}
+	if len(scopedGroups) == 0 {
+		if s.cfg.Routing.IncludeDefaultGroup {
+			scopedGroups["default"] = struct{}{}
 		}
 	}
 	if len(scopedGroups) == 0 {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -339,6 +339,34 @@ func TestGroupedV1RouteForbiddenByChannelGroupAllowedModels(t *testing.T) {
 	}
 }
 
+func TestRootV1RouteForbiddenByDefaultChannelGroupAllowedModels(t *testing.T) {
+	server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
+		cfg.Routing.IncludeDefaultGroup = true
+		cfg.Routing.ChannelGroups = []proxyconfig.RoutingChannelGroup{
+			{
+				Name:          "default",
+				AllowedModels: []string{"gpt-5.5"},
+			},
+		}
+		cfg.SanitizeRouting()
+	})
+
+	body := `{"model":"minimax-m2.7","messages":[{"role":"user","content":"hello"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "model_not_allowed") {
+		t.Fatalf("expected model_not_allowed in body, got %s", rr.Body.String())
+	}
+}
+
 func TestGroupedNestedResponsesSuccessReturnsOK(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary
- apply default channel group allowed-model restrictions to root path POST requests
- filter root /v1/models availability in management model path data when the default group restricts models
- add regressions for root default restrictions and existing grouped-path behavior

## Tests
- go test ./internal/api ./internal/api/handlers/management
- go test ./...