### PR TITLE
feat: 新增 GET /models/configured-availability 聚合接口

### DIFF
--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -355,6 +355,143 @@ func modelConfigParamID(c *gin.Context) string {
 	return strings.TrimPrefix(strings.TrimSpace(c.Param("id")), "/")
 }
 
+// GetConfiguredModelAvailability returns the currently configured and serviceable
+// model IDs with pricing/metadata and active_metadata for owner/source filtering.
+//
+// Endpoint:
+//
+//	GET /v0/management/models/configured-availability
+func (h *Handler) GetConfiguredModelAvailability(c *gin.Context) {
+	modelRegistry := registry.GetGlobalRegistry()
+	allModels := modelRegistry.GetAvailableModels("openai")
+
+	// Parse optional channel/group filters (same param semantics as GetModels).
+	allowedRaw := strings.TrimSpace(c.Query("allowed_channels"))
+	if allowedRaw == "" {
+		allowedRaw = strings.TrimSpace(c.Query("allowed-channels"))
+	}
+	allowedGroupsRaw := strings.TrimSpace(c.Query("allowed_channel_groups"))
+	if allowedGroupsRaw == "" {
+		allowedGroupsRaw = strings.TrimSpace(c.Query("allowed-channel-groups"))
+	}
+	allowedGroups := internalrouting.ParseNormalizedSet(allowedGroupsRaw, internalrouting.NormalizeGroupName)
+
+	filterModels := func(models []map[string]any) []map[string]any {
+		if h == nil || h.authManager == nil {
+			return models
+		}
+		if allowedRaw != "" && allowedRaw != "*" && !strings.EqualFold(allowedRaw, "all") {
+			allowed := make(map[string]struct{})
+			for _, part := range strings.Split(allowedRaw, ",") {
+				key := strings.ToLower(strings.TrimSpace(part))
+				if key == "" {
+					continue
+				}
+				allowed[key] = struct{}{}
+			}
+			if len(allowed) > 0 {
+				filtered := make([]map[string]any, 0, len(models))
+				for _, model := range models {
+					id, _ := model["id"].(string)
+					if id == "" {
+						continue
+					}
+					if h.authManager.CanServeModelWithScopes(id, allowed, allowedGroups, "") {
+						filtered = append(filtered, model)
+					}
+				}
+				return filtered
+			}
+		}
+		if len(allowedGroups) > 0 {
+			filtered := make([]map[string]any, 0, len(models))
+			for _, model := range models {
+				id, _ := model["id"].(string)
+				if id == "" {
+					continue
+				}
+				if h.authManager.CanServeModelWithScopes(id, nil, allowedGroups, "") {
+					filtered = append(filtered, model)
+				}
+			}
+			return filtered
+		}
+		return models
+	}
+	allModels = filterModels(allModels)
+
+	// Build model config index for metadata/pricing.
+	allConfigRows := usage.ListModelConfigs()
+	configByID := make(map[string]usage.ModelConfigRow, len(allConfigRows))
+	for _, row := range allConfigRows {
+		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
+	}
+
+	// Build data array with metadata from model configs.
+	type configuredModelEntry struct {
+		ID      string         `json:"id"`
+		OwnedBy string         `json:"owned_by,omitempty"`
+		Pricing map[string]any `json:"pricing,omitempty"`
+		Source  string         `json:"source"`
+	}
+
+	data := make([]map[string]any, 0, len(allModels))
+	for _, model := range allModels {
+		id, _ := model["id"].(string)
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		entry := map[string]any{
+			"id":     id,
+			"object": "model",
+			"source": "registry",
+		}
+		if ownedBy, exists := model["owned_by"]; exists {
+			entry["owned_by"] = ownedBy
+		}
+		if row, ok := configByID[strings.ToLower(id)]; ok {
+			attachModelConfigCapabilities(entry, row)
+			entry["pricing"] = map[string]any{
+				"mode":                     row.PricingMode,
+				"input_price_per_million":  row.InputPricePerMillion,
+				"output_price_per_million": row.OutputPricePerMillion,
+				"cached_price_per_million": row.CachedPricePerMillion,
+				"price_per_call":           row.PricePerCall,
+			}
+			if row.Description != "" {
+				entry["description"] = row.Description
+			}
+			if row.Source != "" {
+				entry["metadata_source"] = row.Source
+			}
+		}
+		data = append(data, entry)
+	}
+
+	// Determine scoped: true when auth manager is configured (provider configs exist).
+	scoped := h != nil && h.authManager != nil
+
+	// active_metadata: all user and seed model configs for owner/source filtering.
+	activeRows := filterModelConfigRowsByScope(allConfigRows, "active")
+	activeMetadata := make([]map[string]any, 0, len(activeRows))
+	for _, row := range activeRows {
+		activeMetadata = append(activeMetadata, map[string]any{
+			"id":        row.ModelID,
+			"owned_by":  row.OwnedBy,
+			"source":    row.Source,
+			"enabled":   row.Enabled,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"object":          "list",
+		"scoped":          scoped,
+		"data":            data,
+		"active_metadata": activeMetadata,
+	})
+}
+
 // GetModels returns the list of all available models from the global registry
 // along with their pricing information.
 //

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -656,6 +656,7 @@ func (s *Server) registerManagementRoutes() {
 			s.mgmt.SystemStatsWebSocket(c)
 		})
 		mgmt.GET("/models", s.mgmt.GetModels)
+		mgmt.GET("/models/configured-availability", s.mgmt.GetConfiguredModelAvailability)
 		mgmt.GET("/model-path-availability", s.mgmt.GetModelPathAvailability)
 		mgmt.GET("/model-configs", s.mgmt.GetModelConfigs)
 		mgmt.POST("/model-configs", s.mgmt.PostModelConfig)


### PR DESCRIPTION
新增后端聚合接口 GET /v0/management/models/configured-availability，替代前端 N+1 API 拼凑逻辑。

### 功能
- 复用全局 registry 获取所有可用模型
- 支持 allowed_channels / allowed_channel_groups 过滤（同 /models）
- 返回 data（模型列表 + pricing + capabilities）
- 返回 active_metadata（供前端 owner/source 过滤）
- scoped 字段标识是否存在已配置模型范围

### 后端实现
- 复用 registry.GetGlobalRegistry() 和 authManager.CanServeModelWithScopes()
- 复用 usage.ListModelConfigs() 获取 pricing/metadata
- 复用 attachModelConfigCapabilities 输出 capabilities

详见设计文档 docs/ccswitch-model-availability-performance-issue_CN.md