### PR TITLE
backend: support multi-value request log filters

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -101,9 +101,9 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 		Page:                  intQueryDefault(c, "page", 1),
 		Size:                  intQueryDefault(c, "size", 50),
 		Days:                  intQueryDefault(c, "days", 7),
-		APIKey:                strings.TrimSpace(c.Query("api_key")),
-		Model:                 strings.TrimSpace(c.Query("model")),
-		Status:                strings.TrimSpace(c.Query("status")),
+		APIKeys:               queryStringListMulti(c, "api_key", "api_keys"),
+		Models:                queryStringListMulti(c, "model", "models"),
+		Statuses:              queryStringListMulti(c, "status", "statuses"),
 		AuthIndexes:           authIndexes,
 		ChannelNames:          channelNames,
 		AuthIndexChannelNames: authIndexChannelNames,
@@ -784,6 +784,40 @@ func queryStringList(c *gin.Context, key string) []string {
 		}
 	}
 	return values
+}
+
+// queryStringListMulti parses query parameters that can be provided as:
+//  1. Repeated singular keys: ?api_key=a&api_key=b
+//  2. Plural comma-separated key: ?api_keys=a,b
+//  3. Single value: ?api_key=a
+func queryStringListMulti(c *gin.Context, singular, plural string) []string {
+	values := make([]string, 0)
+	// 1. Repeated singular keys: QueryArray handles ?key=a&key=b
+	values = append(values, c.QueryArray(singular)...)
+	// 2. Plural comma-separated key
+	if raw := strings.TrimSpace(c.Query(plural)); raw != "" {
+		values = append(values, strings.Split(raw, ",")...)
+	}
+	// 3. Single singular value (QueryArray already covered this, but be safe)
+	if raw := strings.TrimSpace(c.Query(singular)); raw != "" {
+		values = append(values, raw)
+	}
+	// Normalize: trim, deduplicate, remove empties
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, raw := range values {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if _, ok := seen[lower]; ok {
+			continue
+		}
+		seen[lower] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
 }
 
 func (h *Handler) GetAuthFileGroupTrend(c *gin.Context) {

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -41,9 +41,12 @@ type LogQueryParams struct {
 	Page         int      // 1-based
 	Size         int      // rows per page
 	Days         int      // time range in days
-	APIKey       string   // exact match filter
-	Model        string   // exact match filter
-	Status       string   // "success", "failed", or "" (all)
+	APIKey       string   // exact match filter (deprecated, use APIKeys)
+	Model        string   // exact match filter (deprecated, use Models)
+	Status       string   // "success", "failed", or "" (all) (deprecated, use Statuses)
+	APIKeys      []string // multi-value API key filter
+	Models       []string // multi-value model filter
+	Statuses     []string // multi-value status filter
 	AuthIndexes  []string // optional auth_index IN (...) filter
 	ChannelNames []string // optional channel_name IN (...) filter
 	// Optional precise legacy matches for renamed auth channels whose stored
@@ -1178,7 +1181,50 @@ func cutoffDayKey(days int) string {
 	return localDayKeyAt(CutoffStartUTC(days))
 }
 
+// normalizeLogQueryParams merges deprecated single-value fields into their
+// multi-value counterparts. It trims spaces, deduplicates, and removes empties.
+func normalizeLogQueryParams(params LogQueryParams) LogQueryParams {
+	if params.APIKey != "" {
+		params.APIKeys = append(params.APIKeys, params.APIKey)
+		params.APIKey = ""
+	}
+	if params.Model != "" {
+		params.Models = append(params.Models, params.Model)
+		params.Model = ""
+	}
+	if params.Status != "" {
+		params.Statuses = append(params.Statuses, params.Status)
+		params.Status = ""
+	}
+	params.APIKeys = normalizeStringList(params.APIKeys)
+	params.Models = normalizeStringList(params.Models)
+	params.Statuses = normalizeStringList(params.Statuses)
+	return params
+}
+
+func normalizeStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, v := range values {
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if _, ok := seen[lower]; ok {
+			continue
+		}
+		seen[lower] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
+}
+
 func buildWhereClause(params LogQueryParams) (string, []interface{}) {
+	params = normalizeLogQueryParams(params)
 	conditions := make([]string, 0, 4)
 	args := make([]interface{}, 0, 4)
 
@@ -1186,35 +1232,75 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 	conditions = append(conditions, "timestamp >= ?")
 	args = append(args, CutoffStartUTC(params.Days).Format(time.RFC3339))
 
-	if params.APIKey != "" {
-		if params.APIKey == systemRequestLogFilterValue {
-			conditions = append(conditions, `(
-				trim(coalesce(api_key_name, '')) = ''
-				AND (
-					trim(coalesce(api_key, '')) = ''
-					OR trim(coalesce(api_key, '')) LIKE '/%'
-					OR upper(trim(coalesce(api_key, ''))) LIKE 'GET /%'
-					OR upper(trim(coalesce(api_key, ''))) LIKE 'POST /%'
-					OR upper(trim(coalesce(api_key, ''))) LIKE 'PUT /%'
-					OR upper(trim(coalesce(api_key, ''))) LIKE 'PATCH /%'
-					OR upper(trim(coalesce(api_key, ''))) LIKE 'DELETE /%'
-					OR upper(trim(coalesce(api_key, ''))) LIKE 'OPTIONS /%'
-					OR upper(trim(coalesce(api_key, ''))) LIKE 'HEAD /%'
-				)
-			)`)
-		} else {
-			conditions = append(conditions, "api_key = ?")
-			args = append(args, params.APIKey)
+	// API Key multi-value filter
+	if len(params.APIKeys) > 0 {
+		apiKeyConds := make([]string, 0, len(params.APIKeys))
+		systemConds := make([]string, 0)
+		normalKeys := make([]string, 0, len(params.APIKeys))
+		for _, key := range params.APIKeys {
+			if key == systemRequestLogFilterValue {
+				systemConds = append(systemConds, `(
+					trim(coalesce(api_key_name, '')) = ''
+					AND (
+						trim(coalesce(api_key, '')) = ''
+						OR trim(coalesce(api_key, '')) LIKE '/%'
+						OR upper(trim(coalesce(api_key, ''))) LIKE 'GET /%'
+						OR upper(trim(coalesce(api_key, ''))) LIKE 'POST /%'
+						OR upper(trim(coalesce(api_key, ''))) LIKE 'PUT /%'
+						OR upper(trim(coalesce(api_key, ''))) LIKE 'PATCH /%'
+						OR upper(trim(coalesce(api_key, ''))) LIKE 'DELETE /%'
+						OR upper(trim(coalesce(api_key, ''))) LIKE 'OPTIONS /%'
+						OR upper(trim(coalesce(api_key, ''))) LIKE 'HEAD /%'
+					)
+				)`)
+			} else {
+				normalKeys = append(normalKeys, key)
+			}
+		}
+		if len(normalKeys) > 0 {
+			placeholders := make([]string, 0, len(normalKeys))
+			for _, k := range normalKeys {
+				placeholders = append(placeholders, "?")
+				args = append(args, k)
+			}
+			apiKeyConds = append(apiKeyConds, "api_key IN ("+strings.Join(placeholders, ",")+")")
+		}
+		apiKeyConds = append(apiKeyConds, systemConds...)
+		if len(apiKeyConds) == 1 {
+			conditions = append(conditions, apiKeyConds[0])
+		} else if len(apiKeyConds) > 1 {
+			conditions = append(conditions, "("+strings.Join(apiKeyConds, " OR ")+")")
 		}
 	}
-	if params.Model != "" {
-		conditions = append(conditions, "model = ?")
-		args = append(args, params.Model)
+
+	// Model multi-value filter
+	if len(params.Models) > 0 {
+		placeholders := make([]string, 0, len(params.Models))
+		for _, m := range params.Models {
+			placeholders = append(placeholders, "?")
+			args = append(args, m)
+		}
+		conditions = append(conditions, "model IN ("+strings.Join(placeholders, ",")+")")
 	}
-	if params.Status == "success" {
-		conditions = append(conditions, "failed = 0")
-	} else if params.Status == "failed" {
-		conditions = append(conditions, "failed = 1")
+
+	// Status multi-value filter
+	if len(params.Statuses) > 0 {
+		hasSuccess := false
+		hasFailed := false
+		for _, s := range params.Statuses {
+			switch strings.ToLower(s) {
+			case "success":
+				hasSuccess = true
+			case "failed":
+				hasFailed = true
+			}
+		}
+		if hasSuccess && !hasFailed {
+			conditions = append(conditions, "failed = 0")
+		} else if hasFailed && !hasSuccess {
+			conditions = append(conditions, "failed = 1")
+		}
+		// Both success and failed: no status filter needed (equivalent to "all")
 	}
 	if len(params.AuthIndexes) > 0 || len(params.ChannelNames) > 0 {
 		filterConditions := make([]string, 0, 2)


### PR DESCRIPTION
## Summary
- Extend LogQueryParams with multi-value fields (APIKeys, Models, Statuses)
- Add normalizeLogQueryParams to merge deprecated single-value fields
- Update buildWhereClause to generate IN (...) clauses for multi-value filters
- Add queryStringListMulti handler for parsing repeatable/comma-separated query params
- Handle __system__ API key with separate OR conditions
- Handle success+failed status as "no filter"
- All existing callers remain backward-compatible

## Test plan
- [x] go build passes
- [x] go test ./internal/api/handlers/management/... passes
- [x] go test ./internal/usage/... passes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>