### PR TITLE
fix: validate OpenCode Go usage workspace input

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1835,7 +1835,11 @@ func normalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
-	entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
+	if workspaceID, err := normalizeOpenCodeGoWorkspaceID(entry.WorkspaceID); err == nil {
+		entry.WorkspaceID = workspaceID
+	} else {
+		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
+	}
 	entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
 }
 

--- a/internal/api/handlers/management/opencode_go_config_test.go
+++ b/internal/api/handlers/management/opencode_go_config_test.go
@@ -33,7 +33,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v", h.cfg.OpenCodeGoKey)
 	}
 
-	patchBody := []byte(`{"index":0,"value":{"name":"secondary","excluded-models":[" minimax-m2.5 "],"vision-fallback-model":" qwen3.6-plus ","workspace-id":" wrk_456 ","auth-cookie":" auth-next "}}`)
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","excluded-models":[" minimax-m2.5 "],"vision-fallback-model":" qwen3.6-plus ","workspace-id":" https://opencode.ai/workspace/wrk_456/go ","auth-cookie":" auth-next "}}`)
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/opencode-go-api-key", bytes.NewReader(patchBody))

--- a/internal/api/handlers/management/opencode_go_usage.go
+++ b/internal/api/handlers/management/opencode_go_usage.go
@@ -16,11 +16,14 @@ import (
 )
 
 var (
-	openCodeGoConsoleBaseURL = "https://opencode.ai"
-	openCodeGoUsagePattern   = regexp.MustCompile(`(?i)(Rolling|Weekly|Monthly)\s+Usage\s+([0-9]{1,3})%\s+Resets\s+in\s+`)
-	openCodeGoTagPattern     = regexp.MustCompile(`(?s)<[^>]+>`)
-	openCodeGoSpacePattern   = regexp.MustCompile(`\s+`)
+	openCodeGoConsoleBaseURL  = "https://opencode.ai"
+	openCodeGoUsagePattern    = regexp.MustCompile(`(?i)(Rolling|Weekly|Monthly)\s+Usage\s+([0-9]{1,3})%\s+Resets\s+in\s+`)
+	openCodeGoServerIDPattern = regexp.MustCompile(`(?i)^[a-f0-9]{64}$`)
+	openCodeGoTagPattern      = regexp.MustCompile(`(?s)<[^>]+>`)
+	openCodeGoSpacePattern    = regexp.MustCompile(`\s+`)
 )
+
+const openCodeGoWorkspaceIDHint = "OpenCode Go workspace-id must be the /workspace/{id}/go URL segment from the dashboard address bar, usually starting with wrk_; workspace names like Default and server id hashes are not valid"
 
 type openCodeGoUsageItem struct {
 	Type       string `json:"type"`
@@ -49,13 +52,13 @@ func (h *Handler) QueryOpenCodeGoUsage(c *gin.Context) {
 	}
 
 	entry := h.findOpenCodeGoEntry(body)
-	workspaceID := strings.TrimSpace(body.WorkspaceID)
+	workspaceID, workspaceErr := normalizeOpenCodeGoWorkspaceID(body.WorkspaceID)
 	authCookie := strings.TrimSpace(body.AuthCookie)
 	proxyID := strings.TrimSpace(body.ProxyID)
 	proxyURL := strings.TrimSpace(body.ProxyURL)
 	if entry != nil {
 		if workspaceID == "" {
-			workspaceID = strings.TrimSpace(entry.WorkspaceID)
+			workspaceID, workspaceErr = normalizeOpenCodeGoWorkspaceID(entry.WorkspaceID)
 		}
 		if authCookie == "" {
 			authCookie = strings.TrimSpace(entry.AuthCookie)
@@ -69,6 +72,10 @@ func (h *Handler) QueryOpenCodeGoUsage(c *gin.Context) {
 	}
 	if workspaceID == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "workspace-id is required"})
+		return
+	}
+	if workspaceErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": workspaceErr.Error()})
 		return
 	}
 	authCookie = normalizeOpenCodeGoAuthCookie(authCookie)
@@ -177,7 +184,9 @@ func normalizeOpenCodeGoAuthCookie(raw string) string {
 	if raw == "" {
 		return ""
 	}
-	raw = strings.TrimPrefix(raw, "Cookie:")
+	if strings.HasPrefix(strings.ToLower(raw), "cookie:") {
+		raw = strings.TrimSpace(raw[len("cookie:"):])
+	}
 	raw = strings.TrimSpace(raw)
 	for _, part := range strings.Split(raw, ";") {
 		part = strings.TrimSpace(part)
@@ -189,6 +198,49 @@ func normalizeOpenCodeGoAuthCookie(raw string) string {
 		return ""
 	}
 	return raw
+}
+
+func normalizeOpenCodeGoWorkspaceID(raw string) (string, error) {
+	raw = strings.Trim(strings.TrimSpace(raw), `"'`)
+	if raw == "" {
+		return "", nil
+	}
+	if id := extractOpenCodeGoWorkspaceID(raw); id != "" {
+		return id, nil
+	}
+	trimmed := strings.Trim(raw, "/")
+	if strings.EqualFold(trimmed, "default") || openCodeGoServerIDPattern.MatchString(trimmed) {
+		return trimmed, openCodeGoUsageError(openCodeGoWorkspaceIDHint)
+	}
+	return trimmed, nil
+}
+
+func extractOpenCodeGoWorkspaceID(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Path != "" {
+		if id := extractOpenCodeGoWorkspaceIDFromPath(parsed.Path); id != "" {
+			return id
+		}
+	}
+	return extractOpenCodeGoWorkspaceIDFromPath(raw)
+}
+
+func extractOpenCodeGoWorkspaceIDFromPath(path string) string {
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if part != "workspace" || i+1 >= len(parts) {
+			continue
+		}
+		id := strings.TrimSpace(parts[i+1])
+		if id == "" {
+			continue
+		}
+		if unescaped, err := url.PathUnescape(id); err == nil {
+			id = unescaped
+		}
+		return strings.TrimSpace(id)
+	}
+	return ""
 }
 
 func parseOpenCodeGoUsageHTML(body string) []openCodeGoUsageItem {

--- a/internal/api/handlers/management/opencode_go_usage_test.go
+++ b/internal/api/handlers/management/opencode_go_usage_test.go
@@ -38,12 +38,43 @@ func TestNormalizeOpenCodeGoAuthCookie(t *testing.T) {
 		"token":                        "token",
 		" auth=abc123; oc_locale=en ":  "abc123",
 		"Cookie: foo=bar; auth=abc; z": "abc",
+		"cookie: auth=lowercase":       "lowercase",
 		"foo=bar; session=not-an-auth": "",
 		"token=with-padding":           "token=with-padding",
 	}
 	for input, want := range tests {
 		if got := normalizeOpenCodeGoAuthCookie(input); got != want {
 			t.Fatalf("normalizeOpenCodeGoAuthCookie(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestNormalizeOpenCodeGoWorkspaceID(t *testing.T) {
+	tests := map[string]string{
+		"wrk_123": "wrk_123",
+		" https://opencode.ai/workspace/wrk_123/go ":  "wrk_123",
+		"/workspace/wrk_456/go":                       "wrk_456",
+		"https://opencode.ai/workspace/wrk_789/usage": "wrk_789",
+	}
+	for input, want := range tests {
+		got, err := normalizeOpenCodeGoWorkspaceID(input)
+		if err != nil {
+			t.Fatalf("normalizeOpenCodeGoWorkspaceID(%q) error: %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("normalizeOpenCodeGoWorkspaceID(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestNormalizeOpenCodeGoWorkspaceIDRejectsNamesAndServerIDs(t *testing.T) {
+	tests := []string{
+		"Default",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	for _, input := range tests {
+		if _, err := normalizeOpenCodeGoWorkspaceID(input); err == nil {
+			t.Fatalf("normalizeOpenCodeGoWorkspaceID(%q) error = nil, want validation error", input)
 		}
 	}
 }
@@ -99,6 +130,55 @@ func TestQueryOpenCodeGoUsageFetchesDashboard(t *testing.T) {
 	}
 	if decoded.WorkspaceID != "wrk_test" || len(decoded.Usage) != 3 || decoded.Usage[2].Percentage != 56 {
 		t.Fatalf("response = %+v", decoded)
+	}
+}
+
+func TestQueryOpenCodeGoUsageAcceptsDashboardURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/workspace/wrk_test/go" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`Rolling Usage 1% Resets in 1 hour Weekly Usage 2% Resets in 2 days Monthly Usage 3% Resets in 3 days`))
+	}))
+	defer upstream.Close()
+
+	prevBaseURL := openCodeGoConsoleBaseURL
+	openCodeGoConsoleBaseURL = upstream.URL
+	defer func() { openCodeGoConsoleBaseURL = prevBaseURL }()
+
+	h := &Handler{cfg: &config.Config{}}
+	body := []byte(`{"workspace-id":"https://opencode.ai/workspace/wrk_test/go","auth-cookie":"token"}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/opencode-go-api-key/usage", bytes.NewReader(body))
+
+	h.QueryOpenCodeGoUsage(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`"workspace_id":"wrk_test"`)) {
+		t.Fatalf("body = %s", w.Body.String())
+	}
+}
+
+func TestQueryOpenCodeGoUsageRejectsWorkspaceName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{cfg: &config.Config{}}
+	body := []byte(`{"workspace-id":"Default","auth-cookie":"token"}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/opencode-go-api-key/usage", bytes.NewReader(body))
+
+	h.QueryOpenCodeGoUsage(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("/workspace/{id}/go")) {
+		t.Fatalf("body = %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize OpenCode Go dashboard URLs into workspace IDs before querying usage
- return a clear validation error for workspace names or server id hashes instead of reporting an expired cookie
- accept case-insensitive Cookie headers and normalize saved dashboard URL inputs

## Validation
- go test ./internal/api/handlers/management
- git diff --check HEAD~1..HEAD