### PR TITLE
fix: import sqlite from consistent snapshot

### DIFF
--- a/internal/storage/postgres/sqliteinventory/import.go
+++ b/internal/storage/postgres/sqliteinventory/import.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -93,20 +94,32 @@ func Import(ctx context.Context, opts ImportOptions) (ImportReport, error) {
 	if postgresDSN == "" {
 		return ImportReport{}, fmt.Errorf("sqlite import: postgres dsn is required")
 	}
-	inventory, err := Collect(ctx, Options{Path: sqlitePath, Now: opts.Now})
+	sqlitePath, err := filepath.Abs(sqlitePath)
 	if err != nil {
-		return ImportReport{}, err
+		return ImportReport{}, fmt.Errorf("sqlite import: absolute path: %w", err)
 	}
-	sourceFingerprint := importSourceFingerprint(inventory)
-	now := opts.Now
-	if now.IsZero() {
-		now = time.Now().UTC()
-	}
-	src, err := sql.Open("sqlite", "file:"+inventory.Path+"?mode=ro&_pragma=busy_timeout(5000)")
+	src, err := sql.Open("sqlite", "file:"+sqlitePath+"?mode=ro&_pragma=busy_timeout(5000)")
 	if err != nil {
 		return ImportReport{}, fmt.Errorf("sqlite import: open sqlite read-only: %w", err)
 	}
 	defer src.Close()
+	if err := src.PingContext(ctx); err != nil {
+		return ImportReport{}, fmt.Errorf("sqlite import: ping sqlite read-only: %w", err)
+	}
+	srcTx, err := src.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return ImportReport{}, fmt.Errorf("sqlite import: begin sqlite snapshot: %w", err)
+	}
+	defer func() { _ = srcTx.Rollback() }()
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	inventory, err := collectFromQuerier(ctx, sqlitePath, now, srcTx)
+	if err != nil {
+		return ImportReport{}, err
+	}
+	sourceFingerprint := importSourceFingerprint(inventory)
 	dst, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: postgresDSN, MaxOpenConns: 4, MaxIdleConns: 1})
 	if err != nil {
 		return ImportReport{}, err
@@ -147,7 +160,7 @@ func Import(ctx context.Context, opts ImportOptions) (ImportReport, error) {
 			continue
 		}
 		reportImportProgress(opts.Progress, "sqlite import progress: table %d/%d %s", i+1, len(runtimeImportTables), table)
-		row, err := importTable(ctx, src, dst, table, srcCols, opts.DryRun)
+		row, err := importTable(ctx, srcTx, dst, table, srcCols, opts.DryRun)
 		if err != nil {
 			return ImportReport{}, err
 		}
@@ -242,7 +255,7 @@ func markImportCompleted(ctx context.Context, db *sql.DB, sourceFingerprint, sql
 	return nil
 }
 
-func importTable(ctx context.Context, src, dst *sql.DB, table string, srcCols []string, dryRun bool) (ImportTableReport, error) {
+func importTable(ctx context.Context, src queryer, dst *sql.DB, table string, srcCols []string, dryRun bool) (ImportTableReport, error) {
 	dstCols, err := postgresColumns(ctx, dst, table)
 	if err != nil {
 		return ImportTableReport{}, err
@@ -351,7 +364,7 @@ func intersectColumns(source, target []string) []string {
 	return columns
 }
 
-func countRows(ctx context.Context, db *sql.DB, table string) (int64, error) {
+func countRows(ctx context.Context, db queryer, table string) (int64, error) {
 	var count int64
 	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&count); err != nil {
 		return 0, fmt.Errorf("sqlite import: count %s: %w", table, err)
@@ -359,7 +372,7 @@ func countRows(ctx context.Context, db *sql.DB, table string) (int64, error) {
 	return count, nil
 }
 
-func checksumRows(ctx context.Context, db *sql.DB, table string, columns []string, orderBy string) (string, error) {
+func checksumRows(ctx context.Context, db queryer, table string, columns []string, orderBy string) (string, error) {
 	query := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", quotedList(columns), quoteIdent(table), orderBy)
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
@@ -388,7 +401,7 @@ func checksumRows(ctx context.Context, db *sql.DB, table string, columns []strin
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func copyRows(ctx context.Context, src, dst *sql.DB, table string, columns []string, orderBy string) (int64, error) {
+func copyRows(ctx context.Context, src queryer, dst *sql.DB, table string, columns []string, orderBy string) (int64, error) {
 	query := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", quotedList(columns), quoteIdent(table), orderBy)
 	rows, err := src.QueryContext(ctx, query)
 	if err != nil {

--- a/internal/storage/postgres/sqliteinventory/import_test.go
+++ b/internal/storage/postgres/sqliteinventory/import_test.go
@@ -279,6 +279,110 @@ func TestImportSQLiteApplyUsesPostgresLockAndCompletionMarker(t *testing.T) {
 	}
 }
 
+func TestImportSQLiteUsesSingleSourceSnapshot(t *testing.T) {
+	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	ctx := context.Background()
+	pgDB, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	defer pgDB.Close()
+	if _, err := pgDB.Exec(`
+		DROP TABLE IF EXISTS sqlite_import_runs;
+		TRUNCATE
+			request_log_content,
+			request_logs
+		RESTART IDENTITY CASCADE
+	`); err != nil {
+		t.Fatalf("reset postgres: %v", err)
+	}
+
+	sqlitePath := filepath.Join(t.TempDir(), "usage.db")
+	sqliteDB, err := sql.Open("sqlite", sqlitePath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if _, err := sqliteDB.Exec(`
+		PRAGMA journal_mode = WAL;
+		CREATE TABLE request_logs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			timestamp DATETIME NOT NULL,
+			api_key TEXT NOT NULL,
+			api_key_id TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			failed INTEGER NOT NULL DEFAULT 0,
+			total_tokens INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE request_log_content (
+			log_id INTEGER PRIMARY KEY,
+			timestamp DATETIME NOT NULL,
+			compression TEXT NOT NULL DEFAULT 'zstd',
+			input_content BLOB NOT NULL DEFAULT X'',
+			output_content BLOB NOT NULL DEFAULT X'',
+			detail_content BLOB NOT NULL DEFAULT X''
+		);
+		INSERT INTO request_logs (id, timestamp, api_key, api_key_id, model, failed, total_tokens)
+		VALUES (1, '2026-07-05T01:00:00Z', 'fixture-key-a', 'key-a', 'gpt-test', 0, 11);
+		INSERT INTO request_log_content (log_id, timestamp, input_content, output_content, detail_content)
+		VALUES (1, '2026-07-05T01:00:00Z', X'7B7D', X'7B226F6B223A747275657D', X'7B2264657461696C223A747275657D');
+	`); err != nil {
+		t.Fatalf("seed sqlite: %v", err)
+	}
+	if err := sqliteDB.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+
+	src, err := sql.Open("sqlite", "file:"+sqlitePath+"?mode=ro&_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatalf("open source snapshot: %v", err)
+	}
+	defer src.Close()
+	srcTx, err := src.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("begin source snapshot: %v", err)
+	}
+	defer func() { _ = srcTx.Rollback() }()
+	inventory, err := collectFromQuerier(ctx, sqlitePath, time.Date(2026, 7, 5, 6, 0, 0, 0, time.UTC), srcTx)
+	if err != nil {
+		t.Fatalf("collect inventory: %v", err)
+	}
+	sourceColumns := make(map[string][]string, len(inventory.Tables))
+	for _, table := range inventory.Tables {
+		sourceColumns[table.Name] = table.Columns
+	}
+	if _, err := importTable(ctx, srcTx, pgDB, "request_logs", sourceColumns["request_logs"], false); err != nil {
+		t.Fatalf("import request_logs: %v", err)
+	}
+
+	writer, err := sql.Open("sqlite", sqlitePath)
+	if err != nil {
+		t.Fatalf("open sqlite writer: %v", err)
+	}
+	defer writer.Close()
+	if _, err := writer.Exec(`
+		INSERT INTO request_logs (id, timestamp, api_key, api_key_id, model, failed, total_tokens)
+		VALUES (2, '2026-07-05T01:01:00Z', 'fixture-key-b', 'key-b', 'gpt-test', 0, 22);
+		INSERT INTO request_log_content (log_id, timestamp, input_content, output_content, detail_content)
+		VALUES (2, '2026-07-05T01:01:00Z', X'7B7D', X'7B7D', X'7B7D');
+	`); err != nil {
+		t.Fatalf("write concurrent sqlite rows: %v", err)
+	}
+
+	if _, err := importTable(ctx, srcTx, pgDB, "request_log_content", sourceColumns["request_log_content"], false); err != nil {
+		t.Fatalf("import request_log_content: %v", err)
+	}
+	var count int
+	if err := pgDB.QueryRow("SELECT COUNT(*) FROM request_log_content").Scan(&count); err != nil {
+		t.Fatalf("count imported content: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("imported content rows = %d, want snapshot row only", count)
+	}
+}
+
 func findImportTable(rows []ImportTableReport, name string) *ImportTableReport {
 	for i := range rows {
 		if rows[i].Name == name {

--- a/internal/storage/postgres/sqliteinventory/inventory.go
+++ b/internal/storage/postgres/sqliteinventory/inventory.go
@@ -40,6 +40,11 @@ type Options struct {
 	Now  time.Time
 }
 
+type queryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
 var identifierRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 func WriteJSON(ctx context.Context, out io.Writer, opts Options) error {
@@ -73,23 +78,27 @@ func Collect(ctx context.Context, opts Options) (Inventory, error) {
 	if err := db.PingContext(ctx); err != nil {
 		return Inventory{}, fmt.Errorf("sqlite inventory: ping read-only: %w", err)
 	}
-	tables, err := listTables(ctx, db)
+	return collectFromQuerier(ctx, abs, now, db)
+}
+
+func collectFromQuerier(ctx context.Context, path string, now time.Time, q queryer) (Inventory, error) {
+	tables, err := listTables(ctx, q)
 	if err != nil {
 		return Inventory{}, err
 	}
 	stats := make([]TableStats, 0, len(tables))
 	for _, table := range tables {
-		row, err := tableStats(ctx, db, table)
+		row, err := tableStats(ctx, q, table)
 		if err != nil {
 			return Inventory{}, err
 		}
 		stats = append(stats, row)
 	}
-	return Inventory{Path: abs, ScannedAt: now.UTC(), Tables: stats}, nil
+	return Inventory{Path: path, ScannedAt: now.UTC(), Tables: stats}, nil
 }
 
-func listTables(ctx context.Context, db *sql.DB) ([]string, error) {
-	rows, err := db.QueryContext(ctx, `
+func listTables(ctx context.Context, q queryer) ([]string, error) {
+	rows, err := q.QueryContext(ctx, `
 		SELECT name
 		  FROM sqlite_master
 		 WHERE type = 'table'
@@ -116,8 +125,8 @@ func listTables(ctx context.Context, db *sql.DB) ([]string, error) {
 	return tables, nil
 }
 
-func tableStats(ctx context.Context, db *sql.DB, table string) (TableStats, error) {
-	columns, err := tableColumns(ctx, db, table)
+func tableStats(ctx context.Context, q queryer, table string) (TableStats, error) {
+	columns, err := tableColumns(ctx, q, table)
 	if err != nil {
 		return TableStats{}, err
 	}
@@ -127,12 +136,12 @@ func tableStats(ctx context.Context, db *sql.DB, table string) (TableStats, erro
 		DryRunOnly: true,
 	}
 	quotedTable := quoteIdent(table)
-	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+quotedTable).Scan(&stat.RowCount); err != nil {
+	if err := q.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+quotedTable).Scan(&stat.RowCount); err != nil {
 		return TableStats{}, fmt.Errorf("sqlite inventory: count %s: %w", table, err)
 	}
-	if hasColumn(columns, "id") && numericIDColumn(ctx, db, quotedTable) {
+	if hasColumn(columns, "id") && numericIDColumn(ctx, q, quotedTable) {
 		var minID, maxID sql.NullInt64
-		if err := db.QueryRowContext(ctx, "SELECT MIN(id), MAX(id) FROM "+quotedTable).Scan(&minID, &maxID); err != nil {
+		if err := q.QueryRowContext(ctx, "SELECT MIN(id), MAX(id) FROM "+quotedTable).Scan(&minID, &maxID); err != nil {
 			return TableStats{}, fmt.Errorf("sqlite inventory: id range %s: %w", table, err)
 		}
 		if minID.Valid {
@@ -146,13 +155,13 @@ func tableStats(ctx context.Context, db *sql.DB, table string) (TableStats, erro
 	if timeColumn != "" {
 		var minTime, maxTime sql.NullString
 		query := fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s", quoteIdent(timeColumn), quoteIdent(timeColumn), quotedTable)
-		if err := db.QueryRowContext(ctx, query).Scan(&minTime, &maxTime); err != nil {
+		if err := q.QueryRowContext(ctx, query).Scan(&minTime, &maxTime); err != nil {
 			return TableStats{}, fmt.Errorf("sqlite inventory: time range %s: %w", table, err)
 		}
 		stat.MinTime = minTime.String
 		stat.MaxTime = maxTime.String
 	}
-	checksum, err := tableChecksum(ctx, db, table, columns)
+	checksum, err := tableChecksum(ctx, q, table, columns)
 	if err != nil {
 		return TableStats{}, err
 	}
@@ -160,11 +169,11 @@ func tableStats(ctx context.Context, db *sql.DB, table string) (TableStats, erro
 	return stat, nil
 }
 
-func tableColumns(ctx context.Context, db *sql.DB, table string) ([]string, error) {
+func tableColumns(ctx context.Context, q queryer, table string) ([]string, error) {
 	if !validIdentifier(table) {
 		return nil, fmt.Errorf("sqlite inventory: invalid table name %q", table)
 	}
-	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+quoteIdent(table)+")")
+	rows, err := q.QueryContext(ctx, "PRAGMA table_info("+quoteIdent(table)+")")
 	if err != nil {
 		return nil, fmt.Errorf("sqlite inventory: columns %s: %w", table, err)
 	}
@@ -189,7 +198,7 @@ func tableColumns(ctx context.Context, db *sql.DB, table string) ([]string, erro
 	return columns, nil
 }
 
-func tableChecksum(ctx context.Context, db *sql.DB, table string, columns []string) (string, error) {
+func tableChecksum(ctx context.Context, q queryer, table string, columns []string) (string, error) {
 	if len(columns) == 0 {
 		return "", nil
 	}
@@ -198,7 +207,7 @@ func tableChecksum(ctx context.Context, db *sql.DB, table string, columns []stri
 		quotedColumns = append(quotedColumns, quoteIdent(column))
 	}
 	query := fmt.Sprintf("SELECT %s FROM %s ORDER BY rowid", strings.Join(quotedColumns, ","), quoteIdent(table))
-	rows, err := db.QueryContext(ctx, query)
+	rows, err := q.QueryContext(ctx, query)
 	if err != nil {
 		return "", fmt.Errorf("sqlite inventory: checksum query %s: %w", table, err)
 	}
@@ -245,10 +254,10 @@ func hasColumn(columns []string, name string) bool {
 	return false
 }
 
-func numericIDColumn(ctx context.Context, db *sql.DB, quotedTable string) bool {
+func numericIDColumn(ctx context.Context, q queryer, quotedTable string) bool {
 	var typ sql.NullString
 	query := "SELECT typeof(id) FROM " + quotedTable + " WHERE id IS NOT NULL LIMIT 1"
-	if err := db.QueryRowContext(ctx, query).Scan(&typ); err != nil {
+	if err := q.QueryRowContext(ctx, query).Scan(&typ); err != nil {
 		return false
 	}
 	return typ.String == "integer"


### PR DESCRIPTION
## Summary
- import SQLite inventory and runtime tables from one read-only SQLite transaction
- keep online update migration progress output
- add regression coverage for live SQLite writes during import

## Root cause
The online updater copied request_logs and request_log_content from different SQLite read moments while the old service kept writing. New request_log_content rows could reference request_logs rows that were not included in the earlier parent-table snapshot, triggering PostgreSQL foreign key failures.

## Validation
- CLIRELAY_POSTGRES_TEST_DSN='postgres://cliproxy:cliproxy@127.0.0.1:55432/cliproxy?sslmode=disable' go test ./cmd/updater ./cmd/server ./internal/storage/postgres ./internal/storage/postgres/sqliteinventory
- CLIRELAY_POSTGRES_TEST_DSN='postgres://cliproxy:cliproxy@127.0.0.1:55432/cliproxy?sslmode=disable' go test -count=1 -v ./internal/storage/postgres/sqliteinventory