### PR TITLE
fix: repair docker bind mount permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 # ── Runtime ──────────────────────────────────────────────────────────────────
 FROM alpine:3.22.0
 
-RUN apk add --no-cache tzdata ca-certificates docker-cli docker-cli-compose
+RUN apk add --no-cache tzdata ca-certificates docker-cli docker-cli-compose su-exec
 
 RUN addgroup -S -g 10001 clirelay \
   && adduser -S -D -H -u 10001 -h /CLIProxyAPI -s /sbin/nologin -G clirelay clirelay \
@@ -87,6 +87,7 @@ COPY --from=backend-builder --chown=clirelay:clirelay /app/clirelay-updater /CLI
 COPY --from=frontend-builder --chown=clirelay:clirelay /frontend/dist/ /CLIProxyAPI/panel/
 
 COPY --chown=clirelay:clirelay config.example.yaml /CLIProxyAPI/config.example.yaml
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 WORKDIR /CLIProxyAPI
 
@@ -97,9 +98,13 @@ ENV TZ=Asia/Shanghai \
     AUTH_PATH=/CLIProxyAPI/auths \
     CLIRELAY_LOCALE=zh
 
-RUN cp /usr/share/zoneinfo/${TZ} /etc/localtime && echo "${TZ}" > /etc/timezone
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
+  && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
+  && echo "${TZ}" > /etc/timezone
 
-USER clirelay
+USER root
+
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD wget -q -T 2 -O /dev/null http://127.0.0.1:8317/healthz

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+case "${1:-}" in
+  ./CLIProxyAPI|CLIProxyAPI|/CLIProxyAPI/CLIProxyAPI)
+    auth_path="${AUTH_PATH:-/CLIProxyAPI/auths}"
+    mkdir -p /CLIProxyAPI/data /CLIProxyAPI/logs "$auth_path"
+    case "$auth_path" in
+      /root/*) chmod 755 /root ;;
+    esac
+    chown -R clirelay:clirelay /CLIProxyAPI/data /CLIProxyAPI/logs "$auth_path"
+    if [ -e /CLIProxyAPI/config.yaml ]; then
+      chown clirelay:clirelay /CLIProxyAPI/config.yaml 2>/dev/null || true
+    fi
+    exec su-exec clirelay:clirelay "$@"
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -895,6 +895,9 @@ main() {
 
     step 3 "$(is_zh && echo "准备配置与部署元数据" || echo "Preparing configuration and deployment metadata")"
     mkdir -p "${INSTALL_DIR}" "${INSTALL_DIR}/auths" "${INSTALL_DIR}/logs" "${INSTALL_DIR}/data"
+    if [[ "${OS_NAME}" != "Darwin" ]]; then
+        chown -R 10001:10001 "${INSTALL_DIR}/auths" "${INSTALL_DIR}/logs" "${INSTALL_DIR}/data" || warn "Could not chown data directories; the container entrypoint will retry at startup."
+    fi
     if [[ "$is_update" == "true" ]]; then
         if is_zh; then
             success "保留现有配置: ${INSTALL_DIR}/config.yaml"
@@ -909,6 +912,9 @@ main() {
         else
             success "Configuration file written"
         fi
+    fi
+    if [[ "${OS_NAME}" != "Darwin" ]] && [[ -f "${INSTALL_DIR}/config.yaml" ]]; then
+        chown 10001:10001 "${INSTALL_DIR}/config.yaml" || warn "Could not chown config.yaml; management config writes may require the container entrypoint to repair it."
     fi
     write_env
     write_compose


### PR DESCRIPTION
## Summary
- add a Docker entrypoint that repairs writable bind mount ownership before starting the main service
- keep the updater sidecar running as root so online updates keep working
- make install.sh best-effort chown new deployment data/config paths

## Verification
- sh -n docker-entrypoint.sh
- bash -n install.sh
- go test ./...
- Alpine container simulation for root-owned data/log/auth/config paths and updater root execution