### PR TITLE
fix: harden audit remediation baseline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,8 @@ management.html
 panel-meta.json
 dist/
 panel-dist.zip
+cli-proxy-api
+CLIProxyAPI
 
 # Development/editor
 bin/*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,14 +9,17 @@ linters:
     - gosimple
     - ineffassign
     - staticcheck
+    - bodyclose
 
 issues:
-  exclude-dirs:
-    - internal/translator
   exclude-rules:
     # "alt" is a legacy cross-package context key also consumed by translator code.
     # We keep the string key for compatibility and suppress SA1029 for now.
     - path: internal/runtime/executor/.*
+      text: "SA1029"
+      linters:
+        - staticcheck
+    - path: internal/translator/.*_test\.go
       text: "SA1029"
       linters:
         - staticcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,13 +77,16 @@ FROM alpine:3.22.0
 
 RUN apk add --no-cache tzdata ca-certificates docker-cli docker-cli-compose
 
-RUN mkdir -p /CLIProxyAPI/panel
+RUN addgroup -S -g 10001 clirelay \
+  && adduser -S -D -H -u 10001 -h /CLIProxyAPI -s /sbin/nologin -G clirelay clirelay \
+  && mkdir -p /CLIProxyAPI/panel /CLIProxyAPI/auths /CLIProxyAPI/logs /CLIProxyAPI/data \
+  && chown -R clirelay:clirelay /CLIProxyAPI
 
-COPY --from=backend-builder /app/CLIProxyAPI /CLIProxyAPI/CLIProxyAPI
-COPY --from=backend-builder /app/clirelay-updater /CLIProxyAPI/clirelay-updater
-COPY --from=frontend-builder /frontend/dist/ /CLIProxyAPI/panel/
+COPY --from=backend-builder --chown=clirelay:clirelay /app/CLIProxyAPI /CLIProxyAPI/CLIProxyAPI
+COPY --from=backend-builder --chown=clirelay:clirelay /app/clirelay-updater /CLIProxyAPI/clirelay-updater
+COPY --from=frontend-builder --chown=clirelay:clirelay /frontend/dist/ /CLIProxyAPI/panel/
 
-COPY config.example.yaml /CLIProxyAPI/config.example.yaml
+COPY --chown=clirelay:clirelay config.example.yaml /CLIProxyAPI/config.example.yaml
 
 WORKDIR /CLIProxyAPI
 
@@ -91,8 +94,14 @@ EXPOSE 8317
 
 ENV TZ=Asia/Shanghai \
     MANAGEMENT_PANEL_DIR=/CLIProxyAPI/panel \
+    AUTH_PATH=/CLIProxyAPI/auths \
     CLIRELAY_LOCALE=zh
 
 RUN cp /usr/share/zoneinfo/${TZ} /etc/localtime && echo "${TZ}" > /etc/timezone
+
+USER clirelay
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -q -T 2 -O /dev/null http://127.0.0.1:8317/healthz
 
 CMD ["./CLIProxyAPI"]

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ Docker Compose is the recommended installation path for CliRelay. The included `
 git clone https://github.com/kittors/CliRelay.git
 cd CliRelay
 cp config.example.yaml config.yaml
+mkdir -p auths logs data
+# Linux bind mounts need write access for the non-root container user:
+# sudo chown -R 10001:10001 auths logs data
 docker compose up -d
 ```
 

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -9,11 +9,14 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -23,6 +26,7 @@ const (
 	defaultEnvFile       = ""
 	defaultTargetService = "clirelay"
 	updateCommandTimeout = 10 * time.Minute
+	shutdownTimeout      = 10 * time.Second
 	maxUpdateLogEntries  = 200
 )
 
@@ -43,6 +47,7 @@ type updaterConfig struct {
 	ProjectName    string
 	DefaultService string
 	Runner         composeRunner
+	Context        context.Context
 }
 
 type updaterServer struct {
@@ -57,6 +62,7 @@ type updaterServer struct {
 	status         updateStatusResponse
 	pullSkipped    bool
 	pullSkipLog    string
+	ctx            context.Context
 }
 
 type updateLogEntry struct {
@@ -95,7 +101,20 @@ type updateRequest struct {
 }
 
 func main() {
-	cfg := updaterConfig{
+	if err := run(); err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return runUpdater(ctx, updaterConfigFromEnv())
+}
+
+func updaterConfigFromEnv() updaterConfig {
+	return updaterConfig{
 		Addr:           envOrDefault("CLIRELAY_UPDATER_ADDR", defaultListenAddr),
 		Token:          strings.TrimSpace(os.Getenv("CLIRELAY_UPDATER_TOKEN")),
 		ComposeFile:    envOrDefault("CLIRELAY_COMPOSE_FILE", defaultComposeFile),
@@ -104,6 +123,25 @@ func main() {
 		DefaultService: envOrDefault("CLIRELAY_TARGET_SERVICE", defaultTargetService),
 		Runner:         runComposeUpdate,
 	}
+}
+
+func runUpdater(ctx context.Context, cfg updaterConfig) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	addr := envOrDefaultValue(cfg.Addr, defaultListenAddr)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("clirelay updater: listen on %s failed: %w", addr, err)
+	}
+	return serveUpdater(ctx, cfg, listener)
+}
+
+func serveUpdater(ctx context.Context, cfg updaterConfig, listener net.Listener) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg.Context = ctx
 	server := newUpdaterServer(cfg)
 
 	mux := http.NewServeMux()
@@ -111,9 +149,34 @@ func main() {
 	mux.HandleFunc("/v1/status", server.handleStatus)
 	mux.HandleFunc("/v1/update", server.handleUpdate)
 
-	log.Printf("clirelay updater listening on %s", cfg.Addr)
-	if err := http.ListenAndServe(cfg.Addr, mux); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		log.Fatal(err)
+	httpServer := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		BaseContext: func(net.Listener) context.Context {
+			return ctx
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		log.Printf("clirelay updater listening on %s", listener.Addr())
+		if err := httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("clirelay updater: shutdown failed: %w", err)
+		}
+		return <-errCh
+	case err := <-errCh:
+		return err
 	}
 }
 
@@ -122,6 +185,10 @@ func newUpdaterServer(cfg updaterConfig) *updaterServer {
 	if runner == nil {
 		runner = runComposeUpdate
 	}
+	ctx := cfg.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return &updaterServer{
 		token:          strings.TrimSpace(cfg.Token),
 		composeFile:    envOrDefaultValue(cfg.ComposeFile, defaultComposeFile),
@@ -129,6 +196,7 @@ func newUpdaterServer(cfg updaterConfig) *updaterServer {
 		projectName:    strings.TrimSpace(cfg.ProjectName),
 		defaultService: envOrDefaultValue(cfg.DefaultService, defaultTargetService),
 		runner:         runner,
+		ctx:            ctx,
 		status: updateStatusResponse{
 			Status: "idle",
 			Stage:  "idle",
@@ -200,7 +268,7 @@ func (s *updaterServer) handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 	runID := s.startUpdate(service, req)
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), updateCommandTimeout)
+		ctx, cancel := context.WithTimeout(s.context(), updateCommandTimeout)
 		defer cancel()
 		reporter := updaterRunReporter{server: s, runID: runID}
 		if err := s.runner(ctx, s.composeFile, s.envFile, s.projectName, service, reporter); err != nil {
@@ -219,6 +287,13 @@ func (s *updaterServer) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "accepted", "service": service})
+}
+
+func (s *updaterServer) context() context.Context {
+	if s == nil || s.ctx == nil {
+		return context.Background()
+	}
+	return s.ctx
 }
 
 func persistRequestedImage(envFile string, image string, tag string) error {

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,6 +51,73 @@ func TestUpdaterRejectsRequestsWhenConfiguredTokenIsEmpty(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestServeUpdaterStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- serveUpdater(ctx, updaterConfig{Token: "secret"}, listener)
+	}()
+
+	waitForUpdaterHealth(t, listener.Addr().String())
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("serveUpdater returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for updater shutdown")
+	}
+}
+
+func TestUpdaterCancelsRunnerOnServerContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	server := newUpdaterServer(updaterConfig{
+		Token:   "secret",
+		Context: ctx,
+		Runner: func(ctx context.Context, _ string, _ string, _ string, _ string, _ updateReporter) error {
+			close(started)
+			<-ctx.Done()
+			done <- ctx.Err()
+			return ctx.Err()
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/update", strings.NewReader(`{"service":"clirelay"}`))
+	setUpdaterAuth(req)
+	rec := httptest.NewRecorder()
+
+	server.handleUpdate(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("runner context error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner cancellation")
 	}
 }
 
@@ -389,4 +457,26 @@ func eventually(t *testing.T, timeout time.Duration, condition func() bool) {
 		return
 	}
 	t.Fatal("condition was not met before timeout")
+}
+
+func waitForUpdaterHealth(t *testing.T, addr string) {
+	t.Helper()
+	client := http.Client{Timeout: 100 * time.Millisecond}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/v1/health", nil)
+		if err != nil {
+			t.Fatalf("create health request: %v", err)
+		}
+		setUpdaterAuth(req)
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("updater health did not become ready")
 }

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+// These are configuration drift guard tests: they assert shipped workflow text,
+// not runtime behavior.
 func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/deploy.yml")
 	if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       CLIRELAY_UPDATER_URL: ${CLIRELAY_UPDATER_URL:-http://clirelay-updater:8320}
       CLIRELAY_UPDATER_TOKEN: ${CLIRELAY_UPDATER_TOKEN:?CLIRELAY_UPDATER_TOKEN is required for updater sidecar}
       CLIRELAY_TARGET_SERVICE: ${CLIRELAY_TARGET_SERVICE:-cli-proxy-api}
-      AUTH_PATH: ${AUTH_PATH:-/root/.cli-proxy-api}
+      AUTH_PATH: ${AUTH_PATH:-/CLIProxyAPI/auths}
       LANG: ${CLIRELAY_LANG:-C.UTF-8}
       LANGUAGE: ${CLIRELAY_LANGUAGE:-en_US:en}
       LC_ALL: ${CLIRELAY_LANG:-C.UTF-8}
@@ -36,7 +36,7 @@ services:
       - "127.0.0.1:11451:11451"
     volumes:
       - ${CLI_PROXY_CONFIG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/config.yaml}:/CLIProxyAPI/config.yaml
-      - ${CLI_PROXY_AUTH_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/auths}:${AUTH_PATH:-/root/.cli-proxy-api}
+      - ${CLI_PROXY_AUTH_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/auths}:${AUTH_PATH:-/CLIProxyAPI/auths}
       - ${CLI_PROXY_LOG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/logs}:/CLIProxyAPI/logs
       - ${CLI_PROXY_DATA_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/data}:/CLIProxyAPI/data
     restart: unless-stopped
@@ -45,6 +45,7 @@ services:
     image: ${CLI_PROXY_IMAGE:-ghcr.io/kittors/clirelay:latest}
     pull_policy: ${CLI_PROXY_PULL_POLICY:-always}
     command: ["./clirelay-updater"]
+    user: "0:0"
     environment:
       CLIRELAY_UPDATER_TOKEN: ${CLIRELAY_UPDATER_TOKEN:?CLIRELAY_UPDATER_TOKEN is required for updater sidecar}
       CLIRELAY_PROJECT_DIR: ${CLIRELAY_PROJECT_DIR:-${PWD:-.}}

--- a/docker_compose_test.go
+++ b/docker_compose_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+// These are configuration drift guard tests: they assert shipped compose text,
+// not runtime behavior.
 func TestRepositoryComposeUsesProjectDirForDefaultDataMounts(t *testing.T) {
 	data, err := os.ReadFile("docker-compose.yml")
 	if err != nil {
@@ -15,7 +17,7 @@ func TestRepositoryComposeUsesProjectDirForDefaultDataMounts(t *testing.T) {
 
 	for _, want := range []string{
 		"${CLI_PROXY_CONFIG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/config.yaml}:/CLIProxyAPI/config.yaml",
-		"${CLI_PROXY_AUTH_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/auths}:${AUTH_PATH:-/root/.cli-proxy-api}",
+		"${CLI_PROXY_AUTH_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/auths}:${AUTH_PATH:-/CLIProxyAPI/auths}",
 		"${CLI_PROXY_LOG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/logs}:/CLIProxyAPI/logs",
 		"${CLI_PROXY_DATA_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/data}:/CLIProxyAPI/data",
 	} {
@@ -32,7 +34,7 @@ func TestRepositoryComposePassesContainerAuthPath(t *testing.T) {
 	}
 	content := string(data)
 
-	want := "AUTH_PATH: ${AUTH_PATH:-/root/.cli-proxy-api}"
+	want := "AUTH_PATH: ${AUTH_PATH:-/CLIProxyAPI/auths}"
 	if !strings.Contains(content, want) {
 		t.Fatalf("docker-compose.yml missing %q", want)
 	}

--- a/frontend_static_asset_guard_test.go
+++ b/frontend_static_asset_guard_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+// These are configuration drift guard tests: they assert repository hygiene
+// markers, not runtime behavior.
 func TestRepositoryDoesNotVendorManagementPanelBuildOutput(t *testing.T) {
 	for _, path := range []string{
 		"assets",

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.26.0
 toolchain go1.26.1
 
 require (
-	github.com/andybalholm/brotli v1.0.6
+	github.com/andybalholm/brotli v1.2.2
 	github.com/atotto/clipboard v0.1.4
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -17,7 +18,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/joho/godotenv v1.5.1
-	github.com/klauspost/compress v1.17.4
+	github.com/klauspost/compress v1.19.0
 	github.com/minio/minio-go/v7 v7.0.66
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/refraction-networking/utls v1.8.2
@@ -31,6 +32,7 @@ require (
 	golang.org/x/net v0.47.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.18.0
+	golang.org/x/sys v0.38.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.46.1
@@ -40,7 +42,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
@@ -111,7 +112,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
-github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
-github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
+github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -129,8 +129,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kevinburke/ssh_config v1.4.0 h1:6xxtP5bZ2E4NF5tuQulISpTO2z8XbtH8cg1PWkxoFkQ=
 github.com/kevinburke/ssh_config v1.4.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
-github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
-github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
+github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
@@ -240,6 +240,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/install_compose_test.go
+++ b/install_compose_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+// These are configuration drift guard tests: they assert generated install
+// script text, not runtime behavior.
 func TestInstallEnvProvidesHostAbsoluteBindPaths(t *testing.T) {
 	data, err := os.ReadFile("install.sh")
 	if err != nil {

--- a/internal/api/middleware/quota.go
+++ b/internal/api/middleware/quota.go
@@ -88,6 +88,9 @@ func (w *tokenWindow) sum() int64 {
 var (
 	rpmTrackers sync.Map // map[string]*slidingWindow
 	tpmTrackers sync.Map // map[string]*tokenWindow
+
+	inFlightMu    sync.Mutex
+	inFlightByKey = map[string]int{}
 )
 
 func getRPMTracker(apiKey string) *slidingWindow {
@@ -166,6 +169,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 		// Parse limits from metadata
 		dailyLimit := parseIntMetadata(metadata, "daily-limit")
 		totalQuota := parseIntMetadata(metadata, "total-quota")
+		concurrencyLimit := parseIntMetadata(metadata, "concurrency-limit")
 		rpmLimit := parseIntMetadata(metadata, "rpm-limit")
 		tpmLimit := parseIntMetadata(metadata, "tpm-limit")
 		spendingLimit := parseFloatMetadata(metadata, "spending-limit")
@@ -174,9 +178,24 @@ func QuotaMiddleware() gin.HandlerFunc {
 		UpdateKeyLimits(apiKey, rpmLimit, tpmLimit)
 
 		// No limits configured — skip all checks
-		if dailyLimit <= 0 && totalQuota <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 {
+		if dailyLimit <= 0 && totalQuota <= 0 && concurrencyLimit <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 {
 			c.Next()
 			return
+		}
+
+		if concurrencyLimit > 0 {
+			release, ok := acquireKeyConcurrency(apiKey, concurrencyLimit)
+			if !ok {
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+					"error": map[string]interface{}{
+						"message": fmt.Sprintf("concurrency limit (%d in-flight requests) exceeded for this API key", concurrencyLimit),
+						"type":    "rate_limit_exceeded",
+						"code":    "concurrency_limit_exceeded",
+					},
+				})
+				return
+			}
+			defer release()
 		}
 
 		// --- RPM check (sliding window, in-memory) ---
@@ -297,6 +316,32 @@ func parseIntMetadata(metadata map[string]string, key string) int {
 		return 0
 	}
 	return n
+}
+
+func acquireKeyConcurrency(apiKey string, limit int) (func(), bool) {
+	if apiKey == "" || limit <= 0 {
+		return func() {}, true
+	}
+
+	inFlightMu.Lock()
+	defer inFlightMu.Unlock()
+
+	if inFlightByKey[apiKey] >= limit {
+		return nil, false
+	}
+	inFlightByKey[apiKey]++
+
+	return func() {
+		inFlightMu.Lock()
+		defer inFlightMu.Unlock()
+
+		current := inFlightByKey[apiKey]
+		if current <= 1 {
+			delete(inFlightByKey, apiKey)
+			return
+		}
+		inFlightByKey[apiKey] = current - 1
+	}, true
 }
 
 func maskKey(key string) string {

--- a/internal/api/middleware/quota_test.go
+++ b/internal/api/middleware/quota_test.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestQuotaMiddlewareEnforcesConcurrencyLimitPerKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetQuotaMiddlewareState(t)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enteredOnce sync.Once
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		key := c.GetHeader("X-Test-Key")
+		if key == "" {
+			key = "key-a"
+		}
+		c.Set("apiKey", key)
+		c.Set("accessMetadata", map[string]string{"concurrency-limit": "1"})
+		c.Next()
+	})
+	router.Use(QuotaMiddleware())
+	router.POST("/v1/chat/completions", func(c *gin.Context) {
+		if key, _ := c.Get("apiKey"); key == "key-a" {
+			enteredOnce.Do(func() { close(entered) })
+			<-release
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	firstDone := make(chan struct{})
+	first := httptest.NewRecorder()
+	go func() {
+		defer close(firstDone)
+		router.ServeHTTP(first, newQuotaPostRequest("key-a"))
+	}()
+
+	<-entered
+
+	secondSameKey := httptest.NewRecorder()
+	router.ServeHTTP(secondSameKey, newQuotaPostRequest("key-a"))
+	if secondSameKey.Code != http.StatusTooManyRequests {
+		t.Fatalf("same-key concurrent status = %d, want %d", secondSameKey.Code, http.StatusTooManyRequests)
+	}
+
+	secondOtherKey := httptest.NewRecorder()
+	router.ServeHTTP(secondOtherKey, newQuotaPostRequest("key-b"))
+	if secondOtherKey.Code != http.StatusNoContent {
+		t.Fatalf("other-key concurrent status = %d, want %d", secondOtherKey.Code, http.StatusNoContent)
+	}
+
+	close(release)
+	<-firstDone
+	if first.Code != http.StatusNoContent {
+		t.Fatalf("first status = %d, want %d", first.Code, http.StatusNoContent)
+	}
+
+	afterRelease := httptest.NewRecorder()
+	router.ServeHTTP(afterRelease, newQuotaPostRequest("key-a"))
+	if afterRelease.Code != http.StatusNoContent {
+		t.Fatalf("after-release status = %d, want %d", afterRelease.Code, http.StatusNoContent)
+	}
+}
+
+func newQuotaPostRequest(key string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("X-Test-Key", key)
+	return req
+}
+
+func resetQuotaMiddlewareState(t *testing.T) {
+	t.Helper()
+
+	rpmTrackers = sync.Map{}
+	tpmTrackers = sync.Map{}
+	snapshotLimits = sync.Map{}
+	inFlightMu.Lock()
+	inFlightByKey = map[string]int{}
+	inFlightMu.Unlock()
+}

--- a/internal/api/modules/amp/proxy_test.go
+++ b/internal/api/modules/amp/proxy_test.go
@@ -145,6 +145,7 @@ func TestModifyResponse_GzipScenarios(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			resp := mkResp(tc.status, tc.header, tc.body)
+			t.Cleanup(func() { _ = resp.Body.Close() })
 			if err := proxy.ModifyResponse(resp); err != nil {
 				t.Fatalf("ModifyResponse error: %v", err)
 			}
@@ -176,6 +177,7 @@ func TestModifyResponse_UpdatesContentLengthHeader(t *testing.T) {
 	resp := mkResp(200, http.Header{
 		"Content-Length": []string{fmt.Sprintf("%d", len(gzipped))}, // Compressed size
 	}, gzipped)
+	t.Cleanup(func() { _ = resp.Body.Close() })
 
 	if err := proxy.ModifyResponse(resp); err != nil {
 		t.Fatalf("ModifyResponse error: %v", err)
@@ -211,6 +213,7 @@ func TestModifyResponse_SkipsStreamingResponses(t *testing.T) {
 
 	t.Run("sse_skips_decompression", func(t *testing.T) {
 		resp := mkResp(200, http.Header{"Content-Type": []string{"text/event-stream"}}, gzipped)
+		t.Cleanup(func() { _ = resp.Body.Close() })
 		if err := proxy.ModifyResponse(resp); err != nil {
 			t.Fatalf("ModifyResponse error: %v", err)
 		}
@@ -234,6 +237,7 @@ func TestModifyResponse_DecompressesChunkedJSON(t *testing.T) {
 	t.Run("chunked_json_decompresses", func(t *testing.T) {
 		// Chunked JSON responses (like thread APIs) should be decompressed
 		resp := mkResp(200, http.Header{"Transfer-Encoding": []string{"chunked"}}, gzipped)
+		t.Cleanup(func() { _ = resp.Body.Close() })
 		if err := proxy.ModifyResponse(resp); err != nil {
 			t.Fatalf("ModifyResponse error: %v", err)
 		}

--- a/internal/api/routes_public.go
+++ b/internal/api/routes_public.go
@@ -14,6 +14,10 @@ import (
 // setupRoutes configures the API routes for the server.
 // It defines the endpoints and associates them with their respective handlers.
 func (s *Server) setupRoutes() {
+	s.engine.GET("/healthz", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
 	s.engine.GET("/manage", s.serveManagementControlPanel)
 	s.engine.GET("/manage/*filepath", s.serveManagementControlPanel)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	// Main API requests can legitimately spend several minutes waiting on upstream model execution.
+	// Non-streaming API responses should not keep a downstream connection occupied for minutes.
 	// Long-lived SSE and websocket routes explicitly clear this deadline before streaming/upgrading.
-	mainAPIServerWriteTimeout = 10 * time.Minute
+	mainAPINonStreamingWriteTimeout = 60 * time.Second
 )
 
 // Server represents the main API server.

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -264,7 +264,7 @@ func buildHTTPServer(cfg *config.Config, engine *gin.Engine) *http.Server {
 		Handler:           engine,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       readTimeout,
-		WriteTimeout:      mainAPIServerWriteTimeout,
+		WriteTimeout:      mainAPINonStreamingWriteTimeout,
 		IdleTimeout:       2 * time.Minute,
 		MaxHeaderBytes:    1 << 20,
 	}

--- a/internal/api/server_http_middleware.go
+++ b/internal/api/server_http_middleware.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -81,10 +80,6 @@ func resolveAllowedCORSOrigin(r *http.Request, cfg *config.Config) string {
 		return origin
 	}
 
-	if isChromeExtensionOrigin(origin) {
-		return origin
-	}
-
 	if cfg == nil {
 		return ""
 	}
@@ -94,22 +89,6 @@ func resolveAllowedCORSOrigin(r *http.Request, cfg *config.Config) string {
 		}
 	}
 	return ""
-}
-
-func isChromeExtensionOrigin(origin string) bool {
-	trimmed := strings.TrimSpace(origin)
-	if trimmed == "" {
-		return false
-	}
-
-	parsed, err := url.Parse(trimmed)
-	if err != nil || parsed == nil {
-		return false
-	}
-	if !strings.EqualFold(parsed.Scheme, "chrome-extension") {
-		return false
-	}
-	return strings.TrimSpace(parsed.Host) != ""
 }
 
 func versionHeaderMiddleware(configFilePath string) gin.HandlerFunc {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -104,6 +104,18 @@ func newTestServerWithConfig(t *testing.T, configure func(*proxyconfig.Config)) 
 	return NewServer(cfg, authManager, accessManager, configPath)
 }
 
+func TestHealthzReturnsNoContent(t *testing.T) {
+	server := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+}
+
 func TestAmpProviderModelRoutes(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -581,13 +593,13 @@ func TestGroupedV1RouteUnknownGroupReturnsNotFound(t *testing.T) {
 	}
 }
 
-func TestNewServerSetsMainWriteTimeout(t *testing.T) {
+func TestNewServerSetsMainNonStreamingWriteTimeout(t *testing.T) {
 	server := newTestServer(t)
 	if server.server == nil {
 		t.Fatal("expected http server to be initialized")
 	}
-	if got := server.server.WriteTimeout; got != mainAPIServerWriteTimeout {
-		t.Fatalf("WriteTimeout = %s, want %s", got, mainAPIServerWriteTimeout)
+	if got := server.server.WriteTimeout; got != mainAPINonStreamingWriteTimeout {
+		t.Fatalf("WriteTimeout = %s, want %s", got, mainAPINonStreamingWriteTimeout)
 	}
 	if got := server.server.ReadTimeout; got != proxyconfig.DefaultMainAPIReadTimeout {
 		t.Fatalf("ReadTimeout = %s, want %s", got, proxyconfig.DefaultMainAPIReadTimeout)
@@ -691,6 +703,24 @@ func TestGetContextWithCancelClearsWriteDeadlineForStreamingRequests(t *testing.
 	}
 }
 
+func TestGetContextWithCancelKeepsWriteDeadlineForNonStreamingRequests(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"test-model"}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+	tracking := &deadlineTrackingWriter{ResponseWriter: c.Writer}
+	c.Writer = tracking
+
+	handler := &sdkhandlers.BaseAPIHandler{Cfg: &sdkconfig.SDKConfig{}}
+	_, cancelHandler := handler.GetContextWithCancel(nil, c, c.Request.Context())
+	cancelHandler()
+
+	if tracking.sawZeroDeadline() {
+		t.Fatal("expected non-streaming request to keep the server write deadline")
+	}
+}
+
 func TestAttachWebsocketRouteClearsWriteDeadlineBeforeServingHandler(t *testing.T) {
 	server := newTestServer(t)
 
@@ -772,8 +802,27 @@ func TestCORSMiddlewareAllowsConfiguredOrigin(t *testing.T) {
 	}
 }
 
-func TestCORSMiddlewareAllowsChromeExtensionOriginByDefault(t *testing.T) {
+func TestCORSMiddlewareRejectsUnconfiguredChromeExtensionOrigin(t *testing.T) {
 	server := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/v1/models", nil)
+	req.Header.Set("Origin", "chrome-extension://abcdefghijklmnop")
+
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+	}
+}
+
+func TestCORSMiddlewareAllowsConfiguredChromeExtensionOrigin(t *testing.T) {
+	server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
+		cfg.CORSAllowOrigins = []string{"chrome-extension://abcdefghijklmnop"}
+	})
 
 	req := httptest.NewRequest(http.MethodOptions, "/v1/models", nil)
 	req.Header.Set("Origin", "chrome-extension://abcdefghijklmnop")

--- a/internal/auth/iflow/iflow_auth_test.go
+++ b/internal/auth/iflow/iflow_auth_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -77,5 +79,35 @@ func TestRefreshAPIKeyRejectsOversizedCompressedResponse(t *testing.T) {
 	_, err := auth.RefreshAPIKey(context.Background(), "sid=test", "demo")
 	if err == nil || !strings.Contains(err.Error(), "response body exceeds") {
 		t.Fatalf("RefreshAPIKey error = %v, want response body exceeds", err)
+	}
+}
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	authFilePath := filepath.Join(t.TempDir(), "auth", "iflow-user.json")
+	storage := &IFlowTokenStorage{
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		APIKey:       "api-key",
+		Email:        "user@example.com",
+	}
+
+	if err := storage.SaveTokenToFile(authFilePath); err != nil {
+		t.Fatalf("SaveTokenToFile returned error: %v", err)
+	}
+
+	dirInfo, err := os.Stat(filepath.Dir(authFilePath))
+	if err != nil {
+		t.Fatalf("stat auth dir failed: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("auth dir permissions = %o, want 700", got)
+	}
+
+	fileInfo, err := os.Stat(authFilePath)
+	if err != nil {
+		t.Fatalf("stat auth file failed: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("auth file permissions = %o, want 600", got)
 	}
 }

--- a/internal/auth/iflow/iflow_token.go
+++ b/internal/auth/iflow/iflow_token.go
@@ -40,11 +40,14 @@ func (ts *IFlowTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("iflow token: create directory failed: %w", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("iflow token: create file failed: %w", err)
 	}
 	defer func() { _ = f.Close() }()
+	if err = f.Chmod(0o600); err != nil {
+		return fmt.Errorf("iflow token: secure file permissions failed: %w", err)
+	}
 
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)

--- a/internal/config/oauth_clients.go
+++ b/internal/config/oauth_clients.go
@@ -11,13 +11,13 @@ const (
 
 	// GeminiCLIOAuthClientID and GeminiCLIOAuthClientSecret are the OAuth
 	// client credentials published by Google's Gemini CLI for Code Assist login.
-	GeminiCLIOAuthClientID     = "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
-	GeminiCLIOAuthClientSecret = "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"
+	GeminiCLIOAuthClientID     = "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com" // #nosec G101 -- upstream-published OAuth client ID, overridable by config/env.
+	GeminiCLIOAuthClientSecret = "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"                                      // #nosec G101 -- upstream-published OAuth client secret, overridable by config/env.
 
 	// AntigravityOAuthClientID and AntigravityOAuthClientSecret are the OAuth
 	// client credentials used by Antigravity for Google Code Assist login.
-	AntigravityOAuthClientID     = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
-	AntigravityOAuthClientSecret = "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"
+	AntigravityOAuthClientID     = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com" // #nosec G101 -- upstream-published OAuth client ID, overridable by config/env.
+	AntigravityOAuthClientSecret = "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"                                       // #nosec G101 -- upstream-published OAuth client secret, overridable by config/env.
 
 	EnvGeminiOAuthClientID     = "CLIRELAY_GEMINI_OAUTH_CLIENT_ID"
 	EnvGeminiOAuthClientSecret = "CLIRELAY_GEMINI_OAUTH_CLIENT_SECRET"

--- a/internal/config/oauth_clients_test.go
+++ b/internal/config/oauth_clients_test.go
@@ -10,7 +10,7 @@ func TestGeminiOAuthClientCredentialsDefaultsToGeminiCLIClient(t *testing.T) {
 
 	clientID, clientSecret := cfg.OAuthClientCredentials(OAuthClientGemini)
 
-	if clientID != "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com" {
+	if clientID != GeminiCLIOAuthClientID {
 		t.Fatalf("clientID = %q, want official Gemini CLI OAuth client", clientID)
 	}
 	if clientSecret == "" {

--- a/internal/management/oauth/providers/geminicli/onboarding_test.go
+++ b/internal/management/oauth/providers/geminicli/onboarding_test.go
@@ -75,7 +75,7 @@ type sequenceTransport struct {
 }
 
 func (s *sequenceTransport) enqueue(fn func(*http.Request) *http.Response) {
-	s.steps = append(s.steps, fn)
+	s.steps = append(s.steps, fn) //nolint:bodyclose // RoundTrip hands the response to http.Client; tested code closes the body.
 }
 
 func (s *sequenceTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/runtime/executor/bedrock_executor.go
+++ b/internal/runtime/executor/bedrock_executor.go
@@ -193,7 +193,7 @@ func (e *BedrockExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.
 	}
 
 	recorder := execCtx.Recorder()
-	httpResp, err := e.doBedrockRequest(execCtx, mappedModel, true, body)
+	httpResp, err := e.doBedrockRequest(execCtx, mappedModel, true, body) //nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	if err != nil {
 		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
 		return nil, err

--- a/internal/runtime/executor/codex_client_admission_test.go
+++ b/internal/runtime/executor/codex_client_admission_test.go
@@ -207,7 +207,10 @@ func TestCodexExecutorHttpRequestEnforcesAdmissionWithoutGinContext(t *testing.T
 	}
 	req.Header.Set("User-Agent", "curl/8.0")
 
-	_, err = NewCodexExecutor(&config.Config{}).HttpRequest(context.Background(), codexOAuthAdmissionTestAuth(true, nil), req)
+	resp, err := NewCodexExecutor(&config.Config{}).HttpRequest(context.Background(), codexOAuthAdmissionTestAuth(true, nil), req)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
 	if err == nil {
 		t.Fatal("HttpRequest() error = nil, want admission denial")
 	}
@@ -272,7 +275,10 @@ func TestCodexExecutorHttpRequestPrefersGinContextHeaders(t *testing.T) {
 	}
 	req.Header.Set("User-Agent", "codex_cli_rs/0.130.0")
 
-	_, err = NewCodexExecutor(&config.Config{}).HttpRequest(ctx, codexOAuthAdmissionTestAuth(true, nil), req)
+	resp, err := NewCodexExecutor(&config.Config{}).HttpRequest(ctx, codexOAuthAdmissionTestAuth(true, nil), req)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
 	if err == nil {
 		t.Fatal("HttpRequest() error = nil, want admission denial from Gin headers")
 	}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -165,7 +165,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
 	httpClient := execCtx.HTTPClient(0)
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := httpClient.Do(httpReq) //nolint:bodyclose // body is closed by the defer below.
 	if err != nil {
 		recorder.RecordResponseError(err)
 		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
@@ -266,6 +266,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // body is closed by the defer below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -348,6 +349,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)

--- a/internal/runtime/executor/codex_image_backend.go
+++ b/internal/runtime/executor/codex_image_backend.go
@@ -92,7 +92,7 @@ func fetchCodexImageChatRequirements(ctx context.Context, client *http.Client, h
 		{"p": generateCodexImageRequirementsToken(headers.Get("User-Agent"))},
 	} {
 		body, _ := json.Marshal(payload)
-		resp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/sentinel/chat-requirements"), headers, body)
+		resp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/sentinel/chat-requirements"), headers, body) //nolint:bodyclose // readAndCloseCodexImageBody closes the body below.
 		if err != nil {
 			lastErr = err
 			continue
@@ -129,7 +129,7 @@ func initializeCodexImageConversation(ctx context.Context, client *http.Client, 
 		"system_hints":            []string{"picture_v2"},
 	}
 	body, _ := json.Marshal(payload)
-	resp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/conversation/init"), headers, body)
+	resp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/conversation/init"), headers, body) //nolint:bodyclose // readAndCloseCodexImageBody closes the body below.
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func prepareCodexImageConversation(ctx context.Context, client *http.Client, hea
 		prepareHeaders.Set("openai-sentinel-proof-token", strings.TrimSpace(proofToken))
 	}
 	body, _ := json.Marshal(payload)
-	resp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/f/conversation/prepare"), prepareHeaders, body)
+	resp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/f/conversation/prepare"), prepareHeaders, body) //nolint:bodyclose // readAndCloseCodexImageBody closes the body below.
 	if err != nil {
 		return "", err
 	}
@@ -208,7 +208,7 @@ func uploadCodexImageFiles(ctx context.Context, client *http.Client, headers htt
 			"file_size": len(item.Data),
 			"use_case":  "multimodal",
 		})
-		resp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/files"), headers, payload)
+		resp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/files"), headers, payload) //nolint:bodyclose // readAndCloseCodexImageBody closes the body below.
 		if err != nil {
 			return nil, err
 		}
@@ -239,7 +239,7 @@ func uploadCodexImageFiles(ctx context.Context, client *http.Client, headers htt
 		putReq.Header.Set("x-ms-blob-type", "BlockBlob")
 		putReq.Header.Set("x-ms-version", "2020-04-08")
 		putReq.Header.Set("User-Agent", headers.Get("User-Agent"))
-		putResp, err := client.Do(putReq)
+		putResp, err := client.Do(putReq) //nolint:bodyclose // readAndCloseCodexImageBody closes the body below.
 		if err != nil {
 			return nil, err
 		}
@@ -252,7 +252,7 @@ func uploadCodexImageFiles(ctx context.Context, client *http.Client, headers htt
 		}
 
 		donePayload, _ := json.Marshal(map[string]any{})
-		doneResp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/files/"+created.FileID+"/uploaded"), headers, donePayload)
+		doneResp, err := doCodexImageJSON(ctx, client, http.MethodPost, codexImageURL("/backend-api/files/"+created.FileID+"/uploaded"), headers, donePayload) //nolint:bodyclose // readAndCloseCodexImageBody closes the body below.
 		if err != nil {
 			return nil, err
 		}

--- a/internal/runtime/executor/codex_image_pointers.go
+++ b/internal/runtime/executor/codex_image_pointers.go
@@ -353,7 +353,7 @@ func pollCodexImageConversation(ctx context.Context, client *http.Client, header
 			}
 			return nil, timeoutErr
 		}
-		resp, err := doCodexImageJSON(ctx, client, http.MethodGet, codexImageURL("/backend-api/conversation/"+conversationID), headers, nil)
+		resp, err := doCodexImageJSON(ctx, client, http.MethodGet, codexImageURL("/backend-api/conversation/"+conversationID), headers, nil) //nolint:bodyclose // readAndCloseCodexImageBody closes the body below.
 		if err != nil {
 			if timeoutErr := codexImagePollTimeoutError(ctx, startedAt, deadline, conversationID); timeoutErr != nil {
 				return nil, timeoutErr
@@ -624,7 +624,7 @@ func fetchCodexImageDownloadURL(ctx context.Context, client *http.Client, header
 	default:
 		return "", fmt.Errorf("unsupported image pointer: %s", pointer)
 	}
-	resp, err := doCodexImageJSON(ctx, client, http.MethodGet, url, headers, nil)
+	resp, err := doCodexImageJSON(ctx, client, http.MethodGet, url, headers, nil) //nolint:bodyclose // readAndCloseCodexImageBody closes the body below.
 	if err != nil {
 		return "", err
 	}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -197,7 +197,10 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
 			// execution session.
-			connRetry, _, errDialRetry := e.ensureUpstreamConn(execCtx.Context, auth, sess, authID, wsURL, wsHeaders)
+			connRetry, respRetry, errDialRetry := e.ensureUpstreamConn(execCtx.Context, auth, sess, authID, wsURL, wsHeaders) //nolint:bodyclose // failed handshake body is closed below; successful websocket response is owned by connRetry.
+			if errDialRetry != nil {
+				_ = websocketHandshakeBody(respRetry)
+			}
 			if errDialRetry == nil && connRetry != nil {
 				sess.connMu.Lock()
 				allowAppend = sess.connCreateSent
@@ -382,7 +385,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
 
 			// Retry once with a new websocket connection for the same execution session.
-			connRetry, _, errDialRetry := e.ensureUpstreamConn(execCtx.Context, auth, sess, authID, wsURL, wsHeaders)
+			connRetry, respRetry, errDialRetry := e.ensureUpstreamConn(execCtx.Context, auth, sess, authID, wsURL, wsHeaders) //nolint:bodyclose // failed handshake body is closed below; successful websocket response is owned by connRetry.
+			if errDialRetry != nil {
+				_ = websocketHandshakeBody(respRetry)
+			}
 			if errDialRetry != nil || connRetry == nil {
 				recorder.RecordResponseError(errDialRetry)
 				sess.clearActive(readCh)

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -155,6 +155,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -239,6 +240,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)

--- a/internal/runtime/executor/gemini_vertex_pipeline.go
+++ b/internal/runtime/executor/gemini_vertex_pipeline.go
@@ -111,6 +111,7 @@ func (e *GeminiVertexExecutor) executeVertexNonStream(
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
 
+	//nolint:bodyclose // body is closed by the defer below.
 	httpResp, err := execCtx.HTTPClient(0).Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -169,6 +170,7 @@ func (e *GeminiVertexExecutor) executeVertexStream(
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
 
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := execCtx.HTTPClient(0).Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)

--- a/internal/runtime/executor/iflow_executor.go
+++ b/internal/runtime/executor/iflow_executor.go
@@ -119,6 +119,7 @@ func (e *IFlowExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	recorder.RecordRequest(endpoint, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // body is closed by the defer below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -223,6 +224,7 @@ func (e *IFlowExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	recorder.RecordRequest(endpoint, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -347,7 +349,8 @@ func (e *IFlowExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 
 // refreshCookieBased refreshes API key using browser cookie
 func (e *IFlowExecutor) refreshCookieBased(ctx context.Context, auth *cliproxyauth.Auth, cookie, email string) (*cliproxyauth.Auth, error) {
-	log.Debugf("iflow executor: checking refresh need for cookie-based API key for user: %s", email)
+	maskedEmail := util.HideAPIKey(email)
+	log.Debugf("iflow executor: checking refresh need for cookie-based API key for user: %s", maskedEmail)
 
 	// Get current expiry time from metadata
 	var currentExpire string
@@ -363,11 +366,11 @@ func (e *IFlowExecutor) refreshCookieBased(ctx context.Context, auth *cliproxyau
 		log.Warnf("iflow executor: failed to check refresh need: %v", err)
 		// If we can't check, continue with refresh anyway as a safety measure
 	} else if !needsRefresh {
-		log.Debugf("iflow executor: no refresh needed for user: %s", email)
+		log.Debugf("iflow executor: no refresh needed for user: %s", maskedEmail)
 		return auth, nil
 	}
 
-	log.Infof("iflow executor: refreshing cookie-based API key for user: %s", email)
+	log.Infof("iflow executor: refreshing cookie-based API key for user: %s", maskedEmail)
 
 	svc := iflowauth.NewIFlowAuth(e.cfg)
 	keyData, err := svc.RefreshAPIKey(ctx, cookie, email)

--- a/internal/runtime/executor/iflow_executor_test.go
+++ b/internal/runtime/executor/iflow_executor_test.go
@@ -1,9 +1,16 @@
 package executor
 
 import (
+	"bytes"
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestIFlowExecutorParseSuffix(t *testing.T) {
@@ -63,5 +70,38 @@ func TestPreserveReasoningContentInMessages(t *testing.T) {
 				t.Errorf("preserveReasoningContentInMessages() = %s, want %s", got, want)
 			}
 		})
+	}
+}
+
+func TestIFlowCookieRefreshLogsMaskedEmail(t *testing.T) {
+	var buf bytes.Buffer
+	previousOutput := log.StandardLogger().Out
+	previousLevel := log.GetLevel()
+	log.SetOutput(&buf)
+	log.SetLevel(log.DebugLevel)
+	t.Cleanup(func() {
+		log.SetOutput(previousOutput)
+		log.SetLevel(previousLevel)
+	})
+
+	email := "user@example.com"
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{
+		"expired": time.Now().Add(72 * time.Hour).Format("2006-01-02 15:04"),
+	}}
+
+	gotAuth, err := (&IFlowExecutor{}).refreshCookieBased(context.Background(), auth, "BXAuth=secret;", email)
+	if err != nil {
+		t.Fatalf("refreshCookieBased returned error: %v", err)
+	}
+	if gotAuth != auth {
+		t.Fatalf("refreshCookieBased returned different auth when refresh was not needed")
+	}
+
+	got := buf.String()
+	if strings.Contains(got, email) {
+		t.Fatalf("refreshCookieBased log leaked full email: %s", got)
+	}
+	if masked := util.HideAPIKey(email); !strings.Contains(got, masked) {
+		t.Fatalf("refreshCookieBased log = %q, want masked email %q", got, masked)
 	}
 }

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -117,6 +117,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -218,6 +219,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -157,6 +157,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -280,6 +281,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)

--- a/internal/runtime/executor/opencode_go_messages.go
+++ b/internal/runtime/executor/opencode_go_messages.go
@@ -61,6 +61,7 @@ func (e *OpenCodeGoExecutor) executeMessages(ctx context.Context, auth *cliproxy
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -147,6 +148,7 @@ func (e *OpenCodeGoExecutor) executeMessagesStream(ctx context.Context, auth *cl
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -259,6 +259,7 @@ func (e *QwenExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
@@ -366,6 +367,7 @@ func (e *QwenExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), translated)
 
 	httpClient := execCtx.HTTPClient(0)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)

--- a/internal/translator/antigravity/claude/antigravity_claude_response.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_response.go
@@ -157,11 +157,6 @@ func ConvertAntigravityResponseToClaude(_ context.Context, _ string, originalReq
 						// Transition from another state to thinking
 						// First, close any existing content block
 						if params.ResponseType != 0 {
-							if params.ResponseType == 2 {
-								// output = output + "event: content_block_delta\n"
-								// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, params.ResponseIndex)
-								// output = output + "\n\n\n"
-							}
 							output = output + "event: content_block_stop\n"
 							output = output + fmt.Sprintf(`data: {"type":"content_block_stop","index":%d}`, params.ResponseIndex)
 							output = output + "\n\n\n"
@@ -195,11 +190,6 @@ func ConvertAntigravityResponseToClaude(_ context.Context, _ string, originalReq
 							// Transition from another state to text content
 							// First, close any existing content block
 							if params.ResponseType != 0 {
-								if params.ResponseType == 2 {
-									// output = output + "event: content_block_delta\n"
-									// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, params.ResponseIndex)
-									// output = output + "\n\n\n"
-								}
 								output = output + "event: content_block_stop\n"
 								output = output + fmt.Sprintf(`data: {"type":"content_block_stop","index":%d}`, params.ResponseIndex)
 								output = output + "\n\n\n"
@@ -233,13 +223,6 @@ func ConvertAntigravityResponseToClaude(_ context.Context, _ string, originalReq
 					output = output + "\n\n\n"
 					params.ResponseIndex++
 					params.ResponseType = 0
-				}
-
-				// Special handling for thinking state transition
-				if params.ResponseType == 2 {
-					// output = output + "event: content_block_delta\n"
-					// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, params.ResponseIndex)
-					// output = output + "\n\n\n"
 				}
 
 				// Close any other existing content block

--- a/internal/translator/gemini-cli/claude/gemini-cli_claude_response.go
+++ b/internal/translator/gemini-cli/claude/gemini-cli_claude_response.go
@@ -117,11 +117,6 @@ func ConvertGeminiCLIResponseToClaude(_ context.Context, _ string, originalReque
 						// Transition from another state to thinking
 						// First, close any existing content block
 						if (*param).(*Params).ResponseType != 0 {
-							if (*param).(*Params).ResponseType == 2 {
-								// output = output + "event: content_block_delta\n"
-								// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-								// output = output + "\n\n\n"
-							}
 							output = output + "event: content_block_stop\n"
 							output = output + fmt.Sprintf(`data: {"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex)
 							output = output + "\n\n\n"
@@ -150,11 +145,6 @@ func ConvertGeminiCLIResponseToClaude(_ context.Context, _ string, originalReque
 						// Transition from another state to text content
 						// First, close any existing content block
 						if (*param).(*Params).ResponseType != 0 {
-							if (*param).(*Params).ResponseType == 2 {
-								// output = output + "event: content_block_delta\n"
-								// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-								// output = output + "\n\n\n"
-							}
 							output = output + "event: content_block_stop\n"
 							output = output + fmt.Sprintf(`data: {"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex)
 							output = output + "\n\n\n"
@@ -186,13 +176,6 @@ func ConvertGeminiCLIResponseToClaude(_ context.Context, _ string, originalReque
 					output = output + "\n\n\n"
 					(*param).(*Params).ResponseIndex++
 					(*param).(*Params).ResponseType = 0
-				}
-
-				// Special handling for thinking state transition
-				if (*param).(*Params).ResponseType == 2 {
-					// output = output + "event: content_block_delta\n"
-					// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-					// output = output + "\n\n\n"
 				}
 
 				// Close any other existing content block

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -117,11 +117,6 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 						// Transition from another state to thinking
 						// First, close any existing content block
 						if (*param).(*Params).ResponseType != 0 {
-							if (*param).(*Params).ResponseType == 2 {
-								// output = output + "event: content_block_delta\n"
-								// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-								// output = output + "\n\n\n"
-							}
 							output = output + "event: content_block_stop\n"
 							output = output + fmt.Sprintf(`data: {"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex)
 							output = output + "\n\n\n"
@@ -150,11 +145,6 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 						// Transition from another state to text content
 						// First, close any existing content block
 						if (*param).(*Params).ResponseType != 0 {
-							if (*param).(*Params).ResponseType == 2 {
-								// output = output + "event: content_block_delta\n"
-								// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-								// output = output + "\n\n\n"
-							}
 							output = output + "event: content_block_stop\n"
 							output = output + fmt.Sprintf(`data: {"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex)
 							output = output + "\n\n\n"
@@ -198,13 +188,6 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 					output = output + "\n\n\n"
 					(*param).(*Params).ResponseIndex++
 					(*param).(*Params).ResponseType = 0
-				}
-
-				// Special handling for thinking state transition
-				if (*param).(*Params).ResponseType == 2 {
-					// output = output + "event: content_block_delta\n"
-					// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-					// output = output + "\n\n\n"
 				}
 
 				// Close any other existing content block

--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -203,7 +203,6 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 				hasContent := len(contentItems) > 0
 				hasReasoning := reasoningContent != ""
 				hasToolCalls := len(toolCalls) > 0
-				hasToolResults := len(toolResults) > 0
 
 				// OpenAI requires: tool messages MUST immediately follow the assistant message with tool_calls.
 				// Therefore, we emit tool_result messages FIRST (they respond to the previous assistant's tool_calls),
@@ -256,8 +255,6 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 						msgJSON, _ = sjson.SetRaw(msgJSON, "content", contentArrayJSON)
 
 						messagesJSON, _ = sjson.Set(messagesJSON, "-1", gjson.Parse(msgJSON).Value())
-					} else if hasToolResults && !hasContent {
-						// tool_results already emitted above, no additional user message needed
 					}
 				}
 

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -712,10 +712,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 		includeReasoning = gjson.GetBytes(requestRawJSON, "reasoning").Exists()
 	}
 	if includeReasoning {
-		rid := id
-		if strings.HasPrefix(rid, "resp_") {
-			rid = strings.TrimPrefix(rid, "resp_")
-		}
+		rid := strings.TrimPrefix(id, "resp_")
 		// Prefer summary_text from reasoning_content; encrypted_content is optional
 		reasoningItem := `{"id":"","type":"reasoning","encrypted_content":"","summary":[]}`
 		reasoningItem, _ = sjson.Set(reasoningItem, "id", fmt.Sprintf("rs_%s", rid))

--- a/internal/usage/request_log_query_builder_test.go
+++ b/internal/usage/request_log_query_builder_test.go
@@ -1,0 +1,105 @@
+package usage
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestBuildWhereClauseUsesParameterizedFilters(t *testing.T) {
+	where, args := buildWhereClause(LogQueryParams{
+		Days:                  3,
+		APIKeys:               []string{" sk-a ", "sk-b", "SK-B"},
+		Models:                []string{" gpt-5 ", "gpt-4"},
+		Statuses:              []string{"failed"},
+		AuthIndexes:           []string{" auth-1 ", ""},
+		AuthIndexChannelNames: map[string][]string{" auth-2 ": {" Legacy ", ""}},
+		ChannelNames:          []string{" Codex ", ""},
+	})
+
+	wantWhere := " WHERE timestamp >= ? AND (api_key = ? OR api_key = ?) AND model IN (?,?) AND failed = 1 AND ((auth_index IN (?) AND trim(coalesce(channel_name, '')) = '') OR (auth_index = ? AND lower(trim(channel_name)) IN (?)) OR lower(trim(channel_name)) IN (?))"
+	if where != wantWhere {
+		t.Fatalf("where = %q, want %q", where, wantWhere)
+	}
+	if len(args) == 0 {
+		t.Fatal("expected cutoff argument")
+	}
+	cutoff, ok := args[0].(string)
+	if !ok {
+		t.Fatalf("cutoff arg type = %T, want string", args[0])
+	}
+	if _, err := time.Parse(time.RFC3339, cutoff); err != nil {
+		t.Fatalf("cutoff arg %q is not RFC3339: %v", cutoff, err)
+	}
+
+	wantArgs := []interface{}{"sk-a", "sk-b", "gpt-5", "gpt-4", "auth-1", "auth-2", "legacy", "codex"}
+	if !reflect.DeepEqual(args[1:], wantArgs) {
+		t.Fatalf("args[1:] = %#v, want %#v", args[1:], wantArgs)
+	}
+}
+
+func TestBuildWhereClauseSupportsSystemRequestFilter(t *testing.T) {
+	where, args := buildWhereClause(LogQueryParams{
+		Days:    1,
+		APIKeys: []string{systemRequestLogFilterValue},
+	})
+
+	for _, want := range []string{
+		"trim(coalesce(api_key_name, '')) = ''",
+		"trim(coalesce(api_key, '')) LIKE '/%'",
+		"upper(trim(coalesce(api_key, ''))) LIKE 'POST /%'",
+	} {
+		if !strings.Contains(where, want) {
+			t.Fatalf("system filter where missing %q in %q", want, where)
+		}
+	}
+	if len(args) != 1 {
+		t.Fatalf("system filter args = %#v, want only cutoff", args)
+	}
+}
+
+func TestBuildWhereClauseExplicitEmptyFiltersMatchNothing(t *testing.T) {
+	for _, params := range []LogQueryParams{
+		{MatchNoAPIKeys: true},
+		{MatchNoModels: true},
+		{MatchNoStatuses: true},
+		{MatchNoChannels: true},
+	} {
+		where, args := buildWhereClause(params)
+		if where != " WHERE 1 = 0" {
+			t.Fatalf("where = %q, want match-none clause for %+v", where, params)
+		}
+		if args != nil {
+			t.Fatalf("args = %#v, want nil for %+v", args, params)
+		}
+	}
+}
+
+func TestBuildSingleAPIKeySelectorClauseUsesStableIdentityWhenAvailable(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	if err := UpsertAPIKey(APIKeyRow{ID: "stable-key-1", Key: "sk-live", Name: "Primary"}); err != nil {
+		t.Fatalf("UpsertAPIKey() error = %v", err)
+	}
+
+	clause, args := buildSingleAPIKeySelectorClause(" sk-live ")
+	wantClause := " WHERE (api_key_id = ? OR (trim(coalesce(api_key_id, '')) = '' AND api_key = ?))"
+	if clause != wantClause {
+		t.Fatalf("clause = %q, want %q", clause, wantClause)
+	}
+	wantArgs := []interface{}{"stable-key-1", "sk-live"}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", args, wantArgs)
+	}
+
+	clause, args = buildSingleAPIKeySelectorClause(" missing-key ")
+	if clause != " WHERE api_key = ?" {
+		t.Fatalf("missing key clause = %q, want raw api_key selector", clause)
+	}
+	wantArgs = []interface{}{"missing-key"}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("missing key args = %#v, want %#v", args, wantArgs)
+	}
+}

--- a/internal/util/origin.go
+++ b/internal/util/origin.go
@@ -46,14 +46,6 @@ func WebsocketOriginAllowed(r *http.Request) bool {
 }
 
 func requestHost(r *http.Request) string {
-	// Prefer X-Forwarded-Host when present (common for reverse proxies).
-	if xf := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); xf != "" {
-		// Take the first host if multiple are present.
-		if idx := strings.IndexByte(xf, ','); idx >= 0 {
-			xf = xf[:idx]
-		}
-		return strings.TrimSpace(xf)
-	}
 	return strings.TrimSpace(r.Host)
 }
 

--- a/internal/util/origin_test.go
+++ b/internal/util/origin_test.go
@@ -31,12 +31,12 @@ func TestWebsocketOriginAllowed_DeniesCrossHostOrigin(t *testing.T) {
 	}
 }
 
-func TestWebsocketOriginAllowed_UsesForwardedHost(t *testing.T) {
+func TestWebsocketOriginAllowed_DeniesForwardedHostSpoof(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "http://internal.local/v1/ws", nil)
 	r.Host = "internal.local"
 	r.Header.Set("X-Forwarded-Host", "panel.example.com")
 	r.Header.Set("Origin", "https://panel.example.com")
-	if !WebsocketOriginAllowed(r) {
-		t.Fatal("expected Origin to be checked against X-Forwarded-Host")
+	if WebsocketOriginAllowed(r) {
+		t.Fatal("expected spoofed X-Forwarded-Host not to bypass Origin check")
 	}
 }

--- a/internal/wsrelay/manager_test.go
+++ b/internal/wsrelay/manager_test.go
@@ -33,8 +33,11 @@ func connectManagerClient(t *testing.T, mgr *Manager) (*websocket.Conn, func()) 
 	t.Helper()
 
 	server := httptest.NewServer(mgr.Handler())
-	conn, _, err := websocket.DefaultDialer.Dial(wsURLFromHTTP(server.URL, mgr.Path()), nil)
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURLFromHTTP(server.URL, mgr.Path()), nil)
 	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
 		server.Close()
 		t.Fatalf("dial websocket: %v", err)
 	}


### PR DESCRIPTION
## Summary
- tighten CORS/origin handling and quota concurrency coverage
- harden Docker/runtime defaults, health check, timeouts, updater shutdown, and iFlow credential hygiene
- enable bodyclose lint coverage, upgrade compression dependencies, and add SQL builder tests

## Verification
- rtk /Users/kittors/go/bin/golangci-lint run --config .golangci.yml
- rtk go test ./...
