### PR TITLE
fix: keep dynamic provider models visible

### DIFF
--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -23,11 +23,11 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	var ownerMappings map[string]string
 	var ownerKeys map[string]bool
 	if shouldUseDefaultMappedOwnerScope(allowedChannelsRaw, allowedGroupsRaw) {
-		if rows, keys, ok := s.defaultMappedOwnerRows(); ok {
+		if rows, keys, configuredModelKeys, ok := s.defaultMappedOwnerRows(); ok {
 			usesMappedOwners = true
 			ownerKeys = keys
 			ownerMappings = authGroupOwnerMappingMap()
-			allModels = withDefaultMappedOwnerRows(modelRegistry, allModels, rows, ownerKeys, authByID, ownerMappings)
+			allModels = withDefaultMappedOwnerRows(modelRegistry, allModels, rows, ownerKeys, configuredModelKeys, authByID, ownerMappings)
 		}
 	}
 
@@ -52,9 +52,7 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		if ownedBy, exists := model["owned_by"]; exists {
 			entry["owned_by"] = ownedBy
 		}
-		row, hasConfig := configByID[strings.ToLower(id)]
-		modelOwnedByMappedOwner := hasConfig && row.Enabled && ownerKeys[normalizeModelOwnerKey(row.OwnedBy)]
-		if sources := s.modelSourceEntries(modelRegistry, id, authByID, ownerMappings, ownerKeys, modelOwnedByMappedOwner); len(sources) > 0 {
+		if sources := s.modelSourceEntries(modelRegistry, id, authByID, ownerMappings, ownerKeys); len(sources) > 0 {
 			entry["sources"] = sources
 		}
 		if row, ok := configByID[strings.ToLower(id)]; ok {
@@ -252,22 +250,26 @@ func shouldUseDefaultMappedOwnerScope(allowedChannelsRaw, allowedGroupsRaw strin
 	return strings.TrimSpace(allowedChannelsRaw) == "" && strings.TrimSpace(allowedGroupsRaw) == ""
 }
 
-func (s *Service) defaultMappedOwnerRows() ([]usage.ModelConfigRow, map[string]bool, bool) {
+func (s *Service) defaultMappedOwnerRows() ([]usage.ModelConfigRow, map[string]bool, map[string]bool, bool) {
 	ownerKeys := s.defaultMappedOwnerKeys()
 	if len(ownerKeys) == 0 {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	rows := modelconfigsettings.ListAllConfigs()
 	out := make([]usage.ModelConfigRow, 0, len(rows))
+	configuredModelKeys := make(map[string]bool, len(rows))
 	for _, row := range rows {
 		if !row.Enabled {
 			continue
+		}
+		if key := strings.ToLower(strings.TrimSpace(row.ModelID)); key != "" {
+			configuredModelKeys[key] = true
 		}
 		if ownerKeys[normalizeModelOwnerKey(row.OwnedBy)] {
 			out = append(out, row)
 		}
 	}
-	return out, ownerKeys, true
+	return out, ownerKeys, configuredModelKeys, true
 }
 
 func withDefaultMappedOwnerRows(
@@ -275,18 +277,20 @@ func withDefaultMappedOwnerRows(
 	models []map[string]any,
 	rows []usage.ModelConfigRow,
 	ownerKeys map[string]bool,
+	configuredModelKeys map[string]bool,
 	authByID map[string]*coreauth.Auth,
 	ownerMappings map[string]string,
 ) []map[string]any {
 	out := make([]map[string]any, 0, len(models)+len(rows))
 	seen := make(map[string]struct{}, len(models)+len(rows))
+	rowModelKeys := mappedOwnerRowModelKeys(rows, ownerKeys)
 	for _, model := range models {
 		id, _ := model["id"].(string)
 		key := strings.ToLower(strings.TrimSpace(id))
 		if key == "" {
 			continue
 		}
-		if registryModelCoveredByMappedOwners(modelRegistry, id, authByID, ownerMappings, ownerKeys) {
+		if registryModelCoveredByMappedOwners(modelRegistry, id, authByID, ownerMappings, ownerKeys, configuredModelKeys, rowModelKeys) {
 			continue
 		}
 		if _, exists := seen[key]; exists {
@@ -309,15 +313,35 @@ func withDefaultMappedOwnerRows(
 	return out
 }
 
+func mappedOwnerRowModelKeys(rows []usage.ModelConfigRow, ownerKeys map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		key := strings.ToLower(strings.TrimSpace(row.ModelID))
+		if key == "" || !row.Enabled || !ownerKeys[normalizeModelOwnerKey(row.OwnedBy)] {
+			continue
+		}
+		out[key] = true
+	}
+	return out
+}
+
 func registryModelCoveredByMappedOwners(
 	modelRegistry *registry.ModelRegistry,
 	modelID string,
 	authByID map[string]*coreauth.Auth,
 	ownerMappings map[string]string,
 	ownerKeys map[string]bool,
+	configuredModelKeys map[string]bool,
+	rowModelKeys map[string]bool,
 ) bool {
 	if modelRegistry == nil || len(ownerMappings) == 0 || len(ownerKeys) == 0 {
 		return false
+	}
+	key := strings.ToLower(strings.TrimSpace(modelID))
+	if !configuredModelKeys[key] && !rowModelKeys[key] {
+		if registryModelOnlyHasDynamicProviderSources(modelRegistry, modelID, authByID) {
+			return false
+		}
 	}
 	sources := modelRegistry.GetModelClientSources(modelID)
 	if len(sources) == 0 {
@@ -329,6 +353,27 @@ func registryModelCoveredByMappedOwners(
 		}
 		owner := mappedOwnerForSource(source, authByID, ownerMappings)
 		if owner == "" || !ownerKeys[owner] {
+			return false
+		}
+	}
+	return true
+}
+
+func registryModelOnlyHasDynamicProviderSources(modelRegistry *registry.ModelRegistry, modelID string, authByID map[string]*coreauth.Auth) bool {
+	sources := modelRegistry.GetModelClientSources(modelID)
+	if len(sources) == 0 {
+		return false
+	}
+	for _, source := range sources {
+		provider := strings.ToLower(strings.TrimSpace(source.Provider))
+		if auth := authByID[strings.TrimSpace(source.ClientID)]; auth != nil && strings.TrimSpace(auth.Provider) != "" {
+			provider = strings.ToLower(strings.TrimSpace(auth.Provider))
+		}
+		// These config-backed providers publish their serviceable models from runtime model lists,
+		// so a missing system model-config row must not hide the registry model.
+		switch provider {
+		case "opencode-go", "cline", "ollama-cloud":
+		default:
 			return false
 		}
 	}
@@ -425,7 +470,6 @@ func (s *Service) modelSourceEntries(
 	authByID map[string]*coreauth.Auth,
 	ownerMappings map[string]string,
 	ownerKeys map[string]bool,
-	modelOwnedByMappedOwner bool,
 ) []map[string]any {
 	if modelRegistry == nil {
 		return nil
@@ -436,8 +480,15 @@ func (s *Service) modelSourceEntries(
 	}
 	out := make([]map[string]any, 0, len(rawSources))
 	seen := make(map[string]struct{}, len(rawSources))
+	hasExplicitConfigSource := false
 	for _, raw := range rawSources {
-		if !modelOwnedByMappedOwner && sourceCoveredByMappedOwners(raw, authByID, ownerMappings, ownerKeys) {
+		if sourceHasExplicitConfigModels(raw, authByID) {
+			hasExplicitConfigSource = true
+			break
+		}
+	}
+	for _, raw := range rawSources {
+		if hasExplicitConfigSource && sourceCoveredByMappedOwners(raw, authByID, ownerMappings, ownerKeys) {
 			continue
 		}
 		clientID := strings.TrimSpace(raw.ClientID)

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -103,5 +104,100 @@ func TestConfiguredAvailabilityIncludesClineAliasUpstreamModelID(t *testing.T) {
 	source := sources[0]
 	if source["provider"] != "cline" || source["model_id"] != modelID || source["upstream_model_id"] != upstreamModelID {
 		t.Fatalf("source = %#v, want cline alias with upstream model id", source)
+	}
+}
+
+func TestDefaultMappedOwnerRowsKeepProviderModelWithoutConfigRow(t *testing.T) {
+	const modelID = "glm-5.2"
+	const clientID = "source-test-ollama-cloud"
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(clientID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	modelRegistry.RegisterClient(clientID, "ollama-cloud", []*registry.ModelInfo{{
+		ID:      modelID,
+		Object:  "model",
+		OwnedBy: "ollama",
+	}})
+
+	authByID := map[string]*coreauth.Auth{
+		clientID: {ID: clientID, Provider: "ollama-cloud", Label: "Ollama Cloud", Status: coreauth.StatusActive},
+	}
+	ownerMappings := map[string]string{"ollama-cloud": "ollama"}
+	ownerKeys := map[string]bool{"ollama": true}
+	models := []map[string]any{{"id": modelID, "object": "model", "owned_by": "ollama"}}
+
+	got := withDefaultMappedOwnerRows(modelRegistry, models, nil, ownerKeys, nil, authByID, ownerMappings)
+	if len(got) != 1 || got[0]["id"] != modelID {
+		t.Fatalf("models = %#v, want provider model kept when no enabled mapped-owner config row exists", got)
+	}
+}
+
+func TestDefaultMappedOwnerRowsReplaceProviderModelWhenConfigRowExists(t *testing.T) {
+	const modelID = "qwen3.7-max"
+	const clientID = "source-test-cline-replace"
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(clientID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	modelRegistry.RegisterClient(clientID, "cline", []*registry.ModelInfo{{
+		ID:      modelID,
+		Object:  "model",
+		OwnedBy: "cline",
+	}})
+
+	authByID := map[string]*coreauth.Auth{
+		clientID: {ID: clientID, Provider: "cline", Label: "ClinePass", Status: coreauth.StatusActive},
+	}
+	ownerMappings := map[string]string{"cline": "cline"}
+	ownerKeys := map[string]bool{"cline": true}
+	models := []map[string]any{{"id": modelID, "object": "model", "owned_by": "cline"}}
+	rows := []usage.ModelConfigRow{{
+		ModelID: modelID,
+		OwnedBy: "cline",
+		Enabled: true,
+		Source:  "seed",
+	}}
+
+	got := withDefaultMappedOwnerRows(modelRegistry, models, rows, ownerKeys, map[string]bool{modelID: true}, authByID, ownerMappings)
+	if len(got) != 1 || got[0]["id"] != modelID || got[0]["source"] != "seed" {
+		t.Fatalf("models = %#v, want mapped-owner config row to replace matching provider registry model", got)
+	}
+}
+
+func TestModelSourceEntriesKeepMappedProviderSourceForRetainedRegistryModel(t *testing.T) {
+	const modelID = "glm-5.2"
+	const clientID = "source-test-ollama-cloud-source"
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(clientID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	modelRegistry.RegisterClient(clientID, "ollama-cloud", []*registry.ModelInfo{{
+		ID:      modelID,
+		Object:  "model",
+		OwnedBy: "ollama",
+	}})
+
+	authByID := map[string]*coreauth.Auth{
+		clientID: {ID: clientID, Provider: "ollama-cloud", Label: "Ollama Cloud", Status: coreauth.StatusActive},
+	}
+	sources := New(&config.Config{}, nil).modelSourceEntries(
+		modelRegistry,
+		modelID,
+		authByID,
+		map[string]string{"ollama-cloud": "ollama"},
+		map[string]bool{"ollama": true},
+	)
+	if len(sources) != 1 || sources[0]["provider"] != "ollama-cloud" || sources[0]["channel"] != "Ollama Cloud" || sources[0]["model_id"] != modelID {
+		t.Fatalf("sources = %#v, want retained registry model to show mapped provider source", sources)
 	}
 }


### PR DESCRIPTION
## Summary
- keep dynamic provider registry models visible in configured availability when no explicit system config row exists
- preserve mapped-owner replacement behavior for existing configured rows
- keep source information for retained dynamic provider models

## Tests
- rtk go test ./internal/management/modelcatalog
- rtk go test ./internal/app/service ./internal/api/handlers/management ./internal/management/modelcatalog ./internal/management/settings/providers
- rtk go test ./...

## Scope
- CliRelay backend only
- fixes Ollama Cloud / OpenCode Go / ClinePass model availability in management model permissions
