### PR TITLE
fix: preserve streaming write deadline through logging wrapper

### DIFF
--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -67,6 +67,11 @@ func NewResponseWriterWrapper(w gin.ResponseWriter, logger logging.RequestLogger
 	}
 }
 
+// Unwrap lets net/http.ResponseController reach the real connection through this logging wrapper.
+func (w *ResponseWriterWrapper) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 // Write wraps the underlying ResponseWriter's Write method to capture response data.
 // For non-streaming responses, it writes to an internal buffer. For streaming responses,
 // it sends data chunks to a non-blocking channel for asynchronous logging.

--- a/internal/api/middleware/response_writer_test.go
+++ b/internal/api/middleware/response_writer_test.go
@@ -1,11 +1,83 @@
 package middleware
 
 import (
+	"bytes"
+	"io"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
+
+func TestResponseWriterWrapperUnwrapReturnsWrappedWriter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	wrapper := NewResponseWriterWrapper(c.Writer, stubRequestLogger{}, &RequestInfo{}, c)
+	if got := wrapper.Unwrap(); got != c.Writer {
+		t.Fatal("expected Unwrap to return the wrapped response writer")
+	}
+}
+
+func TestRequestLoggingMiddlewareAllowsStreamingPastServerWriteTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const writeTimeout = 100 * time.Millisecond
+	r := gin.New()
+	r.Use(RequestLoggingMiddleware(stubRequestLogger{}))
+	r.POST("/v1/chat/completions", func(c *gin.Context) {
+		if err := http.NewResponseController(c.Writer).SetWriteDeadline(time.Time{}); err != nil {
+			c.String(http.StatusInternalServerError, "set write deadline: %v", err)
+			return
+		}
+
+		c.Header("Content-Type", "text/event-stream")
+		c.Status(http.StatusOK)
+		if _, err := c.Writer.Write([]byte("data: first\n\n")); err != nil {
+			return
+		}
+		c.Writer.Flush()
+
+		time.Sleep(3 * writeTimeout)
+
+		if _, err := c.Writer.Write([]byte("data: second\n\n")); err != nil {
+			return
+		}
+		c.Writer.Flush()
+	})
+
+	server := httptest.NewUnstartedServer(r)
+	server.Config.WriteTimeout = writeTimeout
+	server.Start()
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/chat/completions", bytes.NewBufferString(`{"stream":true}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("post streaming request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read streaming response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, http.StatusOK, body)
+	}
+	if got := string(body); !strings.Contains(got, "data: first") || !strings.Contains(got, "data: second") {
+		t.Fatalf("streaming body = %q, want both chunks", got)
+	}
+}
 
 func TestExtractRequestBodyPrefersOverride(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -14,6 +14,7 @@ import (
 
 	gin "github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
@@ -692,7 +693,7 @@ func TestGetContextWithCancelClearsWriteDeadlineForStreamingRequests(t *testing.
 	req.Header.Set("Content-Type", "application/json")
 	c.Request = req
 	tracking := &deadlineTrackingWriter{ResponseWriter: c.Writer}
-	c.Writer = tracking
+	c.Writer = middleware.NewResponseWriterWrapper(tracking, nil, &middleware.RequestInfo{}, c)
 
 	handler := &sdkhandlers.BaseAPIHandler{Cfg: &sdkconfig.SDKConfig{}}
 	_, cancelHandler := handler.GetContextWithCancel(nil, c, c.Request.Context())


### PR DESCRIPTION
## Summary
- add Unwrap() to ResponseWriterWrapper so net/http.ResponseController can reach the real server writer
- cover streaming deadline bypass through the logging wrapper
- add httptest.Server regression coverage with a short WriteTimeout and delayed SSE chunk

## Tests
- go test ./internal/api/middleware
- go test ./internal/api -run 'Test(GetContextWithCancelClearsWriteDeadlineForStreamingRequests|GetContextWithCancelKeepsWriteDeadlineForNonStreamingRequests|NewServerSetsMainWriteTimeout|ClearServerWriteDeadlineUsesZeroDeadline)$'\n- go test ./internal/api\n- go test ./sdk/api/handlers\n- go test ./...\n- go test ./internal/api/middleware -run TestRequestLoggingMiddlewareAllowsStreamingPastServerWriteTimeout -count=5