### PR TITLE
feat: add blue-green deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,18 +40,18 @@ jobs:
               -X 'github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo.BuildDate=${BUILD_DATE}'" \
             -o cli-proxy-api-new ./cmd/server/
 
-      - name: Upload binary (as temp name)
+      - name: Upload binary and deploy script
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SERVER_HOST }}
           port: ${{ secrets.SERVER_PORT }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "cli-proxy-api-new"
+          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh"
           target: "/opt/clirelay2/"
           overwrite: true
 
-      - name: Stop, swap, and restart
+      - name: Blue-green deploy
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -59,63 +59,4 @@ jobs:
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            SERVICE_BIN="$(systemctl show -p ExecStart --value clirelay2 | sed -nE 's/.*path=([^ ;]+).*/\1/p' | head -n1)"
-            if [ -z "$SERVICE_BIN" ]; then
-              if [ -x /opt/clirelay2/clirelay2 ]; then
-                SERVICE_BIN="/opt/clirelay2/clirelay2"
-              else
-                SERVICE_BIN="/opt/clirelay2/cli-proxy-api"
-              fi
-            fi
-            SERVICE_DIR="$(dirname "$SERVICE_BIN")"
-            SERVICE_NAME="$(basename "$SERVICE_BIN")"
-            TEMP_BIN="/opt/clirelay2/cli-proxy-api-new"
-            if [ ! -f "$TEMP_BIN" ]; then
-              echo "uploaded temp binary not found: $TEMP_BIN"
-              exit 1
-            fi
-            cd "$SERVICE_DIR"
-            echo "Service binary: $SERVICE_BIN"
-            # Stop via systemd
-            systemctl stop clirelay2 2>/dev/null || true
-            sleep 1
-            # Kill any stray processes
-            PIDS=$(pgrep -f "^${SERVICE_BIN}$" 2>/dev/null) || true
-            if [ -n "$PIDS" ]; then
-              kill $PIDS 2>/dev/null || true
-              sleep 2
-            fi
-            # Backup current binary
-            if [ -f "$SERVICE_NAME" ]; then
-              cp "$SERVICE_NAME" "${SERVICE_NAME}.bak.$(date +%Y%m%d_%H%M%S)"
-            fi
-            # Swap in new binary
-            mv "$TEMP_BIN" "$SERVICE_NAME"
-            chmod +x "$SERVICE_NAME"
-            # Clean up old backups, keep last 3
-            ls -1t "${SERVICE_NAME}.bak."* 2>/dev/null | tail -n +4 | xargs -r rm -f
-            # Ensure Nginx can accept large request bodies (Codex /v1/responses payload can be large).
-            if [ -d /etc/nginx ]; then
-              BODY_SIZE_CONF="/etc/nginx/conf.d/90-clirelay-body-size.conf"
-              mkdir -p "$(dirname "$BODY_SIZE_CONF")"
-              cat > "$BODY_SIZE_CONF" <<'EOF'
-            # Managed by CliRelay GitHub Actions deploy workflow
-            client_max_body_size 2000m;
-            EOF
-              if command -v nginx >/dev/null 2>&1; then
-                nginx -t
-                nginx -s reload || systemctl reload nginx || systemctl restart nginx
-              else
-                systemctl reload nginx || systemctl restart nginx
-              fi
-            else
-              echo "/etc/nginx not found; skip client_max_body_size tuning"
-            fi
-            # Start service
-            systemctl start clirelay2
-            sleep 3
-            systemctl is-active clirelay2
-            if ! grep -a -q "${{ github.sha }}" "$SERVICE_BIN"; then
-              echo "deployed binary does not contain expected commit SHA"
-              exit 1
-            fi
+            COMMIT_SHA="${{ github.sha }}" bash /opt/clirelay2/scripts/deploy-blue-green.sh

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -16,8 +17,9 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 	content := string(data)
 
 	for _, want := range []string{
-		`Upload binary (as temp name)`,
-		`source: "cli-proxy-api-new"`,
+		`Upload binary and deploy script`,
+		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh"`,
+		`scripts/deploy-blue-green.sh`,
 		`target: "/opt/clirelay2/"`,
 	} {
 		if !strings.Contains(content, want) {
@@ -35,6 +37,57 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 	} {
 		if strings.Contains(content, forbidden) {
 			t.Fatalf("backend deploy workflow must not publish frontend panel assets, found %q", forbidden)
+		}
+	}
+}
+
+func TestDeployWorkflowUsesBlueGreenDeployment(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/deploy.yml")
+	if err != nil {
+		t.Fatalf("read deploy workflow: %v", err)
+	}
+	content := string(data)
+
+	for _, want := range []string{
+		`Blue-green deploy`,
+		`COMMIT_SHA="${{ github.sha }}" bash /opt/clirelay2/scripts/deploy-blue-green.sh`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("deploy workflow missing blue-green marker %q", want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		`systemctl stop clirelay2`,
+		`systemctl start clirelay2`,
+		`Stop, swap, and restart`,
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("deploy workflow still has outage-prone restart marker %q", forbidden)
+		}
+	}
+}
+
+func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
+	cmd := exec.Command("bash", "-n", "scripts/deploy-blue-green.sh")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("deploy script syntax failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile("scripts/deploy-blue-green.sh")
+	if err != nil {
+		t.Fatalf("read deploy script: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`/healthz`,
+		`CLIRELAY_PORT=`,
+		`.active-port`,
+		`nginx -t`,
+		`DRAIN_SECONDS`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("deploy script missing guard %q", want)
 		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -194,6 +194,23 @@ func TestLoadConfigAllowsAuthPathEnvOverride(t *testing.T) {
 	}
 }
 
+func TestLoadConfigAllowsPortEnvOverride(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8318\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(EnvPort, "8319")
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if cfg.Port != 8319 {
+		t.Fatalf("Port = %d, want CLIRELAY_PORT override", cfg.Port)
+	}
+}
+
 func TestLoadConfigDefaultsAutoUpdateEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -12,4 +12,8 @@ const (
 
 	// EnvAuthPath overrides auth-dir with the path visible inside the running container/process.
 	EnvAuthPath = "AUTH_PATH"
+	// EnvPort overrides the configured listen port for blue-green deploy slots.
+	EnvPort = "CLIRELAY_PORT"
+	// EnvLegacyPort keeps the existing Docker installer PORT environment useful.
+	EnvLegacyPort = "PORT"
 )

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -220,5 +221,13 @@ func (cfg *Config) ApplyEnvOverrides() {
 	}
 	if authPath := strings.TrimSpace(os.Getenv(EnvAuthPath)); authPath != "" {
 		cfg.AuthDir = authPath
+	}
+	for _, key := range []string{EnvPort, EnvLegacyPort} {
+		if rawPort := strings.TrimSpace(os.Getenv(key)); rawPort != "" {
+			if port, err := strconv.Atoi(rawPort); err == nil && port > 0 {
+				cfg.Port = port
+			}
+			return
+		}
 	}
 }

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
+BASE_DIR="${BASE_DIR:-/opt/clirelay2}"
+TEMP_BIN="${TEMP_BIN:-${BASE_DIR}/cli-proxy-api-new}"
+DOMAIN="${DOMAIN:-relay.07230805.xyz}"
+PORT_A="${PORT_A:-8318}"
+PORT_B="${PORT_B:-8319}"
+DRAIN_SECONDS="${DRAIN_SECONDS:-35}"
+COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+ACTIVE_PORT_FILE="${BASE_DIR}/.active-port"
+
+fail() {
+	echo "$*" >&2
+	exit 1
+}
+
+read_service_property() {
+	systemctl show -p "$1" --value "$SERVICE_NAME" 2>/dev/null || true
+}
+
+service_exec="$(read_service_property ExecStart)"
+service_bin="$(printf '%s\n' "$service_exec" | sed -nE 's/.*path=([^ ;]+).*/\1/p' | head -n1)"
+if [ -z "$service_bin" ]; then
+	if [ -x "${BASE_DIR}/clirelay2" ]; then
+		service_bin="${BASE_DIR}/clirelay2"
+	else
+		service_bin="${BASE_DIR}/cli-proxy-api"
+	fi
+fi
+service_dir="$(dirname "$service_bin")"
+config_path="$(printf '%s\n' "$service_exec" | sed -nE 's/.* -config[= ]([^ ;]+).*/\1/p' | head -n1)"
+config_path="${config_path:-${service_dir}/config.yaml}"
+
+[ -f "$TEMP_BIN" ] || fail "uploaded temp binary not found: $TEMP_BIN"
+[ -f "$config_path" ] || fail "config file not found: $config_path"
+
+config_port="$(awk '/^port:[[:space:]]*[0-9]+/ {print $2; exit}' "$config_path" 2>/dev/null || true)"
+active_port="$(cat "$ACTIVE_PORT_FILE" 2>/dev/null || true)"
+active_port="${active_port:-${config_port:-$PORT_A}}"
+# Alternate between two local ports so nginx can cut over only after the new slot is healthy.
+case "$active_port" in
+	"$PORT_A") next_port="$PORT_B" ;;
+	*) next_port="$PORT_A" ;;
+esac
+
+next_unit="${SERVICE_NAME}-${next_port}"
+next_bin="${BASE_DIR}/${next_unit}"
+cutover_done=0
+# If anything fails before nginx is switched, stop the candidate slot and keep the old service live.
+cleanup_failed_deploy() {
+	status=$?
+	if [ "$status" -ne 0 ] && [ "$cutover_done" -ne 1 ]; then
+		systemctl disable --now "$next_unit" >/dev/null 2>&1 || true
+	fi
+	exit "$status"
+}
+trap cleanup_failed_deploy EXIT
+
+install -m 0755 "$TEMP_BIN" "$next_bin"
+rm -f "$TEMP_BIN"
+
+if ! grep -a -q "$COMMIT_SHA" "$next_bin"; then
+	fail "uploaded binary does not contain expected commit SHA"
+fi
+
+working_dir="$(read_service_property WorkingDirectory)"
+working_dir="${working_dir:-$service_dir}"
+environment="$(read_service_property Environment)"
+user="$(read_service_property User)"
+group="$(read_service_property Group)"
+
+unit_file="/etc/systemd/system/${next_unit}.service"
+{
+	echo "[Unit]"
+	echo "Description=CliRelay blue-green slot ${next_port}"
+	echo "After=network.target"
+	echo
+	echo "[Service]"
+	echo "Type=simple"
+	echo "WorkingDirectory=${working_dir}"
+	[ -n "$user" ] && echo "User=${user}"
+	[ -n "$group" ] && echo "Group=${group}"
+	[ -n "$environment" ] && echo "Environment=${environment}"
+	# Keep the canonical config path; only override the listen port for this deploy slot.
+	echo "Environment=CLIRELAY_PORT=${next_port} PORT=${next_port}"
+	echo "ExecStart=${next_bin} -config ${config_path}"
+	echo "Restart=always"
+	echo "RestartSec=3"
+	echo "KillSignal=SIGTERM"
+	echo "TimeoutStopSec=45"
+	echo
+	echo "[Install]"
+	echo "WantedBy=multi-user.target"
+} > "$unit_file"
+
+systemctl daemon-reload
+systemctl enable --now "$next_unit"
+
+http_ok() {
+	if command -v curl >/dev/null 2>&1; then
+		curl -fsS "$1" >/dev/null 2>&1
+	else
+		wget -q -O /dev/null "$1" >/dev/null 2>&1
+	fi
+}
+
+health_url="http://127.0.0.1:${next_port}/healthz"
+for _ in $(seq 1 30); do
+	if http_ok "$health_url"; then
+		break
+	fi
+	sleep 1
+done
+http_ok "$health_url" || fail "new slot failed health check: $health_url"
+
+ensure_body_size_conf() {
+	[ -d /etc/nginx ] || return 0
+	body_size_conf="/etc/nginx/conf.d/90-clirelay-body-size.conf"
+	mkdir -p "$(dirname "$body_size_conf")"
+	cat > "$body_size_conf" <<'EOF'
+# Managed by CliRelay GitHub Actions deploy workflow
+client_max_body_size 2000m;
+EOF
+}
+
+find_nginx_conf() {
+	if [ -n "${NGINX_CONF:-}" ]; then
+		echo "$NGINX_CONF"
+		return
+	fi
+	grep -Rsl "$DOMAIN" /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | head -n1
+}
+
+nginx_conf="$(find_nginx_conf)"
+[ -n "$nginx_conf" ] || fail "nginx config for ${DOMAIN} not found; set NGINX_CONF"
+[ -f "$nginx_conf" ] || fail "nginx config not found: $nginx_conf"
+
+ensure_body_size_conf
+backup="${nginx_conf}.bak.$(date +%Y%m%d_%H%M%S)"
+cp "$nginx_conf" "$backup"
+if ! grep -Eq ":${active_port}\\b" "$nginx_conf"; then
+	fail "nginx config $nginx_conf does not reference active port ${active_port}"
+fi
+# Replace only the active backend port, leaving the existing nginx layout untouched.
+perl -0pi -e "s/:${active_port}\\b/:${next_port}/g" "$nginx_conf"
+
+if ! nginx -t; then
+	cp "$backup" "$nginx_conf"
+	nginx -t || true
+	fail "nginx config test failed; reverted $nginx_conf"
+fi
+nginx -s reload || systemctl reload nginx
+
+echo "$next_port" > "$ACTIVE_PORT_FILE"
+cutover_done=1
+echo "CliRelay is serving on ${next_unit} (${next_port}); draining ${active_port} for ${DRAIN_SECONDS}s"
+sleep "$DRAIN_SECONDS"
+
+for old_unit in "$SERVICE_NAME" "${SERVICE_NAME}-${active_port}"; do
+	if [ "$old_unit" != "$next_unit" ]; then
+		systemctl disable --now "$old_unit" 2>/dev/null || systemctl stop "$old_unit" 2>/dev/null || true
+	fi
+done
+
+find "$BASE_DIR" -maxdepth 1 -type f -name "${SERVICE_NAME}-*" ! -name "$(basename "$next_bin")" -mtime +7 -delete 2>/dev/null || true
+echo "Deploy complete: ${next_unit}"


### PR DESCRIPTION
## Summary
- switch the dev deploy workflow to upload a blue-green deploy script with the backend binary
- add a two-slot systemd/nginx cutover script for relay.07230805.xyz
- allow CLIRELAY_PORT/PORT to override the configured listen port for deploy slots
- add workflow/config guard tests

## Tests
- bash -n scripts/deploy-blue-green.sh
- go test ./internal/config . -run 'TestDeployWorkflow|TestBlueGreen|TestLoadConfigAllowsPortEnvOverride|TestLoadConfigAllowsAuthPathEnvOverride'\n- TZ=UTC go test ./...\n\nNote: plain local go test ./... in Asia/Shanghai still hits the existing usage heatmap date-boundary failure; UTC matches GitHub Actions runner behavior.