### PR TITLE
fix: allow ccswitch mapped target model prefixes

### DIFF
--- a/internal/routing/scope.go
+++ b/internal/routing/scope.go
@@ -20,6 +20,10 @@ func PathRouteContextFromContext(ctx context.Context) *PathRouteContext {
 	return sdkrouting.PathRouteContextFromContext(ctx)
 }
 
+func IsCcSwitchMappedTargetModel(route *PathRouteContext, modelName string) bool {
+	return sdkrouting.IsCcSwitchMappedTargetModel(route, modelName)
+}
+
 func NormalizeGroupName(value string) string {
 	return sdkrouting.NormalizeGroupName(value)
 }

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -1054,7 +1054,7 @@ func (h *BaseAPIHandler) getRequestDetails(ctx context.Context, modelName string
 	baseModel := strings.TrimSpace(parsed.ModelName)
 	routeCtx := routeContextFromExecutionContext(ctx)
 	requestedPrefix, unprefixedModel := splitRequestedModelPrefix(baseModel)
-	if routeCtx != nil && routeCtx.Group != "" && requestedPrefix != "" && requestedPrefix != routeCtx.Group {
+	if routeCtx != nil && routeCtx.Group != "" && requestedPrefix != "" && requestedPrefix != routeCtx.Group && !internalrouting.IsCcSwitchMappedTargetModel(routeCtx, baseModel) {
 		return nil, "", &interfaces.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
 			Error:      fmt.Errorf(`{"error":{"message":"model prefix conflicts with route group","type":"invalid_request_error","code":"model_prefix_conflict"}}`),

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -215,6 +215,48 @@ func TestGetRequestDetails_RouteGroupRejectsConflictingModelPrefix(t *testing.T)
 	}
 }
 
+func TestGetRequestDetails_CcSwitchMappedTargetModelAllowsProviderPrefix(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	modelRegistry := registry.GetGlobalRegistry()
+	now := time.Now().Unix()
+	modelRegistry.RegisterClient("test-request-details-ccswitch-target", "deepseek", []*registry.ModelInfo{
+		{ID: "cline-pass/deepseek-v4-flash", Created: now},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient("test-request-details-ccswitch-target")
+	})
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, coreauth.NewManager(nil, nil, nil))
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Set(internalrouting.GinPathRouteContextKey, &internalrouting.PathRouteContext{
+		RoutePath: "/group1/cs_test",
+		Group:     "group1",
+		Fallback:  "none",
+		CcSwitch: &internalrouting.CcSwitchRouteContext{
+			ClientType: "claude",
+			ModelMappings: []internalrouting.CcSwitchModelMapping{
+				{
+					RequestModel: "claude-sonnet-5",
+					TargetModel:  "cline-pass/deepseek-v4-flash",
+				},
+			},
+		},
+	})
+	ctx := context.WithValue(context.Background(), util.ContextKeyGin, ginCtx)
+
+	providers, model, errMsg := handler.getRequestDetails(ctx, "cline-pass/deepseek-v4-flash")
+	if errMsg != nil {
+		t.Fatalf("getRequestDetails() unexpected error = %v", errMsg)
+	}
+	if !reflect.DeepEqual(providers, []string{"deepseek"}) {
+		t.Fatalf("providers = %v, want [deepseek]", providers)
+	}
+	if model != "cline-pass/deepseek-v4-flash" {
+		t.Fatalf("model = %q, want cline-pass/deepseek-v4-flash", model)
+	}
+}
+
 func TestRequestExecutionMetadata_UsesPathRouteContextFromRequestContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/requestdispatch/model_resolution.go
+++ b/sdk/requestdispatch/model_resolution.go
@@ -30,7 +30,7 @@ func ResolveRequestDetails(ctx context.Context, modelName string) (providers []s
 	baseModel := strings.TrimSpace(parsed.ModelName)
 	routeCtx := routeContextFromExecutionContext(ctx)
 	requestedPrefix, unprefixedModel := splitRequestedModelPrefix(baseModel)
-	if routeCtx != nil && routeCtx.Group != "" && requestedPrefix != "" && requestedPrefix != routeCtx.Group {
+	if routeCtx != nil && routeCtx.Group != "" && requestedPrefix != "" && requestedPrefix != routeCtx.Group && !sdkrouting.IsCcSwitchMappedTargetModel(routeCtx, baseModel) {
 		return nil, "", &sdklogging.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
 			Error: fmt.Errorf(

--- a/sdk/requestdispatch/model_resolution_test.go
+++ b/sdk/requestdispatch/model_resolution_test.go
@@ -1,0 +1,64 @@
+package requestdispatch
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	sdkrouting "github.com/router-for-me/CLIProxyAPI/v6/sdk/routing"
+)
+
+func TestResolveRequestDetails_RouteGroupRejectsConflictingModelPrefix(t *testing.T) {
+	ctx := sdkrouting.WithPathRouteContext(context.Background(), &sdkrouting.PathRouteContext{
+		RoutePath: "/pro",
+		Group:     "pro",
+		Fallback:  "none",
+	})
+
+	_, _, errMsg := ResolveRequestDetails(ctx, "free/gpt-5")
+	if errMsg == nil {
+		t.Fatal("expected model_prefix_conflict error")
+	}
+	if errMsg.StatusCode != 400 {
+		t.Fatalf("status = %d, want 400", errMsg.StatusCode)
+	}
+}
+
+func TestResolveRequestDetails_CcSwitchMappedTargetModelAllowsProviderPrefix(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	now := time.Now().Unix()
+	modelRegistry.RegisterClient("test-requestdispatch-ccswitch-target", "deepseek", []*registry.ModelInfo{
+		{ID: "cline-pass/deepseek-v4-flash", Created: now},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient("test-requestdispatch-ccswitch-target")
+	})
+
+	ctx := sdkrouting.WithPathRouteContext(context.Background(), &sdkrouting.PathRouteContext{
+		RoutePath: "/group1/cs_test",
+		Group:     "group1",
+		Fallback:  "none",
+		CcSwitch: &sdkrouting.CcSwitchRouteContext{
+			ClientType: "claude",
+			ModelMappings: []sdkrouting.CcSwitchModelMapping{
+				{
+					RequestModel: "claude-sonnet-5",
+					TargetModel:  "cline-pass/deepseek-v4-flash",
+				},
+			},
+		},
+	})
+
+	providers, model, errMsg := ResolveRequestDetails(ctx, "cline-pass/deepseek-v4-flash")
+	if errMsg != nil {
+		t.Fatalf("ResolveRequestDetails() unexpected error = %v", errMsg)
+	}
+	if !reflect.DeepEqual(providers, []string{"deepseek"}) {
+		t.Fatalf("providers = %v, want [deepseek]", providers)
+	}
+	if model != "cline-pass/deepseek-v4-flash" {
+		t.Fatalf("model = %q, want cline-pass/deepseek-v4-flash", model)
+	}
+}

--- a/sdk/routing/scope.go
+++ b/sdk/routing/scope.go
@@ -62,6 +62,19 @@ func PathRouteContextFromContext(ctx context.Context) *PathRouteContext {
 	return clonePathRouteContext(route)
 }
 
+func IsCcSwitchMappedTargetModel(route *PathRouteContext, modelName string) bool {
+	modelName = strings.TrimSpace(modelName)
+	if route == nil || route.CcSwitch == nil || modelName == "" {
+		return false
+	}
+	for _, mapping := range route.CcSwitch.ModelMappings {
+		if strings.TrimSpace(mapping.TargetModel) == modelName {
+			return true
+		}
+	}
+	return false
+}
+
 func clonePathRouteContext(route *PathRouteContext) *PathRouteContext {
 	if route == nil {
 		return nil


### PR DESCRIPTION
## Summary
- allow CC Switch mapped target models such as `cline-pass/deepseek-v4-flash` to pass route-group prefix validation
- keep normal conflicting route-group prefixes rejected outside configured CC Switch mappings
- cover both legacy handler request detail resolution and SDK requestdispatch resolution paths

## Tests
- `rtk go test ./sdk/api/handlers ./sdk/requestdispatch ./sdk/api/handlers/claude ./internal/api`
- `rtk go test ./...`