### PR TITLE
fix: backfill gpt image call pricing

### DIFF
--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -457,13 +457,16 @@ func openRouterApplyImageGenerationSemantics(row *ModelConfigRow, model OpenRout
 	row.InputPricePerMillion = 0
 	row.OutputPricePerMillion = 0
 	row.CachedPricePerMillion = 0
-	if row.PricePerCall < 0 {
-		row.PricePerCall = 0
+	if row.PricePerCall <= 0 {
+		row.PricePerCall = openRouterDefaultImageGenerationPricePerCall(row.ModelID)
 	}
 
 	inputModalities, outputModalities := openRouterModelModalities(model)
 	row.InputModalities = unionModalities(row.InputModalities, inputModalities)
-	row.OutputModalities = unionModalities(row.OutputModalities, imageOutputModalities(outputModalities))
+	row.OutputModalities = unionModalities(
+		imageOutputModalities(row.OutputModalities),
+		imageOutputModalities(outputModalities),
+	)
 	if len(row.InputModalities) == 0 {
 		row.InputModalities = []string{"text"}
 	}
@@ -485,6 +488,15 @@ func openRouterIsImageGenerationRow(row ModelConfigRow) bool {
 		}
 	}
 	return false
+}
+
+func openRouterDefaultImageGenerationPricePerCall(modelID string) float64 {
+	switch strings.ToLower(strings.TrimSpace(modelID)) {
+	case "gpt-image-2":
+		return 0.04
+	default:
+		return 0
+	}
 }
 
 func imageOutputModalities(modalities []string) []string {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -160,6 +160,58 @@ func TestSyncOpenRouterModelsPreservesImageGenerationCallPricingAndOutputModalit
 	}
 }
 
+func TestSyncOpenRouterModelsBackfillsImageGenerationDefaultCallPrice(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "gpt-image-2",
+		OwnedBy:               "codex",
+		Description:           "Previously corrupted image model",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  5,
+		OutputPricePerMillion: 20,
+		PricePerCall:          0,
+		Source:                "seed",
+		InputModalities:       []string{"text"},
+		OutputModalities:      []string{"text"},
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	_, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "openai/gpt-image-2",
+			Description: "Remote image model description",
+			Architecture: OpenRouterRemoteArchitecture{
+				InputModalities:  []string{"text"},
+				OutputModalities: []string{"text"},
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:     "0.000005",
+				Completion: "0.000020",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+
+	model, ok := GetModelConfig("gpt-image-2")
+	if !ok {
+		t.Fatal("expected gpt-image-2 config")
+	}
+	if model.PricingMode != "call" || model.PricePerCall != 0.04 {
+		t.Fatalf("expected gpt-image-2 default call pricing to be backfilled, got %+v", model)
+	}
+	if model.InputPricePerMillion != 0 || model.OutputPricePerMillion != 0 {
+		t.Fatalf("expected token pricing to be cleared, got %+v", model)
+	}
+	if !containsModality(model.OutputModalities, "image") || containsModality(model.OutputModalities, "text") {
+		t.Fatalf("expected image-only output modality, got %+v", model.OutputModalities)
+	}
+}
+
 func TestSyncOpenRouterModelsUpdatesExistingClinePassWrapperFromCanonicalModel(t *testing.T) {
 	initModelConfigTestDB(t)
 


### PR DESCRIPTION
## Summary
- backfill corrupted gpt-image-2 rows with the default per-call price when OpenRouter sync sees a zero call price
- keep image-generation output modalities image-only during OpenRouter sync
- cover the historical token-priced/image-text-output corruption case in tests

## Tests
- rtk go test ./internal/usage ./internal/management/settings/modelconfig ./internal/management/modelcatalog