### PR TITLE
fix: use correct Responses API field name for vision preprocessed image descriptions

### DIFF
--- a/internal/runtime/executor/opencode_go_vision.go
+++ b/internal/runtime/executor/opencode_go_vision.go
@@ -241,6 +241,7 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 			payload, _ = sjson.SetBytes(payload, contentPath+".type", "text")
 			payload, _ = sjson.SetBytes(payload, contentPath+".text", "[Image: "+description+"]")
 			payload, _ = sjson.DeleteBytes(payload, contentPath+".image_url")
+			payload, _ = sjson.DeleteBytes(payload, contentPath+".detail")
 			modified = true
 		}
 		return payload
@@ -297,8 +298,9 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 					}
 					contentPath := fmt.Sprintf("input.%d.content.%d", i, pIdx)
 					payload, _ = sjson.SetBytes(payload, contentPath+".type", "input_text")
-					payload, _ = sjson.SetBytes(payload, contentPath+".input_text", "[Image: "+description+"]")
+					payload, _ = sjson.SetBytes(payload, contentPath+".text", "[Image: "+description+"]")
 					payload, _ = sjson.DeleteBytes(payload, contentPath+".image_url")
+					payload, _ = sjson.DeleteBytes(payload, contentPath+".detail")
 					modified = true
 				}
 			}


### PR DESCRIPTION
## Summary
- Fix bug where vision preprocessed image descriptions used `.input_text` field name instead of `.text` in Responses API path
- Responses API `input_text` content parts use `text` as the data field name, not `input_text`
- This caused image descriptions to be silently dropped when the translator converted from openai-response to openai format
- Also cleans up leftover `detail` field from original `input_image` parts in both code paths

## Root cause
In `opencode_go_vision.go:300`, the Responses API processing path set the image description under `.input_text` instead of `.text`. The standard Responses API format for `input_text` content parts is:
```json
{"type": "input_text", "text": "description here"}
```
NOT:
```json
{"type": "input_text", "input_text": "description here"}
```

## Test plan
- [x] All 50 OpenCodeGo executor tests pass
- [x] Full executor test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)