### PR TITLE
fix: route opencode go tool output images to vision fallback

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -346,17 +346,7 @@ func opencodeGoPayloadHasImage(payload []byte) bool {
 }
 
 func opencodeGoCurrentRequestHasImage(payload []byte) bool {
-	if len(payload) == 0 || !json.Valid(payload) {
-		return false
-	}
-	var value any
-	if err := json.Unmarshal(payload, &value); err != nil {
-		return false
-	}
-	if hasImage, recognized := opencodeGoCurrentValueHasImage(value); recognized {
-		return hasImage
-	}
-	return opencodeGoValueHasImage(value)
+	return vision.CurrentTurnHasImages(payload)
 }
 
 func opencodeGoSanitizeHistoricalImages(payload []byte) ([]byte, bool) {

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -110,6 +110,46 @@ func TestOpenCodeGoExecutorUsesVisionFallbackForImageRequests(t *testing.T) {
 	}
 }
 
+func TestOpenCodeGoExecutorUsesVisionFallbackForResponsesFunctionCallOutputImage(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_tool_vision","object":"chat.completion","created":1,"model":"qwen3.5-plus","choices":[{"index":0,"message":{"role":"assistant","content":"tool vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":               "test-key",
+			"vision_fallback_model": "qwen3.5-plus",
+		},
+	}
+	payload := []byte(`{"model":"deepseek-v4-flash","input":[{"role":"user","content":[{"type":"input_text","text":"inspect this screenshot"}]},{"type":"function_call","call_id":"call_1","name":"get_app_state","arguments":"{}"},{"type":"function_call_output","call_id":"call_1","output":[{"type":"input_image","image_url":"data:image/png;base64,aGVsbG8="}]}]}`)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "qwen3.5-plus" {
+		t.Fatalf("upstream model = %q, want qwen3.5-plus; body=%s", gotModel, string(gotBody))
+	}
+	if gotModel := gjson.GetBytes(resp.Payload, "model").String(); gotModel != "deepseek-v4-flash" {
+		t.Fatalf("response model = %q, want deepseek-v4-flash; payload=%s", gotModel, string(resp.Payload))
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "output.0.content.0.text").String(); gotText != "tool vision ok" {
+		t.Fatalf("response text = %q, want tool vision ok; payload=%s", gotText, string(resp.Payload))
+	}
+}
+
 func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/vision/registry_test.go
+++ b/internal/vision/registry_test.go
@@ -200,6 +200,56 @@ func TestWalkPayloadResponses(t *testing.T) {
 	}
 }
 
+func TestWalkPayloadResponsesFunctionCallOutputCurrentImage(t *testing.T) {
+	payload := []byte(`{
+		"model": "deepseek-v4-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "inspect this screenshot"}]},
+			{"type": "function_call", "call_id": "call_1", "name": "get_app_state", "arguments": "{}"},
+			{"type": "function_call_output", "call_id": "call_1", "output": [{"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="}]}
+		]
+	}`)
+
+	walk := WalkPayload(payload)
+	if len(walk.Parts) != 1 {
+		t.Fatalf("expected 1 image part, got %d", len(walk.Parts))
+	}
+	if !walk.Parts[0].IsCurrent {
+		t.Fatal("expected function_call_output image after latest user to be current")
+	}
+	if !walk.CurrentImages || walk.HistoricalOnly {
+		t.Fatalf("current flags = CurrentImages:%v HistoricalOnly:%v, want current only", walk.CurrentImages, walk.HistoricalOnly)
+	}
+	if walk.Parts[0].Path != "input.2.output.0" {
+		t.Fatalf("path = %q, want input.2.output.0", walk.Parts[0].Path)
+	}
+	if walk.Parts[0].Data != "iVBORw0KGgo=" {
+		t.Fatalf("data = %q, want iVBORw0KGgo=", walk.Parts[0].Data)
+	}
+}
+
+func TestWalkPayloadResponsesFunctionCallOutputBeforeLatestUserIsHistorical(t *testing.T) {
+	payload := []byte(`{
+		"model": "deepseek-v4-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "inspect this screenshot"}]},
+			{"type": "function_call_output", "call_id": "call_1", "output": [{"type": "input_image", "image_url": "data:image/png;base64,oldImage="}]},
+			{"role": "user", "content": [{"type": "input_text", "text": "now answer a normal text question"}]}
+		]
+	}`)
+
+	walk := WalkPayload(payload)
+	if len(walk.Parts) != 1 {
+		t.Fatalf("expected 1 image part, got %d", len(walk.Parts))
+	}
+	if walk.Parts[0].IsCurrent {
+		t.Fatal("expected function_call_output image before latest user to be historical")
+	}
+	if !walk.HistoricalOnly {
+		t.Fatal("expected HistoricalOnly to be true")
+	}
+}
+
 func TestWalkPayloadHistorical(t *testing.T) {
 	payload := []byte(`{
 		"model": "deepseek-v4-flash",

--- a/internal/vision/walk.go
+++ b/internal/vision/walk.go
@@ -10,6 +10,7 @@ type ImagePart struct {
 	ArrayName string // "messages" or "input"
 	MsgIdx    int    // index in the array
 	PartIdx   int    // index in the content array
+	Path      string // path to the image part or data URL string
 	Type      string // original type ("image_url" / "input_image" / "image")
 	Data      string // base64 data (may be empty for remote URLs)
 	RemoteURL string // remote URL if not inline
@@ -66,6 +67,9 @@ func (r *WalkResult) walkArray(payload []byte, arrayName string, items []gjson.R
 
 	for i, item := range items {
 		if item.Get("role").String() != "user" {
+			if arrayName == "input" && isFunctionOutputItem(item) {
+				r.walkFunctionOutputItem(payload, arrayName, i, item, i > lastUserIdx)
+			}
 			continue
 		}
 		isCurrent := (i == lastUserIdx)
@@ -101,6 +105,7 @@ func (r *WalkResult) walkMessage(payload []byte, arrayName string, msgIdx int, m
 				ArrayName: arrayName,
 				MsgIdx:    msgIdx,
 				PartIdx:   0,
+				Path:      arrayName + "." + indexStr(msgIdx) + ".content",
 				Type:      "text",
 				Data:      text,
 				IsCurrent: isCurrent,
@@ -110,6 +115,10 @@ func (r *WalkResult) walkMessage(payload []byte, arrayName string, msgIdx int, m
 }
 
 func (r *WalkResult) walkContentPart(payload []byte, arrayName string, msgIdx, pIdx int, part gjson.Result, isCurrent bool) {
+	r.walkContentPartAtPath(payload, arrayName, msgIdx, pIdx, part, isCurrent, arrayName+"."+indexStr(msgIdx)+".content."+indexStr(pIdx))
+}
+
+func (r *WalkResult) walkContentPartAtPath(payload []byte, arrayName string, msgIdx, pIdx int, part gjson.Result, isCurrent bool, path string) {
 	partType := part.Get("type").String()
 	if !isImageType(partType) && !part.Get("image_url").Exists() {
 		return
@@ -119,6 +128,7 @@ func (r *WalkResult) walkContentPart(payload []byte, arrayName string, msgIdx, p
 		ArrayName: arrayName,
 		MsgIdx:    msgIdx,
 		PartIdx:   pIdx,
+		Path:      path,
 		Type:      partType,
 		IsCurrent: isCurrent,
 	}
@@ -152,6 +162,56 @@ func (r *WalkResult) walkContentPart(payload []byte, arrayName string, msgIdx, p
 	r.Parts = append(r.Parts, ip)
 }
 
+func (r *WalkResult) walkFunctionOutputItem(payload []byte, arrayName string, msgIdx int, item gjson.Result, isCurrent bool) {
+	for _, field := range []string{"output", "content"} {
+		value := item.Get(field)
+		if !value.Exists() {
+			continue
+		}
+		r.walkFunctionOutputValue(payload, arrayName, msgIdx, value, isCurrent, arrayName+"."+indexStr(msgIdx)+"."+field)
+	}
+}
+
+func (r *WalkResult) walkFunctionOutputValue(payload []byte, arrayName string, msgIdx int, value gjson.Result, isCurrent bool, path string) {
+	if value.IsArray() {
+		for i, child := range value.Array() {
+			r.walkFunctionOutputValue(payload, arrayName, msgIdx, child, isCurrent, path+"."+indexStr(i))
+		}
+		return
+	}
+	if value.IsObject() {
+		partType := value.Get("type").String()
+		if isImageType(partType) || value.Get("image_url").Exists() {
+			r.walkContentPartAtPath(payload, arrayName, msgIdx, 0, value, isCurrent, path)
+			return
+		}
+		for key, child := range value.Map() {
+			r.walkFunctionOutputValue(payload, arrayName, msgIdx, child, isCurrent, path+"."+key)
+		}
+		return
+	}
+	text := value.String()
+	if hasDataImagePrefix(text) {
+		r.Parts = append(r.Parts, ImagePart{
+			ArrayName: arrayName,
+			MsgIdx:    msgIdx,
+			PartIdx:   0,
+			Path:      path,
+			Type:      "text",
+			Data:      text,
+			IsCurrent: isCurrent,
+		})
+	}
+}
+
+func isFunctionOutputItem(item gjson.Result) bool {
+	switch item.Get("type").String() {
+	case "function_call_output", "computer_call_output":
+		return true
+	}
+	return false
+}
+
 // ReplaceImagePart replaces an image content part with a text placeholder,
 // using the array type to determine the correct content type field name.
 func ReplaceImagePart(payload []byte, ip ImagePart, placeholderText string) ([]byte, error) {
@@ -168,6 +228,14 @@ func ReplaceImagePartEx(payload []byte, ip ImagePart, placeholderText string, ar
 	contentField := "text" // Responses API input_text uses "text" as field name
 
 	dataPath := ip.ArrayName + "." + indexStr(ip.MsgIdx) + ".content." + indexStr(ip.PartIdx)
+	if ip.Path != "" {
+		dataPath = ip.Path
+	}
+
+	current := gjson.GetBytes(payload, dataPath)
+	if current.Exists() && current.Type == gjson.String {
+		return sjson.SetBytes(payload, dataPath, placeholderText)
+	}
 
 	payload, err := sjson.SetBytes(payload, dataPath+".type", contentType)
 	if err != nil {


### PR DESCRIPTION
## Summary
- detect Responses API function_call_output/computer_call_output images in the vision walker
- reuse the shared current-turn image detection for OpenCode Go vision fallback routing
- add regression coverage for tool-output image fallback while preserving the original response model

## Tests
- rtk go test ./...