### PR TITLE
fix: preserve request logs when stats disabled

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,7 +85,8 @@ type Config struct {
 	// When exceeded, the oldest error log files are deleted. Default is 10. Set to 0 to disable cleanup.
 	ErrorLogsMaxFiles int `yaml:"error-logs-max-files" json:"error-logs-max-files"`
 
-	// UsageStatisticsEnabled toggles in-memory usage aggregation; when false, usage data is discarded.
+	// UsageStatisticsEnabled toggles in-memory usage aggregation; request log
+	// metadata is still persisted so monitoring/history pages keep working.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
 
 	// DisableCooling disables quota cooldown scheduling when true.

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -53,15 +53,13 @@ type LoggerPlugin struct {
 func NewLoggerPlugin() *LoggerPlugin { return &LoggerPlugin{stats: defaultRequestStatistics} }
 
 // HandleUsage implements coreusage.Plugin.
-// It updates the in-memory statistics store whenever a usage record is received.
+// It persists request log metadata for every usage record and updates the
+// in-memory statistics store when usage statistics are enabled.
 //
 // Parameters:
 //   - ctx: The context for the usage record
 //   - record: The usage record to aggregate
 func (p *LoggerPlugin) HandleUsage(ctx context.Context, record coreusage.Record) {
-	if !statisticsEnabled.Load() {
-		return
-	}
 	if p == nil || p.stats == nil {
 		return
 	}
@@ -69,6 +67,7 @@ func (p *LoggerPlugin) HandleUsage(ctx context.Context, record coreusage.Record)
 }
 
 // SetStatisticsEnabled toggles whether in-memory statistics are recorded.
+// Request log metadata remains persisted even when aggregation is disabled.
 func SetStatisticsEnabled(enabled bool) { statisticsEnabled.Store(enabled) }
 
 // StatisticsEnabled reports the current recording state.
@@ -290,12 +289,10 @@ func NewRequestStatistics() *RequestStatistics {
 	}
 }
 
-// Record ingests a new usage record and updates the aggregates.
+// Record ingests a new usage record, persists the request log, and updates the
+// in-memory aggregates when usage statistics are enabled.
 func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record) {
 	if s == nil {
-		return
-	}
-	if !statisticsEnabled.Load() {
 		return
 	}
 	timestamp := record.RequestedAt
@@ -317,39 +314,42 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	if modelName == "" {
 		modelName = "unknown"
 	}
-	dayKey := timestamp.Format("2006-01-02")
-	hourKey := timestamp.Hour()
 
-	s.mu.Lock()
-	s.totalRequests++
-	if success {
-		s.successCount++
-	} else {
-		s.failureCount++
+	if statisticsEnabled.Load() {
+		dayKey := timestamp.Format("2006-01-02")
+		hourKey := timestamp.Hour()
+
+		s.mu.Lock()
+		s.totalRequests++
+		if success {
+			s.successCount++
+		} else {
+			s.failureCount++
+		}
+		s.totalTokens += totalTokens
+
+		stats, ok := s.apis[statsKey]
+		if !ok {
+			stats = &apiStats{Models: make(map[string]*modelStats)}
+			s.apis[statsKey] = stats
+		}
+		s.updateAPIStats(stats, modelName, RequestDetail{
+			Timestamp:    timestamp,
+			Source:       record.Source,
+			AuthIndex:    record.AuthIndex,
+			ChannelName:  record.ChannelName,
+			Tokens:       detail,
+			LatencyMs:    record.LatencyMs,
+			FirstTokenMs: record.FirstTokenMs,
+			Failed:       failed,
+		})
+
+		s.requestsByDay[dayKey]++
+		s.requestsByHour[hourKey]++
+		s.tokensByDay[dayKey] += totalTokens
+		s.tokensByHour[hourKey] += totalTokens
+		s.mu.Unlock()
 	}
-	s.totalTokens += totalTokens
-
-	stats, ok := s.apis[statsKey]
-	if !ok {
-		stats = &apiStats{Models: make(map[string]*modelStats)}
-		s.apis[statsKey] = stats
-	}
-	s.updateAPIStats(stats, modelName, RequestDetail{
-		Timestamp:    timestamp,
-		Source:       record.Source,
-		AuthIndex:    record.AuthIndex,
-		ChannelName:  record.ChannelName,
-		Tokens:       detail,
-		LatencyMs:    record.LatencyMs,
-		FirstTokenMs: record.FirstTokenMs,
-		Failed:       failed,
-	})
-
-	s.requestsByDay[dayKey]++
-	s.requestsByHour[hourKey]++
-	s.tokensByDay[dayKey] += totalTokens
-	s.tokensByHour[hourKey] += totalTokens
-	s.mu.Unlock()
 
 	// Persist request logs in the usage manager worker so SQLite writes stay
 	// serialized and do not spawn one goroutine per request.

--- a/internal/usage/request_log_model_backfill.go
+++ b/internal/usage/request_log_model_backfill.go
@@ -28,6 +28,8 @@ const providerEchoModelPattern = "accounts/%/models/%"
 // the stored request body (request_log_content.input_content, or the legacy
 // request_logs.input_content fallback) and rewrites both the model and the cost (which
 // was zero because the echo string has no pricing entry).
+// This is intentionally not run from InitDB: historical content rows can be large or
+// damaged, and service startup must not depend on decompressing old request bodies.
 //
 // Rows whose stored request body has been cleared cannot be recovered: they are left
 // as-is and counted in a warning so the operator can decide what to do. The function is

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -446,8 +446,6 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	initAPIKeysTable(db)
 	log.Debugf("usage: backfilling request log api_key_id values")
 	backfillRequestLogAPIKeyIDs(db)
-	log.Debugf("usage: backfilling request log provider-echo model values")
-	backfillRequestLogModelNames(db)
 	log.Debugf("usage: initializing api_key_permission_profiles table")
 	initAPIKeyPermissionProfilesTable(db)
 	log.Debugf("usage: initializing ccswitch_import_configs table")

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1635,6 +1635,70 @@ func TestRequestStatisticsPersistsAPIKeyIdentitySnapshotAcrossRename(t *testing.
 	}
 }
 
+func TestRequestStatisticsPersistsRequestLogWhenStatisticsDisabled(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	wasEnabled := StatisticsEnabled()
+	SetStatisticsEnabled(false)
+	t.Cleanup(func() { SetStatisticsEnabled(wasEnabled) })
+
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "sk-disabled-stats",
+		APIKeyName:  "Disabled Stats",
+		Model:       "glm-5.2",
+		Source:      "source",
+		ChannelName: "channel",
+		AuthIndex:   "auth-1",
+		RequestedAt: time.Now().UTC(),
+		Detail: coreusage.Detail{
+			InputTokens:  10,
+			OutputTokens: 5,
+			TotalTokens:  15,
+		},
+	})
+
+	snapshot := stats.Snapshot()
+	if snapshot.TotalRequests != 0 {
+		t.Fatalf("snapshot.TotalRequests = %d, want 0 when statistics disabled", snapshot.TotalRequests)
+	}
+
+	var count int
+	if err := getDB().QueryRow("SELECT COUNT(*) FROM request_logs WHERE api_key = ?", "sk-disabled-stats").Scan(&count); err != nil {
+		t.Fatalf("query persisted request log: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("persisted request log count = %d, want 1", count)
+	}
+}
+
+func TestInitDBDoesNotRunProviderEchoModelBackfill(t *testing.T) {
+	CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("initial InitDB() error = %v", err)
+	}
+	stopRequestLogMaintenance()
+
+	db := getDB()
+	id := insertProviderEchoRequestLog(t, db, "accounts/fireworks/models/glm-5p2", 100)
+	insertRequestLogContentRow(t, db, id, `{"model":"glm-5.2","messages":[]}`)
+	CloseDB()
+
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("second InitDB() error = %v", err)
+	}
+	stopRequestLogMaintenance()
+	t.Cleanup(CloseDB)
+
+	var model string
+	if err := getDB().QueryRow("SELECT model FROM request_logs WHERE id = ?", id).Scan(&model); err != nil {
+		t.Fatalf("query provider echo row: %v", err)
+	}
+	if model != "accounts/fireworks/models/glm-5p2" {
+		t.Fatalf("model = %q, want InitDB to leave provider-echo history unchanged", model)
+	}
+}
+
 func TestClearAllRequestLogsRemovesRequestLogTablesOnly(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,


### PR DESCRIPTION
## Summary
- keep durable request log writes active even when in-memory usage statistics are disabled
- gate only in-memory aggregate mutation behind usage-statistics-enabled
- remove provider-echo model history backfill from synchronous InitDB startup
- document the corrected config contract and add regression tests

## Production evidence
- relay.07230805.xyz has usage-statistics-enabled: false
- traffic continued in /opt/clirelay2/logs/main.log
- request_logs max(timestamp) was stuck at 2026-06-20T11:01:22.525884316Z

## Tests
- go test ./internal/usage/ ./internal/runtime/executor/ ./internal/api/handlers/management/ ./internal/management/usagelogs/
- go vet ./internal/usage/ ./internal/runtime/executor/ ./internal/api/handlers/management/
- go build ./...
- go test ./...