### PR TITLE
fix: 缓存命中率改为 token 口径，Dashboard KPI 增加 cache_rate

### DIFF
--- a/internal/api/handlers/management/dashboard_summary.go
+++ b/internal/api/handlers/management/dashboard_summary.go
@@ -67,6 +67,7 @@ func (h *Handler) GetDashboardSummary(c *gin.Context) {
 			"cached_tokens":    kpi.CachedTokens,
 			"total_tokens":     kpi.TotalTokens,
 			"total_cost":       kpi.TotalCost,
+			"cache_rate":       kpi.CacheRate,
 		},
 		"counts": gin.H{
 			"api_keys":         apiKeyCount,

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -590,11 +590,11 @@ func QueryStats(params LogQueryParams) (LogStats, error) {
 
 	where, args := buildWhereClause(params)
 
-	var total, successCount, totalTokens, cacheHitCount int64
+	var total, successCount, totalTokens, totalInputTokens, totalCachedTokens int64
 	var totalCost float64
-	statsSQL := "SELECT COUNT(*), COALESCE(SUM(CASE WHEN failed=0 THEN 1 ELSE 0 END),0), COALESCE(SUM(total_tokens),0), COALESCE(SUM(cost),0), COALESCE(SUM(CASE WHEN cached_tokens>0 THEN 1 ELSE 0 END),0) " +
+	statsSQL := "SELECT COUNT(*), COALESCE(SUM(CASE WHEN failed=0 THEN 1 ELSE 0 END),0), COALESCE(SUM(total_tokens),0), COALESCE(SUM(cost),0), COALESCE(SUM(input_tokens),0), COALESCE(SUM(cached_tokens),0) " +
 		"FROM request_logs" + where
-	if err := db.QueryRow(statsSQL, args...).Scan(&total, &successCount, &totalTokens, &totalCost, &cacheHitCount); err != nil {
+	if err := db.QueryRow(statsSQL, args...).Scan(&total, &successCount, &totalTokens, &totalCost, &totalInputTokens, &totalCachedTokens); err != nil {
 		return LogStats{}, fmt.Errorf("usage: stats query: %w", err)
 	}
 
@@ -604,8 +604,8 @@ func QueryStats(params LogQueryParams) (LogStats, error) {
 	}
 
 	var cacheRate float64
-	if total > 0 {
-		cacheRate = float64(cacheHitCount) / float64(total) * 100
+	if totalInputTokens > 0 {
+		cacheRate = float64(totalCachedTokens) / float64(totalInputTokens) * 100
 	}
 
 	return LogStats{
@@ -805,6 +805,7 @@ type DashboardKPI struct {
 	CachedTokens    int64   `json:"cached_tokens"`
 	TotalTokens     int64   `json:"total_tokens"`
 	TotalCost       float64 `json:"total_cost"`
+	CacheRate       float64 `json:"cache_rate"`
 }
 
 type DashboardTrendPoint struct {
@@ -870,6 +871,9 @@ func QueryDashboardKPI(days int) (DashboardKPI, error) {
 
 	if kpi.TotalRequests > 0 {
 		kpi.SuccessRate = float64(kpi.SuccessRequests) / float64(kpi.TotalRequests) * 100
+	}
+	if kpi.InputTokens > 0 {
+		kpi.CacheRate = float64(kpi.CachedTokens) / float64(kpi.InputTokens) * 100
 	}
 
 	return kpi, nil


### PR DESCRIPTION
修复缓存命中率从请求命中率改为 token 占比口径，并在 Dashboard KPI 中返回一致的数据。修改文件：
- internal/usage/usage_db.go
- internal/api/handlers/management/dashboard_summary.go