### PR TITLE
fix: expand tag channel groups for scoped models

### DIFF
--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -330,6 +330,89 @@ func TestScopedModelsIncludeOwnerMappedConfiguredModels(t *testing.T) {
 	}
 }
 
+func TestScopedModelsExpandTagMatchedChannelGroupsForConfiguredRows(t *testing.T) {
+	initManagementModelsTestDB(t)
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name: "plus-codex-opencode",
+					Match: config.ChannelGroupMatch{
+						Tags: []string{"plus", "opencode-go"},
+					},
+				},
+			},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex-plus",
+		Provider: "codex",
+		Label:    "Codex Plus",
+		Metadata: map[string]any{"plan_type": "plus"},
+	}); err != nil {
+		t.Fatalf("Register codex auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "opencode-go",
+		Provider: "opencode-go",
+		Label:    "OpenCode Go",
+	}); err != nil {
+		t.Fatalf("Register opencode auth: %v", err)
+	}
+	if err := usage.UpsertAuthGroupOwnerMapping(usage.AuthGroupOwnerMappingRow{
+		AuthGroup: "codex",
+		Owner:     "codex",
+	}); err != nil {
+		t.Fatalf("UpsertAuthGroupOwnerMapping: %v", err)
+	}
+	for _, row := range []usage.ModelConfigRow{
+		{ModelID: "gpt-5.5", OwnedBy: "codex", Description: "GPT 5.5", Enabled: true, Source: "seed"},
+		{ModelID: "glm-5.2", OwnedBy: "opencode", Description: "GLM 5.2", Enabled: true, Source: "opencode-go"},
+		{ModelID: "unrelated-openai", OwnedBy: "openai", Description: "OpenAI", Enabled: true, Source: "seed"},
+	} {
+		if err := usage.UpsertModelConfig(row); err != nil {
+			t.Fatalf("UpsertModelConfig(%s): %v", row.ModelID, err)
+		}
+	}
+	h := NewHandler(cfg, "", manager)
+	decodeIDs := func(rec *httptest.ResponseRecorder) map[string]struct{} {
+		t.Helper()
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+		}
+		var payload struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		ids := make(map[string]struct{}, len(payload.Data))
+		for _, item := range payload.Data {
+			ids[item.ID] = struct{}{}
+		}
+		return ids
+	}
+
+	ids := decodeIDs(performModelsRequest(
+		http.MethodGet,
+		"/models/configured-availability?allowed_channel_groups=plus-codex-opencode",
+		nil,
+		h.Models().GetConfiguredModelAvailability,
+	))
+	for _, id := range []string{"gpt-5.5", "glm-5.2"} {
+		if _, ok := ids[id]; !ok {
+			t.Fatalf("tag-matched group missing configured model %q; ids=%v", id, ids)
+		}
+	}
+	if _, ok := ids["unrelated-openai"]; ok {
+		t.Fatalf("tag-matched group unexpectedly included unrelated model; ids=%v", ids)
+	}
+}
+
 func TestDefaultConfiguredAvailabilityUsesMappedOwnerModels(t *testing.T) {
 	initManagementModelsTestDB(t)
 

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -3,6 +3,8 @@ package modelcatalog
 import (
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
@@ -524,6 +526,11 @@ func (s *Service) modelOwnerScope(channels []string, groups map[string]struct{})
 			ownerKeys[owner] = true
 		}
 	}
+	addOwnersForAuth := func(auth *coreauth.Auth) {
+		for _, channel := range auth.ChannelIdentifiers() {
+			addOwnersForChannel(channel)
+		}
+	}
 	if s.cfg != nil {
 		for _, group := range s.cfg.Routing.ChannelGroups {
 			groupName := internalrouting.NormalizeGroupName(group.Name)
@@ -539,6 +546,14 @@ func (s *Service) modelOwnerScope(channels []string, groups map[string]struct{})
 			for _, channel := range group.Match.Channels {
 				addOwnersForChannel(channel)
 			}
+			for _, auth := range auths {
+				if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+					continue
+				}
+				if routingGroupMatchesAuthForModelScope(group, auth) {
+					addOwnersForAuth(auth)
+				}
+			}
 		}
 	}
 	if len(groups) == 0 {
@@ -547,6 +562,46 @@ func (s *Service) modelOwnerScope(channels []string, groups map[string]struct{})
 		}
 	}
 	return ownerKeys, explicitModels
+}
+
+func routingGroupMatchesAuthForModelScope(group config.RoutingChannelGroup, auth *coreauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	prefix := internalrouting.NormalizeGroupName(auth.Prefix)
+	for _, candidate := range group.Match.Prefixes {
+		if prefix != "" && prefix == internalrouting.NormalizeGroupName(candidate) {
+			return true
+		}
+	}
+	for _, channel := range group.Match.Channels {
+		if authChannelMatches(auth, channel) {
+			return true
+		}
+	}
+	return authMatchesRoutingTags(auth, group.Match.Tags)
+}
+
+func authMatchesRoutingTags(auth *coreauth.Auth, tags []string) bool {
+	if auth == nil || len(tags) == 0 {
+		return false
+	}
+	displayTags := make(map[string]struct{})
+	for _, tag := range managementauthfiles.BuildTagPayload(auth).DisplayTags {
+		normalized := config.NormalizeRoutingTag(tag)
+		if normalized != "" {
+			displayTags[normalized] = struct{}{}
+		}
+	}
+	if len(displayTags) == 0 {
+		return false
+	}
+	for _, tag := range tags {
+		if _, ok := displayTags[config.NormalizeRoutingTag(tag)]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func authGroupOwnerMappingMap() map[string]string {


### PR DESCRIPTION
## Summary
- expand scoped model owner resolution for channel groups matched by prefixes, channels, and tags
- keep allowed-models restrictions intact while adding tag/prefix member expansion
- add regression coverage for tag-only channel groups used by CC Switch model selection

## Tests
- go test ./internal/api/handlers/management -run 'TestScopedModels|TestDefaultConfiguredAvailabilityUsesMappedOwnerModels'\n- go test ./internal/management/modelcatalog\n- go test ./internal/api/handlers/management\n- go test ./internal/management/modelcatalog ./sdk/cliproxy/auth\n- go test ./internal/management/authfiles\n- go test ./...\n- bun run --filter @code-proxy/admin-panel test -- pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx