### PR TITLE
feat: add request diagnostics to error logs

### DIFF
--- a/internal/api/auth_middleware.go
+++ b/internal/api/auth_middleware.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	log "github.com/sirupsen/logrus"
 )
@@ -11,6 +13,7 @@ import (
 func AuthMiddleware(manager *sdkaccess.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if manager == nil {
+			diagnostics.SetLocalError(c, http.StatusInternalServerError, "local_auth", "auth_manager_unavailable", "server_error", "authentication manager not initialized")
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authentication manager not initialized"})
 			return
 		}
@@ -20,6 +23,13 @@ func AuthMiddleware(manager *sdkaccess.Manager) gin.HandlerFunc {
 			if result != nil {
 				c.Set("apiKey", result.Principal)
 				c.Set("accessProvider", result.Provider)
+				apiKeyID := ""
+				apiKeyName := ""
+				if identity := usage.ResolveAPIKeyIdentity(result.Principal); identity != nil {
+					apiKeyID = identity.ID
+					apiKeyName = identity.Name
+				}
+				diagnostics.SetAuth(c, result.Provider, result.Principal, apiKeyID, apiKeyName)
 				if len(result.Metadata) > 0 {
 					c.Set("accessMetadata", result.Metadata)
 				}
@@ -32,6 +42,7 @@ func AuthMiddleware(manager *sdkaccess.Manager) gin.HandlerFunc {
 		if statusCode >= http.StatusInternalServerError {
 			log.Errorf("authentication middleware error: %v", err)
 		}
+		diagnostics.SetLocalError(c, statusCode, "local_auth", "authentication_failed", "authentication_error", err.Message)
 		c.AbortWithStatusJSON(statusCode, gin.H{"error": err.Message})
 	}
 }

--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -2,7 +2,9 @@ package management
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -15,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 )
 
@@ -24,7 +27,24 @@ const (
 	maxLogLimit             = 20000
 	logScannerInitialBuffer = 64 * 1024
 	logScannerMaxBuffer     = 8 * 1024 * 1024
+	requestDiagnosticHeader = "=== DIAGNOSTIC METADATA ==="
+	maxErrorLogSummaryBytes = 256 * 1024
 )
+
+type errorLogSummary struct {
+	RequestID      string `json:"request_id,omitempty"`
+	Status         int    `json:"status,omitempty"`
+	ErrorCode      string `json:"error_code,omitempty"`
+	ErrorType      string `json:"error_type,omitempty"`
+	OriginalURL    string `json:"original_url,omitempty"`
+	EffectiveURL   string `json:"effective_url,omitempty"`
+	RouteGroup     string `json:"route_group,omitempty"`
+	RoutePath      string `json:"route_path,omitempty"`
+	Model          string `json:"model,omitempty"`
+	Provider       string `json:"provider,omitempty"`
+	UpstreamStatus int    `json:"upstream_status,omitempty"`
+	RejectedBy     string `json:"rejected_by,omitempty"`
+}
 
 // GetLogs returns log lines with optional incremental loading.
 func (h *Handler) GetLogs(c *gin.Context) {
@@ -187,9 +207,10 @@ func (h *Handler) GetRequestErrorLogs(c *gin.Context) {
 	}
 
 	type errorLog struct {
-		Name     string `json:"name"`
-		Size     int64  `json:"size"`
-		Modified int64  `json:"modified"`
+		Name string `json:"name"`
+		errorLogSummary
+		Size     int64 `json:"size"`
+		Modified int64 `json:"modified"`
 	}
 
 	files := make([]errorLog, 0, len(entries))
@@ -206,10 +227,12 @@ func (h *Handler) GetRequestErrorLogs(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to read log info for %s: %v", name, errInfo)})
 			return
 		}
+		summary := readErrorLogSummary(filepath.Join(dir, name))
 		files = append(files, errorLog{
-			Name:     name,
-			Size:     info.Size(),
-			Modified: info.ModTime().Unix(),
+			Name:            name,
+			errorLogSummary: summary,
+			Size:            info.Size(),
+			Modified:        info.ModTime().Unix(),
 		})
 	}
 
@@ -360,6 +383,151 @@ func (h *Handler) DownloadRequestErrorLog(c *gin.Context) {
 	}
 
 	c.FileAttachment(fullPath, name)
+}
+
+func readErrorLogSummary(path string) errorLogSummary {
+	file, err := os.Open(path)
+	if err != nil {
+		return errorLogSummary{}
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(file, maxErrorLogSummaryBytes))
+	if err != nil || len(data) == 0 {
+		return errorLogSummary{}
+	}
+
+	summary := parseLegacyErrorLogSummary(data)
+	if snapshot, ok := parseDiagnosticSnapshot(data); ok {
+		summary = mergeErrorLogSummary(summary, errorLogSummaryFromDiagnostic(snapshot))
+	}
+	return summary
+}
+
+func parseDiagnosticSnapshot(data []byte) (diagnostics.Snapshot, bool) {
+	idx := bytes.Index(data, []byte(requestDiagnosticHeader))
+	if idx < 0 {
+		return diagnostics.Snapshot{}, false
+	}
+	section := data[idx+len(requestDiagnosticHeader):]
+	section = bytes.TrimLeft(section, " \t\r\n")
+	if end := bytes.Index(section, []byte("\n=== ")); end >= 0 {
+		section = section[:end]
+	}
+	section = bytes.TrimSpace(section)
+	if len(section) == 0 {
+		return diagnostics.Snapshot{}, false
+	}
+	var snapshot diagnostics.Snapshot
+	if err := json.Unmarshal(section, &snapshot); err != nil {
+		return diagnostics.Snapshot{}, false
+	}
+	return snapshot, !snapshot.IsZero()
+}
+
+func errorLogSummaryFromDiagnostic(snapshot diagnostics.Snapshot) errorLogSummary {
+	summary := errorLogSummary{
+		RequestID:    snapshot.RequestID,
+		OriginalURL:  snapshot.OriginalURL,
+		EffectiveURL: snapshot.EffectiveURL,
+	}
+	if snapshot.Route != nil {
+		summary.RouteGroup = snapshot.Route.Group
+		summary.RoutePath = snapshot.Route.RoutePath
+		if snapshot.Route.CcSwitch != nil {
+			summary.Model = snapshot.Route.CcSwitch.DefaultModel
+		}
+	}
+	if snapshot.Auth != nil {
+		summary.Provider = snapshot.Auth.Provider
+	}
+	if snapshot.Quota != nil {
+		summary.RejectedBy = snapshot.Quota.RejectedBy
+		if summary.ErrorCode == "" {
+			summary.ErrorCode = snapshot.Quota.ErrorCode
+		}
+		if summary.ErrorType == "" {
+			summary.ErrorType = snapshot.Quota.ErrorType
+		}
+	}
+	if snapshot.Upstream != nil {
+		if snapshot.Upstream.Provider != "" {
+			summary.Provider = snapshot.Upstream.Provider
+		}
+		summary.UpstreamStatus = snapshot.Upstream.Status
+	}
+	if snapshot.Response != nil {
+		summary.Status = snapshot.Response.Status
+		summary.ErrorCode = snapshot.Response.ErrorCode
+		summary.ErrorType = snapshot.Response.ErrorType
+	}
+	if snapshot.Body != nil && snapshot.Body.Model != "" {
+		summary.Model = snapshot.Body.Model
+	}
+	return summary
+}
+
+func parseLegacyErrorLogSummary(data []byte) errorLogSummary {
+	summary := errorLogSummary{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, logScannerInitialBuffer), logScannerMaxBuffer)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "URL: "):
+			summary.OriginalURL = strings.TrimSpace(strings.TrimPrefix(line, "URL: "))
+		case strings.HasPrefix(line, "Effective URL: "):
+			summary.EffectiveURL = strings.TrimSpace(strings.TrimPrefix(line, "Effective URL: "))
+		case strings.HasPrefix(line, "Request ID: "):
+			summary.RequestID = strings.TrimSpace(strings.TrimPrefix(line, "Request ID: "))
+		case strings.HasPrefix(line, "Status: "):
+			status, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "Status: ")))
+			if err == nil {
+				summary.Status = status
+			}
+		}
+	}
+	return summary
+}
+
+func mergeErrorLogSummary(base, override errorLogSummary) errorLogSummary {
+	if override.RequestID != "" {
+		base.RequestID = override.RequestID
+	}
+	if override.Status != 0 {
+		base.Status = override.Status
+	}
+	if override.ErrorCode != "" {
+		base.ErrorCode = override.ErrorCode
+	}
+	if override.ErrorType != "" {
+		base.ErrorType = override.ErrorType
+	}
+	if override.OriginalURL != "" {
+		base.OriginalURL = override.OriginalURL
+	}
+	if override.EffectiveURL != "" {
+		base.EffectiveURL = override.EffectiveURL
+	}
+	if override.RouteGroup != "" {
+		base.RouteGroup = override.RouteGroup
+	}
+	if override.RoutePath != "" {
+		base.RoutePath = override.RoutePath
+	}
+	if override.Model != "" {
+		base.Model = override.Model
+	}
+	if override.Provider != "" {
+		base.Provider = override.Provider
+	}
+	if override.UpstreamStatus != 0 {
+		base.UpstreamStatus = override.UpstreamStatus
+	}
+	if override.RejectedBy != "" {
+		base.RejectedBy = override.RejectedBy
+	}
+	return base
 }
 
 func (h *Handler) logDirectory() string {

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -1,85 +1,157 @@
 package management
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 )
 
-func TestGetLogsReturnsEmptySnapshotWhenFileLoggingDisabled(t *testing.T) {
+func TestReadErrorLogSummaryParsesDiagnosticMetadata(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "error-deepseek-v1-responses-2026-07-03T103816-reqabc123.log")
+	content := `=== REQUEST INFO ===
+Version: dev-test
+URL: /deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses
+Effective URL: /v1/responses
+Request ID: reqabc123
+Method: POST
+Timestamp: 2026-07-03T10:38:16Z
+
+=== DIAGNOSTIC METADATA ===
+{
+  "request_id": "reqabc123",
+  "original_url": "/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses",
+  "effective_url": "/v1/responses",
+  "route": {
+    "route_path": "/deepseekv4flash-chatgpt/cs_3e13ca9880fc",
+    "group": "deepseekv4flash-chatgpt"
+  },
+  "auth": {
+    "provider": "api-key",
+    "api_key": "sk-t...test",
+    "api_key_id": "key-1",
+    "api_key_name": "Codex Desktop"
+  },
+  "quota": {
+    "rpm_limit": 10,
+    "rejected": true,
+    "rejected_by": "rpm",
+    "current": 11,
+    "error_code": "rpm_limit_exceeded",
+    "error_type": "rate_limit_exceeded"
+  },
+  "response": {
+    "status": 429,
+    "error_code": "rpm_limit_exceeded",
+    "error_type": "rate_limit_exceeded",
+    "source": "local_quota"
+  },
+  "body": {
+    "model": "deepseek-v4-flash",
+    "captured_bytes": 48,
+    "redacted": true
+  }
+}
+
+=== HEADERS ===
+Authorization: Bearer ***
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+
+	summary := readErrorLogSummary(path)
+	if summary.RequestID != "reqabc123" {
+		t.Fatalf("request ID = %q", summary.RequestID)
+	}
+	if summary.Status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", summary.Status, http.StatusTooManyRequests)
+	}
+	if summary.ErrorCode != "rpm_limit_exceeded" || summary.ErrorType != "rate_limit_exceeded" {
+		t.Fatalf("error summary = %#v", summary)
+	}
+	if summary.OriginalURL != "/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses" {
+		t.Fatalf("original URL = %q", summary.OriginalURL)
+	}
+	if summary.EffectiveURL != "/v1/responses" {
+		t.Fatalf("effective URL = %q", summary.EffectiveURL)
+	}
+	if summary.RouteGroup != "deepseekv4flash-chatgpt" || summary.RoutePath != "/deepseekv4flash-chatgpt/cs_3e13ca9880fc" {
+		t.Fatalf("route summary = %#v", summary)
+	}
+	if summary.Provider != "api-key" || summary.Model != "deepseek-v4-flash" || summary.RejectedBy != "rpm" {
+		t.Fatalf("metadata summary = %#v", summary)
+	}
+}
+
+func TestGetRequestErrorLogsIncludesDiagnosticSummary(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	h := NewHandler(&config.Config{LoggingToFile: false}, "", nil)
+	dir := t.TempDir()
+	name := "error-deepseek-v1-responses-2026-07-03T103816-reqabc123.log"
+	path := filepath.Join(dir, name)
+	content := `=== REQUEST INFO ===
+Version: dev-test
+URL: /deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses
+Effective URL: /v1/responses
+Request ID: reqabc123
+
+=== DIAGNOSTIC METADATA ===
+{"request_id":"reqabc123","original_url":"/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses","effective_url":"/v1/responses","response":{"status":429,"error_code":"rpm_limit_exceeded"},"quota":{"rejected_by":"rpm"}}
+
+=== RESPONSE ===
+Status: 429
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+	modified := time.Date(2026, 7, 3, 10, 38, 16, 0, time.UTC)
+	if err := os.Chtimes(path, modified, modified); err != nil {
+		t.Fatalf("Chtimes(%s) error = %v", path, err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{LoggingToFile: true}, nil)
+	h.SetLogDirectory(dir)
 	defer h.Close()
 
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodGet, "/logs?limit=50000&after=1714567890", nil)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/request-error-logs", nil)
+	h.GetRequestErrorLogs(c)
 
-	h.GetLogs(c)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
-
 	var payload struct {
-		Lines           []string `json:"lines"`
-		LineCount       int      `json:"line-count"`
-		LatestTimestamp int64    `json:"latest-timestamp"`
+		Files []struct {
+			Name         string `json:"name"`
+			RequestID    string `json:"request_id"`
+			Status       int    `json:"status"`
+			ErrorCode    string `json:"error_code"`
+			OriginalURL  string `json:"original_url"`
+			EffectiveURL string `json:"effective_url"`
+			RejectedBy   string `json:"rejected_by"`
+		} `json:"files"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if len(payload.Lines) != 0 {
-		t.Fatalf("lines = %v, want empty", payload.Lines)
+	if len(payload.Files) != 1 {
+		t.Fatalf("files = %d, want 1", len(payload.Files))
 	}
-	if payload.LineCount != 0 {
-		t.Fatalf("line-count = %d, want 0", payload.LineCount)
+	file := payload.Files[0]
+	if file.Name != name || file.RequestID != "reqabc123" || file.Status != http.StatusTooManyRequests || file.ErrorCode != "rpm_limit_exceeded" || file.RejectedBy != "rpm" {
+		t.Fatalf("file summary = %#v", file)
 	}
-	if payload.LatestTimestamp != 1714567890 {
-		t.Fatalf("latest-timestamp = %d, want 1714567890", payload.LatestTimestamp)
-	}
-}
-
-func TestParseLimitRejectsOversizedLimit(t *testing.T) {
-	if _, err := parseLimit("20001"); err == nil {
-		t.Fatal("expected oversized limit to be rejected")
-	}
-}
-
-func TestLogAccumulatorReadsGzipRotatedLog(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "main-2026-06-09T12-00-00.log.gz")
-
-	var buf bytes.Buffer
-	zw := gzip.NewWriter(&buf)
-	if _, err := zw.Write([]byte("[2026-06-09 12:00:01] [info ] rotated line\n")); err != nil {
-		t.Fatalf("write gzip payload: %v", err)
-	}
-	if err := zw.Close(); err != nil {
-		t.Fatalf("close gzip writer: %v", err)
-	}
-	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
-		t.Fatalf("write gzip log file: %v", err)
-	}
-
-	acc := newLogAccumulator(0, 10)
-	if err := acc.consumeFile(path); err != nil {
-		t.Fatalf("consume gzip log: %v", err)
-	}
-	lines, total, latest := acc.result()
-	if total != 1 || len(lines) != 1 || lines[0] != "[2026-06-09 12:00:01] [info ] rotated line" {
-		t.Fatalf("unexpected result: total=%d latest=%d lines=%#v", total, latest, lines)
-	}
-	if latest == 0 {
-		t.Fatal("expected latest timestamp to be parsed")
+	if file.OriginalURL != "/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses" || file.EffectiveURL != "/v1/responses" {
+		t.Fatalf("file URLs = %#v", file)
 	}
 }

--- a/internal/api/middleware/quota.go
+++ b/internal/api/middleware/quota.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -174,6 +175,15 @@ func QuotaMiddleware() gin.HandlerFunc {
 		tpmLimit := parseIntMetadata(metadata, "tpm-limit")
 		spendingLimit := parseFloatMetadata(metadata, "spending-limit")
 		dailySpendingLimit := parseFloatMetadata(metadata, "daily-spending-limit")
+		diagnostics.SetQuotaLimits(c, diagnostics.QuotaSnapshot{
+			DailyLimit:         dailyLimit,
+			TotalQuota:         totalQuota,
+			ConcurrencyLimit:   concurrencyLimit,
+			RPMLimit:           rpmLimit,
+			TPMLimit:           tpmLimit,
+			SpendingLimit:      spendingLimit,
+			DailySpendingLimit: dailySpendingLimit,
+		})
 
 		// Cache limits for dashboard snapshot
 		UpdateKeyLimits(apiKey, rpmLimit, tpmLimit)
@@ -187,9 +197,11 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if concurrencyLimit > 0 {
 			release, ok := acquireKeyConcurrency(apiKey, concurrencyLimit)
 			if !ok {
+				message := fmt.Sprintf("concurrency limit (%d in-flight requests) exceeded for this API key", concurrencyLimit)
+				diagnostics.SetQuotaRejection(c, "concurrency", float64(concurrencyLimit), float64(keyConcurrencyCount(apiKey)), "concurrency_limit_exceeded", "rate_limit_exceeded", message)
 				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 					"error": map[string]interface{}{
-						"message": fmt.Sprintf("concurrency limit (%d in-flight requests) exceeded for this API key", concurrencyLimit),
+						"message": message,
 						"type":    "rate_limit_exceeded",
 						"code":    "concurrency_limit_exceeded",
 					},
@@ -201,10 +213,13 @@ func QuotaMiddleware() gin.HandlerFunc {
 
 		// --- RPM check (sliding window, in-memory) ---
 		if rpmLimit > 0 {
-			if rpmTracker.count() > rpmLimit {
+			currentRPM := rpmTracker.count()
+			if currentRPM > rpmLimit {
+				message := fmt.Sprintf("RPM limit (%d requests/min) exceeded for this API key", rpmLimit)
+				diagnostics.SetQuotaRejection(c, "rpm", float64(rpmLimit), float64(currentRPM), "rpm_limit_exceeded", "rate_limit_exceeded", message)
 				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 					"error": map[string]interface{}{
-						"message": fmt.Sprintf("RPM limit (%d requests/min) exceeded for this API key", rpmLimit),
+						"message": message,
 						"type":    "rate_limit_exceeded",
 						"code":    "rpm_limit_exceeded",
 					},
@@ -216,10 +231,13 @@ func QuotaMiddleware() gin.HandlerFunc {
 		// --- TPM check (sliding window, in-memory) ---
 		if tpmLimit > 0 {
 			tracker := getTPMTracker(apiKey)
-			if tracker.sum() >= int64(tpmLimit) {
+			currentTPM := tracker.sum()
+			if currentTPM >= int64(tpmLimit) {
+				message := fmt.Sprintf("TPM limit (%d tokens/min) exceeded for this API key", tpmLimit)
+				diagnostics.SetQuotaRejection(c, "tpm", float64(tpmLimit), float64(currentTPM), "tpm_limit_exceeded", "rate_limit_exceeded", message)
 				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 					"error": map[string]interface{}{
-						"message": fmt.Sprintf("TPM limit (%d tokens/min) exceeded for this API key", tpmLimit),
+						"message": message,
 						"type":    "rate_limit_exceeded",
 						"code":    "tpm_limit_exceeded",
 					},
@@ -234,9 +252,11 @@ func QuotaMiddleware() gin.HandlerFunc {
 			if err != nil {
 				log.Warnf("quota: failed to query daily usage for key %s: %v", maskKey(apiKey), err)
 			} else if todayCount >= int64(dailyLimit) {
+				message := fmt.Sprintf("daily request limit (%d) exceeded for this API key", dailyLimit)
+				diagnostics.SetQuotaRejection(c, "daily", float64(dailyLimit), float64(todayCount), "daily_limit_exceeded", "rate_limit_exceeded", message)
 				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 					"error": map[string]interface{}{
-						"message": fmt.Sprintf("daily request limit (%d) exceeded for this API key", dailyLimit),
+						"message": message,
 						"type":    "rate_limit_exceeded",
 						"code":    "daily_limit_exceeded",
 					},
@@ -251,9 +271,11 @@ func QuotaMiddleware() gin.HandlerFunc {
 			if err != nil {
 				log.Warnf("quota: failed to query total usage for key %s: %v", maskKey(apiKey), err)
 			} else if totalCount >= int64(totalQuota) {
+				message := fmt.Sprintf("total request quota (%d) exhausted for this API key", totalQuota)
+				diagnostics.SetQuotaRejection(c, "total", float64(totalQuota), float64(totalCount), "total_quota_exceeded", "rate_limit_exceeded", message)
 				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 					"error": map[string]interface{}{
-						"message": fmt.Sprintf("total request quota (%d) exhausted for this API key", totalQuota),
+						"message": message,
 						"type":    "rate_limit_exceeded",
 						"code":    "total_quota_exceeded",
 					},
@@ -268,9 +290,11 @@ func QuotaMiddleware() gin.HandlerFunc {
 			if err != nil {
 				log.Warnf("quota: failed to query total cost for key %s: %v", maskKey(apiKey), err)
 			} else if totalCost >= spendingLimit {
+				message := fmt.Sprintf("spending limit ($%.2f) exceeded for this API key (current: $%.2f)", spendingLimit, totalCost)
+				diagnostics.SetQuotaRejection(c, "spending", spendingLimit, totalCost, "spending_limit_exceeded", "rate_limit_exceeded", message)
 				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 					"error": map[string]interface{}{
-						"message": fmt.Sprintf("spending limit ($%.2f) exceeded for this API key (current: $%.2f)", spendingLimit, totalCost),
+						"message": message,
 						"type":    "rate_limit_exceeded",
 						"code":    "spending_limit_exceeded",
 					},
@@ -285,9 +309,11 @@ func QuotaMiddleware() gin.HandlerFunc {
 			if err != nil {
 				log.Warnf("quota: failed to query today cost for key %s: %v", maskKey(apiKey), err)
 			} else if todayCost >= dailySpendingLimit {
+				message := fmt.Sprintf("daily spending limit ($%.2f) exceeded for this API key (today: $%.2f)", dailySpendingLimit, todayCost)
+				diagnostics.SetQuotaRejection(c, "daily_spending", dailySpendingLimit, todayCost, "daily_spending_limit_exceeded", "rate_limit_exceeded", message)
 				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 					"error": map[string]interface{}{
-						"message": fmt.Sprintf("daily spending limit ($%.2f) exceeded for this API key (today: $%.2f)", dailySpendingLimit, todayCost),
+						"message": message,
 						"type":    "rate_limit_exceeded",
 						"code":    "daily_spending_limit_exceeded",
 					},
@@ -363,6 +389,15 @@ func acquireKeyConcurrency(apiKey string, limit int) (func(), bool) {
 		}
 		inFlightByKey[apiKey] = current - 1
 	}, true
+}
+
+func keyConcurrencyCount(apiKey string) int {
+	if apiKey == "" {
+		return 0
+	}
+	inFlightMu.Lock()
+	defer inFlightMu.Unlock()
+	return inFlightByKey[apiKey]
 }
 
 func maskKey(key string) string {

--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -4,17 +4,23 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
 
 const maxErrorOnlyCapturedRequestBodyBytes int64 = 1 << 20 // 1 MiB
+
+const requestLoggingWrappedGinKey = "cliproxy.request_logging_wrapped"
+
+type requestLoggingWrappedContextKey struct{}
 
 // RequestLoggingMiddleware creates a Gin middleware that logs HTTP requests and responses.
 // It captures detailed information about the request and response, including headers and body,
@@ -34,6 +40,22 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 
 		path := c.Request.URL.Path
 		if !shouldLogRequest(path) {
+			c.Next()
+			return
+		}
+
+		requestID := ensureRequestLoggingRequestID(c)
+		diagnostic := diagnostics.EnsureGin(c, requestID)
+		if diagnostic != nil {
+			diagnostic.UpdateRequest(c.Request)
+		}
+
+		if wrapper := requestLoggingExistingWrapper(c); wrapper != nil {
+			c.Writer = wrapper
+			c.Next()
+			return
+		}
+		if requestLoggingAlreadyWrapped(c) {
 			c.Next()
 			return
 		}
@@ -59,6 +81,7 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 			wrapper.logOnErrorOnly = true
 		}
 		c.Writer = wrapper
+		markRequestLoggingWrapped(c, wrapper)
 
 		// Process the request
 		c.Next()
@@ -69,6 +92,57 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 			_ = c.Error(err)
 		}
 	}
+}
+
+func requestLoggingAlreadyWrapped(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	if _, exists := c.Get(requestLoggingWrappedGinKey); exists {
+		return true
+	}
+	if c.Request == nil {
+		return false
+	}
+	return c.Request.Context().Value(requestLoggingWrappedContextKey{}) != nil
+}
+
+func requestLoggingExistingWrapper(c *gin.Context) *ResponseWriterWrapper {
+	if c == nil {
+		return nil
+	}
+	if raw, exists := c.Get(requestLoggingWrappedGinKey); exists {
+		if wrapper, ok := raw.(*ResponseWriterWrapper); ok {
+			return wrapper
+		}
+	}
+	if c.Request == nil {
+		return nil
+	}
+	wrapper, _ := c.Request.Context().Value(requestLoggingWrappedContextKey{}).(*ResponseWriterWrapper)
+	return wrapper
+}
+
+func markRequestLoggingWrapped(c *gin.Context, wrapper *ResponseWriterWrapper) {
+	if c == nil {
+		return
+	}
+	c.Set(requestLoggingWrappedGinKey, wrapper)
+	if c.Request != nil {
+		c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), requestLoggingWrappedContextKey{}, wrapper))
+	}
+}
+
+func ensureRequestLoggingRequestID(c *gin.Context) string {
+	if existing := logging.GetGinRequestID(c); existing != "" {
+		return existing
+	}
+	requestID := logging.GenerateRequestID()
+	logging.SetGinRequestID(c, requestID)
+	if c != nil && c.Request != nil {
+		c.Request = c.Request.WithContext(logging.WithRequestID(c.Request.Context(), requestID))
+	}
+	return requestID
 }
 
 func shouldSkipMethodForRequestLogging(req *http.Request) bool {
@@ -117,6 +191,11 @@ func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) 
 	url := c.Request.URL.Path
 	if maskedQuery != "" {
 		url += "?" + maskedQuery
+	}
+	if diagnostic := diagnostics.FromGin(c); diagnostic != nil {
+		if snapshot := diagnostic.Snapshot(); snapshot.OriginalURL != "" {
+			url = snapshot.OriginalURL
+		}
 	}
 
 	// Capture method

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 )
@@ -203,6 +204,33 @@ func (l *captureRequestLogger) LogStreamingRequest(_ string, _ string, _ map[str
 
 func (l *captureRequestLogger) IsEnabled() bool { return true }
 
+type diagnosticRequestLogger struct {
+	url        string
+	requestID  string
+	statusCode int
+	calls      int
+	diagnostic diagnostics.Snapshot
+}
+
+func (l *diagnosticRequestLogger) LogRequest(string, string, map[string][]string, []byte, int, map[string][]string, []byte, []byte, []byte, []*interfaces.ErrorMessage, string, time.Time, time.Time) error {
+	return nil
+}
+
+func (l *diagnosticRequestLogger) LogRequestWithOptionsAndDiagnostics(url string, _ string, _ map[string][]string, _ []byte, statusCode int, _ map[string][]string, _ []byte, _ []byte, _ []byte, _ []*interfaces.ErrorMessage, _ bool, requestID string, _ time.Time, _ time.Time, diagnostic diagnostics.Snapshot) error {
+	l.calls++
+	l.url = url
+	l.requestID = requestID
+	l.statusCode = statusCode
+	l.diagnostic = diagnostic
+	return nil
+}
+
+func (l *diagnosticRequestLogger) LogStreamingRequest(string, string, map[string][]string, []byte, string) (logging.StreamingLogWriter, error) {
+	return stubStreamingLogWriter{}, nil
+}
+
+func (l *diagnosticRequestLogger) IsEnabled() bool { return false }
+
 func gzipBodyForRequestLoggingTest(t *testing.T, raw []byte) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -282,5 +310,65 @@ func TestRequestLoggingMiddlewareUsesCachedDecodedBody(t *testing.T) {
 	}
 	if string(logger.requestBody) != string(raw) {
 		t.Fatalf("logged request body = %s, want %s", logger.requestBody, raw)
+	}
+}
+
+func TestRequestLoggingMiddlewarePreservesOriginalURLAcrossRewrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logger := &diagnosticRequestLogger{}
+	r := gin.New()
+	r.Use(RequestLoggingMiddleware(logger))
+	r.POST("/v1/responses", func(c *gin.Context) {
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+			"error": map[string]any{
+				"message": "RPM limit (10 requests/min) exceeded for this API key",
+				"type":    "rate_limit_exceeded",
+				"code":    "rpm_limit_exceeded",
+			},
+		})
+	})
+	r.NoRoute(func(c *gin.Context) {
+		if _, rewritten := c.Get("test.rewritten"); rewritten {
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+		c.Set("test.rewritten", true)
+		c.Request.URL.Path = "/v1/responses"
+		c.Request.RequestURI = "/v1/responses"
+		diagnostics.SetEffectiveURL(c, "/v1/responses")
+		r.HandleContext(c)
+		c.Abort()
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses", strings.NewReader(`{"model":"deepseek","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusTooManyRequests, w.Body.String())
+	}
+	if logger.calls != 1 {
+		t.Fatalf("log calls = %d, want 1", logger.calls)
+	}
+	if logger.url != "/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses" {
+		t.Fatalf("logged url = %q", logger.url)
+	}
+	if logger.requestID == "" {
+		t.Fatal("request ID should be generated for rewritten requests")
+	}
+	if logger.statusCode != http.StatusTooManyRequests {
+		t.Fatalf("logged status = %d, want %d", logger.statusCode, http.StatusTooManyRequests)
+	}
+	if logger.diagnostic.OriginalURL != "/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses" {
+		t.Fatalf("diagnostic original URL = %q", logger.diagnostic.OriginalURL)
+	}
+	if logger.diagnostic.EffectiveURL != "/v1/responses" {
+		t.Fatalf("diagnostic effective URL = %q", logger.diagnostic.EffectiveURL)
+	}
+	if logger.diagnostic.Response == nil || logger.diagnostic.Response.ErrorCode != "rpm_limit_exceeded" {
+		t.Fatalf("diagnostic response = %#v", logger.diagnostic.Response)
 	}
 }

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -299,6 +300,7 @@ func (w *ResponseWriterWrapper) Finalize(c *gin.Context) error {
 	}
 
 	hasAPIError := len(slicesAPIResponseError) > 0 || finalStatusCode >= http.StatusBadRequest
+	diagnostics.RecordResponse(c, finalStatusCode, w.body.Bytes())
 	forceLog := w.logOnErrorOnly && hasAPIError && !w.logger.IsEnabled()
 	if !w.logger.IsEnabled() && !forceLog {
 		return nil
@@ -426,6 +428,42 @@ func (w *ResponseWriterWrapper) hydrateRequestInfoBody(c *gin.Context) []byte {
 func (w *ResponseWriterWrapper) logRequest(requestBody []byte, statusCode int, headers map[string][]string, body []byte, apiRequestBody, apiResponseBody []byte, apiResponseTimestamp time.Time, apiResponseErrors []*interfaces.ErrorMessage, forceLog bool) error {
 	if w.requestInfo == nil {
 		return nil
+	}
+
+	if w.ginCtx != nil {
+		if forceLog && diagnostics.ShouldRedactErrorOnlyBody(w.ginCtx, statusCode) {
+			summary := diagnostics.RecordBody(w.ginCtx, requestBody, true, "local_4xx_error")
+			requestBody = diagnostics.FormatBodySummary(summary)
+		} else {
+			diagnostics.RecordBody(w.ginCtx, requestBody, false, "")
+		}
+	}
+
+	diagnosticSnapshot := diagnostics.Snapshot{}
+	if diagnostic := diagnostics.FromGin(w.ginCtx); diagnostic != nil {
+		diagnosticSnapshot = diagnostic.Snapshot()
+	}
+
+	if loggerWithDiagnostics, ok := w.logger.(interface {
+		LogRequestWithOptionsAndDiagnostics(string, string, map[string][]string, []byte, int, map[string][]string, []byte, []byte, []byte, []*interfaces.ErrorMessage, bool, string, time.Time, time.Time, diagnostics.Snapshot) error
+	}); ok {
+		return loggerWithDiagnostics.LogRequestWithOptionsAndDiagnostics(
+			w.requestInfo.URL,
+			w.requestInfo.Method,
+			w.requestInfo.Headers,
+			requestBody,
+			statusCode,
+			headers,
+			body,
+			apiRequestBody,
+			apiResponseBody,
+			apiResponseErrors,
+			forceLog,
+			w.requestInfo.RequestID,
+			w.requestInfo.Timestamp,
+			apiResponseTimestamp,
+			diagnosticSnapshot,
+		)
 	}
 
 	if loggerWithOptions, ok := w.logger.(interface {

--- a/internal/api/path_routing.go
+++ b/internal/api/path_routing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -16,6 +17,7 @@ func attachPathRouteContext(c *gin.Context, route *internalrouting.PathRouteCont
 		return
 	}
 	c.Set(internalrouting.GinPathRouteContextKey, route)
+	diagnostics.SetRoute(c, route)
 	if c.Request != nil {
 		c.Request = c.Request.WithContext(internalrouting.WithPathRouteContext(c.Request.Context(), route))
 	}
@@ -109,6 +111,7 @@ func abortChannelGroupRouteNotFound(c *gin.Context) {
 	if c == nil {
 		return
 	}
+	diagnostics.SetLocalError(c, http.StatusNotFound, "local_route", "route_group_unavailable", "invalid_request_error", "channel group route not found")
 	c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
 		"error": map[string]any{
 			"message": "channel group route not found",
@@ -167,6 +170,7 @@ func channelGroupAuthorizationMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		diagnostics.SetLocalError(c, http.StatusForbidden, "local_route", "channel_group_forbidden", "forbidden", "channel group is not allowed for this API key")
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
 			"error": map[string]any{
 				"message": "channel group is not allowed for this API key",

--- a/internal/api/routes_public.go
+++ b/internal/api/routes_public.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/gemini"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/openai"
@@ -107,8 +109,10 @@ func (s *Server) setupRoutes() {
 		c.Request.URL.Path = apiPath
 		if c.Request.URL.RawQuery != "" {
 			c.Request.RequestURI = apiPath + "?" + c.Request.URL.RawQuery
+			diagnostics.SetEffectiveURL(c, apiPath+"?"+util.MaskSensitiveQuery(c.Request.URL.RawQuery))
 		} else {
 			c.Request.RequestURI = apiPath
+			diagnostics.SetEffectiveURL(c, apiPath)
 		}
 		c.Status(http.StatusOK)
 		s.engine.HandleContext(c)

--- a/internal/diagnostics/request.go
+++ b/internal/diagnostics/request.go
@@ -1,0 +1,704 @@
+package diagnostics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+)
+
+const GinKey = "cliproxy.request_diagnostic"
+
+type contextKey struct{}
+
+type RequestDiagnostic struct {
+	mu sync.Mutex
+
+	RequestID      string
+	Method         string
+	OriginalURL    string
+	EffectiveURL   string
+	OriginalPath   string
+	EffectivePath  string
+	Host           string
+	RemoteAddr     string
+	ClientIP       string
+	ClientIPSource string
+	UserAgent      string
+	ContentType    string
+	ContentLength  int64
+
+	Route    *RouteSnapshot
+	Auth     *AuthSnapshot
+	Quota    *QuotaSnapshot
+	Upstream *UpstreamSnapshot
+	Egress   map[string]any
+	Response *ResponseSnapshot
+	Body     *BodySnapshot
+}
+
+type Snapshot struct {
+	RequestID      string            `json:"request_id,omitempty"`
+	Method         string            `json:"method,omitempty"`
+	OriginalURL    string            `json:"original_url,omitempty"`
+	EffectiveURL   string            `json:"effective_url,omitempty"`
+	OriginalPath   string            `json:"original_path,omitempty"`
+	EffectivePath  string            `json:"effective_path,omitempty"`
+	Host           string            `json:"host,omitempty"`
+	RemoteAddr     string            `json:"remote_addr,omitempty"`
+	ClientIP       string            `json:"client_ip,omitempty"`
+	ClientIPSource string            `json:"client_ip_source,omitempty"`
+	UserAgent      string            `json:"user_agent,omitempty"`
+	ContentType    string            `json:"content_type,omitempty"`
+	ContentLength  int64             `json:"content_length,omitempty"`
+	Route          *RouteSnapshot    `json:"route,omitempty"`
+	Auth           *AuthSnapshot     `json:"auth,omitempty"`
+	Quota          *QuotaSnapshot    `json:"quota,omitempty"`
+	Upstream       *UpstreamSnapshot `json:"upstream,omitempty"`
+	Egress         map[string]any    `json:"egress,omitempty"`
+	Response       *ResponseSnapshot `json:"response,omitempty"`
+	Body           *BodySnapshot     `json:"body,omitempty"`
+}
+
+type RouteSnapshot struct {
+	RoutePath string            `json:"route_path,omitempty"`
+	Group     string            `json:"group,omitempty"`
+	Fallback  string            `json:"fallback,omitempty"`
+	CcSwitch  *CcSwitchSnapshot `json:"ccswitch,omitempty"`
+}
+
+type CcSwitchSnapshot struct {
+	ConfigID             string   `json:"config_id,omitempty"`
+	ClientType           string   `json:"client_type,omitempty"`
+	DefaultModel         string   `json:"default_model,omitempty"`
+	RoutePath            string   `json:"route_path,omitempty"`
+	EndpointPath         string   `json:"endpoint_path,omitempty"`
+	AllowedChannelGroups []string `json:"allowed_channel_groups,omitempty"`
+}
+
+type AuthSnapshot struct {
+	Provider   string `json:"provider,omitempty"`
+	APIKey     string `json:"api_key,omitempty"`
+	APIKeyID   string `json:"api_key_id,omitempty"`
+	APIKeyName string `json:"api_key_name,omitempty"`
+}
+
+type QuotaSnapshot struct {
+	DailyLimit         int     `json:"daily_limit,omitempty"`
+	TotalQuota         int     `json:"total_quota,omitempty"`
+	ConcurrencyLimit   int     `json:"concurrency_limit,omitempty"`
+	RPMLimit           int     `json:"rpm_limit,omitempty"`
+	TPMLimit           int     `json:"tpm_limit,omitempty"`
+	SpendingLimit      float64 `json:"spending_limit,omitempty"`
+	DailySpendingLimit float64 `json:"daily_spending_limit,omitempty"`
+	Rejected           bool    `json:"rejected,omitempty"`
+	RejectedBy         string  `json:"rejected_by,omitempty"`
+	Limit              float64 `json:"limit,omitempty"`
+	Current            float64 `json:"current,omitempty"`
+	ErrorCode          string  `json:"error_code,omitempty"`
+	ErrorType          string  `json:"error_type,omitempty"`
+	ErrorMessage       string  `json:"error_message,omitempty"`
+}
+
+type UpstreamSnapshot struct {
+	Attempt      int    `json:"attempt,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	AuthID       string `json:"auth_id,omitempty"`
+	AuthLabel    string `json:"auth_label,omitempty"`
+	URL          string `json:"url,omitempty"`
+	Method       string `json:"method,omitempty"`
+	Status       int    `json:"status,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type ResponseSnapshot struct {
+	Status       int    `json:"status,omitempty"`
+	ErrorCode    string `json:"error_code,omitempty"`
+	ErrorType    string `json:"error_type,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	Source       string `json:"source,omitempty"`
+}
+
+type BodySnapshot struct {
+	ContentType   string `json:"content_type,omitempty"`
+	ContentLength int64  `json:"content_length,omitempty"`
+	CapturedBytes int    `json:"captured_bytes,omitempty"`
+	Redacted      bool   `json:"redacted,omitempty"`
+	RedactedBy    string `json:"redacted_by,omitempty"`
+	Model         string `json:"model,omitempty"`
+	Stream        *bool  `json:"stream,omitempty"`
+	InputItems    int    `json:"input_items,omitempty"`
+	Messages      int    `json:"messages,omitempty"`
+}
+
+func EnsureGin(c *gin.Context, requestID string) *RequestDiagnostic {
+	if c == nil {
+		return nil
+	}
+	if existing := FromGin(c); existing != nil {
+		if requestID != "" {
+			existing.SetRequestID(requestID)
+		}
+		existing.UpdateRequest(c.Request)
+		return existing
+	}
+	d := &RequestDiagnostic{}
+	d.SetRequestID(requestID)
+	d.UpdateRequest(c.Request)
+	c.Set(GinKey, d)
+	if c.Request != nil {
+		c.Request = c.Request.WithContext(WithContext(c.Request.Context(), d))
+	}
+	return d
+}
+
+func FromGin(c *gin.Context) *RequestDiagnostic {
+	if c == nil {
+		return nil
+	}
+	if raw, exists := c.Get(GinKey); exists {
+		if d, ok := raw.(*RequestDiagnostic); ok {
+			return d
+		}
+	}
+	if c.Request != nil {
+		return FromContext(c.Request.Context())
+	}
+	return nil
+}
+
+func WithContext(ctx context.Context, d *RequestDiagnostic) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if d == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKey{}, d)
+}
+
+func FromContext(ctx context.Context) *RequestDiagnostic {
+	if ctx == nil {
+		return nil
+	}
+	d, _ := ctx.Value(contextKey{}).(*RequestDiagnostic)
+	return d
+}
+
+func (d *RequestDiagnostic) SetRequestID(requestID string) {
+	if d == nil || strings.TrimSpace(requestID) == "" {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.RequestID = strings.TrimSpace(requestID)
+}
+
+func (d *RequestDiagnostic) UpdateRequest(req *http.Request) {
+	if d == nil || req == nil || req.URL == nil {
+		return
+	}
+	url := requestURL(req)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.OriginalURL == "" {
+		d.OriginalURL = url
+		d.OriginalPath = req.URL.Path
+	}
+	d.EffectiveURL = url
+	d.EffectivePath = req.URL.Path
+	d.Method = req.Method
+	d.Host = req.Host
+	d.RemoteAddr = req.RemoteAddr
+	d.UserAgent = req.UserAgent()
+	d.ContentType = req.Header.Get("Content-Type")
+	d.ContentLength = req.ContentLength
+	if ip, source := util.ForwardedClientIP(req); ip != "" {
+		d.ClientIP = ip
+		d.ClientIPSource = source
+	} else if ip := util.RemoteAddrIP(req.RemoteAddr); ip != "" {
+		d.ClientIP = ip
+		d.ClientIPSource = "remote_addr"
+	}
+}
+
+func SetOriginalURL(c *gin.Context, rawURL string) {
+	d := FromGin(c)
+	if d == nil {
+		return
+	}
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return
+	}
+	path := rawURL
+	if idx := strings.IndexAny(path, "?#"); idx >= 0 {
+		path = path[:idx]
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.OriginalURL = rawURL
+	d.OriginalPath = path
+}
+
+func SetEffectiveURL(c *gin.Context, rawURL string) {
+	d := FromGin(c)
+	if d == nil {
+		return
+	}
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return
+	}
+	path := rawURL
+	if idx := strings.IndexAny(path, "?#"); idx >= 0 {
+		path = path[:idx]
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.EffectiveURL = rawURL
+	d.EffectivePath = path
+}
+
+func SetRoute(c *gin.Context, route *internalrouting.PathRouteContext) {
+	d := FromGin(c)
+	if d == nil || route == nil {
+		return
+	}
+	snapshot := RouteSnapshot{
+		RoutePath: strings.TrimSpace(route.RoutePath),
+		Group:     strings.TrimSpace(route.Group),
+		Fallback:  strings.TrimSpace(route.Fallback),
+	}
+	if route.CcSwitch != nil {
+		snapshot.CcSwitch = &CcSwitchSnapshot{
+			ConfigID:             strings.TrimSpace(route.CcSwitch.ConfigID),
+			ClientType:           strings.TrimSpace(route.CcSwitch.ClientType),
+			DefaultModel:         strings.TrimSpace(route.CcSwitch.DefaultModel),
+			RoutePath:            strings.TrimSpace(route.CcSwitch.RoutePath),
+			EndpointPath:         strings.TrimSpace(route.CcSwitch.EndpointPath),
+			AllowedChannelGroups: append([]string(nil), route.CcSwitch.AllowedChannelGroups...),
+		}
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.Route = &snapshot
+}
+
+func SetAuth(c *gin.Context, provider, apiKey, apiKeyID, apiKeyName string) {
+	d := FromGin(c)
+	if d == nil {
+		return
+	}
+	auth := &AuthSnapshot{
+		Provider:   strings.TrimSpace(provider),
+		APIKey:     util.HideAPIKey(strings.TrimSpace(apiKey)),
+		APIKeyID:   strings.TrimSpace(apiKeyID),
+		APIKeyName: strings.TrimSpace(apiKeyName),
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.Auth = auth
+}
+
+func SetQuotaLimits(c *gin.Context, quota QuotaSnapshot) {
+	d := FromGin(c)
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.Quota == nil {
+		d.Quota = &QuotaSnapshot{}
+	}
+	d.Quota.DailyLimit = quota.DailyLimit
+	d.Quota.TotalQuota = quota.TotalQuota
+	d.Quota.ConcurrencyLimit = quota.ConcurrencyLimit
+	d.Quota.RPMLimit = quota.RPMLimit
+	d.Quota.TPMLimit = quota.TPMLimit
+	d.Quota.SpendingLimit = quota.SpendingLimit
+	d.Quota.DailySpendingLimit = quota.DailySpendingLimit
+}
+
+func SetQuotaRejection(c *gin.Context, rejectedBy string, limit, current float64, code, typ, message string) {
+	d := FromGin(c)
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.Quota == nil {
+		d.Quota = &QuotaSnapshot{}
+	}
+	d.Quota.Rejected = true
+	d.Quota.RejectedBy = strings.TrimSpace(rejectedBy)
+	d.Quota.Limit = limit
+	d.Quota.Current = current
+	d.Quota.ErrorCode = strings.TrimSpace(code)
+	d.Quota.ErrorType = strings.TrimSpace(typ)
+	d.Quota.ErrorMessage = strings.TrimSpace(message)
+	setResponseLocked(d, http.StatusTooManyRequests, code, typ, message, "local_quota")
+}
+
+func SetLocalError(c *gin.Context, status int, source, code, typ, message string) {
+	d := FromGin(c)
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	setResponseLocked(d, status, code, typ, message, source)
+}
+
+func SetUpstreamRequest(ctx context.Context, attempt int, provider, authID, authLabel, rawURL, method string) {
+	d := FromContext(ctx)
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.Upstream == nil {
+		d.Upstream = &UpstreamSnapshot{}
+	}
+	d.Upstream.Attempt = attempt
+	d.Upstream.Provider = strings.TrimSpace(provider)
+	d.Upstream.AuthID = strings.TrimSpace(authID)
+	d.Upstream.AuthLabel = strings.TrimSpace(authLabel)
+	d.Upstream.URL = strings.TrimSpace(rawURL)
+	d.Upstream.Method = strings.TrimSpace(method)
+}
+
+func SetUpstreamResponse(ctx context.Context, status int) {
+	d := FromContext(ctx)
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.Upstream == nil {
+		d.Upstream = &UpstreamSnapshot{}
+	}
+	d.Upstream.Status = status
+}
+
+func SetUpstreamError(ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
+	d := FromContext(ctx)
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.Upstream == nil {
+		d.Upstream = &UpstreamSnapshot{}
+	}
+	d.Upstream.ErrorMessage = strings.TrimSpace(err.Error())
+}
+
+func SetEgress(c *gin.Context, egress map[string]any) {
+	d := FromGin(c)
+	if d == nil || len(egress) == 0 {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.Egress = cloneAnyMap(egress)
+}
+
+func RecordResponse(c *gin.Context, status int, body []byte) {
+	d := FromGin(c)
+	if d == nil {
+		return
+	}
+	code, typ, message := parseErrorBody(body)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.Response != nil {
+		if d.Response.Status == 0 {
+			d.Response.Status = status
+		}
+		if d.Response.ErrorCode == "" {
+			d.Response.ErrorCode = code
+		}
+		if d.Response.ErrorType == "" {
+			d.Response.ErrorType = typ
+		}
+		if d.Response.ErrorMessage == "" {
+			d.Response.ErrorMessage = message
+		}
+		return
+	}
+	source := ""
+	if status >= http.StatusBadRequest && d.Upstream != nil {
+		if d.Upstream.Status > 0 || d.Upstream.ErrorMessage != "" {
+			source = "upstream"
+		}
+	}
+	d.Response = &ResponseSnapshot{
+		Status:       status,
+		ErrorCode:    code,
+		ErrorType:    typ,
+		ErrorMessage: message,
+		Source:       source,
+	}
+}
+
+func RecordBody(c *gin.Context, body []byte, redacted bool, reason string) *BodySnapshot {
+	d := FromGin(c)
+	if d == nil {
+		return nil
+	}
+	contentType := ""
+	contentLength := int64(0)
+	if c != nil && c.Request != nil {
+		contentType = c.Request.Header.Get("Content-Type")
+		contentLength = c.Request.ContentLength
+	}
+	snapshot := summarizeBody(body, contentType, contentLength, redacted, reason)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.Body = &snapshot
+	return &snapshot
+}
+
+func ShouldRedactErrorOnlyBody(c *gin.Context, status int) bool {
+	d := FromGin(c)
+	if d == nil || status < 400 || status >= 500 {
+		return false
+	}
+	snapshot := d.Snapshot()
+	if snapshot.Response == nil {
+		return false
+	}
+	return strings.HasPrefix(snapshot.Response.Source, "local_")
+}
+
+func (d *RequestDiagnostic) Snapshot() Snapshot {
+	if d == nil {
+		return Snapshot{}
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return Snapshot{
+		RequestID:      d.RequestID,
+		Method:         d.Method,
+		OriginalURL:    d.OriginalURL,
+		EffectiveURL:   d.EffectiveURL,
+		OriginalPath:   d.OriginalPath,
+		EffectivePath:  d.EffectivePath,
+		Host:           d.Host,
+		RemoteAddr:     d.RemoteAddr,
+		ClientIP:       d.ClientIP,
+		ClientIPSource: d.ClientIPSource,
+		UserAgent:      d.UserAgent,
+		ContentType:    d.ContentType,
+		ContentLength:  d.ContentLength,
+		Route:          cloneRoute(d.Route),
+		Auth:           cloneAuth(d.Auth),
+		Quota:          cloneQuota(d.Quota),
+		Upstream:       cloneUpstream(d.Upstream),
+		Egress:         cloneAnyMap(d.Egress),
+		Response:       cloneResponse(d.Response),
+		Body:           cloneBody(d.Body),
+	}
+}
+
+func (s Snapshot) JSON() ([]byte, error) {
+	return json.MarshalIndent(s, "", "  ")
+}
+
+func (s Snapshot) IsZero() bool {
+	return s.RequestID == "" &&
+		s.Method == "" &&
+		s.OriginalURL == "" &&
+		s.EffectiveURL == "" &&
+		s.OriginalPath == "" &&
+		s.EffectivePath == "" &&
+		s.Host == "" &&
+		s.RemoteAddr == "" &&
+		s.ClientIP == "" &&
+		s.ClientIPSource == "" &&
+		s.UserAgent == "" &&
+		s.ContentType == "" &&
+		s.ContentLength == 0 &&
+		s.Route == nil &&
+		s.Auth == nil &&
+		s.Quota == nil &&
+		s.Upstream == nil &&
+		s.Egress == nil &&
+		s.Response == nil &&
+		s.Body == nil
+}
+
+func FormatBodySummary(snapshot *BodySnapshot) []byte {
+	if snapshot == nil {
+		return nil
+	}
+	data, err := json.MarshalIndent(map[string]any{
+		"note":    "request body redacted for local gateway error log",
+		"summary": snapshot,
+	}, "", "  ")
+	if err != nil {
+		return []byte("[request body redacted]\n")
+	}
+	return append(data, '\n')
+}
+
+func requestURL(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+	rawQuery := util.MaskSensitiveQuery(req.URL.RawQuery)
+	if rawQuery == "" {
+		return req.URL.Path
+	}
+	return req.URL.Path + "?" + rawQuery
+}
+
+func setResponseLocked(d *RequestDiagnostic, status int, code, typ, message, source string) {
+	if d.Response == nil {
+		d.Response = &ResponseSnapshot{}
+	}
+	d.Response.Status = status
+	d.Response.ErrorCode = strings.TrimSpace(code)
+	d.Response.ErrorType = strings.TrimSpace(typ)
+	d.Response.ErrorMessage = strings.TrimSpace(message)
+	d.Response.Source = strings.TrimSpace(source)
+}
+
+func parseErrorBody(body []byte) (string, string, string) {
+	if len(body) == 0 {
+		return "", "", ""
+	}
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err != nil {
+		return "", "", ""
+	}
+	errValue, ok := root["error"]
+	if !ok {
+		return "", "", ""
+	}
+	switch value := errValue.(type) {
+	case string:
+		return "", "", strings.TrimSpace(value)
+	case map[string]any:
+		return stringValue(value["code"]), stringValue(value["type"]), stringValue(value["message"])
+	default:
+		return "", "", ""
+	}
+}
+
+func summarizeBody(body []byte, contentType string, contentLength int64, redacted bool, reason string) BodySnapshot {
+	snapshot := BodySnapshot{
+		ContentType:   strings.TrimSpace(contentType),
+		ContentLength: contentLength,
+		CapturedBytes: len(body),
+		Redacted:      redacted,
+		RedactedBy:    strings.TrimSpace(reason),
+	}
+	if len(body) == 0 || !strings.Contains(strings.ToLower(contentType), "json") {
+		return snapshot
+	}
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err != nil {
+		return snapshot
+	}
+	snapshot.Model = stringValue(root["model"])
+	if stream, ok := root["stream"].(bool); ok {
+		snapshot.Stream = &stream
+	}
+	if items, ok := root["input"].([]any); ok {
+		snapshot.InputItems = len(items)
+	}
+	if messages, ok := root["messages"].([]any); ok {
+		snapshot.Messages = len(messages)
+	}
+	return snapshot
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case fmt.Stringer:
+		return strings.TrimSpace(v.String())
+	default:
+		return ""
+	}
+}
+
+func cloneRoute(in *RouteSnapshot) *RouteSnapshot {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.CcSwitch != nil {
+		cc := *in.CcSwitch
+		cc.AllowedChannelGroups = append([]string(nil), in.CcSwitch.AllowedChannelGroups...)
+		out.CcSwitch = &cc
+	}
+	return &out
+}
+
+func cloneAuth(in *AuthSnapshot) *AuthSnapshot {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func cloneQuota(in *QuotaSnapshot) *QuotaSnapshot {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func cloneUpstream(in *UpstreamSnapshot) *UpstreamSnapshot {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func cloneResponse(in *ResponseSnapshot) *ResponseSnapshot {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func cloneBody(in *BodySnapshot) *BodySnapshot {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Stream != nil {
+		stream := *in.Stream
+		out.Stream = &stream
+	}
+	return &out
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	log "github.com/sirupsen/logrus"
 )
@@ -32,16 +33,20 @@ func (l *FileRequestLogger) SetErrorLogsMaxFiles(maxFiles int) {
 }
 
 func (l *FileRequestLogger) LogRequest(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, apiRequest, apiResponse []byte, apiResponseErrors []*interfaces.ErrorMessage, requestID string, requestTimestamp, apiResponseTimestamp time.Time) error {
-	return l.logRequest(url, method, requestHeaders, body, statusCode, responseHeaders, response, apiRequest, apiResponse, apiResponseErrors, false, requestID, requestTimestamp, apiResponseTimestamp)
+	return l.logRequest(url, method, requestHeaders, body, statusCode, responseHeaders, response, apiRequest, apiResponse, apiResponseErrors, false, requestID, requestTimestamp, apiResponseTimestamp, diagnostics.Snapshot{})
 }
 
 // LogRequestWithOptions keeps forced error-log writes available even when
 // regular request logging is disabled.
 func (l *FileRequestLogger) LogRequestWithOptions(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, apiRequest, apiResponse []byte, apiResponseErrors []*interfaces.ErrorMessage, force bool, requestID string, requestTimestamp, apiResponseTimestamp time.Time) error {
-	return l.logRequest(url, method, requestHeaders, body, statusCode, responseHeaders, response, apiRequest, apiResponse, apiResponseErrors, force, requestID, requestTimestamp, apiResponseTimestamp)
+	return l.logRequest(url, method, requestHeaders, body, statusCode, responseHeaders, response, apiRequest, apiResponse, apiResponseErrors, force, requestID, requestTimestamp, apiResponseTimestamp, diagnostics.Snapshot{})
 }
 
-func (l *FileRequestLogger) logRequest(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, apiRequest, apiResponse []byte, apiResponseErrors []*interfaces.ErrorMessage, force bool, requestID string, requestTimestamp, apiResponseTimestamp time.Time) error {
+func (l *FileRequestLogger) LogRequestWithOptionsAndDiagnostics(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, apiRequest, apiResponse []byte, apiResponseErrors []*interfaces.ErrorMessage, force bool, requestID string, requestTimestamp, apiResponseTimestamp time.Time, diagnostic diagnostics.Snapshot) error {
+	return l.logRequest(url, method, requestHeaders, body, statusCode, responseHeaders, response, apiRequest, apiResponse, apiResponseErrors, force, requestID, requestTimestamp, apiResponseTimestamp, diagnostic)
+}
+
+func (l *FileRequestLogger) logRequest(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, apiRequest, apiResponse []byte, apiResponseErrors []*interfaces.ErrorMessage, force bool, requestID string, requestTimestamp, apiResponseTimestamp time.Time, diagnostic diagnostics.Snapshot) error {
 	if !l.enabled && !force {
 		return nil
 	}
@@ -49,9 +54,14 @@ func (l *FileRequestLogger) logRequest(url, method string, requestHeaders map[st
 		return fmt.Errorf("failed to create logs directory: %w", errEnsure)
 	}
 
-	filename := l.generateFilename(url, requestID)
+	logURL := url
+	if diagnostic.OriginalURL != "" {
+		logURL = diagnostic.OriginalURL
+	}
+	filenameURL := logURL
+	filename := l.generateFilename(filenameURL, requestID)
 	if force && !l.enabled {
-		filename = l.generateErrorFilename(url, requestID)
+		filename = l.generateErrorFilename(filenameURL, requestID)
 	}
 	filePath := filepath.Join(l.logsDir, filename)
 
@@ -79,7 +89,7 @@ func (l *FileRequestLogger) logRequest(url, method string, requestHeaders map[st
 
 	writeErr := l.writeNonStreamingLog(
 		logFile,
-		url,
+		logURL,
 		method,
 		requestHeaders,
 		body,
@@ -93,6 +103,7 @@ func (l *FileRequestLogger) logRequest(url, method string, requestHeaders map[st
 		decompressErr,
 		requestTimestamp,
 		apiResponseTimestamp,
+		diagnostic,
 	)
 	if errClose := logFile.Close(); errClose != nil {
 		log.WithError(errClose).Warn("failed to close request log file")

--- a/internal/logging/request_logger_format.go
+++ b/internal/logging/request_logger_format.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	log "github.com/sirupsen/logrus"
@@ -29,11 +31,12 @@ func (l *FileRequestLogger) writeNonStreamingLog(
 	decompressErr error,
 	requestTimestamp time.Time,
 	apiResponseTimestamp time.Time,
+	diagnostic diagnostics.Snapshot,
 ) error {
 	if requestTimestamp.IsZero() {
 		requestTimestamp = time.Now()
 	}
-	if errWrite := writeRequestInfoWithBody(w, url, method, requestHeaders, requestBody, requestBodyPath, requestTimestamp); errWrite != nil {
+	if errWrite := writeRequestInfoWithBody(w, url, method, requestHeaders, requestBody, requestBodyPath, requestTimestamp, diagnostic); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeAPISection(w, "=== API REQUEST ===\n", "=== API REQUEST", apiRequest, time.Time{}); errWrite != nil {
@@ -55,6 +58,7 @@ func writeRequestInfoWithBody(
 	body []byte,
 	bodyPath string,
 	timestamp time.Time,
+	diagnostic diagnostics.Snapshot,
 ) error {
 	if _, errWrite := io.WriteString(w, "=== REQUEST INFO ===\n"); errWrite != nil {
 		return errWrite
@@ -65,6 +69,16 @@ func writeRequestInfoWithBody(
 	if _, errWrite := io.WriteString(w, fmt.Sprintf("URL: %s\n", url)); errWrite != nil {
 		return errWrite
 	}
+	if diagnostic.EffectiveURL != "" && diagnostic.EffectiveURL != url {
+		if _, errWrite := io.WriteString(w, fmt.Sprintf("Effective URL: %s\n", diagnostic.EffectiveURL)); errWrite != nil {
+			return errWrite
+		}
+	}
+	if diagnostic.RequestID != "" {
+		if _, errWrite := io.WriteString(w, fmt.Sprintf("Request ID: %s\n", diagnostic.RequestID)); errWrite != nil {
+			return errWrite
+		}
+	}
 	if _, errWrite := io.WriteString(w, fmt.Sprintf("Method: %s\n", method)); errWrite != nil {
 		return errWrite
 	}
@@ -73,6 +87,21 @@ func writeRequestInfoWithBody(
 	}
 	if _, errWrite := io.WriteString(w, "\n"); errWrite != nil {
 		return errWrite
+	}
+	if hasDiagnosticMetadata(diagnostic) {
+		if _, errWrite := io.WriteString(w, "=== DIAGNOSTIC METADATA ===\n"); errWrite != nil {
+			return errWrite
+		}
+		data, errJSON := json.MarshalIndent(diagnostic, "", "  ")
+		if errJSON != nil {
+			return errJSON
+		}
+		if _, errWrite := w.Write(data); errWrite != nil {
+			return errWrite
+		}
+		if _, errWrite := io.WriteString(w, "\n\n"); errWrite != nil {
+			return errWrite
+		}
 	}
 
 	if _, errWrite := io.WriteString(w, "=== HEADERS ===\n"); errWrite != nil {
@@ -112,6 +141,19 @@ func writeRequestInfoWithBody(
 		return errWrite
 	}
 	return nil
+}
+
+func hasDiagnosticMetadata(diagnostic diagnostics.Snapshot) bool {
+	return diagnostic.RequestID != "" ||
+		diagnostic.OriginalURL != "" ||
+		diagnostic.EffectiveURL != "" ||
+		diagnostic.Route != nil ||
+		diagnostic.Auth != nil ||
+		diagnostic.Quota != nil ||
+		diagnostic.Upstream != nil ||
+		diagnostic.Egress != nil ||
+		diagnostic.Response != nil ||
+		diagnostic.Body != nil
 }
 
 func writeAPISection(w io.Writer, sectionHeader string, sectionPrefix string, payload []byte, timestamp time.Time) error {

--- a/internal/logging/request_logger_test.go
+++ b/internal/logging/request_logger_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 )
 
 func TestSanitizeForFilenameNormalizesUnsafeCharacters(t *testing.T) {
@@ -84,6 +86,87 @@ func TestLogRequestWithOptionsCleansUpOldErrorLogs(t *testing.T) {
 	}
 	if len(errorLogs) != 1 {
 		t.Fatalf("error log files = %d, want 1; files=%v", len(errorLogs), errorLogs)
+	}
+}
+
+func TestLogRequestWithDiagnosticsUsesOriginalURL(t *testing.T) {
+	t.Parallel()
+
+	logsDir := t.TempDir()
+	logger := NewFileRequestLogger(false, logsDir, "", 10)
+	diagnostic := diagnostics.Snapshot{
+		RequestID:    "reqabc123",
+		OriginalURL:  "/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses",
+		EffectiveURL: "/v1/responses",
+		Route: &diagnostics.RouteSnapshot{
+			RoutePath: "/deepseekv4flash-chatgpt/cs_3e13ca9880fc",
+			Group:     "deepseekv4flash-chatgpt",
+		},
+		Quota: &diagnostics.QuotaSnapshot{
+			Rejected:     true,
+			RejectedBy:   "rpm",
+			RPMLimit:     10,
+			Current:      11,
+			ErrorCode:    "rpm_limit_exceeded",
+			ErrorType:    "rate_limit_exceeded",
+			ErrorMessage: "RPM limit (10 requests/min) exceeded for this API key",
+		},
+		Response: &diagnostics.ResponseSnapshot{
+			Status:       429,
+			ErrorCode:    "rpm_limit_exceeded",
+			ErrorType:    "rate_limit_exceeded",
+			ErrorMessage: "RPM limit (10 requests/min) exceeded for this API key",
+			Source:       "local_quota",
+		},
+	}
+
+	if err := logger.LogRequestWithOptionsAndDiagnostics(
+		"/v1/responses",
+		"POST",
+		map[string][]string{"Authorization": {"Bearer secret-token-value"}},
+		[]byte(`{"model":"deepseek","input":"hello"}`),
+		429,
+		nil,
+		[]byte(`{"error":{"code":"rpm_limit_exceeded"}}`),
+		nil,
+		nil,
+		nil,
+		true,
+		"reqabc123",
+		timeZero(),
+		timeZero(),
+		diagnostic,
+	); err != nil {
+		t.Fatalf("LogRequestWithOptionsAndDiagnostics() error = %v", err)
+	}
+
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s) error = %v", logsDir, err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("log files = %d, want 1", len(entries))
+	}
+	name := entries[0].Name()
+	if !strings.HasPrefix(name, "error-deepseekv4flash-chatgpt-cs_3e13ca9880fc-v1-responses-") {
+		t.Fatalf("error log name = %q, want original custom route prefix", name)
+	}
+	content, err := os.ReadFile(filepath.Join(logsDir, name))
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", name, err)
+	}
+	text := string(content)
+	for _, want := range []string{
+		"URL: /deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses",
+		"Effective URL: /v1/responses",
+		"=== DIAGNOSTIC METADATA ===",
+		`"original_url": "/deepseekv4flash-chatgpt/cs_3e13ca9880fc/v1/responses"`,
+		`"rejected_by": "rpm"`,
+		`"source": "local_quota"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("log content missing %q:\n%s", want, text)
+		}
 	}
 }
 

--- a/internal/logging/streaming_log_writer.go
+++ b/internal/logging/streaming_log_writer.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -157,7 +158,7 @@ func (w *FileStreamingLogWriter) asyncWriter() {
 }
 
 func (w *FileStreamingLogWriter) writeFinalLog(logFile *os.File) error {
-	if errWrite := writeRequestInfoWithBody(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.timestamp); errWrite != nil {
+	if errWrite := writeRequestInfoWithBody(logFile, w.url, w.method, w.requestHeaders, nil, w.requestBodyPath, w.timestamp, diagnostics.Snapshot{}); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeAPISection(logFile, "=== API REQUEST ===\n", "=== API REQUEST", w.apiRequest, time.Time{}); errWrite != nil {

--- a/internal/runtime/executor/logging_helpers.go
+++ b/internal/runtime/executor/logging_helpers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	log "github.com/sirupsen/logrus"
@@ -19,9 +20,10 @@ import (
 )
 
 const (
-	apiAttemptsKey = "API_UPSTREAM_ATTEMPTS"
-	apiRequestKey  = "API_REQUEST"
-	apiResponseKey = "API_RESPONSE"
+	apiAttemptsKey               = "API_UPSTREAM_ATTEMPTS"
+	apiDiagnosticAttemptCountKey = "API_UPSTREAM_DIAGNOSTIC_ATTEMPT_COUNT"
+	apiRequestKey                = "API_REQUEST"
+	apiResponseKey               = "API_RESPONSE"
 )
 
 // upstreamRequestLog captures the outbound upstream request details for logging.
@@ -51,11 +53,12 @@ type upstreamAttempt struct {
 
 // recordAPIRequest stores the upstream request metadata in Gin context for request logging.
 func recordAPIRequest(ctx context.Context, cfg *config.Config, info upstreamRequestLog) {
-	if !shouldCaptureAPIExchangeLog(cfg) {
-		return
-	}
 	ginCtx := ginContextFrom(ctx)
 	if ginCtx == nil {
+		return
+	}
+	diagnostics.SetUpstreamRequest(ctx, nextUpstreamDiagnosticAttempt(ginCtx), info.Provider, info.AuthID, info.AuthLabel, info.URL, info.Method)
+	if !shouldCaptureAPIExchangeLog(cfg) {
 		return
 	}
 
@@ -98,11 +101,12 @@ func recordAPIRequest(ctx context.Context, cfg *config.Config, info upstreamRequ
 
 // recordAPIResponseMetadata captures upstream response status/header information for the latest attempt.
 func recordAPIResponseMetadata(ctx context.Context, cfg *config.Config, status int, headers http.Header) {
-	if !shouldCaptureAPIExchangeLog(cfg) {
-		return
-	}
+	diagnostics.SetUpstreamResponse(ctx, status)
 	ginCtx := ginContextFrom(ctx)
 	if ginCtx == nil {
+		return
+	}
+	if !shouldCaptureAPIExchangeLog(cfg) {
 		return
 	}
 	attempts, attempt := ensureAttempt(ginCtx)
@@ -124,11 +128,15 @@ func recordAPIResponseMetadata(ctx context.Context, cfg *config.Config, status i
 
 // recordAPIResponseError adds an error entry for the latest attempt when no HTTP response is available.
 func recordAPIResponseError(ctx context.Context, cfg *config.Config, err error) {
-	if !shouldCaptureAPIExchangeLog(cfg) || err == nil {
+	if err == nil {
 		return
 	}
+	diagnostics.SetUpstreamError(ctx, err)
 	ginCtx := ginContextFrom(ctx)
 	if ginCtx == nil {
+		return
+	}
+	if !shouldCaptureAPIExchangeLog(cfg) {
 		return
 	}
 	attempts, attempt := ensureAttempt(ginCtx)
@@ -204,6 +212,24 @@ func getAttempts(ginCtx *gin.Context) []*upstreamAttempt {
 		}
 	}
 	return nil
+}
+
+func nextUpstreamDiagnosticAttempt(ginCtx *gin.Context) int {
+	if ginCtx == nil {
+		return 0
+	}
+	count := 0
+	if value, exists := ginCtx.Get(apiDiagnosticAttemptCountKey); exists {
+		switch v := value.(type) {
+		case int:
+			count = v
+		case int64:
+			count = int(v)
+		}
+	}
+	count++
+	ginCtx.Set(apiDiagnosticAttemptCountKey, count)
+	return count
 }
 
 func ensureAttempt(ginCtx *gin.Context) ([]*upstreamAttempt, *upstreamAttempt) {

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
@@ -155,6 +156,30 @@ func recordRequestLogEgressRoute(ctx context.Context, cfg *config.Config, auth *
 	}
 
 	ginCtx.Set(requestLogEgressRouteKey, route)
+	diagnostics.SetEgress(ginCtx, requestLogEgressRouteMap(route))
+}
+
+func requestLogEgressRouteMap(route requestLogEgressRoute) map[string]any {
+	result := map[string]any{}
+	if route.RouteKind != "" {
+		result["route_kind"] = route.RouteKind
+	}
+	if route.ProxySource != "" {
+		result["proxy_source"] = route.ProxySource
+	}
+	if route.ProxyID != "" {
+		result["proxy_id"] = route.ProxyID
+	}
+	if route.ProxyName != "" {
+		result["proxy_name"] = route.ProxyName
+	}
+	if route.ProxyURLHost != "" {
+		result["proxy_url_host"] = route.ProxyURLHost
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func maskProxyURLHost(raw string) string {

--- a/internal/runtime/executor/usage_request_details.go
+++ b/internal/runtime/executor/usage_request_details.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -78,6 +79,11 @@ func buildRequestDetailContent(ctx context.Context) string {
 	if timing := upstreamTimingFromContext(ginCtx); len(timing) > 0 {
 		detail["upstream_timing"] = timing
 	}
+	if diagnostic := diagnostics.FromGin(ginCtx); diagnostic != nil {
+		if snapshot := diagnostic.Snapshot(); !snapshot.IsZero() {
+			detail["diagnostic"] = snapshot
+		}
+	}
 
 	data, err := json.Marshal(detail)
 	if err != nil {
@@ -123,27 +129,7 @@ func requestLogEgressFromContext(ginCtx *gin.Context) map[string]any {
 	if !ok {
 		return nil
 	}
-
-	result := map[string]any{}
-	if route.RouteKind != "" {
-		result["route_kind"] = route.RouteKind
-	}
-	if route.ProxySource != "" {
-		result["proxy_source"] = route.ProxySource
-	}
-	if route.ProxyID != "" {
-		result["proxy_id"] = route.ProxyID
-	}
-	if route.ProxyName != "" {
-		result["proxy_name"] = route.ProxyName
-	}
-	if route.ProxyURLHost != "" {
-		result["proxy_url_host"] = route.ProxyURLHost
-	}
-	if len(result) == 0 {
-		return nil
-	}
-	return result
+	return requestLogEgressRouteMap(route)
 }
 
 func cloneHeaderValues(headers http.Header) map[string][]string {


### PR DESCRIPTION
## Summary
- Preserve original and effective request URLs across routing/proxy execution.
- Add structured diagnostic metadata to request/error logs and management log parsing.
- Improve gateway 4xx error-only logging without leaking full request bodies by default.

## Verification
- rtk go test ./internal/diagnostics ./internal/api/middleware ./internal/logging ./internal/runtime/executor ./internal/api/handlers/management
- rtk go test ./...
- rtk git diff --check