### PR TITLE
feat: hybrid vision handling — preprocess historical images, fallback current image to vision model

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -89,7 +89,7 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	if visionModel == "" {
 		visionModel = "qwen3.5-plus"
 	}
-	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoHasCurrentImage(req.Payload) && apiKey != ""  {
+	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoPayloadHasImage(req.Payload) && apiKey != ""  {
 		if preprocessed, ok := opencodeGoPreprocessVision(ctx, e.cfg, auth, apiKey, visionModel, req.Payload); ok {
 			req.Payload = preprocessed
 		}
@@ -153,7 +153,7 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 	if visionModel == "" {
 		visionModel = "qwen3.5-plus"
 	}
-	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoHasCurrentImage(req.Payload) && apiKey != ""  {
+	if !opencodeGoSupportsNativeVision(baseModel) && opencodeGoPayloadHasImage(req.Payload) && apiKey != ""  {
 		if preprocessed, ok := opencodeGoPreprocessVision(ctx, e.cfg, auth, apiKey, visionModel, req.Payload); ok {
 			req.Payload = preprocessed
 		}

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -62,18 +62,11 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		reqModel := gjson.GetBytes(body, "model").String()
-		if reqModel == "qwen3.5-plus" {
-			// Vision preprocessing call to describe the image
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a test image description"}}]}`))
-			return
-		}
-		// Actual execution call — stays on original model
+		// Vision fallback execution — image sent directly to qwen3.5-plus
 		gotPath = r.URL.Path
 		gotBody = body
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"qwen3.5-plus","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
 	}))
 	defer server.Close()
 
@@ -100,17 +93,17 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 	if gotPath != "/zen/go/v1/chat/completions" {
 		t.Fatalf("path = %q, want /zen/go/v1/chat/completions", gotPath)
 	}
-	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
-		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
+		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
 	}
-	if strings.Contains(string(gotBody), `"image_url"`) {
-		t.Fatalf("image should be replaced with text after vision preprocessing; body=%s", string(gotBody))
+	if !strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("image should be preserved for vision fallback model; body=%s", string(gotBody))
 	}
 	if gotModel := gjson.GetBytes(resp.Payload, "model").String(); gotModel != "deepseek-v4-flash" {
 		t.Fatalf("response model = %q, want deepseek-v4-flash; payload=%s", gotModel, string(resp.Payload))
 	}
-	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
-		t.Fatalf("enable_thinking should not be present when no vision fallback is applied; body=%s", string(gotBody))
+	if !gjson.GetBytes(gotBody, "enable_thinking").Exists() || gjson.GetBytes(gotBody, "enable_thinking").Bool() {
+		t.Fatalf("enable_thinking should be false for qwen vision fallback; body=%s", string(gotBody))
 	}
 	if gotText := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); gotText != "vision ok" {
 		t.Fatalf("response text = %q, want vision ok; payload=%s", gotText, string(resp.Payload))
@@ -155,11 +148,11 @@ func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
 		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
-		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "mimo-v2-omni" {
+		t.Fatalf("upstream model = %q, want mimo-v2-omni; body=%s", gotModel, string(gotBody))
 	}
-	if strings.Contains(string(gotBody), `"image_url"`) {
-		t.Fatalf("image should be replaced with text after vision preprocessing; body=%s", string(gotBody))
+	if !strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("image should be preserved for vision fallback model; body=%s", string(gotBody))
 	}
 	if gjson.GetBytes(gotBody, "enable_thinking").Exists() {
 		t.Fatalf("enable_thinking should not be added for non-qwen fallback; body=%s", string(gotBody))
@@ -329,17 +322,10 @@ func TestOpenCodeGoExecutorStreamRewritesVisionFallbackModel(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		reqModel := gjson.GetBytes(body, "model").String()
-		if reqModel == "qwen3.5-plus" {
-			// Vision preprocessing call to describe the image
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a test image description"}}]}`))
-			return
-		}
-		// Actual execution call — stays on original model
+		// Vision fallback execution — image sent directly to qwen3.5-plus
 		gotBody = body
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_stream","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_stream","object":"chat.completion.chunk","created":1,"model":"qwen3.5-plus","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}` + "\n\n"))
 		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	}))
 	defer server.Close()
@@ -371,8 +357,8 @@ func TestOpenCodeGoExecutorStreamRewritesVisionFallbackModel(t *testing.T) {
 		}
 		chunks.Write(chunk.Payload)
 	}
-	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
-		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
+		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
 	}
 	out := chunks.String()
 	if strings.Contains(out, "qwen3.5-plus") {

--- a/internal/runtime/executor/opencode_go_vision.go
+++ b/internal/runtime/executor/opencode_go_vision.go
@@ -251,7 +251,7 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 	messages := gjson.GetBytes(payload, "messages")
 	if messages.Exists() && messages.IsArray() {
 		items := messages.Array()
-		for i := len(items) - 1; i >= 0; i-- {
+		for i := len(items) - 2; i >= 0; i-- {
 			item := items[i]
 			if item.Get("role").String() != "user" {
 				continue
@@ -267,7 +267,7 @@ func opencodeGoPreprocessVision(ctx context.Context, cfg *config.Config, auth *c
 	input := gjson.GetBytes(payload, "input")
 	if input.Exists() && input.IsArray() {
 		items := input.Array()
-		for i := len(items) - 1; i >= 0; i-- {
+		for i := len(items) - 2; i >= 0; i-- {
 			item := items[i]
 			if item.Get("role").String() != "user" {
 				continue


### PR DESCRIPTION
## Summary
Hybrid approach for vision preprocessing that avoids base64 in DeepSeek context while preserving cross-turn image context:

1. **Historical images** → preprocessed to `[Image: description]` text (no base64, preserves context)
2. **Current message images** → left for `applyVisionFallback` model-switching, sent directly to qwen3.5-plus (or configured vision model)
3. Condition changed from `opencodeGoHasCurrentImage` (last message only) to `opencodeGoPayloadHasImage` (any message), enabling preprocessing to handle historical images in follow-up text-only turns

## Why
- Old preprocessing: image → one-sentence `[Image: desc]` → DeepSeek (can't ask detailed follow-ups)
- Old fallback: swap model entirely (model name leakage, reasoning cache broken)
- Hybrid: current image gets full analysis by vision model, historical images preserved as text

## Test plan
- [x] All executor tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)