### PR TITLE
fix: add A3 vision processing and Phase 2 session follow-up for OpenCodeGo

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -94,6 +94,25 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	fallback := e.applyVisionFallback(auth, req, opts)
 	req = fallback.Request
 
+	// A3: If the current turn still has images and no vision fallback was applied,
+	// use the analyzer to generate text summaries. This prevents base64 image data
+	// from being sent to a text-only model that cannot process it.
+	if !fallback.Applied && vision.CurrentTurnHasImages(req.Payload) {
+		baseModel := thinking.ParseSuffix(req.Model).ModelName
+		if !opencodeGoSupportsNativeVision(baseModel) {
+			analyzer := e.newAnalyzer(auth)
+			if analyzer != nil {
+				a3Processor := vision.NewProcessor(analyzer)
+				a3Payload, a3Err := a3Processor.A3ProcessCurrentTurn(ctx, req.Payload, sessionKey, 0)
+				if a3Err == nil {
+					req.Payload = a3Payload
+				}
+			} else {
+				req.Payload, _ = vision.ReplaceCurrentTurnImages(req.Payload, "[Image Registry] 无可用的图片分析模型，无法生成图片摘要。")
+			}
+		}
+	}
+
 	// Inject cached reasoning_content for models that need it (e.g., DeepSeek thinking mode).
 	sessionID := opencodeGoSessionID(opts, auth)
 	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
@@ -152,6 +171,25 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 	// vision model for direct image analysis.
 	fallback := e.applyVisionFallback(auth, req, opts)
 	req = fallback.Request
+
+	// A3: If the current turn still has images and no vision fallback was applied,
+	// use the analyzer to generate text summaries.
+	if !fallback.Applied && vision.CurrentTurnHasImages(req.Payload) {
+		baseModel := thinking.ParseSuffix(req.Model).ModelName
+		if !opencodeGoSupportsNativeVision(baseModel) {
+			analyzer := e.newAnalyzer(auth)
+			if analyzer != nil {
+				a3Processor := vision.NewProcessor(analyzer)
+				a3Payload, a3Err := a3Processor.A3ProcessCurrentTurn(ctx, req.Payload, sessionKey, 0)
+				if a3Err == nil {
+					req.Payload = a3Payload
+				}
+			} else {
+				req.Payload, _ = vision.ReplaceCurrentTurnImages(req.Payload, "[Image Registry] 无可用的图片分析模型，无法生成图片摘要。")
+			}
+		}
+	}
+
 	sessionID := opencodeGoSessionID(opts, auth)
 	if opencodeGoNeedsReasoningInjection(req.Model) && sessionID != "" {
 		req.Payload = opencodeGoInjectReasoningContentIntoPayload(req.Payload, req.Model, sessionID)
@@ -907,11 +945,79 @@ func (e *OpenCodeGoExecutor) requestLog(url string, req *http.Request, body []by
 
 func (e *OpenCodeGoExecutor) newAnalyzer(auth *cliproxyauth.Auth) *vision.OpenCodeGoAnalyzer {
 	apiKey := opencodeGoAPIKey(auth)
-	model := opencodeGoVisionFallbackModel(e.cfg, auth)
-	if model == "" {
-		model = "qwen3.5-plus"
+	model, ok := opencodeGoResolveAnalyzerModel(e.cfg, auth)
+	if !ok || model == "" {
+		return nil
 	}
 	return vision.NewOpenCodeGoAnalyzer(opencodeGoBaseURL, apiKey, model)
+}
+
+// opencodeGoResolveAnalyzerModel determines the model to use for the image
+// analyzer, respecting excluded_models from both auth attributes and config.
+// Returns (model, false) when no usable analyzer model is available.
+func opencodeGoResolveAnalyzerModel(cfg *config.Config, auth *cliproxyauth.Auth) (string, bool) {
+	model := opencodeGoVisionFallbackModel(cfg, auth)
+	if model != "" {
+		return model, true
+	}
+	// Check why the fallback model is empty:
+	if opencodeGoFallbackIsConfigured(cfg, auth) {
+		// Fallback was configured but excluded -- don't default to anything
+		return "", false
+	}
+	// No fallback configured -- use default if not excluded
+	defaultModel := "qwen3.5-plus"
+	if opencodeGoModelIsExcluded(defaultModel, cfg, auth) {
+		return "", false
+	}
+	return defaultModel, true
+}
+
+// opencodeGoFallbackIsConfigured returns true when a fallback model name
+// exists in config or auth attributes (regardless of exclusion).
+func opencodeGoFallbackIsConfigured(cfg *config.Config, auth *cliproxyauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.Attributes != nil {
+		if strings.TrimSpace(auth.Attributes["vision_fallback_model"]) != "" {
+			return true
+		}
+	}
+	if cfg == nil {
+		return false
+	}
+	apiKey := opencodeGoAPIKey(auth)
+	if apiKey == "" {
+		return false
+	}
+	for i := range cfg.OpenCodeGoKey {
+		if strings.EqualFold(strings.TrimSpace(cfg.OpenCodeGoKey[i].APIKey), apiKey) {
+			return strings.TrimSpace(cfg.OpenCodeGoKey[i].VisionFallbackModel) != ""
+		}
+	}
+	return false
+}
+
+// opencodeGoModelIsExcluded checks if a model is excluded by either auth
+// attribute excluded_models or config ExcludedModels for this API key.
+func opencodeGoModelIsExcluded(model string, cfg *config.Config, auth *cliproxyauth.Auth) bool {
+	if auth != nil && auth.Attributes != nil {
+		if opencodeGoModelExcluded(model, auth.Attributes["excluded_models"]) {
+			return true
+		}
+	}
+	apiKey := opencodeGoAPIKey(auth)
+	if apiKey == "" || cfg == nil {
+		return false
+	}
+	for i := range cfg.OpenCodeGoKey {
+		if strings.EqualFold(strings.TrimSpace(cfg.OpenCodeGoKey[i].APIKey), apiKey) {
+			excluded := strings.Join(cfg.OpenCodeGoKey[i].ExcludedModels, ",")
+			return opencodeGoModelExcluded(model, excluded)
+		}
+	}
+	return false
 }
 
 func opencodeGoStripOrphanedToolCalls(payload []byte) []byte {

--- a/internal/vision/analyzer.go
+++ b/internal/vision/analyzer.go
@@ -15,12 +15,16 @@ import (
 
 // AnalyzeRequest carries all context needed for image analysis.
 type AnalyzeRequest struct {
-	ImageData  string       // base64 data from current request
-	MIMEType   string       // "image/png", "image/jpeg", etc.
-	Existing   ImageSummary // previously accumulated summary (empty on first analysis)
+	Model      string       // target model for analysis (empty = analyzer default)
+	SessionKey SessionKey   // session key for registry tracking
 	Query      string       // user's current question (empty on first analysis)
-	IsFollowUp bool         // true if this is a follow-up analysis
+	Existing   ImageSummary // previously accumulated summary (empty on first analysis)
+	ImageData  string       // base64 data from current request
+	ImageURL   string       // remote URL if not inline
+	MIMEType   string       // "image/png", "image/jpeg", etc.
 	SourceKind ImageSourceKind
+	TurnIndex  int          // conversation turn index
+	IsFollowUp bool         // true if this is a follow-up analysis
 }
 
 // AnalyzeResponse contains the analysis result.
@@ -69,7 +73,11 @@ func (a *OpenCodeGoAnalyzer) Analyze(ctx context.Context, req AnalyzeRequest) (A
 		prompt = a.buildInitialPrompt()
 	}
 
-	body := a.buildRequestBody(prompt, req.ImageData, req.MIMEType)
+	model := a.model
+	if req.Model != "" {
+		model = req.Model
+	}
+	body := a.buildRequestBody(model, prompt, req.ImageData, req.MIMEType)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		a.baseURL+"/chat/completions", bytes.NewReader(body))
@@ -129,7 +137,7 @@ Look at the original image again. Provide ONLY new or supplementary information 
 	)
 }
 
-func (a *OpenCodeGoAnalyzer) buildRequestBody(prompt, imageData, mimeType string) []byte {
+func (a *OpenCodeGoAnalyzer) buildRequestBody(model, prompt, imageData, mimeType string) []byte {
 	var mime string
 	switch {
 	case strings.Contains(mimeType, "png"):
@@ -147,7 +155,7 @@ func (a *OpenCodeGoAnalyzer) buildRequestBody(prompt, imageData, mimeType string
 	dataURL := "data:" + mime + ";base64," + imageData
 
 	body := map[string]any{
-		"model": a.model,
+		"model": model,
 		"messages": []map[string]any{
 			{
 				"role":    "system",

--- a/internal/vision/processor.go
+++ b/internal/vision/processor.go
@@ -2,6 +2,9 @@ package vision
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -37,10 +40,6 @@ func (p *Processor) Process(ctx context.Context, payload []byte, sessionKey Sess
 	result := &ProcessResult{Payload: payload}
 
 	walk := WalkPayload(payload)
-	if len(walk.Parts) == 0 {
-		return result, nil
-	}
-	result.ImagesFound = len(walk.Parts)
 
 	hasSession := sessionKey != ""
 	var sessionStore *SessionStore
@@ -48,75 +47,43 @@ func (p *Processor) Process(ctx context.Context, payload []byte, sessionKey Sess
 		sessionStore = p.registry.GetOrCreateSession(sessionKey)
 		sessionStore.ResetReachability()
 	}
-	ephemeralEntries := make(map[ImageHash]*ImageEntry)
-	ephemeralNextOrdinal := 0
 
-	// Separate current-turn from historical images
-	var currentParts, historicalParts []ImagePart
-	for _, part := range walk.Parts {
-		if part.IsCurrent {
-			currentParts = append(currentParts, part)
-		} else {
-			historicalParts = append(historicalParts, part)
-		}
-	}
+	// ── Phase 1: Payload image update & cleanup ──
+	// Handles current-turn image recording and historical-image placeholder replacement.
+	// Only runs when the current payload actually contains image parts.
+	if len(walk.Parts) > 0 {
+		result.ImagesFound = len(walk.Parts)
 
-	result.HasNewImages = len(currentParts) > 0
-	result.HistoricalOnly = len(currentParts) == 0 && len(historicalParts) > 0
+		ephemeralEntries := make(map[ImageHash]*ImageEntry)
+		ephemeralNextOrdinal := 0
 
-	// Record current-turn images in registry (don't replace them)
-	for _, part := range currentParts {
-		data, _ := ExtractImageData(&part)
-		if data == "" {
-			continue
-		}
-		if sessionStore == nil {
-			continue
-		}
-		hash := ComputeHash(data)
-		if sessionStore.GetEntry(hash) == nil {
-			ordinal := sessionStore.NextOrdinal()
-			sessionStore.GetOrCreateEntry(hash, ordinal, p.maxEntries)
-		}
-		sessionStore.UpdateEntry(hash, func(e *ImageEntry) {
-			e.SourceKind = ImageSourceUserUpload
-			if e.FirstSeenTurn == 0 {
-				e.FirstSeenTurn = turnIndex
+		// Separate current-turn from historical images
+		var currentParts, historicalParts []ImagePart
+		for _, part := range walk.Parts {
+			if part.IsCurrent {
+				currentParts = append(currentParts, part)
+			} else {
+				historicalParts = append(historicalParts, part)
 			}
-			e.LastSeenTurn = turnIndex
-			e.CurrentPayloadReachable = true
-			e.Availability = ImageAvailableInline
-			e.Occurrences = append(e.Occurrences, ImageOccurrence{
-				TurnIndex:  turnIndex,
-				MessageIdx: part.MsgIdx,
-				PartIdx:    part.PartIdx,
-			})
-		})
-	}
-
-	// Determine the array type for content type decisions
-	arrayType := detectArrayType(payload) // "messages" → "text", "input" → "input_text"
-
-	// Build a map of hash → image data for re-analysis (extract BEFORE replacement)
-	imageDataByHash := make(map[ImageHash]ImageDataInfo)
-	for _, part := range historicalParts {
-		data, mime := ExtractImageData(&part)
-		if data == "" {
-			continue
 		}
-		hash := ComputeHash(data)
-		imageDataByHash[hash] = ImageDataInfo{Data: data, MIMEType: mime}
-	}
 
-	// Replace historical images with placeholders
-	for _, part := range historicalParts {
-		data, _ := ExtractImageData(&part)
-		if data == "" {
-			continue
-		}
-		hash := ComputeHash(data)
-		entry := p.findOrCreateEntry(sessionStore, hash, turnIndex, ephemeralEntries, &ephemeralNextOrdinal)
-		if sessionStore != nil {
+		result.HasNewImages = len(currentParts) > 0
+		result.HistoricalOnly = len(currentParts) == 0 && len(historicalParts) > 0
+
+		// Record current-turn images in registry (don't replace them)
+		for _, part := range currentParts {
+			data, _ := ExtractImageData(&part)
+			if data == "" {
+				continue
+			}
+			if sessionStore == nil {
+				continue
+			}
+			hash := ComputeHash(data)
+			if sessionStore.GetEntry(hash) == nil {
+				ordinal := sessionStore.NextOrdinal()
+				sessionStore.GetOrCreateEntry(hash, ordinal, p.maxEntries)
+			}
 			sessionStore.UpdateEntry(hash, func(e *ImageEntry) {
 				e.SourceKind = ImageSourceUserUpload
 				if e.FirstSeenTurn == 0 {
@@ -132,38 +99,123 @@ func (p *Processor) Process(ctx context.Context, payload []byte, sessionKey Sess
 				})
 			})
 		}
-		placeholder := BuildShortPlaceholder(entry)
 
-		var err error
-		result.Payload, err = ReplaceImagePartEx(result.Payload, part, placeholder, arrayType)
-		if err != nil {
-			log.Warnf("vision: replace image part: %v", err)
+		// Determine the array type for content type decisions
+		arrayType := detectArrayType(payload) // "messages" → "text", "input" → "input_text"
+
+		// Build a map of hash → image data for re-analysis (extract BEFORE replacement)
+		imageDataByHash := make(map[ImageHash]ImageDataInfo)
+		for _, part := range historicalParts {
+			data, mime := ExtractImageData(&part)
+			if data == "" {
+				continue
+			}
+			hash := ComputeHash(data)
+			imageDataByHash[hash] = ImageDataInfo{Data: data, MIMEType: mime}
 		}
-	}
 
-	// Detect intent and generate registry note
-	if sessionStore != nil && len(historicalParts) > 0 {
-		lastMsg := extractLastUserText(result.Payload)
-		entries := sessionStore.AllEntries()
-		refNum := ExtractImageReference(lastMsg)
+		// Replace historical images with placeholders
+		for _, part := range historicalParts {
+			data, _ := ExtractImageData(&part)
+			if data == "" {
+				continue
+			}
+			hash := ComputeHash(data)
+			entry := p.findOrCreateEntry(sessionStore, hash, turnIndex, ephemeralEntries, &ephemeralNextOrdinal)
+			if sessionStore != nil {
+				sessionStore.UpdateEntry(hash, func(e *ImageEntry) {
+					e.SourceKind = ImageSourceUserUpload
+					if e.FirstSeenTurn == 0 {
+						e.FirstSeenTurn = turnIndex
+					}
+					e.LastSeenTurn = turnIndex
+					e.CurrentPayloadReachable = true
+					e.Availability = ImageAvailableInline
+					e.Occurrences = append(e.Occurrences, ImageOccurrence{
+						TurnIndex:  turnIndex,
+						MessageIdx: part.MsgIdx,
+						PartIdx:    part.PartIdx,
+					})
+				})
+			}
+			placeholder := BuildShortPlaceholder(entry)
 
-		if refNum > 0 {
-			p.handleReAnalysis(ctx, sessionStore, refNum, lastMsg, imageDataByHash, result)
-		} else {
-			intent := DetectIntent(lastMsg, len(entries))
-			switch intent {
-			case IntentFollowUp:
-				result.RegistryNote = BuildRegistryNote(entries, 0)
-			case IntentAmbiguous:
-				result.RegistryNote = BuildAmbiguityNote(entries)
+			var err error
+			result.Payload, err = ReplaceImagePartEx(result.Payload, part, placeholder, arrayType)
+			if err != nil {
+				log.Warnf("vision: replace image part: %v", err)
 			}
 		}
 
-		if result.RegistryNote != "" {
-			var err error
-			result.Payload, err = InjectRegistryNoteEx(result.Payload, result.RegistryNote, arrayType)
-			if err != nil {
-				log.Warnf("vision: inject registry note: %v", err)
+		// Detect intent and generate registry note for historical parts in payload
+		if sessionStore != nil && len(historicalParts) > 0 {
+			lastMsg := extractLastUserText(result.Payload)
+			entries := sessionStore.AllEntries()
+			refNum := ExtractImageReference(lastMsg)
+
+			if refNum > 0 {
+				p.handleReAnalysis(ctx, sessionStore, sessionKey, refNum, lastMsg, imageDataByHash, result)
+			} else {
+				intent := DetectIntent(lastMsg, len(entries))
+				switch intent {
+				case IntentFollowUp:
+					result.RegistryNote = BuildRegistryNote(entries, 0)
+				case IntentAmbiguous:
+					result.RegistryNote = BuildAmbiguityNote(entries)
+				}
+			}
+
+			if result.RegistryNote != "" {
+				var err error
+				result.Payload, err = InjectRegistryNoteEx(result.Payload, result.RegistryNote, arrayType)
+				if err != nil {
+					log.Warnf("vision: inject registry note: %v", err)
+				}
+			}
+		}
+	}
+
+	// ── Phase 2: Session follow-up injection ──
+	// Fires when the current payload has no image parts at all (pure text follow-up),
+	// but the session store has cached image entries from previous turns.
+	// This phase enables "what was in Image #1?" style questions without requiring
+	// the client to resend original images.
+	if len(walk.Parts) == 0 && sessionStore != nil {
+		entries := sessionStore.AllEntries()
+		if len(entries) > 0 {
+			lastMsg := extractLastUserText(result.Payload)
+			refNum := ExtractImageReference(lastMsg)
+
+			if refNum > 0 {
+				// Explicit reference to a numbered image.
+				// No image data available (no parts in payload), so only cached summary.
+				var target *ImageEntry
+				for _, e := range entries {
+					if e.StableOrdinal == refNum {
+						target = e
+						break
+					}
+				}
+				if target != nil {
+					result.RegistryNote = BuildRegistryNote([]*ImageEntry{target}, refNum)
+				}
+			} else {
+				intent := DetectIntent(lastMsg, len(entries))
+				switch intent {
+				case IntentFollowUp:
+					result.RegistryNote = BuildRegistryNote(entries, 0)
+				case IntentAmbiguous:
+					result.RegistryNote = BuildAmbiguityNote(entries)
+				}
+			}
+
+			if result.RegistryNote != "" {
+				arrayType := detectArrayType(result.Payload)
+				var err error
+				result.Payload, err = InjectRegistryNoteEx(result.Payload, result.RegistryNote, arrayType)
+				if err != nil {
+					log.Warnf("vision: inject registry note: %v", err)
+				}
 			}
 		}
 	}
@@ -207,7 +259,7 @@ func (p *Processor) findOrCreateEntry(sessionStore *SessionStore, hash ImageHash
 	return entry
 }
 
-func (p *Processor) handleReAnalysis(ctx context.Context, sessionStore *SessionStore, targetOrdinal int, query string, imageDataByHash map[ImageHash]ImageDataInfo, result *ProcessResult) {
+func (p *Processor) handleReAnalysis(ctx context.Context, sessionStore *SessionStore, sessionKey SessionKey, targetOrdinal int, query string, imageDataByHash map[ImageHash]ImageDataInfo, result *ProcessResult) {
 	entries := sessionStore.AllEntries()
 	var target *ImageEntry
 	for _, e := range entries {
@@ -226,18 +278,29 @@ func (p *Processor) handleReAnalysis(ctx context.Context, sessionStore *SessionS
 		return
 	}
 
-	req := AnalyzeRequest{
-		Existing:   target.Summary,
-		Query:      query,
-		IsFollowUp: target.Summary.Summary != "",
-		SourceKind: target.SourceKind,
-		ImageData:  imgInfo.Data,
-		MIMEType:   imgInfo.MIMEType,
-	}
-
-	resp, err := p.analyzer.Analyze(ctx, req)
+	// Singleflight: deduplicate concurrent analyzer calls for same
+	// session+image+query across streaming/non-streaming paths and retries.
+	// Key includes sessionKey to prevent cross-session sharing.
+	sfKey := fmt.Sprintf("analyze:%s:%s:%s", sessionKey, target.Hash, queryFingerprint(query))
+	sfResult, err, _ := p.registry.sfGroup.Do(sfKey, func() (any, error) {
+		req := AnalyzeRequest{
+			Existing:   target.Summary,
+			Query:      query,
+			IsFollowUp: target.Summary.Summary != "",
+			SourceKind: target.SourceKind,
+			ImageData:  imgInfo.Data,
+			MIMEType:   imgInfo.MIMEType,
+			TurnIndex:  target.LastSeenTurn,
+		}
+		return p.analyzer.Analyze(ctx, req)
+	})
 	if err != nil {
 		log.Warnf("vision: re-analysis failed for Image #%d: %v", targetOrdinal, err)
+		result.RegistryNote = BuildRegistryNote([]*ImageEntry{target}, targetOrdinal)
+		return
+	}
+	resp, ok := sfResult.(AnalyzeResponse)
+	if !ok {
 		result.RegistryNote = BuildRegistryNote([]*ImageEntry{target}, targetOrdinal)
 		return
 	}
@@ -333,6 +396,12 @@ func CurrentTurnHasImages(payload []byte) bool {
 	return false
 }
 
+// queryFingerprint returns a stable short hash of the query for singleflight dedup.
+func queryFingerprint(query string) string {
+	h := sha256.Sum256([]byte(query))
+	return fmt.Sprintf("%x", h[:8])
+}
+
 func mergeSummaries(existing, newSummary string) string {
 	if existing == "" {
 		return newSummary
@@ -360,4 +429,138 @@ func mergeHints(existing, newHints []string, max int) []string {
 		}
 	}
 	return merged
+}
+
+// A3ProcessCurrentTurn replaces current-turn images with text summaries when no
+// vision-capable model is available. Uses the Processor's analyzer to generate a
+// short structured summary for each new image, writes the summary into the registry
+// for future follow-up, and includes a clear degradation note so the model cannot
+// claim to have seen the original image.
+func (p *Processor) A3ProcessCurrentTurn(ctx context.Context, payload []byte, sessionKey SessionKey, turnIndex int) ([]byte, error) {
+	walk := WalkPayload(payload)
+
+	hasSession := sessionKey != ""
+	var sessionStore *SessionStore
+	if hasSession {
+		sessionStore = p.registry.GetOrCreateSession(sessionKey)
+	}
+
+	arrayType := detectArrayType(payload)
+
+	for _, part := range walk.Parts {
+		if !part.IsCurrent {
+			continue
+		}
+		data, mime := ExtractImageData(&part)
+		if data == "" {
+			placeholder := "[Image Registry] 远程图片 — A3 暂不支持远程 URL 图片分析，仅支持 inline/base64 图片。"
+			var err error
+			payload, err = ReplaceImagePartEx(payload, part, placeholder, arrayType)
+			if err != nil {
+				log.Warnf("vision: A3 replace remote image: %v", err)
+			}
+			continue
+		}
+
+		hash := ComputeHash(data)
+
+		// Call analyzer for initial structured summary
+		req := AnalyzeRequest{
+			ImageData:  data,
+			MIMEType:   mime,
+			SourceKind: ImageSourceUserUpload,
+			TurnIndex:  turnIndex,
+		}
+
+		resp, aErr := p.analyzer.Analyze(ctx, req)
+
+		var placeholder string
+		var summary ImageSummary
+
+		if aErr != nil {
+			log.Warnf("vision: A3 analyze failed: %v", aErr)
+			placeholder = "[Image Registry] 图片内容分析失败，无法提供文本摘要。"
+		} else {
+			summary = resp.Summary
+			if summary.Summary == "" {
+				summary.Summary = "图片内容"
+			}
+			summary.Confidence = "medium"
+			placeholder = buildA3SummaryPlaceholder(resp.Summary)
+		}
+
+		// Write summary to registry for future follow-up
+		if sessionStore != nil {
+			if sessionStore.GetEntry(hash) == nil {
+				ordinal := sessionStore.NextOrdinal()
+				sessionStore.GetOrCreateEntry(hash, ordinal, p.maxEntries)
+			}
+			sessionStore.UpdateEntry(hash, func(e *ImageEntry) {
+				if e.FirstSeenTurn == 0 {
+					e.FirstSeenTurn = turnIndex
+				}
+				e.LastSeenTurn = turnIndex
+				e.CurrentPayloadReachable = true
+				e.Availability = ImageAvailableInline
+				e.SourceKind = ImageSourceUserUpload
+				if summary.Summary != "" {
+					e.Summary = summary
+					e.LastAnalyzedAt = time.Now()
+				}
+				e.Occurrences = append(e.Occurrences, ImageOccurrence{
+					TurnIndex:  turnIndex,
+					MessageIdx: part.MsgIdx,
+					PartIdx:    part.PartIdx,
+				})
+			})
+		}
+
+		var err error
+		payload, err = ReplaceImagePartEx(payload, part, placeholder, arrayType)
+		if err != nil {
+			log.Warnf("vision: A3 replace image part: %v", err)
+		}
+	}
+
+	return payload, nil
+}
+
+// ReplaceCurrentTurnImages replaces all current-turn image parts in the payload
+// with a generic placeholder text. No analyzer call is made — used when no
+// vision-capable model or analyzer is available (e.g., all models excluded).
+func ReplaceCurrentTurnImages(payload []byte, placeholder string) ([]byte, error) {
+	walk := WalkPayload(payload)
+	arrayType := detectArrayType(payload)
+	for _, part := range walk.Parts {
+		if !part.IsCurrent {
+			continue
+		}
+		var err error
+		payload, err = ReplaceImagePartEx(payload, part, placeholder, arrayType)
+		if err != nil {
+			return payload, err
+		}
+	}
+	return payload, nil
+}
+
+// buildA3SummaryPlaceholder constructs the replacement text for a current-turn image
+// in the A3 path. Includes a clear degradation note so the model knows it did not
+// see the original image directly.
+func buildA3SummaryPlaceholder(s ImageSummary) string {
+	var b strings.Builder
+	b.WriteString("[Image Registry - Text Summary] ")
+
+	if s.Summary != "" {
+		b.WriteString(s.Summary)
+	} else if len(s.OCRHints) > 0 {
+		b.WriteString(strings.Join(s.OCRHints, "; "))
+	} else if len(s.LayoutHints) > 0 {
+		b.WriteString(strings.Join(s.LayoutHints, "; "))
+	} else if len(s.DetailHints) > 0 {
+		b.WriteString(s.DetailHints[0])
+	}
+
+	b.WriteString("（注意：此图片内容已通过文本摘要方式提供，AI模型未直接查看原图。）")
+	return b.String()
 }

--- a/internal/vision/registry.go
+++ b/internal/vision/registry.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // GlobalRegistry manages all session stores with resource limits and GC.
@@ -13,6 +15,7 @@ type GlobalRegistry struct {
 	sessions map[SessionKey]*SessionStore
 	config   GlobalConfig
 	done     chan struct{}
+	sfGroup  singleflight.Group
 }
 
 var global *GlobalRegistry

--- a/internal/vision/registry_test.go
+++ b/internal/vision/registry_test.go
@@ -495,3 +495,263 @@ func TestProcessorResetsReachabilityPerRequest(t *testing.T) {
 		t.Fatalf("registry note should mark exactly one older image unavailable: %q", res.RegistryNote)
 	}
 }
+
+func TestProcessorPhase2NoImagesInPayload(t *testing.T) {
+	registry := newGlobalRegistry(DefaultGlobalConfig())
+	processor := &Processor{
+		registry:   registry,
+		analyzer:   fakeAnalyzer{},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	// First request: establish an image in the session store
+	payload1 := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"first"},{"type":"image_url","image_url":{"url":"data:image/png;base64,QUJD"}}]}]}`)
+	res1, err := processor.Process(context.Background(), payload1, SessionKey("sess-phase2"), 1)
+	if err != nil {
+		t.Fatalf("first Process() error = %v", err)
+	}
+	if res1.ImagesFound != 1 {
+		t.Fatalf("expected 1 image in first request, got %d", res1.ImagesFound)
+	}
+
+	// Manually seed a summary so Phase 2 has something to inject
+	store := registry.GetSession("sess-phase2")
+	if store == nil {
+		t.Fatal("expected session store to exist")
+	}
+	store.UpdateEntry(ComputeHash("QUJD"), func(e *ImageEntry) {
+		e.Summary = ImageSummary{
+			Summary:    "Test UI design screenshot",
+			OCRHints:   []string{"Button: Submit", "Title: Welcome"},
+			Confidence: "high",
+		}
+	})
+
+	// Second request: pure text, no images -- Phase 2 should fire
+	payload2 := []byte(`{"messages":[{"role":"user","content":"Image #1 what was in it?"}]}`)
+	res2, err := processor.Process(context.Background(), payload2, SessionKey("sess-phase2"), 2)
+	if err != nil {
+		t.Fatalf("second Process() error = %v", err)
+	}
+	if res2.ImagesFound != 0 {
+		t.Fatalf("expected 0 images in second request, got %d", res2.ImagesFound)
+	}
+	if res2.RegistryNote == "" {
+		t.Fatal("Phase 2 should inject a registry note even when payload has no image parts")
+	}
+	if !strings.Contains(res2.RegistryNote, "Image #1") {
+		t.Fatalf("registry note should reference Image #1: %q", res2.RegistryNote)
+	}
+}
+
+func TestProcessorPhase2ExplicitReferenceNoImageData(t *testing.T) {
+	registry := newGlobalRegistry(DefaultGlobalConfig())
+	processor := &Processor{
+		registry:   registry,
+		analyzer:   fakeAnalyzer{},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload1 := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"check this"},{"type":"image_url","image_url":{"url":"data:image/png;base64,WFla"}}]}]}`)
+	if _, err := processor.Process(context.Background(), payload1, SessionKey("sess-ref"), 1); err != nil {
+		t.Fatalf("first Process() error = %v", err)
+	}
+
+	store := registry.GetSession("sess-ref")
+	store.UpdateEntry(ComputeHash("WFla"), func(e *ImageEntry) {
+		e.Summary = ImageSummary{
+			Summary:    "Error log: connection timeout",
+			OCRHints:   []string{"Error: 503", "Service Unavailable"},
+			Confidence: "high",
+		}
+	})
+
+	// Explicit "Image #1" reference, no images in payload
+	payload2 := []byte(`{"messages":[{"role":"user","content":"Image #1 what error?"}]}`)
+	res2, err := processor.Process(context.Background(), payload2, SessionKey("sess-ref"), 2)
+	if err != nil {
+		t.Fatalf("second Process() error = %v", err)
+	}
+	if !strings.Contains(res2.RegistryNote, "Image #1") {
+		t.Fatalf("registry note should reference Image #1: %q", res2.RegistryNote)
+	}
+	if !strings.Contains(res2.RegistryNote, "connection timeout") {
+		t.Fatalf("registry note should include cached summary: %q", res2.RegistryNote)
+	}
+}
+
+func TestProcessorPhase2AmbiguityWithoutImages(t *testing.T) {
+	registry := newGlobalRegistry(DefaultGlobalConfig())
+	processor := &Processor{
+		registry:   registry,
+		analyzer:   fakeAnalyzer{},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	p1 := []byte(`{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,QUFB"}}]}]}`)
+	if _, err := processor.Process(context.Background(), p1, SessionKey("sess-ambig"), 1); err != nil {
+		t.Fatal(err)
+	}
+	p2 := []byte(`{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,QkJC"}}]}]}`)
+	if _, err := processor.Process(context.Background(), p2, SessionKey("sess-ambig"), 2); err != nil {
+		t.Fatal(err)
+	}
+	p3 := []byte(`{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,Q0ND"}}]}]}`)
+	if _, err := processor.Process(context.Background(), p3, SessionKey("sess-ambig"), 3); err != nil {
+		t.Fatal(err)
+	}
+
+	store := registry.GetSession("sess-ambig")
+	store.UpdateEntry(ComputeHash("QUFB"), func(e *ImageEntry) {
+		e.Summary = ImageSummary{Summary: "First image", Confidence: "high"}
+	})
+	store.UpdateEntry(ComputeHash("QkJC"), func(e *ImageEntry) {
+		e.Summary = ImageSummary{Summary: "Second image", Confidence: "high"}
+	})
+	store.UpdateEntry(ComputeHash("Q0ND"), func(e *ImageEntry) {
+		e.Summary = ImageSummary{Summary: "Third image", Confidence: "high"}
+	})
+
+	// Ambiguous question with 3+ cached images, no payload images
+	p4 := []byte(`{"messages":[{"role":"user","content":"detail?"}]}`)
+	res3, err := processor.Process(context.Background(), p4, SessionKey("sess-ambig"), 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res3.RegistryNote, "未明确指向") {
+		t.Fatalf("Phase 2 should inject ambiguity note: %q", res3.RegistryNote)
+	}
+}
+
+func TestProcessorPhase2DoesNotFireWhenNoSession(t *testing.T) {
+	processor := &Processor{
+		registry:   newGlobalRegistry(DefaultGlobalConfig()),
+		analyzer:   fakeAnalyzer{},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	res, err := processor.Process(context.Background(), payload, "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RegistryNote != "" {
+		t.Fatalf("expected no registry note without session, got: %q", res.RegistryNote)
+	}
+	if string(res.Payload) != string(payload) {
+		t.Fatal("payload should be unchanged without session")
+	}
+}
+
+func TestA3ProcessCurrentTurnReplacesImage(t *testing.T) {
+	a3Resp := AnalyzeResponse{
+		Summary: ImageSummary{
+			Summary:    "A login form with username and password fields",
+			OCRHints:   []string{"Username:", "Password:"},
+			Confidence: "high",
+		},
+	}
+	processor := &Processor{
+		registry:   newGlobalRegistry(DefaultGlobalConfig()),
+		analyzer:   fakeAnalyzer{resp: a3Resp},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
+
+	modified, err := processor.A3ProcessCurrentTurn(context.Background(), payload, SessionKey("sess-a3"), 1)
+	if err != nil {
+		t.Fatalf("A3ProcessCurrentTurn() error = %v", err)
+	}
+
+	walk := WalkPayload(modified)
+	if len(walk.Parts) > 0 {
+		t.Fatal("A3 should replace all current-turn images, leaving no image parts")
+	}
+
+	modifiedStr := string(modified)
+	if !strings.Contains(modifiedStr, "login form") {
+		t.Fatalf("modified payload should contain analyzer summary: %s", modifiedStr)
+	}
+	if !strings.Contains(modifiedStr, "未直接查看原图") {
+		t.Fatalf("modified payload should contain degradation note: %s", modifiedStr)
+	}
+}
+
+func TestA3ProcessCurrentTurnWritesToRegistry(t *testing.T) {
+	a3Resp := AnalyzeResponse{
+		Summary: ImageSummary{
+			Summary:  "Code editor showing syntax highlighting",
+			OCRHints: []string{"function main()"},
+		},
+	}
+	processor := &Processor{
+		registry:   newGlobalRegistry(DefaultGlobalConfig()),
+		analyzer:   fakeAnalyzer{resp: a3Resp},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,Y29kZQ=="}}]}]}`)
+
+	if _, err := processor.A3ProcessCurrentTurn(context.Background(), payload, SessionKey("sess-a3-store"), 1); err != nil {
+		t.Fatalf("A3ProcessCurrentTurn() error = %v", err)
+	}
+
+	store := processor.registry.GetSession("sess-a3-store")
+	if store == nil {
+		t.Fatal("expected session store to exist")
+	}
+	entries := store.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry in session store, got %d", len(entries))
+	}
+	if entries[0].Summary.Summary != "Code editor showing syntax highlighting" {
+		t.Fatalf("expected cached summary, got: %q", entries[0].Summary.Summary)
+	}
+	if !entries[0].CurrentPayloadReachable {
+		t.Fatal("A3-processed image should be marked as reachable")
+	}
+}
+
+func TestA3ProcessCurrentTurnRemoteImage(t *testing.T) {
+	processor := &Processor{
+		registry:   newGlobalRegistry(DefaultGlobalConfig()),
+		analyzer:   fakeAnalyzer{},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}]}`)
+
+	modified, err := processor.A3ProcessCurrentTurn(context.Background(), payload, SessionKey("sess-remote"), 1)
+	if err != nil {
+		t.Fatalf("A3ProcessCurrentTurn() error = %v", err)
+	}
+
+	modifiedStr := string(modified)
+	if strings.Contains(modifiedStr, "https://example.com") {
+		t.Fatalf("remote URL should be removed: %s", modifiedStr)
+	}
+	if !strings.Contains(modifiedStr, "暂不支持远程") {
+		t.Fatalf("should contain remote image note: %s", modifiedStr)
+	}
+}
+
+func TestA3WithNoSessionStillReplacesImage(t *testing.T) {
+	processor := &Processor{
+		registry:   newGlobalRegistry(DefaultGlobalConfig()),
+		analyzer:   fakeAnalyzer{resp: AnalyzeResponse{Summary: ImageSummary{Summary: "terminal output"}}},
+		maxEntries: DefaultGlobalConfig().MaxEntriesPerSession,
+	}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,dGVybQ=="}}]}]}`)
+
+	modified, err := processor.A3ProcessCurrentTurn(context.Background(), payload, "", 1)
+	if err != nil {
+		t.Fatalf("A3ProcessCurrentTurn() error = %v", err)
+	}
+
+	walk := WalkPayload(modified)
+	if len(walk.Parts) > 0 {
+		t.Fatal("A3 should replace images even without a session key")
+	}
+}


### PR DESCRIPTION
## Summary

- **A3 Processing** (Analyze-As-Alternative): When OpenCodeGo routes to a model without vision capabilities, current-turn images are now analyzed by a text model and replaced with structured text summaries instead of being discarded.
- **Phase 2 Session Follow-up**: Text-only follow-up messages that reference historical images (e.g., "what was in Image #1?") now inject registry notes with cached summaries from the session store.
- **Singleflight Deduplication**: Concurrent analyzer calls for the same session/image/query are deduplicated to prevent redundant API calls.
- **Analyzer Model Resolution**: Refactored to respect `excluded_models` from both auth attributes and config, preventing use of excluded models as the analyzer fallback.

## Test Plan

- [x] Build passes (`go build ./cmd/...`)
- [x] Added unit tests for Phase 2, A3 processing, edge cases
- [x] Existing vision tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)