### PR TITLE
refactor: move authfiles delete service

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1388,
+        "max_lines": 1340,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1388 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1340 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -223,37 +223,19 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		return
 	}
 	ctx := c.Request.Context()
+	service := managementauthfiles.DeleteService{
+		AuthDir:        h.cfg.AuthDir,
+		Manager:        h.authManager,
+		Repository:     h.authFileRepository(),
+		RemoveChannels: h.removeChannelReferences,
+	}
 	if managementauthfiles.IsDeleteAllValue(c.Query("all")) {
-		entries, err := os.ReadDir(h.cfg.AuthDir)
+		result, err := service.DeleteAll(ctx)
 		if err != nil {
-			c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", err)})
+			c.JSON(500, gin.H{"error": err.Error()})
 			return
 		}
-		deleted := 0
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			name := e.Name()
-			if !managementauthfiles.IsJSONFileName(name) {
-				continue
-			}
-			full := managementauthfiles.FilePath(h.cfg.AuthDir, name)
-			deletedChannels := deletedAuthChannelIdentifiers(h.findAuthByNameOrID(name))
-			if err = os.Remove(full); err == nil {
-				if errDel := h.deleteTokenRecord(ctx, full); errDel != nil {
-					c.JSON(500, gin.H{"error": errDel.Error()})
-					return
-				}
-				deleted++
-				h.removeAuth(ctx, full)
-				if errCleanup := h.removeChannelReferences(deletedChannels); errCleanup != nil {
-					c.JSON(500, gin.H{"error": errCleanup.Error()})
-					return
-				}
-			}
-		}
-		c.JSON(200, gin.H{"status": "ok", "deleted": deleted})
+		c.JSON(200, gin.H{"status": "ok", "deleted": result.Deleted})
 		return
 	}
 	name, errValidate := managementauthfiles.ValidateFileQueryName(c.Query("name"), false)
@@ -261,23 +243,12 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		c.JSON(400, gin.H{"error": errValidate.Error()})
 		return
 	}
-	full := managementauthfiles.FilePath(h.cfg.AuthDir, name)
-	deletedChannels := deletedAuthChannelIdentifiers(h.findAuthByNameOrID(name))
-	if err := os.Remove(full); err != nil {
-		if os.IsNotExist(err) {
+	if _, err := service.DeleteOne(ctx, name); err != nil {
+		if errors.Is(err, managementauthfiles.ErrAuthFileNotFound) {
 			c.JSON(404, gin.H{"error": "file not found"})
 		} else {
-			c.JSON(500, gin.H{"error": fmt.Sprintf("failed to remove file: %v", err)})
+			c.JSON(500, gin.H{"error": err.Error()})
 		}
-		return
-	}
-	if err := h.deleteTokenRecord(ctx, full); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
-		return
-	}
-	h.removeAuth(ctx, full)
-	if err := h.removeChannelReferences(deletedChannels); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(200, gin.H{"status": "ok"})
@@ -288,10 +259,6 @@ func (h *Handler) findAuthByNameOrID(name string) *coreauth.Auth {
 		return nil
 	}
 	return managementauthfiles.FindByNameOrID(h.authManager, name)
-}
-
-func deletedAuthChannelIdentifiers(auth *coreauth.Auth) []string {
-	return managementauthfiles.DeletedChannelIdentifiers(auth)
 }
 
 func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []byte) error {
@@ -408,21 +375,6 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
-}
-
-func (h *Handler) removeAuth(ctx context.Context, id string) {
-	if h == nil || h.authManager == nil {
-		return
-	}
-	authDir := ""
-	if h.cfg != nil {
-		authDir = h.cfg.AuthDir
-	}
-	managementauthfiles.RemoveFromManager(ctx, h.authManager, authDir, id)
-}
-
-func (h *Handler) deleteTokenRecord(ctx context.Context, path string) error {
-	return h.authFileRepository().Delete(ctx, path)
 }
 
 func (h *Handler) authFileRepository() managementauthfiles.Repository {

--- a/internal/management/authfiles/delete.go
+++ b/internal/management/authfiles/delete.go
@@ -1,0 +1,80 @@
+package authfiles
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+var ErrAuthFileNotFound = errors.New("auth file not found")
+
+type DeleteService struct {
+	AuthDir        string
+	Manager        *coreauth.Manager
+	Repository     Repository
+	RemoveChannels func([]string) error
+}
+
+type DeleteResult struct {
+	Deleted int
+}
+
+func (s DeleteService) DeleteAll(ctx context.Context) (DeleteResult, error) {
+	entries, err := os.ReadDir(s.AuthDir)
+	if err != nil {
+		return DeleteResult{}, fmt.Errorf("failed to read auth dir: %w", err)
+	}
+	result := DeleteResult{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !IsJSONFileName(name) {
+			continue
+		}
+		full := FilePath(s.AuthDir, name)
+		deletedChannels := DeletedChannelIdentifiers(FindByNameOrID(s.Manager, name))
+		if errRemove := os.Remove(full); errRemove != nil {
+			continue
+		}
+		if errDelete := s.Repository.Delete(ctx, full); errDelete != nil {
+			return result, errDelete
+		}
+		result.Deleted++
+		RemoveFromManager(ctx, s.Manager, s.AuthDir, full)
+		if errCleanup := s.removeChannelReferences(deletedChannels); errCleanup != nil {
+			return result, errCleanup
+		}
+	}
+	return result, nil
+}
+
+func (s DeleteService) DeleteOne(ctx context.Context, name string) (DeleteResult, error) {
+	full := FilePath(s.AuthDir, name)
+	deletedChannels := DeletedChannelIdentifiers(FindByNameOrID(s.Manager, name))
+	if err := os.Remove(full); err != nil {
+		if os.IsNotExist(err) {
+			return DeleteResult{}, ErrAuthFileNotFound
+		}
+		return DeleteResult{}, fmt.Errorf("failed to remove file: %w", err)
+	}
+	if err := s.Repository.Delete(ctx, full); err != nil {
+		return DeleteResult{}, err
+	}
+	RemoveFromManager(ctx, s.Manager, s.AuthDir, full)
+	if err := s.removeChannelReferences(deletedChannels); err != nil {
+		return DeleteResult{}, err
+	}
+	return DeleteResult{Deleted: 1}, nil
+}
+
+func (s DeleteService) removeChannelReferences(channels []string) error {
+	if len(channels) == 0 || s.RemoveChannels == nil {
+		return nil
+	}
+	return s.RemoveChannels(channels)
+}

--- a/internal/management/authfiles/delete_test.go
+++ b/internal/management/authfiles/delete_test.go
@@ -1,0 +1,112 @@
+package authfiles
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestDeleteServiceDeleteOneRemovesFileManagerTokenAndChannels(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "codex.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	store := &managerStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex.json",
+		FileName: "codex.json",
+		Provider: "codex",
+		Label:    "Team Codex",
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+		Attributes: map[string]string{
+			"path": path,
+		},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	var removedChannels []string
+
+	result, err := DeleteService{
+		AuthDir:    authDir,
+		Manager:    manager,
+		Repository: Repository{Store: store, BaseDir: authDir},
+		RemoveChannels: func(channels []string) error {
+			removedChannels = append([]string(nil), channels...)
+			return nil
+		},
+	}.DeleteOne(context.Background(), "codex.json")
+	if err != nil {
+		t.Fatalf("DeleteOne() error = %v", err)
+	}
+	if result.Deleted != 1 {
+		t.Fatalf("Deleted = %d, want 1", result.Deleted)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("deleted file still exists or unexpected stat error: %v", err)
+	}
+	if _, ok := manager.GetByID("codex.json"); ok {
+		t.Fatal("auth still registered")
+	}
+	if len(removedChannels) != 2 || removedChannels[0] != "Team Codex" || removedChannels[1] != "codex@example.com" {
+		t.Fatalf("removed channels = %#v, want label and email", removedChannels)
+	}
+}
+
+func TestDeleteServiceDeleteOneMissingFile(t *testing.T) {
+	_, err := DeleteService{AuthDir: t.TempDir()}.DeleteOne(context.Background(), "missing.json")
+	if !errors.Is(err, ErrAuthFileNotFound) {
+		t.Fatalf("DeleteOne() error = %v, want ErrAuthFileNotFound", err)
+	}
+}
+
+func TestDeleteServiceDeleteAllSkipsNonJSONAndCountsDeleted(t *testing.T) {
+	authDir := t.TempDir()
+	for _, name := range []string{"a.json", "b.json", "notes.txt"} {
+		if err := os.WriteFile(filepath.Join(authDir, name), []byte(`{}`), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s): %v", name, err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(authDir, "nested.json"), 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	store := &managerStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	for _, name := range []string{"a.json", "b.json"} {
+		if _, err := manager.Register(context.Background(), &coreauth.Auth{
+			ID:       name,
+			FileName: name,
+			Provider: "codex",
+			Attributes: map[string]string{
+				"path": filepath.Join(authDir, name),
+			},
+		}); err != nil {
+			t.Fatalf("Register(%s): %v", name, err)
+		}
+	}
+
+	result, err := DeleteService{
+		AuthDir:    authDir,
+		Manager:    manager,
+		Repository: Repository{Store: store, BaseDir: authDir},
+	}.DeleteAll(context.Background())
+	if err != nil {
+		t.Fatalf("DeleteAll() error = %v", err)
+	}
+	if result.Deleted != 2 {
+		t.Fatalf("Deleted = %d, want 2", result.Deleted)
+	}
+	if _, err := os.Stat(filepath.Join(authDir, "notes.txt")); err != nil {
+		t.Fatalf("notes.txt should remain: %v", err)
+	}
+	if _, ok := manager.GetByID("a.json"); ok {
+		t.Fatal("a.json still registered")
+	}
+}


### PR DESCRIPTION
Summary
- Move auth-file single and bulk delete coordination into internal/management/authfiles.
- Keep the management handler responsible for request validation and HTTP error mapping.
- Add authfiles unit coverage for single delete, missing-file handling, and bulk delete behavior.
- Tighten the backend structure baseline after reducing the handler size.

Validation
- go test ./internal/management/authfiles
- go test ./internal/api/handlers/management -run "TestDeleteAuthFile|Test.*AuthFile|Test.*PermissionProfiles|Test.*APIKeyEntries"
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check