### PR TITLE
refactor: move authfiles model entries

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1444,
+        "max_lines": 1408,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1444 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1408 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -109,44 +109,8 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 		return
 	}
 
-	// Try to find auth ID via authManager
-	var authID string
-	if h.authManager != nil {
-		auths := h.authManager.List()
-		for _, auth := range auths {
-			if auth.FileName == name || auth.ID == name {
-				authID = auth.ID
-				break
-			}
-		}
-	}
-
-	if authID == "" {
-		authID = name // fallback to filename as ID
-	}
-
-	// Get models from registry
-	reg := registry.GetGlobalRegistry()
-	models := reg.GetModelsForClient(authID)
-
-	result := make([]gin.H, 0, len(models))
-	for _, m := range models {
-		entry := gin.H{
-			"id": m.ID,
-		}
-		if m.DisplayName != "" {
-			entry["display_name"] = m.DisplayName
-		}
-		if m.Type != "" {
-			entry["type"] = m.Type
-		}
-		if m.OwnedBy != "" {
-			entry["owned_by"] = m.OwnedBy
-		}
-		result = append(result, entry)
-	}
-
-	c.JSON(200, gin.H{"models": result})
+	models := managementauthfiles.ListModelEntries(h.authManager, registry.GetGlobalRegistry(), name)
+	c.JSON(200, gin.H{"models": models})
 }
 
 // List auth files from disk when the auth manager is unavailable.

--- a/internal/management/authfiles/models.go
+++ b/internal/management/authfiles/models.go
@@ -1,0 +1,58 @@
+package authfiles
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type ModelSource interface {
+	GetModelsForClient(clientID string) []*registry.ModelInfo
+}
+
+func ModelLookupAuthID(manager *coreauth.Manager, name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	if manager != nil {
+		for _, auth := range manager.List() {
+			if auth == nil {
+				continue
+			}
+			if auth.FileName == name || auth.ID == name {
+				return auth.ID
+			}
+		}
+	}
+	return name
+}
+
+func ListModelEntries(manager *coreauth.Manager, source ModelSource, name string) []map[string]any {
+	if source == nil {
+		return nil
+	}
+	authID := ModelLookupAuthID(manager, name)
+	models := source.GetModelsForClient(authID)
+	result := make([]map[string]any, 0, len(models))
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		entry := map[string]any{
+			"id": model.ID,
+		}
+		if model.DisplayName != "" {
+			entry["display_name"] = model.DisplayName
+		}
+		if model.Type != "" {
+			entry["type"] = model.Type
+		}
+		if model.OwnedBy != "" {
+			entry["owned_by"] = model.OwnedBy
+		}
+		result = append(result, entry)
+	}
+	return result
+}

--- a/internal/management/authfiles/models_test.go
+++ b/internal/management/authfiles/models_test.go
@@ -1,0 +1,77 @@
+package authfiles
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type modelSourceStub struct {
+	clientID string
+	models   []*registry.ModelInfo
+}
+
+func (s *modelSourceStub) GetModelsForClient(clientID string) []*registry.ModelInfo {
+	s.clientID = clientID
+	return s.models
+}
+
+func TestModelLookupAuthIDUsesMatchingAuthID(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "auth-id",
+		FileName: "codex.json",
+		Provider: "codex",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if got := ModelLookupAuthID(manager, "codex.json"); got != "auth-id" {
+		t.Fatalf("ModelLookupAuthID() = %q, want auth-id", got)
+	}
+	if got := ModelLookupAuthID(manager, "missing.json"); got != "missing.json" {
+		t.Fatalf("ModelLookupAuthID() fallback = %q, want missing.json", got)
+	}
+}
+
+func TestListModelEntriesBuildsPublicPayload(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "auth-id",
+		FileName: "codex.json",
+		Provider: "codex",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	source := &modelSourceStub{
+		models: []*registry.ModelInfo{
+			{
+				ID:          "gpt-test",
+				DisplayName: "GPT Test",
+				Type:        "codex",
+				OwnedBy:     "openai",
+			},
+			nil,
+			{ID: "minimal"},
+		},
+	}
+
+	got := ListModelEntries(manager, source, "codex.json")
+	if source.clientID != "auth-id" {
+		t.Fatalf("source clientID = %q, want auth-id", source.clientID)
+	}
+	if len(got) != 2 {
+		t.Fatalf("entries length = %d, want 2: %#v", len(got), got)
+	}
+	if got[0]["id"] != "gpt-test" || got[0]["display_name"] != "GPT Test" || got[0]["type"] != "codex" || got[0]["owned_by"] != "openai" {
+		t.Fatalf("entry[0] = %#v, want full public payload", got[0])
+	}
+	if _, ok := got[1]["display_name"]; ok {
+		t.Fatalf("minimal entry has display_name: %#v", got[1])
+	}
+	if got[1]["id"] != "minimal" {
+		t.Fatalf("minimal id = %#v, want minimal", got[1]["id"])
+	}
+}


### PR DESCRIPTION
Summary
- Move auth-file model lookup and public model entry construction into internal/management/authfiles.
- Keep the management handler focused on query validation and response writing.
- Add authfiles unit coverage for auth ID lookup and model payload shaping.
- Tighten the backend structure baseline after reducing the handler size.

Validation
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run "Test.*AuthFile|Test.*Models|Test.*PermissionProfiles|Test.*APIKeyEntries"
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check