### PR TITLE
fix: inject reasoning_content after Responses API → Chat Completions translation

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -113,6 +113,15 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		}
 	}
 
+	// OpenCode-Go: the translator drops reasoning_content when converting
+	// from Responses API. Inject it here into translated payload so it survives.
+	if e.provider == openCodeGoProvider && opencodeGoNeedsReasoningInjection(baseModel) {
+		sessionID := opencodeGoSessionID(opts, auth)
+		if sessionID != "" {
+			translated = opencodeGoInjectMessagesArray(translated, req.Model, sessionID)
+		}
+	}
+
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
@@ -215,6 +224,14 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		translated, err = normalizeKimiToolMessageLinks(translated)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// Inject reasoning_content for OpenCode-Go after Responses API translation.
+	if e.provider == openCodeGoProvider && opencodeGoNeedsReasoningInjection(baseModel) {
+		sessionID := opencodeGoSessionID(opts, auth)
+		if sessionID != "" {
+			translated = opencodeGoInjectMessagesArray(translated, req.Model, sessionID)
 		}
 	}
 

--- a/internal/runtime/executor/opencode_go_reasoning.go
+++ b/internal/runtime/executor/opencode_go_reasoning.go
@@ -295,3 +295,9 @@ func opencodeGoWrapStreamCacheReasoning(result *cliproxyexecutor.StreamResult, m
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: result.Headers, Chunks: out}
 }
+
+// opencodeGoInjectMessagesArray is a convenience wrapper that injects reasoning_content
+// into a Chat Completions format payload (messages array).
+func opencodeGoInjectMessagesArray(payload []byte, model, sessionID string) []byte {
+	return opencodeGoInjectReasoningContentIntoPayload(payload, model, sessionID)
+}


### PR DESCRIPTION
## Summary
- Reasoning_content injection was happening on the source format payload
- The Responses API → Chat Completions translator drops non-standard fields
- Fixed: inject directly into the translated payload inside OpenAICompatExecutor
- Both Execute and ExecuteStream paths covered