### PR TITLE
refactor: move authfiles manager adapter

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1599,
+        "max_lines": 1557,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1599 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1557 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -369,39 +369,14 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 }
 
 func (h *Handler) findAuthByNameOrID(name string) *coreauth.Auth {
-	if h == nil || h.authManager == nil {
+	if h == nil {
 		return nil
 	}
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return nil
-	}
-	if auth, ok := h.authManager.GetByID(name); ok {
-		return auth
-	}
-	for _, auth := range h.authManager.List() {
-		if auth == nil {
-			continue
-		}
-		if strings.EqualFold(strings.TrimSpace(auth.FileName), name) {
-			return auth
-		}
-		if path := strings.TrimSpace(managementauthfiles.Attribute(auth, "path")); path != "" && strings.EqualFold(filepath.Base(path), name) {
-			return auth
-		}
-	}
-	return nil
+	return managementauthfiles.FindByNameOrID(h.authManager, name)
 }
 
 func deletedAuthChannelIdentifiers(auth *coreauth.Auth) []string {
-	if auth == nil {
-		return nil
-	}
-	accountType, _ := auth.AccountInfo()
-	if !strings.EqualFold(accountType, "oauth") {
-		return nil
-	}
-	return auth.ChannelIdentifiers()
+	return managementauthfiles.DeletedChannelIdentifiers(auth)
 }
 
 func (h *Handler) authIDForPath(path string) string {
@@ -608,28 +583,11 @@ func (h *Handler) removeAuth(ctx context.Context, id string) {
 	if h == nil || h.authManager == nil {
 		return
 	}
-	candidates := []string{
-		h.authIDForPath(id),
-		strings.TrimSpace(id),
-		filepath.Base(strings.TrimSpace(id)),
+	authDir := ""
+	if h.cfg != nil {
+		authDir = h.cfg.AuthDir
 	}
-	seen := make(map[string]struct{}, len(candidates))
-	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" || candidate == "." {
-			continue
-		}
-		if _, ok := seen[candidate]; ok {
-			continue
-		}
-		seen[candidate] = struct{}{}
-		if deleted, _ := h.authManager.Delete(coreauth.WithSkipPersist(ctx), candidate); deleted != nil {
-			return
-		}
-	}
-	if auth := h.findAuthByNameOrID(filepath.Base(strings.TrimSpace(id))); auth != nil {
-		_, _ = h.authManager.Delete(coreauth.WithSkipPersist(ctx), auth.ID)
-	}
+	managementauthfiles.RemoveFromManager(ctx, h.authManager, authDir, id)
 }
 
 func (h *Handler) deleteTokenRecord(ctx context.Context, path string) error {

--- a/internal/management/authfiles/manager.go
+++ b/internal/management/authfiles/manager.go
@@ -1,0 +1,74 @@
+package authfiles
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func FindByNameOrID(manager *coreauth.Manager, name string) *coreauth.Auth {
+	if manager == nil {
+		return nil
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	if auth, ok := manager.GetByID(name); ok {
+		return auth
+	}
+	for _, auth := range manager.List() {
+		if auth == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(auth.FileName), name) {
+			return auth
+		}
+		if path := strings.TrimSpace(Attribute(auth, "path")); path != "" && strings.EqualFold(filepath.Base(path), name) {
+			return auth
+		}
+	}
+	return nil
+}
+
+func DeletedChannelIdentifiers(auth *coreauth.Auth) []string {
+	if auth == nil {
+		return nil
+	}
+	accountType, _ := auth.AccountInfo()
+	if !strings.EqualFold(accountType, "oauth") {
+		return nil
+	}
+	return auth.ChannelIdentifiers()
+}
+
+func RemoveFromManager(ctx context.Context, manager *coreauth.Manager, authDir, id string) {
+	if manager == nil {
+		return
+	}
+	trimmedID := strings.TrimSpace(id)
+	candidates := []string{
+		AuthIDForPath(authDir, trimmedID),
+		trimmedID,
+		filepath.Base(trimmedID),
+	}
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || candidate == "." {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if deleted, _ := manager.Delete(coreauth.WithSkipPersist(ctx), candidate); deleted != nil {
+			return
+		}
+	}
+	if auth := FindByNameOrID(manager, filepath.Base(trimmedID)); auth != nil {
+		_, _ = manager.Delete(coreauth.WithSkipPersist(ctx), auth.ID)
+	}
+}

--- a/internal/management/authfiles/manager_test.go
+++ b/internal/management/authfiles/manager_test.go
@@ -1,0 +1,101 @@
+package authfiles
+
+import (
+	"context"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type managerStore struct {
+	items map[string]*coreauth.Auth
+}
+
+func (s *managerStore) List(context.Context) ([]*coreauth.Auth, error) {
+	out := make([]*coreauth.Auth, 0, len(s.items))
+	for _, auth := range s.items {
+		out = append(out, auth.Clone())
+	}
+	return out, nil
+}
+
+func (s *managerStore) Save(_ context.Context, auth *coreauth.Auth) (string, error) {
+	if s.items == nil {
+		s.items = make(map[string]*coreauth.Auth)
+	}
+	s.items[auth.ID] = auth.Clone()
+	return auth.ID, nil
+}
+
+func (s *managerStore) Delete(_ context.Context, id string) error {
+	delete(s.items, id)
+	return nil
+}
+
+func TestFindByNameOrIDMatchesIDFileNameAndPathBase(t *testing.T) {
+	manager := coreauth.NewManager(&managerStore{}, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "auth-id",
+		FileName: "account.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/auth/account.json",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	for _, name := range []string{"auth-id", "account.json"} {
+		if got := FindByNameOrID(manager, name); got == nil || got.ID != "auth-id" {
+			t.Fatalf("FindByNameOrID(%q) = %#v, want auth-id", name, got)
+		}
+	}
+}
+
+func TestDeletedChannelIdentifiersRequiresOAuthAccount(t *testing.T) {
+	apiKeyAuth := &coreauth.Auth{
+		ID:       "api-key",
+		Provider: "openai",
+		Attributes: map[string]string{
+			"api_key": "key",
+		},
+	}
+	if got := DeletedChannelIdentifiers(apiKeyAuth); got != nil {
+		t.Fatalf("DeletedChannelIdentifiers(api key) = %#v, want nil", got)
+	}
+
+	oauthAuth := &coreauth.Auth{
+		ID:       "oauth",
+		Provider: "codex",
+		Label:    "Team Codex",
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+	}
+	got := DeletedChannelIdentifiers(oauthAuth)
+	if len(got) != 2 || got[0] != "Team Codex" || got[1] != "codex@example.com" {
+		t.Fatalf("DeletedChannelIdentifiers(oauth) = %#v, want label and email", got)
+	}
+}
+
+func TestRemoveFromManagerDeletesByPathCandidate(t *testing.T) {
+	manager := coreauth.NewManager(&managerStore{}, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "account.json",
+		FileName: "account.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/auth/account.json",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	RemoveFromManager(context.Background(), manager, "/tmp/auth", "/tmp/auth/account.json")
+
+	if _, ok := manager.GetByID("account.json"); ok {
+		t.Fatal("expected auth to be removed")
+	}
+}


### PR DESCRIPTION
## Summary
- move auth manager lookup, delete, and deleted-channel identifier helpers into the authfiles package
- keep the management handler on thin compatibility wrappers while authfiles owns the manager-adapter behavior
- tighten the backend structure baseline for auth_files.go after the extraction

## Verification
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run 'Test.*AuthFile|Test.*PermissionProfiles|Test.*APIKeyEntries|TestRequest.*Token'\n- go test ./internal/management/... ./internal/api/handlers/management\n- python3 scripts/check-backend-structure.py\n- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json\n- git diff --check