### PR TITLE
feat: support custom provider model aliases

### DIFF
--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -85,6 +85,9 @@ func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []cha
 		for _, entry := range cfg.ClineKey {
 			push(entry.Name, entry.Prefix, "cline", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, managementauthfiles.BuildTagPayloadFromValues("cline", nil))
 		}
+		for _, entry := range cfg.OllamaCloudKey {
+			push(entry.Name, entry.Prefix, "ollama-cloud", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, managementauthfiles.BuildTagPayloadFromValues("ollama-cloud", nil))
+		}
 		for _, entry := range cfg.VertexCompatAPIKey {
 			push("", entry.Prefix, "vertex", false, channelDisabledAuthorityConfig, managementauthfiles.BuildTagPayloadFromValues("vertex", nil))
 		}

--- a/internal/api/handlers/management/channel_names.go
+++ b/internal/api/handlers/management/channel_names.go
@@ -146,6 +146,14 @@ func collectKnownChannelsWithPolicy(cfg *config.Config, auths []*coreauth.Auth, 
 				return nil, err
 			}
 		}
+		for _, entry := range cfg.OllamaCloudKey {
+			if strings.TrimSpace(entry.APIKey) == "" {
+				continue
+			}
+			if err := addKnownChannelWithPolicy(known, entry.Name, entry.Name, "Ollama Cloud API key config", failOnConflict); err != nil {
+				return nil, err
+			}
+		}
 		for _, entry := range cfg.OpenAICompatibility {
 			if strings.TrimSpace(entry.BaseURL) == "" {
 				continue

--- a/internal/api/handlers/management/cline_config_test.go
+++ b/internal/api/handlers/management/cline_config_test.go
@@ -32,8 +32,8 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if len(h.cfg.ClineKey) != 1 || h.cfg.ClineKey[0].APIKey != "cline-key" || h.cfg.ClineKey[0].Prefix != "team" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL {
 		t.Fatalf("ClineKey after PUT = %+v", h.cfg.ClineKey)
 	}
-	if len(h.cfg.ClineKey[0].Models) != 0 {
-		t.Fatalf("ClineKey models after PUT = %+v, want nil", h.cfg.ClineKey[0].Models)
+	if len(h.cfg.ClineKey[0].Models) != 1 || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/glm-5.2" {
+		t.Fatalf("ClineKey models after PUT = %+v, want sanitized model", h.cfg.ClineKey[0].Models)
 	}
 	if len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/minimax-m3" {
 		t.Fatalf("ClineKey excluded models after PUT = %+v", h.cfg.ClineKey[0].ExcludedModels)
@@ -50,7 +50,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 0 || len(h.cfg.ClineKey[0].ExcludedModels) != 2 || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || h.cfg.ClineKey[0].ExcludedModels[1] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 1 || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/qwen3.7-max" || len(h.cfg.ClineKey[0].ExcludedModels) != 2 || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || h.cfg.ClineKey[0].ExcludedModels[1] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
 		t.Fatalf("ClineKey after PATCH = %+v", h.cfg.ClineKey[0])
 	}
 
@@ -67,7 +67,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 2 || getBody.Items[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || getBody.Items[0].ExcludedModels[1] != "*" || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "cline-pass/qwen3.7-max" || len(getBody.Items[0].ExcludedModels) != 2 || getBody.Items[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || getBody.Items[0].ExcludedModels[1] != "*" || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 
@@ -83,7 +83,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 }
 
-func TestClineKeyManagementDropsPerKeyModels(t *testing.T) {
+func TestClineKeyManagementRejectsNonClinePassModels(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
@@ -99,10 +99,10 @@ func TestClineKeyManagementDropsPerKeyModels(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/cline-api-key", bytes.NewReader(putBody))
 	h.ProviderKeys().PutClineKeys(c)
-	if w.Code != http.StatusOK {
-		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("PUT status = %d body=%s, want 400", w.Code, w.Body.String())
 	}
-	if got := h.cfg.ClineKey; len(got) != 1 || got[0].APIKey != "cline-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "cline-pass/mimo-v2.5-pro" || len(got[0].ExcludedModels) != 2 || got[0].ExcludedModels[0] != "cline-pass/minimax-m3" || got[0].ExcludedModels[1] != "*" {
-		t.Fatalf("ClineKey after PUT = %+v, want sanitized entry", got)
+	if got := h.cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" {
+		t.Fatalf("ClineKey after rejected PUT = %+v, want unchanged existing entry", got)
 	}
 }

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -154,6 +154,15 @@ func sanitizeConfigForAPI(cfg *config.Config) *config.Config {
 		copy.ClineKey[i].ExcludedModels = nil
 	}
 
+	// Mask Ollama Cloud API keys, names, URLs, and exclusions
+	for i := range copy.OllamaCloudKey {
+		copy.OllamaCloudKey[i].APIKey = maskKey(copy.OllamaCloudKey[i].APIKey)
+		copy.OllamaCloudKey[i].Name = maskName(copy.OllamaCloudKey[i].Name)
+		copy.OllamaCloudKey[i].BaseURL = maskBaseURL(copy.OllamaCloudKey[i].BaseURL)
+		copy.OllamaCloudKey[i].ProxyURL = maskBaseURL(copy.OllamaCloudKey[i].ProxyURL)
+		copy.OllamaCloudKey[i].ExcludedModels = nil
+	}
+
 	// Mask OpenAI compatibility API keys, names, URLs, and models
 	for i := range copy.OpenAICompatibility {
 		copy.OpenAICompatibility[i].Name = maskName(copy.OpenAICompatibility[i].Name)

--- a/internal/api/handlers/management/opencode_go_config_test.go
+++ b/internal/api/handlers/management/opencode_go_config_test.go
@@ -21,7 +21,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	h := &Handler{cfg: &config.Config{}, configFilePath: configPath}
 
-	putBody := []byte(`[{"api-key":" go-key ","name":" primary ","prefix":" team ","headers":{"X-Test":" yes "},"models":[{"name":"cline-pass/glm-5.2"}],"excluded-models":["minimax-m2.5","*"],"vision-fallback-model":" qwen3.5-plus ","workspace-id":" wrk_123 ","auth-cookie":" auth-token "}]`)
+	putBody := []byte(`[{"api-key":" go-key ","name":" primary ","prefix":" team ","headers":{"X-Test":" yes "},"models":[{"name":"qwen3.5-plus"}],"excluded-models":["minimax-m2.5","*"],"vision-fallback-model":" qwen3.5-plus ","workspace-id":" wrk_123 ","auth-cookie":" auth-token "}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/opencode-go-api-key", bytes.NewReader(putBody))
@@ -29,7 +29,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 0 || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 2 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].ExcludedModels[1] != "*" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
+	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 1 || h.cfg.OpenCodeGoKey[0].Models[0].Name != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 2 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].ExcludedModels[1] != "*" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v", h.cfg.OpenCodeGoKey)
 	}
 
@@ -41,7 +41,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 1 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.6-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 0 || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_456" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-next" {
+	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 1 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.6-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 1 || h.cfg.OpenCodeGoKey[0].Models[0].Name != "qwen3.7-max" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_456" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-next" {
 		t.Fatalf("OpenCodeGoKey after PATCH = %+v", h.cfg.OpenCodeGoKey[0])
 	}
 
@@ -58,7 +58,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "minimax-m2.5" || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "qwen3.7-max" || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "minimax-m2.5" || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 
@@ -74,7 +74,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 }
 
-func TestOpenCodeGoKeyManagementDropsPerKeyModels(t *testing.T) {
+func TestOpenCodeGoKeyManagementKeepsPerKeyModels(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
@@ -93,7 +93,7 @@ func TestOpenCodeGoKeyManagementDropsPerKeyModels(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "qwen3.5-plus" || len(got[0].ExcludedModels) != 2 || got[0].ExcludedModels[0] != "minimax-m2.5" || got[0].ExcludedModels[1] != "*" {
+	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || len(got[0].ExcludedModels) != 2 || got[0].ExcludedModels[0] != "minimax-m2.5" || got[0].ExcludedModels[1] != "*" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v, want sanitized entry", got)
 	}
 }

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -92,25 +92,60 @@ func syncConfigDerivedAuthModels(cfg *config.Config, auth *coreauth.Auth) {
 		return
 	}
 	switch strings.ToLower(strings.TrimSpace(auth.Provider)) {
-	case "opencode-go":
-		syncOpenCodeGoConfigAuthModels(reg, cfg, auth)
-	case "ollama-cloud":
-		syncOllamaCloudConfigAuthModels(reg, cfg, auth)
+	case "opencode-go", "cline", "ollama-cloud":
+		syncDynamicConfigAuthModels(reg, cfg, auth)
 	}
 }
 
-func syncOpenCodeGoConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.Config, auth *coreauth.Auth) {
-	entry := resolveConfigOpenCodeGoKey(cfg, auth)
-	if entry == nil {
+func syncDynamicConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.Config, auth *coreauth.Auth) {
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	staticModels := sdkmodelcatalog.StaticModelDefinitionsByChannel(provider)
+	models := staticModels
+	excluded := []string(nil)
+	ownedBy := provider
+	switch provider {
+	case "opencode-go":
+		ownedBy = "opencode"
+		entry := resolveConfigOpenCodeGoKey(cfg, auth)
+		if entry == nil {
+			reg.UnregisterClient(auth.ID)
+			return
+		}
+		if len(entry.Models) > 0 {
+			models = buildNamedConfigModels(entry.Models, staticModels, ownedBy, provider)
+		}
+		excluded = entry.ExcludedModels
+	case "cline":
+		entry := resolveConfigClineKey(cfg, auth)
+		if entry == nil {
+			reg.UnregisterClient(auth.ID)
+			return
+		}
+		if len(entry.Models) > 0 {
+			models = buildNamedConfigModels(entry.Models, staticModels, ownedBy, provider)
+		}
+		excluded = entry.ExcludedModels
+	case "ollama-cloud":
+		ownedBy = "ollama"
+		entry := resolveConfigOllamaCloudKey(cfg, auth)
+		if entry == nil {
+			reg.UnregisterClient(auth.ID)
+			return
+		}
+		if len(entry.Models) > 0 {
+			models = buildNamedConfigModels(entry.Models, staticModels, ownedBy, provider)
+		}
+		excluded = entry.ExcludedModels
+	default:
 		reg.UnregisterClient(auth.ID)
 		return
 	}
-	models := sdkmodelcatalog.StaticModelDefinitionsByChannel("opencode-go")
-	if len(entry.Models) > 0 {
-		models = buildOpenCodeGoConfigModels(entry.Models, models)
+	models = applyConfigModelExclusions(models, excluded)
+	if len(models) == 0 {
+		reg.UnregisterClient(auth.ID)
+		return
 	}
-	models = applyConfigModelExclusions(models, entry.ExcludedModels)
-	reg.RegisterClient(auth.ID, "opencode-go", applyConfigModelPrefixes(models, auth.Prefix, cfg.ForceModelPrefix))
+	reg.RegisterClient(auth.ID, provider, applyConfigModelPrefixes(models, auth.Prefix, cfg.ForceModelPrefix))
 }
 
 func resolveConfigOpenCodeGoKey(cfg *config.Config, auth *coreauth.Auth) *config.OpenCodeGoKey {
@@ -129,58 +164,25 @@ func resolveConfigOpenCodeGoKey(cfg *config.Config, auth *coreauth.Auth) *config
 	return nil
 }
 
-func buildOpenCodeGoConfigModels(models []config.OpenCodeGoModel, staticModels []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
-	staticByID := make(map[string]*sdkmodelcatalog.ModelInfo, len(staticModels))
-	for _, model := range staticModels {
-		if model == nil {
-			continue
+func resolveConfigClineKey(cfg *config.Config, auth *coreauth.Auth) *config.ClineKey {
+	if cfg == nil || auth == nil || auth.Attributes == nil {
+		return nil
+	}
+	attrKey := strings.TrimSpace(auth.Attributes["api_key"])
+	attrBase := strings.TrimSpace(auth.Attributes["base_url"])
+	for i := range cfg.ClineKey {
+		entry := &cfg.ClineKey[i]
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if cfgBase == "" {
+			cfgBase = config.DefaultClineBaseURL
 		}
-		if id := strings.ToLower(strings.TrimSpace(model.ID)); id != "" {
-			staticByID[id] = model
+		if attrKey != "" && strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) {
+			if attrBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
 		}
 	}
-
-	now := time.Now().Unix()
-	seen := make(map[string]struct{}, len(models))
-	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
-	for i := range models {
-		name := strings.TrimSpace(models[i].Name)
-		if name == "" {
-			continue
-		}
-		key := strings.ToLower(name)
-		if _, exists := seen[key]; exists {
-			continue
-		}
-		seen[key] = struct{}{}
-		if model := staticByID[key]; model != nil {
-			clone := *model
-			clone.UserDefined = true
-			out = append(out, &clone)
-			continue
-		}
-		out = append(out, &sdkmodelcatalog.ModelInfo{
-			ID:          name,
-			Object:      "model",
-			Created:     now,
-			OwnedBy:     "opencode",
-			Type:        "opencode-go",
-			DisplayName: name,
-			UserDefined: true,
-		})
-	}
-	return out
-}
-
-func syncOllamaCloudConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.Config, auth *coreauth.Auth) {
-	entry := resolveConfigOllamaCloudKey(cfg, auth)
-	if entry == nil {
-		reg.UnregisterClient(auth.ID)
-		return
-	}
-	models := sdkmodelcatalog.StaticModelDefinitionsByChannel("ollama-cloud")
-	models = applyConfigModelExclusions(models, entry.ExcludedModels)
-	reg.RegisterClient(auth.ID, "ollama-cloud", applyConfigModelPrefixes(models, auth.Prefix, cfg.ForceModelPrefix))
+	return nil
 }
 
 func resolveConfigOllamaCloudKey(cfg *config.Config, auth *coreauth.Auth) *config.OllamaCloudKey {
@@ -189,23 +191,27 @@ func resolveConfigOllamaCloudKey(cfg *config.Config, auth *coreauth.Auth) *confi
 	}
 	attrKey := strings.TrimSpace(auth.Attributes["api_key"])
 	attrBase := strings.TrimSpace(auth.Attributes["base_url"])
-	if attrKey == "" {
-		return nil
-	}
 	for i := range cfg.OllamaCloudKey {
 		entry := &cfg.OllamaCloudKey[i]
 		cfgBase := strings.TrimSpace(entry.BaseURL)
 		if cfgBase == "" {
 			cfgBase = config.DefaultOllamaCloudBaseURL
 		}
-		if strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) && (attrBase == "" || strings.EqualFold(cfgBase, attrBase)) {
-			return entry
+		if attrKey != "" && strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) {
+			if attrBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
 		}
 	}
 	return nil
 }
 
-func buildOllamaCloudConfigModels(models []config.OllamaCloudModel, staticModels []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+type namedConfigModel interface {
+	GetName() string
+	GetAlias() string
+}
+
+func buildNamedConfigModels[T namedConfigModel](models []T, staticModels []*sdkmodelcatalog.ModelInfo, ownedBy, modelType string) []*sdkmodelcatalog.ModelInfo {
 	staticByID := make(map[string]*sdkmodelcatalog.ModelInfo, len(staticModels))
 	for _, model := range staticModels {
 		if model == nil {
@@ -220,34 +226,44 @@ func buildOllamaCloudConfigModels(models []config.OllamaCloudModel, staticModels
 	seen := make(map[string]struct{}, len(models))
 	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
 	for i := range models {
-		name := strings.TrimSpace(models[i].Name)
-		alias := strings.TrimSpace(models[i].Alias)
-		if alias == "" {
-			alias = name
-		}
-		if alias == "" {
+		name := strings.TrimSpace(models[i].GetName())
+		alias := strings.TrimSpace(models[i].GetAlias())
+		if name == "" {
 			continue
 		}
-		key := strings.ToLower(alias)
+		id := name
+		if alias != "" {
+			id = alias
+		}
+		key := strings.ToLower(id)
 		if _, exists := seen[key]; exists {
 			continue
 		}
 		seen[key] = struct{}{}
-		if model := staticByID[strings.ToLower(name)]; model != nil && strings.EqualFold(name, alias) {
+		if model := staticByID[strings.ToLower(name)]; model != nil {
 			clone := *model
+			clone.ID = id
+			clone.DisplayName = name
+			if alias != "" && !strings.EqualFold(alias, name) {
+				clone.UpstreamModelID = name
+			}
 			clone.UserDefined = true
 			out = append(out, &clone)
 			continue
 		}
-		out = append(out, &sdkmodelcatalog.ModelInfo{
-			ID:          alias,
+		info := &sdkmodelcatalog.ModelInfo{
+			ID:          id,
 			Object:      "model",
 			Created:     now,
-			OwnedBy:     "ollama",
-			Type:        "ollama-cloud",
+			OwnedBy:     ownedBy,
+			Type:        modelType,
 			DisplayName: name,
 			UserDefined: true,
-		})
+		}
+		if alias != "" && !strings.EqualFold(alias, name) {
+			info.UpstreamModelID = name
+		}
+		out = append(out, info)
 	}
 	return out
 }

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -225,7 +225,7 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
-		entry.Models = nil
+		entry.Models = NormalizeOpenCodeGoModels(entry.Models)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
@@ -251,7 +251,8 @@ func NormalizeOpenCodeGoModels(models []OpenCodeGoModel) []OpenCodeGoModel {
 			continue
 		}
 		seen[key] = struct{}{}
-		out = append(out, OpenCodeGoModel{Name: name})
+		alias := strings.TrimSpace(models[i].Alias)
+		out = append(out, OpenCodeGoModel{Name: name, Alias: alias})
 	}
 	return out
 }
@@ -279,7 +280,7 @@ func (cfg *Config) SanitizeClineKeys() {
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
-		entry.Models = nil
+		entry.Models = NormalizeClineModels(entry.Models)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
@@ -343,6 +344,7 @@ func (cfg *Config) SanitizeOllamaCloudKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeOllamaCloudModels(entry.Models)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
 	cfg.OllamaCloudKey = out

--- a/internal/config/opencode_go_test.go
+++ b/internal/config/opencode_go_test.go
@@ -50,8 +50,8 @@ opencode-go-api-key:
 	if len(got.ExcludedModels) != 2 || got.ExcludedModels[0] != "deepseek-v4-pro" || got.ExcludedModels[1] != "*" {
 		t.Fatalf("excluded models = %#v", got.ExcludedModels)
 	}
-	if len(got.Models) != 0 {
-		t.Fatalf("models = %#v, want nil", got.Models)
+	if len(got.Models) != 2 || got.Models[0].Name != "qwen3.7-max" || got.Models[1].Name != "kimi-k2.7-code" {
+		t.Fatalf("models = %#v, want normalized unique models", got.Models)
 	}
 	if got.VisionFallbackModel != "qwen3.5-plus" {
 		t.Fatalf("vision fallback model = %q, want qwen3.5-plus", got.VisionFallbackModel)
@@ -82,8 +82,8 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 	if cfg.OpenCodeGoKey[1].VisionFallbackModel != "qwen3.6-plus" {
 		t.Fatalf("vision fallback model = %q, want qwen3.6-plus", cfg.OpenCodeGoKey[1].VisionFallbackModel)
 	}
-	if len(cfg.OpenCodeGoKey[1].Models) != 0 {
-		t.Fatalf("models = %#v, want nil", cfg.OpenCodeGoKey[1].Models)
+	if len(cfg.OpenCodeGoKey[1].Models) != 1 || cfg.OpenCodeGoKey[1].Models[0].Name != "glm-5.2" {
+		t.Fatalf("models = %#v, want normalized unique model", cfg.OpenCodeGoKey[1].Models)
 	}
 	if len(cfg.OpenCodeGoKey[1].ExcludedModels) != 2 || cfg.OpenCodeGoKey[1].ExcludedModels[0] != "glm-5.2" || cfg.OpenCodeGoKey[1].ExcludedModels[1] != "*" {
 		t.Fatalf("excluded models = %#v, want normalized exclusions", cfg.OpenCodeGoKey[1].ExcludedModels)

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -264,11 +264,12 @@ type OpenCodeGoKey struct {
 
 // OpenCodeGoModel describes a model explicitly enabled for OpenCode Go routing.
 type OpenCodeGoModel struct {
-	Name string `yaml:"name" json:"name"`
+	Name  string `yaml:"name" json:"name"`
+	Alias string `yaml:"alias,omitempty" json:"alias,omitempty"`
 }
 
 func (m OpenCodeGoModel) GetName() string  { return m.Name }
-func (m OpenCodeGoModel) GetAlias() string { return "" }
+func (m OpenCodeGoModel) GetAlias() string { return m.Alias }
 
 const DefaultClineBaseURL = "https://api.cline.bot/api/v1"
 
@@ -348,7 +349,13 @@ type OllamaCloudKey struct {
 
 	// ExcludedModels lists model IDs that should be excluded for this provider.
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+
+	// VisionFallbackModel is used for image requests whose requested model lacks vision support.
+	VisionFallbackModel string `yaml:"vision-fallback-model,omitempty" json:"vision-fallback-model,omitempty"`
 }
+
+func (k OllamaCloudKey) GetAPIKey() string  { return k.APIKey }
+func (k OllamaCloudKey) GetBaseURL() string { return k.BaseURL }
 
 type OllamaCloudModel struct {
 	Name  string `yaml:"name" json:"name"`

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -512,103 +512,6 @@ func (s *Service) deleteClineKeyByIndex(index int) {
 	s.cfg.SanitizeClineKeys()
 }
 
-func NormalizeBedrockKey(entry *config.BedrockKey) {
-	if entry == nil {
-		return
-	}
-	entry.Name = strings.TrimSpace(entry.Name)
-	entry.Prefix = strings.TrimSpace(entry.Prefix)
-	entry.AuthMode = strings.TrimSpace(entry.AuthMode)
-	entry.APIKey = strings.TrimSpace(entry.APIKey)
-	entry.AccessKeyID = strings.TrimSpace(entry.AccessKeyID)
-	entry.SecretAccessKey = strings.TrimSpace(entry.SecretAccessKey)
-	entry.SessionToken = strings.TrimSpace(entry.SessionToken)
-	entry.Region = strings.TrimSpace(entry.Region)
-	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
-	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
-	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
-	entry.Headers = config.NormalizeHeaders(entry.Headers)
-	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	if len(entry.Models) == 0 {
-		return
-	}
-	normalized := make([]config.BedrockModel, 0, len(entry.Models))
-	for i := range entry.Models {
-		model := entry.Models[i]
-		model.Name = strings.TrimSpace(model.Name)
-		model.Alias = strings.TrimSpace(model.Alias)
-		if model.Name == "" && model.Alias == "" {
-			continue
-		}
-		normalized = append(normalized, model)
-	}
-	entry.Models = normalized
-}
-
-func NormalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
-	if entry == nil {
-		return
-	}
-	entry.Name = strings.TrimSpace(entry.Name)
-	entry.APIKey = strings.TrimSpace(entry.APIKey)
-	entry.Prefix = strings.TrimSpace(entry.Prefix)
-	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
-	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
-	entry.Headers = config.NormalizeHeaders(entry.Headers)
-	entry.Models = nil
-	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
-	if workspaceID, err := normalizeOpenCodeGoWorkspaceID(entry.WorkspaceID); err == nil {
-		entry.WorkspaceID = workspaceID
-	} else {
-		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
-	}
-	entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
-}
-
-func NormalizedOpenCodeGoKeyEntries(entries []config.OpenCodeGoKey) []config.OpenCodeGoKey {
-	if len(entries) == 0 {
-		return nil
-	}
-	out := make([]config.OpenCodeGoKey, len(entries))
-	for i := range entries {
-		out[i] = entries[i]
-		NormalizeOpenCodeGoKey(&out[i])
-	}
-	return out
-}
-
-func NormalizeClineKey(entry *config.ClineKey) {
-	if entry == nil {
-		return
-	}
-	entry.Name = strings.TrimSpace(entry.Name)
-	entry.APIKey = strings.TrimSpace(entry.APIKey)
-	entry.Prefix = strings.TrimSpace(entry.Prefix)
-	entry.BaseURL = strings.TrimSuffix(strings.TrimSpace(entry.BaseURL), "/")
-	if entry.BaseURL == "" {
-		entry.BaseURL = config.DefaultClineBaseURL
-	}
-	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
-	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
-	entry.Headers = config.NormalizeHeaders(entry.Headers)
-	entry.Models = nil
-	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
-}
-
-func NormalizedClineKeyEntries(entries []config.ClineKey) []config.ClineKey {
-	if len(entries) == 0 {
-		return nil
-	}
-	out := make([]config.ClineKey, len(entries))
-	for i := range entries {
-		out[i] = entries[i]
-		NormalizeClineKey(&out[i])
-	}
-	return out
-}
-
 type OllamaCloudPatch struct {
 	APIKey         *string                    `json:"api-key"`
 	Name           *string                    `json:"name"`
@@ -620,6 +523,7 @@ type OllamaCloudPatch struct {
 	Headers        *map[string]string         `json:"headers"`
 	Models         *[]config.OllamaCloudModel `json:"models"`
 	ExcludedModels *[]string                  `json:"excluded-models"`
+	VisionFallback *string                    `json:"vision-fallback-model"`
 }
 
 func (s *Service) OllamaCloudKeys() []config.OllamaCloudKey {
@@ -637,6 +541,9 @@ func (s *Service) ReplaceOllamaCloudKeys(entries []config.OllamaCloudKey) error 
 	for i := range entries {
 		NormalizeOllamaCloudKey(&entries[i])
 		if strings.TrimSpace(entries[i].APIKey) != "" {
+			if err := validateOllamaCloudKeyModels(entries[i]); err != nil {
+				return err
+			}
 			filtered = append(filtered, entries[i])
 		}
 	}
@@ -711,10 +618,16 @@ func (s *Service) PatchOllamaCloudKey(index *int, apiKey *string, name *string, 
 	if patch.ExcludedModels != nil {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*patch.ExcludedModels)
 	}
+	if patch.VisionFallback != nil {
+		entry.VisionFallbackModel = strings.TrimSpace(*patch.VisionFallback)
+	}
 	NormalizeOllamaCloudKey(&entry)
 	if entry.APIKey == "" {
 		s.deleteOllamaCloudKeyByIndex(targetIndex)
 		return nil
+	}
+	if err := validateOllamaCloudKeyModels(entry); err != nil {
+		return err
 	}
 	prev := append([]config.OllamaCloudKey(nil), s.cfg.OllamaCloudKey...)
 	s.cfg.OllamaCloudKey[targetIndex] = entry
@@ -765,6 +678,103 @@ func (s *Service) deleteOllamaCloudKeyByIndex(index int) {
 	s.cfg.SanitizeOllamaCloudKeys()
 }
 
+func NormalizeBedrockKey(entry *config.BedrockKey) {
+	if entry == nil {
+		return
+	}
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.AuthMode = strings.TrimSpace(entry.AuthMode)
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.AccessKeyID = strings.TrimSpace(entry.AccessKeyID)
+	entry.SecretAccessKey = strings.TrimSpace(entry.SecretAccessKey)
+	entry.SessionToken = strings.TrimSpace(entry.SessionToken)
+	entry.Region = strings.TrimSpace(entry.Region)
+	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	if len(entry.Models) == 0 {
+		return
+	}
+	normalized := make([]config.BedrockModel, 0, len(entry.Models))
+	for i := range entry.Models {
+		model := entry.Models[i]
+		model.Name = strings.TrimSpace(model.Name)
+		model.Alias = strings.TrimSpace(model.Alias)
+		if model.Name == "" && model.Alias == "" {
+			continue
+		}
+		normalized = append(normalized, model)
+	}
+	entry.Models = normalized
+}
+
+func NormalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
+	if entry == nil {
+		return
+	}
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.Models = config.NormalizeOpenCodeGoModels(entry.Models)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+	if workspaceID, err := normalizeOpenCodeGoWorkspaceID(entry.WorkspaceID); err == nil {
+		entry.WorkspaceID = workspaceID
+	} else {
+		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
+	}
+	entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
+}
+
+func NormalizedOpenCodeGoKeyEntries(entries []config.OpenCodeGoKey) []config.OpenCodeGoKey {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.OpenCodeGoKey, len(entries))
+	for i := range entries {
+		out[i] = entries[i]
+		NormalizeOpenCodeGoKey(&out[i])
+	}
+	return out
+}
+
+func NormalizeClineKey(entry *config.ClineKey) {
+	if entry == nil {
+		return
+	}
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.BaseURL = strings.TrimSuffix(strings.TrimSpace(entry.BaseURL), "/")
+	if entry.BaseURL == "" {
+		entry.BaseURL = config.DefaultClineBaseURL
+	}
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.Models = config.NormalizeClineModels(entry.Models)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+}
+
+func NormalizedClineKeyEntries(entries []config.ClineKey) []config.ClineKey {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.ClineKey, len(entries))
+	for i := range entries {
+		out[i] = entries[i]
+		NormalizeClineKey(&out[i])
+	}
+	return out
+}
+
 func NormalizeOllamaCloudKey(entry *config.OllamaCloudKey) {
 	if entry == nil {
 		return
@@ -781,6 +791,7 @@ func NormalizeOllamaCloudKey(entry *config.OllamaCloudKey) {
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.Models = config.NormalizeOllamaCloudModels(entry.Models)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 }
 
 func NormalizedOllamaCloudKeyEntries(entries []config.OllamaCloudKey) []config.OllamaCloudKey {

--- a/internal/management/settings/providers/provider_model_validation.go
+++ b/internal/management/settings/providers/provider_model_validation.go
@@ -23,9 +23,6 @@ func validateOpenCodeGoKeyModels(entry config.OpenCodeGoKey) error {
 			return providerModelOwnershipError("opencode-go", "excluded-models", model, "must not use cline-pass model IDs")
 		}
 	}
-	if isClinePassModelID(entry.VisionFallbackModel) {
-		return providerModelOwnershipError("opencode-go", "vision-fallback-model", entry.VisionFallbackModel, "must not use cline-pass model IDs")
-	}
 	return nil
 }
 
@@ -43,8 +40,22 @@ func validateClineKeyModels(entry config.ClineKey) error {
 			return providerModelOwnershipError("cline", "excluded-models", model, "must use cline-pass model IDs")
 		}
 	}
-	if entry.VisionFallbackModel != "" && !isClinePassModelID(entry.VisionFallbackModel) {
-		return providerModelOwnershipError("cline", "vision-fallback-model", entry.VisionFallbackModel, "must use cline-pass model IDs")
+	return nil
+}
+
+func validateOllamaCloudKeyModels(entry config.OllamaCloudKey) error {
+	for _, model := range entry.Models {
+		if isClinePassModelID(model.Name) {
+			return providerModelOwnershipError("ollama-cloud", "models", model.Name, "must not use cline-pass model IDs")
+		}
+	}
+	for _, model := range entry.ExcludedModels {
+		if model == "*" {
+			continue
+		}
+		if isClinePassModelID(model) {
+			return providerModelOwnershipError("ollama-cloud", "excluded-models", model, "must not use cline-pass model IDs")
+		}
 	}
 	return nil
 }

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -373,7 +373,7 @@ func TestOpenCodeGoKeysReplacePatchDeleteAndRollback(t *testing.T) {
 	}
 }
 
-func TestOpenCodeGoKeysDropPerKeyModels(t *testing.T) {
+func TestOpenCodeGoKeysKeepPerKeyModels(t *testing.T) {
 	cfg := &config.Config{
 		OpenCodeGoKey: []config.OpenCodeGoKey{{
 			APIKey: "existing",
@@ -395,7 +395,7 @@ func TestOpenCodeGoKeysDropPerKeyModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReplaceOpenCodeGoKeys() error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "qwen3.5-plus" || !reflect.DeepEqual(got[0].ExcludedModels, []string{"minimax-m2.5", "*"}) {
+	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || !reflect.DeepEqual(got[0].ExcludedModels, []string{"minimax-m2.5", "*"}) {
 		t.Fatalf("OpenCodeGoKey after replace = %#v, want sanitized entry", got)
 	}
 
@@ -410,12 +410,12 @@ func TestOpenCodeGoKeysDropPerKeyModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PatchOpenCodeGoKey(valid models) error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*", "minimax-m2.5"}) || got.VisionFallbackModel != "qwen3.5-plus" {
+	if got := cfg.OpenCodeGoKey[0]; len(got.Models) != 1 || got.Models[0].Name != "glm-5.2" || !reflect.DeepEqual(got.ExcludedModels, []string{"*", "minimax-m2.5"}) || got.VisionFallbackModel != "qwen3.5-plus" {
 		t.Fatalf("OpenCodeGoKey after valid patch = %#v", got)
 	}
 }
 
-func TestClineKeysDropPerKeyModels(t *testing.T) {
+func TestClineKeysRejectNonClinePassModelsButAllowCrossProviderFallback(t *testing.T) {
 	cfg := &config.Config{
 		ClineKey: []config.ClineKey{{
 			APIKey: "existing",
@@ -434,17 +434,26 @@ func TestClineKeysDropPerKeyModels(t *testing.T) {
 		ExcludedModels:      []string{"cline-pass/minimax-m3", "*"},
 		VisionFallbackModel: "cline-pass/mimo-v2.5-pro",
 	}})
-	if err != nil {
-		t.Fatalf("ReplaceClineKeys() error = %v, want nil", err)
+	if err == nil {
+		t.Fatal("ReplaceClineKeys() error = nil, want invalid non-ClinePass model error")
 	}
-	if got := cfg.ClineKey; len(got) != 1 || got[0].APIKey != "cline-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "cline-pass/mimo-v2.5-pro" || !reflect.DeepEqual(got[0].ExcludedModels, []string{"cline-pass/minimax-m3", "*"}) {
-		t.Fatalf("ClineKey after replace = %#v, want sanitized entry", got)
+	if got := cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" || got[0].Models[0].Name != "cline-pass/glm-5.2" {
+		t.Fatalf("ClineKey after rejected replace = %#v, want unchanged existing entry", got)
+	}
+
+	crossProviderFallback := "qwen3.5-plus"
+	err = svc.PatchClineKey(nil, stringPtr("existing"), nil, ClinePatch{VisionFallback: &crossProviderFallback})
+	if err != nil {
+		t.Fatalf("PatchClineKey(vision-fallback-model) error = %v, want nil", err)
+	}
+	if got := cfg.ClineKey[0].VisionFallbackModel; got != "qwen3.5-plus" {
+		t.Fatalf("ClineKey vision fallback after patch = %q, want cross-provider fallback", got)
 	}
 
 	validExcluded := []string{"*", " cline-pass/minimax-m3 "}
 	validFallback := " cline-pass/mimo-v2.5-pro "
 	validModels := []config.ClineModel{{Name: " cline-pass/qwen3.7-max "}}
-	err = svc.PatchClineKey(nil, stringPtr("cline-key"), nil, ClinePatch{
+	err = svc.PatchClineKey(nil, stringPtr("existing"), nil, ClinePatch{
 		Models:         &validModels,
 		ExcludedModels: &validExcluded,
 		VisionFallback: &validFallback,
@@ -452,7 +461,7 @@ func TestClineKeysDropPerKeyModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PatchClineKey(valid models) error = %v, want nil", err)
 	}
-	if got := cfg.ClineKey[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*", "cline-pass/minimax-m3"}) || got.VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
+	if got := cfg.ClineKey[0]; len(got.Models) != 1 || got.Models[0].Name != "cline-pass/qwen3.7-max" || !reflect.DeepEqual(got.ExcludedModels, []string{"*", "cline-pass/minimax-m3"}) || got.VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
 		t.Fatalf("ClineKey after valid patch = %#v", got)
 	}
 }

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -72,10 +72,10 @@ func (e *OpenAICompatExecutor) HttpRequest(ctx context.Context, auth *cliproxyau
 
 func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	fallback := opencodeGoVisionFallbackResult{Request: req}
-	if e.provider == "cline" {
+	if openAICompatSupportsVisionFallback(e.provider) {
 		originalRequestedModel := payloadRequestedModel(opts, req.Model)
 		originalUpstreamModel := thinking.ParseSuffix(req.Model).ModelName
-		fallback = applyVisionFallback(req, opts, clineVisionFallbackModel(e.cfg, auth))
+		fallback = applyVisionFallback(req, opts, openAICompatVisionFallbackModel(e.cfg, auth, e.provider))
 		if fallback.Applied {
 			ctx = contextWithVisionFallbackLog(ctx, originalRequestedModel, originalUpstreamModel, fallback.FallbackModel)
 		}
@@ -210,10 +210,10 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 
 func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	fallback := opencodeGoVisionFallbackResult{Request: req}
-	if e.provider == "cline" {
+	if openAICompatSupportsVisionFallback(e.provider) {
 		originalRequestedModel := payloadRequestedModel(opts, req.Model)
 		originalUpstreamModel := thinking.ParseSuffix(req.Model).ModelName
-		fallback = applyVisionFallback(req, opts, clineVisionFallbackModel(e.cfg, auth))
+		fallback = applyVisionFallback(req, opts, openAICompatVisionFallbackModel(e.cfg, auth, e.provider))
 		if fallback.Applied {
 			ctx = contextWithVisionFallbackLog(ctx, originalRequestedModel, originalUpstreamModel, fallback.FallbackModel)
 		}

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -272,9 +272,6 @@ func applyVisionFallback(req cliproxyexecutor.Request, opts cliproxyexecutor.Opt
 	if fallback == "" || !opencodeGoCurrentRequestHasImage(req.Payload) {
 		return result
 	}
-	if !opencodeGoSupportsNativeVision(fallback) {
-		return result
-	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	if strings.EqualFold(baseModel, fallback) || opencodeGoSupportsNativeVision(baseModel) {
 		return result
@@ -290,7 +287,27 @@ func applyVisionFallback(req cliproxyexecutor.Request, opts cliproxyexecutor.Opt
 	return result
 }
 
-func clineVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth) string {
+func openAICompatSupportsVisionFallback(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "cline", "ollama-cloud":
+		return true
+	default:
+		return false
+	}
+}
+
+func openAICompatVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth, provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "cline":
+		return configOpenAICompatVisionFallbackModel(cfg, auth, "cline")
+	case "ollama-cloud":
+		return configOpenAICompatVisionFallbackModel(cfg, auth, "ollama-cloud")
+	default:
+		return ""
+	}
+}
+
+func configOpenAICompatVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth, provider string) string {
 	if auth == nil {
 		return ""
 	}
@@ -312,9 +329,25 @@ func clineVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth) strin
 	if apiKey == "" {
 		return ""
 	}
-	for i := range cfg.ClineKey {
-		entry := &cfg.ClineKey[i]
-		if strings.EqualFold(strings.TrimSpace(entry.APIKey), apiKey) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "cline":
+		for i := range cfg.ClineKey {
+			entry := &cfg.ClineKey[i]
+			if !strings.EqualFold(strings.TrimSpace(entry.APIKey), apiKey) {
+				continue
+			}
+			fallback := strings.TrimSpace(entry.VisionFallbackModel)
+			if opencodeGoModelExcluded(fallback, strings.Join(entry.ExcludedModels, ",")) {
+				return ""
+			}
+			return fallback
+		}
+	case "ollama-cloud":
+		for i := range cfg.OllamaCloudKey {
+			entry := &cfg.OllamaCloudKey[i]
+			if !strings.EqualFold(strings.TrimSpace(entry.APIKey), apiKey) {
+				continue
+			}
 			fallback := strings.TrimSpace(entry.VisionFallbackModel)
 			if opencodeGoModelExcluded(fallback, strings.Join(entry.ExcludedModels, ",")) {
 				return ""

--- a/internal/runtime/executor/opencode_go_executor_test.go
+++ b/internal/runtime/executor/opencode_go_executor_test.go
@@ -202,7 +202,7 @@ func TestOpenCodeGoExecutorUsesConfiguredNonQwenVisionFallback(t *testing.T) {
 	}
 }
 
-func TestOpenCodeGoExecutorIgnoresConfiguredTextOnlyFallbackModel(t *testing.T) {
+func TestOpenCodeGoExecutorAppliesConfiguredFallbackModel(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -213,7 +213,8 @@ func TestOpenCodeGoExecutorIgnoresConfiguredTextOnlyFallbackModel(t *testing.T) 
 			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"a description"}}]}`))
 			return
 		}
-		// Actual execution call — text-only model, stays on original model
+		// Actual execution call uses the configured fallback model. Cross-provider
+		// aliases are allowed here; the router resolves them later for the selected auth.
 		gotBody = body
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"chatcmpl_text_only_fallback","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
@@ -239,8 +240,8 @@ func TestOpenCodeGoExecutorIgnoresConfiguredTextOnlyFallbackModel(t *testing.T) 
 		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-flash" {
-		t.Fatalf("upstream model = %q, want deepseek-v4-flash; body=%s", gotModel, string(gotBody))
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deepseek-v4-pro" {
+		t.Fatalf("upstream model = %q, want deepseek-v4-pro; body=%s", gotModel, string(gotBody))
 	}
 }
 

--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -22,6 +22,7 @@ const (
 	RuntimeSettingBedrockKeys          = runtimeconfig.RuntimeSettingBedrockKeys
 	RuntimeSettingOpenCodeGoKeys       = runtimeconfig.RuntimeSettingOpenCodeGoKeys
 	RuntimeSettingClineKeys            = runtimeconfig.RuntimeSettingClineKeys
+	RuntimeSettingOllamaCloudKeys      = runtimeconfig.RuntimeSettingOllamaCloudKeys
 	RuntimeSettingOpenAICompatibility  = runtimeconfig.RuntimeSettingOpenAICompatibility
 	RuntimeSettingVertexCompatKeys     = runtimeconfig.RuntimeSettingVertexCompatKeys
 	RuntimeSettingClaudeHeaderDefaults = runtimeconfig.RuntimeSettingClaudeHeaderDefaults

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -100,7 +100,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.clientsMutex.Unlock()
 	}
 
-	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + bedrockAPIKeyCount + openCodeGoAPIKeyCount + openAICompatCount
+	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + bedrockAPIKeyCount + openCodeGoAPIKeyCount + ollamaCloudAPIKeyCount + openAICompatCount
 
 	if w.reloadCallback != nil {
 		log.Debugf("triggering server update callback before auth refresh")
@@ -109,7 +109,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 
 	w.refreshAuthState(forceAuthRefresh)
 
-	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d Bedrock keys + %d OpenCode Go keys + %d OpenAI-compat)",
+	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d Bedrock keys + %d OpenCode Go keys + %d Ollama Cloud keys + %d OpenAI-compat)",
 		totalNewClients,
 		authFileCount,
 		geminiAPIKeyCount,
@@ -118,6 +118,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		codexAPIKeyCount,
 		bedrockAPIKeyCount,
 		openCodeGoAPIKeyCount,
+		ollamaCloudAPIKeyCount,
 		openAICompatCount,
 	)
 }

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -106,10 +106,26 @@ func ComputeOpenCodeGoModelsHash(models []config.OpenCodeGoModel) string {
 	keys := normalizeModelPairs(func(out func(key string)) {
 		for _, model := range models {
 			name := strings.TrimSpace(model.Name)
-			if name == "" {
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+		}
+	})
+	return hashJoined(keys)
+}
+
+// ComputeClineModelsHash returns a stable hash for Cline model aliases.
+func ComputeClineModelsHash(models []config.ClineModel) string {
+	keys := normalizeModelPairs(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
 		}
 	})
 	return hashJoined(keys)

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -389,6 +389,12 @@ func (s *ConfigSynthesizer) synthesizeClineKeys(ctx *SynthesisContext) []*coreau
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
+		if hash := diff.ComputeClineModelsHash(entry.Models); hash != "" {
+			attrs["models_hash"] = hash
+		}
+		if visionFallbackModel := strings.TrimSpace(entry.VisionFallbackModel); visionFallbackModel != "" {
+			attrs["vision_fallback_model"] = visionFallbackModel
+		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
 		label := strings.TrimSpace(entry.Name)
 		if label == "" {
@@ -439,6 +445,7 @@ func (s *ConfigSynthesizer) synthesizeOllamaCloudKeys(ctx *SynthesisContext) []*
 			"source":       fmt.Sprintf("config:ollama-cloud[%s]", token),
 			"api_key":      key,
 			"base_url":     base,
+			"compat_name":  "Ollama Cloud",
 			"provider_key": "ollama-cloud",
 		}
 		if entry.Priority != 0 {
@@ -446,6 +453,9 @@ func (s *ConfigSynthesizer) synthesizeOllamaCloudKeys(ctx *SynthesisContext) []*
 		}
 		if hash := diff.ComputeOllamaCloudModelsHash(entry.Models); hash != "" {
 			attrs["models_hash"] = hash
+		}
+		if visionFallbackModel := strings.TrimSpace(entry.VisionFallbackModel); visionFallbackModel != "" {
+			attrs["vision_fallback_model"] = visionFallbackModel
 		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
 		label := strings.TrimSpace(entry.Name)

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -394,6 +394,7 @@ func TestConfigSynthesizer_ClineKeys(t *testing.T) {
 					ProxyURL:            "http://proxy",
 					ProxyID:             "hk",
 					Headers:             map[string]string{"X-Test": "yes"},
+					Models:              []config.ClineModel{{Name: "cline-pass/mimo-v2.5-pro", Alias: "mimo"}},
 					ExcludedModels:      []string{"cline-pass/minimax-m3"},
 					VisionFallbackModel: "cline-pass/mimo-v2.5-pro",
 				},
@@ -426,8 +427,8 @@ func TestConfigSynthesizer_ClineKeys(t *testing.T) {
 	if auth.Attributes["auth_kind"] != "apikey" || auth.Attributes["excluded_models"] != "cline-pass/minimax-m3" {
 		t.Fatalf("expected api key metadata, got %#v", auth.Attributes)
 	}
-	if auth.Attributes["models_hash"] != "" || auth.Attributes["vision_fallback_model"] != "" {
-		t.Fatalf("expected ClinePass per-key model metadata to be ignored, got %#v", auth.Attributes)
+	if auth.Attributes["models_hash"] == "" || auth.Attributes["vision_fallback_model"] != "cline-pass/mimo-v2.5-pro" {
+		t.Fatalf("expected ClinePass per-key model metadata, got %#v", auth.Attributes)
 	}
 }
 

--- a/sdk/cliproxy/auth/api_key_model_alias_test.go
+++ b/sdk/cliproxy/auth/api_key_model_alias_test.go
@@ -130,7 +130,7 @@ func TestAPIKeyModelAlias_MultipleProviders(t *testing.T) {
 		{"gemini-auth", "gp", "gemini-2.5-pro"},
 		{"claude-auth", "cs4", "claude-sonnet-4"},
 		{"codex-auth", "o", "o3"},
-		{"cline-auth", "mimo-v2.5-pro", ""},
+		{"cline-auth", "mimo-v2.5-pro", "cline-pass/mimo-v2.5-pro"},
 		{"bedrock-auth", "aws-sonnet", "claude-sonnet-4-5"},
 	}
 

--- a/sdk/cliproxy/auth/conductor_api_key_alias.go
+++ b/sdk/cliproxy/auth/conductor_api_key_alias.go
@@ -39,6 +39,8 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 		upstreamModel = resolveUpstreamModelForCodexAPIKey(cfg, auth, requestedModel)
 	case "cline":
 		upstreamModel = resolveUpstreamModelForClineAPIKey(cfg, auth, requestedModel)
+	case "ollama-cloud":
+		upstreamModel = resolveUpstreamModelForOllamaCloudAPIKey(cfg, auth, requestedModel)
 	case "bedrock":
 		upstreamModel = resolveUpstreamModelForBedrockAPIKey(cfg, auth, requestedModel)
 	case "vertex":
@@ -128,6 +130,13 @@ func resolveClineAPIKeyConfig(cfg *runtimeConfigSnapshot, auth *Auth) *runtimeAP
 		return nil
 	}
 	return resolveAPIKeyConfig(cfg.ClineKey, auth)
+}
+
+func resolveOllamaCloudAPIKeyConfig(cfg *runtimeConfigSnapshot, auth *Auth) *runtimeAPIKeyModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	return resolveAPIKeyConfig(cfg.OllamaCloudKey, auth)
 }
 
 func resolveBedrockAPIKeyConfig(cfg *runtimeConfigSnapshot, auth *Auth) *runtimeBedrockKeyConfig {
@@ -222,6 +231,14 @@ func resolveUpstreamModelForCodexAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, 
 
 func resolveUpstreamModelForClineAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, requestedModel string) string {
 	return ""
+}
+
+func resolveUpstreamModelForOllamaCloudAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, requestedModel string) string {
+	entry := resolveOllamaCloudAPIKeyConfig(cfg, auth)
+	if entry == nil {
+		return ""
+	}
+	return resolveModelAliasFromConfigModels(requestedModel, asModelAliasEntries(entry.Models))
 }
 
 func resolveUpstreamModelForBedrockAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, requestedModel string) string {

--- a/sdk/cliproxy/auth/conductor_runtime_config.go
+++ b/sdk/cliproxy/auth/conductor_runtime_config.go
@@ -102,6 +102,14 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *runtimeConfigSnapshot) {
 			if entry := resolveCodexAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
 			}
+		case "cline":
+			if entry := resolveClineAPIKeyConfig(cfg, auth); entry != nil {
+				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+			}
+		case "ollama-cloud":
+			if entry := resolveOllamaCloudAPIKeyConfig(cfg, auth); entry != nil {
+				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+			}
 		case "bedrock":
 			if entry := resolveBedrockAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)

--- a/sdk/cliproxy/auth/conductor_runtime_snapshot.go
+++ b/sdk/cliproxy/auth/conductor_runtime_snapshot.go
@@ -12,6 +12,7 @@ type runtimeConfigSnapshot struct {
 	ClaudeKey           []runtimeAPIKeyModelConfig
 	CodexKey            []runtimeAPIKeyModelConfig
 	ClineKey            []runtimeAPIKeyModelConfig
+	OllamaCloudKey      []runtimeAPIKeyModelConfig
 	BedrockKey          []runtimeBedrockKeyConfig
 	VertexCompatAPIKey  []runtimeAPIKeyModelConfig
 	OpenAICompatibility []runtimeOpenAICompatibilityConfig
@@ -98,6 +99,7 @@ func newRuntimeConfigSnapshot(cfg *sdkconfig.Config) *runtimeConfigSnapshot {
 		ClaudeKey:           cloneRuntimeAPIKeyModelConfigs(cfg.ClaudeKey),
 		CodexKey:            cloneRuntimeAPIKeyModelConfigs(cfg.CodexKey),
 		ClineKey:            cloneRuntimeClineModelConfigs(cfg.ClineKey),
+		OllamaCloudKey:      cloneRuntimeAPIKeyModelConfigs(cfg.OllamaCloudKey),
 		BedrockKey:          cloneRuntimeBedrockKeyConfigs(cfg.BedrockKey),
 		VertexCompatAPIKey:  cloneRuntimeAPIKeyModelConfigs(cfg.VertexCompatAPIKey),
 		OpenAICompatibility: cloneRuntimeOpenAICompatibilityConfigs(cfg.OpenAICompatibility),
@@ -186,6 +188,8 @@ func modelsForRuntimeConfigEntry[T any](entry T) []runtimeModelAliasEntry {
 	case sdkconfig.CodexKey:
 		return cloneRuntimeModelAliasEntries(typed.Models)
 	case sdkconfig.ClineKey:
+		return cloneRuntimeModelAliasEntries(typed.Models)
+	case sdkconfig.OllamaCloudKey:
 		return cloneRuntimeModelAliasEntries(typed.Models)
 	case sdkconfig.VertexCompatKey:
 		return cloneRuntimeModelAliasEntries(typed.Models)

--- a/sdk/cliproxy/service_cline_test.go
+++ b/sdk/cliproxy/service_cline_test.go
@@ -66,7 +66,7 @@ func TestRegisterModelsForAuth_ClineRegistersDefaultModels(t *testing.T) {
 	}
 }
 
-func TestRegisterModelsForAuth_ClineIgnoresPerKeyModels(t *testing.T) {
+func TestRegisterModelsForAuth_ClineUsesPerKeyModels(t *testing.T) {
 	service := &Service{cfg: &config.Config{
 		ClineKey: []config.ClineKey{{
 			APIKey: "cline-key-explicit",
@@ -96,18 +96,18 @@ func TestRegisterModelsForAuth_ClineIgnoresPerKeyModels(t *testing.T) {
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetModelsForClient(auth.ID)
-	if len(models) != 9 {
-		t.Fatalf("expected default cline models, got %d: %+v", len(models), models)
+	if len(models) != 1 {
+		t.Fatalf("expected configured cline models after exclusion, got %d: %+v", len(models), models)
 	}
-	if hasModelID(models, "cline-pass/new-model") {
-		t.Fatalf("per-key ClinePass model should be ignored; got %+v", models)
+	if !hasModelID(models, "cline-pass/new-model") {
+		t.Fatalf("per-key ClinePass model should be registered; got %+v", models)
 	}
 	if hasModelID(models, "cline-pass/glm-5.2") {
 		t.Fatalf("specific ClinePass exclusion should be applied; got %+v", models)
 	}
 }
 
-func TestRegisterModelsForAuth_ClineIgnoresPerKeyAlias(t *testing.T) {
+func TestRegisterModelsForAuth_ClineUsesPerKeyAlias(t *testing.T) {
 	service := &Service{cfg: &config.Config{
 		ClineKey: []config.ClineKey{{
 			APIKey: "cline-key-alias",
@@ -135,12 +135,10 @@ func TestRegisterModelsForAuth_ClineIgnoresPerKeyAlias(t *testing.T) {
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetModelsForClient(auth.ID)
-	for _, model := range models {
-		if model.ID == "mimo-v2.5-pro" {
-			t.Fatalf("per-key ClinePass alias should be ignored; got %+v", models)
-		}
+	if !hasModelID(models, "mimo-v2.5-pro") {
+		t.Fatalf("per-key ClinePass alias should be registered; got %+v", models)
 	}
-	if !hasModelID(models, "cline-pass/mimo-v2.5-pro") {
-		t.Fatalf("default ClinePass model should be registered; got %+v", models)
+	if hasModelID(models, "cline-pass/mimo-v2.5-pro") {
+		t.Fatalf("aliased ClinePass upstream id should not be registered separately; got %+v", models)
 	}
 }

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -151,21 +151,26 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	case "opencode-go":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("opencode-go")
 		if entry := s.resolveConfigOpenCodeGoKey(a); entry != nil && authKind == "apikey" {
+			if len(entry.Models) > 0 {
+				models = buildOpenCodeGoConfigModels(entry)
+			}
 			excluded = entry.ExcludedModels
 		}
 		models = applyExcludedModels(models, excluded)
 	case "cline":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("cline")
 		if entry := s.resolveConfigClineKey(a); entry != nil && authKind == "apikey" {
+			if len(entry.Models) > 0 {
+				models = buildClineConfigModels(entry)
+			}
 			excluded = entry.ExcludedModels
 		}
 		models = applyExcludedModels(models, excluded)
 	case "ollama-cloud":
-		staticModels := sdkmodelcatalog.StaticModelDefinitionsByChannel("ollama-cloud")
-		models = staticModels
+		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("ollama-cloud")
 		if entry := s.resolveConfigOllamaCloudKey(a); entry != nil && authKind == "apikey" {
 			if len(entry.Models) > 0 {
-				models = buildOllamaCloudConfigModels(entry, staticModels)
+				models = buildOllamaCloudConfigModels(entry)
 			}
 			excluded = entry.ExcludedModels
 		}

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -327,55 +327,25 @@ func buildCodexConfigModels(entry *config.CodexKey, resolveThinking staticThinki
 	return buildConfigModels(entry.Models, "openai", "openai", resolveThinking)
 }
 
-func buildOllamaCloudConfigModels(entry *config.OllamaCloudKey, staticModels []*ModelInfo) []*ModelInfo {
+func buildOpenCodeGoConfigModels(entry *config.OpenCodeGoKey) []*ModelInfo {
 	if entry == nil || len(entry.Models) == 0 {
 		return nil
 	}
-	return buildNamedConfigModels(entry.Models, staticModels, "ollama", "ollama-cloud")
+	return buildConfigModels(entry.Models, "opencode", "opencode-go", nil)
 }
 
-func buildNamedConfigModels[T interface{ GetName() string }](models []T, staticModels []*ModelInfo, ownedBy, modelType string) []*ModelInfo {
-	staticByID := make(map[string]*ModelInfo, len(staticModels))
-	for _, model := range staticModels {
-		if model == nil {
-			continue
-		}
-		if id := strings.ToLower(strings.TrimSpace(model.ID)); id != "" {
-			staticByID[id] = model
-		}
+func buildClineConfigModels(entry *config.ClineKey) []*ModelInfo {
+	if entry == nil || len(entry.Models) == 0 {
+		return nil
 	}
+	return buildConfigModels(entry.Models, "cline", "cline", nil)
+}
 
-	now := time.Now().Unix()
-	seen := make(map[string]struct{}, len(models))
-	out := make([]*ModelInfo, 0, len(models))
-	for i := range models {
-		name := strings.TrimSpace(models[i].GetName())
-		if name == "" {
-			continue
-		}
-		key := strings.ToLower(name)
-		if _, exists := seen[key]; exists {
-			continue
-		}
-		seen[key] = struct{}{}
-
-		if model := staticByID[key]; model != nil {
-			clone := *model
-			clone.UserDefined = true
-			out = append(out, &clone)
-			continue
-		}
-		out = append(out, &ModelInfo{
-			ID:          name,
-			Object:      "model",
-			Created:     now,
-			OwnedBy:     ownedBy,
-			Type:        modelType,
-			DisplayName: name,
-			UserDefined: true,
-		})
+func buildOllamaCloudConfigModels(entry *config.OllamaCloudKey) []*ModelInfo {
+	if entry == nil || len(entry.Models) == 0 {
+		return nil
 	}
-	return out
+	return buildConfigModels(entry.Models, "ollama", "ollama-cloud", nil)
 }
 
 func rewriteModelInfoName(name, oldID, newID string) string {

--- a/sdk/cliproxy/service_opencode_go_test.go
+++ b/sdk/cliproxy/service_opencode_go_test.go
@@ -71,7 +71,7 @@ func TestRegisterModelsForAuth_OpenCodeGoRegistersAllDefaultModels(t *testing.T)
 	}
 }
 
-func TestRegisterModelsForAuth_OpenCodeGoIgnoresPerKeyModels(t *testing.T) {
+func TestRegisterModelsForAuth_OpenCodeGoUsesPerKeyModels(t *testing.T) {
 	service := &Service{cfg: &config.Config{
 		OpenCodeGoKey: []config.OpenCodeGoKey{{
 			APIKey: "go-key-explicit",
@@ -100,13 +100,13 @@ func TestRegisterModelsForAuth_OpenCodeGoIgnoresPerKeyModels(t *testing.T) {
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetModelsForClient(auth.ID)
-	if len(models) != 20 {
-		t.Fatalf("expected default opencode-go models, got %d: %+v", len(models), models)
+	if len(models) != 2 {
+		t.Fatalf("expected configured opencode-go models, got %d: %+v", len(models), models)
 	}
-	if hasModelID(models, "official-new-model") {
-		t.Fatalf("per-key OpenCode Go model should be ignored; got %+v", models)
+	if !hasModelID(models, "official-new-model") {
+		t.Fatalf("per-key OpenCode Go model should be registered; got %+v", models)
 	}
-	if !hasModelID(models, "deepseek-v4-flash") {
-		t.Fatalf("default OpenCode Go models should be registered; got %+v", models)
+	if hasModelID(models, "deepseek-v4-flash") {
+		t.Fatalf("configured OpenCode Go models should replace defaults; got %+v", models)
 	}
 }

--- a/sdk/cliproxy/service_startup_registration_test.go
+++ b/sdk/cliproxy/service_startup_registration_test.go
@@ -110,10 +110,10 @@ func TestLoadInitialState_RegistersConfigDerivedClineModels(t *testing.T) {
 	t.Cleanup(func() { reg.UnregisterClient(clineAuth.ID) })
 
 	models := reg.GetModelsForClient(clineAuth.ID)
-	if len(models) != 10 || !hasModelID(models, "cline-pass/mimo-v2.5-pro") {
-		t.Fatalf("expected default ClinePass models registered from config auth %+v, got %+v", clineAuth.Attributes, models)
+	if len(models) != 1 || !hasModelID(models, "mimo-v2.5-pro") {
+		t.Fatalf("expected configured ClinePass alias registered from config auth %+v, got %+v", clineAuth.Attributes, models)
 	}
-	if hasModelID(models, "mimo-v2.5-pro") {
-		t.Fatalf("per-key ClinePass alias should be ignored; got %+v", models)
+	if hasModelID(models, "cline-pass/mimo-v2.5-pro") {
+		t.Fatalf("aliased ClinePass upstream id should not be registered separately; got %+v", models)
 	}
 }


### PR DESCRIPTION
## Summary
- support configured model aliases for OpenCode Go, ClinePass, and Ollama Cloud
- keep provider-bound model/exclusion validation while allowing cross-provider vision fallback models
- preserve each provider's own runtime/model-list endpoints

## Tests
- rtk go test ./internal/config ./internal/management/settings/providers ./internal/api/handlers/management ./internal/watcher ./internal/watcher/synthesizer ./internal/app/service ./internal/runtime/executor ./sdk/cliproxy ./sdk/cliproxy/auth