### PR TITLE
fix: support docker nginx blue-green deploy

### DIFF
--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -83,6 +83,10 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`/healthz`,
 		`CLIRELAY_PORT=`,
 		`.active-port`,
+		`HEALTH_TIMEOUT_SECONDS`,
+		`MIN_AVAILABLE_MB`,
+		`NGINX_CONTAINER`,
+		`docker exec "$NGINX_CONTAINER" nginx -t`,
 		`nginx -t`,
 		`DRAIN_SECONDS`,
 	} {

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -8,6 +8,9 @@ DOMAIN="${DOMAIN:-relay.07230805.xyz}"
 PORT_A="${PORT_A:-8318}"
 PORT_B="${PORT_B:-8319}"
 DRAIN_SECONDS="${DRAIN_SECONDS:-35}"
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-90}"
+MIN_AVAILABLE_MB="${MIN_AVAILABLE_MB:-512}"
+NGINX_CONTAINER="${NGINX_CONTAINER:-nginx}"
 COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
 ACTIVE_PORT_FILE="${BASE_DIR}/.active-port"
 
@@ -58,6 +61,11 @@ cleanup_failed_deploy() {
 }
 trap cleanup_failed_deploy EXIT
 
+available_mb="$(awk '/MemAvailable:/ {print int($2 / 1024); exit}' /proc/meminfo 2>/dev/null || true)"
+if [ -n "$available_mb" ] && [ "$available_mb" -lt "$MIN_AVAILABLE_MB" ]; then
+	fail "not enough free memory for blue-green deploy: ${available_mb}MB available, need ${MIN_AVAILABLE_MB}MB"
+fi
+
 install -m 0755 "$TEMP_BIN" "$next_bin"
 rm -f "$TEMP_BIN"
 
@@ -107,15 +115,19 @@ http_ok() {
 }
 
 health_url="http://127.0.0.1:${next_port}/healthz"
-for _ in $(seq 1 30); do
+for _ in $(seq 1 "$HEALTH_TIMEOUT_SECONDS"); do
 	if http_ok "$health_url"; then
 		break
 	fi
 	sleep 1
 done
-http_ok "$health_url" || fail "new slot failed health check: $health_url"
+if ! http_ok "$health_url"; then
+	systemctl status "$next_unit" --no-pager -l >&2 || true
+	journalctl -u "$next_unit" --no-pager -n 80 >&2 || true
+	fail "new slot failed health check after ${HEALTH_TIMEOUT_SECONDS}s: $health_url"
+fi
 
-ensure_body_size_conf() {
+ensure_host_body_size_conf() {
 	[ -d /etc/nginx ] || return 0
 	body_size_conf="/etc/nginx/conf.d/90-clirelay-body-size.conf"
 	mkdir -p "$(dirname "$body_size_conf")"
@@ -125,33 +137,75 @@ client_max_body_size 2000m;
 EOF
 }
 
-find_nginx_conf() {
+ensure_container_body_size_conf() {
+	docker exec -i "$NGINX_CONTAINER" sh -c 'cat > /etc/nginx/conf.d/90-clirelay-body-size.conf' <<'EOF'
+# Managed by CliRelay GitHub Actions deploy workflow
+client_max_body_size 2000m;
+EOF
+}
+
+find_host_nginx_conf() {
 	if [ -n "${NGINX_CONF:-}" ]; then
 		echo "$NGINX_CONF"
 		return
 	fi
-	grep -Rsl "$DOMAIN" /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | head -n1
+	grep -Rsl "$DOMAIN" /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | head -n1 || true
 }
 
-nginx_conf="$(find_nginx_conf)"
-[ -n "$nginx_conf" ] || fail "nginx config for ${DOMAIN} not found; set NGINX_CONF"
-[ -f "$nginx_conf" ] || fail "nginx config not found: $nginx_conf"
+find_container_nginx_conf() {
+	if ! command -v docker >/dev/null 2>&1; then
+		return
+	fi
+	if ! docker inspect "$NGINX_CONTAINER" >/dev/null 2>&1; then
+		return
+	fi
+	docker exec "$NGINX_CONTAINER" sh -c "grep -Rsl '$DOMAIN' /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | head -n1" || true
+}
 
-ensure_body_size_conf
-backup="${nginx_conf}.bak.$(date +%Y%m%d_%H%M%S)"
-cp "$nginx_conf" "$backup"
-if ! grep -Eq ":${active_port}\\b" "$nginx_conf"; then
-	fail "nginx config $nginx_conf does not reference active port ${active_port}"
+nginx_mode="host"
+nginx_conf="$(find_host_nginx_conf)"
+if [ -z "$nginx_conf" ]; then
+	nginx_conf="$(find_container_nginx_conf)"
+	nginx_mode="container"
 fi
-# Replace only the active backend port, leaving the existing nginx layout untouched.
-perl -0pi -e "s/:${active_port}\\b/:${next_port}/g" "$nginx_conf"
+[ -n "$nginx_conf" ] || fail "nginx config for ${DOMAIN} not found on host or docker container ${NGINX_CONTAINER}; set NGINX_CONF/NGINX_CONTAINER"
 
-if ! nginx -t; then
-	cp "$backup" "$nginx_conf"
-	nginx -t || true
-	fail "nginx config test failed; reverted $nginx_conf"
+if [ "$nginx_mode" = "container" ]; then
+	tmp_conf="$(mktemp)"
+	backup="${nginx_conf}.bak.$(date +%Y%m%d_%H%M%S)"
+	docker cp "${NGINX_CONTAINER}:${nginx_conf}" "$tmp_conf"
+	docker exec "$NGINX_CONTAINER" cp "$nginx_conf" "$backup"
+	if ! grep -Eq ":${active_port}\\b" "$tmp_conf"; then
+		fail "nginx config ${NGINX_CONTAINER}:${nginx_conf} does not reference active port ${active_port}"
+	fi
+	# Replace only the active backend port, leaving the existing nginx layout untouched.
+	perl -0pi -e "s/:${active_port}\\b/:${next_port}/g" "$tmp_conf"
+	ensure_container_body_size_conf
+	docker cp "$tmp_conf" "${NGINX_CONTAINER}:${nginx_conf}"
+	rm -f "$tmp_conf"
+	if ! docker exec "$NGINX_CONTAINER" nginx -t; then
+		docker exec "$NGINX_CONTAINER" cp "$backup" "$nginx_conf"
+		docker exec "$NGINX_CONTAINER" nginx -t || true
+		fail "nginx config test failed; reverted ${NGINX_CONTAINER}:${nginx_conf}"
+	fi
+	docker exec "$NGINX_CONTAINER" nginx -s reload
+else
+	[ -f "$nginx_conf" ] || fail "nginx config not found: $nginx_conf"
+	ensure_host_body_size_conf
+	backup="${nginx_conf}.bak.$(date +%Y%m%d_%H%M%S)"
+	cp "$nginx_conf" "$backup"
+	if ! grep -Eq ":${active_port}\\b" "$nginx_conf"; then
+		fail "nginx config $nginx_conf does not reference active port ${active_port}"
+	fi
+	# Replace only the active backend port, leaving the existing nginx layout untouched.
+	perl -0pi -e "s/:${active_port}\\b/:${next_port}/g" "$nginx_conf"
+	if ! nginx -t; then
+		cp "$backup" "$nginx_conf"
+		nginx -t || true
+		fail "nginx config test failed; reverted $nginx_conf"
+	fi
+	nginx -s reload || systemctl reload nginx
 fi
-nginx -s reload || systemctl reload nginx
 
 echo "$next_port" > "$ACTIVE_PORT_FILE"
 cutover_done=1


### PR DESCRIPTION
## Summary
- support Docker-hosted nginx when cutting over blue-green deploys
- add deploy health timeout diagnostics and an early memory guard
- keep deploy workflow tests checking the new guards

## Tests
- rtk bash -n scripts/deploy-blue-green.sh
- rtk go test . -run 'TestDeployWorkflow|TestBlueGreen'\n- rtk git diff --check\n- rtk bash -lc 'TZ=UTC go test ./...'