### PR TITLE
fix: strip base64 screenshots from tool results to prevent context overflow

### DIFF
--- a/internal/runtime/executor/opencode_go_computer_use.go
+++ b/internal/runtime/executor/opencode_go_computer_use.go
@@ -286,3 +286,61 @@ func opencodeGoInjectComputerUseTools(payload []byte) []byte {
 
 	return payload
 }
+
+// opencodeGoStripScreenshots removes base64 image data from tool result messages
+// in the request payload. After the model processes a screenshot (via get_app_state),
+// the raw image data is no longer needed and wastes large amounts of context tokens.
+func opencodeGoStripScreenshots(payload []byte) []byte {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return payload
+	}
+	payload = opencodeGoStripArrayScreenshots(payload, "messages")
+	payload = opencodeGoStripArrayScreenshots(payload, "input")
+	return payload
+}
+
+func opencodeGoStripArrayScreenshots(payload []byte, arrayPath string) []byte {
+	arr := gjson.GetBytes(payload, arrayPath)
+	if !arr.Exists() || !arr.IsArray() || len(arr.Array()) == 0 {
+		return payload
+	}
+	modified := false
+	items := arr.Array()
+	for i, item := range items {
+		if item.Get("role").String() != "tool" {
+			continue
+		}
+		content := item.Get("content")
+		if !content.Exists() {
+			continue
+		}
+		path := fmt.Sprintf("%s.%d.content", arrayPath, i)
+		if content.IsArray() {
+			parts := content.Array()
+			for j, part := range parts {
+				partType := part.Get("type").String()
+				if partType == "input_image" || partType == "image" || partType == "image_url" {
+					partPath := fmt.Sprintf("%s.%d.content.%d", arrayPath, i, j)
+					payload, _ = sjson.SetBytes(payload, partPath+".type", "text")
+					payload, _ = sjson.SetBytes(payload, partPath+".text", "[Screenshot from previous turn]")
+					_, _ = sjson.DeleteBytes(payload, partPath+".image_url")
+					modified = true
+				}
+			}
+		} else {
+			text := content.String()
+			if strings.HasPrefix(text, "data:image") || strings.HasPrefix(text, "[data:image") {
+				payload, _ = sjson.SetBytes(payload, path, "[Screenshot from previous turn]")
+				modified = true
+			} else if len(text) > 1000 && strings.Contains(text, "base64") {
+				payload, _ = sjson.SetBytes(payload, path, "[Screenshot from previous turn]")
+				modified = true
+			}
+		}
+	}
+	if !modified {
+		return payload
+	}
+	return payload
+}
+

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -96,6 +96,10 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 		if opencodeGoNeedsReasoningInjection(req.Model) {
 			req.Payload = opencodeGoInjectComputerUseTools(req.Payload)
 		}
+		// Strip old base64 screenshots from tool result messages to save context.
+		if opencodeGoNeedsReasoningInjection(req.Model) {
+			req.Payload = opencodeGoStripScreenshots(req.Payload)
+		}
 	var resp cliproxyexecutor.Response
 	var err error
 	if opencodeGoUsesMessages(req.Model) {
@@ -135,6 +139,10 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 		// so DeepSeek models don't see Computer Use capabilities.
 		if opencodeGoNeedsReasoningInjection(req.Model) {
 			req.Payload = opencodeGoInjectComputerUseTools(req.Payload)
+		}
+		// Strip old base64 screenshots from tool result messages to save context.
+		if opencodeGoNeedsReasoningInjection(req.Model) {
+			req.Payload = opencodeGoStripScreenshots(req.Payload)
 		}
 	var result *cliproxyexecutor.StreamResult
 	var err error


### PR DESCRIPTION
## Summary
- Computer Use get_app_state returns base64 screenshots that consume ~800K tokens each
- After the model processes a screenshot, the raw image stays in conversation history
- With 3-4 screenshots, conversation exceeds DeepSeek's 1M token limit
- Fix: strip base64 image data from tool role messages, replacing with short placeholder
- Handles both `messages` and `input` arrays, both string and content-array formats

## Test plan
- All existing tests pass
- Manual: deploy and test Computer Use with deepseek-v4-flash for multi-turn sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)