### PR TITLE
fix: allow grouped route auth failover

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -289,20 +289,6 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	return meta
 }
 
-func isGroupedRouteRequestMeta(meta map[string]any) bool {
-	if len(meta) == 0 {
-		return false
-	}
-	switch raw := meta[coreexecutor.RouteGroupMetadataKey].(type) {
-	case string:
-		return strings.TrimSpace(raw) != ""
-	case []byte:
-		return strings.TrimSpace(string(raw)) != ""
-	default:
-		return false
-	}
-}
-
 func pinnedAuthIDFromContext(ctx context.Context) string {
 	if ctx == nil {
 		return ""
@@ -719,7 +705,6 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
-	groupedRoute := isGroupedRouteRequestMeta(reqMeta)
 	payload := rawJSON
 	if len(payload) == 0 {
 		payload = nil
@@ -837,7 +822,7 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 					streamErr := chunk.Err
 					// Safe bootstrap recovery: if the upstream fails before any payload bytes are sent,
 					// retry a few times (to allow auth rotation / transient recovery) and then attempt model fallback.
-					if !sentPayload && !groupedRoute && bootstrapRetries < maxBootstrapRetries && bootstrapEligible(streamErr) {
+					if !sentPayload && bootstrapRetries < maxBootstrapRetries && bootstrapEligible(streamErr) {
 						bootstrapRetries++
 						retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 						if retryErr == nil {

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -248,10 +248,10 @@ func (e *authAwareStreamExecutor) ExecuteStream(ctx context.Context, auth *corea
 	if authID == "auth1" {
 		ch <- coreexecutor.StreamChunk{
 			Err: &coreauth.Error{
-				Code:       "unauthorized",
-				Message:    "unauthorized",
+				Code:       "usage_limit_reached",
+				Message:    "You've hit your usage limit.",
 				Retryable:  false,
-				HTTPStatus: http.StatusUnauthorized,
+				HTTPStatus: http.StatusTooManyRequests,
 			},
 		}
 		close(ch)
@@ -538,9 +538,11 @@ func TestExecuteStreamWithAuthManager_PinnedAuthKeepsSameUpstream(t *testing.T) 
 	}
 
 	var gotErr error
+	var gotStatus int
 	for msg := range errChan {
 		if msg != nil && msg.Error != nil {
 			gotErr = msg.Error
+			gotStatus = msg.StatusCode
 		}
 	}
 
@@ -550,9 +552,12 @@ func TestExecuteStreamWithAuthManager_PinnedAuthKeepsSameUpstream(t *testing.T) 
 	if gotErr == nil {
 		t.Fatalf("expected terminal error, got nil")
 	}
+	if gotStatus != http.StatusTooManyRequests {
+		t.Fatalf("expected status %d, got %d", http.StatusTooManyRequests, gotStatus)
+	}
 	authIDs := executor.AuthIDs()
-	if len(authIDs) == 0 {
-		t.Fatalf("expected at least one upstream attempt")
+	if len(authIDs) != 1 {
+		t.Fatalf("expected exactly 1 upstream attempt for pinned auth, got %v", authIDs)
 	}
 	for _, authID := range authIDs {
 		if authID != "auth1" {
@@ -561,7 +566,7 @@ func TestExecuteStreamWithAuthManager_PinnedAuthKeepsSameUpstream(t *testing.T) 
 	}
 }
 
-func TestExecuteStreamWithAuthManager_GroupedRouteDoesNotBootstrapRetry(t *testing.T) {
+func TestExecuteStreamWithAuthManager_GroupedRouteRetriesWithinGroupBeforeFirstByte(t *testing.T) {
 	executor := &authAwareStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -624,18 +629,18 @@ func TestExecuteStreamWithAuthManager_GroupedRouteDoesNotBootstrapRetry(t *testi
 		}
 	}
 
-	if len(got) != 0 {
-		t.Fatalf("expected empty payload, got %q", string(got))
+	if string(got) != "ok" {
+		t.Fatalf("expected payload ok after grouped route retry, got %q", string(got))
 	}
-	if gotErr == nil {
-		t.Fatalf("expected terminal error, got nil")
+	if gotErr != nil {
+		t.Fatalf("expected no terminal error after grouped route retry, got %v", gotErr)
 	}
 	authIDs := executor.AuthIDs()
-	if len(authIDs) != 1 {
-		t.Fatalf("expected exactly 1 upstream attempt, got %v", authIDs)
+	if len(authIDs) != 2 {
+		t.Fatalf("expected 2 upstream attempts within group, got %v", authIDs)
 	}
-	if authIDs[0] != "auth1" {
-		t.Fatalf("expected grouped route to stop on auth1, got %v", authIDs)
+	if authIDs[0] != "auth1" || authIDs[1] != "auth2" {
+		t.Fatalf("expected grouped route retry sequence [auth1 auth2], got %v", authIDs)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -926,12 +926,13 @@ func hasRequestedModelMetadata(meta map[string]any) bool {
 	}
 }
 
+// Explicit single-pick controls pin execution to one auth; route groups only scope candidates.
 func isSinglePickRouteRequest(meta map[string]any) bool {
-	if routeGroupFromMetadata(meta) != "" {
-		return true
-	}
 	if len(meta) == 0 {
 		return false
+	}
+	if pinnedAuthIDFromMetadata(meta) != "" {
+		return true
 	}
 	raw, ok := meta[cliproxyexecutor.SinglePickMetadataKey]
 	if !ok || raw == nil {

--- a/sdk/cliproxy/auth/conductor_grouped_route_test.go
+++ b/sdk/cliproxy/auth/conductor_grouped_route_test.go
@@ -139,7 +139,7 @@ func registerGroupedRouteTestAuths(t *testing.T, manager *Manager) {
 	}
 }
 
-func TestManagerExecute_GroupedRouteStopsAfterFirstFailure(t *testing.T) {
+func TestManagerExecute_GroupedRouteFailsOverWithinGroup(t *testing.T) {
 	t.Parallel()
 
 	executor := &sequenceExecutor{}
@@ -147,19 +147,22 @@ func TestManagerExecute_GroupedRouteStopsAfterFirstFailure(t *testing.T) {
 	manager.RegisterExecutor(executor)
 	registerGroupedRouteTestAuths(t, manager)
 
-	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{}, cliproxyexecutor.Options{
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{}, cliproxyexecutor.Options{
 		Metadata: map[string]any{cliproxyexecutor.RouteGroupMetadataKey: "pro"},
 	})
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if string(resp.Payload) != "ok" {
+		t.Fatalf("Execute() payload = %q, want %q", string(resp.Payload), "ok")
 	}
 
 	calls := executor.Calls()
-	if len(calls) != 1 {
-		t.Fatalf("expected exactly 1 upstream attempt, got %v", calls)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 upstream attempts within group, got %v", calls)
 	}
-	if calls[0] != "auth-a" {
-		t.Fatalf("expected grouped route to use the first selected auth, got %v", calls)
+	if calls[0] != "auth-a" || calls[1] != "auth-b" {
+		t.Fatalf("expected grouped route failover sequence [auth-a auth-b], got %v", calls)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -56,7 +56,7 @@ func TestManager_ShouldRetryAfterError_RespectsAuthRequestRetryOverride(t *testi
 	}
 }
 
-func TestManager_ShouldRetryAfterError_DisablesInternalRetryForGroupedRoute(t *testing.T) {
+func TestManager_ShouldRetryAfterError_AllowsInternalRetryForGroupedRoute(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	m.SetRetryConfig(3, 30*time.Second)
 
@@ -80,11 +80,11 @@ func TestManager_ShouldRetryAfterError_DisablesInternalRetryForGroupedRoute(t *t
 	_, maxWait := m.retrySettings()
 	meta := map[string]any{"route_group": "pro"}
 	wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: 500, Message: "boom"}, 0, []string{"claude"}, model, maxWait, meta)
-	if shouldRetry {
-		t.Fatalf("expected shouldRetry=false for grouped route, got true (wait=%v)", wait)
+	if !shouldRetry {
+		t.Fatalf("expected shouldRetry=true for grouped route with cooled-down auth, got false")
 	}
-	if wait != 0 {
-		t.Fatalf("expected wait=0 for grouped route, got %v", wait)
+	if wait <= 0 {
+		t.Fatalf("expected wait > 0 for grouped route retry, got %v", wait)
 	}
 }
 
@@ -117,6 +117,38 @@ func TestManager_ShouldRetryAfterError_DisablesInternalRetryForSinglePick(t *tes
 	}
 	if wait != 0 {
 		t.Fatalf("expected wait=0 for single-pick request, got %v", wait)
+	}
+}
+
+func TestManager_ShouldRetryAfterError_DisablesInternalRetryForPinnedAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(3, 30*time.Second)
+
+	model := "test-model"
+	next := time.Now().Add(5 * time.Second)
+	auth := &Auth{
+		ID:       "auth-1",
+		Provider: "codex",
+		ModelStates: map[string]*ModelState{
+			model: {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: next,
+			},
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	_, maxWait := m.retrySettings()
+	meta := map[string]any{"pinned_auth_id": "auth-1"}
+	wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: 500, Message: "boom"}, 0, []string{"codex"}, model, maxWait, meta)
+	if shouldRetry {
+		t.Fatalf("expected shouldRetry=false for pinned auth request, got true (wait=%v)", wait)
+	}
+	if wait != 0 {
+		t.Fatalf("expected wait=0 for pinned auth request, got %v", wait)
 	}
 }
 


### PR DESCRIPTION
Summary
- Treat route_group as a candidate scope instead of a single-pick request so retriable upstream failures can rotate within the group.
- Keep explicit single_pick and pinned_auth_id requests fixed to one auth for internal retry decisions.
- Allow pre-payload stream bootstrap retries for grouped routes while preserving invalid-request and after-payload protections.

Tests
- go test ./sdk/api/... ./sdk/cliproxy/... -count=1