### PR TITLE
Add scoped entity usage stats

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -736,8 +736,10 @@ func (h *Handler) GetUsageChartData(c *gin.Context) {
 func (h *Handler) GetEntityUsageStats(c *gin.Context) {
 	apiKey := strings.TrimSpace(c.Query("api_key"))
 	days := intQueryDefault(c, "days", 7)
+	authIndexes := queryStringList(c, "auth_index")
+	sources := queryStringList(c, "source")
 
-	sourceStats, err := usage.QueryEntityStats(apiKey, days, "source")
+	sourceStats, err := usage.QueryEntityStats(apiKey, days, "source", sources)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -746,7 +748,7 @@ func (h *Handler) GetEntityUsageStats(c *gin.Context) {
 		sourceStats = []usage.EntityStatPoint{}
 	}
 
-	authIndexStats, err := usage.QueryEntityStats(apiKey, days, "auth_index")
+	authIndexStats, err := usage.QueryEntityStats(apiKey, days, "auth_index", authIndexes)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -759,6 +761,29 @@ func (h *Handler) GetEntityUsageStats(c *gin.Context) {
 		"source":     sourceStats,
 		"auth_index": authIndexStats,
 	})
+}
+
+func queryStringList(c *gin.Context, key string) []string {
+	rawValues := c.QueryArray(key)
+	if len(rawValues) == 0 {
+		rawValues = []string{c.Query(key)}
+	}
+	seen := map[string]struct{}{}
+	values := make([]string, 0, len(rawValues))
+	for _, raw := range rawValues {
+		for _, part := range strings.Split(raw, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			values = append(values, trimmed)
+		}
+	}
+	return values
 }
 
 func (h *Handler) GetAuthFileGroupTrend(c *gin.Context) {

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -561,6 +561,69 @@ func TestGetAuthFileGroupTrendAggregatesByProvider(t *testing.T) {
 	}
 }
 
+func TestGetEntityUsageStatsScopesAuthIndexesAndSources(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	now := time.Now().UTC()
+	usage.InsertLog("", "", "gpt-5.4", "codex-a", "Codex A", "auth-a", false, now, 10, 1, usage.TokenStats{TotalTokens: 11}, "", "")
+	usage.InsertLog("", "", "gpt-5.4", "codex-b", "Codex B", "auth-b", true, now, 20, 1, usage.TokenStats{TotalTokens: 21}, "", "")
+	usage.InsertLog("", "", "gpt-5.4", "codex-c", "Codex C", "auth-c", false, now, 30, 1, usage.TokenStats{TotalTokens: 31}, "", "")
+
+	h := &Handler{cfg: &config.Config{}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(
+		http.MethodGet,
+		"/usage/entity-stats?days=30&auth_index=auth-a&auth_index=auth-b&source=codex-b",
+		nil,
+	)
+
+	h.GetEntityUsageStats(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Source []struct {
+			EntityName string `json:"entity_name"`
+			Requests   int64  `json:"requests"`
+			Failed     int64  `json:"failed"`
+		} `json:"source"`
+		AuthIndex []struct {
+			EntityName string `json:"entity_name"`
+			Requests   int64  `json:"requests"`
+			Failed     int64  `json:"failed"`
+		} `json:"auth_index"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Source) != 1 || payload.Source[0].EntityName != "codex-b" {
+		t.Fatalf("source payload = %+v, want only codex-b", payload.Source)
+	}
+	if len(payload.AuthIndex) != 2 {
+		t.Fatalf("auth_index payload len = %d, want 2: %+v", len(payload.AuthIndex), payload.AuthIndex)
+	}
+	for _, point := range payload.AuthIndex {
+		if point.EntityName == "auth-c" {
+			t.Fatalf("auth_index payload included unrequested auth-c: %+v", payload.AuthIndex)
+		}
+	}
+}
+
 func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -1775,7 +1775,7 @@ type EntityStatPoint struct {
 
 // QueryEntityStats returns aggregates grouped by a given column (e.g. "source" or "auth_index").
 // Time range is derived from days logic.
-func QueryEntityStats(apiKey string, days int, groupColumn string) ([]EntityStatPoint, error) {
+func QueryEntityStats(apiKey string, days int, groupColumn string, entityNames []string) ([]EntityStatPoint, error) {
 	db := getDB()
 	if db == nil {
 		return nil, nil
@@ -1789,6 +1789,19 @@ func QueryEntityStats(apiKey string, days int, groupColumn string) ([]EntityStat
 
 	params := LogQueryParams{APIKey: apiKey, Days: days}
 	where, args := buildWhereClause(params)
+	entityNames = normalizeEntityStatFilters(entityNames)
+	if len(entityNames) > 0 {
+		placeholders := make([]string, 0, len(entityNames))
+		for _, name := range entityNames {
+			placeholders = append(placeholders, "?")
+			args = append(args, name)
+		}
+		if where == "" {
+			where = " WHERE " + groupColumn + " IN (" + strings.Join(placeholders, ",") + ")"
+		} else {
+			where += " AND " + groupColumn + " IN (" + strings.Join(placeholders, ",") + ")"
+		}
+	}
 
 	q := fmt.Sprintf(`
 		SELECT %s, COUNT(*), COALESCE(SUM(failed),0), COALESCE(AVG(latency_ms),0), COALESCE(SUM(total_tokens),0)
@@ -1811,6 +1824,26 @@ func QueryEntityStats(apiKey string, days int, groupColumn string) ([]EntityStat
 		result = append(result, p)
 	}
 	return result, rows.Err()
+}
+
+func normalizeEntityStatFilters(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
 }
 
 func QueryDailyCallsByAuthIndexes(authIndexes []string, days int) ([]DailyCountPoint, error) {

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -85,6 +85,42 @@ func TestQueryDailyCallsByAuthIndexesBucketsByProjectTimezone(t *testing.T) {
 	}
 }
 
+func TestQueryEntityStatsFiltersByRequestedEntities(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	now := time.Now().UTC()
+	InsertLog("", "", "gpt-5.4", "codex-a", "Codex A", "auth-a", false, now, 10, 1, TokenStats{TotalTokens: 11}, "", "")
+	InsertLog("", "", "gpt-5.4", "codex-b", "Codex B", "auth-b", true, now, 20, 1, TokenStats{TotalTokens: 21}, "", "")
+	InsertLog("", "", "gpt-5.4", "codex-c", "Codex C", "auth-c", false, now, 30, 1, TokenStats{TotalTokens: 31}, "", "")
+
+	authStats, err := QueryEntityStats("", 30, "auth_index", []string{"auth-a", "auth-b"})
+	if err != nil {
+		t.Fatalf("QueryEntityStats(auth_index) error = %v", err)
+	}
+	if len(authStats) != 2 {
+		t.Fatalf("auth stats len = %d, want 2: %+v", len(authStats), authStats)
+	}
+	for _, point := range authStats {
+		if point.EntityName == "auth-c" {
+			t.Fatalf("auth stats included unrequested auth-c: %+v", authStats)
+		}
+	}
+
+	sourceStats, err := QueryEntityStats("", 30, "source", []string{"codex-b"})
+	if err != nil {
+		t.Fatalf("QueryEntityStats(source) error = %v", err)
+	}
+	if len(sourceStats) != 1 {
+		t.Fatalf("source stats len = %d, want 1: %+v", len(sourceStats), sourceStats)
+	}
+	if sourceStats[0].EntityName != "codex-b" {
+		t.Fatalf("source entity = %q, want codex-b", sourceStats[0].EntityName)
+	}
+	if sourceStats[0].Requests != 1 || sourceStats[0].Failed != 1 {
+		t.Fatalf("source stats = %+v, want one failed request", sourceStats[0])
+	}
+}
+
 func TestQuotaSnapshotPointsKeepFineGrainedSeries(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 


### PR DESCRIPTION
Summary

- Add auth_index and source query filters to the management entity usage stats endpoint.
- Apply normalized entity filters at the usage DB query layer so scoped callers do not receive unrelated entities.
- Support repeated and comma-separated query params for multi-entity stats requests.
- Add regressions for handler-level scoping and DB-level entity filtering.

Tests

- go test ./...
- go test ./internal/usage ./internal/api/handlers/management
- git diff --check
