### PR TITLE
fix: handle Claude system messages

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -117,6 +117,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 
 	body = execCtx.ApplyPayloadConfig(body, originalTranslated)
+	body = rebuildMidSystemMessagesToTopLevel(body)
 
 	if !skipAnthropic {
 		// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
@@ -252,6 +253,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	}
 
 	body = execCtx.ApplyPayloadConfig(body, originalTranslated)
+	body = rebuildMidSystemMessagesToTopLevel(body)
 
 	if !skipAnthropic {
 		// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
@@ -398,6 +400,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	})
 	body, _ := execCtx.TranslateRequestPair(req.Payload)
 	body, _ = sjson.SetBytes(body, "model", execCtx.BaseModel)
+	body = rebuildMidSystemMessagesToTopLevel(body)
 
 	if !strings.HasPrefix(execCtx.BaseModel, "claude-3-5-haiku") {
 		body = checkSystemInstructions(body)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,146 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+// TestRebuildMidSystemMessagesToTopLevel 验证 system-role messages 会转换为顶层 system blocks。
+func TestRebuildMidSystemMessagesToTopLevel(t *testing.T) {
+	input := []byte(`{
+		"system": [{"type":"text","text":"existing system"}],
+		"messages": [
+			{"role":"system","content":"metadata system"},
+			{"role":"user","content":[{"type":"text","text":"hi"}]},
+			{"role":"SYSTEM","content":[
+				"array text",
+				{"type":"text","text":"block text"},
+				{"type":"image","source":{"type":"url","url":"https://example.com/image.png"}}
+			]},
+			{"role":"assistant","content":[{"type":"text","text":"hello"}]}
+		]
+	}`)
+
+	out := rebuildMidSystemMessagesToTopLevel(input)
+
+	if got := gjson.GetBytes(out, "messages.#").Int(); got != 2 {
+		t.Fatalf("messages count = %d, want 2; body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "messages.0.role").String(); got != "user" {
+		t.Fatalf("messages.0.role = %q, want user", got)
+	}
+	if got := gjson.GetBytes(out, "messages.1.role").String(); got != "assistant" {
+		t.Fatalf("messages.1.role = %q, want assistant", got)
+	}
+	wantSystem := []string{"existing system", "metadata system", "array text", "block text"}
+	for i, want := range wantSystem {
+		path := fmt.Sprintf("system.%d.text", i)
+		if got := gjson.GetBytes(out, path).String(); got != want {
+			t.Fatalf("%s = %q, want %q; body=%s", path, got, want, string(out))
+		}
+	}
+}
+
+// TestClaudeExecutorRebuildsSystemMessagesForUpstreamRequests 验证所有 Claude 上游路径都会清理 system-role messages。
+func TestClaudeExecutorRebuildsSystemMessagesForUpstreamRequests(t *testing.T) {
+	for _, mode := range []string{"execute", "stream", "count_tokens"} {
+		t.Run(mode, func(t *testing.T) {
+			var gotBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var wantPath string
+				if mode == "count_tokens" {
+					wantPath = "/v1/messages/count_tokens"
+				} else {
+					wantPath = "/v1/messages"
+				}
+				if r.URL.Path != wantPath {
+					t.Fatalf("path = %q, want %q", r.URL.Path, wantPath)
+				}
+				var err error
+				gotBody, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("read request body: %v", err)
+				}
+				if mode == "stream" {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if mode == "count_tokens" {
+					_, _ = w.Write([]byte(`{"input_tokens":1}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{
+					"id":"msg_1",
+					"type":"message",
+					"model":"claude-3-5-sonnet",
+					"role":"assistant",
+					"content":[{"type":"text","text":"ok"}],
+					"usage":{"input_tokens":1,"output_tokens":1}
+				}`))
+			}))
+			defer server.Close()
+
+			executor := NewClaudeExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"api_key":                   "key-123",
+				"base_url":                  server.URL,
+				"skip_anthropic_processing": "true",
+			}}
+			payload := []byte(`{
+				"model":"claude-3-5-sonnet",
+				"system":[{"type":"text","text":"existing system"}],
+				"messages":[
+					{"role":"system","content":"metadata system"},
+					{"role":"user","content":[{"type":"text","text":"hi"}]}
+				]
+			}`)
+			req := cliproxyexecutor.Request{Model: "claude-3-5-sonnet", Payload: payload}
+			opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
+
+			switch mode {
+			case "execute":
+				if _, err := executor.Execute(context.Background(), auth, req, opts); err != nil {
+					t.Fatalf("Execute error: %v", err)
+				}
+			case "stream":
+				result, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+				if err != nil {
+					t.Fatalf("ExecuteStream error: %v", err)
+				}
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatalf("stream chunk error: %v", chunk.Err)
+					}
+				}
+			case "count_tokens":
+				if _, err := executor.CountTokens(context.Background(), auth, req, opts); err != nil {
+					t.Fatalf("CountTokens error: %v", err)
+				}
+			}
+
+			messages := gjson.GetBytes(gotBody, "messages")
+			messages.ForEach(func(index, message gjson.Result) bool {
+				if strings.EqualFold(message.Get("role").String(), "system") {
+					t.Fatalf("messages.%d.role = system; body=%s", index.Int(), string(gotBody))
+				}
+				return true
+			})
+			foundExisting := false
+			foundMetadata := false
+			gjson.GetBytes(gotBody, "system").ForEach(func(_, part gjson.Result) bool {
+				switch part.Get("text").String() {
+				case "existing system":
+					foundExisting = true
+				case "metadata system":
+					foundMetadata = true
+				}
+				return true
+			})
+			if !foundExisting || !foundMetadata {
+				t.Fatalf("system blocks missing existing=%v metadata=%v; body=%s", foundExisting, foundMetadata, string(gotBody))
+			}
+		})
+	}
+}
 
 func TestApplyClaudeToolPrefix(t *testing.T) {
 	input := []byte(`{"tools":[{"name":"alpha"},{"name":"proxy_bravo"}],"tool_choice":{"type":"tool","name":"charlie"},"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"delta","id":"t1","input":{}}]}]}`)

--- a/internal/runtime/executor/claude_tool_prefix.go
+++ b/internal/runtime/executor/claude_tool_prefix.go
@@ -28,6 +28,98 @@ func checkSystemInstructions(payload []byte) []byte {
 	return payload
 }
 
+// rebuildMidSystemMessagesToTopLevel 将 Anthropic 不兼容的 system-role 消息移到顶层 system。
+func rebuildMidSystemMessagesToTopLevel(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return payload
+	}
+
+	var movedSystemParts []string
+	removedSystemMessage := false
+	keptMessages := make([]string, 0, int(messages.Get("#").Int()))
+	messages.ForEach(func(_, message gjson.Result) bool {
+		if strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "system") {
+			removedSystemMessage = true
+			movedSystemParts = append(movedSystemParts, claudeSystemTextParts(message.Get("content"))...)
+			return true
+		}
+		keptMessages = append(keptMessages, message.Raw)
+		return true
+	})
+	if !removedSystemMessage {
+		return payload
+	}
+
+	systemParts := claudeSystemTextParts(gjson.GetBytes(payload, "system"))
+	systemParts = append(systemParts, movedSystemParts...)
+	if len(systemParts) > 0 {
+		if updated, err := sjson.SetRawBytes(payload, "system", rawJSONArray(systemParts)); err == nil {
+			payload = updated
+		}
+	}
+	if updated, err := sjson.SetRawBytes(payload, "messages", rawJSONArray(keptMessages)); err == nil {
+		payload = updated
+	}
+	return payload
+}
+
+// claudeSystemTextParts 从支持的 system content 结构中提取有效的 Anthropic text block。
+func claudeSystemTextParts(content gjson.Result) []string {
+	if !content.Exists() {
+		return nil
+	}
+	if content.Type == gjson.String {
+		text := content.String()
+		if strings.TrimSpace(text) == "" {
+			return nil
+		}
+		block := []byte(`{"type":"text","text":""}`)
+		block, _ = sjson.SetBytes(block, "text", text)
+		return []string{string(block)}
+	}
+	if !content.IsArray() {
+		return nil
+	}
+
+	parts := make([]string, 0, int(content.Get("#").Int()))
+	content.ForEach(func(_, item gjson.Result) bool {
+		if item.Type == gjson.String {
+			text := item.String()
+			if strings.TrimSpace(text) != "" {
+				block := []byte(`{"type":"text","text":""}`)
+				block, _ = sjson.SetBytes(block, "text", text)
+				parts = append(parts, string(block))
+			}
+			return true
+		}
+		if item.IsObject() &&
+			item.Get("type").String() == "text" &&
+			strings.TrimSpace(item.Get("text").String()) != "" {
+			parts = append(parts, item.Raw)
+		}
+		return true
+	})
+	return parts
+}
+
+// rawJSONArray 用已编码的 JSON item 字符串构造 JSON array。
+func rawJSONArray(items []string) []byte {
+	if len(items) == 0 {
+		return []byte("[]")
+	}
+	var builder strings.Builder
+	builder.WriteByte('[')
+	for i, item := range items {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(item)
+	}
+	builder.WriteByte(']')
+	return []byte(builder.String())
+}
+
 func isClaudeOAuthToken(apiKey string) bool {
 	return strings.Contains(apiKey, "sk-ant-oat")
 }

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -65,6 +65,9 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 		for i := 0; i < len(messageResults); i++ {
 			messageResult := messageResults[i]
 			messageRole := messageResult.Get("role").String()
+			if strings.EqualFold(strings.TrimSpace(messageRole), "system") {
+				messageRole = "developer"
+			}
 
 			newMessage := func() string {
 				msg := `{"type": "message","role":"","content":[]}`

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -26,6 +27,34 @@ func TestConvertClaudeRequestToCodex_StripsDeferLoading(t *testing.T) {
 	tools.ForEach(func(i, tool gjson.Result) bool {
 		if tool.Get("defer_loading").Exists() {
 			t.Fatalf("tool %d still has defer_loading: %s", i.Int(), tool.Raw)
+		}
+		return true
+	})
+}
+
+func TestConvertClaudeRequestToCodexConvertsSystemRoleMessagesToDeveloper(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"messages": [
+			{"role": "system", "content": "metadata system"},
+			{"role": "user", "content": "hi"}
+		]
+	}`)
+
+	out := ConvertClaudeRequestToCodex("gpt-5.5", input, true)
+
+	if got := gjson.GetBytes(out, "input.0.role").String(); got != "developer" {
+		t.Fatalf("input.0.role = %q, want developer; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "input.0.content.0.text").String(); got != "metadata system" {
+		t.Fatalf("input.0.content.0.text = %q, want metadata system; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "input.1.role").String(); got != "user" {
+		t.Fatalf("input.1.role = %q, want user; body=%s", got, out)
+	}
+	gjson.GetBytes(out, "input").ForEach(func(index, item gjson.Result) bool {
+		if strings.EqualFold(strings.TrimSpace(item.Get("role").String()), "system") {
+			t.Fatalf("input.%d.role = system; body=%s", index.Int(), out)
 		}
 		return true
 	})


### PR DESCRIPTION
## Summary
- Move Claude `messages[].role == \"system\"` entries into top-level `system` before calling Anthropic-compatible upstreams.
- Convert Claude system-role messages to Codex `developer` messages for Claude CLI requests routed to Codex models like `gpt-5.5`.
- Add regression coverage for Claude non-stream, stream, count_tokens, and Claude-to-Codex translation paths.

## Test plan
- [x] `mise x go@1.26.1 -- go test ./internal/runtime/executor ./internal/translator/codex/claude`
- [x] Runtime verified Claude-to-Claude upstream path with non-stream, stream, and count_tokens requests against a fake Anthropic upstream.
- [x] Runtime verified Claude-to-Codex path with non-stream, stream, and count_tokens requests against a fake Codex upstream; upstream payloads no longer contain system-role input/messages.
- [x] Manually verified `claude -p \"hi\"` works through the local service after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)