### PR TITLE
fix: disable config API keys on wildcard exclusions

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -256,6 +256,51 @@ func TestUpdateClientsDisablesRemovedConfigAuths(t *testing.T) {
 	}
 }
 
+func TestUpdateClientsDisableAllModelsMarksConfigAuthDisabled(t *testing.T) {
+	server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
+		cfg.ClaudeKey = []proxyconfig.ClaudeKey{{
+			APIKey:  "sk-claude-hot-reload-key",
+			Name:    "Kimi渠道",
+			BaseURL: "https://api.kimi.com/coding/",
+			Models:  []proxyconfig.ClaudeModel{{Name: "K2.6", Alias: "claude-sonnet-4-6"}},
+		}}
+	})
+	manager := server.handlers.AuthManager
+
+	server.UpdateClients(server.cfg)
+	var active *auth.Auth
+	for _, candidate := range manager.List() {
+		if candidate != nil && candidate.Provider == "claude" {
+			active = candidate
+			break
+		}
+	}
+	if active == nil {
+		t.Fatal("expected initial config-derived Claude auth")
+	}
+	if active.Disabled || active.Status != auth.StatusActive {
+		t.Fatalf("expected initial active auth, got disabled=%t status=%s", active.Disabled, active.Status)
+	}
+
+	next := *server.cfg
+	next.ClaudeKey = []proxyconfig.ClaudeKey{{
+		APIKey:         "sk-claude-hot-reload-key",
+		Name:           "Kimi渠道",
+		BaseURL:        "https://api.kimi.com/coding/",
+		Models:         []proxyconfig.ClaudeModel{{Name: "K2.6", Alias: "claude-sonnet-4-6"}},
+		ExcludedModels: []string{"*"},
+	}}
+	server.UpdateClients(&next)
+
+	updated, ok := manager.GetByID(active.ID)
+	if !ok {
+		t.Fatal("expected config-derived auth to remain registered")
+	}
+	if !updated.Disabled || updated.Status != auth.StatusDisabled {
+		t.Fatalf("expected disable-all config auth to be disabled, got disabled=%t status=%s", updated.Disabled, updated.Status)
+	}
+}
+
 func TestGroupedV1RouteForbiddenByAPIKeyGroups(t *testing.T) {
 	server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
 		cfg.SDKConfig.APIKeys = nil

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -92,6 +92,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeys(ctx *SynthesisContext) []*corea
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
+		ApplyDisableAllModelsState(a, entry.ExcludedModels)
 		out = append(out, a)
 	}
 	return out
@@ -149,6 +150,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, ck.ExcludedModels, "apikey")
+		ApplyDisableAllModelsState(a, ck.ExcludedModels)
 		out = append(out, a)
 	}
 	return out
@@ -239,6 +241,7 @@ func (s *ConfigSynthesizer) synthesizeBedrockKeys(ctx *SynthesisContext) []*core
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
+		ApplyDisableAllModelsState(a, entry.ExcludedModels)
 		out = append(out, a)
 	}
 	return out
@@ -295,6 +298,7 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, ck.ExcludedModels, "apikey")
+		ApplyDisableAllModelsState(a, ck.ExcludedModels)
 		out = append(out, a)
 	}
 	return out
@@ -345,6 +349,7 @@ func (s *ConfigSynthesizer) synthesizeOpenCodeGoKeys(ctx *SynthesisContext) []*c
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
+		ApplyDisableAllModelsState(a, entry.ExcludedModels)
 		out = append(out, a)
 	}
 	return out

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -230,6 +230,42 @@ func TestConfigSynthesizer_ClaudeKeys_SkipsEmptyAndHeaders(t *testing.T) {
 	}
 }
 
+func TestConfigSynthesizer_ClaudeKeyDisableAllModelsMarksAuthDisabled(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			ClaudeKey: []config.ClaudeKey{
+				{
+					APIKey:         "sk-claude-disabled",
+					Name:           "Kimi渠道",
+					BaseURL:        "https://api.kimi.com/coding/",
+					ExcludedModels: []string{"*"},
+					Models: []config.ClaudeModel{
+						{Name: "K2.6", Alias: "claude-sonnet-4-6"},
+					},
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	auth := auths[0]
+	if !auth.Disabled || auth.Status != coreauth.StatusDisabled {
+		t.Fatalf("expected disabled auth for excluded-models wildcard, got disabled=%t status=%s", auth.Disabled, auth.Status)
+	}
+	if auth.Attributes["excluded_models"] != "*" || auth.Attributes["auth_kind"] != "apikey" {
+		t.Fatalf("expected exclusion metadata to be preserved, got %#v", auth.Attributes)
+	}
+}
+
 func TestConfigSynthesizer_CodexKeys(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -103,6 +103,21 @@ func ApplyAuthExcludedModelsMeta(auth *coreauth.Auth, cfg *config.Config, perKey
 	}
 }
 
+func ApplyDisableAllModelsState(auth *coreauth.Auth, excludedModels []string) {
+	if auth == nil {
+		return
+	}
+	for _, model := range excludedModels {
+		if strings.TrimSpace(model) != "*" {
+			continue
+		}
+		auth.Disabled = true
+		auth.Status = coreauth.StatusDisabled
+		auth.StatusMessage = "disabled via excluded-models wildcard"
+		return
+	}
+}
+
 // addConfigHeadersToAttrs adds header configuration to auth attributes.
 // Headers are prefixed with "header:" in the attributes map.
 func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string) {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
 	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher/synthesizer"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/wsrelay"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
@@ -391,6 +392,8 @@ func (s *Service) applyConfigReload(newCfg *config.Config, refreshRegisteredMode
 	s.applyPprofConfig(newCfg)
 	if s.server != nil {
 		s.server.UpdateClients(newCfg)
+	} else {
+		s.syncConfigDerivedAuths(newCfg)
 	}
 	s.cfgMu.Lock()
 	s.cfg = newCfg
@@ -408,6 +411,74 @@ func (s *Service) applyConfigReload(newCfg *config.Config, refreshRegisteredMode
 			s.registerModelsForAuth(context.Background(), auth)
 		}
 	}
+}
+
+func (s *Service) syncConfigDerivedAuths(cfg *config.Config) {
+	if s == nil || s.coreManager == nil || cfg == nil {
+		return
+	}
+
+	ctx := coreauth.WithSkipPersist(context.Background())
+	synth := synthesizer.NewConfigSynthesizer()
+	auths, err := synth.Synthesize(&synthesizer.SynthesisContext{
+		Config:      cfg,
+		AuthDir:     cfg.AuthDir,
+		Now:         time.Now(),
+		IDGenerator: synthesizer.NewStableIDGenerator(),
+	})
+	if err != nil {
+		log.WithError(err).Warn("failed to synthesize config auths during service config reload")
+		return
+	}
+
+	desiredIDs := make(map[string]struct{}, len(auths))
+	for _, next := range auths {
+		if next == nil || strings.TrimSpace(next.ID) == "" {
+			continue
+		}
+		desiredIDs[next.ID] = struct{}{}
+		if existing, ok := s.coreManager.GetByID(next.ID); ok && existing != nil {
+			next.CreatedAt = existing.CreatedAt
+			next.LastRefreshedAt = existing.LastRefreshedAt
+			next.NextRefreshAfter = existing.NextRefreshAfter
+			_, err = s.coreManager.Update(ctx, next)
+		} else {
+			_, err = s.coreManager.Register(ctx, next)
+		}
+		if err != nil {
+			log.WithError(err).Warnf("failed to apply config auth %s", next.ID)
+		}
+	}
+
+	for _, existing := range s.coreManager.List() {
+		if existing == nil || strings.TrimSpace(existing.ID) == "" {
+			continue
+		}
+		if !isServiceConfigDerivedAuth(existing) {
+			continue
+		}
+		if _, stillConfigured := desiredIDs[existing.ID]; stillConfigured {
+			continue
+		}
+		if existing.Disabled && existing.Status == coreauth.StatusDisabled {
+			continue
+		}
+		disabled := existing.Clone()
+		disabled.Disabled = true
+		disabled.Status = coreauth.StatusDisabled
+		disabled.StatusMessage = "removed via config update"
+		disabled.UpdatedAt = time.Now()
+		if _, err := s.coreManager.Update(ctx, disabled); err != nil {
+			log.WithError(err).Warnf("failed to disable removed config auth %s", disabled.ID)
+		}
+	}
+}
+
+func isServiceConfigDerivedAuth(authState *coreauth.Auth) bool {
+	if authState == nil || authState.Attributes == nil {
+		return false
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(authState.Attributes["source"])), "config:")
 }
 
 func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName string, ok bool) {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -62,6 +62,68 @@ func TestApplyConfigReloadRefreshesModelRegistryForConfigAuths(t *testing.T) {
 	}
 }
 
+func TestApplyConfigReloadDisableAllModelsPreventsClaudeAPIKeySelection(t *testing.T) {
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{IncludeDefaultGroup: true},
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey:  "sk-claude-hot-reload-key",
+			Name:    "Kimi渠道",
+			BaseURL: "https://api.kimi.com/coding/",
+			Models:  []internalconfig.ClaudeModel{{Name: "K2.6", Alias: "claude-sonnet-4-6"}},
+		}},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: cfg, coreManager: manager}
+	auth := &coreauth.Auth{
+		ID:       "claude-hot-reload-auth",
+		Provider: "claude",
+		Label:    "Kimi渠道",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":   "sk-claude-hot-reload-key",
+			"base_url":  "https://api.kimi.com/coding/",
+			"auth_kind": "apikey",
+			"source":    "config:claude[test]",
+		},
+	}
+	ctx := context.Background()
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(ctx, auth)
+	if !manager.CanServeModelWithScopes("claude-sonnet-4-6", nil, nil, "") {
+		t.Fatal("expected model to be routeable before disable-all config")
+	}
+
+	next := *cfg
+	next.ClaudeKey = []config.ClaudeKey{{
+		APIKey:         "sk-claude-hot-reload-key",
+		Name:           "Kimi渠道",
+		BaseURL:        "https://api.kimi.com/coding/",
+		Models:         []internalconfig.ClaudeModel{{Name: "K2.6", Alias: "claude-sonnet-4-6"}},
+		ExcludedModels: []string{"*"},
+	}}
+	service.applyConfigReload(&next, true)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected config auth to remain registered as disabled")
+	}
+	if !updated.Disabled || updated.Status != coreauth.StatusDisabled {
+		t.Fatalf("expected disabled config auth, got disabled=%t status=%s", updated.Disabled, updated.Status)
+	}
+	if manager.CanServeModelWithScopes("claude-sonnet-4-6", nil, nil, "") {
+		t.Fatal("disabled config auth should not be routeable")
+	}
+}
+
 func TestApplyConfigReloadDropsDisabledOpenAICompatibleProviderModels(t *testing.T) {
 	cfg := &config.Config{
 		OpenAICompatibility: []config.OpenAICompatibility{{


### PR DESCRIPTION
## Summary
- Treat config API-key entries with wildcard model exclusions as disabled auth records.
- Sync config-derived auth records during SDK-only config reloads so disabled state is applied before model refresh.
- Add regression coverage for synthesizer, SDK reload, and server config update paths.

## Validation
- go test ./internal/watcher/synthesizer ./sdk/cliproxy ./internal/api
