### PR TITLE
fix: prevent OpenCode vision fallback model leakage

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -76,19 +76,36 @@ func (e *OpenCodeGoExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth
 }
 
 func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	req = e.applyVisionFallback(auth, req)
+	fallback := e.applyVisionFallback(auth, req, opts)
+	req = fallback.Request
+	var resp cliproxyexecutor.Response
+	var err error
 	if opencodeGoUsesMessages(req.Model) {
-		return e.executeMessages(ctx, auth, req, opts)
+		resp, err = e.executeMessages(ctx, auth, req, opts)
+	} else {
+		resp, err = e.openAIExecutor().Execute(ctx, opencodeGoAuthWithBaseURL(auth), req, opts)
 	}
-	return e.openAIExecutor().Execute(ctx, opencodeGoAuthWithBaseURL(auth), req, opts)
+	if err != nil || !fallback.Applied {
+		return resp, err
+	}
+	resp.Payload = opencodeGoRewriteFallbackResponseModel(resp.Payload, fallback.OriginalModel)
+	return resp, nil
 }
 
 func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
-	req = e.applyVisionFallback(auth, req)
+	fallback := e.applyVisionFallback(auth, req, opts)
+	req = fallback.Request
+	var result *cliproxyexecutor.StreamResult
+	var err error
 	if opencodeGoUsesMessages(req.Model) {
-		return e.executeMessagesStream(ctx, auth, req, opts)
+		result, err = e.executeMessagesStream(ctx, auth, req, opts)
+	} else {
+		result, err = e.openAIExecutor().ExecuteStream(ctx, opencodeGoAuthWithBaseURL(auth), req, opts)
 	}
-	return e.openAIExecutor().ExecuteStream(ctx, opencodeGoAuthWithBaseURL(auth), req, opts)
+	if err != nil || !fallback.Applied {
+		return result, err
+	}
+	return opencodeGoRewriteFallbackStreamResult(result, fallback.OriginalModel), nil
 }
 
 func (e *OpenCodeGoExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
@@ -107,24 +124,38 @@ func (e *OpenCodeGoExecutor) openAIExecutor() *OpenAICompatExecutor {
 	return NewOpenAICompatExecutor(openCodeGoProvider, e.cfg)
 }
 
-func (e *OpenCodeGoExecutor) applyVisionFallback(auth *cliproxyauth.Auth, req cliproxyexecutor.Request) cliproxyexecutor.Request {
+type opencodeGoVisionFallbackResult struct {
+	Request       cliproxyexecutor.Request
+	OriginalModel string
+	FallbackModel string
+	Applied       bool
+}
+
+func (e *OpenCodeGoExecutor) applyVisionFallback(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) opencodeGoVisionFallbackResult {
+	result := opencodeGoVisionFallbackResult{
+		Request:       req,
+		OriginalModel: payloadRequestedModel(opts, req.Model),
+	}
 	fallback := opencodeGoVisionFallbackModel(e.cfg, auth)
-	if fallback == "" || !opencodeGoPayloadHasImage(req.Payload) {
-		return req
+	if fallback == "" || !opencodeGoCurrentRequestHasImage(req.Payload) {
+		return result
 	}
 	if !opencodeGoSupportsNativeVision(fallback) {
-		return req
+		return result
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	if strings.EqualFold(baseModel, fallback) || opencodeGoSupportsNativeVision(baseModel) {
-		return req
+		return result
 	}
 	req.Model = fallback
 	req.Payload, _ = sjson.SetBytes(req.Payload, "model", fallback)
 	if opencodeGoDisablesThinkingForVisionFallback(fallback) {
 		req.Payload, _ = sjson.SetBytes(req.Payload, "enable_thinking", false)
 	}
-	return req
+	result.Request = req
+	result.FallbackModel = fallback
+	result.Applied = true
+	return result
 }
 
 func opencodeGoVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth) string {
@@ -190,6 +221,94 @@ func opencodeGoPayloadHasImage(payload []byte) bool {
 	return opencodeGoValueHasImage(value)
 }
 
+func opencodeGoCurrentRequestHasImage(payload []byte) bool {
+	if len(payload) == 0 || !json.Valid(payload) {
+		return false
+	}
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return false
+	}
+	if hasImage, recognized := opencodeGoCurrentValueHasImage(value); recognized {
+		return hasImage
+	}
+	return opencodeGoValueHasImage(value)
+}
+
+func opencodeGoCurrentValueHasImage(value any) (bool, bool) {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return false, false
+	}
+	if messages, ok := root["messages"].([]any); ok {
+		return opencodeGoLatestUserMessageHasImage(messages)
+	}
+	if input, ok := root["input"]; ok {
+		return opencodeGoInputHasImage(input)
+	}
+	return false, false
+}
+
+func opencodeGoLatestUserMessageHasImage(messages []any) (bool, bool) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		message, ok := messages[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := message["role"].(string)
+		if !strings.EqualFold(strings.TrimSpace(role), "user") {
+			continue
+		}
+		if content, ok := message["content"]; ok {
+			return opencodeGoValueHasImage(content), true
+		}
+		return opencodeGoValueHasImage(message), true
+	}
+	return false, false
+}
+
+func opencodeGoInputHasImage(input any) (bool, bool) {
+	switch typed := input.(type) {
+	case string:
+		return false, true
+	case map[string]any:
+		return opencodeGoValueHasImage(typed), true
+	case []any:
+		if hasImage, recognized := opencodeGoLatestUserInputItemHasImage(typed); recognized {
+			return hasImage, true
+		}
+		return opencodeGoValueHasImage(typed), true
+	default:
+		return false, false
+	}
+}
+
+func opencodeGoLatestUserInputItemHasImage(items []any) (bool, bool) {
+	sawRole := false
+	for i := len(items) - 1; i >= 0; i-- {
+		item, ok := items[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		role, ok := item["role"].(string)
+		if !ok {
+			continue
+		}
+		sawRole = true
+		if !strings.EqualFold(strings.TrimSpace(role), "user") {
+			continue
+		}
+		if content, ok := item["content"]; ok {
+			return opencodeGoValueHasImage(content), true
+		}
+		return opencodeGoValueHasImage(item), true
+	}
+	if sawRole {
+		return false, true
+	}
+	return false, false
+}
+
 func opencodeGoValueHasImage(value any) bool {
 	switch typed := value.(type) {
 	case map[string]any:
@@ -229,6 +348,85 @@ func opencodeGoSupportsNativeVision(model string) bool {
 func opencodeGoDisablesThinkingForVisionFallback(model string) bool {
 	baseModel := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(model).ModelName))
 	return strings.HasPrefix(baseModel, "qwen")
+}
+
+var opencodeGoFallbackModelFieldPaths = []string{
+	"model",
+	"modelVersion",
+	"message.model",
+	"response.model",
+	"response.modelVersion",
+}
+
+func opencodeGoRewriteFallbackResponseModel(data []byte, originalModel string) []byte {
+	originalModel = strings.TrimSpace(originalModel)
+	if originalModel == "" || len(data) == 0 || !gjson.ValidBytes(bytes.TrimSpace(data)) {
+		return data
+	}
+	out := data
+	for _, path := range opencodeGoFallbackModelFieldPaths {
+		if !gjson.GetBytes(out, path).Exists() {
+			continue
+		}
+		updated, err := sjson.SetBytes(out, path, originalModel)
+		if err == nil {
+			out = updated
+		}
+	}
+	return out
+}
+
+func opencodeGoRewriteFallbackStreamResult(result *cliproxyexecutor.StreamResult, originalModel string) *cliproxyexecutor.StreamResult {
+	if result == nil || strings.TrimSpace(originalModel) == "" {
+		return result
+	}
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		for chunk := range result.Chunks {
+			if chunk.Err == nil && len(chunk.Payload) > 0 {
+				chunk.Payload = opencodeGoRewriteFallbackStreamPayload(chunk.Payload, originalModel)
+			}
+			out <- chunk
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: result.Headers, Chunks: out}
+}
+
+func opencodeGoRewriteFallbackStreamPayload(payload []byte, originalModel string) []byte {
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return payload
+	}
+	if gjson.ValidBytes(trimmed) {
+		return opencodeGoRewriteFallbackResponseModel(payload, originalModel)
+	}
+	lines := bytes.Split(payload, []byte("\n"))
+	modified := false
+	for i, line := range lines {
+		dataIdx := bytes.Index(line, []byte("data:"))
+		if dataIdx < 0 {
+			continue
+		}
+		raw := bytes.TrimSpace(line[dataIdx+len("data:"):])
+		if len(raw) == 0 || bytes.Equal(raw, []byte("[DONE]")) || !gjson.ValidBytes(raw) {
+			continue
+		}
+		rewritten := opencodeGoRewriteFallbackResponseModel(raw, originalModel)
+		if bytes.Equal(rewritten, raw) {
+			continue
+		}
+		rebuilt := make([]byte, 0, len(line)-len(raw)+len(rewritten)+1)
+		rebuilt = append(rebuilt, line[:dataIdx]...)
+		rebuilt = append(rebuilt, []byte("data: ")...)
+		rebuilt = append(rebuilt, rewritten...)
+		lines[i] = rebuilt
+		modified = true
+	}
+	if !modified {
+		return payload
+	}
+	return bytes.Join(lines, []byte("\n"))
 }
 
 func (e *OpenCodeGoExecutor) executeMessages(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -93,6 +94,9 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
 		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
 	}
+	if gotModel := gjson.GetBytes(resp.Payload, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("response model = %q, want deepseek-v4-flash; payload=%s", gotModel, string(resp.Payload))
+	}
 	if !gjson.GetBytes(gotBody, "enable_thinking").Exists() || gjson.GetBytes(gotBody, "enable_thinking").Bool() {
 		t.Fatalf("enable_thinking = %s, want false; body=%s", gjson.GetBytes(gotBody, "enable_thinking").Raw, string(gotBody))
 	}
@@ -134,6 +138,102 @@ func TestOpenCodeGoExecutorLeavesTextRequestsOnRequestedModel(t *testing.T) {
 	}
 	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
 		t.Fatalf("enable_thinking should not be added for text requests; body=%s", string(gotBody))
+	}
+}
+
+func TestOpenCodeGoExecutorLeavesTextFollowUpWithHistoricalImageOnRequestedModel(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_followup","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"text follow-up ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "qwen3.5-plus",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]},{"role":"assistant","content":"vision ok"},{"role":"user","content":"now answer a normal text question"}]}`)
+	if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
+		t.Fatalf("enable_thinking should not be added for text follow-up; body=%s", string(gotBody))
+	}
+}
+
+func TestOpenCodeGoExecutorStreamRewritesVisionFallbackModel(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_stream","object":"chat.completion.chunk","created":1,"model":"qwen3.5-plus","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}` + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "qwen3.5-plus",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream returned error: %v", err)
+	}
+
+	var chunks strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		chunks.Write(chunk.Payload)
+	}
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
+		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
+	}
+	out := chunks.String()
+	if strings.Contains(out, "qwen3.5-plus") {
+		t.Fatalf("stream leaked fallback model qwen3.5-plus; chunks=%s", out)
+	}
+	if !strings.Contains(out, "deepseek-v4-flash") {
+		t.Fatalf("stream chunks should expose original model; chunks=%s", out)
+	}
+}
+
+func TestOpenCodeGoRewriteFallbackStreamPayloadRewritesSSEModelFields(t *testing.T) {
+	chunk := []byte("event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"qwen3.5-plus\"}}\n\n")
+	got := string(opencodeGoRewriteFallbackStreamPayload(chunk, "deepseek-v4-flash"))
+	if strings.Contains(got, "qwen3.5-plus") {
+		t.Fatalf("SSE chunk leaked fallback model: %s", got)
+	}
+	if !strings.Contains(got, `"model":"deepseek-v4-flash"`) {
+		t.Fatalf("SSE chunk should expose original model: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- limit OpenCode Go vision fallback detection to the current user input so historical image turns do not force later text-only requests onto the vision model
- rewrite fallback response model fields back to the client-requested model for non-streaming and streaming responses
- add regression coverage for image fallback, text follow-ups with historical images, and streaming model rewriting

## Tests
- go test ./internal/runtime/executor -run 'TestOpenCodeGoExecutor'\n- go test ./internal/runtime/executor\n- go test ./internal/config ./internal/api/handlers/management ./internal/watcher/synthesizer\n- git diff --check