### PR TITLE
fix: clarify online update migration status

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -581,11 +581,11 @@ func runComposeUpdate(ctx context.Context, composeFile string, envFile string, p
 		if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "postgres", "redis"); err != nil {
 			return err
 		}
-		reporter.Stage("migrating", "migrating legacy SQLite data before restarting service")
+		reporter.Stage("migrating", "checking legacy SQLite migration before service restart")
 		if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "run", "--rm", "clirelay-migrate"); err != nil {
 			return err
 		}
-		reporter.Stage("migrating", "finishing SQLite migration before service restart")
+		reporter.Stage("migrating", "legacy SQLite migration check finished before service restart")
 	}
 	reporter.Stage("restarting", "recreating service container without restarting dependencies")
 	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "--no-deps", "--remove-orphans", service); err != nil {

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -80,7 +80,7 @@ type updateStatusResponse struct {
 	Status          string           `json:"status"`
 	Stage           string           `json:"stage"`
 	Message         string           `json:"message,omitempty"`
-	ProgressPercent int              `json:"progress_percent,omitempty"`
+	ProgressPercent float64          `json:"progress_percent,omitempty"`
 	Migration       *migrationStatus `json:"migration,omitempty"`
 	Service         string           `json:"service,omitempty"`
 	TargetImage     string           `json:"target_image,omitempty"`
@@ -577,7 +577,7 @@ func runComposeUpdate(ctx context.Context, composeFile string, envFile string, p
 		return err
 	}
 	if composeFileHasService(composeFile, "clirelay-migrate") {
-		reporter.Stage("migrating", "starting PostgreSQL/Redis before SQLite migration")
+		reporter.Stage("migrating", "starting PostgreSQL/Redis before data migration check")
 		if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "postgres", "redis"); err != nil {
 			return err
 		}

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -424,8 +424,8 @@ func TestUpdaterStatusParsesSQLiteMigrationProgress(t *testing.T) {
 	if payload.Stage != "migrating" {
 		t.Fatalf("Stage = %q, want migrating", payload.Stage)
 	}
-	if payload.ProgressPercent < 86 {
-		t.Fatalf("ProgressPercent = %d, want table-based progress", payload.ProgressPercent)
+	if payload.ProgressPercent < 84 || payload.ProgressPercent >= 86 {
+		t.Fatalf("ProgressPercent = %.2f, want row-based progress inside table 16/17", payload.ProgressPercent)
 	}
 	if payload.Migration == nil {
 		t.Fatal("Migration = nil, want migration detail")
@@ -441,6 +441,12 @@ func TestUpdaterStatusParsesSQLiteMigrationProgress(t *testing.T) {
 	}
 	if payload.Migration.InsertedRows != 2 || payload.Migration.TargetRows != 167648 {
 		t.Fatalf("Migration rows = %+v, want inserted/target rows", payload.Migration)
+	}
+
+	reporter.Log("stderr", "clirelay-migrate  | sqlite import progress: table request_logs inserted_rows=167648 target_rows=167648")
+	payload = server.snapshot()
+	if payload.ProgressPercent <= 86 || payload.ProgressPercent >= 89 {
+		t.Fatalf("ProgressPercent = %.2f, want row progress near completed table 16/17", payload.ProgressPercent)
 	}
 }
 
@@ -464,7 +470,7 @@ func TestUpdaterStatusMarksSQLiteMigrationSkipped(t *testing.T) {
 		t.Fatalf("Migration = %+v, want skipped disabled", payload.Migration)
 	}
 	if payload.ProgressPercent < 88 {
-		t.Fatalf("ProgressPercent = %d, want skip progress near restart", payload.ProgressPercent)
+		t.Fatalf("ProgressPercent = %.2f, want skip progress near restart", payload.ProgressPercent)
 	}
 }
 

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -414,7 +414,8 @@ func TestUpdaterStatusParsesSQLiteMigrationProgress(t *testing.T) {
 	runID := server.startUpdate("cli-proxy-api", updateRequest{})
 
 	reporter := updaterRunReporter{server: server, runID: runID}
-	reporter.Stage("migrating", "migrating legacy SQLite data before restarting service")
+	reporter.Stage("migrating", "checking legacy SQLite migration before service restart")
+	reporter.Log("stderr", "clirelay sqlite migration: legacy SQLite found at /CLIProxyAPI/data/usage.db")
 	reporter.Log("stderr", "clirelay sqlite migration: applying SQLite import into PostgreSQL")
 	reporter.Log("stderr", "clirelay-migrate  | sqlite import progress: table 16/17 request_logs")
 	reporter.Log("stderr", "clirelay-migrate  | sqlite import progress: table request_logs inserted_rows=2 target_rows=167648")
@@ -440,6 +441,30 @@ func TestUpdaterStatusParsesSQLiteMigrationProgress(t *testing.T) {
 	}
 	if payload.Migration.InsertedRows != 2 || payload.Migration.TargetRows != 167648 {
 		t.Fatalf("Migration rows = %+v, want inserted/target rows", payload.Migration)
+	}
+}
+
+func TestUpdaterStatusMarksSQLiteMigrationSkipped(t *testing.T) {
+	server := newUpdaterServer(updaterConfig{Token: "secret"})
+	runID := server.startUpdate("cli-proxy-api", updateRequest{})
+
+	reporter := updaterRunReporter{server: server, runID: runID}
+	reporter.Stage("migrating", "checking legacy SQLite migration before service restart")
+	reporter.Log("stderr", "clirelay sqlite migration: disabled by CLIRELAY_SQLITE_AUTO_MIGRATE")
+	reporter.Stage("migrating", "legacy SQLite migration check finished before service restart")
+
+	payload := server.snapshot()
+	if payload.Message != "legacy SQLite migration skipped because auto-migration is disabled" {
+		t.Fatalf("Message = %q, want disabled skip message", payload.Message)
+	}
+	if payload.Migration == nil {
+		t.Fatal("Migration = nil, want skipped migration detail")
+	}
+	if payload.Migration.Phase != "skipped" || payload.Migration.SkipReason != "disabled" {
+		t.Fatalf("Migration = %+v, want skipped disabled", payload.Migration)
+	}
+	if payload.ProgressPercent < 88 {
+		t.Fatalf("ProgressPercent = %d, want skip progress near restart", payload.ProgressPercent)
 	}
 }
 

--- a/cmd/updater/migration_progress.go
+++ b/cmd/updater/migration_progress.go
@@ -24,25 +24,25 @@ func (s *updaterServer) updateProgressFromStage(stage string, message string) {
 		migration := s.ensureMigrationStatus()
 		migration.TargetDatabase = "PostgreSQL"
 		switch strings.TrimSpace(message) {
-		case "starting PostgreSQL/Redis before SQLite migration":
+		case "starting PostgreSQL/Redis before SQLite migration", "starting PostgreSQL/Redis before data migration check":
 			migration.Phase = "starting_runtime"
-			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 35)
+			s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 35)
 		case "checking legacy SQLite migration before service restart":
 			migration.Phase = "checking"
-			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 40)
+			s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 40)
 		case "legacy SQLite migration check finished before service restart", "finishing SQLite migration before service restart":
 			if migration.Phase == "skipped" {
 				s.status.Message = migrationSkippedMessage(migration.SkipReason)
-				s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 90)
+				s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 90)
 				return
 			}
 			migration.Phase = "finalizing"
-			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 90)
+			s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 90)
 		}
 	case "restarting":
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 92)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 92)
 	case "verifying":
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 97)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 97)
 	}
 }
 
@@ -53,7 +53,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration.SkipReason = "disabled"
 		migration.TargetDatabase = "PostgreSQL"
 		s.status.Message = "legacy SQLite migration skipped because auto-migration is disabled"
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 88)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 88)
 		return
 	}
 	if strings.Contains(message, "clirelay sqlite migration: no legacy usage.db found") {
@@ -62,7 +62,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration.SkipReason = "no_legacy_sqlite"
 		migration.TargetDatabase = "PostgreSQL"
 		s.status.Message = "no legacy SQLite database found; continuing with PostgreSQL runtime data"
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 88)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 88)
 		return
 	}
 	if strings.Contains(message, "clirelay sqlite migration: apply disabled by CLIRELAY_SQLITE_AUTO_IMPORT") {
@@ -71,7 +71,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration.SkipReason = "import_disabled"
 		migration.TargetDatabase = "PostgreSQL"
 		s.status.Message = "SQLite import dry-run complete; apply is disabled"
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 88)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 88)
 		return
 	}
 	if strings.Contains(message, "clirelay sqlite migration: legacy SQLite found at ") {
@@ -79,7 +79,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration.Phase = "preparing"
 		migration.TargetDatabase = "PostgreSQL"
 		s.status.Message = "legacy SQLite database found; preparing PostgreSQL import"
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 42)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 42)
 		return
 	}
 	if strings.Contains(message, "clirelay sqlite migration: running read-only SQLite inventory") {
@@ -87,7 +87,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration.Phase = "inventory"
 		migration.TargetDatabase = "PostgreSQL"
 		s.status.Message = "running SQLite inventory before PostgreSQL import"
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 44)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 44)
 		return
 	}
 	if strings.Contains(message, "clirelay sqlite migration: running PostgreSQL import dry-run") {
@@ -95,7 +95,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration.Phase = "dry_run"
 		migration.TargetDatabase = "PostgreSQL"
 		s.status.Message = "running PostgreSQL import dry-run"
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 54)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 54)
 		return
 	}
 	if strings.Contains(message, "clirelay sqlite migration: applying SQLite import into PostgreSQL") {
@@ -103,7 +103,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration.Phase = "applying"
 		migration.TargetDatabase = "PostgreSQL"
 		s.status.Message = "applying legacy SQLite data into PostgreSQL"
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 62)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 62)
 		return
 	}
 	if strings.Contains(message, "clirelay sqlite migration: migration complete") {
@@ -111,7 +111,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration.Phase = "finalizing"
 		migration.TargetDatabase = "PostgreSQL"
 		s.status.Message = "legacy SQLite migration complete; preparing service restart"
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 90)
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, 90)
 		return
 	}
 	if strings.Contains(message, "sqlite import progress: table ") {
@@ -156,7 +156,7 @@ func (s *updaterServer) updateSQLiteTableProgress(message string) {
 		if migration.Phase == "" || migration.Phase == "checking" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
 			migration.Phase = "applying"
 		}
-		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, migrationTablePercent(index, total))
+		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, migrationTableStartPercent(index, total))
 		return
 	}
 	fields := strings.Fields(text)
@@ -184,6 +184,17 @@ func (s *updaterServer) updateSQLiteTableProgress(message string) {
 			}
 		}
 	}
+	if migration.TableIndex > 0 && migration.TableTotal > 0 && migration.TargetRows > 0 {
+		s.status.ProgressPercent = maxFloat(
+			s.status.ProgressPercent,
+			migrationTableRowPercent(
+				migration.TableIndex,
+				migration.TableTotal,
+				migration.InsertedRows,
+				migration.TargetRows,
+			),
+		)
+	}
 	if strings.Contains(text, "dry-run") {
 		migration.Phase = "dry_run"
 	} else if migration.Phase == "" || migration.Phase == "checking" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
@@ -191,7 +202,7 @@ func (s *updaterServer) updateSQLiteTableProgress(message string) {
 	}
 }
 
-func progressPercentForStage(stage string) int {
+func progressPercentForStage(stage string) float64 {
 	switch strings.TrimSpace(stage) {
 	case "idle":
 		return 0
@@ -212,17 +223,35 @@ func progressPercentForStage(stage string) int {
 	}
 }
 
-func migrationTablePercent(index int, total int) int {
+func migrationTableStartPercent(index int, total int) float64 {
 	if index <= 0 || total <= 0 {
 		return 62
 	}
 	if index > total {
 		index = total
 	}
-	return 62 + (index * 26 / total)
+	return 62 + (float64(index-1) * 26 / float64(total))
 }
 
-func maxInt(left int, right int) int {
+func migrationTableRowPercent(index int, total int, inserted int64, target int64) float64 {
+	if index <= 0 || total <= 0 || target <= 0 {
+		return migrationTableStartPercent(index, total)
+	}
+	if index > total {
+		index = total
+	}
+	if inserted < 0 {
+		inserted = 0
+	}
+	if inserted > target {
+		inserted = target
+	}
+	completed := float64(index - 1)
+	fraction := float64(inserted) / float64(target)
+	return 62 + ((completed + fraction) * 26 / float64(total))
+}
+
+func maxFloat(left float64, right float64) float64 {
 	if left > right {
 		return left
 	}

--- a/cmd/updater/migration_progress.go
+++ b/cmd/updater/migration_progress.go
@@ -9,6 +9,7 @@ import (
 type migrationStatus struct {
 	Phase          string `json:"phase,omitempty"`
 	TargetDatabase string `json:"target_database,omitempty"`
+	SkipReason     string `json:"skip_reason,omitempty"`
 	Table          string `json:"table,omitempty"`
 	TableIndex     int    `json:"table_index,omitempty"`
 	TableTotal     int    `json:"table_total,omitempty"`
@@ -26,10 +27,15 @@ func (s *updaterServer) updateProgressFromStage(stage string, message string) {
 		case "starting PostgreSQL/Redis before SQLite migration":
 			migration.Phase = "starting_runtime"
 			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 35)
-		case "migrating legacy SQLite data before restarting service":
-			migration.Phase = "preparing"
+		case "checking legacy SQLite migration before service restart":
+			migration.Phase = "checking"
 			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 40)
-		case "finishing SQLite migration before service restart":
+		case "legacy SQLite migration check finished before service restart", "finishing SQLite migration before service restart":
+			if migration.Phase == "skipped" {
+				s.status.Message = migrationSkippedMessage(migration.SkipReason)
+				s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 90)
+				return
+			}
 			migration.Phase = "finalizing"
 			s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 90)
 		}
@@ -41,10 +47,46 @@ func (s *updaterServer) updateProgressFromStage(stage string, message string) {
 }
 
 func (s *updaterServer) updateProgressFromLog(message string) {
+	if strings.Contains(message, "clirelay sqlite migration: disabled by CLIRELAY_SQLITE_AUTO_MIGRATE") {
+		migration := s.ensureMigrationStatus()
+		migration.Phase = "skipped"
+		migration.SkipReason = "disabled"
+		migration.TargetDatabase = "PostgreSQL"
+		s.status.Message = "legacy SQLite migration skipped because auto-migration is disabled"
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 88)
+		return
+	}
+	if strings.Contains(message, "clirelay sqlite migration: no legacy usage.db found") {
+		migration := s.ensureMigrationStatus()
+		migration.Phase = "skipped"
+		migration.SkipReason = "no_legacy_sqlite"
+		migration.TargetDatabase = "PostgreSQL"
+		s.status.Message = "no legacy SQLite database found; continuing with PostgreSQL runtime data"
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 88)
+		return
+	}
+	if strings.Contains(message, "clirelay sqlite migration: apply disabled by CLIRELAY_SQLITE_AUTO_IMPORT") {
+		migration := s.ensureMigrationStatus()
+		migration.Phase = "skipped"
+		migration.SkipReason = "import_disabled"
+		migration.TargetDatabase = "PostgreSQL"
+		s.status.Message = "SQLite import dry-run complete; apply is disabled"
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 88)
+		return
+	}
+	if strings.Contains(message, "clirelay sqlite migration: legacy SQLite found at ") {
+		migration := s.ensureMigrationStatus()
+		migration.Phase = "preparing"
+		migration.TargetDatabase = "PostgreSQL"
+		s.status.Message = "legacy SQLite database found; preparing PostgreSQL import"
+		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 42)
+		return
+	}
 	if strings.Contains(message, "clirelay sqlite migration: running read-only SQLite inventory") {
 		migration := s.ensureMigrationStatus()
 		migration.Phase = "inventory"
 		migration.TargetDatabase = "PostgreSQL"
+		s.status.Message = "running SQLite inventory before PostgreSQL import"
 		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 44)
 		return
 	}
@@ -52,6 +94,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration := s.ensureMigrationStatus()
 		migration.Phase = "dry_run"
 		migration.TargetDatabase = "PostgreSQL"
+		s.status.Message = "running PostgreSQL import dry-run"
 		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 54)
 		return
 	}
@@ -59,6 +102,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration := s.ensureMigrationStatus()
 		migration.Phase = "applying"
 		migration.TargetDatabase = "PostgreSQL"
+		s.status.Message = "applying legacy SQLite data into PostgreSQL"
 		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 62)
 		return
 	}
@@ -66,6 +110,7 @@ func (s *updaterServer) updateProgressFromLog(message string) {
 		migration := s.ensureMigrationStatus()
 		migration.Phase = "finalizing"
 		migration.TargetDatabase = "PostgreSQL"
+		s.status.Message = "legacy SQLite migration complete; preparing service restart"
 		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, 90)
 		return
 	}
@@ -79,6 +124,19 @@ func (s *updaterServer) ensureMigrationStatus() *migrationStatus {
 		s.status.Migration = &migrationStatus{TargetDatabase: "PostgreSQL"}
 	}
 	return s.status.Migration
+}
+
+func migrationSkippedMessage(reason string) string {
+	switch reason {
+	case "disabled":
+		return "legacy SQLite migration skipped because auto-migration is disabled"
+	case "no_legacy_sqlite":
+		return "no legacy SQLite database found; continuing with PostgreSQL runtime data"
+	case "import_disabled":
+		return "SQLite import dry-run complete; apply is disabled"
+	default:
+		return "legacy SQLite migration check finished before service restart"
+	}
 }
 
 func (s *updaterServer) updateSQLiteTableProgress(message string) {
@@ -95,7 +153,7 @@ func (s *updaterServer) updateSQLiteTableProgress(message string) {
 		migration.TableIndex = index
 		migration.TableTotal = total
 		migration.Table = strings.TrimSpace(table)
-		if migration.Phase == "" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
+		if migration.Phase == "" || migration.Phase == "checking" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
 			migration.Phase = "applying"
 		}
 		s.status.ProgressPercent = maxInt(s.status.ProgressPercent, migrationTablePercent(index, total))
@@ -128,7 +186,7 @@ func (s *updaterServer) updateSQLiteTableProgress(message string) {
 	}
 	if strings.Contains(text, "dry-run") {
 		migration.Phase = "dry_run"
-	} else if migration.Phase == "" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
+	} else if migration.Phase == "" || migration.Phase == "checking" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
 		migration.Phase = "applying"
 	}
 }

--- a/internal/api/handlers/management/update_test.go
+++ b/internal/api/handlers/management/update_test.go
@@ -710,7 +710,7 @@ func TestFetchUpdateProgressProxiesUpdaterStatus(t *testing.T) {
 		t.Fatalf("Stage = %q, want migrating", progress.Stage)
 	}
 	if progress.ProgressPercent != 86 {
-		t.Fatalf("ProgressPercent = %d, want 86", progress.ProgressPercent)
+		t.Fatalf("ProgressPercent = %.2f, want 86", progress.ProgressPercent)
 	}
 	if progress.Migration == nil || progress.Migration.Table != "request_logs" || progress.Migration.TargetRows != 167648 {
 		t.Fatalf("Migration = %+v, want migration details", progress.Migration)
@@ -720,6 +720,25 @@ func TestFetchUpdateProgressProxiesUpdaterStatus(t *testing.T) {
 	}
 	if len(progress.Logs) != 1 || progress.Logs[0].Message != "docker compose pull clirelay" {
 		t.Fatalf("Logs = %+v, want updater log entry", progress.Logs)
+	}
+}
+
+func TestFetchUpdateProgressProxiesMigrationSkipReason(t *testing.T) {
+	updater := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"running","stage":"migrating","progress_percent":88,"message":"no legacy SQLite database found; continuing with PostgreSQL runtime data","migration":{"phase":"skipped","target_database":"PostgreSQL","skip_reason":"no_legacy_sqlite"}}`))
+	}))
+	t.Cleanup(updater.Close)
+	t.Setenv("CLIRELAY_UPDATER_URL", updater.URL)
+	t.Setenv("CLIRELAY_UPDATER_TOKEN", "test-token")
+
+	handler := &Handler{cfg: &config.Config{}}
+	progress, err := handler.fetchUpdateProgress(context.Background())
+	if err != nil {
+		t.Fatalf("fetchUpdateProgress() error = %v, want nil", err)
+	}
+	if progress.Migration == nil || progress.Migration.SkipReason != "no_legacy_sqlite" {
+		t.Fatalf("Migration = %+v, want proxied skip reason", progress.Migration)
 	}
 }
 

--- a/internal/management/updateflow/types.go
+++ b/internal/management/updateflow/types.go
@@ -63,7 +63,7 @@ type ProgressResponse struct {
 	Status          string             `json:"status"`
 	Stage           string             `json:"stage"`
 	Message         string             `json:"message,omitempty"`
-	ProgressPercent int                `json:"progress_percent,omitempty"`
+	ProgressPercent float64            `json:"progress_percent,omitempty"`
 	Migration       *MigrationProgress `json:"migration,omitempty"`
 	Service         string             `json:"service,omitempty"`
 	TargetImage     string             `json:"target_image,omitempty"`
@@ -82,6 +82,7 @@ type ProgressResponse struct {
 type MigrationProgress struct {
 	Phase          string `json:"phase,omitempty"`
 	TargetDatabase string `json:"target_database,omitempty"`
+	SkipReason     string `json:"skip_reason,omitempty"`
 	Table          string `json:"table,omitempty"`
 	TableIndex     int    `json:"table_index,omitempty"`
 	TableTotal     int    `json:"table_total,omitempty"`

--- a/internal/storage/postgres/sqliteinventory/import.go
+++ b/internal/storage/postgres/sqliteinventory/import.go
@@ -160,7 +160,7 @@ func Import(ctx context.Context, opts ImportOptions) (ImportReport, error) {
 			continue
 		}
 		reportImportProgress(opts.Progress, "sqlite import progress: table %d/%d %s", i+1, len(runtimeImportTables), table)
-		row, err := importTable(ctx, srcTx, dst, table, srcCols, opts.DryRun)
+		row, err := importTable(ctx, srcTx, dst, table, srcCols, opts.DryRun, opts.Progress)
 		if err != nil {
 			return ImportReport{}, err
 		}
@@ -255,7 +255,7 @@ func markImportCompleted(ctx context.Context, db *sql.DB, sourceFingerprint, sql
 	return nil
 }
 
-func importTable(ctx context.Context, src queryer, dst *sql.DB, table string, srcCols []string, dryRun bool) (ImportTableReport, error) {
+func importTable(ctx context.Context, src queryer, dst *sql.DB, table string, srcCols []string, dryRun bool, progress io.Writer) (ImportTableReport, error) {
 	dstCols, err := postgresColumns(ctx, dst, table)
 	if err != nil {
 		return ImportTableReport{}, err
@@ -294,7 +294,7 @@ func importTable(ctx context.Context, src queryer, dst *sql.DB, table string, sr
 	if dryRun || sourceRows == 0 {
 		return row, nil
 	}
-	inserted, err := copyRows(ctx, src, dst, table, columns, orderBy)
+	inserted, err := copyRows(ctx, src, dst, table, columns, orderBy, sourceRows, progress)
 	if err != nil {
 		return ImportTableReport{}, err
 	}
@@ -401,7 +401,7 @@ func checksumRows(ctx context.Context, db queryer, table string, columns []strin
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func copyRows(ctx context.Context, src queryer, dst *sql.DB, table string, columns []string, orderBy string) (int64, error) {
+func copyRows(ctx context.Context, src queryer, dst *sql.DB, table string, columns []string, orderBy string, plannedRows int64, progress io.Writer) (int64, error) {
 	query := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", quotedList(columns), quoteIdent(table), orderBy)
 	rows, err := src.QueryContext(ctx, query)
 	if err != nil {
@@ -449,6 +449,7 @@ func copyRows(ctx context.Context, src queryer, dst *sql.DB, table string, colum
 			if err := commit(); err != nil {
 				return 0, fmt.Errorf("sqlite import: commit %s: %w", table, err)
 			}
+			reportImportProgress(progress, "sqlite import progress: table %s inserted_rows=%d target_rows=%d", table, inserted, plannedRows)
 			tx, err = dst.BeginTx(ctx, nil)
 			if err != nil {
 				return 0, fmt.Errorf("sqlite import: begin %s: %w", table, err)
@@ -463,6 +464,7 @@ func copyRows(ctx context.Context, src queryer, dst *sql.DB, table string, colum
 	if err := commit(); err != nil {
 		return 0, fmt.Errorf("sqlite import: commit %s: %w", table, err)
 	}
+	reportImportProgress(progress, "sqlite import progress: table %s inserted_rows=%d target_rows=%d", table, inserted, plannedRows)
 	return inserted, nil
 }
 

--- a/internal/storage/postgres/sqliteinventory/import_test.go
+++ b/internal/storage/postgres/sqliteinventory/import_test.go
@@ -1,10 +1,12 @@
 package sqliteinventory
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -353,8 +355,12 @@ func TestImportSQLiteUsesSingleSourceSnapshot(t *testing.T) {
 	for _, table := range inventory.Tables {
 		sourceColumns[table.Name] = table.Columns
 	}
-	if _, err := importTable(ctx, srcTx, pgDB, "request_logs", sourceColumns["request_logs"], false); err != nil {
+	var progress bytes.Buffer
+	if _, err := importTable(ctx, srcTx, pgDB, "request_logs", sourceColumns["request_logs"], false, &progress); err != nil {
 		t.Fatalf("import request_logs: %v", err)
+	}
+	if !strings.Contains(progress.String(), "sqlite import progress: table request_logs inserted_rows=1 target_rows=1") {
+		t.Fatalf("progress log = %q, want request_logs row progress", progress.String())
 	}
 
 	writer, err := sql.Open("sqlite", sqlitePath)
@@ -371,7 +377,7 @@ func TestImportSQLiteUsesSingleSourceSnapshot(t *testing.T) {
 		t.Fatalf("write concurrent sqlite rows: %v", err)
 	}
 
-	if _, err := importTable(ctx, srcTx, pgDB, "request_log_content", sourceColumns["request_log_content"], false); err != nil {
+	if _, err := importTable(ctx, srcTx, pgDB, "request_log_content", sourceColumns["request_log_content"], false, nil); err != nil {
 		t.Fatalf("import request_log_content: %v", err)
 	}
 	var count int


### PR DESCRIPTION
## Summary\n- change updater migration stage from active migration to legacy SQLite migration check before the migrate task reports real work\n- surface skipped/no legacy SQLite/dry-run/apply/complete states from migration logs\n- preserve skipped migration status through the final migration-check stage\n\n## Verification\n- rtk go test ./cmd/updater\n- rtk go test ./...