### PR TITLE
fix: sanitize OpenCode historical image parts

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -78,6 +78,9 @@ func (e *OpenCodeGoExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth
 func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	fallback := e.applyVisionFallback(auth, req, opts)
 	req = fallback.Request
+	if !fallback.Applied {
+		req = e.sanitizeHistoricalImagesForTextModel(req)
+	}
 	var resp cliproxyexecutor.Response
 	var err error
 	if opencodeGoUsesMessages(req.Model) {
@@ -95,6 +98,9 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	fallback := e.applyVisionFallback(auth, req, opts)
 	req = fallback.Request
+	if !fallback.Applied {
+		req = e.sanitizeHistoricalImagesForTextModel(req)
+	}
 	var result *cliproxyexecutor.StreamResult
 	var err error
 	if opencodeGoUsesMessages(req.Model) {
@@ -156,6 +162,20 @@ func (e *OpenCodeGoExecutor) applyVisionFallback(auth *cliproxyauth.Auth, req cl
 	result.FallbackModel = fallback
 	result.Applied = true
 	return result
+}
+
+func (e *OpenCodeGoExecutor) sanitizeHistoricalImagesForTextModel(req cliproxyexecutor.Request) cliproxyexecutor.Request {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	if opencodeGoSupportsNativeVision(baseModel) {
+		return req
+	}
+	if opencodeGoCurrentRequestHasImage(req.Payload) || !opencodeGoPayloadHasImage(req.Payload) {
+		return req
+	}
+	if payload, ok := opencodeGoSanitizeHistoricalImages(req.Payload); ok {
+		req.Payload = payload
+	}
+	return req
 }
 
 func opencodeGoVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth) string {
@@ -233,6 +253,161 @@ func opencodeGoCurrentRequestHasImage(payload []byte) bool {
 		return hasImage
 	}
 	return opencodeGoValueHasImage(value)
+}
+
+func opencodeGoSanitizeHistoricalImages(payload []byte) ([]byte, bool) {
+	if len(payload) == 0 || !json.Valid(payload) {
+		return payload, false
+	}
+	var root map[string]any
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return payload, false
+	}
+	changed := false
+	if messages, ok := root["messages"].([]any); ok {
+		if opencodeGoSanitizeMessageArray(messages) {
+			root["messages"] = messages
+			changed = true
+		}
+	}
+	if input, ok := root["input"]; ok {
+		if sanitized, ok := opencodeGoSanitizeResponsesInput(input); ok {
+			root["input"] = sanitized
+			changed = true
+		}
+	}
+	if !changed {
+		return payload, false
+	}
+	out, err := json.Marshal(root)
+	if err != nil {
+		return payload, false
+	}
+	return out, true
+}
+
+func opencodeGoSanitizeMessageArray(messages []any) bool {
+	changed := false
+	for _, raw := range messages {
+		message, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		content, ok := message["content"]
+		if !ok {
+			continue
+		}
+		if sanitized, ok := opencodeGoSanitizeContentParts(content, "text"); ok {
+			message["content"] = sanitized
+			changed = true
+		}
+	}
+	return changed
+}
+
+func opencodeGoSanitizeResponsesInput(input any) (any, bool) {
+	switch typed := input.(type) {
+	case []any:
+		changed := false
+		for i, raw := range typed {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if opencodeGoContentPartIsImage(item) {
+				typed[i] = opencodeGoImagePlaceholderPart("input_text")
+				changed = true
+				continue
+			}
+			content, ok := item["content"]
+			if !ok {
+				continue
+			}
+			if sanitized, ok := opencodeGoSanitizeContentParts(content, "input_text"); ok {
+				item["content"] = sanitized
+				changed = true
+			}
+		}
+		return typed, changed
+	case map[string]any:
+		if opencodeGoContentPartIsImage(typed) {
+			return opencodeGoImagePlaceholderPart("input_text"), true
+		}
+		content, ok := typed["content"]
+		if !ok {
+			return input, false
+		}
+		if sanitized, ok := opencodeGoSanitizeContentParts(content, "input_text"); ok {
+			typed["content"] = sanitized
+			return typed, true
+		}
+	}
+	return input, false
+}
+
+func opencodeGoSanitizeContentParts(content any, placeholderType string) (any, bool) {
+	parts, ok := content.([]any)
+	if !ok {
+		return content, false
+	}
+	changed := false
+	out := make([]any, 0, len(parts))
+	for _, part := range parts {
+		partMap, ok := part.(map[string]any)
+		if !ok || !opencodeGoContentPartIsImage(partMap) {
+			out = append(out, part)
+			continue
+		}
+		if !opencodeGoContentPartsHaveText(out) {
+			out = append(out, opencodeGoImagePlaceholderPart(placeholderType))
+		}
+		changed = true
+	}
+	if !changed {
+		return content, false
+	}
+	if len(out) == 0 {
+		out = append(out, opencodeGoImagePlaceholderPart(placeholderType))
+	}
+	return out, true
+}
+
+func opencodeGoContentPartIsImage(part map[string]any) bool {
+	rawType, _ := part["type"].(string)
+	switch strings.ToLower(strings.TrimSpace(rawType)) {
+	case "image", "image_url", "input_image":
+		return true
+	}
+	_, ok := part["image_url"]
+	return ok
+}
+
+func opencodeGoContentPartsHaveText(parts []any) bool {
+	for _, part := range parts {
+		partMap, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		rawType, _ := partMap["type"].(string)
+		switch strings.ToLower(strings.TrimSpace(rawType)) {
+		case "text", "input_text", "output_text":
+			if text, _ := partMap["text"].(string); strings.TrimSpace(text) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func opencodeGoImagePlaceholderPart(partType string) map[string]any {
+	partType = strings.TrimSpace(partType)
+	if partType == "" {
+		partType = "text"
+	}
+	return map[string]any{
+		"type": partType,
+		"text": "[Image omitted from previous turn.]",
+	}
 }
 
 func opencodeGoCurrentValueHasImage(value any) (bool, bool) {

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -94,6 +94,9 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
 		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
 	}
+	if !strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("current image should be preserved for vision fallback; body=%s", string(gotBody))
+	}
 	if gotModel := gjson.GetBytes(resp.Payload, "model").String(); gotModel != "deepseek-v4-flash" {
 		t.Fatalf("response model = %q, want deepseek-v4-flash; payload=%s", gotModel, string(resp.Payload))
 	}
@@ -172,8 +175,50 @@ func TestOpenCodeGoExecutorLeavesTextFollowUpWithHistoricalImageOnRequestedModel
 	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
 		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
 	}
+	if strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("historical image_url should be sanitized for text follow-up; body=%s", string(gotBody))
+	}
 	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
 		t.Fatalf("enable_thinking should not be added for text follow-up; body=%s", string(gotBody))
+	}
+}
+
+func TestOpenCodeGoExecutorSanitizesResponsesHistoryImagesForTextFollowUp(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_response_followup","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"response follow-up ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "qwen3.5-plus",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","input":[{"role":"user","content":[{"type":"input_text","text":"what is this?"},{"type":"input_image","image_url":"data:image/png;base64,aGVsbG8="}]},{"role":"assistant","content":[{"type":"output_text","text":"vision ok"}]},{"role":"user","content":[{"type":"input_text","text":"now answer a normal text question"}]}]}`)
+	if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	}
+	if strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("historical input_image should not translate to upstream image_url; body=%s", string(gotBody))
+	}
+	if !strings.Contains(string(gotBody), "now answer a normal text question") {
+		t.Fatalf("current text should be preserved; body=%s", string(gotBody))
 	}
 }
 


### PR DESCRIPTION
## Summary
- sanitize historical image content before sending text-only follow-up requests to non-vision OpenCode Go models
- preserve current-turn images so configured vision fallback still receives image inputs
- add regression coverage for chat completions and responses history with prior images

## Tests
- go test ./internal/runtime/executor -run 'TestOpenCodeGoExecutor'\n- go test ./internal/runtime/executor\n- go test ./internal/config ./internal/api/handlers/management ./internal/watcher/synthesizer\n- git diff --check