### PR TITLE
Fix image request model-scoped auth selection

### DIFF
--- a/internal/api/handlers/management/image_generation.go
+++ b/internal/api/handlers/management/image_generation.go
@@ -20,6 +20,7 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
 )
 
 const (
@@ -115,6 +116,10 @@ func (h *Handler) runImageGenerationTask(taskID string, payload []byte, alt stri
 }
 
 func (h *Handler) executeImageGenerationTest(ctx context.Context, payload []byte, alt string) ([]byte, error) {
+	modelName := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
+	if modelName == "" {
+		modelName = imageGenerationModel
+	}
 	imageCount, err := imageGenerationRequestCount(payload)
 	if err != nil {
 		return nil, err
@@ -130,7 +135,7 @@ func (h *Handler) executeImageGenerationTest(ctx context.Context, payload []byte
 			}
 		}
 		resp, execErr := h.authManager.Execute(ctx, []string{"codex"}, coreexecutor.Request{
-			Model:   "",
+			Model:   modelName,
 			Payload: execPayload,
 			Format:  sdktranslator.FromString("openai"),
 		}, coreexecutor.Options{

--- a/internal/api/handlers/management/image_generation_test.go
+++ b/internal/api/handlers/management/image_generation_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
@@ -75,20 +76,36 @@ func (e *managementImageExecutor) HttpRequest(context.Context, *coreauth.Auth, *
 	return nil, errors.New("not implemented")
 }
 
-func TestPostImageGenerationTestReturnsStructuredUpstreamError(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	executor := &managementImageExecutor{err: errors.New("openai image conversation returned no downloadable images")}
-	manager := coreauth.NewManager(nil, nil, nil)
-	manager.RegisterExecutor(executor)
+func registerManagementImageAuth(t *testing.T, manager *coreauth.Manager, id string, models ...string) {
+	t.Helper()
 	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
+		ID:       id,
 		Provider: "codex",
 		Status:   coreauth.StatusActive,
 		Metadata: map[string]any{"access_token": "token"},
 	}); err != nil {
 		t.Fatalf("Register auth: %v", err)
 	}
+
+	modelInfos := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if strings.TrimSpace(model) != "" {
+			modelInfos = append(modelInfos, &registry.ModelInfo{ID: model})
+		}
+	}
+	registry.GetGlobalRegistry().RegisterClient(id, "codex", modelInfos)
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(id)
+	})
+}
+
+func TestPostImageGenerationTestReturnsStructuredUpstreamError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &managementImageExecutor{err: errors.New("openai image conversation returned no downloadable images")}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	registerManagementImageAuth(t, manager, "codex-auth-structured-error", imageGenerationModel)
 
 	h := &Handler{authManager: manager}
 	_, execErr := h.executeImageGenerationTest(context.Background(), []byte(`{
@@ -135,14 +152,7 @@ func TestPostImageGenerationTestIncludesOfficialUpstreamErrorBody(t *testing.T) 
 	}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerManagementImageAuth(t, manager, "codex-auth-official-error", imageGenerationModel)
 
 	h := &Handler{authManager: manager}
 	_, execErr := h.executeImageGenerationTest(context.Background(), []byte(`{
@@ -188,14 +198,7 @@ func TestPostImageGenerationTestExecutesCodexImageAlt(t *testing.T) {
 	executor := &managementImageExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerManagementImageAuth(t, manager, "codex-auth-execute-alt", imageGenerationModel)
 
 	h := &Handler{authManager: manager}
 	_, err := h.executeImageGenerationTest(context.Background(), []byte(`{"model":"gpt-image-2","prompt":"test prompt"}`), imageGenerationAlt)
@@ -209,8 +212,8 @@ func TestPostImageGenerationTestExecutesCodexImageAlt(t *testing.T) {
 	if executor.alt != "images/generations" {
 		t.Fatalf("alt = %q, want images/generations", executor.alt)
 	}
-	if executor.model != "" {
-		t.Fatalf("model = %q, want empty route model for direct codex selection", executor.model)
+	if executor.model != imageGenerationModel {
+		t.Fatalf("model = %q, want %q", executor.model, imageGenerationModel)
 	}
 	if !strings.Contains(executor.payload, "test prompt") || !strings.Contains(executor.payload, "gpt-image-2") {
 		t.Fatalf("payload = %s, want prompt and model", executor.payload)
@@ -229,14 +232,7 @@ func TestPostImageGenerationTestForwardsGenerationOptions(t *testing.T) {
 	executor := &managementImageExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerManagementImageAuth(t, manager, "codex-auth-generation-options", imageGenerationModel)
 
 	h := &Handler{authManager: manager}
 	result, err := h.executeImageGenerationTest(context.Background(), []byte(`{
@@ -254,6 +250,9 @@ func TestPostImageGenerationTestForwardsGenerationOptions(t *testing.T) {
 	}
 	if executor.alt != "images/generations" {
 		t.Fatalf("alt = %q, want images/generations", executor.alt)
+	}
+	if executor.model != imageGenerationModel {
+		t.Fatalf("model = %q, want %q", executor.model, imageGenerationModel)
 	}
 	for i, payload := range executor.payloads {
 		for _, want := range []string{`"size":"1024x1792"`, `"quality":"high"`, `"n":1`} {
@@ -281,14 +280,7 @@ func TestPostImageGenerationTestCreatesTaskAndPollsSucceededResult(t *testing.T)
 	executor := &managementImageExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerManagementImageAuth(t, manager, "codex-auth-task-success", imageGenerationModel)
 
 	h := &Handler{authManager: manager}
 	rec := httptest.NewRecorder()
@@ -362,14 +354,7 @@ func TestPostImageGenerationTestCreatesTaskAndPollsFailedError(t *testing.T) {
 	}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerManagementImageAuth(t, manager, "codex-auth-task-failed", imageGenerationModel)
 
 	h := &Handler{authManager: manager}
 	rec := httptest.NewRecorder()
@@ -457,14 +442,7 @@ func TestPostImageGenerationTestAcceptsMultipartImageEdits(t *testing.T) {
 	executor := &managementImageExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerManagementImageAuth(t, manager, "codex-auth-multipart-edits", imageGenerationModel)
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
@@ -525,6 +503,9 @@ func TestPostImageGenerationTestAcceptsMultipartImageEdits(t *testing.T) {
 	}
 	if executor.alt != imageEditsAlt {
 		t.Fatalf("alt = %q, want %q", executor.alt, imageEditsAlt)
+	}
+	if executor.model != imageGenerationModel {
+		t.Fatalf("model = %q, want %q", executor.model, imageGenerationModel)
 	}
 	if !strings.Contains(executor.payload, `"mask_file"`) {
 		t.Fatalf("payload = %s, want mask_file", executor.payload)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1754,25 +1754,19 @@ func (s *Server) modelRestrictionMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		// Get allowed-models from auth metadata
-		metadataVal, exists := c.Get("accessMetadata")
-		if !exists {
-			c.Next()
-			return
+		allowedStr := ""
+		if metadataVal, exists := c.Get("accessMetadata"); exists {
+			if metadata, ok := metadataVal.(map[string]string); ok {
+				allowedStr = strings.TrimSpace(metadata["allowed-models"])
+			}
 		}
-		metadata, ok := metadataVal.(map[string]string)
-		if !ok {
-			c.Next()
-			return
-		}
-		allowedStr, exists := metadata["allowed-models"]
 		route := pathRouteContextFromGin(c)
 		routeGroup := ""
 		if route != nil {
 			routeGroup = route.Group
 		}
 		allowedGroups := allowedChannelGroupsFromAccessMetadata(c)
-		if (!exists || allowedStr == "") && !s.hasScopedRoutingModelRestriction(routeGroup, allowedGroups) {
+		if allowedStr == "" && !s.hasScopedRoutingModelRestriction(routeGroup, allowedGroups) {
 			// No restriction — allow all models
 			c.Next()
 			return

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -15,6 +15,7 @@ import (
 	gin "github.com/gin-gonic/gin"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	sdkhandlers "github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -358,6 +359,44 @@ func TestRootV1RouteForbiddenByDefaultChannelGroupAllowedModels(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "model_not_allowed") {
+		t.Fatalf("expected model_not_allowed in body, got %s", rr.Body.String())
+	}
+}
+
+func TestRouteAllowedModelsApplyWithoutAccessMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &proxyconfig.Config{
+		Routing: proxyconfig.RoutingConfig{
+			ChannelGroups: []proxyconfig.RoutingChannelGroup{
+				{
+					Name:          "pro",
+					AllowedModels: []string{"gpt-5.5"},
+				},
+			},
+		},
+	}
+	cfg.SanitizeRouting()
+	server := &Server{cfg: cfg}
+
+	router := gin.New()
+	router.POST("/test", func(c *gin.Context) {
+		attachPathRouteContext(c, &internalrouting.PathRouteContext{Group: "pro"})
+		c.Next()
+	}, server.modelRestrictionMiddleware(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"model":"gpt-image-2"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusForbidden, rr.Body.String())

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -90,7 +90,7 @@ func (h *OpenAIImagesAPIHandler) executeImages(c *gin.Context, rawJSON []byte, a
 			}
 		}
 		resp, err := h.AuthManager.Execute(cliCtx, []string{"codex"}, coreexecutor.Request{
-			Model:   "",
+			Model:   modelName,
 			Payload: execPayload,
 			Format:  sdktranslator.FromString("openai"),
 		}, coreexecutor.Options{

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
@@ -60,14 +61,10 @@ func (e *imageCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *htt
 	return nil, errors.New("not implemented")
 }
 
-func TestOpenAIImagesGenerationsExecutesCodexImageAlt(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	executor := &imageCaptureExecutor{}
-	manager := coreauth.NewManager(nil, nil, nil)
-	manager.RegisterExecutor(executor)
+func registerImageTestCodexAuth(t *testing.T, manager *coreauth.Manager, id string, models ...string) {
+	t.Helper()
 	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
+		ID:       id,
 		Provider: "codex",
 		Label:    "Team Codex",
 		Status:   coreauth.StatusActive,
@@ -75,6 +72,26 @@ func TestOpenAIImagesGenerationsExecutesCodexImageAlt(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Register auth: %v", err)
 	}
+
+	modelInfos := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if strings.TrimSpace(model) != "" {
+			modelInfos = append(modelInfos, &registry.ModelInfo{ID: model})
+		}
+	}
+	registry.GetGlobalRegistry().RegisterClient(id, "codex", modelInfos)
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(id)
+	})
+}
+
+func TestOpenAIImagesGenerationsExecutesCodexImageAlt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &imageCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	registerImageTestCodexAuth(t, manager, "codex-auth", openAIImageModelID)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
 	h := NewOpenAIImagesAPIHandler(base)
@@ -98,8 +115,8 @@ func TestOpenAIImagesGenerationsExecutesCodexImageAlt(t *testing.T) {
 	if executor.alt != "images/generations" {
 		t.Fatalf("alt = %q, want %q", executor.alt, "images/generations")
 	}
-	if executor.model != "" {
-		t.Fatalf("model = %q, want empty route model for direct codex selection", executor.model)
+	if executor.model != openAIImageModelID {
+		t.Fatalf("model = %q, want %q", executor.model, openAIImageModelID)
 	}
 	if !strings.Contains(executor.payload, "draw a fox") || !strings.Contains(executor.payload, "gpt-image-2") {
 		t.Fatalf("payload = %s, want prompt", executor.payload)
@@ -121,15 +138,7 @@ func TestOpenAIImagesGenerationsDefaultsModel(t *testing.T) {
 	executor := &imageCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Label:    "Team Codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token", "email": "team@example.com"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerImageTestCodexAuth(t, manager, "codex-auth-default-model", openAIImageModelID)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
 	h := NewOpenAIImagesAPIHandler(base)
@@ -144,11 +153,40 @@ func TestOpenAIImagesGenerationsDefaultsModel(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
 	}
-	if executor.model != "" {
-		t.Fatalf("model = %q, want empty route model for direct codex selection", executor.model)
+	if executor.model != openAIImageModelID {
+		t.Fatalf("model = %q, want %q", executor.model, openAIImageModelID)
 	}
 	if !strings.Contains(executor.payload, "gpt-image-2") {
 		t.Fatalf("payload = %s, want default model in payload", executor.payload)
+	}
+}
+
+func TestOpenAIImagesGenerationsRequiresImageModelSupport(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &imageCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	registerImageTestCodexAuth(t, manager, "codex-auth-text-only", "gpt-5.5")
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIImagesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/images/generations", h.Generations)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"gpt-image-2","prompt":"draw a fox"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusBadGateway, resp.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("executor calls = %d, want 0", executor.calls)
+	}
+	if !strings.Contains(resp.Body.String(), "auth_not_found") {
+		t.Fatalf("body = %s, want auth_not_found", resp.Body.String())
 	}
 }
 
@@ -158,15 +196,7 @@ func TestOpenAIImagesGenerationsSplitsMultipleImagesIntoSingleImageExecutions(t 
 	executor := &imageCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Label:    "Team Codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token", "email": "team@example.com"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerImageTestCodexAuth(t, manager, "codex-auth-multiple-images", openAIImageModelID)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
 	h := NewOpenAIImagesAPIHandler(base)
@@ -183,6 +213,9 @@ func TestOpenAIImagesGenerationsSplitsMultipleImagesIntoSingleImageExecutions(t 
 	}
 	if executor.calls != 3 {
 		t.Fatalf("executor calls = %d, want 3", executor.calls)
+	}
+	if executor.model != openAIImageModelID {
+		t.Fatalf("model = %q, want %q", executor.model, openAIImageModelID)
 	}
 	for i, payload := range executor.payloads {
 		if !strings.Contains(payload, `"n":1`) {
@@ -208,15 +241,7 @@ func TestOpenAIImagesEditsExecutesCodexImageEditsAlt(t *testing.T) {
 	executor := &imageCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
-	if _, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:       "codex-auth",
-		Provider: "codex",
-		Label:    "Team Codex",
-		Status:   coreauth.StatusActive,
-		Metadata: map[string]any{"access_token": "token", "email": "team@example.com"},
-	}); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
+	registerImageTestCodexAuth(t, manager, "codex-auth-edits", openAIImageModelID)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
 	h := NewOpenAIImagesAPIHandler(base)
@@ -258,6 +283,9 @@ func TestOpenAIImagesEditsExecutesCodexImageEditsAlt(t *testing.T) {
 	}
 	if executor.alt != "images/edits" {
 		t.Fatalf("alt = %q, want %q", executor.alt, "images/edits")
+	}
+	if executor.model != openAIImageModelID {
+		t.Fatalf("model = %q, want %q", executor.model, openAIImageModelID)
 	}
 	if !strings.Contains(executor.payload, `"output_format":"webp"`) {
 		t.Fatalf("payload = %s, want output_format", executor.payload)


### PR DESCRIPTION
## Summary
- Pass the parsed image model into auth selection for OpenAI image requests and management image tests
- Keep route-scoped allowed-model checks active even when API key metadata is absent
- Add regression coverage for image model capability filtering and route model restrictions

## Tests
- go test ./sdk/api/handlers/openai ./internal/api/handlers/management ./sdk/cliproxy/auth ./internal/api