### PR TITLE
fix: drop disabled compatible provider models

### DIFF
--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -436,6 +436,29 @@ func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName 
 	return "", "", false
 }
 
+func openAICompatAuthEntryActive(compat *config.OpenAICompatibility, auth *coreauth.Auth) bool {
+	if compat == nil || compat.Disabled {
+		return false
+	}
+	if len(compat.APIKeyEntries) == 0 {
+		return true
+	}
+	authKey := ""
+	if auth != nil && auth.Attributes != nil {
+		authKey = strings.TrimSpace(auth.Attributes["api_key"])
+	}
+	for i := range compat.APIKeyEntries {
+		entry := &compat.APIKeyEntries[i]
+		if entry.Disabled {
+			continue
+		}
+		if strings.TrimSpace(entry.APIKey) == authKey {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Service) ensureExecutorsForAuth(a *coreauth.Auth) {
 	s.ensureExecutorsForAuthWithMode(a, false)
 }
@@ -955,6 +978,10 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 			for i := range s.cfg.OpenAICompatibility {
 				compat := &s.cfg.OpenAICompatibility[i]
 				if strings.EqualFold(compat.Name, compatName) {
+					if !openAICompatAuthEntryActive(compat, a) {
+						GlobalModelRegistry().UnregisterClient(a.ID)
+						return
+					}
 					// Convert compatibility models to registry models
 					ms := make([]*ModelInfo, 0, len(compat.Models))
 					for j := range compat.Models {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -62,6 +62,63 @@ func TestApplyConfigReloadRefreshesModelRegistryForConfigAuths(t *testing.T) {
 	}
 }
 
+func TestApplyConfigReloadDropsDisabledOpenAICompatibleProviderModels(t *testing.T) {
+	cfg := &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:    "Compat Hot Reload",
+			BaseURL: "https://compat.example.com/v1",
+			Models: []config.OpenAICompatibilityModel{{
+				Name:  "upstream-compat-hot-reload-model",
+				Alias: "compat-hot-reload-model",
+			}},
+		}},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: cfg, coreManager: manager}
+	auth := &coreauth.Auth{
+		ID:       "compat-hot-reload-auth",
+		Provider: "compat hot reload",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind":    "apikey",
+			"compat_name":  "Compat Hot Reload",
+			"provider_key": "compat hot reload",
+			"source":       "config:compat hot reload[test]",
+		},
+	}
+	ctx := context.Background()
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(ctx, auth)
+	if !hasModelID(registry.GetAvailableModelsByProvider("compat hot reload"), "compat-hot-reload-model") {
+		t.Fatal("expected compatible provider model to be registered before config reload")
+	}
+
+	next := *cfg
+	next.OpenAICompatibility = []config.OpenAICompatibility{{
+		Name:     "Compat Hot Reload",
+		Disabled: true,
+		BaseURL:  "https://compat.example.com/v1",
+		Models: []config.OpenAICompatibilityModel{{
+			Name:  "upstream-compat-hot-reload-model",
+			Alias: "compat-hot-reload-model",
+		}},
+	}}
+	service.applyConfigReload(&next, true)
+
+	if hasModelID(registry.GetAvailableModelsByProvider("compat hot reload"), "compat-hot-reload-model") {
+		t.Fatal("expected model registry to drop disabled OpenAI-compatible provider models after config reload")
+	}
+}
+
 func hasModelID(models []*ModelInfo, id string) bool {
 	for _, model := range models {
 		if model != nil && strings.EqualFold(strings.TrimSpace(model.ID), id) {


### PR DESCRIPTION
## Summary
- unregister OpenAI-compatible provider models when the matched provider or API key entry is disabled
- add a regression test for config reload clearing stale compatible provider models

## Verification
- go test ./sdk/cliproxy -run 'TestApplyConfigReloadDropsDisabledOpenAICompatibleProviderModels|TestApplyConfigReloadRefreshesModelRegistryForConfigAuths|TestRegisterModelsForAuth_UsesPreMergedExcludedModelsAttribute' -count=1\n- go test ./sdk/cliproxy -count=1\n- git diff --check\n\nFixes #218