### PR TITLE
fix: link request log filter facets

### DIFF
--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -76,7 +76,7 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	if err != nil {
 		return nil, err
 	}
-	filters, err := usage.QueryFilters(params.Days)
+	filters, err := usage.QueryFiltersForLogs(params)
 	if err != nil {
 		return nil, err
 	}
@@ -154,6 +154,9 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	}
 	if filters.Channels == nil {
 		filters.Channels = make([]string, 0)
+	}
+	if filters.Statuses == nil {
+		filters.Statuses = make([]string, 0)
 	}
 	if filters.APIKeyNames == nil {
 		filters.APIKeyNames = make(map[string]string)

--- a/internal/usage/request_log_concurrency_test.go
+++ b/internal/usage/request_log_concurrency_test.go
@@ -115,7 +115,7 @@ func TestQueryDistinctErrorIsLogged(t *testing.T) {
 		t.Fatalf("close memory db: %v", err)
 	}
 
-	_, err = queryDistinct(closedDB, "model", time.Now().UTC().Format(time.RFC3339))
+	_, err = queryDistinct(closedDB, "model", LogQueryParams{Days: 7})
 	if err == nil {
 		t.Fatal("expected queryDistinct to error against a closed handle")
 	}

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -165,9 +165,13 @@ func hydrateStreamingFromContent(db *sql.DB, items []LogRow) {
 
 // QueryFilters returns the distinct API keys and models within the time range.
 func QueryFilters(days int) (FilterOptions, error) {
-	if days < 1 {
-		days = 7
-	}
+	return QueryFiltersForLogs(LogQueryParams{Days: days})
+}
+
+// QueryFiltersForLogs returns candidate filter values constrained by the
+// current request-log query. Each facet ignores its own selection so users can
+// widen that facet without resetting every filter first.
+func QueryFiltersForLogs(params LogQueryParams) (FilterOptions, error) {
 	db := getReadDB()
 	if db == nil {
 		// Ensure stable JSON shape: slices => [] (not null), maps => {} (not null).
@@ -176,24 +180,29 @@ func QueryFilters(days int) (FilterOptions, error) {
 			APIKeyNames: make(map[string]string),
 			Models:      make([]string, 0),
 			Channels:    make([]string, 0),
+			Statuses:    make([]string, 0),
 		}, nil
 	}
 
-	cutoff := CutoffStartUTC(days).Format(time.RFC3339)
-
-	keys, keyNames, err := queryDistinctAPIKeys(db, cutoff)
+	params = normalizeLogQueryParams(params)
+	keys, keyNames, err := queryDistinctAPIKeys(db, params.withoutFacet("api_key"))
 	if err != nil {
 		log.Warnf("usage: query distinct api keys failed: %v", err)
 		return FilterOptions{}, err
 	}
-	models, err := queryDistinct(db, "model", cutoff)
+	models, err := queryDistinct(db, "model", params.withoutFacet("model"))
 	if err != nil {
 		log.Warnf("usage: query distinct models failed: %v", err)
 		return FilterOptions{}, err
 	}
-	channels, err := queryDistinct(db, "channel_name", cutoff)
+	channels, err := queryDistinct(db, "channel_name", params.withoutFacet("channel"))
 	if err != nil {
 		log.Warnf("usage: query distinct channels failed: %v", err)
+		return FilterOptions{}, err
+	}
+	statuses, err := queryDistinctStatuses(db, params.withoutFacet("status"))
+	if err != nil {
+		log.Warnf("usage: query distinct statuses failed: %v", err)
 		return FilterOptions{}, err
 	}
 
@@ -202,7 +211,33 @@ func QueryFilters(days int) (FilterOptions, error) {
 		APIKeyNames: keyNames,
 		Models:      models,
 		Channels:    channels,
+		Statuses:    statuses,
 	}, nil
+}
+
+func (params LogQueryParams) withoutFacet(facet string) LogQueryParams {
+	params.Page = 0
+	params.Size = 0
+	switch facet {
+	case "api_key":
+		params.APIKey = ""
+		params.APIKeys = nil
+		params.MatchNoAPIKeys = false
+	case "model":
+		params.Model = ""
+		params.Models = nil
+		params.MatchNoModels = false
+	case "channel":
+		params.AuthIndexes = nil
+		params.ChannelNames = nil
+		params.AuthIndexChannelNames = nil
+		params.MatchNoChannels = false
+	case "status":
+		params.Status = ""
+		params.Statuses = nil
+		params.MatchNoStatuses = false
+	}
+	return params
 }
 
 // QueryStats returns aggregated statistics over the filtered dataset.
@@ -607,9 +642,10 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 	return " WHERE " + strings.Join(conditions, " AND "), args
 }
 
-func queryDistinct(db *sql.DB, column, cutoff string) ([]string, error) {
-	q := fmt.Sprintf("SELECT DISTINCT %s FROM request_logs WHERE timestamp >= ? ORDER BY %s", column, column)
-	rows, err := db.Query(q, cutoff)
+func queryDistinct(db *sql.DB, column string, params LogQueryParams) ([]string, error) {
+	where, args := buildWhereClause(params)
+	q := fmt.Sprintf("SELECT DISTINCT %s FROM request_logs%s ORDER BY %s", column, where, column)
+	rows, err := db.Query(q, args...)
 	if err != nil {
 		log.Warnf("usage: distinct %s query failed: %v", column, err)
 		return nil, fmt.Errorf("usage: distinct %s: %w", column, err)
@@ -630,8 +666,37 @@ func queryDistinct(db *sql.DB, column, cutoff string) ([]string, error) {
 	return result, nil
 }
 
-func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]string, error) {
+func queryDistinctStatuses(db *sql.DB, params LogQueryParams) ([]string, error) {
+	where, args := buildWhereClause(params)
+	rows, err := db.Query("SELECT DISTINCT failed FROM request_logs"+where+" ORDER BY failed", args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: distinct statuses: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]string, 0, 2)
+	for rows.Next() {
+		var failed int
+		if err := rows.Scan(&failed); err != nil {
+			return nil, err
+		}
+		if failed == 0 {
+			result = append(result, "success")
+		} else {
+			result = append(result, "failed")
+		}
+	}
+	return result, rows.Err()
+}
+
+func queryDistinctAPIKeys(db *sql.DB, params LogQueryParams) ([]string, map[string]string, error) {
 	currentByID := currentAPIKeyRowsByID()
+	where, args := buildWhereClause(params)
+	if where == "" {
+		where = " WHERE api_key != ''"
+	} else {
+		where += " AND api_key != ''"
+	}
 	rows, err := db.Query(`
 		SELECT
 			CASE
@@ -642,10 +707,10 @@ func queryDistinctAPIKeys(db *sql.DB, cutoff string) ([]string, map[string]strin
 			MAX(api_key) AS snapshot_key,
 			COALESCE(NULLIF(MAX(api_key_name), ''), '') AS snapshot_name
 		FROM request_logs
-		WHERE timestamp >= ? AND api_key != ''
+		`+where+`
 		GROUP BY logical_selector
 		ORDER BY logical_selector
-	`, cutoff)
+	`, args...)
 	if err != nil {
 		log.Warnf("usage: distinct api_key logical groups query failed: %v", err)
 		return nil, nil, fmt.Errorf("usage: distinct api_key logical groups: %w", err)

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -75,6 +75,7 @@ type FilterOptions struct {
 	APIKeyNames map[string]string `json:"api_key_names"`
 	Models      []string          `json:"models"`
 	Channels    []string          `json:"channels"`
+	Statuses    []string          `json:"statuses"`
 }
 
 // LogStats holds aggregated stats over the filtered result set.

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"math"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -1628,6 +1629,50 @@ func TestQueryAPIKeySelectorsHandleLegacyRowsWithoutAPIKeyID(t *testing.T) {
 	}
 	if dist[0].Requests != 1 || dist[0].Tokens != 30 {
 		t.Fatalf("distribution point = %#v, want one request and 30 tokens", dist[0])
+	}
+}
+
+func TestQueryFiltersForLogsLinksFilterFacets(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	now := time.Now().UTC()
+	InsertLog("sk-a", "A", "glm-5.2", "source-a", "OpenCode", "auth-a", false, now, 1, 1, TokenStats{TotalTokens: 1}, "", "")
+	InsertLog("sk-b", "B", "gpt-4.1", "source-b", "Codex", "auth-b", false, now, 1, 1, TokenStats{TotalTokens: 1}, "", "")
+	InsertLog("sk-c", "C", "glm-5.2", "source-c", "Anthropic", "auth-c", true, now, 1, 1, TokenStats{TotalTokens: 1}, "", "")
+
+	filters, err := QueryFiltersForLogs(LogQueryParams{Days: 7, Models: []string{"glm-5.2"}})
+	if err != nil {
+		t.Fatalf("QueryFiltersForLogs() error = %v", err)
+	}
+	if !slices.Equal(filters.APIKeys, []string{"sk-a", "sk-c"}) {
+		t.Fatalf("filters.APIKeys = %#v, want [sk-a sk-c]", filters.APIKeys)
+	}
+	if !slices.Equal(filters.Channels, []string{"Anthropic", "OpenCode"}) {
+		t.Fatalf("filters.Channels = %#v, want [Anthropic OpenCode]", filters.Channels)
+	}
+	if !slices.Equal(filters.Models, []string{"glm-5.2", "gpt-4.1"}) {
+		t.Fatalf("filters.Models = %#v, want own facet to stay expandable", filters.Models)
+	}
+	if !slices.Equal(filters.Statuses, []string{"success", "failed"}) {
+		t.Fatalf("filters.Statuses = %#v, want [success failed]", filters.Statuses)
+	}
+
+	filters, err = QueryFiltersForLogs(LogQueryParams{
+		Days:    7,
+		APIKeys: []string{"sk-a"},
+		Models:  []string{"glm-5.2"},
+	})
+	if err != nil {
+		t.Fatalf("QueryFiltersForLogs(api key + model) error = %v", err)
+	}
+	if !slices.Equal(filters.APIKeys, []string{"sk-a", "sk-c"}) {
+		t.Fatalf("filters.APIKeys = %#v, want model-compatible keys", filters.APIKeys)
+	}
+	if !slices.Equal(filters.Models, []string{"glm-5.2"}) {
+		t.Fatalf("filters.Models = %#v, want key-compatible models", filters.Models)
+	}
+	if !slices.Equal(filters.Statuses, []string{"success"}) {
+		t.Fatalf("filters.Statuses = %#v, want key-compatible statuses", filters.Statuses)
 	}
 }
 


### PR DESCRIPTION
## Summary
- compute request-log filter candidates from the current query
- keep each facet expandable by excluding only its own selection
- include backend status filter candidates

## Tests
- rtk go test ./internal/usage ./internal/management/usagelogs ./internal/api/handlers/management
- rtk go test ./...