### PR TITLE
refactor: move auth file field patching

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 2687,
+        "max_lines": 2497,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 596 |
-| 生产 Go 文件 | 411 |
-| 测试 Go 文件 | 185 |
-| `internal/` Go 文件 | 473 |
-| `internal/` 生产 Go 文件 | 340 |
-| `internal/` 测试 Go 文件 | 133 |
+| Go 文件总数 | 598 |
+| 生产 Go 文件 | 412 |
+| 测试 Go 文件 | 186 |
+| `internal/` Go 文件 | 475 |
+| `internal/` 生产 Go 文件 | 341 |
+| `internal/` 测试 Go 文件 | 134 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 2687 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 2497 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -760,20 +760,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Name                  string    `json:"name"`
-		Label                 *string   `json:"label"`
-		CustomTags            *[]string `json:"custom_tags"`
-		HiddenDefaultTags     *[]string `json:"hidden_default_tags"`
-		DisplayTags           *[]string `json:"display_tags"`
-		Prefix                *string   `json:"prefix"`
-		ProxyURL              *string   `json:"proxy_url"`
-		ProxyID               *string   `json:"proxy_id"`
-		Priority              *int      `json:"priority"`
-		SubscriptionStartedAt *string   `json:"subscription_started_at"`
-		SubscriptionPeriod    *string   `json:"subscription_period"`
-		SubscriptionExpiresAt *string   `json:"subscription_expires_at"`
-	}
+	var req managementauthfiles.FieldPatch
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 		return
@@ -806,190 +793,13 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		return
 	}
 
-	changed := false
-	var oldChannelIdentifiers []string
-	var newChannelLabel string
-	if req.Label != nil {
-		accountType, _ := targetAuth.AccountInfo()
-		if !strings.EqualFold(accountType, "oauth") {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "label is only supported for oauth auth files"})
-			return
-		}
-		if managementauthfiles.IsRuntimeOnly(targetAuth) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "runtime-only auth files cannot rename channel"})
-			return
-		}
-		label, errValidate := h.validateAuthChannelName(*req.Label, targetAuth.ID)
-		if errValidate != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
-			return
-		}
-		oldChannelIdentifiers = targetAuth.ChannelIdentifiers()
-		newChannelLabel = label
-		targetAuth.Label = label
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		targetAuth.Metadata["label"] = label
-		changed = true
-	}
-	if req.Prefix != nil {
-		targetAuth.Prefix = strings.TrimSpace(*req.Prefix)
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if targetAuth.Prefix == "" {
-			delete(targetAuth.Metadata, "prefix")
-		} else {
-			targetAuth.Metadata["prefix"] = targetAuth.Prefix
-		}
-		changed = true
-	}
-	if req.CustomTags != nil {
-		tags, errNormalize := managementauthfiles.NormalizeEditableTags(*req.CustomTags, managementauthfiles.MaxCustomTags)
-		if errNormalize != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": errNormalize.Error()})
-			return
-		}
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if len(tags) == 0 {
-			delete(targetAuth.Metadata, "custom_tags")
-		} else {
-			targetAuth.Metadata["custom_tags"] = tags
-		}
-		changed = true
-	}
-	if req.HiddenDefaultTags != nil {
-		tags := managementauthfiles.NormalizeTagList(*req.HiddenDefaultTags)
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if len(tags) == 0 {
-			delete(targetAuth.Metadata, "hidden_default_tags")
-		} else {
-			targetAuth.Metadata["hidden_default_tags"] = tags
-		}
-		changed = true
-	}
-	if req.DisplayTags != nil {
-		tags := managementauthfiles.NormalizeTagList(*req.DisplayTags)
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		targetAuth.Metadata["display_tags"] = tags
-		changed = true
-	}
-	if req.ProxyURL != nil {
-		targetAuth.ProxyURL = strings.TrimSpace(*req.ProxyURL)
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if targetAuth.ProxyURL == "" {
-			delete(targetAuth.Metadata, "proxy_url")
-			delete(targetAuth.Metadata, "proxy-url")
-			delete(targetAuth.Metadata, "proxyUrl")
-		} else {
-			targetAuth.Metadata["proxy_url"] = targetAuth.ProxyURL
-		}
-		changed = true
-	}
-	if req.ProxyID != nil {
-		targetAuth.ProxyID = strings.TrimSpace(*req.ProxyID)
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if targetAuth.ProxyID == "" {
-			delete(targetAuth.Metadata, "proxy_id")
-		} else {
-			targetAuth.Metadata["proxy_id"] = targetAuth.ProxyID
-		}
-		changed = true
-	}
-	if req.Priority != nil {
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if *req.Priority == 0 {
-			delete(targetAuth.Metadata, "priority")
-		} else {
-			targetAuth.Metadata["priority"] = *req.Priority
-		}
-		changed = true
-	}
-	if req.SubscriptionStartedAt != nil {
-		value := strings.TrimSpace(*req.SubscriptionStartedAt)
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if value == "" {
-			managementauthfiles.ClearSubscriptionMetadata(targetAuth.Metadata)
-		} else {
-			ts, ok := managementauthfiles.ParseSubscriptionTimestampValue(value)
-			if !ok || ts.IsZero() {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "subscription_started_at must be a valid time"})
-				return
-			}
-			managementauthfiles.DeleteSubscriptionStartMetadata(targetAuth.Metadata)
-			managementauthfiles.DeleteSubscriptionExpirationMetadata(targetAuth.Metadata)
-			targetAuth.Metadata["subscription_started_at"] = ts.UTC().Format(time.RFC3339)
-			if req.SubscriptionPeriod == nil {
-				if period, okPeriod := managementauthfiles.ExtractSubscriptionPeriod(targetAuth.Metadata); okPeriod {
-					targetAuth.Metadata["subscription_period"] = period
-					delete(targetAuth.Metadata, "subscriptionPeriod")
-				} else {
-					targetAuth.Metadata["subscription_period"] = "monthly"
-				}
-			}
-		}
-		changed = true
-	}
-	if req.SubscriptionPeriod != nil {
-		value := strings.TrimSpace(*req.SubscriptionPeriod)
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if value == "" {
-			managementauthfiles.DeleteSubscriptionPeriodMetadata(targetAuth.Metadata)
-		} else {
-			period, ok := managementauthfiles.NormalizeSubscriptionPeriodValue(value)
-			if !ok {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "subscription_period must be monthly or yearly"})
-				return
-			}
-			managementauthfiles.DeleteSubscriptionPeriodMetadata(targetAuth.Metadata)
-			targetAuth.Metadata["subscription_period"] = period
-		}
-		changed = true
-	}
-	if req.SubscriptionExpiresAt != nil {
-		value := strings.TrimSpace(*req.SubscriptionExpiresAt)
-		if targetAuth.Metadata == nil {
-			targetAuth.Metadata = make(map[string]any)
-		}
-		if value == "" {
-			managementauthfiles.ClearSubscriptionMetadata(targetAuth.Metadata)
-		} else {
-			ts, ok := managementauthfiles.ParseSubscriptionTimestampValue(value)
-			if !ok || ts.IsZero() {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "subscription_expires_at must be a valid time"})
-				return
-			}
-			managementauthfiles.DeleteSubscriptionStartMetadata(targetAuth.Metadata)
-			managementauthfiles.DeleteSubscriptionPeriodMetadata(targetAuth.Metadata)
-			managementauthfiles.DeleteSubscriptionExpirationMetadata(targetAuth.Metadata)
-			targetAuth.Metadata["subscription_expires_at"] = ts.UTC().Format(time.RFC3339)
-		}
-		changed = true
-	}
-
-	if !changed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no fields to update"})
+	patchResult, errPatch := managementauthfiles.ApplyFieldPatch(targetAuth, req, managementauthfiles.FieldPatchOptions{
+		ValidateLabel: h.validateAuthChannelName,
+	})
+	if errPatch != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errPatch.Error()})
 		return
 	}
-
-	targetAuth.UpdatedAt = time.Now()
 
 	if _, err := h.authManager.Update(ctx, targetAuth); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update auth: %v", err)})
@@ -1001,8 +811,8 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			return
 		}
 	}
-	if len(oldChannelIdentifiers) > 0 {
-		if err := h.renameChannelReferences(oldChannelIdentifiers, newChannelLabel); err != nil {
+	if len(patchResult.OldChannelIdentifiers) > 0 {
+		if err := h.renameChannelReferences(patchResult.OldChannelIdentifiers, patchResult.NewChannelLabel); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -1,0 +1,222 @@
+package authfiles
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// FieldPatch carries editable auth-file fields from the management API into
+// the authfiles use case layer.
+type FieldPatch struct {
+	Name                  string    `json:"name"`
+	Label                 *string   `json:"label"`
+	CustomTags            *[]string `json:"custom_tags"`
+	HiddenDefaultTags     *[]string `json:"hidden_default_tags"`
+	DisplayTags           *[]string `json:"display_tags"`
+	Prefix                *string   `json:"prefix"`
+	ProxyURL              *string   `json:"proxy_url"`
+	ProxyID               *string   `json:"proxy_id"`
+	Priority              *int      `json:"priority"`
+	SubscriptionStartedAt *string   `json:"subscription_started_at"`
+	SubscriptionPeriod    *string   `json:"subscription_period"`
+	SubscriptionExpiresAt *string   `json:"subscription_expires_at"`
+}
+
+type FieldPatchOptions struct {
+	Now           time.Time
+	ValidateLabel func(label, excludeAuthID string) (string, error)
+}
+
+type FieldPatchResult struct {
+	OldChannelIdentifiers []string
+	NewChannelLabel       string
+}
+
+// ApplyFieldPatch applies editable auth-file field changes and returns the
+// channel rename side effect that the transport layer must coordinate.
+func ApplyFieldPatch(auth *coreauth.Auth, patch FieldPatch, opts FieldPatchOptions) (FieldPatchResult, error) {
+	var result FieldPatchResult
+	if auth == nil {
+		return result, fmt.Errorf("auth file not found")
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	changed := false
+	if patch.Label != nil {
+		accountType, _ := auth.AccountInfo()
+		if !strings.EqualFold(accountType, "oauth") {
+			return result, fmt.Errorf("label is only supported for oauth auth files")
+		}
+		if IsRuntimeOnly(auth) {
+			return result, fmt.Errorf("runtime-only auth files cannot rename channel")
+		}
+		validateLabel := opts.ValidateLabel
+		if validateLabel == nil {
+			validateLabel = defaultValidateLabel
+		}
+		label, errValidate := validateLabel(*patch.Label, auth.ID)
+		if errValidate != nil {
+			return result, errValidate
+		}
+		result.OldChannelIdentifiers = auth.ChannelIdentifiers()
+		result.NewChannelLabel = label
+		auth.Label = label
+		metadata := ensureMetadata(auth)
+		metadata["label"] = label
+		changed = true
+	}
+	if patch.Prefix != nil {
+		auth.Prefix = strings.TrimSpace(*patch.Prefix)
+		metadata := ensureMetadata(auth)
+		if auth.Prefix == "" {
+			delete(metadata, "prefix")
+		} else {
+			metadata["prefix"] = auth.Prefix
+		}
+		changed = true
+	}
+	if patch.CustomTags != nil {
+		tags, errNormalize := NormalizeEditableTags(*patch.CustomTags, MaxCustomTags)
+		if errNormalize != nil {
+			return result, errNormalize
+		}
+		metadata := ensureMetadata(auth)
+		if len(tags) == 0 {
+			delete(metadata, "custom_tags")
+		} else {
+			metadata["custom_tags"] = tags
+		}
+		changed = true
+	}
+	if patch.HiddenDefaultTags != nil {
+		tags := NormalizeTagList(*patch.HiddenDefaultTags)
+		metadata := ensureMetadata(auth)
+		if len(tags) == 0 {
+			delete(metadata, "hidden_default_tags")
+		} else {
+			metadata["hidden_default_tags"] = tags
+		}
+		changed = true
+	}
+	if patch.DisplayTags != nil {
+		tags := NormalizeTagList(*patch.DisplayTags)
+		metadata := ensureMetadata(auth)
+		metadata["display_tags"] = tags
+		changed = true
+	}
+	if patch.ProxyURL != nil {
+		auth.ProxyURL = strings.TrimSpace(*patch.ProxyURL)
+		metadata := ensureMetadata(auth)
+		if auth.ProxyURL == "" {
+			delete(metadata, "proxy_url")
+			delete(metadata, "proxy-url")
+			delete(metadata, "proxyUrl")
+		} else {
+			metadata["proxy_url"] = auth.ProxyURL
+		}
+		changed = true
+	}
+	if patch.ProxyID != nil {
+		auth.ProxyID = strings.TrimSpace(*patch.ProxyID)
+		metadata := ensureMetadata(auth)
+		if auth.ProxyID == "" {
+			delete(metadata, "proxy_id")
+		} else {
+			metadata["proxy_id"] = auth.ProxyID
+		}
+		changed = true
+	}
+	if patch.Priority != nil {
+		metadata := ensureMetadata(auth)
+		if *patch.Priority == 0 {
+			delete(metadata, "priority")
+		} else {
+			metadata["priority"] = *patch.Priority
+		}
+		changed = true
+	}
+	if patch.SubscriptionStartedAt != nil {
+		value := strings.TrimSpace(*patch.SubscriptionStartedAt)
+		metadata := ensureMetadata(auth)
+		if value == "" {
+			ClearSubscriptionMetadata(metadata)
+		} else {
+			ts, ok := ParseSubscriptionTimestampValue(value)
+			if !ok || ts.IsZero() {
+				return result, fmt.Errorf("subscription_started_at must be a valid time")
+			}
+			DeleteSubscriptionStartMetadata(metadata)
+			DeleteSubscriptionExpirationMetadata(metadata)
+			metadata["subscription_started_at"] = ts.UTC().Format(time.RFC3339)
+			if patch.SubscriptionPeriod == nil {
+				if period, okPeriod := ExtractSubscriptionPeriod(metadata); okPeriod {
+					metadata["subscription_period"] = period
+					delete(metadata, "subscriptionPeriod")
+				} else {
+					metadata["subscription_period"] = "monthly"
+				}
+			}
+		}
+		changed = true
+	}
+	if patch.SubscriptionPeriod != nil {
+		value := strings.TrimSpace(*patch.SubscriptionPeriod)
+		metadata := ensureMetadata(auth)
+		if value == "" {
+			DeleteSubscriptionPeriodMetadata(metadata)
+		} else {
+			period, ok := NormalizeSubscriptionPeriodValue(value)
+			if !ok {
+				return result, fmt.Errorf("subscription_period must be monthly or yearly")
+			}
+			DeleteSubscriptionPeriodMetadata(metadata)
+			metadata["subscription_period"] = period
+		}
+		changed = true
+	}
+	if patch.SubscriptionExpiresAt != nil {
+		value := strings.TrimSpace(*patch.SubscriptionExpiresAt)
+		metadata := ensureMetadata(auth)
+		if value == "" {
+			ClearSubscriptionMetadata(metadata)
+		} else {
+			ts, ok := ParseSubscriptionTimestampValue(value)
+			if !ok || ts.IsZero() {
+				return result, fmt.Errorf("subscription_expires_at must be a valid time")
+			}
+			DeleteSubscriptionStartMetadata(metadata)
+			DeleteSubscriptionPeriodMetadata(metadata)
+			DeleteSubscriptionExpirationMetadata(metadata)
+			metadata["subscription_expires_at"] = ts.UTC().Format(time.RFC3339)
+		}
+		changed = true
+	}
+
+	if !changed {
+		return result, fmt.Errorf("no fields to update")
+	}
+	auth.UpdatedAt = now
+	return result, nil
+}
+
+func defaultValidateLabel(label, excludeAuthID string) (string, error) {
+	_ = excludeAuthID
+	trimmed := strings.TrimSpace(label)
+	if trimmed == "" {
+		return "", fmt.Errorf("channel name is required")
+	}
+	return trimmed, nil
+}
+
+func ensureMetadata(auth *coreauth.Auth) map[string]any {
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	return auth.Metadata
+}

--- a/internal/management/authfiles/patch_test.go
+++ b/internal/management/authfiles/patch_test.go
@@ -1,0 +1,194 @@
+package authfiles
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestApplyFieldPatchUpdatesOAuthLabel(t *testing.T) {
+	now := time.Date(2026, 6, 6, 10, 0, 0, 0, time.UTC)
+	auth := &coreauth.Auth{
+		ID:       "oauth-auth",
+		Provider: "codex",
+		Label:    "Old Label",
+		Metadata: map[string]any{
+			"email": "user@example.com",
+		},
+	}
+
+	label := " Team Alpha "
+	result, err := ApplyFieldPatch(auth, FieldPatch{Label: &label}, FieldPatchOptions{
+		Now: now,
+		ValidateLabel: func(label, excludeAuthID string) (string, error) {
+			if excludeAuthID != "oauth-auth" {
+				t.Fatalf("excludeAuthID = %q, want oauth-auth", excludeAuthID)
+			}
+			return strings.TrimSpace(label), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if auth.Label != "Team Alpha" {
+		t.Fatalf("Label = %q, want Team Alpha", auth.Label)
+	}
+	if got, _ := auth.Metadata["label"].(string); got != "Team Alpha" {
+		t.Fatalf("metadata label = %q, want Team Alpha", got)
+	}
+	if len(result.OldChannelIdentifiers) == 0 || result.NewChannelLabel != "Team Alpha" {
+		t.Fatalf("result = %#v, want old identifiers and new label", result)
+	}
+	if !auth.UpdatedAt.Equal(now) {
+		t.Fatalf("UpdatedAt = %v, want %v", auth.UpdatedAt, now)
+	}
+}
+
+func TestApplyFieldPatchRejectsNonOAuthLabel(t *testing.T) {
+	label := "Team Alpha"
+	auth := &coreauth.Auth{
+		ID:       "api-key-auth",
+		Provider: "openai",
+		Attributes: map[string]string{
+			"api_key": "redacted",
+		},
+	}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{Label: &label}, FieldPatchOptions{})
+	if err == nil || err.Error() != "label is only supported for oauth auth files" {
+		t.Fatalf("ApplyFieldPatch() error = %v, want label oauth error", err)
+	}
+}
+
+func TestApplyFieldPatchUpdatesTagsPrefixAndProxyFields(t *testing.T) {
+	customTags := []string{" Team ", "priority", "team"}
+	hiddenTags := []string{" codex "}
+	displayTags := []string{"codex", "priority"}
+	prefix := " team-a "
+	proxyURL := ""
+	proxyID := " proxy-main "
+	priority := 3
+	auth := &coreauth.Auth{
+		ID:       "editable",
+		Provider: "codex",
+		ProxyURL: "http://old-proxy.example",
+		Metadata: map[string]any{
+			"proxy_url": "http://old-proxy.example",
+			"proxy-url": "legacy",
+			"proxyUrl":  "legacy",
+		},
+	}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{
+		CustomTags:        &customTags,
+		HiddenDefaultTags: &hiddenTags,
+		DisplayTags:       &displayTags,
+		Prefix:            &prefix,
+		ProxyURL:          &proxyURL,
+		ProxyID:           &proxyID,
+		Priority:          &priority,
+	}, FieldPatchOptions{})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if auth.Prefix != "team-a" || auth.ProxyURL != "" || auth.ProxyID != "proxy-main" {
+		t.Fatalf("auth fields = prefix %q proxyURL %q proxyID %q", auth.Prefix, auth.ProxyURL, auth.ProxyID)
+	}
+	if got := auth.Metadata["custom_tags"]; !stringSliceEqual(got, []string{"team", "priority"}) {
+		t.Fatalf("custom_tags = %#v, want [team priority]", got)
+	}
+	if got := auth.Metadata["hidden_default_tags"]; !stringSliceEqual(got, []string{"codex"}) {
+		t.Fatalf("hidden_default_tags = %#v, want [codex]", got)
+	}
+	if got := auth.Metadata["display_tags"]; !stringSliceEqual(got, []string{"codex", "priority"}) {
+		t.Fatalf("display_tags = %#v, want [codex priority]", got)
+	}
+	if _, ok := auth.Metadata["proxy_url"]; ok {
+		t.Fatalf("proxy_url still present: %#v", auth.Metadata["proxy_url"])
+	}
+	if _, ok := auth.Metadata["proxy-url"]; ok {
+		t.Fatalf("proxy-url still present: %#v", auth.Metadata["proxy-url"])
+	}
+	if _, ok := auth.Metadata["proxyUrl"]; ok {
+		t.Fatalf("proxyUrl still present: %#v", auth.Metadata["proxyUrl"])
+	}
+	if got, _ := auth.Metadata["proxy_id"].(string); got != "proxy-main" {
+		t.Fatalf("proxy_id = %q, want proxy-main", got)
+	}
+	if got, _ := auth.Metadata["priority"].(int); got != 3 {
+		t.Fatalf("priority = %d, want 3", got)
+	}
+}
+
+func TestApplyFieldPatchRejectsTooManyCustomTags(t *testing.T) {
+	customTags := []string{"one", "two", "three", "four"}
+	auth := &coreauth.Auth{ID: "editable", Provider: "codex"}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{CustomTags: &customTags}, FieldPatchOptions{})
+	if err == nil || err.Error() != "custom_tags supports at most 3 items" {
+		t.Fatalf("ApplyFieldPatch() error = %v, want too many tags", err)
+	}
+}
+
+func TestApplyFieldPatchUpdatesSubscriptionFields(t *testing.T) {
+	startedAt := "2026-04-01T09:30:00Z"
+	period := "year"
+	auth := &coreauth.Auth{
+		ID:       "subscription",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"subscriptionExpiresAt": "2026-05-01T09:30:00Z",
+		},
+	}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{
+		SubscriptionStartedAt: &startedAt,
+		SubscriptionPeriod:    &period,
+	}, FieldPatchOptions{})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if got, _ := auth.Metadata["subscription_started_at"].(string); got != "2026-04-01T09:30:00Z" {
+		t.Fatalf("subscription_started_at = %q, want canonical start", got)
+	}
+	if got, _ := auth.Metadata["subscription_period"].(string); got != "yearly" {
+		t.Fatalf("subscription_period = %q, want yearly", got)
+	}
+	if _, ok := auth.Metadata["subscriptionExpiresAt"]; ok {
+		t.Fatalf("legacy expiration key still present")
+	}
+}
+
+func TestApplyFieldPatchRejectsInvalidSubscriptionExpiration(t *testing.T) {
+	expiresAt := "not-a-time"
+	auth := &coreauth.Auth{ID: "subscription", Provider: "codex"}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{SubscriptionExpiresAt: &expiresAt}, FieldPatchOptions{})
+	if err == nil || err.Error() != "subscription_expires_at must be a valid time" {
+		t.Fatalf("ApplyFieldPatch() error = %v, want invalid expiration", err)
+	}
+}
+
+func TestApplyFieldPatchRejectsNoFields(t *testing.T) {
+	auth := &coreauth.Auth{ID: "empty", Provider: "codex"}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{}, FieldPatchOptions{})
+	if err == nil || err.Error() != "no fields to update" {
+		t.Fatalf("ApplyFieldPatch() error = %v, want no fields", err)
+	}
+}
+
+func stringSliceEqual(value any, want []string) bool {
+	got, ok := value.([]string)
+	if !ok || len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Move editable auth-file field patching into internal/management/authfiles.ApplyFieldPatch.
- Keep the management handler focused on JSON binding, auth lookup, persistence, and channel rename side effects.
- Add use-case tests for label, tags, proxy fields, subscription fields, and validation errors.
- Tighten the backend structure baseline after reducing auth_files.go.

## Validation
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check