### PR TITLE
refactor: move authfiles status patch

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1503,
+        "max_lines": 1497,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1503 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1497 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -451,16 +451,10 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 		return
 	}
 
-	// Update disabled state
-	targetAuth.Disabled = *req.Disabled
-	if *req.Disabled {
-		targetAuth.Status = coreauth.StatusDisabled
-		targetAuth.StatusMessage = "disabled via management API"
-	} else {
-		targetAuth.Status = coreauth.StatusActive
-		targetAuth.StatusMessage = ""
+	if errPatch := managementauthfiles.ApplyStatusPatch(targetAuth, *req.Disabled, time.Now()); errPatch != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errPatch.Error()})
+		return
 	}
-	targetAuth.UpdatedAt = time.Now()
 
 	if _, err := h.authManager.Update(ctx, targetAuth); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update auth: %v", err)})

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -35,6 +35,25 @@ type FieldPatchResult struct {
 	NewChannelLabel       string
 }
 
+func ApplyStatusPatch(auth *coreauth.Auth, disabled bool, now time.Time) error {
+	if auth == nil {
+		return fmt.Errorf("auth file not found")
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	auth.Disabled = disabled
+	if disabled {
+		auth.Status = coreauth.StatusDisabled
+		auth.StatusMessage = "disabled via management API"
+	} else {
+		auth.Status = coreauth.StatusActive
+		auth.StatusMessage = ""
+	}
+	auth.UpdatedAt = now
+	return nil
+}
+
 // ApplyFieldPatch applies editable auth-file field changes and returns the
 // channel rename side effect that the transport layer must coordinate.
 func ApplyFieldPatch(auth *coreauth.Auth, patch FieldPatch, opts FieldPatchOptions) (FieldPatchResult, error) {

--- a/internal/management/authfiles/patch_test.go
+++ b/internal/management/authfiles/patch_test.go
@@ -8,6 +8,60 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
+func TestApplyStatusPatchDisablesAuth(t *testing.T) {
+	now := time.Date(2026, 6, 6, 10, 0, 0, 0, time.UTC)
+	auth := &coreauth.Auth{ID: "codex", Status: coreauth.StatusActive}
+
+	if err := ApplyStatusPatch(auth, true, now); err != nil {
+		t.Fatalf("ApplyStatusPatch() error = %v", err)
+	}
+	if !auth.Disabled {
+		t.Fatal("Disabled = false, want true")
+	}
+	if auth.Status != coreauth.StatusDisabled {
+		t.Fatalf("Status = %q, want %q", auth.Status, coreauth.StatusDisabled)
+	}
+	if auth.StatusMessage != "disabled via management API" {
+		t.Fatalf("StatusMessage = %q, want disabled message", auth.StatusMessage)
+	}
+	if !auth.UpdatedAt.Equal(now) {
+		t.Fatalf("UpdatedAt = %v, want %v", auth.UpdatedAt, now)
+	}
+}
+
+func TestApplyStatusPatchEnablesAuth(t *testing.T) {
+	now := time.Date(2026, 6, 6, 11, 0, 0, 0, time.UTC)
+	auth := &coreauth.Auth{
+		ID:            "codex",
+		Disabled:      true,
+		Status:        coreauth.StatusDisabled,
+		StatusMessage: "disabled via management API",
+	}
+
+	if err := ApplyStatusPatch(auth, false, now); err != nil {
+		t.Fatalf("ApplyStatusPatch() error = %v", err)
+	}
+	if auth.Disabled {
+		t.Fatal("Disabled = true, want false")
+	}
+	if auth.Status != coreauth.StatusActive {
+		t.Fatalf("Status = %q, want %q", auth.Status, coreauth.StatusActive)
+	}
+	if auth.StatusMessage != "" {
+		t.Fatalf("StatusMessage = %q, want empty", auth.StatusMessage)
+	}
+	if !auth.UpdatedAt.Equal(now) {
+		t.Fatalf("UpdatedAt = %v, want %v", auth.UpdatedAt, now)
+	}
+}
+
+func TestApplyStatusPatchRejectsMissingAuth(t *testing.T) {
+	err := ApplyStatusPatch(nil, true, time.Time{})
+	if err == nil || err.Error() != "auth file not found" {
+		t.Fatalf("ApplyStatusPatch() error = %v, want not found", err)
+	}
+}
+
 func TestApplyFieldPatchUpdatesOAuthLabel(t *testing.T) {
 	now := time.Date(2026, 6, 6, 10, 0, 0, 0, time.UTC)
 	auth := &coreauth.Auth{


### PR DESCRIPTION
Summary
- Move auth-file enable/disable state mutation into internal/management/authfiles.
- Keep the management handler responsible for request binding and HTTP responses.
- Add authfiles unit coverage for status patch behavior and tighten the structure baseline.

Validation
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run "TestPatchAuthFile|Test.*AuthFile|Test.*PermissionProfiles|Test.*APIKeyEntries"
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check