### PR TITLE
refactor: move authfiles register service

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1497,
+        "max_lines": 1444,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1497 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1444 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -351,70 +350,18 @@ func deletedAuthChannelIdentifiers(auth *coreauth.Auth) []string {
 	return managementauthfiles.DeletedChannelIdentifiers(auth)
 }
 
-func (h *Handler) authIDForPath(path string) string {
-	if h == nil || h.cfg == nil {
-		return managementauthfiles.AuthIDForPath("", path)
-	}
-	return managementauthfiles.AuthIDForPath(h.cfg.AuthDir, path)
-}
-
 func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []byte) error {
 	if h.authManager == nil {
 		return nil
-	}
-	if path == "" {
-		return fmt.Errorf("auth path is empty")
-	}
-	if data == nil {
-		var err error
-		data, err = os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to read auth file: %w", err)
-		}
-	}
-	metadata := make(map[string]any)
-	if err := json.Unmarshal(data, &metadata); err != nil {
-		return fmt.Errorf("invalid auth file: %w", err)
-	}
-	provider := sdkAuth.InferAuthProvider(metadata)
-	normalized := sdkAuth.NormalizeAuthMetadata(metadata, provider)
-	if !reflect.DeepEqual(metadata, normalized) {
-		metadata = normalized
-		normalizedData, errMarshal := json.Marshal(metadata)
-		if errMarshal != nil {
-			return fmt.Errorf("failed to normalize auth file: %w", errMarshal)
-		}
-		if errWrite := os.WriteFile(path, normalizedData, 0o600); errWrite != nil {
-			return fmt.Errorf("failed to write normalized auth file: %w", errWrite)
-		}
-	}
-	authID := h.authIDForPath(path)
-	if authID == "" {
-		authID = path
 	}
 	authDir := ""
 	if h.cfg != nil {
 		authDir = h.cfg.AuthDir
 	}
-	if existing, ok := h.authManager.GetByID(authID); ok {
-		auth := managementauthfiles.BuildRecord(managementauthfiles.RecordOptions{
-			AuthDir:  authDir,
-			Path:     path,
-			Provider: provider,
-			Metadata: metadata,
-			Existing: existing,
-		})
-		_, err := h.authManager.Update(ctx, auth)
-		return err
-	}
-	auth := managementauthfiles.BuildRecord(managementauthfiles.RecordOptions{
-		AuthDir:  authDir,
-		Path:     path,
-		Provider: provider,
-		Metadata: metadata,
-	})
-	_, err := h.authManager.Register(ctx, auth)
-	return err
+	return managementauthfiles.Registrar{
+		Manager: h.authManager,
+		AuthDir: authDir,
+	}.RegisterFile(ctx, path, data)
 }
 
 // PatchAuthFileStatus toggles the disabled state of an auth file

--- a/internal/api/handlers/management/auth_files_upload_test.go
+++ b/internal/api/handlers/management/auth_files_upload_test.go
@@ -370,9 +370,6 @@ func TestRegisterAuthFromFileUsesRelativeIDForRelativeAuthDir(t *testing.T) {
 	if err := os.WriteFile(absPath, data, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if got := h.authIDForPath(absPath); got != fileName {
-		t.Fatalf("authIDForPath(%q) = %q, want %q", absPath, got, fileName)
-	}
 
 	watcherID := fileName
 	if _, err := manager.Register(context.Background(), &coreauth.Auth{

--- a/internal/management/authfiles/register.go
+++ b/internal/management/authfiles/register.go
@@ -1,0 +1,81 @@
+package authfiles
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type Registrar struct {
+	Manager *coreauth.Manager
+	AuthDir string
+	Now     time.Time
+}
+
+func (r Registrar) RegisterFile(ctx context.Context, path string, data []byte) error {
+	if r.Manager == nil {
+		return nil
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("auth path is empty")
+	}
+	if data == nil {
+		var err error
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read auth file: %w", err)
+		}
+	}
+	metadata, provider, err := r.normalizeFile(path, data)
+	if err != nil {
+		return err
+	}
+	authID := AuthIDForPath(r.AuthDir, path)
+	if authID == "" {
+		authID = path
+	}
+	opts := RecordOptions{
+		AuthDir:  r.AuthDir,
+		Path:     path,
+		Provider: provider,
+		Metadata: metadata,
+		Now:      r.Now,
+	}
+	if existing, ok := r.Manager.GetByID(authID); ok {
+		opts.Existing = existing
+		auth := BuildRecord(opts)
+		_, err := r.Manager.Update(ctx, auth)
+		return err
+	}
+	auth := BuildRecord(opts)
+	_, err = r.Manager.Register(ctx, auth)
+	return err
+}
+
+func (r Registrar) normalizeFile(path string, data []byte) (map[string]any, string, error) {
+	metadata := make(map[string]any)
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, "", fmt.Errorf("invalid auth file: %w", err)
+	}
+	provider := sdkAuth.InferAuthProvider(metadata)
+	normalized := sdkAuth.NormalizeAuthMetadata(metadata, provider)
+	if reflect.DeepEqual(metadata, normalized) {
+		return metadata, provider, nil
+	}
+	normalizedData, errMarshal := json.Marshal(normalized)
+	if errMarshal != nil {
+		return nil, "", fmt.Errorf("failed to normalize auth file: %w", errMarshal)
+	}
+	if errWrite := os.WriteFile(path, normalizedData, 0o600); errWrite != nil {
+		return nil, "", fmt.Errorf("failed to write normalized auth file: %w", errWrite)
+	}
+	return normalized, provider, nil
+}

--- a/internal/management/authfiles/register_test.go
+++ b/internal/management/authfiles/register_test.go
@@ -1,0 +1,176 @@
+package authfiles
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestRegistrarRegisterFileAddsAuthRecord(t *testing.T) {
+	authDir := t.TempDir()
+	manager := coreauth.NewManager(nil, nil, nil)
+	path := filepath.Join(authDir, "claude-pro.json")
+	data := []byte(`{"type":"claude","email":"pro@example.com","prefix":"team-a","proxy_url":"http://auth-proxy.example","proxy_id":"premium-egress"}`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err := Registrar{Manager: manager, AuthDir: authDir}.RegisterFile(context.Background(), path, data)
+	if err != nil {
+		t.Fatalf("RegisterFile() error = %v", err)
+	}
+	auth, ok := manager.GetByID("claude-pro.json")
+	if !ok || auth == nil {
+		t.Fatal("registered auth not found")
+	}
+	if auth.Provider != "claude" || auth.Label != "pro@example.com" {
+		t.Fatalf("provider/label = %q/%q", auth.Provider, auth.Label)
+	}
+	if auth.Prefix != "team-a" || auth.ProxyURL != "http://auth-proxy.example" || auth.ProxyID != "premium-egress" {
+		t.Fatalf("routing fields = %q/%q/%q", auth.Prefix, auth.ProxyURL, auth.ProxyID)
+	}
+}
+
+func TestRegistrarRegisterFileUpdatesExistingRelativeAuth(t *testing.T) {
+	rootDir := t.TempDir()
+	authDir := filepath.Join(rootDir, "auths")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	previousWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(previousWD)
+	})
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	fileName := "codex.json"
+	path := filepath.Join(authDir, fileName)
+	data := []byte(`{"type":"codex","email":"new@example.com"}`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	createdAt := time.Date(2026, 1, 2, 3, 4, 0, 0, time.UTC)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:        fileName,
+		FileName:  fileName,
+		Provider:  "codex",
+		Label:     "old@example.com",
+		Status:    coreauth.StatusActive,
+		CreatedAt: createdAt,
+		Attributes: map[string]string{
+			"path": path,
+		},
+		Metadata: map[string]any{
+			"type":  "codex",
+			"email": "old@example.com",
+		},
+	}); err != nil {
+		t.Fatalf("Register existing auth: %v", err)
+	}
+
+	err = Registrar{Manager: manager, AuthDir: "auths"}.RegisterFile(context.Background(), path, data)
+	if err != nil {
+		t.Fatalf("RegisterFile() error = %v", err)
+	}
+	auths := manager.List()
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	auth := auths[0]
+	if auth.ID != fileName || auth.Label != "new@example.com" {
+		t.Fatalf("updated auth = id %q label %q", auth.ID, auth.Label)
+	}
+	if !auth.CreatedAt.Equal(createdAt) {
+		t.Fatalf("CreatedAt = %v, want preserved %v", auth.CreatedAt, createdAt)
+	}
+}
+
+func TestRegistrarRegisterFileNormalizesOpenAIBundle(t *testing.T) {
+	authDir := t.TempDir()
+	manager := coreauth.NewManager(nil, nil, nil)
+	accountID := "acct-bundle"
+	issuedAt := int64(1_779_210_280)
+	expiresAt := int64(1_780_074_280)
+	accessToken := makeRegisterJWT(t, map[string]any{
+		"iat": issuedAt,
+		"exp": expiresAt,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": accountID,
+			"chatgpt_plan_type":  "plus",
+		},
+	})
+	idToken := makeRegisterJWT(t, map[string]any{
+		"email": "bundle@example.com",
+		"iat":   issuedAt,
+		"exp":   expiresAt,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": accountID,
+			"chatgpt_plan_type":  "plus",
+		},
+	})
+	path := filepath.Join(authDir, "openai-bundle.json")
+	data, err := json.Marshal(map[string]any{
+		"version":              1,
+		"platform":             "openai",
+		"account_claims_email": "bundle@example.com",
+		"access_token":         accessToken,
+		"id_token":             idToken,
+		"refresh_token":        "",
+		"client_id":            "app_test",
+		"chatgpt_account_id":   accountID,
+		"disabled":             false,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err = Registrar{Manager: manager, AuthDir: authDir}.RegisterFile(context.Background(), path, data)
+	if err != nil {
+		t.Fatalf("RegisterFile() error = %v", err)
+	}
+	auth, ok := manager.GetByID("openai-bundle.json")
+	if !ok || auth == nil {
+		t.Fatal("registered auth not found")
+	}
+	if auth.Provider != "codex" || auth.Metadata["type"] != "codex" {
+		t.Fatalf("provider/type = %q/%#v, want codex", auth.Provider, auth.Metadata["type"])
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var persisted map[string]any
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("Unmarshal persisted: %v", err)
+	}
+	if persisted["account_id"] != accountID || persisted["type"] != "codex" {
+		t.Fatalf("persisted normalized fields = %#v", persisted)
+	}
+}
+
+func makeRegisterJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	encode := func(v any) string {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal jwt part: %v", err)
+		}
+		return base64.RawURLEncoding.EncodeToString(raw)
+	}
+	return encode(map[string]any{"alg": "none", "typ": "JWT"}) + "." + encode(claims) + ".sig"
+}


### PR DESCRIPTION
Summary
- Move auth-file JSON normalization and manager register/update flow into internal/management/authfiles.
- Keep the management handler as a thin upload/import adapter.
- Add use-case unit coverage for register, update, and normalized file persistence behavior.
- Tighten the backend structure baseline after reducing the handler size.

Validation
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run "TestUploadAuthFile|TestRegisterAuthFromFile|TestImportVertexCredential|Test.*AuthFile|Test.*PermissionProfiles|Test.*APIKeyEntries"
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check