### PR TITLE
fix: probe ai-routed egress IPs correctly

### DIFF
--- a/internal/api/handlers/management/usage_logs_egress.go
+++ b/internal/api/handlers/management/usage_logs_egress.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -22,6 +23,8 @@ import (
 const usageLogEgressProbeTimeout = 6 * time.Second
 
 var usageLogEgressProbeURLs = []string{
+	"https://chatgpt.com/cdn-cgi/trace",
+	"https://openai.com/cdn-cgi/trace",
 	"https://api.ipify.org",
 	"https://ifconfig.me/ip",
 	"https://icanhazip.com",
@@ -292,15 +295,39 @@ func probeUsageLogEgressIP(ctx context.Context, proxyURL string, sdkCfg *config.
 			lastErr = readErr
 			continue
 		}
-		if ip := strings.TrimSpace(string(body)); ip != "" {
+		if ip := extractUsageLogProbeIP(body); ip != "" {
 			return ip, nil
 		}
-		lastErr = fmt.Errorf("probe %s returned empty body", probeURL)
+		lastErr = fmt.Errorf("probe %s returned unusable body", probeURL)
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("all egress probe services failed")
 	}
 	return "", lastErr
+}
+
+func extractUsageLogProbeIP(body []byte) string {
+	text := strings.TrimSpace(string(body))
+	if text == "" {
+		return ""
+	}
+
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(strings.ToLower(line), "ip=") {
+			continue
+		}
+		value := strings.TrimSpace(line[len("ip="):])
+		if parsed := net.ParseIP(strings.Trim(value, "[]")); parsed != nil {
+			return parsed.String()
+		}
+		return ""
+	}
+
+	if parsed := net.ParseIP(strings.Trim(text, "[]")); parsed != nil {
+		return parsed.String()
+	}
+	return ""
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/api/handlers/management/usage_logs_egress_test.go
+++ b/internal/api/handlers/management/usage_logs_egress_test.go
@@ -217,3 +217,44 @@ func TestGetUsageLogEgressHandlesHistoricalLogsWithoutMetadata(t *testing.T) {
 		t.Fatal("using_proxy = true, want false")
 	}
 }
+
+func TestExtractUsageLogProbeIPParsesCloudflareTrace(t *testing.T) {
+	body := []byte("fl=1230f106\nh=chatgpt.com\nip=66.227.101.209\nts=1781158999.000\n")
+	if got := extractUsageLogProbeIP(body); got != "66.227.101.209" {
+		t.Fatalf("extractUsageLogProbeIP(trace) = %q, want %q", got, "66.227.101.209")
+	}
+}
+
+func TestProbeUsageLogEgressIPFallsBackToPlainIPProbe(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/trace":
+			_, _ = w.Write([]byte("fl=1230f106\nh=chatgpt.com\nwarp=off\n"))
+		case "/plain":
+			_, _ = w.Write([]byte("203.0.113.50\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	savedProbeURLs := usageLogEgressProbeURLs
+	usageLogEgressProbeURLs = []string{
+		server.URL + "/trace",
+		server.URL + "/plain",
+	}
+	t.Cleanup(func() {
+		usageLogEgressProbeURLs = savedProbeURLs
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	got, err := probeUsageLogEgressIP(ctx, "", nil)
+	if err != nil {
+		t.Fatalf("probeUsageLogEgressIP: %v", err)
+	}
+	if got != "203.0.113.50" {
+		t.Fatalf("probeUsageLogEgressIP = %q, want %q", got, "203.0.113.50")
+	}
+}


### PR DESCRIPTION
## Summary
- probe AI-routed domains before generic IP-check sites in usage log egress rechecks
- parse Cloudflare trace responses so domain-routed proxies report the actual egress IP
- add regression coverage for trace parsing and probe fallback

## Testing
- rtk go test ./internal/api/handlers/management -count=1