### PR TITLE
fix: record final stream usage for cache tokens

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/sjson"
@@ -318,6 +319,8 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+		var lastUsage coreusage.Detail
+		hasUsage := false
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			recorder.AppendResponseChunk(line)
@@ -327,7 +330,8 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			// provider-internal path (e.g. accounts/fireworks/models/glm-5p2) that
 			// must not override the clean request-time model used for logging/cost.
 			if detail, ok := parseOpenAIStreamUsage(line); ok {
-				reporter.publish(execCtx.Context, detail)
+				lastUsage = detail
+				hasUsage = true
 			}
 			if len(line) == 0 {
 				continue
@@ -348,6 +352,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			recorder.RecordResponseError(errScan)
 			reporter.publishFailure(execCtx.Context)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		}
+		if hasUsage {
+			reporter.publish(execCtx.Context, lastUsage)
 		}
 		// Ensure we record the request if no usage chunk was ever seen
 		reporter.ensurePublished(execCtx.Context)

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -232,7 +232,8 @@ func TestOpenAICompatExecutorStreamUsagePreservesRequestModelOverUpstreamEcho(t 
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte(strings.Join([]string{
 			`data: {"id":"chatcmpl-echo","object":"chat.completion.chunk","created":1,"model":"accounts/fireworks/models/glm-5p2","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}`,
-			`data: {"id":"chatcmpl-echo","object":"chat.completion.chunk","created":1,"model":"accounts/fireworks/models/glm-5p2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+			`data: {"id":"chatcmpl-echo","object":"chat.completion.chunk","created":1,"model":"accounts/fireworks/models/glm-5p2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8,"prompt_tokens_details":null}}`,
+			`data: {"id":"chatcmpl-echo","object":"chat.completion.chunk","created":1,"model":"accounts/fireworks/models/glm-5p2","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8,"prompt_tokens_details":{"cached_tokens":10}}}`,
 			`data: [DONE]`,
 			``,
 		}, "\n\n")))
@@ -270,6 +271,9 @@ func TestOpenAICompatExecutorStreamUsagePreservesRequestModelOverUpstreamEcho(t 
 				t.Fatalf("stream usage record model = upstream echo %q; must stay the clean request model", record.Model)
 			}
 			if record.Model == "glm-5.2" {
+				if record.Detail.CachedTokens != 10 {
+					t.Fatalf("stream cached tokens = %d, want 10", record.Detail.CachedTokens)
+				}
 				return
 			}
 		case <-timer:


### PR DESCRIPTION
## Summary
- record the final OpenAI-compatible streaming usage chunk instead of the first one
- preserve cache token stats when upstream sends cached_tokens in a trailing usage chunk
- add regression coverage for first usage without cache followed by final usage with cache

## Verification
- go test ./internal/runtime/executor