### PR TITLE
fix: warm residential proxy connections

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -91,6 +91,10 @@ type Server struct {
 	publicLookupRateMu          sync.Mutex
 	publicLookupRate            map[string]publicLookupRateLimitEntry
 	publicLookupRateLastCleanup time.Time
+
+	proxyWarmMu        sync.Mutex
+	proxyWarmManager   interface{ Stop() }
+	proxyWarmSignature string
 }
 
 // Start begins listening for and serving HTTP or HTTPS requests.
@@ -137,6 +141,7 @@ func (s *Server) Stop(ctx context.Context) error {
 	if s.mgmt != nil {
 		s.mgmt.Close()
 	}
+	s.stopProxyWarmup()
 
 	// Shutdown the HTTP server.
 	if err := s.server.Shutdown(ctx); err != nil {

--- a/internal/api/server_config_reload.go
+++ b/internal/api/server_config_reload.go
@@ -48,6 +48,7 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	s.applyUsageStatisticsConfig(oldCfg, cfg)
 	s.applyAuthRuntimeConfig(oldCfg, cfg)
 	s.applyRuntimeLogLevel(oldCfg, cfg)
+	s.applyProxyWarmupConfig(cfg)
 	s.updateManagementRouteAvailability(oldCfg, cfg)
 	s.applyAccessConfig(oldCfg, cfg)
 	s.commitUpdatedConfig(oldCfg, cfg)

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -145,6 +145,7 @@ func (s *Server) applyInitialRuntimeConfig(cfg *config.Config, authManager *auth
 	}
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
+	s.applyProxyWarmupConfig(cfg)
 }
 
 func (s *Server) configureManagementHandler(

--- a/internal/api/server_proxy_warmup.go
+++ b/internal/api/server_proxy_warmup.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+func (s *Server) applyProxyWarmupConfig(cfg *config.Config) {
+	if s == nil || cfg == nil {
+		return
+	}
+	cfg.SanitizeProxyWarmup()
+	proxyURL := resolveProxyWarmupURL(cfg)
+	signature := proxyWarmupSignature(cfg, proxyURL)
+
+	s.proxyWarmMu.Lock()
+	defer s.proxyWarmMu.Unlock()
+
+	if !cfg.ProxyWarmup.Enabled || proxyURL == "" {
+		if cfg.ProxyWarmup.Enabled && proxyURL == "" {
+			log.Warn("proxy_warmup: enabled but no proxy URL could be resolved")
+		}
+		s.replaceProxyWarmupLocked(nil, "")
+		return
+	}
+
+	if s.proxyWarmManager != nil && s.proxyWarmSignature == signature {
+		return
+	}
+
+	manager := executor.NewProxyWarmManager(cfg.ProxyWarmup, proxyURL, &cfg.SDKConfig)
+	manager.Start(context.Background())
+	s.replaceProxyWarmupLocked(manager, signature)
+	log.Infof("proxy_warmup: enabled for %s", maskWarmProxyURL(proxyURL))
+}
+
+func (s *Server) stopProxyWarmup() {
+	if s == nil {
+		return
+	}
+	s.proxyWarmMu.Lock()
+	defer s.proxyWarmMu.Unlock()
+	s.replaceProxyWarmupLocked(nil, "")
+}
+
+func (s *Server) replaceProxyWarmupLocked(next interface{ Stop() }, signature string) {
+	previous := s.proxyWarmManager
+	s.proxyWarmManager = next
+	s.proxyWarmSignature = signature
+	if manager, ok := next.(*executor.ProxyWarmManager); ok {
+		executor.SetGlobalWarmManager(manager)
+	} else {
+		executor.SetGlobalWarmManager(nil)
+	}
+	if previous != nil {
+		previous.Stop()
+	}
+}
+
+func resolveProxyWarmupURL(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if proxyID := strings.TrimSpace(cfg.ProxyWarmup.ProxyID); proxyID != "" {
+		return resolveProxyWarmupPoolURL(cfg, proxyID)
+	}
+	if proxyURL := validProxyWarmupURL(cfg.ProxyWarmup.ProxyURL); proxyURL != "" {
+		return proxyURL
+	}
+	if proxyURL := validProxyWarmupURL(cfg.ProxyURL); proxyURL != "" {
+		return proxyURL
+	}
+
+	var resolved string
+	for _, entry := range cfg.ProxyPool {
+		if !entry.Enabled || strings.TrimSpace(entry.URL) == "" {
+			continue
+		}
+		proxyURL := validProxyWarmupURL(entry.URL)
+		if proxyURL == "" {
+			continue
+		}
+		if resolved != "" {
+			return ""
+		}
+		resolved = proxyURL
+	}
+	return resolved
+}
+
+func resolveProxyWarmupPoolURL(cfg *config.Config, proxyID string) string {
+	if cfg == nil {
+		return ""
+	}
+	id := config.NormalizeProxyID(proxyID)
+	if id == "" {
+		return ""
+	}
+	for _, entry := range cfg.ProxyPool {
+		if !entry.Enabled {
+			continue
+		}
+		if config.NormalizeProxyID(entry.ID) == id {
+			return validProxyWarmupURL(entry.URL)
+		}
+	}
+	return ""
+}
+
+func validProxyWarmupURL(raw string) string {
+	proxyURL := strings.TrimSpace(raw)
+	if proxyURL == "" {
+		return ""
+	}
+	if err := config.ValidateProxyURL(proxyURL); err != nil {
+		log.Warnf("proxy_warmup: ignoring invalid proxy URL %s", maskWarmProxyURL(proxyURL))
+		return ""
+	}
+	return proxyURL
+}
+
+func proxyWarmupSignature(cfg *config.Config, proxyURL string) string {
+	if cfg == nil {
+		return ""
+	}
+	payload := struct {
+		Warm               config.ProxyWarmConfig `json:"warm"`
+		ProxyURL           string                 `json:"proxy_url"`
+		PreferIPv4         bool                   `json:"prefer_ipv4"`
+		InsecureSkipVerify bool                   `json:"insecure_skip_verify"`
+		CACert             string                 `json:"ca_cert"`
+	}{
+		Warm:               cfg.ProxyWarmup,
+		ProxyURL:           strings.TrimSpace(proxyURL),
+		PreferIPv4:         cfg.PreferIPv4,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		CACert:             strings.TrimSpace(cfg.CACert),
+	}
+	data, _ := json.Marshal(payload)
+	return string(data)
+}
+
+func maskWarmProxyURL(raw string) string {
+	masked := raw
+	if at := strings.LastIndex(masked, "@"); at >= 0 {
+		if scheme := strings.Index(masked, "://"); scheme >= 0 && scheme < at {
+			masked = masked[:scheme+3] + "***@" + masked[at+1:]
+		}
+	}
+	return masked
+}

--- a/internal/api/server_proxy_warmup_test.go
+++ b/internal/api/server_proxy_warmup_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestResolveProxyWarmupURLUsesProxyIDBeforeProxyURL(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ProxyWarmup: config.ProxyWarmConfig{
+			ProxyID:  "residential",
+			ProxyURL: "http://explicit.example:8080",
+		},
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "residential", URL: "socks5://127.0.0.1:1080", Enabled: true},
+		},
+	}
+
+	if got := resolveProxyWarmupURL(cfg); got != "socks5://127.0.0.1:1080" {
+		t.Fatalf("resolveProxyWarmupURL() = %q, want proxy-id target", got)
+	}
+}
+
+func TestResolveProxyWarmupURLDoesNotFallbackWhenProxyIDMissing(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{ProxyURL: "http://global.example:8080"},
+		ProxyWarmup: config.ProxyWarmConfig{
+			ProxyID: "missing",
+		},
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "residential", URL: "socks5://127.0.0.1:1080", Enabled: true},
+		},
+	}
+
+	if got := resolveProxyWarmupURL(cfg); got != "" {
+		t.Fatalf("resolveProxyWarmupURL() = %q, want empty when explicit proxy-id is missing", got)
+	}
+}
+
+func TestResolveProxyWarmupURLUsesSingleEnabledProxyPoolEntry(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "disabled", URL: "http://disabled.example:8080", Enabled: false},
+			{ID: "residential", URL: "socks5://127.0.0.1:1080", Enabled: true},
+		},
+	}
+
+	if got := resolveProxyWarmupURL(cfg); got != "socks5://127.0.0.1:1080" {
+		t.Fatalf("resolveProxyWarmupURL() = %q, want the only enabled proxy-pool entry", got)
+	}
+}
+
+func TestResolveProxyWarmupURLRefusesAmbiguousProxyPool(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "one", URL: "socks5://127.0.0.1:1080", Enabled: true},
+			{ID: "two", URL: "http://127.0.0.1:8080", Enabled: true},
+		},
+	}
+
+	if got := resolveProxyWarmupURL(cfg); got != "" {
+		t.Fatalf("resolveProxyWarmupURL() = %q, want empty for ambiguous proxy-pool entries", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,10 @@
 // debug settings, proxy configuration, and API keys.
 package config
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 const DefaultMainAPIReadTimeout = 2 * time.Minute
 
@@ -128,6 +131,11 @@ type Config struct {
 	// ProxyPool stores reusable outbound proxies that can be referenced by providers and auth files.
 	ProxyPool []ProxyPoolEntry `yaml:"proxy-pool,omitempty" json:"proxy-pool,omitempty"`
 
+	// ProxyWarmup configures proactive upstream connection warming for fixed proxy hosts.
+	// When enabled, the server establishes and maintains idle TLS/HTTP2 connections
+	// to common upstream AI API hosts through the fixed residential proxy.
+	ProxyWarmup ProxyWarmConfig `yaml:"proxy-warmup,omitempty" json:"proxy-warmup,omitempty"`
+
 	// OpenAICompatibility defines OpenAI API compatibility configurations for external providers.
 	OpenAICompatibility []OpenAICompatibility `yaml:"openai-compatibility" json:"openai-compatibility"`
 
@@ -178,4 +186,118 @@ type KimiHeaderDefaults struct {
 	UserAgent string `yaml:"user-agent" json:"user-agent"`
 	Platform  string `yaml:"platform" json:"platform"`
 	Version   string `yaml:"version" json:"version"`
+}
+
+// ProxyWarmConfig controls proactive upstream connection warming for fixed proxy hosts.
+// Warming establishes idle TLS/HTTP2 connections through the proxy before real requests arrive.
+type ProxyWarmConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// ProxyID references a proxy-pool entry to warm. It takes precedence over ProxyURL.
+	ProxyID string `yaml:"proxy-id,omitempty" json:"proxy-id,omitempty"`
+	// ProxyURL warms this explicit proxy when ProxyID is empty.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+	// StartupDelaySeconds waits this long after server start before beginning warmup.
+	StartupDelaySeconds int `yaml:"startup-delay-seconds,omitempty" json:"startup-delay-seconds,omitempty"`
+	// IntervalSeconds is the base interval between warmup rounds for active hosts.
+	IntervalSeconds int `yaml:"interval-seconds,omitempty" json:"interval-seconds,omitempty"`
+	// IntervalJitterSeconds adds random jitter to warmup interval to avoid fixed patterns.
+	IntervalJitterSeconds int `yaml:"interval-jitter-seconds,omitempty" json:"interval-jitter-seconds,omitempty"`
+	// TimeoutSeconds per individual warmup request.
+	TimeoutSeconds int `yaml:"timeout-seconds,omitempty" json:"timeout-seconds,omitempty"`
+	// InactiveTTLMinutes removes a host from warmup if unused for this long.
+	InactiveTTLMinutes int `yaml:"inactive-ttl-minutes,omitempty" json:"inactive-ttl-minutes,omitempty"`
+	// MaxHostsPerProxy limits the number of concurrently warmed hosts.
+	MaxHostsPerProxy int `yaml:"max-hosts-per-proxy,omitempty" json:"max-hosts-per-proxy,omitempty"`
+	// AllowedHostSuffixes restricts warming to matching host suffixes (e.g. chatgpt.com).
+	AllowedHostSuffixes []string `yaml:"allowed-host-suffixes,omitempty" json:"allowed-host-suffixes,omitempty"`
+	// Targets lists the specific URLs to warm for each host.
+	Targets []ProxyWarmTarget `yaml:"targets,omitempty" json:"targets,omitempty"`
+}
+
+// ProxyWarmTarget defines a single warmup request target.
+type ProxyWarmTarget struct {
+	Host   string `yaml:"host" json:"host"`
+	URL    string `yaml:"url" json:"url"`
+	Method string `yaml:"method" json:"method"`
+}
+
+func defaultProxyWarmConfig() ProxyWarmConfig {
+	return ProxyWarmConfig{
+		Enabled:               false,
+		StartupDelaySeconds:   15,
+		IntervalSeconds:       60,
+		IntervalJitterSeconds: 15,
+		TimeoutSeconds:        5,
+		InactiveTTLMinutes:    10,
+		MaxHostsPerProxy:      8,
+		AllowedHostSuffixes: []string{
+			"chatgpt.com",
+			"openai.com",
+			"oaistatic.com",
+			"oaiusercontent.com",
+		},
+		Targets: []ProxyWarmTarget{
+			{Host: "chatgpt.com", URL: "https://chatgpt.com/robots.txt", Method: "GET"},
+			{Host: "api.openai.com", URL: "https://api.openai.com/", Method: "HEAD"},
+			{Host: "chat.openai.com", URL: "https://chat.openai.com/", Method: "HEAD"},
+		},
+	}
+}
+
+func (cfg *Config) SanitizeProxyWarmup() {
+	if cfg == nil {
+		return
+	}
+	defaults := defaultProxyWarmConfig()
+	warm := cfg.ProxyWarmup
+	warm.ProxyID = strings.TrimSpace(warm.ProxyID)
+	warm.ProxyURL = strings.TrimSpace(warm.ProxyURL)
+	if warm.StartupDelaySeconds <= 0 {
+		warm.StartupDelaySeconds = defaults.StartupDelaySeconds
+	}
+	if warm.IntervalSeconds <= 0 {
+		warm.IntervalSeconds = defaults.IntervalSeconds
+	}
+	if warm.IntervalJitterSeconds < 0 {
+		warm.IntervalJitterSeconds = 0
+	}
+	if warm.TimeoutSeconds <= 0 {
+		warm.TimeoutSeconds = defaults.TimeoutSeconds
+	}
+	if warm.InactiveTTLMinutes <= 0 {
+		warm.InactiveTTLMinutes = defaults.InactiveTTLMinutes
+	}
+	if warm.MaxHostsPerProxy <= 0 {
+		warm.MaxHostsPerProxy = defaults.MaxHostsPerProxy
+	}
+	if len(warm.AllowedHostSuffixes) == 0 {
+		warm.AllowedHostSuffixes = defaults.AllowedHostSuffixes
+	} else {
+		out := make([]string, 0, len(warm.AllowedHostSuffixes))
+		for _, suffix := range warm.AllowedHostSuffixes {
+			if trimmed := strings.ToLower(strings.TrimSpace(suffix)); trimmed != "" {
+				out = append(out, trimmed)
+			}
+		}
+		warm.AllowedHostSuffixes = out
+	}
+	if len(warm.Targets) == 0 {
+		warm.Targets = defaults.Targets
+	} else {
+		out := make([]ProxyWarmTarget, 0, len(warm.Targets))
+		for _, target := range warm.Targets {
+			target.Host = strings.ToLower(strings.TrimSpace(target.Host))
+			target.URL = strings.TrimSpace(target.URL)
+			target.Method = strings.ToUpper(strings.TrimSpace(target.Method))
+			if target.Method == "" {
+				target.Method = "HEAD"
+			}
+			if target.Host == "" || target.URL == "" {
+				continue
+			}
+			out = append(out, target)
+		}
+		warm.Targets = out
+	}
+	cfg.ProxyWarmup = warm
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,6 +53,33 @@ func TestLoadConfigReadsMainAPIReadTimeoutOverride(t *testing.T) {
 	}
 }
 
+func TestLoadConfigSanitizesProxyWarmupDefaults(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("proxy-warmup:\n  enabled: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if !cfg.ProxyWarmup.Enabled {
+		t.Fatal("ProxyWarmup.Enabled = false, want true")
+	}
+	if cfg.ProxyWarmup.IntervalSeconds <= 0 {
+		t.Fatalf("ProxyWarmup.IntervalSeconds = %d, want default > 0", cfg.ProxyWarmup.IntervalSeconds)
+	}
+	if len(cfg.ProxyWarmup.Targets) == 0 {
+		t.Fatal("ProxyWarmup.Targets is empty, want default warm targets")
+	}
+	if cfg.ProxyWarmup.Targets[0].Method == "" {
+		t.Fatal("ProxyWarmup target method is empty, want sanitized default")
+	}
+}
+
 func TestSanitizeRoutingPreservesChannelGroupSettings(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -81,6 +81,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.AutoUpdate.Repository = DefaultAutoUpdateRepository
 	cfg.AutoUpdate.DockerImage = DefaultAutoUpdateDockerImage
 	cfg.AutoUpdate.UpdaterURL = DefaultAutoUpdateUpdaterURL
+	cfg.ProxyWarmup = defaultProxyWarmConfig()
 	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		if optional {
 			// In cloud deploy mode, if YAML parsing fails, return empty config instead of error.
@@ -113,6 +114,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.SanitizeClaudeKeys()
 	cfg.SanitizeOpenCodeGoKeys()
 	cfg.SanitizeGeminiKeys()
+	cfg.SanitizeProxyWarmup()
 
 	// Normalize secret-key: if provided and not bcrypt-hashed, hash it on load for runtime use.
 	if cfg.RemoteManagement.SecretKey != "" && !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -14,6 +15,13 @@ import (
 	sdkexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
 )
+
+var globalWarmManager atomic.Pointer[ProxyWarmManager]
+
+// SetGlobalWarmManager installs the global warm manager used by newProxyAwareHTTPClient.
+func SetGlobalWarmManager(m *ProxyWarmManager) {
+	globalWarmManager.Store(m)
+}
 
 const requestLogEgressRouteKey = "cliproxy.request_log.egress_route"
 
@@ -61,17 +69,19 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		transport := cachedProxyTransport(proxyURL, cfgToSDKCfg(cfg))
 		if transport != nil {
 			httpClient.Transport = transport
-			return httpClient
+		} else {
+			// If proxy setup failed, log and fall through to context RoundTripper
+			log.Debugf("failed to setup proxy from URL: %s, falling back to context transport", maskProxyURLHost(proxyURL))
 		}
-		// If proxy setup failed, log and fall through to context RoundTripper
-		log.Debugf("failed to setup proxy from URL: %s, falling back to context transport", maskProxyURLHost(proxyURL))
 	}
 
 	// Priority 4: Use RoundTripper from context (typically from RoundTripperFor)
-	if rt := sdkexecutor.RoundTripperFromContext(ctx); rt != nil {
-		httpClient.Transport = rt
-	} else if rt, ok := ctx.Value(util.ContextKeyRoundTripper).(http.RoundTripper); ok && rt != nil {
-		httpClient.Transport = rt
+	if httpClient.Transport == nil {
+		if rt := sdkexecutor.RoundTripperFromContext(ctx); rt != nil {
+			httpClient.Transport = rt
+		} else if rt, ok := ctx.Value(util.ContextKeyRoundTripper).(http.RoundTripper); ok && rt != nil {
+			httpClient.Transport = rt
+		}
 	}
 
 	if httpClient.Transport == nil {
@@ -82,6 +92,17 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		}
 	}
 
+	if proxyURL != "" {
+		if manager := globalWarmManager.Load(); manager != nil && httpClient.Transport != nil {
+			httpClient.Transport = &warmingRoundTripper{
+				base:    httpClient.Transport,
+				manager: manager,
+			}
+		}
+	}
+	if ginCtx, ok := ctx.Value(util.ContextKeyGin).(*gin.Context); ok && ginCtx != nil && httpClient.Transport != nil {
+		httpClient.Transport = &upstreamTracingTransport{base: httpClient.Transport, ginCtx: ginCtx}
+	}
 	return httpClient
 }
 

--- a/internal/runtime/executor/proxy_helpers_test.go
+++ b/internal/runtime/executor/proxy_helpers_test.go
@@ -2,13 +2,16 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -177,5 +180,49 @@ func TestNewProxyAwareHTTPClientSeparatesProxyTransportByTLSConfig(t *testing.T)
 	}
 	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
 		t.Fatalf("expected insecure TLS setting to be applied to cached proxy transport")
+	}
+}
+
+func TestNewProxyAwareHTTPClientRecordsProxyUpstreamTiming(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.String() != "http://target.example/check" {
+			t.Fatalf("proxy received URL %q", r.URL.String())
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxyServer.Close()
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	inbound := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	ginCtx.Request = inbound
+	ctx := context.WithValue(inbound.Context(), util.ContextKeyGin, ginCtx)
+
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{ProxyURL: proxyServer.URL}
+	client := newProxyAwareHTTPClient(ctx, cfg, auth, 0)
+
+	resp, err := client.Get("http://target.example/check")
+	if err != nil {
+		t.Fatalf("client.Get returned error: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	var detail struct {
+		Egress map[string]any `json:"egress"`
+		Timing map[string]any `json:"upstream_timing"`
+	}
+	if err := json.Unmarshal([]byte(buildRequestDetailContent(ctx)), &detail); err != nil {
+		t.Fatalf("unmarshal request details: %v", err)
+	}
+	if detail.Egress["route_kind"] != "proxy" {
+		t.Fatalf("egress.route_kind = %v, want proxy", detail.Egress["route_kind"])
+	}
+	if detail.Timing["host"] != "target.example" {
+		t.Fatalf("upstream_timing.host = %v, want target.example", detail.Timing["host"])
+	}
+	if _, ok := detail.Timing["got_conn_reused"]; !ok {
+		t.Fatalf("upstream_timing missing got_conn_reused: %#v", detail.Timing)
 	}
 }

--- a/internal/runtime/executor/proxy_warmup.go
+++ b/internal/runtime/executor/proxy_warmup.go
@@ -300,9 +300,7 @@ func (m *ProxyWarmManager) isHostAllowed(host string) bool {
 		if suffix == "" {
 			continue
 		}
-		if strings.HasPrefix(suffix, "*.") {
-			suffix = strings.TrimPrefix(suffix, "*.")
-		}
+		suffix = strings.TrimPrefix(suffix, "*.")
 		if host == suffix || strings.HasSuffix(host, "."+suffix) {
 			return true
 		}

--- a/internal/runtime/executor/proxy_warmup.go
+++ b/internal/runtime/executor/proxy_warmup.go
@@ -1,0 +1,382 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	log "github.com/sirupsen/logrus"
+)
+
+// ProxyWarmManager maintains idle connections from a fixed proxy to upstream AI API hosts.
+// It sends lightweight, credential-free requests on a timer so that Go's http.Transport
+// keeps TLS/HTTP2 connections warm, reducing first-token latency for real requests.
+type ProxyWarmManager struct {
+	cfg      config.ProxyWarmConfig
+	proxyURL string
+	sdkCfg   *config.SDKConfig
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu    sync.Mutex
+	hosts map[string]*warmHostState
+}
+
+type warmHostState struct {
+	host             string
+	lastUsed         time.Time
+	consecutiveFails int
+	nextWarmAt       time.Time
+	targetURL        string
+	targetMethod     string
+}
+
+// NewProxyWarmManager creates a warm manager. It is not started automatically—call Start().
+func NewProxyWarmManager(cfg config.ProxyWarmConfig, proxyURL string, sdkCfg *config.SDKConfig) *ProxyWarmManager {
+	m := &ProxyWarmManager{
+		cfg:      cfg,
+		proxyURL: proxyURL,
+		sdkCfg:   sdkCfg,
+		hosts:    make(map[string]*warmHostState),
+	}
+	m.seedConfiguredTargets()
+	return m
+}
+
+// Start begins background connection warming. It blocks until the warmup loop is running
+// or the context is cancelled. Call Stop() to shut down.
+func (m *ProxyWarmManager) Start(parent context.Context) {
+	if m == nil || !m.cfg.Enabled || m.proxyURL == "" {
+		return
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	m.ctx, m.cancel = context.WithCancel(parent)
+	m.wg.Add(1)
+	go m.run()
+}
+
+// Stop terminates the warmup loop and releases resources.
+func (m *ProxyWarmManager) Stop() {
+	if m == nil || m.cancel == nil {
+		return
+	}
+	m.cancel()
+	m.wg.Wait()
+}
+
+// MarkUsed records that a real request just accessed the given host through the proxy.
+// This ensures the host stays in the active warmup set.
+func (m *ProxyWarmManager) MarkUsed(host string) {
+	if m == nil || host == "" || !m.cfg.Enabled {
+		return
+	}
+	host = normalizeWarmHost(host)
+	if host == "" {
+		return
+	}
+	if !m.isHostAllowed(host) {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, exists := m.hosts[host]
+	if !exists {
+		// Find target config for this host
+		var targetURL, targetMethod string
+		for _, t := range m.cfg.Targets {
+			if strings.EqualFold(normalizeWarmHost(t.Host), host) {
+				targetURL = t.URL
+				targetMethod = t.Method
+				break
+			}
+		}
+		if targetURL == "" {
+			// Dynamic host without a configured target — skip warming
+			return
+		}
+		targetMethod = strings.ToUpper(strings.TrimSpace(targetMethod))
+		if targetMethod == "" {
+			targetMethod = http.MethodHead
+		}
+		m.hosts[host] = &warmHostState{
+			host:         host,
+			targetURL:    targetURL,
+			targetMethod: targetMethod,
+			lastUsed:     time.Now(),
+			nextWarmAt:   time.Now(),
+		}
+		return
+	}
+	state.lastUsed = time.Now()
+}
+
+func (m *ProxyWarmManager) run() {
+	defer m.wg.Done()
+
+	startupDelay := warmDuration(m.cfg.StartupDelaySeconds)
+	log.Debugf("proxy_warmup: starting in %v", startupDelay)
+
+	select {
+	case <-m.ctx.Done():
+		return
+	case <-time.After(startupDelay):
+	}
+
+	baseInterval := warmDuration(m.cfg.IntervalSeconds)
+	inactiveTTL := time.Duration(m.cfg.InactiveTTLMinutes) * time.Minute
+	timeout := warmDuration(m.cfg.TimeoutSeconds)
+
+	var tickInterval time.Duration
+	if baseInterval > 0 {
+		tickInterval = baseInterval
+	} else {
+		tickInterval = 60 * time.Second
+	}
+	if tickInterval < time.Second {
+		tickInterval = time.Second
+	}
+
+	m.warmRound(inactiveTTL, timeout)
+
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.warmRound(inactiveTTL, timeout)
+		}
+	}
+}
+
+func (m *ProxyWarmManager) warmRound(inactiveTTL, timeout time.Duration) {
+	m.mu.Lock()
+	// Collect hosts ready for warming
+	now := time.Now()
+	for host, state := range m.hosts {
+		// Remove inactive hosts
+		if m.isInactive(state, now, inactiveTTL) {
+			delete(m.hosts, host)
+			log.Debugf("proxy_warmup: removing inactive host %s", host)
+			continue
+		}
+	}
+	// Build worklist
+	type warmJob struct {
+		host  string
+		state *warmHostState
+	}
+	var worklist []warmJob
+	for host, state := range m.hosts {
+		if now.Before(state.nextWarmAt) {
+			continue
+		}
+		if m.cfg.MaxHostsPerProxy > 0 && len(worklist) >= m.cfg.MaxHostsPerProxy {
+			break
+		}
+		worklist = append(worklist, warmJob{host: host, state: state})
+	}
+	m.mu.Unlock()
+
+	for _, job := range worklist {
+		select {
+		case <-m.ctx.Done():
+			return
+		default:
+		}
+		m.doWarm(job.host, job.state, timeout)
+	}
+}
+
+func (m *ProxyWarmManager) doWarm(host string, state *warmHostState, timeout time.Duration) {
+	transport := cachedProxyTransport(m.proxyURL, m.sdkCfg)
+	if transport == nil {
+		log.Debugf("proxy_warmup: no transport for %s", m.proxyURL)
+		return
+	}
+
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+
+	ctx := m.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	method := strings.ToUpper(strings.TrimSpace(state.targetMethod))
+	if method == "" {
+		method = http.MethodHead
+	}
+	req, err := http.NewRequestWithContext(ctx, method, state.targetURL, nil)
+	if err != nil {
+		log.Debugf("proxy_warmup: failed to create request for %s: %v", host, err)
+		m.markFailure(state)
+		return
+	}
+	req.Header.Set("User-Agent", "CliRelay-Warmup/1.0")
+
+	started := time.Now()
+	resp, err := client.Do(req)
+	elapsed := time.Since(started)
+
+	var drainErr error
+	if resp != nil && resp.Body != nil {
+		_, drainErr = io.Copy(io.Discard, resp.Body)
+		if closeErr := resp.Body.Close(); drainErr == nil {
+			drainErr = closeErr
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err != nil {
+		log.Debugf("proxy_warmup: %s failed after %v: %v", host, elapsed, err)
+		m.markFailureLocked(state)
+		return
+	}
+	if drainErr != nil {
+		log.Debugf("proxy_warmup: %s response drain failed after %v: %v", host, elapsed, drainErr)
+		m.markFailureLocked(state)
+		return
+	}
+
+	// Only log success at debug; avoid noisy success logs
+	log.Debugf("proxy_warmup: %s %s -> %d in %v", method, host, resp.StatusCode, elapsed)
+	m.markSuccessLocked(state)
+}
+
+func (m *ProxyWarmManager) markFailure(state *warmHostState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.markFailureLocked(state)
+}
+
+func (m *ProxyWarmManager) markFailureLocked(state *warmHostState) {
+	state.consecutiveFails++
+	// Exponential backoff: 1min -> 2min -> 5min -> 10min -> capped at 10min
+	backoff := []time.Duration{time.Minute, 2 * time.Minute, 5 * time.Minute, 10 * time.Minute}
+	idx := state.consecutiveFails - 1
+	if idx >= len(backoff) {
+		idx = len(backoff) - 1
+	}
+	state.nextWarmAt = time.Now().Add(backoff[idx])
+}
+
+func (m *ProxyWarmManager) markSuccessLocked(state *warmHostState) {
+	state.consecutiveFails = 0
+	jitter := randomJitter(m.cfg.IntervalJitterSeconds)
+	state.nextWarmAt = time.Now().Add(time.Duration(m.cfg.IntervalSeconds) * time.Second).Add(jitter)
+}
+
+func (m *ProxyWarmManager) isInactive(state *warmHostState, now time.Time, ttl time.Duration) bool {
+	if ttl <= 0 {
+		return false
+	}
+	return now.Sub(state.lastUsed) > ttl
+}
+
+func (m *ProxyWarmManager) isHostAllowed(host string) bool {
+	if len(m.cfg.AllowedHostSuffixes) == 0 {
+		return true
+	}
+	host = normalizeWarmHost(host)
+	for _, suffix := range m.cfg.AllowedHostSuffixes {
+		suffix = strings.ToLower(strings.TrimSpace(suffix))
+		if suffix == "" {
+			continue
+		}
+		if strings.HasPrefix(suffix, "*.") {
+			suffix = strings.TrimPrefix(suffix, "*.")
+		}
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *ProxyWarmManager) seedConfiguredTargets() {
+	if m == nil || len(m.cfg.Targets) == 0 {
+		return
+	}
+	now := time.Now()
+	for _, target := range m.cfg.Targets {
+		host := normalizeWarmHost(target.Host)
+		if host == "" || target.URL == "" || !m.isHostAllowed(host) {
+			continue
+		}
+		method := strings.ToUpper(strings.TrimSpace(target.Method))
+		if method == "" {
+			method = http.MethodHead
+		}
+		if _, exists := m.hosts[host]; exists {
+			continue
+		}
+		m.hosts[host] = &warmHostState{
+			host:         host,
+			targetURL:    strings.TrimSpace(target.URL),
+			targetMethod: method,
+			lastUsed:     now,
+			nextWarmAt:   now,
+		}
+	}
+}
+
+// warmingRoundTripper wraps an http.RoundTripper and records host usage for connection warming.
+type warmingRoundTripper struct {
+	base    http.RoundTripper
+	manager *ProxyWarmManager
+}
+
+func (w *warmingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if w.manager != nil && req.URL != nil {
+		w.manager.MarkUsed(req.URL.Host)
+	}
+	base := w.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+func warmDuration(seconds int) time.Duration {
+	return time.Duration(seconds) * time.Second
+}
+
+func randomJitter(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Intn(seconds*1000)) * time.Millisecond
+}
+
+func normalizeWarmHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return ""
+	}
+	if strings.Contains(host, "://") {
+		if req, err := http.NewRequest(http.MethodGet, host, nil); err == nil && req.URL != nil {
+			host = req.URL.Host
+		}
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.Trim(host, "[]")
+}

--- a/internal/runtime/executor/proxy_warmup_test.go
+++ b/internal/runtime/executor/proxy_warmup_test.go
@@ -1,0 +1,141 @@
+package executor
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestProxyWarmManagerAllowsExactAndSubdomainSuffixesOnly(t *testing.T) {
+	t.Parallel()
+
+	manager := NewProxyWarmManager(config.ProxyWarmConfig{
+		Enabled:             true,
+		AllowedHostSuffixes: []string{"openai.com"},
+	}, "http://127.0.0.1:8080", nil)
+
+	if !manager.isHostAllowed("openai.com") {
+		t.Fatal("openai.com should be allowed")
+	}
+	if !manager.isHostAllowed("api.openai.com") {
+		t.Fatal("api.openai.com should be allowed")
+	}
+	if manager.isHostAllowed("badopenai.com") {
+		t.Fatal("badopenai.com should not match openai.com suffix")
+	}
+}
+
+func TestNormalizeWarmHostRemovesURLAndPort(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeWarmHost("https://API.OpenAI.com:443/v1/responses"); got != "api.openai.com" {
+		t.Fatalf("normalizeWarmHost URL = %q, want api.openai.com", got)
+	}
+	if got := normalizeWarmHost("[2001:db8::1]:443"); got != "2001:db8::1" {
+		t.Fatalf("normalizeWarmHost IPv6 = %q, want 2001:db8::1", got)
+	}
+}
+
+func TestProxyWarmManagerSeedsConfiguredTargets(t *testing.T) {
+	t.Parallel()
+
+	manager := NewProxyWarmManager(config.ProxyWarmConfig{
+		Enabled:             true,
+		AllowedHostSuffixes: []string{"openai.com"},
+		Targets: []config.ProxyWarmTarget{
+			{Host: "api.openai.com", URL: "https://api.openai.com/", Method: ""},
+			{Host: "badopenai.com", URL: "https://badopenai.com/", Method: "GET"},
+		},
+	}, "http://127.0.0.1:8080", nil)
+
+	if _, ok := manager.hosts["api.openai.com"]; !ok {
+		t.Fatal("configured api.openai.com target was not seeded")
+	}
+	if manager.hosts["api.openai.com"].targetMethod != http.MethodHead {
+		t.Fatalf("target method = %q, want HEAD", manager.hosts["api.openai.com"].targetMethod)
+	}
+	if _, ok := manager.hosts["badopenai.com"]; ok {
+		t.Fatal("lookalike suffix host should not be seeded")
+	}
+}
+
+func TestProxyWarmManagerDrainsWarmupResponseForConnectionReuse(t *testing.T) {
+	var newConnections atomic.Int32
+	proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("warm body"))
+	}))
+	proxyServer.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+	proxyServer.Start()
+	defer proxyServer.Close()
+
+	manager := NewProxyWarmManager(config.ProxyWarmConfig{
+		Enabled:               true,
+		IntervalSeconds:       60,
+		IntervalJitterSeconds: 0,
+		TimeoutSeconds:        1,
+		AllowedHostSuffixes:   []string{"target.test"},
+		Targets: []config.ProxyWarmTarget{
+			{Host: "target.test", URL: "http://target.test/warm", Method: http.MethodGet},
+		},
+	}, proxyServer.URL, nil)
+	manager.ctx = context.Background()
+	state := &warmHostState{
+		host:         "target.test",
+		targetURL:    "http://target.test/warm",
+		targetMethod: http.MethodGet,
+		lastUsed:     time.Now(),
+	}
+
+	manager.doWarm("target.test", state, time.Second)
+	manager.doWarm("target.test", state, time.Second)
+
+	if got := newConnections.Load(); got > 1 {
+		t.Fatalf("warmup opened %d proxy connections, want reuse of the first connection", got)
+	}
+	if transport := cachedProxyTransport(proxyServer.URL, nil); transport != nil {
+		transport.CloseIdleConnections()
+	}
+}
+
+func TestProxyWarmManagerRunsFirstWarmRoundAfterStartupDelay(t *testing.T) {
+	warmed := make(chan struct{}, 1)
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case warmed <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxyServer.Close()
+
+	manager := NewProxyWarmManager(config.ProxyWarmConfig{
+		Enabled:               true,
+		StartupDelaySeconds:   0,
+		IntervalSeconds:       60,
+		IntervalJitterSeconds: 0,
+		TimeoutSeconds:        1,
+		AllowedHostSuffixes:   []string{"target.test"},
+		Targets: []config.ProxyWarmTarget{
+			{Host: "target.test", URL: "http://target.test/warm", Method: http.MethodHead},
+		},
+	}, proxyServer.URL, nil)
+	manager.Start(context.Background())
+	defer manager.Stop()
+
+	select {
+	case <-warmed:
+	case <-time.After(time.Second):
+		t.Fatal("warmup did not run immediately after startup delay")
+	}
+}

--- a/internal/runtime/executor/upstream_timing.go
+++ b/internal/runtime/executor/upstream_timing.go
@@ -1,0 +1,153 @@
+package executor
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptrace"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+)
+
+type upstreamTraceTimings struct {
+	Host          string `json:"host,omitempty"`
+	Scheme        string `json:"scheme,omitempty"`
+	GotConnReused bool   `json:"got_conn_reused"`
+	WasIdle       bool   `json:"was_idle,omitempty"`
+	IdleMs        int64  `json:"idle_ms,omitempty"`
+	ConnectMs     int64  `json:"connect_ms,omitempty"`
+	TLSMs         int64  `json:"tls_ms,omitempty"`
+	HeaderTTFBMs  int64  `json:"header_ttfb_ms,omitempty"`
+
+	getConnAt              time.Time
+	gotConnAt              time.Time
+	connectStartAt         time.Time
+	connectDoneAt          time.Time
+	tlsHandshakeStartAt    time.Time
+	tlsHandshakeDoneAt     time.Time
+	gotFirstResponseByteAt time.Time
+	requestStart           time.Time
+}
+
+const upstreamTimingKey = "cliproxy.request_log.upstream_timing"
+
+func (t *upstreamTraceTimings) clientTrace() *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			t.getConnAt = time.Now()
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.gotConnAt = time.Now()
+			t.GotConnReused = info.Reused
+			t.WasIdle = info.WasIdle
+			if info.WasIdle {
+				t.IdleMs = info.IdleTime.Milliseconds()
+			}
+		},
+		ConnectStart: func(_, _ string) {
+			t.connectStartAt = time.Now()
+		},
+		ConnectDone: func(_, _ string, err error) {
+			t.connectDoneAt = time.Now()
+			if err == nil && !t.connectStartAt.IsZero() {
+				t.ConnectMs = t.connectDoneAt.Sub(t.connectStartAt).Milliseconds()
+			}
+		},
+		TLSHandshakeStart: func() {
+			t.tlsHandshakeStartAt = time.Now()
+		},
+		TLSHandshakeDone: func(_ tls.ConnectionState, err error) {
+			t.tlsHandshakeDoneAt = time.Now()
+			if err == nil && !t.tlsHandshakeStartAt.IsZero() {
+				t.TLSMs = t.tlsHandshakeDoneAt.Sub(t.tlsHandshakeStartAt).Milliseconds()
+			}
+		},
+		GotFirstResponseByte: func() {
+			t.gotFirstResponseByteAt = time.Now()
+			if !t.gotConnAt.IsZero() {
+				t.HeaderTTFBMs = t.gotFirstResponseByteAt.Sub(t.gotConnAt).Milliseconds()
+			}
+		},
+	}
+}
+
+type upstreamTracingTransport struct {
+	base   http.RoundTripper
+	ginCtx *gin.Context
+}
+
+func (t *upstreamTracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ginCtx := t.ginCtx
+	if ginCtx == nil {
+		ginCtx, _ = req.Context().Value(util.ContextKeyGin).(*gin.Context)
+	}
+
+	trace := &upstreamTraceTimings{requestStart: time.Now()}
+	if req.URL != nil {
+		trace.Host = req.URL.Host
+		trace.Scheme = req.URL.Scheme
+	}
+
+	traceCtx := httptrace.WithClientTrace(req.Context(), trace.clientTrace())
+	reqWithTrace := req.WithContext(traceCtx)
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	resp, err := base.RoundTrip(reqWithTrace)
+
+	if ginCtx != nil {
+		storeUpstreamTiming(ginCtx, trace)
+	}
+
+	return resp, err
+}
+
+func storeUpstreamTiming(ginCtx *gin.Context, trace *upstreamTraceTimings) {
+	if ginCtx == nil || trace == nil {
+		return
+	}
+	ginCtx.Set(upstreamTimingKey, trace)
+}
+
+func upstreamTimingFromContext(ginCtx *gin.Context) map[string]any {
+	if ginCtx == nil {
+		return nil
+	}
+	value, exists := ginCtx.Get(upstreamTimingKey)
+	if !exists {
+		return nil
+	}
+	trace, ok := value.(*upstreamTraceTimings)
+	if !ok || trace == nil {
+		return nil
+	}
+
+	result := map[string]any{}
+	if trace.Host != "" {
+		result["host"] = trace.Host
+	}
+	if trace.Scheme != "" {
+		result["scheme"] = trace.Scheme
+	}
+	result["got_conn_reused"] = trace.GotConnReused
+	if trace.WasIdle {
+		result["was_idle"] = true
+		result["idle_ms"] = trace.IdleMs
+	}
+	if trace.ConnectMs > 0 {
+		result["connect_ms"] = trace.ConnectMs
+	}
+	if trace.TLSMs > 0 {
+		result["tls_ms"] = trace.TLSMs
+	}
+	if trace.HeaderTTFBMs > 0 {
+		result["header_ttfb_ms"] = trace.HeaderTTFBMs
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/internal/runtime/executor/usage_request_details.go
+++ b/internal/runtime/executor/usage_request_details.go
@@ -75,6 +75,9 @@ func buildRequestDetailContent(ctx context.Context) string {
 	if egress := requestLogEgressFromContext(ginCtx); len(egress) > 0 {
 		detail["egress"] = egress
 	}
+	if timing := upstreamTimingFromContext(ginCtx); len(timing) > 0 {
+		detail["upstream_timing"] = timing
+	}
 
 	data, err := json.Marshal(detail)
 	if err != nil {

--- a/internal/util/proxy.go
+++ b/internal/util/proxy.go
@@ -75,15 +75,20 @@ func BuildProxyTransport(proxyURL string, preferIPv4 bool) *http.Transport {
 			password, _ := parsedURL.User.Password()
 			proxyAuth = &proxy.Auth{User: username, Password: password}
 		}
-		dialer, errSOCKS5 := proxy.SOCKS5("tcp", parsedURL.Host, proxyAuth, proxy.Direct)
+		proxyNetwork := "tcp"
+		if preferIPv4 {
+			proxyNetwork = "tcp4"
+		}
+		forwardDialer := &net.Dialer{Timeout: DefaultHTTPDialTimeout, KeepAlive: 30 * time.Second}
+		dialer, errSOCKS5 := proxy.SOCKS5(proxyNetwork, parsedURL.Host, proxyAuth, forwardDialer)
 		if errSOCKS5 != nil {
 			log.Errorf("create SOCKS5 dialer failed: %v", errSOCKS5)
 			return nil
 		}
 		transport.Proxy = nil
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if preferIPv4 {
-				network = "tcp4"
+			if contextDialer, ok := dialer.(proxy.ContextDialer); ok {
+				return contextDialer.DialContext(ctx, network, addr)
 			}
 			return dialer.Dial(network, addr)
 		}

--- a/internal/util/proxy_test.go
+++ b/internal/util/proxy_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -38,5 +39,62 @@ func TestBuildProxyTransportUsesLongResponseHeaderTimeout(t *testing.T) {
 	}
 	if proxyURL == nil || proxyURL.String() != "http://127.0.0.1:8080" {
 		t.Fatalf("Proxy URL = %v, want http://127.0.0.1:8080", proxyURL)
+	}
+}
+
+func TestBuildProxyTransportSocks5HonorsClientTimeout(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	defer func() {
+		close(done)
+		_ = listener.Close()
+	}()
+
+	accepted := make(chan struct{}, 1)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case accepted <- struct{}{}:
+			default:
+			}
+			go func() {
+				defer conn.Close()
+				<-done
+			}()
+		}
+	}()
+
+	transport := BuildProxyTransport("socks5://"+listener.Addr().String(), false)
+	if transport == nil {
+		t.Fatal("BuildProxyTransport returned nil")
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   200 * time.Millisecond,
+	}
+
+	started := time.Now()
+	resp, err := client.Get("http://example.com/")
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatal("client.Get returned nil error, want timeout while SOCKS5 server stalls")
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("SOCKS5 dial elapsed %s, want client timeout to cancel promptly", elapsed)
+	}
+	select {
+	case <-accepted:
+	default:
+		t.Fatal("test SOCKS5 listener did not receive a connection")
 	}
 }


### PR DESCRIPTION
## Summary
- add proxy warmup runtime lifecycle and config resolution
- reuse warmed proxy transports and record upstream timing in request details
- make SOCKS5 dialing honor context cancellation and warmup drain responses for connection reuse
- add focused tests for warmup reuse, proxy-id resolution, timing details, and SOCKS5 timeout behavior

## Tests
- rtk go test ./internal/runtime/executor ./internal/config ./internal/api ./internal/util
- rtk go test ./...
