### PR TITLE
fix: update proxy pool entries by stable id

### DIFF
--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -91,6 +92,82 @@ func (h *Handler) PutProxyPool(c *gin.Context) {
 	h.cfg.ProxyPool = normalized
 	h.mu.Unlock()
 
+	h.persist(c)
+}
+
+// PatchProxyPoolEntry updates one reusable proxy entry identified by its stable ID.
+func (h *Handler) PatchProxyPoolEntry(c *gin.Context) {
+	originalID := config.NormalizeProxyID(c.Param("id"))
+	if originalID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+
+	var body struct {
+		Name        *string `json:"name"`
+		URL         *string `json:"url"`
+		Enabled     *bool   `json:"enabled"`
+		Description *string `json:"description"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Name == nil || body.URL == nil || body.Enabled == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+
+	normalized := config.NormalizeProxyPool([]config.ProxyPoolEntry{{
+		ID:          originalID,
+		Name:        *body.Name,
+		URL:         *body.URL,
+		Enabled:     *body.Enabled,
+		Description: stringValue(body.Description),
+	}})
+	if len(normalized) != 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no valid proxy entries"})
+		return
+	}
+	updated := normalized[0]
+
+	if proxypoolsettings.StoreAvailable() {
+		if err := proxypoolsettings.Update(originalID, updated); err != nil {
+			if errors.Is(err, proxypoolsettings.ErrItemNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update proxy pool entry: %v", err)})
+			return
+		}
+		h.mu.Lock()
+		if h.cfg == nil {
+			h.cfg = &config.Config{}
+		}
+		h.cfg.ProxyPool = proxypoolsettings.List()
+		h.mu.Unlock()
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		return
+	}
+
+	h.mu.Lock()
+	if h.cfg == nil {
+		h.cfg = &config.Config{}
+	}
+	found := false
+	for i := range h.cfg.ProxyPool {
+		if config.NormalizeProxyID(h.cfg.ProxyPool[i].ID) != originalID {
+			continue
+		}
+		h.cfg.ProxyPool[i] = updated
+		found = true
+		break
+	}
+	if found {
+		h.cfg.ProxyPool = config.NormalizeProxyPool(h.cfg.ProxyPool)
+	}
+	h.mu.Unlock()
+
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
+		return
+	}
 	h.persist(c)
 }
 
@@ -225,4 +302,11 @@ func maskProxyPoolURL(raw string) string {
 		return "***"
 	}
 	return strings.ToLower(parsed.Scheme) + "://" + parsed.Host
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }

--- a/internal/api/handlers/management/proxy_pool_test.go
+++ b/internal/api/handlers/management/proxy_pool_test.go
@@ -88,6 +88,53 @@ func TestPutProxyPoolNormalizesAndPersists(t *testing.T) {
 	}
 }
 
+func TestPatchProxyPoolEntryUpdatesConfigWithoutAppending(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	initialConfig := "proxy-pool:\n  - id: hk\n    name: HK Proxy\n    url: http://127.0.0.1:7890\n    enabled: true\n"
+	if err := os.WriteFile(configPath, []byte(initialConfig), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	h := NewHandler(&config.Config{
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "hk", Name: "HK Proxy", URL: "http://127.0.0.1:7890", Enabled: true},
+		},
+	}, configPath, nil)
+	defer h.Close()
+
+	payload := []byte(`{"name":"Updated HK Proxy","url":"http://127.0.0.1:7891","enabled":false,"description":"rotated"}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "hk"}}
+	c.Request = httptest.NewRequest(http.MethodPatch, "/proxy-pool/hk", bytes.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchProxyPoolEntry(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if len(h.cfg.ProxyPool) != 1 {
+		t.Fatalf("proxy pool length = %d, want 1: %#v", len(h.cfg.ProxyPool), h.cfg.ProxyPool)
+	}
+	if h.cfg.ProxyPool[0].ID != "hk" || h.cfg.ProxyPool[0].Name != "Updated HK Proxy" || h.cfg.ProxyPool[0].URL != "http://127.0.0.1:7891" || h.cfg.ProxyPool[0].Enabled {
+		t.Fatalf("updated proxy pool = %#v", h.cfg.ProxyPool)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Count(string(data), "id: hk") != 1 {
+		t.Fatalf("expected exactly one hk proxy entry after patch:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "name: Updated HK Proxy") || !strings.Contains(string(data), "url: http://127.0.0.1:7891") {
+		t.Fatalf("persisted config missing updated values:\n%s", string(data))
+	}
+}
+
 func TestPostProxyPoolCheckUsesConfiguredProxy(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -191,6 +238,51 @@ func TestProxyPoolHandlersUseSQLiteWhenAvailable(t *testing.T) {
 		t.Fatalf("SQLite proxy pool = %#v", rows)
 	}
 	if len(h.cfg.ProxyPool) != 1 || h.cfg.ProxyPool[0].ID != "new" {
+		t.Fatalf("runtime proxy pool = %#v", h.cfg.ProxyPool)
+	}
+}
+
+func TestPatchProxyPoolEntryUsesSQLiteWhenAvailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := usageTestProxyPoolDB(t)
+	defer cleanup()
+
+	if err := usage.ReplaceProxyPool([]config.ProxyPoolEntry{
+		{ID: "db", Name: "DB Proxy", URL: "http://127.0.0.1:7890", Enabled: true},
+	}); err != nil {
+		t.Fatalf("ReplaceProxyPool: %v", err)
+	}
+
+	h := NewHandler(&config.Config{
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "yaml", Name: "YAML Proxy", URL: "http://127.0.0.1:8888", Enabled: true},
+		},
+	}, "", nil)
+	defer h.Close()
+
+	payload := []byte(`{"name":"Updated DB Proxy","url":"http://127.0.0.1:9001","enabled":false,"description":"rotated"}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "db"}}
+	c.Request = httptest.NewRequest(http.MethodPatch, "/proxy-pool/db", bytes.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchProxyPoolEntry(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	rows := usage.ListProxyPool()
+	if len(rows) != 1 {
+		t.Fatalf("SQLite proxy pool length = %d, want 1: %#v", len(rows), rows)
+	}
+	if rows[0].ID != "db" || rows[0].Name != "Updated DB Proxy" || rows[0].URL != "http://127.0.0.1:9001" || rows[0].Enabled {
+		t.Fatalf("SQLite proxy pool = %#v", rows)
+	}
+	if rows[0].Description != "rotated" {
+		t.Fatalf("SQLite description = %q, want rotated", rows[0].Description)
+	}
+	if len(h.cfg.ProxyPool) != 1 || h.cfg.ProxyPool[0].ID != "db" || h.cfg.ProxyPool[0].Name != "Updated DB Proxy" {
 		t.Fatalf("runtime proxy pool = %#v", h.cfg.ProxyPool)
 	}
 }

--- a/internal/api/routes/management_settings_routes.go
+++ b/internal/api/routes/management_settings_routes.go
@@ -47,6 +47,7 @@ func registerManagementSettingsRoutes(group *gin.RouterGroup, h *managementhandl
 	group.DELETE("/proxy-url", h.DeleteProxyURL)
 	group.GET("/proxy-pool", h.GetProxyPool)
 	group.PUT("/proxy-pool", h.PutProxyPool)
+	group.PATCH("/proxy-pool/:id", h.PatchProxyPoolEntry)
 	group.POST("/proxy-pool/check", h.PostProxyPoolCheck)
 
 	group.POST("/api-call", h.APITools().APICall)

--- a/internal/config/proxy_pool.go
+++ b/internal/config/proxy_pool.go
@@ -101,6 +101,12 @@ func (cfg *Config) ResolveProxyURL(proxyID string, fallbackURL string) string {
 	return ""
 }
 
+// NormalizeProxyID exposes the shared proxy ID normalization used by storage,
+// management handlers, and runtime resolution.
+func NormalizeProxyID(raw string) string {
+	return normalizeProxyID(raw)
+}
+
 func normalizeProxyID(raw string) string {
 	trimmed := strings.ToLower(strings.TrimSpace(raw))
 	if trimmed == "" {

--- a/internal/management/settings/proxypool/service.go
+++ b/internal/management/settings/proxypool/service.go
@@ -1,9 +1,14 @@
 package proxypool
 
 import (
+	"errors"
+
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	sqlproxypool "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/sqlite/proxypool"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
+
+var ErrItemNotFound = errors.New("item not found")
 
 func StoreAvailable() bool {
 	return usage.ProxyPoolStoreAvailable()
@@ -19,4 +24,12 @@ func Get(id string) *config.ProxyPoolEntry {
 
 func Replace(entries []config.ProxyPoolEntry) error {
 	return usage.ReplaceProxyPool(entries)
+}
+
+func Update(id string, entry config.ProxyPoolEntry) error {
+	err := usage.UpdateProxyPoolEntry(id, entry)
+	if errors.Is(err, sqlproxypool.ErrEntryNotFound) {
+		return ErrItemNotFound
+	}
+	return err
 }

--- a/internal/storage/sqlite/proxypool/store.go
+++ b/internal/storage/sqlite/proxypool/store.go
@@ -2,10 +2,9 @@ package proxypool
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
-	"unicode"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	log "github.com/sirupsen/logrus"
@@ -26,6 +25,8 @@ CREATE TABLE IF NOT EXISTS proxy_pool (
 type Store struct {
 	db *sql.DB
 }
+
+var ErrEntryNotFound = errors.New("proxy pool entry not found")
 
 type scanner interface {
 	Scan(dest ...any) error
@@ -78,7 +79,7 @@ func (s Store) Get(id string) *config.ProxyPoolEntry {
 		return nil
 	}
 
-	normalizedID := normalizeEntryID(id)
+	normalizedID := config.NormalizeProxyID(id)
 	if normalizedID == "" {
 		return nil
 	}
@@ -131,6 +132,44 @@ func (s Store) Replace(entries []config.ProxyPoolEntry) error {
 	return tx.Commit()
 }
 
+func (s Store) Update(id string, entry config.ProxyPoolEntry) error {
+	if s.db == nil {
+		return fmt.Errorf("database not initialised")
+	}
+
+	normalizedID := config.NormalizeProxyID(id)
+	if normalizedID == "" {
+		return ErrEntryNotFound
+	}
+
+	enabledInt := 0
+	if entry.Enabled {
+		enabledInt = 1
+	}
+	result, err := s.db.Exec(
+		`UPDATE proxy_pool
+		 SET name = ?, url = ?, enabled = ?, description = ?, updated_at = ?
+		 WHERE id = ?`,
+		entry.Name,
+		entry.URL,
+		enabledInt,
+		entry.Description,
+		time.Now().UTC().Format(time.RFC3339),
+		normalizedID,
+	)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrEntryNotFound
+	}
+	return nil
+}
+
 func (s Store) ApplyToConfig(cfg *config.Config) bool {
 	if s.db == nil || cfg == nil {
 		return false
@@ -175,25 +214,4 @@ func scanEntry(scanner scanner) (config.ProxyPoolEntry, bool) {
 	}
 	entry.Enabled = enabledInt != 0
 	return entry, true
-}
-
-func normalizeEntryID(raw string) string {
-	trimmed := strings.ToLower(strings.TrimSpace(raw))
-	if trimmed == "" {
-		return ""
-	}
-	var b strings.Builder
-	lastDash := false
-	for _, r := range trimmed {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			b.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash {
-			b.WriteByte('-')
-			lastDash = true
-		}
-	}
-	return strings.Trim(b.String(), "-")
 }

--- a/internal/usage/proxy_pool_db.go
+++ b/internal/usage/proxy_pool_db.go
@@ -40,6 +40,11 @@ func ReplaceProxyPool(entries []config.ProxyPoolEntry) error {
 	return proxyPoolStore().Replace(entries)
 }
 
+// UpdateProxyPoolEntry updates one reusable proxy identified by its stable ID.
+func UpdateProxyPoolEntry(id string, entry config.ProxyPoolEntry) error {
+	return proxyPoolStore().Update(id, entry)
+}
+
 // ApplyStoredProxyPool overlays the DB-backed proxy pool onto the runtime config.
 func ApplyStoredProxyPool(cfg *config.Config) bool {
 	if cfg == nil || !ProxyPoolStoreAvailable() {

--- a/internal/usage/proxy_pool_db_test.go
+++ b/internal/usage/proxy_pool_db_test.go
@@ -73,6 +73,42 @@ func TestProxyPoolReplaceListAndGet(t *testing.T) {
 	}
 }
 
+func TestProxyPoolUpdateByStableID(t *testing.T) {
+	cleanup := setupProxyPoolTestDB(t)
+	defer cleanup()
+
+	if err := ReplaceProxyPool([]config.ProxyPoolEntry{
+		{ID: "hk", Name: "HK Proxy", URL: "http://127.0.0.1:7890", Enabled: true, Description: "primary"},
+	}); err != nil {
+		t.Fatalf("ReplaceProxyPool: %v", err)
+	}
+
+	err := UpdateProxyPoolEntry(" HK ", config.ProxyPoolEntry{
+		ID:          "ignored-during-update",
+		Name:        "Updated HK Proxy",
+		URL:         "http://127.0.0.1:7891",
+		Enabled:     false,
+		Description: "rotated",
+	})
+	if err != nil {
+		t.Fatalf("UpdateProxyPoolEntry: %v", err)
+	}
+
+	rows := ListProxyPool()
+	if len(rows) != 1 {
+		t.Fatalf("ListProxyPool length = %d, want 1: %#v", len(rows), rows)
+	}
+	if rows[0].ID != "hk" {
+		t.Fatalf("updated proxy id = %q, want hk", rows[0].ID)
+	}
+	if rows[0].Name != "Updated HK Proxy" || rows[0].URL != "http://127.0.0.1:7891" || rows[0].Enabled {
+		t.Fatalf("updated proxy row = %#v", rows[0])
+	}
+	if rows[0].Description != "rotated" {
+		t.Fatalf("updated description = %q, want rotated", rows[0].Description)
+	}
+}
+
 func TestProxyPoolMigrationMovesConfigEntriesIntoSQLite(t *testing.T) {
 	cleanup := setupProxyPoolTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- add a single-item proxy pool patch API keyed by stable id
- update YAML and SQLite-backed proxy pool storage through the new update path
- add regression coverage for editing an existing proxy without appending a new row

## Testing
- rtk go test ./internal/api/handlers/management -run 'Test(Put|Patch|Get|Post|DefaultProxyCheckURL|ProxyPool)'\n- rtk go test ./internal/usage -run 'TestProxyPool'