### PR TITLE
fix: populate text field in done events during Claude→Responses streaming

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -222,14 +222,17 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			done := `{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`
 			done, _ = sjson.Set(done, "sequence_number", nextSeq())
 			done, _ = sjson.Set(done, "item_id", st.CurrentMsgID)
+			done, _ = sjson.Set(done, "text", st.TextBuf.String())
 			out = append(out, emitEvent("response.output_text.done", done))
 			partDone := `{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`
 			partDone, _ = sjson.Set(partDone, "sequence_number", nextSeq())
 			partDone, _ = sjson.Set(partDone, "item_id", st.CurrentMsgID)
+			partDone, _ = sjson.Set(partDone, "part.text", st.TextBuf.String())
 			out = append(out, emitEvent("response.content_part.done", partDone))
 			final := `{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","text":""}],"role":"assistant"}}`
 			final, _ = sjson.Set(final, "sequence_number", nextSeq())
 			final, _ = sjson.Set(final, "item.id", st.CurrentMsgID)
+			final, _ = sjson.Set(final, "item.content.0.text", st.TextBuf.String())
 			out = append(out, emitEvent("response.output_item.done", final))
 			st.InTextBlock = false
 		} else if st.InFuncBlock {


### PR DESCRIPTION
## Summary

The `content_block_stop` handler for text blocks in the Claude → OpenAI Responses streaming translator emitted empty `text` fields in three done events, even though `st.TextBuf` had correctly accumulated the full content via delta events.

This caused clients like **Codex Desktop** to briefly display streamed text (via `response.output_text.delta`) and then immediately clear it when processing the done events with empty text.

## Changes

Added three `sjson.Set` calls to populate the accumulated text from `st.TextBuf.String()` into:

1. `response.output_text.done` → `"text"` field
2. `response.content_part.done` → `"part.text"` field
3. `response.output_item.done` → `"item.content.0.text"` field

## Testing

Verified with streaming curl request against a Claude-compatible endpoint (Zhipu GLM via Anthropic protocol). Before fix, all three done events had `text: ""`. After fix, they correctly contain the full accumulated text. Codex Desktop no longer clears messages after display.

Closes #325