### PR TITLE
fix: address code review findings for variant merge (P1, P2, P3)

### DIFF
--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -420,8 +420,8 @@ func openRouterLocalModelID(remoteModelID, owner string) string {
 	modelID := openRouterProviderlessModelID(remoteModelID)
 	if normalizeModelOwnerValue(owner) == "anthropic" {
 		modelID = strings.ReplaceAll(modelID, ".", "-")
+		modelID = openRouterStripDateSuffix(modelID)
 	}
-	modelID = openRouterStripDateSuffix(modelID)
 	return modelID
 }
 
@@ -668,6 +668,20 @@ func openRouterIsAnthropicReleaseDateAlias(modelID, baseModelID string) bool {
 	return openRouterIsDateSuffixAlias(modelID, baseModelID)
 }
 
+// openRouterCanonicalGroupID computes a unique group key for variant merging.
+// It applies the same normalizations as openRouterLocalModelID (Anthropic dot-to-dash)
+// and then strips date/version suffixes. Unlike openRouterLocalModelID, this is
+// called on raw remote IDs (with provider prefix) and always strips date suffixes
+// regardless of owner, so exact matches and date variants of the same model are
+// grouped together in the merge pass.
+func openRouterCanonicalGroupID(remoteModelID string) string {
+	providerless := openRouterProviderlessModelID(remoteModelID)
+	if normalizeModelOwnerValue(openRouterOwnerFromModelID(remoteModelID)) == "anthropic" {
+		providerless = strings.ReplaceAll(providerless, ".", "-")
+	}
+	return openRouterStripDateSuffix(providerless)
+}
+
 // openRouterMergeVariantGroups performs a second pass after the main sync loop.
 // It groups all remote models by their date-stripped base ID and updates existing
 // base model config rows with the highest prices and best metadata found across
@@ -690,7 +704,7 @@ func openRouterMergeVariantGroups(models []OpenRouterRemoteModel) error {
 			continue
 		}
 		providerless := openRouterProviderlessModelID(remoteModelID)
-		baseID := openRouterStripDateSuffix(providerless)
+		baseID := openRouterCanonicalGroupID(remoteModelID)
 		groups[baseID] = append(groups[baseID], groupEntry{
 			providerlessID: providerless,
 			model:          m,
@@ -702,11 +716,6 @@ func openRouterMergeVariantGroups(models []OpenRouterRemoteModel) error {
 		if !exists {
 			continue
 		}
-		// Skip groups with only one member — the main loop already handled it.
-		if len(entries) < 2 {
-			continue
-		}
-
 		// Aggregate: highest prices, best description, most complete modalities.
 		bestInputPrice := baseModel.InputPricePerMillion
 		bestOutputPrice := baseModel.OutputPricePerMillion
@@ -734,12 +743,8 @@ func openRouterMergeVariantGroups(models []OpenRouterRemoteModel) error {
 				bestDesc = desc
 			}
 			inMod, outMod := openRouterModelModalities(e.model)
-			if len(inMod) > len(bestModalities.input) {
-				bestModalities.input = inMod
-			}
-			if len(outMod) > len(bestModalities.output) {
-				bestModalities.output = outMod
-			}
+			bestModalities.input = unionModalities(bestModalities.input, inMod)
+			bestModalities.output = unionModalities(bestModalities.output, outMod)
 		}
 
 		// Apply the merged data back to the base model.
@@ -775,6 +780,36 @@ func openRouterMergeVariantGroups(models []OpenRouterRemoteModel) error {
 	}
 
 	return nil
+}
+
+// unionModalities returns a deduplicated union of two modality slices.
+// The order is preserved from a, with any missing entries from b appended.
+func unionModalities(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, m := range a {
+		m = strings.TrimSpace(m)
+		if m == "" {
+			continue
+		}
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		out = append(out, m)
+	}
+	for _, m := range b {
+		m = strings.TrimSpace(m)
+		if m == "" {
+			continue
+		}
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		out = append(out, m)
+	}
+	return out
 }
 
 func ownerMatchesOpenRouterAliasPrefix(owner, cleanOwner string) bool {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -522,8 +522,12 @@ func TestSyncOpenRouterModelsQwen8DigitDateSuffixUpdatesBaseModel(t *testing.T) 
 	if err != nil {
 		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
 	}
-	if result.Seen != 1 || result.Added != 0 || result.Updated != 1 || result.Skipped != 0 {
+	if result.Seen != 1 || result.Added != 1 || result.Updated != 0 || result.Skipped != 0 {
 		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	if _, ok := GetModelConfig("qwen3.5-plus-20260420"); !ok {
+		t.Fatal("expected variant qwen3.5-plus-20260420 to exist as a separate row")
 	}
 
 	updated, ok := GetModelConfig("qwen3.5-plus")
@@ -578,9 +582,10 @@ func TestSyncOpenRouterModelsQwenSegmentedDateSuffixUpdatesBaseModel(t *testing.
 
 func TestSyncOpenRouterModelsVariantGroupHighestPricing(t *testing.T) {
 	initModelConfigTestDB(t)
+	seedBaseModelForTest(t, "qwen3.5-plus", "qwen")
 
-	// Both variants map to the same base qwen3.5-plus. The first sync creates the
-	// base row; the merge pass aggregates the highest prices from both variants.
+	// Both variants are stored with their full IDs. The merge pass groups
+	// them by canonical base ID and aggregates the highest prices.
 	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
 		{
 			ID:          "qwen/qwen3.5-plus-20260420",
@@ -607,8 +612,8 @@ func TestSyncOpenRouterModelsVariantGroupHighestPricing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
 	}
-	if result.Seen != 2 || result.Updated < 1 {
-		t.Fatalf("expected 2 seen and at least 1 updated, got %+v", result)
+	if result.Seen != 2 || result.Added != 2 {
+		t.Fatalf("expected 2 seen and 2 added (one per variant), got %+v", result)
 	}
 
 	updated, ok := GetModelConfig("qwen3.5-plus")
@@ -625,6 +630,7 @@ func TestSyncOpenRouterModelsVariantGroupHighestPricing(t *testing.T) {
 
 func TestSyncOpenRouterModelsVariantGroupTwoVariantsSecondHasHigherCachedPrice(t *testing.T) {
 	initModelConfigTestDB(t)
+	seedBaseModelForTest(t, "qwen3.5-plus", "qwen")
 
 	_, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
 		{
@@ -729,8 +735,7 @@ func TestSyncOpenRouterModelsExactBaseMatchBeforeVariant(t *testing.T) {
 		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
 	}
 	// First model: exact match → modelID="qwen3.5-plus" (no strip) → added=1
-	// Second model: variant → modelID="qwen3.5-plus" (stripped) → updated=1
-	if result.Seen != 2 || result.Added != 1 || result.Updated < 1 {
+	if result.Seen != 2 || result.Added != 2 {
 		t.Fatalf("unexpected sync result: %+v", result)
 	}
 


### PR DESCRIPTION
## Summary
Fix three code review findings from PR #314:

- **P1**: Variant model IDs now stored as independent DB rows instead of being stripped. Merge pass handles base model update.
- **P2**: Shared openRouterCanonicalGroupID ensures Anthropic dot-to-dash normalization is consistent between main loop and merge pass.
- **P3**: Modalities merged as set union instead of len()-based selection.

## Test plan
- [x] `go test ./internal/usage/` — all 19 OpenRouter + 1 unit test pass
- [x] `go test ./internal/api/handlers/management/` — passes
- [x] `go build ./...` — clean build