### PR TITLE
fix(auth): skip disabled auth auto refresh

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2392,6 +2392,9 @@ func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
 	if a == nil {
 		return false
 	}
+	if a.Disabled || a.Status == StatusDisabled {
+		return false
+	}
 	if !a.NextRefreshAfter.IsZero() && now.Before(a.NextRefreshAfter) {
 		return false
 	}

--- a/sdk/cliproxy/auth/disabled_refresh_test.go
+++ b/sdk/cliproxy/auth/disabled_refresh_test.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type refreshAlwaysRuntime struct{}
+
+func (refreshAlwaysRuntime) ShouldRefresh(time.Time, *Auth) bool {
+	return true
+}
+
+func TestManagerShouldRefreshSkipsDisabledAuths(t *testing.T) {
+	mgr := NewManager(nil, nil, nil)
+	now := time.Now()
+
+	tests := []struct {
+		name string
+		auth *Auth
+	}{
+		{
+			name: "disabled flag",
+			auth: &Auth{
+				ID:       "disabled-flag",
+				Provider: "test-provider",
+				Status:   StatusActive,
+				Disabled: true,
+				Runtime:  refreshAlwaysRuntime{},
+			},
+		},
+		{
+			name: "disabled status",
+			auth: &Auth{
+				ID:       "disabled-status",
+				Provider: "test-provider",
+				Status:   StatusDisabled,
+				Runtime:  refreshAlwaysRuntime{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if mgr.shouldRefresh(tt.auth, now) {
+				t.Fatal("shouldRefresh returned true for disabled auth")
+			}
+		})
+	}
+}
+
+func TestCheckRefreshesSkipsDisabledAuth(t *testing.T) {
+	mgr := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "disabled-auth",
+		Provider: "test-provider",
+		Status:   StatusDisabled,
+		Disabled: true,
+		Runtime:  refreshAlwaysRuntime{},
+	}
+
+	if _, err := mgr.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	refreshCalled := make(chan struct{}, 1)
+	mgr.RegisterExecutor(&stubExecutor{
+		onRefresh: func() {
+			refreshCalled <- struct{}{}
+		},
+	})
+
+	mgr.checkRefreshes(context.Background())
+
+	select {
+	case <-refreshCalled:
+		t.Fatal("Refresh called for disabled auth")
+	case <-time.After(100 * time.Millisecond):
+	}
+	current, ok := mgr.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected disabled auth to remain registered")
+	}
+	if !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("disabled state changed to disabled=%v status=%q", current.Disabled, current.Status)
+	}
+}


### PR DESCRIPTION
Summary
- Skip auto-refresh scheduling for auths marked disabled or status=disabled.
- Add regression coverage for disabled refresh decisions and auto-refresh dispatch.

Verification
- go test ./sdk/cliproxy/auth -count=1
- go test ./internal/api/handlers/management -run TestDeleteAuthFileRemovesDeletedChannelReferences -count=1