### PR TITLE
Fix stale channel cleanup for auth file deletion

### DIFF
--- a/internal/api/handlers/management/api_key_entries_test.go
+++ b/internal/api/handlers/management/api_key_entries_test.go
@@ -86,3 +86,88 @@ func TestPatchAPIKeyEntryRejectsChangingToExistingKey(t *testing.T) {
 		t.Fatalf("target key changed unexpectedly: %#v", got)
 	}
 }
+
+func TestPutAPIKeyEntriesPrunesUnknownChannelsBeforeSave(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupAPIKeyEntriesTestDB(t)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(
+		http.MethodPut,
+		"/api-key-entries",
+		bytes.NewReader([]byte(`[{
+      "key": "sk-prune-stale-channel",
+      "name": "Prune Stale Channel",
+      "allowed-channels": ["kimi-A", "kimi-B"]
+    }]`)),
+	)
+
+	h := NewHandler(&config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{Name: "kimi-B", BaseURL: "https://example.invalid"},
+		},
+	}, "", nil)
+	h.PutAPIKeyEntries(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	got := usage.GetAPIKey("sk-prune-stale-channel")
+	if got == nil {
+		t.Fatal("expected API key after PUT")
+	}
+	if containsString(got.AllowedChannels, "kimi-A") {
+		t.Fatalf("allowed-channels = %v, should not keep unknown channel", got.AllowedChannels)
+	}
+	if !containsString(got.AllowedChannels, "kimi-B") {
+		t.Fatalf("allowed-channels = %v, should keep known channel", got.AllowedChannels)
+	}
+}
+
+func TestPatchAPIKeyEntryPrunesUnknownChannelsBeforeSave(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupAPIKeyEntriesTestDB(t)
+
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{
+		Key:             "sk-patch-prune",
+		Name:            "Patch Prune",
+		AllowedChannels: []string{"kimi-A", "kimi-B"},
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	body := []byte(`{
+  "match": "sk-patch-prune",
+  "value": {
+    "allowed-channels": ["kimi-A", "kimi-B"]
+  }
+}`)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/api-key-entries", bytes.NewReader(body))
+
+	h := NewHandler(&config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{Name: "kimi-B", BaseURL: "https://example.invalid"},
+		},
+	}, "", nil)
+	h.PatchAPIKeyEntry(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	got := usage.GetAPIKey("sk-patch-prune")
+	if got == nil {
+		t.Fatal("expected API key after PATCH")
+	}
+	if containsString(got.AllowedChannels, "kimi-A") {
+		t.Fatalf("allowed-channels = %v, should not keep unknown channel", got.AllowedChannels)
+	}
+	if !containsString(got.AllowedChannels, "kimi-B") {
+		t.Fatalf("allowed-channels = %v, should keep known channel", got.AllowedChannels)
+	}
+}

--- a/internal/api/handlers/management/api_key_permission_profiles_test.go
+++ b/internal/api/handlers/management/api_key_permission_profiles_test.go
@@ -106,6 +106,45 @@ func TestPutAPIKeyPermissionProfilesRejectsMissingIdentity(t *testing.T) {
 	}
 }
 
+func TestPutAPIKeyPermissionProfilesPrunesUnknownChannelsBeforeSave(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	body := []byte(`[
+  {
+    "id": "standard",
+    "name": "Standard",
+    "allowed-channels": ["kimi-A", "kimi-B"]
+  }
+]`)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "/api-key-permission-profiles", bytes.NewReader(body))
+
+	h := NewHandler(&config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{Name: "kimi-B", BaseURL: "https://example.invalid"},
+		},
+	}, "", nil)
+	h.PutAPIKeyPermissionProfiles(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	profiles := usage.ListAPIKeyPermissionProfiles()
+	if len(profiles) != 1 {
+		t.Fatalf("profiles len = %d, want 1", len(profiles))
+	}
+	if containsString(profiles[0].AllowedChannels, "kimi-A") {
+		t.Fatalf("allowed-channels = %v, should not keep unknown channel", profiles[0].AllowedChannels)
+	}
+	if !containsString(profiles[0].AllowedChannels, "kimi-B") {
+		t.Fatalf("allowed-channels = %v, should keep known channel", profiles[0].AllowedChannels)
+	}
+}
+
 func TestPatchAPIKeyEntryPersistsPermissionProfileID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	setupPermissionProfilesTestDB(t)

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1182,6 +1182,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 					full = abs
 				}
 			}
+			deletedChannels := deletedAuthChannelIdentifiers(h.findAuthByNameOrID(name))
 			if err = os.Remove(full); err == nil {
 				if errDel := h.deleteTokenRecord(ctx, full); errDel != nil {
 					c.JSON(500, gin.H{"error": errDel.Error()})
@@ -1189,6 +1190,10 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 				}
 				deleted++
 				h.disableAuth(ctx, full)
+				if errCleanup := h.removeChannelReferences(deletedChannels); errCleanup != nil {
+					c.JSON(500, gin.H{"error": errCleanup.Error()})
+					return
+				}
 			}
 		}
 		c.JSON(200, gin.H{"status": "ok", "deleted": deleted})
@@ -1205,6 +1210,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 			full = abs
 		}
 	}
+	deletedChannels := deletedAuthChannelIdentifiers(h.findAuthByNameOrID(name))
 	if err := os.Remove(full); err != nil {
 		if os.IsNotExist(err) {
 			c.JSON(404, gin.H{"error": "file not found"})
@@ -1218,7 +1224,47 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		return
 	}
 	h.disableAuth(ctx, full)
+	if err := h.removeChannelReferences(deletedChannels); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(200, gin.H{"status": "ok"})
+}
+
+func (h *Handler) findAuthByNameOrID(name string) *coreauth.Auth {
+	if h == nil || h.authManager == nil {
+		return nil
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	if auth, ok := h.authManager.GetByID(name); ok {
+		return auth
+	}
+	for _, auth := range h.authManager.List() {
+		if auth == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(auth.FileName), name) {
+			return auth
+		}
+		if path := strings.TrimSpace(authAttribute(auth, "path")); path != "" && strings.EqualFold(filepath.Base(path), name) {
+			return auth
+		}
+	}
+	return nil
+}
+
+func deletedAuthChannelIdentifiers(auth *coreauth.Auth) []string {
+	if auth == nil {
+		return nil
+	}
+	accountType, _ := auth.AccountInfo()
+	if !strings.EqualFold(accountType, "oauth") {
+		return nil
+	}
+	return auth.ChannelIdentifiers()
 }
 
 func (h *Handler) authIDForPath(path string) string {

--- a/internal/api/handlers/management/auth_files_delete_test.go
+++ b/internal/api/handlers/management/auth_files_delete_test.go
@@ -1,0 +1,163 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestDeleteAuthFileRemovesDeletedChannelReferences(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	authDir := t.TempDir()
+	authAPath := filepath.Join(authDir, "kimi-a.json")
+	authBPath := filepath.Join(authDir, "kimi-b.json")
+	if err := os.WriteFile(authAPath, []byte(`{"type":"kimi","access_token":"at-a","refresh_token":"rt-a","label":"kimi-A"}`), 0o600); err != nil {
+		t.Fatalf("write auth A: %v", err)
+	}
+	if err := os.WriteFile(authBPath, []byte(`{"type":"kimi","access_token":"at-b","refresh_token":"rt-b","label":"kimi-B"}`), 0o600); err != nil {
+		t.Fatalf("write auth B: %v", err)
+	}
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	for _, auth := range []*coreauth.Auth{
+		{
+			ID:       "kimi-a.json",
+			FileName: "kimi-a.json",
+			Provider: "kimi",
+			Label:    "kimi-A",
+			Metadata: map[string]any{
+				"type":          "kimi",
+				"access_token":  "at-a",
+				"refresh_token": "rt-a",
+				"label":         "kimi-A",
+			},
+			Attributes: map[string]string{"path": authAPath, "source": authAPath},
+		},
+		{
+			ID:       "kimi-b.json",
+			FileName: "kimi-b.json",
+			Provider: "kimi",
+			Label:    "kimi-B",
+			Metadata: map[string]any{
+				"type":          "kimi",
+				"access_token":  "at-b",
+				"refresh_token": "rt-b",
+				"label":         "kimi-B",
+			},
+			Attributes: map[string]string{"path": authBPath, "source": authBPath},
+		},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register auth %s: %v", auth.FileName, err)
+		}
+	}
+
+	if err := usage.ReplaceAllAPIKeyPermissionProfiles([]usage.APIKeyPermissionProfileRow{
+		{
+			ID:              "hermes",
+			Name:            "Hermes",
+			AllowedChannels: []string{"kimi-A", "kimi-B"},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllAPIKeyPermissionProfiles: %v", err)
+	}
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{
+		Key:                 "sk-bound-profile",
+		Name:                "Bound Profile",
+		PermissionProfileID: "hermes",
+		AllowedChannels:     []string{"kimi-A", "kimi-B"},
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	h := &Handler{
+		cfg: &config.Config{
+			AuthDir: authDir,
+			Routing: config.RoutingConfig{
+				ChannelGroups: []config.RoutingChannelGroup{
+					{
+						Name: "kimi-mix",
+						Match: config.ChannelGroupMatch{
+							Channels: []string{"kimi-A", "kimi-B"},
+						},
+						ChannelPriorities: map[string]int{
+							"kimi-A": 90,
+							"kimi-B": 20,
+						},
+					},
+				},
+			},
+			OAuthModelAlias: map[string][]config.OAuthModelAlias{
+				"kimi-a": {{Name: "kimi-k2", Alias: "kimi-a-k2"}},
+				"kimi-b": {{Name: "kimi-k2", Alias: "kimi-b-k2"}},
+			},
+			SDKConfig: config.SDKConfig{
+				APIKeyEntries: []config.APIKeyEntry{
+					{Key: "sk-config-entry", Name: "Config Entry", AllowedChannels: []string{"kimi-A", "kimi-B"}},
+				},
+			},
+		},
+		authManager: manager,
+		tokenStore:  store,
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/auth-files?name=kimi-a.json", nil)
+
+	h.DeleteAuthFile(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	profiles := usage.ListAPIKeyPermissionProfiles()
+	if len(profiles) != 1 {
+		t.Fatalf("profiles len = %d, want 1", len(profiles))
+	}
+	if containsString(profiles[0].AllowedChannels, "kimi-A") {
+		t.Fatalf("profile allowed-channels = %v, should not keep deleted channel", profiles[0].AllowedChannels)
+	}
+	if !containsString(profiles[0].AllowedChannels, "kimi-B") {
+		t.Fatalf("profile allowed-channels = %v, should keep remaining channel", profiles[0].AllowedChannels)
+	}
+
+	row := usage.GetAPIKey("sk-bound-profile")
+	if row == nil {
+		t.Fatal("expected API key row")
+	}
+	if containsString(row.AllowedChannels, "kimi-A") {
+		t.Fatalf("api key allowed-channels = %v, should not keep deleted channel", row.AllowedChannels)
+	}
+	if !containsString(row.AllowedChannels, "kimi-B") {
+		t.Fatalf("api key allowed-channels = %v, should keep remaining channel", row.AllowedChannels)
+	}
+
+	group := h.cfg.Routing.ChannelGroups[0]
+	if containsString(group.Match.Channels, "kimi-A") {
+		t.Fatalf("routing match channels = %v, should not keep deleted channel", group.Match.Channels)
+	}
+	if _, exists := group.ChannelPriorities["kimi-A"]; exists {
+		t.Fatalf("routing channel priorities = %v, should not keep deleted channel", group.ChannelPriorities)
+	}
+	if containsString(h.cfg.APIKeyEntries[0].AllowedChannels, "kimi-A") {
+		t.Fatalf("config api key allowed-channels = %v, should not keep deleted channel", h.cfg.APIKeyEntries[0].AllowedChannels)
+	}
+	if _, exists := h.cfg.OAuthModelAlias["kimi-a"]; exists {
+		t.Fatalf("oauth model aliases = %v, should not keep deleted channel", h.cfg.OAuthModelAlias)
+	}
+	if _, exists := h.cfg.OAuthModelAlias["kimi-b"]; !exists {
+		t.Fatalf("oauth model aliases = %v, should keep remaining channel", h.cfg.OAuthModelAlias)
+	}
+}

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -829,6 +830,17 @@ func TestPatchAuthFileFieldsClearsSubscriptionExpiration(t *testing.T) {
 
 func TestPatchAuthFileFieldsRenamesRoutingChannelReferences(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	if err := usage.ReplaceAllAPIKeyPermissionProfiles([]usage.APIKeyPermissionProfileRow{
+		{
+			ID:              "standard",
+			Name:            "Standard",
+			AllowedChannels: []string{"Team Old", "Other Channel"},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllAPIKeyPermissionProfiles: %v", err)
+	}
 
 	store := &memoryAuthStore{}
 	manager := coreauth.NewManager(store, nil, nil)
@@ -912,6 +924,16 @@ func TestPatchAuthFileFieldsRenamesRoutingChannelReferences(t *testing.T) {
 	}
 	if !containsString(h.cfg.APIKeyEntries[0].AllowedChannels, "Team New") {
 		t.Fatalf("allowed-channels = %v, want renamed channel", h.cfg.APIKeyEntries[0].AllowedChannels)
+	}
+	profiles := usage.ListAPIKeyPermissionProfiles()
+	if len(profiles) != 1 {
+		t.Fatalf("profiles len = %d, want 1", len(profiles))
+	}
+	if !containsString(profiles[0].AllowedChannels, "Team New") {
+		t.Fatalf("profile allowed-channels = %v, want renamed channel", profiles[0].AllowedChannels)
+	}
+	if containsString(profiles[0].AllowedChannels, "Team Old") {
+		t.Fatalf("profile allowed-channels = %v, should not keep old channel", profiles[0].AllowedChannels)
 	}
 }
 

--- a/internal/api/handlers/management/channel_names.go
+++ b/internal/api/handlers/management/channel_names.go
@@ -301,10 +301,14 @@ func (h *Handler) validateAllowedChannels(values []string) ([]string, error) {
 		return nil, nil
 	}
 	var auths []*coreauth.Auth
+	var cfg *config.Config
+	if h != nil {
+		cfg = h.cfg
+	}
 	if h != nil && h.authManager != nil {
 		auths = h.authManager.List()
 	}
-	known, err := collectKnownChannels(h.cfg, auths, "")
+	known, err := collectKnownChannels(cfg, auths, "")
 	if err != nil {
 		return nil, err
 	}
@@ -326,6 +330,53 @@ func (h *Handler) validateAllowedChannels(values []string) ([]string, error) {
 		}
 		seen[canonicalKey] = struct{}{}
 		resolved = append(resolved, canonical)
+	}
+	return resolved, nil
+}
+
+func (h *Handler) sanitizeAllowedChannelsForSave(values []string) ([]string, error) {
+	normalized := uniqueChannels(values)
+	if len(normalized) == 0 {
+		return nil, nil
+	}
+
+	var auths []*coreauth.Auth
+	var cfg *config.Config
+	if h != nil {
+		cfg = h.cfg
+	}
+	if h != nil && h.authManager != nil {
+		auths = h.authManager.List()
+	}
+	known, err := collectKnownChannels(cfg, auths, "")
+	if err != nil {
+		return nil, err
+	}
+	if len(known) == 0 {
+		return h.validateAllowedChannels(normalized)
+	}
+
+	resolved := make([]string, 0, len(normalized))
+	seen := make(map[string]struct{}, len(normalized))
+	for _, value := range normalized {
+		key := strings.ToLower(strings.TrimSpace(value))
+		entry, exists := known[key]
+		if !exists {
+			continue
+		}
+		canonical := strings.TrimSpace(entry.Canonical)
+		if canonical == "" {
+			canonical = strings.TrimSpace(value)
+		}
+		canonicalKey := strings.ToLower(canonical)
+		if _, exists := seen[canonicalKey]; exists {
+			continue
+		}
+		seen[canonicalKey] = struct{}{}
+		resolved = append(resolved, canonical)
+	}
+	if len(resolved) == 0 {
+		return nil, nil
 	}
 	return resolved, nil
 }

--- a/internal/api/handlers/management/channel_rename.go
+++ b/internal/api/handlers/management/channel_rename.go
@@ -41,6 +41,58 @@ func (h *Handler) renameChannelReferences(oldNames []string, newName string) err
 	if err := renameSQLiteAPIKeyChannels(oldNameSet, newName); err != nil {
 		return err
 	}
+	if err := renameSQLiteAPIKeyPermissionProfileChannels(oldNameSet, newName); err != nil {
+		return err
+	}
+	if configChanged && h.cfg != nil && strings.TrimSpace(h.configFilePath) != "" {
+		if err := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); err != nil {
+			return fmt.Errorf("failed to save config: %w", err)
+		}
+		if usage.ConfigStoreAvailable() {
+			usage.CleanDBBackedConfigFromYAML(h.configFilePath)
+		}
+	}
+	if configChanged && h.authManager != nil {
+		h.authManager.SetConfig(h.cfg)
+	}
+	return nil
+}
+
+func (h *Handler) removeChannelReferences(oldNames []string) error {
+	oldNameSet := channelRenameSet(oldNames, "")
+	if h == nil || len(oldNameSet) == 0 {
+		return nil
+	}
+
+	configChanged := false
+	routingChanged := false
+	if h.cfg != nil {
+		if removeRoutingChannelReferences(&h.cfg.Routing, oldNameSet) {
+			configChanged = true
+			routingChanged = true
+		}
+		if removeConfigAPIKeyChannels(h.cfg.APIKeyEntries, oldNameSet) {
+			configChanged = true
+		}
+		if removeOAuthModelAliasChannels(h.cfg, oldNameSet) {
+			configChanged = true
+			if err := usage.UpsertRuntimeSetting(usage.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias); err != nil {
+				return fmt.Errorf("failed to persist oauth model aliases: %w", err)
+			}
+		}
+	}
+
+	if routingChanged && h.cfg != nil {
+		if err := usage.UpsertRoutingConfig(h.cfg.Routing); err != nil {
+			return fmt.Errorf("failed to persist routing config: %w", err)
+		}
+	}
+	if err := removeSQLiteAPIKeyChannels(oldNameSet); err != nil {
+		return err
+	}
+	if err := removeSQLiteAPIKeyPermissionProfileChannels(oldNameSet); err != nil {
+		return err
+	}
 	if configChanged && h.cfg != nil && strings.TrimSpace(h.configFilePath) != "" {
 		if err := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); err != nil {
 			return fmt.Errorf("failed to save config: %w", err)
@@ -103,6 +155,36 @@ func renameChannelList(values []string, oldNameSet map[string]struct{}, newName 
 	return out, changed
 }
 
+func removeChannelList(values []string, oldNameSet map[string]struct{}) ([]string, bool) {
+	if len(values) == 0 {
+		return values, false
+	}
+	changed := false
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if shouldRenameChannel(trimmed, oldNameSet) {
+			changed = true
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, exists := seen[key]; exists {
+			changed = true
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		out = nil
+	}
+	return out, changed
+}
+
 func renameRoutingChannelReferences(routing *config.RoutingConfig, oldNameSet map[string]struct{}, newName string) bool {
 	if routing == nil || len(routing.ChannelGroups) == 0 {
 		return false
@@ -133,10 +215,49 @@ func renameRoutingChannelReferences(routing *config.RoutingConfig, oldNameSet ma
 	return changed
 }
 
+func removeRoutingChannelReferences(routing *config.RoutingConfig, oldNameSet map[string]struct{}) bool {
+	if routing == nil || len(routing.ChannelGroups) == 0 {
+		return false
+	}
+	changed := false
+	for i := range routing.ChannelGroups {
+		channels, channelsChanged := removeChannelList(routing.ChannelGroups[i].Match.Channels, oldNameSet)
+		if channelsChanged {
+			routing.ChannelGroups[i].Match.Channels = channels
+			changed = true
+		}
+		if priorities := routing.ChannelGroups[i].ChannelPriorities; len(priorities) > 0 {
+			for channel := range priorities {
+				if !shouldRenameChannel(channel, oldNameSet) {
+					continue
+				}
+				delete(priorities, channel)
+				changed = true
+			}
+			if len(priorities) == 0 {
+				routing.ChannelGroups[i].ChannelPriorities = nil
+			}
+		}
+	}
+	return changed
+}
+
 func renameConfigAPIKeyChannels(entries []config.APIKeyEntry, oldNameSet map[string]struct{}, newName string) bool {
 	changed := false
 	for i := range entries {
 		channels, channelsChanged := renameChannelList(entries[i].AllowedChannels, oldNameSet, newName)
+		if channelsChanged {
+			entries[i].AllowedChannels = channels
+			changed = true
+		}
+	}
+	return changed
+}
+
+func removeConfigAPIKeyChannels(entries []config.APIKeyEntry, oldNameSet map[string]struct{}) bool {
+	changed := false
+	for i := range entries {
+		channels, channelsChanged := removeChannelList(entries[i].AllowedChannels, oldNameSet)
 		if channelsChanged {
 			entries[i].AllowedChannels = channels
 			changed = true
@@ -159,6 +280,60 @@ func renameSQLiteAPIKeyChannels(oldNameSet map[string]struct{}, newName string) 
 	return nil
 }
 
+func removeSQLiteAPIKeyChannels(oldNameSet map[string]struct{}) error {
+	for _, row := range usage.ListAPIKeys() {
+		channels, changed := removeChannelList(row.AllowedChannels, oldNameSet)
+		if !changed {
+			continue
+		}
+		row.AllowedChannels = channels
+		if err := usage.UpsertAPIKey(row); err != nil {
+			return fmt.Errorf("failed to persist api key channel restrictions: %w", err)
+		}
+	}
+	return nil
+}
+
+func renameSQLiteAPIKeyPermissionProfileChannels(oldNameSet map[string]struct{}, newName string) error {
+	profiles := usage.ListAPIKeyPermissionProfiles()
+	changed := false
+	for i := range profiles {
+		channels, channelsChanged := renameChannelList(profiles[i].AllowedChannels, oldNameSet, newName)
+		if !channelsChanged {
+			continue
+		}
+		profiles[i].AllowedChannels = channels
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	if err := usage.ReplaceAllAPIKeyPermissionProfiles(profiles); err != nil {
+		return fmt.Errorf("failed to persist api key permission profile channel restrictions: %w", err)
+	}
+	return nil
+}
+
+func removeSQLiteAPIKeyPermissionProfileChannels(oldNameSet map[string]struct{}) error {
+	profiles := usage.ListAPIKeyPermissionProfiles()
+	changed := false
+	for i := range profiles {
+		channels, channelsChanged := removeChannelList(profiles[i].AllowedChannels, oldNameSet)
+		if !channelsChanged {
+			continue
+		}
+		profiles[i].AllowedChannels = channels
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	if err := usage.ReplaceAllAPIKeyPermissionProfiles(profiles); err != nil {
+		return fmt.Errorf("failed to persist api key permission profile channel restrictions: %w", err)
+	}
+	return nil
+}
+
 func renameOAuthModelAliasChannels(cfg *config.Config, oldNameSet map[string]struct{}, newName string) bool {
 	if cfg == nil || len(cfg.OAuthModelAlias) == 0 {
 		return false
@@ -171,6 +346,24 @@ func renameOAuthModelAliasChannels(cfg *config.Config, oldNameSet map[string]str
 		}
 		delete(cfg.OAuthModelAlias, channel)
 		cfg.OAuthModelAlias[newKey] = append(cfg.OAuthModelAlias[newKey], aliases...)
+		changed = true
+	}
+	if changed {
+		cfg.OAuthModelAlias = sanitizedOAuthModelAlias(cfg.OAuthModelAlias)
+	}
+	return changed
+}
+
+func removeOAuthModelAliasChannels(cfg *config.Config, oldNameSet map[string]struct{}) bool {
+	if cfg == nil || len(cfg.OAuthModelAlias) == 0 {
+		return false
+	}
+	changed := false
+	for channel := range cfg.OAuthModelAlias {
+		if !shouldRenameChannel(channel, oldNameSet) {
+			continue
+		}
+		delete(cfg.OAuthModelAlias, channel)
 		changed = true
 	}
 	if changed {

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -241,6 +241,12 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
 			return
 		}
+		if cleaned, errClean := h.sanitizeAllowedChannelsForSave(profiles[idx].AllowedChannels); errClean != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": errClean.Error()})
+			return
+		} else {
+			profiles[idx].AllowedChannels = cleaned
+		}
 	}
 
 	if err := usage.ReplaceAllAPIKeyPermissionProfiles(profiles); err != nil {
@@ -288,14 +294,13 @@ func (h *Handler) PutAPIKeyEntries(c *gin.Context) {
 		routingCfg = h.cfg.Routing
 	}
 	for _, entry := range arr {
-		entry.AllowedChannels = uniqueChannels(entry.AllowedChannels)
 		entry.AllowedChannelGroups = uniqueChannelGroups(entry.AllowedChannelGroups)
-		validated, errValidate := h.validateAllowedChannels(entry.AllowedChannels)
+		cleanedChannels, errValidate := h.sanitizeAllowedChannelsForSave(entry.AllowedChannels)
 		if errValidate != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
 			return
 		}
-		entry.AllowedChannels = validated
+		entry.AllowedChannels = cleanedChannels
 		validatedGroups, errValidate := h.validateAllowedChannelGroups(entry.AllowedChannelGroups)
 		if errValidate != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
@@ -423,7 +428,7 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 		entry.AllowedModels = append([]string(nil), (*body.Value.AllowedModels)...)
 	}
 	if body.Value.AllowedChannels != nil {
-		validated, errValidate := h.validateAllowedChannels(*body.Value.AllowedChannels)
+		validated, errValidate := h.sanitizeAllowedChannelsForSave(*body.Value.AllowedChannels)
 		if errValidate != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
 			return


### PR DESCRIPTION
## Summary
- Remove deleted OAuth auth-file channel references from routing, API key rows, permission profiles, and OAuth model aliases.
- Keep rename cleanup consistent by updating API key permission profiles alongside other channel references.
- Prune stale unknown channel names during management saves so old references do not block future edits.

## Test Plan
- `go test ./internal/api/handlers/management -run 'Test(DeleteAuthFileRemovesDeletedChannelReferences|PatchAuthFileFieldsRenamesRoutingChannelReferences|PutAPIKeyPermissionProfilesPrunesUnknownChannelsBeforeSave|PutAPIKeyEntriesPrunesUnknownChannelsBeforeSave|PatchAPIKeyEntryPrunesUnknownChannelsBeforeSave)$' -count=1`
