### PR TITLE
fix: show forwarded client IP in live logs

### DIFF
--- a/internal/logging/gin_logger.go
+++ b/internal/logging/gin_logger.go
@@ -71,6 +71,9 @@ func GinLogrusLogger() gin.HandlerFunc {
 
 		statusCode := c.Writer.Status()
 		clientIP := c.ClientIP()
+		if ip, _ := util.ForwardedClientIP(c.Request); ip != "" {
+			clientIP = ip
+		}
 		method := c.Request.Method
 		errorMessage := c.Errors.ByType(gin.ErrorTypePrivate).String()
 

--- a/internal/logging/gin_logger_test.go
+++ b/internal/logging/gin_logger_test.go
@@ -1,12 +1,15 @@
 package logging
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestGinLogrusRecoveryRepanicsErrAbortHandler(t *testing.T) {
@@ -56,5 +59,41 @@ func TestGinLogrusRecoveryHandlesRegularPanic(t *testing.T) {
 	engine.ServeHTTP(recorder, req)
 	if recorder.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", recorder.Code)
+	}
+}
+
+func TestGinLogrusLoggerPrefersForwardedClientIPForCDNRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var buf bytes.Buffer
+	originalOutput := log.StandardLogger().Out
+	defer log.SetOutput(originalOutput)
+	log.SetOutput(&buf)
+
+	engine := gin.New()
+	if err := engine.SetTrustedProxies(nil); err != nil {
+		t.Fatalf("SetTrustedProxies(nil): %v", err)
+	}
+	engine.Use(GinLogrusLogger())
+	engine.GET("/probe", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.RemoteAddr = "198.51.100.10:4321"
+	req.Header.Set("CF-Connecting-IP", "203.0.113.24")
+	recorder := httptest.NewRecorder()
+
+	engine.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	line := buf.String()
+	if !strings.Contains(line, "203.0.113.24") {
+		t.Fatalf("log line = %q, want real forwarded client IP", line)
+	}
+	if strings.Contains(line, "198.51.100.10") {
+		t.Fatalf("log line = %q, should not use proxy connection IP", line)
 	}
 }

--- a/internal/runtime/executor/usage_helpers.go
+++ b/internal/runtime/executor/usage_helpers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -396,7 +395,7 @@ func buildRequestDetailContent(ctx context.Context) string {
 }
 
 func requestLogClientIP(ginCtx *gin.Context, req *http.Request) (string, string) {
-	if ip, source := forwardedClientIP(req); ip != "" {
+	if ip, source := util.ForwardedClientIP(req); ip != "" {
 		return ip, source
 	}
 	if ginCtx != nil {
@@ -405,91 +404,11 @@ func requestLogClientIP(ginCtx *gin.Context, req *http.Request) (string, string)
 		}
 	}
 	if req != nil {
-		if ip := remoteAddrIP(req.RemoteAddr); ip != "" {
+		if ip := util.RemoteAddrIP(req.RemoteAddr); ip != "" {
 			return ip, "remote_addr"
 		}
 	}
 	return "", ""
-}
-
-func forwardedClientIP(req *http.Request) (string, string) {
-	if req == nil || req.Header == nil {
-		return "", ""
-	}
-	headerPriority := []string{
-		"CF-Connecting-IP",
-		"True-Client-IP",
-		"X-Real-IP",
-		"X-Forwarded-For",
-	}
-	for _, header := range headerPriority {
-		if ip := firstHeaderIP(req.Header, header); ip != "" {
-			return ip, header
-		}
-	}
-	if ip := forwardedHeaderIP(req.Header); ip != "" {
-		return ip, "Forwarded"
-	}
-	return "", ""
-}
-
-func firstHeaderIP(headers http.Header, header string) string {
-	for _, value := range headers.Values(header) {
-		for _, candidate := range strings.Split(value, ",") {
-			if ip := normalizeIPCandidate(candidate); ip != "" {
-				return ip
-			}
-		}
-	}
-	return ""
-}
-
-func forwardedHeaderIP(headers http.Header) string {
-	for _, value := range headers.Values("Forwarded") {
-		for _, entry := range strings.Split(value, ",") {
-			for _, part := range strings.Split(entry, ";") {
-				key, rawValue, ok := strings.Cut(part, "=")
-				if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {
-					continue
-				}
-				if ip := normalizeIPCandidate(rawValue); ip != "" {
-					return ip
-				}
-			}
-		}
-	}
-	return ""
-}
-
-func remoteAddrIP(remoteAddr string) string {
-	remoteAddr = strings.TrimSpace(remoteAddr)
-	if remoteAddr == "" {
-		return ""
-	}
-	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
-		return normalizeIPCandidate(host)
-	}
-	return normalizeIPCandidate(remoteAddr)
-}
-
-func normalizeIPCandidate(candidate string) string {
-	candidate = strings.TrimSpace(candidate)
-	candidate = strings.Trim(candidate, `"`)
-	if candidate == "" || strings.EqualFold(candidate, "unknown") {
-		return ""
-	}
-	if strings.HasPrefix(candidate, "[") {
-		if end := strings.Index(candidate, "]"); end > 0 {
-			candidate = candidate[1:end]
-		}
-	} else if host, _, err := net.SplitHostPort(candidate); err == nil {
-		candidate = host
-	}
-	ip := net.ParseIP(strings.TrimSpace(candidate))
-	if ip == nil {
-		return ""
-	}
-	return ip.String()
 }
 
 func bytesToString(value any) string {

--- a/internal/util/client_ip.go
+++ b/internal/util/client_ip.go
@@ -1,0 +1,94 @@
+package util
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ForwardedClientIP extracts the original client IP from common CDN/proxy headers.
+// It is intended for audit/log display only; access control should continue to use
+// the framework's trusted-proxy-aware client IP.
+func ForwardedClientIP(req *http.Request) (string, string) {
+	if req == nil || req.Header == nil {
+		return "", ""
+	}
+	headerPriority := []string{
+		"CF-Connecting-IP",
+		"True-Client-IP",
+		"X-Real-IP",
+		"X-Forwarded-For",
+	}
+	for _, header := range headerPriority {
+		if ip := firstHeaderIP(req.Header, header); ip != "" {
+			return ip, header
+		}
+	}
+	if ip := forwardedHeaderIP(req.Header); ip != "" {
+		return ip, "Forwarded"
+	}
+	return "", ""
+}
+
+func firstHeaderIP(headers http.Header, header string) string {
+	for _, value := range headers.Values(header) {
+		for _, candidate := range strings.Split(value, ",") {
+			if ip := normalizeIPCandidate(candidate); ip != "" {
+				return ip
+			}
+		}
+	}
+	return ""
+}
+
+func forwardedHeaderIP(headers http.Header) string {
+	for _, value := range headers.Values("Forwarded") {
+		for _, entry := range strings.Split(value, ",") {
+			for _, part := range strings.Split(entry, ";") {
+				key, rawValue, ok := strings.Cut(part, "=")
+				if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {
+					continue
+				}
+				if ip := normalizeIPCandidate(rawValue); ip != "" {
+					return ip
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// RemoteAddrIP extracts and normalizes the IP part of net/http Request.RemoteAddr.
+func RemoteAddrIP(remoteAddr string) string {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if remoteAddr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return normalizeIPCandidate(host)
+	}
+	return normalizeIPCandidate(remoteAddr)
+}
+
+func normalizeIPCandidate(candidate string) string {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return ""
+	}
+	candidate = strings.Trim(candidate, `"`)
+	if candidate == "" || strings.EqualFold(candidate, "unknown") {
+		return ""
+	}
+	if strings.HasPrefix(candidate, "[") && strings.Contains(candidate, "]") {
+		if end := strings.Index(candidate, "]"); end >= 0 {
+			candidate = candidate[1:end]
+		}
+	} else if host, _, err := net.SplitHostPort(candidate); err == nil {
+		candidate = host
+	}
+	ip := net.ParseIP(strings.TrimSpace(candidate))
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}


### PR DESCRIPTION
## Summary
- Use the shared forwarded-client-IP parser for live application request logs, so CDN/proxy headers are reflected in the logs viewer.
- Keep management access control on Gin ClientIP and reuse the parser for request-log details.
- Add a regression test covering CDN-style forwarded IP headers with trusted proxies disabled.

Fixes #69

## Verification
- go test ./internal/logging -run TestGinLogrusLoggerPrefersForwardedClientIPForCDNRequests -count=1
- go test ./internal/runtime/executor -run TestRequestDetailsPreferForwardedClientIPForCDNRequests -count=1
- go test ./internal/api -run TestManagementRemoteRestrictionIgnoresForgedForwardedFor -count=1
- go test ./internal/util -count=1
- git diff --check
- go test ./...