### PR TITLE
fix: support docker runtime stack upgrades

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -551,16 +551,58 @@ func (r updaterRunReporter) Log(stream string, message string) {
 }
 
 func runComposeUpdate(ctx context.Context, composeFile string, envFile string, projectName string, service string, reporter updateReporter) error {
+	if err := ensureRuntimeDataStackConfig(composeFile, envFile); err != nil {
+		return err
+	}
 	reporter.Stage("pulling", "pulling target image")
 	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "pull", service); err != nil {
 		return err
 	}
 	reporter.Stage("restarting", "restarting service container")
-	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "--remove-orphans", service); err != nil {
+	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "--remove-orphans"); err != nil {
 		return err
 	}
 	reporter.Stage("verifying", "docker update commands completed")
 	return nil
+}
+
+func ensureRuntimeDataStackConfig(composeFile string, envFile string) error {
+	composeData, err := os.ReadFile(composeFile)
+	if strings.TrimSpace(composeFile) == "" || os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read docker compose file: %w", err)
+	}
+	composeText := string(composeData)
+	if hasComposeService(composeText, "postgres") && hasComposeService(composeText, "redis") {
+		return nil
+	}
+
+	envData, err := os.ReadFile(envFile)
+	if strings.TrimSpace(envFile) == "" || os.IsNotExist(err) {
+		return fmt.Errorf("docker compose runtime data stack is missing PostgreSQL/Redis services; run install.sh update or update docker-compose.yml before using online update")
+	}
+	if err != nil {
+		return fmt.Errorf("read docker env file: %w", err)
+	}
+	envText := string(envData)
+	if strings.Contains(envText, "CLIRELAY_POSTGRES_DSN=") &&
+		strings.Contains(envText, "CLIRELAY_REDIS_ENABLE=true") &&
+		strings.Contains(envText, "CLIRELAY_REDIS_ADDR=") {
+		return nil
+	}
+	return fmt.Errorf("docker compose runtime data stack is missing PostgreSQL/Redis services; run install.sh update or update docker-compose.yml before using online update")
+}
+
+func hasComposeService(content string, service string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == service+":" && len(line) > len(strings.TrimLeft(line, " \t")) {
+			return true
+		}
+	}
+	return false
 }
 
 func runDockerCompose(ctx context.Context, composeFile string, envFile string, projectName string, reporter updateReporter, args ...string) error {

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -444,6 +444,59 @@ func TestBuildComposeArgsIncludesProjectName(t *testing.T) {
 	}
 }
 
+func TestRunComposeUpdateStartsFullComposeStack(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "docker.log")
+	dockerPath := filepath.Join(dir, "docker")
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(dockerPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$COMPOSE_LOG\"\n"), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	if err := os.WriteFile(composePath, []byte("services:\n  clirelay:\n    image: clirelay\n  postgres:\n    image: postgres:15-alpine\n  redis:\n    image: redis:7-alpine\n"), 0o644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	if err := os.WriteFile(envPath, []byte("CLI_PROXY_IMAGE=clirelay\n"), 0o644); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("COMPOSE_LOG", logPath)
+
+	err := runComposeUpdate(context.Background(), composePath, envPath, "cliproxy", "clirelay", updaterRunReporter{})
+	if err != nil {
+		t.Fatalf("runComposeUpdate failed: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read compose log: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{
+		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " pull clirelay",
+		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --remove-orphans",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("compose commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestRunComposeUpdateRejectsLegacySQLiteComposeWithoutRuntimeStack(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(composePath, []byte("services:\n  clirelay:\n    image: clirelay\n"), 0o644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	if err := os.WriteFile(envPath, []byte("CLI_PROXY_IMAGE=clirelay\n"), 0o644); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+	err := runComposeUpdate(context.Background(), composePath, envPath, "cliproxy", "clirelay", updaterRunReporter{})
+	if err == nil || !strings.Contains(err.Error(), "runtime data stack is missing PostgreSQL/Redis") {
+		t.Fatalf("runComposeUpdate error = %v, want runtime data stack guard", err)
+	}
+}
+
 func eventually(t *testing.T, timeout time.Duration, condition func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)

--- a/install.sh
+++ b/install.sh
@@ -458,7 +458,8 @@ host: ""
 port: ${CFG_PORT}
 
 redis:
-  enable: false
+  enable: true
+  addr: redis:6379
 
 remote-management:
   allow-remote: ${CFG_REMOTE}
@@ -489,6 +490,17 @@ YAML
 }
 
 write_env() {
+    local updater_token postgres_db postgres_user postgres_password postgres_dsn postgres_data_path redis_addr redis_password redis_db redis_data_path
+    updater_token="${CLIRELAY_UPDATER_TOKEN:-$(rand_hex 16)}"
+    postgres_db="${CLIRELAY_POSTGRES_DB:-cliproxy}"
+    postgres_user="${CLIRELAY_POSTGRES_USER:-cliproxy}"
+    postgres_password="${CLIRELAY_POSTGRES_PASSWORD:-$(rand_hex 16)}"
+    postgres_dsn="${CLIRELAY_POSTGRES_DSN:-postgres://${postgres_user}:${postgres_password}@postgres:5432/${postgres_db}?sslmode=disable}"
+    postgres_data_path="${CLIRELAY_POSTGRES_DATA_PATH:-${INSTALL_DIR}/postgres-data}"
+    redis_addr="${CLIRELAY_REDIS_ADDR:-redis:6379}"
+    redis_password="${CLIRELAY_REDIS_PASSWORD:-}"
+    redis_db="${CLIRELAY_REDIS_DB:-0}"
+    redis_data_path="${CLIRELAY_REDIS_DATA_PATH:-${INSTALL_DIR}/redis-data}"
     cat >"${INSTALL_DIR}/.env" <<EOF
 CLI_PROXY_IMAGE=${CLI_PROXY_IMAGE:-$DOCKER_IMAGE_DEFAULT}
 CLI_PROXY_PLATFORM=${DOCKER_PLATFORM}
@@ -500,9 +512,19 @@ CLIRELAY_LANGUAGE=$(language_tag)
 CLIRELAY_PORT=${CFG_PORT}
 CLIRELAY_UPDATE_CHANNEL=main
 CLIRELAY_UPDATER_URL=http://clirelay-updater:8320
-CLIRELAY_UPDATER_TOKEN=$(rand_hex 16)
+CLIRELAY_UPDATER_TOKEN=${updater_token}
 CLIRELAY_TARGET_SERVICE=clirelay
 CLIRELAY_COMPOSE_PROJECT_NAME=$(basename "${INSTALL_DIR}")
+CLIRELAY_POSTGRES_DB=${postgres_db}
+CLIRELAY_POSTGRES_USER=${postgres_user}
+CLIRELAY_POSTGRES_PASSWORD=${postgres_password}
+CLIRELAY_POSTGRES_DSN=${postgres_dsn}
+CLIRELAY_POSTGRES_DATA_PATH=${postgres_data_path}
+CLIRELAY_REDIS_ENABLE=true
+CLIRELAY_REDIS_ADDR=${redis_addr}
+CLIRELAY_REDIS_PASSWORD=${redis_password}
+CLIRELAY_REDIS_DB=${redis_db}
+CLIRELAY_REDIS_DATA_PATH=${redis_data_path}
 CLI_PROXY_CONFIG_PATH=${INSTALL_DIR}/config.yaml
 CLI_PROXY_AUTH_PATH=${INSTALL_DIR}/auths
 AUTH_PATH=/root/.cli-proxy-api
@@ -534,6 +556,11 @@ services:
       CLIRELAY_UPDATER_URL: ${CLIRELAY_UPDATER_URL}
       CLIRELAY_UPDATER_TOKEN: ${CLIRELAY_UPDATER_TOKEN}
       CLIRELAY_TARGET_SERVICE: ${CLIRELAY_TARGET_SERVICE}
+      CLIRELAY_POSTGRES_DSN: ${CLIRELAY_POSTGRES_DSN}
+      CLIRELAY_REDIS_ENABLE: ${CLIRELAY_REDIS_ENABLE}
+      CLIRELAY_REDIS_ADDR: ${CLIRELAY_REDIS_ADDR}
+      CLIRELAY_REDIS_PASSWORD: ${CLIRELAY_REDIS_PASSWORD}
+      CLIRELAY_REDIS_DB: ${CLIRELAY_REDIS_DB}
       AUTH_PATH: ${AUTH_PATH}
       LANG: ${CLIRELAY_LANG}
       LANGUAGE: ${CLIRELAY_LANGUAGE}
@@ -545,6 +572,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
 
   clirelay-updater:
@@ -561,6 +593,33 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker-compose.yml:${CLIRELAY_INSTALL_DIR}/docker-compose.yml:ro
       - ./.env:${CLIRELAY_INSTALL_DIR}/.env
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: ${CLIRELAY_POSTGRES_DB}
+      POSTGRES_USER: ${CLIRELAY_POSTGRES_USER}
+      POSTGRES_PASSWORD: ${CLIRELAY_POSTGRES_PASSWORD}
+    volumes:
+      - ${CLIRELAY_POSTGRES_DATA_PATH}:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - ${CLIRELAY_REDIS_DATA_PATH}:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     restart: unless-stopped
 YAML
 }
@@ -894,7 +953,7 @@ main() {
     check_docker
 
     step 3 "$(is_zh && echo "准备配置与部署元数据" || echo "Preparing configuration and deployment metadata")"
-    mkdir -p "${INSTALL_DIR}" "${INSTALL_DIR}/auths" "${INSTALL_DIR}/logs" "${INSTALL_DIR}/data"
+    mkdir -p "${INSTALL_DIR}" "${INSTALL_DIR}/auths" "${INSTALL_DIR}/logs" "${INSTALL_DIR}/data" "${INSTALL_DIR}/postgres-data" "${INSTALL_DIR}/redis-data"
     if [[ "${OS_NAME}" != "Darwin" ]]; then
         chown -R 10001:10001 "${INSTALL_DIR}/auths" "${INSTALL_DIR}/logs" "${INSTALL_DIR}/data" || warn "Could not chown data directories; the container entrypoint will retry at startup."
     fi

--- a/install_compose_test.go
+++ b/install_compose_test.go
@@ -88,3 +88,39 @@ func TestInstallComposeMirrorsDeploymentFilesAtHostPathInUpdater(t *testing.T) {
 		}
 	}
 }
+
+func TestInstallComposeIncludesRuntimeDataStack(t *testing.T) {
+	data, err := os.ReadFile("install.sh")
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+	content := string(data)
+
+	for _, want := range []string{
+		`updater_token="${CLIRELAY_UPDATER_TOKEN:-$(rand_hex 16)}"`,
+		`postgres_db="${CLIRELAY_POSTGRES_DB:-cliproxy}"`,
+		`postgres_user="${CLIRELAY_POSTGRES_USER:-cliproxy}"`,
+		`postgres_password="${CLIRELAY_POSTGRES_PASSWORD:-$(rand_hex 16)}"`,
+		`postgres_dsn="${CLIRELAY_POSTGRES_DSN:-postgres://${postgres_user}:${postgres_password}@postgres:5432/${postgres_db}?sslmode=disable}"`,
+		`redis_addr="${CLIRELAY_REDIS_ADDR:-redis:6379}"`,
+		`redis_db="${CLIRELAY_REDIS_DB:-0}"`,
+		"CLIRELAY_UPDATER_TOKEN=${updater_token}",
+		"CLIRELAY_POSTGRES_DB=${postgres_db}",
+		"CLIRELAY_POSTGRES_USER=${postgres_user}",
+		"CLIRELAY_POSTGRES_DSN=${postgres_dsn}",
+		"CLIRELAY_REDIS_ENABLE=true",
+		"CLIRELAY_REDIS_ADDR=${redis_addr}",
+		"CLIRELAY_REDIS_DB=${redis_db}",
+		"CLIRELAY_POSTGRES_DATA_PATH=${postgres_data_path}",
+		"CLIRELAY_REDIS_DATA_PATH=${redis_data_path}",
+		"CLIRELAY_POSTGRES_DSN: ${CLIRELAY_POSTGRES_DSN}",
+		"CLIRELAY_REDIS_ENABLE: ${CLIRELAY_REDIS_ENABLE}",
+		"postgres:\n    image: postgres:15-alpine",
+		"redis:\n    image: redis:7-alpine",
+		"depends_on:\n      postgres:\n        condition: service_healthy\n      redis:\n        condition: service_healthy",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("install.sh missing runtime data stack text %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- make the Docker updater restart the full compose stack so newly added PostgreSQL/Redis services are created during online updates
- add a runtime data-stack guard for legacy SQLite-only compose/env files so `/manage/system` online update fails safely instead of restarting into a broken PG/Redis-less stack
- update `install.sh` generated Docker deployment to include PostgreSQL 15 + Redis 7, enable Redis in generated config, and preserve existing `.env` secrets/custom DB values during updates
- add regression tests for updater compose behavior, legacy compose guard, and install-generated runtime stack config

## Verification
- `rtk bash -n install.sh scripts/migrate-sqlite-to-postgres.sh docker-entrypoint.sh` ✅
- `rtk go test ./cmd/updater` ✅ `14 passed in 1 packages`
- `rtk go test ./ -run 'Test.*Compose|TestInstall.*'` ✅ `9 passed in 1 packages`
- `rtk go test ./internal/storage/postgres/sqliteinventory ./cmd/updater` ✅ `15 passed in 2 packages`
- `rtk go test ./...` ✅ `2488 passed in 177 packages`
- Current-branch Docker smoke ✅ `api_count=1 request_log_count=1 import_marker_count=1 redis_ping=PONG sqlite_exists=yes updater_health={"error":"","status":"idle"}`

## Notes / Residual Risk
- Full repository `Dockerfile` build with the local Docker legacy builder failed because this machine lacks the `docker buildx` component required by `FROM --platform=$BUILDPLATFORM`. To keep validation meaningful, I built current Linux/arm64 `CLIProxyAPI` and `clirelay-updater` binaries and overlaid them onto the existing migration smoke image before running the Docker smoke.
- A truly old Docker compose file that does not define PostgreSQL/Redis cannot be magically rewritten by the updater sidecar through `/manage/system`; this PR makes that path fail safely with an explicit runtime data-stack error. Users should run the updated `install.sh` update path or update their compose file first, then online updates can bring up the full stack.
