### PR TITLE
Refactor iFlow cookie record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1743,
+        "max_lines": 1717,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1743 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1717 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1638,33 +1638,7 @@ func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 		return
 	}
 
-	fileName := iflowauth.SanitizeIFlowFileName(email)
-	if fileName == "" {
-		fileName = fmt.Sprintf("iflow-%d", time.Now().UnixMilli())
-	} else {
-		fileName = fmt.Sprintf("iflow-%s", fileName)
-	}
-
-	tokenStorage.Email = email
-	timestamp := time.Now().Unix()
-
-	record := &coreauth.Auth{
-		ID:       fmt.Sprintf("%s-%d.json", fileName, timestamp),
-		Provider: "iflow",
-		FileName: fmt.Sprintf("%s-%d.json", fileName, timestamp),
-		Storage:  tokenStorage,
-		Metadata: map[string]any{
-			"email":        email,
-			"api_key":      tokenStorage.APIKey,
-			"expired":      tokenStorage.Expire,
-			"cookie":       tokenStorage.Cookie,
-			"type":         tokenStorage.Type,
-			"last_refresh": tokenStorage.LastRefresh,
-		},
-		Attributes: map[string]string{
-			"api_key": tokenStorage.APIKey,
-		},
-	}
+	record := iflowprovider.CookieRecordFromTokenStorage(tokenStorage, time.Now())
 
 	savedPath, errSave := h.saveTokenRecord(ctx, record)
 	if errSave != nil {

--- a/internal/management/oauth/providers/iflow/record.go
+++ b/internal/management/oauth/providers/iflow/record.go
@@ -34,6 +34,38 @@ func RecordFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage, now t
 	}
 }
 
+func CookieRecordFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage, now time.Time) *coreauth.Auth {
+	if tokenStorage == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	email := strings.TrimSpace(tokenStorage.Email)
+	if email == "" {
+		return nil
+	}
+
+	fileStem := internaliflow.SanitizeIFlowFileName(email)
+	if fileStem == "" {
+		fileStem = fmt.Sprintf("iflow-%d", now.UnixMilli())
+	} else {
+		fileStem = fmt.Sprintf("iflow-%s", fileStem)
+	}
+	fileName := fmt.Sprintf("%s-%d.json", fileStem, now.Unix())
+	tokenStorage.Email = email
+
+	return &coreauth.Auth{
+		ID:         fileName,
+		Provider:   "iflow",
+		FileName:   fileName,
+		Storage:    tokenStorage,
+		Metadata:   CookieMetadataFromTokenStorage(tokenStorage),
+		Attributes: AttributesFromTokenStorage(tokenStorage),
+	}
+}
+
 func MetadataFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage, identifier string) map[string]any {
 	metadata := map[string]any{
 		"email": strings.TrimSpace(identifier),
@@ -43,6 +75,20 @@ func MetadataFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage, ide
 	}
 	metadata["api_key"] = tokenStorage.APIKey
 	return metadata
+}
+
+func CookieMetadataFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage) map[string]any {
+	if tokenStorage == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"email":        strings.TrimSpace(tokenStorage.Email),
+		"api_key":      tokenStorage.APIKey,
+		"expired":      tokenStorage.Expire,
+		"cookie":       tokenStorage.Cookie,
+		"type":         tokenStorage.Type,
+		"last_refresh": tokenStorage.LastRefresh,
+	}
 }
 
 func AttributesFromTokenStorage(tokenStorage *internaliflow.IFlowTokenStorage) map[string]string {

--- a/internal/management/oauth/providers/iflow/record_test.go
+++ b/internal/management/oauth/providers/iflow/record_test.go
@@ -58,3 +58,64 @@ func TestRecordFromTokenStorageHandlesNilStorage(t *testing.T) {
 		t.Fatalf("RecordFromTokenStorage(nil) = %#v, want nil", record)
 	}
 }
+
+func TestCookieRecordFromTokenStorageBuildsCookieRecord(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 30, 45, 123000000, time.UTC)
+	storage := &internaliflow.IFlowTokenStorage{
+		Email:       " user*name@example.com ",
+		APIKey:      "api-key",
+		Expire:      "2026-06-07T00:00:00Z",
+		Cookie:      "BXAuth=cookie;",
+		Type:        "iflow",
+		LastRefresh: "2026-06-06T12:00:00Z",
+	}
+
+	record := CookieRecordFromTokenStorage(storage, now)
+	if record == nil {
+		t.Fatal("CookieRecordFromTokenStorage() = nil")
+	}
+	if record.ID != "iflow-userxname@example.com-1780749045.json" || record.FileName != "iflow-userxname@example.com-1780749045.json" {
+		t.Fatalf("ID/FileName = %q/%q, want sanitized timestamped cookie filename", record.ID, record.FileName)
+	}
+	if storage.Email != "user*name@example.com" {
+		t.Fatalf("storage.Email = %q, want trimmed original email", storage.Email)
+	}
+	if record.Provider != "iflow" || record.Storage != storage {
+		t.Fatalf("provider/storage = %q/%#v, want iflow/original storage", record.Provider, record.Storage)
+	}
+	for key, want := range map[string]string{
+		"email":        "user*name@example.com",
+		"api_key":      "api-key",
+		"expired":      "2026-06-07T00:00:00Z",
+		"cookie":       "BXAuth=cookie;",
+		"type":         "iflow",
+		"last_refresh": "2026-06-06T12:00:00Z",
+	} {
+		if got, _ := record.Metadata[key].(string); got != want {
+			t.Fatalf("metadata[%s] = %q, want %q", key, got, want)
+		}
+	}
+	if got := record.Attributes["api_key"]; got != "api-key" {
+		t.Fatalf("attributes[api_key] = %q, want api-key", got)
+	}
+}
+
+func TestCookieRecordFromTokenStorageUsesTimestampFallbackForUnsanitizableEmail(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 30, 45, 123000000, time.UTC)
+	record := CookieRecordFromTokenStorage(&internaliflow.IFlowTokenStorage{Email: " 用户 "}, now)
+	if record == nil {
+		t.Fatal("CookieRecordFromTokenStorage() = nil")
+	}
+	if record.ID != "iflow-1780749045123-1780749045.json" {
+		t.Fatalf("ID = %q, want timestamp fallback filename", record.ID)
+	}
+}
+
+func TestCookieRecordFromTokenStorageRequiresEmail(t *testing.T) {
+	if record := CookieRecordFromTokenStorage(&internaliflow.IFlowTokenStorage{}, time.Time{}); record != nil {
+		t.Fatalf("CookieRecordFromTokenStorage(empty email) = %#v, want nil", record)
+	}
+	if record := CookieRecordFromTokenStorage(nil, time.Time{}); record != nil {
+		t.Fatalf("CookieRecordFromTokenStorage(nil) = %#v, want nil", record)
+	}
+}


### PR DESCRIPTION
## Summary
- Move iFlow cookie authentication metadata and auth record construction into the management OAuth provider package.
- Preserve existing iFlow cookie credential filename, metadata, and api-key attribute fields while reducing management handler responsibilities.
- Tighten the backend structure baseline and allowlist for the reduced auth-files handler.

## Verification
- rtk go test ./internal/management/oauth/providers/iflow
- rtk go test ./internal/api/handlers/management -run 'TestRequestIFlowCookieToken|TestRequestIFlowToken|TestPatchAuthFileFields|TestBuildAuthFileEntry'
- rtk go test ./internal/management/... ./internal/api/handlers/management
- rtk python3 scripts/check-backend-structure.py
- rtk python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- rtk git diff --check
- rtk git diff --cached --check