### PR TITLE
fix: default OpenCodeGo vision preprocessing to qwen3.5-plus

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -86,7 +86,10 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	apiKey := opencodeGoAPIKey(auth)
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	visionModel := opencodeGoVisionFallbackModel(e.cfg, auth)
-	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoHasCurrentImage(req.Payload) && apiKey != "" && visionModel != "" {
+	if visionModel == "" {
+		visionModel = "qwen3.5-plus"
+	}
+	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoHasCurrentImage(req.Payload) && apiKey != ""  {
 		if preprocessed, ok := opencodeGoPreprocessVision(ctx, e.cfg, auth, apiKey, visionModel, req.Payload); ok {
 			req.Payload = preprocessed
 		}
@@ -147,7 +150,10 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 	apiKey := opencodeGoAPIKey(auth)
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	visionModel := opencodeGoVisionFallbackModel(e.cfg, auth)
-	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoHasCurrentImage(req.Payload) && apiKey != "" && visionModel != "" {
+	if visionModel == "" {
+		visionModel = "qwen3.5-plus"
+	}
+	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoHasCurrentImage(req.Payload) && apiKey != ""  {
 		if preprocessed, ok := opencodeGoPreprocessVision(ctx, e.cfg, auth, apiKey, visionModel, req.Payload); ok {
 			req.Payload = preprocessed
 		}


### PR DESCRIPTION
## Summary
- Fix regression from commit 4ad182b5 where vision preprocessing was expanded to all non-vision models but required `vision_fallback_model` to be configured
- When `vision_fallback_model` is not configured, default to `qwen3.5-plus` (OpenCodeGo's universally available vision model)
- Restores backward compatibility: DeepSeek models once again get automatic vision preprocessing without explicit configuration

## Root cause
Commit 4ad182b5 added `&& visionModel != ""` to the vision preprocessing condition. When no `vision-fallback-model` was configured, both the vision preprocessing AND the applyVisionFallback model-switching path were skipped, causing images to be sent raw to DeepSeek (which silently ignores them).

## Test plan
- [x] Existing vision fallback tests pass
- [x] Config and synthesizer tests pass  
- [x] Full executor test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)