### PR TITLE
fix: preserve stable api key identity in request logs

### DIFF
--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -9,8 +9,9 @@ import (
 	"sync"
 	"time"
 
+	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
-	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -22,6 +23,8 @@ type usageReporter struct {
 	authID      string
 	authIndex   string
 	apiKey      string
+	apiKeyID    string
+	apiKeyName  string
 	source      string
 	channelName string
 	requestedAt time.Time
@@ -45,6 +48,10 @@ func newUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 		apiKey:      apiKey,
 		source:      resolveUsageSource(auth, apiKey),
 	}
+	if identity := internalusage.ResolveAPIKeyIdentity(apiKey); identity != nil {
+		reporter.apiKeyID = identity.ID
+		reporter.apiKeyName = identity.Name
+	}
 	if auth != nil {
 		reporter.authID = auth.ID
 		reporter.authIndex = auth.EnsureIndex()
@@ -53,11 +60,11 @@ func newUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 	return reporter
 }
 
-func (r *usageReporter) publish(ctx context.Context, detail usage.Detail) {
+func (r *usageReporter) publish(ctx context.Context, detail coreusage.Detail) {
 	r.publishWithOutcome(ctx, detail, false)
 }
 
-func (r *usageReporter) publishWithContent(ctx context.Context, detail usage.Detail, inputContent, outputContent string) {
+func (r *usageReporter) publishWithContent(ctx context.Context, detail coreusage.Detail, inputContent, outputContent string) {
 	r.inputContent = inputContent
 	r.outputContent = outputContent
 	r.publishWithOutcome(ctx, detail, false)
@@ -106,7 +113,7 @@ func (r *usageReporter) appendOutputChunk(chunk []byte) {
 }
 
 func (r *usageReporter) publishFailure(ctx context.Context) {
-	r.publishWithOutcome(ctx, usage.Detail{}, true)
+	r.publishWithOutcome(ctx, coreusage.Detail{}, true)
 }
 
 // publishFailureWithContent records a failed request together with the
@@ -123,7 +130,7 @@ func (r *usageReporter) publishFailureWithContent(ctx context.Context, inputCont
 	r.inputContent = inputContent
 	r.outputContent = outputContent
 	r.contentMu.Unlock()
-	r.publishWithOutcome(ctx, usage.Detail{}, true)
+	r.publishWithOutcome(ctx, coreusage.Detail{}, true)
 }
 
 func (r *usageReporter) trackFailure(ctx context.Context, errPtr *error) {
@@ -190,7 +197,7 @@ func parseStructuredUpstreamBody(body string) any {
 	return body
 }
 
-func (r *usageReporter) publishWithOutcome(ctx context.Context, detail usage.Detail, failed bool) {
+func (r *usageReporter) publishWithOutcome(ctx context.Context, detail coreusage.Detail, failed bool) {
 	if r == nil {
 		return
 	}
@@ -210,12 +217,14 @@ func (r *usageReporter) publishWithOutcome(ctx context.Context, detail usage.Det
 			latencyMs = 0
 		}
 		firstTokenMs := firstTokenLatencyMsFromContext(ctx, r.requestedAt)
-		usage.PublishRecord(ctx, usage.Record{
+		coreusage.PublishRecord(ctx, coreusage.Record{
 			Provider:      r.provider,
 			Model:         r.model,
 			Source:        r.source,
 			ChannelName:   r.channelName,
 			APIKey:        r.apiKey,
+			APIKeyID:      r.apiKeyID,
+			APIKeyName:    r.apiKeyName,
 			AuthID:        r.authID,
 			AuthIndex:     r.authIndex,
 			RequestedAt:   r.requestedAt,
@@ -245,19 +254,21 @@ func (r *usageReporter) ensurePublished(ctx context.Context) {
 			latencyMs = 0
 		}
 		firstTokenMs := firstTokenLatencyMsFromContext(ctx, r.requestedAt)
-		usage.PublishRecord(ctx, usage.Record{
+		coreusage.PublishRecord(ctx, coreusage.Record{
 			Provider:      r.provider,
 			Model:         r.model,
 			Source:        r.source,
 			ChannelName:   r.channelName,
 			APIKey:        r.apiKey,
+			APIKeyID:      r.apiKeyID,
+			APIKeyName:    r.apiKeyName,
 			AuthID:        r.authID,
 			AuthIndex:     r.authIndex,
 			RequestedAt:   r.requestedAt,
 			LatencyMs:     latencyMs,
 			FirstTokenMs:  firstTokenMs,
 			Failed:        false,
-			Detail:        usage.Detail{},
+			Detail:        coreusage.Detail{},
 			InputContent:  inputContent,
 			OutputContent: outputContent,
 			DetailContent: buildRequestDetailContent(ctx),

--- a/internal/usage/api_key_identity.go
+++ b/internal/usage/api_key_identity.go
@@ -72,6 +72,56 @@ func uniqueAPIKeyIDByNameFromRows(rows []APIKeyRow) map[string]string {
 	return result
 }
 
+func uniqueRequestLogAPIKeyIDByKeyFromDB(db *sql.DB) map[string]string {
+	if db == nil {
+		return nil
+	}
+
+	rows, err := db.Query(`
+		SELECT api_key, api_key_id
+		FROM request_logs
+		WHERE trim(coalesce(api_key, '')) <> ''
+		  AND trim(coalesce(api_key_id, '')) <> ''
+	`)
+	if err != nil {
+		log.Warnf("usage: query unique request_log api_key_id by raw key failed: %v", err)
+		return nil
+	}
+	defer rows.Close()
+
+	conflicts := make(map[string]bool)
+	ids := make(map[string]string)
+	for rows.Next() {
+		var rawKey string
+		var rawID string
+		if err := rows.Scan(&rawKey, &rawID); err != nil {
+			log.Warnf("usage: scan request_log api_key identity row failed: %v", err)
+			return nil
+		}
+		key := strings.TrimSpace(rawKey)
+		id := strings.TrimSpace(rawID)
+		if key == "" || id == "" {
+			continue
+		}
+		if existing, ok := ids[key]; ok {
+			if existing != id {
+				conflicts[key] = true
+				continue
+			}
+		} else {
+			ids[key] = id
+		}
+	}
+
+	result := make(map[string]string)
+	for key, id := range ids {
+		if !conflicts[key] {
+			result[key] = id
+		}
+	}
+	return result
+}
+
 func backfillRequestLogAPIKeyIDs(db *sql.DB) {
 	if db == nil {
 		return
@@ -114,6 +164,26 @@ func backfillRequestLogAPIKeyIDs(db *sql.DB) {
 		}
 		if rows, rowsErr := result.RowsAffected(); rowsErr == nil && rows > 0 {
 			log.Infof("usage: backfilled api_key_id for %d request_logs by unique api_key_name=%q", rows, lowerName)
+		}
+	}
+
+	keyToID := uniqueRequestLogAPIKeyIDByKeyFromDB(db)
+	if len(keyToID) == 0 {
+		return
+	}
+	for rawKey, id := range keyToID {
+		result, err := db.Exec(`
+			UPDATE request_logs
+			SET api_key_id = ?
+			WHERE trim(coalesce(api_key_id, '')) = ''
+			  AND trim(coalesce(api_key, '')) = ?
+		`, id, rawKey)
+		if err != nil {
+			log.Warnf("usage: backfill request_logs api_key_id by historical raw key failed for %q: %v", rawKey, err)
+			continue
+		}
+		if rows, rowsErr := result.RowsAffected(); rowsErr == nil && rows > 0 {
+			log.Infof("usage: backfilled api_key_id for %d request_logs by historical raw api_key=%q", rows, rawKey)
 		}
 	}
 }

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -353,14 +353,16 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 
 	// Persist request logs in the usage manager worker so SQLite writes stay
 	// serialized and do not spawn one goroutine per request.
-	// Look up the display name for this API key so it's persisted in the log.
-	apiKeyName := ""
-	if statsKey != "" {
+	// Use the request-start identity snapshot when available so key renames
+	// during in-flight requests do not orphan log records.
+	apiKeyID := strings.TrimSpace(record.APIKeyID)
+	apiKeyName := strings.TrimSpace(record.APIKeyName)
+	if apiKeyName == "" && statsKey != "" {
 		if row := GetAPIKey(statsKey); row != nil && row.Name != "" {
 			apiKeyName = row.Name
 		}
 	}
-	InsertLogWithDetails(statsKey, apiKeyName, modelName, record.Source, record.ChannelName,
+	InsertLogWithDetailsIdentity(statsKey, apiKeyID, apiKeyName, modelName, record.Source, record.ChannelName,
 		record.AuthIndex, failed, timestamp, record.LatencyMs, record.FirstTokenMs, detail,
 		record.InputContent, record.OutputContent, record.DetailContent)
 }

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -358,16 +358,22 @@ func CloseDB() {
 func InsertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent string) {
-	insertLog(apiKey, apiKeyName, model, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "")
+	insertLogIdentity(apiKey, "", apiKeyName, model, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "")
 }
 
 func InsertLogWithDetails(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLog(apiKey, apiKeyName, model, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, "", apiKeyName, model, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
 }
 
-func insertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
+func InsertLogWithDetailsIdentity(apiKey, apiKeyID, apiKeyName, model, source, channelName, authIndex string,
+	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
+	inputContent, outputContent, detailContent string) {
+	insertLogIdentity(apiKey, apiKeyID, apiKeyName, model, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+}
+
+func insertLogIdentity(apiKey, apiKeyID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
 	db := getDB()
@@ -383,9 +389,12 @@ func insertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	// Calculate cost based on model pricing using semantic cache read/write
 	cost := CalculateCostV2(model, tokens)
 
-	apiKeyID := ""
+	apiKeyID = strings.TrimSpace(apiKeyID)
+	apiKeyName = strings.TrimSpace(apiKeyName)
 	if identity := ResolveAPIKeyIdentity(apiKey); identity != nil {
-		apiKeyID = identity.ID
+		if apiKeyID == "" {
+			apiKeyID = identity.ID
+		}
 		if apiKeyName == "" {
 			apiKeyName = identity.Name
 		}

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"context"
 	"database/sql"
 	"math"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 )
 
 func makePseudoRandomText(size int) string {
@@ -1108,6 +1110,51 @@ func TestBackfillRequestLogAPIKeyIDsUsesUniqueAPIKeyName(t *testing.T) {
 	}
 }
 
+func TestBackfillRequestLogAPIKeyIDsUsesHistoricalRawKeyIdentity(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	if err := UpsertAPIKey(APIKeyRow{ID: "stable-key-1", Key: "sk-current", Name: "袁蔚"}); err != nil {
+		t.Fatalf("UpsertAPIKey(sk-current): %v", err)
+	}
+
+	db := getDB()
+	firstTS := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano)
+	secondTS := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, api_key_id, api_key_name, model, source, channel_name, auth_index,
+			 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		firstTS, "sk-legacy", "stable-key-1", "袁蔚", "gpt-test", "source", "channel", "auth-1",
+		0, 123, 45, 10, 20, 0, 0, 30, 0,
+	); err != nil {
+		t.Fatalf("insert resolved request_log: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, api_key_id, api_key_name, model, source, channel_name, auth_index,
+			 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		secondTS, "sk-legacy", "", "", "gpt-test", "source", "channel", "auth-1",
+		0, 123, 45, 10, 20, 0, 0, 30, 0,
+	); err != nil {
+		t.Fatalf("insert orphan request_log: %v", err)
+	}
+
+	backfillRequestLogAPIKeyIDs(db)
+
+	var apiKeyID string
+	if err := db.QueryRow(
+		"SELECT api_key_id FROM request_logs WHERE api_key = ? AND timestamp = ?",
+		"sk-legacy", secondTS,
+	).Scan(&apiKeyID); err != nil {
+		t.Fatalf("query orphan api_key_id: %v", err)
+	}
+	if apiKeyID != "stable-key-1" {
+		t.Fatalf("orphan api_key_id = %q, want stable-key-1", apiKeyID)
+	}
+}
+
 func TestQueryAPIKeySelectorsHandleLegacyRowsWithoutAPIKeyID(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 
@@ -1150,6 +1197,57 @@ func TestQueryAPIKeySelectorsHandleLegacyRowsWithoutAPIKeyID(t *testing.T) {
 	}
 	if dist[0].Requests != 1 || dist[0].Tokens != 30 {
 		t.Fatalf("distribution point = %#v, want one request and 30 tokens", dist[0])
+	}
+}
+
+func TestRequestStatisticsPersistsAPIKeyIdentitySnapshotAcrossRename(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	const stableID = "stable-key-1"
+	if err := UpsertAPIKey(APIKeyRow{ID: stableID, Key: "sk-old", Name: "袁蔚"}); err != nil {
+		t.Fatalf("UpsertAPIKey(sk-old): %v", err)
+	}
+	if err := UpdateAPIKeyByID(APIKeyRow{ID: stableID, Key: "sk-new", Name: "袁蔚"}); err != nil {
+		t.Fatalf("UpdateAPIKeyByID(sk-new): %v", err)
+	}
+
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "sk-old",
+		APIKeyID:    stableID,
+		APIKeyName:  "袁蔚",
+		Model:       "gpt-5.5",
+		Source:      "source",
+		ChannelName: "channel",
+		AuthIndex:   "auth-1",
+		RequestedAt: time.Now().UTC(),
+		Detail: coreusage.Detail{
+			InputTokens:  1,
+			OutputTokens: 2,
+			TotalTokens:  3,
+		},
+	})
+
+	filters, err := QueryFilters(7)
+	if err != nil {
+		t.Fatalf("QueryFilters() error = %v", err)
+	}
+	if len(filters.APIKeys) != 1 || filters.APIKeys[0] != "sk-new" {
+		t.Fatalf("filters.APIKeys = %#v, want [sk-new]", filters.APIKeys)
+	}
+	if filters.APIKeyNames["sk-new"] != "袁蔚" {
+		t.Fatalf("filters.APIKeyNames[sk-new] = %q, want 袁蔚", filters.APIKeyNames["sk-new"])
+	}
+
+	dist, err := QueryAPIKeyDistribution(7)
+	if err != nil {
+		t.Fatalf("QueryAPIKeyDistribution() error = %v", err)
+	}
+	if len(dist) != 1 || dist[0].APIKey != "sk-new" {
+		t.Fatalf("distribution = %#v, want one sk-new point", dist)
+	}
+	if dist[0].Name != "袁蔚" {
+		t.Fatalf("distribution name = %q, want 袁蔚", dist[0].Name)
 	}
 }
 

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -13,6 +13,8 @@ type Record struct {
 	Provider     string
 	Model        string
 	APIKey       string
+	APIKeyID     string
+	APIKeyName   string
 	AuthID       string
 	AuthIndex    string
 	Source       string


### PR DESCRIPTION
## Summary
- snapshot api key stable identity at request start and carry it through usage records
- persist request logs from the captured identity instead of re-resolving against mutable current config
- backfill orphan request logs by unique historical raw api key identity

## Testing
- rtk go test ./internal/usage -count=1 -timeout 120s
- rtk go test ./internal/api/handlers/management -count=1 -timeout 120s
- rtk go test ./internal/runtime/executor -count=1 -timeout 120s