### PR TITLE
refactor: move oauth callback file waiter

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1665,
+        "max_lines": 1654,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1665 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1654 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1124,40 +1124,29 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		}
 
 		// Wait for callback file
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-codex-%s.oauth", state))
-		deadline := time.Now().Add(oauthCallbackWaitTimeout)
-		var code string
-		for {
-			if !IsOAuthSessionPending(state, "codex") {
+		resultMap, errWait := WaitOAuthCallbackFile(h.cfg.AuthDir, "codex", state, oauthCallbackWaitTimeout)
+		if errWait != nil {
+			if errors.Is(errWait, errOAuthSessionNotPending) {
 				return
 			}
-			if time.Now().After(deadline) {
-				authErr := codex.NewAuthenticationError(codex.ErrCallbackTimeout, fmt.Errorf("timeout waiting for OAuth callback"))
-				log.Error(codex.GetUserFriendlyMessage(authErr))
-				SetOAuthSessionError(state, "Timeout waiting for OAuth callback")
-				return
-			}
-			if data, errR := os.ReadFile(waitFile); errR == nil {
-				var m map[string]string
-				_ = json.Unmarshal(data, &m)
-				_ = os.Remove(waitFile)
-				if errStr := m["error"]; errStr != "" {
-					oauthErr := codex.NewOAuthError(errStr, "", http.StatusBadRequest)
-					log.Error(codex.GetUserFriendlyMessage(oauthErr))
-					SetOAuthSessionError(state, "Bad Request")
-					return
-				}
-				if m["state"] != state {
-					authErr := codex.NewAuthenticationError(codex.ErrInvalidState, fmt.Errorf("expected %s, got %s", state, m["state"]))
-					SetOAuthSessionError(state, "State code error")
-					log.Error(codex.GetUserFriendlyMessage(authErr))
-					return
-				}
-				code = m["code"]
-				break
-			}
-			time.Sleep(500 * time.Millisecond)
+			authErr := codex.NewAuthenticationError(codex.ErrCallbackTimeout, errWait)
+			log.Error(codex.GetUserFriendlyMessage(authErr))
+			SetOAuthSessionError(state, "Timeout waiting for OAuth callback")
+			return
 		}
+		if errStr := resultMap["error"]; errStr != "" {
+			oauthErr := codex.NewOAuthError(errStr, "", http.StatusBadRequest)
+			log.Error(codex.GetUserFriendlyMessage(oauthErr))
+			SetOAuthSessionError(state, "Bad Request")
+			return
+		}
+		if resultMap["state"] != state {
+			authErr := codex.NewAuthenticationError(codex.ErrInvalidState, fmt.Errorf("expected %s, got %s", state, resultMap["state"]))
+			SetOAuthSessionError(state, "State code error")
+			log.Error(codex.GetUserFriendlyMessage(authErr))
+			return
+		}
+		code := resultMap["code"]
 
 		log.Debug("Authorization code received, exchanging for tokens...")
 		// Exchange code for tokens using internal auth service

--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -61,3 +61,7 @@ func WriteOAuthCallbackFile(authDir, provider, state, code, errorMessage string)
 func WriteOAuthCallbackFileForPendingSession(authDir, provider, state, code, errorMessage string) (string, error) {
 	return oauthSessions.WriteCallbackFileForPending(authDir, provider, state, code, errorMessage)
 }
+
+func WaitOAuthCallbackFile(authDir, provider, state string, timeout time.Duration) (map[string]string, error) {
+	return oauthSessions.WaitCallbackFile(authDir, provider, state, timeout, 500*time.Millisecond)
+}

--- a/internal/management/oauth/session/session.go
+++ b/internal/management/oauth/session/session.go
@@ -21,6 +21,7 @@ var (
 	ErrInvalidState    = errors.New("invalid oauth state")
 	ErrUnsupportedFlow = errors.New("unsupported oauth provider")
 	ErrNotPending      = errors.New("oauth session is not pending")
+	ErrCallbackTimeout = errors.New("timeout waiting for oauth callback")
 )
 
 type Session struct {
@@ -284,4 +285,39 @@ func (s *Store) WriteCallbackFileForPending(authDir, provider, state, code, erro
 		return "", ErrNotPending
 	}
 	return WriteCallbackFile(authDir, canonicalProvider, state, code, errorMessage)
+}
+
+func (s *Store) WaitCallbackFile(authDir, provider, state string, timeout, pollInterval time.Duration) (map[string]string, error) {
+	canonicalProvider, err := NormalizeProvider(provider)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateState(state); err != nil {
+		return nil, err
+	}
+	if timeout <= 0 {
+		timeout = DefaultTTL
+	}
+	if pollInterval <= 0 {
+		pollInterval = 500 * time.Millisecond
+	}
+
+	fileName := fmt.Sprintf(".oauth-%s-%s.oauth", canonicalProvider, state)
+	filePath := filepath.Join(authDir, fileName)
+	deadline := time.Now().Add(timeout)
+	for {
+		if !s.IsPending(state, canonicalProvider) {
+			return nil, ErrNotPending
+		}
+		if time.Now().After(deadline) {
+			return nil, ErrCallbackTimeout
+		}
+		if data, errRead := os.ReadFile(filePath); errRead == nil {
+			var payload map[string]string
+			_ = json.Unmarshal(data, &payload)
+			_ = os.Remove(filePath)
+			return payload, nil
+		}
+		time.Sleep(pollInterval)
+	}
 }

--- a/internal/management/oauth/session/session_test.go
+++ b/internal/management/oauth/session/session_test.go
@@ -76,3 +76,32 @@ func TestWriteCallbackFileForPendingRejectsCompletedSession(t *testing.T) {
 		t.Fatalf("WriteCallbackFileForPending() error = %v, want ErrNotPending", err)
 	}
 }
+
+func TestWaitCallbackFileReadsAndRemovesPayload(t *testing.T) {
+	store := NewStore(time.Minute)
+	store.Register("session-1", "codex")
+	authDir := t.TempDir()
+	if _, err := WriteCallbackFile(authDir, "codex", "session-1", "code", ""); err != nil {
+		t.Fatalf("WriteCallbackFile() error = %v", err)
+	}
+
+	payload, err := store.WaitCallbackFile(authDir, "codex", "session-1", time.Second, time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitCallbackFile() error = %v", err)
+	}
+	if payload["code"] != "code" || payload["state"] != "session-1" {
+		t.Fatalf("payload = %#v, want callback code and state", payload)
+	}
+	if _, err := os.Stat(filepath.Join(authDir, ".oauth-codex-session-1.oauth")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("callback file stat error = %v, want not exist", err)
+	}
+}
+
+func TestWaitCallbackFileReturnsNotPending(t *testing.T) {
+	store := NewStore(time.Minute)
+
+	_, err := store.WaitCallbackFile(t.TempDir(), "codex", "session-1", time.Millisecond, time.Millisecond)
+	if !errors.Is(err, ErrNotPending) {
+		t.Fatalf("WaitCallbackFile() error = %v, want ErrNotPending", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared OAuth callback-file waiter to the internal session package
- migrate the Codex OAuth flow to use the shared waiter while keeping response handling compatible
- tighten the backend structure baseline for auth_files.go after the extraction

## Verification
- go test ./internal/management/oauth/session
- go test ./internal/api/handlers/management -run 'Test.*OAuth|TestRequestCodexToken|TestRequestAnthropicToken|TestRequestAntigravityToken'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json\n- git diff --check