### PR TITLE
test: cover management route registration table

### DIFF
--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -18,16 +18,16 @@ docs/internal-review/backend-structure-allowlist.json
 
 ## 当前结构指标
 
-基于 2026-06-06 Phase 1 management route domains 拆分后的基线：
+基于 2026-06-06 Phase 1 management route smoke test 后的基线：
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 664 |
+| Go 文件总数 | 665 |
 | 生产 Go 文件 | 450 |
-| 测试 Go 文件 | 214 |
-| `internal/` Go 文件 | 541 |
+| 测试 Go 文件 | 215 |
+| `internal/` Go 文件 | 542 |
 | `internal/` 生产 Go 文件 | 379 |
-| `internal/` 测试 Go 文件 | 162 |
+| `internal/` 测试 Go 文件 | 163 |
 | 生产 Go 文件中 `>800` 行 | 25 |
 | 生产 Go 文件中 `>1200` 行 | 13 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 22 |
@@ -36,8 +36,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 管理端 `Handler` receiver 方法 | 245 |
 | `server.go` 内管理路由注册 | 0 |
 | `internal/` 生产目录 | 91 |
-| `internal/` 有同级测试目录 | 45 |
-| `internal/` 无同级测试目录 | 46 |
+| `internal/` 有同级测试目录 | 46 |
+| `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
 

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -1,0 +1,48 @@
+package routes
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	managementhandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
+)
+
+func TestRegisterManagementRouteTable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	RegisterManagement(engine, &managementhandlers.Handler{}, ManagementOptions{})
+
+	routes := make(map[string]gin.RouteInfo)
+	for _, route := range engine.Routes() {
+		key := route.Method + " " + route.Path
+		if _, exists := routes[key]; exists {
+			t.Fatalf("duplicate route registered: %s", key)
+		}
+		routes[key] = route
+	}
+
+	if got, want := len(routes), 205; got != want {
+		t.Fatalf("route count = %d, want %d", got, want)
+	}
+
+	required := []string{
+		"GET /v0/management/dashboard-summary",
+		"GET /v0/management/system-stats/ws",
+		"GET /v0/management/model-configs",
+		"PUT /v0/management/model-configs/*id",
+		"GET /v0/management/usage/logs/:id/content",
+		"POST /v0/management/api-call",
+		"PATCH /v0/management/api-key-entries",
+		"POST /v0/management/opencode-go-api-key/usage",
+		"GET /v0/management/auth-files/models",
+		"POST /v0/management/oauth-callback",
+		"GET /v0/management/public/usage/logs/:id/content",
+		"POST /v0/management/public/usage/summary",
+	}
+	for _, key := range required {
+		if _, ok := routes[key]; !ok {
+			t.Fatalf("required route %s was not registered", key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add a route table smoke test for `routes.RegisterManagement`.
- Assert the management/public management route count and representative routes across domains.
- Refresh the backend structure baseline after adding the focused test.

## Validation
- `go test ./internal/api/routes`
- `go test ./internal/api/... ./internal/management/...`
- `python3 scripts/check-backend-structure.py`
- `python3 -m json.tool docs/internal-review/backend-structure-allowlist.json`
- `git diff --check`
- Sensitive-string scan reviewed; matches are generic code identifiers/routes only.