### PR TITLE
fix: retain public lookup channel names

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -1446,6 +1446,86 @@ func TestGetPublicUsageLogs_ReturnsCurrentAPIKeyName(t *testing.T) {
 	}
 }
 
+func TestGetPublicUsageLogs_ReturnsChannelNameWithoutSensitiveFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "public-lookup-auth",
+		FileName: "codex-test.json",
+		Provider: "codex",
+		Label:    "Codex 主渠道",
+		Metadata: map[string]any{"email": "owner@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	usage.InsertLog(
+		"sk-test", "Primary", "gpt-5.5", "owner@example.com", "owner@example.com", auth.Index,
+		false, time.Now().UTC(), 123, 45,
+		usage.TokenStats{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+		"", "",
+	)
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body := []byte(`{"api_key":"sk-test","days":7,"page":1,"size":50}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/v0/management/public/usage/logs",
+		bytes.NewReader(body),
+	)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.UsageLogs().GetPublicUsageLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Items []struct {
+			APIKey      string `json:"api_key"`
+			APIKeyName  string `json:"api_key_name"`
+			Source      string `json:"source"`
+			AuthIndex   string `json:"auth_index"`
+			ChannelName string `json:"channel_name"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(payload.Items))
+	}
+	item := payload.Items[0]
+	if item.ChannelName != "Codex 主渠道" {
+		t.Fatalf("channel_name = %q, want Codex 主渠道", item.ChannelName)
+	}
+	if item.APIKey != "" || item.APIKeyName != "" || item.Source != "" || item.AuthIndex != "" {
+		t.Fatalf("sensitive fields not scrubbed: %+v", item)
+	}
+}
+
 func TestGetPublicUsageLogs_DoesNotReadAPIKeyFromQuery(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -92,24 +92,8 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 				item.APIKeyName = name
 			}
 		}
-		if item.ChannelName != "" {
-			if name, ok := authIndexChannelMap[item.AuthIndex]; ok && strings.TrimSpace(name) != "" {
-				if _, legacy := channelNameMap[item.ChannelName]; legacy || containsFold(ambiguousAuthIndexChannelMap[item.AuthIndex], item.ChannelName) {
-					item.ChannelName = name
-					continue
-				}
-			}
-			if name, ok := channelNameMap[item.ChannelName]; ok && strings.TrimSpace(name) != "" {
-				item.ChannelName = name
-			}
-			continue
-		}
-		if name, ok := authIndexChannelMap[item.AuthIndex]; ok && strings.TrimSpace(name) != "" {
-			item.ChannelName = name
-			continue
-		}
-		if name, ok := channelNameMap[item.Source]; ok {
-			item.ChannelName = name
+		if channelName := displayChannelNameForLog(*item, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap); channelName != "" {
+			item.ChannelName = channelName
 		}
 	}
 
@@ -188,6 +172,7 @@ func (s *Service) ClearRequestLogs(options usage.ClearRequestLogsOptions) (int, 
 }
 
 func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, error) {
+	_, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap := s.buildNameMaps()
 	params := usage.LogQueryParams{
 		Page:   input.Page,
 		Size:   input.Size,
@@ -211,9 +196,10 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		if apiKeyName == "" {
 			apiKeyName = strings.TrimSpace(result.Items[i].APIKeyName)
 		}
+		channelName := displayChannelNameForLog(result.Items[i], channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap)
 		result.Items[i].Source = ""
 		result.Items[i].AuthIndex = ""
-		result.Items[i].ChannelName = ""
+		result.Items[i].ChannelName = channelName
 		result.Items[i].APIKey = ""
 		result.Items[i].APIKeyName = ""
 	}
@@ -242,6 +228,27 @@ func (s *Service) publicAPIKeyName(apiKey string) string {
 		return ""
 	}
 	return strings.TrimSpace(row.Name)
+}
+
+func displayChannelNameForLog(item usage.LogRow, channelNameMap, authIndexChannelMap map[string]string, ambiguousAuthIndexChannelMap map[string][]string) string {
+	if channel := strings.TrimSpace(item.ChannelName); channel != "" {
+		if name, ok := authIndexChannelMap[item.AuthIndex]; ok && strings.TrimSpace(name) != "" {
+			if _, legacy := channelNameMap[channel]; legacy || containsFold(ambiguousAuthIndexChannelMap[item.AuthIndex], channel) {
+				return strings.TrimSpace(name)
+			}
+		}
+		if name, ok := channelNameMap[channel]; ok && strings.TrimSpace(name) != "" {
+			return strings.TrimSpace(name)
+		}
+		return channel
+	}
+	if name, ok := authIndexChannelMap[item.AuthIndex]; ok && strings.TrimSpace(name) != "" {
+		return strings.TrimSpace(name)
+	}
+	if name, ok := channelNameMap[item.Source]; ok {
+		return strings.TrimSpace(name)
+	}
+	return ""
 }
 
 func (s *Service) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelMap map[string]string, ambiguousAuthIndexChannelMap map[string][]string) {


### PR DESCRIPTION
## Summary
- keep display channel names in public API key lookup logs
- continue scrubbing sensitive fields from public log rows
- add coverage for channel name exposure without sensitive fields

## Verification
- rtk go test ./internal/api/handlers/management ./internal/management/usagelogs