### PR TITLE
fix: preserve auth quota cooldown across refresh

### DIFF
--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -365,12 +365,6 @@ func (r *ModelRegistry) RegisterClient(clientID, clientProvider string, models [
 				reg.InfoByProvider[provider] = cloneModelInfo(model)
 			}
 			reg.LastUpdated = now
-			if reg.QuotaExceededClients != nil {
-				delete(reg.QuotaExceededClients, clientID)
-			}
-			if reg.SuspendedClients != nil {
-				delete(reg.SuspendedClients, clientID)
-			}
 			if providerChanged && provider != "" {
 				if _, newlyAdded := addedSet[id]; newlyAdded {
 					continue

--- a/internal/registry/model_registry_quota_test.go
+++ b/internal/registry/model_registry_quota_test.go
@@ -1,0 +1,25 @@
+package registry
+
+import "testing"
+
+func TestRegisterClientPreservesQuotaAndSuspensionForExistingModel(t *testing.T) {
+	r := newTestModelRegistry()
+	model := "gpt-5.5"
+
+	r.RegisterClient("client-1", "codex", []*ModelInfo{{ID: model, DisplayName: "GPT 5.5"}})
+	r.SetModelQuotaExceeded("client-1", model)
+	r.SuspendClientModel("client-1", model, "quota")
+
+	r.RegisterClient("client-1", "codex", []*ModelInfo{{ID: model, DisplayName: "GPT 5.5 updated"}})
+
+	registration := r.models[model]
+	if registration == nil {
+		t.Fatalf("expected model registration to be present")
+	}
+	if _, ok := registration.QuotaExceededClients["client-1"]; !ok {
+		t.Fatalf("expected quota exceeded marker to survive model re-registration")
+	}
+	if reason, ok := registration.SuspendedClients["client-1"]; !ok || reason != "quota" {
+		t.Fatalf("expected suspension marker to survive model re-registration, got reason=%q ok=%v", reason, ok)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -553,6 +553,10 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	auth.EnsureIndex()
 	snapshot := auth.Clone()
+	if previous != nil {
+		preserveRuntimeFields(snapshot, previous)
+		preserveAvailabilityRuntimeForUpdate(snapshot, previous, time.Now())
+	}
 	m.auths[auth.ID] = snapshot
 	m.mu.Unlock()
 	if err := m.persist(ctx, snapshot); err != nil {
@@ -1444,18 +1448,28 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		if result.Success {
 			if result.Model != "" {
 				state := ensureModelState(auth, result.Model)
-				resetModelState(state, now)
-				updateAggregatedAvailability(auth, now)
-				if !hasModelError(auth, now) {
-					auth.LastError = nil
-					auth.StatusMessage = ""
-					auth.Status = StatusActive
+				if activeModelQuotaCooldown(state, now) {
+					updateAggregatedAvailability(auth, now)
+					auth.UpdatedAt = now
+				} else {
+					resetModelState(state, now)
+					updateAggregatedAvailability(auth, now)
+					if !hasModelError(auth, now) {
+						auth.LastError = nil
+						auth.StatusMessage = ""
+						auth.Status = StatusActive
+					}
+					auth.UpdatedAt = now
+					shouldResumeModel = true
+					clearModelQuota = true
 				}
-				auth.UpdatedAt = now
-				shouldResumeModel = true
-				clearModelQuota = true
 			} else {
-				clearAuthStateOnSuccess(auth, now)
+				if activeAuthQuotaCooldown(auth, now) {
+					updateAggregatedAvailability(auth, now)
+					auth.UpdatedAt = now
+				} else {
+					clearAuthStateOnSuccess(auth, now)
+				}
 			}
 		} else {
 			if result.Model != "" {
@@ -1647,6 +1661,62 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		auth.Quota.NextRecoverAt = time.Time{}
 		auth.Quota.BackoffLevel = 0
 	}
+}
+
+func activeModelQuotaCooldown(state *ModelState, now time.Time) bool {
+	if state == nil {
+		return false
+	}
+	return activeQuotaCooldown(state.Quota, state.NextRetryAfter, now)
+}
+
+func activeAuthQuotaCooldown(auth *Auth, now time.Time) bool {
+	if auth == nil {
+		return false
+	}
+	return activeQuotaCooldown(auth.Quota, auth.NextRetryAfter, now)
+}
+
+func activeQuotaCooldown(quota QuotaState, retryAfter time.Time, now time.Time) bool {
+	if !quota.Exceeded {
+		return false
+	}
+	if !quota.NextRecoverAt.IsZero() {
+		return quota.NextRecoverAt.After(now)
+	}
+	return !retryAfter.IsZero() && retryAfter.After(now)
+}
+
+func activeModelRuntimeState(state *ModelState, now time.Time) bool {
+	if state == nil {
+		return false
+	}
+	if activeModelQuotaCooldown(state, now) {
+		return true
+	}
+	if state.Unavailable {
+		return state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now)
+	}
+	if state.Status == StatusError && state.LastError != nil {
+		return state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now)
+	}
+	return false
+}
+
+func activeAuthRuntimeState(auth *Auth, now time.Time) bool {
+	if auth == nil {
+		return false
+	}
+	if activeAuthQuotaCooldown(auth, now) {
+		return true
+	}
+	if auth.Unavailable {
+		return auth.NextRetryAfter.IsZero() || auth.NextRetryAfter.After(now)
+	}
+	if auth.Status == StatusError && auth.LastError != nil {
+		return auth.NextRetryAfter.IsZero() || auth.NextRetryAfter.After(now)
+	}
+	return false
 }
 
 func hasModelError(auth *Auth, now time.Time) bool {
@@ -2732,6 +2802,75 @@ func preserveRuntimeFields(dst *Auth, src *Auth) {
 	if dst.FileName == "" {
 		dst.FileName = src.FileName
 	}
+}
+
+func preserveAvailabilityRuntimeForUpdate(dst *Auth, src *Auth, now time.Time) {
+	if dst == nil || src == nil {
+		return
+	}
+	if dst.Disabled || dst.Status == StatusDisabled {
+		return
+	}
+
+	preservedModelState := false
+	if len(src.ModelStates) > 0 {
+		if dst.ModelStates == nil {
+			dst.ModelStates = make(map[string]*ModelState, len(src.ModelStates))
+		}
+		for model, srcState := range src.ModelStates {
+			if !shouldPreserveModelRuntimeState(dst.ModelStates[model], srcState, now) {
+				continue
+			}
+			dst.ModelStates[model] = srcState.Clone()
+			preservedModelState = true
+		}
+	}
+
+	if preservedModelState {
+		updateAggregatedAvailability(dst, now)
+		if dst.Status == "" || dst.Status == StatusUnknown || dst.Status == StatusActive {
+			dst.Status = src.Status
+		}
+		if dst.StatusMessage == "" {
+			dst.StatusMessage = src.StatusMessage
+		}
+		if dst.LastError == nil {
+			dst.LastError = cloneError(src.LastError)
+		}
+	}
+
+	if !shouldPreserveAuthRuntimeState(dst, src, now) {
+		return
+	}
+	dst.Unavailable = src.Unavailable
+	dst.Status = src.Status
+	dst.StatusMessage = src.StatusMessage
+	dst.LastError = cloneError(src.LastError)
+	dst.Quota = src.Quota
+	dst.NextRetryAfter = src.NextRetryAfter
+}
+
+func shouldPreserveModelRuntimeState(dst *ModelState, src *ModelState, now time.Time) bool {
+	if !activeModelRuntimeState(src, now) {
+		return false
+	}
+	if dst == nil {
+		return true
+	}
+	if dst.Status == StatusDisabled {
+		return false
+	}
+	return !activeModelRuntimeState(dst, now)
+}
+
+func shouldPreserveAuthRuntimeState(dst *Auth, src *Auth, now time.Time) bool {
+	if !activeAuthRuntimeState(src, now) {
+		return false
+	}
+	if dst.Disabled || dst.Status == StatusDisabled {
+		return false
+	}
+	return !activeAuthRuntimeState(dst, now)
 }
 
 func canKeepRefreshFailureActive(auth *Auth, now time.Time) bool {

--- a/sdk/cliproxy/auth/conductor_runtime_quota_test.go
+++ b/sdk/cliproxy/auth/conductor_runtime_quota_test.go
@@ -1,0 +1,175 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestManagerUpdatePreservesRuntimeQuotaState(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "gpt-5.5"
+
+	if _, err := m.Register(ctx, &Auth{
+		ID:       "auth-1",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token": "old-token",
+		},
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	retryAfter := 2 * time.Hour
+	m.MarkResult(ctx, Result{
+		AuthID:     "auth-1",
+		Provider:   "codex",
+		Model:      model,
+		Success:    false,
+		RetryAfter: &retryAfter,
+		Error: &Error{
+			Code:               "usage_limit_reached",
+			Message:            "usage limit reached",
+			HTTPStatus:         429,
+			QuotaWindow:        "5h",
+			QuotaWindowMinutes: 300,
+		},
+	})
+
+	before, ok := m.GetByID("auth-1")
+	if !ok {
+		t.Fatalf("expected auth to be present")
+	}
+	beforeState := before.ModelStates[model]
+	if beforeState == nil || !beforeState.Quota.Exceeded {
+		t.Fatalf("test setup failed: expected model quota to be exceeded")
+	}
+
+	updated, err := m.Update(ctx, &Auth{
+		ID:       "auth-1",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token": "new-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected runtime model state to survive update")
+	}
+	if !state.Quota.Exceeded {
+		t.Fatalf("state.Quota.Exceeded = false, want true")
+	}
+	if !state.NextRetryAfter.Equal(beforeState.NextRetryAfter) {
+		t.Fatalf("state.NextRetryAfter = %v, want %v", state.NextRetryAfter, beforeState.NextRetryAfter)
+	}
+	if !updated.Quota.Exceeded {
+		t.Fatalf("auth.Quota.Exceeded = false, want true")
+	}
+	if !updated.Unavailable {
+		t.Fatalf("auth.Unavailable = false, want true")
+	}
+}
+
+func TestManagerUpdateDoesNotPreserveRuntimeQuotaWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "gpt-5.5"
+
+	if _, err := m.Register(ctx, &Auth{ID: "auth-1", Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	retryAfter := 2 * time.Hour
+	m.MarkResult(ctx, Result{
+		AuthID:     "auth-1",
+		Provider:   "codex",
+		Model:      model,
+		Success:    false,
+		RetryAfter: &retryAfter,
+		Error:      &Error{Code: "usage_limit_reached", Message: "usage limit reached", HTTPStatus: 429},
+	})
+
+	updated, err := m.Update(ctx, &Auth{
+		ID:       "auth-1",
+		Provider: "codex",
+		Status:   StatusDisabled,
+		Disabled: true,
+	})
+	if err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+
+	if updated.Quota.Exceeded {
+		t.Fatalf("auth.Quota.Exceeded = true, want false for disabled auth update")
+	}
+	if updated.Unavailable {
+		t.Fatalf("auth.Unavailable = true, want false for disabled auth update")
+	}
+	if len(updated.ModelStates) != 0 {
+		t.Fatalf("expected no preserved model states for disabled auth update, got %d", len(updated.ModelStates))
+	}
+	if !updated.Disabled || updated.Status != StatusDisabled {
+		t.Fatalf("expected disabled status to be preserved, got disabled=%v status=%q", updated.Disabled, updated.Status)
+	}
+}
+
+func TestManagerMarkResultSuccessKeepsActiveQuotaCooldown(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "gpt-5.5"
+
+	if _, err := m.Register(ctx, &Auth{ID: "auth-1", Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	retryAfter := 2 * time.Hour
+	m.MarkResult(ctx, Result{
+		AuthID:     "auth-1",
+		Provider:   "codex",
+		Model:      model,
+		Success:    false,
+		RetryAfter: &retryAfter,
+		Error:      &Error{Code: "usage_limit_reached", Message: "usage limit reached", HTTPStatus: 429},
+	})
+
+	before, ok := m.GetByID("auth-1")
+	if !ok {
+		t.Fatalf("expected auth to be present")
+	}
+	beforeState := before.ModelStates[model]
+	if beforeState == nil || !beforeState.Quota.Exceeded {
+		t.Fatalf("test setup failed: expected model quota to be exceeded")
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:   "auth-1",
+		Provider: "codex",
+		Model:    model,
+		Success:  true,
+	})
+
+	updated, ok := m.GetByID("auth-1")
+	if !ok {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+	if !state.Quota.Exceeded {
+		t.Fatalf("state.Quota.Exceeded = false, want true while cooldown is still in the future")
+	}
+	if !state.NextRetryAfter.Equal(beforeState.NextRetryAfter) {
+		t.Fatalf("state.NextRetryAfter = %v, want %v", state.NextRetryAfter, beforeState.NextRetryAfter)
+	}
+	if !updated.Quota.Exceeded {
+		t.Fatalf("auth.Quota.Exceeded = false, want true while cooldown is still in the future")
+	}
+}


### PR DESCRIPTION
Summary:
- Preserve active auth/model quota cooldown state when auth entries are refreshed or updated from storage.
- Keep registry quota and suspension markers when model metadata is re-registered for an existing client.
- Avoid clearing a future quota cooldown when an older successful request finishes after the quota error.

Tests:
- go test ./sdk/cliproxy/... ./internal/registry -count=1
- git diff --check HEAD~1..HEAD