### PR TITLE
fix: ignore nginx backup configs during deploy

### DIFF
--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -89,6 +89,7 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`docker exec "$NGINX_CONTAINER" nginx -t`,
 		`nginx -t`,
 		`DRAIN_SECONDS`,
+		`grep -v '\.bak\.'`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("deploy script missing guard %q", want)

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -149,7 +149,7 @@ find_host_nginx_conf() {
 		echo "$NGINX_CONF"
 		return
 	fi
-	grep -Rsl "$DOMAIN" /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | head -n1 || true
+	grep -Rsl "$DOMAIN" /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | grep -v '\.bak\.' | head -n1 || true
 }
 
 find_container_nginx_conf() {
@@ -159,7 +159,7 @@ find_container_nginx_conf() {
 	if ! docker inspect "$NGINX_CONTAINER" >/dev/null 2>&1; then
 		return
 	fi
-	docker exec "$NGINX_CONTAINER" sh -c "grep -Rsl '$DOMAIN' /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | head -n1" || true
+	docker exec "$NGINX_CONTAINER" sh -c "grep -Rsl '$DOMAIN' /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | grep -v '\\.bak\\.' | head -n1" || true
 }
 
 nginx_mode="host"


### PR DESCRIPTION
## Summary
- ignore nginx .bak config files when auto-discovering the relay nginx config
- keep deploy script from selecting stale backups before checking the Docker nginx config

## Tests
- bash -n scripts/deploy-blue-green.sh
- go test ./...