### PR TITLE
refactor: move auth file entry builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 2765,
+        "max_lines": 2687,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 594 |
-| 生产 Go 文件 | 410 |
-| 测试 Go 文件 | 184 |
-| `internal/` Go 文件 | 471 |
-| `internal/` 生产 Go 文件 | 339 |
-| `internal/` 测试 Go 文件 | 132 |
+| Go 文件总数 | 596 |
+| 生产 Go 文件 | 411 |
+| 测试 Go 文件 | 185 |
+| `internal/` Go 文件 | 473 |
+| `internal/` 生产 Go 文件 | 340 |
+| `internal/` 测试 Go 文件 | 133 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 2765 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 2687 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -337,93 +337,15 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 }
 
 func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
-	if auth == nil {
-		return nil
-	}
-	auth.EnsureIndex()
-	runtimeOnly := managementauthfiles.IsRuntimeOnly(auth)
-	if runtimeOnly && (auth.Disabled || auth.Status == coreauth.StatusDisabled) {
-		return nil
-	}
-	path := strings.TrimSpace(managementauthfiles.Attribute(auth, "path"))
-	if path == "" && !runtimeOnly {
-		return nil
-	}
-	name := strings.TrimSpace(auth.FileName)
-	if name == "" {
-		name = auth.ID
-	}
-	entry := gin.H{
-		"id":             auth.ID,
-		"auth_index":     auth.Index,
-		"name":           name,
-		"type":           strings.TrimSpace(auth.Provider),
-		"provider":       strings.TrimSpace(auth.Provider),
-		"label":          auth.ChannelName(),
-		"status":         auth.Status,
-		"status_message": auth.StatusMessage,
-		"disabled":       auth.Disabled,
-		"unavailable":    auth.Unavailable,
-		"runtime_only":   runtimeOnly,
-		"source":         "memory",
-		"size":           int64(0),
-	}
-	if email := managementauthfiles.Email(auth); email != "" {
-		entry["email"] = email
-	}
-	if accountType, account := auth.AccountInfo(); accountType != "" || account != "" {
-		if accountType != "" {
-			entry["account_type"] = accountType
-		}
-		if account != "" {
-			entry["account"] = account
-		}
-	}
-	tags := managementauthfiles.BuildTagPayload(auth)
-	entry["default_tags"] = tags.DefaultTags
-	entry["custom_tags"] = tags.CustomTags
-	entry["hidden_default_tags"] = tags.HiddenDefaultTags
-	entry["display_tags"] = tags.DisplayTags
-	if planType := managementauthfiles.NormalizeTagValue(managementauthfiles.MetadataString(auth.Metadata, "plan_type", "planType")); planType != "" {
-		entry["plan_type"] = planType
-	}
-	managementauthfiles.AddSubscriptionFields(entry, auth.Metadata, time.Now())
-	if !auth.CreatedAt.IsZero() {
-		entry["created_at"] = auth.CreatedAt
-	}
-	if !auth.UpdatedAt.IsZero() {
-		entry["modtime"] = auth.UpdatedAt
-		entry["updated_at"] = auth.UpdatedAt
-	}
-	if !auth.LastRefreshedAt.IsZero() {
-		entry["last_refresh"] = auth.LastRefreshedAt
-	}
-	if !auth.NextRetryAfter.IsZero() {
-		entry["next_retry_after"] = auth.NextRetryAfter
-	}
-	if restrictions := managementauthfiles.BuildRestrictionPayload(auth, time.Now()); len(restrictions) > 0 {
-		entry["restrictions"] = restrictions
-	}
-	if path != "" {
-		entry["path"] = path
-		entry["source"] = "file"
-		if info, err := os.Stat(path); err == nil {
-			entry["size"] = info.Size()
-			entry["modtime"] = info.ModTime()
-		} else if os.IsNotExist(err) {
-			// Hide credentials removed from disk but still lingering in memory.
-			if !runtimeOnly && (auth.Disabled || auth.Status == coreauth.StatusDisabled || strings.EqualFold(strings.TrimSpace(auth.StatusMessage), "removed via management api")) {
-				return nil
-			}
-			entry["source"] = "memory"
-		} else {
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{
+		OnStatError: func(path string, err error) {
 			log.WithError(err).Warnf("failed to stat auth file %s", path)
-		}
+		},
+	})
+	if entry == nil {
+		return nil
 	}
-	if claims := managementauthfiles.CodexIDTokenClaims(auth); claims != nil {
-		entry["id_token"] = claims
-	}
-	return entry
+	return gin.H(entry)
 }
 
 // Download single auth file by name

--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -1,0 +1,117 @@
+package authfiles
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type EntryOptions struct {
+	Now         time.Time
+	Stat        func(string) (os.FileInfo, error)
+	OnStatError func(string, error)
+}
+
+// BuildEntry returns the public management auth-file entry for an auth record.
+// It preserves legacy response fields while keeping file-stat side effects
+// injected by the transport wrapper.
+func BuildEntry(auth *coreauth.Auth, opts EntryOptions) map[string]any {
+	if auth == nil {
+		return nil
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	stat := opts.Stat
+	if stat == nil {
+		stat = os.Stat
+	}
+
+	auth.EnsureIndex()
+	runtimeOnly := IsRuntimeOnly(auth)
+	if runtimeOnly && (auth.Disabled || auth.Status == coreauth.StatusDisabled) {
+		return nil
+	}
+	path := strings.TrimSpace(Attribute(auth, "path"))
+	if path == "" && !runtimeOnly {
+		return nil
+	}
+	name := strings.TrimSpace(auth.FileName)
+	if name == "" {
+		name = auth.ID
+	}
+	entry := map[string]any{
+		"id":             auth.ID,
+		"auth_index":     auth.Index,
+		"name":           name,
+		"type":           strings.TrimSpace(auth.Provider),
+		"provider":       strings.TrimSpace(auth.Provider),
+		"label":          auth.ChannelName(),
+		"status":         auth.Status,
+		"status_message": auth.StatusMessage,
+		"disabled":       auth.Disabled,
+		"unavailable":    auth.Unavailable,
+		"runtime_only":   runtimeOnly,
+		"source":         "memory",
+		"size":           int64(0),
+	}
+	if email := Email(auth); email != "" {
+		entry["email"] = email
+	}
+	if accountType, account := auth.AccountInfo(); accountType != "" || account != "" {
+		if accountType != "" {
+			entry["account_type"] = accountType
+		}
+		if account != "" {
+			entry["account"] = account
+		}
+	}
+	tags := BuildTagPayload(auth)
+	entry["default_tags"] = tags.DefaultTags
+	entry["custom_tags"] = tags.CustomTags
+	entry["hidden_default_tags"] = tags.HiddenDefaultTags
+	entry["display_tags"] = tags.DisplayTags
+	if planType := NormalizeTagValue(MetadataString(auth.Metadata, "plan_type", "planType")); planType != "" {
+		entry["plan_type"] = planType
+	}
+	AddSubscriptionFields(entry, auth.Metadata, now)
+	if !auth.CreatedAt.IsZero() {
+		entry["created_at"] = auth.CreatedAt
+	}
+	if !auth.UpdatedAt.IsZero() {
+		entry["modtime"] = auth.UpdatedAt
+		entry["updated_at"] = auth.UpdatedAt
+	}
+	if !auth.LastRefreshedAt.IsZero() {
+		entry["last_refresh"] = auth.LastRefreshedAt
+	}
+	if !auth.NextRetryAfter.IsZero() {
+		entry["next_retry_after"] = auth.NextRetryAfter
+	}
+	if restrictions := BuildRestrictionPayload(auth, now); len(restrictions) > 0 {
+		entry["restrictions"] = restrictions
+	}
+	if path != "" {
+		entry["path"] = path
+		entry["source"] = "file"
+		if info, err := stat(path); err == nil {
+			entry["size"] = info.Size()
+			entry["modtime"] = info.ModTime()
+		} else if os.IsNotExist(err) {
+			// Hide credentials removed from disk but still lingering in memory.
+			if !runtimeOnly && (auth.Disabled || auth.Status == coreauth.StatusDisabled || strings.EqualFold(strings.TrimSpace(auth.StatusMessage), "removed via management api")) {
+				return nil
+			}
+			entry["source"] = "memory"
+		} else if opts.OnStatError != nil {
+			opts.OnStatError(path, err)
+		}
+	}
+	if claims := CodexIDTokenClaims(auth); claims != nil {
+		entry["id_token"] = claims
+	}
+	return entry
+}

--- a/internal/management/authfiles/entry_test.go
+++ b/internal/management/authfiles/entry_test.go
@@ -1,0 +1,130 @@
+package authfiles
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestBuildEntryRequiresPathForNonRuntimeAuth(t *testing.T) {
+	auth := &coreauth.Auth{ID: "missing-path", Provider: "codex"}
+	if entry := BuildEntry(auth, EntryOptions{}); entry != nil {
+		t.Fatalf("BuildEntry() = %#v, want nil", entry)
+	}
+}
+
+func TestBuildEntryAllowsRuntimeOnlyAuthWithoutPath(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "runtime",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{})
+	if entry == nil {
+		t.Fatal("expected runtime-only entry")
+	}
+	if runtimeOnly, _ := entry["runtime_only"].(bool); !runtimeOnly {
+		t.Fatalf("runtime_only = %#v, want true", entry["runtime_only"])
+	}
+	if source, _ := entry["source"].(string); source != "memory" {
+		t.Fatalf("source = %q, want memory", source)
+	}
+}
+
+func TestBuildEntryUsesInjectedStat(t *testing.T) {
+	modtime := time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC)
+	auth := &coreauth.Auth{
+		ID:       "file-auth",
+		FileName: "file-auth.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/file-auth.json",
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{
+		Stat: func(path string) (os.FileInfo, error) {
+			if path != "/tmp/file-auth.json" {
+				t.Fatalf("stat path = %q, want /tmp/file-auth.json", path)
+			}
+			return fakeFileInfo{size: 42, modtime: modtime}, nil
+		},
+	})
+	if entry == nil {
+		t.Fatal("expected file entry")
+	}
+	if got, _ := entry["size"].(int64); got != 42 {
+		t.Fatalf("size = %d, want 42", got)
+	}
+	if got, _ := entry["modtime"].(time.Time); !got.Equal(modtime) {
+		t.Fatalf("modtime = %v, want %v", got, modtime)
+	}
+}
+
+func TestBuildEntryHidesRemovedDisabledFileAuth(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "removed-auth",
+		Provider: "codex",
+		Disabled: true,
+		Attributes: map[string]string{
+			"path": "/tmp/removed-auth.json",
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{
+		Stat: func(string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		},
+	})
+	if entry != nil {
+		t.Fatalf("BuildEntry() = %#v, want nil", entry)
+	}
+}
+
+func TestBuildEntryCallsStatErrorHook(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "stat-error",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/stat-error.json",
+		},
+	}
+	wantErr := errors.New("boom")
+	var called bool
+
+	entry := BuildEntry(auth, EntryOptions{
+		Stat: func(string) (os.FileInfo, error) {
+			return nil, wantErr
+		},
+		OnStatError: func(path string, err error) {
+			called = true
+			if path != "/tmp/stat-error.json" || !errors.Is(err, wantErr) {
+				t.Fatalf("stat hook = (%q, %v), want path and boom", path, err)
+			}
+		},
+	})
+	if entry == nil {
+		t.Fatal("expected entry even when stat fails")
+	}
+	if !called {
+		t.Fatal("expected stat error hook")
+	}
+}
+
+type fakeFileInfo struct {
+	size    int64
+	modtime time.Time
+}
+
+func (f fakeFileInfo) Name() string       { return "fake" }
+func (f fakeFileInfo) Size() int64        { return f.size }
+func (f fakeFileInfo) Mode() os.FileMode  { return 0 }
+func (f fakeFileInfo) ModTime() time.Time { return f.modtime }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }


### PR DESCRIPTION
## Summary
- Move auth file entry presentation into internal/management/authfiles.BuildEntry.
- Keep the management handler as a thin adapter for stat error logging.
- Update the backend structure baseline and allowlist after reducing auth_files.go.

## Validation
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run 'Test(BuildAuthFileEntry|PatchAuthFileFields|ChannelGroup|CodexWham|Reconcile|API|UploadAuthFile)'
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check