### PR TITLE
Fix Codex auth JSON normalization

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1273,9 +1274,17 @@ func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		return fmt.Errorf("invalid auth file: %w", err)
 	}
-	provider, _ := metadata["type"].(string)
-	if provider == "" {
-		provider = "unknown"
+	provider := sdkAuth.InferAuthProvider(metadata)
+	normalized := sdkAuth.NormalizeAuthMetadata(metadata, provider)
+	if !reflect.DeepEqual(metadata, normalized) {
+		metadata = normalized
+		normalizedData, errMarshal := json.Marshal(metadata)
+		if errMarshal != nil {
+			return fmt.Errorf("failed to normalize auth file: %w", errMarshal)
+		}
+		if errWrite := os.WriteFile(path, normalizedData, 0o600); errWrite != nil {
+			return fmt.Errorf("failed to write normalized auth file: %w", errWrite)
+		}
 	}
 	label := authChannelLabelFromMetadata(metadata, provider)
 	lastRefresh, hasLastRefresh := extractLastRefreshTimestamp(metadata)

--- a/internal/api/handlers/management/auth_files_upload_test.go
+++ b/internal/api/handlers/management/auth_files_upload_test.go
@@ -3,12 +3,15 @@ package management
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
@@ -150,6 +153,145 @@ func TestRegisterAuthFromFileAppliesRoutingMetadata(t *testing.T) {
 	if auth.ProxyID != "premium-egress" {
 		t.Fatalf("ProxyID = %q, want premium-egress", auth.ProxyID)
 	}
+}
+
+func TestRegisterAuthFromFileInfersCodexProviderForOpenAIOAuthJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	h := &Handler{
+		cfg: &config.Config{
+			AuthDir: authDir,
+		},
+		authManager: manager,
+	}
+
+	fileName := "openai-oauth.json"
+	absPath := filepath.Join(authDir, fileName)
+	data := []byte(`{"chatgpt_account_id":"acct-123","client_id":"app_test","access_token":"access-token","id_token":"id-token","email":"subscriber@example.com","plan_type":"plus"}`)
+	if err := os.WriteFile(absPath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := h.registerAuthFromFile(context.Background(), absPath, data); err != nil {
+		t.Fatalf("registerAuthFromFile: %v", err)
+	}
+
+	auth, ok := manager.GetByID(fileName)
+	if !ok || auth == nil {
+		t.Fatalf("registered auth not found")
+	}
+	if auth.Provider != "codex" {
+		t.Fatalf("Provider = %q, want codex", auth.Provider)
+	}
+	if auth.Metadata["type"] != "codex" {
+		t.Fatalf("metadata type = %#v, want codex", auth.Metadata["type"])
+	}
+}
+
+func TestRegisterAuthFromFileNormalizesOpenAIBundleJSONForCodex(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	h := &Handler{
+		cfg: &config.Config{
+			AuthDir: authDir,
+		},
+		authManager: manager,
+	}
+
+	accountID := "acct-bundle"
+	issuedAt := int64(1_779_210_280)
+	expiresAt := int64(1_780_074_280)
+	accessToken := makeJWTForAuthFilesUploadTest(t, map[string]any{
+		"iat": issuedAt,
+		"exp": expiresAt,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": accountID,
+			"chatgpt_plan_type":  "plus",
+		},
+	})
+	idToken := makeJWTForAuthFilesUploadTest(t, map[string]any{
+		"email": "bundle@example.com",
+		"iat":   issuedAt,
+		"exp":   expiresAt,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": accountID,
+			"chatgpt_plan_type":  "plus",
+		},
+	})
+	fileName := "openai-bundle.json"
+	absPath := filepath.Join(authDir, fileName)
+	data, err := json.Marshal(map[string]any{
+		"version":              1,
+		"platform":             "openai",
+		"account_claims_email": "bundle@example.com",
+		"access_token":         accessToken,
+		"id_token":             idToken,
+		"refresh_token":        "",
+		"client_id":            "app_test",
+		"chatgpt_account_id":   accountID,
+		"disabled":             false,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(absPath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := h.registerAuthFromFile(context.Background(), absPath, data); err != nil {
+		t.Fatalf("registerAuthFromFile: %v", err)
+	}
+
+	auth, ok := manager.GetByID(fileName)
+	if !ok || auth == nil {
+		t.Fatalf("registered auth not found")
+	}
+	if auth.Provider != "codex" {
+		t.Fatalf("Provider = %q, want codex", auth.Provider)
+	}
+	wantExpired := time.Unix(expiresAt, 0).UTC().Format(time.RFC3339)
+	wantLastRefresh := time.Unix(issuedAt, 0).UTC().Format(time.RFC3339)
+	for key, want := range map[string]any{
+		"type":         "codex",
+		"account_id":   accountID,
+		"email":        "bundle@example.com",
+		"expired":      wantExpired,
+		"last_refresh": wantLastRefresh,
+		"plan_type":    "plus",
+	} {
+		if got := auth.Metadata[key]; got != want {
+			t.Fatalf("metadata[%s] = %#v, want %#v", key, got, want)
+		}
+	}
+	raw, err := os.ReadFile(absPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var persisted map[string]any
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("Unmarshal persisted: %v", err)
+	}
+	if persisted["account_id"] != accountID || persisted["type"] != "codex" {
+		t.Fatalf("persisted normalized fields = %#v", persisted)
+	}
+}
+
+func makeJWTForAuthFilesUploadTest(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	encode := func(v any) string {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal jwt part: %v", err)
+		}
+		return base64.RawURLEncoding.EncodeToString(raw)
+	}
+	return encode(map[string]any{"alg": "none", "typ": "JWT"}) + "." + encode(claims) + ".sig"
 }
 
 func TestImportVertexCredentialRejectsOversizedMultipart(t *testing.T) {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -2,13 +2,17 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -187,9 +191,18 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 	if err = json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("unmarshal auth json: %w", err)
 	}
-	provider, _ := metadata["type"].(string)
-	if provider == "" {
-		provider = "unknown"
+	provider := InferAuthProvider(metadata)
+	if provider == "codex" {
+		normalized := NormalizeAuthMetadata(metadata, provider)
+		if !reflect.DeepEqual(metadata, normalized) {
+			metadata = normalized
+			if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
+				if file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); errOpen == nil {
+					_, _ = file.Write(raw)
+					_ = file.Close()
+				}
+			}
+		}
 	}
 	if provider == "antigravity" || provider == "gemini" {
 		projectID := ""
@@ -269,6 +282,140 @@ func metadataString(metadata map[string]any, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// InferAuthProvider returns the explicit provider type, or derives it for
+// credential JSON shapes that are produced by supported OAuth flows.
+func InferAuthProvider(metadata map[string]any) string {
+	provider := metadataString(metadata, "type")
+	if provider == "" && isCodexOAuthMetadata(metadata) {
+		provider = "codex"
+		if metadata != nil {
+			metadata["type"] = provider
+		}
+	}
+	if provider == "" {
+		return "unknown"
+	}
+	return provider
+}
+
+func isCodexOAuthMetadata(metadata map[string]any) bool {
+	if len(metadata) == 0 {
+		return false
+	}
+	hasAccount := metadataString(metadata, "chatgpt_account_id", "chatgptAccountID", "account_id") != ""
+	hasToken := metadataString(metadata, "access_token", "id_token", "refresh_token", "session_token") != ""
+	hasOpenAIClient := strings.HasPrefix(metadataString(metadata, "client_id"), "app_")
+	hasCodexClaims := metadataString(metadata, "chatgpt_plan_type", "account_claims_email") != ""
+	return hasToken && (hasAccount || hasOpenAIClient || hasCodexClaims)
+}
+
+// NormalizeAuthMetadata fills canonical fields expected by provider executors
+// while preserving any source-specific metadata that may be useful later.
+func NormalizeAuthMetadata(metadata map[string]any, provider string) map[string]any {
+	if len(metadata) == 0 {
+		return metadata
+	}
+	normalized := maps.Clone(metadata)
+	if strings.EqualFold(strings.TrimSpace(provider), "codex") {
+		normalizeCodexAuthMetadata(normalized)
+	}
+	return normalized
+}
+
+func normalizeCodexAuthMetadata(metadata map[string]any) {
+	if metadata == nil {
+		return
+	}
+	metadata["type"] = "codex"
+	if accountID := metadataString(metadata, "account_id", "chatgpt_account_id", "chatgptAccountID"); accountID != "" {
+		metadata["account_id"] = accountID
+	}
+	if email := metadataString(metadata, "email", "account_claims_email", "accountClaimsEmail"); email != "" {
+		metadata["email"] = email
+	}
+	if planType := strings.ToLower(metadataString(metadata, "plan_type", "planType", "chatgpt_plan_type")); planType != "" {
+		metadata["plan_type"] = planType
+	}
+	normalizeCodexMetadataFromJWT(metadataString(metadata, "id_token"), metadata)
+	normalizeCodexMetadataFromJWT(metadataString(metadata, "access_token"), metadata)
+}
+
+func normalizeCodexMetadataFromJWT(token string, metadata map[string]any) {
+	claims, ok := parseJWTClaimsMap(token)
+	if !ok {
+		return
+	}
+	if metadataString(metadata, "email") == "" {
+		if email, ok := claims["email"].(string); ok && strings.TrimSpace(email) != "" {
+			metadata["email"] = strings.TrimSpace(email)
+		}
+	}
+	if metadataString(metadata, "expired") == "" {
+		if exp, ok := jwtNumericClaim(claims, "exp"); ok && exp > 0 {
+			metadata["expired"] = time.Unix(exp, 0).UTC().Format(time.RFC3339)
+		}
+	}
+	if metadataString(metadata, "last_refresh") == "" {
+		if iat, ok := jwtNumericClaim(claims, "iat"); ok && iat > 0 {
+			metadata["last_refresh"] = time.Unix(iat, 0).UTC().Format(time.RFC3339)
+		}
+	}
+	authClaims, _ := claims["https://api.openai.com/auth"].(map[string]any)
+	if len(authClaims) == 0 {
+		return
+	}
+	if metadataString(metadata, "account_id") == "" {
+		if accountID := metadataString(authClaims, "account_id", "chatgpt_account_id"); accountID != "" {
+			metadata["account_id"] = accountID
+		}
+	}
+	if metadataString(metadata, "plan_type") == "" {
+		if planType := strings.ToLower(metadataString(authClaims, "chatgpt_plan_type", "plan_type")); planType != "" {
+			metadata["plan_type"] = planType
+		}
+	}
+}
+
+func parseJWTClaimsMap(token string) (map[string]any, bool) {
+	token = strings.TrimSpace(token)
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+	}
+	if err != nil {
+		return nil, false
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, false
+	}
+	return claims, true
+}
+
+func jwtNumericClaim(claims map[string]any, key string) (int64, bool) {
+	switch value := claims[key].(type) {
+	case float64:
+		return int64(value), value > 0
+	case int64:
+		return value, value > 0
+	case int:
+		return int64(value), value > 0
+	case json.Number:
+		if i, err := value.Int64(); err == nil && i > 0 {
+			return i, true
+		}
+	case string:
+		if i, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil && i > 0 {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 func syncRoutingMetadata(auth *cliproxyauth.Auth) {

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -113,6 +114,109 @@ func TestFileTokenStoreListAppliesRoutingMetadata(t *testing.T) {
 	}
 	if auth.ProxyID != "premium-egress" {
 		t.Fatalf("ProxyID = %q, want premium-egress", auth.ProxyID)
+	}
+}
+
+func TestFileTokenStoreListInfersCodexProviderForOpenAIOAuthJSON(t *testing.T) {
+	dir := t.TempDir()
+	fileName := "openai-oauth.json"
+	data := []byte(`{"chatgpt_account_id":"acct-123","client_id":"app_test","access_token":"access-token","id_token":"id-token","email":"subscriber@example.com","plan_type":"plus"}`)
+	if err := os.WriteFile(filepath.Join(dir, fileName), data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	if auths[0].Provider != "codex" {
+		t.Fatalf("Provider = %q, want codex", auths[0].Provider)
+	}
+	if auths[0].Metadata["type"] != "codex" {
+		t.Fatalf("metadata type = %#v, want codex", auths[0].Metadata["type"])
+	}
+}
+
+func TestFileTokenStoreListNormalizesOpenAIBundleJSONForCodex(t *testing.T) {
+	dir := t.TempDir()
+	fileName := "openai-bundle.json"
+	accountID := "acct-bundle"
+	issuedAt := int64(1_779_210_280)
+	expiresAt := int64(1_780_074_280)
+	accessToken := makeJWTForTest(t, map[string]any{
+		"iat": issuedAt,
+		"exp": expiresAt,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": accountID,
+			"chatgpt_plan_type":  "plus",
+		},
+	})
+	idToken := makeJWTForTest(t, map[string]any{
+		"email": "bundle@example.com",
+		"iat":   issuedAt,
+		"exp":   expiresAt,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": accountID,
+			"chatgpt_plan_type":  "plus",
+		},
+	})
+	data, err := json.Marshal(map[string]any{
+		"version":              1,
+		"platform":             "openai",
+		"account_claims_email": "bundle@example.com",
+		"access_token":         accessToken,
+		"id_token":             idToken,
+		"refresh_token":        "",
+		"client_id":            "app_test",
+		"chatgpt_account_id":   accountID,
+		"disabled":             false,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	path := filepath.Join(dir, fileName)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	wantExpired := time.Unix(expiresAt, 0).UTC().Format(time.RFC3339)
+	wantLastRefresh := time.Unix(issuedAt, 0).UTC().Format(time.RFC3339)
+	for key, want := range map[string]any{
+		"type":         "codex",
+		"account_id":   accountID,
+		"email":        "bundle@example.com",
+		"expired":      wantExpired,
+		"last_refresh": wantLastRefresh,
+		"plan_type":    "plus",
+	} {
+		if got := auths[0].Metadata[key]; got != want {
+			t.Fatalf("metadata[%s] = %#v, want %#v", key, got, want)
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var persisted map[string]any
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("Unmarshal persisted: %v", err)
+	}
+	if persisted["account_id"] != accountID || persisted["type"] != "codex" {
+		t.Fatalf("persisted normalized fields = %#v", persisted)
 	}
 }
 


### PR DESCRIPTION
## Summary
- infer Codex provider for supported OpenAI OAuth auth JSON without an explicit type
- normalize supported OpenAI bundle-shaped JSON into canonical Codex auth metadata fields
- persist normalized metadata during upload registration and file-store reloads

## Verification
- go test ./internal/api/handlers/management ./sdk/auth
- git diff --check