### PR TITLE
Fix default route channel isolation

### DIFF
--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -30,17 +30,18 @@ const (
 )
 
 type channelGroupItem struct {
-	Name           string                      `json:"name"`
-	Description    string                      `json:"description,omitempty"`
-	Strategy       string                      `json:"strategy,omitempty"`
-	Priority       int                         `json:"priority,omitempty"`
-	Implicit       bool                        `json:"implicit"`
-	Prefixes       []string                    `json:"prefixes,omitempty"`
-	Tags           []string                    `json:"tags,omitempty"`
-	Channels       []string                    `json:"channels,omitempty"`
-	ChannelDetails []channelGroupChannelDetail `json:"channel-details,omitempty"`
-	AllowedModels  []string                    `json:"allowed-models,omitempty"`
-	PathRoutes     []string                    `json:"path-routes,omitempty"`
+	Name               string                      `json:"name"`
+	Description        string                      `json:"description,omitempty"`
+	Strategy           string                      `json:"strategy,omitempty"`
+	Priority           int                         `json:"priority,omitempty"`
+	ExcludeFromDefault bool                        `json:"exclude-from-default,omitempty"`
+	Implicit           bool                        `json:"implicit"`
+	Prefixes           []string                    `json:"prefixes,omitempty"`
+	Tags               []string                    `json:"tags,omitempty"`
+	Channels           []string                    `json:"channels,omitempty"`
+	ChannelDetails     []channelGroupChannelDetail `json:"channel-details,omitempty"`
+	AllowedModels      []string                    `json:"allowed-models,omitempty"`
+	PathRoutes         []string                    `json:"path-routes,omitempty"`
 }
 
 func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []channelDescriptor {
@@ -187,6 +188,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 		item.Description = group.Description
 		item.Strategy = group.Strategy
 		item.Priority = group.Priority
+		item.ExcludeFromDefault = group.ExcludeFromDefault
 		item.AllowedModels = append(item.AllowedModels, group.AllowedModels...)
 		item.Prefixes = append(item.Prefixes, group.Match.Prefixes...)
 		item.Tags = append(item.Tags, group.Match.Tags...)
@@ -209,6 +211,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 	for _, channel := range items {
 		prefix := internalrouting.NormalizeGroupName(channel.Prefix)
 		channelName := strings.TrimSpace(channel.Name)
+		excludedFromDefault := channelExcludedFromImplicitDefault(routingCfg, channel)
 		for groupName, group := range groupMap {
 			matched := false
 			for _, candidatePrefix := range group.Prefixes {
@@ -229,7 +232,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 				matched = true
 			}
 			if !matched {
-				if group.Name == "default" && prefix == "" && includeDefault {
+				if group.Name == "default" && prefix == "" && includeDefault && !excludedFromDefault {
 					matched = true
 				} else if prefix != "" && group.Name == prefix {
 					matched = true
@@ -263,6 +266,41 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
+}
+
+func channelExcludedFromImplicitDefault(routingCfg config.RoutingConfig, channel channelDescriptor) bool {
+	if internalrouting.NormalizeGroupName(channel.Prefix) != "" {
+		return false
+	}
+	for _, group := range routingCfg.ChannelGroups {
+		if !group.ExcludeFromDefault {
+			continue
+		}
+		groupName := internalrouting.NormalizeGroupName(group.Name)
+		if groupName == "" || groupName == "default" {
+			continue
+		}
+		if channelGroupMatchesDescriptor(group, channel) {
+			return true
+		}
+	}
+	return false
+}
+
+func channelGroupMatchesDescriptor(group config.RoutingChannelGroup, channel channelDescriptor) bool {
+	prefix := internalrouting.NormalizeGroupName(channel.Prefix)
+	for _, candidatePrefix := range group.Match.Prefixes {
+		if prefix != "" && prefix == internalrouting.NormalizeGroupName(candidatePrefix) {
+			return true
+		}
+	}
+	channelName := strings.TrimSpace(channel.Name)
+	for _, candidateChannel := range group.Match.Channels {
+		if channelName != "" && strings.EqualFold(strings.TrimSpace(candidateChannel), channelName) {
+			return true
+		}
+	}
+	return channelMatchesAnyTag(channel, group.Match.Tags)
 }
 
 func channelMatchesAnyTag(channel channelDescriptor, tags []string) bool {

--- a/internal/api/handlers/management/channel_groups_test.go
+++ b/internal/api/handlers/management/channel_groups_test.go
@@ -433,6 +433,63 @@ func TestBuildChannelGroupItemsKeepsRenamedKimiOAuthChannelsSeparate(t *testing.
 	}
 }
 
+func TestBuildChannelGroupItemsExcludesIsolatedGroupChannelsFromDefault(t *testing.T) {
+	auths := []*coreauth.Auth{
+		{
+			ID:       "codex-default",
+			Label:    "Default Codex",
+			Provider: "codex",
+		},
+		{
+			ID:       "kimi-isolated",
+			Label:    "Kimi Channel",
+			Provider: "kimi",
+		},
+	}
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:               "kimicode",
+					ExcludeFromDefault: true,
+					Match: config.ChannelGroupMatch{
+						Channels: []string{"Kimi Channel"},
+					},
+				},
+			},
+		},
+	}
+
+	items := buildChannelGroupItems(cfg, auths)
+	byName := make(map[string]channelGroupItem, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+
+	defaultGroup, ok := byName["default"]
+	if !ok {
+		t.Fatal("expected default group")
+	}
+	if !containsString(defaultGroup.Channels, "Default Codex") {
+		t.Fatalf("default channels = %v, want Default Codex", defaultGroup.Channels)
+	}
+	if containsString(defaultGroup.Channels, "Kimi Channel") {
+		t.Fatalf("default channels = %v, should not include isolated Kimi channel", defaultGroup.Channels)
+	}
+
+	kimiGroup, ok := byName["kimicode"]
+	if !ok {
+		t.Fatal("expected kimicode group")
+	}
+	if !kimiGroup.ExcludeFromDefault {
+		t.Fatal("expected exclude-from-default flag in group response")
+	}
+	if !containsString(kimiGroup.Channels, "Kimi Channel") {
+		t.Fatalf("kimicode channels = %v, want Kimi Channel", kimiGroup.Channels)
+	}
+}
+
 func TestBuildChannelGroupItemsCanonicalizesRenamedOAuthChannel(t *testing.T) {
 	cfg := &config.Config{
 		Routing: config.RoutingConfig{

--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -263,24 +263,13 @@ func (h *Handler) modelRootRouteScopedModels(models []map[string]any) []map[stri
 	if h == nil || h.authManager == nil || h.cfg == nil || !h.cfg.Routing.IncludeDefaultGroup {
 		return models
 	}
-	restricted := false
-	for _, group := range h.cfg.Routing.ChannelGroups {
-		if internalrouting.NormalizeGroupName(group.Name) == "default" && len(group.AllowedModels) > 0 {
-			restricted = true
-			break
-		}
-	}
-	if !restricted {
-		return models
-	}
-	allowedGroups := map[string]struct{}{"default": {}}
 	filtered := make([]map[string]any, 0, len(models))
 	for _, model := range models {
 		id := strings.TrimSpace(modelPathStringValue(model["id"]))
 		if id == "" {
 			continue
 		}
-		if h.authManager.CanServeModelWithScopes(id, nil, allowedGroups, "") {
+		if h.authManager.CanServeModelWithScopes(id, nil, nil, "") {
 			filtered = append(filtered, model)
 		}
 	}

--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -495,6 +495,102 @@ func TestGetModelPathAvailabilityFiltersRootByDefaultAllowedModels(t *testing.T)
 	}
 }
 
+func TestGetModelPathAvailabilityExcludesIsolatedGroupFromRoot(t *testing.T) {
+	rootModelID := "model-path-availability-root-default"
+	isolatedModelID := "model-path-availability-root-isolated"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("model-path-availability-root-default-auth", "openai", []*registry.ModelInfo{
+		{ID: rootModelID, Object: "model", OwnedBy: "openai", Type: "openai"},
+	})
+	reg.RegisterClient("model-path-availability-root-isolated-auth", "openai", []*registry.ModelInfo{
+		{ID: isolatedModelID, Object: "model", OwnedBy: "openai", Type: "openai"},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient("model-path-availability-root-default-auth")
+		reg.UnregisterClient("model-path-availability-root-isolated-auth")
+	})
+
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:               "kimicode",
+					ExcludeFromDefault: true,
+					Match: config.ChannelGroupMatch{
+						Channels: []string{"Kimi Channel"},
+					},
+				},
+			},
+			PathRoutes: []config.RoutingPathRoute{
+				{Path: "/kimicode", Group: "kimicode"},
+			},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	for _, auth := range []*coreauth.Auth{
+		{
+			ID:       "model-path-availability-root-default-auth",
+			Label:    "Default Channel",
+			Provider: "openai",
+		},
+		{
+			ID:       "model-path-availability-root-isolated-auth",
+			Label:    "Kimi Channel",
+			Provider: "openai",
+		},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, err)
+		}
+	}
+
+	h := NewHandler(cfg, "", manager)
+	rec := performModelsRequest(http.MethodGet, "/model-path-availability", nil, h.GetModelPathAvailability)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GetModelPathAvailability status = %d body = %s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Data []struct {
+			ID    string `json:"id"`
+			Paths []struct {
+				Method string `json:"method"`
+				Path   string `json:"path"`
+			} `json:"paths"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	hasPath := func(modelID, path string) bool {
+		t.Helper()
+		for _, item := range payload.Data {
+			if item.ID != modelID {
+				continue
+			}
+			for _, itemPath := range item.Paths {
+				if itemPath.Method == http.MethodGet && itemPath.Path == path {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	if !hasPath(rootModelID, "/v1/models") {
+		t.Fatalf("expected %q to have root /v1/models path", rootModelID)
+	}
+	if hasPath(isolatedModelID, "/v1/models") {
+		t.Fatalf("did not expect %q to have root /v1/models path", isolatedModelID)
+	}
+	if !hasPath(isolatedModelID, "/kimicode/v1/models") {
+		t.Fatalf("expected %q to have /kimicode/v1/models path", isolatedModelID)
+	}
+}
+
 func TestGetModelPathAvailabilityIncludesCcSwitchRoutePaths(t *testing.T) {
 	initManagementModelsTestDB(t)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,7 +28,7 @@ func TestLoadConfigDefaultsDisableControlPanel(t *testing.T) {
 	}
 }
 
-func TestSanitizeRoutingPreservesChannelGroupStrategy(t *testing.T) {
+func TestSanitizeRoutingPreservesChannelGroupSettings(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
@@ -36,15 +36,17 @@ func TestSanitizeRoutingPreservesChannelGroupStrategy(t *testing.T) {
 			Strategy: "fill-first",
 			ChannelGroups: []RoutingChannelGroup{
 				{
-					Name:     " Team ",
-					Strategy: "round-robin",
+					Name:               " Team ",
+					Strategy:           "round-robin",
+					ExcludeFromDefault: true,
 					Match: ChannelGroupMatch{
 						Channels: []string{"Team Channel"},
 					},
 				},
 				{
-					Name:     " Cache ",
-					Strategy: "ff",
+					Name:               " Default ",
+					Strategy:           "ff",
+					ExcludeFromDefault: true,
 					Match: ChannelGroupMatch{
 						Channels: []string{"Cache Channel"},
 					},
@@ -60,6 +62,12 @@ func TestSanitizeRoutingPreservesChannelGroupStrategy(t *testing.T) {
 	}
 	if got := cfg.Routing.ChannelGroups[1].Strategy; got != "fill-first" {
 		t.Fatalf("group strategy alias = %q, want fill-first", got)
+	}
+	if !cfg.Routing.ChannelGroups[0].ExcludeFromDefault {
+		t.Fatal("exclude-from-default should be preserved for non-default groups")
+	}
+	if cfg.Routing.ChannelGroups[1].ExcludeFromDefault {
+		t.Fatal("exclude-from-default should be cleared for the default group")
 	}
 }
 

--- a/internal/config/routing_groups.go
+++ b/internal/config/routing_groups.go
@@ -15,13 +15,14 @@ type ChannelGroupMatch struct {
 
 // RoutingChannelGroup defines a named channel group used by routing and API-key permissions.
 type RoutingChannelGroup struct {
-	Name              string            `yaml:"name" json:"name"`
-	Description       string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Strategy          string            `yaml:"strategy,omitempty" json:"strategy,omitempty"`
-	Match             ChannelGroupMatch `yaml:"match,omitempty" json:"match,omitempty"`
-	Priority          int               `yaml:"priority,omitempty" json:"priority,omitempty"`
-	ChannelPriorities map[string]int    `yaml:"channel-priorities,omitempty" json:"channel-priorities,omitempty"`
-	AllowedModels     []string          `yaml:"allowed-models,omitempty" json:"allowed-models,omitempty"`
+	Name               string            `yaml:"name" json:"name"`
+	Description        string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Strategy           string            `yaml:"strategy,omitempty" json:"strategy,omitempty"`
+	Match              ChannelGroupMatch `yaml:"match,omitempty" json:"match,omitempty"`
+	ExcludeFromDefault bool              `yaml:"exclude-from-default,omitempty" json:"exclude-from-default,omitempty"`
+	Priority           int               `yaml:"priority,omitempty" json:"priority,omitempty"`
+	ChannelPriorities  map[string]int    `yaml:"channel-priorities,omitempty" json:"channel-priorities,omitempty"`
+	AllowedModels      []string          `yaml:"allowed-models,omitempty" json:"allowed-models,omitempty"`
 }
 
 // RoutingPathRoute maps a URL namespace path to a channel group.
@@ -118,6 +119,9 @@ func (cfg *Config) SanitizeRouting() {
 		group.Name = internalrouting.NormalizeGroupName(group.Name)
 		group.Description = strings.TrimSpace(group.Description)
 		group.Strategy = normalizeOptionalRoutingStrategy(group.Strategy)
+		if group.Name == "default" {
+			group.ExcludeFromDefault = false
+		}
 		group.Match.Prefixes = normalizeStringList(group.Match.Prefixes, internalrouting.NormalizeGroupName)
 		group.Match.Channels = normalizeStringList(group.Match.Channels, func(value string) string {
 			return strings.TrimSpace(value)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2116,6 +2116,21 @@ func (m *Manager) CloseExecutionSession(sessionID string) {
 	}
 }
 
+func optionsForSelectionRouteGroup(opts cliproxyexecutor.Options, routeGroup string) cliproxyexecutor.Options {
+	next := opts
+	meta := make(map[string]any, len(opts.Metadata)+1)
+	for key, value := range opts.Metadata {
+		meta[key] = value
+	}
+	if routeGroup != "" {
+		meta[cliproxyexecutor.RouteGroupMetadataKey] = routeGroup
+	} else {
+		delete(meta, cliproxyexecutor.RouteGroupMetadataKey)
+	}
+	next.Metadata = meta
+	return next
+}
+
 func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
 	allowedChannels := allowedChannelsFromMetadata(opts.Metadata)
@@ -2138,8 +2153,9 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 			modelKey = strings.TrimSpace(parsed.ModelName)
 		}
 	}
+	selectionRouteGroup := effectiveRouteGroupForSelection(cfg, routeGroup, allowedGroups, modelKey)
 	registryRef := registry.GetGlobalRegistry()
-	buildCandidates := func(enforceRouteGroup bool) []*Auth {
+	buildCandidates := func(scopedRouteGroup string) []*Auth {
 		candidates := make([]*Auth, 0, len(m.auths))
 		for _, candidate := range m.auths {
 			if candidate.Provider != provider || candidate.Disabled {
@@ -2154,33 +2170,31 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 			if !authAllowedByGroups(cfg, candidate, allowedGroups) {
 				continue
 			}
-			if enforceRouteGroup && !authInRouteGroup(cfg, candidate, routeGroup) {
+			if scopedRouteGroup != "" && !authInRouteGroup(cfg, candidate, scopedRouteGroup) {
 				continue
 			}
 			if _, used := tried[candidate.ID]; used {
 				continue
 			}
-			if modelKey != "" && !candidateSupportsModel(cfg, registryRef, candidate, modelKey, routeGroup, allowedGroups) {
+			if modelKey != "" && !candidateSupportsModel(cfg, registryRef, candidate, modelKey, scopedRouteGroup, allowedGroups) {
 				continue
-			}
-			scopedRouteGroup := ""
-			if enforceRouteGroup {
-				scopedRouteGroup = routeGroup
 			}
 			candidates = append(candidates, prepareCandidateForSelection(cfg, candidate, scopedRouteGroup, allowedGroups))
 		}
 		return candidates
 	}
-	candidates := buildCandidates(routeGroup != "")
+	selectorRouteGroup := selectionRouteGroup
+	candidates := buildCandidates(selectorRouteGroup)
 	if len(candidates) == 0 && routeGroup != "" && routeFallback == "default" {
-		candidates = buildCandidates(false)
+		selectorRouteGroup = defaultRouteGroupForSelection(cfg, modelKey)
+		candidates = buildCandidates(selectorRouteGroup)
 	}
 	if len(candidates) == 0 {
 		m.mu.RUnlock()
 		return nil, nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	selector := m.selectorForRoutingScopeLocked(cfg, routeGroup, allowedGroups)
-	selected, errPick := selector.Pick(ctx, provider, model, opts, candidates)
+	selector := m.selectorForRoutingScopeLocked(cfg, selectorRouteGroup, allowedGroups)
+	selected, errPick := selector.Pick(ctx, provider, model, optionsForSelectionRouteGroup(opts, selectorRouteGroup), candidates)
 	if errPick != nil {
 		m.mu.RUnlock()
 		return nil, nil, errPick
@@ -2231,8 +2245,9 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 			modelKey = strings.TrimSpace(parsed.ModelName)
 		}
 	}
+	selectionRouteGroup := effectiveRouteGroupForSelection(cfg, routeGroup, allowedGroups, modelKey)
 	registryRef := registry.GetGlobalRegistry()
-	buildCandidates := func(enforceRouteGroup bool) []*Auth {
+	buildCandidates := func(scopedRouteGroup string) []*Auth {
 		candidates := make([]*Auth, 0, len(m.auths))
 		for _, candidate := range m.auths {
 			if candidate == nil || candidate.Disabled {
@@ -2247,7 +2262,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 			if !authAllowedByGroups(cfg, candidate, allowedGroups) {
 				continue
 			}
-			if enforceRouteGroup && !authInRouteGroup(cfg, candidate, routeGroup) {
+			if scopedRouteGroup != "" && !authInRouteGroup(cfg, candidate, scopedRouteGroup) {
 				continue
 			}
 			providerKey := strings.TrimSpace(strings.ToLower(candidate.Provider))
@@ -2263,27 +2278,25 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 			if _, ok := m.executors[providerKey]; !ok {
 				continue
 			}
-			if modelKey != "" && !candidateSupportsModel(cfg, registryRef, candidate, modelKey, routeGroup, allowedGroups) {
+			if modelKey != "" && !candidateSupportsModel(cfg, registryRef, candidate, modelKey, scopedRouteGroup, allowedGroups) {
 				continue
-			}
-			scopedRouteGroup := ""
-			if enforceRouteGroup {
-				scopedRouteGroup = routeGroup
 			}
 			candidates = append(candidates, prepareCandidateForSelection(cfg, candidate, scopedRouteGroup, allowedGroups))
 		}
 		return candidates
 	}
-	candidates := buildCandidates(routeGroup != "")
+	selectorRouteGroup := selectionRouteGroup
+	candidates := buildCandidates(selectorRouteGroup)
 	if len(candidates) == 0 && routeGroup != "" && routeFallback == "default" {
-		candidates = buildCandidates(false)
+		selectorRouteGroup = defaultRouteGroupForSelection(cfg, modelKey)
+		candidates = buildCandidates(selectorRouteGroup)
 	}
 	if len(candidates) == 0 {
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	selector := m.selectorForRoutingScopeLocked(cfg, routeGroup, allowedGroups)
-	selected, errPick := selector.Pick(ctx, "mixed", model, opts, candidates)
+	selector := m.selectorForRoutingScopeLocked(cfg, selectorRouteGroup, allowedGroups)
+	selected, errPick := selector.Pick(ctx, "mixed", model, optionsForSelectionRouteGroup(opts, selectorRouteGroup), candidates)
 	if errPick != nil {
 		m.mu.RUnlock()
 		return nil, nil, "", errPick

--- a/sdk/cliproxy/auth/conductor_grouped_route_test.go
+++ b/sdk/cliproxy/auth/conductor_grouped_route_test.go
@@ -86,6 +86,15 @@ func (e *successfulSequenceExecutor) Execute(ctx context.Context, auth *Auth, re
 	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
 }
 
+type successfulProviderExecutor struct {
+	sequenceExecutor
+	provider string
+}
+
+func (e *successfulProviderExecutor) Identifier() string {
+	return e.provider
+}
+
 type invalidModelExecutor struct {
 	sequenceExecutor
 }
@@ -171,6 +180,11 @@ func TestManagerExecute_NonGroupedRouteStillFailsOver(t *testing.T) {
 
 	executor := &sequenceExecutor{}
 	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			IncludeDefaultGroup: false,
+		},
+	})
 	manager.RegisterExecutor(executor)
 	registerGroupedRouteTestAuths(t, manager)
 
@@ -188,6 +202,66 @@ func TestManagerExecute_NonGroupedRouteStillFailsOver(t *testing.T) {
 	}
 	if calls[0] != "auth-a" || calls[1] != "auth-b" {
 		t.Fatalf("expected failover sequence [auth-a auth-b], got %v", calls)
+	}
+}
+
+func TestManagerExecute_RootRouteUsesDefaultGroupAndExcludesIsolatedGroups(t *testing.T) {
+	codexExecutor := &successfulProviderExecutor{provider: "codex"}
+	kimiExecutor := &successfulProviderExecutor{provider: "kimi"}
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{
+					Name:               "kimicode",
+					ExcludeFromDefault: true,
+					Match: internalconfig.ChannelGroupMatch{
+						Channels: []string{"Kimi Channel"},
+					},
+				},
+			},
+		},
+	})
+	manager.RegisterExecutor(codexExecutor)
+	manager.RegisterExecutor(kimiExecutor)
+	for _, auth := range []*Auth{
+		{
+			ID:       "codex-default-auth",
+			Label:    "Default Codex",
+			Provider: "codex",
+			Status:   StatusActive,
+		},
+		{
+			ID:       "kimi-isolated-auth",
+			Label:    "Kimi Channel",
+			Provider: "kimi",
+			Status:   StatusActive,
+		},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", auth.ID, err)
+		}
+	}
+
+	if _, err := manager.Execute(context.Background(), []string{"kimi", "codex"}, cliproxyexecutor.Request{}, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if calls := kimiExecutor.Calls(); len(calls) != 0 {
+		t.Fatalf("root default route should not call isolated Kimi group, got %v", calls)
+	}
+	if calls := codexExecutor.Calls(); len(calls) != 1 || calls[0] != "codex-default-auth" {
+		t.Fatalf("root default route should call default Codex auth, got %v", calls)
+	}
+
+	if _, err := manager.Execute(context.Background(), []string{"kimi", "codex"}, cliproxyexecutor.Request{}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.RouteGroupMetadataKey: "kimicode"},
+	}); err != nil {
+		t.Fatalf("group Execute() error = %v", err)
+	}
+	if calls := kimiExecutor.Calls(); len(calls) != 1 || calls[0] != "kimi-isolated-auth" {
+		t.Fatalf("explicit group route should call isolated Kimi auth, got %v", calls)
 	}
 }
 

--- a/sdk/cliproxy/auth/routing_groups.go
+++ b/sdk/cliproxy/auth/routing_groups.go
@@ -296,46 +296,94 @@ func includeDefaultGroup(cfg *internalconfig.Config) bool {
 	return cfg.Routing.IncludeDefaultGroup
 }
 
+func routingChannelGroupMatchesAuth(auth *Auth, group internalconfig.RoutingChannelGroup, authPrefix string) bool {
+	if auth == nil {
+		return false
+	}
+	if authPrefix == "" {
+		authPrefix = internalrouting.NormalizeGroupName(auth.Prefix)
+	}
+	for _, prefix := range group.Match.Prefixes {
+		if authPrefix != "" && internalrouting.NormalizeGroupName(prefix) == authPrefix {
+			return true
+		}
+	}
+	for _, channel := range group.Match.Channels {
+		if authMatchesChannelName(auth, channel) {
+			return true
+		}
+	}
+	return authMatchesAnyTag(auth, group.Match.Tags)
+}
+
+func requestedModelHasRoutingPrefix(model string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	parts := strings.SplitN(model, "/", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	return internalrouting.NormalizeGroupName(parts[0]) != "" && strings.TrimSpace(parts[1]) != ""
+}
+
+func defaultRouteGroupForSelection(cfg *internalconfig.Config, model string) string {
+	if cfg == nil || !cfg.Routing.IncludeDefaultGroup || requestedModelHasRoutingPrefix(model) {
+		return ""
+	}
+	return "default"
+}
+
+func effectiveRouteGroupForSelection(cfg *internalconfig.Config, routeGroup string, allowedGroups map[string]struct{}, model string) string {
+	if routeGroup = internalrouting.NormalizeGroupName(routeGroup); routeGroup != "" {
+		return routeGroup
+	}
+	if len(allowedGroups) > 0 {
+		return ""
+	}
+	return defaultRouteGroupForSelection(cfg, model)
+}
+
 func authGroups(cfg *internalconfig.Config, auth *Auth) map[string]struct{} {
 	if auth == nil {
 		return nil
 	}
 	out := make(map[string]struct{})
-	if prefix := internalrouting.NormalizeGroupName(auth.Prefix); prefix != "" {
-		out[prefix] = struct{}{}
-	} else if includeDefaultGroup(cfg) {
-		out["default"] = struct{}{}
-	}
+	authPrefix := internalrouting.NormalizeGroupName(auth.Prefix)
 	if cfg == nil {
+		if authPrefix != "" {
+			out[authPrefix] = struct{}{}
+		} else if includeDefaultGroup(cfg) {
+			out["default"] = struct{}{}
+		}
 		if len(out) == 0 {
 			return nil
 		}
 		return out
 	}
-	authPrefix := internalrouting.NormalizeGroupName(auth.Prefix)
+	explicitGroups := make(map[string]struct{})
+	excludeFromDefault := false
 	for i := range cfg.Routing.ChannelGroups {
 		group := cfg.Routing.ChannelGroups[i]
-		matched := false
-		for _, prefix := range group.Match.Prefixes {
-			if authPrefix != "" && internalrouting.NormalizeGroupName(prefix) == authPrefix {
-				matched = true
-				break
+		groupName := internalrouting.NormalizeGroupName(group.Name)
+		if groupName == "" {
+			continue
+		}
+		if routingChannelGroupMatchesAuth(auth, group, authPrefix) {
+			explicitGroups[groupName] = struct{}{}
+			if groupName != "default" && group.ExcludeFromDefault {
+				excludeFromDefault = true
 			}
 		}
-		if !matched {
-			for _, channel := range group.Match.Channels {
-				if authMatchesChannelName(auth, channel) {
-					matched = true
-					break
-				}
-			}
-		}
-		if !matched && authMatchesAnyTag(auth, group.Match.Tags) {
-			matched = true
-		}
-		if matched {
-			out[group.Name] = struct{}{}
-		}
+	}
+	if authPrefix != "" {
+		out[authPrefix] = struct{}{}
+	} else if includeDefaultGroup(cfg) && !excludeFromDefault {
+		out["default"] = struct{}{}
+	}
+	for group := range explicitGroups {
+		out[group] = struct{}{}
 	}
 	if len(out) == 0 {
 		return nil
@@ -587,6 +635,7 @@ func (m *Manager) CanServeModelWithScopes(modelID string, allowedChannels, allow
 	}
 	registryRef := registry.GetGlobalRegistry()
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	selectionRouteGroup := effectiveRouteGroupForSelection(cfg, routeGroup, allowedGroups, modelID)
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -600,10 +649,10 @@ func (m *Manager) CanServeModelWithScopes(modelID string, allowedChannels, allow
 		if !authAllowedByGroups(cfg, candidate, allowedGroups) {
 			continue
 		}
-		if !authInRouteGroup(cfg, candidate, routeGroup) {
+		if !authInRouteGroup(cfg, candidate, selectionRouteGroup) {
 			continue
 		}
-		if candidateSupportsModel(cfg, registryRef, candidate, modelID, routeGroup, allowedGroups) {
+		if candidateSupportsModel(cfg, registryRef, candidate, modelID, selectionRouteGroup, allowedGroups) {
 			return true
 		}
 	}

--- a/sdk/cliproxy/auth/routing_groups_test.go
+++ b/sdk/cliproxy/auth/routing_groups_test.go
@@ -129,6 +129,64 @@ func TestAuthGroupsMatchesLegacyOAuthEmailAfterRename(t *testing.T) {
 	}
 }
 
+func TestAuthGroupsExcludeFromDefaultKeepsExplicitGroup(t *testing.T) {
+	t.Parallel()
+
+	cfg := &internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{
+					Name:               "kimicode",
+					ExcludeFromDefault: true,
+					Match: internalconfig.ChannelGroupMatch{
+						Channels: []string{"Kimi Channel"},
+					},
+				},
+			},
+		},
+	}
+	auth := &Auth{
+		Label:    "Kimi Channel",
+		Provider: "kimi",
+	}
+
+	groups := authGroups(cfg, auth)
+	if _, ok := groups["kimicode"]; !ok {
+		t.Fatalf("expected explicit kimicode group, got %v", groups)
+	}
+	if _, ok := groups["default"]; ok {
+		t.Fatalf("exclusive group member should not be in default, got %v", groups)
+	}
+	if authAllowedByGroups(cfg, auth, map[string]struct{}{"default": {}}) {
+		t.Fatal("expected default group restriction to reject isolated auth")
+	}
+	if !authAllowedByGroups(cfg, auth, map[string]struct{}{"kimicode": {}}) {
+		t.Fatal("expected explicit group restriction to allow isolated auth")
+	}
+}
+
+func TestEffectiveRouteGroupForSelectionDefaultsOnlyForUnprefixedRootModels(t *testing.T) {
+	t.Parallel()
+
+	cfg := &internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{IncludeDefaultGroup: true},
+	}
+
+	if got := effectiveRouteGroupForSelection(cfg, "", nil, "gpt-5.5"); got != "default" {
+		t.Fatalf("unprefixed root route group = %q, want default", got)
+	}
+	if got := effectiveRouteGroupForSelection(cfg, "", nil, "kimicode/gpt-5.5"); got != "" {
+		t.Fatalf("prefixed root route group = %q, want empty", got)
+	}
+	if got := effectiveRouteGroupForSelection(cfg, "kimicode", nil, "gpt-5.5"); got != "kimicode" {
+		t.Fatalf("explicit route group = %q, want kimicode", got)
+	}
+	if got := effectiveRouteGroupForSelection(cfg, "", map[string]struct{}{"kimicode": {}}, "gpt-5.5"); got != "" {
+		t.Fatalf("allowed group route group = %q, want empty", got)
+	}
+}
+
 func TestAuthGroupsMatchesAnyDisplayTagDynamically(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- scope unprefixed root requests to the implicit default routing group when default routing is enabled
- add an explicit channel-group flag to exclude matched channels from the implicit default group
- align management channel-group/model-path views with the runtime selection semantics

## Tests
- go test ./sdk/cliproxy/auth ./internal/api ./internal/api/handlers/management ./internal/config