### PR TITLE
chore: add backend structure guard

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Reject vendored panel assets
         run: ./scripts/ensure-no-vendored-panel-assets.sh
+      - name: Backend structure guard
+        run: python3 scripts/check-backend-structure.py
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -1,0 +1,278 @@
+{
+  "large_files": {
+    "allow_above_1200": [
+      {
+        "path": "internal/api/handlers/management/auth_files.go",
+        "max_lines": 3374,
+        "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
+      },
+      {
+        "path": "internal/api/handlers/management/config_lists.go",
+        "max_lines": 2307,
+        "reason": "Phase 1/2 legacy management config-list debt; move settings/API-key/provider-key use cases behind services and DB-first stores."
+      },
+      {
+        "path": "internal/api/server.go",
+        "max_lines": 2090,
+        "reason": "Phase 6 legacy server wiring debt; split routes, middleware, management panel, keep-alive, and reload logic."
+      },
+      {
+        "path": "internal/config/config.go",
+        "max_lines": 2216,
+        "reason": "Phase 2 legacy config schema/YAML/compat debt; split schema, normalize, yamlio, and compat packages."
+      },
+      {
+        "path": "internal/logging/request_logger.go",
+        "max_lines": 1268,
+        "reason": "Legacy request logging debt; keep stable while request-log storage and retention are separated in Phase 3."
+      },
+      {
+        "path": "internal/registry/model_definitions_static_data.go",
+        "max_lines": 1233,
+        "reason": "Static model definition data exception; keep out of business-logic large-file goals unless generation/storage changes."
+      },
+      {
+        "path": "internal/runtime/executor/antigravity_executor.go",
+        "max_lines": 1766,
+        "reason": "Phase 4 legacy provider executor debt; migrate provider-specific protocol logic behind the runtime pipeline."
+      },
+      {
+        "path": "internal/runtime/executor/claude_executor.go",
+        "max_lines": 1456,
+        "reason": "Phase 4 legacy provider executor debt; migrate headers/cache/streaming behavior behind the runtime pipeline."
+      },
+      {
+        "path": "internal/runtime/executor/codex_image_executor.go",
+        "max_lines": 2233,
+        "reason": "Phase 4 legacy Codex image executor debt; split request/upload/conversation/poll/download/error modules."
+      },
+      {
+        "path": "internal/runtime/executor/codex_websockets_executor.go",
+        "max_lines": 1453,
+        "reason": "Phase 4 legacy Codex WebSocket executor debt; migrate transport-specific logic behind provider adapters."
+      },
+      {
+        "path": "internal/runtime/executor/opencode_go_executor.go",
+        "max_lines": 1314,
+        "reason": "Phase 4 legacy provider executor debt; move common request/stream/error handling into the runtime pipeline."
+      },
+      {
+        "path": "internal/usage/usage_db.go",
+        "max_lines": 2530,
+        "reason": "Phase 3 legacy usage database debt; split request logs, quota snapshots, cleanup, and dashboard queries."
+      },
+      {
+        "path": "sdk/cliproxy/auth/conductor.go",
+        "max_lines": 3223,
+        "reason": "Phase 5 legacy auth manager facade debt; split registry, selector, execution, refresh, cooldown, aliases, and persistence."
+      },
+      {
+        "path": "sdk/cliproxy/service.go",
+        "max_lines": 1788,
+        "reason": "Phase 6/7 legacy service host debt; move service implementation into internal app/runtime wiring and keep SDK facade stable."
+      }
+    ]
+  },
+  "sdk_internal_imports": {
+    "allow": {
+      "sdk/api/handlers/claude/ccswitch_model_mapping.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+      ],
+      "sdk/api/handlers/claude/code_handlers.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/constant",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+      ],
+      "sdk/api/handlers/gemini/gemini-cli_handlers.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/constant",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/api/handlers/gemini/gemini_handlers.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/constant",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+      ],
+      "sdk/api/handlers/handlers.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/logging",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/routing",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/api/handlers/openai/openai_handlers.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/constant",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/openai/openai/responses"
+      ],
+      "sdk/api/handlers/openai/openai_images_handlers.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/routing",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/api/handlers/openai/openai_responses_handlers.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/constant",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+      ],
+      "sdk/api/handlers/openai/openai_responses_websocket.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/api/handlers/stream_forwarder.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+      ],
+      "sdk/api/management.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
+      ],
+      "sdk/api/options.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/api"
+      ],
+      "sdk/auth/antigravity.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/antigravity",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/browser",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/misc",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/auth/claude.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/browser",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/misc",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/auth/codex.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/browser",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/misc",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/auth/codex_device.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/browser",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/auth/errors.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+      ],
+      "sdk/auth/filestore.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/auth/gemini.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+      ],
+      "sdk/auth/iflow.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/iflow",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/browser",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/misc",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/auth/interfaces.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+      ],
+      "sdk/auth/kimi.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/browser",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+      ],
+      "sdk/auth/manager.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+      ],
+      "sdk/auth/qwen.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/browser",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+      ],
+      "sdk/cliproxy/auth/conductor.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/logging",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+      ],
+      "sdk/cliproxy/auth/oauth_model_alias.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+      ],
+      "sdk/cliproxy/auth/quota_reconcile.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+      ],
+      "sdk/cliproxy/auth/routing_groups.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+      ],
+      "sdk/cliproxy/auth/selector.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+      ],
+      "sdk/cliproxy/auth/types.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/auth"
+      ],
+      "sdk/cliproxy/builder.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/api"
+      ],
+      "sdk/cliproxy/model_registry.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+      ],
+      "sdk/cliproxy/pprof_server.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+      ],
+      "sdk/cliproxy/providers.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
+      ],
+      "sdk/cliproxy/service.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/api",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/registry",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/usage",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/watcher",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/watcher/synthesizer",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/wsrelay"
+      ],
+      "sdk/cliproxy/types.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
+      ],
+      "sdk/cliproxy/watcher.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
+      ],
+      "sdk/config/config.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+      ],
+      "sdk/logging/request_logger.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+      ],
+      "sdk/translator/builtin/builtin.go": [
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+      ]
+    }
+  },
+  "management_persistence_calls": {
+    "allow": {
+      "internal/api/handlers/management/channel_rename.go": {
+        "config.SaveConfigPreserveComments": 2,
+        "usage.UpsertRuntimeSetting": 2,
+        "usage.CleanDBBackedConfigFromYAML": 2
+      },
+      "internal/api/handlers/management/config_basic.go": {
+        "usage.MigrateRuntimeSettingsFromConfig": 1,
+        "usage.ApplyStoredRuntimeSettings": 1
+      },
+      "internal/api/handlers/management/handler.go": {
+        "config.SaveConfigPreserveComments": 1,
+        "usage.UpsertRuntimeSetting": 1,
+        "usage.PersistRuntimeSettingsFromConfig": 1,
+        "usage.CleanDBBackedConfigFromYAML": 2
+      }
+    }
+  }
+}

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -1,0 +1,98 @@
+# Backend Structure Baseline
+
+更新时间：2026-06-06
+
+本基线对应后端结构治理 Phase 0。目标是先冻结当前结构债务，避免后续重构期间继续新增大文件、反向依赖和 handler 直连持久化路径。
+
+## 扫描命令
+
+```bash
+python3 scripts/check-backend-structure.py
+```
+
+CI 中也会运行同一脚本。扫描器只依赖 Python 标准库，allowlist 位于：
+
+```text
+docs/internal-review/backend-structure-allowlist.json
+```
+
+## 当前结构指标
+
+基于 `origin/dev` 的 2026-06-06 基线：
+
+| 指标 | 数量 |
+| --- | ---: |
+| Go 文件总数 | 586 |
+| 生产 Go 文件 | 406 |
+| 测试 Go 文件 | 180 |
+| `internal/` Go 文件 | 463 |
+| `internal/` 生产 Go 文件 | 335 |
+| `internal/` 测试 Go 文件 | 128 |
+| 生产 Go 文件中 `>800` 行 | 26 |
+| 生产 Go 文件中 `>1200` 行 | 14 |
+| `internal/` 生产 Go 文件中 `>800` 行 | 23 |
+| `internal/` 生产 Go 文件中 `>1200` 行 | 12 |
+| 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
+| 管理端 `Handler` receiver 方法 | 252 |
+| `server.go` 内管理路由注册 | 194 |
+| `internal/` 生产目录 | 80 |
+| `internal/` 有同级测试目录 | 35 |
+| `internal/` 无同级测试目录 | 45 |
+
+## 当前 `>1200` 行生产文件
+
+这些文件是历史债务，只允许通过 allowlist 保持现状；继续增长会触发结构扫描失败。
+
+| 文件 | 行数 | 治理阶段 |
+| --- | ---: | --- |
+| `internal/api/handlers/management/auth_files.go` | 3374 | Phase 1 |
+| `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
+| `internal/usage/usage_db.go` | 2530 | Phase 3 |
+| `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |
+| `internal/runtime/executor/codex_image_executor.go` | 2233 | Phase 4 |
+| `internal/config/config.go` | 2216 | Phase 2 |
+| `internal/api/server.go` | 2090 | Phase 6 |
+| `sdk/cliproxy/service.go` | 1788 | Phase 6/7 |
+| `internal/runtime/executor/antigravity_executor.go` | 1766 | Phase 4 |
+| `internal/runtime/executor/claude_executor.go` | 1456 | Phase 4 |
+| `internal/runtime/executor/codex_websockets_executor.go` | 1453 | Phase 4 |
+| `internal/runtime/executor/opencode_go_executor.go` | 1314 | Phase 4 |
+| `internal/logging/request_logger.go` | 1268 | Phase 3 |
+| `internal/registry/model_definitions_static_data.go` | 1233 | 静态数据例外 |
+
+## 门禁规则
+
+- 生产 Go 文件 `>800` 行：扫描输出 warning，作为治理提示。
+- 生产 Go 文件 `>1200` 行：默认失败；只有 `backend-structure-allowlist.json` 中登记的历史债务可通过。
+- allowlist 中的大文件带有 `max_lines`，文件继续增长会失败；收敛后应同步收紧 allowlist。
+- 生产 `sdk/**` 文件禁止新增对 `github.com/router-for-me/CLIProxyAPI/v6/internal/**` 的导入。
+- 现存 `sdk -> internal` 导入按文件和 import path 精确登记；同一文件新增 internal import 也会失败。
+- 管理端 handler 禁止新增对 YAML/SQLite 持久化函数的直接调用。
+- 现存管理端直连持久化调用按文件、符号和次数登记；新增调用次数会失败。
+
+## 架构例外登记
+
+- `internal/registry/model_definitions_static_data.go` 是静态模型定义数据，暂按静态数据例外处理；如果后续引入生成器或数据文件，应将其移出业务大文件债务。
+- 其余 `>1200` 行文件均为业务逻辑或装配逻辑债务，不属于长期例外，只是迁移前兼容基线。
+
+## 重构前契约测试清单
+
+后续阶段开始迁移前，应按影响面补齐或复核以下测试：
+
+- 管理 API route smoke。
+- auth files list/upload/delete/patch 响应字段和状态码。
+- config YAML 与 DB-backed runtime settings overlay 顺序。
+- request logs query/filter/content/cleanup。
+- quota snapshot 写入、查询与保留策略。
+- provider executor non-stream/stream/error body 基础路径。
+- SSE event translation 和 usage reporting。
+- auth manager selection/retry/cooldown/refresh 并发行为。
+- service/server route registration、middleware 顺序和 shutdown path。
+- SDK public package compatibility compile tests。
+
+## 后续维护要求
+
+- 新业务数据默认进入 SQLite/数据库和管理 API，不得为了前端实现方便新增到 `config.yaml`。
+- 新管理 API 必须通过 transport + use case/service 边界进入，不得把业务规则继续堆到超级 `Handler`。
+- 新 provider 执行逻辑必须优先复用 runtime pipeline 或先补 pipeline 抽象，不得复制完整横切 executor 模板。
+- 每个阶段结束时都要更新本基线或 allowlist，确保债务数量只减少、不扩大。

--- a/docs/internal-review/quality-baseline.md
+++ b/docs/internal-review/quality-baseline.md
@@ -62,9 +62,11 @@ bun run check
 - 页面主文件目标：`400-600` 行
 - 告警阈值：`> 800` 行
 - 阻塞阈值：`> 1200` 行
+- 后端结构基线与 allowlist 见 [`backend-structure-baseline.md`](backend-structure-baseline.md)。
 
 配套扫描脚本：
 
 ```bash
 /Users/kittors/Developer/opensource/CliProxy/scripts/scan-large-files.sh
+python3 scripts/check-backend-structure.py
 ```

--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -60,13 +60,13 @@ type modelConfigPayload struct {
 	InputModalities  *[]string `json:"input_modalities"`
 	OutputModalities *[]string `json:"output_modalities"`
 	Pricing          struct {
-		Mode                    string  `json:"mode"`
-		InputPricePerMillion    float64 `json:"input_price_per_million"`
-		OutputPricePerMillion   float64 `json:"output_price_per_million"`
-		CachedPricePerMillion   float64 `json:"cached_price_per_million"`
+		Mode                      string  `json:"mode"`
+		InputPricePerMillion      float64 `json:"input_price_per_million"`
+		OutputPricePerMillion     float64 `json:"output_price_per_million"`
+		CachedPricePerMillion     float64 `json:"cached_price_per_million"`
 		CacheReadPricePerMillion  float64 `json:"cache_read_price_per_million"`
 		CacheWritePricePerMillion float64 `json:"cache_write_price_per_million"`
-		PricePerCall            float64 `json:"price_per_call"`
+		PricePerCall              float64 `json:"price_per_call"`
 	} `json:"pricing"`
 }
 
@@ -77,13 +77,13 @@ func modelConfigResponse(row usage.ModelConfigRow) map[string]any {
 		"description": row.Description,
 		"enabled":     row.Enabled,
 		"pricing": map[string]any{
-			"mode":                       row.PricingMode,
-			"input_price_per_million":    row.InputPricePerMillion,
-			"output_price_per_million":   row.OutputPricePerMillion,
-			"cached_price_per_million":   row.CachedPricePerMillion,
+			"mode":                          row.PricingMode,
+			"input_price_per_million":       row.InputPricePerMillion,
+			"output_price_per_million":      row.OutputPricePerMillion,
+			"cached_price_per_million":      row.CachedPricePerMillion,
 			"cache_read_price_per_million":  row.CacheReadPricePerMillion,
 			"cache_write_price_per_million": row.CacheWritePricePerMillion,
-			"price_per_call":             row.PricePerCall,
+			"price_per_call":                row.PricePerCall,
 		},
 		"source":     row.Source,
 		"updated_at": row.UpdatedAt,
@@ -335,18 +335,18 @@ func modelConfigPayloadToRow(payload modelConfigPayload, scope string) usage.Mod
 		source = "seed"
 	}
 	row := usage.ModelConfigRow{
-		ModelID:                 strings.TrimSpace(payload.ID),
-		OwnedBy:                 strings.TrimSpace(payload.OwnedBy),
-		Description:             strings.TrimSpace(payload.Description),
-		Enabled:                 payload.Enabled,
-		PricingMode:             strings.TrimSpace(payload.Pricing.Mode),
-		InputPricePerMillion:    payload.Pricing.InputPricePerMillion,
-		OutputPricePerMillion:   payload.Pricing.OutputPricePerMillion,
-		CachedPricePerMillion:   payload.Pricing.CachedPricePerMillion,
+		ModelID:                   strings.TrimSpace(payload.ID),
+		OwnedBy:                   strings.TrimSpace(payload.OwnedBy),
+		Description:               strings.TrimSpace(payload.Description),
+		Enabled:                   payload.Enabled,
+		PricingMode:               strings.TrimSpace(payload.Pricing.Mode),
+		InputPricePerMillion:      payload.Pricing.InputPricePerMillion,
+		OutputPricePerMillion:     payload.Pricing.OutputPricePerMillion,
+		CachedPricePerMillion:     payload.Pricing.CachedPricePerMillion,
 		CacheReadPricePerMillion:  payload.Pricing.CacheReadPricePerMillion,
 		CacheWritePricePerMillion: payload.Pricing.CacheWritePricePerMillion,
-		PricePerCall:            payload.Pricing.PricePerCall,
-		Source:                  source,
+		PricePerCall:              payload.Pricing.PricePerCall,
+		Source:                    source,
 	}
 	if payload.InputModalities != nil {
 		row.InputModalities = *payload.InputModalities
@@ -459,13 +459,13 @@ func (h *Handler) GetConfiguredModelAvailability(c *gin.Context) {
 		if row, ok := configByID[strings.ToLower(id)]; ok {
 			attachModelConfigCapabilities(entry, row)
 			entry["pricing"] = map[string]any{
-				"mode":                       row.PricingMode,
-				"input_price_per_million":    row.InputPricePerMillion,
-				"output_price_per_million":   row.OutputPricePerMillion,
-				"cached_price_per_million":   row.CachedPricePerMillion,
+				"mode":                          row.PricingMode,
+				"input_price_per_million":       row.InputPricePerMillion,
+				"output_price_per_million":      row.OutputPricePerMillion,
+				"cached_price_per_million":      row.CachedPricePerMillion,
 				"cache_read_price_per_million":  row.CacheReadPricePerMillion,
 				"cache_write_price_per_million": row.CacheWritePricePerMillion,
-				"price_per_call":             row.PricePerCall,
+				"price_per_call":                row.PricePerCall,
 			}
 			if row.Description != "" {
 				entry["description"] = row.Description
@@ -829,13 +829,13 @@ func (h *Handler) GetModelPricing(c *gin.Context) {
 	items := make([]map[string]any, 0, len(pricingMap))
 	for _, row := range pricingMap {
 		items = append(items, map[string]any{
-			"model_id":                    row.ModelID,
-			"input_price_per_million":     row.InputPricePerMillion,
-			"output_price_per_million":    row.OutputPricePerMillion,
-			"cached_price_per_million":    row.CachedPricePerMillion,
+			"model_id":                      row.ModelID,
+			"input_price_per_million":       row.InputPricePerMillion,
+			"output_price_per_million":      row.OutputPricePerMillion,
+			"cached_price_per_million":      row.CachedPricePerMillion,
 			"cache_read_price_per_million":  row.CacheReadPricePerMillion,
 			"cache_write_price_per_million": row.CacheWritePricePerMillion,
-			"updated_at":                  row.UpdatedAt,
+			"updated_at":                    row.UpdatedAt,
 		})
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
@@ -851,10 +851,10 @@ func (h *Handler) GetModelPricing(c *gin.Context) {
 func (h *Handler) PutModelPricing(c *gin.Context) {
 	var body struct {
 		Items []struct {
-			ModelID               string  `json:"model_id"`
-			InputPricePerMillion  float64 `json:"input_price_per_million"`
-			OutputPricePerMillion float64 `json:"output_price_per_million"`
-			CachedPricePerMillion float64 `json:"cached_price_per_million"`
+			ModelID                   string  `json:"model_id"`
+			InputPricePerMillion      float64 `json:"input_price_per_million"`
+			OutputPricePerMillion     float64 `json:"output_price_per_million"`
+			CachedPricePerMillion     float64 `json:"cached_price_per_million"`
 			CacheReadPricePerMillion  float64 `json:"cache_read_price_per_million"`
 			CacheWritePricePerMillion float64 `json:"cache_write_price_per_million"`
 		} `json:"items"`

--- a/internal/usage/model_config_db.go
+++ b/internal/usage/model_config_db.go
@@ -14,21 +14,21 @@ import (
 )
 
 type ModelConfigRow struct {
-	ModelID                 string   `json:"model_id"`
-	OwnedBy                 string   `json:"owned_by"`
-	Description             string   `json:"description"`
-	Enabled                 bool     `json:"enabled"`
-	InputModalities         []string `json:"input_modalities,omitempty"`
-	OutputModalities        []string `json:"output_modalities,omitempty"`
-	PricingMode             string   `json:"pricing_mode"`
-	InputPricePerMillion    float64  `json:"input_price_per_million"`
-	OutputPricePerMillion   float64  `json:"output_price_per_million"`
-	CachedPricePerMillion   float64  `json:"cached_price_per_million"`
-	CacheReadPricePerMillion  float64 `json:"cache_read_price_per_million,omitempty"`
-	CacheWritePricePerMillion float64 `json:"cache_write_price_per_million,omitempty"`
-	PricePerCall            float64  `json:"price_per_call"`
-	Source                  string   `json:"source"`
-	UpdatedAt               string   `json:"updated_at"`
+	ModelID                   string   `json:"model_id"`
+	OwnedBy                   string   `json:"owned_by"`
+	Description               string   `json:"description"`
+	Enabled                   bool     `json:"enabled"`
+	InputModalities           []string `json:"input_modalities,omitempty"`
+	OutputModalities          []string `json:"output_modalities,omitempty"`
+	PricingMode               string   `json:"pricing_mode"`
+	InputPricePerMillion      float64  `json:"input_price_per_million"`
+	OutputPricePerMillion     float64  `json:"output_price_per_million"`
+	CachedPricePerMillion     float64  `json:"cached_price_per_million"`
+	CacheReadPricePerMillion  float64  `json:"cache_read_price_per_million,omitempty"`
+	CacheWritePricePerMillion float64  `json:"cache_write_price_per_million,omitempty"`
+	PricePerCall              float64  `json:"price_per_call"`
+	Source                    string   `json:"source"`
+	UpdatedAt                 string   `json:"updated_at"`
 }
 
 type ModelOwnerPresetRow struct {

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -12,13 +12,13 @@ import (
 
 // ModelPricingRow represents a single model's pricing configuration.
 type ModelPricingRow struct {
-	ModelID                 string  `json:"model_id"`
-	InputPricePerMillion    float64 `json:"input_price_per_million"`
-	OutputPricePerMillion   float64 `json:"output_price_per_million"`
-	CachedPricePerMillion   float64 `json:"cached_price_per_million"`
+	ModelID                   string  `json:"model_id"`
+	InputPricePerMillion      float64 `json:"input_price_per_million"`
+	OutputPricePerMillion     float64 `json:"output_price_per_million"`
+	CachedPricePerMillion     float64 `json:"cached_price_per_million"`
 	CacheReadPricePerMillion  float64 `json:"cache_read_price_per_million,omitempty"`
 	CacheWritePricePerMillion float64 `json:"cache_write_price_per_million,omitempty"`
-	UpdatedAt               string  `json:"updated_at"`
+	UpdatedAt                 string  `json:"updated_at"`
 }
 
 const createPricingTableSQL = `
@@ -130,13 +130,13 @@ func UpsertModelPricingV2(modelID string, input, output, cached, cacheRead, cach
 		pricingCache = make(map[string]ModelPricingRow)
 	}
 	pricingCache[modelID] = ModelPricingRow{
-		ModelID:                 modelID,
-		InputPricePerMillion:    input,
-		OutputPricePerMillion:   output,
-		CachedPricePerMillion:   cached,
+		ModelID:                   modelID,
+		InputPricePerMillion:      input,
+		OutputPricePerMillion:     output,
+		CachedPricePerMillion:     cached,
 		CacheReadPricePerMillion:  cacheRead,
 		CacheWritePricePerMillion: cacheWrite,
-		UpdatedAt:               now,
+		UpdatedAt:                 now,
 	}
 	pricingCacheMu.Unlock()
 	upsertLegacyPricingIntoModelConfig(db, modelID, input, output, cached, now)

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -70,12 +70,12 @@ func TestCalculateCostV2CacheReadIncludedInInput(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	if err := UpsertModelConfig(ModelConfigRow{
-		ModelID:                 "openai-cache-model",
-		Enabled:                 true,
-		PricingMode:             "token",
-		InputPricePerMillion:    10,
-		OutputPricePerMillion:   20,
-		CachedPricePerMillion:   1.5,
+		ModelID:                  "openai-cache-model",
+		Enabled:                  true,
+		PricingMode:              "token",
+		InputPricePerMillion:     10,
+		OutputPricePerMillion:    20,
+		CachedPricePerMillion:    1.5,
 		CacheReadPricePerMillion: 0.5,
 	}); err != nil {
 		t.Fatalf("UpsertModelConfig() error = %v", err)
@@ -105,11 +105,11 @@ func TestCalculateCostV2CacheReadSeparate(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	if err := UpsertModelConfig(ModelConfigRow{
-		ModelID:                 "claude-cache-model",
-		Enabled:                 true,
-		PricingMode:             "token",
-		InputPricePerMillion:    10,
-		OutputPricePerMillion:   20,
+		ModelID:                  "claude-cache-model",
+		Enabled:                  true,
+		PricingMode:              "token",
+		InputPricePerMillion:     10,
+		OutputPricePerMillion:    20,
 		CacheReadPricePerMillion: 0.3,
 	}); err != nil {
 		t.Fatalf("UpsertModelConfig() error = %v", err)
@@ -138,21 +138,21 @@ func TestCalculateCostV2CacheWriteOnly(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	if err := UpsertModelConfig(ModelConfigRow{
-		ModelID:                  "creation-model",
-		Enabled:                  true,
-		PricingMode:              "token",
-		InputPricePerMillion:     10,
-		OutputPricePerMillion:    20,
+		ModelID:                   "creation-model",
+		Enabled:                   true,
+		PricingMode:               "token",
+		InputPricePerMillion:      10,
+		OutputPricePerMillion:     20,
 		CacheWritePricePerMillion: 5,
 	}); err != nil {
 		t.Fatalf("UpsertModelConfig() error = %v", err)
 	}
 
 	tokens := TokenStats{
-		InputTokens:     1000,
-		OutputTokens:    500,
+		InputTokens:      1000,
+		OutputTokens:     500,
 		CacheWriteTokens: 800,
-		CachedTokens:    800,
+		CachedTokens:     800,
 	}
 
 	cost := CalculateCostV2("creation-model", tokens)
@@ -170,12 +170,12 @@ func TestCalculateCostV2CacheReadAndWriteBothPresent(t *testing.T) {
 	initModelConfigTestDB(t)
 
 	if err := UpsertModelConfig(ModelConfigRow{
-		ModelID:                  "claude-both-cache-model",
-		Enabled:                  true,
-		PricingMode:              "token",
-		InputPricePerMillion:     10,
-		OutputPricePerMillion:    20,
-		CachedPricePerMillion:    0.3,
+		ModelID:                   "claude-both-cache-model",
+		Enabled:                   true,
+		PricingMode:               "token",
+		InputPricePerMillion:      10,
+		OutputPricePerMillion:     20,
+		CachedPricePerMillion:     0.3,
 		CacheReadPricePerMillion:  0.3,
 		CacheWritePricePerMillion: 8,
 	}); err != nil {
@@ -183,11 +183,11 @@ func TestCalculateCostV2CacheReadAndWriteBothPresent(t *testing.T) {
 	}
 
 	tokens := TokenStats{
-		InputTokens:     1000,
-		OutputTokens:    500,
+		InputTokens:      1000,
+		OutputTokens:     500,
 		CacheReadTokens:  700,
 		CacheWriteTokens: 300,
-		CachedTokens:    700,
+		CachedTokens:     700,
 	}
 
 	cost := CalculateCostV2("claude-both-cache-model", tokens)

--- a/scripts/check-backend-structure.py
+++ b/scripts/check-backend-structure.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Lightweight backend structure guard for architecture refactors.
+
+The guard intentionally uses only Python's standard library so it can run in
+local shells and GitHub Actions without installing project-specific tooling.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+WARNING_LINE_THRESHOLD = 800
+BLOCKING_LINE_THRESHOLD = 1200
+
+ALLOWLIST_PATH = Path("docs/internal-review/backend-structure-allowlist.json")
+MANAGEMENT_DIR = Path("internal/api/handlers/management")
+SERVER_PATH = Path("internal/api/server.go")
+
+MANAGEMENT_PERSISTENCE_SYMBOLS = (
+    "config.SaveConfigPreserveComments",
+    "config.SaveConfigPreserveCommentsUpdateNestedScalar",
+    "usage.UpsertRuntimeSetting",
+    "usage.PersistRuntimeSettingsFromConfig",
+    "usage.CleanDBBackedConfigFromYAML",
+    "usage.MigrateRuntimeSettingsFromConfig",
+    "usage.ApplyStoredRuntimeSettings",
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(repo_root()).as_posix()
+
+
+def read_module_path(root: Path) -> str:
+    go_mod = root / "go.mod"
+    for line in go_mod.read_text(encoding="utf-8").splitlines():
+        if line.startswith("module "):
+            return line.split(None, 1)[1].strip()
+    raise RuntimeError("go.mod does not declare a module path")
+
+
+def load_allowlist(root: Path) -> dict[str, Any]:
+    path = root / ALLOWLIST_PATH
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"missing allowlist: {ALLOWLIST_PATH}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid JSON in {ALLOWLIST_PATH}: {exc}") from exc
+
+
+def go_files(root: Path) -> list[Path]:
+    skip_dirs = {".git", ".gocache", ".tmp-go", "vendor"}
+    files: list[Path] = []
+    for path in root.rglob("*.go"):
+        if any(part in skip_dirs for part in path.relative_to(root).parts):
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def line_count(path: Path) -> int:
+    with path.open("rb") as handle:
+        return sum(1 for _ in handle)
+
+
+def quoted_imports(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    return set(re.findall(r'"([^"]+)"', text))
+
+
+def count_symbol_occurrences(path: Path, symbols: tuple[str, ...]) -> dict[str, int]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    counts: dict[str, int] = {}
+    for symbol in symbols:
+        count = len(re.findall(re.escape(symbol), text))
+        if count:
+            counts[symbol] = count
+    return counts
+
+
+def internal_dirs(files: list[Path], root: Path) -> tuple[set[str], set[str]]:
+    prod_dirs: set[str] = set()
+    test_dirs: set[str] = set()
+    for path in files:
+        relative = path.relative_to(root)
+        if not relative.parts or relative.parts[0] != "internal":
+            continue
+        directory = relative.parent.as_posix()
+        if path.name.endswith("_test.go"):
+            test_dirs.add(directory)
+        else:
+            prod_dirs.add(directory)
+    return prod_dirs, test_dirs
+
+
+def scan() -> int:
+    root = repo_root()
+    module_path = read_module_path(root)
+    internal_import_prefix = f"{module_path}/internal/"
+    allowlist = load_allowlist(root)
+
+    files = go_files(root)
+    production_files = [p for p in files if not p.name.endswith("_test.go")]
+    test_files = [p for p in files if p.name.endswith("_test.go")]
+    internal_files = [p for p in files if p.relative_to(root).parts[:1] == ("internal",)]
+    internal_production_files = [p for p in internal_files if not p.name.endswith("_test.go")]
+
+    failures: list[str] = []
+    warnings: list[str] = []
+    notes: list[str] = []
+
+    large_allowlist = {
+        entry["path"]: entry
+        for entry in allowlist.get("large_files", {}).get("allow_above_1200", [])
+    }
+    over_800: list[tuple[str, int]] = []
+    over_1200: list[tuple[str, int]] = []
+    for path in production_files:
+        lines = line_count(path)
+        relative = rel(path)
+        if lines > WARNING_LINE_THRESHOLD:
+            over_800.append((relative, lines))
+        if lines > BLOCKING_LINE_THRESHOLD:
+            over_1200.append((relative, lines))
+            entry = large_allowlist.get(relative)
+            if entry is None:
+                failures.append(
+                    f"{relative} has {lines} lines and is not in the >1200 line allowlist"
+                )
+                continue
+            max_lines = int(entry.get("max_lines", 0))
+            if max_lines and lines > max_lines:
+                failures.append(
+                    f"{relative} grew from allowlisted max {max_lines} to {lines} lines"
+                )
+            elif max_lines and lines < max_lines:
+                notes.append(
+                    f"{relative} is below allowlisted max {max_lines}; consider tightening the allowlist"
+                )
+    for relative, lines in over_800:
+        warnings.append(f"{relative}: {lines} lines")
+
+    sdk_allowlist: dict[str, list[str]] = allowlist.get("sdk_internal_imports", {}).get(
+        "allow", {}
+    )
+    sdk_internal_files: dict[str, list[str]] = {}
+    for path in sorted((root / "sdk").rglob("*.go")):
+        if path.name.endswith("_test.go"):
+            continue
+        imports = sorted(i for i in quoted_imports(path) if i.startswith(internal_import_prefix))
+        if not imports:
+            continue
+        relative = rel(path)
+        sdk_internal_files[relative] = imports
+        allowed_imports = set(sdk_allowlist.get(relative, []))
+        if not allowed_imports:
+            failures.append(f"{relative} imports internal packages but is not allowlisted")
+            continue
+        for import_path in imports:
+            if import_path not in allowed_imports:
+                failures.append(f"{relative} has new internal import {import_path}")
+        removed = sorted(allowed_imports.difference(imports))
+        if removed:
+            notes.append(
+                f"{relative} no longer imports {', '.join(removed)}; consider tightening the allowlist"
+            )
+
+    persistence_allowlist: dict[str, dict[str, int]] = allowlist.get(
+        "management_persistence_calls", {}
+    ).get("allow", {})
+    persistence_files: dict[str, dict[str, int]] = {}
+    for path in sorted((root / MANAGEMENT_DIR).rglob("*.go")):
+        if path.name.endswith("_test.go"):
+            continue
+        counts = count_symbol_occurrences(path, MANAGEMENT_PERSISTENCE_SYMBOLS)
+        if not counts:
+            continue
+        relative = rel(path)
+        persistence_files[relative] = counts
+        allowed_counts = persistence_allowlist.get(relative, {})
+        if not allowed_counts:
+            failures.append(
+                f"{relative} directly calls persistence functions but is not allowlisted"
+            )
+            continue
+        for symbol, count in counts.items():
+            allowed_count = int(allowed_counts.get(symbol, 0))
+            if count > allowed_count:
+                failures.append(
+                    f"{relative} has {count} {symbol} calls; allowlisted maximum is {allowed_count}"
+                )
+            elif count < allowed_count:
+                notes.append(
+                    f"{relative} has fewer {symbol} calls than the allowlist; consider tightening it"
+                )
+
+    server_text = (root / SERVER_PATH).read_text(encoding="utf-8", errors="ignore")
+    management_routes = len(re.findall(r"\bmgmt\.(GET|POST|PUT|PATCH|DELETE)\s*\(", server_text))
+    handler_methods = 0
+    for path in sorted((root / MANAGEMENT_DIR).rglob("*.go")):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        handler_methods += len(re.findall(r"func\s*\(\s*h\s+\*Handler\s*\)", text))
+
+    prod_dirs, test_dirs = internal_dirs(files, root)
+    missing_test_dirs = sorted(prod_dirs.difference(test_dirs))
+
+    print("Backend structure scan")
+    print(f"Repository: {root}")
+    print(f"Go files: {len(files)} total, {len(production_files)} production, {len(test_files)} tests")
+    print(
+        "Internal Go files: "
+        f"{len(internal_files)} total, {len(internal_production_files)} production, "
+        f"{len(internal_files) - len(internal_production_files)} tests"
+    )
+    print(
+        f"Large production files: {len(over_800)} over {WARNING_LINE_THRESHOLD} lines, "
+        f"{len(over_1200)} over {BLOCKING_LINE_THRESHOLD} lines"
+    )
+    print(f"SDK production files importing internal packages: {len(sdk_internal_files)}")
+    print(f"Management handler files with direct persistence calls: {len(persistence_files)}")
+    print(f"Management routes registered in {SERVER_PATH}: {management_routes}")
+    print(f"management.Handler receiver methods: {handler_methods}")
+    print(
+        "Internal production directories: "
+        f"{len(prod_dirs)} total, {len(test_dirs)} with direct tests, "
+        f"{len(missing_test_dirs)} without direct tests"
+    )
+
+    if warnings:
+        print("\nWarnings")
+        for warning in warnings:
+            print(f"- {warning}")
+
+    if notes:
+        print("\nNotes")
+        for note in notes:
+            print(f"- {note}")
+
+    if failures:
+        print("\nFailures")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("\nResult: passed")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(scan())
+    except RuntimeError as exc:
+        print(f"Backend structure scan failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -34,14 +34,14 @@ type Record struct {
 
 // Detail holds the token usage breakdown.
 type Detail struct {
-	InputTokens            int64
-	OutputTokens           int64
-	ReasoningTokens        int64
-	CachedTokens           int64 // legacy/compat: equals CacheReadTokens if cache read exists, else equals CacheWriteTokens
-	TotalTokens            int64
-	CacheReadTokens        int64 // tokens served from cache (cache read / cache hit)
-	CacheWriteTokens       int64 // tokens written to cache (cache creation)
-	CacheReadIncludedInInput bool // when true, CacheReadTokens is a subset of InputTokens (OpenAI-compatible style)
+	InputTokens              int64
+	OutputTokens             int64
+	ReasoningTokens          int64
+	CachedTokens             int64 // legacy/compat: equals CacheReadTokens if cache read exists, else equals CacheWriteTokens
+	TotalTokens              int64
+	CacheReadTokens          int64 // tokens served from cache (cache read / cache hit)
+	CacheWriteTokens         int64 // tokens written to cache (cache creation)
+	CacheReadIncludedInInput bool  // when true, CacheReadTokens is a subset of InputTokens (OpenAI-compatible style)
 }
 
 // Plugin consumes usage records emitted by the proxy runtime.


### PR DESCRIPTION
## Summary

- Add a backend structure baseline document and allowlist for Phase 0 architecture governance.
- Add a lightweight Python structure guard for large files, SDK-to-internal imports, and management handler persistence calls.
- Run the guard in PR CI before Go setup so structural regressions fail early.
- Include a mechanical `gofmt` cleanup for existing model-pricing files that were already failing the PR format gate.

## Verification

- `python3 -m py_compile scripts/check-backend-structure.py`
- `python3 -m json.tool docs/internal-review/backend-structure-allowlist.json`
- `python3 scripts/check-backend-structure.py`
- `gofmt -l internal/api/handlers/management/models.go internal/usage/model_config_db.go internal/usage/pricing_db.go internal/usage/pricing_db_test.go sdk/cliproxy/usage/manager.go`
- `git diff --check`

## Notes

- No runtime config, database migration, API contract, or production deployment changes.
- This is Phase 0 only; later architecture phases should reduce the allowlist rather than expand it.
