### PR TITLE
feat: add usage log egress inspection

### DIFF
--- a/internal/api/handlers/management/usage_logs_egress.go
+++ b/internal/api/handlers/management/usage_logs_egress.go
@@ -1,0 +1,312 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const usageLogEgressProbeTimeout = 6 * time.Second
+
+var usageLogEgressProbeURLs = []string{
+	"https://api.ipify.org",
+	"https://ifconfig.me/ip",
+	"https://icanhazip.com",
+	"https://ipinfo.io/ip",
+}
+
+var usageLogEgressProbeFn = probeUsageLogEgressIP
+
+type usageLogEgressMetadata struct {
+	RouteKind    string `json:"route_kind,omitempty"`
+	ProxySource  string `json:"proxy_source,omitempty"`
+	ProxyID      string `json:"proxy_id,omitempty"`
+	ProxyName    string `json:"proxy_name,omitempty"`
+	ProxyURLHost string `json:"proxy_url_host,omitempty"`
+}
+
+type usageLogEgressResponse struct {
+	ID              int64  `json:"id"`
+	Model           string `json:"model,omitempty"`
+	RouteKind       string `json:"route_kind,omitempty"`
+	ProxySource     string `json:"proxy_source,omitempty"`
+	ProxyID         string `json:"proxy_id,omitempty"`
+	ProxyName       string `json:"proxy_name,omitempty"`
+	ProxyURLHost    string `json:"proxy_url_host,omitempty"`
+	EffectiveIP     string `json:"effective_ip,omitempty"`
+	ServerIP        string `json:"server_ip,omitempty"`
+	MatchesServerIP *bool  `json:"matches_server_ip,omitempty"`
+	UsingProxy      bool   `json:"using_proxy"`
+	Error           string `json:"error,omitempty"`
+}
+
+// GetUsageLogEgress probes the effective egress IP for a stored request log.
+func (h *Handler) GetUsageLogEgress(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(strings.TrimSpace(idStr), 10, 64)
+	if err != nil || id < 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid log id"})
+		return
+	}
+
+	logRow, err := usage.QueryLogRowByID(id)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			c.JSON(http.StatusNotFound, gin.H{"error": "log entry not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	detailsPart, err := usage.QueryLogContentPart(id, "details")
+	if err != nil && !strings.Contains(err.Error(), "no rows") {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	meta := parseUsageLogEgressMetadata(detailsPart.Content)
+	resp := usageLogEgressResponse{
+		ID:           logRow.ID,
+		Model:        firstNonEmpty(strings.TrimSpace(logRow.Model), strings.TrimSpace(detailsPart.Model)),
+		RouteKind:    meta.RouteKind,
+		ProxySource:  meta.ProxySource,
+		ProxyID:      meta.ProxyID,
+		ProxyName:    meta.ProxyName,
+		ProxyURLHost: meta.ProxyURLHost,
+		UsingProxy:   strings.EqualFold(meta.RouteKind, "proxy"),
+	}
+
+	if resp.RouteKind == "" {
+		resp.Error = "no stored egress metadata for this request"
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), usageLogEgressProbeTimeout)
+	defer cancel()
+
+	serverIP, serverErr := usageLogEgressProbeFn(ctx, "", h.sdkConfig())
+	if serverErr == nil {
+		resp.ServerIP = strings.TrimSpace(serverIP)
+	}
+
+	effectiveIP := resp.ServerIP
+	effectiveErr := serverErr
+	if resp.UsingProxy {
+		proxyURL := h.resolveUsageLogEgressProxyURL(logRow.AuthIndex, meta)
+		if proxyURL == "" {
+			resp.Error = "proxy configuration is no longer available for recheck"
+			if serverErr != nil {
+				resp.Error += "; server egress probe failed: " + serverErr.Error()
+			}
+			c.JSON(http.StatusOK, resp)
+			return
+		}
+		effectiveIP, effectiveErr = usageLogEgressProbeFn(ctx, proxyURL, h.sdkConfig())
+	}
+
+	if effectiveErr == nil {
+		resp.EffectiveIP = strings.TrimSpace(effectiveIP)
+	}
+	if resp.EffectiveIP != "" && resp.ServerIP != "" {
+		matches := strings.EqualFold(resp.EffectiveIP, resp.ServerIP)
+		resp.MatchesServerIP = &matches
+	}
+
+	if effectiveErr != nil {
+		resp.Error = effectiveErr.Error()
+	} else if serverErr != nil {
+		resp.Error = "server egress probe failed: " + serverErr.Error()
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+func parseUsageLogEgressMetadata(raw string) usageLogEgressMetadata {
+	if strings.TrimSpace(raw) == "" {
+		return usageLogEgressMetadata{}
+	}
+	var payload struct {
+		Egress usageLogEgressMetadata `json:"egress"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return usageLogEgressMetadata{}
+	}
+	payload.Egress.RouteKind = strings.TrimSpace(payload.Egress.RouteKind)
+	payload.Egress.ProxySource = strings.TrimSpace(payload.Egress.ProxySource)
+	payload.Egress.ProxyID = strings.TrimSpace(payload.Egress.ProxyID)
+	payload.Egress.ProxyName = strings.TrimSpace(payload.Egress.ProxyName)
+	payload.Egress.ProxyURLHost = strings.TrimSpace(payload.Egress.ProxyURLHost)
+	return payload.Egress
+}
+
+func (h *Handler) resolveUsageLogEgressProxyURL(authIndex string, meta usageLogEgressMetadata) string {
+	cfg := h.cfg
+	auth := h.findAuthByIndex(authIndex)
+	proxyID := strings.TrimSpace(meta.ProxyID)
+	if proxyID == "" && auth != nil {
+		proxyID = strings.TrimSpace(auth.ProxyID)
+	}
+	authProxyURL := ""
+	if auth != nil {
+		authProxyURL = strings.TrimSpace(auth.ProxyURL)
+	}
+
+	switch strings.ToLower(meta.ProxySource) {
+	case "proxy_id":
+		if proxyID != "" {
+			if resolved := resolveUsageLogProxyPoolURL(cfg, proxyID, authProxyURL); resolved != "" {
+				return resolved
+			}
+		}
+	case "auth_proxy_url":
+		if authProxyURL != "" && usageLogProxyURLMatchesMaskedHost(authProxyURL, meta.ProxyURLHost) {
+			return authProxyURL
+		}
+	case "global_proxy_url":
+		if cfg != nil {
+			if proxyURL := strings.TrimSpace(cfg.ProxyURL); proxyURL != "" && usageLogProxyURLMatchesMaskedHost(proxyURL, meta.ProxyURLHost) {
+				return proxyURL
+			}
+		}
+	case "proxy_url":
+		if authProxyURL != "" && usageLogProxyURLMatchesMaskedHost(authProxyURL, meta.ProxyURLHost) {
+			return authProxyURL
+		}
+		if cfg != nil {
+			if proxyURL := strings.TrimSpace(cfg.ProxyURL); proxyURL != "" && usageLogProxyURLMatchesMaskedHost(proxyURL, meta.ProxyURLHost) {
+				return proxyURL
+			}
+		}
+	}
+
+	if proxyID != "" {
+		if resolved := resolveUsageLogProxyPoolURL(cfg, proxyID, authProxyURL); resolved != "" {
+			return resolved
+		}
+	}
+	if authProxyURL != "" && (meta.ProxyURLHost == "" || usageLogProxyURLMatchesMaskedHost(authProxyURL, meta.ProxyURLHost)) {
+		return authProxyURL
+	}
+	if cfg != nil {
+		if proxyURL := strings.TrimSpace(cfg.ProxyURL); proxyURL != "" && (meta.ProxyURLHost == "" || usageLogProxyURLMatchesMaskedHost(proxyURL, meta.ProxyURLHost)) {
+			return proxyURL
+		}
+	}
+	return ""
+}
+
+func resolveUsageLogProxyPoolURL(cfg *config.Config, proxyID string, fallbackURL string) string {
+	if entry := usage.GetProxyPoolEntry(proxyID); entry != nil && entry.Enabled {
+		if proxyURL := strings.TrimSpace(entry.URL); proxyURL != "" {
+			return proxyURL
+		}
+	}
+	if cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.ResolveProxyURL(proxyID, fallbackURL))
+}
+
+func (h *Handler) findAuthByIndex(authIndex string) *coreauth.Auth {
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" || h == nil || h.authManager == nil {
+		return nil
+	}
+	for _, auth := range h.authManager.List() {
+		if auth == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(auth.EnsureIndex()), authIndex) {
+			return auth
+		}
+	}
+	return nil
+}
+
+func (h *Handler) sdkConfig() *config.SDKConfig {
+	if h == nil || h.cfg == nil {
+		return nil
+	}
+	return &h.cfg.SDKConfig
+}
+
+func usageLogProxyURLMatchesMaskedHost(proxyURL string, maskedHost string) bool {
+	maskedHost = strings.TrimSpace(strings.ToLower(maskedHost))
+	if maskedHost == "" {
+		return true
+	}
+	parsed, err := url.Parse(strings.TrimSpace(proxyURL))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return false
+	}
+	return maskedHost == strings.ToLower(parsed.Scheme)+"://"+parsed.Host
+}
+
+func probeUsageLogEgressIP(ctx context.Context, proxyURL string, sdkCfg *config.SDKConfig) (string, error) {
+	preferIPv4 := sdkCfg != nil && sdkCfg.PreferIPv4
+	transport := util.NewDefaultTransport(preferIPv4)
+	if strings.TrimSpace(proxyURL) != "" {
+		transport = util.BuildProxyTransport(proxyURL, preferIPv4)
+		if transport == nil {
+			return "", fmt.Errorf("failed to build proxy transport")
+		}
+	}
+	util.ApplyTLSConfig(transport, sdkCfg)
+	client := &http.Client{Timeout: usageLogEgressProbeTimeout, Transport: transport}
+
+	var lastErr error
+	for _, probeURL := range usageLogEgressProbeURLs {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("User-Agent", "CLIProxyAPI egress probe")
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 256))
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("probe %s returned status %d", probeURL, resp.StatusCode)
+			continue
+		}
+		if readErr != nil {
+			lastErr = readErr
+			continue
+		}
+		if ip := strings.TrimSpace(string(body)); ip != "" {
+			return ip, nil
+		}
+		lastErr = fmt.Errorf("probe %s returned empty body", probeURL)
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("all egress probe services failed")
+	}
+	return "", lastErr
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/api/handlers/management/usage_logs_egress_test.go
+++ b/internal/api/handlers/management/usage_logs_egress_test.go
@@ -1,0 +1,219 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestGetUsageLogEgressReturnsProxyProbeDetails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "proxy-auth",
+		FileName: "proxy-auth.json",
+		Provider: "codex",
+		Label:    "Proxy Auth",
+		ProxyID:  "premium-egress",
+		ProxyURL: "http://legacy-proxy.local:8080",
+		Metadata: map[string]any{
+			"label": "Proxy Auth",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	details := `{"egress":{"route_kind":"proxy","proxy_source":"proxy_id","proxy_id":"premium-egress","proxy_name":"Premium egress","proxy_url_host":"http://pool-proxy.local:8080"}}`
+	usage.InsertLogWithDetails(
+		"sk-test", "Primary", "gpt-test", "codex", "Codex", auth.Index,
+		false, time.Now().UTC(), 100, 10,
+		usage.TokenStats{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
+		`{"messages":[]}`, `{"choices":[]}`, details,
+	)
+	rows, err := usage.QueryLogs(usage.LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs: %v", err)
+	}
+	if len(rows.Items) != 1 {
+		t.Fatalf("expected one log row, got %d", len(rows.Items))
+	}
+
+	savedProbe := usageLogEgressProbeFn
+	usageLogEgressProbeFn = func(_ context.Context, proxyURL string, _ *config.SDKConfig) (string, error) {
+		switch proxyURL {
+		case "":
+			return "198.51.100.10", nil
+		case "http://pool-proxy.local:8080":
+			return "203.0.113.50", nil
+		default:
+			return "", fmt.Errorf("unexpected proxy url %q", proxyURL)
+		}
+	}
+	t.Cleanup(func() {
+		usageLogEgressProbeFn = savedProbe
+	})
+
+	h := &Handler{
+		cfg: &config.Config{
+			ProxyPool: []config.ProxyPoolEntry{
+				{ID: "premium-egress", Name: "Premium egress", URL: "http://pool-proxy.local:8080", Enabled: true},
+			},
+		},
+		authManager: manager,
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: strconv.FormatInt(rows.Items[0].ID, 10)}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs/1/egress", nil)
+
+	h.GetUsageLogEgress(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		RouteKind       string `json:"route_kind"`
+		ProxyID         string `json:"proxy_id"`
+		ProxyName       string `json:"proxy_name"`
+		ProxyURLHost    string `json:"proxy_url_host"`
+		EffectiveIP     string `json:"effective_ip"`
+		ServerIP        string `json:"server_ip"`
+		MatchesServerIP *bool  `json:"matches_server_ip"`
+		UsingProxy      bool   `json:"using_proxy"`
+		Error           string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload.RouteKind != "proxy" {
+		t.Fatalf("route_kind = %q, want proxy", payload.RouteKind)
+	}
+	if !payload.UsingProxy {
+		t.Fatal("using_proxy = false, want true")
+	}
+	if payload.ProxyID != "premium-egress" {
+		t.Fatalf("proxy_id = %q, want premium-egress", payload.ProxyID)
+	}
+	if payload.ProxyName != "Premium egress" {
+		t.Fatalf("proxy_name = %q, want Premium egress", payload.ProxyName)
+	}
+	if payload.ProxyURLHost != "http://pool-proxy.local:8080" {
+		t.Fatalf("proxy_url_host = %q, want masked proxy host", payload.ProxyURLHost)
+	}
+	if payload.ServerIP != "198.51.100.10" {
+		t.Fatalf("server_ip = %q, want direct server IP", payload.ServerIP)
+	}
+	if payload.EffectiveIP != "203.0.113.50" {
+		t.Fatalf("effective_ip = %q, want proxy egress IP", payload.EffectiveIP)
+	}
+	if payload.MatchesServerIP == nil || *payload.MatchesServerIP {
+		t.Fatalf("matches_server_ip = %#v, want false", payload.MatchesServerIP)
+	}
+	if payload.Error != "" {
+		t.Fatalf("error = %q, want empty", payload.Error)
+	}
+}
+
+func TestGetUsageLogEgressHandlesHistoricalLogsWithoutMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	usage.InsertLogWithDetails(
+		"sk-test", "Primary", "gpt-test", "codex", "Codex", "auth-1",
+		false, time.Now().UTC(), 100, 10,
+		usage.TokenStats{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
+		`{"messages":[]}`, `{"choices":[]}`, `{"client":{"ip":"203.0.113.8"}}`,
+	)
+	rows, err := usage.QueryLogs(usage.LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs: %v", err)
+	}
+	if len(rows.Items) != 1 {
+		t.Fatalf("expected one log row, got %d", len(rows.Items))
+	}
+
+	probeCalled := false
+	savedProbe := usageLogEgressProbeFn
+	usageLogEgressProbeFn = func(_ context.Context, _ string, _ *config.SDKConfig) (string, error) {
+		probeCalled = true
+		return "", fmt.Errorf("unexpected probe")
+	}
+	t.Cleanup(func() {
+		usageLogEgressProbeFn = savedProbe
+	})
+
+	h := &Handler{cfg: &config.Config{}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: strconv.FormatInt(rows.Items[0].ID, 10)}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs/1/egress", nil)
+
+	h.GetUsageLogEgress(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if probeCalled {
+		t.Fatal("egress probe should not run when request has no stored egress metadata")
+	}
+	var payload struct {
+		Error      string `json:"error"`
+		UsingProxy bool   `json:"using_proxy"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload.Error == "" {
+		t.Fatal("expected a missing-metadata error")
+	}
+	if payload.UsingProxy {
+		t.Fatal("using_proxy = true, want false")
+	}
+}

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -22,7 +22,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 205; got != want {
+	if got, want := len(routes), 206; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 
@@ -32,6 +32,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"GET /v0/management/model-configs",
 		"PUT /v0/management/model-configs/*id",
 		"GET /v0/management/usage/logs/:id/content",
+		"GET /v0/management/usage/logs/:id/egress",
 		"POST /v0/management/api-call",
 		"PATCH /v0/management/api-key-entries",
 		"POST /v0/management/opencode-go-api-key/usage",

--- a/internal/api/routes/management_usage_routes.go
+++ b/internal/api/routes/management_usage_routes.go
@@ -12,6 +12,7 @@ func registerManagementUsageRoutes(group *gin.RouterGroup, h *managementhandlers
 	group.GET("/usage/logs", h.GetUsageLogs)
 	group.DELETE("/usage/logs", h.DeleteUsageLogs)
 	group.GET("/usage/logs/:id/content", h.GetLogContent)
+	group.GET("/usage/logs/:id/egress", h.GetUsageLogEgress)
 	group.GET("/usage/auth-file-group-trend", h.GetAuthFileGroupTrend)
 	group.GET("/usage/auth-file-trend", h.GetAuthFileTrend)
 	group.POST("/usage/auth-file-quota-snapshot", h.PostAuthFileQuotaSnapshot)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -26,7 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
-	"golang.org/x/net/proxy"
 )
 
 const (
@@ -632,7 +630,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 }
 
 func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *cliproxyauth.Auth, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {
-	dialer := newProxyAwareWebsocketDialer(e.cfg, auth)
+	dialer := newProxyAwareWebsocketDialer(ctx, e.cfg, auth)
 	dialer.HandshakeTimeout = codexResponsesWebsocketHandshakeTO
 	dialer.EnableCompression = true
 	if ctx == nil {
@@ -738,65 +736,6 @@ func markCodexWebsocketCreateSent(sess *codexWebsocketSession, conn *websocket.C
 		sess.connCreateSent = true
 	}
 	sess.connMu.Unlock()
-}
-
-func newProxyAwareWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth) *websocket.Dialer {
-	dialer := &websocket.Dialer{
-		Proxy:             http.ProxyFromEnvironment,
-		HandshakeTimeout:  codexResponsesWebsocketHandshakeTO,
-		EnableCompression: true,
-		NetDialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-	}
-
-	proxyURL := ""
-	if cfg != nil {
-		proxyID := ""
-		fallbackURL := ""
-		if auth != nil {
-			proxyID = auth.ProxyID
-			fallbackURL = auth.ProxyURL
-		}
-		proxyURL = cfg.ResolveProxyURL(proxyID, fallbackURL)
-	} else if auth != nil {
-		proxyURL = strings.TrimSpace(auth.ProxyURL)
-	}
-	if proxyURL == "" {
-		return dialer
-	}
-
-	parsedURL, errParse := url.Parse(proxyURL)
-	if errParse != nil {
-		log.Errorf("codex websockets executor: parse proxy URL failed: %v", errParse)
-		return dialer
-	}
-
-	switch parsedURL.Scheme {
-	case "socks5":
-		var proxyAuth *proxy.Auth
-		if parsedURL.User != nil {
-			username := parsedURL.User.Username()
-			password, _ := parsedURL.User.Password()
-			proxyAuth = &proxy.Auth{User: username, Password: password}
-		}
-		socksDialer, errSOCKS5 := proxy.SOCKS5("tcp", parsedURL.Host, proxyAuth, proxy.Direct)
-		if errSOCKS5 != nil {
-			log.Errorf("codex websockets executor: create SOCKS5 dialer failed: %v", errSOCKS5)
-			return dialer
-		}
-		dialer.Proxy = nil
-		dialer.NetDialContext = func(_ context.Context, network, addr string) (net.Conn, error) {
-			return socksDialer.Dial(network, addr)
-		}
-	case "http", "https":
-		dialer.Proxy = http.ProxyURL(parsedURL)
-	default:
-		log.Errorf("codex websockets executor: unsupported proxy scheme: %s", parsedURL.Scheme)
-	}
-
-	return dialer
 }
 
 func buildCodexResponsesWebsocketURL(httpURL string) (string, error) {

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -3,14 +3,26 @@ package executor
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
 )
+
+const requestLogEgressRouteKey = "cliproxy.request_log.egress_route"
+
+type requestLogEgressRoute struct {
+	RouteKind    string `json:"route_kind,omitempty"`
+	ProxySource  string `json:"proxy_source,omitempty"`
+	ProxyID      string `json:"proxy_id,omitempty"`
+	ProxyName    string `json:"proxy_name,omitempty"`
+	ProxyURLHost string `json:"proxy_url_host,omitempty"`
+}
 
 // newProxyAwareHTTPClient creates an HTTP client with proper proxy configuration priority:
 // 1. Use auth.ProxyID when it resolves to an enabled proxy-pool entry
@@ -41,6 +53,7 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	} else if auth != nil {
 		proxyURL = strings.TrimSpace(auth.ProxyURL)
 	}
+	recordRequestLogEgressRoute(ctx, cfg, auth, proxyURL)
 
 	// If we have a proxy URL configured, set up the transport
 	if proxyURL != "" {
@@ -70,6 +83,69 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	}
 
 	return httpClient
+}
+
+func recordRequestLogEgressRoute(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, proxyURL string) {
+	ginCtx, _ := ctx.Value(util.ContextKeyGin).(*gin.Context)
+	if ginCtx == nil {
+		return
+	}
+
+	proxyURL = strings.TrimSpace(proxyURL)
+	route := requestLogEgressRoute{
+		RouteKind: "direct",
+	}
+	if proxyURL != "" {
+		route.RouteKind = "proxy"
+		route.ProxyURLHost = maskProxyURLHost(proxyURL)
+	}
+
+	proxyID := ""
+	fallbackURL := ""
+	if auth != nil {
+		proxyID = strings.TrimSpace(auth.ProxyID)
+		fallbackURL = strings.TrimSpace(auth.ProxyURL)
+	}
+	route.ProxyID = proxyID
+
+	switch {
+	case proxyURL == "":
+		route.ProxySource = "direct"
+	case proxyID != "":
+		route.ProxySource = "proxy_id"
+	case fallbackURL != "" && strings.EqualFold(proxyURL, fallbackURL):
+		route.ProxySource = "auth_proxy_url"
+	case cfg != nil && strings.TrimSpace(cfg.ProxyURL) != "" && strings.EqualFold(proxyURL, cfg.ProxyURL):
+		route.ProxySource = "global_proxy_url"
+	default:
+		route.ProxySource = "proxy_url"
+	}
+
+	if cfg != nil && proxyID != "" {
+		for _, entry := range cfg.ProxyPool {
+			if !entry.Enabled {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(entry.ID), proxyID) {
+				route.ProxyName = strings.TrimSpace(entry.Name)
+				break
+			}
+		}
+	}
+
+	ginCtx.Set(requestLogEgressRouteKey, route)
+}
+
+func maskProxyURLHost(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "***"
+	}
+	return strings.ToLower(parsed.Scheme) + "://" + parsed.Host
 }
 
 // cfgToSDKCfg extracts the embedded SDKConfig from Config for TLS settings.

--- a/internal/runtime/executor/usage_helpers.go
+++ b/internal/runtime/executor/usage_helpers.go
@@ -386,6 +386,9 @@ func buildRequestDetailContent(ctx context.Context) string {
 			"upstream_log": bytesToString(apiResponse),
 		},
 	}
+	if egress := requestLogEgressFromContext(ginCtx); len(egress) > 0 {
+		detail["egress"] = egress
+	}
 
 	data, err := json.Marshal(detail)
 	if err != nil {
@@ -417,6 +420,41 @@ func bytesToString(value any) string {
 		return ""
 	}
 	return string(data)
+}
+
+func requestLogEgressFromContext(ginCtx *gin.Context) map[string]any {
+	if ginCtx == nil {
+		return nil
+	}
+	value, exists := ginCtx.Get(requestLogEgressRouteKey)
+	if !exists {
+		return nil
+	}
+	route, ok := value.(requestLogEgressRoute)
+	if !ok {
+		return nil
+	}
+
+	result := map[string]any{}
+	if route.RouteKind != "" {
+		result["route_kind"] = route.RouteKind
+	}
+	if route.ProxySource != "" {
+		result["proxy_source"] = route.ProxySource
+	}
+	if route.ProxyID != "" {
+		result["proxy_id"] = route.ProxyID
+	}
+	if route.ProxyName != "" {
+		result["proxy_name"] = route.ProxyName
+	}
+	if route.ProxyURLHost != "" {
+		result["proxy_url_host"] = route.ProxyURLHost
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func cloneHeaderValues(headers http.Header) map[string][]string {

--- a/internal/runtime/executor/websocket_proxy_helpers.go
+++ b/internal/runtime/executor/websocket_proxy_helpers.go
@@ -1,0 +1,76 @@
+package executor
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/proxy"
+)
+
+func newProxyAwareWebsocketDialer(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth) *websocket.Dialer {
+	dialer := &websocket.Dialer{
+		Proxy:             http.ProxyFromEnvironment,
+		HandshakeTimeout:  codexResponsesWebsocketHandshakeTO,
+		EnableCompression: true,
+		NetDialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+	}
+
+	proxyURL := ""
+	if cfg != nil {
+		proxyID := ""
+		fallbackURL := ""
+		if auth != nil {
+			proxyID = auth.ProxyID
+			fallbackURL = auth.ProxyURL
+		}
+		proxyURL = cfg.ResolveProxyURL(proxyID, fallbackURL)
+	} else if auth != nil {
+		proxyURL = strings.TrimSpace(auth.ProxyURL)
+	}
+	recordRequestLogEgressRoute(ctx, cfg, auth, proxyURL)
+	if proxyURL == "" {
+		return dialer
+	}
+
+	parsedURL, errParse := url.Parse(proxyURL)
+	if errParse != nil {
+		log.Errorf("codex websockets executor: parse proxy URL failed: %v", errParse)
+		return dialer
+	}
+
+	switch parsedURL.Scheme {
+	case "socks5":
+		var proxyAuth *proxy.Auth
+		if parsedURL.User != nil {
+			username := parsedURL.User.Username()
+			password, _ := parsedURL.User.Password()
+			proxyAuth = &proxy.Auth{User: username, Password: password}
+		}
+		socksDialer, errSOCKS5 := proxy.SOCKS5("tcp", parsedURL.Host, proxyAuth, proxy.Direct)
+		if errSOCKS5 != nil {
+			log.Errorf("codex websockets executor: create SOCKS5 dialer failed: %v", errSOCKS5)
+			return dialer
+		}
+		dialer.Proxy = nil
+		dialer.NetDialContext = func(_ context.Context, network, addr string) (net.Conn, error) {
+			return socksDialer.Dial(network, addr)
+		}
+	case "http", "https":
+		dialer.Proxy = http.ProxyURL(parsedURL)
+	default:
+		log.Errorf("codex websockets executor: unsupported proxy scheme: %s", parsedURL.Scheme)
+	}
+
+	return dialer
+}

--- a/internal/usage/usage_log_queries.go
+++ b/internal/usage/usage_log_queries.go
@@ -1,0 +1,39 @@
+package usage
+
+import (
+	"fmt"
+	"time"
+)
+
+// QueryLogRowByID returns a single request log row by primary key.
+func QueryLogRowByID(id int64) (LogRow, error) {
+	db := getDB()
+	if db == nil {
+		return LogRow{}, fmt.Errorf("usage: database not initialised")
+	}
+
+	var row LogRow
+	var ts string
+	var failedInt, hasContentInt int
+	err := db.QueryRow(
+		"SELECT id, timestamp, api_key, api_key_name, model, source, channel_name, auth_index, "+
+			"failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, "+
+			"cost, "+
+			"(CASE WHEN EXISTS (SELECT 1 FROM request_log_content content WHERE content.log_id = request_logs.id) "+
+			"OR length(input_content) > 0 OR length(output_content) > 0 THEN 1 ELSE 0 END) as has_content "+
+			"FROM request_logs WHERE id = ?",
+		id,
+	).Scan(
+		&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.Source, &row.ChannelName,
+		&row.AuthIndex, &failedInt, &row.LatencyMs, &row.FirstTokenMs,
+		&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
+		&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,
+	)
+	if err != nil {
+		return LogRow{}, fmt.Errorf("usage: query log row: %w", err)
+	}
+	row.Timestamp, _ = time.Parse(time.RFC3339Nano, ts)
+	row.Failed = failedInt != 0
+	row.HasContent = hasContentInt != 0
+	return row, nil
+}


### PR DESCRIPTION
This PR adds an egress inspection endpoint for management usage logs and records proxy route metadata so the panel can show whether a request exited through a proxy or the server network. The effective egress IP is resolved on demand from log context, so the normal request path stays lightweight.\n\nVerification: rtk go test ./internal/api/handlers/management ./internal/runtime/executor ./internal/usage