### PR TITLE
feat: add Ollama Cloud provider

### DIFF
--- a/internal/api/handlers/management/provider_settings.go
+++ b/internal/api/handlers/management/provider_settings.go
@@ -407,6 +407,84 @@ func (h *ProviderKeysHandler) DeleteClineKey(c *gin.Context) {
 	c.JSON(400, gin.H{"error": "missing api-key, name, or index"})
 }
 
+// ollama-cloud-api-key: []OllamaCloudKey
+func (h *ProviderKeysHandler) GetOllamaCloudKeys(c *gin.Context) {
+	c.JSON(200, gin.H{"ollama-cloud-api-key": providerSettingsService(h).OllamaCloudKeys()})
+}
+
+func (h *ProviderKeysHandler) PutOllamaCloudKeys(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var arr []config.OllamaCloudKey
+	if err = json.Unmarshal(data, &arr); err != nil {
+		var obj struct {
+			Items []config.OllamaCloudKey `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		arr = obj.Items
+	}
+	if err := providerSettingsService(h).ReplaceOllamaCloudKeys(arr); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	h.persist(c)
+}
+
+func (h *ProviderKeysHandler) PatchOllamaCloudKey(c *gin.Context) {
+	var body struct {
+		APIKey *string                            `json:"api-key"`
+		Name   *string                            `json:"name"`
+		Index  *int                               `json:"index"`
+		Value  *providersettings.OllamaCloudPatch `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	if err := providerSettingsService(h).PatchOllamaCloudKey(body.Index, body.APIKey, body.Name, *body.Value); err != nil {
+		if errors.Is(err, providersettings.ErrItemNotFound) {
+			c.JSON(404, gin.H{"error": "item not found"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	h.persist(c)
+}
+
+func (h *ProviderKeysHandler) DeleteOllamaCloudKey(c *gin.Context) {
+	if apiKey := strings.TrimSpace(c.Query("api-key")); apiKey != "" {
+		if providerSettingsService(h).DeleteOllamaCloudKeyByAPIKey(apiKey) {
+			h.persist(c)
+			return
+		}
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+	if name := strings.TrimSpace(c.Query("name")); name != "" {
+		if providerSettingsService(h).DeleteOllamaCloudKeyByName(name) {
+			h.persist(c)
+			return
+		}
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+	if idxStr := c.Query("index"); idxStr != "" {
+		var idx int
+		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && providerSettingsService(h).DeleteOllamaCloudKeyByIndex(idx) {
+			h.persist(c)
+			return
+		}
+	}
+	c.JSON(400, gin.H{"error": "missing api-key, name, or index"})
+}
+
 // openai-compatibility: []OpenAICompatibility
 func (h *ProviderKeysHandler) GetOpenAICompat(c *gin.Context) {
 	c.JSON(200, gin.H{"openai-compatibility": providerSettingsService(h).OpenAICompatibility()})

--- a/internal/api/routes/management_keys_routes.go
+++ b/internal/api/routes/management_keys_routes.go
@@ -49,6 +49,11 @@ func registerManagementProviderRoutes(group *gin.RouterGroup, h *managementhandl
 	group.PATCH("/cline-api-key", keys.PatchClineKey)
 	group.DELETE("/cline-api-key", keys.DeleteClineKey)
 
+	group.GET("/ollama-cloud-api-key", keys.GetOllamaCloudKeys)
+	group.PUT("/ollama-cloud-api-key", keys.PutOllamaCloudKeys)
+	group.PATCH("/ollama-cloud-api-key", keys.PatchOllamaCloudKey)
+	group.DELETE("/ollama-cloud-api-key", keys.DeleteOllamaCloudKey)
+
 	group.GET("/codex-api-key", keys.GetCodexKeys)
 	group.PUT("/codex-api-key", keys.PutCodexKeys)
 	group.PATCH("/codex-api-key", keys.PatchCodexKey)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -25,7 +25,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 222; got != want {
+	if got, want := len(routes), 226; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -48,6 +48,10 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"PUT /v0/management/cline-api-key",
 		"PATCH /v0/management/cline-api-key",
 		"DELETE /v0/management/cline-api-key",
+		"GET /v0/management/ollama-cloud-api-key",
+		"PUT /v0/management/ollama-cloud-api-key",
+		"PATCH /v0/management/ollama-cloud-api-key",
+		"DELETE /v0/management/ollama-cloud-api-key",
 		"GET /v0/management/auth-files/models",
 		"GET /v0/management/image-generation/size-presets",
 		"PUT /v0/management/image-generation/size-presets",
@@ -111,6 +115,7 @@ func expectedManagementRoutes() []string {
 		"DELETE /v0/management/model-configs/*id",
 		"DELETE /v0/management/oauth-excluded-models",
 		"DELETE /v0/management/oauth-model-alias",
+		"DELETE /v0/management/ollama-cloud-api-key",
 		"DELETE /v0/management/opencode-go-api-key",
 		"DELETE /v0/management/openai-compatibility",
 		"DELETE /v0/management/proxy-url",
@@ -174,6 +179,7 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/models/configured-availability",
 		"GET /v0/management/oauth-excluded-models",
 		"GET /v0/management/oauth-model-alias",
+		"GET /v0/management/ollama-cloud-api-key",
 		"GET /v0/management/opencode-go-api-key",
 		"GET /v0/management/openai-compatibility",
 		"GET /v0/management/proxy-pool",
@@ -237,6 +243,7 @@ func expectedManagementRoutes() []string {
 		"PATCH /v0/management/max-retry-interval",
 		"PATCH /v0/management/oauth-excluded-models",
 		"PATCH /v0/management/oauth-model-alias",
+		"PATCH /v0/management/ollama-cloud-api-key",
 		"PATCH /v0/management/opencode-go-api-key",
 		"PATCH /v0/management/openai-compatibility",
 		"PATCH /v0/management/proxy-pool/:id",
@@ -303,6 +310,7 @@ func expectedManagementRoutes() []string {
 		"PUT /v0/management/model-pricing",
 		"PUT /v0/management/oauth-excluded-models",
 		"PUT /v0/management/oauth-model-alias",
+		"PUT /v0/management/ollama-cloud-api-key",
 		"PUT /v0/management/opencode-go-api-key",
 		"PUT /v0/management/openai-compatibility",
 		"PUT /v0/management/proxy-pool",

--- a/internal/app/service/runtime_access.go
+++ b/internal/app/service/runtime_access.go
@@ -45,7 +45,7 @@ func ConfigureServiceAccess(cfg *config.Config, accessManager *sdkaccess.Manager
 	accessManager.SetProviders(sdkaccess.RegisteredProviders())
 }
 
-func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int) {
+func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int, int) {
 	return watcher.BuildAPIKeyClients(cfg)
 }
 

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -94,6 +94,8 @@ func syncConfigDerivedAuthModels(cfg *config.Config, auth *coreauth.Auth) {
 	switch strings.ToLower(strings.TrimSpace(auth.Provider)) {
 	case "opencode-go":
 		syncOpenCodeGoConfigAuthModels(reg, cfg, auth)
+	case "ollama-cloud":
+		syncOllamaCloudConfigAuthModels(reg, cfg, auth)
 	}
 }
 
@@ -163,6 +165,89 @@ func buildOpenCodeGoConfigModels(models []config.OpenCodeGoModel, staticModels [
 			Created:     now,
 			OwnedBy:     "opencode",
 			Type:        "opencode-go",
+			DisplayName: name,
+			UserDefined: true,
+		})
+	}
+	return out
+}
+
+func syncOllamaCloudConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.Config, auth *coreauth.Auth) {
+	entry := resolveConfigOllamaCloudKey(cfg, auth)
+	if entry == nil {
+		reg.UnregisterClient(auth.ID)
+		return
+	}
+	models := sdkmodelcatalog.StaticModelDefinitionsByChannel("ollama-cloud")
+	if len(entry.Models) > 0 {
+		models = buildOllamaCloudConfigModels(entry.Models, models)
+	}
+	models = applyConfigModelExclusions(models, entry.ExcludedModels)
+	reg.RegisterClient(auth.ID, "ollama-cloud", applyConfigModelPrefixes(models, auth.Prefix, cfg.ForceModelPrefix))
+}
+
+func resolveConfigOllamaCloudKey(cfg *config.Config, auth *coreauth.Auth) *config.OllamaCloudKey {
+	if cfg == nil || auth == nil || auth.Attributes == nil {
+		return nil
+	}
+	attrKey := strings.TrimSpace(auth.Attributes["api_key"])
+	attrBase := strings.TrimSpace(auth.Attributes["base_url"])
+	if attrKey == "" {
+		return nil
+	}
+	for i := range cfg.OllamaCloudKey {
+		entry := &cfg.OllamaCloudKey[i]
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if cfgBase == "" {
+			cfgBase = config.DefaultOllamaCloudBaseURL
+		}
+		if strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) && (attrBase == "" || strings.EqualFold(cfgBase, attrBase)) {
+			return entry
+		}
+	}
+	return nil
+}
+
+func buildOllamaCloudConfigModels(models []config.OllamaCloudModel, staticModels []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	staticByID := make(map[string]*sdkmodelcatalog.ModelInfo, len(staticModels))
+	for _, model := range staticModels {
+		if model == nil {
+			continue
+		}
+		if id := strings.ToLower(strings.TrimSpace(model.ID)); id != "" {
+			staticByID[id] = model
+		}
+	}
+
+	now := time.Now().Unix()
+	seen := make(map[string]struct{}, len(models))
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for i := range models {
+		name := strings.TrimSpace(models[i].Name)
+		alias := strings.TrimSpace(models[i].Alias)
+		if alias == "" {
+			alias = name
+		}
+		if alias == "" {
+			continue
+		}
+		key := strings.ToLower(alias)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		if model := staticByID[strings.ToLower(name)]; model != nil && strings.EqualFold(name, alias) {
+			clone := *model
+			clone.UserDefined = true
+			out = append(out, &clone)
+			continue
+		}
+		out = append(out, &sdkmodelcatalog.ModelInfo{
+			ID:          alias,
+			Object:      "model",
+			Created:     now,
+			OwnedBy:     "ollama",
+			Type:        "ollama-cloud",
 			DisplayName: name,
 			UserDefined: true,
 		})
@@ -326,6 +411,8 @@ func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, 
 		coreManager.RegisterExecutor(executor.NewBedrockExecutor(cfg))
 	case "opencode-go":
 		coreManager.RegisterExecutor(executor.NewOpenCodeGoExecutor(cfg))
+	case "ollama-cloud":
+		coreManager.RegisterExecutor(executor.NewOllamaCloudExecutor(cfg))
 	case "qwen":
 		coreManager.RegisterExecutor(executor.NewQwenExecutor(cfg))
 	case "iflow":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,6 +127,9 @@ type Config struct {
 	// ClineKey defines ClinePass API key configurations.
 	ClineKey []ClineKey `yaml:"cline-api-key" json:"cline-api-key"`
 
+	// OllamaCloudKey defines Ollama Cloud API key configurations.
+	OllamaCloudKey []OllamaCloudKey `yaml:"ollama-cloud-api-key" json:"ollama-cloud-api-key"`
+
 	// ClaudeHeaderDefaults configures default header values for Claude API requests.
 	// These are used as fallbacks when the client does not send its own headers.
 	ClaudeHeaderDefaults ClaudeHeaderDefaults `yaml:"claude-header-defaults" json:"claude-header-defaults"`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -118,6 +118,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.SanitizeClaudeKeys()
 	cfg.SanitizeOpenCodeGoKeys()
 	cfg.SanitizeClineKeys()
+	cfg.SanitizeOllamaCloudKeys()
 	cfg.SanitizeGeminiKeys()
 	cfg.SanitizeProxyWarmup()
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -317,6 +317,67 @@ func normalizeClineBaseURL(baseURL string) string {
 	return strings.TrimSuffix(base, "/")
 }
 
+// SanitizeOllamaCloudKeys deduplicates and normalizes Ollama Cloud credentials.
+func (cfg *Config) SanitizeOllamaCloudKeys() {
+	if cfg == nil || len(cfg.OllamaCloudKey) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(cfg.OllamaCloudKey))
+	out := make([]OllamaCloudKey, 0, len(cfg.OllamaCloudKey))
+	for i := range cfg.OllamaCloudKey {
+		entry := cfg.OllamaCloudKey[i]
+		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		if entry.APIKey == "" {
+			continue
+		}
+		entry.BaseURL = normalizeOllamaCloudBaseURL(entry.BaseURL)
+		seenKey := entry.APIKey + "\x00" + entry.BaseURL
+		if _, exists := seen[seenKey]; exists {
+			continue
+		}
+		seen[seenKey] = struct{}{}
+		entry.Name = strings.TrimSpace(entry.Name)
+		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+		entry.Headers = NormalizeHeaders(entry.Headers)
+		entry.Models = NormalizeOllamaCloudModels(entry.Models)
+		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		out = append(out, entry)
+	}
+	cfg.OllamaCloudKey = out
+}
+
+func NormalizeOllamaCloudModels(models []OllamaCloudModel) []OllamaCloudModel {
+	if len(models) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(models))
+	out := make([]OllamaCloudModel, 0, len(models))
+	for i := range models {
+		name := strings.TrimSpace(models[i].Name)
+		if name == "" {
+			continue
+		}
+		alias := strings.TrimSpace(models[i].Alias)
+		key := strings.ToLower(name)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, OllamaCloudModel{Name: name, Alias: alias})
+	}
+	return out
+}
+
+func normalizeOllamaCloudBaseURL(baseURL string) string {
+	base := strings.TrimSpace(baseURL)
+	if base == "" {
+		return DefaultOllamaCloudBaseURL
+	}
+	return strings.TrimSuffix(base, "/")
+}
+
 // SanitizeGeminiKeys deduplicates and normalizes Gemini credentials.
 func (cfg *Config) SanitizeGeminiKeys() {
 	if cfg == nil {

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -314,3 +314,46 @@ type ClineModel struct {
 
 func (m ClineModel) GetName() string  { return m.Name }
 func (m ClineModel) GetAlias() string { return m.Alias }
+
+const DefaultOllamaCloudBaseURL = "https://ollama.com"
+
+// OllamaCloudKey represents an Ollama Cloud API key.
+type OllamaCloudKey struct {
+	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// Name is a human-readable label for this channel.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
+	// Priority controls selection preference when multiple credentials match.
+	// Higher values are preferred; defaults to 0.
+	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Prefix optionally namespaces models for this credential.
+	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// BaseURL is the Ollama API host. Defaults to DefaultOllamaCloudBaseURL.
+	BaseURL string `yaml:"base-url,omitempty" json:"base-url,omitempty"`
+
+	// ProxyURL overrides the global proxy setting for this API key if provided.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+
+	// ProxyID references a reusable proxy-pool entry. When valid, it takes precedence over ProxyURL.
+	ProxyID string `yaml:"proxy-id,omitempty" json:"proxy-id,omitempty"`
+
+	// Models defines upstream Ollama model IDs and optional client-facing aliases.
+	Models []OllamaCloudModel `yaml:"models,omitempty" json:"models,omitempty"`
+
+	// Headers optionally adds extra HTTP headers for requests sent with this key.
+	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+
+	// ExcludedModels lists model IDs that should be excluded for this provider.
+	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+}
+
+type OllamaCloudModel struct {
+	Name  string `yaml:"name" json:"name"`
+	Alias string `yaml:"alias,omitempty" json:"alias,omitempty"`
+}
+
+func (m OllamaCloudModel) GetName() string  { return m.Name }
+func (m OllamaCloudModel) GetAlias() string { return m.Alias }

--- a/internal/config/sdkbridge/bridge.go
+++ b/internal/config/sdkbridge/bridge.go
@@ -32,6 +32,10 @@ type BedrockKey = coreconfig.BedrockKey
 type BedrockModel = coreconfig.BedrockModel
 type OpenCodeGoKey = coreconfig.OpenCodeGoKey
 type OpenCodeGoModel = coreconfig.OpenCodeGoModel
+type ClineKey = coreconfig.ClineKey
+type ClineModel = coreconfig.ClineModel
+type OllamaCloudKey = coreconfig.OllamaCloudKey
+type OllamaCloudModel = coreconfig.OllamaCloudModel
 type VertexCompatKey = coreconfig.VertexCompatKey
 type VertexCompatModel = coreconfig.VertexCompatModel
 type OpenAICompatibility = coreconfig.OpenAICompatibility
@@ -43,6 +47,8 @@ type TLS = coreconfig.TLSConfig
 const (
 	DefaultPanelGitHubRepository = coreconfig.DefaultPanelGitHubRepository
 	DefaultBedrockRegion         = coreconfig.DefaultBedrockRegion
+	DefaultClineBaseURL          = coreconfig.DefaultClineBaseURL
+	DefaultOllamaCloudBaseURL    = coreconfig.DefaultOllamaCloudBaseURL
 )
 
 func LoadConfig(configFile string) (*Config, error) { return coreconfig.LoadConfig(configFile) }

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -609,6 +609,192 @@ func NormalizedClineKeyEntries(entries []config.ClineKey) []config.ClineKey {
 	return out
 }
 
+type OllamaCloudPatch struct {
+	APIKey         *string                    `json:"api-key"`
+	Name           *string                    `json:"name"`
+	Priority       *int                       `json:"priority"`
+	Prefix         *string                    `json:"prefix"`
+	BaseURL        *string                    `json:"base-url"`
+	ProxyURL       *string                    `json:"proxy-url"`
+	ProxyID        *string                    `json:"proxy-id"`
+	Headers        *map[string]string         `json:"headers"`
+	Models         *[]config.OllamaCloudModel `json:"models"`
+	ExcludedModels *[]string                  `json:"excluded-models"`
+}
+
+func (s *Service) OllamaCloudKeys() []config.OllamaCloudKey {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return NormalizedOllamaCloudKeyEntries(s.cfg.OllamaCloudKey)
+}
+
+func (s *Service) ReplaceOllamaCloudKeys(entries []config.OllamaCloudKey) error {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	filtered := make([]config.OllamaCloudKey, 0, len(entries))
+	for i := range entries {
+		NormalizeOllamaCloudKey(&entries[i])
+		if strings.TrimSpace(entries[i].APIKey) != "" {
+			filtered = append(filtered, entries[i])
+		}
+	}
+	prev := append([]config.OllamaCloudKey(nil), s.cfg.OllamaCloudKey...)
+	s.cfg.OllamaCloudKey = filtered
+	s.cfg.SanitizeOllamaCloudKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.OllamaCloudKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) PatchOllamaCloudKey(index *int, apiKey *string, name *string, patch OllamaCloudPatch) error {
+	if s == nil || s.cfg == nil {
+		return ErrItemNotFound
+	}
+	targetIndex := -1
+	if index != nil && *index >= 0 && *index < len(s.cfg.OllamaCloudKey) {
+		targetIndex = *index
+	}
+	if targetIndex == -1 && apiKey != nil {
+		match := strings.TrimSpace(*apiKey)
+		for i := range s.cfg.OllamaCloudKey {
+			if s.cfg.OllamaCloudKey[i].APIKey == match {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 && name != nil {
+		match := strings.TrimSpace(*name)
+		for i := range s.cfg.OllamaCloudKey {
+			if s.cfg.OllamaCloudKey[i].Name == match {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 {
+		return ErrItemNotFound
+	}
+
+	entry := s.cfg.OllamaCloudKey[targetIndex]
+	if patch.APIKey != nil {
+		entry.APIKey = strings.TrimSpace(*patch.APIKey)
+	}
+	if patch.Name != nil {
+		entry.Name = strings.TrimSpace(*patch.Name)
+	}
+	if patch.Priority != nil {
+		entry.Priority = *patch.Priority
+	}
+	if patch.Prefix != nil {
+		entry.Prefix = strings.TrimSpace(*patch.Prefix)
+	}
+	if patch.BaseURL != nil {
+		entry.BaseURL = strings.TrimSpace(*patch.BaseURL)
+	}
+	if patch.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*patch.ProxyURL)
+	}
+	if patch.ProxyID != nil {
+		entry.ProxyID = strings.TrimSpace(*patch.ProxyID)
+	}
+	if patch.Headers != nil {
+		entry.Headers = config.NormalizeHeaders(*patch.Headers)
+	}
+	if patch.Models != nil {
+		entry.Models = append([]config.OllamaCloudModel(nil), (*patch.Models)...)
+	}
+	if patch.ExcludedModels != nil {
+		entry.ExcludedModels = config.NormalizeExcludedModels(*patch.ExcludedModels)
+	}
+	NormalizeOllamaCloudKey(&entry)
+	if entry.APIKey == "" {
+		s.deleteOllamaCloudKeyByIndex(targetIndex)
+		return nil
+	}
+	prev := append([]config.OllamaCloudKey(nil), s.cfg.OllamaCloudKey...)
+	s.cfg.OllamaCloudKey[targetIndex] = entry
+	s.cfg.SanitizeOllamaCloudKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.OllamaCloudKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) DeleteOllamaCloudKeyByAPIKey(apiKey string) bool {
+	return s.deleteOllamaCloudKeys(func(entry config.OllamaCloudKey) bool { return entry.APIKey == apiKey })
+}
+
+func (s *Service) DeleteOllamaCloudKeyByName(name string) bool {
+	return s.deleteOllamaCloudKeys(func(entry config.OllamaCloudKey) bool { return entry.Name == name })
+}
+
+func (s *Service) DeleteOllamaCloudKeyByIndex(index int) bool {
+	if s == nil || s.cfg == nil || index < 0 || index >= len(s.cfg.OllamaCloudKey) {
+		return false
+	}
+	s.deleteOllamaCloudKeyByIndex(index)
+	return true
+}
+
+func (s *Service) deleteOllamaCloudKeys(match func(config.OllamaCloudKey) bool) bool {
+	if s == nil || s.cfg == nil {
+		return false
+	}
+	out := make([]config.OllamaCloudKey, 0, len(s.cfg.OllamaCloudKey))
+	for _, entry := range s.cfg.OllamaCloudKey {
+		if !match(entry) {
+			out = append(out, entry)
+		}
+	}
+	if len(out) == len(s.cfg.OllamaCloudKey) {
+		return false
+	}
+	s.cfg.OllamaCloudKey = out
+	s.cfg.SanitizeOllamaCloudKeys()
+	return true
+}
+
+func (s *Service) deleteOllamaCloudKeyByIndex(index int) {
+	s.cfg.OllamaCloudKey = append(s.cfg.OllamaCloudKey[:index], s.cfg.OllamaCloudKey[index+1:]...)
+	s.cfg.SanitizeOllamaCloudKeys()
+}
+
+func NormalizeOllamaCloudKey(entry *config.OllamaCloudKey) {
+	if entry == nil {
+		return
+	}
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.BaseURL = strings.TrimSuffix(strings.TrimSpace(entry.BaseURL), "/")
+	if entry.BaseURL == "" {
+		entry.BaseURL = config.DefaultOllamaCloudBaseURL
+	}
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.Models = config.NormalizeOllamaCloudModels(entry.Models)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+}
+
+func NormalizedOllamaCloudKeyEntries(entries []config.OllamaCloudKey) []config.OllamaCloudKey {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.OllamaCloudKey, len(entries))
+	for i := range entries {
+		out[i] = entries[i]
+		NormalizeOllamaCloudKey(&out[i])
+	}
+	return out
+}
+
 func normalizeOpenCodeGoWorkspaceID(raw string) (string, error) {
 	raw = strings.Trim(strings.TrimSpace(raw), `"'`)
 	if raw == "" {

--- a/internal/management/settings/runtimeconfig/spec.go
+++ b/internal/management/settings/runtimeconfig/spec.go
@@ -15,6 +15,7 @@ const (
 	RuntimeSettingBedrockKeys          = "bedrock-api-key"
 	RuntimeSettingOpenCodeGoKeys       = "opencode-go-api-key"
 	RuntimeSettingClineKeys            = "cline-api-key"
+	RuntimeSettingOllamaCloudKeys      = "ollama-cloud-api-key"
 	RuntimeSettingOpenAICompatibility  = "openai-compatibility"
 	RuntimeSettingVertexCompatKeys     = "vertex-api-key"
 	RuntimeSettingClaudeHeaderDefaults = "claude-header-defaults"
@@ -164,6 +165,28 @@ func Specs() []Spec {
 				holder := &config.Config{ClineKey: value}
 				holder.SanitizeClineKeys()
 				cfg.ClineKey = holder.ClineKey
+				return true
+			},
+		},
+		{
+			Key: RuntimeSettingOllamaCloudKeys,
+			Meaningful: func(cfg *config.Config) bool {
+				return len(cfg.OllamaCloudKey) > 0
+			},
+			Value: func(cfg *config.Config) any {
+				holder := &config.Config{OllamaCloudKey: append([]config.OllamaCloudKey(nil), cfg.OllamaCloudKey...)}
+				holder.SanitizeOllamaCloudKeys()
+				return holder.OllamaCloudKey
+			},
+			Apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.OllamaCloudKey
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("runtimeconfig: decode %s: %v", RuntimeSettingOllamaCloudKeys, err)
+					return false
+				}
+				holder := &config.Config{OllamaCloudKey: value}
+				holder.SanitizeOllamaCloudKeys()
+				cfg.OllamaCloudKey = holder.OllamaCloudKey
 				return true
 			},
 		},

--- a/internal/management/settings/store/runtime_settings.go
+++ b/internal/management/settings/store/runtime_settings.go
@@ -16,6 +16,7 @@ const (
 	RuntimeSettingBedrockKeys          = runtimeconfig.RuntimeSettingBedrockKeys
 	RuntimeSettingOpenCodeGoKeys       = runtimeconfig.RuntimeSettingOpenCodeGoKeys
 	RuntimeSettingClineKeys            = runtimeconfig.RuntimeSettingClineKeys
+	RuntimeSettingOllamaCloudKeys      = runtimeconfig.RuntimeSettingOllamaCloudKeys
 	RuntimeSettingOpenAICompatibility  = runtimeconfig.RuntimeSettingOpenAICompatibility
 	RuntimeSettingVertexCompatKeys     = runtimeconfig.RuntimeSettingVertexCompatKeys
 	RuntimeSettingClaudeHeaderDefaults = runtimeconfig.RuntimeSettingClaudeHeaderDefaults

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -23,6 +23,7 @@ import (
 //   - kimi
 //   - opencode-go
 //   - cline
+//   - ollama-cloud
 //   - antigravity (returns static overrides only)
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	key := strings.ToLower(strings.TrimSpace(channel))
@@ -51,6 +52,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetOpenCodeGoModels()
 	case "cline":
 		return GetClineModels()
+	case "ollama-cloud":
+		return GetOllamaCloudModels()
 	case "antigravity":
 		cfg := GetAntigravityModelConfig()
 		if len(cfg) == 0 {
@@ -99,6 +102,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		GetKimiModels(),
 		GetOpenCodeGoModels(),
 		GetClineModels(),
+		GetOllamaCloudModels(),
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -1187,3 +1187,17 @@ func GetClineModels() []*ModelInfo {
 	}
 	return models
 }
+
+// GetOllamaCloudModels returns Ollama Cloud model definitions documented by Ollama.
+func GetOllamaCloudModels() []*ModelInfo {
+	return []*ModelInfo{
+		{
+			ID:          "gpt-oss:120b",
+			Object:      "model",
+			Created:     1781751220,
+			OwnedBy:     "ollama",
+			Type:        "ollama-cloud",
+			DisplayName: "GPT OSS 120B",
+		},
+	}
+}

--- a/internal/runtime/executor/ollama_cloud_executor.go
+++ b/internal/runtime/executor/ollama_cloud_executor.go
@@ -1,0 +1,436 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+type OllamaCloudExecutor struct {
+	cfg *config.Config
+}
+
+func NewOllamaCloudExecutor(cfg *config.Config) *OllamaCloudExecutor {
+	return &OllamaCloudExecutor{cfg: cfg}
+}
+
+func (e *OllamaCloudExecutor) Identifier() string { return "ollama-cloud" }
+
+func (e *OllamaCloudExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
+	if req == nil {
+		return nil
+	}
+	_, apiKey := e.resolveCredentials(auth)
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	return nil
+}
+
+func (e *OllamaCloudExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ollama cloud executor: request is nil")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	httpReq := req.WithContext(ctx)
+	if err := e.PrepareRequest(httpReq, auth); err != nil {
+		return nil, err
+	}
+	return newProxyAwareHTTPClient(ctx, e.cfg, auth, 0).Do(httpReq)
+}
+
+func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	execCtx, translated, err := e.prepareOpenAIChat(ctx, auth, req, opts, false)
+	if err != nil {
+		return resp, err
+	}
+	reporter := execCtx.Reporter()
+	defer reporter.trackFailure(execCtx.Context, &err)
+
+	baseURL, apiKey := e.resolveCredentials(auth)
+	if baseURL == "" {
+		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
+		return resp, err
+	}
+	ollamaPayload, err := openAIChatToOllamaPayload(translated, false)
+	if err != nil {
+		return resp, err
+	}
+	body, _ := json.Marshal(ollamaPayload)
+	url := strings.TrimSuffix(baseURL, "/") + "/api/chat"
+	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	e.applyHeaders(httpReq, auth, apiKey)
+	recorder := execCtx.Recorder()
+	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
+
+	httpResp, err := execCtx.HTTPClient(0).Do(httpReq)
+	if err != nil {
+		recorder.RecordResponseError(err)
+		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("ollama cloud executor: close response body error: %v", errClose)
+		}
+	}()
+	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+		recorder.AppendResponseChunk(b)
+		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
+		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
+		return resp, err
+	}
+	upstreamBody, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
+	if err != nil {
+		recorder.RecordResponseError(err)
+		return resp, err
+	}
+	recorder.AppendResponseChunk(upstreamBody)
+	openAIResp, usage := ollamaChatResponseToOpenAI(upstreamBody, gjson.GetBytes(translated, "model").String())
+	reporter.publishWithContent(execCtx.Context, usage, string(req.Payload), string(openAIResp))
+	reporter.ensurePublished(execCtx.Context)
+
+	var param any
+	out := sdktranslator.TranslateNonStream(execCtx.Context, sdktranslator.FormatOpenAI, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, openAIResp, &param)
+	return cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}, nil
+}
+
+func (e *OllamaCloudExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	execCtx, translated, err := e.prepareOpenAIChat(ctx, auth, req, opts, true)
+	if err != nil {
+		return nil, err
+	}
+	reporter := execCtx.Reporter()
+	defer reporter.trackFailure(execCtx.Context, &err)
+
+	baseURL, apiKey := e.resolveCredentials(auth)
+	if baseURL == "" {
+		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
+		return nil, err
+	}
+	ollamaPayload, err := openAIChatToOllamaPayload(translated, true)
+	if err != nil {
+		return nil, err
+	}
+	body, _ := json.Marshal(ollamaPayload)
+	url := strings.TrimSuffix(baseURL, "/") + "/api/chat"
+	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	e.applyHeaders(httpReq, auth, apiKey)
+	httpReq.Header.Set("Accept", "application/x-ndjson")
+	recorder := execCtx.Recorder()
+	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
+
+	httpResp, err := execCtx.HTTPClient(0).Do(httpReq) //nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
+	if err != nil {
+		recorder.RecordResponseError(err)
+		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		return nil, err
+	}
+	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+		recorder.AppendResponseChunk(b)
+		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("ollama cloud executor: close response body error: %v", errClose)
+		}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
+		return nil, err
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	reporter.setInputContent(string(req.Payload))
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("ollama cloud executor: close response body error: %v", errClose)
+			}
+		}()
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800)
+		var param any
+		var lastUsage coreusage.Detail
+		hasUsage := false
+		for scanner.Scan() {
+			line := bytes.TrimSpace(scanner.Bytes())
+			if len(line) == 0 {
+				continue
+			}
+			recorder.AppendResponseChunk(line)
+			reporter.appendOutputChunk(line)
+			openAILine, usage, done := ollamaStreamChunkToOpenAI(line, gjson.GetBytes(translated, "model").String())
+			if usage.TotalTokens > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
+				lastUsage = usage
+				hasUsage = true
+			}
+			if len(openAILine) > 0 {
+				chunks := sdktranslator.TranslateStream(execCtx.Context, sdktranslator.FormatOpenAI, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, openAILine, &param)
+				for i := range chunks {
+					out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
+				}
+			}
+			if done {
+				doneChunks := sdktranslator.TranslateStream(execCtx.Context, sdktranslator.FormatOpenAI, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, []byte("data: [DONE]\n\n"), &param)
+				for i := range doneChunks {
+					out <- cliproxyexecutor.StreamChunk{Payload: []byte(doneChunks[i])}
+				}
+			}
+		}
+		if errScan := scanner.Err(); errScan != nil {
+			recorder.RecordResponseError(errScan)
+			reporter.publishFailure(execCtx.Context)
+			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			return
+		}
+		if hasUsage {
+			reporter.publish(execCtx.Context, lastUsage)
+		}
+		reporter.ensurePublished(execCtx.Context)
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func (e *OllamaCloudExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return NewOpenAICompatExecutor(e.Identifier(), e.cfg).CountTokens(ctx, auth, req, opts)
+}
+
+func (e *OllamaCloudExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	_ = ctx
+	return auth, nil
+}
+
+func (e *OllamaCloudExecutor) prepareOpenAIChat(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*ExecutionContext, []byte, error) {
+	to := sdktranslator.FormatOpenAI
+	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
+		TargetFormat:      to,
+		TranslateAsStream: stream,
+	})
+	translated, originalTranslated := execCtx.TranslateRequestPair(req.Payload)
+	translated = execCtx.ApplyPayloadConfig(translated, originalTranslated)
+	var err error
+	translated, err = thinking.ApplyThinking(translated, req.Model, execCtx.SourceFormat.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, nil, err
+	}
+	translated = normalizeOpenAIChatToolCallMessages(translated)
+	return execCtx, translated, nil
+}
+
+func (e *OllamaCloudExecutor) applyHeaders(req *http.Request, auth *cliproxyauth.Auth, apiKey string) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cli-proxy-ollama-cloud")
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(req, attrs)
+}
+
+func (e *OllamaCloudExecutor) resolveCredentials(auth *cliproxyauth.Auth) (baseURL, apiKey string) {
+	baseURL = config.DefaultOllamaCloudBaseURL
+	if auth == nil {
+		return baseURL, ""
+	}
+	if auth.Attributes != nil {
+		if v := strings.TrimSpace(auth.Attributes["base_url"]); v != "" {
+			baseURL = strings.TrimSuffix(v, "/")
+		}
+		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+	}
+	return baseURL, apiKey
+}
+
+type ollamaChatPayload struct {
+	Model    string          `json:"model"`
+	Messages []ollamaMessage `json:"messages"`
+	Stream   bool            `json:"stream"`
+	Options  map[string]any  `json:"options,omitempty"`
+}
+
+type ollamaMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+func openAIChatToOllamaPayload(body []byte, stream bool) (ollamaChatPayload, error) {
+	payload := ollamaChatPayload{
+		Model:  strings.TrimSpace(gjson.GetBytes(body, "model").String()),
+		Stream: stream,
+	}
+	for _, msg := range gjson.GetBytes(body, "messages").Array() {
+		role := strings.TrimSpace(msg.Get("role").String())
+		if role == "" {
+			role = "user"
+		}
+		content := openAIMessageContentText(msg.Get("content"))
+		if content == "" && msg.Get("tool_calls").Exists() {
+			continue
+		}
+		payload.Messages = append(payload.Messages, ollamaMessage{Role: role, Content: content})
+	}
+	options := map[string]any{}
+	copyNumberOption(body, options, "temperature", "temperature")
+	copyNumberOption(body, options, "top_p", "top_p")
+	copyNumberOption(body, options, "presence_penalty", "presence_penalty")
+	copyNumberOption(body, options, "frequency_penalty", "frequency_penalty")
+	copyNumberOption(body, options, "max_tokens", "num_predict")
+	if len(options) > 0 {
+		payload.Options = options
+	}
+	if payload.Model == "" {
+		return payload, fmt.Errorf("ollama cloud executor: missing model")
+	}
+	return payload, nil
+}
+
+func openAIMessageContentText(value gjson.Result) string {
+	if !value.Exists() {
+		return ""
+	}
+	if value.Type == gjson.String {
+		return value.String()
+	}
+	if !value.IsArray() {
+		return value.String()
+	}
+	parts := make([]string, 0)
+	for _, part := range value.Array() {
+		if strings.EqualFold(part.Get("type").String(), "text") {
+			if text := part.Get("text").String(); text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func copyNumberOption(body []byte, options map[string]any, from, to string) {
+	value := gjson.GetBytes(body, from)
+	if !value.Exists() {
+		return
+	}
+	switch value.Type {
+	case gjson.Number:
+		options[to] = value.Value()
+	default:
+		if strings.TrimSpace(value.String()) != "" {
+			options[to] = value.String()
+		}
+	}
+}
+
+func ollamaChatResponseToOpenAI(body []byte, fallbackModel string) ([]byte, coreusage.Detail) {
+	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	if model == "" {
+		model = fallbackModel
+	}
+	content := gjson.GetBytes(body, "message.content").String()
+	promptTokens := int(gjson.GetBytes(body, "prompt_eval_count").Int())
+	completionTokens := int(gjson.GetBytes(body, "eval_count").Int())
+	usage := coreusage.Detail{
+		InputTokens:  int64(promptTokens),
+		OutputTokens: int64(completionTokens),
+		TotalTokens:  int64(promptTokens + completionTokens),
+	}
+	out := map[string]any{
+		"id":      fmt.Sprintf("chatcmpl-ollama-%d", time.Now().UnixNano()),
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]any{{
+			"index": 0,
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": content,
+			},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]any{
+			"prompt_tokens":     promptTokens,
+			"completion_tokens": completionTokens,
+			"total_tokens":      promptTokens + completionTokens,
+		},
+	}
+	data, _ := json.Marshal(out)
+	return data, usage
+}
+
+func ollamaStreamChunkToOpenAI(body []byte, fallbackModel string) ([]byte, coreusage.Detail, bool) {
+	if !gjson.ValidBytes(body) {
+		return nil, coreusage.Detail{}, false
+	}
+	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	if model == "" {
+		model = fallbackModel
+	}
+	content := gjson.GetBytes(body, "message.content").String()
+	done := gjson.GetBytes(body, "done").Bool()
+	promptTokens := int(gjson.GetBytes(body, "prompt_eval_count").Int())
+	completionTokens := int(gjson.GetBytes(body, "eval_count").Int())
+	usage := coreusage.Detail{
+		InputTokens:  int64(promptTokens),
+		OutputTokens: int64(completionTokens),
+		TotalTokens:  int64(promptTokens + completionTokens),
+	}
+	chunk := map[string]any{
+		"id":      fmt.Sprintf("chatcmpl-ollama-%d", time.Now().UnixNano()),
+		"object":  "chat.completion.chunk",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]any{{
+			"index": 0,
+			"delta": map[string]any{
+				"content": content,
+			},
+			"finish_reason": nil,
+		}},
+	}
+	if done {
+		chunk["choices"] = []map[string]any{{
+			"index":         0,
+			"delta":         map[string]any{},
+			"finish_reason": "stop",
+		}}
+		chunk["usage"] = map[string]any{
+			"prompt_tokens":     promptTokens,
+			"completion_tokens": completionTokens,
+			"total_tokens":      promptTokens + completionTokens,
+		}
+	}
+	data, _ := json.Marshal(chunk)
+	return append(append([]byte("data: "), data...), []byte("\n\n")...), usage, done
+}

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -55,8 +55,8 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.clientsMutex.Unlock()
 	}
 
-	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, bedrockAPIKeyCount, openCodeGoAPIKeyCount, openAICompatCount := BuildAPIKeyClients(cfg)
-	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + bedrockAPIKeyCount + openCodeGoAPIKeyCount + openAICompatCount
+	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, bedrockAPIKeyCount, openCodeGoAPIKeyCount, ollamaCloudAPIKeyCount, openAICompatCount := BuildAPIKeyClients(cfg)
+	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + bedrockAPIKeyCount + openCodeGoAPIKeyCount + ollamaCloudAPIKeyCount + openAICompatCount
 	log.Debugf("loaded %d API key clients", totalAPIKeyClients)
 
 	var authFileCount int
@@ -244,17 +244,18 @@ func (w *Watcher) loadFileClients(cfg *config.Config) int {
 	return authFileCount
 }
 
-func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int) {
+func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int, int) {
 	geminiAPIKeyCount := 0
 	vertexCompatAPIKeyCount := 0
 	claudeAPIKeyCount := 0
 	codexAPIKeyCount := 0
 	bedrockAPIKeyCount := 0
 	openCodeGoAPIKeyCount := 0
+	ollamaCloudAPIKeyCount := 0
 	openAICompatCount := 0
 
 	if cfg == nil {
-		return 0, 0, 0, 0, 0, 0, 0
+		return 0, 0, 0, 0, 0, 0, 0, 0
 	}
 	if len(cfg.GeminiKey) > 0 {
 		geminiAPIKeyCount += len(cfg.GeminiKey)
@@ -274,6 +275,9 @@ func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int) 
 	if len(cfg.OpenCodeGoKey) > 0 {
 		openCodeGoAPIKeyCount += len(cfg.OpenCodeGoKey)
 	}
+	if len(cfg.OllamaCloudKey) > 0 {
+		ollamaCloudAPIKeyCount += len(cfg.OllamaCloudKey)
+	}
 	if len(cfg.OpenAICompatibility) > 0 {
 		for _, compatConfig := range cfg.OpenAICompatibility {
 			if compatConfig.Disabled {
@@ -282,7 +286,7 @@ func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int) 
 			openAICompatCount += len(compatConfig.APIKeyEntries)
 		}
 	}
-	return geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, bedrockAPIKeyCount, openCodeGoAPIKeyCount, openAICompatCount
+	return geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, bedrockAPIKeyCount, openCodeGoAPIKeyCount, ollamaCloudAPIKeyCount, openAICompatCount
 }
 
 func (w *Watcher) persistConfigAsync() {

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -115,6 +115,21 @@ func ComputeOpenCodeGoModelsHash(models []config.OpenCodeGoModel) string {
 	return hashJoined(keys)
 }
 
+// ComputeOllamaCloudModelsHash returns a stable hash for Ollama Cloud model aliases.
+func ComputeOllamaCloudModelsHash(models []config.OllamaCloudModel) string {
+	keys := normalizeModelPairs(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+		}
+	})
+	return hashJoined(keys)
+}
+
 // ComputeExcludedModelsHash returns a normalized hash for excluded model lists.
 func ComputeExcludedModelsHash(excluded []string) string {
 	if len(excluded) == 0 {

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ConfigSynthesizer generates Auth entries from configuration API keys.
-// It handles Gemini, Claude, Bedrock, Codex, OpenCode Go, Cline, OpenAI-compat, and Vertex-compat providers.
+// It handles Gemini, Claude, Bedrock, Codex, OpenCode Go, Cline, Ollama Cloud, OpenAI-compat, and Vertex-compat providers.
 type ConfigSynthesizer struct{}
 
 // NewConfigSynthesizer creates a new ConfigSynthesizer instance.
@@ -38,6 +38,8 @@ func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth,
 	out = append(out, s.synthesizeOpenCodeGoKeys(ctx)...)
 	// Cline API Keys
 	out = append(out, s.synthesizeClineKeys(ctx)...)
+	// Ollama Cloud API Keys
+	out = append(out, s.synthesizeOllamaCloudKeys(ctx)...)
 	// OpenAI-compat
 	out = append(out, s.synthesizeOpenAICompat(ctx)...)
 	// Vertex-compat
@@ -404,6 +406,64 @@ func (s *ConfigSynthesizer) synthesizeClineKeys(ctx *SynthesisContext) []*coreau
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "cline",
+			Label:      label,
+			Prefix:     prefix,
+			Status:     coreauth.StatusActive,
+			ProxyURL:   proxyURL,
+			ProxyID:    proxyID,
+			Attributes: attrs,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
+		ApplyDisableAllModelsState(a, entry.ExcludedModels)
+		out = append(out, a)
+	}
+	return out
+}
+
+// synthesizeOllamaCloudKeys creates Auth entries for Ollama Cloud API keys.
+func (s *ConfigSynthesizer) synthesizeOllamaCloudKeys(ctx *SynthesisContext) []*coreauth.Auth {
+	cfg := ctx.Config
+	now := ctx.Now
+	idGen := ctx.IDGenerator
+
+	out := make([]*coreauth.Auth, 0, len(cfg.OllamaCloudKey))
+	for i := range cfg.OllamaCloudKey {
+		entry := cfg.OllamaCloudKey[i]
+		key := strings.TrimSpace(entry.APIKey)
+		if key == "" {
+			continue
+		}
+		prefix := strings.TrimSpace(entry.Prefix)
+		base := strings.TrimSpace(entry.BaseURL)
+		if base == "" {
+			base = config.DefaultOllamaCloudBaseURL
+		}
+		base = strings.TrimSuffix(base, "/")
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		proxyID := strings.TrimSpace(entry.ProxyID)
+		id, token := idGen.Next("ollama-cloud:apikey", key, base, proxyURL)
+		attrs := map[string]string{
+			"source":       fmt.Sprintf("config:ollama-cloud[%s]", token),
+			"api_key":      key,
+			"base_url":     base,
+			"provider_key": "ollama-cloud",
+		}
+		if entry.Priority != 0 {
+			attrs["priority"] = strconv.Itoa(entry.Priority)
+		}
+		if hash := diff.ComputeOllamaCloudModelsHash(entry.Models); hash != "" {
+			attrs["models_hash"] = hash
+		}
+		addConfigHeadersToAttrs(entry.Headers, attrs)
+		label := strings.TrimSpace(entry.Name)
+		if label == "" {
+			label = "ollama-cloud-apikey"
+		}
+		a := &coreauth.Auth{
+			ID:         id,
+			Provider:   "ollama-cloud",
 			Label:      label,
 			Prefix:     prefix,
 			Status:     coreauth.StatusActive,

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -73,14 +73,17 @@ func TestBuildAPIKeyClientsCounts(t *testing.T) {
 			{AuthMode: "sigv4", AccessKeyID: "AKIA", SecretAccessKey: "SECRET"},
 		},
 		OpenCodeGoKey: []config.OpenCodeGoKey{{APIKey: "go1"}},
+		OllamaCloudKey: []config.OllamaCloudKey{
+			{APIKey: "ollama1"},
+		},
 		OpenAICompatibility: []config.OpenAICompatibility{
 			{APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "o1"}, {APIKey: "o2"}}},
 		},
 	}
 
-	gemini, vertex, claude, codex, bedrock, opencodeGo, compat := BuildAPIKeyClients(cfg)
-	if gemini != 2 || vertex != 1 || claude != 1 || codex != 2 || bedrock != 2 || opencodeGo != 1 || compat != 2 {
-		t.Fatalf("unexpected counts: %d %d %d %d %d %d %d", gemini, vertex, claude, codex, bedrock, opencodeGo, compat)
+	gemini, vertex, claude, codex, bedrock, opencodeGo, ollamaCloud, compat := BuildAPIKeyClients(cfg)
+	if gemini != 2 || vertex != 1 || claude != 1 || codex != 2 || bedrock != 2 || opencodeGo != 1 || ollamaCloud != 1 || compat != 2 {
+		t.Fatalf("unexpected counts: %d %d %d %d %d %d %d %d", gemini, vertex, claude, codex, bedrock, opencodeGo, ollamaCloud, compat)
 	}
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -327,7 +327,7 @@ func NewAPIKeyClientProvider() APIKeyClientProvider {
 type apiKeyClientProvider struct{}
 
 func (p *apiKeyClientProvider) Load(ctx context.Context, cfg *config.Config) (*APIKeyClientResult, error) {
-	geminiCount, vertexCompatCount, claudeCount, codexCount, bedrockCount, openCodeGoCount, openAICompat := buildAPIKeyClients(cfg)
+	geminiCount, vertexCompatCount, claudeCount, codexCount, bedrockCount, openCodeGoCount, ollamaCloudCount, openAICompat := buildAPIKeyClients(cfg)
 	if ctx != nil {
 		select {
 		case <-ctx.Done():
@@ -342,6 +342,7 @@ func (p *apiKeyClientProvider) Load(ctx context.Context, cfg *config.Config) (*A
 		CodexKeyCount:        codexCount,
 		BedrockKeyCount:      bedrockCount,
 		OpenCodeGoKeyCount:   openCodeGoCount,
+		OllamaCloudKeyCount:  ollamaCloudCount,
 		OpenAICompatCount:    openAICompat,
 	}, nil
 }

--- a/sdk/cliproxy/service_app_bridge.go
+++ b/sdk/cliproxy/service_app_bridge.go
@@ -33,7 +33,7 @@ func newDefaultAuthManager() *sdkAuth.Manager {
 	return serviceapp.NewDefaultAuthManager()
 }
 
-func buildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int) {
+func buildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int, int) {
 	return serviceapp.BuildAPIKeyClients(cfg)
 }
 

--- a/sdk/cliproxy/service_model_config_resolvers.go
+++ b/sdk/cliproxy/service_model_config_resolvers.go
@@ -173,6 +173,35 @@ func (s *Service) resolveConfigClineKey(auth *coreauth.Auth) *config.ClineKey {
 	return nil
 }
 
+func (s *Service) resolveConfigOllamaCloudKey(auth *coreauth.Auth) *config.OllamaCloudKey {
+	if auth == nil || s.cfg == nil {
+		return nil
+	}
+	var attrKey, attrBase string
+	if auth.Attributes != nil {
+		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
+		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	for i := range s.cfg.OllamaCloudKey {
+		entry := &s.cfg.OllamaCloudKey[i]
+		cfgKey := strings.TrimSpace(entry.APIKey)
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if cfgBase == "" {
+			cfgBase = config.DefaultOllamaCloudBaseURL
+		}
+		if attrKey != "" && strings.EqualFold(cfgKey, attrKey) {
+			if attrBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
+		if attrKey == "" && attrBase != "" && strings.EqualFold(cfgBase, attrBase) {
+			return entry
+		}
+	}
+	return nil
+}
+
 func (s *Service) resolveConfigVertexCompatKey(auth *coreauth.Auth) *config.VertexCompatKey {
 	if auth == nil || s.cfg == nil {
 		return nil

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -168,6 +168,16 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 			excluded = entry.ExcludedModels
 		}
 		models = applyExcludedModels(models, excluded)
+	case "ollama-cloud":
+		staticModels := sdkmodelcatalog.StaticModelDefinitionsByChannel("ollama-cloud")
+		models = staticModels
+		if entry := s.resolveConfigOllamaCloudKey(a); entry != nil && authKind == "apikey" {
+			if len(entry.Models) > 0 {
+				models = buildOllamaCloudConfigModels(entry, staticModels)
+			}
+			excluded = entry.ExcludedModels
+		}
+		models = applyExcludedModels(models, excluded)
 	case "codex":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("codex")
 		if entry := s.resolveConfigCodexKey(a); entry != nil {

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -341,6 +341,13 @@ func buildClineConfigModels(entry *config.ClineKey, staticModels []*ModelInfo) [
 	return buildConfigModels(entry.Models, "cline", "cline", nil)
 }
 
+func buildOllamaCloudConfigModels(entry *config.OllamaCloudKey, staticModels []*ModelInfo) []*ModelInfo {
+	if entry == nil || len(entry.Models) == 0 {
+		return nil
+	}
+	return buildNamedConfigModels(entry.Models, staticModels, "ollama", "ollama-cloud")
+}
+
 func buildNamedConfigModels[T interface{ GetName() string }](models []T, staticModels []*ModelInfo, ownedBy, modelType string) []*ModelInfo {
 	staticByID := make(map[string]*ModelInfo, len(staticModels))
 	for _, model := range staticModels {

--- a/sdk/cliproxy/types.go
+++ b/sdk/cliproxy/types.go
@@ -67,6 +67,9 @@ type APIKeyClientResult struct {
 	// OpenCodeGoKeyCount is the number of OpenCode Go API keys loaded
 	OpenCodeGoKeyCount int
 
+	// OllamaCloudKeyCount is the number of Ollama Cloud API keys loaded
+	OllamaCloudKeyCount int
+
 	// OpenAICompatCount is the number of OpenAI compatibility API keys loaded
 	OpenAICompatCount int
 }

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -35,6 +35,8 @@ type OpenCodeGoKey = bridgeconfig.OpenCodeGoKey
 type OpenCodeGoModel = bridgeconfig.OpenCodeGoModel
 type ClineKey = bridgeconfig.ClineKey
 type ClineModel = bridgeconfig.ClineModel
+type OllamaCloudKey = bridgeconfig.OllamaCloudKey
+type OllamaCloudModel = bridgeconfig.OllamaCloudModel
 type VertexCompatKey = bridgeconfig.VertexCompatKey
 type VertexCompatModel = bridgeconfig.VertexCompatModel
 type OpenAICompatibility = bridgeconfig.OpenAICompatibility
@@ -47,6 +49,7 @@ const (
 	DefaultPanelGitHubRepository = bridgeconfig.DefaultPanelGitHubRepository
 	DefaultBedrockRegion         = bridgeconfig.DefaultBedrockRegion
 	DefaultClineBaseURL          = bridgeconfig.DefaultClineBaseURL
+	DefaultOllamaCloudBaseURL    = bridgeconfig.DefaultOllamaCloudBaseURL
 	DefaultPprofAddr             = bridgeconfig.DefaultPprofAddr
 )
 

--- a/sdkbridge/config/config.go
+++ b/sdkbridge/config/config.go
@@ -32,6 +32,8 @@ type OpenCodeGoKey = internalconfig.OpenCodeGoKey
 type OpenCodeGoModel = internalconfig.OpenCodeGoModel
 type ClineKey = internalconfig.ClineKey
 type ClineModel = internalconfig.ClineModel
+type OllamaCloudKey = internalconfig.OllamaCloudKey
+type OllamaCloudModel = internalconfig.OllamaCloudModel
 type VertexCompatKey = internalconfig.VertexCompatKey
 type VertexCompatModel = internalconfig.VertexCompatModel
 type OpenAICompatibility = internalconfig.OpenAICompatibility
@@ -44,6 +46,7 @@ const (
 	DefaultPanelGitHubRepository = internalconfig.DefaultPanelGitHubRepository
 	DefaultBedrockRegion         = internalconfig.DefaultBedrockRegion
 	DefaultClineBaseURL          = internalconfig.DefaultClineBaseURL
+	DefaultOllamaCloudBaseURL    = internalconfig.DefaultOllamaCloudBaseURL
 	DefaultPprofAddr             = internalconfig.DefaultPprofAddr
 )
 

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -71,7 +71,7 @@ func NewDefaultAuthManager() *sdkAuth.Manager {
 	return internalserviceapp.NewDefaultAuthManager()
 }
 
-func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int) {
+func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int, int, int) {
 	return internalserviceapp.BuildAPIKeyClients(cfg)
 }
 


### PR DESCRIPTION
## Summary
- add Ollama Cloud provider settings and runtime executor
- register Ollama Cloud models and SDK bridge config

## Tests
- rtk go test ./internal/config ./internal/watcher ./internal/watcher/synthesizer ./internal/management/settings/... ./internal/api/handlers/management ./internal/api/routes ./internal/runtime/executor ./internal/registry ./sdk/cliproxy/... ./sdk/... ./sdkbridge/...
- rtk git diff --check