### PR TITLE
Refactor Qwen OAuth record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1783,
+        "max_lines": 1777,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 612 |
-| 生产 Go 文件 | 419 |
-| 测试 Go 文件 | 193 |
-| `internal/` Go 文件 | 489 |
-| `internal/` 生产 Go 文件 | 348 |
-| `internal/` 测试 Go 文件 | 141 |
+| Go 文件总数 | 614 |
+| 生产 Go 文件 | 420 |
+| 测试 Go 文件 | 194 |
+| `internal/` Go 文件 | 491 |
+| `internal/` 生产 Go 文件 | 349 |
+| `internal/` 测试 Go 文件 | 142 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 252 |
 | `server.go` 内管理路由注册 | 194 |
-| `internal/` 生产目录 | 86 |
-| `internal/` 有同级测试目录 | 41 |
+| `internal/` 生产目录 | 87 |
+| `internal/` 有同级测试目录 | 42 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1783 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1777 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -29,6 +29,7 @@ import (
 	claudeprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/claude"
 	codexprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/codex"
 	geminicli "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/geminicli"
+	qwenprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -1415,14 +1416,7 @@ func (h *Handler) RequestQwenToken(c *gin.Context) {
 		// Create token storage
 		tokenStorage := qwenAuth.CreateTokenStorage(tokenData)
 
-		tokenStorage.Email = fmt.Sprintf("%d", time.Now().UnixMilli())
-		record := &coreauth.Auth{
-			ID:       fmt.Sprintf("qwen-%s.json", tokenStorage.Email),
-			Provider: "qwen",
-			FileName: fmt.Sprintf("qwen-%s.json", tokenStorage.Email),
-			Storage:  tokenStorage,
-			Metadata: map[string]any{"email": tokenStorage.Email},
-		}
+		record := qwenprovider.RecordFromTokenStorage(tokenStorage, time.Now())
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save authentication tokens: %v", errSave)

--- a/internal/management/oauth/providers/qwen/record.go
+++ b/internal/management/oauth/providers/qwen/record.go
@@ -1,0 +1,42 @@
+package qwen
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	internalqwen "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func RecordFromTokenStorage(tokenStorage *internalqwen.QwenTokenStorage, now time.Time) *coreauth.Auth {
+	if tokenStorage == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	identifier := fmt.Sprintf("%d", now.UnixMilli())
+	tokenStorage.Email = identifier
+	fileName := CredentialFileName(identifier)
+
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: "qwen",
+		FileName: fileName,
+		Storage:  tokenStorage,
+		Metadata: MetadataFromTokenStorage(tokenStorage),
+	}
+}
+
+func MetadataFromTokenStorage(tokenStorage *internalqwen.QwenTokenStorage) map[string]any {
+	if tokenStorage == nil {
+		return map[string]any{}
+	}
+	return map[string]any{"email": tokenStorage.Email}
+}
+
+func CredentialFileName(identifier string) string {
+	return fmt.Sprintf("qwen-%s.json", strings.TrimSpace(identifier))
+}

--- a/internal/management/oauth/providers/qwen/record_test.go
+++ b/internal/management/oauth/providers/qwen/record_test.go
@@ -1,0 +1,47 @@
+package qwen
+
+import (
+	"testing"
+	"time"
+
+	internalqwen "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
+)
+
+func TestRecordFromTokenStorageBuildsTimestampedRecord(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 30, 0, 123000000, time.UTC)
+	storage := &internalqwen.QwenTokenStorage{
+		AccessToken: "access-token",
+		Email:       "existing@example.com",
+	}
+
+	record := RecordFromTokenStorage(storage, now)
+	if record == nil {
+		t.Fatal("RecordFromTokenStorage() = nil")
+	}
+
+	identifier := "1780749000123"
+	if storage.Email != identifier {
+		t.Fatalf("storage.Email = %q, want %q", storage.Email, identifier)
+	}
+	if record.ID != "qwen-"+identifier+".json" || record.FileName != "qwen-"+identifier+".json" {
+		t.Fatalf("ID/FileName = %q/%q, want timestamped qwen filename", record.ID, record.FileName)
+	}
+	if record.Provider != "qwen" || record.Storage != storage {
+		t.Fatalf("provider/storage = %q/%#v, want qwen/original storage", record.Provider, record.Storage)
+	}
+	if got, _ := record.Metadata["email"].(string); got != identifier {
+		t.Fatalf("metadata[email] = %q, want %q", got, identifier)
+	}
+}
+
+func TestRecordFromTokenStorageHandlesNilStorage(t *testing.T) {
+	if record := RecordFromTokenStorage(nil, time.Time{}); record != nil {
+		t.Fatalf("RecordFromTokenStorage(nil) = %#v, want nil", record)
+	}
+}
+
+func TestCredentialFileNameTrimsIdentifier(t *testing.T) {
+	if got := CredentialFileName(" 123 "); got != "qwen-123.json" {
+		t.Fatalf("CredentialFileName() = %q, want qwen-123.json", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Move Qwen OAuth token storage to auth record construction into the management OAuth provider package.
- Preserve the existing timestamp-based Qwen credential identifier behavior while reducing management handler responsibilities.
- Tighten the backend structure baseline and allowlist for the reduced auth-files handler.

## Verification
- rtk go test ./internal/management/oauth/providers/qwen
- rtk go test ./internal/api/handlers/management -run 'TestRequestQwenToken|TestPatchAuthFileFields|TestBuildAuthFileEntry'
- rtk go test ./internal/management/... ./internal/api/handlers/management
- rtk python3 scripts/check-backend-structure.py
- rtk python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- rtk git diff --check
- rtk git diff --cached --check