### PR TITLE
feat: add account identity fingerprint detail API

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -26,11 +26,13 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 		h.listAuthFilesFromDisk(c)
 		return
 	}
-	files := managementauthfiles.ListEntries(h.authManager.List(), managementauthfiles.EntryOptions{
+	auths := h.authManager.List()
+	files := managementauthfiles.ListEntries(auths, managementauthfiles.EntryOptions{
 		OnStatError: func(path string, err error) {
 			log.WithError(err).Warnf("failed to stat auth file %s", path)
 		},
 	})
+	h.enrichAuthFileIdentityFingerprintSummaries(files, auths)
 	c.JSON(200, gin.H{"files": files})
 }
 

--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -27,16 +27,7 @@ type identityFingerprintProviderStatus struct {
 }
 
 func (h *Handler) GetIdentityFingerprint(c *gin.Context) {
-	h.mu.Lock()
-	current := config.IdentityFingerprintConfig{}
-	if h.cfg != nil {
-		current = h.cfg.IdentityFingerprint
-	}
-	h.mu.Unlock()
-
-	current.Codex = config.CleanCodexIdentityFingerprint(current.Codex)
-	current.Claude = config.CleanClaudeIdentityFingerprint(current.Claude)
-	current.Gemini = config.CleanGeminiIdentityFingerprint(current.Gemini)
+	current := h.currentIdentityFingerprintConfig()
 	learned, effective := h.identityFingerprintState(current)
 	c.JSON(http.StatusOK, identityFingerprintResponse{
 		IdentityFingerprint: current,

--- a/internal/api/handlers/management/identity_fingerprint_account.go
+++ b/internal/api/handlers/management/identity_fingerprint_account.go
@@ -1,0 +1,269 @@
+package management
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type identityFingerprintAccountSummary struct {
+	Provider        string         `json:"provider"`
+	AccountKey      string         `json:"account_key,omitempty"`
+	AuthSubjectID   string         `json:"auth_subject_id,omitempty"`
+	Enabled         bool           `json:"enabled"`
+	PrimarySource   string         `json:"primary_source"`
+	Learned         bool           `json:"learned"`
+	LearnedFields   int            `json:"learned_fields"`
+	EffectiveFields int            `json:"effective_fields"`
+	SourceCounts    map[string]int `json:"source_counts"`
+	ClientProduct   string         `json:"client_product,omitempty"`
+	ClientVariant   string         `json:"client_variant,omitempty"`
+	Version         string         `json:"version,omitempty"`
+	UpdatedAt       *time.Time     `json:"updated_at,omitempty"`
+	LastSeenAt      *time.Time     `json:"last_seen_at,omitempty"`
+}
+
+type identityFingerprintAccountDetail struct {
+	Summary        identityFingerprintAccountSummary        `json:"summary"`
+	Effective      identityfingerprint.EffectiveFingerprint `json:"effective"`
+	Learned        *identityfingerprint.LearnedRecord       `json:"learned,omitempty"`
+	Preset         any                                      `json:"preset"`
+	BuiltinDefault any                                      `json:"builtin_default"`
+}
+
+func (h *Handler) GetIdentityFingerprintAccount(c *gin.Context) {
+	provider, ok := normalizeIdentityFingerprintProvider(c.Query("provider"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "provider must be one of claude, codex, gemini"})
+		return
+	}
+	accountKey := strings.TrimSpace(c.Query("account_key"))
+	if accountKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "account_key is required"})
+		return
+	}
+	detail, err := h.identityFingerprintAccountDetail(provider, accountKey, strings.TrimSpace(c.Query("auth_subject_id")))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, detail)
+}
+
+func (h *Handler) enrichAuthFileIdentityFingerprintSummaries(files []map[string]any, auths []*coreauth.Auth) {
+	if len(files) == 0 || len(auths) == 0 {
+		return
+	}
+	current := h.currentIdentityFingerprintConfig()
+	summaries := make(map[string]identityFingerprintAccountSummary, len(auths))
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		summary := h.identityFingerprintSummaryForAuth(current, auth)
+		if summary == nil {
+			continue
+		}
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			summaries[id] = *summary
+		}
+	}
+	if len(summaries) == 0 {
+		return
+	}
+	for _, file := range files {
+		id, _ := file["id"].(string)
+		if summary, ok := summaries[strings.TrimSpace(id)]; ok {
+			file["identity_fingerprint_summary"] = summary
+		}
+	}
+}
+
+func (h *Handler) identityFingerprintSummaryForAuth(current config.IdentityFingerprintConfig, auth *coreauth.Auth) *identityFingerprintAccountSummary {
+	provider, ok := normalizeIdentityFingerprintProvider("")
+	if auth != nil {
+		provider, ok = normalizeIdentityFingerprintProvider(auth.Provider)
+	}
+	if !ok {
+		return nil
+	}
+	accountKey, authSubjectID := identityFingerprintAccountForAuth(auth)
+	if accountKey == "" {
+		return nil
+	}
+	learned, err := usage.GetIdentityFingerprint(provider, accountKey)
+	if err != nil {
+		return nil
+	}
+	effective, _, _ := resolveIdentityFingerprint(current, provider, learned)
+	effective.AccountKey = accountKey
+	if effective.AuthSubjectID == "" {
+		effective.AuthSubjectID = authSubjectID
+	}
+	return buildIdentityFingerprintSummary(provider, accountKey, authSubjectID, learned, effective)
+}
+
+func (h *Handler) identityFingerprintAccountDetail(provider identityfingerprint.Provider, accountKey, authSubjectID string) (identityFingerprintAccountDetail, error) {
+	current := h.currentIdentityFingerprintConfig()
+	learned, err := usage.GetIdentityFingerprint(provider, accountKey)
+	if err != nil {
+		return identityFingerprintAccountDetail{}, err
+	}
+	effective, preset, builtinDefault := resolveIdentityFingerprint(current, provider, learned)
+	effective.AccountKey = accountKey
+	if effective.AuthSubjectID == "" {
+		effective.AuthSubjectID = authSubjectID
+	}
+	return identityFingerprintAccountDetail{
+		Summary:        *buildIdentityFingerprintSummary(provider, accountKey, effective.AuthSubjectID, learned, effective),
+		Effective:      effective,
+		Learned:        learned,
+		Preset:         preset,
+		BuiltinDefault: builtinDefault,
+	}, nil
+}
+
+func (h *Handler) currentIdentityFingerprintConfig() config.IdentityFingerprintConfig {
+	current := config.IdentityFingerprintConfig{}
+	if h != nil {
+		h.mu.Lock()
+		if h.cfg != nil {
+			current = h.cfg.IdentityFingerprint
+		}
+		h.mu.Unlock()
+	}
+	current.Codex = config.CleanCodexIdentityFingerprint(current.Codex)
+	current.Claude = config.CleanClaudeIdentityFingerprint(current.Claude)
+	current.Gemini = config.CleanGeminiIdentityFingerprint(current.Gemini)
+	return current
+}
+
+func resolveIdentityFingerprint(current config.IdentityFingerprintConfig, provider identityfingerprint.Provider, learned *identityfingerprint.LearnedRecord) (identityfingerprint.EffectiveFingerprint, any, any) {
+	switch provider {
+	case identityfingerprint.ProviderClaude:
+		_, effective := identityfingerprint.ResolveClaude(current.Claude, learned)
+		return effective, current.Claude, config.DefaultClaudeIdentityFingerprint()
+	case identityfingerprint.ProviderCodex:
+		_, effective := identityfingerprint.ResolveCodex(current.Codex, learned)
+		return effective, current.Codex, config.DefaultCodexIdentityFingerprint()
+	case identityfingerprint.ProviderGemini:
+		_, effective := identityfingerprint.ResolveGemini(current.Gemini, learned)
+		return effective, current.Gemini, config.DefaultGeminiIdentityFingerprint()
+	default:
+		return identityfingerprint.EffectiveFingerprint{}, nil, nil
+	}
+}
+
+func buildIdentityFingerprintSummary(provider identityfingerprint.Provider, accountKey, authSubjectID string, learned *identityfingerprint.LearnedRecord, effective identityfingerprint.EffectiveFingerprint) *identityFingerprintAccountSummary {
+	counts := identityFingerprintSourceCounts(effective.Fields)
+	learnedFields := 0
+	if learned != nil {
+		for _, value := range learned.Fields {
+			if strings.TrimSpace(value) != "" {
+				learnedFields++
+			}
+		}
+	}
+	summary := &identityFingerprintAccountSummary{
+		Provider:        string(provider),
+		AccountKey:      strings.TrimSpace(accountKey),
+		AuthSubjectID:   strings.TrimSpace(authSubjectID),
+		Enabled:         effective.Enabled,
+		PrimarySource:   primaryIdentityFingerprintSource(counts),
+		Learned:         learned != nil && learnedFields > 0,
+		LearnedFields:   learnedFields,
+		EffectiveFields: sumIdentityFingerprintCounts(counts),
+		SourceCounts:    counts,
+		ClientProduct:   effective.ClientProduct,
+		Version:         effective.Version,
+	}
+	if learned != nil {
+		summary.ClientVariant = learned.ClientVariant
+		if !learned.UpdatedAt.IsZero() {
+			updatedAt := learned.UpdatedAt
+			summary.UpdatedAt = &updatedAt
+		}
+		if !learned.LastSeenAt.IsZero() {
+			lastSeenAt := learned.LastSeenAt
+			summary.LastSeenAt = &lastSeenAt
+		}
+	}
+	return summary
+}
+
+func identityFingerprintSourceCounts(fields map[string]identityfingerprint.FieldValue) map[string]int {
+	counts := map[string]int{
+		string(identityfingerprint.FieldSourceLearned):        0,
+		string(identityfingerprint.FieldSourcePreset):         0,
+		string(identityfingerprint.FieldSourceBuiltinDefault): 0,
+	}
+	for _, field := range fields {
+		if strings.TrimSpace(field.Value) == "" {
+			continue
+		}
+		source := strings.TrimSpace(string(field.Source))
+		if source == "" {
+			source = string(identityfingerprint.FieldSourceBuiltinDefault)
+		}
+		counts[source]++
+	}
+	return counts
+}
+
+func primaryIdentityFingerprintSource(counts map[string]int) string {
+	for _, source := range []identityfingerprint.FieldSource{
+		identityfingerprint.FieldSourceLearned,
+		identityfingerprint.FieldSourcePreset,
+		identityfingerprint.FieldSourceBuiltinDefault,
+	} {
+		if counts[string(source)] > 0 {
+			return string(source)
+		}
+	}
+	return string(identityfingerprint.FieldSourceBuiltinDefault)
+}
+
+func sumIdentityFingerprintCounts(counts map[string]int) int {
+	total := 0
+	for _, count := range counts {
+		total += count
+	}
+	return total
+}
+
+func identityFingerprintAccountForAuth(auth *coreauth.Auth) (string, string) {
+	identity := usage.ResolveAuthSubjectIdentity(auth)
+	if identity != nil {
+		id := strings.TrimSpace(identity.ID)
+		return id, id
+	}
+	if auth == nil {
+		return "", ""
+	}
+	if id := strings.TrimSpace(auth.ID); id != "" {
+		return id, ""
+	}
+	if idx := strings.TrimSpace(auth.EnsureIndex()); idx != "" {
+		return idx, ""
+	}
+	return "", ""
+}
+
+func normalizeIdentityFingerprintProvider(value string) (identityfingerprint.Provider, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(identityfingerprint.ProviderClaude):
+		return identityfingerprint.ProviderClaude, true
+	case string(identityfingerprint.ProviderCodex), "openai":
+		return identityfingerprint.ProviderCodex, true
+	case string(identityfingerprint.ProviderGemini), "google":
+		return identityfingerprint.ProviderGemini, true
+	default:
+		return "", false
+	}
+}

--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -1,16 +1,20 @@
 package management
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 func TestGetCodexFingerprintRecommendationsReturnsLogDerivedCandidates(t *testing.T) {
@@ -105,4 +109,206 @@ func TestGetCodexFingerprintRecommendationsReturnsLogDerivedCandidates(t *testin
 	if item.IgnoredHeaders["Session_id"] == "session-handler-secret" {
 		t.Fatalf("session id must be masked in ignored headers")
 	}
+}
+
+func TestListAuthFilesIncludesIdentityFingerprintSummary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	authPath := filepath.Join(t.TempDir(), "claude-oauth.json")
+	if err := writeTestAuthFile(authPath); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	auth := &coreauth.Auth{
+		ID:       "claude-oauth-1",
+		FileName: "claude-oauth.json",
+		Provider: "claude",
+		Attributes: map[string]string{
+			"path": authPath,
+		},
+		Metadata: map[string]any{
+			"email": "claude@example.com",
+		},
+	}
+	identity := usage.ResolveAuthSubjectIdentity(auth)
+	if identity == nil || identity.ID == "" {
+		t.Fatal("expected auth subject identity")
+	}
+	if err := usage.UpsertIdentityFingerprint(&identityfingerprint.LearnedRecord{
+		Provider:        identityfingerprint.ProviderClaude,
+		AccountKey:      identity.ID,
+		AuthSubjectID:   identity.ID,
+		ClientProduct:   "claude-cli",
+		Version:         "2.1.170",
+		Fields:          map[string]string{identityfingerprint.FieldUserAgent: "claude-cli/2.1.170 (external, cli)"},
+		ObservedHeaders: map[string]string{"User-Agent": "claude-cli/2.1.170 (external, cli)"},
+		CreatedAt:       time.Date(2026, 6, 23, 1, 0, 0, 0, time.UTC),
+		UpdatedAt:       time.Date(2026, 6, 23, 1, 1, 0, 0, time.UTC),
+		LastSeenAt:      time.Date(2026, 6, 23, 1, 2, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("UpsertIdentityFingerprint: %v", err)
+	}
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	h := &Handler{
+		cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
+			Claude: config.ClaudeIdentityFingerprintConfig{Enabled: true},
+		}},
+		authManager: manager,
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/auth-files", nil)
+
+	h.ListAuthFiles(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload struct {
+		Files []struct {
+			ID                         string `json:"id"`
+			IdentityFingerprintSummary struct {
+				Provider      string         `json:"provider"`
+				AccountKey    string         `json:"account_key"`
+				PrimarySource string         `json:"primary_source"`
+				Learned       bool           `json:"learned"`
+				LearnedFields int            `json:"learned_fields"`
+				SourceCounts  map[string]int `json:"source_counts"`
+				Version       string         `json:"version"`
+			} `json:"identity_fingerprint_summary"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Files) != 1 {
+		t.Fatalf("files length = %d, want 1", len(payload.Files))
+	}
+	summary := payload.Files[0].IdentityFingerprintSummary
+	if summary.Provider != "claude" || summary.AccountKey != identity.ID {
+		t.Fatalf("summary identity = %+v, want provider/account %s", summary, identity.ID)
+	}
+	if !summary.Learned || summary.PrimarySource != "learned" || summary.Version != "2.1.170" {
+		t.Fatalf("summary learned/source/version = %+v", summary)
+	}
+	if summary.SourceCounts["learned"] != 1 || summary.SourceCounts["builtin_default"] == 0 {
+		t.Fatalf("source counts = %#v, want learned and builtin_default fallback fields", summary.SourceCounts)
+	}
+}
+
+func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	accountKey := "authsub_codex_test"
+	if err := usage.UpsertIdentityFingerprint(&identityfingerprint.LearnedRecord{
+		Provider:      identityfingerprint.ProviderCodex,
+		AccountKey:    accountKey,
+		AuthSubjectID: accountKey,
+		ClientProduct: "codex-tui",
+		Version:       "0.125.0",
+		Fields: map[string]string{
+			identityfingerprint.FieldUserAgent:       "codex-tui/0.125.0 (Mac OS 26.5; arm64)",
+			identityfingerprint.FieldCodexVersion:    "0.125.0",
+			identityfingerprint.FieldCodexOriginator: "codex-tui",
+		},
+		ObservedHeaders: map[string]string{
+			"User-Agent": "codex-tui/0.125.0 (Mac OS 26.5; arm64)",
+			"Version":    "0.125.0",
+			"Originator": "codex-tui",
+		},
+		CreatedAt:  time.Date(2026, 6, 23, 2, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 23, 2, 1, 0, 0, time.UTC),
+		LastSeenAt: time.Date(2026, 6, 23, 2, 2, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("UpsertIdentityFingerprint: %v", err)
+	}
+
+	h := &Handler{cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
+		Codex: config.CodexIdentityFingerprintConfig{
+			Enabled:       true,
+			UserAgent:     "codex-tui/0.118.0 (Mac OS 26.3.1; arm64)",
+			WebsocketBeta: "responses_websockets=2026-02-06",
+		},
+	}}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/identity-fingerprint/account?provider=codex&account_key="+accountKey, nil)
+
+	h.GetIdentityFingerprintAccount(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload struct {
+		Summary struct {
+			PrimarySource string         `json:"primary_source"`
+			SourceCounts  map[string]int `json:"source_counts"`
+			LearnedFields int            `json:"learned_fields"`
+		} `json:"summary"`
+		Effective struct {
+			Fields map[string]struct {
+				Value  string `json:"value"`
+				Source string `json:"source"`
+			} `json:"fields"`
+		} `json:"effective"`
+		Learned struct {
+			ObservedHeaders map[string]string `json:"observed_headers"`
+		} `json:"learned"`
+		Preset struct {
+			UserAgent string `json:"user-agent"`
+		} `json:"preset"`
+		BuiltinDefault struct {
+			Originator string `json:"originator"`
+		} `json:"builtin_default"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got := payload.Effective.Fields[identityfingerprint.FieldUserAgent]; got.Value != "codex-tui/0.125.0 (Mac OS 26.5; arm64)" || got.Source != "learned" {
+		t.Fatalf("user-agent field = %+v, want learned Codex client", got)
+	}
+	if got := payload.Effective.Fields[identityfingerprint.FieldCodexWebsocketBeta]; got.Value != "responses_websockets=2026-02-06" || got.Source != "preset" {
+		t.Fatalf("websocket beta field = %+v, want preset fallback", got)
+	}
+	if payload.Summary.PrimarySource != "learned" || payload.Summary.LearnedFields != 3 {
+		t.Fatalf("summary = %+v, want learned primary with three learned fields", payload.Summary)
+	}
+	if payload.Preset.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64)" {
+		t.Fatalf("preset user-agent = %q", payload.Preset.UserAgent)
+	}
+	if payload.BuiltinDefault.Originator != "codex-tui" {
+		t.Fatalf("builtin default originator = %q", payload.BuiltinDefault.Originator)
+	}
+	if payload.Learned.ObservedHeaders["Version"] != "0.125.0" {
+		t.Fatalf("observed headers = %#v", payload.Learned.ObservedHeaders)
+	}
+}
+
+func writeTestAuthFile(path string) error {
+	return os.WriteFile(path, []byte(`{"type":"claude"}`), 0o600)
 }

--- a/internal/api/routes/management_model_routes.go
+++ b/internal/api/routes/management_model_routes.go
@@ -27,6 +27,7 @@ func registerManagementModelRoutes(group *gin.RouterGroup, h *managementhandlers
 	group.GET("/routing-config", h.GetRoutingConfig)
 	group.PUT("/routing-config", h.PutRoutingConfig)
 	group.GET("/identity-fingerprint", h.GetIdentityFingerprint)
+	group.GET("/identity-fingerprint/account", h.GetIdentityFingerprintAccount)
 	group.GET("/identity-fingerprint/codex/recommendations", h.GetCodexFingerprintRecommendations)
 	group.PUT("/identity-fingerprint", h.PutIdentityFingerprint)
 	group.DELETE("/identity-fingerprint/learned", h.DeleteIdentityFingerprintLearned)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -24,7 +24,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 216; got != want {
+	if got, want := len(routes), 217; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 
@@ -43,6 +43,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"GET /v0/management/auth-files/models",
 		"GET /v0/management/image-generation/size-presets",
 		"PUT /v0/management/image-generation/size-presets",
+		"GET /v0/management/identity-fingerprint/account",
 		"GET /v0/management/identity-fingerprint/codex/recommendations",
 		"DELETE /v0/management/identity-fingerprint/learned",
 		"GET /v0/management/codex-oauth-admission",

--- a/internal/identityfingerprint/extract_resolve_test.go
+++ b/internal/identityfingerprint/extract_resolve_test.go
@@ -103,7 +103,7 @@ func TestMergeObservationIgnoresDifferentProduct(t *testing.T) {
 	}
 }
 
-func TestResolveClaudeUsesFieldLevelCustomLearnedDefaultPriority(t *testing.T) {
+func TestResolveClaudeUsesFieldLevelLearnedPresetBuiltinPriority(t *testing.T) {
 	learned := &LearnedRecord{
 		Provider:      ProviderClaude,
 		AccountKey:    "acct",
@@ -119,27 +119,45 @@ func TestResolveClaudeUsesFieldLevelCustomLearnedDefaultPriority(t *testing.T) {
 
 	fp, effective := ResolveClaude(config.ClaudeIdentityFingerprintConfig{
 		Enabled:                 true,
-		StainlessRuntimeVersion: "custom-runtime",
+		StainlessRuntimeVersion: "preset-runtime",
 	}, learned)
 
 	if fp.UserAgent != "claude-cli/2.1.170 (external, cli)" {
 		t.Fatalf("UserAgent = %q, want learned", fp.UserAgent)
 	}
-	if fp.StainlessRuntimeVersion != "custom-runtime" {
-		t.Fatalf("RuntimeVersion = %q, want custom", fp.StainlessRuntimeVersion)
+	if fp.StainlessRuntimeVersion != "v24.4.0" {
+		t.Fatalf("RuntimeVersion = %q, want learned", fp.StainlessRuntimeVersion)
 	}
 	if got := effective.Fields[FieldUserAgent].Source; got != FieldSourceLearned {
 		t.Fatalf("UserAgent source = %q, want learned", got)
 	}
-	if got := effective.Fields[FieldClaudeStainlessRuntime].Source; got != FieldSourceCustom {
-		t.Fatalf("runtime source = %q, want custom", got)
+	if got := effective.Fields[FieldClaudeStainlessRuntime].Source; got != FieldSourceLearned {
+		t.Fatalf("runtime source = %q, want learned", got)
 	}
-	if got := effective.Fields[FieldClaudeStainlessPackage].Source; got != FieldSourceDefault {
-		t.Fatalf("package source = %q, want default", got)
+	if got := effective.Fields[FieldClaudeStainlessPackage].Source; got != FieldSourceBuiltinDefault {
+		t.Fatalf("package source = %q, want builtin_default", got)
 	}
 }
 
-func TestResolveGeminiUsesLearnedWhenCustomEmpty(t *testing.T) {
+func TestResolveCodexUsesPresetBeforeBuiltinDefault(t *testing.T) {
+	fp, effective := ResolveCodex(config.CodexIdentityFingerprintConfig{
+		Enabled:    true,
+		UserAgent:  "codex-tui/0.125.0 (Mac OS 26.5; arm64)",
+		Originator: "codex-tui",
+	}, nil)
+
+	if fp.UserAgent != "codex-tui/0.125.0 (Mac OS 26.5; arm64)" {
+		t.Fatalf("UserAgent = %q, want preset", fp.UserAgent)
+	}
+	if got := effective.Fields[FieldUserAgent].Source; got != FieldSourcePreset {
+		t.Fatalf("UserAgent source = %q, want preset", got)
+	}
+	if got := effective.Fields[FieldCodexWebsocketBeta].Source; got != FieldSourceBuiltinDefault {
+		t.Fatalf("websocket beta source = %q, want builtin_default", got)
+	}
+}
+
+func TestResolveGeminiUsesLearnedWhenPresetEmpty(t *testing.T) {
 	learned := &LearnedRecord{
 		Provider:   ProviderGemini,
 		AccountKey: "acct",

--- a/internal/identityfingerprint/resolve.go
+++ b/internal/identityfingerprint/resolve.go
@@ -10,8 +10,8 @@ func ResolveClaude(cfg config.ClaudeIdentityFingerprintConfig, learned *LearnedR
 	clean := config.CleanClaudeIdentityFingerprint(cfg)
 	defaults := config.DefaultClaudeIdentityFingerprint()
 	fields := make(map[string]FieldValue)
-	pick := func(field, custom, learnedValue, defaultValue string) string {
-		value, source := pickField(custom, learnedValue, defaultValue)
+	pick := func(field, preset, learnedValue, defaultValue string) string {
+		value, source := pickField(preset, learnedValue, defaultValue)
 		fields[field] = FieldValue{Value: value, Source: source}
 		return value
 	}
@@ -50,8 +50,8 @@ func ResolveCodex(cfg config.CodexIdentityFingerprintConfig, learned *LearnedRec
 	clean := config.CleanCodexIdentityFingerprint(cfg)
 	defaults := config.DefaultCodexIdentityFingerprint()
 	fields := make(map[string]FieldValue)
-	pick := func(field, custom, learnedValue, defaultValue string) string {
-		value, source := pickField(custom, learnedValue, defaultValue)
+	pick := func(field, preset, learnedValue, defaultValue string) string {
+		value, source := pickField(preset, learnedValue, defaultValue)
 		fields[field] = FieldValue{Value: value, Source: source}
 		return value
 	}
@@ -84,8 +84,8 @@ func ResolveGemini(cfg config.GeminiIdentityFingerprintConfig, learned *LearnedR
 	clean := config.CleanGeminiIdentityFingerprint(cfg)
 	defaults := config.DefaultGeminiIdentityFingerprint()
 	fields := make(map[string]FieldValue)
-	pick := func(field, custom, learnedValue, defaultValue string) string {
-		value, source := pickField(custom, learnedValue, defaultValue)
+	pick := func(field, preset, learnedValue, defaultValue string) string {
+		value, source := pickField(preset, learnedValue, defaultValue)
 		fields[field] = FieldValue{Value: value, Source: source}
 		return value
 	}
@@ -100,14 +100,14 @@ func ResolveGemini(cfg config.GeminiIdentityFingerprintConfig, learned *LearnedR
 	return resolved, effective(ProviderGemini, clean.Enabled, learned, fields)
 }
 
-func pickField(custom, learned, fallback string) (string, FieldSource) {
-	if value := strings.TrimSpace(custom); value != "" {
-		return value, FieldSourceCustom
-	}
+func pickField(preset, learned, fallback string) (string, FieldSource) {
 	if value := strings.TrimSpace(learned); value != "" {
 		return value, FieldSourceLearned
 	}
-	return strings.TrimSpace(fallback), FieldSourceDefault
+	if value := strings.TrimSpace(preset); value != "" {
+		return value, FieldSourcePreset
+	}
+	return strings.TrimSpace(fallback), FieldSourceBuiltinDefault
 }
 
 func learnedField(record *LearnedRecord, field string) string {

--- a/internal/identityfingerprint/types.go
+++ b/internal/identityfingerprint/types.go
@@ -13,9 +13,13 @@ const (
 type FieldSource string
 
 const (
-	FieldSourceCustom  FieldSource = "custom"
-	FieldSourceLearned FieldSource = "learned"
-	FieldSourceDefault FieldSource = "default"
+	FieldSourceLearned        FieldSource = "learned"
+	FieldSourcePreset         FieldSource = "preset"
+	FieldSourceBuiltinDefault FieldSource = "builtin_default"
+
+	// Deprecated aliases kept for older callers; new responses emit preset or builtin_default.
+	FieldSourceCustom  = FieldSourcePreset
+	FieldSourceDefault = FieldSourceBuiltinDefault
 )
 
 type FieldValue struct {


### PR DESCRIPTION
## Summary
- add account-level identity fingerprint detail API for auth files
- expose learned/effective fingerprint fields for management UI
- cover identity fingerprint detail resolution in management tests

## Tests
- rtk go test ./...