### PR TITLE
fix: stabilize online update migration progress

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -80,6 +80,8 @@ type updateStatusResponse struct {
 	Status          string           `json:"status"`
 	Stage           string           `json:"stage"`
 	Message         string           `json:"message,omitempty"`
+	ProgressPercent int              `json:"progress_percent,omitempty"`
+	Migration       *migrationStatus `json:"migration,omitempty"`
 	Service         string           `json:"service,omitempty"`
 	TargetImage     string           `json:"target_image,omitempty"`
 	TargetTag       string           `json:"target_tag,omitempty"`
@@ -443,6 +445,7 @@ func (s *updaterServer) startUpdate(service string, req updateRequest) uint64 {
 		Status:          "running",
 		Stage:           "preparing",
 		Message:         "preparing update",
+		ProgressPercent: 5,
 		Service:         service,
 		TargetImage:     strings.TrimSpace(req.Image),
 		TargetTag:       strings.TrimSpace(req.Tag),
@@ -467,6 +470,7 @@ func (s *updaterServer) setStatus(status string, message string) {
 	s.status.Status = strings.TrimSpace(status)
 	s.status.Stage = strings.TrimSpace(status)
 	s.status.Message = strings.TrimSpace(message)
+	s.status.ProgressPercent = progressPercentForStage(status)
 	s.status.UpdatedAt = now
 	if status == "failed" || status == "completed" {
 		s.status.FinishedAt = now
@@ -490,6 +494,7 @@ func (s *updaterServer) appendLog(runID uint64, stream string, message string) {
 		}
 	}
 	s.status.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	s.updateProgressFromLog(trimmed)
 	s.status.Logs = append(s.status.Logs, updateLogEntry{
 		Timestamp: s.status.UpdatedAt,
 		Stream:    strings.TrimSpace(stream),
@@ -508,6 +513,8 @@ func (s *updaterServer) updateStage(runID uint64, stage string, message string) 
 	}
 	s.status.Stage = strings.TrimSpace(stage)
 	s.status.Message = strings.TrimSpace(message)
+	s.status.ProgressPercent = progressPercentForStage(stage)
+	s.updateProgressFromStage(stage, message)
 	s.status.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 }
 
@@ -521,6 +528,7 @@ func (s *updaterServer) finishUpdate(runID uint64, status string, stage string, 
 	s.status.Status = strings.TrimSpace(status)
 	s.status.Stage = strings.TrimSpace(stage)
 	s.status.Message = strings.TrimSpace(message)
+	s.status.ProgressPercent = progressPercentForStage(stage)
 	s.status.UpdatedAt = now
 	s.status.FinishedAt = now
 }
@@ -529,23 +537,14 @@ func (s *updaterServer) snapshot() updateStatusResponse {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	snapshot := s.status
+	if s.status.Migration != nil {
+		migration := *s.status.Migration
+		snapshot.Migration = &migration
+	}
 	if len(s.status.Logs) > 0 {
 		snapshot.Logs = append([]updateLogEntry(nil), s.status.Logs...)
 	}
 	return snapshot
-}
-
-func (s *updaterServer) pullSkipFailure(runID uint64) (string, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if runID != s.runID || !s.pullSkipped {
-		return "", false
-	}
-	message := "docker compose pull skipped the target service; check pull policy and image refresh settings"
-	if strings.TrimSpace(s.pullSkipLog) != "" {
-		message += ": " + strings.TrimSpace(s.pullSkipLog)
-	}
-	return message, true
 }
 
 type updaterRunReporter struct {
@@ -586,9 +585,10 @@ func runComposeUpdate(ctx context.Context, composeFile string, envFile string, p
 		if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "run", "--rm", "clirelay-migrate"); err != nil {
 			return err
 		}
+		reporter.Stage("migrating", "finishing SQLite migration before service restart")
 	}
-	reporter.Stage("restarting", "restarting service container")
-	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "--remove-orphans"); err != nil {
+	reporter.Stage("restarting", "recreating service container without restarting dependencies")
+	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "--no-deps", "--remove-orphans", service); err != nil {
 		return err
 	}
 	reporter.Stage("verifying", "docker update commands completed")

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -409,6 +409,40 @@ func TestUpdaterStatusExposesTargetStageAndLogs(t *testing.T) {
 	close(releaseRunner)
 }
 
+func TestUpdaterStatusParsesSQLiteMigrationProgress(t *testing.T) {
+	server := newUpdaterServer(updaterConfig{Token: "secret"})
+	runID := server.startUpdate("cli-proxy-api", updateRequest{})
+
+	reporter := updaterRunReporter{server: server, runID: runID}
+	reporter.Stage("migrating", "migrating legacy SQLite data before restarting service")
+	reporter.Log("stderr", "clirelay sqlite migration: applying SQLite import into PostgreSQL")
+	reporter.Log("stderr", "clirelay-migrate  | sqlite import progress: table 16/17 request_logs")
+	reporter.Log("stderr", "clirelay-migrate  | sqlite import progress: table request_logs inserted_rows=2 target_rows=167648")
+
+	payload := server.snapshot()
+	if payload.Stage != "migrating" {
+		t.Fatalf("Stage = %q, want migrating", payload.Stage)
+	}
+	if payload.ProgressPercent < 86 {
+		t.Fatalf("ProgressPercent = %d, want table-based progress", payload.ProgressPercent)
+	}
+	if payload.Migration == nil {
+		t.Fatal("Migration = nil, want migration detail")
+	}
+	if payload.Migration.TargetDatabase != "PostgreSQL" {
+		t.Fatalf("TargetDatabase = %q, want PostgreSQL", payload.Migration.TargetDatabase)
+	}
+	if payload.Migration.Phase != "applying" {
+		t.Fatalf("Phase = %q, want applying", payload.Migration.Phase)
+	}
+	if payload.Migration.Table != "request_logs" || payload.Migration.TableIndex != 16 || payload.Migration.TableTotal != 17 {
+		t.Fatalf("Migration table = %+v, want request_logs 16/17", payload.Migration)
+	}
+	if payload.Migration.InsertedRows != 2 || payload.Migration.TargetRows != 167648 {
+		t.Fatalf("Migration rows = %+v, want inserted/target rows", payload.Migration)
+	}
+}
+
 func TestUpdaterFailsWhenComposePullSkipsTargetService(t *testing.T) {
 	called := make(chan struct{}, 1)
 	envFile := filepath.Join(t.TempDir(), ".env")
@@ -482,7 +516,7 @@ func TestBuildComposeArgsIncludesProjectName(t *testing.T) {
 	}
 }
 
-func TestRunComposeUpdateStartsFullComposeStack(t *testing.T) {
+func TestRunComposeUpdateRecreatesOnlyTargetService(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "docker.log")
 	dockerPath := filepath.Join(dir, "docker")
@@ -514,7 +548,7 @@ func TestRunComposeUpdateStartsFullComposeStack(t *testing.T) {
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " pull clirelay",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d postgres redis",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " run --rm clirelay-migrate",
-		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --remove-orphans",
+		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --no-deps --remove-orphans clirelay",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("compose commands = %#v, want %#v", got, want)
@@ -553,7 +587,7 @@ func TestRunComposeUpdateUsesEnvFileNextToComposeWhenUnset(t *testing.T) {
 		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " pull clirelay",
 		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " up -d postgres redis",
 		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " run --rm clirelay-migrate",
-		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " up -d --remove-orphans",
+		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " up -d --no-deps --remove-orphans clirelay",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("compose commands = %#v, want %#v", got, want)
@@ -634,7 +668,7 @@ func TestRunComposeUpdateUpgradesLegacySQLiteComposeWithRuntimeStack(t *testing.
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " pull clirelay",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d postgres redis",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " run --rm clirelay-migrate",
-		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --remove-orphans",
+		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --no-deps --remove-orphans clirelay",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("compose commands = %#v, want %#v", got, want)

--- a/cmd/updater/migration_progress.go
+++ b/cmd/updater/migration_progress.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type migrationStatus struct {
+	Phase          string `json:"phase,omitempty"`
+	TargetDatabase string `json:"target_database,omitempty"`
+	Table          string `json:"table,omitempty"`
+	TableIndex     int    `json:"table_index,omitempty"`
+	TableTotal     int    `json:"table_total,omitempty"`
+	InsertedRows   int64  `json:"inserted_rows,omitempty"`
+	TargetRows     int64  `json:"target_rows,omitempty"`
+	PlannedInserts int64  `json:"planned_inserts,omitempty"`
+}
+
+func (s *updaterServer) updateProgressFromStage(stage string, message string) {
+	switch strings.TrimSpace(stage) {
+	case "migrating":
+		migration := s.ensureMigrationStatus()
+		migration.TargetDatabase = "PostgreSQL"
+		switch strings.TrimSpace(message) {
+		case "starting PostgreSQL/Redis before SQLite migration":
+			migration.Phase = "starting_runtime"
+			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 35)
+		case "migrating legacy SQLite data before restarting service":
+			migration.Phase = "preparing"
+			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 40)
+		case "finishing SQLite migration before service restart":
+			migration.Phase = "finalizing"
+			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 90)
+		}
+	case "restarting":
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 92)
+	case "verifying":
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 97)
+	}
+}
+
+func (s *updaterServer) updateProgressFromLog(message string) {
+	if strings.Contains(message, "clirelay sqlite migration: running read-only SQLite inventory") {
+		migration := s.ensureMigrationStatus()
+		migration.Phase = "inventory"
+		migration.TargetDatabase = "PostgreSQL"
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 44)
+		return
+	}
+	if strings.Contains(message, "clirelay sqlite migration: running PostgreSQL import dry-run") {
+		migration := s.ensureMigrationStatus()
+		migration.Phase = "dry_run"
+		migration.TargetDatabase = "PostgreSQL"
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 54)
+		return
+	}
+	if strings.Contains(message, "clirelay sqlite migration: applying SQLite import into PostgreSQL") {
+		migration := s.ensureMigrationStatus()
+		migration.Phase = "applying"
+		migration.TargetDatabase = "PostgreSQL"
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 62)
+		return
+	}
+	if strings.Contains(message, "clirelay sqlite migration: migration complete") {
+		migration := s.ensureMigrationStatus()
+		migration.Phase = "finalizing"
+		migration.TargetDatabase = "PostgreSQL"
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 90)
+		return
+	}
+	if strings.Contains(message, "sqlite import progress: table ") {
+		s.updateSQLiteTableProgress(message)
+	}
+}
+
+func (s *updaterServer) ensureMigrationStatus() *migrationStatus {
+	if s.status.Migration == nil {
+		s.status.Migration = &migrationStatus{TargetDatabase: "PostgreSQL"}
+	}
+	return s.status.Migration
+}
+
+func (s *updaterServer) updateSQLiteTableProgress(message string) {
+	migration := s.ensureMigrationStatus()
+	migration.TargetDatabase = "PostgreSQL"
+	_, text, ok := strings.Cut(message, "sqlite import progress: table ")
+	if !ok {
+		return
+	}
+	text = strings.TrimSpace(text)
+	var index, total int
+	var table string
+	if n, _ := fmt.Sscanf(text, "%d/%d %s", &index, &total, &table); n == 3 {
+		migration.TableIndex = index
+		migration.TableTotal = total
+		migration.Table = strings.TrimSpace(table)
+		if migration.Phase == "" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
+			migration.Phase = "applying"
+		}
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, migrationTablePercent(index, total))
+		return
+	}
+	fields := strings.Fields(text)
+	if len(fields) == 0 {
+		return
+	}
+	migration.Table = fields[0]
+	for _, field := range fields[1:] {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "inserted_rows":
+			if parsed, err := strconv.ParseInt(value, 10, 64); err == nil {
+				migration.InsertedRows = parsed
+			}
+		case "target_rows":
+			if parsed, err := strconv.ParseInt(value, 10, 64); err == nil {
+				migration.TargetRows = parsed
+			}
+		case "planned_inserts":
+			if parsed, err := strconv.ParseInt(value, 10, 64); err == nil {
+				migration.PlannedInserts = parsed
+			}
+		}
+	}
+	if strings.Contains(text, "dry-run") {
+		migration.Phase = "dry_run"
+	} else if migration.Phase == "" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
+		migration.Phase = "applying"
+	}
+}
+
+func progressPercentForStage(stage string) int {
+	switch strings.TrimSpace(stage) {
+	case "idle":
+		return 0
+	case "preparing":
+		return 5
+	case "pulling":
+		return 15
+	case "migrating":
+		return 35
+	case "restarting":
+		return 92
+	case "verifying":
+		return 97
+	case "completed":
+		return 100
+	default:
+		return 0
+	}
+}
+
+func migrationTablePercent(index int, total int) int {
+	if index <= 0 || total <= 0 {
+		return 62
+	}
+	if index > total {
+		index = total
+	}
+	return 62 + (index * 26 / total)
+}
+
+func maxInt(left int, right int) int {
+	if left > right {
+		return left
+	}
+	return right
+}

--- a/cmd/updater/status_helpers.go
+++ b/cmd/updater/status_helpers.go
@@ -1,0 +1,16 @@
+package main
+
+import "strings"
+
+func (s *updaterServer) pullSkipFailure(runID uint64) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if runID != s.runID || !s.pullSkipped {
+		return "", false
+	}
+	message := "docker compose pull skipped the target service; check pull policy and image refresh settings"
+	if strings.TrimSpace(s.pullSkipLog) != "" {
+		message += ": " + strings.TrimSpace(s.pullSkipLog)
+	}
+	return message, true
+}

--- a/internal/api/handlers/management/update_test.go
+++ b/internal/api/handlers/management/update_test.go
@@ -692,7 +692,7 @@ func TestFetchUpdateProgressProxiesUpdaterStatus(t *testing.T) {
 			t.Fatalf("Authorization = %q, want Bearer test-token", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"running","stage":"pulling","target_version":"dev-abcdef1","logs":[{"timestamp":"2026-04-20T07:30:01Z","stream":"stdout","message":"docker compose pull clirelay"}]}`))
+		_, _ = w.Write([]byte(`{"status":"running","stage":"migrating","progress_percent":86,"target_version":"dev-abcdef1","migration":{"phase":"applying","target_database":"PostgreSQL","table":"request_logs","table_index":16,"table_total":17,"inserted_rows":2,"target_rows":167648},"logs":[{"timestamp":"2026-04-20T07:30:01Z","stream":"stdout","message":"docker compose pull clirelay"}]}`))
 	}))
 	t.Cleanup(updater.Close)
 	t.Setenv("CLIRELAY_UPDATER_URL", updater.URL)
@@ -706,8 +706,14 @@ func TestFetchUpdateProgressProxiesUpdaterStatus(t *testing.T) {
 	if progress.Status != "running" {
 		t.Fatalf("Status = %q, want running", progress.Status)
 	}
-	if progress.Stage != "pulling" {
-		t.Fatalf("Stage = %q, want pulling", progress.Stage)
+	if progress.Stage != "migrating" {
+		t.Fatalf("Stage = %q, want migrating", progress.Stage)
+	}
+	if progress.ProgressPercent != 86 {
+		t.Fatalf("ProgressPercent = %d, want 86", progress.ProgressPercent)
+	}
+	if progress.Migration == nil || progress.Migration.Table != "request_logs" || progress.Migration.TargetRows != 167648 {
+		t.Fatalf("Migration = %+v, want migration details", progress.Migration)
 	}
 	if progress.TargetVersion != "dev-abcdef1" {
 		t.Fatalf("TargetVersion = %q, want dev-abcdef1", progress.TargetVersion)

--- a/internal/management/updateflow/types.go
+++ b/internal/management/updateflow/types.go
@@ -63,6 +63,8 @@ type ProgressResponse struct {
 	Status          string             `json:"status"`
 	Stage           string             `json:"stage"`
 	Message         string             `json:"message,omitempty"`
+	ProgressPercent int                `json:"progress_percent,omitempty"`
+	Migration       *MigrationProgress `json:"migration,omitempty"`
 	Service         string             `json:"service,omitempty"`
 	TargetImage     string             `json:"target_image,omitempty"`
 	TargetTag       string             `json:"target_tag,omitempty"`
@@ -75,6 +77,17 @@ type ProgressResponse struct {
 	UpdatedAt       string             `json:"updated_at,omitempty"`
 	FinishedAt      string             `json:"finished_at,omitempty"`
 	Logs            []ProgressLogEntry `json:"logs,omitempty"`
+}
+
+type MigrationProgress struct {
+	Phase          string `json:"phase,omitempty"`
+	TargetDatabase string `json:"target_database,omitempty"`
+	Table          string `json:"table,omitempty"`
+	TableIndex     int    `json:"table_index,omitempty"`
+	TableTotal     int    `json:"table_total,omitempty"`
+	InsertedRows   int64  `json:"inserted_rows,omitempty"`
+	TargetRows     int64  `json:"target_rows,omitempty"`
+	PlannedInserts int64  `json:"planned_inserts,omitempty"`
 }
 
 type GitCommitActor struct {


### PR DESCRIPTION
## Summary
- avoid rerunning the migration job during final service recreation by using no-deps for the target service
- expose structured SQLite to PostgreSQL migration progress from the updater
- proxy migration progress through the management API

## Tests
- rtk go test ./cmd/updater
- rtk go test ./internal/api/handlers/management ./internal/management/updateflow
- rtk go test ./...