### PR TITLE
Fix API key permission profile bindings

### DIFF
--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -38,7 +38,9 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 
 	// Primary: load from SQLite
 	rows := usage.ListAPIKeys()
+	profiles := usage.ListAPIKeyPermissionProfiles()
 	for _, row := range rows {
+		row = usage.EffectiveAPIKeyRowWithProfiles(row, profiles)
 		trimmed := strings.TrimSpace(row.Key)
 		if trimmed == "" || row.Disabled {
 			continue
@@ -62,6 +64,7 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 
 	// Fallback: YAML config (for backward compatibility during migration)
 	for _, entry := range cfg.APIKeyEntries {
+		row := usage.EffectiveAPIKeyRowWithProfiles(usage.APIKeyRowFromConfig(entry), profiles)
 		trimmed := strings.TrimSpace(entry.Key)
 		if trimmed == "" || entry.Disabled {
 			continue
@@ -70,16 +73,16 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 			continue
 		}
 		result[trimmed] = keyConfig{
-			allowedModels:        entry.AllowedModels,
-			allowedChannels:      entry.AllowedChannels,
-			allowedChannelGroups: entry.AllowedChannelGroups,
-			dailyLimit:           entry.DailyLimit,
-			totalQuota:           entry.TotalQuota,
-			spendingLimit:        entry.SpendingLimit,
-			concurrencyLimit:     entry.ConcurrencyLimit,
-			rpmLimit:             entry.RPMLimit,
-			tpmLimit:             entry.TPMLimit,
-			systemPrompt:         entry.SystemPrompt,
+			allowedModels:        row.AllowedModels,
+			allowedChannels:      row.AllowedChannels,
+			allowedChannelGroups: row.AllowedChannelGroups,
+			dailyLimit:           row.DailyLimit,
+			totalQuota:           row.TotalQuota,
+			spendingLimit:        row.SpendingLimit,
+			concurrencyLimit:     row.ConcurrencyLimit,
+			rpmLimit:             row.RPMLimit,
+			tpmLimit:             row.TPMLimit,
+			systemPrompt:         row.SystemPrompt,
 		}
 	}
 	for _, k := range cfg.APIKeys {

--- a/internal/api/handlers/management/api_key_cache_refresh_test.go
+++ b/internal/api/handlers/management/api_key_cache_refresh_test.go
@@ -1,12 +1,15 @@
 package management
 
 import (
+	"bytes"
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -75,5 +78,94 @@ func TestRefreshAPIKeyCacheUpdatesLiveAccessManager(t *testing.T) {
 	}
 	if got := res.Metadata["allowed-channels"]; got != "kimi" {
 		t.Fatalf("allowed-channels = %q, want %q", got, "kimi")
+	}
+}
+
+func TestPermissionProfileUpdateRefreshesBoundAPIKeyCache(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tmpFile, err := os.CreateTemp("", "usage-bound-profile-*.db")
+	if err != nil {
+		t.Fatalf("create temp db: %v", err)
+	}
+	dbPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	defer func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	}()
+
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	if err := usage.ReplaceAllAPIKeyPermissionProfiles([]usage.APIKeyPermissionProfileRow{
+		{
+			ID:                   "standard",
+			Name:                 "Standard",
+			DailyLimit:           10,
+			AllowedChannelGroups: []string{"legacy"},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllAPIKeyPermissionProfiles: %v", err)
+	}
+	const key = "sk-test-bound-profile"
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{
+		Key:                 key,
+		Name:                "Bound",
+		PermissionProfileID: "standard",
+		DailyLimit:          1,
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	cfg := &config.Config{}
+	accessManager := sdkaccess.NewManager()
+	configaccess.Register(&cfg.SDKConfig)
+	accessManager.SetProviders(sdkaccess.RegisteredProviders())
+
+	req := httptest.NewRequest("POST", "/v1/responses", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	res, authErr := accessManager.Authenticate(context.Background(), req)
+	if authErr != nil {
+		t.Fatalf("Authenticate (before profile update): %v", authErr)
+	}
+	if got := res.Metadata["daily-limit"]; got != "10" {
+		t.Fatalf("daily-limit before profile update = %q, want 10", got)
+	}
+	if got := res.Metadata["allowed-channel-groups"]; got != "legacy" {
+		t.Fatalf("allowed-channel-groups before profile update = %q, want legacy", got)
+	}
+
+	body := []byte(`[
+  {
+    "id": "standard",
+    "name": "Standard",
+    "daily-limit": 20,
+    "allowed-channel-groups": ["pro"],
+    "allowed-channels": [],
+    "allowed-models": []
+  }
+]`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "/api-key-permission-profiles", bytes.NewReader(body))
+
+	h := NewHandler(cfg, "", nil)
+	h.SetAccessManager(accessManager)
+	h.PutAPIKeyPermissionProfiles(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT profile status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	res, authErr = accessManager.Authenticate(context.Background(), req)
+	if authErr != nil {
+		t.Fatalf("Authenticate (after profile update): %v", authErr)
+	}
+	if got := res.Metadata["daily-limit"]; got != "20" {
+		t.Fatalf("daily-limit after profile update = %q, want 20", got)
+	}
+	if got := res.Metadata["allowed-channel-groups"]; got != "pro" {
+		t.Fatalf("allowed-channel-groups after profile update = %q, want pro", got)
 	}
 }

--- a/internal/api/handlers/management/api_key_permission_profiles_test.go
+++ b/internal/api/handlers/management/api_key_permission_profiles_test.go
@@ -105,3 +105,43 @@ func TestPutAPIKeyPermissionProfilesRejectsMissingIdentity(t *testing.T) {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
 }
+
+func TestPatchAPIKeyEntryPersistsPermissionProfileID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{Key: "sk-bound-profile", Name: "Bound"}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	body := []byte(`{
+  "match": "sk-bound-profile",
+  "value": {
+    "permission-profile-id": "standard",
+    "daily-limit": 15000,
+    "allowed-channel-groups": ["pro"]
+  }
+}`)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/api-key-entries", bytes.NewReader(body))
+
+	h := NewHandler(&config.Config{
+		Routing: config.RoutingConfig{
+			ChannelGroups: []config.RoutingChannelGroup{{Name: "pro"}},
+		},
+	}, "", nil)
+	h.PatchAPIKeyEntry(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	got := usage.GetAPIKey("sk-bound-profile")
+	if got == nil {
+		t.Fatal("expected API key after PATCH")
+	}
+	if got.PermissionProfileID != "standard" {
+		t.Fatalf("permission profile id = %q, want standard", got.PermissionProfileID)
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -247,12 +247,13 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	h.refreshAPIKeyCache()
 	c.JSON(200, gin.H{"status": "ok"})
 }
 
 // api-key-entries: backed by SQLite api_keys table
 func (h *Handler) GetAPIKeyEntries(c *gin.Context) {
-	rows := usage.ListAPIKeys()
+	rows := usage.EffectiveAPIKeyRows(usage.ListAPIKeys())
 	entries := make([]config.APIKeyEntry, 0, len(rows))
 	for _, r := range rows {
 		entries = append(entries, r.ToConfigEntry())
@@ -324,6 +325,7 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 	type apiKeyEntryPatch struct {
 		Key                  *string   `json:"key"`
 		Name                 *string   `json:"name"`
+		PermissionProfileID  *string   `json:"permission-profile-id"`
 		DailyLimit           *int      `json:"daily-limit"`
 		TotalQuota           *int      `json:"total-quota"`
 		SpendingLimit        *float64  `json:"spending-limit"`
@@ -395,6 +397,9 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 	// Apply patches
 	if body.Value.Name != nil {
 		entry.Name = strings.TrimSpace(*body.Value.Name)
+	}
+	if body.Value.PermissionProfileID != nil {
+		entry.PermissionProfileID = strings.TrimSpace(*body.Value.PermissionProfileID)
 	}
 	if body.Value.DailyLimit != nil {
 		entry.DailyLimit = *body.Value.DailyLimit

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -104,6 +104,10 @@ type APIKeyEntry struct {
 	// Disabled marks this key as inactive. Disabled keys cannot authenticate.
 	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 
+	// PermissionProfileID links this key to a reusable permission profile.
+	// When set, the current profile values are used for limits and restrictions.
+	PermissionProfileID string `yaml:"permission-profile-id,omitempty" json:"permission-profile-id,omitempty"`
+
 	// DailyLimit is the maximum number of requests per day. 0 means unlimited.
 	DailyLimit int `yaml:"daily-limit,omitempty" json:"daily-limit,omitempty"`
 

--- a/internal/usage/apikey_db.go
+++ b/internal/usage/apikey_db.go
@@ -16,6 +16,7 @@ type APIKeyRow struct {
 	Key                  string   `json:"key"`
 	Name                 string   `json:"name,omitempty"`
 	Disabled             bool     `json:"disabled,omitempty"`
+	PermissionProfileID  string   `json:"permission-profile-id,omitempty"`
 	DailyLimit           int      `json:"daily-limit,omitempty"`
 	TotalQuota           int      `json:"total-quota,omitempty"`
 	SpendingLimit        float64  `json:"spending-limit,omitempty"`
@@ -36,6 +37,7 @@ func (r *APIKeyRow) ToConfigEntry() config.APIKeyEntry {
 		Key:                  r.Key,
 		Name:                 r.Name,
 		Disabled:             r.Disabled,
+		PermissionProfileID:  r.PermissionProfileID,
 		DailyLimit:           r.DailyLimit,
 		TotalQuota:           r.TotalQuota,
 		SpendingLimit:        r.SpendingLimit,
@@ -56,6 +58,7 @@ func APIKeyRowFromConfig(entry config.APIKeyEntry) APIKeyRow {
 		Key:                  entry.Key,
 		Name:                 entry.Name,
 		Disabled:             entry.Disabled,
+		PermissionProfileID:  entry.PermissionProfileID,
 		DailyLimit:           entry.DailyLimit,
 		TotalQuota:           entry.TotalQuota,
 		SpendingLimit:        entry.SpendingLimit,
@@ -75,6 +78,7 @@ CREATE TABLE IF NOT EXISTS api_keys (
   key               TEXT PRIMARY KEY NOT NULL,
   name              TEXT NOT NULL DEFAULT '',
   disabled          INTEGER NOT NULL DEFAULT 0,
+  permission_profile_id TEXT NOT NULL DEFAULT '',
   daily_limit       INTEGER NOT NULL DEFAULT 0,
   total_quota       INTEGER NOT NULL DEFAULT 0,
   spending_limit    REAL NOT NULL DEFAULT 0,
@@ -103,6 +107,7 @@ func migrateAPIKeyColumns(db *sql.DB) {
 		name       string
 		definition string
 	}{
+		{name: "permission_profile_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "allowed_channels", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "allowed_channel_groups", definition: "TEXT NOT NULL DEFAULT '[]'"},
 	} {
@@ -258,9 +263,9 @@ func MigrateAPIKeysFromConfig(cfg *config.Config, configFilePath string) int {
 	}
 
 	stmt, err := tx.Prepare(`INSERT OR IGNORE INTO api_keys
-		(key, name, disabled, daily_limit, total_quota, spending_limit,
+		(key, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		log.Errorf("usage: prepare api_keys migration: %v", err)
@@ -287,7 +292,7 @@ func MigrateAPIKeysFromConfig(cfg *config.Config, configFilePath string) int {
 			disabledInt = 1
 		}
 		if _, err := stmt.Exec(
-			row.Key, row.Name, disabledInt,
+			row.Key, row.Name, disabledInt, strings.TrimSpace(row.PermissionProfileID),
 			row.DailyLimit, row.TotalQuota, row.SpendingLimit,
 			row.ConcurrencyLimit, row.RPMLimit, row.TPMLimit,
 			string(modelsJSON), string(channelsJSON), string(channelGroupsJSON), row.SystemPrompt,
@@ -321,6 +326,58 @@ func MigrateAPIKeysFromConfig(cfg *config.Config, configFilePath string) int {
 	return imported
 }
 
+// EffectiveAPIKeyRow applies the currently linked permission profile to an API key row.
+// If the profile is missing, the row's copied/custom settings remain the fallback.
+func EffectiveAPIKeyRow(row APIKeyRow) APIKeyRow {
+	return EffectiveAPIKeyRowWithProfiles(row, ListAPIKeyPermissionProfiles())
+}
+
+// EffectiveAPIKeyRowWithProfiles applies a preloaded permission profile snapshot.
+func EffectiveAPIKeyRowWithProfiles(row APIKeyRow, profiles []APIKeyPermissionProfileRow) APIKeyRow {
+	profileID := strings.TrimSpace(row.PermissionProfileID)
+	if profileID == "" {
+		return row
+	}
+
+	var matched *APIKeyPermissionProfileRow
+	for _, profile := range profiles {
+		if profile.ID == profileID {
+			copy := profile
+			matched = &copy
+			break
+		}
+	}
+	if matched == nil {
+		return row
+	}
+
+	row.PermissionProfileID = profileID
+	row.DailyLimit = matched.DailyLimit
+	row.TotalQuota = matched.TotalQuota
+	row.SpendingLimit = 0
+	row.ConcurrencyLimit = matched.ConcurrencyLimit
+	row.RPMLimit = matched.RPMLimit
+	row.TPMLimit = matched.TPMLimit
+	row.AllowedModels = append([]string(nil), matched.AllowedModels...)
+	row.AllowedChannels = append([]string(nil), matched.AllowedChannels...)
+	row.AllowedChannelGroups = append([]string(nil), matched.AllowedChannelGroups...)
+	row.SystemPrompt = matched.SystemPrompt
+	return row
+}
+
+// EffectiveAPIKeyRows applies the current permission profile snapshot to each row.
+func EffectiveAPIKeyRows(rows []APIKeyRow) []APIKeyRow {
+	if len(rows) == 0 {
+		return rows
+	}
+	profiles := ListAPIKeyPermissionProfiles()
+	out := make([]APIKeyRow, len(rows))
+	for idx, row := range rows {
+		out[idx] = EffectiveAPIKeyRowWithProfiles(row, profiles)
+	}
+	return out
+}
+
 // ListAPIKeys retrieves all API key entries from SQLite.
 func ListAPIKeys() []APIKeyRow {
 	db := getDB()
@@ -329,7 +386,7 @@ func ListAPIKeys() []APIKeyRow {
 	}
 
 	rows, err := db.Query(`SELECT key, name, disabled, daily_limit, total_quota,
-		spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_keys ORDER BY created_at ASC`)
 	if err != nil {
@@ -349,7 +406,7 @@ func GetAPIKey(key string) *APIKeyRow {
 	}
 
 	row := db.QueryRow(`SELECT key, name, disabled, daily_limit, total_quota,
-		spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_keys WHERE key = ?`, key)
 
@@ -369,6 +426,7 @@ func UpsertAPIKey(entry APIKeyRow) error {
 	}
 	entry.Key = trimmed
 	entry.Name = strings.TrimSpace(entry.Name)
+	entry.PermissionProfileID = strings.TrimSpace(entry.PermissionProfileID)
 
 	modelsJSON, _ := json.Marshal(entry.AllowedModels)
 	if entry.AllowedModels == nil {
@@ -392,11 +450,12 @@ func UpsertAPIKey(entry APIKeyRow) error {
 	}
 
 	_, err := db.Exec(`INSERT INTO api_keys
-		(key, name, disabled, daily_limit, total_quota, spending_limit,
+		(key, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(key) DO UPDATE SET
 			name=excluded.name, disabled=excluded.disabled,
+			permission_profile_id=excluded.permission_profile_id,
 			daily_limit=excluded.daily_limit, total_quota=excluded.total_quota,
 			spending_limit=excluded.spending_limit, concurrency_limit=excluded.concurrency_limit,
 			rpm_limit=excluded.rpm_limit, tpm_limit=excluded.tpm_limit,
@@ -404,7 +463,7 @@ func UpsertAPIKey(entry APIKeyRow) error {
 			allowed_channel_groups=excluded.allowed_channel_groups,
 			system_prompt=excluded.system_prompt,
 			updated_at=excluded.updated_at`,
-		trimmed, entry.Name, disabledInt,
+		trimmed, entry.Name, disabledInt, entry.PermissionProfileID,
 		entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit,
 		entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		string(modelsJSON), string(channelsJSON), string(channelGroupsJSON), entry.SystemPrompt,
@@ -441,9 +500,9 @@ func ReplaceAllAPIKeys(entries []APIKeyRow) error {
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_keys
-		(key, name, disabled, daily_limit, total_quota, spending_limit,
+		(key, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -458,6 +517,7 @@ func ReplaceAllAPIKeys(entries []APIKeyRow) error {
 		}
 		entry.Key = trimmed
 		entry.Name = strings.TrimSpace(entry.Name)
+		entry.PermissionProfileID = strings.TrimSpace(entry.PermissionProfileID)
 		modelsJSON, _ := json.Marshal(entry.AllowedModels)
 		if entry.AllowedModels == nil {
 			modelsJSON = []byte("[]")
@@ -478,7 +538,7 @@ func ReplaceAllAPIKeys(entries []APIKeyRow) error {
 			entry.CreatedAt = now
 		}
 		if _, err := stmt.Exec(
-			trimmed, entry.Name, disabledInt,
+			trimmed, entry.Name, disabledInt, entry.PermissionProfileID,
 			entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit,
 			entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 			string(modelsJSON), string(channelsJSON), string(channelGroupsJSON), entry.SystemPrompt,
@@ -517,7 +577,7 @@ func scanAPIKeyFromRow(row scannable) *APIKeyRow {
 	var channelGroupsJSON string
 	if err := row.Scan(
 		&r.Key, &r.Name, &disabledInt,
-		&r.DailyLimit, &r.TotalQuota, &r.SpendingLimit,
+		&r.DailyLimit, &r.TotalQuota, &r.PermissionProfileID, &r.SpendingLimit,
 		&r.ConcurrencyLimit, &r.RPMLimit, &r.TPMLimit,
 		&modelsJSON, &channelsJSON, &channelGroupsJSON, &r.SystemPrompt,
 		&r.CreatedAt, &r.UpdatedAt,
@@ -525,6 +585,7 @@ func scanAPIKeyFromRow(row scannable) *APIKeyRow {
 		return nil
 	}
 	r.Disabled = disabledInt != 0
+	r.PermissionProfileID = strings.TrimSpace(r.PermissionProfileID)
 	if modelsJSON != "" && modelsJSON != "[]" {
 		_ = json.Unmarshal([]byte(modelsJSON), &r.AllowedModels)
 	}
@@ -545,7 +606,7 @@ func scanSingleAPIKeyRow(row *sql.Row) *APIKeyRow {
 	var channelGroupsJSON string
 	if err := row.Scan(
 		&r.Key, &r.Name, &disabledInt,
-		&r.DailyLimit, &r.TotalQuota, &r.SpendingLimit,
+		&r.DailyLimit, &r.TotalQuota, &r.PermissionProfileID, &r.SpendingLimit,
 		&r.ConcurrencyLimit, &r.RPMLimit, &r.TPMLimit,
 		&modelsJSON, &channelsJSON, &channelGroupsJSON, &r.SystemPrompt,
 		&r.CreatedAt, &r.UpdatedAt,
@@ -553,6 +614,7 @@ func scanSingleAPIKeyRow(row *sql.Row) *APIKeyRow {
 		return nil
 	}
 	r.Disabled = disabledInt != 0
+	r.PermissionProfileID = strings.TrimSpace(r.PermissionProfileID)
 	if modelsJSON != "" && modelsJSON != "[]" {
 		_ = json.Unmarshal([]byte(modelsJSON), &r.AllowedModels)
 	}

--- a/internal/usage/apikey_db_test.go
+++ b/internal/usage/apikey_db_test.go
@@ -54,10 +54,11 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 	defer cleanup()
 
 	entry := APIKeyRow{
-		Key:          "sk-test-123",
-		Name:         "Test Key",
-		DailyLimit:   100,
-		SystemPrompt: "You are a helpful assistant.\n### Special chars: # * ** ☢️",
+		Key:                 "sk-test-123",
+		Name:                "Test Key",
+		PermissionProfileID: "standard",
+		DailyLimit:          100,
+		SystemPrompt:        "You are a helpful assistant.\n### Special chars: # * ** ☢️",
 	}
 
 	if err := UpsertAPIKey(entry); err != nil {
@@ -74,12 +75,16 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 	if got.DailyLimit != 100 {
 		t.Errorf("daily_limit = %d, want 100", got.DailyLimit)
 	}
+	if got.PermissionProfileID != "standard" {
+		t.Errorf("permission_profile_id = %q, want %q", got.PermissionProfileID, "standard")
+	}
 	if got.SystemPrompt != entry.SystemPrompt {
 		t.Errorf("system_prompt = %q, want %q", got.SystemPrompt, entry.SystemPrompt)
 	}
 
 	// Update
 	entry.Name = "Updated Key"
+	entry.PermissionProfileID = "strict"
 	entry.DailyLimit = 200
 	if err := UpsertAPIKey(entry); err != nil {
 		t.Fatalf("UpsertAPIKey (update): %v", err)
@@ -94,6 +99,9 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 	}
 	if got.DailyLimit != 200 {
 		t.Errorf("daily_limit after update = %d, want 200", got.DailyLimit)
+	}
+	if got.PermissionProfileID != "strict" {
+		t.Errorf("permission_profile_id after update = %q, want %q", got.PermissionProfileID, "strict")
 	}
 }
 
@@ -196,7 +204,7 @@ func TestAPIKeyReplaceAll(t *testing.T) {
 
 	// Replace all
 	newKeys := []APIKeyRow{
-		{Key: "sk-new-a", Name: "New A"},
+		{Key: "sk-new-a", Name: "New A", PermissionProfileID: "standard"},
 		{Key: "sk-new-b", Name: "New B"},
 	}
 	if err := ReplaceAllAPIKeys(newKeys); err != nil {
@@ -209,6 +217,15 @@ func TestAPIKeyReplaceAll(t *testing.T) {
 	}
 	if list[0].Key != "sk-new-a" && list[1].Key != "sk-new-a" {
 		t.Fatal("expected sk-new-a in list")
+	}
+	var profileID string
+	for _, row := range list {
+		if row.Key == "sk-new-a" {
+			profileID = row.PermissionProfileID
+		}
+	}
+	if profileID != "standard" {
+		t.Fatalf("permission_profile_id for sk-new-a = %q, want standard", profileID)
 	}
 
 	// Old keys should be gone


### PR DESCRIPTION
## Summary
- Persist API key permission profile bindings with a stable `permission-profile-id` field.
- Resolve bound API keys against the current permission profile for management API responses and runtime access cache.
- Refresh API key access cache after permission profile updates.

## Test Plan
- `go test ./...`
- `git diff --check`
