### PR TITLE
fix: stabilize online update failure recovery

### DIFF
--- a/cmd/updater/env_file.go
+++ b/cmd/updater/env_file.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func configuredImageInFile(envFile string) string {
+	if strings.TrimSpace(envFile) == "" {
+		return ""
+	}
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		return ""
+	}
+	return configuredImageRef(splitEnvLines(string(data)))
+}
+
+func restoreRequestedImage(ctx context.Context, envFile string, imageRef string, reporter updateReporter, updateErr error) error {
+	if strings.TrimSpace(envFile) == "" || strings.TrimSpace(imageRef) == "" {
+		return updateErr
+	}
+	if err := writeEnvKey(ctx, envFile, "CLI_PROXY_IMAGE", imageRef, reporter); err != nil {
+		return fmt.Errorf("%w; restore previous CLI_PROXY_IMAGE failed: %v", updateErr, err)
+	}
+	reporter.Log("stdout", "restored previous CLI_PROXY_IMAGE after failed update")
+	return updateErr
+}
+
+func writeEnvKey(ctx context.Context, envFile string, key string, value string, reporter updateReporter) error {
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		return err
+	}
+	lines := splitEnvLines(string(data))
+	line := key + "=" + value
+	for i, existing := range lines {
+		currentKey, _, ok := strings.Cut(existing, "=")
+		if ok && strings.TrimSpace(currentKey) == key {
+			lines[i] = line
+			return writeDeploymentFile(ctx, envFile, []byte(strings.Join(lines, "\n")+"\n"), 0o600, reporter)
+		}
+	}
+	lines = append(lines, line)
+	return writeDeploymentFile(ctx, envFile, []byte(strings.Join(lines, "\n")+"\n"), 0o600, reporter)
+}

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -269,6 +269,7 @@ func (s *updaterServer) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	if strings.TrimSpace(envFile) == "" && strings.TrimSpace(s.composeFile) != "" {
 		envFile = filepath.Join(filepath.Dir(s.composeFile), ".env")
 	}
+	previousImage := configuredImageInFile(envFile)
 	if err := persistRequestedImage(s.context(), envFile, req.Image, req.Tag); err != nil {
 		if errors.Is(err, errRequestedImageNotAllowed) {
 			message := err.Error()
@@ -290,12 +291,14 @@ func (s *updaterServer) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 		reporter := updaterRunReporter{server: s, runID: runID}
 		if err := s.runner(ctx, s.composeFile, s.envFile, s.projectName, service, reporter); err != nil {
+			err = restoreRequestedImage(ctx, envFile, previousImage, reporter, err)
 			log.Printf("compose update failed: %v", err)
 			reporter.Stage("failed", err.Error())
 			s.finishUpdate(runID, "failed", "failed", err.Error())
 			return
 		}
 		if message, skipped := s.pullSkipFailure(runID); skipped {
+			message = restoreRequestedImage(ctx, envFile, previousImage, reporter, errors.New(message)).Error()
 			reporter.Stage("failed", message)
 			s.finishUpdate(runID, "failed", "failed", message)
 			return

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -181,6 +182,56 @@ func TestUpdaterPersistsRequestedImageBeforeComposeUpdate(t *testing.T) {
 	case <-called:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for runner")
+	}
+}
+
+func TestUpdaterRestoresRequestedImageAfterRunnerFailure(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:latest\nOTHER=value\n"), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	called := make(chan struct{}, 1)
+	server := newUpdaterServer(updaterConfig{
+		Token:   "secret",
+		EnvFile: envFile,
+		Runner: func(_ context.Context, _ string, _ string, _ string, _ string, _ updateReporter) error {
+			called <- struct{}{}
+			return errors.New("compose failed")
+		},
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/update",
+		strings.NewReader(`{"service":"cli-proxy-api","image":"ghcr.io/kittors/clirelay","tag":"dev"}`),
+	)
+	setUpdaterAuth(req)
+	rec := httptest.NewRecorder()
+
+	server.handleUpdate(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner")
+	}
+	eventually(t, time.Second, func() bool {
+		return server.snapshot().Status == "failed"
+	})
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:latest\n") || strings.Contains(content, "CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:dev\n") {
+		t.Fatalf("env file content = %q, want previous image restored", content)
+	}
+	if !strings.Contains(content, "OTHER=value\n") {
+		t.Fatalf("env file content = %q, want unrelated values preserved", content)
 	}
 }
 
@@ -522,6 +573,13 @@ func TestUpdaterFailsWhenComposePullSkipsTargetService(t *testing.T) {
 	}
 	if !strings.Contains(payload.Message, "pull skipped") {
 		t.Fatalf("Message = %q, want pull skipped hint", payload.Message)
+	}
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	if string(data) != "CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:old\n" {
+		t.Fatalf("env file content = %q, want previous image restored", string(data))
 	}
 }
 

--- a/cmd/updater/migration_progress.go
+++ b/cmd/updater/migration_progress.go
@@ -153,9 +153,10 @@ func (s *updaterServer) updateSQLiteTableProgress(message string) {
 		migration.TableIndex = index
 		migration.TableTotal = total
 		migration.Table = strings.TrimSpace(table)
-		if migration.Phase == "" || migration.Phase == "checking" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
+		if migration.Phase == "" || migration.Phase == "checking" || migration.Phase == "preparing" {
 			migration.Phase = "applying"
 		}
+		s.status.Message = "applying legacy SQLite data into PostgreSQL"
 		s.status.ProgressPercent = maxFloat(s.status.ProgressPercent, migrationTableStartPercent(index, total))
 		return
 	}
@@ -199,6 +200,9 @@ func (s *updaterServer) updateSQLiteTableProgress(message string) {
 		migration.Phase = "dry_run"
 	} else if migration.Phase == "" || migration.Phase == "checking" || migration.Phase == "preparing" || migration.Phase == "dry_run" {
 		migration.Phase = "applying"
+	}
+	if migration.Phase == "applying" {
+		s.status.Message = "applying legacy SQLite data into PostgreSQL"
 	}
 }
 


### PR DESCRIPTION
## Summary
- restore the previous CLI_PROXY_IMAGE when compose update fails after persisting the requested image
- also restore the image when docker compose pull skips the target service
- keep SQLite dry-run progress from being mislabeled as applying rows

## Verification
- rtk go test ./cmd/updater
- rtk go test ./cmd/updater ./internal/management/updateflow ./internal/api/handlers/management
- rtk go test ./...