### PR TITLE
fix: expose codex quota restriction window

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -940,6 +940,12 @@ func buildRestrictionEntry(scope, model string, status coreauth.Status, statusMe
 		if quota.Reason != "" {
 			entry["reason"] = quota.Reason
 		}
+		if quota.Window != "" {
+			entry["quota_window"] = quota.Window
+		}
+		if quota.WindowMinutes > 0 {
+			entry["quota_window_minutes"] = quota.WindowMinutes
+		}
 		if !quota.NextRecoverAt.IsZero() && quota.NextRecoverAt.After(now) {
 			entry["next_recover_at"] = quota.NextRecoverAt
 		}

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -538,6 +538,8 @@ func TestBuildAuthFileEntryDedupesDuplicateRestrictions(t *testing.T) {
 			Exceeded:      true,
 			Reason:        "quota",
 			NextRecoverAt: nextRecover,
+			Window:        "5h",
+			WindowMinutes: 300,
 		},
 		ModelStates: map[string]*coreauth.ModelState{
 			"gpt-5.4-mini": makeModelState(),
@@ -559,6 +561,9 @@ func TestBuildAuthFileEntryDedupesDuplicateRestrictions(t *testing.T) {
 	got := restrictions[0]
 	if got["scope"] != "auth" || got["http_status"] != http.StatusTooManyRequests {
 		t.Fatalf("restriction = %#v, want auth 429", got)
+	}
+	if got["quota_window"] != "5h" || got["quota_window_minutes"] != 300 {
+		t.Fatalf("quota window = %#v/%#v, want 5h/300", got["quota_window"], got["quota_window_minutes"])
 	}
 	if _, hasModel := got["model"]; hasModel {
 		t.Fatalf("restriction model = %#v, want no model field", got["model"])

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -193,7 +194,7 @@ func (e *CodexExecutor) ProbeQuotaRecovery(ctx context.Context, auth *cliproxyau
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, newCodexStatusErr(resp.StatusCode, body)
+		return nil, newCodexStatusErr(resp.StatusCode, body, resp.Header)
 	}
 	return parseCodexQuotaProbe(body), nil
 }
@@ -285,7 +286,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		appendAPIResponseChunk(ctx, e.cfg, b)
 		logWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		reporter.publishFailureWithContent(ctx, string(req.Payload), string(b))
-		err = newCodexStatusErr(httpResp.StatusCode, b)
+		err = newCodexStatusErr(httpResp.StatusCode, b, httpResp.Header)
 		return resp, err
 	}
 	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
@@ -403,7 +404,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		appendAPIResponseChunk(ctx, e.cfg, b)
 		logWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		reporter.publishFailureWithContent(ctx, string(req.Payload), string(b))
-		err = newCodexStatusErr(httpResp.StatusCode, b)
+		err = newCodexStatusErr(httpResp.StatusCode, b, httpResp.Header)
 		return resp, err
 	}
 	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
@@ -504,7 +505,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		appendAPIResponseChunk(ctx, e.cfg, data)
 		logWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
 		reporter.publishFailureWithContent(ctx, string(req.Payload), string(data))
-		err = newCodexStatusErr(httpResp.StatusCode, data)
+		err = newCodexStatusErr(httpResp.StatusCode, data, httpResp.Header)
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -864,12 +865,115 @@ func applyCodexHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.A
 	}
 }
 
-func newCodexStatusErr(statusCode int, body []byte) statusErr {
+func newCodexStatusErr(statusCode int, body []byte, headers ...http.Header) statusErr {
 	err := statusErr{code: statusCode, msg: string(body)}
 	if retryAfter := parseCodexRetryAfter(statusCode, body, time.Now()); retryAfter != nil {
 		err.retryAfter = retryAfter
 	}
+	var header http.Header
+	if len(headers) > 0 {
+		header = headers[0]
+	}
+	if window, minutes := parseCodexQuotaWindow(statusCode, body, header); window != "" {
+		err.quotaWindow = window
+		err.quotaWindowMinutes = minutes
+	}
 	return err
+}
+
+func parseCodexQuotaWindow(statusCode int, errorBody []byte, header http.Header) (string, int) {
+	if statusCode != http.StatusTooManyRequests || len(errorBody) == 0 || header == nil {
+		return "", 0
+	}
+	if strings.TrimSpace(gjson.GetBytes(errorBody, "error.type").String()) != "usage_limit_reached" {
+		return "", 0
+	}
+
+	bodyResetAt := gjson.GetBytes(errorBody, "error.resets_at").Int()
+	if window, minutes := codexQuotaWindowFromHeaderReset(header, bodyResetAt); window != "" {
+		return window, minutes
+	}
+	if window, minutes := codexQuotaExhaustedWindow(header, "Secondary"); window != "" {
+		return window, minutes
+	}
+	if window, minutes := codexQuotaExhaustedWindow(header, "Primary"); window != "" {
+		return window, minutes
+	}
+	return "", 0
+}
+
+func codexQuotaWindowFromHeaderReset(header http.Header, bodyResetAt int64) (string, int) {
+	if bodyResetAt <= 0 {
+		return "", 0
+	}
+	for _, prefix := range []string{"Primary", "Secondary"} {
+		resetAt, ok := codexHeaderInt64(header, "X-Codex-"+prefix+"-Reset-At")
+		if !ok || resetAt != bodyResetAt {
+			continue
+		}
+		minutes, _ := codexHeaderInt(header, "X-Codex-"+prefix+"-Window-Minutes")
+		return codexQuotaWindowLabel(minutes), minutes
+	}
+	return "", 0
+}
+
+func codexQuotaExhaustedWindow(header http.Header, prefix string) (string, int) {
+	usedPercent, ok := codexHeaderFloat(header, "X-Codex-"+prefix+"-Used-Percent")
+	if !ok || usedPercent < 100 {
+		return "", 0
+	}
+	minutes, _ := codexHeaderInt(header, "X-Codex-"+prefix+"-Window-Minutes")
+	return codexQuotaWindowLabel(minutes), minutes
+}
+
+func codexHeaderInt(header http.Header, key string) (int, bool) {
+	value := strings.TrimSpace(header.Get(key))
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func codexHeaderInt64(header http.Header, key string) (int64, bool) {
+	value := strings.TrimSpace(header.Get(key))
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func codexHeaderFloat(header http.Header, key string) (float64, bool) {
+	value := strings.TrimSpace(header.Get(key))
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func codexQuotaWindowLabel(minutes int) string {
+	switch minutes {
+	case 300:
+		return "5h"
+	case 10080:
+		return "week"
+	default:
+		if minutes > 0 {
+			return fmt.Sprintf("%dm", minutes)
+		}
+		return ""
+	}
 }
 
 func parseCodexRetryAfter(statusCode int, errorBody []byte, now time.Time) *time.Duration {

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -60,6 +60,47 @@ func TestParseCodexRetryAfter(t *testing.T) {
 	})
 }
 
+func TestNewCodexStatusErrCarriesActiveLimitWindow(t *testing.T) {
+	t.Run("primary five hour window", func(t *testing.T) {
+		body := []byte(`{"error":{"type":"usage_limit_reached","resets_at":1778566866,"resets_in_seconds":4438}}`)
+		headers := http.Header{
+			"X-Codex-Active-Limit":                  []string{"premium"},
+			"X-Codex-Primary-Used-Percent":          []string{"100"},
+			"X-Codex-Primary-Window-Minutes":        []string{"300"},
+			"X-Codex-Primary-Reset-After-Seconds":   []string{"4439"},
+			"X-Codex-Primary-Reset-At":              []string{"1778566866"},
+			"X-Codex-Secondary-Used-Percent":        []string{"16"},
+			"X-Codex-Secondary-Window-Minutes":      []string{"10080"},
+			"X-Codex-Secondary-Reset-After-Seconds": []string{"591239"},
+			"X-Codex-Secondary-Reset-At":            []string{"1779153666"},
+		}
+
+		err := newCodexStatusErr(http.StatusTooManyRequests, body, headers)
+		window, minutes := err.QuotaWindow()
+		if window != "5h" || minutes != 300 {
+			t.Fatalf("QuotaWindow() = %q, %d; want 5h, 300", window, minutes)
+		}
+	})
+
+	t.Run("secondary weekly window", func(t *testing.T) {
+		body := []byte(`{"error":{"type":"usage_limit_reached","resets_at":1779153666,"resets_in_seconds":591239}}`)
+		headers := http.Header{
+			"X-Codex-Primary-Used-Percent":     []string{"42"},
+			"X-Codex-Primary-Window-Minutes":   []string{"300"},
+			"X-Codex-Primary-Reset-At":         []string{"1778566866"},
+			"X-Codex-Secondary-Used-Percent":   []string{"100"},
+			"X-Codex-Secondary-Window-Minutes": []string{"10080"},
+			"X-Codex-Secondary-Reset-At":       []string{"1779153666"},
+		}
+
+		err := newCodexStatusErr(http.StatusTooManyRequests, body, headers)
+		window, minutes := err.QuotaWindow()
+		if window != "week" || minutes != 10080 {
+			t.Fatalf("QuotaWindow() = %q, %d; want week, 10080", window, minutes)
+		}
+	})
+}
+
 func TestParseCodexQuotaProbe(t *testing.T) {
 	t.Run("does not recover when primary window is exhausted", func(t *testing.T) {
 		primaryResetAt := time.Date(2030, 1, 1, 1, 0, 0, 0, time.UTC).Unix()

--- a/internal/runtime/executor/codex_image_executor.go
+++ b/internal/runtime/executor/codex_image_executor.go
@@ -1013,7 +1013,7 @@ func (e *CodexExecutor) executeCodexImageViaResponses(
 			upstreamBody := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
 			_ = httpResp.Body.Close()
 			appendAPIResponseChunk(ctx, e.cfg, upstreamBody)
-			return nil, nil, newCodexStatusErr(httpResp.StatusCode, upstreamBody)
+			return nil, nil, newCodexStatusErr(httpResp.StatusCode, upstreamBody, httpResp.Header)
 		}
 
 		rawBody, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -407,10 +407,12 @@ func shouldNormalizeKimiCompatPayload(model string) bool {
 }
 
 type statusErr struct {
-	code         int
-	msg          string
-	retryAfter   *time.Duration
-	upstreamBody []byte
+	code               int
+	msg                string
+	retryAfter         *time.Duration
+	upstreamBody       []byte
+	quotaWindow        string
+	quotaWindowMinutes int
 }
 
 func (e statusErr) Error() string {
@@ -421,6 +423,7 @@ func (e statusErr) Error() string {
 }
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+func (e statusErr) QuotaWindow() (string, int) { return e.quotaWindow, e.quotaWindowMinutes }
 func (e statusErr) UpstreamErrorBody() []byte {
 	if len(e.upstreamBody) == 0 {
 		return nil

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -729,10 +729,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if errCtx := execCtx.Err(); errCtx != nil {
 				return cliproxyexecutor.Response{}, errCtx
 			}
-			result.Error = &Error{Message: errExec.Error()}
-			if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
-				result.Error.HTTPStatus = se.StatusCode()
-			}
+			result.Error = errorFromExecution(errExec)
 			if ra := retryAfterFromError(errExec); ra != nil {
 				result.RetryAfter = ra
 			}
@@ -838,10 +835,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			if errCtx := execCtx.Err(); errCtx != nil {
 				return nil, errCtx
 			}
-			rerr := &Error{Message: errStream.Error()}
-			if se, ok := errors.AsType[cliproxyexecutor.StatusError](errStream); ok && se != nil {
-				rerr.HTTPStatus = se.StatusCode()
-			}
+			rerr := errorFromExecution(errStream)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(errStream)
 			m.MarkResult(execCtx, result)
@@ -862,10 +856,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			for chunk := range streamChunks {
 				if chunk.Err != nil && !failed {
 					failed = true
-					rerr := &Error{Message: chunk.Err.Error()}
-					if se, ok := errors.AsType[cliproxyexecutor.StatusError](chunk.Err); ok && se != nil {
-						rerr.HTTPStatus = se.StatusCode()
-					}
+					rerr := errorFromExecution(chunk.Err)
 					m.MarkResult(streamCtx, Result{AuthID: streamAuth.ID, Provider: streamProvider, Model: routeModel, Success: false, Error: rerr})
 				}
 				if !forward {
@@ -1512,6 +1503,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					state.Quota = QuotaState{
 						Exceeded:      true,
 						Reason:        "quota",
+						Window:        result.Error.QuotaWindow,
+						WindowMinutes: result.Error.QuotaWindowMinutes,
 						NextRecoverAt: next,
 						BackoffLevel:  backoffLevel,
 					}
@@ -1592,6 +1585,8 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	earliestRetry := time.Time{}
 	quotaExceeded := false
 	quotaRecover := time.Time{}
+	quotaWindow := ""
+	quotaWindowMinutes := 0
 	maxBackoffLevel := 0
 	for _, state := range auth.ModelStates {
 		if state == nil {
@@ -1620,6 +1615,11 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 			quotaExceeded = true
 			if quotaRecover.IsZero() || (!state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.Before(quotaRecover)) {
 				quotaRecover = state.Quota.NextRecoverAt
+				quotaWindow = state.Quota.Window
+				quotaWindowMinutes = state.Quota.WindowMinutes
+			} else if quotaWindow == "" {
+				quotaWindow = state.Quota.Window
+				quotaWindowMinutes = state.Quota.WindowMinutes
 			}
 			if state.Quota.BackoffLevel > maxBackoffLevel {
 				maxBackoffLevel = state.Quota.BackoffLevel
@@ -1635,11 +1635,15 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	if quotaExceeded {
 		auth.Quota.Exceeded = true
 		auth.Quota.Reason = "quota"
+		auth.Quota.Window = quotaWindow
+		auth.Quota.WindowMinutes = quotaWindowMinutes
 		auth.Quota.NextRecoverAt = quotaRecover
 		auth.Quota.BackoffLevel = maxBackoffLevel
 	} else {
 		auth.Quota.Exceeded = false
 		auth.Quota.Reason = ""
+		auth.Quota.Window = ""
+		auth.Quota.WindowMinutes = 0
 		auth.Quota.NextRecoverAt = time.Time{}
 		auth.Quota.BackoffLevel = 0
 	}
@@ -1674,6 +1678,8 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.StatusMessage = ""
 	auth.Quota.Exceeded = false
 	auth.Quota.Reason = ""
+	auth.Quota.Window = ""
+	auth.Quota.WindowMinutes = 0
 	auth.Quota.NextRecoverAt = time.Time{}
 	auth.Quota.BackoffLevel = 0
 	auth.LastError = nil
@@ -1686,11 +1692,28 @@ func cloneError(err *Error) *Error {
 		return nil
 	}
 	return &Error{
-		Code:       err.Code,
-		Message:    err.Message,
-		Retryable:  err.Retryable,
-		HTTPStatus: err.HTTPStatus,
+		Code:               err.Code,
+		Message:            err.Message,
+		Retryable:          err.Retryable,
+		HTTPStatus:         err.HTTPStatus,
+		QuotaWindow:        err.QuotaWindow,
+		QuotaWindowMinutes: err.QuotaWindowMinutes,
 	}
+}
+
+func errorFromExecution(err error) *Error {
+	result := &Error{Message: err.Error()}
+	if se, ok := errors.AsType[cliproxyexecutor.StatusError](err); ok && se != nil {
+		result.HTTPStatus = se.StatusCode()
+	}
+	type quotaWindowProvider interface {
+		QuotaWindow() (string, int)
+	}
+	var qwp quotaWindowProvider
+	if errors.As(err, &qwp) && qwp != nil {
+		result.QuotaWindow, result.QuotaWindowMinutes = qwp.QuotaWindow()
+	}
+	return result
 }
 
 func statusCodeFromError(err error) int {
@@ -1850,6 +1873,10 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.StatusMessage = "quota exhausted"
 		auth.Quota.Exceeded = true
 		auth.Quota.Reason = "quota"
+		if resultErr != nil {
+			auth.Quota.Window = resultErr.QuotaWindow
+			auth.Quota.WindowMinutes = resultErr.QuotaWindowMinutes
+		}
 		var next time.Time
 		if retryAfter != nil {
 			next = now.Add(*retryAfter)

--- a/sdk/cliproxy/auth/errors.go
+++ b/sdk/cliproxy/auth/errors.go
@@ -10,6 +10,10 @@ type Error struct {
 	Retryable bool `json:"retryable"`
 	// HTTPStatus optionally records an HTTP-like status code for the error.
 	HTTPStatus int `json:"http_status,omitempty"`
+	// QuotaWindow identifies the provider quota window that was exhausted.
+	QuotaWindow string `json:"quota_window,omitempty"`
+	// QuotaWindowMinutes stores the provider quota window duration when known.
+	QuotaWindowMinutes int `json:"quota_window_minutes,omitempty"`
 }
 
 // Error implements the error interface.

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -103,6 +103,11 @@ type QuotaState struct {
 	Exceeded bool `json:"exceeded"`
 	// Reason provides an optional provider specific human readable description.
 	Reason string `json:"reason,omitempty"`
+	// Window identifies the provider quota window that was exhausted, such as
+	// "5h" or "week" for Codex.
+	Window string `json:"window,omitempty"`
+	// WindowMinutes stores the provider quota window duration when known.
+	WindowMinutes int `json:"window_minutes,omitempty"`
 	// NextRecoverAt is when the credential may become available again.
 	NextRecoverAt time.Time `json:"next_recover_at"`
 	// BackoffLevel stores the progressive cooldown exponent used for rate limits.


### PR DESCRIPTION
Expose Codex quota limit window metadata in auth-file restrictions so the management UI can distinguish five-hour and weekly quota limits.