### PR TITLE
chore: split session sticky handler helper

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -307,28 +307,6 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	return meta
 }
 
-func requestSessionStickyHeaderKey(c *gin.Context) string {
-	if c == nil {
-		return ""
-	}
-	for _, header := range []string{
-		"Session-Id",
-		"session_id",
-		"X-Session-Id",
-		"X-Codex-Session-Id",
-		"X-Claude-Code-Session-Id",
-		"Conversation-Id",
-		"conversation_id",
-		"X-Conversation-Id",
-		"OpenAI-Conversation-Id",
-	} {
-		if value := strings.TrimSpace(c.GetHeader(header)); value != "" {
-			return "header:" + strings.ToLower(header) + ":" + value
-		}
-	}
-	return ""
-}
-
 func pinnedAuthIDFromContext(ctx context.Context) string {
 	if ctx == nil {
 		return ""

--- a/sdk/api/handlers/session_sticky.go
+++ b/sdk/api/handlers/session_sticky.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func requestSessionStickyHeaderKey(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	for _, header := range []string{
+		"Session-Id",
+		"session_id",
+		"X-Session-Id",
+		"X-Codex-Session-Id",
+		"X-Claude-Code-Session-Id",
+		"Conversation-Id",
+		"conversation_id",
+		"X-Conversation-Id",
+		"OpenAI-Conversation-Id",
+	} {
+		if value := strings.TrimSpace(c.GetHeader(header)); value != "" {
+			return "header:" + strings.ToLower(header) + ":" + value
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- move session sticky header extraction out of the oversized handlers file
- keep backend structure guard under the blocking threshold

## Verification
- rtk python3 scripts/check-backend-structure.py
- rtk go test ./...