### PR TITLE
feat: match channel groups by auth tags

### DIFF
--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -30,6 +30,7 @@ type channelGroupItem struct {
 	Priority       int                         `json:"priority,omitempty"`
 	Implicit       bool                        `json:"implicit"`
 	Prefixes       []string                    `json:"prefixes,omitempty"`
+	Tags           []string                    `json:"tags,omitempty"`
 	Channels       []string                    `json:"channels,omitempty"`
 	ChannelDetails []channelGroupChannelDetail `json:"channel-details,omitempty"`
 	AllowedModels  []string                    `json:"allowed-models,omitempty"`
@@ -148,6 +149,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 		item.Priority = group.Priority
 		item.AllowedModels = append(item.AllowedModels, group.AllowedModels...)
 		item.Prefixes = append(item.Prefixes, group.Match.Prefixes...)
+		item.Tags = append(item.Tags, group.Match.Tags...)
 		configuredChannelsByGroup[item.Name] = append(configuredChannelsByGroup[item.Name], group.Match.Channels...)
 	}
 
@@ -183,6 +185,9 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 					}
 				}
 			}
+			if !matched && channelMatchesAnyTag(channel, group.Tags) {
+				matched = true
+			}
 			if !matched {
 				if group.Name == "default" && prefix == "" && includeDefault {
 					matched = true
@@ -209,6 +214,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 	for name, item := range groupMap {
 		item.Name = name
 		item.Prefixes = uniqueSortedStrings(item.Prefixes, internalrouting.NormalizeGroupName)
+		item.Tags = uniqueSortedStrings(item.Tags, config.NormalizeRoutingTag)
 		item.Channels = uniqueSortedStrings(item.Channels, func(value string) string { return strings.TrimSpace(value) })
 		item.ChannelDetails = uniqueSortedChannelDetails(item.ChannelDetails)
 		item.PathRoutes = uniqueSortedStrings(knownPaths[name], internalrouting.NormalizeNamespacePath)
@@ -216,6 +222,28 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
+}
+
+func channelMatchesAnyTag(channel channelDescriptor, tags []string) bool {
+	if len(tags) == 0 {
+		return false
+	}
+	displayTags := make(map[string]struct{}, len(channel.DisplayTags))
+	for _, tag := range channel.DisplayTags {
+		normalized := config.NormalizeRoutingTag(tag)
+		if normalized != "" {
+			displayTags[normalized] = struct{}{}
+		}
+	}
+	if len(displayTags) == 0 {
+		return false
+	}
+	for _, tag := range tags {
+		if _, ok := displayTags[config.NormalizeRoutingTag(tag)]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func uniqueSortedStrings(values []string, normalizer func(string) string) []string {
@@ -391,6 +419,9 @@ func channelGroupMatchesAnyDescriptor(group config.RoutingChannelGroup, descript
 			if channel != "" && strings.EqualFold(strings.TrimSpace(candidateChannel), channel) {
 				return true
 			}
+		}
+		if channelMatchesAnyTag(descriptor, group.Match.Tags) {
+			return true
 		}
 	}
 	return false

--- a/internal/api/handlers/management/channel_groups_test.go
+++ b/internal/api/handlers/management/channel_groups_test.go
@@ -332,6 +332,68 @@ func TestGetChannelGroupsReturnsChannelDetailsWithTags(t *testing.T) {
 	}
 }
 
+func TestBuildChannelGroupItemsMatchesChannelsByAnyDisplayTag(t *testing.T) {
+	auths := []*coreauth.Auth{
+		{
+			ID:       "team-a",
+			Label:    "Team A Codex",
+			Provider: "codex",
+			Metadata: map[string]any{
+				"custom_tags": []string{"team-a"},
+			},
+		},
+		{
+			ID:       "pro",
+			Label:    "Pro Codex",
+			Provider: "codex",
+			Metadata: map[string]any{
+				"plan_type": "pro",
+			},
+		},
+		{
+			ID:       "free",
+			Label:    "Free Codex",
+			Provider: "codex",
+			Metadata: map[string]any{
+				"plan_type": "free",
+			},
+		},
+	}
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name: "tag-pool",
+					Match: config.ChannelGroupMatch{
+						Tags: []string{"team-a", "pro"},
+					},
+				},
+			},
+		},
+	}
+
+	items := buildChannelGroupItems(cfg, auths)
+	var tagPool *channelGroupItem
+	for i := range items {
+		if items[i].Name == "tag-pool" {
+			tagPool = &items[i]
+			break
+		}
+	}
+	if tagPool == nil {
+		t.Fatal("expected tag-pool group")
+	}
+	if !containsString(tagPool.Channels, "Team A Codex") {
+		t.Fatalf("channels = %v, want Team A Codex from custom tag", tagPool.Channels)
+	}
+	if !containsString(tagPool.Channels, "Pro Codex") {
+		t.Fatalf("channels = %v, want Pro Codex from plan tag", tagPool.Channels)
+	}
+	if containsString(tagPool.Channels, "Free Codex") {
+		t.Fatalf("channels = %v, should not include Free Codex", tagPool.Channels)
+	}
+}
+
 func TestBuildChannelGroupItemsKeepsRenamedKimiOAuthChannelsSeparate(t *testing.T) {
 	auths := []*coreauth.Auth{
 		{

--- a/internal/config/routing_groups.go
+++ b/internal/config/routing_groups.go
@@ -10,6 +10,7 @@ import (
 type ChannelGroupMatch struct {
 	Prefixes []string `yaml:"prefixes,omitempty" json:"prefixes,omitempty"`
 	Channels []string `yaml:"channels,omitempty" json:"channels,omitempty"`
+	Tags     []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 }
 
 // RoutingChannelGroup defines a named channel group used by routing and API-key permissions.
@@ -88,6 +89,14 @@ func NormalizeRoutingStrategy(strategy string) string {
 	}
 }
 
+func NormalizeRoutingTag(value string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	if trimmed == "" {
+		return ""
+	}
+	return strings.Join(strings.Fields(trimmed), "-")
+}
+
 func normalizeOptionalRoutingStrategy(strategy string) string {
 	if strings.TrimSpace(strategy) == "" {
 		return ""
@@ -113,6 +122,7 @@ func (cfg *Config) SanitizeRouting() {
 		group.Match.Channels = normalizeStringList(group.Match.Channels, func(value string) string {
 			return strings.TrimSpace(value)
 		})
+		group.Match.Tags = normalizeStringList(group.Match.Tags, NormalizeRoutingTag)
 		group.ChannelPriorities = normalizeChannelPriorities(group.ChannelPriorities)
 		group.AllowedModels = normalizeStringList(group.AllowedModels, func(value string) string {
 			return strings.TrimSpace(value)

--- a/sdk/cliproxy/auth/routing_groups.go
+++ b/sdk/cliproxy/auth/routing_groups.go
@@ -11,6 +11,16 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
 
+var routingCodexPlanDisplayTags = map[string]struct{}{
+	"business":   {},
+	"edu":        {},
+	"enterprise": {},
+	"free":       {},
+	"plus":       {},
+	"pro":        {},
+	"team":       {},
+}
+
 func metadataStringSet(meta map[string]any, key string, normalizer func(string) string) map[string]struct{} {
 	if len(meta) == 0 {
 		return nil
@@ -48,6 +58,162 @@ func metadataStringSet(meta map[string]any, key string, normalizer func(string) 
 		return nil
 	}
 	return out
+}
+
+func metadataTagList(meta map[string]any, key string) ([]string, bool) {
+	if len(meta) == 0 {
+		return nil, false
+	}
+	raw, ok := meta[key]
+	if !ok || raw == nil {
+		return nil, ok
+	}
+	var values []string
+	switch typed := raw.(type) {
+	case string:
+		values = strings.Split(typed, ",")
+	case []string:
+		values = typed
+	case []any:
+		values = make([]string, 0, len(typed))
+		for _, item := range typed {
+			values = append(values, fmt.Sprint(item))
+		}
+	default:
+		return nil, ok
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		tag := internalconfig.NormalizeRoutingTag(value)
+		if tag == "" {
+			continue
+		}
+		if _, exists := seen[tag]; exists {
+			continue
+		}
+		seen[tag] = struct{}{}
+		out = append(out, tag)
+	}
+	return out, ok
+}
+
+func metadataStringValue(meta map[string]any, keys ...string) string {
+	if len(meta) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		if value, ok := meta[key].(string); ok {
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+func appendUniqueTag(values []string, tag string) []string {
+	normalized := internalconfig.NormalizeRoutingTag(tag)
+	if normalized == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == normalized {
+			return values
+		}
+	}
+	return append(values, normalized)
+}
+
+func authDisplayTags(auth *Auth) []string {
+	if auth == nil {
+		return nil
+	}
+	defaultTags := make([]string, 0, 2)
+	if provider := internalconfig.NormalizeRoutingTag(auth.Provider); provider != "" && provider != "unknown" {
+		defaultTags = appendUniqueTag(defaultTags, provider)
+	}
+	if planType := internalconfig.NormalizeRoutingTag(metadataStringValue(auth.Metadata, "plan_type", "planType")); planType != "" {
+		defaultTags = appendUniqueTag(defaultTags, planType)
+	}
+
+	customTags, _ := metadataTagList(auth.Metadata, "custom_tags")
+	hiddenDefaultTags, _ := metadataTagList(auth.Metadata, "hidden_default_tags")
+	explicitDisplayTags, hasExplicitDisplayTags := metadataTagList(auth.Metadata, "display_tags")
+	if hasExplicitDisplayTags {
+		allowed := make(map[string]struct{}, len(defaultTags)+len(customTags))
+		for _, tag := range defaultTags {
+			allowed[tag] = struct{}{}
+		}
+		for _, tag := range customTags {
+			allowed[tag] = struct{}{}
+		}
+		out := make([]string, 0, len(explicitDisplayTags))
+		providerTag := internalconfig.NormalizeRoutingTag(auth.Provider)
+		currentPlan := internalconfig.NormalizeRoutingTag(metadataStringValue(auth.Metadata, "plan_type", "planType"))
+		for _, tag := range explicitDisplayTags {
+			if _, ok := allowed[tag]; ok {
+				out = appendUniqueTag(out, tag)
+				continue
+			}
+			if isStaleCodexRoutingPlanDisplayTag(providerTag, currentPlan, tag) {
+				if _, ok := allowed[currentPlan]; ok {
+					out = appendUniqueTag(out, currentPlan)
+				}
+			}
+		}
+		return out
+	}
+
+	hidden := make(map[string]struct{}, len(hiddenDefaultTags))
+	for _, tag := range hiddenDefaultTags {
+		hidden[tag] = struct{}{}
+	}
+	out := make([]string, 0, len(defaultTags)+len(customTags))
+	for _, tag := range defaultTags {
+		if _, skip := hidden[tag]; !skip {
+			out = appendUniqueTag(out, tag)
+		}
+	}
+	for _, tag := range customTags {
+		if _, skip := hidden[tag]; !skip {
+			out = appendUniqueTag(out, tag)
+		}
+	}
+	return out
+}
+
+func isStaleCodexRoutingPlanDisplayTag(providerTag string, currentPlan string, tag string) bool {
+	if providerTag != "codex" || currentPlan == "" || tag == currentPlan {
+		return false
+	}
+	if _, ok := routingCodexPlanDisplayTags[currentPlan]; !ok {
+		return false
+	}
+	_, ok := routingCodexPlanDisplayTags[tag]
+	return ok
+}
+
+func authMatchesAnyTag(auth *Auth, tags []string) bool {
+	if auth == nil || len(tags) == 0 {
+		return false
+	}
+	displayTags := make(map[string]struct{})
+	for _, tag := range authDisplayTags(auth) {
+		normalized := internalconfig.NormalizeRoutingTag(tag)
+		if normalized != "" {
+			displayTags[normalized] = struct{}{}
+		}
+	}
+	if len(displayTags) == 0 {
+		return false
+	}
+	for _, tag := range tags {
+		if _, ok := displayTags[internalconfig.NormalizeRoutingTag(tag)]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func allowedChannelGroupsFromMetadata(meta map[string]any) map[string]struct{} {
@@ -163,6 +329,9 @@ func authGroups(cfg *internalconfig.Config, auth *Auth) map[string]struct{} {
 					break
 				}
 			}
+		}
+		if !matched && authMatchesAnyTag(auth, group.Match.Tags) {
+			matched = true
 		}
 		if matched {
 			out[group.Name] = struct{}{}

--- a/sdk/cliproxy/auth/routing_groups_test.go
+++ b/sdk/cliproxy/auth/routing_groups_test.go
@@ -129,6 +129,77 @@ func TestAuthGroupsMatchesLegacyOAuthEmailAfterRename(t *testing.T) {
 	}
 }
 
+func TestAuthGroupsMatchesAnyDisplayTagDynamically(t *testing.T) {
+	t.Parallel()
+
+	cfg := &internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{
+					Name: "tag-pool",
+					Match: internalconfig.ChannelGroupMatch{
+						Tags: []string{"vip", "team-a"},
+					},
+				},
+			},
+		},
+	}
+	auth := &Auth{
+		Label:    "codex-account",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"custom_tags": []string{"vip"},
+		},
+	}
+
+	groups := authGroups(cfg, auth)
+	if _, ok := groups["tag-pool"]; !ok {
+		t.Fatalf("expected tag-pool from matching tag, got %v", groups)
+	}
+
+	auth.Metadata["custom_tags"] = []string{"other"}
+	groups = authGroups(cfg, auth)
+	if _, ok := groups["tag-pool"]; ok {
+		t.Fatalf("tag-pool should disappear after the matching tag is removed, got %v", groups)
+	}
+}
+
+func TestAuthGroupsIgnoresHiddenDisplayTags(t *testing.T) {
+	t.Parallel()
+
+	cfg := &internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{
+					Name: "pro-pool",
+					Match: internalconfig.ChannelGroupMatch{
+						Tags: []string{"pro"},
+					},
+				},
+			},
+		},
+	}
+	auth := &Auth{
+		Label:    "codex-account",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"plan_type":           "pro",
+			"hidden_default_tags": []string{"pro"},
+		},
+	}
+
+	groups := authGroups(cfg, auth)
+	if _, ok := groups["pro-pool"]; ok {
+		t.Fatalf("pro-pool should not match a hidden display tag, got %v", groups)
+	}
+
+	auth.Metadata["display_tags"] = []string{}
+	groups = authGroups(cfg, auth)
+	if _, ok := groups["pro-pool"]; ok {
+		t.Fatalf("pro-pool should not match an explicit empty display tag list, got %v", groups)
+	}
+}
+
 func TestDerivedGroupPriorityPreservesExplicitZero(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `match.tags` support to routing channel groups.
- Match auth channels by final display tags so tag changes dynamically affect group membership.
- Include tag metadata in channel-group management responses and cover dynamic tag matching with tests.

## Test Plan
- go test ./internal/config ./internal/api/handlers/management ./sdk/cliproxy/auth -count=1