### PR TITLE
fix: make body cache space check cross-platform

### DIFF
--- a/internal/api/bodyutil/body_storage.go
+++ b/internal/api/bodyutil/body_storage.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 )
 
@@ -282,12 +281,7 @@ func RequestBodyCacheAvailable(requiredBytes int64) bool {
 	if requiredBytes < 0 {
 		requiredBytes = 0
 	}
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(dir, &stat); err != nil {
-		return false
-	}
-	available := int64(stat.Bavail) * int64(stat.Bsize)
-	return available-requiredBytes >= bodyStorageMinFreeBytes
+	return requestBodyCacheHasFreeSpace(dir, requiredBytes)
 }
 
 // CleanupOldRequestBodyCacheFiles removes abandoned request body temp files.

--- a/internal/api/bodyutil/body_storage_space_fallback.go
+++ b/internal/api/bodyutil/body_storage_space_fallback.go
@@ -1,0 +1,7 @@
+//go:build !unix && !windows
+
+package bodyutil
+
+func requestBodyCacheHasFreeSpace(string, int64) bool {
+	return false
+}

--- a/internal/api/bodyutil/body_storage_space_unix.go
+++ b/internal/api/bodyutil/body_storage_space_unix.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package bodyutil
+
+import "golang.org/x/sys/unix"
+
+func requestBodyCacheHasFreeSpace(dir string, requiredBytes int64) bool {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(dir, &stat); err != nil {
+		return false
+	}
+	available := int64(stat.Bavail) * int64(stat.Bsize)
+	return available-requiredBytes >= bodyStorageMinFreeBytes
+}

--- a/internal/api/bodyutil/body_storage_space_windows.go
+++ b/internal/api/bodyutil/body_storage_space_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package bodyutil
+
+import "golang.org/x/sys/windows"
+
+func requestBodyCacheHasFreeSpace(dir string, requiredBytes int64) bool {
+	path, err := windows.UTF16PtrFromString(dir)
+	if err != nil {
+		return false
+	}
+	var free uint64
+	if err := windows.GetDiskFreeSpaceEx(path, &free, nil, nil); err != nil {
+		return false
+	}
+	needed := uint64(requiredBytes) + uint64(bodyStorageMinFreeBytes)
+	if needed < uint64(requiredBytes) {
+		return false
+	}
+	return free >= needed
+}


### PR DESCRIPTION
## Summary
- move request body cache free-space checks into per-platform files
- use x/sys/unix on Unix and x/sys/windows on Windows so GoReleaser can build all release targets
- keep unknown platforms conservative by disabling disk cache when free space cannot be checked

## Verification
- rtk go test ./internal/api/bodyutil ./...
- rtk env GOOS=windows GOARCH=amd64 go build -o /tmp/clirelay-windows-amd64.exe ./cmd/server
- rtk env GOOS=darwin GOARCH=arm64 go build -o /tmp/clirelay-darwin-arm64 ./cmd/server
- rtk python3 scripts/check-backend-structure.py
- rtk git diff --check