### PR TITLE
fix: preserve glm cache controls on opencode chat path

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -117,6 +117,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 			return resp, err
 		}
 	}
+	if e.provider == openCodeGoProvider && execCtx.SourceFormat == sdktranslator.FormatClaude && endpoint == "/chat/completions" {
+		translated = opencodeGoPreserveClaudeCacheControl(translated, req.Payload)
+	}
 
 	// OpenCode-Go: the translator drops reasoning_content when converting
 	// from Responses API. Inject it here into translated payload so it survives.
@@ -241,6 +244,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		if err != nil {
 			return nil, err
 		}
+	}
+	if e.provider == openCodeGoProvider && execCtx.SourceFormat == sdktranslator.FormatClaude {
+		translated = opencodeGoPreserveClaudeCacheControl(translated, req.Payload)
 	}
 
 	// Inject reasoning_content for OpenCode-Go after Responses API translation.

--- a/internal/runtime/executor/opencode_go_cache_control.go
+++ b/internal/runtime/executor/opencode_go_cache_control.go
@@ -1,0 +1,118 @@
+package executor
+
+import (
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type opencodeGoCacheControlPart struct {
+	role  string
+	value string
+}
+
+func opencodeGoPreserveClaudeCacheControl(translated, source []byte) []byte {
+	controls := opencodeGoCollectClaudeCacheControls(source)
+	if len(controls) == 0 || !gjson.ValidBytes(translated) {
+		return translated
+	}
+
+	out := translated
+	controlIndex := 0
+	messages := gjson.GetBytes(out, "messages")
+	if !messages.IsArray() {
+		return out
+	}
+	messages.ForEach(func(messageIndex, message gjson.Result) bool {
+		if controlIndex >= len(controls) {
+			return false
+		}
+		role := message.Get("role").String()
+		content := message.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(contentIndex, part gjson.Result) bool {
+			if controlIndex >= len(controls) {
+				return false
+			}
+			if role != controls[controlIndex].role {
+				return true
+			}
+			if part.Get("cache_control").Exists() || !opencodeGoChatContentPartSupportsCacheControl(part) {
+				return true
+			}
+			path := fmt.Sprintf("messages.%d.content.%d.cache_control", messageIndex.Int(), contentIndex.Int())
+			updated, err := sjson.SetRawBytes(out, path, []byte(controls[controlIndex].value))
+			if err == nil {
+				out = updated
+				controlIndex++
+			}
+			return true
+		})
+		return true
+	})
+	return out
+}
+
+func opencodeGoCollectClaudeCacheControls(source []byte) []opencodeGoCacheControlPart {
+	if !gjson.ValidBytes(source) {
+		return nil
+	}
+	controls := make([]opencodeGoCacheControlPart, 0, 4)
+	system := gjson.GetBytes(source, "system")
+	if system.IsArray() {
+		system.ForEach(func(_, part gjson.Result) bool {
+			opencodeGoAppendClaudeCacheControl(&controls, "system", part)
+			return true
+		})
+	}
+	messages := gjson.GetBytes(source, "messages")
+	if messages.IsArray() {
+		messages.ForEach(func(_, message gjson.Result) bool {
+			role := message.Get("role").String()
+			content := message.Get("content")
+			if !content.IsArray() {
+				return true
+			}
+			content.ForEach(func(_, part gjson.Result) bool {
+				opencodeGoAppendClaudeCacheControl(&controls, role, part)
+				return true
+			})
+			return true
+		})
+	}
+	return controls
+}
+
+func opencodeGoAppendClaudeCacheControl(controls *[]opencodeGoCacheControlPart, role string, part gjson.Result) {
+	cacheControl := part.Get("cache_control")
+	if role == "" || !cacheControl.Exists() || !opencodeGoClaudePartMapsToChatContent(part) {
+		return
+	}
+	*controls = append(*controls, opencodeGoCacheControlPart{
+		role:  role,
+		value: cacheControl.Raw,
+	})
+}
+
+func opencodeGoClaudePartMapsToChatContent(part gjson.Result) bool {
+	switch part.Get("type").String() {
+	case "text":
+		return part.Get("text").String() != ""
+	case "image":
+		return part.Get("source").Exists() || part.Get("url").String() != ""
+	default:
+		return false
+	}
+}
+
+func opencodeGoChatContentPartSupportsCacheControl(part gjson.Result) bool {
+	switch part.Get("type").String() {
+	case "text", "image_url":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -26,7 +26,6 @@ var opencodeGoBaseURL = "https://opencode.ai/zen/go/v1"
 var opencodeGoMessagesModels = map[string]struct{}{
 	"minimax-m2.7": {},
 	"minimax-m2.5": {},
-	"glm-5.2":      {},
 }
 
 var opencodeGoKnownNativeVisionModels = map[string]struct{}{

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -504,17 +504,15 @@ func TestOpenCodeGoExecutorRoutesMiniMaxModelsToMessages(t *testing.T) {
 	}
 }
 
-func TestOpenCodeGoExecutorRoutesGLM52ClaudeStreamToMessagesWithCacheControl(t *testing.T) {
-	var gotPath, gotAuth, gotAnthropicVersion string
+func TestOpenCodeGoExecutorRoutesGLM52ClaudeToChatCompletionsWithCacheControl(t *testing.T) {
+	var gotPath, gotAuth string
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
-		gotAnthropicVersion = r.Header.Get("Anthropic-Version")
 		gotBody, _ = io.ReadAll(r.Body)
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":101,"output_tokens":2,"cache_read_input_tokens":10}}` + "\n\n"))
-		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_glm","object":"chat.completion","created":1,"model":"glm-5.2","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":101,"completion_tokens":2,"total_tokens":103,"prompt_tokens_details":{"cached_tokens":10}}}`))
 	}))
 	defer server.Close()
 
@@ -524,28 +522,20 @@ func TestOpenCodeGoExecutorRoutesGLM52ClaudeStreamToMessagesWithCacheControl(t *
 
 	exec := NewOpenCodeGoExecutor(&config.Config{})
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key"}}
-	payload := []byte(`{"model":"glm-5.2","max_tokens":32,"stream":true,"system":[{"type":"text","text":"system prompt","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"cached context","cache_control":{"type":"ephemeral"}},{"type":"text","text":"hi"}]}]}`)
-	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+	payload := []byte(`{"model":"glm-5.2","max_tokens":32,"system":[{"type":"text","text":"system prompt","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"cached context","cache_control":{"type":"ephemeral"}},{"type":"text","text":"hi"}]}]}`)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "glm-5.2",
 		Payload: payload,
-	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: true})
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
 	if err != nil {
-		t.Fatalf("ExecuteStream returned error: %v", err)
-	}
-	for chunk := range result.Chunks {
-		if chunk.Err != nil {
-			t.Fatalf("stream chunk error: %v", chunk.Err)
-		}
+		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	if gotPath != "/zen/go/v1/messages" {
-		t.Fatalf("path = %q, want /zen/go/v1/messages", gotPath)
+	if gotPath != "/zen/go/v1/chat/completions" {
+		t.Fatalf("path = %q, want /zen/go/v1/chat/completions", gotPath)
 	}
 	if gotAuth != "Bearer test-key" {
 		t.Fatalf("Authorization = %q, want bearer key", gotAuth)
-	}
-	if gotAnthropicVersion != "2023-06-01" {
-		t.Fatalf("Anthropic-Version = %q, want 2023-06-01", gotAnthropicVersion)
 	}
 	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "glm-5.2" {
 		t.Fatalf("upstream model = %q, want glm-5.2; body=%s", gotModel, string(gotBody))
@@ -555,6 +545,9 @@ func TestOpenCodeGoExecutorRoutesGLM52ClaudeStreamToMessagesWithCacheControl(t *
 	}
 	if count := strings.Count(string(gotBody), `"ephemeral"`); count != 2 {
 		t.Fatalf("ephemeral count = %d, want 2; body=%s", count, string(gotBody))
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "content.0.text").String(); gotText != "ok" {
+		t.Fatalf("response text = %q, want ok; payload=%s", gotText, string(resp.Payload))
 	}
 }
 


### PR DESCRIPTION
## Summary
- route `glm-5.2` back through the OpenCode Go `/chat/completions` path instead of the unsupported `/messages` path
- preserve existing Claude `cache_control` metadata in the OpenCode Go executor path before sending the OpenAI-compatible chat request
- keep cache token accounting sourced only from upstream usage fields; this does not synthesize cached token counts
- avoid `internal/translator/**` changes so the repository translator guard remains satisfied

## Verification
- `rtk go test ./internal/runtime/executor ./internal/translator/openai/claude`
- clean worktree: `rtk go test ./...`
- clean worktree: `rtk go build -o /tmp/clirelay-hotfix-580c3188/clirelay-hotfix ./cmd/server`