### PR TITLE
fix: skip status-disabled auths during selection (bug #139398)

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2158,7 +2158,7 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 	buildCandidates := func(scopedRouteGroup string) []*Auth {
 		candidates := make([]*Auth, 0, len(m.auths))
 		for _, candidate := range m.auths {
-			if candidate.Provider != provider || candidate.Disabled {
+			if candidate.Provider != provider || candidate.Disabled || candidate.Status == StatusDisabled {
 				continue
 			}
 			if pinnedAuthID != "" && candidate.ID != pinnedAuthID {
@@ -2250,7 +2250,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 	buildCandidates := func(scopedRouteGroup string) []*Auth {
 		candidates := make([]*Auth, 0, len(m.auths))
 		for _, candidate := range m.auths {
-			if candidate == nil || candidate.Disabled {
+			if candidate == nil || candidate.Disabled || candidate.Status == StatusDisabled {
 				continue
 			}
 			if pinnedAuthID != "" && candidate.ID != pinnedAuthID {

--- a/sdk/cliproxy/auth/conductor_disabled_status_test.go
+++ b/sdk/cliproxy/auth/conductor_disabled_status_test.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func TestPickNextSkipsStatusDisabledAuth(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(&stubExecutor{id: "gemini"})
+	manager.runtimeConfig.Store(&internalconfig.Config{Routing: internalconfig.RoutingConfig{IncludeDefaultGroup: true}})
+
+	active := &Auth{ID: "a1", Provider: "gemini", Label: "Active", Disabled: false, Status: StatusActive}
+	disabled := &Auth{ID: "a2", Provider: "gemini", Label: "Disabled", Disabled: false, Status: StatusDisabled}
+	if _, err := manager.Register(context.Background(), active); err != nil {
+		t.Fatalf("register active: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), disabled); err != nil {
+		t.Fatalf("register disabled: %v", err)
+	}
+
+	auth, _, err := manager.pickNext(context.Background(), "gemini", "", cliproxyexecutor.Options{}, map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("pickNext: %v", err)
+	}
+	if auth == nil {
+		t.Fatalf("pickNext returned nil auth")
+	}
+	if auth.ID != active.ID {
+		t.Fatalf("selected auth = %q, want %q", auth.ID, active.ID)
+	}
+}
+
+func TestPickNextMixedSkipsStatusDisabledAuth(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(&stubExecutor{id: "gemini"})
+	manager.runtimeConfig.Store(&internalconfig.Config{Routing: internalconfig.RoutingConfig{IncludeDefaultGroup: true}})
+
+	active := &Auth{ID: "a1", Provider: "gemini", Label: "Active", Disabled: false, Status: StatusActive}
+	disabled := &Auth{ID: "a2", Provider: "gemini", Label: "Disabled", Disabled: false, Status: StatusDisabled}
+	if _, err := manager.Register(context.Background(), active); err != nil {
+		t.Fatalf("register active: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), disabled); err != nil {
+		t.Fatalf("register disabled: %v", err)
+	}
+
+	auth, _, provider, err := manager.pickNextMixed(context.Background(), []string{"gemini"}, "", cliproxyexecutor.Options{}, map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("pickNextMixed: %v", err)
+	}
+	if provider != "gemini" {
+		t.Fatalf("provider = %q, want gemini", provider)
+	}
+	if auth == nil {
+		t.Fatalf("pickNextMixed returned nil auth")
+	}
+	if auth.ID != active.ID {
+		t.Fatalf("selected auth = %q, want %q", auth.ID, active.ID)
+	}
+}

--- a/sdk/cliproxy/auth/routing_groups.go
+++ b/sdk/cliproxy/auth/routing_groups.go
@@ -640,7 +640,7 @@ func (m *Manager) CanServeModelWithScopes(modelID string, allowedChannels, allow
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, candidate := range m.auths {
-		if candidate == nil || candidate.Disabled {
+		if candidate == nil || candidate.Disabled || candidate.Status == StatusDisabled {
 			continue
 		}
 		if !authAllowedByChannels(candidate, allowedChannels) {


### PR DESCRIPTION
根因：Auth 选择与 CanServeModelWithScopes 只判断 candidate.Disabled，未判断 candidate.Status==disabled，导致被管理端标记为 disabled 的渠道（Disabled=false, Status=disabled）仍会被选中发起请求。

修复：在 auth selection（pickNext / pickNextMixed）以及模型可用性探测（CanServeModelWithScopes）中同时跳过 StatusDisabled。

验证：新增单测覆盖 pickNext/pickNextMixed 不会选到 StatusDisabled。