### PR TITLE
feat: limit image size presets

### DIFF
--- a/internal/api/handlers/management/image_generation.go
+++ b/internal/api/handlers/management/image_generation.go
@@ -24,11 +24,13 @@ import (
 )
 
 const (
-	imageGenerationModel        = "gpt-image-2"
-	imageGenerationAlt          = "images/generations"
-	imageEditsAlt               = "images/edits"
-	imageMaxUploads             = 5
-	imageGenerationSystemAPIKey = "POST /image-generation/test"
+	imageGenerationModel         = "gpt-image-2"
+	imageGenerationAlt           = "images/generations"
+	imageEditsAlt                = "images/edits"
+	imageMaxUploads              = 5
+	imageGenerationSystemAPIKey  = "POST /image-generation/test"
+	imageGenerationMaxSizeEdge   = 8192
+	imageGenerationMaxSizePixels = imageGenerationMaxSizeEdge * imageGenerationMaxSizeEdge
 )
 
 var defaultImageGenerationSizePresets = []string{
@@ -95,9 +97,9 @@ func normalizeImageGenerationSizePresets(values []string) ([]string, error) {
 		if strings.TrimSpace(value) == "" {
 			continue
 		}
-		size, ok := normalizeImageGenerationSizePreset(value)
-		if !ok {
-			return nil, fmt.Errorf("invalid size %q", value)
+		size, err := parseImageGenerationSizePreset(value)
+		if err != nil {
+			return nil, err
 		}
 		if _, exists := seen[size]; exists {
 			continue
@@ -143,29 +145,50 @@ func mergeImageGenerationSizePresets(lists ...[]string) []string {
 }
 
 func normalizeImageGenerationSizePreset(value string) (string, bool) {
+	size, err := parseImageGenerationSizePreset(value)
+	return size, err == nil
+}
+
+func parseImageGenerationSizePreset(value string) (string, error) {
 	normalized := strings.NewReplacer("X", "x", "×", "x", "*", "x").Replace(strings.TrimSpace(value))
 	parts := strings.Split(normalized, "x")
 	if len(parts) != 2 {
-		return "", false
+		return "", fmt.Errorf("invalid size %q", value)
 	}
-	width := strings.TrimSpace(parts[0])
-	height := strings.TrimSpace(parts[1])
-	if !validImageGenerationSizeDimension(width) || !validImageGenerationSizeDimension(height) {
-		return "", false
+	width, ok := parseImageGenerationSizeDimension(strings.TrimSpace(parts[0]))
+	if !ok {
+		return "", fmt.Errorf("invalid size %q", value)
 	}
-	return width + "x" + height, true
+	height, ok := parseImageGenerationSizeDimension(strings.TrimSpace(parts[1]))
+	if !ok {
+		return "", fmt.Errorf("invalid size %q", value)
+	}
+	if width > imageGenerationMaxSizeEdge || height > imageGenerationMaxSizeEdge || width*height > imageGenerationMaxSizePixels {
+		return "", fmt.Errorf(
+			"size %q exceeds maximum %dx%d pixels and %d on either edge",
+			value,
+			imageGenerationMaxSizeEdge,
+			imageGenerationMaxSizeEdge,
+			imageGenerationMaxSizeEdge,
+		)
+	}
+	return strconv.Itoa(width) + "x" + strconv.Itoa(height), nil
 }
 
-func validImageGenerationSizeDimension(value string) bool {
+func parseImageGenerationSizeDimension(value string) (int, bool) {
 	if value == "" || value[0] == '0' {
-		return false
+		return 0, false
 	}
 	for _, char := range value {
 		if char < '0' || char > '9' {
-			return false
+			return 0, false
 		}
 	}
-	return true
+	dimension, err := strconv.Atoi(value)
+	if err != nil || dimension <= 0 {
+		return 0, false
+	}
+	return dimension, true
 }
 
 func (h *Handler) PostImageGenerationTest(c *gin.Context) {

--- a/internal/api/handlers/management/image_generation_test.go
+++ b/internal/api/handlers/management/image_generation_test.go
@@ -506,6 +506,62 @@ func TestImageGenerationSizePresetsRejectInvalidSize(t *testing.T) {
 	}
 }
 
+func TestImageGenerationSizePresetsAcceptMaxSize(t *testing.T) {
+	initManagementModelsTestDB(t)
+
+	h := &Handler{}
+	rec := performModelsRequest(
+		http.MethodPut,
+		"/image-generation/size-presets",
+		[]byte(`{"sizes":["8192x8192"]}`),
+		h.PutImageGenerationSizePresets,
+	)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Sizes []string `json:"sizes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("Unmarshal response: %v", err)
+	}
+	if got := strings.Join(body.Sizes, ","); !strings.Contains(got, "8192x8192") {
+		t.Fatalf("sizes = %v, want 8192x8192", body.Sizes)
+	}
+}
+
+func TestImageGenerationSizePresetsRejectOversizedSize(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "edge", body: `{"sizes":["8193x1024"]}`},
+		{name: "pixels", body: `{"sizes":["8192x8193"]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initManagementModelsTestDB(t)
+
+			h := &Handler{}
+			rec := performModelsRequest(
+				http.MethodPut,
+				"/image-generation/size-presets",
+				[]byte(tt.body),
+				h.PutImageGenerationSizePresets,
+			)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "exceeds maximum") {
+				t.Fatalf("body = %s, want oversized error", rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestPostImageGenerationTestAcceptsMultipartImageEdits(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary
- enforce image size preset max edge/pixel limits in management API
- keep invalid or oversized persisted presets out of merged preset responses
- add tests for max and oversized preset values

## Tests
- rtk python3 scripts/check-backend-structure.py
- rtk go test ./internal/api/handlers/management
- rtk go test ./internal/api/handlers/management ./internal/api/routes
- rtk go test ./...