### PR TITLE
fix: enforce provider model ownership

### DIFF
--- a/internal/api/handlers/management/cline_config_test.go
+++ b/internal/api/handlers/management/cline_config_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -80,5 +81,32 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	if len(h.cfg.ClineKey) != 0 {
 		t.Fatalf("ClineKey after DELETE = %+v", h.cfg.ClineKey)
+	}
+}
+
+func TestClineKeyManagementRejectsBareModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	h := &Handler{
+		cfg:            &config.Config{ClineKey: []config.ClineKey{{APIKey: "existing"}}},
+		configFilePath: configPath,
+	}
+
+	putBody := []byte(`[{"api-key":"cline-key","models":[{"name":"glm-5.2"}]}]`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/cline-api-key", bytes.NewReader(putBody))
+	h.ProviderKeys().PutClineKeys(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("PUT status = %d body=%s, want 400", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cline models contains invalid model") {
+		t.Fatalf("PUT body = %s, want invalid model error", w.Body.String())
+	}
+	if got := h.cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" {
+		t.Fatalf("ClineKey after rejected PUT = %+v, want unchanged existing entry", got)
 	}
 }

--- a/internal/api/handlers/management/opencode_go_config_test.go
+++ b/internal/api/handlers/management/opencode_go_config_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -71,5 +72,32 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	if len(h.cfg.OpenCodeGoKey) != 0 {
 		t.Fatalf("OpenCodeGoKey after DELETE = %+v", h.cfg.OpenCodeGoKey)
+	}
+}
+
+func TestOpenCodeGoKeyManagementRejectsClinePassModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	h := &Handler{
+		cfg:            &config.Config{OpenCodeGoKey: []config.OpenCodeGoKey{{APIKey: "existing"}}},
+		configFilePath: configPath,
+	}
+
+	putBody := []byte(`[{"api-key":"go-key","models":[{"name":"cline-pass/glm-5.2"}]}]`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/opencode-go-api-key", bytes.NewReader(putBody))
+	h.ProviderKeys().PutOpenCodeGoKeys(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("PUT status = %d body=%s, want 400", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "opencode-go models contains invalid model") {
+		t.Fatalf("PUT body = %s, want invalid model error", w.Body.String())
+	}
+	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "existing" {
+		t.Fatalf("OpenCodeGoKey after rejected PUT = %+v, want unchanged existing entry", got)
 	}
 }

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -206,6 +206,9 @@ func (s *Service) ReplaceOpenCodeGoKeys(entries []config.OpenCodeGoKey) error {
 	for i := range entries {
 		NormalizeOpenCodeGoKey(&entries[i])
 		if strings.TrimSpace(entries[i].APIKey) != "" {
+			if err := validateOpenCodeGoKeyModels(entries[i]); err != nil {
+				return err
+			}
 			filtered = append(filtered, entries[i])
 		}
 	}
@@ -291,6 +294,9 @@ func (s *Service) PatchOpenCodeGoKey(index *int, apiKey *string, name *string, p
 		s.deleteOpenCodeGoKeyByIndex(targetIndex)
 		return nil
 	}
+	if err := validateOpenCodeGoKeyModels(entry); err != nil {
+		return err
+	}
 	prev := append([]config.OpenCodeGoKey(nil), s.cfg.OpenCodeGoKey...)
 	s.cfg.OpenCodeGoKey[targetIndex] = entry
 	s.cfg.SanitizeOpenCodeGoKeys()
@@ -369,6 +375,9 @@ func (s *Service) ReplaceClineKeys(entries []config.ClineKey) error {
 	for i := range entries {
 		NormalizeClineKey(&entries[i])
 		if strings.TrimSpace(entries[i].APIKey) != "" {
+			if err := validateClineKeyModels(entries[i]); err != nil {
+				return err
+			}
 			filtered = append(filtered, entries[i])
 		}
 	}
@@ -450,6 +459,9 @@ func (s *Service) PatchClineKey(index *int, apiKey *string, name *string, patch 
 	if entry.APIKey == "" {
 		s.deleteClineKeyByIndex(targetIndex)
 		return nil
+	}
+	if err := validateClineKeyModels(entry); err != nil {
+		return err
 	}
 	prev := append([]config.ClineKey(nil), s.cfg.ClineKey...)
 	s.cfg.ClineKey[targetIndex] = entry

--- a/internal/management/settings/providers/provider_model_validation.go
+++ b/internal/management/settings/providers/provider_model_validation.go
@@ -1,0 +1,58 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+const clinePassModelPrefix = "cline-pass/"
+
+func validateOpenCodeGoKeyModels(entry config.OpenCodeGoKey) error {
+	for _, model := range entry.Models {
+		if isClinePassModelID(model.Name) {
+			return providerModelOwnershipError("opencode-go", "models", model.Name, "must not use cline-pass model IDs")
+		}
+	}
+	for _, model := range entry.ExcludedModels {
+		if model == "*" {
+			continue
+		}
+		if isClinePassModelID(model) {
+			return providerModelOwnershipError("opencode-go", "excluded-models", model, "must not use cline-pass model IDs")
+		}
+	}
+	if isClinePassModelID(entry.VisionFallbackModel) {
+		return providerModelOwnershipError("opencode-go", "vision-fallback-model", entry.VisionFallbackModel, "must not use cline-pass model IDs")
+	}
+	return nil
+}
+
+func validateClineKeyModels(entry config.ClineKey) error {
+	for _, model := range entry.Models {
+		if !isClinePassModelID(model.Name) {
+			return providerModelOwnershipError("cline", "models", model.Name, "must use cline-pass model IDs")
+		}
+	}
+	for _, model := range entry.ExcludedModels {
+		if model == "*" {
+			continue
+		}
+		if !isClinePassModelID(model) {
+			return providerModelOwnershipError("cline", "excluded-models", model, "must use cline-pass model IDs")
+		}
+	}
+	if entry.VisionFallbackModel != "" && !isClinePassModelID(entry.VisionFallbackModel) {
+		return providerModelOwnershipError("cline", "vision-fallback-model", entry.VisionFallbackModel, "must use cline-pass model IDs")
+	}
+	return nil
+}
+
+func isClinePassModelID(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), clinePassModelPrefix)
+}
+
+func providerModelOwnershipError(provider, field, model, rule string) error {
+	return fmt.Errorf("%s %s contains invalid model %q: %s", provider, field, strings.TrimSpace(model), rule)
+}

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -371,4 +372,106 @@ func TestOpenCodeGoKeysReplacePatchDeleteAndRollback(t *testing.T) {
 	if len(cfg.OpenCodeGoKey) != 0 {
 		t.Fatalf("OpenCodeGoKey after delete = %#v, want empty", cfg.OpenCodeGoKey)
 	}
+}
+
+func TestOpenCodeGoKeysRejectClinePassModels(t *testing.T) {
+	cfg := &config.Config{
+		OpenCodeGoKey: []config.OpenCodeGoKey{{
+			APIKey: "existing",
+			Models: []config.OpenCodeGoModel{{
+				Name: "glm-5.2",
+			}},
+		}},
+	}
+	svc := NewService(cfg, nil)
+
+	err := svc.ReplaceOpenCodeGoKeys([]config.OpenCodeGoKey{{
+		APIKey: "go-key",
+		Models: []config.OpenCodeGoModel{{
+			Name: " cline-pass/glm-5.2 ",
+		}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "opencode-go models contains invalid model") {
+		t.Fatalf("ReplaceOpenCodeGoKeys() error = %v, want invalid opencode-go model error", err)
+	}
+	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "existing" || got[0].Models[0].Name != "glm-5.2" {
+		t.Fatalf("OpenCodeGoKey after rejected replace = %#v, want unchanged existing entry", got)
+	}
+
+	badExcluded := []string{"cline-pass/minimax-m3"}
+	err = svc.PatchOpenCodeGoKey(nil, stringPtr("existing"), nil, OpenCodeGoPatch{ExcludedModels: &badExcluded})
+	if err == nil || !strings.Contains(err.Error(), "opencode-go excluded-models contains invalid model") {
+		t.Fatalf("PatchOpenCodeGoKey(excluded-models) error = %v, want invalid opencode-go model error", err)
+	}
+	if got := cfg.OpenCodeGoKey[0].ExcludedModels; len(got) != 0 {
+		t.Fatalf("OpenCodeGoKey excluded models after rejected patch = %#v, want unchanged empty list", got)
+	}
+
+	validExcluded := []string{"*"}
+	validFallback := " qwen3.5-plus "
+	validModels := []config.OpenCodeGoModel{{Name: " glm-5.2 "}}
+	err = svc.PatchOpenCodeGoKey(nil, stringPtr("existing"), nil, OpenCodeGoPatch{
+		Models:         &validModels,
+		ExcludedModels: &validExcluded,
+		VisionFallback: &validFallback,
+	})
+	if err != nil {
+		t.Fatalf("PatchOpenCodeGoKey(valid models) error = %v, want nil", err)
+	}
+	if got := cfg.OpenCodeGoKey[0]; got.Models[0].Name != "glm-5.2" || got.ExcludedModels[0] != "*" || got.VisionFallbackModel != "qwen3.5-plus" {
+		t.Fatalf("OpenCodeGoKey after valid patch = %#v", got)
+	}
+}
+
+func TestClineKeysRejectNonClinePassModels(t *testing.T) {
+	cfg := &config.Config{
+		ClineKey: []config.ClineKey{{
+			APIKey: "existing",
+			Models: []config.ClineModel{{
+				Name: "cline-pass/glm-5.2",
+			}},
+		}},
+	}
+	svc := NewService(cfg, nil)
+
+	err := svc.ReplaceClineKeys([]config.ClineKey{{
+		APIKey: "cline-key",
+		Models: []config.ClineModel{{
+			Name: " glm-5.2 ",
+		}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "cline models contains invalid model") {
+		t.Fatalf("ReplaceClineKeys() error = %v, want invalid cline model error", err)
+	}
+	if got := cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" || got[0].Models[0].Name != "cline-pass/glm-5.2" {
+		t.Fatalf("ClineKey after rejected replace = %#v, want unchanged existing entry", got)
+	}
+
+	badFallback := "qwen3.5-plus"
+	err = svc.PatchClineKey(nil, stringPtr("existing"), nil, ClinePatch{VisionFallback: &badFallback})
+	if err == nil || !strings.Contains(err.Error(), "cline vision-fallback-model contains invalid model") {
+		t.Fatalf("PatchClineKey(vision-fallback-model) error = %v, want invalid cline model error", err)
+	}
+	if got := cfg.ClineKey[0].VisionFallbackModel; got != "" {
+		t.Fatalf("ClineKey vision fallback after rejected patch = %q, want unchanged empty value", got)
+	}
+
+	validExcluded := []string{"*", " cline-pass/minimax-m3 "}
+	validFallback := " cline-pass/mimo-v2.5-pro "
+	validModels := []config.ClineModel{{Name: " cline-pass/qwen3.7-max "}}
+	err = svc.PatchClineKey(nil, stringPtr("existing"), nil, ClinePatch{
+		Models:         &validModels,
+		ExcludedModels: &validExcluded,
+		VisionFallback: &validFallback,
+	})
+	if err != nil {
+		t.Fatalf("PatchClineKey(valid models) error = %v, want nil", err)
+	}
+	if got := cfg.ClineKey[0]; got.Models[0].Name != "cline-pass/qwen3.7-max" || got.ExcludedModels[0] != "*" || got.ExcludedModels[1] != "cline-pass/minimax-m3" || got.VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
+		t.Fatalf("ClineKey after valid patch = %#v", got)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
 }


### PR DESCRIPTION
## Summary
- reject ClinePass model IDs in OpenCode Go provider settings
- require ClinePass provider models to use the cline-pass/ prefix
- cover replace and patch management settings paths with tests

## Tests
- rtk go test ./internal/management/settings/providers ./internal/api/handlers/management