### PR TITLE
fix: migrate sqlite before compose service restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ auto-update:
 
 CliRelay uses PostgreSQL 15+ as the runtime primary database through Ent ORM. Redis 7+ is intentionally limited to cache, locks, limits, queues, and rebuildable snapshots. The bundled Docker Compose file starts both services and injects container-local connection settings automatically through the generated `.env`.
 
-For old Docker deployments that still have a SQLite-only compose file, update from `/manage/system` can upgrade `docker-compose.yml` and `.env` before it runs `docker compose up -d --remove-orphans`. The updater adds the `clirelay-init`, PostgreSQL, Redis, and updater services, keeps the existing application service, writes missing generated settings, and then lets the container entrypoint import the legacy SQLite database. SQLite is left in place.
+For old Docker deployments that still have a SQLite-only compose file, update from `/manage/system` can upgrade `docker-compose.yml` and `.env` before it restarts the application container. The updater adds the `clirelay-init`, `clirelay-migrate`, PostgreSQL, Redis, and updater services, keeps the existing application service running, starts PostgreSQL/Redis, streams the SQLite migration progress, and only recreates the application container after migration succeeds. SQLite is left in place.
 
 If the updater cannot write the deployment files because the old container was mounted without access to the project directory, replace `docker-compose.yml` with the latest one from this repository and run `docker compose up -d` once. After that, future online updates can update the compose file automatically.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -262,7 +262,7 @@ auto-update:
 
 CliRelay 通过 Ent ORM 使用 PostgreSQL 15+ 作为运行时主数据库。Redis 7+ 只负责缓存、锁、限流、队列和可重建快照。仓库内的 Docker Compose 会自动启动这两个服务，并通过生成的 `.env` 注入容器内连接地址。
 
-如果旧 Docker 部署还停留在 SQLite-only compose，在 `/manage/system` 里触发在线更新时，updater 会先升级 `docker-compose.yml` 和 `.env`，再执行 `docker compose up -d --remove-orphans`。升级会补上 `clirelay-init`、PostgreSQL、Redis 和 updater 服务，保留原应用服务，写入缺失的生成配置，然后由容器 entrypoint 导入旧 SQLite 数据。SQLite 文件会原样保留。
+如果旧 Docker 部署还停留在 SQLite-only compose，在 `/manage/system` 里触发在线更新时，updater 会先升级 `docker-compose.yml` 和 `.env`，但不会立刻重启业务容器。升级会补上 `clirelay-init`、`clirelay-migrate`、PostgreSQL、Redis 和 updater 服务，保留原应用服务继续运行，先启动 PostgreSQL/Redis，实时输出 SQLite 迁移进度，并且只在迁移成功后才重建业务容器。SQLite 文件会原样保留。
 
 如果旧容器因为挂载方式太老，导致 updater 无法写回部署文件，请先把 `docker-compose.yml` 替换成仓库最新版，再执行一次 `docker compose up -d`。完成后，后续在线更新就可以自动更新 compose 文件。
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -160,6 +160,7 @@ func main() {
 			SQLitePath:  sqliteImportPath,
 			PostgresDSN: dsn,
 			DryRun:      sqliteImportDryRun,
+			Progress:    os.Stderr,
 		}); err != nil {
 			log.Errorf("sqlite import failed: %v", err)
 			os.Exit(1)

--- a/cmd/updater/compose_migrate.go
+++ b/cmd/updater/compose_migrate.go
@@ -1,0 +1,27 @@
+package main
+
+import "os"
+
+func migrateComposeService(target map[string]any, image string) map[string]any {
+	return map[string]any{
+		"image":       "${CLI_PROXY_IMAGE:-" + image + "}",
+		"command":     []any{"migrate-sqlite-to-postgres.sh"},
+		"entrypoint":  sourceEnvEntrypoint(),
+		"environment": withoutEnvKeys(target["environment"], "CLIRELAY_SQLITE_AUTO_MIGRATE"),
+		"volumes":     target["volumes"],
+		"depends_on": map[string]any{
+			"clirelay-init": map[string]any{"condition": "service_completed_successfully"},
+			"postgres":      map[string]any{"condition": "service_healthy"},
+			"redis":         map[string]any{"condition": "service_healthy"},
+		},
+		"restart": "no",
+	}
+}
+
+func composeFileHasService(path string, service string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return hasComposeService(string(data), service)
+}

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -577,6 +577,16 @@ func runComposeUpdate(ctx context.Context, composeFile string, envFile string, p
 	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "pull", service); err != nil {
 		return err
 	}
+	if composeFileHasService(composeFile, "clirelay-migrate") {
+		reporter.Stage("migrating", "starting PostgreSQL/Redis before SQLite migration")
+		if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "postgres", "redis"); err != nil {
+			return err
+		}
+		reporter.Stage("migrating", "migrating legacy SQLite data before restarting service")
+		if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "run", "--rm", "clirelay-migrate"); err != nil {
+			return err
+		}
+	}
 	reporter.Stage("restarting", "restarting service container")
 	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "--remove-orphans"); err != nil {
 		return err
@@ -598,7 +608,7 @@ func ensureRuntimeDataStackConfig(ctx context.Context, composeFile string, envFi
 	}
 	projectDir := deploymentProjectDir(ctx, composeFile)
 	composeText := string(composeData)
-	if hasComposeService(composeText, "postgres") && hasComposeService(composeText, "redis") && hasComposeService(composeText, "clirelay-init") {
+	if hasComposeService(composeText, "postgres") && hasComposeService(composeText, "redis") && hasComposeService(composeText, "clirelay-init") && hasComposeService(composeText, "clirelay-migrate") {
 		if err := ensureRuntimeEnvFile(ctx, envFile, projectDir, service, composeAppImage(composeText, service), reporter); err != nil {
 			return envFile, err
 		}
@@ -650,20 +660,24 @@ func upgradeComposeRuntimeStack(composeText string, projectDir string, service s
 	if !hasComposeCommand(target["command"]) {
 		target["command"] = []any{"./CLIProxyAPI"}
 	}
-	target["environment"] = withoutEnvKeys(target["environment"], runtimeStackEnvKeys()...)
+	targetEnv := withoutEnvKeys(target["environment"], runtimeStackEnvKeys()...)
+	targetEnv["CLIRELAY_SQLITE_AUTO_MIGRATE"] = "false"
+	target["environment"] = targetEnv
 	target["volumes"] = appendVolume(target["volumes"], "${CLIRELAY_PROJECT_DIR:-"+projectDir+"}:/clirelay-deploy")
 	targetNetworks := target["networks"]
 	target["depends_on"] = map[string]any{
-		"clirelay-init": map[string]any{"condition": "service_completed_successfully"},
-		"postgres":      map[string]any{"condition": "service_healthy"},
-		"redis":         map[string]any{"condition": "service_healthy"},
+		"clirelay-init":    map[string]any{"condition": "service_completed_successfully"},
+		"clirelay-migrate": map[string]any{"condition": "service_completed_successfully"},
+		"postgres":         map[string]any{"condition": "service_healthy"},
+		"redis":            map[string]any{"condition": "service_healthy"},
 	}
 	services["clirelay-init"] = initComposeService(projectDir, targetName, appImage)
+	services["clirelay-migrate"] = migrateComposeService(target, appImage)
 	services["postgres"] = postgresComposeService()
 	services["redis"] = redisComposeService()
 	services["clirelay-updater"] = updaterComposeService(projectDir, targetName, appImage)
 	if targetNetworks != nil {
-		for _, name := range []string{"clirelay-init", "postgres", "redis", "clirelay-updater"} {
+		for _, name := range []string{"clirelay-init", "clirelay-migrate", "postgres", "redis", "clirelay-updater"} {
 			if generated, ok := stringMap(services[name]); ok {
 				generated["networks"] = targetNetworks
 			}

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -512,6 +512,8 @@ func TestRunComposeUpdateStartsFullComposeStack(t *testing.T) {
 	got := strings.Split(strings.TrimSpace(string(data)), "\n")
 	want := []string{
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " pull clirelay",
+		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d postgres redis",
+		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " run --rm clirelay-migrate",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --remove-orphans",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -549,6 +551,8 @@ func TestRunComposeUpdateUsesEnvFileNextToComposeWhenUnset(t *testing.T) {
 	got := strings.Split(strings.TrimSpace(string(data)), "\n")
 	want := []string{
 		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " pull clirelay",
+		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " up -d postgres redis",
+		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " run --rm clirelay-migrate",
 		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " up -d --remove-orphans",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -586,6 +590,7 @@ func TestRunComposeUpdateUpgradesLegacySQLiteComposeWithRuntimeStack(t *testing.
 	composeText := string(composeData)
 	for _, want := range []string{
 		"clirelay-init:",
+		"clirelay-migrate:",
 		"postgres:",
 		"redis:",
 		"clirelay-updater:",
@@ -627,6 +632,8 @@ func TestRunComposeUpdateUpgradesLegacySQLiteComposeWithRuntimeStack(t *testing.
 	got := strings.Split(strings.TrimSpace(string(data)), "\n")
 	want := []string{
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " pull clirelay",
+		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d postgres redis",
+		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " run --rm clirelay-migrate",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --remove-orphans",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -676,6 +683,9 @@ services:
 			t.Fatalf("environment still contains generated runtime key %s: %#v", forbidden, env)
 		}
 	}
+	if env["CLIRELAY_SQLITE_AUTO_MIGRATE"] != "false" {
+		t.Fatalf("clirelay must skip startup SQLite migration, environment = %#v", env)
+	}
 	if got := clirelay["entrypoint"]; got == nil {
 		t.Fatalf("clirelay service missing source-env entrypoint:\n%s", upgraded)
 	}
@@ -686,10 +696,17 @@ services:
 	if !ok || !containsAnyString(volumes, "${CLIRELAY_PROJECT_DIR:-/opt/clirelay}:/clirelay-deploy") {
 		t.Fatalf("clirelay service missing /clirelay-deploy volume: %#v\n%s", clirelay["volumes"], upgraded)
 	}
-	for _, name := range []string{"clirelay-init", "postgres", "redis", "clirelay-updater"} {
+	for _, name := range []string{"clirelay-init", "clirelay-migrate", "postgres", "redis", "clirelay-updater"} {
 		if _, ok := services[name]; !ok {
 			t.Fatalf("upgraded compose missing service %s:\n%s", name, upgraded)
 		}
+	}
+	migrate, ok := stringMap(services["clirelay-migrate"])
+	if !ok {
+		t.Fatalf("clirelay-migrate service not found:\n%s", upgraded)
+	}
+	if !reflect.DeepEqual(migrate["command"], []any{"migrate-sqlite-to-postgres.sh"}) {
+		t.Fatalf("clirelay-migrate command = %#v, want migrate script\n%s", migrate["command"], upgraded)
 	}
 }
 
@@ -721,7 +738,7 @@ networks:
 		t.Fatalf("target service missing:\n%s", upgraded)
 	}
 	wantNetworks := target["networks"]
-	for _, name := range []string{"postgres", "redis", "clirelay-updater"} {
+	for _, name := range []string{"postgres", "redis", "clirelay-migrate", "clirelay-updater"} {
 		service, ok := stringMap(services[name])
 		if !ok {
 			t.Fatalf("service %s missing:\n%s", name, upgraded)
@@ -762,7 +779,7 @@ func TestEnsureRuntimeDataStackConfigUpgradesStackWithoutInitService(t *testing.
 		t.Fatalf("read compose: %v", err)
 	}
 	upgraded := string(upgradedData)
-	for _, want := range []string{"clirelay-init:", "/clirelay-deploy/.env", "service_completed_successfully"} {
+	for _, want := range []string{"clirelay-init:", "clirelay-migrate:", "/clirelay-deploy/.env", "service_completed_successfully"} {
 		if !strings.Contains(upgraded, want) {
 			t.Fatalf("compose missing %q:\n%s", want, upgraded)
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     #   - .env
     environment:
       DEPLOY: ${DEPLOY:-}
+      CLIRELAY_SQLITE_AUTO_MIGRATE: "false"
       CLIRELAY_LOCALE: ${CLIRELAY_LOCALE:-zh}
       CLIRELAY_UPDATE_CHANNEL: ${CLIRELAY_UPDATE_CHANNEL:-main}
       AUTH_PATH: ${AUTH_PATH:-/CLIProxyAPI/auths}
@@ -55,11 +56,41 @@ services:
     depends_on:
       clirelay-init:
         condition: service_completed_successfully
+      clirelay-migrate:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
     restart: unless-stopped
+
+  clirelay-migrate:
+    image: ${CLI_PROXY_IMAGE:-ghcr.io/kittors/clirelay:latest}
+    pull_policy: ${CLI_PROXY_PULL_POLICY:-always}
+    command: ["migrate-sqlite-to-postgres.sh"]
+    entrypoint: ["sh", "-c", "set -a; . /clirelay-deploy/.env; set +a; exec docker-entrypoint.sh \"$@\"", "--"]
+    environment:
+      DEPLOY: ${DEPLOY:-}
+      CLIRELAY_LOCALE: ${CLIRELAY_LOCALE:-zh}
+      CLIRELAY_UPDATE_CHANNEL: ${CLIRELAY_UPDATE_CHANNEL:-main}
+      AUTH_PATH: ${AUTH_PATH:-/CLIProxyAPI/auths}
+      LANG: ${CLIRELAY_LANG:-C.UTF-8}
+      LANGUAGE: ${CLIRELAY_LANGUAGE:-en_US:en}
+      LC_ALL: ${CLIRELAY_LANG:-C.UTF-8}
+    volumes:
+      - ${CLI_PROXY_CONFIG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/config.yaml}:/CLIProxyAPI/config.yaml
+      - ${CLI_PROXY_AUTH_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/auths}:${AUTH_PATH:-/CLIProxyAPI/auths}
+      - ${CLI_PROXY_LOG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/logs}:/CLIProxyAPI/logs
+      - ${CLI_PROXY_DATA_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/data}:/CLIProxyAPI/data
+      - ${CLIRELAY_PROJECT_DIR:-${PWD:-.}}:/clirelay-deploy
+    depends_on:
+      clirelay-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: "no"
 
   clirelay-updater:
     image: ${CLI_PROXY_IMAGE:-ghcr.io/kittors/clirelay:latest}

--- a/internal/storage/postgres/sqliteinventory/import.go
+++ b/internal/storage/postgres/sqliteinventory/import.go
@@ -24,6 +24,7 @@ type ImportOptions struct {
 	PostgresDSN string
 	DryRun      bool
 	Now         time.Time
+	Progress    io.Writer
 }
 
 type ImportReport struct {
@@ -140,14 +141,20 @@ func Import(ctx context.Context, opts ImportOptions) (ImportReport, error) {
 		sourceColumns[table.Name] = table.Columns
 	}
 	report := ImportReport{SQLitePath: inventory.Path, ScannedAt: now.UTC(), DryRun: opts.DryRun, SourceFingerprint: sourceFingerprint}
-	for _, table := range runtimeImportTables {
+	for i, table := range runtimeImportTables {
 		srcCols, ok := sourceColumns[table]
 		if !ok {
 			continue
 		}
+		reportImportProgress(opts.Progress, "sqlite import progress: table %d/%d %s", i+1, len(runtimeImportTables), table)
 		row, err := importTable(ctx, src, dst, table, srcCols, opts.DryRun)
 		if err != nil {
 			return ImportReport{}, err
+		}
+		if opts.DryRun {
+			reportImportProgress(opts.Progress, "sqlite import progress: table %s dry-run source_rows=%d target_rows=%d planned_inserts=%d", table, row.SourceRows, row.TargetRows, row.PlannedInserts)
+		} else {
+			reportImportProgress(opts.Progress, "sqlite import progress: table %s inserted_rows=%d target_rows=%d", table, row.InsertedRows, row.TargetRows)
 		}
 		report.Tables = append(report.Tables, row)
 	}
@@ -415,6 +422,7 @@ func copyRows(ctx context.Context, src, dst *sql.DB, table string, columns []str
 			_ = tx.Rollback()
 			return 0, fmt.Errorf("sqlite import: scan %s: %w", table, err)
 		}
+		normalizeImportValues(table, columns, values)
 		result, err := tx.ExecContext(ctx, insertSQL, values...)
 		if err != nil {
 			_ = tx.Rollback()
@@ -443,6 +451,40 @@ func copyRows(ctx context.Context, src, dst *sql.DB, table string, columns []str
 		return 0, fmt.Errorf("sqlite import: commit %s: %w", table, err)
 	}
 	return inserted, nil
+}
+
+var importNullDefaults = map[string]map[string]any{
+	"request_logs": {
+		"input_content":  "",
+		"output_content": "",
+	},
+	"request_log_content": {
+		"input_content":  []byte{},
+		"output_content": []byte{},
+		"detail_content": []byte{},
+		"session_id":     "",
+	},
+}
+
+func normalizeImportValues(table string, columns []string, values []any) {
+	defaults := importNullDefaults[table]
+	if len(defaults) == 0 {
+		return
+	}
+	for i, column := range columns {
+		if values[i] == nil {
+			if value, ok := defaults[column]; ok {
+				values[i] = value
+			}
+		}
+	}
+}
+
+func reportImportProgress(out io.Writer, format string, args ...any) {
+	if out == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(out, format+"\n", args...)
 }
 
 func resetPostgresSequence(ctx context.Context, db *sql.DB, table, column string) error {

--- a/internal/storage/postgres/sqliteinventory/import_test.go
+++ b/internal/storage/postgres/sqliteinventory/import_test.go
@@ -128,6 +128,23 @@ func TestImportSQLiteDryRunAndApply(t *testing.T) {
 	}
 }
 
+func TestNormalizeImportValuesCoalescesLegacyNullContent(t *testing.T) {
+	columns := []string{"log_id", "input_content", "output_content", "detail_content", "session_id"}
+	values := []any{int64(7), nil, nil, nil, nil}
+
+	normalizeImportValues("request_log_content", columns, values)
+
+	for _, idx := range []int{1, 2, 3} {
+		got, ok := values[idx].([]byte)
+		if !ok || len(got) != 0 {
+			t.Fatalf("values[%d] = %#v, want empty []byte", idx, values[idx])
+		}
+	}
+	if values[4] != "" {
+		t.Fatalf("session_id = %#v, want empty string", values[4])
+	}
+}
+
 func TestImportSQLiteApplyUsesPostgresLockAndCompletionMarker(t *testing.T) {
 	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
 	if dsn == "" {


### PR DESCRIPTION
## Summary
- add a one-shot clirelay-migrate compose service and run it before recreating the app container
- keep the app container from running SQLite migration during startup once compose migration is responsible
- stream SQLite import table progress and coalesce legacy NULL request log content during import

## Tests
- go test ./cmd/updater
- go test ./internal/storage/postgres/sqliteinventory
- go test ./cmd/server ./cmd/updater ./internal/storage/postgres/sqliteinventory
- go test ./...
- docker compose config