### PR TITLE
fix: polish vision registry follow-up handling

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -46,7 +46,7 @@ func (h *Handler) GetUsageLogs(c *gin.Context) {
 	// to stable auth_index values (and reflect renamed OAuth channels).
 	keyNameMap, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap := h.buildNameMaps()
 
-		// Read channel multi-value: support repeated ?channel=x&channel=y,
+	// Read channel multi-value: support repeated ?channel=x&channel=y,
 	// plural ?channels=x,y, and legacy alias ?channel_name=x / ?channel-name=x.
 	channelValues := queryStringListMulti(c, "channel", "channels")
 	// Merge legacy aliases (channel_name, channel-name) into channelValues.

--- a/internal/runtime/executor/opencode_go_computer_use.go
+++ b/internal/runtime/executor/opencode_go_computer_use.go
@@ -226,21 +226,19 @@ func opencodeGoInjectComputerUseTools(payload []byte) []byte {
 	//   3. Responses API:           {"type":"function","name":"...","parameters":{...}} (no "function" key but has "type"="function")
 	isClaudeFormat := false
 	isResponsesAPIFormat := false
-	for _, tool := range toolArray {
-		if tool.Get("function").Exists() {
-			// #1: OpenAI Chat Completions format
-			isClaudeFormat = false
-			isResponsesAPIFormat = false
-		} else if tool.Get("type").String() == "function" && tool.Get("name").Exists() {
-			// #3: Responses API format - has top-level "type"="function" and "name"
-			isClaudeFormat = false
-			isResponsesAPIFormat = true
-		} else if tool.Get("name").Exists() {
-			// #2: Claude format - only has top-level "name" (no "type"="function")
-			isClaudeFormat = true
-			isResponsesAPIFormat = false
-		}
-		break
+	firstTool := toolArray[0]
+	if firstTool.Get("function").Exists() {
+		// #1: OpenAI Chat Completions format
+		isClaudeFormat = false
+		isResponsesAPIFormat = false
+	} else if firstTool.Get("type").String() == "function" && firstTool.Get("name").Exists() {
+		// #3: Responses API format - has top-level "type"="function" and "name"
+		isClaudeFormat = false
+		isResponsesAPIFormat = true
+	} else if firstTool.Get("name").Exists() {
+		// #2: Claude format - only has top-level "name" (no "type"="function")
+		isClaudeFormat = true
+		isResponsesAPIFormat = false
 	}
 
 	// If Computer Use tools are already present, do nothing.

--- a/internal/runtime/executor/opencode_go_computer_use.go
+++ b/internal/runtime/executor/opencode_go_computer_use.go
@@ -24,12 +24,12 @@ var mcpComputerUseFunctions = []map[string]any{
 			"parameters": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"app":          map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
-					"click_count":  map[string]any{"type": "integer", "description": "Number of clicks. Defaults to 1"},
+					"app":           map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"click_count":   map[string]any{"type": "integer", "description": "Number of clicks. Defaults to 1"},
 					"element_index": map[string]any{"type": "string", "description": "Element index to click"},
-					"mouse_button": map[string]any{"type": "string", "description": "Mouse button to click. Defaults to left.", "enum": []string{"left", "right", "middle"}},
-					"x":            map[string]any{"type": "number", "description": "X coordinate in screenshot pixel coordinates"},
-					"y":            map[string]any{"type": "number", "description": "Y coordinate in screenshot pixel coordinates"},
+					"mouse_button":  map[string]any{"type": "string", "description": "Mouse button to click. Defaults to left.", "enum": []string{"left", "right", "middle"}},
+					"x":             map[string]any{"type": "number", "description": "X coordinate in screenshot pixel coordinates"},
+					"y":             map[string]any{"type": "number", "description": "Y coordinate in screenshot pixel coordinates"},
 				},
 				"required":             []string{"app"},
 				"additionalProperties": false,
@@ -45,11 +45,11 @@ var mcpComputerUseFunctions = []map[string]any{
 			"parameters": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"app":   map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
+					"app":    map[string]any{"type": "string", "description": "App name, full app path, or unambiguous bundle identifier"},
 					"from_x": map[string]any{"type": "number", "description": "Start X coordinate"},
 					"from_y": map[string]any{"type": "number", "description": "Start Y coordinate"},
-					"to_x":  map[string]any{"type": "number", "description": "End X coordinate"},
-					"to_y":  map[string]any{"type": "number", "description": "End Y coordinate"},
+					"to_x":   map[string]any{"type": "number", "description": "End X coordinate"},
+					"to_y":   map[string]any{"type": "number", "description": "End Y coordinate"},
 				},
 				"required":             []string{"app", "from_x", "from_y", "to_x", "to_y"},
 				"additionalProperties": false,
@@ -381,4 +381,3 @@ func opencodeGoStripArrayScreenshots(payload []byte, arrayPath string) []byte {
 	}
 	return payload
 }
-

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/vision"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/vision"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
@@ -83,38 +83,38 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	// Image registry: handle historical image references and inject
 	// registry notes for follow-up questions. Current-turn images are
 	// left for the existing vision fallback path below.
-		sessionKey, _ := vision.ResolveSessionKey(opts, auth)
-		processor := vision.NewProcessor(e.newAnalyzer(auth))
-		procRes, _ := processor.Process(ctx, req.Payload, sessionKey, 0)
-		req.Payload = procRes.Payload
+	sessionKey, _ := vision.ResolveSessionKey(opts, auth)
+	processor := vision.NewProcessor(e.newAnalyzer(auth))
+	procRes, _ := processor.Process(ctx, req.Payload, sessionKey, 0)
+	req.Payload = procRes.Payload
 
-		// Vision fallback: if the current message has new images and the
-		// model doesn't natively support vision, route to the configured
-		// vision model for direct image analysis.
-		fallback := e.applyVisionFallback(auth, req, opts)
-		req = fallback.Request
+	// Vision fallback: if the current message has new images and the
+	// model doesn't natively support vision, route to the configured
+	// vision model for direct image analysis.
+	fallback := e.applyVisionFallback(auth, req, opts)
+	req = fallback.Request
 
 	// Inject cached reasoning_content for models that need it (e.g., DeepSeek thinking mode).
 	sessionID := opencodeGoSessionID(opts, auth)
 	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
 		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
 	}
-		// Inject Computer Use function tools for models that need them.
-		// Codex Desktop skips mcp__computer_use__ when routing through /v1/messages,
-		// so DeepSeek models don't see Computer Use capabilities.
-		if opencodeGoNeedsReasoningInjection(req.Model) {
-			req.Payload = opencodeGoInjectComputerUseTools(req.Payload)
-		}
-		// Strip old base64 screenshots from tool result messages to save context.
-		if opencodeGoNeedsReasoningInjection(req.Model) {
-			req.Payload = opencodeGoStripScreenshots(req.Payload)
-		}
-			// Strip orphaned tool_calls that strict upstreams reject.
-			cleaned := opencodeGoStripOrphanedToolCalls(req.Payload)
-			if len(cleaned) != len(req.Payload) {
-				log.Warnf("opencode: stripped orphaned tool_calls")
-			}
-			req.Payload = cleaned
+	// Inject Computer Use function tools for models that need them.
+	// Codex Desktop skips mcp__computer_use__ when routing through /v1/messages,
+	// so DeepSeek models don't see Computer Use capabilities.
+	if opencodeGoNeedsReasoningInjection(req.Model) {
+		req.Payload = opencodeGoInjectComputerUseTools(req.Payload)
+	}
+	// Strip old base64 screenshots from tool result messages to save context.
+	if opencodeGoNeedsReasoningInjection(req.Model) {
+		req.Payload = opencodeGoStripScreenshots(req.Payload)
+	}
+	// Strip orphaned tool_calls that strict upstreams reject.
+	cleaned := opencodeGoStripOrphanedToolCalls(req.Payload)
+	if len(cleaned) != len(req.Payload) {
+		log.Warnf("opencode: stripped orphaned tool_calls")
+	}
+	req.Payload = cleaned
 	var resp cliproxyexecutor.Response
 	var err error
 	if opencodeGoUsesMessages(req.Model) {
@@ -156,22 +156,22 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
 		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
 	}
-		// Inject Computer Use function tools for models that need them.
-		// Codex Desktop skips mcp__computer_use__ when routing through /v1/messages,
-		// so DeepSeek models don't see Computer Use capabilities.
-		if opencodeGoNeedsReasoningInjection(req.Model) {
-			req.Payload = opencodeGoInjectComputerUseTools(req.Payload)
-		}
-		// Strip old base64 screenshots from tool result messages to save context.
-		if opencodeGoNeedsReasoningInjection(req.Model) {
-			req.Payload = opencodeGoStripScreenshots(req.Payload)
-		}
-			// Strip orphaned tool_calls that strict upstreams reject.
-			cleaned := opencodeGoStripOrphanedToolCalls(req.Payload)
-			if len(cleaned) != len(req.Payload) {
-				log.Warnf("opencode: stripped orphaned tool_calls")
-			}
-			req.Payload = cleaned
+	// Inject Computer Use function tools for models that need them.
+	// Codex Desktop skips mcp__computer_use__ when routing through /v1/messages,
+	// so DeepSeek models don't see Computer Use capabilities.
+	if opencodeGoNeedsReasoningInjection(req.Model) {
+		req.Payload = opencodeGoInjectComputerUseTools(req.Payload)
+	}
+	// Strip old base64 screenshots from tool result messages to save context.
+	if opencodeGoNeedsReasoningInjection(req.Model) {
+		req.Payload = opencodeGoStripScreenshots(req.Payload)
+	}
+	// Strip orphaned tool_calls that strict upstreams reject.
+	cleaned := opencodeGoStripOrphanedToolCalls(req.Payload)
+	if len(cleaned) != len(req.Payload) {
+		log.Warnf("opencode: stripped orphaned tool_calls")
+	}
+	req.Payload = cleaned
 	var result *cliproxyexecutor.StreamResult
 	var err error
 	if opencodeGoUsesMessages(req.Model) {
@@ -245,8 +245,6 @@ func (e *OpenCodeGoExecutor) applyVisionFallback(auth *cliproxyauth.Auth, req cl
 	result.Applied = true
 	return result
 }
-
-
 
 func opencodeGoVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth) string {
 	if auth == nil {
@@ -903,7 +901,6 @@ func (e *OpenCodeGoExecutor) requestLog(url string, req *http.Request, body []by
 	}
 }
 
-
 // opencodeGoStripOrphanedToolCalls removes tool_calls from assistant messages
 // that are not followed by tool messages responding to them. Strict upstream
 // providers (e.g., DeepSeek) reject requests with unresolved tool_calls.
@@ -979,7 +976,6 @@ func opencodeGoStripOrphanedToolCalls(payload []byte) []byte {
 	}
 	return payload
 }
-
 
 func opencodeGoUsesMessages(model string) bool {
 	base := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(model).ModelName))

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -112,20 +112,20 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 
 func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
 	var gotBody []byte
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			body, _ := io.ReadAll(r.Body)
-			reqModel := gjson.GetBytes(body, "model").String()
-			if reqModel == "qwen3.5-plus" {
-				// Vision preprocessing call to describe the image
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a test image description"}}]}`))
-				return
-			}
-			// Actual execution call — stays on original model
-			gotBody = body
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		reqModel := gjson.GetBytes(body, "model").String()
+		if reqModel == "qwen3.5-plus" {
+			// Vision preprocessing call to describe the image
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
-		}))
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a test image description"}}]}`))
+			return
+		}
+		// Actual execution call — stays on original model
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_vision","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+	}))
 	defer server.Close()
 
 	oldBaseURL := opencodeGoBaseURL
@@ -164,20 +164,20 @@ func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
 
 func TestOpenCodeGoExecutorIgnoresConfiguredTextOnlyFallbackModel(t *testing.T) {
 	var gotBody []byte
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			body, _ := io.ReadAll(r.Body)
-			reqModel := gjson.GetBytes(body, "model").String()
-			if reqModel == "qwen3.5-plus" {
-				// Vision preprocessing call to describe the image
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a description"}}]}`))
-				return
-			}
-			// Actual execution call — text-only model, stays on original model
-			gotBody = body
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		reqModel := gjson.GetBytes(body, "model").String()
+		if reqModel == "qwen3.5-plus" {
+			// Vision preprocessing call to describe the image
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"id":"chatcmpl_text_only_fallback","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
-		}))
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a description"}}]}`))
+			return
+		}
+		// Actual execution call — text-only model, stays on original model
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_text_only_fallback","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
 	defer server.Close()
 
 	oldBaseURL := opencodeGoBaseURL
@@ -382,20 +382,20 @@ func TestOpenCodeGoRewriteFallbackStreamPayloadRewritesSSEModelFields(t *testing
 
 func TestOpenCodeGoExecutorIgnoresExcludedVisionFallback(t *testing.T) {
 	var gotBody []byte
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			body, _ := io.ReadAll(r.Body)
-			reqModel := gjson.GetBytes(body, "model").String()
-			if reqModel == "qwen3.5-plus" {
-				// Vision preprocessing call to describe the image
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a description"}}]}`))
-				return
-			}
-			// Actual execution call — stays on original model
-			gotBody = body
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		reqModel := gjson.GetBytes(body, "model").String()
+		if reqModel == "qwen3.5-plus" {
+			// Vision preprocessing call to describe the image
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"id":"chatcmpl_excluded","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
-		}))
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a description"}}]}`))
+			return
+		}
+		// Actual execution call — stays on original model
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_excluded","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
 	defer server.Close()
 
 	oldBaseURL := opencodeGoBaseURL

--- a/internal/runtime/executor/opencode_go_reasoning.go
+++ b/internal/runtime/executor/opencode_go_reasoning.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	reasoningContentCacheTTL        = 30 * time.Minute
-	reasoningCacheCleanupInterval   = 5 * time.Minute
-	reasoningCacheMaxEntriesPerKey  = 1
+	reasoningContentCacheTTL       = 30 * time.Minute
+	reasoningCacheCleanupInterval  = 5 * time.Minute
+	reasoningCacheMaxEntriesPerKey = 1
 )
 
 var (

--- a/internal/runtime/executor/opencode_go_reasoning_test.go
+++ b/internal/runtime/executor/opencode_go_reasoning_test.go
@@ -395,8 +395,8 @@ func TestOpenCodeGoInjectReasoningContentMultipleAssistants(t *testing.T) {
 	// a3 (index 5) - text assistant, should get the cached reasoning_content
 	if rc := msgs[5].Get("reasoning_content").String(); rc != "cached reasoning" {
 		t.Errorf("last assistant at index 5 should get cached reasoning_content, got %q", rc)
-}
 	}
+}
 
 func TestOpenCodeGoInjectReasoningContentPreservesModelName(t *testing.T) {
 	reasoningCache = sync.Map{}

--- a/internal/runtime/executor/opencode_go_vision.go
+++ b/internal/runtime/executor/opencode_go_vision.go
@@ -183,10 +183,7 @@ func contentHasImage(item gjson.Result) bool {
 	}
 	// Plain string content with data URL
 	text := content.String()
-	if strings.HasPrefix(text, "data:image") {
-		return true
-	}
-	return false
+	return strings.HasPrefix(text, "data:image")
 }
 
 // opencodeGoPreprocessVision replaces images in the current user message with

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -582,7 +582,7 @@ func QueryStats(params LogQueryParams) (LogStats, error) {
 	db := getDB()
 	if db == nil {
 
-	return LogStats{CacheRate: 0}, nil
+		return LogStats{CacheRate: 0}, nil
 	}
 	if params.Days < 1 {
 		params.Days = 7

--- a/internal/vision/analyzer.go
+++ b/internal/vision/analyzer.go
@@ -15,12 +15,12 @@ import (
 
 // AnalyzeRequest carries all context needed for image analysis.
 type AnalyzeRequest struct {
-	ImageData    string        // base64 data from current request
-	MIMEType     string        // "image/png", "image/jpeg", etc.
-	Existing     ImageSummary  // previously accumulated summary (empty on first analysis)
-	Query        string        // user's current question (empty on first analysis)
-	IsFollowUp   bool          // true if this is a follow-up analysis
-	SourceKind   ImageSourceKind
+	ImageData  string       // base64 data from current request
+	MIMEType   string       // "image/png", "image/jpeg", etc.
+	Existing   ImageSummary // previously accumulated summary (empty on first analysis)
+	Query      string       // user's current question (empty on first analysis)
+	IsFollowUp bool         // true if this is a follow-up analysis
+	SourceKind ImageSourceKind
 }
 
 // AnalyzeResponse contains the analysis result.
@@ -51,9 +51,9 @@ func NewOpenCodeGoAnalyzer(baseURL, apiKey, model string) *OpenCodeGoAnalyzer {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
-				MaxIdleConns:        10,
-				IdleConnTimeout:     90 * time.Second,
-				DisableCompression:  false,
+				MaxIdleConns:       10,
+				IdleConnTimeout:    90 * time.Second,
+				DisableCompression: false,
 			},
 		},
 	}
@@ -150,7 +150,7 @@ func (a *OpenCodeGoAnalyzer) buildRequestBody(prompt, imageData, mimeType string
 		"model": a.model,
 		"messages": []map[string]any{
 			{
-				"role": "system",
+				"role":    "system",
 				"content": "You are an expert image analyst. Provide structured, detailed descriptions.",
 			},
 			{

--- a/internal/vision/intent.go
+++ b/internal/vision/intent.go
@@ -9,10 +9,10 @@ import (
 type Intent int
 
 const (
-	IntentNone        Intent = iota // no historical image action needed
-	IntentFollowUp                  // user is asking about a specific image
-	IntentAmbiguous                 // user references image but target is unclear
-	IntentNewImage                  // current turn has new images
+	IntentNone      Intent = iota // no historical image action needed
+	IntentFollowUp                // user is asking about a specific image
+	IntentAmbiguous               // user references image but target is unclear
+	IntentNewImage                // current turn has new images
 )
 
 // DetectIntent examines the last user message and registry state to determine

--- a/internal/vision/processor.go
+++ b/internal/vision/processor.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/tidwall/gjson"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 )
 
 // ProcessResult contains the outcome of processing a payload through the registry.
@@ -46,7 +46,10 @@ func (p *Processor) Process(ctx context.Context, payload []byte, sessionKey Sess
 	var sessionStore *SessionStore
 	if hasSession {
 		sessionStore = p.registry.GetOrCreateSession(sessionKey)
+		sessionStore.ResetReachability()
 	}
+	ephemeralEntries := make(map[ImageHash]*ImageEntry)
+	ephemeralNextOrdinal := 0
 
 	// Separate current-turn from historical images
 	var currentParts, historicalParts []ImagePart
@@ -67,18 +70,27 @@ func (p *Processor) Process(ctx context.Context, payload []byte, sessionKey Sess
 		if data == "" {
 			continue
 		}
-		hash := ComputeHash(data)
 		if sessionStore == nil {
 			continue
 		}
-		ordinal := sessionStore.NextOrdinal()
-		sessionStore.GetOrCreateEntry(hash, ordinal, p.maxEntries)
+		hash := ComputeHash(data)
+		if sessionStore.GetEntry(hash) == nil {
+			ordinal := sessionStore.NextOrdinal()
+			sessionStore.GetOrCreateEntry(hash, ordinal, p.maxEntries)
+		}
 		sessionStore.UpdateEntry(hash, func(e *ImageEntry) {
 			e.SourceKind = ImageSourceUserUpload
-			e.FirstSeenTurn = turnIndex
+			if e.FirstSeenTurn == 0 {
+				e.FirstSeenTurn = turnIndex
+			}
 			e.LastSeenTurn = turnIndex
 			e.CurrentPayloadReachable = true
 			e.Availability = ImageAvailableInline
+			e.Occurrences = append(e.Occurrences, ImageOccurrence{
+				TurnIndex:  turnIndex,
+				MessageIdx: part.MsgIdx,
+				PartIdx:    part.PartIdx,
+			})
 		})
 	}
 
@@ -103,7 +115,23 @@ func (p *Processor) Process(ctx context.Context, payload []byte, sessionKey Sess
 			continue
 		}
 		hash := ComputeHash(data)
-		entry := p.findOrCreateEntry(sessionStore, hash, data, turnIndex)
+		entry := p.findOrCreateEntry(sessionStore, hash, turnIndex, ephemeralEntries, &ephemeralNextOrdinal)
+		if sessionStore != nil {
+			sessionStore.UpdateEntry(hash, func(e *ImageEntry) {
+				e.SourceKind = ImageSourceUserUpload
+				if e.FirstSeenTurn == 0 {
+					e.FirstSeenTurn = turnIndex
+				}
+				e.LastSeenTurn = turnIndex
+				e.CurrentPayloadReachable = true
+				e.Availability = ImageAvailableInline
+				e.Occurrences = append(e.Occurrences, ImageOccurrence{
+					TurnIndex:  turnIndex,
+					MessageIdx: part.MsgIdx,
+					PartIdx:    part.PartIdx,
+				})
+			})
+		}
 		placeholder := BuildShortPlaceholder(entry)
 
 		var err error
@@ -149,13 +177,21 @@ type ImageDataInfo struct {
 	MIMEType string
 }
 
-func (p *Processor) findOrCreateEntry(sessionStore *SessionStore, hash ImageHash, data string, turnIndex int) *ImageEntry {
+func (p *Processor) findOrCreateEntry(sessionStore *SessionStore, hash ImageHash, turnIndex int, ephemeralEntries map[ImageHash]*ImageEntry, ephemeralNextOrdinal *int) *ImageEntry {
 	if sessionStore == nil {
-		return &ImageEntry{
-			Hash:          hash,
-			StableOrdinal: 1,
-			Summary:       ImageSummary{Confidence: "low"},
+		if entry, ok := ephemeralEntries[hash]; ok {
+			return entry
 		}
+		*ephemeralNextOrdinal = *ephemeralNextOrdinal + 1
+		entry := &ImageEntry{
+			Hash:                    hash,
+			StableOrdinal:           *ephemeralNextOrdinal,
+			CurrentPayloadReachable: true,
+			Availability:            ImageAvailableInline,
+			Summary:                 ImageSummary{Confidence: "low"},
+		}
+		ephemeralEntries[hash] = entry
+		return entry
 	}
 	existing := sessionStore.GetEntry(hash)
 	if existing != nil {

--- a/internal/vision/registry.go
+++ b/internal/vision/registry.go
@@ -147,6 +147,18 @@ func (s *SessionStore) NextOrdinal() int {
 	return s.nextOrdinal
 }
 
+// ResetReachability marks all entries as not reachable for the current request.
+// Callers should then mark the entries actually present in the request as reachable.
+func (s *SessionStore) ResetReachability() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		e.CurrentPayloadReachable = false
+		e.Availability = ImageUnavailableNow
+	}
+	s.updatedAt = time.Now()
+}
+
 // GetOrCreateEntry finds an existing entry by hash or creates a new one.
 func (s *SessionStore) GetOrCreateEntry(hash ImageHash, ordinal int, maxEntries int) *ImageEntry {
 	s.mu.Lock()

--- a/internal/vision/registry_test.go
+++ b/internal/vision/registry_test.go
@@ -1,12 +1,25 @@
 package vision
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
+
+type fakeAnalyzer struct {
+	resp AnalyzeResponse
+	err  error
+}
+
+func (f fakeAnalyzer) Analyze(context.Context, AnalyzeRequest) (AnalyzeResponse, error) {
+	return f.resp, f.err
+}
+
+func (f fakeAnalyzer) Name() string { return "fake" }
 
 func TestComputeHash(t *testing.T) {
 	h1 := ComputeHash("same-data")
@@ -241,9 +254,9 @@ func TestInjectRegistryNote(t *testing.T) {
 
 func TestDetectIntent(t *testing.T) {
 	tests := []struct {
-		msg     string
-		count   int
-		want    Intent
+		msg   string
+		count int
+		want  Intent
 	}{
 		{"好的", 2, IntentNone},
 		{"继续", 2, IntentNone},
@@ -362,10 +375,123 @@ func TestSessionKeyResolution(t *testing.T) {
 }
 
 func TestComputeImageHash(t *testing.T) {
-    h1 := ComputeHash("data")
-    h2 := ComputeHash("data2")
-    if h1 == h2 {
-        t.Fatal("different data should produce different hashes")
-    }
+	h1 := ComputeHash("data")
+	h2 := ComputeHash("data2")
+	if h1 == h2 {
+		t.Fatal("different data should produce different hashes")
+	}
 }
 
+func TestProcessorHistoricalReanalysisKeepsReachableState(t *testing.T) {
+	registry := newGlobalRegistry(DefaultGlobalConfig())
+	processor := &Processor{
+		registry: registry,
+		analyzer: fakeAnalyzer{resp: AnalyzeResponse{
+			Summary: ImageSummary{
+				Summary:  "reanalyzed",
+				OCRHints: []string{"ocr2"},
+			},
+		}},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"first"},{"type":"image_url","image_url":{"url":"data:image/png;base64,QUJD"}}]},{"role":"assistant","content":"ok"},{"role":"user","content":"第一张图里有什么？"}]}`)
+
+	res, err := processor.Process(context.Background(), payload, SessionKey("sess-1"), 1)
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if !strings.Contains(res.RegistryNote, "Image #1: reanalyzed") {
+		t.Fatalf("registry note = %q, want reanalyzed summary", res.RegistryNote)
+	}
+	if strings.Contains(res.RegistryNote, "未出现在当前请求") {
+		t.Fatalf("registry note should not claim image is unavailable: %q", res.RegistryNote)
+	}
+
+	entries := registry.GetSession("sess-1").AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if !entries[0].CurrentPayloadReachable {
+		t.Fatal("historical image present in payload should be marked reachable")
+	}
+}
+
+func TestProcessorWithoutSessionAssignsDistinctEphemeralOrdinals(t *testing.T) {
+	processor := &Processor{
+		registry:   newGlobalRegistry(DefaultGlobalConfig()),
+		analyzer:   fakeAnalyzer{},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"a"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]},{"role":"assistant","content":"ok"},{"role":"user","content":[{"type":"text","text":"b"},{"type":"image_url","image_url":{"url":"data:image/png;base64,BBBB"}}]},{"role":"assistant","content":"ok2"},{"role":"user","content":"继续"}]}`)
+
+	res, err := processor.Process(context.Background(), payload, "", 1)
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	out := string(res.Payload)
+	if strings.Count(out, "[Image #1 from previous turn]") != 1 {
+		t.Fatalf("payload should contain exactly one Image #1 placeholder: %s", out)
+	}
+	if strings.Count(out, "[Image #2 from previous turn]") != 1 {
+		t.Fatalf("payload should contain exactly one Image #2 placeholder: %s", out)
+	}
+}
+
+func TestProcessorDuplicateCurrentImageDoesNotAdvanceOrdinal(t *testing.T) {
+	registry := newGlobalRegistry(DefaultGlobalConfig())
+	processor := &Processor{
+		registry:   registry,
+		analyzer:   fakeAnalyzer{},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"first"},{"type":"image_url","image_url":{"url":"data:image/png;base64,QUJD"}}]}]}`)
+
+	if _, err := processor.Process(context.Background(), payload, SessionKey("sess-dup"), 1); err != nil {
+		t.Fatalf("first Process() error = %v", err)
+	}
+	if _, err := processor.Process(context.Background(), payload, SessionKey("sess-dup"), 2); err != nil {
+		t.Fatalf("second Process() error = %v", err)
+	}
+
+	store := registry.GetSession("sess-dup")
+	if store == nil {
+		t.Fatal("expected session store to exist")
+	}
+	if store.nextOrdinal != 1 {
+		t.Fatalf("nextOrdinal = %d, want 1 for repeated same image", store.nextOrdinal)
+	}
+	if len(store.AllEntries()) != 1 {
+		t.Fatalf("expected 1 entry for repeated same image, got %d", len(store.AllEntries()))
+	}
+}
+
+func TestProcessorResetsReachabilityPerRequest(t *testing.T) {
+	registry := newGlobalRegistry(DefaultGlobalConfig())
+	processor := &Processor{
+		registry:   registry,
+		analyzer:   fakeAnalyzer{},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload1 := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"first"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]}]}`)
+	payload2 := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"second"},{"type":"image_url","image_url":{"url":"data:image/png;base64,BBBB"}}]}]}`)
+	payload3 := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"first again"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]},{"role":"assistant","content":"ok"},{"role":"user","content":"还有什么细节？"}]}`)
+
+	if _, err := processor.Process(context.Background(), payload1, SessionKey("sess-reset"), 1); err != nil {
+		t.Fatalf("payload1 Process() error = %v", err)
+	}
+	if _, err := processor.Process(context.Background(), payload2, SessionKey("sess-reset"), 2); err != nil {
+		t.Fatalf("payload2 Process() error = %v", err)
+	}
+	res, err := processor.Process(context.Background(), payload3, SessionKey("sess-reset"), 3)
+	if err != nil {
+		t.Fatalf("payload3 Process() error = %v", err)
+	}
+
+	if strings.Count(res.RegistryNote, "未出现在当前请求") != 1 {
+		t.Fatalf("registry note should mark exactly one older image unavailable: %q", res.RegistryNote)
+	}
+}

--- a/internal/vision/types.go
+++ b/internal/vision/types.go
@@ -51,7 +51,7 @@ type ImageOccurrence struct {
 // ImageEntry represents one unique image tracked across turns.
 type ImageEntry struct {
 	Hash                    ImageHash
-	StableOrdinal           int               // stable across turns: Image #1, #2, ...
+	StableOrdinal           int // stable across turns: Image #1, #2, ...
 	SourceKind              ImageSourceKind
 	FirstSeenTurn           int
 	LastSeenTurn            int

--- a/internal/vision/walk.go
+++ b/internal/vision/walk.go
@@ -7,14 +7,14 @@ import (
 
 // ImagePart describes a single image content part found in a payload.
 type ImagePart struct {
-	ArrayName  string // "messages" or "input"
-	MsgIdx     int    // index in the array
-	PartIdx    int    // index in the content array
-	Type       string // original type ("image_url" / "input_image" / "image")
-	Data       string // base64 data (may be empty for remote URLs)
-	RemoteURL  string // remote URL if not inline
-	MIMEType   string
-	IsCurrent  bool // true if this part belongs to the last user message
+	ArrayName string // "messages" or "input"
+	MsgIdx    int    // index in the array
+	PartIdx   int    // index in the content array
+	Type      string // original type ("image_url" / "input_image" / "image")
+	Data      string // base64 data (may be empty for remote URLs)
+	RemoteURL string // remote URL if not inline
+	MIMEType  string
+	IsCurrent bool // true if this part belongs to the last user message
 }
 
 // WalkResult contains all image parts found and whether any are current/historical.


### PR DESCRIPTION
## Summary
- refresh image reachability state per request before marking images seen in the current payload
- keep distinct ephemeral ordinals when no session key is available, while avoiding duplicate ordinal bumps for repeated current-turn images
- add processor regressions for reachable historical re-analysis, no-session placeholder numbering, duplicate current-image ordinal stability, and per-request reachability reset

## Validation
- `rtk go test ./internal/vision ./internal/runtime/executor -run 'Test(OpenCodeGo|WalkPayload|ReplaceImagePart|InjectRegistryNote|DetectIntent|Ambiguity|ExtractImageReference|SessionKey|ComputeHash|ExtractLastUserText|NextOrdinal|MergeHints|Processor)'`
- manual payload reproduction for historical follow-up re-analysis and no-session multi-image placeholders
