### PR TITLE
Refactor Kimi OAuth record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1777,
+        "max_lines": 1754,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 614 |
-| 生产 Go 文件 | 420 |
-| 测试 Go 文件 | 194 |
-| `internal/` Go 文件 | 491 |
-| `internal/` 生产 Go 文件 | 349 |
-| `internal/` 测试 Go 文件 | 142 |
+| Go 文件总数 | 616 |
+| 生产 Go 文件 | 421 |
+| 测试 Go 文件 | 195 |
+| `internal/` Go 文件 | 493 |
+| `internal/` 生产 Go 文件 | 350 |
+| `internal/` 测试 Go 文件 | 143 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 252 |
 | `server.go` 内管理路由注册 | 194 |
-| `internal/` 生产目录 | 87 |
-| `internal/` 有同级测试目录 | 42 |
+| `internal/` 生产目录 | 88 |
+| `internal/` 有同级测试目录 | 43 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1777 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1754 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -29,6 +29,7 @@ import (
 	claudeprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/claude"
 	codexprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/codex"
 	geminicli "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/geminicli"
+	kimiprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/kimi"
 	qwenprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
@@ -1467,31 +1468,7 @@ func (h *Handler) RequestKimiToken(c *gin.Context) {
 		// Create token storage
 		tokenStorage := kimiAuth.CreateTokenStorage(authBundle)
 
-		metadata := map[string]any{
-			"type":          "kimi",
-			"access_token":  authBundle.TokenData.AccessToken,
-			"refresh_token": authBundle.TokenData.RefreshToken,
-			"token_type":    authBundle.TokenData.TokenType,
-			"scope":         authBundle.TokenData.Scope,
-			"timestamp":     time.Now().UnixMilli(),
-		}
-		if authBundle.TokenData.ExpiresAt > 0 {
-			expired := time.Unix(authBundle.TokenData.ExpiresAt, 0).UTC().Format(time.RFC3339)
-			metadata["expired"] = expired
-		}
-		if strings.TrimSpace(authBundle.DeviceID) != "" {
-			metadata["device_id"] = strings.TrimSpace(authBundle.DeviceID)
-		}
-
-		fileName := fmt.Sprintf("kimi-%d.json", time.Now().UnixMilli())
-		record := &coreauth.Auth{
-			ID:       fileName,
-			Provider: "kimi",
-			FileName: fileName,
-			Label:    "Kimi User",
-			Storage:  tokenStorage,
-			Metadata: metadata,
-		}
+		record := kimiprovider.RecordFromAuthBundle(tokenStorage, authBundle, time.Now())
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save authentication tokens: %v", errSave)

--- a/internal/management/oauth/providers/kimi/record.go
+++ b/internal/management/oauth/providers/kimi/record.go
@@ -1,0 +1,61 @@
+package kimi
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	internalkimi "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func RecordFromAuthBundle(tokenStorage *internalkimi.KimiTokenStorage, authBundle *internalkimi.KimiAuthBundle, now time.Time) *coreauth.Auth {
+	if tokenStorage == nil || authBundle == nil || authBundle.TokenData == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	fileName := CredentialFileName(now)
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: "kimi",
+		FileName: fileName,
+		Label:    "Kimi User",
+		Storage:  tokenStorage,
+		Metadata: MetadataFromAuthBundle(authBundle, now),
+	}
+}
+
+func MetadataFromAuthBundle(authBundle *internalkimi.KimiAuthBundle, now time.Time) map[string]any {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	metadata := map[string]any{
+		"type":      "kimi",
+		"timestamp": now.UnixMilli(),
+	}
+	if authBundle == nil || authBundle.TokenData == nil {
+		return metadata
+	}
+
+	metadata["access_token"] = authBundle.TokenData.AccessToken
+	metadata["refresh_token"] = authBundle.TokenData.RefreshToken
+	metadata["token_type"] = authBundle.TokenData.TokenType
+	metadata["scope"] = authBundle.TokenData.Scope
+	if authBundle.TokenData.ExpiresAt > 0 {
+		metadata["expired"] = time.Unix(authBundle.TokenData.ExpiresAt, 0).UTC().Format(time.RFC3339)
+	}
+	if deviceID := strings.TrimSpace(authBundle.DeviceID); deviceID != "" {
+		metadata["device_id"] = deviceID
+	}
+	return metadata
+}
+
+func CredentialFileName(now time.Time) string {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return fmt.Sprintf("kimi-%d.json", now.UnixMilli())
+}

--- a/internal/management/oauth/providers/kimi/record_test.go
+++ b/internal/management/oauth/providers/kimi/record_test.go
@@ -1,0 +1,79 @@
+package kimi
+
+import (
+	"testing"
+	"time"
+
+	internalkimi "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+)
+
+func TestRecordFromAuthBundleBuildsPersistableRecord(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 30, 0, 123000000, time.UTC)
+	expiresAt := now.Add(time.Hour).Unix()
+	storage := &internalkimi.KimiTokenStorage{AccessToken: "storage-access"}
+	bundle := &internalkimi.KimiAuthBundle{
+		TokenData: &internalkimi.KimiTokenData{
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+			TokenType:    "Bearer",
+			Scope:        "openid profile",
+			ExpiresAt:    expiresAt,
+		},
+		DeviceID: " device-1 ",
+	}
+
+	record := RecordFromAuthBundle(storage, bundle, now)
+	if record == nil {
+		t.Fatal("RecordFromAuthBundle() = nil")
+	}
+	if record.ID != "kimi-1780749000123.json" || record.FileName != "kimi-1780749000123.json" {
+		t.Fatalf("ID/FileName = %q/%q, want timestamped kimi filename", record.ID, record.FileName)
+	}
+	if record.Provider != "kimi" || record.Label != "Kimi User" || record.Storage != storage {
+		t.Fatalf("provider/label/storage = %q/%q/%#v", record.Provider, record.Label, record.Storage)
+	}
+
+	for key, want := range map[string]string{
+		"type":          "kimi",
+		"access_token":  "access-token",
+		"refresh_token": "refresh-token",
+		"token_type":    "Bearer",
+		"scope":         "openid profile",
+		"expired":       time.Unix(expiresAt, 0).UTC().Format(time.RFC3339),
+		"device_id":     "device-1",
+	} {
+		if got, _ := record.Metadata[key].(string); got != want {
+			t.Fatalf("metadata[%s] = %q, want %q", key, got, want)
+		}
+	}
+	if got, _ := record.Metadata["timestamp"].(int64); got != now.UnixMilli() {
+		t.Fatalf("metadata[timestamp] = %#v, want %d", record.Metadata["timestamp"], now.UnixMilli())
+	}
+}
+
+func TestMetadataFromAuthBundleOmitsOptionalFields(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 30, 0, 0, time.UTC)
+	metadata := MetadataFromAuthBundle(&internalkimi.KimiAuthBundle{
+		TokenData: &internalkimi.KimiTokenData{},
+		DeviceID:  " ",
+	}, now)
+
+	if _, ok := metadata["expired"]; ok {
+		t.Fatalf("metadata[expired] = %#v, want omitted", metadata["expired"])
+	}
+	if _, ok := metadata["device_id"]; ok {
+		t.Fatalf("metadata[device_id] = %#v, want omitted", metadata["device_id"])
+	}
+}
+
+func TestRecordFromAuthBundleHandlesNilInputs(t *testing.T) {
+	if record := RecordFromAuthBundle(nil, &internalkimi.KimiAuthBundle{}, time.Time{}); record != nil {
+		t.Fatalf("RecordFromAuthBundle(nil storage) = %#v, want nil", record)
+	}
+	if record := RecordFromAuthBundle(&internalkimi.KimiTokenStorage{}, nil, time.Time{}); record != nil {
+		t.Fatalf("RecordFromAuthBundle(nil bundle) = %#v, want nil", record)
+	}
+	if record := RecordFromAuthBundle(&internalkimi.KimiTokenStorage{}, &internalkimi.KimiAuthBundle{}, time.Time{}); record != nil {
+		t.Fatalf("RecordFromAuthBundle(nil token data) = %#v, want nil", record)
+	}
+}


### PR DESCRIPTION
## Summary
- Move Kimi OAuth device-flow metadata and auth record construction into the management OAuth provider package.
- Preserve the existing timestamp-based Kimi credential filename and metadata fields while reducing management handler responsibilities.
- Tighten the backend structure baseline and allowlist for the reduced auth-files handler.

## Verification
- rtk go test ./internal/management/oauth/providers/kimi
- rtk go test ./internal/api/handlers/management -run 'TestRequestKimiToken|TestPatchAuthFileFields|TestBuildAuthFileEntry'
- rtk go test ./internal/management/... ./internal/api/handlers/management
- rtk python3 scripts/check-backend-structure.py
- rtk python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- rtk git diff --check
- rtk git diff --cached --check