### PR TITLE
Fix disabled provider channels in channel groups

### DIFF
--- a/internal/api/handlers/management/auth_tags.go
+++ b/internal/api/handlers/management/auth_tags.go
@@ -248,9 +248,10 @@ func metadataString(metadata map[string]any, keys ...string) string {
 }
 
 type channelGroupChannelDetail struct {
-	Name              string   `json:"name"`
-	Source            string   `json:"source,omitempty"`
-	Disabled          bool     `json:"disabled,omitempty"`
+	Name              string `json:"name"`
+	Source            string `json:"source,omitempty"`
+	Disabled          bool   `json:"disabled,omitempty"`
+	disabledAuthority int
 	DefaultTags       []string `json:"default_tags"`
 	CustomTags        []string `json:"custom_tags"`
 	HiddenDefaultTags []string `json:"hidden_default_tags"`
@@ -282,8 +283,20 @@ func uniqueSortedChannelDetails(values []channelGroupChannelDetail) []channelGro
 		}
 		key := strings.ToLower(name)
 		existing, ok := seen[key]
-		if !ok || tagPayloadScore(value) >= tagPayloadScore(existing) {
+		if !ok {
 			seen[key] = value
+			continue
+		}
+
+		disabled := mergedChannelDisabled(existing, value)
+		if tagPayloadScore(value) >= tagPayloadScore(existing) {
+			value.Disabled = disabled
+			value.disabledAuthority = max(existing.disabledAuthority, value.disabledAuthority)
+			seen[key] = value
+		} else {
+			existing.Disabled = disabled
+			existing.disabledAuthority = max(existing.disabledAuthority, value.disabledAuthority)
+			seen[key] = existing
 		}
 	}
 	if len(seen) == 0 {
@@ -300,9 +313,15 @@ func uniqueSortedChannelDetails(values []channelGroupChannelDetail) []channelGro
 }
 
 func tagPayloadScore(value channelGroupChannelDetail) int {
-	score := len(value.DisplayTags)*100 + len(value.DefaultTags)*10 + len(value.CustomTags)
-	if value.Disabled {
-		score -= 10000
+	return len(value.DisplayTags)*100 + len(value.DefaultTags)*10 + len(value.CustomTags)
+}
+
+func mergedChannelDisabled(existing channelGroupChannelDetail, value channelGroupChannelDetail) bool {
+	if existing.disabledAuthority > value.disabledAuthority {
+		return existing.Disabled
 	}
-	return score
+	if value.disabledAuthority > existing.disabledAuthority {
+		return value.Disabled
+	}
+	return existing.Disabled || value.Disabled
 }

--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -17,11 +17,17 @@ type channelDescriptor struct {
 	Prefix            string
 	Source            string
 	Disabled          bool
+	DisabledAuthority int
 	DefaultTags       []string
 	CustomTags        []string
 	HiddenDefaultTags []string
 	DisplayTags       []string
 }
+
+const (
+	channelDisabledAuthorityRuntime = 1
+	channelDisabledAuthorityConfig  = 2
+)
 
 type channelGroupItem struct {
 	Name           string                      `json:"name"`
@@ -39,7 +45,7 @@ type channelGroupItem struct {
 
 func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []channelDescriptor {
 	items := make([]channelDescriptor, 0)
-	push := func(name, prefix, source string, disabled bool, tags authTagPayload) {
+	push := func(name, prefix, source string, disabled bool, disabledAuthority int, tags authTagPayload) {
 		name = strings.TrimSpace(name)
 		prefix = internalrouting.NormalizeGroupName(prefix)
 		if name == "" && prefix == "" {
@@ -50,6 +56,7 @@ func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []cha
 			Prefix:            prefix,
 			Source:            source,
 			Disabled:          disabled,
+			DisabledAuthority: disabledAuthority,
 			DefaultTags:       append([]string{}, tags.DefaultTags...),
 			CustomTags:        append([]string{}, tags.CustomTags...),
 			HiddenDefaultTags: append([]string{}, tags.HiddenDefaultTags...),
@@ -59,19 +66,25 @@ func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []cha
 
 	if cfg != nil {
 		for _, entry := range cfg.GeminiKey {
-			push(entry.Name, entry.Prefix, "gemini", false, buildAuthTagPayloadFromValues("gemini", nil))
+			push(entry.Name, entry.Prefix, "gemini", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, buildAuthTagPayloadFromValues("gemini", nil))
 		}
 		for _, entry := range cfg.ClaudeKey {
-			push(entry.Name, entry.Prefix, "claude", false, buildAuthTagPayloadFromValues("claude", nil))
+			push(entry.Name, entry.Prefix, "claude", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, buildAuthTagPayloadFromValues("claude", nil))
+		}
+		for _, entry := range cfg.BedrockKey {
+			push(entry.Name, entry.Prefix, "bedrock", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, buildAuthTagPayloadFromValues("bedrock", nil))
 		}
 		for _, entry := range cfg.CodexKey {
-			push(entry.Name, entry.Prefix, "codex", false, buildAuthTagPayloadFromValues("codex", nil))
+			push(entry.Name, entry.Prefix, "codex", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, buildAuthTagPayloadFromValues("codex", nil))
+		}
+		for _, entry := range cfg.OpenCodeGoKey {
+			push(entry.Name, entry.Prefix, "opencode-go", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, buildAuthTagPayloadFromValues("opencode-go", nil))
 		}
 		for _, entry := range cfg.VertexCompatAPIKey {
-			push("", entry.Prefix, "vertex", false, buildAuthTagPayloadFromValues("vertex", nil))
+			push("", entry.Prefix, "vertex", false, channelDisabledAuthorityConfig, buildAuthTagPayloadFromValues("vertex", nil))
 		}
 		for _, entry := range cfg.OpenAICompatibility {
-			push(entry.Name, entry.Prefix, "openai", entry.Disabled, buildAuthTagPayloadFromValues("openai", nil))
+			push(entry.Name, entry.Prefix, "openai", entry.Disabled, channelDisabledAuthorityConfig, buildAuthTagPayloadFromValues("openai", nil))
 		}
 	}
 
@@ -83,12 +96,39 @@ func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []cha
 			auth.ChannelName(),
 			auth.Prefix,
 			auth.Provider,
-			auth.Disabled || auth.Status == coreauth.StatusDisabled,
+			authChannelDisabled(auth),
+			channelDisabledAuthorityRuntime,
 			buildAuthTagPayload(auth),
 		)
 	}
 
 	return items
+}
+
+func providerExcludesAllModels(excludedModels []string) bool {
+	for _, model := range excludedModels {
+		if strings.TrimSpace(model) == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func authExcludesAllModels(auth *coreauth.Auth) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Attributes["auth_kind"]), "apikey") {
+		return false
+	}
+	return providerExcludesAllModels(strings.Split(auth.Attributes["excluded_models"], ","))
+}
+
+func authChannelDisabled(auth *coreauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	return auth.Disabled || auth.Status == coreauth.StatusDisabled || authExcludesAllModels(auth)
 }
 
 func includeAuthInChannelGroups(auth *coreauth.Auth) bool {
@@ -201,6 +241,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 					Name:              channelName,
 					Source:            channel.Source,
 					Disabled:          channel.Disabled,
+					disabledAuthority: channel.DisabledAuthority,
 					DefaultTags:       append([]string{}, channel.DefaultTags...),
 					CustomTags:        append([]string{}, channel.CustomTags...),
 					HiddenDefaultTags: append([]string{}, channel.HiddenDefaultTags...),

--- a/internal/api/handlers/management/channel_groups_test.go
+++ b/internal/api/handlers/management/channel_groups_test.go
@@ -580,6 +580,219 @@ func TestBuildChannelGroupItemsMarksDisabledOpenAICompatChannels(t *testing.T) {
 	}
 }
 
+func TestBuildChannelGroupItemsMarksProviderKeysWithDisableAllModelsRule(t *testing.T) {
+	cfg := &config.Config{
+		CodexKey: []config.CodexKey{
+			{
+				APIKey:         "sk-codex-disabled",
+				Name:           "Codex Disabled",
+				Prefix:         "team-codex",
+				ExcludedModels: []string{"*"},
+			},
+			{
+				APIKey: "sk-codex-enabled",
+				Name:   "Codex Enabled",
+				Prefix: "team-codex",
+			},
+		},
+		OpenCodeGoKey: []config.OpenCodeGoKey{
+			{
+				APIKey:         "sk-opencode-disabled",
+				Name:           "OpenCode Disabled",
+				Prefix:         "team-opencode",
+				ExcludedModels: []string{"minimax-m2.5", "*"},
+			},
+		},
+	}
+	auths := []*coreauth.Auth{
+		{
+			ID:       "config-codex-disabled",
+			Label:    "Codex Disabled",
+			Prefix:   "team-codex",
+			Provider: "codex",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				"auth_kind":       "apikey",
+				"excluded_models": "*",
+				"source":          "config:codex[disabled]",
+			},
+		},
+		{
+			ID:       "config-codex-enabled",
+			Label:    "Codex Enabled",
+			Prefix:   "team-codex",
+			Provider: "codex",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				"auth_kind": "apikey",
+				"source":    "config:codex[enabled]",
+			},
+		},
+		{
+			ID:       "config-opencode-disabled",
+			Label:    "OpenCode Disabled",
+			Prefix:   "team-opencode",
+			Provider: "opencode-go",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				"auth_kind":       "apikey",
+				"excluded_models": "minimax-m2.5,*",
+				"source":          "config:opencode-go[disabled]",
+			},
+		},
+	}
+
+	items := buildChannelGroupItems(cfg, auths)
+	byName := make(map[string]channelGroupItem, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+
+	codexGroup, ok := byName["team-codex"]
+	if !ok {
+		t.Fatal("expected team-codex group for configured Codex channels")
+	}
+	if len(codexGroup.ChannelDetails) != 2 {
+		t.Fatalf("codex channel details = %#v, want two details", codexGroup.ChannelDetails)
+	}
+	codexDetails := make(map[string]channelGroupChannelDetail, len(codexGroup.ChannelDetails))
+	for _, detail := range codexGroup.ChannelDetails {
+		codexDetails[detail.Name] = detail
+	}
+	if !codexDetails["Codex Disabled"].Disabled {
+		t.Fatalf("Codex Disabled detail = %#v, want disabled=true", codexDetails["Codex Disabled"])
+	}
+	if codexDetails["Codex Enabled"].Disabled {
+		t.Fatalf("Codex Enabled detail = %#v, want disabled=false", codexDetails["Codex Enabled"])
+	}
+
+	opencodeGroup, ok := byName["team-opencode"]
+	if !ok {
+		t.Fatal("expected team-opencode group for configured OpenCode Go channel")
+	}
+	if len(opencodeGroup.ChannelDetails) != 1 {
+		t.Fatalf("opencode channel details = %#v, want one detail", opencodeGroup.ChannelDetails)
+	}
+	if !opencodeGroup.ChannelDetails[0].Disabled {
+		t.Fatalf("OpenCode detail = %#v, want disabled=true", opencodeGroup.ChannelDetails[0])
+	}
+}
+
+func TestBuildChannelGroupItemsKeepsConfigDisabledStateWhenSynthesizedAuthIsStale(t *testing.T) {
+	cfg := &config.Config{
+		CodexKey: []config.CodexKey{
+			{
+				APIKey:         "sk-codex-disabled",
+				Name:           "Codex Disabled",
+				Prefix:         "team-codex",
+				ExcludedModels: []string{"*"},
+			},
+		},
+	}
+	auths := []*coreauth.Auth{
+		{
+			ID:       "config-codex-stale",
+			Label:    "Codex Disabled",
+			Prefix:   "team-codex",
+			Provider: "codex",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				"auth_kind": "apikey",
+				"source":    "config:codex[stale]",
+			},
+		},
+	}
+
+	items := buildChannelGroupItems(cfg, auths)
+	byName := make(map[string]channelGroupItem, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+
+	codexGroup, ok := byName["team-codex"]
+	if !ok {
+		t.Fatal("expected team-codex group")
+	}
+	if len(codexGroup.ChannelDetails) != 1 {
+		t.Fatalf("codex channel details = %#v, want one deduped detail", codexGroup.ChannelDetails)
+	}
+	if !codexGroup.ChannelDetails[0].Disabled {
+		t.Fatalf("Codex detail = %#v, want disabled=true from latest config", codexGroup.ChannelDetails[0])
+	}
+}
+
+func TestBuildChannelGroupItemsKeepsConfigEnabledStateWhenSynthesizedAuthIsStale(t *testing.T) {
+	cfg := &config.Config{
+		CodexKey: []config.CodexKey{
+			{
+				APIKey: "sk-codex-enabled",
+				Name:   "Codex Enabled",
+				Prefix: "team-codex",
+			},
+		},
+	}
+	auths := []*coreauth.Auth{
+		{
+			ID:       "config-codex-stale-disabled",
+			Label:    "Codex Enabled",
+			Prefix:   "team-codex",
+			Provider: "codex",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				"auth_kind":       "apikey",
+				"excluded_models": "*",
+				"source":          "config:codex[stale-disabled]",
+			},
+		},
+	}
+
+	items := buildChannelGroupItems(cfg, auths)
+	byName := make(map[string]channelGroupItem, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+
+	codexGroup, ok := byName["team-codex"]
+	if !ok {
+		t.Fatal("expected team-codex group")
+	}
+	if len(codexGroup.ChannelDetails) != 1 {
+		t.Fatalf("codex channel details = %#v, want one deduped detail", codexGroup.ChannelDetails)
+	}
+	if codexGroup.ChannelDetails[0].Disabled {
+		t.Fatalf("Codex detail = %#v, want disabled=false from latest config", codexGroup.ChannelDetails[0])
+	}
+}
+
+func TestCollectKnownChannelsIncludesBedrockConfigChannels(t *testing.T) {
+	cfg := &config.Config{
+		BedrockKey: []config.BedrockKey{
+			{
+				Name:            "Bedrock SigV4",
+				AuthMode:        config.BedrockAuthModeSigV4,
+				AccessKeyID:     "AKIA",
+				SecretAccessKey: "SECRET",
+			},
+			{
+				Name:     "Bedrock API",
+				AuthMode: config.BedrockAuthModeAPIKey,
+				APIKey:   "bedrock-api-key",
+			},
+		},
+	}
+
+	known, err := collectKnownChannels(cfg, nil, "")
+	if err != nil {
+		t.Fatalf("collectKnownChannels() error = %v", err)
+	}
+	if got := known["bedrock sigv4"].Canonical; got != "Bedrock SigV4" {
+		t.Fatalf("Bedrock SigV4 canonical = %q, want Bedrock SigV4", got)
+	}
+	if got := known["bedrock api"].Canonical; got != "Bedrock API" {
+		t.Fatalf("Bedrock API canonical = %q, want Bedrock API", got)
+	}
+}
+
 func TestBuildChannelGroupItemsDoesNotSurfaceDeletedConfiguredChannels(t *testing.T) {
 	cfg := &config.Config{
 		Routing: config.RoutingConfig{

--- a/internal/api/handlers/management/channel_names.go
+++ b/internal/api/handlers/management/channel_names.go
@@ -130,6 +130,14 @@ func collectKnownChannelsWithPolicy(cfg *config.Config, auths []*coreauth.Auth, 
 				return nil, err
 			}
 		}
+		for _, entry := range cfg.BedrockKey {
+			if strings.TrimSpace(entry.GetAPIKey()) == "" {
+				continue
+			}
+			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "Bedrock API key config", failOnConflict); err != nil {
+				return nil, err
+			}
+		}
 		for _, entry := range cfg.CodexKey {
 			if strings.TrimSpace(entry.APIKey) == "" {
 				continue


### PR DESCRIPTION
## Summary
- mark provider key channels disabled in channel group details when all models are excluded
- preserve current config disabled state when deduping channel details with synthesized auth entries
- include Bedrock config channels in known channel validation

## Tests
- go test ./internal/api/handlers/management -count=1
- go test ./internal/watcher/synthesizer -count=1
- git diff --check