### PR TITLE
Refactor Codex OAuth record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1834,
+        "max_lines": 1810,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 608 |
-| 生产 Go 文件 | 417 |
-| 测试 Go 文件 | 191 |
-| `internal/` Go 文件 | 485 |
-| `internal/` 生产 Go 文件 | 346 |
-| `internal/` 测试 Go 文件 | 139 |
+| Go 文件总数 | 610 |
+| 生产 Go 文件 | 418 |
+| 测试 Go 文件 | 192 |
+| `internal/` Go 文件 | 487 |
+| `internal/` 生产 Go 文件 | 347 |
+| `internal/` 测试 Go 文件 | 140 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 252 |
 | `server.go` 内管理路由注册 | 194 |
-| `internal/` 生产目录 | 84 |
-| `internal/` 有同级测试目录 | 39 |
+| `internal/` 生产目录 | 85 |
+| `internal/` 有同级测试目录 | 40 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1834 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1810 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2,8 +2,6 @@ package management
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +26,7 @@ import (
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	oauthcallback "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/callback"
 	claudeprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/claude"
+	codexprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/codex"
 	geminicli "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/geminicli"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
@@ -1218,32 +1217,9 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 			return
 		}
 
-		// Extract additional info for filename generation
-		claims, _ := codex.ParseJWTToken(bundle.TokenData.IDToken)
-		planType := ""
-		hashAccountID := ""
-		if claims != nil {
-			planType = strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType)
-			if accountID := claims.GetAccountID(); accountID != "" {
-				digest := sha256.Sum256([]byte(accountID))
-				hashAccountID = hex.EncodeToString(digest[:])[:8]
-			}
-		}
-
 		// Create token storage and persist
 		tokenStorage := openaiAuth.CreateTokenStorage(bundle)
-		fileName := codex.CredentialFileName(tokenStorage.Email, planType, hashAccountID, true)
-		record := &coreauth.Auth{
-			ID:       fileName,
-			Provider: "codex",
-			FileName: fileName,
-			Storage:  tokenStorage,
-			Metadata: map[string]any{
-				"email":      tokenStorage.Email,
-				"account_id": tokenStorage.AccountID,
-				"plan_type":  strings.ToLower(planType),
-			},
-		}
+		record := codexprovider.RecordFromTokenStorage(tokenStorage)
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			SetOAuthSessionError(state, "Failed to save authentication tokens")

--- a/internal/management/oauth/providers/codex/record.go
+++ b/internal/management/oauth/providers/codex/record.go
@@ -1,0 +1,55 @@
+package codex
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	internalcodex "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func RecordFromTokenStorage(tokenStorage *internalcodex.CodexTokenStorage) *coreauth.Auth {
+	if tokenStorage == nil {
+		return nil
+	}
+
+	planType, accountHash := planAndAccountHashFromIDToken(tokenStorage.IDToken)
+	fileName := internalcodex.CredentialFileName(tokenStorage.Email, planType, accountHash, true)
+
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: "codex",
+		FileName: fileName,
+		Storage:  tokenStorage,
+		Metadata: MetadataFromTokenStorage(tokenStorage, planType),
+	}
+}
+
+func MetadataFromTokenStorage(tokenStorage *internalcodex.CodexTokenStorage, planType string) map[string]any {
+	metadata := map[string]any{
+		"plan_type": strings.ToLower(strings.TrimSpace(planType)),
+	}
+	if tokenStorage == nil {
+		return metadata
+	}
+	metadata["email"] = tokenStorage.Email
+	metadata["account_id"] = tokenStorage.AccountID
+	return metadata
+}
+
+func planAndAccountHashFromIDToken(idToken string) (string, string) {
+	claims, _ := internalcodex.ParseJWTToken(idToken)
+	if claims == nil {
+		return "", ""
+	}
+
+	planType := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType)
+	accountID := claims.GetAccountID()
+	if accountID == "" {
+		return planType, ""
+	}
+
+	digest := sha256.Sum256([]byte(accountID))
+	return planType, hex.EncodeToString(digest[:])[:8]
+}

--- a/internal/management/oauth/providers/codex/record_test.go
+++ b/internal/management/oauth/providers/codex/record_test.go
@@ -1,0 +1,96 @@
+package codex
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	internalcodex "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+)
+
+func TestRecordFromTokenStorageUsesPlanAndAccountHashFromIDToken(t *testing.T) {
+	idToken := unsignedJWT(t, map[string]any{
+		"email": "claims@example.com",
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": "acct-team",
+			"chatgpt_plan_type":  " team ",
+		},
+	})
+	storage := &internalcodex.CodexTokenStorage{
+		IDToken:   idToken,
+		Email:     "codex@example.com",
+		AccountID: "acct-storage",
+	}
+
+	record := RecordFromTokenStorage(storage)
+	if record == nil {
+		t.Fatal("RecordFromTokenStorage() = nil")
+	}
+	wantHash := shortHash("acct-team")
+	wantFileName := fmt.Sprintf("codex-%s-codex@example.com-team.json", wantHash)
+	if record.ID != wantFileName || record.FileName != wantFileName {
+		t.Fatalf("ID/FileName = %q/%q, want %q", record.ID, record.FileName, wantFileName)
+	}
+	if record.Provider != "codex" || record.Storage != storage {
+		t.Fatalf("provider/storage = %q/%#v, want codex/original storage", record.Provider, record.Storage)
+	}
+	if got, _ := record.Metadata["email"].(string); got != "codex@example.com" {
+		t.Fatalf("metadata[email] = %q, want codex@example.com", got)
+	}
+	if got, _ := record.Metadata["account_id"].(string); got != "acct-storage" {
+		t.Fatalf("metadata[account_id] = %q, want acct-storage", got)
+	}
+	if got, _ := record.Metadata["plan_type"].(string); got != "team" {
+		t.Fatalf("metadata[plan_type] = %q, want team", got)
+	}
+}
+
+func TestRecordFromTokenStorageFallsBackWhenIDTokenCannotBeParsed(t *testing.T) {
+	storage := &internalcodex.CodexTokenStorage{
+		IDToken:   "not-a-jwt",
+		Email:     "codex@example.com",
+		AccountID: "acct-storage",
+	}
+
+	record := RecordFromTokenStorage(storage)
+	if record == nil {
+		t.Fatal("RecordFromTokenStorage() = nil")
+	}
+	if record.FileName != "codex-codex@example.com.json" {
+		t.Fatalf("FileName = %q, want fallback filename", record.FileName)
+	}
+	if got, _ := record.Metadata["plan_type"].(string); got != "" {
+		t.Fatalf("metadata[plan_type] = %q, want empty", got)
+	}
+}
+
+func TestRecordFromTokenStorageHandlesNilStorage(t *testing.T) {
+	if record := RecordFromTokenStorage(nil); record != nil {
+		t.Fatalf("RecordFromTokenStorage(nil) = %#v, want nil", record)
+	}
+}
+
+func unsignedJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	header := map[string]any{"alg": "none"}
+	return encodeJWTPart(t, header) + "." + encodeJWTPart(t, claims) + "."
+}
+
+func encodeJWTPart(t *testing.T, value any) string {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal jwt part: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func shortHash(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])[:8]
+}


### PR DESCRIPTION
## Summary
- Move Codex OAuth token storage to auth record construction into the management OAuth provider package.
- Keep the management handler focused on OAuth orchestration and token persistence.
- Tighten the backend structure baseline and allowlist for the reduced auth-files handler.

## Verification
- rtk go test ./internal/management/oauth/providers/codex
- rtk go test ./internal/api/handlers/management -run 'TestRequestCodexToken|TestPatchAuthFileFields|TestBuildAuthFileEntry'
- rtk go test ./internal/management/... ./internal/api/handlers/management
- rtk python3 scripts/check-backend-structure.py
- rtk python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- rtk git diff --check
- rtk git diff --cached --check