### PR TITLE
refactor: move auth file record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 2441,
+        "max_lines": 2428,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 600 |
-| 生产 Go 文件 | 413 |
-| 测试 Go 文件 | 187 |
-| `internal/` Go 文件 | 477 |
-| `internal/` 生产 Go 文件 | 342 |
-| `internal/` 测试 Go 文件 | 135 |
+| Go 文件总数 | 602 |
+| 生产 Go 文件 | 414 |
+| 测试 Go 文件 | 188 |
+| `internal/` Go 文件 | 479 |
+| `internal/` 生产 Go 文件 | 343 |
+| `internal/` 测试 Go 文件 | 136 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 2441 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 2428 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -589,44 +589,31 @@ func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []
 			return fmt.Errorf("failed to write normalized auth file: %w", errWrite)
 		}
 	}
-	label := authChannelLabelFromMetadata(metadata, provider)
-	lastRefresh, hasLastRefresh := managementauthfiles.ExtractLastRefreshTimestamp(metadata)
-
 	authID := h.authIDForPath(path)
 	if authID == "" {
 		authID = path
 	}
-	attr := map[string]string{
-		"path":   path,
-		"source": path,
-	}
-	auth := &coreauth.Auth{
-		ID:         authID,
-		Provider:   provider,
-		Prefix:     managementauthfiles.MetadataString(metadata, "prefix"),
-		ProxyURL:   managementauthfiles.MetadataString(metadata, "proxy_url", "proxy-url", "proxyUrl"),
-		ProxyID:    managementauthfiles.MetadataString(metadata, "proxy_id", "proxy-id", "proxyId"),
-		FileName:   filepath.Base(path),
-		Label:      label,
-		Status:     coreauth.StatusActive,
-		Attributes: attr,
-		Metadata:   metadata,
-		CreatedAt:  time.Now(),
-		UpdatedAt:  time.Now(),
-	}
-	if hasLastRefresh {
-		auth.LastRefreshedAt = lastRefresh
+	authDir := ""
+	if h.cfg != nil {
+		authDir = h.cfg.AuthDir
 	}
 	if existing, ok := h.authManager.GetByID(authID); ok {
-		auth.CreatedAt = existing.CreatedAt
-		if !hasLastRefresh {
-			auth.LastRefreshedAt = existing.LastRefreshedAt
-		}
-		auth.NextRefreshAfter = existing.NextRefreshAfter
-		auth.Runtime = existing.Runtime
+		auth := managementauthfiles.BuildRecord(managementauthfiles.RecordOptions{
+			AuthDir:  authDir,
+			Path:     path,
+			Provider: provider,
+			Metadata: metadata,
+			Existing: existing,
+		})
 		_, err := h.authManager.Update(ctx, auth)
 		return err
 	}
+	auth := managementauthfiles.BuildRecord(managementauthfiles.RecordOptions{
+		AuthDir:  authDir,
+		Path:     path,
+		Provider: provider,
+		Metadata: metadata,
+	})
 	_, err := h.authManager.Register(ctx, auth)
 	return err
 }

--- a/internal/api/handlers/management/channel_names.go
+++ b/internal/api/handlers/management/channel_names.go
@@ -13,22 +13,6 @@ func normalizeChannelName(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
 
-func authChannelLabelFromMetadata(metadata map[string]any, provider string) string {
-	if metadata != nil {
-		if raw, ok := metadata["label"].(string); ok {
-			if label := strings.TrimSpace(raw); label != "" {
-				return label
-			}
-		}
-		if raw, ok := metadata["email"].(string); ok {
-			if email := strings.TrimSpace(raw); email != "" {
-				return email
-			}
-		}
-	}
-	return strings.TrimSpace(provider)
-}
-
 type knownChannel struct {
 	Canonical string
 	Source    string

--- a/internal/management/authfiles/record.go
+++ b/internal/management/authfiles/record.go
@@ -1,0 +1,79 @@
+package authfiles
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type RecordOptions struct {
+	AuthDir  string
+	Path     string
+	Provider string
+	Metadata map[string]any
+	Existing *coreauth.Auth
+	Now      time.Time
+}
+
+func BuildRecord(opts RecordOptions) *coreauth.Auth {
+	path := strings.TrimSpace(opts.Path)
+	if path == "" {
+		return nil
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	authID := AuthIDForPath(opts.AuthDir, path)
+	if authID == "" {
+		authID = path
+	}
+	lastRefresh, hasLastRefresh := ExtractLastRefreshTimestamp(opts.Metadata)
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: opts.Provider,
+		Prefix:   MetadataString(opts.Metadata, "prefix"),
+		ProxyURL: MetadataString(opts.Metadata, "proxy_url", "proxy-url", "proxyUrl"),
+		ProxyID:  MetadataString(opts.Metadata, "proxy_id", "proxy-id", "proxyId"),
+		FileName: filepath.Base(path),
+		Label:    ChannelLabelFromMetadata(opts.Metadata, opts.Provider),
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path":   path,
+			"source": path,
+		},
+		Metadata:  opts.Metadata,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if hasLastRefresh {
+		auth.LastRefreshedAt = lastRefresh
+	}
+	if opts.Existing != nil {
+		auth.CreatedAt = opts.Existing.CreatedAt
+		if !hasLastRefresh {
+			auth.LastRefreshedAt = opts.Existing.LastRefreshedAt
+		}
+		auth.NextRefreshAfter = opts.Existing.NextRefreshAfter
+		auth.Runtime = opts.Existing.Runtime
+	}
+	return auth
+}
+
+func ChannelLabelFromMetadata(metadata map[string]any, provider string) string {
+	if metadata != nil {
+		if raw, ok := metadata["label"].(string); ok {
+			if label := strings.TrimSpace(raw); label != "" {
+				return label
+			}
+		}
+		if raw, ok := metadata["email"].(string); ok {
+			if email := strings.TrimSpace(raw); email != "" {
+				return email
+			}
+		}
+	}
+	return strings.TrimSpace(provider)
+}

--- a/internal/management/authfiles/record_test.go
+++ b/internal/management/authfiles/record_test.go
@@ -1,0 +1,128 @@
+package authfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestBuildRecordMapsMetadataToAuth(t *testing.T) {
+	authDir := t.TempDir()
+	now := time.Date(2026, 6, 6, 11, 0, 0, 0, time.UTC)
+	lastRefresh := time.Date(2026, 6, 6, 10, 30, 0, 0, time.UTC)
+	path := filepath.Join(authDir, "claude-pro.json")
+	metadata := map[string]any{
+		"email":        "pro@example.com",
+		"prefix":       "team-a",
+		"proxy-url":    "http://proxy.example",
+		"proxy_id":     "premium-egress",
+		"last_refresh": lastRefresh.Format(time.RFC3339),
+	}
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	auth := BuildRecord(RecordOptions{
+		AuthDir:  authDir,
+		Path:     path,
+		Provider: "claude",
+		Metadata: metadata,
+		Now:      now,
+	})
+	if auth == nil {
+		t.Fatal("BuildRecord() = nil")
+	}
+	if auth.ID != "claude-pro.json" || auth.FileName != "claude-pro.json" {
+		t.Fatalf("ID/FileName = %q/%q, want claude-pro.json", auth.ID, auth.FileName)
+	}
+	if auth.Provider != "claude" || auth.Label != "pro@example.com" || auth.Status != coreauth.StatusActive {
+		t.Fatalf("provider/label/status = %q/%q/%q", auth.Provider, auth.Label, auth.Status)
+	}
+	if auth.Prefix != "team-a" || auth.ProxyURL != "http://proxy.example" || auth.ProxyID != "premium-egress" {
+		t.Fatalf("routing fields = %q/%q/%q", auth.Prefix, auth.ProxyURL, auth.ProxyID)
+	}
+	if auth.Attributes["path"] != path || auth.Attributes["source"] != path {
+		t.Fatalf("attributes = %#v, want path/source", auth.Attributes)
+	}
+	auth.Metadata["test_marker"] = "kept"
+	if metadata["test_marker"] != "kept" {
+		t.Fatalf("metadata map was not preserved")
+	}
+	if !auth.CreatedAt.Equal(now) || !auth.UpdatedAt.Equal(now) || !auth.LastRefreshedAt.Equal(lastRefresh) {
+		t.Fatalf("timestamps = created %v updated %v refresh %v", auth.CreatedAt, auth.UpdatedAt, auth.LastRefreshedAt)
+	}
+}
+
+func TestBuildRecordPreservesExistingRuntimeFields(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "codex.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	createdAt := time.Date(2026, 1, 2, 3, 4, 0, 0, time.UTC)
+	lastRefresh := time.Date(2026, 1, 3, 3, 4, 0, 0, time.UTC)
+	nextRefresh := time.Date(2026, 1, 4, 3, 4, 0, 0, time.UTC)
+	runtime := struct{ Value string }{Value: "kept"}
+
+	auth := BuildRecord(RecordOptions{
+		AuthDir:  authDir,
+		Path:     path,
+		Provider: "codex",
+		Metadata: map[string]any{"email": "codex@example.com"},
+		Existing: &coreauth.Auth{
+			CreatedAt:        createdAt,
+			LastRefreshedAt:  lastRefresh,
+			NextRefreshAfter: nextRefresh,
+			Runtime:          runtime,
+		},
+	})
+	if auth == nil {
+		t.Fatal("BuildRecord() = nil")
+	}
+	if !auth.CreatedAt.Equal(createdAt) || !auth.LastRefreshedAt.Equal(lastRefresh) || !auth.NextRefreshAfter.Equal(nextRefresh) {
+		t.Fatalf("existing timestamps not preserved: %#v", auth)
+	}
+	if auth.Runtime != runtime {
+		t.Fatalf("Runtime = %#v, want %#v", auth.Runtime, runtime)
+	}
+}
+
+func TestBuildRecordMetadataLastRefreshOverridesExisting(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "codex.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	metadataRefresh := time.Date(2026, 2, 3, 4, 5, 0, 0, time.UTC)
+
+	auth := BuildRecord(RecordOptions{
+		AuthDir:  authDir,
+		Path:     path,
+		Provider: "codex",
+		Metadata: map[string]any{"last_refresh": metadataRefresh.Format(time.RFC3339)},
+		Existing: &coreauth.Auth{
+			LastRefreshedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	if auth == nil {
+		t.Fatal("BuildRecord() = nil")
+	}
+	if !auth.LastRefreshedAt.Equal(metadataRefresh) {
+		t.Fatalf("LastRefreshedAt = %v, want metadata value %v", auth.LastRefreshedAt, metadataRefresh)
+	}
+}
+
+func TestChannelLabelFromMetadataFallbacks(t *testing.T) {
+	if got := ChannelLabelFromMetadata(map[string]any{"label": " Team A ", "email": "user@example.com"}, "codex"); got != "Team A" {
+		t.Fatalf("label fallback = %q, want Team A", got)
+	}
+	if got := ChannelLabelFromMetadata(map[string]any{"email": " user@example.com "}, "codex"); got != "user@example.com" {
+		t.Fatalf("email fallback = %q, want user@example.com", got)
+	}
+	if got := ChannelLabelFromMetadata(nil, " codex "); got != "codex" {
+		t.Fatalf("provider fallback = %q, want codex", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Move auth-file metadata-to-auth record construction into internal/management/authfiles.BuildRecord.
- Keep registerAuthFromFile focused on JSON parsing, metadata normalization, persistence write-back, and auth manager register/update side effects.
- Add record builder tests for routing fields, label fallback, last refresh, and existing runtime field preservation.
- Tighten the backend structure baseline after reducing auth_files.go.

## Validation
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check