### PR TITLE
refactor: move auth file path validation

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 2497,
+        "max_lines": 2441,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 598 |
-| 生产 Go 文件 | 412 |
-| 测试 Go 文件 | 186 |
-| `internal/` Go 文件 | 475 |
-| `internal/` 生产 Go 文件 | 341 |
-| `internal/` 测试 Go 文件 | 134 |
+| Go 文件总数 | 600 |
+| 生产 Go 文件 | 413 |
+| 测试 Go 文件 | 187 |
+| `internal/` Go 文件 | 477 |
+| `internal/` 生产 Go 文件 | 342 |
+| `internal/` 测试 Go 文件 | 135 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 2497 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 2441 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -350,16 +350,12 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 
 // Download single auth file by name
 func (h *Handler) DownloadAuthFile(c *gin.Context) {
-	name := c.Query("name")
-	if name == "" || strings.Contains(name, string(os.PathSeparator)) {
-		c.JSON(400, gin.H{"error": "invalid name"})
+	name, errValidate := managementauthfiles.ValidateFileQueryName(c.Query("name"), true)
+	if errValidate != nil {
+		c.JSON(400, gin.H{"error": errValidate.Error()})
 		return
 	}
-	if !strings.HasSuffix(strings.ToLower(name), ".json") {
-		c.JSON(400, gin.H{"error": "name must end with .json"})
-		return
-	}
-	full := filepath.Join(h.cfg.AuthDir, name)
+	full := managementauthfiles.FilePath(h.cfg.AuthDir, name)
 	_, err := os.Stat(full)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -397,17 +393,12 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "file too large"})
 			return
 		}
-		name := filepath.Base(file.Filename)
-		if !strings.HasSuffix(strings.ToLower(name), ".json") {
-			c.JSON(400, gin.H{"error": "file must be .json"})
+		name, errValidate := managementauthfiles.ValidateUploadedFileName(file.Filename)
+		if errValidate != nil {
+			c.JSON(400, gin.H{"error": errValidate.Error()})
 			return
 		}
-		dst := filepath.Join(h.cfg.AuthDir, name)
-		if !filepath.IsAbs(dst) {
-			if abs, errAbs := filepath.Abs(dst); errAbs == nil {
-				dst = abs
-			}
-		}
+		dst := managementauthfiles.FilePath(h.cfg.AuthDir, name)
 		if errSave := c.SaveUploadedFile(file, dst); errSave != nil {
 			c.JSON(500, gin.H{"error": fmt.Sprintf("failed to save file: %v", errSave)})
 			return
@@ -428,13 +419,9 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})
 		return
 	}
-	name := c.Query("name")
-	if name == "" || strings.Contains(name, string(os.PathSeparator)) {
-		c.JSON(400, gin.H{"error": "invalid name"})
-		return
-	}
-	if !strings.HasSuffix(strings.ToLower(name), ".json") {
-		c.JSON(400, gin.H{"error": "name must end with .json"})
+	name, errValidate := managementauthfiles.ValidateFileQueryName(c.Query("name"), true)
+	if errValidate != nil {
+		c.JSON(400, gin.H{"error": errValidate.Error()})
 		return
 	}
 	data, err := bodyutil.ReadRequestBody(c, bodyutil.AuthFileBodyLimit)
@@ -446,12 +433,7 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "failed to read body"})
 		return
 	}
-	dst := filepath.Join(h.cfg.AuthDir, filepath.Base(name))
-	if !filepath.IsAbs(dst) {
-		if abs, errAbs := filepath.Abs(dst); errAbs == nil {
-			dst = abs
-		}
-	}
+	dst := managementauthfiles.FilePath(h.cfg.AuthDir, name)
 	if errWrite := os.WriteFile(dst, data, 0o600); errWrite != nil {
 		c.JSON(500, gin.H{"error": fmt.Sprintf("failed to write file: %v", errWrite)})
 		return
@@ -474,7 +456,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		return
 	}
 	ctx := c.Request.Context()
-	if all := c.Query("all"); all == "true" || all == "1" || all == "*" {
+	if managementauthfiles.IsDeleteAllValue(c.Query("all")) {
 		entries, err := os.ReadDir(h.cfg.AuthDir)
 		if err != nil {
 			c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", err)})
@@ -486,15 +468,10 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 				continue
 			}
 			name := e.Name()
-			if !strings.HasSuffix(strings.ToLower(name), ".json") {
+			if !managementauthfiles.IsJSONFileName(name) {
 				continue
 			}
-			full := filepath.Join(h.cfg.AuthDir, name)
-			if !filepath.IsAbs(full) {
-				if abs, errAbs := filepath.Abs(full); errAbs == nil {
-					full = abs
-				}
-			}
+			full := managementauthfiles.FilePath(h.cfg.AuthDir, name)
 			deletedChannels := deletedAuthChannelIdentifiers(h.findAuthByNameOrID(name))
 			if err = os.Remove(full); err == nil {
 				if errDel := h.deleteTokenRecord(ctx, full); errDel != nil {
@@ -512,17 +489,12 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok", "deleted": deleted})
 		return
 	}
-	name := c.Query("name")
-	if name == "" || strings.Contains(name, string(os.PathSeparator)) {
-		c.JSON(400, gin.H{"error": "invalid name"})
+	name, errValidate := managementauthfiles.ValidateFileQueryName(c.Query("name"), false)
+	if errValidate != nil {
+		c.JSON(400, gin.H{"error": errValidate.Error()})
 		return
 	}
-	full := filepath.Join(h.cfg.AuthDir, filepath.Base(name))
-	if !filepath.IsAbs(full) {
-		if abs, errAbs := filepath.Abs(full); errAbs == nil {
-			full = abs
-		}
-	}
+	full := managementauthfiles.FilePath(h.cfg.AuthDir, name)
 	deletedChannels := deletedAuthChannelIdentifiers(h.findAuthByNameOrID(name))
 	if err := os.Remove(full); err != nil {
 		if os.IsNotExist(err) {
@@ -581,38 +553,10 @@ func deletedAuthChannelIdentifiers(auth *coreauth.Auth) []string {
 }
 
 func (h *Handler) authIDForPath(path string) string {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return ""
-	}
 	if h == nil || h.cfg == nil {
-		return filepath.Clean(path)
+		return managementauthfiles.AuthIDForPath("", path)
 	}
-	authDir, errResolve := util.ResolveAuthDir(h.cfg.AuthDir)
-	if errResolve != nil || strings.TrimSpace(authDir) == "" {
-		return filepath.Clean(path)
-	}
-	if !filepath.IsAbs(authDir) {
-		if abs, errAbs := filepath.Abs(authDir); errAbs == nil {
-			authDir = abs
-		}
-	}
-	if evaluated, errEval := filepath.EvalSymlinks(authDir); errEval == nil {
-		authDir = evaluated
-	}
-	normalizedPath := filepath.Clean(path)
-	if !filepath.IsAbs(normalizedPath) {
-		if abs, errAbs := filepath.Abs(normalizedPath); errAbs == nil {
-			normalizedPath = abs
-		}
-	}
-	if evaluated, errEval := filepath.EvalSymlinks(normalizedPath); errEval == nil {
-		normalizedPath = evaluated
-	}
-	if rel, err := filepath.Rel(authDir, normalizedPath); err == nil && rel != "" && rel != "." && !strings.HasPrefix(rel, "..") {
-		return rel
-	}
-	return normalizedPath
+	return managementauthfiles.AuthIDForPath(h.cfg.AuthDir, path)
 }
 
 func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []byte) error {

--- a/internal/management/authfiles/paths.go
+++ b/internal/management/authfiles/paths.go
@@ -1,0 +1,82 @@
+package authfiles
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+)
+
+func ValidateFileQueryName(name string, requireJSON bool) (string, error) {
+	if name == "" || strings.Contains(name, string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid name")
+	}
+	if requireJSON && !IsJSONFileName(name) {
+		return "", fmt.Errorf("name must end with .json")
+	}
+	return name, nil
+}
+
+func ValidateUploadedFileName(filename string) (string, error) {
+	name := filepath.Base(filename)
+	if !IsJSONFileName(name) {
+		return "", fmt.Errorf("file must be .json")
+	}
+	return name, nil
+}
+
+func IsDeleteAllValue(value string) bool {
+	return value == "true" || value == "1" || value == "*"
+}
+
+func IsJSONFileName(name string) bool {
+	return strings.HasSuffix(strings.ToLower(name), ".json")
+}
+
+func FilePath(authDir, name string) string {
+	full := filepath.Join(authDir, filepath.Base(name))
+	if filepath.IsAbs(full) {
+		return full
+	}
+	if abs, errAbs := filepath.Abs(full); errAbs == nil {
+		return abs
+	}
+	return full
+}
+
+func AuthIDForPath(authDir, path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if strings.TrimSpace(authDir) == "" {
+		return filepath.Clean(path)
+	}
+	resolvedAuthDir, errResolve := util.ResolveAuthDir(authDir)
+	if errResolve != nil || strings.TrimSpace(resolvedAuthDir) == "" {
+		return filepath.Clean(path)
+	}
+	if !filepath.IsAbs(resolvedAuthDir) {
+		if abs, errAbs := filepath.Abs(resolvedAuthDir); errAbs == nil {
+			resolvedAuthDir = abs
+		}
+	}
+	if evaluated, errEval := filepath.EvalSymlinks(resolvedAuthDir); errEval == nil {
+		resolvedAuthDir = evaluated
+	}
+	normalizedPath := filepath.Clean(path)
+	if !filepath.IsAbs(normalizedPath) {
+		if abs, errAbs := filepath.Abs(normalizedPath); errAbs == nil {
+			normalizedPath = abs
+		}
+	}
+	if evaluated, errEval := filepath.EvalSymlinks(normalizedPath); errEval == nil {
+		normalizedPath = evaluated
+	}
+	if rel, err := filepath.Rel(resolvedAuthDir, normalizedPath); err == nil && rel != "" && rel != "." && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return normalizedPath
+}

--- a/internal/management/authfiles/paths_test.go
+++ b/internal/management/authfiles/paths_test.go
@@ -1,0 +1,86 @@
+package authfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateFileQueryName(t *testing.T) {
+	tests := []struct {
+		name        string
+		requireJSON bool
+		want        string
+		wantErr     string
+	}{
+		{name: "", requireJSON: true, wantErr: "invalid name"},
+		{name: "nested/auth.json", requireJSON: true, wantErr: "invalid name"},
+		{name: "auth.txt", requireJSON: true, wantErr: "name must end with .json"},
+		{name: "auth.txt", requireJSON: false, want: "auth.txt"},
+		{name: "auth.json", requireJSON: true, want: "auth.json"},
+	}
+
+	for _, tt := range tests {
+		got, err := ValidateFileQueryName(tt.name, tt.requireJSON)
+		if tt.wantErr != "" {
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("ValidateFileQueryName(%q, %t) error = %v, want %q", tt.name, tt.requireJSON, err, tt.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("ValidateFileQueryName(%q, %t) error = %v", tt.name, tt.requireJSON, err)
+		}
+		if got != tt.want {
+			t.Fatalf("ValidateFileQueryName(%q, %t) = %q, want %q", tt.name, tt.requireJSON, got, tt.want)
+		}
+	}
+}
+
+func TestValidateUploadedFileName(t *testing.T) {
+	got, err := ValidateUploadedFileName("nested/auth.json")
+	if err != nil {
+		t.Fatalf("ValidateUploadedFileName() error = %v", err)
+	}
+	if got != "auth.json" {
+		t.Fatalf("ValidateUploadedFileName() = %q, want auth.json", got)
+	}
+
+	_, err = ValidateUploadedFileName("auth.txt")
+	if err == nil || err.Error() != "file must be .json" {
+		t.Fatalf("ValidateUploadedFileName() error = %v, want file must be .json", err)
+	}
+}
+
+func TestFilePathReturnsAbsoluteBasePath(t *testing.T) {
+	authDir := t.TempDir()
+	got := FilePath(authDir, "nested/auth.json")
+	want := filepath.Join(authDir, "auth.json")
+	if got != want {
+		t.Fatalf("FilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestAuthIDForPathReturnsRelativeIDWithinAuthDir(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "codex.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	got := AuthIDForPath(authDir, path)
+	if got != "codex.json" {
+		t.Fatalf("AuthIDForPath() = %q, want codex.json", got)
+	}
+}
+
+func TestAuthIDForPathFallsBackForExternalPath(t *testing.T) {
+	authDir := t.TempDir()
+	externalDir := t.TempDir()
+	path := filepath.Join(externalDir, "codex.json")
+
+	got := AuthIDForPath(authDir, path)
+	if got != path {
+		t.Fatalf("AuthIDForPath() = %q, want %q", got, path)
+	}
+}


### PR DESCRIPTION
## Summary
- Move auth-file name validation, upload filename normalization, delete-all query handling, file path resolution, and auth ID path normalization into internal/management/authfiles.
- Keep download/upload/delete handlers focused on HTTP flow, filesystem actions, auth manager updates, and persistence side effects.
- Add use-case tests for path validation and auth ID normalization.
- Tighten the backend structure baseline after reducing auth_files.go.

## Validation
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check