### PR TITLE
fix: persist OpenCode Go model availability

### DIFF
--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -225,6 +225,7 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
+		entry.Models = NormalizeOpenCodeGoModels(entry.Models)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
@@ -232,6 +233,27 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		out = append(out, entry)
 	}
 	cfg.OpenCodeGoKey = out
+}
+
+func NormalizeOpenCodeGoModels(models []OpenCodeGoModel) []OpenCodeGoModel {
+	if len(models) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(models))
+	out := make([]OpenCodeGoModel, 0, len(models))
+	for i := range models {
+		name := strings.TrimSpace(models[i].Name)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, OpenCodeGoModel{Name: name})
+	}
+	return out
 }
 
 // SanitizeGeminiKeys deduplicates and normalizes Gemini credentials.

--- a/internal/config/opencode_go_test.go
+++ b/internal/config/opencode_go_test.go
@@ -20,6 +20,10 @@ opencode-go-api-key:
       X-Test: " yes "
     excluded-models:
       - " deepseek-v4-pro "
+    models:
+      - name: " qwen3.7-max "
+      - name: " qwen3.7-max "
+      - name: " kimi-k2.7-code "
     vision-fallback-model: " qwen3.5-plus "
 `), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -45,6 +49,9 @@ opencode-go-api-key:
 	if len(got.ExcludedModels) != 1 || got.ExcludedModels[0] != "deepseek-v4-pro" {
 		t.Fatalf("excluded models = %#v", got.ExcludedModels)
 	}
+	if len(got.Models) != 2 || got.Models[0].Name != "qwen3.7-max" || got.Models[1].Name != "kimi-k2.7-code" {
+		t.Fatalf("models = %#v", got.Models)
+	}
 	if got.VisionFallbackModel != "qwen3.5-plus" {
 		t.Fatalf("vision fallback model = %q, want qwen3.5-plus", got.VisionFallbackModel)
 	}
@@ -56,7 +63,7 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 			{APIKey: " "},
 			{APIKey: "go-key", Prefix: " team "},
 			{APIKey: "go-key", Prefix: "duplicate"},
-			{APIKey: "go-key-2", Headers: map[string]string{" X-Trace ": " on "}, VisionFallbackModel: " qwen3.6-plus ", WorkspaceID: " wrk_123 ", AuthCookie: " auth-token "},
+			{APIKey: "go-key-2", Headers: map[string]string{" X-Trace ": " on "}, Models: []OpenCodeGoModel{{Name: " glm-5.2 "}, {Name: "GLM-5.2"}, {Name: " "}}, VisionFallbackModel: " qwen3.6-plus ", WorkspaceID: " wrk_123 ", AuthCookie: " auth-token "},
 		},
 	}
 
@@ -73,6 +80,9 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 	}
 	if cfg.OpenCodeGoKey[1].VisionFallbackModel != "qwen3.6-plus" {
 		t.Fatalf("vision fallback model = %q, want qwen3.6-plus", cfg.OpenCodeGoKey[1].VisionFallbackModel)
+	}
+	if len(cfg.OpenCodeGoKey[1].Models) != 1 || cfg.OpenCodeGoKey[1].Models[0].Name != "glm-5.2" {
+		t.Fatalf("models = %#v, want normalized unique model", cfg.OpenCodeGoKey[1].Models)
 	}
 	if cfg.OpenCodeGoKey[1].WorkspaceID != "wrk_123" || cfg.OpenCodeGoKey[1].AuthCookie != "auth-token" {
 		t.Fatalf("usage fields not normalized: %+v", cfg.OpenCodeGoKey[1])

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -243,6 +243,9 @@ type OpenCodeGoKey struct {
 	// ProxyID references a reusable proxy-pool entry. When valid, it takes precedence over ProxyURL.
 	ProxyID string `yaml:"proxy-id,omitempty" json:"proxy-id,omitempty"`
 
+	// Models defines the OpenCode Go model IDs explicitly enabled for this key.
+	Models []OpenCodeGoModel `yaml:"models,omitempty" json:"models,omitempty"`
+
 	// Headers optionally adds extra HTTP headers for requests sent with this key.
 	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
 
@@ -258,3 +261,11 @@ type OpenCodeGoKey struct {
 	// AuthCookie stores the OpenCode dashboard auth cookie value used for usage checks.
 	AuthCookie string `yaml:"-" json:"auth-cookie,omitempty"`
 }
+
+// OpenCodeGoModel describes a model explicitly enabled for OpenCode Go routing.
+type OpenCodeGoModel struct {
+	Name string `yaml:"name" json:"name"`
+}
+
+func (m OpenCodeGoModel) GetName() string  { return m.Name }
+func (m OpenCodeGoModel) GetAlias() string { return "" }

--- a/internal/config/sdkbridge/bridge.go
+++ b/internal/config/sdkbridge/bridge.go
@@ -31,6 +31,7 @@ type ClaudeKey = coreconfig.ClaudeKey
 type BedrockKey = coreconfig.BedrockKey
 type BedrockModel = coreconfig.BedrockModel
 type OpenCodeGoKey = coreconfig.OpenCodeGoKey
+type OpenCodeGoModel = coreconfig.OpenCodeGoModel
 type VertexCompatKey = coreconfig.VertexCompatKey
 type VertexCompatModel = coreconfig.VertexCompatModel
 type OpenAICompatibility = coreconfig.OpenAICompatibility

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -22,6 +22,7 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	for _, row := range allConfigRows {
 		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
 	}
+	authByID := s.authByID()
 
 	data := make([]map[string]any, 0, len(allModels))
 	activeMetadata := make([]map[string]any, 0, len(allModels))
@@ -38,6 +39,9 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		}
 		if ownedBy, exists := model["owned_by"]; exists {
 			entry["owned_by"] = ownedBy
+		}
+		if sources := s.modelSourceEntries(modelRegistry, id, authByID); len(sources) > 0 {
+			entry["sources"] = sources
 		}
 		if row, ok := configByID[strings.ToLower(id)]; ok {
 			attachModelConfigCapabilities(entry, row)
@@ -225,6 +229,82 @@ func (s *Service) scopedModelConfigRows(allowedChannelsRaw, allowedGroupsRaw str
 		if ownerKeys[normalizeModelOwnerKey(row.OwnedBy)] || ownerKeys[normalizeModelOwnerKey(row.Source)] {
 			out = append(out, row)
 		}
+	}
+	return out
+}
+
+func (s *Service) authByID() map[string]*coreauth.Auth {
+	if s == nil || s.authManager == nil {
+		return nil
+	}
+	auths := s.authManager.List()
+	if len(auths) == 0 {
+		return nil
+	}
+	out := make(map[string]*coreauth.Auth, len(auths))
+	for _, auth := range auths {
+		if auth == nil || strings.TrimSpace(auth.ID) == "" {
+			continue
+		}
+		out[auth.ID] = auth
+	}
+	return out
+}
+
+func (s *Service) modelSourceEntries(modelRegistry *registry.ModelRegistry, modelID string, authByID map[string]*coreauth.Auth) []map[string]any {
+	if modelRegistry == nil {
+		return nil
+	}
+	rawSources := modelRegistry.GetModelClientSources(modelID)
+	if len(rawSources) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(rawSources))
+	seen := make(map[string]struct{}, len(rawSources))
+	for _, raw := range rawSources {
+		clientID := strings.TrimSpace(raw.ClientID)
+		provider := strings.TrimSpace(raw.Provider)
+		channel := ""
+		source := ""
+		if auth := authByID[clientID]; auth != nil {
+			if provider == "" {
+				provider = strings.TrimSpace(auth.Provider)
+			}
+			channel = strings.TrimSpace(auth.ChannelName())
+			if auth.Attributes != nil {
+				source = strings.TrimSpace(auth.Attributes["source"])
+			}
+		}
+
+		label := provider
+		if channel != "" {
+			label = channel
+			if provider != "" && !strings.EqualFold(provider, channel) {
+				label = provider + " · " + channel
+			}
+		}
+		if label == "" {
+			label = clientID
+		}
+		key := provider + "\x00" + channel + "\x00" + label + "\x00" + source + "\x00" + clientID
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		entry := map[string]any{
+			"label":     label,
+			"provider":  provider,
+			"client_id": clientID,
+			"model_id":  strings.TrimSpace(raw.ModelID),
+		}
+		if channel != "" {
+			entry["channel"] = channel
+		}
+		if source != "" {
+			entry["source"] = source
+		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -1,0 +1,59 @@
+package modelcatalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestConfiguredAvailabilityIncludesModelSources(t *testing.T) {
+	const modelID = "source-test-model"
+	const codexClientID = "source-test-codex"
+	const openCodeClientID = "source-test-opencode"
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(codexClientID)
+	modelRegistry.UnregisterClient(openCodeClientID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(codexClientID)
+		modelRegistry.UnregisterClient(openCodeClientID)
+	})
+
+	modelRegistry.RegisterClient(codexClientID, "codex", []*registry.ModelInfo{{ID: modelID, Object: "model", OwnedBy: "openai"}})
+	modelRegistry.RegisterClient(openCodeClientID, "opencode-go", []*registry.ModelInfo{{ID: modelID, Object: "model", OwnedBy: "opencode"}})
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{ID: codexClientID, Provider: "codex", Label: "Codex Pro", Status: coreauth.StatusActive}); err != nil {
+		t.Fatalf("register codex auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{ID: openCodeClientID, Provider: "opencode-go", Label: "OpenCode Go", Status: coreauth.StatusActive}); err != nil {
+		t.Fatalf("register opencode auth: %v", err)
+	}
+
+	result := New(&config.Config{}, manager).ConfiguredAvailability("", "")
+	data, ok := result["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v, want []map[string]any", result["data"])
+	}
+
+	var sources []map[string]any
+	for _, item := range data {
+		if item["id"] == modelID {
+			sources, _ = item["sources"].([]map[string]any)
+			break
+		}
+	}
+	if len(sources) != 2 {
+		t.Fatalf("sources = %#v, want two sources", sources)
+	}
+	labels := map[string]bool{}
+	for _, source := range sources {
+		labels[source["label"].(string)] = true
+	}
+	if !labels["codex · Codex Pro"] || !labels["opencode-go · OpenCode Go"] {
+		t.Fatalf("source labels = %#v", labels)
+	}
+}

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -177,17 +177,18 @@ func (s *Service) deleteBedrockKeys(match func(config.BedrockKey) bool) bool {
 }
 
 type OpenCodeGoPatch struct {
-	APIKey         *string            `json:"api-key"`
-	Name           *string            `json:"name"`
-	Priority       *int               `json:"priority"`
-	Prefix         *string            `json:"prefix"`
-	ProxyURL       *string            `json:"proxy-url"`
-	ProxyID        *string            `json:"proxy-id"`
-	Headers        *map[string]string `json:"headers"`
-	ExcludedModels *[]string          `json:"excluded-models"`
-	VisionFallback *string            `json:"vision-fallback-model"`
-	WorkspaceID    *string            `json:"workspace-id"`
-	AuthCookie     *string            `json:"auth-cookie"`
+	APIKey         *string                   `json:"api-key"`
+	Name           *string                   `json:"name"`
+	Priority       *int                      `json:"priority"`
+	Prefix         *string                   `json:"prefix"`
+	ProxyURL       *string                   `json:"proxy-url"`
+	ProxyID        *string                   `json:"proxy-id"`
+	Headers        *map[string]string        `json:"headers"`
+	Models         *[]config.OpenCodeGoModel `json:"models"`
+	ExcludedModels *[]string                 `json:"excluded-models"`
+	VisionFallback *string                   `json:"vision-fallback-model"`
+	WorkspaceID    *string                   `json:"workspace-id"`
+	AuthCookie     *string                   `json:"auth-cookie"`
 }
 
 func (s *Service) OpenCodeGoKeys() []config.OpenCodeGoKey {
@@ -269,6 +270,9 @@ func (s *Service) PatchOpenCodeGoKey(index *int, apiKey *string, name *string, p
 	}
 	if patch.Headers != nil {
 		entry.Headers = config.NormalizeHeaders(*patch.Headers)
+	}
+	if patch.Models != nil {
+		entry.Models = append([]config.OpenCodeGoModel(nil), (*patch.Models)...)
 	}
 	if patch.ExcludedModels != nil {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*patch.ExcludedModels)
@@ -379,6 +383,7 @@ func NormalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.Models = config.NormalizeOpenCodeGoModels(entry.Models)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 	if workspaceID, err := normalizeOpenCodeGoWorkspaceID(entry.WorkspaceID); err == nil {

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -1116,118 +1116,42 @@ func GetKimiModels() []*ModelInfo {
 
 // GetOpenCodeGoModels returns the OpenCode Go plan model definitions.
 func GetOpenCodeGoModels() []*ModelInfo {
-	return []*ModelInfo{
-		{
-			ID:          "deepseek-v4-flash",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "DeepSeek V4 Flash",
-		},
-		{
-			ID:          "deepseek-v4-pro",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "DeepSeek V4 Pro",
-		},
-		{
-			ID:          "glm-5.1",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "GLM 5.1",
-		},
-		{
-			ID:          "glm-5",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "GLM 5",
-		},
-		{
-			ID:          "kimi-k2.6",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "Kimi K2.6",
-		},
-		{
-			ID:          "kimi-k2.5",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "Kimi K2.5",
-		},
-		{
-			ID:          "qwen3.6-plus",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "Qwen3.6 Plus",
-		},
-		{
-			ID:          "qwen3.5-plus",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "Qwen3.5 Plus",
-		},
-		{
-			ID:          "mimo-v2-pro",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "MiMo V2 Pro",
-		},
-		{
-			ID:          "mimo-v2-omni",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "MiMo V2 Omni",
-		},
-		{
-			ID:          "mimo-v2.5-pro",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "MiMo V2.5 Pro",
-		},
-		{
-			ID:          "mimo-v2.5",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "MiMo V2.5",
-		},
-		{
-			ID:          "minimax-m2.7",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "MiniMax M2.7",
-		},
-		{
-			ID:          "minimax-m2.5",
-			Object:      "model",
-			Created:     1770393600,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: "MiniMax M2.5",
-		},
+	definitions := []struct {
+		id          string
+		displayName string
+	}{
+		{"minimax-m3", "MiniMax M3"},
+		{"minimax-m2.7", "MiniMax M2.7"},
+		{"minimax-m2.5", "MiniMax M2.5"},
+		{"kimi-k2.7-code", "Kimi K2.7 Code"},
+		{"kimi-k2.6", "Kimi K2.6"},
+		{"kimi-k2.5", "Kimi K2.5"},
+		{"glm-5.2", "GLM 5.2"},
+		{"glm-5.1", "GLM 5.1"},
+		{"glm-5", "GLM 5"},
+		{"deepseek-v4-pro", "DeepSeek V4 Pro"},
+		{"deepseek-v4-flash", "DeepSeek V4 Flash"},
+		{"qwen3.7-max", "Qwen3.7 Max"},
+		{"qwen3.7-plus", "Qwen3.7 Plus"},
+		{"qwen3.6-plus", "Qwen3.6 Plus"},
+		{"qwen3.5-plus", "Qwen3.5 Plus"},
+		{"mimo-v2-pro", "MiMo V2 Pro"},
+		{"mimo-v2-omni", "MiMo V2 Omni"},
+		{"mimo-v2.5-pro", "MiMo V2.5 Pro"},
+		{"mimo-v2.5", "MiMo V2.5"},
+		{"hy3-preview", "HY3 Preview"},
 	}
+
+	models := make([]*ModelInfo, 0, len(definitions))
+	for _, definition := range definitions {
+		models = append(models, &ModelInfo{
+			ID:          definition.id,
+			Object:      "model",
+			Created:     1781751220,
+			OwnedBy:     "opencode",
+			Type:        "opencode-go",
+			DisplayName: definition.displayName,
+		})
+	}
+	return models
 }

--- a/internal/registry/model_registry_queries.go
+++ b/internal/registry/model_registry_queries.go
@@ -12,6 +12,12 @@ import (
 // - Responsibility: compute public availability snapshots, provider views, and lookup helpers.
 // - Non-goals: client registration reconciliation and quota/suspension mutation.
 
+type ModelClientSource struct {
+	ClientID string `json:"client_id"`
+	Provider string `json:"provider"`
+	ModelID  string `json:"model_id"`
+}
+
 // GetAvailableModels returns all models that have at least one available client.
 func (r *ModelRegistry) GetAvailableModels(handlerType string) []map[string]any {
 	r.mutex.RLock()
@@ -243,6 +249,49 @@ func (r *ModelRegistry) GetModelProviders(modelID string) []string {
 		result = append(result, item.name)
 	}
 	return result
+}
+
+func (r *ModelRegistry) GetModelClientSources(modelID string) []ModelClientSource {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return nil
+	}
+	target := strings.ToLower(modelID)
+
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	out := make([]ModelClientSource, 0)
+	seen := make(map[string]struct{})
+	for clientID, modelIDs := range r.clientModels {
+		if strings.TrimSpace(clientID) == "" {
+			continue
+		}
+		provider := r.clientProviders[clientID]
+		for _, registeredID := range modelIDs {
+			registeredID = strings.TrimSpace(registeredID)
+			if registeredID == "" || strings.ToLower(registeredID) != target {
+				continue
+			}
+			key := clientID + "\x00" + provider + "\x00" + registeredID
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, ModelClientSource{
+				ClientID: clientID,
+				Provider: provider,
+				ModelID:  registeredID,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Provider == out[j].Provider {
+			return out[i].ClientID < out[j].ClientID
+		}
+		return out[i].Provider < out[j].Provider
+	})
+	return out
 }
 
 // GetModelInfo returns ModelInfo, prioritizing provider-specific definition if available.

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -149,8 +149,12 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		}
 		models = applyExcludedModels(models, excluded)
 	case "opencode-go":
-		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("opencode-go")
+		staticModels := sdkmodelcatalog.StaticModelDefinitionsByChannel("opencode-go")
+		models = staticModels
 		if entry := s.resolveConfigOpenCodeGoKey(a); entry != nil && authKind == "apikey" {
+			if len(entry.Models) > 0 {
+				models = buildOpenCodeGoConfigModels(entry, staticModels)
+			}
 			excluded = entry.ExcludedModels
 		}
 		models = applyExcludedModels(models, excluded)

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -324,6 +324,53 @@ func buildCodexConfigModels(entry *config.CodexKey, resolveThinking staticThinki
 	return buildConfigModels(entry.Models, "openai", "openai", resolveThinking)
 }
 
+func buildOpenCodeGoConfigModels(entry *config.OpenCodeGoKey, staticModels []*ModelInfo) []*ModelInfo {
+	if entry == nil || len(entry.Models) == 0 {
+		return nil
+	}
+	staticByID := make(map[string]*ModelInfo, len(staticModels))
+	for _, model := range staticModels {
+		if model == nil {
+			continue
+		}
+		if id := strings.ToLower(strings.TrimSpace(model.ID)); id != "" {
+			staticByID[id] = model
+		}
+	}
+
+	now := time.Now().Unix()
+	seen := make(map[string]struct{}, len(entry.Models))
+	out := make([]*ModelInfo, 0, len(entry.Models))
+	for i := range entry.Models {
+		name := strings.TrimSpace(entry.Models[i].Name)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		if model := staticByID[key]; model != nil {
+			clone := *model
+			clone.UserDefined = true
+			out = append(out, &clone)
+			continue
+		}
+		out = append(out, &ModelInfo{
+			ID:          name,
+			Object:      "model",
+			Created:     now,
+			OwnedBy:     "opencode",
+			Type:        "opencode-go",
+			DisplayName: name,
+			UserDefined: true,
+		})
+	}
+	return out
+}
+
 func rewriteModelInfoName(name, oldID, newID string) string {
 	trimmed := strings.TrimSpace(name)
 	if trimmed == "" {

--- a/sdk/cliproxy/service_opencode_go_test.go
+++ b/sdk/cliproxy/service_opencode_go_test.go
@@ -51,8 +51,8 @@ func TestRegisterModelsForAuth_OpenCodeGoRegistersAllDefaultModels(t *testing.T)
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetAvailableModelsByProvider("opencode-go")
-	if len(models) != 14 {
-		t.Fatalf("expected 14 registered opencode-go models, got %d: %+v", len(models), models)
+	if len(models) != 20 {
+		t.Fatalf("expected 20 registered opencode-go models, got %d: %+v", len(models), models)
 	}
 	ids := make(map[string]struct{}, len(models))
 	for _, model := range models {
@@ -65,5 +65,51 @@ func TestRegisterModelsForAuth_OpenCodeGoRegistersAllDefaultModels(t *testing.T)
 	}
 	if _, ok := ids["minimax-m2.7"]; !ok {
 		t.Fatalf("minimax-m2.7 not registered; got ids %#v", ids)
+	}
+	if _, ok := ids["kimi-k2.7-code"]; !ok {
+		t.Fatalf("kimi-k2.7-code not registered; got ids %#v", ids)
+	}
+}
+
+func TestRegisterModelsForAuth_OpenCodeGoUsesExplicitModels(t *testing.T) {
+	service := &Service{cfg: &config.Config{
+		OpenCodeGoKey: []config.OpenCodeGoKey{{
+			APIKey: "go-key-explicit",
+			Models: []config.OpenCodeGoModel{
+				{Name: "qwen3.7-max"},
+				{Name: "official-new-model"},
+			},
+		}},
+	}}
+	auth := &coreauth.Auth{
+		ID:       "opencode-go-auth-explicit-models",
+		Provider: "opencode-go",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "go-key-explicit",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := registry.GetModelsForClient(auth.ID)
+	if len(models) != 2 {
+		t.Fatalf("expected 2 explicit opencode-go models, got %d: %+v", len(models), models)
+	}
+	if !hasModelID(models, "qwen3.7-max") {
+		t.Fatalf("qwen3.7-max not registered; got %+v", models)
+	}
+	if !hasModelID(models, "official-new-model") {
+		t.Fatalf("official-new-model not registered; got %+v", models)
+	}
+	if hasModelID(models, "deepseek-v4-flash") {
+		t.Fatalf("deepseek-v4-flash should not be registered from explicit models; got %+v", models)
 	}
 }

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -32,6 +32,7 @@ type ClaudeKey = bridgeconfig.ClaudeKey
 type BedrockKey = bridgeconfig.BedrockKey
 type BedrockModel = bridgeconfig.BedrockModel
 type OpenCodeGoKey = bridgeconfig.OpenCodeGoKey
+type OpenCodeGoModel = bridgeconfig.OpenCodeGoModel
 type VertexCompatKey = bridgeconfig.VertexCompatKey
 type VertexCompatModel = bridgeconfig.VertexCompatModel
 type OpenAICompatibility = bridgeconfig.OpenAICompatibility

--- a/sdkbridge/config/config.go
+++ b/sdkbridge/config/config.go
@@ -29,6 +29,7 @@ type ClaudeKey = internalconfig.ClaudeKey
 type BedrockKey = internalconfig.BedrockKey
 type BedrockModel = internalconfig.BedrockModel
 type OpenCodeGoKey = internalconfig.OpenCodeGoKey
+type OpenCodeGoModel = internalconfig.OpenCodeGoModel
 type VertexCompatKey = internalconfig.VertexCompatKey
 type VertexCompatModel = internalconfig.VertexCompatModel
 type OpenAICompatibility = internalconfig.OpenAICompatibility


### PR DESCRIPTION
## Summary
- persist OpenCode Go `models` through config normalize, patch, and runtime bridge paths
- register only explicitly enabled OpenCode Go models when `models` is configured, with legacy fallback preserved
- expose configured model `sources` for management debugging

## Tests
- `rtk go test ./...`
- `rtk git -C CliRelay diff --cached --check`