### PR TITLE
fix: reject incomplete responses streams

### DIFF
--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -141,6 +142,8 @@ type authAwareStreamExecutor struct {
 
 type invalidJSONStreamExecutor struct{}
 
+type incompleteResponsesStreamExecutor struct{}
+
 func (e *invalidJSONStreamExecutor) Identifier() string { return "codex" }
 
 func (e *invalidJSONStreamExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
@@ -163,6 +166,35 @@ func (e *invalidJSONStreamExecutor) CountTokens(context.Context, *coreauth.Auth,
 }
 
 func (e *invalidJSONStreamExecutor) HttpRequest(ctx context.Context, auth *coreauth.Auth, req *http.Request) (*http.Response, error) {
+	return nil, &coreauth.Error{
+		Code:       "not_implemented",
+		Message:    "HttpRequest not implemented",
+		HTTPStatus: http.StatusNotImplemented,
+	}
+}
+
+func (e *incompleteResponsesStreamExecutor) Identifier() string { return "codex" }
+
+func (e *incompleteResponsesStreamExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, &coreauth.Error{Code: "not_implemented", Message: "Execute not implemented"}
+}
+
+func (e *incompleteResponsesStreamExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	ch := make(chan coreexecutor.StreamChunk, 1)
+	ch <- coreexecutor.StreamChunk{Payload: []byte("event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n")}
+	close(ch)
+	return &coreexecutor.StreamResult{Chunks: ch}, nil
+}
+
+func (e *incompleteResponsesStreamExecutor) Refresh(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *incompleteResponsesStreamExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, &coreauth.Error{Code: "not_implemented", Message: "CountTokens not implemented"}
+}
+
+func (e *incompleteResponsesStreamExecutor) HttpRequest(ctx context.Context, auth *coreauth.Auth, req *http.Request) (*http.Response, error) {
 	return nil, &coreauth.Error{
 		Code:       "not_implemented",
 		Message:    "HttpRequest not implemented",
@@ -831,5 +863,67 @@ func TestExecuteStreamWithAuthManager_ValidatesOpenAIResponsesStreamDataJSON(t *
 	}
 	if !gotErr {
 		t.Fatalf("expected terminal error")
+	}
+}
+
+func TestExecuteStreamWithAuthManager_RejectsOpenAIResponsesStreamWithoutCompleted(t *testing.T) {
+	executor := &incompleteResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth1 := &coreauth.Auth{
+		ID:       "auth1",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "test1@example.com"},
+	}
+	if _, err := manager.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("manager.Register(auth1): %v", err)
+	}
+
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+	})
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai-response", "test-model", []byte(`{"model":"test-model"}`), "")
+	if dataChan == nil || errChan == nil {
+		t.Fatalf("expected non-nil channels")
+	}
+
+	var got []byte
+	for chunk := range dataChan {
+		got = append(got, chunk...)
+	}
+	if len(got) == 0 {
+		t.Fatalf("expected partial payload before protocol error")
+	}
+
+	var gotErr *interfaces.ErrorMessage
+	for msg := range errChan {
+		if msg != nil {
+			gotErr = msg
+		}
+	}
+	if gotErr == nil {
+		t.Fatalf("expected terminal error")
+	}
+	if gotErr.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected status %d, got %d", http.StatusBadGateway, gotErr.StatusCode)
+	}
+	if gotErr.Error == nil || !strings.Contains(gotErr.Error.Error(), "upstream responses stream closed before response.completed") {
+		t.Fatalf("unexpected error: %v", gotErr.Error)
+	}
+
+	updated, ok := manager.GetByID("auth1")
+	if !ok {
+		t.Fatalf("expected auth to be present")
+	}
+	if !updated.Unavailable {
+		t.Fatalf("expected incomplete stream to mark auth unavailable")
+	}
+	if updated.LastError == nil || !strings.Contains(updated.LastError.Message, "upstream responses stream closed before response.completed") {
+		t.Fatalf("expected protocol failure LastError, got %+v", updated.LastError)
 	}
 }

--- a/sdk/cliproxy/auth/conductor_execution_service.go
+++ b/sdk/cliproxy/auth/conductor_execution_service.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 )
 
 type executionService struct {
@@ -189,7 +190,7 @@ func (s executionService) executeStreamMixedOnce(ctx context.Context, providers 
 			continue
 		}
 
-		return s.wrapStreamResult(candidate.execCtx, candidate.auth, candidate.provider, scope.routeModel, streamResult), nil
+		return s.wrapStreamResult(candidate.execCtx, candidate.auth, candidate.provider, scope.routeModel, scope.opts.SourceFormat, streamResult), nil
 	}
 }
 
@@ -251,6 +252,7 @@ func (s executionService) wrapStreamResult(
 	auth *Auth,
 	provider string,
 	routeModel string,
+	sourceFormat sdktranslator.Format,
 	streamResult *cliproxyexecutor.StreamResult,
 ) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -259,7 +261,11 @@ func (s executionService) wrapStreamResult(
 		defer close(out)
 		var failed bool
 		forward := true
+		completionTracker := newResponsesStreamCompletionTracker(sourceFormat)
 		for chunk := range streamChunks {
+			if chunk.Err == nil && completionTracker != nil && len(chunk.Payload) > 0 {
+				completionTracker.Observe(chunk.Payload)
+			}
 			if chunk.Err != nil && !failed {
 				failed = true
 				rerr := errorFromExecution(chunk.Err)
@@ -288,6 +294,32 @@ func (s executionService) wrapStreamResult(
 			case <-streamCtx.Done():
 				forward = false
 			case out <- chunk:
+			}
+		}
+		if !failed && completionTracker != nil {
+			if err := completionTracker.ErrIfIncomplete(); err != nil {
+				failed = true
+				rerr := errorFromExecution(err)
+				s.manager.MarkResult(streamCtx, Result{
+					AuthID:     streamAuth.ID,
+					Provider:   streamProvider,
+					Model:      routeModel,
+					Success:    false,
+					Error:      rerr,
+					RetryAfter: retryAfterFromError(err),
+					Headers:    headers.Clone(),
+				})
+				if forward {
+					chunk := cliproxyexecutor.StreamChunk{Err: err}
+					if streamCtx == nil {
+						out <- chunk
+					} else {
+						select {
+						case <-streamCtx.Done():
+						case out <- chunk:
+						}
+					}
+				}
 			}
 		}
 		if !failed {

--- a/sdk/cliproxy/auth/responses_stream_completion.go
+++ b/sdk/cliproxy/auth/responses_stream_completion.go
@@ -1,0 +1,127 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+const responsesStreamCompletedType = "response.completed"
+
+type responsesStreamCompletionTracker struct {
+	buffer    []byte
+	completed bool
+}
+
+func newResponsesStreamCompletionTracker(sourceFormat sdktranslator.Format) *responsesStreamCompletionTracker {
+	if sourceFormat != sdktranslator.FormatOpenAIResponse {
+		return nil
+	}
+	return &responsesStreamCompletionTracker{}
+}
+
+func (t *responsesStreamCompletionTracker) Observe(chunk []byte) {
+	if t == nil || t.completed || len(chunk) == 0 {
+		return
+	}
+	t.buffer = append(t.buffer, chunk...)
+	for {
+		block, rest, ok := takeSSEBlock(t.buffer)
+		if !ok {
+			return
+		}
+		t.buffer = rest
+		if responsesSSEBlockCompleted(block) {
+			t.completed = true
+			return
+		}
+	}
+}
+
+func (t *responsesStreamCompletionTracker) ErrIfIncomplete() error {
+	if t == nil || t.completed {
+		return nil
+	}
+	if len(bytes.TrimSpace(t.buffer)) > 0 && responsesSSEBlockCompleted(t.buffer) {
+		return nil
+	}
+	return &Error{
+		Code:       "response_stream_incomplete",
+		Message:    "upstream responses stream closed before response.completed",
+		Retryable:  true,
+		HTTPStatus: http.StatusBadGateway,
+	}
+}
+
+func takeSSEBlock(buffer []byte) ([]byte, []byte, bool) {
+	end, delimLen := firstSSEBlockEnd(buffer)
+	if end < 0 {
+		return nil, buffer, false
+	}
+	block := buffer[:end]
+	rest := buffer[end+delimLen:]
+	return block, rest, true
+}
+
+func firstSSEBlockEnd(buffer []byte) (int, int) {
+	type delimiter struct {
+		value []byte
+		len   int
+	}
+	delimiters := []delimiter{
+		{value: []byte("\n\n"), len: 2},
+		{value: []byte("\r\n\r\n"), len: 4},
+		{value: []byte("\r\r"), len: 2},
+	}
+	best := -1
+	bestLen := 0
+	for _, delimiter := range delimiters {
+		idx := bytes.Index(buffer, delimiter.value)
+		if idx < 0 {
+			continue
+		}
+		if best < 0 || idx < best {
+			best = idx
+			bestLen = delimiter.len
+		}
+	}
+	return best, bestLen
+}
+
+func responsesSSEBlockCompleted(block []byte) bool {
+	var eventType string
+	var dataLines []string
+	for _, rawLine := range bytes.Split(block, []byte("\n")) {
+		line := strings.TrimSpace(strings.TrimSuffix(string(rawLine), "\r"))
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "event:"); ok {
+			eventType = strings.TrimSpace(value)
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "data:"); ok {
+			dataLines = append(dataLines, strings.TrimSpace(value))
+		}
+	}
+	if eventType == responsesStreamCompletedType {
+		return true
+	}
+	if len(dataLines) == 0 {
+		return false
+	}
+	data := strings.TrimSpace(strings.Join(dataLines, "\n"))
+	if data == "" || data == "[DONE]" {
+		return false
+	}
+	var payload struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		return false
+	}
+	return strings.TrimSpace(payload.Type) == responsesStreamCompletedType
+}


### PR DESCRIPTION
## Summary
- add an OpenAI Responses SSE completion guard for stream execution
- mark streams that close before `response.completed` as upstream protocol failures
- add regression coverage for incomplete Responses streams and auth failure marking

## Tests
- `rtk go test ./sdk/api/handlers -run 'TestExecuteStreamWithAuthManager_(RejectsOpenAIResponsesStreamWithoutCompleted|ValidatesOpenAIResponsesStreamDataJSON|RetriesBeforeFirstByte|DoesNotRetryAfterFirstByte|PinnedAuthKeepsSameUpstream|GroupedRouteRequestContextDoesNotRetryInvalidModel)' -count=1`\n- `rtk go test ./sdk/cliproxy/auth ./sdk/api/handlers`\n- `rtk go test ./...`