### PR TITLE
feat: return public api key name

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -1397,6 +1397,55 @@ func TestGetPublicUsageLogs_AcceptsPOSTBody(t *testing.T) {
 	}
 }
 
+func TestGetPublicUsageLogs_ReturnsCurrentAPIKeyName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{Key: "sk-test", Name: "Primary"}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	h := &Handler{
+		cfg: &config.Config{},
+	}
+
+	body := []byte(`{"api_key":"sk-test","days":7,"page":1,"size":50}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/v0/management/public/usage/logs",
+		bytes.NewReader(body),
+	)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.UsageLogs().GetPublicUsageLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		APIKeyName string `json:"api_key_name"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload.APIKeyName != "Primary" {
+		t.Fatalf("api_key_name = %q, want Primary", payload.APIKeyName)
+	}
+}
+
 func TestGetPublicUsageLogs_DoesNotReadAPIKeyFromQuery(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -28,6 +28,7 @@ func (s *Service) PublicChartData(apiKey string, days int) (map[string]any, erro
 		"daily_series":       daily,
 		"model_distribution": models,
 		"stats":              stats,
+		"api_key_name":       s.publicAPIKeyName(apiKey),
 	}, nil
 }
 

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -206,7 +206,11 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		return nil, err
 	}
 
+	apiKeyName := s.publicAPIKeyName(input.APIKey)
 	for i := range result.Items {
+		if apiKeyName == "" {
+			apiKeyName = strings.TrimSpace(result.Items[i].APIKeyName)
+		}
 		result.Items[i].Source = ""
 		result.Items[i].AuthIndex = ""
 		result.Items[i].ChannelName = ""
@@ -220,15 +224,24 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 	}
 
 	return map[string]any{
-		"items": result.Items,
-		"total": result.Total,
-		"page":  result.Page,
-		"size":  result.Size,
-		"stats": stats,
+		"items":        result.Items,
+		"total":        result.Total,
+		"page":         result.Page,
+		"size":         result.Size,
+		"stats":        stats,
+		"api_key_name": apiKeyName,
 		"filters": map[string]any{
 			"models": models,
 		},
 	}, nil
+}
+
+func (s *Service) publicAPIKeyName(apiKey string) string {
+	row := apikeysettings.NewService(nil).GetRow(apiKey)
+	if row == nil {
+		return ""
+	}
+	return strings.TrimSpace(row.Name)
 }
 
 func (s *Service) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelMap map[string]string, ambiguousAuthIndexChannelMap map[string][]string) {


### PR DESCRIPTION
## Summary
- include api_key_name in public usage log and chart responses
- resolve the current key nickname from settings with log snapshot fallback
- keep per-log sensitive key fields cleared

## Verification
- rtk go test ./internal/management/usagelogs ./internal/api/handlers/management -run 'TestGetPublicUsageLogs_ReturnsCurrentAPIKeyName|TestGetPublicUsageLogs_AcceptsPOSTBody|TestGetPublicUsageLogs_EmptyDB_DoesNotReturnNullModels'