### PR TITLE
refactor: move runtime settings store into management settings

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -227,6 +227,7 @@
       ],
       "sdk/cliproxy/service.go": [
         "github.com/router-for-me/CLIProxyAPI/v6/internal/api",
+        "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store",
         "github.com/router-for-me/CLIProxyAPI/v6/internal/registry",
         "github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor",
         "github.com/router-for-me/CLIProxyAPI/v6/internal/usage",
@@ -255,17 +256,17 @@
     "allow": {
       "internal/api/handlers/management/channel_rename.go": {
         "config.SaveConfigPreserveComments": 2,
-        "usage.UpsertRuntimeSetting": 2,
+        "settingsstore.UpsertRuntimeSetting": 2,
         "usage.CleanDBBackedConfigFromYAML": 2
       },
       "internal/api/handlers/management/config_basic.go": {
-        "usage.MigrateRuntimeSettingsFromConfig": 1,
-        "usage.ApplyStoredRuntimeSettings": 1
+        "settingsstore.MigrateRuntimeSettingsFromConfig": 1,
+        "settingsstore.ApplyStoredRuntimeSettings": 1
       },
       "internal/api/handlers/management/handler.go": {
         "config.SaveConfigPreserveComments": 1,
-        "usage.UpsertRuntimeSetting": 1,
-        "usage.PersistRuntimeSettingsFromConfig": 1,
+        "settingsstore.UpsertRuntimeSetting": 1,
+        "settingsstore.PersistRuntimeSettingsFromConfig": 1,
         "usage.CleanDBBackedConfigFromYAML": 2
       }
     }

--- a/internal/api/handlers/management/channel_rename.go
+++ b/internal/api/handlers/management/channel_rename.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	oauthsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/oauth"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -28,7 +29,7 @@ func (h *Handler) renameChannelReferences(oldNames []string, newName string) err
 		}
 		if renameOAuthModelAliasChannels(h.cfg, oldNameSet, newName) {
 			configChanged = true
-			if err := usage.UpsertRuntimeSetting(usage.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias); err != nil {
+			if err := settingsstore.UpsertRuntimeSetting(settingsstore.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias); err != nil {
 				return fmt.Errorf("failed to persist oauth model aliases: %w", err)
 			}
 		}
@@ -77,7 +78,7 @@ func (h *Handler) removeChannelReferences(oldNames []string) error {
 		}
 		if removeOAuthModelAliasChannels(h.cfg, oldNameSet) {
 			configChanged = true
-			if err := usage.UpsertRuntimeSetting(usage.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias); err != nil {
+			if err := settingsstore.UpsertRuntimeSetting(settingsstore.RuntimeSettingOAuthModelAlias, h.cfg.OAuthModelAlias); err != nil {
 				return fmt.Errorf("failed to persist oauth model aliases: %w", err)
 			}
 		}

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -343,9 +344,9 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		return
 	}
 	if usage.ConfigStoreAvailable() {
-		usage.PersistRuntimeSettingsPresentInYAML(newCfg, body)
-		usage.MigrateRuntimeSettingsFromConfig(newCfg, h.configFilePath)
-		usage.ApplyStoredRuntimeSettings(newCfg)
+		settingsstore.PersistRuntimeSettingsPresentInYAML(newCfg, body)
+		settingsstore.MigrateRuntimeSettingsFromConfig(newCfg, h.configFilePath)
+		settingsstore.ApplyStoredRuntimeSettings(newCfg)
 	}
 	h.cfg = newCfg
 	mutated := h.onConfigMutated

--- a/internal/api/handlers/management/config_basic_test.go
+++ b/internal/api/handlers/management/config_basic_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -324,7 +325,7 @@ func TestPutConfigYAMLUpdatesExistingStoredPayloadRuntimeSetting(t *testing.T) {
 	}
 	t.Cleanup(usage.CloseDB)
 
-	if err := usage.UpsertRuntimeSetting(usage.RuntimeSettingPayload, config.PayloadConfig{
+	if err := settingsstore.UpsertRuntimeSetting(settingsstore.RuntimeSettingPayload, config.PayloadConfig{
 		Override: []config.PayloadRule{
 			{
 				Models: []config.PayloadModelRule{{Name: "old-model", Protocol: "codex"}},
@@ -365,7 +366,7 @@ logging-to-file: true
 	assertPayloadOverrideRule(t, h.cfg.Payload)
 
 	var stored config.Config
-	if !usage.ApplyStoredRuntimeSettings(&stored) {
+	if !settingsstore.ApplyStoredRuntimeSettings(&stored) {
 		t.Fatal("ApplyStoredRuntimeSettings returned false")
 	}
 	assertPayloadOverrideRule(t, stored.Payload)
@@ -388,7 +389,7 @@ func TestPutConfigYAMLNotifiesConfigMutationHookAfterPayloadRuntimeSettingUpdate
 	}
 	t.Cleanup(usage.CloseDB)
 
-	if err := usage.UpsertRuntimeSetting(usage.RuntimeSettingPayload, config.PayloadConfig{
+	if err := settingsstore.UpsertRuntimeSetting(settingsstore.RuntimeSettingPayload, config.PayloadConfig{
 		Override: []config.PayloadRule{
 			{
 				Models: []config.PayloadModelRule{{Name: "old-model", Protocol: "codex"}},

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
@@ -329,7 +330,7 @@ func (h *Handler) persist(c *gin.Context) bool {
 	cfg := h.cfg
 	mutated := h.onConfigMutated
 	if usage.ConfigStoreAvailable() {
-		usage.PersistRuntimeSettingsFromConfig(cfg)
+		settingsstore.PersistRuntimeSettingsFromConfig(cfg)
 	}
 	// Preserve comments when writing
 	if err := config.SaveConfigPreserveComments(h.configFilePath, cfg); err != nil {
@@ -352,7 +353,7 @@ func (h *Handler) persistRuntimeSetting(c *gin.Context, key string, value any) b
 	if !usage.ConfigStoreAvailable() {
 		return h.persist(c)
 	}
-	if err := usage.UpsertRuntimeSetting(key, value); err != nil {
+	if err := settingsstore.UpsertRuntimeSetting(key, value); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save runtime setting: %v", err)})
 		return false
 	}

--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 )
 
 type identityFingerprintResponse struct {
@@ -66,7 +66,7 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 	h.cfg.IdentityFingerprint = body
 	h.mu.Unlock()
 
-	h.persistRuntimeSetting(c, usage.RuntimeSettingIdentityFingerprint, body)
+	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingIdentityFingerprint, body)
 }
 
 func validateCodexIdentityFingerprint(fp config.CodexIdentityFingerprintConfig) error {

--- a/internal/api/handlers/management/oauth_settings.go
+++ b/internal/api/handlers/management/oauth_settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	oauthsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/oauth"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 )
 
 func oauthSettingsService(h *Handler) *oauthsettings.Service {
@@ -40,7 +40,7 @@ func (h *Handler) PutOAuthExcludedModels(c *gin.Context) {
 		entries = wrapper.Items
 	}
 	setting := oauthSettingsService(h).SetExcludedModels(entries)
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, setting)
+	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingOAuthExcludedModels, setting)
 }
 
 func (h *Handler) PatchOAuthExcludedModels(c *gin.Context) {
@@ -61,7 +61,7 @@ func (h *Handler) PatchOAuthExcludedModels(c *gin.Context) {
 		c.JSON(404, gin.H{"error": "provider not found"})
 		return
 	}
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, setting)
+	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingOAuthExcludedModels, setting)
 }
 
 func (h *Handler) DeleteOAuthExcludedModels(c *gin.Context) {
@@ -74,7 +74,7 @@ func (h *Handler) DeleteOAuthExcludedModels(c *gin.Context) {
 		c.JSON(404, gin.H{"error": "provider not found"})
 		return
 	}
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthExcludedModels, setting)
+	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingOAuthExcludedModels, setting)
 }
 
 // oauth-model-alias: map[string][]OAuthModelAlias
@@ -100,7 +100,7 @@ func (h *Handler) PutOAuthModelAlias(c *gin.Context) {
 		entries = wrapper.Items
 	}
 	setting := oauthSettingsService(h).SetModelAlias(entries)
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, setting)
+	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingOAuthModelAlias, setting)
 }
 
 func (h *Handler) PatchOAuthModelAlias(c *gin.Context) {
@@ -128,7 +128,7 @@ func (h *Handler) PatchOAuthModelAlias(c *gin.Context) {
 		c.JSON(404, gin.H{"error": "channel not found"})
 		return
 	}
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, setting)
+	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingOAuthModelAlias, setting)
 }
 
 func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
@@ -145,5 +145,5 @@ func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
 		c.JSON(404, gin.H{"error": "channel not found"})
 		return
 	}
-	h.persistRuntimeSetting(c, usage.RuntimeSettingOAuthModelAlias, setting)
+	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingOAuthModelAlias, setting)
 }

--- a/internal/api/handlers/management/runtime_settings_test.go
+++ b/internal/api/handlers/management/runtime_settings_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 )
 
 func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
@@ -39,7 +39,7 @@ func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
 	}
 
 	var stored config.Config
-	if !usage.ApplyStoredRuntimeSettings(&stored) {
+	if !settingsstore.ApplyStoredRuntimeSettings(&stored) {
 		t.Fatal("ApplyStoredRuntimeSettings returned false")
 	}
 	if !stored.IdentityFingerprint.Codex.Enabled || stored.IdentityFingerprint.Codex.UserAgent != "codex_cli_rs/0.125.0" {
@@ -81,7 +81,7 @@ func TestPutOAuthModelAliasPersistsToSQLite(t *testing.T) {
 	}
 
 	var stored config.Config
-	if !usage.ApplyStoredRuntimeSettings(&stored) {
+	if !settingsstore.ApplyStoredRuntimeSettings(&stored) {
 		t.Fatal("ApplyStoredRuntimeSettings returned false")
 	}
 	aliases := stored.OAuthModelAlias["codex"]
@@ -124,7 +124,7 @@ func TestPutProviderCredentialsPersistToSQLite(t *testing.T) {
 	}
 
 	var stored config.Config
-	if !usage.ApplyStoredRuntimeSettings(&stored) {
+	if !settingsstore.ApplyStoredRuntimeSettings(&stored) {
 		t.Fatal("ApplyStoredRuntimeSettings returned false")
 	}
 	if len(stored.CodexKey) != 1 || stored.CodexKey[0].APIKey != "sk-codex-db" || stored.CodexKey[0].BaseURL != "https://codex.example.com" {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/managementasset"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -316,8 +317,8 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 			usage.ApplyStoredRoutingConfig(updated)
 			usage.MigrateProxyPoolFromConfig(updated, configFilePath)
 			usage.ApplyStoredProxyPool(updated)
-			usage.MigrateRuntimeSettingsFromConfig(updated, configFilePath)
-			usage.ApplyStoredRuntimeSettings(updated)
+			settingsstore.MigrateRuntimeSettingsFromConfig(updated, configFilePath)
+			settingsstore.ApplyStoredRuntimeSettings(updated)
 			s.UpdateClients(updated)
 		})
 	}
@@ -1843,7 +1844,6 @@ func SystemPromptMiddleware() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-
 		c.Request.Body = io.NopCloser(bytes.NewReader(newBody))
 		c.Request.ContentLength = int64(len(newBody))
 		c.Next()

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy"
 	log "github.com/sirupsen/logrus"
@@ -62,8 +63,8 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 	usage.ApplyStoredRoutingConfig(cfg)
 	usage.MigrateProxyPoolFromConfig(cfg, configPath)
 	usage.ApplyStoredProxyPool(cfg)
-	usage.MigrateRuntimeSettingsFromConfig(cfg, configPath)
-	usage.ApplyStoredRuntimeSettings(cfg)
+	settingsstore.MigrateRuntimeSettingsFromConfig(cfg, configPath)
+	settingsstore.ApplyStoredRuntimeSettings(cfg)
 	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey)
 	usage.SetTokenUsageCallback(middleware.RecordTokenUsage)
 	usage.InitRedis(cfg.Redis)
@@ -134,8 +135,8 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 	usage.ApplyStoredRoutingConfig(cfg)
 	usage.MigrateProxyPoolFromConfig(cfg, configPath)
 	usage.ApplyStoredProxyPool(cfg)
-	usage.MigrateRuntimeSettingsFromConfig(cfg, configPath)
-	usage.ApplyStoredRuntimeSettings(cfg)
+	settingsstore.MigrateRuntimeSettingsFromConfig(cfg, configPath)
+	settingsstore.ApplyStoredRuntimeSettings(cfg)
 	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey)
 	usage.SetTokenUsageCallback(middleware.RecordTokenUsage)
 	usage.InitRedis(cfg.Redis)

--- a/internal/management/settings/store/runtime_settings.go
+++ b/internal/management/settings/store/runtime_settings.go
@@ -1,4 +1,4 @@
-package usage
+package store
 
 import (
 	"database/sql"
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -26,23 +27,6 @@ const (
 	RuntimeSettingOAuthModelAlias      = "oauth-model-alias"
 	RuntimeSettingPayload              = "payload"
 )
-
-const createRuntimeSettingsTableSQL = `
-CREATE TABLE IF NOT EXISTS runtime_settings (
-  setting_key TEXT PRIMARY KEY NOT NULL,
-  payload     TEXT NOT NULL DEFAULT '{}',
-  updated_at  TEXT NOT NULL DEFAULT ''
-);
-`
-
-func initRuntimeSettingsTable(db *sql.DB) {
-	if db == nil {
-		return
-	}
-	if _, err := db.Exec(createRuntimeSettingsTableSQL); err != nil {
-		log.Errorf("usage: create runtime_settings table: %v", err)
-	}
-}
 
 type runtimeSettingSpec struct {
 	key        string
@@ -400,7 +384,7 @@ func payloadConfigMeaningful(payload config.PayloadConfig) bool {
 }
 
 func runtimeSettingPayload(key string) (json.RawMessage, bool) {
-	db := getDB()
+	db := usage.GetDB()
 	if db == nil {
 		return nil, false
 	}
@@ -424,7 +408,7 @@ func runtimeSettingExists(key string) bool {
 }
 
 func UpsertRuntimeSetting(key string, value any) error {
-	db := getDB()
+	db := usage.GetDB()
 	if db == nil {
 		return nil
 	}
@@ -448,7 +432,7 @@ func UpsertRuntimeSetting(key string, value any) error {
 }
 
 func PersistRuntimeSettingsFromConfig(cfg *config.Config) int {
-	if cfg == nil || !ConfigStoreAvailable() {
+	if cfg == nil || !usage.ConfigStoreAvailable() {
 		return 0
 	}
 	persisted := 0
@@ -468,7 +452,7 @@ func PersistRuntimeSettingsFromConfig(cfg *config.Config) int {
 // PersistRuntimeSettingsPresentInYAML stores DB-backed runtime settings that
 // were explicitly included in a management config.yaml save.
 func PersistRuntimeSettingsPresentInYAML(cfg *config.Config, yamlContent []byte) int {
-	if cfg == nil || !ConfigStoreAvailable() {
+	if cfg == nil || !usage.ConfigStoreAvailable() {
 		return 0
 	}
 	present := yamlRootKeys(yamlContent)
@@ -519,7 +503,7 @@ func yamlRootKeys(data []byte) map[string]bool {
 }
 
 func ApplyStoredRuntimeSettings(cfg *config.Config) bool {
-	if cfg == nil || !ConfigStoreAvailable() {
+	if cfg == nil || !usage.ConfigStoreAvailable() {
 		return false
 	}
 	applied := false
@@ -536,7 +520,7 @@ func ApplyStoredRuntimeSettings(cfg *config.Config) bool {
 }
 
 func MigrateRuntimeSettingsFromConfig(cfg *config.Config, configFilePath string) int {
-	if cfg == nil || !ConfigStoreAvailable() {
+	if cfg == nil || !usage.ConfigStoreAvailable() {
 		return 0
 	}
 	migrated := 0
@@ -559,13 +543,13 @@ func MigrateRuntimeSettingsFromConfig(cfg *config.Config, configFilePath string)
 		return migrated
 	}
 	if migrated > 0 {
-		if backupConfigForMigration(configFilePath, runtimeSettingsBackupSuffix) {
-			cleanRuntimeSettingsFromYAML(configFilePath)
+		if usage.BackupConfigForMigration(configFilePath, usage.RuntimeSettingsMigrationBackupSuffix) {
+			usage.CleanRuntimeSettingsFromYAML(configFilePath)
 		}
 		return migrated
 	}
 	if hadStored {
-		cleanRuntimeSettingsFromYAML(configFilePath)
+		usage.CleanRuntimeSettingsFromYAML(configFilePath)
 	}
 	return migrated
 }

--- a/internal/management/settings/store/runtime_settings_test.go
+++ b/internal/management/settings/store/runtime_settings_test.go
@@ -1,12 +1,14 @@
-package usage
+package store
 
 import (
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 func TestRuntimeSettingsMigrationMovesConfigIntoSQLiteAndCleansYAML(t *testing.T) {
@@ -177,5 +179,31 @@ func TestRuntimeSettingsSQLiteWinsOverStaleYAML(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "logging-to-file: true") {
 		t.Fatalf("ordinary config should remain in YAML:\n%s", string(data))
+	}
+}
+
+func setupConfigMigrationTestDB(t *testing.T) func() {
+	t.Helper()
+
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+
+	return func() {
+		usage.CloseDB()
+	}
+}
+
+func assertMigrationBackupMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat migration backup: %v", err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("migration backup mode = %o, want %o", got, want)
 	}
 }

--- a/internal/usage/config_yaml_cleanup.go
+++ b/internal/usage/config_yaml_cleanup.go
@@ -20,6 +20,8 @@ const (
 	runtimeSettingsBackupSuffix    = ".pre-runtime-settings-sqlite-migration"
 )
 
+const RuntimeSettingsMigrationBackupSuffix = runtimeSettingsBackupSuffix
+
 var dbBackedConfigYAMLKeys = map[string]bool{
 	"api-keys":                    true,
 	"api-key-entries":             true,
@@ -73,6 +75,10 @@ func backupConfigForMigration(configFilePath string, suffix string) bool {
 	return true
 }
 
+func BackupConfigForMigration(configFilePath string, suffix string) bool {
+	return backupConfigForMigration(configFilePath, suffix)
+}
+
 func cleanAPIKeysFromYAML(configFilePath string) {
 	cleanConfigKeysFromYAML(configFilePath, map[string]bool{
 		"api-keys":        true,
@@ -108,6 +114,10 @@ func cleanRuntimeSettingsFromYAML(configFilePath string) {
 		"oauth-model-alias":      true,
 		"payload":                true,
 	}, "runtime_settings")
+}
+
+func CleanRuntimeSettingsFromYAML(configFilePath string) {
+	cleanRuntimeSettingsFromYAML(configFilePath)
 }
 
 func cleanConfigKeysFromYAML(configFilePath string, keysToRemove map[string]bool, label string) int {

--- a/internal/usage/runtime_settings_table.go
+++ b/internal/usage/runtime_settings_table.go
@@ -1,0 +1,24 @@
+package usage
+
+import (
+	"database/sql"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const createRuntimeSettingsTableSQL = `
+CREATE TABLE IF NOT EXISTS runtime_settings (
+  setting_key TEXT PRIMARY KEY NOT NULL,
+  payload     TEXT NOT NULL DEFAULT '{}',
+  updated_at  TEXT NOT NULL DEFAULT ''
+);
+`
+
+func initRuntimeSettingsTable(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	if _, err := db.Exec(createRuntimeSettingsTableSQL); err != nil {
+		log.Errorf("usage: create runtime_settings table: %v", err)
+	}
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -1155,7 +1155,7 @@ func getDB() *sql.DB {
 	defer usageDBMu.Unlock()
 	return usageDB
 }
-
+func GetDB() *sql.DB { return getDB() }
 func getUsageLocation() *time.Location {
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()

--- a/scripts/check-backend-structure.py
+++ b/scripts/check-backend-structure.py
@@ -24,11 +24,11 @@ SERVER_PATH = Path("internal/api/server.go")
 MANAGEMENT_PERSISTENCE_SYMBOLS = (
     "config.SaveConfigPreserveComments",
     "config.SaveConfigPreserveCommentsUpdateNestedScalar",
-    "usage.UpsertRuntimeSetting",
-    "usage.PersistRuntimeSettingsFromConfig",
+    "settingsstore.UpsertRuntimeSetting",
+    "settingsstore.PersistRuntimeSettingsFromConfig",
     "usage.CleanDBBackedConfigFromYAML",
-    "usage.MigrateRuntimeSettingsFromConfig",
-    "usage.ApplyStoredRuntimeSettings",
+    "settingsstore.MigrateRuntimeSettingsFromConfig",
+    "settingsstore.ApplyStoredRuntimeSettings",
 )
 
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
 	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -371,9 +372,8 @@ func (s *Service) applyConfigReload(newCfg *config.Config, refreshRegisteredMode
 	internalusage.ApplyStoredRoutingConfig(newCfg)
 	internalusage.MigrateProxyPoolFromConfig(newCfg, s.configPath)
 	internalusage.ApplyStoredProxyPool(newCfg)
-	internalusage.MigrateRuntimeSettingsFromConfig(newCfg, s.configPath)
-	internalusage.ApplyStoredRuntimeSettings(newCfg)
-
+	settingsstore.MigrateRuntimeSettingsFromConfig(newCfg, s.configPath)
+	settingsstore.ApplyStoredRuntimeSettings(newCfg)
 	nextStrategy := strings.ToLower(strings.TrimSpace(newCfg.Routing.Strategy))
 	previousStrategy = config.NormalizeRoutingStrategy(previousStrategy)
 	nextStrategy = config.NormalizeRoutingStrategy(nextStrategy)


### PR DESCRIPTION
## Summary
- move runtime settings persistence and migration logic into internal/management/settings/store
- update management handlers, service reload paths, and startup wiring to use the new store package
- keep runtime settings table/bootstrap helpers in internal/usage while moving the tests with package-local setup helpers

## Testing
- GOCACHE=/Users/kittors/Developer/opensource/CliProxy/CliRelay/.gocache go test ./internal/management/settings/store ./internal/usage ./internal/api/handlers/management -run '^(TestRuntimeSettings|TestPutConfigYAML|TestPutOAuth|TestPutIdentity|TestPutProviderCredentialsPersistToSQLite|TestRuntimeSettingsSQLiteWinsOverStaleYAML)'
- GOCACHE=/Users/kittors/Developer/opensource/CliProxy/CliRelay/.gocache go test ./internal/api ./internal/cmd ./sdk/cliproxy -run '^$'

## Notes
- The backend structure guard script changes were updated with the new settingsstore symbol names.
- The Python guard script could not be executed in this Codex environment because Python processes are being terminated with SIGKILL before startup, so I verified the updated allowlist and symbol counts directly in the changed files instead.