### PR TITLE
fix: stop logging upstream model echo, repair history, fix usage read 500s

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	managementusagelogs "github.com/router-for-me/CLIProxyAPI/v6/internal/management/usagelogs"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	log "github.com/sirupsen/logrus"
 )
 
 const authFileGroupTrendCacheTTL = 30 * time.Second
@@ -83,6 +84,7 @@ func (h *UsageLogsHandler) GetUsageLogs(c *gin.Context) {
 		MatchNoChannels: queryBool(c, "channels_empty"),
 	})
 	if err != nil {
+		log.Warnf("management usage logs: get usage logs failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -93,6 +95,7 @@ func (h *UsageLogsHandler) DeleteUsageLogs(c *gin.Context) {
 	if c.Request.ContentLength == 0 {
 		result, err := h.service().ClearAllRequestLogs()
 		if err != nil {
+			log.Warnf("management usage logs: clear all request logs failed: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -150,6 +153,7 @@ func (h *UsageLogsHandler) GetPublicUsageLogs(c *gin.Context) {
 		Days:   req.Days,
 	})
 	if err != nil {
+		log.Warnf("management usage logs: public usage logs failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -169,6 +173,7 @@ func (h *UsageLogsHandler) GetPublicUsageChartData(c *gin.Context) {
 	}
 	payload, err := h.service().PublicChartData(req.APIKey, req.Days)
 	if err != nil {
+		log.Warnf("management usage logs: public chart data failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -198,6 +203,7 @@ func (h *UsageLogsHandler) GetPublicLogContent(c *gin.Context) {
 func (h *UsageLogsHandler) GetUsageChartData(c *gin.Context) {
 	payload, err := h.service().UsageChartData(strings.TrimSpace(c.Query("api_key")), intQueryDefault(c, "days", 7))
 	if err != nil {
+		log.Warnf("management usage logs: usage chart data failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -213,6 +219,7 @@ func (h *UsageLogsHandler) GetEntityUsageStats(c *gin.Context) {
 		queryStringList(c, "source"),
 	)
 	if err != nil {
+		log.Warnf("management usage logs: entity usage stats failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -286,6 +293,7 @@ func (h *UsageLogsHandler) GetAuthFileGroupTrend(c *gin.Context) {
 
 	payload, err := h.service().AuthFileGroupTrend(group, days)
 	if err != nil {
+		log.Warnf("management usage logs: auth file group trend failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/management/usage_summary_public.go
+++ b/internal/api/handlers/management/usage_summary_public.go
@@ -9,6 +9,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	log "github.com/sirupsen/logrus"
 )
 
 type usageSummaryResponse struct {
@@ -55,6 +56,7 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 
 	stats, err := usage.QueryStats(usage.LogQueryParams{APIKey: apiKey, Days: 1})
 	if err != nil {
+		log.Warnf("management usage logs: public usage summary query failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query usage summary"})
 		return
 	}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -165,7 +165,12 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	recorder.AppendResponseChunk(body)
-	reporter.setModel(parseOpenAIResponseModel(body))
+	// Preserve the clean, request-time model (ec.BaseModel) for the usage record.
+	// The upstream response's "model" field echoes a provider-internal path such as
+	// "accounts/fireworks/models/glm-5p2", which is not a valid model name for
+	// display, pricing lookup (CalculateCostV2) or filtering. All other executors
+	// (codex/claude/gemini/...) never override the reporter's model, so this keeps
+	// the OpenAI-compat path consistent with them.
 	reporter.publishWithContent(execCtx.Context, parseOpenAIUsage(body), string(req.Payload), string(body))
 	// Ensure we at least record the request even if upstream doesn't return usage
 	reporter.ensurePublished(execCtx.Context)
@@ -272,7 +277,10 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			line := scanner.Bytes()
 			recorder.AppendResponseChunk(line)
 			reporter.appendOutputChunk(line)
-			reporter.setModel(parseOpenAIStreamModel(line))
+			// Intentionally do NOT call reporter.setModel(parseOpenAIStreamModel(line)).
+			// See the non-stream branch above: the upstream "model" echo is a
+			// provider-internal path (e.g. accounts/fireworks/models/glm-5p2) that
+			// must not override the clean request-time model used for logging/cost.
 			if detail, ok := parseOpenAIStreamUsage(line); ok {
 				reporter.publish(execCtx.Context, detail)
 			}

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -116,13 +116,17 @@ func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	}
 }
 
-func TestOpenAICompatExecutorUsageUsesUpstreamResponseModel(t *testing.T) {
+func TestOpenAICompatExecutorUsagePreservesRequestModelOverUpstreamEcho(t *testing.T) {
 	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 4)}
 	cliproxyusage.RegisterPlugin(usagePlugin)
 
+	// Upstream echoes a provider-internal model path (like Fireworks does for
+	// glm-5.2 -> "accounts/fireworks/models/glm-5p2"). The usage record must keep
+	// the clean request-time model, not the upstream echo, so display/cost/filter
+	// keep working. This guards against re-introducing the setModel override.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"resp_1","model":"gpt-5.4","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+		_, _ = w.Write([]byte(`{"id":"resp_1","model":"accounts/fireworks/models/glm-5p2","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
 	}))
 	defer server.Close()
 
@@ -132,8 +136,8 @@ func TestOpenAICompatExecutorUsageUsesUpstreamResponseModel(t *testing.T) {
 		"api_key":  "test",
 	}}
 	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "codex-auto-review",
-		Payload: []byte(`{"model":"codex-auto-review","input":"ping"}`),
+		Model:   "glm-5.2",
+		Payload: []byte(`{"model":"glm-5.2","input":"ping"}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("openai-response"),
 		Alt:          "responses/compact",
@@ -146,11 +150,68 @@ func TestOpenAICompatExecutorUsageUsesUpstreamResponseModel(t *testing.T) {
 	for {
 		select {
 		case record := <-usagePlugin.records:
-			if record.Model == "gpt-5.4" {
+			if record.Model == "accounts/fireworks/models/glm-5p2" {
+				t.Fatalf("usage record model = upstream echo %q; must stay the clean request model", record.Model)
+			}
+			if record.Model == "glm-5.2" {
 				return
 			}
 		case <-timer:
-			t.Fatal("timed out waiting for usage record with model gpt-5.4")
+			t.Fatal("timed out waiting for usage record with clean model glm-5.2")
+		}
+	}
+}
+
+func TestOpenAICompatExecutorStreamUsagePreservesRequestModelOverUpstreamEcho(t *testing.T) {
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 4)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"id":"chatcmpl-echo","object":"chat.completion.chunk","created":1,"model":"accounts/fireworks/models/glm-5p2","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl-echo","object":"chat.completion.chunk","created":1,"model":"accounts/fireworks/models/glm-5p2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{"model":"glm-5.2","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "glm-5.2",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	timer := time.After(time.Second)
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Model == "accounts/fireworks/models/glm-5p2" {
+				t.Fatalf("stream usage record model = upstream echo %q; must stay the clean request model", record.Model)
+			}
+			if record.Model == "glm-5.2" {
+				return
+			}
+		case <-timer:
+			t.Fatal("timed out waiting for stream usage record with clean model glm-5.2")
 		}
 	}
 }

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -74,6 +74,11 @@ func (r *usageReporter) publishWithContent(ctx context.Context, detail coreusage
 	r.publishWithOutcome(ctx, detail, false)
 }
 
+// setModel overrides the reporter's model. It is intentionally NOT called from
+// the OpenAI-compat executor: the upstream response's "model" field echoes a
+// provider-internal path (e.g. accounts/fireworks/models/glm-5p2) that must not
+// replace the clean request-time model used for logging and cost calculation.
+// It is retained for explicit callers that have a verified-clean model string.
 func (r *usageReporter) setModel(model string) {
 	if r == nil {
 		return

--- a/internal/usage/auth_index_cost_query.go
+++ b/internal/usage/auth_index_cost_query.go
@@ -7,7 +7,7 @@ import (
 )
 
 func QueryCostByAuthIndexSince(authIndex string, since time.Time) (float64, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return 0, nil
 	}

--- a/internal/usage/auth_subject_usage_query.go
+++ b/internal/usage/auth_subject_usage_query.go
@@ -20,7 +20,7 @@ func QueryDailyCallsByAuthSubject(matcher AuthSubjectMatcher, days int) ([]Daily
 }
 
 func QueryDailyUsageByAuthSubject(matcher AuthSubjectMatcher, days int) ([]DailyUsagePoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return []DailyUsagePoint{}, nil
 	}
@@ -95,7 +95,7 @@ func QueryHourlyCallsByAuthSubject(matcher AuthSubjectMatcher, hours int) ([]Hou
 }
 
 func QueryHourlyUsageByAuthSubject(matcher AuthSubjectMatcher, hours int) ([]HourlyUsagePoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return []HourlyUsagePoint{}, nil
 	}
@@ -160,7 +160,7 @@ func QueryRequestCountByAuthSubjectSince(matcher AuthSubjectMatcher, since time.
 }
 
 func QueryCostByAuthSubjectSince(matcher AuthSubjectMatcher, since time.Time) (float64, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return 0, nil
 	}
@@ -187,7 +187,7 @@ func QueryCostByAuthSubjectSince(matcher AuthSubjectMatcher, since time.Time) (f
 }
 
 func queryCountByAuthSubjectSince(matcher AuthSubjectMatcher, since time.Time, aggregate string) (int64, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return 0, nil
 	}

--- a/internal/usage/codex_fingerprint_recommendations.go
+++ b/internal/usage/codex_fingerprint_recommendations.go
@@ -99,7 +99,7 @@ func QueryCodexFingerprintRecommendations(params CodexFingerprintRecommendationQ
 		Limit: params.Limit,
 	}
 
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return result, nil
 	}

--- a/internal/usage/request_log_auth_trends.go
+++ b/internal/usage/request_log_auth_trends.go
@@ -36,7 +36,7 @@ type HourlyUsagePoint struct {
 }
 
 func QueryDailyCallsByAuthIndexes(authIndexes []string, days int) ([]DailyCountPoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return []DailyCountPoint{}, nil
 	}
@@ -112,7 +112,7 @@ func QueryDailyCallsByAuthIndexes(authIndexes []string, days int) ([]DailyCountP
 }
 
 func QueryHourlyCallsByAuthIndex(authIndex string, hours int) ([]HourlyCountPoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return []HourlyCountPoint{}, nil
 	}
@@ -166,7 +166,7 @@ func QueryHourlyCallsByAuthIndex(authIndex string, hours int) ([]HourlyCountPoin
 }
 
 func QueryRequestCountByAuthIndexSince(authIndex string, since time.Time) (int64, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return 0, nil
 	}

--- a/internal/usage/request_log_concurrency_test.go
+++ b/internal/usage/request_log_concurrency_test.go
@@ -1,0 +1,136 @@
+package usage
+
+import (
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	_ "modernc.org/sqlite"
+)
+
+// TestQueryLogsConcurrentWithInserts verifies that management read queries stay
+// responsive and error-free while inserts run concurrently. This guards the
+// read/write connection split: reads must not serialize behind (or be blocked by)
+// writes on the single write connection.
+func TestQueryLogsConcurrentWithInserts(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+
+	// Seed a few rows so reads have data to scan.
+	for i := 0; i < 5; i++ {
+		InsertLog("sk-test", "tester", "glm-5.2", "source", "channel", "auth-1",
+			false, time.Now().UTC(), 100, 20, TokenStats{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+			`{"model":"glm-5.2","messages":[]}`, "")
+	}
+
+	const writers = 4
+	const writesPerWriter = 25
+	const readers = 4
+	const readsPerReader = 25
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	// Writers: insert rows continuously.
+	for w := 0; w < writers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < writesPerWriter; i++ {
+				InsertLog("sk-test", "tester", "glm-5.2", "source", "channel", "auth-1",
+					false, time.Now().UTC(), 50, 10, TokenStats{InputTokens: 8, OutputTokens: 4, TotalTokens: 12},
+					`{"model":"glm-5.2","messages":[]}`, "")
+			}
+		}()
+	}
+
+	// Readers: query logs concurrently with the writers.
+	readErrs := make(chan error, readers*readsPerReader)
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < readsPerReader; i++ {
+				result, err := QueryLogs(LogQueryParams{Page: 1, Size: 50, Days: 7})
+				if err != nil {
+					readErrs <- err
+					continue
+				}
+				if result.Items == nil {
+					readErrs <- errQueryNilItems
+				}
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for concurrent reads/writes to finish")
+	}
+	close(readErrs)
+	for err := range readErrs {
+		t.Fatalf("concurrent read returned error: %v", err)
+	}
+
+	// Sanity: the row count reflects at least the seeded + written rows.
+	var total int64
+	if err := db.QueryRow("SELECT COUNT(*) FROM request_logs").Scan(&total); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	expected := int64(5 + writers*writesPerWriter)
+	if total < expected {
+		t.Fatalf("row count = %d, want at least %d", total, expected)
+	}
+}
+
+// errQueryNilItems is a sentinel used by TestQueryLogsConcurrentWithInserts to
+// report a nil items slice via the shared error channel.
+var errQueryNilItems = newSentinelError("query logs returned nil items")
+
+func newSentinelError(msg string) error { return &sentinelError{msg: msg} }
+
+type sentinelError struct{ msg string }
+
+func (e *sentinelError) Error() string { return e.msg }
+
+// TestQueryDistinctErrorIsLogged verifies that when a read helper hits a DB error,
+// it logs a warning (not silently swallowed into the HTTP 500 body only). This
+// guards the error-logging fix so future 500s leave a trace in main.log. It uses
+// a closed handle passed directly to the helper, avoiding any global-state mutation.
+func TestQueryDistinctErrorIsLogged(t *testing.T) {
+	hook := test.NewLocal(log.StandardLogger())
+	defer hook.Reset()
+
+	// Open then immediately close a handle so any query against it fails.
+	closedDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	if err := closedDB.Close(); err != nil {
+		t.Fatalf("close memory db: %v", err)
+	}
+
+	_, err = queryDistinct(closedDB, "model", time.Now().UTC().Format(time.RFC3339))
+	if err == nil {
+		t.Fatal("expected queryDistinct to error against a closed handle")
+	}
+
+	found := false
+	for _, entry := range hook.AllEntries() {
+		if entry.Level != log.WarnLevel {
+			continue
+		}
+		if entry.Message != "" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warn-level log entry for the queryDistinct error; got %d entries", len(hook.AllEntries()))
+	}
+}

--- a/internal/usage/request_log_content.go
+++ b/internal/usage/request_log_content.go
@@ -37,7 +37,7 @@ func normalizeLogContentPart(part string) (string, error) {
 
 // QueryLogContent retrieves the stored request/response content for a single log entry.
 func QueryLogContent(id int64) (LogContentResult, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return LogContentResult{}, fmt.Errorf("usage: database not initialised")
 	}
@@ -67,7 +67,7 @@ func QueryLogContent(id int64) (LogContentResult, error) {
 // QueryLogContentPart retrieves only one side (input/output) of the stored request/response content
 // for a single log entry. This avoids decompressing/transferring both blobs for the UI.
 func QueryLogContentPart(id int64, part string) (LogContentPartResult, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return LogContentPartResult{}, fmt.Errorf("usage: database not initialised")
 	}
@@ -124,7 +124,7 @@ func QueryLogContentPart(id int64, part string) (LogContentPartResult, error) {
 // QueryLogContentForKey retrieves log content for a single entry, but only if it belongs to the given API key.
 // This is used by the public endpoint to ensure users can only access their own logs.
 func QueryLogContentForKey(id int64, apiKey string) (LogContentResult, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return LogContentResult{}, fmt.Errorf("usage: database not initialised")
 	}
@@ -158,7 +158,7 @@ func QueryLogContentForKey(id int64, apiKey string) (LogContentResult, error) {
 // QueryLogContentPartForKey retrieves only one side (input/output) of the stored request/response content
 // for a single entry, but only if it belongs to the given API key.
 func QueryLogContentPartForKey(id int64, apiKey string, part string) (LogContentPartResult, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return LogContentPartResult{}, fmt.Errorf("usage: database not initialised")
 	}

--- a/internal/usage/request_log_dashboard.go
+++ b/internal/usage/request_log_dashboard.go
@@ -54,7 +54,7 @@ const dashboardThroughputBucketCount = 7
 // QueryDashboardKPI returns aggregated KPI data from SQLite for the dashboard.
 // This replaces the old in-memory snapshot-based counting which lost data on restart.
 func QueryDashboardKPI(days int) (DashboardKPI, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return DashboardKPI{}, nil
 	}
@@ -106,7 +106,7 @@ func QueryDashboardKPI(days int) (DashboardKPI, error) {
 // KPI trends follow the selected day range, while throughput always shows the
 // most recent 7 one-minute buckets.
 func QueryDashboardTrends(days int) (DashboardTrends, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return emptyDashboardTrends(days), nil
 	}
@@ -238,7 +238,7 @@ func buildRecentThroughputBucketsAt(now time.Time, loc *time.Location) []dashboa
 }
 
 func queryDashboardThroughputSeriesAt(now time.Time, loc *time.Location) ([]DashboardThroughputPoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return throughputSeriesFromBuckets(buildRecentThroughputBucketsAt(now, loc)), nil
 	}

--- a/internal/usage/request_log_model_backfill.go
+++ b/internal/usage/request_log_model_backfill.go
@@ -1,0 +1,250 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// providerEchoModelPattern is the SQLite LIKE pattern that marks request_logs.model
+// values that are upstream provider-internal paths echoed back in an
+// OpenAI-compatible response's "model" field (e.g. "accounts/fireworks/models/glm-5p2").
+// These are not valid model names for display, pricing lookup or filtering, and were
+// persisted because the OpenAI-compat executor used to override the reporter's clean
+// request-time model with this echo. The override has been removed; this backfill
+// repairs the rows already written with the bad value.
+//
+// Only the "accounts/<x>/models/<y>" shape is treated as bad. Other slash model names
+// (e.g. "meta/llama-3.1-8b-instruct") are legitimate upstream conventions and are
+// left untouched.
+const providerEchoModelPattern = "accounts/%/models/%"
+
+// backfillRequestLogModelNames repairs request_logs rows whose model column holds an
+// upstream provider-echo path. It recovers the original client-requested model from
+// the stored request body (request_log_content.input_content, or the legacy
+// request_logs.input_content fallback) and rewrites both the model and the cost (which
+// was zero because the echo string has no pricing entry).
+//
+// Rows whose stored request body has been cleared cannot be recovered: they are left
+// as-is and counted in a warning so the operator can decide what to do. The function is
+// idempotent: only rows still matching the bad pattern are considered, so re-running
+// after a successful backfill is a no-op (recovered rows no longer match).
+func backfillRequestLogModelNames(db *sql.DB) {
+	if db == nil {
+		return
+	}
+
+	const batchSize = 200
+	backfilled := 0
+	unrecoverable := 0
+	// Cursor: only look at rows with id greater than the last id inspected. This
+	// guarantees forward progress even when some rows cannot be recovered (they keep
+	// matching the bad pattern and would otherwise reappear every batch).
+	var lastID int64
+
+	for {
+		processed, unrecoverableThisBatch, lastSeen, err := backfillRequestLogModelNamesBatch(db, batchSize, lastID)
+		if err != nil {
+			log.Warnf("usage: backfill request_logs model batch failed: %v", err)
+			return
+		}
+		backfilled += processed
+		unrecoverable += unrecoverableThisBatch
+		if lastSeen > lastID {
+			lastID = lastSeen
+		}
+		if processed == 0 && unrecoverableThisBatch == 0 {
+			break
+		}
+	}
+
+	if backfilled > 0 {
+		log.Infof("usage: backfilled model for %d request_logs rows from stored request body", backfilled)
+	}
+	if unrecoverable > 0 {
+		log.Warnf("usage: %d request_logs rows still hold a provider-echo model but have no stored request body to recover the clean model from; left unchanged", unrecoverable)
+	}
+}
+
+// backfillRequestLogModelNamesBatch processes up to batchSize rows whose id is greater
+// than afterID. It returns the number of rows rewritten, the number of rows that
+// matched the bad pattern but could not be recovered, the highest id inspected, and
+// any error.
+func backfillRequestLogModelNamesBatch(db *sql.DB, batchSize int, afterID int64) (rewritten, unrecoverable int, lastID int64, err error) {
+	if db == nil {
+		return 0, 0, 0, nil
+	}
+	if batchSize <= 0 {
+		batchSize = 200
+	}
+
+	// Prefer the compressed content row; fall back to the legacy uncompressed
+	// input_content column on request_logs for older rows.
+	rows, err := db.Query(
+		`SELECT logs.id,
+		        logs.input_tokens, logs.output_tokens, logs.reasoning_tokens,
+		        logs.cached_tokens, logs.total_tokens,
+		        coalesce(content.compression, '')   AS compression,
+		        coalesce(content.input_content, '') AS content_input,
+		        logs.input_content                  AS legacy_input
+		 FROM request_logs logs
+		 LEFT JOIN request_log_content content ON content.log_id = logs.id
+		 WHERE logs.model LIKE '`+providerEchoModelPattern+`'
+		   AND logs.id > ?
+		 ORDER BY logs.id
+		 LIMIT ?`,
+		afterID, batchSize,
+	)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("usage: query provider-echo model rows: %w", err)
+	}
+	defer rows.Close()
+
+	type targetRow struct {
+		ID              int64
+		InputTokens     int64
+		OutputTokens    int64
+		ReasoningTokens int64
+		CachedTokens    int64
+		TotalTokens     int64
+		Compression     string
+		ContentInput    []byte
+		LegacyInput     string
+		RecoveredModel  string
+	}
+	batch := make([]targetRow, 0, batchSize)
+	for rows.Next() {
+		var row targetRow
+		if err := rows.Scan(
+			&row.ID,
+			&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
+			&row.CachedTokens, &row.TotalTokens,
+			&row.Compression,
+			&row.ContentInput,
+			&row.LegacyInput,
+		); err != nil {
+			return 0, 0, 0, fmt.Errorf("usage: scan provider-echo model row: %w", err)
+		}
+		if row.ID > lastID {
+			lastID = row.ID
+		}
+		batch = append(batch, row)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, 0, 0, fmt.Errorf("usage: iterate provider-echo model rows: %w", err)
+	}
+	if len(batch) == 0 {
+		return 0, 0, 0, nil
+	}
+
+	for i := range batch {
+		row := &batch[i]
+		model, ok := recoverModelFromStoredInput(row.Compression, row.ContentInput, row.LegacyInput)
+		if !ok {
+			unrecoverable++
+			continue
+		}
+		row.RecoveredModel = model
+	}
+
+	// Backfill is a DB maintenance task, not bound to any request lifecycle. Use the
+	// root context so the transaction is governed only by DB errors.
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return 0, unrecoverable, lastID, fmt.Errorf("usage: begin model backfill tx: %w", err)
+	}
+
+	for i := range batch {
+		row := &batch[i]
+		if row.RecoveredModel == "" {
+			continue
+		}
+		cost := CalculateCostV2(row.RecoveredModel, TokenStats{
+			InputTokens:     row.InputTokens,
+			OutputTokens:    row.OutputTokens,
+			ReasoningTokens: row.ReasoningTokens,
+			CachedTokens:    row.CachedTokens,
+			TotalTokens:     row.TotalTokens,
+		})
+		if _, errExec := tx.Exec(
+			`UPDATE request_logs SET model = ?, cost = ? WHERE id = ?`,
+			row.RecoveredModel, cost, row.ID,
+		); errExec != nil {
+			_ = tx.Rollback()
+			return 0, unrecoverable, lastID, fmt.Errorf("usage: update request_logs model: %w", errExec)
+		}
+		rewritten++
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, unrecoverable, lastID, fmt.Errorf("usage: commit model backfill: %w", err)
+	}
+	return rewritten, unrecoverable, lastID, nil
+}
+
+// recoverModelFromStoredInput extracts the original client-requested model from the
+// stored request body. It tries the compressed content row first, then the legacy
+// uncompressed input_content column. Returns the clean model and true only when a
+// usable, non-echo model name was recovered.
+func recoverModelFromStoredInput(compression string, contentInput []byte, legacyInput string) (string, bool) {
+	var raw string
+	if len(contentInput) > 0 {
+		decoded, err := decompressLogContent(compression, contentInput)
+		if err != nil {
+			return "", false
+		}
+		raw = decoded
+	} else if strings.TrimSpace(legacyInput) != "" {
+		raw = legacyInput
+	} else {
+		return "", false
+	}
+
+	model := extractModelFromPayload(raw)
+	if !isUsableCleanModel(model) {
+		return "", false
+	}
+	return model, true
+}
+
+// extractModelFromPayload reads the "model" field from a JSON request body. It
+// tolerates leading whitespace; on any parse failure it returns "".
+func extractModelFromPayload(payload string) string {
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		return ""
+	}
+	var probe struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal([]byte(payload), &probe); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(probe.Model)
+}
+
+// isUsableCleanModel reports whether a recovered model string is safe to write back:
+// non-empty, not itself a provider-echo path, and not the "unknown" placeholder.
+func isUsableCleanModel(model string) bool {
+	if model == "" {
+		return false
+	}
+	if isProviderEchoModel(model) {
+		return false
+	}
+	if model == "unknown" {
+		return false
+	}
+	return true
+}
+
+// isProviderEchoModel matches the upstream provider-internal path shape that this
+// backfill repairs. Kept conservative on purpose: legitimate slash model names from
+// other providers are not matched.
+func isProviderEchoModel(model string) bool {
+	return strings.HasPrefix(model, "accounts/") && strings.Contains(model, "/models/")
+}

--- a/internal/usage/request_log_model_backfill_test.go
+++ b/internal/usage/request_log_model_backfill_test.go
@@ -1,0 +1,222 @@
+package usage
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// insertProviderEchoRequestLog inserts a request_logs row with a bad provider-echo
+// model and returns its id. Token columns are populated so cost recompute is testable.
+func insertProviderEchoRequestLog(t *testing.T, db *sql.DB, model string, inputTokens int64) int64 {
+	t.Helper()
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
+	res, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, api_key_name, model, source, channel_name, auth_index,
+			 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		timestamp, "sk-test", "tester", model, "source", "channel", "auth-1",
+		0, 123, 45, inputTokens, 20, 0, 0, inputTokens+20, 0,
+	)
+	if err != nil {
+		t.Fatalf("insert request_log with model %q: %v", model, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	return id
+}
+
+func insertRequestLogContentRow(t *testing.T, db *sql.DB, logID int64, inputJSON string) {
+	t.Helper()
+	compressed, err := compressLogContent(inputJSON)
+	if err != nil {
+		t.Fatalf("compress content: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO request_log_content (log_id, timestamp, compression, input_content, output_content, detail_content)
+		 VALUES (?, ?, 'zstd', ?, X'', X'')`,
+		logID, time.Now().UTC().Format(time.RFC3339Nano), compressed,
+	); err != nil {
+		t.Fatalf("insert request_log_content row: %v", err)
+	}
+}
+
+func upsertTestModelPricing(t *testing.T, modelID string, inputPricePerMillion float64) {
+	t.Helper()
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               modelID,
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  inputPricePerMillion,
+		OutputPricePerMillion: 0,
+		UpdatedAt:             time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(%s): %v", modelID, err)
+	}
+}
+
+// TestBackfillRequestLogModelNamesRecoversFromCompressedContent verifies the main
+// path: a row with a provider-echo model and a compressed request_log_content row
+// gets its model recovered from the stored request body and cost recomputed.
+func TestBackfillRequestLogModelNamesRecoversFromCompressedContent(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+
+	// Register pricing for the clean model so cost recompute is verifiable.
+	upsertTestModelPricing(t, "glm-5.2", 1.0) // $1 per million input tokens
+
+	id := insertProviderEchoRequestLog(t, db, "accounts/fireworks/models/glm-5p2", 1000)
+	insertRequestLogContentRow(t, db, id, `{"model":"glm-5.2","messages":[{"role":"user","content":"hi"}]}`)
+
+	backfillRequestLogModelNames(db)
+
+	var model string
+	var cost float64
+	if err := db.QueryRow("SELECT model, cost FROM request_logs WHERE id = ?", id).Scan(&model, &cost); err != nil {
+		t.Fatalf("query repaired row: %v", err)
+	}
+	if model != "glm-5.2" {
+		t.Fatalf("model = %q, want glm-5.2", model)
+	}
+	// 1000 input tokens @ $1/M = 0.001
+	if cost <= 0 {
+		t.Fatalf("cost = %v, expected recompute to a positive value for glm-5.2", cost)
+	}
+}
+
+// TestBackfillRequestLogModelNamesRecoversFromLegacyInput verifies the fallback to
+// the legacy uncompressed request_logs.input_content column for older rows.
+func TestBackfillRequestLogModelNamesRecoversFromLegacyInput(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+
+	id := insertProviderEchoRequestLog(t, db, "accounts/fireworks/models/glm-5p2", 500)
+	// Write the request body into the legacy input_content column directly (no
+	// request_log_content row).
+	if _, err := db.Exec(
+		`UPDATE request_logs SET input_content = ? WHERE id = ?`,
+		`{"model":"glm-5.2","input":"ping"}`, id,
+	); err != nil {
+		t.Fatalf("set legacy input_content: %v", err)
+	}
+
+	backfillRequestLogModelNames(db)
+
+	var model string
+	if err := db.QueryRow("SELECT model FROM request_logs WHERE id = ?", id).Scan(&model); err != nil {
+		t.Fatalf("query repaired row: %v", err)
+	}
+	if model != "glm-5.2" {
+		t.Fatalf("model = %q, want glm-5.2 (legacy recovery)", model)
+	}
+}
+
+// TestBackfillRequestLogModelNamesSkipsUnrecoverableRows verifies that a bad row
+// with no stored request body is left unchanged (not silently fabricated).
+func TestBackfillRequestLogModelNamesSkipsUnrecoverableRows(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+
+	id := insertProviderEchoRequestLog(t, db, "accounts/fireworks/models/glm-5p2", 100)
+	// No content row, no legacy input_content.
+
+	backfillRequestLogModelNames(db)
+
+	var model string
+	if err := db.QueryRow("SELECT model FROM request_logs WHERE id = ?", id).Scan(&model); err != nil {
+		t.Fatalf("query row: %v", err)
+	}
+	if model != "accounts/fireworks/models/glm-5p2" {
+		t.Fatalf("unrecoverable row model = %q, must be left unchanged", model)
+	}
+}
+
+// TestBackfillRequestLogModelNamesLeavesLegitimateSlashModelsUntouched verifies
+// that legitimate slash model names (e.g. meta/llama-3.1-8b-instruct) are not
+// treated as bad provider-echo paths and are left alone.
+func TestBackfillRequestLogModelNamesLeavesLegitimateSlashModelsUntouched(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+
+	id := insertProviderEchoRequestLog(t, db, "meta/llama-3.1-8b-instruct", 100)
+	insertRequestLogContentRow(t, db, id, `{"model":"meta/llama-3.1-8b-instruct","messages":[]}`)
+
+	backfillRequestLogModelNames(db)
+
+	var model string
+	if err := db.QueryRow("SELECT model FROM request_logs WHERE id = ?", id).Scan(&model); err != nil {
+		t.Fatalf("query row: %v", err)
+	}
+	if model != "meta/llama-3.1-8b-instruct" {
+		t.Fatalf("legitimate slash model changed to %q, must stay meta/llama-3.1-8b-instruct", model)
+	}
+}
+
+// TestBackfillRequestLogModelNamesIsIdempotent verifies that re-running the
+// backfill after a successful repair does not reprocess or alter rows.
+func TestBackfillRequestLogModelNamesIsIdempotent(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+
+	id := insertProviderEchoRequestLog(t, db, "accounts/fireworks/models/glm-5p2", 800)
+	insertRequestLogContentRow(t, db, id, `{"model":"glm-5.2","messages":[]}`)
+
+	backfillRequestLogModelNames(db)
+	var model string
+	if err := db.QueryRow("SELECT model FROM request_logs WHERE id = ?", id).Scan(&model); err != nil {
+		t.Fatalf("query row after first backfill: %v", err)
+	}
+	// Run again — must be a no-op for this row.
+	backfillRequestLogModelNames(db)
+
+	if err := db.QueryRow("SELECT model FROM request_logs WHERE id = ?", id).Scan(&model); err != nil {
+		t.Fatalf("query row after second backfill: %v", err)
+	}
+	if model != "glm-5.2" {
+		t.Fatalf("model = %q after idempotent re-run, want glm-5.2", model)
+	}
+}
+
+// TestRecoverModelFromStoredInputGuards verifies the recovery helper rejects
+// recovered values that are themselves echo paths or placeholders.
+func TestRecoverModelFromStoredInputGuards(t *testing.T) {
+	cases := []struct {
+		name        string
+		compression string
+		content     string
+		legacy      string
+		wantOK      bool
+		wantModel   string
+	}{
+		{name: "clean from legacy", legacy: `{"model":"glm-5.2"}`, wantOK: true, wantModel: "glm-5.2"},
+		{name: "echo recovered is rejected", legacy: `{"model":"accounts/fireworks/models/glm-5p2"}`, wantOK: false},
+		{name: "unknown placeholder rejected", legacy: `{"model":"unknown"}`, wantOK: false},
+		{name: "empty body", legacy: "", wantOK: false},
+		{name: "non-json body", legacy: "not json", wantOK: false},
+		{name: "missing model field", legacy: `{"foo":"bar"}`, wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var contentBytes []byte
+			if tc.content != "" {
+				c, err := compressLogContent(tc.content)
+				if err != nil {
+					t.Fatalf("compress: %v", err)
+				}
+				contentBytes = c
+			}
+			gotModel, gotOK := recoverModelFromStoredInput(tc.compression, contentBytes, tc.legacy)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (model=%q)", gotOK, tc.wantOK, gotModel)
+			}
+			if gotOK && gotModel != tc.wantModel {
+				t.Fatalf("model = %q, want %q", gotModel, tc.wantModel)
+			}
+		})
+	}
+}

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -25,7 +25,9 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		params.Days = 7
 	}
 
-	db := getDB()
+	// Read path: use the dedicated read-only pool so management log queries do not
+	// block on the single writer or maintenance ops (wal_checkpoint/VACUUM).
+	db := getReadDB()
 	if db == nil {
 		// Never return nil slices in JSON responses (nil slice => null in JSON).
 		return LogQueryResult{
@@ -42,6 +44,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 	var total int64
 	countSQL := "SELECT COUNT(*) FROM request_logs" + where
 	if err := db.QueryRow(countSQL, args...).Scan(&total); err != nil {
+		log.Warnf("usage: count query failed: %v", err)
 		return LogQueryResult{}, fmt.Errorf("usage: count query: %w", err)
 	}
 
@@ -58,6 +61,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 
 	rows, err := db.Query(querySQL, queryArgs...)
 	if err != nil {
+		log.Warnf("usage: query logs failed: %v", err)
 		return LogQueryResult{}, fmt.Errorf("usage: query logs: %w", err)
 	}
 	defer rows.Close()
@@ -73,6 +77,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 			&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
 			&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,
 		); err != nil {
+			log.Warnf("usage: scan log row failed: %v", err)
 			return LogQueryResult{}, fmt.Errorf("usage: scan row: %w", err)
 		}
 		row.Timestamp, _ = time.Parse(time.RFC3339Nano, ts)
@@ -163,7 +168,7 @@ func QueryFilters(days int) (FilterOptions, error) {
 	if days < 1 {
 		days = 7
 	}
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		// Ensure stable JSON shape: slices => [] (not null), maps => {} (not null).
 		return FilterOptions{
@@ -178,14 +183,17 @@ func QueryFilters(days int) (FilterOptions, error) {
 
 	keys, keyNames, err := queryDistinctAPIKeys(db, cutoff)
 	if err != nil {
+		log.Warnf("usage: query distinct api keys failed: %v", err)
 		return FilterOptions{}, err
 	}
 	models, err := queryDistinct(db, "model", cutoff)
 	if err != nil {
+		log.Warnf("usage: query distinct models failed: %v", err)
 		return FilterOptions{}, err
 	}
 	channels, err := queryDistinct(db, "channel_name", cutoff)
 	if err != nil {
+		log.Warnf("usage: query distinct channels failed: %v", err)
 		return FilterOptions{}, err
 	}
 
@@ -199,7 +207,7 @@ func QueryFilters(days int) (FilterOptions, error) {
 
 // QueryStats returns aggregated statistics over the filtered dataset.
 func QueryStats(params LogQueryParams) (LogStats, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 
 		return LogStats{CacheRate: 0}, nil
@@ -215,6 +223,7 @@ func QueryStats(params LogQueryParams) (LogStats, error) {
 	statsSQL := "SELECT COUNT(*), COALESCE(SUM(CASE WHEN failed=0 THEN 1 ELSE 0 END),0), COALESCE(SUM(total_tokens),0), COALESCE(SUM(cost),0), COALESCE(SUM(" + cacheRateEffectiveInputSQL + "),0), COALESCE(SUM(cached_tokens),0) " +
 		"FROM request_logs" + where
 	if err := db.QueryRow(statsSQL, args...).Scan(&total, &successCount, &totalTokens, &totalCost, &effectiveInputTokens, &totalCachedTokens); err != nil {
+		log.Warnf("usage: stats query failed: %v", err)
 		return LogStats{}, fmt.Errorf("usage: stats query: %w", err)
 	}
 
@@ -602,6 +611,7 @@ func queryDistinct(db *sql.DB, column, cutoff string) ([]string, error) {
 	q := fmt.Sprintf("SELECT DISTINCT %s FROM request_logs WHERE timestamp >= ? ORDER BY %s", column, column)
 	rows, err := db.Query(q, cutoff)
 	if err != nil {
+		log.Warnf("usage: distinct %s query failed: %v", column, err)
 		return nil, fmt.Errorf("usage: distinct %s: %w", column, err)
 	}
 	defer rows.Close()
@@ -610,6 +620,7 @@ func queryDistinct(db *sql.DB, column, cutoff string) ([]string, error) {
 	for rows.Next() {
 		var v string
 		if err := rows.Scan(&v); err != nil {
+			log.Warnf("usage: distinct %s scan failed: %v", column, err)
 			return nil, err
 		}
 		if v != "" {
@@ -636,6 +647,7 @@ func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]strin
 		ORDER BY logical_selector
 	`, cutoff)
 	if err != nil {
+		log.Warnf("usage: distinct api_key logical groups query failed: %v", err)
 		return nil, nil, fmt.Errorf("usage: distinct api_key logical groups: %w", err)
 	}
 	defer rows.Close()
@@ -649,6 +661,7 @@ func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]strin
 		var snapshotKey string
 		var snapshotName string
 		if err := rows.Scan(&logicalSelector, &logicalID, &snapshotKey, &snapshotName); err != nil {
+			log.Warnf("usage: distinct api_key scan failed: %v", err)
 			return nil, nil, err
 		}
 
@@ -700,7 +713,7 @@ func buildSingleAPIKeySelectorClause(selector string) (string, []interface{}) {
 
 // QueryModelsForKey returns the distinct models used by a specific API key within the time range.
 func QueryModelsForKey(apiKey string, days int) ([]string, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return make([]string, 0), nil
 	}
@@ -714,6 +727,7 @@ func QueryModelsForKey(apiKey string, days int) ([]string, error) {
 		args...,
 	)
 	if err != nil {
+		log.Warnf("usage: distinct models for key query failed: %v", err)
 		return nil, fmt.Errorf("usage: distinct models for key: %w", err)
 	}
 	defer rows.Close()
@@ -722,6 +736,7 @@ func QueryModelsForKey(apiKey string, days int) ([]string, error) {
 	for rows.Next() {
 		var v string
 		if err := rows.Scan(&v); err != nil {
+			log.Warnf("usage: distinct models for key scan failed: %v", err)
 			return nil, err
 		}
 		result = append(result, v)

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -25,7 +25,7 @@ type ModelDistributionPoint struct {
 
 // QueryDailySeries returns per-day aggregated request count and token usage for a given API key.
 func QueryDailySeries(apiKey string, days int) ([]DailySeriesPoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return nil, nil
 	}
@@ -65,7 +65,7 @@ func QueryDailySeries(apiKey string, days int) ([]DailySeriesPoint, error) {
 
 // QueryModelDistribution returns request count and token usage grouped by model for a given API key.
 func QueryModelDistribution(apiKey string, days int) ([]ModelDistributionPoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return nil, nil
 	}
@@ -109,7 +109,7 @@ type APIKeyDistributionPoint struct {
 
 // QueryAPIKeyDistribution returns request count and token usage grouped by api_key.
 func QueryAPIKeyDistribution(days int) ([]APIKeyDistributionPoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return nil, nil
 	}
@@ -188,7 +188,7 @@ type HourlyModelPoint struct {
 
 // QueryHourlySeries returns per-hour token and model aggregates for the last N hours.
 func QueryHourlySeries(apiKey string, hours int) ([]HourlyTokenPoint, []HourlyModelPoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return nil, nil, nil
 	}
@@ -268,7 +268,7 @@ type EntityStatPoint struct {
 // QueryEntityStats returns aggregates grouped by a given column (e.g. "source" or "auth_index").
 // Time range is derived from days logic.
 func QueryEntityStats(apiKey string, days int, groupColumn string, entityNames []string) ([]EntityStatPoint, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return nil, nil
 	}

--- a/internal/usage/request_log_storage_stats.go
+++ b/internal/usage/request_log_storage_stats.go
@@ -11,7 +11,7 @@ import (
 // request_log_content and any legacy inline content not yet migrated out of
 // request_logs.
 func GetRequestLogStorageBytes() (int64, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return 0, nil
 	}
@@ -48,7 +48,7 @@ type ChannelLatency struct {
 // GetChannelAvgLatency returns average request latency grouped by source (channel)
 // for the last N days.
 func GetChannelAvgLatency(days int) ([]ChannelLatency, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return nil, fmt.Errorf("usage: database not initialised")
 	}
@@ -80,7 +80,7 @@ func GetChannelAvgLatency(days int) ([]ChannelLatency, error) {
 
 // CountTodayByKey returns the number of requests made by the given API key today (project timezone).
 func CountTodayByKey(apiKey string) (int64, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return 0, nil
 	}
@@ -99,7 +99,7 @@ func CountTodayByKey(apiKey string) (int64, error) {
 
 // CountTotalByKey returns the total number of requests made by the given API key.
 func CountTotalByKey(apiKey string) (int64, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return 0, nil
 	}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -111,6 +111,7 @@ const systemRequestLogFilterValue = "__system__"
 
 var (
 	usageDB     *sql.DB
+	usageReadDB *sql.DB
 	usageDBMu   sync.Mutex
 	usageDBPath string
 	usageLoc    *time.Location
@@ -382,6 +383,32 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	} else {
 		log.Debugf("usage: journal_mode set (result: %v)", res)
 	}
+	// synchronous=NORMAL under WAL is safe (no corruption on power loss for
+	// committed txns) and reduces fsync contention between the writer and readers.
+	if _, err := db.Exec("PRAGMA synchronous = NORMAL"); err != nil {
+		log.Warnf("usage: failed to set synchronous=NORMAL: %v", err)
+	}
+
+	// Open a separate read-only connection pool so management reads (QueryLogs,
+	// QueryStats, QueryFilters, content queries) do not serialize behind the
+	// single writer or maintenance ops (wal_checkpoint/VACUUM). WAL mode allows
+	// concurrent readers alongside a writer, so reads stay responsive while inserts
+	// or maintenance hold the write connection. WAL is persisted on the DB file by
+	// the writer above, so the read-only handle opens in WAL mode automatically.
+	readDB, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=busy_timeout(5000)")
+	if err != nil {
+		_ = db.Close()
+		return fmt.Errorf("usage: open sqlite read-only handle: %w", err)
+	}
+	// Readers can run concurrently with each other and with the writer under WAL.
+	readDB.SetMaxOpenConns(4)
+	readDB.SetMaxIdleConns(2)
+	readDB.SetConnMaxLifetime(30 * time.Minute)
+	if err := readDB.PingContext(pingCtx); err != nil {
+		_ = db.Close()
+		_ = readDB.Close()
+		return fmt.Errorf("usage: ping sqlite read-only handle: %w", err)
+	}
 
 	log.Debugf("usage: creating tables")
 	if _, err := db.Exec(createTableSQL); err != nil {
@@ -390,6 +417,7 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	}
 
 	usageDB = db
+	usageReadDB = readDB
 	usageDBPath = dbPath
 	requestLogStorage = normalizeRequestLogStorageConfig(storageCfg)
 	log.Debugf("usage: running content column migration")
@@ -418,6 +446,8 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	initAPIKeysTable(db)
 	log.Debugf("usage: backfilling request log api_key_id values")
 	backfillRequestLogAPIKeyIDs(db)
+	log.Debugf("usage: backfilling request log provider-echo model values")
+	backfillRequestLogModelNames(db)
 	log.Debugf("usage: initializing api_key_permission_profiles table")
 	initAPIKeyPermissionProfilesTable(db)
 	log.Debugf("usage: initializing ccswitch_import_configs table")
@@ -442,9 +472,13 @@ func CloseDB() {
 	if usageDB != nil {
 		_ = usageDB.Close()
 		usageDB = nil
-		usageLoc = nil
-		log.Info("usage: SQLite database closed")
 	}
+	if usageReadDB != nil {
+		_ = usageReadDB.Close()
+		usageReadDB = nil
+	}
+	usageLoc = nil
+	log.Info("usage: SQLite database closed")
 }
 
 // InsertLog writes a single request log entry into the SQLite database.
@@ -603,6 +637,19 @@ func parseStoredTime(value string) (time.Time, bool) {
 func getDB() *sql.DB {
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()
+	return usageDB
+}
+
+// getReadDB returns the dedicated read-only connection pool used by management
+// read paths (QueryLogs/QueryStats/QueryFilters/content queries) so they do not
+// block on the single writer or maintenance ops. It falls back to the write
+// handle when no read pool is available, preserving correctness.
+func getReadDB() *sql.DB {
+	usageDBMu.Lock()
+	defer usageDBMu.Unlock()
+	if usageReadDB != nil {
+		return usageReadDB
+	}
 	return usageDB
 }
 

--- a/internal/usage/usage_log_queries.go
+++ b/internal/usage/usage_log_queries.go
@@ -7,7 +7,7 @@ import (
 
 // QueryLogRowByID returns a single request log row by primary key.
 func QueryLogRowByID(id int64) (LogRow, error) {
-	db := getDB()
+	db := getReadDB()
 	if db == nil {
 		return LogRow{}, fmt.Errorf("usage: database not initialised")
 	}


### PR DESCRIPTION
## Summary

Three related fixes for the `request_logs` / management read path, all confined to `CliRelay/`.

### 1. Write path — stop logging the upstream model echo
The OpenAI-compat executor overwrote the usage reporter's clean request-time model with the upstream response's `model` field, persisting provider-internal paths like `accounts/fireworks/models/glm-5p2` instead of the requested `glm-5.2`. That echo also broke cost calculation — no pricing entry exists for the path string, so `cost` was recorded as 0.

- Removed `reporter.setModel(parseOpenAI*Model(...))` in both the non-stream and stream branches of `openai_compat_executor.go`.
- Every other executor (codex/claude/gemini/…) already keeps the request-time model and never overrides it; this makes the compat path consistent with them.
- Cost lookup (`CalculateCostV2`) keys on the clean model name, so this also fixes cost attribution.
- Updated the prior test that locked in the echo behavior (`TestOpenAICompatExecutorUsageUsesUpstreamResponseModel` → `…PreservesRequestModelOverUpstreamEcho`) and added a stream-path regression test.

### 2. Backfill — repair historical bad model values from stored request bodies
New `backfillRequestLogModelNames(db)`, run once at `InitDB` startup (after the existing `api_key_id` backfill).

- Recovers the original client-requested model from each row's stored request body (compressed `request_log_content` or legacy `request_logs.input_content`) for rows whose `model` matches the upstream echo shape `accounts/%/models/%`, then rewrites `model` and recomputes `cost`.
- Idempotent: only rows still matching the bad pattern are processed.
- Conservative: legitimate slash model names (e.g. `meta/llama-3.1-8b-instruct`) are **not** touched.
- Rows whose stored request body was cleared are left unchanged and counted in a warning — no fabrication.
- Production scoping (read-only): 148 bad rows total — 146 `accounts/fireworks/models/glm-5p2` (all recoverable, `glm-5.2` pricing exists in `model_configs`) + 2 `meta/llama-3.1-8b-instruct` (legitimate, untouched).

### 3. Management read 500s + observability
The intermittent 500s on `/v0/management/usage/logs` came from the single SQLite connection (`MaxOpenConns=1`) serializing reads behind writes/maintenance, plus errors being returned to the HTTP body only — never logged, so `main.log` showed only `500 | 158ms` with no cause.

- **Read/write split** in `usage_db.go`: kept the single write connection (serialized writes), added a separate read-only pool (`file:<path>?mode=ro`, `MaxOpenConns=4`) for all management read queries. WAL allows concurrent readers alongside the writer. Added `synchronous=NORMAL`.
- Switched the read path (`QueryLogs`/`QueryStats`/`QueryFilters`, content, dashboard, series, storage_stats, auth_trends, entity stats, fingerprint) to `getReadDB()`; writes/maintenance (`VACUUM`, `ClearRequestLogs`, `DeleteLogsByAPIKey`) stay on `getDB()`.
- **Error logging**: added `log.Warnf` at every silently-swallowed query error in `internal/usage` and at every management handler 500 branch. The public usage summary handler previously dropped the error string entirely — now it is logged.
- Tests: a concurrent read/write test (4 writers × 25 + 4 readers × 25, asserts reads stay error-free) and a log-capture test (asserts a query error emits a warn-level log entry).

## Scope / impact
- **Directories touched**: `CliRelay/internal/usage`, `CliRelay/internal/runtime/executor`, `CliRelay/internal/api/handlers/management`.
- **No `codeProxy/` (frontend) changes** — the response shape is unchanged.
- **No `config.yaml` changes, no schema changes** (no new columns; backfill is UPDATE-only).
- Does not touch `CliRelay/` runtime config or table structure.

## Verification
- `go build ./...` — clean
- `go vet ./internal/usage/ ./internal/runtime/executor/ ./internal/api/handlers/management/` — clean
- `go test ./internal/usage/ ./internal/runtime/executor/ ./internal/api/handlers/management/ ./internal/management/usagelogs/` — all pass
- Backfill tests: compressed-content recovery + cost recompute, legacy recovery, unrecoverable-skip, legitimate-slash-model-untouched, idempotent, recovery-helper guards — all pass
- Concurrency + log-capture tests — pass
- Production DB probed read-only to confirm `glm-5.2` pricing exists (so the backfill cost recompute is effective) and to scope bad rows.

## Note
Per request, this PR does **not** include server deployment. The backfill runs automatically on the next `clirelay2` start; verification that `accounts/fireworks/models/glm-5p2` is cleared and cost is recomputed should be done after the service is restarted by the operator.