### PR TITLE
fix: vision fallback repeatedly triggers on tool-call follow-ups

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -113,6 +113,15 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		}
 	}
 
+	// OpenCode-Go: the translator drops reasoning_content when converting
+	// from Responses API. Inject it here into translated payload so it survives.
+	if e.provider == openCodeGoProvider && opencodeGoNeedsReasoningInjection(baseModel) {
+		sessionID := opencodeGoSessionID(opts, auth)
+		if sessionID != "" {
+			translated = opencodeGoInjectMessagesArray(translated, req.Model, sessionID)
+		}
+	}
+
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
@@ -215,6 +224,14 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		translated, err = normalizeKimiToolMessageLinks(translated)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// Inject reasoning_content for OpenCode-Go after Responses API translation.
+	if e.provider == openCodeGoProvider && opencodeGoNeedsReasoningInjection(baseModel) {
+		sessionID := opencodeGoSessionID(opts, auth)
+		if sessionID != "" {
+			translated = opencodeGoInjectMessagesArray(translated, req.Model, sessionID)
 		}
 	}
 

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -479,21 +479,24 @@ func opencodeGoCurrentValueHasImage(value any) (bool, bool) {
 }
 
 func opencodeGoLatestUserMessageHasImage(messages []any) (bool, bool) {
-	for i := len(messages) - 1; i >= 0; i-- {
-		message, ok := messages[i].(map[string]any)
-		if !ok {
-			continue
-		}
-		role, _ := message["role"].(string)
-		if !strings.EqualFold(strings.TrimSpace(role), "user") {
-			continue
-		}
-		if content, ok := message["content"]; ok {
-			return opencodeGoValueHasImage(content), true
-		}
-		return opencodeGoValueHasImage(message), true
+	// Only check the VERY LAST message. Scanning backwards for any user
+	// message causes the vision fallback to trigger on follow-up tool-call
+	// requests where the most recent user message is an old image message.
+	if len(messages) == 0 {
+		return false, false
 	}
-	return false, false
+	message, ok := messages[len(messages)-1].(map[string]any)
+	if !ok {
+		return false, false
+	}
+	role, _ := message["role"].(string)
+	if !strings.EqualFold(strings.TrimSpace(role), "user") {
+		return false, false
+	}
+	if content, ok := message["content"]; ok {
+		return opencodeGoValueHasImage(content), true
+	}
+	return opencodeGoValueHasImage(message), true
 }
 
 func opencodeGoInputHasImage(input any) (bool, bool) {

--- a/internal/runtime/executor/opencode_go_reasoning.go
+++ b/internal/runtime/executor/opencode_go_reasoning.go
@@ -295,3 +295,9 @@ func opencodeGoWrapStreamCacheReasoning(result *cliproxyexecutor.StreamResult, m
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: result.Headers, Chunks: out}
 }
+
+// opencodeGoInjectMessagesArray is a convenience wrapper that injects reasoning_content
+// into a Chat Completions format payload (messages array).
+func opencodeGoInjectMessagesArray(payload []byte, model, sessionID string) []byte {
+	return opencodeGoInjectReasoningContentIntoPayload(payload, model, sessionID)
+}


### PR DESCRIPTION
opencodeGoLatestUserMessageHasImage scanned backwards for any user message with an image. On follow-up tool-call requests, it found the old image message and triggered fallback again. Fix: only check the last message.