### PR TITLE
feat: fetch ClinePass models dynamically

### DIFF
--- a/internal/api/handlers/management/model_definitions.go
+++ b/internal/api/handlers/management/model_definitions.go
@@ -1,11 +1,20 @@
 package management
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+)
+
+var (
+	clineRecommendedModelsURL    = "https://api.cline.bot/api/v1/ai/cline/recommended-models"
+	clineRecommendedModelsClient = &http.Client{Timeout: 5 * time.Second}
 )
 
 // GetStaticModelDefinitions returns static model metadata for a given channel.
@@ -20,14 +29,70 @@ func (h *Handler) GetStaticModelDefinitions(c *gin.Context) {
 		return
 	}
 
-	models := registry.GetStaticModelDefinitionsByChannel(channel)
+	normalizedChannel := strings.ToLower(strings.TrimSpace(channel))
+	models := registry.GetStaticModelDefinitionsByChannel(normalizedChannel)
 	if models == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown channel", "channel": channel})
 		return
 	}
+	if normalizedChannel == "cline" {
+		if remoteModels, err := fetchClinePassModelDefinitions(c.Request.Context()); err == nil && len(remoteModels) > 0 {
+			models = remoteModels
+		}
+	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"channel": strings.ToLower(strings.TrimSpace(channel)),
+		"channel": normalizedChannel,
 		"models":  models,
 	})
+}
+
+func fetchClinePassModelDefinitions(ctx context.Context) ([]*registry.ModelInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clineRecommendedModelsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := clineRecommendedModelsClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cline recommended models status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		ClinePass []struct {
+			ID          string   `json:"id"`
+			Name        string   `json:"name"`
+			Description string   `json:"description"`
+			Tags        []string `json:"tags"`
+		} `json:"clinePass"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	models := make([]*registry.ModelInfo, 0, len(payload.ClinePass))
+	for _, item := range payload.ClinePass {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			continue
+		}
+		displayName := strings.TrimSpace(item.Name)
+		if displayName == "" {
+			displayName = id
+		}
+		models = append(models, &registry.ModelInfo{
+			ID:          id,
+			Object:      "model",
+			OwnedBy:     "cline",
+			Type:        "cline",
+			DisplayName: displayName,
+			Description: strings.TrimSpace(item.Description),
+		})
+	}
+	return models, nil
 }

--- a/internal/api/handlers/management/model_definitions_test.go
+++ b/internal/api/handlers/management/model_definitions_test.go
@@ -1,0 +1,100 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func performModelDefinitionsRequest(handler gin.HandlerFunc, channel string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "channel", Value: channel}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/model-definitions/"+channel, nil)
+	handler(c)
+	return rec
+}
+
+func withClineRecommendedModelsServer(t *testing.T, status int, body string) {
+	t.Helper()
+	previousURL := clineRecommendedModelsURL
+	previousClient := clineRecommendedModelsClient
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		clineRecommendedModelsURL = previousURL
+		clineRecommendedModelsClient = previousClient
+	})
+	clineRecommendedModelsURL = server.URL + "/models"
+	clineRecommendedModelsClient = server.Client()
+}
+
+func TestGetStaticModelDefinitionsUsesClineRecommendedModels(t *testing.T) {
+	withClineRecommendedModelsServer(t, http.StatusOK, `{
+		"clinePass": [
+			{"id": "cline-pass/fresh", "name": "Fresh Model", "description": "from cline"},
+			{"id": " ", "name": "ignored"}
+		]
+	}`)
+	h := NewHandler(&config.Config{}, "", nil)
+
+	rec := performModelDefinitionsRequest(h.GetStaticModelDefinitions, "cline")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Models []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+			Description string `json:"description"`
+			OwnedBy     string `json:"owned_by"`
+			Type        string `json:"type"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Models) != 1 {
+		t.Fatalf("expected one remote model, got %+v", payload.Models)
+	}
+	model := payload.Models[0]
+	if model.ID != "cline-pass/fresh" || model.DisplayName != "Fresh Model" || model.Description != "from cline" || model.OwnedBy != "cline" || model.Type != "cline" {
+		t.Fatalf("unexpected model payload: %+v", model)
+	}
+}
+
+func TestGetStaticModelDefinitionsFallsBackToClineStaticModels(t *testing.T) {
+	withClineRecommendedModelsServer(t, http.StatusBadGateway, `{"error":"upstream unavailable"}`)
+	h := NewHandler(&config.Config{}, "", nil)
+
+	rec := performModelDefinitionsRequest(h.GetStaticModelDefinitions, "cline")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Models []struct {
+			ID string `json:"id"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	for _, model := range payload.Models {
+		if model.ID == "cline-pass/glm-5.2" {
+			return
+		}
+	}
+	t.Fatalf("expected static fallback to include cline-pass/glm-5.2, got %+v", payload.Models)
+}


### PR DESCRIPTION
## Summary
- fetch ClinePass model definitions from Cline's public recommended-models endpoint for management model definitions
- extract the clinePass list and preserve the existing static Cline model table as fallback
- add tests for remote success and fallback behavior

## Investigation
- Cline's documented endpoint remains POST /api/v1/chat/completions; no documented OpenAI-compatible GET /models endpoint was found
- Cline exposes GET https://api.cline.bot/api/v1/ai/cline/recommended-models, which returns a clinePass array matching the current ClinePass model list

## Tests
- rtk go test ./internal/api/handlers/management -run 'TestGetStaticModelDefinitions|TestCline'
- rtk go test ./internal/registry -run Cline
- rtk go test ./...
