### PR TITLE
fix: preserve mapped owner model sources

### DIFF
--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -353,6 +353,7 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	})
 	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{
 		{ID: codexConfigModel, Object: "model", OwnedBy: "openai", Type: "openai"},
+		{ID: mappedModel, Object: "model", OwnedBy: "openai", Type: "openai"},
 	})
 	reg.RegisterClient(codexConfigAuthID, "codex", []*registry.ModelInfo{
 		{ID: codexConfigModel, Object: "model", OwnedBy: "openai", Type: "openai", UserDefined: true},
@@ -375,7 +376,7 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	if _, err := manager.Register(context.Background(), &coreauth.Auth{
 		ID:       authID,
 		Provider: "codex",
-		Label:    "Codex",
+		Label:    "Codex Plus",
 		Status:   coreauth.StatusActive,
 	}); err != nil {
 		t.Fatalf("Register codex auth: %v", err)
@@ -476,8 +477,11 @@ func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	if !sourcesByID[codexConfigModel]["codex · tabcode-pro"] {
 		t.Fatalf("missing explicit codex provider source for %q; sources=%v", codexConfigModel, sourcesByID[codexConfigModel])
 	}
-	if sourcesByID[codexConfigModel]["codex · Codex"] {
+	if sourcesByID[codexConfigModel]["codex · Codex Plus"] {
 		t.Fatalf("unexpected mapped owner oauth source for %q; sources=%v", codexConfigModel, sourcesByID[codexConfigModel])
+	}
+	if !sourcesByID[mappedModel]["codex · Codex Plus"] {
+		t.Fatalf("missing mapped owner auth source for %q; sources=%v", mappedModel, sourcesByID[mappedModel])
 	}
 	if _, ok := ids[oldModel]; ok {
 		t.Fatalf("unexpected registry model outside mapped owner %q; ids=%v", oldModel, ids)

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -50,7 +50,9 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		if ownedBy, exists := model["owned_by"]; exists {
 			entry["owned_by"] = ownedBy
 		}
-		if sources := s.modelSourceEntries(modelRegistry, id, authByID, ownerMappings, ownerKeys); len(sources) > 0 {
+		row, hasConfig := configByID[strings.ToLower(id)]
+		modelOwnedByMappedOwner := hasConfig && row.Enabled && ownerKeys[normalizeModelOwnerKey(row.OwnedBy)]
+		if sources := s.modelSourceEntries(modelRegistry, id, authByID, ownerMappings, ownerKeys, modelOwnedByMappedOwner); len(sources) > 0 {
 			entry["sources"] = sources
 		}
 		if row, ok := configByID[strings.ToLower(id)]; ok {
@@ -421,6 +423,7 @@ func (s *Service) modelSourceEntries(
 	authByID map[string]*coreauth.Auth,
 	ownerMappings map[string]string,
 	ownerKeys map[string]bool,
+	modelOwnedByMappedOwner bool,
 ) []map[string]any {
 	if modelRegistry == nil {
 		return nil
@@ -432,7 +435,7 @@ func (s *Service) modelSourceEntries(
 	out := make([]map[string]any, 0, len(rawSources))
 	seen := make(map[string]struct{}, len(rawSources))
 	for _, raw := range rawSources {
-		if sourceCoveredByMappedOwners(raw, authByID, ownerMappings, ownerKeys) {
+		if !modelOwnedByMappedOwner && sourceCoveredByMappedOwners(raw, authByID, ownerMappings, ownerKeys) {
 			continue
 		}
 		clientID := strings.TrimSpace(raw.ClientID)


### PR DESCRIPTION
## Summary
- Preserve auth-file/OAuth source labels for models that are themselves included via mapped owner availability.
- Keep filtering mapped-owner OAuth sources from non-mapped-owner explicit provider models like gpt-5.2.
- Extend the management availability regression test to cover both sides of that boundary.

## Tests
- go test ./internal/api/handlers/management -run TestDefaultConfiguredAvailabilityUsesMappedOwnerModels -count=1
- go test ./internal/api/handlers/management ./internal/management/modelcatalog -count=1
- go test ./... -count=1
- bun run --filter @code-proxy/admin-panel test pages/system/__tests__/SystemPage.test.tsx
- bun run build