### PR TITLE
fix: include scoped configured models in catalog

### DIFF
--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -219,6 +219,198 @@ func TestModelConfigHandlersScopeFiltering(t *testing.T) {
 	}
 }
 
+func TestScopedModelsIncludeOwnerMappedConfiguredModels(t *testing.T) {
+	initManagementModelsTestDB(t)
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name: "kimi+deepseek v4 flash",
+					Match: config.ChannelGroupMatch{
+						Channels: []string{"kimi-B", "opencode go"},
+					},
+				},
+			},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "kimi-b",
+		Provider: "kimi",
+		Label:    "kimi-B",
+	}); err != nil {
+		t.Fatalf("Register kimi auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "opencode-go",
+		Provider: "opencode-go",
+		Label:    "opencode go",
+	}); err != nil {
+		t.Fatalf("Register opencode auth: %v", err)
+	}
+	if err := usage.UpsertAuthGroupOwnerMapping(usage.AuthGroupOwnerMappingRow{
+		AuthGroup: "kimi",
+		Owner:     "kimi-code",
+	}); err != nil {
+		t.Fatalf("UpsertAuthGroupOwnerMapping: %v", err)
+	}
+	for _, row := range []usage.ModelConfigRow{
+		{ModelID: "kimi-k2.7", OwnedBy: "kimi-code", Description: "Kimi K2.7", Enabled: true, Source: "seed"},
+		{ModelID: "kimi-k2.7-code", OwnedBy: "kimi-code", Description: "Kimi K2.7 Code", Enabled: true, Source: "seed"},
+		{ModelID: "qwen3.5-plus", OwnedBy: "opencode", Description: "Qwen 3.5 Plus", Enabled: true, Source: "opencode-go"},
+		{ModelID: "kimi-disabled", OwnedBy: "kimi-code", Description: "Disabled Kimi", Enabled: false, Source: "seed"},
+		{ModelID: "other-owner", OwnedBy: "other", Description: "Other owner", Enabled: true, Source: "seed"},
+	} {
+		if err := usage.UpsertModelConfig(row); err != nil {
+			t.Fatalf("UpsertModelConfig(%s): %v", row.ModelID, err)
+		}
+	}
+	h := NewHandler(cfg, "", manager)
+
+	decodeIDs := func(rec *httptest.ResponseRecorder) map[string]struct{} {
+		t.Helper()
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+		}
+		var payload struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		ids := make(map[string]struct{}, len(payload.Data))
+		for _, item := range payload.Data {
+			ids[item.ID] = struct{}{}
+		}
+		return ids
+	}
+
+	models := decodeIDs(performModelsRequest(
+		http.MethodGet,
+		"/models?allowed_channel_groups=kimi%2Bdeepseek+v4+flash",
+		nil,
+		h.Models().GetModels,
+	))
+	for _, id := range []string{"kimi-k2.7", "kimi-k2.7-code", "qwen3.5-plus"} {
+		if _, ok := models[id]; !ok {
+			t.Fatalf("/models missing owner-mapped configured model %q; ids=%v", id, models)
+		}
+	}
+	for _, id := range []string{"kimi-disabled", "other-owner"} {
+		if _, ok := models[id]; ok {
+			t.Fatalf("/models unexpectedly included %q; ids=%v", id, models)
+		}
+	}
+
+	availability := decodeIDs(performModelsRequest(
+		http.MethodGet,
+		"/models/configured-availability?allowed_channel_groups=kimi%2Bdeepseek+v4+flash",
+		nil,
+		h.Models().GetConfiguredModelAvailability,
+	))
+	for _, id := range []string{"kimi-k2.7", "kimi-k2.7-code", "qwen3.5-plus"} {
+		if _, ok := availability[id]; !ok {
+			t.Fatalf("/models/configured-availability missing owner-mapped configured model %q; ids=%v", id, availability)
+		}
+	}
+
+	channelScopedModels := decodeIDs(performModelsRequest(
+		http.MethodGet,
+		"/models?allowed_channels=kimi-B,opencode+go",
+		nil,
+		h.Models().GetModels,
+	))
+	for _, id := range []string{"kimi-k2.7", "kimi-k2.7-code", "qwen3.5-plus"} {
+		if _, ok := channelScopedModels[id]; !ok {
+			t.Fatalf("/models allowed_channels missing configured model %q; ids=%v", id, channelScopedModels)
+		}
+	}
+}
+
+func TestScopedModelsHonorChannelGroupAllowedModelsForConfiguredRows(t *testing.T) {
+	initManagementModelsTestDB(t)
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:          "kimi-limited",
+					AllowedModels: []string{"kimi-k2.7-code"},
+					Match: config.ChannelGroupMatch{
+						Channels: []string{"kimi-B"},
+					},
+				},
+			},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "kimi-b-limited",
+		Provider: "kimi",
+		Label:    "kimi-B",
+	}); err != nil {
+		t.Fatalf("Register kimi auth: %v", err)
+	}
+	if err := usage.UpsertAuthGroupOwnerMapping(usage.AuthGroupOwnerMappingRow{
+		AuthGroup: "kimi",
+		Owner:     "kimi-code",
+	}); err != nil {
+		t.Fatalf("UpsertAuthGroupOwnerMapping: %v", err)
+	}
+	for _, row := range []usage.ModelConfigRow{
+		{ModelID: "kimi-k2.7", OwnedBy: "kimi-code", Description: "Kimi K2.7", Enabled: true, Source: "seed"},
+		{ModelID: "kimi-k2.7-code", OwnedBy: "kimi-code", Description: "Kimi K2.7 Code", Enabled: true, Source: "seed"},
+	} {
+		if err := usage.UpsertModelConfig(row); err != nil {
+			t.Fatalf("UpsertModelConfig(%s): %v", row.ModelID, err)
+		}
+	}
+	h := NewHandler(cfg, "", manager)
+	rec := performModelsRequest(
+		http.MethodGet,
+		"/models/configured-availability?allowed_channel_groups=kimi-limited",
+		nil,
+		h.Models().GetConfiguredModelAvailability,
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+		ActiveMetadata []struct {
+			ID string `json:"id"`
+		} `json:"active_metadata"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	ids := make(map[string]struct{}, len(payload.Data))
+	for _, item := range payload.Data {
+		ids[item.ID] = struct{}{}
+	}
+	if _, ok := ids["kimi-k2.7-code"]; !ok {
+		t.Fatalf("expected allowed configured model in response; ids=%v", ids)
+	}
+	if _, ok := ids["kimi-k2.7"]; ok {
+		t.Fatalf("did not expect configured model outside group allowed-models; ids=%v", ids)
+	}
+	metadataIDs := make(map[string]struct{}, len(payload.ActiveMetadata))
+	for _, item := range payload.ActiveMetadata {
+		metadataIDs[item.ID] = struct{}{}
+	}
+	if _, ok := metadataIDs["kimi-k2.7-code"]; !ok {
+		t.Fatalf("expected allowed configured model metadata; ids=%v", metadataIDs)
+	}
+	if _, ok := metadataIDs["kimi-k2.7"]; ok {
+		t.Fatalf("did not expect metadata outside group allowed-models; ids=%v", metadataIDs)
+	}
+}
+
 func TestModelOwnerPresetHandlersReplacePresets(t *testing.T) {
 	initManagementModelsTestDB(t)
 	h := NewHandler(&config.Config{}, "", nil)

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -7,14 +7,15 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 // Availability contract:
 // - Owner: model availability query boundary.
 // - Responsibility: turn registry state plus stored capabilities into management-facing availability DTOs.
-func (s *Service) ConfiguredAvailability(allowedRaw, allowedGroupsRaw string) map[string]any {
+func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
 	modelRegistry := registry.GetGlobalRegistry()
-	allModels := s.filterModelsByScopes(modelRegistry.GetAvailableModels("openai"), allowedRaw, allowedGroupsRaw)
+	allModels := s.effectiveModels(modelRegistry.GetAvailableModels("openai"), allowedChannelsRaw, allowedGroupsRaw)
 
 	allConfigRows := modelconfigsettings.ListAllConfigs()
 	configByID := make(map[string]usage.ModelConfigRow, len(allConfigRows))
@@ -23,6 +24,7 @@ func (s *Service) ConfiguredAvailability(allowedRaw, allowedGroupsRaw string) ma
 	}
 
 	data := make([]map[string]any, 0, len(allModels))
+	activeMetadata := make([]map[string]any, 0, len(allModels))
 	for _, model := range allModels {
 		id, _ := model["id"].(string)
 		id = strings.TrimSpace(id)
@@ -54,19 +56,16 @@ func (s *Service) ConfiguredAvailability(allowedRaw, allowedGroupsRaw string) ma
 			if row.Source != "" {
 				entry["metadata_source"] = row.Source
 			}
+			if row.Enabled {
+				activeMetadata = append(activeMetadata, map[string]any{
+					"id":       row.ModelID,
+					"owned_by": row.OwnedBy,
+					"source":   row.Source,
+					"enabled":  row.Enabled,
+				})
+			}
 		}
 		data = append(data, entry)
-	}
-
-	activeRows := modelconfigsettings.ListConfigs("active")
-	activeMetadata := make([]map[string]any, 0, len(activeRows))
-	for _, row := range activeRows {
-		activeMetadata = append(activeMetadata, map[string]any{
-			"id":       row.ModelID,
-			"owned_by": row.OwnedBy,
-			"source":   row.Source,
-			"enabled":  row.Enabled,
-		})
 	}
 
 	return map[string]any{
@@ -77,9 +76,9 @@ func (s *Service) ConfiguredAvailability(allowedRaw, allowedGroupsRaw string) ma
 	}
 }
 
-func (s *Service) Models(allowedRaw, allowedGroupsRaw string) map[string]any {
+func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
 	modelRegistry := registry.GetGlobalRegistry()
-	allModels := s.filterModelsByScopes(modelRegistry.GetAvailableModels("openai"), allowedRaw, allowedGroupsRaw)
+	allModels := s.effectiveModels(modelRegistry.GetAvailableModels("openai"), allowedChannelsRaw, allowedGroupsRaw)
 
 	pricingMap := usage.GetAllModelPricing()
 	filteredModels := make([]map[string]any, len(allModels))
@@ -115,15 +114,20 @@ func (s *Service) Models(allowedRaw, allowedGroupsRaw string) map[string]any {
 	}
 }
 
-func (s *Service) filterModelsByScopes(models []map[string]any, allowedRaw, allowedGroupsRaw string) []map[string]any {
-	allowedRaw = strings.TrimSpace(allowedRaw)
+func (s *Service) effectiveModels(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string) []map[string]any {
+	filtered := s.filterModelsByScopes(models, allowedChannelsRaw, allowedGroupsRaw)
+	return s.withScopedModelConfigRows(filtered, allowedChannelsRaw, allowedGroupsRaw)
+}
+
+func (s *Service) filterModelsByScopes(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string) []map[string]any {
+	allowedChannelsRaw = strings.TrimSpace(allowedChannelsRaw)
 	allowedGroups := internalrouting.ParseNormalizedSet(strings.TrimSpace(allowedGroupsRaw), internalrouting.NormalizeGroupName)
 	if s == nil || s.authManager == nil {
 		return models
 	}
-	if allowedRaw != "" && allowedRaw != "*" && !strings.EqualFold(allowedRaw, "all") {
+	if allowedChannelsRaw != "" && allowedChannelsRaw != "*" && !strings.EqualFold(allowedChannelsRaw, "all") {
 		allowed := make(map[string]struct{})
-		for _, part := range strings.Split(allowedRaw, ",") {
+		for _, part := range strings.Split(allowedChannelsRaw, ",") {
 			key := strings.ToLower(strings.TrimSpace(part))
 			if key == "" {
 				continue
@@ -159,4 +163,264 @@ func (s *Service) filterModelsByScopes(models []map[string]any, allowedRaw, allo
 		}
 	}
 	return filtered
+}
+
+func (s *Service) withScopedModelConfigRows(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string) []map[string]any {
+	rows := s.scopedModelConfigRows(allowedChannelsRaw, allowedGroupsRaw)
+	if len(rows) == 0 {
+		return models
+	}
+	out := make([]map[string]any, 0, len(models)+len(rows))
+	seen := make(map[string]struct{}, len(models)+len(rows))
+	for _, model := range models {
+		id, _ := model["id"].(string)
+		key := strings.ToLower(strings.TrimSpace(id))
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, model)
+	}
+	for _, row := range rows {
+		key := strings.ToLower(strings.TrimSpace(row.ModelID))
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, modelConfigRowAsOpenAIModel(row))
+	}
+	return out
+}
+
+func (s *Service) scopedModelConfigRows(allowedChannelsRaw, allowedGroupsRaw string) []usage.ModelConfigRow {
+	allowedGroups := internalrouting.ParseNormalizedSet(strings.TrimSpace(allowedGroupsRaw), internalrouting.NormalizeGroupName)
+	allowedChannels := parseScopedChannelList(allowedChannelsRaw)
+	if len(allowedGroups) == 0 && len(allowedChannels) == 0 {
+		return nil
+	}
+	ownerKeys, explicitModels := s.modelOwnerScope(allowedChannels, allowedGroups)
+	if len(ownerKeys) == 0 && len(explicitModels) == 0 {
+		return nil
+	}
+	rows := modelconfigsettings.ListAllConfigs()
+	out := make([]usage.ModelConfigRow, 0, len(rows))
+	for _, row := range rows {
+		modelID := strings.TrimSpace(row.ModelID)
+		if modelID == "" || !row.Enabled {
+			continue
+		}
+		if len(explicitModels) > 0 {
+			if _, ok := explicitModels[strings.ToLower(modelID)]; !ok {
+				continue
+			}
+			out = append(out, row)
+			continue
+		}
+		if ownerKeys[normalizeModelOwnerKey(row.OwnedBy)] || ownerKeys[normalizeModelOwnerKey(row.Source)] {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func parseScopedChannelList(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "*" || strings.EqualFold(value, "all") {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, part := range strings.Split(value, ",") {
+		channel := strings.TrimSpace(part)
+		key := strings.ToLower(channel)
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, channel)
+	}
+	return out
+}
+
+func (s *Service) modelOwnerScope(channels []string, groups map[string]struct{}) (map[string]bool, map[string]struct{}) {
+	ownerMappings := authGroupOwnerMappingMap()
+	providerOwners := modelConfigOwnersBySource()
+	ownerKeys := make(map[string]bool)
+	explicitModels := make(map[string]struct{})
+	if s == nil {
+		return ownerKeys, explicitModels
+	}
+	auths := []*coreauth.Auth(nil)
+	if s.authManager != nil {
+		auths = s.authManager.List()
+	}
+	addOwnersForChannel := func(channel string) {
+		for _, owner := range ownersForChannel(channel, auths, ownerMappings, providerOwners) {
+			ownerKeys[owner] = true
+		}
+	}
+	if s.cfg != nil {
+		for _, group := range s.cfg.Routing.ChannelGroups {
+			groupName := internalrouting.NormalizeGroupName(group.Name)
+			if _, ok := groups[groupName]; !ok {
+				continue
+			}
+			for _, model := range group.AllowedModels {
+				model = strings.ToLower(strings.TrimSpace(model))
+				if model != "" {
+					explicitModels[model] = struct{}{}
+				}
+			}
+			for _, channel := range group.Match.Channels {
+				addOwnersForChannel(channel)
+			}
+		}
+	}
+	if len(groups) == 0 {
+		for _, channel := range channels {
+			addOwnersForChannel(channel)
+		}
+	}
+	return ownerKeys, explicitModels
+}
+
+func authGroupOwnerMappingMap() map[string]string {
+	rows := modelconfigsettings.ListAuthGroupOwnerMappings()
+	out := make(map[string]string, len(rows))
+	for _, row := range rows {
+		authGroup := normalizeAuthGroupKey(row.AuthGroup)
+		owner := normalizeModelOwnerKey(row.Owner)
+		if authGroup == "" || owner == "" {
+			continue
+		}
+		out[authGroup] = owner
+	}
+	return out
+}
+
+func modelConfigOwnersBySource() map[string][]string {
+	rows := modelconfigsettings.ListAllConfigs()
+	ownersBySource := make(map[string]map[string]struct{})
+	for _, row := range rows {
+		if !row.Enabled {
+			continue
+		}
+		source := normalizeAuthGroupKey(row.Source)
+		owner := normalizeModelOwnerKey(row.OwnedBy)
+		if source == "" || owner == "" {
+			continue
+		}
+		if ownersBySource[source] == nil {
+			ownersBySource[source] = make(map[string]struct{})
+		}
+		ownersBySource[source][owner] = struct{}{}
+	}
+	out := make(map[string][]string, len(ownersBySource))
+	for source, owners := range ownersBySource {
+		for owner := range owners {
+			out[source] = append(out[source], owner)
+		}
+	}
+	return out
+}
+
+func ownersForChannel(channel string, auths []*coreauth.Auth, ownerMappings map[string]string, providerOwners map[string][]string) []string {
+	channel = strings.TrimSpace(channel)
+	if channel == "" {
+		return nil
+	}
+	owners := make(map[string]bool)
+	addMappedOwner := func(value string) {
+		key := normalizeAuthGroupKey(value)
+		if key == "" {
+			return
+		}
+		if owner := ownerMappings[key]; owner != "" {
+			owners[owner] = true
+		}
+	}
+	addProviderOwners := func(value string) {
+		key := normalizeAuthGroupKey(value)
+		if key == "" {
+			return
+		}
+		for _, owner := range providerOwners[key] {
+			if owner != "" {
+				owners[owner] = true
+			}
+		}
+	}
+	addMappedOwner(channel)
+	addProviderOwners(channel)
+	for _, auth := range auths {
+		if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+			continue
+		}
+		if !authChannelMatches(auth, channel) {
+			continue
+		}
+		addMappedOwner(auth.Provider)
+		addMappedOwner(auth.ChannelName())
+		addProviderOwners(auth.Provider)
+		addProviderOwners(auth.ChannelName())
+		for _, identifier := range auth.ChannelIdentifiers() {
+			addMappedOwner(identifier)
+			addProviderOwners(identifier)
+		}
+	}
+	out := make([]string, 0, len(owners))
+	for owner := range owners {
+		out = append(out, owner)
+	}
+	return out
+}
+
+func authChannelMatches(auth *coreauth.Auth, channel string) bool {
+	if auth == nil {
+		return false
+	}
+	for _, identifier := range auth.ChannelIdentifiers() {
+		if strings.EqualFold(strings.TrimSpace(identifier), channel) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeAuthGroupKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeModelOwnerKey(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), "-"))
+}
+
+func modelConfigRowAsOpenAIModel(row usage.ModelConfigRow) map[string]any {
+	entry := map[string]any{
+		"id":          row.ModelID,
+		"object":      "model",
+		"owned_by":    row.OwnedBy,
+		"source":      row.Source,
+		"description": row.Description,
+		"pricing": map[string]any{
+			"mode":                          row.PricingMode,
+			"input_price_per_million":       row.InputPricePerMillion,
+			"output_price_per_million":      row.OutputPricePerMillion,
+			"cached_price_per_million":      row.CachedPricePerMillion,
+			"cache_read_price_per_million":  row.CacheReadPricePerMillion,
+			"cache_write_price_per_million": row.CacheWritePricePerMillion,
+			"price_per_call":                row.PricePerCall,
+		},
+	}
+	attachModelConfigCapabilities(entry, row)
+	return entry
 }


### PR DESCRIPTION
## Summary
- include enabled model-config rows in scoped /models and /models/configured-availability responses
- derive scoped owners from channel groups, auth group owner mappings, and configured model source owners
- keep active_metadata scoped to the same availability result

## Tests
- rtk go test ./internal/api/handlers/management ./internal/management/modelcatalog
- rtk go test ./internal/api/handlers/management ./internal/management/modelcatalog ./internal/usage