### PR TITLE
fix: speed up API key usage lookups

### DIFF
--- a/internal/usage/api_key_identity.go
+++ b/internal/usage/api_key_identity.go
@@ -78,10 +78,15 @@ func uniqueRequestLogAPIKeyIDByKeyFromDB(db *sql.DB) map[string]string {
 	}
 
 	rows, err := db.Query(`
-		SELECT api_key, api_key_id
-		FROM request_logs
-		WHERE trim(coalesce(api_key, '')) <> ''
-		  AND trim(coalesce(api_key_id, '')) <> ''
+		SELECT existing.api_key, existing.api_key_id
+		FROM request_logs AS existing
+		JOIN (
+			SELECT DISTINCT api_key
+			FROM request_logs
+			WHERE api_key_id = ''
+			  AND api_key != ''
+		) AS missing ON missing.api_key = existing.api_key
+		WHERE existing.api_key_id != ''
 	`)
 	if err != nil {
 		log.Warnf("usage: query unique request_log api_key_id by raw key failed: %v", err)
@@ -126,24 +131,31 @@ func backfillRequestLogAPIKeyIDs(db *sql.DB) {
 	if db == nil {
 		return
 	}
+	if !hasRequestLogsMissingAPIKeyID(db) {
+		return
+	}
 
 	result, err := db.Exec(`
 		UPDATE request_logs
 		SET api_key_id = (
 			SELECT id FROM api_keys WHERE api_keys.key = request_logs.api_key
 		)
-		WHERE trim(coalesce(api_key_id, '')) = ''
+		WHERE api_key_id = ''
+		  AND api_key != ''
 		  AND EXISTS (
 			SELECT 1
 			FROM api_keys
 			WHERE api_keys.key = request_logs.api_key
-			  AND trim(coalesce(api_keys.id, '')) <> ''
+			  AND api_keys.id != ''
 		  )
 	`)
 	if err != nil {
 		log.Warnf("usage: backfill request_logs api_key_id by key failed: %v", err)
 	} else if rows, rowsErr := result.RowsAffected(); rowsErr == nil && rows > 0 {
 		log.Infof("usage: backfilled api_key_id for %d request_logs by exact key match", rows)
+	}
+	if !hasRequestLogsMissingAPIKeyID(db) {
+		return
 	}
 
 	nameToID := uniqueAPIKeyIDByNameFromDB(db)
@@ -154,9 +166,9 @@ func backfillRequestLogAPIKeyIDs(db *sql.DB) {
 		result, err := db.Exec(`
 			UPDATE request_logs
 			SET api_key_id = ?
-			WHERE trim(coalesce(api_key_id, '')) = ''
+			WHERE api_key_id = ''
 			  AND lower(trim(coalesce(api_key_name, ''))) = ?
-			  AND trim(coalesce(api_key, '')) <> ''
+			  AND api_key != ''
 		`, id, lowerName)
 		if err != nil {
 			log.Warnf("usage: backfill request_logs api_key_id by name failed for %q: %v", lowerName, err)
@@ -165,6 +177,9 @@ func backfillRequestLogAPIKeyIDs(db *sql.DB) {
 		if rows, rowsErr := result.RowsAffected(); rowsErr == nil && rows > 0 {
 			log.Infof("usage: backfilled api_key_id for %d request_logs by unique api_key_name=%q", rows, lowerName)
 		}
+	}
+	if !hasRequestLogsMissingAPIKeyID(db) {
+		return
 	}
 
 	keyToID := uniqueRequestLogAPIKeyIDByKeyFromDB(db)
@@ -175,8 +190,8 @@ func backfillRequestLogAPIKeyIDs(db *sql.DB) {
 		result, err := db.Exec(`
 			UPDATE request_logs
 			SET api_key_id = ?
-			WHERE trim(coalesce(api_key_id, '')) = ''
-			  AND trim(coalesce(api_key, '')) = ?
+			WHERE api_key_id = ''
+			  AND api_key = ?
 		`, id, rawKey)
 		if err != nil {
 			log.Warnf("usage: backfill request_logs api_key_id by historical raw key failed for %q: %v", rawKey, err)
@@ -186,4 +201,17 @@ func backfillRequestLogAPIKeyIDs(db *sql.DB) {
 			log.Infof("usage: backfilled api_key_id for %d request_logs by historical raw api_key=%q", rows, rawKey)
 		}
 	}
+}
+
+func hasRequestLogsMissingAPIKeyID(db *sql.DB) bool {
+	var exists int
+	err := db.QueryRow("SELECT 1 FROM request_logs WHERE api_key_id = '' AND api_key != '' LIMIT 1").Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	if err != nil {
+		log.Warnf("usage: query request_logs missing api_key_id failed: %v", err)
+		return false
+	}
+	return exists == 1
 }

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -159,6 +159,7 @@ CREATE TABLE IF NOT EXISTS request_log_content (
 
 CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON request_logs(timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_logs_api_key ON request_logs(api_key);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key_timestamp ON request_logs(api_key, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_logs_model ON request_logs(model);
 CREATE INDEX IF NOT EXISTS idx_logs_failed ON request_logs(failed);
 CREATE INDEX IF NOT EXISTS idx_logs_auth_index ON request_logs(auth_index);
@@ -273,6 +274,17 @@ func migrateAPIKeyIDColumn(db *sql.DB) {
 	}
 	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_logs_api_key_id ON request_logs(api_key_id)"); err != nil {
 		log.Warnf("usage: create idx_logs_api_key_id: %v", err)
+	}
+}
+
+func ensureRequestLogLookupIndexes(db *sql.DB) {
+	for _, stmt := range []string{
+		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_timestamp ON request_logs(api_key, timestamp DESC)",
+		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_timestamp ON request_logs(api_key_id, timestamp DESC)",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			log.Warnf("usage: create request log lookup index: %v", err)
+		}
 	}
 }
 
@@ -456,6 +468,8 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	migrateVisionFallbackModelColumn(db)
 	log.Debugf("usage: running api_key_id column migration")
 	migrateAPIKeyIDColumn(db)
+	log.Debugf("usage: ensuring request log lookup indexes")
+	ensureRequestLogLookupIndexes(db)
 	log.Debugf("usage: running auth_subject_id column migration")
 	migrateAuthSubjectIDColumns(db)
 	log.Debugf("usage: running first_token_ms column migration")

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -672,6 +672,38 @@ func TestInitDBMigratesFirstTokenAndStreamingColumns(t *testing.T) {
 	}
 }
 
+func TestInitDBEnsuresRequestLogLookupIndexes(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	rows, err := getDB().Query("PRAGMA index_list(request_logs)")
+	if err != nil {
+		t.Fatalf("PRAGMA index_list(request_logs): %v", err)
+	}
+	defer rows.Close()
+
+	found := map[string]bool{}
+	for rows.Next() {
+		var seq int
+		var name string
+		var unique int
+		var origin string
+		var partial int
+		if err := rows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			t.Fatalf("scan index_list: %v", err)
+		}
+		found[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate index_list: %v", err)
+	}
+
+	for _, name := range []string{"idx_logs_api_key_timestamp", "idx_logs_api_key_id_timestamp"} {
+		if !found[name] {
+			t.Fatalf("expected %s to exist after InitDB", name)
+		}
+	}
+}
+
 func TestInitDBMigratesAuthSubjectColumnsAndCycleTable(t *testing.T) {
 	CloseDB()
 	dbPath := filepath.Join(t.TempDir(), "usage.db")
@@ -1587,6 +1619,33 @@ func TestBackfillRequestLogAPIKeyIDsUsesHistoricalRawKeyIdentity(t *testing.T) {
 	}
 }
 
+func TestUniqueRequestLogAPIKeyIDByKeyOnlyChecksMissingRawKeys(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	db := getDB()
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentity("sk-missing", "missing-id", "", "gpt-test", "source", "channel", "auth-1", false, now, 1, 1, TokenStats{TotalTokens: 1}, "", "", "")
+	InsertLogWithDetailsIdentity("sk-unrelated", "unrelated-id", "", "gpt-test", "source", "channel", "auth-1", false, now, 1, 1, TokenStats{TotalTokens: 1}, "", "", "")
+	if _, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, api_key_id, api_key_name, model, source, channel_name, auth_index,
+			 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		now.Add(time.Second).Format(time.RFC3339Nano), "sk-missing", "", "", "gpt-test", "source", "channel", "auth-1",
+		0, 123, 45, 10, 20, 0, 0, 30, 0,
+	); err != nil {
+		t.Fatalf("insert missing api_key_id request_log: %v", err)
+	}
+
+	got := uniqueRequestLogAPIKeyIDByKeyFromDB(db)
+	if got["sk-missing"] != "missing-id" {
+		t.Fatalf("sk-missing id = %q, want missing-id", got["sk-missing"])
+	}
+	if _, ok := got["sk-unrelated"]; ok {
+		t.Fatalf("sk-unrelated should not be queried when it has no missing api_key_id rows")
+	}
+}
+
 func TestQueryAPIKeySelectorsHandleLegacyRowsWithoutAPIKeyID(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 
@@ -1935,7 +1994,7 @@ func TestQueryStatsAndHeatmapCountSessionsFromDetails(t *testing.T) {
 		CleanupIntervalMinutes: 1440,
 	})
 
-	today := time.Now().UTC()
+	today := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
 	yesterday := today.AddDate(0, 0, -1)
 	InsertLogWithDetails("sk-heatmap", "Heatmap", "gpt-5.4", "codex", "Codex", "auth-1", false, today, 10, 5, TokenStats{
 		InputTokens: 10, OutputTokens: 20, TotalTokens: 30,


### PR DESCRIPTION
## Summary
- add composite request_logs indexes for API key + timestamp lookups
- skip expensive API key backfill scans when there are no missing request_log api_key_id rows
- keep request log identity repair scoped to raw keys that still need backfill

## Tests
- rtk go test ./internal/usage ./internal/management/usagelogs ./internal/api/handlers/management

## Notes
- First deploy may spend one-time time creating SQLite indexes on existing usage.db; subsequent lookup queries should use the new composite indexes.