### PR TITLE
fix: keep dev deploy blue-green only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/migrate-sqlite-to-postgres.sh,scripts/prepare-runtime-data-stack.sh"
+          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh"
           target: "/opt/clirelay2/"
           overwrite: true
 

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -18,10 +18,8 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 
 	for _, want := range []string{
 		`Upload binary and deploy script`,
-		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/migrate-sqlite-to-postgres.sh,scripts/prepare-runtime-data-stack.sh"`,
+		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh"`,
 		`scripts/deploy-blue-green.sh`,
-		`scripts/migrate-sqlite-to-postgres.sh`,
-		`scripts/prepare-runtime-data-stack.sh`,
 		`target: "/opt/clirelay2/"`,
 	} {
 		if !strings.Contains(content, want) {
@@ -32,6 +30,8 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 	for _, forbidden := range []string{
 		`Upload panel assets`,
 		`source: "manage.html,management.html,assets"`,
+		`scripts/migrate-sqlite-to-postgres.sh`,
+		`scripts/prepare-runtime-data-stack.sh`,
 		`PANEL_SRC=`,
 		`PANEL_DIR=`,
 		`relay-panel`,
@@ -75,10 +75,6 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("deploy script syntax failed: %v\n%s", err, out)
 	}
-	cmd = exec.Command("bash", "-n", "scripts/prepare-runtime-data-stack.sh")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("runtime data stack script syntax failed: %v\n%s", err, out)
-	}
 
 	data, err := os.ReadFile("scripts/deploy-blue-green.sh")
 	if err != nil {
@@ -100,6 +96,17 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("deploy script missing guard %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		`migrate-sqlite-to-postgres.sh`,
+		`Legacy SQLite`,
+		`stop_active_units_for_migration`,
+		`CLIRELAY_SQLITE_PATH`,
+		`usage.db`,
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("deploy script must not run legacy SQLite migration during blue-green deploy, found %q", forbidden)
 		}
 	}
 }

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -91,49 +91,15 @@ esac
 next_unit="${SERVICE_NAME}-${next_port}"
 next_bin="${BASE_DIR}/${next_unit}"
 cutover_done=0
-stopped_units_for_migration=""
 # If anything fails before nginx is switched, stop the candidate slot and keep the old service live.
 cleanup_failed_deploy() {
 	status=$?
 	if [ "$status" -ne 0 ] && [ "$cutover_done" -ne 1 ]; then
 		systemctl disable --now "$next_unit" >/dev/null 2>&1 || true
-		for unit in $stopped_units_for_migration; do
-			systemctl start "$unit" >/dev/null 2>&1 || true
-		done
 	fi
 	exit "$status"
 }
 trap cleanup_failed_deploy EXIT
-
-find_legacy_sqlite() {
-	if [ -n "${CLIRELAY_SQLITE_PATH:-}" ] && [ -f "$CLIRELAY_SQLITE_PATH" ]; then
-		echo "$CLIRELAY_SQLITE_PATH"
-		return
-	fi
-	for candidate in \
-		"${BASE_DIR}/data/usage.db" \
-		"${BASE_DIR}/usage.db" \
-		"${BASE_DIR}/logs/usage.db" \
-		"${working_dir}/data/usage.db" \
-		"${working_dir}/usage.db" \
-		"${working_dir}/logs/usage.db"
-	do
-		if [ -f "$candidate" ]; then
-			echo "$candidate"
-			return
-		fi
-	done
-	return 0
-}
-
-stop_active_units_for_migration() {
-	for unit in "$SERVICE_NAME" "${SERVICE_NAME}-${active_port}"; do
-		if systemctl is-active --quiet "$unit"; then
-			systemctl stop "$unit"
-			stopped_units_for_migration="${stopped_units_for_migration} ${unit}"
-		fi
-	done
-}
 
 available_mb="$(awk '/MemAvailable:/ {print int($2 / 1024); exit}' /proc/meminfo 2>/dev/null || true)"
 if [ -n "$available_mb" ] && [ "$available_mb" -lt "$MIN_AVAILABLE_MB" ]; then
@@ -152,28 +118,6 @@ working_dir="${working_dir:-$service_dir}"
 environment="$(read_service_property Environment)"
 user="$(read_service_property User)"
 group="$(read_service_property Group)"
-
-migration_script="${BASE_DIR}/scripts/migrate-sqlite-to-postgres.sh"
-legacy_sqlite="$(find_legacy_sqlite)"
-if [ -f "$migration_script" ]; then
-	chmod +x "$migration_script" 2>/dev/null || true
-	if [ -n "$legacy_sqlite" ]; then
-		echo "Legacy SQLite found at ${legacy_sqlite}; stopping active slot for lossless final import"
-		stop_active_units_for_migration
-		CLIRELAY_BIN="$next_bin" \
-			CLIRELAY_POSTGRES_DSN="$postgres_dsn" \
-			CLIRELAY_SQLITE_PATH="$legacy_sqlite" \
-			"$migration_script" "$legacy_sqlite"
-	else
-		CLIRELAY_BIN="$next_bin" \
-			CLIRELAY_POSTGRES_DSN="$postgres_dsn" \
-			"$migration_script"
-	fi
-elif [ -n "$legacy_sqlite" ]; then
-	fail "legacy SQLite found at ${legacy_sqlite}, but migration script is missing: ${migration_script}"
-else
-	echo "SQLite migration script not found at ${migration_script}; skipping legacy SQLite import hook"
-fi
 
 unit_file="/etc/systemd/system/${next_unit}.service"
 {


### PR DESCRIPTION
## Summary
- stop uploading legacy SQLite migration/runtime preparation scripts in dev deploy
- remove legacy SQLite migration stop-the-active-slot path from blue-green deploy
- add guard tests so dev deploy stays binary + blue-green only

## Tests
- rtk bash -n scripts/deploy-blue-green.sh
- rtk go test .