### PR TITLE
feat(apikey): add daily spending limit

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -218,6 +218,7 @@ routing:
 # api-key-entries:
 #   - key: "sk-user-pro"
 #     name: "Pro User"
+#     daily-spending-limit: 2.0
 #     allowed-channel-groups: ["pro"]
 #   - key: "sk-team-a"
 #     name: "Team A"

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -53,6 +53,7 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 			dailyLimit:           entry.DailyLimit,
 			totalQuota:           entry.TotalQuota,
 			spendingLimit:        entry.SpendingLimit,
+			dailySpendingLimit:   entry.DailySpendingLimit,
 			concurrencyLimit:     entry.ConcurrencyLimit,
 			rpmLimit:             entry.RPMLimit,
 			tpmLimit:             entry.TPMLimit,
@@ -78,6 +79,7 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 			dailyLimit:           row.DailyLimit,
 			totalQuota:           row.TotalQuota,
 			spendingLimit:        row.SpendingLimit,
+			dailySpendingLimit:   row.DailySpendingLimit,
 			concurrencyLimit:     row.ConcurrencyLimit,
 			rpmLimit:             row.RPMLimit,
 			tpmLimit:             row.TPMLimit,
@@ -105,6 +107,7 @@ type keyConfig struct {
 	dailyLimit           int
 	totalQuota           int
 	spendingLimit        float64
+	dailySpendingLimit   float64
 	concurrencyLimit     int
 	rpmLimit             int
 	tpmLimit             int
@@ -198,6 +201,9 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 			}
 			if kc.spendingLimit > 0 {
 				metadata["spending-limit"] = fmt.Sprintf("%f", kc.spendingLimit)
+			}
+			if kc.dailySpendingLimit > 0 {
+				metadata["daily-spending-limit"] = fmt.Sprintf("%f", kc.dailySpendingLimit)
 			}
 			if kc.systemPrompt != "" {
 				metadata["system-prompt"] = kc.systemPrompt

--- a/internal/access/config_access/provider_test.go
+++ b/internal/access/config_access/provider_test.go
@@ -1,0 +1,29 @@
+package configaccess
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestProviderEmitsDailySpendingLimitMetadata(t *testing.T) {
+	cfg := &config.SDKConfig{
+		APIKeyEntries: []config.APIKeyEntry{{
+			Key:                "sk-daily-cost",
+			DailySpendingLimit: 4.5,
+		}},
+	}
+	p := newProvider("test", buildKeyConfigMap(cfg))
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-daily-cost")
+	res, authErr := p.Authenticate(context.Background(), req)
+	if authErr != nil {
+		t.Fatalf("Authenticate() error = %v", authErr)
+	}
+	if got := res.Metadata["daily-spending-limit"]; got != "4.500000" {
+		t.Fatalf("daily-spending-limit metadata = %q, want 4.500000", got)
+	}
+}

--- a/internal/api/middleware/quota.go
+++ b/internal/api/middleware/quota.go
@@ -123,7 +123,7 @@ func RecordTokenUsage(apiKey string, totalTokens int64) {
 // ─── Quota Middleware ───────────────────────────────────────────────────────
 
 // QuotaMiddleware enforces daily-limit, total-quota, RPM (requests per minute),
-// and TPM (tokens per minute) restrictions for authenticated API keys.
+// TPM (tokens per minute), and spending restrictions for authenticated API keys.
 //
 // It reads the limits from the accessMetadata set by the auth provider.
 // This middleware MUST be placed after AuthMiddleware and before route handlers.
@@ -173,12 +173,13 @@ func QuotaMiddleware() gin.HandlerFunc {
 		rpmLimit := parseIntMetadata(metadata, "rpm-limit")
 		tpmLimit := parseIntMetadata(metadata, "tpm-limit")
 		spendingLimit := parseFloatMetadata(metadata, "spending-limit")
+		dailySpendingLimit := parseFloatMetadata(metadata, "daily-spending-limit")
 
 		// Cache limits for dashboard snapshot
 		UpdateKeyLimits(apiKey, rpmLimit, tpmLimit)
 
 		// No limits configured — skip all checks
-		if dailyLimit <= 0 && totalQuota <= 0 && concurrencyLimit <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 {
+		if dailyLimit <= 0 && totalQuota <= 0 && concurrencyLimit <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 && dailySpendingLimit <= 0 {
 			c.Next()
 			return
 		}
@@ -278,6 +279,23 @@ func QuotaMiddleware() gin.HandlerFunc {
 			}
 		}
 
+		// --- Daily spending limit check (from usage DB) ---
+		if dailySpendingLimit > 0 {
+			todayCost, err := queryTodayCostByKeyFunc(apiKey)
+			if err != nil {
+				log.Warnf("quota: failed to query today cost for key %s: %v", maskKey(apiKey), err)
+			} else if todayCost >= dailySpendingLimit {
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+					"error": map[string]interface{}{
+						"message": fmt.Sprintf("daily spending limit ($%.2f) exceeded for this API key (today: $%.2f)", dailySpendingLimit, todayCost),
+						"type":    "rate_limit_exceeded",
+						"code":    "daily_spending_limit_exceeded",
+					},
+				})
+				return
+			}
+		}
+
 		c.Next()
 	}
 }
@@ -290,6 +308,7 @@ var (
 	countTodayByKeyFunc     = func(string) (int64, error) { return 0, nil }
 	countTotalByKeyFunc     = func(string) (int64, error) { return 0, nil }
 	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
 )
 
 // InitQuotaUsageFuncs injects the usage DB query functions into the middleware.
@@ -298,10 +317,12 @@ func InitQuotaUsageFuncs(
 	countToday func(string) (int64, error),
 	countTotal func(string) (int64, error),
 	totalCost func(string) (float64, error),
+	todayCost func(string) (float64, error),
 ) {
 	countTodayByKeyFunc = countToday
 	countTotalByKeyFunc = countTotal
 	queryTotalCostByKeyFunc = totalCost
+	queryTodayCostByKeyFunc = todayCost
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/internal/api/middleware/quota_test.go
+++ b/internal/api/middleware/quota_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -70,6 +71,53 @@ func TestQuotaMiddlewareEnforcesConcurrencyLimitPerKey(t *testing.T) {
 	}
 }
 
+func TestQuotaMiddlewareDailySpendingLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetQuotaMiddlewareState(t)
+
+	queryTodayCostByKeyFunc = func(key string) (float64, error) {
+		if key == "key-over" {
+			return 50, nil
+		}
+		return 20, nil
+	}
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("apiKey", c.GetHeader("X-Test-Key"))
+		c.Set("accessMetadata", map[string]string{"daily-spending-limit": "50"})
+		c.Next()
+	})
+	router.Use(QuotaMiddleware())
+	router.POST("/v1/chat/completions", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	allowed := httptest.NewRecorder()
+	router.ServeHTTP(allowed, newQuotaPostRequest("key-under"))
+	if allowed.Code != http.StatusNoContent {
+		t.Fatalf("under-limit status = %d, want %d", allowed.Code, http.StatusNoContent)
+	}
+
+	blocked := httptest.NewRecorder()
+	router.ServeHTTP(blocked, newQuotaPostRequest("key-over"))
+	if blocked.Code != http.StatusTooManyRequests {
+		t.Fatalf("over-limit status = %d, want %d", blocked.Code, http.StatusTooManyRequests)
+	}
+
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(blocked.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body.Error.Code != "daily_spending_limit_exceeded" {
+		t.Fatalf("error code = %q, want daily_spending_limit_exceeded", body.Error.Code)
+	}
+}
+
 func newQuotaPostRequest(key string) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("X-Test-Key", key)
@@ -85,4 +133,14 @@ func resetQuotaMiddlewareState(t *testing.T) {
 	inFlightMu.Lock()
 	inFlightByKey = map[string]int{}
 	inFlightMu.Unlock()
+	countTodayByKeyFunc = func(string) (int64, error) { return 0, nil }
+	countTotalByKeyFunc = func(string) (int64, error) { return 0, nil }
+	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+	t.Cleanup(func() {
+		countTodayByKeyFunc = func(string) (int64, error) { return 0, nil }
+		countTotalByKeyFunc = func(string) (int64, error) { return 0, nil }
+		queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+		queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+	})
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -65,7 +65,7 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 	usage.ApplyStoredProxyPool(cfg)
 	settingsstore.MigrateRuntimeSettingsFromConfig(cfg, configPath)
 	settingsstore.ApplyStoredRuntimeSettings(cfg)
-	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey)
+	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey, usage.QueryTodayCostByKey)
 	usage.SetTokenUsageCallback(middleware.RecordTokenUsage)
 	usage.InitRedis(cfg.Redis)
 	defer usage.StopRedis()
@@ -137,7 +137,7 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 	usage.ApplyStoredProxyPool(cfg)
 	settingsstore.MigrateRuntimeSettingsFromConfig(cfg, configPath)
 	settingsstore.ApplyStoredRuntimeSettings(cfg)
-	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey)
+	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey, usage.QueryTodayCostByKey)
 	usage.SetTokenUsageCallback(middleware.RecordTokenUsage)
 	usage.InitRedis(cfg.Redis)
 

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -123,6 +123,10 @@ type APIKeyEntry struct {
 	// total accumulated cost exceeds this limit.
 	SpendingLimit float64 `yaml:"spending-limit,omitempty" json:"spending-limit,omitempty"`
 
+	// DailySpendingLimit is the maximum allowed spending in US dollars per day. 0 means
+	// unlimited. It resets at the project timezone day boundary.
+	DailySpendingLimit float64 `yaml:"daily-spending-limit,omitempty" json:"daily-spending-limit,omitempty"`
+
 	// ConcurrencyLimit is the maximum number of concurrent requests. 0 means unlimited.
 	ConcurrencyLimit int `yaml:"concurrency-limit,omitempty" json:"concurrency-limit,omitempty"`
 

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -41,6 +41,7 @@ type EntryPatch struct {
 	DailyLimit           *int      `json:"daily-limit"`
 	TotalQuota           *int      `json:"total-quota"`
 	SpendingLimit        *float64  `json:"spending-limit"`
+	DailySpendingLimit   *float64  `json:"daily-spending-limit"`
 	ConcurrencyLimit     *int      `json:"concurrency-limit"`
 	RPMLimit             *int      `json:"rpm-limit"`
 	TPMLimit             *int      `json:"tpm-limit"`
@@ -285,6 +286,9 @@ func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryP
 	}
 	if patch.SpendingLimit != nil {
 		entry.SpendingLimit = *patch.SpendingLimit
+	}
+	if patch.DailySpendingLimit != nil {
+		entry.DailySpendingLimit = *patch.DailySpendingLimit
 	}
 	if patch.ConcurrencyLimit != nil {
 		entry.ConcurrencyLimit = *patch.ConcurrencyLimit

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -108,6 +108,28 @@ func TestPatchEntryRenamePreservesStableID(t *testing.T) {
 	}
 }
 
+func TestPatchEntryUpdatesDailySpendingLimit(t *testing.T) {
+	setupTestDB(t)
+	svc := NewService(nil)
+
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{ID: "key-1", Key: "sk-cost", DailySpendingLimit: 1}); err != nil {
+		t.Fatalf("UpsertAPIKey(sk-cost): %v", err)
+	}
+
+	limit := 4.5
+	if err := svc.PatchEntry(&[]string{"key-1"}[0], nil, nil, EntryPatch{DailySpendingLimit: &limit}); err != nil {
+		t.Fatalf("PatchEntry() error = %v", err)
+	}
+
+	got := usage.GetAPIKey("sk-cost")
+	if got == nil {
+		t.Fatal("expected patched key")
+	}
+	if got.DailySpendingLimit != limit {
+		t.Fatalf("DailySpendingLimit = %v, want %v", got.DailySpendingLimit, limit)
+	}
+}
+
 func TestReplacePermissionProfilesValidatesAndSanitizes(t *testing.T) {
 	setupTestDB(t)
 	svc := NewService(func(channels []string) ([]string, error) {

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS api_keys (
   daily_limit       INTEGER NOT NULL DEFAULT 0,
   total_quota       INTEGER NOT NULL DEFAULT 0,
   spending_limit    REAL NOT NULL DEFAULT 0,
+  daily_spending_limit REAL NOT NULL DEFAULT 0,
   concurrency_limit INTEGER NOT NULL DEFAULT 0,
   rpm_limit         INTEGER NOT NULL DEFAULT 0,
   tpm_limit         INTEGER NOT NULL DEFAULT 0,
@@ -46,6 +47,7 @@ type APIKeyRow struct {
 	DailyLimit           int      `json:"daily-limit,omitempty"`
 	TotalQuota           int      `json:"total-quota,omitempty"`
 	SpendingLimit        float64  `json:"spending-limit,omitempty"`
+	DailySpendingLimit   float64  `json:"daily-spending-limit,omitempty"`
 	ConcurrencyLimit     int      `json:"concurrency-limit,omitempty"`
 	RPMLimit             int      `json:"rpm-limit,omitempty"`
 	TPMLimit             int      `json:"tpm-limit,omitempty"`
@@ -111,6 +113,7 @@ func (r APIKeyRow) ToConfigEntry() config.APIKeyEntry {
 		DailyLimit:           r.DailyLimit,
 		TotalQuota:           r.TotalQuota,
 		SpendingLimit:        r.SpendingLimit,
+		DailySpendingLimit:   r.DailySpendingLimit,
 		ConcurrencyLimit:     r.ConcurrencyLimit,
 		RPMLimit:             r.RPMLimit,
 		TPMLimit:             r.TPMLimit,
@@ -132,6 +135,7 @@ func APIKeyRowFromConfig(entry config.APIKeyEntry) APIKeyRow {
 		DailyLimit:           entry.DailyLimit,
 		TotalQuota:           entry.TotalQuota,
 		SpendingLimit:        entry.SpendingLimit,
+		DailySpendingLimit:   entry.DailySpendingLimit,
 		ConcurrencyLimit:     entry.ConcurrencyLimit,
 		RPMLimit:             entry.RPMLimit,
 		TPMLimit:             entry.TPMLimit,
@@ -173,7 +177,7 @@ func (s Store) List() []APIKeyRow {
 	}
 
 	rows, err := s.db.Query(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_keys ORDER BY created_at ASC`)
 	if err != nil {
@@ -196,7 +200,7 @@ func (s Store) Get(key string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_keys WHERE key = ?`, trimmed)
 	entry, ok := scanAPIKeyRow(row)
@@ -217,7 +221,7 @@ func (s Store) GetByID(id string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_keys WHERE id = ?`, trimmed)
 	entry, ok := scanAPIKeyRow(row)
@@ -255,22 +259,22 @@ func (s Store) Upsert(entry APIKeyRow) error {
 	}
 
 	_, err := s.db.Exec(`INSERT INTO api_keys
-		(key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
+		(key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(key) DO UPDATE SET
 			id=excluded.id,
 			name=excluded.name, disabled=excluded.disabled,
 			permission_profile_id=excluded.permission_profile_id,
 			daily_limit=excluded.daily_limit, total_quota=excluded.total_quota,
-			spending_limit=excluded.spending_limit, concurrency_limit=excluded.concurrency_limit,
+			spending_limit=excluded.spending_limit, daily_spending_limit=excluded.daily_spending_limit, concurrency_limit=excluded.concurrency_limit,
 			rpm_limit=excluded.rpm_limit, tpm_limit=excluded.tpm_limit,
 			allowed_models=excluded.allowed_models, allowed_channels=excluded.allowed_channels,
 			allowed_channel_groups=excluded.allowed_channel_groups,
 			system_prompt=excluded.system_prompt,
 			updated_at=excluded.updated_at`,
 		entry.Key, entry.ID, entry.Name, disabledInt, entry.PermissionProfileID,
-		entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit,
+		entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit, entry.DailySpendingLimit,
 		entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
@@ -308,12 +312,12 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 
 	_, err := s.db.Exec(`UPDATE api_keys SET
 		key = ?, name = ?, disabled = ?, permission_profile_id = ?, daily_limit = ?, total_quota = ?,
-		spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
+		spending_limit = ?, daily_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
 		allowed_models = ?, allowed_channels = ?, allowed_channel_groups = ?, system_prompt = ?,
 		created_at = ?, updated_at = ?
 		WHERE id = ?`,
 		entry.Key, entry.Name, disabledInt, entry.PermissionProfileID, entry.DailyLimit, entry.TotalQuota,
-		entry.SpendingLimit, entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
+		entry.SpendingLimit, entry.DailySpendingLimit, entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
 		entry.CreatedAt, now, entry.ID,
@@ -370,9 +374,9 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_keys
-		(key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit,
+		(key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -401,7 +405,7 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 		}
 		if _, err := stmt.Exec(
 			entry.Key, entry.ID, entry.Name, disabledInt, entry.PermissionProfileID,
-			entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit,
+			entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit, entry.DailySpendingLimit,
 			entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 			mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 			mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
@@ -437,6 +441,7 @@ func EffectiveAPIKeyRowWithProfiles(row APIKeyRow, profiles []PermissionProfileS
 	row.DailyLimit = matched.DailyLimit
 	row.TotalQuota = matched.TotalQuota
 	row.SpendingLimit = 0
+	row.DailySpendingLimit = 0
 	row.ConcurrencyLimit = matched.ConcurrencyLimit
 	row.RPMLimit = matched.RPMLimit
 	row.TPMLimit = matched.TPMLimit
@@ -467,6 +472,7 @@ func migrateColumns(db *sql.DB) {
 		{name: "permission_profile_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "allowed_channels", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "allowed_channel_groups", definition: "TEXT NOT NULL DEFAULT '[]'"},
+		{name: "daily_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
 	} {
 		if _, err := db.Exec("ALTER TABLE api_keys ADD COLUMN " + col.name + " " + col.definition); err != nil {
 			if !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
@@ -625,7 +631,7 @@ func scanAPIKeyRow(row scanner) (*APIKeyRow, bool) {
 		&entry.Key, &entry.Name, &disabledInt,
 		&entry.ID,
 		&entry.DailyLimit, &entry.TotalQuota, &entry.PermissionProfileID, &entry.SpendingLimit,
-		&entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
+		&entry.DailySpendingLimit, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
 		&modelsJSON, &channelsJSON, &channelGroupsJSON, &entry.SystemPrompt,
 		&entry.CreatedAt, &entry.UpdatedAt,
 	); err != nil {

--- a/internal/usage/apikey_db_test.go
+++ b/internal/usage/apikey_db_test.go
@@ -58,6 +58,7 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 		Name:                "Test Key",
 		PermissionProfileID: "standard",
 		DailyLimit:          100,
+		DailySpendingLimit:  12.5,
 		SystemPrompt:        "You are a helpful assistant.\n### Special chars: # * ** ☢️",
 	}
 
@@ -75,6 +76,9 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 	if got.DailyLimit != 100 {
 		t.Errorf("daily_limit = %d, want 100", got.DailyLimit)
 	}
+	if got.DailySpendingLimit != 12.5 {
+		t.Errorf("daily_spending_limit = %v, want 12.5", got.DailySpendingLimit)
+	}
 	if got.PermissionProfileID != "standard" {
 		t.Errorf("permission_profile_id = %q, want %q", got.PermissionProfileID, "standard")
 	}
@@ -86,6 +90,7 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 	entry.Name = "Updated Key"
 	entry.PermissionProfileID = "strict"
 	entry.DailyLimit = 200
+	entry.DailySpendingLimit = 7.25
 	if err := UpsertAPIKey(entry); err != nil {
 		t.Fatalf("UpsertAPIKey (update): %v", err)
 	}
@@ -99,6 +104,9 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 	}
 	if got.DailyLimit != 200 {
 		t.Errorf("daily_limit after update = %d, want 200", got.DailyLimit)
+	}
+	if got.DailySpendingLimit != 7.25 {
+		t.Errorf("daily_spending_limit after update = %v, want 7.25", got.DailySpendingLimit)
 	}
 	if got.PermissionProfileID != "strict" {
 		t.Errorf("permission_profile_id after update = %q, want %q", got.PermissionProfileID, "strict")
@@ -314,10 +322,11 @@ func TestAPIKeySystemPromptSpecialChars(t *testing.T) {
 
 func TestAPIKeyToConfigEntry(t *testing.T) {
 	row := APIKeyRow{
-		Key:           "sk-convert",
-		Name:          "Converted",
-		DailyLimit:    50,
-		AllowedModels: []string{"model-a"},
+		Key:                "sk-convert",
+		Name:               "Converted",
+		DailyLimit:         50,
+		DailySpendingLimit: 3.5,
+		AllowedModels:      []string{"model-a"},
 		AllowedChannels: []string{
 			"Claude Team",
 		},
@@ -328,6 +337,9 @@ func TestAPIKeyToConfigEntry(t *testing.T) {
 	entry := row.ToConfigEntry()
 	if entry.Key != row.Key || entry.Name != row.Name || entry.DailyLimit != row.DailyLimit {
 		t.Errorf("ToConfigEntry mismatch: %+v", entry)
+	}
+	if entry.DailySpendingLimit != row.DailySpendingLimit {
+		t.Errorf("DailySpendingLimit mismatch: %v vs %v", entry.DailySpendingLimit, row.DailySpendingLimit)
 	}
 	if entry.SystemPrompt != row.SystemPrompt {
 		t.Errorf("SystemPrompt mismatch: %q vs %q", entry.SystemPrompt, row.SystemPrompt)

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -346,3 +346,22 @@ func QueryTotalCostByKey(apiKey string) (float64, error) {
 	}
 	return total, nil
 }
+
+// QueryTodayCostByKey returns the project-day accumulated cost for an API key.
+func QueryTodayCostByKey(apiKey string) (float64, error) {
+	db := getDB()
+	if db == nil {
+		return 0, nil
+	}
+	clause, args := buildSingleAPIKeySelectorClause(apiKey)
+	args = append(args, CutoffStartUTC(1).Format(time.RFC3339))
+	var total float64
+	err := db.QueryRow(
+		"SELECT COALESCE(SUM(cost), 0) FROM request_logs"+clause+" AND timestamp >= ?",
+		args...,
+	).Scan(&total)
+	if err != nil {
+		return 0, fmt.Errorf("usage: query today cost: %w", err)
+	}
+	return total, nil
+}

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -1,6 +1,10 @@
 package usage
 
-import "testing"
+import (
+	"math"
+	"testing"
+	"time"
+)
 
 func TestCalculateCostDiscountsCachedInputSubset(t *testing.T) {
 	initModelConfigTestDB(t)
@@ -253,5 +257,41 @@ func TestCalculateCostV2FallbackLegacyWithModelPricingTable(t *testing.T) {
 	want := CalculateCost("legacy-table-model", 1000, 500, 800)
 	if cost != want {
 		t.Fatalf("cost = %.10f, want %.10f (legacy CalculateCost = %.10f)", cost, want, want)
+	}
+}
+
+func TestQueryTodayCostByKeyResetsDaily(t *testing.T) {
+	initModelConfigTestDB(t)
+	db := getDB()
+	if db == nil {
+		t.Fatal("expected test db")
+	}
+
+	today := CutoffStartUTC(1)
+	yesterday := today.Add(-time.Second)
+	for _, row := range []struct {
+		ts   time.Time
+		cost float64
+	}{
+		{ts: today.Add(time.Hour), cost: 1.25},
+		{ts: today.Add(2 * time.Hour), cost: 2.75},
+		{ts: yesterday, cost: 100},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO request_logs
+			 (timestamp, api_key, model, source, failed, latency_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+			 VALUES (?, ?, ?, ?, 0, 1, 0, 0, 0, 0, 0, ?)`,
+			row.ts.Format(time.RFC3339), "sk-daily-spending", "model", "test", row.cost,
+		); err != nil {
+			t.Fatalf("insert request log: %v", err)
+		}
+	}
+
+	got, err := QueryTodayCostByKey("sk-daily-spending")
+	if err != nil {
+		t.Fatalf("QueryTodayCostByKey() error = %v", err)
+	}
+	if math.Abs(got-4) > 1e-12 {
+		t.Fatalf("today cost = %v, want 4", got)
 	}
 }


### PR DESCRIPTION
## Summary
- add `daily-spending-limit` for API keys as a per-day cost cap separate from cumulative `spending-limit`
- persist `daily_spending_limit` in SQLite with safe default migration
- wire the field through config entries, management patching, access metadata, usage cost lookup, and quota middleware
- reject capped requests with HTTP 429 and `daily_spending_limit_exceeded`

## Tests
- `rtk go test ./internal/api/middleware ./internal/usage ./internal/access/config_access ./internal/management/settings/apikey`
- `rtk git diff --check`
- `rtk go test ./internal/storage/sqlite/apikey`
- `rtk go test ./internal/...`
- `rtk go build ./internal/... ./cmd/... ./sdk/... ./sdkbridge/...`

Closes #442
Supersedes #471