### PR TITLE
refactor: use shared antigravity callback waiter

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1654,
+        "max_lines": 1643,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1654 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1643 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1228,41 +1228,30 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			defer oauthcallback.StopInstance(ctx, callbackPort, forwarder)
 		}
 
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-antigravity-%s.oauth", state))
-		deadline := time.Now().Add(oauthCallbackWaitTimeout)
-		var authCode string
-		for {
-			if !IsOAuthSessionPending(state, "antigravity") {
+		payload, errWait := WaitOAuthCallbackFile(h.cfg.AuthDir, "antigravity", state, oauthCallbackWaitTimeout)
+		if errWait != nil {
+			if errors.Is(errWait, errOAuthSessionNotPending) {
 				return
 			}
-			if time.Now().After(deadline) {
-				log.Error("oauth flow timed out")
-				SetOAuthSessionError(state, "OAuth flow timed out")
-				return
-			}
-			if data, errReadFile := os.ReadFile(waitFile); errReadFile == nil {
-				var payload map[string]string
-				_ = json.Unmarshal(data, &payload)
-				_ = os.Remove(waitFile)
-				if errStr := strings.TrimSpace(payload["error"]); errStr != "" {
-					log.Errorf("Authentication failed: %s", errStr)
-					SetOAuthSessionError(state, "Authentication failed")
-					return
-				}
-				if payloadState := strings.TrimSpace(payload["state"]); payloadState != "" && payloadState != state {
-					log.Errorf("Authentication failed: state mismatch")
-					SetOAuthSessionError(state, "Authentication failed: state mismatch")
-					return
-				}
-				authCode = strings.TrimSpace(payload["code"])
-				if authCode == "" {
-					log.Error("Authentication failed: code not found")
-					SetOAuthSessionError(state, "Authentication failed: code not found")
-					return
-				}
-				break
-			}
-			time.Sleep(500 * time.Millisecond)
+			log.Error("oauth flow timed out")
+			SetOAuthSessionError(state, "OAuth flow timed out")
+			return
+		}
+		if errStr := strings.TrimSpace(payload["error"]); errStr != "" {
+			log.Errorf("Authentication failed: %s", errStr)
+			SetOAuthSessionError(state, "Authentication failed")
+			return
+		}
+		if payloadState := strings.TrimSpace(payload["state"]); payloadState != "" && payloadState != state {
+			log.Errorf("Authentication failed: state mismatch")
+			SetOAuthSessionError(state, "Authentication failed: state mismatch")
+			return
+		}
+		authCode := strings.TrimSpace(payload["code"])
+		if authCode == "" {
+			log.Error("Authentication failed: code not found")
+			SetOAuthSessionError(state, "Authentication failed: code not found")
+			return
 		}
 
 		tokenResp, errToken := authSvc.ExchangeCodeForTokens(ctx, authCode, redirectURI)


### PR DESCRIPTION
## Summary
- migrate the Antigravity OAuth flow to the shared callback-file waiter
- preserve Antigravity-specific callback error handling, optional state validation, and code trimming
- tighten the backend structure baseline for auth_files.go after the extraction

## Verification
- go test ./internal/management/oauth/session
- go test ./internal/api/handlers/management -run 'Test.*OAuth|TestRequestAntigravityToken|TestRequestCodexToken'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json\n- git diff --check