### PR TITLE
refactor: use shared gemini callback waiter

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1621,
+        "max_lines": 1609,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1621 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1609 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -845,38 +845,26 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			defer oauthcallback.StopInstance(ctx, callbackPort, forwarder)
 		}
 
-		// Wait for callback file written by server route
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-gemini-%s.oauth", state))
 		fmt.Println("Waiting for authentication callback...")
-		deadline := time.Now().Add(oauthCallbackWaitTimeout)
-		var authCode string
-		for {
-			if !IsOAuthSessionPending(state, "gemini") {
+		resultMap, errWait := WaitOAuthCallbackFile(h.cfg.AuthDir, "gemini", state, oauthCallbackWaitTimeout)
+		if errWait != nil {
+			if errors.Is(errWait, errOAuthSessionNotPending) {
 				return
 			}
-			if time.Now().After(deadline) {
-				log.Error("oauth flow timed out")
-				SetOAuthSessionError(state, "OAuth flow timed out")
-				return
-			}
-			if data, errR := os.ReadFile(waitFile); errR == nil {
-				var m map[string]string
-				_ = json.Unmarshal(data, &m)
-				_ = os.Remove(waitFile)
-				if errStr := m["error"]; errStr != "" {
-					log.Errorf("Authentication failed: %s", errStr)
-					SetOAuthSessionError(state, "Authentication failed")
-					return
-				}
-				authCode = m["code"]
-				if authCode == "" {
-					log.Errorf("Authentication failed: code not found")
-					SetOAuthSessionError(state, "Authentication failed: code not found")
-					return
-				}
-				break
-			}
-			time.Sleep(500 * time.Millisecond)
+			log.Error("oauth flow timed out")
+			SetOAuthSessionError(state, "OAuth flow timed out")
+			return
+		}
+		if errStr := resultMap["error"]; errStr != "" {
+			log.Errorf("Authentication failed: %s", errStr)
+			SetOAuthSessionError(state, "Authentication failed")
+			return
+		}
+		authCode := resultMap["code"]
+		if authCode == "" {
+			log.Errorf("Authentication failed: code not found")
+			SetOAuthSessionError(state, "Authentication failed: code not found")
+			return
 		}
 
 		// Exchange authorization code for token


### PR DESCRIPTION
## Summary
- migrate the Gemini CLI OAuth flow to the shared callback-file waiter
- preserve existing Gemini callback timeout, error, and missing-code session messages
- tighten the backend structure baseline for auth_files.go after the extraction

## Verification
- go test ./internal/management/oauth/session ./internal/management/oauth/providers/geminicli
- go test ./internal/api/handlers/management -run 'Test.*OAuth|TestRequestGemini|TestRequestAnthropicToken|TestRequestAntigravityToken|TestRequestCodexToken'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json\n- git diff --check