### PR TITLE
fix: support public lookup log filters

### DIFF
--- a/internal/api/handlers/management/public_lookup_request.go
+++ b/internal/api/handlers/management/public_lookup_request.go
@@ -12,14 +12,22 @@ import (
 const publicLookupBodyLimit int64 = 8 << 10
 
 type publicLookupRequest struct {
-	APIKey string `json:"api_key"`
-	Days   int    `json:"days"`
-	Page   int    `json:"page"`
-	Size   int    `json:"size"`
-	Model  string `json:"model"`
-	Status string `json:"status"`
-	Part   string `json:"part"`
-	Format string `json:"format"`
+	APIKey        string   `json:"api_key"`
+	Days          int      `json:"days"`
+	Page          int      `json:"page"`
+	Size          int      `json:"size"`
+	Model         string   `json:"model"`
+	Models        []string `json:"models"`
+	Channel       string   `json:"channel"`
+	ChannelName   string   `json:"channel_name"`
+	Channels      []string `json:"channels"`
+	Status        string   `json:"status"`
+	Statuses      []string `json:"statuses"`
+	ModelsEmpty   bool     `json:"models_empty"`
+	ChannelsEmpty bool     `json:"channels_empty"`
+	StatusesEmpty bool     `json:"statuses_empty"`
+	Part          string   `json:"part"`
+	Format        string   `json:"format"`
 }
 
 func readPublicLookupRequest(c *gin.Context) (publicLookupRequest, int, string) {
@@ -57,8 +65,20 @@ func readPublicLookupRequest(c *gin.Context) (publicLookupRequest, int, string) 
 	if strings.TrimSpace(req.Model) == "" {
 		req.Model = strings.TrimSpace(c.Query("model"))
 	}
+	req.Models = append(req.Models, queryStringListMulti(c, "model", "models")...)
 	if strings.TrimSpace(req.Status) == "" {
 		req.Status = strings.TrimSpace(c.Query("status"))
+	}
+	req.Statuses = append(req.Statuses, queryStringListMulti(c, "status", "statuses")...)
+	if strings.TrimSpace(req.Channel) == "" {
+		req.Channel = strings.TrimSpace(c.Query("channel"))
+	}
+	if strings.TrimSpace(req.ChannelName) == "" {
+		req.ChannelName = strings.TrimSpace(c.Query("channel_name"))
+	}
+	req.Channels = append(req.Channels, queryStringListMulti(c, "channel", "channels")...)
+	if req.ChannelName != "" {
+		req.Channels = append(req.Channels, req.ChannelName)
 	}
 	if strings.TrimSpace(req.Part) == "" {
 		req.Part = strings.TrimSpace(c.Query("part"))
@@ -68,9 +88,43 @@ func readPublicLookupRequest(c *gin.Context) (publicLookupRequest, int, string) 
 	}
 
 	req.Model = strings.TrimSpace(req.Model)
+	if req.Model != "" {
+		req.Models = append(req.Models, req.Model)
+	}
+	req.Models = dedupePublicLookupStrings(req.Models)
 	req.Status = strings.TrimSpace(req.Status)
+	if req.Status != "" {
+		req.Statuses = append(req.Statuses, req.Status)
+	}
+	req.Statuses = dedupePublicLookupStrings(req.Statuses)
+	req.Channel = strings.TrimSpace(req.Channel)
+	if req.Channel != "" {
+		req.Channels = append(req.Channels, req.Channel)
+	}
+	req.Channels = dedupePublicLookupStrings(req.Channels)
+	req.ModelsEmpty = req.ModelsEmpty || queryBool(c, "models_empty")
+	req.ChannelsEmpty = req.ChannelsEmpty || queryBool(c, "channels_empty")
+	req.StatusesEmpty = req.StatusesEmpty || queryBool(c, "statuses_empty")
 	req.Part = normalizeLogContentPartValue(req.Part)
 	req.Format = normalizeLogContentFormatValue(req.Format)
 
 	return req, 0, ""
+}
+
+func dedupePublicLookupStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, raw := range values {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
 }

--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -145,12 +145,16 @@ func (h *UsageLogsHandler) GetPublicUsageLogs(c *gin.Context) {
 		return
 	}
 	payload, err := h.service().PublicUsageLogs(managementusagelogs.PublicLogQueryInput{
-		APIKey: req.APIKey,
-		Model:  req.Model,
-		Status: req.Status,
-		Page:   req.Page,
-		Size:   req.Size,
-		Days:   req.Days,
+		APIKey:          req.APIKey,
+		Models:          req.Models,
+		Channels:        req.Channels,
+		Statuses:        req.Statuses,
+		MatchNoModels:   req.ModelsEmpty,
+		MatchNoChannels: req.ChannelsEmpty,
+		MatchNoStatuses: req.StatusesEmpty,
+		Page:            req.Page,
+		Size:            req.Size,
+		Days:            req.Days,
 	})
 	if err != nil {
 		log.Warnf("management usage logs: public usage logs failed: %v", err)

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -1338,7 +1338,9 @@ func TestGetPublicUsageLogs_EmptyDB_DoesNotReturnNullModels(t *testing.T) {
 
 	var payload struct {
 		Filters struct {
-			Models []string `json:"models"`
+			Models   []string `json:"models"`
+			Channels []string `json:"channels"`
+			Statuses []string `json:"statuses"`
 		} `json:"filters"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
@@ -1346,6 +1348,12 @@ func TestGetPublicUsageLogs_EmptyDB_DoesNotReturnNullModels(t *testing.T) {
 	}
 	if payload.Filters.Models == nil {
 		t.Fatalf("filters.models is null; expected []")
+	}
+	if payload.Filters.Channels == nil {
+		t.Fatalf("filters.channels is null; expected []")
+	}
+	if payload.Filters.Statuses == nil {
+		t.Fatalf("filters.statuses is null; expected []")
 	}
 }
 
@@ -1386,7 +1394,9 @@ func TestGetPublicUsageLogs_AcceptsPOSTBody(t *testing.T) {
 
 	var payload struct {
 		Filters struct {
-			Models []string `json:"models"`
+			Models   []string `json:"models"`
+			Channels []string `json:"channels"`
+			Statuses []string `json:"statuses"`
 		} `json:"filters"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
@@ -1394,6 +1404,12 @@ func TestGetPublicUsageLogs_AcceptsPOSTBody(t *testing.T) {
 	}
 	if payload.Filters.Models == nil {
 		t.Fatalf("filters.models is null; expected []")
+	}
+	if payload.Filters.Channels == nil {
+		t.Fatalf("filters.channels is null; expected []")
+	}
+	if payload.Filters.Statuses == nil {
+		t.Fatalf("filters.statuses is null; expected []")
 	}
 }
 
@@ -1523,6 +1539,78 @@ func TestGetPublicUsageLogs_ReturnsChannelNameWithoutSensitiveFields(t *testing.
 	}
 	if item.APIKey != "" || item.APIKeyName != "" || item.Source != "" || item.AuthIndex != "" {
 		t.Fatalf("sensitive fields not scrubbed: %+v", item)
+	}
+}
+
+func TestGetPublicUsageLogs_FiltersByDisplayedChannelName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "public-lookup-filter-auth",
+		FileName: "codex-test.json",
+		Provider: "codex",
+		Label:    "Codex 主渠道",
+		Metadata: map[string]any{"email": "owner@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	now := time.Now().UTC()
+	usage.InsertLog("sk-test", "Primary", "gpt-5.5", "owner@example.com", "owner@example.com", auth.Index, false, now, 123, 45, usage.TokenStats{TotalTokens: 3}, "", "")
+	usage.InsertLog("sk-test", "Primary", "gpt-5.5", "other", "OpenCode", "auth-other", false, now.Add(time.Second), 123, 45, usage.TokenStats{TotalTokens: 3}, "", "")
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	body := []byte(`{"api_key":"sk-test","days":7,"page":1,"size":50,"channels":["Codex 主渠道"],"statuses":["success"]}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/public/usage/logs", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.UsageLogs().GetPublicUsageLogs(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Items []struct {
+			ChannelName string `json:"channel_name"`
+		} `json:"items"`
+		Filters struct {
+			Channels []string `json:"channels"`
+			Statuses []string `json:"statuses"`
+		} `json:"filters"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Items) != 1 || payload.Items[0].ChannelName != "Codex 主渠道" {
+		t.Fatalf("items = %+v, want only Codex 主渠道", payload.Items)
+	}
+	if !containsString(payload.Filters.Channels, "Codex 主渠道") || !containsString(payload.Filters.Channels, "OpenCode") {
+		t.Fatalf("filters.channels = %#v, want linked channel options", payload.Filters.Channels)
+	}
+	if !containsString(payload.Filters.Statuses, "success") {
+		t.Fatalf("filters.statuses = %#v, want success", payload.Filters.Statuses)
 	}
 }
 

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -13,48 +13,7 @@ import (
 
 func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any, error) {
 	keyNameMap, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap := s.buildNameMaps()
-
-	selectedChannelKeys := make(map[string]struct{})
-	for _, part := range input.Channels {
-		key := strings.ToLower(strings.TrimSpace(part))
-		if key == "" {
-			continue
-		}
-		selectedChannelKeys[key] = struct{}{}
-	}
-
-	var authIndexes []string
-	var channelNames []string
-	authIndexChannelNames := make(map[string][]string)
-	if len(selectedChannelKeys) > 0 {
-		for key := range selectedChannelKeys {
-			channelNames = append(channelNames, key)
-		}
-		for raw, name := range channelNameMap {
-			key := strings.ToLower(strings.TrimSpace(name))
-			if key == "" {
-				continue
-			}
-			if _, ok := selectedChannelKeys[key]; ok {
-				channelNames = append(channelNames, raw)
-			}
-		}
-		for idx, name := range authIndexChannelMap {
-			key := strings.ToLower(strings.TrimSpace(name))
-			if key == "" {
-				continue
-			}
-			if _, ok := selectedChannelKeys[key]; ok {
-				authIndexes = append(authIndexes, idx)
-				if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
-					authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
-				}
-			}
-		}
-		if len(authIndexes) == 0 && len(channelNames) == 0 {
-			authIndexes = []string{""}
-		}
-	}
+	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap)
 
 	params := usage.LogQueryParams{
 		Page:                  input.Page,
@@ -105,27 +64,7 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 			filters.APIKeyNames[key] = name
 		}
 	}
-	if len(filters.Channels) > 0 {
-		seen := make(map[string]struct{})
-		channels := make([]string, 0, len(filters.Channels))
-		for _, value := range filters.Channels {
-			trimmed := strings.TrimSpace(value)
-			if name, ok := channelNameMap[trimmed]; ok && strings.TrimSpace(name) != "" {
-				trimmed = strings.TrimSpace(name)
-			}
-			key := strings.ToLower(trimmed)
-			if key == "" {
-				continue
-			}
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			channels = append(channels, trimmed)
-		}
-		sort.Slice(channels, func(i, j int) bool { return strings.ToLower(channels[i]) < strings.ToLower(channels[j]) })
-		filters.Channels = channels
-	}
+	filters.Channels = displayChannelFilters(filters.Channels, channelNameMap)
 
 	if result.Items == nil {
 		result.Items = make([]usage.LogRow, 0)
@@ -173,13 +112,20 @@ func (s *Service) ClearRequestLogs(options usage.ClearRequestLogsOptions) (int, 
 
 func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, error) {
 	_, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap := s.buildNameMaps()
+	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap)
 	params := usage.LogQueryParams{
-		Page:   input.Page,
-		Size:   input.Size,
-		Days:   input.Days,
-		APIKey: input.APIKey,
-		Model:  input.Model,
-		Status: input.Status,
+		Page:                  input.Page,
+		Size:                  input.Size,
+		Days:                  input.Days,
+		APIKey:                input.APIKey,
+		Models:                input.Models,
+		Statuses:              input.Statuses,
+		MatchNoModels:         input.MatchNoModels,
+		MatchNoChannels:       input.MatchNoChannels,
+		MatchNoStatuses:       input.MatchNoStatuses,
+		AuthIndexes:           authIndexes,
+		ChannelNames:          channelNames,
+		AuthIndexChannelNames: authIndexChannelNames,
 	}
 
 	result, err := usage.QueryLogs(params)
@@ -187,6 +133,10 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		return nil, err
 	}
 	stats, err := usage.QueryStats(params)
+	if err != nil {
+		return nil, err
+	}
+	filters, err := usage.QueryFiltersForLogs(params)
 	if err != nil {
 		return nil, err
 	}
@@ -204,9 +154,18 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		result.Items[i].APIKeyName = ""
 	}
 
-	models, _ := usage.QueryModelsForKey(input.APIKey, params.Days)
-	if models == nil {
-		models = make([]string, 0)
+	filters.Channels = displayChannelFilters(filters.Channels, channelNameMap)
+	if result.Items == nil {
+		result.Items = make([]usage.LogRow, 0)
+	}
+	if filters.Models == nil {
+		filters.Models = make([]string, 0)
+	}
+	if filters.Channels == nil {
+		filters.Channels = make([]string, 0)
+	}
+	if filters.Statuses == nil {
+		filters.Statuses = make([]string, 0)
 	}
 
 	return map[string]any{
@@ -217,9 +176,82 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		"stats":        stats,
 		"api_key_name": apiKeyName,
 		"filters": map[string]any{
-			"models": models,
+			"models":   filters.Models,
+			"channels": filters.Channels,
+			"statuses": filters.Statuses,
 		},
 	}, nil
+}
+
+func channelFilterSelectors(channels []string, channelNameMap, authIndexChannelMap map[string]string, ambiguousAuthIndexChannelMap map[string][]string) ([]string, []string, map[string][]string) {
+	selectedChannelKeys := make(map[string]struct{})
+	for _, part := range channels {
+		key := strings.ToLower(strings.TrimSpace(part))
+		if key == "" {
+			continue
+		}
+		selectedChannelKeys[key] = struct{}{}
+	}
+	if len(selectedChannelKeys) == 0 {
+		return nil, nil, nil
+	}
+
+	var authIndexes []string
+	var channelNames []string
+	authIndexChannelNames := make(map[string][]string)
+	for key := range selectedChannelKeys {
+		channelNames = append(channelNames, key)
+	}
+	for raw, name := range channelNameMap {
+		key := strings.ToLower(strings.TrimSpace(name))
+		if key == "" {
+			continue
+		}
+		if _, ok := selectedChannelKeys[key]; ok {
+			channelNames = append(channelNames, raw)
+		}
+	}
+	for idx, name := range authIndexChannelMap {
+		key := strings.ToLower(strings.TrimSpace(name))
+		if key == "" {
+			continue
+		}
+		if _, ok := selectedChannelKeys[key]; ok {
+			authIndexes = append(authIndexes, idx)
+			if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
+				authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
+			}
+		}
+	}
+	if len(authIndexes) == 0 && len(channelNames) == 0 {
+		authIndexes = []string{""}
+	}
+	return authIndexes, channelNames, authIndexChannelNames
+}
+
+func displayChannelFilters(values []string, channelNameMap map[string]string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	seen := make(map[string]struct{})
+	channels := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if name, ok := channelNameMap[trimmed]; ok && strings.TrimSpace(name) != "" {
+			trimmed = strings.TrimSpace(name)
+		}
+		key := strings.ToLower(trimmed)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		channels = append(channels, trimmed)
+	}
+	sort.Slice(channels, func(i, j int) bool { return strings.ToLower(channels[i]) < strings.ToLower(channels[j]) })
+	return channels
 }
 
 func (s *Service) publicAPIKeyName(apiKey string) string {

--- a/internal/management/usagelogs/types.go
+++ b/internal/management/usagelogs/types.go
@@ -17,12 +17,16 @@ type ManagementLogQueryInput struct {
 }
 
 type PublicLogQueryInput struct {
-	APIKey string
-	Model  string
-	Status string
-	Page   int
-	Size   int
-	Days   int
+	APIKey          string
+	Models          []string
+	Channels        []string
+	Statuses        []string
+	MatchNoModels   bool
+	MatchNoChannels bool
+	MatchNoStatuses bool
+	Page            int
+	Size            int
+	Days            int
 }
 
 type LogContentResponse struct {


### PR DESCRIPTION
## Summary
- accept linked model/channel/status filters for public API key lookup logs
- reuse channel display-name matching for public and management log filters
- return non-null public filter facets for models, channels, and statuses

## Validation
- rtk go test ./internal/api/handlers/management ./internal/management/usagelogs ./internal/usage