### PR TITLE
fix: preserve provider models with mapped owners

### DIFF
--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -334,18 +334,25 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	initManagementModelsTestDB(t)
 
 	const (
-		authID      = "codex-default-mapped-owner-auth"
-		registryID  = "codex-default-mapped-owner-registry"
-		mappedModel = "mapped-codex-owner-model"
-		oldModel    = "old-codex-registry-model"
+		authID             = "codex-default-mapped-owner-auth"
+		openCodeAuthID     = "opencode-default-mapped-owner-auth"
+		registryID         = "codex-default-mapped-owner-registry"
+		openCodeRegistryID = "opencode-default-mapped-owner-registry"
+		mappedModel        = "mapped-codex-owner-model"
+		oldModel           = "old-codex-registry-model"
+		openCodeModel      = "opencode-provider-model"
 	)
 
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient(registryID, "codex", []*registry.ModelInfo{
 		{ID: oldModel, Object: "model", OwnedBy: "openai", Type: "openai"},
 	})
+	reg.RegisterClient(openCodeRegistryID, "opencode-go", []*registry.ModelInfo{
+		{ID: openCodeModel, Object: "model", OwnedBy: "opencode", Type: "opencode-go"},
+	})
 	t.Cleanup(func() {
 		reg.UnregisterClient(registryID)
+		reg.UnregisterClient(openCodeRegistryID)
 	})
 
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -356,6 +363,14 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 		Status:   coreauth.StatusActive,
 	}); err != nil {
 		t.Fatalf("Register codex auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       openCodeAuthID,
+		Provider: "opencode-go",
+		Label:    "OpenCode Go",
+		Status:   coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("Register opencode auth: %v", err)
 	}
 	if err := usage.UpsertAuthGroupOwnerMapping(usage.AuthGroupOwnerMappingRow{
 		AuthGroup: "codex",
@@ -401,6 +416,9 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	}
 	if _, ok := ids[mappedModel]; !ok {
 		t.Fatalf("missing mapped owner model %q; ids=%v", mappedModel, ids)
+	}
+	if _, ok := ids[openCodeModel]; !ok {
+		t.Fatalf("missing unmapped provider model %q; ids=%v", openCodeModel, ids)
 	}
 	if _, ok := ids[oldModel]; ok {
 		t.Fatalf("unexpected registry model outside mapped owner %q; ids=%v", oldModel, ids)

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -16,14 +16,12 @@ import (
 func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
 	modelRegistry := registry.GetGlobalRegistry()
 	allModels := s.effectiveModels(modelRegistry.GetAvailableModels("openai"), allowedChannelsRaw, allowedGroupsRaw)
+	authByID := s.authByID()
 	usesMappedOwners := false
 	if shouldUseDefaultMappedOwnerScope(allowedChannelsRaw, allowedGroupsRaw) {
-		if rows, ok := s.defaultMappedOwnerRows(); ok {
+		if rows, ownerKeys, ok := s.defaultMappedOwnerRows(); ok {
 			usesMappedOwners = true
-			allModels = make([]map[string]any, 0, len(rows))
-			for _, row := range rows {
-				allModels = append(allModels, modelConfigRowAsOpenAIModel(row))
-			}
+			allModels = withDefaultMappedOwnerRows(modelRegistry, allModels, rows, ownerKeys, authByID)
 		}
 	}
 
@@ -32,8 +30,6 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	for _, row := range allConfigRows {
 		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
 	}
-	authByID := s.authByID()
-
 	data := make([]map[string]any, 0, len(allModels))
 	activeMetadata := make([]map[string]any, 0, len(allModels))
 	for _, model := range allModels {
@@ -248,10 +244,10 @@ func shouldUseDefaultMappedOwnerScope(allowedChannelsRaw, allowedGroupsRaw strin
 	return strings.TrimSpace(allowedChannelsRaw) == "" && strings.TrimSpace(allowedGroupsRaw) == ""
 }
 
-func (s *Service) defaultMappedOwnerRows() ([]usage.ModelConfigRow, bool) {
+func (s *Service) defaultMappedOwnerRows() ([]usage.ModelConfigRow, map[string]bool, bool) {
 	ownerKeys := s.defaultMappedOwnerKeys()
 	if len(ownerKeys) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	rows := modelconfigsettings.ListAllConfigs()
 	out := make([]usage.ModelConfigRow, 0, len(rows))
@@ -263,7 +259,83 @@ func (s *Service) defaultMappedOwnerRows() ([]usage.ModelConfigRow, bool) {
 			out = append(out, row)
 		}
 	}
-	return out, true
+	return out, ownerKeys, true
+}
+
+func withDefaultMappedOwnerRows(
+	modelRegistry *registry.ModelRegistry,
+	models []map[string]any,
+	rows []usage.ModelConfigRow,
+	ownerKeys map[string]bool,
+	authByID map[string]*coreauth.Auth,
+) []map[string]any {
+	out := make([]map[string]any, 0, len(models)+len(rows))
+	seen := make(map[string]struct{}, len(models)+len(rows))
+	ownerMappings := authGroupOwnerMappingMap()
+	for _, model := range models {
+		id, _ := model["id"].(string)
+		key := strings.ToLower(strings.TrimSpace(id))
+		if key == "" {
+			continue
+		}
+		if registryModelCoveredByMappedOwners(modelRegistry, id, authByID, ownerMappings, ownerKeys) {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, model)
+	}
+	for _, row := range rows {
+		key := strings.ToLower(strings.TrimSpace(row.ModelID))
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, modelConfigRowAsOpenAIModel(row))
+	}
+	return out
+}
+
+func registryModelCoveredByMappedOwners(
+	modelRegistry *registry.ModelRegistry,
+	modelID string,
+	authByID map[string]*coreauth.Auth,
+	ownerMappings map[string]string,
+	ownerKeys map[string]bool,
+) bool {
+	if modelRegistry == nil || len(ownerMappings) == 0 || len(ownerKeys) == 0 {
+		return false
+	}
+	sources := modelRegistry.GetModelClientSources(modelID)
+	if len(sources) == 0 {
+		return false
+	}
+	for _, source := range sources {
+		owner := mappedOwnerForSource(source, authByID, ownerMappings)
+		if owner == "" || !ownerKeys[owner] {
+			return false
+		}
+	}
+	return true
+}
+
+func mappedOwnerForSource(source registry.ModelClientSource, authByID map[string]*coreauth.Auth, ownerMappings map[string]string) string {
+	values := []string{source.Provider}
+	if auth := authByID[strings.TrimSpace(source.ClientID)]; auth != nil {
+		values = append(values, auth.Provider, auth.ChannelName())
+		values = append(values, auth.ChannelIdentifiers()...)
+	}
+	for _, value := range values {
+		if owner := ownerMappings[normalizeAuthGroupKey(value)]; owner != "" {
+			return owner
+		}
+	}
+	return ""
 }
 
 func (s *Service) defaultMappedOwnerKeys() map[string]bool {


### PR DESCRIPTION
## Summary\n- keep unmapped provider registry models in default configured availability when auth-group owner mappings are active\n- still replace mapped auth-group registry contributions with enabled model config rows\n- add regression coverage for Codex mapped owners plus OpenCode Go/provider models\n\n## Tests\n- go test ./internal/management/modelcatalog ./internal/api/handlers/management ./sdk/cliproxy\n- go test ./...