### PR TITLE
fix: restore main api write timeout

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	// Non-streaming API responses should not keep a downstream connection occupied for minutes.
-	// Long-lived SSE and websocket routes explicitly clear this deadline before streaming/upgrading.
-	mainAPINonStreamingWriteTimeout = 60 * time.Second
+	// Main API requests can legitimately spend several minutes waiting on upstream model execution.
+	mainAPIServerWriteTimeout = 10 * time.Minute
 )
 
 // Server represents the main API server.

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -264,7 +264,7 @@ func buildHTTPServer(cfg *config.Config, engine *gin.Engine) *http.Server {
 		Handler:           engine,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       readTimeout,
-		WriteTimeout:      mainAPINonStreamingWriteTimeout,
+		WriteTimeout:      mainAPIServerWriteTimeout,
 		IdleTimeout:       2 * time.Minute,
 		MaxHeaderBytes:    1 << 20,
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -593,13 +593,13 @@ func TestGroupedV1RouteUnknownGroupReturnsNotFound(t *testing.T) {
 	}
 }
 
-func TestNewServerSetsMainNonStreamingWriteTimeout(t *testing.T) {
+func TestNewServerSetsMainWriteTimeout(t *testing.T) {
 	server := newTestServer(t)
 	if server.server == nil {
 		t.Fatal("expected http server to be initialized")
 	}
-	if got := server.server.WriteTimeout; got != mainAPINonStreamingWriteTimeout {
-		t.Fatalf("WriteTimeout = %s, want %s", got, mainAPINonStreamingWriteTimeout)
+	if got := server.server.WriteTimeout; got != mainAPIServerWriteTimeout {
+		t.Fatalf("WriteTimeout = %s, want %s", got, mainAPIServerWriteTimeout)
 	}
 	if got := server.server.ReadTimeout; got != proxyconfig.DefaultMainAPIReadTimeout {
 		t.Fatalf("ReadTimeout = %s, want %s", got, proxyconfig.DefaultMainAPIReadTimeout)


### PR DESCRIPTION
## Summary
- restore main API WriteTimeout to 10 minutes
- update the server timeout regression test name and expected constant

## Verification
- rtk go test ./internal/api