### PR TITLE
fix: prefer exhausted codex quota window

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1010,9 +1010,13 @@ func parseCodexQuotaProbe(body []byte) *cliproxyauth.QuotaProbeResult {
 	allowed := rateLimit.Get("allowed")
 	limitReached := rateLimit.Get("limit_reached")
 	if limitReached.Exists() && limitReached.Bool() {
+		nextRecoverAt := codexQuotaProbeNextRecoverAt(rateLimit, true)
+		if nextRecoverAt.IsZero() {
+			nextRecoverAt = codexQuotaProbeNextRecoverAt(rateLimit, false)
+		}
 		return &cliproxyauth.QuotaProbeResult{
 			Recovered:     false,
-			NextRecoverAt: codexQuotaProbeNextRecoverAt(rateLimit, false),
+			NextRecoverAt: nextRecoverAt,
 		}
 	}
 

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -135,6 +135,24 @@ func TestParseCodexQuotaProbe(t *testing.T) {
 			t.Fatalf("NextRecoverAt = %v, want %v", got.NextRecoverAt, time.Unix(resetAt, 0))
 		}
 	})
+
+	t.Run("prefers exhausted window reset when explicit limit reached", func(t *testing.T) {
+		primaryResetAt := time.Date(2030, 1, 1, 1, 0, 0, 0, time.UTC).Unix()
+		secondaryResetAt := time.Date(2030, 1, 1, 6, 0, 0, 0, time.UTC).Unix()
+		body := []byte(`{"rate_limit":{"allowed":false,"limit_reached":true,"primary_window":{"used_percent":1,"reset_at":` + itoa(primaryResetAt) + `},"secondary_window":{"used_percent":100,"reset_at":` + itoa(secondaryResetAt) + `}}}`)
+
+		got := parseCodexQuotaProbe(body)
+		if got == nil {
+			t.Fatal("expected quota probe result, got nil")
+		}
+		if got.Recovered {
+			t.Fatal("Recovered = true, want false while limit_reached is true")
+		}
+		wantRecoverAt := time.Unix(secondaryResetAt, 0)
+		if !got.NextRecoverAt.Equal(wantRecoverAt) {
+			t.Fatalf("NextRecoverAt = %v, want %v", got.NextRecoverAt, wantRecoverAt)
+		}
+	})
 }
 
 func itoa(v int64) string {


### PR DESCRIPTION
## Summary
- prefer exhausted Codex quota windows when `limit_reached=true`
- fall back to the earliest reset only when no exhausted window can be identified
- add a regression test for mixed-window rate limit responses

## Testing
- go test ./internal/runtime/executor -run TestParseCodexQuotaProbe
- go test ./internal/runtime/executor