### PR TITLE
refactor: move api key entry settings use cases

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -37,9 +37,25 @@ func (h *Handler) refreshAPIKeyCache() {
 
 func (h *Handler) apiKeySettings() *apikeysettings.Service {
 	if h == nil {
-		return apikeysettings.NewService(nil)
+		return apikeysettings.NewService(nil, nil, nil)
 	}
-	return apikeysettings.NewService(h.sanitizeAllowedChannelsForSave)
+	validateEntry := func(entry config.APIKeyEntry) error {
+		var auths []*coreauth.Auth
+		if h.authManager != nil {
+			auths = h.authManager.List()
+		}
+		routingCfg := config.RoutingConfig{}
+		if h.cfg != nil {
+			routingCfg = h.cfg.Routing
+		}
+		return validateRoutingAndAPIKeyRestrictions(&config.Config{
+			SDKConfig: config.SDKConfig{
+				APIKeyEntries: []config.APIKeyEntry{entry},
+			},
+			Routing: routingCfg,
+		}, auths)
+	}
+	return apikeysettings.NewService(h.sanitizeAllowedChannelsForSave, h.validateAllowedChannelGroups, validateEntry)
 }
 
 func providerSettingsService(h *Handler) *providersettings.Service {
@@ -238,12 +254,7 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 
 // api-key-entries: backed by SQLite api_keys table
 func (h *Handler) GetAPIKeyEntries(c *gin.Context) {
-	rows := usage.EffectiveAPIKeyRows(usage.ListAPIKeys())
-	entries := make([]config.APIKeyEntry, 0, len(rows))
-	for _, r := range rows {
-		entries = append(entries, r.ToConfigEntry())
-	}
-	c.JSON(200, gin.H{"api-key-entries": entries})
+	c.JSON(200, gin.H{"api-key-entries": h.apiKeySettings().APIKeyEntries()})
 }
 
 func (h *Handler) PutAPIKeyEntries(c *gin.Context) {
@@ -263,41 +274,11 @@ func (h *Handler) PutAPIKeyEntries(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
-	var rows []usage.APIKeyRow
-	var auths []*coreauth.Auth
-	if h != nil && h.authManager != nil {
-		auths = h.authManager.List()
-	}
-	routingCfg := config.RoutingConfig{}
-	if h != nil && h.cfg != nil {
-		routingCfg = h.cfg.Routing
-	}
-	for _, entry := range arr {
-		entry.AllowedChannelGroups = uniqueChannelGroups(entry.AllowedChannelGroups)
-		cleanedChannels, errValidate := h.sanitizeAllowedChannelsForSave(entry.AllowedChannels)
-		if errValidate != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
+	if err := h.apiKeySettings().ReplaceEntries(arr); err != nil {
+		if errors.Is(err, apikeysettings.ErrInvalidEntry) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		entry.AllowedChannels = cleanedChannels
-		validatedGroups, errValidate := h.validateAllowedChannelGroups(entry.AllowedChannelGroups)
-		if errValidate != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
-			return
-		}
-		entry.AllowedChannelGroups = validatedGroups
-		if errValidate := validateRoutingAndAPIKeyRestrictions(&config.Config{
-			SDKConfig: config.SDKConfig{
-				APIKeyEntries: []config.APIKeyEntry{entry},
-			},
-			Routing: routingCfg,
-		}, auths); errValidate != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
-			return
-		}
-		rows = append(rows, usage.APIKeyRowFromConfig(entry))
-	}
-	if err := usage.ReplaceAllAPIKeys(rows); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -306,147 +287,30 @@ func (h *Handler) PutAPIKeyEntries(c *gin.Context) {
 }
 
 func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
-	type apiKeyEntryPatch struct {
-		Key                  *string   `json:"key"`
-		Name                 *string   `json:"name"`
-		PermissionProfileID  *string   `json:"permission-profile-id"`
-		DailyLimit           *int      `json:"daily-limit"`
-		TotalQuota           *int      `json:"total-quota"`
-		SpendingLimit        *float64  `json:"spending-limit"`
-		ConcurrencyLimit     *int      `json:"concurrency-limit"`
-		RPMLimit             *int      `json:"rpm-limit"`
-		TPMLimit             *int      `json:"tpm-limit"`
-		AllowedModels        *[]string `json:"allowed-models"`
-		AllowedChannels      *[]string `json:"allowed-channels"`
-		AllowedChannelGroups *[]string `json:"allowed-channel-groups"`
-		SystemPrompt         *string   `json:"system-prompt"`
-		CreatedAt            *string   `json:"created-at"`
-	}
 	var body struct {
-		Index *int              `json:"index"`
-		Match *string           `json:"match"`
-		Value *apiKeyEntryPatch `json:"value"`
+		Index *int                             `json:"index"`
+		Match *string                          `json:"match"`
+		Value *apikeysettings.APIKeyEntryPatch `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-
-	// Find existing entry by index or match key
-	var targetKey string
-	if body.Match != nil {
-		targetKey = strings.TrimSpace(*body.Match)
-	}
-	if targetKey == "" && body.Index != nil {
-		rows := usage.ListAPIKeys()
-		if *body.Index >= 0 && *body.Index < len(rows) {
-			targetKey = rows[*body.Index].Key
-		}
-	}
-
-	var entry usage.APIKeyRow
-	if targetKey != "" {
-		if existing := usage.GetAPIKey(targetKey); existing != nil {
-			entry = *existing
-		} else {
-			// If setting a new key via patch, start fresh
-			entry.Key = targetKey
-		}
-	} else {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	// Handle key deletion (empty key)
-	if body.Value.Key != nil {
-		trimmed := strings.TrimSpace(*body.Value.Key)
-		if trimmed == "" {
+	if err := h.apiKeySettings().PatchEntry(body.Index, body.Match, *body.Value); err != nil {
+		switch {
+		case errors.Is(err, apikeysettings.ErrItemNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
+			return
+		case errors.Is(err, apikeysettings.ErrKeyRequired):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "key is required"})
 			return
-		}
-		// Key change: delete old, insert new
-		if trimmed != targetKey {
-			if existing := usage.GetAPIKey(trimmed); existing != nil {
-				c.JSON(http.StatusConflict, gin.H{"error": "api key already exists"})
-				return
-			}
-			if err := usage.DeleteAPIKey(targetKey); err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
-		}
-		entry.Key = trimmed
-	}
-
-	// Apply patches
-	if body.Value.Name != nil {
-		entry.Name = strings.TrimSpace(*body.Value.Name)
-	}
-	if body.Value.PermissionProfileID != nil {
-		entry.PermissionProfileID = strings.TrimSpace(*body.Value.PermissionProfileID)
-	}
-	if body.Value.DailyLimit != nil {
-		entry.DailyLimit = *body.Value.DailyLimit
-	}
-	if body.Value.TotalQuota != nil {
-		entry.TotalQuota = *body.Value.TotalQuota
-	}
-	if body.Value.SpendingLimit != nil {
-		entry.SpendingLimit = *body.Value.SpendingLimit
-	}
-	if body.Value.ConcurrencyLimit != nil {
-		entry.ConcurrencyLimit = *body.Value.ConcurrencyLimit
-	}
-	if body.Value.RPMLimit != nil {
-		entry.RPMLimit = *body.Value.RPMLimit
-	}
-	if body.Value.TPMLimit != nil {
-		entry.TPMLimit = *body.Value.TPMLimit
-	}
-	if body.Value.AllowedModels != nil {
-		entry.AllowedModels = append([]string(nil), (*body.Value.AllowedModels)...)
-	}
-	if body.Value.AllowedChannels != nil {
-		validated, errValidate := h.sanitizeAllowedChannelsForSave(*body.Value.AllowedChannels)
-		if errValidate != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
+		case errors.Is(err, apikeysettings.ErrAPIKeyExists):
+			c.JSON(http.StatusConflict, gin.H{"error": "api key already exists"})
+			return
+		case errors.Is(err, apikeysettings.ErrInvalidEntry):
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		entry.AllowedChannels = validated
-	}
-	if body.Value.AllowedChannelGroups != nil {
-		validated, errValidate := h.validateAllowedChannelGroups(*body.Value.AllowedChannelGroups)
-		if errValidate != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
-			return
-		}
-		entry.AllowedChannelGroups = validated
-	}
-	var auths []*coreauth.Auth
-	if h != nil && h.authManager != nil {
-		auths = h.authManager.List()
-	}
-	routingCfg := config.RoutingConfig{}
-	if h != nil && h.cfg != nil {
-		routingCfg = h.cfg.Routing
-	}
-	if errValidate := validateRoutingAndAPIKeyRestrictions(&config.Config{
-		SDKConfig: config.SDKConfig{
-			APIKeyEntries: []config.APIKeyEntry{entry.ToConfigEntry()},
-		},
-		Routing: routingCfg,
-	}, auths); errValidate != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": errValidate.Error()})
-		return
-	}
-	if body.Value.SystemPrompt != nil {
-		entry.SystemPrompt = strings.TrimSpace(*body.Value.SystemPrompt)
-	}
-	if body.Value.CreatedAt != nil {
-		entry.CreatedAt = strings.TrimSpace(*body.Value.CreatedAt)
-	}
-
-	if err := usage.UpsertAPIKey(entry); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -456,40 +320,28 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 
 func (h *Handler) DeleteAPIKeyEntry(c *gin.Context) {
 	deleteLogs := shouldDeleteAPIKeyLogs(c)
-	if val := strings.TrimSpace(c.Query("key")); val != "" {
-		if err := usage.DeleteAPIKey(val); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	var index *int
+	if idxStr := c.Query("index"); idxStr != "" {
+		parsed, err := strconv.Atoi(idxStr)
+		if err == nil {
+			index = &parsed
+		}
+	}
+	deletedKey, err := h.apiKeySettings().DeleteEntry(c.Query("key"), index)
+	if err != nil {
+		if errors.Is(err, apikeysettings.ErrMissingValue) {
+			c.JSON(400, gin.H{"error": "missing key or index"})
 			return
 		}
-		var logsDeleted int64
-		if deleteLogs {
-			logsDeleted, _ = usage.DeleteLogsByAPIKey(val)
-		}
-		h.refreshAPIKeyCache()
-		c.JSON(200, gin.H{"status": "ok", "logs_deleted": logsDeleted})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if idxStr := c.Query("index"); idxStr != "" {
-		var idx int
-		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil {
-			rows := usage.ListAPIKeys()
-			if idx >= 0 && idx < len(rows) {
-				keyVal := rows[idx].Key
-				if err := usage.DeleteAPIKey(keyVal); err != nil {
-					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-					return
-				}
-				var logsDeleted int64
-				if deleteLogs {
-					logsDeleted, _ = usage.DeleteLogsByAPIKey(keyVal)
-				}
-				h.refreshAPIKeyCache()
-				c.JSON(200, gin.H{"status": "ok", "logs_deleted": logsDeleted})
-				return
-			}
-		}
+	var logsDeleted int64
+	if deleteLogs && deletedKey != "" {
+		logsDeleted, _ = usage.DeleteLogsByAPIKey(deletedKey)
 	}
-	c.JSON(400, gin.H{"error": "missing key or index"})
+	h.refreshAPIKeyCache()
+	c.JSON(200, gin.H{"status": "ok", "logs_deleted": logsDeleted})
 }
 
 func shouldDeleteAPIKeyLogs(c *gin.Context) bool {

--- a/internal/management/settings/apikey/entries.go
+++ b/internal/management/settings/apikey/entries.go
@@ -1,0 +1,199 @@
+package apikey
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+type APIKeyEntryPatch struct {
+	Key                  *string   `json:"key"`
+	Name                 *string   `json:"name"`
+	PermissionProfileID  *string   `json:"permission-profile-id"`
+	DailyLimit           *int      `json:"daily-limit"`
+	TotalQuota           *int      `json:"total-quota"`
+	SpendingLimit        *float64  `json:"spending-limit"`
+	ConcurrencyLimit     *int      `json:"concurrency-limit"`
+	RPMLimit             *int      `json:"rpm-limit"`
+	TPMLimit             *int      `json:"tpm-limit"`
+	AllowedModels        *[]string `json:"allowed-models"`
+	AllowedChannels      *[]string `json:"allowed-channels"`
+	AllowedChannelGroups *[]string `json:"allowed-channel-groups"`
+	SystemPrompt         *string   `json:"system-prompt"`
+	CreatedAt            *string   `json:"created-at"`
+}
+
+func (s *Service) APIKeyEntries() []config.APIKeyEntry {
+	rows := usage.EffectiveAPIKeyRows(usage.ListAPIKeys())
+	entries := make([]config.APIKeyEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, row.ToConfigEntry())
+	}
+	return entries
+}
+
+func (s *Service) ReplaceEntries(entries []config.APIKeyEntry) error {
+	rows := make([]usage.APIKeyRow, 0, len(entries))
+	for _, entry := range entries {
+		normalized, err := s.normalizeEntry(entry)
+		if err != nil {
+			return err
+		}
+		rows = append(rows, usage.APIKeyRowFromConfig(normalized))
+	}
+	return usage.ReplaceAllAPIKeys(rows)
+}
+
+func (s *Service) PatchEntry(index *int, match *string, patch APIKeyEntryPatch) error {
+	targetKey := ""
+	if match != nil {
+		targetKey = strings.TrimSpace(*match)
+	}
+	if targetKey == "" && index != nil {
+		rows := usage.ListAPIKeys()
+		if *index >= 0 && *index < len(rows) {
+			targetKey = rows[*index].Key
+		}
+	}
+	if targetKey == "" {
+		return ErrItemNotFound
+	}
+
+	var entry usage.APIKeyRow
+	if existing := usage.GetAPIKey(targetKey); existing != nil {
+		entry = *existing
+	} else {
+		entry.Key = targetKey
+	}
+
+	if patch.Key != nil {
+		trimmed := strings.TrimSpace(*patch.Key)
+		if trimmed == "" {
+			return ErrKeyRequired
+		}
+		if trimmed != targetKey {
+			if existing := usage.GetAPIKey(trimmed); existing != nil {
+				return ErrAPIKeyExists
+			}
+			if err := usage.DeleteAPIKey(targetKey); err != nil {
+				return err
+			}
+		}
+		entry.Key = trimmed
+	}
+	if patch.Name != nil {
+		entry.Name = strings.TrimSpace(*patch.Name)
+	}
+	if patch.PermissionProfileID != nil {
+		entry.PermissionProfileID = strings.TrimSpace(*patch.PermissionProfileID)
+	}
+	if patch.DailyLimit != nil {
+		entry.DailyLimit = *patch.DailyLimit
+	}
+	if patch.TotalQuota != nil {
+		entry.TotalQuota = *patch.TotalQuota
+	}
+	if patch.SpendingLimit != nil {
+		entry.SpendingLimit = *patch.SpendingLimit
+	}
+	if patch.ConcurrencyLimit != nil {
+		entry.ConcurrencyLimit = *patch.ConcurrencyLimit
+	}
+	if patch.RPMLimit != nil {
+		entry.RPMLimit = *patch.RPMLimit
+	}
+	if patch.TPMLimit != nil {
+		entry.TPMLimit = *patch.TPMLimit
+	}
+	if patch.AllowedModels != nil {
+		entry.AllowedModels = append([]string(nil), (*patch.AllowedModels)...)
+	}
+	if patch.AllowedChannels != nil {
+		entry.AllowedChannels = append([]string(nil), (*patch.AllowedChannels)...)
+	}
+	if patch.AllowedChannelGroups != nil {
+		entry.AllowedChannelGroups = append([]string(nil), (*patch.AllowedChannelGroups)...)
+	}
+	if patch.SystemPrompt != nil {
+		entry.SystemPrompt = strings.TrimSpace(*patch.SystemPrompt)
+	}
+	if patch.CreatedAt != nil {
+		entry.CreatedAt = strings.TrimSpace(*patch.CreatedAt)
+	}
+
+	normalized, err := s.normalizeEntry(entry.ToConfigEntry())
+	if err != nil {
+		return err
+	}
+	return usage.UpsertAPIKey(usage.APIKeyRowFromConfig(normalized))
+}
+
+func (s *Service) DeleteEntry(key string, index *int) (string, error) {
+	if trimmed := strings.TrimSpace(key); trimmed != "" {
+		return trimmed, usage.DeleteAPIKey(trimmed)
+	}
+	if index != nil {
+		rows := usage.ListAPIKeys()
+		if *index >= 0 && *index < len(rows) {
+			keyValue := rows[*index].Key
+			return keyValue, usage.DeleteAPIKey(keyValue)
+		}
+	}
+	return "", ErrMissingValue
+}
+
+func (s *Service) normalizeEntry(entry config.APIKeyEntry) (config.APIKeyEntry, error) {
+	entry.Key = strings.TrimSpace(entry.Key)
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.PermissionProfileID = strings.TrimSpace(entry.PermissionProfileID)
+	entry.SystemPrompt = strings.TrimSpace(entry.SystemPrompt)
+	entry.CreatedAt = strings.TrimSpace(entry.CreatedAt)
+	entry.AllowedChannelGroups = uniqueChannelGroups(entry.AllowedChannelGroups)
+
+	if s != nil && s.sanitizeChannels != nil {
+		cleaned, err := s.sanitizeChannels(entry.AllowedChannels)
+		if err != nil {
+			return config.APIKeyEntry{}, fmt.Errorf("%w: %v", ErrInvalidEntry, err)
+		}
+		entry.AllowedChannels = cleaned
+	}
+	if s != nil && s.sanitizeChannelGroups != nil {
+		cleaned, err := s.sanitizeChannelGroups(entry.AllowedChannelGroups)
+		if err != nil {
+			return config.APIKeyEntry{}, fmt.Errorf("%w: %v", ErrInvalidEntry, err)
+		}
+		entry.AllowedChannelGroups = cleaned
+	}
+	if s != nil && s.validateEntry != nil {
+		if err := s.validateEntry(entry); err != nil {
+			return config.APIKeyEntry{}, fmt.Errorf("%w: %v", ErrInvalidEntry, err)
+		}
+	}
+	return entry, nil
+}
+
+func uniqueChannelGroups(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized := internalrouting.NormalizeGroupName(value)
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/management/settings/apikey/entries_test.go
+++ b/internal/management/settings/apikey/entries_test.go
@@ -1,0 +1,122 @@
+package apikey
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func setupAPIKeySettingsDB(t *testing.T) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "apikey-settings.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+}
+
+func TestReplaceEntriesNormalizesAndValidates(t *testing.T) {
+	setupAPIKeySettingsDB(t)
+
+	service := NewService(
+		func(values []string) ([]string, error) {
+			out := make([]string, 0, len(values))
+			for _, value := range values {
+				if value == "kimi-B" {
+					out = append(out, value)
+				}
+			}
+			return out, nil
+		},
+		func(values []string) ([]string, error) { return values, nil },
+		func(entry config.APIKeyEntry) error {
+			if len(entry.AllowedChannelGroups) != 1 || entry.AllowedChannelGroups[0] != "pro" {
+				return errors.New("unexpected channel groups")
+			}
+			return nil
+		},
+	)
+
+	err := service.ReplaceEntries([]config.APIKeyEntry{{
+		Key:                  " sk-test ",
+		Name:                 " Test Key ",
+		PermissionProfileID:  " standard ",
+		AllowedChannels:      []string{"kimi-A", "kimi-B"},
+		AllowedChannelGroups: []string{" Pro ", "pro"},
+		SystemPrompt:         " keep me ",
+	}})
+	if err != nil {
+		t.Fatalf("ReplaceEntries() error = %v", err)
+	}
+
+	got := usage.GetAPIKey("sk-test")
+	if got == nil {
+		t.Fatal("expected API key after ReplaceEntries")
+	}
+	if got.Name != "Test Key" || got.PermissionProfileID != "standard" {
+		t.Fatalf("stored row = %#v", got)
+	}
+	if len(got.AllowedChannels) != 1 || got.AllowedChannels[0] != "kimi-B" {
+		t.Fatalf("allowed channels = %#v", got.AllowedChannels)
+	}
+	if len(got.AllowedChannelGroups) != 1 || got.AllowedChannelGroups[0] != "pro" {
+		t.Fatalf("allowed channel groups = %#v", got.AllowedChannelGroups)
+	}
+	if got.SystemPrompt != "keep me" {
+		t.Fatalf("system prompt = %q, want %q", got.SystemPrompt, "keep me")
+	}
+}
+
+func TestPatchEntryRejectsBlankAndDuplicateKeys(t *testing.T) {
+	setupAPIKeySettingsDB(t)
+
+	for _, row := range []usage.APIKeyRow{
+		{Key: "sk-original", Name: "Original"},
+		{Key: "sk-target", Name: "Target"},
+	} {
+		if err := usage.UpsertAPIKey(row); err != nil {
+			t.Fatalf("UpsertAPIKey(%q): %v", row.Key, err)
+		}
+	}
+
+	service := NewService(nil, nil, nil)
+
+	err := service.PatchEntry(nil, stringPtr("sk-original"), APIKeyEntryPatch{Key: stringPtr("   ")})
+	if !errors.Is(err, ErrKeyRequired) {
+		t.Fatalf("PatchEntry(blank key) error = %v, want %v", err, ErrKeyRequired)
+	}
+
+	err = service.PatchEntry(nil, stringPtr("sk-original"), APIKeyEntryPatch{Key: stringPtr("sk-target")})
+	if !errors.Is(err, ErrAPIKeyExists) {
+		t.Fatalf("PatchEntry(duplicate key) error = %v, want %v", err, ErrAPIKeyExists)
+	}
+}
+
+func TestDeleteEntryByIndexReturnsDeletedKey(t *testing.T) {
+	setupAPIKeySettingsDB(t)
+
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{Key: "sk-delete-me", Name: "Delete Me"}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	service := NewService(nil, nil, nil)
+	index := 0
+	deletedKey, err := service.DeleteEntry("", &index)
+	if err != nil {
+		t.Fatalf("DeleteEntry() error = %v", err)
+	}
+	if deletedKey != "sk-delete-me" {
+		t.Fatalf("deleted key = %q, want %q", deletedKey, "sk-delete-me")
+	}
+	if got := usage.GetAPIKey("sk-delete-me"); got != nil {
+		t.Fatalf("expected key to be deleted, got %#v", got)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -11,16 +12,28 @@ var (
 	ErrInvalidProfileID   = errors.New("id is required")
 	ErrInvalidProfileName = errors.New("name is required")
 	ErrMissingValue       = errors.New("missing value")
+	ErrItemNotFound       = errors.New("item not found")
+	ErrKeyRequired        = errors.New("key is required")
+	ErrAPIKeyExists       = errors.New("api key already exists")
+	ErrInvalidEntry       = errors.New("invalid api key entry")
 )
 
 type ChannelSanitizer func([]string) ([]string, error)
+type ChannelGroupSanitizer func([]string) ([]string, error)
+type EntryValidator func(config.APIKeyEntry) error
 
 type Service struct {
-	sanitizeChannels ChannelSanitizer
+	sanitizeChannels      ChannelSanitizer
+	sanitizeChannelGroups ChannelGroupSanitizer
+	validateEntry         EntryValidator
 }
 
-func NewService(sanitizeChannels ChannelSanitizer) *Service {
-	return &Service{sanitizeChannels: sanitizeChannels}
+func NewService(sanitizeChannels ChannelSanitizer, sanitizeChannelGroups ChannelGroupSanitizer, validateEntry EntryValidator) *Service {
+	return &Service{
+		sanitizeChannels:      sanitizeChannels,
+		sanitizeChannelGroups: sanitizeChannelGroups,
+		validateEntry:         validateEntry,
+	}
 }
 
 func (s *Service) EnabledKeys() []string {

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -32,7 +32,7 @@ func setupTestDB(t *testing.T) {
 
 func TestReplaceKeysNormalizesAndListsEnabledKeys(t *testing.T) {
 	setupTestDB(t)
-	svc := NewService(nil)
+	svc := NewService(nil, nil, nil)
 
 	if err := svc.ReplaceKeys([]string{" sk-one ", "", "sk-two"}); err != nil {
 		t.Fatalf("ReplaceKeys() error = %v, want nil", err)
@@ -48,7 +48,7 @@ func TestReplaceKeysNormalizesAndListsEnabledKeys(t *testing.T) {
 
 func TestPatchAndDeleteKey(t *testing.T) {
 	setupTestDB(t)
-	svc := NewService(nil)
+	svc := NewService(nil, nil, nil)
 
 	if err := svc.PatchKey("", " sk-created "); err != nil {
 		t.Fatalf("PatchKey(create) error = %v, want nil", err)
@@ -87,7 +87,7 @@ func TestReplacePermissionProfilesValidatesAndSanitizes(t *testing.T) {
 			out = append(out, channel)
 		}
 		return out, nil
-	})
+	}, nil, nil)
 
 	err := svc.ReplacePermissionProfiles([]usage.APIKeyPermissionProfileRow{{
 		ID:              " standard ",
@@ -112,7 +112,7 @@ func TestReplacePermissionProfilesValidatesAndSanitizes(t *testing.T) {
 
 func TestReplacePermissionProfilesRejectsMissingIdentity(t *testing.T) {
 	setupTestDB(t)
-	svc := NewService(nil)
+	svc := NewService(nil, nil, nil)
 
 	if err := svc.ReplacePermissionProfiles([]usage.APIKeyPermissionProfileRow{{Name: "Name"}}); !errors.Is(err, ErrInvalidProfileID) {
 		t.Fatalf("missing id error = %v, want ErrInvalidProfileID", err)


### PR DESCRIPTION
## Summary
- move API key entry list/replace/patch/delete logic into `internal/management/settings/apikey`
- keep management transport focused on request binding and HTTP response mapping
- add service coverage for entry normalization, duplicate key rejection, and indexed delete behavior

## Testing
- go test ./internal/management/settings/apikey ./internal/api/handlers/management