### PR TITLE
fix: speed up compact fallback timeouts

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -31,6 +31,8 @@ const (
 	// Keep defaults aligned with upstream CLIProxyAPI (codex-tui).
 	codexUserAgent  = "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
 	codexOriginator = "codex-tui"
+
+	codexCompactResponseHeaderTimeout = 30 * time.Second
 )
 
 var dataTag = []byte("data:")

--- a/sdk/api/handlers/openai/openai_responses_compact_test.go
+++ b/sdk/api/handlers/openai/openai_responses_compact_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -17,17 +18,29 @@ import (
 )
 
 type compactCaptureExecutor struct {
+	provider     string
 	alt          string
 	sourceFormat string
 	calls        int
+	models       []string
+	failures     map[string]error
 }
 
-func (e *compactCaptureExecutor) Identifier() string { return "test-provider" }
+func (e *compactCaptureExecutor) Identifier() string {
+	if strings.TrimSpace(e.provider) != "" {
+		return e.provider
+	}
+	return "test-provider"
+}
 
 func (e *compactCaptureExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
 	e.calls++
 	e.alt = opts.Alt
 	e.sourceFormat = opts.SourceFormat.String()
+	e.models = append(e.models, req.Model)
+	if err := e.failures[req.Model]; err != nil {
+		return coreexecutor.Response{}, err
+	}
 	return coreexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
 }
 
@@ -116,5 +129,227 @@ func TestOpenAIResponsesCompactExecute(t *testing.T) {
 	}
 	if strings.TrimSpace(resp.Body.String()) != `{"ok":true}` {
 		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+type compactStatusErr struct {
+	code int
+	msg  string
+}
+
+func (e compactStatusErr) Error() string   { return e.msg }
+func (e compactStatusErr) StatusCode() int { return e.code }
+
+func TestOpenAIResponsesCompactFallsBackToSupportedModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{
+		provider: "codex",
+		failures: map[string]error{
+			"test-model": compactStatusErr{code: http.StatusNotFound, msg: `{"error":"compact unsupported"}`},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "auth3", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{
+		{ID: "test-model"},
+		{ID: "gpt-5.5"},
+	})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusOK)
+	}
+	if len(executor.models) != 2 {
+		t.Fatalf("models = %#v, want 2 attempts", executor.models)
+	}
+	if executor.models[0] != "test-model" {
+		t.Fatalf("first model = %q, want %q", executor.models[0], "test-model")
+	}
+	if executor.models[1] != "gpt-5.5" {
+		t.Fatalf("fallback model = %q, want %q", executor.models[1], "gpt-5.5")
+	}
+}
+
+func TestOpenAIResponsesCompactFallsBackOnHeaderTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{
+		provider: "codex",
+		failures: map[string]error{
+			"test-model": compactStatusErr{code: http.StatusGatewayTimeout, msg: `Post "https://chatgpt.com/backend-api/codex/responses/compact": http2: timeout awaiting response headers`},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "auth-timeout", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{
+		{ID: "test-model"},
+		{ID: "gpt-5.5"},
+	})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusOK)
+	}
+	if len(executor.models) != 2 {
+		t.Fatalf("models = %#v, want 2 attempts", executor.models)
+	}
+	if executor.models[1] != "gpt-5.5" {
+		t.Fatalf("fallback model = %q, want %q", executor.models[1], "gpt-5.5")
+	}
+}
+
+func TestOpenAIResponsesCompactFallsBackOnModelNotSupported(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{
+		provider: "codex",
+		failures: map[string]error{
+			"test-model": compactStatusErr{
+				code: http.StatusBadRequest,
+				msg:  `{"detail":"The 'test-model' model is not supported when using Codex with a ChatGPT account."}`,
+			},
+			"gpt-5.5": compactStatusErr{
+				code: http.StatusBadRequest,
+				msg:  `{"detail":"The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account."}`,
+			},
+			"gpt-5.1-codex-max": compactStatusErr{
+				code: http.StatusBadRequest,
+				msg:  `{"detail":"The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account."}`,
+			},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "auth-unsupported", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{
+		{ID: "test-model"},
+		{ID: "gpt-5.5"},
+		{ID: "gpt-5.1-codex-max"},
+		{ID: "gpt-5.3-codex"},
+	})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (should fall back to gpt-5.3-codex)", resp.Code, http.StatusOK)
+	}
+	found := false
+	for _, m := range executor.models {
+		if m == "gpt-5.3-codex" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("models = %#v, want gpt-5.3-codex to be attempted", executor.models)
+	}
+}
+
+func TestIsCompactModelUnsupportedError(t *testing.T) {
+	tests := []struct {
+		name       string
+		errMsg     *interfaces.ErrorMessage
+		wantResult bool
+	}{
+		{
+			name:       "nil error message",
+			errMsg:     nil,
+			wantResult: false,
+		},
+		{
+			name: "400 model is not supported",
+			errMsg: &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadRequest,
+				Error:      errors.New(`{"detail":"The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account."}`),
+			},
+			wantResult: true,
+		},
+		{
+			name: "400 model not supported short form",
+			errMsg: &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadRequest,
+				Error:      errors.New("model not supported"),
+			},
+			wantResult: true,
+		},
+		{
+			name: "400 invalid_request_error should not match",
+			errMsg: &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadRequest,
+				Error:      errors.New("invalid_request_error: bad input"),
+			},
+			wantResult: false,
+		},
+		{
+			name: "404 not found should not match",
+			errMsg: &interfaces.ErrorMessage{
+				StatusCode: http.StatusNotFound,
+				Error:      errors.New("model is not supported"),
+			},
+			wantResult: false,
+		},
+		{
+			name: "400 nil error",
+			errMsg: &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadRequest,
+				Error:      nil,
+			},
+			wantResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isCompactModelUnsupportedError(tt.errMsg)
+			if got != tt.wantResult {
+				t.Errorf("isCompactModelUnsupportedError() = %v, want %v", got, tt.wantResult)
+			}
+		})
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -8,13 +8,16 @@ package openai
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/router-for-me/CLIProxyAPI/v6/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -109,7 +112,7 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, c.Request.Context())
 	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
-	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "responses/compact")
+	resp, upstreamHeaders, errMsg := h.executeCompactWithFallback(cliCtx, modelName, rawJSON)
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
@@ -119,6 +122,126 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	_, _ = c.Writer.Write(resp)
 	cliCancel()
+}
+
+var compactFallbackModels = []string{
+	"gpt-5.5",
+	"codex-auto-review",
+	"gpt-5.4",
+	"gpt-5.1-codex-max",
+	"gpt-5.3-codex",
+}
+
+func (h *OpenAIResponsesAPIHandler) executeCompactWithFallback(cliCtx context.Context, requestedModel string, rawJSON []byte) ([]byte, http.Header, *interfaces.ErrorMessage) {
+	models := compactAttemptModels(requestedModel)
+	var lastErr *interfaces.ErrorMessage
+	for idx, candidateModel := range models {
+		attemptJSON := rawJSON
+		if candidateModel != requestedModel {
+			updated, err := sjson.SetBytes(rawJSON, "model", candidateModel)
+			if err != nil {
+				return nil, nil, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err}
+			}
+			attemptJSON = updated
+		}
+		resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), candidateModel, attemptJSON, "responses/compact")
+		if errMsg == nil {
+			return resp, upstreamHeaders, nil
+		}
+		lastErr = errMsg
+		if isCompactModelUnsupportedError(errMsg) {
+			continue
+		}
+		if idx == 0 && !shouldRetryCompactWithFallback(errMsg) {
+			return nil, nil, errMsg
+		}
+	}
+	return nil, nil, lastErr
+}
+
+func compactAttemptModels(requestedModel string) []string {
+	models := make([]string, 0, 1+len(compactFallbackModels))
+	seen := make(map[string]struct{}, 1+len(compactFallbackModels))
+	addModel := func(model string, requireCompactProvider bool) {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			return
+		}
+		if _, exists := seen[model]; exists {
+			return
+		}
+		if requireCompactProvider && !modelHasCompactCapableProvider(model) {
+			return
+		}
+		seen[model] = struct{}{}
+		models = append(models, model)
+	}
+	addModel(requestedModel, false)
+	for _, model := range compactFallbackModels {
+		addModel(model, true)
+	}
+	return models
+}
+
+func modelHasCompactCapableProvider(model string) bool {
+	for _, provider := range util.GetProviderName(model) {
+		if providerSupportsCompact(provider) {
+			return true
+		}
+	}
+	return false
+}
+
+func providerSupportsCompact(provider string) bool {
+	return strings.EqualFold(strings.TrimSpace(provider), "codex")
+}
+
+func shouldRetryCompactWithFallback(errMsg *interfaces.ErrorMessage) bool {
+	if errMsg == nil {
+		return false
+	}
+	if isCompactModelUnsupportedError(errMsg) {
+		return true
+	}
+	switch errMsg.StatusCode {
+	case http.StatusRequestTimeout,
+		http.StatusNotFound,
+		http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		http.StatusNotImplemented,
+		499:
+		return true
+	}
+	if errMsg.Error == nil {
+		return false
+	}
+	errText := strings.ToLower(strings.TrimSpace(errMsg.Error.Error()))
+	return isCompactUpstreamTimeout(errText) || strings.Contains(errText, "responses/compact") || strings.Contains(errText, "unknown provider")
+}
+
+func isCompactUpstreamTimeout(errText string) bool {
+	return strings.Contains(errText, "timeout awaiting response headers") ||
+		strings.Contains(errText, "client.timeout exceeded") ||
+		strings.Contains(errText, "context deadline exceeded") ||
+		strings.Contains(errText, "i/o timeout")
+}
+
+func isCompactModelUnsupportedError(errMsg *interfaces.ErrorMessage) bool {
+	if errMsg == nil {
+		return false
+	}
+	if errMsg.StatusCode != http.StatusBadRequest {
+		return false
+	}
+	if errMsg.Error == nil {
+		return false
+	}
+	errText := strings.ToLower(strings.TrimSpace(errMsg.Error.Error()))
+	return strings.Contains(errText, "model is not supported") ||
+		strings.Contains(errText, "model not supported") ||
+		strings.Contains(errText, "not supported when using codex with a chatgpt account")
 }
 
 // handleNonStreamingResponse handles non-streaming chat completion responses


### PR DESCRIPTION
## Summary
- reduce Codex `/responses/compact` upstream response-header timeout from 120s to 30s
- retry compact fallback on 408/499/504 and common upstream timeout errors
- add coverage for fallback after `timeout awaiting response headers`

## Tests
- `go test ./sdk/api/handlers/openai ./internal/runtime/executor`
