### PR TITLE
refactor: move qwen device oauth flow

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/auth_files.go",
-        "max_lines": 1340,
+        "max_lines": 1312,
         "reason": "Phase 1 legacy management auth-files handler debt; move transport/use cases into internal/management/authfiles and oauth."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -45,7 +45,7 @@ docs/internal-review/backend-structure-allowlist.json
 
 | 文件 | 行数 | 治理阶段 |
 | --- | ---: | --- |
-| `internal/api/handlers/management/auth_files.go` | 1340 | Phase 1 |
+| `internal/api/handlers/management/auth_files.go` | 1312 | Phase 1 |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -19,7 +19,6 @@ import (
 	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
 	iflowauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/iflow"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	oauthcallback "github.com/router-for-me/CLIProxyAPI/v6/internal/management/oauth/callback"
@@ -1022,49 +1021,22 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 func (h *Handler) RequestQwenToken(c *gin.Context) {
 	ctx := detachedAuthContext(c)
 
-	fmt.Println("Initializing Qwen authentication...")
-
-	state := fmt.Sprintf("gem-%d", time.Now().UnixNano())
-	// Initialize Qwen auth service
-	qwenAuth := qwen.NewQwenAuth(h.cfg)
-
-	// Generate authorization URL
-	deviceFlow, err := qwenAuth.InitiateDeviceFlow(ctx)
+	result, err := qwenprovider.StartDeviceLogin(ctx, qwenprovider.DeviceLoginOptions{
+		Config:     h.cfg,
+		SaveRecord: h.saveTokenRecord,
+		Sessions: qwenprovider.SessionCallbacks{
+			Register: RegisterOAuthSession,
+			SetError: SetOAuthSessionError,
+			Complete: CompleteOAuthSession,
+		},
+	})
 	if err != nil {
 		log.Errorf("Failed to generate authorization URL: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
 		return
 	}
-	authURL := deviceFlow.VerificationURIComplete
 
-	RegisterOAuthSession(state, "qwen")
-
-	go func() {
-		fmt.Println("Waiting for authentication...")
-		tokenData, errPollForToken := qwenAuth.PollForToken(deviceFlow.DeviceCode, deviceFlow.CodeVerifier)
-		if errPollForToken != nil {
-			SetOAuthSessionError(state, "Authentication failed")
-			fmt.Printf("Authentication failed: %v\n", errPollForToken)
-			return
-		}
-
-		// Create token storage
-		tokenStorage := qwenAuth.CreateTokenStorage(tokenData)
-
-		record := qwenprovider.RecordFromTokenStorage(tokenStorage, time.Now())
-		savedPath, errSave := h.saveTokenRecord(ctx, record)
-		if errSave != nil {
-			log.Errorf("Failed to save authentication tokens: %v", errSave)
-			SetOAuthSessionError(state, "Failed to save authentication tokens")
-			return
-		}
-
-		fmt.Printf("Authentication successful! Token saved to %s\n", savedPath)
-		fmt.Println("You can now use Qwen services through this CLI")
-		CompleteOAuthSession(state)
-	}()
-
-	c.JSON(200, gin.H{"status": "ok", "url": authURL, "state": state})
+	c.JSON(200, gin.H{"status": "ok", "url": result.AuthURL, "state": result.State})
 }
 
 func (h *Handler) RequestKimiToken(c *gin.Context) {

--- a/internal/management/oauth/providers/qwen/flow.go
+++ b/internal/management/oauth/providers/qwen/flow.go
@@ -1,0 +1,117 @@
+package qwen
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	internalqwen "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+type DeviceAuth interface {
+	InitiateDeviceFlow(context.Context) (*internalqwen.DeviceFlow, error)
+	PollForToken(deviceCode, codeVerifier string) (*internalqwen.QwenTokenData, error)
+	CreateTokenStorage(*internalqwen.QwenTokenData) *internalqwen.QwenTokenStorage
+}
+
+type SessionCallbacks struct {
+	Register func(state, provider string)
+	SetError func(state, message string)
+	Complete func(state string)
+}
+
+type SaveRecordFunc func(context.Context, *coreauth.Auth) (string, error)
+
+type DeviceLoginOptions struct {
+	Config     *config.Config
+	Auth       DeviceAuth
+	Sessions   SessionCallbacks
+	SaveRecord SaveRecordFunc
+	Now        func() time.Time
+	State      func() string
+}
+
+type DeviceLoginResult struct {
+	AuthURL string
+	State   string
+}
+
+func StartDeviceLogin(ctx context.Context, opts DeviceLoginOptions) (DeviceLoginResult, error) {
+	fmt.Println("Initializing Qwen authentication...")
+
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	state := ""
+	if opts.State != nil {
+		state = opts.State()
+	}
+	if state == "" {
+		state = fmt.Sprintf("gem-%d", now().UnixNano())
+	}
+	auth := opts.Auth
+	if auth == nil {
+		auth = internalqwen.NewQwenAuth(opts.Config)
+	}
+
+	deviceFlow, err := auth.InitiateDeviceFlow(ctx)
+	if err != nil {
+		return DeviceLoginResult{}, err
+	}
+	result := DeviceLoginResult{
+		AuthURL: deviceFlow.VerificationURIComplete,
+		State:   state,
+	}
+	opts.Sessions.register(state, "qwen")
+
+	go func() {
+		fmt.Println("Waiting for authentication...")
+		tokenData, errPollForToken := auth.PollForToken(deviceFlow.DeviceCode, deviceFlow.CodeVerifier)
+		if errPollForToken != nil {
+			opts.Sessions.setError(state, "Authentication failed")
+			fmt.Printf("Authentication failed: %v\n", errPollForToken)
+			return
+		}
+
+		tokenStorage := auth.CreateTokenStorage(tokenData)
+		record := RecordFromTokenStorage(tokenStorage, now())
+		if opts.SaveRecord == nil {
+			opts.Sessions.setError(state, "Failed to save authentication tokens")
+			return
+		}
+		savedPath, errSave := opts.SaveRecord(ctx, record)
+		if errSave != nil {
+			log.Errorf("Failed to save authentication tokens: %v", errSave)
+			opts.Sessions.setError(state, "Failed to save authentication tokens")
+			return
+		}
+
+		fmt.Printf("Authentication successful! Token saved to %s\n", savedPath)
+		fmt.Println("You can now use Qwen services through this CLI")
+		opts.Sessions.complete(state)
+	}()
+
+	return result, nil
+}
+
+func (s SessionCallbacks) register(state, provider string) {
+	if s.Register != nil {
+		s.Register(state, provider)
+	}
+}
+
+func (s SessionCallbacks) setError(state, message string) {
+	if s.SetError != nil {
+		s.SetError(state, message)
+	}
+}
+
+func (s SessionCallbacks) complete(state string) {
+	if s.Complete != nil {
+		s.Complete(state)
+	}
+}

--- a/internal/management/oauth/providers/qwen/flow_test.go
+++ b/internal/management/oauth/providers/qwen/flow_test.go
@@ -1,0 +1,141 @@
+package qwen
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	internalqwen "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type qwenDeviceAuthStub struct {
+	initiateErr error
+	pollErr     error
+}
+
+func (s qwenDeviceAuthStub) InitiateDeviceFlow(context.Context) (*internalqwen.DeviceFlow, error) {
+	if s.initiateErr != nil {
+		return nil, s.initiateErr
+	}
+	return &internalqwen.DeviceFlow{
+		DeviceCode:              "device-code",
+		CodeVerifier:            "code-verifier",
+		VerificationURIComplete: "https://example.com/qwen",
+	}, nil
+}
+
+func (s qwenDeviceAuthStub) PollForToken(deviceCode, codeVerifier string) (*internalqwen.QwenTokenData, error) {
+	if deviceCode != "device-code" || codeVerifier != "code-verifier" {
+		return nil, errors.New("unexpected device flow values")
+	}
+	if s.pollErr != nil {
+		return nil, s.pollErr
+	}
+	return &internalqwen.QwenTokenData{
+		AccessToken: "access",
+		TokenType:   "Bearer",
+	}, nil
+}
+
+func (s qwenDeviceAuthStub) CreateTokenStorage(tokenData *internalqwen.QwenTokenData) *internalqwen.QwenTokenStorage {
+	return &internalqwen.QwenTokenStorage{
+		AccessToken: tokenData.AccessToken,
+		Type:        "qwen",
+	}
+}
+
+func TestStartDeviceLoginRegistersAndCompletesSession(t *testing.T) {
+	done := make(chan struct{})
+	var registeredState string
+	var savedProvider string
+
+	result, err := StartDeviceLogin(context.Background(), DeviceLoginOptions{
+		Auth: qwenDeviceAuthStub{},
+		Now: func() time.Time {
+			return time.Date(2026, 6, 6, 10, 0, 0, 0, time.UTC)
+		},
+		State: func() string { return "qwen-state" },
+		Sessions: SessionCallbacks{
+			Register: func(state, provider string) {
+				registeredState = state + ":" + provider
+			},
+			Complete: func(state string) {
+				if state != "qwen-state" {
+					t.Errorf("complete state = %q, want qwen-state", state)
+				}
+				close(done)
+			},
+		},
+		SaveRecord: func(ctx context.Context, record *coreauth.Auth) (string, error) {
+			_ = ctx
+			if record == nil {
+				t.Fatal("record is nil")
+			}
+			savedProvider = record.Provider
+			return "/tmp/qwen.json", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartDeviceLogin() error = %v", err)
+	}
+	if result.AuthURL != "https://example.com/qwen" || result.State != "qwen-state" {
+		t.Fatalf("result = %#v, want auth url and state", result)
+	}
+	if registeredState != "qwen-state:qwen" {
+		t.Fatalf("registered = %q, want qwen-state:qwen", registeredState)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for completion")
+	}
+	if savedProvider != "qwen" {
+		t.Fatalf("saved provider = %q, want qwen", savedProvider)
+	}
+}
+
+func TestStartDeviceLoginSetsErrorOnPollFailure(t *testing.T) {
+	done := make(chan struct{})
+	var status string
+
+	_, err := StartDeviceLogin(context.Background(), DeviceLoginOptions{
+		Auth:  qwenDeviceAuthStub{pollErr: errors.New("denied")},
+		State: func() string { return "qwen-state" },
+		Sessions: SessionCallbacks{
+			SetError: func(state, message string) {
+				if state != "qwen-state" {
+					t.Errorf("error state = %q, want qwen-state", state)
+				}
+				status = message
+				close(done)
+			},
+		},
+		SaveRecord: func(context.Context, *coreauth.Auth) (string, error) {
+			t.Fatal("SaveRecord should not be called")
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartDeviceLogin() error = %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for error")
+	}
+	if status != "Authentication failed" {
+		t.Fatalf("status = %q, want Authentication failed", status)
+	}
+}
+
+func TestStartDeviceLoginReturnsInitiateError(t *testing.T) {
+	wantErr := errors.New("network")
+	_, err := StartDeviceLogin(context.Background(), DeviceLoginOptions{
+		Auth: qwenDeviceAuthStub{initiateErr: wantErr},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("StartDeviceLogin() error = %v, want %v", err, wantErr)
+	}
+}


### PR DESCRIPTION
Summary
- Move the Qwen device OAuth orchestration into internal/management/oauth/providers/qwen.
- Keep the management handler responsible for invoking the provider flow and writing HTTP responses.
- Add provider-flow unit coverage for success, poll failure, and initiate failure paths.
- Tighten the backend structure baseline after reducing the handler size.

Validation
- go test ./internal/management/oauth/providers/qwen
- go test ./internal/api/handlers/management -run "Test.*AuthFile|Test.*OAuth|Test.*PermissionProfiles|Test.*APIKeyEntries"
- go test ./internal/management/... ./internal/api/handlers/management
- python3 scripts/check-backend-structure.py
- python3 -m json.tool docs/internal-review/backend-structure-allowlist.json
- git diff --check