### PR TITLE
feat: persist auth group owner mappings

### DIFF
--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -154,6 +154,33 @@ func (h *ModelsHandler) PutModelOwnerPresets(c *gin.Context) {
 	c.JSON(http.StatusOK, payload)
 }
 
+// GetAuthGroupModelOwnerMappings returns persisted auth-group to model-owner mappings.
+func (h *ModelsHandler) GetAuthGroupModelOwnerMappings(c *gin.Context) {
+	c.JSON(http.StatusOK, h.service().AuthGroupOwnerMappings())
+}
+
+// PatchAuthGroupModelOwnerMapping upserts or deletes a persisted auth-group to model-owner mapping.
+func (h *ModelsHandler) PatchAuthGroupModelOwnerMapping(c *gin.Context) {
+	var body struct {
+		AuthGroup string `json:"auth_group"`
+		Owner     string `json:"owner"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	payload, err := h.service().PatchAuthGroupOwnerMapping(body.AuthGroup, body.Owner)
+	if err != nil {
+		if errors.Is(err, modelcatalog.ErrAuthGroupRequired) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, payload)
+}
+
 // GetModelPricing returns all model pricing entries.
 func (h *ModelsHandler) GetModelPricing(c *gin.Context) {
 	c.JSON(http.StatusOK, h.service().Pricing())

--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -243,6 +243,57 @@ func TestModelOwnerPresetHandlersReplacePresets(t *testing.T) {
 	}
 }
 
+func TestAuthGroupModelOwnerMappingHandlersPatchAndList(t *testing.T) {
+	initManagementModelsTestDB(t)
+	h := NewHandler(&config.Config{}, "", nil)
+
+	patchRec := performModelsRequest(
+		http.MethodPatch,
+		"/auth-group-model-owner-mappings",
+		[]byte(`{"auth_group":"claude","owner":"anthropic"}`),
+		h.Models().PatchAuthGroupModelOwnerMapping,
+	)
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("PatchAuthGroupModelOwnerMapping status = %d body = %s", patchRec.Code, patchRec.Body.String())
+	}
+
+	listRec := performModelsRequest(
+		http.MethodGet,
+		"/auth-group-model-owner-mappings",
+		nil,
+		h.Models().GetAuthGroupModelOwnerMappings,
+	)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("GetAuthGroupModelOwnerMappings status = %d body = %s", listRec.Code, listRec.Body.String())
+	}
+
+	var listPayload struct {
+		Items []struct {
+			AuthGroup string `json:"auth_group"`
+			Owner     string `json:"owner"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listPayload); err != nil {
+		t.Fatalf("unmarshal auth group owner mapping list: %v", err)
+	}
+	if len(listPayload.Items) != 1 || listPayload.Items[0].AuthGroup != "claude" || listPayload.Items[0].Owner != "anthropic" {
+		t.Fatalf("unexpected auth group owner mapping list: %+v", listPayload.Items)
+	}
+
+	deleteRec := performModelsRequest(
+		http.MethodPatch,
+		"/auth-group-model-owner-mappings",
+		[]byte(`{"auth_group":"claude","owner":""}`),
+		h.Models().PatchAuthGroupModelOwnerMapping,
+	)
+	if deleteRec.Code != http.StatusOK {
+		t.Fatalf("PatchAuthGroupModelOwnerMapping delete status = %d body = %s", deleteRec.Code, deleteRec.Body.String())
+	}
+	if _, ok := usage.GetAuthGroupOwnerMapping("claude"); ok {
+		t.Fatal("expected claude auth group owner mapping to be deleted")
+	}
+}
+
 func TestGetModelPathAvailabilityIncludesRootAndConfiguredPath(t *testing.T) {
 	modelID := "model-path-availability-test"
 	reg := registry.GetGlobalRegistry()

--- a/internal/api/routes/management_model_routes.go
+++ b/internal/api/routes/management_model_routes.go
@@ -16,6 +16,8 @@ func registerManagementModelRoutes(group *gin.RouterGroup, h *managementhandlers
 	group.DELETE("/model-configs/*id", models.DeleteModelConfig)
 	group.GET("/model-owner-presets", models.GetModelOwnerPresets)
 	group.PUT("/model-owner-presets", models.PutModelOwnerPresets)
+	group.GET("/auth-group-model-owner-mappings", models.GetAuthGroupModelOwnerMappings)
+	group.PATCH("/auth-group-model-owner-mappings", models.PatchAuthGroupModelOwnerMapping)
 	group.GET("/model-openrouter-sync", models.GetOpenRouterModelSync)
 	group.PUT("/model-openrouter-sync", models.PutOpenRouterModelSync)
 	group.POST("/model-openrouter-sync/run", models.PostOpenRouterModelSyncRun)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -24,7 +24,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 206; got != want {
+	if got, want := len(routes), 208; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 
@@ -33,6 +33,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"GET /v0/management/system-stats/ws",
 		"GET /v0/management/model-configs",
 		"PUT /v0/management/model-configs/*id",
+		"PATCH /v0/management/auth-group-model-owner-mappings",
 		"GET /v0/management/usage/logs/:id/content",
 		"GET /v0/management/usage/logs/:id/egress",
 		"POST /v0/management/api-call",

--- a/internal/management/modelcatalog/configs.go
+++ b/internal/management/modelcatalog/configs.go
@@ -3,6 +3,7 @@ package modelcatalog
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
@@ -10,6 +11,7 @@ import (
 )
 
 var ErrModelIDRequired = errors.New("model id is required")
+var ErrAuthGroupRequired = errors.New("auth group is required")
 
 // Config contract:
 // - Owner: model config / owner preset / pricing management boundary.
@@ -81,6 +83,54 @@ func (s *Service) ReplaceOwnerPresets(rows []usage.ModelOwnerPresetRow) (map[str
 		return nil, err
 	}
 	return map[string]any{"status": "ok", "updated": len(rows)}, nil
+}
+
+func (s *Service) AuthGroupOwnerMappings() map[string]any {
+	rows := modelconfigsettings.ListAuthGroupOwnerMappings()
+	items := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, map[string]any{
+			"auth_group": row.AuthGroup,
+			"owner":      row.Owner,
+			"updated_at": row.UpdatedAt,
+		})
+	}
+	return map[string]any{"items": items}
+}
+
+func (s *Service) PatchAuthGroupOwnerMapping(authGroup, owner string) (map[string]any, error) {
+	authGroup = strings.TrimSpace(authGroup)
+	owner = strings.TrimSpace(owner)
+	if authGroup == "" {
+		return nil, ErrAuthGroupRequired
+	}
+	if owner == "" {
+		if err := modelconfigsettings.DeleteAuthGroupOwnerMapping(authGroup); err != nil {
+			if errors.Is(err, modelconfigsettings.ErrAuthGroupRequired) {
+				return nil, ErrAuthGroupRequired
+			}
+			return nil, err
+		}
+		return map[string]any{
+			"status":     "ok",
+			"auth_group": strings.ToLower(strings.Join(strings.Fields(authGroup), "-")),
+			"deleted":    true,
+		}, nil
+	}
+
+	saved, err := modelconfigsettings.UpsertAuthGroupOwnerMapping(authGroup, owner)
+	if err != nil {
+		if errors.Is(err, modelconfigsettings.ErrAuthGroupRequired) {
+			return nil, ErrAuthGroupRequired
+		}
+		return nil, err
+	}
+	return map[string]any{
+		"status":     "ok",
+		"auth_group": saved.AuthGroup,
+		"owner":      saved.Owner,
+		"updated_at": saved.UpdatedAt,
+	}, nil
 }
 
 func (s *Service) Pricing() map[string]any {

--- a/internal/management/settings/modelconfig/service.go
+++ b/internal/management/settings/modelconfig/service.go
@@ -11,6 +11,7 @@ import (
 )
 
 var ErrModelIDRequired = errors.New("model id is required")
+var ErrAuthGroupRequired = errors.New("auth group is required")
 
 type UpsertConfigInput struct {
 	OriginalID                string
@@ -153,6 +154,36 @@ func ListOwnerPresetsWithCounts() []OwnerPresetWithCount {
 
 func ReplaceOwnerPresets(rows []usage.ModelOwnerPresetRow) error {
 	return usage.ReplaceModelOwnerPresets(rows)
+}
+
+func ListAuthGroupOwnerMappings() []usage.AuthGroupOwnerMappingRow {
+	return usage.ListAuthGroupOwnerMappings()
+}
+
+func UpsertAuthGroupOwnerMapping(authGroup, owner string) (usage.AuthGroupOwnerMappingRow, error) {
+	row := usage.AuthGroupOwnerMappingRow{
+		AuthGroup: strings.TrimSpace(authGroup),
+		Owner:     strings.TrimSpace(owner),
+	}
+	if row.AuthGroup == "" {
+		return usage.AuthGroupOwnerMappingRow{}, ErrAuthGroupRequired
+	}
+	if err := usage.UpsertAuthGroupOwnerMapping(row); err != nil {
+		return usage.AuthGroupOwnerMappingRow{}, err
+	}
+	saved, ok := usage.GetAuthGroupOwnerMapping(row.AuthGroup)
+	if !ok {
+		return row, nil
+	}
+	return saved, nil
+}
+
+func DeleteAuthGroupOwnerMapping(authGroup string) error {
+	authGroup = strings.TrimSpace(authGroup)
+	if authGroup == "" {
+		return ErrAuthGroupRequired
+	}
+	return usage.DeleteAuthGroupOwnerMapping(authGroup)
 }
 
 func ListPricing() []usage.ModelPricingRow {

--- a/internal/storage/sqlite/modelconfig/auth_group_owner_mapping.go
+++ b/internal/storage/sqlite/modelconfig/auth_group_owner_mapping.go
@@ -1,0 +1,127 @@
+package modelconfig
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type AuthGroupOwnerMappingRow struct {
+	AuthGroup string `json:"auth_group"`
+	Owner     string `json:"owner"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+var (
+	authGroupOwnerMappingCache   map[string]AuthGroupOwnerMappingRow
+	authGroupOwnerMappingCacheMu sync.RWMutex
+)
+
+func NormalizeAuthGroupKey(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), "-"))
+}
+
+func (s Store) ListAuthGroupOwnerMappings() []AuthGroupOwnerMappingRow {
+	authGroupOwnerMappingCacheMu.RLock()
+	defer authGroupOwnerMappingCacheMu.RUnlock()
+
+	result := make([]AuthGroupOwnerMappingRow, 0, len(authGroupOwnerMappingCache))
+	for _, row := range authGroupOwnerMappingCache {
+		result = append(result, row)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return strings.ToLower(result[i].AuthGroup) < strings.ToLower(result[j].AuthGroup)
+	})
+	return result
+}
+
+func (s Store) GetAuthGroupOwnerMapping(authGroup string) (AuthGroupOwnerMappingRow, bool) {
+	authGroupOwnerMappingCacheMu.RLock()
+	defer authGroupOwnerMappingCacheMu.RUnlock()
+
+	row, ok := authGroupOwnerMappingCache[NormalizeAuthGroupKey(authGroup)]
+	return row, ok
+}
+
+func (s Store) UpsertAuthGroupOwnerMapping(row AuthGroupOwnerMappingRow) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialised")
+	}
+
+	row.AuthGroup = NormalizeAuthGroupKey(row.AuthGroup)
+	row.Owner = NormalizeModelOwnerValue(row.Owner)
+	if row.AuthGroup == "" {
+		return fmt.Errorf("auth group is required")
+	}
+	if row.Owner == "" {
+		return fmt.Errorf("owner is required")
+	}
+	row.UpdatedAt = nowRFC3339()
+
+	_, err := s.db.Exec(
+		`INSERT INTO auth_group_model_owner_mappings (auth_group, owner, updated_at)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT(auth_group) DO UPDATE SET
+		   owner = excluded.owner,
+		   updated_at = excluded.updated_at`,
+		row.AuthGroup,
+		row.Owner,
+		row.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert auth group owner mapping: %w", err)
+	}
+
+	reloadAuthGroupOwnerMappingCache(s.db)
+	return nil
+}
+
+func (s Store) DeleteAuthGroupOwnerMapping(authGroup string) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialised")
+	}
+
+	authGroup = NormalizeAuthGroupKey(authGroup)
+	if authGroup == "" {
+		return fmt.Errorf("auth group is required")
+	}
+	if _, err := s.db.Exec("DELETE FROM auth_group_model_owner_mappings WHERE auth_group = ?", authGroup); err != nil {
+		return fmt.Errorf("delete auth group owner mapping: %w", err)
+	}
+
+	reloadAuthGroupOwnerMappingCache(s.db)
+	return nil
+}
+
+func reloadAuthGroupOwnerMappingCache(db *sql.DB) {
+	rows, err := db.Query("SELECT auth_group, owner, updated_at FROM auth_group_model_owner_mappings")
+	if err != nil {
+		log.Errorf("sqlite/modelconfig: load auth group owner mapping cache: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	cache := make(map[string]AuthGroupOwnerMappingRow)
+	for rows.Next() {
+		var row AuthGroupOwnerMappingRow
+		if err := rows.Scan(&row.AuthGroup, &row.Owner, &row.UpdatedAt); err != nil {
+			log.Errorf("sqlite/modelconfig: scan auth group owner mapping row: %v", err)
+			continue
+		}
+		row.AuthGroup = NormalizeAuthGroupKey(row.AuthGroup)
+		row.Owner = NormalizeModelOwnerValue(row.Owner)
+		if row.AuthGroup == "" || row.Owner == "" {
+			continue
+		}
+		cache[row.AuthGroup] = row
+	}
+
+	authGroupOwnerMappingCacheMu.Lock()
+	authGroupOwnerMappingCache = cache
+	authGroupOwnerMappingCacheMu.Unlock()
+	log.Infof("sqlite/modelconfig: loaded %d auth group owner mappings into cache", len(cache))
+}

--- a/internal/storage/sqlite/modelconfig/store.go
+++ b/internal/storage/sqlite/modelconfig/store.go
@@ -68,6 +68,15 @@ CREATE TABLE IF NOT EXISTS model_owner_presets (
   updated_at  DATETIME NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS auth_group_model_owner_mappings (
+  auth_group TEXT PRIMARY KEY,
+  owner      TEXT NOT NULL DEFAULT '',
+  updated_at DATETIME NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_group_model_owner_mappings_owner
+  ON auth_group_model_owner_mappings(owner);
+
 CREATE TABLE IF NOT EXISTS model_openrouter_sync_state (
   id               INTEGER PRIMARY KEY CHECK(id = 1),
   enabled          INTEGER NOT NULL DEFAULT 0,
@@ -132,6 +141,7 @@ func InitTables(db *sql.DB) {
 	mergeLegacyPricingIntoModelConfigs(db)
 	reloadModelConfigCache(db)
 	reloadModelOwnerPresetCache(db)
+	reloadAuthGroupOwnerMappingCache(db)
 }
 
 func NormalizeModelOwnerValue(value string) string {

--- a/internal/usage/model_config_db.go
+++ b/internal/usage/model_config_db.go
@@ -15,6 +15,7 @@ import (
 // - Exit condition: remaining callers move to modelconfig settings or narrower bridges; do not add new imports here.
 type ModelConfigRow = sqlmodelconfig.ModelConfigRow
 type ModelOwnerPresetRow = sqlmodelconfig.ModelOwnerPresetRow
+type AuthGroupOwnerMappingRow = sqlmodelconfig.AuthGroupOwnerMappingRow
 
 func initModelConfigTables(db *sql.DB) {
 	sqlmodelconfig.InitTables(db)
@@ -26,6 +27,10 @@ func modelConfigStore() sqlmodelconfig.Store {
 
 func normalizeModelOwnerValue(value string) string {
 	return sqlmodelconfig.NormalizeModelOwnerValue(value)
+}
+
+func normalizeAuthGroupKey(value string) string {
+	return sqlmodelconfig.NormalizeAuthGroupKey(value)
 }
 
 func normalizePricingMode(mode string) string {
@@ -132,4 +137,20 @@ func UpsertModelOwnerPreset(row ModelOwnerPresetRow) error {
 
 func ReplaceModelOwnerPresets(rows []ModelOwnerPresetRow) error {
 	return modelConfigStore().ReplaceModelOwnerPresets(rows)
+}
+
+func ListAuthGroupOwnerMappings() []AuthGroupOwnerMappingRow {
+	return modelConfigStore().ListAuthGroupOwnerMappings()
+}
+
+func GetAuthGroupOwnerMapping(authGroup string) (AuthGroupOwnerMappingRow, bool) {
+	return modelConfigStore().GetAuthGroupOwnerMapping(authGroup)
+}
+
+func UpsertAuthGroupOwnerMapping(row AuthGroupOwnerMappingRow) error {
+	return modelConfigStore().UpsertAuthGroupOwnerMapping(row)
+}
+
+func DeleteAuthGroupOwnerMapping(authGroup string) error {
+	return modelConfigStore().DeleteAuthGroupOwnerMapping(authGroup)
 }


### PR DESCRIPTION
## Summary
- persist auth-group -> model-owner mappings in the management backend
- expose management APIs for listing and updating the mapping
- support the admin panel workflow that shares configured models across auth-file types

## Verification
- rtk go test ./internal/api/handlers/management ./internal/api/routes ./internal/storage/sqlite/modelconfig ./internal/usage ./internal/management/settings/modelconfig