### PR TITLE
refactor: move oauth settings use cases

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -3,7 +3,7 @@
     "allow_above_1200": [
       {
         "path": "internal/api/handlers/management/config_lists.go",
-        "max_lines": 2184,
+        "max_lines": 2119,
         "reason": "Phase 1/2 legacy management config-list debt; move settings/API-key/provider-key use cases behind services and DB-first stores."
       },
       {

--- a/docs/internal-review/backend-structure-baseline.md
+++ b/docs/internal-review/backend-structure-baseline.md
@@ -18,16 +18,16 @@ docs/internal-review/backend-structure-allowlist.json
 
 ## 当前结构指标
 
-基于 2026-06-06 Phase 1 Amp settings service 拆分后的基线：
+基于 2026-06-06 Phase 1 OAuth settings service 拆分后的基线：
 
 | 指标 | 数量 |
 | --- | ---: |
-| Go 文件总数 | 667 |
-| 生产 Go 文件 | 451 |
-| 测试 Go 文件 | 216 |
-| `internal/` Go 文件 | 544 |
-| `internal/` 生产 Go 文件 | 380 |
-| `internal/` 测试 Go 文件 | 164 |
+| Go 文件总数 | 669 |
+| 生产 Go 文件 | 452 |
+| 测试 Go 文件 | 217 |
+| `internal/` Go 文件 | 546 |
+| `internal/` 生产 Go 文件 | 381 |
+| `internal/` 测试 Go 文件 | 165 |
 | 生产 Go 文件中 `>800` 行 | 25 |
 | 生产 Go 文件中 `>1200` 行 | 13 |
 | `internal/` 生产 Go 文件中 `>800` 行 | 22 |
@@ -35,8 +35,8 @@ docs/internal-review/backend-structure-allowlist.json
 | 生产 `sdk/**` 中直接导入 `internal/**` 的文件 | 40 |
 | 管理端 `Handler` receiver 方法 | 245 |
 | `server.go` 内管理路由注册 | 0 |
-| `internal/` 生产目录 | 92 |
-| `internal/` 有同级测试目录 | 47 |
+| `internal/` 生产目录 | 93 |
+| `internal/` 有同级测试目录 | 48 |
 | `internal/` 无同级测试目录 | 45 |
 
 ## 当前 `>1200` 行生产文件
@@ -49,7 +49,7 @@ docs/internal-review/backend-structure-allowlist.json
 | `internal/usage/usage_db.go` | 2530 | Phase 3 |
 | `internal/runtime/executor/codex_image_executor.go` | 2233 | Phase 4 |
 | `internal/config/config.go` | 2216 | Phase 2 |
-| `internal/api/handlers/management/config_lists.go` | 2184 | Phase 1/2 |
+| `internal/api/handlers/management/config_lists.go` | 2119 | Phase 1/2 |
 | `internal/api/server.go` | 1851 | Phase 6 |
 | `sdk/cliproxy/service.go` | 1788 | Phase 6/7 |
 | `internal/runtime/executor/antigravity_executor.go` | 1766 | Phase 4 |

--- a/internal/api/handlers/management/channel_rename.go
+++ b/internal/api/handlers/management/channel_rename.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	oauthsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/oauth"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -349,7 +350,7 @@ func renameOAuthModelAliasChannels(cfg *config.Config, oldNameSet map[string]str
 		changed = true
 	}
 	if changed {
-		cfg.OAuthModelAlias = sanitizedOAuthModelAlias(cfg.OAuthModelAlias)
+		cfg.OAuthModelAlias = oauthsettings.NormalizeModelAlias(cfg.OAuthModelAlias)
 	}
 	return changed
 }
@@ -367,7 +368,7 @@ func removeOAuthModelAliasChannels(cfg *config.Config, oldNameSet map[string]str
 		changed = true
 	}
 	if changed {
-		cfg.OAuthModelAlias = sanitizedOAuthModelAlias(cfg.OAuthModelAlias)
+		cfg.OAuthModelAlias = oauthsettings.NormalizeModelAlias(cfg.OAuthModelAlias)
 	}
 	return changed
 }

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -12,6 +12,7 @@ import (
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	ampsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/amp"
+	oauthsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/oauth"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -1474,9 +1475,16 @@ func (h *Handler) DeleteVertexCompatKey(c *gin.Context) {
 	c.JSON(400, gin.H{"error": "missing api-key or index"})
 }
 
+func oauthSettingsService(h *Handler) *oauthsettings.Service {
+	if h == nil {
+		return oauthsettings.NewService(nil)
+	}
+	return oauthsettings.NewService(h.cfg)
+}
+
 // oauth-excluded-models: map[string][]string
 func (h *Handler) GetOAuthExcludedModels(c *gin.Context) {
-	c.JSON(200, gin.H{"oauth-excluded-models": config.NormalizeOAuthExcludedModels(h.cfg.OAuthExcludedModels)})
+	c.JSON(200, gin.H{"oauth-excluded-models": oauthSettingsService(h).ExcludedModels()})
 }
 
 func (h *Handler) PutOAuthExcludedModels(c *gin.Context) {
@@ -1496,8 +1504,8 @@ func (h *Handler) PutOAuthExcludedModels(c *gin.Context) {
 		}
 		entries = wrapper.Items
 	}
-	h.cfg.OAuthExcludedModels = config.NormalizeOAuthExcludedModels(entries)
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, h.cfg.OAuthExcludedModels)
+	setting := oauthSettingsService(h).SetExcludedModels(entries)
+	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, setting)
 }
 
 func (h *Handler) PatchOAuthExcludedModels(c *gin.Context) {
@@ -1509,59 +1517,34 @@ func (h *Handler) PatchOAuthExcludedModels(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	provider := strings.ToLower(strings.TrimSpace(*body.Provider))
-	if provider == "" {
+	setting, err := oauthSettingsService(h).PatchExcludedModels(*body.Provider, body.Models)
+	if err == oauthsettings.ErrInvalidProvider {
 		c.JSON(400, gin.H{"error": "invalid provider"})
 		return
 	}
-	normalized := config.NormalizeExcludedModels(body.Models)
-	if len(normalized) == 0 {
-		if h.cfg.OAuthExcludedModels == nil {
-			c.JSON(404, gin.H{"error": "provider not found"})
-			return
-		}
-		if _, ok := h.cfg.OAuthExcludedModels[provider]; !ok {
-			c.JSON(404, gin.H{"error": "provider not found"})
-			return
-		}
-		delete(h.cfg.OAuthExcludedModels, provider)
-		if len(h.cfg.OAuthExcludedModels) == 0 {
-			h.cfg.OAuthExcludedModels = nil
-		}
-		h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, h.cfg.OAuthExcludedModels)
+	if err == oauthsettings.ErrProviderNotFound {
+		c.JSON(404, gin.H{"error": "provider not found"})
 		return
 	}
-	if h.cfg.OAuthExcludedModels == nil {
-		h.cfg.OAuthExcludedModels = make(map[string][]string)
-	}
-	h.cfg.OAuthExcludedModels[provider] = normalized
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, h.cfg.OAuthExcludedModels)
+	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, setting)
 }
 
 func (h *Handler) DeleteOAuthExcludedModels(c *gin.Context) {
-	provider := strings.ToLower(strings.TrimSpace(c.Query("provider")))
-	if provider == "" {
+	setting, err := oauthSettingsService(h).DeleteExcludedModels(c.Query("provider"))
+	if err == oauthsettings.ErrInvalidProvider {
 		c.JSON(400, gin.H{"error": "missing provider"})
 		return
 	}
-	if h.cfg.OAuthExcludedModels == nil {
+	if err == oauthsettings.ErrProviderNotFound {
 		c.JSON(404, gin.H{"error": "provider not found"})
 		return
 	}
-	if _, ok := h.cfg.OAuthExcludedModels[provider]; !ok {
-		c.JSON(404, gin.H{"error": "provider not found"})
-		return
-	}
-	delete(h.cfg.OAuthExcludedModels, provider)
-	if len(h.cfg.OAuthExcludedModels) == 0 {
-		h.cfg.OAuthExcludedModels = nil
-	}
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, h.cfg.OAuthExcludedModels)
+	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, setting)
 }
 
 // oauth-model-alias: map[string][]OAuthModelAlias
 func (h *Handler) GetOAuthModelAlias(c *gin.Context) {
-	c.JSON(200, gin.H{"oauth-model-alias": sanitizedOAuthModelAlias(h.cfg.OAuthModelAlias)})
+	c.JSON(200, gin.H{"oauth-model-alias": oauthSettingsService(h).ModelAlias()})
 }
 
 func (h *Handler) PutOAuthModelAlias(c *gin.Context) {
@@ -1581,8 +1564,8 @@ func (h *Handler) PutOAuthModelAlias(c *gin.Context) {
 		}
 		entries = wrapper.Items
 	}
-	h.cfg.OAuthModelAlias = sanitizedOAuthModelAlias(entries)
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias)
+	setting := oauthSettingsService(h).SetModelAlias(entries)
+	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, setting)
 }
 
 func (h *Handler) PatchOAuthModelAlias(c *gin.Context) {
@@ -1601,35 +1584,16 @@ func (h *Handler) PatchOAuthModelAlias(c *gin.Context) {
 	} else if body.Provider != nil {
 		channelRaw = *body.Provider
 	}
-	channel := strings.ToLower(strings.TrimSpace(channelRaw))
-	if channel == "" {
+	setting, err := oauthSettingsService(h).PatchModelAlias(channelRaw, body.Aliases)
+	if err == oauthsettings.ErrInvalidChannel {
 		c.JSON(400, gin.H{"error": "invalid channel"})
 		return
 	}
-
-	normalizedMap := sanitizedOAuthModelAlias(map[string][]config.OAuthModelAlias{channel: body.Aliases})
-	normalized := normalizedMap[channel]
-	if len(normalized) == 0 {
-		if h.cfg.OAuthModelAlias == nil {
-			c.JSON(404, gin.H{"error": "channel not found"})
-			return
-		}
-		if _, ok := h.cfg.OAuthModelAlias[channel]; !ok {
-			c.JSON(404, gin.H{"error": "channel not found"})
-			return
-		}
-		delete(h.cfg.OAuthModelAlias, channel)
-		if len(h.cfg.OAuthModelAlias) == 0 {
-			h.cfg.OAuthModelAlias = nil
-		}
-		h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias)
+	if err == oauthsettings.ErrChannelNotFound {
+		c.JSON(404, gin.H{"error": "channel not found"})
 		return
 	}
-	if h.cfg.OAuthModelAlias == nil {
-		h.cfg.OAuthModelAlias = make(map[string][]config.OAuthModelAlias)
-	}
-	h.cfg.OAuthModelAlias[channel] = normalized
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias)
+	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, setting)
 }
 
 func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
@@ -1641,19 +1605,12 @@ func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "missing channel"})
 		return
 	}
-	if h.cfg.OAuthModelAlias == nil {
+	setting, err := oauthSettingsService(h).DeleteModelAlias(channel)
+	if err == oauthsettings.ErrChannelNotFound {
 		c.JSON(404, gin.H{"error": "channel not found"})
 		return
 	}
-	if _, ok := h.cfg.OAuthModelAlias[channel]; !ok {
-		c.JSON(404, gin.H{"error": "channel not found"})
-		return
-	}
-	delete(h.cfg.OAuthModelAlias, channel)
-	if len(h.cfg.OAuthModelAlias) == 0 {
-		h.cfg.OAuthModelAlias = nil
-	}
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias)
+	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, setting)
 }
 
 // codex-api-key: []CodexKey
@@ -1983,28 +1940,6 @@ func normalizeVertexCompatKey(entry *config.VertexCompatKey) {
 		normalized = append(normalized, model)
 	}
 	entry.Models = normalized
-}
-
-func sanitizedOAuthModelAlias(entries map[string][]config.OAuthModelAlias) map[string][]config.OAuthModelAlias {
-	if len(entries) == 0 {
-		return nil
-	}
-	copied := make(map[string][]config.OAuthModelAlias, len(entries))
-	for channel, aliases := range entries {
-		if len(aliases) == 0 {
-			continue
-		}
-		copied[channel] = append([]config.OAuthModelAlias(nil), aliases...)
-	}
-	if len(copied) == 0 {
-		return nil
-	}
-	cfg := config.Config{OAuthModelAlias: copied}
-	cfg.SanitizeOAuthModelAlias()
-	if len(cfg.OAuthModelAlias) == 0 {
-		return nil
-	}
-	return cfg.OAuthModelAlias
 }
 
 func ampSettingsService(h *Handler) *ampsettings.Service {

--- a/internal/management/settings/oauth/service.go
+++ b/internal/management/settings/oauth/service.go
@@ -1,0 +1,182 @@
+package oauth
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+var (
+	ErrInvalidProvider  = errors.New("invalid provider")
+	ErrProviderNotFound = errors.New("provider not found")
+	ErrInvalidChannel   = errors.New("invalid channel")
+	ErrChannelNotFound  = errors.New("channel not found")
+)
+
+type Service struct {
+	cfg *config.Config
+}
+
+func NewService(cfg *config.Config) *Service {
+	return &Service{cfg: cfg}
+}
+
+func NormalizeModelAlias(entries map[string][]config.OAuthModelAlias) map[string][]config.OAuthModelAlias {
+	if len(entries) == 0 {
+		return nil
+	}
+	copied := make(map[string][]config.OAuthModelAlias, len(entries))
+	for channel, aliases := range entries {
+		if len(aliases) == 0 {
+			continue
+		}
+		copied[channel] = append([]config.OAuthModelAlias(nil), aliases...)
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	cfg := config.Config{OAuthModelAlias: copied}
+	cfg.SanitizeOAuthModelAlias()
+	if len(cfg.OAuthModelAlias) == 0 {
+		return nil
+	}
+	return cfg.OAuthModelAlias
+}
+
+func (s *Service) ExcludedModels() map[string][]string {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return config.NormalizeOAuthExcludedModels(s.cfg.OAuthExcludedModels)
+}
+
+func (s *Service) SetExcludedModels(entries map[string][]string) map[string][]string {
+	normalized := config.NormalizeOAuthExcludedModels(entries)
+	if s == nil || s.cfg == nil {
+		return normalized
+	}
+	s.cfg.OAuthExcludedModels = normalized
+	return s.cfg.OAuthExcludedModels
+}
+
+func (s *Service) PatchExcludedModels(provider string, models []string) (map[string][]string, error) {
+	provider = normalizeKey(provider)
+	if provider == "" {
+		return nil, ErrInvalidProvider
+	}
+	normalized := config.NormalizeExcludedModels(models)
+	if s == nil || s.cfg == nil {
+		if len(normalized) == 0 {
+			return nil, ErrProviderNotFound
+		}
+		return map[string][]string{provider: normalized}, nil
+	}
+	if len(normalized) == 0 {
+		if s.cfg.OAuthExcludedModels == nil {
+			return nil, ErrProviderNotFound
+		}
+		if _, ok := s.cfg.OAuthExcludedModels[provider]; !ok {
+			return nil, ErrProviderNotFound
+		}
+		delete(s.cfg.OAuthExcludedModels, provider)
+		if len(s.cfg.OAuthExcludedModels) == 0 {
+			s.cfg.OAuthExcludedModels = nil
+		}
+		return s.cfg.OAuthExcludedModels, nil
+	}
+	if s.cfg.OAuthExcludedModels == nil {
+		s.cfg.OAuthExcludedModels = make(map[string][]string)
+	}
+	s.cfg.OAuthExcludedModels[provider] = normalized
+	return s.cfg.OAuthExcludedModels, nil
+}
+
+func (s *Service) DeleteExcludedModels(provider string) (map[string][]string, error) {
+	provider = normalizeKey(provider)
+	if provider == "" {
+		return nil, ErrInvalidProvider
+	}
+	if s == nil || s.cfg == nil || s.cfg.OAuthExcludedModels == nil {
+		return nil, ErrProviderNotFound
+	}
+	if _, ok := s.cfg.OAuthExcludedModels[provider]; !ok {
+		return nil, ErrProviderNotFound
+	}
+	delete(s.cfg.OAuthExcludedModels, provider)
+	if len(s.cfg.OAuthExcludedModels) == 0 {
+		s.cfg.OAuthExcludedModels = nil
+	}
+	return s.cfg.OAuthExcludedModels, nil
+}
+
+func (s *Service) ModelAlias() map[string][]config.OAuthModelAlias {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return NormalizeModelAlias(s.cfg.OAuthModelAlias)
+}
+
+func (s *Service) SetModelAlias(entries map[string][]config.OAuthModelAlias) map[string][]config.OAuthModelAlias {
+	normalized := NormalizeModelAlias(entries)
+	if s == nil || s.cfg == nil {
+		return normalized
+	}
+	s.cfg.OAuthModelAlias = normalized
+	return s.cfg.OAuthModelAlias
+}
+
+func (s *Service) PatchModelAlias(channel string, aliases []config.OAuthModelAlias) (map[string][]config.OAuthModelAlias, error) {
+	channel = normalizeKey(channel)
+	if channel == "" {
+		return nil, ErrInvalidChannel
+	}
+	normalizedMap := NormalizeModelAlias(map[string][]config.OAuthModelAlias{channel: aliases})
+	normalized := normalizedMap[channel]
+	if s == nil || s.cfg == nil {
+		if len(normalized) == 0 {
+			return nil, ErrChannelNotFound
+		}
+		return map[string][]config.OAuthModelAlias{channel: normalized}, nil
+	}
+	if len(normalized) == 0 {
+		if s.cfg.OAuthModelAlias == nil {
+			return nil, ErrChannelNotFound
+		}
+		if _, ok := s.cfg.OAuthModelAlias[channel]; !ok {
+			return nil, ErrChannelNotFound
+		}
+		delete(s.cfg.OAuthModelAlias, channel)
+		if len(s.cfg.OAuthModelAlias) == 0 {
+			s.cfg.OAuthModelAlias = nil
+		}
+		return s.cfg.OAuthModelAlias, nil
+	}
+	if s.cfg.OAuthModelAlias == nil {
+		s.cfg.OAuthModelAlias = make(map[string][]config.OAuthModelAlias)
+	}
+	s.cfg.OAuthModelAlias[channel] = normalized
+	return s.cfg.OAuthModelAlias, nil
+}
+
+func (s *Service) DeleteModelAlias(channel string) (map[string][]config.OAuthModelAlias, error) {
+	channel = normalizeKey(channel)
+	if channel == "" {
+		return nil, ErrInvalidChannel
+	}
+	if s == nil || s.cfg == nil || s.cfg.OAuthModelAlias == nil {
+		return nil, ErrChannelNotFound
+	}
+	if _, ok := s.cfg.OAuthModelAlias[channel]; !ok {
+		return nil, ErrChannelNotFound
+	}
+	delete(s.cfg.OAuthModelAlias, channel)
+	if len(s.cfg.OAuthModelAlias) == 0 {
+		s.cfg.OAuthModelAlias = nil
+	}
+	return s.cfg.OAuthModelAlias, nil
+}
+
+func normalizeKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/management/settings/oauth/service_test.go
+++ b/internal/management/settings/oauth/service_test.go
@@ -1,0 +1,105 @@
+package oauth
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestServiceSetPatchAndDeleteExcludedModels(t *testing.T) {
+	cfg := &config.Config{}
+	service := NewService(cfg)
+
+	service.SetExcludedModels(map[string][]string{
+		" Codex ": {" gpt-5 ", "", "gpt-5"},
+		" ":       {"ignored"},
+	})
+	wantAfterSet := map[string][]string{"codex": {"gpt-5"}}
+	if !reflect.DeepEqual(cfg.OAuthExcludedModels, wantAfterSet) {
+		t.Fatalf("excluded models after set = %#v", cfg.OAuthExcludedModels)
+	}
+
+	if _, err := service.PatchExcludedModels(" CODEX ", []string{" gpt-5.3-codex "}); err != nil {
+		t.Fatalf("patch excluded models returned error: %v", err)
+	}
+	wantAfterPatch := map[string][]string{"codex": {"gpt-5.3-codex"}}
+	if !reflect.DeepEqual(cfg.OAuthExcludedModels, wantAfterPatch) {
+		t.Fatalf("excluded models after patch = %#v", cfg.OAuthExcludedModels)
+	}
+
+	if _, err := service.PatchExcludedModels("codex", nil); err != nil {
+		t.Fatalf("empty patch should delete existing provider: %v", err)
+	}
+	if cfg.OAuthExcludedModels != nil {
+		t.Fatalf("excluded models were not cleared: %#v", cfg.OAuthExcludedModels)
+	}
+
+	if _, err := service.PatchExcludedModels("codex", nil); !errors.Is(err, ErrProviderNotFound) {
+		t.Fatalf("missing provider patch error = %v, want ErrProviderNotFound", err)
+	}
+	if _, err := service.DeleteExcludedModels(" "); !errors.Is(err, ErrInvalidProvider) {
+		t.Fatalf("blank delete error = %v, want ErrInvalidProvider", err)
+	}
+}
+
+func TestServiceSetPatchAndDeleteModelAlias(t *testing.T) {
+	cfg := &config.Config{}
+	service := NewService(cfg)
+
+	service.SetModelAlias(map[string][]config.OAuthModelAlias{
+		" Codex ": {
+			{Name: " gpt-5.3-codex ", Alias: " codex-latest ", Fork: true},
+			{Name: "same", Alias: "same"},
+			{Name: "", Alias: "ignored"},
+		},
+	})
+	wantAfterSet := map[string][]config.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.3-codex", Alias: "codex-latest", Fork: true}},
+	}
+	if !reflect.DeepEqual(cfg.OAuthModelAlias, wantAfterSet) {
+		t.Fatalf("model alias after set = %#v", cfg.OAuthModelAlias)
+	}
+
+	if _, err := service.PatchModelAlias(" CODEX ", []config.OAuthModelAlias{
+		{Name: "gpt-5.3-codex", Alias: "codex-main"},
+		{Name: "gpt-5.3-codex", Alias: "codex-main"},
+	}); err != nil {
+		t.Fatalf("patch model alias returned error: %v", err)
+	}
+	wantAfterPatch := map[string][]config.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.3-codex", Alias: "codex-main"}},
+	}
+	if !reflect.DeepEqual(cfg.OAuthModelAlias, wantAfterPatch) {
+		t.Fatalf("model alias after patch = %#v", cfg.OAuthModelAlias)
+	}
+
+	if _, err := service.PatchModelAlias("codex", nil); err != nil {
+		t.Fatalf("empty patch should delete existing channel: %v", err)
+	}
+	if cfg.OAuthModelAlias != nil {
+		t.Fatalf("model alias was not cleared: %#v", cfg.OAuthModelAlias)
+	}
+
+	if _, err := service.PatchModelAlias("codex", nil); !errors.Is(err, ErrChannelNotFound) {
+		t.Fatalf("missing channel patch error = %v, want ErrChannelNotFound", err)
+	}
+	if _, err := service.DeleteModelAlias(" "); !errors.Is(err, ErrInvalidChannel) {
+		t.Fatalf("blank delete error = %v, want ErrInvalidChannel", err)
+	}
+}
+
+func TestNormalizeModelAliasDoesNotMutateInput(t *testing.T) {
+	input := map[string][]config.OAuthModelAlias{
+		" Codex ": {{Name: " gpt-5.3-codex ", Alias: " codex-latest "}},
+	}
+
+	normalized := NormalizeModelAlias(input)
+	if _, ok := normalized["codex"]; !ok {
+		t.Fatalf("normalized aliases = %#v", normalized)
+	}
+	if input[" Codex "][0].Name != " gpt-5.3-codex " {
+		t.Fatalf("input was mutated: %#v", input)
+	}
+}


### PR DESCRIPTION
## Summary
- Move OAuth excluded-model and model-alias mutation logic into `internal/management/settings/oauth`.
- Keep management handlers focused on request binding, status mapping, and runtime setting persistence.
- Reuse the new alias normalization path from channel rename handling.
- Add focused unit coverage for OAuth settings normalization, patch, and delete behavior.
- Refresh backend structure baseline and tighten the `config_lists.go` allowlist after reducing the file.

## Validation
- `go test ./internal/api/... ./internal/management/... ./internal/config`
- `python3 scripts/check-backend-structure.py`
- `python3 -m json.tool docs/internal-review/backend-structure-allowlist.json`
- `git diff --check`
- Sensitive-string scan reviewed; matches are generic code identifiers/routes only.