### PR TITLE
feat: add ClinePass vision fallback

### DIFF
--- a/internal/api/handlers/management/cline_config_test.go
+++ b/internal/api/handlers/management/cline_config_test.go
@@ -21,7 +21,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	h := &Handler{cfg: &config.Config{}, configFilePath: configPath}
 
-	putBody := []byte(`[{"api-key":" cline-key ","name":" primary ","prefix":" team ","base-url":" https://api.cline.bot/api/v1/ ","headers":{"X-Test":" yes "},"models":[{"name":" cline-pass/glm-5.2 "}],"excluded-models":[" cline-pass/minimax-m3 "]}]`)
+	putBody := []byte(`[{"api-key":" cline-key ","name":" primary ","prefix":" team ","base-url":" https://api.cline.bot/api/v1/ ","headers":{"X-Test":" yes "},"models":[{"name":" cline-pass/glm-5.2 "}],"excluded-models":[" cline-pass/minimax-m3 "],"vision-fallback-model":" cline-pass/mimo-v2.5-pro "}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/cline-api-key", bytes.NewReader(putBody))
@@ -38,8 +38,11 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/minimax-m3" {
 		t.Fatalf("ClineKey excluded models after PUT = %+v", h.cfg.ClineKey[0].ExcludedModels)
 	}
+	if h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
+		t.Fatalf("ClineKey vision fallback after PUT = %+v", h.cfg.ClineKey[0])
+	}
 
-	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"cline-pass/qwen3.7-max"}],"excluded-models":[" cline-pass/deepseek-v4-flash "]}}`)
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"cline-pass/qwen3.7-max"}],"excluded-models":[" cline-pass/deepseek-v4-flash "],"vision-fallback-model":" cline-pass/qwen3.7-vl "}}`)
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/cline-api-key", bytes.NewReader(patchBody))
@@ -47,7 +50,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/qwen3.7-max" || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" {
+	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/qwen3.7-max" || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
 		t.Fatalf("ClineKey after PATCH = %+v", h.cfg.ClineKey[0])
 	}
 
@@ -64,7 +67,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -281,6 +281,7 @@ func (cfg *Config) SanitizeClineKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeClineModels(entry.Models)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
 	cfg.ClineKey = out

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -302,6 +302,9 @@ type ClineKey struct {
 
 	// ExcludedModels lists model IDs that should be excluded for this provider.
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+
+	// VisionFallbackModel is used for image requests whose requested model lacks vision support.
+	VisionFallbackModel string `yaml:"vision-fallback-model,omitempty" json:"vision-fallback-model,omitempty"`
 }
 
 type ClineModel struct {

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -351,6 +351,7 @@ type ClinePatch struct {
 	Headers        *map[string]string   `json:"headers"`
 	Models         *[]config.ClineModel `json:"models"`
 	ExcludedModels *[]string            `json:"excluded-models"`
+	VisionFallback *string              `json:"vision-fallback-model"`
 }
 
 func (s *Service) ClineKeys() []config.ClineKey {
@@ -441,6 +442,9 @@ func (s *Service) PatchClineKey(index *int, apiKey *string, name *string, patch 
 	}
 	if patch.ExcludedModels != nil {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*patch.ExcludedModels)
+	}
+	if patch.VisionFallback != nil {
+		entry.VisionFallbackModel = strings.TrimSpace(*patch.VisionFallback)
 	}
 	NormalizeClineKey(&entry)
 	if entry.APIKey == "" {
@@ -578,6 +582,7 @@ func NormalizeClineKey(entry *config.ClineKey) {
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.Models = config.NormalizeClineModels(entry.Models)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 }
 
 func NormalizedClineKeyEntries(entries []config.ClineKey) []config.ClineKey {

--- a/internal/runtime/executor/openai_compat_cline_test.go
+++ b/internal/runtime/executor/openai_compat_cline_test.go
@@ -1,0 +1,57 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAICompatExecutorClineUsesVisionFallbackForImageRequests(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"cline-pass/mimo-v2.5-pro","choices":[{"index":0,"message":{"role":"assistant","content":"vision ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("cline", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":              server.URL + "/api/v1",
+		"api_key":               "test-key",
+		"vision_fallback_model": "cline-pass/mimo-v2.5-pro",
+	}}
+	payload := []byte(`{"model":"cline-pass/deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"what is this?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/deepseek-v4-flash",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotPath != "/api/v1/chat/completions" {
+		t.Fatalf("path = %q, want /api/v1/chat/completions", gotPath)
+	}
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "cline-pass/mimo-v2.5-pro" {
+		t.Fatalf("upstream model = %q, want cline-pass/mimo-v2.5-pro; body=%s", gotModel, string(gotBody))
+	}
+	if !strings.Contains(string(gotBody), `"image_url"`) {
+		t.Fatalf("image should be preserved for vision fallback model; body=%s", string(gotBody))
+	}
+	if gotModel := gjson.GetBytes(resp.Payload, "model").String(); gotModel != "cline-pass/deepseek-v4-flash" {
+		t.Fatalf("response model = %q, want cline-pass/deepseek-v4-flash; payload=%s", gotModel, string(resp.Payload))
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -69,6 +69,12 @@ func (e *OpenAICompatExecutor) HttpRequest(ctx context.Context, auth *cliproxyau
 }
 
 func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	fallback := opencodeGoVisionFallbackResult{Request: req}
+	if e.provider == "cline" {
+		fallback = applyVisionFallback(req, opts, clineVisionFallbackModel(e.cfg, auth))
+		req = fallback.Request
+	}
+
 	to := sdktranslator.FromString("openai")
 	endpoint := "/chat/completions"
 	if opts.Alt == "responses/compact" {
@@ -185,10 +191,19 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	var param any
 	out := sdktranslator.TranslateNonStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, body, &param)
 	resp = cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}
+	if fallback.Applied {
+		resp.Payload = opencodeGoRewriteFallbackResponseModel(resp.Payload, fallback.OriginalModel)
+	}
 	return resp, nil
 }
 
 func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	fallback := opencodeGoVisionFallbackResult{Request: req}
+	if e.provider == "cline" {
+		fallback = applyVisionFallback(req, opts, clineVisionFallbackModel(e.cfg, auth))
+		req = fallback.Request
+	}
+
 	to := sdktranslator.FromString("openai")
 	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
 		TargetFormat:      to,
@@ -319,7 +334,11 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		// Ensure we record the request if no usage chunk was ever seen
 		reporter.ensurePublished(execCtx.Context)
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	result := &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}
+	if fallback.Applied {
+		result = opencodeGoRewriteFallbackStreamResult(result, fallback.OriginalModel)
+	}
+	return result, nil
 }
 
 func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -250,11 +250,15 @@ type opencodeGoVisionFallbackResult struct {
 }
 
 func (e *OpenCodeGoExecutor) applyVisionFallback(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) opencodeGoVisionFallbackResult {
+	return applyVisionFallback(req, opts, opencodeGoVisionFallbackModel(e.cfg, auth))
+}
+
+func applyVisionFallback(req cliproxyexecutor.Request, opts cliproxyexecutor.Options, fallback string) opencodeGoVisionFallbackResult {
 	result := opencodeGoVisionFallbackResult{
 		Request:       req,
 		OriginalModel: payloadRequestedModel(opts, req.Model),
 	}
-	fallback := opencodeGoVisionFallbackModel(e.cfg, auth)
+	fallback = strings.TrimSpace(fallback)
 	if fallback == "" || !opencodeGoCurrentRequestHasImage(req.Payload) {
 		return result
 	}
@@ -274,6 +278,41 @@ func (e *OpenCodeGoExecutor) applyVisionFallback(auth *cliproxyauth.Auth, req cl
 	result.FallbackModel = fallback
 	result.Applied = true
 	return result
+}
+
+func clineVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if auth.Attributes != nil {
+		if fallback := strings.TrimSpace(auth.Attributes["vision_fallback_model"]); fallback != "" {
+			if opencodeGoModelExcluded(fallback, auth.Attributes["excluded_models"]) {
+				return ""
+			}
+			return fallback
+		}
+	}
+	if cfg == nil {
+		return ""
+	}
+	apiKey := ""
+	if auth.Attributes != nil {
+		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+	}
+	if apiKey == "" {
+		return ""
+	}
+	for i := range cfg.ClineKey {
+		entry := &cfg.ClineKey[i]
+		if strings.EqualFold(strings.TrimSpace(entry.APIKey), apiKey) {
+			fallback := strings.TrimSpace(entry.VisionFallbackModel)
+			if opencodeGoModelExcluded(fallback, strings.Join(entry.ExcludedModels, ",")) {
+				return ""
+			}
+			return fallback
+		}
+	}
+	return ""
 }
 
 func opencodeGoVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth) string {
@@ -607,10 +646,26 @@ func opencodeGoSupportsNativeVision(model string) bool {
 	if baseModel == "" {
 		return false
 	}
-	if _, ok := opencodeGoKnownNativeVisionModels[baseModel]; ok {
-		return true
+	for _, candidate := range opencodeGoVisionModelCandidates(baseModel) {
+		if _, ok := opencodeGoKnownNativeVisionModels[candidate]; ok {
+			return true
+		}
+		if opencodeGoModelNameImpliesVision(candidate) {
+			return true
+		}
 	}
-	return opencodeGoModelNameImpliesVision(baseModel)
+	return false
+}
+
+func opencodeGoVisionModelCandidates(model string) []string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+	if idx := strings.LastIndex(model, "/"); idx >= 0 && idx+1 < len(model) {
+		return []string{model, model[idx+1:]}
+	}
+	return []string{model}
 }
 
 func opencodeGoModelNameImpliesVision(model string) bool {
@@ -631,7 +686,12 @@ func opencodeGoModelNameImpliesVision(model string) bool {
 
 func opencodeGoDisablesThinkingForVisionFallback(model string) bool {
 	baseModel := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(model).ModelName))
-	return strings.HasPrefix(baseModel, "qwen")
+	for _, candidate := range opencodeGoVisionModelCandidates(baseModel) {
+		if strings.HasPrefix(candidate, "qwen") {
+			return true
+		}
+	}
+	return false
 }
 
 var opencodeGoFallbackModelFieldPaths = []string{

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -384,11 +384,14 @@ func (s *ConfigSynthesizer) synthesizeClineKeys(ctx *SynthesisContext) []*coreau
 			"source":       fmt.Sprintf("config:cline[%s]", token),
 			"api_key":      key,
 			"base_url":     base,
-			"compat_name":  "Cline",
+			"compat_name":  "ClinePass",
 			"provider_key": "cline",
 		}
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
+		}
+		if visionFallbackModel := strings.TrimSpace(entry.VisionFallbackModel); visionFallbackModel != "" {
+			attrs["vision_fallback_model"] = visionFallbackModel
 		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
 		label := strings.TrimSpace(entry.Name)

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -385,15 +385,16 @@ func TestConfigSynthesizer_ClineKeys(t *testing.T) {
 		Config: &config.Config{
 			ClineKey: []config.ClineKey{
 				{
-					APIKey:         "cline-key",
-					Name:           "cline",
-					Priority:       7,
-					Prefix:         "team",
-					BaseURL:        "https://api.cline.bot/api/v1/",
-					ProxyURL:       "http://proxy",
-					ProxyID:        "hk",
-					Headers:        map[string]string{"X-Test": "yes"},
-					ExcludedModels: []string{"cline-pass/minimax-m3"},
+					APIKey:              "cline-key",
+					Name:                "cline",
+					Priority:            7,
+					Prefix:              "team",
+					BaseURL:             "https://api.cline.bot/api/v1/",
+					ProxyURL:            "http://proxy",
+					ProxyID:             "hk",
+					Headers:             map[string]string{"X-Test": "yes"},
+					ExcludedModels:      []string{"cline-pass/minimax-m3"},
+					VisionFallbackModel: "cline-pass/mimo-v2.5-pro",
 				},
 			},
 		},
@@ -412,7 +413,7 @@ func TestConfigSynthesizer_ClineKeys(t *testing.T) {
 	if auth.Provider != "cline" || auth.Label != "cline" || auth.Prefix != "team" {
 		t.Fatalf("unexpected auth identity: %+v", auth)
 	}
-	if auth.Attributes["api_key"] != "cline-key" || auth.Attributes["base_url"] != config.DefaultClineBaseURL || auth.Attributes["provider_key"] != "cline" || auth.Attributes["compat_name"] != "Cline" {
+	if auth.Attributes["api_key"] != "cline-key" || auth.Attributes["base_url"] != config.DefaultClineBaseURL || auth.Attributes["provider_key"] != "cline" || auth.Attributes["compat_name"] != "ClinePass" {
 		t.Fatalf("unexpected attrs: %#v", auth.Attributes)
 	}
 	if auth.Attributes["priority"] != "7" || auth.Attributes["header:X-Test"] != "yes" {
@@ -423,6 +424,9 @@ func TestConfigSynthesizer_ClineKeys(t *testing.T) {
 	}
 	if auth.Attributes["auth_kind"] != "apikey" || auth.Attributes["excluded_models"] != "cline-pass/minimax-m3" {
 		t.Fatalf("expected api key exclusion metadata, got %#v", auth.Attributes)
+	}
+	if auth.Attributes["vision_fallback_model"] != "cline-pass/mimo-v2.5-pro" {
+		t.Fatalf("expected vision fallback metadata, got %#v", auth.Attributes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- rename Cline-facing metadata to ClinePass
- add ClinePass vision fallback model config
- reuse OpenCode Go image fallback request and response model rewrite logic

## Tests
- rtk go test ./internal/config ./internal/watcher/synthesizer ./internal/runtime/executor ./internal/management/settings/providers ./internal/api/handlers/management