### PR TITLE
fix: support disabling OpenAI-compatible providers

### DIFF
--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -70,7 +70,7 @@ func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []cha
 			push("", entry.Prefix, "vertex", false, buildAuthTagPayloadFromValues("vertex", nil))
 		}
 		for _, entry := range cfg.OpenAICompatibility {
-			push(entry.Name, entry.Prefix, "openai", false, buildAuthTagPayloadFromValues("openai", nil))
+			push(entry.Name, entry.Prefix, "openai", entry.Disabled, buildAuthTagPayloadFromValues("openai", nil))
 		}
 	}
 

--- a/internal/api/handlers/management/channel_groups_test.go
+++ b/internal/api/handlers/management/channel_groups_test.go
@@ -487,6 +487,37 @@ func TestBuildChannelGroupItemsIncludesDisabledAuthFileChannels(t *testing.T) {
 	}
 }
 
+func TestBuildChannelGroupItemsMarksDisabledOpenAICompatChannels(t *testing.T) {
+	cfg := &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{
+				Name:     "OpenAI Main",
+				Disabled: true,
+				BaseURL:  "https://example.com/v1",
+				Prefix:   "openai-main",
+				Models:   []config.OpenAICompatibilityModel{{Name: "gpt-4.1"}},
+			},
+		},
+	}
+
+	items := buildChannelGroupItems(cfg, nil)
+	byName := make(map[string]channelGroupItem, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+
+	defaultGroup, ok := byName["openai-main"]
+	if !ok {
+		t.Fatal("expected openai-main group for OpenAI compatibility channel")
+	}
+	if len(defaultGroup.ChannelDetails) != 1 {
+		t.Fatalf("channel details = %#v, want one OpenAI channel detail", defaultGroup.ChannelDetails)
+	}
+	if !defaultGroup.ChannelDetails[0].Disabled {
+		t.Fatalf("channel detail = %#v, want disabled=true", defaultGroup.ChannelDetails[0])
+	}
+}
+
 func TestBuildChannelGroupItemsDoesNotSurfaceDeletedConfiguredChannels(t *testing.T) {
 	cfg := &config.Config{
 		Routing: config.RoutingConfig{

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1215,6 +1215,7 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	type openAICompatPatch struct {
 		Name          *string                             `json:"name"`
+		Disabled      *bool                               `json:"disabled"`
 		Prefix        *string                             `json:"prefix"`
 		BaseURL       *string                             `json:"base-url"`
 		APIKeyEntries *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
@@ -1251,6 +1252,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	entry := h.cfg.OpenAICompatibility[targetIndex]
 	if body.Value.Name != nil {
 		entry.Name = strings.TrimSpace(*body.Value.Name)
+	}
+	if body.Value.Disabled != nil {
+		entry.Disabled = *body.Value.Disabled
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -653,6 +653,9 @@ type OpenAICompatibility struct {
 	// Name is the identifier for this OpenAI compatibility configuration.
 	Name string `yaml:"name" json:"name"`
 
+	// Disabled marks this provider as inactive while preserving its configuration.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// Priority controls selection preference when multiple providers or credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -276,6 +276,9 @@ func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int) 
 	}
 	if len(cfg.OpenAICompatibility) > 0 {
 		for _, compatConfig := range cfg.OpenAICompatibility {
+			if compatConfig.Disabled {
+				continue
+			}
 			openAICompatCount += len(compatConfig.APIKeyEntries)
 		}
 	}

--- a/internal/watcher/diff/openai_compat.go
+++ b/internal/watcher/diff/openai_compat.go
@@ -66,6 +66,9 @@ func describeOpenAICompatibilityUpdate(oldEntry, newEntry config.OpenAICompatibi
 	oldModelCount := countOpenAIModels(oldEntry.Models)
 	newModelCount := countOpenAIModels(newEntry.Models)
 	details := make([]string, 0, 3)
+	if oldEntry.Disabled != newEntry.Disabled {
+		details = append(details, fmt.Sprintf("disabled %t -> %t", oldEntry.Disabled, newEntry.Disabled))
+	}
 	if oldKeyCount != newKeyCount {
 		details = append(details, fmt.Sprintf("api-keys %d -> %d", oldKeyCount, newKeyCount))
 	}
@@ -141,6 +144,9 @@ func openAICompatSignature(entry config.OpenAICompatibility) string {
 	}
 	if v := strings.TrimSpace(entry.BaseURL); v != "" {
 		parts = append(parts, "base="+v)
+	}
+	if entry.Disabled {
+		parts = append(parts, "disabled=true")
 	}
 
 	models := make([]string, 0, len(entry.Models))

--- a/internal/watcher/diff/openai_compat_test.go
+++ b/internal/watcher/diff/openai_compat_test.go
@@ -67,6 +67,30 @@ func TestDiffOpenAICompatibility_RemovedAndUnchanged(t *testing.T) {
 	expectContains(t, changes, "provider removed: provider-a (api-keys=1, models=1)")
 }
 
+func TestDiffOpenAICompatibility_DisabledFlagChange(t *testing.T) {
+	oldList := []config.OpenAICompatibility{
+		{
+			Name:          "provider-a",
+			BaseURL:       "https://provider-a.example/v1",
+			APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "key-a"}},
+		},
+	}
+	newList := []config.OpenAICompatibility{
+		{
+			Name:          "provider-a",
+			Disabled:      true,
+			BaseURL:       "https://provider-a.example/v1",
+			APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "key-a"}},
+		},
+	}
+
+	changes := DiffOpenAICompatibility(oldList, newList)
+	if len(changes) != 1 {
+		t.Fatalf("expected one change, got %v", changes)
+	}
+	expectContains(t, changes, "provider updated: provider-a (disabled false -> true)")
+}
+
 func TestOpenAICompatKeyFallbacks(t *testing.T) {
 	entry := config.OpenAICompatibility{
 		BaseURL: "http://base",

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -356,6 +356,9 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 	out := make([]*coreauth.Auth, 0)
 	for i := range cfg.OpenAICompatibility {
 		compat := &cfg.OpenAICompatibility[i]
+		if compat.Disabled {
+			continue
+		}
 		prefix := strings.TrimSpace(compat.Prefix)
 		providerName := strings.ToLower(strings.TrimSpace(compat.Name))
 		if providerName == "" {

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -1,6 +1,7 @@
 package synthesizer
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -386,6 +387,20 @@ func TestConfigSynthesizer_OpenAICompat(t *testing.T) {
 			wantLen: 0,
 		},
 		{
+			name: "provider disabled skips all APIKeyEntries",
+			compat: mustDecodeOpenAICompatibility(t, `[
+				{
+					"name": "DisabledProvider",
+					"disabled": true,
+					"base-url": "https://disabled.api.com",
+					"api-key-entries": [
+						{"api-key": "key-enabled"}
+					]
+				}
+			]`),
+			wantLen: 0,
+		},
+		{
 			name: "empty APIKeyEntries included (legacy)",
 			compat: []config.OpenAICompatibility{
 				{
@@ -441,6 +456,15 @@ func TestConfigSynthesizer_OpenAICompat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustDecodeOpenAICompatibility(t *testing.T, raw string) []config.OpenAICompatibility {
+	t.Helper()
+	var out []config.OpenAICompatibility
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("decode openai compatibility: %v", err)
+	}
+	return out
 }
 
 func TestConfigSynthesizer_VertexCompat(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a provider-level disabled flag for OpenAI-compatible provider configs
- skip disabled providers during runtime auth synthesis and provider counting
- expose disabled state in management channel metadata and config diff output

## Tests
- go test ./... -count=1