### PR TITLE
fix: sync cline wrappers from openrouter models

### DIFF
--- a/internal/storage/sqlite/modelconfig/store.go
+++ b/internal/storage/sqlite/modelconfig/store.go
@@ -488,6 +488,7 @@ func defaultModelConfigRows() []ModelConfigRow {
 		"qwen",
 		"iflow",
 		"kimi",
+		"cline",
 		"opencode-go",
 		"antigravity",
 	}

--- a/internal/usage/model_config_db_test.go
+++ b/internal/usage/model_config_db_test.go
@@ -56,6 +56,14 @@ func TestInitDBSeedsDefaultModelConfigs(t *testing.T) {
 	if opencodeModel.OwnedBy != "opencode" || opencodeModel.Source != "seed" {
 		t.Fatalf("unexpected opencode-go seed model config: %+v", opencodeModel)
 	}
+
+	clineModel, ok := GetModelConfig("cline-pass/deepseek-v4-flash")
+	if !ok {
+		t.Fatal("expected cline-pass/deepseek-v4-flash to be seeded")
+	}
+	if clineModel.OwnedBy != "cline" || clineModel.Source != "seed" {
+		t.Fatalf("unexpected cline seed model config: %+v", clineModel)
+	}
 }
 
 func TestUpsertModelConfigAndPerCallCost(t *testing.T) {

--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -119,6 +119,9 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			if err := openRouterSyncExistingAliasRows(modelID, model, owner, legacyModelIDs); err != nil {
 				return result, err
 			}
+			if err := openRouterSyncExistingWrapperRows(modelID, model); err != nil {
+				return result, err
+			}
 			result.Updated++
 			continue
 		}
@@ -128,6 +131,9 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 		}
 		if migrated {
 			if err := openRouterSyncExistingAliasRows(modelID, model, owner, legacyModelIDs); err != nil {
+				return result, err
+			}
+			if err := openRouterSyncExistingWrapperRows(modelID, model); err != nil {
 				return result, err
 			}
 			result.Updated++
@@ -146,10 +152,14 @@ func SyncOpenRouterModelList(ctx context.Context, models []OpenRouterRemoteModel
 			Source:                openRouterModelSource,
 		}
 		row.InputModalities, row.OutputModalities = openRouterModelModalities(model)
+		openRouterApplyImageGenerationSemantics(&row, model)
 		if err := UpsertModelConfig(row); err != nil {
 			return result, fmt.Errorf("sync openrouter model %s: %w", modelID, err)
 		}
 		if err := openRouterSyncExistingAliasRows(modelID, model, owner, legacyModelIDs); err != nil {
+			return result, err
+		}
+		if err := openRouterSyncExistingWrapperRows(modelID, model); err != nil {
 			return result, err
 		}
 		result.Added++
@@ -415,6 +425,16 @@ func openRouterApplyModelSync(row *ModelConfigRow, model OpenRouterRemoteModel, 
 	if description := openRouterModelDescription(model); description != "" && openRouterShouldSyncDescription(*row) {
 		row.Description = description
 	}
+	openRouterApplyModelSyncValues(row, model)
+}
+
+func openRouterApplyModelSyncValues(row *ModelConfigRow, model OpenRouterRemoteModel) {
+	if row == nil {
+		return
+	}
+	if openRouterApplyImageGenerationSemantics(row, model) {
+		return
+	}
 	row.PricingMode = "token"
 	row.InputPricePerMillion = openRouterPricePerMillion(model.Pricing.Prompt)
 	row.OutputPricePerMillion = openRouterPricePerMillion(model.Pricing.Completion)
@@ -427,6 +447,53 @@ func openRouterApplyModelSync(row *ModelConfigRow, model OpenRouterRemoteModel, 
 	if len(outputModalities) > 0 {
 		row.OutputModalities = outputModalities
 	}
+}
+
+func openRouterApplyImageGenerationSemantics(row *ModelConfigRow, model OpenRouterRemoteModel) bool {
+	if row == nil || !openRouterIsImageGenerationRow(*row) {
+		return false
+	}
+	row.PricingMode = "call"
+	row.InputPricePerMillion = 0
+	row.OutputPricePerMillion = 0
+	row.CachedPricePerMillion = 0
+	if row.PricePerCall < 0 {
+		row.PricePerCall = 0
+	}
+
+	inputModalities, outputModalities := openRouterModelModalities(model)
+	row.InputModalities = unionModalities(row.InputModalities, inputModalities)
+	row.OutputModalities = unionModalities(row.OutputModalities, imageOutputModalities(outputModalities))
+	if len(row.InputModalities) == 0 {
+		row.InputModalities = []string{"text"}
+	}
+	row.OutputModalities = unionModalities(row.OutputModalities, []string{"image"})
+	return true
+}
+
+func openRouterIsImageGenerationRow(row ModelConfigRow) bool {
+	modelID := strings.ToLower(strings.TrimSpace(row.ModelID))
+	if strings.HasPrefix(modelID, "gpt-image-") {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(row.PricingMode), "call") {
+		return true
+	}
+	for _, modality := range row.OutputModalities {
+		if strings.EqualFold(strings.TrimSpace(modality), "image") {
+			return true
+		}
+	}
+	return false
+}
+
+func imageOutputModalities(modalities []string) []string {
+	for _, modality := range modalities {
+		if strings.EqualFold(strings.TrimSpace(modality), "image") {
+			return []string{"image"}
+		}
+	}
+	return nil
 }
 
 func openRouterShouldSyncDescription(row ModelConfigRow) bool {
@@ -496,6 +563,32 @@ func openRouterSyncExistingAliasRows(baseModelID string, model OpenRouterRemoteM
 	return nil
 }
 
+func openRouterSyncExistingWrapperRows(baseModelID string, model OpenRouterRemoteModel) error {
+	for _, wrapperID := range openRouterWrapperModelIDs(baseModelID) {
+		existing, exists := GetModelConfig(wrapperID)
+		if !exists {
+			continue
+		}
+		existing.OwnedBy = "cline"
+		if description := openRouterModelDescription(model); description != "" && openRouterShouldSyncDescription(existing) {
+			existing.Description = description
+		}
+		openRouterApplyModelSyncValues(&existing, model)
+		if err := UpsertModelConfig(existing); err != nil {
+			return fmt.Errorf("sync openrouter model wrapper %s: %w", wrapperID, err)
+		}
+	}
+	return nil
+}
+
+func openRouterWrapperModelIDs(baseModelID string) []string {
+	baseModelID = strings.TrimSpace(baseModelID)
+	if baseModelID == "" || strings.Contains(baseModelID, "/") {
+		return nil
+	}
+	return []string{"cline-pass/" + baseModelID}
+}
+
 func openRouterStaticBaseModelRow(modelID string) (ModelConfigRow, bool) {
 	modelID = strings.TrimSpace(modelID)
 	if modelID == "" {
@@ -561,6 +654,7 @@ func openRouterMergeVariantGroups(models []OpenRouterRemoteModel) error {
 				continue
 			}
 		}
+		imageGenerationBase := openRouterIsImageGenerationRow(baseModel)
 		// Aggregate: highest prices, best description, most complete modalities.
 		bestInputPrice := baseModel.InputPricePerMillion
 		bestOutputPrice := baseModel.OutputPricePerMillion
@@ -589,15 +683,19 @@ func openRouterMergeVariantGroups(models []OpenRouterRemoteModel) error {
 			}
 			inMod, outMod := openRouterModelModalities(e.model)
 			bestModalities.input = unionModalities(bestModalities.input, inMod)
-			bestModalities.output = unionModalities(bestModalities.output, outMod)
+			if imageGenerationBase {
+				bestModalities.output = unionModalities(bestModalities.output, imageOutputModalities(outMod))
+			} else {
+				bestModalities.output = unionModalities(bestModalities.output, outMod)
+			}
 		}
 
 		// Apply the merged data back to the base model.
 		updated := false
 
-		if bestInputPrice != baseModel.InputPricePerMillion ||
+		if !imageGenerationBase && (bestInputPrice != baseModel.InputPricePerMillion ||
 			bestOutputPrice != baseModel.OutputPricePerMillion ||
-			bestCachedPrice != baseModel.CachedPricePerMillion {
+			bestCachedPrice != baseModel.CachedPricePerMillion) {
 			baseModel.PricingMode = "token"
 			baseModel.InputPricePerMillion = bestInputPrice
 			baseModel.OutputPricePerMillion = bestOutputPrice

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -106,6 +106,121 @@ func TestSyncOpenRouterModelsUpdatesExistingUserModelPricingOnly(t *testing.T) {
 	}
 }
 
+func TestSyncOpenRouterModelsPreservesImageGenerationCallPricingAndOutputModality(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	before, ok := GetModelConfig("gpt-image-2")
+	if !ok {
+		t.Fatal("expected gpt-image-2 seed config")
+	}
+	if before.PricingMode != "call" || before.PricePerCall <= 0 {
+		t.Fatalf("expected seeded gpt-image-2 call pricing, got %+v", before)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "openai/gpt-image-2",
+			Description: "Remote image model description",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality:         "text->text",
+				InputModalities:  []string{"text"},
+				OutputModalities: []string{"text"},
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000005",
+				Completion: "0.000020",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Added != 0 || result.Updated != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	after, ok := GetModelConfig("gpt-image-2")
+	if !ok {
+		t.Fatal("expected gpt-image-2 to remain configured")
+	}
+	if after.PricingMode != "call" || after.PricePerCall != before.PricePerCall {
+		t.Fatalf("image generation pricing should remain per-call, before=%+v after=%+v", before, after)
+	}
+	if after.InputPricePerMillion != 0 || after.OutputPricePerMillion != 0 || after.CachedPricePerMillion != 0 {
+		t.Fatalf("image generation model should not be converted to token pricing: %+v", after)
+	}
+	if !containsModality(after.OutputModalities, "image") {
+		t.Fatalf("image generation model should keep image output modality: %+v", after.OutputModalities)
+	}
+	if containsModality(after.OutputModalities, "text") {
+		t.Fatalf("image generation model should not inherit misleading text output modality: %+v", after.OutputModalities)
+	}
+	if cost := CalculateCost("gpt-image-2", 1_000_000, 1_000_000, 0); cost != before.PricePerCall {
+		t.Fatalf("expected CalculateCost to use per-call pricing %v, got %v", before.PricePerCall, cost)
+	}
+}
+
+func TestSyncOpenRouterModelsUpdatesExistingClinePassWrapperFromCanonicalModel(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "cline-pass/deepseek-v4-flash",
+		OwnedBy:     "cline",
+		Description: "",
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "seed",
+		InputModalities: []string{
+			"text",
+		},
+		OutputModalities: []string{
+			"text",
+		},
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "deepseek/deepseek-v4-flash",
+			Description: "DeepSeek V4 Flash from OpenRouter",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality:         "text+image->text",
+				InputModalities:  []string{"text", "image"},
+				OutputModalities: []string{"text"},
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.0000003",
+				Completion:     "0.0000012",
+				InputCacheRead: "0.00000003",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	model, ok := GetModelConfig("cline-pass/deepseek-v4-flash")
+	if !ok {
+		t.Fatal("expected existing cline-pass wrapper to remain configured")
+	}
+	if model.OwnedBy != "cline" || model.Source != "seed" {
+		t.Fatalf("cline wrapper identity should be preserved: %+v", model)
+	}
+	if model.Description != "DeepSeek V4 Flash from OpenRouter" {
+		t.Fatalf("cline wrapper should inherit remote description, got %q", model.Description)
+	}
+	if model.InputPricePerMillion != 0.3 || model.OutputPricePerMillion != 1.2 || model.CachedPricePerMillion != 0.03 {
+		t.Fatalf("cline wrapper should inherit canonical pricing: %+v", model)
+	}
+	if strings.Join(model.InputModalities, ",") != "text,image" || strings.Join(model.OutputModalities, ",") != "text" {
+		t.Fatalf("cline wrapper should inherit canonical modalities: %+v -> %+v", model.InputModalities, model.OutputModalities)
+	}
+}
+
 func TestSyncOpenRouterModelsUpdatesExistingOpenRouterDescription(t *testing.T) {
 	initModelConfigTestDB(t)
 
@@ -1023,4 +1138,13 @@ func TestUnionModalities(t *testing.T) {
 			}
 		})
 	}
+}
+
+func containsModality(modalities []string, expected string) bool {
+	for _, modality := range modalities {
+		if strings.EqualFold(strings.TrimSpace(modality), expected) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- seed Cline model configs so cline-pass wrappers are available in the model library
- preserve image-generation call pricing and image output modality during OpenRouter sync
- sync existing cline-pass wrapper rows from their canonical OpenRouter model metadata while preserving Cline ownership

## Tests
- rtk go test ./internal/usage ./internal/management/settings/modelconfig ./internal/management/modelcatalog
- rtk go test ./internal/api/handlers/management ./internal/storage/sqlite/modelconfig ./internal/registry