### PR TITLE
fix: keep runtime services on compose network

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -648,6 +648,7 @@ func upgradeComposeRuntimeStack(composeText string, projectDir string, service s
 	target["entrypoint"] = sourceEnvEntrypoint()
 	target["environment"] = withoutEnvKeys(target["environment"], runtimeStackEnvKeys()...)
 	target["volumes"] = appendVolume(target["volumes"], "${CLIRELAY_PROJECT_DIR:-"+projectDir+"}:/clirelay-deploy")
+	targetNetworks := target["networks"]
 	target["depends_on"] = map[string]any{
 		"clirelay-init": map[string]any{"condition": "service_completed_successfully"},
 		"postgres":      map[string]any{"condition": "service_healthy"},
@@ -657,6 +658,13 @@ func upgradeComposeRuntimeStack(composeText string, projectDir string, service s
 	services["postgres"] = postgresComposeService()
 	services["redis"] = redisComposeService()
 	services["clirelay-updater"] = updaterComposeService(projectDir, targetName, appImage)
+	if targetNetworks != nil {
+		for _, name := range []string{"clirelay-init", "postgres", "redis", "clirelay-updater"} {
+			if generated, ok := stringMap(services[name]); ok {
+				generated["networks"] = targetNetworks
+			}
+		}
+	}
 
 	out, err := yaml.Marshal(doc)
 	if err != nil {

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -690,6 +690,45 @@ services:
 	}
 }
 
+func TestUpgradeComposeRuntimeStackKeepsGeneratedServicesOnTargetNetwork(t *testing.T) {
+	upgraded, _, err := upgradeComposeRuntimeStack(`
+services:
+  cli-proxy-api:
+    image: ghcr.io/kittors/clirelay:dev
+    networks:
+      - clirelay
+networks:
+  clirelay:
+    name: clirelay
+`, "/root/cliproxy", "cli-proxy-api")
+	if err != nil {
+		t.Fatalf("upgradeComposeRuntimeStack failed: %v", err)
+	}
+
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(upgraded), &doc); err != nil {
+		t.Fatalf("parse upgraded compose: %v", err)
+	}
+	services, ok := stringMap(doc["services"])
+	if !ok {
+		t.Fatalf("services not found in upgraded compose:\n%s", upgraded)
+	}
+	target, ok := stringMap(services["cli-proxy-api"])
+	if !ok {
+		t.Fatalf("target service missing:\n%s", upgraded)
+	}
+	wantNetworks := target["networks"]
+	for _, name := range []string{"postgres", "redis", "clirelay-updater"} {
+		service, ok := stringMap(services[name])
+		if !ok {
+			t.Fatalf("service %s missing:\n%s", name, upgraded)
+		}
+		if !reflect.DeepEqual(service["networks"], wantNetworks) {
+			t.Fatalf("%s networks = %#v, want %#v\n%s", name, service["networks"], wantNetworks, upgraded)
+		}
+	}
+}
+
 func TestEnsureRuntimeDataStackConfigUpgradesStackWithoutInitService(t *testing.T) {
 	dir := t.TempDir()
 	composePath := filepath.Join(dir, "docker-compose.yml")


### PR DESCRIPTION
## Summary
- keep generated runtime stack services on the target service compose network during online update
- cover legacy compose with explicit clirelay network in updater tests

## Tests
- rtk go test ./cmd/updater
- rtk go test ./internal/management/updateflow ./internal/api/handlers/management
- rtk go test ./...