### PR TITLE
feat: generic model variant metadata and pricing merge for OpenRouter sync

### DIFF
--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -153,6 +153,9 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 		}
 		result.Added++
 	}
+	if err := openRouterMergeVariantGroups(models); err != nil {
+		return result, err
+	}
 	return result, nil
 }
 
@@ -417,8 +420,8 @@ func openRouterLocalModelID(remoteModelID, owner string) string {
 	modelID := openRouterProviderlessModelID(remoteModelID)
 	if normalizeModelOwnerValue(owner) == "anthropic" {
 		modelID = strings.ReplaceAll(modelID, ".", "-")
-		modelID = openRouterStripAnthropicReleaseDate(modelID)
 	}
+	modelID = openRouterStripDateSuffix(modelID)
 	return modelID
 }
 
@@ -430,9 +433,32 @@ func openRouterProviderlessModelID(remoteModelID string) string {
 	return modelID
 }
 
-func openRouterStripAnthropicReleaseDate(modelID string) string {
+func openRouterStripDateSuffix(modelID string) string {
 	modelID = strings.TrimSpace(modelID)
-	if !strings.HasPrefix(modelID, "claude-") || len(modelID) <= 9 {
+	if modelID == "" {
+		return modelID
+	}
+	// Iteratively strip known date/version suffixes from the tail.
+	// This handles models like qwen3.5-plus-20260420 → qwen3.5-plus
+	// or qwen3.5-plus-02-15 → qwen3.5-plus. Must NOT strip semantic suffixes
+	// like -thinking, -max, -turbo, -preview, -v2, etc.
+	for {
+		stripped := stripTrailing8DigitDate(modelID)
+		if stripped == modelID {
+			stripped = stripTrailingSegmentedDate(modelID)
+		}
+		if stripped == modelID {
+			break
+		}
+		modelID = stripped
+	}
+	return modelID
+}
+
+// stripTrailing8DigitDate strips a trailing -YYYYMMDD suffix (8 digits, preceded by a dash).
+// Example: "qwen3.5-plus-20260420" → "qwen3.5-plus", "claude-3-5-haiku-20241022" → "claude-3-5-haiku"
+func stripTrailing8DigitDate(modelID string) string {
+	if len(modelID) < 10 { // need at least "a-12345678" (1 char + dash + 8 digits)
 		return modelID
 	}
 	dateStart := len(modelID) - 8
@@ -445,6 +471,46 @@ func openRouterStripAnthropicReleaseDate(modelID string) string {
 		}
 	}
 	return modelID[:dateStart-1]
+}
+
+// stripTrailingSegmentedDate strips trailing date patterns like -MM-DD or -YYYY-MM-DD.
+// Examples: "qwen3.5-plus-02-15" → "qwen3.5-plus", "model-2026-04-20" → "model"
+func stripTrailingSegmentedDate(modelID string) string {
+	// Reconstruct to find the last segment
+	parts := strings.Split(modelID, "-")
+	if len(parts) < 3 {
+		return modelID
+	}
+	tail2 := parts[len(parts)-2]
+	tail1 := parts[len(parts)-1]
+	// Try -YYYY-MM-DD first (3 trailing parts: 4 digits, 2 digits, 2 digits)
+	// Check before MM-DD to avoid partial stripping like "model-2026-04-20" → "model-2026".
+	if len(parts) >= 4 {
+		tail3 := parts[len(parts)-3]
+		if len(tail3) == 4 && len(tail2) == 2 && len(tail1) == 2 && isAllDigits(tail3) && isAllDigits(tail2) && isAllDigits(tail1) {
+			return strings.Join(parts[:len(parts)-3], "-")
+		}
+	}
+	// Try -MM-DD (2 trailing parts, both 2 digits)
+	if len(tail2) == 2 && len(tail1) == 2 && isAllDigits(tail2) && isAllDigits(tail1) {
+		return strings.Join(parts[:len(parts)-2], "-")
+	}
+	return modelID
+}
+
+func isAllDigits(s string) bool {
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// openRouterStripAnthropicReleaseDate is retained for backward compat in legacy alias detection.
+// New code should use openRouterStripDateSuffix instead.
+func openRouterStripAnthropicReleaseDate(modelID string) string {
+	return openRouterStripDateSuffix(modelID)
 }
 
 func openRouterLegacyLocalModelIDs(remoteModelID, owner, modelID string) []string {
@@ -467,14 +533,14 @@ func openRouterLegacyLocalModelIDs(remoteModelID, owner, modelID string) []strin
 	add(providerless)
 	if normalizeModelOwnerValue(owner) == "anthropic" {
 		add(strings.ReplaceAll(providerless, ".", "-"))
-		for _, aliasID := range openRouterExistingAnthropicReleaseDateAliasIDs(modelID) {
-			add(aliasID)
-		}
+	}
+	for _, aliasID := range openRouterExistingDateSuffixAliasIDs(modelID) {
+		add(aliasID)
 	}
 	return ids
 }
 
-func openRouterExistingAnthropicReleaseDateAliasIDs(modelID string) []string {
+func openRouterExistingDateSuffixAliasIDs(modelID string) []string {
 	modelID = strings.TrimSpace(modelID)
 	if modelID == "" {
 		return nil
@@ -486,11 +552,17 @@ func openRouterExistingAnthropicReleaseDateAliasIDs(modelID string) []string {
 		if aliasID == modelID || !strings.HasPrefix(aliasID, prefix) {
 			continue
 		}
-		if openRouterStripAnthropicReleaseDate(aliasID) == modelID {
+		if openRouterStripDateSuffix(aliasID) == modelID {
 			aliases = append(aliases, aliasID)
 		}
 	}
 	return aliases
+}
+
+// openRouterExistingAnthropicReleaseDateAliasIDs is retained for backward compat.
+// New code should use openRouterExistingDateSuffixAliasIDs instead.
+func openRouterExistingAnthropicReleaseDateAliasIDs(modelID string) []string {
+	return openRouterExistingDateSuffixAliasIDs(modelID)
 }
 
 func openRouterApplyModelSync(row *ModelConfigRow, model OpenRouterRemoteModel, owner string) {
@@ -531,7 +603,7 @@ func openRouterShouldSyncDescription(row ModelConfigRow) bool {
 
 func openRouterMigrateLegacyOpenRouterRow(modelID, owner string, model OpenRouterRemoteModel, legacyModelIDs []string) (bool, error) {
 	for _, legacyModelID := range legacyModelIDs {
-		if openRouterIsAnthropicReleaseDateAlias(legacyModelID, modelID) {
+		if openRouterIsDateSuffixAlias(legacyModelID, modelID) {
 			continue
 		}
 		existing, exists := GetModelConfig(legacyModelID)
@@ -553,7 +625,7 @@ func openRouterMigrateLegacyOpenRouterRow(modelID, owner string, model OpenRoute
 
 func openRouterDeleteLegacyOpenRouterRows(baseModelID string, modelIDs []string) error {
 	for _, modelID := range modelIDs {
-		if openRouterIsAnthropicReleaseDateAlias(modelID, baseModelID) {
+		if openRouterIsDateSuffixAlias(modelID, baseModelID) {
 			continue
 		}
 		existing, exists := GetModelConfig(modelID)
@@ -573,7 +645,7 @@ func openRouterSyncExistingAliasRows(baseModelID string, model OpenRouterRemoteM
 		if !exists {
 			continue
 		}
-		if existing.Source == openRouterModelSource && !openRouterIsAnthropicReleaseDateAlias(modelID, baseModelID) {
+		if existing.Source == openRouterModelSource && !openRouterIsDateSuffixAlias(modelID, baseModelID) {
 			continue
 		}
 		openRouterApplyModelSync(&existing, model, owner)
@@ -584,10 +656,125 @@ func openRouterSyncExistingAliasRows(baseModelID string, model OpenRouterRemoteM
 	return nil
 }
 
-func openRouterIsAnthropicReleaseDateAlias(modelID, baseModelID string) bool {
+func openRouterIsDateSuffixAlias(modelID, baseModelID string) bool {
 	modelID = strings.TrimSpace(modelID)
 	baseModelID = strings.TrimSpace(baseModelID)
-	return modelID != "" && baseModelID != "" && modelID != baseModelID && openRouterStripAnthropicReleaseDate(modelID) == baseModelID
+	return modelID != "" && baseModelID != "" && modelID != baseModelID && openRouterStripDateSuffix(modelID) == baseModelID
+}
+
+// openRouterIsAnthropicReleaseDateAlias is retained for backward compat.
+// New code should use openRouterIsDateSuffixAlias instead.
+func openRouterIsAnthropicReleaseDateAlias(modelID, baseModelID string) bool {
+	return openRouterIsDateSuffixAlias(modelID, baseModelID)
+}
+
+// openRouterMergeVariantGroups performs a second pass after the main sync loop.
+// It groups all remote models by their date-stripped base ID and updates existing
+// base model config rows with the highest prices and best metadata found across
+// all models that share the same base. This ensures:
+//   - When OpenRouter only returns dated/versioned variants
+//     (e.g. qwen3.5-plus-20260420), the base model (qwen3.5-plus) gets correct data.
+//   - When an exact base match AND dated variants exist in the same sync batch,
+//     the base model ends up with the highest prices from any member of the group,
+//     rather than being overwritten by the last-processed variant.
+func openRouterMergeVariantGroups(models []OpenRouterRemoteModel) error {
+	type groupEntry struct {
+		providerlessID string
+		model          OpenRouterRemoteModel
+	}
+	groups := make(map[string][]groupEntry)
+
+	for _, m := range models {
+		remoteModelID := strings.TrimSpace(m.ID)
+		if remoteModelID == "" {
+			continue
+		}
+		providerless := openRouterProviderlessModelID(remoteModelID)
+		baseID := openRouterStripDateSuffix(providerless)
+		groups[baseID] = append(groups[baseID], groupEntry{
+			providerlessID: providerless,
+			model:          m,
+		})
+	}
+
+	for baseID, entries := range groups {
+		baseModel, exists := GetModelConfig(baseID)
+		if !exists {
+			continue
+		}
+		// Skip groups with only one member — the main loop already handled it.
+		if len(entries) < 2 {
+			continue
+		}
+
+		// Aggregate: highest prices, best description, most complete modalities.
+		bestInputPrice := baseModel.InputPricePerMillion
+		bestOutputPrice := baseModel.OutputPricePerMillion
+		bestCachedPrice := baseModel.CachedPricePerMillion
+		bestModalities := struct {
+			input  []string
+			output []string
+		}{baseModel.InputModalities, baseModel.OutputModalities}
+		bestDesc := ""
+
+		for _, e := range entries {
+			price := openRouterPricePerMillion(e.model.Pricing.Prompt)
+			if price > bestInputPrice {
+				bestInputPrice = price
+			}
+			price = openRouterPricePerMillion(e.model.Pricing.Completion)
+			if price > bestOutputPrice {
+				bestOutputPrice = price
+			}
+			price = openRouterPricePerMillion(e.model.Pricing.InputCacheRead)
+			if price > bestCachedPrice {
+				bestCachedPrice = price
+			}
+			if desc := openRouterModelDescription(e.model); desc != "" && (bestDesc == "" || len(desc) > len(bestDesc)) {
+				bestDesc = desc
+			}
+			inMod, outMod := openRouterModelModalities(e.model)
+			if len(inMod) > len(bestModalities.input) {
+				bestModalities.input = inMod
+			}
+			if len(outMod) > len(bestModalities.output) {
+				bestModalities.output = outMod
+			}
+		}
+
+		// Apply the merged data back to the base model.
+		updated := false
+
+		if bestInputPrice != baseModel.InputPricePerMillion ||
+			bestOutputPrice != baseModel.OutputPricePerMillion ||
+			bestCachedPrice != baseModel.CachedPricePerMillion {
+			baseModel.PricingMode = "token"
+			baseModel.InputPricePerMillion = bestInputPrice
+			baseModel.OutputPricePerMillion = bestOutputPrice
+			baseModel.CachedPricePerMillion = bestCachedPrice
+			updated = true
+		}
+
+		if len(bestModalities.input) > len(baseModel.InputModalities) ||
+			len(bestModalities.output) > len(baseModel.OutputModalities) {
+			baseModel.InputModalities = bestModalities.input
+			baseModel.OutputModalities = bestModalities.output
+			updated = true
+		}
+
+		if bestDesc != "" && openRouterShouldSyncDescription(baseModel) {
+			baseModel.Description = bestDesc
+			updated = true
+		}
+
+		if updated {
+			if err := UpsertModelConfig(baseModel); err != nil {
+				return fmt.Errorf("merge variant group for %s: %w", baseID, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func ownerMatchesOpenRouterAliasPrefix(owner, cleanOwner string) bool {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -441,3 +441,355 @@ func TestOpenRouterPricePerMillionRoundsFloatArtifacts(t *testing.T) {
 		t.Fatalf("expected clean per-million price, got %.17g", got)
 	}
 }
+
+func TestOpenRouterStripDateSuffix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"qwen3.5-plus-20260420", "qwen3.5-plus"},
+		{"claude-3-5-haiku-20241022", "claude-3-5-haiku"},
+		{"deepseek-r1-20250101", "deepseek-r1"},
+		{"qwen3.5-plus-02-15", "qwen3.5-plus"},
+		{"model-name-12-31", "model-name"},
+		{"model-2026-04-20", "model"},
+		{"test-2025-01-01", "test"},
+		{"qwen3.5-plus", "qwen3.5-plus"},
+		{"qwen3.5-plus-thinking", "qwen3.5-plus-thinking"},
+		{"qwen3.5-max", "qwen3.5-max"},
+		{"gpt-4-turbo", "gpt-4-turbo"},
+		{"gpt-4o", "gpt-4o"},
+		{"deepseek-r1", "deepseek-r1"},
+		{"", ""},
+		{"model-v2", "model-v2"},
+		{"claude-3-5-haiku", "claude-3-5-haiku"},
+	}
+	for _, tt := range tests {
+		got := openRouterStripDateSuffix(tt.input)
+		if got != tt.expected {
+			t.Errorf("openRouterStripDateSuffix(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+// seedBaseModelForTest creates a base model with zero pricing so variant-merging
+// tests can verify that the base is updated correctly.
+func seedBaseModelForTest(t *testing.T, modelID, owner string) {
+	t.Helper()
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               modelID,
+		OwnedBy:               owner,
+		Description:           "",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0,
+		OutputPricePerMillion: 0,
+		Source:                "seed",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(%s) error = %v", modelID, err)
+	}
+}
+
+func TestSyncOpenRouterModelsQwen8DigitDateSuffixUpdatesBaseModel(t *testing.T) {
+	initModelConfigTestDB(t)
+	seedBaseModelForTest(t, "qwen3.5-plus", "qwen")
+
+	baseModel, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus to exist after seeding")
+	}
+	if baseModel.InputPricePerMillion != 0 || baseModel.OutputPricePerMillion != 0 {
+		t.Fatalf("expected seeded qwen3.5-plus to have zero pricing, got %+v", baseModel)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "qwen/qwen3.5-plus-20260420",
+			Name:        "Qwen 3.5 Plus (2026-04-20)",
+			Description: "Qwen 3.5 Plus with 8-digit date suffix",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality:         "text+image->text",
+				InputModalities:  []string{"text", "image"},
+				OutputModalities: []string{"text"},
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.00000175",
+				Completion:     "0.000014",
+				InputCacheRead: "0.000000175",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 0 || result.Updated != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	updated, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus to still exist")
+	}
+	if updated.InputPricePerMillion != 1.75 || updated.OutputPricePerMillion != 14 || updated.CachedPricePerMillion != 0.175 {
+		t.Fatalf("expected qwen3.5-plus pricing to be synced from variant, got %+v", updated)
+	}
+	if strings.Join(updated.InputModalities, ",") != "text,image" || strings.Join(updated.OutputModalities, ",") != "text" {
+		t.Fatalf("expected qwen3.5-plus modalities to be synced from variant, got input=%v output=%v",
+			updated.InputModalities, updated.OutputModalities)
+	}
+	if updated.Description != "Qwen 3.5 Plus with 8-digit date suffix" {
+		t.Fatalf("expected qwen3.5-plus description to be synced from variant, got %q", updated.Description)
+	}
+	if updated.OwnedBy != "qwen" {
+		t.Fatalf("expected qwen3.5-plus owner to be qwen, got %q", updated.OwnedBy)
+	}
+}
+
+func TestSyncOpenRouterModelsQwenSegmentedDateSuffixUpdatesBaseModel(t *testing.T) {
+	initModelConfigTestDB(t)
+	seedBaseModelForTest(t, "qwen3.5-plus", "qwen")
+
+	_, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "qwen/qwen3.5-plus-02-15",
+			Name:        "Qwen 3.5 Plus (Feb 15)",
+			Description: "Qwen 3.5 Plus with MM-DD suffix",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality: "text->text",
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000002",
+				Completion: "0.000015",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+
+	updated, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus to exist")
+	}
+	if updated.InputPricePerMillion != 2 || updated.OutputPricePerMillion != 15 {
+		t.Fatalf("expected qwen3.5-plus pricing from MM-DD variant, got %+v", updated)
+	}
+}
+
+func TestSyncOpenRouterModelsVariantGroupHighestPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	// Both variants map to the same base qwen3.5-plus. The first sync creates the
+	// base row; the merge pass aggregates the highest prices from both variants.
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "qwen/qwen3.5-plus-20260420",
+			Name:        "High price variant",
+			Description: "Qwen 3.5 Plus high price",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality: "text+image->text",
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000003",
+				Completion: "0.000020",
+			},
+		},
+		{
+			ID:          "qwen/qwen3.5-plus-02-15",
+			Name:        "Low price variant",
+			Description: "Qwen 3.5 Plus low price",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000001",
+				Completion: "0.000008",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 2 || result.Updated < 1 {
+		t.Fatalf("expected 2 seen and at least 1 updated, got %+v", result)
+	}
+
+	updated, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus to exist")
+	}
+	if updated.InputPricePerMillion != 3 {
+		t.Fatalf("expected highest input price (3), got %v", updated.InputPricePerMillion)
+	}
+	if updated.OutputPricePerMillion != 20 {
+		t.Fatalf("expected highest output price (20), got %v", updated.OutputPricePerMillion)
+	}
+}
+
+func TestSyncOpenRouterModelsVariantGroupTwoVariantsSecondHasHigherCachedPrice(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	_, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "qwen/qwen3.5-plus-20260420",
+			Description: "Qwen 3.5 Plus v1",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.000003",
+				Completion:     "0.000020",
+				InputCacheRead: "0.0000001",
+			},
+		},
+		{
+			ID:          "qwen/qwen3.5-plus-02-15",
+			Description: "Qwen 3.5 Plus v2",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.000001",
+				Completion:     "0.000008",
+				InputCacheRead: "0.0000005",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+
+	updated, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus to exist")
+	}
+	if updated.InputPricePerMillion != 3 {
+		t.Fatalf("expected input price 3 (from variant 1), got %v", updated.InputPricePerMillion)
+	}
+	if updated.OutputPricePerMillion != 20 {
+		t.Fatalf("expected output price 20 (from variant 1), got %v", updated.OutputPricePerMillion)
+	}
+	if updated.CachedPricePerMillion != 0.5 {
+		t.Fatalf("expected cached price 0.5 (from variant 2), got %v", updated.CachedPricePerMillion)
+	}
+}
+
+func TestSyncOpenRouterModelsPreservesNonDateSuffix(t *testing.T) {
+	initModelConfigTestDB(t)
+	seedBaseModelForTest(t, "qwen3.5-plus", "qwen")
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "qwen/qwen3.5-plus-thinking",
+			Description: "Qwen 3.5 Plus Thinking",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000002",
+				Completion: "0.000010",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 1 {
+		t.Fatalf("expected qwen3.5-plus-thinking to be added as new model, got %+v", result)
+	}
+	if _, ok := GetModelConfig("qwen3.5-plus-thinking"); !ok {
+		t.Fatal("expected qwen3.5-plus-thinking to exist")
+	}
+	base, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus to exist")
+	}
+	if base.InputPricePerMillion != 0 || base.OutputPricePerMillion != 0 {
+		t.Fatalf("expected qwen3.5-plus pricing to remain zero (not affected by -thinking variant), got %+v", base)
+	}
+}
+
+func TestSyncOpenRouterModelsExactBaseMatchBeforeVariant(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	// The exact-match Qwen model creates qwen3.5-plus first, then the variant
+	// overwrites. The merge pass restores the higher prices from the exact match.
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "chat/qwen3.5-plus",
+			Name:        "Qwen 3.5 Plus (exact)",
+			Description: "Exact match description",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality: "text+image->text",
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000003",
+				Completion: "0.000020",
+			},
+		},
+		{
+			ID:          "qwen/qwen3.5-plus-20260420",
+			Name:        "Qwen 3.5 Plus (dated)",
+			Description: "Lower price dated variant",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000001",
+				Completion: "0.000008",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	// First model: exact match → modelID="qwen3.5-plus" (no strip) → added=1
+	// Second model: variant → modelID="qwen3.5-plus" (stripped) → updated=1
+	if result.Seen != 2 || result.Added != 1 || result.Updated < 1 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	updated, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus to exist")
+	}
+	if updated.InputPricePerMillion != 3 || updated.OutputPricePerMillion != 20 {
+		t.Fatalf("expected highest pricing across both variants, got input=%v output=%v (expected 3, 20)",
+			updated.InputPricePerMillion, updated.OutputPricePerMillion)
+	}
+}
+
+func TestSyncOpenRouterModelsUserDescriptionNotOverwrittenByVariantMerge(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "qwen3.5-plus",
+		OwnedBy:               "custom-owner",
+		Description:           "User defined description",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  5,
+		OutputPricePerMillion: 10,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	_, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "qwen/qwen3.5-plus-20260420",
+			Description: "OpenRouter variant description",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000002",
+				Completion: "0.000015",
+			},
+		},
+		{
+			ID:          "qwen/qwen3.5-plus-02-15",
+			Description: "Another variant description",
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000003",
+				Completion: "0.000020",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+
+	model, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus to exist")
+	}
+	if model.Description != "User defined description" {
+		t.Fatalf("user description should NOT be overwritten by variant merge, got %q", model.Description)
+	}
+	if model.Source != "user" {
+		t.Fatalf("user source should be preserved, got %q", model.Source)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace Anthropic-only date suffix stripping with vendor-agnostic mechanism
- Add openRouterStripDateSuffix supporting 8-digit, full-date, and MM-DD patterns
- Add openRouterMergeVariantGroups post-sync pass for highest-price aggregation
- Add 9 new test cases covering Qwen variants, price aggregation, negative tests
- All 19 OpenRouter sync tests pass; existing Anthropic behavior unchanged

## Test plan
- [x] `go test ./internal/usage/` - full usage package passes
- [x] `go test ./internal/api/handlers/management/` - management API passes
- [x] `go build ./...` - full project builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)