### PR TITLE
fix: /v1/models on CC switch route should only return configured models

### DIFF
--- a/internal/api/path_routing.go
+++ b/internal/api/path_routing.go
@@ -81,6 +81,7 @@ func ccSwitchRouteContextFromImportConfig(row usage.CcSwitchImportConfigRow) *in
 	return &internalrouting.CcSwitchRouteContext{
 		ConfigID:             strings.TrimSpace(row.ID),
 		ClientType:           strings.ToLower(strings.TrimSpace(row.ClientType)),
+		DefaultModel:         strings.TrimSpace(row.DefaultModel),
 		RoutePath:            row.RoutePath,
 		EndpointPath:         row.EndpointPath,
 		AllowedChannelGroups: append([]string(nil), row.AllowedChannelGroups...),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1247,6 +1247,31 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 		}
 		resp.Data = filtered
 
+		// Filter models by CC switch target models if this is a CC switch route
+		if routeCtx != nil && routeCtx.CcSwitch != nil {
+			ccswitchModels := make(map[string]struct{})
+			for _, mapping := range routeCtx.CcSwitch.ModelMappings {
+				target := strings.TrimSpace(mapping.TargetModel)
+				if target != "" {
+					ccswitchModels[target] = struct{}{}
+				}
+			}
+			if dm := strings.TrimSpace(routeCtx.CcSwitch.DefaultModel); dm != "" {
+				ccswitchModels[dm] = struct{}{}
+			}
+			if len(ccswitchModels) > 0 {
+				var ccswitchFiltered []map[string]interface{}
+				for _, model := range resp.Data {
+					if id, ok := model["id"].(string); ok {
+						if _, exists := ccswitchModels[id]; exists {
+							ccswitchFiltered = append(ccswitchFiltered, model)
+						}
+					}
+				}
+				resp.Data = ccswitchFiltered
+			}
+		}
+
 		// Write filtered response
 		filteredJSON, err := json.Marshal(resp)
 		if err != nil {

--- a/internal/routing/scope.go
+++ b/internal/routing/scope.go
@@ -23,6 +23,7 @@ type PathRouteContext struct {
 type CcSwitchRouteContext struct {
 	ConfigID             string
 	ClientType           string
+	DefaultModel         string
 	RoutePath            string
 	EndpointPath         string
 	AllowedChannelGroups []string


### PR DESCRIPTION
## Summary
- 修复 CC switch 路由的 `/v1/models` 接口返回全部模型的问题
- 现在只返回 model_mappings 中配置的 target-model + default-model
- 根路径 `/v1/models` 和其他路由不受影响

## 改动
- `routing/scope.go`: CcSwitchRouteContext 新增 DefaultModel 字段
- `api/path_routing.go`: 构建 CcSwitchRouteContext 时传入 DefaultModel
- `api/server.go`: unifiedModelsHandler 添加 CC switch 模型过滤逻辑

## Test plan
- [ ] 请求 CC switch 路由的 /v1/models，验证只返回配置的模型
- [ ] 请求根路径 /v1/models，验证不受影响

🤖 Generated with Claude Code