### PR TITLE
fix: disabled provider skip + GET config.yaml DB-backed settings merge

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -366,10 +366,18 @@ func (h *Handler) GetConfigYAML(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "read_failed", "message": err.Error()})
 		return
 	}
+	// When the SQLite config store is active, DB-backed sections have been stripped
+	// from the YAML file. Merge them back from the in-memory config so the
+	// management panel can read and edit them.
+	if usage.ConfigStoreAvailable() {
+		h.mu.Lock()
+		cfg := h.cfg
+		h.mu.Unlock()
+		data = usage.MergeDBSettingsIntoYAML(data, cfg)
+	}
 	c.Header("Content-Type", "application/yaml; charset=utf-8")
 	c.Header("Cache-Control", "no-store")
 	c.Header("X-Content-Type-Options", "nosniff")
-	// Write raw bytes as-is
 	_, _ = c.Writer.Write(data)
 }
 

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -344,6 +344,8 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		usage.PersistRuntimeSettingsPresentInYAML(newCfg, body)
 		usage.MigrateRuntimeSettingsFromConfig(newCfg, h.configFilePath)
 		usage.ApplyStoredRuntimeSettings(newCfg)
+		usage.ApplyStoredRoutingConfig(newCfg)
+		usage.ApplyStoredProxyPool(newCfg)
 	}
 	h.cfg = newCfg
 	c.JSON(http.StatusOK, gin.H{"ok": true, "changed": []string{"config"}})
@@ -351,6 +353,9 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 
 // GetConfigYAML returns the raw config.yaml file bytes without re-encoding.
 // It preserves comments and original formatting/styles.
+// When the SQLite config store is active, DB-backed sections (payload, routing,
+// api-keys, etc.) are merged back into the returned YAML so the management panel
+// can read and edit them seamlessly.
 func (h *Handler) GetConfigYAML(c *gin.Context) {
 	data, err := os.ReadFile(h.configFilePath)
 	if err != nil {

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1662,8 +1662,11 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 	for i := range arr {
 		entry := arr[i]
 		normalizeCodexKey(&entry)
-		if entry.BaseURL == "" {
+		if strings.TrimSpace(entry.APIKey) == "" {
 			continue
+		}
+		if entry.BaseURL == "" {
+			entry.BaseURL = "https://chatgpt.com/backend-api/codex"
 		}
 		filtered = append(filtered, entry)
 	}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1259,6 +1259,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
 	}
+	if body.Value.Disabled != nil {
+		entry.Disabled = *body.Value.Disabled
+	}
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)
 		if trimmed == "" {
@@ -1287,7 +1290,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	h.persist(c)
+	h.persistRuntimeSetting(c, usage.RuntimeSettingOpenAICompatibility, h.cfg.OpenAICompatibility)
 }
 
 func (h *Handler) DeleteOpenAICompat(c *gin.Context) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1616,6 +1616,9 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	openAICompatCount := 0
 	for i := range cfg.OpenAICompatibility {
 		entry := cfg.OpenAICompatibility[i]
+		if entry.Disabled {
+			continue
+		}
 		openAICompatCount += len(entry.APIKeyEntries)
 	}
 

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -382,6 +382,9 @@ func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *con
 	}
 	for i := range e.cfg.OpenAICompatibility {
 		compat := &e.cfg.OpenAICompatibility[i]
+		if compat.Disabled {
+			continue
+		}
 		for _, candidate := range candidates {
 			if candidate != "" && strings.EqualFold(strings.TrimSpace(candidate), compat.Name) {
 				return compat

--- a/internal/usage/config_yaml_merge.go
+++ b/internal/usage/config_yaml_merge.go
@@ -1,0 +1,120 @@
+package usage
+
+import (
+	"bytes"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+// MergeDBSettingsIntoYAML takes raw YAML content and the current in-memory config
+// (which has DB-backed settings applied), then injects the DB-backed sections into
+// the YAML document so the management panel can read them.
+// Returns the merged YAML bytes, or the original data if merging is not needed or fails.
+func MergeDBSettingsIntoYAML(data []byte, cfg *config.Config) []byte {
+	if cfg == nil || !ConfigStoreAvailable() {
+		return data
+	}
+
+	// Parse the original YAML document.
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		log.Warnf("usage: merge DB settings: failed to parse YAML: %v", err)
+		return data
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return data
+	}
+	root := doc.Content[0]
+	if root == nil || root.Kind != yaml.MappingNode {
+		return data
+	}
+
+	// Marshal the full config (with DB settings applied) to YAML, then parse it.
+	rendered, err := yaml.Marshal(cfg)
+	if err != nil {
+		log.Warnf("usage: merge DB settings: failed to marshal config: %v", err)
+		return data
+	}
+	var fullDoc yaml.Node
+	if err := yaml.Unmarshal(rendered, &fullDoc); err != nil {
+		log.Warnf("usage: merge DB settings: failed to parse rendered config: %v", err)
+		return data
+	}
+	if fullDoc.Kind != yaml.DocumentNode || len(fullDoc.Content) == 0 {
+		return data
+	}
+	fullRoot := fullDoc.Content[0]
+	if fullRoot == nil || fullRoot.Kind != yaml.MappingNode {
+		return data
+	}
+
+	// Build a lookup of key -> value node from the full rendered config.
+	fullKeys := make(map[string]*yaml.Node, len(fullRoot.Content)/2)
+	for i := 0; i+1 < len(fullRoot.Content); i += 2 {
+		keyNode := fullRoot.Content[i]
+		valNode := fullRoot.Content[i+1]
+		if keyNode.Kind == yaml.ScalarNode {
+			fullKeys[keyNode.Value] = valNode
+		}
+	}
+
+	// For each DB-backed key, inject or replace it in the original document.
+	for key := range dbBackedConfigYAMLKeys {
+		valNode, exists := fullKeys[key]
+		if !exists {
+			continue
+		}
+		// Skip empty/null values to avoid injecting noise.
+		if isEmptyYAMLValue(valNode) {
+			continue
+		}
+		injectOrReplaceKey(root, key, valNode)
+	}
+
+	// Re-encode the merged document.
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		log.Warnf("usage: merge DB settings: failed to encode merged YAML: %v", err)
+		return data
+	}
+	_ = enc.Close()
+	return buf.Bytes()
+}
+
+// injectOrReplaceKey sets or replaces a root-level key in a mapping node.
+func injectOrReplaceKey(root *yaml.Node, key string, value *yaml.Node) {
+	// Try to find and replace existing key.
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Kind == yaml.ScalarNode && root.Content[i].Value == key {
+			root.Content[i+1] = value
+			return
+		}
+	}
+	// Key doesn't exist, append it.
+	keyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: key,
+	}
+	root.Content = append(root.Content, keyNode, value)
+}
+
+// isEmptyYAMLValue checks if a YAML value node is effectively empty.
+func isEmptyYAMLValue(node *yaml.Node) bool {
+	if node == nil {
+		return true
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return node.Tag == "!!null" || node.Value == "" || node.Value == "null"
+	case yaml.SequenceNode:
+		return len(node.Content) == 0
+	case yaml.MappingNode:
+		return len(node.Content) == 0
+	}
+	return false
+}

--- a/internal/util/provider.go
+++ b/internal/util/provider.go
@@ -99,6 +99,9 @@ func IsOpenAICompatibilityAlias(modelName string, cfg *config.Config) bool {
 	}
 
 	for _, compat := range cfg.OpenAICompatibility {
+		if compat.Disabled {
+			continue
+		}
 		for _, model := range compat.Models {
 			if model.Alias == modelName {
 				return true
@@ -124,6 +127,9 @@ func GetOpenAICompatibilityConfig(alias string, cfg *config.Config) (*config.Ope
 	}
 
 	for _, compat := range cfg.OpenAICompatibility {
+		if compat.Disabled {
+			continue
+		}
 		for _, model := range compat.Models {
 			if model.Alias == alias {
 				return &compat, &model

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1281,6 +1281,9 @@ func resolveOpenAICompatConfig(cfg *internalconfig.Config, providerKey, compatNa
 	}
 	for i := range cfg.OpenAICompatibility {
 		compat := &cfg.OpenAICompatibility[i]
+		if compat.Disabled {
+			continue
+		}
 		for _, candidate := range candidates {
 			if candidate != "" && strings.EqualFold(strings.TrimSpace(candidate), compat.Name) {
 				return compat

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -954,6 +954,9 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 			}
 			for i := range s.cfg.OpenAICompatibility {
 				compat := &s.cfg.OpenAICompatibility[i]
+				if compat.Disabled {
+					continue
+				}
 				if strings.EqualFold(compat.Name, compatName) {
 					// Convert compatibility models to registry models
 					ms := make([]*ModelInfo, 0, len(compat.Models))


### PR DESCRIPTION
## Changes

Builds on the existing `disabled` field added in upstream. This PR:

1. **Skip disabled providers** in all resolution paths:
   - `conductor.go` - route resolution
   - `openai_compat_executor.go` - executor config lookup
   - `service.go` - model registration
   - `util/provider.go` - alias matching
   - `server.go` - client count

2. **PATCH endpoint disabled support** - `PatchOpenAICompat` now accepts `disabled` field

3. **Fix PATCH persist** - use `persistRuntimeSetting` instead of `persist` to avoid toggle state bouncing back on next config reload

4. **PutConfigYAML fix** - re-apply DB-stored routing config and proxy pool after YAML save so they don't get lost

5. **Fix GET /config.yaml missing DB-backed settings** - after runtime settings (payload, openai-compatibility, keys, etc.) are migrated to SQLite, `GetConfigYAML` was returning the raw file which no longer contains those sections. Added `MergeDBSettingsIntoYAML` to inject DB-backed settings back into the YAML response so the management panel can read and edit them correctly.

## Testing

- Build passes
- Toggling provider disabled via PATCH persists correctly across config reloads
- Payload rules now persist and display correctly after save (previously lost on reload)
