### PR TITLE
refactor: move authfiles disk listing

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1531,
+        "max_lines": 1503,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1531 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1503 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -152,38 +152,10 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 
 // List auth files from disk when the auth manager is unavailable.
 func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
-	entries, err := os.ReadDir(h.cfg.AuthDir)
+	files, err := managementauthfiles.ListDiskEntries(h.cfg.AuthDir, time.Now())
 	if err != nil {
 		c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", err)})
 		return
-	}
-	files := make([]gin.H, 0)
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasSuffix(strings.ToLower(name), ".json") {
-			continue
-		}
-		if info, errInfo := e.Info(); errInfo == nil {
-			fileData := gin.H{"name": name, "size": info.Size(), "modtime": info.ModTime()}
-
-			// Read file to get type field
-			full := filepath.Join(h.cfg.AuthDir, name)
-			if data, errRead := os.ReadFile(full); errRead == nil {
-				typeValue := gjson.GetBytes(data, "type").String()
-				emailValue := gjson.GetBytes(data, "email").String()
-				fileData["type"] = typeValue
-				fileData["email"] = emailValue
-				metadata := make(map[string]any)
-				if errJSON := json.Unmarshal(data, &metadata); errJSON == nil {
-					managementauthfiles.AddSubscriptionFields(fileData, metadata, time.Now())
-				}
-			}
-
-			files = append(files, fileData)
-		}
 	}
 	c.JSON(200, gin.H{"files": files})
 }

--- a/internal/management/authfiles/disk.go
+++ b/internal/management/authfiles/disk.go
@@ -1,0 +1,51 @@
+package authfiles
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+func ListDiskEntries(authDir string, now time.Time) ([]map[string]any, error) {
+	entries, err := os.ReadDir(authDir)
+	if err != nil {
+		return nil, err
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	files := make([]map[string]any, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !IsJSONFileName(name) {
+			continue
+		}
+		info, errInfo := entry.Info()
+		if errInfo != nil {
+			continue
+		}
+		fileData := map[string]any{
+			"name":    name,
+			"size":    info.Size(),
+			"modtime": info.ModTime(),
+		}
+
+		full := FilePath(authDir, name)
+		if data, errRead := os.ReadFile(full); errRead == nil {
+			fileData["type"] = gjson.GetBytes(data, "type").String()
+			fileData["email"] = gjson.GetBytes(data, "email").String()
+			metadata := make(map[string]any)
+			if errJSON := json.Unmarshal(data, &metadata); errJSON == nil {
+				AddSubscriptionFields(fileData, metadata, now)
+			}
+		}
+
+		files = append(files, fileData)
+	}
+	return files, nil
+}

--- a/internal/management/authfiles/disk_test.go
+++ b/internal/management/authfiles/disk_test.go
@@ -1,0 +1,59 @@
+package authfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestListDiskEntriesBuildsPresentationFields(t *testing.T) {
+	authDir := t.TempDir()
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	startedAt := now.AddDate(0, -1, 0).Format(time.RFC3339)
+	if err := os.WriteFile(filepath.Join(authDir, "codex.json"), []byte(`{
+		"type": "codex",
+		"email": "user@example.com",
+		"subscription_started_at": "`+startedAt+`",
+		"subscription_period": "monthly"
+	}`), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "notes.txt"), []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write non-json file: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(authDir, "nested.json"), 0o755); err != nil {
+		t.Fatalf("make nested dir: %v", err)
+	}
+
+	got, err := ListDiskEntries(authDir, now)
+	if err != nil {
+		t.Fatalf("ListDiskEntries() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListDiskEntries() length = %d, want 1: %#v", len(got), got)
+	}
+	entry := got[0]
+	if entry["name"] != "codex.json" {
+		t.Fatalf("name = %#v, want codex.json", entry["name"])
+	}
+	if entry["type"] != "codex" {
+		t.Fatalf("type = %#v, want codex", entry["type"])
+	}
+	if entry["email"] != "user@example.com" {
+		t.Fatalf("email = %#v, want user@example.com", entry["email"])
+	}
+	if entry["subscription_period"] != "monthly" {
+		t.Fatalf("subscription_period = %#v, want monthly", entry["subscription_period"])
+	}
+	if _, ok := entry["subscription_expires_at"]; !ok {
+		t.Fatalf("subscription_expires_at missing from %#v", entry)
+	}
+}
+
+func TestListDiskEntriesReturnsReadDirError(t *testing.T) {
+	_, err := ListDiskEntries(filepath.Join(t.TempDir(), "missing"), time.Time{})
+	if err == nil {
+		t.Fatal("ListDiskEntries() error = nil, want error")
+	}
+}


### PR DESCRIPTION
Summary
- Move auth-file disk fallback listing into internal/management/authfiles.
- Keep the management handler as the HTTP response adapter for the fallback path.
- Tighten the backend structure baseline and allowlist after reducing the handler size.

Validation
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run "Test.*AuthFile|Test.*PermissionProfiles|Test.*APIKeyEntries"
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check