### PR TITLE
fix: reuse proxy transports for upstream requests

### DIFF
--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -58,16 +58,13 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 
 	// If we have a proxy URL configured, set up the transport
 	if proxyURL != "" {
-		transport := util.BuildProxyTransport(proxyURL, cfg != nil && cfg.PreferIPv4)
+		transport := cachedProxyTransport(proxyURL, cfgToSDKCfg(cfg))
 		if transport != nil {
 			httpClient.Transport = transport
-			if sdkCfg := cfgToSDKCfg(cfg); sdkCfg != nil {
-				util.ApplyTLSConfig(transport, sdkCfg)
-			}
 			return httpClient
 		}
 		// If proxy setup failed, log and fall through to context RoundTripper
-		log.Debugf("failed to setup proxy from URL: %s, falling back to context transport", proxyURL)
+		log.Debugf("failed to setup proxy from URL: %s, falling back to context transport", maskProxyURLHost(proxyURL))
 	}
 
 	// Priority 4: Use RoundTripper from context (typically from RoundTripperFor)

--- a/internal/runtime/executor/proxy_helpers_test.go
+++ b/internal/runtime/executor/proxy_helpers_test.go
@@ -117,3 +117,65 @@ func TestNewProxyAwareHTTPClientHonorsPreferIPv4ForHTTPProxy(t *testing.T) {
 		t.Fatalf("proxy hits = %d, want 0 when preferIPv4 blocks IPv6-only proxy", proxyHits)
 	}
 }
+
+func TestNewProxyAwareHTTPClientReusesProxyTransport(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{ProxyURL: "http://proxy-reuse.example:8080"}
+
+	first := newProxyAwareHTTPClient(context.Background(), cfg, auth, 0)
+	second := newProxyAwareHTTPClient(context.Background(), cfg, auth, 0)
+
+	if first.Transport == nil || second.Transport == nil {
+		t.Fatalf("expected proxy transports to be configured")
+	}
+	if first.Transport != second.Transport {
+		t.Fatalf("expected same proxy transport to be reused")
+	}
+}
+
+func TestNewProxyAwareHTTPClientSeparatesProxyTransportByPreferIPv4(t *testing.T) {
+	t.Parallel()
+
+	auth := &cliproxyauth.Auth{ProxyURL: "http://proxy-ip-mode.example:8080"}
+	ipv6Allowed := &config.Config{}
+	ipv4Only := &config.Config{}
+	ipv4Only.PreferIPv4 = true
+
+	first := newProxyAwareHTTPClient(context.Background(), ipv6Allowed, auth, 0)
+	second := newProxyAwareHTTPClient(context.Background(), ipv4Only, auth, 0)
+
+	if first.Transport == nil || second.Transport == nil {
+		t.Fatalf("expected proxy transports to be configured")
+	}
+	if first.Transport == second.Transport {
+		t.Fatalf("expected prefer-ipv4 change to use a distinct proxy transport")
+	}
+}
+
+func TestNewProxyAwareHTTPClientSeparatesProxyTransportByTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	auth := &cliproxyauth.Auth{ProxyURL: "http://proxy-tls-mode.example:8080"}
+	normalTLS := &config.Config{}
+	insecureTLS := &config.Config{}
+	insecureTLS.InsecureSkipVerify = true
+
+	first := newProxyAwareHTTPClient(context.Background(), normalTLS, auth, 0)
+	second := newProxyAwareHTTPClient(context.Background(), insecureTLS, auth, 0)
+
+	if first.Transport == nil || second.Transport == nil {
+		t.Fatalf("expected proxy transports to be configured")
+	}
+	if first.Transport == second.Transport {
+		t.Fatalf("expected TLS config change to use a distinct proxy transport")
+	}
+	transport, ok := second.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("second transport type = %T, want *http.Transport", second.Transport)
+	}
+	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("expected insecure TLS setting to be applied to cached proxy transport")
+	}
+}

--- a/internal/runtime/executor/proxy_transport_cache.go
+++ b/internal/runtime/executor/proxy_transport_cache.go
@@ -1,0 +1,120 @@
+package executor
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+)
+
+const maxProxyTransportCacheEntries = 128
+
+var sharedProxyTransportCache = newProxyTransportCache()
+
+type proxyTransportCacheKey struct {
+	proxyURL           string
+	preferIPv4         bool
+	insecureSkipVerify bool
+	caCert             string
+	caCertStat         string
+}
+
+type proxyTransportCacheEntry struct {
+	transport *http.Transport
+	lastUsed  time.Time
+}
+
+type proxyTransportCache struct {
+	mu         sync.Mutex
+	transports map[proxyTransportCacheKey]*proxyTransportCacheEntry
+}
+
+func newProxyTransportCache() *proxyTransportCache {
+	return &proxyTransportCache{
+		transports: make(map[proxyTransportCacheKey]*proxyTransportCacheEntry),
+	}
+}
+
+func cachedProxyTransport(proxyURL string, sdkCfg *config.SDKConfig) *http.Transport {
+	return sharedProxyTransportCache.get(proxyURL, sdkCfg)
+}
+
+func (c *proxyTransportCache) get(proxyURL string, sdkCfg *config.SDKConfig) *http.Transport {
+	if c == nil {
+		return nil
+	}
+	key := newProxyTransportCacheKey(proxyURL, sdkCfg)
+	if key.proxyURL == "" {
+		return nil
+	}
+
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry := c.transports[key]; entry != nil {
+		entry.lastUsed = now
+		return entry.transport
+	}
+
+	transport := util.BuildProxyTransport(key.proxyURL, key.preferIPv4)
+	if transport == nil {
+		return nil
+	}
+	util.ApplyTLSConfig(transport, sdkCfg)
+
+	if len(c.transports) >= maxProxyTransportCacheEntries {
+		c.evictOldestLocked()
+	}
+	c.transports[key] = &proxyTransportCacheEntry{
+		transport: transport,
+		lastUsed:  now,
+	}
+	return transport
+}
+
+func (c *proxyTransportCache) evictOldestLocked() {
+	var oldestKey proxyTransportCacheKey
+	var oldestEntry *proxyTransportCacheEntry
+	for key, entry := range c.transports {
+		if oldestEntry == nil || entry.lastUsed.Before(oldestEntry.lastUsed) {
+			oldestKey = key
+			oldestEntry = entry
+		}
+	}
+	if oldestEntry == nil {
+		return
+	}
+	delete(c.transports, oldestKey)
+	oldestEntry.transport.CloseIdleConnections()
+}
+
+func newProxyTransportCacheKey(proxyURL string, sdkCfg *config.SDKConfig) proxyTransportCacheKey {
+	key := proxyTransportCacheKey{
+		proxyURL: strings.TrimSpace(proxyURL),
+	}
+	if sdkCfg == nil {
+		return key
+	}
+	key.preferIPv4 = sdkCfg.PreferIPv4
+	key.insecureSkipVerify = sdkCfg.InsecureSkipVerify
+	key.caCert = strings.TrimSpace(sdkCfg.CACert)
+	key.caCertStat = caCertStatFingerprint(key.caCert)
+	return key
+}
+
+func caCertStatFingerprint(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "missing"
+	}
+	return fmt.Sprintf("%d:%d", info.Size(), info.ModTime().UnixNano())
+}


### PR DESCRIPTION
## Summary
- add a runtime proxy transport cache keyed by effective proxy URL and transport-affecting settings
- reuse cached proxy transports in upstream request execution to preserve idle/TLS/HTTP connection reuse
- add regression tests for proxy transport reuse and config separation

## Tests
- rtk go test ./...
