### PR TITLE
fix: add Codex Desktop catalog model field

### DIFF
--- a/internal/usage/ccswitch_codex_model_catalog.go
+++ b/internal/usage/ccswitch_codex_model_catalog.go
@@ -47,6 +47,7 @@ type CcSwitchCodexModelMessages struct {
 
 type CcSwitchCodexModelCatalogEntry struct {
 	Slug                          string                        `json:"slug"`
+	Model                         string                        `json:"model"`
 	DisplayName                   string                        `json:"display_name"`
 	Description                   string                        `json:"description"`
 	DefaultReasoningLevel         string                        `json:"default_reasoning_level"`
@@ -177,6 +178,7 @@ func buildCcSwitchCodexModelCatalogEntry(model string, priority int) CcSwitchCod
 
 	return CcSwitchCodexModelCatalogEntry{
 		Slug:                          model,
+		Model:                         model,
 		DisplayName:                   model,
 		Description:                   model,
 		DefaultReasoningLevel:         "medium",

--- a/internal/usage/ccswitch_codex_model_catalog_test.go
+++ b/internal/usage/ccswitch_codex_model_catalog_test.go
@@ -34,6 +34,9 @@ func TestBuildCcSwitchCodexModelCatalogUsesRequestModels(t *testing.T) {
 	}
 
 	deepseek := catalog.Models[1]
+	if deepseek.Model != deepseek.Slug {
+		t.Fatalf("model = %q, want same as slug %q", deepseek.Model, deepseek.Slug)
+	}
 	if deepseek.ContextWindow != ccSwitchCodexDefaultContextWindow {
 		t.Fatalf("context_window = %d, want %d", deepseek.ContextWindow, ccSwitchCodexDefaultContextWindow)
 	}


### PR DESCRIPTION
## Summary
- add the Codex Desktop-facing model field to generated cc-switch model catalog entries
- assert generated catalog entries keep model and slug aligned

## Tests
- rtk go test ./internal/usage