### PR TITLE
feat: expose auth file cost and quota usage trends

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -820,15 +820,22 @@ func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 	}
 
 	var payload struct {
-		AuthIndex         string  `json:"auth_index"`
-		RequestTotal      int64   `json:"request_total"`
-		CycleRequestTotal int64   `json:"cycle_request_total"`
-		CycleCostTotal    float64 `json:"cycle_cost_total"`
-		CycleStart        string  `json:"cycle_start"`
+		AuthIndex         string   `json:"auth_index"`
+		RequestTotal      int64    `json:"request_total"`
+		CycleRequestTotal int64    `json:"cycle_request_total"`
+		CycleCostTotal    float64  `json:"cycle_cost_total"`
+		WeeklyQuotaUsed   *float64 `json:"weekly_quota_used_percent"`
+		CycleStart        string   `json:"cycle_start"`
 		DailyUsage        []struct {
-			Date     string `json:"date"`
-			Requests int64  `json:"requests"`
+			Date     string  `json:"date"`
+			Requests int64   `json:"requests"`
+			Cost     float64 `json:"cost"`
 		} `json:"daily_usage"`
+		HourlyUsage []struct {
+			Hour     string  `json:"hour"`
+			Requests int64   `json:"requests"`
+			Cost     float64 `json:"cost"`
+		} `json:"hourly_usage"`
 		QuotaSeries []struct {
 			QuotaKey      string `json:"quota_key"`
 			QuotaLabel    string `json:"quota_label"`
@@ -855,11 +862,28 @@ func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 	if math.Abs(payload.CycleCostTotal-0.008) > 1e-12 {
 		t.Fatalf("cycle_cost_total = %v, want 0.008", payload.CycleCostTotal)
 	}
+	if payload.WeeklyQuotaUsed == nil || math.Abs(*payload.WeeklyQuotaUsed-7) > 1e-12 {
+		t.Fatalf("weekly_quota_used_percent = %v, want 7", payload.WeeklyQuotaUsed)
+	}
 	if payload.CycleStart != cycleStart.Format(time.RFC3339) {
 		t.Fatalf("cycle_start = %q, want %q", payload.CycleStart, cycleStart.Format(time.RFC3339))
 	}
 	if len(payload.DailyUsage) != 7 {
 		t.Fatalf("daily_usage len = %d, want 7", len(payload.DailyUsage))
+	}
+	var dailyCostTotal float64
+	for _, point := range payload.DailyUsage {
+		dailyCostTotal += point.Cost
+	}
+	if math.Abs(dailyCostTotal-0.013) > 1e-12 {
+		t.Fatalf("daily_usage cost total = %v, want 0.013", dailyCostTotal)
+	}
+	var hourlyCostTotal float64
+	for _, point := range payload.HourlyUsage {
+		hourlyCostTotal += point.Cost
+	}
+	if math.Abs(hourlyCostTotal-0.003) > 1e-12 {
+		t.Fatalf("hourly_usage cost total = %v, want 0.003", hourlyCostTotal)
 	}
 	if len(payload.QuotaSeries) != 1 {
 		t.Fatalf("quota_series len = %d, want 1", len(payload.QuotaSeries))

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -43,18 +43,18 @@ func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any
 	matcher := s.authSubjectMatcher(auth)
 	preferredWeeklyQuotaKeys := primaryWeeklyQuotaKeysForProvider(auth.Provider)
 
-	dailyRaw, err := usage.QueryDailyCallsByAuthSubject(matcher, days)
+	dailyRaw, err := usage.QueryDailyUsageByAuthSubject(matcher, days)
 	if err != nil {
 		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 	}
-	daily := fillDailyCountPoints(dailyRaw, days)
+	daily := fillDailyUsagePoints(dailyRaw, days)
 
-	hourly, err := usage.QueryHourlyCallsByAuthSubject(matcher, hours)
+	hourly, err := usage.QueryHourlyUsageByAuthSubject(matcher, hours)
 	if err != nil {
 		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 	}
 	if hourly == nil {
-		hourly = []usage.HourlyCountPoint{}
+		hourly = []usage.HourlyUsagePoint{}
 	}
 
 	cutoff := usage.CutoffStartUTC(days)
@@ -72,6 +72,7 @@ func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any
 	if series == nil {
 		series = []usage.QuotaSnapshotSeries{}
 	}
+	weeklyQuotaUsed := latestWeeklyQuotaUsedPercent(series, preferredWeeklyQuotaKeys...)
 
 	var cycleStart time.Time
 	if identity := usage.ResolveAuthSubjectIdentity(auth); identity != nil && identity.ID != "" {
@@ -114,6 +115,7 @@ func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any
 		RequestTotal:      requestTotal,
 		CycleRequestTotal: cycleRequestTotal,
 		CycleCostTotal:    cycleCostTotal,
+		WeeklyQuotaUsed:   weeklyQuotaUsed,
 		CycleKnown:        cycleKnown,
 		CycleStart:        cycleStartStr,
 		DailyUsage:        daily,
@@ -122,21 +124,81 @@ func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any
 	}
 }
 
-func fillDailyCountPoints(points []usage.DailyCountPoint, days int) []usage.DailyCountPoint {
+func fillDailyUsagePoints(points []usage.DailyUsagePoint, days int) []usage.DailyUsagePoint {
 	if days < 1 {
 		days = 7
 	}
-	byDate := make(map[string]int64, len(points))
+	byDate := make(map[string]usage.DailyUsagePoint, len(points))
 	for _, point := range points {
-		byDate[point.Date] += point.Requests
+		existing := byDate[point.Date]
+		existing.Date = point.Date
+		existing.Requests += point.Requests
+		existing.Cost += point.Cost
+		byDate[point.Date] = existing
 	}
 	start := usage.CutoffStartUTC(days)
-	result := make([]usage.DailyCountPoint, 0, days)
+	result := make([]usage.DailyUsagePoint, 0, days)
 	for i := 0; i < days; i++ {
 		date := usage.LocalDayKeyAt(start.AddDate(0, 0, i))
-		result = append(result, usage.DailyCountPoint{Date: date, Requests: byDate[date]})
+		point := byDate[date]
+		point.Date = date
+		result = append(result, point)
 	}
 	return result
+}
+
+func latestWeeklyQuotaUsedPercent(series []usage.QuotaSnapshotSeries, preferredQuotaKeys ...string) *float64 {
+	latest := latestWeeklyQuotaPercentPoint(series, preferredQuotaKeys...)
+	if latest == nil || latest.Percent == nil {
+		return nil
+	}
+	value := 100 - *latest.Percent
+	if value < 0 {
+		value = 0
+	}
+	if value > 100 {
+		value = 100
+	}
+	return &value
+}
+
+func latestWeeklyQuotaPercentPoint(series []usage.QuotaSnapshotSeries, preferredQuotaKeys ...string) *usage.QuotaSnapshotSeriesPoint {
+	point := latestWeeklyQuotaPercentPointStrict(series, preferredQuotaKeys...)
+	if point != nil {
+		return point
+	}
+	return latestWeeklyQuotaPercentPointStrict(series)
+}
+
+func latestWeeklyQuotaPercentPointStrict(series []usage.QuotaSnapshotSeries, preferredQuotaKeys ...string) *usage.QuotaSnapshotSeriesPoint {
+	preferred := make(map[string]struct{}, len(preferredQuotaKeys))
+	for _, quotaKey := range preferredQuotaKeys {
+		if trimmed := strings.TrimSpace(quotaKey); trimmed != "" {
+			preferred[trimmed] = struct{}{}
+		}
+	}
+	requiresPreferredKey := len(preferred) > 0
+	var latestPoint *usage.QuotaSnapshotSeriesPoint
+	for i := range series {
+		if series[i].WindowSeconds < 604800 {
+			continue
+		}
+		if requiresPreferredKey {
+			if _, ok := preferred[strings.TrimSpace(series[i].QuotaKey)]; !ok {
+				continue
+			}
+		}
+		for j := range series[i].Points {
+			point := &series[i].Points[j]
+			if point.Percent == nil {
+				continue
+			}
+			if latestPoint == nil || point.Timestamp.After(latestPoint.Timestamp) {
+				latestPoint = point
+			}
+		}
+	}
+	return latestPoint
 }
 
 func latestWeeklyQuotaCycleStart(series []usage.QuotaSnapshotSeries, preferredQuotaKeys ...string) (time.Time, bool) {

--- a/internal/management/usagelogs/types.go
+++ b/internal/management/usagelogs/types.go
@@ -47,9 +47,10 @@ type AuthFileTrendResponse struct {
 	RequestTotal      int64                       `json:"request_total"`
 	CycleRequestTotal int64                       `json:"cycle_request_total"`
 	CycleCostTotal    float64                     `json:"cycle_cost_total"`
+	WeeklyQuotaUsed   *float64                    `json:"weekly_quota_used_percent"`
 	CycleKnown        bool                        `json:"cycle_known"`
 	CycleStart        string                      `json:"cycle_start"`
-	DailyUsage        []usage.DailyCountPoint     `json:"daily_usage"`
-	HourlyUsage       []usage.HourlyCountPoint    `json:"hourly_usage"`
+	DailyUsage        []usage.DailyUsagePoint     `json:"daily_usage"`
+	HourlyUsage       []usage.HourlyUsagePoint    `json:"hourly_usage"`
 	QuotaSeries       []usage.QuotaSnapshotSeries `json:"quota_series"`
 }

--- a/internal/usage/auth_subject_usage_query.go
+++ b/internal/usage/auth_subject_usage_query.go
@@ -8,9 +8,21 @@ import (
 )
 
 func QueryDailyCallsByAuthSubject(matcher AuthSubjectMatcher, days int) ([]DailyCountPoint, error) {
+	usagePoints, err := QueryDailyUsageByAuthSubject(matcher, days)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]DailyCountPoint, 0, len(usagePoints))
+	for _, point := range usagePoints {
+		result = append(result, DailyCountPoint{Date: point.Date, Requests: point.Requests})
+	}
+	return result, nil
+}
+
+func QueryDailyUsageByAuthSubject(matcher AuthSubjectMatcher, days int) ([]DailyUsagePoint, error) {
 	db := getDB()
 	if db == nil {
-		return []DailyCountPoint{}, nil
+		return []DailyUsagePoint{}, nil
 	}
 	if days < 1 {
 		days = 7
@@ -18,7 +30,7 @@ func QueryDailyCallsByAuthSubject(matcher AuthSubjectMatcher, days int) ([]Daily
 
 	matchSQL, matchArgs := buildAuthSubjectMatchClause(matcher, "source", "channel_name")
 	if matchSQL == "" {
-		return []DailyCountPoint{}, nil
+		return []DailyUsagePoint{}, nil
 	}
 
 	args := make([]interface{}, 0, len(matchArgs)+1)
@@ -26,35 +38,43 @@ func QueryDailyCallsByAuthSubject(matcher AuthSubjectMatcher, days int) ([]Daily
 	args = append(args, matchArgs...)
 
 	rows, err := db.Query(fmt.Sprintf(`
-		SELECT timestamp
+		SELECT timestamp, cost
 		FROM request_logs
 		WHERE timestamp >= ? AND (%s)
 		ORDER BY timestamp ASC
 	`, matchSQL), args...)
 	if err != nil {
-		return nil, fmt.Errorf("usage: daily calls by auth subject query: %w", err)
+		return nil, fmt.Errorf("usage: daily usage by auth subject query: %w", err)
 	}
 	defer rows.Close()
 
-	byDate := make(map[string]int64, days)
+	byDate := make(map[string]*DailyUsagePoint, days)
 	for rows.Next() {
 		var ts string
-		if err := rows.Scan(&ts); err != nil {
-			return nil, fmt.Errorf("usage: daily calls by auth subject scan: %w", err)
+		var cost float64
+		if err := rows.Scan(&ts, &cost); err != nil {
+			return nil, fmt.Errorf("usage: daily usage by auth subject scan: %w", err)
 		}
 		parsed, ok := parseStoredTime(ts)
 		if !ok {
 			continue
 		}
-		byDate[localDayKeyAt(parsed)]++
+		key := localDayKeyAt(parsed)
+		point := byDate[key]
+		if point == nil {
+			point = &DailyUsagePoint{Date: key}
+			byDate[key] = point
+		}
+		point.Requests++
+		point.Cost += cost
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	result := make([]DailyCountPoint, 0, len(byDate))
-	for date, requests := range byDate {
-		result = append(result, DailyCountPoint{Date: date, Requests: requests})
+	result := make([]DailyUsagePoint, 0, len(byDate))
+	for _, point := range byDate {
+		result = append(result, *point)
 	}
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Date < result[j].Date
@@ -63,9 +83,21 @@ func QueryDailyCallsByAuthSubject(matcher AuthSubjectMatcher, days int) ([]Daily
 }
 
 func QueryHourlyCallsByAuthSubject(matcher AuthSubjectMatcher, hours int) ([]HourlyCountPoint, error) {
+	usagePoints, err := QueryHourlyUsageByAuthSubject(matcher, hours)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]HourlyCountPoint, 0, len(usagePoints))
+	for _, point := range usagePoints {
+		result = append(result, HourlyCountPoint{Hour: point.Hour, Requests: point.Requests})
+	}
+	return result, nil
+}
+
+func QueryHourlyUsageByAuthSubject(matcher AuthSubjectMatcher, hours int) ([]HourlyUsagePoint, error) {
 	db := getDB()
 	if db == nil {
-		return []HourlyCountPoint{}, nil
+		return []HourlyUsagePoint{}, nil
 	}
 	if hours < 1 {
 		hours = 5
@@ -76,17 +108,17 @@ func QueryHourlyCallsByAuthSubject(matcher AuthSubjectMatcher, hours int) ([]Hou
 
 	matchSQL, matchArgs := buildAuthSubjectMatchClause(matcher, "source", "channel_name")
 	if matchSQL == "" {
-		return []HourlyCountPoint{}, nil
+		return []HourlyUsagePoint{}, nil
 	}
 
 	loc := getUsageLocation()
 	now := time.Now().In(loc).Truncate(time.Hour)
 	start := now.Add(-time.Duration(hours-1) * time.Hour)
-	buckets := make([]HourlyCountPoint, 0, hours)
-	byKey := make(map[string]*HourlyCountPoint, hours)
+	buckets := make([]HourlyUsagePoint, 0, hours)
+	byKey := make(map[string]*HourlyUsagePoint, hours)
 	for i := 0; i < hours; i++ {
 		key := start.Add(time.Duration(i) * time.Hour).Format("2006-01-02 15:00")
-		buckets = append(buckets, HourlyCountPoint{Hour: key})
+		buckets = append(buckets, HourlyUsagePoint{Hour: key})
 		byKey[key] = &buckets[len(buckets)-1]
 	}
 
@@ -95,19 +127,20 @@ func QueryHourlyCallsByAuthSubject(matcher AuthSubjectMatcher, hours int) ([]Hou
 	args = append(args, matchArgs...)
 
 	rows, err := db.Query(fmt.Sprintf(`
-		SELECT timestamp
+		SELECT timestamp, cost
 		FROM request_logs
 		WHERE timestamp >= ? AND (%s)
 	`, matchSQL), args...)
 	if err != nil {
-		return nil, fmt.Errorf("usage: hourly calls by auth subject query: %w", err)
+		return nil, fmt.Errorf("usage: hourly usage by auth subject query: %w", err)
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var ts string
-		if err := rows.Scan(&ts); err != nil {
-			return nil, fmt.Errorf("usage: hourly calls by auth subject scan: %w", err)
+		var cost float64
+		if err := rows.Scan(&ts, &cost); err != nil {
+			return nil, fmt.Errorf("usage: hourly usage by auth subject scan: %w", err)
 		}
 		parsed, ok := parseStoredTime(ts)
 		if !ok {
@@ -116,6 +149,7 @@ func QueryHourlyCallsByAuthSubject(matcher AuthSubjectMatcher, hours int) ([]Hou
 		key := parsed.In(loc).Truncate(time.Hour).Format("2006-01-02 15:00")
 		if bucket := byKey[key]; bucket != nil {
 			bucket.Requests++
+			bucket.Cost += cost
 		}
 	}
 	return buckets, rows.Err()

--- a/internal/usage/request_log_auth_trends.go
+++ b/internal/usage/request_log_auth_trends.go
@@ -12,6 +12,12 @@ type DailyCountPoint struct {
 	Requests int64  `json:"requests"`
 }
 
+type DailyUsagePoint struct {
+	Date     string  `json:"date"`
+	Requests int64   `json:"requests"`
+	Cost     float64 `json:"cost"`
+}
+
 type DailyQuotaPoint struct {
 	Date    string   `json:"date"`
 	Percent *float64 `json:"percent"`
@@ -21,6 +27,12 @@ type DailyQuotaPoint struct {
 type HourlyCountPoint struct {
 	Hour     string `json:"hour"`
 	Requests int64  `json:"requests"`
+}
+
+type HourlyUsagePoint struct {
+	Hour     string  `json:"hour"`
+	Requests int64   `json:"requests"`
+	Cost     float64 `json:"cost"`
 }
 
 func QueryDailyCallsByAuthIndexes(authIndexes []string, days int) ([]DailyCountPoint, error) {


### PR DESCRIPTION
## Summary
- include per-day and per-hour cost in auth-file trend API
- expose weekly quota used percentage derived from weekly quota snapshots
- cover cost and quota usage response fields in management handler tests

## Validation
- rtk go test ./internal/usage ./internal/management/usagelogs ./internal/api/handlers/management
- rtk go test ./internal/api/handlers/management -run 'TestGetAuthFileTrend|TestPostAuthFileQuotaSnapshot'