### PR TITLE
fix: guard against empty tool_use/function.name in protocol conversion

### DIFF
--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -157,9 +157,13 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 					case "tool_use":
 						// Only allow tool_use -> tool_calls for assistant messages (security: prevent injection).
 						if role == "assistant" {
+							toolName := part.Get("name").String()
+							if toolName == "" {
+								return true // skip tool_use with empty name
+							}
 							toolCallJSON := `{"id":"","type":"function","function":{"name":"","arguments":""}}`
 							toolCallJSON, _ = sjson.Set(toolCallJSON, "id", part.Get("id").String())
-							toolCallJSON, _ = sjson.Set(toolCallJSON, "function.name", part.Get("name").String())
+							toolCallJSON, _ = sjson.Set(toolCallJSON, "function.name", toolName)
 
 							// Convert input to arguments JSON string
 							if input := part.Get("input"); input.Exists() {

--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -214,7 +214,7 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 
 				// Handle function name
 				if function := toolCall.Get("function"); function.Exists() {
-					if name := function.Get("name"); name.Exists() {
+					if name := function.Get("name"); name.Exists() && name.String() != "" {
 						accumulator.Name = name.String()
 
 						stopThinkingContentBlock(param, &results)
@@ -390,9 +390,13 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) []string {
 		// Handle tool calls
 		if toolCalls := choice.Get("message.tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {
 			toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
+				toolName := toolCall.Get("function.name").String()
+				if toolName == "" {
+					return true // skip tool_call with empty function name
+				}
 				toolUseBlock := `{"type":"tool_use","id":"","name":"","input":{}}`
 				toolUseBlock, _ = sjson.Set(toolUseBlock, "id", toolCall.Get("id").String())
-				toolUseBlock, _ = sjson.Set(toolUseBlock, "name", toolCall.Get("function.name").String())
+				toolUseBlock, _ = sjson.Set(toolUseBlock, "name", toolName)
 
 				argsStr := util.FixJSON(toolCall.Get("function.arguments").String())
 				if argsStr != "" && gjson.Valid(argsStr) {
@@ -587,10 +591,14 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 							toolCalls := item.Get("tool_calls")
 							if toolCalls.IsArray() {
 								toolCalls.ForEach(func(_, tc gjson.Result) bool {
+									toolName := tc.Get("function.name").String()
+									if toolName == "" {
+										return true // skip tool_call with empty function name
+									}
 									hasToolCall = true
 									toolUse := `{"type":"tool_use","id":"","name":"","input":{}}`
 									toolUse, _ = sjson.Set(toolUse, "id", tc.Get("id").String())
-									toolUse, _ = sjson.Set(toolUse, "name", tc.Get("function.name").String())
+									toolUse, _ = sjson.Set(toolUse, "name", toolName)
 
 									argsStr := util.FixJSON(tc.Get("function.arguments").String())
 									if argsStr != "" && gjson.Valid(argsStr) {
@@ -644,10 +652,14 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 
 			if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {
 				toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
+					toolName := toolCall.Get("function.name").String()
+					if toolName == "" {
+						return true // skip tool_call with empty function name
+					}
 					hasToolCall = true
 					toolUseBlock := `{"type":"tool_use","id":"","name":"","input":{}}`
 					toolUseBlock, _ = sjson.Set(toolUseBlock, "id", toolCall.Get("id").String())
-					toolUseBlock, _ = sjson.Set(toolUseBlock, "name", toolCall.Get("function.name").String())
+					toolUseBlock, _ = sjson.Set(toolUseBlock, "name", toolName)
 
 					argsStr := util.FixJSON(toolCall.Get("function.arguments").String())
 					if argsStr != "" && gjson.Valid(argsStr) {


### PR DESCRIPTION
## Summary

Skip tool calls with empty `function.name` at all conversion points. Upstream providers occasionally return `tool_calls` with empty `function.name`, which produces downstream JSON with empty names that Claude Code rejects.

## Changes

- **Streaming response**: check `name.String() != ""` (not just `Exists`)
- **Non-streaming response**: skip in `convertOpenAINonStreamingToAnthropic`
- **Non-streaming alternative**: skip in `ConvertOpenAIResponseToClaudeNonStream` (both content-array and message-level `tool_calls` paths)
- **Request back-conversion**: skip `tool_use` with empty name

## Files

- `internal/translator/openai/claude/openai_claude_request.go` (+5, -1)
- `internal/translator/openai/claude/openai_claude_response.go` (+16, -4)

## Test Plan

- [x] `go test ./test/...` passes locally