### PR TITLE
fix: speed up public usage chart sessions

### DIFF
--- a/internal/usage/log_content_store.go
+++ b/internal/usage/log_content_store.go
@@ -256,6 +256,7 @@ func insertLogContentTx(tx *sql.Tx, logID int64, timestamp time.Time, inputConte
 	if tx == nil || logID < 1 || (!requestLogStorage.StoreContent) {
 		return nil
 	}
+	sessionID := extractSessionIDFromDetails(detailContent)
 
 	inputCompressed, err := compressLogContent(inputContent)
 	if err != nil {
@@ -278,20 +279,22 @@ func insertLogContentTx(tx *sql.Tx, logID int64, timestamp time.Time, inputConte
 	}
 
 	_, err = tx.Exec(
-		`INSERT INTO request_log_content (log_id, timestamp, compression, input_content, output_content, detail_content)
-		 VALUES (?, ?, ?, ?, ?, ?)
+		`INSERT INTO request_log_content (log_id, timestamp, compression, input_content, output_content, detail_content, session_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(log_id) DO UPDATE SET
 		   timestamp = excluded.timestamp,
 		   compression = excluded.compression,
 		   input_content = excluded.input_content,
 		   output_content = excluded.output_content,
-		   detail_content = excluded.detail_content`,
+		   detail_content = excluded.detail_content,
+		   session_id = excluded.session_id`,
 		logID,
 		timestamp.UTC().Format(time.RFC3339Nano),
 		requestLogContentCompression,
 		inputCompressed,
 		outputCompressed,
 		detailCompressed,
+		sessionID,
 	)
 	if err != nil {
 		return fmt.Errorf("usage: insert compressed content: %w", err)

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -400,7 +400,7 @@ func ClearRequestLogs(options ClearRequestLogsOptions) (ClearRequestLogsResult, 
 
 		if options.ClearDetailContent {
 			detailResult, err := tx.Exec(
-				"UPDATE request_log_content SET detail_content = X'' WHERE length(detail_content) > 0",
+				"UPDATE request_log_content SET detail_content = X'', session_id = '' WHERE length(detail_content) > 0 OR session_id <> ''",
 			)
 			if err != nil {
 				return ClearRequestLogsResult{}, fmt.Errorf("usage: clear request_log_content details: %w", err)
@@ -412,7 +412,7 @@ func ClearRequestLogs(options ClearRequestLogsOptions) (ClearRequestLogsResult, 
 		}
 
 		deleteEmptyRowsResult, err := tx.Exec(
-			"DELETE FROM request_log_content WHERE length(input_content) = 0 AND length(output_content) = 0 AND length(detail_content) = 0",
+			"DELETE FROM request_log_content WHERE length(input_content) = 0 AND length(output_content) = 0 AND length(detail_content) = 0 AND session_id = ''",
 		)
 		if err != nil {
 			return ClearRequestLogsResult{}, fmt.Errorf("usage: delete empty request_log_content rows: %w", err)

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -2,11 +2,12 @@ package usage
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/tidwall/gjson"
 )
 
 // DailySeriesPoint holds one day of aggregated usage data.
@@ -354,29 +355,24 @@ func querySessionSetsByDate(params LogQueryParams) (map[string]map[string]struct
 
 	where, args := buildWhereClause(params)
 	rows, err := db.Query(
-		`SELECT date(logs.timestamp, 'localtime'), content.compression, content.detail_content
+		`SELECT date(logs.timestamp, 'localtime'), content.session_id
 		   FROM (SELECT id, timestamp FROM request_logs`+where+`) logs
 		   JOIN request_log_content content ON content.log_id = logs.id
-		  WHERE length(content.detail_content) > 0`,
+		  WHERE content.session_id <> ''`,
 		args...,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("usage: session details query: %w", err)
+		return nil, fmt.Errorf("usage: session query: %w", err)
 	}
 	defer rows.Close()
 
 	seenByDate := make(map[string]map[string]struct{})
 	for rows.Next() {
-		var dateKey, compression string
-		var compressed []byte
-		if err := rows.Scan(&dateKey, &compression, &compressed); err != nil {
-			return nil, fmt.Errorf("usage: session details scan: %w", err)
+		var dateKey, sessionID string
+		if err := rows.Scan(&dateKey, &sessionID); err != nil {
+			return nil, fmt.Errorf("usage: session scan: %w", err)
 		}
-		detail, err := decompressLogContent(compression, compressed)
-		if err != nil {
-			return nil, err
-		}
-		sessionID := extractSessionIDFromDetails(detail)
+		sessionID = strings.TrimSpace(sessionID)
 		if sessionID == "" {
 			continue
 		}
@@ -395,14 +391,14 @@ func extractSessionIDFromDetails(detail string) string {
 	if strings.TrimSpace(detail) == "" {
 		return ""
 	}
-	var payload any
-	if err := json.Unmarshal([]byte(detail), &payload); err != nil {
+	payload := gjson.Parse(detail)
+	if !payload.Exists() {
 		return ""
 	}
 	bestRank := 99
 	bestValue := ""
-	var walk func(any, string)
-	walk = func(value any, key string) {
+	var walk func(gjson.Result, string)
+	walk = func(value gjson.Result, key string) {
 		rank := sessionDetailKeyRank(key)
 		if rank < bestRank {
 			if text := sessionDetailString(value); text != "" {
@@ -410,19 +406,35 @@ func extractSessionIDFromDetails(detail string) string {
 				bestValue = text
 			}
 		}
-		switch typed := value.(type) {
-		case map[string]any:
-			for childKey, childValue := range typed {
-				walk(childValue, childKey)
-			}
-		case []any:
-			for _, childValue := range typed {
-				walk(childValue, "")
-			}
+		if bestRank == 0 {
+			return
+		}
+		if value.Type == gjson.JSON {
+			value.ForEach(func(childKey, childValue gjson.Result) bool {
+				walk(childValue, childKey.String())
+				return bestRank != 0
+			})
 		}
 	}
 	walk(payload, "")
 	return bestValue
+}
+
+func sessionDetailString(value gjson.Result) string {
+	if value.Type == gjson.String {
+		return strings.TrimSpace(value.String())
+	}
+	if value.IsArray() {
+		result := ""
+		value.ForEach(func(_, item gjson.Result) bool {
+			if item.Type == gjson.String {
+				result = strings.TrimSpace(item.String())
+			}
+			return result == ""
+		})
+		return result
+	}
+	return ""
 }
 
 func sessionDetailKeyRank(key string) int {
@@ -435,20 +447,6 @@ func sessionDetailKeyRank(key string) int {
 	default:
 		return 99
 	}
-}
-
-func sessionDetailString(value any) string {
-	switch typed := value.(type) {
-	case string:
-		return strings.TrimSpace(typed)
-	case []any:
-		for _, item := range typed {
-			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
-				return strings.TrimSpace(text)
-			}
-		}
-	}
-	return ""
 }
 
 // QueryModelDistribution returns request count and token usage grouped by model for a given API key.

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -154,6 +154,7 @@ CREATE TABLE IF NOT EXISTS request_log_content (
   input_content    BLOB NOT NULL DEFAULT X'',
   output_content   BLOB NOT NULL DEFAULT X'',
   detail_content   BLOB NOT NULL DEFAULT X'',
+  session_id       TEXT NOT NULL DEFAULT '',
   FOREIGN KEY(log_id) REFERENCES request_logs(id) ON DELETE CASCADE
 );
 
@@ -362,6 +363,15 @@ func migrateRequestLogDetailColumn(db *sql.DB) {
 	}
 }
 
+func migrateRequestLogContentSessionIDColumn(db *sql.DB) {
+	_, err := db.Exec("ALTER TABLE request_log_content ADD COLUMN session_id TEXT NOT NULL DEFAULT ''")
+	if err != nil {
+		if !strings.Contains(err.Error(), "duplicate") {
+			log.Warnf("usage: migrate column session_id: %v", err)
+		}
+	}
+}
+
 func ensureRequestLogDetailIndexes(db *sql.DB) {
 	if _, err := db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_log_content_detail_timestamp
@@ -370,6 +380,93 @@ func ensureRequestLogDetailIndexes(db *sql.DB) {
 	`); err != nil {
 		log.Warnf("usage: create idx_log_content_detail_timestamp: %v", err)
 	}
+	if _, err := db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_log_content_session_timestamp
+		ON request_log_content(session_id, timestamp DESC)
+		WHERE session_id <> ''
+	`); err != nil {
+		log.Warnf("usage: create idx_log_content_session_timestamp: %v", err)
+	}
+}
+
+func backfillRequestLogContentSessionIDs(db *sql.DB) {
+	rows, err := db.Query(`
+		SELECT log_id, compression, detail_content
+		  FROM request_log_content
+		 WHERE session_id = ''
+		   AND length(detail_content) > 0
+	`)
+	if err != nil {
+		log.Warnf("usage: query request log session_id backfill rows: %v", err)
+		return
+	}
+
+	type update struct {
+		logID     int64
+		sessionID string
+	}
+	updates := make([]update, 0)
+	var scanned int64
+	for rows.Next() {
+		var logID int64
+		var compression string
+		var compressed []byte
+		if err := rows.Scan(&logID, &compression, &compressed); err != nil {
+			_ = rows.Close()
+			log.Warnf("usage: scan request log session_id backfill row: %v", err)
+			return
+		}
+		scanned++
+		detail, err := decompressLogContent(compression, compressed)
+		if err != nil {
+			log.Warnf("usage: decompress request log session_id backfill row %d: %v", logID, err)
+			continue
+		}
+		if sessionID := extractSessionIDFromDetails(detail); sessionID != "" {
+			updates = append(updates, update{logID: logID, sessionID: sessionID})
+		}
+	}
+	if err := rows.Close(); err != nil {
+		log.Warnf("usage: close request log session_id backfill rows: %v", err)
+		return
+	}
+	if err := rows.Err(); err != nil {
+		log.Warnf("usage: iterate request log session_id backfill rows: %v", err)
+		return
+	}
+	if len(updates) == 0 {
+		return
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		log.Warnf("usage: begin request log session_id backfill: %v", err)
+		return
+	}
+	stmt, err := tx.Prepare("UPDATE request_log_content SET session_id = ? WHERE log_id = ?")
+	if err != nil {
+		_ = tx.Rollback()
+		log.Warnf("usage: prepare request log session_id backfill: %v", err)
+		return
+	}
+	for _, update := range updates {
+		if _, err := stmt.Exec(update.sessionID, update.logID); err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			log.Warnf("usage: update request log session_id backfill row %d: %v", update.logID, err)
+			return
+		}
+	}
+	if err := stmt.Close(); err != nil {
+		_ = tx.Rollback()
+		log.Warnf("usage: close request log session_id backfill statement: %v", err)
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		log.Warnf("usage: commit request log session_id backfill: %v", err)
+		return
+	}
+	log.Infof("usage: backfilled request log session_id values: %d/%d", len(updates), scanned)
 }
 
 // InitDB opens (or creates) the SQLite database at the given path and creates
@@ -480,8 +577,12 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	migrateStreamingColumn(db)
 	log.Debugf("usage: running request log detail column migration")
 	migrateRequestLogDetailColumn(db)
+	log.Debugf("usage: running request log content session_id column migration")
+	migrateRequestLogContentSessionIDColumn(db)
 	log.Debugf("usage: ensuring request log detail indexes")
 	ensureRequestLogDetailIndexes(db)
+	log.Debugf("usage: backfilling request log content session_id values")
+	backfillRequestLogContentSessionIDs(db)
 	log.Debugf("usage: initializing pricing table")
 	initPricingTable(db)
 	log.Debugf("usage: initializing model config tables")

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -2011,6 +2011,14 @@ func TestQueryStatsAndHeatmapCountSessionsFromDetails(t *testing.T) {
 		InputTokens: 1, OutputTokens: 2, TotalTokens: 3,
 	}, "{}", "{}", `{"conversation_id":"session-b"}`)
 
+	var storedSessions int
+	if err := getDB().QueryRow("SELECT COUNT(*) FROM request_log_content WHERE session_id <> ''").Scan(&storedSessions); err != nil {
+		t.Fatalf("count stored session_id rows: %v", err)
+	}
+	if storedSessions != 3 {
+		t.Fatalf("stored session_id rows = %d, want 3", storedSessions)
+	}
+
 	stats, err := QueryStats(LogQueryParams{APIKey: "sk-heatmap", Days: 7})
 	if err != nil {
 		t.Fatalf("QueryStats() error = %v", err)
@@ -2062,6 +2070,17 @@ func TestQueryStatsAndHeatmapCountSessionsFromDetails(t *testing.T) {
 	}
 	if chartHeatmap[LocalDayKeyAt(today)].Sessions != 1 || chartHeatmap[LocalDayKeyAt(yesterday)].Sessions != 1 {
 		t.Fatalf("public chart heatmap = %#v, want sessions by day populated", chartHeatmap)
+	}
+
+	if _, err := ClearRequestLogs(ClearRequestLogsOptions{ClearDetailContent: true}); err != nil {
+		t.Fatalf("ClearRequestLogs(details) error = %v", err)
+	}
+	sessionCount, err = QuerySessionCount(LogQueryParams{APIKey: "sk-heatmap", Days: 7})
+	if err != nil {
+		t.Fatalf("QuerySessionCount() after detail cleanup error = %v", err)
+	}
+	if sessionCount != 0 {
+		t.Fatalf("QuerySessionCount() after detail cleanup = %d, want 0", sessionCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- store extracted request session IDs in request_log_content.session_id
- backfill historical session IDs once during DB init
- read session counts from the indexed session_id column instead of decompressing detail_content for chart-data
- clear session_id together with detail content cleanup

## Tests
- go test ./internal/usage
- go test ./internal/usage ./internal/management/usagelogs ./internal/api/handlers/management
- go test ./...