### PR TITLE
Refactor Claude OAuth metadata

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1858,
+        "max_lines": 1834,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 606 |
-| 生产 Go 文件 | 416 |
-| 测试 Go 文件 | 190 |
-| `internal/` Go 文件 | 483 |
-| `internal/` 生产 Go 文件 | 345 |
-| `internal/` 测试 Go 文件 | 138 |
+| Go 文件总数 | 608 |
+| 生产 Go 文件 | 417 |
+| 测试 Go 文件 | 191 |
+| `internal/` Go 文件 | 485 |
+| `internal/` 生产 Go 文件 | 346 |
+| `internal/` 测试 Go 文件 | 139 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 252 |
 | `server.go` 内管理路由注册 | 194 |
-| `internal/` 生产目录 | 83 |
-| `internal/` 有同级测试目录 | 38 |
+| `internal/` 生产目录 | 84 |
+| `internal/` 有同级测试目录 | 39 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1858 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1834 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -27,6 +27,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	oauthcallback "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/callback"
+	claudeprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/claude"
 	geminicli "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/geminicli"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
@@ -692,31 +693,6 @@ func (h *Handler) saveTokenRecord(ctx context.Context, record *coreauth.Auth) (s
 	return store.Save(ctx, record)
 }
 
-func claudeOAuthMetadataFromTokenStorage(tokenStorage *claude.ClaudeTokenStorage) map[string]any {
-	metadata := map[string]any{
-		"type": "claude",
-	}
-	if tokenStorage == nil {
-		return metadata
-	}
-	if email := strings.TrimSpace(tokenStorage.Email); email != "" {
-		metadata["email"] = email
-	}
-	if accessToken := strings.TrimSpace(tokenStorage.AccessToken); accessToken != "" {
-		metadata["access_token"] = accessToken
-	}
-	if refreshToken := strings.TrimSpace(tokenStorage.RefreshToken); refreshToken != "" {
-		metadata["refresh_token"] = refreshToken
-	}
-	if expired := strings.TrimSpace(tokenStorage.Expire); expired != "" {
-		metadata["expired"] = expired
-	}
-	if lastRefresh := strings.TrimSpace(tokenStorage.LastRefresh); lastRefresh != "" {
-		metadata["last_refresh"] = lastRefresh
-	}
-	return metadata
-}
-
 func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	ctx := detachedAuthContext(c)
 
@@ -845,7 +821,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 			Provider: "claude",
 			FileName: fmt.Sprintf("claude-%s.json", tokenStorage.Email),
 			Storage:  tokenStorage,
-			Metadata: claudeOAuthMetadataFromTokenStorage(tokenStorage),
+			Metadata: claudeprovider.MetadataFromTokenStorage(tokenStorage),
 		}
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -640,32 +639,6 @@ func TestBuildAuthFileEntryIncludesSubscriptionStartAndPeriod(t *testing.T) {
 	}
 	if _, ok := entry["subscription_remaining_days"].(int64); !ok {
 		t.Fatalf("subscription_remaining_days = %#v, want int64", entry["subscription_remaining_days"])
-	}
-}
-
-func TestClaudeOAuthMetadataFromTokenStorageIncludesRuntimeTokens(t *testing.T) {
-	expired := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
-	lastRefresh := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
-
-	meta := claudeOAuthMetadataFromTokenStorage(&claude.ClaudeTokenStorage{
-		AccessToken:  "access-token",
-		RefreshToken: "refresh-token",
-		Email:        "claude@example.com",
-		Expire:       expired,
-		LastRefresh:  lastRefresh,
-	})
-
-	for key, want := range map[string]string{
-		"type":          "claude",
-		"access_token":  "access-token",
-		"refresh_token": "refresh-token",
-		"email":         "claude@example.com",
-		"expired":       expired,
-		"last_refresh":  lastRefresh,
-	} {
-		if got, _ := meta[key].(string); got != want {
-			t.Fatalf("metadata[%s] = %q, want %q", key, got, want)
-		}
 	}
 }
 

--- a/internal/management/oauth/providers/claude/metadata.go
+++ b/internal/management/oauth/providers/claude/metadata.go
@@ -1,0 +1,32 @@
+package claude
+
+import (
+	"strings"
+
+	internalclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
+)
+
+func MetadataFromTokenStorage(tokenStorage *internalclaude.ClaudeTokenStorage) map[string]any {
+	metadata := map[string]any{
+		"type": "claude",
+	}
+	if tokenStorage == nil {
+		return metadata
+	}
+	if email := strings.TrimSpace(tokenStorage.Email); email != "" {
+		metadata["email"] = email
+	}
+	if accessToken := strings.TrimSpace(tokenStorage.AccessToken); accessToken != "" {
+		metadata["access_token"] = accessToken
+	}
+	if refreshToken := strings.TrimSpace(tokenStorage.RefreshToken); refreshToken != "" {
+		metadata["refresh_token"] = refreshToken
+	}
+	if expired := strings.TrimSpace(tokenStorage.Expire); expired != "" {
+		metadata["expired"] = expired
+	}
+	if lastRefresh := strings.TrimSpace(tokenStorage.LastRefresh); lastRefresh != "" {
+		metadata["last_refresh"] = lastRefresh
+	}
+	return metadata
+}

--- a/internal/management/oauth/providers/claude/metadata_test.go
+++ b/internal/management/oauth/providers/claude/metadata_test.go
@@ -1,0 +1,44 @@
+package claude
+
+import (
+	"testing"
+	"time"
+
+	internalclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
+)
+
+func TestMetadataFromTokenStorageIncludesRuntimeTokens(t *testing.T) {
+	expired := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	lastRefresh := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+
+	meta := MetadataFromTokenStorage(&internalclaude.ClaudeTokenStorage{
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		Email:        "claude@example.com",
+		Expire:       expired,
+		LastRefresh:  lastRefresh,
+	})
+
+	for key, want := range map[string]string{
+		"type":          "claude",
+		"access_token":  "access-token",
+		"refresh_token": "refresh-token",
+		"email":         "claude@example.com",
+		"expired":       expired,
+		"last_refresh":  lastRefresh,
+	} {
+		if got, _ := meta[key].(string); got != want {
+			t.Fatalf("metadata[%s] = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestMetadataFromTokenStorageHandlesNilStorage(t *testing.T) {
+	meta := MetadataFromTokenStorage(nil)
+	if got, _ := meta["type"].(string); got != "claude" {
+		t.Fatalf("metadata[type] = %q, want claude", got)
+	}
+	if len(meta) != 1 {
+		t.Fatalf("metadata = %#v, want only type", meta)
+	}
+}


### PR DESCRIPTION
## Summary
- Move Claude OAuth token metadata construction into the management OAuth provider package.
- Keep the management handler focused on orchestration and cover metadata behavior in provider package tests.
- Tighten the backend structure baseline and allowlist for the reduced auth-files handler.

## Verification
- rtk go test ./internal/management/oauth/providers/claude
- rtk go test ./internal/api/handlers/management -run 'Test(Claude|PatchAuthFileFields|BuildAuthFileEntry)'
- rtk go test ./internal/management/... ./internal/api/handlers/management
- rtk python3 scripts/check-backend-structure.py
- rtk python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- rtk git diff --check
- rtk git diff --cached --check