### PR TITLE
fix: add public usage summary endpoint for CC Switch integration

### DIFF
--- a/internal/api/handlers/management/usage_summary_public.go
+++ b/internal/api/handlers/management/usage_summary_public.go
@@ -1,0 +1,72 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+type usageSummaryResponse struct {
+	Found bool           `json:"found"`
+	Range string         `json:"range"`
+	Stats usageStatsBody `json:"stats"`
+}
+
+type usageStatsBody struct {
+	TotalCalls int64   `json:"total_calls"`
+	QuotaCost  float64 `json:"quota_cost"`
+}
+
+// GetPublicUsageSummary returns today's call count and quota cost for an API key.
+// This is a lightweight endpoint designed for CC Switch Provider card polling.
+func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
+	apiKey := ""
+	var req publicLookupRequest
+
+	if c.Request.Method == http.MethodPost {
+		body, err := bodyutil.ReadRequestBody(c, publicLookupBodyLimit)
+		if err != nil {
+			if bodyutil.IsTooLarge(err) {
+				c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
+				return
+			}
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
+			return
+		}
+		if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
+			if err := json.Unmarshal(body, &req); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json body"})
+				return
+			}
+		}
+		apiKey = strings.TrimSpace(req.APIKey)
+	}
+
+	if apiKey == "" {
+		apiKey = strings.TrimSpace(c.Query("api_key"))
+	}
+	if apiKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+		return
+	}
+
+	stats, err := usage.QueryStats(usage.LogQueryParams{APIKey: apiKey, Days: 1})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query usage summary"})
+		return
+	}
+
+	resp := usageSummaryResponse{
+		Found: stats.Total > 0,
+		Range: "today",
+		Stats: usageStatsBody{
+			TotalCalls: stats.Total,
+			QuotaCost:  stats.TotalCost,
+		},
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/internal/api/handlers/management/usage_summary_public_test.go
+++ b/internal/api/handlers/management/usage_summary_public_test.go
@@ -1,0 +1,155 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func setupUsageSummaryTestDB(t *testing.T) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "usage-summary-*.db")
+	if err != nil {
+		t.Fatalf("create temp db: %v", err)
+	}
+	dbPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+}
+
+func insertTestLog(t *testing.T, apiKey string) {
+	t.Helper()
+	usage.InsertLog(apiKey, "test", "gpt-4", "test", "chan", "idx", false, time.Now(), 100, 50,
+		usage.TokenStats{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+		"", "",
+	)
+}
+
+func TestGetPublicUsageSummary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupUsageSummaryTestDB(t)
+
+	const (
+		keyWithData    = "sk-test-key-with-usage"
+		keyWithoutData = "sk-test-key-empty"
+	)
+
+	insertTestLog(t, keyWithData)
+	insertTestLog(t, keyWithData)
+
+	t.Run("returns today stats for key with usage", func(t *testing.T) {
+		body := []byte(`{"api_key":"` + keyWithData + `"}`)
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage/summary", bytes.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+
+		h := NewHandler(&config.Config{}, "", nil)
+		h.GetPublicUsageSummary(ctx)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+		}
+
+		var got struct {
+			Found bool   `json:"found"`
+			Range string `json:"range"`
+			Stats struct {
+				TotalCalls int64   `json:"total_calls"`
+				QuotaCost  float64 `json:"quota_cost"`
+			} `json:"stats"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !got.Found {
+			t.Errorf("found = false, want true")
+		}
+		if got.Range != "today" {
+			t.Errorf("range = %q, want %q", got.Range, "today")
+		}
+		if got.Stats.TotalCalls != 2 {
+			t.Errorf("total_calls = %d, want 2", got.Stats.TotalCalls)
+		}
+		if got.Stats.QuotaCost < 0 {
+			t.Errorf("quota_cost = %f, want >= 0", got.Stats.QuotaCost)
+		}
+	})
+
+	t.Run("returns found=false for key without usage", func(t *testing.T) {
+		body := []byte(`{"api_key":"` + keyWithoutData + `"}`)
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage/summary", bytes.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+
+		h := NewHandler(&config.Config{}, "", nil)
+		h.GetPublicUsageSummary(ctx)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+		}
+
+		var got struct {
+			Found bool   `json:"found"`
+			Range string `json:"range"`
+			Stats struct {
+				TotalCalls int64   `json:"total_calls"`
+				QuotaCost  float64 `json:"quota_cost"`
+			} `json:"stats"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Found {
+			t.Errorf("found = true, want false")
+		}
+		if got.Stats.TotalCalls != 0 {
+			t.Errorf("total_calls = %d, want 0", got.Stats.TotalCalls)
+		}
+	})
+
+	t.Run("returns 400 for empty api_key", func(t *testing.T) {
+		body := []byte(`{}`)
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage/summary", bytes.NewReader(body))
+
+		h := NewHandler(&config.Config{}, "", nil)
+		h.GetPublicUsageSummary(ctx)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("returns 400 for missing body", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage/summary", nil)
+
+		h := NewHandler(&config.Config{}, "", nil)
+		h.GetPublicUsageSummary(ctx)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+		}
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -890,6 +890,7 @@ func (s *Server) registerManagementRoutes() {
 		pub.POST("/usage/logs/:id/content", s.mgmt.GetPublicLogContent)
 		pub.GET("/usage/chart-data", s.mgmt.GetPublicUsageChartData)
 		pub.POST("/usage/chart-data", s.mgmt.GetPublicUsageChartData)
+			pub.POST("/usage/summary", s.mgmt.GetPublicUsageSummary)
 	}
 }
 


### PR DESCRIPTION
## Summary
- New POST /v0/management/public/usage/summary endpoint
- Returns today's total_calls and quota_cost for an API key
- Lightweight contract for CC Switch Provider card polling