### PR TITLE
fix: notify config mutation after sqlite proxy pool updates

### DIFF
--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -80,8 +80,10 @@ func (h *Handler) PutProxyPool(c *gin.Context) {
 			h.cfg = &config.Config{}
 		}
 		h.cfg.ProxyPool = proxypoolsettings.List()
+		cfgRef := h.cfg
 		h.mu.Unlock()
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		h.notifyConfigMutated(cfgRef)
 		return
 	}
 
@@ -141,8 +143,10 @@ func (h *Handler) PatchProxyPoolEntry(c *gin.Context) {
 			h.cfg = &config.Config{}
 		}
 		h.cfg.ProxyPool = proxypoolsettings.List()
+		cfgRef := h.cfg
 		h.mu.Unlock()
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		h.notifyConfigMutated(cfgRef)
 		return
 	}
 
@@ -309,4 +313,11 @@ func stringValue(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func (h *Handler) notifyConfigMutated(cfg *config.Config) {
+	if h == nil || h.onConfigMutated == nil {
+		return
+	}
+	h.onConfigMutated(cfg)
 }

--- a/internal/api/handlers/management/proxy_pool_test.go
+++ b/internal/api/handlers/management/proxy_pool_test.go
@@ -210,6 +210,14 @@ func TestProxyPoolHandlersUseSQLiteWhenAvailable(t *testing.T) {
 		},
 	}, "", nil)
 	defer h.Close()
+	var hookCalled bool
+	var hookProxyPool []config.ProxyPoolEntry
+	h.SetConfigMutatedHook(func(updated *config.Config) {
+		hookCalled = true
+		if updated != nil {
+			hookProxyPool = append([]config.ProxyPoolEntry(nil), updated.ProxyPool...)
+		}
+	})
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -240,6 +248,12 @@ func TestProxyPoolHandlersUseSQLiteWhenAvailable(t *testing.T) {
 	if len(h.cfg.ProxyPool) != 1 || h.cfg.ProxyPool[0].ID != "new" {
 		t.Fatalf("runtime proxy pool = %#v", h.cfg.ProxyPool)
 	}
+	if !hookCalled {
+		t.Fatal("config mutation hook was not called")
+	}
+	if len(hookProxyPool) != 1 || hookProxyPool[0].ID != "new" {
+		t.Fatalf("hook proxy pool = %#v", hookProxyPool)
+	}
 }
 
 func TestPatchProxyPoolEntryUsesSQLiteWhenAvailable(t *testing.T) {
@@ -259,6 +273,14 @@ func TestPatchProxyPoolEntryUsesSQLiteWhenAvailable(t *testing.T) {
 		},
 	}, "", nil)
 	defer h.Close()
+	var hookCalled bool
+	var hookProxyPool []config.ProxyPoolEntry
+	h.SetConfigMutatedHook(func(updated *config.Config) {
+		hookCalled = true
+		if updated != nil {
+			hookProxyPool = append([]config.ProxyPoolEntry(nil), updated.ProxyPool...)
+		}
+	})
 
 	payload := []byte(`{"name":"Updated DB Proxy","url":"http://127.0.0.1:9001","enabled":false,"description":"rotated"}`)
 	w := httptest.NewRecorder()
@@ -284,6 +306,12 @@ func TestPatchProxyPoolEntryUsesSQLiteWhenAvailable(t *testing.T) {
 	}
 	if len(h.cfg.ProxyPool) != 1 || h.cfg.ProxyPool[0].ID != "db" || h.cfg.ProxyPool[0].Name != "Updated DB Proxy" {
 		t.Fatalf("runtime proxy pool = %#v", h.cfg.ProxyPool)
+	}
+	if !hookCalled {
+		t.Fatal("config mutation hook was not called")
+	}
+	if len(hookProxyPool) != 1 || hookProxyPool[0].ID != "db" || hookProxyPool[0].Name != "Updated DB Proxy" {
+		t.Fatalf("hook proxy pool = %#v", hookProxyPool)
 	}
 }
 


### PR DESCRIPTION
## Summary
- notify `onConfigMutated` after SQLite-backed proxy pool replace succeeds
- notify `onConfigMutated` after SQLite-backed proxy pool patch succeeds
- add regression coverage for both SQLite write paths

## Testing
- rtk go test ./internal/api/handlers/management -run TestPostImageGenerationTestCreatesTaskAndPollsSucceededResult -count=1
- rtk go test ./internal/api/handlers/management -run "TestProxyPoolHandlersUseSQLiteWhenAvailable|TestPatchProxyPoolEntryUsesSQLiteWhenAvailable" -count=1
- rtk go test ./internal/api/handlers/management -count=1