### PR TITLE
Fix runtime reload after config YAML save

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -329,14 +329,15 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		return
 	}
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	if WriteConfig(h.configFilePath, body) != nil {
+		h.mu.Unlock()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "write_failed", "message": "failed to write config"})
 		return
 	}
 	// Reload into handler to keep memory in sync
 	newCfg, err := config.LoadConfig(h.configFilePath)
 	if err != nil {
+		h.mu.Unlock()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "reload_failed", "message": err.Error()})
 		return
 	}
@@ -346,7 +347,12 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		usage.ApplyStoredRuntimeSettings(newCfg)
 	}
 	h.cfg = newCfg
+	mutated := h.onConfigMutated
+	h.mu.Unlock()
 	c.JSON(http.StatusOK, gin.H{"ok": true, "changed": []string{"config"}})
+	if mutated != nil {
+		mutated(newCfg)
+	}
 }
 
 // GetConfigYAML returns the raw config.yaml file bytes without re-encoding.

--- a/internal/api/handlers/management/config_basic_test.go
+++ b/internal/api/handlers/management/config_basic_test.go
@@ -375,6 +375,67 @@ logging-to-file: true
 	}
 }
 
+func TestPutConfigYAMLNotifiesConfigMutationHookAfterPayloadRuntimeSettingUpdate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	if err := usage.UpsertRuntimeSetting(usage.RuntimeSettingPayload, config.PayloadConfig{
+		Override: []config.PayloadRule{
+			{
+				Models: []config.PayloadModelRule{{Name: "old-model", Protocol: "codex"}},
+				Params: map[string]any{"service_tier": "standard"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed payload runtime setting: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8318\nlogging-to-file: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	body := []byte(`port: 8318
+payload:
+  override:
+    - models:
+        - name: gpt-5.4
+          protocol: codex
+        - name: gpt-5.4-mini
+          protocol: codex
+      params:
+        service_tier: priority
+logging-to-file: true
+`)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "/config.yaml", bytes.NewReader(body))
+
+	var hookCalled bool
+	var hookPayload config.PayloadConfig
+	h := NewHandler(&config.Config{}, configPath, nil)
+	h.SetConfigMutatedHook(func(updated *config.Config) {
+		hookCalled = true
+		if updated != nil {
+			hookPayload = updated.Payload
+		}
+	})
+	h.PutConfigYAML(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PutConfigYAML status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if !hookCalled {
+		t.Fatal("config mutation hook was not called")
+	}
+	assertPayloadOverrideRule(t, hookPayload)
+}
+
 func assertPayloadOverrideRule(t *testing.T, payload config.PayloadConfig) {
 	t.Helper()
 	if len(payload.Override) != 1 {


### PR DESCRIPTION
## Summary
- call the config mutation hook after successful `config.yaml` saves
- keep the hook payload aligned with stored runtime settings before runtime reload
- add a regression test for payload override saves triggering runtime config reload

Refs #208

## Tests
- go test ./internal/api/handlers/management -run 'TestPutConfigYAML(UpdatesExistingStoredPayloadRuntimeSetting|NotifiesConfigMutationHookAfterPayloadRuntimeSettingUpdate)' -count=1\n- go test ./internal/api/handlers/management -count=1\n- git diff --check