### PR TITLE
fix: speed up public usage chart data

### DIFF
--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -3,44 +3,16 @@ package usagelogs
 import "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 
 func (s *Service) PublicChartData(apiKey string, days int) (map[string]any, error) {
-	daily, err := usage.QueryDailySeries(apiKey, days)
+	chartData, err := usage.QueryPublicChartData(apiKey, days)
 	if err != nil {
 		return nil, err
-	}
-	if daily == nil {
-		daily = []usage.DailySeriesPoint{}
-	}
-
-	models, err := usage.QueryModelDistribution(apiKey, days)
-	if err != nil {
-		return nil, err
-	}
-	if models == nil {
-		models = []usage.ModelDistributionPoint{}
-	}
-
-	stats, err := usage.QueryStats(usage.LogQueryParams{APIKey: apiKey, Days: days})
-	if err != nil {
-		return nil, err
-	}
-	stats.TotalSessions, err = usage.QuerySessionCount(usage.LogQueryParams{APIKey: apiKey, Days: days})
-	if err != nil {
-		return nil, err
-	}
-
-	heatmap, err := usage.QueryDailyHeatmapSeries(apiKey, 365)
-	if err != nil {
-		return nil, err
-	}
-	if heatmap == nil {
-		heatmap = []usage.DailyHeatmapPoint{}
 	}
 
 	return map[string]any{
-		"daily_series":       daily,
-		"heatmap_series":     heatmap,
-		"model_distribution": models,
-		"stats":              stats,
+		"daily_series":       chartData.DailySeries,
+		"heatmap_series":     chartData.HeatmapSeries,
+		"model_distribution": chartData.ModelDistribution,
+		"stats":              chartData.Stats,
 		"api_key_name":       s.publicAPIKeyName(apiKey),
 	}, nil
 }

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -771,7 +771,7 @@ func buildSingleAPIKeySelectorClause(selector string) (string, []interface{}) {
 		return "", nil
 	}
 	if identity := ResolveAPIKeyIdentity(trimmed); identity != nil {
-		return " WHERE (api_key_id = ? OR (trim(coalesce(api_key_id, '')) = '' AND api_key = ?))", []interface{}{identity.ID, identity.Key}
+		return " WHERE (api_key_id = ? OR (api_key_id = '' AND api_key = ?))", []interface{}{identity.ID, identity.Key}
 	}
 	return " WHERE api_key = ?", []interface{}{trimmed}
 }

--- a/internal/usage/request_log_query_builder_test.go
+++ b/internal/usage/request_log_query_builder_test.go
@@ -85,7 +85,7 @@ func TestBuildSingleAPIKeySelectorClauseUsesStableIdentityWhenAvailable(t *testi
 	}
 
 	clause, args := buildSingleAPIKeySelectorClause(" sk-live ")
-	wantClause := " WHERE (api_key_id = ? OR (trim(coalesce(api_key_id, '')) = '' AND api_key = ?))"
+	wantClause := " WHERE (api_key_id = ? OR (api_key_id = '' AND api_key = ?))"
 	if clause != wantClause {
 		t.Fatalf("clause = %q, want %q", clause, wantClause)
 	}

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -31,6 +32,205 @@ type ModelDistributionPoint struct {
 	Model    string `json:"model"`
 	Requests int64  `json:"requests"`
 	Tokens   int64  `json:"tokens"`
+}
+
+type PublicChartData struct {
+	DailySeries       []DailySeriesPoint
+	HeatmapSeries     []DailyHeatmapPoint
+	ModelDistribution []ModelDistributionPoint
+	Stats             LogStats
+}
+
+// QueryPublicChartData aggregates the public API-key lookup charts in one indexed pass.
+func QueryPublicChartData(apiKey string, days int) (PublicChartData, error) {
+	db := getReadDB()
+	if db == nil {
+		return PublicChartData{
+			DailySeries:       []DailySeriesPoint{},
+			HeatmapSeries:     []DailyHeatmapPoint{},
+			ModelDistribution: []ModelDistributionPoint{},
+			Stats:             LogStats{CacheRate: 0},
+		}, nil
+	}
+	if days < 1 {
+		days = 7
+	}
+
+	const heatmapDays = 365
+	scanDays := days
+	if scanDays < heatmapDays {
+		scanDays = heatmapDays
+	}
+	statsCutoff := CutoffStartUTC(days).Format(time.RFC3339)
+	heatmapCutoff := CutoffStartUTC(heatmapDays).Format(time.RFC3339)
+
+	params := LogQueryParams{APIKey: apiKey, Days: scanDays}
+	where, args := buildWhereClause(params)
+	queryArgs := make([]interface{}, 0, len(args)+2)
+	queryArgs = append(queryArgs, statsCutoff, heatmapCutoff)
+	queryArgs = append(queryArgs, args...)
+
+	rows, err := db.Query(`SELECT
+	             date(timestamp, 'localtime') as d,
+	             model,
+	             CASE WHEN failed = 1 OR failed = 'true' THEN 1 ELSE 0 END as failed_flag,
+	             input_tokens,
+	             output_tokens,
+	             total_tokens,
+	             cost,
+	             cached_tokens,
+	             CASE WHEN timestamp >= ? THEN 1 ELSE 0 END as in_stats_range,
+	             CASE WHEN timestamp >= ? THEN 1 ELSE 0 END as in_heatmap_range
+	      FROM request_logs`+where, queryArgs...)
+	if err != nil {
+		return PublicChartData{}, fmt.Errorf("usage: public chart data query: %w", err)
+	}
+	defer rows.Close()
+
+	dailyByDate := make(map[string]*DailySeriesPoint)
+	heatmapByDate := make(map[string]*DailyHeatmapPoint)
+	modelByName := make(map[string]*ModelDistributionPoint)
+	var stats LogStats
+	var effectiveInputTokens int64
+	var cachedTokens int64
+	var successCount int64
+
+	for rows.Next() {
+		var dateKey string
+		var model string
+		var failedFlag int
+		var inputTokens int64
+		var outputTokens int64
+		var totalTokens int64
+		var cost float64
+		var rowCachedTokens int64
+		var inStatsRange int
+		var inHeatmapRange int
+		if err := rows.Scan(&dateKey, &model, &failedFlag, &inputTokens, &outputTokens, &totalTokens, &cost, &rowCachedTokens, &inStatsRange, &inHeatmapRange); err != nil {
+			return PublicChartData{}, fmt.Errorf("usage: public chart data scan: %w", err)
+		}
+
+		if inHeatmapRange != 0 {
+			point := heatmapByDate[dateKey]
+			if point == nil {
+				point = &DailyHeatmapPoint{Date: dateKey}
+				heatmapByDate[dateKey] = point
+			}
+			point.Requests++
+			point.Tokens += totalTokens
+			point.Cost += cost
+		}
+
+		if inStatsRange == 0 {
+			continue
+		}
+		daily := dailyByDate[dateKey]
+		if daily == nil {
+			daily = &DailySeriesPoint{Date: dateKey}
+			dailyByDate[dateKey] = daily
+		}
+		daily.Requests++
+		if failedFlag != 0 {
+			daily.FailedReq++
+		} else {
+			successCount++
+		}
+		daily.InputTokens += int(inputTokens)
+		daily.OutputTokens += int(outputTokens)
+
+		modelPoint := modelByName[model]
+		if modelPoint == nil {
+			modelPoint = &ModelDistributionPoint{Model: model}
+			modelByName[model] = modelPoint
+		}
+		modelPoint.Requests++
+		modelPoint.Tokens += totalTokens
+
+		stats.Total++
+		stats.TotalTokens += totalTokens
+		stats.TotalCost += cost
+		effectiveInputTokens += effectiveInputTokenTotal(inputTokens, rowCachedTokens)
+		cachedTokens += rowCachedTokens
+	}
+	if err := rows.Err(); err != nil {
+		return PublicChartData{}, err
+	}
+
+	sessionsByDate, err := querySessionSetsByDate(params)
+	if err != nil {
+		return PublicChartData{}, err
+	}
+	statsStartDay := LocalDayKeyAt(CutoffStartUTC(days))
+	heatmapStartDay := LocalDayKeyAt(CutoffStartUTC(heatmapDays))
+	totalSessions := make(map[string]struct{})
+	for dateKey, sessions := range sessionsByDate {
+		if dateKey >= heatmapStartDay {
+			point := heatmapByDate[dateKey]
+			if point != nil {
+				point.Sessions = int64(len(sessions))
+			}
+		}
+		if dateKey >= statsStartDay {
+			for sessionID := range sessions {
+				totalSessions[sessionID] = struct{}{}
+			}
+		}
+	}
+	stats.TotalSessions = int64(len(totalSessions))
+	if stats.Total > 0 {
+		stats.SuccessRate = float64(successCount) / float64(stats.Total) * 100
+	}
+	stats.CacheRate = cacheRateFromTokenTotals(effectiveInputTokens, cachedTokens)
+
+	return PublicChartData{
+		DailySeries:       sortedDailySeries(dailyByDate),
+		HeatmapSeries:     sortedHeatmapSeries(heatmapByDate),
+		ModelDistribution: sortedModelDistribution(modelByName),
+		Stats:             stats,
+	}, nil
+}
+
+func effectiveInputTokenTotal(inputTokens, cachedTokens int64) int64 {
+	if cachedTokens > inputTokens {
+		return inputTokens + cachedTokens
+	}
+	return inputTokens
+}
+
+func sortedDailySeries(points map[string]*DailySeriesPoint) []DailySeriesPoint {
+	result := make([]DailySeriesPoint, 0, len(points))
+	for _, point := range points {
+		result = append(result, *point)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Date < result[j].Date
+	})
+	return result
+}
+
+func sortedHeatmapSeries(points map[string]*DailyHeatmapPoint) []DailyHeatmapPoint {
+	result := make([]DailyHeatmapPoint, 0, len(points))
+	for _, point := range points {
+		result = append(result, *point)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Date < result[j].Date
+	})
+	return result
+}
+
+func sortedModelDistribution(points map[string]*ModelDistributionPoint) []ModelDistributionPoint {
+	result := make([]ModelDistributionPoint, 0, len(points))
+	for _, point := range points {
+		result = append(result, *point)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Requests == result[j].Requests {
+			return result[i].Model < result[j].Model
+		}
+		return result[i].Requests > result[j].Requests
+	})
+	return result
 }
 
 // QueryDailySeries returns per-day aggregated request count and token usage for a given API key.

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -281,6 +281,8 @@ func ensureRequestLogLookupIndexes(db *sql.DB) {
 	for _, stmt := range []string{
 		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_timestamp ON request_logs(api_key, timestamp DESC)",
 		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_timestamp ON request_logs(api_key_id, timestamp DESC)",
+		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_chart_cover ON request_logs(api_key, api_key_id, timestamp DESC, model, failed, input_tokens, output_tokens, total_tokens, cost, cached_tokens)",
+		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_chart_cover ON request_logs(api_key_id, timestamp DESC, model, failed, input_tokens, output_tokens, total_tokens, cost, cached_tokens)",
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			log.Warnf("usage: create request log lookup index: %v", err)

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -697,7 +697,12 @@ func TestInitDBEnsuresRequestLogLookupIndexes(t *testing.T) {
 		t.Fatalf("iterate index_list: %v", err)
 	}
 
-	for _, name := range []string{"idx_logs_api_key_timestamp", "idx_logs_api_key_id_timestamp"} {
+	for _, name := range []string{
+		"idx_logs_api_key_timestamp",
+		"idx_logs_api_key_id_timestamp",
+		"idx_logs_api_key_chart_cover",
+		"idx_logs_api_key_id_chart_cover",
+	} {
 		if !found[name] {
 			t.Fatalf("expected %s to exist after InitDB", name)
 		}
@@ -2036,6 +2041,27 @@ func TestQueryStatsAndHeatmapCountSessionsFromDetails(t *testing.T) {
 	yesterdayPoint := byDate[LocalDayKeyAt(yesterday)]
 	if yesterdayPoint.Requests != 1 || yesterdayPoint.Tokens != 3 || yesterdayPoint.Sessions != 1 {
 		t.Fatalf("yesterday heatmap point = %#v, want requests=1 tokens=3 sessions=1", yesterdayPoint)
+	}
+
+	chartData, err := QueryPublicChartData("sk-heatmap", 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartData() error = %v", err)
+	}
+	if chartData.Stats.Total != 3 || chartData.Stats.TotalTokens != 83 || chartData.Stats.TotalSessions != 2 {
+		t.Fatalf("public chart stats = %#v, want total=3 total_tokens=83 sessions=2", chartData.Stats)
+	}
+	if len(chartData.DailySeries) != 2 {
+		t.Fatalf("public chart daily len = %d, want 2", len(chartData.DailySeries))
+	}
+	if len(chartData.ModelDistribution) != 1 || chartData.ModelDistribution[0].Requests != 3 || chartData.ModelDistribution[0].Tokens != 83 {
+		t.Fatalf("public chart models = %#v, want one model with 3 requests and 83 tokens", chartData.ModelDistribution)
+	}
+	chartHeatmap := make(map[string]DailyHeatmapPoint, len(chartData.HeatmapSeries))
+	for _, point := range chartData.HeatmapSeries {
+		chartHeatmap[point.Date] = point
+	}
+	if chartHeatmap[LocalDayKeyAt(today)].Sessions != 1 || chartHeatmap[LocalDayKeyAt(yesterday)].Sessions != 1 {
+		t.Fatalf("public chart heatmap = %#v, want sessions by day populated", chartHeatmap)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add covering indexes for public API-key usage chart lookups
- aggregate public chart data in one indexed pass instead of several serial request_logs scans
- parse session detail once for both heatmap sessions and total sessions

## Verification
- rtk go test ./internal/usage ./internal/management/usagelogs ./internal/api/handlers/management
- rtk go test ./...
- verified final chart query on a copy of the production usage DB: 365-day row scan dropped to about 0.7s after covering indexes