### PR TITLE
feat: add OpenCode Go usage query config

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -141,6 +141,7 @@ func sanitizeConfigForAPI(cfg *config.Config) *config.Config {
 		copy.OpenCodeGoKey[i].APIKey = maskKey(copy.OpenCodeGoKey[i].APIKey)
 		copy.OpenCodeGoKey[i].Name = maskName(copy.OpenCodeGoKey[i].Name)
 		copy.OpenCodeGoKey[i].ProxyURL = maskBaseURL(copy.OpenCodeGoKey[i].ProxyURL)
+		copy.OpenCodeGoKey[i].AuthCookie = maskKey(copy.OpenCodeGoKey[i].AuthCookie)
 		copy.OpenCodeGoKey[i].ExcludedModels = nil
 	}
 

--- a/internal/api/handlers/management/config_basic_test.go
+++ b/internal/api/handlers/management/config_basic_test.go
@@ -126,6 +126,7 @@ func TestSanitizeConfigForAPI(t *testing.T) {
 				APIKey:         "sk-goXXXX1234000000",
 				Name:           "OpenCode Go 渠道",
 				ProxyURL:       "https://proxy.example.com/go",
+				AuthCookie:     "auth-cookie-secret",
 				ExcludedModels: []string{"minimax-m2.5"},
 			},
 		},
@@ -214,6 +215,9 @@ func TestSanitizeConfigForAPI(t *testing.T) {
 		}
 		if c.ProxyURL == "https://proxy.example.com/go" {
 			t.Error("OpenCodeGoKey: proxy-url not masked")
+		}
+		if c.AuthCookie == "auth-cookie-secret" {
+			t.Error("OpenCodeGoKey: auth-cookie not masked")
 		}
 	}
 

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1059,6 +1059,8 @@ func (h *Handler) PatchOpenCodeGoKey(c *gin.Context) {
 		Headers        *map[string]string `json:"headers"`
 		ExcludedModels *[]string          `json:"excluded-models"`
 		VisionFallback *string            `json:"vision-fallback-model"`
+		WorkspaceID    *string            `json:"workspace-id"`
+		AuthCookie     *string            `json:"auth-cookie"`
 	}
 	var body struct {
 		APIKey *string          `json:"api-key"`
@@ -1124,6 +1126,12 @@ func (h *Handler) PatchOpenCodeGoKey(c *gin.Context) {
 	}
 	if body.Value.VisionFallback != nil {
 		entry.VisionFallbackModel = strings.TrimSpace(*body.Value.VisionFallback)
+	}
+	if body.Value.WorkspaceID != nil {
+		entry.WorkspaceID = strings.TrimSpace(*body.Value.WorkspaceID)
+	}
+	if body.Value.AuthCookie != nil {
+		entry.AuthCookie = strings.TrimSpace(*body.Value.AuthCookie)
 	}
 	normalizeOpenCodeGoKey(&entry)
 	if entry.APIKey == "" {
@@ -1827,6 +1835,8 @@ func normalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+	entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
+	entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
 }
 
 func normalizedOpenCodeGoKeyEntries(entries []config.OpenCodeGoKey) []config.OpenCodeGoKey {

--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -477,10 +477,10 @@ func (h *Handler) GetConfiguredModelAvailability(c *gin.Context) {
 	activeMetadata := make([]map[string]any, 0, len(activeRows))
 	for _, row := range activeRows {
 		activeMetadata = append(activeMetadata, map[string]any{
-			"id":        row.ModelID,
-			"owned_by":  row.OwnedBy,
-			"source":    row.Source,
-			"enabled":   row.Enabled,
+			"id":       row.ModelID,
+			"owned_by": row.OwnedBy,
+			"source":   row.Source,
+			"enabled":  row.Enabled,
 		})
 	}
 

--- a/internal/api/handlers/management/opencode_go_config_test.go
+++ b/internal/api/handlers/management/opencode_go_config_test.go
@@ -21,7 +21,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	h := &Handler{cfg: &config.Config{}, configFilePath: configPath}
 
-	putBody := []byte(`[{"api-key":" go-key ","name":" primary ","prefix":" team ","headers":{"X-Test":" yes "},"vision-fallback-model":" qwen3.5-plus "}]`)
+	putBody := []byte(`[{"api-key":" go-key ","name":" primary ","prefix":" team ","headers":{"X-Test":" yes "},"vision-fallback-model":" qwen3.5-plus ","workspace-id":" wrk_123 ","auth-cookie":" auth-token "}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/opencode-go-api-key", bytes.NewReader(putBody))
@@ -29,11 +29,11 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" {
+	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v", h.cfg.OpenCodeGoKey)
 	}
 
-	patchBody := []byte(`{"index":0,"value":{"name":"secondary","excluded-models":[" minimax-m2.5 "],"vision-fallback-model":" qwen3.6-plus "}}`)
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","excluded-models":[" minimax-m2.5 "],"vision-fallback-model":" qwen3.6-plus ","workspace-id":" wrk_456 ","auth-cookie":" auth-next "}}`)
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/opencode-go-api-key", bytes.NewReader(patchBody))
@@ -41,7 +41,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.6-plus" {
+	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.6-plus" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_456" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-next" {
 		t.Fatalf("OpenCodeGoKey after PATCH = %+v", h.cfg.OpenCodeGoKey[0])
 	}
 
@@ -58,7 +58,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/api/handlers/management/opencode_go_usage.go
+++ b/internal/api/handlers/management/opencode_go_usage.go
@@ -1,0 +1,229 @@
+package management
+
+import (
+	"context"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+)
+
+var (
+	openCodeGoConsoleBaseURL = "https://opencode.ai"
+	openCodeGoUsagePattern   = regexp.MustCompile(`(?i)(Rolling|Weekly|Monthly)\s+Usage\s+([0-9]{1,3})%\s+Resets\s+in\s+`)
+	openCodeGoTagPattern     = regexp.MustCompile(`(?s)<[^>]+>`)
+	openCodeGoSpacePattern   = regexp.MustCompile(`\s+`)
+)
+
+type openCodeGoUsageItem struct {
+	Type       string `json:"type"`
+	Label      string `json:"label"`
+	Percentage int    `json:"percentage"`
+	ResetsIn   string `json:"resets_in"`
+}
+
+type openCodeGoUsageRequest struct {
+	Index       *int    `json:"index"`
+	APIKey      string  `json:"api-key"`
+	Name        string  `json:"name"`
+	WorkspaceID string  `json:"workspace-id"`
+	AuthCookie  string  `json:"auth-cookie"`
+	ProxyID     string  `json:"proxy-id"`
+	ProxyURL    string  `json:"proxy-url"`
+	TimeoutSec  float64 `json:"timeout_sec"`
+}
+
+// QueryOpenCodeGoUsage fetches the OpenCode Go dashboard page and parses usage limits.
+func (h *Handler) QueryOpenCodeGoUsage(c *gin.Context) {
+	var body openCodeGoUsageRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+
+	entry := h.findOpenCodeGoEntry(body)
+	workspaceID := strings.TrimSpace(body.WorkspaceID)
+	authCookie := strings.TrimSpace(body.AuthCookie)
+	proxyID := strings.TrimSpace(body.ProxyID)
+	proxyURL := strings.TrimSpace(body.ProxyURL)
+	if entry != nil {
+		if workspaceID == "" {
+			workspaceID = strings.TrimSpace(entry.WorkspaceID)
+		}
+		if authCookie == "" {
+			authCookie = strings.TrimSpace(entry.AuthCookie)
+		}
+		if proxyID == "" {
+			proxyID = strings.TrimSpace(entry.ProxyID)
+		}
+		if proxyURL == "" {
+			proxyURL = strings.TrimSpace(entry.ProxyURL)
+		}
+	}
+	if workspaceID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "workspace-id is required"})
+		return
+	}
+	authCookie = normalizeOpenCodeGoAuthCookie(authCookie)
+	if authCookie == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth-cookie is required"})
+		return
+	}
+
+	timeout := 20 * time.Second
+	if body.TimeoutSec > 0 {
+		timeout = time.Duration(body.TimeoutSec * float64(time.Second))
+		if timeout < 3*time.Second {
+			timeout = 3 * time.Second
+		}
+		if timeout > 60*time.Second {
+			timeout = 60 * time.Second
+		}
+	}
+
+	items, err := h.fetchOpenCodeGoUsage(c.Request.Context(), workspaceID, authCookie, proxyID, proxyURL, timeout)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"workspace_id": workspaceID,
+		"usage":        items,
+	})
+}
+
+func (h *Handler) findOpenCodeGoEntry(body openCodeGoUsageRequest) *config.OpenCodeGoKey {
+	if h == nil || h.cfg == nil {
+		return nil
+	}
+	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.OpenCodeGoKey) {
+		return &h.cfg.OpenCodeGoKey[*body.Index]
+	}
+	apiKey := strings.TrimSpace(body.APIKey)
+	if apiKey != "" {
+		for i := range h.cfg.OpenCodeGoKey {
+			if strings.TrimSpace(h.cfg.OpenCodeGoKey[i].APIKey) == apiKey {
+				return &h.cfg.OpenCodeGoKey[i]
+			}
+		}
+	}
+	name := strings.TrimSpace(body.Name)
+	if name != "" {
+		for i := range h.cfg.OpenCodeGoKey {
+			if strings.TrimSpace(h.cfg.OpenCodeGoKey[i].Name) == name {
+				return &h.cfg.OpenCodeGoKey[i]
+			}
+		}
+	}
+	return nil
+}
+
+func (h *Handler) fetchOpenCodeGoUsage(ctx context.Context, workspaceID, authCookie, proxyID, proxyURL string, timeout time.Duration) ([]openCodeGoUsageItem, error) {
+	client := util.NewHTTPClient(timeout)
+	if h != nil && h.cfg != nil {
+		if resolved := strings.TrimSpace(h.cfg.ResolveProxyURL(proxyID, proxyURL)); resolved != "" {
+			if transport := util.BuildProxyTransport(resolved, h.cfg.PreferIPv4); transport != nil {
+				client.Transport = transport
+			}
+		}
+	}
+
+	pageURL := strings.TrimRight(openCodeGoConsoleBaseURL, "/") + "/workspace/" + url.PathEscape(workspaceID) + "/go"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Cookie", "auth="+authCookie+"; oc_locale=en")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; CliRelay OpenCode Go usage checker)")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, openCodeGoUsageError("OpenCode Go usage page returned HTTP " + resp.Status)
+	}
+	items := parseOpenCodeGoUsageHTML(string(body))
+	if len(items) == 0 {
+		text := strings.ToLower(stripOpenCodeGoHTML(string(body)))
+		if strings.Contains(text, "continue with github") || strings.Contains(text, "continue with google") {
+			return nil, openCodeGoUsageError("OpenCode Go auth cookie is invalid or expired")
+		}
+		return nil, openCodeGoUsageError("OpenCode Go usage data was not found on the dashboard page")
+	}
+	return items, nil
+}
+
+type openCodeGoUsageError string
+
+func (e openCodeGoUsageError) Error() string { return string(e) }
+
+func normalizeOpenCodeGoAuthCookie(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	raw = strings.TrimPrefix(raw, "Cookie:")
+	raw = strings.TrimSpace(raw)
+	for _, part := range strings.Split(raw, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(strings.ToLower(part), "auth=") {
+			return strings.TrimSpace(part[5:])
+		}
+	}
+	if strings.Contains(raw, ";") && strings.Contains(raw, "=") {
+		return ""
+	}
+	return raw
+}
+
+func parseOpenCodeGoUsageHTML(body string) []openCodeGoUsageItem {
+	text := stripOpenCodeGoHTML(body)
+	matches := openCodeGoUsagePattern.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	items := make([]openCodeGoUsageItem, 0, len(matches))
+	for i, match := range matches {
+		if len(match) < 6 {
+			continue
+		}
+		percentage := 0
+		for _, ch := range text[match[4]:match[5]] {
+			percentage = percentage*10 + int(ch-'0')
+		}
+		resetEnd := len(text)
+		if i+1 < len(matches) {
+			resetEnd = matches[i+1][0]
+		}
+		label := strings.TrimSpace(text[match[2]:match[3]])
+		items = append(items, openCodeGoUsageItem{
+			Type:       strings.ToLower(label),
+			Label:      label,
+			Percentage: percentage,
+			ResetsIn:   strings.TrimSpace(text[match[1]:resetEnd]),
+		})
+	}
+	return items
+}
+
+func stripOpenCodeGoHTML(body string) string {
+	text := openCodeGoTagPattern.ReplaceAllString(body, " ")
+	text = html.UnescapeString(text)
+	text = openCodeGoSpacePattern.ReplaceAllString(text, " ")
+	return strings.TrimSpace(text)
+}

--- a/internal/api/handlers/management/opencode_go_usage_test.go
+++ b/internal/api/handlers/management/opencode_go_usage_test.go
@@ -1,0 +1,131 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestParseOpenCodeGoUsageHTML(t *testing.T) {
+	html := `<div data-slot="usage">
+		<div>Rolling Usage</div><span>3%</span><span>Resets in 31 minutes</span>
+		<div>Weekly Usage</div><span>1%</span><span>Resets in 5 days 16 hours</span>
+		<div>Monthly Usage</div><span>0%</span><span>Resets in 29 days 0 hours</span>
+	</div>`
+
+	items := parseOpenCodeGoUsageHTML(html)
+	if len(items) != 3 {
+		t.Fatalf("usage item count = %d, want 3: %+v", len(items), items)
+	}
+	if items[0].Type != "rolling" || items[0].Percentage != 3 || items[0].ResetsIn != "31 minutes" {
+		t.Fatalf("rolling item = %+v", items[0])
+	}
+	if items[1].Type != "weekly" || items[1].Percentage != 1 || items[1].ResetsIn != "5 days 16 hours" {
+		t.Fatalf("weekly item = %+v", items[1])
+	}
+	if items[2].Type != "monthly" || items[2].Percentage != 0 || items[2].ResetsIn != "29 days 0 hours" {
+		t.Fatalf("monthly item = %+v", items[2])
+	}
+}
+
+func TestNormalizeOpenCodeGoAuthCookie(t *testing.T) {
+	tests := map[string]string{
+		"token":                        "token",
+		" auth=abc123; oc_locale=en ":  "abc123",
+		"Cookie: foo=bar; auth=abc; z": "abc",
+		"foo=bar; session=not-an-auth": "",
+		"token=with-padding":           "token=with-padding",
+	}
+	for input, want := range tests {
+		if got := normalizeOpenCodeGoAuthCookie(input); got != want {
+			t.Fatalf("normalizeOpenCodeGoAuthCookie(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestQueryOpenCodeGoUsageFetchesDashboard(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/workspace/wrk_test/go" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Cookie"); got != "auth=token; oc_locale=en" {
+			t.Fatalf("cookie = %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<div data-slot="usage">
+			Rolling Usage <strong>12%</strong> Resets in 2 hours
+			Weekly Usage <strong>34%</strong> Resets in 4 days
+			Monthly Usage <strong>56%</strong> Resets in 20 days
+		</div>`))
+	}))
+	defer upstream.Close()
+
+	prevBaseURL := openCodeGoConsoleBaseURL
+	openCodeGoConsoleBaseURL = upstream.URL
+	defer func() { openCodeGoConsoleBaseURL = prevBaseURL }()
+
+	h := &Handler{cfg: &config.Config{
+		OpenCodeGoKey: []config.OpenCodeGoKey{{
+			APIKey:      "sk-go",
+			Name:        "OpenCode Go",
+			WorkspaceID: "wrk_test",
+			AuthCookie:  "auth=token; oc_locale=zh-CN",
+		}},
+	}}
+
+	body := []byte(`{"index":0}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/opencode-go-api-key/usage", bytes.NewReader(body))
+
+	h.QueryOpenCodeGoUsage(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var decoded struct {
+		WorkspaceID string                `json:"workspace_id"`
+		Usage       []openCodeGoUsageItem `json:"usage"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if decoded.WorkspaceID != "wrk_test" || len(decoded.Usage) != 3 || decoded.Usage[2].Percentage != 56 {
+		t.Fatalf("response = %+v", decoded)
+	}
+}
+
+func TestQueryOpenCodeGoUsageReportsExpiredCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`Continue with GitHub Continue with Google`))
+	}))
+	defer upstream.Close()
+
+	prevBaseURL := openCodeGoConsoleBaseURL
+	openCodeGoConsoleBaseURL = upstream.URL
+	defer func() { openCodeGoConsoleBaseURL = prevBaseURL }()
+
+	h := &Handler{cfg: &config.Config{}}
+	body := []byte(`{"workspace-id":"wrk_test","auth-cookie":"token"}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/opencode-go-api-key/usage", bytes.NewReader(body))
+
+	h.QueryOpenCodeGoUsage(c)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("invalid or expired")) {
+		t.Fatalf("body = %s", w.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -824,6 +824,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PUT("/opencode-go-api-key", s.mgmt.PutOpenCodeGoKeys)
 		mgmt.PATCH("/opencode-go-api-key", s.mgmt.PatchOpenCodeGoKey)
 		mgmt.DELETE("/opencode-go-api-key", s.mgmt.DeleteOpenCodeGoKey)
+		mgmt.POST("/opencode-go-api-key/usage", s.mgmt.QueryOpenCodeGoUsage)
 
 		mgmt.GET("/codex-api-key", s.mgmt.GetCodexKeys)
 		mgmt.PUT("/codex-api-key", s.mgmt.PutCodexKeys)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -734,6 +734,12 @@ type OpenCodeGoKey struct {
 
 	// VisionFallbackModel is used for image requests whose requested model lacks vision support.
 	VisionFallbackModel string `yaml:"vision-fallback-model,omitempty" json:"vision-fallback-model,omitempty"`
+
+	// WorkspaceID identifies the OpenCode workspace used for dashboard usage checks.
+	WorkspaceID string `yaml:"-" json:"workspace-id,omitempty"`
+
+	// AuthCookie stores the OpenCode dashboard auth cookie value used for usage checks.
+	AuthCookie string `yaml:"-" json:"auth-cookie,omitempty"`
 }
 
 // LoadConfig reads a YAML configuration file from the given path,
@@ -1166,6 +1172,8 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
+		entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
 		out = append(out, entry)
 	}
 	cfg.OpenCodeGoKey = out

--- a/internal/config/opencode_go_test.go
+++ b/internal/config/opencode_go_test.go
@@ -56,7 +56,7 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 			{APIKey: " "},
 			{APIKey: "go-key", Prefix: " team "},
 			{APIKey: "go-key", Prefix: "duplicate"},
-			{APIKey: "go-key-2", Headers: map[string]string{" X-Trace ": " on "}, VisionFallbackModel: " qwen3.6-plus "},
+			{APIKey: "go-key-2", Headers: map[string]string{" X-Trace ": " on "}, VisionFallbackModel: " qwen3.6-plus ", WorkspaceID: " wrk_123 ", AuthCookie: " auth-token "},
 		},
 	}
 
@@ -73,5 +73,8 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 	}
 	if cfg.OpenCodeGoKey[1].VisionFallbackModel != "qwen3.6-plus" {
 		t.Fatalf("vision fallback model = %q, want qwen3.6-plus", cfg.OpenCodeGoKey[1].VisionFallbackModel)
+	}
+	if cfg.OpenCodeGoKey[1].WorkspaceID != "wrk_123" || cfg.OpenCodeGoKey[1].AuthCookie != "auth-token" {
+		t.Fatalf("usage fields not normalized: %+v", cfg.OpenCodeGoKey[1])
 	}
 }


### PR DESCRIPTION
## Summary
- add management API support for querying OpenCode Go dashboard usage from saved workspace credentials
- persist workspace ID and dashboard auth cookie in runtime OpenCode Go provider settings without adding YAML business fields
- mask dashboard auth cookie in basic config responses and cover parsing/config behavior with tests

## Validation
- go test ./internal/config ./internal/api/handlers/management
- git diff --check HEAD~1..HEAD