### PR TITLE
fix: address reproducible proxy bugs

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,8 @@ const (
 	updateCommandTimeout = 10 * time.Minute
 	maxUpdateLogEntries  = 200
 )
+
+var errRequestedImageNotAllowed = errors.New("requested image is not allowed")
 
 type composeRunner func(ctx context.Context, composeFile string, envFile string, projectName string, service string, reporter updateReporter) error
 
@@ -181,6 +184,13 @@ func (s *updaterServer) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := persistRequestedImage(s.envFile, req.Image, req.Tag); err != nil {
+		if errors.Is(err, errRequestedImageNotAllowed) {
+			message := err.Error()
+			log.Print(message)
+			s.setStatus("failed", message)
+			http.Error(w, message, http.StatusBadRequest)
+			return
+		}
 		message := "failed to update env file: " + err.Error()
 		log.Print(message)
 		s.setStatus("failed", message)
@@ -213,17 +223,35 @@ func (s *updaterServer) handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 func persistRequestedImage(envFile string, image string, tag string) error {
 	imageRef := requestedImageRef(image, tag)
-	if imageRef == "" || strings.TrimSpace(envFile) == "" {
+	if imageRef == "" {
+		if strings.TrimSpace(image) == "" && strings.TrimSpace(tag) == "" {
+			return nil
+		}
+		return fmt.Errorf("%w: invalid image or tag", errRequestedImageNotAllowed)
+	}
+	if strings.TrimSpace(envFile) == "" {
 		return nil
 	}
 
 	data, err := os.ReadFile(envFile)
-	if err != nil && !os.IsNotExist(err) {
+	if os.IsNotExist(err) {
+		return fmt.Errorf("%w: missing configured CLI_PROXY_IMAGE", errRequestedImageNotAllowed)
+	}
+	if err != nil {
 		return err
 	}
 
-	line := "CLI_PROXY_IMAGE=" + imageRef
 	lines := splitEnvLines(string(data))
+	configuredRepo := imageRepository(configuredImageRef(lines))
+	requestedRepo := imageRepository(imageRef)
+	if configuredRepo == "" {
+		return fmt.Errorf("%w: missing configured CLI_PROXY_IMAGE", errRequestedImageNotAllowed)
+	}
+	if requestedRepo != configuredRepo {
+		return fmt.Errorf("%w: %s does not match %s", errRequestedImageNotAllowed, requestedRepo, configuredRepo)
+	}
+
+	line := "CLI_PROXY_IMAGE=" + imageRef
 	replaced := false
 	for i, existing := range lines {
 		if strings.HasPrefix(existing, "CLI_PROXY_IMAGE=") {
@@ -237,6 +265,33 @@ func persistRequestedImage(envFile string, image string, tag string) error {
 	}
 	content := strings.Join(lines, "\n") + "\n"
 	return os.WriteFile(envFile, []byte(content), 0o600)
+}
+
+func configuredImageRef(lines []string) string {
+	for _, line := range lines {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "CLI_PROXY_IMAGE" {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(value), `"'`)
+	}
+	return ""
+}
+
+func imageRepository(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if digestIndex := strings.Index(ref, "@"); digestIndex >= 0 {
+		return ref[:digestIndex]
+	}
+	lastSlash := strings.LastIndex(ref, "/")
+	lastColon := strings.LastIndex(ref, ":")
+	if lastColon > lastSlash {
+		return ref[:lastColon]
+	}
+	return ref
 }
 
 func requestedImageRef(image string, tag string) string {
@@ -278,13 +333,13 @@ func isSafeImagePart(value string) bool {
 
 func (s *updaterServer) authorized(r *http.Request) bool {
 	if s.token == "" {
-		return true
+		return false
 	}
 	value := strings.TrimSpace(r.Header.Get("Authorization"))
 	if strings.HasPrefix(strings.ToLower(value), "bearer ") {
 		value = strings.TrimSpace(value[len("Bearer "):])
 	}
-	return value == s.token
+	return subtle.ConstantTimeCompare([]byte(value), []byte(s.token)) == 1
 }
 
 func (s *updaterServer) startUpdate(service string, req updateRequest) uint64 {

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -13,11 +13,32 @@ import (
 	"time"
 )
 
+func setUpdaterAuth(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer secret")
+}
+
 func TestUpdaterRejectsInvalidBearerToken(t *testing.T) {
 	server := newUpdaterServer(updaterConfig{
 		Token: "secret",
 		Runner: func(context.Context, string, string, string, string, updateReporter) error {
 			t.Fatal("runner should not be called")
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/update", strings.NewReader(`{"service":"clirelay"}`))
+	rec := httptest.NewRecorder()
+
+	server.handleUpdate(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestUpdaterRejectsRequestsWhenConfiguredTokenIsEmpty(t *testing.T) {
+	server := newUpdaterServer(updaterConfig{
+		Runner: func(context.Context, string, string, string, string, updateReporter) error {
 			return nil
 		},
 	})
@@ -51,6 +72,7 @@ func TestUpdaterPersistsRequestedImageBeforeComposeUpdate(t *testing.T) {
 
 	called := make(chan struct{}, 1)
 	server := newUpdaterServer(updaterConfig{
+		Token:   "secret",
 		EnvFile: envFile,
 		Runner: func(_ context.Context, _ string, _ string, _ string, _ string, reporter updateReporter) error {
 			data, err := os.ReadFile(envFile)
@@ -76,6 +98,7 @@ func TestUpdaterPersistsRequestedImageBeforeComposeUpdate(t *testing.T) {
 		"/v1/update",
 		strings.NewReader(`{"service":"cli-proxy-api","image":"ghcr.io/kittors/clirelay","tag":"latest"}`),
 	)
+	setUpdaterAuth(req)
 	rec := httptest.NewRecorder()
 
 	server.handleUpdate(rec, req)
@@ -92,16 +115,14 @@ func TestUpdaterPersistsRequestedImageBeforeComposeUpdate(t *testing.T) {
 }
 
 func TestUpdaterRejectsRequestWhenEnvFileCannotBeUpdated(t *testing.T) {
-	envDir := filepath.Join(t.TempDir(), "readonly")
-	if err := os.Mkdir(envDir, 0o500); err != nil {
-		t.Fatalf("make readonly dir: %v", err)
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.Mkdir(envFile, 0o700); err != nil {
+		t.Fatalf("make env path directory: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = os.Chmod(envDir, 0o700)
-	})
 
 	server := newUpdaterServer(updaterConfig{
-		EnvFile: filepath.Join(envDir, ".env"),
+		Token:   "secret",
+		EnvFile: envFile,
 		Runner: func(_ context.Context, _ string, _ string, _ string, _ string, _ updateReporter) error {
 			t.Fatal("runner should not be called when env file cannot be updated")
 			return nil
@@ -113,6 +134,7 @@ func TestUpdaterRejectsRequestWhenEnvFileCannotBeUpdated(t *testing.T) {
 		"/v1/update",
 		strings.NewReader(`{"service":"cli-proxy-api","image":"ghcr.io/kittors/clirelay","tag":"dev"}`),
 	)
+	setUpdaterAuth(req)
 	rec := httptest.NewRecorder()
 
 	server.handleUpdate(rec, req)
@@ -122,6 +144,49 @@ func TestUpdaterRejectsRequestWhenEnvFileCannotBeUpdated(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "failed to update env file") {
 		t.Fatalf("body = %q, want env update failure", rec.Body.String())
+	}
+}
+
+func TestUpdaterRejectsRequestedImageRepositoryChange(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:dev\n"), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	called := make(chan struct{}, 1)
+	server := newUpdaterServer(updaterConfig{
+		Token:   "secret",
+		EnvFile: envFile,
+		Runner: func(_ context.Context, _ string, _ string, _ string, _ string, _ updateReporter) error {
+			called <- struct{}{}
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/update",
+		strings.NewReader(`{"service":"cli-proxy-api","image":"ghcr.io/attacker/clirelay","tag":"latest"}`),
+	)
+	setUpdaterAuth(req)
+	rec := httptest.NewRecorder()
+
+	server.handleUpdate(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	if string(data) != "CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:dev\n" {
+		t.Fatalf("env file content = %q, want unchanged", string(data))
+	}
+	select {
+	case <-called:
+		t.Fatal("runner should not be called")
+	default:
 	}
 }
 
@@ -171,8 +236,13 @@ func TestUpdaterAcceptsRequestAndRunsComposeUpdate(t *testing.T) {
 func TestUpdaterStatusExposesTargetStageAndLogs(t *testing.T) {
 	called := make(chan struct{}, 1)
 	releaseRunner := make(chan struct{})
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:old\n"), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
 	server := newUpdaterServer(updaterConfig{
-		EnvFile: filepath.Join(t.TempDir(), ".env"),
+		Token:   "secret",
+		EnvFile: envFile,
 		Runner: func(_ context.Context, _ string, _ string, _ string, service string, reporter updateReporter) error {
 			reporter.Stage("pulling", "pulling image")
 			reporter.Log("stdout", "docker compose pull "+service)
@@ -189,6 +259,7 @@ func TestUpdaterStatusExposesTargetStageAndLogs(t *testing.T) {
 		"/v1/update",
 		strings.NewReader(`{"service":"clirelay","image":"ghcr.io/kittors/clirelay","tag":"dev","version":"dev-abcdef1","commit":"abcdef123456","channel":"dev"}`),
 	)
+	setUpdaterAuth(req)
 	rec := httptest.NewRecorder()
 	server.handleUpdate(rec, req)
 	if rec.Code != http.StatusAccepted {
@@ -202,7 +273,9 @@ func TestUpdaterStatusExposesTargetStageAndLogs(t *testing.T) {
 	}
 
 	statusRec := httptest.NewRecorder()
-	server.handleStatus(statusRec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+	statusReq := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+	setUpdaterAuth(statusReq)
+	server.handleStatus(statusRec, statusReq)
 	if statusRec.Code != http.StatusOK {
 		t.Fatalf("status endpoint code = %d, body=%s", statusRec.Code, statusRec.Body.String())
 	}
@@ -232,8 +305,13 @@ func TestUpdaterStatusExposesTargetStageAndLogs(t *testing.T) {
 
 func TestUpdaterFailsWhenComposePullSkipsTargetService(t *testing.T) {
 	called := make(chan struct{}, 1)
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:old\n"), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
 	server := newUpdaterServer(updaterConfig{
-		EnvFile: filepath.Join(t.TempDir(), ".env"),
+		Token:   "secret",
+		EnvFile: envFile,
 		Runner: func(_ context.Context, _ string, _ string, _ string, service string, reporter updateReporter) error {
 			reporter.Stage("pulling", "pulling image")
 			reporter.Log("stdout", "docker compose pull "+service)
@@ -250,6 +328,7 @@ func TestUpdaterFailsWhenComposePullSkipsTargetService(t *testing.T) {
 		"/v1/update",
 		strings.NewReader(`{"service":"cli-proxy-api","image":"ghcr.io/kittors/clirelay","tag":"dev","version":"dev-6704f60","commit":"6704f60ee834bce20e22fc65e67868801f483e32","channel":"dev"}`),
 	)
+	setUpdaterAuth(req)
 	rec := httptest.NewRecorder()
 	server.handleUpdate(rec, req)
 	if rec.Code != http.StatusAccepted {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -386,7 +386,10 @@ func TestResolveTokenForAuth_Claude_SkipsRefreshWhenTokenValid(t *testing.T) {
 func TestAPICallReconcilesCodexWhamUsagePlanType(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != "93.184.216.34" {
+			t.Fatalf("unexpected proxy host: %s", r.Host)
+		}
 		if r.URL.Path != "/backend-api/wham/usage" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -399,7 +402,7 @@ func TestAPICallReconcilesCodexWhamUsagePlanType(t *testing.T) {
 			"plan_type": "free",
 		})
 	}))
-	t.Cleanup(upstream.Close)
+	t.Cleanup(proxy.Close)
 
 	store := &memoryAuthStore{}
 	manager := coreauth.NewManager(store, nil, nil)
@@ -424,7 +427,7 @@ func TestAPICallReconcilesCodexWhamUsagePlanType(t *testing.T) {
 	requestBody, err := json.Marshal(map[string]any{
 		"authIndex": registered.Index,
 		"method":    "GET",
-		"url":       upstream.URL + "/backend-api/wham/usage",
+		"url":       "http://93.184.216.34/backend-api/wham/usage",
 		"header": map[string]string{
 			"Authorization": "Bearer $TOKEN$",
 		},
@@ -433,7 +436,7 @@ func TestAPICallReconcilesCodexWhamUsagePlanType(t *testing.T) {
 		t.Fatalf("marshal request body: %v", err)
 	}
 
-	h := &Handler{cfg: &config.Config{}, authManager: manager}
+	h := &Handler{cfg: &config.Config{SDKConfig: config.SDKConfig{ProxyURL: proxy.URL}}, authManager: manager}
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/api-call", bytes.NewReader(requestBody))
@@ -467,23 +470,72 @@ func TestAPICallReconcilesCodexWhamUsagePlanType(t *testing.T) {
 	}
 }
 
+func TestAPICallRejectsLoopbackTarget(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{cfg: &config.Config{}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"method":"GET","url":"http://127.0.0.1:1/metadata"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/api-call", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	h.APITools().APICall(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "blocked url") {
+		t.Fatalf("expected blocked url error, got body=%s", rec.Body.String())
+	}
+}
+
+func TestAPICallRejectsRedirectToLoopbackTarget(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://127.0.0.1:1/metadata", http.StatusFound)
+	}))
+	t.Cleanup(proxy.Close)
+
+	h := &Handler{cfg: &config.Config{SDKConfig: config.SDKConfig{ProxyURL: proxy.URL}}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"method":"GET","url":"http://93.184.216.34/redirect"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/api-call", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	h.APITools().APICall(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "blocked url") {
+		t.Fatalf("expected blocked url error, got body=%s", rec.Body.String())
+	}
+}
+
 func TestAPICallRejectsOversizedUpstreamResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", r.Method)
 		}
 		w.Header().Set("Content-Type", "text/plain")
 		_, _ = w.Write(bytes.Repeat([]byte("a"), int(managementAPICallResponseLimit)+1))
 	}))
-	t.Cleanup(upstream.Close)
+	t.Cleanup(proxy.Close)
 
-	h := &Handler{cfg: &config.Config{}}
+	h := &Handler{cfg: &config.Config{SDKConfig: config.SDKConfig{ProxyURL: proxy.URL}}}
 
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
-	body := []byte(`{"method":"GET","url":"` + upstream.URL + `"}`)
+	body := []byte(`{"method":"GET","url":"http://93.184.216.34/large"}`)
 	req := httptest.NewRequest(http.MethodPost, "/v0/management/api-call", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	c.Request = req

--- a/internal/api/modules/amp/amp_test.go
+++ b/internal/api/modules/amp/amp_test.go
@@ -2,6 +2,7 @@ package amp
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -14,6 +15,15 @@ import (
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 )
+
+func requireAmpAuth(c *gin.Context) {
+	if c.GetHeader("Authorization") != "Bearer client-key" {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+	c.Set("apiKey", "client-key")
+	c.Next()
+}
 
 func TestAmpModule_Name(t *testing.T) {
 	m := New()
@@ -75,6 +85,51 @@ func TestAmpModule_Register_WithUpstream(t *testing.T) {
 	}
 	if m.secretSource == nil {
 		t.Fatal("secretSource should be initialized")
+	}
+}
+
+func TestAmpModule_RootRoutesRequireAuthBeforeProxy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	upstreamHit := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit <- r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer upstream.Close()
+
+	m := NewLegacy(sdkaccess.NewManager(), requireAmpAuth)
+	ctx := modules.Context{
+		Engine:      r,
+		BaseHandler: &handlers.BaseAPIHandler{},
+		Config: &config.Config{AmpCode: config.AmpCode{
+			UpstreamURL:    upstream.URL,
+			UpstreamAPIKey: "upstream-key",
+		}},
+		AuthMiddleware: requireAmpAuth,
+	}
+	if err := m.Register(ctx); err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+
+	server := httptest.NewServer(r)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/threads")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	select {
+	case headers := <-upstreamHit:
+		t.Fatalf("upstream should not be reached; got X-Api-Key=%q", headers.Get("X-Api-Key"))
+	default:
 	}
 }
 

--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -127,20 +127,6 @@ func (m *AmpModule) managementAvailabilityMiddleware() gin.HandlerFunc {
 	}
 }
 
-// wrapManagementAuth skips auth for selected management paths while keeping authentication elsewhere.
-func wrapManagementAuth(auth gin.HandlerFunc, prefixes ...string) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		path := c.Request.URL.Path
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(path, prefix) && (len(path) == len(prefix) || path[len(prefix)] == '/') {
-				c.Next()
-				return
-			}
-		}
-		auth(c)
-	}
-}
-
 // registerManagementRoutes registers Amp management proxy routes
 // These routes proxy through to the Amp control plane for OAuth, user management, etc.
 // Uses dynamic middleware and proxy getter for hot-reload support.
@@ -155,10 +141,8 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	ampAPI.Use(m.localhostOnlyMiddleware())
 
 	// Apply authentication middleware - requires valid API key in Authorization header
-	var authWithBypass gin.HandlerFunc
 	if auth != nil {
 		ampAPI.Use(auth)
-		authWithBypass = wrapManagementAuth(auth, "/threads", "/auth", "/docs", "/settings")
 	}
 
 	// Inject client API key into request context for per-client upstream routing
@@ -207,8 +191,8 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	// Root-level routes that AMP CLI expects without /api prefix
 	// These need the same security middleware as the /api/* routes (dynamic for hot-reload)
 	rootMiddleware := []gin.HandlerFunc{m.managementAvailabilityMiddleware(), noCORSMiddleware(), m.localhostOnlyMiddleware()}
-	if authWithBypass != nil {
-		rootMiddleware = append(rootMiddleware, authWithBypass)
+	if auth != nil {
+		rootMiddleware = append(rootMiddleware, auth)
 	}
 	// Add clientAPIKeyMiddleware after auth for per-client upstream routing
 	rootMiddleware = append(rootMiddleware, clientAPIKeyMiddleware())

--- a/internal/management/apitools/api_call.go
+++ b/internal/management/apitools/api_call.go
@@ -3,8 +3,11 @@ package apitools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
 	"time"
@@ -15,6 +18,26 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
 )
+
+var errBlockedAPICallTarget = errors.New("blocked api-call target")
+
+var blockedAPICallPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+}
 
 func (s *Service) APICall(ctx context.Context, body APICallRequest) (int, any) {
 	method := strings.ToUpper(strings.TrimSpace(body.Method))
@@ -29,6 +52,9 @@ func (s *Service) APICall(ctx context.Context, body APICallRequest) (int, any) {
 	parsedURL, errParseURL := url.Parse(urlStr)
 	if errParseURL != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
 		return http.StatusBadRequest, map[string]any{"error": "invalid url"}
+	}
+	if errValidateURL := validateAPICallURL(ctx, parsedURL); errValidateURL != nil {
+		return http.StatusBadRequest, map[string]any{"error": "blocked url"}
 	}
 
 	authIndex := FirstNonEmptyString(body.AuthIndexSnake, body.AuthIndexCamel, body.AuthIndexPascal)
@@ -86,9 +112,18 @@ func (s *Service) APICall(ctx context.Context, body APICallRequest) (int, any) {
 
 	httpClient := util.NewHTTPClient(s.defaultAPICallTimeout())
 	httpClient.Transport = s.APICallTransport(auth)
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return http.ErrUseLastResponse
+		}
+		return validateAPICallURL(req.Context(), req.URL)
+	}
 
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
+		if errors.Is(errDo, errBlockedAPICallTarget) {
+			return http.StatusBadRequest, map[string]any{"error": "blocked url"}
+		}
 		log.WithError(errDo).Debug("management APICall request failed")
 		return http.StatusBadGateway, map[string]any{"error": "request failed"}
 	}
@@ -114,6 +149,52 @@ func (s *Service) APICall(ctx context.Context, body APICallRequest) (int, any) {
 		Header:     resp.Header,
 		Body:       string(respBody),
 	}
+}
+
+func validateAPICallURL(ctx context.Context, parsedURL *url.URL) error {
+	if parsedURL == nil {
+		return errBlockedAPICallTarget
+	}
+	scheme := strings.ToLower(strings.TrimSpace(parsedURL.Scheme))
+	if scheme != "http" && scheme != "https" {
+		return errBlockedAPICallTarget
+	}
+	host := strings.TrimSpace(parsedURL.Hostname())
+	if host == "" {
+		return errBlockedAPICallTarget
+	}
+	if addr, err := netip.ParseAddr(host); err == nil {
+		if apiCallAddrBlocked(addr) {
+			return errBlockedAPICallTarget
+		}
+		return nil
+	}
+	addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+	if err != nil || len(addrs) == 0 {
+		return errBlockedAPICallTarget
+	}
+	for _, addr := range addrs {
+		if apiCallAddrBlocked(addr) {
+			return errBlockedAPICallTarget
+		}
+	}
+	return nil
+}
+
+func apiCallAddrBlocked(addr netip.Addr) bool {
+	if !addr.IsValid() {
+		return true
+	}
+	addr = addr.Unmap()
+	if addr.IsLoopback() || addr.IsPrivate() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsUnspecified() {
+		return true
+	}
+	for _, prefix := range blockedAPICallPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }
 
 func FirstNonEmptyString(values ...*string) string {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -199,7 +199,7 @@ attemptLoop:
 				return resp, err
 			}
 
-			reporter.publish(execCtx.Context, parseAntigravityUsage(bodyBytes))
+			reporter.publishWithContent(execCtx.Context, parseAntigravityUsage(bodyBytes), string(req.Payload), string(bodyBytes))
 			var param any
 			converted := sdktranslator.TranslateNonStream(execCtx.Context, execCtx.Execution.TargetFormat, execCtx.SourceFormat, req.Model, execCtx.OriginalPayload, translated, bodyBytes, &param)
 			resp = cliproxyexecutor.Response{Payload: []byte(converted), Headers: httpResp.Header.Clone()}
@@ -349,6 +349,7 @@ attemptLoop:
 			}
 
 			out := make(chan cliproxyexecutor.StreamChunk)
+			reporter.setInputContent(string(req.Payload))
 			go func(resp *http.Response) {
 				defer close(out)
 				defer func() {
@@ -362,6 +363,7 @@ attemptLoop:
 				for scanner.Scan() {
 					line := scanner.Bytes()
 					recorder.AppendResponseChunk(line)
+					reporter.appendOutputChunk(line)
 
 					line = FilterSSEUsageMetadata(line)
 

--- a/internal/runtime/executor/antigravity_nonstream.go
+++ b/internal/runtime/executor/antigravity_nonstream.go
@@ -136,6 +136,7 @@ attemptLoop:
 			}
 
 			out := make(chan cliproxyexecutor.StreamChunk)
+			reporter.setInputContent(string(req.Payload))
 			go func(resp *http.Response) {
 				defer close(out)
 				defer func() {
@@ -148,6 +149,7 @@ attemptLoop:
 				for scanner.Scan() {
 					line := scanner.Bytes()
 					recorder.AppendResponseChunk(line)
+					reporter.appendOutputChunk(line)
 
 					line = FilterSSEUsageMetadata(line)
 
@@ -183,7 +185,7 @@ attemptLoop:
 			}
 			resp = cliproxyexecutor.Response{Payload: e.convertStreamToNonStream(buffer.Bytes())}
 
-			reporter.publish(execCtx.Context, parseAntigravityUsage(resp.Payload))
+			reporter.publishWithContent(execCtx.Context, parseAntigravityUsage(resp.Payload), string(req.Payload), string(resp.Payload))
 			var param any
 			converted := sdktranslator.TranslateNonStream(execCtx.Context, execCtx.Execution.TargetFormat, execCtx.SourceFormat, req.Model, execCtx.OriginalPayload, translated, resp.Payload, &param)
 			resp = cliproxyexecutor.Response{Payload: []byte(converted), Headers: httpResp.Header.Clone()}

--- a/internal/runtime/executor/antigravity_usage_content_test.go
+++ b/internal/runtime/executor/antigravity_usage_content_test.go
@@ -1,0 +1,119 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+func TestAntigravityExecutePublishesUsageContent(t *testing.T) {
+	const input = `{"request":{"contents":[{"role":"user","parts":[{"text":"ag input marker"}]}]}}`
+	const output = `{"response":{"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":3,"totalTokenCount":5}}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != antigravityGeneratePath {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(output))
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	resp, err := NewAntigravityExecutor(&config.Config{}).Execute(context.Background(), antigravityTestAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gemini-2.5-pro",
+		Payload: []byte(input),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("antigravity")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(resp.Payload) == 0 {
+		t.Fatal("expected response payload")
+	}
+
+	record := waitForAntigravityUsageRecord(t, usagePlugin.records, "ag input marker")
+	if !strings.Contains(record.InputContent, "ag input marker") {
+		t.Fatalf("InputContent = %q, want request payload", record.InputContent)
+	}
+	if !strings.Contains(record.OutputContent, "usageMetadata") {
+		t.Fatalf("OutputContent = %q, want upstream response", record.OutputContent)
+	}
+}
+
+func TestAntigravityExecuteStreamPublishesUsageContent(t *testing.T) {
+	const input = `{"request":{"contents":[{"role":"user","parts":[{"text":"ag stream marker"}]}]}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != antigravityStreamPath {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"response\":{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hello\"}]}}]}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"response\":{\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":3,\"totalTokenCount\":5}}}\n\n")
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	stream, err := NewAntigravityExecutor(&config.Config{}).ExecuteStream(context.Background(), antigravityTestAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gemini-2.5-pro",
+		Payload: []byte(input),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("antigravity")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range stream.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+
+	record := waitForAntigravityUsageRecord(t, usagePlugin.records, "ag stream marker")
+	if !strings.Contains(record.InputContent, "ag stream marker") {
+		t.Fatalf("InputContent = %q, want request payload", record.InputContent)
+	}
+	if !strings.Contains(record.OutputContent, "usageMetadata") {
+		t.Fatalf("OutputContent = %q, want SSE response", record.OutputContent)
+	}
+}
+
+func antigravityTestAuth(baseURL string) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		ID:       "antigravity-test-auth",
+		Provider: antigravityAuthType,
+		Status:   cliproxyauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url": baseURL,
+		},
+		Metadata: map[string]any{
+			"access_token": "test-token",
+			"expired":      time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+}
+
+func waitForAntigravityUsageRecord(t *testing.T, records <-chan cliproxyusage.Record, inputMarker string) cliproxyusage.Record {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case record := <-records:
+			if record.Provider == antigravityAuthType && strings.Contains(record.InputContent, inputMarker) {
+				return record
+			}
+		case <-timer.C:
+			t.Fatal("timed out waiting for antigravity usage record")
+		}
+	}
+}

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -78,6 +78,9 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 				contentsResult.ForEach(func(_, contentResult gjson.Result) bool {
 					switch contentResult.Get("type").String() {
 					case "text":
+						if contentResult.Get("text").String() == "" {
+							return true
+						}
 						part := `{"text":""}`
 						part, _ = sjson.Set(part, "text", contentResult.Get("text").String())
 						contentJSON, _ = sjson.SetRaw(contentJSON, "parts.-1", part)
@@ -109,11 +112,33 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 						part, _ = sjson.Set(part, "functionResponse.name", funcName)
 						part, _ = sjson.Set(part, "functionResponse.response.result", responseData)
 						contentJSON, _ = sjson.SetRaw(contentJSON, "parts.-1", part)
+
+					case "image":
+						sourceResult := contentResult.Get("source")
+						if sourceResult.Get("type").String() != "base64" {
+							return true
+						}
+						inlineData := `{}`
+						if mimeType := sourceResult.Get("media_type").String(); mimeType != "" {
+							inlineData, _ = sjson.Set(inlineData, "mimeType", mimeType)
+						}
+						if data := sourceResult.Get("data").String(); data != "" {
+							inlineData, _ = sjson.Set(inlineData, "data", data)
+						}
+						part := `{}`
+						part, _ = sjson.SetRaw(part, "inlineData", inlineData)
+						contentJSON, _ = sjson.SetRaw(contentJSON, "parts.-1", part)
 					}
 					return true
 				})
+				if len(gjson.Get(contentJSON, "parts").Array()) == 0 {
+					return true
+				}
 				out, _ = sjson.SetRaw(out, "contents.-1", contentJSON)
 			} else if contentsResult.Type == gjson.String {
+				if contentsResult.String() == "" {
+					return true
+				}
 				part := `{"text":""}`
 				part, _ = sjson.Set(part, "text", contentsResult.String())
 				contentJSON, _ = sjson.SetRaw(contentJSON, "parts.-1", part)

--- a/internal/translator/gemini/claude/gemini_claude_request_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_request_test.go
@@ -1,0 +1,38 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertClaudeRequestToGeminiSkipsEmptyPartsAndKeepsImages(t *testing.T) {
+	raw := []byte(`{
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": ""}]},
+			{"role": "user", "content": [
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}},
+				{"type": "text", "text": "describe it"}
+			]}
+		]
+	}`)
+
+	out := ConvertClaudeRequestToGemini("gemini-test", raw, true)
+	if !gjson.ValidBytes(out) {
+		t.Fatalf("invalid json: %s", out)
+	}
+	contents := gjson.GetBytes(out, "contents").Array()
+	if len(contents) != 1 {
+		t.Fatalf("contents len = %d, want 1", len(contents))
+	}
+	parts := contents[0].Get("parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("parts len = %d, want 2", len(parts))
+	}
+	if got := parts[0].Get("inlineData.mimeType").String(); got != "image/png" {
+		t.Fatalf("image mimeType = %q, want image/png", got)
+	}
+	if got := parts[1].Get("text").String(); got != "describe it" {
+		t.Fatalf("text = %q, want describe it", got)
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -297,55 +297,60 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						st.MsgItemDone[idx] = true
 					}
 
-					// Only emit item.added once per tool call and preserve call_id across chunks.
-					newCallID := tcs.Get("0.id").String()
-					nameChunk := tcs.Get("0.function.name").String()
-					if nameChunk != "" {
-						st.FuncNames[idx] = nameChunk
-					}
-					existingCallID := st.FuncCallIDs[idx]
-					effectiveCallID := existingCallID
-					shouldEmitItem := false
-					if existingCallID == "" && newCallID != "" {
-						// First time seeing a valid call_id for this index
-						effectiveCallID = newCallID
-						st.FuncCallIDs[idx] = newCallID
-						shouldEmitItem = true
-					}
-
-					if shouldEmitItem && effectiveCallID != "" {
-						o := `{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`
-						o, _ = sjson.Set(o, "sequence_number", nextSeq())
-						o, _ = sjson.Set(o, "output_index", idx)
-						o, _ = sjson.Set(o, "item.id", fmt.Sprintf("fc_%s", effectiveCallID))
-						o, _ = sjson.Set(o, "item.call_id", effectiveCallID)
-						name := st.FuncNames[idx]
-						o, _ = sjson.Set(o, "item.name", name)
-						out = append(out, emitRespEvent("response.output_item.added", o))
-					}
-
-					// Ensure args buffer exists for this index
-					if st.FuncArgsBuf[idx] == nil {
-						st.FuncArgsBuf[idx] = &strings.Builder{}
-					}
-
-					// Append arguments delta if available and we have a valid call_id to reference
-					if args := tcs.Get("0.function.arguments"); args.Exists() && args.String() != "" {
-						// Prefer an already known call_id; fall back to newCallID if first time
-						refCallID := st.FuncCallIDs[idx]
-						if refCallID == "" {
-							refCallID = newCallID
+					tcs.ForEach(func(pos, tc gjson.Result) bool {
+						callIndex := idx
+						if tc.Get("index").Exists() {
+							callIndex = int(tc.Get("index").Int())
+						} else if len(tcs.Array()) > 1 {
+							callIndex = idx + int(pos.Int())
 						}
-						if refCallID != "" {
-							ad := `{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`
-							ad, _ = sjson.Set(ad, "sequence_number", nextSeq())
-							ad, _ = sjson.Set(ad, "item_id", fmt.Sprintf("fc_%s", refCallID))
-							ad, _ = sjson.Set(ad, "output_index", idx)
-							ad, _ = sjson.Set(ad, "delta", args.String())
-							out = append(out, emitRespEvent("response.function_call_arguments.delta", ad))
+
+						// Only emit item.added once per tool call and preserve call_id across chunks.
+						newCallID := tc.Get("id").String()
+						nameChunk := tc.Get("function.name").String()
+						if nameChunk != "" {
+							st.FuncNames[callIndex] = nameChunk
 						}
-						st.FuncArgsBuf[idx].WriteString(args.String())
-					}
+						existingCallID := st.FuncCallIDs[callIndex]
+						effectiveCallID := existingCallID
+						shouldEmitItem := false
+						if existingCallID == "" && newCallID != "" {
+							effectiveCallID = newCallID
+							st.FuncCallIDs[callIndex] = newCallID
+							shouldEmitItem = true
+						}
+
+						if shouldEmitItem && effectiveCallID != "" {
+							o := `{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`
+							o, _ = sjson.Set(o, "sequence_number", nextSeq())
+							o, _ = sjson.Set(o, "output_index", callIndex)
+							o, _ = sjson.Set(o, "item.id", fmt.Sprintf("fc_%s", effectiveCallID))
+							o, _ = sjson.Set(o, "item.call_id", effectiveCallID)
+							o, _ = sjson.Set(o, "item.name", st.FuncNames[callIndex])
+							out = append(out, emitRespEvent("response.output_item.added", o))
+						}
+
+						if st.FuncArgsBuf[callIndex] == nil {
+							st.FuncArgsBuf[callIndex] = &strings.Builder{}
+						}
+
+						if args := tc.Get("function.arguments"); args.Exists() && args.String() != "" {
+							refCallID := st.FuncCallIDs[callIndex]
+							if refCallID == "" {
+								refCallID = newCallID
+							}
+							if refCallID != "" {
+								ad := `{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`
+								ad, _ = sjson.Set(ad, "sequence_number", nextSeq())
+								ad, _ = sjson.Set(ad, "item_id", fmt.Sprintf("fc_%s", refCallID))
+								ad, _ = sjson.Set(ad, "output_index", callIndex)
+								ad, _ = sjson.Set(ad, "delta", args.String())
+								out = append(out, emitRespEvent("response.function_call_arguments.delta", ad))
+							}
+							st.FuncArgsBuf[callIndex].WriteString(args.String())
+						}
+						return true
+					})
 				}
 			}
 

--- a/internal/translator/openai/openai/responses/openai_openai_responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai_responses_response_test.go
@@ -1,0 +1,40 @@
+package responses
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesPreservesParallelToolCalls(t *testing.T) {
+	var param any
+	chunks := [][]byte{
+		[]byte(`data: {"id":"chatcmpl-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"exec_command","arguments":"{\"cmd\":\"one\""}},{"index":1,"id":"call_b","type":"function","function":{"name":"update_plan","arguments":"{\"plan\":"}}]},"finish_reason":null}]}`),
+		[]byte(`data: {"id":"chatcmpl-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}},{"index":1,"function":{"arguments":"\"two\"}"}}]},"finish_reason":null}]}`),
+		[]byte(`data: {"id":"chatcmpl-parallel","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`),
+	}
+
+	var out strings.Builder
+	for _, chunk := range chunks {
+		for _, event := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "m", nil, nil, chunk, &param) {
+			out.WriteString(event)
+			out.WriteByte('\n')
+		}
+	}
+	got := out.String()
+	if strings.Count(got, "event: response.function_call_arguments.done") != 2 {
+		t.Fatalf("expected two completed function calls:\n%s", got)
+	}
+	for _, want := range []string{
+		`"call_id":"call_a"`,
+		`"name":"exec_command"`,
+		`"arguments":"{\"cmd\":\"one\"}"`,
+		`"call_id":"call_b"`,
+		`"name":"update_plan"`,
+		`"arguments":"{\"plan\":\"two\"}"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %s in converted events:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- fix Claude-to-Gemini empty parts/image conversion
- record Antigravity usage request/response content
- preserve parallel OpenAI-compatible tool calls
- require updater token, restrict updater image repo changes
- require Amp root route auth before proxying upstream secrets
- block management api-call SSRF targets and redirect hops

## Tests
- go test ./cmd/updater ./internal/api/modules/amp ./internal/api/handlers/management ./internal/management/apitools ./internal/translator/gemini/claude ./internal/runtime/executor ./internal/translator/openai/openai/responses -count=1
- go test ./internal/api/handlers/management -count=1
- go test ./internal/api/modules/amp -count=1
- go test ./cmd/updater -count=1
- go test ./... -count=1