### PR TITLE
fix: include final usage in responses streams

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -17,6 +17,7 @@ import (
 	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -321,6 +322,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		var param any
 		var lastUsage coreusage.Detail
 		hasUsage := false
+		var pendingResponsesCompleted []byte
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			recorder.AppendResponseChunk(line)
@@ -332,6 +334,10 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			if detail, ok := parseOpenAIStreamUsage(line); ok {
 				lastUsage = detail
 				hasUsage = true
+				if len(pendingResponsesCompleted) > 0 && isOpenAIStreamUsageOnly(line) {
+					out <- cliproxyexecutor.StreamChunk{Payload: patchResponsesCompletedUsage(pendingResponsesCompleted, lastUsage)}
+					pendingResponsesCompleted = nil
+				}
 			}
 			if len(line) == 0 {
 				continue
@@ -345,8 +351,18 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			// Pass through translator; it yields one or more chunks for the target schema.
 			chunks := sdktranslator.TranslateStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(line), &param)
 			for i := range chunks {
+				if shouldHoldResponsesCompleted(execCtx.SourceFormat, line, []byte(chunks[i])) {
+					pendingResponsesCompleted = []byte(chunks[i])
+					continue
+				}
 				out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
 			}
+		}
+		if len(pendingResponsesCompleted) > 0 {
+			if hasUsage {
+				pendingResponsesCompleted = patchResponsesCompletedUsage(pendingResponsesCompleted, lastUsage)
+			}
+			out <- cliproxyexecutor.StreamChunk{Payload: pendingResponsesCompleted}
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			recorder.RecordResponseError(errScan)
@@ -364,6 +380,89 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		result = opencodeGoRewriteFallbackStreamResult(result, fallback.OriginalModel)
 	}
 	return result, nil
+}
+
+func shouldHoldResponsesCompleted(sourceFormat sdktranslator.Format, line, chunk []byte) bool {
+	return sourceFormat == sdktranslator.FormatOpenAIResponse &&
+		isOpenAIStreamFinish(line) &&
+		!openAIStreamHasCachedTokens(line) &&
+		isResponsesCompletedChunk(chunk)
+}
+
+func isOpenAIStreamFinish(line []byte) bool {
+	payload := jsonPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return false
+	}
+	for _, choice := range gjson.GetBytes(payload, "choices").Array() {
+		if strings.TrimSpace(choice.Get("finish_reason").String()) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func openAIStreamHasCachedTokens(line []byte) bool {
+	payload := jsonPayload(line)
+	return len(payload) > 0 && gjson.GetBytes(payload, "usage.prompt_tokens_details.cached_tokens").Exists()
+}
+
+func isOpenAIStreamUsageOnly(line []byte) bool {
+	payload := jsonPayload(line)
+	if len(payload) == 0 || !gjson.GetBytes(payload, "usage").Exists() {
+		return false
+	}
+	choices := gjson.GetBytes(payload, "choices")
+	return !choices.Exists() || len(choices.Array()) == 0
+}
+
+func isResponsesCompletedChunk(chunk []byte) bool {
+	payload := responsesSSEData(chunk)
+	return len(payload) > 0 && gjson.GetBytes(payload, "type").String() == "response.completed"
+}
+
+func patchResponsesCompletedUsage(chunk []byte, detail coreusage.Detail) []byte {
+	payload := responsesSSEData(chunk)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return chunk
+	}
+	updated, err := sjson.SetBytes(payload, "response.usage.input_tokens", detail.InputTokens)
+	if err != nil {
+		return chunk
+	}
+	cachedTokens := detail.CacheReadTokens
+	if cachedTokens == 0 {
+		cachedTokens = detail.CachedTokens
+	}
+	updated, _ = sjson.SetBytes(updated, "response.usage.input_tokens_details.cached_tokens", cachedTokens)
+	updated, _ = sjson.SetBytes(updated, "response.usage.output_tokens", detail.OutputTokens)
+	if detail.ReasoningTokens > 0 {
+		updated, _ = sjson.SetBytes(updated, "response.usage.output_tokens_details.reasoning_tokens", detail.ReasoningTokens)
+	}
+	totalTokens := detail.TotalTokens
+	if totalTokens == 0 {
+		totalTokens = detail.InputTokens + detail.OutputTokens
+	}
+	updated, _ = sjson.SetBytes(updated, "response.usage.total_tokens", totalTokens)
+
+	lines := strings.Split(string(chunk), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "data:") {
+			lines[i] = "data: " + string(updated)
+			break
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func responsesSSEData(chunk []byte) []byte {
+	for _, line := range bytes.Split(chunk, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if bytes.HasPrefix(trimmed, []byte("data:")) {
+			return bytes.TrimSpace(trimmed[len("data:"):])
+		}
+	}
+	return nil
 }
 
 func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -282,6 +282,76 @@ func TestOpenAICompatExecutorStreamUsagePreservesRequestModelOverUpstreamEcho(t 
 	}
 }
 
+func TestOpenAICompatExecutorResponsesStreamUsesFinalUsageChunk(t *testing.T) {
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 4)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"id":"chatcmpl-cache","object":"chat.completion.chunk","created":1,"model":"provider/cache-model","choices":[{"index":0,"delta":{"role":"assistant","content":"pong"},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl-cache","object":"chat.completion.chunk","created":1,"model":"provider/cache-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":31,"completion_tokens":7,"total_tokens":38,"prompt_tokens_details":null}}`,
+			`data: {"id":"chatcmpl-cache","object":"chat.completion.chunk","created":1,"model":"provider/cache-model","choices":[],"usage":{"prompt_tokens":31,"completion_tokens":7,"total_tokens":38,"prompt_tokens_details":{"cached_tokens":10}}}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{"model":"cache-model","stream":true,"input":[{"role":"user","content":[{"type":"input_text","text":"ping"}]}]}`)
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "cache-model",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		OriginalRequest: payload,
+		SourceFormat:    sdktranslator.FromString("openai-response"),
+		Stream:          true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var response strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		response.Write(chunk.Payload)
+		response.WriteByte('\n')
+	}
+	out := response.String()
+	if got := strings.Count(out, `"type":"response.completed"`); got != 1 {
+		t.Fatalf("response.completed count = %d, want 1:\n%s", got, out)
+	}
+	completed := responseCompletedPayload(out)
+	if len(completed) == 0 {
+		t.Fatalf("missing response.completed payload:\n%s", out)
+	}
+	if got := gjson.GetBytes(completed, "response.usage.input_tokens_details.cached_tokens").Int(); got != 10 {
+		t.Fatalf("client cached_tokens = %d, want 10:\n%s", got, out)
+	}
+
+	timer := time.After(time.Second)
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Model == "cache-model" {
+				if record.Detail.CachedTokens != 10 {
+					t.Fatalf("usage cached tokens = %d, want 10", record.Detail.CachedTokens)
+				}
+				return
+			}
+		case <-timer:
+			t.Fatal("timed out waiting for stream usage record")
+		}
+	}
+}
+
 func TestOpenAICompatExecutorClaudeStreamSkipsEmptyToolNameEndToEnd(t *testing.T) {
 	var gotPath string
 	var gotBody []byte
@@ -364,6 +434,21 @@ func TestOpenAICompatExecutorClaudeStreamSkipsEmptyToolNameEndToEnd(t *testing.T
 	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
 		t.Fatalf("empty-only OpenAI tool_calls finish must map to Claude end_turn:\n%s", out)
 	}
+}
+
+func responseCompletedPayload(stream string) []byte {
+	var event string
+	for _, line := range strings.Split(stream, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "event:") {
+			event = strings.TrimSpace(strings.TrimPrefix(trimmed, "event:"))
+			continue
+		}
+		if event == "response.completed" && strings.HasPrefix(trimmed, "data:") {
+			return []byte(strings.TrimSpace(strings.TrimPrefix(trimmed, "data:")))
+		}
+	}
+	return nil
 }
 
 func TestOpenAICompatExecutorClaudeStreamSkipsMissingToolNameArgumentsEndToEnd(t *testing.T) {


### PR DESCRIPTION
## Summary
- record usage-only final OpenAI stream chunks in Responses stream conversion
- delay response.completed until final usage or DONE when the finish chunk has incomplete usage details
- add regression coverage for cached_tokens in final usage-only chunks

## Tests
- rtk go test ./internal/runtime/executor ./internal/translator/openai/...

## Live evidence
- relay.07230805.xyz chat/message formats already record cache hits
- responses stream DB records cached_tokens, but client response.completed previously emitted cached_tokens=0 before the final usage-only chunk