### PR TITLE
fix: align cache token rate denominator

### DIFF
--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -79,6 +79,15 @@ type LogStats struct {
 	CacheRate   float64 `json:"cache_rate"`
 }
 
+const cacheRateEffectiveInputSQL = "CASE WHEN cached_tokens > input_tokens THEN input_tokens + cached_tokens ELSE input_tokens END"
+
+func cacheRateFromTokenTotals(effectiveInputTokens, cachedTokens int64) float64 {
+	if effectiveInputTokens <= 0 {
+		return 0
+	}
+	return float64(cachedTokens) / float64(effectiveInputTokens) * 100
+}
+
 type ClearRequestLogsResult struct {
 	DeletedLogs       int64 `json:"deleted_logs"`
 	DeletedContents   int64 `json:"deleted_contents"`
@@ -590,11 +599,11 @@ func QueryStats(params LogQueryParams) (LogStats, error) {
 
 	where, args := buildWhereClause(params)
 
-	var total, successCount, totalTokens, totalInputTokens, totalCachedTokens int64
+	var total, successCount, totalTokens, effectiveInputTokens, totalCachedTokens int64
 	var totalCost float64
-	statsSQL := "SELECT COUNT(*), COALESCE(SUM(CASE WHEN failed=0 THEN 1 ELSE 0 END),0), COALESCE(SUM(total_tokens),0), COALESCE(SUM(cost),0), COALESCE(SUM(CASE WHEN cached_tokens > input_tokens THEN input_tokens + cached_tokens ELSE input_tokens END),0), COALESCE(SUM(cached_tokens),0) " +
+	statsSQL := "SELECT COUNT(*), COALESCE(SUM(CASE WHEN failed=0 THEN 1 ELSE 0 END),0), COALESCE(SUM(total_tokens),0), COALESCE(SUM(cost),0), COALESCE(SUM(" + cacheRateEffectiveInputSQL + "),0), COALESCE(SUM(cached_tokens),0) " +
 		"FROM request_logs" + where
-	if err := db.QueryRow(statsSQL, args...).Scan(&total, &successCount, &totalTokens, &totalCost, &totalInputTokens, &totalCachedTokens); err != nil {
+	if err := db.QueryRow(statsSQL, args...).Scan(&total, &successCount, &totalTokens, &totalCost, &effectiveInputTokens, &totalCachedTokens); err != nil {
 		return LogStats{}, fmt.Errorf("usage: stats query: %w", err)
 	}
 
@@ -603,16 +612,11 @@ func QueryStats(params LogQueryParams) (LogStats, error) {
 		successRate = float64(successCount) / float64(total) * 100
 	}
 
-	var cacheRate float64
-	if totalInputTokens > 0 {
-		cacheRate = float64(totalCachedTokens) / float64(totalInputTokens) * 100
-	}
-
 	return LogStats{
 		Total:       total,
 		SuccessRate: successRate,
 		TotalTokens: totalTokens,
-		CacheRate:   cacheRate,
+		CacheRate:   cacheRateFromTokenTotals(effectiveInputTokens, totalCachedTokens),
 		TotalCost:   totalCost,
 	}, nil
 }
@@ -841,20 +845,20 @@ func QueryDashboardKPI(days int) (DashboardKPI, error) {
 	cutoff := CutoffStartUTC(days).Format(time.RFC3339)
 
 	var kpi DashboardKPI
-	err := db.QueryRow(`
-		SELECT
-			COUNT(*),
-			COALESCE(SUM(CASE WHEN failed=0 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN failed=1 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(input_tokens), 0),
-			COALESCE(SUM(output_tokens), 0),
-			COALESCE(SUM(reasoning_tokens), 0),
-			COALESCE(SUM(cached_tokens), 0),
-			COALESCE(SUM(total_tokens), 0),
-			COALESCE(SUM(cost), 0)
-		FROM request_logs
-		WHERE timestamp >= ?
-	`, cutoff).Scan(
+	var effectiveInputTokens int64
+	kpiSQL := "SELECT " +
+		"COUNT(*), " +
+		"COALESCE(SUM(CASE WHEN failed=0 THEN 1 ELSE 0 END), 0), " +
+		"COALESCE(SUM(CASE WHEN failed=1 THEN 1 ELSE 0 END), 0), " +
+		"COALESCE(SUM(input_tokens), 0), " +
+		"COALESCE(SUM(output_tokens), 0), " +
+		"COALESCE(SUM(reasoning_tokens), 0), " +
+		"COALESCE(SUM(cached_tokens), 0), " +
+		"COALESCE(SUM(total_tokens), 0), " +
+		"COALESCE(SUM(cost), 0), " +
+		"COALESCE(SUM(" + cacheRateEffectiveInputSQL + "), 0) " +
+		"FROM request_logs WHERE timestamp >= ?"
+	err := db.QueryRow(kpiSQL, cutoff).Scan(
 		&kpi.TotalRequests,
 		&kpi.SuccessRequests,
 		&kpi.FailedRequests,
@@ -864,6 +868,7 @@ func QueryDashboardKPI(days int) (DashboardKPI, error) {
 		&kpi.CachedTokens,
 		&kpi.TotalTokens,
 		&kpi.TotalCost,
+		&effectiveInputTokens,
 	)
 	if err != nil {
 		return DashboardKPI{}, fmt.Errorf("usage: dashboard KPI query: %w", err)
@@ -872,13 +877,7 @@ func QueryDashboardKPI(days int) (DashboardKPI, error) {
 	if kpi.TotalRequests > 0 {
 		kpi.SuccessRate = float64(kpi.SuccessRequests) / float64(kpi.TotalRequests) * 100
 	}
-	if kpi.InputTokens > 0 {
-		effectiveInput := kpi.InputTokens
-		if kpi.CachedTokens > kpi.InputTokens {
-			effectiveInput = kpi.InputTokens + kpi.CachedTokens
-		}
-		kpi.CacheRate = float64(kpi.CachedTokens) / float64(effectiveInput) * 100
-	}
+	kpi.CacheRate = cacheRateFromTokenTotals(effectiveInputTokens, kpi.CachedTokens)
 
 	return kpi, nil
 }

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"database/sql"
+	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -118,6 +119,84 @@ func TestQueryEntityStatsFiltersByRequestedEntities(t *testing.T) {
 	}
 	if sourceStats[0].Requests != 1 || sourceStats[0].Failed != 1 {
 		t.Fatalf("source stats = %+v, want one failed request", sourceStats[0])
+	}
+}
+
+func TestCacheRateUsesEffectiveInputTokenTotals(t *testing.T) {
+	testCases := []struct {
+		name string
+		rows []TokenStats
+		want float64
+	}{
+		{
+			name: "cached tokens are part of input tokens",
+			rows: []TokenStats{{InputTokens: 1000, CachedTokens: 400, TotalTokens: 1000}},
+			want: 40,
+		},
+		{
+			name: "cached tokens are reported separately from small input tokens",
+			rows: []TokenStats{{InputTokens: 21, CachedTokens: 188086, TotalTokens: 188107}},
+			want: float64(188086) / float64(188107) * 100,
+		},
+		{
+			name: "cached tokens without raw input tokens",
+			rows: []TokenStats{{CachedTokens: 250, TotalTokens: 250}},
+			want: 100,
+		},
+		{
+			name: "mixed provider semantics are handled per request row",
+			rows: []TokenStats{
+				{InputTokens: 100, TotalTokens: 100},
+				{CachedTokens: 50, TotalTokens: 50},
+			},
+			want: float64(50) / float64(150) * 100,
+		},
+		{
+			name: "zero token totals",
+			rows: []TokenStats{{TotalTokens: 0}},
+			want: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+			now := time.Now().UTC()
+			for index, row := range tc.rows {
+				InsertLog(
+					"sk-cache-rate",
+					"",
+					"gpt-5.4",
+					"codex",
+					"Codex",
+					"auth-cache-rate",
+					false,
+					now.Add(time.Duration(index)*time.Second),
+					1,
+					0,
+					row,
+					"",
+					"",
+				)
+			}
+
+			stats, err := QueryStats(LogQueryParams{Days: 30})
+			if err != nil {
+				t.Fatalf("QueryStats() error = %v", err)
+			}
+			if math.Abs(stats.CacheRate-tc.want) > 0.000001 {
+				t.Fatalf("QueryStats().CacheRate = %.9f, want %.9f", stats.CacheRate, tc.want)
+			}
+
+			kpi, err := QueryDashboardKPI(30)
+			if err != nil {
+				t.Fatalf("QueryDashboardKPI() error = %v", err)
+			}
+			if math.Abs(kpi.CacheRate-tc.want) > 0.000001 {
+				t.Fatalf("QueryDashboardKPI().CacheRate = %.9f, want %.9f", kpi.CacheRate, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Share the effective input-token denominator between usage stats and dashboard KPI cache_rate
- Keep per-row handling for providers that report cached tokens separately from input tokens
- Add storage-layer coverage for included-cache, separate-cache, zero-input, mixed, and zero-token cases

## Verification
- go test ./internal/usage ./internal/api/handlers/management
- git diff --check