### PR TITLE
feat: persist image generation size presets

### DIFF
--- a/internal/api/handlers/management/image_generation.go
+++ b/internal/api/handlers/management/image_generation.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	imagegeneration "github.com/router-for-me/CLIProxyAPI/v6/internal/management/imagegeneration"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
@@ -29,6 +30,143 @@ const (
 	imageMaxUploads             = 5
 	imageGenerationSystemAPIKey = "POST /image-generation/test"
 )
+
+var defaultImageGenerationSizePresets = []string{
+	"1024x1024",
+	"1792x1024",
+	"1024x1792",
+	"2560x1440",
+	"2160x3840",
+}
+
+func (h *Handler) GetImageGenerationSizePresets(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"sizes": imageGenerationSizePresets()})
+}
+
+func (h *Handler) PutImageGenerationSizePresets(c *gin.Context) {
+	var body settingsstore.ImageSizePresetsSetting
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	sizes, err := normalizeImageGenerationSizePresets(body.Sizes)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	customSizes := customImageGenerationSizePresets(sizes)
+	if err := settingsstore.StoreImageSizePresetsSetting(customSizes); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save size presets: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"sizes": mergeImageGenerationSizePresets(defaultImageGenerationSizePresets, customSizes)})
+}
+
+func imageGenerationSizePresets() []string {
+	customSizes := loadImageGenerationCustomSizePresets()
+	return mergeImageGenerationSizePresets(defaultImageGenerationSizePresets, customSizes)
+}
+
+func loadImageGenerationCustomSizePresets() []string {
+	return filterValidImageGenerationSizePresets(settingsstore.LoadImageSizePresetsSetting())
+}
+
+func filterValidImageGenerationSizePresets(values []string) []string {
+	sizes := make([]string, 0, len(values))
+	seen := make(map[string]struct{})
+	for _, value := range values {
+		size, ok := normalizeImageGenerationSizePreset(value)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[size]; exists {
+			continue
+		}
+		seen[size] = struct{}{}
+		sizes = append(sizes, size)
+	}
+	return sizes
+}
+
+func normalizeImageGenerationSizePresets(values []string) ([]string, error) {
+	sizes := make([]string, 0, len(values))
+	seen := make(map[string]struct{})
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		size, ok := normalizeImageGenerationSizePreset(value)
+		if !ok {
+			return nil, fmt.Errorf("invalid size %q", value)
+		}
+		if _, exists := seen[size]; exists {
+			continue
+		}
+		seen[size] = struct{}{}
+		sizes = append(sizes, size)
+	}
+	return sizes, nil
+}
+
+func customImageGenerationSizePresets(values []string) []string {
+	defaults := make(map[string]struct{}, len(defaultImageGenerationSizePresets))
+	for _, value := range defaultImageGenerationSizePresets {
+		defaults[value] = struct{}{}
+	}
+	custom := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := defaults[value]; ok {
+			continue
+		}
+		custom = append(custom, value)
+	}
+	return custom
+}
+
+func mergeImageGenerationSizePresets(lists ...[]string) []string {
+	merged := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, list := range lists {
+		for _, value := range list {
+			size, ok := normalizeImageGenerationSizePreset(value)
+			if !ok {
+				continue
+			}
+			if _, exists := seen[size]; exists {
+				continue
+			}
+			seen[size] = struct{}{}
+			merged = append(merged, size)
+		}
+	}
+	return merged
+}
+
+func normalizeImageGenerationSizePreset(value string) (string, bool) {
+	normalized := strings.NewReplacer("X", "x", "×", "x", "*", "x").Replace(strings.TrimSpace(value))
+	parts := strings.Split(normalized, "x")
+	if len(parts) != 2 {
+		return "", false
+	}
+	width := strings.TrimSpace(parts[0])
+	height := strings.TrimSpace(parts[1])
+	if !validImageGenerationSizeDimension(width) || !validImageGenerationSizeDimension(height) {
+		return "", false
+	}
+	return width + "x" + height, true
+}
+
+func validImageGenerationSizeDimension(value string) bool {
+	if value == "" || value[0] == '0' {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
 
 func (h *Handler) PostImageGenerationTest(c *gin.Context) {
 	payload, alt, err := parseImageGenerationTestPayload(c)

--- a/internal/api/handlers/management/image_generation_test.go
+++ b/internal/api/handlers/management/image_generation_test.go
@@ -436,6 +436,76 @@ func waitForImageGenerationTask(t *testing.T, h *Handler, taskID string, done fu
 	}
 }
 
+func TestImageGenerationSizePresetsReturnDefaults(t *testing.T) {
+	initManagementModelsTestDB(t)
+
+	h := &Handler{}
+	rec := performModelsRequest(http.MethodGet, "/image-generation/size-presets", nil, h.GetImageGenerationSizePresets)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Sizes []string `json:"sizes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("Unmarshal response: %v", err)
+	}
+	want := []string{"1024x1024", "1792x1024", "1024x1792", "2560x1440", "2160x3840"}
+	if got := strings.Join(body.Sizes, ","); got != strings.Join(want, ",") {
+		t.Fatalf("sizes = %v, want %v", body.Sizes, want)
+	}
+}
+
+func TestImageGenerationSizePresetsPersistCustomSizes(t *testing.T) {
+	initManagementModelsTestDB(t)
+
+	h := &Handler{}
+	putRec := performModelsRequest(
+		http.MethodPut,
+		"/image-generation/size-presets",
+		[]byte(`{"sizes":["1024x1024","4096X2304","4096×2304","8192 * 4608"]}`),
+		h.PutImageGenerationSizePresets,
+	)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d, body=%s", putRec.Code, http.StatusOK, putRec.Body.String())
+	}
+
+	getRec := performModelsRequest(http.MethodGet, "/image-generation/size-presets", nil, h.GetImageGenerationSizePresets)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d, body=%s", getRec.Code, http.StatusOK, getRec.Body.String())
+	}
+	var body struct {
+		Sizes []string `json:"sizes"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("Unmarshal response: %v", err)
+	}
+	want := []string{"1024x1024", "1792x1024", "1024x1792", "2560x1440", "2160x3840", "4096x2304", "8192x4608"}
+	if got := strings.Join(body.Sizes, ","); got != strings.Join(want, ",") {
+		t.Fatalf("sizes = %v, want %v", body.Sizes, want)
+	}
+}
+
+func TestImageGenerationSizePresetsRejectInvalidSize(t *testing.T) {
+	initManagementModelsTestDB(t)
+
+	h := &Handler{}
+	rec := performModelsRequest(
+		http.MethodPut,
+		"/image-generation/size-presets",
+		[]byte(`{"sizes":["0x1024"]}`),
+		h.PutImageGenerationSizePresets,
+	)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid size") {
+		t.Fatalf("body = %s, want invalid size error", rec.Body.String())
+	}
+}
+
 func TestPostImageGenerationTestAcceptsMultipartImageEdits(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/routes/management_auth_routes.go
+++ b/internal/api/routes/management_auth_routes.go
@@ -10,6 +10,8 @@ func registerManagementAuthRoutes(group *gin.RouterGroup, h *managementhandlers.
 	group.GET("/auth-files/models", h.GetAuthFileModels)
 	group.GET("/model-definitions/:channel", h.GetStaticModelDefinitions)
 	group.GET("/image-generation/channels", h.ListImageGenerationChannels)
+	group.GET("/image-generation/size-presets", h.GetImageGenerationSizePresets)
+	group.PUT("/image-generation/size-presets", h.PutImageGenerationSizePresets)
 	group.POST("/image-generation/test", h.PostImageGenerationTest)
 	group.GET("/image-generation/test/:task_id", h.GetImageGenerationTestTask)
 	group.GET("/auth-files/download", h.DownloadAuthFile)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -24,7 +24,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 211; got != want {
+	if got, want := len(routes), 213; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 
@@ -41,6 +41,8 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"PATCH /v0/management/api-key-entries",
 		"POST /v0/management/opencode-go-api-key/usage",
 		"GET /v0/management/auth-files/models",
+		"GET /v0/management/image-generation/size-presets",
+		"PUT /v0/management/image-generation/size-presets",
 		"GET /v0/management/identity-fingerprint/codex/recommendations",
 		"POST /v0/management/oauth-callback",
 		"GET /v0/management/public/ping",

--- a/internal/management/settings/store/runtime_settings.go
+++ b/internal/management/settings/store/runtime_settings.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"encoding/json"
+
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/runtimeconfig"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/runtimeconfigpersist"
@@ -21,7 +23,12 @@ const (
 	RuntimeSettingOAuthExcludedModels  = runtimeconfig.RuntimeSettingOAuthExcludedModels
 	RuntimeSettingOAuthModelAlias      = runtimeconfig.RuntimeSettingOAuthModelAlias
 	RuntimeSettingPayload              = runtimeconfig.RuntimeSettingPayload
+	RuntimeSettingImageSizePresets     = "image-generation-size-presets"
 )
+
+type ImageSizePresetsSetting struct {
+	Sizes []string `json:"sizes"`
+}
 
 func PersistRuntimeSettingsFromConfig(cfg *config.Config) {
 	usage.PersistRuntimeSettingsFromConfig(cfg)
@@ -41,6 +48,32 @@ func ApplyStoredRuntimeSettings(cfg *config.Config) bool {
 
 func UpsertRuntimeSetting(key string, value any) error {
 	return usage.UpsertRuntimeSetting(key, value)
+}
+
+func GetRuntimeSettingPayload(key string) (json.RawMessage, bool) {
+	return usage.GetRuntimeSettingPayload(key)
+}
+
+func LoadImageSizePresetsSetting() []string {
+	payload, ok := GetRuntimeSettingPayload(RuntimeSettingImageSizePresets)
+	if !ok {
+		return nil
+	}
+	var body ImageSizePresetsSetting
+	if err := json.Unmarshal(payload, &body); err != nil {
+		var legacy []string
+		if legacyErr := json.Unmarshal(payload, &legacy); legacyErr != nil {
+			return nil
+		}
+		body.Sizes = legacy
+	}
+	return append([]string(nil), body.Sizes...)
+}
+
+func StoreImageSizePresetsSetting(sizes []string) error {
+	return UpsertRuntimeSetting(RuntimeSettingImageSizePresets, ImageSizePresetsSetting{
+		Sizes: append([]string(nil), sizes...),
+	})
 }
 
 func SaveConfig(cfg *config.Config, configFilePath string) error {

--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"database/sql"
+	"encoding/json"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -40,6 +41,13 @@ func runtimeSettingsStore() sqlsettings.RuntimeSettingsStore {
 
 func UpsertRuntimeSetting(key string, value any) error {
 	return runtimeSettingsStore().Upsert(key, value)
+}
+
+func GetRuntimeSettingPayload(key string) (json.RawMessage, bool) {
+	if !ConfigStoreAvailable() {
+		return nil, false
+	}
+	return runtimeSettingsStore().Payload(key)
 }
 
 func PersistRuntimeSettingsFromConfig(cfg *config.Config) int {


### PR DESCRIPTION
## Summary
- add management APIs to read and persist image generation size presets in runtime_settings
- normalize custom size presets without imposing a maximum edge limit
- register routes and cover defaults, persistence, invalid input, and route table tests

## Tests
- go test ./internal/api/handlers/management ./internal/api/routes
- go test ./...