### PR TITLE
fix: route ollama cloud through official APIs

### DIFF
--- a/internal/api/handlers/management/cline_config_test.go
+++ b/internal/api/handlers/management/cline_config_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -33,17 +32,17 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if len(h.cfg.ClineKey) != 1 || h.cfg.ClineKey[0].APIKey != "cline-key" || h.cfg.ClineKey[0].Prefix != "team" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL {
 		t.Fatalf("ClineKey after PUT = %+v", h.cfg.ClineKey)
 	}
-	if len(h.cfg.ClineKey[0].Models) != 1 || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/glm-5.2" {
-		t.Fatalf("ClineKey models after PUT = %+v", h.cfg.ClineKey[0].Models)
+	if len(h.cfg.ClineKey[0].Models) != 0 {
+		t.Fatalf("ClineKey models after PUT = %+v, want nil", h.cfg.ClineKey[0].Models)
 	}
 	if len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/minimax-m3" {
 		t.Fatalf("ClineKey excluded models after PUT = %+v", h.cfg.ClineKey[0].ExcludedModels)
 	}
-	if h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
+	if h.cfg.ClineKey[0].VisionFallbackModel != "" {
 		t.Fatalf("ClineKey vision fallback after PUT = %+v", h.cfg.ClineKey[0])
 	}
 
-	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"cline-pass/qwen3.7-max"}],"excluded-models":[" cline-pass/deepseek-v4-flash "],"vision-fallback-model":" cline-pass/qwen3.7-vl "}}`)
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"cline-pass/qwen3.7-max"}],"excluded-models":[" cline-pass/deepseek-v4-flash ","*"],"vision-fallback-model":" cline-pass/qwen3.7-vl "}}`)
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/cline-api-key", bytes.NewReader(patchBody))
@@ -51,7 +50,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/qwen3.7-max" || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 0 || len(h.cfg.ClineKey[0].ExcludedModels) != 2 || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || h.cfg.ClineKey[0].ExcludedModels[1] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "" {
 		t.Fatalf("ClineKey after PATCH = %+v", h.cfg.ClineKey[0])
 	}
 
@@ -68,7 +67,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 2 || getBody.Items[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || getBody.Items[0].ExcludedModels[1] != "*" || getBody.Items[0].VisionFallbackModel != "" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 
@@ -84,7 +83,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 }
 
-func TestClineKeyManagementRejectsBareModels(t *testing.T) {
+func TestClineKeyManagementDropsPerKeyModels(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
@@ -95,18 +94,15 @@ func TestClineKeyManagementRejectsBareModels(t *testing.T) {
 		configFilePath: configPath,
 	}
 
-	putBody := []byte(`[{"api-key":"cline-key","models":[{"name":"glm-5.2"}]}]`)
+	putBody := []byte(`[{"api-key":"cline-key","models":[{"name":"glm-5.2"}],"excluded-models":["cline-pass/minimax-m3","*"],"vision-fallback-model":"cline-pass/mimo-v2.5-pro"}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/cline-api-key", bytes.NewReader(putBody))
 	h.ProviderKeys().PutClineKeys(c)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("PUT status = %d body=%s, want 400", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "cline models contains invalid model") {
-		t.Fatalf("PUT body = %s, want invalid model error", w.Body.String())
-	}
-	if got := h.cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" {
-		t.Fatalf("ClineKey after rejected PUT = %+v, want unchanged existing entry", got)
+	if got := h.cfg.ClineKey; len(got) != 1 || got[0].APIKey != "cline-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "" || len(got[0].ExcludedModels) != 2 || got[0].ExcludedModels[0] != "cline-pass/minimax-m3" || got[0].ExcludedModels[1] != "*" {
+		t.Fatalf("ClineKey after PUT = %+v, want sanitized entry", got)
 	}
 }

--- a/internal/api/handlers/management/model_definitions.go
+++ b/internal/api/handlers/management/model_definitions.go
@@ -15,6 +15,8 @@ import (
 var (
 	clineRecommendedModelsURL    = "https://api.cline.bot/api/v1/ai/cline/recommended-models"
 	clineRecommendedModelsClient = &http.Client{Timeout: 5 * time.Second}
+	ollamaCloudModelsURL         = "https://ollama.com/v1/models"
+	ollamaCloudModelsClient      = &http.Client{Timeout: 5 * time.Second}
 )
 
 // GetStaticModelDefinitions returns static model metadata for a given channel.
@@ -40,11 +42,70 @@ func (h *Handler) GetStaticModelDefinitions(c *gin.Context) {
 			models = remoteModels
 		}
 	}
+	if normalizedChannel == "ollama-cloud" {
+		if remoteModels, err := fetchOllamaCloudModelDefinitions(c.Request.Context()); err == nil && len(remoteModels) > 0 {
+			models = remoteModels
+		}
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"channel": normalizedChannel,
 		"models":  models,
 	})
+}
+
+func fetchOllamaCloudModelDefinitions(ctx context.Context) ([]*registry.ModelInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ollamaCloudModelsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := ollamaCloudModelsClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("ollama cloud models status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Data []struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			Created int64  `json:"created"`
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	models := make([]*registry.ModelInfo, 0, len(payload.Data))
+	for _, item := range payload.Data {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			continue
+		}
+		object := strings.TrimSpace(item.Object)
+		if object == "" {
+			object = "model"
+		}
+		ownedBy := strings.TrimSpace(item.OwnedBy)
+		if ownedBy == "" {
+			ownedBy = "ollama"
+		}
+		models = append(models, &registry.ModelInfo{
+			ID:          id,
+			Object:      object,
+			Created:     item.Created,
+			OwnedBy:     ownedBy,
+			Type:        "ollama-cloud",
+			DisplayName: id,
+		})
+	}
+	return models, nil
 }
 
 func fetchClinePassModelDefinitions(ctx context.Context) ([]*registry.ModelInfo, error) {

--- a/internal/api/handlers/management/model_definitions_test.go
+++ b/internal/api/handlers/management/model_definitions_test.go
@@ -41,6 +41,27 @@ func withClineRecommendedModelsServer(t *testing.T, status int, body string) {
 	clineRecommendedModelsClient = server.Client()
 }
 
+func withOllamaCloudModelsServer(t *testing.T, status int, body string) {
+	t.Helper()
+	previousURL := ollamaCloudModelsURL
+	previousClient := ollamaCloudModelsClient
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		ollamaCloudModelsURL = previousURL
+		ollamaCloudModelsClient = previousClient
+	})
+	ollamaCloudModelsURL = server.URL + "/v1/models"
+	ollamaCloudModelsClient = server.Client()
+}
+
 func TestGetStaticModelDefinitionsUsesClineRecommendedModels(t *testing.T) {
 	withClineRecommendedModelsServer(t, http.StatusOK, `{
 		"clinePass": [
@@ -97,4 +118,38 @@ func TestGetStaticModelDefinitionsFallsBackToClineStaticModels(t *testing.T) {
 		}
 	}
 	t.Fatalf("expected static fallback to include cline-pass/glm-5.2, got %+v", payload.Models)
+}
+
+func TestGetStaticModelDefinitionsUsesOllamaCloudModelsAPI(t *testing.T) {
+	withOllamaCloudModelsServer(t, http.StatusOK, `{
+		"object": "list",
+		"data": [
+			{"id": "gpt-oss:120b", "object": "model", "created": 1, "owned_by": "ollama"},
+			{"id": " ", "object": "model"}
+		]
+	}`)
+	h := NewHandler(&config.Config{}, "", nil)
+
+	rec := performModelDefinitionsRequest(h.GetStaticModelDefinitions, "ollama-cloud")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Models []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+			OwnedBy     string `json:"owned_by"`
+			Type        string `json:"type"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Models) != 1 {
+		t.Fatalf("expected one remote model, got %+v", payload.Models)
+	}
+	model := payload.Models[0]
+	if model.ID != "gpt-oss:120b" || model.DisplayName != "gpt-oss:120b" || model.OwnedBy != "ollama" || model.Type != "ollama-cloud" {
+		t.Fatalf("unexpected model payload: %+v", model)
+	}
 }

--- a/internal/api/handlers/management/opencode_go_config_test.go
+++ b/internal/api/handlers/management/opencode_go_config_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -22,7 +21,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	h := &Handler{cfg: &config.Config{}, configFilePath: configPath}
 
-	putBody := []byte(`[{"api-key":" go-key ","name":" primary ","prefix":" team ","headers":{"X-Test":" yes "},"vision-fallback-model":" qwen3.5-plus ","workspace-id":" wrk_123 ","auth-cookie":" auth-token "}]`)
+	putBody := []byte(`[{"api-key":" go-key ","name":" primary ","prefix":" team ","headers":{"X-Test":" yes "},"models":[{"name":"cline-pass/glm-5.2"}],"excluded-models":["minimax-m2.5","*"],"vision-fallback-model":" qwen3.5-plus ","workspace-id":" wrk_123 ","auth-cookie":" auth-token "}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/opencode-go-api-key", bytes.NewReader(putBody))
@@ -30,11 +29,11 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
+	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "" || len(h.cfg.OpenCodeGoKey[0].Models) != 0 || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 2 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].ExcludedModels[1] != "*" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v", h.cfg.OpenCodeGoKey)
 	}
 
-	patchBody := []byte(`{"index":0,"value":{"name":"secondary","excluded-models":[" minimax-m2.5 "],"vision-fallback-model":" qwen3.6-plus ","workspace-id":" https://opencode.ai/workspace/wrk_456/go ","auth-cookie":" auth-next "}}`)
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","models":[{"name":"qwen3.7-max"}],"excluded-models":[" minimax-m2.5 "],"vision-fallback-model":" qwen3.6-plus ","workspace-id":" https://opencode.ai/workspace/wrk_456/go ","auth-cookie":" auth-next "}}`)
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/opencode-go-api-key", bytes.NewReader(patchBody))
@@ -42,7 +41,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.6-plus" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_456" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-next" {
+	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 1 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "" || len(h.cfg.OpenCodeGoKey[0].Models) != 0 || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_456" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-next" {
 		t.Fatalf("OpenCodeGoKey after PATCH = %+v", h.cfg.OpenCodeGoKey[0])
 	}
 
@@ -59,7 +58,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "" || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "minimax-m2.5" || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 
@@ -75,7 +74,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 }
 
-func TestOpenCodeGoKeyManagementRejectsClinePassModels(t *testing.T) {
+func TestOpenCodeGoKeyManagementDropsPerKeyModels(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
@@ -86,18 +85,15 @@ func TestOpenCodeGoKeyManagementRejectsClinePassModels(t *testing.T) {
 		configFilePath: configPath,
 	}
 
-	putBody := []byte(`[{"api-key":"go-key","models":[{"name":"cline-pass/glm-5.2"}]}]`)
+	putBody := []byte(`[{"api-key":"go-key","models":[{"name":"cline-pass/glm-5.2"}],"excluded-models":["minimax-m2.5","*"],"vision-fallback-model":"cline-pass/mimo-v2.5-pro"}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/opencode-go-api-key", bytes.NewReader(putBody))
 	h.ProviderKeys().PutOpenCodeGoKeys(c)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("PUT status = %d body=%s, want 400", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "opencode-go models contains invalid model") {
-		t.Fatalf("PUT body = %s, want invalid model error", w.Body.String())
-	}
-	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "existing" {
-		t.Fatalf("OpenCodeGoKey after rejected PUT = %+v, want unchanged existing entry", got)
+	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "" || len(got[0].ExcludedModels) != 2 || got[0].ExcludedModels[0] != "minimax-m2.5" || got[0].ExcludedModels[1] != "*" {
+		t.Fatalf("OpenCodeGoKey after PUT = %+v, want sanitized entry", got)
 	}
 }

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -179,9 +179,6 @@ func syncOllamaCloudConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.C
 		return
 	}
 	models := sdkmodelcatalog.StaticModelDefinitionsByChannel("ollama-cloud")
-	if len(entry.Models) > 0 {
-		models = buildOllamaCloudConfigModels(entry.Models, models)
-	}
 	models = applyConfigModelExclusions(models, entry.ExcludedModels)
 	reg.RegisterClient(auth.ID, "ollama-cloud", applyConfigModelPrefixes(models, auth.Prefix, cfg.ForceModelPrefix))
 }

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -225,9 +225,9 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
-		entry.Models = NormalizeOpenCodeGoModels(entry.Models)
+		entry.Models = nil
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
-		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+		entry.VisionFallbackModel = ""
 		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
 		entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
 		out = append(out, entry)
@@ -279,9 +279,9 @@ func (cfg *Config) SanitizeClineKeys() {
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
-		entry.Models = NormalizeClineModels(entry.Models)
+		entry.Models = nil
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
-		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+		entry.VisionFallbackModel = ""
 		out = append(out, entry)
 	}
 	cfg.ClineKey = out

--- a/internal/config/ollama_cloud_test.go
+++ b/internal/config/ollama_cloud_test.go
@@ -1,0 +1,25 @@
+package config
+
+import "testing"
+
+func TestSanitizeOllamaCloudKeysPreservesModels(t *testing.T) {
+	cfg := &Config{OllamaCloudKey: []OllamaCloudKey{{
+		APIKey:         " sk-ollama ",
+		BaseURL:        "https://ollama.com/",
+		Models:         []OllamaCloudModel{{Name: "gpt-oss:120b"}},
+		ExcludedModels: []string{"gpt-oss:20b", "*"},
+	}}}
+
+	cfg.SanitizeOllamaCloudKeys()
+
+	if len(cfg.OllamaCloudKey) != 1 {
+		t.Fatalf("keys len = %d", len(cfg.OllamaCloudKey))
+	}
+	got := cfg.OllamaCloudKey[0]
+	if len(got.Models) != 1 || got.Models[0].Name != "gpt-oss:120b" {
+		t.Fatalf("models = %#v, want normalized per-key models", got.Models)
+	}
+	if len(got.ExcludedModels) != 2 || got.ExcludedModels[0] != "gpt-oss:20b" || got.ExcludedModels[1] != "*" {
+		t.Fatalf("excluded models = %#v, want normalized exclusions", got.ExcludedModels)
+	}
+}

--- a/internal/config/opencode_go_test.go
+++ b/internal/config/opencode_go_test.go
@@ -20,6 +20,7 @@ opencode-go-api-key:
       X-Test: " yes "
     excluded-models:
       - " deepseek-v4-pro "
+      - " * "
     models:
       - name: " qwen3.7-max "
       - name: " qwen3.7-max "
@@ -46,14 +47,14 @@ opencode-go-api-key:
 	if got.Headers["X-Test"] != "yes" {
 		t.Fatalf("headers = %#v, want normalized X-Test", got.Headers)
 	}
-	if len(got.ExcludedModels) != 1 || got.ExcludedModels[0] != "deepseek-v4-pro" {
+	if len(got.ExcludedModels) != 2 || got.ExcludedModels[0] != "deepseek-v4-pro" || got.ExcludedModels[1] != "*" {
 		t.Fatalf("excluded models = %#v", got.ExcludedModels)
 	}
-	if len(got.Models) != 2 || got.Models[0].Name != "qwen3.7-max" || got.Models[1].Name != "kimi-k2.7-code" {
-		t.Fatalf("models = %#v", got.Models)
+	if len(got.Models) != 0 {
+		t.Fatalf("models = %#v, want nil", got.Models)
 	}
-	if got.VisionFallbackModel != "qwen3.5-plus" {
-		t.Fatalf("vision fallback model = %q, want qwen3.5-plus", got.VisionFallbackModel)
+	if got.VisionFallbackModel != "" {
+		t.Fatalf("vision fallback model = %q, want empty", got.VisionFallbackModel)
 	}
 }
 
@@ -63,7 +64,7 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 			{APIKey: " "},
 			{APIKey: "go-key", Prefix: " team "},
 			{APIKey: "go-key", Prefix: "duplicate"},
-			{APIKey: "go-key-2", Headers: map[string]string{" X-Trace ": " on "}, Models: []OpenCodeGoModel{{Name: " glm-5.2 "}, {Name: "GLM-5.2"}, {Name: " "}}, VisionFallbackModel: " qwen3.6-plus ", WorkspaceID: " wrk_123 ", AuthCookie: " auth-token "},
+			{APIKey: "go-key-2", Headers: map[string]string{" X-Trace ": " on "}, Models: []OpenCodeGoModel{{Name: " glm-5.2 "}, {Name: "GLM-5.2"}, {Name: " "}}, ExcludedModels: []string{"glm-5.2", "*"}, VisionFallbackModel: " qwen3.6-plus ", WorkspaceID: " wrk_123 ", AuthCookie: " auth-token "},
 		},
 	}
 
@@ -78,11 +79,14 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 	if cfg.OpenCodeGoKey[1].Headers["X-Trace"] != "on" {
 		t.Fatalf("headers = %#v, want normalized header", cfg.OpenCodeGoKey[1].Headers)
 	}
-	if cfg.OpenCodeGoKey[1].VisionFallbackModel != "qwen3.6-plus" {
-		t.Fatalf("vision fallback model = %q, want qwen3.6-plus", cfg.OpenCodeGoKey[1].VisionFallbackModel)
+	if cfg.OpenCodeGoKey[1].VisionFallbackModel != "" {
+		t.Fatalf("vision fallback model = %q, want empty", cfg.OpenCodeGoKey[1].VisionFallbackModel)
 	}
-	if len(cfg.OpenCodeGoKey[1].Models) != 1 || cfg.OpenCodeGoKey[1].Models[0].Name != "glm-5.2" {
-		t.Fatalf("models = %#v, want normalized unique model", cfg.OpenCodeGoKey[1].Models)
+	if len(cfg.OpenCodeGoKey[1].Models) != 0 {
+		t.Fatalf("models = %#v, want nil", cfg.OpenCodeGoKey[1].Models)
+	}
+	if len(cfg.OpenCodeGoKey[1].ExcludedModels) != 2 || cfg.OpenCodeGoKey[1].ExcludedModels[0] != "glm-5.2" || cfg.OpenCodeGoKey[1].ExcludedModels[1] != "*" {
+		t.Fatalf("excluded models = %#v, want normalized exclusions", cfg.OpenCodeGoKey[1].ExcludedModels)
 	}
 	if cfg.OpenCodeGoKey[1].WorkspaceID != "wrk_123" || cfg.OpenCodeGoKey[1].AuthCookie != "auth-token" {
 		t.Fatalf("usage fields not normalized: %+v", cfg.OpenCodeGoKey[1])

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -555,9 +555,9 @@ func NormalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
-	entry.Models = config.NormalizeOpenCodeGoModels(entry.Models)
+	entry.Models = nil
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+	entry.VisionFallbackModel = ""
 	if workspaceID, err := normalizeOpenCodeGoWorkspaceID(entry.WorkspaceID); err == nil {
 		entry.WorkspaceID = workspaceID
 	} else {
@@ -592,9 +592,9 @@ func NormalizeClineKey(entry *config.ClineKey) {
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
-	entry.Models = config.NormalizeClineModels(entry.Models)
+	entry.Models = nil
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+	entry.VisionFallbackModel = ""
 }
 
 func NormalizedClineKeyEntries(entries []config.ClineKey) []config.ClineKey {

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"errors"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -362,7 +361,7 @@ func TestOpenCodeGoKeysReplacePatchDeleteAndRollback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PatchOpenCodeGoKey() error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey[0]; got.Name != "secondary" || !reflect.DeepEqual(got.ExcludedModels, []string{"minimax-m2.5"}) || got.WorkspaceID != "wrk_456" || got.AuthCookie != "auth-next" {
+	if got := cfg.OpenCodeGoKey[0]; got.Name != "secondary" || !reflect.DeepEqual(got.ExcludedModels, []string{"minimax-m2.5"}) || got.VisionFallbackModel != "" || got.WorkspaceID != "wrk_456" || got.AuthCookie != "auth-next" {
 		t.Fatalf("patched opencode go key = %#v", got)
 	}
 
@@ -374,7 +373,7 @@ func TestOpenCodeGoKeysReplacePatchDeleteAndRollback(t *testing.T) {
 	}
 }
 
-func TestOpenCodeGoKeysRejectClinePassModels(t *testing.T) {
+func TestOpenCodeGoKeysDropPerKeyModels(t *testing.T) {
 	cfg := &config.Config{
 		OpenCodeGoKey: []config.OpenCodeGoKey{{
 			APIKey: "existing",
@@ -390,27 +389,20 @@ func TestOpenCodeGoKeysRejectClinePassModels(t *testing.T) {
 		Models: []config.OpenCodeGoModel{{
 			Name: " cline-pass/glm-5.2 ",
 		}},
+		ExcludedModels:      []string{"minimax-m2.5", "*"},
+		VisionFallbackModel: "cline-pass/mimo-v2.5-pro",
 	}})
-	if err == nil || !strings.Contains(err.Error(), "opencode-go models contains invalid model") {
-		t.Fatalf("ReplaceOpenCodeGoKeys() error = %v, want invalid opencode-go model error", err)
+	if err != nil {
+		t.Fatalf("ReplaceOpenCodeGoKeys() error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "existing" || got[0].Models[0].Name != "glm-5.2" {
-		t.Fatalf("OpenCodeGoKey after rejected replace = %#v, want unchanged existing entry", got)
-	}
-
-	badExcluded := []string{"cline-pass/minimax-m3"}
-	err = svc.PatchOpenCodeGoKey(nil, stringPtr("existing"), nil, OpenCodeGoPatch{ExcludedModels: &badExcluded})
-	if err == nil || !strings.Contains(err.Error(), "opencode-go excluded-models contains invalid model") {
-		t.Fatalf("PatchOpenCodeGoKey(excluded-models) error = %v, want invalid opencode-go model error", err)
-	}
-	if got := cfg.OpenCodeGoKey[0].ExcludedModels; len(got) != 0 {
-		t.Fatalf("OpenCodeGoKey excluded models after rejected patch = %#v, want unchanged empty list", got)
+	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "" || !reflect.DeepEqual(got[0].ExcludedModels, []string{"minimax-m2.5", "*"}) {
+		t.Fatalf("OpenCodeGoKey after replace = %#v, want sanitized entry", got)
 	}
 
-	validExcluded := []string{"*"}
+	validExcluded := []string{"*", "minimax-m2.5"}
 	validFallback := " qwen3.5-plus "
 	validModels := []config.OpenCodeGoModel{{Name: " glm-5.2 "}}
-	err = svc.PatchOpenCodeGoKey(nil, stringPtr("existing"), nil, OpenCodeGoPatch{
+	err = svc.PatchOpenCodeGoKey(nil, stringPtr("go-key"), nil, OpenCodeGoPatch{
 		Models:         &validModels,
 		ExcludedModels: &validExcluded,
 		VisionFallback: &validFallback,
@@ -418,12 +410,12 @@ func TestOpenCodeGoKeysRejectClinePassModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PatchOpenCodeGoKey(valid models) error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey[0]; got.Models[0].Name != "glm-5.2" || got.ExcludedModels[0] != "*" || got.VisionFallbackModel != "qwen3.5-plus" {
+	if got := cfg.OpenCodeGoKey[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*", "minimax-m2.5"}) || got.VisionFallbackModel != "" {
 		t.Fatalf("OpenCodeGoKey after valid patch = %#v", got)
 	}
 }
 
-func TestClineKeysRejectNonClinePassModels(t *testing.T) {
+func TestClineKeysDropPerKeyModels(t *testing.T) {
 	cfg := &config.Config{
 		ClineKey: []config.ClineKey{{
 			APIKey: "existing",
@@ -439,27 +431,20 @@ func TestClineKeysRejectNonClinePassModels(t *testing.T) {
 		Models: []config.ClineModel{{
 			Name: " glm-5.2 ",
 		}},
+		ExcludedModels:      []string{"cline-pass/minimax-m3", "*"},
+		VisionFallbackModel: "cline-pass/mimo-v2.5-pro",
 	}})
-	if err == nil || !strings.Contains(err.Error(), "cline models contains invalid model") {
-		t.Fatalf("ReplaceClineKeys() error = %v, want invalid cline model error", err)
+	if err != nil {
+		t.Fatalf("ReplaceClineKeys() error = %v, want nil", err)
 	}
-	if got := cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" || got[0].Models[0].Name != "cline-pass/glm-5.2" {
-		t.Fatalf("ClineKey after rejected replace = %#v, want unchanged existing entry", got)
-	}
-
-	badFallback := "qwen3.5-plus"
-	err = svc.PatchClineKey(nil, stringPtr("existing"), nil, ClinePatch{VisionFallback: &badFallback})
-	if err == nil || !strings.Contains(err.Error(), "cline vision-fallback-model contains invalid model") {
-		t.Fatalf("PatchClineKey(vision-fallback-model) error = %v, want invalid cline model error", err)
-	}
-	if got := cfg.ClineKey[0].VisionFallbackModel; got != "" {
-		t.Fatalf("ClineKey vision fallback after rejected patch = %q, want unchanged empty value", got)
+	if got := cfg.ClineKey; len(got) != 1 || got[0].APIKey != "cline-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "" || !reflect.DeepEqual(got[0].ExcludedModels, []string{"cline-pass/minimax-m3", "*"}) {
+		t.Fatalf("ClineKey after replace = %#v, want sanitized entry", got)
 	}
 
 	validExcluded := []string{"*", " cline-pass/minimax-m3 "}
 	validFallback := " cline-pass/mimo-v2.5-pro "
 	validModels := []config.ClineModel{{Name: " cline-pass/qwen3.7-max "}}
-	err = svc.PatchClineKey(nil, stringPtr("existing"), nil, ClinePatch{
+	err = svc.PatchClineKey(nil, stringPtr("cline-key"), nil, ClinePatch{
 		Models:         &validModels,
 		ExcludedModels: &validExcluded,
 		VisionFallback: &validFallback,
@@ -467,7 +452,7 @@ func TestClineKeysRejectNonClinePassModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PatchClineKey(valid models) error = %v, want nil", err)
 	}
-	if got := cfg.ClineKey[0]; got.Models[0].Name != "cline-pass/qwen3.7-max" || got.ExcludedModels[0] != "*" || got.ExcludedModels[1] != "cline-pass/minimax-m3" || got.VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
+	if got := cfg.ClineKey[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*", "cline-pass/minimax-m3"}) || got.VisionFallbackModel != "" {
 		t.Fatalf("ClineKey after valid patch = %#v", got)
 	}
 }

--- a/internal/runtime/executor/ollama_cloud_executor.go
+++ b/internal/runtime/executor/ollama_cloud_executor.go
@@ -4,11 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
@@ -19,6 +17,7 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 type OllamaCloudExecutor struct {
@@ -61,36 +60,53 @@ func (e *OllamaCloudExecutor) HttpRequest(ctx context.Context, auth *cliproxyaut
 	return newProxyAwareHTTPClient(ctx, e.cfg, auth, 0).Do(httpReq)
 }
 
-func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	execCtx, translated, err := e.prepareOpenAIChat(ctx, auth, req, opts, false)
+func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if opts.Alt != "responses/compact" {
+		switch opts.SourceFormat {
+		case sdktranslator.FormatOpenAIResponse:
+			return e.executeDirect(ctx, auth, req, opts, sdktranslator.FormatOpenAIResponse, "/responses", parseOpenAIUsage)
+		case sdktranslator.FormatClaude:
+			return e.executeDirect(ctx, auth, req, opts, sdktranslator.FormatClaude, "/messages", parseClaudeUsage)
+		}
+	}
+	return e.openAIExecutor().Execute(ctx, e.openAIAuth(auth), req, opts)
+}
+
+func (e *OllamaCloudExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if opts.Alt != "responses/compact" {
+		switch opts.SourceFormat {
+		case sdktranslator.FormatOpenAIResponse:
+			return e.executeDirectStream(ctx, auth, req, opts, sdktranslator.FormatOpenAIResponse, "/responses", parseOpenAIResponsesStreamUsage)
+		case sdktranslator.FormatClaude:
+			return e.executeDirectStream(ctx, auth, req, opts, sdktranslator.FormatClaude, "/messages", parseClaudeStreamUsage)
+		}
+	}
+	return e.openAIExecutor().ExecuteStream(ctx, e.openAIAuth(auth), req, opts)
+}
+
+func (e *OllamaCloudExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return e.openAIExecutor().CountTokens(ctx, e.openAIAuth(auth), req, opts)
+}
+
+func (e *OllamaCloudExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	_ = ctx
+	return auth, nil
+}
+
+func (e *OllamaCloudExecutor) openAIExecutor() *OpenAICompatExecutor {
+	return NewOpenAICompatExecutor(e.Identifier(), e.cfg)
+}
+
+func (e *OllamaCloudExecutor) executeDirect(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, target sdktranslator.Format, endpoint string, parseUsage func([]byte) coreusage.Detail) (resp cliproxyexecutor.Response, err error) {
+	execCtx, body, err := e.prepareDirect(ctx, auth, req, opts, target, false)
 	if err != nil {
 		return resp, err
 	}
 	reporter := execCtx.Reporter()
 	defer reporter.trackFailure(execCtx.Context, &err)
 
-	baseURL, apiKey := e.resolveCredentials(auth)
-	if baseURL == "" {
-		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
-		return resp, err
-	}
-	ollamaPayload, err := openAIChatToOllamaPayload(translated, false)
+	httpResp, err := e.doJSON(execCtx, auth, endpoint, body, false)
 	if err != nil {
-		return resp, err
-	}
-	body, _ := json.Marshal(ollamaPayload)
-	url := strings.TrimSuffix(baseURL, "/") + "/api/chat"
-	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return resp, err
-	}
-	e.applyHeaders(httpReq, auth, apiKey)
-	recorder := execCtx.Recorder()
-	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
-
-	httpResp, err := execCtx.HTTPClient(0).Do(httpReq)
-	if err != nil {
-		recorder.RecordResponseError(err)
 		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
 		return resp, err
 	}
@@ -99,6 +115,7 @@ func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 			log.Errorf("ollama cloud executor: close response body error: %v", errClose)
 		}
 	}()
+	recorder := execCtx.Recorder()
 	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
@@ -107,55 +124,35 @@ func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
 		return resp, err
 	}
-	upstreamBody, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
+	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
 	if err != nil {
 		recorder.RecordResponseError(err)
 		return resp, err
 	}
-	recorder.AppendResponseChunk(upstreamBody)
-	openAIResp, usage := ollamaChatResponseToOpenAI(upstreamBody, gjson.GetBytes(translated, "model").String())
-	reporter.publishWithContent(execCtx.Context, usage, string(req.Payload), string(openAIResp))
+	recorder.AppendResponseChunk(data)
+	reporter.publishWithContent(execCtx.Context, parseUsage(data), string(req.Payload), string(data))
 	reporter.ensurePublished(execCtx.Context)
 
 	var param any
-	out := sdktranslator.TranslateNonStream(execCtx.Context, sdktranslator.FormatOpenAI, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, openAIResp, &param)
+	out := sdktranslator.TranslateNonStream(execCtx.Context, target, execCtx.SourceFormat, req.Model, opts.OriginalRequest, body, data, &param)
 	return cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}, nil
 }
 
-func (e *OllamaCloudExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	execCtx, translated, err := e.prepareOpenAIChat(ctx, auth, req, opts, true)
+func (e *OllamaCloudExecutor) executeDirectStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, target sdktranslator.Format, endpoint string, parseUsage func([]byte) (coreusage.Detail, bool)) (_ *cliproxyexecutor.StreamResult, err error) {
+	execCtx, body, err := e.prepareDirect(ctx, auth, req, opts, target, true)
 	if err != nil {
 		return nil, err
 	}
 	reporter := execCtx.Reporter()
 	defer reporter.trackFailure(execCtx.Context, &err)
 
-	baseURL, apiKey := e.resolveCredentials(auth)
-	if baseURL == "" {
-		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
-		return nil, err
-	}
-	ollamaPayload, err := openAIChatToOllamaPayload(translated, true)
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
+	httpResp, err := e.doJSON(execCtx, auth, endpoint, body, true)
 	if err != nil {
-		return nil, err
-	}
-	body, _ := json.Marshal(ollamaPayload)
-	url := strings.TrimSuffix(baseURL, "/") + "/api/chat"
-	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	e.applyHeaders(httpReq, auth, apiKey)
-	httpReq.Header.Set("Accept", "application/x-ndjson")
-	recorder := execCtx.Recorder()
-	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
-
-	httpResp, err := execCtx.HTTPClient(0).Do(httpReq) //nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
-	if err != nil {
-		recorder.RecordResponseError(err)
 		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
 		return nil, err
 	}
+	recorder := execCtx.Recorder()
 	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
@@ -180,31 +177,19 @@ func (e *OllamaCloudExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800)
 		var param any
-		var lastUsage coreusage.Detail
-		hasUsage := false
 		for scanner.Scan() {
-			line := bytes.TrimSpace(scanner.Bytes())
-			if len(line) == 0 {
-				continue
-			}
+			line := scanner.Bytes()
 			recorder.AppendResponseChunk(line)
 			reporter.appendOutputChunk(line)
-			openAILine, usage, done := ollamaStreamChunkToOpenAI(line, gjson.GetBytes(translated, "model").String())
-			if usage.TotalTokens > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
-				lastUsage = usage
-				hasUsage = true
+			if detail, ok := parseUsage(line); ok {
+				reporter.publish(execCtx.Context, detail)
 			}
-			if len(openAILine) > 0 {
-				chunks := sdktranslator.TranslateStream(execCtx.Context, sdktranslator.FormatOpenAI, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, openAILine, &param)
-				for i := range chunks {
-					out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
-				}
+			if execCtx.SourceFormat == target {
+				out <- cliproxyexecutor.StreamChunk{Payload: append(bytes.Clone(line), '\n')}
+				continue
 			}
-			if done {
-				doneChunks := sdktranslator.TranslateStream(execCtx.Context, sdktranslator.FormatOpenAI, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, []byte("data: [DONE]\n\n"), &param)
-				for i := range doneChunks {
-					out <- cliproxyexecutor.StreamChunk{Payload: []byte(doneChunks[i])}
-				}
+			for _, chunk := range sdktranslator.TranslateStream(execCtx.Context, target, execCtx.SourceFormat, req.Model, opts.OriginalRequest, body, bytes.Clone(line), &param) {
+				out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunk)}
 			}
 		}
 		if errScan := scanner.Err(); errScan != nil {
@@ -213,51 +198,61 @@ func (e *OllamaCloudExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
 			return
 		}
-		if hasUsage {
-			reporter.publish(execCtx.Context, lastUsage)
-		}
 		reporter.ensurePublished(execCtx.Context)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }
 
-func (e *OllamaCloudExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	return NewOpenAICompatExecutor(e.Identifier(), e.cfg).CountTokens(ctx, auth, req, opts)
-}
-
-func (e *OllamaCloudExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
-	_ = ctx
-	return auth, nil
-}
-
-func (e *OllamaCloudExecutor) prepareOpenAIChat(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*ExecutionContext, []byte, error) {
-	to := sdktranslator.FormatOpenAI
+func (e *OllamaCloudExecutor) prepareDirect(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, target sdktranslator.Format, stream bool) (*ExecutionContext, []byte, error) {
 	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
-		TargetFormat:      to,
+		TargetFormat:      target,
 		TranslateAsStream: stream,
 	})
 	translated, originalTranslated := execCtx.TranslateRequestPair(req.Payload)
+	translated, _ = sjson.SetBytes(translated, "model", execCtx.BaseModel)
 	translated = execCtx.ApplyPayloadConfig(translated, originalTranslated)
-	var err error
-	translated, err = thinking.ApplyThinking(translated, req.Model, execCtx.SourceFormat.String(), to.String(), e.Identifier())
+	updated, err := thinking.ApplyThinking(translated, req.Model, execCtx.SourceFormat.String(), target.String(), e.Identifier())
 	if err != nil {
 		return nil, nil, err
 	}
-	translated = normalizeOpenAIChatToolCallMessages(translated)
-	return execCtx, translated, nil
+	return execCtx, updated, nil
 }
 
-func (e *OllamaCloudExecutor) applyHeaders(req *http.Request, auth *cliproxyauth.Auth, apiKey string) {
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "cli-proxy-ollama-cloud")
+func (e *OllamaCloudExecutor) doJSON(execCtx *ExecutionContext, auth *cliproxyauth.Auth, endpoint string, body []byte, stream bool) (*http.Response, error) {
+	baseURL, apiKey := e.resolveCredentials(auth)
+	if baseURL == "" {
+		return nil, statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
+	}
+	url := ollamaCloudOpenAIBaseURL(baseURL) + endpoint
+	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", "cli-proxy-ollama-cloud")
 	if apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	if endpoint == "/messages" {
+		httpReq.Header.Set("Anthropic-Version", "2023-06-01")
+	}
+	if stream {
+		httpReq.Header.Set("Accept", "text/event-stream")
+		httpReq.Header.Set("Cache-Control", "no-cache")
+	} else {
+		httpReq.Header.Set("Accept", "application/json")
 	}
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes
 	}
-	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	execCtx.Recorder().RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
+	resp, err := execCtx.HTTPClient(0).Do(httpReq) //nolint:bodyclose // stream bodies are closed by the stream goroutine.
+	if err != nil {
+		execCtx.Recorder().RecordResponseError(err)
+	}
+	return resp, err
 }
 
 func (e *OllamaCloudExecutor) resolveCredentials(auth *cliproxyauth.Auth) (baseURL, apiKey string) {
@@ -274,163 +269,43 @@ func (e *OllamaCloudExecutor) resolveCredentials(auth *cliproxyauth.Auth) (baseU
 	return baseURL, apiKey
 }
 
-type ollamaChatPayload struct {
-	Model    string          `json:"model"`
-	Messages []ollamaMessage `json:"messages"`
-	Stream   bool            `json:"stream"`
-	Options  map[string]any  `json:"options,omitempty"`
+func (e *OllamaCloudExecutor) openAIAuth(auth *cliproxyauth.Auth) *cliproxyauth.Auth {
+	baseURL, _ := e.resolveCredentials(auth)
+	if auth == nil {
+		return &cliproxyauth.Auth{Attributes: map[string]string{"base_url": ollamaCloudOpenAIBaseURL(baseURL)}}
+	}
+	clone := *auth
+	attrs := make(map[string]string, len(auth.Attributes)+1)
+	for k, v := range auth.Attributes {
+		attrs[k] = v
+	}
+	attrs["base_url"] = ollamaCloudOpenAIBaseURL(baseURL)
+	clone.Attributes = attrs
+	return &clone
 }
 
-type ollamaMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+func ollamaCloudOpenAIBaseURL(baseURL string) string {
+	base := strings.TrimSuffix(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		base = config.DefaultOllamaCloudBaseURL
+	}
+	if strings.HasSuffix(strings.ToLower(base), "/v1") {
+		return base
+	}
+	return base + "/v1"
 }
 
-func openAIChatToOllamaPayload(body []byte, stream bool) (ollamaChatPayload, error) {
-	payload := ollamaChatPayload{
-		Model:  strings.TrimSpace(gjson.GetBytes(body, "model").String()),
-		Stream: stream,
+func parseOpenAIResponsesStreamUsage(line []byte) (coreusage.Detail, bool) {
+	payload := responsesSSEData(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return coreusage.Detail{}, false
 	}
-	for _, msg := range gjson.GetBytes(body, "messages").Array() {
-		role := strings.TrimSpace(msg.Get("role").String())
-		if role == "" {
-			role = "user"
-		}
-		content := openAIMessageContentText(msg.Get("content"))
-		if content == "" && msg.Get("tool_calls").Exists() {
-			continue
-		}
-		payload.Messages = append(payload.Messages, ollamaMessage{Role: role, Content: content})
+	if detail, ok := parseCodexUsage(payload); ok {
+		return detail, true
 	}
-	options := map[string]any{}
-	copyNumberOption(body, options, "temperature", "temperature")
-	copyNumberOption(body, options, "top_p", "top_p")
-	copyNumberOption(body, options, "presence_penalty", "presence_penalty")
-	copyNumberOption(body, options, "frequency_penalty", "frequency_penalty")
-	copyNumberOption(body, options, "max_tokens", "num_predict")
-	if len(options) > 0 {
-		payload.Options = options
+	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		return coreusage.Detail{}, false
 	}
-	if payload.Model == "" {
-		return payload, fmt.Errorf("ollama cloud executor: missing model")
-	}
-	return payload, nil
-}
-
-func openAIMessageContentText(value gjson.Result) string {
-	if !value.Exists() {
-		return ""
-	}
-	if value.Type == gjson.String {
-		return value.String()
-	}
-	if !value.IsArray() {
-		return value.String()
-	}
-	parts := make([]string, 0)
-	for _, part := range value.Array() {
-		if strings.EqualFold(part.Get("type").String(), "text") {
-			if text := part.Get("text").String(); text != "" {
-				parts = append(parts, text)
-			}
-		}
-	}
-	return strings.Join(parts, "\n")
-}
-
-func copyNumberOption(body []byte, options map[string]any, from, to string) {
-	value := gjson.GetBytes(body, from)
-	if !value.Exists() {
-		return
-	}
-	switch value.Type {
-	case gjson.Number:
-		options[to] = value.Value()
-	default:
-		if strings.TrimSpace(value.String()) != "" {
-			options[to] = value.String()
-		}
-	}
-}
-
-func ollamaChatResponseToOpenAI(body []byte, fallbackModel string) ([]byte, coreusage.Detail) {
-	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
-	if model == "" {
-		model = fallbackModel
-	}
-	content := gjson.GetBytes(body, "message.content").String()
-	promptTokens := int(gjson.GetBytes(body, "prompt_eval_count").Int())
-	completionTokens := int(gjson.GetBytes(body, "eval_count").Int())
-	usage := coreusage.Detail{
-		InputTokens:  int64(promptTokens),
-		OutputTokens: int64(completionTokens),
-		TotalTokens:  int64(promptTokens + completionTokens),
-	}
-	out := map[string]any{
-		"id":      fmt.Sprintf("chatcmpl-ollama-%d", time.Now().UnixNano()),
-		"object":  "chat.completion",
-		"created": time.Now().Unix(),
-		"model":   model,
-		"choices": []map[string]any{{
-			"index": 0,
-			"message": map[string]any{
-				"role":    "assistant",
-				"content": content,
-			},
-			"finish_reason": "stop",
-		}},
-		"usage": map[string]any{
-			"prompt_tokens":     promptTokens,
-			"completion_tokens": completionTokens,
-			"total_tokens":      promptTokens + completionTokens,
-		},
-	}
-	data, _ := json.Marshal(out)
-	return data, usage
-}
-
-func ollamaStreamChunkToOpenAI(body []byte, fallbackModel string) ([]byte, coreusage.Detail, bool) {
-	if !gjson.ValidBytes(body) {
-		return nil, coreusage.Detail{}, false
-	}
-	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
-	if model == "" {
-		model = fallbackModel
-	}
-	content := gjson.GetBytes(body, "message.content").String()
-	done := gjson.GetBytes(body, "done").Bool()
-	promptTokens := int(gjson.GetBytes(body, "prompt_eval_count").Int())
-	completionTokens := int(gjson.GetBytes(body, "eval_count").Int())
-	usage := coreusage.Detail{
-		InputTokens:  int64(promptTokens),
-		OutputTokens: int64(completionTokens),
-		TotalTokens:  int64(promptTokens + completionTokens),
-	}
-	chunk := map[string]any{
-		"id":      fmt.Sprintf("chatcmpl-ollama-%d", time.Now().UnixNano()),
-		"object":  "chat.completion.chunk",
-		"created": time.Now().Unix(),
-		"model":   model,
-		"choices": []map[string]any{{
-			"index": 0,
-			"delta": map[string]any{
-				"content": content,
-			},
-			"finish_reason": nil,
-		}},
-	}
-	if done {
-		chunk["choices"] = []map[string]any{{
-			"index":         0,
-			"delta":         map[string]any{},
-			"finish_reason": "stop",
-		}}
-		chunk["usage"] = map[string]any{
-			"prompt_tokens":     promptTokens,
-			"completion_tokens": completionTokens,
-			"total_tokens":      promptTokens + completionTokens,
-		}
-	}
-	data, _ := json.Marshal(chunk)
-	return append(append([]byte("data: "), data...), []byte("\n\n")...), usage, done
+	return parseOpenAIUsage(payload), true
 }

--- a/internal/runtime/executor/ollama_cloud_executor_test.go
+++ b/internal/runtime/executor/ollama_cloud_executor_test.go
@@ -1,0 +1,138 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestOllamaCloudExecutorRoutesChatToOpenAICompatibleV1(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"gpt-oss:120b","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-oss:120b",
+		Payload: []byte(`{"model":"gpt-oss:120b","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Fatalf("path = %q, want /v1/chat/completions", gotPath)
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); gotText != "ok" {
+		t.Fatalf("response text = %q, want ok; payload=%s", gotText, string(resp.Payload))
+	}
+}
+
+func TestOllamaCloudExecutorRoutesResponsesToOfficialEndpoint(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","created_at":1,"model":"gpt-oss:120b","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-oss:120b",
+		Payload: []byte(`{"model":"client-prefix/gpt-oss:120b","input":"hi"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "gpt-oss:120b" {
+		t.Fatalf("upstream model = %q, want gpt-oss:120b; body=%s", gotModel, string(gotBody))
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "output.0.content.0.text").String(); gotText != "ok" {
+		t.Fatalf("response text = %q, want ok; payload=%s", gotText, string(resp.Payload))
+	}
+}
+
+func TestOllamaCloudExecutorStreamsResponsesFromOfficialEndpoint(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.created","response":{"id":"resp_1"}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-oss:120b",
+		Payload: []byte(`{"model":"gpt-oss:120b","input":"hi","stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse})
+	if err != nil {
+		t.Fatalf("ExecuteStream returned error: %v", err)
+	}
+	var chunks strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		chunks.Write(chunk.Payload)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if got := chunks.String(); got != "event: response.created\n"+`data: {"type":"response.created","response":{"id":"resp_1"}}`+"\n\n" {
+		t.Fatalf("stream payload = %q", got)
+	}
+}
+
+func TestOllamaCloudExecutorRoutesClaudeMessagesToOfficialEndpoint(t *testing.T) {
+	var gotPath, gotVersion string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotVersion = r.Header.Get("Anthropic-Version")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"gpt-oss:120b","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-oss:120b",
+		Payload: []byte(`{"model":"gpt-oss:120b","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if gotPath != "/v1/messages" {
+		t.Fatalf("path = %q, want /v1/messages", gotPath)
+	}
+	if gotVersion != "2023-06-01" {
+		t.Fatalf("Anthropic-Version = %q, want 2023-06-01", gotVersion)
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "content.0.text").String(); gotText != "ok" {
+		t.Fatalf("response text = %q, want ok; payload=%s", gotText, string(resp.Payload))
+	}
+}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -333,12 +333,6 @@ func (s *ConfigSynthesizer) synthesizeOpenCodeGoKeys(ctx *SynthesisContext) []*c
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
-		if hash := diff.ComputeOpenCodeGoModelsHash(entry.Models); hash != "" {
-			attrs["models_hash"] = hash
-		}
-		if visionFallbackModel := strings.TrimSpace(entry.VisionFallbackModel); visionFallbackModel != "" {
-			attrs["vision_fallback_model"] = visionFallbackModel
-		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
 		label := strings.TrimSpace(entry.Name)
 		if label == "" {
@@ -394,9 +388,6 @@ func (s *ConfigSynthesizer) synthesizeClineKeys(ctx *SynthesisContext) []*coreau
 		}
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
-		}
-		if visionFallbackModel := strings.TrimSpace(entry.VisionFallbackModel); visionFallbackModel != "" {
-			attrs["vision_fallback_model"] = visionFallbackModel
 		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
 		label := strings.TrimSpace(entry.Name)

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -373,13 +373,10 @@ func TestConfigSynthesizer_OpenCodeGoKeys(t *testing.T) {
 		t.Fatalf("unexpected proxy settings: %+v", auth)
 	}
 	if auth.Attributes["auth_kind"] != "apikey" || auth.Attributes["excluded_models"] != "minimax-m2.5" {
-		t.Fatalf("expected api key exclusion metadata, got %#v", auth.Attributes)
+		t.Fatalf("expected api key metadata, got %#v", auth.Attributes)
 	}
-	if auth.Attributes["models_hash"] == "" {
-		t.Fatalf("expected models_hash for explicit OpenCode Go models, got %#v", auth.Attributes)
-	}
-	if auth.Attributes["vision_fallback_model"] != "qwen3.5-plus" {
-		t.Fatalf("expected vision fallback metadata, got %#v", auth.Attributes)
+	if auth.Attributes["models_hash"] != "" || auth.Attributes["vision_fallback_model"] != "" {
+		t.Fatalf("expected OpenCode Go per-key model metadata to be ignored, got %#v", auth.Attributes)
 	}
 }
 
@@ -427,10 +424,10 @@ func TestConfigSynthesizer_ClineKeys(t *testing.T) {
 		t.Fatalf("unexpected proxy settings: %+v", auth)
 	}
 	if auth.Attributes["auth_kind"] != "apikey" || auth.Attributes["excluded_models"] != "cline-pass/minimax-m3" {
-		t.Fatalf("expected api key exclusion metadata, got %#v", auth.Attributes)
+		t.Fatalf("expected api key metadata, got %#v", auth.Attributes)
 	}
-	if auth.Attributes["vision_fallback_model"] != "cline-pass/mimo-v2.5-pro" {
-		t.Fatalf("expected vision fallback metadata, got %#v", auth.Attributes)
+	if auth.Attributes["models_hash"] != "" || auth.Attributes["vision_fallback_model"] != "" {
+		t.Fatalf("expected ClinePass per-key model metadata to be ignored, got %#v", auth.Attributes)
 	}
 }
 

--- a/sdk/cliproxy/auth/api_key_model_alias_test.go
+++ b/sdk/cliproxy/auth/api_key_model_alias_test.go
@@ -130,7 +130,7 @@ func TestAPIKeyModelAlias_MultipleProviders(t *testing.T) {
 		{"gemini-auth", "gp", "gemini-2.5-pro"},
 		{"claude-auth", "cs4", "claude-sonnet-4"},
 		{"codex-auth", "o", "o3"},
-		{"cline-auth", "mimo-v2.5-pro", "cline-pass/mimo-v2.5-pro"},
+		{"cline-auth", "mimo-v2.5-pro", ""},
 		{"bedrock-auth", "aws-sonnet", "claude-sonnet-4-5"},
 	}
 

--- a/sdk/cliproxy/auth/conductor_api_key_alias.go
+++ b/sdk/cliproxy/auth/conductor_api_key_alias.go
@@ -221,11 +221,7 @@ func resolveUpstreamModelForCodexAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, 
 }
 
 func resolveUpstreamModelForClineAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, requestedModel string) string {
-	entry := resolveClineAPIKeyConfig(cfg, auth)
-	if entry == nil {
-		return ""
-	}
-	return resolveModelAliasFromConfigModels(requestedModel, asModelAliasEntries(entry.Models))
+	return ""
 }
 
 func resolveUpstreamModelForBedrockAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, requestedModel string) string {

--- a/sdk/cliproxy/auth/conductor_runtime_config.go
+++ b/sdk/cliproxy/auth/conductor_runtime_config.go
@@ -102,10 +102,6 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *runtimeConfigSnapshot) {
 			if entry := resolveCodexAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
 			}
-		case "cline":
-			if entry := resolveClineAPIKeyConfig(cfg, auth); entry != nil {
-				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
-			}
 		case "bedrock":
 			if entry := resolveBedrockAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)

--- a/sdk/cliproxy/service_cline_test.go
+++ b/sdk/cliproxy/service_cline_test.go
@@ -66,7 +66,7 @@ func TestRegisterModelsForAuth_ClineRegistersDefaultModels(t *testing.T) {
 	}
 }
 
-func TestRegisterModelsForAuth_ClineUsesExplicitAndExcludedModels(t *testing.T) {
+func TestRegisterModelsForAuth_ClineIgnoresPerKeyModels(t *testing.T) {
 	service := &Service{cfg: &config.Config{
 		ClineKey: []config.ClineKey{{
 			APIKey: "cline-key-explicit",
@@ -96,18 +96,18 @@ func TestRegisterModelsForAuth_ClineUsesExplicitAndExcludedModels(t *testing.T) 
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetModelsForClient(auth.ID)
-	if len(models) != 1 {
-		t.Fatalf("expected 1 explicit cline model after exclusion, got %d: %+v", len(models), models)
+	if len(models) != 9 {
+		t.Fatalf("expected default cline models, got %d: %+v", len(models), models)
+	}
+	if hasModelID(models, "cline-pass/new-model") {
+		t.Fatalf("per-key ClinePass model should be ignored; got %+v", models)
 	}
 	if hasModelID(models, "cline-pass/glm-5.2") {
-		t.Fatalf("cline-pass/glm-5.2 should be excluded; got %+v", models)
-	}
-	if !hasModelID(models, "cline-pass/new-model") {
-		t.Fatalf("cline-pass/new-model not registered; got %+v", models)
+		t.Fatalf("specific ClinePass exclusion should be applied; got %+v", models)
 	}
 }
 
-func TestRegisterModelsForAuth_ClineRegistersAliasWithUpstreamModelID(t *testing.T) {
+func TestRegisterModelsForAuth_ClineIgnoresPerKeyAlias(t *testing.T) {
 	service := &Service{cfg: &config.Config{
 		ClineKey: []config.ClineKey{{
 			APIKey: "cline-key-alias",
@@ -137,11 +137,10 @@ func TestRegisterModelsForAuth_ClineRegistersAliasWithUpstreamModelID(t *testing
 	models := registry.GetModelsForClient(auth.ID)
 	for _, model := range models {
 		if model.ID == "mimo-v2.5-pro" {
-			if model.UpstreamModelID != "cline-pass/mimo-v2.5-pro" {
-				t.Fatalf("UpstreamModelID = %q, want cline-pass/mimo-v2.5-pro", model.UpstreamModelID)
-			}
-			return
+			t.Fatalf("per-key ClinePass alias should be ignored; got %+v", models)
 		}
 	}
-	t.Fatalf("mimo-v2.5-pro alias not registered; got %+v", models)
+	if !hasModelID(models, "cline-pass/mimo-v2.5-pro") {
+		t.Fatalf("default ClinePass model should be registered; got %+v", models)
+	}
 }

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -149,22 +149,14 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		}
 		models = applyExcludedModels(models, excluded)
 	case "opencode-go":
-		staticModels := sdkmodelcatalog.StaticModelDefinitionsByChannel("opencode-go")
-		models = staticModels
+		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("opencode-go")
 		if entry := s.resolveConfigOpenCodeGoKey(a); entry != nil && authKind == "apikey" {
-			if len(entry.Models) > 0 {
-				models = buildOpenCodeGoConfigModels(entry, staticModels)
-			}
 			excluded = entry.ExcludedModels
 		}
 		models = applyExcludedModels(models, excluded)
 	case "cline":
-		staticModels := sdkmodelcatalog.StaticModelDefinitionsByChannel("cline")
-		models = staticModels
+		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("cline")
 		if entry := s.resolveConfigClineKey(a); entry != nil && authKind == "apikey" {
-			if len(entry.Models) > 0 {
-				models = buildClineConfigModels(entry, staticModels)
-			}
 			excluded = entry.ExcludedModels
 		}
 		models = applyExcludedModels(models, excluded)

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -327,20 +327,6 @@ func buildCodexConfigModels(entry *config.CodexKey, resolveThinking staticThinki
 	return buildConfigModels(entry.Models, "openai", "openai", resolveThinking)
 }
 
-func buildOpenCodeGoConfigModels(entry *config.OpenCodeGoKey, staticModels []*ModelInfo) []*ModelInfo {
-	if entry == nil || len(entry.Models) == 0 {
-		return nil
-	}
-	return buildNamedConfigModels(entry.Models, staticModels, "opencode", "opencode-go")
-}
-
-func buildClineConfigModels(entry *config.ClineKey, staticModels []*ModelInfo) []*ModelInfo {
-	if entry == nil || len(entry.Models) == 0 {
-		return nil
-	}
-	return buildConfigModels(entry.Models, "cline", "cline", nil)
-}
-
 func buildOllamaCloudConfigModels(entry *config.OllamaCloudKey, staticModels []*ModelInfo) []*ModelInfo {
 	if entry == nil || len(entry.Models) == 0 {
 		return nil

--- a/sdk/cliproxy/service_opencode_go_test.go
+++ b/sdk/cliproxy/service_opencode_go_test.go
@@ -71,7 +71,7 @@ func TestRegisterModelsForAuth_OpenCodeGoRegistersAllDefaultModels(t *testing.T)
 	}
 }
 
-func TestRegisterModelsForAuth_OpenCodeGoUsesExplicitModels(t *testing.T) {
+func TestRegisterModelsForAuth_OpenCodeGoIgnoresPerKeyModels(t *testing.T) {
 	service := &Service{cfg: &config.Config{
 		OpenCodeGoKey: []config.OpenCodeGoKey{{
 			APIKey: "go-key-explicit",
@@ -100,16 +100,13 @@ func TestRegisterModelsForAuth_OpenCodeGoUsesExplicitModels(t *testing.T) {
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetModelsForClient(auth.ID)
-	if len(models) != 2 {
-		t.Fatalf("expected 2 explicit opencode-go models, got %d: %+v", len(models), models)
+	if len(models) != 20 {
+		t.Fatalf("expected default opencode-go models, got %d: %+v", len(models), models)
 	}
-	if !hasModelID(models, "qwen3.7-max") {
-		t.Fatalf("qwen3.7-max not registered; got %+v", models)
+	if hasModelID(models, "official-new-model") {
+		t.Fatalf("per-key OpenCode Go model should be ignored; got %+v", models)
 	}
-	if !hasModelID(models, "official-new-model") {
-		t.Fatalf("official-new-model not registered; got %+v", models)
-	}
-	if hasModelID(models, "deepseek-v4-flash") {
-		t.Fatalf("deepseek-v4-flash should not be registered from explicit models; got %+v", models)
+	if !hasModelID(models, "deepseek-v4-flash") {
+		t.Fatalf("default OpenCode Go models should be registered; got %+v", models)
 	}
 }

--- a/sdk/cliproxy/service_startup_registration_test.go
+++ b/sdk/cliproxy/service_startup_registration_test.go
@@ -110,10 +110,10 @@ func TestLoadInitialState_RegistersConfigDerivedClineModels(t *testing.T) {
 	t.Cleanup(func() { reg.UnregisterClient(clineAuth.ID) })
 
 	models := reg.GetModelsForClient(clineAuth.ID)
-	if len(models) != 1 || !hasModelID(models, "mimo-v2.5-pro") {
-		t.Fatalf("expected Cline alias model registered from config auth %+v, got %+v", clineAuth.Attributes, models)
+	if len(models) != 10 || !hasModelID(models, "cline-pass/mimo-v2.5-pro") {
+		t.Fatalf("expected default ClinePass models registered from config auth %+v, got %+v", clineAuth.Attributes, models)
 	}
-	if models[0].UpstreamModelID != "cline-pass/mimo-v2.5-pro" {
-		t.Fatalf("UpstreamModelID = %q, want cline-pass/mimo-v2.5-pro", models[0].UpstreamModelID)
+	if hasModelID(models, "mimo-v2.5-pro") {
+		t.Fatalf("per-key ClinePass alias should be ignored; got %+v", models)
 	}
 }


### PR DESCRIPTION
## Summary
- route Ollama Cloud chat, responses, and Anthropic messages through official /v1 endpoints
- fetch Ollama Cloud model definitions from the official /v1/models endpoint with static fallback
- stop persisting per-key Ollama Cloud model lists while keeping provider disable semantics

## Tests
- rtk go test ./internal/runtime/executor ./internal/config ./internal/api/handlers/management ./internal/management/settings/providers ./internal/app/service ./sdk/cliproxy
- rtk git diff --check