### PR TITLE
refactor: move amp settings use cases

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/config_lists.go",
-        "max_lines": 2307,
+        "max_lines": 2184,
         "reason": "Phase 1/2 legacy management config-list debt; move settings/API-key/provider-key use cases behind services and DB-first stores."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -18,16 +18,16 @@ docs/internal-review/backend-structure-allowlist.json
 
 ## 当前结构指标
 
-基于 2026-06-06 Phase 1 management route smoke test 后的基线：
+基于 2026-06-06 Phase 1 Amp settings service 拆分后的基线：
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 665 |
-| 生产 Go 文件 | 450 |
-| 测试 Go 文件 | 215 |
-| `internal/` Go 文件 | 542 |
-| `internal/` 生产 Go 文件 | 379 |
-| `internal/` 测试 Go 文件 | 163 |
+| Go 文件总数 | 667 |
+| 生产 Go 文件 | 451 |
+| 测试 Go 文件 | 216 |
+| `internal/` Go 文件 | 544 |
+| `internal/` 生产 Go 文件 | 380 |
+| `internal/` 测试 Go 文件 | 164 |
 | 生产 Go 文件中 `>800` 行 | 25 |
 | 生产 Go 文件中 `>1200` 行 | 13 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 22 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 245 |
 | `server.go` 内管理路由注册 | 0 |
-| `internal/` 生产目录 | 91 |
-| `internal/` 有同级测试目录 | 46 |
+| `internal/` 生产目录 | 92 |
+| `internal/` 有同级测试目录 | 47 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -47,9 +47,9 @@ docs/internal-review/backend-structure-allowlist.json
 | --- | ---: | --- |
 | `sdk/cliproxy/auth/conductor.go` | 3223 | Phase 5 |
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
-| `internal/api/handlers/management/config_lists.go` | 2307 | Phase 1/2 |
 | `internal/runtime/executor/codex_image_executor.go` | 2233 | Phase 4 |
 | `internal/config/config.go` | 2216 | Phase 2 |
+| `internal/api/handlers/management/config_lists.go` | 2184 | Phase 1/2 |
 | `internal/api/server.go` | 1851 | Phase 6 |
 | `sdk/cliproxy/service.go` | 1788 | Phase 6/7 |
 | `internal/runtime/executor/antigravity_executor.go` | 1766 | Phase 4 |

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -11,6 +11,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/access"
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	ampsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/amp"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -2006,76 +2007,63 @@ func sanitizedOAuthModelAlias(entries map[string][]config.OAuthModelAlias) map[s
 	return cfg.OAuthModelAlias
 }
 
+func ampSettingsService(h *Handler) *ampsettings.Service {
+	if h == nil {
+		return ampsettings.NewService(nil)
+	}
+	return ampsettings.NewService(h.cfg)
+}
+
 // GetAmpCode returns the complete ampcode configuration.
 func (h *Handler) GetAmpCode(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"ampcode": config.AmpCode{}})
-		return
-	}
-	c.JSON(200, gin.H{"ampcode": h.cfg.AmpCode})
+	c.JSON(200, gin.H{"ampcode": ampSettingsService(h).Snapshot()})
 }
 
 // GetAmpUpstreamURL returns the ampcode upstream URL.
 func (h *Handler) GetAmpUpstreamURL(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"upstream-url": ""})
-		return
-	}
-	c.JSON(200, gin.H{"upstream-url": h.cfg.AmpCode.UpstreamURL})
+	c.JSON(200, gin.H{"upstream-url": ampSettingsService(h).UpstreamURL()})
 }
 
 // PutAmpUpstreamURL updates the ampcode upstream URL.
 func (h *Handler) PutAmpUpstreamURL(c *gin.Context) {
-	h.updateStringField(c, func(v string) { h.cfg.AmpCode.UpstreamURL = strings.TrimSpace(v) })
+	h.updateStringField(c, func(v string) { ampSettingsService(h).SetUpstreamURL(v) })
 }
 
 // DeleteAmpUpstreamURL clears the ampcode upstream URL.
 func (h *Handler) DeleteAmpUpstreamURL(c *gin.Context) {
-	h.cfg.AmpCode.UpstreamURL = ""
+	ampSettingsService(h).ClearUpstreamURL()
 	h.persist(c)
 }
 
 // GetAmpUpstreamAPIKey returns the ampcode upstream API key.
 func (h *Handler) GetAmpUpstreamAPIKey(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"upstream-api-key": ""})
-		return
-	}
-	c.JSON(200, gin.H{"upstream-api-key": h.cfg.AmpCode.UpstreamAPIKey})
+	c.JSON(200, gin.H{"upstream-api-key": ampSettingsService(h).UpstreamAPIKey()})
 }
 
 // PutAmpUpstreamAPIKey updates the ampcode upstream API key.
 func (h *Handler) PutAmpUpstreamAPIKey(c *gin.Context) {
-	h.updateStringField(c, func(v string) { h.cfg.AmpCode.UpstreamAPIKey = strings.TrimSpace(v) })
+	h.updateStringField(c, func(v string) { ampSettingsService(h).SetUpstreamAPIKey(v) })
 }
 
 // DeleteAmpUpstreamAPIKey clears the ampcode upstream API key.
 func (h *Handler) DeleteAmpUpstreamAPIKey(c *gin.Context) {
-	h.cfg.AmpCode.UpstreamAPIKey = ""
+	ampSettingsService(h).ClearUpstreamAPIKey()
 	h.persist(c)
 }
 
 // GetAmpRestrictManagementToLocalhost returns the localhost restriction setting.
 func (h *Handler) GetAmpRestrictManagementToLocalhost(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"restrict-management-to-localhost": true})
-		return
-	}
-	c.JSON(200, gin.H{"restrict-management-to-localhost": h.cfg.AmpCode.RestrictManagementToLocalhost})
+	c.JSON(200, gin.H{"restrict-management-to-localhost": ampSettingsService(h).RestrictManagementToLocalhost()})
 }
 
 // PutAmpRestrictManagementToLocalhost updates the localhost restriction setting.
 func (h *Handler) PutAmpRestrictManagementToLocalhost(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.AmpCode.RestrictManagementToLocalhost = v })
+	h.updateBoolField(c, func(v bool) { ampSettingsService(h).SetRestrictManagementToLocalhost(v) })
 }
 
 // GetAmpModelMappings returns the ampcode model mappings.
 func (h *Handler) GetAmpModelMappings(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"model-mappings": []config.AmpModelMapping{}})
-		return
-	}
-	c.JSON(200, gin.H{"model-mappings": h.cfg.AmpCode.ModelMappings})
+	c.JSON(200, gin.H{"model-mappings": ampSettingsService(h).ModelMappings()})
 }
 
 // PutAmpModelMappings replaces all ampcode model mappings.
@@ -2087,7 +2075,7 @@ func (h *Handler) PutAmpModelMappings(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	h.cfg.AmpCode.ModelMappings = body.Value
+	ampSettingsService(h).SetModelMappings(body.Value)
 	h.persist(c)
 }
 
@@ -2101,20 +2089,7 @@ func (h *Handler) PatchAmpModelMappings(c *gin.Context) {
 		return
 	}
 
-	existing := make(map[string]int)
-	for i, m := range h.cfg.AmpCode.ModelMappings {
-		existing[strings.TrimSpace(m.From)] = i
-	}
-
-	for _, newMapping := range body.Value {
-		from := strings.TrimSpace(newMapping.From)
-		if idx, ok := existing[from]; ok {
-			h.cfg.AmpCode.ModelMappings[idx] = newMapping
-		} else {
-			h.cfg.AmpCode.ModelMappings = append(h.cfg.AmpCode.ModelMappings, newMapping)
-			existing[from] = len(h.cfg.AmpCode.ModelMappings) - 1
-		}
-	}
+	ampSettingsService(h).PatchModelMappings(body.Value)
 	h.persist(c)
 }
 
@@ -2124,47 +2099,28 @@ func (h *Handler) DeleteAmpModelMappings(c *gin.Context) {
 		Value []string `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || len(body.Value) == 0 {
-		h.cfg.AmpCode.ModelMappings = nil
+		ampSettingsService(h).DeleteModelMappings(nil)
 		h.persist(c)
 		return
 	}
 
-	toRemove := make(map[string]bool)
-	for _, from := range body.Value {
-		toRemove[strings.TrimSpace(from)] = true
-	}
-
-	newMappings := make([]config.AmpModelMapping, 0, len(h.cfg.AmpCode.ModelMappings))
-	for _, m := range h.cfg.AmpCode.ModelMappings {
-		if !toRemove[strings.TrimSpace(m.From)] {
-			newMappings = append(newMappings, m)
-		}
-	}
-	h.cfg.AmpCode.ModelMappings = newMappings
+	ampSettingsService(h).DeleteModelMappings(body.Value)
 	h.persist(c)
 }
 
 // GetAmpForceModelMappings returns whether model mappings are forced.
 func (h *Handler) GetAmpForceModelMappings(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"force-model-mappings": false})
-		return
-	}
-	c.JSON(200, gin.H{"force-model-mappings": h.cfg.AmpCode.ForceModelMappings})
+	c.JSON(200, gin.H{"force-model-mappings": ampSettingsService(h).ForceModelMappings()})
 }
 
 // PutAmpForceModelMappings updates the force model mappings setting.
 func (h *Handler) PutAmpForceModelMappings(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.AmpCode.ForceModelMappings = v })
+	h.updateBoolField(c, func(v bool) { ampSettingsService(h).SetForceModelMappings(v) })
 }
 
 // GetAmpUpstreamAPIKeys returns the ampcode upstream API keys mapping.
 func (h *Handler) GetAmpUpstreamAPIKeys(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"upstream-api-keys": []config.AmpUpstreamAPIKeyEntry{}})
-		return
-	}
-	c.JSON(200, gin.H{"upstream-api-keys": h.cfg.AmpCode.UpstreamAPIKeys})
+	c.JSON(200, gin.H{"upstream-api-keys": ampSettingsService(h).UpstreamAPIKeys()})
 }
 
 // PutAmpUpstreamAPIKeys replaces all ampcode upstream API keys mappings.
@@ -2176,9 +2132,7 @@ func (h *Handler) PutAmpUpstreamAPIKeys(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	// Normalize entries: trim whitespace, filter empty
-	normalized := normalizeAmpUpstreamAPIKeyEntries(body.Value)
-	h.cfg.AmpCode.UpstreamAPIKeys = normalized
+	ampSettingsService(h).SetUpstreamAPIKeys(body.Value)
 	h.persist(c)
 }
 
@@ -2193,27 +2147,7 @@ func (h *Handler) PatchAmpUpstreamAPIKeys(c *gin.Context) {
 		return
 	}
 
-	existing := make(map[string]int)
-	for i, entry := range h.cfg.AmpCode.UpstreamAPIKeys {
-		existing[strings.TrimSpace(entry.UpstreamAPIKey)] = i
-	}
-
-	for _, newEntry := range body.Value {
-		upstreamKey := strings.TrimSpace(newEntry.UpstreamAPIKey)
-		if upstreamKey == "" {
-			continue
-		}
-		normalizedEntry := config.AmpUpstreamAPIKeyEntry{
-			UpstreamAPIKey: upstreamKey,
-			APIKeys:        normalizeAPIKeysList(newEntry.APIKeys),
-		}
-		if idx, ok := existing[upstreamKey]; ok {
-			h.cfg.AmpCode.UpstreamAPIKeys[idx] = normalizedEntry
-		} else {
-			h.cfg.AmpCode.UpstreamAPIKeys = append(h.cfg.AmpCode.UpstreamAPIKeys, normalizedEntry)
-			existing[upstreamKey] = len(h.cfg.AmpCode.UpstreamAPIKeys) - 1
-		}
-	}
+	ampSettingsService(h).PatchUpstreamAPIKeys(body.Value)
 	h.persist(c)
 }
 
@@ -2237,71 +2171,14 @@ func (h *Handler) DeleteAmpUpstreamAPIKeys(c *gin.Context) {
 
 	// Empty array means clear all
 	if len(body.Value) == 0 {
-		h.cfg.AmpCode.UpstreamAPIKeys = nil
+		_ = ampSettingsService(h).DeleteUpstreamAPIKeys(body.Value)
 		h.persist(c)
 		return
 	}
 
-	toRemove := make(map[string]bool)
-	for _, key := range body.Value {
-		trimmed := strings.TrimSpace(key)
-		if trimmed == "" {
-			continue
-		}
-		toRemove[trimmed] = true
-	}
-	if len(toRemove) == 0 {
+	if err := ampSettingsService(h).DeleteUpstreamAPIKeys(body.Value); err != nil {
 		c.JSON(400, gin.H{"error": "empty value"})
 		return
 	}
-
-	newEntries := make([]config.AmpUpstreamAPIKeyEntry, 0, len(h.cfg.AmpCode.UpstreamAPIKeys))
-	for _, entry := range h.cfg.AmpCode.UpstreamAPIKeys {
-		if !toRemove[strings.TrimSpace(entry.UpstreamAPIKey)] {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	h.cfg.AmpCode.UpstreamAPIKeys = newEntries
 	h.persist(c)
-}
-
-// normalizeAmpUpstreamAPIKeyEntries normalizes a list of upstream API key entries.
-func normalizeAmpUpstreamAPIKeyEntries(entries []config.AmpUpstreamAPIKeyEntry) []config.AmpUpstreamAPIKeyEntry {
-	if len(entries) == 0 {
-		return nil
-	}
-	out := make([]config.AmpUpstreamAPIKeyEntry, 0, len(entries))
-	for _, entry := range entries {
-		upstreamKey := strings.TrimSpace(entry.UpstreamAPIKey)
-		if upstreamKey == "" {
-			continue
-		}
-		apiKeys := normalizeAPIKeysList(entry.APIKeys)
-		out = append(out, config.AmpUpstreamAPIKeyEntry{
-			UpstreamAPIKey: upstreamKey,
-			APIKeys:        apiKeys,
-		})
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-// normalizeAPIKeysList trims and filters empty strings from a list of API keys.
-func normalizeAPIKeysList(keys []string) []string {
-	if len(keys) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(keys))
-	for _, k := range keys {
-		trimmed := strings.TrimSpace(k)
-		if trimmed != "" {
-			out = append(out, trimmed)
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
 }

--- a/internal/management/settings/amp/service.go
+++ b/internal/management/settings/amp/service.go
@@ -1,0 +1,262 @@
+package amp
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+var ErrEmptyValue = errors.New("empty value")
+
+type Service struct {
+	cfg *config.Config
+}
+
+func NewService(cfg *config.Config) *Service {
+	return &Service{cfg: cfg}
+}
+
+func (s *Service) Snapshot() config.AmpCode {
+	if s == nil || s.cfg == nil {
+		return config.AmpCode{}
+	}
+	return s.cfg.AmpCode
+}
+
+func (s *Service) UpstreamURL() string {
+	if s == nil || s.cfg == nil {
+		return ""
+	}
+	return s.cfg.AmpCode.UpstreamURL
+}
+
+func (s *Service) SetUpstreamURL(value string) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	s.cfg.AmpCode.UpstreamURL = strings.TrimSpace(value)
+}
+
+func (s *Service) ClearUpstreamURL() {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	s.cfg.AmpCode.UpstreamURL = ""
+}
+
+func (s *Service) UpstreamAPIKey() string {
+	if s == nil || s.cfg == nil {
+		return ""
+	}
+	return s.cfg.AmpCode.UpstreamAPIKey
+}
+
+func (s *Service) SetUpstreamAPIKey(value string) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	s.cfg.AmpCode.UpstreamAPIKey = strings.TrimSpace(value)
+}
+
+func (s *Service) ClearUpstreamAPIKey() {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	s.cfg.AmpCode.UpstreamAPIKey = ""
+}
+
+func (s *Service) RestrictManagementToLocalhost() bool {
+	if s == nil || s.cfg == nil {
+		return true
+	}
+	return s.cfg.AmpCode.RestrictManagementToLocalhost
+}
+
+func (s *Service) SetRestrictManagementToLocalhost(value bool) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	s.cfg.AmpCode.RestrictManagementToLocalhost = value
+}
+
+func (s *Service) ModelMappings() []config.AmpModelMapping {
+	if s == nil || s.cfg == nil {
+		return []config.AmpModelMapping{}
+	}
+	return s.cfg.AmpCode.ModelMappings
+}
+
+func (s *Service) SetModelMappings(value []config.AmpModelMapping) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	s.cfg.AmpCode.ModelMappings = value
+}
+
+func (s *Service) PatchModelMappings(value []config.AmpModelMapping) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	existing := make(map[string]int)
+	for i, mapping := range s.cfg.AmpCode.ModelMappings {
+		existing[strings.TrimSpace(mapping.From)] = i
+	}
+
+	for _, newMapping := range value {
+		from := strings.TrimSpace(newMapping.From)
+		if idx, ok := existing[from]; ok {
+			s.cfg.AmpCode.ModelMappings[idx] = newMapping
+			continue
+		}
+		s.cfg.AmpCode.ModelMappings = append(s.cfg.AmpCode.ModelMappings, newMapping)
+		existing[from] = len(s.cfg.AmpCode.ModelMappings) - 1
+	}
+}
+
+func (s *Service) DeleteModelMappings(value []string) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	if len(value) == 0 {
+		s.cfg.AmpCode.ModelMappings = nil
+		return
+	}
+
+	toRemove := make(map[string]bool)
+	for _, from := range value {
+		toRemove[strings.TrimSpace(from)] = true
+	}
+
+	newMappings := make([]config.AmpModelMapping, 0, len(s.cfg.AmpCode.ModelMappings))
+	for _, mapping := range s.cfg.AmpCode.ModelMappings {
+		if !toRemove[strings.TrimSpace(mapping.From)] {
+			newMappings = append(newMappings, mapping)
+		}
+	}
+	s.cfg.AmpCode.ModelMappings = newMappings
+}
+
+func (s *Service) ForceModelMappings() bool {
+	if s == nil || s.cfg == nil {
+		return false
+	}
+	return s.cfg.AmpCode.ForceModelMappings
+}
+
+func (s *Service) SetForceModelMappings(value bool) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	s.cfg.AmpCode.ForceModelMappings = value
+}
+
+func (s *Service) UpstreamAPIKeys() []config.AmpUpstreamAPIKeyEntry {
+	if s == nil || s.cfg == nil {
+		return []config.AmpUpstreamAPIKeyEntry{}
+	}
+	return s.cfg.AmpCode.UpstreamAPIKeys
+}
+
+func (s *Service) SetUpstreamAPIKeys(value []config.AmpUpstreamAPIKeyEntry) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	s.cfg.AmpCode.UpstreamAPIKeys = normalizeUpstreamAPIKeyEntries(value)
+}
+
+func (s *Service) PatchUpstreamAPIKeys(value []config.AmpUpstreamAPIKeyEntry) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	existing := make(map[string]int)
+	for i, entry := range s.cfg.AmpCode.UpstreamAPIKeys {
+		existing[strings.TrimSpace(entry.UpstreamAPIKey)] = i
+	}
+
+	for _, newEntry := range value {
+		upstreamKey := strings.TrimSpace(newEntry.UpstreamAPIKey)
+		if upstreamKey == "" {
+			continue
+		}
+		normalizedEntry := config.AmpUpstreamAPIKeyEntry{
+			UpstreamAPIKey: upstreamKey,
+			APIKeys:        normalizeAPIKeys(newEntry.APIKeys),
+		}
+		if idx, ok := existing[upstreamKey]; ok {
+			s.cfg.AmpCode.UpstreamAPIKeys[idx] = normalizedEntry
+			continue
+		}
+		s.cfg.AmpCode.UpstreamAPIKeys = append(s.cfg.AmpCode.UpstreamAPIKeys, normalizedEntry)
+		existing[upstreamKey] = len(s.cfg.AmpCode.UpstreamAPIKeys) - 1
+	}
+}
+
+func (s *Service) DeleteUpstreamAPIKeys(value []string) error {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	if len(value) == 0 {
+		s.cfg.AmpCode.UpstreamAPIKeys = nil
+		return nil
+	}
+
+	toRemove := make(map[string]bool)
+	for _, key := range value {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		toRemove[trimmed] = true
+	}
+	if len(toRemove) == 0 {
+		return ErrEmptyValue
+	}
+
+	newEntries := make([]config.AmpUpstreamAPIKeyEntry, 0, len(s.cfg.AmpCode.UpstreamAPIKeys))
+	for _, entry := range s.cfg.AmpCode.UpstreamAPIKeys {
+		if !toRemove[strings.TrimSpace(entry.UpstreamAPIKey)] {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	s.cfg.AmpCode.UpstreamAPIKeys = newEntries
+	return nil
+}
+
+func normalizeUpstreamAPIKeyEntries(entries []config.AmpUpstreamAPIKeyEntry) []config.AmpUpstreamAPIKeyEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.AmpUpstreamAPIKeyEntry, 0, len(entries))
+	for _, entry := range entries {
+		upstreamKey := strings.TrimSpace(entry.UpstreamAPIKey)
+		if upstreamKey == "" {
+			continue
+		}
+		out = append(out, config.AmpUpstreamAPIKeyEntry{
+			UpstreamAPIKey: upstreamKey,
+			APIKeys:        normalizeAPIKeys(entry.APIKeys),
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizeAPIKeys(keys []string) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/management/settings/amp/service_test.go
+++ b/internal/management/settings/amp/service_test.go
@@ -1,0 +1,134 @@
+package amp
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestServiceScalarFields(t *testing.T) {
+	cfg := &config.Config{}
+	service := NewService(cfg)
+
+	service.SetUpstreamURL(" https://amp.example.test/api ")
+	service.SetUpstreamAPIKey(" upstream-key ")
+	service.SetRestrictManagementToLocalhost(true)
+	service.SetForceModelMappings(true)
+
+	if got := cfg.AmpCode.UpstreamURL; got != "https://amp.example.test/api" {
+		t.Fatalf("upstream url = %q", got)
+	}
+	if got := cfg.AmpCode.UpstreamAPIKey; got != "upstream-key" {
+		t.Fatalf("upstream api key = %q", got)
+	}
+	if !cfg.AmpCode.RestrictManagementToLocalhost {
+		t.Fatal("restrict management flag was not updated")
+	}
+	if !cfg.AmpCode.ForceModelMappings {
+		t.Fatal("force model mappings flag was not updated")
+	}
+
+	service.ClearUpstreamURL()
+	service.ClearUpstreamAPIKey()
+
+	if cfg.AmpCode.UpstreamURL != "" {
+		t.Fatalf("upstream url was not cleared: %q", cfg.AmpCode.UpstreamURL)
+	}
+	if cfg.AmpCode.UpstreamAPIKey != "" {
+		t.Fatalf("upstream api key was not cleared: %q", cfg.AmpCode.UpstreamAPIKey)
+	}
+}
+
+func TestServicePatchAndDeleteModelMappings(t *testing.T) {
+	cfg := &config.Config{
+		AmpCode: config.AmpCode{
+			ModelMappings: []config.AmpModelMapping{
+				{From: " claude-opus ", To: "old-target"},
+				{From: "claude-haiku", To: "keep-target"},
+			},
+		},
+	}
+	service := NewService(cfg)
+
+	service.PatchModelMappings([]config.AmpModelMapping{
+		{From: "claude-opus", To: "new-target"},
+		{From: "claude-sonnet", To: "sonnet-target", Regex: true},
+	})
+
+	wantAfterPatch := []config.AmpModelMapping{
+		{From: "claude-opus", To: "new-target"},
+		{From: "claude-haiku", To: "keep-target"},
+		{From: "claude-sonnet", To: "sonnet-target", Regex: true},
+	}
+	if !reflect.DeepEqual(cfg.AmpCode.ModelMappings, wantAfterPatch) {
+		t.Fatalf("model mappings after patch = %#v", cfg.AmpCode.ModelMappings)
+	}
+
+	service.DeleteModelMappings([]string{" claude-haiku "})
+	wantAfterDelete := []config.AmpModelMapping{
+		{From: "claude-opus", To: "new-target"},
+		{From: "claude-sonnet", To: "sonnet-target", Regex: true},
+	}
+	if !reflect.DeepEqual(cfg.AmpCode.ModelMappings, wantAfterDelete) {
+		t.Fatalf("model mappings after delete = %#v", cfg.AmpCode.ModelMappings)
+	}
+
+	service.DeleteModelMappings(nil)
+	if cfg.AmpCode.ModelMappings != nil {
+		t.Fatalf("model mappings were not cleared: %#v", cfg.AmpCode.ModelMappings)
+	}
+}
+
+func TestServiceNormalizePatchAndDeleteUpstreamAPIKeys(t *testing.T) {
+	cfg := &config.Config{}
+	service := NewService(cfg)
+
+	service.SetUpstreamAPIKeys([]config.AmpUpstreamAPIKeyEntry{
+		{UpstreamAPIKey: " upstream-a ", APIKeys: []string{" client-a ", "", "client-b"}},
+		{UpstreamAPIKey: " ", APIKeys: []string{"ignored"}},
+	})
+
+	wantAfterSet := []config.AmpUpstreamAPIKeyEntry{
+		{UpstreamAPIKey: "upstream-a", APIKeys: []string{"client-a", "client-b"}},
+	}
+	if !reflect.DeepEqual(cfg.AmpCode.UpstreamAPIKeys, wantAfterSet) {
+		t.Fatalf("upstream api keys after set = %#v", cfg.AmpCode.UpstreamAPIKeys)
+	}
+
+	service.PatchUpstreamAPIKeys([]config.AmpUpstreamAPIKeyEntry{
+		{UpstreamAPIKey: " upstream-a ", APIKeys: []string{" client-c "}},
+		{UpstreamAPIKey: "upstream-b", APIKeys: []string{"client-d", " "}},
+		{UpstreamAPIKey: " ", APIKeys: []string{"ignored"}},
+	})
+
+	wantAfterPatch := []config.AmpUpstreamAPIKeyEntry{
+		{UpstreamAPIKey: "upstream-a", APIKeys: []string{"client-c"}},
+		{UpstreamAPIKey: "upstream-b", APIKeys: []string{"client-d"}},
+	}
+	if !reflect.DeepEqual(cfg.AmpCode.UpstreamAPIKeys, wantAfterPatch) {
+		t.Fatalf("upstream api keys after patch = %#v", cfg.AmpCode.UpstreamAPIKeys)
+	}
+
+	if err := service.DeleteUpstreamAPIKeys([]string{" upstream-a "}); err != nil {
+		t.Fatalf("delete upstream api keys returned error: %v", err)
+	}
+	wantAfterDelete := []config.AmpUpstreamAPIKeyEntry{
+		{UpstreamAPIKey: "upstream-b", APIKeys: []string{"client-d"}},
+	}
+	if !reflect.DeepEqual(cfg.AmpCode.UpstreamAPIKeys, wantAfterDelete) {
+		t.Fatalf("upstream api keys after delete = %#v", cfg.AmpCode.UpstreamAPIKeys)
+	}
+
+	if err := service.DeleteUpstreamAPIKeys([]string{" "}); !errors.Is(err, ErrEmptyValue) {
+		t.Fatalf("delete empty values error = %v, want ErrEmptyValue", err)
+	}
+
+	if err := service.DeleteUpstreamAPIKeys(nil); err != nil {
+		t.Fatalf("clear upstream api keys returned error: %v", err)
+	}
+	if cfg.AmpCode.UpstreamAPIKeys != nil {
+		t.Fatalf("upstream api keys were not cleared: %#v", cfg.AmpCode.UpstreamAPIKeys)
+	}
+}


### PR DESCRIPTION
## Summary
- Move Amp management settings mutation logic into `internal/management/settings/amp`.
- Keep Gin handlers focused on request binding, response status, and persistence coordination.
- Add focused unit coverage for Amp scalar fields, model mappings, and upstream API key mapping behavior.
- Refresh backend structure baseline and tighten the `config_lists.go` allowlist after reducing the file.

## Validation
- `go test ./internal/api/... ./internal/management/...`
- `python3 scripts/check-backend-structure.py`
- `python3 -m json.tool docs/internal-review/backend-structure-allowlist.json`
- `git diff --check`
- Sensitive-string scan reviewed; matches are generic code identifiers/routes only.