### PR TITLE
fix: route glm 5.2 through opencode messages

### DIFF
--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -26,6 +26,7 @@ var opencodeGoBaseURL = "https://opencode.ai/zen/go/v1"
 var opencodeGoMessagesModels = map[string]struct{}{
 	"minimax-m2.7": {},
 	"minimax-m2.5": {},
+	"glm-5.2":      {},
 }
 
 var opencodeGoKnownNativeVisionModels = map[string]struct{}{

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -504,6 +504,60 @@ func TestOpenCodeGoExecutorRoutesMiniMaxModelsToMessages(t *testing.T) {
 	}
 }
 
+func TestOpenCodeGoExecutorRoutesGLM52ClaudeStreamToMessagesWithCacheControl(t *testing.T) {
+	var gotPath, gotAuth, gotAnthropicVersion string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotAnthropicVersion = r.Header.Get("Anthropic-Version")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":101,"output_tokens":2,"cache_read_input_tokens":10}}` + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	oldBaseURL := opencodeGoBaseURL
+	opencodeGoBaseURL = server.URL + "/zen/go/v1"
+	t.Cleanup(func() { opencodeGoBaseURL = oldBaseURL })
+
+	exec := NewOpenCodeGoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
+	payload := []byte(`{"model":"glm-5.2","max_tokens":32,"stream":true,"system":[{"type":"text","text":"system prompt","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"cached context","cache_control":{"type":"ephemeral"}},{"type":"text","text":"hi"}]}]}`)
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "glm-5.2",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream returned error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	if gotPath != "/zen/go/v1/messages" {
+		t.Fatalf("path = %q, want /zen/go/v1/messages", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("Authorization = %q, want bearer key", gotAuth)
+	}
+	if gotAnthropicVersion != "2023-06-01" {
+		t.Fatalf("Anthropic-Version = %q, want 2023-06-01", gotAnthropicVersion)
+	}
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "glm-5.2" {
+		t.Fatalf("upstream model = %q, want glm-5.2; body=%s", gotModel, string(gotBody))
+	}
+	if count := strings.Count(string(gotBody), `"cache_control"`); count != 2 {
+		t.Fatalf("cache_control count = %d, want 2; body=%s", count, string(gotBody))
+	}
+	if count := strings.Count(string(gotBody), `"ephemeral"`); count != 2 {
+		t.Fatalf("ephemeral count = %d, want 2; body=%s", count, string(gotBody))
+	}
+}
+
 func TestOpenCodeGoExecutorSupportsResponsesAPIForOpenAIModels(t *testing.T) {
 	var gotPath string
 	var gotBody []byte


### PR DESCRIPTION
## Summary
- route OpenCode Go glm-5.2 requests through the Anthropic /messages endpoint
- preserve Claude cache_control markers for glm-5.2 streaming requests
- add regression coverage for glm-5.2 Claude streaming cache_control forwarding

## Tests
- rtk go test ./internal/runtime/executor ./internal/translator/openai/claude
- rtk go test ./...
- rtk go build -o /tmp/clirelay-cache-fix ./cmd/server