### PR TITLE
fix: normalize gateway protocol adapters

### DIFF
--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -101,8 +101,10 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 	// Model mapping to specify which Claude Code model to use
 	out, _ = sjson.Set(out, "model", modelName)
 
-	// Max tokens configuration with fallback to default value
-	if maxTokens := root.Get("max_tokens"); maxTokens.Exists() {
+	// Max tokens configuration with fallback to the legacy max_tokens field.
+	if maxTokens := root.Get("max_completion_tokens"); maxTokens.Exists() {
+		out, _ = sjson.Set(out, "max_tokens", maxTokens.Int())
+	} else if maxTokens := root.Get("max_tokens"); maxTokens.Exists() {
 		out, _ = sjson.Set(out, "max_tokens", maxTokens.Int())
 	}
 

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
@@ -73,3 +73,16 @@ func TestConvertOpenAIRequestToClaude_AssistantReasoningContentWithToolCalls(t *
 		t.Fatalf("expected assistant content[2].type to be tool_use, got %q; body=%s", gotType, got)
 	}
 }
+
+func TestConvertOpenAIRequestToClaude_MapsMaxCompletionTokens(t *testing.T) {
+	input := []byte(`{
+		"model": "test-model",
+		"max_completion_tokens": 2048,
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+
+	got := ConvertOpenAIRequestToClaude("test-model", input, false)
+	if limit := gjson.GetBytes(got, "max_tokens").Int(); limit != 2048 {
+		t.Fatalf("max_tokens = %d, want 2048; body=%s", limit, got)
+	}
+}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response.go
@@ -65,9 +65,10 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 
 	root := gjson.ParseBytes(rawJSON)
 	eventType := root.Get("type").String()
+	state := (*param).(*ConvertAnthropicResponseToOpenAIParams)
 
 	// Base OpenAI streaming response template
-	template := `{"id":"","object":"chat.completion.chunk","created":0,"model":"","choices":[{"index":0,"delta":{},"finish_reason":null}]}`
+	template := `{"id":"","object":"chat.completion.chunk","created":0,"model":"","choices":[{"index":0,"delta":{},"finish_reason":null}],"usage":null}`
 
 	// Set model
 	if modelName != "" {
@@ -75,30 +76,30 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 	}
 
 	// Set response ID and creation time
-	if (*param).(*ConvertAnthropicResponseToOpenAIParams).ResponseID != "" {
-		template, _ = sjson.Set(template, "id", (*param).(*ConvertAnthropicResponseToOpenAIParams).ResponseID)
+	if state.ResponseID != "" {
+		template, _ = sjson.Set(template, "id", state.ResponseID)
 	}
-	if (*param).(*ConvertAnthropicResponseToOpenAIParams).CreatedAt > 0 {
-		template, _ = sjson.Set(template, "created", (*param).(*ConvertAnthropicResponseToOpenAIParams).CreatedAt)
+	if state.CreatedAt > 0 {
+		template, _ = sjson.Set(template, "created", state.CreatedAt)
 	}
 
 	switch eventType {
 	case "message_start":
 		// Initialize response with message metadata when a new message begins
 		if message := root.Get("message"); message.Exists() {
-			(*param).(*ConvertAnthropicResponseToOpenAIParams).ResponseID = message.Get("id").String()
-			(*param).(*ConvertAnthropicResponseToOpenAIParams).CreatedAt = time.Now().Unix()
+			state.ResponseID = message.Get("id").String()
+			state.CreatedAt = time.Now().Unix()
 
-			template, _ = sjson.Set(template, "id", (*param).(*ConvertAnthropicResponseToOpenAIParams).ResponseID)
+			template, _ = sjson.Set(template, "id", state.ResponseID)
 			template, _ = sjson.Set(template, "model", modelName)
-			template, _ = sjson.Set(template, "created", (*param).(*ConvertAnthropicResponseToOpenAIParams).CreatedAt)
+			template, _ = sjson.Set(template, "created", state.CreatedAt)
 
 			// Set initial role to assistant for the response
 			template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
 
 			// Initialize tool calls accumulator for tracking tool call progress
-			if (*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator == nil {
-				(*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator = make(map[int]*ToolCallAccumulator)
+			if state.ToolCallsAccumulator == nil {
+				state.ToolCallsAccumulator = make(map[int]*ToolCallAccumulator)
 			}
 		}
 		return []string{template}
@@ -114,11 +115,11 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 				toolName := contentBlock.Get("name").String()
 				index := int(root.Get("index").Int())
 
-				if (*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator == nil {
-					(*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator = make(map[int]*ToolCallAccumulator)
+				if state.ToolCallsAccumulator == nil {
+					state.ToolCallsAccumulator = make(map[int]*ToolCallAccumulator)
 				}
 
-				(*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator[index] = &ToolCallAccumulator{
+				state.ToolCallsAccumulator[index] = &ToolCallAccumulator{
 					ID:   toolCallID,
 					Name: toolName,
 				}
@@ -143,17 +144,13 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 					hasContent = true
 				}
 			case "thinking_delta":
-				// Accumulate reasoning/thinking content
-				if thinking := delta.Get("thinking"); thinking.Exists() {
-					template, _ = sjson.Set(template, "choices.0.delta.reasoning_content", thinking.String())
-					hasContent = true
-				}
+				return []string{}
 			case "input_json_delta":
 				// Tool use input delta - accumulate arguments for tool calls
 				if partialJSON := delta.Get("partial_json"); partialJSON.Exists() {
 					index := int(root.Get("index").Int())
-					if (*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator != nil {
-						if accumulator, exists := (*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator[index]; exists {
+					if state.ToolCallsAccumulator != nil {
+						if accumulator, exists := state.ToolCallsAccumulator[index]; exists {
 							accumulator.Arguments.WriteString(partialJSON.String())
 						}
 					}
@@ -171,8 +168,8 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 	case "content_block_stop":
 		// End of content block - output complete tool call if it's a tool_use block
 		index := int(root.Get("index").Int())
-		if (*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator != nil {
-			if accumulator, exists := (*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator[index]; exists {
+		if state.ToolCallsAccumulator != nil {
+			if accumulator, exists := state.ToolCallsAccumulator[index]; exists {
 				// Build complete tool call with accumulated arguments
 				arguments := accumulator.Arguments.String()
 				if arguments == "" {
@@ -185,7 +182,7 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 				template, _ = sjson.Set(template, "choices.0.delta.tool_calls.0.function.arguments", arguments)
 
 				// Clean up the accumulator for this index
-				delete((*param).(*ConvertAnthropicResponseToOpenAIParams).ToolCallsAccumulator, index)
+				delete(state.ToolCallsAccumulator, index)
 
 				return []string{template}
 			}
@@ -194,25 +191,23 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 
 	case "message_delta":
 		// Handle message-level changes including stop reason and usage
+		var outputs []string
 		if delta := root.Get("delta"); delta.Exists() {
 			if stopReason := delta.Get("stop_reason"); stopReason.Exists() {
-				(*param).(*ConvertAnthropicResponseToOpenAIParams).FinishReason = mapAnthropicStopReasonToOpenAI(stopReason.String())
-				template, _ = sjson.Set(template, "choices.0.finish_reason", (*param).(*ConvertAnthropicResponseToOpenAIParams).FinishReason)
+				state.FinishReason = mapAnthropicStopReasonToOpenAI(stopReason.String())
+				template, _ = sjson.Set(template, "choices.0.finish_reason", state.FinishReason)
+				outputs = append(outputs, template)
 			}
 		}
 
-		// Handle usage information for token counts
-		if usage := root.Get("usage"); usage.Exists() {
-			inputTokens := usage.Get("input_tokens").Int()
-			outputTokens := usage.Get("output_tokens").Int()
-			cacheReadInputTokens := usage.Get("cache_read_input_tokens").Int()
-			cacheCreationInputTokens := usage.Get("cache_creation_input_tokens").Int()
-			template, _ = sjson.Set(template, "usage.prompt_tokens", inputTokens+cacheCreationInputTokens)
-			template, _ = sjson.Set(template, "usage.completion_tokens", outputTokens)
-			template, _ = sjson.Set(template, "usage.total_tokens", inputTokens+outputTokens)
-			template, _ = sjson.Set(template, "usage.prompt_tokens_details.cached_tokens", cacheReadInputTokens)
+		if includeUsageInClaudeChatStream(originalRequestRawJSON) {
+			if usage := root.Get("usage"); usage.Exists() {
+				if usageChunk := buildClaudeChatUsageChunk(state, modelName, usage); usageChunk != "" {
+					outputs = append(outputs, usageChunk)
+				}
+			}
 		}
-		return []string{template}
+		return outputs
 
 	case "message_stop":
 		// Final message event - no additional output needed
@@ -286,7 +281,6 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	var createdAt int64
 	var stopReason string
 	var contentParts []string
-	var reasoningParts []string
 	toolCallsAccumulator := make(map[int]*ToolCallAccumulator)
 
 	for _, chunk := range chunks {
@@ -330,10 +324,6 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 						contentParts = append(contentParts, text.String())
 					}
 				case "thinking_delta":
-					// Accumulate reasoning/thinking content
-					if thinking := delta.Get("thinking"); thinking.Exists() {
-						reasoningParts = append(reasoningParts, thinking.String())
-					}
 				case "input_json_delta":
 					// Accumulate tool call arguments
 					if partialJSON := delta.Get("partial_json"); partialJSON.Exists() {
@@ -383,13 +373,6 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	messageContent := strings.Join(contentParts, "")
 	out, _ = sjson.Set(out, "choices.0.message.content", messageContent)
 
-	// Add reasoning content if available (following OpenAI reasoning format)
-	if len(reasoningParts) > 0 {
-		reasoningContent := strings.Join(reasoningParts, "")
-		// Add reasoning as a separate field in the message
-		out, _ = sjson.Set(out, "choices.0.message.reasoning", reasoningContent)
-	}
-
 	// Set tool calls if any were accumulated during processing
 	if len(toolCallsAccumulator) > 0 {
 		toolCallsCount := 0
@@ -429,4 +412,35 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	}
 
 	return out
+}
+
+func includeUsageInClaudeChatStream(originalRequestRawJSON []byte) bool {
+	return gjson.GetBytes(originalRequestRawJSON, "stream_options.include_usage").Bool()
+}
+
+func buildClaudeChatUsageChunk(state *ConvertAnthropicResponseToOpenAIParams, modelName string, usage gjson.Result) string {
+	if !usage.Exists() || !usage.IsObject() {
+		return ""
+	}
+	template := `{"id":"","object":"chat.completion.chunk","created":0,"model":"","choices":[],"usage":{}}`
+	if state != nil {
+		if state.ResponseID != "" {
+			template, _ = sjson.Set(template, "id", state.ResponseID)
+		}
+		if state.CreatedAt > 0 {
+			template, _ = sjson.Set(template, "created", state.CreatedAt)
+		}
+	}
+	if modelName != "" {
+		template, _ = sjson.Set(template, "model", modelName)
+	}
+	inputTokens := usage.Get("input_tokens").Int()
+	outputTokens := usage.Get("output_tokens").Int()
+	cacheReadInputTokens := usage.Get("cache_read_input_tokens").Int()
+	cacheCreationInputTokens := usage.Get("cache_creation_input_tokens").Int()
+	template, _ = sjson.Set(template, "usage.prompt_tokens", inputTokens+cacheCreationInputTokens)
+	template, _ = sjson.Set(template, "usage.completion_tokens", outputTokens)
+	template, _ = sjson.Set(template, "usage.total_tokens", inputTokens+outputTokens)
+	template, _ = sjson.Set(template, "usage.prompt_tokens_details.cached_tokens", cacheReadInputTokens)
+	return template
 }

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -1,0 +1,70 @@
+package chat_completions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertClaudeResponseToOpenAI_StripsThinkingAndEmitsUsageChunk(t *testing.T) {
+	ctx := context.Background()
+	originalReq := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"只输出 OK"}],"stream":true,"stream_options":{"include_usage":true}}`)
+
+	var param any
+
+	start := ConvertClaudeResponseToOpenAI(ctx, "claude-sonnet-4-5", originalReq, nil, []byte(`data: {"type":"message_start","message":{"id":"msg_1"}}`), &param)
+	if len(start) != 1 {
+		t.Fatalf("start chunks = %d, want 1", len(start))
+	}
+	if got := gjson.Get(start[0], "choices.0.delta.role").String(); got != "assistant" {
+		t.Fatalf("start role = %q, want assistant; chunk=%s", got, start[0])
+	}
+
+	thinking := ConvertClaudeResponseToOpenAI(ctx, "claude-sonnet-4-5", originalReq, nil, []byte(`data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"secret"}}`), &param)
+	if len(thinking) != 0 {
+		t.Fatalf("thinking chunks = %d, want 0; chunks=%v", len(thinking), thinking)
+	}
+
+	text := ConvertClaudeResponseToOpenAI(ctx, "claude-sonnet-4-5", originalReq, nil, []byte(`data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"OK"}}`), &param)
+	if len(text) != 1 {
+		t.Fatalf("text chunks = %d, want 1", len(text))
+	}
+	if got := gjson.Get(text[0], "choices.0.delta.content").String(); got != "OK" {
+		t.Fatalf("delta content = %q, want OK; chunk=%s", got, text[0])
+	}
+	if gjson.Get(text[0], "choices.0.delta.reasoning_content").Exists() {
+		t.Fatalf("unexpected reasoning_content in chunk: %s", text[0])
+	}
+
+	done := ConvertClaudeResponseToOpenAI(ctx, "claude-sonnet-4-5", originalReq, nil, []byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":11,"output_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":0}}`), &param)
+	if len(done) != 2 {
+		t.Fatalf("done chunks = %d, want 2; chunks=%v", len(done), done)
+	}
+	if got := gjson.Get(done[0], "choices.0.finish_reason").String(); got != "stop" {
+		t.Fatalf("finish_reason = %q, want stop; chunk=%s", got, done[0])
+	}
+	if got := len(gjson.Get(done[1], "choices").Array()); got != 0 {
+		t.Fatalf("usage chunk choices len = %d, want 0; chunk=%s", got, done[1])
+	}
+	if got := gjson.Get(done[1], "usage.prompt_tokens").Int(); got != 11 {
+		t.Fatalf("usage prompt_tokens = %d, want 11; chunk=%s", got, done[1])
+	}
+}
+
+func TestConvertClaudeResponseToOpenAINonStream_StripsThinking(t *testing.T) {
+	raw := []byte(
+		"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-sonnet-4-5\"}}\n\n" +
+			"data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"secret\"}}\n\n" +
+			"data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n" +
+			"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":2,\"output_tokens\":1}}\n\n",
+	)
+
+	got := ConvertClaudeResponseToOpenAINonStream(context.Background(), "claude-sonnet-4-5", nil, nil, raw, nil)
+	if content := gjson.Get(got, "choices.0.message.content").String(); content != "Hello" {
+		t.Fatalf("message content = %q, want Hello; payload=%s", content, got)
+	}
+	if gjson.Get(got, "choices.0.message.reasoning").Exists() {
+		t.Fatalf("unexpected reasoning field in payload: %s", got)
+	}
+}

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -45,13 +45,13 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 	// 	out, _ = sjson.Set(out, "top_k", v.Value())
 	// }
 
-	// Map token limits
-	// if v := gjson.GetBytes(rawJSON, "max_tokens"); v.Exists() {
-	// 	out, _ = sjson.Set(out, "max_output_tokens", v.Value())
-	// }
-	// if v := gjson.GetBytes(rawJSON, "max_completion_tokens"); v.Exists() {
-	// 	out, _ = sjson.Set(out, "max_output_tokens", v.Value())
-	// }
+	// Map token limits. Prefer max_completion_tokens because it is the modern
+	// Chat Completions field.
+	if v := gjson.GetBytes(rawJSON, "max_completion_tokens"); v.Exists() {
+		out, _ = sjson.Set(out, "max_output_tokens", v.Value())
+	} else if v := gjson.GetBytes(rawJSON, "max_tokens"); v.Exists() {
+		out, _ = sjson.Set(out, "max_output_tokens", v.Value())
+	}
 
 	// Map reasoning effort
 	if v := gjson.GetBytes(rawJSON, "reasoning_effort"); v.Exists() {

--- a/internal/translator/codex/openai/chat-completions/codex_openai_response.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_response.go
@@ -26,6 +26,7 @@ type ConvertCliToOpenAIParams struct {
 	FunctionCallIndex         int
 	HasReceivedArgumentsDelta bool
 	HasToolCallAnnounced      bool
+	RoleAnnounced             bool
 }
 
 // ConvertCodexResponseToOpenAI translates a single chunk of a streaming response from the
@@ -51,6 +52,7 @@ func ConvertCodexResponseToOpenAI(_ context.Context, modelName string, originalR
 			FunctionCallIndex:         -1,
 			HasReceivedArgumentsDelta: false,
 			HasToolCallAnnounced:      false,
+			RoleAnnounced:             false,
 		}
 	}
 
@@ -58,83 +60,69 @@ func ConvertCodexResponseToOpenAI(_ context.Context, modelName string, originalR
 		return []string{}
 	}
 	rawJSON = bytes.TrimSpace(rawJSON[5:])
-
-	// Initialize the OpenAI SSE template.
-	template := `{"id":"","object":"chat.completion.chunk","created":12345,"model":"model","choices":[{"index":0,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":null},"finish_reason":null,"native_finish_reason":null}]}`
+	if bytes.Equal(rawJSON, []byte("[DONE]")) {
+		return []string{}
+	}
 
 	rootResult := gjson.ParseBytes(rawJSON)
+	state := (*param).(*ConvertCliToOpenAIParams)
 
 	typeResult := rootResult.Get("type")
 	dataType := typeResult.String()
 	if dataType == "response.created" {
-		(*param).(*ConvertCliToOpenAIParams).ResponseID = rootResult.Get("response.id").String()
-		(*param).(*ConvertCliToOpenAIParams).CreatedAt = rootResult.Get("response.created_at").Int()
-		(*param).(*ConvertCliToOpenAIParams).Model = rootResult.Get("response.model").String()
-		return []string{}
-	}
-
-	// Extract and set the model version.
-	if modelResult := gjson.GetBytes(rawJSON, "model"); modelResult.Exists() {
-		template, _ = sjson.Set(template, "model", modelResult.String())
-	}
-
-	template, _ = sjson.Set(template, "created", (*param).(*ConvertCliToOpenAIParams).CreatedAt)
-
-	// Extract and set the response ID.
-	template, _ = sjson.Set(template, "id", (*param).(*ConvertCliToOpenAIParams).ResponseID)
-
-	// Extract and set usage metadata (token counts).
-	if usageResult := gjson.GetBytes(rawJSON, "response.usage"); usageResult.Exists() {
-		if outputTokensResult := usageResult.Get("output_tokens"); outputTokensResult.Exists() {
-			template, _ = sjson.Set(template, "usage.completion_tokens", outputTokensResult.Int())
+		state.ResponseID = rootResult.Get("response.id").String()
+		state.CreatedAt = rootResult.Get("response.created_at").Int()
+		if upstreamModel := rootResult.Get("response.model").String(); upstreamModel != "" {
+			state.Model = upstreamModel
 		}
-		if totalTokensResult := usageResult.Get("total_tokens"); totalTokensResult.Exists() {
-			template, _ = sjson.Set(template, "usage.total_tokens", totalTokensResult.Int())
-		}
-		if inputTokensResult := usageResult.Get("input_tokens"); inputTokensResult.Exists() {
-			template, _ = sjson.Set(template, "usage.prompt_tokens", inputTokensResult.Int())
-		}
-		if cachedTokensResult := usageResult.Get("input_tokens_details.cached_tokens"); cachedTokensResult.Exists() {
-			template, _ = sjson.Set(template, "usage.prompt_tokens_details.cached_tokens", cachedTokensResult.Int())
-		}
-		if reasoningTokensResult := usageResult.Get("output_tokens_details.reasoning_tokens"); reasoningTokensResult.Exists() {
-			template, _ = sjson.Set(template, "usage.completion_tokens_details.reasoning_tokens", reasoningTokensResult.Int())
-		}
+		template := buildCodexChatChunk(state)
+		template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
+		state.RoleAnnounced = true
+		return []string{template}
 	}
 
 	if dataType == "response.reasoning_summary_text.delta" {
-		if deltaResult := rootResult.Get("delta"); deltaResult.Exists() {
-			template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
-			template, _ = sjson.Set(template, "choices.0.delta.reasoning_content", deltaResult.String())
-		}
+		return []string{}
 	} else if dataType == "response.reasoning_summary_text.done" {
-		template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
-		template, _ = sjson.Set(template, "choices.0.delta.reasoning_content", "\n\n")
+		return []string{}
 	} else if dataType == "response.output_text.delta" {
+		template := buildCodexChatChunk(state)
 		if deltaResult := rootResult.Get("delta"); deltaResult.Exists() {
-			template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
+			if !state.RoleAnnounced {
+				template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
+				state.RoleAnnounced = true
+			}
 			template, _ = sjson.Set(template, "choices.0.delta.content", deltaResult.String())
 		}
+		return []string{template}
 	} else if dataType == "response.completed" {
+		template := buildCodexChatChunk(state)
 		finishReason := "stop"
-		if (*param).(*ConvertCliToOpenAIParams).FunctionCallIndex != -1 {
+		if state.FunctionCallIndex != -1 {
 			finishReason = "tool_calls"
 		}
 		template, _ = sjson.Set(template, "choices.0.finish_reason", finishReason)
-		template, _ = sjson.Set(template, "choices.0.native_finish_reason", finishReason)
+		outputs := []string{template}
+		if includeUsageInChatStream(originalRequestRawJSON) {
+			if usageChunk := buildCodexChatUsageChunk(state, rootResult.Get("response.usage")); usageChunk != "" {
+				outputs = append(outputs, usageChunk)
+			}
+		}
+		return outputs
 	} else if dataType == "response.output_item.added" {
+		template := buildCodexChatChunk(state)
 		itemResult := rootResult.Get("item")
 		if !itemResult.Exists() || itemResult.Get("type").String() != "function_call" {
 			return []string{}
 		}
 
 		// Increment index for this new function call item.
-		(*param).(*ConvertCliToOpenAIParams).FunctionCallIndex++
-		(*param).(*ConvertCliToOpenAIParams).HasReceivedArgumentsDelta = false
-		(*param).(*ConvertCliToOpenAIParams).HasToolCallAnnounced = true
+		state.FunctionCallIndex++
+		state.HasReceivedArgumentsDelta = false
+		state.HasToolCallAnnounced = true
 
 		functionCallItemTemplate := `{"index":0,"id":"","type":"function","function":{"name":"","arguments":""}}`
-		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", (*param).(*ConvertCliToOpenAIParams).FunctionCallIndex)
+		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", state.FunctionCallIndex)
 		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "id", itemResult.Get("call_id").String())
 
 		// Restore original tool name if it was shortened.
@@ -146,53 +134,62 @@ func ConvertCodexResponseToOpenAI(_ context.Context, modelName string, originalR
 		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.name", name)
 		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.arguments", "")
 
-		template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
+		if !state.RoleAnnounced {
+			template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
+			state.RoleAnnounced = true
+		}
 		template, _ = sjson.SetRaw(template, "choices.0.delta.tool_calls", `[]`)
 		template, _ = sjson.SetRaw(template, "choices.0.delta.tool_calls.-1", functionCallItemTemplate)
+		return []string{template}
 
 	} else if dataType == "response.function_call_arguments.delta" {
-		(*param).(*ConvertCliToOpenAIParams).HasReceivedArgumentsDelta = true
+		template := buildCodexChatChunk(state)
+		state.HasReceivedArgumentsDelta = true
 
 		deltaValue := rootResult.Get("delta").String()
 		functionCallItemTemplate := `{"index":0,"function":{"arguments":""}}`
-		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", (*param).(*ConvertCliToOpenAIParams).FunctionCallIndex)
+		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", state.FunctionCallIndex)
 		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.arguments", deltaValue)
 
 		template, _ = sjson.SetRaw(template, "choices.0.delta.tool_calls", `[]`)
 		template, _ = sjson.SetRaw(template, "choices.0.delta.tool_calls.-1", functionCallItemTemplate)
+		return []string{template}
 
 	} else if dataType == "response.function_call_arguments.done" {
-		if (*param).(*ConvertCliToOpenAIParams).HasReceivedArgumentsDelta {
+		if state.HasReceivedArgumentsDelta {
 			// Arguments were already streamed via delta events; nothing to emit.
 			return []string{}
 		}
 
+		template := buildCodexChatChunk(state)
 		// Fallback: no delta events were received, emit the full arguments as a single chunk.
 		fullArgs := rootResult.Get("arguments").String()
 		functionCallItemTemplate := `{"index":0,"function":{"arguments":""}}`
-		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", (*param).(*ConvertCliToOpenAIParams).FunctionCallIndex)
+		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", state.FunctionCallIndex)
 		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.arguments", fullArgs)
 
 		template, _ = sjson.SetRaw(template, "choices.0.delta.tool_calls", `[]`)
 		template, _ = sjson.SetRaw(template, "choices.0.delta.tool_calls.-1", functionCallItemTemplate)
+		return []string{template}
 
 	} else if dataType == "response.output_item.done" {
+		template := buildCodexChatChunk(state)
 		itemResult := rootResult.Get("item")
 		if !itemResult.Exists() || itemResult.Get("type").String() != "function_call" {
 			return []string{}
 		}
 
-		if (*param).(*ConvertCliToOpenAIParams).HasToolCallAnnounced {
+		if state.HasToolCallAnnounced {
 			// Tool call was already announced via output_item.added; skip emission.
-			(*param).(*ConvertCliToOpenAIParams).HasToolCallAnnounced = false
+			state.HasToolCallAnnounced = false
 			return []string{}
 		}
 
 		// Fallback path: model skipped output_item.added, so emit complete tool call now.
-		(*param).(*ConvertCliToOpenAIParams).FunctionCallIndex++
+		state.FunctionCallIndex++
 
 		functionCallItemTemplate := `{"index":0,"id":"","type":"function","function":{"name":"","arguments":""}}`
-		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", (*param).(*ConvertCliToOpenAIParams).FunctionCallIndex)
+		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", state.FunctionCallIndex)
 
 		template, _ = sjson.SetRaw(template, "choices.0.delta.tool_calls", `[]`)
 		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "id", itemResult.Get("call_id").String())
@@ -206,14 +203,15 @@ func ConvertCodexResponseToOpenAI(_ context.Context, modelName string, originalR
 		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.name", name)
 
 		functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.arguments", itemResult.Get("arguments").String())
-		template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
+		if !state.RoleAnnounced {
+			template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
+			state.RoleAnnounced = true
+		}
 		template, _ = sjson.SetRaw(template, "choices.0.delta.tool_calls.-1", functionCallItemTemplate)
-
-	} else {
-		return []string{}
+		return []string{template}
 	}
 
-	return []string{template}
+	return []string{}
 }
 
 // ConvertCodexResponseToOpenAINonStream converts a non-streaming Codex response to a non-streaming OpenAI response.
@@ -240,7 +238,7 @@ func ConvertCodexResponseToOpenAINonStream(_ context.Context, _ string, original
 
 	responseResult := rootResult.Get("response")
 
-	template := `{"id":"","object":"chat.completion","created":123456,"model":"model","choices":[{"index":0,"message":{"role":"assistant","content":null,"reasoning_content":null,"tool_calls":null},"finish_reason":null,"native_finish_reason":null}]}`
+	template := `{"id":"","object":"chat.completion","created":123456,"model":"model","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":null},"finish_reason":null}]}`
 
 	// Extract and set the model version.
 	if modelResult := responseResult.Get("model"); modelResult.Exists() {
@@ -283,24 +281,12 @@ func ConvertCodexResponseToOpenAINonStream(_ context.Context, _ string, original
 	if outputResult.IsArray() {
 		outputArray := outputResult.Array()
 		var contentText string
-		var reasoningText string
 		var toolCalls []string
 
 		for _, outputItem := range outputArray {
 			outputType := outputItem.Get("type").String()
 
 			switch outputType {
-			case "reasoning":
-				// Extract reasoning content from summary
-				if summaryResult := outputItem.Get("summary"); summaryResult.IsArray() {
-					summaryArray := summaryResult.Array()
-					for _, summaryItem := range summaryArray {
-						if summaryItem.Get("type").String() == "summary_text" {
-							reasoningText = summaryItem.Get("text").String()
-							break
-						}
-					}
-				}
 			case "message":
 				// Extract message content
 				if contentResult := outputItem.Get("content"); contentResult.IsArray() {
@@ -343,11 +329,6 @@ func ConvertCodexResponseToOpenAINonStream(_ context.Context, _ string, original
 			template, _ = sjson.Set(template, "choices.0.message.role", "assistant")
 		}
 
-		if reasoningText != "" {
-			template, _ = sjson.Set(template, "choices.0.message.reasoning_content", reasoningText)
-			template, _ = sjson.Set(template, "choices.0.message.role", "assistant")
-		}
-
 		// Add tool calls if any
 		if len(toolCalls) > 0 {
 			template, _ = sjson.SetRaw(template, "choices.0.message.tool_calls", `[]`)
@@ -363,11 +344,70 @@ func ConvertCodexResponseToOpenAINonStream(_ context.Context, _ string, original
 		status := statusResult.String()
 		if status == "completed" {
 			template, _ = sjson.Set(template, "choices.0.finish_reason", "stop")
-			template, _ = sjson.Set(template, "choices.0.native_finish_reason", "stop")
 		}
 	}
 
 	return template
+}
+
+func buildCodexChatChunk(state *ConvertCliToOpenAIParams) string {
+	template := `{"id":"","object":"chat.completion.chunk","created":0,"model":"","choices":[{"index":0,"delta":{},"finish_reason":null}],"usage":null}`
+	if state == nil {
+		return template
+	}
+	if state.ResponseID != "" {
+		template, _ = sjson.Set(template, "id", state.ResponseID)
+	}
+	if state.CreatedAt > 0 {
+		template, _ = sjson.Set(template, "created", state.CreatedAt)
+	}
+	if state.Model != "" {
+		template, _ = sjson.Set(template, "model", state.Model)
+	}
+	return template
+}
+
+func buildCodexChatUsageChunk(state *ConvertCliToOpenAIParams, usageResult gjson.Result) string {
+	if state == nil || !usageResult.Exists() || !usageResult.IsObject() {
+		return ""
+	}
+	template := `{"id":"","object":"chat.completion.chunk","created":0,"model":"","choices":[],"usage":{}}`
+	if state.ResponseID != "" {
+		template, _ = sjson.Set(template, "id", state.ResponseID)
+	}
+	if state.CreatedAt > 0 {
+		template, _ = sjson.Set(template, "created", state.CreatedAt)
+	}
+	if state.Model != "" {
+		template, _ = sjson.Set(template, "model", state.Model)
+	}
+	return setChatUsage(template, usageResult)
+}
+
+func setChatUsage(template string, usageResult gjson.Result) string {
+	if !usageResult.Exists() || !usageResult.IsObject() {
+		return template
+	}
+	if outputTokensResult := usageResult.Get("output_tokens"); outputTokensResult.Exists() {
+		template, _ = sjson.Set(template, "usage.completion_tokens", outputTokensResult.Int())
+	}
+	if totalTokensResult := usageResult.Get("total_tokens"); totalTokensResult.Exists() {
+		template, _ = sjson.Set(template, "usage.total_tokens", totalTokensResult.Int())
+	}
+	if inputTokensResult := usageResult.Get("input_tokens"); inputTokensResult.Exists() {
+		template, _ = sjson.Set(template, "usage.prompt_tokens", inputTokensResult.Int())
+	}
+	if cachedTokensResult := usageResult.Get("input_tokens_details.cached_tokens"); cachedTokensResult.Exists() {
+		template, _ = sjson.Set(template, "usage.prompt_tokens_details.cached_tokens", cachedTokensResult.Int())
+	}
+	if reasoningTokensResult := usageResult.Get("output_tokens_details.reasoning_tokens"); reasoningTokensResult.Exists() {
+		template, _ = sjson.Set(template, "usage.completion_tokens_details.reasoning_tokens", reasoningTokensResult.Int())
+	}
+	return template
+}
+
+func includeUsageInChatStream(originalRequestRawJSON []byte) bool {
+	return gjson.GetBytes(originalRequestRawJSON, "stream_options.include_usage").Bool()
 }
 
 // buildReverseMapFromOriginalOpenAI builds a map of shortened tool name -> original tool name

--- a/internal/translator/codex/openai/chat-completions/codex_openai_response_test.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_response_test.go
@@ -1,0 +1,77 @@
+package chat_completions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertCodexResponseToOpenAI_EmitsStandardChatChunks(t *testing.T) {
+	ctx := context.Background()
+	originalReq := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"只输出 OK"}],"stream":true,"stream_options":{"include_usage":true}}`)
+	req := []byte(`{"model":"gpt-5.4","stream":true}`)
+
+	var param any
+
+	created := ConvertCodexResponseToOpenAI(ctx, "gpt-5.4", originalReq, req, []byte(`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.4","created_at":1710000001}}`), &param)
+	if len(created) != 1 {
+		t.Fatalf("created chunks = %d, want 1", len(created))
+	}
+	if got := gjson.Get(created[0], "choices.0.delta.role").String(); got != "assistant" {
+		t.Fatalf("created role = %q, want assistant; chunk=%s", got, created[0])
+	}
+
+	reasoning := ConvertCodexResponseToOpenAI(ctx, "gpt-5.4", originalReq, req, []byte(`data: {"type":"response.reasoning_summary_text.delta","delta":"thinking"}`), &param)
+	if len(reasoning) != 0 {
+		t.Fatalf("reasoning chunks = %d, want 0; chunks=%v", len(reasoning), reasoning)
+	}
+
+	text := ConvertCodexResponseToOpenAI(ctx, "gpt-5.4", originalReq, req, []byte(`data: {"type":"response.output_text.delta","delta":"OK"}`), &param)
+	if len(text) != 1 {
+		t.Fatalf("text chunks = %d, want 1", len(text))
+	}
+	if got := gjson.Get(text[0], "model").String(); got != "gpt-5.4" {
+		t.Fatalf("chunk model = %q, want gpt-5.4; chunk=%s", got, text[0])
+	}
+	if got := gjson.Get(text[0], "choices.0.delta.content").String(); got != "OK" {
+		t.Fatalf("delta content = %q, want OK; chunk=%s", got, text[0])
+	}
+	if gjson.Get(text[0], "choices.0.delta.reasoning_content").Exists() {
+		t.Fatalf("unexpected reasoning_content in chat chunk: %s", text[0])
+	}
+
+	done := ConvertCodexResponseToOpenAI(ctx, "gpt-5.4", originalReq, req, []byte(`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.4","created_at":1710000001,"usage":{"input_tokens":9,"output_tokens":24,"total_tokens":33,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":17}}}}`), &param)
+	if len(done) != 2 {
+		t.Fatalf("done chunks = %d, want 2; chunks=%v", len(done), done)
+	}
+	if got := gjson.Get(done[0], "choices.0.finish_reason").String(); got != "stop" {
+		t.Fatalf("finish_reason = %q, want stop; chunk=%s", got, done[0])
+	}
+	if got := len(gjson.Get(done[1], "choices").Array()); got != 0 {
+		t.Fatalf("usage chunk choices len = %d, want 0; chunk=%s", got, done[1])
+	}
+	if got := gjson.Get(done[1], "usage.prompt_tokens").Int(); got != 9 {
+		t.Fatalf("usage prompt_tokens = %d, want 9; chunk=%s", got, done[1])
+	}
+}
+
+func TestConvertCodexResponseToOpenAINonStream_StripsReasoningSummary(t *testing.T) {
+	raw := []byte(`{"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.4","created_at":1710000001,"status":"completed","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"secret thinking"}]},{"type":"message","content":[{"type":"output_text","text":"Hello!"}]}],"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}}`)
+
+	got := ConvertCodexResponseToOpenAINonStream(context.Background(), "gpt-5.4", []byte(`{"tools":[]}`), nil, raw, nil)
+	if content := gjson.Get(got, "choices.0.message.content").String(); content != "Hello!" {
+		t.Fatalf("message content = %q, want Hello!; payload=%s", content, got)
+	}
+	if gjson.Get(got, "choices.0.message.reasoning_content").Exists() {
+		t.Fatalf("unexpected reasoning_content in non-stream payload: %s", got)
+	}
+}
+
+func TestConvertOpenAIRequestToCodex_MapsMaxCompletionTokens(t *testing.T) {
+	input := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hi"}],"max_completion_tokens":1024}`)
+	got := ConvertOpenAIRequestToCodex("gpt-5.4", input, true)
+	if limit := gjson.GetBytes(got, "max_output_tokens").Int(); limit != 1024 {
+		t.Fatalf("max_output_tokens = %d, want 1024; payload=%s", limit, got)
+	}
+}

--- a/sdk/api/handlers/header_filter.go
+++ b/sdk/api/handlers/header_filter.go
@@ -24,6 +24,19 @@ var hopByHopHeaders = map[string]struct{}{
 	"Content-Encoding": {},
 }
 
+var blockedUpstreamHeaderPrefixes = []string{
+	"X-Codex-",
+	"X-Openai-Proxy-",
+	"Cf-",
+}
+
+var blockedUpstreamHeaders = map[string]struct{}{
+	"Alt-Svc":       {},
+	"Nel":           {},
+	"Report-To":     {},
+	"Server-Timing": {},
+}
+
 // FilterUpstreamHeaders returns a copy of src with hop-by-hop and security-sensitive
 // headers removed. Returns nil if src is nil or empty after filtering.
 func FilterUpstreamHeaders(src http.Header) http.Header {
@@ -34,7 +47,7 @@ func FilterUpstreamHeaders(src http.Header) http.Header {
 	dst := make(http.Header)
 	for key, values := range src {
 		canonicalKey := http.CanonicalHeaderKey(key)
-		if _, blocked := hopByHopHeaders[canonicalKey]; blocked {
+		if isBlockedUpstreamHeader(canonicalKey) {
 			continue
 		}
 		if _, scoped := connectionScoped[canonicalKey]; scoped {
@@ -77,4 +90,19 @@ func WriteUpstreamHeaders(dst http.Header, src http.Header) {
 			dst.Add(key, v)
 		}
 	}
+}
+
+func isBlockedUpstreamHeader(canonicalKey string) bool {
+	if _, blocked := hopByHopHeaders[canonicalKey]; blocked {
+		return true
+	}
+	if _, blocked := blockedUpstreamHeaders[canonicalKey]; blocked {
+		return true
+	}
+	for _, prefix := range blockedUpstreamHeaderPrefixes {
+		if strings.HasPrefix(canonicalKey, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/sdk/api/handlers/header_filter_test.go
+++ b/sdk/api/handlers/header_filter_test.go
@@ -53,3 +53,25 @@ func TestFilterUpstreamHeaders_ReturnsNilWhenAllHeadersBlocked(t *testing.T) {
 		t.Fatalf("expected nil when all headers are filtered, got %#v", filtered)
 	}
 }
+
+func TestFilterUpstreamHeaders_RemovesProviderFingerprintHeaders(t *testing.T) {
+	src := http.Header{}
+	src.Set("X-Codex-Active-Limit", "premium")
+	src.Set("X-Openai-Proxy-Wasm", "v0.1")
+	src.Set("Cf-Ray", "trace")
+	src.Set("Server-Timing", "cfCacheStatus")
+	src.Set("X-Request-Id", "req-1")
+
+	filtered := FilterUpstreamHeaders(src)
+	if filtered == nil {
+		t.Fatalf("expected filtered headers, got nil")
+	}
+	for _, key := range []string{"X-Codex-Active-Limit", "X-Openai-Proxy-Wasm", "Cf-Ray", "Server-Timing"} {
+		if value := filtered.Get(key); value != "" {
+			t.Fatalf("expected %s to be removed, got %q", key, value)
+		}
+	}
+	if got := filtered.Get("X-Request-Id"); got != "req-1" {
+		t.Fatalf("expected X-Request-Id to be preserved, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize Codex and Claude chat-completions adapters so Chat requests always return standard chat chunks
- split Chat streaming finish and usage chunks, stop leaking reasoning/thinking deltas, and preserve the requested model name
- map max_completion_tokens for cross-protocol requests and filter upstream fingerprint headers

## Testing
- rtk go test ./internal/translator/codex/openai/chat-completions
- rtk go test ./internal/translator/claude/openai/chat-completions
- rtk go test ./sdk/api/handlers
- rtk go test ./internal/runtime/executor
- rtk go test ./sdk/api/handlers/openai
- rtk go test ./...