### PR TITLE
Fix payload override rules being lost on config save

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -341,6 +341,7 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		return
 	}
 	if usage.ConfigStoreAvailable() {
+		usage.PersistRuntimeSettingsPresentInYAML(newCfg, body)
 		usage.MigrateRuntimeSettingsFromConfig(newCfg, h.configFilePath)
 		usage.ApplyStoredRuntimeSettings(newCfg)
 	}

--- a/internal/api/handlers/management/config_basic_test.go
+++ b/internal/api/handlers/management/config_basic_test.go
@@ -4,11 +4,16 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 func TestMaskKey(t *testing.T) {
@@ -303,5 +308,89 @@ func TestPutConfigYAMLRejectsOversizedBody(t *testing.T) {
 
 	if rec.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("expected status %d, got %d", http.StatusRequestEntityTooLarge, rec.Code)
+	}
+}
+
+func TestPutConfigYAMLUpdatesExistingStoredPayloadRuntimeSetting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	if err := usage.UpsertRuntimeSetting(usage.RuntimeSettingPayload, config.PayloadConfig{
+		Override: []config.PayloadRule{
+			{
+				Models: []config.PayloadModelRule{{Name: "old-model", Protocol: "codex"}},
+				Params: map[string]any{"service_tier": "standard"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed payload runtime setting: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8318\nlogging-to-file: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	body := []byte(`port: 8318
+payload:
+  override:
+    - models:
+        - name: gpt-5.4
+          protocol: codex
+        - name: gpt-5.4-mini
+          protocol: codex
+      params:
+        service_tier: priority
+logging-to-file: true
+`)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "/config.yaml", bytes.NewReader(body))
+
+	h := NewHandler(&config.Config{}, configPath, nil)
+	h.PutConfigYAML(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PutConfigYAML status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	assertPayloadOverrideRule(t, h.cfg.Payload)
+
+	var stored config.Config
+	if !usage.ApplyStoredRuntimeSettings(&stored) {
+		t.Fatal("ApplyStoredRuntimeSettings returned false")
+	}
+	assertPayloadOverrideRule(t, stored.Payload)
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(data), "payload:") {
+		t.Fatalf("payload should be migrated out of YAML after save:\n%s", string(data))
+	}
+}
+
+func assertPayloadOverrideRule(t *testing.T, payload config.PayloadConfig) {
+	t.Helper()
+	if len(payload.Override) != 1 {
+		t.Fatalf("payload override rule count = %d, want 1: %#v", len(payload.Override), payload.Override)
+	}
+	rule := payload.Override[0]
+	if len(rule.Models) != 2 {
+		t.Fatalf("payload override model count = %d, want 2: %#v", len(rule.Models), rule.Models)
+	}
+	if rule.Models[0].Name != "gpt-5.4" || rule.Models[0].Protocol != "codex" {
+		t.Fatalf("first payload model = %#v", rule.Models[0])
+	}
+	if rule.Models[1].Name != "gpt-5.4-mini" || rule.Models[1].Protocol != "codex" {
+		t.Fatalf("second payload model = %#v", rule.Models[1])
+	}
+	if got := rule.Params["service_tier"]; got != "priority" {
+		t.Fatalf("service_tier = %#v, want priority", got)
 	}
 }

--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -462,6 +463,59 @@ func PersistRuntimeSettingsFromConfig(cfg *config.Config) int {
 		persisted++
 	}
 	return persisted
+}
+
+// PersistRuntimeSettingsPresentInYAML stores DB-backed runtime settings that
+// were explicitly included in a management config.yaml save.
+func PersistRuntimeSettingsPresentInYAML(cfg *config.Config, yamlContent []byte) int {
+	if cfg == nil || !ConfigStoreAvailable() {
+		return 0
+	}
+	present := yamlRootKeys(yamlContent)
+	if len(present) == 0 {
+		return 0
+	}
+	persisted := 0
+	for _, spec := range runtimeSettingSpecs() {
+		if !present[spec.key] {
+			continue
+		}
+		if err := UpsertRuntimeSetting(spec.key, spec.value(cfg)); err != nil {
+			log.Errorf("usage: persist runtime setting %s from YAML save: %v", spec.key, err)
+			continue
+		}
+		persisted++
+	}
+	return persisted
+}
+
+func yamlRootKeys(data []byte) map[string]bool {
+	if len(data) == 0 {
+		return nil
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil
+	}
+	mapping := root.Content[0]
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	keys := make(map[string]bool, len(mapping.Content)/2)
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := mapping.Content[i]
+		if key == nil || key.Kind != yaml.ScalarNode {
+			continue
+		}
+		name := strings.TrimSpace(key.Value)
+		if name != "" {
+			keys[name] = true
+		}
+	}
+	return keys
 }
 
 func ApplyStoredRuntimeSettings(cfg *config.Config) bool {


### PR DESCRIPTION
## Summary
- persist runtime settings that are explicitly present in a config.yaml save before cleaning DB-backed YAML sections
- preserve payload override rules when an existing SQLite runtime setting row is present
- add a regression test for the issue #208 payload override save path

Fixes #208

## Tests
- go test ./internal/api/handlers/management -run TestPutConfigYAMLUpdatesExistingStoredPayloadRuntimeSetting -count=1
- go test ./internal/usage -run 'TestRuntimeSettings|TestConfigYAML|TestClean' -count=1\n- go test ./internal/api/handlers/management ./internal/usage ./internal/config ./internal/api -count=1\n- git diff --check\n- go test ./...