### PR TITLE
fix: record upstream OpenAI compatible usage model

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -165,6 +165,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	recorder.AppendResponseChunk(body)
+	reporter.setModel(parseOpenAIResponseModel(body))
 	reporter.publishWithContent(execCtx.Context, parseOpenAIUsage(body), string(req.Payload), string(body))
 	// Ensure we at least record the request even if upstream doesn't return usage
 	reporter.ensurePublished(execCtx.Context)
@@ -271,6 +272,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			line := scanner.Bytes()
 			recorder.AppendResponseChunk(line)
 			reporter.appendOutputChunk(line)
+			reporter.setModel(parseOpenAIStreamModel(line))
 			if detail, ok := parseOpenAIStreamUsage(line); ok {
 				reporter.publish(execCtx.Context, detail)
 			}

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	"github.com/tidwall/gjson"
 )
@@ -111,6 +113,45 @@ func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	}
 	if string(resp.Payload) != `{"id":"resp_1","object":"response.compaction","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}` {
 		t.Fatalf("payload = %s", string(resp.Payload))
+	}
+}
+
+func TestOpenAICompatExecutorUsageUsesUpstreamResponseModel(t *testing.T) {
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 4)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","model":"gpt-5.4","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "codex-auto-review",
+		Payload: []byte(`{"model":"codex-auto-review","input":"ping"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Alt:          "responses/compact",
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	timer := time.After(time.Second)
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Model == "gpt-5.4" {
+				return
+			}
+		case <-timer:
+			t.Fatal("timed out waiting for usage record with model gpt-5.4")
+		}
 	}
 }
 

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -57,6 +57,15 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIResponseModel(t *testing.T) {
+	if got := parseOpenAIResponseModel([]byte(`{"model":"gpt-5.4","usage":{"total_tokens":1}}`)); got != "gpt-5.4" {
+		t.Fatalf("model = %q, want gpt-5.4", got)
+	}
+	if got := parseOpenAIStreamModel([]byte(`data: {"model":"gpt-5.4-mini-2026-03-17","usage":{"total_tokens":1}}`)); got != "gpt-5.4-mini-2026-03-17" {
+		t.Fatalf("stream model = %q, want gpt-5.4-mini-2026-03-17", got)
+	}
+}
+
 func TestUsageReporterSpillsLargeStreamingOutputToTempFile(t *testing.T) {
 	reporter := newUsageReporter(context.Background(), "provider", "model", nil)
 	chunk := bytes.Repeat([]byte("x"), usageReporterOutputMemoryLimit/2)

--- a/internal/runtime/executor/usage_parsers.go
+++ b/internal/runtime/executor/usage_parsers.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"strings"
+
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	"github.com/tidwall/gjson"
 )
@@ -61,6 +63,21 @@ func parseOpenAIUsage(data []byte) usage.Detail {
 		detail.ReasoningTokens = reasoning.Int()
 	}
 	return detail
+}
+
+func parseOpenAIResponseModel(data []byte) string {
+	if len(data) == 0 || !gjson.ValidBytes(data) {
+		return ""
+	}
+	return strings.TrimSpace(gjson.GetBytes(data, "model").String())
+}
+
+func parseOpenAIStreamModel(line []byte) string {
+	payload := jsonPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return ""
+	}
+	return strings.TrimSpace(gjson.GetBytes(payload, "model").String())
 }
 
 func parseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -74,6 +74,15 @@ func (r *usageReporter) publishWithContent(ctx context.Context, detail coreusage
 	r.publishWithOutcome(ctx, detail, false)
 }
 
+func (r *usageReporter) setModel(model string) {
+	if r == nil {
+		return
+	}
+	if model = strings.TrimSpace(model); model != "" {
+		r.model = model
+	}
+}
+
 // setInputContent stores the request payload for inclusion in usage records.
 // Call before starting the streaming goroutine.
 func (r *usageReporter) setInputContent(content string) {


### PR DESCRIPTION
## Summary
- record OpenAI-compatible usage logs with the upstream response model when present
- cover codex-auto-review returning gpt-5.4 in executor usage logging

## Tests
- rtk git diff --check
- rtk go test ./internal/runtime/executor -count=1