### PR TITLE
refactor: move api key settings use cases

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	ampsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/amp"
+	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
 	oauthsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/oauth"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -30,6 +32,13 @@ func (h *Handler) refreshAPIKeyCache() {
 	if h.accessManager != nil {
 		_, _ = access.ApplyAccessProviders(h.accessManager, nil, h.cfg)
 	}
+}
+
+func (h *Handler) apiKeySettings() *apikeysettings.Service {
+	if h == nil {
+		return apikeysettings.NewService(nil)
+	}
+	return apikeysettings.NewService(h.sanitizeAllowedChannelsForSave)
 }
 
 // Generic helpers for list[string]
@@ -129,14 +138,7 @@ func (h *Handler) deleteFromStringList(c *gin.Context, target *[]string, after f
 
 // api-keys (legacy simple list — now backed by SQLite)
 func (h *Handler) GetAPIKeys(c *gin.Context) {
-	rows := usage.ListAPIKeys()
-	keys := make([]string, 0, len(rows))
-	for _, r := range rows {
-		if !r.Disabled {
-			keys = append(keys, r.Key)
-		}
-	}
-	c.JSON(200, gin.H{"api-keys": keys})
+	c.JSON(200, gin.H{"api-keys": h.apiKeySettings().EnabledKeys()})
 }
 func (h *Handler) PutAPIKeys(c *gin.Context) {
 	data, err := c.GetRawData()
@@ -155,14 +157,7 @@ func (h *Handler) PutAPIKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
-	var rows []usage.APIKeyRow
-	for _, k := range arr {
-		trimmed := strings.TrimSpace(k)
-		if trimmed != "" {
-			rows = append(rows, usage.APIKeyRow{Key: trimmed})
-		}
-	}
-	if err := usage.ReplaceAllAPIKeys(rows); err != nil {
+	if err := h.apiKeySettings().ReplaceKeys(arr); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -178,35 +173,28 @@ func (h *Handler) PatchAPIKeys(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	oldKey := strings.TrimSpace(*body.Old)
-	newKey := strings.TrimSpace(*body.New)
-	if oldKey != "" {
-		_ = usage.DeleteAPIKey(oldKey)
-	}
-	if newKey != "" {
-		if err := usage.UpsertAPIKey(usage.APIKeyRow{Key: newKey}); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
+	if err := h.apiKeySettings().PatchKey(*body.Old, *body.New); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
 	h.refreshAPIKeyCache()
 	c.JSON(200, gin.H{"status": "ok"})
 }
 func (h *Handler) DeleteAPIKeys(c *gin.Context) {
-	if val := strings.TrimSpace(c.Query("value")); val != "" {
-		if err := usage.DeleteAPIKey(val); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.apiKeySettings().DeleteKey(c.Query("value")); err != nil {
+		if errors.Is(err, apikeysettings.ErrMissingValue) {
+			c.JSON(400, gin.H{"error": "missing value"})
 			return
 		}
-		h.refreshAPIKeyCache()
-		c.JSON(200, gin.H{"status": "ok"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(400, gin.H{"error": "missing value"})
+	h.refreshAPIKeyCache()
+	c.JSON(200, gin.H{"status": "ok"})
 }
 
 func (h *Handler) GetAPIKeyPermissionProfiles(c *gin.Context) {
-	profiles := usage.ListAPIKeyPermissionProfiles()
+	profiles := h.apiKeySettings().PermissionProfiles()
 	c.JSON(200, gin.H{
 		"api-key-permission-profiles": profiles,
 		"items":                       profiles,
@@ -232,26 +220,7 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 		profiles = obj.Items
 	}
 
-	for idx := range profiles {
-		profiles[idx].ID = strings.TrimSpace(profiles[idx].ID)
-		profiles[idx].Name = strings.TrimSpace(profiles[idx].Name)
-		if profiles[idx].ID == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
-			return
-		}
-		if profiles[idx].Name == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
-			return
-		}
-		if cleaned, errClean := h.sanitizeAllowedChannelsForSave(profiles[idx].AllowedChannels); errClean != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": errClean.Error()})
-			return
-		} else {
-			profiles[idx].AllowedChannels = cleaned
-		}
-	}
-
-	if err := usage.ReplaceAllAPIKeyPermissionProfiles(profiles); err != nil {
+	if err := h.apiKeySettings().ReplacePermissionProfiles(profiles); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -1,0 +1,93 @@
+package apikey
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+var (
+	ErrInvalidProfileID   = errors.New("id is required")
+	ErrInvalidProfileName = errors.New("name is required")
+	ErrMissingValue       = errors.New("missing value")
+)
+
+type ChannelSanitizer func([]string) ([]string, error)
+
+type Service struct {
+	sanitizeChannels ChannelSanitizer
+}
+
+func NewService(sanitizeChannels ChannelSanitizer) *Service {
+	return &Service{sanitizeChannels: sanitizeChannels}
+}
+
+func (s *Service) EnabledKeys() []string {
+	rows := usage.ListAPIKeys()
+	keys := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if !row.Disabled {
+			keys = append(keys, row.Key)
+		}
+	}
+	return keys
+}
+
+func (s *Service) ReplaceKeys(keys []string) error {
+	rows := make([]usage.APIKeyRow, 0, len(keys))
+	for _, key := range keys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed != "" {
+			rows = append(rows, usage.APIKeyRow{Key: trimmed})
+		}
+	}
+	return usage.ReplaceAllAPIKeys(rows)
+}
+
+func (s *Service) PatchKey(oldKey string, newKey string) error {
+	oldKey = strings.TrimSpace(oldKey)
+	newKey = strings.TrimSpace(newKey)
+	if oldKey != "" {
+		_ = usage.DeleteAPIKey(oldKey)
+	}
+	if newKey == "" {
+		return nil
+	}
+	return usage.UpsertAPIKey(usage.APIKeyRow{Key: newKey})
+}
+
+func (s *Service) DeleteKey(key string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ErrMissingValue
+	}
+	return usage.DeleteAPIKey(key)
+}
+
+func (s *Service) PermissionProfiles() []usage.APIKeyPermissionProfileRow {
+	return usage.ListAPIKeyPermissionProfiles()
+}
+
+func (s *Service) ReplacePermissionProfiles(profiles []usage.APIKeyPermissionProfileRow) error {
+	normalized := make([]usage.APIKeyPermissionProfileRow, len(profiles))
+	copy(normalized, profiles)
+	for idx := range normalized {
+		normalized[idx].ID = strings.TrimSpace(normalized[idx].ID)
+		normalized[idx].Name = strings.TrimSpace(normalized[idx].Name)
+		if normalized[idx].ID == "" {
+			return ErrInvalidProfileID
+		}
+		if normalized[idx].Name == "" {
+			return ErrInvalidProfileName
+		}
+		if s != nil && s.sanitizeChannels != nil {
+			cleaned, err := s.sanitizeChannels(normalized[idx].AllowedChannels)
+			if err != nil {
+				return err
+			}
+			normalized[idx].AllowedChannels = cleaned
+		}
+	}
+	return usage.ReplaceAllAPIKeyPermissionProfiles(normalized)
+}

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -1,0 +1,123 @@
+package apikey
+
+import (
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func setupTestDB(t *testing.T) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "apikey-settings-*.db")
+	if err != nil {
+		t.Fatalf("create temp db: %v", err)
+	}
+	dbPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+}
+
+func TestReplaceKeysNormalizesAndListsEnabledKeys(t *testing.T) {
+	setupTestDB(t)
+	svc := NewService(nil)
+
+	if err := svc.ReplaceKeys([]string{" sk-one ", "", "sk-two"}); err != nil {
+		t.Fatalf("ReplaceKeys() error = %v, want nil", err)
+	}
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{Key: "sk-disabled", Disabled: true}); err != nil {
+		t.Fatalf("UpsertAPIKey(disabled): %v", err)
+	}
+
+	if got := svc.EnabledKeys(); !reflect.DeepEqual(got, []string{"sk-one", "sk-two"}) {
+		t.Fatalf("EnabledKeys() = %#v, want sk-one/sk-two", got)
+	}
+}
+
+func TestPatchAndDeleteKey(t *testing.T) {
+	setupTestDB(t)
+	svc := NewService(nil)
+
+	if err := svc.PatchKey("", " sk-created "); err != nil {
+		t.Fatalf("PatchKey(create) error = %v, want nil", err)
+	}
+	if got := usage.GetAPIKey("sk-created"); got == nil {
+		t.Fatal("PatchKey(create) did not persist new key")
+	}
+	if err := svc.PatchKey(" sk-created ", " sk-renamed "); err != nil {
+		t.Fatalf("PatchKey(rename) error = %v, want nil", err)
+	}
+	if got := usage.GetAPIKey("sk-created"); got != nil {
+		t.Fatal("PatchKey(rename) kept old key")
+	}
+	if got := usage.GetAPIKey("sk-renamed"); got == nil {
+		t.Fatal("PatchKey(rename) did not persist new key")
+	}
+	if err := svc.DeleteKey(" sk-renamed "); err != nil {
+		t.Fatalf("DeleteKey() error = %v, want nil", err)
+	}
+	if got := usage.GetAPIKey("sk-renamed"); got != nil {
+		t.Fatal("DeleteKey() kept deleted key")
+	}
+	if err := svc.DeleteKey(" "); !errors.Is(err, ErrMissingValue) {
+		t.Fatalf("DeleteKey(blank) error = %v, want ErrMissingValue", err)
+	}
+}
+
+func TestReplacePermissionProfilesValidatesAndSanitizes(t *testing.T) {
+	setupTestDB(t)
+	svc := NewService(func(channels []string) ([]string, error) {
+		out := make([]string, 0, len(channels))
+		for _, channel := range channels {
+			if channel == "drop" {
+				continue
+			}
+			out = append(out, channel)
+		}
+		return out, nil
+	})
+
+	err := svc.ReplacePermissionProfiles([]usage.APIKeyPermissionProfileRow{{
+		ID:              " standard ",
+		Name:            " Standard ",
+		AllowedChannels: []string{"keep", "drop"},
+	}})
+	if err != nil {
+		t.Fatalf("ReplacePermissionProfiles() error = %v, want nil", err)
+	}
+
+	got := svc.PermissionProfiles()
+	if len(got) != 1 {
+		t.Fatalf("PermissionProfiles() len = %d, want 1", len(got))
+	}
+	if got[0].ID != "standard" || got[0].Name != "Standard" {
+		t.Fatalf("profile identity = %#v, want trimmed values", got[0])
+	}
+	if !reflect.DeepEqual(got[0].AllowedChannels, []string{"keep"}) {
+		t.Fatalf("AllowedChannels = %#v, want keep", got[0].AllowedChannels)
+	}
+}
+
+func TestReplacePermissionProfilesRejectsMissingIdentity(t *testing.T) {
+	setupTestDB(t)
+	svc := NewService(nil)
+
+	if err := svc.ReplacePermissionProfiles([]usage.APIKeyPermissionProfileRow{{Name: "Name"}}); !errors.Is(err, ErrInvalidProfileID) {
+		t.Fatalf("missing id error = %v, want ErrInvalidProfileID", err)
+	}
+	if err := svc.ReplacePermissionProfiles([]usage.APIKeyPermissionProfileRow{{ID: "standard"}}); !errors.Is(err, ErrInvalidProfileName) {
+		t.Fatalf("missing name error = %v, want ErrInvalidProfileName", err)
+	}
+}


### PR DESCRIPTION
Summary:
- Add a management settings service for legacy API key list and permission profile use cases.
- Move normalization, validation, channel sanitization, and SQLite write coordination out of the management handler.
- Keep handler responsibilities focused on JSON binding, HTTP responses, and cache refresh; leave API key entry routing validation for a separate follow-up.

Validation:
- go test ./internal/management/settings/apikey
- go test ./internal/api/handlers/management -run 'APIKey|PermissionProfile'
- go test ./internal/api/handlers/management ./internal/management/settings/...
- python3 scripts/check-backend-structure.py
- git diff --check