### PR TITLE
fix: expand vision preprocessing to all non-vision models, use configured fallback model

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -81,11 +81,13 @@ func (e *OpenCodeGoExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth
 func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	// Vision preprocessing: when the model doesn't support vision but the
 	// current request has images, call qwen3.5-plus internally to get a text
-	// description and replace the image. The model is never changed, so
-	// Codex Desktop always sees deepseek-v4-flash.
+	// description and replace the image. The model is never changed, so the
+	// original model is preserved for subsequent requests and usage logging.
 	apiKey := opencodeGoAPIKey(auth)
-	if opencodeGoNeedsReasoningInjection(req.Model) && opencodeGoHasCurrentImage(req.Payload) && apiKey != "" {
-		if preprocessed, ok := opencodeGoPreprocessVision(ctx, e.cfg, auth, apiKey, req.Payload); ok {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	visionModel := opencodeGoVisionFallbackModel(e.cfg, auth)
+	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoHasCurrentImage(req.Payload) && apiKey != "" && visionModel != "" {
+		if preprocessed, ok := opencodeGoPreprocessVision(ctx, e.cfg, auth, apiKey, visionModel, req.Payload); ok {
 			req.Payload = preprocessed
 		}
 	}
@@ -135,10 +137,12 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 }
 
 func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
-	// Vision preprocessing: replace images with qwen descriptions.
+	// Vision preprocessing: replace images with text from the configured vision model.
 	apiKey := opencodeGoAPIKey(auth)
-	if opencodeGoNeedsReasoningInjection(req.Model) && opencodeGoHasCurrentImage(req.Payload) && apiKey != "" {
-		if preprocessed, ok := opencodeGoPreprocessVision(ctx, e.cfg, auth, apiKey, req.Payload); ok {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	visionModel := opencodeGoVisionFallbackModel(e.cfg, auth)
+	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoHasCurrentImage(req.Payload) && apiKey != "" && visionModel != "" {
+		if preprocessed, ok := opencodeGoPreprocessVision(ctx, e.cfg, auth, apiKey, visionModel, req.Payload); ok {
 			req.Payload = preprocessed
 		}
 	}

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -61,10 +61,19 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 	var gotPath string
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		reqModel := gjson.GetBytes(body, "model").String()
+		if reqModel == "qwen3.5-plus" {
+			// Vision preprocessing call to describe the image
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a test image description"}}]}`))
+			return
+		}
+		// Actual execution call — stays on original model
 		gotPath = r.URL.Path
-		gotBody, _ = io.ReadAll(r.Body)
+		gotBody = body
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"qwen3.5-plus","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
 	}))
 	defer server.Close()
 
@@ -91,17 +100,17 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 	if gotPath != "/zen/go/v1/chat/completions" {
 		t.Fatalf("path = %q, want /zen/go/v1/chat/completions", gotPath)
 	}
-	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
-		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
 	}
-	if !strings.Contains(string(gotBody), `"image_url"`) {
-		t.Fatalf("current image should be preserved for vision fallback; body=%s", string(gotBody))
+	if strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("image should be replaced with text after vision preprocessing; body=%s", string(gotBody))
 	}
 	if gotModel := gjson.GetBytes(resp.Payload, "model").String(); gotModel != "deepseek-v4-flash" {
 		t.Fatalf("response model = %q, want deepseek-v4-flash; payload=%s", gotModel, string(resp.Payload))
 	}
-	if !gjson.GetBytes(gotBody, "enable_thinking").Exists() || gjson.GetBytes(gotBody, "enable_thinking").Bool() {
-		t.Fatalf("enable_thinking = %s, want false; body=%s", gjson.GetBytes(gotBody, "enable_thinking").Raw, string(gotBody))
+	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
+		t.Fatalf("enable_thinking should not be present when no vision fallback is applied; body=%s", string(gotBody))
 	}
 	if gotText := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); gotText != "vision ok" {
 		t.Fatalf("response text = %q, want vision ok; payload=%s", gotText, string(resp.Payload))
@@ -110,11 +119,20 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 
 func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
 	var gotBody []byte
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"mimo-v2-omni","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
-	}))
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			reqModel := gjson.GetBytes(body, "model").String()
+			if reqModel == "qwen3.5-plus" {
+				// Vision preprocessing call to describe the image
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a test image description"}}]}`))
+				return
+			}
+			// Actual execution call — stays on original model
+			gotBody = body
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+		}))
 	defer server.Close()
 
 	oldBaseURL := opencodeGoBaseURL
@@ -137,11 +155,11 @@ func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
 		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "mimo-v2-omni" {
-		t.Fatalf("upstream model = %q, want mimo-v2-omni; body=%s", gotModel, string(gotBody))
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
 	}
-	if !strings.Contains(string(gotBody), `"image_url"`) {
-		t.Fatalf("current image should be preserved for configured vision fallback; body=%s", string(gotBody))
+	if strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("image should be replaced with text after vision preprocessing; body=%s", string(gotBody))
 	}
 	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
 		t.Fatalf("enable_thinking should not be added for non-qwen fallback; body=%s", string(gotBody))
@@ -153,11 +171,20 @@ func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
 
 func TestOpenCodeGoExecutorIgnoresConfiguredTextOnlyFallbackModel(t *testing.T) {
 	var gotBody []byte
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"chatcmpl_text_only_fallback","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
-	}))
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			reqModel := gjson.GetBytes(body, "model").String()
+			if reqModel == "qwen3.5-plus" {
+				// Vision preprocessing call to describe the image
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a description"}}]}`))
+				return
+			}
+			// Actual execution call — text-only model, stays on original model
+			gotBody = body
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_text_only_fallback","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+		}))
 	defer server.Close()
 
 	oldBaseURL := opencodeGoBaseURL
@@ -201,7 +228,7 @@ func TestOpenCodeGoExecutorLeavesTextRequestsOnRequestedModel(t *testing.T) {
 	auth := &cliproxyauth.Auth{
 		Attributes: map[string]string{
 			"api_key":               "test-key",
-			"vision_fallback_model": "qwen3.5-plus",
+			"vision_fallback_model": "deepseek-v4-flash",
 		},
 	}
 	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}`)
@@ -237,7 +264,7 @@ func TestOpenCodeGoExecutorLeavesTextFollowUpWithHistoricalImageOnRequestedModel
 	auth := &cliproxyauth.Auth{
 		Attributes: map[string]string{
 			"api_key":               "test-key",
-			"vision_fallback_model": "qwen3.5-plus",
+			"vision_fallback_model": "deepseek-v4-flash",
 		},
 	}
 	payload := []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]},{"role":"assistant","content":"vision ok"},{"role":"user","content":"now answer a normal text question"}]}`)
@@ -276,7 +303,7 @@ func TestOpenCodeGoExecutorSanitizesResponsesHistoryImagesForTextFollowUp(t *tes
 	auth := &cliproxyauth.Auth{
 		Attributes: map[string]string{
 			"api_key":               "test-key",
-			"vision_fallback_model": "qwen3.5-plus",
+			"vision_fallback_model": "deepseek-v4-flash",
 		},
 	}
 	payload := []byte(`{"model":"deepseek-v4-flash","input":[{"role":"user","content":[{"type":"input_text","text":"what is this?"},{"type":"input_image","image_url":"data:image/png;base64,aGVsbG8="}]},{"role":"assistant","content":[{"type":"output_text","text":"vision ok"}]},{"role":"user","content":[{"type":"input_text","text":"now answer a normal text question"}]}]}`)
@@ -301,9 +328,18 @@ func TestOpenCodeGoExecutorSanitizesResponsesHistoryImagesForTextFollowUp(t *tes
 func TestOpenCodeGoExecutorStreamRewritesVisionFallbackModel(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
+		reqModel := gjson.GetBytes(body, "model").String()
+		if reqModel == "qwen3.5-plus" {
+			// Vision preprocessing call to describe the image
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a test image description"}}]}`))
+			return
+		}
+		// Actual execution call — stays on original model
+		gotBody = body
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_stream","object":"chat.completion.chunk","created":1,"model":"qwen3.5-plus","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_stream","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}` + "\n\n"))
 		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	}))
 	defer server.Close()
@@ -335,8 +371,8 @@ func TestOpenCodeGoExecutorStreamRewritesVisionFallbackModel(t *testing.T) {
 		}
 		chunks.Write(chunk.Payload)
 	}
-	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
-		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
 	}
 	out := chunks.String()
 	if strings.Contains(out, "qwen3.5-plus") {
@@ -360,11 +396,20 @@ func TestOpenCodeGoRewriteFallbackStreamPayloadRewritesSSEModelFields(t *testing
 
 func TestOpenCodeGoExecutorIgnoresExcludedVisionFallback(t *testing.T) {
 	var gotBody []byte
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"chatcmpl_excluded","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
-	}))
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			reqModel := gjson.GetBytes(body, "model").String()
+			if reqModel == "qwen3.5-plus" {
+				// Vision preprocessing call to describe the image
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a description"}}]}`))
+				return
+			}
+			// Actual execution call — stays on original model
+			gotBody = body
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_excluded","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+		}))
 	defer server.Close()
 
 	oldBaseURL := opencodeGoBaseURL

--- a/internal/runtime/executor/opencode_go_vision.go
+++ b/internal/runtime/executor/opencode_go_vision.go
@@ -19,13 +19,14 @@ import (
 
 const visionPreprocessTimeout = 30 * time.Second
 
-// opencodeGoVisionPreprocessImage sends a base64-encoded image to qwen3.5-plus
-// via OpenCode and returns a concise text description. When the API call fails
-// we return a generic placeholder so the calling code can degrade gracefully.
-func opencodeGoVisionPreprocessImage(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, apiKey, imageData, imageType string) (string, error) {
+// opencodeGoVisionPreprocessImage sends a base64-encoded image to the configured
+// vision model via OpenCode and returns a concise text description. When the API
+// call fails we return a generic placeholder so the calling code can degrade
+// gracefully.
+func opencodeGoVisionPreprocessImage(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, apiKey, visionModel, imageData, imageType string) (string, error) {
 	prompt := "Describe what you see in this image concisely in one or two sentences. Focus on visual details relevant to a coding assistant."
 
-	body := buildVisionRequestBody("qwen3.5-plus", prompt, imageData, imageType)
+	body := buildVisionRequestBody(visionModel, prompt, imageData, imageType)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, opencodeGoBaseURL+"/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("build vision request: %w", err)
@@ -189,13 +190,14 @@ func contentHasImage(item gjson.Result) bool {
 }
 
 // opencodeGoPreprocessVision replaces images in the current user message with
-// text descriptions from qwen3.5-plus. The model in the payload is NOT changed
-// — Codex Desktop always sees deepseek-v4-flash.
+// text descriptions from the configured vision model (vision_fallback_model).
+// The model in the payload is NOT changed — requests always stay on the
+// original model.
 //
 // Returns the modified payload and a boolean indicating whether any replacement
 // was performed.
-func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, apiKey string, payload []byte) ([]byte, bool) {
-	if len(payload) == 0 || !gjson.ValidBytes(payload) || apiKey == "" {
+func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, apiKey, visionModel string, payload []byte) ([]byte, bool) {
+	if visionModel == "" || len(payload) == 0 || !gjson.ValidBytes(payload) || apiKey == "" {
 		return payload, false
 	}
 
@@ -228,7 +230,7 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 			}
 
 			// Call qwen to describe the image
-			description, err := opencodeGoVisionPreprocessImage(visionCtx, cfg, auth, apiKey, imgData, imgType)
+			description, err := opencodeGoVisionPreprocessImage(visionCtx, cfg, auth, apiKey, visionModel, imgData, imgType)
 			if err != nil {
 				procErr = err
 				description = "[Image description unavailable]"
@@ -238,7 +240,7 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 			contentPath := fmt.Sprintf("messages.%d.content.%d", msgIdx, pIdx)
 			payload, _ = sjson.SetBytes(payload, contentPath+".type", "text")
 			payload, _ = sjson.SetBytes(payload, contentPath+".text", "[Image: "+description+"]")
-			_, _ = sjson.DeleteBytes(payload, contentPath+".image_url")
+			payload, _ = sjson.DeleteBytes(payload, contentPath+".image_url")
 			modified = true
 		}
 		return payload
@@ -288,7 +290,7 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 					if imgData == "" {
 						continue
 					}
-					description, err := opencodeGoVisionPreprocessImage(visionCtx, cfg, auth, apiKey, imgData, imgType)
+					description, err := opencodeGoVisionPreprocessImage(visionCtx, cfg, auth, apiKey, visionModel, imgData, imgType)
 					if err != nil {
 						procErr = err
 						description = "[Image description unavailable]"
@@ -296,7 +298,7 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 					contentPath := fmt.Sprintf("input.%d.content.%d", i, pIdx)
 					payload, _ = sjson.SetBytes(payload, contentPath+".type", "input_text")
 					payload, _ = sjson.SetBytes(payload, contentPath+".input_text", "[Image: "+description+"]")
-					_, _ = sjson.DeleteBytes(payload, contentPath+".image_url")
+					payload, _ = sjson.DeleteBytes(payload, contentPath+".image_url")
 					modified = true
 				}
 			}


### PR DESCRIPTION
## Summary
- Fixes "model stickiness" issue where vision fallback model (qwen3.5-plus) would persist across subsequent requests
- Extends internal vision preprocessing (image → text via vision model) from only DeepSeek models to all models that don't natively support vision
- Fixes `sjson.DeleteBytes` return value being discarded, causing `image_url` to remain in payload after preprocessing
- Uses configured `vision_fallback_model` instead of hardcoded `qwen3.5-plus` for preprocessing calls
- All 21 executor tests + full project tests pass

## Test plan
- [x] `TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests` — verifies images replaced with text, model stays on original
- [x] `TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback` — verifies non-qwen fallback config works
- [x] `TestOpenCodeGoExecutorStreamRewritesVisionFallbackModel` — verifies streaming path
- [x] `TestOpenCodeGoExecutorIgnoresConfiguredTextOnlyFallbackModel` — verifies text-only fallback is skipped
- [x] `TestOpenCodeGoExecutorIgnoresExcludedVisionFallback` — verifies excluded models are respected
- [x] Full project: `go test ./...` — 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)