### PR TITLE
feat: add OpenCode Go vision fallback

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1058,6 +1058,7 @@ func (h *Handler) PatchOpenCodeGoKey(c *gin.Context) {
 		ProxyID        *string            `json:"proxy-id"`
 		Headers        *map[string]string `json:"headers"`
 		ExcludedModels *[]string          `json:"excluded-models"`
+		VisionFallback *string            `json:"vision-fallback-model"`
 	}
 	var body struct {
 		APIKey *string          `json:"api-key"`
@@ -1120,6 +1121,9 @@ func (h *Handler) PatchOpenCodeGoKey(c *gin.Context) {
 	}
 	if body.Value.ExcludedModels != nil {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+	}
+	if body.Value.VisionFallback != nil {
+		entry.VisionFallbackModel = strings.TrimSpace(*body.Value.VisionFallback)
 	}
 	normalizeOpenCodeGoKey(&entry)
 	if entry.APIKey == "" {
@@ -1822,6 +1826,7 @@ func normalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
 	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 }
 
 func normalizedOpenCodeGoKeyEntries(entries []config.OpenCodeGoKey) []config.OpenCodeGoKey {

--- a/internal/api/handlers/management/opencode_go_config_test.go
+++ b/internal/api/handlers/management/opencode_go_config_test.go
@@ -21,7 +21,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	h := &Handler{cfg: &config.Config{}, configFilePath: configPath}
 
-	putBody := []byte(`[{"api-key":" go-key ","name":" primary ","prefix":" team ","headers":{"X-Test":" yes "}}]`)
+	putBody := []byte(`[{"api-key":" go-key ","name":" primary ","prefix":" team ","headers":{"X-Test":" yes "},"vision-fallback-model":" qwen3.5-plus "}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/opencode-go-api-key", bytes.NewReader(putBody))
@@ -29,11 +29,11 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" {
+	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v", h.cfg.OpenCodeGoKey)
 	}
 
-	patchBody := []byte(`{"index":0,"value":{"name":"secondary","excluded-models":[" minimax-m2.5 "]}}`)
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","excluded-models":[" minimax-m2.5 "],"vision-fallback-model":" qwen3.6-plus "}}`)
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/opencode-go-api-key", bytes.NewReader(patchBody))
@@ -41,7 +41,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" {
+	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.6-plus" {
 		t.Fatalf("OpenCodeGoKey after PATCH = %+v", h.cfg.OpenCodeGoKey[0])
 	}
 
@@ -58,7 +58,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -731,6 +731,9 @@ type OpenCodeGoKey struct {
 
 	// ExcludedModels lists model IDs that should be excluded for this provider.
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+
+	// VisionFallbackModel is used for image requests whose requested model lacks vision support.
+	VisionFallbackModel string `yaml:"vision-fallback-model,omitempty" json:"vision-fallback-model,omitempty"`
 }
 
 // LoadConfig reads a YAML configuration file from the given path,
@@ -1162,6 +1165,7 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
 	cfg.OpenCodeGoKey = out

--- a/internal/config/opencode_go_test.go
+++ b/internal/config/opencode_go_test.go
@@ -20,6 +20,7 @@ opencode-go-api-key:
       X-Test: " yes "
     excluded-models:
       - " deepseek-v4-pro "
+    vision-fallback-model: " qwen3.5-plus "
 `), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -44,6 +45,9 @@ opencode-go-api-key:
 	if len(got.ExcludedModels) != 1 || got.ExcludedModels[0] != "deepseek-v4-pro" {
 		t.Fatalf("excluded models = %#v", got.ExcludedModels)
 	}
+	if got.VisionFallbackModel != "qwen3.5-plus" {
+		t.Fatalf("vision fallback model = %q, want qwen3.5-plus", got.VisionFallbackModel)
+	}
 }
 
 func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
@@ -52,7 +56,7 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 			{APIKey: " "},
 			{APIKey: "go-key", Prefix: " team "},
 			{APIKey: "go-key", Prefix: "duplicate"},
-			{APIKey: "go-key-2", Headers: map[string]string{" X-Trace ": " on "}},
+			{APIKey: "go-key-2", Headers: map[string]string{" X-Trace ": " on "}, VisionFallbackModel: " qwen3.6-plus "},
 		},
 	}
 
@@ -66,5 +70,8 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 	}
 	if cfg.OpenCodeGoKey[1].Headers["X-Trace"] != "on" {
 		t.Fatalf("headers = %#v, want normalized header", cfg.OpenCodeGoKey[1].Headers)
+	}
+	if cfg.OpenCodeGoKey[1].VisionFallbackModel != "qwen3.6-plus" {
+		t.Fatalf("vision fallback model = %q, want qwen3.6-plus", cfg.OpenCodeGoKey[1].VisionFallbackModel)
 	}
 }

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -26,6 +27,11 @@ var opencodeGoBaseURL = "https://opencode.ai/zen/go/v1"
 var opencodeGoMessagesModels = map[string]struct{}{
 	"minimax-m2.7": {},
 	"minimax-m2.5": {},
+}
+
+var opencodeGoVisionModels = map[string]struct{}{
+	"qwen3.5-plus": {},
+	"qwen3.6-plus": {},
 }
 
 // OpenCodeGoExecutor routes OpenCode Go models to the provider's mixed OpenAI/Anthropic endpoints.
@@ -70,6 +76,7 @@ func (e *OpenCodeGoExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth
 }
 
 func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	req = e.applyVisionFallback(auth, req)
 	if opencodeGoUsesMessages(req.Model) {
 		return e.executeMessages(ctx, auth, req, opts)
 	}
@@ -77,6 +84,7 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 }
 
 func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	req = e.applyVisionFallback(auth, req)
 	if opencodeGoUsesMessages(req.Model) {
 		return e.executeMessagesStream(ctx, auth, req, opts)
 	}
@@ -97,6 +105,130 @@ func (e *OpenCodeGoExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Aut
 
 func (e *OpenCodeGoExecutor) openAIExecutor() *OpenAICompatExecutor {
 	return NewOpenAICompatExecutor(openCodeGoProvider, e.cfg)
+}
+
+func (e *OpenCodeGoExecutor) applyVisionFallback(auth *cliproxyauth.Auth, req cliproxyexecutor.Request) cliproxyexecutor.Request {
+	fallback := opencodeGoVisionFallbackModel(e.cfg, auth)
+	if fallback == "" || !opencodeGoPayloadHasImage(req.Payload) {
+		return req
+	}
+	if !opencodeGoSupportsNativeVision(fallback) {
+		return req
+	}
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	if strings.EqualFold(baseModel, fallback) || opencodeGoSupportsNativeVision(baseModel) {
+		return req
+	}
+	req.Model = fallback
+	req.Payload, _ = sjson.SetBytes(req.Payload, "model", fallback)
+	if opencodeGoDisablesThinkingForVisionFallback(fallback) {
+		req.Payload, _ = sjson.SetBytes(req.Payload, "enable_thinking", false)
+	}
+	return req
+}
+
+func opencodeGoVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if auth.Attributes != nil {
+		if fallback := strings.TrimSpace(auth.Attributes["vision_fallback_model"]); fallback != "" {
+			if opencodeGoModelExcluded(fallback, auth.Attributes["excluded_models"]) {
+				return ""
+			}
+			return fallback
+		}
+	}
+	if cfg == nil {
+		return ""
+	}
+	apiKey := ""
+	if auth.Attributes != nil {
+		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+	}
+	if apiKey == "" {
+		return ""
+	}
+	for i := range cfg.OpenCodeGoKey {
+		entry := &cfg.OpenCodeGoKey[i]
+		if strings.EqualFold(strings.TrimSpace(entry.APIKey), apiKey) {
+			fallback := strings.TrimSpace(entry.VisionFallbackModel)
+			if opencodeGoModelExcluded(fallback, strings.Join(entry.ExcludedModels, ",")) {
+				return ""
+			}
+			return fallback
+		}
+	}
+	return ""
+}
+
+func opencodeGoModelExcluded(model, excluded string) bool {
+	model = strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(model).ModelName))
+	if model == "" {
+		return true
+	}
+	for _, entry := range strings.Split(excluded, ",") {
+		entry = strings.ToLower(strings.TrimSpace(entry))
+		if entry == "" {
+			continue
+		}
+		if entry == "*" || entry == model {
+			return true
+		}
+	}
+	return false
+}
+
+func opencodeGoPayloadHasImage(payload []byte) bool {
+	if len(payload) == 0 || !json.Valid(payload) {
+		return false
+	}
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return false
+	}
+	return opencodeGoValueHasImage(value)
+}
+
+func opencodeGoValueHasImage(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		if rawType, ok := typed["type"].(string); ok {
+			switch strings.ToLower(strings.TrimSpace(rawType)) {
+			case "image", "image_url", "input_image":
+				return true
+			}
+		}
+		if _, ok := typed["image_url"]; ok {
+			return true
+		}
+		for _, child := range typed {
+			if opencodeGoValueHasImage(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if opencodeGoValueHasImage(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func opencodeGoSupportsNativeVision(model string) bool {
+	baseModel := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(model).ModelName))
+	if baseModel == "" {
+		return false
+	}
+	_, ok := opencodeGoVisionModels[baseModel]
+	return ok
+}
+
+func opencodeGoDisablesThinkingForVisionFallback(model string) bool {
+	baseModel := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(model).ModelName))
+	return strings.HasPrefix(baseModel, "qwen")
 }
 
 func (e *OpenCodeGoExecutor) executeMessages(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -56,6 +56,154 @@ func TestOpenCodeGoExecutorRoutesOpenAIModelsToChatCompletions(t *testing.T) {
 	}
 }
 
+func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"qwen3.5-plus","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "qwen3.5-plus",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotPath != "/zen/go/v1/chat/completions" {
+		t.Fatalf("path = %q, want /zen/go/v1/chat/completions", gotPath)
+	}
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
+		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
+	}
+	if !gjson.GetBytes(gotBody, "enable_thinking").Exists() || gjson.GetBytes(gotBody, "enable_thinking").Bool() {
+		t.Fatalf("enable_thinking = %s, want false; body=%s", gjson.GetBytes(gotBody, "enable_thinking").Raw, string(gotBody))
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); gotText != "vision ok" {
+		t.Fatalf("response text = %q, want vision ok; payload=%s", gotText, string(resp.Payload))
+	}
+}
+
+func TestOpenCodeGoExecutorLeavesTextRequestsOnRequestedModel(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_text","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"text ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "qwen3.5-plus",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}`)
+	if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
+		t.Fatalf("enable_thinking should not be added for text requests; body=%s", string(gotBody))
+	}
+}
+
+func TestOpenCodeGoExecutorIgnoresExcludedVisionFallback(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_excluded","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "qwen3.5-plus",
+			"excluded_models":       "qwen3.5-plus",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
+	if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	}
+}
+
+func TestOpenCodeGoExecutorIgnoresNonVisionFallback(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_nonvision","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "deepseek-v4-pro",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
+	if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	}
+}
+
 func TestOpenCodeGoExecutorRoutesMiniMaxModelsToMessages(t *testing.T) {
 	var gotPath, gotAuth string
 	var gotBody []byte

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -324,6 +324,9 @@ func (s *ConfigSynthesizer) synthesizeOpenCodeGoKeys(ctx *SynthesisContext) []*c
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
+		if visionFallbackModel := strings.TrimSpace(entry.VisionFallbackModel); visionFallbackModel != "" {
+			attrs["vision_fallback_model"] = visionFallbackModel
+		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
 		label := strings.TrimSpace(entry.Name)
 		if label == "" {

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -302,14 +302,15 @@ func TestConfigSynthesizer_OpenCodeGoKeys(t *testing.T) {
 		Config: &config.Config{
 			OpenCodeGoKey: []config.OpenCodeGoKey{
 				{
-					APIKey:         "go-key",
-					Name:           "go",
-					Priority:       9,
-					Prefix:         "team",
-					ProxyURL:       "http://proxy",
-					ProxyID:        "hk",
-					Headers:        map[string]string{"X-Test": "yes"},
-					ExcludedModels: []string{"minimax-m2.5"},
+					APIKey:              "go-key",
+					Name:                "go",
+					Priority:            9,
+					Prefix:              "team",
+					ProxyURL:            "http://proxy",
+					ProxyID:             "hk",
+					Headers:             map[string]string{"X-Test": "yes"},
+					ExcludedModels:      []string{"minimax-m2.5"},
+					VisionFallbackModel: "qwen3.5-plus",
 				},
 			},
 		},
@@ -336,6 +337,9 @@ func TestConfigSynthesizer_OpenCodeGoKeys(t *testing.T) {
 	}
 	if auth.Attributes["auth_kind"] != "apikey" || auth.Attributes["excluded_models"] != "minimax-m2.5" {
 		t.Fatalf("expected api key exclusion metadata, got %#v", auth.Attributes)
+	}
+	if auth.Attributes["vision_fallback_model"] != "qwen3.5-plus" {
+		t.Fatalf("expected vision fallback metadata, got %#v", auth.Attributes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an OpenCode Go key setting for a vision fallback model
- route image requests from non-vision OpenCode Go models to the configured native vision model
- preserve text requests on the originally requested model and reject unavailable fallback choices

## Validation
- go test ./internal/runtime/executor -run 'TestOpenCodeGoExecutor'
- go test ./internal/runtime/executor ./internal/config ./internal/api/handlers/management ./internal/watcher/synthesizer
- git diff --check
