### PR TITLE
test: update management route table coverage

### DIFF
--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -24,7 +24,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 209; got != want {
+	if got, want := len(routes), 210; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 
@@ -34,6 +34,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"GET /v0/management/model-configs",
 		"PUT /v0/management/model-configs/*id",
 		"PATCH /v0/management/auth-group-model-owner-mappings",
+		"PATCH /v0/management/proxy-pool/:id",
 		"GET /v0/management/usage/logs/:id/content",
 		"GET /v0/management/usage/logs/:id/egress",
 		"POST /v0/management/api-call",


### PR DESCRIPTION
## Summary
- update management route table count to include the new proxy pool patch route
- assert the stable proxy pool patch route is registered explicitly

## Validation
- rtk go test ./...
- rtk go build ./...
- rtk go test ./internal/api/routes