### PR TITLE
feat: record request log stream mode

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -77,6 +77,7 @@ func TestGetUsageLogsResolvesLegacySourceChannelName(t *testing.T) {
 		Items []struct {
 			ChannelName  string `json:"channel_name"`
 			AuthIndex    string `json:"auth_index"`
+			Streaming    bool   `json:"streaming"`
 			FirstTokenMs int64  `json:"first_token_ms"`
 		} `json:"items"`
 	}
@@ -94,6 +95,9 @@ func TestGetUsageLogsResolvesLegacySourceChannelName(t *testing.T) {
 	}
 	if payload.Items[0].FirstTokenMs != 45 {
 		t.Fatalf("first_token_ms = %d, want %d", payload.Items[0].FirstTokenMs, 45)
+	}
+	if payload.Items[0].Streaming {
+		t.Fatalf("streaming = true, want false")
 	}
 }
 

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -48,7 +48,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 	// Fetch page
 	offset := (params.Page - 1) * params.Size
 	querySQL := "SELECT id, timestamp, api_key, api_key_name, model, source, channel_name, auth_index, " +
-		"failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, " +
+		"failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, " +
 		"cost, " +
 		"(CASE WHEN EXISTS (SELECT 1 FROM request_log_content content WHERE content.log_id = request_logs.id) " +
 		"OR length(input_content) > 0 OR length(output_content) > 0 THEN 1 ELSE 0 END) as has_content " +
@@ -66,10 +66,10 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 	for rows.Next() {
 		var row LogRow
 		var ts string
-		var failedInt, hasContentInt int
+		var failedInt, streamingInt, hasContentInt int
 		if err := rows.Scan(
 			&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.Source, &row.ChannelName,
-			&row.AuthIndex, &failedInt, &row.LatencyMs, &row.FirstTokenMs,
+			&row.AuthIndex, &failedInt, &streamingInt, &row.LatencyMs, &row.FirstTokenMs,
 			&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
 			&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,
 		); err != nil {
@@ -77,9 +77,11 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		}
 		row.Timestamp, _ = time.Parse(time.RFC3339Nano, ts)
 		row.Failed = failedInt != 0
+		row.Streaming = streamingInt != 0
 		row.HasContent = hasContentInt != 0
 		items = append(items, row)
 	}
+	hydrateStreamingFromContent(db, items)
 
 	return LogQueryResult{
 		Items: items,
@@ -87,6 +89,73 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		Page:  params.Page,
 		Size:  params.Size,
 	}, nil
+}
+
+func hydrateStreamingFromContent(db *sql.DB, items []LogRow) {
+	if db == nil || len(items) == 0 {
+		return
+	}
+
+	indexByID := make(map[int64]int, len(items))
+	ids := make([]int64, 0, len(items))
+	for i := range items {
+		if items[i].Streaming {
+			continue
+		}
+		indexByID[items[i].ID] = i
+		ids = append(ids, items[i].ID)
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	rows, err := db.Query(
+		`SELECT logs.id, logs.input_content, content.compression, content.input_content
+		FROM request_logs logs
+		LEFT JOIN request_log_content content ON content.log_id = logs.id
+		WHERE logs.id IN (`+placeholders+`) AND (length(logs.input_content) > 0 OR length(content.input_content) > 0)`,
+		args...,
+	)
+	if err != nil {
+		log.Warnf("usage: query request log content for streaming flag: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		var legacyInput string
+		var compression sql.NullString
+		var storedInput []byte
+		if err := rows.Scan(&id, &legacyInput, &compression, &storedInput); err != nil {
+			log.Warnf("usage: scan request log content for streaming flag: %v", err)
+			continue
+		}
+		streaming := isStreamingRequestContent(legacyInput)
+		if !streaming && len(storedInput) > 0 {
+			compressionName := "zstd"
+			if compression.Valid {
+				compressionName = compression.String
+			}
+			input, err := decompressLogContent(compressionName, storedInput)
+			if err != nil {
+				log.Warnf("usage: decompress request log content for streaming flag: %v", err)
+				continue
+			}
+			streaming = isStreamingRequestContent(input)
+		}
+		if index, ok := indexByID[id]; ok && streaming {
+			items[index].Streaming = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		log.Warnf("usage: iterate request log content for streaming flag: %v", err)
+	}
 }
 
 // QueryFilters returns the distinct API keys and models within the time range.

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -24,6 +25,7 @@ type LogRow struct {
 	ChannelName     string    `json:"channel_name"`
 	AuthIndex       string    `json:"auth_index"`
 	Failed          bool      `json:"failed"`
+	Streaming       bool      `json:"streaming"`
 	LatencyMs       int64     `json:"latency_ms"`
 	FirstTokenMs    int64     `json:"first_token_ms"`
 	InputTokens     int64     `json:"input_tokens"`
@@ -126,6 +128,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
   channel_name     TEXT NOT NULL DEFAULT '',
   auth_index       TEXT NOT NULL DEFAULT '',
   failed           INTEGER NOT NULL DEFAULT 0,
+  streaming        INTEGER NOT NULL DEFAULT 0,
   latency_ms       INTEGER NOT NULL DEFAULT 0,
   first_token_ms   INTEGER NOT NULL DEFAULT 0,
   input_tokens     INTEGER NOT NULL DEFAULT 0,
@@ -302,6 +305,15 @@ func migrateFirstTokenColumn(db *sql.DB) {
 	}
 }
 
+func migrateStreamingColumn(db *sql.DB) {
+	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN streaming INTEGER NOT NULL DEFAULT 0")
+	if err != nil {
+		if !strings.Contains(err.Error(), "duplicate") {
+			log.Warnf("usage: migrate column streaming: %v", err)
+		}
+	}
+}
+
 func migrateRequestLogDetailColumn(db *sql.DB) {
 	_, err := db.Exec("ALTER TABLE request_log_content ADD COLUMN detail_content BLOB NOT NULL DEFAULT X''")
 	if err != nil {
@@ -392,6 +404,8 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	migrateAuthSubjectIDColumns(db)
 	log.Debugf("usage: running first_token_ms column migration")
 	migrateFirstTokenColumn(db)
+	log.Debugf("usage: running streaming column migration")
+	migrateStreamingColumn(db)
 	log.Debugf("usage: running request log detail column migration")
 	migrateRequestLogDetailColumn(db)
 	log.Debugf("usage: ensuring request log detail indexes")
@@ -471,6 +485,10 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, sourc
 	if failed {
 		failedInt = 1
 	}
+	streamingInt := 0
+	if isStreamingRequestContent(inputContent) {
+		streamingInt = 1
+	}
 
 	// Calculate cost based on model pricing using semantic cache read/write
 	cost := CalculateCostV2(model, tokens)
@@ -498,11 +516,11 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, sourc
 	result, err := tx.Exec(
 		`INSERT INTO request_logs
 			(timestamp, api_key, api_key_id, auth_subject_id, api_key_name, model, source, channel_name, auth_index,
-			 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		timestamp.UTC().Format(time.RFC3339Nano),
 		apiKey, apiKeyID, authSubjectID, apiKeyName, model, source, channelName, authIndex,
-		failedInt, latencyMs, firstTokenMs,
+		failedInt, streamingInt, latencyMs, firstTokenMs,
 		tokens.InputTokens, tokens.OutputTokens, tokens.ReasoningTokens,
 		tokens.CachedTokens, tokens.TotalTokens, cost,
 	)
@@ -535,6 +553,16 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, sourc
 	if tokenUsageCallback != nil && tokens.TotalTokens > 0 {
 		tokenUsageCallback(apiKey, tokens.TotalTokens)
 	}
+}
+
+func isStreamingRequestContent(content string) bool {
+	var payload struct {
+		Stream bool `json:"stream"`
+	}
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		return false
+	}
+	return payload.Stream
 }
 
 // tokenUsageCallback is set by SetTokenUsageCallback to notify external

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -554,7 +554,7 @@ func TestQueryLogContentPartReturnsStoredRequestDetails(t *testing.T) {
 	}
 }
 
-func TestInitDBMigratesFirstTokenColumn(t *testing.T) {
+func TestInitDBMigratesFirstTokenAndStreamingColumns(t *testing.T) {
 	CloseDB()
 	dbPath := filepath.Join(t.TempDir(), "usage.db")
 
@@ -597,7 +597,7 @@ func TestInitDBMigratesFirstTokenColumn(t *testing.T) {
 	t.Cleanup(CloseDB)
 
 	db := getDB()
-	var found bool
+	found := map[string]bool{}
 	rows, err := db.Query("PRAGMA table_info(request_logs)")
 	if err != nil {
 		t.Fatalf("PRAGMA table_info(request_logs): %v", err)
@@ -612,13 +612,15 @@ func TestInitDBMigratesFirstTokenColumn(t *testing.T) {
 		if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &pk); err != nil {
 			t.Fatalf("scan table info: %v", err)
 		}
-		if name == "first_token_ms" {
-			found = true
-			break
+		if name == "first_token_ms" || name == "streaming" {
+			found[name] = true
 		}
 	}
-	if !found {
+	if !found["first_token_ms"] {
 		t.Fatalf("expected first_token_ms column to exist after InitDB migration")
+	}
+	if !found["streaming"] {
+		t.Fatalf("expected streaming column to exist after InitDB migration")
 	}
 }
 
@@ -750,6 +752,9 @@ func TestInsertLogStoresCompressedContentOutsideMainTable(t *testing.T) {
 	if result.Items[0].FirstTokenMs != 45 {
 		t.Fatalf("FirstTokenMs = %d, want %d", result.Items[0].FirstTokenMs, 45)
 	}
+	if result.Items[0].Streaming {
+		t.Fatalf("Streaming = true, want false for non-stream request")
+	}
 	if !result.Items[0].HasContent {
 		t.Fatalf("expected HasContent to be true")
 	}
@@ -786,6 +791,86 @@ func TestInsertLogStoresCompressedContentOutsideMainTable(t *testing.T) {
 	}
 	if len(compressedInput) == 0 || len(compressedOutput) == 0 {
 		t.Fatalf("expected compressed content blobs to be present")
+	}
+}
+
+func TestQueryLogsMarksStreamingRequests(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	timestamp := time.Now().UTC()
+	InsertLog("sk-test", "", "gpt-test", "source", "channel", "auth-1", false, timestamp, 123, 45, TokenStats{
+		InputTokens:  10,
+		OutputTokens: 20,
+		TotalTokens:  30,
+	}, `{"model":"gpt-test","stream":true}`, "")
+
+	result, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() error = %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 log row, got %d", len(result.Items))
+	}
+	if !result.Items[0].Streaming {
+		t.Fatalf("Streaming = false, want true")
+	}
+}
+
+func TestQueryLogsHydratesLegacyStreamingFlagFromContent(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	timestamp := time.Now().UTC()
+	InsertLog("sk-test", "", "gpt-test", "source", "channel", "auth-1", false, timestamp, 123, 45, TokenStats{
+		InputTokens:  10,
+		OutputTokens: 20,
+		TotalTokens:  30,
+	}, `{"model":"gpt-test","stream":true}`, "")
+
+	db := getDB()
+	if _, err := db.Exec("UPDATE request_logs SET streaming = 0"); err != nil {
+		t.Fatalf("reset streaming flag: %v", err)
+	}
+
+	result, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() error = %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 log row, got %d", len(result.Items))
+	}
+	if !result.Items[0].Streaming {
+		t.Fatalf("Streaming = false, want true from stored content")
+	}
+}
+
+func TestQueryLogsHydratesLegacyStreamingFlagFromInlineContent(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	db := getDB()
+	timestamp := time.Now().UTC()
+	_, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, model, source, channel_name, auth_index,
+			 failed, latency_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens,
+			 cost, input_content)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		timestamp.Format(time.RFC3339Nano),
+		"sk-legacy", "gpt-test", "source", "channel", "auth-legacy",
+		0, 123, 10, 20, 0, 0, 30, 0, `{"model":"gpt-test","stream":true}`,
+	)
+	if err != nil {
+		t.Fatalf("insert legacy inline row: %v", err)
+	}
+
+	result, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() error = %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 log row, got %d", len(result.Items))
+	}
+	if !result.Items[0].Streaming {
+		t.Fatalf("Streaming = false, want true from inline content")
 	}
 }
 

--- a/internal/usage/usage_log_queries.go
+++ b/internal/usage/usage_log_queries.go
@@ -14,10 +14,10 @@ func QueryLogRowByID(id int64) (LogRow, error) {
 
 	var row LogRow
 	var ts string
-	var failedInt, hasContentInt int
+	var failedInt, streamingInt, hasContentInt int
 	err := db.QueryRow(
 		"SELECT id, timestamp, api_key, api_key_name, model, source, channel_name, auth_index, "+
-			"failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, "+
+			"failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, "+
 			"cost, "+
 			"(CASE WHEN EXISTS (SELECT 1 FROM request_log_content content WHERE content.log_id = request_logs.id) "+
 			"OR length(input_content) > 0 OR length(output_content) > 0 THEN 1 ELSE 0 END) as has_content "+
@@ -25,7 +25,7 @@ func QueryLogRowByID(id int64) (LogRow, error) {
 		id,
 	).Scan(
 		&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.Source, &row.ChannelName,
-		&row.AuthIndex, &failedInt, &row.LatencyMs, &row.FirstTokenMs,
+		&row.AuthIndex, &failedInt, &streamingInt, &row.LatencyMs, &row.FirstTokenMs,
 		&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
 		&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,
 	)
@@ -34,6 +34,10 @@ func QueryLogRowByID(id int64) (LogRow, error) {
 	}
 	row.Timestamp, _ = time.Parse(time.RFC3339Nano, ts)
 	row.Failed = failedInt != 0
+	row.Streaming = streamingInt != 0
 	row.HasContent = hasContentInt != 0
+	rows := []LogRow{row}
+	hydrateStreamingFromContent(db, rows)
+	row = rows[0]
 	return row, nil
 }


### PR DESCRIPTION
## Summary
- add request log streaming metadata and migration
- hydrate legacy rows from stored request content
- cover stream mode in usage log tests

## Verification
- rtk go test ./internal/usage ./internal/api/handlers/management