### PR TITLE
refactor: move authfiles token repository

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1697,
+        "max_lines": 1665,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1697 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1665 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -633,67 +633,35 @@ func (h *Handler) removeAuth(ctx context.Context, id string) {
 }
 
 func (h *Handler) deleteTokenRecord(ctx context.Context, path string) error {
-	if strings.TrimSpace(path) == "" {
-		return fmt.Errorf("auth path is empty")
-	}
-	store := h.tokenStoreWithBaseDir()
-	if store == nil {
-		return fmt.Errorf("token store unavailable")
-	}
-	return store.Delete(ctx, path)
+	return h.authFileRepository().Delete(ctx, path)
 }
 
-func (h *Handler) tokenStoreWithBaseDir() coreauth.Store {
+func (h *Handler) authFileRepository() managementauthfiles.Repository {
 	if h == nil {
-		return nil
+		return managementauthfiles.Repository{}
 	}
 	store := h.tokenStore
 	if store == nil {
 		store = sdkAuth.GetTokenStore()
 		h.tokenStore = store
 	}
+	baseDir := ""
 	if h.cfg != nil {
-		if dirSetter, ok := store.(interface{ SetBaseDir(string) }); ok {
-			dirSetter.SetBaseDir(h.cfg.AuthDir)
-		}
+		baseDir = h.cfg.AuthDir
 	}
-	return store
+	return managementauthfiles.Repository{
+		Store:        store,
+		BaseDir:      baseDir,
+		PostAuthHook: h.postAuthHook,
+	}
 }
 
 func (h *Handler) persistAuthFileChange(ctx context.Context, message string, paths ...string) error {
-	store := h.tokenStoreWithBaseDir()
-	if store == nil {
-		return nil
-	}
-	persister, ok := store.(interface {
-		PersistAuthFiles(context.Context, string, ...string) error
-	})
-	if !ok {
-		return nil
-	}
-	if strings.TrimSpace(message) == "" {
-		message = "Update auth file"
-	}
-	if err := persister.PersistAuthFiles(ctx, message, paths...); err != nil {
-		return fmt.Errorf("failed to persist auth file: %w", err)
-	}
-	return nil
+	return h.authFileRepository().PersistChange(ctx, message, paths...)
 }
 
 func (h *Handler) saveTokenRecord(ctx context.Context, record *coreauth.Auth) (string, error) {
-	if record == nil {
-		return "", fmt.Errorf("token record is nil")
-	}
-	store := h.tokenStoreWithBaseDir()
-	if store == nil {
-		return "", fmt.Errorf("token store unavailable")
-	}
-	if h.postAuthHook != nil {
-		if err := h.postAuthHook(ctx, record); err != nil {
-			return "", fmt.Errorf("post-auth hook failed: %w", err)
-		}
-	}
-	return store.Save(ctx, record)
+	return h.authFileRepository().Save(ctx, record)
 }
 
 func (h *Handler) RequestAnthropicToken(c *gin.Context) {

--- a/internal/management/authfiles/repository.go
+++ b/internal/management/authfiles/repository.go
@@ -1,0 +1,73 @@
+package authfiles
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type Repository struct {
+	Store        coreauth.Store
+	BaseDir      string
+	PostAuthHook coreauth.PostAuthHook
+}
+
+func (r Repository) storeWithBaseDir() coreauth.Store {
+	store := r.Store
+	if store == nil {
+		return nil
+	}
+	if dirSetter, ok := store.(interface{ SetBaseDir(string) }); ok {
+		dirSetter.SetBaseDir(r.BaseDir)
+	}
+	return store
+}
+
+func (r Repository) Delete(ctx context.Context, path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("auth path is empty")
+	}
+	store := r.storeWithBaseDir()
+	if store == nil {
+		return fmt.Errorf("token store unavailable")
+	}
+	return store.Delete(ctx, path)
+}
+
+func (r Repository) PersistChange(ctx context.Context, message string, paths ...string) error {
+	store := r.storeWithBaseDir()
+	if store == nil {
+		return nil
+	}
+	persister, ok := store.(interface {
+		PersistAuthFiles(context.Context, string, ...string) error
+	})
+	if !ok {
+		return nil
+	}
+	if strings.TrimSpace(message) == "" {
+		message = "Update auth file"
+	}
+	if err := persister.PersistAuthFiles(ctx, message, paths...); err != nil {
+		return fmt.Errorf("failed to persist auth file: %w", err)
+	}
+	return nil
+}
+
+func (r Repository) Save(ctx context.Context, record *coreauth.Auth) (string, error) {
+	if record == nil {
+		return "", fmt.Errorf("token record is nil")
+	}
+	store := r.storeWithBaseDir()
+	if store == nil {
+		return "", fmt.Errorf("token store unavailable")
+	}
+	if r.PostAuthHook != nil {
+		if err := r.PostAuthHook(ctx, record); err != nil {
+			return "", fmt.Errorf("post-auth hook failed: %w", err)
+		}
+	}
+	return store.Save(ctx, record)
+}

--- a/internal/management/authfiles/repository_test.go
+++ b/internal/management/authfiles/repository_test.go
@@ -1,0 +1,99 @@
+package authfiles
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type repositoryStore struct {
+	baseDir          string
+	saved            *coreauth.Auth
+	deleted          string
+	persistMessage   string
+	persistedPaths   []string
+	persistShouldErr error
+}
+
+func (s *repositoryStore) List(context.Context) ([]*coreauth.Auth, error) {
+	return nil, nil
+}
+
+func (s *repositoryStore) Save(_ context.Context, auth *coreauth.Auth) (string, error) {
+	s.saved = auth
+	return auth.ID, nil
+}
+
+func (s *repositoryStore) Delete(_ context.Context, id string) error {
+	s.deleted = id
+	return nil
+}
+
+func (s *repositoryStore) SetBaseDir(dir string) {
+	s.baseDir = dir
+}
+
+func (s *repositoryStore) PersistAuthFiles(_ context.Context, message string, paths ...string) error {
+	s.persistMessage = message
+	s.persistedPaths = append([]string(nil), paths...)
+	return s.persistShouldErr
+}
+
+func TestRepositorySaveAppliesBaseDirAndPostAuthHook(t *testing.T) {
+	store := &repositoryStore{}
+	record := &coreauth.Auth{ID: "auth.json"}
+	var hookCalled bool
+
+	path, err := (Repository{
+		Store:   store,
+		BaseDir: "/auth-dir",
+		PostAuthHook: func(ctx context.Context, auth *coreauth.Auth) error {
+			_ = ctx
+			hookCalled = true
+			if auth != record {
+				t.Fatalf("hook auth = %#v, want original record", auth)
+			}
+			return nil
+		},
+	}).Save(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if path != "auth.json" {
+		t.Fatalf("Save() path = %q, want auth.json", path)
+	}
+	if store.baseDir != "/auth-dir" {
+		t.Fatalf("baseDir = %q, want /auth-dir", store.baseDir)
+	}
+	if store.saved != record {
+		t.Fatalf("saved = %#v, want original record", store.saved)
+	}
+	if !hookCalled {
+		t.Fatal("expected post-auth hook")
+	}
+}
+
+func TestRepositoryDeleteRejectsEmptyPath(t *testing.T) {
+	err := (Repository{Store: &repositoryStore{}}).Delete(context.Background(), " ")
+	if err == nil {
+		t.Fatal("Delete() error = nil, want error")
+	}
+}
+
+func TestRepositoryPersistChangeUsesDefaultMessageAndWrapsError(t *testing.T) {
+	wantErr := errors.New("boom")
+	store := &repositoryStore{persistShouldErr: wantErr}
+
+	err := (Repository{Store: store}).PersistChange(context.Background(), "", "auth.json")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("PersistChange() error = %v, want wrapped boom", err)
+	}
+	if store.persistMessage != "Update auth file" {
+		t.Fatalf("persist message = %q, want default message", store.persistMessage)
+	}
+	if len(store.persistedPaths) != 1 || store.persistedPaths[0] != "auth.json" {
+		t.Fatalf("persisted paths = %#v, want [auth.json]", store.persistedPaths)
+	}
+}


### PR DESCRIPTION
## Summary
- add an authfiles repository adapter for token store save, delete, and auth-file persistence operations
- keep the management handler responsible only for wiring the existing store, base directory, and post-auth hook
- tighten the backend structure baseline for auth_files.go after moving store logic out

## Verification
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run 'Test.*AuthFile|TestRequest.*Token|TestImportVertex|TestPostOAuthCallback'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json\n- git diff --check