### PR TITLE
fix: skip empty tool names in Claude conversion

### DIFF
--- a/docs/internal-review/empty-tool-name-chain-test-report-20260613.md
+++ b/docs/internal-review/empty-tool-name-chain-test-report-20260613.md
@@ -8,9 +8,9 @@ PR：<https://github.com/kittors/CliRelay/pull/430>
 
 ## 结论
 
-本轮已经完成针对“OpenAI Chat Completions 空/空白 `function.name` 转 Claude `tool_use`”问题的系统分析、功能测试、接口级测试、场景链路测试、高保真模拟测试和全仓回归。
+本轮已经完成针对“OpenAI Chat Completions 空/空白 `function.name` 转 Claude `tool_use`”问题的系统分析、功能测试、接口级测试、场景链路测试、高保真模拟测试、不变量生成测试和全仓回归。
 
-当前修复不是宣称数学意义上的“绝对保证”。更准确的结论是：本项目内与该问题相关的转换边界、SDK 注册链路、executor HTTP 接口链路、历史回放链路、参考项目推理出的 provider-shaped chunk 序列和全仓回归均已覆盖并通过；真实第三方供应商未来可能输出新的非标准事件形态，仍需要后续按样本补充回归。
+当前修复不能宣称覆盖未来所有第三方 provider 可能发明的新协议形态；但对本项目当前声明支持的 OpenAI Chat Completions ↔ Claude Messages 相关状态空间，已经把“不得出现空工具名、不得出现孤儿工具 delta/stop、不得误报 `stop_reason=tool_use`、不得在下一轮回放产生孤儿 `tool` message”转成不变量，并用生成测试覆盖通过。
 
 ## 问题范围
 
@@ -87,6 +87,46 @@ PR：<https://github.com/kittors/CliRelay/pull/430>
 - executor 接口层新增 `TestOpenAICompatExecutorClaudeStreamSkipsMissingToolNameArgumentsEndToEnd`：Claude dirty history -> OpenAI upstream request -> provider-shaped missing-name stream -> Claude response 全链路。
 - executor 接口层新增 `TestOpenAICompatExecutorClaudeStreamPreservesValidParallelToolWhenEmptyIndexFirstEndToEnd`：mock OpenAI-compatible HTTP SSE 返回空 index + 有效 index，验证最终 Claude stream 只保留有效工具。
 
+## 不变量生成测试
+
+为把“绝对没问题”落到可验证边界，本轮新增有限状态空间生成测试，而不是只靠固定样例。
+
+输出侧不变量：
+
+- 任意 `tool_use` content block 的 `name` 必须 `TrimSpace(name) != ""`。
+- 任意 `input_json_delta` 必须挂在已经打开的 `tool_use` block 上。
+- 任意 `text_delta` 必须挂在已经打开的 `text` block 上。
+- 任意 `thinking_delta` 必须挂在已经打开的 `thinking` block 上。
+- 任意 `content_block_stop` 必须有对应的 `content_block_start`。
+- 流结束时不能留下未关闭 content block。
+- 若没有实际发出有效 `tool_use`，`message_delta.delta.stop_reason` 不能是 `tool_use`。
+- 每条流必须且只能有一个 `message_stop`。
+
+生成覆盖：
+
+- `function.name` 状态：字段缺失、空字符串、空白字符串、首 chunk 有效、后续 chunk 有效。
+- `function.arguments` 状态：无参数、首 chunk 参数、参数分片、后续 chunk 参数。
+- finish reason：`tool_calls` 与 legacy `function_call`。
+- usage：有 usage-only chunk 与无 usage-only chunk。
+- 并行工具：无效 `index=0` 与有效 `index=1` 同时/随后出现。
+- 非流式形态：`message.tool_calls` 与 content-array `tool_calls`。
+
+请求侧不变量：
+
+- Claude 历史中的空/空白/缺失 `tool_use.name` 不能转成 OpenAI `tool_calls`。
+- 被跳过的 `tool_use` 对应 `tool_result` 不能转成 OpenAI `role=tool`。
+- 有效 `tool_use` 必须保留对应 `tool_calls` 与 `tool_result`。
+- 空/空白/缺失 `tools[].name` 不能进入 OpenAI `tools`。
+- 空/空白/缺失 `tool_choice.name` 必须降级为 `auto`。
+
+新增生成测试：
+
+- `TestOpenAIStreamingToolNameStateInvariantsGenerated`
+- `TestOpenAIStreamingParallelToolNameStateInvariantsGenerated`
+- `TestOpenAINonStreamingToolNameStateInvariantsGenerated`
+- `TestConvertClaudeRequestToOpenAI_ToolUseNameInvariantsGenerated`
+- `TestConvertClaudeRequestToOpenAI_ToolsAndToolChoiceNameInvariantsGenerated`
+
 ## 功能测试
 
 文件：`internal/translator/openai/claude/openai_claude_response_test.go`
@@ -116,7 +156,7 @@ PR：<https://github.com/kittors/CliRelay/pull/430>
 
 ```text
 rtk go test ./internal/translator/openai/claude -count=1 -v
-Go test: 35 passed in 1 packages
+Go test: 174 passed in 1 packages
 ```
 
 ## 场景链路测试
@@ -172,7 +212,7 @@ Go test: 4 passed in 1 packages
 
 ```text
 rtk go test ./internal/translator/... -count=1
-Go test: 110 passed in 30 packages
+Go test: 249 passed in 30 packages
 
 rtk go test ./test -count=1
 Go test: 276 passed in 1 packages
@@ -185,7 +225,7 @@ Go test: 221 passed in 1 packages
 
 ```text
 rtk go test ./... -count=1
-Go test: 2044 passed in 147 packages
+Go test: 2183 passed in 147 packages
 
 rtk go vet ./...
 Go vet: No issues found

--- a/docs/internal-review/empty-tool-name-chain-test-report-20260613.md
+++ b/docs/internal-review/empty-tool-name-chain-test-report-20260613.md
@@ -247,6 +247,25 @@ passed
 
 PR #430 当前 base 为 `dev`。普通 build 已通过；但仓库策略 `translator-path-guard / ensure-no-translator-changes` 会阻止 PR 修改 `internal/translator/**`，因此该 PR 不能直接按普通策略合并。该阻塞不是测试失败，而是仓库治理策略。
 
+## Translator Path Guard 审计
+
+工作流文件：`.github/workflows/pr-path-guard.yml`
+
+规则摘要：
+
+- 触发条件：`pull_request` 的 `opened`、`synchronize`、`reopened`。
+- 检测范围：`internal/translator/**`。
+- 检测方式：`tj-actions/changed-files@v45`。
+- 失败条件：`steps.changed-files.outputs.any_changed == 'true'`。
+- 失败信息：`Changes under internal/translator are not allowed in pull requests.`，并提示 `You need to create an issue for our maintenance team to make the necessary changes.`
+
+本 PR 的触发证据：
+
+- PR #430 changed files 包含 `internal/translator/openai/claude/openai_claude_request.go`、`internal/translator/openai/claude/openai_claude_response.go` 及对应测试。
+- `translator-path-guard / ensure-no-translator-changes` 在 GitHub Actions run `27453301752`、job `81152865941` 中失败。
+- 日志显示比较范围为 `4852be243a4ff1827320be688d6d08c4de860975 (dev)` 到 `59f79e965c00beadedaa06b6f6020e90b485adb7 (codex/fix-empty-tool-name-state)`，并命中 `internal/translator/**`。
+- 该 workflow 未发现 label、手动输入、路径白名单或 PR body 开关，因此普通 PR 路径下没有不修改治理策略的自动通过方式。
+
 后续选项：
 
 - 维护者临时批准 translator 路径变更后合并 PR #430。

--- a/docs/internal-review/empty-tool-name-chain-test-report-20260613.md
+++ b/docs/internal-review/empty-tool-name-chain-test-report-20260613.md
@@ -1,0 +1,193 @@
+# Empty Tool Name Conversion Chain Test Report
+
+日期：2026-06-13
+
+分支：`codex/fix-empty-tool-name-state`
+
+PR：<https://github.com/kittors/CliRelay/pull/430>
+
+## 结论
+
+本轮已经完成针对“OpenAI Chat Completions 空/空白 `function.name` 转 Claude `tool_use`”问题的系统分析、功能测试、接口级测试、场景链路测试和全仓回归。
+
+当前修复不是宣称数学意义上的“绝对保证”。更准确的结论是：本项目内与该问题相关的转换边界、SDK 注册链路、executor HTTP 接口链路、历史回放链路和全仓回归均已覆盖并通过；真实第三方供应商未来可能输出新的非标准事件形态，仍需要后续按样本补充回归。
+
+## 问题范围
+
+风险链路：
+
+1. 上游 OpenAI-compatible stream/non-stream 响应返回 `tool_calls`，但 `function.name` 为空字符串或空白字符串。
+2. 转换器若仍创建 Claude `tool_use`，会产生非法 `tool_use.name`。
+3. 转换器若没有创建 `content_block_start`，但仍输出 `input_json_delta` 或 `content_block_stop`，会产生孤儿 content block 事件。
+4. 只有空工具名时，如果仍把 OpenAI `finish_reason=tool_calls/function_call` 映射成 Claude `stop_reason=tool_use`，客户端会以为需要执行工具，但响应里没有合法工具块。
+5. 下一轮 Claude 历史回放时，空 `tool_use` 可能被转成 OpenAI `tool_calls`，对应 `tool_result` 可能变成没有前置调用的孤儿 `role=tool` 消息。
+
+## 修复策略
+
+响应侧：`internal/translator/openai/claude/openai_claude_response.go`
+
+- `ToolCallAccumulator` 增加 `Started` 与 `BlockIndex` 状态。
+- 只有 `strings.TrimSpace(function.name)` 非空时，才分配 Claude content block index 并发送 `content_block_start`。
+- `arguments` 可以先缓存；等后续 chunk 收到有效 name 后再补发合法 `input_json_delta`。
+- `finalizeToolContentBlocks` 只结束已经 `Started` 的工具块，不为未启动的空工具名调用发送 `input_json_delta` 或 `content_block_stop`。
+- `tool_calls/function_call` finish reason 只有在实际发出有效 `tool_use` 时才映射为 `tool_use`；否则映射为 `end_turn`。
+- 非流式路径同样跳过空/空白 `function.name`，并用有效工具存在性决定 `stop_reason`。
+
+请求侧：`internal/translator/openai/claude/openai_claude_request.go`
+
+- Claude `tool_use.name` 为空或空白时，不转成 OpenAI `tool_calls`。
+- 用 `validToolUseIDs` 记录真正保留的工具调用 ID；对应 `tool_result` 只有命中该集合时才转成 OpenAI `role=tool`。
+- `tools[].name` 为空或空白时跳过。
+- `tool_choice.type=tool` 但 `name` 为空或空白时降级为 `auto`。
+
+## 参考项目对比
+
+参考源码为 2026-06-13 浅克隆快照：
+
+- `QuantumNous/new-api`：`51475c8`
+- `Wei-Shaw/sub2api`：`e34ad2b`
+
+`new-api` 观察结论：
+
+- `service/convert.go` 的 OpenAI stream -> Claude 逻辑会在首个 tool chunk 直接用 `toolCall.Function.Name` 创建 `tool_use`。
+- 中间 chunk 分支只在 `toolCall.Function.Name != ""` 时发送 `content_block_start`，但 `Function.Arguments` 非空时仍会发送 `input_json_delta`。
+- 结束时 `stopReasonOpenAI2Claude(info.FinishReason)` 仍按 `tool_calls -> tool_use` 映射。
+- 非流式 `ResponseOpenAI2Claude` 也直接把 `toolUse.Function.Name` 写入 Claude `tool_use`。
+- 未检索到针对空/空白工具名的专门测试。
+
+`sub2api` 观察结论：
+
+- `backend/internal/pkg/apicompat/responses_to_anthropic_request.go` 对 `tool_use/tool_result` 邻接关系有系统修复，会丢弃无匹配关系的孤儿工具结果。
+- `backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go` 在 ChatCompletions stream -> Responses stream 时，首次看到 `tool_calls` 就创建 `function_call` item，`Name` 取当时的 `stored.Function.Name`；如果 name 尚未到达或为空，会把空 name 带入后续 Responses 事件。
+- `backend/internal/pkg/apicompat/responses_to_anthropic.go` 把 `function_call` 直接转成 Claude `tool_use`，未看到空 name 门禁。
+- 未检索到针对空/空白工具名的专门测试。
+
+对本项目的启发：
+
+- 只修邻接关系不够；空工具名要在“工具块真正启动”的状态边界处理。
+- 只在 `content_block_start` 上判空也不够；必须同时处理 `input_json_delta`、`content_block_stop` 和 `stop_reason`。
+- 请求侧必须连同历史回放一起修，避免下一轮请求重新制造非法 `tool_calls` 或孤儿 `tool` message。
+
+## 功能测试
+
+文件：`internal/translator/openai/claude/openai_claude_response_test.go`
+
+覆盖点：
+
+- 流式空 `function.name` 不产生 `tool_use`、`input_json_delta`、孤儿 `content_block_stop`。
+- 流式空白 `function.name` 同样跳过。
+- 文本后接空工具名时，保留文本，跳过非法工具。
+- usage-only chunk 延后到达时，`stop_reason` 仍为 `end_turn`，且只发送一次 `message_stop`。
+- `arguments` 先到、有效 `name` 后到时，缓存参数并输出完整合法工具块。
+- 有效工具和空工具混合时，只保留有效工具。
+- 非流式 message-level `tool_calls` 空名跳过，`stop_reason=end_turn`。
+- 非流式 content-array `tool_calls` 空名跳过，`stop_reason=end_turn`。
+
+文件：`internal/translator/openai/claude/openai_claude_request_test.go`
+
+覆盖点：
+
+- Claude 空 `tool_use.name` 不转成 OpenAI `tool_calls`。
+- 被跳过的 `tool_use` 对应 `tool_result` 不转成孤儿 OpenAI `role=tool`。
+- 有效 `tool_use` 与匹配 `tool_result` 保持正常回放。
+- 空/空白 `tools[].name` 被跳过。
+- 空白 `tool_choice.name` 降级为 `auto`。
+
+执行结果：
+
+```text
+rtk go test ./internal/translator/openai/claude -count=1 -v
+Go test: 32 passed in 1 packages
+```
+
+## 场景链路测试
+
+文件：`test/openai_claude_empty_tool_chain_test.go`
+
+该测试不直接调用包内函数，而是走 public `sdktranslator` registry，覆盖更接近实际使用的转换注册链路。
+
+覆盖点：
+
+- OpenAI 流式空 `function.name` -> Claude SSE：不产生非法工具块，`stop_reason=end_turn`。
+- Dirty Claude 历史回放 -> 下一轮 OpenAI 请求：不产生空 `tool_calls` 或孤儿 `role=tool`。
+- `arguments` 先到、有效 `name` 后到：合法工具保留，历史回放也保留。
+- 有效工具和空白工具混合：只保留有效工具。
+- 非流式空工具名：不产生 Claude `tool_use`，`stop_reason=end_turn`。
+
+执行结果：
+
+```text
+rtk go test ./test -run 'TestOpenAIClaude.*Tool.*Chain|TestOpenAIClaudeEmptyToolNameNonStreamingChain' -count=1 -v
+Go test: 4 passed in 1 packages
+```
+
+## 接口级测试
+
+文件：`internal/runtime/executor/openai_compat_executor_compact_test.go`
+
+新增测试：
+
+- `TestOpenAICompatExecutorClaudeStreamSkipsEmptyToolNameEndToEnd`
+- `TestOpenAICompatExecutorClaudeNonStreamSkipsEmptyToolNameEndToEnd`
+
+该组测试通过真实 `OpenAICompatExecutor` 和 `httptest.NewServer` mock OpenAI-compatible `/v1/chat/completions`，覆盖 executor 层的入站、出站和响应转换：
+
+1. 入站 Claude dirty history 包含空/空白 `tool_use.name` 与对应 `tool_result`。
+2. executor 转给 mock OpenAI 上游的请求中，不允许出现空 `tool_calls` 或孤儿 `role=tool`。
+3. mock 上游返回空 `function.name` 的 OpenAI stream/non-stream 响应。
+4. executor 转回 Claude 响应时，不允许出现非法 `tool_use`、孤儿 `input_json_delta` 或孤儿 `content_block_stop`。
+5. 空工具名-only 响应必须落到 `stop_reason=end_turn`。
+
+执行结果：
+
+```text
+rtk go test ./internal/runtime/executor -run 'TestOpenAICompatExecutorClaude(Stream|NonStream)SkipsEmptyToolNameEndToEnd' -count=1 -v
+Go test: 2 passed in 1 packages
+```
+
+## 回归测试
+
+包级回归：
+
+```text
+rtk go test ./internal/translator/... -count=1
+Go test: 107 passed in 30 packages
+
+rtk go test ./test -count=1
+Go test: 274 passed in 1 packages
+
+rtk go test ./internal/runtime/executor -count=1
+Go test: 219 passed in 1 packages
+```
+
+全仓回归与静态检查：
+
+```text
+rtk go test ./... -count=1
+Go test: 2037 passed in 147 packages
+
+rtk go vet ./...
+Go vet: No issues found
+
+rtk go build ./...
+Go build: Success
+
+rtk git diff --check
+passed
+```
+
+## 未覆盖边界
+
+- 未连接真实第三方供应商账号做线上流式采样；本轮用确定性 mock 覆盖协议形态，避免真实供应商输出波动导致测试不可复现。
+- 未修改 OpenAI Responses API 与 Gemini/Bedrock 等无关转换链路；本问题限定在 OpenAI Chat Completions 与 Claude Messages 互转链路。
+- 不能证明未来所有非标准 provider 输出都安全；如果后续出现新的 chunk 顺序或字段形态，需要把真实样本补成回归测试。
+
+## PR 与合并状态
+
+PR #430 当前 base 为 `dev`。普通 build 已通过；但仓库策略 `translator-path-guard / ensure-no-translator-changes` 会阻止 PR 修改 `internal/translator/**`，因此该 PR 不能直接按普通策略合并。该阻塞不是测试失败，而是仓库治理策略。
+
+后续选项：
+
+- 维护者临时批准 translator 路径变更后合并 PR #430。
+- 或按维护 issue #431 先调整治理策略，再合并。
+- 或由维护者在受信任分支接管同等修复并合并。

--- a/docs/internal-review/empty-tool-name-chain-test-report-20260613.md
+++ b/docs/internal-review/empty-tool-name-chain-test-report-20260613.md
@@ -8,9 +8,9 @@ PR：<https://github.com/kittors/CliRelay/pull/430>
 
 ## 结论
 
-本轮已经完成针对“OpenAI Chat Completions 空/空白 `function.name` 转 Claude `tool_use`”问题的系统分析、功能测试、接口级测试、场景链路测试和全仓回归。
+本轮已经完成针对“OpenAI Chat Completions 空/空白 `function.name` 转 Claude `tool_use`”问题的系统分析、功能测试、接口级测试、场景链路测试、高保真模拟测试和全仓回归。
 
-当前修复不是宣称数学意义上的“绝对保证”。更准确的结论是：本项目内与该问题相关的转换边界、SDK 注册链路、executor HTTP 接口链路、历史回放链路和全仓回归均已覆盖并通过；真实第三方供应商未来可能输出新的非标准事件形态，仍需要后续按样本补充回归。
+当前修复不是宣称数学意义上的“绝对保证”。更准确的结论是：本项目内与该问题相关的转换边界、SDK 注册链路、executor HTTP 接口链路、历史回放链路、参考项目推理出的 provider-shaped chunk 序列和全仓回归均已覆盖并通过；真实第三方供应商未来可能输出新的非标准事件形态，仍需要后续按样本补充回归。
 
 ## 问题范围
 
@@ -68,6 +68,25 @@ PR：<https://github.com/kittors/CliRelay/pull/430>
 - 只在 `content_block_start` 上判空也不够；必须同时处理 `input_json_delta`、`content_block_stop` 和 `stop_reason`。
 - 请求侧必须连同历史回放一起修，避免下一轮请求重新制造非法 `tool_calls` 或孤儿 `tool` message。
 
+## 高保真模拟设计
+
+由于当前没有真实第三方供应商账号和可复现线上样本，本轮没有停留在普通 mock，而是根据 `new-api` 与 `sub2api` 的状态机行为推理出更接近真实风险的输入形态：
+
+- `new-api` 风险形态 A：首个 tool chunk 已经包含 `arguments`，但 `function.name` 缺失或为空；结束 chunk 仍给 `finish_reason=tool_calls`。
+- `new-api` 风险形态 B：代码只在 `content_block_start` 上看 name，但 arguments 分支独立执行，因此可能出现没有 start 的 `input_json_delta`。
+- `sub2api` 风险形态 C：ChatCompletions bridge 首次看到 `tool_calls` 就创建后续工具状态；如果 name 当时尚未到达，后续可能携带空 name 继续进入 Responses/Anthropic 转换。
+- 并行工具风险形态 D：空工具调用在 `index=0`，有效工具调用在 `index=1`；修复不能因为跳过空 index 而破坏有效并行工具。
+
+对应新增模拟：
+
+- 转换器层新增 `TestOpenAIStreamingToolArgumentsWithoutValidNameSkipped`：arguments 到达但有效 name 永远不到，不能产生任何 Claude 工具事件，`stop_reason=end_turn`。
+- 转换器层新增 `TestOpenAIStreamingWhitespaceNameAfterBufferedArgumentsSkipped`：先缓存 arguments，后续 name 只有空白，仍不能启动工具块。
+- 转换器层新增 `TestOpenAIStreamingEmptyIndexBeforeValidIndexKeepsValidOnly`：并行工具空 index 先到，有效 index 保留，空工具完全不输出。
+- SDK 场景层新增 `TestOpenAIClaudeProviderStyleMissingToolNameStreamingChain`：走 public registry 验证 provider-shaped missing-name stream。
+- SDK 场景层新增 `TestOpenAIClaudeProviderStyleParallelEmptyFirstIndexStreamingChain`：走 public registry 验证并行工具空 index 先到的场景。
+- executor 接口层新增 `TestOpenAICompatExecutorClaudeStreamSkipsMissingToolNameArgumentsEndToEnd`：Claude dirty history -> OpenAI upstream request -> provider-shaped missing-name stream -> Claude response 全链路。
+- executor 接口层新增 `TestOpenAICompatExecutorClaudeStreamPreservesValidParallelToolWhenEmptyIndexFirstEndToEnd`：mock OpenAI-compatible HTTP SSE 返回空 index + 有效 index，验证最终 Claude stream 只保留有效工具。
+
 ## 功能测试
 
 文件：`internal/translator/openai/claude/openai_claude_response_test.go`
@@ -97,7 +116,7 @@ PR：<https://github.com/kittors/CliRelay/pull/430>
 
 ```text
 rtk go test ./internal/translator/openai/claude -count=1 -v
-Go test: 32 passed in 1 packages
+Go test: 35 passed in 1 packages
 ```
 
 ## 场景链路测试
@@ -118,7 +137,7 @@ Go test: 32 passed in 1 packages
 
 ```text
 rtk go test ./test -run 'TestOpenAIClaude.*Tool.*Chain|TestOpenAIClaudeEmptyToolNameNonStreamingChain' -count=1 -v
-Go test: 4 passed in 1 packages
+Go test: 6 passed in 1 packages
 ```
 
 ## 接口级测试
@@ -128,6 +147,8 @@ Go test: 4 passed in 1 packages
 新增测试：
 
 - `TestOpenAICompatExecutorClaudeStreamSkipsEmptyToolNameEndToEnd`
+- `TestOpenAICompatExecutorClaudeStreamSkipsMissingToolNameArgumentsEndToEnd`
+- `TestOpenAICompatExecutorClaudeStreamPreservesValidParallelToolWhenEmptyIndexFirstEndToEnd`
 - `TestOpenAICompatExecutorClaudeNonStreamSkipsEmptyToolNameEndToEnd`
 
 该组测试通过真实 `OpenAICompatExecutor` 和 `httptest.NewServer` mock OpenAI-compatible `/v1/chat/completions`，覆盖 executor 层的入站、出站和响应转换：
@@ -141,8 +162,8 @@ Go test: 4 passed in 1 packages
 执行结果：
 
 ```text
-rtk go test ./internal/runtime/executor -run 'TestOpenAICompatExecutorClaude(Stream|NonStream)SkipsEmptyToolNameEndToEnd' -count=1 -v
-Go test: 2 passed in 1 packages
+rtk go test ./internal/runtime/executor -run 'TestOpenAICompatExecutorClaude(StreamSkipsEmptyToolNameEndToEnd|StreamSkipsMissingToolNameArgumentsEndToEnd|StreamPreservesValidParallelToolWhenEmptyIndexFirstEndToEnd|NonStreamSkipsEmptyToolNameEndToEnd)' -count=1 -v
+Go test: 4 passed in 1 packages
 ```
 
 ## 回归测试
@@ -151,20 +172,20 @@ Go test: 2 passed in 1 packages
 
 ```text
 rtk go test ./internal/translator/... -count=1
-Go test: 107 passed in 30 packages
+Go test: 110 passed in 30 packages
 
 rtk go test ./test -count=1
-Go test: 274 passed in 1 packages
+Go test: 276 passed in 1 packages
 
 rtk go test ./internal/runtime/executor -count=1
-Go test: 219 passed in 1 packages
+Go test: 221 passed in 1 packages
 ```
 
 全仓回归与静态检查：
 
 ```text
 rtk go test ./... -count=1
-Go test: 2037 passed in 147 packages
+Go test: 2044 passed in 147 packages
 
 rtk go vet ./...
 Go vet: No issues found

--- a/internal/management/imagegeneration/service.go
+++ b/internal/management/imagegeneration/service.go
@@ -80,10 +80,11 @@ func (s *Service) Start(payload []byte, alt string) Snapshot {
 		s.tasks = make(map[string]*task)
 	}
 	s.tasks[item.ID] = item
+	snapshot := s.snapshot(item)
 	s.mu.Unlock()
 
 	go s.run(item.ID, payload, alt)
-	return s.snapshot(item)
+	return snapshot
 }
 
 func (s *Service) Get(taskID string) (Snapshot, bool) {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -110,5 +111,149 @@ func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	}
 	if string(resp.Payload) != `{"id":"resp_1","object":"response.compaction","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}` {
 		t.Fatalf("payload = %s", string(resp.Payload))
+	}
+}
+
+func TestOpenAICompatExecutorClaudeStreamSkipsEmptyToolNameEndToEnd(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotPath = r.URL.Path
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"id":"chatcmpl-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+			`data: {"id":"chatcmpl-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{
+		"model":"claude-3-opus",
+		"max_tokens":1024,
+		"stream":true,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_empty","name":"","input":{"path":"x"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_empty","content":"orphan result"}]}
+		]
+	}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "m",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		OriginalRequest: payload,
+		SourceFormat:    sdktranslator.FromString("claude"),
+		Stream:          true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	if gotPath != "/v1/chat/completions" {
+		t.Fatalf("path = %q, want /v1/chat/completions", gotPath)
+	}
+	messages := gjson.GetBytes(gotBody, "messages").Array()
+	for _, msg := range messages {
+		if msg.Get("tool_calls").Exists() {
+			t.Fatalf("upstream OpenAI request must not include empty-name tool_calls: %s", gotBody)
+		}
+		if msg.Get("role").String() == "tool" {
+			t.Fatalf("upstream OpenAI request must not include orphan tool result: %s", gotBody)
+		}
+	}
+
+	var response strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		response.Write(chunk.Payload)
+	}
+	out := response.String()
+	if strings.Contains(out, `"type":"tool_use"`) {
+		t.Fatalf("Claude stream must not include tool_use for empty OpenAI function.name:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"input_json_delta"`) {
+		t.Fatalf("Claude stream must not include input_json_delta for empty OpenAI function.name:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"content_block_stop"`) {
+		t.Fatalf("Claude stream must not include orphan content_block_stop for empty OpenAI function.name:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Fatalf("empty-only OpenAI tool_calls finish must map to Claude end_turn:\n%s", out)
+	}
+}
+
+func TestOpenAICompatExecutorClaudeNonStreamSkipsEmptyToolNameEndToEnd(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-empty-tool","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{
+		"model":"claude-3-opus",
+		"max_tokens":1024,
+		"stream":false,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_empty","name":"   ","input":{"path":"x"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_empty","content":"orphan result"}]}
+		]
+	}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "m",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		OriginalRequest: payload,
+		SourceFormat:    sdktranslator.FromString("claude"),
+		Stream:          false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	messages := gjson.GetBytes(gotBody, "messages").Array()
+	for _, msg := range messages {
+		if msg.Get("tool_calls").Exists() {
+			t.Fatalf("upstream OpenAI request must not include whitespace-name tool_calls: %s", gotBody)
+		}
+		if msg.Get("role").String() == "tool" {
+			t.Fatalf("upstream OpenAI request must not include orphan tool result: %s", gotBody)
+		}
+	}
+
+	out := string(resp.Payload)
+	if strings.Contains(out, `"type":"tool_use"`) || strings.Contains(out, `"name":""`) {
+		t.Fatalf("Claude non-stream response must not include tool_use for empty OpenAI function.name:\n%s", out)
+	}
+	if got := gjson.Get(out, "stop_reason").String(); got != "end_turn" {
+		t.Fatalf("Claude non-stream stop_reason = %q, want end_turn: %s", got, out)
 	}
 }

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -198,6 +198,147 @@ func TestOpenAICompatExecutorClaudeStreamSkipsEmptyToolNameEndToEnd(t *testing.T
 	}
 }
 
+func TestOpenAICompatExecutorClaudeStreamSkipsMissingToolNameArgumentsEndToEnd(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"id":"chatcmpl-provider-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_missing","type":"function","function":{"arguments":"{\"path\":\"a.go\"}"}}]},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl-provider-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"   ","arguments":"{\"offset\":10}"}}]},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl-provider-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+			`data: {"id":"chatcmpl-provider-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":11,"total_tokens":18}}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{
+		"model":"claude-3-opus",
+		"max_tokens":1024,
+		"stream":true,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_missing","name":"","input":{"path":"a.go"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_missing","content":"orphan result"}]}
+		]
+	}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "m",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		OriginalRequest: payload,
+		SourceFormat:    sdktranslator.FromString("claude"),
+		Stream:          true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	messages := gjson.GetBytes(gotBody, "messages").Array()
+	for _, msg := range messages {
+		if msg.Get("tool_calls").Exists() {
+			t.Fatalf("upstream OpenAI request must not include missing-name tool_calls: %s", gotBody)
+		}
+		if msg.Get("role").String() == "tool" {
+			t.Fatalf("upstream OpenAI request must not include orphan tool result: %s", gotBody)
+		}
+	}
+
+	var response strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		response.Write(chunk.Payload)
+	}
+	out := response.String()
+	if strings.Contains(out, `"type":"tool_use"`) {
+		t.Fatalf("Claude stream must not include tool_use when no valid OpenAI function.name arrives:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"input_json_delta"`) {
+		t.Fatalf("Claude stream must not include input_json_delta when no valid OpenAI function.name arrives:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"content_block_stop"`) {
+		t.Fatalf("Claude stream must not include orphan content_block_stop when no valid OpenAI function.name arrives:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Fatalf("missing-name OpenAI tool_calls finish must map to Claude end_turn:\n%s", out)
+	}
+}
+
+func TestOpenAICompatExecutorClaudeStreamPreservesValidParallelToolWhenEmptyIndexFirstEndToEnd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"id":"chatcmpl-provider-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_empty","type":"function","function":{"arguments":"{\"path\":\"x\"}"}},{"index":1,"id":"call_valid","type":"function","function":{"name":"Read","arguments":"{\"file_path\":\"a.go\""}}]},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl-provider-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":""}},{"index":1,"function":{"arguments":",\"offset\":10}"}}]},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl-provider-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{
+		"model":"claude-3-opus",
+		"max_tokens":1024,
+		"stream":true,
+		"messages":[{"role":"user","content":[{"type":"text","text":"read file"}]}]
+	}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "m",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		OriginalRequest: payload,
+		SourceFormat:    sdktranslator.FromString("claude"),
+		Stream:          true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var response strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		response.Write(chunk.Payload)
+	}
+	out := response.String()
+	if got := strings.Count(out, `"type":"tool_use"`); got != 1 {
+		t.Fatalf("expected exactly one valid Claude tool_use, got %d:\n%s", got, out)
+	}
+	if strings.Contains(out, `call_empty`) {
+		t.Fatalf("Claude stream must not include empty first-index tool call:\n%s", out)
+	}
+	if !strings.Contains(out, `"name":"Read"`) {
+		t.Fatalf("Claude stream should preserve valid parallel tool name:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"tool_use"`) {
+		t.Fatalf("valid parallel tool should keep stop_reason=tool_use:\n%s", out)
+	}
+}
+
 func TestOpenAICompatExecutorClaudeNonStreamSkipsEmptyToolNameEndToEnd(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -89,6 +89,7 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 
 	// Process messages and system
 	var messagesJSON = "[]"
+	validToolUseIDs := make(map[string]bool)
 
 	// Handle system message first
 	systemMsgJSON := `{"role":"system","content":[]}`
@@ -157,9 +158,14 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 					case "tool_use":
 						// Only allow tool_use -> tool_calls for assistant messages (security: prevent injection).
 						if role == "assistant" {
+							toolName := strings.TrimSpace(part.Get("name").String())
+							if toolName == "" {
+								return true
+							}
 							toolCallJSON := `{"id":"","type":"function","function":{"name":"","arguments":""}}`
-							toolCallJSON, _ = sjson.Set(toolCallJSON, "id", part.Get("id").String())
-							toolCallJSON, _ = sjson.Set(toolCallJSON, "function.name", part.Get("name").String())
+							toolUseID := part.Get("id").String()
+							toolCallJSON, _ = sjson.Set(toolCallJSON, "id", toolUseID)
+							toolCallJSON, _ = sjson.Set(toolCallJSON, "function.name", toolName)
 
 							// Convert input to arguments JSON string
 							if input := part.Get("input"); input.Exists() {
@@ -169,12 +175,19 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 							}
 
 							toolCalls = append(toolCalls, gjson.Parse(toolCallJSON).Value())
+							if toolUseID != "" {
+								validToolUseIDs[toolUseID] = true
+							}
 						}
 
 					case "tool_result":
 						// Collect tool_result to emit after the main message (ensures tool results follow tool_calls)
+						toolUseID := part.Get("tool_use_id").String()
+						if toolUseID == "" || !validToolUseIDs[toolUseID] {
+							return true
+						}
 						toolResultJSON := `{"role":"tool","tool_call_id":"","content":""}`
-						toolResultJSON, _ = sjson.Set(toolResultJSON, "tool_call_id", part.Get("tool_use_id").String())
+						toolResultJSON, _ = sjson.Set(toolResultJSON, "tool_call_id", toolUseID)
 						toolResultJSON, _ = sjson.Set(toolResultJSON, "content", convertClaudeToolResultContentToString(part.Get("content")))
 						toolResults = append(toolResults, toolResultJSON)
 					}
@@ -270,8 +283,12 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 		var toolsJSON = "[]"
 
 		tools.ForEach(func(_, tool gjson.Result) bool {
+			toolName := strings.TrimSpace(tool.Get("name").String())
+			if toolName == "" {
+				return true
+			}
 			openAIToolJSON := `{"type":"function","function":{"name":"","description":""}}`
-			openAIToolJSON, _ = sjson.Set(openAIToolJSON, "function.name", tool.Get("name").String())
+			openAIToolJSON, _ = sjson.Set(openAIToolJSON, "function.name", toolName)
 			openAIToolJSON, _ = sjson.Set(openAIToolJSON, "function.description", tool.Get("description").String())
 
 			// Convert Anthropic input_schema to OpenAI function parameters
@@ -297,7 +314,11 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 			out, _ = sjson.Set(out, "tool_choice", "required")
 		case "tool":
 			// Specific tool choice
-			toolName := toolChoice.Get("name").String()
+			toolName := strings.TrimSpace(toolChoice.Get("name").String())
+			if toolName == "" {
+				out, _ = sjson.Set(out, "tool_choice", "auto")
+				break
+			}
 			toolChoiceJSON := `{"type":"function","function":{"name":""}}`
 			toolChoiceJSON, _ = sjson.Set(toolChoiceJSON, "function.name", toolName)
 			out, _ = sjson.SetRaw(out, "tool_choice", toolChoiceJSON)

--- a/internal/translator/openai/claude/openai_claude_request_test.go
+++ b/internal/translator/openai/claude/openai_claude_request_test.go
@@ -1,6 +1,8 @@
 package claude
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -679,5 +681,124 @@ func TestConvertClaudeRequestToOpenAI_SkipsEmptyToolsAndDowngradesEmptyToolChoic
 	}
 	if got := resultJSON.Get("tool_choice").String(); got != "auto" {
 		t.Fatalf("Expected empty tool_choice name to downgrade to auto, got %q: %s", got, result)
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_ToolUseNameInvariantsGenerated(t *testing.T) {
+	names := []struct {
+		name        string
+		field       string
+		expectValid bool
+	}{
+		{name: "missing", field: "", expectValid: false},
+		{name: "empty", field: `"name": "",`, expectValid: false},
+		{name: "blank", field: `"name": " \t ",`, expectValid: false},
+		{name: "valid", field: `"name": "Read",`, expectValid: true},
+	}
+
+	for _, tc := range names {
+		t.Run(tc.name, func(t *testing.T) {
+			inputJSON := fmt.Sprintf(`{
+				"model": "claude-3-opus",
+				"messages": [
+					{
+						"role": "assistant",
+						"content": [
+							{"type": "tool_use", "id": "call_%s", %s "input": {"file_path": "a.go"}}
+						]
+					},
+					{
+						"role": "user",
+						"content": [
+							{"type": "tool_result", "tool_use_id": "call_%s", "content": "file contents"}
+						]
+					}
+				]
+			}`, tc.name, tc.field, tc.name)
+
+			result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+			resultJSON := gjson.ParseBytes(result)
+			messages := resultJSON.Get("messages").Array()
+			hasToolCalls := false
+			hasToolResult := false
+			for _, msg := range messages {
+				if msg.Get("tool_calls").Exists() {
+					hasToolCalls = true
+					msg.Get("tool_calls").ForEach(func(_, call gjson.Result) bool {
+						if strings.TrimSpace(call.Get("function.name").String()) == "" {
+							t.Fatalf("OpenAI tool_calls contains empty function.name: %s", result)
+						}
+						return true
+					})
+				}
+				if msg.Get("role").String() == "tool" {
+					hasToolResult = true
+				}
+			}
+
+			if hasToolCalls != tc.expectValid {
+				t.Fatalf("tool_calls presence = %v, want %v: %s", hasToolCalls, tc.expectValid, result)
+			}
+			if hasToolResult != tc.expectValid {
+				t.Fatalf("tool result presence = %v, want %v: %s", hasToolResult, tc.expectValid, result)
+			}
+			if tc.expectValid {
+				if got := resultJSON.Get("messages.0.tool_calls.0.function.name").String(); got != "Read" {
+					t.Fatalf("valid tool function.name = %q, want Read: %s", got, result)
+				}
+				if got := resultJSON.Get("messages.1.tool_call_id").String(); got != "call_valid" {
+					t.Fatalf("valid tool result id = %q, want call_valid: %s", got, result)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_ToolsAndToolChoiceNameInvariantsGenerated(t *testing.T) {
+	choices := []struct {
+		name        string
+		field       string
+		expectValid bool
+	}{
+		{name: "missing", field: "", expectValid: false},
+		{name: "empty", field: `"name": "",`, expectValid: false},
+		{name: "blank", field: `"name": " \t ",`, expectValid: false},
+		{name: "valid", field: `"name": "Read",`, expectValid: true},
+	}
+
+	for _, tc := range choices {
+		t.Run(tc.name, func(t *testing.T) {
+			toolObject := fmt.Sprintf(`{%s "description": "read", "input_schema": {"type": "object"}}`, tc.field)
+			toolChoice := fmt.Sprintf(`{"type": "tool", %s "disable_parallel_tool_use": false}`, tc.field)
+			inputJSON := fmt.Sprintf(`{
+				"model": "claude-3-opus",
+				"messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+				"tools": [%s],
+				"tool_choice": %s
+			}`, toolObject, toolChoice)
+
+			result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+			resultJSON := gjson.ParseBytes(result)
+
+			hasTools := resultJSON.Get("tools").Exists()
+			if hasTools != tc.expectValid {
+				t.Fatalf("tools presence = %v, want %v: %s", hasTools, tc.expectValid, result)
+			}
+			if tc.expectValid {
+				if got := resultJSON.Get("tools.0.function.name").String(); got != "Read" {
+					t.Fatalf("tool name = %q, want Read: %s", got, result)
+				}
+				if got := resultJSON.Get("tool_choice.function.name").String(); got != "Read" {
+					t.Fatalf("tool_choice function.name = %q, want Read: %s", got, result)
+				}
+			} else {
+				if resultJSON.Get("tools.0.function.name").Exists() {
+					t.Fatalf("invalid tool name should not be emitted: %s", result)
+				}
+				if got := resultJSON.Get("tool_choice").String(); got != "auto" {
+					t.Fatalf("invalid tool_choice should downgrade to auto, got %q: %s", got, result)
+				}
+			}
+		})
 	}
 }

--- a/internal/translator/openai/claude/openai_claude_request_test.go
+++ b/internal/translator/openai/claude/openai_claude_request_test.go
@@ -588,3 +588,96 @@ func TestConvertClaudeRequestToOpenAI_AssistantThinkingToolUseThinkingSplit(t *t
 		t.Fatalf("Expected reasoning_content %q, got %q", "t1\n\nt2", got)
 	}
 }
+
+func TestConvertClaudeRequestToOpenAI_SkipsEmptyToolUseAndMatchingToolResult(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "call_empty", "name": "", "input": {"path": "x"}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "call_empty", "content": "orphan result"}
+				]
+			}
+		]
+	}`
+
+	result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+	for _, msg := range messages {
+		if msg.Get("tool_calls").Exists() {
+			t.Fatalf("empty-name tool_use must not become OpenAI tool_calls: %s", result)
+		}
+		if msg.Get("role").String() == "tool" && msg.Get("tool_call_id").String() == "call_empty" {
+			t.Fatalf("tool_result for skipped tool_use must not become orphan tool message: %s", result)
+		}
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_ValidToolUseKeepsMatchingToolResult(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "call_valid", "name": "Read", "input": {"file_path": "a.go"}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "call_valid", "content": "package a"}
+				]
+			}
+		]
+	}`
+
+	result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("Expected assistant tool_calls + tool result, got %d: %s", len(messages), result)
+	}
+	if got := messages[0].Get("tool_calls.0.function.name").String(); got != "Read" {
+		t.Fatalf("Expected valid tool_call name Read, got %q: %s", got, result)
+	}
+	if got := messages[1].Get("role").String(); got != "tool" {
+		t.Fatalf("Expected second message role tool, got %q: %s", got, result)
+	}
+	if got := messages[1].Get("tool_call_id").String(); got != "call_valid" {
+		t.Fatalf("Expected matching tool_call_id call_valid, got %q: %s", got, result)
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_SkipsEmptyToolsAndDowngradesEmptyToolChoice(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+		"tools": [
+			{"name": "", "description": "empty", "input_schema": {"type": "object"}},
+			{"name": "   ", "description": "blank", "input_schema": {"type": "object"}},
+			{"name": "Read", "description": "read a file", "input_schema": {"type": "object"}}
+		],
+		"tool_choice": {"type": "tool", "name": "   "}
+	}`
+
+	result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	if got := resultJSON.Get("tools.#").Int(); got != 1 {
+		t.Fatalf("Expected exactly one non-empty tool definition, got %d: %s", got, result)
+	}
+	if got := resultJSON.Get("tools.0.function.name").String(); got != "Read" {
+		t.Fatalf("Expected preserved tool name Read, got %q: %s", got, result)
+	}
+	if got := resultJSON.Get("tool_choice").String(); got != "auto" {
+		t.Fatalf("Expected empty tool_choice name to downgrade to auto, got %q: %s", got, result)
+	}
+}

--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -43,6 +44,8 @@ type ConvertOpenAIResponseToAnthropicParams struct {
 	MessageStarted bool
 	// Track if message_stop has been sent
 	MessageStopSent bool
+	// Track whether a valid tool_use block has actually been emitted
+	HasToolUse bool
 	// Tool call content block index mapping
 	ToolCallBlockIndexes map[int]int
 	// Index assigned to text content block
@@ -55,9 +58,11 @@ type ConvertOpenAIResponseToAnthropicParams struct {
 
 // ToolCallAccumulator holds the state for accumulating tool call data
 type ToolCallAccumulator struct {
-	ID        string
-	Name      string
-	Arguments strings.Builder
+	ID         string
+	Name       string
+	Arguments  strings.Builder
+	Started    bool
+	BlockIndex int
 }
 
 // ConvertOpenAIResponseToClaude converts OpenAI streaming response format to Anthropic API format.
@@ -85,6 +90,7 @@ func ConvertOpenAIResponseToClaude(_ context.Context, _ string, originalRequestR
 			FinishReason:                "",
 			ContentBlocksStopped:        false,
 			MessageDeltaSent:            false,
+			HasToolUse:                  false,
 			ToolCallBlockIndexes:        make(map[int]int),
 			TextContentBlockIndex:       -1,
 			ThinkingContentBlockIndex:   -1,
@@ -198,11 +204,12 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 
 			toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
 				index := int(toolCall.Get("index").Int())
-				blockIndex := param.toolContentBlockIndex(index)
 
 				// Initialize accumulator if needed
 				if _, exists := param.ToolCallsAccumulator[index]; !exists {
-					param.ToolCallsAccumulator[index] = &ToolCallAccumulator{}
+					param.ToolCallsAccumulator[index] = &ToolCallAccumulator{
+						BlockIndex: -1,
+					}
 				}
 
 				accumulator := param.ToolCallsAccumulator[index]
@@ -215,18 +222,28 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 				// Handle function name
 				if function := toolCall.Get("function"); function.Exists() {
 					if name := function.Get("name"); name.Exists() {
-						accumulator.Name = name.String()
+						toolName := strings.TrimSpace(name.String())
+						if toolName != "" {
+							accumulator.Name = toolName
 
-						stopThinkingContentBlock(param, &results)
+							if !accumulator.Started {
+								blockIndex := param.toolContentBlockIndex(index)
+								accumulator.BlockIndex = blockIndex
 
-						stopTextContentBlock(param, &results)
+								stopThinkingContentBlock(param, &results)
 
-						// Send content_block_start for tool_use
-						contentBlockStartJSON := `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"","name":"","input":{}}}`
-						contentBlockStartJSON, _ = sjson.Set(contentBlockStartJSON, "index", blockIndex)
-						contentBlockStartJSON, _ = sjson.Set(contentBlockStartJSON, "content_block.id", accumulator.ID)
-						contentBlockStartJSON, _ = sjson.Set(contentBlockStartJSON, "content_block.name", accumulator.Name)
-						results = append(results, "event: content_block_start\ndata: "+contentBlockStartJSON+"\n\n")
+								stopTextContentBlock(param, &results)
+
+								// Send content_block_start for tool_use
+								contentBlockStartJSON := `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"","name":"","input":{}}}`
+								contentBlockStartJSON, _ = sjson.Set(contentBlockStartJSON, "index", blockIndex)
+								contentBlockStartJSON, _ = sjson.Set(contentBlockStartJSON, "content_block.id", accumulator.ID)
+								contentBlockStartJSON, _ = sjson.Set(contentBlockStartJSON, "content_block.name", accumulator.Name)
+								results = append(results, "event: content_block_start\ndata: "+contentBlockStartJSON+"\n\n")
+								accumulator.Started = true
+								param.HasToolUse = true
+							}
+						}
 					}
 
 					// Handle function arguments
@@ -260,27 +277,7 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 		// Send content_block_stop for text if text content block was started
 		stopTextContentBlock(param, &results)
 
-		// Send content_block_stop for any tool calls
-		if !param.ContentBlocksStopped {
-			for index := range param.ToolCallsAccumulator {
-				accumulator := param.ToolCallsAccumulator[index]
-				blockIndex := param.toolContentBlockIndex(index)
-
-				// Send complete input_json_delta with all accumulated arguments
-				if accumulator.Arguments.Len() > 0 {
-					inputDeltaJSON := `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
-					inputDeltaJSON, _ = sjson.Set(inputDeltaJSON, "index", blockIndex)
-					inputDeltaJSON, _ = sjson.Set(inputDeltaJSON, "delta.partial_json", util.FixJSON(accumulator.Arguments.String()))
-					results = append(results, "event: content_block_delta\ndata: "+inputDeltaJSON+"\n\n")
-				}
-
-				contentBlockStopJSON := `{"type":"content_block_stop","index":0}`
-				contentBlockStopJSON, _ = sjson.Set(contentBlockStopJSON, "index", blockIndex)
-				results = append(results, "event: content_block_stop\ndata: "+contentBlockStopJSON+"\n\n")
-				delete(param.ToolCallBlockIndexes, index)
-			}
-			param.ContentBlocksStopped = true
-		}
+		finalizeToolContentBlocks(param, &results)
 
 		// Don't send message_delta here - wait for usage info or [DONE]
 	}
@@ -294,7 +291,7 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 			inputTokens, outputTokens, cachedTokens = extractOpenAIUsage(usage)
 			// Send message_delta with usage
 			messageDeltaJSON := `{"type":"message_delta","delta":{"stop_reason":"","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`
-			messageDeltaJSON, _ = sjson.Set(messageDeltaJSON, "delta.stop_reason", mapOpenAIFinishReasonToAnthropic(param.FinishReason))
+			messageDeltaJSON, _ = sjson.Set(messageDeltaJSON, "delta.stop_reason", mapOpenAIFinishReasonToAnthropicWithToolState(param.FinishReason, param.HasToolUse))
 			messageDeltaJSON, _ = sjson.Set(messageDeltaJSON, "usage.input_tokens", inputTokens)
 			messageDeltaJSON, _ = sjson.Set(messageDeltaJSON, "usage.output_tokens", outputTokens)
 			if cachedTokens > 0 {
@@ -325,30 +322,12 @@ func convertOpenAIDoneToAnthropic(param *ConvertOpenAIResponseToAnthropicParams)
 
 	stopTextContentBlock(param, &results)
 
-	if !param.ContentBlocksStopped {
-		for index := range param.ToolCallsAccumulator {
-			accumulator := param.ToolCallsAccumulator[index]
-			blockIndex := param.toolContentBlockIndex(index)
-
-			if accumulator.Arguments.Len() > 0 {
-				inputDeltaJSON := `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
-				inputDeltaJSON, _ = sjson.Set(inputDeltaJSON, "index", blockIndex)
-				inputDeltaJSON, _ = sjson.Set(inputDeltaJSON, "delta.partial_json", util.FixJSON(accumulator.Arguments.String()))
-				results = append(results, "event: content_block_delta\ndata: "+inputDeltaJSON+"\n\n")
-			}
-
-			contentBlockStopJSON := `{"type":"content_block_stop","index":0}`
-			contentBlockStopJSON, _ = sjson.Set(contentBlockStopJSON, "index", blockIndex)
-			results = append(results, "event: content_block_stop\ndata: "+contentBlockStopJSON+"\n\n")
-			delete(param.ToolCallBlockIndexes, index)
-		}
-		param.ContentBlocksStopped = true
-	}
+	finalizeToolContentBlocks(param, &results)
 
 	// If we haven't sent message_delta yet (no usage info was received), send it now
 	if param.FinishReason != "" && !param.MessageDeltaSent {
 		messageDeltaJSON := `{"type":"message_delta","delta":{"stop_reason":"","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`
-		messageDeltaJSON, _ = sjson.Set(messageDeltaJSON, "delta.stop_reason", mapOpenAIFinishReasonToAnthropic(param.FinishReason))
+		messageDeltaJSON, _ = sjson.Set(messageDeltaJSON, "delta.stop_reason", mapOpenAIFinishReasonToAnthropicWithToolState(param.FinishReason, param.HasToolUse))
 		results = append(results, "event: message_delta\ndata: "+messageDeltaJSON+"\n\n")
 		param.MessageDeltaSent = true
 	}
@@ -365,6 +344,7 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) []string {
 	out := `{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`
 	out, _ = sjson.Set(out, "id", root.Get("id").String())
 	out, _ = sjson.Set(out, "model", root.Get("model").String())
+	hasToolCall := false
 
 	// Process message content and tool calls
 	if choices := root.Get("choices"); choices.Exists() && choices.IsArray() && len(choices.Array()) > 0 {
@@ -390,9 +370,13 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) []string {
 		// Handle tool calls
 		if toolCalls := choice.Get("message.tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {
 			toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
+				toolName := strings.TrimSpace(toolCall.Get("function.name").String())
+				if toolName == "" {
+					return true
+				}
 				toolUseBlock := `{"type":"tool_use","id":"","name":"","input":{}}`
 				toolUseBlock, _ = sjson.Set(toolUseBlock, "id", toolCall.Get("id").String())
-				toolUseBlock, _ = sjson.Set(toolUseBlock, "name", toolCall.Get("function.name").String())
+				toolUseBlock, _ = sjson.Set(toolUseBlock, "name", toolName)
 
 				argsStr := util.FixJSON(toolCall.Get("function.arguments").String())
 				if argsStr != "" && gjson.Valid(argsStr) {
@@ -407,13 +391,14 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) []string {
 				}
 
 				out, _ = sjson.SetRaw(out, "content.-1", toolUseBlock)
+				hasToolCall = true
 				return true
 			})
 		}
 
 		// Set stop reason
 		if finishReason := choice.Get("finish_reason"); finishReason.Exists() {
-			out, _ = sjson.Set(out, "stop_reason", mapOpenAIFinishReasonToAnthropic(finishReason.String()))
+			out, _ = sjson.Set(out, "stop_reason", mapOpenAIFinishReasonToAnthropicWithToolState(finishReason.String(), hasToolCall))
 		}
 	}
 
@@ -448,6 +433,18 @@ func mapOpenAIFinishReasonToAnthropic(openAIReason string) string {
 	}
 }
 
+func mapOpenAIFinishReasonToAnthropicWithToolState(openAIReason string, hasToolUse bool) string {
+	switch openAIReason {
+	case "tool_calls", "function_call":
+		if hasToolUse {
+			return "tool_use"
+		}
+		return "end_turn"
+	default:
+		return mapOpenAIFinishReasonToAnthropic(openAIReason)
+	}
+}
+
 func (p *ConvertOpenAIResponseToAnthropicParams) toolContentBlockIndex(openAIToolIndex int) int {
 	if idx, ok := p.ToolCallBlockIndexes[openAIToolIndex]; ok {
 		return idx
@@ -456,6 +453,46 @@ func (p *ConvertOpenAIResponseToAnthropicParams) toolContentBlockIndex(openAIToo
 	p.NextContentBlockIndex++
 	p.ToolCallBlockIndexes[openAIToolIndex] = idx
 	return idx
+}
+
+func finalizeToolContentBlocks(param *ConvertOpenAIResponseToAnthropicParams, results *[]string) {
+	if param.ContentBlocksStopped {
+		return
+	}
+	param.ContentBlocksStopped = true
+	if param.ToolCallsAccumulator == nil {
+		return
+	}
+
+	indexes := make([]int, 0, len(param.ToolCallsAccumulator))
+	for index := range param.ToolCallsAccumulator {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+
+	for _, index := range indexes {
+		accumulator := param.ToolCallsAccumulator[index]
+		if accumulator == nil || !accumulator.Started {
+			continue
+		}
+
+		blockIndex := accumulator.BlockIndex
+		if blockIndex < 0 {
+			blockIndex = param.toolContentBlockIndex(index)
+		}
+
+		if accumulator.Arguments.Len() > 0 {
+			inputDeltaJSON := `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
+			inputDeltaJSON, _ = sjson.Set(inputDeltaJSON, "index", blockIndex)
+			inputDeltaJSON, _ = sjson.Set(inputDeltaJSON, "delta.partial_json", util.FixJSON(accumulator.Arguments.String()))
+			*results = append(*results, "event: content_block_delta\ndata: "+inputDeltaJSON+"\n\n")
+		}
+
+		contentBlockStopJSON := `{"type":"content_block_stop","index":0}`
+		contentBlockStopJSON, _ = sjson.Set(contentBlockStopJSON, "index", blockIndex)
+		*results = append(*results, "event: content_block_stop\ndata: "+contentBlockStopJSON+"\n\n")
+		delete(param.ToolCallBlockIndexes, index)
+	}
 }
 
 func collectOpenAIReasoningTexts(node gjson.Result) []string {
@@ -541,12 +578,13 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 
 	hasToolCall := false
 	stopReasonSet := false
+	finishReasonValue := ""
 
 	if choices := root.Get("choices"); choices.Exists() && choices.IsArray() && len(choices.Array()) > 0 {
 		choice := choices.Array()[0]
 
 		if finishReason := choice.Get("finish_reason"); finishReason.Exists() {
-			out, _ = sjson.Set(out, "stop_reason", mapOpenAIFinishReasonToAnthropic(finishReason.String()))
+			finishReasonValue = finishReason.String()
 			stopReasonSet = true
 		}
 
@@ -587,10 +625,14 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 							toolCalls := item.Get("tool_calls")
 							if toolCalls.IsArray() {
 								toolCalls.ForEach(func(_, tc gjson.Result) bool {
+									toolName := strings.TrimSpace(tc.Get("function.name").String())
+									if toolName == "" {
+										return true
+									}
 									hasToolCall = true
 									toolUse := `{"type":"tool_use","id":"","name":"","input":{}}`
 									toolUse, _ = sjson.Set(toolUse, "id", tc.Get("id").String())
-									toolUse, _ = sjson.Set(toolUse, "name", tc.Get("function.name").String())
+									toolUse, _ = sjson.Set(toolUse, "name", toolName)
 
 									argsStr := util.FixJSON(tc.Get("function.arguments").String())
 									if argsStr != "" && gjson.Valid(argsStr) {
@@ -644,10 +686,14 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 
 			if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {
 				toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
+					toolName := strings.TrimSpace(toolCall.Get("function.name").String())
+					if toolName == "" {
+						return true
+					}
 					hasToolCall = true
 					toolUseBlock := `{"type":"tool_use","id":"","name":"","input":{}}`
 					toolUseBlock, _ = sjson.Set(toolUseBlock, "id", toolCall.Get("id").String())
-					toolUseBlock, _ = sjson.Set(toolUseBlock, "name", toolCall.Get("function.name").String())
+					toolUseBlock, _ = sjson.Set(toolUseBlock, "name", toolName)
 
 					argsStr := util.FixJSON(toolCall.Get("function.arguments").String())
 					if argsStr != "" && gjson.Valid(argsStr) {
@@ -683,6 +729,8 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 		} else {
 			out, _ = sjson.Set(out, "stop_reason", "end_turn")
 		}
+	} else {
+		out, _ = sjson.Set(out, "stop_reason", mapOpenAIFinishReasonToAnthropicWithToolState(finishReasonValue, hasToolCall))
 	}
 
 	return out

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -167,6 +167,47 @@ func TestOpenAIStreamingToolArgumentsBeforeNamePreserved(t *testing.T) {
 	assertNoOrphanContentBlockEvents(t, out)
 }
 
+func TestOpenAIStreamingToolArgumentsWithoutValidNameSkipped(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_missing","type":"function","function":{"arguments":"{\"path\":\"a.go\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"extra\":true}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if strings.Contains(out, `"type":"tool_use"`) {
+		t.Fatalf("arguments without a valid function.name must not emit tool_use:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"input_json_delta"`) {
+		t.Fatalf("arguments without a valid function.name must not emit input_json_delta:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"content_block_stop"`) {
+		t.Fatalf("arguments without a valid function.name must not emit orphan content_block_stop:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Fatalf("tool_calls finish without a valid tool block should become end_turn:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
+func TestOpenAIStreamingWhitespaceNameAfterBufferedArgumentsSkipped(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-blank-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_blank","type":"function","function":{"arguments":"{\"path\":\"a.go\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-blank-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"   "}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-blank-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"tail\":1}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-blank-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if strings.Contains(out, `"type":"tool_use"`) || strings.Contains(out, `"type":"input_json_delta"`) {
+		t.Fatalf("buffered arguments with whitespace-only function.name must not emit tool events:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Fatalf("whitespace-only late tool name should leave stop_reason=end_turn:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
 func TestOpenAIStreamingMixedValidAndEmptyToolCalls(t *testing.T) {
 	out := collectOpenAIToClaudeStream(t,
 		`data: {"id":"chatcmpl-mixed-tools","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_valid","type":"function","function":{"name":"Read","arguments":"{\"file_path\":\"a.go\"}"}},{"index":1,"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
@@ -182,6 +223,26 @@ func TestOpenAIStreamingMixedValidAndEmptyToolCalls(t *testing.T) {
 	}
 	if !strings.Contains(out, `"name":"Read"`) || !strings.Contains(out, `"stop_reason":"tool_use"`) {
 		t.Fatalf("valid tool call should be preserved:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
+func TestOpenAIStreamingEmptyIndexBeforeValidIndexKeepsValidOnly(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-empty-first-index","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_empty","type":"function","function":{"arguments":"{\"path\":\"x\"}"}},{"index":1,"id":"call_valid","type":"function","function":{"name":"Read","arguments":"{\"file_path\":\"a.go\""}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-empty-first-index","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":""}},{"index":1,"function":{"arguments":",\"tail\":true}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-empty-first-index","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if got := strings.Count(out, `"type":"tool_use"`); got != 1 {
+		t.Fatalf("expected exactly one valid tool_use, got %d:\n%s", got, out)
+	}
+	if strings.Contains(out, `call_empty`) {
+		t.Fatalf("empty first-index tool call must not be emitted:\n%s", out)
+	}
+	if !strings.Contains(out, `"name":"Read"`) || !strings.Contains(out, `"stop_reason":"tool_use"`) {
+		t.Fatalf("valid second-index tool call should be preserved:\n%s", out)
 	}
 	assertNoOrphanContentBlockEvents(t, out)
 }

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -2,6 +2,8 @@ package claude
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -61,6 +63,175 @@ func assertNoOrphanContentBlockEvents(t *testing.T, stream string) {
 			delete(openBlocks, idx)
 		}
 	}
+}
+
+func assertAnthropicToolStreamInvariants(t *testing.T, stream string, wantToolUse bool) {
+	t.Helper()
+
+	openBlocks := make(map[int]string)
+	toolUseCount := 0
+	messageStopCount := 0
+	var stopReasons []string
+
+	for _, segment := range strings.Split(stream, "\n\n") {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+
+		var eventType, data string
+		for _, line := range strings.Split(segment, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event:"):
+				eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		}
+		if data == "" {
+			continue
+		}
+
+		payload := gjson.Parse(data)
+		switch eventType {
+		case "content_block_start":
+			idx := int(payload.Get("index").Int())
+			blockType := payload.Get("content_block.type").String()
+			if blockType == "" {
+				t.Fatalf("content_block_start missing content_block.type:\n%s", stream)
+			}
+			if openBlocks[idx] != "" {
+				t.Fatalf("content_block_start reused open index %d:\n%s", idx, stream)
+			}
+			if blockType == "tool_use" {
+				toolUseCount++
+				if strings.TrimSpace(payload.Get("content_block.name").String()) == "" {
+					t.Fatalf("tool_use content_block_start has empty name:\n%s", stream)
+				}
+			}
+			openBlocks[idx] = blockType
+
+		case "content_block_delta":
+			idx := int(payload.Get("index").Int())
+			blockType := openBlocks[idx]
+			if blockType == "" {
+				t.Fatalf("content_block_delta without matching content_block_start at index %d:\n%s", idx, stream)
+			}
+			deltaType := payload.Get("delta.type").String()
+			switch deltaType {
+			case "input_json_delta":
+				if blockType != "tool_use" {
+					t.Fatalf("input_json_delta attached to %s block at index %d:\n%s", blockType, idx, stream)
+				}
+			case "text_delta":
+				if blockType != "text" {
+					t.Fatalf("text_delta attached to %s block at index %d:\n%s", blockType, idx, stream)
+				}
+			case "thinking_delta":
+				if blockType != "thinking" {
+					t.Fatalf("thinking_delta attached to %s block at index %d:\n%s", blockType, idx, stream)
+				}
+			default:
+				t.Fatalf("unknown content_block_delta type %q:\n%s", deltaType, stream)
+			}
+
+		case "content_block_stop":
+			idx := int(payload.Get("index").Int())
+			if openBlocks[idx] == "" {
+				t.Fatalf("content_block_stop without matching content_block_start at index %d:\n%s", idx, stream)
+			}
+			delete(openBlocks, idx)
+
+		case "message_delta":
+			if stopReason := payload.Get("delta.stop_reason"); stopReason.Exists() {
+				stopReasons = append(stopReasons, stopReason.String())
+			}
+
+		case "message_stop":
+			messageStopCount++
+		}
+	}
+
+	if len(openBlocks) > 0 {
+		t.Fatalf("stream ended with open content blocks %v:\n%s", openBlocks, stream)
+	}
+	if wantToolUse && toolUseCount == 0 {
+		t.Fatalf("expected at least one valid tool_use block:\n%s", stream)
+	}
+	if !wantToolUse && toolUseCount != 0 {
+		t.Fatalf("expected no tool_use blocks, got %d:\n%s", toolUseCount, stream)
+	}
+	for _, stopReason := range stopReasons {
+		if wantToolUse && stopReason != "tool_use" {
+			t.Fatalf("valid tool stream stop_reason = %q, want tool_use:\n%s", stopReason, stream)
+		}
+		if !wantToolUse && stopReason == "tool_use" {
+			t.Fatalf("invalid tool stream must not stop with tool_use:\n%s", stream)
+		}
+	}
+	if messageStopCount != 1 {
+		t.Fatalf("stream should emit exactly one message_stop, got %d:\n%s", messageStopCount, stream)
+	}
+}
+
+type streamToolDeltaSpec struct {
+	Index   int
+	ID      string
+	HasName bool
+	Name    string
+	HasArgs bool
+	Args    string
+}
+
+func openAIStreamToolDelta(spec streamToolDeltaSpec) string {
+	fields := []string{fmt.Sprintf(`"index":%d`, spec.Index)}
+	if spec.ID != "" {
+		fields = append(fields, `"id":`+strconv.Quote(spec.ID))
+	}
+	fields = append(fields, `"type":"function"`)
+
+	var functionFields []string
+	if spec.HasName {
+		functionFields = append(functionFields, `"name":`+strconv.Quote(spec.Name))
+	}
+	if spec.HasArgs {
+		functionFields = append(functionFields, `"arguments":`+strconv.Quote(spec.Args))
+	}
+	if len(functionFields) > 0 {
+		fields = append(fields, `"function":{`+strings.Join(functionFields, ",")+`}`)
+	}
+
+	return "{" + strings.Join(fields, ",") + "}"
+}
+
+func openAIStreamChunk(id string, toolDeltas []streamToolDeltaSpec, finishReason string) string {
+	deltaFields := []string{}
+	if len(toolDeltas) > 0 {
+		var toolJSON []string
+		for _, delta := range toolDeltas {
+			toolJSON = append(toolJSON, openAIStreamToolDelta(delta))
+		}
+		deltaFields = append(deltaFields, `"tool_calls":[`+strings.Join(toolJSON, ",")+`]`)
+	}
+
+	finish := "null"
+	if finishReason != "" {
+		finish = strconv.Quote(finishReason)
+	}
+
+	return fmt.Sprintf(
+		`data: {"id":%s,"object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{%s},"finish_reason":%s}]}`,
+		strconv.Quote(id),
+		strings.Join(deltaFields, ","),
+		finish,
+	)
+}
+
+func openAIStreamUsageChunk(id string) string {
+	return fmt.Sprintf(
+		`data: {"id":%s,"object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+		strconv.Quote(id),
+	)
 }
 
 func TestOpenAIStreamingEmptyToolNameSkipsOrphanToolEvents(t *testing.T) {
@@ -247,6 +418,133 @@ func TestOpenAIStreamingEmptyIndexBeforeValidIndexKeepsValidOnly(t *testing.T) {
 	assertNoOrphanContentBlockEvents(t, out)
 }
 
+func TestOpenAIStreamingToolNameStateInvariantsGenerated(t *testing.T) {
+	type namePlan struct {
+		name        string
+		step        int
+		value       string
+		expectValid bool
+	}
+	namePlans := []namePlan{
+		{name: "absent_forever", step: -1, expectValid: false},
+		{name: "empty_initial", step: 0, value: "", expectValid: false},
+		{name: "blank_initial", step: 0, value: " \t ", expectValid: false},
+		{name: "empty_late", step: 1, value: "", expectValid: false},
+		{name: "blank_late", step: 1, value: " \n ", expectValid: false},
+		{name: "valid_initial", step: 0, value: "Read", expectValid: true},
+		{name: "valid_late", step: 1, value: "Read", expectValid: true},
+	}
+	type argPlan struct {
+		name string
+		args [2]string
+	}
+	argPlans := []argPlan{
+		{name: "none"},
+		{name: "initial", args: [2]string{`{"path":"a.go"}`, ""}},
+		{name: "before_and_after", args: [2]string{`{"path":"a.go"`, `,"line":1}`}},
+		{name: "after_only", args: [2]string{"", `{"late":true}`}},
+	}
+	finishReasons := []string{"tool_calls", "function_call"}
+	usageVariants := []bool{false, true}
+
+	for _, names := range namePlans {
+		for _, args := range argPlans {
+			for _, finishReason := range finishReasons {
+				for _, withUsage := range usageVariants {
+					testName := strings.Join([]string{names.name, args.name, finishReason, fmt.Sprintf("usage_%v", withUsage)}, "/")
+					t.Run(testName, func(t *testing.T) {
+						var chunks []string
+						for step := 0; step < 2; step++ {
+							spec := streamToolDeltaSpec{Index: 0, ID: "call_generated"}
+							include := false
+							if names.step == step {
+								spec.HasName = true
+								spec.Name = names.value
+								include = true
+							}
+							if args.args[step] != "" {
+								spec.HasArgs = true
+								spec.Args = args.args[step]
+								include = true
+							}
+							if include {
+								chunks = append(chunks, openAIStreamChunk("chatcmpl-generated", []streamToolDeltaSpec{spec}, ""))
+							}
+						}
+						chunks = append(chunks, openAIStreamChunk("chatcmpl-generated", nil, finishReason))
+						if withUsage {
+							chunks = append(chunks, openAIStreamUsageChunk("chatcmpl-generated"))
+						}
+						chunks = append(chunks, `data: [DONE]`)
+
+						out := collectOpenAIToClaudeStream(t, chunks...)
+						assertAnthropicToolStreamInvariants(t, out, names.expectValid)
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestOpenAIStreamingParallelToolNameStateInvariantsGenerated(t *testing.T) {
+	invalidNames := []struct {
+		name    string
+		hasName bool
+		value   string
+	}{
+		{name: "absent", hasName: false},
+		{name: "empty", hasName: true, value: ""},
+		{name: "blank", hasName: true, value: " \t "},
+	}
+	secondChunkArgs := []string{"", `,"line":1}`}
+
+	for _, invalid := range invalidNames {
+		for _, tailArgs := range secondChunkArgs {
+			t.Run(invalid.name+"/tail_"+strconv.Quote(tailArgs), func(t *testing.T) {
+				firstEmpty := streamToolDeltaSpec{
+					Index:   0,
+					ID:      "call_empty",
+					HasArgs: true,
+					Args:    `{"path":"x"}`,
+				}
+				firstValid := streamToolDeltaSpec{
+					Index:   1,
+					ID:      "call_valid",
+					HasName: true,
+					Name:    "Read",
+					HasArgs: true,
+					Args:    `{"file_path":"a.go"`,
+				}
+				secondEmpty := streamToolDeltaSpec{
+					Index:   0,
+					HasName: invalid.hasName,
+					Name:    invalid.value,
+				}
+				secondValid := streamToolDeltaSpec{
+					Index:   1,
+					HasArgs: tailArgs != "",
+					Args:    tailArgs,
+				}
+
+				chunks := []string{
+					openAIStreamChunk("chatcmpl-parallel-generated", []streamToolDeltaSpec{firstEmpty, firstValid}, ""),
+					openAIStreamChunk("chatcmpl-parallel-generated", []streamToolDeltaSpec{secondEmpty, secondValid}, ""),
+					openAIStreamChunk("chatcmpl-parallel-generated", nil, "tool_calls"),
+					`data: [DONE]`,
+				}
+				out := collectOpenAIToClaudeStream(t, chunks...)
+				assertAnthropicToolStreamInvariants(t, out, true)
+				if strings.Contains(out, "call_empty") {
+					t.Fatalf("empty parallel tool call leaked into Claude stream:\n%s", out)
+				}
+				if got := strings.Count(out, `"type":"tool_use"`); got != 1 {
+					t.Fatalf("expected only one valid tool_use, got %d:\n%s", got, out)
+				}
+			})
+		}
+	}
+}
+
 func TestOpenAINonStreamingEmptyToolNameSkippedAndStopReasonEndTurn(t *testing.T) {
 	raw := []byte(`{"id":"chatcmpl-empty-tool","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":"tool_calls"}]}`)
 
@@ -276,5 +574,59 @@ func TestOpenAINonStreamingContentArrayEmptyToolNameSkipped(t *testing.T) {
 	}
 	if got := gjson.Get(out, "stop_reason").String(); got != "end_turn" {
 		t.Fatalf("stop_reason = %q, want end_turn; payload=%s", got, out)
+	}
+}
+
+func TestOpenAINonStreamingToolNameStateInvariantsGenerated(t *testing.T) {
+	names := []struct {
+		name        string
+		field       string
+		expectValid bool
+	}{
+		{name: "missing", field: "", expectValid: false},
+		{name: "empty", field: `"name":"",`, expectValid: false},
+		{name: "blank", field: `"name":" \t ",`, expectValid: false},
+		{name: "valid", field: `"name":"Read",`, expectValid: true},
+	}
+	contentShapes := []struct {
+		name     string
+		template string
+	}{
+		{
+			name:     "message_tool_calls",
+			template: `{"id":"chatcmpl-%s","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_%s","type":"function","function":{%s"arguments":"{\"path\":\"x\"}"}}]},"finish_reason":"tool_calls"}]}`,
+		},
+		{
+			name:     "content_array_tool_calls",
+			template: `{"id":"chatcmpl-%s","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":[{"type":"tool_calls","tool_calls":[{"id":"call_%s","type":"function","function":{%s"arguments":"{\"path\":\"x\"}"}}]}]},"finish_reason":"tool_calls"}]}`,
+		},
+	}
+
+	for _, shape := range contentShapes {
+		for _, tc := range names {
+			t.Run(shape.name+"/"+tc.name, func(t *testing.T) {
+				raw := []byte(fmt.Sprintf(shape.template, tc.name, tc.name, tc.field))
+				out := ConvertOpenAIResponseToClaudeNonStream(context.Background(), "m", nil, nil, raw, nil)
+				hasToolUse := strings.Contains(out, `"type":"tool_use"`)
+				if hasToolUse != tc.expectValid {
+					t.Fatalf("tool_use presence = %v, want %v: %s", hasToolUse, tc.expectValid, out)
+				}
+				if tc.expectValid {
+					if got := gjson.Get(out, "content.#(type==\"tool_use\").name").String(); got != "Read" {
+						t.Fatalf("valid tool_use name = %q, want Read: %s", got, out)
+					}
+					if got := gjson.Get(out, "stop_reason").String(); got != "tool_use" {
+						t.Fatalf("valid tool stop_reason = %q, want tool_use: %s", got, out)
+					}
+				} else {
+					if strings.Contains(out, `"name":""`) || strings.Contains(out, `"name":" `) {
+						t.Fatalf("invalid tool name leaked into Claude response: %s", out)
+					}
+					if got := gjson.Get(out, "stop_reason").String(); got == "tool_use" {
+						t.Fatalf("invalid tool stop_reason must not be tool_use: %s", out)
+					}
+				}
+			})
+		}
 	}
 }

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -1,0 +1,219 @@
+package claude
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func collectOpenAIToClaudeStream(t *testing.T, chunks ...string) string {
+	t.Helper()
+
+	originalRequest := []byte(`{"stream":true}`)
+	var param any
+	var out []string
+	for _, chunk := range chunks {
+		out = append(out, ConvertOpenAIResponseToClaude(context.Background(), "m", originalRequest, nil, []byte(chunk), &param)...)
+	}
+	return strings.Join(out, "")
+}
+
+func assertNoOrphanContentBlockEvents(t *testing.T, stream string) {
+	t.Helper()
+
+	openBlocks := make(map[int]bool)
+	for _, segment := range strings.Split(stream, "\n\n") {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+
+		var eventType, data string
+		for _, line := range strings.Split(segment, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event:"):
+				eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		}
+		if data == "" {
+			continue
+		}
+
+		payload := gjson.Parse(data)
+		switch eventType {
+		case "content_block_start":
+			idx := int(payload.Get("index").Int())
+			openBlocks[idx] = true
+		case "content_block_delta":
+			idx := int(payload.Get("index").Int())
+			if !openBlocks[idx] {
+				t.Fatalf("content_block_delta without matching content_block_start at index %d:\n%s", idx, stream)
+			}
+		case "content_block_stop":
+			idx := int(payload.Get("index").Int())
+			if !openBlocks[idx] {
+				t.Fatalf("content_block_stop without matching content_block_start at index %d:\n%s", idx, stream)
+			}
+			delete(openBlocks, idx)
+		}
+	}
+}
+
+func TestOpenAIStreamingEmptyToolNameSkipsOrphanToolEvents(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if strings.Contains(out, `"type":"tool_use"`) {
+		t.Fatalf("empty function.name must not emit tool_use block:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"input_json_delta"`) {
+		t.Fatalf("empty function.name must not emit input_json_delta:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"content_block_stop"`) {
+		t.Fatalf("empty function.name must not emit orphan content_block_stop:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Fatalf("empty-only tool_calls finish should become end_turn:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
+func TestOpenAIStreamingWhitespaceToolNameSkipped(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-space-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_space","type":"function","function":{"name":"   ","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-space-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if strings.Contains(out, `"type":"tool_use"`) || strings.Contains(out, `"type":"input_json_delta"`) {
+		t.Fatalf("whitespace function.name must not emit tool events:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Fatalf("whitespace-only tool_calls finish should become end_turn:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
+func TestOpenAIStreamingTextWithEmptyToolNameKeepsTextOnly(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-text-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-text-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-text-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if !strings.Contains(out, `"type":"text_delta","text":"hello"`) {
+		t.Fatalf("text before empty-name tool call should be preserved:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"tool_use"`) || strings.Contains(out, `"type":"input_json_delta"`) {
+		t.Fatalf("empty-name tool call must not emit tool events after text:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Fatalf("empty-only tool_calls finish after text should become end_turn:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
+func TestOpenAIStreamingEmptyToolNameWithUsageChunkStopReasonEndTurn(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-empty-tool-usage","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-empty-tool-usage","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: {"id":"chatcmpl-empty-tool-usage","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+		`data: [DONE]`,
+	)
+
+	if strings.Contains(out, `"type":"tool_use"`) || strings.Contains(out, `"type":"input_json_delta"`) {
+		t.Fatalf("empty-name tool call must not emit tool events with usage chunk:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Fatalf("usage message_delta should use end_turn when no valid tool was emitted:\n%s", out)
+	}
+	if strings.Count(out, `"type":"message_stop"`) != 1 {
+		t.Fatalf("stream should emit exactly one message_stop:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
+func TestOpenAIStreamingToolArgumentsBeforeNamePreserved(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_late","type":"function","function":{"arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"Read"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	start := strings.Index(out, `"type":"tool_use"`)
+	delta := strings.Index(out, `"type":"input_json_delta"`)
+	stop := strings.Index(out, `"type":"content_block_stop"`)
+	if start == -1 || delta == -1 || stop == -1 {
+		t.Fatalf("late valid name should emit complete tool block:\n%s", out)
+	}
+	if !(start < delta && delta < stop) {
+		t.Fatalf("tool block events out of order:\n%s", out)
+	}
+	if !strings.Contains(out, `"name":"Read"`) || !strings.Contains(out, `"partial_json":"{\"path\":\"x\"}"`) {
+		t.Fatalf("late valid name should preserve name and buffered arguments:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"tool_use"`) {
+		t.Fatalf("valid tool call should keep tool_use stop_reason:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
+func TestOpenAIStreamingMixedValidAndEmptyToolCalls(t *testing.T) {
+	out := collectOpenAIToClaudeStream(t,
+		`data: {"id":"chatcmpl-mixed-tools","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_valid","type":"function","function":{"name":"Read","arguments":"{\"file_path\":\"a.go\"}"}},{"index":1,"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-mixed-tools","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if got := strings.Count(out, `"type":"tool_use"`); got != 1 {
+		t.Fatalf("expected exactly one valid tool_use, got %d:\n%s", got, out)
+	}
+	if strings.Contains(out, `call_empty`) {
+		t.Fatalf("empty-name tool call must not be emitted:\n%s", out)
+	}
+	if !strings.Contains(out, `"name":"Read"`) || !strings.Contains(out, `"stop_reason":"tool_use"`) {
+		t.Fatalf("valid tool call should be preserved:\n%s", out)
+	}
+	assertNoOrphanContentBlockEvents(t, out)
+}
+
+func TestOpenAINonStreamingEmptyToolNameSkippedAndStopReasonEndTurn(t *testing.T) {
+	raw := []byte(`{"id":"chatcmpl-empty-tool","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":"tool_calls"}]}`)
+
+	streamCompat := strings.Join(convertOpenAINonStreamingToAnthropic(raw), "")
+	if strings.Contains(streamCompat, `"type":"tool_use"`) || strings.Contains(streamCompat, `"name":""`) {
+		t.Fatalf("empty function.name must not emit non-streaming tool_use:\n%s", streamCompat)
+	}
+	if got := gjson.Get(streamCompat, "stop_reason").String(); got != "end_turn" {
+		t.Fatalf("stream-compatible non-stream stop_reason = %q, want end_turn; payload=%s", got, streamCompat)
+	}
+
+	nonStream := ConvertOpenAIResponseToClaudeNonStream(context.Background(), "m", nil, nil, raw, nil)
+	if strings.Contains(nonStream, `"type":"tool_use"`) || strings.Contains(nonStream, `"name":""`) {
+		t.Fatalf("empty function.name must not emit non-streaming tool_use:\n%s", nonStream)
+	}
+	if got := gjson.Get(nonStream, "stop_reason").String(); got != "end_turn" {
+		t.Fatalf("non-stream stop_reason = %q, want end_turn; payload=%s", got, nonStream)
+	}
+}
+
+func TestOpenAINonStreamingContentArrayEmptyToolNameSkipped(t *testing.T) {
+	raw := []byte(`{"id":"chatcmpl-empty-tool-array","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":[{"type":"tool_calls","tool_calls":[{"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]}]},"finish_reason":"tool_calls"}]}`)
+
+	out := ConvertOpenAIResponseToClaudeNonStream(context.Background(), "m", nil, nil, raw, nil)
+	if strings.Contains(out, `"type":"tool_use"`) || strings.Contains(out, `"name":""`) {
+		t.Fatalf("empty function.name in content-array tool_calls must be skipped:\n%s", out)
+	}
+	if got := gjson.Get(out, "stop_reason").String(); got != "end_turn" {
+		t.Fatalf("stop_reason = %q, want end_turn; payload=%s", got, out)
+	}
+}

--- a/test/openai_claude_empty_tool_chain_test.go
+++ b/test/openai_claude_empty_tool_chain_test.go
@@ -116,6 +116,27 @@ func TestOpenAIClaudeEmptyToolNameStreamingChainSkipsInvalidHistory(t *testing.T
 	}
 }
 
+func TestOpenAIClaudeProviderStyleMissingToolNameStreamingChain(t *testing.T) {
+	stream := collectOpenAIToClaudeStreamViaSDK(t,
+		`data: {"id":"chatcmpl-provider-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_missing","type":"function","function":{"arguments":"{\"path\":\"a.go\""}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-provider-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\"offset\":10}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-provider-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: {"id":"chatcmpl-provider-missing-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":11,"total_tokens":18}}`,
+		`data: [DONE]`,
+	)
+
+	if strings.Contains(stream, `"type":"tool_use"`) {
+		t.Fatalf("provider-style arguments without function.name must not become Claude tool_use:\n%s", stream)
+	}
+	if strings.Contains(stream, `"type":"input_json_delta"`) || strings.Contains(stream, `"type":"content_block_stop"`) {
+		t.Fatalf("provider-style arguments without function.name must not emit orphan tool events:\n%s", stream)
+	}
+	if !strings.Contains(stream, `"stop_reason":"end_turn"`) {
+		t.Fatalf("provider-style missing tool name must finish as end_turn:\n%s", stream)
+	}
+	assertNoOrphanAnthropicContentEvents(t, stream)
+}
+
 func TestOpenAIClaudeLateValidToolNameStreamingChainPreservesToolResultReplay(t *testing.T) {
 	stream := collectOpenAIToClaudeStreamViaSDK(t,
 		`data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_late","type":"function","function":{"arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
@@ -176,6 +197,26 @@ func TestOpenAIClaudeMixedValidAndEmptyToolNameStreamingChain(t *testing.T) {
 	}
 	if !strings.Contains(stream, `"name":"Read"`) || !strings.Contains(stream, `"stop_reason":"tool_use"`) {
 		t.Fatalf("valid tool call should be preserved while empty one is skipped:\n%s", stream)
+	}
+	assertNoOrphanAnthropicContentEvents(t, stream)
+}
+
+func TestOpenAIClaudeProviderStyleParallelEmptyFirstIndexStreamingChain(t *testing.T) {
+	stream := collectOpenAIToClaudeStreamViaSDK(t,
+		`data: {"id":"chatcmpl-provider-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_empty","type":"function","function":{"arguments":"{\"path\":\"x\"}"}},{"index":1,"id":"call_valid","type":"function","function":{"name":"Read","arguments":"{\"file_path\":\"a.go\""}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-provider-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"   "}},{"index":1,"function":{"arguments":",\"offset\":10}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-provider-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if got := strings.Count(stream, `"type":"tool_use"`); got != 1 {
+		t.Fatalf("expected exactly one valid Claude tool_use, got %d:\n%s", got, stream)
+	}
+	if strings.Contains(stream, "call_empty") {
+		t.Fatalf("empty first-index tool call must not appear in Claude stream:\n%s", stream)
+	}
+	if !strings.Contains(stream, `"name":"Read"`) || !strings.Contains(stream, `"stop_reason":"tool_use"`) {
+		t.Fatalf("valid parallel tool should be preserved while empty one is skipped:\n%s", stream)
 	}
 	assertNoOrphanAnthropicContentEvents(t, stream)
 }

--- a/test/openai_claude_empty_tool_chain_test.go
+++ b/test/openai_claude_empty_tool_chain_test.go
@@ -1,0 +1,202 @@
+package test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func collectOpenAIToClaudeStreamViaSDK(t *testing.T, chunks ...string) string {
+	t.Helper()
+
+	originalRequest := []byte(`{"model":"m","stream":true,"stream_options":{"include_usage":true}}`)
+	translatedRequest := []byte(`{"model":"m","stream":true}`)
+	var param any
+	var out []string
+	for _, chunk := range chunks {
+		out = append(out, sdktranslator.TranslateStream(
+			context.Background(),
+			sdktranslator.FormatOpenAI,
+			sdktranslator.FormatClaude,
+			"m",
+			originalRequest,
+			translatedRequest,
+			[]byte(chunk),
+			&param,
+		)...)
+	}
+	return strings.Join(out, "")
+}
+
+func assertNoOrphanAnthropicContentEvents(t *testing.T, stream string) {
+	t.Helper()
+
+	openBlocks := make(map[int]bool)
+	for _, segment := range strings.Split(stream, "\n\n") {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+
+		var eventType, data string
+		for _, line := range strings.Split(segment, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event:"):
+				eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		}
+		if data == "" {
+			continue
+		}
+
+		payload := gjson.Parse(data)
+		switch eventType {
+		case "content_block_start":
+			openBlocks[int(payload.Get("index").Int())] = true
+		case "content_block_delta":
+			idx := int(payload.Get("index").Int())
+			if !openBlocks[idx] {
+				t.Fatalf("content_block_delta without content_block_start at index %d:\n%s", idx, stream)
+			}
+		case "content_block_stop":
+			idx := int(payload.Get("index").Int())
+			if !openBlocks[idx] {
+				t.Fatalf("content_block_stop without content_block_start at index %d:\n%s", idx, stream)
+			}
+			delete(openBlocks, idx)
+		}
+	}
+}
+
+func TestOpenAIClaudeEmptyToolNameStreamingChainSkipsInvalidHistory(t *testing.T) {
+	stream := collectOpenAIToClaudeStreamViaSDK(t,
+		`data: {"id":"chatcmpl-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: {"id":"chatcmpl-empty-tool","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+		`data: [DONE]`,
+	)
+
+	if strings.Contains(stream, `"type":"tool_use"`) {
+		t.Fatalf("empty OpenAI function.name must not become Claude tool_use:\n%s", stream)
+	}
+	if strings.Contains(stream, `"type":"input_json_delta"`) {
+		t.Fatalf("empty OpenAI function.name must not emit Claude input_json_delta:\n%s", stream)
+	}
+	if !strings.Contains(stream, `"stop_reason":"end_turn"`) {
+		t.Fatalf("empty-only OpenAI tool_calls finish must become Claude end_turn:\n%s", stream)
+	}
+	if strings.Count(stream, `"type":"message_stop"`) != 1 {
+		t.Fatalf("stream should emit exactly one message_stop:\n%s", stream)
+	}
+	assertNoOrphanAnthropicContentEvents(t, stream)
+
+	dirtyReplay := []byte(`{
+		"model":"claude-3-opus",
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_empty","name":"","input":{"path":"x"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_empty","content":"orphan result"}]}
+		]
+	}`)
+	nextOpenAIRequest := sdktranslator.TranslateRequest(sdktranslator.FormatClaude, sdktranslator.FormatOpenAI, "m", dirtyReplay, false)
+	messages := gjson.GetBytes(nextOpenAIRequest, "messages").Array()
+	for _, msg := range messages {
+		if msg.Get("tool_calls").Exists() {
+			t.Fatalf("dirty empty-name Claude history must not replay as OpenAI tool_calls: %s", nextOpenAIRequest)
+		}
+		if msg.Get("role").String() == "tool" {
+			t.Fatalf("tool_result for skipped tool_use must not replay as orphan OpenAI tool message: %s", nextOpenAIRequest)
+		}
+	}
+}
+
+func TestOpenAIClaudeLateValidToolNameStreamingChainPreservesToolResultReplay(t *testing.T) {
+	stream := collectOpenAIToClaudeStreamViaSDK(t,
+		`data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_late","type":"function","function":{"arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"Read"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	start := strings.Index(stream, `"type":"tool_use"`)
+	delta := strings.Index(stream, `"type":"input_json_delta"`)
+	stop := strings.Index(stream, `"type":"content_block_stop"`)
+	if start == -1 || delta == -1 || stop == -1 || !(start < delta && delta < stop) {
+		t.Fatalf("late valid tool name should emit ordered Claude tool block events:\n%s", stream)
+	}
+	if !strings.Contains(stream, `"name":"Read"`) || !strings.Contains(stream, `"partial_json":"{\"path\":\"x\"}"`) {
+		t.Fatalf("late valid tool name should preserve name and buffered arguments:\n%s", stream)
+	}
+	if !strings.Contains(stream, `"stop_reason":"tool_use"`) {
+		t.Fatalf("valid OpenAI tool call must remain Claude tool_use stop_reason:\n%s", stream)
+	}
+	assertNoOrphanAnthropicContentEvents(t, stream)
+
+	replay := []byte(`{
+		"model":"claude-3-opus",
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_late","name":"Read","input":{"path":"x"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_late","content":"file contents"}]}
+		]
+	}`)
+	nextOpenAIRequest := sdktranslator.TranslateRequest(sdktranslator.FormatClaude, sdktranslator.FormatOpenAI, "m", replay, false)
+	messages := gjson.GetBytes(nextOpenAIRequest, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("valid Claude tool replay should produce assistant tool_calls and tool result, got %d: %s", len(messages), nextOpenAIRequest)
+	}
+	if got := messages[0].Get("tool_calls.0.function.name").String(); got != "Read" {
+		t.Fatalf("tool_calls.0.function.name = %q, want Read: %s", got, nextOpenAIRequest)
+	}
+	if got := messages[1].Get("role").String(); got != "tool" {
+		t.Fatalf("second replayed message role = %q, want tool: %s", got, nextOpenAIRequest)
+	}
+	if got := messages[1].Get("tool_call_id").String(); got != "call_late" {
+		t.Fatalf("tool_call_id = %q, want call_late: %s", got, nextOpenAIRequest)
+	}
+}
+
+func TestOpenAIClaudeMixedValidAndEmptyToolNameStreamingChain(t *testing.T) {
+	stream := collectOpenAIToClaudeStreamViaSDK(t,
+		`data: {"id":"chatcmpl-mixed-tools","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_valid","type":"function","function":{"name":"Read","arguments":"{\"file_path\":\"a.go\"}"}},{"index":1,"id":"call_empty","type":"function","function":{"name":"   ","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-mixed-tools","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+
+	if got := strings.Count(stream, `"type":"tool_use"`); got != 1 {
+		t.Fatalf("expected exactly one valid Claude tool_use, got %d:\n%s", got, stream)
+	}
+	if strings.Contains(stream, "call_empty") {
+		t.Fatalf("empty-name OpenAI tool call must not appear in Claude stream:\n%s", stream)
+	}
+	if !strings.Contains(stream, `"name":"Read"`) || !strings.Contains(stream, `"stop_reason":"tool_use"`) {
+		t.Fatalf("valid tool call should be preserved while empty one is skipped:\n%s", stream)
+	}
+	assertNoOrphanAnthropicContentEvents(t, stream)
+}
+
+func TestOpenAIClaudeEmptyToolNameNonStreamingChain(t *testing.T) {
+	raw := []byte(`{"id":"chatcmpl-empty-tool","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]},"finish_reason":"tool_calls"}]}`)
+
+	out := sdktranslator.TranslateNonStream(
+		context.Background(),
+		sdktranslator.FormatOpenAI,
+		sdktranslator.FormatClaude,
+		"m",
+		[]byte(`{"model":"m","stream":false}`),
+		[]byte(`{"model":"m","stream":false}`),
+		raw,
+		nil,
+	)
+	if strings.Contains(out, `"type":"tool_use"`) || strings.Contains(out, `"name":""`) {
+		t.Fatalf("empty OpenAI function.name must not become Claude non-streaming tool_use:\n%s", out)
+	}
+	if got := gjson.Get(out, "stop_reason").String(); got != "end_turn" {
+		t.Fatalf("Claude non-streaming stop_reason = %q, want end_turn: %s", got, out)
+	}
+}


### PR DESCRIPTION
## Summary
- Gate OpenAI->Claude streaming tool_use blocks on a non-empty function.name before assigning an Anthropic content block.
- Finalize only started tool blocks, so empty-name tool calls cannot emit orphan input_json_delta/content_block_stop events.
- Map tool_calls/function_call finish reasons to end_turn when no valid tool_use was emitted.
- Skip empty tool_use/tools/tool_choice names on Claude->OpenAI requests and avoid orphan tool_result messages for skipped tool_use ids.
- Stabilize image-generation task creation by returning the queued snapshot before the worker goroutine can advance task state; this fixes the CI race observed in TestPostImageGenerationTestCreatesTaskAndPollsSucceededResult.
- Add SDK-level chain tests for OpenAI->Claude streaming/non-streaming empty tool names, late valid tool names, mixed valid/empty tools, and dirty-history replay back to OpenAI.
- Add executor-level httptest coverage for Claude request -> OpenAI-compatible upstream -> Claude response, both stream and non-stream.
- Add provider-style simulations inferred from `new-api` and `sub2api`: arguments without a valid tool name, whitespace late name, and parallel empty index before valid index.
- Add generated invariant coverage for the finite OpenAI Chat Completions <-> Claude Messages tool-name state space: missing/empty/blank/valid names, argument timing, finish reasons, usage chunks, parallel indexes, non-streaming shapes, and request replay.
- Add a detailed Chinese test/investigation report: `docs/internal-review/empty-tool-name-chain-test-report-20260613.md`.
- Document the exact `translator-path-guard` merge blocker and maintainer handoff evidence.

## Reference Investigation
- Reviewed `QuantumNous/new-api` at `51475c8`: its OpenAI->Claude conversion appears to still allow empty-name tool chunks to create invalid/orphan tool events in some paths, and no dedicated empty-name tool tests were found.
- Reviewed `Wei-Shaw/sub2api` at `e34ad2b`: it has strong tool_use/tool_result pairing repair, but the inspected ChatCompletions/Responses/Anthropic conversion paths do not show a complete empty tool name gate, and no dedicated empty-name tool tests were found.
- Conclusion: this fix should guard the local conversion state machine directly rather than relying on adjacent-pair repair only.

## Tests
- rtk go test ./internal/translator/openai/claude -count=1 -v
- rtk go test ./internal/translator/openai/claude -run 'TestOpenAIStreaming(ToolNameStateInvariantsGenerated|ParallelToolNameStateInvariantsGenerated)|TestOpenAINonStreamingToolNameStateInvariantsGenerated' -count=1 -v
- rtk go test ./internal/translator/openai/claude -run 'TestConvertClaudeRequestToOpenAI_(ToolUseNameInvariantsGenerated|ToolsAndToolChoiceNameInvariantsGenerated)' -count=1 -v
- rtk go test ./test -run 'TestOpenAIClaude.*Tool.*Chain|TestOpenAIClaudeEmptyToolNameNonStreamingChain' -count=1 -v
- rtk go test ./internal/runtime/executor -run 'TestOpenAICompatExecutorClaude(StreamSkipsEmptyToolNameEndToEnd|StreamSkipsMissingToolNameArgumentsEndToEnd|StreamPreservesValidParallelToolWhenEmptyIndexFirstEndToEnd|NonStreamSkipsEmptyToolNameEndToEnd)' -count=1 -v
- rtk go test ./internal/translator/... -count=1
- rtk go test ./test -count=1
- rtk go test ./internal/runtime/executor -count=1
- rtk go test ./internal/api/handlers/management -run TestPostImageGenerationTestCreatesTaskAndPollsSucceededResult -count=50
- rtk go test ./internal/api/handlers/management -count=1
- rtk go test ./... -count=1
- rtk go vet ./...
- rtk go build ./...
- rtk git diff --check

## Notes
- This PR intentionally touches `internal/translator/**`; the current `translator-path-guard` policy blocks that path. A separate maintenance issue tracks the governance decision required to merge this safely.
- Guard audit: `.github/workflows/pr-path-guard.yml` hard-codes `internal/translator/**` and does not expose a label/manual-input/body switch for this PR to pass automatically.
