### PR TITLE
fix: normalize OAuth identity fingerprint versions

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint_account.go
+++ b/internal/api/handlers/management/identity_fingerprint_account.go
@@ -181,7 +181,7 @@ func buildIdentityFingerprintSummary(provider identityfingerprint.Provider, acco
 		EffectiveFields: sumIdentityFingerprintCounts(counts),
 		SourceCounts:    counts,
 		ClientProduct:   effective.ClientProduct,
-		Version:         effective.Version,
+		Version:         identityFingerprintSummaryVersion(provider, effective),
 	}
 	if learned != nil {
 		summary.ClientVariant = learned.ClientVariant
@@ -195,6 +195,27 @@ func buildIdentityFingerprintSummary(provider identityfingerprint.Provider, acco
 		}
 	}
 	return summary
+}
+
+func identityFingerprintSummaryVersion(provider identityfingerprint.Provider, effective identityfingerprint.EffectiveFingerprint) string {
+	switch provider {
+	case identityfingerprint.ProviderClaude:
+		if value := identityFingerprintEffectiveField(effective, identityfingerprint.FieldClaudeCLIVersion); value != "" {
+			return value
+		}
+	case identityfingerprint.ProviderCodex:
+		if value := identityFingerprintEffectiveField(effective, identityfingerprint.FieldCodexVersion); value != "" {
+			return value
+		}
+	}
+	return strings.TrimSpace(effective.Version)
+}
+
+func identityFingerprintEffectiveField(effective identityfingerprint.EffectiveFingerprint, field string) string {
+	if effective.Fields == nil {
+		return ""
+	}
+	return strings.TrimSpace(effective.Fields[field].Value)
 }
 
 func identityFingerprintSourceCounts(fields map[string]identityfingerprint.FieldValue) map[string]int {

--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -206,7 +206,7 @@ func TestListAuthFilesIncludesIdentityFingerprintSummary(t *testing.T) {
 	if !summary.Learned || summary.PrimarySource != "learned" || summary.Version != "2.1.170" {
 		t.Fatalf("summary learned/source/version = %+v", summary)
 	}
-	if summary.SourceCounts["learned"] != 1 || summary.SourceCounts["builtin_default"] == 0 {
+	if summary.SourceCounts["learned"] != 2 || summary.SourceCounts["builtin_default"] == 0 {
 		t.Fatalf("source counts = %#v, want learned and builtin_default fallback fields", summary.SourceCounts)
 	}
 }
@@ -306,6 +306,62 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 	}
 	if payload.Learned.ObservedHeaders["Version"] != "0.125.0" {
 		t.Fatalf("observed headers = %#v", payload.Learned.ObservedHeaders)
+	}
+}
+
+func TestBuildIdentityFingerprintSummaryUsesCodexPresetVersionWhenLearnedVersionMissing(t *testing.T) {
+	learned := &identityfingerprint.LearnedRecord{
+		Provider:      identityfingerprint.ProviderCodex,
+		AccountKey:    "authsub_codex_desktop",
+		AuthSubjectID: "authsub_codex_desktop",
+		ClientProduct: "codex",
+		ClientVariant: "Codex Desktop",
+		Fields: map[string]string{
+			identityfingerprint.FieldUserAgent:       "Codex Desktop/0.142.0 (Windows 10.0.26200; x86_64) unknown (Codex Desktop; 26.616.81150)",
+			identityfingerprint.FieldCodexOriginator: "Codex Desktop",
+		},
+	}
+	_, effective := identityfingerprint.ResolveCodex(config.CodexIdentityFingerprintConfig{
+		Enabled: true,
+		Version: "0.140.0",
+	}, learned)
+
+	summary := buildIdentityFingerprintSummary(
+		identityfingerprint.ProviderCodex,
+		"authsub_codex_desktop",
+		"authsub_codex_desktop",
+		learned,
+		effective,
+	)
+
+	if summary.Version != "0.140.0" {
+		t.Fatalf("summary version = %q, want preset version fallback", summary.Version)
+	}
+}
+
+func TestBuildIdentityFingerprintSummaryUsesClaudeLearnedCLIVersion(t *testing.T) {
+	learned := &identityfingerprint.LearnedRecord{
+		Provider:      identityfingerprint.ProviderClaude,
+		AccountKey:    "authsub_claude_cli",
+		AuthSubjectID: "authsub_claude_cli",
+		ClientProduct: "claude-cli",
+		Fields: map[string]string{
+			identityfingerprint.FieldClaudeCLIVersion: "2.1.170",
+			identityfingerprint.FieldUserAgent:        "claude-cli/2.1.170 (external, cli)",
+		},
+	}
+	_, effective := identityfingerprint.ResolveClaude(config.ClaudeIdentityFingerprintConfig{Enabled: true}, learned)
+
+	summary := buildIdentityFingerprintSummary(
+		identityfingerprint.ProviderClaude,
+		"authsub_claude_cli",
+		"authsub_claude_cli",
+		learned,
+		effective,
+	)
+
+	if summary.Version != "2.1.170" {
+		t.Fatalf("summary version = %q, want learned cli-version", summary.Version)
 	}
 }
 

--- a/internal/identityfingerprint/extract.go
+++ b/internal/identityfingerprint/extract.go
@@ -25,9 +25,10 @@ const (
 )
 
 var (
-	claudeUARe = regexp.MustCompile(`(?i)^claude-cli/([0-9]+(?:\.[0-9]+){0,3})\s+\(external,\s*([^)]+)\)`)
-	tokenVerRe = regexp.MustCompile(`(?i)^([a-z0-9_.-]*codex[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})`)
-	geminiUARe = regexp.MustCompile(`(?i)^google-api-nodejs-client/([0-9]+(?:\.[0-9]+){0,3})`)
+	claudeUARe       = regexp.MustCompile(`(?i)^claude-cli/([0-9]+(?:\.[0-9]+){0,3})\s+\(external,\s*([^)]+)\)`)
+	codexDesktopUARe = regexp.MustCompile(`(?i)\bcodex\s+desktop/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
+	tokenVerRe       = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*codex[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
+	geminiUARe       = regexp.MustCompile(`(?i)^google-api-nodejs-client/([0-9]+(?:\.[0-9]+){0,3})`)
 )
 
 func ExtractObservation(input LearnInput) (Observation, bool) {
@@ -236,18 +237,19 @@ func codexProductVersion(ua string) (string, string) {
 	if ua == "" {
 		return "", ""
 	}
-	first := strings.Fields(ua)
-	if len(first) == 0 {
-		return "", ""
+
+	if matches := codexDesktopUARe.FindStringSubmatch(ua); len(matches) > 0 {
+		return "codex", matches[1]
 	}
-	matches := tokenVerRe.FindStringSubmatch(first[0])
-	if len(matches) == 0 {
-		if strings.Contains(strings.ToLower(ua), "codex") {
-			return "codex", ""
-		}
-		return "", ""
+
+	if matches := tokenVerRe.FindStringSubmatch(ua); len(matches) > 0 {
+		return strings.ToLower(matches[1]), matches[2]
 	}
-	return strings.ToLower(matches[1]), matches[2]
+
+	if strings.Contains(strings.ToLower(ua), "codex") {
+		return "codex", ""
+	}
+	return "", ""
 }
 
 func addHeaderField(fields map[string]string, headers http.Header, headerName, fieldName string) {

--- a/internal/identityfingerprint/extract_resolve_test.go
+++ b/internal/identityfingerprint/extract_resolve_test.go
@@ -34,6 +34,67 @@ func TestExtractClaudeObservationFromRealClientHeaders(t *testing.T) {
 	}
 }
 
+func TestExtractCodexObservationFromDesktopUserAgent(t *testing.T) {
+	tests := []struct {
+		name string
+		ua   string
+	}{
+		{
+			name: "windows desktop",
+			ua:   "Codex Desktop/0.142.0 (Windows 10.0.26200; x86_64) unknown (Codex Desktop; 26.616.81150)",
+		},
+		{
+			name: "mac desktop",
+			ua:   "Codex Desktop/0.142.0 (Mac OS 26.5.1; arm64) unknown (Codex Desktop; 26.616.81150)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := http.Header{}
+			headers.Set("User-Agent", tt.ua)
+			headers.Set("Originator", "Codex Desktop")
+			headers.Set("OpenAI-Beta", "responses_websockets=2026-02-06")
+
+			obs, ok := ExtractObservation(LearnInput{
+				Provider:   ProviderCodex,
+				AccountKey: "acct",
+				Headers:    headers,
+				ObservedAt: time.Date(2026, 6, 24, 1, 2, 3, 0, time.UTC),
+			})
+			if !ok {
+				t.Fatal("ExtractObservation returned false")
+			}
+			if obs.ClientProduct != "codex" || obs.ClientVariant != "Codex Desktop" {
+				t.Fatalf("product/variant = %s/%s, want codex/Codex Desktop", obs.ClientProduct, obs.ClientVariant)
+			}
+			if obs.Version != "0.142.0" || obs.Fields[FieldCodexVersion] != "0.142.0" {
+				t.Fatalf("version fields = %s/%s, want 0.142.0", obs.Version, obs.Fields[FieldCodexVersion])
+			}
+		})
+	}
+}
+
+func TestExtractCodexObservationVersionHeaderOverridesUserAgentVersion(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("User-Agent", "Codex Desktop/0.142.0 (Windows 10.0.26200; x86_64) unknown (Codex Desktop; 26.616.81150)")
+	headers.Set("Version", "0.143.1")
+	headers.Set("Originator", "Codex Desktop")
+
+	obs, ok := ExtractObservation(LearnInput{
+		Provider:   ProviderCodex,
+		AccountKey: "acct",
+		Headers:    headers,
+		ObservedAt: time.Date(2026, 6, 24, 1, 2, 3, 0, time.UTC),
+	})
+	if !ok {
+		t.Fatal("ExtractObservation returned false")
+	}
+	if obs.Version != "0.143.1" || obs.Fields[FieldCodexVersion] != "0.143.1" {
+		t.Fatalf("version fields = %s/%s, want Version header", obs.Version, obs.Fields[FieldCodexVersion])
+	}
+}
+
 func TestMergeObservationUpdatesOnlyNewerSameProductAndPreservesMissingFields(t *testing.T) {
 	existing := &LearnedRecord{
 		Provider:      ProviderClaude,
@@ -154,6 +215,49 @@ func TestResolveCodexUsesPresetBeforeBuiltinDefault(t *testing.T) {
 	}
 	if got := effective.Fields[FieldCodexWebsocketBeta].Source; got != FieldSourceBuiltinDefault {
 		t.Fatalf("websocket beta source = %q, want builtin_default", got)
+	}
+}
+
+func TestResolveCodexEffectiveVersionUsesFieldLevelPriority(t *testing.T) {
+	learned := &LearnedRecord{
+		Provider:   ProviderCodex,
+		AccountKey: "acct",
+		Fields: map[string]string{
+			FieldCodexVersion: "0.142.0",
+		},
+	}
+
+	fp, effective := ResolveCodex(config.CodexIdentityFingerprintConfig{
+		Enabled: true,
+		Version: "0.140.0",
+	}, learned)
+
+	if fp.Version != "0.142.0" {
+		t.Fatalf("resolved version = %q, want learned field", fp.Version)
+	}
+	if effective.Version != "0.142.0" {
+		t.Fatalf("effective version = %q, want learned field", effective.Version)
+	}
+	if got := effective.Fields[FieldCodexVersion].Source; got != FieldSourceLearned {
+		t.Fatalf("version source = %q, want learned", got)
+	}
+}
+
+func TestResolveClaudeEffectiveVersionFallsBackToPreset(t *testing.T) {
+	_, effective := ResolveClaude(config.ClaudeIdentityFingerprintConfig{
+		Enabled:    true,
+		CLIVersion: "2.1.170",
+	}, &LearnedRecord{
+		Provider:   ProviderClaude,
+		AccountKey: "acct",
+		Fields:     map[string]string{},
+	})
+
+	if effective.Version != "2.1.170" {
+		t.Fatalf("effective version = %q, want preset cli-version", effective.Version)
+	}
+	if got := effective.Fields[FieldClaudeCLIVersion].Source; got != FieldSourcePreset {
+		t.Fatalf("cli-version source = %q, want preset", got)
 	}
 }
 

--- a/internal/identityfingerprint/resolve.go
+++ b/internal/identityfingerprint/resolve.go
@@ -16,7 +16,7 @@ func ResolveClaude(cfg config.ClaudeIdentityFingerprintConfig, learned *LearnedR
 		return value
 	}
 
-	cliVersion := pick(FieldClaudeCLIVersion, clean.CLIVersion, learnedField(learned, FieldClaudeCLIVersion), defaults.CLIVersion)
+	cliVersion := pick(FieldClaudeCLIVersion, clean.CLIVersion, learnedFieldOrVersion(learned, FieldClaudeCLIVersion), defaults.CLIVersion)
 	entrypoint := pick(FieldClaudeEntrypoint, clean.Entrypoint, learnedField(learned, FieldClaudeEntrypoint), defaults.Entrypoint)
 	userAgentDefault := config.BuildClaudeFingerprintUserAgent(cliVersion, entrypoint)
 	userAgent := pick(FieldUserAgent, clean.UserAgent, learnedField(learned, FieldUserAgent), userAgentDefault)
@@ -43,7 +43,9 @@ func ResolveClaude(cfg config.ClaudeIdentityFingerprintConfig, learned *LearnedR
 		DeviceID:                clean.DeviceID,
 		CustomHeaders:           clean.CustomHeaders,
 	}
-	return resolved, effective(ProviderClaude, clean.Enabled, learned, fields)
+	effective := effective(ProviderClaude, clean.Enabled, learned, fields)
+	effective.Version = cliVersion
+	return resolved, effective
 }
 
 func ResolveCodex(cfg config.CodexIdentityFingerprintConfig, learned *LearnedRecord) (config.CodexIdentityFingerprintConfig, EffectiveFingerprint) {
@@ -57,7 +59,7 @@ func ResolveCodex(cfg config.CodexIdentityFingerprintConfig, learned *LearnedRec
 	}
 
 	userAgent := pick(FieldUserAgent, clean.UserAgent, learnedField(learned, FieldUserAgent), defaults.UserAgent)
-	version := pick(FieldCodexVersion, clean.Version, learnedField(learned, FieldCodexVersion), defaults.Version)
+	version := pick(FieldCodexVersion, clean.Version, learnedFieldOrVersion(learned, FieldCodexVersion), defaults.Version)
 	originator := pick(FieldCodexOriginator, clean.Originator, learnedField(learned, FieldCodexOriginator), defaults.Originator)
 	websocketBeta := pick(FieldCodexWebsocketBeta, clean.WebsocketBeta, learnedField(learned, FieldCodexWebsocketBeta), defaults.WebsocketBeta)
 	betaFeatures := pick(FieldCodexBetaFeatures, clean.BetaFeatures, learnedField(learned, FieldCodexBetaFeatures), defaults.BetaFeatures)
@@ -77,7 +79,9 @@ func ResolveCodex(cfg config.CodexIdentityFingerprintConfig, learned *LearnedRec
 		SessionID:     clean.SessionID,
 		CustomHeaders: clean.CustomHeaders,
 	}
-	return resolved, effective(ProviderCodex, clean.Enabled, learned, fields)
+	effective := effective(ProviderCodex, clean.Enabled, learned, fields)
+	effective.Version = version
+	return resolved, effective
 }
 
 func ResolveGemini(cfg config.GeminiIdentityFingerprintConfig, learned *LearnedRecord) (config.GeminiIdentityFingerprintConfig, EffectiveFingerprint) {
@@ -115,6 +119,16 @@ func learnedField(record *LearnedRecord, field string) string {
 		return ""
 	}
 	return strings.TrimSpace(record.Fields[field])
+}
+
+func learnedFieldOrVersion(record *LearnedRecord, field string) string {
+	if value := learnedField(record, field); value != "" {
+		return value
+	}
+	if record == nil {
+		return ""
+	}
+	return strings.TrimSpace(record.Version)
 }
 
 func effective(provider Provider, enabled bool, learned *LearnedRecord, fields map[string]FieldValue) EffectiveFingerprint {


### PR DESCRIPTION
## Summary
- parse Codex Desktop user-agent versions with spaced product names
- propagate Claude/Codex effective versions into management summaries
- preserve learned-version fallback for older records

## Tests
- rtk go test ./...
