### PR TITLE
fix: filter dirty model access provider models

### DIFF
--- a/sdk/cliproxy/service_cline_test.go
+++ b/sdk/cliproxy/service_cline_test.go
@@ -107,6 +107,43 @@ func TestRegisterModelsForAuth_ClineUsesPerKeyModels(t *testing.T) {
 	}
 }
 
+func TestRegisterModelsForAuth_ClineFiltersDirtyNonClinePassModels(t *testing.T) {
+	service := &Service{cfg: &config.Config{
+		ClineKey: []config.ClineKey{{
+			APIKey: "cline-key-dirty",
+			Models: []config.ClineModel{
+				{Name: "glm-5.2"},
+				{Name: "cline-pass/qwen3.7-max"},
+			},
+		}},
+	}}
+	auth := &coreauth.Auth{
+		ID:       "cline-auth-dirty-models",
+		Provider: "cline",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "cline-key-dirty",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := registry.GetModelsForClient(auth.ID)
+	if len(models) != 1 || !hasModelID(models, "cline-pass/qwen3.7-max") {
+		t.Fatalf("expected only valid ClinePass model after dirty filtering, got %+v", models)
+	}
+	if hasModelID(models, "glm-5.2") {
+		t.Fatalf("dirty non-ClinePass model should not be registered for Cline; got %+v", models)
+	}
+}
+
 func TestRegisterModelsForAuth_ClineUsesPerKeyAlias(t *testing.T) {
 	service := &Service{cfg: &config.Config{
 		ClineKey: []config.ClineKey{{

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -152,7 +152,9 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("opencode-go")
 		if entry := s.resolveConfigOpenCodeGoKey(a); entry != nil && authKind == "apikey" {
 			if len(entry.Models) > 0 {
-				models = buildOpenCodeGoConfigModels(entry)
+				if configuredModels := buildOpenCodeGoConfigModels(entry); len(configuredModels) > 0 {
+					models = configuredModels
+				}
 			}
 			excluded = entry.ExcludedModels
 		}
@@ -161,7 +163,9 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("cline")
 		if entry := s.resolveConfigClineKey(a); entry != nil && authKind == "apikey" {
 			if len(entry.Models) > 0 {
-				models = buildClineConfigModels(entry)
+				if configuredModels := buildClineConfigModels(entry); len(configuredModels) > 0 {
+					models = configuredModels
+				}
 			}
 			excluded = entry.ExcludedModels
 		}
@@ -170,7 +174,9 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("ollama-cloud")
 		if entry := s.resolveConfigOllamaCloudKey(a); entry != nil && authKind == "apikey" {
 			if len(entry.Models) > 0 {
-				models = buildOllamaCloudConfigModels(entry)
+				if configuredModels := buildOllamaCloudConfigModels(entry); len(configuredModels) > 0 {
+					models = configuredModels
+				}
 			}
 			excluded = entry.ExcludedModels
 		}

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -187,6 +187,23 @@ func buildConfigModels[T modelEntry](
 	return out
 }
 
+func filterConfigModels[T modelEntry](models []T, keep func(string) bool) []T {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]T, 0, len(models))
+	for _, model := range models {
+		if keep(model.GetName()) {
+			out = append(out, model)
+		}
+	}
+	return out
+}
+
+func isClinePassConfigModelID(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "cline-pass/")
+}
+
 func buildVertexCompatConfigModels(
 	entry *config.VertexCompatKey,
 	resolveThinking staticThinkingResolver,
@@ -331,21 +348,28 @@ func buildOpenCodeGoConfigModels(entry *config.OpenCodeGoKey) []*ModelInfo {
 	if entry == nil || len(entry.Models) == 0 {
 		return nil
 	}
-	return buildConfigModels(entry.Models, "opencode", "opencode-go", nil)
+	models := filterConfigModels(entry.Models, func(name string) bool {
+		return !isClinePassConfigModelID(name)
+	})
+	return buildConfigModels(models, "opencode", "opencode-go", nil)
 }
 
 func buildClineConfigModels(entry *config.ClineKey) []*ModelInfo {
 	if entry == nil || len(entry.Models) == 0 {
 		return nil
 	}
-	return buildConfigModels(entry.Models, "cline", "cline", nil)
+	models := filterConfigModels(entry.Models, isClinePassConfigModelID)
+	return buildConfigModels(models, "cline", "cline", nil)
 }
 
 func buildOllamaCloudConfigModels(entry *config.OllamaCloudKey) []*ModelInfo {
 	if entry == nil || len(entry.Models) == 0 {
 		return nil
 	}
-	return buildConfigModels(entry.Models, "ollama", "ollama-cloud", nil)
+	models := filterConfigModels(entry.Models, func(name string) bool {
+		return !isClinePassConfigModelID(name)
+	})
+	return buildConfigModels(models, "ollama", "ollama-cloud", nil)
 }
 
 func rewriteModelInfoName(name, oldID, newID string) string {

--- a/sdk/cliproxy/service_ollama_cloud_test.go
+++ b/sdk/cliproxy/service_ollama_cloud_test.go
@@ -1,0 +1,48 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+func TestRegisterModelsForAuth_OllamaCloudFiltersDirtyClinePassModels(t *testing.T) {
+	service := &Service{cfg: &config.Config{
+		OllamaCloudKey: []config.OllamaCloudKey{{
+			APIKey:  "ollama-key-dirty",
+			BaseURL: config.DefaultOllamaCloudBaseURL,
+			Models: []config.OllamaCloudModel{
+				{Name: "cline-pass/glm-5.2"},
+				{Name: "gpt-oss:120b"},
+			},
+		}},
+	}}
+	auth := &coreauth.Auth{
+		ID:       "ollama-cloud-auth-dirty-models",
+		Provider: "ollama-cloud",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "ollama-key-dirty",
+			"base_url":  config.DefaultOllamaCloudBaseURL,
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := registry.GetModelsForClient(auth.ID)
+	if len(models) != 1 || !hasModelID(models, "gpt-oss:120b") {
+		t.Fatalf("expected only valid Ollama Cloud model after dirty filtering, got %+v", models)
+	}
+	if hasModelID(models, "cline-pass/glm-5.2") {
+		t.Fatalf("dirty ClinePass model should not be registered for Ollama Cloud; got %+v", models)
+	}
+}

--- a/sdk/cliproxy/service_opencode_go_test.go
+++ b/sdk/cliproxy/service_opencode_go_test.go
@@ -110,3 +110,73 @@ func TestRegisterModelsForAuth_OpenCodeGoUsesPerKeyModels(t *testing.T) {
 		t.Fatalf("configured OpenCode Go models should replace defaults; got %+v", models)
 	}
 }
+
+func TestRegisterModelsForAuth_OpenCodeGoFiltersDirtyClinePassModels(t *testing.T) {
+	service := &Service{cfg: &config.Config{
+		OpenCodeGoKey: []config.OpenCodeGoKey{{
+			APIKey: "go-key-dirty",
+			Models: []config.OpenCodeGoModel{
+				{Name: "cline-pass/glm-5.2"},
+				{Name: "qwen3.7-max"},
+			},
+		}},
+	}}
+	auth := &coreauth.Auth{
+		ID:       "opencode-go-auth-dirty-models",
+		Provider: "opencode-go",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "go-key-dirty",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := registry.GetModelsForClient(auth.ID)
+	if len(models) != 1 || !hasModelID(models, "qwen3.7-max") {
+		t.Fatalf("expected only valid OpenCode Go model after dirty filtering, got %+v", models)
+	}
+	if hasModelID(models, "cline-pass/glm-5.2") {
+		t.Fatalf("dirty ClinePass model should not be registered for OpenCode Go; got %+v", models)
+	}
+}
+
+func TestRegisterModelsForAuth_OpenCodeGoFallsBackWhenOnlyDirtyModelsRemain(t *testing.T) {
+	service := &Service{cfg: &config.Config{
+		OpenCodeGoKey: []config.OpenCodeGoKey{{
+			APIKey: "go-key-only-dirty",
+			Models: []config.OpenCodeGoModel{
+				{Name: "cline-pass/glm-5.2"},
+			},
+		}},
+	}}
+	auth := &coreauth.Auth{
+		ID:       "opencode-go-auth-only-dirty-models",
+		Provider: "opencode-go",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "go-key-only-dirty",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := registry.GetModelsForClient(auth.ID)
+	if !hasModelID(models, "deepseek-v4-flash") || hasModelID(models, "cline-pass/glm-5.2") {
+		t.Fatalf("expected OpenCode Go defaults after all dirty models were filtered, got %+v", models)
+	}
+}


### PR DESCRIPTION
## Summary
- filter stale ClinePass model entries out of OpenCode Go and Ollama Cloud registry models
- keep ClinePass registry models scoped to cline-pass/*
- fall back to static defaults when dirty persisted models leave no valid configured models

## Verification
- rtk gofmt -w sdk/cliproxy/service_model_registry_helpers.go sdk/cliproxy/service_model_registration.go sdk/cliproxy/service_opencode_go_test.go sdk/cliproxy/service_cline_test.go sdk/cliproxy/service_ollama_cloud_test.go
- rtk go test ./sdk/cliproxy