### PR TITLE
feat: add stable api key identities to usage logs

### DIFF
--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -194,6 +194,7 @@ func (h *Handler) PutAPIKeyEntries(c *gin.Context) {
 
 func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 	var body struct {
+		ID    *string                    `json:"id"`
 		Index *int                       `json:"index"`
 		Match *string                    `json:"match"`
 		Value *apikeysettings.EntryPatch `json:"value"`
@@ -202,7 +203,7 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	if err := h.apiKeySettings().PatchEntry(body.Index, body.Match, *body.Value); err != nil {
+	if err := h.apiKeySettings().PatchEntry(body.ID, body.Index, body.Match, *body.Value); err != nil {
 		switch {
 		case errors.Is(err, apikeysettings.ErrItemNotFound):
 			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
@@ -222,6 +223,10 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 }
 
 func (h *Handler) DeleteAPIKeyEntry(c *gin.Context) {
+	var id *string
+	if value := strings.TrimSpace(c.Query("id")); value != "" {
+		id = &value
+	}
 	var index *int
 	if idxStr := strings.TrimSpace(c.Query("index")); idxStr != "" {
 		parsed, err := strconv.Atoi(idxStr)
@@ -232,7 +237,7 @@ func (h *Handler) DeleteAPIKeyEntry(c *gin.Context) {
 		index = &parsed
 	}
 
-	result, err := h.apiKeySettings().DeleteEntry(c.Query("key"), index, shouldDeleteAPIKeyLogs(c))
+	result, err := h.apiKeySettings().DeleteEntry(c.Query("key"), id, index, shouldDeleteAPIKeyLogs(c))
 	if err != nil {
 		if errors.Is(err, apikeysettings.ErrMissingKeyOrIndex) {
 			c.JSON(400, gin.H{"error": "missing key or index"})

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -370,6 +370,66 @@ func TestGetUsageLogs_EmptyDB_DoesNotReturnNullSlices(t *testing.T) {
 	}
 }
 
+func TestGetUsageLogsCollapsesRenamedAPIKeysByStableIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	stableID := "api-key-stable-1"
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{ID: stableID, Key: "sk-old", Name: "袁蔚"}); err != nil {
+		t.Fatalf("UpsertAPIKey(sk-old): %v", err)
+	}
+	now := time.Now().UTC()
+	usage.InsertLog("sk-old", "袁蔚", "gpt-5.4", "codex", "Codex", "auth-1", false, now, 100, 10, usage.TokenStats{
+		InputTokens: 1, OutputTokens: 1, TotalTokens: 2,
+	}, "", "")
+
+	if err := usage.UpdateAPIKeyByID(usage.APIKeyRow{ID: stableID, Key: "sk-new", Name: "袁蔚"}); err != nil {
+		t.Fatalf("UpdateAPIKeyByID(sk-new): %v", err)
+	}
+	usage.InsertLog("sk-new", "袁蔚", "gpt-5.4", "codex", "Codex", "auth-1", false, now.Add(time.Second), 120, 12, usage.TokenStats{
+		InputTokens: 2, OutputTokens: 2, TotalTokens: 4,
+	}, "", "")
+
+	h := &Handler{cfg: &config.Config{}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50", nil)
+
+	h.UsageLogs().GetUsageLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Filters struct {
+			APIKeys     []string          `json:"api_keys"`
+			APIKeyNames map[string]string `json:"api_key_names"`
+		} `json:"filters"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(payload.Filters.APIKeys) != 1 || payload.Filters.APIKeys[0] != "sk-new" {
+		t.Fatalf("filters.api_keys = %#v, want [sk-new]", payload.Filters.APIKeys)
+	}
+	if payload.Filters.APIKeyNames["sk-new"] != "袁蔚" {
+		t.Fatalf("filters.api_key_names[sk-new] = %q, want 袁蔚", payload.Filters.APIKeyNames["sk-new"])
+	}
+}
+
 func TestGetLogContent_ReturnsRequestDetailsPart(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -95,6 +95,10 @@ type StreamingConfig struct {
 
 // APIKeyEntry represents an API key with optional metadata for advanced management.
 type APIKeyEntry struct {
+	// ID is the stable identity of this logical API key entry.
+	// It is API-managed only and is not persisted back into YAML.
+	ID string `yaml:"-" json:"id,omitempty"`
+
 	// Key is the API key string used for authentication.
 	Key string `yaml:"key" json:"key"`
 

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -102,6 +102,10 @@ func (s *Service) GetRow(key string) *usage.APIKeyRow {
 	return usage.GetAPIKey(strings.TrimSpace(key))
 }
 
+func (s *Service) GetRowByID(id string) *usage.APIKeyRow {
+	return usage.GetAPIKeyByID(strings.TrimSpace(id))
+}
+
 func (s *Service) ReplaceKeys(keys []string) error {
 	rows := make([]usage.APIKeyRow, 0, len(keys))
 	for _, key := range keys {
@@ -116,13 +120,25 @@ func (s *Service) ReplaceKeys(keys []string) error {
 func (s *Service) PatchKey(oldKey string, newKey string) error {
 	oldKey = strings.TrimSpace(oldKey)
 	newKey = strings.TrimSpace(newKey)
-	if oldKey != "" {
-		_ = usage.DeleteAPIKey(oldKey)
+	if oldKey == "" {
+		if newKey == "" {
+			return nil
+		}
+		return usage.UpsertAPIKey(usage.APIKeyRow{Key: newKey})
+	}
+	existing := usage.GetAPIKey(oldKey)
+	if existing == nil {
+		if newKey == "" {
+			return nil
+		}
+		return usage.UpsertAPIKey(usage.APIKeyRow{Key: newKey})
 	}
 	if newKey == "" {
-		return nil
+		return usage.DeleteAPIKeyByID(existing.ID)
 	}
-	return usage.UpsertAPIKey(usage.APIKeyRow{Key: newKey})
+	updated := *existing
+	updated.Key = newKey
+	return usage.UpdateAPIKeyByID(updated)
 }
 
 func (s *Service) DeleteKey(key string) error {
@@ -243,20 +259,14 @@ func (s *Service) ReplaceEntries(entries []config.APIKeyEntry) error {
 	return usage.ReplaceAllAPIKeys(rows)
 }
 
-func (s *Service) PatchEntry(index *int, match *string, patch EntryPatch) error {
-	targetKey := resolvePatchTargetKey(index, match)
-	if targetKey == "" {
+func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryPatch) error {
+	existing := resolvePatchTargetRow(id, index, match)
+	if existing == nil {
 		return ErrItemNotFound
 	}
-
-	existing := usage.GetAPIKey(targetKey)
-	entry := usage.APIKeyRow{}
-	if existing != nil {
-		entry = *existing
-	} else {
-		entry.Key = targetKey
-	}
+	entry := *existing
 	originalKey := strings.TrimSpace(entry.Key)
+	originalID := strings.TrimSpace(entry.ID)
 
 	if patch.Key != nil {
 		entry.Key = strings.TrimSpace(*patch.Key)
@@ -306,34 +316,24 @@ func (s *Service) PatchEntry(index *int, match *string, patch EntryPatch) error 
 		return err
 	}
 	desiredKey := strings.TrimSpace(normalized.Key)
-	if desiredKey != targetKey {
-		if existingKey := usage.GetAPIKey(desiredKey); existingKey != nil {
+	if desiredKey != originalKey {
+		if existingKey := usage.GetAPIKey(desiredKey); existingKey != nil && strings.TrimSpace(existingKey.ID) != originalID {
 			return ErrDuplicateKey
 		}
 	}
-
-	if existing != nil && originalKey != "" && desiredKey != originalKey {
-		if err := usage.DeleteAPIKey(originalKey); err != nil {
-			return err
-		}
-	}
-	return usage.UpsertAPIKey(usage.APIKeyRowFromConfig(normalized))
+	updated := usage.APIKeyRowFromConfig(normalized)
+	updated.ID = originalID
+	return usage.UpdateAPIKeyByID(updated)
 }
 
-func (s *Service) DeleteEntry(key string, index *int, deleteLogs bool) (DeleteEntryResult, error) {
+func (s *Service) DeleteEntry(key string, id *string, index *int, deleteLogs bool) (DeleteEntryResult, error) {
 	targetKey := strings.TrimSpace(key)
-	if targetKey == "" {
-		if index == nil || *index < 0 {
-			return DeleteEntryResult{}, ErrMissingKeyOrIndex
-		}
-		rows := usage.ListAPIKeys()
-		if *index >= len(rows) {
-			return DeleteEntryResult{}, ErrMissingKeyOrIndex
-		}
-		targetKey = rows[*index].Key
+	row := resolvePatchTargetRow(id, index, &targetKey)
+	if row == nil {
+		return DeleteEntryResult{}, ErrMissingKeyOrIndex
 	}
-
-	if err := usage.DeleteAPIKey(targetKey); err != nil {
+	targetKey = row.Key
+	if err := usage.DeleteAPIKeyByID(row.ID); err != nil {
 		return DeleteEntryResult{}, err
 	}
 
@@ -378,20 +378,26 @@ func (s *Service) prepareEntryForSave(entry config.APIKeyEntry) (config.APIKeyEn
 	return entry, nil
 }
 
-func resolvePatchTargetKey(index *int, match *string) string {
+func resolvePatchTargetRow(id *string, index *int, match *string) *usage.APIKeyRow {
+	if id != nil {
+		if targetID := strings.TrimSpace(*id); targetID != "" {
+			return usage.GetAPIKeyByID(targetID)
+		}
+	}
 	if match != nil {
 		if targetKey := strings.TrimSpace(*match); targetKey != "" {
-			return targetKey
+			return usage.GetAPIKey(targetKey)
 		}
 	}
 	if index == nil || *index < 0 {
-		return ""
+		return nil
 	}
 	rows := usage.ListAPIKeys()
 	if *index >= len(rows) {
-		return ""
+		return nil
 	}
-	return strings.TrimSpace(rows[*index].Key)
+	row := rows[*index]
+	return &row
 }
 
 func normalizeChannelGroups(values []string) []string {

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -76,6 +76,38 @@ func TestPatchAndDeleteKey(t *testing.T) {
 	}
 }
 
+func TestPatchEntryRenamePreservesStableID(t *testing.T) {
+	setupTestDB(t)
+	svc := NewService(nil)
+
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{ID: "key-1", Key: "sk-old", Name: "Old"}); err != nil {
+		t.Fatalf("UpsertAPIKey(sk-old): %v", err)
+	}
+
+	newKey := "sk-new"
+	newName := "Renamed"
+	if err := svc.PatchEntry(&[]string{"key-1"}[0], nil, nil, EntryPatch{
+		Key:  &newKey,
+		Name: &newName,
+	}); err != nil {
+		t.Fatalf("PatchEntry() error = %v", err)
+	}
+
+	if got := usage.GetAPIKey("sk-old"); got != nil {
+		t.Fatalf("old key should not remain addressable by key, got %#v", got)
+	}
+	got := usage.GetAPIKey("sk-new")
+	if got == nil {
+		t.Fatal("expected renamed API key to exist")
+	}
+	if got.ID != "key-1" {
+		t.Fatalf("stable id = %q, want key-1", got.ID)
+	}
+	if got.Name != "Renamed" {
+		t.Fatalf("name = %q, want Renamed", got.Name)
+	}
+}
+
 func TestReplacePermissionProfilesValidatesAndSanitizes(t *testing.T) {
 	setupTestDB(t)
 	svc := NewService(func(channels []string) ([]string, error) {
@@ -232,7 +264,7 @@ func TestPatchEntryValidationFailureKeepsOriginalKey(t *testing.T) {
 
 	newKey := "sk-new"
 	name := "Renamed"
-	err := svc.PatchEntry(nil, &[]string{"sk-old"}[0], EntryPatch{
+	err := svc.PatchEntry(nil, nil, &[]string{"sk-old"}[0], EntryPatch{
 		Key:  &newKey,
 		Name: &name,
 	})
@@ -262,7 +294,7 @@ func TestDeleteEntryByIndexDeletesLogsWhenRequested(t *testing.T) {
 		t.Fatalf("UpsertAPIKey(sk-delete): %v", err)
 	}
 
-	result, err := svc.DeleteEntry("", &[]int{0}[0], true)
+	result, err := svc.DeleteEntry("", nil, &[]int{0}[0], true)
 	if err != nil {
 		t.Fatalf("DeleteEntry() error = %v, want nil", err)
 	}

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -109,7 +109,9 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 		}
 	}
 
-	filters.APIKeyNames = make(map[string]string, len(filters.APIKeys))
+	if filters.APIKeyNames == nil {
+		filters.APIKeyNames = make(map[string]string, len(filters.APIKeys))
+	}
 	for _, key := range filters.APIKeys {
 		if name, ok := keyNameMap[key]; ok {
 			filters.APIKeyNames[key] = name

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	log "github.com/sirupsen/logrus"
 )
@@ -14,6 +15,7 @@ import (
 const createAPIKeysTableSQL = `
 CREATE TABLE IF NOT EXISTS api_keys (
   key               TEXT PRIMARY KEY NOT NULL,
+  id                TEXT NOT NULL DEFAULT '',
   name              TEXT NOT NULL DEFAULT '',
   disabled          INTEGER NOT NULL DEFAULT 0,
   permission_profile_id TEXT NOT NULL DEFAULT '',
@@ -30,9 +32,13 @@ CREATE TABLE IF NOT EXISTS api_keys (
   created_at        TEXT NOT NULL DEFAULT '',
   updated_at        TEXT NOT NULL DEFAULT ''
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);
 `
 
 type APIKeyRow struct {
+	ID                   string   `json:"id,omitempty"`
 	Key                  string   `json:"key"`
 	Name                 string   `json:"name,omitempty"`
 	Disabled             bool     `json:"disabled,omitempty"`
@@ -84,6 +90,7 @@ func InitTable(db *sql.DB) {
 		log.Errorf("sqlite/apikey: create api_keys table: %v", err)
 	}
 	migrateColumns(db)
+	backfillIDs(db)
 	backfillNames(db)
 }
 
@@ -96,6 +103,7 @@ func BackfillNames(db *sql.DB) {
 
 func (r APIKeyRow) ToConfigEntry() config.APIKeyEntry {
 	return config.APIKeyEntry{
+		ID:                   r.ID,
 		Key:                  r.Key,
 		Name:                 r.Name,
 		Disabled:             r.Disabled,
@@ -116,6 +124,7 @@ func (r APIKeyRow) ToConfigEntry() config.APIKeyEntry {
 
 func APIKeyRowFromConfig(entry config.APIKeyEntry) APIKeyRow {
 	return APIKeyRow{
+		ID:                   entry.ID,
 		Key:                  entry.Key,
 		Name:                 entry.Name,
 		Disabled:             entry.Disabled,
@@ -163,7 +172,7 @@ func (s Store) List() []APIKeyRow {
 		return nil
 	}
 
-	rows, err := s.db.Query(`SELECT key, name, disabled, daily_limit, total_quota,
+	rows, err := s.db.Query(`SELECT key, name, disabled, id, daily_limit, total_quota,
 		permission_profile_id, spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_keys ORDER BY created_at ASC`)
@@ -186,10 +195,31 @@ func (s Store) Get(key string) *APIKeyRow {
 		return nil
 	}
 
-	row := s.db.QueryRow(`SELECT key, name, disabled, daily_limit, total_quota,
+	row := s.db.QueryRow(`SELECT key, name, disabled, id, daily_limit, total_quota,
 		permission_profile_id, spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_keys WHERE key = ?`, trimmed)
+	entry, ok := scanAPIKeyRow(row)
+	if !ok {
+		return nil
+	}
+	return entry
+}
+
+func (s Store) GetByID(id string) *APIKeyRow {
+	if s.db == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return nil
+	}
+
+	row := s.db.QueryRow(`SELECT key, name, disabled, id, daily_limit, total_quota,
+		permission_profile_id, spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
+		FROM api_keys WHERE id = ?`, trimmed)
 	entry, ok := scanAPIKeyRow(row)
 	if !ok {
 		return nil
@@ -206,6 +236,13 @@ func (s Store) Upsert(entry APIKeyRow) error {
 	if entry.Key == "" {
 		return fmt.Errorf("key is required")
 	}
+	if entry.ID == "" {
+		if existing := s.Get(entry.Key); existing != nil && existing.ID != "" {
+			entry.ID = existing.ID
+		} else {
+			entry.ID = uuid.NewString()
+		}
+	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	if entry.CreatedAt == "" {
@@ -218,10 +255,11 @@ func (s Store) Upsert(entry APIKeyRow) error {
 	}
 
 	_, err := s.db.Exec(`INSERT INTO api_keys
-		(key, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
+		(key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(key) DO UPDATE SET
+			id=excluded.id,
 			name=excluded.name, disabled=excluded.disabled,
 			permission_profile_id=excluded.permission_profile_id,
 			daily_limit=excluded.daily_limit, total_quota=excluded.total_quota,
@@ -231,12 +269,54 @@ func (s Store) Upsert(entry APIKeyRow) error {
 			allowed_channel_groups=excluded.allowed_channel_groups,
 			system_prompt=excluded.system_prompt,
 			updated_at=excluded.updated_at`,
-		entry.Key, entry.Name, disabledInt, entry.PermissionProfileID,
+		entry.Key, entry.ID, entry.Name, disabledInt, entry.PermissionProfileID,
 		entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit,
 		entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
 		entry.CreatedAt, now,
+	)
+	return err
+}
+
+func (s Store) UpdateByID(entry APIKeyRow) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialised")
+	}
+
+	entry = normalizeRow(entry)
+	if entry.ID == "" {
+		return fmt.Errorf("id is required")
+	}
+	if entry.Key == "" {
+		return fmt.Errorf("key is required")
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if entry.CreatedAt == "" {
+		if existing := s.GetByID(entry.ID); existing != nil && existing.CreatedAt != "" {
+			entry.CreatedAt = existing.CreatedAt
+		} else {
+			entry.CreatedAt = now
+		}
+	}
+
+	disabledInt := 0
+	if entry.Disabled {
+		disabledInt = 1
+	}
+
+	_, err := s.db.Exec(`UPDATE api_keys SET
+		key = ?, name = ?, disabled = ?, permission_profile_id = ?, daily_limit = ?, total_quota = ?,
+		spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
+		allowed_models = ?, allowed_channels = ?, allowed_channel_groups = ?, system_prompt = ?,
+		created_at = ?, updated_at = ?
+		WHERE id = ?`,
+		entry.Key, entry.Name, disabledInt, entry.PermissionProfileID, entry.DailyLimit, entry.TotalQuota,
+		entry.SpendingLimit, entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
+		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
+		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
+		entry.CreatedAt, now, entry.ID,
 	)
 	return err
 }
@@ -253,9 +333,30 @@ func (s Store) Delete(key string) error {
 	return err
 }
 
+func (s Store) DeleteByID(id string) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialised")
+	}
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return fmt.Errorf("id is required")
+	}
+	_, err := s.db.Exec("DELETE FROM api_keys WHERE id = ?", trimmed)
+	return err
+}
+
 func (s Store) ReplaceAll(entries []APIKeyRow) error {
 	if s.db == nil {
 		return fmt.Errorf("database not initialised")
+	}
+	existingIDsByKey := make(map[string]string)
+	for _, row := range s.List() {
+		key := strings.TrimSpace(row.Key)
+		id := strings.TrimSpace(row.ID)
+		if key == "" || id == "" {
+			continue
+		}
+		existingIDsByKey[key] = id
 	}
 
 	tx, err := s.db.Begin()
@@ -269,9 +370,9 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_keys
-		(key, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
+		(key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -284,6 +385,13 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 		if entry.Key == "" {
 			continue
 		}
+		if entry.ID == "" {
+			if existingID := existingIDsByKey[entry.Key]; existingID != "" {
+				entry.ID = existingID
+			} else {
+				entry.ID = uuid.NewString()
+			}
+		}
 		if entry.CreatedAt == "" {
 			entry.CreatedAt = now
 		}
@@ -292,7 +400,7 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 			disabledInt = 1
 		}
 		if _, err := stmt.Exec(
-			entry.Key, entry.Name, disabledInt, entry.PermissionProfileID,
+			entry.Key, entry.ID, entry.Name, disabledInt, entry.PermissionProfileID,
 			entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit,
 			entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 			mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
@@ -355,6 +463,7 @@ func migrateColumns(db *sql.DB) {
 		name       string
 		definition string
 	}{
+		{name: "id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "permission_profile_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "allowed_channels", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "allowed_channel_groups", definition: "TEXT NOT NULL DEFAULT '[]'"},
@@ -365,6 +474,62 @@ func migrateColumns(db *sql.DB) {
 			}
 		}
 	}
+	if _, err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id)"); err != nil {
+		log.Warnf("sqlite/apikey: ensure api_keys id index: %v", err)
+	}
+	if _, err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key)"); err != nil {
+		log.Warnf("sqlite/apikey: ensure api_keys key index: %v", err)
+	}
+}
+
+func backfillIDs(db *sql.DB) {
+	rows, err := db.Query(`SELECT key FROM api_keys WHERE trim(coalesce(id, '')) = '' ORDER BY created_at ASC, key ASC`)
+	if err != nil {
+		log.Warnf("sqlite/apikey: query api_keys without id: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	keys := make([]string, 0)
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err == nil && strings.TrimSpace(key) != "" {
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) == 0 {
+		return
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		log.Warnf("sqlite/apikey: begin api_keys id backfill: %v", err)
+		return
+	}
+
+	stmt, err := tx.Prepare(`UPDATE api_keys SET id = ?, updated_at = ? WHERE key = ? AND trim(coalesce(id, '')) = ''`)
+	if err != nil {
+		_ = tx.Rollback()
+		log.Warnf("sqlite/apikey: prepare api_keys id backfill: %v", err)
+		return
+	}
+	defer stmt.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, key := range keys {
+		if _, err := stmt.Exec(uuid.NewString(), now, key); err != nil {
+			_ = tx.Rollback()
+			log.Warnf("sqlite/apikey: update api_keys id backfill for %s: %v", key, err)
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Warnf("sqlite/apikey: commit api_keys id backfill: %v", err)
+		return
+	}
+
+	log.Infof("sqlite/apikey: backfilled ids for %d api_keys", len(keys))
 }
 
 func backfillNames(db *sql.DB) {
@@ -418,6 +583,7 @@ func backfillNames(db *sql.DB) {
 }
 
 func normalizeRow(row APIKeyRow) APIKeyRow {
+	row.ID = strings.TrimSpace(row.ID)
 	row.Key = strings.TrimSpace(row.Key)
 	row.Name = strings.TrimSpace(row.Name)
 	row.PermissionProfileID = strings.TrimSpace(row.PermissionProfileID)
@@ -457,6 +623,7 @@ func scanAPIKeyRow(row scanner) (*APIKeyRow, bool) {
 	var channelGroupsJSON string
 	if err := row.Scan(
 		&entry.Key, &entry.Name, &disabledInt,
+		&entry.ID,
 		&entry.DailyLimit, &entry.TotalQuota, &entry.PermissionProfileID, &entry.SpendingLimit,
 		&entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
 		&modelsJSON, &channelsJSON, &channelGroupsJSON, &entry.SystemPrompt,

--- a/internal/usage/api_key_identity.go
+++ b/internal/usage/api_key_identity.go
@@ -1,0 +1,119 @@
+package usage
+
+import (
+	"database/sql"
+	"strings"
+
+	sqlapikey "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/sqlite/apikey"
+	log "github.com/sirupsen/logrus"
+)
+
+type APIKeyIdentity struct {
+	ID   string
+	Key  string
+	Name string
+}
+
+func ResolveAPIKeyIdentity(key string) *APIKeyIdentity {
+	row := GetAPIKey(strings.TrimSpace(key))
+	if row == nil || strings.TrimSpace(row.ID) == "" {
+		return nil
+	}
+	return &APIKeyIdentity{
+		ID:   strings.TrimSpace(row.ID),
+		Key:  strings.TrimSpace(row.Key),
+		Name: strings.TrimSpace(row.Name),
+	}
+}
+
+func currentAPIKeyRowsByID() map[string]APIKeyRow {
+	rows := ListAPIKeys()
+	result := make(map[string]APIKeyRow, len(rows))
+	for _, row := range rows {
+		id := strings.TrimSpace(row.ID)
+		if id == "" {
+			continue
+		}
+		result[id] = row
+	}
+	return result
+}
+
+func uniqueAPIKeyIDByName() map[string]string {
+	return uniqueAPIKeyIDByNameFromRows(ListAPIKeys())
+}
+
+func uniqueAPIKeyIDByNameFromDB(db *sql.DB) map[string]string {
+	if db == nil {
+		return nil
+	}
+	return uniqueAPIKeyIDByNameFromRows(sqlapikey.NewStore(db).List())
+}
+
+func uniqueAPIKeyIDByNameFromRows(rows []APIKeyRow) map[string]string {
+	counts := make(map[string]int)
+	ids := make(map[string]string)
+	for _, row := range rows {
+		id := strings.TrimSpace(row.ID)
+		name := strings.ToLower(strings.TrimSpace(row.Name))
+		if id == "" || name == "" {
+			continue
+		}
+		counts[name]++
+		ids[name] = id
+	}
+
+	result := make(map[string]string)
+	for name, id := range ids {
+		if counts[name] == 1 {
+			result[name] = id
+		}
+	}
+	return result
+}
+
+func backfillRequestLogAPIKeyIDs(db *sql.DB) {
+	if db == nil {
+		return
+	}
+
+	result, err := db.Exec(`
+		UPDATE request_logs
+		SET api_key_id = (
+			SELECT id FROM api_keys WHERE api_keys.key = request_logs.api_key
+		)
+		WHERE trim(coalesce(api_key_id, '')) = ''
+		  AND EXISTS (
+			SELECT 1
+			FROM api_keys
+			WHERE api_keys.key = request_logs.api_key
+			  AND trim(coalesce(api_keys.id, '')) <> ''
+		  )
+	`)
+	if err != nil {
+		log.Warnf("usage: backfill request_logs api_key_id by key failed: %v", err)
+	} else if rows, rowsErr := result.RowsAffected(); rowsErr == nil && rows > 0 {
+		log.Infof("usage: backfilled api_key_id for %d request_logs by exact key match", rows)
+	}
+
+	nameToID := uniqueAPIKeyIDByNameFromDB(db)
+	if len(nameToID) == 0 {
+		return
+	}
+	for lowerName, id := range nameToID {
+		result, err := db.Exec(`
+			UPDATE request_logs
+			SET api_key_id = ?
+			WHERE trim(coalesce(api_key_id, '')) = ''
+			  AND lower(trim(coalesce(api_key_name, ''))) = ?
+			  AND trim(coalesce(api_key, '')) <> ''
+		`, id, lowerName)
+		if err != nil {
+			log.Warnf("usage: backfill request_logs api_key_id by name failed for %q: %v", lowerName, err)
+			continue
+		}
+		if rows, rowsErr := result.RowsAffected(); rowsErr == nil && rows > 0 {
+			log.Infof("usage: backfilled api_key_id for %d request_logs by unique api_key_name=%q", rows, lowerName)
+		}
+	}
+}

--- a/internal/usage/apikey_db.go
+++ b/internal/usage/apikey_db.go
@@ -156,14 +156,29 @@ func GetAPIKey(key string) *APIKeyRow {
 	return apiKeyStore().Get(key)
 }
 
+// GetAPIKeyByID retrieves a single API key entry by stable id.
+func GetAPIKeyByID(id string) *APIKeyRow {
+	return apiKeyStore().GetByID(id)
+}
+
 // UpsertAPIKey inserts or updates an API key entry.
 func UpsertAPIKey(entry APIKeyRow) error {
 	return apiKeyStore().Upsert(entry)
 }
 
+// UpdateAPIKeyByID updates an API key entry by stable id.
+func UpdateAPIKeyByID(entry APIKeyRow) error {
+	return apiKeyStore().UpdateByID(entry)
+}
+
 // DeleteAPIKey removes an API key entry by key string.
 func DeleteAPIKey(key string) error {
 	return apiKeyStore().Delete(key)
+}
+
+// DeleteAPIKeyByID removes an API key entry by stable id.
+func DeleteAPIKeyByID(id string) error {
+	return apiKeyStore().DeleteByID(id)
 }
 
 // ReplaceAllAPIKeys atomically replaces all API keys with the given list.

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -335,10 +335,11 @@ func QueryTotalCostByKey(apiKey string) (float64, error) {
 	if db == nil {
 		return 0, nil
 	}
+	clause, args := buildSingleAPIKeySelectorClause(apiKey)
 	var total float64
 	err := db.QueryRow(
-		"SELECT COALESCE(SUM(cost), 0) FROM request_logs WHERE api_key = ?",
-		apiKey,
+		"SELECT COALESCE(SUM(cost), 0) FROM request_logs"+clause,
+		args...,
 	).Scan(&total)
 	if err != nil {
 		return 0, fmt.Errorf("usage: query total cost: %w", err)

--- a/internal/usage/request_log_content.go
+++ b/internal/usage/request_log_content.go
@@ -128,14 +128,17 @@ func QueryLogContentForKey(id int64, apiKey string) (LogContentResult, error) {
 	if db == nil {
 		return LogContentResult{}, fmt.Errorf("usage: database not initialised")
 	}
+	clause, args := buildSingleAPIKeySelectorClause(apiKey)
+	predicate := strings.TrimPrefix(clause, " WHERE ")
+	queryArgs := append([]interface{}{id}, args...)
 
 	result, err := queryCompressedLogContent(
 		db,
 		`SELECT logs.id, logs.model, content.compression, content.input_content, content.output_content
 		 FROM request_logs logs
 		 JOIN request_log_content content ON content.log_id = logs.id
-		 WHERE logs.id = ? AND logs.api_key = ?`,
-		id, apiKey,
+		 WHERE logs.id = ? AND `+predicate,
+		queryArgs...,
 	)
 	if err == nil {
 		return result, nil
@@ -143,7 +146,8 @@ func QueryLogContentForKey(id int64, apiKey string) (LogContentResult, error) {
 
 	var fallback LogContentResult
 	err = db.QueryRow(
-		"SELECT id, model, input_content, output_content FROM request_logs WHERE id = ? AND api_key = ?", id, apiKey,
+		"SELECT id, model, input_content, output_content FROM request_logs WHERE id = ? AND "+predicate,
+		queryArgs...,
 	).Scan(&fallback.ID, &fallback.Model, &fallback.InputContent, &fallback.OutputContent)
 	if err != nil {
 		return LogContentResult{}, fmt.Errorf("usage: query log content: %w", err)
@@ -170,6 +174,9 @@ func QueryLogContentPartForKey(id int64, apiKey string, part string) (LogContent
 	} else if part == "details" {
 		column = "detail_content"
 	}
+	clause, args := buildSingleAPIKeySelectorClause(apiKey)
+	predicate := strings.TrimPrefix(clause, " WHERE ")
+	queryArgs := append([]interface{}{id}, args...)
 
 	result, err := queryCompressedLogContentPart(
 		db,
@@ -178,10 +185,11 @@ func QueryLogContentPartForKey(id int64, apiKey string, part string) (LogContent
 			`SELECT logs.id, logs.model, content.compression, content.%s
 			 FROM request_logs logs
 			 JOIN request_log_content content ON content.log_id = logs.id
-			 WHERE logs.id = ? AND logs.api_key = ?`,
+			 WHERE logs.id = ? AND %s`,
 			column,
+			predicate,
 		),
-		id, apiKey,
+		queryArgs...,
 	)
 	if err == nil {
 		return result, nil
@@ -189,7 +197,7 @@ func QueryLogContentPartForKey(id int64, apiKey string, part string) (LogContent
 	if part == "details" {
 		var fallback LogContentPartResult
 		fallback.Part = part
-		err = db.QueryRow("SELECT id, model FROM request_logs WHERE id = ? AND api_key = ?", id, apiKey).Scan(&fallback.ID, &fallback.Model)
+		err = db.QueryRow("SELECT id, model FROM request_logs WHERE id = ? AND "+predicate, queryArgs...).Scan(&fallback.ID, &fallback.Model)
 		if err != nil {
 			return LogContentPartResult{}, fmt.Errorf("usage: query log content part: %w", err)
 		}
@@ -199,8 +207,8 @@ func QueryLogContentPartForKey(id int64, apiKey string, part string) (LogContent
 	var fallback LogContentPartResult
 	fallback.Part = part
 	err = db.QueryRow(
-		fmt.Sprintf("SELECT id, model, %s FROM request_logs WHERE id = ? AND api_key = ?", column),
-		id, apiKey,
+		fmt.Sprintf("SELECT id, model, %s FROM request_logs WHERE id = ? AND %s", column, predicate),
+		queryArgs...,
 	).Scan(&fallback.ID, &fallback.Model, &fallback.Content)
 	if err != nil {
 		return LogContentPartResult{}, fmt.Errorf("usage: query log content part: %w", err)

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -107,7 +107,7 @@ func QueryFilters(days int) (FilterOptions, error) {
 
 	cutoff := CutoffStartUTC(days).Format(time.RFC3339)
 
-	keys, err := queryDistinct(db, "api_key", cutoff)
+	keys, keyNames, err := queryDistinctAPIKeys(db, cutoff)
 	if err != nil {
 		return FilterOptions{}, err
 	}
@@ -122,7 +122,7 @@ func QueryFilters(days int) (FilterOptions, error) {
 
 	return FilterOptions{
 		APIKeys:     keys,
-		APIKeyNames: make(map[string]string),
+		APIKeyNames: keyNames,
 		Models:      models,
 		Channels:    channels,
 	}, nil
@@ -176,11 +176,12 @@ func DeleteLogsByAPIKey(apiKey string) (int64, error) {
 
 	// Delete associated content rows first (FK cascade may handle this,
 	// but be explicit to ensure cleanup even without FK enforcement).
+	clause, args := buildSingleAPIKeySelectorClause(apiKey)
 	_, _ = db.Exec(
 		`DELETE FROM request_log_content WHERE log_id IN
-		 (SELECT id FROM request_logs WHERE api_key = ?)`, apiKey)
+		 (SELECT id FROM request_logs`+clause+`)`, args...)
 
-	result, err := db.Exec("DELETE FROM request_logs WHERE api_key = ?", apiKey)
+	result, err := db.Exec("DELETE FROM request_logs"+clause, args...)
 	if err != nil {
 		return 0, fmt.Errorf("usage: delete logs by api_key: %w", err)
 	}
@@ -416,12 +417,11 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 			}
 		}
 		if len(normalKeys) > 0 {
-			placeholders := make([]string, 0, len(normalKeys))
 			for _, k := range normalKeys {
-				placeholders = append(placeholders, "?")
-				args = append(args, k)
+				clause, clauseArgs := buildSingleAPIKeySelectorClause(k)
+				apiKeyConds = append(apiKeyConds, strings.TrimPrefix(clause, " WHERE "))
+				args = append(args, clauseArgs...)
 			}
-			apiKeyConds = append(apiKeyConds, "api_key IN ("+strings.Join(placeholders, ",")+")")
 		}
 		apiKeyConds = append(apiKeyConds, systemConds...)
 		if len(apiKeyConds) == 1 {
@@ -547,6 +547,78 @@ func queryDistinct(db *sql.DB, column, cutoff string) ([]string, error) {
 	return result, nil
 }
 
+func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]string, error) {
+	currentByID := currentAPIKeyRowsByID()
+	rows, err := db.Query(`
+		SELECT
+			CASE
+				WHEN trim(coalesce(api_key_id, '')) <> '' THEN api_key_id
+				ELSE 'raw:' || api_key
+			END AS logical_selector,
+			MAX(NULLIF(trim(coalesce(api_key_id, '')), '')) AS logical_id,
+			MAX(api_key) AS snapshot_key,
+			COALESCE(NULLIF(MAX(api_key_name), ''), '') AS snapshot_name
+		FROM request_logs
+		WHERE timestamp >= ? AND api_key != ''
+		GROUP BY logical_selector
+		ORDER BY logical_selector
+	`, cutoff)
+	if err != nil {
+		return nil, nil, fmt.Errorf("usage: distinct api_key logical groups: %w", err)
+	}
+	defer rows.Close()
+
+	values := make([]string, 0)
+	names := make(map[string]string)
+	seen := make(map[string]struct{})
+	for rows.Next() {
+		var logicalSelector string
+		var logicalID string
+		var snapshotKey string
+		var snapshotName string
+		if err := rows.Scan(&logicalSelector, &logicalID, &snapshotKey, &snapshotName); err != nil {
+			return nil, nil, err
+		}
+
+		value := strings.TrimSpace(snapshotKey)
+		name := strings.TrimSpace(snapshotName)
+		if row, ok := currentByID[strings.TrimSpace(logicalID)]; ok {
+			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
+				value = trimmed
+			}
+			if trimmed := strings.TrimSpace(row.Name); trimmed != "" {
+				name = trimmed
+			}
+		}
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			if name != "" {
+				names[value] = name
+			}
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+		if name != "" {
+			names[value] = name
+		}
+	}
+	return values, names, rows.Err()
+}
+
+func buildSingleAPIKeySelectorClause(selector string) (string, []interface{}) {
+	trimmed := strings.TrimSpace(selector)
+	if trimmed == "" {
+		return "", nil
+	}
+	if identity := ResolveAPIKeyIdentity(trimmed); identity != nil {
+		return " WHERE (api_key_id = ? OR (trim(coalesce(api_key_id, '')) = '' AND api_key = ?))", []interface{}{identity.ID, identity.Key}
+	}
+	return " WHERE api_key = ?", []interface{}{trimmed}
+}
+
 // QueryModelsForKey returns the distinct models used by a specific API key within the time range.
 func QueryModelsForKey(apiKey string, days int) ([]string, error) {
 	db := getDB()
@@ -556,11 +628,11 @@ func QueryModelsForKey(apiKey string, days int) ([]string, error) {
 	if days < 1 {
 		days = 7
 	}
-	cutoff := CutoffStartUTC(days).Format(time.RFC3339)
-
+	params := LogQueryParams{APIKey: apiKey, Days: days}
+	where, args := buildWhereClause(params)
 	rows, err := db.Query(
-		"SELECT DISTINCT model FROM request_logs WHERE api_key = ? AND timestamp >= ? AND model != '' ORDER BY model",
-		apiKey, cutoff,
+		"SELECT DISTINCT model FROM request_logs"+where+" AND model != '' ORDER BY model",
+		args...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("usage: distinct models for key: %w", err)

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -118,14 +118,21 @@ func QueryAPIKeyDistribution(days int) ([]APIKeyDistributionPoint, error) {
 
 	params := LogQueryParams{Days: days}
 	where, args := buildWhereClause(params)
+	currentByID := currentAPIKeyRowsByID()
 
-	q := `SELECT api_key,
-	             COALESCE(NULLIF(MAX(api_key_name),''), '') as name,
+	q := `SELECT
+	             CASE
+	               WHEN trim(coalesce(api_key_id, '')) <> '' THEN api_key_id
+	               ELSE 'raw:' || api_key
+	             END as logical_selector,
+	             MAX(NULLIF(trim(coalesce(api_key_id, '')), '')) as logical_id,
+	             MAX(api_key) as snapshot_key,
+	             COALESCE(NULLIF(MAX(api_key_name),''), '') as snapshot_name,
 	             COUNT(*) as reqs,
 	             COALESCE(SUM(total_tokens),0)
 	      FROM request_logs` + where + `
 	      AND api_key != ''
-	      GROUP BY api_key ORDER BY reqs DESC`
+	      GROUP BY logical_selector ORDER BY reqs DESC`
 
 	rows, err := db.Query(q, args...)
 	if err != nil {
@@ -135,9 +142,26 @@ func QueryAPIKeyDistribution(days int) ([]APIKeyDistributionPoint, error) {
 
 	var result []APIKeyDistributionPoint
 	for rows.Next() {
+		var logicalSelector string
+		var logicalID string
+		var snapshotKey string
+		var snapshotName string
 		var p APIKeyDistributionPoint
-		if err := rows.Scan(&p.APIKey, &p.Name, &p.Requests, &p.Tokens); err != nil {
+		if err := rows.Scan(&logicalSelector, &logicalID, &snapshotKey, &snapshotName, &p.Requests, &p.Tokens); err != nil {
 			return nil, fmt.Errorf("usage: apikey distribution scan: %w", err)
+		}
+		p.APIKey = strings.TrimSpace(snapshotKey)
+		p.Name = strings.TrimSpace(snapshotName)
+		if row, ok := currentByID[strings.TrimSpace(logicalID)]; ok {
+			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
+				p.APIKey = trimmed
+			}
+			if trimmed := strings.TrimSpace(row.Name); trimmed != "" {
+				p.Name = trimmed
+			}
+		}
+		if p.APIKey == "" {
+			continue
 		}
 		result = append(result, p)
 	}
@@ -180,8 +204,13 @@ func QueryHourlySeries(apiKey string, hours int) ([]HourlyTokenPoint, []HourlyMo
 	conditions := []string{"timestamp >= ?"}
 	args := []interface{}{cutoff}
 	if apiKey != "" {
-		conditions = append(conditions, "api_key = ?")
-		args = append(args, apiKey)
+		if identity := ResolveAPIKeyIdentity(apiKey); identity != nil {
+			conditions = append(conditions, "(api_key_id = ? OR (trim(coalesce(api_key_id, '')) = '' AND api_key = ?))")
+			args = append(args, identity.ID, identity.Key)
+		} else {
+			conditions = append(conditions, "api_key = ?")
+			args = append(args, apiKey)
+		}
 	}
 	where := " WHERE " + strings.Join(conditions, " AND ")
 

--- a/internal/usage/request_log_storage_stats.go
+++ b/internal/usage/request_log_storage_stats.go
@@ -84,10 +84,12 @@ func CountTodayByKey(apiKey string) (int64, error) {
 	if db == nil {
 		return 0, nil
 	}
+	clause, args := buildSingleAPIKeySelectorClause(apiKey)
 	var count int64
+	queryArgs := append(args, CutoffStartUTC(1).Format(time.RFC3339))
 	err := db.QueryRow(
-		"SELECT COUNT(*) FROM request_logs WHERE api_key = ? AND timestamp >= ?",
-		apiKey, CutoffStartUTC(1).Format(time.RFC3339),
+		"SELECT COUNT(*) FROM request_logs"+clause+" AND timestamp >= ?",
+		queryArgs...,
 	).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("usage: count today: %w", err)
@@ -101,11 +103,9 @@ func CountTotalByKey(apiKey string) (int64, error) {
 	if db == nil {
 		return 0, nil
 	}
+	clause, args := buildSingleAPIKeySelectorClause(apiKey)
 	var count int64
-	err := db.QueryRow(
-		"SELECT COUNT(*) FROM request_logs WHERE api_key = ?",
-		apiKey,
-	).Scan(&count)
+	err := db.QueryRow("SELECT COUNT(*) FROM request_logs"+clause, args...).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("usage: count total: %w", err)
 	}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -115,6 +115,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
   id               INTEGER PRIMARY KEY AUTOINCREMENT,
   timestamp        DATETIME NOT NULL,
   api_key          TEXT NOT NULL DEFAULT '',
+  api_key_id       TEXT NOT NULL DEFAULT '',
   model            TEXT NOT NULL DEFAULT '',
   source           TEXT NOT NULL DEFAULT '',
   channel_name     TEXT NOT NULL DEFAULT '',
@@ -213,6 +214,18 @@ func migrateApiKeyNameColumn(db *sql.DB) {
 	}
 }
 
+func migrateAPIKeyIDColumn(db *sql.DB) {
+	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN api_key_id TEXT NOT NULL DEFAULT ''")
+	if err != nil {
+		if !strings.Contains(err.Error(), "duplicate") {
+			log.Warnf("usage: migrate column api_key_id: %v", err)
+		}
+	}
+	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_logs_api_key_id ON request_logs(api_key_id)"); err != nil {
+		log.Warnf("usage: create idx_logs_api_key_id: %v", err)
+	}
+}
+
 // migrateFirstTokenColumn adds first_token_ms column to an existing request_logs table.
 func migrateFirstTokenColumn(db *sql.DB) {
 	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN first_token_ms INTEGER NOT NULL DEFAULT 0")
@@ -297,6 +310,8 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	migrateCostColumn(db)
 	log.Debugf("usage: running api_key_name column migration")
 	migrateApiKeyNameColumn(db)
+	log.Debugf("usage: running api_key_id column migration")
+	migrateAPIKeyIDColumn(db)
 	log.Debugf("usage: running first_token_ms column migration")
 	migrateFirstTokenColumn(db)
 	log.Debugf("usage: running request log detail column migration")
@@ -307,6 +322,8 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	initModelConfigTables(db)
 	log.Debugf("usage: initializing api_keys table")
 	initAPIKeysTable(db)
+	log.Debugf("usage: backfilling request log api_key_id values")
+	backfillRequestLogAPIKeyIDs(db)
 	log.Debugf("usage: initializing api_key_permission_profiles table")
 	initAPIKeyPermissionProfilesTable(db)
 	log.Debugf("usage: initializing ccswitch_import_configs table")
@@ -366,6 +383,14 @@ func insertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	// Calculate cost based on model pricing using semantic cache read/write
 	cost := CalculateCostV2(model, tokens)
 
+	apiKeyID := ""
+	if identity := ResolveAPIKeyIdentity(apiKey); identity != nil {
+		apiKeyID = identity.ID
+		if apiKeyName == "" {
+			apiKeyName = identity.Name
+		}
+	}
+
 	// 插入 request log 的事务由 usage 存储层统一拥有，不从外部 HTTP 请求透传 context，
 	// 以避免请求取消把已经选定要持久化的审计记录中断在半途。
 	tx, err := db.BeginTx(context.Background(), nil)
@@ -376,11 +401,11 @@ func insertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 
 	result, err := tx.Exec(
 		`INSERT INTO request_logs
-			(timestamp, api_key, api_key_name, model, source, channel_name, auth_index,
+			(timestamp, api_key, api_key_id, api_key_name, model, source, channel_name, auth_index,
 			 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		timestamp.UTC().Format(time.RFC3339Nano),
-		apiKey, apiKeyName, model, source, channelName, authIndex,
+		apiKey, apiKeyID, apiKeyName, model, source, channelName, authIndex,
 		failedInt, latencyMs, firstTokenMs,
 		tokens.InputTokens, tokens.OutputTokens, tokens.ReasoningTokens,
 		tokens.CachedTokens, tokens.TotalTokens, cost,

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1077,6 +1077,37 @@ func TestDeleteLogsByAPIKeyRemovesLogsAndContent(t *testing.T) {
 	}
 }
 
+func TestBackfillRequestLogAPIKeyIDsUsesUniqueAPIKeyName(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	if err := UpsertAPIKey(APIKeyRow{ID: "stable-key-1", Key: "sk-current", Name: "袁蔚"}); err != nil {
+		t.Fatalf("UpsertAPIKey(sk-current): %v", err)
+	}
+
+	db := getDB()
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, api_key_name, model, source, channel_name, auth_index,
+			 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		timestamp, "sk-legacy", "袁蔚", "gpt-test", "source", "channel", "auth-1",
+		0, 123, 45, 10, 20, 0, 0, 30, 0,
+	); err != nil {
+		t.Fatalf("insert legacy request_log: %v", err)
+	}
+
+	backfillRequestLogAPIKeyIDs(db)
+
+	var apiKeyID string
+	if err := db.QueryRow("SELECT api_key_id FROM request_logs WHERE api_key = ?", "sk-legacy").Scan(&apiKeyID); err != nil {
+		t.Fatalf("query api_key_id: %v", err)
+	}
+	if apiKeyID != "stable-key-1" {
+		t.Fatalf("api_key_id = %q, want stable-key-1", apiKeyID)
+	}
+}
+
 func TestClearAllRequestLogsRemovesRequestLogTablesOnly(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,


### PR DESCRIPTION
## Summary
- add stable ids for api key rows and use them for update/delete flows
- backfill and persist api_key_id across request-log and usage queries
- extend cleanup and management tests around api key identity handling

## Verification
- rtk go test ./internal/api/handlers/management ./internal/management/settings/apikey ./internal/storage/sqlite/apikey ./internal/usage