### PR TITLE
feat: add session sticky routing

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -474,6 +474,8 @@ func normalizeRoutingStrategy(strategy string) (string, bool) {
 	switch normalized {
 	case "", "round-robin", "roundrobin", "rr":
 		return "round-robin", true
+	case "session-sticky", "sessionsticky", "sticky", "ss":
+		return "session-sticky", true
 	case "fill-first", "fillfirst", "ff":
 		return "fill-first", true
 	default:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -136,11 +136,11 @@ func TestSanitizeRoutingPreservesChannelGroupSettings(t *testing.T) {
 
 	cfg := &Config{
 		Routing: RoutingConfig{
-			Strategy: "fill-first",
+			Strategy: "sticky",
 			ChannelGroups: []RoutingChannelGroup{
 				{
 					Name:               " Team ",
-					Strategy:           "round-robin",
+					Strategy:           "sessionsticky",
 					ExcludeFromDefault: true,
 					Match: ChannelGroupMatch{
 						Channels: []string{"Team Channel"},
@@ -160,8 +160,11 @@ func TestSanitizeRoutingPreservesChannelGroupSettings(t *testing.T) {
 
 	cfg.SanitizeRouting()
 
-	if got := cfg.Routing.ChannelGroups[0].Strategy; got != "round-robin" {
-		t.Fatalf("group strategy = %q, want round-robin", got)
+	if got := cfg.Routing.Strategy; got != "session-sticky" {
+		t.Fatalf("global strategy = %q, want session-sticky", got)
+	}
+	if got := cfg.Routing.ChannelGroups[0].Strategy; got != "session-sticky" {
+		t.Fatalf("group strategy = %q, want session-sticky", got)
 	}
 	if got := cfg.Routing.ChannelGroups[1].Strategy; got != "fill-first" {
 		t.Fatalf("group strategy alias = %q, want fill-first", got)

--- a/internal/config/routing_groups.go
+++ b/internal/config/routing_groups.go
@@ -83,6 +83,8 @@ func normalizeChannelPriorities(values map[string]int) map[string]int {
 
 func NormalizeRoutingStrategy(strategy string) string {
 	switch strings.TrimSpace(strings.ToLower(strategy)) {
+	case "session-sticky", "sessionsticky", "sticky", "ss":
+		return "session-sticky"
 	case "fill-first", "fillfirst", "ff":
 		return "fill-first"
 	default:

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -242,6 +242,7 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	allowedChannelGroups := ""
 	routeGroup := ""
 	routeFallback := ""
+	sessionStickyKey := ""
 	if route := internalrouting.PathRouteContextFromContext(ctx); route != nil {
 		routeGroup = strings.TrimSpace(route.Group)
 		routeFallback = strings.TrimSpace(route.Fallback)
@@ -249,6 +250,7 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	if ctx != nil {
 		if ginCtx, ok := ctx.Value(util.ContextKeyGin).(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
 			key = strings.TrimSpace(ginCtx.GetHeader("Idempotency-Key"))
+			sessionStickyKey = requestSessionStickyHeaderKey(ginCtx)
 			if metadataVal, exists := ginCtx.Get("accessMetadata"); exists {
 				if metadata, okMeta := metadataVal.(map[string]string); okMeta {
 					allowedChannels = strings.TrimSpace(metadata["allowed-channels"])
@@ -299,7 +301,32 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	if executionSessionID := executionSessionIDFromContext(ctx); executionSessionID != "" {
 		meta[coreexecutor.ExecutionSessionMetadataKey] = executionSessionID
 	}
+	if sessionStickyKey != "" {
+		meta[coreexecutor.SessionStickyMetadataKey] = sessionStickyKey
+	}
 	return meta
+}
+
+func requestSessionStickyHeaderKey(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	for _, header := range []string{
+		"Session-Id",
+		"session_id",
+		"X-Session-Id",
+		"X-Codex-Session-Id",
+		"X-Claude-Code-Session-Id",
+		"Conversation-Id",
+		"conversation_id",
+		"X-Conversation-Id",
+		"OpenAI-Conversation-Id",
+	} {
+		if value := strings.TrimSpace(c.GetHeader(header)); value != "" {
+			return "header:" + strings.ToLower(header) + ":" + value
+		}
+	}
+	return ""
 }
 
 func pinnedAuthIDFromContext(ctx context.Context) string {

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -12,6 +12,7 @@ import (
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
 
@@ -233,6 +234,20 @@ func TestRequestExecutionMetadata_UsesPathRouteContextFromRequestContext(t *test
 	}
 	if got := meta["route_fallback"]; got != "none" {
 		t.Fatalf("route_fallback = %v, want %q", got, "none")
+	}
+}
+
+func TestRequestExecutionMetadata_CapturesSessionStickyHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	ginCtx.Request.Header.Set("Session-Id", "sess-1")
+
+	ctx := context.WithValue(context.Background(), util.ContextKeyGin, ginCtx)
+	meta := requestExecutionMetadata(ctx)
+	if got := meta[coreexecutor.SessionStickyMetadataKey]; got != "header:session-id:sess-1" {
+		t.Fatalf("session sticky key = %v, want header:session-id:sess-1", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -140,14 +140,15 @@ func (NoopHook) OnResult(context.Context, Result) {}
 
 // Manager orchestrates auth lifecycle, selection, execution, and persistence.
 type Manager struct {
-	store              Store
-	executors          map[string]ProviderExecutor
-	selector           Selector
-	roundRobinSelector *RoundRobinSelector
-	fillFirstSelector  *FillFirstSelector
-	hook               Hook
-	mu                 sync.RWMutex
-	auths              map[string]*Auth
+	store                 Store
+	executors             map[string]ProviderExecutor
+	selector              Selector
+	roundRobinSelector    *RoundRobinSelector
+	fillFirstSelector     *FillFirstSelector
+	sessionStickySelector *SessionStickySelector
+	hook                  Hook
+	mu                    sync.RWMutex
+	auths                 map[string]*Auth
 	// providerOffsets tracks per-model provider rotation state for multi-provider routing.
 	providerOffsets map[string]int
 
@@ -190,20 +191,25 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	if fillFirstSelector == nil {
 		fillFirstSelector = &FillFirstSelector{}
 	}
+	sessionStickySelector, _ := selector.(*SessionStickySelector)
+	if sessionStickySelector == nil {
+		sessionStickySelector = NewSessionStickySelector(roundRobinSelector)
+	}
 	if hook == nil {
 		hook = NoopHook{}
 	}
 	manager := &Manager{
-		store:              store,
-		executors:          make(map[string]ProviderExecutor),
-		selector:           selector,
-		roundRobinSelector: roundRobinSelector,
-		fillFirstSelector:  fillFirstSelector,
-		hook:               hook,
-		auths:              make(map[string]*Auth),
-		providerOffsets:    make(map[string]int),
-		refreshSemaphore:   make(chan struct{}, refreshMaxConcurrency),
-		quotaProbeAfter:    make(map[string]time.Time),
+		store:                 store,
+		executors:             make(map[string]ProviderExecutor),
+		selector:              selector,
+		roundRobinSelector:    roundRobinSelector,
+		fillFirstSelector:     fillFirstSelector,
+		sessionStickySelector: sessionStickySelector,
+		hook:                  hook,
+		auths:                 make(map[string]*Auth),
+		providerOffsets:       make(map[string]int),
+		refreshSemaphore:      make(chan struct{}, refreshMaxConcurrency),
+		quotaProbeAfter:       make(map[string]time.Time),
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(newRuntimeConfigSnapshot(nil))

--- a/sdk/cliproxy/auth/conductor_grouped_route_test.go
+++ b/sdk/cliproxy/auth/conductor_grouped_route_test.go
@@ -364,3 +364,38 @@ func TestManagerExecute_GroupStrategyRoundRobinOverridesGlobalFillFirst(t *testi
 		t.Fatalf("group round-robin should rotate scoped route auths, got %v", calls)
 	}
 }
+
+func TestManagerExecute_GlobalSessionStickyKeepsSameSessionOnAuth(t *testing.T) {
+	t.Parallel()
+
+	executor := &successfulSequenceExecutor{}
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			Strategy:            "session-sticky",
+			IncludeDefaultGroup: false,
+		},
+	})
+	manager.RegisterExecutor(executor)
+	registerGroupedRouteTestAuths(t, manager)
+
+	opts := cliproxyexecutor.Options{
+		SourceFormat: "openai",
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:session-id:sess-1",
+		},
+	}
+	for i := 0; i < 2; i++ {
+		resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{}, opts)
+		if err != nil {
+			t.Fatalf("Execute(%d) error = %v", i, err)
+		}
+		if string(resp.Payload) != "ok" {
+			t.Fatalf("Execute(%d) payload = %q, want ok", i, string(resp.Payload))
+		}
+	}
+
+	if calls := executor.Calls(); len(calls) != 2 || calls[0] != "auth-a" || calls[1] != "auth-a" {
+		t.Fatalf("global session-sticky should keep using the first session auth, got %v", calls)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_runtime_snapshot.go
+++ b/sdk/cliproxy/auth/conductor_runtime_snapshot.go
@@ -17,6 +17,7 @@ type runtimeConfigSnapshot struct {
 }
 
 type runtimeRoutingConfigSnapshot struct {
+	Strategy            string
 	IncludeDefaultGroup bool
 	ChannelGroups       []runtimeRoutingChannelGroup
 }
@@ -88,6 +89,7 @@ func newRuntimeConfigSnapshot(cfg *sdkconfig.Config) *runtimeConfigSnapshot {
 	}
 	return &runtimeConfigSnapshot{
 		Routing: runtimeRoutingConfigSnapshot{
+			Strategy:            normalizeOptionalRuntimeRoutingStrategy(cfg.Routing.Strategy),
 			IncludeDefaultGroup: cfg.Routing.IncludeDefaultGroup,
 			ChannelGroups:       cloneRuntimeRoutingChannelGroups(cfg.Routing.ChannelGroups),
 		},
@@ -248,6 +250,8 @@ func normalizeOptionalRuntimeRoutingStrategy(strategy string) string {
 	switch strings.ToLower(strings.TrimSpace(strategy)) {
 	case "":
 		return ""
+	case "session-sticky", "sessionsticky", "sticky", "ss":
+		return "session-sticky"
 	case "fill-first", "fillfirst", "ff":
 		return "fill-first"
 	default:

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -48,11 +48,17 @@ func (m *Manager) SetSelector(selector Selector) {
 	if fillFirstSelector, ok := selector.(*FillFirstSelector); ok {
 		m.fillFirstSelector = fillFirstSelector
 	}
+	if sessionStickySelector, ok := selector.(*SessionStickySelector); ok {
+		m.sessionStickySelector = sessionStickySelector
+	}
 	if m.roundRobinSelector == nil {
 		m.roundRobinSelector = &RoundRobinSelector{}
 	}
 	if m.fillFirstSelector == nil {
 		m.fillFirstSelector = &FillFirstSelector{}
+	}
+	if m.sessionStickySelector == nil {
+		m.sessionStickySelector = NewSessionStickySelector(m.roundRobinSelector)
 	}
 	m.mu.Unlock()
 }
@@ -62,6 +68,11 @@ func (m *Manager) selectorForRoutingScopeLocked(cfg *runtimeConfigSnapshot, rout
 		return &RoundRobinSelector{}
 	}
 	switch scopedRoutingStrategy(cfg, routeGroup, allowedGroups) {
+	case "session-sticky":
+		if m.sessionStickySelector != nil {
+			return m.sessionStickySelector
+		}
+		return NewSessionStickySelector(m.roundRobinSelector)
 	case "fill-first":
 		if m.fillFirstSelector != nil {
 			return m.fillFirstSelector

--- a/sdk/cliproxy/auth/routing_groups_scope.go
+++ b/sdk/cliproxy/auth/routing_groups_scope.go
@@ -38,12 +38,24 @@ func onlyAllowedGroupName(allowedGroups map[string]struct{}) string {
 
 func scopedRoutingStrategy(cfg *runtimeConfigSnapshot, routeGroup string, allowedGroups map[string]struct{}) string {
 	if routeGroup = normalizeGroupName(routeGroup); routeGroup != "" {
-		return channelGroupStrategy(cfg, routeGroup)
+		if strategy := channelGroupStrategy(cfg, routeGroup); strategy != "" {
+			return strategy
+		}
+		return globalRoutingStrategy(cfg)
 	}
 	if allowedGroup := onlyAllowedGroupName(allowedGroups); allowedGroup != "" {
-		return channelGroupStrategy(cfg, allowedGroup)
+		if strategy := channelGroupStrategy(cfg, allowedGroup); strategy != "" {
+			return strategy
+		}
 	}
-	return ""
+	return globalRoutingStrategy(cfg)
+}
+
+func globalRoutingStrategy(cfg *runtimeConfigSnapshot) string {
+	if cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Routing.Strategy)
 }
 
 func includeDefaultGroup(cfg *runtimeConfigSnapshot) bool {

--- a/sdk/cliproxy/auth/selector_session_sticky.go
+++ b/sdk/cliproxy/auth/selector_session_sticky.go
@@ -1,0 +1,299 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tidwall/gjson"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+const (
+	sessionStickyTTL     = time.Hour
+	sessionStickyMaxKeys = 4096
+)
+
+type sessionStickyBinding struct {
+	authID    string
+	expiresAt time.Time
+}
+
+// SessionStickySelector keeps stable client sessions on the same auth while it remains available.
+type SessionStickySelector struct {
+	mu       sync.Mutex
+	bindings map[string]sessionStickyBinding
+	fallback Selector
+	maxKeys  int
+}
+
+func NewSessionStickySelector(fallback Selector) *SessionStickySelector {
+	if fallback == nil {
+		fallback = &RoundRobinSelector{}
+	}
+	return &SessionStickySelector{fallback: fallback}
+}
+
+func (s *SessionStickySelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	key := sessionStickySelectionKey(provider, opts, sessionStickyKey(opts))
+	if key == "" {
+		return s.pickFallback(ctx, provider, model, opts, auths)
+	}
+
+	now := time.Now()
+	available, err := getAvailableAuths(auths, provider, model, now, false)
+	if err != nil {
+		return nil, err
+	}
+	available = preferCodexWebsocketAuths(ctx, provider, available)
+
+	if boundID := s.boundAuthID(key, now); boundID != "" {
+		for _, auth := range available {
+			if auth != nil && auth.ID == boundID {
+				s.refreshBinding(key, boundID, now)
+				return auth, nil
+			}
+		}
+		s.deleteBinding(key)
+	}
+
+	selected, err := s.pickFallback(ctx, provider, model, opts, available)
+	if err != nil {
+		return nil, err
+	}
+	if selected != nil && strings.TrimSpace(selected.ID) != "" {
+		s.refreshBinding(key, selected.ID, now)
+	}
+	return selected, nil
+}
+
+func (s *SessionStickySelector) pickFallback(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if s == nil || s.fallback == nil {
+		return (&RoundRobinSelector{}).Pick(ctx, provider, model, opts, auths)
+	}
+	return s.fallback.Pick(ctx, provider, model, opts, auths)
+}
+
+func (s *SessionStickySelector) boundAuthID(key string, now time.Time) string {
+	if s == nil || key == "" {
+		return ""
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	binding, ok := s.bindings[key]
+	if !ok {
+		return ""
+	}
+	if !binding.expiresAt.IsZero() && now.After(binding.expiresAt) {
+		delete(s.bindings, key)
+		return ""
+	}
+	return binding.authID
+}
+
+func (s *SessionStickySelector) refreshBinding(key, authID string, now time.Time) {
+	if s == nil || key == "" || authID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	limit := s.maxKeys
+	if limit <= 0 {
+		limit = sessionStickyMaxKeys
+	}
+	if s.bindings == nil {
+		s.bindings = make(map[string]sessionStickyBinding)
+	} else if len(s.bindings) >= limit {
+		s.bindings = make(map[string]sessionStickyBinding)
+	}
+	s.bindings[key] = sessionStickyBinding{
+		authID:    authID,
+		expiresAt: now.Add(sessionStickyTTL),
+	}
+}
+
+func (s *SessionStickySelector) deleteBinding(key string) {
+	if s == nil || key == "" {
+		return
+	}
+	s.mu.Lock()
+	delete(s.bindings, key)
+	s.mu.Unlock()
+}
+
+func sessionStickySelectionKey(provider string, opts cliproxyexecutor.Options, sessionKey string) string {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return ""
+	}
+	scope := strings.TrimSpace(metadataStringValue(opts.Metadata, cliproxyexecutor.RouteGroupMetadataKey))
+	if scope == "" {
+		scope = strings.TrimSpace(metadataStringValue(opts.Metadata, "allowed-channel-groups"))
+	}
+	if scope == "" {
+		scope = "default"
+	}
+	return strings.ToLower(strings.TrimSpace(provider)) + "|" + strings.TrimSpace(opts.SourceFormat.String()) + "|" + scope + "|" + sessionKey
+}
+
+func sessionStickyKey(opts cliproxyexecutor.Options) string {
+	if key := metadataStringValue(opts.Metadata, cliproxyexecutor.SessionStickyMetadataKey); key != "" {
+		return key
+	}
+	if key := metadataStringValue(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); key != "" {
+		return "execution:" + key
+	}
+	return bodySessionStickyKey(opts.OriginalRequest)
+}
+
+func bodySessionStickyKey(body []byte) string {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return ""
+	}
+	paths := []string{
+		"session_id",
+		"sessionId",
+		"conversation_id",
+		"conversationId",
+		"prompt_cache_key",
+		"promptCacheKey",
+		"metadata.session_id",
+		"metadata.conversation_id",
+		"metadata.user_id.session_id",
+		"metadata.user_id",
+	}
+	for _, path := range paths {
+		if key := gjson.GetBytes(body, path).String(); strings.TrimSpace(key) != "" {
+			return path + ":" + strings.TrimSpace(key)
+		}
+	}
+	if text := cacheControlStickyText(body); text != "" {
+		return "cache_control:" + shortStableHash(text)
+	}
+	if text := firstUserStickyText(body); text != "" {
+		return "first_user:" + shortStableHash(text)
+	}
+	return ""
+}
+
+func cacheControlStickyText(body []byte) string {
+	var builder strings.Builder
+	appendCacheControlText(&builder, gjson.GetBytes(body, "system"))
+	messages := gjson.GetBytes(body, "messages")
+	if messages.IsArray() {
+		messages.ForEach(func(_, msg gjson.Result) bool {
+			appendCacheControlText(&builder, msg.Get("content"))
+			return true
+		})
+	}
+	return builder.String()
+}
+
+func appendCacheControlText(builder *strings.Builder, value gjson.Result) {
+	if builder == nil || !value.Exists() {
+		return
+	}
+	if value.IsArray() {
+		value.ForEach(func(_, item gjson.Result) bool {
+			if item.Get("cache_control.type").String() == "ephemeral" {
+				appendContentText(builder, item)
+			}
+			return true
+		})
+		return
+	}
+	if value.Get("cache_control.type").String() == "ephemeral" {
+		appendContentText(builder, value)
+	}
+}
+
+func firstUserStickyText(body []byte) string {
+	if input := gjson.GetBytes(body, "input"); input.Exists() {
+		if input.Type == gjson.String {
+			return strings.TrimSpace(input.String())
+		}
+		if input.IsArray() {
+			if text := firstInputText(input); text != "" {
+				return text
+			}
+		}
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return ""
+	}
+	var text string
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "user" {
+			return true
+		}
+		var builder strings.Builder
+		appendContentText(&builder, msg.Get("content"))
+		text = strings.TrimSpace(builder.String())
+		return false
+	})
+	return text
+}
+
+func firstInputText(input gjson.Result) string {
+	var text string
+	input.ForEach(func(_, item gjson.Result) bool {
+		if item.Type == gjson.String {
+			text = strings.TrimSpace(item.String())
+			return false
+		}
+		switch item.Get("role").String() {
+		case "user", "system", "developer":
+			var builder strings.Builder
+			appendContentText(&builder, item.Get("content"))
+			text = strings.TrimSpace(builder.String())
+			return text == ""
+		default:
+			if item.Get("type").String() == "input_text" {
+				text = strings.TrimSpace(item.Get("text").String())
+				return text == ""
+			}
+		}
+		return true
+	})
+	return text
+}
+
+func appendContentText(builder *strings.Builder, value gjson.Result) {
+	if builder == nil || !value.Exists() {
+		return
+	}
+	if value.Type == gjson.String {
+		_, _ = builder.WriteString(value.String())
+		return
+	}
+	if text := strings.TrimSpace(value.Get("text").String()); text != "" {
+		_, _ = builder.WriteString(text)
+		return
+	}
+	if !value.IsArray() {
+		return
+	}
+	value.ForEach(func(_, item gjson.Result) bool {
+		if item.Type == gjson.String {
+			_, _ = builder.WriteString(item.String())
+			return true
+		}
+		switch item.Get("type").String() {
+		case "text", "input_text":
+			if text := item.Get("text").String(); text != "" {
+				_, _ = builder.WriteString(text)
+			}
+		}
+		return true
+	})
+}
+
+func shortStableHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:16])
+}

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -60,6 +60,105 @@ func TestRoundRobinSelectorPick_CyclesDeterministic(t *testing.T) {
 	}
 }
 
+func TestSessionStickySelectorPick_SticksSameSessionKey(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionStickySelector(&RoundRobinSelector{})
+	auths := []*Auth{{ID: "a"}, {ID: "b"}}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: "openai",
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:session-id:sess-1",
+		},
+	}
+
+	first, err := selector.Pick(context.Background(), "gemini", "", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() first error = %v", err)
+	}
+	second, err := selector.Pick(context.Background(), "gemini", "", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() second error = %v", err)
+	}
+	if first == nil || second == nil {
+		t.Fatal("Pick() returned nil auth")
+	}
+	if first.ID != "a" || second.ID != "a" {
+		t.Fatalf("Pick() auth IDs = [%s %s], want [a a]", first.ID, second.ID)
+	}
+}
+
+func TestSessionStickySelectorPick_FallsBackWithoutSessionKey(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionStickySelector(&RoundRobinSelector{})
+	auths := []*Auth{{ID: "a"}, {ID: "b"}}
+
+	first, err := selector.Pick(context.Background(), "gemini", "", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() first error = %v", err)
+	}
+	second, err := selector.Pick(context.Background(), "gemini", "", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() second error = %v", err)
+	}
+	if first == nil || second == nil {
+		t.Fatal("Pick() returned nil auth")
+	}
+	if first.ID != "a" || second.ID != "b" {
+		t.Fatalf("Pick() auth IDs = [%s %s], want [a b]", first.ID, second.ID)
+	}
+}
+
+func TestSessionStickySelectorPick_RebindsUnavailableAuth(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionStickySelector(&RoundRobinSelector{})
+	auths := []*Auth{{ID: "a"}, {ID: "b"}}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: "openai",
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:session-id:sess-1",
+		},
+	}
+
+	first, err := selector.Pick(context.Background(), "gemini", "", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() first error = %v", err)
+	}
+	if first == nil || first.ID != "a" {
+		t.Fatalf("Pick() first auth = %#v, want a", first)
+	}
+
+	auths[0].Disabled = true
+	second, err := selector.Pick(context.Background(), "gemini", "", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() second error = %v", err)
+	}
+	third, err := selector.Pick(context.Background(), "gemini", "", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() third error = %v", err)
+	}
+	if second == nil || third == nil {
+		t.Fatal("Pick() returned nil auth")
+	}
+	if second.ID != "b" || third.ID != "b" {
+		t.Fatalf("Pick() auth IDs after disable = [%s %s], want [b b]", second.ID, third.ID)
+	}
+}
+
+func TestSessionStickyKeyUsesPromptCacheKey(t *testing.T) {
+	t.Parallel()
+
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"model":"gpt-5","prompt_cache_key":"cache-1","messages":[{"role":"user","content":"hello"}]}`),
+	}
+
+	if got := sessionStickyKey(opts); got != "prompt_cache_key:cache-1" {
+		t.Fatalf("sessionStickyKey() = %q, want prompt_cache_key:cache-1", got)
+	}
+}
+
 func TestRoundRobinSelectorPick_PriorityBuckets(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -26,6 +26,8 @@ const (
 	SelectedAuthCallbackMetadataKey = "selected_auth_callback"
 	// ExecutionSessionMetadataKey identifies a long-lived downstream execution session.
 	ExecutionSessionMetadataKey = "execution_session_id"
+	// SessionStickyMetadataKey carries a stable client session key for sticky routing.
+	SessionStickyMetadataKey = "session_sticky_key"
 )
 
 // Request encapsulates the translated payload that will be sent to a provider executor.


### PR DESCRIPTION
## Summary
- add session-sticky routing strategy for global and channel-group scheduling
- extract stable session keys from headers/body metadata and keep sessions on the same auth while available
- cover config normalization, metadata extraction, selector behavior, and manager execution path

## Tests
- rtk go test ./...
- rtk go test ./sdk/cliproxy/auth ./sdk/api/handlers ./internal/config ./internal/api/handlers/management