### PR TITLE
fix: strip trailing [...] context window markers from model names

### DIFF
--- a/internal/thinking/suffix.go
+++ b/internal/thinking/suffix.go
@@ -9,6 +9,69 @@ import (
 	"strings"
 )
 
+// isContextWindowSuffix checks whether the content is a known context-window
+// marker suffix (digits optionally followed by k/m for KB/MB scale).
+// Valid examples: "1M", "128K", "32k", "4096". Invalid: "beta", "preview", "".
+func isContextWindowSuffix(content string) bool {
+	if content == "" {
+		return false
+	}
+	// Must start with at least one digit
+	i := 0
+	for i < len(content) && content[i] >= '0' && content[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return false
+	}
+	// Optionally followed by a k/m scale suffix (case-insensitive)
+	if i < len(content) {
+		switch content[i] {
+		case 'k', 'K', 'm', 'M':
+			i++
+		default:
+			return false
+		}
+	}
+	return i == len(content)
+}
+
+// StripBracketSuffix strips trailing [...] content from a model name
+// when the content matches a known context-window marker pattern.
+//
+// Some clients append context window markers (e.g., "[1M]", "[128K]") to the
+// model name. These markers should be stripped before model identification
+// and are never treated as thinking suffixes. Non-matching bracket content
+// (e.g., "[beta]", "[preview]") is preserved to avoid corrupting valid
+// custom or provider model IDs.
+//
+// Examples:
+//   - "deepseek-v4-flash[1M]" -> "deepseek-v4-flash"
+//   - "model[128K]" -> "model"
+//   - "model[beta]" -> "model[beta]" (unchanged, not a known marker)
+//   - "model" -> "model" (unchanged)
+//   - "model[1M](high)" -> "model(high)" (only trailing bracket stripped)
+func StripBracketSuffix(model string) string {
+	lastOpen := strings.LastIndex(model, "[")
+	if lastOpen == -1 {
+		return model
+	}
+	if !strings.HasSuffix(model, "]") {
+		return model
+	}
+	// Only strip if there's content between brackets
+	if lastOpen+1 >= len(model)-1 {
+		return model
+	}
+	// Only strip known context-window markers to avoid corrupting
+	// valid model IDs that legitimately end with brackets
+	content := model[lastOpen+1 : len(model)-1]
+	if !isContextWindowSuffix(content) {
+		return model
+	}
+	return model[:lastOpen]
+}
+
 // ParseSuffix extracts thinking suffix from a model name.
 //
 // The suffix format is: model-name(value)
@@ -16,11 +79,19 @@ import (
 //   - "claude-sonnet-4-5(16384)" -> ModelName="claude-sonnet-4-5", RawSuffix="16384"
 //   - "gpt-5.2(high)" -> ModelName="gpt-5.2", RawSuffix="high"
 //   - "gemini-2.5-pro" -> ModelName="gemini-2.5-pro", HasSuffix=false
+//   - "deepseek-v4-flash[1M]" -> ModelName="deepseek-v4-flash", HasSuffix=false
+//   - "model[128K](8192)" -> ModelName="model", RawSuffix="8192"
+//   - "model[1M](8192)" -> ModelName="model", RawSuffix="8192" (two-pass strip)
 //
-// This function only extracts the suffix; it does not validate or interpret
-// the suffix content. Use ParseNumericSuffix, ParseLevelSuffix, etc. for
-// content interpretation.
+// Trailing [...] context window markers (digits + optional k/m) are stripped
+// before and after round bracket parsing. Non-marker bracket content is
+// preserved as part of the model name.
 func ParseSuffix(model string) SuffixResult {
+	// Strip trailing [...] bracket suffix (e.g., "[1M]", "[128K]") before
+	// looking for round bracket thinking suffix. These are context window
+	// markers appended by some clients and must not affect model identification.
+	model = StripBracketSuffix(model)
+
 	// Find the last opening parenthesis
 	lastOpen := strings.LastIndex(model, "(")
 	if lastOpen == -1 {
@@ -35,6 +106,10 @@ func ParseSuffix(model string) SuffixResult {
 	// Extract components
 	modelName := model[:lastOpen]
 	rawSuffix := model[lastOpen+1 : len(model)-1]
+
+	// Strip trailing [...] from the extracted model name too, in case
+	// a bracket marker precedes the thinking suffix (e.g., "model[1M](8192)").
+	modelName = StripBracketSuffix(modelName)
 
 	return SuffixResult{
 		ModelName: modelName,

--- a/internal/thinking/suffix_test.go
+++ b/internal/thinking/suffix_test.go
@@ -1,0 +1,148 @@
+package thinking
+
+import (
+	"testing"
+)
+
+func TestStripBracketSuffix(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bracket 1M suffix", "deepseek-v4-flash[1M]", "deepseek-v4-flash"},
+		{"bracket 128K suffix", "model[128K]", "model"},
+		{"bracket 32k lowercase", "model[32k]", "model"},
+		{"bracket 4096 digits only", "model[4096]", "model"},
+		{"bracket 1m lowercase m", "model[1m]", "model"},
+		{"no bracket", "gemini-2.5-pro", "gemini-2.5-pro"},
+		{"empty string", "", ""},
+		{"bracket with thinking suffix", "model[1M](8192)", "model[1M](8192)"},
+		{"thinking suffix only", "model(8192)", "model(8192)"},
+		{"non-marker beta preserved", "model[beta]", "model[beta]"},
+		{"non-marker preview preserved", "model[preview]", "model[preview]"},
+		{"mixed: marker then non-marker", "model[1M][test]", "model[1M][test]"},
+		{"no closing bracket", "model[1M", "model[1M"},
+		{"no opening bracket", "model]", "model]"},
+		{"empty brackets", "model[]", "model[]"},
+		{"bracket at start", "[1M]model", "[1M]model"},
+		{"text after bracket", "model[1M]extra", "model[1M]extra"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripBracketSuffix(tt.input)
+			if got != tt.want {
+				t.Errorf("StripBracketSuffix(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSuffix_BracketSuffix(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantModelName  string
+		wantHasSuffix  bool
+		wantRawSuffix  string
+	}{
+		{
+			name:          "deepseek-v4-flash with 1M bracket",
+			input:         "deepseek-v4-flash[1M]",
+			wantModelName: "deepseek-v4-flash",
+			wantHasSuffix: false,
+			wantRawSuffix: "",
+		},
+		{
+			name:          "model with 128K bracket",
+			input:         "claude-sonnet-4-5[128K]",
+			wantModelName: "claude-sonnet-4-5",
+			wantHasSuffix: false,
+			wantRawSuffix: "",
+		},
+		{
+			name:          "bracket before thinking suffix",
+			input:         "model[1M](8192)",
+			wantModelName: "model",
+			wantHasSuffix: true,
+			wantRawSuffix: "8192",
+		},
+		{
+			name:          "thinking suffix then bracket",
+			input:         "model(8192)[1M]",
+			wantModelName: "model",
+			wantHasSuffix: true,
+			wantRawSuffix: "8192",
+		},
+		{
+			name:          "round bracket suffix unchanged",
+			input:         "gemini-2.5-pro(8192)",
+			wantModelName: "gemini-2.5-pro",
+			wantHasSuffix: true,
+			wantRawSuffix: "8192",
+		},
+		{
+			name:          "level suffix unchanged",
+			input:         "gpt-5.2(high)",
+			wantModelName: "gpt-5.2",
+			wantHasSuffix: true,
+			wantRawSuffix: "high",
+		},
+		{
+			name:          "no suffix unchanged",
+			input:         "claude-sonnet-4-5",
+			wantModelName: "claude-sonnet-4-5",
+			wantHasSuffix: false,
+			wantRawSuffix: "",
+		},
+		{
+			name:          "special suffix none",
+			input:         "gemini-2.5-flash(none)",
+			wantModelName: "gemini-2.5-flash",
+			wantHasSuffix: true,
+			wantRawSuffix: "none",
+		},
+		{
+			name:          "special suffix auto",
+			input:         "claude-sonnet-4-5(auto)",
+			wantModelName: "claude-sonnet-4-5",
+			wantHasSuffix: true,
+			wantRawSuffix: "auto",
+		},
+		{
+			name:          "non-marker bracket preserved",
+			input:         "custom-model[beta]",
+			wantModelName: "custom-model[beta]",
+			wantHasSuffix: false,
+			wantRawSuffix: "",
+		},
+		{
+			name:          "non-marker bracket with thinking suffix preserved",
+			input:         "custom-model[beta](8192)",
+			wantModelName: "custom-model[beta]",
+			wantHasSuffix: true,
+			wantRawSuffix: "8192",
+		},
+		{
+			name:          "bracket with trailing whitespace",
+			input:         " model[1M]",
+			wantModelName: " model",
+			wantHasSuffix: false,
+			wantRawSuffix: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseSuffix(tt.input)
+			if result.ModelName != tt.wantModelName {
+				t.Errorf("ParseSuffix(%q).ModelName = %q, want %q", tt.input, result.ModelName, tt.wantModelName)
+			}
+			if result.HasSuffix != tt.wantHasSuffix {
+				t.Errorf("ParseSuffix(%q).HasSuffix = %v, want %v", tt.input, result.HasSuffix, tt.wantHasSuffix)
+			}
+			if result.RawSuffix != tt.wantRawSuffix {
+				t.Errorf("ParseSuffix(%q).RawSuffix = %q, want %q", tt.input, result.RawSuffix, tt.wantRawSuffix)
+			}
+		})
+	}
+}

--- a/internal/thinking/types.go
+++ b/internal/thinking/types.go
@@ -78,12 +78,18 @@ type ThinkingConfig struct {
 //
 // A thinking suffix is specified in the format model-name(value), where value
 // can be a numeric budget (e.g., "16384") or a level name (e.g., "high").
+//
+// Trailing [...] context window markers (e.g., "[1M]", "[128K]") are stripped
+// from ModelName before thinking suffix parsing. These markers do not set
+// HasSuffix and have no RawSuffix value.
 type SuffixResult struct {
-	// ModelName is the model name with the suffix removed.
-	// If no suffix was found, this equals the original input.
+	// ModelName is the model name with any trailing [...] marker and/or
+	// (thinking-suffix) removed. If no suffix or marker was found, this
+	// equals the original input (with trailing [...] stripped if present).
 	ModelName string
 
-	// HasSuffix indicates whether a valid suffix was found.
+	// HasSuffix indicates whether a valid (thinking-suffix) was found.
+	// Trailing [...] markers do not set HasSuffix.
 	HasSuffix bool
 
 	// RawSuffix is the content inside the parentheses, without the parentheses.

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -1045,6 +1045,16 @@ func (h *BaseAPIHandler) getRequestDetails(ctx context.Context, modelName string
 		return nil, "", &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("unknown provider for model %s", modelName)}
 	}
 
+	// Reconstruct the returned model name from parsed result to ensure trailing
+	// [...] context window markers (e.g., "[1M]", "[128K]") are stripped, even
+	// when they appear before a thinking suffix (e.g., "model[1M](8192)").
+	// Round bracket thinking suffixes are preserved for existing thinking config.
+	if parsed.HasSuffix {
+		resolvedModelName = parsed.ModelName + "(" + parsed.RawSuffix + ")"
+	} else {
+		resolvedModelName = parsed.ModelName
+	}
+
 	// The thinking suffix is preserved in the model name itself, so no
 	// metadata-based configuration passing is needed.
 	return providers, resolvedModelName, nil

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -29,12 +29,19 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 	modelRegistry.RegisterClient("test-request-details-claude", "claude", []*registry.ModelInfo{
 		{ID: "claude-sonnet-4-5", Created: now + 5},
 	})
+	modelRegistry.RegisterClient("test-request-details-opencode-go", "opencode-go", []*registry.ModelInfo{
+		{ID: "deepseek-v4-flash", Created: now + 10},
+	})
+	modelRegistry.RegisterClient("test-request-details-custom", "openai", []*registry.ModelInfo{
+		{ID: "custom-model[beta]", Created: now + 15},
+	})
 
 	// Ensure cleanup of all test registrations.
 	clientIDs := []string{
 		"test-request-details-gemini",
 		"test-request-details-openai",
 		"test-request-details-claude",
+		"test-request-details-opencode-go",
 	}
 	for _, clientID := range clientIDs {
 		id := clientID
@@ -92,6 +99,41 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 			inputModel:    "gemini-2.5-flash(none)",
 			wantProviders: []string{"gemini"},
 			wantModel:     "gemini-2.5-flash(none)",
+			wantErr:       false,
+		},
+		{
+			name:          "bracket suffix 1M stripped for provider lookup",
+			inputModel:    "deepseek-v4-flash[1M]",
+			wantProviders: []string{"opencode-go"},
+			wantModel:     "deepseek-v4-flash",
+			wantErr:       false,
+		},
+		{
+			name:          "bracket suffix 128K stripped",
+			inputModel:    "deepseek-v4-flash[128K]",
+			wantProviders: []string{"opencode-go"},
+			wantModel:     "deepseek-v4-flash",
+			wantErr:       false,
+		},
+		{
+			name:          "bracket suffix unknown model",
+			inputModel:    "unknown-model[1M]",
+			wantProviders: nil,
+			wantModel:     "",
+			wantErr:       true,
+		},
+		{
+			name:          "bracket suffix preserved round bracket thinking suffix",
+			inputModel:    "deepseek-v4-flash[1M](8192)",
+			wantProviders: []string{"opencode-go"},
+			wantModel:     "deepseek-v4-flash(8192)",
+			wantErr:       false,
+		},
+		{
+			name:          "custom model with bracket suffix preserved",
+			inputModel:    "custom-model[beta]",
+			wantProviders: []string{"openai"},
+			wantModel:     "custom-model[beta]",
 			wantErr:       false,
 		},
 		{


### PR DESCRIPTION
Strip trailing bracket context window markers (e.g. [1M], [128K]) from model names before model identification. Non-marker bracket content like [beta] is preserved to avoid corrupting valid custom model IDs.