### PR TITLE
feat: add api key usage heatmap data

### DIFF
--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -23,9 +23,22 @@ func (s *Service) PublicChartData(apiKey string, days int) (map[string]any, erro
 	if err != nil {
 		return nil, err
 	}
+	stats.TotalSessions, err = usage.QuerySessionCount(usage.LogQueryParams{APIKey: apiKey, Days: days})
+	if err != nil {
+		return nil, err
+	}
+
+	heatmap, err := usage.QueryDailyHeatmapSeries(apiKey, 365)
+	if err != nil {
+		return nil, err
+	}
+	if heatmap == nil {
+		heatmap = []usage.DailyHeatmapPoint{}
+	}
 
 	return map[string]any{
 		"daily_series":       daily,
+		"heatmap_series":     heatmap,
 		"model_distribution": models,
 		"stats":              stats,
 		"api_key_name":       s.publicAPIKeyName(apiKey),

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -14,6 +15,15 @@ type DailySeriesPoint struct {
 	FailedReq    int    `json:"failed_requests"`
 	InputTokens  int    `json:"input_tokens"`
 	OutputTokens int    `json:"output_tokens"`
+}
+
+// DailyHeatmapPoint holds one day of usage for the calendar heatmap.
+type DailyHeatmapPoint struct {
+	Date     string  `json:"date"`
+	Requests int64   `json:"requests"`
+	Sessions int64   `json:"sessions"`
+	Tokens   int64   `json:"tokens"`
+	Cost     float64 `json:"cost"`
 }
 
 // ModelDistributionPoint holds aggregated usage data for a single model.
@@ -61,6 +71,184 @@ func QueryDailySeries(apiKey string, days int) ([]DailySeriesPoint, error) {
 		result = append(result, p)
 	}
 	return result, rows.Err()
+}
+
+// QueryDailyHeatmapSeries returns sparse daily usage for the calendar heatmap.
+func QueryDailyHeatmapSeries(apiKey string, days int) ([]DailyHeatmapPoint, error) {
+	db := getReadDB()
+	if db == nil {
+		return nil, nil
+	}
+	if days < 1 {
+		days = 365
+	}
+
+	params := LogQueryParams{APIKey: apiKey, Days: days}
+	where, args := buildWhereClause(params)
+
+	q := `SELECT date(timestamp, 'localtime') as d,
+	             COUNT(*) as reqs,
+	             COALESCE(SUM(total_tokens),0),
+	             COALESCE(SUM(cost),0)
+	      FROM request_logs` + where + `
+	      GROUP BY d ORDER BY d`
+
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: daily heatmap query: %w", err)
+	}
+	defer rows.Close()
+
+	sessionsByDate, err := querySessionCountsByDate(params)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []DailyHeatmapPoint
+	for rows.Next() {
+		var p DailyHeatmapPoint
+		if err := rows.Scan(&p.Date, &p.Requests, &p.Tokens, &p.Cost); err != nil {
+			return nil, fmt.Errorf("usage: daily heatmap scan: %w", err)
+		}
+		p.Sessions = sessionsByDate[p.Date]
+		result = append(result, p)
+	}
+	return result, rows.Err()
+}
+
+// QuerySessionCount returns the distinct count of session-like request detail IDs.
+func QuerySessionCount(params LogQueryParams) (int64, error) {
+	seenByDate, err := querySessionSetsByDate(params)
+	if err != nil {
+		return 0, err
+	}
+	seen := make(map[string]struct{})
+	for _, sessions := range seenByDate {
+		for sessionID := range sessions {
+			seen[sessionID] = struct{}{}
+		}
+	}
+	return int64(len(seen)), nil
+}
+
+func querySessionCountsByDate(params LogQueryParams) (map[string]int64, error) {
+	seenByDate, err := querySessionSetsByDate(params)
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int64, len(seenByDate))
+	for dateKey, sessions := range seenByDate {
+		counts[dateKey] = int64(len(sessions))
+	}
+	return counts, nil
+}
+
+func querySessionSetsByDate(params LogQueryParams) (map[string]map[string]struct{}, error) {
+	db := getReadDB()
+	if db == nil {
+		return map[string]map[string]struct{}{}, nil
+	}
+	if params.Days < 1 {
+		params.Days = 7
+	}
+
+	where, args := buildWhereClause(params)
+	rows, err := db.Query(
+		`SELECT date(logs.timestamp, 'localtime'), content.compression, content.detail_content
+		   FROM (SELECT id, timestamp FROM request_logs`+where+`) logs
+		   JOIN request_log_content content ON content.log_id = logs.id
+		  WHERE length(content.detail_content) > 0`,
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("usage: session details query: %w", err)
+	}
+	defer rows.Close()
+
+	seenByDate := make(map[string]map[string]struct{})
+	for rows.Next() {
+		var dateKey, compression string
+		var compressed []byte
+		if err := rows.Scan(&dateKey, &compression, &compressed); err != nil {
+			return nil, fmt.Errorf("usage: session details scan: %w", err)
+		}
+		detail, err := decompressLogContent(compression, compressed)
+		if err != nil {
+			return nil, err
+		}
+		sessionID := extractSessionIDFromDetails(detail)
+		if sessionID == "" {
+			continue
+		}
+		if seenByDate[dateKey] == nil {
+			seenByDate[dateKey] = make(map[string]struct{})
+		}
+		seenByDate[dateKey][sessionID] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return seenByDate, nil
+}
+
+func extractSessionIDFromDetails(detail string) string {
+	if strings.TrimSpace(detail) == "" {
+		return ""
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(detail), &payload); err != nil {
+		return ""
+	}
+	bestRank := 99
+	bestValue := ""
+	var walk func(any, string)
+	walk = func(value any, key string) {
+		rank := sessionDetailKeyRank(key)
+		if rank < bestRank {
+			if text := sessionDetailString(value); text != "" {
+				bestRank = rank
+				bestValue = text
+			}
+		}
+		switch typed := value.(type) {
+		case map[string]any:
+			for childKey, childValue := range typed {
+				walk(childValue, childKey)
+			}
+		case []any:
+			for _, childValue := range typed {
+				walk(childValue, "")
+			}
+		}
+	}
+	walk(payload, "")
+	return bestValue
+}
+
+func sessionDetailKeyRank(key string) int {
+	normalized := strings.NewReplacer("-", "_", " ", "_").Replace(strings.ToLower(strings.TrimSpace(key)))
+	switch normalized {
+	case "session_id", "sessionid":
+		return 0
+	case "conversation_id", "conversationid":
+		return 1
+	default:
+		return 99
+	}
+}
+
+func sessionDetailString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []any:
+		for _, item := range typed {
+			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+				return strings.TrimSpace(text)
+			}
+		}
+	}
+	return ""
 }
 
 // QueryModelDistribution returns request count and token usage grouped by model for a given API key.

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -80,11 +80,12 @@ type FilterOptions struct {
 
 // LogStats holds aggregated stats over the filtered result set.
 type LogStats struct {
-	Total       int64   `json:"total"`
-	SuccessRate float64 `json:"success_rate"`
-	TotalTokens int64   `json:"total_tokens"`
-	TotalCost   float64 `json:"total_cost"`
-	CacheRate   float64 `json:"cache_rate"`
+	Total         int64   `json:"total"`
+	SuccessRate   float64 `json:"success_rate"`
+	TotalTokens   int64   `json:"total_tokens"`
+	TotalSessions int64   `json:"total_sessions"`
+	TotalCost     float64 `json:"total_cost"`
+	CacheRate     float64 `json:"cache_rate"`
 }
 
 const cacheRateEffectiveInputSQL = "CASE WHEN cached_tokens > input_tokens THEN input_tokens + cached_tokens ELSE input_tokens END"

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1928,6 +1928,58 @@ func TestClearRequestLogsClearsBodiesButKeepsRequestRows(t *testing.T) {
 	}
 }
 
+func TestQueryStatsAndHeatmapCountSessionsFromDetails(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	today := time.Now().UTC()
+	yesterday := today.AddDate(0, 0, -1)
+	InsertLogWithDetails("sk-heatmap", "Heatmap", "gpt-5.4", "codex", "Codex", "auth-1", false, today, 10, 5, TokenStats{
+		InputTokens: 10, OutputTokens: 20, TotalTokens: 30,
+	}, "{}", "{}", `{"session_id":"session-a","request_id":"req-a1"}`)
+	InsertLogWithDetails("sk-heatmap", "Heatmap", "gpt-5.4", "codex", "Codex", "auth-1", false, today.Add(time.Minute), 10, 5, TokenStats{
+		InputTokens: 20, OutputTokens: 30, TotalTokens: 50,
+	}, "{}", "{}", `{"session_id":"session-a","request_id":"req-a2"}`)
+	InsertLogWithDetails("sk-heatmap", "Heatmap", "gpt-5.4", "codex", "Codex", "auth-1", false, yesterday, 10, 5, TokenStats{
+		InputTokens: 1, OutputTokens: 2, TotalTokens: 3,
+	}, "{}", "{}", `{"conversation_id":"session-b"}`)
+
+	stats, err := QueryStats(LogQueryParams{APIKey: "sk-heatmap", Days: 7})
+	if err != nil {
+		t.Fatalf("QueryStats() error = %v", err)
+	}
+	if stats.Total != 3 || stats.TotalTokens != 83 {
+		t.Fatalf("stats = %#v, want total=3 total_tokens=83", stats)
+	}
+	sessionCount, err := QuerySessionCount(LogQueryParams{APIKey: "sk-heatmap", Days: 7})
+	if err != nil {
+		t.Fatalf("QuerySessionCount() error = %v", err)
+	}
+	if sessionCount != 2 {
+		t.Fatalf("QuerySessionCount() = %d, want 2", sessionCount)
+	}
+
+	points, err := QueryDailyHeatmapSeries("sk-heatmap", 7)
+	if err != nil {
+		t.Fatalf("QueryDailyHeatmapSeries() error = %v", err)
+	}
+	byDate := make(map[string]DailyHeatmapPoint, len(points))
+	for _, point := range points {
+		byDate[point.Date] = point
+	}
+	todayPoint := byDate[LocalDayKeyAt(today)]
+	if todayPoint.Requests != 2 || todayPoint.Tokens != 80 || todayPoint.Sessions != 1 {
+		t.Fatalf("today heatmap point = %#v, want requests=2 tokens=80 sessions=1", todayPoint)
+	}
+	yesterdayPoint := byDate[LocalDayKeyAt(yesterday)]
+	if yesterdayPoint.Requests != 1 || yesterdayPoint.Tokens != 3 || yesterdayPoint.Sessions != 1 {
+		t.Fatalf("yesterday heatmap point = %#v, want requests=1 tokens=3 sessions=1", yesterdayPoint)
+	}
+}
+
 func TestClearRequestLogsAllowsNewContentAfterSizeCapCleanup(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,


### PR DESCRIPTION
## Summary
- add public heatmap series for API key usage charts
- add total session counting from session_id / conversation_id details
- cover session aggregation with usage DB test

## Verification
- rtk go test ./internal/usage ./internal/management/usagelogs