### PR TITLE
fix: allow oversized codex image size hints

### DIFF
--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -24,7 +24,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 210; got != want {
+	if got, want := len(routes), 211; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 
@@ -41,6 +41,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"PATCH /v0/management/api-key-entries",
 		"POST /v0/management/opencode-go-api-key/usage",
 		"GET /v0/management/auth-files/models",
+		"GET /v0/management/identity-fingerprint/codex/recommendations",
 		"POST /v0/management/oauth-callback",
 		"GET /v0/management/public/ping",
 		"GET /v0/management/public/usage/logs/:id/content",

--- a/internal/runtime/executor/codex_executor_image_test.go
+++ b/internal/runtime/executor/codex_executor_image_test.go
@@ -18,6 +18,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
 )
 
 type usageCapturePlugin struct {
@@ -514,7 +515,7 @@ func TestCodexExecutorExecuteImageGenerationViaResponsesToolChoice(t *testing.T)
 
 	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "gpt-image-2",
-		Payload: []byte(`{"model":"gpt-image-2","prompt":"给我绘制一个 springboot 的系统架构图","size":"1024x1024","quality":"high"}`),
+		Payload: []byte(`{"model":"gpt-image-2","prompt":"给我绘制一个 springboot 的系统架构图","size":"4096x2304","quality":"high"}`),
 		Format:  sdktranslator.FromString("openai"),
 	}, cliproxyexecutor.Options{
 		Alt:          "images/generations",
@@ -532,6 +533,12 @@ func TestCodexExecutorExecuteImageGenerationViaResponsesToolChoice(t *testing.T)
 	}
 	if !strings.Contains(lastBody, `"model":"gpt-image-2"`) {
 		t.Fatalf("request body = %s, want gpt-image-2 tool model", lastBody)
+	}
+	if gjson.Get(lastBody, "tools.0.size").Exists() {
+		t.Fatalf("request body = %s, want size stripped from image_generation tool", lastBody)
+	}
+	if got := gjson.Get(lastBody, "input.0.content.0.text").String(); !strings.Contains(got, "Preferred image size: 4096x2304.") {
+		t.Fatalf("input text = %q, want oversized size hint; request body=%s", got, lastBody)
 	}
 
 	var payload struct {

--- a/internal/runtime/executor/codex_executor_responses_bridge_test.go
+++ b/internal/runtime/executor/codex_executor_responses_bridge_test.go
@@ -44,7 +44,7 @@ func TestCodexExecutorExecutePreservesResponsesImageBridgeModel(t *testing.T) {
 
 	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "gpt-image-2",
-		Payload: []byte(`{"model":"gpt-image-2","input":"draw a fox","size":"1024x1024"}`),
+		Payload: []byte(`{"model":"gpt-image-2","input":"draw a fox","size":"4096x2304"}`),
 		Format:  sdktranslator.FromString("openai-response"),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("openai-response"),
@@ -61,6 +61,12 @@ func TestCodexExecutorExecutePreservesResponsesImageBridgeModel(t *testing.T) {
 	}
 	if got := gjson.Get(lastBody, "tools.0.model").String(); got != "gpt-image-2" {
 		t.Fatalf("tools.0.model = %q, want %q; body=%s", got, "gpt-image-2", lastBody)
+	}
+	if gjson.Get(lastBody, "tools.0.size").Exists() {
+		t.Fatalf("tools.0.size should be stripped before Codex upstream call; body=%s", lastBody)
+	}
+	if got := gjson.Get(lastBody, "input.0.content.0.text").String(); got != "draw a fox\n\nPreferred image size: 4096x2304." {
+		t.Fatalf("input text = %q, want prompt with size hint; body=%s", got, lastBody)
 	}
 }
 

--- a/internal/runtime/executor/codex_image_responses.go
+++ b/internal/runtime/executor/codex_image_responses.go
@@ -124,7 +124,7 @@ func buildCodexImageResponsesRequest(parsed *codexImageRequest, toolModel string
 	req, _ = sjson.SetBytes(req, "model", codexImageResponsesMainModel)
 
 	input := []byte(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`)
-	input, _ = sjson.SetBytes(input, "0.content.0.text", prompt)
+	input, _ = sjson.SetBytes(input, "0.content.0.text", buildCodexImageResponsesInputText(parsed, prompt))
 	for index, imageURL := range inputImages {
 		part := []byte(`{"type":"input_image","image_url":""}`)
 		part, _ = sjson.SetBytes(part, "image_url", imageURL)
@@ -143,7 +143,6 @@ func buildCodexImageResponsesRequest(parsed *codexImageRequest, toolModel string
 		path  string
 		value string
 	}{
-		{path: "size", value: parsed.Size},
 		{path: "quality", value: parsed.Quality},
 		{path: "background", value: parsed.Background},
 		{path: "output_format", value: parsed.OutputFormat},
@@ -174,6 +173,25 @@ func buildCodexImageResponsesRequest(parsed *codexImageRequest, toolModel string
 	req, _ = sjson.SetRawBytes(req, "tools", []byte(`[]`))
 	req, _ = sjson.SetRawBytes(req, "tools.-1", tool)
 	return req, nil
+}
+
+func buildCodexImageResponsesInputText(parsed *codexImageRequest, prompt string) string {
+	if parsed == nil {
+		return prompt
+	}
+	size := strings.TrimSpace(parsed.Size)
+	if size == "" {
+		return prompt
+	}
+	hint := "Preferred image size: " + size + "."
+	if strings.Contains(prompt, hint) || strings.Contains(prompt, "Preferred image size: ") {
+		return prompt
+	}
+	prompt = strings.TrimRight(prompt, " \t\r\n")
+	if prompt == "" {
+		return hint
+	}
+	return prompt + "\n\n" + hint
 }
 
 func collectCodexImagesFromResponsesBody(body []byte) ([]codexResponsesImageResult, int64, error) {

--- a/internal/runtime/executor/codex_responses.go
+++ b/internal/runtime/executor/codex_responses.go
@@ -2,11 +2,14 @@ package executor
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+const codexResponsesImageSizeHintPrefix = "Preferred image size: "
 
 func ensureTranslatedCodexModel(body []byte, fallback string) []byte {
 	if strings.TrimSpace(gjson.GetBytes(body, "model").String()) != "" {
@@ -24,7 +27,112 @@ func sanitizeCodexResponsesRequest(body []byte) []byte {
 	} {
 		body, _ = sjson.DeleteBytes(body, field)
 	}
+	body = stripCodexResponsesImageGenerationSize(body)
 	return body
+}
+
+func stripCodexResponsesImageGenerationSize(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return body
+	}
+	var sizeHint string
+	for index, tool := range tools.Array() {
+		if strings.TrimSpace(tool.Get("type").String()) != "image_generation" {
+			continue
+		}
+		sizePath := fmt.Sprintf("tools.%d.size", index)
+		size := gjson.GetBytes(body, sizePath)
+		if !size.Exists() {
+			continue
+		}
+		if trimmed := strings.TrimSpace(size.String()); trimmed != "" && sizeHint == "" {
+			sizeHint = trimmed
+		}
+		body, _ = sjson.DeleteBytes(body, sizePath)
+	}
+	return appendCodexResponsesImageSizeHint(body, sizeHint)
+}
+
+func appendCodexResponsesImageSizeHint(body []byte, size string) []byte {
+	size = strings.TrimSpace(size)
+	if size == "" {
+		return body
+	}
+	hint := codexResponsesImageSizeHintPrefix + size + "."
+	inputResult := gjson.GetBytes(body, "input")
+	if inputResult.Type == gjson.String {
+		body, _ = sjson.SetBytes(body, "input", appendCodexResponsesImageHintToText(inputResult.String(), hint))
+		return body
+	}
+	if inputResult.IsArray() {
+		items := inputResult.Array()
+		for itemIndex, item := range items {
+			if strings.TrimSpace(item.Get("role").String()) != "user" {
+				continue
+			}
+			if updated, ok := appendCodexResponsesImageHintToInputItem(body, itemIndex, item, hint); ok {
+				return updated
+			}
+		}
+		for itemIndex, item := range items {
+			if updated, ok := appendCodexResponsesImageHintToInputItem(body, itemIndex, item, hint); ok {
+				return updated
+			}
+		}
+		body, _ = sjson.SetRawBytes(body, "input.-1", codexResponsesUserTextMessage(hint))
+		return body
+	}
+	body, _ = sjson.SetRawBytes(body, "input", []byte(`[]`))
+	body, _ = sjson.SetRawBytes(body, "input.-1", codexResponsesUserTextMessage(hint))
+	return body
+}
+
+func appendCodexResponsesImageHintToInputItem(body []byte, itemIndex int, item gjson.Result, hint string) ([]byte, bool) {
+	content := item.Get("content")
+	if content.Type == gjson.String {
+		path := fmt.Sprintf("input.%d.content", itemIndex)
+		body, _ = sjson.SetBytes(body, path, appendCodexResponsesImageHintToText(content.String(), hint))
+		return body, true
+	}
+	if !content.IsArray() {
+		return body, false
+	}
+	for contentIndex, part := range content.Array() {
+		text := part.Get("text")
+		if text.Type != gjson.String {
+			continue
+		}
+		path := fmt.Sprintf("input.%d.content.%d.text", itemIndex, contentIndex)
+		body, _ = sjson.SetBytes(body, path, appendCodexResponsesImageHintToText(text.String(), hint))
+		return body, true
+	}
+	path := fmt.Sprintf("input.%d.content.-1", itemIndex)
+	body, _ = sjson.SetRawBytes(body, path, codexResponsesInputTextMessagePart(hint))
+	return body, true
+}
+
+func appendCodexResponsesImageHintToText(text string, hint string) string {
+	if strings.Contains(text, hint) || strings.Contains(text, codexResponsesImageSizeHintPrefix) {
+		return text
+	}
+	text = strings.TrimRight(text, " \t\r\n")
+	if text == "" {
+		return hint
+	}
+	return text + "\n\n" + hint
+}
+
+func codexResponsesUserTextMessage(text string) []byte {
+	message := []byte(`{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}`)
+	message, _ = sjson.SetBytes(message, "content.0.text", text)
+	return message
+}
+
+func codexResponsesInputTextMessagePart(text string) []byte {
+	part := []byte(`{"type":"input_text","text":""}`)
+	part, _ = sjson.SetBytes(part, "text", text)
+	return part
 }
 
 func extractCodexResponsesOutputItemDone(payload []byte) ([]byte, string, bool) {

--- a/internal/runtime/executor/codex_responses_test.go
+++ b/internal/runtime/executor/codex_responses_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -20,5 +21,33 @@ func TestSanitizeCodexResponsesRequestStripsUnsupportedTokenLimitFields(t *testi
 	}
 	if !gjson.GetBytes(got, "stream").Bool() {
 		t.Fatalf("stream should be preserved; payload=%s", got)
+	}
+}
+
+func TestSanitizeCodexResponsesRequestMovesImageToolSizeToUserPromptHint(t *testing.T) {
+	input := []byte(`{
+		"model":"gpt-5.4-mini",
+		"input":[
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"stay concise"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"draw a poster"}]}
+		],
+		"tools":[{"type":"image_generation","model":"gpt-image-2","size":"4096x2304","quality":"high"}],
+		"tool_choice":{"type":"image_generation"}
+	}`)
+
+	got := sanitizeCodexResponsesRequest(input)
+
+	if gjson.GetBytes(got, "tools.0.size").Exists() {
+		t.Fatalf("tools.0.size should be stripped for codex upstream; payload=%s", got)
+	}
+	if quality := gjson.GetBytes(got, "tools.0.quality").String(); quality != "high" {
+		t.Fatalf("tools.0.quality = %q, want high; payload=%s", quality, got)
+	}
+	if developerText := gjson.GetBytes(got, "input.0.content.0.text").String(); strings.Contains(developerText, codexResponsesImageSizeHintPrefix) {
+		t.Fatalf("developer message should not receive size hint; text=%q payload=%s", developerText, got)
+	}
+	userText := gjson.GetBytes(got, "input.1.content.0.text").String()
+	if !strings.Contains(userText, "draw a poster") || !strings.Contains(userText, "Preferred image size: 4096x2304.") {
+		t.Fatalf("user message should keep prompt and receive size hint; text=%q payload=%s", userText, got)
 	}
 }


### PR DESCRIPTION
## Summary
- strip image generation size from Codex upstream tool payloads to avoid tool schema limits
- preserve requested image size as a prompt hint for both Responses and Images API flows
- update route table test expectation for the current dev route set

## Tests
- rtk go test ./internal/translator/codex/openai/responses ./internal/runtime/executor ./internal/api/handlers/management ./sdk/api/handlers/openai
- rtk go test ./internal/api/routes
- rtk go test ./...