### PR TITLE
fix: CC switch routes should reject POST requests with models not in configured mappings

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1771,8 +1771,8 @@ func AuthMiddleware(manager *sdkaccess.Manager) gin.HandlerFunc {
 	}
 }
 
-// modelRestrictionMiddleware enforces model restrictions from API key config
-// and route-scoped channel-group allowed-models before a request reaches an upstream.
+// modelRestrictionMiddleware enforces model restrictions from API key config,
+// route-scoped channel-group allowed-models, and CC switch route model mappings.
 func (s *Server) modelRestrictionMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Only check POST requests (GET /models etc. don't need restriction)
@@ -1793,18 +1793,57 @@ func (s *Server) modelRestrictionMiddleware() gin.HandlerFunc {
 			routeGroup = route.Group
 		}
 		allowedGroups := allowedChannelGroupsFromAccessMetadata(c)
-		if allowedStr == "" && !s.hasScopedRoutingModelRestriction(routeGroup, allowedGroups) {
+
+		// Build CC switch route model restrictions (target-models + request-models + default-model)
+		var ccSwitchAllowed map[string]struct{}
+		if route != nil && route.CcSwitch != nil {
+			ccSwitchAllowed = make(map[string]struct{})
+			for _, mapping := range route.CcSwitch.ModelMappings {
+				if t := strings.TrimSpace(mapping.TargetModel); t != "" {
+					ccSwitchAllowed[t] = struct{}{}
+				}
+				if r := strings.TrimSpace(mapping.RequestModel); r != "" {
+					ccSwitchAllowed[r] = struct{}{}
+				}
+			}
+			if dm := strings.TrimSpace(route.CcSwitch.DefaultModel); dm != "" {
+				ccSwitchAllowed[dm] = struct{}{}
+			}
+			if len(ccSwitchAllowed) == 0 {
+				ccSwitchAllowed = nil
+			}
+		}
+
+		hasScopedRestriction := s.hasScopedRoutingModelRestriction(routeGroup, allowedGroups)
+		if allowedStr == "" && !hasScopedRestriction && ccSwitchAllowed == nil {
 			// No restriction — allow all models
 			c.Next()
 			return
 		}
 
 		// Parse allowed models into a set
-		allowedModels := make(map[string]struct{})
-		for _, m := range strings.Split(allowedStr, ",") {
-			trimmed := strings.TrimSpace(m)
-			if trimmed != "" {
-				allowedModels[trimmed] = struct{}{}
+		var allowedModels map[string]struct{}
+		if allowedStr != "" {
+			allowedModels = make(map[string]struct{})
+			for _, m := range strings.Split(allowedStr, ",") {
+				trimmed := strings.TrimSpace(m)
+				if trimmed != "" {
+					allowedModels[trimmed] = struct{}{}
+				}
+			}
+		}
+
+		// Merge CC switch route model restrictions
+		if ccSwitchAllowed != nil {
+			if len(allowedModels) == 0 {
+				allowedModels = ccSwitchAllowed
+			} else {
+				// Intersection: model must be in both
+				for m := range allowedModels {
+					if _, ok := ccSwitchAllowed[m]; !ok {
+						delete(allowedModels, m)
+					}
+				}
 			}
 		}
 		// Read the body to extract the model field


### PR DESCRIPTION
## Summary
- CC switch 路由的 POST 请求现在会校验模型是否在配置的 model_mappings 和 default-model 中
- 不在配置中的模型返回 403，而非透传到上游
- 根路径 `/v1/chat/completions` 和其他非 CC switch 路由不受影响

## 改动
- `api/server.go`: modelRestrictionMiddleware 新增 CC switch 模型白名单校验

## Test plan
- [ ] POST gpt-5.4（在配置中）→ 200
- [ ] POST gpt-5.2（不在配置中）→ 403
- [ ] POST 根路径任意模型 → 200（不受影响）

🤖 Generated with Claude Code