### PR TITLE
fix: add missing fields to WebSocket prewarm response

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -403,8 +403,17 @@ func responsesWebsocketPrewarmPayloads(requestJSON []byte) ([][]byte, bool) {
 	}
 
 	syntheticID := "resp_prewarm_" + uuid.NewString()
-	created := []byte(fmt.Sprintf(`{"type":"response.created","response":{"id":%q}}`, syntheticID))
-	done := []byte(fmt.Sprintf(`{"type":"response.done","response":{"id":%q,"output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`, syntheticID))
+	modelName := gjson.GetBytes(requestJSON, "model").String()
+	now := time.Now().Unix()
+
+	created := []byte(fmt.Sprintf(
+		`{"type":"response.created","response":{"id":%q,"object":"response","created_at":%d,"status":"in_progress","background":false,"completed_at":null,"error":null,"model":%q}}`,
+		syntheticID, now, modelName,
+	))
+	done := []byte(fmt.Sprintf(
+		`{"type":"response.done","response":{"id":%q,"object":"response","created_at":%d,"status":"completed","background":false,"completed_at":%d,"error":null,"model":%q,"output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`,
+		syntheticID, now, now, modelName,
+	))
 	return [][]byte{created, done}, true
 }
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -61,6 +61,30 @@ func TestResponsesWebsocketPrewarmPayloads(t *testing.T) {
 	if gjson.GetBytes(payloads[1], "response.usage.total_tokens").Int() != 0 {
 		t.Fatalf("done payload total_tokens must be 0")
 	}
+	if gjson.GetBytes(payloads[0], "response.object").String() != "response" {
+		t.Fatalf("created payload missing response.object: %s", gjson.GetBytes(payloads[0], "response.object").String())
+	}
+	if gjson.GetBytes(payloads[0], "response.status").String() != "in_progress" {
+		t.Fatalf("created payload response.status = %s, want in_progress", gjson.GetBytes(payloads[0], "response.status").String())
+	}
+	if gjson.GetBytes(payloads[0], "response.model").String() != "test-model" {
+		t.Fatalf("created payload response.model = %s, want test-model", gjson.GetBytes(payloads[0], "response.model").String())
+	}
+	if gjson.GetBytes(payloads[1], "response.object").String() != "response" {
+		t.Fatalf("completed payload missing response.object: %s", gjson.GetBytes(payloads[1], "response.object").String())
+	}
+	if gjson.GetBytes(payloads[1], "response.status").String() != "completed" {
+		t.Fatalf("completed payload response.status = %s, want completed", gjson.GetBytes(payloads[1], "response.status").String())
+	}
+	if gjson.GetBytes(payloads[1], "response.model").String() != "test-model" {
+		t.Fatalf("completed payload response.model = %s, want test-model", gjson.GetBytes(payloads[1], "response.model").String())
+	}
+	if gjson.GetBytes(payloads[1], "response.created_at").Int() == 0 {
+		t.Fatalf("completed payload missing response.created_at")
+	}
+	if gjson.GetBytes(payloads[1], "response.completed_at").Int() == 0 {
+		t.Fatalf("completed payload missing response.completed_at")
+	}
 }
 
 func TestResponsesWebsocketPrewarmPayloadsDisabledForGenerateTrue(t *testing.T) {


### PR DESCRIPTION
## Problem

Codex Desktop sends a `response.create` with `generate=false` (prewarm) to establish a WebSocket connection before sending the actual request. The proxy was returning a minimal prewarm response missing critical fields that Codex Desktop expects.

## Root Cause

The prewarm response was missing these fields:
- `status` — **most critical**: without `"status":"completed"`, Codex Desktop cannot recognize the prewarm as complete
- `object` — `"response"` 
- `model` — the requested model name
- `created_at` / `completed_at` — timestamps
- `background` — `false`
- `error` — `null`

Without `status: "completed"`, Codex Desktop never sent a follow-up request, the 60s idle timeout fired, and the user saw:
```
The custom model provider has returned empty content. (HTTP Status: 500) (4028)
```

## Fix

Added all missing fields to the prewarm response to match the real OpenAI API response format:

**Before:**
```json
{"type":"response.created","response":{"id":"resp_prewarm_..."}}
{"type":"response.completed","response":{"id":"resp_prewarm_...","output":[],"usage":{...}}}
```

**After:**
```json
{"type":"response.created","response":{"id":"resp_prewarm_...","object":"response","created_at":1778576237,"status":"in_progress","background":false,"completed_at":null,"error":null,"model":"gpt-5.4"}}
{"type":"response.completed","response":{"id":"resp_prewarm_...","object":"response","created_at":1778576237,"status":"completed","background":false,"completed_at":1778576237,"error":null,"model":"gpt-5.4","output":[],"usage":{...}}}
```

## Testing

- All existing prewarm tests pass
- Added new assertions for `object`, `status`, `model`, `created_at`, `completed_at` fields