### PR TITLE
refactor: move provider key settings use cases

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -506,7 +506,7 @@ func shouldDeleteAPIKeyLogs(c *gin.Context) bool {
 
 // gemini-api-key: []GeminiKey
 func (h *Handler) GetGeminiKeys(c *gin.Context) {
-	c.JSON(200, gin.H{"gemini-api-key": h.cfg.GeminiKey})
+	c.JSON(200, gin.H{"gemini-api-key": providerSettingsService(h).GeminiKeys()})
 }
 func (h *Handler) PutGeminiKeys(c *gin.Context) {
 	data, err := c.GetRawData()
@@ -525,89 +525,27 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
-	prev := append([]config.GeminiKey(nil), h.cfg.GeminiKey...)
-	h.cfg.GeminiKey = append([]config.GeminiKey(nil), arr...)
-	h.cfg.SanitizeGeminiKeys()
-	if err := h.validateChannelNames(); err != nil {
-		h.cfg.GeminiKey = prev
+	if err := providerSettingsService(h).ReplaceGeminiKeys(arr); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	h.persist(c)
 }
 func (h *Handler) PatchGeminiKey(c *gin.Context) {
-	type geminiKeyPatch struct {
-		APIKey         *string            `json:"api-key"`
-		Prefix         *string            `json:"prefix"`
-		BaseURL        *string            `json:"base-url"`
-		ProxyURL       *string            `json:"proxy-url"`
-		ProxyID        *string            `json:"proxy-id"`
-		Headers        *map[string]string `json:"headers"`
-		ExcludedModels *[]string          `json:"excluded-models"`
-	}
 	var body struct {
-		Index *int            `json:"index"`
-		Match *string         `json:"match"`
-		Value *geminiKeyPatch `json:"value"`
+		Index *int                             `json:"index"`
+		Match *string                          `json:"match"`
+		Value *providersettings.GeminiKeyPatch `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	targetIndex := -1
-	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.GeminiKey) {
-		targetIndex = *body.Index
-	}
-	if targetIndex == -1 && body.Match != nil {
-		match := strings.TrimSpace(*body.Match)
-		if match != "" {
-			for i := range h.cfg.GeminiKey {
-				if h.cfg.GeminiKey[i].APIKey == match {
-					targetIndex = i
-					break
-				}
-			}
-		}
-	}
-	if targetIndex == -1 {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	entry := h.cfg.GeminiKey[targetIndex]
-	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.GeminiKey = append(h.cfg.GeminiKey[:targetIndex], h.cfg.GeminiKey[targetIndex+1:]...)
-			h.cfg.SanitizeGeminiKeys()
-			h.persist(c)
+	if err := providerSettingsService(h).PatchGeminiKey(body.Index, body.Match, *body.Value); err != nil {
+		if errors.Is(err, providersettings.ErrItemNotFound) {
+			c.JSON(404, gin.H{"error": "item not found"})
 			return
 		}
-		entry.APIKey = trimmed
-	}
-	if body.Value.Prefix != nil {
-		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
-	}
-	if body.Value.BaseURL != nil {
-		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
-	}
-	if body.Value.ProxyURL != nil {
-		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
-	}
-	if body.Value.ProxyID != nil {
-		entry.ProxyID = strings.TrimSpace(*body.Value.ProxyID)
-	}
-	if body.Value.Headers != nil {
-		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
-	}
-	if body.Value.ExcludedModels != nil {
-		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
-	}
-	prev := append([]config.GeminiKey(nil), h.cfg.GeminiKey...)
-	h.cfg.GeminiKey[targetIndex] = entry
-	h.cfg.SanitizeGeminiKeys()
-	if err := h.validateChannelNames(); err != nil {
-		h.cfg.GeminiKey = prev
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -616,15 +554,7 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 
 func (h *Handler) DeleteGeminiKey(c *gin.Context) {
 	if val := strings.TrimSpace(c.Query("api-key")); val != "" {
-		out := make([]config.GeminiKey, 0, len(h.cfg.GeminiKey))
-		for _, v := range h.cfg.GeminiKey {
-			if v.APIKey != val {
-				out = append(out, v)
-			}
-		}
-		if len(out) != len(h.cfg.GeminiKey) {
-			h.cfg.GeminiKey = out
-			h.cfg.SanitizeGeminiKeys()
+		if providerSettingsService(h).DeleteGeminiKeyByAPIKey(val) {
 			h.persist(c)
 		} else {
 			c.JSON(404, gin.H{"error": "item not found"})
@@ -633,9 +563,7 @@ func (h *Handler) DeleteGeminiKey(c *gin.Context) {
 	}
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
-		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && idx >= 0 && idx < len(h.cfg.GeminiKey) {
-			h.cfg.GeminiKey = append(h.cfg.GeminiKey[:idx], h.cfg.GeminiKey[idx+1:]...)
-			h.cfg.SanitizeGeminiKeys()
+		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && providerSettingsService(h).DeleteGeminiKeyByIndex(idx) {
 			h.persist(c)
 			return
 		}
@@ -645,7 +573,7 @@ func (h *Handler) DeleteGeminiKey(c *gin.Context) {
 
 // claude-api-key: []ClaudeKey
 func (h *Handler) GetClaudeKeys(c *gin.Context) {
-	c.JSON(200, gin.H{"claude-api-key": h.cfg.ClaudeKey})
+	c.JSON(200, gin.H{"claude-api-key": providerSettingsService(h).ClaudeKeys()})
 }
 func (h *Handler) PutClaudeKeys(c *gin.Context) {
 	data, err := c.GetRawData()
@@ -664,92 +592,27 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
-	for i := range arr {
-		normalizeClaudeKey(&arr[i])
-	}
-	prev := append([]config.ClaudeKey(nil), h.cfg.ClaudeKey...)
-	h.cfg.ClaudeKey = arr
-	h.cfg.SanitizeClaudeKeys()
-	if err := h.validateChannelNames(); err != nil {
-		h.cfg.ClaudeKey = prev
+	if err := providerSettingsService(h).ReplaceClaudeKeys(arr); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	h.persist(c)
 }
 func (h *Handler) PatchClaudeKey(c *gin.Context) {
-	type claudeKeyPatch struct {
-		Name           *string               `json:"name"`
-		APIKey         *string               `json:"api-key"`
-		Prefix         *string               `json:"prefix"`
-		BaseURL        *string               `json:"base-url"`
-		ProxyURL       *string               `json:"proxy-url"`
-		ProxyID        *string               `json:"proxy-id"`
-		Models         *[]config.ClaudeModel `json:"models"`
-		Headers        *map[string]string    `json:"headers"`
-		ExcludedModels *[]string             `json:"excluded-models"`
-	}
 	var body struct {
-		Index *int            `json:"index"`
-		Match *string         `json:"match"`
-		Value *claudeKeyPatch `json:"value"`
+		Index *int                             `json:"index"`
+		Match *string                          `json:"match"`
+		Value *providersettings.ClaudeKeyPatch `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	targetIndex := -1
-	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.ClaudeKey) {
-		targetIndex = *body.Index
-	}
-	if targetIndex == -1 && body.Match != nil {
-		match := strings.TrimSpace(*body.Match)
-		for i := range h.cfg.ClaudeKey {
-			if h.cfg.ClaudeKey[i].APIKey == match {
-				targetIndex = i
-				break
-			}
+	if err := providerSettingsService(h).PatchClaudeKey(body.Index, body.Match, *body.Value); err != nil {
+		if errors.Is(err, providersettings.ErrItemNotFound) {
+			c.JSON(404, gin.H{"error": "item not found"})
+			return
 		}
-	}
-	if targetIndex == -1 {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	entry := h.cfg.ClaudeKey[targetIndex]
-	if body.Value.Name != nil {
-		entry.Name = strings.TrimSpace(*body.Value.Name)
-	}
-	if body.Value.APIKey != nil {
-		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
-	}
-	if body.Value.Prefix != nil {
-		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
-	}
-	if body.Value.BaseURL != nil {
-		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
-	}
-	if body.Value.ProxyURL != nil {
-		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
-	}
-	if body.Value.ProxyID != nil {
-		entry.ProxyID = strings.TrimSpace(*body.Value.ProxyID)
-	}
-	if body.Value.Models != nil {
-		entry.Models = append([]config.ClaudeModel(nil), (*body.Value.Models)...)
-	}
-	if body.Value.Headers != nil {
-		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
-	}
-	if body.Value.ExcludedModels != nil {
-		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
-	}
-	normalizeClaudeKey(&entry)
-	prev := append([]config.ClaudeKey(nil), h.cfg.ClaudeKey...)
-	h.cfg.ClaudeKey[targetIndex] = entry
-	h.cfg.SanitizeClaudeKeys()
-	if err := h.validateChannelNames(); err != nil {
-		h.cfg.ClaudeKey = prev
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -758,23 +621,14 @@ func (h *Handler) PatchClaudeKey(c *gin.Context) {
 
 func (h *Handler) DeleteClaudeKey(c *gin.Context) {
 	if val := c.Query("api-key"); val != "" {
-		out := make([]config.ClaudeKey, 0, len(h.cfg.ClaudeKey))
-		for _, v := range h.cfg.ClaudeKey {
-			if v.APIKey != val {
-				out = append(out, v)
-			}
-		}
-		h.cfg.ClaudeKey = out
-		h.cfg.SanitizeClaudeKeys()
+		providerSettingsService(h).DeleteClaudeKeyByAPIKey(val)
 		h.persist(c)
 		return
 	}
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
 		_, err := fmt.Sscanf(idxStr, "%d", &idx)
-		if err == nil && idx >= 0 && idx < len(h.cfg.ClaudeKey) {
-			h.cfg.ClaudeKey = append(h.cfg.ClaudeKey[:idx], h.cfg.ClaudeKey[idx+1:]...)
-			h.cfg.SanitizeClaudeKeys()
+		if err == nil && providerSettingsService(h).DeleteClaudeKeyByIndex(idx) {
 			h.persist(c)
 			return
 		}
@@ -1438,7 +1292,7 @@ func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
 
 // codex-api-key: []CodexKey
 func (h *Handler) GetCodexKeys(c *gin.Context) {
-	c.JSON(200, gin.H{"codex-api-key": h.cfg.CodexKey})
+	c.JSON(200, gin.H{"codex-api-key": providerSettingsService(h).CodexKeys()})
 }
 func (h *Handler) PutCodexKeys(c *gin.Context) {
 	data, err := c.GetRawData()
@@ -1457,102 +1311,27 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
-	// Filter out codex entries with empty base-url (treat as removed)
-	filtered := make([]config.CodexKey, 0, len(arr))
-	for i := range arr {
-		entry := arr[i]
-		normalizeCodexKey(&entry)
-		if entry.BaseURL == "" {
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	prev := append([]config.CodexKey(nil), h.cfg.CodexKey...)
-	h.cfg.CodexKey = filtered
-	h.cfg.SanitizeCodexKeys()
-	if err := h.validateChannelNames(); err != nil {
-		h.cfg.CodexKey = prev
+	if err := providerSettingsService(h).ReplaceCodexKeys(arr); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	h.persist(c)
 }
 func (h *Handler) PatchCodexKey(c *gin.Context) {
-	type codexKeyPatch struct {
-		APIKey         *string              `json:"api-key"`
-		Prefix         *string              `json:"prefix"`
-		BaseURL        *string              `json:"base-url"`
-		ProxyURL       *string              `json:"proxy-url"`
-		ProxyID        *string              `json:"proxy-id"`
-		Models         *[]config.CodexModel `json:"models"`
-		Headers        *map[string]string   `json:"headers"`
-		ExcludedModels *[]string            `json:"excluded-models"`
-	}
 	var body struct {
-		Index *int           `json:"index"`
-		Match *string        `json:"match"`
-		Value *codexKeyPatch `json:"value"`
+		Index *int                            `json:"index"`
+		Match *string                         `json:"match"`
+		Value *providersettings.CodexKeyPatch `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	targetIndex := -1
-	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.CodexKey) {
-		targetIndex = *body.Index
-	}
-	if targetIndex == -1 && body.Match != nil {
-		match := strings.TrimSpace(*body.Match)
-		for i := range h.cfg.CodexKey {
-			if h.cfg.CodexKey[i].APIKey == match {
-				targetIndex = i
-				break
-			}
-		}
-	}
-	if targetIndex == -1 {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	entry := h.cfg.CodexKey[targetIndex]
-	if body.Value.APIKey != nil {
-		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
-	}
-	if body.Value.Prefix != nil {
-		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
-	}
-	if body.Value.BaseURL != nil {
-		trimmed := strings.TrimSpace(*body.Value.BaseURL)
-		if trimmed == "" {
-			h.cfg.CodexKey = append(h.cfg.CodexKey[:targetIndex], h.cfg.CodexKey[targetIndex+1:]...)
-			h.cfg.SanitizeCodexKeys()
-			h.persist(c)
+	if err := providerSettingsService(h).PatchCodexKey(body.Index, body.Match, *body.Value); err != nil {
+		if errors.Is(err, providersettings.ErrItemNotFound) {
+			c.JSON(404, gin.H{"error": "item not found"})
 			return
 		}
-		entry.BaseURL = trimmed
-	}
-	if body.Value.ProxyURL != nil {
-		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
-	}
-	if body.Value.ProxyID != nil {
-		entry.ProxyID = strings.TrimSpace(*body.Value.ProxyID)
-	}
-	if body.Value.Models != nil {
-		entry.Models = append([]config.CodexModel(nil), (*body.Value.Models)...)
-	}
-	if body.Value.Headers != nil {
-		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
-	}
-	if body.Value.ExcludedModels != nil {
-		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
-	}
-	normalizeCodexKey(&entry)
-	prev := append([]config.CodexKey(nil), h.cfg.CodexKey...)
-	h.cfg.CodexKey[targetIndex] = entry
-	h.cfg.SanitizeCodexKeys()
-	if err := h.validateChannelNames(); err != nil {
-		h.cfg.CodexKey = prev
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -1561,23 +1340,14 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 
 func (h *Handler) DeleteCodexKey(c *gin.Context) {
 	if val := c.Query("api-key"); val != "" {
-		out := make([]config.CodexKey, 0, len(h.cfg.CodexKey))
-		for _, v := range h.cfg.CodexKey {
-			if v.APIKey != val {
-				out = append(out, v)
-			}
-		}
-		h.cfg.CodexKey = out
-		h.cfg.SanitizeCodexKeys()
+		providerSettingsService(h).DeleteCodexKeyByAPIKey(val)
 		h.persist(c)
 		return
 	}
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
 		_, err := fmt.Sscanf(idxStr, "%d", &idx)
-		if err == nil && idx >= 0 && idx < len(h.cfg.CodexKey) {
-			h.cfg.CodexKey = append(h.cfg.CodexKey[:idx], h.cfg.CodexKey[idx+1:]...)
-			h.cfg.SanitizeCodexKeys()
+		if err == nil && providerSettingsService(h).DeleteCodexKeyByIndex(idx) {
 			h.persist(c)
 			return
 		}
@@ -1617,33 +1387,6 @@ func normalizedOpenCodeGoKeyEntries(entries []config.OpenCodeGoKey) []config.Ope
 	return out
 }
 
-func normalizeClaudeKey(entry *config.ClaudeKey) {
-	if entry == nil {
-		return
-	}
-	entry.Name = strings.TrimSpace(entry.Name)
-	entry.APIKey = strings.TrimSpace(entry.APIKey)
-	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
-	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
-	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
-	entry.Headers = config.NormalizeHeaders(entry.Headers)
-	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	if len(entry.Models) == 0 {
-		return
-	}
-	normalized := make([]config.ClaudeModel, 0, len(entry.Models))
-	for i := range entry.Models {
-		model := entry.Models[i]
-		model.Name = strings.TrimSpace(model.Name)
-		model.Alias = strings.TrimSpace(model.Alias)
-		if model.Name == "" && model.Alias == "" {
-			continue
-		}
-		normalized = append(normalized, model)
-	}
-	entry.Models = normalized
-}
-
 func normalizeBedrockKey(entry *config.BedrockKey) {
 	if entry == nil {
 		return
@@ -1665,33 +1408,6 @@ func normalizeBedrockKey(entry *config.BedrockKey) {
 		return
 	}
 	normalized := make([]config.BedrockModel, 0, len(entry.Models))
-	for i := range entry.Models {
-		model := entry.Models[i]
-		model.Name = strings.TrimSpace(model.Name)
-		model.Alias = strings.TrimSpace(model.Alias)
-		if model.Name == "" && model.Alias == "" {
-			continue
-		}
-		normalized = append(normalized, model)
-	}
-	entry.Models = normalized
-}
-
-func normalizeCodexKey(entry *config.CodexKey) {
-	if entry == nil {
-		return
-	}
-	entry.APIKey = strings.TrimSpace(entry.APIKey)
-	entry.Prefix = strings.TrimSpace(entry.Prefix)
-	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
-	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
-	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
-	entry.Headers = config.NormalizeHeaders(entry.Headers)
-	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	if len(entry.Models) == 0 {
-		return
-	}
-	normalized := make([]config.CodexModel, 0, len(entry.Models))
 	for i := range entry.Models {
 		model := entry.Models[i]
 		model.Name = strings.TrimSpace(model.Name)

--- a/internal/management/settings/providers/service.go
+++ b/internal/management/settings/providers/service.go
@@ -151,6 +151,378 @@ type VertexCompatPatch struct {
 	Models   *[]config.VertexCompatModel `json:"models"`
 }
 
+type GeminiKeyPatch struct {
+	APIKey         *string            `json:"api-key"`
+	Prefix         *string            `json:"prefix"`
+	BaseURL        *string            `json:"base-url"`
+	ProxyURL       *string            `json:"proxy-url"`
+	ProxyID        *string            `json:"proxy-id"`
+	Headers        *map[string]string `json:"headers"`
+	ExcludedModels *[]string          `json:"excluded-models"`
+}
+
+type ClaudeKeyPatch struct {
+	Name           *string               `json:"name"`
+	APIKey         *string               `json:"api-key"`
+	Prefix         *string               `json:"prefix"`
+	BaseURL        *string               `json:"base-url"`
+	ProxyURL       *string               `json:"proxy-url"`
+	ProxyID        *string               `json:"proxy-id"`
+	Models         *[]config.ClaudeModel `json:"models"`
+	Headers        *map[string]string    `json:"headers"`
+	ExcludedModels *[]string             `json:"excluded-models"`
+}
+
+type CodexKeyPatch struct {
+	APIKey         *string              `json:"api-key"`
+	Prefix         *string              `json:"prefix"`
+	BaseURL        *string              `json:"base-url"`
+	ProxyURL       *string              `json:"proxy-url"`
+	ProxyID        *string              `json:"proxy-id"`
+	Models         *[]config.CodexModel `json:"models"`
+	Headers        *map[string]string   `json:"headers"`
+	ExcludedModels *[]string            `json:"excluded-models"`
+}
+
+func (s *Service) GeminiKeys() []config.GeminiKey {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return s.cfg.GeminiKey
+}
+
+func (s *Service) ReplaceGeminiKeys(entries []config.GeminiKey) error {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	prev := append([]config.GeminiKey(nil), s.cfg.GeminiKey...)
+	s.cfg.GeminiKey = append([]config.GeminiKey(nil), entries...)
+	s.cfg.SanitizeGeminiKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.GeminiKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) PatchGeminiKey(index *int, match *string, patch GeminiKeyPatch) error {
+	if s == nil || s.cfg == nil {
+		return ErrItemNotFound
+	}
+	targetIndex := -1
+	if index != nil && *index >= 0 && *index < len(s.cfg.GeminiKey) {
+		targetIndex = *index
+	}
+	if targetIndex == -1 && match != nil {
+		matchValue := strings.TrimSpace(*match)
+		if matchValue != "" {
+			for i := range s.cfg.GeminiKey {
+				if s.cfg.GeminiKey[i].APIKey == matchValue {
+					targetIndex = i
+					break
+				}
+			}
+		}
+	}
+	if targetIndex == -1 {
+		return ErrItemNotFound
+	}
+
+	entry := s.cfg.GeminiKey[targetIndex]
+	if patch.APIKey != nil {
+		trimmed := strings.TrimSpace(*patch.APIKey)
+		if trimmed == "" {
+			s.deleteGeminiKeyByIndex(targetIndex)
+			return nil
+		}
+		entry.APIKey = trimmed
+	}
+	if patch.Prefix != nil {
+		entry.Prefix = strings.TrimSpace(*patch.Prefix)
+	}
+	if patch.BaseURL != nil {
+		entry.BaseURL = strings.TrimSpace(*patch.BaseURL)
+	}
+	if patch.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*patch.ProxyURL)
+	}
+	if patch.ProxyID != nil {
+		entry.ProxyID = strings.TrimSpace(*patch.ProxyID)
+	}
+	if patch.Headers != nil {
+		entry.Headers = config.NormalizeHeaders(*patch.Headers)
+	}
+	if patch.ExcludedModels != nil {
+		entry.ExcludedModels = config.NormalizeExcludedModels(*patch.ExcludedModels)
+	}
+	prev := append([]config.GeminiKey(nil), s.cfg.GeminiKey...)
+	s.cfg.GeminiKey[targetIndex] = entry
+	s.cfg.SanitizeGeminiKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.GeminiKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) DeleteGeminiKeyByAPIKey(apiKey string) bool {
+	if s == nil || s.cfg == nil {
+		return false
+	}
+	out := make([]config.GeminiKey, 0, len(s.cfg.GeminiKey))
+	for _, entry := range s.cfg.GeminiKey {
+		if entry.APIKey != apiKey {
+			out = append(out, entry)
+		}
+	}
+	if len(out) == len(s.cfg.GeminiKey) {
+		return false
+	}
+	s.cfg.GeminiKey = out
+	s.cfg.SanitizeGeminiKeys()
+	return true
+}
+
+func (s *Service) DeleteGeminiKeyByIndex(index int) bool {
+	if s == nil || s.cfg == nil || index < 0 || index >= len(s.cfg.GeminiKey) {
+		return false
+	}
+	s.deleteGeminiKeyByIndex(index)
+	return true
+}
+
+func (s *Service) deleteGeminiKeyByIndex(index int) {
+	s.cfg.GeminiKey = append(s.cfg.GeminiKey[:index], s.cfg.GeminiKey[index+1:]...)
+	s.cfg.SanitizeGeminiKeys()
+}
+
+func (s *Service) ClaudeKeys() []config.ClaudeKey {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return s.cfg.ClaudeKey
+}
+
+func (s *Service) ReplaceClaudeKeys(entries []config.ClaudeKey) error {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	normalized := append([]config.ClaudeKey(nil), entries...)
+	for i := range normalized {
+		NormalizeClaudeKey(&normalized[i])
+	}
+	prev := append([]config.ClaudeKey(nil), s.cfg.ClaudeKey...)
+	s.cfg.ClaudeKey = normalized
+	s.cfg.SanitizeClaudeKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.ClaudeKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) PatchClaudeKey(index *int, match *string, patch ClaudeKeyPatch) error {
+	if s == nil || s.cfg == nil {
+		return ErrItemNotFound
+	}
+	targetIndex := -1
+	if index != nil && *index >= 0 && *index < len(s.cfg.ClaudeKey) {
+		targetIndex = *index
+	}
+	if targetIndex == -1 && match != nil {
+		matchValue := strings.TrimSpace(*match)
+		for i := range s.cfg.ClaudeKey {
+			if s.cfg.ClaudeKey[i].APIKey == matchValue {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 {
+		return ErrItemNotFound
+	}
+
+	entry := s.cfg.ClaudeKey[targetIndex]
+	if patch.Name != nil {
+		entry.Name = strings.TrimSpace(*patch.Name)
+	}
+	if patch.APIKey != nil {
+		entry.APIKey = strings.TrimSpace(*patch.APIKey)
+	}
+	if patch.Prefix != nil {
+		entry.Prefix = strings.TrimSpace(*patch.Prefix)
+	}
+	if patch.BaseURL != nil {
+		entry.BaseURL = strings.TrimSpace(*patch.BaseURL)
+	}
+	if patch.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*patch.ProxyURL)
+	}
+	if patch.ProxyID != nil {
+		entry.ProxyID = strings.TrimSpace(*patch.ProxyID)
+	}
+	if patch.Models != nil {
+		entry.Models = append([]config.ClaudeModel(nil), (*patch.Models)...)
+	}
+	if patch.Headers != nil {
+		entry.Headers = config.NormalizeHeaders(*patch.Headers)
+	}
+	if patch.ExcludedModels != nil {
+		entry.ExcludedModels = config.NormalizeExcludedModels(*patch.ExcludedModels)
+	}
+	NormalizeClaudeKey(&entry)
+	prev := append([]config.ClaudeKey(nil), s.cfg.ClaudeKey...)
+	s.cfg.ClaudeKey[targetIndex] = entry
+	s.cfg.SanitizeClaudeKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.ClaudeKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) DeleteClaudeKeyByAPIKey(apiKey string) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	out := make([]config.ClaudeKey, 0, len(s.cfg.ClaudeKey))
+	for _, entry := range s.cfg.ClaudeKey {
+		if entry.APIKey != apiKey {
+			out = append(out, entry)
+		}
+	}
+	s.cfg.ClaudeKey = out
+	s.cfg.SanitizeClaudeKeys()
+}
+
+func (s *Service) DeleteClaudeKeyByIndex(index int) bool {
+	if s == nil || s.cfg == nil || index < 0 || index >= len(s.cfg.ClaudeKey) {
+		return false
+	}
+	s.cfg.ClaudeKey = append(s.cfg.ClaudeKey[:index], s.cfg.ClaudeKey[index+1:]...)
+	s.cfg.SanitizeClaudeKeys()
+	return true
+}
+
+func (s *Service) CodexKeys() []config.CodexKey {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return s.cfg.CodexKey
+}
+
+func (s *Service) ReplaceCodexKeys(entries []config.CodexKey) error {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	filtered := make([]config.CodexKey, 0, len(entries))
+	for i := range entries {
+		entry := entries[i]
+		NormalizeCodexKey(&entry)
+		if entry.BaseURL == "" {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	prev := append([]config.CodexKey(nil), s.cfg.CodexKey...)
+	s.cfg.CodexKey = filtered
+	s.cfg.SanitizeCodexKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.CodexKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) PatchCodexKey(index *int, match *string, patch CodexKeyPatch) error {
+	if s == nil || s.cfg == nil {
+		return ErrItemNotFound
+	}
+	targetIndex := -1
+	if index != nil && *index >= 0 && *index < len(s.cfg.CodexKey) {
+		targetIndex = *index
+	}
+	if targetIndex == -1 && match != nil {
+		matchValue := strings.TrimSpace(*match)
+		for i := range s.cfg.CodexKey {
+			if s.cfg.CodexKey[i].APIKey == matchValue {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 {
+		return ErrItemNotFound
+	}
+
+	entry := s.cfg.CodexKey[targetIndex]
+	if patch.APIKey != nil {
+		entry.APIKey = strings.TrimSpace(*patch.APIKey)
+	}
+	if patch.Prefix != nil {
+		entry.Prefix = strings.TrimSpace(*patch.Prefix)
+	}
+	if patch.BaseURL != nil {
+		trimmed := strings.TrimSpace(*patch.BaseURL)
+		if trimmed == "" {
+			s.deleteCodexKeyByIndex(targetIndex)
+			return nil
+		}
+		entry.BaseURL = trimmed
+	}
+	if patch.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*patch.ProxyURL)
+	}
+	if patch.ProxyID != nil {
+		entry.ProxyID = strings.TrimSpace(*patch.ProxyID)
+	}
+	if patch.Models != nil {
+		entry.Models = append([]config.CodexModel(nil), (*patch.Models)...)
+	}
+	if patch.Headers != nil {
+		entry.Headers = config.NormalizeHeaders(*patch.Headers)
+	}
+	if patch.ExcludedModels != nil {
+		entry.ExcludedModels = config.NormalizeExcludedModels(*patch.ExcludedModels)
+	}
+	NormalizeCodexKey(&entry)
+	prev := append([]config.CodexKey(nil), s.cfg.CodexKey...)
+	s.cfg.CodexKey[targetIndex] = entry
+	s.cfg.SanitizeCodexKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.CodexKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) DeleteCodexKeyByAPIKey(apiKey string) {
+	if s == nil || s.cfg == nil {
+		return
+	}
+	out := make([]config.CodexKey, 0, len(s.cfg.CodexKey))
+	for _, entry := range s.cfg.CodexKey {
+		if entry.APIKey != apiKey {
+			out = append(out, entry)
+		}
+	}
+	s.cfg.CodexKey = out
+	s.cfg.SanitizeCodexKeys()
+}
+
+func (s *Service) DeleteCodexKeyByIndex(index int) bool {
+	if s == nil || s.cfg == nil || index < 0 || index >= len(s.cfg.CodexKey) {
+		return false
+	}
+	s.deleteCodexKeyByIndex(index)
+	return true
+}
+
+func (s *Service) deleteCodexKeyByIndex(index int) {
+	s.cfg.CodexKey = append(s.cfg.CodexKey[:index], s.cfg.CodexKey[index+1:]...)
+	s.cfg.SanitizeCodexKeys()
+}
+
 func (s *Service) VertexCompatKeys() []config.VertexCompatKey {
 	if s == nil || s.cfg == nil {
 		return nil
@@ -312,6 +684,60 @@ func NormalizeVertexCompatKey(entry *config.VertexCompatKey) {
 		model.Name = strings.TrimSpace(model.Name)
 		model.Alias = strings.TrimSpace(model.Alias)
 		if model.Name == "" || model.Alias == "" {
+			continue
+		}
+		normalized = append(normalized, model)
+	}
+	entry.Models = normalized
+}
+
+func NormalizeClaudeKey(entry *config.ClaudeKey) {
+	if entry == nil {
+		return
+	}
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	if len(entry.Models) == 0 {
+		return
+	}
+	normalized := make([]config.ClaudeModel, 0, len(entry.Models))
+	for i := range entry.Models {
+		model := entry.Models[i]
+		model.Name = strings.TrimSpace(model.Name)
+		model.Alias = strings.TrimSpace(model.Alias)
+		if model.Name == "" && model.Alias == "" {
+			continue
+		}
+		normalized = append(normalized, model)
+	}
+	entry.Models = normalized
+}
+
+func NormalizeCodexKey(entry *config.CodexKey) {
+	if entry == nil {
+		return
+	}
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	if len(entry.Models) == 0 {
+		return
+	}
+	normalized := make([]config.CodexModel, 0, len(entry.Models))
+	for i := range entry.Models {
+		model := entry.Models[i]
+		model.Name = strings.TrimSpace(model.Name)
+		model.Alias = strings.TrimSpace(model.Alias)
+		if model.Name == "" && model.Alias == "" {
 			continue
 		}
 		normalized = append(normalized, model)

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -144,3 +144,113 @@ func TestVertexCompatKeysNormalizePatchAndDelete(t *testing.T) {
 		t.Fatalf("VertexCompatAPIKey after delete = %#v, want empty", cfg.VertexCompatAPIKey)
 	}
 }
+
+func TestGeminiKeysReplacePatchDeleteAndRollback(t *testing.T) {
+	validationErr := errors.New("invalid channel")
+	cfg := &config.Config{
+		GeminiKey: []config.GeminiKey{{APIKey: "existing"}},
+	}
+	svc := NewService(cfg, func() error { return validationErr })
+
+	err := svc.ReplaceGeminiKeys([]config.GeminiKey{{APIKey: " next "}})
+	if !errors.Is(err, validationErr) {
+		t.Fatalf("ReplaceGeminiKeys() error = %v, want validation error", err)
+	}
+	if got := cfg.GeminiKey; len(got) != 1 || got[0].APIKey != "existing" {
+		t.Fatalf("GeminiKey after rollback = %#v, want existing entry", got)
+	}
+
+	svc = NewService(cfg, nil)
+	err = svc.ReplaceGeminiKeys([]config.GeminiKey{{APIKey: " next ", Prefix: " /team/ ", ProxyURL: " http://proxy.example "}})
+	if err != nil {
+		t.Fatalf("ReplaceGeminiKeys() error = %v, want nil", err)
+	}
+	if got := cfg.GeminiKey[0]; got.APIKey != "next" || got.Prefix != "team" || got.ProxyURL != "http://proxy.example" {
+		t.Fatalf("normalized gemini key = %#v", got)
+	}
+
+	match := " next "
+	emptyAPIKey := " "
+	err = svc.PatchGeminiKey(nil, &match, GeminiKeyPatch{APIKey: &emptyAPIKey})
+	if err != nil {
+		t.Fatalf("PatchGeminiKey(delete) error = %v, want nil", err)
+	}
+	if len(cfg.GeminiKey) != 0 {
+		t.Fatalf("GeminiKey after delete = %#v, want empty", cfg.GeminiKey)
+	}
+}
+
+func TestClaudeKeysReplacePatchAndDelete(t *testing.T) {
+	cfg := &config.Config{}
+	svc := NewService(cfg, nil)
+
+	err := svc.ReplaceClaudeKeys([]config.ClaudeKey{
+		{Name: "oauth-row", APIKey: ""},
+		{
+			Name:    " claude ",
+			APIKey:  " sk-claude ",
+			BaseURL: " https://claude.example ",
+			Models:  []config.ClaudeModel{{Name: " claude-sonnet-4 ", Alias: " sonnet "}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceClaudeKeys() error = %v, want nil", err)
+	}
+	if len(cfg.ClaudeKey) != 1 {
+		t.Fatalf("ClaudeKey len = %d, want 1", len(cfg.ClaudeKey))
+	}
+	if got := cfg.ClaudeKey[0]; got.Name != "claude" || got.APIKey != "sk-claude" || got.BaseURL != "https://claude.example" {
+		t.Fatalf("normalized claude key = %#v", got)
+	}
+
+	match := "sk-claude"
+	blankAPIKey := " "
+	err = svc.PatchClaudeKey(nil, &match, ClaudeKeyPatch{APIKey: &blankAPIKey})
+	if err != nil {
+		t.Fatalf("PatchClaudeKey(blank api key) error = %v, want nil", err)
+	}
+	if len(cfg.ClaudeKey) != 0 {
+		t.Fatalf("ClaudeKey after blank api key patch = %#v, want empty", cfg.ClaudeKey)
+	}
+}
+
+func TestCodexKeysReplacePatchDeleteAndRollback(t *testing.T) {
+	validationErr := errors.New("channel conflict")
+	cfg := &config.Config{
+		CodexKey: []config.CodexKey{{APIKey: "existing", BaseURL: "https://old.example"}},
+	}
+	svc := NewService(cfg, func() error { return validationErr })
+
+	err := svc.ReplaceCodexKeys([]config.CodexKey{{APIKey: "next", BaseURL: "https://new.example"}})
+	if !errors.Is(err, validationErr) {
+		t.Fatalf("ReplaceCodexKeys() error = %v, want validation error", err)
+	}
+	if got := cfg.CodexKey; len(got) != 1 || got[0].APIKey != "existing" {
+		t.Fatalf("CodexKey after rollback = %#v, want existing entry", got)
+	}
+
+	svc = NewService(cfg, nil)
+	err = svc.ReplaceCodexKeys([]config.CodexKey{
+		{APIKey: "next", BaseURL: " https://codex.example ", ProxyURL: " http://proxy.example "},
+		{APIKey: "drop", BaseURL: " "},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceCodexKeys() error = %v, want nil", err)
+	}
+	if len(cfg.CodexKey) != 1 {
+		t.Fatalf("CodexKey len = %d, want 1", len(cfg.CodexKey))
+	}
+	if got := cfg.CodexKey[0]; got.BaseURL != "https://codex.example" || got.ProxyURL != "http://proxy.example" {
+		t.Fatalf("normalized codex key = %#v", got)
+	}
+
+	match := "next"
+	emptyBaseURL := " "
+	err = svc.PatchCodexKey(nil, &match, CodexKeyPatch{BaseURL: &emptyBaseURL})
+	if err != nil {
+		t.Fatalf("PatchCodexKey(delete) error = %v, want nil", err)
+	}
+	if len(cfg.CodexKey) != 0 {
+		t.Fatalf("CodexKey after delete = %#v, want empty", cfg.CodexKey)
+	}
+}


### PR DESCRIPTION
Summary:
- Extend the management provider settings service to cover Gemini, Claude, and Codex credential use cases.
- Move provider key normalization, patch/delete behavior, and validation rollback out of the management handler.
- Keep the handler focused on JSON binding, HTTP status mapping, response shape, and persistence coordination.

Validation:
- go test ./internal/management/settings/providers
- go test ./internal/api/handlers/management -run 'Gemini|Claude|Codex|OpenAICompat|VertexCompat|ChannelGroup|RuntimeSettings|ProviderCredentials'
- go test ./internal/api/handlers/management ./internal/management/settings/...
- python3 scripts/check-backend-structure.py
- git diff --check