### PR TITLE
fix: target deployed server in proxy latency checks

### DIFF
--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	defaultProxyCheckURL     = "https://www.gstatic.com/generate_204"
-	defaultProxyCheckTimeout = 8 * time.Second
+	defaultProxyCheckFallbackURL = "https://www.gstatic.com/generate_204"
+	defaultProxyCheckPublicPath  = "/v0/management/public/ping"
+	defaultProxyCheckTimeout     = 8 * time.Second
 )
 
 type proxyPoolAPIEntry struct {
@@ -93,7 +94,12 @@ func (h *Handler) PutProxyPool(c *gin.Context) {
 	h.persist(c)
 }
 
-// PostProxyPoolCheck checks whether a proxy can reach a test URL.
+// GetPublicPing returns a lightweight public 204 endpoint for proxy latency probes.
+func (h *Handler) GetPublicPing(c *gin.Context) {
+	c.Status(http.StatusNoContent)
+}
+
+// PostProxyPoolCheck checks whether a proxy can reach the deployed server.
 func (h *Handler) PostProxyPoolCheck(c *gin.Context) {
 	var body struct {
 		ID      string `json:"id"`
@@ -121,7 +127,7 @@ func (h *Handler) PostProxyPoolCheck(c *gin.Context) {
 
 	testURL := strings.TrimSpace(body.TestURL)
 	if testURL == "" {
-		testURL = defaultProxyCheckURL
+		testURL = defaultProxyCheckURL(c.Request)
 	}
 	if _, err := url.ParseRequestURI(testURL); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid test_url"})
@@ -145,12 +151,12 @@ func (h *Handler) PostProxyPoolCheck(c *gin.Context) {
 	}
 
 	ok := statusCode >= 200 && statusCode < 400
-	c.JSON(http.StatusOK, gin.H{
+	payload := gin.H{
 		"ok":         ok,
 		"statusCode": statusCode,
 		"latencyMs":  latencyMs,
-		"message":    fmt.Sprintf("status %d", statusCode),
-	})
+	}
+	c.JSON(http.StatusOK, payload)
 }
 
 func checkProxyConnectivity(ctx context.Context, proxyURL string, testURL string, sdkCfg *config.SDKConfig) (int, error) {
@@ -176,6 +182,37 @@ func checkProxyConnectivity(ctx context.Context, proxyURL string, testURL string
 	}()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
 	return resp.StatusCode, nil
+}
+
+func defaultProxyCheckURL(r *http.Request) string {
+	if r == nil {
+		return defaultProxyCheckFallbackURL
+	}
+
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if idx := strings.IndexByte(host, ','); idx >= 0 {
+		host = host[:idx]
+	}
+	if host == "" {
+		host = strings.TrimSpace(r.Host)
+	}
+	if host == "" {
+		return defaultProxyCheckFallbackURL
+	}
+
+	scheme := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+	if idx := strings.IndexByte(scheme, ','); idx >= 0 {
+		scheme = scheme[:idx]
+	}
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	return scheme + "://" + host + defaultProxyCheckPublicPath
 }
 
 func maskProxyPoolURL(raw string) string {

--- a/internal/api/handlers/management/proxy_pool_test.go
+++ b/internal/api/handlers/management/proxy_pool_test.go
@@ -129,6 +129,21 @@ func TestPostProxyPoolCheckUsesConfiguredProxy(t *testing.T) {
 	if !body.OK || body.StatusCode != http.StatusNoContent {
 		t.Fatalf("check response = %#v", body)
 	}
+	if body.Message != "" {
+		t.Fatalf("success message = %q, want empty", body.Message)
+	}
+}
+
+func TestDefaultProxyCheckURLPrefersForwardedOrigin(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodPost, "/proxy-pool/check", nil)
+	req.Host = "127.0.0.1:8080"
+	req.Header.Set("X-Forwarded-Host", "panel.example.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	if got, want := defaultProxyCheckURL(req), "https://panel.example.com/v0/management/public/ping"; got != want {
+		t.Fatalf("defaultProxyCheckURL = %q, want %q", got, want)
+	}
 }
 
 func TestProxyPoolHandlersUseSQLiteWhenAvailable(t *testing.T) {

--- a/internal/api/routes/management_public_routes.go
+++ b/internal/api/routes/management_public_routes.go
@@ -21,6 +21,7 @@ func registerPublicManagementRoutes(engine *gin.Engine, h *managementhandlers.Ha
 	pub.Use(publicMiddlewares...)
 	usageLogs := h.UsageLogs()
 	{
+		pub.GET("/ping", h.GetPublicPing)
 		pub.GET("/usage", h.GetPublicUsageByAPIKey)
 		pub.POST("/usage", h.GetPublicUsageByAPIKey)
 		pub.GET("/ccswitch-import-configs", h.GetPublicCcSwitchImportConfigs)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -24,7 +24,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 208; got != want {
+	if got, want := len(routes), 209; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 
@@ -41,6 +41,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"POST /v0/management/opencode-go-api-key/usage",
 		"GET /v0/management/auth-files/models",
 		"POST /v0/management/oauth-callback",
+		"GET /v0/management/public/ping",
 		"GET /v0/management/public/usage/logs/:id/content",
 		"POST /v0/management/public/usage/summary",
 	}


### PR DESCRIPTION
## Summary
- add a lightweight public ping endpoint for proxy latency probes
- make proxy pool checks target the current deployed server by default instead of gstatic
- stop returning a synthetic success message for HTTP 204 probe results

## Testing
- rtk go test ./internal/api/handlers/management ./internal/api/routes