### PR TITLE
feat: add Claude Opus 4.8 model definition

### DIFF
--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -64,6 +64,18 @@ func GetClaudeModels() []*ModelInfo {
 			Thinking:            &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: false, Levels: []string{"low", "medium", "high", "xhigh", "max"}},
 		},
 		{
+			ID:                  "claude-opus-4-8",
+			Object:              "model",
+			Created:             1779926400, // 2026-05-28
+			OwnedBy:             "anthropic",
+			Type:                "claude",
+			DisplayName:         "Claude Opus 4.8",
+			Description:         "Premium model combining maximum intelligence with practical performance",
+			ContextLength:       1000000,
+			MaxCompletionTokens: 128000,
+			Thinking:            &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: false, Levels: []string{"low", "medium", "high", "xhigh", "max"}},
+		},
+		{
 			ID:                  "claude-opus-4-5-20251101",
 			Object:              "model",
 			Created:             1761955200, // 2025-11-01


### PR DESCRIPTION
## Summary

- Add the static Claude model definition for `claude-opus-4-8`.
- Mirror the `claude-opus-4-7` capabilities: 1M context, 128k max completion tokens, and the same thinking level support.

## Verification

- Built local Docker image `clirelay:claude-opus-4-8-7f969176`.
- Deployed with `docker compose up -d` using the local image.
- Confirmed `cli-proxy-api` and `clirelay-updater` started successfully with commit `7f969176`.
- Confirmed the built binary contains `claude-opus-4-8` / `Claude Opus 4.8`.
- User verified the new model is accessible from Claude CLI.
- Ran `gofmt` on `internal/registry/model_definitions_static_data.go`.
- Ran `git diff --check`.
- Ran `go test ./internal/registry`.
- Ran `go test ./cmd/server`.
- Ran `go test ./internal/registry ./internal/thinking/...`.

## Notes

`go test ./...` currently has unrelated failures in `cmd/updater` and `internal/usage` around existing permission/mode expectations; the registry package passed.
