### PR TITLE
refactor: extract auth file identity presenter

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 2839,
+        "max_lines": 2765,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 590 |
-| 生产 Go 文件 | 408 |
-| 测试 Go 文件 | 182 |
-| `internal/` Go 文件 | 467 |
-| `internal/` 生产 Go 文件 | 337 |
-| `internal/` 测试 Go 文件 | 130 |
+| Go 文件总数 | 592 |
+| 生产 Go 文件 | 409 |
+| 测试 Go 文件 | 183 |
+| `internal/` Go 文件 | 469 |
+| `internal/` 生产 Go 文件 | 338 |
+| `internal/` 测试 Go 文件 | 131 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 2839 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 2765 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -341,11 +341,11 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 		return nil
 	}
 	auth.EnsureIndex()
-	runtimeOnly := isRuntimeOnlyAuth(auth)
+	runtimeOnly := managementauthfiles.IsRuntimeOnly(auth)
 	if runtimeOnly && (auth.Disabled || auth.Status == coreauth.StatusDisabled) {
 		return nil
 	}
-	path := strings.TrimSpace(authAttribute(auth, "path"))
+	path := strings.TrimSpace(managementauthfiles.Attribute(auth, "path"))
 	if path == "" && !runtimeOnly {
 		return nil
 	}
@@ -368,7 +368,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 		"source":         "memory",
 		"size":           int64(0),
 	}
-	if email := authEmail(auth); email != "" {
+	if email := managementauthfiles.Email(auth); email != "" {
 		entry["email"] = email
 	}
 	if accountType, account := auth.AccountInfo(); accountType != "" || account != "" {
@@ -420,84 +420,10 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 			log.WithError(err).Warnf("failed to stat auth file %s", path)
 		}
 	}
-	if claims := extractCodexIDTokenClaims(auth); claims != nil {
+	if claims := managementauthfiles.CodexIDTokenClaims(auth); claims != nil {
 		entry["id_token"] = claims
 	}
 	return entry
-}
-
-func extractCodexIDTokenClaims(auth *coreauth.Auth) gin.H {
-	if auth == nil || auth.Metadata == nil {
-		return nil
-	}
-	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
-		return nil
-	}
-	idTokenRaw, ok := auth.Metadata["id_token"].(string)
-	if !ok {
-		return nil
-	}
-	idToken := strings.TrimSpace(idTokenRaw)
-	if idToken == "" {
-		return nil
-	}
-	claims, err := codex.ParseJWTToken(idToken)
-	if err != nil || claims == nil {
-		return nil
-	}
-
-	result := gin.H{}
-	if v := strings.TrimSpace(claims.CodexAuthInfo.ChatgptAccountID); v != "" {
-		result["chatgpt_account_id"] = v
-	}
-	if v := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType); v != "" {
-		result["plan_type"] = v
-	}
-	if v := claims.CodexAuthInfo.ChatgptSubscriptionActiveStart; v != nil {
-		result["chatgpt_subscription_active_start"] = v
-	}
-	if v := claims.CodexAuthInfo.ChatgptSubscriptionActiveUntil; v != nil {
-		result["chatgpt_subscription_active_until"] = v
-	}
-
-	if len(result) == 0 {
-		return nil
-	}
-	return result
-}
-
-func authEmail(auth *coreauth.Auth) string {
-	if auth == nil {
-		return ""
-	}
-	if auth.Metadata != nil {
-		if v, ok := auth.Metadata["email"].(string); ok {
-			return strings.TrimSpace(v)
-		}
-	}
-	if auth.Attributes != nil {
-		if v := strings.TrimSpace(auth.Attributes["email"]); v != "" {
-			return v
-		}
-		if v := strings.TrimSpace(auth.Attributes["account_email"]); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
-func authAttribute(auth *coreauth.Auth, key string) string {
-	if auth == nil || len(auth.Attributes) == 0 {
-		return ""
-	}
-	return auth.Attributes[key]
-}
-
-func isRuntimeOnlyAuth(auth *coreauth.Auth) bool {
-	if auth == nil || len(auth.Attributes) == 0 {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(auth.Attributes["runtime_only"]), "true")
 }
 
 // Download single auth file by name
@@ -714,7 +640,7 @@ func (h *Handler) findAuthByNameOrID(name string) *coreauth.Auth {
 		if strings.EqualFold(strings.TrimSpace(auth.FileName), name) {
 			return auth
 		}
-		if path := strings.TrimSpace(authAttribute(auth, "path")); path != "" && strings.EqualFold(filepath.Base(path), name) {
+		if path := strings.TrimSpace(managementauthfiles.Attribute(auth, "path")); path != "" && strings.EqualFold(filepath.Base(path), name) {
 			return auth
 		}
 	}
@@ -967,7 +893,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "label is only supported for oauth auth files"})
 			return
 		}
-		if isRuntimeOnlyAuth(targetAuth) {
+		if managementauthfiles.IsRuntimeOnly(targetAuth) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "runtime-only auth files cannot rename channel"})
 			return
 		}
@@ -1147,7 +1073,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update auth: %v", err)})
 		return
 	}
-	if path := strings.TrimSpace(authAttribute(targetAuth, "path")); path != "" {
+	if path := strings.TrimSpace(managementauthfiles.Attribute(targetAuth, "path")); path != "" {
 		if err := h.persistAuthFileChange(ctx, "Update auth "+targetAuth.FileName, path); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -438,9 +438,9 @@ func TestBuildAuthFileEntryExposesMetadataPlanTypeBeforeIDTokenClaim(t *testing.
 	if got, _ := entry["plan_type"].(string); got != "free" {
 		t.Fatalf("plan_type = %q, want free", got)
 	}
-	claims, ok := entry["id_token"].(gin.H)
+	claims, ok := entry["id_token"].(map[string]any)
 	if !ok {
-		t.Fatalf("id_token type = %T, want gin.H", entry["id_token"])
+		t.Fatalf("id_token type = %T, want map[string]any", entry["id_token"])
 	}
 	if got, _ := claims["plan_type"].(string); got != "plus" {
 		t.Fatalf("id_token.plan_type = %q, want plus", got)

--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -141,7 +142,7 @@ func includeAuthInChannelGroups(auth *coreauth.Auth) bool {
 		strings.EqualFold(statusMessage, "removed via config update") {
 		return false
 	}
-	if isRuntimeOnlyAuth(auth) && (auth.Disabled || auth.Status == coreauth.StatusDisabled) {
+	if managementauthfiles.IsRuntimeOnly(auth) && (auth.Disabled || auth.Status == coreauth.StatusDisabled) {
 		return false
 	}
 	return true

--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -342,7 +343,7 @@ func (h *Handler) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelM
 					})
 				}
 			}
-			if email := strings.TrimSpace(authEmail(auth)); email != "" {
+			if email := strings.TrimSpace(managementauthfiles.Email(auth)); email != "" {
 				legacyCandidates = append(legacyCandidates, legacyChannelCandidate{
 					key:       email,
 					channel:   channel,

--- a/internal/management/authfiles/identity.go
+++ b/internal/management/authfiles/identity.go
@@ -1,0 +1,84 @@
+package authfiles
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// Email returns the display email stored in auth metadata or attributes.
+func Email(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if email := MetadataString(auth.Metadata, "email"); email != "" {
+		return email
+	}
+	if auth.Attributes != nil {
+		if v := strings.TrimSpace(auth.Attributes["email"]); v != "" {
+			return v
+		}
+		if v := strings.TrimSpace(auth.Attributes["account_email"]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// Attribute returns an auth attribute value without exposing the attributes map
+// to callers that only need read-only display data.
+func Attribute(auth *coreauth.Auth, key string) string {
+	if auth == nil || len(auth.Attributes) == 0 {
+		return ""
+	}
+	return auth.Attributes[key]
+}
+
+// IsRuntimeOnly reports whether an auth entry exists only in memory and should
+// not require a backing file path.
+func IsRuntimeOnly(auth *coreauth.Auth) bool {
+	return strings.EqualFold(strings.TrimSpace(Attribute(auth, "runtime_only")), "true")
+}
+
+// CodexIDTokenClaims extracts the user-facing Codex id-token claims shown by
+// the management auth-file response.
+func CodexIDTokenClaims(auth *coreauth.Auth) map[string]any {
+	if auth == nil || auth.Metadata == nil {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return nil
+	}
+	idTokenRaw, ok := auth.Metadata["id_token"].(string)
+	if !ok {
+		return nil
+	}
+	idToken := strings.TrimSpace(idTokenRaw)
+	if idToken == "" {
+		return nil
+	}
+	claims, err := codex.ParseJWTToken(idToken)
+	if err != nil || claims == nil {
+		return nil
+	}
+
+	result := map[string]any{}
+	if v := strings.TrimSpace(claims.CodexAuthInfo.ChatgptAccountID); v != "" {
+		result["chatgpt_account_id"] = v
+	}
+	if v := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType); v != "" {
+		result["plan_type"] = v
+	}
+	if v := claims.CodexAuthInfo.ChatgptSubscriptionActiveStart; v != nil {
+		result["chatgpt_subscription_active_start"] = v
+	}
+	if v := claims.CodexAuthInfo.ChatgptSubscriptionActiveUntil; v != nil {
+		result["chatgpt_subscription_active_until"] = v
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/internal/management/authfiles/identity_test.go
+++ b/internal/management/authfiles/identity_test.go
@@ -1,0 +1,69 @@
+package authfiles
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestEmailPrefersMetadataThenAttributes(t *testing.T) {
+	auth := &coreauth.Auth{
+		Metadata: map[string]any{"email": " metadata@example.com "},
+		Attributes: map[string]string{
+			"email": "attribute@example.com",
+		},
+	}
+	if got := Email(auth); got != "metadata@example.com" {
+		t.Fatalf("Email() = %q, want metadata@example.com", got)
+	}
+
+	delete(auth.Metadata, "email")
+	if got := Email(auth); got != "attribute@example.com" {
+		t.Fatalf("Email() = %q, want attribute@example.com", got)
+	}
+}
+
+func TestIsRuntimeOnlyUsesRuntimeOnlyAttribute(t *testing.T) {
+	auth := &coreauth.Auth{Attributes: map[string]string{"runtime_only": " true "}}
+	if !IsRuntimeOnly(auth) {
+		t.Fatal("IsRuntimeOnly() = false, want true")
+	}
+}
+
+func TestCodexIDTokenClaimsReturnsDisplayClaims(t *testing.T) {
+	idToken := makeJWTForTest(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_plan_type":  "plus",
+			"chatgpt_account_id": "acct_123",
+		},
+	})
+	auth := &coreauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"id_token": idToken},
+	}
+
+	claims := CodexIDTokenClaims(auth)
+	if claims == nil {
+		t.Fatal("expected id token claims")
+	}
+	if got, _ := claims["plan_type"].(string); got != "plus" {
+		t.Fatalf("plan_type = %q, want plus", got)
+	}
+	if got, _ := claims["chatgpt_account_id"].(string); got != "acct_123" {
+		t.Fatalf("chatgpt_account_id = %q, want acct_123", got)
+	}
+}
+
+func makeJWTForTest(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	encode := func(v any) string {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal jwt part: %v", err)
+		}
+		return base64.RawURLEncoding.EncodeToString(raw)
+	}
+	return encode(map[string]any{"alg": "none", "typ": "JWT"}) + "." + encode(claims) + ".sig"
+}


### PR DESCRIPTION
## Summary

- Move auth-file display helpers for email, runtime-only attributes, and Codex id-token claims into `internal/management/authfiles`.
- Keep response fields compatible while removing more presenter logic from the legacy management handler.
- Update channel group and usage-log callers to use the same authfiles display helpers.
- Tighten the backend structure allowlist for `auth_files.go` from 2839 to 2765 lines and refresh structure counts.

## Verification

- `go test ./internal/management/... ./internal/api/handlers/management`
- `python3 scripts/check-backend-structure.py`
- `python3 -m json.tool docs/internal-review/backend-structure-allowlist.json`
- `git diff --check`

## Notes

- No API route, database migration, runtime config, OAuth flow, or production deployment changes.
- Tags remain in the existing management helper because channel groups and API tools already share that logic.
