### PR TITLE
feat: process all historical images in vision preprocessing for cross-turn context

### DIFF
--- a/internal/runtime/executor/opencode_go_vision.go
+++ b/internal/runtime/executor/opencode_go_vision.go
@@ -260,7 +260,6 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 			if content.Exists() && content.IsArray() {
 				payload = processContentArray(i, content)
 			}
-			break // Only the last user message
 		}
 	}
 
@@ -304,7 +303,6 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 					modified = true
 				}
 			}
-			break
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Remove `break` statements in `opencodeGoPreprocessVision` so ALL user messages (not just the last one) get their images preprocessed
- This ensures that in follow-up turns, historical image descriptions persist as `[Image: description]` text rather than being sanitized to `[Image omitted from previous turn.]`
- The model can now answer questions about images sent in previous turns

## Problem
When the user sends a follow-up message asking about a previously sent image:
1. Codex Desktop resends the full conversation history with original image data
2. Vision preprocessing only checked the last user message (current text question)
3. `sanitizeHistoricalImagesForTextModel` replaced historical images with generic placeholder
4. The model had no context about what was in the previous image

## Solution
Remove the `break` that limited preprocessing to the last user message. The loop now processes ALL user messages, converting every image to `[Image: description]` text. Historical messages that already had their images preprocessed in a previous turn get their `[Image: ...]` text reprocessed (which is idempotent since there are no more raw images to describe).

## Test plan
- [x] Full executor test suite passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)