### PR TITLE
fix: harden large request body storage

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,6 +30,12 @@ main-api-read-timeout-seconds: 120
 # upload endpoints keep narrower endpoint-specific limits.
 request-body:
   model-max-mb: 128
+  # Decoded request bodies at or above this size are cached in a temporary file
+  # for downstream reuse instead of being retained in memory for the whole request.
+  disk-threshold-mb: 8
+  # Optional dedicated directory for large reusable request-body temp files.
+  # Empty uses the OS temp directory under a CliRelay-specific subdirectory.
+  cache-dir: ""
 
 # Project timezone (IANA name). Affects "today" boundaries and day-based aggregation in monitoring/usage pages.
 # Examples: "Asia/Shanghai", "UTC", "America/Los_Angeles"

--- a/internal/api/bodyutil/body_storage.go
+++ b/internal/api/bodyutil/body_storage.go
@@ -1,0 +1,463 @@
+package bodyutil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const (
+	bodyStorageCacheDirName = "clirelay-request-body-cache"
+	bodyStorageTempPattern  = "clirelay-request-body-*.tmp"
+	bodyStorageMinFreeBytes = 16 << 20
+)
+
+var ErrBodyStorageClosed = os.ErrClosed
+var ErrBodyStorageUnavailable = errors.New("request body disk cache unavailable")
+
+var requestBodyCacheDir atomic.Value
+
+var requestBodyStorageStats struct {
+	activeMemoryBytes atomic.Int64
+	activeDiskBytes   atomic.Int64
+	activeDiskFiles   atomic.Int64
+	memoryCreates     atomic.Int64
+	diskCreates       atomic.Int64
+}
+
+// RequestBodyStorageStats snapshots active reusable body storage.
+type RequestBodyStorageStats struct {
+	ActiveMemoryBytes int64
+	ActiveDiskBytes   int64
+	ActiveDiskFiles   int64
+	MemoryCreates     int64
+	DiskCreates       int64
+}
+
+// BodyStorage keeps request bodies reusable without forcing large payloads to
+// stay resident in memory for the rest of the request.
+type BodyStorage interface {
+	io.ReadSeeker
+	io.Closer
+	Bytes() ([]byte, error)
+	Size() int64
+	IsDisk() bool
+}
+
+type memoryBodyStorage struct {
+	mu     sync.Mutex
+	data   []byte
+	reader *bytes.Reader
+	size   int64
+	closed bool
+}
+
+func newMemoryBodyStorage(data []byte) *memoryBodyStorage {
+	size := int64(len(data))
+	requestBodyStorageStats.activeMemoryBytes.Add(size)
+	requestBodyStorageStats.memoryCreates.Add(1)
+	return &memoryBodyStorage{
+		data:   data,
+		reader: bytes.NewReader(data),
+		size:   size,
+	}
+}
+
+func (s *memoryBodyStorage) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, ErrBodyStorageClosed
+	}
+	return s.reader.Read(p)
+}
+
+func (s *memoryBodyStorage) Seek(offset int64, whence int) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, ErrBodyStorageClosed
+	}
+	return s.reader.Seek(offset, whence)
+}
+
+func (s *memoryBodyStorage) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	requestBodyStorageStats.activeMemoryBytes.Add(-s.size)
+	s.data = nil
+	s.reader = bytes.NewReader(nil)
+	return nil
+}
+
+func (s *memoryBodyStorage) Bytes() ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, ErrBodyStorageClosed
+	}
+	return s.data, nil
+}
+
+func (s *memoryBodyStorage) Size() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0
+	}
+	return s.size
+}
+
+func (s *memoryBodyStorage) IsDisk() bool {
+	return false
+}
+
+type diskBodyStorage struct {
+	mu     sync.Mutex
+	file   *os.File
+	path   string
+	size   int64
+	closed bool
+}
+
+func newDiskBodyStorage(data []byte) (*diskBodyStorage, error) {
+	file, path, err := createDiskBodyStorageFile(int64(len(data)))
+	if err != nil {
+		return nil, err
+	}
+	if _, err = file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	if _, err = file.Seek(0, io.SeekStart); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	requestBodyStorageStats.activeDiskBytes.Add(int64(len(data)))
+	requestBodyStorageStats.activeDiskFiles.Add(1)
+	requestBodyStorageStats.diskCreates.Add(1)
+	return &diskBodyStorage{file: file, path: path, size: int64(len(data))}, nil
+}
+
+func createDiskBodyStorageFile(requiredBytes int64) (*os.File, string, error) {
+	if requiredBytes <= 0 {
+		requiredBytes = RequestBodyDiskThreshold()
+	}
+	if !RequestBodyCacheAvailable(requiredBytes) {
+		return nil, "", ErrBodyStorageUnavailable
+	}
+	dir := RequestBodyCacheDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, "", err
+	}
+	file, err := os.CreateTemp(dir, bodyStorageTempPattern)
+	if err != nil {
+		return nil, "", err
+	}
+	return file, file.Name(), nil
+}
+
+func (s *diskBodyStorage) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.file == nil {
+		return 0, ErrBodyStorageClosed
+	}
+	return s.file.Read(p)
+}
+
+func (s *diskBodyStorage) Seek(offset int64, whence int) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.file == nil {
+		return 0, ErrBodyStorageClosed
+	}
+	return s.file.Seek(offset, whence)
+}
+
+func (s *diskBodyStorage) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	var err error
+	if s.file != nil {
+		err = s.file.Close()
+		s.file = nil
+	}
+	if s.path != "" {
+		if removeErr := os.Remove(s.path); removeErr != nil && !os.IsNotExist(removeErr) && err == nil {
+			err = removeErr
+		}
+		s.path = ""
+	}
+	requestBodyStorageStats.activeDiskBytes.Add(-s.size)
+	requestBodyStorageStats.activeDiskFiles.Add(-1)
+	return err
+}
+
+func (s *diskBodyStorage) Bytes() ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.file == nil {
+		return nil, ErrBodyStorageClosed
+	}
+	current, err := s.file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = s.file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	data := make([]byte, s.size)
+	_, err = io.ReadFull(s.file, data)
+	if _, seekErr := s.file.Seek(current, io.SeekStart); seekErr != nil && err == nil {
+		err = seekErr
+	}
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (s *diskBodyStorage) Size() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0
+	}
+	return s.size
+}
+
+func (s *diskBodyStorage) IsDisk() bool {
+	return true
+}
+
+// RequestBodyCacheDir returns the dedicated directory used for request body temp files.
+func RequestBodyCacheDir() string {
+	if value := requestBodyCacheDir.Load(); value != nil {
+		if dir, ok := value.(string); ok && dir != "" {
+			return filepath.Clean(dir)
+		}
+	}
+	return filepath.Join(os.TempDir(), bodyStorageCacheDirName)
+}
+
+// SetRequestBodyCacheDir configures the dedicated request-body cache directory.
+func SetRequestBodyCacheDir(dir string) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		requestBodyCacheDir.Store("")
+		return
+	}
+	requestBodyCacheDir.Store(filepath.Clean(dir))
+}
+
+// ResetRequestBodyCacheDir restores the default request-body cache directory.
+func ResetRequestBodyCacheDir() {
+	requestBodyCacheDir.Store("")
+}
+
+// RequestBodyCacheAvailable reports whether the cache filesystem has room for a body.
+func RequestBodyCacheAvailable(requiredBytes int64) bool {
+	dir := RequestBodyCacheDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false
+	}
+	if requiredBytes < 0 {
+		requiredBytes = 0
+	}
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(dir, &stat); err != nil {
+		return false
+	}
+	available := int64(stat.Bavail) * int64(stat.Bsize)
+	return available-requiredBytes >= bodyStorageMinFreeBytes
+}
+
+// CleanupOldRequestBodyCacheFiles removes abandoned request body temp files.
+func CleanupOldRequestBodyCacheFiles(maxAge time.Duration) error {
+	if maxAge <= 0 {
+		maxAge = 5 * time.Minute
+	}
+	if err := cleanupOldBodyFilesInDir(RequestBodyCacheDir(), maxAge); err != nil {
+		return err
+	}
+	return cleanupOldBodyFilesInDir(os.TempDir(), maxAge)
+}
+
+func cleanupOldBodyFilesInDir(dir string, maxAge time.Duration) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	cutoff := time.Now().Add(-maxAge)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if matched, _ := filepath.Match(bodyStorageTempPattern, entry.Name()); !matched {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, entry.Name()))
+	}
+	return nil
+}
+
+// CurrentRequestBodyStorageStats returns active memory/disk usage counters.
+func CurrentRequestBodyStorageStats() RequestBodyStorageStats {
+	return RequestBodyStorageStats{
+		ActiveMemoryBytes: requestBodyStorageStats.activeMemoryBytes.Load(),
+		ActiveDiskBytes:   requestBodyStorageStats.activeDiskBytes.Load(),
+		ActiveDiskFiles:   requestBodyStorageStats.activeDiskFiles.Load(),
+		MemoryCreates:     requestBodyStorageStats.memoryCreates.Load(),
+		DiskCreates:       requestBodyStorageStats.diskCreates.Load(),
+	}
+}
+
+// CreateBodyStorage stores data in memory until it crosses the configured disk
+// threshold. Disk creation failure falls back to memory because the caller
+// already owns the complete payload.
+func CreateBodyStorage(data []byte) BodyStorage {
+	if int64(len(data)) >= RequestBodyDiskThreshold() && RequestBodyCacheAvailable(int64(len(data))) {
+		if storage, err := newDiskBodyStorage(data); err == nil {
+			return storage
+		}
+	}
+	return newMemoryBodyStorage(data)
+}
+
+// CreateBodyStorageFromReader streams a body into reusable storage while
+// enforcing limit. Large or unknown-length bodies spill to disk as soon as they
+// cross the configured threshold.
+func CreateBodyStorageFromReader(reader io.Reader, contentLength int64, limit int64) (BodyStorage, error) {
+	limit = normalizeLimit(limit)
+	threshold := RequestBodyDiskThreshold()
+	if threshold <= 0 {
+		threshold = DefaultRequestBodyDiskThreshold
+	}
+	if threshold > limit {
+		threshold = limit
+	}
+	if contentLength > limit {
+		return nil, ErrBodyTooLarge
+	}
+	if contentLength >= threshold && contentLength > 0 {
+		return newDiskBodyStorageFromReader(reader, contentLength, limit)
+	}
+
+	var buf bytes.Buffer
+	var file *os.File
+	var path string
+	var total int64
+	chunk := make([]byte, 32*1024)
+	cleanup := func() {
+		if file != nil {
+			_ = file.Close()
+			_ = os.Remove(path)
+		}
+	}
+
+	for {
+		n, readErr := reader.Read(chunk)
+		if n > 0 {
+			total += int64(n)
+			if total > limit {
+				cleanup()
+				return nil, ErrBodyTooLarge
+			}
+			if file == nil && int64(buf.Len()+n) < threshold {
+				_, _ = buf.Write(chunk[:n])
+			} else {
+				if file == nil {
+					var err error
+					file, path, err = createDiskBodyStorageFile(total)
+					if err != nil {
+						return nil, err
+					}
+					if _, err = file.Write(buf.Bytes()); err != nil {
+						cleanup()
+						return nil, err
+					}
+					buf.Reset()
+				}
+				if _, err := file.Write(chunk[:n]); err != nil {
+					cleanup()
+					return nil, err
+				}
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			cleanup()
+			return nil, readErr
+		}
+	}
+
+	if file == nil {
+		return newMemoryBodyStorage(buf.Bytes()), nil
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		cleanup()
+		return nil, err
+	}
+	requestBodyStorageStats.activeDiskBytes.Add(total)
+	requestBodyStorageStats.activeDiskFiles.Add(1)
+	requestBodyStorageStats.diskCreates.Add(1)
+	return &diskBodyStorage{file: file, path: path, size: total}, nil
+}
+
+func newDiskBodyStorageFromReader(reader io.Reader, expectedSize int64, limit int64) (BodyStorage, error) {
+	if expectedSize <= 0 {
+		expectedSize = limit
+	}
+	file, path, err := createDiskBodyStorageFile(expectedSize)
+	if err != nil {
+		return nil, err
+	}
+	limited := &io.LimitedReader{R: reader, N: limit + 1}
+	written, err := io.CopyBuffer(file, limited, make([]byte, 32*1024))
+	if err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	if written > limit {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return nil, ErrBodyTooLarge
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	requestBodyStorageStats.activeDiskBytes.Add(written)
+	requestBodyStorageStats.activeDiskFiles.Add(1)
+	requestBodyStorageStats.diskCreates.Add(1)
+	return &diskBodyStorage{file: file, path: path, size: written}, nil
+}

--- a/internal/api/bodyutil/bodyutil.go
+++ b/internal/api/bodyutil/bodyutil.go
@@ -3,6 +3,7 @@ package bodyutil
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -14,12 +15,13 @@ import (
 )
 
 const (
-	DefaultRequestBodyLimit   int64 = 16 << 20
-	DefaultModelBodyLimit     int64 = 128 << 20
-	ManagementBodyLimit       int64 = 2 << 20
-	ConfigYAMLBodyLimit       int64 = 2 << 20
-	AuthFileBodyLimit         int64 = 2 << 20
-	VertexCredentialBodyLimit int64 = 2 << 20
+	DefaultRequestBodyLimit         int64 = 16 << 20
+	DefaultModelBodyLimit           int64 = 128 << 20
+	DefaultRequestBodyDiskThreshold int64 = 8 << 20
+	ManagementBodyLimit             int64 = 2 << 20
+	ConfigYAMLBodyLimit             int64 = 2 << 20
+	AuthFileBodyLimit               int64 = 2 << 20
+	VertexCredentialBodyLimit       int64 = 2 << 20
 )
 
 var ErrBodyTooLarge = errors.New("request body too large")
@@ -27,9 +29,11 @@ var ErrBodyTooLarge = errors.New("request body too large")
 const requestBodyCacheKey = "cliproxy.request_body_cache"
 
 var modelRequestBodyLimit atomic.Int64
+var requestBodyDiskThreshold atomic.Int64
 
 func init() {
 	modelRequestBodyLimit.Store(DefaultModelBodyLimit)
+	requestBodyDiskThreshold.Store(DefaultRequestBodyDiskThreshold)
 }
 
 // SetModelRequestBodyLimit configures the request-body limit used by model API endpoints.
@@ -49,6 +53,23 @@ func ModelRequestBodyLimit() int64 {
 	return limit
 }
 
+// SetRequestBodyDiskThreshold configures when reusable request bodies spill to disk.
+func SetRequestBodyDiskThreshold(threshold int64) {
+	if threshold <= 0 {
+		threshold = DefaultRequestBodyDiskThreshold
+	}
+	requestBodyDiskThreshold.Store(threshold)
+}
+
+// RequestBodyDiskThreshold returns the active in-memory threshold for reusable request bodies.
+func RequestBodyDiskThreshold() int64 {
+	threshold := requestBodyDiskThreshold.Load()
+	if threshold <= 0 {
+		return DefaultRequestBodyDiskThreshold
+	}
+	return threshold
+}
+
 func normalizeLimit(limit int64) int64 {
 	if limit <= 0 {
 		return DefaultRequestBodyLimit
@@ -56,7 +77,7 @@ func normalizeLimit(limit int64) int64 {
 	return limit
 }
 
-func cachedRequestBody(c *gin.Context) ([]byte, bool) {
+func cachedRequestBodyStorage(c *gin.Context) (BodyStorage, bool) {
 	if c == nil {
 		return nil, false
 	}
@@ -64,8 +85,31 @@ func cachedRequestBody(c *gin.Context) ([]byte, bool) {
 	if !ok || bodyVal == nil {
 		return nil, false
 	}
-	body, ok := bodyVal.([]byte)
-	return body, ok
+	storage, ok := bodyVal.(BodyStorage)
+	return storage, ok && storage != nil
+}
+
+func restoreRequestBody(c *gin.Context, storage BodyStorage) error {
+	if c == nil || c.Request == nil || storage == nil {
+		return nil
+	}
+	if _, err := storage.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	c.Request.Body = io.NopCloser(storage)
+	c.Request.ContentLength = storage.Size()
+	return nil
+}
+
+func setRequestBodyStorage(c *gin.Context, storage BodyStorage) {
+	if c == nil || c.Request == nil || storage == nil {
+		return
+	}
+	if previous, ok := cachedRequestBodyStorage(c); ok && previous != storage {
+		_ = previous.Close()
+	}
+	c.Set(requestBodyCacheKey, storage)
+	_ = restoreRequestBody(c, storage)
 }
 
 // SetRequestBody caches and restores a request body for downstream consumers.
@@ -73,43 +117,125 @@ func SetRequestBody(c *gin.Context, body []byte) {
 	if c == nil || c.Request == nil {
 		return
 	}
-	c.Set(requestBodyCacheKey, body)
-	c.Request.Body = io.NopCloser(bytes.NewReader(body))
-	c.Request.ContentLength = int64(len(body))
+	setRequestBodyStorage(c, CreateBodyStorage(body))
+}
+
+// CachedRequestBody returns a cached request body without reading from the network stream.
+func CachedRequestBody(c *gin.Context, maxBytes int64) ([]byte, bool) {
+	storage, ok := cachedRequestBodyStorage(c)
+	if !ok {
+		return nil, false
+	}
+	if maxBytes > 0 && storage.Size() > maxBytes {
+		return nil, false
+	}
+	body, err := storage.Bytes()
+	if err != nil {
+		return nil, false
+	}
+	return bytes.Clone(body), true
+}
+
+// CleanupRequestBody closes reusable request-body storage after request handling.
+func CleanupRequestBody(c *gin.Context) {
+	storage, ok := cachedRequestBodyStorage(c)
+	if !ok {
+		return
+	}
+	_ = storage.Close()
+	c.Set(requestBodyCacheKey, nil)
 }
 
 // ReadRequestBody reads and restores an incoming HTTP request body with a strict size limit.
 func ReadRequestBody(c *gin.Context, limit int64) ([]byte, error) {
-	if c == nil || c.Request == nil || c.Request.Body == nil {
+	if c == nil || c.Request == nil {
+		return nil, nil
+	}
+
+	storage, err := GetRequestBodyStorage(c, limit)
+	if err != nil {
+		return nil, err
+	}
+	if storage == nil {
+		return nil, nil
+	}
+	body, err := storage.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// GetRequestBodyStorage reads and restores an incoming request body as reusable storage.
+func GetRequestBodyStorage(c *gin.Context, limit int64) (BodyStorage, error) {
+	if c == nil || c.Request == nil {
 		return nil, nil
 	}
 
 	limit = normalizeLimit(limit)
-	if cached, ok := cachedRequestBody(c); ok {
-		if int64(len(cached)) > limit {
+	if storage, ok := cachedRequestBodyStorage(c); ok {
+		if storage.Size() > limit {
 			return nil, ErrBodyTooLarge
 		}
-		c.Request.Body = io.NopCloser(bytes.NewReader(cached))
-		c.Request.ContentLength = int64(len(cached))
-		return cached, nil
-	}
-
-	if c.Writer == nil {
-		body, err := ReadAll(c.Request.Body, limit)
-		if err != nil {
+		if err := restoreRequestBody(c, storage); err != nil {
 			return nil, err
 		}
-		SetRequestBody(c, body)
-		return body, nil
+		return storage, nil
+	}
+	if c.Request.Body == nil {
+		return nil, nil
 	}
 
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, limit)
-	body, err := io.ReadAll(c.Request.Body)
+	if c.Request.ContentLength > limit {
+		return nil, ErrBodyTooLarge
+	}
+	bodyReader := c.Request.Body
+	if c.Writer != nil {
+		bodyReader = http.MaxBytesReader(c.Writer, bodyReader, limit)
+		c.Request.Body = bodyReader
+	}
+	storage, err := CreateBodyStorageFromReader(bodyReader, c.Request.ContentLength, limit)
+	_ = bodyReader.Close()
 	if err != nil {
 		return nil, err
 	}
-	SetRequestBody(c, body)
-	return body, nil
+	setRequestBodyStorage(c, storage)
+	return storage, nil
+}
+
+// DecodeJSONRequestBody decodes a reusable JSON body without materializing disk-backed storage.
+func DecodeJSONRequestBody(c *gin.Context, limit int64, v any) error {
+	storage, err := GetRequestBodyStorage(c, limit)
+	if err != nil {
+		return err
+	}
+	if storage == nil {
+		return nil
+	}
+	if _, err := storage.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(storage)
+	if err := decoder.Decode(v); err != nil {
+		_ = restoreRequestBody(c, storage)
+		return err
+	}
+	if err := ensureSingleJSONValue(decoder); err != nil {
+		_ = restoreRequestBody(c, storage)
+		return err
+	}
+	return restoreRequestBody(c, storage)
+}
+
+func ensureSingleJSONValue(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("request body must contain a single JSON value")
+		}
+		return err
+	}
+	return nil
 }
 
 // ReadAll reads from any reader with a strict size limit.
@@ -132,6 +258,10 @@ func IsTooLarge(err error) bool {
 	}
 	var maxBytesErr *http.MaxBytesError
 	return errors.As(err, &maxBytesErr)
+}
+
+func IsStorageUnavailable(err error) bool {
+	return errors.Is(err, ErrBodyStorageUnavailable)
 }
 
 func IsTimeout(err error) bool {

--- a/internal/api/bodyutil/bodyutil_test.go
+++ b/internal/api/bodyutil/bodyutil_test.go
@@ -2,14 +2,26 @@ package bodyutil
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
+
+func useTempRequestBodyCache(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	SetRequestBodyCacheDir(dir)
+	t.Cleanup(ResetRequestBodyCacheDir)
+	return dir
+}
 
 func TestLimitBodyMiddlewareRejectsOversizedRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -80,6 +92,9 @@ func TestLimitBodyMiddlewareRejectsOversizedDeleteRequest(t *testing.T) {
 
 func TestReadRequestBodyUsesCacheAndSetRequestBodyRefreshesIt(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	previousThreshold := RequestBodyDiskThreshold()
+	t.Cleanup(func() { SetRequestBodyDiskThreshold(previousThreshold) })
+	SetRequestBodyDiskThreshold(1 << 20)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -112,6 +127,228 @@ func TestReadRequestBodyUsesCacheAndSetRequestBodyRefreshesIt(t *testing.T) {
 	}
 }
 
+func TestReadRequestBodySpillsLargePayloadToDiskAndCleanupRemovesIt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cacheDir := useTempRequestBodyCache(t)
+	previousThreshold := RequestBodyDiskThreshold()
+	t.Cleanup(func() { SetRequestBodyDiskThreshold(previousThreshold) })
+	SetRequestBodyDiskThreshold(8)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"value":"larger-than-threshold"}`))
+
+	body, err := ReadRequestBody(c, 128)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if string(body) != `{"value":"larger-than-threshold"}` {
+		t.Fatalf("body = %s", body)
+	}
+	storage, ok := cachedRequestBodyStorage(c)
+	if !ok {
+		t.Fatal("expected cached body storage")
+	}
+	if !storage.IsDisk() {
+		t.Fatalf("expected disk-backed body storage, got %T", storage)
+	}
+	diskStorage, ok := storage.(*diskBodyStorage)
+	if !ok {
+		t.Fatalf("cached storage type = %T, want *diskBodyStorage", storage)
+	}
+	path := diskStorage.path
+	if filepath.Dir(path) != cacheDir {
+		t.Fatalf("temp body file dir = %q, want %q", filepath.Dir(path), cacheDir)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected temp body file to exist: %v", err)
+	}
+
+	CleanupRequestBody(c)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected temp body file to be removed, stat err=%v", err)
+	}
+	if _, ok := cachedRequestBodyStorage(c); ok {
+		t.Fatal("expected body storage cache to be cleared")
+	}
+}
+
+func TestSetRequestBodyRefreshClosesPreviousDiskStorage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	useTempRequestBodyCache(t)
+	previousThreshold := RequestBodyDiskThreshold()
+	t.Cleanup(func() { SetRequestBodyDiskThreshold(previousThreshold) })
+	SetRequestBodyDiskThreshold(8)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"value":"larger-than-threshold"}`))
+	if _, err := ReadRequestBody(c, 128); err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	storage, ok := cachedRequestBodyStorage(c)
+	if !ok {
+		t.Fatal("expected cached body storage")
+	}
+	diskStorage, ok := storage.(*diskBodyStorage)
+	if !ok {
+		t.Fatalf("cached storage type = %T, want *diskBodyStorage", storage)
+	}
+	path := diskStorage.path
+
+	SetRequestBody(c, []byte(`{"value":"small"}`))
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected previous temp body file to be removed, stat err=%v", err)
+	}
+	body, err := ReadRequestBody(c, 128)
+	if err != nil {
+		t.Fatalf("unexpected refreshed read error: %v", err)
+	}
+	if string(body) != `{"value":"small"}` {
+		t.Fatalf("body = %s", body)
+	}
+}
+
+func TestCreateBodyStorageFromReaderSpillsAtThreshold(t *testing.T) {
+	useTempRequestBodyCache(t)
+	previousThreshold := RequestBodyDiskThreshold()
+	t.Cleanup(func() { SetRequestBodyDiskThreshold(previousThreshold) })
+	SetRequestBodyDiskThreshold(8)
+
+	storage, err := CreateBodyStorageFromReader(strings.NewReader("12345678"), -1, 16)
+	if err != nil {
+		t.Fatalf("CreateBodyStorageFromReader: %v", err)
+	}
+	defer storage.Close()
+
+	if !storage.IsDisk() {
+		t.Fatalf("expected payload exactly at threshold to use disk storage, got %T", storage)
+	}
+	if storage.Size() != 8 {
+		t.Fatalf("storage size = %d, want 8", storage.Size())
+	}
+}
+
+func TestCurrentRequestBodyStorageStatsTracksActiveStorage(t *testing.T) {
+	useTempRequestBodyCache(t)
+	previousThreshold := RequestBodyDiskThreshold()
+	t.Cleanup(func() { SetRequestBodyDiskThreshold(previousThreshold) })
+	SetRequestBodyDiskThreshold(8)
+
+	before := CurrentRequestBodyStorageStats()
+	memory := CreateBodyStorage([]byte("small"))
+	afterMemory := CurrentRequestBodyStorageStats()
+	if afterMemory.ActiveMemoryBytes-before.ActiveMemoryBytes != 5 {
+		t.Fatalf("active memory delta = %d, want 5", afterMemory.ActiveMemoryBytes-before.ActiveMemoryBytes)
+	}
+
+	disk := CreateBodyStorage([]byte("larger-than-threshold"))
+	afterDisk := CurrentRequestBodyStorageStats()
+	if afterDisk.ActiveDiskFiles-afterMemory.ActiveDiskFiles != 1 {
+		t.Fatalf("active disk file delta = %d, want 1", afterDisk.ActiveDiskFiles-afterMemory.ActiveDiskFiles)
+	}
+	if afterDisk.ActiveDiskBytes-afterMemory.ActiveDiskBytes != int64(len("larger-than-threshold")) {
+		t.Fatalf("active disk byte delta = %d", afterDisk.ActiveDiskBytes-afterMemory.ActiveDiskBytes)
+	}
+
+	if err := memory.Close(); err != nil {
+		t.Fatalf("close memory storage: %v", err)
+	}
+	if err := disk.Close(); err != nil {
+		t.Fatalf("close disk storage: %v", err)
+	}
+	afterClose := CurrentRequestBodyStorageStats()
+	if afterClose.ActiveMemoryBytes != before.ActiveMemoryBytes {
+		t.Fatalf("active memory after close = %d, want %d", afterClose.ActiveMemoryBytes, before.ActiveMemoryBytes)
+	}
+	if afterClose.ActiveDiskFiles != before.ActiveDiskFiles || afterClose.ActiveDiskBytes != before.ActiveDiskBytes {
+		t.Fatalf("active disk after close files=%d bytes=%d, want files=%d bytes=%d", afterClose.ActiveDiskFiles, afterClose.ActiveDiskBytes, before.ActiveDiskFiles, before.ActiveDiskBytes)
+	}
+}
+
+func TestCleanupOldRequestBodyCacheFiles(t *testing.T) {
+	cacheDir := useTempRequestBodyCache(t)
+	oldPath := filepath.Join(cacheDir, "clirelay-request-body-old.tmp")
+	freshPath := filepath.Join(cacheDir, "clirelay-request-body-fresh.tmp")
+	otherPath := filepath.Join(cacheDir, "other.tmp")
+	for _, path := range []string{oldPath, freshPath, otherPath} {
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes old cache: %v", err)
+	}
+
+	if err := CleanupOldRequestBodyCacheFiles(5 * time.Minute); err != nil {
+		t.Fatalf("CleanupOldRequestBodyCacheFiles: %v", err)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("expected old cache file removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(freshPath); err != nil {
+		t.Fatalf("expected fresh cache file kept: %v", err)
+	}
+	if _, err := os.Stat(otherPath); err != nil {
+		t.Fatalf("expected non body-cache file kept: %v", err)
+	}
+}
+
+type noBytesBodyStorage struct {
+	*bytes.Reader
+	data        []byte
+	bytesCalled bool
+}
+
+func newNoBytesBodyStorage(data []byte) *noBytesBodyStorage {
+	return &noBytesBodyStorage{
+		Reader: bytes.NewReader(data),
+		data:   data,
+	}
+}
+
+func (s *noBytesBodyStorage) Close() error { return nil }
+func (s *noBytesBodyStorage) Bytes() ([]byte, error) {
+	s.bytesCalled = true
+	return nil, errors.New("Bytes must not be called")
+}
+func (s *noBytesBodyStorage) Size() int64  { return int64(len(s.data)) }
+func (s *noBytesBodyStorage) IsDisk() bool { return true }
+
+func TestDecodeJSONRequestBodyDoesNotCallBytesForDiskStorage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	payload := []byte(`{"model":"gpt-5.5","input":"large-value","stream":true}`)
+	storage := newNoBytesBodyStorage(payload)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set(requestBodyCacheKey, storage)
+
+	var decoded struct {
+		Model string `json:"model"`
+	}
+	if err := DecodeJSONRequestBody(c, 1024, &decoded); err != nil {
+		t.Fatalf("DecodeJSONRequestBody: %v", err)
+	}
+	if storage.bytesCalled {
+		t.Fatal("DecodeJSONRequestBody called Bytes on disk-backed storage")
+	}
+	if decoded.Model != "gpt-5.5" {
+		t.Fatalf("decoded model = %q", decoded.Model)
+	}
+	restored, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(restored) != string(payload) {
+		t.Fatalf("restored body = %s", restored)
+	}
+}
+
 func TestModelRequestBodyLimitCanBeConfigured(t *testing.T) {
 	previous := ModelRequestBodyLimit()
 	t.Cleanup(func() { SetModelRequestBodyLimit(previous) })
@@ -124,5 +361,20 @@ func TestModelRequestBodyLimitCanBeConfigured(t *testing.T) {
 	SetModelRequestBodyLimit(0)
 	if got := ModelRequestBodyLimit(); got != DefaultModelBodyLimit {
 		t.Fatalf("ModelRequestBodyLimit default = %d, want %d", got, DefaultModelBodyLimit)
+	}
+}
+
+func TestRequestBodyDiskThresholdCanBeConfigured(t *testing.T) {
+	previous := RequestBodyDiskThreshold()
+	t.Cleanup(func() { SetRequestBodyDiskThreshold(previous) })
+
+	SetRequestBodyDiskThreshold(32)
+	if got := RequestBodyDiskThreshold(); got != 32 {
+		t.Fatalf("RequestBodyDiskThreshold = %d, want 32", got)
+	}
+
+	SetRequestBodyDiskThreshold(0)
+	if got := RequestBodyDiskThreshold(); got != DefaultRequestBodyDiskThreshold {
+		t.Fatalf("RequestBodyDiskThreshold default = %d, want %d", got, DefaultRequestBodyDiskThreshold)
 	}
 }

--- a/internal/api/middleware/request_body_cleanup.go
+++ b/internal/api/middleware/request_body_cleanup.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+)
+
+// RequestBodyCleanupMiddleware releases reusable request-body storage after the
+// request has finished logging and handler processing.
+func RequestBodyCleanupMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		bodyutil.CleanupRequestBody(c)
+	}
+}

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 )
@@ -185,6 +187,35 @@ func (stubRequestLogger) LogStreamingRequest(string, string, map[string][]string
 
 func (stubRequestLogger) IsEnabled() bool { return true }
 
+type captureRequestLogger struct {
+	requestBody []byte
+}
+
+func (l *captureRequestLogger) LogRequest(_ string, _ string, _ map[string][]string, requestBody []byte, _ int, _ map[string][]string, _ []byte, _ []byte, _ []byte, _ []*interfaces.ErrorMessage, _ string, _ time.Time, _ time.Time) error {
+	l.requestBody = bytes.Clone(requestBody)
+	return nil
+}
+
+func (l *captureRequestLogger) LogStreamingRequest(_ string, _ string, _ map[string][]string, requestBody []byte, _ string) (logging.StreamingLogWriter, error) {
+	l.requestBody = bytes.Clone(requestBody)
+	return stubStreamingLogWriter{}, nil
+}
+
+func (l *captureRequestLogger) IsEnabled() bool { return true }
+
+func gzipBodyForRequestLoggingTest(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	if _, err := writer.Write(raw); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
 func TestRequestLoggingMiddlewareDoesNotRejectOversizedBody(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -208,5 +239,48 @@ func TestRequestLoggingMiddlewareDoesNotRejectOversizedBody(t *testing.T) {
 	}
 	if !reachedHandler {
 		t.Fatal("request should reach handler; logging must not enforce API body limits")
+	}
+}
+
+func TestRequestLoggingMiddlewareUsesCachedDecodedBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousLimit := bodyutil.ModelRequestBodyLimit()
+	previousThreshold := bodyutil.RequestBodyDiskThreshold()
+	t.Cleanup(func() {
+		bodyutil.SetModelRequestBodyLimit(previousLimit)
+		bodyutil.SetRequestBodyDiskThreshold(previousThreshold)
+	})
+	bodyutil.SetModelRequestBodyLimit(1 << 20)
+	bodyutil.SetRequestBodyDiskThreshold(1 << 20)
+
+	raw := []byte(`{"model":"gpt-5.5","input":"hello","stream":false}`)
+	logger := &captureRequestLogger{}
+	r := gin.New()
+	r.Use(DecompressRequestMiddleware())
+	r.Use(RequestBodyCleanupMiddleware())
+	r.Use(RequestLoggingMiddleware(logger))
+	r.POST("/v1/responses", func(c *gin.Context) {
+		body, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
+		if err != nil {
+			t.Fatalf("ReadRequestBody: %v", err)
+		}
+		if string(body) != string(raw) {
+			t.Fatalf("decoded body = %s", body)
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(gzipBodyForRequestLoggingTest(t, raw)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusNoContent, w.Code, w.Body.String())
+	}
+	if string(logger.requestBody) != string(raw) {
+		t.Fatalf("logged request body = %s, want %s", logger.requestBody, raw)
 	}
 }

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -154,6 +155,7 @@ func (w *ResponseWriterWrapper) WriteHeader(statusCode int) {
 
 	// Capture response headers using the new method
 	w.captureCurrentHeaders()
+	w.hydrateRequestInfoBody(w.ginCtx)
 
 	// Detect streaming based on Content-Type
 	contentType := w.ResponseWriter.Header().Get("Content-Type")
@@ -161,11 +163,12 @@ func (w *ResponseWriterWrapper) WriteHeader(statusCode int) {
 
 	// If streaming, initialize streaming log writer
 	if w.isStreaming && w.logger.IsEnabled() {
+		requestBody := w.extractRequestBody(w.ginCtx)
 		streamWriter, err := w.logger.LogStreamingRequest(
 			w.requestInfo.URL,
 			w.requestInfo.Method,
 			w.requestInfo.Headers,
-			w.requestInfo.Body,
+			requestBody,
 			w.requestInfo.RequestID,
 		)
 		if err == nil {
@@ -175,7 +178,7 @@ func (w *ResponseWriterWrapper) WriteHeader(statusCode int) {
 			w.streamDone = doneChan
 
 			// Start async chunk processor
-			go w.processStreamingChunks(doneChan)
+			go w.processStreamingChunks(doneChan, streamWriter, w.chunkChannel)
 
 			// Write status immediately
 			_ = streamWriter.WriteStatus(statusCode, w.headers)
@@ -248,19 +251,19 @@ func (w *ResponseWriterWrapper) detectStreaming(contentType string) bool {
 
 // processStreamingChunks runs in a separate goroutine to process response chunks from the chunkChannel.
 // It asynchronously writes each chunk to the streaming log writer.
-func (w *ResponseWriterWrapper) processStreamingChunks(done chan struct{}) {
+func (w *ResponseWriterWrapper) processStreamingChunks(done chan struct{}, streamWriter logging.StreamingLogWriter, chunkChannel <-chan []byte) {
 	if done == nil {
 		return
 	}
 
 	defer close(done)
 
-	if w.streamWriter == nil || w.chunkChannel == nil {
+	if streamWriter == nil || chunkChannel == nil {
 		return
 	}
 
-	for chunk := range w.chunkChannel {
-		w.streamWriter.WriteChunkAsync(chunk)
+	for chunk := range chunkChannel {
+		streamWriter.WriteChunkAsync(chunk)
 	}
 }
 
@@ -392,8 +395,25 @@ func (w *ResponseWriterWrapper) extractRequestBody(c *gin.Context) []byte {
 			}
 		}
 	}
+	if body := w.hydrateRequestInfoBody(c); len(body) > 0 {
+		return body
+	}
 	if w.requestInfo != nil && len(w.requestInfo.Body) > 0 {
 		return w.requestInfo.Body
+	}
+	return nil
+}
+
+func (w *ResponseWriterWrapper) hydrateRequestInfoBody(c *gin.Context) []byte {
+	if w == nil || w.requestInfo == nil {
+		return nil
+	}
+	if len(w.requestInfo.Body) > 0 {
+		return w.requestInfo.Body
+	}
+	if body, ok := bodyutil.CachedRequestBody(c, maxErrorOnlyCapturedRequestBodyBytes); ok && len(body) > 0 {
+		w.requestInfo.Body = body
+		return body
 	}
 	return nil
 }

--- a/internal/api/modules/amp/fallback_handlers.go
+++ b/internal/api/modules/amp/fallback_handlers.go
@@ -1,8 +1,6 @@
 package amp
 
 import (
-	"bytes"
-	"io"
 	"net/http/httputil"
 	"strings"
 	"time"
@@ -190,7 +188,7 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 			if mappedModel, mappedProviders := resolveMappedModel(); mappedModel != "" {
 				// Mapping found and provider available - rewrite the model in request body
 				bodyBytes = rewriteModelInRequest(bodyBytes, mappedModel)
-				c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				bodyutil.SetRequestBody(c, bodyBytes)
 				// Store mapped model in context for handlers that check it (like gemini bridge)
 				c.Set(MappedModelContextKey, mappedModel)
 				resolvedModel = mappedModel
@@ -211,7 +209,7 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 				if mappedModel, mappedProviders := resolveMappedModel(); mappedModel != "" {
 					// Mapping found and provider available - rewrite the model in request body
 					bodyBytes = rewriteModelInRequest(bodyBytes, mappedModel)
-					c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+					bodyutil.SetRequestBody(c, bodyBytes)
 					// Store mapped model in context for handlers that check it (like gemini bridge)
 					c.Set(MappedModelContextKey, mappedModel)
 					resolvedModel = mappedModel
@@ -229,7 +227,7 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 				logAmpRouting(RouteTypeAmpCredits, modelName, "", "", requestPath)
 
 				// Restore body again for the proxy
-				c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				bodyutil.SetRequestBody(c, bodyBytes)
 
 				// Forward to ampcode.com
 				proxy.ServeHTTP(c.Writer, c.Request)
@@ -254,7 +252,7 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 			c.Writer = rewriter
 			// Filter Anthropic-Beta header only for local handling paths
 			filterAntropicBetaHeader(c)
-			c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			bodyutil.SetRequestBody(c, bodyBytes)
 			handler(c)
 			rewriter.Flush()
 			log.Debugf("amp model mapping: response %s -> %s", resolvedModel, modelName)
@@ -263,11 +261,11 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 			logAmpRouting(RouteTypeLocalProvider, modelName, resolvedModel, providerName, requestPath)
 			// Filter Anthropic-Beta header only for local handling paths
 			filterAntropicBetaHeader(c)
-			c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			bodyutil.SetRequestBody(c, bodyBytes)
 			handler(c)
 		} else {
 			// No provider, no mapping, no proxy: fall back to the wrapped handler so it can return an error response
-			c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			bodyutil.SetRequestBody(c, bodyBytes)
 			handler(c)
 		}
 	}

--- a/internal/api/request_body_chain_test.go
+++ b/internal/api/request_body_chain_test.go
@@ -63,6 +63,7 @@ func TestResponsesBodyChainAllowsPayloadAboveLegacyLimitWithRequestLogging(t *te
 
 	r := gin.New()
 	r.Use(middleware.DecompressRequestMiddleware())
+	r.Use(middleware.RequestBodyCleanupMiddleware())
 	r.Use(middleware.RequestLoggingMiddleware(chainRequestLogger{}))
 	r.POST("/v1/responses", func(c *gin.Context) {
 		body, ok := sdkhandlers.ReadJSONRequestBody(c)
@@ -95,6 +96,7 @@ func TestResponsesBodyChainDecodesZstdAndRefreshesBodyAfterSystemPrompt(t *testi
 	raw := []byte(`{"model":"gpt-5.5","input":"hello","stream":true}`)
 	r := gin.New()
 	r.Use(middleware.DecompressRequestMiddleware())
+	r.Use(middleware.RequestBodyCleanupMiddleware())
 	r.Use(middleware.RequestLoggingMiddleware(chainRequestLogger{}))
 	r.Use(func(c *gin.Context) {
 		c.Set("accessMetadata", map[string]string{"system-prompt": "system from metadata"})
@@ -137,6 +139,7 @@ func TestResponsesBodyChainRejectsOversizedDecodedZstdBody(t *testing.T) {
 
 	r := gin.New()
 	r.Use(middleware.DecompressRequestMiddleware())
+	r.Use(middleware.RequestBodyCleanupMiddleware())
 	r.Use(middleware.RequestLoggingMiddleware(chainRequestLogger{}))
 	r.POST("/v1/responses", func(c *gin.Context) {
 		_, _ = sdkhandlers.ReadJSONRequestBody(c)

--- a/internal/api/server_config_reload.go
+++ b/internal/api/server_config_reload.go
@@ -68,6 +68,19 @@ func (s *Server) applyRequestBodyConfig(oldCfg, cfg *config.Config) {
 	if oldCfg == nil || oldCfg.ModelRequestBodyLimitBytes() != cfg.ModelRequestBodyLimitBytes() {
 		bodyutil.SetModelRequestBodyLimit(cfg.ModelRequestBodyLimitBytes())
 	}
+	if oldCfg == nil || oldCfg.RequestBodyDiskThresholdBytes() != cfg.RequestBodyDiskThresholdBytes() {
+		bodyutil.SetRequestBodyDiskThreshold(cfg.RequestBodyDiskThresholdBytes())
+	}
+	if oldCfg == nil || oldCfg.RequestBodyCacheDir() != cfg.RequestBodyCacheDir() {
+		if cfg.RequestBodyCacheDir() == "" {
+			bodyutil.ResetRequestBodyCacheDir()
+		} else {
+			bodyutil.SetRequestBodyCacheDir(cfg.RequestBodyCacheDir())
+		}
+		if err := bodyutil.CleanupOldRequestBodyCacheFiles(5 * time.Minute); err != nil {
+			log.Warnf("failed to cleanup request body cache files: %v", err)
+		}
+	}
 }
 
 func (s *Server) oldConfigSnapshot() *config.Config {

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -41,7 +41,10 @@ func configureServerMode(cfg *config.Config) {
 
 func newServerEngine(cfg *config.Config, optionState *serverOptionConfig) *gin.Engine {
 	engine := gin.New()
-	bodyutil.SetModelRequestBodyLimit(configModelRequestBodyLimitBytes(cfg))
+	applyBodyUtilRequestBodyConfig(cfg)
+	if err := bodyutil.CleanupOldRequestBodyCacheFiles(5 * time.Minute); err != nil {
+		log.Warnf("failed to cleanup request body cache files: %v", err)
+	}
 	if cfg != nil {
 		configureTrustedProxies(engine, cfg.TrustedProxies)
 	}
@@ -52,6 +55,7 @@ func newServerEngine(cfg *config.Config, optionState *serverOptionConfig) *gin.E
 	engine.Use(logging.GinLogrusLogger())
 	engine.Use(logging.GinLogrusRecovery())
 	engine.Use(middleware.DecompressRequestMiddleware())
+	engine.Use(middleware.RequestBodyCleanupMiddleware())
 	if optionState != nil {
 		for _, mw := range optionState.extraMiddleware {
 			engine.Use(mw)
@@ -137,7 +141,7 @@ func (s *Server) applyInitialRuntimeConfig(cfg *config.Config, authManager *auth
 	if s == nil || cfg == nil {
 		return
 	}
-	bodyutil.SetModelRequestBodyLimit(configModelRequestBodyLimitBytes(cfg))
+	applyBodyUtilRequestBodyConfig(cfg)
 	if s.handlers != nil {
 		s.handlers.AuthManager = authManager
 	}
@@ -157,6 +161,23 @@ func configModelRequestBodyLimitBytes(cfg *config.Config) int64 {
 		return int64(config.DefaultModelRequestBodyMB) << 20
 	}
 	return cfg.ModelRequestBodyLimitBytes()
+}
+
+func configRequestBodyDiskThresholdBytes(cfg *config.Config) int64 {
+	if cfg == nil {
+		return int64(config.DefaultRequestBodyDiskThresholdMB) << 20
+	}
+	return cfg.RequestBodyDiskThresholdBytes()
+}
+
+func applyBodyUtilRequestBodyConfig(cfg *config.Config) {
+	bodyutil.SetModelRequestBodyLimit(configModelRequestBodyLimitBytes(cfg))
+	bodyutil.SetRequestBodyDiskThreshold(configRequestBodyDiskThresholdBytes(cfg))
+	if cfg == nil || cfg.RequestBodyCacheDir() == "" {
+		bodyutil.ResetRequestBodyCacheDir()
+		return
+	}
+	bodyutil.SetRequestBodyCacheDir(cfg.RequestBodyCacheDir())
 }
 
 func (s *Server) configureManagementHandler(

--- a/internal/api/server_model_restriction.go
+++ b/internal/api/server_model_restriction.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -78,20 +77,23 @@ func (s *Server) modelRestrictionMiddleware() gin.HandlerFunc {
 			}
 		}
 
-		bodyBytes, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
+		var bodyObj struct {
+			Model string `json:"model"`
+		}
+		err := bodyutil.DecodeJSONRequestBody(c, bodyutil.ModelRequestBodyLimit(), &bodyObj)
 		if err != nil {
 			if bodyutil.IsTooLarge(err) {
 				c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
 				return
 			}
+			if bodyutil.IsStorageUnavailable(err) {
+				c.AbortWithStatusJSON(http.StatusInsufficientStorage, gin.H{"error": "request body temporary storage unavailable"})
+				return
+			}
 			c.Next()
 			return
 		}
-
-		var bodyObj struct {
-			Model string `json:"model"`
-		}
-		if err := json.Unmarshal(bodyBytes, &bodyObj); err != nil || bodyObj.Model == "" {
+		if bodyObj.Model == "" {
 			c.Next()
 			return
 		}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	gin "github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
@@ -448,6 +449,57 @@ func TestRouteAllowedModelsApplyWithoutAccessMetadata(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "model_not_allowed") {
 		t.Fatalf("expected model_not_allowed in body, got %s", rr.Body.String())
+	}
+}
+
+func TestRouteAllowedModelsReadsDiskBackedBodyAndRestores(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousThreshold := bodyutil.RequestBodyDiskThreshold()
+	t.Cleanup(func() {
+		bodyutil.SetRequestBodyDiskThreshold(previousThreshold)
+		bodyutil.ResetRequestBodyCacheDir()
+	})
+	bodyutil.SetRequestBodyDiskThreshold(8)
+	bodyutil.SetRequestBodyCacheDir(t.TempDir())
+
+	cfg := &proxyconfig.Config{
+		Routing: proxyconfig.RoutingConfig{
+			ChannelGroups: []proxyconfig.RoutingChannelGroup{
+				{
+					Name:          "pro",
+					AllowedModels: []string{"gpt-5.5"},
+				},
+			},
+		},
+	}
+	cfg.SanitizeRouting()
+	server := &Server{cfg: cfg}
+
+	payload := `{"model":"gpt-5.5","input":"` + strings.Repeat("x", 64) + `"}`
+	router := gin.New()
+	router.POST("/test", func(c *gin.Context) {
+		attachPathRouteContext(c, &internalrouting.PathRouteContext{Group: "pro"})
+		c.Next()
+	}, server.modelRestrictionMiddleware(), func(c *gin.Context) {
+		defer bodyutil.CleanupRequestBody(c)
+		body, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
+		if err != nil {
+			t.Fatalf("ReadRequestBody: %v", err)
+		}
+		if string(body) != payload {
+			t.Fatalf("restored body = %s", body)
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,12 @@ type RequestBodyConfig struct {
 	// ModelMaxMB is the maximum decoded request body size for model endpoints.
 	// Management and upload endpoints keep their narrower endpoint-specific limits.
 	ModelMaxMB int `yaml:"model-max-mb,omitempty" json:"model-max-mb,omitempty"`
+	// DiskThresholdMB is the decoded body size above which reusable request
+	// bodies spill to a temporary file instead of staying cached in memory.
+	DiskThresholdMB int `yaml:"disk-threshold-mb,omitempty" json:"disk-threshold-mb,omitempty"`
+	// CacheDir optionally overrides the dedicated request-body temp file directory.
+	// When empty, the runtime uses the OS temp directory under a CliRelay-specific subdirectory.
+	CacheDir string `yaml:"cache-dir,omitempty" json:"cache-dir,omitempty"`
 }
 
 // ModelRequestBodyLimitBytes returns the decoded body limit for model endpoints.
@@ -187,6 +193,23 @@ func (cfg *Config) ModelRequestBodyLimitBytes() int64 {
 		maxMB = cfg.RequestBody.ModelMaxMB
 	}
 	return int64(maxMB) << 20
+}
+
+// RequestBodyDiskThresholdBytes returns the memory threshold for reusable body storage.
+func (cfg *Config) RequestBodyDiskThresholdBytes() int64 {
+	thresholdMB := DefaultRequestBodyDiskThresholdMB
+	if cfg != nil && cfg.RequestBody.DiskThresholdMB > 0 {
+		thresholdMB = cfg.RequestBody.DiskThresholdMB
+	}
+	return int64(thresholdMB) << 20
+}
+
+// RequestBodyCacheDir returns the optional request-body temp cache directory.
+func (cfg *Config) RequestBodyCacheDir() string {
+	if cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.RequestBody.CacheDir)
 }
 
 // ClaudeHeaderDefaults configures default header values injected into Claude API requests

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,7 +57,7 @@ func TestLoadConfigReadsRequestBodyModelLimit(t *testing.T) {
 	t.Parallel()
 
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(configPath, []byte("request-body:\n  model-max-mb: 64\n"), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte("request-body:\n  model-max-mb: 64\n  disk-threshold-mb: 4\n  cache-dir: /tmp/clirelay-body-cache\n"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -71,6 +71,15 @@ func TestLoadConfigReadsRequestBodyModelLimit(t *testing.T) {
 	}
 	if cfg.ModelRequestBodyLimitBytes() != 64<<20 {
 		t.Fatalf("ModelRequestBodyLimitBytes = %d, want %d", cfg.ModelRequestBodyLimitBytes(), int64(64<<20))
+	}
+	if cfg.RequestBody.DiskThresholdMB != 4 {
+		t.Fatalf("RequestBody.DiskThresholdMB = %d, want 4", cfg.RequestBody.DiskThresholdMB)
+	}
+	if cfg.RequestBodyDiskThresholdBytes() != 4<<20 {
+		t.Fatalf("RequestBodyDiskThresholdBytes = %d, want %d", cfg.RequestBodyDiskThresholdBytes(), int64(4<<20))
+	}
+	if cfg.RequestBodyCacheDir() != "/tmp/clirelay-body-cache" {
+		t.Fatalf("RequestBodyCacheDir = %q, want /tmp/clirelay-body-cache", cfg.RequestBodyCacheDir())
 	}
 }
 
@@ -89,6 +98,9 @@ func TestLoadConfigDefaultsRequestBodyModelLimit(t *testing.T) {
 
 	if cfg.RequestBody.ModelMaxMB != DefaultModelRequestBodyMB {
 		t.Fatalf("RequestBody.ModelMaxMB = %d, want %d", cfg.RequestBody.ModelMaxMB, DefaultModelRequestBodyMB)
+	}
+	if cfg.RequestBody.DiskThresholdMB != DefaultRequestBodyDiskThresholdMB {
+		t.Fatalf("RequestBody.DiskThresholdMB = %d, want %d", cfg.RequestBody.DiskThresholdMB, DefaultRequestBodyDiskThresholdMB)
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,13 +1,14 @@
 package config
 
 const (
-	DefaultPanelGitHubRepository = "https://github.com/kittors/codeProxy"
-	DefaultPprofAddr             = "127.0.0.1:8316"
-	DefaultAutoUpdateChannel     = "main"
-	DefaultAutoUpdateRepository  = "https://github.com/kittors/CliRelay"
-	DefaultAutoUpdateDockerImage = "ghcr.io/kittors/clirelay"
-	DefaultAutoUpdateUpdaterURL  = "http://clirelay-updater:8320"
-	DefaultModelRequestBodyMB    = 128
+	DefaultPanelGitHubRepository      = "https://github.com/kittors/codeProxy"
+	DefaultPprofAddr                  = "127.0.0.1:8316"
+	DefaultAutoUpdateChannel          = "main"
+	DefaultAutoUpdateRepository       = "https://github.com/kittors/CliRelay"
+	DefaultAutoUpdateDockerImage      = "ghcr.io/kittors/clirelay"
+	DefaultAutoUpdateUpdaterURL       = "http://clirelay-updater:8320"
+	DefaultModelRequestBodyMB         = 128
+	DefaultRequestBodyDiskThresholdMB = 8
 
 	// EnvAuthPath overrides auth-dir with the path visible inside the running container/process.
 	EnvAuthPath = "AUTH_PATH"

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -63,6 +63,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
 	cfg.RequestBody.ModelMaxMB = DefaultModelRequestBodyMB
+	cfg.RequestBody.DiskThresholdMB = DefaultRequestBodyDiskThresholdMB
 	cfg.UsageStatisticsEnabled = false
 	cfg.RequestLogStorage.StoreContent = true
 	cfg.RequestLogStorage.ContentRetentionDays = 30
@@ -148,6 +149,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	}
 	if cfg.RequestBody.ModelMaxMB <= 0 {
 		cfg.RequestBody.ModelMaxMB = DefaultModelRequestBodyMB
+	}
+	if cfg.RequestBody.DiskThresholdMB <= 0 {
+		cfg.RequestBody.DiskThresholdMB = DefaultRequestBodyDiskThresholdMB
 	}
 	if cfg.RequestLogStorage.ContentRetentionDays < 0 {
 		cfg.RequestLogStorage.ContentRetentionDays = 0

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -27,7 +27,6 @@ import (
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
-	"github.com/tidwall/gjson"
 )
 
 // ErrorResponse represents a standard error response format for the API.
@@ -80,6 +79,11 @@ func ReadJSONRequestBody(c *gin.Context) ([]byte, bool) {
 		status = http.StatusRequestEntityTooLarge
 		message = "Request body too large"
 		code = "request_body_too_large"
+	} else if bodyutil.IsStorageUnavailable(err) {
+		status = http.StatusInsufficientStorage
+		message = "Request body temporary storage unavailable"
+		errType = "server_error"
+		code = "request_body_storage_unavailable"
 	} else if bodyutil.IsTimeout(err) {
 		status = http.StatusRequestTimeout
 		message = "Request timed out while reading the request body"
@@ -434,11 +438,32 @@ func requestNeedsWriteTimeoutBypass(c *gin.Context) bool {
 	default:
 		return false
 	}
-	body, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
-	if err != nil || len(body) == 0 {
+	var request struct {
+		Stream flexibleJSONBool `json:"stream"`
+	}
+	if err := bodyutil.DecodeJSONRequestBody(c, bodyutil.ModelRequestBodyLimit(), &request); err != nil {
 		return false
 	}
-	return gjson.GetBytes(body, "stream").Bool()
+	return request.Stream.Bool()
+}
+
+type flexibleJSONBool bool
+
+func (b *flexibleJSONBool) UnmarshalJSON(data []byte) error {
+	value := strings.TrimSpace(strings.ToLower(string(data)))
+	value = strings.Trim(value, `"`)
+	value = strings.TrimSpace(value)
+	switch value {
+	case "true", "1":
+		*b = true
+	default:
+		*b = false
+	}
+	return nil
+}
+
+func (b flexibleJSONBool) Bool() bool {
+	return bool(b)
 }
 
 func clearWriteDeadlineForLongLivedRequest(c *gin.Context) {

--- a/sdk/api/handlers/request_body_test.go
+++ b/sdk/api/handlers/request_body_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -121,6 +122,35 @@ func TestReadJSONRequestBodyRestoresRequestBody(t *testing.T) {
 	}
 	if string(bodyAgain) != string(body) {
 		t.Fatalf("expected restored body %q, got %q", string(body), string(bodyAgain))
+	}
+}
+
+func TestRequestNeedsWriteTimeoutBypassDecodesDiskBackedStreamFlag(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousThreshold := bodyutil.RequestBodyDiskThreshold()
+	t.Cleanup(func() {
+		bodyutil.SetRequestBodyDiskThreshold(previousThreshold)
+		bodyutil.ResetRequestBodyCacheDir()
+	})
+	bodyutil.SetRequestBodyDiskThreshold(8)
+	bodyutil.SetRequestBodyCacheDir(t.TempDir())
+
+	payload := `{"model":"gpt-5.5","input":"` + strings.Repeat("x", 64) + `","stream":true}`
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	if !requestNeedsWriteTimeoutBypass(c) {
+		t.Fatal("expected stream:true request to bypass write timeout")
+	}
+	restored, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(restored) != payload {
+		t.Fatalf("restored body = %s", restored)
 	}
 }
 


### PR DESCRIPTION
## Summary
- align request body reuse with new-api style BodyStorage: memory/disk storage, request-end cleanup, dedicated cache dir, old cache cleanup, and disk availability checks
- add stream-aware JSON decoding for read-only middleware so model restriction and stream detection do not materialize disk-backed bodies
- add request-body config for disk threshold/cache dir and regression tests for large /v1/responses chains, threshold boundaries, cleanup, stats, and race-prone response writing

## Verification
- rtk go test ./internal/api/bodyutil ./internal/api/middleware ./internal/config ./sdk/api/handlers ./internal/api
- rtk go test ./internal/api/... ./sdk/api/handlers/...
- rtk go test -race ./internal/api/... ./sdk/api/handlers/...
- rtk go test ./...

Root review doc: /Users/kittors/Developer/opensource/CliProxy/docs/review/006-clirelay-newapi-body-storage-final-review-20260614.md