### PR TITLE
fix: gate auto updates on docker publish readiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV VITE_PANEL_REF=${FRONTEND_REF}
 ENV VITE_PANEL_COMMIT=${FRONTEND_COMMIT}
 ENV VITE_PANEL_BUILD_DATE=${BUILD_DATE}
 RUN bun install --frozen-lockfile
-RUN bunx vite build
+RUN bun run build
 
 # ── Backend build ────────────────────────────────────────────────────────────
 FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS backend-builder

--- a/internal/api/handlers/management/update.go
+++ b/internal/api/handlers/management/update.go
@@ -27,6 +27,7 @@ const (
 	githubTokenEnv        = "CLIRELAY_GITHUB_TOKEN"
 	autoUpdateChannelEnv  = "CLIRELAY_UPDATE_CHANNEL"
 	defaultUpdaterService = "clirelay"
+	dockerPublishWorkflow = "docker-publish.yml"
 )
 
 type updateCheckResponse struct {
@@ -80,13 +81,36 @@ type branchCommitInfo struct {
 	SHA     string `json:"sha"`
 	HTMLURL string `json:"html_url"`
 	Commit  struct {
-		Message string `json:"message"`
+		Message   string         `json:"message"`
+		Author    gitCommitActor `json:"author"`
+		Committer gitCommitActor `json:"committer"`
 	} `json:"commit"`
 }
 
+type gitCommitActor struct {
+	Date time.Time `json:"date"`
+}
+
+type workflowRunInfo struct {
+	ID         int64     `json:"id"`
+	HTMLURL    string    `json:"html_url"`
+	HeadSHA    string    `json:"head_sha"`
+	HeadBranch string    `json:"head_branch"`
+	Status     string    `json:"status"`
+	Conclusion string    `json:"conclusion"`
+	Event      string    `json:"event"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type workflowRunsResponse struct {
+	WorkflowRuns []workflowRunInfo `json:"workflow_runs"`
+}
+
 var (
-	fetchBranchCommitForUpdateCheck      = fetchBranchCommit
-	fetchLatestReleaseInfoForUpdateCheck = fetchLatestReleaseInfo
+	fetchBranchCommitForUpdateCheck                = fetchBranchCommit
+	fetchLatestReleaseInfoForUpdateCheck           = fetchLatestReleaseInfo
+	fetchLatestSuccessfulWorkflowRunForUpdateCheck = fetchLatestSuccessfulWorkflowRun
 )
 
 func (h *Handler) GetAutoUpdateEnabled(c *gin.Context) {
@@ -165,7 +189,11 @@ func (h *Handler) ApplyUpdate(c *gin.Context) {
 		return
 	}
 	if !check.UpdateAvailable {
-		c.JSON(http.StatusOK, gin.H{"status": "noop", "message": "already up to date"})
+		message := strings.TrimSpace(check.Message)
+		if message == "" {
+			message = "already up to date"
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "noop", "message": message})
 		return
 	}
 
@@ -259,6 +287,16 @@ func (h *Handler) buildUpdateCheck(ctx context.Context) (*updateCheckResponse, e
 
 	backendUpdateAvailable := branchErr == nil && autoUpdateAvailableFromCommit(currentCommit, branch.SHA)
 	frontendUpdateAvailable := frontendErr == nil && autoUpdateAvailableFromCommit(currentUICommit, frontendBranch.SHA)
+	rawUpdateAvailable := backendUpdateAvailable || frontendUpdateAvailable
+
+	dockerPublishReady := true
+	dockerPublishMessage := ""
+	if cfg.AutoUpdate.Enabled && rawUpdateAvailable && branchErr == nil && frontendErr == nil && shouldVerifyDockerPublish(cfg, repo) {
+		if err := verifyDockerPublishReady(ctx, client, repo, channel, branch, frontendBranch); err != nil {
+			dockerPublishReady = false
+			dockerPublishMessage = err.Error()
+		}
+	}
 
 	resp := &updateCheckResponse{
 		Enabled:           cfg.AutoUpdate.Enabled,
@@ -278,13 +316,15 @@ func (h *Handler) buildUpdateCheck(ctx context.Context) (*updateCheckResponse, e
 		DockerTag:         dockerTagForChannel(channel, branch.SHA),
 		ReleaseNotes:      releaseNotes,
 		ReleaseURL:        strings.TrimSpace(release.HTMLURL),
-		UpdateAvailable:   cfg.AutoUpdate.Enabled && (backendUpdateAvailable || frontendUpdateAvailable),
+		UpdateAvailable:   cfg.AutoUpdate.Enabled && rawUpdateAvailable && dockerPublishReady,
 		UpdaterAvailable:  checkUpdaterAvailable(ctx, cfg),
 	}
 	if !resp.Enabled {
 		resp.Message = "auto update disabled"
 	} else if branchErr != nil || frontendErr != nil {
 		resp.Message = buildUpdateCheckWarning(branchErr, frontendErr)
+	} else if !dockerPublishReady {
+		resp.Message = dockerPublishMessage
 	} else if !resp.UpdateAvailable {
 		resp.Message = "already up to date"
 	}
@@ -421,6 +461,96 @@ func fetchLatestReleaseInfo(ctx context.Context, client *http.Client, repo strin
 		return info, fmt.Errorf("github release status %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
 	}
 	return info, json.NewDecoder(resp.Body).Decode(&info)
+}
+
+func fetchLatestSuccessfulWorkflowRun(ctx context.Context, client *http.Client, repo string, workflow string, branch string) (workflowRunInfo, error) {
+	var info workflowRunInfo
+	endpoint := githubAPIURL(repo, "actions/workflows/"+url.PathEscape(strings.TrimSpace(workflow))+"/runs")
+	query := url.Values{}
+	query.Set("branch", strings.TrimSpace(branch))
+	query.Set("status", "success")
+	query.Set("per_page", "20")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+query.Encode(), nil)
+	if err != nil {
+		return info, err
+	}
+	applyGitHubAPIHeaders(req)
+	resp, err := client.Do(req)
+	if err != nil {
+		return info, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return info, fmt.Errorf("github workflow runs status %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	var payload workflowRunsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return info, err
+	}
+	for _, run := range payload.WorkflowRuns {
+		if strings.EqualFold(strings.TrimSpace(run.Status), "completed") &&
+			strings.EqualFold(strings.TrimSpace(run.Conclusion), "success") {
+			return run, nil
+		}
+	}
+	return info, fmt.Errorf("no successful %s run found for %s", workflow, strings.TrimSpace(branch))
+}
+
+func shouldVerifyDockerPublish(cfg *config.Config, repo string) bool {
+	if cfg == nil {
+		return false
+	}
+	return normalizeGitHubRepository(repo) == normalizeGitHubRepository(config.DefaultAutoUpdateRepository) &&
+		strings.EqualFold(strings.TrimSpace(cfg.AutoUpdate.DockerImage), config.DefaultAutoUpdateDockerImage)
+}
+
+func verifyDockerPublishReady(ctx context.Context, client *http.Client, repo string, channel string, backend branchCommitInfo, frontend branchCommitInfo) error {
+	run, err := fetchLatestSuccessfulWorkflowRunForUpdateCheck(ctx, client, repo, dockerPublishWorkflow, channel)
+	if err != nil {
+		return fmt.Errorf("docker image readiness check failed: %w", err)
+	}
+	if !sameCommit(run.HeadSHA, backend.SHA) {
+		return fmt.Errorf(
+			"docker image for %s is not ready; latest successful publish is %s but branch head is %s",
+			channel,
+			shortCommit(run.HeadSHA),
+			shortCommit(backend.SHA),
+		)
+	}
+
+	sourceTime := latestCommitTime(backend, frontend)
+	runTime := run.CreatedAt
+	if runTime.IsZero() {
+		runTime = run.UpdatedAt
+	}
+	if !sourceTime.IsZero() && !runTime.IsZero() && runTime.Before(sourceTime) {
+		return fmt.Errorf("docker image for %s is not ready; latest successful publish predates the latest source commit", channel)
+	}
+	return nil
+}
+
+func latestCommitTime(commits ...branchCommitInfo) time.Time {
+	var latest time.Time
+	for _, commit := range commits {
+		candidate := commit.Commit.Committer.Date
+		if candidate.IsZero() {
+			candidate = commit.Commit.Author.Date
+		}
+		if candidate.After(latest) {
+			latest = candidate
+		}
+	}
+	return latest
+}
+
+func sameCommit(left string, right string) bool {
+	a := strings.ToLower(strings.TrimSpace(left))
+	b := strings.ToLower(strings.TrimSpace(right))
+	if a == "" || b == "" {
+		return false
+	}
+	return strings.HasPrefix(a, b) || strings.HasPrefix(b, a)
 }
 
 func inferAutoUpdateChannel(version string, envChannel string) string {

--- a/internal/api/handlers/management/update_test.go
+++ b/internal/api/handlers/management/update_test.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo"
@@ -229,6 +230,231 @@ func TestBuildUpdateCheckGracefullyHandlesGitHubFailures(t *testing.T) {
 	}
 }
 
+func TestBuildUpdateCheckWaitsForDevDockerPublishRun(t *testing.T) {
+	origFetchBranchCommit := fetchBranchCommitForUpdateCheck
+	origFetchLatestRelease := fetchLatestReleaseInfoForUpdateCheck
+	origFetchWorkflowRun := fetchLatestSuccessfulWorkflowRunForUpdateCheck
+	origVersion := buildinfo.Version
+	origCommit := buildinfo.Commit
+	origFrontendVersion := buildinfo.FrontendVersion
+	origFrontendCommit := buildinfo.FrontendCommit
+	origFrontendRef := buildinfo.FrontendRef
+	t.Cleanup(func() {
+		fetchBranchCommitForUpdateCheck = origFetchBranchCommit
+		fetchLatestReleaseInfoForUpdateCheck = origFetchLatestRelease
+		fetchLatestSuccessfulWorkflowRunForUpdateCheck = origFetchWorkflowRun
+		buildinfo.Version = origVersion
+		buildinfo.Commit = origCommit
+		buildinfo.FrontendVersion = origFrontendVersion
+		buildinfo.FrontendCommit = origFrontendCommit
+		buildinfo.FrontendRef = origFrontendRef
+	})
+
+	currentBackend := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	latestBackend := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	frontendCommit := "cccccccccccccccccccccccccccccccccccccccc"
+	sourceTime := time.Date(2026, 6, 6, 10, 30, 0, 0, time.UTC)
+
+	fetchBranchCommitForUpdateCheck = func(ctx context.Context, client *http.Client, repo string, channel string) (branchCommitInfo, error) {
+		switch repo {
+		case "kittors/CliRelay":
+			return branchCommitAt(latestBackend, sourceTime), nil
+		case "kittors/codeProxy":
+			return branchCommitAt(frontendCommit, sourceTime.Add(-time.Minute)), nil
+		default:
+			t.Fatalf("unexpected repo %q", repo)
+			return branchCommitInfo{}, nil
+		}
+	}
+	fetchLatestReleaseInfoForUpdateCheck = func(ctx context.Context, client *http.Client, repo string) (releaseInfo, error) {
+		return releaseInfo{}, nil
+	}
+	fetchLatestSuccessfulWorkflowRunForUpdateCheck = func(ctx context.Context, client *http.Client, repo string, workflow string, branch string) (workflowRunInfo, error) {
+		if workflow != dockerPublishWorkflow {
+			t.Fatalf("workflow = %q, want %q", workflow, dockerPublishWorkflow)
+		}
+		return workflowRunInfo{
+			HeadSHA:    currentBackend,
+			Status:     "completed",
+			Conclusion: "success",
+			CreatedAt:  sourceTime.Add(-time.Hour),
+		}, nil
+	}
+
+	buildinfo.Version = "dev-" + shortCommit(currentBackend)
+	buildinfo.Commit = currentBackend
+	buildinfo.FrontendVersion = "panel-dev-" + shortCommit(frontendCommit)
+	buildinfo.FrontendCommit = frontendCommit
+	buildinfo.FrontendRef = "dev"
+
+	cfg := &config.Config{}
+	cfg.AutoUpdate.Enabled = true
+	cfg.AutoUpdate.Channel = "dev"
+	cfg.AutoUpdate.Repository = config.DefaultAutoUpdateRepository
+	cfg.AutoUpdate.DockerImage = config.DefaultAutoUpdateDockerImage
+	cfg.RemoteManagement.PanelGitHubRepository = config.DefaultPanelGitHubRepository
+
+	resp, err := (&Handler{cfg: cfg}).buildUpdateCheck(context.Background())
+	if err != nil {
+		t.Fatalf("buildUpdateCheck() error = %v, want nil", err)
+	}
+	if resp.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = true, want false while dev image publish has not completed")
+	}
+	if !strings.Contains(resp.Message, "not ready") {
+		t.Fatalf("Message = %q, want docker publish readiness warning", resp.Message)
+	}
+	if resp.LatestCommit != latestBackend {
+		t.Fatalf("LatestCommit = %q, want branch head %q", resp.LatestCommit, latestBackend)
+	}
+}
+
+func TestBuildUpdateCheckWaitsForFrontendDevDockerRebuild(t *testing.T) {
+	origFetchBranchCommit := fetchBranchCommitForUpdateCheck
+	origFetchLatestRelease := fetchLatestReleaseInfoForUpdateCheck
+	origFetchWorkflowRun := fetchLatestSuccessfulWorkflowRunForUpdateCheck
+	origVersion := buildinfo.Version
+	origCommit := buildinfo.Commit
+	origFrontendVersion := buildinfo.FrontendVersion
+	origFrontendCommit := buildinfo.FrontendCommit
+	origFrontendRef := buildinfo.FrontendRef
+	t.Cleanup(func() {
+		fetchBranchCommitForUpdateCheck = origFetchBranchCommit
+		fetchLatestReleaseInfoForUpdateCheck = origFetchLatestRelease
+		fetchLatestSuccessfulWorkflowRunForUpdateCheck = origFetchWorkflowRun
+		buildinfo.Version = origVersion
+		buildinfo.Commit = origCommit
+		buildinfo.FrontendVersion = origFrontendVersion
+		buildinfo.FrontendCommit = origFrontendCommit
+		buildinfo.FrontendRef = origFrontendRef
+	})
+
+	backendCommit := "dddddddddddddddddddddddddddddddddddddddd"
+	currentFrontend := "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	latestFrontend := "ffffffffffffffffffffffffffffffffffffffff"
+	frontendTime := time.Date(2026, 6, 6, 11, 0, 0, 0, time.UTC)
+
+	fetchBranchCommitForUpdateCheck = func(ctx context.Context, client *http.Client, repo string, channel string) (branchCommitInfo, error) {
+		switch repo {
+		case "kittors/CliRelay":
+			return branchCommitAt(backendCommit, frontendTime.Add(-time.Hour)), nil
+		case "kittors/codeProxy":
+			return branchCommitAt(latestFrontend, frontendTime), nil
+		default:
+			t.Fatalf("unexpected repo %q", repo)
+			return branchCommitInfo{}, nil
+		}
+	}
+	fetchLatestReleaseInfoForUpdateCheck = func(ctx context.Context, client *http.Client, repo string) (releaseInfo, error) {
+		return releaseInfo{}, nil
+	}
+	fetchLatestSuccessfulWorkflowRunForUpdateCheck = func(ctx context.Context, client *http.Client, repo string, workflow string, branch string) (workflowRunInfo, error) {
+		return workflowRunInfo{
+			HeadSHA:    backendCommit,
+			Status:     "completed",
+			Conclusion: "success",
+			CreatedAt:  frontendTime.Add(-time.Minute),
+		}, nil
+	}
+
+	buildinfo.Version = "dev-" + shortCommit(backendCommit)
+	buildinfo.Commit = backendCommit
+	buildinfo.FrontendVersion = "panel-dev-" + shortCommit(currentFrontend)
+	buildinfo.FrontendCommit = currentFrontend
+	buildinfo.FrontendRef = "dev"
+
+	cfg := &config.Config{}
+	cfg.AutoUpdate.Enabled = true
+	cfg.AutoUpdate.Channel = "dev"
+	cfg.AutoUpdate.Repository = config.DefaultAutoUpdateRepository
+	cfg.AutoUpdate.DockerImage = config.DefaultAutoUpdateDockerImage
+	cfg.RemoteManagement.PanelGitHubRepository = config.DefaultPanelGitHubRepository
+
+	resp, err := (&Handler{cfg: cfg}).buildUpdateCheck(context.Background())
+	if err != nil {
+		t.Fatalf("buildUpdateCheck() error = %v, want nil", err)
+	}
+	if resp.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = true, want false while frontend dev rebuild has not been published")
+	}
+	if !strings.Contains(resp.Message, "predates the latest source commit") {
+		t.Fatalf("Message = %q, want frontend rebuild readiness warning", resp.Message)
+	}
+}
+
+func TestBuildUpdateCheckAllowsDevUpdateAfterDockerPublishReady(t *testing.T) {
+	origFetchBranchCommit := fetchBranchCommitForUpdateCheck
+	origFetchLatestRelease := fetchLatestReleaseInfoForUpdateCheck
+	origFetchWorkflowRun := fetchLatestSuccessfulWorkflowRunForUpdateCheck
+	origVersion := buildinfo.Version
+	origCommit := buildinfo.Commit
+	origFrontendVersion := buildinfo.FrontendVersion
+	origFrontendCommit := buildinfo.FrontendCommit
+	origFrontendRef := buildinfo.FrontendRef
+	t.Cleanup(func() {
+		fetchBranchCommitForUpdateCheck = origFetchBranchCommit
+		fetchLatestReleaseInfoForUpdateCheck = origFetchLatestRelease
+		fetchLatestSuccessfulWorkflowRunForUpdateCheck = origFetchWorkflowRun
+		buildinfo.Version = origVersion
+		buildinfo.Commit = origCommit
+		buildinfo.FrontendVersion = origFrontendVersion
+		buildinfo.FrontendCommit = origFrontendCommit
+		buildinfo.FrontendRef = origFrontendRef
+	})
+
+	currentBackend := "1111111111111111111111111111111111111111"
+	latestBackend := "2222222222222222222222222222222222222222"
+	frontendCommit := "3333333333333333333333333333333333333333"
+	sourceTime := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+
+	fetchBranchCommitForUpdateCheck = func(ctx context.Context, client *http.Client, repo string, channel string) (branchCommitInfo, error) {
+		switch repo {
+		case "kittors/CliRelay":
+			return branchCommitAt(latestBackend, sourceTime), nil
+		case "kittors/codeProxy":
+			return branchCommitAt(frontendCommit, sourceTime), nil
+		default:
+			t.Fatalf("unexpected repo %q", repo)
+			return branchCommitInfo{}, nil
+		}
+	}
+	fetchLatestReleaseInfoForUpdateCheck = func(ctx context.Context, client *http.Client, repo string) (releaseInfo, error) {
+		return releaseInfo{}, nil
+	}
+	fetchLatestSuccessfulWorkflowRunForUpdateCheck = func(ctx context.Context, client *http.Client, repo string, workflow string, branch string) (workflowRunInfo, error) {
+		return workflowRunInfo{
+			HeadSHA:    latestBackend,
+			Status:     "completed",
+			Conclusion: "success",
+			CreatedAt:  sourceTime.Add(time.Minute),
+		}, nil
+	}
+
+	buildinfo.Version = "dev-" + shortCommit(currentBackend)
+	buildinfo.Commit = currentBackend
+	buildinfo.FrontendVersion = "panel-dev-" + shortCommit(frontendCommit)
+	buildinfo.FrontendCommit = frontendCommit
+	buildinfo.FrontendRef = "dev"
+
+	cfg := &config.Config{}
+	cfg.AutoUpdate.Enabled = true
+	cfg.AutoUpdate.Channel = "dev"
+	cfg.AutoUpdate.Repository = config.DefaultAutoUpdateRepository
+	cfg.AutoUpdate.DockerImage = config.DefaultAutoUpdateDockerImage
+	cfg.RemoteManagement.PanelGitHubRepository = config.DefaultPanelGitHubRepository
+
+	resp, err := (&Handler{cfg: cfg}).buildUpdateCheck(context.Background())
+	if err != nil {
+		t.Fatalf("buildUpdateCheck() error = %v, want nil", err)
+	}
+	if !resp.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = false, want true after dev image publish completes; message=%q", resp.Message)
+	}
+	if resp.Message != "" {
+		t.Fatalf("Message = %q, want empty for available update", resp.Message)
+	}
+}
+
 func TestBuildUpdateCheckUsesConfiguredPanelRepository(t *testing.T) {
 	origFetchBranchCommit := fetchBranchCommitForUpdateCheck
 	origFetchLatestRelease := fetchLatestReleaseInfoForUpdateCheck
@@ -437,6 +663,12 @@ func TestFetchUpdateProgressProxiesUpdaterStatus(t *testing.T) {
 	if len(progress.Logs) != 1 || progress.Logs[0].Message != "docker compose pull clirelay" {
 		t.Fatalf("Logs = %+v, want updater log entry", progress.Logs)
 	}
+}
+
+func branchCommitAt(sha string, at time.Time) branchCommitInfo {
+	info := branchCommitInfo{SHA: sha}
+	info.Commit.Committer.Date = at
+	return info
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)


### PR DESCRIPTION
## Summary
- gate Docker update availability on the latest successful docker publish workflow for the selected channel
- keep dev updates hidden while the publish workflow is pending, failed, or older than the target source commits
- use the workspace build script for the embedded management panel build in Docker images

## Validation
- go test ./internal/api/handlers/management
- go test ./internal/api/... ./cmd/updater
- python3 scripts/check-backend-structure.py
- git diff --check
- bun run build in the management panel workspace