### PR TITLE
fix: support CC Switch Codex model mappings

### DIFF
--- a/internal/api/routes_public.go
+++ b/internal/api/routes_public.go
@@ -54,6 +54,7 @@ func (s *Server) setupRoutes() {
 	v1.Use(channelGroupAuthorizationMiddleware())
 	v1.Use(middleware.QuotaMiddleware())
 	v1.Use(s.modelRestrictionMiddleware())
+	v1.Use(ccSwitchOpenAIModelMappingMiddleware())
 	v1.Use(SystemPromptMiddleware())
 	registerV1Routes(v1)
 
@@ -63,6 +64,7 @@ func (s *Server) setupRoutes() {
 	groupedV1.Use(channelGroupAuthorizationMiddleware())
 	groupedV1.Use(middleware.QuotaMiddleware())
 	groupedV1.Use(s.modelRestrictionMiddleware())
+	groupedV1.Use(ccSwitchOpenAIModelMappingMiddleware())
 	groupedV1.Use(SystemPromptMiddleware())
 	registerV1Routes(groupedV1)
 

--- a/internal/api/server_ccswitch_model_mapping.go
+++ b/internal/api/server_ccswitch_model_mapping.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const ccSwitchOpenAIModelMappingContextKey = "cliproxy.ccswitch_openai_model_mapping"
+
+func ccSwitchOpenAIModelMappingMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		mapping := ccSwitchOpenAIModelMapping(pathRouteContextFromGin(c))
+		if len(mapping) == 0 {
+			c.Next()
+			return
+		}
+		c.Set(ccSwitchOpenAIModelMappingContextKey, mapping)
+		if c.Request.Method != http.MethodPost {
+			c.Next()
+			return
+		}
+
+		bodyBytes, err := bodyutil.ReadRequestBody(c, bodyutil.ModelRequestBodyLimit())
+		if err != nil {
+			if bodyutil.IsTooLarge(err) {
+				c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
+				return
+			}
+			if bodyutil.IsStorageUnavailable(err) {
+				c.AbortWithStatusJSON(http.StatusInsufficientStorage, gin.H{"error": "request body temporary storage unavailable"})
+				return
+			}
+			c.Next()
+			return
+		}
+
+		rewritten, _, mapped := rewriteCcSwitchOpenAIModel(bodyBytes, mapping)
+		if mapped {
+			bodyutil.SetRequestBody(c, rewritten)
+		} else {
+			bodyutil.SetRequestBody(c, bodyBytes)
+		}
+		c.Next()
+	}
+}
+
+func ccSwitchOpenAIModelMapping(route *internalrouting.PathRouteContext) map[string]string {
+	if route == nil || route.CcSwitch == nil || !strings.EqualFold(strings.TrimSpace(route.CcSwitch.ClientType), "codex") {
+		return nil
+	}
+	mapping := make(map[string]string)
+	for _, item := range route.CcSwitch.ModelMappings {
+		requestModel := strings.TrimSpace(item.RequestModel)
+		targetModel := strings.TrimSpace(item.TargetModel)
+		if requestModel != "" && targetModel != "" {
+			mapping[requestModel] = targetModel
+		}
+	}
+	return mapping
+}
+
+func rewriteCcSwitchOpenAIModel(rawJSON []byte, mapping map[string]string) ([]byte, string, bool) {
+	modelName := strings.TrimSpace(gjson.GetBytes(rawJSON, "model").String())
+	if modelName == "" || len(mapping) == 0 {
+		return rawJSON, modelName, false
+	}
+	for requestModel, targetModel := range mapping {
+		if !strings.EqualFold(strings.TrimSpace(requestModel), modelName) {
+			continue
+		}
+		targetModel = strings.TrimSpace(targetModel)
+		if targetModel == "" {
+			return rawJSON, modelName, false
+		}
+		rewritten, err := sjson.SetBytes(rawJSON, "model", targetModel)
+		if err != nil {
+			return rawJSON, modelName, false
+		}
+		return rewritten, targetModel, true
+	}
+	return rawJSON, modelName, false
+}

--- a/internal/api/server_ccswitch_model_mapping_test.go
+++ b/internal/api/server_ccswitch_model_mapping_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"testing"
+
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/tidwall/gjson"
+)
+
+func TestCcSwitchOpenAIModelMappingUsesCodexMappings(t *testing.T) {
+	route := &internalrouting.PathRouteContext{
+		CcSwitch: &internalrouting.CcSwitchRouteContext{
+			ClientType: "codex",
+			ModelMappings: []internalrouting.CcSwitchModelMapping{
+				{RequestModel: "deepseek-v4-flash", TargetModel: "deepseek-chat"},
+			},
+		},
+	}
+
+	mapping := ccSwitchOpenAIModelMapping(route)
+	if mapping["deepseek-v4-flash"] != "deepseek-chat" {
+		t.Fatalf("mapping = %#v, want deepseek-v4-flash -> deepseek-chat", mapping)
+	}
+}
+
+func TestRewriteCcSwitchOpenAIModelMapsRequestModel(t *testing.T) {
+	rawJSON := []byte(`{"model":"deepseek-v4-flash","input":"ok"}`)
+
+	rewritten, modelName, mapped := rewriteCcSwitchOpenAIModel(rawJSON, map[string]string{
+		"deepseek-v4-flash": "deepseek-chat",
+	})
+	if !mapped {
+		t.Fatal("mapped = false, want true")
+	}
+	if modelName != "deepseek-chat" {
+		t.Fatalf("modelName = %q, want deepseek-chat", modelName)
+	}
+	if got := gjson.GetBytes(rewritten, "model").String(); got != "deepseek-chat" {
+		t.Fatalf("rewritten model = %q, want deepseek-chat", got)
+	}
+}

--- a/internal/api/server_models_endpoint.go
+++ b/internal/api/server_models_endpoint.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/openai"
 )
@@ -94,7 +95,7 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 		for _, model := range resp.Data {
 			if id, ok := model["id"].(string); ok {
 				if allowedModels != nil {
-					if _, allowed := allowedModels[id]; !allowed {
+					if !modelInSet(id, allowedModels) && !ccSwitchRequestModelAllowedForTarget(id, routeCtx, allowedModels) {
 						continue
 					}
 				}
@@ -112,27 +113,7 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 		resp.Data = filtered
 
 		if routeCtx != nil && routeCtx.CcSwitch != nil {
-			ccswitchModels := make(map[string]struct{})
-			for _, mapping := range routeCtx.CcSwitch.ModelMappings {
-				target := strings.TrimSpace(mapping.TargetModel)
-				if target != "" {
-					ccswitchModels[target] = struct{}{}
-				}
-			}
-			if dm := strings.TrimSpace(routeCtx.CcSwitch.DefaultModel); dm != "" {
-				ccswitchModels[dm] = struct{}{}
-			}
-			if len(ccswitchModels) > 0 {
-				var ccswitchFiltered []map[string]interface{}
-				for _, model := range resp.Data {
-					if id, ok := model["id"].(string); ok {
-						if _, exists := ccswitchModels[id]; exists {
-							ccswitchFiltered = append(ccswitchFiltered, model)
-						}
-					}
-				}
-				resp.Data = ccswitchFiltered
-			}
+			resp.Data = filterModelsForCcSwitchRoute(resp.Data, routeCtx)
 		}
 
 		filteredJSON, err := json.Marshal(resp)
@@ -146,6 +127,122 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 		recorder.ResponseWriter.WriteHeader(http.StatusOK)
 		_, _ = recorder.ResponseWriter.Write(filteredJSON)
 	}
+}
+
+func ccSwitchRequestModelAllowedForTarget(id string, route *internalrouting.PathRouteContext, allowedModels map[string]struct{}) bool {
+	id = strings.TrimSpace(id)
+	if id == "" || route == nil || route.CcSwitch == nil || len(allowedModels) == 0 {
+		return false
+	}
+	for _, mapping := range route.CcSwitch.ModelMappings {
+		target := strings.TrimSpace(mapping.TargetModel)
+		request := strings.TrimSpace(mapping.RequestModel)
+		if target == "" || request == "" || !strings.EqualFold(target, id) {
+			continue
+		}
+		if modelInSet(request, allowedModels) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterModelsForCcSwitchRoute(models []map[string]interface{}, route *internalrouting.PathRouteContext) []map[string]interface{} {
+	if route == nil || route.CcSwitch == nil {
+		return models
+	}
+	if strings.EqualFold(strings.TrimSpace(route.CcSwitch.ClientType), "codex") {
+		return filterCodexModelsForCcSwitchRoute(models, route.CcSwitch)
+	}
+	return filterTargetModelsForCcSwitchRoute(models, route.CcSwitch)
+}
+
+func filterTargetModelsForCcSwitchRoute(models []map[string]interface{}, ccSwitch *internalrouting.CcSwitchRouteContext) []map[string]interface{} {
+	ccswitchModels := make(map[string]struct{})
+	for _, mapping := range ccSwitch.ModelMappings {
+		target := strings.TrimSpace(mapping.TargetModel)
+		if target != "" {
+			ccswitchModels[target] = struct{}{}
+		}
+	}
+	if dm := strings.TrimSpace(ccSwitch.DefaultModel); dm != "" {
+		ccswitchModels[dm] = struct{}{}
+	}
+	if len(ccswitchModels) == 0 {
+		return models
+	}
+	filtered := make([]map[string]interface{}, 0, len(models))
+	for _, model := range models {
+		if id, ok := model["id"].(string); ok {
+			if _, exists := ccswitchModels[id]; exists {
+				filtered = append(filtered, model)
+			}
+		}
+	}
+	return filtered
+}
+
+func filterCodexModelsForCcSwitchRoute(models []map[string]interface{}, ccSwitch *internalrouting.CcSwitchRouteContext) []map[string]interface{} {
+	targetToRequests := make(map[string][]string)
+	for _, mapping := range ccSwitch.ModelMappings {
+		request := strings.TrimSpace(mapping.RequestModel)
+		target := strings.TrimSpace(mapping.TargetModel)
+		if request == "" || target == "" {
+			continue
+		}
+		key := strings.ToLower(target)
+		targetToRequests[key] = appendUniqueModel(targetToRequests[key], request)
+	}
+	defaultModel := strings.TrimSpace(ccSwitch.DefaultModel)
+	if len(targetToRequests) == 0 && defaultModel == "" {
+		return models
+	}
+
+	filtered := make([]map[string]interface{}, 0, len(models))
+	seen := make(map[string]struct{})
+	for _, model := range models {
+		id, ok := model["id"].(string)
+		if !ok {
+			continue
+		}
+		if requests := targetToRequests[strings.ToLower(strings.TrimSpace(id))]; len(requests) > 0 {
+			for _, request := range requests {
+				appendModelClone(&filtered, seen, model, request)
+			}
+			continue
+		}
+		if defaultModel != "" && strings.EqualFold(strings.TrimSpace(id), defaultModel) {
+			appendModelClone(&filtered, seen, model, defaultModel)
+		}
+	}
+	return filtered
+}
+
+func appendUniqueModel(models []string, model string) []string {
+	for _, existing := range models {
+		if strings.EqualFold(existing, model) {
+			return models
+		}
+	}
+	return append(models, model)
+}
+
+func appendModelClone(models *[]map[string]interface{}, seen map[string]struct{}, model map[string]interface{}, id string) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return
+	}
+	key := strings.ToLower(id)
+	if _, exists := seen[key]; exists {
+		return
+	}
+	seen[key] = struct{}{}
+	clone := make(map[string]interface{}, len(model))
+	for k, v := range model {
+		clone[k] = v
+	}
+	clone["id"] = id
+	*models = append(*models, clone)
 }
 
 // responseRecorder captures the response body for post-processing.

--- a/internal/api/server_models_endpoint_test.go
+++ b/internal/api/server_models_endpoint_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"testing"
+
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+)
+
+func TestFilterCodexModelsForCcSwitchRouteReturnsRequestModels(t *testing.T) {
+	models := []map[string]interface{}{
+		{"id": "deepseek-chat", "object": "model", "owned_by": "deepseek"},
+		{"id": "kimi-k2", "object": "model", "owned_by": "moonshot"},
+		{"id": "gpt-5.5", "object": "model", "owned_by": "openai"},
+	}
+	route := &internalrouting.PathRouteContext{
+		CcSwitch: &internalrouting.CcSwitchRouteContext{
+			ClientType:   "codex",
+			DefaultModel: "deepseek-v4-flash",
+			ModelMappings: []internalrouting.CcSwitchModelMapping{
+				{RequestModel: "deepseek-v4-flash", TargetModel: "deepseek-chat"},
+				{RequestModel: "deepseek-v4-pro", TargetModel: "deepseek-chat"},
+			},
+		},
+	}
+
+	filtered := filterModelsForCcSwitchRoute(models, route)
+	got := modelIDs(filtered)
+	want := []string{"deepseek-v4-flash", "deepseek-v4-pro"}
+	if !sameStrings(got, want) {
+		t.Fatalf("model ids = %#v, want %#v", got, want)
+	}
+	if filtered[0]["owned_by"] != "deepseek" {
+		t.Fatalf("owned_by = %v, want deepseek", filtered[0]["owned_by"])
+	}
+}
+
+func TestCcSwitchRequestModelAllowedForTarget(t *testing.T) {
+	route := &internalrouting.PathRouteContext{
+		CcSwitch: &internalrouting.CcSwitchRouteContext{
+			ModelMappings: []internalrouting.CcSwitchModelMapping{
+				{RequestModel: "deepseek-v4-flash", TargetModel: "deepseek-chat"},
+			},
+		},
+	}
+
+	if !ccSwitchRequestModelAllowedForTarget("deepseek-chat", route, map[string]struct{}{"deepseek-v4-flash": {}}) {
+		t.Fatal("request model alias was not allowed for target")
+	}
+	if ccSwitchRequestModelAllowedForTarget("kimi-k2", route, map[string]struct{}{"deepseek-v4-flash": {}}) {
+		t.Fatal("unmapped target was allowed")
+	}
+}
+
+func modelIDs(models []map[string]interface{}) []string {
+	ids := make([]string, 0, len(models))
+	for _, model := range models {
+		if id, ok := model["id"].(string); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/sdk/api/handlers/openai/ccswitch_model_mapping_test.go
+++ b/sdk/api/handlers/openai/ccswitch_model_mapping_test.go
@@ -1,0 +1,45 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+func TestRewriteCcSwitchOpenAIRequestModelMapsCodexRequestModel(t *testing.T) {
+	rawJSON := []byte(`{"model":"deepseek-v4-flash","input":"ok"}`)
+	c := &gin.Context{}
+	c.Set(ccSwitchOpenAIModelMappingContextKey, map[string]string{
+		"deepseek-v4-flash": "deepseek-chat",
+	})
+
+	rewritten, modelName, mapped := rewriteCcSwitchOpenAIRequestModel(rawJSON, c)
+	if !mapped {
+		t.Fatal("mapped = false, want true")
+	}
+	if modelName != "deepseek-chat" {
+		t.Fatalf("modelName = %q, want deepseek-chat", modelName)
+	}
+	if got := gjson.GetBytes(rewritten, "model").String(); got != "deepseek-chat" {
+		t.Fatalf("rewritten model = %q, want deepseek-chat", got)
+	}
+	if got := gjson.GetBytes(rawJSON, "model").String(); got != "deepseek-v4-flash" {
+		t.Fatalf("input rawJSON mutated, model = %q", got)
+	}
+}
+
+func TestRewriteCcSwitchOpenAIRequestModelIgnoresClaudeRoute(t *testing.T) {
+	rawJSON := []byte(`{"model":"deepseek-v4-flash","input":"ok"}`)
+
+	rewritten, modelName, mapped := rewriteCcSwitchOpenAIRequestModel(rawJSON, &gin.Context{})
+	if mapped {
+		t.Fatal("mapped = true, want false")
+	}
+	if modelName != "deepseek-v4-flash" {
+		t.Fatalf("modelName = %q, want original model", modelName)
+	}
+	if string(rewritten) != string(rawJSON) {
+		t.Fatalf("rewritten JSON changed: %s", rewritten)
+	}
+}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
@@ -21,6 +22,8 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+const ccSwitchOpenAIModelMappingContextKey = "cliproxy.ccswitch_openai_model_mapping"
 
 // OpenAIAPIHandler contains the handlers for OpenAI API endpoints.
 // It holds a pool of clients to interact with the backend service.
@@ -52,6 +55,36 @@ func (h *OpenAIAPIHandler) Models() []map[string]any {
 	// Get dynamic models from the global registry
 	modelRegistry := registry.GetGlobalRegistry()
 	return modelRegistry.GetAvailableModels("openai")
+}
+
+func rewriteCcSwitchOpenAIRequestModel(rawJSON []byte, c *gin.Context) ([]byte, string, bool) {
+	modelName := strings.TrimSpace(gjson.GetBytes(rawJSON, "model").String())
+	if modelName == "" || c == nil {
+		return rawJSON, modelName, false
+	}
+	raw, exists := c.Get(ccSwitchOpenAIModelMappingContextKey)
+	if !exists {
+		return rawJSON, modelName, false
+	}
+	mapping, ok := raw.(map[string]string)
+	if !ok || len(mapping) == 0 {
+		return rawJSON, modelName, false
+	}
+	targetModel := ""
+	for request, target := range mapping {
+		if strings.EqualFold(strings.TrimSpace(request), modelName) {
+			targetModel = strings.TrimSpace(target)
+			break
+		}
+	}
+	if targetModel == "" {
+		return rawJSON, modelName, false
+	}
+	rewritten, err := sjson.SetBytes(rawJSON, "model", targetModel)
+	if err != nil {
+		return rawJSON, modelName, false
+	}
+	return rewritten, targetModel, true
 }
 
 // OpenAIModels handles the /v1/models endpoint.
@@ -99,6 +132,7 @@ func (h *OpenAIAPIHandler) ChatCompletions(c *gin.Context) {
 	if !ok {
 		return
 	}
+	rawJSON, _, _ = rewriteCcSwitchOpenAIRequestModel(rawJSON, c)
 
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
@@ -147,6 +181,7 @@ func (h *OpenAIAPIHandler) Completions(c *gin.Context) {
 	if !ok {
 		return
 	}
+	rawJSON, _, _ = rewriteCcSwitchOpenAIRequestModel(rawJSON, c)
 
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -73,6 +73,7 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 	if !ok {
 		return
 	}
+	rawJSON, _, _ = rewriteCcSwitchOpenAIRequestModel(rawJSON, c)
 
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
@@ -88,6 +89,7 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	if !ok {
 		return
 	}
+	rawJSON, _, _ = rewriteCcSwitchOpenAIRequestModel(rawJSON, c)
 
 	streamResult := gjson.GetBytes(rawJSON, "stream")
 	if streamResult.Type == gjson.True {

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -140,6 +140,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			continue
 		}
 		lastRequest = updatedLastRequest
+		requestJSON, _, _ = rewriteCcSwitchOpenAIRequestModel(requestJSON, c)
 
 		if prewarmPayloads, ok := responsesWebsocketPrewarmPayloads(requestJSON); ok {
 			for _, prewarmPayload := range prewarmPayloads {


### PR DESCRIPTION
## Summary
- return CC Switch Codex request-side model IDs from /v1/models
- rewrite CC Switch Codex/OpenAI request models to target models before execution
- add focused coverage for model list aliases and request rewrite

## Tests
- go test ./internal/api ./sdk/api/handlers/openai