### PR TITLE
refactor: use shared anthropic callback waiter

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1643,
+        "max_lines": 1621,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1643 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1621 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -725,36 +725,14 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 			defer oauthcallback.StopInstance(ctx, callbackPort, forwarder)
 		}
 
-		// Helper: wait for callback file
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-anthropic-%s.oauth", state))
-		waitForFile := func(path string, timeout time.Duration) (map[string]string, error) {
-			deadline := time.Now().Add(timeout)
-			for {
-				if !IsOAuthSessionPending(state, "anthropic") {
-					return nil, errOAuthSessionNotPending
-				}
-				if time.Now().After(deadline) {
-					SetOAuthSessionError(state, "Timeout waiting for OAuth callback")
-					return nil, fmt.Errorf("timeout waiting for OAuth callback")
-				}
-				data, errRead := os.ReadFile(path)
-				if errRead == nil {
-					var m map[string]string
-					_ = json.Unmarshal(data, &m)
-					_ = os.Remove(path)
-					return m, nil
-				}
-				time.Sleep(500 * time.Millisecond)
-			}
-		}
-
 		fmt.Println("Waiting for authentication callback...")
 		// Keep the callback waiter alive for the full session lifetime.
-		resultMap, errWait := waitForFile(waitFile, oauthCallbackWaitTimeout)
+		resultMap, errWait := WaitOAuthCallbackFile(h.cfg.AuthDir, "anthropic", state, oauthCallbackWaitTimeout)
 		if errWait != nil {
 			if errors.Is(errWait, errOAuthSessionNotPending) {
 				return
 			}
+			SetOAuthSessionError(state, "Timeout waiting for OAuth callback")
 			authErr := claude.NewAuthenticationError(claude.ErrCallbackTimeout, errWait)
 			log.Error(claude.GetUserFriendlyMessage(authErr))
 			return


### PR DESCRIPTION
## Summary
- migrate the Anthropic OAuth flow to the shared callback-file waiter
- preserve the existing timeout session status update and Claude-specific error handling
- tighten the backend structure baseline for auth_files.go after the extraction

## Verification
- go test ./internal/management/oauth/session
- go test ./internal/api/handlers/management -run 'Test.*OAuth|TestRequestAnthropicToken|TestRequestAntigravityToken|TestRequestCodexToken'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json\n- git diff --check