### PR TITLE
fix: harden management API security

### DIFF
--- a/internal/api/bodyutil/bodyutil.go
+++ b/internal/api/bodyutil/bodyutil.go
@@ -120,7 +120,7 @@ func shouldLimitRequestBody(req *http.Request) bool {
 		return false
 	}
 	switch req.Method {
-	case http.MethodPost, http.MethodPut, http.MethodPatch:
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
 	default:
 		return false
 	}

--- a/internal/api/bodyutil/bodyutil_test.go
+++ b/internal/api/bodyutil/bodyutil_test.go
@@ -55,3 +55,23 @@ func TestLimitBodyMiddlewareRestoresBodyForHandler(t *testing.T) {
 		t.Fatalf("unexpected response body: %s", got)
 	}
 }
+
+func TestLimitBodyMiddlewareRejectsOversizedDeleteRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(LimitBodyMiddleware(8))
+	r.DELETE("/management", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/management", bytes.NewReader([]byte(`{"value":"too-large"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status %d, got %d", http.StatusRequestEntityTooLarge, w.Code)
+	}
+}

--- a/internal/api/handlers/management/ccswitch_import_configs_public.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public.go
@@ -140,12 +140,14 @@ func (h *Handler) GetPublicCcSwitchImportConfigs(c *gin.Context) {
 	}
 
 	row := apikeysettings.NewService(nil).GetRow(apiKey)
+	maskedAPIKey := maskKey(apiKey)
 	if row == nil {
 		items := []usage.CcSwitchImportConfigRow{}
 		c.JSON(http.StatusOK, gin.H{
 			"ccswitch-import-configs": items,
 			"items":                   items,
-			"api_key":                 apiKey,
+			"api_key":                 maskedAPIKey,
+			"api_key_masked":          maskedAPIKey,
 			"found":                   false,
 		})
 		return
@@ -158,7 +160,8 @@ func (h *Handler) GetPublicCcSwitchImportConfigs(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"ccswitch-import-configs": items,
 			"items":                   items,
-			"api_key":                 apiKey,
+			"api_key":                 maskedAPIKey,
+			"api_key_masked":          maskedAPIKey,
 			"found":                   false,
 		})
 		return
@@ -179,7 +182,8 @@ func (h *Handler) GetPublicCcSwitchImportConfigs(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"ccswitch-import-configs": filtered,
 		"items":                   filtered,
-		"api_key":                 apiKey,
+		"api_key":                 maskedAPIKey,
+		"api_key_masked":          maskedAPIKey,
 		"found":                   true,
 	})
 }

--- a/internal/api/handlers/management/ccswitch_import_configs_public_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public_test.go
@@ -75,14 +75,18 @@ func TestPublicCcSwitchImportConfigsFiltersByAPIKeyPermissions(t *testing.T) {
 	}
 
 	var got struct {
-		Items []usage.CcSwitchImportConfigRow `json:"items"`
-		Found bool                            `json:"found"`
+		Items  []usage.CcSwitchImportConfigRow `json:"items"`
+		Found  bool                            `json:"found"`
+		APIKey string                          `json:"api_key"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
 	if !got.Found {
 		t.Fatalf("found = false, want true")
+	}
+	if got.APIKey == apiKey || got.APIKey == "" {
+		t.Fatalf("api_key should be masked, got %q", got.APIKey)
 	}
 	if len(got.Items) != 2 {
 		t.Fatalf("items len = %d, want 2", len(got.Items))

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -4,7 +4,6 @@ package management
 
 import (
 	"context"
-	"crypto/subtle"
 	"fmt"
 	"net/http"
 	"os"
@@ -19,6 +18,7 @@ import (
 	imagegeneration "github.com/router-for-me/CLIProxyAPI/v6/internal/management/imagegeneration"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -281,7 +281,8 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 				h.attemptsMu.Unlock()
 			}
 		}
-		if secretHash == "" && envSecret == "" {
+		localPasswordConfigured := localClient && h.localPassword != ""
+		if secretHash == "" && envSecret == "" && !localPasswordConfigured {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "remote management key not set"})
 			return
 		}
@@ -299,14 +300,16 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		if provided == "" {
 			provided = c.GetHeader("X-Management-Key")
 		}
-		// Fallback: ?token= query param (needed for WebSocket — browsers can't set custom headers)
-		if provided == "" {
+		// Fallback: ?token= query param is accepted only for WebSocket handshakes;
+		// normal HTTP requests must not carry credentials in URLs.
+		if provided == "" && shouldReadManagementTokenFromQuery(c) {
 			provided = c.Query("token")
 		}
 
 		if provided == "" {
 			if !localClient {
 				if remaining, banned := isBanned(); banned {
+					c.Header("Retry-After", retryAfterSecondsHeader(remaining))
 					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)})
 					return
 				}
@@ -318,14 +321,14 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 
 		if localClient {
 			if lp := h.localPassword; lp != "" {
-				if subtle.ConstantTimeCompare([]byte(provided), []byte(lp)) == 1 {
+				if util.ConstantTimeStringEqual(provided, lp) {
 					c.Next()
 					return
 				}
 			}
 		}
 
-		if envSecret != "" && subtle.ConstantTimeCompare([]byte(provided), []byte(envSecret)) == 1 {
+		if envSecret != "" && util.ConstantTimeStringEqual(provided, envSecret) {
 			clearFailures()
 			c.Next()
 			return
@@ -334,6 +337,7 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		if secretHash == "" || bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) != nil {
 			if !localClient {
 				if remaining, banned := isBanned(); banned {
+					c.Header("Retry-After", retryAfterSecondsHeader(remaining))
 					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)})
 					return
 				}

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -78,3 +78,97 @@ func TestMiddlewareAllowsValidKeyAfterRemoteIPIsBanned(t *testing.T) {
 		t.Fatalf("missing-key status after valid key cleared ban = %d, want %d; body=%s", rrAfterClear.Code, http.StatusUnauthorized, rrAfterClear.Body.String())
 	}
 }
+
+func TestMiddlewareAllowsLocalPasswordWithoutRemoteSecret(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, nil)
+	h.SetLocalPassword("local-management-password")
+	defer h.Close()
+
+	router := gin.New()
+	router.Use(h.Middleware())
+	router.GET("/v0/management/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+	req.RemoteAddr = "127.0.0.1:4321"
+	req.Header.Set("Authorization", "Bearer local-management-password")
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("local-password status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+}
+
+func TestMiddlewareRejectsQueryTokenOnNormalHTTPRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const managementKey = "correct-management-key"
+	hashed, err := bcrypt.GenerateFromPassword([]byte(managementKey), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash test management key: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		RemoteManagement: config.RemoteManagement{
+			AllowRemote: true,
+			SecretKey:   string(hashed),
+		},
+	}, nil)
+	defer h.Close()
+
+	router := gin.New()
+	router.Use(h.Middleware())
+	router.GET("/v0/management/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/ping?token="+managementKey, nil)
+	req.RemoteAddr = "203.0.113.20:4321"
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusUnauthorized, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "missing management key") {
+		t.Fatalf("expected query token to be ignored on normal route, got body=%s", rr.Body.String())
+	}
+}
+
+func TestMiddlewareAllowsQueryTokenOnlyForSystemStatsWebSocket(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const managementKey = "correct-management-key"
+	hashed, err := bcrypt.GenerateFromPassword([]byte(managementKey), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash test management key: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		RemoteManagement: config.RemoteManagement{
+			AllowRemote: true,
+			SecretKey:   string(hashed),
+		},
+	}, nil)
+	defer h.Close()
+
+	router := gin.New()
+	router.Use(h.Middleware())
+	router.GET("/v0/management/system-stats/ws", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/system-stats/ws?token="+managementKey, nil)
+	req.RemoteAddr = "203.0.113.21:4321"
+	req.Header.Set("Upgrade", "websocket")
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+}

--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -2,7 +2,9 @@ package management
 
 import (
 	"bufio"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"os"
@@ -19,6 +21,7 @@ import (
 const (
 	defaultLogFileName      = "main.log"
 	defaultLogLimit         = 5000
+	maxLogLimit             = 20000
 	logScannerInitialBuffer = 64 * 1024
 	logScannerMaxBuffer     = 8 * 1024 * 1024
 )
@@ -74,7 +77,7 @@ func (h *Handler) GetLogs(c *gin.Context) {
 	acc := newLogAccumulator(cutoff, limit)
 	for i := range files {
 		if errProcess := acc.consumeFile(files[i]); errProcess != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to read log file %s: %v", files[i], errProcess)})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to read log file %s: %v", filepath.Base(files[i]), errProcess)})
 			return
 		}
 	}
@@ -436,7 +439,17 @@ func (acc *logAccumulator) consumeFile(path string) error {
 		_ = file.Close()
 	}()
 
-	scanner := bufio.NewScanner(file)
+	var reader io.Reader = file
+	if strings.HasSuffix(strings.ToLower(path), ".gz") {
+		gzReader, errGzip := gzip.NewReader(file)
+		if errGzip != nil {
+			return errGzip
+		}
+		defer func() { _ = gzReader.Close() }()
+		reader = gzReader
+	}
+
+	scanner := bufio.NewScanner(reader)
 	buf := make([]byte, 0, logScannerInitialBuffer)
 	scanner.Buffer(buf, logScannerMaxBuffer)
 	for scanner.Scan() {
@@ -504,6 +517,9 @@ func parseLimit(raw string) (int, error) {
 	}
 	if limit <= 0 {
 		return 0, fmt.Errorf("must be greater than zero")
+	}
+	if limit > maxLogLimit {
+		return 0, fmt.Errorf("must not exceed %d", maxLogLimit)
 	}
 	return limit, nil
 }

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -1,9 +1,13 @@
 package management
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -42,5 +46,40 @@ func TestGetLogsReturnsEmptySnapshotWhenFileLoggingDisabled(t *testing.T) {
 	}
 	if payload.LatestTimestamp != 1714567890 {
 		t.Fatalf("latest-timestamp = %d, want 1714567890", payload.LatestTimestamp)
+	}
+}
+
+func TestParseLimitRejectsOversizedLimit(t *testing.T) {
+	if _, err := parseLimit("20001"); err == nil {
+		t.Fatal("expected oversized limit to be rejected")
+	}
+}
+
+func TestLogAccumulatorReadsGzipRotatedLog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main-2026-06-09T12-00-00.log.gz")
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write([]byte("[2026-06-09 12:00:01] [info ] rotated line\n")); err != nil {
+		t.Fatalf("write gzip payload: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write gzip log file: %v", err)
+	}
+
+	acc := newLogAccumulator(0, 10)
+	if err := acc.consumeFile(path); err != nil {
+		t.Fatalf("consume gzip log: %v", err)
+	}
+	lines, total, latest := acc.result()
+	if total != 1 || len(lines) != 1 || lines[0] != "[2026-06-09 12:00:01] [info ] rotated line" {
+		t.Fatalf("unexpected result: total=%d latest=%d lines=%#v", total, latest, lines)
+	}
+	if latest == 0 {
+		t.Fatal("expected latest timestamp to be parsed")
 	}
 }

--- a/internal/api/handlers/management/security_helpers.go
+++ b/internal/api/handlers/management/security_helpers.go
@@ -1,0 +1,39 @@
+package management
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func retryAfterSecondsHeader(duration time.Duration) string {
+	seconds := int(duration / time.Second)
+	if duration%time.Second != 0 {
+		seconds++
+	}
+	if seconds < 1 {
+		seconds = 1
+	}
+	return strconv.Itoa(seconds)
+}
+
+func shouldReadManagementTokenFromQuery(c *gin.Context) bool {
+	if c == nil || c.Request == nil || c.Request.URL == nil {
+		return false
+	}
+	if strings.TrimSpace(c.Query("token")) == "" {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(c.GetHeader("Upgrade")), "websocket") {
+		return false
+	}
+	path := strings.TrimSpace(c.FullPath())
+	if path == "" {
+		path = c.Request.URL.Path
+	}
+	// Query-string credentials are kept only for browser WebSocket handshakes,
+	// where custom Authorization headers cannot be set.
+	return path == "/v0/management/system-stats/ws" || strings.HasSuffix(path, "/system-stats/ws")
+}

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -67,21 +67,24 @@ func (h *Handler) GetPublicUsageByAPIKey(c *gin.Context) {
 
 	// Find the matching API key entry
 	apiData, found := snapshot.APIs[apiKey]
+	maskedAPIKey := maskKey(apiKey)
 	if !found {
 		c.JSON(http.StatusOK, gin.H{
 			"usage": usage.StatisticsSnapshot{
 				APIs: map[string]usage.APISnapshot{},
 			},
-			"api_key": apiKey,
-			"found":   false,
+			"api_key":        maskedAPIKey,
+			"api_key_masked": maskedAPIKey,
+			"found":          false,
 		})
 		return
 	}
 
-	// Return only the matched API key's data
+	// Return only the matched API key's data. Use the masked key as the public
+	// map key so the response never leaks the full credential.
 	filteredSnapshot := usage.StatisticsSnapshot{
 		APIs: map[string]usage.APISnapshot{
-			apiKey: apiData,
+			maskedAPIKey: apiData,
 		},
 	}
 
@@ -90,9 +93,10 @@ func (h *Handler) GetPublicUsageByAPIKey(c *gin.Context) {
 	filteredSnapshot.SanitizeForPublic()
 
 	c.JSON(http.StatusOK, gin.H{
-		"usage":   filteredSnapshot,
-		"api_key": apiKey,
-		"found":   true,
+		"usage":          filteredSnapshot,
+		"api_key":        maskedAPIKey,
+		"api_key_masked": maskedAPIKey,
+		"found":          true,
 	})
 }
 

--- a/internal/api/handlers/management/usage_public_test.go
+++ b/internal/api/handlers/management/usage_public_test.go
@@ -1,0 +1,66 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+)
+
+func TestGetPublicUsageByAPIKeyMasksCredentialEverywhere(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const apiKey = "sk-test-public-usage-secret-123456"
+	stats := usage.NewRequestStatistics()
+	wasEnabled := usage.StatisticsEnabled()
+	usage.SetStatisticsEnabled(true)
+	t.Cleanup(func() { usage.SetStatisticsEnabled(wasEnabled) })
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey: apiKey,
+		Model:  "gpt-4o-mini",
+		Detail: coreusage.Detail{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+	})
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage", bytes.NewReader([]byte(`{"api_key":"`+apiKey+`"}`)))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.SetUsageStatistics(stats)
+	h.GetPublicUsageByAPIKey(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), apiKey) {
+		t.Fatalf("public response leaked full API key: %s", rec.Body.String())
+	}
+
+	var got struct {
+		APIKey string `json:"api_key"`
+		Usage  struct {
+			APIs map[string]usage.APISnapshot `json:"apis"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.APIKey == apiKey || got.APIKey == "" {
+		t.Fatalf("api_key = %q, want masked non-empty value", got.APIKey)
+	}
+	if _, exists := got.Usage.APIs[apiKey]; exists {
+		t.Fatalf("usage.apis contains raw API key")
+	}
+	if _, exists := got.Usage.APIs[got.APIKey]; !exists {
+		t.Fatalf("usage.apis does not contain masked key %q: %#v", got.APIKey, got.Usage.APIs)
+	}
+}

--- a/internal/api/public_lookup_middleware.go
+++ b/internal/api/public_lookup_middleware.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"strings"
 )
 
 const (
@@ -25,6 +25,8 @@ func publicLookupNoStoreMiddleware() gin.HandlerFunc {
 		c.Header("Cache-Control", "no-store, private, max-age=0")
 		c.Header("Pragma", "no-cache")
 		c.Header("Expires", "0")
+		c.Header("Referrer-Policy", "no-referrer")
+		c.Header("X-Content-Type-Options", "nosniff")
 		c.Next()
 	}
 }
@@ -43,12 +45,6 @@ func (s *Server) publicLookupRateLimitMiddleware() gin.HandlerFunc {
 		}
 		if key == "" {
 			key = "unknown"
-		}
-		if c != nil && c.Request != nil {
-			userAgent := strings.TrimSpace(c.Request.UserAgent())
-			if userAgent != "" {
-				key += "|" + userAgent
-			}
 		}
 
 		allowed, retryAfter := s.allowPublicLookupRequest(key, now)

--- a/internal/api/public_lookup_middleware_test.go
+++ b/internal/api/public_lookup_middleware_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -35,6 +36,12 @@ func TestPublicLookupMiddlewareAppliesNoStoreHeaders(t *testing.T) {
 	}
 	if got := rec.Header().Get("Expires"); got != "0" {
 		t.Fatalf("Expires = %q", got)
+	}
+	if got := rec.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("Referrer-Policy = %q", got)
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q", got)
 	}
 }
 
@@ -112,5 +119,37 @@ func TestPublicLookupRateLimitMiddlewareKeepsFailureResponseStable(t *testing.T)
 	}
 	if firstReject.Header().Get("Retry-After") == "" || secondReject.Header().Get("Retry-After") == "" {
 		t.Fatal("Retry-After header missing on repeated rejection")
+	}
+}
+
+func TestPublicLookupRateLimitIgnoresUserAgentRotation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &Server{}
+	router := gin.New()
+	router.Use(publicLookupNoStoreMiddleware(), server.publicLookupRateLimitMiddleware())
+	router.POST("/v0/management/public/test", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	for i := 0; i < publicLookupRateLimitMaxRequests; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v0/management/public/test", nil)
+		req.RemoteAddr = "198.51.100.40:4321"
+		req.Header.Set("User-Agent", strconv.Itoa(i))
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("request %d status = %d, want %d", i+1, rec.Code, http.StatusNoContent)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/public/test", nil)
+	req.RemoteAddr = "198.51.100.40:4321"
+	req.Header.Set("User-Agent", "rotated-agent")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusTooManyRequests)
 	}
 }

--- a/internal/api/routes/management.go
+++ b/internal/api/routes/management.go
@@ -23,11 +23,16 @@ func RegisterManagement(engine *gin.Engine, h *managementhandlers.Handler, opts 
 		clearWriteDeadline = func(*gin.Context) {}
 	}
 
-	mgmtMiddlewares := make([]gin.HandlerFunc, 0, 3)
+	mgmtMiddlewares := make([]gin.HandlerFunc, 0, 4)
 	if opts.Availability != nil {
 		mgmtMiddlewares = append(mgmtMiddlewares, opts.Availability)
 	}
-	mgmtMiddlewares = append(mgmtMiddlewares, h.Middleware(), bodyutil.LimitBodyMiddleware(bodyutil.ManagementBodyLimit))
+	mgmtMiddlewares = append(
+		mgmtMiddlewares,
+		managementSecurityHeaders(),
+		h.Middleware(),
+		bodyutil.LimitBodyMiddleware(bodyutil.ManagementBodyLimit),
+	)
 
 	mgmt := engine.Group("/v0/management")
 	mgmt.Use(mgmtMiddlewares...)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -45,5 +47,26 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		if _, ok := routes[key]; !ok {
 			t.Fatalf("required route %s was not registered", key)
 		}
+	}
+}
+
+func TestManagementRoutesApplySecurityHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	RegisterManagement(engine, &managementhandlers.Handler{}, ManagementOptions{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/config", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Cache-Control"); got != "no-store, private, max-age=0" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q", got)
+	}
+	if got := rec.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("Referrer-Policy = %q", got)
 	}
 }

--- a/internal/api/routes/security_headers.go
+++ b/internal/api/routes/security_headers.go
@@ -1,0 +1,14 @@
+package routes
+
+import "github.com/gin-gonic/gin"
+
+func managementSecurityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Cache-Control", "no-store, private, max-age=0")
+		c.Header("Pragma", "no-cache")
+		c.Header("Expires", "0")
+		c.Header("Referrer-Policy", "no-referrer")
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Next()
+	}
+}

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -217,11 +217,17 @@ func (s *Server) configureInitialKeepAlive(optionState *serverOptionConfig) {
 
 func buildHTTPServer(cfg *config.Config, engine *gin.Engine) *http.Server {
 	readTimeout := config.DefaultMainAPIReadTimeout
+	host := ""
+	port := 8315
 	if cfg != nil {
 		readTimeout = cfg.MainAPIReadTimeout()
+		host = strings.TrimSpace(cfg.Host)
+		if cfg.Port > 0 {
+			port = cfg.Port
+		}
 	}
 	return &http.Server{
-		Addr:              fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
+		Addr:              fmt.Sprintf("%s:%d", host, port),
 		Handler:           engine,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       readTimeout,

--- a/internal/api/server_keepalive.go
+++ b/internal/api/server_keepalive.go
@@ -1,12 +1,12 @@
 package api
 
 import (
-	"crypto/subtle"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -38,7 +38,7 @@ func (s *Server) handleKeepAlive(c *gin.Context) {
 		if provided == "" {
 			provided = strings.TrimSpace(c.GetHeader("X-Local-Password"))
 		}
-		if subtle.ConstantTimeCompare([]byte(provided), []byte(s.localPassword)) != 1 {
+		if !util.ConstantTimeStringEqual(provided, s.localPassword) {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid password"})
 			return
 		}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -554,6 +554,20 @@ func TestNewServerUsesConfiguredMainReadTimeout(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPServerHandlesNilConfig(t *testing.T) {
+	engine := gin.New()
+	server := buildHTTPServer(nil, engine)
+	if server == nil {
+		t.Fatal("expected http server")
+	}
+	if got := server.Addr; got != ":8315" {
+		t.Fatalf("Addr = %q, want :8315", got)
+	}
+	if got := server.ReadTimeout; got != proxyconfig.DefaultMainAPIReadTimeout {
+		t.Fatalf("ReadTimeout = %s, want %s", got, proxyconfig.DefaultMainAPIReadTimeout)
+	}
+}
+
 func TestOAuthCallbackRouteStillServesSuccessHTML(t *testing.T) {
 	server := newTestServer(t)
 

--- a/internal/management/authfiles/paths.go
+++ b/internal/management/authfiles/paths.go
@@ -2,15 +2,18 @@ package authfiles
 
 import (
 	"fmt"
-	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
 
+const invalidFilePathPlaceholder = "__invalid_auth_file_name__"
+
 func ValidateFileQueryName(name string, requireJSON bool) (string, error) {
-	if name == "" || strings.Contains(name, string(os.PathSeparator)) {
+	name = strings.TrimSpace(name)
+	if !isSafeSingleFileName(name) {
 		return "", fmt.Errorf("invalid name")
 	}
 	if requireJSON && !IsJSONFileName(name) {
@@ -20,11 +23,31 @@ func ValidateFileQueryName(name string, requireJSON bool) (string, error) {
 }
 
 func ValidateUploadedFileName(filename string) (string, error) {
-	name := filepath.Base(filename)
+	name := singleFileBaseName(filename)
+	if !isSafeSingleFileName(name) {
+		return "", fmt.Errorf("invalid name")
+	}
 	if !IsJSONFileName(name) {
 		return "", fmt.Errorf("file must be .json")
 	}
 	return name, nil
+}
+
+func singleFileBaseName(name string) string {
+	return path.Base(strings.ReplaceAll(strings.TrimSpace(name), "\\", "/"))
+}
+
+func isSafeSingleFileName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsAny(name, `/\`) || strings.ContainsRune(name, 0) {
+		return false
+	}
+	if strings.ContainsAny(name, "\r\n\t") {
+		return false
+	}
+	return filepath.Base(name) == name && singleFileBaseName(name) == name
 }
 
 func IsDeleteAllValue(value string) bool {
@@ -36,7 +59,11 @@ func IsJSONFileName(name string) bool {
 }
 
 func FilePath(authDir, name string) string {
-	full := filepath.Join(authDir, filepath.Base(name))
+	baseName := singleFileBaseName(name)
+	if !isSafeSingleFileName(baseName) {
+		baseName = invalidFilePathPlaceholder
+	}
+	full := filepath.Join(authDir, baseName)
 	if filepath.IsAbs(full) {
 		return full
 	}

--- a/internal/management/authfiles/paths_test.go
+++ b/internal/management/authfiles/paths_test.go
@@ -15,6 +15,10 @@ func TestValidateFileQueryName(t *testing.T) {
 	}{
 		{name: "", requireJSON: true, wantErr: "invalid name"},
 		{name: "nested/auth.json", requireJSON: true, wantErr: "invalid name"},
+		{name: `nested\auth.json`, requireJSON: true, wantErr: "invalid name"},
+		{name: "../auth.json", requireJSON: true, wantErr: "invalid name"},
+		{name: `..\auth.json`, requireJSON: true, wantErr: "invalid name"},
+		{name: ".", requireJSON: false, wantErr: "invalid name"},
 		{name: "auth.txt", requireJSON: true, wantErr: "name must end with .json"},
 		{name: "auth.txt", requireJSON: false, want: "auth.txt"},
 		{name: "auth.json", requireJSON: true, want: "auth.json"},
@@ -38,17 +42,24 @@ func TestValidateFileQueryName(t *testing.T) {
 }
 
 func TestValidateUploadedFileName(t *testing.T) {
-	got, err := ValidateUploadedFileName("nested/auth.json")
-	if err != nil {
-		t.Fatalf("ValidateUploadedFileName() error = %v", err)
-	}
-	if got != "auth.json" {
-		t.Fatalf("ValidateUploadedFileName() = %q, want auth.json", got)
+	for _, filename := range []string{"nested/auth.json", `nested\auth.json`} {
+		got, err := ValidateUploadedFileName(filename)
+		if err != nil {
+			t.Fatalf("ValidateUploadedFileName(%q) error = %v", filename, err)
+		}
+		if got != "auth.json" {
+			t.Fatalf("ValidateUploadedFileName(%q) = %q, want auth.json", filename, got)
+		}
 	}
 
-	_, err = ValidateUploadedFileName("auth.txt")
+	_, err := ValidateUploadedFileName("auth.txt")
 	if err == nil || err.Error() != "file must be .json" {
 		t.Fatalf("ValidateUploadedFileName() error = %v, want file must be .json", err)
+	}
+
+	_, err = ValidateUploadedFileName("../")
+	if err == nil || err.Error() != "invalid name" {
+		t.Fatalf("ValidateUploadedFileName() error = %v, want invalid name", err)
 	}
 }
 
@@ -56,6 +67,15 @@ func TestFilePathReturnsAbsoluteBasePath(t *testing.T) {
 	authDir := t.TempDir()
 	got := FilePath(authDir, "nested/auth.json")
 	want := filepath.Join(authDir, "auth.json")
+	if got != want {
+		t.Fatalf("FilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestFilePathRejectsInvalidBaseNameFallback(t *testing.T) {
+	authDir := t.TempDir()
+	got := FilePath(authDir, "../")
+	want := filepath.Join(authDir, invalidFilePathPlaceholder)
 	if got != want {
 		t.Fatalf("FilePath() = %q, want %q", got, want)
 	}

--- a/internal/util/constant_time.go
+++ b/internal/util/constant_time.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+)
+
+// ConstantTimeStringEqual compares two secrets without leaking length through timing.
+// Both values are hashed to a fixed-size digest before constant-time comparison.
+func ConstantTimeStringEqual(a, b string) bool {
+	ad := sha256.Sum256([]byte(a))
+	bd := sha256.Sum256([]byte(b))
+	return subtle.ConstantTimeCompare(ad[:], bd[:]) == 1
+}

--- a/internal/util/constant_time_test.go
+++ b/internal/util/constant_time_test.go
@@ -1,0 +1,15 @@
+package util
+
+import "testing"
+
+func TestConstantTimeStringEqual(t *testing.T) {
+	if !ConstantTimeStringEqual("secret", "secret") {
+		t.Fatal("expected identical values to match")
+	}
+	if ConstantTimeStringEqual("secret", "different") {
+		t.Fatal("expected different values not to match")
+	}
+	if ConstantTimeStringEqual("secret", "secret-longer") {
+		t.Fatal("expected different length values not to match")
+	}
+}


### PR DESCRIPTION
## Summary\n- Harden management authentication and security headers\n- Tighten public lookup limits and public API key masking\n- Add log limit/gzip support and auth-files path validation\n\n## Verification\n- rtk go test ./internal/api/bodyutil ./internal/api/routes ./internal/api/handlers/management ./internal/api ./internal/management/authfiles ./internal/util\n- rtk go test ./...