### PR TITLE
feat: public endpoint for CC Switch import presets

### DIFF
--- a/internal/api/handlers/management/ccswitch_import_configs_public.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public.go
@@ -1,0 +1,185 @@
+package management
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func normalizeLowerStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
+		text := strings.ToLower(strings.TrimSpace(raw))
+		if text == "" {
+			continue
+		}
+		if _, ok := seen[text]; ok {
+			continue
+		}
+		seen[text] = struct{}{}
+		out = append(out, text)
+	}
+	return out
+}
+
+func normalizeExactStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
+		text := strings.TrimSpace(raw)
+		if text == "" {
+			continue
+		}
+		if _, ok := seen[text]; ok {
+			continue
+		}
+		seen[text] = struct{}{}
+		out = append(out, text)
+	}
+	return out
+}
+
+func ccSwitchImportConfigTargetModels(config usage.CcSwitchImportConfigRow) []string {
+	seen := map[string]struct{}{}
+	var targets []string
+
+	for _, mapping := range config.ModelMappings {
+		target := strings.TrimSpace(mapping.TargetModel)
+		if target == "" {
+			continue
+		}
+		if _, ok := seen[target]; ok {
+			continue
+		}
+		seen[target] = struct{}{}
+		targets = append(targets, target)
+	}
+
+	if len(targets) > 0 {
+		return targets
+	}
+
+	if model := strings.TrimSpace(config.DefaultModel); model != "" {
+		return []string{model}
+	}
+
+	return nil
+}
+
+func ccSwitchImportConfigMatchesAllowedModels(config usage.CcSwitchImportConfigRow, allowedModels []string) bool {
+	if len(allowedModels) == 0 {
+		return true
+	}
+	targets := ccSwitchImportConfigTargetModels(config)
+	if len(targets) == 0 {
+		return true
+	}
+	allowed := make(map[string]struct{}, len(allowedModels))
+	for _, model := range allowedModels {
+		allowed[strings.TrimSpace(model)] = struct{}{}
+	}
+	for _, model := range targets {
+		if _, ok := allowed[model]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func ccSwitchImportConfigMatchesAPIKeyPermissions(config usage.CcSwitchImportConfigRow, entry *usage.APIKeyRow) bool {
+	if entry == nil {
+		return true
+	}
+
+	entryGroups := normalizeLowerStringList(entry.AllowedChannelGroups)
+	configGroups := normalizeLowerStringList(config.AllowedChannelGroups)
+	matchesGroups := len(entryGroups) == 0 || len(configGroups) == 0
+	if !matchesGroups {
+		set := make(map[string]struct{}, len(entryGroups))
+		for _, group := range entryGroups {
+			set[group] = struct{}{}
+		}
+		for _, group := range configGroups {
+			if _, ok := set[group]; ok {
+				matchesGroups = true
+				break
+			}
+		}
+	}
+
+	return matchesGroups && ccSwitchImportConfigMatchesAllowedModels(config, normalizeExactStringList(entry.AllowedModels))
+}
+
+// GetPublicCcSwitchImportConfigs returns CC Switch import presets filtered by the API key's
+// permission restrictions. This is a public endpoint (no management key required).
+//
+// SECURITY:
+// - Requires api_key in POST body; does not accept query params to avoid leaking secrets in URLs.
+// - Returns an empty list when the key does not exist or is disabled.
+func (h *Handler) GetPublicCcSwitchImportConfigs(c *gin.Context) {
+	req, status, message := readPublicLookupRequest(c)
+	if message != "" {
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	apiKey := strings.TrimSpace(req.APIKey)
+	if apiKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+		return
+	}
+
+	row := usage.GetAPIKey(apiKey)
+	if row == nil {
+		items := []usage.CcSwitchImportConfigRow{}
+		c.JSON(http.StatusOK, gin.H{
+			"ccswitch-import-configs": items,
+			"items":                   items,
+			"api_key":                 apiKey,
+			"found":                   false,
+		})
+		return
+	}
+
+	profiles := usage.ListAPIKeyPermissionProfiles()
+	effective := usage.EffectiveAPIKeyRowWithProfiles(*row, profiles)
+	if effective.Disabled {
+		items := []usage.CcSwitchImportConfigRow{}
+		c.JSON(http.StatusOK, gin.H{
+			"ccswitch-import-configs": items,
+			"items":                   items,
+			"api_key":                 apiKey,
+			"found":                   false,
+		})
+		return
+	}
+
+	configs := usage.ListCcSwitchImportConfigs()
+	if configs == nil {
+		configs = []usage.CcSwitchImportConfigRow{}
+	}
+
+	filtered := make([]usage.CcSwitchImportConfigRow, 0, len(configs))
+	for _, cfg := range configs {
+		if ccSwitchImportConfigMatchesAPIKeyPermissions(cfg, &effective) {
+			filtered = append(filtered, cfg)
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"ccswitch-import-configs": filtered,
+		"items":                   filtered,
+		"api_key":                 apiKey,
+		"found":                   true,
+	})
+}
+

--- a/internal/api/handlers/management/ccswitch_import_configs_public.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public.go
@@ -182,4 +182,3 @@ func (h *Handler) GetPublicCcSwitchImportConfigs(c *gin.Context) {
 		"found":                   true,
 	})
 }
-

--- a/internal/api/handlers/management/ccswitch_import_configs_public_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public_test.go
@@ -1,0 +1,124 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func TestPublicCcSwitchImportConfigsFiltersByAPIKeyPermissions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	if err := usage.ReplaceAllCcSwitchImportConfigs([]usage.CcSwitchImportConfigRow{
+		{
+			ID:                   "claude-1",
+			ClientType:           "claude",
+			ProviderName:         "Claude Code A",
+			DefaultModel:         "kimi-k2.6",
+			AllowedChannelGroups: []string{"claude-code"},
+			EndpointPath:         "/anthropic",
+			UsageAutoInterval:    30,
+			APIKeyField:          "ANTHROPIC_AUTH_TOKEN",
+		},
+		{
+			ID:                   "claude-2",
+			ClientType:           "claude",
+			ProviderName:         "Claude Code B",
+			DefaultModel:         "kimi-k2.6",
+			AllowedChannelGroups: []string{"claude-code"},
+			EndpointPath:         "/anthropic",
+			UsageAutoInterval:    30,
+			APIKeyField:          "ANTHROPIC_AUTH_TOKEN",
+		},
+		{
+			ID:                   "codex-1",
+			ClientType:           "codex",
+			ProviderName:         "Codex A",
+			DefaultModel:         "gpt-5.2",
+			AllowedChannelGroups: []string{"codex"},
+			EndpointPath:         "/openai",
+			UsageAutoInterval:    30,
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllCcSwitchImportConfigs: %v", err)
+	}
+
+	const apiKey = "sk-nyw1boql0aetf5o7dl2srrf9ciftgd95"
+	if err := usage.ReplaceAllAPIKeys([]usage.APIKeyRow{
+		{
+			Key:                  apiKey,
+			Name:                 "test",
+			AllowedChannelGroups: []string{"claude-code"},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllAPIKeys: %v", err)
+	}
+
+	body := []byte(`{"api_key":"` + apiKey + `"}`)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/public/ccswitch-import-configs", bytes.NewReader(body))
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.GetPublicCcSwitchImportConfigs(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got struct {
+		Items []usage.CcSwitchImportConfigRow `json:"items"`
+		Found bool                            `json:"found"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !got.Found {
+		t.Fatalf("found = false, want true")
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("items len = %d, want 2", len(got.Items))
+	}
+	if got.Items[0].ClientType != "claude" || got.Items[1].ClientType != "claude" {
+		t.Fatalf("items = %#v, want claude only", got.Items)
+	}
+}
+
+func TestPublicCcSwitchImportConfigsReturnsEmptyWhenKeyUnknown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/public/ccswitch-import-configs", bytes.NewReader([]byte(`{"api_key":"sk-unknown"}`)))
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.GetPublicCcSwitchImportConfigs(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got struct {
+		Items []usage.CcSwitchImportConfigRow `json:"items"`
+		Found bool                            `json:"found"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got.Found {
+		t.Fatalf("found = true, want false")
+	}
+	if len(got.Items) != 0 {
+		t.Fatalf("items len = %d, want 0", len(got.Items))
+	}
+}
+

--- a/internal/api/handlers/management/ccswitch_import_configs_public_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public_test.go
@@ -121,4 +121,3 @@ func TestPublicCcSwitchImportConfigsReturnsEmptyWhenKeyUnknown(t *testing.T) {
 		t.Fatalf("items len = %d, want 0", len(got.Items))
 	}
 }
-

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -880,6 +880,8 @@ func (s *Server) registerManagementRoutes() {
 	{
 		pub.GET("/usage", s.mgmt.GetPublicUsageByAPIKey)
 		pub.POST("/usage", s.mgmt.GetPublicUsageByAPIKey)
+		pub.GET("/ccswitch-import-configs", s.mgmt.GetPublicCcSwitchImportConfigs)
+		pub.POST("/ccswitch-import-configs", s.mgmt.GetPublicCcSwitchImportConfigs)
 		pub.GET("/usage/logs", s.mgmt.GetPublicUsageLogs)
 		pub.POST("/usage/logs", s.mgmt.GetPublicUsageLogs)
 		pub.GET("/usage/logs/:id/content", s.mgmt.GetPublicLogContent)


### PR DESCRIPTION
Adds a public endpoint to support the standalone API key lookup page Quick Import without requiring a management key.

- Add `/v0/management/public/ccswitch-import-configs` (GET/POST) returning presets filtered by the provided `api_key` permissions.
- Unknown/disabled keys return an empty list (`found=false`).
- Includes unit tests.

Validation:
- go test ./internal/api/handlers/management -run TestPublicCcSwitchImportConfigs
