### PR TITLE
Refactor iFlow OAuth record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1754,
+        "max_lines": 1743,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -22,12 +22,12 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 616 |
-| 生产 Go 文件 | 421 |
-| 测试 Go 文件 | 195 |
-| `internal/` Go 文件 | 493 |
-| `internal/` 生产 Go 文件 | 350 |
-| `internal/` 测试 Go 文件 | 143 |
+| Go 文件总数 | 618 |
+| 生产 Go 文件 | 422 |
+| 测试 Go 文件 | 196 |
+| `internal/` Go 文件 | 495 |
+| `internal/` 生产 Go 文件 | 351 |
+| `internal/` 测试 Go 文件 | 144 |
 | 生产 Go 文件中 `>800` 行 | 26 |
 | 生产 Go 文件中 `>1200` 行 | 14 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 23 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 252 |
 | `server.go` 内管理路由注册 | 194 |
-| `internal/` 生产目录 | 88 |
-| `internal/` 有同级测试目录 | 43 |
+| `internal/` 生产目录 | 89 |
+| `internal/` 有同级测试目录 | 44 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1754 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1743 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -29,6 +29,7 @@ import (
 	claudeprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/claude"
 	codexprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/codex"
 	geminicli "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/geminicli"
+	iflowprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/iflow"
 	kimiprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/kimi"
 	qwenprovider "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/providers/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
@@ -1565,19 +1566,7 @@ func (h *Handler) RequestIFlowToken(c *gin.Context) {
 		}
 
 		tokenStorage := authSvc.CreateTokenStorage(tokenData)
-		identifier := strings.TrimSpace(tokenStorage.Email)
-		if identifier == "" {
-			identifier = fmt.Sprintf("%d", time.Now().UnixMilli())
-			tokenStorage.Email = identifier
-		}
-		record := &coreauth.Auth{
-			ID:         fmt.Sprintf("iflow-%s.json", identifier),
-			Provider:   "iflow",
-			FileName:   fmt.Sprintf("iflow-%s.json", identifier),
-			Storage:    tokenStorage,
-			Metadata:   map[string]any{"email": identifier, "api_key": tokenStorage.APIKey},
-			Attributes: map[string]string{"api_key": tokenStorage.APIKey},
-		}
+		record := iflowprovider.RecordFromTokenStorage(tokenStorage, time.Now())
 
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {

--- a/internal/management/oauth/providers/iflow/record.go
+++ b/internal/management/oauth/providers/iflow/record.go
@@ -1,0 +1,57 @@
+package iflow
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	internaliflow "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/iflow"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func RecordFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage, now time.Time) *coreauth.Auth {
+	if tokenStorage == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	identifier := strings.TrimSpace(tokenStorage.Email)
+	if identifier == "" {
+		identifier = fmt.Sprintf("%d", now.UnixMilli())
+		tokenStorage.Email = identifier
+	}
+	fileName := CredentialFileName(identifier)
+
+	return &coreauth.Auth{
+		ID:         fileName,
+		Provider:   "iflow",
+		FileName:   fileName,
+		Storage:    tokenStorage,
+		Metadata:   MetadataFromTokenStorage(tokenStorage, identifier),
+		Attributes: AttributesFromTokenStorage(tokenStorage),
+	}
+}
+
+func MetadataFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage, identifier string) map[string]any {
+	metadata := map[string]any{
+		"email": strings.TrimSpace(identifier),
+	}
+	if tokenStorage == nil {
+		return metadata
+	}
+	metadata["api_key"] = tokenStorage.APIKey
+	return metadata
+}
+
+func AttributesFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage) map[string]string {
+	if tokenStorage == nil {
+		return map[string]string{}
+	}
+	return map[string]string{"api_key": tokenStorage.APIKey}
+}
+
+func CredentialFileName(identifier string) string {
+	return fmt.Sprintf("iflow-%s.json", strings.TrimSpace(identifier))
+}

--- a/internal/management/oauth/providers/iflow/record_test.go
+++ b/internal/management/oauth/providers/iflow/record_test.go
@@ -1,0 +1,60 @@
+package iflow
+
+import (
+	"testing"
+	"time"
+
+	internaliflow "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/iflow"
+)
+
+func TestRecordFromTokenStorageBuildsEmailRecord(t *testing.T) {
+	storage := &internaliflow.IFlowTokenStorage{
+		Email:  " user@example.com ",
+		APIKey: "api-key",
+	}
+
+	record := RecordFromTokenStorage(storage, time.Date(2026, 6, 6, 12, 30, 0, 0, time.UTC))
+	if record == nil {
+		t.Fatal("RecordFromTokenStorage() = nil")
+	}
+	if record.ID != "iflow-user@example.com.json" || record.FileName != "iflow-user@example.com.json" {
+		t.Fatalf("ID/FileName = %q/%q, want iflow-user@example.com.json", record.ID, record.FileName)
+	}
+	if record.Provider != "iflow" || record.Storage != storage {
+		t.Fatalf("provider/storage = %q/%#v, want iflow/original storage", record.Provider, record.Storage)
+	}
+	if got, _ := record.Metadata["email"].(string); got != "user@example.com" {
+		t.Fatalf("metadata[email] = %q, want user@example.com", got)
+	}
+	if got, _ := record.Metadata["api_key"].(string); got != "api-key" {
+		t.Fatalf("metadata[api_key] = %q, want api-key", got)
+	}
+	if got := record.Attributes["api_key"]; got != "api-key" {
+		t.Fatalf("attributes[api_key] = %q, want api-key", got)
+	}
+}
+
+func TestRecordFromTokenStorageUsesTimestampFallback(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 30, 0, 123000000, time.UTC)
+	storage := &internaliflow.IFlowTokenStorage{APIKey: "api-key"}
+
+	record := RecordFromTokenStorage(storage, now)
+	if record == nil {
+		t.Fatal("RecordFromTokenStorage() = nil")
+	}
+	if storage.Email != "1780749000123" {
+		t.Fatalf("storage.Email = %q, want timestamp identifier", storage.Email)
+	}
+	if record.ID != "iflow-1780749000123.json" || record.FileName != "iflow-1780749000123.json" {
+		t.Fatalf("ID/FileName = %q/%q, want timestamped iflow filename", record.ID, record.FileName)
+	}
+	if got, _ := record.Metadata["email"].(string); got != "1780749000123" {
+		t.Fatalf("metadata[email] = %q, want timestamp identifier", got)
+	}
+}
+
+func TestRecordFromTokenStorageHandlesNilStorage(t *testing.T) {
+	if record := RecordFromTokenStorage(nil, time.Time{}); record != nil {
+		t.Fatalf("RecordFromTokenStorage(nil) = %#v, want nil", record)
+	}
+}


### PR DESCRIPTION
## Summary
- Move iFlow OAuth token storage to auth record construction into the management OAuth provider package.
- Preserve the existing iFlow metadata and api-key attribute fields while reducing management handler responsibilities.
- Tighten the backend structure baseline and allowlist for the reduced auth-files handler.

## Verification
- rtk go test ./internal/management/oauth/providers/iflow
- rtk go test ./internal/api/handlers/management -run 'TestRequestIFlowToken|TestPatchAuthFileFields|TestBuildAuthFileEntry'
- rtk go test ./internal/management/... ./internal/api/handlers/management
- rtk python3 scripts/check-backend-structure.py
- rtk python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- rtk git diff --check
- rtk git diff --cached --check