### PR TITLE
refactor: move authfiles manager listing

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1408,
+        "max_lines": 1388,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1408 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1388 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -86,17 +85,10 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 		h.listAuthFilesFromDisk(c)
 		return
 	}
-	auths := h.authManager.List()
-	files := make([]gin.H, 0, len(auths))
-	for _, auth := range auths {
-		if entry := h.buildAuthFileEntry(auth); entry != nil {
-			files = append(files, entry)
-		}
-	}
-	sort.Slice(files, func(i, j int) bool {
-		nameI, _ := files[i]["name"].(string)
-		nameJ, _ := files[j]["name"].(string)
-		return strings.ToLower(nameI) < strings.ToLower(nameJ)
+	files := managementauthfiles.ListEntries(h.authManager.List(), managementauthfiles.EntryOptions{
+		OnStatError: func(path string, err error) {
+			log.WithError(err).Warnf("failed to stat auth file %s", path)
+		},
 	})
 	c.JSON(200, gin.H{"files": files})
 }
@@ -121,18 +113,6 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 		return
 	}
 	c.JSON(200, gin.H{"files": files})
-}
-
-func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
-	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{
-		OnStatError: func(path string, err error) {
-			log.WithError(err).Warnf("failed to stat auth file %s", path)
-		},
-	})
-	if entry == nil {
-		return nil
-	}
-	return gin.H(entry)
 }
 
 // Download single auth file by name

--- a/internal/api/handlers/management/auth_files_patch_test.go
+++ b/internal/api/handlers/management/auth_files_patch_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -328,7 +329,7 @@ func TestBuildAuthFileEntryIncludesDefaultAndDisplayTags(t *testing.T) {
 		},
 	}
 
-	entry := (&Handler{}).buildAuthFileEntry(auth)
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{})
 	if entry == nil {
 		t.Fatal("expected auth file entry")
 	}
@@ -363,7 +364,7 @@ func TestBuildAuthFileEntryHonorsExplicitEmptyDisplayTags(t *testing.T) {
 		},
 	}
 
-	entry := (&Handler{}).buildAuthFileEntry(auth)
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{})
 	if entry == nil {
 		t.Fatal("expected auth file entry")
 	}
@@ -390,7 +391,7 @@ func TestBuildAuthFileEntryReplacesStaleExplicitPlanDisplayTag(t *testing.T) {
 		},
 	}
 
-	entry := (&Handler{}).buildAuthFileEntry(auth)
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{})
 	if entry == nil {
 		t.Fatal("expected auth file entry")
 	}
@@ -430,7 +431,7 @@ func TestBuildAuthFileEntryExposesMetadataPlanTypeBeforeIDTokenClaim(t *testing.
 		},
 	}
 
-	entry := (&Handler{}).buildAuthFileEntry(auth)
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{})
 	if entry == nil {
 		t.Fatal("expected auth file entry")
 	}
@@ -479,7 +480,7 @@ func TestBuildAuthFileEntryIncludesActiveRestrictions(t *testing.T) {
 		},
 	}
 
-	entry := (&Handler{}).buildAuthFileEntry(auth)
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{})
 	if entry == nil {
 		t.Fatal("expected auth file entry")
 	}
@@ -547,7 +548,7 @@ func TestBuildAuthFileEntryDedupesDuplicateRestrictions(t *testing.T) {
 		},
 	}
 
-	entry := (&Handler{}).buildAuthFileEntry(auth)
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{})
 	if entry == nil {
 		t.Fatal("expected auth file entry")
 	}
@@ -584,7 +585,7 @@ func TestBuildAuthFileEntryIncludesSubscriptionExpiration(t *testing.T) {
 		},
 	}
 
-	entry := (&Handler{}).buildAuthFileEntry(auth)
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{})
 	if entry == nil {
 		t.Fatal("expected auth file entry")
 	}
@@ -617,7 +618,7 @@ func TestBuildAuthFileEntryIncludesSubscriptionStartAndPeriod(t *testing.T) {
 		},
 	}
 
-	entry := (&Handler{}).buildAuthFileEntry(auth)
+	entry := managementauthfiles.BuildEntry(auth, managementauthfiles.EntryOptions{})
 	if entry == nil {
 		t.Fatal("expected auth file entry")
 	}

--- a/internal/api/handlers/management/dashboard_summary.go
+++ b/internal/api/handlers/management/dashboard_summary.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	log "github.com/sirupsen/logrus"
 )
 
 // GetDashboardSummary is a lightweight endpoint that returns only the
@@ -36,11 +38,11 @@ func (h *Handler) GetDashboardSummary(c *gin.Context) {
 	apiKeyCount = len(usage.ListAPIKeys())
 
 	if h.authManager != nil {
-		for _, auth := range h.authManager.List() {
-			if entry := h.buildAuthFileEntry(auth); entry != nil {
-				authFileCount++
-			}
-		}
+		authFileCount = len(managementauthfiles.ListEntries(h.authManager.List(), managementauthfiles.EntryOptions{
+			OnStatError: func(path string, err error) {
+				log.WithError(err).Warnf("failed to stat auth file %s", path)
+			},
+		}))
 	}
 
 	providerTotal := geminiCount + claudeCount + codexCount + vertexCount + openaiCount

--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -2,6 +2,7 @@ package authfiles
 
 import (
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -12,6 +13,21 @@ type EntryOptions struct {
 	Now         time.Time
 	Stat        func(string) (os.FileInfo, error)
 	OnStatError func(string, error)
+}
+
+func ListEntries(auths []*coreauth.Auth, opts EntryOptions) []map[string]any {
+	files := make([]map[string]any, 0, len(auths))
+	for _, auth := range auths {
+		if entry := BuildEntry(auth, opts); entry != nil {
+			files = append(files, entry)
+		}
+	}
+	sort.Slice(files, func(i, j int) bool {
+		nameI, _ := files[i]["name"].(string)
+		nameJ, _ := files[j]["name"].(string)
+		return strings.ToLower(nameI) < strings.ToLower(nameJ)
+	})
+	return files
 }
 
 // BuildEntry returns the public management auth-file entry for an auth record.

--- a/internal/management/authfiles/entry_test.go
+++ b/internal/management/authfiles/entry_test.go
@@ -16,6 +16,40 @@ func TestBuildEntryRequiresPathForNonRuntimeAuth(t *testing.T) {
 	}
 }
 
+func TestListEntriesBuildsAndSortsAuthEntries(t *testing.T) {
+	auths := []*coreauth.Auth{
+		{
+			ID:       "zeta",
+			FileName: "zeta.json",
+			Provider: "codex",
+			Attributes: map[string]string{
+				"runtime_only": "true",
+			},
+		},
+		nil,
+		{
+			ID:       "alpha",
+			FileName: "alpha.json",
+			Provider: "claude",
+			Attributes: map[string]string{
+				"runtime_only": "true",
+			},
+		},
+		{
+			ID:       "hidden",
+			Provider: "codex",
+		},
+	}
+
+	got := ListEntries(auths, EntryOptions{})
+	if len(got) != 2 {
+		t.Fatalf("ListEntries() length = %d, want 2: %#v", len(got), got)
+	}
+	if got[0]["name"] != "alpha.json" || got[1]["name"] != "zeta.json" {
+		t.Fatalf("sorted names = %#v, want alpha then zeta", []any{got[0]["name"], got[1]["name"]})
+	}
+}
+
 func TestBuildEntryAllowsRuntimeOnlyAuthWithoutPath(t *testing.T) {
 	auth := &coreauth.Auth{
 		ID:       "runtime",


### PR DESCRIPTION
Summary
- Move manager-backed auth-file list entry construction and sorting into internal/management/authfiles.
- Update dashboard summary and tests to use the authfiles presenter directly.
- Remove the handler-only buildAuthFileEntry receiver method and tighten the structure baseline.

Validation
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run "Test.*AuthFile|Test.*Models|Test.*PermissionProfiles|Test.*APIKeyEntries|Test.*Dashboard"
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check