### PR TITLE
refactor: extract auth file subscription presenter

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 3374,
+        "max_lines": 3061,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 586 |
-| 生产 Go 文件 | 406 |
-| 测试 Go 文件 | 180 |
-| `internal/` Go 文件 | 463 |
-| `internal/` 生产 Go 文件 | 335 |
-| `internal/` 测试 Go 文件 | 128 |
+| Go 文件总数 | 588 |
+| 生产 Go 文件 | 407 |
+| 测试 Go 文件 | 181 |
+| `internal/` Go 文件 | 465 |
+| `internal/` 生产 Go 文件 | 336 |
+| `internal/` 测试 Go 文件 | 129 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 252 |
 | `server.go` 内管理路由注册 | 194 |
-| `internal/` 生产目录 | 80 |
-| `internal/` 有同级测试目录 | 35 |
+| `internal/` 生产目录 | 81 |
+| `internal/` 有同级测试目录 | 36 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 3374 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 3061 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -32,6 +31,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -41,21 +41,6 @@ import (
 	"github.com/tidwall/gjson"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-)
-
-var (
-	lastRefreshKeys               = []string{"last_refresh", "lastRefresh", "last_refreshed_at", "lastRefreshedAt"}
-	subscriptionStartKeys         = []string{"subscription_started_at", "subscriptionStartedAt", "subscription_start_at", "subscriptionStartAt"}
-	subscriptionPeriodKeys        = []string{"subscription_period", "subscriptionPeriod"}
-	subscriptionExpirationKeys    = []string{"subscription_expires_at", "subscriptionExpiresAt"}
-	subscriptionExpirationLayouts = []string{
-		time.RFC3339,
-		time.RFC3339Nano,
-		"2006-01-02 15:04:05",
-		"2006-01-02 15:04",
-		"2006-01-02T15:04:05Z07:00",
-		"2006-01-02T15:04",
-	}
 )
 
 const (
@@ -84,304 +69,6 @@ var (
 	callbackForwardersMu sync.Mutex
 	callbackForwarders   = make(map[int]*callbackForwarder)
 )
-
-func extractLastRefreshTimestamp(meta map[string]any) (time.Time, bool) {
-	if len(meta) == 0 {
-		return time.Time{}, false
-	}
-	for _, key := range lastRefreshKeys {
-		if val, ok := meta[key]; ok {
-			if ts, ok1 := parseLastRefreshValue(val); ok1 {
-				return ts, true
-			}
-		}
-	}
-	return time.Time{}, false
-}
-
-func parseLastRefreshValue(v any) (time.Time, bool) {
-	switch val := v.(type) {
-	case string:
-		s := strings.TrimSpace(val)
-		if s == "" {
-			return time.Time{}, false
-		}
-		layouts := []string{time.RFC3339, time.RFC3339Nano, "2006-01-02 15:04:05", "2006-01-02T15:04:05Z07:00"}
-		for _, layout := range layouts {
-			if ts, err := time.Parse(layout, s); err == nil {
-				return ts.UTC(), true
-			}
-		}
-		if unix, err := strconv.ParseInt(s, 10, 64); err == nil && unix > 0 {
-			return time.Unix(unix, 0).UTC(), true
-		}
-	case float64:
-		if val <= 0 {
-			return time.Time{}, false
-		}
-		return time.Unix(int64(val), 0).UTC(), true
-	case int64:
-		if val <= 0 {
-			return time.Time{}, false
-		}
-		return time.Unix(val, 0).UTC(), true
-	case int:
-		if val <= 0 {
-			return time.Time{}, false
-		}
-		return time.Unix(int64(val), 0).UTC(), true
-	case json.Number:
-		if i, err := val.Int64(); err == nil && i > 0 {
-			return time.Unix(i, 0).UTC(), true
-		}
-	}
-	return time.Time{}, false
-}
-
-func extractSubscriptionExpirationTimestamp(meta map[string]any) (time.Time, bool) {
-	if len(meta) == 0 {
-		return time.Time{}, false
-	}
-	for _, key := range subscriptionExpirationKeys {
-		if val, ok := meta[key]; ok {
-			if ts, okParse := parseSubscriptionExpirationValue(val); okParse && !ts.IsZero() {
-				return ts.UTC(), true
-			}
-		}
-	}
-	return time.Time{}, false
-}
-
-func extractSubscriptionStartTimestamp(meta map[string]any) (time.Time, bool) {
-	if len(meta) == 0 {
-		return time.Time{}, false
-	}
-	for _, key := range subscriptionStartKeys {
-		if val, ok := meta[key]; ok {
-			if ts, okParse := parseSubscriptionExpirationValue(val); okParse && !ts.IsZero() {
-				return ts.UTC(), true
-			}
-		}
-	}
-	return time.Time{}, false
-}
-
-func extractSubscriptionPeriod(meta map[string]any) (string, bool) {
-	if len(meta) == 0 {
-		return "", false
-	}
-	for _, key := range subscriptionPeriodKeys {
-		if val, ok := meta[key]; ok {
-			if period, okParse := normalizeSubscriptionPeriodValue(val); okParse {
-				return period, true
-			}
-		}
-	}
-	return "", false
-}
-
-func normalizeSubscriptionPeriodValue(v any) (string, bool) {
-	switch val := v.(type) {
-	case string:
-		switch strings.ToLower(strings.TrimSpace(val)) {
-		case "monthly", "month":
-			return "monthly", true
-		case "yearly", "annual", "annually", "year":
-			return "yearly", true
-		default:
-			return "", false
-		}
-	case json.Number:
-		i, err := val.Int64()
-		if err != nil {
-			return "", false
-		}
-		if i == 12 {
-			return "yearly", true
-		}
-		if i == 1 {
-			return "monthly", true
-		}
-	case float64:
-		if val == 12 {
-			return "yearly", true
-		}
-		if val == 1 {
-			return "monthly", true
-		}
-	case int:
-		if val == 12 {
-			return "yearly", true
-		}
-		if val == 1 {
-			return "monthly", true
-		}
-	case int64:
-		if val == 12 {
-			return "yearly", true
-		}
-		if val == 1 {
-			return "monthly", true
-		}
-	}
-	return "", false
-}
-
-func parseSubscriptionExpirationValue(v any) (time.Time, bool) {
-	switch val := v.(type) {
-	case string:
-		s := strings.TrimSpace(val)
-		if s == "" {
-			return time.Time{}, false
-		}
-		for _, layout := range subscriptionExpirationLayouts {
-			if ts, err := time.Parse(layout, s); err == nil {
-				return ts.UTC(), true
-			}
-		}
-		if unix, err := strconv.ParseInt(s, 10, 64); err == nil {
-			return normalizeSubscriptionUnix(unix), true
-		}
-	case float64:
-		return normalizeSubscriptionUnix(int64(val)), true
-	case int64:
-		return normalizeSubscriptionUnix(val), true
-	case int:
-		return normalizeSubscriptionUnix(int64(val)), true
-	case json.Number:
-		if i, err := val.Int64(); err == nil {
-			return normalizeSubscriptionUnix(i), true
-		}
-		if f, err := val.Float64(); err == nil {
-			return normalizeSubscriptionUnix(int64(f)), true
-		}
-	}
-	return time.Time{}, false
-}
-
-func normalizeSubscriptionUnix(raw int64) time.Time {
-	if raw <= 0 {
-		return time.Time{}
-	}
-	if raw > 1_000_000_000_000 {
-		return time.UnixMilli(raw).UTC()
-	}
-	return time.Unix(raw, 0).UTC()
-}
-
-func routingMetadataString(metadata map[string]any, keys ...string) string {
-	if len(metadata) == 0 {
-		return ""
-	}
-	for _, key := range keys {
-		if key == "" {
-			continue
-		}
-		if raw, ok := metadata[key].(string); ok {
-			if value := strings.TrimSpace(raw); value != "" {
-				return value
-			}
-		}
-	}
-	return ""
-}
-
-func subscriptionExpirationFromStart(startedAt time.Time, period string) time.Time {
-	if strings.EqualFold(period, "yearly") {
-		return startedAt.AddDate(1, 0, 0).UTC()
-	}
-	return startedAt.AddDate(0, 1, 0).UTC()
-}
-
-func subscriptionRemainingMinutes(now, expiresAt time.Time) int64 {
-	diff := expiresAt.Sub(now)
-	if diff == 0 {
-		return 0
-	}
-	if diff > 0 {
-		return int64((diff + time.Minute - time.Nanosecond) / time.Minute)
-	}
-	return -int64((-diff + time.Minute - time.Nanosecond) / time.Minute)
-}
-
-func subscriptionRemainingDays(now, expiresAt time.Time) int64 {
-	diff := expiresAt.Sub(now)
-	if diff == 0 {
-		return 0
-	}
-	day := 24 * time.Hour
-	if diff > 0 {
-		return int64((diff + day - time.Nanosecond) / day)
-	}
-	return -int64((-diff + day - time.Nanosecond) / day)
-}
-
-func addSubscriptionExpirationFields(entry gin.H, meta map[string]any, now time.Time) {
-	expiresAt, ok := extractSubscriptionExpirationTimestamp(meta)
-	if !ok {
-		return
-	}
-	entry["subscription_expires_at"] = expiresAt.Format(time.RFC3339)
-	entry["subscription_expires_at_ms"] = expiresAt.UnixMilli()
-	entry["subscription_remaining_days"] = subscriptionRemainingDays(now, expiresAt)
-	entry["subscription_remaining_minutes"] = subscriptionRemainingMinutes(now, expiresAt)
-	entry["subscription_expired"] = !now.Before(expiresAt)
-}
-
-func addSubscriptionFields(entry gin.H, meta map[string]any, now time.Time) {
-	startedAt, ok := extractSubscriptionStartTimestamp(meta)
-	if !ok {
-		addSubscriptionExpirationFields(entry, meta, now)
-		return
-	}
-	period, ok := extractSubscriptionPeriod(meta)
-	if !ok {
-		period = "monthly"
-	}
-	expiresAt := subscriptionExpirationFromStart(startedAt, period)
-	entry["subscription_started_at"] = startedAt.Format(time.RFC3339)
-	entry["subscription_started_at_ms"] = startedAt.UnixMilli()
-	entry["subscription_period"] = period
-	entry["subscription_expires_at"] = expiresAt.Format(time.RFC3339)
-	entry["subscription_expires_at_ms"] = expiresAt.UnixMilli()
-	entry["subscription_remaining_days"] = subscriptionRemainingDays(now, expiresAt)
-	entry["subscription_remaining_minutes"] = subscriptionRemainingMinutes(now, expiresAt)
-	entry["subscription_expired"] = !now.Before(expiresAt)
-}
-
-func deleteSubscriptionStartMetadata(meta map[string]any) {
-	for _, key := range subscriptionStartKeys {
-		delete(meta, key)
-	}
-	delete(meta, "subscription_started_at_ms")
-	delete(meta, "subscriptionStartedAtMs")
-}
-
-func deleteSubscriptionPeriodMetadata(meta map[string]any) {
-	for _, key := range subscriptionPeriodKeys {
-		delete(meta, key)
-	}
-}
-
-func deleteSubscriptionExpirationMetadata(meta map[string]any) {
-	for _, key := range subscriptionExpirationKeys {
-		delete(meta, key)
-	}
-	delete(meta, "subscription_expires_at_ms")
-	delete(meta, "subscriptionExpiresAtMs")
-	delete(meta, "subscription_remaining_minutes")
-	delete(meta, "subscriptionRemainingMinutes")
-	delete(meta, "subscription_remaining_days")
-	delete(meta, "subscriptionRemainingDays")
-	delete(meta, "subscription_expired")
-	delete(meta, "subscriptionExpired")
-}
-
-func clearSubscriptionMetadata(meta map[string]any) {
-	deleteSubscriptionStartMetadata(meta)
-	deleteSubscriptionPeriodMetadata(meta)
-	deleteSubscriptionExpirationMetadata(meta)
-}
 
 func isWebUIRequest(c *gin.Context) bool {
 	raw := strings.TrimSpace(c.Query("is_webui"))
@@ -639,7 +326,7 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 				fileData["email"] = emailValue
 				metadata := make(map[string]any)
 				if errJSON := json.Unmarshal(data, &metadata); errJSON == nil {
-					addSubscriptionFields(fileData, metadata, time.Now())
+					managementauthfiles.AddSubscriptionFields(fileData, metadata, time.Now())
 				}
 			}
 
@@ -700,7 +387,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	if planType := normalizeTagValue(metadataString(auth.Metadata, "plan_type", "planType")); planType != "" {
 		entry["plan_type"] = planType
 	}
-	addSubscriptionFields(entry, auth.Metadata, time.Now())
+	managementauthfiles.AddSubscriptionFields(entry, auth.Metadata, time.Now())
 	if !auth.CreatedAt.IsZero() {
 		entry["created_at"] = auth.CreatedAt
 	}
@@ -1333,7 +1020,7 @@ func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []
 		}
 	}
 	label := authChannelLabelFromMetadata(metadata, provider)
-	lastRefresh, hasLastRefresh := extractLastRefreshTimestamp(metadata)
+	lastRefresh, hasLastRefresh := managementauthfiles.ExtractLastRefreshTimestamp(metadata)
 
 	authID := h.authIDForPath(path)
 	if authID == "" {
@@ -1346,9 +1033,9 @@ func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []
 	auth := &coreauth.Auth{
 		ID:         authID,
 		Provider:   provider,
-		Prefix:     routingMetadataString(metadata, "prefix"),
-		ProxyURL:   routingMetadataString(metadata, "proxy_url", "proxy-url", "proxyUrl"),
-		ProxyID:    routingMetadataString(metadata, "proxy_id", "proxy-id", "proxyId"),
+		Prefix:     managementauthfiles.MetadataString(metadata, "prefix"),
+		ProxyURL:   managementauthfiles.MetadataString(metadata, "proxy_url", "proxy-url", "proxyUrl"),
+		ProxyID:    managementauthfiles.MetadataString(metadata, "proxy_id", "proxy-id", "proxyId"),
 		FileName:   filepath.Base(path),
 		Label:      label,
 		Status:     coreauth.StatusActive,
@@ -1611,18 +1298,18 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			targetAuth.Metadata = make(map[string]any)
 		}
 		if value == "" {
-			clearSubscriptionMetadata(targetAuth.Metadata)
+			managementauthfiles.ClearSubscriptionMetadata(targetAuth.Metadata)
 		} else {
-			ts, ok := parseSubscriptionExpirationValue(value)
+			ts, ok := managementauthfiles.ParseSubscriptionTimestampValue(value)
 			if !ok || ts.IsZero() {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "subscription_started_at must be a valid time"})
 				return
 			}
-			deleteSubscriptionStartMetadata(targetAuth.Metadata)
-			deleteSubscriptionExpirationMetadata(targetAuth.Metadata)
+			managementauthfiles.DeleteSubscriptionStartMetadata(targetAuth.Metadata)
+			managementauthfiles.DeleteSubscriptionExpirationMetadata(targetAuth.Metadata)
 			targetAuth.Metadata["subscription_started_at"] = ts.UTC().Format(time.RFC3339)
 			if req.SubscriptionPeriod == nil {
-				if period, okPeriod := extractSubscriptionPeriod(targetAuth.Metadata); okPeriod {
+				if period, okPeriod := managementauthfiles.ExtractSubscriptionPeriod(targetAuth.Metadata); okPeriod {
 					targetAuth.Metadata["subscription_period"] = period
 					delete(targetAuth.Metadata, "subscriptionPeriod")
 				} else {
@@ -1638,14 +1325,14 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			targetAuth.Metadata = make(map[string]any)
 		}
 		if value == "" {
-			deleteSubscriptionPeriodMetadata(targetAuth.Metadata)
+			managementauthfiles.DeleteSubscriptionPeriodMetadata(targetAuth.Metadata)
 		} else {
-			period, ok := normalizeSubscriptionPeriodValue(value)
+			period, ok := managementauthfiles.NormalizeSubscriptionPeriodValue(value)
 			if !ok {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "subscription_period must be monthly or yearly"})
 				return
 			}
-			deleteSubscriptionPeriodMetadata(targetAuth.Metadata)
+			managementauthfiles.DeleteSubscriptionPeriodMetadata(targetAuth.Metadata)
 			targetAuth.Metadata["subscription_period"] = period
 		}
 		changed = true
@@ -1656,16 +1343,16 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			targetAuth.Metadata = make(map[string]any)
 		}
 		if value == "" {
-			clearSubscriptionMetadata(targetAuth.Metadata)
+			managementauthfiles.ClearSubscriptionMetadata(targetAuth.Metadata)
 		} else {
-			ts, ok := parseSubscriptionExpirationValue(value)
+			ts, ok := managementauthfiles.ParseSubscriptionTimestampValue(value)
 			if !ok || ts.IsZero() {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "subscription_expires_at must be a valid time"})
 				return
 			}
-			deleteSubscriptionStartMetadata(targetAuth.Metadata)
-			deleteSubscriptionPeriodMetadata(targetAuth.Metadata)
-			deleteSubscriptionExpirationMetadata(targetAuth.Metadata)
+			managementauthfiles.DeleteSubscriptionStartMetadata(targetAuth.Metadata)
+			managementauthfiles.DeleteSubscriptionPeriodMetadata(targetAuth.Metadata)
+			managementauthfiles.DeleteSubscriptionExpirationMetadata(targetAuth.Metadata)
 			targetAuth.Metadata["subscription_expires_at"] = ts.UTC().Format(time.RFC3339)
 		}
 		changed = true

--- a/internal/management/authfiles/subscription.go
+++ b/internal/management/authfiles/subscription.go
@@ -1,0 +1,351 @@
+package authfiles
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	lastRefreshKeys               = []string{"last_refresh", "lastRefresh", "last_refreshed_at", "lastRefreshedAt"}
+	subscriptionStartKeys         = []string{"subscription_started_at", "subscriptionStartedAt", "subscription_start_at", "subscriptionStartAt"}
+	subscriptionPeriodKeys        = []string{"subscription_period", "subscriptionPeriod"}
+	subscriptionExpirationKeys    = []string{"subscription_expires_at", "subscriptionExpiresAt"}
+	subscriptionExpirationLayouts = []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02T15:04",
+	}
+)
+
+// ExtractLastRefreshTimestamp returns the normalized last refresh timestamp from
+// auth metadata while accepting legacy key spellings used by older auth files.
+func ExtractLastRefreshTimestamp(meta map[string]any) (time.Time, bool) {
+	if len(meta) == 0 {
+		return time.Time{}, false
+	}
+	for _, key := range lastRefreshKeys {
+		if val, ok := meta[key]; ok {
+			if ts, ok1 := ParseLastRefreshValue(val); ok1 {
+				return ts, true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+// ParseLastRefreshValue normalizes string, number, and json.Number timestamps.
+func ParseLastRefreshValue(v any) (time.Time, bool) {
+	switch val := v.(type) {
+	case string:
+		s := strings.TrimSpace(val)
+		if s == "" {
+			return time.Time{}, false
+		}
+		layouts := []string{time.RFC3339, time.RFC3339Nano, "2006-01-02 15:04:05", "2006-01-02T15:04:05Z07:00"}
+		for _, layout := range layouts {
+			if ts, err := time.Parse(layout, s); err == nil {
+				return ts.UTC(), true
+			}
+		}
+		if unix, err := strconv.ParseInt(s, 10, 64); err == nil && unix > 0 {
+			return time.Unix(unix, 0).UTC(), true
+		}
+	case float64:
+		if val <= 0 {
+			return time.Time{}, false
+		}
+		return time.Unix(int64(val), 0).UTC(), true
+	case int64:
+		if val <= 0 {
+			return time.Time{}, false
+		}
+		return time.Unix(val, 0).UTC(), true
+	case int:
+		if val <= 0 {
+			return time.Time{}, false
+		}
+		return time.Unix(int64(val), 0).UTC(), true
+	case json.Number:
+		if i, err := val.Int64(); err == nil && i > 0 {
+			return time.Unix(i, 0).UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+// ExtractSubscriptionExpirationTimestamp returns an explicit subscription
+// expiration timestamp from metadata, accepting legacy key spellings.
+func ExtractSubscriptionExpirationTimestamp(meta map[string]any) (time.Time, bool) {
+	if len(meta) == 0 {
+		return time.Time{}, false
+	}
+	for _, key := range subscriptionExpirationKeys {
+		if val, ok := meta[key]; ok {
+			if ts, okParse := ParseSubscriptionTimestampValue(val); okParse && !ts.IsZero() {
+				return ts.UTC(), true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+// ExtractSubscriptionStartTimestamp returns the subscription start timestamp
+// from metadata, accepting legacy key spellings.
+func ExtractSubscriptionStartTimestamp(meta map[string]any) (time.Time, bool) {
+	if len(meta) == 0 {
+		return time.Time{}, false
+	}
+	for _, key := range subscriptionStartKeys {
+		if val, ok := meta[key]; ok {
+			if ts, okParse := ParseSubscriptionTimestampValue(val); okParse && !ts.IsZero() {
+				return ts.UTC(), true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+// ExtractSubscriptionPeriod returns "monthly" or "yearly" from metadata.
+func ExtractSubscriptionPeriod(meta map[string]any) (string, bool) {
+	if len(meta) == 0 {
+		return "", false
+	}
+	for _, key := range subscriptionPeriodKeys {
+		if val, ok := meta[key]; ok {
+			if period, okParse := NormalizeSubscriptionPeriodValue(val); okParse {
+				return period, true
+			}
+		}
+	}
+	return "", false
+}
+
+// NormalizeSubscriptionPeriodValue maps legacy period values onto the public
+// monthly/yearly response values.
+func NormalizeSubscriptionPeriodValue(v any) (string, bool) {
+	switch val := v.(type) {
+	case string:
+		switch strings.ToLower(strings.TrimSpace(val)) {
+		case "monthly", "month":
+			return "monthly", true
+		case "yearly", "annual", "annually", "year":
+			return "yearly", true
+		default:
+			return "", false
+		}
+	case json.Number:
+		i, err := val.Int64()
+		if err != nil {
+			return "", false
+		}
+		if i == 12 {
+			return "yearly", true
+		}
+		if i == 1 {
+			return "monthly", true
+		}
+	case float64:
+		if val == 12 {
+			return "yearly", true
+		}
+		if val == 1 {
+			return "monthly", true
+		}
+	case int:
+		if val == 12 {
+			return "yearly", true
+		}
+		if val == 1 {
+			return "monthly", true
+		}
+	case int64:
+		if val == 12 {
+			return "yearly", true
+		}
+		if val == 1 {
+			return "monthly", true
+		}
+	}
+	return "", false
+}
+
+// ParseSubscriptionTimestampValue accepts RFC3339-like strings and Unix
+// timestamps in seconds or milliseconds.
+func ParseSubscriptionTimestampValue(v any) (time.Time, bool) {
+	switch val := v.(type) {
+	case string:
+		s := strings.TrimSpace(val)
+		if s == "" {
+			return time.Time{}, false
+		}
+		for _, layout := range subscriptionExpirationLayouts {
+			if ts, err := time.Parse(layout, s); err == nil {
+				return ts.UTC(), true
+			}
+		}
+		if unix, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return NormalizeSubscriptionUnix(unix), true
+		}
+	case float64:
+		return NormalizeSubscriptionUnix(int64(val)), true
+	case int64:
+		return NormalizeSubscriptionUnix(val), true
+	case int:
+		return NormalizeSubscriptionUnix(int64(val)), true
+	case json.Number:
+		if i, err := val.Int64(); err == nil {
+			return NormalizeSubscriptionUnix(i), true
+		}
+		if f, err := val.Float64(); err == nil {
+			return NormalizeSubscriptionUnix(int64(f)), true
+		}
+	}
+	return time.Time{}, false
+}
+
+// NormalizeSubscriptionUnix converts positive second or millisecond Unix values
+// to UTC timestamps.
+func NormalizeSubscriptionUnix(raw int64) time.Time {
+	if raw <= 0 {
+		return time.Time{}
+	}
+	if raw > 1_000_000_000_000 {
+		return time.UnixMilli(raw).UTC()
+	}
+	return time.Unix(raw, 0).UTC()
+}
+
+// MetadataString returns the first non-empty string value for the provided keys.
+func MetadataString(metadata map[string]any, keys ...string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if raw, ok := metadata[key].(string); ok {
+			if value := strings.TrimSpace(raw); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+// SubscriptionExpirationFromStart derives the expiration timestamp for monthly
+// and yearly subscription periods.
+func SubscriptionExpirationFromStart(startedAt time.Time, period string) time.Time {
+	if strings.EqualFold(period, "yearly") {
+		return startedAt.AddDate(1, 0, 0).UTC()
+	}
+	return startedAt.AddDate(0, 1, 0).UTC()
+}
+
+// SubscriptionRemainingMinutes rounds away from zero to match the management API
+// countdown fields.
+func SubscriptionRemainingMinutes(now, expiresAt time.Time) int64 {
+	diff := expiresAt.Sub(now)
+	if diff == 0 {
+		return 0
+	}
+	if diff > 0 {
+		return int64((diff + time.Minute - time.Nanosecond) / time.Minute)
+	}
+	return -int64((-diff + time.Minute - time.Nanosecond) / time.Minute)
+}
+
+// SubscriptionRemainingDays rounds away from zero to match the management API
+// countdown fields.
+func SubscriptionRemainingDays(now, expiresAt time.Time) int64 {
+	diff := expiresAt.Sub(now)
+	if diff == 0 {
+		return 0
+	}
+	day := 24 * time.Hour
+	if diff > 0 {
+		return int64((diff + day - time.Nanosecond) / day)
+	}
+	return -int64((-diff + day - time.Nanosecond) / day)
+}
+
+// AddSubscriptionFields adds the public subscription fields used by the
+// management auth-file list/detail responses.
+func AddSubscriptionFields(entry map[string]any, meta map[string]any, now time.Time) {
+	startedAt, ok := ExtractSubscriptionStartTimestamp(meta)
+	if !ok {
+		addSubscriptionExpirationFields(entry, meta, now)
+		return
+	}
+	period, ok := ExtractSubscriptionPeriod(meta)
+	if !ok {
+		period = "monthly"
+	}
+	expiresAt := SubscriptionExpirationFromStart(startedAt, period)
+	entry["subscription_started_at"] = startedAt.Format(time.RFC3339)
+	entry["subscription_started_at_ms"] = startedAt.UnixMilli()
+	entry["subscription_period"] = period
+	entry["subscription_expires_at"] = expiresAt.Format(time.RFC3339)
+	entry["subscription_expires_at_ms"] = expiresAt.UnixMilli()
+	entry["subscription_remaining_days"] = SubscriptionRemainingDays(now, expiresAt)
+	entry["subscription_remaining_minutes"] = SubscriptionRemainingMinutes(now, expiresAt)
+	entry["subscription_expired"] = !now.Before(expiresAt)
+}
+
+func addSubscriptionExpirationFields(entry map[string]any, meta map[string]any, now time.Time) {
+	expiresAt, ok := ExtractSubscriptionExpirationTimestamp(meta)
+	if !ok {
+		return
+	}
+	entry["subscription_expires_at"] = expiresAt.Format(time.RFC3339)
+	entry["subscription_expires_at_ms"] = expiresAt.UnixMilli()
+	entry["subscription_remaining_days"] = SubscriptionRemainingDays(now, expiresAt)
+	entry["subscription_remaining_minutes"] = SubscriptionRemainingMinutes(now, expiresAt)
+	entry["subscription_expired"] = !now.Before(expiresAt)
+}
+
+// DeleteSubscriptionStartMetadata removes canonical and legacy subscription
+// start keys from auth metadata.
+func DeleteSubscriptionStartMetadata(meta map[string]any) {
+	for _, key := range subscriptionStartKeys {
+		delete(meta, key)
+	}
+	delete(meta, "subscription_started_at_ms")
+	delete(meta, "subscriptionStartedAtMs")
+}
+
+// DeleteSubscriptionPeriodMetadata removes canonical and legacy subscription
+// period keys from auth metadata.
+func DeleteSubscriptionPeriodMetadata(meta map[string]any) {
+	for _, key := range subscriptionPeriodKeys {
+		delete(meta, key)
+	}
+}
+
+// DeleteSubscriptionExpirationMetadata removes canonical, legacy, and derived
+// subscription expiration keys from auth metadata.
+func DeleteSubscriptionExpirationMetadata(meta map[string]any) {
+	for _, key := range subscriptionExpirationKeys {
+		delete(meta, key)
+	}
+	delete(meta, "subscription_expires_at_ms")
+	delete(meta, "subscriptionExpiresAtMs")
+	delete(meta, "subscription_remaining_minutes")
+	delete(meta, "subscriptionRemainingMinutes")
+	delete(meta, "subscription_remaining_days")
+	delete(meta, "subscriptionRemainingDays")
+	delete(meta, "subscription_expired")
+	delete(meta, "subscriptionExpired")
+}
+
+// ClearSubscriptionMetadata removes all stored and derived subscription fields.
+func ClearSubscriptionMetadata(meta map[string]any) {
+	DeleteSubscriptionStartMetadata(meta)
+	DeleteSubscriptionPeriodMetadata(meta)
+	DeleteSubscriptionExpirationMetadata(meta)
+}

--- a/internal/management/authfiles/subscription_test.go
+++ b/internal/management/authfiles/subscription_test.go
@@ -1,0 +1,90 @@
+package authfiles
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestExtractLastRefreshTimestampAcceptsLegacyKeys(t *testing.T) {
+	got, ok := ExtractLastRefreshTimestamp(map[string]any{
+		"lastRefreshedAt": json.Number("1772449800"),
+	})
+	if !ok {
+		t.Fatal("expected last refresh timestamp")
+	}
+	want := time.Unix(1772449800, 0).UTC()
+	if !got.Equal(want) {
+		t.Fatalf("timestamp = %s, want %s", got, want)
+	}
+}
+
+func TestParseSubscriptionTimestampValueAcceptsMilliseconds(t *testing.T) {
+	want := time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC)
+	got, ok := ParseSubscriptionTimestampValue(want.UnixMilli())
+	if !ok {
+		t.Fatal("expected subscription timestamp")
+	}
+	if !got.Equal(want) {
+		t.Fatalf("timestamp = %s, want %s", got, want)
+	}
+}
+
+func TestAddSubscriptionFieldsUsesExplicitExpiration(t *testing.T) {
+	now := time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC)
+	expiresAt := now.Add(90 * time.Minute)
+	entry := map[string]any{}
+
+	AddSubscriptionFields(entry, map[string]any{
+		"subscriptionExpiresAt": expiresAt.Format(time.RFC3339),
+	}, now)
+
+	if got, _ := entry["subscription_expires_at"].(string); got != expiresAt.Format(time.RFC3339) {
+		t.Fatalf("subscription_expires_at = %q, want %q", got, expiresAt.Format(time.RFC3339))
+	}
+	if got, _ := entry["subscription_remaining_minutes"].(int64); got != 90 {
+		t.Fatalf("subscription_remaining_minutes = %d, want 90", got)
+	}
+	if expired, _ := entry["subscription_expired"].(bool); expired {
+		t.Fatal("subscription_expired = true, want false")
+	}
+}
+
+func TestAddSubscriptionFieldsDerivesExpirationFromStartAndPeriod(t *testing.T) {
+	now := time.Date(2026, 4, 15, 9, 30, 0, 0, time.UTC)
+	startedAt := time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC)
+	entry := map[string]any{}
+
+	AddSubscriptionFields(entry, map[string]any{
+		"subscription_start_at": startedAt.Format(time.RFC3339),
+		"subscriptionPeriod":    "annual",
+	}, now)
+
+	wantExpiresAt := startedAt.AddDate(1, 0, 0)
+	if got, _ := entry["subscription_period"].(string); got != "yearly" {
+		t.Fatalf("subscription_period = %q, want yearly", got)
+	}
+	if got, _ := entry["subscription_expires_at"].(string); got != wantExpiresAt.Format(time.RFC3339) {
+		t.Fatalf("subscription_expires_at = %q, want %q", got, wantExpiresAt.Format(time.RFC3339))
+	}
+}
+
+func TestClearSubscriptionMetadataRemovesStoredAndDerivedKeys(t *testing.T) {
+	meta := map[string]any{
+		"subscription_started_at":        "2026-04-01T09:30:00Z",
+		"subscriptionStartedAt":          "2026-04-01T09:30:00Z",
+		"subscription_period":            "monthly",
+		"subscriptionPeriod":             "monthly",
+		"subscription_expires_at":        "2026-05-01T09:30:00Z",
+		"subscriptionExpiresAt":          "2026-05-01T09:30:00Z",
+		"subscription_remaining_minutes": 10,
+		"subscriptionRemainingDays":      1,
+		"subscription_expired":           false,
+	}
+
+	ClearSubscriptionMetadata(meta)
+
+	for key := range meta {
+		t.Fatalf("unexpected remaining key %q", key)
+	}
+}


### PR DESCRIPTION
## Summary

- Move auth-file last-refresh and subscription metadata parsing/presenter logic into `internal/management/authfiles`.
- Keep existing management handlers and response fields compatible while delegating the pure metadata logic to the new package.
- Add direct unit coverage for timestamp parsing, subscription response fields, and metadata cleanup.
- Tighten the backend structure allowlist for `auth_files.go` from 3374 to 3061 lines and refresh the structure baseline counts.

## Verification

- `go test ./internal/management/... ./internal/api/handlers/management`
- `python3 scripts/check-backend-structure.py`
- `python3 -m json.tool docs/internal-review/backend-structure-allowlist.json`
- `git diff --check`

## Notes

- No API route, response contract, database migration, runtime config, or production deployment changes.
- This is the first Phase 1 auth-files extraction slice; OAuth/provider flows remain untouched.
