### PR TITLE
fix(auth): remove deleted auths from runtime manager

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1189,7 +1189,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 					return
 				}
 				deleted++
-				h.disableAuth(ctx, full)
+				h.removeAuth(ctx, full)
 				if errCleanup := h.removeChannelReferences(deletedChannels); errCleanup != nil {
 					c.JSON(500, gin.H{"error": errCleanup.Error()})
 					return
@@ -1223,7 +1223,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
-	h.disableAuth(ctx, full)
+	h.removeAuth(ctx, full)
 	if err := h.removeChannelReferences(deletedChannels); err != nil {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
@@ -1698,23 +1698,31 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
-func (h *Handler) disableAuth(ctx context.Context, id string) {
+func (h *Handler) removeAuth(ctx context.Context, id string) {
 	if h == nil || h.authManager == nil {
 		return
 	}
-	authID := h.authIDForPath(id)
-	if authID == "" {
-		authID = strings.TrimSpace(id)
+	candidates := []string{
+		h.authIDForPath(id),
+		strings.TrimSpace(id),
+		filepath.Base(strings.TrimSpace(id)),
 	}
-	if authID == "" {
-		return
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || candidate == "." {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if deleted, _ := h.authManager.Delete(coreauth.WithSkipPersist(ctx), candidate); deleted != nil {
+			return
+		}
 	}
-	if auth, ok := h.authManager.GetByID(authID); ok {
-		auth.Disabled = true
-		auth.Status = coreauth.StatusDisabled
-		auth.StatusMessage = "removed via management API"
-		auth.UpdatedAt = time.Now()
-		_, _ = h.authManager.Update(ctx, auth)
+	if auth := h.findAuthByNameOrID(filepath.Base(strings.TrimSpace(id))); auth != nil {
+		_, _ = h.authManager.Delete(coreauth.WithSkipPersist(ctx), auth.ID)
 	}
 }
 

--- a/internal/api/handlers/management/auth_files_delete_test.go
+++ b/internal/api/handlers/management/auth_files_delete_test.go
@@ -121,6 +121,12 @@ func TestDeleteAuthFileRemovesDeletedChannelReferences(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("DELETE status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
+	if _, ok := manager.GetByID("kimi-a.json"); ok {
+		t.Fatal("expected deleted auth to be removed from manager")
+	}
+	if _, ok := manager.GetByID("kimi-b.json"); !ok {
+		t.Fatal("expected remaining auth to stay in manager")
+	}
 
 	profiles := usage.ListAPIKeyPermissionProfiles()
 	if len(profiles) != 1 {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -575,6 +575,33 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	return snapshot.Clone(), nil
 }
 
+// Delete removes an auth entry from the runtime manager and persistence store.
+func (m *Manager) Delete(ctx context.Context, id string) (*Auth, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, nil
+	}
+	m.mu.Lock()
+	previous, ok := m.auths[id]
+	if !ok || previous == nil {
+		m.mu.Unlock()
+		return nil, nil
+	}
+	snapshot := previous.Clone()
+	delete(m.auths, id)
+	m.mu.Unlock()
+
+	if err := m.deletePersist(ctx, snapshot); err != nil {
+		m.mu.Lock()
+		m.auths[id] = snapshot
+		m.mu.Unlock()
+		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+		return nil, err
+	}
+	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	return snapshot.Clone(), nil
+}
+
 // Load resets manager state from the backing store.
 func (m *Manager) Load(ctx context.Context) error {
 	m.mu.Lock()
@@ -2302,6 +2329,24 @@ func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	}
 	_, err := m.store.Save(ctx, auth)
 	return err
+}
+
+func (m *Manager) deletePersist(ctx context.Context, auth *Auth) error {
+	if m.store == nil || auth == nil || auth.ID == "" {
+		return nil
+	}
+	if shouldSkipPersist(ctx) {
+		return nil
+	}
+	if auth.Attributes != nil {
+		if v := strings.ToLower(strings.TrimSpace(auth.Attributes["runtime_only"])); v == "true" {
+			return nil
+		}
+	}
+	if auth.Metadata == nil {
+		return nil
+	}
+	return m.store.Delete(ctx, auth.ID)
 }
 
 // StartAutoRefresh launches a background loop that evaluates auth freshness

--- a/sdk/cliproxy/auth/persist_policy_test.go
+++ b/sdk/cliproxy/auth/persist_policy_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 type countingStore struct {
-	saveCount atomic.Int32
+	saveCount   atomic.Int32
+	deleteCount atomic.Int32
 }
 
 type snapshotStore struct {
@@ -23,7 +24,10 @@ func (s *countingStore) Save(context.Context, *Auth) (string, error) {
 	return "", nil
 }
 
-func (s *countingStore) Delete(context.Context, string) error { return nil }
+func (s *countingStore) Delete(context.Context, string) error {
+	s.deleteCount.Add(1)
+	return nil
+}
 
 func (s *snapshotStore) List(context.Context) ([]*Auth, error) { return nil, nil }
 
@@ -84,6 +88,58 @@ func TestWithSkipPersist_DisablesRegisterPersistence(t *testing.T) {
 	}
 	if got := store.saveCount.Load(); got != 0 {
 		t.Fatalf("expected 0 Save calls, got %d", got)
+	}
+}
+
+func TestDeleteRemovesAuthAndPersistsDelete(t *testing.T) {
+	store := &countingStore{}
+	mgr := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "auth-1",
+		Provider: "antigravity",
+		Metadata: map[string]any{"type": "antigravity"},
+	}
+
+	if _, err := mgr.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register(skipPersist) returned error: %v", err)
+	}
+
+	deleted, err := mgr.Delete(context.Background(), "auth-1")
+	if err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if deleted == nil || deleted.ID != "auth-1" {
+		t.Fatalf("deleted auth = %+v, want auth-1", deleted)
+	}
+	if _, ok := mgr.GetByID("auth-1"); ok {
+		t.Fatal("expected auth to be removed from manager")
+	}
+	if got := store.deleteCount.Load(); got != 1 {
+		t.Fatalf("expected 1 Delete call, got %d", got)
+	}
+}
+
+func TestDeleteWithSkipPersistRemovesAuthWithoutDeletingStore(t *testing.T) {
+	store := &countingStore{}
+	mgr := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "auth-1",
+		Provider: "antigravity",
+		Metadata: map[string]any{"type": "antigravity"},
+	}
+
+	if _, err := mgr.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register(skipPersist) returned error: %v", err)
+	}
+
+	if _, err := mgr.Delete(WithSkipPersist(context.Background()), "auth-1"); err != nil {
+		t.Fatalf("Delete(skipPersist) returned error: %v", err)
+	}
+	if _, ok := mgr.GetByID("auth-1"); ok {
+		t.Fatal("expected auth to be removed from manager")
+	}
+	if got := store.deleteCount.Load(); got != 0 {
+		t.Fatalf("expected no Delete calls, got %d", got)
 	}
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -332,17 +332,11 @@ func (s *Service) applyCoreAuthRemoval(ctx context.Context, id string) {
 	if s.coreManager == nil {
 		return
 	}
-	GlobalModelRegistry().UnregisterClient(id)
-	if existing, ok := s.coreManager.GetByID(id); ok && existing != nil {
-		existing.Disabled = true
-		existing.Status = coreauth.StatusDisabled
-		if _, err := s.coreManager.Update(ctx, existing); err != nil {
-			log.Errorf("failed to disable auth %s: %v", id, err)
-		}
-		if strings.EqualFold(strings.TrimSpace(existing.Provider), "codex") {
-			s.ensureExecutorsForAuth(existing)
-		}
+	if _, err := s.coreManager.Delete(coreauth.WithSkipPersist(ctx), id); err != nil {
+		log.Errorf("failed to remove auth %s: %v", id, err)
+		return
 	}
+	GlobalModelRegistry().UnregisterClient(id)
 }
 
 func (s *Service) applyRetryConfig(cfg *config.Config) {

--- a/sdk/cliproxy/service_auth_removal_test.go
+++ b/sdk/cliproxy/service_auth_removal_test.go
@@ -1,0 +1,37 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+func TestServiceHandleAuthDeleteRemovesAuthFromManager(t *testing.T) {
+	authID := "kimi-deleted.json"
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(coreauth.WithSkipPersist(context.Background()), &coreauth.Auth{
+		ID:       authID,
+		Provider: "kimi",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"type": "kimi"},
+	}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: manager,
+	}
+
+	service.handleAuthUpdate(context.Background(), watcher.AuthUpdate{
+		Action: watcher.AuthUpdateActionDelete,
+		ID:     authID,
+	})
+
+	if _, ok := manager.GetByID(authID); ok {
+		t.Fatal("expected deleted auth to be removed from manager")
+	}
+}


### PR DESCRIPTION
Summary
- Add a runtime auth manager delete path that removes auths from memory and persists deletes when appropriate.
- Use true runtime removal for management auth-file deletes and service delete updates instead of leaving disabled auth entries behind.
- Keep config-derived removal semantics separate so config removals still disable historical runtime entries.

Verification
- go test ./sdk/cliproxy/auth -count=1
- go test ./sdk/cliproxy -count=1
- go test ./internal/api/handlers/management -count=1
- go test ./internal/watcher -count=1
- go test ./internal/api -run TestUpdateClientsDisablesRemovedConfigAuths -count=1