### PR TITLE
fix: separate vision fallback model logs

### DIFF
--- a/internal/runtime/executor/execution_context.go
+++ b/internal/runtime/executor/execution_context.go
@@ -107,6 +107,37 @@ type ExecutionContext struct {
 	recorder      UpstreamRecorder
 }
 
+type visionFallbackLogContextKey struct{}
+
+type visionFallbackLogInfo struct {
+	RequestedModel string
+	UpstreamModel  string
+	FallbackModel  string
+}
+
+func contextWithVisionFallbackLog(ctx context.Context, requestedModel, upstreamModel, fallbackModel string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	info := visionFallbackLogInfo{
+		RequestedModel: strings.TrimSpace(requestedModel),
+		UpstreamModel:  strings.TrimSpace(upstreamModel),
+		FallbackModel:  strings.TrimSpace(fallbackModel),
+	}
+	if info.FallbackModel == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, visionFallbackLogContextKey{}, info)
+}
+
+func visionFallbackLogFromContext(ctx context.Context) visionFallbackLogInfo {
+	if ctx == nil {
+		return visionFallbackLogInfo{}
+	}
+	info, _ := ctx.Value(visionFallbackLogContextKey{}).(visionFallbackLogInfo)
+	return info
+}
+
 func newExecutionContext(
 	ctx context.Context,
 	provider string,
@@ -148,7 +179,13 @@ func (ec *ExecutionContext) Reporter() *usageReporter {
 	if strings.TrimSpace(model) == "" {
 		model = ec.BaseModel
 	}
-	return newUsageReporter(ec.Context, ec.Provider, model, ec.BaseModel, ec.Auth)
+	reporter := newUsageReporter(ec.Context, ec.Provider, model, ec.BaseModel, ec.Auth)
+	if fallback := visionFallbackLogFromContext(ec.Context); fallback.FallbackModel != "" {
+		reporter.setModel(fallback.RequestedModel)
+		reporter.setUpstreamModel(fallback.UpstreamModel)
+		reporter.setVisionFallbackModel(fallback.FallbackModel)
+	}
+	return reporter
 }
 
 func (ec *ExecutionContext) HTTPClient(timeout time.Duration) *http.Client {

--- a/internal/runtime/executor/execution_context_test.go
+++ b/internal/runtime/executor/execution_context_test.go
@@ -58,6 +58,34 @@ func TestExecutionContextUsesOriginalRequestAndRequestedModel(t *testing.T) {
 	}
 }
 
+func TestExecutionContextReporterKeepsVisionFallbackSeparateFromModelMapping(t *testing.T) {
+	ctx := contextWithVisionFallbackLog(context.Background(), "alias-model", "real-model", "vision-model")
+	req := cliproxyexecutor.Request{
+		Model:   "vision-model",
+		Payload: []byte(`{"messages":[]}`),
+	}
+	execCtx := newExecutionContext(
+		ctx,
+		"openai-compatibility",
+		&config.Config{},
+		nil,
+		req,
+		cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")},
+		ExecutionOptions{TargetFormat: sdktranslator.FromString("openai")},
+	)
+
+	reporter := execCtx.Reporter()
+	if reporter.model != "alias-model" {
+		t.Fatalf("reporter.model = %q, want alias-model", reporter.model)
+	}
+	if reporter.upstreamModel != "real-model" {
+		t.Fatalf("reporter.upstreamModel = %q, want real-model", reporter.upstreamModel)
+	}
+	if reporter.visionFallbackModel != "vision-model" {
+		t.Fatalf("reporter.visionFallbackModel = %q, want vision-model", reporter.visionFallbackModel)
+	}
+}
+
 func TestExecutionContextApplyPayloadConfigUsesProtocolOverride(t *testing.T) {
 	cfg := &config.Config{
 		Payload: config.PayloadConfig{

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -71,7 +71,12 @@ func (e *OpenAICompatExecutor) HttpRequest(ctx context.Context, auth *cliproxyau
 func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	fallback := opencodeGoVisionFallbackResult{Request: req}
 	if e.provider == "cline" {
+		originalRequestedModel := payloadRequestedModel(opts, req.Model)
+		originalUpstreamModel := thinking.ParseSuffix(req.Model).ModelName
 		fallback = applyVisionFallback(req, opts, clineVisionFallbackModel(e.cfg, auth))
+		if fallback.Applied {
+			ctx = contextWithVisionFallbackLog(ctx, originalRequestedModel, originalUpstreamModel, fallback.FallbackModel)
+		}
 		req = fallback.Request
 	}
 
@@ -200,7 +205,12 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	fallback := opencodeGoVisionFallbackResult{Request: req}
 	if e.provider == "cline" {
+		originalRequestedModel := payloadRequestedModel(opts, req.Model)
+		originalUpstreamModel := thinking.ParseSuffix(req.Model).ModelName
 		fallback = applyVisionFallback(req, opts, clineVisionFallbackModel(e.cfg, auth))
+		if fallback.Applied {
+			ctx = contextWithVisionFallbackLog(ctx, originalRequestedModel, originalUpstreamModel, fallback.FallbackModel)
+		}
 		req = fallback.Request
 	}
 

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -89,7 +89,12 @@ func (e *OpenCodeGoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Aut
 	// Vision fallback: if the current message has new images and the
 	// model doesn't natively support vision, route to the configured
 	// vision model for direct image analysis.
+	originalRequestedModel := payloadRequestedModel(opts, req.Model)
+	originalUpstreamModel := thinking.ParseSuffix(req.Model).ModelName
 	fallback := e.applyVisionFallback(auth, req, opts)
+	if fallback.Applied {
+		ctx = contextWithVisionFallbackLog(ctx, originalRequestedModel, originalUpstreamModel, fallback.FallbackModel)
+	}
 	req = fallback.Request
 
 	// A3: If the current turn still has images and no vision fallback was applied,
@@ -164,7 +169,12 @@ func (e *OpenCodeGoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyau
 	// Vision fallback: if the current message has new images and the
 	// model doesn't natively support vision, route to the configured
 	// vision model for direct image analysis.
+	originalRequestedModel := payloadRequestedModel(opts, req.Model)
+	originalUpstreamModel := thinking.ParseSuffix(req.Model).ModelName
 	fallback := e.applyVisionFallback(auth, req, opts)
+	if fallback.Applied {
+		ctx = contextWithVisionFallbackLog(ctx, originalRequestedModel, originalUpstreamModel, fallback.FallbackModel)
+	}
 	req = fallback.Request
 
 	// A3: If the current turn still has images and no vision fallback was applied,

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -18,20 +18,21 @@ import (
 const usageReporterOutputMemoryLimit = 256 * 1024
 
 type usageReporter struct {
-	provider      string
-	model         string
-	upstreamModel string
-	authID        string
-	authIndex     string
-	authSubjectID string
-	apiKey        string
-	apiKeyID      string
-	apiKeyName    string
-	source        string
-	channelName   string
-	requestedAt   time.Time
-	once          sync.Once
-	contentMu     sync.Mutex
+	provider            string
+	model               string
+	upstreamModel       string
+	visionFallbackModel string
+	authID              string
+	authIndex           string
+	authSubjectID       string
+	apiKey              string
+	apiKeyID            string
+	apiKeyName          string
+	source              string
+	channelName         string
+	requestedAt         time.Time
+	once                sync.Once
+	contentMu           sync.Mutex
 
 	// Content captured for log detail viewer
 	inputContent  string
@@ -87,6 +88,24 @@ func (r *usageReporter) setModel(model string) {
 	}
 	if model = strings.TrimSpace(model); model != "" {
 		r.model = model
+	}
+}
+
+func (r *usageReporter) setUpstreamModel(model string) {
+	if r == nil {
+		return
+	}
+	if model = strings.TrimSpace(model); model != "" {
+		r.upstreamModel = model
+	}
+}
+
+func (r *usageReporter) setVisionFallbackModel(model string) {
+	if r == nil {
+		return
+	}
+	if model = strings.TrimSpace(model); model != "" {
+		r.visionFallbackModel = model
 	}
 }
 
@@ -238,25 +257,26 @@ func (r *usageReporter) publishWithOutcome(ctx context.Context, detail coreusage
 		}
 		firstTokenMs := firstTokenLatencyMsFromContext(ctx, r.requestedAt)
 		coreusage.PublishRecord(ctx, coreusage.Record{
-			Provider:      r.provider,
-			Model:         r.model,
-			UpstreamModel: r.upstreamModel,
-			Source:        r.source,
-			ChannelName:   r.channelName,
-			APIKey:        r.apiKey,
-			APIKeyID:      r.apiKeyID,
-			APIKeyName:    r.apiKeyName,
-			AuthID:        r.authID,
-			AuthIndex:     r.authIndex,
-			AuthSubjectID: r.authSubjectID,
-			RequestedAt:   r.requestedAt,
-			LatencyMs:     latencyMs,
-			FirstTokenMs:  firstTokenMs,
-			Failed:        failed,
-			Detail:        detail,
-			InputContent:  inputContent,
-			OutputContent: outputContent,
-			DetailContent: buildRequestDetailContent(ctx),
+			Provider:            r.provider,
+			Model:               r.model,
+			UpstreamModel:       r.upstreamModel,
+			VisionFallbackModel: r.visionFallbackModel,
+			Source:              r.source,
+			ChannelName:         r.channelName,
+			APIKey:              r.apiKey,
+			APIKeyID:            r.apiKeyID,
+			APIKeyName:          r.apiKeyName,
+			AuthID:              r.authID,
+			AuthIndex:           r.authIndex,
+			AuthSubjectID:       r.authSubjectID,
+			RequestedAt:         r.requestedAt,
+			LatencyMs:           latencyMs,
+			FirstTokenMs:        firstTokenMs,
+			Failed:              failed,
+			Detail:              detail,
+			InputContent:        inputContent,
+			OutputContent:       outputContent,
+			DetailContent:       buildRequestDetailContent(ctx),
 		})
 	})
 }
@@ -277,24 +297,26 @@ func (r *usageReporter) ensurePublished(ctx context.Context) {
 		}
 		firstTokenMs := firstTokenLatencyMsFromContext(ctx, r.requestedAt)
 		coreusage.PublishRecord(ctx, coreusage.Record{
-			Provider:      r.provider,
-			Model:         r.model,
-			Source:        r.source,
-			ChannelName:   r.channelName,
-			APIKey:        r.apiKey,
-			APIKeyID:      r.apiKeyID,
-			APIKeyName:    r.apiKeyName,
-			AuthID:        r.authID,
-			AuthIndex:     r.authIndex,
-			AuthSubjectID: r.authSubjectID,
-			RequestedAt:   r.requestedAt,
-			LatencyMs:     latencyMs,
-			FirstTokenMs:  firstTokenMs,
-			Failed:        false,
-			Detail:        coreusage.Detail{},
-			InputContent:  inputContent,
-			OutputContent: outputContent,
-			DetailContent: buildRequestDetailContent(ctx),
+			Provider:            r.provider,
+			Model:               r.model,
+			UpstreamModel:       r.upstreamModel,
+			VisionFallbackModel: r.visionFallbackModel,
+			Source:              r.source,
+			ChannelName:         r.channelName,
+			APIKey:              r.apiKey,
+			APIKeyID:            r.apiKeyID,
+			APIKeyName:          r.apiKeyName,
+			AuthID:              r.authID,
+			AuthIndex:           r.authIndex,
+			AuthSubjectID:       r.authSubjectID,
+			RequestedAt:         r.requestedAt,
+			LatencyMs:           latencyMs,
+			FirstTokenMs:        firstTokenMs,
+			Failed:              false,
+			Detail:              coreusage.Detail{},
+			InputContent:        inputContent,
+			OutputContent:       outputContent,
+			DetailContent:       buildRequestDetailContent(ctx),
 		})
 	})
 }

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -362,7 +362,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 			apiKeyName = row.Name
 		}
 	}
-	InsertLogWithDetailsIdentitySubjectUpstream(statsKey, apiKeyID, record.AuthSubjectID, apiKeyName, modelName, record.UpstreamModel, record.Source, record.ChannelName,
+	InsertLogWithDetailsIdentitySubjectUpstreamVision(statsKey, apiKeyID, record.AuthSubjectID, apiKeyName, modelName, record.UpstreamModel, record.VisionFallbackModel, record.Source, record.ChannelName,
 		record.AuthIndex, failed, timestamp, record.LatencyMs, record.FirstTokenMs, detail,
 		record.InputContent, record.OutputContent, record.DetailContent)
 }

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -50,7 +50,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 
 	// Fetch page
 	offset := (params.Page - 1) * params.Size
-	querySQL := "SELECT id, timestamp, api_key, api_key_name, model, upstream_model, source, channel_name, auth_index, " +
+	querySQL := "SELECT id, timestamp, api_key, api_key_name, model, upstream_model, vision_fallback_model, source, channel_name, auth_index, " +
 		"failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, " +
 		"cost, " +
 		"(CASE WHEN EXISTS (SELECT 1 FROM request_log_content content WHERE content.log_id = request_logs.id) " +
@@ -72,7 +72,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		var ts string
 		var failedInt, streamingInt, hasContentInt int
 		if err := rows.Scan(
-			&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.UpstreamModel, &row.Source, &row.ChannelName,
+			&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.UpstreamModel, &row.VisionFallbackModel, &row.Source, &row.ChannelName,
 			&row.AuthIndex, &failedInt, &streamingInt, &row.LatencyMs, &row.FirstTokenMs,
 			&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
 			&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -16,26 +16,27 @@ import (
 
 // LogRow represents a single request log entry returned by QueryLogs.
 type LogRow struct {
-	ID              int64     `json:"id"`
-	Timestamp       time.Time `json:"timestamp"`
-	APIKey          string    `json:"api_key"`
-	APIKeyName      string    `json:"api_key_name"`
-	Model           string    `json:"model"`
-	UpstreamModel   string    `json:"upstream_model,omitempty"`
-	Source          string    `json:"source"`
-	ChannelName     string    `json:"channel_name"`
-	AuthIndex       string    `json:"auth_index"`
-	Failed          bool      `json:"failed"`
-	Streaming       bool      `json:"streaming"`
-	LatencyMs       int64     `json:"latency_ms"`
-	FirstTokenMs    int64     `json:"first_token_ms"`
-	InputTokens     int64     `json:"input_tokens"`
-	OutputTokens    int64     `json:"output_tokens"`
-	ReasoningTokens int64     `json:"reasoning_tokens"`
-	CachedTokens    int64     `json:"cached_tokens"`
-	TotalTokens     int64     `json:"total_tokens"`
-	Cost            float64   `json:"cost"`
-	HasContent      bool      `json:"has_content"`
+	ID                  int64     `json:"id"`
+	Timestamp           time.Time `json:"timestamp"`
+	APIKey              string    `json:"api_key"`
+	APIKeyName          string    `json:"api_key_name"`
+	Model               string    `json:"model"`
+	UpstreamModel       string    `json:"upstream_model,omitempty"`
+	VisionFallbackModel string    `json:"vision_fallback_model,omitempty"`
+	Source              string    `json:"source"`
+	ChannelName         string    `json:"channel_name"`
+	AuthIndex           string    `json:"auth_index"`
+	Failed              bool      `json:"failed"`
+	Streaming           bool      `json:"streaming"`
+	LatencyMs           int64     `json:"latency_ms"`
+	FirstTokenMs        int64     `json:"first_token_ms"`
+	InputTokens         int64     `json:"input_tokens"`
+	OutputTokens        int64     `json:"output_tokens"`
+	ReasoningTokens     int64     `json:"reasoning_tokens"`
+	CachedTokens        int64     `json:"cached_tokens"`
+	TotalTokens         int64     `json:"total_tokens"`
+	Cost                float64   `json:"cost"`
+	HasContent          bool      `json:"has_content"`
 }
 
 // LogQueryParams holds filter/pagination parameters for QueryLogs.
@@ -127,6 +128,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
   auth_subject_id  TEXT NOT NULL DEFAULT '',
   model            TEXT NOT NULL DEFAULT '',
   upstream_model   TEXT NOT NULL DEFAULT '',
+  vision_fallback_model TEXT NOT NULL DEFAULT '',
   source           TEXT NOT NULL DEFAULT '',
   channel_name     TEXT NOT NULL DEFAULT '',
   auth_index       TEXT NOT NULL DEFAULT '',
@@ -247,6 +249,15 @@ func migrateUpstreamModelColumn(db *sql.DB) {
 	if err != nil {
 		if !strings.Contains(err.Error(), "duplicate") {
 			log.Warnf("usage: migrate column upstream_model: %v", err)
+		}
+	}
+}
+
+func migrateVisionFallbackModelColumn(db *sql.DB) {
+	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN vision_fallback_model TEXT NOT NULL DEFAULT ''")
+	if err != nil {
+		if !strings.Contains(err.Error(), "duplicate") {
+			log.Warnf("usage: migrate column vision_fallback_model: %v", err)
 		}
 	}
 }
@@ -439,6 +450,8 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	migrateApiKeyNameColumn(db)
 	log.Debugf("usage: running upstream_model column migration")
 	migrateUpstreamModelColumn(db)
+	log.Debugf("usage: running vision_fallback_model column migration")
+	migrateVisionFallbackModelColumn(db)
 	log.Debugf("usage: running api_key_id column migration")
 	migrateAPIKeyIDColumn(db)
 	log.Debugf("usage: running auth_subject_id column migration")
@@ -499,34 +512,40 @@ func CloseDB() {
 func InsertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent string) {
-	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "")
+	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "")
 }
 
 func InsertLogWithDetails(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
 }
 
 func InsertLogWithDetailsIdentity(apiKey, apiKeyID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, "", apiKeyName, model, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, apiKeyID, "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
 }
 
 func InsertLogWithDetailsIdentitySubject(apiKey, apiKeyID, authSubjectID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
 }
 
 func InsertLogWithDetailsIdentitySubjectUpstream(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
 }
 
-func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, source, channelName, authIndex string,
+func InsertLogWithDetailsIdentitySubjectUpstreamVision(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
+	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
+	inputContent, outputContent, detailContent string) {
+	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+}
+
+func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
 	db := getDB()
@@ -550,6 +569,7 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstr
 	authSubjectID = strings.TrimSpace(authSubjectID)
 	apiKeyName = strings.TrimSpace(apiKeyName)
 	upstreamModel = strings.TrimSpace(upstreamModel)
+	visionFallbackModel = strings.TrimSpace(visionFallbackModel)
 	if identity := ResolveAPIKeyIdentity(apiKey); identity != nil {
 		if apiKeyID == "" {
 			apiKeyID = identity.ID
@@ -569,11 +589,11 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstr
 
 	result, err := tx.Exec(
 		`INSERT INTO request_logs
-			(timestamp, api_key, api_key_id, auth_subject_id, api_key_name, model, upstream_model, source, channel_name, auth_index,
+			(timestamp, api_key, api_key_id, auth_subject_id, api_key_name, model, upstream_model, vision_fallback_model, source, channel_name, auth_index,
 			 failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		timestamp.UTC().Format(time.RFC3339Nano),
-		apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, source, channelName, authIndex,
+		apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex,
 		failedInt, streamingInt, latencyMs, firstTokenMs,
 		tokens.InputTokens, tokens.OutputTokens, tokens.ReasoningTokens,
 		tokens.CachedTokens, tokens.TotalTokens, cost,

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -482,6 +482,50 @@ func TestQueryLogsSupportsExplicitEmptyMultiSelectFilters(t *testing.T) {
 	}
 }
 
+func TestQueryLogsReturnsVisionFallbackModelSeparately(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentitySubjectUpstreamVision(
+		"sk-live-123",
+		"key-1",
+		"subject-1",
+		"Primary",
+		"alias-model",
+		"real-model",
+		"vision-model",
+		"codex",
+		"Codex",
+		"auth-1",
+		false,
+		now,
+		140,
+		14,
+		TokenStats{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
+		"",
+		"",
+		"",
+	)
+
+	result, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() error = %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(result.Items))
+	}
+	row := result.Items[0]
+	if row.Model != "alias-model" {
+		t.Fatalf("Model = %q, want alias-model", row.Model)
+	}
+	if row.UpstreamModel != "real-model" {
+		t.Fatalf("UpstreamModel = %q, want real-model", row.UpstreamModel)
+	}
+	if row.VisionFallbackModel != "vision-model" {
+		t.Fatalf("VisionFallbackModel = %q, want vision-model", row.VisionFallbackModel)
+	}
+}
+
 func TestQueryLogContentKeepsMissingFailedOutputEmpty(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,
@@ -612,7 +656,7 @@ func TestInitDBMigratesFirstTokenAndStreamingColumns(t *testing.T) {
 		if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &pk); err != nil {
 			t.Fatalf("scan table info: %v", err)
 		}
-		if name == "first_token_ms" || name == "streaming" {
+		if name == "first_token_ms" || name == "streaming" || name == "vision_fallback_model" {
 			found[name] = true
 		}
 	}
@@ -621,6 +665,9 @@ func TestInitDBMigratesFirstTokenAndStreamingColumns(t *testing.T) {
 	}
 	if !found["streaming"] {
 		t.Fatalf("expected streaming column to exist after InitDB migration")
+	}
+	if !found["vision_fallback_model"] {
+		t.Fatalf("expected vision_fallback_model column to exist after InitDB migration")
 	}
 }
 

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -10,22 +10,23 @@ import (
 
 // Record contains the usage statistics captured for a single provider request.
 type Record struct {
-	Provider      string
-	Model         string
-	UpstreamModel string
-	APIKey        string
-	APIKeyID      string
-	APIKeyName    string
-	AuthID        string
-	AuthIndex     string
-	AuthSubjectID string
-	Source        string
-	ChannelName   string
-	RequestedAt   time.Time
-	LatencyMs     int64
-	FirstTokenMs  int64
-	Failed        bool
-	Detail        Detail
+	Provider            string
+	Model               string
+	UpstreamModel       string
+	VisionFallbackModel string
+	APIKey              string
+	APIKeyID            string
+	APIKeyName          string
+	AuthID              string
+	AuthIndex           string
+	AuthSubjectID       string
+	Source              string
+	ChannelName         string
+	RequestedAt         time.Time
+	LatencyMs           int64
+	FirstTokenMs        int64
+	Failed              bool
+	Detail              Detail
 
 	// Optional: request/response content for log detail viewer.
 	// These are stored in SQLite when non-empty and can be retrieved via the


### PR DESCRIPTION
## Summary\n- store vision fallback model in a dedicated request log field\n- keep requested model and upstream model mapping separate when fallback rewrites the execution model\n- add usage/query and execution context regression tests\n\n## Verification\n- rtk go test ./internal/runtime/executor ./internal/usage