### PR TITLE
feat: track claude oauth health

### DIFF
--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -11,11 +11,11 @@ const (
 	DefaultCodexFingerprintWebsocketBeta = "responses_websockets=2026-02-06"
 	DefaultCodexFingerprintSessionMode   = "per-request"
 
-	DefaultClaudeFingerprintCLIVersion              = "2.1.88"
+	DefaultClaudeFingerprintCLIVersion              = "2.1.161"
 	DefaultClaudeFingerprintEntrypoint              = "cli"
-	DefaultClaudeFingerprintAnthropicBeta           = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20,effort-2025-11-24"
-	DefaultClaudeFingerprintStainlessPackageVersion = "0.74.0"
-	DefaultClaudeFingerprintStainlessRuntimeVersion = "v22.13.0"
+	DefaultClaudeFingerprintAnthropicBeta           = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05,effort-2025-11-24,context-management-2025-06-27,extended-cache-ttl-2025-04-11"
+	DefaultClaudeFingerprintStainlessPackageVersion = "0.94.0"
+	DefaultClaudeFingerprintStainlessRuntimeVersion = "v24.3.0"
 	DefaultClaudeFingerprintStainlessTimeout        = "600"
 	DefaultClaudeFingerprintSessionMode             = "per-request"
 )

--- a/internal/config/identity_fingerprint_test.go
+++ b/internal/config/identity_fingerprint_test.go
@@ -45,20 +45,23 @@ func TestDefaultClaudeIdentityFingerprintMirrorsClaudeCode(t *testing.T) {
 	if got.Enabled {
 		t.Fatalf("Enabled = true, want false by default")
 	}
-	if got.CLIVersion != "2.1.88" {
-		t.Fatalf("CLIVersion = %q, want 2.1.88", got.CLIVersion)
+	if got.CLIVersion != "2.1.161" {
+		t.Fatalf("CLIVersion = %q, want 2.1.161", got.CLIVersion)
 	}
 	if got.Entrypoint != "cli" {
 		t.Fatalf("Entrypoint = %q, want cli", got.Entrypoint)
 	}
-	if got.UserAgent != "claude-cli/2.1.88 (external, cli)" {
+	if got.UserAgent != "claude-cli/2.1.161 (external, cli)" {
 		t.Fatalf("UserAgent = %q, want Claude Code user agent", got.UserAgent)
 	}
-	if got.StainlessPackageVersion != "0.74.0" {
-		t.Fatalf("StainlessPackageVersion = %q, want 0.74.0", got.StainlessPackageVersion)
+	if got.StainlessPackageVersion != "0.94.0" {
+		t.Fatalf("StainlessPackageVersion = %q, want 0.94.0", got.StainlessPackageVersion)
 	}
-	if got.StainlessRuntimeVersion != "v22.13.0" {
-		t.Fatalf("StainlessRuntimeVersion = %q, want v22.13.0", got.StainlessRuntimeVersion)
+	if got.StainlessRuntimeVersion != "v24.3.0" {
+		t.Fatalf("StainlessRuntimeVersion = %q, want v24.3.0", got.StainlessRuntimeVersion)
+	}
+	if got.AnthropicBeta != "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05,effort-2025-11-24,context-management-2025-06-27,extended-cache-ttl-2025-04-11" {
+		t.Fatalf("AnthropicBeta = %q, want Claude Code OAuth beta set", got.AnthropicBeta)
 	}
 	if got.SessionMode != "per-request" {
 		t.Fatalf("SessionMode = %q, want per-request", got.SessionMode)

--- a/internal/management/authfiles/claude_oauth_health.go
+++ b/internal/management/authfiles/claude_oauth_health.go
@@ -1,0 +1,85 @@
+package authfiles
+
+import (
+	"strings"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func ClaudeOAuthHealth(auth *coreauth.Auth) map[string]any {
+	if auth == nil || auth.Metadata == nil {
+		return nil
+	}
+	health := sanitizeClaudeOAuthHealthValue(auth.Metadata[coreauth.ClaudeOAuthHealthMetadataKey], 0)
+	asMap, ok := health.(map[string]any)
+	if !ok || len(asMap) == 0 {
+		return nil
+	}
+	return asMap
+}
+
+func sanitizeClaudeOAuthHealthValue(value any, depth int) any {
+	if depth > 8 {
+		return nil
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, val := range typed {
+			if isSensitiveClaudeOAuthHealthKey(key) {
+				continue
+			}
+			if cloned := sanitizeClaudeOAuthHealthValue(val, depth+1); cloned != nil {
+				out[key] = cloned
+			}
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]any, len(typed))
+		for key, val := range typed {
+			if isSensitiveClaudeOAuthHealthKey(key) {
+				continue
+			}
+			out[key] = val
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, val := range typed {
+			if cloned := sanitizeClaudeOAuthHealthValue(val, depth+1); cloned != nil {
+				out = append(out, cloned)
+			}
+		}
+		return out
+	case string:
+		return typed
+	case bool:
+		return typed
+	case int:
+		return typed
+	case int64:
+		return typed
+	case float64:
+		return typed
+	case time.Time:
+		if typed.IsZero() {
+			return nil
+		}
+		return typed.UTC().Format(time.RFC3339Nano)
+	default:
+		return nil
+	}
+}
+
+func isSensitiveClaudeOAuthHealthKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	if normalized == "" {
+		return true
+	}
+	return strings.Contains(normalized, "token") ||
+		strings.Contains(normalized, "api_key") ||
+		normalized == "authorization" ||
+		normalized == "cookie" ||
+		normalized == "secret"
+}

--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -94,6 +94,9 @@ func BuildEntry(auth *coreauth.Auth, opts EntryOptions) map[string]any {
 		entry["plan_type"] = planType
 	}
 	AddSubscriptionFields(entry, auth.Metadata, now)
+	if health := ClaudeOAuthHealth(auth); len(health) > 0 {
+		entry["claude_oauth_health"] = health
+	}
 	if !auth.CreatedAt.IsZero() {
 		entry["created_at"] = auth.CreatedAt
 	}

--- a/internal/management/authfiles/entry_test.go
+++ b/internal/management/authfiles/entry_test.go
@@ -71,6 +71,54 @@ func TestBuildEntryAllowsRuntimeOnlyAuthWithoutPath(t *testing.T) {
 	}
 }
 
+func TestBuildEntryIncludesSanitizedClaudeOAuthHealth(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-oauth",
+		Provider: "claude",
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+		Metadata: map[string]any{
+			"email":         "claude@example.com",
+			"access_token":  "metadata-access-token",
+			"refresh_token": "metadata-refresh-token",
+			coreauth.ClaudeOAuthHealthMetadataKey: map[string]any{
+				"status":        "refresh_pending",
+				"access_token":  "health-access-token",
+				"refresh_token": "health-refresh-token",
+				"windows": map[string]any{
+					"five_hour": map[string]any{
+						"status":      "rejected",
+						"exceeded":    true,
+						"secret":      "hidden",
+						"utilization": 1.02,
+					},
+				},
+			},
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{})
+	if entry == nil {
+		t.Fatal("expected entry")
+	}
+	health, ok := entry["claude_oauth_health"].(map[string]any)
+	if !ok {
+		t.Fatalf("claude_oauth_health = %#v, want map", entry["claude_oauth_health"])
+	}
+	if health["status"] != "refresh_pending" {
+		t.Fatalf("health.status = %v, want refresh_pending", health["status"])
+	}
+	if _, ok := health["access_token"]; ok {
+		t.Fatalf("health leaked access_token: %#v", health)
+	}
+	windows, _ := health["windows"].(map[string]any)
+	fiveHour, _ := windows["five_hour"].(map[string]any)
+	if fiveHour["utilization"] != 1.02 || fiveHour["secret"] != nil {
+		t.Fatalf("five_hour = %#v, want utilization without secret", fiveHour)
+	}
+}
+
 func TestBuildEntryUsesInjectedStat(t *testing.T) {
 	modtime := time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC)
 	auth := &coreauth.Auth{

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -159,7 +159,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		recorder.AppendResponseChunk(b)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
@@ -297,7 +297,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
 		return nil, err
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
@@ -437,7 +437,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 		if errClose := resp.Body.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(b), headers: resp.Header.Clone()}
 	}
 	decodedBody, err := decodeResponseBody(resp.Body, resp.Header.Get("Content-Encoding"))
 	if err != nil {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -374,15 +374,15 @@ func TestClaudeExecutorAppliesClaudeIdentityFingerprint(t *testing.T) {
 	if got := gotHeaders.Get("User-Agent"); got != "claude-cli/2.1.88 (external, cli)" {
 		t.Fatalf("User-Agent = %q, want Claude Code fingerprint", got)
 	}
-	if got := gotHeaders.Get("Anthropic-Beta"); !strings.Contains(got, "redact-thinking-2026-02-12") ||
+	if got := gotHeaders.Get("Anthropic-Beta"); !strings.Contains(got, "extended-cache-ttl-2025-04-11") ||
 		!strings.Contains(got, "oauth-2025-04-20") {
 		t.Fatalf("Anthropic-Beta = %q, want Claude Code OAuth betas", got)
 	}
-	if got := gotHeaders.Get("X-Stainless-Package-Version"); got != "0.74.0" {
-		t.Fatalf("X-Stainless-Package-Version = %q, want 0.74.0", got)
+	if got := gotHeaders.Get("X-Stainless-Package-Version"); got != "0.94.0" {
+		t.Fatalf("X-Stainless-Package-Version = %q, want 0.94.0", got)
 	}
-	if got := gotHeaders.Get("X-Stainless-Runtime-Version"); got != "v22.13.0" {
-		t.Fatalf("X-Stainless-Runtime-Version = %q, want v22.13.0", got)
+	if got := gotHeaders.Get("X-Stainless-Runtime-Version"); got != "v24.3.0" {
+		t.Fatalf("X-Stainless-Runtime-Version = %q, want v24.3.0", got)
 	}
 	if got := gotHeaders.Get("X-Claude-Code-Session-Id"); got != "session-fixed-123" {
 		t.Fatalf("X-Claude-Code-Session-Id = %q, want fixed session", got)

--- a/internal/runtime/executor/claude_transport.go
+++ b/internal/runtime/executor/claude_transport.go
@@ -202,16 +202,12 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 		ginHeaders = ginCtx.Request.Header
 	}
 
-	promptCachingBeta := "prompt-caching-2024-07-31"
-	baseBetas := "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14," + promptCachingBeta
+	baseBetas := config.DefaultClaudeFingerprintAnthropicBeta
 	if val := strings.TrimSpace(ginHeaders.Get("Anthropic-Beta")); val != "" {
 		baseBetas = val
 		if !strings.Contains(val, "oauth") {
 			baseBetas += ",oauth-2025-04-20"
 		}
-	}
-	if !strings.Contains(baseBetas, promptCachingBeta) {
-		baseBetas += "," + promptCachingBeta
 	}
 
 	if len(extraBetas) > 0 {
@@ -234,14 +230,14 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	misc.EnsureHeader(r.Header, ginHeaders, "X-App", "cli")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Helper-Method", "stream")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Retry-Count", "0")
-	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Runtime-Version", hdrDefault(hd.RuntimeVersion, "v24.3.0"))
-	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Package-Version", hdrDefault(hd.PackageVersion, "0.74.0"))
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Runtime-Version", hdrDefault(hd.RuntimeVersion, config.DefaultClaudeFingerprintStainlessRuntimeVersion))
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Package-Version", hdrDefault(hd.PackageVersion, config.DefaultClaudeFingerprintStainlessPackageVersion))
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Runtime", "node")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Lang", "js")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Arch", mapStainlessArch())
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Os", mapStainlessOS())
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Timeout", hdrDefault(hd.Timeout, "600"))
-	misc.EnsureHeader(r.Header, ginHeaders, "User-Agent", hdrDefault(hd.UserAgent, "claude-cli/2.1.44 (external, sdk-cli)"))
+	misc.EnsureHeader(r.Header, ginHeaders, "User-Agent", hdrDefault(hd.UserAgent, config.BuildClaudeFingerprintUserAgent(config.DefaultClaudeFingerprintCLIVersion, config.DefaultClaudeFingerprintEntrypoint)))
 	r.Header.Set("Connection", "keep-alive")
 	r.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
 	if stream {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -159,7 +159,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		recorder.AppendResponseChunk(b)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
 		return resp, err
 	}
 	body, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
@@ -262,7 +262,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -410,6 +410,7 @@ type statusErr struct {
 	upstreamBody       []byte
 	quotaWindow        string
 	quotaWindowMinutes int
+	headers            http.Header
 }
 
 func (e statusErr) Error() string {
@@ -421,6 +422,12 @@ func (e statusErr) Error() string {
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
 func (e statusErr) QuotaWindow() (string, int) { return e.quotaWindow, e.quotaWindowMinutes }
+func (e statusErr) Headers() http.Header {
+	if e.headers == nil {
+		return nil
+	}
+	return e.headers.Clone()
+}
 func (e statusErr) UpstreamErrorBody() []byte {
 	if len(e.upstreamBody) == 0 {
 		return nil

--- a/sdk/cliproxy/auth/claude_oauth_health.go
+++ b/sdk/cliproxy/auth/claude_oauth_health.go
@@ -1,0 +1,452 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ClaudeOAuthHealthMetadataKey = "claude_oauth_health"
+
+	claudeOAuthHealthStatusActive         = "active"
+	claudeOAuthHealthStatusRefreshPending = "refresh_pending"
+	claudeOAuthHealthStatusRateLimited    = "rate_limited"
+	claudeOAuthHealthStatusExhausted      = "exhausted"
+
+	claudeOAuthReasonOAuth401        = "oauth_401"
+	claudeOAuthReasonAnthropic5H     = "anthropic_5h_window_exhausted"
+	claudeOAuthReasonAnthropic7D     = "anthropic_7d_window_exhausted"
+	claudeOAuthRefreshPendingMessage = "claude_oauth_refresh_pending"
+
+	claudeOAuth401Cooldown = 10 * time.Minute
+)
+
+type claudeOAuthRateLimitSpec struct {
+	headerKey  string
+	payloadKey string
+	window     string
+	minutes    int
+	maxFuture  time.Duration
+	reason     string
+}
+
+type claudeOAuthWindowDecision struct {
+	window  string
+	minutes int
+	reason  string
+	resetAt time.Time
+}
+
+var claudeOAuthRateLimitSpecs = []claudeOAuthRateLimitSpec{
+	{
+		headerKey:  "5h",
+		payloadKey: "five_hour",
+		window:     "5h",
+		minutes:    300,
+		maxFuture:  6 * time.Hour,
+		reason:     claudeOAuthReasonAnthropic5H,
+	},
+	{
+		headerKey:  "7d",
+		payloadKey: "seven_day",
+		window:     "7d",
+		minutes:    7 * 24 * 60,
+		maxFuture:  8 * 24 * time.Hour,
+		reason:     claudeOAuthReasonAnthropic7D,
+	},
+}
+
+func isClaudeOAuthAuth(auth *Auth) bool {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "claude") {
+		return false
+	}
+	if authRefreshToken(auth) != "" || authTokenValue(auth, "access_token", "accessToken") != "" {
+		return true
+	}
+	if auth.Metadata != nil {
+		if typ, _ := auth.Metadata["type"].(string); strings.EqualFold(strings.TrimSpace(typ), "claude") {
+			return true
+		}
+	}
+	accountType, _ := auth.AccountInfo()
+	return strings.EqualFold(accountType, "oauth")
+}
+
+func claudeOAuthRefreshPending(auth *Auth) bool {
+	if !isClaudeOAuthAuth(auth) || authRefreshToken(auth) == "" {
+		return false
+	}
+	health := cloneClaudeOAuthHealth(auth)
+	if len(health) == 0 {
+		return false
+	}
+	status, _ := health["status"].(string)
+	reason, _ := health["temporary_unschedulable_reason"].(string)
+	return strings.EqualFold(strings.TrimSpace(status), claudeOAuthHealthStatusRefreshPending) ||
+		strings.EqualFold(strings.TrimSpace(reason), claudeOAuthReasonOAuth401)
+}
+
+func markClaudeOAuthHealthSuccessLocked(auth *Auth, result Result, now time.Time) {
+	if !isClaudeOAuthAuth(auth) {
+		return
+	}
+	health := ensureClaudeOAuthHealth(auth, now)
+	health["status"] = claudeOAuthHealthStatusActive
+	health["last_runtime_at"] = formatClaudeOAuthHealthTime(now)
+	delete(health, "temporary_unschedulable_until")
+	delete(health, "temporary_unschedulable_reason")
+	mergeClaudeOAuthWindowHealth(health, result.Headers, now)
+	auth.Metadata[ClaudeOAuthHealthMetadataKey] = health
+}
+
+func markClaudeOAuthHealthRefreshSuccessLocked(auth *Auth, now time.Time) {
+	if !isClaudeOAuthAuth(auth) {
+		return
+	}
+	health := ensureClaudeOAuthHealth(auth, now)
+	health["status"] = claudeOAuthHealthStatusActive
+	health["last_refresh_at"] = formatClaudeOAuthHealthTime(now)
+	delete(health, "temporary_unschedulable_until")
+	delete(health, "temporary_unschedulable_reason")
+	auth.Metadata[ClaudeOAuthHealthMetadataKey] = health
+}
+
+func applyClaudeOAuthFailureLocked(auth *Auth, result Result, now time.Time, effects *resultStateEffects) bool {
+	if !isClaudeOAuthAuth(auth) {
+		return false
+	}
+	statusCode := statusCodeFromResult(result.Error)
+	if statusCode != http.StatusUnauthorized && statusCode != http.StatusTooManyRequests {
+		return false
+	}
+
+	health := ensureClaudeOAuthHealth(auth, now)
+	health["last_runtime_status"] = statusCode
+	health["last_runtime_at"] = formatClaudeOAuthHealthTime(now)
+	decision := mergeClaudeOAuthWindowHealth(health, result.Headers, now)
+
+	switch statusCode {
+	case http.StatusUnauthorized:
+		health["last_401_at"] = formatClaudeOAuthHealthTime(now)
+		if result.Error != nil && strings.TrimSpace(result.Error.Message) != "" {
+			health["last_401_message"] = trimClaudeOAuthHealthMessage(result.Error.Message)
+		}
+		if authRefreshToken(auth) == "" {
+			health["status"] = "unauthorized"
+			health["refresh_available"] = false
+			auth.Metadata[ClaudeOAuthHealthMetadataKey] = health
+			return false
+		}
+		next := now.Add(claudeOAuth401Cooldown)
+		health["status"] = claudeOAuthHealthStatusRefreshPending
+		health["temporary_unschedulable_until"] = formatClaudeOAuthHealthTime(next)
+		health["temporary_unschedulable_reason"] = claudeOAuthReasonOAuth401
+		auth.Metadata[ClaudeOAuthHealthMetadataKey] = health
+		applyClaudeOAuthTemporaryFailureLocked(auth, result, now, next, claudeOAuthRefreshPendingMessage, claudeOAuthReasonOAuth401, effects)
+		auth.NextRefreshAfter = time.Time{}
+		return true
+	case http.StatusTooManyRequests:
+		if decision == nil {
+			health["status"] = claudeOAuthHealthStatusRateLimited
+			auth.Metadata[ClaudeOAuthHealthMetadataKey] = health
+			return false
+		}
+		health["status"] = claudeOAuthHealthStatusExhausted
+		health["temporary_unschedulable_until"] = formatClaudeOAuthHealthTime(decision.resetAt)
+		health["temporary_unschedulable_reason"] = decision.reason
+		auth.Metadata[ClaudeOAuthHealthMetadataKey] = health
+		applyClaudeOAuthQuotaFailureLocked(auth, result, now, *decision, effects)
+		return true
+	default:
+		return false
+	}
+}
+
+func applyClaudeOAuthTemporaryFailureLocked(auth *Auth, result Result, now time.Time, next time.Time, message string, reason string, effects *resultStateEffects) {
+	if result.Model != "" {
+		state := ensureModelState(auth, result.Model)
+		state.Unavailable = true
+		state.Status = StatusActive
+		state.StatusMessage = message
+		state.NextRetryAfter = next
+		state.LastError = cloneError(result.Error)
+		state.Quota = QuotaState{}
+		state.UpdatedAt = now
+		if effects != nil {
+			effects.suspendReason = reason
+			effects.shouldSuspendModel = true
+		}
+		auth.LastError = cloneError(result.Error)
+		auth.StatusMessage = message
+		auth.Status = StatusActive
+		auth.UpdatedAt = now
+		updateAggregatedAvailability(auth, now)
+		return
+	}
+	auth.Unavailable = true
+	auth.Status = StatusActive
+	auth.StatusMessage = message
+	auth.NextRetryAfter = next
+	auth.LastError = cloneError(result.Error)
+	auth.UpdatedAt = now
+}
+
+func applyClaudeOAuthQuotaFailureLocked(auth *Auth, result Result, now time.Time, decision claudeOAuthWindowDecision, effects *resultStateEffects) {
+	if result.Model != "" {
+		state := ensureModelState(auth, result.Model)
+		state.Unavailable = true
+		state.Status = StatusError
+		state.StatusMessage = decision.reason
+		state.NextRetryAfter = decision.resetAt
+		state.LastError = cloneError(result.Error)
+		state.Quota = QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			Window:        decision.window,
+			WindowMinutes: decision.minutes,
+			NextRecoverAt: decision.resetAt,
+			BackoffLevel:  state.Quota.BackoffLevel,
+		}
+		state.UpdatedAt = now
+		auth.LastError = cloneError(result.Error)
+		auth.StatusMessage = decision.reason
+		auth.Status = StatusError
+		auth.UpdatedAt = now
+		updateAggregatedAvailability(auth, now)
+		if effects != nil {
+			effects.suspendReason = decision.reason
+			effects.shouldSuspendModel = true
+			effects.setModelQuota = true
+		}
+		return
+	}
+	auth.Unavailable = true
+	auth.Status = StatusError
+	auth.StatusMessage = decision.reason
+	auth.NextRetryAfter = decision.resetAt
+	auth.LastError = cloneError(result.Error)
+	auth.Quota = QuotaState{
+		Exceeded:      true,
+		Reason:        "quota",
+		Window:        decision.window,
+		WindowMinutes: decision.minutes,
+		NextRecoverAt: decision.resetAt,
+		BackoffLevel:  auth.Quota.BackoffLevel,
+	}
+	auth.UpdatedAt = now
+}
+
+func ensureClaudeOAuthHealth(auth *Auth, now time.Time) map[string]any {
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	health := cloneClaudeOAuthHealth(auth)
+	health["enabled"] = true
+	health["updated_at"] = formatClaudeOAuthHealthTime(now)
+	health["refresh_available"] = authRefreshToken(auth) != ""
+	health["runtime_profile"] = claudeOAuthRuntimeProfile(auth)
+	return health
+}
+
+func cloneClaudeOAuthHealth(auth *Auth) map[string]any {
+	if auth == nil || auth.Metadata == nil {
+		return map[string]any{}
+	}
+	return cloneAnyMap(auth.Metadata[ClaudeOAuthHealthMetadataKey])
+}
+
+func mergeClaudeOAuthWindowHealth(health map[string]any, headers http.Header, now time.Time) *claudeOAuthWindowDecision {
+	windows, decision := parseClaudeOAuthRateLimitHeaders(headers, now)
+	if len(windows) == 0 {
+		return decision
+	}
+	existing := cloneAnyMap(health["windows"])
+	for key, value := range windows {
+		existing[key] = value
+	}
+	health["windows"] = existing
+	return decision
+}
+
+func parseClaudeOAuthRateLimitHeaders(headers http.Header, now time.Time) (map[string]any, *claudeOAuthWindowDecision) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	windows := make(map[string]any)
+	var decision *claudeOAuthWindowDecision
+	for _, spec := range claudeOAuthRateLimitSpecs {
+		window, ok, exceeded, resetAt := parseClaudeOAuthWindow(headers, spec, now)
+		if !ok {
+			continue
+		}
+		windows[spec.payloadKey] = window
+		if !exceeded || resetAt.IsZero() {
+			continue
+		}
+		current := claudeOAuthWindowDecision{
+			window:  spec.window,
+			minutes: spec.minutes,
+			reason:  spec.reason,
+			resetAt: resetAt,
+		}
+		if decision == nil || spec.window == "7d" {
+			decision = &current
+		}
+	}
+	if len(windows) == 0 {
+		return nil, decision
+	}
+	return windows, decision
+}
+
+func parseClaudeOAuthWindow(headers http.Header, spec claudeOAuthRateLimitSpec, now time.Time) (map[string]any, bool, bool, time.Time) {
+	prefix := "anthropic-ratelimit-unified-" + spec.headerKey + "-"
+	status := strings.ToLower(strings.TrimSpace(headers.Get(prefix + "status")))
+	resetRaw := strings.TrimSpace(headers.Get(prefix + "reset"))
+	utilRaw := strings.TrimSpace(headers.Get(prefix + "utilization"))
+	surpassedRaw := strings.TrimSpace(headers.Get(prefix + "surpassed-threshold"))
+	if status == "" && resetRaw == "" && utilRaw == "" && surpassedRaw == "" {
+		return nil, false, false, time.Time{}
+	}
+
+	resetAt, resetValid := parseClaudeOAuthReset(resetRaw, now, spec.maxFuture)
+	utilization, hasUtilization := parseClaudeOAuthUtilization(utilRaw)
+	surpassed, hasSurpassed := parseClaudeOAuthBool(surpassedRaw)
+	exceeded := status == "rejected" || (hasUtilization && utilization >= 1.0) || (hasSurpassed && surpassed)
+
+	if status == "" {
+		status = "unknown"
+	}
+	out := map[string]any{
+		"status":     status,
+		"exceeded":   exceeded,
+		"updated_at": formatClaudeOAuthHealthTime(now),
+	}
+	if resetValid {
+		out["reset_at"] = formatClaudeOAuthHealthTime(resetAt)
+	}
+	if hasUtilization {
+		out["utilization"] = utilization
+	}
+	if hasSurpassed {
+		out["surpassed_threshold"] = surpassed
+	}
+	return out, true, exceeded, resetAt
+}
+
+func parseClaudeOAuthReset(raw string, now time.Time, maxFuture time.Duration) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || parsed <= 0 {
+		return time.Time{}, false
+	}
+	if parsed > 100_000_000_000 {
+		parsed = parsed / 1000
+	}
+	resetAt := time.Unix(parsed, 0).UTC()
+	if !resetAt.After(now) {
+		return time.Time{}, false
+	}
+	if maxFuture > 0 && resetAt.Sub(now) > maxFuture {
+		return time.Time{}, false
+	}
+	return resetAt, true
+}
+
+func parseClaudeOAuthUtilization(raw string) (float64, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func parseClaudeOAuthBool(raw string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true", "1", "yes":
+		return true, true
+	case "false", "0", "no":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func claudeOAuthRuntimeProfile(auth *Auth) map[string]any {
+	egress := "direct_or_global"
+	if auth != nil {
+		if strings.TrimSpace(auth.ProxyID) != "" {
+			egress = "proxy_pool"
+		} else if strings.TrimSpace(auth.ProxyURL) != "" {
+			egress = "proxy_url"
+		}
+	}
+	return map[string]any{
+		"name":                 "claude_oauth_runtime",
+		"identity_fingerprint": "claude_headers",
+		"transport":            "go_http_transport",
+		"egress":               egress,
+	}
+}
+
+func cloneAnyMap(value any) map[string]any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, val := range typed {
+			out[key] = cloneAnyValue(val)
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]any, len(typed))
+		for key, val := range typed {
+			out[key] = val
+		}
+		return out
+	default:
+		return map[string]any{}
+	}
+}
+
+func cloneAnyValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case map[string]string:
+		return cloneAnyMap(typed)
+	case []any:
+		out := make([]any, len(typed))
+		for i, val := range typed {
+			out[i] = cloneAnyValue(val)
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func formatClaudeOAuthHealthTime(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return ts.UTC().Format(time.RFC3339Nano)
+}
+
+func trimClaudeOAuthHealthMessage(message string) string {
+	message = strings.TrimSpace(message)
+	const maxLen = 512
+	if len(message) <= maxLen {
+		return message
+	}
+	return fmt.Sprintf("%s...", message[:maxLen])
+}

--- a/sdk/cliproxy/auth/claude_oauth_health_test.go
+++ b/sdk/cliproxy/auth/claude_oauth_health_test.go
@@ -1,0 +1,335 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestClaudeOAuthRateLimitHeaders_ParseWindowsAndPreferSevenDay(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 23, 8, 0, 0, 0, time.UTC)
+	fiveHourReset := now.Add(2 * time.Hour).Unix()
+	sevenDayReset := now.Add(72*time.Hour).Unix() * 1000
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status":              []string{"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":               []string{formatInt64(fiveHourReset)},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":         []string{"1.02"},
+		"Anthropic-Ratelimit-Unified-7d-Status":              []string{"allowed_warning"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":               []string{formatInt64(sevenDayReset)},
+		"Anthropic-Ratelimit-Unified-7d-Surpassed-Threshold": []string{"true"},
+	}
+
+	windows, decision := parseClaudeOAuthRateLimitHeaders(headers, now)
+	if decision == nil {
+		t.Fatal("decision = nil, want seven day exhaustion")
+	}
+	if decision.window != "7d" || decision.minutes != 10080 || decision.reason != claudeOAuthReasonAnthropic7D {
+		t.Fatalf("decision = %#v, want seven day decision", decision)
+	}
+	if !decision.resetAt.Equal(now.Add(72 * time.Hour)) {
+		t.Fatalf("decision.resetAt = %v, want %v", decision.resetAt, now.Add(72*time.Hour))
+	}
+	fiveHour, ok := windows["five_hour"].(map[string]any)
+	if !ok {
+		t.Fatalf("five_hour window missing in %#v", windows)
+	}
+	if fiveHour["status"] != "rejected" || fiveHour["exceeded"] != true || fiveHour["utilization"] != 1.02 {
+		t.Fatalf("five_hour = %#v, want rejected/exceeded/utilization", fiveHour)
+	}
+}
+
+func TestClaudeOAuthRateLimitHeaders_RejectsOutOfRangeReset(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 23, 8, 0, 0, 0, time.UTC)
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status": []string{"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":  []string{formatInt64(now.Add(7 * time.Hour).Unix())},
+	}
+
+	windows, decision := parseClaudeOAuthRateLimitHeaders(headers, now)
+	if decision != nil {
+		t.Fatalf("decision = %#v, want nil for out-of-range reset", decision)
+	}
+	fiveHour, ok := windows["five_hour"].(map[string]any)
+	if !ok {
+		t.Fatalf("five_hour window missing in %#v", windows)
+	}
+	if _, ok := fiveHour["reset_at"]; ok {
+		t.Fatalf("reset_at = %v, want omitted for out-of-range reset", fiveHour["reset_at"])
+	}
+}
+
+func TestManagerMarkResult_ClaudeOAuth401WithRefreshTokenIsTemporaryAndRefreshable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "claude-sonnet-4-5"
+	auth := &Auth{
+		ID:       "claude-oauth",
+		Provider: "claude",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "claude",
+			"email":         "claude@example.com",
+			"access_token":  "old-access-token",
+			"refresh_token": "stable-refresh-token",
+		},
+	}
+	if _, err := m.Register(ctx, auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	before := time.Now()
+	m.MarkResult(ctx, Result{
+		AuthID:   "claude-oauth",
+		Provider: "claude",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid oauth token"},
+	})
+
+	got, ok := m.GetByID("claude-oauth")
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	if got.Status != StatusActive {
+		t.Fatalf("auth.Status = %q, want active", got.Status)
+	}
+	if !got.Unavailable {
+		t.Fatal("auth.Unavailable = false, want true while OAuth refresh is pending")
+	}
+	if got.Metadata["refresh_token"] != "stable-refresh-token" || got.Metadata["access_token"] != "old-access-token" {
+		t.Fatalf("tokens were mutated: %#v", got.Metadata)
+	}
+	if !m.shouldRefresh(got, time.Now()) {
+		t.Fatal("shouldRefresh = false, want true for claude_oauth refresh_pending")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.Status != StatusActive || state.StatusMessage != claudeOAuthRefreshPendingMessage {
+		t.Fatalf("model status = %q/%q, want active/%q", state.Status, state.StatusMessage, claudeOAuthRefreshPendingMessage)
+	}
+	if state.NextRetryAfter.Before(before.Add(claudeOAuth401Cooldown-time.Second)) ||
+		state.NextRetryAfter.After(before.Add(claudeOAuth401Cooldown+time.Second)) {
+		t.Fatalf("NextRetryAfter = %v, want about %v", state.NextRetryAfter, before.Add(claudeOAuth401Cooldown))
+	}
+	health := mustClaudeOAuthHealth(t, got)
+	if health["status"] != claudeOAuthHealthStatusRefreshPending {
+		t.Fatalf("health.status = %v, want refresh_pending", health["status"])
+	}
+	if health["refresh_available"] != true || health["temporary_unschedulable_reason"] != claudeOAuthReasonOAuth401 {
+		t.Fatalf("health = %#v, want refresh_available and oauth_401 reason", health)
+	}
+	if _, ok := health["access_token"]; ok {
+		t.Fatalf("health leaked access_token: %#v", health)
+	}
+	if _, ok := health["refresh_token"]; ok {
+		t.Fatalf("health leaked refresh_token: %#v", health)
+	}
+}
+
+func TestManagerMarkResult_ClaudeOAuth401WithoutRefreshTokenFallsBackToUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "claude-sonnet-4-5"
+	if _, err := m.Register(ctx, &Auth{
+		ID:       "claude-oauth",
+		Provider: "claude",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":         "claude",
+			"email":        "claude@example.com",
+			"access_token": "old-access-token",
+		},
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:   "claude-oauth",
+		Provider: "claude",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid oauth token"},
+	})
+
+	got, ok := m.GetByID("claude-oauth")
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.Status != StatusError || state.StatusMessage != "invalid oauth token" {
+		t.Fatalf("model status = %q/%q, want generic unauthorized error", state.Status, state.StatusMessage)
+	}
+	if state.NextRetryAfter.Before(time.Now().Add(29 * time.Minute)) {
+		t.Fatalf("NextRetryAfter = %v, want generic 30m unauthorized cooldown", state.NextRetryAfter)
+	}
+	health := mustClaudeOAuthHealth(t, got)
+	if health["status"] != "unauthorized" || health["refresh_available"] != false {
+		t.Fatalf("health = %#v, want unauthorized without refresh", health)
+	}
+}
+
+func TestManagerMarkResult_ClaudeOAuth429UsesAnthropicFiveHourReset(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "claude-sonnet-4-5"
+	if _, err := m.Register(ctx, newClaudeOAuthTestAuth("claude-oauth")); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	resetAt := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status":      []string{"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":       []string{formatInt64(resetAt.Unix())},
+		"Anthropic-Ratelimit-Unified-5h-Utilization": []string{"1.00"},
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:   "claude-oauth",
+		Provider: "claude",
+		Model:    model,
+		Success:  false,
+		Headers:  headers,
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+	})
+
+	got, ok := m.GetByID("claude-oauth")
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.Quota.Window != "5h" || state.Quota.WindowMinutes != 300 {
+		t.Fatalf("quota = %#v, want 5h/300", state.Quota)
+	}
+	if !state.NextRetryAfter.Equal(resetAt) || !state.Quota.NextRecoverAt.Equal(resetAt) {
+		t.Fatalf("recover = %v/%v, want %v", state.NextRetryAfter, state.Quota.NextRecoverAt, resetAt)
+	}
+	health := mustClaudeOAuthHealth(t, got)
+	if health["status"] != claudeOAuthHealthStatusExhausted || health["temporary_unschedulable_reason"] != claudeOAuthReasonAnthropic5H {
+		t.Fatalf("health = %#v, want exhausted 5h", health)
+	}
+}
+
+func TestManagerMarkResult_ClaudeOAuth429FallsBackWhenNoUsableAnthropicReset(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "claude-sonnet-4-5"
+	if _, err := m.Register(ctx, newClaudeOAuthTestAuth("claude-oauth")); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status": []string{"rejected"},
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:   "claude-oauth",
+		Provider: "claude",
+		Model:    model,
+		Success:  false,
+		Headers:  headers,
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+	})
+
+	got, ok := m.GetByID("claude-oauth")
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.Quota.Window != "" || state.Quota.WindowMinutes != 0 {
+		t.Fatalf("quota = %#v, want generic quota without Anthropic window", state.Quota)
+	}
+	health := mustClaudeOAuthHealth(t, got)
+	if health["status"] != claudeOAuthHealthStatusRateLimited {
+		t.Fatalf("health.status = %v, want rate_limited", health["status"])
+	}
+}
+
+func TestManagerMarkResult_ClaudeOAuthSuccessClearsTemporaryHealth(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "claude-sonnet-4-5"
+	if _, err := m.Register(ctx, newClaudeOAuthTestAuth("claude-oauth")); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:   "claude-oauth",
+		Provider: "claude",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid oauth token"},
+	})
+	m.MarkResult(ctx, Result{
+		AuthID:   "claude-oauth",
+		Provider: "claude",
+		Model:    model,
+		Success:  true,
+	})
+
+	got, ok := m.GetByID("claude-oauth")
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	health := mustClaudeOAuthHealth(t, got)
+	if health["status"] != claudeOAuthHealthStatusActive {
+		t.Fatalf("health.status = %v, want active", health["status"])
+	}
+	if _, ok := health["temporary_unschedulable_until"]; ok {
+		t.Fatalf("temporary_unschedulable_until still present in %#v", health)
+	}
+	if state := got.ModelStates[model]; state == nil || state.Unavailable {
+		t.Fatalf("model state = %#v, want available after success", state)
+	}
+}
+
+func newClaudeOAuthTestAuth(id string) *Auth {
+	return &Auth{
+		ID:       id,
+		Provider: "claude",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"type":          "claude",
+			"email":         "claude@example.com",
+			"access_token":  "old-access-token",
+			"refresh_token": "stable-refresh-token",
+		},
+	}
+}
+
+func mustClaudeOAuthHealth(t *testing.T, auth *Auth) map[string]any {
+	t.Helper()
+	health, ok := auth.Metadata[ClaudeOAuthHealthMetadataKey].(map[string]any)
+	if !ok || len(health) == 0 {
+		t.Fatalf("health missing in %#v", auth.Metadata)
+	}
+	return health
+}
+
+func formatInt64(value int64) string {
+	return strconv.FormatInt(value, 10)
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -107,6 +107,9 @@ type Result struct {
 	Success bool
 	// RetryAfter carries a provider supplied retry hint (e.g. 429 retryDelay).
 	RetryAfter *time.Duration
+	// Headers carries upstream response headers used for provider-specific
+	// runtime health decisions such as Anthropic rate-limit windows.
+	Headers http.Header
 	// Error describes the failure when Success is false.
 	Error *Error
 }

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -166,6 +166,7 @@ func (s cooldownService) applySuccessLocked(auth *Auth, result Result, now time.
 	if auth == nil {
 		return
 	}
+	markClaudeOAuthHealthSuccessLocked(auth, result, now)
 	if result.Model != "" {
 		state := ensureModelState(auth, result.Model)
 		if activeModelQuotaCooldown(state, now) {
@@ -195,6 +196,9 @@ func (s cooldownService) applySuccessLocked(auth *Auth, result Result, now time.
 
 func (s cooldownService) applyFailureLocked(auth *Auth, result Result, now time.Time, effects *resultStateEffects) {
 	if auth == nil {
+		return
+	}
+	if applyClaudeOAuthFailureLocked(auth, result, now, effects) {
 		return
 	}
 	if result.Model != "" {

--- a/sdk/cliproxy/auth/conductor_error_helpers.go
+++ b/sdk/cliproxy/auth/conductor_error_helpers.go
@@ -72,6 +72,24 @@ func retryAfterFromError(err error) *time.Duration {
 	return new(*retryAfter)
 }
 
+func headersFromError(err error) http.Header {
+	if err == nil {
+		return nil
+	}
+	type headerProvider interface {
+		Headers() http.Header
+	}
+	var hp headerProvider
+	if errors.As(err, &hp) && hp != nil {
+		headers := hp.Headers()
+		if len(headers) == 0 {
+			return nil
+		}
+		return headers.Clone()
+	}
+	return nil
+}
+
 func statusCodeFromResult(err *Error) int {
 	if err == nil {
 		return 0

--- a/sdk/cliproxy/auth/conductor_error_helpers_test.go
+++ b/sdk/cliproxy/auth/conductor_error_helpers_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -10,6 +11,7 @@ type statusQuotaErrorStub struct {
 	status       int
 	quotaWindow  string
 	quotaMinutes int
+	headers      http.Header
 }
 
 func (e *statusQuotaErrorStub) Error() string {
@@ -22,6 +24,13 @@ func (e *statusQuotaErrorStub) StatusCode() int {
 
 func (e *statusQuotaErrorStub) QuotaWindow() (string, int) {
 	return e.quotaWindow, e.quotaMinutes
+}
+
+func (e *statusQuotaErrorStub) Headers() http.Header {
+	if e.headers == nil {
+		return nil
+	}
+	return e.headers.Clone()
 }
 
 func TestErrorFromExecution_ExtractsStatusAndQuotaWindow(t *testing.T) {
@@ -46,6 +55,44 @@ func TestErrorFromExecution_ExtractsStatusAndQuotaWindow(t *testing.T) {
 	}
 	if got.QuotaWindow != "5h" || got.QuotaWindowMinutes != 300 {
 		t.Fatalf("QuotaWindow = %q/%d, want 5h/300", got.QuotaWindow, got.QuotaWindowMinutes)
+	}
+}
+
+func TestHeadersFromError_ClonesHeaders(t *testing.T) {
+	t.Parallel()
+
+	err := &statusQuotaErrorStub{
+		message: "quota exceeded",
+		status:  http.StatusTooManyRequests,
+		headers: http.Header{
+			"Anthropic-Ratelimit-Unified-5h-Status": []string{"rejected"},
+		},
+	}
+
+	got := headersFromError(err)
+	if got.Get("Anthropic-Ratelimit-Unified-5h-Status") != "rejected" {
+		t.Fatalf("headersFromError() = %#v, want rate-limit header", got)
+	}
+	got.Set("Anthropic-Ratelimit-Unified-5h-Status", "mutated")
+	if err.headers.Get("Anthropic-Ratelimit-Unified-5h-Status") != "rejected" {
+		t.Fatalf("source headers mutated to %q", err.headers.Get("Anthropic-Ratelimit-Unified-5h-Status"))
+	}
+}
+
+func TestHeadersFromError_ExtractsHeadersFromWrappedError(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("upstream wrapper: %w", &statusQuotaErrorStub{
+		message: "quota exceeded",
+		status:  http.StatusTooManyRequests,
+		headers: http.Header{
+			"Anthropic-Ratelimit-Unified-7d-Status": []string{"rejected"},
+		},
+	})
+
+	got := headersFromError(err)
+	if got.Get("Anthropic-Ratelimit-Unified-7d-Status") != "rejected" {
+		t.Fatalf("headersFromError() = %#v, want wrapped rate-limit header", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_execution_service.go
+++ b/sdk/cliproxy/auth/conductor_execution_service.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"net/http"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
@@ -105,6 +106,7 @@ func (s executionService) executeMixedOnce(ctx context.Context, providers []stri
 				return cliproxyexecutor.Response{}, errCtx
 			}
 			result.Error = errorFromExecution(errExec)
+			result.Headers = headersFromError(errExec)
 			if ra := retryAfterFromError(errExec); ra != nil {
 				result.RetryAfter = ra
 			}
@@ -116,6 +118,7 @@ func (s executionService) executeMixedOnce(ctx context.Context, providers []stri
 			continue
 		}
 
+		result.Headers = resp.Headers.Clone()
 		s.manager.MarkResult(candidate.execCtx, result)
 		return resp, nil
 	}
@@ -176,6 +179,7 @@ func (s executionService) executeStreamMixedOnce(ctx context.Context, providers 
 				Success:    false,
 				Error:      rerr,
 				RetryAfter: retryAfterFromError(errStream),
+				Headers:    headersFromError(errStream),
 			}
 			s.manager.MarkResult(candidate.execCtx, result)
 			if isRequestInvalidError(errStream) || scope.singlePickRoute {
@@ -250,7 +254,8 @@ func (s executionService) wrapStreamResult(
 	streamResult *cliproxyexecutor.StreamResult,
 ) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
-	go func(streamCtx context.Context, streamAuth *Auth, streamProvider string, streamChunks <-chan cliproxyexecutor.StreamChunk) {
+	streamHeaders := streamResult.Headers.Clone()
+	go func(streamCtx context.Context, streamAuth *Auth, streamProvider string, streamChunks <-chan cliproxyexecutor.StreamChunk, headers http.Header) {
 		defer close(out)
 		var failed bool
 		forward := true
@@ -258,12 +263,18 @@ func (s executionService) wrapStreamResult(
 			if chunk.Err != nil && !failed {
 				failed = true
 				rerr := errorFromExecution(chunk.Err)
+				chunkHeaders := headersFromError(chunk.Err)
+				if len(chunkHeaders) == 0 {
+					chunkHeaders = headers.Clone()
+				}
 				s.manager.MarkResult(streamCtx, Result{
-					AuthID:   streamAuth.ID,
-					Provider: streamProvider,
-					Model:    routeModel,
-					Success:  false,
-					Error:    rerr,
+					AuthID:     streamAuth.ID,
+					Provider:   streamProvider,
+					Model:      routeModel,
+					Success:    false,
+					Error:      rerr,
+					RetryAfter: retryAfterFromError(chunk.Err),
+					Headers:    chunkHeaders,
 				})
 			}
 			if !forward {
@@ -285,11 +296,12 @@ func (s executionService) wrapStreamResult(
 				Provider: streamProvider,
 				Model:    routeModel,
 				Success:  true,
+				Headers:  headers.Clone(),
 			})
 		}
-	}(execCtx, auth.Clone(), provider, streamResult.Chunks)
+	}(execCtx, auth.Clone(), provider, streamResult.Chunks, streamHeaders)
 	return &cliproxyexecutor.StreamResult{
-		Headers: streamResult.Headers,
+		Headers: streamHeaders.Clone(),
 		Chunks:  out,
 	}
 }

--- a/sdk/cliproxy/auth/conductor_execution_service_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_service_test.go
@@ -81,6 +81,45 @@ func (e *streamChunkFailureExecutor) HttpRequest(context.Context, *Auth, *http.R
 	return nil, &Error{Code: "not_implemented", Message: "HttpRequest not implemented", HTTPStatus: http.StatusNotImplemented}
 }
 
+type claudeOAuthHeadersExecutor struct {
+	executeResponse cliproxyexecutor.Response
+	executeErr      error
+	countResponse   cliproxyexecutor.Response
+	countErr        error
+	streamHeaders   http.Header
+	streamChunkErr  error
+}
+
+func (e *claudeOAuthHeadersExecutor) Identifier() string { return "claude" }
+
+func (e *claudeOAuthHeadersExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return e.executeResponse, e.executeErr
+}
+
+func (e *claudeOAuthHeadersExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	if e.streamChunkErr != nil {
+		chunks <- cliproxyexecutor.StreamChunk{Err: e.streamChunkErr}
+	}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{
+		Headers: e.streamHeaders.Clone(),
+		Chunks:  chunks,
+	}, nil
+}
+
+func (e *claudeOAuthHeadersExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *claudeOAuthHeadersExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return e.countResponse, e.countErr
+}
+
+func (e *claudeOAuthHeadersExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{Code: "not_implemented", Message: "HttpRequest not implemented", HTTPStatus: http.StatusNotImplemented}
+}
+
 type resultRecordingHook struct {
 	NoopHook
 	mu      sync.Mutex
@@ -215,6 +254,281 @@ func TestManagerExecuteStream_RecordsFailureFromChunkError(t *testing.T) {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("expected 1 hook result, got %d", len(hook.snapshot()))
+}
+
+func TestManagerExecute_ClaudeOAuth401WithRefreshTokenRecordsHealthFromUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "claude-sonnet-4-5"
+	headers := http.Header{
+		"X-Claude-Request-Id": []string{"req-401"},
+	}
+	hook := &resultRecordingHook{}
+	manager := NewManager(nil, &FillFirstSelector{}, hook)
+	manager.RegisterExecutor(&claudeOAuthHeadersExecutor{
+		executeErr: &statusQuotaErrorStub{
+			message: "invalid oauth token",
+			status:  http.StatusUnauthorized,
+			headers: headers,
+		},
+	})
+	auth := newClaudeOAuthTestAuth("claude-oauth")
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, err := manager.Execute(ctx, []string{"claude"}, cliproxyexecutor.Request{
+		Model: model,
+	}, cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SinglePickMetadataKey: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want upstream 401")
+	}
+
+	results := hook.snapshot()
+	if len(results) != 1 {
+		t.Fatalf("hook results = %d, want 1", len(results))
+	}
+	result := results[0]
+	if result.Success {
+		t.Fatal("hook result Success = true, want false")
+	}
+	if result.Error == nil || result.Error.HTTPStatus != http.StatusUnauthorized {
+		t.Fatalf("hook result Error = %#v, want 401", result.Error)
+	}
+	if result.Headers.Get("X-Claude-Request-Id") != "req-401" {
+		t.Fatalf("hook result headers = %#v, want request id from upstream error", result.Headers)
+	}
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	if got.Metadata["access_token"] != "old-access-token" || got.Metadata["refresh_token"] != "stable-refresh-token" {
+		t.Fatalf("tokens were mutated: %#v", got.Metadata)
+	}
+	if !manager.shouldRefresh(got, time.Now()) {
+		t.Fatal("shouldRefresh = false, want true for OAuth refresh_pending")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.Status != StatusActive || state.StatusMessage != claudeOAuthRefreshPendingMessage {
+		t.Fatalf("model status = %q/%q, want active/%q", state.Status, state.StatusMessage, claudeOAuthRefreshPendingMessage)
+	}
+	health := mustClaudeOAuthHealth(t, got)
+	if health["status"] != claudeOAuthHealthStatusRefreshPending ||
+		health["temporary_unschedulable_reason"] != claudeOAuthReasonOAuth401 ||
+		health["refresh_available"] != true {
+		t.Fatalf("health = %#v, want refresh_pending oauth_401 with refresh available", health)
+	}
+}
+
+func TestManagerExecute_ClaudeOAuth429WithAnthropicHeadersPrefersSevenDayWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "claude-sonnet-4-5"
+	fiveHourReset := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
+	sevenDayReset := time.Now().UTC().Add(72 * time.Hour).Truncate(time.Second)
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status":              []string{"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":               []string{formatInt64(fiveHourReset.Unix())},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":         []string{"1.00"},
+		"Anthropic-Ratelimit-Unified-7d-Status":              []string{"allowed_warning"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":               []string{formatInt64(sevenDayReset.Unix() * 1000)},
+		"Anthropic-Ratelimit-Unified-7d-Surpassed-Threshold": []string{"true"},
+	}
+	hook := &resultRecordingHook{}
+	manager := NewManager(nil, &FillFirstSelector{}, hook)
+	manager.RegisterExecutor(&claudeOAuthHeadersExecutor{
+		executeErr: &statusQuotaErrorStub{
+			message: "rate limited",
+			status:  http.StatusTooManyRequests,
+			headers: headers,
+		},
+	})
+	auth := newClaudeOAuthTestAuth("claude-oauth")
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, err := manager.Execute(ctx, []string{"claude"}, cliproxyexecutor.Request{
+		Model: model,
+	}, cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SinglePickMetadataKey: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want upstream 429")
+	}
+
+	results := hook.snapshot()
+	if len(results) != 1 {
+		t.Fatalf("hook results = %d, want 1", len(results))
+	}
+	if gotHeader := results[0].Headers.Get("Anthropic-Ratelimit-Unified-7d-Status"); gotHeader != "allowed_warning" {
+		t.Fatalf("hook 7d header = %q, want allowed_warning", gotHeader)
+	}
+	got, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.Quota.Window != "7d" || state.Quota.WindowMinutes != 10080 {
+		t.Fatalf("quota = %#v, want 7d/10080", state.Quota)
+	}
+	if !state.NextRetryAfter.Equal(sevenDayReset) || !state.Quota.NextRecoverAt.Equal(sevenDayReset) {
+		t.Fatalf("recover = %v/%v, want %v", state.NextRetryAfter, state.Quota.NextRecoverAt, sevenDayReset)
+	}
+	health := mustClaudeOAuthHealth(t, got)
+	if health["status"] != claudeOAuthHealthStatusExhausted ||
+		health["temporary_unschedulable_reason"] != claudeOAuthReasonAnthropic7D {
+		t.Fatalf("health = %#v, want exhausted 7d", health)
+	}
+	windows, ok := health["windows"].(map[string]any)
+	if !ok {
+		t.Fatalf("health windows missing in %#v", health)
+	}
+	sevenDay, ok := windows["seven_day"].(map[string]any)
+	if !ok || sevenDay["exceeded"] != true || sevenDay["surpassed_threshold"] != true {
+		t.Fatalf("seven_day window = %#v, want exceeded surpassed threshold", sevenDay)
+	}
+}
+
+func TestManagerExecuteCount_ClaudeOAuthFailureDoesNotMutateOAuthHealth(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "claude-sonnet-4-5"
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&claudeOAuthHeadersExecutor{
+		executeResponse: cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)},
+		countErr: &statusQuotaErrorStub{
+			message: "invalid oauth token from count_tokens",
+			status:  http.StatusUnauthorized,
+			headers: http.Header{
+				"X-Claude-Request-Id": []string{"req-count-401"},
+			},
+		},
+	})
+	auth := newClaudeOAuthTestAuth("claude-oauth")
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, err := manager.ExecuteCount(ctx, []string{"claude"}, cliproxyexecutor.Request{
+		Model: model,
+	}, cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SinglePickMetadataKey: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("ExecuteCount() error = nil, want upstream 401")
+	}
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	if _, ok := got.Metadata[ClaudeOAuthHealthMetadataKey]; ok {
+		t.Fatalf("claude_oauth_health = %#v, want count_tokens failure not to mutate runtime health", got.Metadata[ClaudeOAuthHealthMetadataKey])
+	}
+	if manager.shouldRefresh(got, time.Now()) {
+		t.Fatal("shouldRefresh = true, want count_tokens failure not to schedule refresh")
+	}
+	resp, err := manager.Execute(ctx, []string{"claude"}, cliproxyexecutor.Request{
+		Model: model,
+	}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() after count_tokens failure error = %v", err)
+	}
+	if string(resp.Payload) != `{"ok":true}` {
+		t.Fatalf("Execute() payload = %q, want ok response", string(resp.Payload))
+	}
+}
+
+func TestManagerExecuteStream_ClaudeOAuthChunkErrorFallsBackToInitialAnthropicHeaders(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "claude-sonnet-4-5"
+	resetAt := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status":      []string{"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":       []string{formatInt64(resetAt.Unix())},
+		"Anthropic-Ratelimit-Unified-5h-Utilization": []string{"1.01"},
+	}
+	hook := &resultRecordingHook{}
+	manager := NewManager(nil, &FillFirstSelector{}, hook)
+	manager.RegisterExecutor(&claudeOAuthHeadersExecutor{
+		streamHeaders:  headers,
+		streamChunkErr: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "stream rate limited"},
+	})
+	auth := newClaudeOAuthTestAuth("claude-oauth")
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	stream, err := manager.ExecuteStream(ctx, []string{"claude"}, cliproxyexecutor.Request{
+		Model: model,
+	}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	if stream == nil {
+		t.Fatal("ExecuteStream() stream = nil")
+	}
+	var chunkErr error
+	for chunk := range stream.Chunks {
+		chunkErr = chunk.Err
+	}
+	if chunkErr == nil {
+		t.Fatal("expected stream chunk error")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		results := hook.snapshot()
+		if len(results) != 1 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		result := results[0]
+		if result.Success {
+			t.Fatal("hook result Success = true, want false")
+		}
+		if result.Headers.Get("Anthropic-Ratelimit-Unified-5h-Status") != "rejected" {
+			t.Fatalf("hook headers = %#v, want initial stream rate-limit headers", result.Headers)
+		}
+		got, ok := manager.GetByID(auth.ID)
+		if !ok {
+			t.Fatal("updated auth missing")
+		}
+		state := got.ModelStates[model]
+		if state == nil {
+			t.Fatal("model state missing")
+		}
+		if state.Quota.Window != "5h" || state.Quota.WindowMinutes != 300 {
+			t.Fatalf("quota = %#v, want 5h/300 from initial stream headers", state.Quota)
+		}
+		if !state.NextRetryAfter.Equal(resetAt) {
+			t.Fatalf("NextRetryAfter = %v, want %v", state.NextRetryAfter, resetAt)
+		}
+		return
 	}
 
 	t.Fatalf("expected 1 hook result, got %d", len(hook.snapshot()))

--- a/sdk/cliproxy/auth/conductor_refresh_service.go
+++ b/sdk/cliproxy/auth/conductor_refresh_service.go
@@ -164,6 +164,9 @@ func (s refreshService) shouldRefresh(auth *Auth, now time.Time) bool {
 	if evaluator, ok := auth.Runtime.(RefreshEvaluator); ok && evaluator != nil {
 		return evaluator.ShouldRefresh(now, auth)
 	}
+	if claudeOAuthRefreshPending(auth) {
+		return true
+	}
 
 	lastRefresh := auth.LastRefreshedAt
 	if lastRefresh.IsZero() {
@@ -303,6 +306,7 @@ func (s refreshService) applyRefreshSuccess(ctx context.Context, auth *Auth, clo
 	updated.NextRefreshAfter = time.Time{}
 	updated.LastError = nil
 	updated.UpdatedAt = now
+	markClaudeOAuthHealthRefreshSuccessLocked(updated, now)
 	_, _ = s.manager.Update(ctx, updated)
 }
 


### PR DESCRIPTION
## Summary
- Track Claude OAuth health metadata for auth files and runtime scheduling.
- Treat OAuth 401 with refresh tokens as refresh-pending and temporarily unschedulable without overwriting credentials.
- Parse Anthropic 5h/7d rate-limit windows and surface sanitized health metadata through management auth-files APIs.

## Verification
- rtk git diff --check
- rtk go test ./...

## Notes
- Real Claude OAuth upstream calls were not run because no Claude Code account is available; coverage is based on simulated upstream behavior and local tests.