### PR TITLE
feat: add quota status clear endpoint

### DIFF
--- a/internal/api/handlers/management/quota.go
+++ b/internal/api/handlers/management/quota.go
@@ -60,6 +60,36 @@ func (h *Handler) PostQuotaReconcile(c *gin.Context) {
 	})
 }
 
+func (h *Handler) PostQuotaClearStatus(c *gin.Context) {
+	if h == nil || h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth manager unavailable"})
+		return
+	}
+
+	var body quotaReconcileRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+
+	authIndex := firstNonEmptyString(body.AuthIndexSnake, body.AuthIndexCamel, body.AuthIndexPascal)
+	auth := h.authByIndex(authIndex)
+	if auth == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "auth not found"})
+		return
+	}
+
+	changed, err := h.authManager.ClearQuotaStatus(c.Request.Context(), auth.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "ok",
+		"changed": changed,
+	})
+}
+
 type quotaSnapshotRequest struct {
 	AuthIndexSnake   *string                     `json:"auth_index"`
 	AuthIndexCamel   *string                     `json:"authIndex"`

--- a/internal/api/handlers/management/quota_test.go
+++ b/internal/api/handlers/management/quota_test.go
@@ -1,0 +1,70 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestPostQuotaClearStatusClearsAuthByIndex(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	next := time.Now().Add(30 * time.Minute)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:             "codex-auth",
+		Provider:       "codex",
+		FileName:       "codex.json",
+		Status:         coreauth.StatusError,
+		StatusMessage:  "quota exhausted",
+		Unavailable:    true,
+		NextRetryAfter: next,
+		LastError:      &coreauth.Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+		Quota: coreauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: next,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if registered.Index == "" {
+		t.Fatalf("registered auth index is empty")
+	}
+
+	h := &Handler{authManager: manager}
+	router := gin.New()
+	router.POST("/quota/clear-status", h.PostQuotaClearStatus)
+
+	body, err := json.Marshal(map[string]string{"authIndex": registered.Index})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/quota/clear-status", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	updated, ok := manager.GetByID(registered.ID)
+	if !ok || updated == nil {
+		t.Fatalf("GetByID() missing auth")
+	}
+	if updated.Status != coreauth.StatusActive {
+		t.Fatalf("auth.Status = %q, want %q", updated.Status, coreauth.StatusActive)
+	}
+	if updated.StatusMessage != "" || updated.Unavailable || !updated.NextRetryAfter.IsZero() || updated.LastError != nil || updated.Quota != (coreauth.QuotaState{}) {
+		t.Fatalf("quota runtime state was not cleared: %#v", updated)
+	}
+}

--- a/internal/api/routes/management_settings_routes.go
+++ b/internal/api/routes/management_settings_routes.go
@@ -60,6 +60,7 @@ func registerManagementSettingsRoutes(group *gin.RouterGroup, h *managementhandl
 	group.PUT("/quota-exceeded/switch-preview-model", h.PutSwitchPreviewModel)
 	group.PATCH("/quota-exceeded/switch-preview-model", h.PutSwitchPreviewModel)
 	group.POST("/quota/reconcile", h.PostQuotaReconcile)
+	group.POST("/quota/clear-status", h.PostQuotaClearStatus)
 }
 
 func registerManagementRuntimeTuningRoutes(group *gin.RouterGroup, h *managementhandlers.Handler) {

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -24,7 +24,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 217; got != want {
+	if got, want := len(routes), 218; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 
@@ -48,6 +48,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"DELETE /v0/management/identity-fingerprint/learned",
 		"GET /v0/management/codex-oauth-admission",
 		"PUT /v0/management/codex-oauth-admission",
+		"POST /v0/management/quota/clear-status",
 		"POST /v0/management/oauth-callback",
 		"GET /v0/management/public/ping",
 		"GET /v0/management/public/usage/logs/:id/content",

--- a/sdk/cliproxy/auth/quota_reconcile.go
+++ b/sdk/cliproxy/auth/quota_reconcile.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -36,6 +37,50 @@ type QuotaRecoveryProber interface {
 // ReconcileQuota forces an immediate quota reconciliation for the given auth entry.
 func (m *Manager) ReconcileQuota(ctx context.Context, id string) (bool, error) {
 	return m.probeQuotaRecovery(ctx, id, true)
+}
+
+// ClearQuotaStatus manually clears local quota/cooldown runtime state for an auth entry.
+func (m *Manager) ClearQuotaStatus(ctx context.Context, id string) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false, nil
+	}
+
+	now := time.Now()
+	var (
+		updated         *Auth
+		recoveredModels []string
+	)
+
+	m.mu.Lock()
+	current, ok := m.auths[id]
+	if !ok || current == nil {
+		delete(m.quotaProbeAfter, id)
+		m.mu.Unlock()
+		return false, nil
+	}
+
+	changed, models := clearQuotaStatusForAuth(current, now)
+	recoveredModels = models
+	delete(m.quotaProbeAfter, id)
+	if changed {
+		current.UpdatedAt = now
+		updated = current.Clone()
+		m.auths[id] = current
+	}
+	m.mu.Unlock()
+
+	if updated != nil {
+		if errPersist := m.persist(ctx, updated); errPersist != nil {
+			return true, errPersist
+		}
+		m.hook.OnAuthUpdated(ctx, updated.Clone())
+	}
+	m.resumeRecoveredQuotaModels(id, recoveredModels)
+	return updated != nil, nil
 }
 
 func (m *Manager) checkQuotaRecoveries(ctx context.Context, snapshot []*Auth, now time.Time) {
@@ -246,6 +291,36 @@ func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) 
 	return changed, nil
 }
 
+func clearQuotaStatusForAuth(auth *Auth, now time.Time) (bool, []string) {
+	if auth == nil {
+		return false, nil
+	}
+
+	authHadQuotaRuntime := hasQuotaRuntimeState(auth.StatusMessage, auth.LastError, auth.Unavailable, auth.NextRetryAfter, auth.Quota)
+	var changed bool
+	recoveredModels := make([]string, 0, len(auth.ModelStates))
+	for modelID, state := range auth.ModelStates {
+		if clearQuotaModelRuntimeState(state, now) {
+			changed = true
+			recoveredModels = append(recoveredModels, modelID)
+		}
+	}
+
+	if len(auth.ModelStates) > 0 {
+		beforeUnavailable := auth.Unavailable
+		beforeNextRetry := auth.NextRetryAfter
+		beforeQuota := auth.Quota
+		updateAggregatedAvailability(auth, now)
+		if auth.Unavailable != beforeUnavailable || !auth.NextRetryAfter.Equal(beforeNextRetry) || auth.Quota != beforeQuota {
+			changed = true
+		}
+	}
+	if clearQuotaAuthRuntimeState(auth, now, authHadQuotaRuntime) {
+		changed = true
+	}
+	return changed, recoveredModels
+}
+
 func normalizeQuotaProbeModels(in map[string]QuotaProbeModelResult) map[string]QuotaProbeModelResult {
 	if len(in) == 0 {
 		return nil
@@ -335,6 +410,27 @@ func clearQuotaModelState(state *ModelState, now time.Time) bool {
 	return changed
 }
 
+func clearQuotaModelRuntimeState(state *ModelState, now time.Time) bool {
+	if state == nil || !hasQuotaRuntimeState(state.StatusMessage, state.LastError, state.Unavailable, state.NextRetryAfter, state.Quota) {
+		return false
+	}
+	preserveDisabled := state.Status == StatusDisabled
+	changed := state.Unavailable || !state.NextRetryAfter.IsZero() || state.LastError != nil || state.Quota != (QuotaState{})
+	state.Unavailable = false
+	state.NextRetryAfter = time.Time{}
+	state.LastError = nil
+	state.Quota = QuotaState{}
+	if !preserveDisabled {
+		if state.Status != StatusActive || state.StatusMessage != "" {
+			changed = true
+		}
+		state.Status = StatusActive
+		state.StatusMessage = ""
+	}
+	state.UpdatedAt = now
+	return changed
+}
+
 func updateQuotaModelRecoverAt(state *ModelState, next time.Time, now time.Time) bool {
 	if state == nil || next.IsZero() {
 		return false
@@ -362,6 +458,44 @@ func clearQuotaAuthState(auth *Auth, now time.Time) bool {
 	auth.Quota = QuotaState{}
 	auth.UpdatedAt = now
 	return changed
+}
+
+func clearQuotaAuthRuntimeState(auth *Auth, now time.Time, force bool) bool {
+	if auth == nil || (!force && !hasQuotaRuntimeState(auth.StatusMessage, auth.LastError, auth.Unavailable, auth.NextRetryAfter, auth.Quota)) {
+		return false
+	}
+	preserveDisabled := auth.Status == StatusDisabled
+	changed := auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.LastError != nil || auth.Quota != (QuotaState{})
+	auth.Unavailable = false
+	auth.NextRetryAfter = time.Time{}
+	auth.LastError = nil
+	auth.Quota = QuotaState{}
+	if !preserveDisabled {
+		if auth.Status != StatusActive || auth.StatusMessage != "" {
+			changed = true
+		}
+		auth.Status = StatusActive
+		auth.StatusMessage = ""
+	}
+	auth.UpdatedAt = now
+	return changed
+}
+
+func hasQuotaRuntimeState(statusMessage string, lastError *Error, unavailable bool, nextRetryAfter time.Time, quota QuotaState) bool {
+	if quota != (QuotaState{}) || unavailable || !nextRetryAfter.IsZero() {
+		return true
+	}
+	if lastError != nil {
+		if lastError.HTTPStatus == http.StatusTooManyRequests {
+			return true
+		}
+		text := strings.ToLower(strings.TrimSpace(lastError.Code + " " + lastError.Message))
+		if strings.Contains(text, "quota") || strings.Contains(text, "rate limit") || strings.Contains(text, "429") || strings.Contains(text, "cooldown") {
+			return true
+		}
+	}
+	text := strings.ToLower(strings.TrimSpace(statusMessage))
+	return strings.Contains(text, "quota") || strings.Contains(text, "rate limit") || strings.Contains(text, "429") || strings.Contains(text, "cooldown")
 }
 
 func updateQuotaAuthRecoverAt(auth *Auth, next time.Time, now time.Time) bool {

--- a/sdk/cliproxy/auth/quota_reconcile_test.go
+++ b/sdk/cliproxy/auth/quota_reconcile_test.go
@@ -190,3 +190,138 @@ func TestManagerReconcileQuota_UpdatesModelRecoverAt(t *testing.T) {
 		t.Fatalf("state.NextRetryAfter = %v, want earlier than %v", state.NextRetryAfter, oldNext)
 	}
 }
+
+func TestManagerClearQuotaStatus_ClearsAuthAndModelRuntimeQuota(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	next := time.Now().Add(30 * time.Minute)
+	auth := &Auth{
+		ID:             "codex-auth",
+		Provider:       "codex",
+		Status:         StatusError,
+		StatusMessage:  "quota exhausted",
+		Unavailable:    true,
+		NextRetryAfter: next,
+		LastError:      &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: next,
+		},
+		ModelStates: map[string]*ModelState{
+			"gpt-5-codex": {
+				Status:         StatusError,
+				StatusMessage:  "quota exhausted",
+				Unavailable:    true,
+				NextRetryAfter: next,
+				LastError:      &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: next,
+				},
+			},
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	changed, err := manager.ClearQuotaStatus(context.Background(), auth.ID)
+	if err != nil {
+		t.Fatalf("ClearQuotaStatus() error = %v", err)
+	}
+	if !changed {
+		t.Fatalf("ClearQuotaStatus() changed = false, want true")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("GetByID() missing auth")
+	}
+	if updated.Status != StatusActive {
+		t.Fatalf("auth.Status = %q, want %q", updated.Status, StatusActive)
+	}
+	if updated.StatusMessage != "" || updated.Unavailable || !updated.NextRetryAfter.IsZero() || updated.LastError != nil || updated.Quota != (QuotaState{}) {
+		t.Fatalf("auth quota runtime state was not cleared: %#v", updated)
+	}
+	state := updated.ModelStates["gpt-5-codex"]
+	if state == nil {
+		t.Fatalf("expected model state")
+	}
+	if state.Status != StatusActive {
+		t.Fatalf("state.Status = %q, want %q", state.Status, StatusActive)
+	}
+	if state.StatusMessage != "" || state.Unavailable || !state.NextRetryAfter.IsZero() || state.LastError != nil || state.Quota != (QuotaState{}) {
+		t.Fatalf("model quota runtime state was not cleared: %#v", state)
+	}
+}
+
+func TestManagerClearQuotaStatus_PreservesStatusDisabled(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	next := time.Now().Add(30 * time.Minute)
+	auth := &Auth{
+		ID:             "disabled-auth",
+		Provider:       "codex",
+		Status:         StatusDisabled,
+		StatusMessage:  "manually disabled",
+		Disabled:       true,
+		Unavailable:    true,
+		NextRetryAfter: next,
+		LastError:      &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: next,
+		},
+		ModelStates: map[string]*ModelState{
+			"gpt-5-codex": {
+				Status:         StatusDisabled,
+				StatusMessage:  "model disabled",
+				Unavailable:    true,
+				NextRetryAfter: next,
+				LastError:      &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: next,
+				},
+			},
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	changed, err := manager.ClearQuotaStatus(context.Background(), auth.ID)
+	if err != nil {
+		t.Fatalf("ClearQuotaStatus() error = %v", err)
+	}
+	if !changed {
+		t.Fatalf("ClearQuotaStatus() changed = false, want true")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("GetByID() missing auth")
+	}
+	if !updated.Disabled || updated.Status != StatusDisabled || updated.StatusMessage != "manually disabled" {
+		t.Fatalf("disabled auth status changed: disabled=%v status=%q message=%q", updated.Disabled, updated.Status, updated.StatusMessage)
+	}
+	if updated.Unavailable || !updated.NextRetryAfter.IsZero() || updated.LastError != nil || updated.Quota != (QuotaState{}) {
+		t.Fatalf("disabled auth quota runtime state was not cleared: %#v", updated)
+	}
+	state := updated.ModelStates["gpt-5-codex"]
+	if state == nil {
+		t.Fatalf("expected model state")
+	}
+	if state.Status != StatusDisabled || state.StatusMessage != "model disabled" {
+		t.Fatalf("disabled model status changed: status=%q message=%q", state.Status, state.StatusMessage)
+	}
+	if state.Unavailable || !state.NextRetryAfter.IsZero() || state.LastError != nil || state.Quota != (QuotaState{}) {
+		t.Fatalf("disabled model quota runtime state was not cleared: %#v", state)
+	}
+}


### PR DESCRIPTION
## Summary
- add a management endpoint to clear local quota/cooldown runtime status for an auth entry
- clear auth-level and model-level quota state while preserving manually disabled status
- add handler and manager tests

## Tests
- rtk go test ./sdk/cliproxy/auth ./internal/api/handlers/management