### PR TITLE
fix: tolerate legacy request-log api key groups

### DIFF
--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -555,7 +555,7 @@ func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]strin
 				WHEN trim(coalesce(api_key_id, '')) <> '' THEN api_key_id
 				ELSE 'raw:' || api_key
 			END AS logical_selector,
-			MAX(NULLIF(trim(coalesce(api_key_id, '')), '')) AS logical_id,
+			COALESCE(MAX(NULLIF(trim(coalesce(api_key_id, '')), '')), '') AS logical_id,
 			MAX(api_key) AS snapshot_key,
 			COALESCE(NULLIF(MAX(api_key_name), ''), '') AS snapshot_name
 		FROM request_logs
@@ -573,7 +573,7 @@ func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]strin
 	seen := make(map[string]struct{})
 	for rows.Next() {
 		var logicalSelector string
-		var logicalID string
+		var logicalID sql.NullString
 		var snapshotKey string
 		var snapshotName string
 		if err := rows.Scan(&logicalSelector, &logicalID, &snapshotKey, &snapshotName); err != nil {
@@ -582,7 +582,7 @@ func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]strin
 
 		value := strings.TrimSpace(snapshotKey)
 		name := strings.TrimSpace(snapshotName)
-		if row, ok := currentByID[strings.TrimSpace(logicalID)]; ok {
+		if row, ok := currentByID[trimNullString(logicalID)]; ok {
 			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
 				value = trimmed
 			}
@@ -606,6 +606,13 @@ func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]strin
 		}
 	}
 	return values, names, rows.Err()
+}
+
+func trimNullString(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return strings.TrimSpace(value.String)
 }
 
 func buildSingleAPIKeySelectorClause(selector string) (string, []interface{}) {

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -125,7 +126,7 @@ func QueryAPIKeyDistribution(days int) ([]APIKeyDistributionPoint, error) {
 	               WHEN trim(coalesce(api_key_id, '')) <> '' THEN api_key_id
 	               ELSE 'raw:' || api_key
 	             END as logical_selector,
-	             MAX(NULLIF(trim(coalesce(api_key_id, '')), '')) as logical_id,
+	             COALESCE(MAX(NULLIF(trim(coalesce(api_key_id, '')), '')), '') as logical_id,
 	             MAX(api_key) as snapshot_key,
 	             COALESCE(NULLIF(MAX(api_key_name),''), '') as snapshot_name,
 	             COUNT(*) as reqs,
@@ -143,7 +144,7 @@ func QueryAPIKeyDistribution(days int) ([]APIKeyDistributionPoint, error) {
 	var result []APIKeyDistributionPoint
 	for rows.Next() {
 		var logicalSelector string
-		var logicalID string
+		var logicalID sql.NullString
 		var snapshotKey string
 		var snapshotName string
 		var p APIKeyDistributionPoint
@@ -152,7 +153,7 @@ func QueryAPIKeyDistribution(days int) ([]APIKeyDistributionPoint, error) {
 		}
 		p.APIKey = strings.TrimSpace(snapshotKey)
 		p.Name = strings.TrimSpace(snapshotName)
-		if row, ok := currentByID[strings.TrimSpace(logicalID)]; ok {
+		if row, ok := currentByID[trimNullString(logicalID)]; ok {
 			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
 				p.APIKey = trimmed
 			}

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1108,6 +1108,51 @@ func TestBackfillRequestLogAPIKeyIDsUsesUniqueAPIKeyName(t *testing.T) {
 	}
 }
 
+func TestQueryAPIKeySelectorsHandleLegacyRowsWithoutAPIKeyID(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	db := getDB()
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, api_key_name, model, source, channel_name, auth_index,
+			 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		timestamp, "sk-legacy", "袁蔚", "gpt-test", "source", "channel", "auth-1",
+		0, 123, 45, 10, 20, 0, 0, 30, 0,
+	); err != nil {
+		t.Fatalf("insert legacy request_log: %v", err)
+	}
+
+	filters, err := QueryFilters(7)
+	if err != nil {
+		t.Fatalf("QueryFilters() error = %v", err)
+	}
+	if len(filters.APIKeys) != 1 || filters.APIKeys[0] != "sk-legacy" {
+		t.Fatalf("filters.APIKeys = %#v, want [sk-legacy]", filters.APIKeys)
+	}
+	if filters.APIKeyNames["sk-legacy"] != "袁蔚" {
+		t.Fatalf("filters.APIKeyNames[sk-legacy] = %q, want 袁蔚", filters.APIKeyNames["sk-legacy"])
+	}
+
+	dist, err := QueryAPIKeyDistribution(7)
+	if err != nil {
+		t.Fatalf("QueryAPIKeyDistribution() error = %v", err)
+	}
+	if len(dist) != 1 {
+		t.Fatalf("distribution len = %d, want 1: %#v", len(dist), dist)
+	}
+	if dist[0].APIKey != "sk-legacy" {
+		t.Fatalf("distribution api_key = %q, want sk-legacy", dist[0].APIKey)
+	}
+	if dist[0].Name != "袁蔚" {
+		t.Fatalf("distribution name = %q, want 袁蔚", dist[0].Name)
+	}
+	if dist[0].Requests != 1 || dist[0].Tokens != 30 {
+		t.Fatalf("distribution point = %#v, want one request and 30 tokens", dist[0])
+	}
+}
+
 func TestClearAllRequestLogsRemovesRequestLogTablesOnly(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,


### PR DESCRIPTION
## Summary
- tolerate legacy request-log groups whose `api_key_id` is still NULL
- guard both request-log filters and api-key distribution queries
- add regression coverage for legacy rows without stable api key ids

## Testing
- rtk go test ./internal/usage -count=1 -timeout 90s
- rtk go test ./internal/api/handlers/management -count=1 -timeout 90s