### PR TITLE
refactor: move gemini cli onboarding helpers

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 2286,
+        "max_lines": 1858,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 604 |
-| 生产 Go 文件 | 415 |
-| 测试 Go 文件 | 189 |
-| `internal/` Go 文件 | 481 |
-| `internal/` 生产 Go 文件 | 344 |
-| `internal/` 测试 Go 文件 | 137 |
+| Go 文件总数 | 606 |
+| 生产 Go 文件 | 416 |
+| 测试 Go 文件 | 190 |
+| `internal/` Go 文件 | 483 |
+| `internal/` 生产 Go 文件 | 345 |
+| `internal/` 测试 Go 文件 | 138 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 252 |
 | `server.go` 内管理路由注册 | 194 |
-| `internal/` 生产目录 | 82 |
-| `internal/` 有同级测试目录 | 37 |
+| `internal/` 生产目录 | 83 |
+| `internal/` 有同级测试目录 | 38 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 2286 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1858 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1,14 +1,12 @@
 package management
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -27,9 +25,9 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	oauthcallback "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/callback"
+	geminicli "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/geminicli"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -45,16 +43,8 @@ const (
 	anthropicCallbackPort                     = 54545
 	geminiCallbackPort                        = 8085
 	codexCallbackPort                         = 1455
-	geminiCLIEndpoint                         = "https://cloudcode-pa.googleapis.com"
-	geminiCLIVersion                          = "v1internal"
-	geminiCLIUserAgent                        = "google-api-nodejs-client/9.15.1"
-	geminiCLIApiClient                        = "gl-node/22.17.0"
-	geminiCLIClientMetadata                   = "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI"
 	oauthCallbackWaitTimeout                  = oauthSessionTTL
 	managementOAuthProfileResponseLimit int64 = 64 << 10
-	managementGCPProjectListLimit       int64 = 1 << 20
-	managementServiceUsageResponseLimit int64 = 128 << 10
-	managementGeminiCLIErrorBodyLimit   int64 = 256 << 10
 )
 
 func isWebUIRequest(c *gin.Context) bool {
@@ -1059,13 +1049,13 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 
 		if strings.EqualFold(requestedProjectID, "ALL") {
 			ts.Auto = false
-			projects, errAll := onboardAllGeminiProjects(ctx, gemClient, &ts)
+			projects, errAll := geminicli.OnboardAllProjects(ctx, gemClient, &ts)
 			if errAll != nil {
 				log.Errorf("Failed to complete Gemini CLI onboarding: %v", errAll)
 				SetOAuthSessionError(state, "Failed to complete Gemini CLI onboarding")
 				return
 			}
-			if errVerify := ensureGeminiProjectsEnabled(ctx, gemClient, projects); errVerify != nil {
+			if errVerify := geminicli.EnsureProjectsEnabled(ctx, gemClient, projects); errVerify != nil {
 				log.Errorf("Failed to verify Cloud AI API status: %v", errVerify)
 				SetOAuthSessionError(state, "Failed to verify Cloud AI API status")
 				return
@@ -1074,7 +1064,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			ts.Checked = true
 		} else if strings.EqualFold(requestedProjectID, "GOOGLE_ONE") {
 			ts.Auto = false
-			if errSetup := performGeminiCLISetup(ctx, gemClient, &ts, ""); errSetup != nil {
+			if errSetup := geminicli.PerformSetup(ctx, gemClient, &ts, ""); errSetup != nil {
 				log.Errorf("Google One auto-discovery failed: %v", errSetup)
 				SetOAuthSessionError(state, "Google One auto-discovery failed")
 				return
@@ -1084,7 +1074,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 				SetOAuthSessionError(state, "Google One auto-discovery returned empty project ID")
 				return
 			}
-			isChecked, errCheck := checkCloudAPIIsEnabled(ctx, gemClient, ts.ProjectID)
+			isChecked, errCheck := geminicli.CheckCloudAPIIsEnabled(ctx, gemClient, ts.ProjectID)
 			if errCheck != nil {
 				log.Errorf("Failed to verify Cloud AI API status: %v", errCheck)
 				SetOAuthSessionError(state, "Failed to verify Cloud AI API status")
@@ -1097,7 +1087,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 				return
 			}
 		} else {
-			if errEnsure := ensureGeminiProjectAndOnboard(ctx, gemClient, &ts, requestedProjectID); errEnsure != nil {
+			if errEnsure := geminicli.EnsureProjectAndOnboard(ctx, gemClient, &ts, requestedProjectID); errEnsure != nil {
 				log.Errorf("Failed to complete Gemini CLI onboarding: %v", errEnsure)
 				SetOAuthSessionError(state, "Failed to complete Gemini CLI onboarding")
 				return
@@ -1109,7 +1099,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 				return
 			}
 
-			isChecked, errCheck := checkCloudAPIIsEnabled(ctx, gemClient, ts.ProjectID)
+			isChecked, errCheck := geminicli.CheckCloudAPIIsEnabled(ctx, gemClient, ts.ProjectID)
 			if errCheck != nil {
 				log.Errorf("Failed to verify Cloud AI API status: %v", errCheck)
 				SetOAuthSessionError(state, "Failed to verify Cloud AI API status")
@@ -1805,424 +1795,6 @@ func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 		"expired":    tokenStorage.Expire,
 		"type":       tokenStorage.Type,
 	})
-}
-
-type projectSelectionRequiredError struct{}
-
-func (e *projectSelectionRequiredError) Error() string {
-	return "gemini cli: project selection required"
-}
-
-func ensureGeminiProjectAndOnboard(ctx context.Context, httpClient *http.Client, storage *geminiAuth.GeminiTokenStorage, requestedProject string) error {
-	if storage == nil {
-		return fmt.Errorf("gemini storage is nil")
-	}
-
-	trimmedRequest := strings.TrimSpace(requestedProject)
-	if trimmedRequest == "" {
-		projects, errProjects := fetchGCPProjects(ctx, httpClient)
-		if errProjects != nil {
-			return fmt.Errorf("fetch project list: %w", errProjects)
-		}
-		if len(projects) == 0 {
-			return fmt.Errorf("no Google Cloud projects available for this account")
-		}
-		trimmedRequest = strings.TrimSpace(projects[0].ProjectID)
-		if trimmedRequest == "" {
-			return fmt.Errorf("resolved project id is empty")
-		}
-		storage.Auto = true
-	} else {
-		storage.Auto = false
-	}
-
-	if err := performGeminiCLISetup(ctx, httpClient, storage, trimmedRequest); err != nil {
-		return err
-	}
-
-	if strings.TrimSpace(storage.ProjectID) == "" {
-		storage.ProjectID = trimmedRequest
-	}
-
-	return nil
-}
-
-func onboardAllGeminiProjects(ctx context.Context, httpClient *http.Client, storage *geminiAuth.GeminiTokenStorage) ([]string, error) {
-	projects, errProjects := fetchGCPProjects(ctx, httpClient)
-	if errProjects != nil {
-		return nil, fmt.Errorf("fetch project list: %w", errProjects)
-	}
-	if len(projects) == 0 {
-		return nil, fmt.Errorf("no Google Cloud projects available for this account")
-	}
-	activated := make([]string, 0, len(projects))
-	seen := make(map[string]struct{}, len(projects))
-	for _, project := range projects {
-		candidate := strings.TrimSpace(project.ProjectID)
-		if candidate == "" {
-			continue
-		}
-		if _, dup := seen[candidate]; dup {
-			continue
-		}
-		if err := performGeminiCLISetup(ctx, httpClient, storage, candidate); err != nil {
-			return nil, fmt.Errorf("onboard project %s: %w", candidate, err)
-		}
-		finalID := strings.TrimSpace(storage.ProjectID)
-		if finalID == "" {
-			finalID = candidate
-		}
-		activated = append(activated, finalID)
-		seen[candidate] = struct{}{}
-	}
-	if len(activated) == 0 {
-		return nil, fmt.Errorf("no Google Cloud projects available for this account")
-	}
-	return activated, nil
-}
-
-func ensureGeminiProjectsEnabled(ctx context.Context, httpClient *http.Client, projectIDs []string) error {
-	for _, pid := range projectIDs {
-		trimmed := strings.TrimSpace(pid)
-		if trimmed == "" {
-			continue
-		}
-		isChecked, errCheck := checkCloudAPIIsEnabled(ctx, httpClient, trimmed)
-		if errCheck != nil {
-			return fmt.Errorf("project %s: %w", trimmed, errCheck)
-		}
-		if !isChecked {
-			return fmt.Errorf("project %s: Cloud AI API not enabled", trimmed)
-		}
-	}
-	return nil
-}
-
-func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage *geminiAuth.GeminiTokenStorage, requestedProject string) error {
-	metadata := map[string]string{
-		"ideType":    "IDE_UNSPECIFIED",
-		"platform":   "PLATFORM_UNSPECIFIED",
-		"pluginType": "GEMINI",
-	}
-
-	trimmedRequest := strings.TrimSpace(requestedProject)
-	explicitProject := trimmedRequest != ""
-
-	loadReqBody := map[string]any{
-		"metadata": metadata,
-	}
-	if explicitProject {
-		loadReqBody["cloudaicompanionProject"] = trimmedRequest
-	}
-
-	var loadResp map[string]any
-	if errLoad := callGeminiCLI(ctx, httpClient, "loadCodeAssist", loadReqBody, &loadResp); errLoad != nil {
-		return fmt.Errorf("load code assist: %w", errLoad)
-	}
-
-	tierID := "legacy-tier"
-	if tiers, okTiers := loadResp["allowedTiers"].([]any); okTiers {
-		for _, rawTier := range tiers {
-			tier, okTier := rawTier.(map[string]any)
-			if !okTier {
-				continue
-			}
-			if isDefault, okDefault := tier["isDefault"].(bool); okDefault && isDefault {
-				if id, okID := tier["id"].(string); okID && strings.TrimSpace(id) != "" {
-					tierID = strings.TrimSpace(id)
-					break
-				}
-			}
-		}
-	}
-
-	projectID := trimmedRequest
-	if projectID == "" {
-		if id, okProject := loadResp["cloudaicompanionProject"].(string); okProject {
-			projectID = strings.TrimSpace(id)
-		}
-		if projectID == "" {
-			if projectMap, okProject := loadResp["cloudaicompanionProject"].(map[string]any); okProject {
-				if id, okID := projectMap["id"].(string); okID {
-					projectID = strings.TrimSpace(id)
-				}
-			}
-		}
-	}
-	if projectID == "" {
-		// Auto-discovery: try onboardUser without specifying a project
-		// to let Google auto-provision one (matches Gemini CLI headless behavior
-		// and Antigravity's FetchProjectID pattern).
-		autoOnboardReq := map[string]any{
-			"tierId":   tierID,
-			"metadata": metadata,
-		}
-
-		autoCtx, autoCancel := context.WithTimeout(ctx, 30*time.Second)
-		defer autoCancel()
-		for attempt := 1; ; attempt++ {
-			var onboardResp map[string]any
-			if errOnboard := callGeminiCLI(autoCtx, httpClient, "onboardUser", autoOnboardReq, &onboardResp); errOnboard != nil {
-				return fmt.Errorf("auto-discovery onboardUser: %w", errOnboard)
-			}
-
-			if done, okDone := onboardResp["done"].(bool); okDone && done {
-				if resp, okResp := onboardResp["response"].(map[string]any); okResp {
-					switch v := resp["cloudaicompanionProject"].(type) {
-					case string:
-						projectID = strings.TrimSpace(v)
-					case map[string]any:
-						if id, okID := v["id"].(string); okID {
-							projectID = strings.TrimSpace(id)
-						}
-					}
-				}
-				break
-			}
-
-			log.Debugf("Auto-discovery: onboarding in progress, attempt %d...", attempt)
-			select {
-			case <-autoCtx.Done():
-				return &projectSelectionRequiredError{}
-			case <-time.After(2 * time.Second):
-			}
-		}
-
-		if projectID == "" {
-			return &projectSelectionRequiredError{}
-		}
-		log.Infof("Auto-discovered project ID via onboarding: %s", projectID)
-	}
-
-	onboardReqBody := map[string]any{
-		"tierId":                  tierID,
-		"metadata":                metadata,
-		"cloudaicompanionProject": projectID,
-	}
-
-	storage.ProjectID = projectID
-
-	for {
-		var onboardResp map[string]any
-		if errOnboard := callGeminiCLI(ctx, httpClient, "onboardUser", onboardReqBody, &onboardResp); errOnboard != nil {
-			return fmt.Errorf("onboard user: %w", errOnboard)
-		}
-
-		if done, okDone := onboardResp["done"].(bool); okDone && done {
-			responseProjectID := ""
-			if resp, okResp := onboardResp["response"].(map[string]any); okResp {
-				switch projectValue := resp["cloudaicompanionProject"].(type) {
-				case map[string]any:
-					if id, okID := projectValue["id"].(string); okID {
-						responseProjectID = strings.TrimSpace(id)
-					}
-				case string:
-					responseProjectID = strings.TrimSpace(projectValue)
-				}
-			}
-
-			finalProjectID := projectID
-			if responseProjectID != "" {
-				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
-					// Check if this is a free user (gen-lang-client projects or free/legacy tier)
-					isFreeUser := strings.HasPrefix(projectID, "gen-lang-client-") ||
-						strings.EqualFold(tierID, "FREE") ||
-						strings.EqualFold(tierID, "LEGACY")
-
-					if isFreeUser {
-						// For free users, use backend project ID for preview model access
-						log.Infof("Gemini onboarding: frontend project %s maps to backend project %s", projectID, responseProjectID)
-						log.Infof("Using backend project ID: %s (recommended for preview model access)", responseProjectID)
-						finalProjectID = responseProjectID
-					} else {
-						// Pro users: keep requested project ID (original behavior)
-						log.Warnf("Gemini onboarding returned project %s instead of requested %s; keeping requested project ID.", responseProjectID, projectID)
-					}
-				} else {
-					finalProjectID = responseProjectID
-				}
-			}
-
-			storage.ProjectID = strings.TrimSpace(finalProjectID)
-			if storage.ProjectID == "" {
-				storage.ProjectID = strings.TrimSpace(projectID)
-			}
-			if storage.ProjectID == "" {
-				return fmt.Errorf("onboard user completed without project id")
-			}
-			log.Infof("Onboarding complete. Using Project ID: %s", storage.ProjectID)
-			return nil
-		}
-
-		log.Println("Onboarding in progress, waiting 5 seconds...")
-		time.Sleep(5 * time.Second)
-	}
-}
-
-func callGeminiCLI(ctx context.Context, httpClient *http.Client, endpoint string, body any, result any) error {
-	endPointURL := fmt.Sprintf("%s/%s:%s", geminiCLIEndpoint, geminiCLIVersion, endpoint)
-	if strings.HasPrefix(endpoint, "operations/") {
-		endPointURL = fmt.Sprintf("%s/%s", geminiCLIEndpoint, endpoint)
-	}
-
-	var reader io.Reader
-	if body != nil {
-		rawBody, errMarshal := json.Marshal(body)
-		if errMarshal != nil {
-			return fmt.Errorf("marshal request body: %w", errMarshal)
-		}
-		reader = bytes.NewReader(rawBody)
-	}
-
-	req, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, endPointURL, reader)
-	if errRequest != nil {
-		return fmt.Errorf("create request: %w", errRequest)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", geminiCLIUserAgent)
-	req.Header.Set("X-Goog-Api-Client", geminiCLIApiClient)
-	req.Header.Set("Client-Metadata", geminiCLIClientMetadata)
-
-	resp, errDo := httpClient.Do(req)
-	if errDo != nil {
-		return fmt.Errorf("execute request: %w", errDo)
-	}
-	defer func() {
-		if errClose := resp.Body.Close(); errClose != nil {
-			log.Errorf("response body close error: %v", errClose)
-		}
-	}()
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		bodyBytes, errReadBody := bodyutil.ReadAll(resp.Body, managementGeminiCLIErrorBodyLimit)
-		if errReadBody != nil {
-			if bodyutil.IsTooLarge(errReadBody) {
-				return fmt.Errorf("api request failed with status %d: response body too large", resp.StatusCode)
-			}
-			return fmt.Errorf("api request failed with status %d and unreadable body: %w", resp.StatusCode, errReadBody)
-		}
-		return fmt.Errorf("api request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
-	}
-
-	if result == nil {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil
-	}
-
-	if errDecode := json.NewDecoder(resp.Body).Decode(result); errDecode != nil {
-		return fmt.Errorf("decode response body: %w", errDecode)
-	}
-
-	return nil
-}
-
-func fetchGCPProjects(ctx context.Context, httpClient *http.Client) ([]interfaces.GCPProjectProjects, error) {
-	req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, "https://cloudresourcemanager.googleapis.com/v1/projects", nil)
-	if errRequest != nil {
-		return nil, fmt.Errorf("could not create project list request: %w", errRequest)
-	}
-
-	resp, errDo := httpClient.Do(req)
-	if errDo != nil {
-		return nil, fmt.Errorf("failed to execute project list request: %w", errDo)
-	}
-	defer func() {
-		if errClose := resp.Body.Close(); errClose != nil {
-			log.Errorf("response body close error: %v", errClose)
-		}
-	}()
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		bodyBytes, errReadBody := bodyutil.ReadAll(resp.Body, managementGCPProjectListLimit)
-		if errReadBody != nil {
-			if bodyutil.IsTooLarge(errReadBody) {
-				return nil, fmt.Errorf("project list request failed with status %d: response body too large", resp.StatusCode)
-			}
-			return nil, fmt.Errorf("project list request failed with status %d and unreadable body: %w", resp.StatusCode, errReadBody)
-		}
-		return nil, fmt.Errorf("project list request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
-	}
-
-	var projects interfaces.GCPProject
-	if errDecode := json.NewDecoder(resp.Body).Decode(&projects); errDecode != nil {
-		return nil, fmt.Errorf("failed to unmarshal project list: %w", errDecode)
-	}
-
-	return projects.Projects, nil
-}
-
-func checkCloudAPIIsEnabled(ctx context.Context, httpClient *http.Client, projectID string) (bool, error) {
-	serviceUsageURL := "https://serviceusage.googleapis.com"
-	requiredServices := []string{
-		"cloudaicompanion.googleapis.com",
-	}
-	for _, service := range requiredServices {
-		checkURL := fmt.Sprintf("%s/v1/projects/%s/services/%s", serviceUsageURL, projectID, service)
-		req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, checkURL, nil)
-		if errRequest != nil {
-			return false, fmt.Errorf("failed to create request: %w", errRequest)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("User-Agent", geminiCLIUserAgent)
-		resp, errDo := httpClient.Do(req)
-		if errDo != nil {
-			return false, fmt.Errorf("failed to execute request: %w", errDo)
-		}
-
-		if resp.StatusCode == http.StatusOK {
-			bodyBytes, errReadBody := bodyutil.ReadAll(resp.Body, managementServiceUsageResponseLimit)
-			if errReadBody != nil {
-				_ = resp.Body.Close()
-				if bodyutil.IsTooLarge(errReadBody) {
-					return false, fmt.Errorf("service usage state response too large")
-				}
-				return false, fmt.Errorf("read service usage state response: %w", errReadBody)
-			}
-			if gjson.GetBytes(bodyBytes, "state").String() == "ENABLED" {
-				_ = resp.Body.Close()
-				continue
-			}
-		}
-		_ = resp.Body.Close()
-
-		enableURL := fmt.Sprintf("%s/v1/projects/%s/services/%s:enable", serviceUsageURL, projectID, service)
-		req, errRequest = http.NewRequestWithContext(ctx, http.MethodPost, enableURL, strings.NewReader("{}"))
-		if errRequest != nil {
-			return false, fmt.Errorf("failed to create request: %w", errRequest)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("User-Agent", geminiCLIUserAgent)
-		resp, errDo = httpClient.Do(req)
-		if errDo != nil {
-			return false, fmt.Errorf("failed to execute request: %w", errDo)
-		}
-
-		bodyBytes, errReadBody := bodyutil.ReadAll(resp.Body, managementServiceUsageResponseLimit)
-		if errReadBody != nil {
-			_ = resp.Body.Close()
-			if bodyutil.IsTooLarge(errReadBody) {
-				return false, fmt.Errorf("service enable response too large")
-			}
-			return false, fmt.Errorf("read service enable response: %w", errReadBody)
-		}
-		errMessage := string(bodyBytes)
-		errMessageResult := gjson.GetBytes(bodyBytes, "error.message")
-		if errMessageResult.Exists() {
-			errMessage = errMessageResult.String()
-		}
-		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
-			_ = resp.Body.Close()
-			continue
-		} else if resp.StatusCode == http.StatusBadRequest {
-			_ = resp.Body.Close()
-			if strings.Contains(strings.ToLower(errMessage), "already enabled") {
-				continue
-			}
-		}
-		_ = resp.Body.Close()
-		return false, fmt.Errorf("project activation required: %s", errMessage)
-	}
-	return true, nil
 }
 
 func (h *Handler) GetAuthStatus(c *gin.Context) {

--- a/internal/management/oauth/providers/geminicli/onboarding.go
+++ b/internal/management/oauth/providers/geminicli/onboarding.go
@@ -1,0 +1,446 @@
+package geminicli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	geminiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	endpoint                = "https://cloudcode-pa.googleapis.com"
+	version                 = "v1internal"
+	userAgent               = "google-api-nodejs-client/9.15.1"
+	apiClient               = "gl-node/22.17.0"
+	clientMetadata          = "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI"
+	projectListLimit  int64 = 1 << 20
+	serviceUsageLimit int64 = 128 << 10
+	errorBodyLimit    int64 = 256 << 10
+)
+
+type projectSelectionRequiredError struct{}
+
+func (e *projectSelectionRequiredError) Error() string {
+	return "gemini cli: project selection required"
+}
+
+func EnsureProjectAndOnboard(ctx context.Context, httpClient *http.Client, storage *geminiauth.GeminiTokenStorage, requestedProject string) error {
+	if storage == nil {
+		return fmt.Errorf("gemini storage is nil")
+	}
+
+	trimmedRequest := strings.TrimSpace(requestedProject)
+	if trimmedRequest == "" {
+		projects, errProjects := fetchGCPProjects(ctx, httpClient)
+		if errProjects != nil {
+			return fmt.Errorf("fetch project list: %w", errProjects)
+		}
+		if len(projects) == 0 {
+			return fmt.Errorf("no Google Cloud projects available for this account")
+		}
+		trimmedRequest = strings.TrimSpace(projects[0].ProjectID)
+		if trimmedRequest == "" {
+			return fmt.Errorf("resolved project id is empty")
+		}
+		storage.Auto = true
+	} else {
+		storage.Auto = false
+	}
+
+	if err := PerformSetup(ctx, httpClient, storage, trimmedRequest); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(storage.ProjectID) == "" {
+		storage.ProjectID = trimmedRequest
+	}
+
+	return nil
+}
+
+func OnboardAllProjects(ctx context.Context, httpClient *http.Client, storage *geminiauth.GeminiTokenStorage) ([]string, error) {
+	projects, errProjects := fetchGCPProjects(ctx, httpClient)
+	if errProjects != nil {
+		return nil, fmt.Errorf("fetch project list: %w", errProjects)
+	}
+	if len(projects) == 0 {
+		return nil, fmt.Errorf("no Google Cloud projects available for this account")
+	}
+	activated := make([]string, 0, len(projects))
+	seen := make(map[string]struct{}, len(projects))
+	for _, project := range projects {
+		candidate := strings.TrimSpace(project.ProjectID)
+		if candidate == "" {
+			continue
+		}
+		if _, dup := seen[candidate]; dup {
+			continue
+		}
+		if err := PerformSetup(ctx, httpClient, storage, candidate); err != nil {
+			return nil, fmt.Errorf("onboard project %s: %w", candidate, err)
+		}
+		finalID := strings.TrimSpace(storage.ProjectID)
+		if finalID == "" {
+			finalID = candidate
+		}
+		activated = append(activated, finalID)
+		seen[candidate] = struct{}{}
+	}
+	if len(activated) == 0 {
+		return nil, fmt.Errorf("no Google Cloud projects available for this account")
+	}
+	return activated, nil
+}
+
+func EnsureProjectsEnabled(ctx context.Context, httpClient *http.Client, projectIDs []string) error {
+	for _, pid := range projectIDs {
+		trimmed := strings.TrimSpace(pid)
+		if trimmed == "" {
+			continue
+		}
+		isChecked, errCheck := CheckCloudAPIIsEnabled(ctx, httpClient, trimmed)
+		if errCheck != nil {
+			return fmt.Errorf("project %s: %w", trimmed, errCheck)
+		}
+		if !isChecked {
+			return fmt.Errorf("project %s: Cloud AI API not enabled", trimmed)
+		}
+	}
+	return nil
+}
+
+func PerformSetup(ctx context.Context, httpClient *http.Client, storage *geminiauth.GeminiTokenStorage, requestedProject string) error {
+	duetProject := ""
+	if storage != nil {
+		duetProject = strings.TrimSpace(storage.ProjectID)
+	}
+	metadata := map[string]string{
+		"ideType":     "IDE_UNSPECIFIED",
+		"platform":    "PLATFORM_UNSPECIFIED",
+		"pluginType":  "GEMINI",
+		"duetProject": duetProject,
+	}
+
+	trimmedRequest := strings.TrimSpace(requestedProject)
+	explicitProject := trimmedRequest != ""
+
+	loadReqBody := map[string]any{
+		"metadata": metadata,
+	}
+	if explicitProject {
+		loadReqBody["cloudaicompanionProject"] = trimmedRequest
+	}
+
+	var loadResp map[string]any
+	if errLoad := call(ctx, httpClient, "loadCodeAssist", loadReqBody, &loadResp); errLoad != nil {
+		return fmt.Errorf("load code assist: %w", errLoad)
+	}
+
+	tierID := "legacy-tier"
+	if tiers, okTiers := loadResp["allowedTiers"].([]any); okTiers {
+		for _, rawTier := range tiers {
+			tier, okTier := rawTier.(map[string]any)
+			if !okTier {
+				continue
+			}
+			if isDefault, okDefault := tier["isDefault"].(bool); okDefault && isDefault {
+				if id, okID := tier["id"].(string); okID && strings.TrimSpace(id) != "" {
+					tierID = strings.TrimSpace(id)
+					break
+				}
+			}
+		}
+	}
+
+	projectID := trimmedRequest
+	if projectID == "" {
+		if id, okProject := loadResp["cloudaicompanionProject"].(string); okProject {
+			projectID = strings.TrimSpace(id)
+		}
+		if projectID == "" {
+			if projectMap, okProject := loadResp["cloudaicompanionProject"].(map[string]any); okProject {
+				if id, okID := projectMap["id"].(string); okID {
+					projectID = strings.TrimSpace(id)
+				}
+			}
+		}
+	}
+	if projectID == "" {
+		autoOnboardReq := map[string]any{
+			"tierId":   tierID,
+			"metadata": metadata,
+		}
+
+		autoCtx, autoCancel := context.WithTimeout(ctx, 30*time.Second)
+		defer autoCancel()
+		for attempt := 1; ; attempt++ {
+			var onboardResp map[string]any
+			if errOnboard := call(autoCtx, httpClient, "onboardUser", autoOnboardReq, &onboardResp); errOnboard != nil {
+				return fmt.Errorf("auto-discovery onboardUser: %w", errOnboard)
+			}
+
+			if done, okDone := onboardResp["done"].(bool); okDone && done {
+				if resp, okResp := onboardResp["response"].(map[string]any); okResp {
+					switch v := resp["cloudaicompanionProject"].(type) {
+					case string:
+						projectID = strings.TrimSpace(v)
+					case map[string]any:
+						if id, okID := v["id"].(string); okID {
+							projectID = strings.TrimSpace(id)
+						}
+					}
+				}
+				break
+			}
+
+			log.Debugf("Auto-discovery: onboarding in progress, attempt %d...", attempt)
+			select {
+			case <-autoCtx.Done():
+				return &projectSelectionRequiredError{}
+			case <-time.After(2 * time.Second):
+			}
+		}
+
+		if projectID == "" {
+			return &projectSelectionRequiredError{}
+		}
+		log.Infof("Auto-discovered project ID via onboarding: %s", projectID)
+	}
+
+	onboardReqBody := map[string]any{
+		"tierId":                  tierID,
+		"metadata":                metadata,
+		"cloudaicompanionProject": projectID,
+	}
+
+	storage.ProjectID = projectID
+
+	for {
+		var onboardResp map[string]any
+		if errOnboard := call(ctx, httpClient, "onboardUser", onboardReqBody, &onboardResp); errOnboard != nil {
+			return fmt.Errorf("onboard user: %w", errOnboard)
+		}
+
+		if done, okDone := onboardResp["done"].(bool); okDone && done {
+			responseProjectID := ""
+			if resp, okResp := onboardResp["response"].(map[string]any); okResp {
+				switch projectValue := resp["cloudaicompanionProject"].(type) {
+				case map[string]any:
+					if id, okID := projectValue["id"].(string); okID {
+						responseProjectID = strings.TrimSpace(id)
+					}
+				case string:
+					responseProjectID = strings.TrimSpace(projectValue)
+				}
+			}
+
+			finalProjectID := projectID
+			if responseProjectID != "" {
+				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
+					isFreeUser := strings.HasPrefix(projectID, "gen-lang-client-") ||
+						strings.EqualFold(tierID, "FREE") ||
+						strings.EqualFold(tierID, "LEGACY")
+
+					if isFreeUser {
+						log.Infof("Gemini onboarding: frontend project %s maps to backend project %s", projectID, responseProjectID)
+						log.Infof("Using backend project ID: %s (recommended for preview model access)", responseProjectID)
+						finalProjectID = responseProjectID
+					} else {
+						log.Warnf("Gemini onboarding returned project %s instead of requested %s; keeping requested project ID.", responseProjectID, projectID)
+					}
+				} else {
+					finalProjectID = responseProjectID
+				}
+			}
+
+			storage.ProjectID = strings.TrimSpace(finalProjectID)
+			if storage.ProjectID == "" {
+				storage.ProjectID = strings.TrimSpace(projectID)
+			}
+			if storage.ProjectID == "" {
+				return fmt.Errorf("onboard user completed without project id")
+			}
+			log.Infof("Onboarding complete. Using Project ID: %s", storage.ProjectID)
+			return nil
+		}
+
+		log.Println("Onboarding in progress, waiting 5 seconds...")
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func call(ctx context.Context, httpClient *http.Client, targetEndpoint string, body any, result any) error {
+	endPointURL := fmt.Sprintf("%s/%s:%s", endpoint, version, targetEndpoint)
+	if strings.HasPrefix(targetEndpoint, "operations/") {
+		endPointURL = fmt.Sprintf("%s/%s", endpoint, targetEndpoint)
+	}
+
+	var reader io.Reader
+	if body != nil {
+		rawBody, errMarshal := json.Marshal(body)
+		if errMarshal != nil {
+			return fmt.Errorf("marshal request body: %w", errMarshal)
+		}
+		reader = bytes.NewReader(rawBody)
+	}
+
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, endPointURL, reader)
+	if errRequest != nil {
+		return fmt.Errorf("create request: %w", errRequest)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("X-Goog-Api-Client", apiClient)
+	req.Header.Set("Client-Metadata", clientMetadata)
+
+	resp, errDo := httpClient.Do(req)
+	if errDo != nil {
+		return fmt.Errorf("execute request: %w", errDo)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("response body close error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		bodyBytes, errReadBody := bodyutil.ReadAll(resp.Body, errorBodyLimit)
+		if errReadBody != nil {
+			if bodyutil.IsTooLarge(errReadBody) {
+				return fmt.Errorf("api request failed with status %d: response body too large", resp.StatusCode)
+			}
+			return fmt.Errorf("api request failed with status %d and unreadable body: %w", resp.StatusCode, errReadBody)
+		}
+		return fmt.Errorf("api request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+	}
+
+	if result == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
+	if errDecode := json.NewDecoder(resp.Body).Decode(result); errDecode != nil {
+		return fmt.Errorf("decode response body: %w", errDecode)
+	}
+
+	return nil
+}
+
+func fetchGCPProjects(ctx context.Context, httpClient *http.Client) ([]interfaces.GCPProjectProjects, error) {
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, "https://cloudresourcemanager.googleapis.com/v1/projects", nil)
+	if errRequest != nil {
+		return nil, fmt.Errorf("could not create project list request: %w", errRequest)
+	}
+
+	resp, errDo := httpClient.Do(req)
+	if errDo != nil {
+		return nil, fmt.Errorf("failed to execute project list request: %w", errDo)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("response body close error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		bodyBytes, errReadBody := bodyutil.ReadAll(resp.Body, projectListLimit)
+		if errReadBody != nil {
+			if bodyutil.IsTooLarge(errReadBody) {
+				return nil, fmt.Errorf("project list request failed with status %d: response body too large", resp.StatusCode)
+			}
+			return nil, fmt.Errorf("project list request failed with status %d and unreadable body: %w", resp.StatusCode, errReadBody)
+		}
+		return nil, fmt.Errorf("project list request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+	}
+
+	var projects interfaces.GCPProject
+	if errDecode := json.NewDecoder(resp.Body).Decode(&projects); errDecode != nil {
+		return nil, fmt.Errorf("failed to unmarshal project list: %w", errDecode)
+	}
+
+	return projects.Projects, nil
+}
+
+func CheckCloudAPIIsEnabled(ctx context.Context, httpClient *http.Client, projectID string) (bool, error) {
+	serviceUsageURL := "https://serviceusage.googleapis.com"
+	requiredServices := []string{
+		"cloudaicompanion.googleapis.com",
+	}
+	for _, service := range requiredServices {
+		checkURL := fmt.Sprintf("%s/v1/projects/%s/services/%s", serviceUsageURL, projectID, service)
+		req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, checkURL, nil)
+		if errRequest != nil {
+			return false, fmt.Errorf("failed to create request: %w", errRequest)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", userAgent)
+		resp, errDo := httpClient.Do(req)
+		if errDo != nil {
+			return false, fmt.Errorf("failed to execute request: %w", errDo)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			bodyBytes, errReadBody := bodyutil.ReadAll(resp.Body, serviceUsageLimit)
+			if errReadBody != nil {
+				_ = resp.Body.Close()
+				if bodyutil.IsTooLarge(errReadBody) {
+					return false, fmt.Errorf("service usage state response too large")
+				}
+				return false, fmt.Errorf("read service usage state response: %w", errReadBody)
+			}
+			if gjson.GetBytes(bodyBytes, "state").String() == "ENABLED" {
+				_ = resp.Body.Close()
+				continue
+			}
+		}
+		_ = resp.Body.Close()
+
+		enableURL := fmt.Sprintf("%s/v1/projects/%s/services/%s:enable", serviceUsageURL, projectID, service)
+		req, errRequest = http.NewRequestWithContext(ctx, http.MethodPost, enableURL, strings.NewReader("{}"))
+		if errRequest != nil {
+			return false, fmt.Errorf("failed to create request: %w", errRequest)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", userAgent)
+		resp, errDo = httpClient.Do(req)
+		if errDo != nil {
+			return false, fmt.Errorf("failed to execute request: %w", errDo)
+		}
+
+		bodyBytes, errReadBody := bodyutil.ReadAll(resp.Body, serviceUsageLimit)
+		if errReadBody != nil {
+			_ = resp.Body.Close()
+			if bodyutil.IsTooLarge(errReadBody) {
+				return false, fmt.Errorf("service enable response too large")
+			}
+			return false, fmt.Errorf("read service enable response: %w", errReadBody)
+		}
+		errMessage := string(bodyBytes)
+		errMessageResult := gjson.GetBytes(bodyBytes, "error.message")
+		if errMessageResult.Exists() {
+			errMessage = errMessageResult.String()
+		}
+		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+			_ = resp.Body.Close()
+			continue
+		} else if resp.StatusCode == http.StatusBadRequest {
+			_ = resp.Body.Close()
+			if strings.Contains(strings.ToLower(errMessage), "already enabled") {
+				continue
+			}
+		}
+		_ = resp.Body.Close()
+		return false, fmt.Errorf("project activation required: %s", errMessage)
+	}
+	return true, nil
+}

--- a/internal/management/oauth/providers/geminicli/onboarding_test.go
+++ b/internal/management/oauth/providers/geminicli/onboarding_test.go
@@ -1,0 +1,122 @@
+package geminicli
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	geminiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
+)
+
+func TestPerformSetupUsesBackendProjectForFreeUser(t *testing.T) {
+	transport := &sequenceTransport{t: t}
+	transport.enqueue(func(req *http.Request) *http.Response {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1internal:loadCodeAssist" {
+			t.Fatalf("request = %s %s, want loadCodeAssist", req.Method, req.URL.Path)
+		}
+		assertGeminiHeaders(t, req)
+		body, _ := io.ReadAll(req.Body)
+		if !strings.Contains(string(body), `"cloudaicompanionProject":"gen-lang-client-front"`) {
+			t.Fatalf("loadCodeAssist body = %s, want requested project", string(body))
+		}
+		return jsonResponse(http.StatusOK, `{"allowedTiers":[{"id":"FREE","isDefault":true}]}`)
+	})
+	transport.enqueue(func(req *http.Request) *http.Response {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1internal:onboardUser" {
+			t.Fatalf("request = %s %s, want onboardUser", req.Method, req.URL.Path)
+		}
+		assertGeminiHeaders(t, req)
+		return jsonResponse(http.StatusOK, `{"done":true,"response":{"cloudaicompanionProject":"backend-project"}}`)
+	})
+
+	storage := &geminiauth.GeminiTokenStorage{}
+	err := PerformSetup(context.Background(), &http.Client{Transport: transport}, storage, "gen-lang-client-front")
+	if err != nil {
+		t.Fatalf("PerformSetup() error = %v", err)
+	}
+	if storage.ProjectID != "backend-project" {
+		t.Fatalf("ProjectID = %q, want backend-project", storage.ProjectID)
+	}
+	transport.assertDone()
+}
+
+func TestCheckCloudAPIIsEnabledEnablesDisabledService(t *testing.T) {
+	transport := &sequenceTransport{t: t}
+	transport.enqueue(func(req *http.Request) *http.Response {
+		if req.Method != http.MethodGet || !strings.Contains(req.URL.Path, "/services/cloudaicompanion.googleapis.com") {
+			t.Fatalf("request = %s %s, want service state", req.Method, req.URL.Path)
+		}
+		assertGeminiUserAgent(t, req)
+		return jsonResponse(http.StatusOK, `{"state":"DISABLED"}`)
+	})
+	transport.enqueue(func(req *http.Request) *http.Response {
+		if req.Method != http.MethodPost || !strings.HasSuffix(req.URL.Path, "/services/cloudaicompanion.googleapis.com:enable") {
+			t.Fatalf("request = %s %s, want service enable", req.Method, req.URL.Path)
+		}
+		assertGeminiUserAgent(t, req)
+		return jsonResponse(http.StatusOK, `{}`)
+	})
+
+	enabled, err := CheckCloudAPIIsEnabled(context.Background(), &http.Client{Transport: transport}, "project-1")
+	if err != nil {
+		t.Fatalf("CheckCloudAPIIsEnabled() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("CheckCloudAPIIsEnabled() = false, want true")
+	}
+	transport.assertDone()
+}
+
+type sequenceTransport struct {
+	t     *testing.T
+	steps []func(*http.Request) *http.Response
+}
+
+func (s *sequenceTransport) enqueue(fn func(*http.Request) *http.Response) {
+	s.steps = append(s.steps, fn)
+}
+
+func (s *sequenceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.t.Helper()
+	if len(s.steps) == 0 {
+		s.t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+	}
+	fn := s.steps[0]
+	s.steps = s.steps[1:]
+	return fn(req), nil
+}
+
+func (s *sequenceTransport) assertDone() {
+	s.t.Helper()
+	if len(s.steps) != 0 {
+		s.t.Fatalf("%d expected requests were not sent", len(s.steps))
+	}
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func assertGeminiHeaders(t *testing.T, req *http.Request) {
+	t.Helper()
+	assertGeminiUserAgent(t, req)
+	if got := req.Header.Get("X-Goog-Api-Client"); got != apiClient {
+		t.Fatalf("X-Goog-Api-Client = %q, want %q", got, apiClient)
+	}
+	if got := req.Header.Get("Client-Metadata"); got != clientMetadata {
+		t.Fatalf("Client-Metadata = %q, want %q", got, clientMetadata)
+	}
+}
+
+func assertGeminiUserAgent(t *testing.T, req *http.Request) {
+	t.Helper()
+	if got := req.Header.Get("User-Agent"); got != userAgent {
+		t.Fatalf("User-Agent = %q, want %q", got, userAgent)
+	}
+}


### PR DESCRIPTION
## Summary
- Move Gemini CLI onboarding, project selection, service enablement, and Cloud Code Assist calls into internal/management/oauth/providers/geminicli.
- Keep the management handler focused on OAuth flow orchestration and token persistence.
- Add provider-package tests for onboarding project mapping and Cloud AI service enablement flow.
- Tighten the backend structure baseline after reducing auth_files.go.

## Validation
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check