### PR TITLE
fix: register configured cline models on startup

### DIFF
--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -57,3 +57,51 @@ func TestConfiguredAvailabilityIncludesModelSources(t *testing.T) {
 		t.Fatalf("source labels = %#v", labels)
 	}
 }
+
+func TestConfiguredAvailabilityIncludesClineAliasUpstreamModelID(t *testing.T) {
+	const modelID = "mimo-v2.5-pro"
+	const upstreamModelID = "cline-pass/mimo-v2.5-pro"
+	const clientID = "source-test-cline-alias"
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(clientID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	modelRegistry.RegisterClient(clientID, "cline", []*registry.ModelInfo{{
+		ID:              modelID,
+		Object:          "model",
+		OwnedBy:         "cline",
+		Type:            "cline",
+		DisplayName:     upstreamModelID,
+		UpstreamModelID: upstreamModelID,
+		UserDefined:     true,
+	}})
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{ID: clientID, Provider: "cline", Label: "Cline", Status: coreauth.StatusActive}); err != nil {
+		t.Fatalf("register cline auth: %v", err)
+	}
+
+	result := New(&config.Config{}, manager).ConfiguredAvailability("", "")
+	data, ok := result["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v, want []map[string]any", result["data"])
+	}
+
+	var sources []map[string]any
+	for _, item := range data {
+		if item["id"] == modelID {
+			sources, _ = item["sources"].([]map[string]any)
+			break
+		}
+	}
+	if len(sources) != 1 {
+		t.Fatalf("sources = %#v, want one cline source", sources)
+	}
+	source := sources[0]
+	if source["provider"] != "cline" || source["model_id"] != modelID || source["upstream_model_id"] != upstreamModelID {
+		t.Fatalf("source = %#v, want cline alias with upstream model id", source)
+	}
+}

--- a/sdk/cliproxy/lifecycle.go
+++ b/sdk/cliproxy/lifecycle.go
@@ -76,11 +76,15 @@ func (s *Service) loadInitialState(ctx context.Context) error {
 		return err
 	}
 
+	s.applyDBBackedRuntimeSettings(s.cfg)
 	s.applyRetryConfig(s.cfg)
 	if s.coreManager != nil {
+		s.coreManager.SetConfig(s.cfg)
+		s.coreManager.SetOAuthModelAlias(s.cfg.OAuthModelAlias)
 		if errLoad := s.coreManager.Load(ctx); errLoad != nil {
 			log.Warnf("failed to load auth store: %v", errLoad)
 		}
+		s.syncConfigDerivedAuths(s.cfg)
 		for _, auth := range s.coreManager.List() {
 			if auth == nil || auth.ID == "" {
 				continue

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -84,7 +84,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	}
 	provider := strings.ToLower(strings.TrimSpace(a.Provider))
 	compatProviderKey, compatDisplayName, compatDetected := openAICompatInfoFromAuth(a)
-	if compatDetected {
+	if compatDetected && provider != "cline" {
 		provider = "openai-compatibility"
 	}
 	excluded := s.oauthExcludedModels(provider, authKind)

--- a/sdk/cliproxy/service_startup_registration_test.go
+++ b/sdk/cliproxy/service_startup_registration_test.go
@@ -71,3 +71,49 @@ func TestServiceRun_RegistersModelsForLoadedAuths(t *testing.T) {
 		t.Fatal("expected codex models to be registered from loaded auths")
 	}
 }
+
+func TestLoadInitialState_RegistersConfigDerivedClineModels(t *testing.T) {
+	reg := GlobalModelRegistry()
+
+	cfg := &config.Config{
+		AuthDir: t.TempDir(),
+		Port:    0,
+		ClineKey: []config.ClineKey{{
+			APIKey: "cline-key",
+			Name:   "ClinePass",
+			Models: []config.ClineModel{{Name: "cline-pass/mimo-v2.5-pro", Alias: "mimo-v2.5-pro"}},
+		}},
+	}
+	manager := coreauth.NewManager(&startupStoreStub{}, &coreauth.RoundRobinSelector{}, nil)
+	service := &Service{
+		cfg:            cfg,
+		configPath:     "/tmp/config.yaml",
+		tokenProvider:  startupTokenProviderStub{},
+		apiKeyProvider: startupAPIKeyProviderStub{},
+		coreManager:    manager,
+	}
+
+	if err := service.loadInitialState(context.Background()); err != nil {
+		t.Fatalf("loadInitialState() error = %v", err)
+	}
+
+	var clineAuth *coreauth.Auth
+	for _, candidate := range manager.List() {
+		if candidate != nil && candidate.Provider == "cline" {
+			clineAuth = candidate
+			break
+		}
+	}
+	if clineAuth == nil {
+		t.Fatal("expected config-derived Cline auth")
+	}
+	t.Cleanup(func() { reg.UnregisterClient(clineAuth.ID) })
+
+	models := reg.GetModelsForClient(clineAuth.ID)
+	if len(models) != 1 || !hasModelID(models, "mimo-v2.5-pro") {
+		t.Fatalf("expected Cline alias model registered from config auth %+v, got %+v", clineAuth.Attributes, models)
+	}
+	if models[0].UpstreamModelID != "cline-pass/mimo-v2.5-pro" {
+		t.Fatalf("UpstreamModelID = %q, want cline-pass/mimo-v2.5-pro", models[0].UpstreamModelID)
+	}
+}


### PR DESCRIPTION
## Summary
- apply DB-backed runtime settings during startup before loading config-derived auths
- sync config-derived auths on startup so configured Cline providers register their models after restart
- keep Cline providers in the Cline model registration path even when they use OpenAI-compatible transport attributes
- add regression coverage for Cline alias registration and upstream model IDs in configured availability

## Tests
- `rtk go test ./internal/management/modelcatalog ./sdk/cliproxy ./internal/api/handlers/management`
