### PR TITLE
fix: use auth ID as fallback for reasoning_content cache key

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -86,7 +86,7 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	}
 
 	// Inject cached reasoning_content for models that need it (e.g., DeepSeek thinking mode).
-	sessionID := opencodeGoSessionID(opts)
+	sessionID := opencodeGoSessionID(opts, auth)
 	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
 		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
 	}
@@ -121,7 +121,7 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 		req = e.sanitizeHistoricalImagesForTextModel(req)
 	}
 	// Inject cached reasoning_content for models that need it (e.g., DeepSeek thinking mode).
-	sessionID := opencodeGoSessionID(opts)
+	sessionID := opencodeGoSessionID(opts, auth)
 	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
 		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
 	}

--- a/internal/runtime/executor/opencode_go_reasoning.go
+++ b/internal/runtime/executor/opencode_go_reasoning.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -53,8 +54,10 @@ func purgeExpiredReasoningEntries() {
 }
 
 // opencodeGoSessionID extracts the session identifier from executor options.
-// Returns empty string if no session identifier is found.
-func opencodeGoSessionID(opts cliproxyexecutor.Options) string {
+// Falls back to the auth ID (which is unique per API key) when session headers
+// are not forwarded to the executor.
+// Returns empty string if no identifier is found at all.
+func opencodeGoSessionID(opts cliproxyexecutor.Options, auth *cliproxyauth.Auth) string {
 	if opts.Headers != nil {
 		if sessionID := opts.Headers.Get("Session-Id"); sessionID != "" {
 			return sessionID
@@ -67,6 +70,12 @@ func opencodeGoSessionID(opts cliproxyexecutor.Options) string {
 		if s, ok := raw.(string); ok {
 			return strings.TrimSpace(s)
 		}
+	}
+	// Fallback: use auth ID (unique per API key / user).
+	// The Session-Id header is not forwarded to executors in all code paths,
+	// but auth ID is always available.
+	if auth != nil && strings.TrimSpace(auth.ID) != "" {
+		return strings.TrimSpace(auth.ID)
 	}
 	return ""
 }

--- a/internal/runtime/executor/opencode_go_reasoning_test.go
+++ b/internal/runtime/executor/opencode_go_reasoning_test.go
@@ -56,7 +56,7 @@ func TestOpenCodeGoSessionID_FromHeaders(t *testing.T) {
 	headers := make(http.Header)
 	headers.Set("Session-Id", "sess_abc123")
 	opts := cliproxyexecutor.Options{Headers: headers}
-	if got := opencodeGoSessionID(opts); got != "sess_abc123" {
+	if got := opencodeGoSessionID(opts, nil); got != "sess_abc123" {
 		t.Errorf("opencodeGoSessionID = %q, want sess_abc123", got)
 	}
 }
@@ -65,7 +65,7 @@ func TestOpenCodeGoSessionID_FromFallbackHeader(t *testing.T) {
 	headers := make(http.Header)
 	headers.Set("X-Client-Request-Id", "req_xyz789")
 	opts := cliproxyexecutor.Options{Headers: headers}
-	if got := opencodeGoSessionID(opts); got != "req_xyz789" {
+	if got := opencodeGoSessionID(opts, nil); got != "req_xyz789" {
 		t.Errorf("opencodeGoSessionID = %q, want req_xyz789", got)
 	}
 }
@@ -76,7 +76,7 @@ func TestOpenCodeGoSessionID_FromMetadata(t *testing.T) {
 			cliproxyexecutor.ExecutionSessionMetadataKey: "meta_session_001",
 		},
 	}
-	if got := opencodeGoSessionID(opts); got != "meta_session_001" {
+	if got := opencodeGoSessionID(opts, nil); got != "meta_session_001" {
 		t.Errorf("opencodeGoSessionID = %q, want meta_session_001", got)
 	}
 }
@@ -86,15 +86,33 @@ func TestOpenCodeGoSessionID_PreferSessionIDOverClientRequest(t *testing.T) {
 	headers.Set("Session-Id", "primary_session")
 	headers.Set("X-Client-Request-Id", "secondary_req")
 	opts := cliproxyexecutor.Options{Headers: headers}
-	if got := opencodeGoSessionID(opts); got != "primary_session" {
+	if got := opencodeGoSessionID(opts, nil); got != "primary_session" {
 		t.Errorf("opencodeGoSessionID = %q, want primary_session", got)
 	}
 }
 
 func TestOpenCodeGoSessionID_Empty(t *testing.T) {
 	opts := cliproxyexecutor.Options{}
-	if got := opencodeGoSessionID(opts); got != "" {
+	if got := opencodeGoSessionID(opts, nil); got != "" {
 		t.Errorf("opencodeGoSessionID = %q, want empty", got)
+	}
+}
+
+func TestOpenCodeGoSessionID_FallbackToAuthID(t *testing.T) {
+	auth := &cliproxyauth.Auth{ID: "opencode-go:apikey:abc123"}
+	opts := cliproxyexecutor.Options{}
+	if got := opencodeGoSessionID(opts, auth); got != "opencode-go:apikey:abc123" {
+		t.Errorf("opencodeGoSessionID = %q, want opencode-go:apikey:abc123", got)
+	}
+}
+
+func TestOpenCodeGoSessionID_PreferSessionOverAuthID(t *testing.T) {
+	auth := &cliproxyauth.Auth{ID: "auth_id_fallback"}
+	headers := make(http.Header)
+	headers.Set("Session-Id", "session_id_preferred")
+	opts := cliproxyexecutor.Options{Headers: headers}
+	if got := opencodeGoSessionID(opts, auth); got != "session_id_preferred" {
+		t.Errorf("opencodeGoSessionID = %q, want session_id_preferred", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The Session-Id header is not forwarded to executors in all code paths, causing the reasoning_content cache to be a no-op
- Added auth ID as a fallback cache key (unique per API key, always available)
- Session-Id is still preferred when available; auth ID is only used when session headers are absent

## Test plan
- 2 new tests for auth ID fallback + session preference
- All 51 OpenCodeGo tests pass
- Manual verification: deploy and confirm deepseek-v4-flash multi-turn conversations no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)