### PR TITLE
refactor: move claude oauth record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1717,
+        "max_lines": 1711,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1717 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1711 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -819,13 +819,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 
 		// Create token storage
 		tokenStorage := anthropicAuth.CreateTokenStorage(bundle)
-		record := &coreauth.Auth{
-			ID:       fmt.Sprintf("claude-%s.json", tokenStorage.Email),
-			Provider: "claude",
-			FileName: fmt.Sprintf("claude-%s.json", tokenStorage.Email),
-			Storage:  tokenStorage,
-			Metadata: claudeprovider.MetadataFromTokenStorage(tokenStorage),
-		}
+		record := claudeprovider.RecordFromTokenStorage(tokenStorage)
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save authentication tokens: %v", errSave)

--- a/internal/management/oauth/providers/claude/metadata.go
+++ b/internal/management/oauth/providers/claude/metadata.go
@@ -1,10 +1,26 @@
 package claude
 
 import (
+	"fmt"
 	"strings"
 
 	internalclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
+
+func RecordFromTokenStorage(tokenStorage *internalclaude.ClaudeTokenStorage) *coreauth.Auth {
+	if tokenStorage == nil {
+		return nil
+	}
+	fileName := CredentialFileName(tokenStorage.Email)
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: "claude",
+		FileName: fileName,
+		Storage:  tokenStorage,
+		Metadata: MetadataFromTokenStorage(tokenStorage),
+	}
+}
 
 func MetadataFromTokenStorage(tokenStorage *internalclaude.ClaudeTokenStorage) map[string]any {
 	metadata := map[string]any{
@@ -29,4 +45,8 @@ func MetadataFromTokenStorage(tokenStorage *internalclaude.ClaudeTokenStorage) m
 		metadata["last_refresh"] = lastRefresh
 	}
 	return metadata
+}
+
+func CredentialFileName(email string) string {
+	return fmt.Sprintf("claude-%s.json", email)
 }

--- a/internal/management/oauth/providers/claude/metadata_test.go
+++ b/internal/management/oauth/providers/claude/metadata_test.go
@@ -7,6 +7,27 @@ import (
 	internalclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
 )
 
+func TestRecordFromTokenStorageBuildsPersistableRecord(t *testing.T) {
+	storage := &internalclaude.ClaudeTokenStorage{
+		AccessToken: "access-token",
+		Email:       "claude@example.com",
+	}
+
+	record := RecordFromTokenStorage(storage)
+	if record == nil {
+		t.Fatal("RecordFromTokenStorage() = nil")
+	}
+	if record.ID != "claude-claude@example.com.json" || record.FileName != "claude-claude@example.com.json" {
+		t.Fatalf("ID/FileName = %q/%q, want claude-claude@example.com.json", record.ID, record.FileName)
+	}
+	if record.Provider != "claude" || record.Storage != storage {
+		t.Fatalf("provider/storage = %q/%#v, want claude/original storage", record.Provider, record.Storage)
+	}
+	if got, _ := record.Metadata["email"].(string); got != "claude@example.com" {
+		t.Fatalf("metadata[email] = %q, want claude@example.com", got)
+	}
+}
+
 func TestMetadataFromTokenStorageIncludesRuntimeTokens(t *testing.T) {
 	expired := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
 	lastRefresh := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
@@ -40,5 +61,11 @@ func TestMetadataFromTokenStorageHandlesNilStorage(t *testing.T) {
 	}
 	if len(meta) != 1 {
 		t.Fatalf("metadata = %#v, want only type", meta)
+	}
+}
+
+func TestRecordFromTokenStorageHandlesNilStorage(t *testing.T) {
+	if record := RecordFromTokenStorage(nil); record != nil {
+		t.Fatalf("RecordFromTokenStorage(nil) = %#v, want nil", record)
 	}
 }


### PR DESCRIPTION
## Summary
- move Claude OAuth auth record construction into the Claude provider package
- keep the management handler as a thin caller for the persisted auth record
- tighten the backend structure baseline for auth_files.go after the extraction

## Verification
- go test ./internal/management/oauth/providers/claude
- go test ./internal/api/handlers/management -run 'TestRequestAnthropicToken|TestRequestClaude|TestPatchAuthFileFields|TestBuildAuthFileEntry'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json\n- git diff --check