### PR TITLE
fix: validate editable API key entries

### DIFF
--- a/internal/api/handlers/management/api_key_entries_test.go
+++ b/internal/api/handlers/management/api_key_entries_test.go
@@ -1,0 +1,88 @@
+package management
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func setupAPIKeyEntriesTestDB(t *testing.T) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+}
+
+func TestPatchAPIKeyEntryRejectsBlankKeyWithoutDeletingExistingEntry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupAPIKeyEntriesTestDB(t)
+
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{
+		Key:  "sk-existing-issue-192",
+		Name: "Existing Key",
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(
+		http.MethodPatch,
+		"/api-key-entries",
+		bytes.NewReader([]byte(`{"index":0,"value":{"key":"   ","name":"Existing Key"}}`)),
+	)
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.PatchAPIKeyEntry(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if got := usage.GetAPIKey("sk-existing-issue-192"); got == nil {
+		t.Fatalf("existing key was deleted after blank-key patch")
+	}
+}
+
+func TestPatchAPIKeyEntryRejectsChangingToExistingKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupAPIKeyEntriesTestDB(t)
+
+	for _, row := range []usage.APIKeyRow{
+		{Key: "sk-original-issue-192", Name: "Original Key"},
+		{Key: "sk-target-issue-192", Name: "Target Key"},
+	} {
+		if err := usage.UpsertAPIKey(row); err != nil {
+			t.Fatalf("UpsertAPIKey(%q): %v", row.Key, err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(
+		http.MethodPatch,
+		"/api-key-entries",
+		bytes.NewReader([]byte(`{"match":"sk-original-issue-192","value":{"key":"sk-target-issue-192","name":"Renamed"}}`)),
+	)
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.PatchAPIKeyEntry(c)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if got := usage.GetAPIKey("sk-original-issue-192"); got == nil || got.Name != "Original Key" {
+		t.Fatalf("original key changed unexpectedly: %#v", got)
+	}
+	if got := usage.GetAPIKey("sk-target-issue-192"); got == nil || got.Name != "Target Key" {
+		t.Fatalf("target key changed unexpectedly: %#v", got)
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -375,17 +375,19 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 	if body.Value.Key != nil {
 		trimmed := strings.TrimSpace(*body.Value.Key)
 		if trimmed == "" {
-			if err := usage.DeleteAPIKey(targetKey); err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
-			h.refreshAPIKeyCache()
-			c.JSON(200, gin.H{"status": "ok"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "key is required"})
 			return
 		}
 		// Key change: delete old, insert new
 		if trimmed != targetKey {
-			_ = usage.DeleteAPIKey(targetKey)
+			if existing := usage.GetAPIKey(trimmed); existing != nil {
+				c.JSON(http.StatusConflict, gin.H{"error": "api key already exists"})
+				return
+			}
+			if err := usage.DeleteAPIKey(targetKey); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
 		}
 		entry.Key = trimmed
 	}


### PR DESCRIPTION
## Summary
- reject blank API key values when patching API key entries
- prevent changing an API key to a value already used by another entry
- add regression coverage for editable API key validation

## Tests
- go test ./internal/api/handlers/management -run 'TestPatchAPIKeyEntryRejects(BlankKeyWithoutDeletingExistingEntry|ChangingToExistingKey)' -count=1\n- go test ./internal/api/handlers/management -count=1\n- go test ./internal/usage -count=1\n- go test ./...