### PR TITLE
fix: speed up codex fingerprint recommendations

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -64,10 +64,18 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 	if h.cfg == nil {
 		h.cfg = &config.Config{}
 	}
+	previous := h.cfg.IdentityFingerprint
 	h.cfg.IdentityFingerprint = body
 	h.mu.Unlock()
 
-	h.persistRuntimeSetting(c, settingsstore.RuntimeSettingIdentityFingerprint, body)
+	if !h.persistRuntimeSetting(c, settingsstore.RuntimeSettingIdentityFingerprint, body) {
+		h.mu.Lock()
+		if h.cfg != nil {
+			h.cfg.IdentityFingerprint = previous
+		}
+		h.mu.Unlock()
+		return
+	}
 }
 
 func (h *Handler) GetCodexFingerprintRecommendations(c *gin.Context) {

--- a/internal/api/handlers/management/runtime_settings_test.go
+++ b/internal/api/handlers/management/runtime_settings_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
@@ -59,6 +60,39 @@ func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "logging-to-file: true") {
 		t.Fatalf("ordinary config should remain in YAML:\n%s", string(data))
+	}
+}
+
+func TestPutIdentityFingerprintFailsWhenRuntimeSettingCannotPersist(t *testing.T) {
+	usage.CloseDB()
+
+	configPath := t.TempDir()
+	h := NewHandler(&config.Config{
+		IdentityFingerprint: config.IdentityFingerprintConfig{
+			Codex: config.CodexIdentityFingerprintConfig{
+				Enabled:   false,
+				UserAgent: "codex_cli_rs/old",
+			},
+		},
+	}, configPath, nil)
+
+	rec := performModelsRequest(http.MethodPut, "/identity-fingerprint", []byte(`{
+		"codex": {
+			"enabled": true,
+			"user-agent": "codex_cli_rs/0.125.0",
+			"originator": "codex_cli_rs",
+			"session-mode": "per-request"
+		},
+		"claude": {
+			"enabled": false,
+			"session-mode": "per-request"
+		}
+	}`), h.PutIdentityFingerprint)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("PutIdentityFingerprint status = %d, want %d, body = %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if h.cfg.IdentityFingerprint.Codex.Enabled || h.cfg.IdentityFingerprint.Codex.UserAgent != "codex_cli_rs/old" {
+		t.Fatalf("identity fingerprint should be rolled back after persist failure, got %#v", h.cfg.IdentityFingerprint.Codex)
 	}
 }
 

--- a/internal/usage/codex_fingerprint_recommendations.go
+++ b/internal/usage/codex_fingerprint_recommendations.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -21,6 +22,7 @@ const (
 	maxCodexFingerprintRecommendationLimit     = 1000
 	maxCodexFingerprintSamples                 = 3
 	maxCodexFingerprintDisplayValue            = 240
+	codexFingerprintRecommendationQueryTimeout = 8 * time.Second
 )
 
 type CodexFingerprintRecommendationQuery struct {
@@ -202,15 +204,23 @@ func normalizeCodexFingerprintRecommendationQuery(params CodexFingerprintRecomme
 
 func queryRecentCodexFingerprintDetailRows(db *sql.DB, params CodexFingerprintRecommendationQuery) ([]codexFingerprintDetailRow, error) {
 	cutoff := CutoffStartUTC(params.Days).Format(time.RFC3339)
-	rows, err := db.Query(
-		`SELECT logs.id, logs.timestamp, logs.model, logs.source, logs.channel_name, logs.auth_index,
-		        logs.failed, content.compression, content.detail_content
-		   FROM request_logs logs
-		   JOIN request_log_content content ON content.log_id = logs.id
-		  WHERE logs.timestamp >= ?
-		    AND length(content.detail_content) > 0
-		  ORDER BY logs.timestamp DESC
-		  LIMIT ?`,
+	ctx, cancel := context.WithTimeout(context.Background(), codexFingerprintRecommendationQueryTimeout)
+	defer cancel()
+	rows, err := db.QueryContext(
+		ctx,
+		`WITH recent_content AS (
+		     SELECT log_id, timestamp, compression, detail_content
+		       FROM request_log_content
+		      WHERE timestamp >= ?
+		        AND length(detail_content) > 0
+		      ORDER BY timestamp DESC
+		      LIMIT ?
+		   )
+		 SELECT logs.id, logs.timestamp, logs.model, logs.source, logs.channel_name, logs.auth_index,
+		        logs.failed, recent_content.compression, recent_content.detail_content
+		   FROM recent_content
+		   JOIN request_logs logs ON logs.id = recent_content.log_id
+		  ORDER BY recent_content.timestamp DESC`,
 		cutoff,
 		params.Limit,
 	)

--- a/internal/usage/codex_fingerprint_recommendations_test.go
+++ b/internal/usage/codex_fingerprint_recommendations_test.go
@@ -98,6 +98,46 @@ func TestQueryCodexFingerprintRecommendationsAggregatesStableHeaders(t *testing.
 	}
 }
 
+func TestInitDBCreatesCodexFingerprintRecommendationDetailIndex(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	rows, err := getDB().Query("PRAGMA index_list(request_log_content)")
+	if err != nil {
+		t.Fatalf("PRAGMA index_list(request_log_content): %v", err)
+	}
+	defer rows.Close()
+
+	found := false
+	for rows.Next() {
+		var (
+			seq     int
+			name    string
+			unique  int
+			origin  string
+			partial int
+		)
+		if err := rows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			t.Fatalf("scan index_list: %v", err)
+		}
+		if name == "idx_log_content_detail_timestamp" {
+			found = true
+			if partial != 1 {
+				t.Fatalf("idx_log_content_detail_timestamp partial = %d, want 1", partial)
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate index_list: %v", err)
+	}
+	if !found {
+		t.Fatal("idx_log_content_detail_timestamp was not created")
+	}
+}
+
 func TestQueryCodexFingerprintRecommendationsSortsByCountThenRecent(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -311,6 +311,16 @@ func migrateRequestLogDetailColumn(db *sql.DB) {
 	}
 }
 
+func ensureRequestLogDetailIndexes(db *sql.DB) {
+	if _, err := db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_log_content_detail_timestamp
+		ON request_log_content(timestamp DESC)
+		WHERE length(detail_content) > 0
+	`); err != nil {
+		log.Warnf("usage: create idx_log_content_detail_timestamp: %v", err)
+	}
+}
+
 // InitDB opens (or creates) the SQLite database at the given path and creates
 // the request_logs table if it doesn't exist.
 func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.Location) error {
@@ -384,6 +394,8 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	migrateFirstTokenColumn(db)
 	log.Debugf("usage: running request log detail column migration")
 	migrateRequestLogDetailColumn(db)
+	log.Debugf("usage: ensuring request log detail indexes")
+	ensureRequestLogDetailIndexes(db)
 	log.Debugf("usage: initializing pricing table")
 	initPricingTable(db)
 	log.Debugf("usage: initializing model config tables")


### PR DESCRIPTION
## Summary
- make identity fingerprint persistence failures return 500 and roll back runtime state
- query recent Codex recommendation details from indexed request_log_content rows before joining logs
- add a partial timestamp index for stored detail content and regression tests

## Tests
- go test ./internal/usage ./internal/api/handlers/management -count=1