### PR TITLE
fix: repair default image model seed pricing

### DIFF
--- a/internal/storage/sqlite/modelconfig/store.go
+++ b/internal/storage/sqlite/modelconfig/store.go
@@ -139,6 +139,7 @@ func InitTables(db *sql.DB) {
 	ensureOpenRouterModelSyncStateSchema(db)
 	seedDefaultModelConfigRows(db)
 	mergeLegacyPricingIntoModelConfigs(db)
+	repairDefaultPerCallModelConfigRows(db)
 	reloadModelConfigCache(db)
 	reloadModelOwnerPresetCache(db)
 	reloadAuthGroupOwnerMappingCache(db)
@@ -661,6 +662,53 @@ func mergeLegacyPricingIntoModelConfigs(db *sql.DB) {
 			row.cached,
 			now,
 		)
+	}
+}
+
+func repairDefaultPerCallModelConfigRows(db *sql.DB) {
+	now := nowRFC3339()
+	for _, row := range defaultModelConfigRows() {
+		if NormalizePricingMode(row.PricingMode) != "call" || row.PricePerCall <= 0 {
+			continue
+		}
+		inputModalities := encodeModelModalities(row.InputModalities)
+		outputModalities := encodeModelModalities(row.OutputModalities)
+		_, err := db.Exec(
+			`UPDATE model_configs
+			 SET input_modalities = ?,
+			     output_modalities = ?,
+			     pricing_mode = 'call',
+			     input_price_per_million = 0,
+			     output_price_per_million = 0,
+			     cached_price_per_million = 0,
+			     cache_read_price_per_million = 0,
+			     cache_write_price_per_million = 0,
+			     price_per_call = ?,
+			     updated_at = ?
+			 WHERE model_id = ?
+			   AND source IN ('seed', 'openrouter', 'legacy-pricing')
+			   AND (
+			     pricing_mode != 'call'
+			     OR input_price_per_million != 0
+			     OR output_price_per_million != 0
+			     OR cached_price_per_million != 0
+			     OR cache_read_price_per_million != 0
+			     OR cache_write_price_per_million != 0
+			     OR price_per_call <= 0
+			     OR input_modalities != ?
+			     OR output_modalities != ?
+			   )`,
+			inputModalities,
+			outputModalities,
+			row.PricePerCall,
+			now,
+			row.ModelID,
+			inputModalities,
+			outputModalities,
+		)
+		if err != nil {
+			log.Warnf("sqlite/modelconfig: repair default per-call model config %s: %v", row.ModelID, err)
+		}
 	}
 }
 

--- a/internal/usage/model_config_db_test.go
+++ b/internal/usage/model_config_db_test.go
@@ -66,6 +66,64 @@ func TestInitDBSeedsDefaultModelConfigs(t *testing.T) {
 	}
 }
 
+func TestInitDBRepairsCorruptedSeedImageModelConfig(t *testing.T) {
+	CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	CloseDB()
+
+	seedDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	seedDB.SetMaxOpenConns(1)
+	if _, err := seedDB.Exec(
+		`UPDATE model_configs
+		 SET pricing_mode = 'token',
+		     input_price_per_million = 5,
+		     output_price_per_million = 20,
+		     cached_price_per_million = 1,
+		     cache_read_price_per_million = 2,
+		     cache_write_price_per_million = 3,
+		     price_per_call = 0,
+		     input_modalities = '["text","image"]',
+		     output_modalities = '["text"]'
+		 WHERE model_id = 'gpt-image-2'`,
+	); err != nil {
+		t.Fatalf("corrupt gpt-image-2 seed row: %v", err)
+	}
+	if err := seedDB.Close(); err != nil {
+		t.Fatalf("close seed db: %v", err)
+	}
+
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(CloseDB)
+
+	imageModel, ok := GetModelConfig("gpt-image-2")
+	if !ok {
+		t.Fatal("expected gpt-image-2 to remain configured")
+	}
+	if imageModel.PricingMode != "call" || imageModel.PricePerCall != 0.04 {
+		t.Fatalf("expected gpt-image-2 call pricing to be repaired, got %+v", imageModel)
+	}
+	if imageModel.InputPricePerMillion != 0 || imageModel.OutputPricePerMillion != 0 || imageModel.CachedPricePerMillion != 0 {
+		t.Fatalf("expected token pricing to be cleared, got %+v", imageModel)
+	}
+	if imageModel.CacheReadPricePerMillion != 0 || imageModel.CacheWritePricePerMillion != 0 {
+		t.Fatalf("expected cache token pricing to be cleared, got %+v", imageModel)
+	}
+	if len(imageModel.InputModalities) != 1 || imageModel.InputModalities[0] != "text" {
+		t.Fatalf("expected text input modality, got %+v", imageModel.InputModalities)
+	}
+	if len(imageModel.OutputModalities) != 1 || imageModel.OutputModalities[0] != "image" {
+		t.Fatalf("expected image-only output modality, got %+v", imageModel.OutputModalities)
+	}
+}
+
 func TestUpsertModelConfigAndPerCallCost(t *testing.T) {
 	initModelConfigTestDB(t)
 


### PR DESCRIPTION
## Summary
- repair corrupted default per-call seed model configs during model config table initialization
- reset default image-generation seed models back to call pricing, zero token pricing, and image-only output without touching user-sourced rows
- add a restart-path regression test for a corrupted gpt-image-2 seed row

## Context
The previous dev deployment succeeded, and OpenRouter sync updated cline-pass/deepseek-v4-flash. However, the live gpt-image-2 row remained at price_per_call=0 because it was not touched by the OpenRouter remote list in that run. This patch repairs the seed row at startup instead of relying on OpenRouter to include it.

## Tests
- rtk go test ./internal/usage ./internal/management/settings/modelconfig ./internal/management/modelcatalog ./internal/storage/sqlite/modelconfig