### PR TITLE
Refactor Antigravity OAuth record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1810,
+        "max_lines": 1783,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 610 |
-| 生产 Go 文件 | 418 |
-| 测试 Go 文件 | 192 |
-| `internal/` Go 文件 | 487 |
-| `internal/` 生产 Go 文件 | 347 |
-| `internal/` 测试 Go 文件 | 140 |
+| Go 文件总数 | 612 |
+| 生产 Go 文件 | 419 |
+| 测试 Go 文件 | 193 |
+| `internal/` Go 文件 | 489 |
+| `internal/` 生产 Go 文件 | 348 |
+| `internal/` 测试 Go 文件 | 141 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 252 |
 | `server.go` 内管理路由注册 | 194 |
-| `internal/` 生产目录 | 85 |
-| `internal/` 有同级测试目录 | 40 |
+| `internal/` 生产目录 | 86 |
+| `internal/` 有同级测试目录 | 41 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1810 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1783 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -25,6 +25,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	oauthcallback "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/callback"
+	antigravityprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/antigravity"
 	claudeprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/claude"
 	codexprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/codex"
 	geminicli "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/geminicli"
@@ -1362,35 +1363,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			}
 		}
 
-		now := time.Now()
-		metadata := map[string]any{
-			"type":          "antigravity",
-			"access_token":  tokenResp.AccessToken,
-			"refresh_token": tokenResp.RefreshToken,
-			"expires_in":    tokenResp.ExpiresIn,
-			"timestamp":     now.UnixMilli(),
-			"expired":       now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339),
-		}
-		if email != "" {
-			metadata["email"] = email
-		}
-		if projectID != "" {
-			metadata["project_id"] = projectID
-		}
-
-		fileName := antigravity.CredentialFileName(email)
-		label := strings.TrimSpace(email)
-		if label == "" {
-			label = "antigravity"
-		}
-
-		record := &coreauth.Auth{
-			ID:       fileName,
-			Provider: "antigravity",
-			FileName: fileName,
-			Label:    label,
-			Metadata: metadata,
-		}
+		record := antigravityprovider.RecordFromTokenResponse(tokenResp, email, projectID, time.Now())
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save token to file: %v", errSave)

--- a/internal/management/oauth/providers/antigravity/record.go
+++ b/internal/management/oauth/providers/antigravity/record.go
@@ -1,0 +1,59 @@
+package antigravity
+
+import (
+	"strings"
+	"time"
+
+	internalantigravity "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/antigravity"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func RecordFromTokenResponse(tokenResp *internalantigravity.TokenResponse, email, projectID string, now time.Time) *coreauth.Auth {
+	if tokenResp == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	email = strings.TrimSpace(email)
+	projectID = strings.TrimSpace(projectID)
+	fileName := internalantigravity.CredentialFileName(email)
+	label := email
+	if label == "" {
+		label = "antigravity"
+	}
+
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: "antigravity",
+		FileName: fileName,
+		Label:    label,
+		Metadata: MetadataFromTokenResponse(tokenResp, email, projectID, now),
+	}
+}
+
+func MetadataFromTokenResponse(tokenResp *internalantigravity.TokenResponse, email, projectID string, now time.Time) map[string]any {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	metadata := map[string]any{
+		"type": "antigravity",
+	}
+	if tokenResp == nil {
+		return metadata
+	}
+
+	metadata["access_token"] = tokenResp.AccessToken
+	metadata["refresh_token"] = tokenResp.RefreshToken
+	metadata["expires_in"] = tokenResp.ExpiresIn
+	metadata["timestamp"] = now.UnixMilli()
+	metadata["expired"] = now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339)
+	if trimmedEmail := strings.TrimSpace(email); trimmedEmail != "" {
+		metadata["email"] = trimmedEmail
+	}
+	if trimmedProjectID := strings.TrimSpace(projectID); trimmedProjectID != "" {
+		metadata["project_id"] = trimmedProjectID
+	}
+	return metadata
+}

--- a/internal/management/oauth/providers/antigravity/record_test.go
+++ b/internal/management/oauth/providers/antigravity/record_test.go
@@ -1,0 +1,71 @@
+package antigravity
+
+import (
+	"testing"
+	"time"
+
+	internalantigravity "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/antigravity"
+)
+
+func TestRecordFromTokenResponseBuildsPersistableRecord(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 30, 0, 0, time.UTC)
+	record := RecordFromTokenResponse(&internalantigravity.TokenResponse{
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		ExpiresIn:    3600,
+	}, " user@example.com ", " project-1 ", now)
+
+	if record == nil {
+		t.Fatal("RecordFromTokenResponse() = nil")
+	}
+	if record.ID != "antigravity-user@example.com.json" || record.FileName != "antigravity-user@example.com.json" {
+		t.Fatalf("ID/FileName = %q/%q, want antigravity-user@example.com.json", record.ID, record.FileName)
+	}
+	if record.Provider != "antigravity" || record.Label != "user@example.com" || record.Storage != nil {
+		t.Fatalf("provider/label/storage = %q/%q/%#v", record.Provider, record.Label, record.Storage)
+	}
+
+	wantExpired := now.Add(time.Hour).Format(time.RFC3339)
+	for key, want := range map[string]string{
+		"type":          "antigravity",
+		"access_token":  "access-token",
+		"refresh_token": "refresh-token",
+		"email":         "user@example.com",
+		"project_id":    "project-1",
+		"expired":       wantExpired,
+	} {
+		if got, _ := record.Metadata[key].(string); got != want {
+			t.Fatalf("metadata[%s] = %q, want %q", key, got, want)
+		}
+	}
+	if got, _ := record.Metadata["expires_in"].(int64); got != 3600 {
+		t.Fatalf("metadata[expires_in] = %#v, want 3600", record.Metadata["expires_in"])
+	}
+	if got, _ := record.Metadata["timestamp"].(int64); got != now.UnixMilli() {
+		t.Fatalf("metadata[timestamp] = %#v, want %d", record.Metadata["timestamp"], now.UnixMilli())
+	}
+}
+
+func TestRecordFromTokenResponseUsesProviderFallbacks(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 30, 0, 0, time.UTC)
+	record := RecordFromTokenResponse(&internalantigravity.TokenResponse{}, "", "", now)
+
+	if record == nil {
+		t.Fatal("RecordFromTokenResponse() = nil")
+	}
+	if record.ID != "antigravity.json" || record.FileName != "antigravity.json" || record.Label != "antigravity" {
+		t.Fatalf("fallback record = %#v", record)
+	}
+	if _, ok := record.Metadata["email"]; ok {
+		t.Fatalf("metadata[email] = %#v, want omitted", record.Metadata["email"])
+	}
+	if _, ok := record.Metadata["project_id"]; ok {
+		t.Fatalf("metadata[project_id] = %#v, want omitted", record.Metadata["project_id"])
+	}
+}
+
+func TestRecordFromTokenResponseHandlesNilResponse(t *testing.T) {
+	if record := RecordFromTokenResponse(nil, "user@example.com", "project-1", time.Time{}); record != nil {
+		t.Fatalf("RecordFromTokenResponse(nil) = %#v, want nil", record)
+	}
+}

--- a/internal/vision/registry.go
+++ b/internal/vision/registry.go
@@ -53,8 +53,10 @@ func (r *GlobalRegistry) GetOrCreateSession(key SessionKey) *SessionStore {
 		r.evictOldestSession()
 	}
 
+	now := time.Now()
 	s := &SessionStore{
-		entries: make(map[ImageHash]*ImageEntry),
+		entries:   make(map[ImageHash]*ImageEntry),
+		updatedAt: now,
 	}
 	r.sessions[key] = s
 	return s


### PR DESCRIPTION
## Summary
- Move Antigravity OAuth token metadata and auth record construction into the management OAuth provider package.
- Preserve the existing metadata-based persistence format while reducing management handler responsibilities.
- Initialize vision session timestamps so LRU session eviction is deterministic under the full test suite.
- Tighten the backend structure baseline and allowlist for the reduced auth-files handler.

## Verification
- rtk go test ./internal/management/oauth/providers/antigravity
- rtk go test ./internal/api/handlers/management -run 'TestRequestAntigravityToken|TestPatchAuthFileFields|TestBuildAuthFileEntry'
- rtk go test ./internal/management/... ./internal/api/handlers/management
- rtk go test ./internal/vision -run TestGlobalEvictOldestSession -count=50
- rtk go test ./internal/vision
- rtk go test ./...
- rtk python3 scripts/check-backend-structure.py
- rtk python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- rtk git diff --check
- rtk git diff --cached --check