### PR TITLE
fix: normalize model request body handling

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,6 +25,12 @@ port: 8317
 # reverse-proxy links. Default is 120 seconds.
 main-api-read-timeout-seconds: 120
 
+# Request body handling for public model API endpoints.
+# The limit is applied after gzip/br/zstd/deflate decompression. Management and
+# upload endpoints keep narrower endpoint-specific limits.
+request-body:
+  model-max-mb: 128
+
 # Project timezone (IANA name). Affects "today" boundaries and day-based aggregation in monitoring/usage pages.
 # Examples: "Asia/Shanghai", "UTC", "America/Los_Angeles"
 timezone: ""

--- a/internal/api/bodyutil/bodyutil.go
+++ b/internal/api/bodyutil/bodyutil.go
@@ -8,12 +8,14 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	"github.com/gin-gonic/gin"
 )
 
 const (
 	DefaultRequestBodyLimit   int64 = 16 << 20
+	DefaultModelBodyLimit     int64 = 128 << 20
 	ManagementBodyLimit       int64 = 2 << 20
 	ConfigYAMLBodyLimit       int64 = 2 << 20
 	AuthFileBodyLimit         int64 = 2 << 20
@@ -22,11 +24,58 @@ const (
 
 var ErrBodyTooLarge = errors.New("request body too large")
 
+const requestBodyCacheKey = "cliproxy.request_body_cache"
+
+var modelRequestBodyLimit atomic.Int64
+
+func init() {
+	modelRequestBodyLimit.Store(DefaultModelBodyLimit)
+}
+
+// SetModelRequestBodyLimit configures the request-body limit used by model API endpoints.
+func SetModelRequestBodyLimit(limit int64) {
+	if limit <= 0 {
+		limit = DefaultModelBodyLimit
+	}
+	modelRequestBodyLimit.Store(limit)
+}
+
+// ModelRequestBodyLimit returns the active request-body limit for model API endpoints.
+func ModelRequestBodyLimit() int64 {
+	limit := modelRequestBodyLimit.Load()
+	if limit <= 0 {
+		return DefaultModelBodyLimit
+	}
+	return limit
+}
+
 func normalizeLimit(limit int64) int64 {
 	if limit <= 0 {
 		return DefaultRequestBodyLimit
 	}
 	return limit
+}
+
+func cachedRequestBody(c *gin.Context) ([]byte, bool) {
+	if c == nil {
+		return nil, false
+	}
+	bodyVal, ok := c.Get(requestBodyCacheKey)
+	if !ok || bodyVal == nil {
+		return nil, false
+	}
+	body, ok := bodyVal.([]byte)
+	return body, ok
+}
+
+// SetRequestBody caches and restores a request body for downstream consumers.
+func SetRequestBody(c *gin.Context, body []byte) {
+	if c == nil || c.Request == nil {
+		return
+	}
+	c.Set(requestBodyCacheKey, body)
+	c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	c.Request.ContentLength = int64(len(body))
 }
 
 // ReadRequestBody reads and restores an incoming HTTP request body with a strict size limit.
@@ -36,12 +85,21 @@ func ReadRequestBody(c *gin.Context, limit int64) ([]byte, error) {
 	}
 
 	limit = normalizeLimit(limit)
+	if cached, ok := cachedRequestBody(c); ok {
+		if int64(len(cached)) > limit {
+			return nil, ErrBodyTooLarge
+		}
+		c.Request.Body = io.NopCloser(bytes.NewReader(cached))
+		c.Request.ContentLength = int64(len(cached))
+		return cached, nil
+	}
+
 	if c.Writer == nil {
 		body, err := ReadAll(c.Request.Body, limit)
 		if err != nil {
 			return nil, err
 		}
-		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+		SetRequestBody(c, body)
 		return body, nil
 	}
 
@@ -50,7 +108,7 @@ func ReadRequestBody(c *gin.Context, limit int64) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	SetRequestBody(c, body)
 	return body, nil
 }
 

--- a/internal/api/bodyutil/bodyutil_test.go
+++ b/internal/api/bodyutil/bodyutil_test.go
@@ -2,8 +2,10 @@ package bodyutil
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -73,5 +75,54 @@ func TestLimitBodyMiddlewareRejectsOversizedDeleteRequest(t *testing.T) {
 
 	if w.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("expected status %d, got %d", http.StatusRequestEntityTooLarge, w.Code)
+	}
+}
+
+func TestReadRequestBodyUsesCacheAndSetRequestBodyRefreshesIt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"value":"original"}`))
+
+	body, err := ReadRequestBody(c, 64)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if string(body) != `{"value":"original"}` {
+		t.Fatalf("body = %s", body)
+	}
+
+	c.Request.Body = io.NopCloser(strings.NewReader(`{"value":"mutated-without-cache-refresh"}`))
+	body, err = ReadRequestBody(c, 64)
+	if err != nil {
+		t.Fatalf("unexpected cached read error: %v", err)
+	}
+	if string(body) != `{"value":"original"}` {
+		t.Fatalf("cached body = %s", body)
+	}
+
+	SetRequestBody(c, []byte(`{"value":"updated"}`))
+	body, err = ReadRequestBody(c, 64)
+	if err != nil {
+		t.Fatalf("unexpected refreshed read error: %v", err)
+	}
+	if string(body) != `{"value":"updated"}` {
+		t.Fatalf("refreshed body = %s", body)
+	}
+}
+
+func TestModelRequestBodyLimitCanBeConfigured(t *testing.T) {
+	previous := ModelRequestBodyLimit()
+	t.Cleanup(func() { SetModelRequestBodyLimit(previous) })
+
+	SetModelRequestBodyLimit(32)
+	if got := ModelRequestBodyLimit(); got != 32 {
+		t.Fatalf("ModelRequestBodyLimit = %d, want 32", got)
+	}
+
+	SetModelRequestBodyLimit(0)
+	if got := ModelRequestBodyLimit(); got != DefaultModelBodyLimit {
+		t.Fatalf("ModelRequestBodyLimit default = %d, want %d", got, DefaultModelBodyLimit)
 	}
 }

--- a/internal/api/handlers/management/proxy_pool_test.go
+++ b/internal/api/handlers/management/proxy_pool_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestGetProxyPoolIncludesMaskedURL(t *testing.T) {
-	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
 	h := NewHandler(&config.Config{
@@ -55,7 +54,6 @@ func TestGetProxyPoolIncludesMaskedURL(t *testing.T) {
 }
 
 func TestPutProxyPoolNormalizesAndPersists(t *testing.T) {
-	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
@@ -89,7 +87,6 @@ func TestPutProxyPoolNormalizesAndPersists(t *testing.T) {
 }
 
 func TestPatchProxyPoolEntryUpdatesConfigWithoutAppending(t *testing.T) {
-	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
@@ -136,7 +133,6 @@ func TestPatchProxyPoolEntryUpdatesConfigWithoutAppending(t *testing.T) {
 }
 
 func TestPostProxyPoolCheckUsesConfiguredProxy(t *testing.T) {
-	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/middleware/request_decompression.go
+++ b/internal/api/middleware/request_decompression.go
@@ -1,0 +1,137 @@
+package middleware
+
+import (
+	"bufio"
+	"compress/gzip"
+	"compress/zlib"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/andybalholm/brotli"
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+)
+
+type decompressedReadCloser struct {
+	io.Reader
+	closeFn func() error
+}
+
+func (r *decompressedReadCloser) Close() error {
+	if r.closeFn != nil {
+		return r.closeFn()
+	}
+	return nil
+}
+
+// DecompressRequestMiddleware normalizes compressed API request bodies before
+// downstream middlewares inspect them. Limits are enforced on both the inbound
+// compressed stream and the decoded stream to prevent oversized requests and
+// decompression bombs.
+func DecompressRequestMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c == nil || c.Request == nil || c.Request.Body == nil || c.Request.Method == http.MethodGet {
+			c.Next()
+			return
+		}
+
+		limit := bodyutil.ModelRequestBodyLimit()
+		origBody := c.Request.Body
+		rawBody := http.MaxBytesReader(c.Writer, origBody, limit)
+		br := bufio.NewReader(rawBody)
+
+		encoding := strings.ToLower(strings.TrimSpace(c.GetHeader("Content-Encoding")))
+		if encoding == "" || encoding == "identity" {
+			if peek, _ := br.Peek(4); len(peek) >= 2 && peek[0] == 0x1f && peek[1] == 0x8b {
+				encoding = "gzip"
+			} else if len(peek) >= 4 && peek[0] == 0x28 && peek[1] == 0xb5 && peek[2] == 0x2f && peek[3] == 0xfd {
+				encoding = "zstd"
+			}
+		}
+
+		wrapDecoded := func(body io.ReadCloser) io.ReadCloser {
+			return http.MaxBytesReader(c.Writer, body, limit)
+		}
+		clearDecodedHeaders := func() {
+			c.Request.Header.Del("Content-Encoding")
+			c.Request.Header.Del("Content-Length")
+			c.Request.ContentLength = -1
+		}
+		abortInvalidEncoding := func(message string, status int) {
+			_ = rawBody.Close()
+			c.AbortWithStatusJSON(status, gin.H{
+				"error": gin.H{
+					"message": message,
+					"type":    "invalid_request_error",
+				},
+			})
+		}
+
+		switch encoding {
+		case "", "identity":
+			c.Request.Body = &decompressedReadCloser{
+				Reader: br,
+				closeFn: func() error {
+					return rawBody.Close()
+				},
+			}
+		case "gzip", "x-gzip":
+			reader, err := gzip.NewReader(br)
+			if err != nil {
+				abortInvalidEncoding("invalid gzip request body", http.StatusBadRequest)
+				return
+			}
+			c.Request.Body = wrapDecoded(&decompressedReadCloser{
+				Reader: reader,
+				closeFn: func() error {
+					_ = reader.Close()
+					return rawBody.Close()
+				},
+			})
+			clearDecodedHeaders()
+		case "br":
+			c.Request.Body = wrapDecoded(&decompressedReadCloser{
+				Reader: brotli.NewReader(br),
+				closeFn: func() error {
+					return rawBody.Close()
+				},
+			})
+			clearDecodedHeaders()
+		case "zstd":
+			reader, err := zstd.NewReader(br)
+			if err != nil {
+				abortInvalidEncoding("invalid zstd request body", http.StatusBadRequest)
+				return
+			}
+			c.Request.Body = wrapDecoded(&decompressedReadCloser{
+				Reader: reader,
+				closeFn: func() error {
+					reader.Close()
+					return rawBody.Close()
+				},
+			})
+			clearDecodedHeaders()
+		case "deflate":
+			reader, err := zlib.NewReader(br)
+			if err != nil {
+				abortInvalidEncoding("invalid deflate request body", http.StatusBadRequest)
+				return
+			}
+			c.Request.Body = wrapDecoded(&decompressedReadCloser{
+				Reader: reader,
+				closeFn: func() error {
+					_ = reader.Close()
+					return rawBody.Close()
+				},
+			})
+			clearDecodedHeaders()
+		default:
+			abortInvalidEncoding("unsupported content encoding: "+encoding, http.StatusUnsupportedMediaType)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/api/middleware/request_decompression_test.go
+++ b/internal/api/middleware/request_decompression_test.go
@@ -1,0 +1,169 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+)
+
+func zstdRequestBody(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter: %v", err)
+	}
+	defer encoder.Close()
+	return encoder.EncodeAll(raw, nil)
+}
+
+func gzipRequestBody(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	if _, err := writer.Write(raw); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func brotliRequestBody(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := brotli.NewWriter(&buf)
+	if _, err := writer.Write(raw); err != nil {
+		t.Fatalf("brotli write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("brotli close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func deflateRequestBody(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := zlib.NewWriter(&buf)
+	if _, err := writer.Write(raw); err != nil {
+		t.Fatalf("deflate write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("deflate close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestDecompressRequestMiddlewareDecodesSupportedContentEncodings(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousLimit := bodyutil.ModelRequestBodyLimit()
+	t.Cleanup(func() { bodyutil.SetModelRequestBodyLimit(previousLimit) })
+	bodyutil.SetModelRequestBodyLimit(1 << 20)
+
+	raw := []byte(`{"model":"gpt-5.5","input":"hello","stream":true}`)
+	tests := []struct {
+		name     string
+		encoding string
+		body     []byte
+	}{
+		{name: "gzip", encoding: "gzip", body: gzipRequestBody(t, raw)},
+		{name: "x-gzip", encoding: "x-gzip", body: gzipRequestBody(t, raw)},
+		{name: "br", encoding: "br", body: brotliRequestBody(t, raw)},
+		{name: "zstd", encoding: "zstd", body: zstdRequestBody(t, raw)},
+		{name: "deflate", encoding: "deflate", body: deflateRequestBody(t, raw)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := gin.New()
+			r.Use(DecompressRequestMiddleware())
+			r.POST("/v1/responses", func(c *gin.Context) {
+				body, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
+				if err != nil {
+					t.Fatalf("ReadRequestBody: %v", err)
+				}
+				if got := c.GetHeader("Content-Encoding"); got != "" {
+					t.Fatalf("Content-Encoding = %q, want empty", got)
+				}
+				if string(body) != string(raw) {
+					t.Fatalf("decoded body = %q, want %q", body, raw)
+				}
+				c.Status(http.StatusNoContent)
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Content-Encoding", tt.encoding)
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestDecompressRequestMiddlewareDetectsZstdWithoutHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousLimit := bodyutil.ModelRequestBodyLimit()
+	t.Cleanup(func() { bodyutil.SetModelRequestBodyLimit(previousLimit) })
+	bodyutil.SetModelRequestBodyLimit(1 << 20)
+
+	raw := []byte(`{"model":"gpt-5.5","input":"hello","stream":true}`)
+	r := gin.New()
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/responses", func(c *gin.Context) {
+		body, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
+		if err != nil {
+			t.Fatalf("ReadRequestBody: %v", err)
+		}
+		if c.GetHeader("Content-Encoding") != "" {
+			t.Fatalf("Content-Encoding was not cleared")
+		}
+		if string(body) != string(raw) {
+			t.Fatalf("decoded body = %q, want %q", body, raw)
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(zstdRequestBody(t, raw)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestDecompressRequestMiddlewareRejectsUnsupportedEncoding(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/responses", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Content-Encoding", "snappy")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusUnsupportedMediaType, w.Body.String())
+	}
+}

--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -92,9 +92,6 @@ func isResponsesWebsocketUpgrade(req *http.Request) bool {
 }
 
 func shouldCaptureRequestBody(loggerEnabled bool, req *http.Request) bool {
-	if loggerEnabled {
-		return true
-	}
 	if req == nil || req.Body == nil {
 		return false
 	}
@@ -103,6 +100,9 @@ func shouldCaptureRequestBody(loggerEnabled bool, req *http.Request) bool {
 		return false
 	}
 	if req.ContentLength <= 0 {
+		return false
+	}
+	if loggerEnabled && req.ContentLength > maxErrorOnlyCapturedRequestBodyBytes {
 		return false
 	}
 	return req.ContentLength <= maxErrorOnlyCapturedRequestBodyBytes

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 )
@@ -80,14 +79,34 @@ func TestShouldCaptureRequestBody(t *testing.T) {
 		want          bool
 	}{
 		{
-			name:          "logger enabled always captures",
+			name:          "logger enabled unknown size skipped",
 			loggerEnabled: true,
 			req: &http.Request{
 				Body:          io.NopCloser(strings.NewReader("{}")),
 				ContentLength: -1,
 				Header:        http.Header{"Content-Type": []string{"application/json"}},
 			},
+			want: false,
+		},
+		{
+			name:          "logger enabled small known size captures",
+			loggerEnabled: true,
+			req: &http.Request{
+				Body:          io.NopCloser(strings.NewReader("{}")),
+				ContentLength: 2,
+				Header:        http.Header{"Content-Type": []string{"application/json"}},
+			},
 			want: true,
+		},
+		{
+			name:          "logger enabled large known size skipped",
+			loggerEnabled: true,
+			req: &http.Request{
+				Body:          io.NopCloser(strings.NewReader("x")),
+				ContentLength: maxErrorOnlyCapturedRequestBodyBytes + 1,
+				Header:        http.Header{"Content-Type": []string{"application/json"}},
+			},
+			want: false,
 		},
 		{
 			name:          "nil request",
@@ -166,7 +185,7 @@ func (stubRequestLogger) LogStreamingRequest(string, string, map[string][]string
 
 func (stubRequestLogger) IsEnabled() bool { return true }
 
-func TestRequestLoggingMiddlewareRejectsOversizedBody(t *testing.T) {
+func TestRequestLoggingMiddlewareDoesNotRejectOversizedBody(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var reachedHandler bool
@@ -177,17 +196,17 @@ func TestRequestLoggingMiddlewareRejectsOversizedBody(t *testing.T) {
 		c.Status(http.StatusNoContent)
 	})
 
-	body := bytes.Repeat([]byte("a"), int(bodyutil.DefaultRequestBodyLimit)+1)
+	body := bytes.Repeat([]byte("a"), int(maxErrorOnlyCapturedRequestBodyBytes)+1)
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusRequestEntityTooLarge {
-		t.Fatalf("expected status %d, got %d", http.StatusRequestEntityTooLarge, w.Code)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, w.Code)
 	}
-	if reachedHandler {
-		t.Fatal("request should have been rejected before reaching handler")
+	if !reachedHandler {
+		t.Fatal("request should reach handler; logging must not enforce API body limits")
 	}
 }

--- a/internal/api/modules/amp/fallback_handlers.go
+++ b/internal/api/modules/amp/fallback_handlers.go
@@ -117,7 +117,7 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 		requestPath := c.Request.URL.Path
 
 		// Read the request body to extract the model name
-		bodyBytes, err := bodyutil.ReadRequestBody(c, bodyutil.DefaultRequestBodyLimit)
+		bodyBytes, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
 		if err != nil {
 			if bodyutil.IsTooLarge(err) {
 				c.AbortWithStatusJSON(413, gin.H{"error": "request body too large"})

--- a/internal/api/request_body_chain_test.go
+++ b/internal/api/request_body_chain_test.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	sdkhandlers "github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	"github.com/tidwall/gjson"
+)
+
+type chainStreamingLogWriter struct{}
+
+func (chainStreamingLogWriter) WriteChunkAsync([]byte)                     {}
+func (chainStreamingLogWriter) WriteStatus(int, map[string][]string) error { return nil }
+func (chainStreamingLogWriter) WriteAPIRequest([]byte) error               { return nil }
+func (chainStreamingLogWriter) WriteAPIResponse([]byte) error              { return nil }
+func (chainStreamingLogWriter) SetFirstChunkTimestamp(time.Time)           {}
+func (chainStreamingLogWriter) Close() error                               { return nil }
+
+type chainRequestLogger struct{}
+
+func (chainRequestLogger) LogRequest(string, string, map[string][]string, []byte, int, map[string][]string, []byte, []byte, []byte, []*interfaces.ErrorMessage, string, time.Time, time.Time) error {
+	return nil
+}
+
+func (chainRequestLogger) LogStreamingRequest(string, string, map[string][]string, []byte, string) (logging.StreamingLogWriter, error) {
+	return chainStreamingLogWriter{}, nil
+}
+
+func (chainRequestLogger) IsEnabled() bool { return true }
+
+func encodeZstdForRequestBodyTest(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter: %v", err)
+	}
+	defer encoder.Close()
+	return encoder.EncodeAll(raw, nil)
+}
+
+func TestResponsesBodyChainAllowsPayloadAboveLegacyLimitWithRequestLogging(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousLimit := bodyutil.ModelRequestBodyLimit()
+	t.Cleanup(func() { bodyutil.SetModelRequestBodyLimit(previousLimit) })
+	bodyutil.SetModelRequestBodyLimit(32 << 20)
+
+	input := bytes.Repeat([]byte("a"), (17<<20)+1)
+	var payload bytes.Buffer
+	payload.Grow(len(input) + 64)
+	payload.WriteString(`{"model":"gpt-5.5","input":"`)
+	payload.Write(input)
+	payload.WriteString(`","stream":true}`)
+
+	r := gin.New()
+	r.Use(middleware.DecompressRequestMiddleware())
+	r.Use(middleware.RequestLoggingMiddleware(chainRequestLogger{}))
+	r.POST("/v1/responses", func(c *gin.Context) {
+		body, ok := sdkhandlers.ReadJSONRequestBody(c)
+		if !ok {
+			return
+		}
+		if gjson.GetBytes(body, "model").String() != "gpt-5.5" {
+			t.Fatalf("model not parsed from body")
+		}
+		c.JSON(http.StatusOK, gin.H{"body_size": len(body)})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(payload.Bytes()))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestResponsesBodyChainDecodesZstdAndRefreshesBodyAfterSystemPrompt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousLimit := bodyutil.ModelRequestBodyLimit()
+	t.Cleanup(func() { bodyutil.SetModelRequestBodyLimit(previousLimit) })
+	bodyutil.SetModelRequestBodyLimit(1 << 20)
+
+	raw := []byte(`{"model":"gpt-5.5","input":"hello","stream":true}`)
+	r := gin.New()
+	r.Use(middleware.DecompressRequestMiddleware())
+	r.Use(middleware.RequestLoggingMiddleware(chainRequestLogger{}))
+	r.Use(func(c *gin.Context) {
+		c.Set("accessMetadata", map[string]string{"system-prompt": "system from metadata"})
+		c.Next()
+	})
+	r.Use(SystemPromptMiddleware())
+	r.POST("/v1/responses", func(c *gin.Context) {
+		body, ok := sdkhandlers.ReadJSONRequestBody(c)
+		if !ok {
+			return
+		}
+		if got := gjson.GetBytes(body, "instructions").String(); got != "system from metadata" {
+			t.Fatalf("instructions = %q", got)
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(encodeZstdForRequestBodyTest(t, raw)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestResponsesBodyChainRejectsOversizedDecodedZstdBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousLimit := bodyutil.ModelRequestBodyLimit()
+	t.Cleanup(func() { bodyutil.SetModelRequestBodyLimit(previousLimit) })
+	bodyutil.SetModelRequestBodyLimit(512)
+
+	input := bytes.Repeat([]byte("a"), 4096)
+	var payload bytes.Buffer
+	payload.WriteString(`{"model":"gpt-5.5","input":"`)
+	payload.Write(input)
+	payload.WriteString(`","stream":true}`)
+
+	r := gin.New()
+	r.Use(middleware.DecompressRequestMiddleware())
+	r.Use(middleware.RequestLoggingMiddleware(chainRequestLogger{}))
+	r.POST("/v1/responses", func(c *gin.Context) {
+		_, _ = sdkhandlers.ReadJSONRequestBody(c)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(encodeZstdForRequestBodyTest(t, payload.Bytes())))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusRequestEntityTooLarge, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("request_body_too_large")) {
+		t.Fatalf("expected request_body_too_large response, got %s", w.Body.String())
+	}
+}

--- a/internal/api/server_config_reload.go
+++ b/internal/api/server_config_reload.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	internalserviceapp "github.com/router-for-me/CLIProxyAPI/v6/internal/app/service"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
@@ -47,6 +48,7 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	s.applyProcessLoggingConfig(oldCfg, cfg)
 	s.applyUsageStatisticsConfig(oldCfg, cfg)
 	s.applyAuthRuntimeConfig(oldCfg, cfg)
+	s.applyRequestBodyConfig(oldCfg, cfg)
 	s.applyRuntimeLogLevel(oldCfg, cfg)
 	s.applyProxyWarmupConfig(cfg)
 	s.updateManagementRouteAvailability(oldCfg, cfg)
@@ -57,6 +59,15 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	s.refreshAmpModule(oldCfg, cfg)
 	s.syncTokenStoreBaseDir(cfg)
 	s.logClientUpdateSummary(cfg)
+}
+
+func (s *Server) applyRequestBodyConfig(oldCfg, cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	if oldCfg == nil || oldCfg.ModelRequestBodyLimitBytes() != cfg.ModelRequestBodyLimitBytes() {
+		bodyutil.SetModelRequestBodyLimit(cfg.ModelRequestBodyLimitBytes())
+	}
 }
 
 func (s *Server) oldConfigSnapshot() *config.Config {

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	managementHandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/modules"
@@ -40,6 +41,7 @@ func configureServerMode(cfg *config.Config) {
 
 func newServerEngine(cfg *config.Config, optionState *serverOptionConfig) *gin.Engine {
 	engine := gin.New()
+	bodyutil.SetModelRequestBodyLimit(configModelRequestBodyLimitBytes(cfg))
 	if cfg != nil {
 		configureTrustedProxies(engine, cfg.TrustedProxies)
 	}
@@ -49,6 +51,7 @@ func newServerEngine(cfg *config.Config, optionState *serverOptionConfig) *gin.E
 
 	engine.Use(logging.GinLogrusLogger())
 	engine.Use(logging.GinLogrusRecovery())
+	engine.Use(middleware.DecompressRequestMiddleware())
 	if optionState != nil {
 		for _, mw := range optionState.extraMiddleware {
 			engine.Use(mw)
@@ -134,6 +137,7 @@ func (s *Server) applyInitialRuntimeConfig(cfg *config.Config, authManager *auth
 	if s == nil || cfg == nil {
 		return
 	}
+	bodyutil.SetModelRequestBodyLimit(configModelRequestBodyLimitBytes(cfg))
 	if s.handlers != nil {
 		s.handlers.AuthManager = authManager
 	}
@@ -146,6 +150,13 @@ func (s *Server) applyInitialRuntimeConfig(cfg *config.Config, authManager *auth
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
 	s.applyProxyWarmupConfig(cfg)
+}
+
+func configModelRequestBodyLimitBytes(cfg *config.Config) int64 {
+	if cfg == nil {
+		return int64(config.DefaultModelRequestBodyMB) << 20
+	}
+	return cfg.ModelRequestBodyLimitBytes()
 }
 
 func (s *Server) configureManagementHandler(

--- a/internal/api/server_model_restriction.go
+++ b/internal/api/server_model_restriction.go
@@ -78,7 +78,7 @@ func (s *Server) modelRestrictionMiddleware() gin.HandlerFunc {
 			}
 		}
 
-		bodyBytes, err := bodyutil.ReadRequestBody(c, bodyutil.DefaultRequestBodyLimit)
+		bodyBytes, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
 		if err != nil {
 			if bodyutil.IsTooLarge(err) {
 				c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})

--- a/internal/api/system_prompt_middleware.go
+++ b/internal/api/system_prompt_middleware.go
@@ -1,9 +1,7 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 
@@ -37,7 +35,7 @@ func SystemPromptMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		bodyBytes, err := bodyutil.ReadRequestBody(c, bodyutil.DefaultRequestBodyLimit)
+		bodyBytes, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
 		if err != nil {
 			if bodyutil.IsTooLarge(err) {
 				c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
@@ -55,7 +53,7 @@ func SystemPromptMiddleware() gin.HandlerFunc {
 			}
 			var body map[string]interface{}
 			if err := json.Unmarshal(bodyBytes, &body); err != nil {
-				c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				bodyutil.SetRequestBody(c, bodyBytes)
 				c.Next()
 				return
 			}
@@ -66,7 +64,7 @@ func SystemPromptMiddleware() gin.HandlerFunc {
 			body["messages"] = newMessages
 			newBody, err = json.Marshal(body)
 			if err != nil {
-				c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				bodyutil.SetRequestBody(c, bodyBytes)
 				c.Next()
 				return
 			}
@@ -79,19 +77,18 @@ func SystemPromptMiddleware() gin.HandlerFunc {
 			}
 			newBody, _ = sjson.SetBytes(bodyBytes, "instructions", combined)
 			if newBody == nil {
-				c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				bodyutil.SetRequestBody(c, bodyBytes)
 				c.Next()
 				return
 			}
 			log.Debugf("[SystemPrompt] injected into instructions (Responses API)")
 		} else {
-			c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			bodyutil.SetRequestBody(c, bodyBytes)
 			c.Next()
 			return
 		}
 
-		c.Request.Body = io.NopCloser(bytes.NewReader(newBody))
-		c.Request.ContentLength = int64(len(newBody))
+		bodyutil.SetRequestBody(c, newBody)
 		c.Next()
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	// When unset or <= 0, DefaultMainAPIReadTimeout is used.
 	MainAPIReadTimeoutSeconds int `yaml:"main-api-read-timeout-seconds,omitempty" json:"main-api-read-timeout-seconds,omitempty"`
 
+	// RequestBody controls request-body limits for public model API endpoints.
+	RequestBody RequestBodyConfig `yaml:"request-body,omitempty" json:"request-body,omitempty"`
+
 	// Timezone configures the project's timezone (IANA name, e.g. "Asia/Shanghai").
 	// It affects "today" boundaries and day-based aggregation in monitoring/usage pages.
 	// When empty, the process local timezone (time.Local) is used.
@@ -168,6 +171,22 @@ func (cfg *Config) MainAPIReadTimeout() time.Duration {
 		return DefaultMainAPIReadTimeout
 	}
 	return time.Duration(cfg.MainAPIReadTimeoutSeconds) * time.Second
+}
+
+// RequestBodyConfig controls public model API request-body handling.
+type RequestBodyConfig struct {
+	// ModelMaxMB is the maximum decoded request body size for model endpoints.
+	// Management and upload endpoints keep their narrower endpoint-specific limits.
+	ModelMaxMB int `yaml:"model-max-mb,omitempty" json:"model-max-mb,omitempty"`
+}
+
+// ModelRequestBodyLimitBytes returns the decoded body limit for model endpoints.
+func (cfg *Config) ModelRequestBodyLimitBytes() int64 {
+	maxMB := DefaultModelRequestBodyMB
+	if cfg != nil && cfg.RequestBody.ModelMaxMB > 0 {
+		maxMB = cfg.RequestBody.ModelMaxMB
+	}
+	return int64(maxMB) << 20
 }
 
 // ClaudeHeaderDefaults configures default header values injected into Claude API requests

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,6 +53,45 @@ func TestLoadConfigReadsMainAPIReadTimeoutOverride(t *testing.T) {
 	}
 }
 
+func TestLoadConfigReadsRequestBodyModelLimit(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("request-body:\n  model-max-mb: 64\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if cfg.RequestBody.ModelMaxMB != 64 {
+		t.Fatalf("RequestBody.ModelMaxMB = %d, want 64", cfg.RequestBody.ModelMaxMB)
+	}
+	if cfg.ModelRequestBodyLimitBytes() != 64<<20 {
+		t.Fatalf("ModelRequestBodyLimitBytes = %d, want %d", cfg.ModelRequestBodyLimitBytes(), int64(64<<20))
+	}
+}
+
+func TestLoadConfigDefaultsRequestBodyModelLimit(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if cfg.RequestBody.ModelMaxMB != DefaultModelRequestBodyMB {
+		t.Fatalf("RequestBody.ModelMaxMB = %d, want %d", cfg.RequestBody.ModelMaxMB, DefaultModelRequestBodyMB)
+	}
+}
+
 func TestLoadConfigSanitizesProxyWarmupDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -7,6 +7,7 @@ const (
 	DefaultAutoUpdateRepository  = "https://github.com/kittors/CliRelay"
 	DefaultAutoUpdateDockerImage = "ghcr.io/kittors/clirelay"
 	DefaultAutoUpdateUpdaterURL  = "http://clirelay-updater:8320"
+	DefaultModelRequestBodyMB    = 128
 
 	// EnvAuthPath overrides auth-dir with the path visible inside the running container/process.
 	EnvAuthPath = "AUTH_PATH"

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -62,6 +62,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.LoggingToFile = false
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
+	cfg.RequestBody.ModelMaxMB = DefaultModelRequestBodyMB
 	cfg.UsageStatisticsEnabled = false
 	cfg.RequestLogStorage.StoreContent = true
 	cfg.RequestLogStorage.ContentRetentionDays = 30
@@ -144,6 +145,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	}
 	if cfg.Port == 0 {
 		cfg.Port = 8315
+	}
+	if cfg.RequestBody.ModelMaxMB <= 0 {
+		cfg.RequestBody.ModelMaxMB = DefaultModelRequestBodyMB
 	}
 	if cfg.RequestLogStorage.ContentRetentionDays < 0 {
 		cfg.RequestLogStorage.ContentRetentionDays = 0

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -67,7 +67,7 @@ func ReadJSONRequestBody(c *gin.Context) ([]byte, bool) {
 		return nil, false
 	}
 
-	body, err := bodyutil.ReadRequestBody(c, bodyutil.DefaultRequestBodyLimit)
+	body, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
 	if err == nil {
 		return body, true
 	}
@@ -434,7 +434,7 @@ func requestNeedsWriteTimeoutBypass(c *gin.Context) bool {
 	default:
 		return false
 	}
-	body, err := bodyutil.ReadRequestBody(c, bodyutil.DefaultRequestBodyLimit)
+	body, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
 	if err != nil || len(body) == 0 {
 		return false
 	}

--- a/sdk/api/handlers/request_body_test.go
+++ b/sdk/api/handlers/request_body_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 )
 
 type timeoutReadCloser struct{}
@@ -29,12 +30,16 @@ func (timeoutReadError) Timeout() bool   { return true }
 func (timeoutReadError) Temporary() bool { return true }
 
 func TestReadJSONRequestBodyReturnsTooLargeError(t *testing.T) {
-	t.Parallel()
-
 	gin.SetMode(gin.TestMode)
+	previousLimit := bodyutil.ModelRequestBodyLimit()
+	t.Cleanup(func() {
+		bodyutil.SetModelRequestBodyLimit(previousLimit)
+	})
+	bodyutil.SetModelRequestBodyLimit(8)
+
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
-	oversized := bytes.Repeat([]byte("a"), (16<<20)+1)
+	oversized := bytes.Repeat([]byte("a"), 9)
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(oversized))
 	req.Header.Set("Content-Type", "application/json")
 	c.Request = req
@@ -60,8 +65,6 @@ func TestReadJSONRequestBodyReturnsTooLargeError(t *testing.T) {
 }
 
 func TestReadJSONRequestBodyReturnsTimeoutError(t *testing.T) {
-	t.Parallel()
-
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
@@ -97,8 +100,6 @@ func TestReadJSONRequestBodyReturnsTimeoutError(t *testing.T) {
 }
 
 func TestReadJSONRequestBodyRestoresRequestBody(t *testing.T) {
-	t.Parallel()
-
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)


### PR DESCRIPTION
## Summary
- add unified model request decompression and decoded-size enforcement for gzip/br/zstd/deflate
- make model request body limit configurable via request-body.model-max-mb with hot reload support
- reuse cached request bodies across logging, system prompt injection, restrictions, and SDK handlers
- keep request logging from pre-reading large request bodies and triggering legacy 413s

## Tests
- rtk go test ./...
- rtk go test -race ./internal/api/... ./sdk/api/handlers/...