### PR TITLE
fix: extend upstream response header timeout

### DIFF
--- a/internal/util/proxy.go
+++ b/internal/util/proxy.go
@@ -20,7 +20,7 @@ const (
 	DefaultHTTPClientTimeout        = 30 * time.Second
 	DefaultHTTPDialTimeout          = 10 * time.Second
 	DefaultHTTPTLSHandshakeTimeout  = 10 * time.Second
-	DefaultHTTPResponseHeaderTimout = 30 * time.Second
+	DefaultHTTPResponseHeaderTimout = 600 * time.Second
 	DefaultHTTPIdleConnTimeout      = 90 * time.Second
 )
 

--- a/internal/util/proxy_test.go
+++ b/internal/util/proxy_test.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewDefaultTransportUsesLongResponseHeaderTimeout(t *testing.T) {
+	transport := NewDefaultTransport(false)
+	if transport == nil {
+		t.Fatal("NewDefaultTransport returned nil")
+	}
+	if transport.ResponseHeaderTimeout != 600*time.Second {
+		t.Fatalf("ResponseHeaderTimeout = %s, want 600s", transport.ResponseHeaderTimeout)
+	}
+}
+
+func TestBuildProxyTransportUsesLongResponseHeaderTimeout(t *testing.T) {
+	transport := BuildProxyTransport("http://127.0.0.1:8080", false)
+	if transport == nil {
+		t.Fatal("BuildProxyTransport returned nil")
+	}
+	if transport.Proxy == nil {
+		t.Fatal("Proxy is nil")
+	}
+	if transport.ResponseHeaderTimeout != 600*time.Second {
+		t.Fatalf("ResponseHeaderTimeout = %s, want 600s", transport.ResponseHeaderTimeout)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	proxyURL, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("Proxy returned error: %v", err)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://127.0.0.1:8080" {
+		t.Fatalf("Proxy URL = %v, want http://127.0.0.1:8080", proxyURL)
+	}
+}


### PR DESCRIPTION
## Summary
- Increase the default HTTP response header timeout from 30 seconds to 600 seconds for outbound clients.
- Add regression coverage for direct and proxy transports so slow upstream headers do not regress.

## Tests
- go test ./internal/util
- go test ./internal/runtime/executor
- go test ./...

Closes #220