### PR TITLE
fix: filter mapped owner sources in model availability

### DIFF
--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -351,6 +351,9 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	reg.RegisterClient(registryID, "codex", []*registry.ModelInfo{
 		{ID: oldModel, Object: "model", OwnedBy: "openai", Type: "openai"},
 	})
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{
+		{ID: codexConfigModel, Object: "model", OwnedBy: "openai", Type: "openai"},
+	})
 	reg.RegisterClient(codexConfigAuthID, "codex", []*registry.ModelInfo{
 		{ID: codexConfigModel, Object: "model", OwnedBy: "openai", Type: "openai", UserDefined: true},
 	})
@@ -362,6 +365,7 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		reg.UnregisterClient(registryID)
+		reg.UnregisterClient(authID)
 		reg.UnregisterClient(codexConfigAuthID)
 		reg.UnregisterClient(codexStaticAuthID)
 		reg.UnregisterClient(openCodeRegistryID)
@@ -379,7 +383,7 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	if _, err := manager.Register(context.Background(), &coreauth.Auth{
 		ID:       codexConfigAuthID,
 		Provider: "codex",
-		Label:    "Codex Config",
+		Label:    "tabcode-pro",
 		Status:   coreauth.StatusActive,
 		Attributes: map[string]string{
 			"auth_kind":   "apikey",
@@ -438,7 +442,10 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	var payload struct {
 		UsesMappedOwners bool `json:"uses_mapped_owners"`
 		Data             []struct {
-			ID string `json:"id"`
+			ID      string `json:"id"`
+			Sources []struct {
+				Label string `json:"label"`
+			} `json:"sources"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
@@ -448,8 +455,14 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 		t.Fatalf("uses_mapped_owners = false, want true; body=%s", rec.Body.String())
 	}
 	ids := make(map[string]struct{}, len(payload.Data))
+	sourcesByID := make(map[string]map[string]bool, len(payload.Data))
 	for _, item := range payload.Data {
 		ids[item.ID] = struct{}{}
+		labels := make(map[string]bool, len(item.Sources))
+		for _, source := range item.Sources {
+			labels[source.Label] = true
+		}
+		sourcesByID[item.ID] = labels
 	}
 	if _, ok := ids[mappedModel]; !ok {
 		t.Fatalf("missing mapped owner model %q; ids=%v", mappedModel, ids)
@@ -459,6 +472,12 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	}
 	if _, ok := ids[codexConfigModel]; !ok {
 		t.Fatalf("missing explicit codex provider model %q; ids=%v", codexConfigModel, ids)
+	}
+	if !sourcesByID[codexConfigModel]["codex · tabcode-pro"] {
+		t.Fatalf("missing explicit codex provider source for %q; sources=%v", codexConfigModel, sourcesByID[codexConfigModel])
+	}
+	if sourcesByID[codexConfigModel]["codex · Codex"] {
+		t.Fatalf("unexpected mapped owner oauth source for %q; sources=%v", codexConfigModel, sourcesByID[codexConfigModel])
 	}
 	if _, ok := ids[oldModel]; ok {
 		t.Fatalf("unexpected registry model outside mapped owner %q; ids=%v", oldModel, ids)

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -18,10 +18,14 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	allModels := s.effectiveModels(modelRegistry.GetAvailableModels("openai"), allowedChannelsRaw, allowedGroupsRaw)
 	authByID := s.authByID()
 	usesMappedOwners := false
+	var ownerMappings map[string]string
+	var ownerKeys map[string]bool
 	if shouldUseDefaultMappedOwnerScope(allowedChannelsRaw, allowedGroupsRaw) {
-		if rows, ownerKeys, ok := s.defaultMappedOwnerRows(); ok {
+		if rows, keys, ok := s.defaultMappedOwnerRows(); ok {
 			usesMappedOwners = true
-			allModels = withDefaultMappedOwnerRows(modelRegistry, allModels, rows, ownerKeys, authByID)
+			ownerKeys = keys
+			ownerMappings = authGroupOwnerMappingMap()
+			allModels = withDefaultMappedOwnerRows(modelRegistry, allModels, rows, ownerKeys, authByID, ownerMappings)
 		}
 	}
 
@@ -46,7 +50,7 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		if ownedBy, exists := model["owned_by"]; exists {
 			entry["owned_by"] = ownedBy
 		}
-		if sources := s.modelSourceEntries(modelRegistry, id, authByID); len(sources) > 0 {
+		if sources := s.modelSourceEntries(modelRegistry, id, authByID, ownerMappings, ownerKeys); len(sources) > 0 {
 			entry["sources"] = sources
 		}
 		if row, ok := configByID[strings.ToLower(id)]; ok {
@@ -268,10 +272,10 @@ func withDefaultMappedOwnerRows(
 	rows []usage.ModelConfigRow,
 	ownerKeys map[string]bool,
 	authByID map[string]*coreauth.Auth,
+	ownerMappings map[string]string,
 ) []map[string]any {
 	out := make([]map[string]any, 0, len(models)+len(rows))
 	seen := make(map[string]struct{}, len(models)+len(rows))
-	ownerMappings := authGroupOwnerMappingMap()
 	for _, model := range models {
 		id, _ := model["id"].(string)
 		key := strings.ToLower(strings.TrimSpace(id))
@@ -325,6 +329,19 @@ func registryModelCoveredByMappedOwners(
 		}
 	}
 	return true
+}
+
+func sourceCoveredByMappedOwners(
+	source registry.ModelClientSource,
+	authByID map[string]*coreauth.Auth,
+	ownerMappings map[string]string,
+	ownerKeys map[string]bool,
+) bool {
+	if len(ownerMappings) == 0 || len(ownerKeys) == 0 || sourceHasExplicitConfigModels(source, authByID) {
+		return false
+	}
+	owner := mappedOwnerForSource(source, authByID, ownerMappings)
+	return owner != "" && ownerKeys[owner]
 }
 
 func sourceHasExplicitConfigModels(source registry.ModelClientSource, authByID map[string]*coreauth.Auth) bool {
@@ -398,7 +415,13 @@ func (s *Service) authByID() map[string]*coreauth.Auth {
 	return out
 }
 
-func (s *Service) modelSourceEntries(modelRegistry *registry.ModelRegistry, modelID string, authByID map[string]*coreauth.Auth) []map[string]any {
+func (s *Service) modelSourceEntries(
+	modelRegistry *registry.ModelRegistry,
+	modelID string,
+	authByID map[string]*coreauth.Auth,
+	ownerMappings map[string]string,
+	ownerKeys map[string]bool,
+) []map[string]any {
 	if modelRegistry == nil {
 		return nil
 	}
@@ -409,6 +432,9 @@ func (s *Service) modelSourceEntries(modelRegistry *registry.ModelRegistry, mode
 	out := make([]map[string]any, 0, len(rawSources))
 	seen := make(map[string]struct{}, len(rawSources))
 	for _, raw := range rawSources {
+		if sourceCoveredByMappedOwners(raw, authByID, ownerMappings, ownerKeys) {
+			continue
+		}
 		clientID := strings.TrimSpace(raw.ClientID)
 		provider := strings.TrimSpace(raw.Provider)
 		channel := ""


### PR DESCRIPTION
## Summary
- filter configured availability sources with the same mapped-owner semantics as model visibility
- preserve explicit config provider models[] sources such as codex · tabcode-pro
- add regression coverage so mapped Codex OAuth/static sources do not appear on the gpt-5.2 source tooltip

## Tests
- go test ./internal/api/handlers/management -run TestDefaultConfiguredAvailabilityUsesMappedOwnerModels
- go test ./internal/api/handlers/management ./internal/management/modelcatalog
- go test ./...
