### PR TITLE
fix: expand OpenCode Go vision fallback models

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -29,9 +29,12 @@ var opencodeGoMessagesModels = map[string]struct{}{
 	"minimax-m2.5": {},
 }
 
-var opencodeGoVisionModels = map[string]struct{}{
-	"qwen3.5-plus": {},
-	"qwen3.6-plus": {},
+var opencodeGoKnownNativeVisionModels = map[string]struct{}{
+	"qwen3.5-plus":  {},
+	"qwen3.6-plus":  {},
+	"mimo-v2-omni":  {},
+	"mimo-v2.5":     {},
+	"mimo-v2.5-pro": {},
 }
 
 // OpenCodeGoExecutor routes OpenCode Go models to the provider's mixed OpenAI/Anthropic endpoints.
@@ -516,8 +519,26 @@ func opencodeGoSupportsNativeVision(model string) bool {
 	if baseModel == "" {
 		return false
 	}
-	_, ok := opencodeGoVisionModels[baseModel]
-	return ok
+	if _, ok := opencodeGoKnownNativeVisionModels[baseModel]; ok {
+		return true
+	}
+	return opencodeGoModelNameImpliesVision(baseModel)
+}
+
+func opencodeGoModelNameImpliesVision(model string) bool {
+	if strings.Contains(model, "vision") ||
+		strings.Contains(model, "multimodal") ||
+		strings.Contains(model, "omni") {
+		return true
+	}
+	for _, token := range strings.FieldsFunc(model, func(r rune) bool {
+		return r == '-' || r == '_' || r == '.' || r == '/' || r == ':'
+	}) {
+		if token == "vl" {
+			return true
+		}
+	}
+	return false
 }
 
 func opencodeGoDisablesThinkingForVisionFallback(model string) bool {

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -108,6 +108,82 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 	}
 }
 
+func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"mimo-v2-omni","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "mimo-v2-omni",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "mimo-v2-omni" {
+		t.Fatalf("upstream model = %q, want mimo-v2-omni; body=%s", gotModel, string(gotBody))
+	}
+	if !strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("current image should be preserved for configured vision fallback; body=%s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
+		t.Fatalf("enable_thinking should not be added for non-qwen fallback; body=%s", string(gotBody))
+	}
+	if gotModel := gjson.GetBytes(resp.Payload, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("response model = %q, want deepseek-v4-flash; payload=%s", gotModel, string(resp.Payload))
+	}
+}
+
+func TestOpenCodeGoExecutorIgnoresConfiguredTextOnlyFallbackModel(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_text_only_fallback","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "deepseek-v4-pro",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
+	if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	}
+}
+
 func TestOpenCodeGoExecutorLeavesTextRequestsOnRequestedModel(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -301,39 +377,6 @@ func TestOpenCodeGoExecutorIgnoresExcludedVisionFallback(t *testing.T) {
 			"api_key":               "test-key",
 			"vision_fallback_model": "qwen3.5-plus",
 			"excluded_models":       "qwen3.5-plus",
-		},
-	}
-	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
-	if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "deepseek-v4-flash",
-		Payload: payload,
-	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}); err != nil {
-		t.Fatalf("Execute returned error: %v", err)
-	}
-
-	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
-		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
-	}
-}
-
-func TestOpenCodeGoExecutorIgnoresNonVisionFallback(t *testing.T) {
-	var gotBody []byte
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"chatcmpl_nonvision","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
-	}))
-	defer server.Close()
-
-	oldBaseURL := opencodeGoBaseURL
-	opencodeGoBaseURL = server.URL + "/zen/go/v1"
-	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
-
-	exec := NewOpenCodeGoExecutor(&config.Config{})
-	auth := &cliproxyauth.Auth{
-		Attributes: map[string]string{
-			"api_key":               "test-key",
-			"vision_fallback_model": "deepseek-v4-pro",
 		},
 	}
 	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)


### PR DESCRIPTION
## Summary
- expand OpenCode Go vision fallback detection beyond the initial qwen-only allowlist
- keep text-only models from being used as image fallback models
- add executor tests for non-qwen vision fallback and text-only fallback rejection

## Verification
- go test ./internal/runtime/executor -run 'TestOpenCodeGoExecutor|TestOpenCodeGoRewriteFallbackStreamPayload'