### PR TITLE
feat: sync model capability metadata

### DIFF
--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -53,11 +53,13 @@ type configuredModelPathRoute struct {
 }
 
 type modelConfigPayload struct {
-	ID          string `json:"id"`
-	OwnedBy     string `json:"owned_by"`
-	Description string `json:"description"`
-	Enabled     bool   `json:"enabled"`
-	Pricing     struct {
+	ID               string    `json:"id"`
+	OwnedBy          string    `json:"owned_by"`
+	Description      string    `json:"description"`
+	Enabled          bool      `json:"enabled"`
+	InputModalities  *[]string `json:"input_modalities"`
+	OutputModalities *[]string `json:"output_modalities"`
+	Pricing          struct {
 		Mode                  string  `json:"mode"`
 		InputPricePerMillion  float64 `json:"input_price_per_million"`
 		OutputPricePerMillion float64 `json:"output_price_per_million"`
@@ -67,7 +69,7 @@ type modelConfigPayload struct {
 }
 
 func modelConfigResponse(row usage.ModelConfigRow) map[string]any {
-	return map[string]any{
+	response := map[string]any{
 		"id":          row.ModelID,
 		"owned_by":    row.OwnedBy,
 		"description": row.Description,
@@ -82,6 +84,30 @@ func modelConfigResponse(row usage.ModelConfigRow) map[string]any {
 		"source":     row.Source,
 		"updated_at": row.UpdatedAt,
 	}
+	attachModelConfigCapabilities(response, row)
+	return response
+}
+
+func modelConfigModalitiesJSON(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return values
+}
+
+func modelConfigSupportsVision(row usage.ModelConfigRow) bool {
+	for _, modality := range row.InputModalities {
+		if strings.EqualFold(strings.TrimSpace(modality), "image") {
+			return true
+		}
+	}
+	return false
+}
+
+func attachModelConfigCapabilities(target map[string]any, row usage.ModelConfigRow) {
+	target["input_modalities"] = modelConfigModalitiesJSON(row.InputModalities)
+	target["output_modalities"] = modelConfigModalitiesJSON(row.OutputModalities)
+	target["supports_vision"] = modelConfigSupportsVision(row)
 }
 
 func capabilityPath(prefix, suffix string) string {
@@ -315,7 +341,7 @@ func modelConfigPayloadToRow(payload modelConfigPayload, scope string) usage.Mod
 	if scope == "library" {
 		source = "seed"
 	}
-	return usage.ModelConfigRow{
+	row := usage.ModelConfigRow{
 		ModelID:               strings.TrimSpace(payload.ID),
 		OwnedBy:               strings.TrimSpace(payload.OwnedBy),
 		Description:           strings.TrimSpace(payload.Description),
@@ -327,6 +353,13 @@ func modelConfigPayloadToRow(payload modelConfigPayload, scope string) usage.Mod
 		PricePerCall:          payload.Pricing.PricePerCall,
 		Source:                source,
 	}
+	if payload.InputModalities != nil {
+		row.InputModalities = *payload.InputModalities
+	}
+	if payload.OutputModalities != nil {
+		row.OutputModalities = *payload.OutputModalities
+	}
+	return row
 }
 
 func modelConfigParamID(c *gin.Context) string {
@@ -408,6 +441,9 @@ func (h *Handler) GetModels(c *gin.Context) {
 
 		// Attach pricing if available
 		if modelID, ok := model["id"].(string); ok {
+			if row, exists := usage.GetModelConfig(modelID); exists {
+				attachModelConfigCapabilities(filteredModel, row)
+			}
 			if pricing, exists := pricingMap[modelID]; exists {
 				filteredModel["pricing"] = map[string]any{
 					"input_price_per_million":  pricing.InputPricePerMillion,
@@ -519,6 +555,14 @@ func (h *Handler) PostModelConfig(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "model id is required"})
 		return
 	}
+	if existing, ok := usage.GetModelConfig(row.ModelID); ok {
+		if payload.InputModalities == nil {
+			row.InputModalities = existing.InputModalities
+		}
+		if payload.OutputModalities == nil {
+			row.OutputModalities = existing.OutputModalities
+		}
+	}
 	if err := usage.UpsertModelConfig(row); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -546,6 +590,19 @@ func (h *Handler) PutModelConfig(c *gin.Context) {
 	if row.ModelID == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "model id is required"})
 		return
+	}
+	var existing usage.ModelConfigRow
+	var hasExisting bool
+	if originalID != "" {
+		existing, hasExisting = usage.GetModelConfig(originalID)
+	}
+	if hasExisting {
+		if payload.InputModalities == nil {
+			row.InputModalities = existing.InputModalities
+		}
+		if payload.OutputModalities == nil {
+			row.OutputModalities = existing.OutputModalities
+		}
 	}
 	if originalID != "" && originalID != row.ModelID {
 		if err := usage.DeleteModelConfig(originalID); err != nil {

--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -50,6 +50,8 @@ func TestModelConfigHandlersCreateListAndDelete(t *testing.T) {
 		"owned_by": "acme-ai",
 		"description": "Custom image model",
 		"enabled": true,
+		"input_modalities": ["text", "image"],
+		"output_modalities": ["text"],
 		"pricing": {
 			"mode": "call",
 			"price_per_call": 0.12
@@ -66,9 +68,12 @@ func TestModelConfigHandlersCreateListAndDelete(t *testing.T) {
 	}
 	var listPayload struct {
 		Data []struct {
-			ID      string `json:"id"`
-			OwnedBy string `json:"owned_by"`
-			Pricing struct {
+			ID               string   `json:"id"`
+			OwnedBy          string   `json:"owned_by"`
+			InputModalities  []string `json:"input_modalities"`
+			OutputModalities []string `json:"output_modalities"`
+			SupportsVision   bool     `json:"supports_vision"`
+			Pricing          struct {
 				Mode         string  `json:"mode"`
 				PricePerCall float64 `json:"price_per_call"`
 			} `json:"pricing"`
@@ -83,6 +88,9 @@ func TestModelConfigHandlersCreateListAndDelete(t *testing.T) {
 			found = true
 			if item.OwnedBy != "acme-ai" || item.Pricing.Mode != "call" || item.Pricing.PricePerCall != 0.12 {
 				t.Fatalf("unexpected custom-image payload: %+v", item)
+			}
+			if !item.SupportsVision || len(item.InputModalities) != 2 || item.InputModalities[1] != "image" || len(item.OutputModalities) != 1 || item.OutputModalities[0] != "text" {
+				t.Fatalf("unexpected custom-image capabilities: %+v", item)
 			}
 		}
 	}

--- a/internal/usage/model_config_db.go
+++ b/internal/usage/model_config_db.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -13,17 +14,19 @@ import (
 )
 
 type ModelConfigRow struct {
-	ModelID               string  `json:"model_id"`
-	OwnedBy               string  `json:"owned_by"`
-	Description           string  `json:"description"`
-	Enabled               bool    `json:"enabled"`
-	PricingMode           string  `json:"pricing_mode"`
-	InputPricePerMillion  float64 `json:"input_price_per_million"`
-	OutputPricePerMillion float64 `json:"output_price_per_million"`
-	CachedPricePerMillion float64 `json:"cached_price_per_million"`
-	PricePerCall          float64 `json:"price_per_call"`
-	Source                string  `json:"source"`
-	UpdatedAt             string  `json:"updated_at"`
+	ModelID               string   `json:"model_id"`
+	OwnedBy               string   `json:"owned_by"`
+	Description           string   `json:"description"`
+	Enabled               bool     `json:"enabled"`
+	InputModalities       []string `json:"input_modalities,omitempty"`
+	OutputModalities      []string `json:"output_modalities,omitempty"`
+	PricingMode           string   `json:"pricing_mode"`
+	InputPricePerMillion  float64  `json:"input_price_per_million"`
+	OutputPricePerMillion float64  `json:"output_price_per_million"`
+	CachedPricePerMillion float64  `json:"cached_price_per_million"`
+	PricePerCall          float64  `json:"price_per_call"`
+	Source                string   `json:"source"`
+	UpdatedAt             string   `json:"updated_at"`
 }
 
 type ModelOwnerPresetRow struct {
@@ -40,6 +43,8 @@ CREATE TABLE IF NOT EXISTS model_configs (
   owned_by                 TEXT NOT NULL DEFAULT '',
   description              TEXT NOT NULL DEFAULT '',
   enabled                  INTEGER NOT NULL DEFAULT 1,
+  input_modalities         TEXT NOT NULL DEFAULT '',
+  output_modalities        TEXT NOT NULL DEFAULT '',
   pricing_mode             TEXT NOT NULL DEFAULT 'token',
   input_price_per_million  REAL NOT NULL DEFAULT 0,
   output_price_per_million REAL NOT NULL DEFAULT 0,
@@ -109,6 +114,7 @@ func initModelConfigTables(db *sql.DB) {
 		log.Errorf("usage: create model config tables: %v", err)
 		return
 	}
+	ensureModelConfigSchema(db)
 	ensureOpenRouterModelSyncStateSchema(db)
 	seedDefaultModelConfigRows(db)
 	mergeLegacyPricingIntoModelConfigs(db)
@@ -140,6 +146,63 @@ func intToBool(value int) bool {
 
 func nowRFC3339() string {
 	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func ensureModelConfigSchema(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	if !sqliteColumnExists(db, "model_configs", "input_modalities") {
+		if _, err := db.Exec("ALTER TABLE model_configs ADD COLUMN input_modalities TEXT NOT NULL DEFAULT ''"); err != nil {
+			log.Warnf("usage: add model config input_modalities column: %v", err)
+		}
+	}
+	if !sqliteColumnExists(db, "model_configs", "output_modalities") {
+		if _, err := db.Exec("ALTER TABLE model_configs ADD COLUMN output_modalities TEXT NOT NULL DEFAULT ''"); err != nil {
+			log.Warnf("usage: add model config output_modalities column: %v", err)
+		}
+	}
+}
+
+func normalizeModelModalities(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		modality := strings.ToLower(strings.TrimSpace(value))
+		if modality == "" {
+			continue
+		}
+		if _, ok := seen[modality]; ok {
+			continue
+		}
+		seen[modality] = struct{}{}
+		out = append(out, modality)
+	}
+	return out
+}
+
+func encodeModelModalities(values []string) string {
+	values = normalizeModelModalities(values)
+	if len(values) == 0 {
+		return ""
+	}
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func decodeModelModalities(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	var values []string
+	if err := json.Unmarshal([]byte(value), &values); err != nil {
+		return nil
+	}
+	return normalizeModelModalities(values)
 }
 
 func defaultModelConfigRows() []ModelConfigRow {
@@ -191,6 +254,8 @@ func defaultModelConfigRows() []ModelConfigRow {
 			}
 			if modelID == "gpt-image-2" {
 				row.Description = "Image generation model billed per invocation"
+				row.InputModalities = []string{"text"}
+				row.OutputModalities = []string{"image"}
 				row.PricingMode = "call"
 				row.PricePerCall = 0.04
 			}
@@ -209,12 +274,14 @@ func seedDefaultModelConfigRows(db *sql.DB) {
 	for _, row := range defaultModelConfigRows() {
 		_, err := db.Exec(
 			`INSERT OR IGNORE INTO model_configs
-			 (model_id, owned_by, description, enabled, pricing_mode, input_price_per_million, output_price_per_million, cached_price_per_million, price_per_call, source, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 (model_id, owned_by, description, enabled, input_modalities, output_modalities, pricing_mode, input_price_per_million, output_price_per_million, cached_price_per_million, price_per_call, source, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			row.ModelID,
 			row.OwnedBy,
 			row.Description,
 			boolToInt(row.Enabled),
+			encodeModelModalities(row.InputModalities),
+			encodeModelModalities(row.OutputModalities),
 			normalizePricingMode(row.PricingMode),
 			row.InputPricePerMillion,
 			row.OutputPricePerMillion,
@@ -325,7 +392,7 @@ func mergeLegacyPricingIntoModelConfigs(db *sql.DB) {
 
 func reloadModelConfigCache(db *sql.DB) {
 	rows, err := db.Query(
-		`SELECT model_id, owned_by, description, enabled, pricing_mode, input_price_per_million, output_price_per_million, cached_price_per_million, price_per_call, source, updated_at
+		`SELECT model_id, owned_by, description, enabled, input_modalities, output_modalities, pricing_mode, input_price_per_million, output_price_per_million, cached_price_per_million, price_per_call, source, updated_at
 		 FROM model_configs`,
 	)
 	if err != nil {
@@ -338,11 +405,14 @@ func reloadModelConfigCache(db *sql.DB) {
 	for rows.Next() {
 		var row ModelConfigRow
 		var enabled int
+		var inputModalities, outputModalities string
 		if err := rows.Scan(
 			&row.ModelID,
 			&row.OwnedBy,
 			&row.Description,
 			&enabled,
+			&inputModalities,
+			&outputModalities,
 			&row.PricingMode,
 			&row.InputPricePerMillion,
 			&row.OutputPricePerMillion,
@@ -355,6 +425,8 @@ func reloadModelConfigCache(db *sql.DB) {
 			continue
 		}
 		row.Enabled = intToBool(enabled)
+		row.InputModalities = decodeModelModalities(inputModalities)
+		row.OutputModalities = decodeModelModalities(outputModalities)
 		row.PricingMode = normalizePricingMode(row.PricingMode)
 		cache[row.ModelID] = row
 	}
@@ -454,6 +526,8 @@ func UpsertModelConfig(row ModelConfigRow) error {
 		return fmt.Errorf("usage: model id is required")
 	}
 	row.OwnedBy = normalizeModelOwnerValue(row.OwnedBy)
+	row.InputModalities = normalizeModelModalities(row.InputModalities)
+	row.OutputModalities = normalizeModelModalities(row.OutputModalities)
 	row.PricingMode = normalizePricingMode(row.PricingMode)
 	if row.Source == "" {
 		row.Source = "user"
@@ -461,12 +535,14 @@ func UpsertModelConfig(row ModelConfigRow) error {
 	row.UpdatedAt = nowRFC3339()
 	_, err := db.Exec(
 		`INSERT INTO model_configs
-		 (model_id, owned_by, description, enabled, pricing_mode, input_price_per_million, output_price_per_million, cached_price_per_million, price_per_call, source, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 (model_id, owned_by, description, enabled, input_modalities, output_modalities, pricing_mode, input_price_per_million, output_price_per_million, cached_price_per_million, price_per_call, source, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(model_id) DO UPDATE SET
 		   owned_by = excluded.owned_by,
 		   description = excluded.description,
 		   enabled = excluded.enabled,
+		   input_modalities = excluded.input_modalities,
+		   output_modalities = excluded.output_modalities,
 		   pricing_mode = excluded.pricing_mode,
 		   input_price_per_million = excluded.input_price_per_million,
 		   output_price_per_million = excluded.output_price_per_million,
@@ -478,6 +554,8 @@ func UpsertModelConfig(row ModelConfigRow) error {
 		row.OwnedBy,
 		row.Description,
 		boolToInt(row.Enabled),
+		encodeModelModalities(row.InputModalities),
+		encodeModelModalities(row.OutputModalities),
 		row.PricingMode,
 		row.InputPricePerMillion,
 		row.OutputPricePerMillion,

--- a/internal/usage/model_config_db_test.go
+++ b/internal/usage/model_config_db_test.go
@@ -37,6 +37,9 @@ func TestInitDBSeedsDefaultModelConfigs(t *testing.T) {
 	if imageModel.PricePerCall <= 0 {
 		t.Fatalf("expected gpt-image-2 default per-call price, got %v", imageModel.PricePerCall)
 	}
+	if len(imageModel.OutputModalities) != 1 || imageModel.OutputModalities[0] != "image" {
+		t.Fatalf("expected gpt-image-2 image output modality, got %+v", imageModel.OutputModalities)
+	}
 
 	owners := ListModelOwnerPresets()
 	if len(owners) == 0 {
@@ -51,12 +54,14 @@ func TestUpsertModelConfigAndPerCallCost(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	err := UpsertModelConfig(ModelConfigRow{
-		ModelID:      "custom-image",
-		OwnedBy:      "acme-ai",
-		Description:  "Custom image model",
-		Enabled:      true,
-		PricingMode:  "call",
-		PricePerCall: 0.12,
+		ModelID:          "custom-image",
+		OwnedBy:          "acme-ai",
+		Description:      "Custom image model",
+		Enabled:          true,
+		InputModalities:  []string{"Text", "image", "text"},
+		OutputModalities: []string{"Image"},
+		PricingMode:      "call",
+		PricePerCall:     0.12,
 	})
 	if err != nil {
 		t.Fatalf("UpsertModelConfig() error = %v", err)
@@ -68,6 +73,12 @@ func TestUpsertModelConfigAndPerCallCost(t *testing.T) {
 	}
 	if model.OwnedBy != "acme-ai" || model.PricePerCall != 0.12 {
 		t.Fatalf("unexpected model config: %+v", model)
+	}
+	if len(model.InputModalities) != 2 || model.InputModalities[0] != "text" || model.InputModalities[1] != "image" {
+		t.Fatalf("unexpected normalized input modalities: %+v", model.InputModalities)
+	}
+	if len(model.OutputModalities) != 1 || model.OutputModalities[0] != "image" {
+		t.Fatalf("unexpected normalized output modalities: %+v", model.OutputModalities)
 	}
 
 	cost := CalculateCost("custom-image", 123, 456, 0)

--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -27,11 +27,18 @@ type OpenRouterRemotePricing struct {
 	InputCacheRead string `json:"input_cache_read"`
 }
 
+type OpenRouterRemoteArchitecture struct {
+	Modality         string   `json:"modality"`
+	InputModalities  []string `json:"input_modalities"`
+	OutputModalities []string `json:"output_modalities"`
+}
+
 type OpenRouterRemoteModel struct {
-	ID          string                  `json:"id"`
-	Name        string                  `json:"name"`
-	Description string                  `json:"description"`
-	Pricing     OpenRouterRemotePricing `json:"pricing"`
+	ID           string                       `json:"id"`
+	Name         string                       `json:"name"`
+	Description  string                       `json:"description"`
+	Architecture OpenRouterRemoteArchitecture `json:"architecture"`
+	Pricing      OpenRouterRemotePricing      `json:"pricing"`
 }
 
 type OpenRouterModelSyncResult struct {
@@ -137,6 +144,7 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			CachedPricePerMillion: openRouterPricePerMillion(model.Pricing.InputCacheRead),
 			Source:                openRouterModelSource,
 		}
+		row.InputModalities, row.OutputModalities = openRouterModelModalities(model)
 		if err := UpsertModelConfig(row); err != nil {
 			return result, fmt.Errorf("sync openrouter model %s: %w", modelID, err)
 		}
@@ -500,6 +508,13 @@ func openRouterApplyModelSync(row *ModelConfigRow, model OpenRouterRemoteModel, 
 	row.OutputPricePerMillion = openRouterPricePerMillion(model.Pricing.Completion)
 	row.CachedPricePerMillion = openRouterPricePerMillion(model.Pricing.InputCacheRead)
 	row.PricePerCall = 0
+	inputModalities, outputModalities := openRouterModelModalities(model)
+	if len(inputModalities) > 0 {
+		row.InputModalities = inputModalities
+	}
+	if len(outputModalities) > 0 {
+		row.OutputModalities = outputModalities
+	}
 }
 
 func openRouterShouldSyncDescription(row ModelConfigRow) bool {
@@ -589,6 +604,37 @@ func openRouterModelDescription(model OpenRouterRemoteModel) string {
 		return description
 	}
 	return strings.TrimSpace(model.Name)
+}
+
+func openRouterModelModalities(model OpenRouterRemoteModel) ([]string, []string) {
+	input := normalizeModelModalities(model.Architecture.InputModalities)
+	output := normalizeModelModalities(model.Architecture.OutputModalities)
+	if len(input) > 0 && len(output) > 0 {
+		return input, output
+	}
+
+	modality := strings.TrimSpace(model.Architecture.Modality)
+	if modality == "" {
+		return input, output
+	}
+	left, right, found := strings.Cut(modality, "->")
+	if !found {
+		return input, output
+	}
+	if len(input) == 0 {
+		input = parseOpenRouterModalityPart(left)
+	}
+	if len(output) == 0 {
+		output = parseOpenRouterModalityPart(right)
+	}
+	return input, output
+}
+
+func parseOpenRouterModalityPart(value string) []string {
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == '+' || r == ',' || r == '|' || r == '/'
+	})
+	return normalizeModelModalities(parts)
 }
 
 func openRouterPricePerMillion(value string) float64 {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -13,6 +14,11 @@ func TestSyncOpenRouterModelsAddsNewModelsWithLocalModelIDPricingAndOwner(t *tes
 			ID:          "openai/gpt-openrouter-test",
 			Name:        "OpenAI: GPT OpenRouter Test",
 			Description: "Agentic test model",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality:         "text+image->text",
+				InputModalities:  []string{"text", "image"},
+				OutputModalities: []string{"text"},
+			},
 			Pricing: OpenRouterRemotePricing{
 				Prompt:         "0.00000175",
 				Completion:     "0.000014",
@@ -40,6 +46,9 @@ func TestSyncOpenRouterModelsAddsNewModelsWithLocalModelIDPricingAndOwner(t *tes
 	if model.InputPricePerMillion != 1.75 || model.OutputPricePerMillion != 14 || model.CachedPricePerMillion != 0.175 {
 		t.Fatalf("unexpected imported model pricing: %+v", model)
 	}
+	if strings.Join(model.InputModalities, ",") != "text,image" || strings.Join(model.OutputModalities, ",") != "text" {
+		t.Fatalf("unexpected imported model modalities: %+v -> %+v", model.InputModalities, model.OutputModalities)
+	}
 	if _, ok := GetModelOwnerPreset("openai"); !ok {
 		t.Fatal("expected openai owner preset to exist")
 	}
@@ -65,6 +74,9 @@ func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 		{
 			ID:          "openai/gpt-openrouter-test",
 			Description: "Remote description",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality: "text+image->text",
+			},
 			Pricing: OpenRouterRemotePricing{
 				Prompt:         "0.00000175",
 				Completion:     "0.000014",
@@ -88,6 +100,9 @@ func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 	}
 	if model.InputPricePerMillion != 1.75 || model.OutputPricePerMillion != 14 || model.CachedPricePerMillion != 0.175 {
 		t.Fatalf("existing user model pricing should be synced: %+v", model)
+	}
+	if strings.Join(model.InputModalities, ",") != "text,image" || strings.Join(model.OutputModalities, ",") != "text" {
+		t.Fatalf("existing user model modalities should be synced: %+v -> %+v", model.InputModalities, model.OutputModalities)
 	}
 }
 


### PR DESCRIPTION
## Summary
- store model input and output modality metadata in the database-backed model config rows
- sync OpenRouter architecture modality fields into model configs
- expose supports_vision and modality arrays through management model APIs

## Verification
- go test ./internal/usage ./internal/api/handlers/management