### PR TITLE
refactor: move gemini oauth record builder

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1711,
+        "max_lines": 1697,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1711 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1697 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1086,21 +1086,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			}
 		}
 
-		recordMetadata := map[string]any{
-			"email":      ts.Email,
-			"project_id": ts.ProjectID,
-			"auto":       ts.Auto,
-			"checked":    ts.Checked,
-		}
-
-		fileName := geminiAuth.CredentialFileName(ts.Email, ts.ProjectID, true)
-		record := &coreauth.Auth{
-			ID:       fileName,
-			Provider: "gemini",
-			FileName: fileName,
-			Storage:  &ts,
-			Metadata: recordMetadata,
-		}
+		record := geminicli.RecordFromTokenStorage(&ts)
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save token to file: %v", errSave)

--- a/internal/management/oauth/providers/geminicli/record.go
+++ b/internal/management/oauth/providers/geminicli/record.go
@@ -1,0 +1,32 @@
+package geminicli
+
+import (
+	geminiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func RecordFromTokenStorage(tokenStorage *geminiauth.GeminiTokenStorage) *coreauth.Auth {
+	if tokenStorage == nil {
+		return nil
+	}
+	fileName := geminiauth.CredentialFileName(tokenStorage.Email, tokenStorage.ProjectID, true)
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: "gemini",
+		FileName: fileName,
+		Storage:  tokenStorage,
+		Metadata: MetadataFromTokenStorage(tokenStorage),
+	}
+}
+
+func MetadataFromTokenStorage(tokenStorage *geminiauth.GeminiTokenStorage) map[string]any {
+	if tokenStorage == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"email":      tokenStorage.Email,
+		"project_id": tokenStorage.ProjectID,
+		"auto":       tokenStorage.Auto,
+		"checked":    tokenStorage.Checked,
+	}
+}

--- a/internal/management/oauth/providers/geminicli/record_test.go
+++ b/internal/management/oauth/providers/geminicli/record_test.go
@@ -1,0 +1,61 @@
+package geminicli
+
+import (
+	"testing"
+
+	geminiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
+)
+
+func TestRecordFromTokenStorageBuildsPersistableRecord(t *testing.T) {
+	storage := &geminiauth.GeminiTokenStorage{
+		Email:     "gemini@example.com",
+		ProjectID: "project-1",
+		Auto:      true,
+		Checked:   true,
+	}
+
+	record := RecordFromTokenStorage(storage)
+	if record == nil {
+		t.Fatal("RecordFromTokenStorage() = nil")
+	}
+	if record.ID != "gemini-gemini@example.com-project-1.json" || record.FileName != "gemini-gemini@example.com-project-1.json" {
+		t.Fatalf("ID/FileName = %q/%q, want gemini-gemini@example.com-project-1.json", record.ID, record.FileName)
+	}
+	if record.Provider != "gemini" || record.Storage != storage {
+		t.Fatalf("provider/storage = %q/%#v, want gemini/original storage", record.Provider, record.Storage)
+	}
+	if got, _ := record.Metadata["project_id"].(string); got != "project-1" {
+		t.Fatalf("metadata[project_id] = %q, want project-1", got)
+	}
+	if got, _ := record.Metadata["checked"].(bool); !got {
+		t.Fatalf("metadata[checked] = %v, want true", got)
+	}
+}
+
+func TestRecordFromTokenStorageBuildsAllProjectsFileName(t *testing.T) {
+	storage := &geminiauth.GeminiTokenStorage{
+		Email:     "gemini@example.com",
+		ProjectID: "project-1,project-2",
+	}
+
+	record := RecordFromTokenStorage(storage)
+	if record == nil {
+		t.Fatal("RecordFromTokenStorage() = nil")
+	}
+	if record.FileName != "gemini-gemini@example.com-all.json" {
+		t.Fatalf("FileName = %q, want gemini-gemini@example.com-all.json", record.FileName)
+	}
+}
+
+func TestRecordFromTokenStorageHandlesNilStorage(t *testing.T) {
+	if record := RecordFromTokenStorage(nil); record != nil {
+		t.Fatalf("RecordFromTokenStorage(nil) = %#v, want nil", record)
+	}
+}
+
+func TestMetadataFromTokenStorageHandlesNilStorage(t *testing.T) {
+	metadata := MetadataFromTokenStorage(nil)
+	if len(metadata) != 0 {
+		t.Fatalf("MetadataFromTokenStorage(nil) = %#v, want empty map", metadata)
+	}
+}


### PR DESCRIPTION
## Summary
- move Gemini CLI OAuth auth record construction into the Gemini CLI provider package
- keep the management handler focused on flow orchestration and persistence call-out
- tighten the backend structure baseline for auth_files.go after the extraction

## Verification
- go test ./internal/management/oauth/providers/geminicli
- go test ./internal/api/handlers/management -run 'TestRequestGemini|TestRequestClaude|TestPatchAuthFileFields|TestBuildAuthFileEntry'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json\n- git diff --check