### PR TITLE
refactor: move oauth session store

### DIFF
--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -1,182 +1,28 @@
 package management
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
 	"time"
+
+	oauthsession "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/session"
 )
 
 const (
-	oauthSessionTTL             = 10 * time.Minute
-	maxOAuthStateLength         = 128
-	oauthSessionStatusCompleted = "__completed__"
+	oauthSessionTTL             = oauthsession.DefaultTTL
+	maxOAuthStateLength         = oauthsession.MaxStateLength
+	oauthSessionStatusCompleted = oauthsession.StatusCompleted
 )
 
 var (
-	errInvalidOAuthState      = errors.New("invalid oauth state")
-	errUnsupportedOAuthFlow   = errors.New("unsupported oauth provider")
-	errOAuthSessionNotPending = errors.New("oauth session is not pending")
+	errInvalidOAuthState      = oauthsession.ErrInvalidState
+	errUnsupportedOAuthFlow   = oauthsession.ErrUnsupportedFlow
+	errOAuthSessionNotPending = oauthsession.ErrNotPending
 )
 
-type oauthSession struct {
-	Provider  string
-	Status    string
-	CreatedAt time.Time
-	ExpiresAt time.Time
-}
-
-type oauthSessionStore struct {
-	mu       sync.RWMutex
-	ttl      time.Duration
-	sessions map[string]oauthSession
-}
-
-func newOAuthSessionStore(ttl time.Duration) *oauthSessionStore {
-	if ttl <= 0 {
-		ttl = oauthSessionTTL
-	}
-	return &oauthSessionStore{
-		ttl:      ttl,
-		sessions: make(map[string]oauthSession),
-	}
-}
-
-func (s *oauthSessionStore) purgeExpiredLocked(now time.Time) {
-	for state, session := range s.sessions {
-		if !session.ExpiresAt.IsZero() && now.After(session.ExpiresAt) {
-			delete(s.sessions, state)
-		}
-	}
-}
-
-func (s *oauthSessionStore) Register(state, provider string) {
-	state = strings.TrimSpace(state)
-	provider = strings.ToLower(strings.TrimSpace(provider))
-	if state == "" || provider == "" {
-		return
-	}
-	now := time.Now()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.purgeExpiredLocked(now)
-	s.sessions[state] = oauthSession{
-		Provider:  provider,
-		Status:    "",
-		CreatedAt: now,
-		ExpiresAt: now.Add(s.ttl),
-	}
-}
-
-func (s *oauthSessionStore) SetError(state, message string) {
-	state = strings.TrimSpace(state)
-	message = strings.TrimSpace(message)
-	if state == "" {
-		return
-	}
-	if message == "" {
-		message = "Authentication failed"
-	}
-	now := time.Now()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.purgeExpiredLocked(now)
-	session, ok := s.sessions[state]
-	if !ok {
-		return
-	}
-	session.Status = message
-	session.ExpiresAt = now.Add(s.ttl)
-	s.sessions[state] = session
-}
-
-func (s *oauthSessionStore) Complete(state string) {
-	state = strings.TrimSpace(state)
-	if state == "" {
-		return
-	}
-	now := time.Now()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.purgeExpiredLocked(now)
-	session, ok := s.sessions[state]
-	if !ok {
-		return
-	}
-	session.Status = oauthSessionStatusCompleted
-	session.ExpiresAt = now.Add(s.ttl)
-	s.sessions[state] = session
-}
-
-func (s *oauthSessionStore) CompleteProvider(provider string) int {
-	provider = strings.ToLower(strings.TrimSpace(provider))
-	if provider == "" {
-		return 0
-	}
-	now := time.Now()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.purgeExpiredLocked(now)
-	removed := 0
-	for state, session := range s.sessions {
-		if strings.EqualFold(session.Provider, provider) {
-			if session.Status == oauthSessionStatusCompleted {
-				continue
-			}
-			delete(s.sessions, state)
-			removed++
-		}
-	}
-	return removed
-}
-
-func (s *oauthSessionStore) Get(state string) (oauthSession, bool) {
-	state = strings.TrimSpace(state)
-	now := time.Now()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.purgeExpiredLocked(now)
-	session, ok := s.sessions[state]
-	return session, ok
-}
-
-func (s *oauthSessionStore) IsPending(state, provider string) bool {
-	state = strings.TrimSpace(state)
-	provider = strings.ToLower(strings.TrimSpace(provider))
-	now := time.Now()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.purgeExpiredLocked(now)
-	session, ok := s.sessions[state]
-	if !ok {
-		return false
-	}
-	if session.Status != "" {
-		return false
-	}
-	if provider == "" {
-		return true
-	}
-	return strings.EqualFold(session.Provider, provider)
-}
-
 var oauthSessions = newOAuthSessionStore(oauthSessionTTL)
+
+func newOAuthSessionStore(ttl time.Duration) *oauthsession.Store {
+	return oauthsession.NewStore(ttl)
+}
 
 func RegisterOAuthSession(state, provider string) { oauthSessions.Register(state, provider) }
 
@@ -201,93 +47,17 @@ func IsOAuthSessionPending(state, provider string) bool {
 }
 
 func ValidateOAuthState(state string) error {
-	trimmed := strings.TrimSpace(state)
-	if trimmed == "" {
-		return fmt.Errorf("%w: empty", errInvalidOAuthState)
-	}
-	if len(trimmed) > maxOAuthStateLength {
-		return fmt.Errorf("%w: too long", errInvalidOAuthState)
-	}
-	if strings.Contains(trimmed, "/") || strings.Contains(trimmed, "\\") {
-		return fmt.Errorf("%w: contains path separator", errInvalidOAuthState)
-	}
-	if strings.Contains(trimmed, "..") {
-		return fmt.Errorf("%w: contains '..'", errInvalidOAuthState)
-	}
-	for _, r := range trimmed {
-		switch {
-		case r >= 'a' && r <= 'z':
-		case r >= 'A' && r <= 'Z':
-		case r >= '0' && r <= '9':
-		case r == '-' || r == '_' || r == '.':
-		default:
-			return fmt.Errorf("%w: invalid character", errInvalidOAuthState)
-		}
-	}
-	return nil
+	return oauthsession.ValidateState(state)
 }
 
 func NormalizeOAuthProvider(provider string) (string, error) {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case "anthropic", "claude":
-		return "anthropic", nil
-	case "codex", "openai":
-		return "codex", nil
-	case "gemini", "google":
-		return "gemini", nil
-	case "iflow", "i-flow":
-		return "iflow", nil
-	case "antigravity", "anti-gravity":
-		return "antigravity", nil
-	case "qwen":
-		return "qwen", nil
-	default:
-		return "", errUnsupportedOAuthFlow
-	}
-}
-
-type oauthCallbackFilePayload struct {
-	Code  string `json:"code"`
-	State string `json:"state"`
-	Error string `json:"error"`
+	return oauthsession.NormalizeProvider(provider)
 }
 
 func WriteOAuthCallbackFile(authDir, provider, state, code, errorMessage string) (string, error) {
-	if strings.TrimSpace(authDir) == "" {
-		return "", fmt.Errorf("auth dir is empty")
-	}
-	canonicalProvider, err := NormalizeOAuthProvider(provider)
-	if err != nil {
-		return "", err
-	}
-	if err := ValidateOAuthState(state); err != nil {
-		return "", err
-	}
-
-	fileName := fmt.Sprintf(".oauth-%s-%s.oauth", canonicalProvider, state)
-	filePath := filepath.Join(authDir, fileName)
-	payload := oauthCallbackFilePayload{
-		Code:  strings.TrimSpace(code),
-		State: strings.TrimSpace(state),
-		Error: strings.TrimSpace(errorMessage),
-	}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return "", fmt.Errorf("marshal oauth callback payload: %w", err)
-	}
-	if err := os.WriteFile(filePath, data, 0o600); err != nil {
-		return "", fmt.Errorf("write oauth callback file: %w", err)
-	}
-	return filePath, nil
+	return oauthsession.WriteCallbackFile(authDir, provider, state, code, errorMessage)
 }
 
 func WriteOAuthCallbackFileForPendingSession(authDir, provider, state, code, errorMessage string) (string, error) {
-	canonicalProvider, err := NormalizeOAuthProvider(provider)
-	if err != nil {
-		return "", err
-	}
-	if !IsOAuthSessionPending(state, canonicalProvider) {
-		return "", errOAuthSessionNotPending
-	}
-	return WriteOAuthCallbackFile(authDir, canonicalProvider, state, code, errorMessage)
+	return oauthSessions.WriteCallbackFileForPending(authDir, provider, state, code, errorMessage)
 }

--- a/internal/management/oauth/session/session.go
+++ b/internal/management/oauth/session/session.go
@@ -1,0 +1,287 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultTTL      = 10 * time.Minute
+	MaxStateLength  = 128
+	StatusCompleted = "__completed__"
+)
+
+var (
+	ErrInvalidState    = errors.New("invalid oauth state")
+	ErrUnsupportedFlow = errors.New("unsupported oauth provider")
+	ErrNotPending      = errors.New("oauth session is not pending")
+)
+
+type Session struct {
+	Provider  string
+	Status    string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+type Store struct {
+	mu       sync.RWMutex
+	ttl      time.Duration
+	sessions map[string]Session
+}
+
+func NewStore(ttl time.Duration) *Store {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	return &Store{
+		ttl:      ttl,
+		sessions: make(map[string]Session),
+	}
+}
+
+func (s *Store) purgeExpiredLocked(now time.Time) {
+	for state, session := range s.sessions {
+		if !session.ExpiresAt.IsZero() && now.After(session.ExpiresAt) {
+			delete(s.sessions, state)
+		}
+	}
+}
+
+func (s *Store) Register(state, provider string) {
+	if s == nil {
+		return
+	}
+	state = strings.TrimSpace(state)
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if state == "" || provider == "" {
+		return
+	}
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.purgeExpiredLocked(now)
+	s.sessions[state] = Session{
+		Provider:  provider,
+		Status:    "",
+		CreatedAt: now,
+		ExpiresAt: now.Add(s.ttl),
+	}
+}
+
+func (s *Store) SetError(state, message string) {
+	if s == nil {
+		return
+	}
+	state = strings.TrimSpace(state)
+	message = strings.TrimSpace(message)
+	if state == "" {
+		return
+	}
+	if message == "" {
+		message = "Authentication failed"
+	}
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.purgeExpiredLocked(now)
+	session, ok := s.sessions[state]
+	if !ok {
+		return
+	}
+	session.Status = message
+	session.ExpiresAt = now.Add(s.ttl)
+	s.sessions[state] = session
+}
+
+func (s *Store) Complete(state string) {
+	if s == nil {
+		return
+	}
+	state = strings.TrimSpace(state)
+	if state == "" {
+		return
+	}
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.purgeExpiredLocked(now)
+	session, ok := s.sessions[state]
+	if !ok {
+		return
+	}
+	session.Status = StatusCompleted
+	session.ExpiresAt = now.Add(s.ttl)
+	s.sessions[state] = session
+}
+
+func (s *Store) CompleteProvider(provider string) int {
+	if s == nil {
+		return 0
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return 0
+	}
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.purgeExpiredLocked(now)
+	removed := 0
+	for state, session := range s.sessions {
+		if strings.EqualFold(session.Provider, provider) {
+			if session.Status == StatusCompleted {
+				continue
+			}
+			delete(s.sessions, state)
+			removed++
+		}
+	}
+	return removed
+}
+
+func (s *Store) Get(state string) (Session, bool) {
+	if s == nil {
+		return Session{}, false
+	}
+	state = strings.TrimSpace(state)
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.purgeExpiredLocked(now)
+	session, ok := s.sessions[state]
+	return session, ok
+}
+
+func (s *Store) IsPending(state, provider string) bool {
+	if s == nil {
+		return false
+	}
+	state = strings.TrimSpace(state)
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.purgeExpiredLocked(now)
+	session, ok := s.sessions[state]
+	if !ok {
+		return false
+	}
+	if session.Status != "" {
+		return false
+	}
+	if provider == "" {
+		return true
+	}
+	return strings.EqualFold(session.Provider, provider)
+}
+
+func ValidateState(state string) error {
+	trimmed := strings.TrimSpace(state)
+	if trimmed == "" {
+		return fmt.Errorf("%w: empty", ErrInvalidState)
+	}
+	if len(trimmed) > MaxStateLength {
+		return fmt.Errorf("%w: too long", ErrInvalidState)
+	}
+	if strings.Contains(trimmed, "/") || strings.Contains(trimmed, "\\") {
+		return fmt.Errorf("%w: contains path separator", ErrInvalidState)
+	}
+	if strings.Contains(trimmed, "..") {
+		return fmt.Errorf("%w: contains '..'", ErrInvalidState)
+	}
+	for _, r := range trimmed {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return fmt.Errorf("%w: invalid character", ErrInvalidState)
+		}
+	}
+	return nil
+}
+
+func NormalizeProvider(provider string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return "anthropic", nil
+	case "codex", "openai":
+		return "codex", nil
+	case "gemini", "google":
+		return "gemini", nil
+	case "iflow", "i-flow":
+		return "iflow", nil
+	case "antigravity", "anti-gravity":
+		return "antigravity", nil
+	case "qwen":
+		return "qwen", nil
+	default:
+		return "", ErrUnsupportedFlow
+	}
+}
+
+type callbackFilePayload struct {
+	Code  string `json:"code"`
+	State string `json:"state"`
+	Error string `json:"error"`
+}
+
+func WriteCallbackFile(authDir, provider, state, code, errorMessage string) (string, error) {
+	if strings.TrimSpace(authDir) == "" {
+		return "", fmt.Errorf("auth dir is empty")
+	}
+	canonicalProvider, err := NormalizeProvider(provider)
+	if err != nil {
+		return "", err
+	}
+	if err := ValidateState(state); err != nil {
+		return "", err
+	}
+
+	fileName := fmt.Sprintf(".oauth-%s-%s.oauth", canonicalProvider, state)
+	filePath := filepath.Join(authDir, fileName)
+	payload := callbackFilePayload{
+		Code:  strings.TrimSpace(code),
+		State: strings.TrimSpace(state),
+		Error: strings.TrimSpace(errorMessage),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal oauth callback payload: %w", err)
+	}
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
+		return "", fmt.Errorf("write oauth callback file: %w", err)
+	}
+	return filePath, nil
+}
+
+func (s *Store) WriteCallbackFileForPending(authDir, provider, state, code, errorMessage string) (string, error) {
+	canonicalProvider, err := NormalizeProvider(provider)
+	if err != nil {
+		return "", err
+	}
+	if !s.IsPending(state, canonicalProvider) {
+		return "", ErrNotPending
+	}
+	return WriteCallbackFile(authDir, canonicalProvider, state, code, errorMessage)
+}

--- a/internal/management/oauth/session/session_test.go
+++ b/internal/management/oauth/session/session_test.go
@@ -1,0 +1,78 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCompleteProviderRetainsCompletedSessions(t *testing.T) {
+	store := NewStore(time.Minute)
+	store.Register("completed-state", "codex")
+	store.Register("stale-state", "codex")
+
+	store.Complete("completed-state")
+	removed := store.CompleteProvider("codex")
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+
+	session, ok := store.Get("completed-state")
+	if !ok {
+		t.Fatal("expected completed session to remain queryable")
+	}
+	if session.Provider != "codex" || session.Status != StatusCompleted {
+		t.Fatalf("session = %#v, want completed codex session", session)
+	}
+	if _, ok := store.Get("stale-state"); ok {
+		t.Fatal("expected stale pending session to be removed")
+	}
+}
+
+func TestValidateStateRejectsPathLikeValues(t *testing.T) {
+	for _, state := range []string{"../state", "path/state", `path\state`, "bad state"} {
+		if err := ValidateState(state); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("ValidateState(%q) error = %v, want ErrInvalidState", state, err)
+		}
+	}
+}
+
+func TestWriteCallbackFileForPendingWritesPayload(t *testing.T) {
+	store := NewStore(time.Minute)
+	store.Register("session-1", "gemini")
+	authDir := t.TempDir()
+
+	path, err := store.WriteCallbackFileForPending(authDir, "gemini", "session-1", " code ", " error ")
+	if err != nil {
+		t.Fatalf("WriteCallbackFileForPending() error = %v", err)
+	}
+	if filepath.Base(path) != ".oauth-gemini-session-1.oauth" {
+		t.Fatalf("path = %q, want gemini callback file", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	var payload callbackFilePayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if payload.Code != "code" || payload.State != "session-1" || payload.Error != "error" {
+		t.Fatalf("payload = %#v, want trimmed callback payload", payload)
+	}
+}
+
+func TestWriteCallbackFileForPendingRejectsCompletedSession(t *testing.T) {
+	store := NewStore(time.Minute)
+	store.Register("session-1", "codex")
+	store.Complete("session-1")
+
+	_, err := store.WriteCallbackFileForPending(t.TempDir(), "codex", "session-1", "code", "")
+	if !errors.Is(err, ErrNotPending) {
+		t.Fatalf("WriteCallbackFileForPending() error = %v, want ErrNotPending", err)
+	}
+}


### PR DESCRIPTION
## Summary
- move OAuth session state, provider normalization, state validation, and callback file writing into an internal OAuth session package
- keep the management handler package on a compatibility facade so existing routes and tests keep the same surface
- add direct unit coverage for the extracted session store behavior

## Verification
- go test ./internal/management/oauth/session
- go test ./internal/api/handlers/management -run 'Test.*OAuth|TestRequestAnthropicToken|TestRequestAntigravityToken|TestRequestCodexToken'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- git diff --check