### PR TITLE
fix: cache and inject reasoning_content for DeepSeek thinking mode in OpenCode Go channel

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -84,6 +84,13 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	if !fallback.Applied {
 		req = e.sanitizeHistoricalImagesForTextModel(req)
 	}
+
+	// Inject cached reasoning_content for models that need it (e.g., DeepSeek thinking mode).
+	sessionID := opencodeGoSessionID(opts)
+	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
+		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
+	}
+
 	var resp cliproxyexecutor.Response
 	var err error
 	if opencodeGoUsesMessages(req.Model) {
@@ -91,8 +98,17 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	} else {
 		resp, err = e.openAIExecutor().Execute(ctx, opencodeGoAuthWithBaseURL(auth), req, opts)
 	}
-	if err != nil || !fallback.Applied {
+	if err != nil {
 		return resp, err
+	}
+
+	// Capture reasoning_content from the upstream response for caching.
+	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
+		opencodeGoCacheReasoningFromNonStream(resp.Payload, req.Model, sessionID)
+	}
+
+	if !fallback.Applied {
+		return resp, nil
 	}
 	resp.Payload = opencodeGoRewriteFallbackResponseModel(resp.Payload, fallback.OriginalModel)
 	return resp, nil
@@ -104,6 +120,12 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 	if !fallback.Applied {
 		req = e.sanitizeHistoricalImagesForTextModel(req)
 	}
+	// Inject cached reasoning_content for models that need it (e.g., DeepSeek thinking mode).
+	sessionID := opencodeGoSessionID(opts)
+	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
+		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
+	}
+
 	var result *cliproxyexecutor.StreamResult
 	var err error
 	if opencodeGoUsesMessages(req.Model) {
@@ -111,9 +133,20 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 	} else {
 		result, err = e.openAIExecutor().ExecuteStream(ctx, opencodeGoAuthWithBaseURL(auth), req, opts)
 	}
-	if err != nil || !fallback.Applied {
+	if err != nil {
 		return result, err
 	}
+
+	// Wrap stream to capture reasoning_content from streaming chunks.
+	// This must happen before the fallback check so non-fallback requests also get caching.
+	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
+		result = opencodeGoWrapStreamCacheReasoning(result, req.Model, sessionID)
+	}
+
+	if !fallback.Applied {
+		return result, nil
+	}
+
 	return opencodeGoRewriteFallbackStreamResult(result, fallback.OriginalModel), nil
 }
 

--- a/internal/runtime/executor/opencode_go_reasoning.go
+++ b/internal/runtime/executor/opencode_go_reasoning.go
@@ -1,0 +1,270 @@
+package executor
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+var (
+	reasoningContentCacheTTL        = 30 * time.Minute
+	reasoningCacheCleanupInterval   = 5 * time.Minute
+	reasoningCacheMaxEntriesPerKey  = 1
+)
+
+var (
+	reasoningCache     sync.Map
+	reasoningCacheOnce sync.Once
+)
+
+type reasoningEntry struct {
+	content   string
+	timestamp time.Time
+}
+
+func startReasoningCacheCleanup() {
+	reasoningCacheOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(reasoningCacheCleanupInterval)
+			defer ticker.Stop()
+			for range ticker.C {
+				purgeExpiredReasoningEntries()
+			}
+		}()
+	})
+}
+
+func purgeExpiredReasoningEntries() {
+	now := time.Now()
+	reasoningCache.Range(func(key, value any) bool {
+		entry := value.(reasoningEntry)
+		if now.Sub(entry.timestamp) > reasoningContentCacheTTL {
+			reasoningCache.Delete(key)
+		}
+		return true
+	})
+}
+
+// opencodeGoSessionID extracts the session identifier from executor options.
+// Returns empty string if no session identifier is found.
+func opencodeGoSessionID(opts cliproxyexecutor.Options) string {
+	if opts.Headers != nil {
+		if sessionID := opts.Headers.Get("Session-Id"); sessionID != "" {
+			return sessionID
+		}
+		if sessionID := opts.Headers.Get("X-Client-Request-Id"); sessionID != "" {
+			return sessionID
+		}
+	}
+	if raw, ok := opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey]; ok {
+		if s, ok := raw.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+// opencodeGoNeedsReasoningInjection checks if the model requires reasoning_content
+// tracking for multi-turn conversations (e.g., DeepSeek thinking mode).
+func opencodeGoNeedsReasoningInjection(model string) bool {
+	base := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(model).ModelName))
+	return strings.HasPrefix(base, "deepseek")
+}
+
+// opencodeGoCacheReasoningContent stores reasoning_content for a given model and session.
+func opencodeGoCacheReasoningContent(model, sessionID, content string) {
+	if model == "" || sessionID == "" || content == "" {
+		return
+	}
+	startReasoningCacheCleanup()
+	key := model + ":" + sessionID
+	reasoningCache.Store(key, reasoningEntry{
+		content:   content,
+		timestamp: time.Now(),
+	})
+}
+
+// opencodeGoGetCachedReasoningContent retrieves reasoning_content for a given model and session.
+// Returns empty string if not found or expired.
+func opencodeGoGetCachedReasoningContent(model, sessionID string) string {
+	if model == "" || sessionID == "" {
+		return ""
+	}
+	val, ok := reasoningCache.Load(model + ":" + sessionID)
+	if !ok {
+		return ""
+	}
+	entry := val.(reasoningEntry)
+	if time.Since(entry.timestamp) > reasoningContentCacheTTL {
+		reasoningCache.Delete(model + ":" + sessionID)
+		return ""
+	}
+	// Refresh TTL on access (sliding expiration)
+	entry.timestamp = time.Now()
+	reasoningCache.Store(model+":"+sessionID, entry)
+	return entry.content
+}
+
+// opencodeGoCacheReasoningFromNonStream extracts reasoning_content from a non-streaming
+// response payload and caches it for future requests.
+func opencodeGoCacheReasoningFromNonStream(payload []byte, model, sessionID string) {
+	if len(payload) == 0 || model == "" || sessionID == "" || !gjson.ValidBytes(payload) {
+		return
+	}
+	// OpenAI chat completions format
+	if content := gjson.GetBytes(payload, "choices.0.message.reasoning_content").String(); content != "" {
+		opencodeGoCacheReasoningContent(model, sessionID, content)
+	}
+	// Anthropic messages format (via executeMessages / executeMessagesStream)
+	// The response has been translated back, so reasoning_content might be in the
+	// translated payload too.
+}
+
+// opencodeGoCacheReasoningFromStreamChunk extracts reasoning_content from a streaming
+// SSE chunk and caches it for future requests. It should be called for every streaming
+// chunk that contains a reasoning_content delta.
+func opencodeGoCacheReasoningFromStreamChunk(payload []byte, model, sessionID string) {
+	if len(payload) == 0 || model == "" || sessionID == "" {
+		return
+	}
+	// Handle SSE format: "data: {...}\n\n"
+	raw := payload
+	dataPrefix := []byte("data: ")
+	if bytes.HasPrefix(bytes.TrimSpace(payload), dataPrefix) {
+		raw = bytes.TrimSpace(payload[len(dataPrefix):])
+	}
+	if !gjson.ValidBytes(raw) {
+		return
+	}
+	// OpenAI chat completions streaming format
+	content := gjson.GetBytes(raw, "choices.0.delta.reasoning_content").String()
+	if content == "" {
+		return
+	}
+	key := model + ":" + sessionID
+	// Accumulate: append to existing entry if it exists
+	val, ok := reasoningCache.Load(key)
+	if ok {
+		entry := val.(reasoningEntry)
+		if time.Since(entry.timestamp) <= reasoningContentCacheTTL {
+			content = entry.content + content
+		}
+	}
+	opencodeGoCacheReasoningContent(model, sessionID, content)
+}
+
+// opencodeGoInjectReasoningContentIntoPayload scans the request payload for assistant
+// messages that are missing reasoning_content and injects the cached content when available.
+// This is needed for DeepSeek models that require reasoning_content in multi-turn thinking mode.
+func opencodeGoInjectReasoningContentIntoPayload(payload []byte, model, sessionID string) []byte {
+	if len(payload) == 0 || model == "" || sessionID == "" || !gjson.ValidBytes(payload) {
+		return payload
+	}
+
+	reasoningContent := opencodeGoGetCachedReasoningContent(model, sessionID)
+	if reasoningContent == "" {
+		return payload
+	}
+
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.Exists() || !messages.IsArray() || len(messages.Array()) == 0 {
+		// Also check for Responses API format (input array)
+		input := gjson.GetBytes(payload, "input")
+		if input.Exists() && input.IsArray() && len(input.Array()) > 0 {
+			return opencodeGoInjectInputArrayReasoning(payload, model, reasoningContent)
+		}
+		return payload
+	}
+
+	msgs := messages.Array()
+	modified := false
+
+	// Find the LAST assistant message that is missing reasoning_content
+	// This is the message from the previous turn that needs injection
+	for i := len(msgs) - 1; i >= 0; i-- {
+		msg := msgs[i]
+		role := msg.Get("role").String()
+		if role != "assistant" {
+			continue
+		}
+		// Skip if already has reasoning_content
+		if msg.Get("reasoning_content").Exists() && msg.Get("reasoning_content").String() != "" {
+			continue
+		}
+		// Skip pure tool_call messages
+		if msg.Get("tool_calls").Exists() && msg.Get("tool_calls").IsArray() &&
+			len(msg.Get("tool_calls").Array()) > 0 && msg.Get("content").String() == "" {
+			continue
+		}
+		path := fmt.Sprintf("messages.%d.reasoning_content", i)
+		var err error
+		payload, err = sjson.SetBytes(payload, path, reasoningContent)
+		if err == nil {
+			modified = true
+		}
+		break
+	}
+
+	if !modified {
+		return payload
+	}
+	return payload
+}
+
+// opencodeGoInjectInputArrayReasoning handles the Responses API format (input array).
+func opencodeGoInjectInputArrayReasoning(payload []byte, model, content string) []byte {
+	input := gjson.GetBytes(payload, "input")
+	if !input.Exists() || !input.IsArray() {
+		return payload
+	}
+	items := input.Array()
+	modified := false
+
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		role := item.Get("role").String()
+		if role != "assistant" {
+			continue
+		}
+		if item.Get("reasoning_content").Exists() && item.Get("reasoning_content").String() != "" {
+			continue
+		}
+		path := fmt.Sprintf("input.%d.reasoning_content", i)
+		var err error
+		payload, err = sjson.SetBytes(payload, path, content)
+		if err == nil {
+			modified = true
+		}
+		break
+	}
+	if !modified {
+		return payload
+	}
+	return payload
+}
+
+// opencodeGoWrapStreamCacheReasoning wraps a StreamResult's chunk channel to intercept
+// and cache reasoning_content from streaming responses.
+func opencodeGoWrapStreamCacheReasoning(result *cliproxyexecutor.StreamResult, model, sessionID string) *cliproxyexecutor.StreamResult {
+	if result == nil || model == "" || sessionID == "" {
+		return result
+	}
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		for chunk := range result.Chunks {
+			if chunk.Err == nil && len(chunk.Payload) > 0 {
+				opencodeGoCacheReasoningFromStreamChunk(chunk.Payload, model, sessionID)
+			}
+			out <- chunk
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: result.Headers, Chunks: out}
+}

--- a/internal/runtime/executor/opencode_go_reasoning_test.go
+++ b/internal/runtime/executor/opencode_go_reasoning_test.go
@@ -1,0 +1,809 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// ---------------------------------------------------------------------------
+// Unit: opencodeGoNeedsReasoningInjection
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoNeedsReasoningInjection(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"deepseek-v4-flash", true},
+		{"deepseek-v4-pro", true},
+		{"deepseek-v3", true},
+		{"DEEPSEEK-v4-flash", true},
+		{"DeepSeek-V4-Flash", true},
+		{"deepseek-v4-flash:think", true},
+		{"gpt-5.5", false},
+		{"gpt-4o", false},
+		{"claude-sonnet-4-5", false},
+		{"gemini-2.5-pro", false},
+		{"minimax-m2.7", false},
+		{"qwen3.5-plus", false},
+	}
+	for _, tc := range tests {
+		got := opencodeGoNeedsReasoningInjection(tc.model)
+		if got != tc.want {
+			t.Errorf("opencodeGoNeedsReasoningInjection(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit: opencodeGoSessionID
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoSessionID_FromHeaders(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Session-Id", "sess_abc123")
+	opts := cliproxyexecutor.Options{Headers: headers}
+	if got := opencodeGoSessionID(opts); got != "sess_abc123" {
+		t.Errorf("opencodeGoSessionID = %q, want sess_abc123", got)
+	}
+}
+
+func TestOpenCodeGoSessionID_FromFallbackHeader(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("X-Client-Request-Id", "req_xyz789")
+	opts := cliproxyexecutor.Options{Headers: headers}
+	if got := opencodeGoSessionID(opts); got != "req_xyz789" {
+		t.Errorf("opencodeGoSessionID = %q, want req_xyz789", got)
+	}
+}
+
+func TestOpenCodeGoSessionID_FromMetadata(t *testing.T) {
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "meta_session_001",
+		},
+	}
+	if got := opencodeGoSessionID(opts); got != "meta_session_001" {
+		t.Errorf("opencodeGoSessionID = %q, want meta_session_001", got)
+	}
+}
+
+func TestOpenCodeGoSessionID_PreferSessionIDOverClientRequest(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Session-Id", "primary_session")
+	headers.Set("X-Client-Request-Id", "secondary_req")
+	opts := cliproxyexecutor.Options{Headers: headers}
+	if got := opencodeGoSessionID(opts); got != "primary_session" {
+		t.Errorf("opencodeGoSessionID = %q, want primary_session", got)
+	}
+}
+
+func TestOpenCodeGoSessionID_Empty(t *testing.T) {
+	opts := cliproxyexecutor.Options{}
+	if got := opencodeGoSessionID(opts); got != "" {
+		t.Errorf("opencodeGoSessionID = %q, want empty", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit: reasoning cache (open/close helpers)
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoReasoningCache_SetGet(t *testing.T) {
+	// Clean state
+	reasoningCache = sync.Map{}
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_001", "previous reasoning step 1")
+	got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_001")
+	if got != "previous reasoning step 1" {
+		t.Errorf("Get cached = %q, want %q", got, "previous reasoning step 1")
+	}
+}
+
+func TestOpenCodeGoReasoningCache_Miss(t *testing.T) {
+	reasoningCache = sync.Map{}
+	if got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "no_such_session"); got != "" {
+		t.Errorf("expected empty for cache miss, got %q", got)
+	}
+}
+
+func TestOpenCodeGoReasoningCache_EmptyModelOrSession(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	opencodeGoCacheReasoningContent("", "sess_001", "content")
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "", "content")
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_001", "")
+
+	if got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_001"); got != "" {
+		t.Errorf("expected empty when nothing was cached, got %q", got)
+	}
+}
+
+func TestOpenCodeGoReasoningCache_TTLExpiry(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	// Use a short TTL for testing
+	origTTL := reasoningContentCacheTTL
+	reasoningContentCacheTTL = 1 * time.Millisecond
+	t.Cleanup(func() { reasoningContentCacheTTL = origTTL })
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_ttl", "some reasoning")
+	time.Sleep(2 * time.Millisecond)
+
+	if got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_ttl"); got != "" {
+		t.Errorf("expected empty after TTL expiry, got %q", got)
+	}
+}
+
+func TestOpenCodeGoReasoningCache_SlidingExpiry(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	origTTL := reasoningContentCacheTTL
+	reasoningContentCacheTTL = 50 * time.Millisecond
+	t.Cleanup(func() { reasoningContentCacheTTL = origTTL })
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_slide", "some reasoning")
+	// Access within TTL - should refresh
+	time.Sleep(20 * time.Millisecond)
+	if got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_slide"); got != "some reasoning" {
+		t.Errorf("expected content within TTL, got %q", got)
+	}
+	// Should still be valid after another 20ms (sliding window refreshed)
+	time.Sleep(20 * time.Millisecond)
+	if got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_slide"); got != "some reasoning" {
+		t.Errorf("expected content still valid with sliding expiry, got %q", got)
+	}
+}
+
+func TestOpenCodeGoReasoningCache_AccumulateOnSecondSet(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	opencodeGoCacheReasoningContent("model-a", "sess_x", "first")
+	opencodeGoCacheReasoningContent("model-a", "sess_x", "second")
+	got := opencodeGoGetCachedReasoningContent("model-a", "sess_x")
+	if got != "second" {
+		t.Errorf("expected second set overwrites first, got %q", got)
+	}
+}
+
+func TestOpenCodeGoReasoningCache_DifferentModelSameSession(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	opencodeGoCacheReasoningContent("model-a", "sess_same", "content a")
+	opencodeGoCacheReasoningContent("model-b", "sess_same", "content b")
+
+	gotA := opencodeGoGetCachedReasoningContent("model-a", "sess_same")
+	gotB := opencodeGoGetCachedReasoningContent("model-b", "sess_same")
+	if gotA != "content a" || gotB != "content b" {
+		t.Errorf("model-a=%q, model-b=%q", gotA, gotB)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit: opencodeGoCacheReasoningFromNonStream
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoCacheReasoningFromNonStream_ChatCompletions(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	payload := []byte(`{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello","reasoning_content":"thinking steps here"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	opencodeGoCacheReasoningFromNonStream(payload, "deepseek-v4-flash", "sess_001")
+
+	got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_001")
+	if got != "thinking steps here" {
+		t.Errorf("got %q, want %q", got, "thinking steps here")
+	}
+}
+
+func TestOpenCodeGoCacheReasoningFromNonStream_NoReasoning(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	payload := []byte(`{"id":"chatcmpl_2","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"No thinking"}}]}`)
+	opencodeGoCacheReasoningFromNonStream(payload, "deepseek-v4-flash", "sess_002")
+
+	if got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_002"); got != "" {
+		t.Errorf("expected empty when no reasoning_content, got %q", got)
+	}
+}
+
+func TestOpenCodeGoCacheReasoningFromNonStream_EmptyPayload(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	opencodeGoCacheReasoningFromNonStream(nil, "deepseek-v4-flash", "sess_003")
+	opencodeGoCacheReasoningFromNonStream([]byte{}, "deepseek-v4-flash", "sess_003")
+	opencodeGoCacheReasoningFromNonStream([]byte(`invalid json`), "deepseek-v4-flash", "sess_003")
+
+	if got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_003"); got != "" {
+		t.Errorf("expected empty for invalid payloads, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit: opencodeGoCacheReasoningFromStreamChunk
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoCacheReasoningFromStreamChunk_Delta(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	chunk := []byte(`data: {"id":"chunk1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"thinking"}}]}`)
+	opencodeGoCacheReasoningFromStreamChunk(chunk, "deepseek-v4-flash", "sess_stream")
+
+	got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_stream")
+	if got != "thinking" {
+		t.Errorf("got %q, want %q", got, "thinking")
+	}
+}
+
+func TestOpenCodeGoCacheReasoningFromStreamChunk_Accumulate(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	chunks := []string{
+		`data: {"id":"chunk1","choices":[{"index":0,"delta":{"reasoning_content":"step1 "}}]}`,
+		`data: {"id":"chunk2","choices":[{"index":0,"delta":{"reasoning_content":"step2 "}}]}`,
+		`data: {"id":"chunk3","choices":[{"index":0,"delta":{"reasoning_content":"step3"}}]}`,
+	}
+	for _, c := range chunks {
+		opencodeGoCacheReasoningFromStreamChunk([]byte(c), "deepseek-v4-flash", "sess_acc")
+	}
+
+	got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_acc")
+	if got != "step1 step2 step3" {
+		t.Errorf("accumulated = %q, want %q", got, "step1 step2 step3")
+	}
+}
+
+func TestOpenCodeGoCacheReasoningFromStreamChunk_NoDataPrefix(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	chunk := []byte(`{"choices":[{"index":0,"delta":{"reasoning_content":"raw json"}}]}`)
+	opencodeGoCacheReasoningFromStreamChunk(chunk, "deepseek-v4-flash", "sess_raw")
+
+	got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_raw")
+	if got != "raw json" {
+		t.Errorf("got %q, want %q", got, "raw json")
+	}
+}
+
+func TestOpenCodeGoCacheReasoningFromStreamChunk_InvalidJSON(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	opencodeGoCacheReasoningFromStreamChunk([]byte(`not json`), "deepseek-v4-flash", "sess_inv")
+	opencodeGoCacheReasoningFromStreamChunk([]byte(`data: not json too`), "deepseek-v4-flash", "sess_inv")
+
+	if got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_inv"); got != "" {
+		t.Errorf("expected empty for invalid json, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit: opencodeGoInjectReasoningContentIntoPayload
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoInjectReasoningContentInjectsIntoLastAssistant(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_inj", "cached reasoning")
+
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"previous response"},{"role":"user","content":"next question"}]}`)
+	got := opencodeGoInjectReasoningContentIntoPayload(payload, "deepseek-v4-flash", "sess_inj")
+
+	// Verify reasoning_content was injected into the last assistant message
+	msgs := gjson.GetBytes(got, "messages").Array()
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	lastAssistant := msgs[1] // index 1 is the assistant message
+	if rc := lastAssistant.Get("reasoning_content").String(); rc != "cached reasoning" {
+		t.Errorf("last assistant reasoning_content = %q, want %q", rc, "cached reasoning")
+	}
+}
+
+func TestOpenCodeGoInjectReasoningContentSkipsAssistantWithExistingReasoning(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_skip", "cached reasoning")
+
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"already has rc","reasoning_content":"existing rc"},{"role":"user","content":"next"}]}`)
+	got := opencodeGoInjectReasoningContentIntoPayload(payload, "deepseek-v4-flash", "sess_skip")
+
+	msgs := gjson.GetBytes(got, "messages").Array()
+	if rc := msgs[1].Get("reasoning_content").String(); rc != "existing rc" {
+		t.Errorf("should preserve existing reasoning_content, got %q", rc)
+	}
+}
+
+func TestOpenCodeGoInjectReasoningContentNoMessages(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_no_msg", "cached")
+
+	payload := []byte(`{"model":"deepseek-v4-flash","prompt":"just a prompt"}`)
+	got := opencodeGoInjectReasoningContentIntoPayload(payload, "deepseek-v4-flash", "sess_no_msg")
+	if string(got) != string(payload) {
+		t.Errorf("payload should not change when no messages array")
+	}
+}
+
+func TestOpenCodeGoInjectReasoningContentNoCache(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"resp"}]}`)
+	got := opencodeGoInjectReasoningContentIntoPayload(payload, "deepseek-v4-flash", "sess_no_cache")
+	if string(got) != string(payload) {
+		t.Errorf("payload should not change when cache is empty")
+	}
+}
+
+func TestOpenCodeGoInjectReasoningContentMultipleAssistants(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_multi", "cached reasoning")
+
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"q1"},{"role":"assistant","content":"a1"},{"role":"user","content":"q2"},{"role":"assistant","content":"a2","tool_calls":[{"id":"call_1","type":"function","function":{"name":"test","arguments":"{}"}}]},{"role":"tool","content":"result","tool_call_id":"call_1"},{"role":"assistant","content":"a3"}]}`)
+	got := opencodeGoInjectReasoningContentIntoPayload(payload, "deepseek-v4-flash", "sess_multi")
+
+	msgs := gjson.GetBytes(got, "messages").Array()
+	// Check that only the last assistant (without tool_calls and without existing reasoning_content) got injection
+	// Index 1 (a1) - not the last assistant (a3 at index 5 is), so should NOT get injection
+	if msgs[1].Get("reasoning_content").Exists() {
+		t.Errorf("assistant at index 1 should not get injection (only the last assistant gets it)")
+	}
+	// Index 3 (a2 with tool_calls) - should NOT get injection (tool_calls + no content)
+	if msgs[3].Get("reasoning_content").Exists() {
+		t.Errorf("assistant with tool_calls should not get reasoning_content injection")
+	}
+	// Index 5 (a3) - the last assistant, no tool_calls, no reasoning_content → should get injection
+	if rc := msgs[5].Get("reasoning_content").String(); rc != "cached reasoning" {
+		t.Errorf("last assistant at index 5 should get injection, got %q", rc)
+	}
+}
+
+func TestOpenCodeGoInjectReasoningContentPreservesModelName(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_pres", "cached")
+
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"resp"}]}`)
+	got := opencodeGoInjectReasoningContentIntoPayload(payload, "deepseek-v4-flash", "sess_pres")
+
+	if model := gjson.GetBytes(got, "model").String(); model != "deepseek-v4-flash" {
+		t.Errorf("model changed to %q", model)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: Execute with reasoning_content caching (non-streaming)
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoExecutorReasoningCacheNonStream(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	// Simulate a first request that gets a response with reasoning_content
+	var gotBodies [][]byte
+	reqCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBodies = append(gotBodies, body)
+		reqCount++
+		w.Header().Set("Content-Type", "application/json")
+		// First response includes reasoning_content
+		if reqCount == 1 {
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"first response","reasoning_content":"first reasoning step"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+		} else {
+			// Second response (should have reasoning_content injected)
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_2","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"second response"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+		}
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
+
+	// First request: inject reasoning_content (cache empty, so no injection)
+	sessionHeaders := make(http.Header)
+	sessionHeaders.Set("Session-Id", "integ_test_session")
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAI,
+		Headers:      sessionHeaders,
+	}
+
+	payload1 := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"first question"}]}`)
+	resp1, err1 := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload1,
+	}, opts)
+	if err1 != nil {
+		t.Fatalf("first Execute error: %v", err1)
+	}
+	if txt := gjson.GetBytes(resp1.Payload, "choices.0.message.content").String(); txt != "first response" {
+		t.Errorf("first response text = %q, want %q", txt, "first response")
+	}
+
+	// Verify reasoning_content was cached
+	cached := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "integ_test_session")
+	if cached != "first reasoning step" {
+		t.Errorf("cached reasoning = %q, want %q", cached, "first reasoning step")
+	}
+
+	// Second request: should have reasoning_content injected into assistant messages
+	payload2 := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"first question"},{"role":"assistant","content":"first response"},{"role":"user","content":"second question"}]}`)
+	resp2, err2 := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload2,
+	}, opts)
+	if err2 != nil {
+		t.Fatalf("second Execute error: %v", err2)
+	}
+	if txt := gjson.GetBytes(resp2.Payload, "choices.0.message.content").String(); txt != "second response" {
+		t.Errorf("second response text = %q, want %q", txt, "second response")
+	}
+
+	// Verify the second request sent to upstream had reasoning_content injected (check request 2: index 1 in gotBodies)
+	if len(gotBodies) < 2 {
+		t.Fatalf("expected at least 2 requests, got %d", len(gotBodies))
+	}
+	req2Body := gotBodies[1]
+	msgs := gjson.GetBytes(req2Body, "messages").Array()
+	if len(msgs) < 2 {
+		t.Fatalf("req2 messages length = %d", len(msgs))
+	}
+	// The last assistant message (index 1) should have reasoning_content
+	assistantMsg := msgs[1]
+	if !assistantMsg.Get("reasoning_content").Exists() {
+		t.Fatalf("second request assistant message missing reasoning_content; body=%s", string(req2Body))
+	}
+	if rc := assistantMsg.Get("reasoning_content").String(); rc != "first reasoning step" {
+		t.Errorf("injected reasoning_content = %q, want %q; body=%s", rc, "first reasoning step", string(req2Body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: ExecuteStream with reasoning_content caching
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoExecutorReasoningCacheStream(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	var gotBodies [][]byte
+	reqCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBodies = append(gotBodies, body)
+		reqCount++
+		w.Header().Set("Content-Type", "text/event-stream")
+		if reqCount == 1 {
+			// First streaming response with reasoning_content
+			_, _ = w.Write([]byte(`data: {"id":"chunk1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"step by step "}}]}` + "\n\n"))
+			_, _ = w.Write([]byte(`data: {"id":"chunk2","choices":[{"index":0,"delta":{"reasoning_content":"thinking "}}]}` + "\n\n"))
+			_, _ = w.Write([]byte(`data: {"id":"chunk3","choices":[{"index":0,"delta":{"content":"final answer"}}]}` + "\n\n"))
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		} else {
+			_, _ = w.Write([]byte(`data: {"id":"chunk1","choices":[{"index":0,"delta":{"content":"second answer"}}]}` + "\n\n"))
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		}
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
+
+	sessionHeaders := make(http.Header)
+	sessionHeaders.Set("Session-Id", "integ_stream_session")
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAI,
+		Headers:      sessionHeaders,
+		Stream:       true,
+	}
+
+	// First streaming request
+	payload1 := []byte(`{"model":"deepseek-v4-flash","stream":true,"messages":[{"role":"user","content":"first q"}]}`)
+	result1, err1 := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload1,
+	}, opts)
+	if err1 != nil {
+		t.Fatalf("first ExecuteStream error: %v", err1)
+	}
+
+	var chunks1 strings.Builder
+	for chunk := range result1.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		chunks1.Write(chunk.Payload)
+	}
+	if !strings.Contains(chunks1.String(), "final answer") {
+		t.Errorf("first stream should contain final answer; got %s", chunks1.String())
+	}
+
+	// Check that reasoning_content was accumulated in cache
+	cached := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "integ_stream_session")
+	if cached != "step by step thinking " {
+		t.Errorf("cached reasoning = %q, want %q", cached, "step by step thinking ")
+	}
+
+	// Second streaming request: should have reasoning_content injected
+	payload2 := []byte(`{"model":"deepseek-v4-flash","stream":true,"messages":[{"role":"user","content":"first q"},{"role":"assistant","content":"final answer"},{"role":"user","content":"second q"}]}`)
+	result2, err2 := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload2,
+	}, opts)
+	if err2 != nil {
+		t.Fatalf("second ExecuteStream error: %v", err2)
+	}
+
+	var chunks2 strings.Builder
+	for chunk := range result2.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("second stream chunk error: %v", chunk.Err)
+		}
+		chunks2.Write(chunk.Payload)
+	}
+	if !strings.Contains(chunks2.String(), "second answer") {
+		t.Errorf("second stream should contain second answer; got %s", chunks2.String())
+	}
+
+	// Verify the second request had reasoning_content injected
+	if len(gotBodies) < 2 {
+		t.Fatalf("expected at least 2 requests, got %d", len(gotBodies))
+	}
+	req2Body := gotBodies[1]
+	msgs := gjson.GetBytes(req2Body, "messages").Array()
+	if len(msgs) < 2 {
+		t.Fatalf("req2 messages length = %d", len(msgs))
+	}
+	assistantMsg := msgs[1]
+	if !assistantMsg.Get("reasoning_content").Exists() {
+		t.Fatalf("second streaming request missing reasoning_content; body=%s", string(req2Body))
+	}
+	if rc := assistantMsg.Get("reasoning_content").String(); rc != "step by step thinking " {
+		t.Errorf("injected reasoning_content = %q, want %q; body=%s", rc, "step by step thinking ", string(req2Body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: Non-deepseek model should NOT get reasoning injection
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoExecutorSkipsReasoningForNonDeepSeek(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	var gotBodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBodies = append(gotBodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"gpt-5.5","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
+
+	sessionHeaders := make(http.Header)
+	sessionHeaders.Set("Session-Id", "gpt_session")
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAI,
+		Headers:      sessionHeaders,
+	}
+
+	payload1 := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}]}`)
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: payload1,
+	}, opts)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	// GPT model should NOT have reasoning_content cached
+	if got := opencodeGoGetCachedReasoningContent("gpt-5.5", "gpt_session"); got != "" {
+		t.Errorf("should not cache reasoning for non-deepseek model, got %q", got)
+	}
+
+	// Second request should not be modified
+	payload2 := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"ok"},{"role":"user","content":"follow up"}]}`)
+	_, err = exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: payload2,
+	}, opts)
+	if err != nil {
+		t.Fatalf("second Execute error: %v", err)
+	}
+
+	if len(gotBodies) < 2 {
+		t.Fatalf("expected 2 requests, got %d", len(gotBodies))
+	}
+	req2Body := gotBodies[1]
+	if gjson.GetBytes(req2Body, "messages.1.reasoning_content").Exists() {
+		t.Errorf("non-deepseek request should not have reasoning_content injected; body=%s", string(req2Body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: messages path (e.g., minimax) should NOT get reasoning injection
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoExecutorSkipsReasoningForMessagesModels(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"minimax-m2.7","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
+
+	sessionHeaders := make(http.Header)
+	sessionHeaders.Set("Session-Id", "minimax_session")
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAI,
+		Headers:      sessionHeaders,
+	}
+
+	payload := []byte(`{"model":"minimax-m2.7","messages":[{"role":"user","content":"hi"}]}`)
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "minimax-m2.7",
+		Payload: payload,
+	}, opts)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	// minimax should NOT have reasoning_content cached
+	if got := opencodeGoGetCachedReasoningContent("minimax-m2.7", "minimax_session"); got != "" {
+		t.Errorf("should not cache reasoning for minimax, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit: inject into Responses API (input array) format
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoInjectReasoningContentResponsesAPI(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_resp", "cached reasoning")
+
+	payload := []byte(`{"model":"deepseek-v4-flash","input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]},{"role":"assistant","content":[{"type":"output_text","text":"prev response"}]},{"role":"user","content":[{"type":"input_text","text":"follow up"}]}]}`)
+	got := opencodeGoInjectReasoningContentIntoPayload(payload, "deepseek-v4-flash", "sess_resp")
+
+	input := gjson.GetBytes(got, "input").Array()
+	if len(input) < 2 {
+		t.Fatalf("expected at least 2 items, got %d", len(input))
+	}
+	assistantMsg := input[1]
+	if !assistantMsg.Get("reasoning_content").Exists() {
+		t.Fatalf("assistant in input should have reasoning_content; body=%s", string(got))
+	}
+	if rc := assistantMsg.Get("reasoning_content").String(); rc != "cached reasoning" {
+		t.Errorf("injected reasoning_content = %q, want %q", rc, "cached reasoning")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit: opencodeGoWrapStreamCacheReasoning
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoWrapStreamCacheReasoningCapturesContent(t *testing.T) {
+	reasoningCache = sync.Map{}
+	reasoningContentCacheTTL = 30 * time.Minute
+
+	chunks := make(chan cliproxyexecutor.StreamChunk, 3)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`data: {"choices":[{"index":0,"delta":{"reasoning_content":"thinking steps"}}]}`)}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`data: {"choices":[{"index":0,"delta":{"content":"answer"}}]}`)}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("data: [DONE]")}
+	close(chunks)
+
+	result := &cliproxyexecutor.StreamResult{
+		Chunks: chunks,
+	}
+	wrapped := opencodeGoWrapStreamCacheReasoning(result, "deepseek-v4-flash", "sess_wrap")
+
+	// Drain wrapped channel
+	for range wrapped.Chunks {
+	}
+
+	got := opencodeGoGetCachedReasoningContent("deepseek-v4-flash", "sess_wrap")
+	if got != "thinking steps" {
+		t.Errorf("cached reasoning = %q, want %q", got, "thinking steps")
+	}
+}
+
+func TestOpenCodeGoWrapStreamCacheReasoningNilResult(t *testing.T) {
+	got := opencodeGoWrapStreamCacheReasoning(nil, "deepseek-v4-flash", "sess_nil")
+	if got != nil {
+		t.Errorf("expected nil for nil input, got %v", got)
+	}
+}
+
+func TestOpenCodeGoWrapStreamCacheReasoningEmptySession(t *testing.T) {
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	close(chunks)
+	result := &cliproxyexecutor.StreamResult{Chunks: chunks}
+	got := opencodeGoWrapStreamCacheReasoning(result, "deepseek-v4-flash", "")
+	if got == nil {
+		t.Errorf("expected non-nil result even with empty session")
+	}
+}
+
+func TestOpenCodeGoWrapStreamCacheReasoningPassesChunksThrough(t *testing.T) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("chunk1")}
+	chunks <- cliproxyexecutor.StreamChunk{Err: io.ErrUnexpectedEOF}
+	close(chunks)
+
+	result := &cliproxyexecutor.StreamResult{Chunks: chunks}
+	wrapped := opencodeGoWrapStreamCacheReasoning(result, "deepseek-v4-flash", "sess_thru")
+
+	var seen [][]byte
+	for chunk := range wrapped.Chunks {
+		seen = append(seen, chunk.Payload)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(seen))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit: cache cleanup
+// ---------------------------------------------------------------------------
+
+func TestPurgeExpiredReasoningEntries(t *testing.T) {
+	reasoningCache = sync.Map{}
+
+	origTTL := reasoningContentCacheTTL
+	reasoningContentCacheTTL = 10 * time.Millisecond
+	t.Cleanup(func() { reasoningContentCacheTTL = origTTL })
+
+	opencodeGoCacheReasoningContent("deepseek-v4-flash", "sess_clean", "will expire")
+	time.Sleep(20 * time.Millisecond)
+
+	purgeExpiredReasoningEntries()
+
+	// Verify cache is empty
+	val, ok := reasoningCache.Load("deepseek-v4-flash:sess_clean")
+	if ok {
+		t.Errorf("expected entry to be purged, got %v", val)
+	}
+}


### PR DESCRIPTION
## Summary
- Added reasoning_content cache and injection for DeepSeek models in OpenCode Go channel
- Fixes HTTP 400 error: "The reasoning_content in the thinking mode must be passed back to the API"
- Uses session ID (Session-Id header) to track reasoning_content across multi-turn conversations
- Only affects deepseek-* models; non-deepseek models unaffected

## Test plan
- 35 new unit/integration tests added, covering cache operations, TTL, streaming accumulation, payload injection, Responses API format, and edge cases
- All 49 OpenCodeGo tests pass
- Manual verification: deploy to test server and confirm DeepSeek multi-turn conversations no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)