### PR TITLE
fix: parse OpenCode Go hydrated usage data

### DIFF
--- a/internal/api/handlers/management/opencode_go_usage.go
+++ b/internal/api/handlers/management/opencode_go_usage.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"html"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,8 +18,14 @@ import (
 )
 
 var (
-	openCodeGoConsoleBaseURL  = "https://opencode.ai"
-	openCodeGoUsagePattern    = regexp.MustCompile(`(?i)(Rolling|Weekly|Monthly)\s+Usage\s+([0-9]{1,3})%\s+Resets\s+in\s+`)
+	openCodeGoConsoleBaseURL = "https://opencode.ai"
+	openCodeGoUsagePattern   = regexp.MustCompile(`(?i)(Rolling|Weekly|Monthly)\s+Usage\s+([0-9]{1,3})%\s+Resets\s+in\s+`)
+	openCodeGoNumberPattern  = `(-?\d+(?:\.\d+)?)`
+	openCodeGoUsageWindows   = []openCodeGoUsageWindowPattern{
+		{usageType: "rolling", label: "Rolling", pctFirst: regexp.MustCompile(`rollingUsage:\$R\[\d+\]=\{[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*\}`), resetFirst: regexp.MustCompile(`rollingUsage:\$R\[\d+\]=\{[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*\}`)},
+		{usageType: "weekly", label: "Weekly", pctFirst: regexp.MustCompile(`weeklyUsage:\$R\[\d+\]=\{[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*\}`), resetFirst: regexp.MustCompile(`weeklyUsage:\$R\[\d+\]=\{[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*\}`)},
+		{usageType: "monthly", label: "Monthly", pctFirst: regexp.MustCompile(`monthlyUsage:\$R\[\d+\]=\{[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*\}`), resetFirst: regexp.MustCompile(`monthlyUsage:\$R\[\d+\]=\{[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*\}`)},
+	}
 	openCodeGoServerIDPattern = regexp.MustCompile(`(?i)^[a-f0-9]{64}$`)
 	openCodeGoTagPattern      = regexp.MustCompile(`(?s)<[^>]+>`)
 	openCodeGoSpacePattern    = regexp.MustCompile(`\s+`)
@@ -30,6 +38,13 @@ type openCodeGoUsageItem struct {
 	Label      string `json:"label"`
 	Percentage int    `json:"percentage"`
 	ResetsIn   string `json:"resets_in"`
+}
+
+type openCodeGoUsageWindowPattern struct {
+	usageType  string
+	label      string
+	pctFirst   *regexp.Regexp
+	resetFirst *regexp.Regexp
 }
 
 type openCodeGoUsageRequest struct {
@@ -244,6 +259,9 @@ func extractOpenCodeGoWorkspaceIDFromPath(path string) string {
 }
 
 func parseOpenCodeGoUsageHTML(body string) []openCodeGoUsageItem {
+	if items := parseOpenCodeGoHydrationUsage(body); len(items) > 0 {
+		return items
+	}
 	text := stripOpenCodeGoHTML(body)
 	matches := openCodeGoUsagePattern.FindAllStringSubmatchIndex(text, -1)
 	if len(matches) == 0 {
@@ -271,6 +289,89 @@ func parseOpenCodeGoUsageHTML(body string) []openCodeGoUsageItem {
 		})
 	}
 	return items
+}
+
+func parseOpenCodeGoHydrationUsage(body string) []openCodeGoUsageItem {
+	items := make([]openCodeGoUsageItem, 0, len(openCodeGoUsageWindows))
+	for _, window := range openCodeGoUsageWindows {
+		percentage, resetInSec, ok := parseOpenCodeGoHydrationWindow(body, window)
+		if !ok {
+			continue
+		}
+		items = append(items, openCodeGoUsageItem{
+			Type:       window.usageType,
+			Label:      window.label,
+			Percentage: percentage,
+			ResetsIn:   formatOpenCodeGoResetIn(resetInSec),
+		})
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	return items
+}
+
+func parseOpenCodeGoHydrationWindow(body string, window openCodeGoUsageWindowPattern) (int, int64, bool) {
+	if match := window.pctFirst.FindStringSubmatch(body); len(match) == 3 {
+		percentage, resetInSec, ok := parseOpenCodeGoHydrationNumbers(match[1], match[2])
+		return percentage, resetInSec, ok
+	}
+	if match := window.resetFirst.FindStringSubmatch(body); len(match) == 3 {
+		percentage, resetInSec, ok := parseOpenCodeGoHydrationNumbers(match[2], match[1])
+		return percentage, resetInSec, ok
+	}
+	return 0, 0, false
+}
+
+func parseOpenCodeGoHydrationNumbers(usagePercentRaw, resetInSecRaw string) (int, int64, bool) {
+	usagePercent, err := strconv.ParseFloat(usagePercentRaw, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	resetInSec, err := strconv.ParseFloat(resetInSecRaw, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	if usagePercent < 0 {
+		usagePercent = 0
+	}
+	if resetInSec < 0 {
+		resetInSec = 0
+	}
+	return int(math.Round(usagePercent)), int64(math.Round(resetInSec)), true
+}
+
+func formatOpenCodeGoResetIn(seconds int64) string {
+	duration := time.Duration(seconds) * time.Second
+	days := int(duration / (24 * time.Hour))
+	duration -= time.Duration(days) * 24 * time.Hour
+	hours := int(duration / time.Hour)
+	duration -= time.Duration(hours) * time.Hour
+	minutes := int(duration / time.Minute)
+	if days > 0 {
+		if hours > 0 {
+			return formatOpenCodeGoDurationPart(days, "day") + " " + formatOpenCodeGoDurationPart(hours, "hour")
+		}
+		return formatOpenCodeGoDurationPart(days, "day")
+	}
+	if hours > 0 {
+		if minutes > 0 {
+			return formatOpenCodeGoDurationPart(hours, "hour") + " " + formatOpenCodeGoDurationPart(minutes, "minute")
+		}
+		return formatOpenCodeGoDurationPart(hours, "hour")
+	}
+	if minutes > 0 {
+		return formatOpenCodeGoDurationPart(minutes, "minute")
+	}
+	return formatOpenCodeGoDurationPart(int(seconds), "second")
+}
+
+func formatOpenCodeGoDurationPart(value int, unit string) string {
+	suffix := unit
+	if value != 1 {
+		suffix += "s"
+	}
+	return strconv.Itoa(value) + " " + suffix
 }
 
 func stripOpenCodeGoHTML(body string) string {

--- a/internal/api/handlers/management/opencode_go_usage_test.go
+++ b/internal/api/handlers/management/opencode_go_usage_test.go
@@ -33,6 +33,28 @@ func TestParseOpenCodeGoUsageHTML(t *testing.T) {
 	}
 }
 
+func TestParseOpenCodeGoUsageHydrationHTML(t *testing.T) {
+	html := `<script>
+		rollingUsage:$R[1]={usagePercent:12.4,resetInSec:3720}
+		weeklyUsage:$R[2]={resetInSec:432000,usagePercent:34}
+		monthlyUsage:$R[3]={usagePercent:56,resetInSec:2505600}
+	</script>`
+
+	items := parseOpenCodeGoUsageHTML(html)
+	if len(items) != 3 {
+		t.Fatalf("usage item count = %d, want 3: %+v", len(items), items)
+	}
+	if items[0].Type != "rolling" || items[0].Percentage != 12 || items[0].ResetsIn != "1 hour 2 minutes" {
+		t.Fatalf("rolling item = %+v", items[0])
+	}
+	if items[1].Type != "weekly" || items[1].Percentage != 34 || items[1].ResetsIn != "5 days" {
+		t.Fatalf("weekly item = %+v", items[1])
+	}
+	if items[2].Type != "monthly" || items[2].Percentage != 56 || items[2].ResetsIn != "29 days" {
+		t.Fatalf("monthly item = %+v", items[2])
+	}
+}
+
 func TestNormalizeOpenCodeGoAuthCookie(t *testing.T) {
 	tests := map[string]string{
 		"token":                        "token",
@@ -129,6 +151,47 @@ func TestQueryOpenCodeGoUsageFetchesDashboard(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 	if decoded.WorkspaceID != "wrk_test" || len(decoded.Usage) != 3 || decoded.Usage[2].Percentage != 56 {
+		t.Fatalf("response = %+v", decoded)
+	}
+}
+
+func TestQueryOpenCodeGoUsageFetchesHydrationDashboard(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/workspace/wrk_test/go" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><script>
+			rollingUsage:$R[10]={usagePercent:7,resetInSec:120}
+			weeklyUsage:$R[11]={resetInSec:3600,usagePercent:8}
+			monthlyUsage:$R[12]={usagePercent:9,resetInSec:86400}
+		</script></html>`))
+	}))
+	defer upstream.Close()
+
+	prevBaseURL := openCodeGoConsoleBaseURL
+	openCodeGoConsoleBaseURL = upstream.URL
+	defer func() { openCodeGoConsoleBaseURL = prevBaseURL }()
+
+	h := &Handler{cfg: &config.Config{}}
+	body := []byte(`{"workspace-id":"wrk_test","auth-cookie":"token"}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/opencode-go-api-key/usage", bytes.NewReader(body))
+
+	h.QueryOpenCodeGoUsage(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var decoded struct {
+		Usage []openCodeGoUsageItem `json:"usage"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(decoded.Usage) != 3 || decoded.Usage[0].Percentage != 7 || decoded.Usage[2].ResetsIn != "1 day" {
 		t.Fatalf("response = %+v", decoded)
 	}
 }


### PR DESCRIPTION
## Summary
- parse OpenCode Go SolidJS hydration usage windows in addition to visible dashboard text
- support both usagePercent-first and resetInSec-first field order for rolling, weekly, and monthly usage
- format reset seconds into the existing resets_in response text

## Validation
- go test -count=1 ./internal/api/handlers/management
- real dashboard smoke check with provided temporary credentials confirmed rolling, weekly, and monthly hydration values are present and parseable
- git diff --check