### PR TITLE
feat: inject Computer Use function tools for DeepSeek models

### DIFF
--- a/internal/runtime/executor/opencode_go_computer_use.go
+++ b/internal/runtime/executor/opencode_go_computer_use.go
@@ -1,0 +1,239 @@
+package executor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// mcpComputerUseFunctions defines the 10 function tools in the mcp__computer_use__
+// namespace. These are vanilla OpenAI function tools — any model with function
+// calling can invoke them. Codex Desktop routes the tool_call back to the local
+// Computer Use MCP server which executes the actual screenshot / click / type
+// operations on the client machine.
+var mcpComputerUseFunctions = []map[string]any{
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__click",
+			"description": "Click an element by index or pixel coordinates from screenshot. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"app":          map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"click_count":  map[string]any{"type": "integer", "description": "Number of clicks. Defaults to 1"},
+					"element_index": map[string]any{"type": "string", "description": "Element index to click"},
+					"mouse_button": map[string]any{"type": "string", "description": "Mouse button to click. Defaults to left.", "enum": []string{"left", "right", "middle"}},
+					"x":            map[string]any{"type": "number", "description": "X coordinate in screenshot pixel coordinates"},
+					"y":            map[string]any{"type": "number", "description": "Y coordinate in screenshot pixel coordinates"},
+				},
+				"required":             []string{"app"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__drag",
+			"description": "Drag from one point to another using pixel coordinates. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"app":   map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"from_x": map[string]any{"type": "number", "description": "Start X coordinate"},
+					"from_y": map[string]any{"type": "number", "description": "Start Y coordinate"},
+					"to_x":  map[string]any{"type": "number", "description": "End X coordinate"},
+					"to_y":  map[string]any{"type": "number", "description": "End Y coordinate"},
+				},
+				"required":             []string{"app", "from_x", "from_y", "to_x", "to_y"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__get_app_state",
+			"description": "Start an app use session if needed, then get the state of the app's key window and return a screenshot and accessibility tree. This must be called once per assistant turn before interacting with the app. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"app": map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+				},
+				"required":             []string{"app"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__list_apps",
+			"description": "List the apps on this computer. Returns the set of apps that are currently running, as well as any that have been used in the last 14 days, including details on usage frequency. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__perform_secondary_action",
+			"description": "Invoke a secondary accessibility action exposed by an element. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"action":        map[string]any{"type": "string", "description": "Secondary accessibility action name"},
+					"app":           map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"element_index": map[string]any{"type": "string", "description": "Element identifier"},
+				},
+				"required":             []string{"app", "element_index", "action"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__press_key",
+			"description": "Press a key or key-combination on the keyboard, including modifier and navigation keys.\n  - This supports xdotool's `key` syntax.\n  - Examples: \"a\", \"Return\", \"Tab\", \"super+c\", \"Up\", \"KP_0\" (for the numpad 0 key). This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"app": map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"key": map[string]any{"type": "string", "description": "Key or key combination to press"},
+				},
+				"required":             []string{"app", "key"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__scroll",
+			"description": "Scroll an element in a direction by a number of pages. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"app":           map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"direction":     map[string]any{"type": "string", "description": "Scroll direction: up, down, left, or right"},
+					"element_index": map[string]any{"type": "string", "description": "Element identifier"},
+					"pages":         map[string]any{"type": "number", "description": "Number of pages to scroll. Fractional values are supported. Defaults to 1"},
+				},
+				"required":             []string{"app", "element_index", "direction"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__select_text",
+			"description": "Select text inside a text element, or place the text cursor before or after it. Provide text exactly as it appears in the accessibility tree, including any Markdown formatting. If the text is not unique, provide surrounding prefix or suffix text to disambiguate it. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"app":           map[string]any{"type": "string", "description": "App name or bundle identifier"},
+					"element_index": map[string]any{"type": "string", "description": "Text element identifier"},
+					"prefix":        map[string]any{"type": "string", "description": "Optional text immediately before the target, used to disambiguate repeated matches"},
+					"selection":     map[string]any{"type": "string", "description": "Whether to select the text or place the cursor before or after it. Defaults to text.", "enum": []string{"text", "cursor_before", "cursor_after"}},
+					"suffix":        map[string]any{"type": "string", "description": "Optional text immediately after the target, used to disambiguate repeated matches"},
+					"text":          map[string]any{"type": "string", "description": "Target text as shown in the accessibility tree"},
+				},
+				"required":             []string{"app", "element_index", "text"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__set_value",
+			"description": "Set the value of a settable accessibility element. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"app":           map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"element_index": map[string]any{"type": "string", "description": "Element identifier"},
+					"value":         map[string]any{"type": "string", "description": "Value to assign"},
+				},
+				"required":             []string{"app", "element_index", "value"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "mcp__computer_use__type_text",
+			"description": "Type literal text using keyboard input. This tool is part of plugin `Computer Use`.",
+			"strict":      false,
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"app":  map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"text": map[string]any{"type": "string", "description": "Literal text to type"},
+				},
+				"required":             []string{"app", "text"},
+				"additionalProperties": false,
+			},
+		},
+	},
+}
+
+// opencodeGoInjectComputerUseTools checks whether the request payload already
+// carries mcp__computer_use__ function definitions.  When they are missing
+// (which is the case for DeepSeek models routed through /v1/messages), it
+// injects them so the model sees Computer Use as regular function tools.
+func opencodeGoInjectComputerUseTools(payload []byte) []byte {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return payload
+	}
+
+	// Only inject when the request already has a tools array.
+	tools := gjson.GetBytes(payload, "tools")
+	if !tools.Exists() || !tools.IsArray() || len(tools.Array()) == 0 {
+		return payload
+	}
+
+	// If Computer Use tools are already present, do nothing.
+	for _, tool := range tools.Array() {
+		name := tool.Get("function.name").String()
+		if strings.HasPrefix(name, "mcp__computer_use__") {
+			return payload
+		}
+		// Also check Responses API format (type=namespace).
+		if tool.Get("type").String() == "namespace" &&
+			strings.EqualFold(tool.Get("name").String(), "mcp__computer_use__") {
+			return payload
+		}
+	}
+
+	// Inject each Computer Use function tool into the tools array.
+	startIdx := len(tools.Array())
+	for i, fn := range mcpComputerUseFunctions {
+		path := fmt.Sprintf("tools.%d", startIdx+i)
+		var err error
+		payload, err = sjson.SetBytes(payload, path, fn)
+		if err != nil {
+			// Non-critical: skip remaining injections if one fails.
+			break
+		}
+	}
+	return payload
+}

--- a/internal/runtime/executor/opencode_go_computer_use_test.go
+++ b/internal/runtime/executor/opencode_go_computer_use_test.go
@@ -1,0 +1,316 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ---------------------------------------------------------------------------
+// Unit: opencodeGoInjectComputerUseTools
+// ---------------------------------------------------------------------------
+
+func TestInjectComputerUseTools_AddsWhenMissing(t *testing.T) {
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"existing_tool"}}]}`)
+	got := opencodeGoInjectComputerUseTools(payload)
+
+	tools := gjson.GetBytes(got, "tools").Array()
+	foundExisting := false
+	foundComputerUse := false
+	for _, tool := range tools {
+		name := tool.Get("function.name").String()
+		if name == "existing_tool" {
+			foundExisting = true
+		}
+		if name == "mcp__computer_use__click" {
+			foundComputerUse = true
+		}
+	}
+	if !foundExisting {
+		t.Error("original tool 'existing_tool' was removed")
+	}
+	if !foundComputerUse {
+		t.Error("mcp__computer_use__click was not injected")
+	}
+	if len(tools) != 11 {
+		t.Errorf("expected 11 tools (1 existing + 10 CU), got %d", len(tools))
+	}
+}
+
+func TestInjectComputerUseTools_SkipsWhenAlreadyPresent(t *testing.T) {
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"mcp__computer_use__click"}}]}`)
+	got := opencodeGoInjectComputerUseTools(payload)
+
+	tools := gjson.GetBytes(got, "tools").Array()
+	if len(tools) != 1 {
+		t.Errorf("expected 1 tool (skip injection since CU already present), got %d", len(tools))
+	}
+}
+
+func TestInjectComputerUseTools_SkipsNoTools(t *testing.T) {
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}`)
+	got := opencodeGoInjectComputerUseTools(payload)
+
+	if gjson.GetBytes(got, "tools").Exists() {
+		t.Error("should not add tools array when none existed")
+	}
+}
+
+func TestInjectComputerUseTools_EmptyTools(t *testing.T) {
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"tools":[]}`)
+	got := opencodeGoInjectComputerUseTools(payload)
+
+	tools := gjson.GetBytes(got, "tools").Array()
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools for empty array, got %d", len(tools))
+	}
+}
+
+func TestInjectComputerUseTools_InvalidJSON(t *testing.T) {
+	got := opencodeGoInjectComputerUseTools([]byte(`not json`))
+	if string(got) != "not json" {
+		t.Error("should return original payload unchanged for invalid JSON")
+	}
+}
+
+func TestInjectComputerUseTools_NilPayload(t *testing.T) {
+	got := opencodeGoInjectComputerUseTools(nil)
+	if got != nil {
+		t.Error("should return nil for nil payload")
+	}
+}
+
+func TestInjectComputerUseTools_SkipsNamespaceAlreadyPresent(t *testing.T) {
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"namespace","name":"mcp__computer_use__"}]}`)
+	got := opencodeGoInjectComputerUseTools(payload)
+
+	tools := gjson.GetBytes(got, "tools").Array()
+	if len(tools) != 1 {
+		t.Errorf("expected 1 tool (skip injection due to existing namespace), got %d", len(tools))
+	}
+}
+
+func TestInjectComputerUseTools_PreservesModelAndMessages(t *testing.T) {
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"test"}],"tools":[{"type":"function","function":{"name":"foo"}}]}`)
+	got := opencodeGoInjectComputerUseTools(payload)
+
+	if model := gjson.GetBytes(got, "model").String(); model != "deepseek-v4-flash" {
+		t.Errorf("model changed, got %q", model)
+	}
+	if msg := gjson.GetBytes(got, "messages.0.content").String(); msg != "test" {
+		t.Errorf("messages changed, got %q", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Verify all 10 Computer Use functions are well-formed
+// ---------------------------------------------------------------------------
+
+func TestComputerUseFunctions_AllValidDefinitions(t *testing.T) {
+	for i, fn := range mcpComputerUseFunctions {
+		fnMap, ok := fn["function"].(map[string]any)
+		if !ok {
+			t.Fatalf("function %d missing 'function' key", i)
+		}
+		name, _ := fnMap["name"].(string)
+		if !hasPrefix(name, "mcp__computer_use__") {
+			t.Errorf("function %d has unexpected name %q", i, name)
+		}
+		// Verify it can be serialized
+		_, err := json.Marshal(fn)
+		if err != nil {
+			t.Fatalf("function %d (%s) failed to marshal: %v", i, name, err)
+		}
+		// Verify sjson.SetBytes works with it
+		testPayload := []byte(`{"tools":[]}`)
+		_, err = sjson.SetBytes(testPayload, "tools.0", fn)
+		if err != nil {
+			t.Fatalf("function %d (%s) failed sjson roundtrip: %v", i, name, err)
+		}
+	}
+}
+
+func TestComputerUseFunctions_Count(t *testing.T) {
+	if len(mcpComputerUseFunctions) != 10 {
+		t.Fatalf("expected 10 Computer Use functions, got %d", len(mcpComputerUseFunctions))
+	}
+
+	expectedNames := []string{
+		"mcp__computer_use__click",
+		"mcp__computer_use__drag",
+		"mcp__computer_use__get_app_state",
+		"mcp__computer_use__list_apps",
+		"mcp__computer_use__perform_secondary_action",
+		"mcp__computer_use__press_key",
+		"mcp__computer_use__scroll",
+		"mcp__computer_use__select_text",
+		"mcp__computer_use__set_value",
+		"mcp__computer_use__type_text",
+	}
+	for _, expected := range expectedNames {
+		found := false
+		for _, fn := range mcpComputerUseFunctions {
+			fnMap, _ := fn["function"].(map[string]any)
+			if fnMap["name"].(string) == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected function %q not found", expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: Execute with Computer Use injection (DeepSeek models)
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoExecutorInjectsComputerUseTools(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_cu","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	oldURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
+	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"use computer"}],"tools":[{"type":"function","function":{"name":"existing_tool"}}]}`)
+
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	// Verify upstream body has Computer Use tools injected
+	tools := gjson.GetBytes(gotBody, "tools").Array()
+	hasCU := false
+	hasExisting := false
+	for _, tool := range tools {
+		name := tool.Get("function.name").String()
+		if name == "mcp__computer_use__get_app_state" {
+			hasCU = true
+		}
+		if name == "existing_tool" {
+			hasExisting = true
+		}
+	}
+	if !hasExisting {
+		t.Error("upstream body missing existing_tool")
+	}
+	if !hasCU {
+		t.Errorf("upstream body missing mcp__computer_use__ tools; body=%s", string(gotBody))
+	}
+}
+
+func TestOpenCodeGoExecutorDoesNotInjectForNonDeepSeek(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_no","object":"chat.completion","created":1,"model":"gpt-5.5","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	oldURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
+	payload := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"existing_tool"}}]}`)
+
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	// Non-deepseek model should NOT get CU tools
+	tools := gjson.GetBytes(gotBody, "tools").Array()
+	for _, tool := range tools {
+		name := tool.Get("function.name").String()
+		if hasPrefix(name, "mcp__computer_use__") {
+			t.Errorf("non-deepseek model should not get CU tools; found %q", name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: ExecuteStream with Computer Use injection
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeGoExecutorStreamInjectsComputerUseTools(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"id":"chunk1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"}}]}` + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	oldURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
+	payload := []byte(`{"model":"deepseek-v4-flash","stream":true,"messages":[{"role":"user","content":"use computer"}],"tools":[{"type":"function","function":{"name":"tool1"}}]}`)
+
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	// Verify upstream body has Computer Use tools
+	hasCU := false
+	for _, tool := range gjson.GetBytes(gotBody, "tools").Array() {
+		if hasPrefix(tool.Get("function.name").String(), "mcp__computer_use__") {
+			hasCU = true
+			break
+		}
+	}
+	if !hasCU {
+		t.Errorf("stream request missing mcp__computer_use__ tools; body=%s", string(gotBody))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -90,7 +90,12 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
 		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
 	}
-
+		// Inject Computer Use function tools for models that need them.
+		// Codex Desktop skips mcp__computer_use__ when routing through /v1/messages,
+		// so DeepSeek models don't see Computer Use capabilities.
+		if opencodeGoNeedsReasoningInjection(req.Model) {
+			req.Payload = opencodeGoInjectComputerUseTools(req.Payload)
+		}
 	var resp cliproxyexecutor.Response
 	var err error
 	if opencodeGoUsesMessages(req.Model) {
@@ -125,7 +130,12 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
 		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
 	}
-
+		// Inject Computer Use function tools for models that need them.
+		// Codex Desktop skips mcp__computer_use__ when routing through /v1/messages,
+		// so DeepSeek models don't see Computer Use capabilities.
+		if opencodeGoNeedsReasoningInjection(req.Model) {
+			req.Payload = opencodeGoInjectComputerUseTools(req.Payload)
+		}
 	var result *cliproxyexecutor.StreamResult
 	var err error
 	if opencodeGoUsesMessages(req.Model) {


### PR DESCRIPTION
## Summary
- Added mcp__computer_use__ function tool injection for DeepSeek models in the OpenCode Go channel
- Computer Use in Codex Desktop is implemented as an MCP server with 10 function-call tools (click, type_text, get_app_state, etc.)
- Codex Desktop skips these tools when routing through /v1/messages (Claude format) for non-Claude models
- This fix injects the tool definitions at the gateway level, so DeepSeek models can use Computer Use
- Only activates when the request already has tools (don't inject into tool-less requests)

## Test plan
- 13 new unit/integration tests covering: injection logic, existing tool preservation, skip logic, namespace detection, non-deepseek exclusion, streaming path
- All 62 OpenCodeGo tests pass
- Manual verification: deploy and test Computer Use with deepseek-v4-flash in Codex Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)