### PR TITLE
feat: add codex fingerprint recommendations

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 type identityFingerprintResponse struct {
@@ -67,6 +68,18 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 	h.mu.Unlock()
 
 	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingIdentityFingerprint, body)
+}
+
+func (h *Handler) GetCodexFingerprintRecommendations(c *gin.Context) {
+	result, err := usage.QueryCodexFingerprintRecommendations(usage.CodexFingerprintRecommendationQuery{
+		Days:  intQueryDefault(c, "days", 7),
+		Limit: intQueryDefault(c, "limit", 200),
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, result)
 }
 
 func validateCodexIdentityFingerprint(fp config.CodexIdentityFingerprintConfig) error {

--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -1,0 +1,104 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func TestGetCodexFingerprintRecommendationsReturnsLogDerivedCandidates(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	detail, err := json.Marshal(map[string]any{
+		"client": map[string]any{
+			"ip":     "203.0.113.20",
+			"method": "POST",
+			"path":   "/v1/responses",
+			"host":   "relay.test",
+			"fingerprint_headers": map[string][]string{
+				"User-Agent":            {"codex-tui/0.125.0 (Mac OS 26.5; arm64)"},
+				"Version":               {"0.125.0"},
+				"Originator":            {"codex-tui"},
+				"X-Codex-Beta-Features": {"exec_command_v2"},
+				"Session_id":            {"session-handler-secret"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal detail: %v", err)
+	}
+	usage.InsertLogWithDetails("sk-test", "Primary", "gpt-5.4", "codex", "Codex", "auth-1", false, time.Now().UTC(), 100, 10, usage.TokenStats{
+		InputTokens: 1, OutputTokens: 1, TotalTokens: 2,
+	}, "", "", string(detail))
+
+	h := &Handler{cfg: &config.Config{}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/identity-fingerprint/codex/recommendations?days=7&limit=20", nil)
+
+	h.GetCodexFingerprintRecommendations(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var payload struct {
+		Items []struct {
+			Count       int `json:"count"`
+			Recommended struct {
+				Enabled       bool              `json:"enabled"`
+				UserAgent     string            `json:"user-agent"`
+				Version       string            `json:"version"`
+				Originator    string            `json:"originator"`
+				SessionID     string            `json:"session-id"`
+				CustomHeaders map[string]string `json:"custom-headers"`
+			} `json:"recommended"`
+			IgnoredHeaders map[string]string `json:"ignored_headers"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("items length = %d, want 1", len(payload.Items))
+	}
+	item := payload.Items[0]
+	if item.Count != 1 {
+		t.Fatalf("Count = %d, want 1", item.Count)
+	}
+	if !item.Recommended.Enabled {
+		t.Fatalf("recommended fingerprint should enable Codex identity")
+	}
+	if item.Recommended.UserAgent != "codex-tui/0.125.0 (Mac OS 26.5; arm64)" {
+		t.Fatalf("user-agent = %q", item.Recommended.UserAgent)
+	}
+	if item.Recommended.Version != "0.125.0" {
+		t.Fatalf("version = %q", item.Recommended.Version)
+	}
+	if item.Recommended.SessionID != "" {
+		t.Fatalf("session-id = %q, want empty", item.Recommended.SessionID)
+	}
+	if got := item.Recommended.CustomHeaders["X-Codex-Beta-Features"]; got != "exec_command_v2" {
+		t.Fatalf("X-Codex-Beta-Features = %q", got)
+	}
+	if item.IgnoredHeaders["Session_id"] == "session-handler-secret" {
+		t.Fatalf("session id must be masked in ignored headers")
+	}
+}

--- a/internal/api/routes/management_model_routes.go
+++ b/internal/api/routes/management_model_routes.go
@@ -27,6 +27,7 @@ func registerManagementModelRoutes(group *gin.RouterGroup, h *managementhandlers
 	group.GET("/routing-config", h.GetRoutingConfig)
 	group.PUT("/routing-config", h.PutRoutingConfig)
 	group.GET("/identity-fingerprint", h.GetIdentityFingerprint)
+	group.GET("/identity-fingerprint/codex/recommendations", h.GetCodexFingerprintRecommendations)
 	group.PUT("/identity-fingerprint", h.PutIdentityFingerprint)
 	group.GET("/model-pricing", models.GetModelPricing)
 	group.PUT("/model-pricing", models.PutModelPricing)

--- a/internal/usage/codex_fingerprint_recommendations.go
+++ b/internal/usage/codex_fingerprint_recommendations.go
@@ -1,0 +1,510 @@
+package usage
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+const (
+	defaultCodexFingerprintRecommendationDays  = 7
+	defaultCodexFingerprintRecommendationLimit = 200
+	maxCodexFingerprintRecommendationDays      = 30
+	maxCodexFingerprintRecommendationLimit     = 1000
+	maxCodexFingerprintSamples                 = 3
+	maxCodexFingerprintDisplayValue            = 240
+)
+
+type CodexFingerprintRecommendationQuery struct {
+	Days  int
+	Limit int
+}
+
+type CodexFingerprintRecommendationResult struct {
+	Items     []CodexFingerprintRecommendation `json:"items"`
+	Days      int                              `json:"days"`
+	Limit     int                              `json:"limit"`
+	Inspected int                              `json:"inspected"`
+	Matched   int                              `json:"matched"`
+}
+
+type CodexFingerprintRecommendation struct {
+	ID             string                                 `json:"id"`
+	Count          int                                    `json:"count"`
+	FirstSeenAt    time.Time                              `json:"first_seen_at"`
+	LastSeenAt     time.Time                              `json:"last_seen_at"`
+	Headers        map[string]string                      `json:"headers"`
+	Recommended    config.CodexIdentityFingerprintConfig  `json:"recommended"`
+	IgnoredHeaders map[string]string                      `json:"ignored_headers,omitempty"`
+	Samples        []CodexFingerprintRecommendationSample `json:"samples"`
+}
+
+type CodexFingerprintRecommendationSample struct {
+	LogID       int64     `json:"log_id"`
+	Timestamp   time.Time `json:"timestamp"`
+	Model       string    `json:"model"`
+	Source      string    `json:"source"`
+	ChannelName string    `json:"channel_name"`
+	AuthIndex   string    `json:"auth_index"`
+	Failed      bool      `json:"failed"`
+	Method      string    `json:"method,omitempty"`
+	Path        string    `json:"path,omitempty"`
+	Host        string    `json:"host,omitempty"`
+	IP          string    `json:"ip,omitempty"`
+}
+
+type codexFingerprintDetailRow struct {
+	logID       int64
+	timestamp   time.Time
+	model       string
+	source      string
+	channelName string
+	authIndex   string
+	failed      bool
+	detail      string
+}
+
+type codexFingerprintClientDetail struct {
+	ip                 string
+	method             string
+	path               string
+	host               string
+	fingerprintHeaders http.Header
+	headers            http.Header
+}
+
+type codexFingerprintParsedCandidate struct {
+	headers        map[string]string
+	ignoredHeaders map[string]string
+	recommended    config.CodexIdentityFingerprintConfig
+}
+
+// QueryCodexFingerprintRecommendations builds candidate Codex identity templates
+// from recent request details captured from real terminal traffic.
+func QueryCodexFingerprintRecommendations(params CodexFingerprintRecommendationQuery) (CodexFingerprintRecommendationResult, error) {
+	params = normalizeCodexFingerprintRecommendationQuery(params)
+	result := CodexFingerprintRecommendationResult{
+		Items: make([]CodexFingerprintRecommendation, 0),
+		Days:  params.Days,
+		Limit: params.Limit,
+	}
+
+	db := getDB()
+	if db == nil {
+		return result, nil
+	}
+
+	rows, err := queryRecentCodexFingerprintDetailRows(db, params)
+	if err != nil {
+		return CodexFingerprintRecommendationResult{}, err
+	}
+	result.Inspected = len(rows)
+
+	byKey := make(map[string]*CodexFingerprintRecommendation)
+	for _, row := range rows {
+		client, ok := parseCodexFingerprintClientDetail(row.detail)
+		if !ok {
+			continue
+		}
+		headers := client.fingerprintHeaders
+		if len(headers) == 0 {
+			headers = client.headers
+		}
+		parsed, ok := codexFingerprintCandidateFromHeaders(headers)
+		if !ok {
+			continue
+		}
+		result.Matched++
+
+		key := codexFingerprintRecommendationKey(parsed.recommended)
+		item, exists := byKey[key]
+		if !exists {
+			item = &CodexFingerprintRecommendation{
+				ID:             codexFingerprintRecommendationID(key),
+				Headers:        parsed.headers,
+				Recommended:    parsed.recommended,
+				IgnoredHeaders: parsed.ignoredHeaders,
+				FirstSeenAt:    row.timestamp,
+				LastSeenAt:     row.timestamp,
+				Samples:        make([]CodexFingerprintRecommendationSample, 0, maxCodexFingerprintSamples),
+			}
+			byKey[key] = item
+		}
+		item.IgnoredHeaders = mergeCodexFingerprintHeaders(item.IgnoredHeaders, parsed.ignoredHeaders)
+		item.Count++
+		if row.timestamp.Before(item.FirstSeenAt) {
+			item.FirstSeenAt = row.timestamp
+		}
+		if row.timestamp.After(item.LastSeenAt) {
+			item.LastSeenAt = row.timestamp
+		}
+		if len(item.Samples) < maxCodexFingerprintSamples {
+			item.Samples = append(item.Samples, codexFingerprintSampleFromRow(row, client))
+		}
+	}
+
+	for _, item := range byKey {
+		result.Items = append(result.Items, *item)
+	}
+	sort.Slice(result.Items, func(i, j int) bool {
+		left := result.Items[i]
+		right := result.Items[j]
+		if left.Count != right.Count {
+			return left.Count > right.Count
+		}
+		if !left.LastSeenAt.Equal(right.LastSeenAt) {
+			return left.LastSeenAt.After(right.LastSeenAt)
+		}
+		return left.ID < right.ID
+	})
+
+	return result, nil
+}
+
+func mergeCodexFingerprintHeaders(target map[string]string, source map[string]string) map[string]string {
+	for key, value := range source {
+		if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		if target == nil {
+			target = make(map[string]string)
+		}
+		if _, exists := target[key]; !exists {
+			target[key] = value
+		}
+	}
+	return target
+}
+
+func normalizeCodexFingerprintRecommendationQuery(params CodexFingerprintRecommendationQuery) CodexFingerprintRecommendationQuery {
+	if params.Days < 1 {
+		params.Days = defaultCodexFingerprintRecommendationDays
+	}
+	if params.Days > maxCodexFingerprintRecommendationDays {
+		params.Days = maxCodexFingerprintRecommendationDays
+	}
+	if params.Limit < 1 {
+		params.Limit = defaultCodexFingerprintRecommendationLimit
+	}
+	if params.Limit > maxCodexFingerprintRecommendationLimit {
+		params.Limit = maxCodexFingerprintRecommendationLimit
+	}
+	return params
+}
+
+func queryRecentCodexFingerprintDetailRows(db *sql.DB, params CodexFingerprintRecommendationQuery) ([]codexFingerprintDetailRow, error) {
+	cutoff := CutoffStartUTC(params.Days).Format(time.RFC3339)
+	rows, err := db.Query(
+		`SELECT logs.id, logs.timestamp, logs.model, logs.source, logs.channel_name, logs.auth_index,
+		        logs.failed, content.compression, content.detail_content
+		   FROM request_logs logs
+		   JOIN request_log_content content ON content.log_id = logs.id
+		  WHERE logs.timestamp >= ?
+		    AND length(content.detail_content) > 0
+		  ORDER BY logs.timestamp DESC
+		  LIMIT ?`,
+		cutoff,
+		params.Limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query codex fingerprint details: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]codexFingerprintDetailRow, 0, params.Limit)
+	for rows.Next() {
+		var (
+			row         codexFingerprintDetailRow
+			timestamp   string
+			failedInt   int
+			compression string
+			compressed  []byte
+		)
+		if err := rows.Scan(
+			&row.logID,
+			&timestamp,
+			&row.model,
+			&row.source,
+			&row.channelName,
+			&row.authIndex,
+			&failedInt,
+			&compression,
+			&compressed,
+		); err != nil {
+			return nil, fmt.Errorf("usage: scan codex fingerprint detail row: %w", err)
+		}
+		if parsed, ok := parseStoredTime(timestamp); ok {
+			row.timestamp = parsed
+		}
+		row.failed = failedInt != 0
+		detail, err := decompressLogContent(compression, compressed)
+		if err != nil {
+			return nil, err
+		}
+		row.detail = detail
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("usage: iterate codex fingerprint detail rows: %w", err)
+	}
+	return result, nil
+}
+
+func parseCodexFingerprintClientDetail(detail string) (codexFingerprintClientDetail, bool) {
+	var payload struct {
+		Client map[string]any `json:"client"`
+	}
+	if strings.TrimSpace(detail) == "" {
+		return codexFingerprintClientDetail{}, false
+	}
+	if err := json.Unmarshal([]byte(detail), &payload); err != nil || payload.Client == nil {
+		return codexFingerprintClientDetail{}, false
+	}
+	client := codexFingerprintClientDetail{
+		ip:                 stringValue(payload.Client["ip"]),
+		method:             stringValue(payload.Client["method"]),
+		path:               stringValue(payload.Client["path"]),
+		host:               stringValue(payload.Client["host"]),
+		fingerprintHeaders: headerMapFromAny(payload.Client["fingerprint_headers"]),
+		headers:            headerMapFromAny(payload.Client["headers"]),
+	}
+	return client, len(client.fingerprintHeaders) > 0 || len(client.headers) > 0
+}
+
+func headerMapFromAny(raw any) http.Header {
+	record, ok := raw.(map[string]any)
+	if !ok || len(record) == 0 {
+		return http.Header{}
+	}
+	headers := http.Header{}
+	for key, value := range record {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		for _, item := range headerValuesFromAny(value) {
+			item = strings.TrimSpace(item)
+			if item != "" {
+				headers.Add(key, item)
+			}
+		}
+	}
+	return headers
+}
+
+func headerValuesFromAny(value any) []string {
+	switch typed := value.(type) {
+	case string:
+		return []string{typed}
+	case []string:
+		return typed
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text := stringValue(item); text != "" {
+				values = append(values, text)
+			}
+		}
+		return values
+	default:
+		text := stringValue(value)
+		if text == "" {
+			return nil
+		}
+		return []string{text}
+	}
+}
+
+func codexFingerprintCandidateFromHeaders(headers http.Header) (codexFingerprintParsedCandidate, bool) {
+	userAgent := firstHeaderValue(headers, "User-Agent")
+	version := firstHeaderValue(headers, "Version")
+	originator := firstHeaderValue(headers, "Originator")
+	openAIBeta := firstHeaderValue(headers, "OpenAI-Beta")
+	codexBetaFeatures := firstHeaderValue(headers, "X-Codex-Beta-Features")
+
+	recommended := config.CodexIdentityFingerprintConfig{
+		Enabled:       true,
+		SessionMode:   config.DefaultCodexFingerprintSessionMode,
+		CustomHeaders: map[string]string{},
+	}
+	if userAgent != "" {
+		recommended.UserAgent = userAgent
+	}
+	if version != "" {
+		recommended.Version = version
+	}
+	if originator != "" {
+		recommended.Originator = originator
+	}
+	if strings.Contains(strings.ToLower(openAIBeta), "responses_websockets=") {
+		recommended.WebsocketBeta = openAIBeta
+	}
+	if codexBetaFeatures != "" {
+		recommended.CustomHeaders["X-Codex-Beta-Features"] = codexBetaFeatures
+	}
+
+	if !looksLikeCodexHeaders(headers, userAgent, originator, codexBetaFeatures, openAIBeta) {
+		return codexFingerprintParsedCandidate{}, false
+	}
+	if recommended.UserAgent == "" && recommended.Version == "" && recommended.Originator == "" &&
+		recommended.WebsocketBeta == "" && len(recommended.CustomHeaders) == 0 {
+		return codexFingerprintParsedCandidate{}, false
+	}
+
+	observed := make(map[string]string)
+	addObservedHeader(observed, "User-Agent", userAgent)
+	addObservedHeader(observed, "Version", version)
+	addObservedHeader(observed, "Originator", originator)
+	addObservedHeader(observed, "OpenAI-Beta", openAIBeta)
+	addObservedHeader(observed, "X-Codex-Beta-Features", codexBetaFeatures)
+
+	ignored := codexFingerprintIgnoredHeaders(headers)
+	return codexFingerprintParsedCandidate{
+		headers:        observed,
+		ignoredHeaders: ignored,
+		recommended:    recommended,
+	}, true
+}
+
+func looksLikeCodexHeaders(headers http.Header, userAgent, originator, codexBetaFeatures, openAIBeta string) bool {
+	if containsFold(userAgent, "codex") ||
+		containsFold(originator, "codex") ||
+		strings.TrimSpace(codexBetaFeatures) != "" ||
+		containsFold(openAIBeta, "responses_websockets=") {
+		return true
+	}
+	for key := range headers {
+		if containsFold(key, "codex") {
+			return true
+		}
+	}
+	return false
+}
+
+func codexFingerprintIgnoredHeaders(headers http.Header) map[string]string {
+	ignored := make(map[string]string)
+	for key, values := range headers {
+		canonical := http.CanonicalHeaderKey(strings.TrimSpace(key))
+		normalized := strings.ToLower(canonical)
+		if canonical == "" || len(values) == 0 {
+			continue
+		}
+		switch {
+		case normalized == "session_id" || normalized == "session-id" || strings.Contains(normalized, "session"):
+			addObservedHeader(ignored, canonical, maskCodexFingerprintHeaderValue(values[0]))
+		case normalized == "x-codex-turn-metadata" || normalized == "x-codex-turn-state" ||
+			normalized == "x-client-request-id" || normalized == "conversation_id":
+			addObservedHeader(ignored, canonical, truncateCodexFingerprintValue(values[0]))
+		}
+	}
+	if len(ignored) == 0 {
+		return nil
+	}
+	return ignored
+}
+
+func addObservedHeader(target map[string]string, key, value string) {
+	value = truncateCodexFingerprintValue(value)
+	if strings.TrimSpace(key) == "" || value == "" {
+		return
+	}
+	target[http.CanonicalHeaderKey(strings.TrimSpace(key))] = value
+}
+
+func firstHeaderValue(headers http.Header, key string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	if value := strings.TrimSpace(headers.Get(key)); value != "" {
+		return value
+	}
+	for existing, values := range headers {
+		if strings.EqualFold(existing, key) && len(values) > 0 {
+			return strings.TrimSpace(values[0])
+		}
+	}
+	return ""
+}
+
+func codexFingerprintRecommendationKey(recommended config.CodexIdentityFingerprintConfig) string {
+	parts := []string{
+		"user-agent=" + strings.TrimSpace(recommended.UserAgent),
+		"version=" + strings.TrimSpace(recommended.Version),
+		"originator=" + strings.TrimSpace(recommended.Originator),
+		"websocket-beta=" + strings.TrimSpace(recommended.WebsocketBeta),
+	}
+	customKeys := make([]string, 0, len(recommended.CustomHeaders))
+	for key := range recommended.CustomHeaders {
+		customKeys = append(customKeys, key)
+	}
+	sort.Strings(customKeys)
+	for _, key := range customKeys {
+		parts = append(parts, "custom:"+strings.TrimSpace(key)+"="+strings.TrimSpace(recommended.CustomHeaders[key]))
+	}
+	return strings.Join(parts, "\n")
+}
+
+func codexFingerprintRecommendationID(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func codexFingerprintSampleFromRow(row codexFingerprintDetailRow, client codexFingerprintClientDetail) CodexFingerprintRecommendationSample {
+	return CodexFingerprintRecommendationSample{
+		LogID:       row.logID,
+		Timestamp:   row.timestamp,
+		Model:       row.model,
+		Source:      row.source,
+		ChannelName: row.channelName,
+		AuthIndex:   row.authIndex,
+		Failed:      row.failed,
+		Method:      client.method,
+		Path:        client.path,
+		Host:        client.host,
+		IP:          client.ip,
+	}
+}
+
+func truncateCodexFingerprintValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= maxCodexFingerprintDisplayValue {
+		return value
+	}
+	return value[:maxCodexFingerprintDisplayValue-3] + "..."
+}
+
+func maskCodexFingerprintHeaderValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if len(value) <= 12 {
+		return "****"
+	}
+	return value[:4] + "..." + value[len(value)-4:]
+}
+
+func containsFold(value, needle string) bool {
+	return strings.Contains(strings.ToLower(value), strings.ToLower(needle))
+}
+
+func stringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	case nil:
+		return ""
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", typed))
+	}
+}

--- a/internal/usage/codex_fingerprint_recommendations_test.go
+++ b/internal/usage/codex_fingerprint_recommendations_test.go
@@ -1,0 +1,154 @@
+package usage
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestQueryCodexFingerprintRecommendationsAggregatesStableHeaders(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	now := time.Now().UTC()
+	insertCodexFingerprintLog(t, now.Add(-2*time.Minute), map[string][]string{
+		"User-Agent":              {"codex-tui/0.125.0 (Mac OS 26.5; arm64) Terminal.app/2.15 (codex-tui; 0.125.0)"},
+		"Version":                 {"0.125.0"},
+		"Originator":              {"codex-tui"},
+		"OpenAI-Beta":             {"responses_websockets=2026-02-06"},
+		"X-Codex-Beta-Features":   {"exec_command_v2"},
+		"Session_id":              {"session-alpha-secret"},
+		"X-Codex-Turn-Metadata":   {`{"turn":"alpha"}`},
+		"Authorization":           {"Bearer should-not-be-exposed"},
+		"X-Client-Request-Id":     {"req-alpha"},
+		"X-Other-Non-Fingerprint": {"ignored"},
+	})
+	insertCodexFingerprintLog(t, now.Add(-time.Minute), map[string][]string{
+		"User-Agent":            {"codex-tui/0.125.0 (Mac OS 26.5; arm64) Terminal.app/2.15 (codex-tui; 0.125.0)"},
+		"Version":               {"0.125.0"},
+		"Originator":            {"codex-tui"},
+		"OpenAI-Beta":           {"responses_websockets=2026-02-06"},
+		"X-Codex-Beta-Features": {"exec_command_v2"},
+		"Session_id":            {"session-beta-secret"},
+	})
+	insertCodexFingerprintLog(t, now, map[string][]string{
+		"User-Agent": {"curl/8.7.1"},
+		"Version":    {"not-codex"},
+	})
+
+	result, err := QueryCodexFingerprintRecommendations(CodexFingerprintRecommendationQuery{
+		Days:  7,
+		Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("QueryCodexFingerprintRecommendations() error = %v", err)
+	}
+
+	if result.Inspected != 3 {
+		t.Fatalf("Inspected = %d, want 3", result.Inspected)
+	}
+	if result.Matched != 2 {
+		t.Fatalf("Matched = %d, want 2", result.Matched)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("items length = %d, want 1", len(result.Items))
+	}
+
+	item := result.Items[0]
+	if item.Count != 2 {
+		t.Fatalf("Count = %d, want 2", item.Count)
+	}
+	if item.Recommended.UserAgent != "codex-tui/0.125.0 (Mac OS 26.5; arm64) Terminal.app/2.15 (codex-tui; 0.125.0)" {
+		t.Fatalf("Recommended.UserAgent = %q", item.Recommended.UserAgent)
+	}
+	if item.Recommended.Version != "0.125.0" {
+		t.Fatalf("Recommended.Version = %q, want 0.125.0", item.Recommended.Version)
+	}
+	if item.Recommended.Originator != "codex-tui" {
+		t.Fatalf("Recommended.Originator = %q, want codex-tui", item.Recommended.Originator)
+	}
+	if item.Recommended.WebsocketBeta != "responses_websockets=2026-02-06" {
+		t.Fatalf("Recommended.WebsocketBeta = %q", item.Recommended.WebsocketBeta)
+	}
+	if item.Recommended.SessionID != "" {
+		t.Fatalf("Recommended.SessionID = %q, want empty", item.Recommended.SessionID)
+	}
+	if got := item.Recommended.CustomHeaders["X-Codex-Beta-Features"]; got != "exec_command_v2" {
+		t.Fatalf("X-Codex-Beta-Features = %q, want exec_command_v2", got)
+	}
+	if _, exists := item.Recommended.CustomHeaders["X-Codex-Turn-Metadata"]; exists {
+		t.Fatalf("turn metadata must not be recommended as a fixed custom header")
+	}
+	if _, exists := item.Headers["Authorization"]; exists {
+		t.Fatalf("Authorization should not be exposed in observed headers")
+	}
+	if got := item.IgnoredHeaders["Session_id"]; got == "" || got == "session-alpha-secret" || got == "session-beta-secret" {
+		t.Fatalf("Session_id ignored header should be masked, got %q", got)
+	}
+	if got := item.IgnoredHeaders["X-Codex-Turn-Metadata"]; got == "" {
+		t.Fatalf("X-Codex-Turn-Metadata should be visible as ignored sample metadata")
+	}
+	if len(item.Samples) != 2 {
+		t.Fatalf("samples length = %d, want 2", len(item.Samples))
+	}
+}
+
+func TestQueryCodexFingerprintRecommendationsSortsByCountThenRecent(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	now := time.Now().UTC()
+	for i := 0; i < 2; i++ {
+		insertCodexFingerprintLog(t, now.Add(time.Duration(i)*time.Second), map[string][]string{
+			"User-Agent": {"codex-tui/0.124.0 (Mac OS 26.4; arm64)"},
+			"Originator": {"codex-tui"},
+		})
+	}
+	insertCodexFingerprintLog(t, now.Add(time.Minute), map[string][]string{
+		"User-Agent": {"codex-tui/0.125.0 (Mac OS 26.5; arm64)"},
+		"Originator": {"codex-tui"},
+	})
+
+	result, err := QueryCodexFingerprintRecommendations(CodexFingerprintRecommendationQuery{Days: 7, Limit: 20})
+	if err != nil {
+		t.Fatalf("QueryCodexFingerprintRecommendations() error = %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("items length = %d, want 2", len(result.Items))
+	}
+	if result.Items[0].Count != 2 {
+		t.Fatalf("first item Count = %d, want 2", result.Items[0].Count)
+	}
+	if result.Items[1].Recommended.UserAgent != "codex-tui/0.125.0 (Mac OS 26.5; arm64)" {
+		t.Fatalf("second item should be the newer one-count candidate, got %q", result.Items[1].Recommended.UserAgent)
+	}
+}
+
+func insertCodexFingerprintLog(t *testing.T, timestamp time.Time, headers map[string][]string) {
+	t.Helper()
+
+	detail, err := json.Marshal(map[string]any{
+		"client": map[string]any{
+			"ip":                  "203.0.113.10",
+			"method":              "POST",
+			"path":                "/v1/responses",
+			"host":                "relay.test",
+			"fingerprint_headers": headers,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal detail: %v", err)
+	}
+
+	InsertLogWithDetails("sk-test", "Primary", "gpt-5.4", "codex", "Codex", "auth-1", false, timestamp, 100, 10, TokenStats{
+		InputTokens: 1, OutputTokens: 1, TotalTokens: 2,
+	}, "", "", string(detail))
+}


### PR DESCRIPTION
## Summary
- add management endpoint for Codex fingerprint recommendations derived from recent request logs
- aggregate stable Codex identity headers and keep session/turn/request metadata sample-only
- add handler and usage-layer tests

## Tests
- rtk go test ./internal/usage ./internal/api/handlers/management -count=1