### PR TITLE
fix: seed static base models for OpenRouter variant merge

### DIFF
--- a/internal/usage/model_config_db.go
+++ b/internal/usage/model_config_db.go
@@ -216,6 +216,7 @@ func defaultModelConfigRows() []ModelConfigRow {
 		"qwen",
 		"iflow",
 		"kimi",
+		"opencode-go",
 		"antigravity",
 	}
 

--- a/internal/usage/model_config_db_test.go
+++ b/internal/usage/model_config_db_test.go
@@ -48,6 +48,14 @@ func TestInitDBSeedsDefaultModelConfigs(t *testing.T) {
 	if _, ok := GetModelOwnerPreset("openai"); !ok {
 		t.Fatal("expected openai owner preset")
 	}
+
+	opencodeModel, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected opencode-go qwen3.5-plus to be seeded")
+	}
+	if opencodeModel.OwnedBy != "opencode" || opencodeModel.Source != "seed" {
+		t.Fatalf("unexpected opencode-go seed model config: %+v", opencodeModel)
+	}
 }
 
 func TestUpsertModelConfigAndPerCallCost(t *testing.T) {

--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -682,6 +683,33 @@ func openRouterCanonicalGroupID(remoteModelID string) string {
 	return openRouterStripDateSuffix(providerless)
 }
 
+func openRouterStaticBaseModelRow(modelID string) (ModelConfigRow, bool) {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return ModelConfigRow{}, false
+	}
+	info := registry.LookupStaticModelInfo(modelID)
+	if info == nil {
+		return ModelConfigRow{}, false
+	}
+	ownedBy := normalizeModelOwnerValue(info.OwnedBy)
+	if ownedBy == "" {
+		ownedBy = normalizeModelOwnerValue(info.Type)
+	}
+	description := strings.TrimSpace(info.Description)
+	if description == "" {
+		description = strings.TrimSpace(info.DisplayName)
+	}
+	return ModelConfigRow{
+		ModelID:     modelID,
+		OwnedBy:     ownedBy,
+		Description: description,
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "seed",
+	}, true
+}
+
 // openRouterMergeVariantGroups performs a second pass after the main sync loop.
 // It groups all remote models by their date-stripped base ID and updates existing
 // base model config rows with the highest prices and best metadata found across
@@ -714,7 +742,11 @@ func openRouterMergeVariantGroups(models []OpenRouterRemoteModel) error {
 	for baseID, entries := range groups {
 		baseModel, exists := GetModelConfig(baseID)
 		if !exists {
-			continue
+			var ok bool
+			baseModel, ok = openRouterStaticBaseModelRow(baseID)
+			if !ok {
+				continue
+			}
 		}
 		// Aggregate: highest prices, best description, most complete modalities.
 		bestInputPrice := baseModel.InputPricePerMillion

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -564,6 +564,68 @@ func TestSyncOpenRouterModelsQwen8DigitDateSuffixUpdatesBaseModel(t *testing.T) 
 	}
 }
 
+func TestSyncOpenRouterModelsCreatesKnownStaticBaseModelWhenMissing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if _, ok := GetModelConfig("qwen3.5-plus"); !ok {
+		t.Fatal("expected qwen3.5-plus to be seeded before missing-base simulation")
+	}
+	if err := DeleteModelConfig("qwen3.5-plus"); err != nil {
+		t.Fatalf("DeleteModelConfig(qwen3.5-plus) error = %v", err)
+	}
+	if _, ok := GetModelConfig("qwen3.5-plus"); ok {
+		t.Fatal("expected qwen3.5-plus to be absent before OpenRouter sync")
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "qwen/qwen3.5-plus-20260420",
+			Name:        "Qwen 3.5 Plus (2026-04-20)",
+			Description: "Qwen 3.5 Plus OpenRouter variant",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality: "text+image->text",
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.0000003",
+				Completion:     "0.0000018",
+				InputCacheRead: "0",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	variant, ok := GetModelConfig("qwen3.5-plus-20260420")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus-20260420 variant row to exist")
+	}
+	if variant.InputPricePerMillion != 0.3 || variant.OutputPricePerMillion != 1.8 {
+		t.Fatalf("unexpected variant pricing: %+v", variant)
+	}
+
+	base, ok := GetModelConfig("qwen3.5-plus")
+	if !ok {
+		t.Fatal("expected qwen3.5-plus base row to be recreated from static model metadata")
+	}
+	if base.Source != "seed" || base.OwnedBy != "opencode" {
+		t.Fatalf("expected recreated base to keep static seed metadata, got %+v", base)
+	}
+	if base.InputPricePerMillion != 0.3 || base.OutputPricePerMillion != 1.8 {
+		t.Fatalf("expected recreated base pricing from variant, got %+v", base)
+	}
+	if strings.Join(base.InputModalities, ",") != "text,image" || strings.Join(base.OutputModalities, ",") != "text" {
+		t.Fatalf("expected recreated base modalities from variant, got input=%v output=%v",
+			base.InputModalities, base.OutputModalities)
+	}
+	if cost := CalculateCost("qwen3.5-plus", 1_000_000, 1_000_000, 0); cost != 2.1 {
+		t.Fatalf("expected CalculateCost(recreated base) = 2.1, got %v", cost)
+	}
+}
+
 func TestSyncOpenRouterModelsQwenSegmentedDateSuffixUpdatesBaseModel(t *testing.T) {
 	initModelConfigTestDB(t)
 	seedBaseModelForTest(t, "qwen3.5-plus", "qwen")
@@ -749,8 +811,9 @@ func TestSyncOpenRouterModelsExactBaseMatchBeforeVariant(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
 	}
-	// First model: exact match → modelID="qwen3.5-plus" (no strip) → added=1
-	if result.Seen != 2 || result.Added != 2 {
+	// qwen3.5-plus is a seeded OpenCode Go model, so the exact match updates
+	// the base row and the dated variant is added as a separate OpenRouter row.
+	if result.Seen != 2 || result.Added != 1 || result.Updated != 1 {
 		t.Fatalf("unexpected sync result: %+v", result)
 	}
 
@@ -813,7 +876,6 @@ func TestSyncOpenRouterModelsUserDescriptionNotOverwrittenByVariantMerge(t *test
 		t.Fatalf("user source should be preserved, got %q", model.Source)
 	}
 }
-
 
 func TestSyncOpenRouterModelsAnthropicDottedExactFirstThenDatedVariant(t *testing.T) {
 	initModelConfigTestDB(t)


### PR DESCRIPTION
## Summary
- include OpenCode Go static models in database-backed model config seeding
- let OpenRouter variant merge create a known static base row when the base config is missing
- add regression coverage for qwen3.5-plus base pricing when only dated OpenRouter variants are synced

## Verification
- go test ./internal/usage
- go test ./internal/api/handlers/management
- go build ./...
- git diff --check