### PR TITLE
fix: prefer primary weekly quota cycle for auth trends

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -988,6 +988,235 @@ func TestGetAuthFileTrendKeepsWeeklyCycleAcrossCodexPlanRename(t *testing.T) {
 	}
 }
 
+func TestGetAuthFileTrendPrefersPrimaryCodeWeekOverAdditionalWeeklyCycle(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex-auth-file-primary-week",
+		FileName: "codex-user@example.com-pro.json",
+		Provider: "codex",
+		Label:    "user@example.com",
+		Metadata: map[string]any{
+			"email":      "user@example.com",
+			"account_id": "acct_same_user",
+			"plan_type":  "pro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	identity := usage.ResolveAuthSubjectIdentity(auth)
+	if identity == nil || identity.ID == "" {
+		t.Fatalf("ResolveAuthSubjectIdentity() returned empty identity: %+v", identity)
+	}
+
+	recordedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	codeResetAt := recordedAt.Add(4 * 24 * time.Hour)
+	codeCycleStart := codeResetAt.Add(-7 * 24 * time.Hour)
+	additionalResetAt := codeResetAt.Add(2 * time.Hour)
+	additionalCycleStart := additionalResetAt.Add(-7 * 24 * time.Hour)
+
+	if err := usage.UpsertModelPricing("gpt-5.4", 1, 2, 0); err != nil {
+		t.Fatalf("UpsertModelPricing: %v", err)
+	}
+
+	usage.InsertLogWithDetailsIdentitySubject("", "", identity.ID, "", "gpt-5.4", "user@example.com", "user@example.com", auth.Index, false, codeCycleStart.Add(-time.Hour), 1, 1, usage.TokenStats{
+		InputTokens:  1000,
+		OutputTokens: 2000,
+		TotalTokens:  3000,
+	}, "", "", "")
+	usage.InsertLogWithDetailsIdentitySubject("", "", identity.ID, "", "gpt-5.4", "user@example.com", "user@example.com", auth.Index, false, codeCycleStart.Add(30*time.Minute), 1, 1, usage.TokenStats{
+		InputTokens:  1000,
+		OutputTokens: 1000,
+		TotalTokens:  2000,
+	}, "", "", "")
+	usage.InsertLogWithDetailsIdentitySubject("", "", identity.ID, "", "gpt-5.4", "user@example.com", "user@example.com", auth.Index, false, additionalCycleStart.Add(30*time.Minute), 1, 1, usage.TokenStats{
+		InputTokens:  1000,
+		OutputTokens: 1000,
+		TotalTokens:  2000,
+	}, "", "", "")
+
+	codeRemaining := 99.0
+	additionalRemaining := 100.0
+	if err := usage.RecordQuotaSnapshotPointsIdentity(auth.Index, identity.ID, "codex", []usage.QuotaSnapshotPoint{
+		{
+			RecordedAt:    recordedAt,
+			QuotaKey:      "code_week",
+			QuotaLabel:    "m_quota.code_weekly",
+			Percent:       &codeRemaining,
+			ResetAt:       &codeResetAt,
+			WindowSeconds: 604800,
+		},
+		{
+			RecordedAt:    recordedAt,
+			QuotaKey:      "additional:codex_bengalfox:week",
+			QuotaLabel:    "GPT-5.3-Codex-Spark: Weekly",
+			Percent:       &additionalRemaining,
+			ResetAt:       &additionalResetAt,
+			WindowSeconds: 604800,
+		},
+	}); err != nil {
+		t.Fatalf("record quota snapshot point: %v", err)
+	}
+
+	h := &Handler{cfg: &config.Config{}, authManager: manager}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/auth-file-trend?auth_index="+auth.Index+"&days=7&hours=5", nil)
+
+	h.UsageLogs().GetAuthFileTrend(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		CycleKnown        bool    `json:"cycle_known"`
+		CycleStart        string  `json:"cycle_start"`
+		CycleRequestTotal int64   `json:"cycle_request_total"`
+		CycleCostTotal    float64 `json:"cycle_cost_total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !payload.CycleKnown {
+		t.Fatalf("cycle_known = false, want true")
+	}
+	if payload.CycleStart != codeCycleStart.Format(time.RFC3339) {
+		t.Fatalf("cycle_start = %q, want %q", payload.CycleStart, codeCycleStart.Format(time.RFC3339))
+	}
+	if payload.CycleRequestTotal != 2 {
+		t.Fatalf("cycle_request_total = %d, want 2", payload.CycleRequestTotal)
+	}
+	if math.Abs(payload.CycleCostTotal-0.006) > 1e-12 {
+		t.Fatalf("cycle_cost_total = %v, want 0.006", payload.CycleCostTotal)
+	}
+}
+
+func TestGetAuthFileTrendFallbackSeriesPrefersPrimaryCodeWeekOverAdditionalWeeklyCycle(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex-auth-file-fallback-week",
+		FileName: "codex-fallback.json",
+		Provider: "codex",
+		Label:    "fallback",
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	recordedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	codeResetAt := recordedAt.Add(4 * 24 * time.Hour)
+	codeCycleStart := codeResetAt.Add(-7 * 24 * time.Hour)
+	additionalResetAt := codeResetAt.Add(2 * time.Hour)
+	additionalCycleStart := additionalResetAt.Add(-7 * 24 * time.Hour)
+
+	if err := usage.UpsertModelPricing("gpt-5.4", 1, 2, 0); err != nil {
+		t.Fatalf("UpsertModelPricing: %v", err)
+	}
+
+	usage.InsertLog("", "", "gpt-5.4", "codex", "fallback", auth.Index, false, codeCycleStart.Add(-time.Hour), 1, 1, usage.TokenStats{
+		InputTokens:  1000,
+		OutputTokens: 2000,
+		TotalTokens:  3000,
+	}, "", "")
+	usage.InsertLog("", "", "gpt-5.4", "codex", "fallback", auth.Index, false, codeCycleStart.Add(30*time.Minute), 1, 1, usage.TokenStats{
+		InputTokens:  1000,
+		OutputTokens: 1000,
+		TotalTokens:  2000,
+	}, "", "")
+	usage.InsertLog("", "", "gpt-5.4", "codex", "fallback", auth.Index, false, additionalCycleStart.Add(30*time.Minute), 1, 1, usage.TokenStats{
+		InputTokens:  1000,
+		OutputTokens: 1000,
+		TotalTokens:  2000,
+	}, "", "")
+
+	codeRemaining := 99.0
+	additionalRemaining := 100.0
+	if err := usage.RecordQuotaSnapshotPoints(auth.Index, "codex", []usage.QuotaSnapshotPoint{
+		{
+			RecordedAt:    recordedAt,
+			QuotaKey:      "code_week",
+			QuotaLabel:    "m_quota.code_weekly",
+			Percent:       &codeRemaining,
+			ResetAt:       &codeResetAt,
+			WindowSeconds: 604800,
+		},
+		{
+			RecordedAt:    recordedAt,
+			QuotaKey:      "additional:codex_bengalfox:week",
+			QuotaLabel:    "GPT-5.3-Codex-Spark: Weekly",
+			Percent:       &additionalRemaining,
+			ResetAt:       &additionalResetAt,
+			WindowSeconds: 604800,
+		},
+	}); err != nil {
+		t.Fatalf("record quota snapshot point: %v", err)
+	}
+
+	h := &Handler{cfg: &config.Config{}, authManager: manager}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/auth-file-trend?auth_index="+auth.Index+"&days=7&hours=5", nil)
+
+	h.UsageLogs().GetAuthFileTrend(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		CycleKnown        bool    `json:"cycle_known"`
+		CycleStart        string  `json:"cycle_start"`
+		CycleRequestTotal int64   `json:"cycle_request_total"`
+		CycleCostTotal    float64 `json:"cycle_cost_total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !payload.CycleKnown {
+		t.Fatalf("cycle_known = false, want true")
+	}
+	if payload.CycleStart != codeCycleStart.Format(time.RFC3339) {
+		t.Fatalf("cycle_start = %q, want %q", payload.CycleStart, codeCycleStart.Format(time.RFC3339))
+	}
+	if payload.CycleRequestTotal != 2 {
+		t.Fatalf("cycle_request_total = %d, want 2", payload.CycleRequestTotal)
+	}
+	if math.Abs(payload.CycleCostTotal-0.006) > 1e-12 {
+		t.Fatalf("cycle_cost_total = %v, want 0.006", payload.CycleCostTotal)
+	}
+}
+
 func TestPostAuthFileQuotaSnapshotStoresFineGrainedPoints(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -41,6 +41,7 @@ func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any
 		return http.StatusNotFound, map[string]any{"error": "auth not found"}
 	}
 	matcher := s.authSubjectMatcher(auth)
+	preferredWeeklyQuotaKeys := primaryWeeklyQuotaKeysForProvider(auth.Provider)
 
 	dailyRaw, err := usage.QueryDailyCallsByAuthSubject(matcher, days)
 	if err != nil {
@@ -74,7 +75,7 @@ func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any
 
 	var cycleStart time.Time
 	if identity := usage.ResolveAuthSubjectIdentity(auth); identity != nil && identity.ID != "" {
-		cycle, err := usage.QueryLatestWeeklyQuotaCycleByAuthSubject(identity.ID)
+		cycle, err := usage.QueryLatestWeeklyQuotaCycleByAuthSubject(identity.ID, preferredWeeklyQuotaKeys...)
 		if err != nil {
 			return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 		}
@@ -83,7 +84,7 @@ func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any
 		}
 	}
 	if cycleStart.IsZero() {
-		if weeklyCycleStart, ok := latestWeeklyQuotaCycleStart(series); ok {
+		if weeklyCycleStart, ok := latestWeeklyQuotaCycleStart(series, preferredWeeklyQuotaKeys...); ok {
 			cycleStart = weeklyCycleStart
 		}
 	}
@@ -138,12 +139,24 @@ func fillDailyCountPoints(points []usage.DailyCountPoint, days int) []usage.Dail
 	return result
 }
 
-func latestWeeklyQuotaCycleStart(series []usage.QuotaSnapshotSeries) (time.Time, bool) {
+func latestWeeklyQuotaCycleStart(series []usage.QuotaSnapshotSeries, preferredQuotaKeys ...string) (time.Time, bool) {
+	preferred := make(map[string]struct{}, len(preferredQuotaKeys))
+	for _, quotaKey := range preferredQuotaKeys {
+		if trimmed := strings.TrimSpace(quotaKey); trimmed != "" {
+			preferred[trimmed] = struct{}{}
+		}
+	}
+	requiresPreferredKey := len(preferred) > 0
 	var latestPoint *usage.QuotaSnapshotSeriesPoint
 	var latestWindow int64
 	for i := range series {
 		if series[i].WindowSeconds < 604800 {
 			continue
+		}
+		if requiresPreferredKey {
+			if _, ok := preferred[strings.TrimSpace(series[i].QuotaKey)]; !ok {
+				continue
+			}
 		}
 		windowSeconds := series[i].WindowSeconds
 		for j := range series[i].Points {
@@ -161,6 +174,17 @@ func latestWeeklyQuotaCycleStart(series []usage.QuotaSnapshotSeries) (time.Time,
 		return time.Time{}, false
 	}
 	return latestPoint.ResetAt.Add(-time.Duration(latestWindow) * time.Second).UTC(), true
+}
+
+func primaryWeeklyQuotaKeysForProvider(provider string) []string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return []string{"seven_day"}
+	case "codex", "kimi":
+		return []string{"code_week"}
+	default:
+		return nil
+	}
 }
 
 func (s *Service) authIndexesForProviderGroup(group string) []string {

--- a/internal/usage/auth_subject_quota_store.go
+++ b/internal/usage/auth_subject_quota_store.go
@@ -285,7 +285,7 @@ func QueryQuotaSnapshotPointsByAuthSubject(matcher AuthSubjectMatcher, start, en
 	return result, rows.Err()
 }
 
-func QueryLatestWeeklyQuotaCycleByAuthSubject(subjectID string) (*AuthSubjectQuotaCycle, error) {
+func QueryLatestWeeklyQuotaCycleByAuthSubject(subjectID string, quotaKeys ...string) (*AuthSubjectQuotaCycle, error) {
 	db := getDB()
 	if db == nil {
 		return nil, nil
@@ -294,18 +294,31 @@ func QueryLatestWeeklyQuotaCycleByAuthSubject(subjectID string) (*AuthSubjectQuo
 	if subjectID == "" {
 		return nil, nil
 	}
+	normalizedKeys := dedupeExactStrings(quotaKeys)
 
 	var cycle AuthSubjectQuotaCycle
 	var cycleStartRaw string
 	var resetRaw string
 	var verifiedRaw string
-	err := db.QueryRow(`
+	query := `
 		SELECT subject_id, auth_index, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
 		FROM auth_subject_quota_cycles
 		WHERE subject_id = ? AND window_seconds >= 604800
+	`
+	args := make([]interface{}, 0, 1+len(normalizedKeys))
+	args = append(args, subjectID)
+	if len(normalizedKeys) > 0 {
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(normalizedKeys)), ",")
+		query += " AND quota_key IN (" + placeholders + ")"
+		for _, quotaKey := range normalizedKeys {
+			args = append(args, quotaKey)
+		}
+	}
+	query += `
 		ORDER BY last_verified_at DESC, reset_at DESC
 		LIMIT 1
-	`, subjectID).Scan(
+	`
+	err := db.QueryRow(query, args...).Scan(
 		&cycle.SubjectID,
 		&cycle.AuthIndex,
 		&cycle.Provider,

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -295,6 +295,52 @@ func TestRecordQuotaSnapshotPointsIdentityStoresWeeklyCycleBySubject(t *testing.
 	}
 }
 
+func TestQueryLatestWeeklyQuotaCycleByAuthSubjectFiltersPreferredQuotaKeys(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	recordedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	codeResetAt := recordedAt.Add(6 * 24 * time.Hour)
+	additionalResetAt := codeResetAt.Add(3 * time.Hour)
+	codeRemaining := 99.0
+	additionalRemaining := 100.0
+
+	err := RecordQuotaSnapshotPointsIdentity("auth-pro", "authsub_test", "codex", []QuotaSnapshotPoint{
+		{
+			RecordedAt:    recordedAt,
+			QuotaKey:      "code_week",
+			QuotaLabel:    "m_quota.code_weekly",
+			Percent:       &codeRemaining,
+			ResetAt:       &codeResetAt,
+			WindowSeconds: 604800,
+		},
+		{
+			RecordedAt:    recordedAt,
+			QuotaKey:      "additional:codex_bengalfox:week",
+			QuotaLabel:    "GPT-5.3-Codex-Spark: Weekly",
+			Percent:       &additionalRemaining,
+			ResetAt:       &additionalResetAt,
+			WindowSeconds: 604800,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RecordQuotaSnapshotPointsIdentity() error = %v", err)
+	}
+
+	cycle, err := QueryLatestWeeklyQuotaCycleByAuthSubject("authsub_test", "code_week")
+	if err != nil {
+		t.Fatalf("QueryLatestWeeklyQuotaCycleByAuthSubject() error = %v", err)
+	}
+	if cycle == nil {
+		t.Fatal("expected filtered weekly cycle, got nil")
+	}
+	if cycle.QuotaKey != "code_week" {
+		t.Fatalf("QuotaKey = %q, want code_week", cycle.QuotaKey)
+	}
+	if !cycle.CycleStartAt.Equal(codeResetAt.Add(-7 * 24 * time.Hour)) {
+		t.Fatalf("CycleStartAt = %s, want %s", cycle.CycleStartAt.Format(time.RFC3339), codeResetAt.Add(-7*24*time.Hour).Format(time.RFC3339))
+	}
+}
+
 func TestQueryUsageByAuthSubjectMatchesLegacyEmailRows(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 


### PR DESCRIPTION
## Summary
- only treat provider primary weekly quota keys as current-cycle anchors
- stop Codex additional weekly quotas from overriding code_week in trend calculations
- add regression coverage for both subject-cycle lookup and series fallback

## Testing
- rtk go test ./internal/usage
- rtk go test ./internal/api/handlers/management
- rtk go test ./internal/runtime/executor