### PR TITLE
feat: automate SQLite to PostgreSQL migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/migrate-sqlite-to-postgres.sh"
+          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/migrate-sqlite-to-postgres.sh,scripts/prepare-runtime-data-stack.sh"
           target: "/opt/clirelay2/"
           overwrite: true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh"
+          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/migrate-sqlite-to-postgres.sh"
           target: "/opt/clirelay2/"
           overwrite: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ COPY --from=frontend-builder --chown=clirelay:clirelay /frontend/dist/ /CLIProxy
 
 COPY --chown=clirelay:clirelay config.example.yaml /CLIProxyAPI/config.example.yaml
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY scripts/migrate-sqlite-to-postgres.sh /usr/local/bin/migrate-sqlite-to-postgres.sh
 
 WORKDIR /CLIProxyAPI
 
@@ -98,7 +99,7 @@ ENV TZ=Asia/Shanghai \
     AUTH_PATH=/CLIProxyAPI/auths \
     CLIRELAY_LOCALE=zh
 
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/migrate-sqlite-to-postgres.sh \
   && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
   && echo "${TZ}" > /etc/timezone
 

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -18,8 +18,9 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 
 	for _, want := range []string{
 		`Upload binary and deploy script`,
-		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh"`,
+		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/migrate-sqlite-to-postgres.sh"`,
 		`scripts/deploy-blue-green.sh`,
+		`scripts/migrate-sqlite-to-postgres.sh`,
 		`target: "/opt/clirelay2/"`,
 	} {
 		if !strings.Contains(content, want) {

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -18,9 +18,10 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 
 	for _, want := range []string{
 		`Upload binary and deploy script`,
-		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/migrate-sqlite-to-postgres.sh"`,
+		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/migrate-sqlite-to-postgres.sh,scripts/prepare-runtime-data-stack.sh"`,
 		`scripts/deploy-blue-green.sh`,
 		`scripts/migrate-sqlite-to-postgres.sh`,
+		`scripts/prepare-runtime-data-stack.sh`,
 		`target: "/opt/clirelay2/"`,
 	} {
 		if !strings.Contains(content, want) {
@@ -74,6 +75,10 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("deploy script syntax failed: %v\n%s", err, out)
 	}
+	cmd = exec.Command("bash", "-n", "scripts/prepare-runtime-data-stack.sh")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("runtime data stack script syntax failed: %v\n%s", err, out)
+	}
 
 	data, err := os.ReadFile("scripts/deploy-blue-green.sh")
 	if err != nil {
@@ -87,6 +92,7 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`HEALTH_TIMEOUT_SECONDS`,
 		`MIN_AVAILABLE_MB`,
 		`NGINX_CONTAINER`,
+		`EnvironmentFile=`,
 		`docker exec "$NGINX_CONTAINER" nginx -t`,
 		`nginx -t`,
 		`DRAIN_SECONDS`,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,6 +12,7 @@ case "${1:-}" in
     if [ -e /CLIProxyAPI/config.yaml ]; then
       chown clirelay:clirelay /CLIProxyAPI/config.yaml 2>/dev/null || true
     fi
+    su-exec clirelay:clirelay /usr/local/bin/migrate-sqlite-to-postgres.sh
     exec su-exec clirelay:clirelay "$@"
     ;;
   *)

--- a/docs/postgres-redis-migration.md
+++ b/docs/postgres-redis-migration.md
@@ -14,6 +14,38 @@ For Docker Compose, the bundled `docker-compose.yml` starts `postgres:15-alpine`
 
 For non-Compose deployments, set the same values in the environment or edit `postgres.dsn` and `redis.*` in `config.yaml`.
 
+For the native `relay.07230805.xyz` style deployment, prepare the local PostgreSQL/Redis stack with one reproducible script:
+
+```bash
+BASE_DIR=/opt/clirelay2 /opt/clirelay2/scripts/prepare-runtime-data-stack.sh
+```
+
+The default `up` action creates `/opt/clirelay2/runtime-data-stack/docker-compose.yml`, writes `/opt/clirelay2/runtime-data-stack/.env`, starts `postgres:15-alpine` and `redis:7-alpine`, waits for health checks, and verifies `psql`/`redis-cli`. PostgreSQL and Redis bind only to `127.0.0.1` by default.
+
+This preparation step does not write `/opt/clirelay2/.env`, does not restart CliRelay, does not import SQLite, and does not switch the running service to PostgreSQL/Redis.
+
+Only after local checks pass and the cutover is approved, activate the generated environment for CliRelay:
+
+```bash
+BASE_DIR=/opt/clirelay2 /opt/clirelay2/scripts/prepare-runtime-data-stack.sh activate-env
+```
+
+After `activate-env`, `scripts/deploy-blue-green.sh` can read `/opt/clirelay2/.env` and run the SQLite import during the approved deploy.
+
+To tear down an unneeded test stack without deleting data, run:
+
+```bash
+BASE_DIR=/opt/clirelay2 /opt/clirelay2/scripts/prepare-runtime-data-stack.sh down
+```
+
+To reset a disposable test stack and delete its generated PostgreSQL/Redis data directories:
+
+```bash
+CLIRELAY_RUNTIME_CONFIRM_RESET=YES_DELETE_CLIRELAY_RUNTIME_DATA \
+BASE_DIR=/tmp/clirelay2-test \
+./scripts/prepare-runtime-data-stack.sh reset
+```
+
 ## Docker Compose Auto Migration
 
 For Docker Compose deployments, the default path is:

--- a/docs/postgres-redis-migration.md
+++ b/docs/postgres-redis-migration.md
@@ -14,6 +14,41 @@ For Docker Compose, the bundled `docker-compose.yml` starts `postgres:15-alpine`
 
 For non-Compose deployments, set the same values in the environment or edit `postgres.dsn` and `redis.*` in `config.yaml`.
 
+## Docker Compose Auto Migration
+
+For Docker Compose deployments, the default path is:
+
+```bash
+docker compose up -d
+```
+
+Compose starts PostgreSQL 15 and Redis 7, waits for their health checks, then the CliRelay entrypoint runs `scripts/migrate-sqlite-to-postgres.sh` before starting the API server. The script looks for a legacy SQLite database in these paths unless `CLIRELAY_SQLITE_PATH` is set:
+
+- `/CLIProxyAPI/data/usage.db`
+- `/CLIProxyAPI/usage.db`
+- `/CLIProxyAPI/logs/usage.db`
+- `./data/usage.db`
+- `./usage.db`
+- `./logs/usage.db`
+
+If no legacy SQLite file exists, the container starts normally with PostgreSQL. If a legacy SQLite file exists, `CLIRELAY_POSTGRES_DSN` is required. The script runs read-only SQLite inventory, PostgreSQL import dry-run, then apply import by default. Set `CLIRELAY_SQLITE_AUTO_IMPORT=false` to stop after dry-run, or `CLIRELAY_SQLITE_AUTO_MIGRATE=false` to skip the startup migration hook.
+
+SQLite is never deleted, moved, or written by this migration path. PostgreSQL records a source fingerprint in `sqlite_import_runs` after a successful apply. Repeated container starts skip an already imported SQLite source, and PostgreSQL advisory locking ensures concurrent starts do not import the same source twice.
+
+If migration fails, the container exits instead of starting against an empty PostgreSQL database.
+
+## Non-Docker Migration Script
+
+For non-Docker deployments, build or download the new CliRelay binary, set `CLIRELAY_POSTGRES_DSN`, then run:
+
+```bash
+CLIRELAY_BIN=/opt/clirelay2/cli-proxy-api-new \
+CLIRELAY_POSTGRES_DSN='postgres://user:pass@127.0.0.1:5432/cliproxy?sslmode=disable' \
+./scripts/migrate-sqlite-to-postgres.sh /opt/clirelay2/usage.db
+```
+
+The same script performs inventory, dry-run, apply, idempotency marking, and leaves SQLite in place.
+
 ## Deploy Gate
 
 Pushes to `dev` build the Linux binary but do not deploy to the server unless repository variable `CLIRELAY_DEV_AUTO_DEPLOY` is set to `true`. Prefer leaving it disabled for this migration and running the deploy workflow manually after PostgreSQL, Redis, SQLite import dry-run/apply, and row-count/checksum checks are complete.

--- a/internal/storage/postgres/sqliteinventory/import.go
+++ b/internal/storage/postgres/sqliteinventory/import.go
@@ -27,10 +27,12 @@ type ImportOptions struct {
 }
 
 type ImportReport struct {
-	SQLitePath string              `json:"sqlite_path"`
-	ScannedAt  time.Time           `json:"scanned_at"`
-	DryRun     bool                `json:"dry_run"`
-	Tables     []ImportTableReport `json:"tables"`
+	SQLitePath        string              `json:"sqlite_path"`
+	ScannedAt         time.Time           `json:"scanned_at"`
+	DryRun            bool                `json:"dry_run"`
+	Skipped           bool                `json:"skipped,omitempty"`
+	SourceFingerprint string              `json:"source_fingerprint"`
+	Tables            []ImportTableReport `json:"tables"`
 }
 
 type ImportTableReport struct {
@@ -94,6 +96,7 @@ func Import(ctx context.Context, opts ImportOptions) (ImportReport, error) {
 	if err != nil {
 		return ImportReport{}, err
 	}
+	sourceFingerprint := importSourceFingerprint(inventory)
 	now := opts.Now
 	if now.IsZero() {
 		now = time.Now().UTC()
@@ -108,12 +111,35 @@ func Import(ctx context.Context, opts ImportOptions) (ImportReport, error) {
 		return ImportReport{}, err
 	}
 	defer dst.Close()
+	if !opts.DryRun {
+		unlock, err := lockImport(ctx, dst)
+		if err != nil {
+			return ImportReport{}, err
+		}
+		defer unlock()
+		if err := ensureImportRunsTable(ctx, dst); err != nil {
+			return ImportReport{}, err
+		}
+		completed, err := importCompleted(ctx, dst, sourceFingerprint)
+		if err != nil {
+			return ImportReport{}, err
+		}
+		if completed {
+			return ImportReport{
+				SQLitePath:        inventory.Path,
+				ScannedAt:         now.UTC(),
+				DryRun:            opts.DryRun,
+				Skipped:           true,
+				SourceFingerprint: sourceFingerprint,
+			}, nil
+		}
+	}
 
 	sourceColumns := make(map[string][]string, len(inventory.Tables))
 	for _, table := range inventory.Tables {
 		sourceColumns[table.Name] = table.Columns
 	}
-	report := ImportReport{SQLitePath: inventory.Path, ScannedAt: now.UTC(), DryRun: opts.DryRun}
+	report := ImportReport{SQLitePath: inventory.Path, ScannedAt: now.UTC(), DryRun: opts.DryRun, SourceFingerprint: sourceFingerprint}
 	for _, table := range runtimeImportTables {
 		srcCols, ok := sourceColumns[table]
 		if !ok {
@@ -125,7 +151,88 @@ func Import(ctx context.Context, opts ImportOptions) (ImportReport, error) {
 		}
 		report.Tables = append(report.Tables, row)
 	}
+	if !opts.DryRun {
+		if err := markImportCompleted(ctx, dst, sourceFingerprint, inventory.Path, report); err != nil {
+			return ImportReport{}, err
+		}
+	}
 	return report, nil
+}
+
+func importSourceFingerprint(inventory Inventory) string {
+	tables := make(map[string]TableStats, len(inventory.Tables))
+	for _, table := range inventory.Tables {
+		tables[table.Name] = table
+	}
+	hash := sha256.New()
+	for _, name := range runtimeImportTables {
+		table, ok := tables[name]
+		if !ok {
+			continue
+		}
+		_, _ = fmt.Fprintf(hash, "%s\t%d\t%s\n", table.Name, table.RowCount, table.Checksum)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func lockImport(ctx context.Context, db *sql.DB) (func(), error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite import: reserve postgres lock connection: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock(hashtext('clirelay_sqlite_import')::bigint)`); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("sqlite import: acquire postgres advisory lock: %w", err)
+	}
+	return func() {
+		_, _ = conn.ExecContext(context.Background(), `SELECT pg_advisory_unlock(hashtext('clirelay_sqlite_import')::bigint)`)
+		_ = conn.Close()
+	}, nil
+}
+
+func ensureImportRunsTable(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS sqlite_import_runs (
+			source_fingerprint TEXT PRIMARY KEY,
+			sqlite_path TEXT NOT NULL,
+			started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			completed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			report JSONB NOT NULL DEFAULT '{}'::jsonb
+		)
+	`); err != nil {
+		return fmt.Errorf("sqlite import: create import runs table: %w", err)
+	}
+	return nil
+}
+
+func importCompleted(ctx context.Context, db *sql.DB, sourceFingerprint string) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM sqlite_import_runs
+		 WHERE source_fingerprint = ?
+	`, sourceFingerprint).Scan(&count); err != nil {
+		return false, fmt.Errorf("sqlite import: read import completion marker: %w", err)
+	}
+	return count > 0, nil
+}
+
+func markImportCompleted(ctx context.Context, db *sql.DB, sourceFingerprint, sqlitePath string, report ImportReport) error {
+	payload, err := json.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("sqlite import: marshal import report: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO sqlite_import_runs (source_fingerprint, sqlite_path, started_at, completed_at, report)
+		VALUES (?, ?, now(), now(), ?::jsonb)
+		ON CONFLICT (source_fingerprint) DO UPDATE
+		   SET sqlite_path = EXCLUDED.sqlite_path,
+		       completed_at = now(),
+		       report = EXCLUDED.report
+	`, sourceFingerprint, sqlitePath, string(payload)); err != nil {
+		return fmt.Errorf("sqlite import: mark import completed: %w", err)
+	}
+	return nil
 }
 
 func importTable(ctx context.Context, src, dst *sql.DB, table string, srcCols []string, dryRun bool) (ImportTableReport, error) {

--- a/internal/storage/postgres/sqliteinventory/import_test.go
+++ b/internal/storage/postgres/sqliteinventory/import_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ func TestImportSQLiteDryRunAndApply(t *testing.T) {
 	}
 	defer pgDB.Close()
 	if _, err := pgDB.Exec(`
+		DROP TABLE IF EXISTS sqlite_import_runs;
 		TRUNCATE
 			request_log_content,
 			request_logs,
@@ -116,6 +118,120 @@ func TestImportSQLiteDryRunAndApply(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("imported request log count = %d", count)
+	}
+	second, err := Import(ctx, opts)
+	if err != nil {
+		t.Fatalf("second apply import: %v", err)
+	}
+	if !second.Skipped {
+		t.Fatalf("second apply should use completion marker, got %#v", second)
+	}
+}
+
+func TestImportSQLiteApplyUsesPostgresLockAndCompletionMarker(t *testing.T) {
+	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	ctx := context.Background()
+	pgDB, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	defer pgDB.Close()
+	if _, err := pgDB.Exec(`
+		DROP TABLE IF EXISTS sqlite_import_runs;
+		TRUNCATE
+			request_log_content,
+			request_logs,
+			api_keys
+		RESTART IDENTITY CASCADE
+	`); err != nil {
+		t.Fatalf("reset postgres: %v", err)
+	}
+
+	sqlitePath := filepath.Join(t.TempDir(), "usage.db")
+	sqliteDB, err := sql.Open("sqlite", sqlitePath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if _, err := sqliteDB.Exec(`
+		CREATE TABLE api_keys (
+			key TEXT PRIMARY KEY,
+			id TEXT NOT NULL,
+			name TEXT NOT NULL DEFAULT '',
+			allowed_models TEXT NOT NULL DEFAULT '[]'
+		);
+		CREATE TABLE request_logs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			timestamp DATETIME NOT NULL,
+			api_key TEXT NOT NULL,
+			api_key_id TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			failed INTEGER NOT NULL DEFAULT 0,
+			total_tokens INTEGER NOT NULL DEFAULT 0
+		);
+		INSERT INTO api_keys (key, id, name, allowed_models)
+		VALUES ('fixture-key-lock', 'key-lock', 'Key Lock', '["gpt-test"]');
+		INSERT INTO request_logs (id, timestamp, api_key, api_key_id, model, failed, total_tokens)
+		VALUES (11, '2026-07-05T02:00:00Z', 'fixture-key-lock', 'key-lock', 'gpt-test', 0, 22);
+	`); err != nil {
+		t.Fatalf("seed sqlite: %v", err)
+	}
+	if err := sqliteDB.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+
+	opts := ImportOptions{
+		SQLitePath:  sqlitePath,
+		PostgresDSN: dsn,
+		DryRun:      false,
+		Now:         time.Date(2026, 7, 5, 5, 0, 0, 0, time.UTC),
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	reports := make(chan ImportReport, 2)
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			report, err := Import(ctx, opts)
+			if err != nil {
+				errs <- err
+				return
+			}
+			reports <- report
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	close(reports)
+	for err := range errs {
+		t.Fatalf("concurrent import: %v", err)
+	}
+	var applied, skipped int
+	for report := range reports {
+		if report.Skipped {
+			skipped++
+		} else {
+			applied++
+		}
+	}
+	if applied != 1 || skipped != 1 {
+		t.Fatalf("applied=%d skipped=%d, want 1/1", applied, skipped)
+	}
+	var count int
+	if err := pgDB.QueryRow("SELECT COUNT(*) FROM request_logs WHERE id = 11 AND api_key = 'fixture-key-lock'").Scan(&count); err != nil {
+		t.Fatalf("count imported request log: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("imported request log count = %d", count)
+	}
+	if err := pgDB.QueryRow("SELECT COUNT(*) FROM sqlite_import_runs").Scan(&count); err != nil {
+		t.Fatalf("count import markers: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("import marker count = %d", count)
 	}
 }
 

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -75,15 +75,49 @@ esac
 next_unit="${SERVICE_NAME}-${next_port}"
 next_bin="${BASE_DIR}/${next_unit}"
 cutover_done=0
+stopped_units_for_migration=""
 # If anything fails before nginx is switched, stop the candidate slot and keep the old service live.
 cleanup_failed_deploy() {
 	status=$?
 	if [ "$status" -ne 0 ] && [ "$cutover_done" -ne 1 ]; then
 		systemctl disable --now "$next_unit" >/dev/null 2>&1 || true
+		for unit in $stopped_units_for_migration; do
+			systemctl start "$unit" >/dev/null 2>&1 || true
+		done
 	fi
 	exit "$status"
 }
 trap cleanup_failed_deploy EXIT
+
+find_legacy_sqlite() {
+	if [ -n "${CLIRELAY_SQLITE_PATH:-}" ] && [ -f "$CLIRELAY_SQLITE_PATH" ]; then
+		echo "$CLIRELAY_SQLITE_PATH"
+		return
+	fi
+	for candidate in \
+		"${BASE_DIR}/data/usage.db" \
+		"${BASE_DIR}/usage.db" \
+		"${BASE_DIR}/logs/usage.db" \
+		"${working_dir}/data/usage.db" \
+		"${working_dir}/usage.db" \
+		"${working_dir}/logs/usage.db"
+	do
+		if [ -f "$candidate" ]; then
+			echo "$candidate"
+			return
+		fi
+	done
+	return 0
+}
+
+stop_active_units_for_migration() {
+	for unit in "$SERVICE_NAME" "${SERVICE_NAME}-${active_port}"; do
+		if systemctl is-active --quiet "$unit"; then
+			systemctl stop "$unit"
+			stopped_units_for_migration="${stopped_units_for_migration} ${unit}"
+		fi
+	done
+}
 
 available_mb="$(awk '/MemAvailable:/ {print int($2 / 1024); exit}' /proc/meminfo 2>/dev/null || true)"
 if [ -n "$available_mb" ] && [ "$available_mb" -lt "$MIN_AVAILABLE_MB" ]; then
@@ -102,6 +136,28 @@ working_dir="${working_dir:-$service_dir}"
 environment="$(read_service_property Environment)"
 user="$(read_service_property User)"
 group="$(read_service_property Group)"
+
+migration_script="${BASE_DIR}/scripts/migrate-sqlite-to-postgres.sh"
+legacy_sqlite="$(find_legacy_sqlite)"
+if [ -f "$migration_script" ]; then
+	chmod +x "$migration_script" 2>/dev/null || true
+	if [ -n "$legacy_sqlite" ]; then
+		echo "Legacy SQLite found at ${legacy_sqlite}; stopping active slot for lossless final import"
+		stop_active_units_for_migration
+		CLIRELAY_BIN="$next_bin" \
+			CLIRELAY_POSTGRES_DSN="$postgres_dsn" \
+			CLIRELAY_SQLITE_PATH="$legacy_sqlite" \
+			"$migration_script" "$legacy_sqlite"
+	else
+		CLIRELAY_BIN="$next_bin" \
+			CLIRELAY_POSTGRES_DSN="$postgres_dsn" \
+			"$migration_script"
+	fi
+elif [ -n "$legacy_sqlite" ]; then
+	fail "legacy SQLite found at ${legacy_sqlite}, but migration script is missing: ${migration_script}"
+else
+	echo "SQLite migration script not found at ${migration_script}; skipping legacy SQLite import hook"
+fi
 
 unit_file="/etc/systemd/system/${next_unit}.service"
 {

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -52,13 +52,29 @@ read_config_scalar() {
 	' "$config_path" 2>/dev/null || true
 }
 
-postgres_dsn="${CLIRELAY_POSTGRES_DSN:-$(read_config_scalar postgres dsn)}"
+read_env_scalar() {
+	[ -f "$2" ] || return 0
+	awk -F= -v key="$1" '
+		$1 == key {
+			value = substr($0, length(key) + 2)
+			gsub(/^[[:space:]"'\'']+|[[:space:]"'\'']+$/, "", value)
+			print value
+			exit
+		}
+	' "$2" 2>/dev/null || true
+}
+
+env_path="${CLIRELAY_ENV_FILE:-${BASE_DIR}/.env}"
+postgres_dsn="${CLIRELAY_POSTGRES_DSN:-$(read_env_scalar CLIRELAY_POSTGRES_DSN "$env_path")}"
+postgres_dsn="${postgres_dsn:-$(read_config_scalar postgres dsn)}"
 [ -n "$postgres_dsn" ] || fail "postgres.dsn or CLIRELAY_POSTGRES_DSN is required before deploying this runtime data stack"
 
-redis_enable="${CLIRELAY_REDIS_ENABLE:-$(read_config_scalar redis enable)}"
+redis_enable="${CLIRELAY_REDIS_ENABLE:-$(read_env_scalar CLIRELAY_REDIS_ENABLE "$env_path")}"
+redis_enable="${redis_enable:-$(read_config_scalar redis enable)}"
 case "${redis_enable,,}" in
 	true|yes|1)
-		redis_addr="${CLIRELAY_REDIS_ADDR:-$(read_config_scalar redis addr)}"
+		redis_addr="${CLIRELAY_REDIS_ADDR:-$(read_env_scalar CLIRELAY_REDIS_ADDR "$env_path")}"
+		redis_addr="${redis_addr:-$(read_config_scalar redis addr)}"
 		[ -n "$redis_addr" ] || fail "redis.addr or CLIRELAY_REDIS_ADDR is required when redis is enabled"
 		;;
 esac
@@ -170,6 +186,7 @@ unit_file="/etc/systemd/system/${next_unit}.service"
 	echo "WorkingDirectory=${working_dir}"
 	[ -n "$user" ] && echo "User=${user}"
 	[ -n "$group" ] && echo "Group=${group}"
+	[ -f "$env_path" ] && echo "EnvironmentFile=${env_path}"
 	[ -n "$environment" ] && echo "Environment=${environment}"
 	# Keep the canonical config path; only override the listen port for this deploy slot.
 	echo "Environment=CLIRELAY_PORT=${next_port} PORT=${next_port}"

--- a/scripts/migrate-sqlite-to-postgres.sh
+++ b/scripts/migrate-sqlite-to-postgres.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -eu
+
+log() {
+	printf '%s\n' "clirelay sqlite migration: $*" >&2
+}
+
+fail() {
+	log "$*"
+	exit 1
+}
+
+is_false() {
+	case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+		false|0|no|off) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+find_binary() {
+	if [ -n "${CLIRELAY_BIN:-}" ]; then
+		printf '%s\n' "$CLIRELAY_BIN"
+		return
+	fi
+	for candidate in ./CLIProxyAPI /CLIProxyAPI/CLIProxyAPI ./cli-proxy-api ./clirelay2; do
+		if [ -x "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return
+		fi
+	done
+	fail "set CLIRELAY_BIN to the CliRelay binary path"
+}
+
+find_sqlite() {
+	if [ -n "${1:-}" ]; then
+		printf '%s\n' "$1"
+		return
+	fi
+	if [ -n "${CLIRELAY_SQLITE_PATH:-}" ]; then
+		printf '%s\n' "$CLIRELAY_SQLITE_PATH"
+		return
+	fi
+	for candidate in \
+		/CLIProxyAPI/data/usage.db \
+		/CLIProxyAPI/usage.db \
+		/CLIProxyAPI/logs/usage.db \
+		./data/usage.db \
+		./usage.db \
+		./logs/usage.db
+	do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return
+		fi
+	done
+	return 0
+}
+
+if is_false "${CLIRELAY_SQLITE_AUTO_MIGRATE:-true}"; then
+	log "disabled by CLIRELAY_SQLITE_AUTO_MIGRATE"
+	exit 0
+fi
+
+sqlite_path="$(find_sqlite "${1:-}")"
+if [ -z "$sqlite_path" ]; then
+	log "no legacy usage.db found; starting with PostgreSQL runtime data"
+	exit 0
+fi
+[ -f "$sqlite_path" ] || fail "sqlite file not found: $sqlite_path"
+[ -n "${CLIRELAY_POSTGRES_DSN:-}" ] || fail "CLIRELAY_POSTGRES_DSN is required when legacy SQLite exists"
+
+bin="$(find_binary)"
+apply_import="${CLIRELAY_SQLITE_AUTO_IMPORT:-true}"
+
+log "legacy SQLite found at $sqlite_path"
+log "running read-only SQLite inventory"
+"$bin" -sqlite-dry-run "$sqlite_path"
+
+log "running PostgreSQL import dry-run"
+"$bin" -sqlite-import "$sqlite_path"
+
+if is_false "$apply_import"; then
+	log "apply disabled by CLIRELAY_SQLITE_AUTO_IMPORT; dry-run complete"
+	exit 0
+fi
+
+log "applying SQLite import into PostgreSQL"
+"$bin" -sqlite-import "$sqlite_path" -sqlite-import-dry-run=false
+log "migration complete; SQLite file was left in place"

--- a/scripts/prepare-runtime-data-stack.sh
+++ b/scripts/prepare-runtime-data-stack.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="${BASE_DIR:-/opt/clirelay2}"
+STACK_DIR="${CLIRELAY_RUNTIME_STACK_DIR:-${BASE_DIR}/runtime-data-stack}"
+STACK_ENV="${CLIRELAY_RUNTIME_STACK_ENV_FILE:-${STACK_DIR}/.env}"
+APP_ENV="${CLIRELAY_RUNTIME_ENV_FILE:-${BASE_DIR}/.env}"
+COMPOSE_FILE="${CLIRELAY_RUNTIME_COMPOSE_FILE:-${STACK_DIR}/docker-compose.yml}"
+PROJECT="${CLIRELAY_RUNTIME_COMPOSE_PROJECT:-clirelay-runtime}"
+ACTION="${1:-up}"
+
+POSTGRES_DB="${CLIRELAY_POSTGRES_DB:-cliproxy}"
+POSTGRES_USER="${CLIRELAY_POSTGRES_USER:-cliproxy}"
+POSTGRES_PORT="${CLIRELAY_POSTGRES_PORT:-55432}"
+POSTGRES_DATA_PATH="${CLIRELAY_POSTGRES_DATA_PATH:-${STACK_DIR}/postgres-data}"
+REDIS_PORT="${CLIRELAY_REDIS_PORT:-56379}"
+REDIS_DATA_PATH="${CLIRELAY_REDIS_DATA_PATH:-${STACK_DIR}/redis-data}"
+REDIS_DB="${CLIRELAY_REDIS_DB:-0}"
+
+fail() {
+	echo "$*" >&2
+	exit 1
+}
+
+file_env_value() {
+	[ -f "$2" ] || return 0
+	awk -F= -v key="$1" '
+		$1 == key {
+			value = substr($0, length(key) + 2)
+			gsub(/^[[:space:]"'\'']+|[[:space:]"'\'']+$/, "", value)
+			print value
+			exit
+		}
+	' "$2"
+}
+
+stack_env_value() {
+	file_env_value "$1" "$STACK_ENV"
+}
+
+random_hex() {
+	od -An -N24 -tx1 /dev/urandom | tr -d ' \n'
+}
+
+compose() {
+	if docker compose version >/dev/null 2>&1; then
+		docker compose --env-file "$STACK_ENV" -f "$COMPOSE_FILE" -p "$PROJECT" "$@" < /dev/null
+	elif command -v docker-compose >/dev/null 2>&1; then
+		docker-compose --env-file "$STACK_ENV" -f "$COMPOSE_FILE" -p "$PROJECT" "$@" < /dev/null
+	else
+		fail "docker compose is required"
+	fi
+}
+
+write_compose_file() {
+	mkdir -p "$STACK_DIR" "$POSTGRES_DATA_PATH" "$REDIS_DATA_PATH"
+	cat > "$COMPOSE_FILE" <<'EOF'
+services:
+  postgres:
+    image: ${CLIRELAY_POSTGRES_IMAGE:-postgres:15-alpine}
+    environment:
+      POSTGRES_DB: ${CLIRELAY_POSTGRES_DB:-cliproxy}
+      POSTGRES_USER: ${CLIRELAY_POSTGRES_USER:-cliproxy}
+      POSTGRES_PASSWORD: ${CLIRELAY_POSTGRES_PASSWORD:?CLIRELAY_POSTGRES_PASSWORD is required}
+    ports:
+      - "127.0.0.1:${CLIRELAY_POSTGRES_PORT:-55432}:5432"
+    volumes:
+      - ${CLIRELAY_POSTGRES_DATA_PATH:?CLIRELAY_POSTGRES_DATA_PATH is required}:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    restart: unless-stopped
+
+  redis:
+    image: ${CLIRELAY_REDIS_IMAGE:-redis:7-alpine}
+    command:
+      - sh
+      - -c
+      - |
+        if [ -n "$${CLIRELAY_REDIS_PASSWORD:-}" ]; then
+          exec redis-server --appendonly yes --requirepass "$${CLIRELAY_REDIS_PASSWORD}"
+        fi
+        exec redis-server --appendonly yes
+    environment:
+      CLIRELAY_REDIS_PASSWORD: ${CLIRELAY_REDIS_PASSWORD:-}
+    ports:
+      - "127.0.0.1:${CLIRELAY_REDIS_PORT:-56379}:6379"
+    volumes:
+      - ${CLIRELAY_REDIS_DATA_PATH:?CLIRELAY_REDIS_DATA_PATH is required}:/data
+    healthcheck:
+      test: ["CMD-SHELL", "if [ -n \"$${CLIRELAY_REDIS_PASSWORD:-}\" ]; then REDISCLI_AUTH=\"$${CLIRELAY_REDIS_PASSWORD}\" redis-cli ping; else redis-cli ping; fi"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    restart: unless-stopped
+EOF
+}
+
+write_stack_env_file() {
+	postgres_password="${CLIRELAY_POSTGRES_PASSWORD:-$(stack_env_value CLIRELAY_POSTGRES_PASSWORD)}"
+	postgres_password="${postgres_password:-$(random_hex)}"
+	redis_password="${CLIRELAY_REDIS_PASSWORD:-$(stack_env_value CLIRELAY_REDIS_PASSWORD)}"
+	postgres_dsn="postgres://${POSTGRES_USER}:${postgres_password}@127.0.0.1:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable"
+
+	mkdir -p "$(dirname "$STACK_ENV")"
+	tmp="$(mktemp "${STACK_ENV}.tmp.XXXXXX")"
+	if [ -f "$STACK_ENV" ]; then
+		awk '
+			/^# BEGIN CLIRELAY RUNTIME DATA STACK$/ {skip=1; next}
+			/^# END CLIRELAY RUNTIME DATA STACK$/ {skip=0; next}
+			!skip {print}
+		' "$STACK_ENV" > "$tmp"
+	fi
+	{
+		printf '%s\n' "# BEGIN CLIRELAY RUNTIME DATA STACK"
+		printf 'CLIRELAY_POSTGRES_DB=%s\n' "$POSTGRES_DB"
+		printf 'CLIRELAY_POSTGRES_USER=%s\n' "$POSTGRES_USER"
+		printf 'CLIRELAY_POSTGRES_PASSWORD=%s\n' "$postgres_password"
+		printf 'CLIRELAY_POSTGRES_PORT=%s\n' "$POSTGRES_PORT"
+		printf 'CLIRELAY_POSTGRES_DATA_PATH=%s\n' "$POSTGRES_DATA_PATH"
+		printf 'CLIRELAY_POSTGRES_DSN=%s\n' "$postgres_dsn"
+		printf 'CLIRELAY_REDIS_ENABLE=true\n'
+		printf 'CLIRELAY_REDIS_ADDR=127.0.0.1:%s\n' "$REDIS_PORT"
+		printf 'CLIRELAY_REDIS_PASSWORD=%s\n' "$redis_password"
+		printf 'CLIRELAY_REDIS_DB=%s\n' "$REDIS_DB"
+		printf 'CLIRELAY_REDIS_PORT=%s\n' "$REDIS_PORT"
+		printf 'CLIRELAY_REDIS_DATA_PATH=%s\n' "$REDIS_DATA_PATH"
+		printf '%s\n' "# END CLIRELAY RUNTIME DATA STACK"
+	} >> "$tmp"
+	chmod 600 "$tmp"
+	mv "$tmp" "$STACK_ENV"
+}
+
+activate_app_env() {
+	[ -f "$STACK_ENV" ] || fail "runtime stack env not found: $STACK_ENV"
+	mkdir -p "$(dirname "$APP_ENV")"
+	tmp="$(mktemp "${APP_ENV}.tmp.XXXXXX")"
+	if [ -f "$APP_ENV" ]; then
+		awk '
+			/^# BEGIN CLIRELAY RUNTIME DATA STACK$/ {skip=1; next}
+			/^# END CLIRELAY RUNTIME DATA STACK$/ {skip=0; next}
+			!skip {print}
+		' "$APP_ENV" > "$tmp"
+	fi
+	sed -n '/^# BEGIN CLIRELAY RUNTIME DATA STACK$/,/^# END CLIRELAY RUNTIME DATA STACK$/p' "$STACK_ENV" >> "$tmp"
+	chmod 600 "$tmp"
+	mv "$tmp" "$APP_ENV"
+	echo "activated runtime data stack env: $APP_ENV"
+}
+
+wait_healthy() {
+	service="$1"
+	for _ in $(seq 1 90); do
+		cid="$(compose ps -q "$service" 2>/dev/null || true)"
+		if [ -n "$cid" ]; then
+			status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$cid" 2>/dev/null || true)"
+			[ "$status" = "healthy" ] && return 0
+		fi
+		sleep 1
+	done
+	compose ps >&2 || true
+	fail "$service did not become healthy"
+}
+
+reset_stack() {
+	[ "${CLIRELAY_RUNTIME_CONFIRM_RESET:-}" = "YES_DELETE_CLIRELAY_RUNTIME_DATA" ] || \
+		fail "set CLIRELAY_RUNTIME_CONFIRM_RESET=YES_DELETE_CLIRELAY_RUNTIME_DATA to reset"
+	compose down --remove-orphans || true
+	rm -rf "$POSTGRES_DATA_PATH" "$REDIS_DATA_PATH"
+	echo "reset complete"
+}
+
+case "$ACTION" in
+	up)
+		write_stack_env_file
+		write_compose_file
+		compose up -d
+		wait_healthy postgres
+		wait_healthy redis
+		compose exec -T -e PGPASSWORD="$(stack_env_value CLIRELAY_POSTGRES_PASSWORD)" postgres \
+			psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -q -c 'SELECT 1' >/dev/null
+		redis_password="$(stack_env_value CLIRELAY_REDIS_PASSWORD)"
+		if [ -n "$redis_password" ]; then
+			compose exec -T -e REDISCLI_AUTH="$redis_password" redis redis-cli ping >/dev/null
+		else
+			compose exec -T redis redis-cli ping >/dev/null
+		fi
+		echo "runtime data stack is ready"
+		echo "stack env file: $STACK_ENV"
+		echo "app env file: $APP_ENV (not modified; run '$0 activate-env' to switch CliRelay)"
+		echo "compose file: $COMPOSE_FILE"
+		echo "postgres dsn: postgres://${POSTGRES_USER}:***@127.0.0.1:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable"
+		echo "redis addr: 127.0.0.1:${REDIS_PORT}"
+		;;
+	activate-env)
+		activate_app_env
+		;;
+	down)
+		compose down --remove-orphans
+		;;
+	reset)
+		reset_stack
+		;;
+	*)
+		fail "usage: $0 [up|activate-env|down|reset]"
+		;;
+esac


### PR DESCRIPTION
## Summary

- Add a bundled `scripts/migrate-sqlite-to-postgres.sh` migration hook for Docker and native deployments.
- Run the hook from `docker-entrypoint.sh` before starting CliRelay so `docker compose up -d` can import legacy `usage.db` into PostgreSQL 15+ automatically.
- Add native blue-green deploy migration handling: require PostgreSQL DSN, stop the active SQLite writer before final import, restart old units on pre-cutover failure, and fail if legacy SQLite exists but the migration script is missing.
- Make SQLite imports idempotent with a PostgreSQL `sqlite_import_runs` marker table, source fingerprinting, and a PostgreSQL advisory lock.
- Document Docker Compose auto migration and non-Docker script usage.

## Safety

- SQLite is opened read-only and is never deleted, moved, or written by the migration path.
- PostgreSQL remains the only runtime primary database.
- Redis remains limited to cache, queue, lock, rate-limit, and rebuildable derived state.
- If migration fails, Docker entrypoint exits instead of starting against an empty PostgreSQL data plane.
- Native deploy fails when legacy SQLite exists but the migration script is unavailable.

## Validation

Passed:

```bash
rtk sh -n docker-entrypoint.sh
rtk sh -n scripts/migrate-sqlite-to-postgres.sh
rtk bash -n scripts/deploy-blue-green.sh
rtk git diff --check
rtk go generate ./internal/storage/postgres/ent
CLIRELAY_POSTGRES_TEST_DSN='postgres://cliproxy:cliproxy@127.0.0.1:55432/cliproxy?sslmode=disable' rtk go test ./internal/storage/postgres/sqliteinventory -count=1 -v
CLIRELAY_POSTGRES_TEST_DSN='postgres://cliproxy:cliproxy@127.0.0.1:55432/cliproxy?sslmode=disable' CLIRELAY_REDIS_TEST_ADDR='127.0.0.1:56379' rtk go test ./internal/usage -run 'TestPostgresRuntimeDataStackIntegration|TestPostgresRuntimeDataStackConcurrencyConstraintsAndHotPaths|TestRedisRuntimeLockAndQueue|TestRedisUnavailableDoesNotBlockPostgresCRUD' -count=1 -v
rtk go test ./internal/api/... ./internal/management/... -count=1
CLIRELAY_POSTGRES_TEST_DSN='postgres://cliproxy:cliproxy@127.0.0.1:55432/cliproxy?sslmode=disable' CLIRELAY_REDIS_TEST_ADDR='127.0.0.1:56379' rtk go test ./...
rtk go vet ./...
rtk /Users/kittors/go/bin/golangci-lint run --config .golangci.yml
rtk go build -o /tmp/clirelay-auto-migration-build ./cmd/server
rtk python3 scripts/check-backend-structure.py
CLIRELAY_UPDATER_TOKEN=test-token CLI_PROXY_IMAGE=clirelay:auto-migration-runtime-test CLI_PROXY_PULL_POLICY=never rtk docker compose config
```

Script smoke tests passed against local `postgres:15-alpine` and `redis:7-alpine` containers:

- legacy SQLite present: inventory, PostgreSQL dry-run, apply import, row count check passed.
- repeated startup: request log count stayed `1`, marker count stayed `1`.
- `CLIRELAY_SQLITE_AUTO_IMPORT=false`: dry-run completed with `0` inserted rows and no marker table.
- no legacy SQLite: script exited `0` and skipped import.

Earlier local Docker Compose runtime smoke also passed using a temporary runtime image built from the same Linux binary, `docker-entrypoint.sh`, and migration script:

- `docker compose up -d` with `postgres:15-alpine`, `redis:7-alpine`, and mounted `data/usage.db` started successfully.
- `/healthz` passed.
- imported request log count was `1` and `sqlite_import_runs` count was `1`.
- app restart kept counts at `1/1` and logged skipped import.

## Known local tooling limitation

The full repository Dockerfile was not built locally because this Docker Desktop environment lacks a working `buildx`, while the legacy builder rejects `FROM --platform=$BUILDPLATFORM`. The migration path itself was verified with a temporary runtime image using the same built binary, entrypoint, and migration script.

## Remaining risk

- Production cutover still requires the server to have a valid PostgreSQL DSN, Redis config if enabled, and enough disk/memory for PostgreSQL/Redis before enabling automatic deploy.
- I did not run the migration on `relay.07230805.xyz` and did not modify production service state.
