### PR TITLE
fix: expose Codex CC Switch model catalog

### DIFF
--- a/internal/api/handlers/management/ccswitch_import_configs.go
+++ b/internal/api/handlers/management/ccswitch_import_configs.go
@@ -14,6 +14,7 @@ func (h *Handler) GetCcSwitchImportConfigs(c *gin.Context) {
 	if items == nil {
 		items = []usage.CcSwitchImportConfigRow{}
 	}
+	items = usage.AttachCcSwitchCodexModelCatalogs(items)
 	c.JSON(http.StatusOK, gin.H{
 		"ccswitch-import-configs": items,
 		"items":                   items,

--- a/internal/api/handlers/management/ccswitch_import_configs_public.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public.go
@@ -175,7 +175,7 @@ func (h *Handler) GetPublicCcSwitchImportConfigs(c *gin.Context) {
 	filtered := make([]usage.CcSwitchImportConfigRow, 0, len(configs))
 	for _, cfg := range configs {
 		if ccSwitchImportConfigMatchesAPIKeyPermissions(cfg, &effective) {
-			filtered = append(filtered, cfg)
+			filtered = append(filtered, usage.AttachCcSwitchCodexModelCatalog(cfg))
 		}
 	}
 

--- a/internal/api/handlers/management/ccswitch_import_configs_public_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public_test.go
@@ -125,3 +125,81 @@ func TestPublicCcSwitchImportConfigsReturnsEmptyWhenKeyUnknown(t *testing.T) {
 		t.Fatalf("items len = %d, want 0", len(got.Items))
 	}
 }
+
+func TestPublicCcSwitchImportConfigsIncludesCodexModelCatalog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	if err := usage.ReplaceAllCcSwitchImportConfigs([]usage.CcSwitchImportConfigRow{
+		{
+			ID:                   "codex-deepseek",
+			ClientType:           "codex",
+			ProviderName:         "pro pool + deepseek",
+			DefaultModel:         "gpt-5.5",
+			AllowedChannelGroups: []string{"codex"},
+			EndpointPath:         "/v1",
+			UsageAutoInterval:    30,
+			ModelMappings: []usage.CcSwitchModelMappingRow{
+				{RequestModel: "gpt-5.5", TargetModel: "gpt-5.5"},
+				{RequestModel: "deepseek-v4-flash", TargetModel: "deepseek-chat"},
+				{RequestModel: "deepseek-v4-pro", TargetModel: "deepseek-reasoner"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllCcSwitchImportConfigs: %v", err)
+	}
+
+	const apiKey = "sk-public-catalog-test"
+	if err := usage.ReplaceAllAPIKeys([]usage.APIKeyRow{
+		{
+			Key:                  apiKey,
+			Name:                 "catalog test",
+			AllowedChannelGroups: []string{"codex"},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceAllAPIKeys: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/public/ccswitch-import-configs", bytes.NewReader([]byte(`{"api_key":"`+apiKey+`"}`)))
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.GetPublicCcSwitchImportConfigs(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got struct {
+		Items []usage.CcSwitchImportConfigRow `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(got.Items))
+	}
+
+	item := got.Items[0]
+	if item.CodexModelCatalogFilename != usage.CcSwitchCodexModelCatalogFilename {
+		t.Fatalf("codex catalog filename = %q, want %q", item.CodexModelCatalogFilename, usage.CcSwitchCodexModelCatalogFilename)
+	}
+	if item.CodexModelCatalog == nil {
+		t.Fatal("codex model catalog = nil, want generated catalog")
+	}
+
+	slugs := make([]string, 0, len(item.CodexModelCatalog.Models))
+	for _, model := range item.CodexModelCatalog.Models {
+		slugs = append(slugs, model.Slug)
+	}
+	want := []string{"gpt-5.5", "deepseek-v4-flash", "deepseek-v4-pro"}
+	if len(slugs) != len(want) {
+		t.Fatalf("catalog slugs len = %d, want %d: %#v", len(slugs), len(want), slugs)
+	}
+	for idx := range want {
+		if slugs[idx] != want[idx] {
+			t.Fatalf("catalog slug[%d] = %q, want %q; all=%#v", idx, slugs[idx], want[idx], slugs)
+		}
+	}
+}

--- a/internal/usage/ccswitch_codex_model_catalog.go
+++ b/internal/usage/ccswitch_codex_model_catalog.go
@@ -1,0 +1,211 @@
+package usage
+
+import "strings"
+
+const CcSwitchCodexModelCatalogFilename = "cc-switch-model-catalog.json"
+
+type CcSwitchCodexModelCatalog struct {
+	Models []CcSwitchCodexModelCatalogEntry `json:"models"`
+}
+
+type CcSwitchCodexReasoningLevel struct {
+	Effort      string `json:"effort"`
+	Description string `json:"description"`
+}
+
+type CcSwitchCodexServiceTier struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type CcSwitchCodexTruncationPolicy struct {
+	Mode  string `json:"mode"`
+	Limit int    `json:"limit"`
+}
+
+type CcSwitchCodexModelMessages struct {
+	InstructionsTemplate          string                        `json:"instructions_template"`
+	InstructionsVariables         map[string]string             `json:"instructions_variables"`
+	SupportsReasoningSummaries    bool                          `json:"supports_reasoning_summaries"`
+	DefaultReasoningSummary       string                        `json:"default_reasoning_summary"`
+	SupportVerbosity              bool                          `json:"support_verbosity"`
+	DefaultVerbosity              string                        `json:"default_verbosity"`
+	ApplyPatchToolType            string                        `json:"apply_patch_tool_type"`
+	WebSearchToolType             string                        `json:"web_search_tool_type"`
+	TruncationPolicy              CcSwitchCodexTruncationPolicy `json:"truncation_policy"`
+	SupportsParallelToolCalls     bool                          `json:"supports_parallel_tool_calls"`
+	SupportsImageDetailOriginal   bool                          `json:"supports_image_detail_original"`
+	ContextWindow                 int                           `json:"context_window"`
+	MaxContextWindow              int                           `json:"max_context_window"`
+	EffectiveContextWindowPercent int                           `json:"effective_context_window_percent"`
+	ExperimentalSupportedTools    []string                      `json:"experimental_supported_tools"`
+	InputModalities               []string                      `json:"input_modalities"`
+	SupportsSearchTool            bool                          `json:"supports_search_tool"`
+	UseResponsesLite              bool                          `json:"use_responses_lite"`
+}
+
+type CcSwitchCodexModelCatalogEntry struct {
+	Slug                          string                        `json:"slug"`
+	DisplayName                   string                        `json:"display_name"`
+	Description                   string                        `json:"description"`
+	DefaultReasoningLevel         string                        `json:"default_reasoning_level"`
+	SupportedReasoningLevels      []CcSwitchCodexReasoningLevel `json:"supported_reasoning_levels"`
+	ShellType                     string                        `json:"shell_type"`
+	Visibility                    string                        `json:"visibility"`
+	SupportedInAPI                bool                          `json:"supported_in_api"`
+	Priority                      int                           `json:"priority"`
+	AdditionalSpeedTiers          []string                      `json:"additional_speed_tiers"`
+	ServiceTiers                  []CcSwitchCodexServiceTier    `json:"service_tiers"`
+	AvailabilityNUX               any                           `json:"availability_nux"`
+	Upgrade                       any                           `json:"upgrade"`
+	BaseInstructions              string                        `json:"base_instructions"`
+	ModelMessages                 CcSwitchCodexModelMessages    `json:"model_messages"`
+	SupportsReasoningSummaries    bool                          `json:"supports_reasoning_summaries"`
+	DefaultReasoningSummary       string                        `json:"default_reasoning_summary"`
+	SupportVerbosity              bool                          `json:"support_verbosity"`
+	DefaultVerbosity              string                        `json:"default_verbosity"`
+	ApplyPatchToolType            string                        `json:"apply_patch_tool_type"`
+	WebSearchToolType             string                        `json:"web_search_tool_type"`
+	TruncationPolicy              CcSwitchCodexTruncationPolicy `json:"truncation_policy"`
+	SupportsParallelToolCalls     bool                          `json:"supports_parallel_tool_calls"`
+	SupportsImageDetailOriginal   bool                          `json:"supports_image_detail_original"`
+	ContextWindow                 int                           `json:"context_window"`
+	MaxContextWindow              int                           `json:"max_context_window"`
+	EffectiveContextWindowPercent int                           `json:"effective_context_window_percent"`
+	ExperimentalSupportedTools    []string                      `json:"experimental_supported_tools"`
+	InputModalities               []string                      `json:"input_modalities"`
+	SupportsSearchTool            bool                          `json:"supports_search_tool"`
+	UseResponsesLite              bool                          `json:"use_responses_lite"`
+}
+
+const ccSwitchCodexDefaultContextWindow = 128000
+const ccSwitchCodexBaseInstructions = "You are Codex, a coding agent."
+
+var ccSwitchCodexSupportedReasoningLevels = []CcSwitchCodexReasoningLevel{
+	{Effort: "low", Description: "Fast responses with lighter reasoning"},
+	{Effort: "medium", Description: "Balances speed and reasoning depth for everyday tasks"},
+	{Effort: "high", Description: "Greater reasoning depth for complex problems"},
+	{Effort: "xhigh", Description: "Extra high reasoning depth for complex problems"},
+}
+
+func BuildCcSwitchCodexModelCatalog(row CcSwitchImportConfigRow) *CcSwitchCodexModelCatalog {
+	if !strings.EqualFold(strings.TrimSpace(row.ClientType), "codex") {
+		return nil
+	}
+
+	models := make([]string, 0, len(row.ModelMappings)+1)
+	if model := strings.TrimSpace(row.DefaultModel); model != "" {
+		models = append(models, model)
+	}
+	for _, mapping := range row.ModelMappings {
+		if strings.TrimSpace(mapping.Role) != "" {
+			continue
+		}
+		model := strings.TrimSpace(mapping.RequestModel)
+		if model == "" {
+			model = strings.TrimSpace(mapping.TargetModel)
+		}
+		if model != "" {
+			models = append(models, model)
+		}
+	}
+
+	seen := make(map[string]struct{}, len(models))
+	entries := make([]CcSwitchCodexModelCatalogEntry, 0, len(models))
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		key := strings.ToLower(model)
+		if model == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		entries = append(entries, buildCcSwitchCodexModelCatalogEntry(model, len(entries)))
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+
+	return &CcSwitchCodexModelCatalog{Models: entries}
+}
+
+func AttachCcSwitchCodexModelCatalog(row CcSwitchImportConfigRow) CcSwitchImportConfigRow {
+	catalog := BuildCcSwitchCodexModelCatalog(row)
+	if catalog == nil {
+		return row
+	}
+	row.CodexModelCatalogFilename = CcSwitchCodexModelCatalogFilename
+	row.CodexModelCatalog = catalog
+	return row
+}
+
+func AttachCcSwitchCodexModelCatalogs(rows []CcSwitchImportConfigRow) []CcSwitchImportConfigRow {
+	if len(rows) == 0 {
+		return rows
+	}
+	out := make([]CcSwitchImportConfigRow, len(rows))
+	for i, row := range rows {
+		out[i] = AttachCcSwitchCodexModelCatalog(row)
+	}
+	return out
+}
+
+func buildCcSwitchCodexModelCatalogEntry(model string, priority int) CcSwitchCodexModelCatalogEntry {
+	messages := CcSwitchCodexModelMessages{
+		InstructionsTemplate:          ccSwitchCodexBaseInstructions,
+		InstructionsVariables:         map[string]string{},
+		SupportsReasoningSummaries:    true,
+		DefaultReasoningSummary:       "none",
+		SupportVerbosity:              true,
+		DefaultVerbosity:              "low",
+		ApplyPatchToolType:            "freeform",
+		WebSearchToolType:             "text_and_image",
+		TruncationPolicy:              CcSwitchCodexTruncationPolicy{Mode: "tokens", Limit: 10000},
+		SupportsParallelToolCalls:     true,
+		SupportsImageDetailOriginal:   true,
+		ContextWindow:                 ccSwitchCodexDefaultContextWindow,
+		MaxContextWindow:              ccSwitchCodexDefaultContextWindow,
+		EffectiveContextWindowPercent: 95,
+		ExperimentalSupportedTools:    []string{},
+		InputModalities:               []string{"text", "image"},
+		SupportsSearchTool:            true,
+		UseResponsesLite:              false,
+	}
+
+	return CcSwitchCodexModelCatalogEntry{
+		Slug:                          model,
+		DisplayName:                   model,
+		Description:                   model,
+		DefaultReasoningLevel:         "medium",
+		SupportedReasoningLevels:      ccSwitchCodexSupportedReasoningLevels,
+		ShellType:                     "shell_command",
+		Visibility:                    "list",
+		SupportedInAPI:                true,
+		Priority:                      1000 + priority,
+		AdditionalSpeedTiers:          []string{},
+		ServiceTiers:                  []CcSwitchCodexServiceTier{},
+		AvailabilityNUX:               nil,
+		Upgrade:                       nil,
+		BaseInstructions:              ccSwitchCodexBaseInstructions,
+		ModelMessages:                 messages,
+		SupportsReasoningSummaries:    true,
+		DefaultReasoningSummary:       "none",
+		SupportVerbosity:              true,
+		DefaultVerbosity:              "low",
+		ApplyPatchToolType:            "freeform",
+		WebSearchToolType:             "text_and_image",
+		TruncationPolicy:              CcSwitchCodexTruncationPolicy{Mode: "tokens", Limit: 10000},
+		SupportsParallelToolCalls:     true,
+		SupportsImageDetailOriginal:   true,
+		ContextWindow:                 ccSwitchCodexDefaultContextWindow,
+		MaxContextWindow:              ccSwitchCodexDefaultContextWindow,
+		EffectiveContextWindowPercent: 95,
+		ExperimentalSupportedTools:    []string{},
+		InputModalities:               []string{"text", "image"},
+		SupportsSearchTool:            true,
+		UseResponsesLite:              false,
+	}
+}

--- a/internal/usage/ccswitch_codex_model_catalog_test.go
+++ b/internal/usage/ccswitch_codex_model_catalog_test.go
@@ -1,0 +1,60 @@
+package usage
+
+import "testing"
+
+func TestBuildCcSwitchCodexModelCatalogUsesRequestModels(t *testing.T) {
+	row := CcSwitchImportConfigRow{
+		ClientType:   "codex",
+		DefaultModel: "gpt-5.5",
+		ModelMappings: []CcSwitchModelMappingRow{
+			{RequestModel: "gpt-5.5", TargetModel: "gpt-5.5"},
+			{RequestModel: "deepseek-v4-flash", TargetModel: "deepseek-chat"},
+			{RequestModel: "DeepSeek-V4-Flash", TargetModel: "deepseek-chat"},
+			{RequestModel: "deepseek-v4-pro", TargetModel: "deepseek-reasoner"},
+		},
+	}
+
+	catalog := BuildCcSwitchCodexModelCatalog(row)
+	if catalog == nil {
+		t.Fatal("catalog = nil, want generated catalog")
+	}
+
+	got := make([]string, 0, len(catalog.Models))
+	for _, model := range catalog.Models {
+		got = append(got, model.Slug)
+	}
+	want := []string{"gpt-5.5", "deepseek-v4-flash", "deepseek-v4-pro"}
+	if len(got) != len(want) {
+		t.Fatalf("slugs len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for idx := range want {
+		if got[idx] != want[idx] {
+			t.Fatalf("slug[%d] = %q, want %q; all=%#v", idx, got[idx], want[idx], got)
+		}
+	}
+
+	deepseek := catalog.Models[1]
+	if deepseek.ContextWindow != ccSwitchCodexDefaultContextWindow {
+		t.Fatalf("context_window = %d, want %d", deepseek.ContextWindow, ccSwitchCodexDefaultContextWindow)
+	}
+	if deepseek.ModelMessages.ContextWindow != ccSwitchCodexDefaultContextWindow {
+		t.Fatalf("model_messages.context_window = %d, want %d", deepseek.ModelMessages.ContextWindow, ccSwitchCodexDefaultContextWindow)
+	}
+	if !deepseek.SupportedInAPI || deepseek.Visibility != "list" {
+		t.Fatalf("catalog entry missing visible API flags: %#v", deepseek)
+	}
+	if deepseek.BaseInstructions == "" || deepseek.ModelMessages.InstructionsTemplate == "" {
+		t.Fatalf("catalog entry missing Codex instruction templates: %#v", deepseek)
+	}
+}
+
+func TestBuildCcSwitchCodexModelCatalogSkipsNonCodex(t *testing.T) {
+	row := CcSwitchImportConfigRow{
+		ClientType:   "claude",
+		DefaultModel: "claude-sonnet-4-5",
+	}
+
+	if catalog := BuildCcSwitchCodexModelCatalog(row); catalog != nil {
+		t.Fatalf("catalog = %#v, want nil", catalog)
+	}
+}

--- a/internal/usage/ccswitch_import_configs_db.go
+++ b/internal/usage/ccswitch_import_configs_db.go
@@ -18,19 +18,21 @@ type CcSwitchModelMappingRow struct {
 }
 
 type CcSwitchImportConfigRow struct {
-	ID                   string                    `json:"id"`
-	ClientType           string                    `json:"client-type"`
-	ProviderName         string                    `json:"provider-name"`
-	Note                 string                    `json:"note"`
-	DefaultModel         string                    `json:"default-model"`
-	ModelMappings        []CcSwitchModelMappingRow `json:"model-mappings"`
-	AllowedChannelGroups []string                  `json:"allowed-channel-groups"`
-	RoutePath            string                    `json:"route-path,omitempty"`
-	EndpointPath         string                    `json:"endpoint-path"`
-	UsageAutoInterval    int                       `json:"usage-auto-interval"`
-	APIKeyField          string                    `json:"api-key-field,omitempty"`
-	CreatedAt            string                    `json:"created-at,omitempty"`
-	UpdatedAt            string                    `json:"updated-at,omitempty"`
+	ID                        string                     `json:"id"`
+	ClientType                string                     `json:"client-type"`
+	ProviderName              string                     `json:"provider-name"`
+	Note                      string                     `json:"note"`
+	DefaultModel              string                     `json:"default-model"`
+	ModelMappings             []CcSwitchModelMappingRow  `json:"model-mappings"`
+	AllowedChannelGroups      []string                   `json:"allowed-channel-groups"`
+	RoutePath                 string                     `json:"route-path,omitempty"`
+	EndpointPath              string                     `json:"endpoint-path"`
+	UsageAutoInterval         int                        `json:"usage-auto-interval"`
+	APIKeyField               string                     `json:"api-key-field,omitempty"`
+	CodexModelCatalogFilename string                     `json:"codex-model-catalog-filename,omitempty"`
+	CodexModelCatalog         *CcSwitchCodexModelCatalog `json:"codex-model-catalog,omitempty"`
+	CreatedAt                 string                     `json:"created-at,omitempty"`
+	UpdatedAt                 string                     `json:"updated-at,omitempty"`
 }
 
 const createCcSwitchImportConfigsTableSQL = `


### PR DESCRIPTION
## Summary
- generate Codex model catalog entries from CC Switch Codex request-side model mappings
- include catalog filename and JSON payload in management and public import config responses
- cover request-side DeepSeek models in backend tests

## Verification
- rtk go test ./...