### PR TITLE
fix: include configured provider models in management availability

### DIFF
--- a/internal/app/service/runtime_executor_registry_test.go
+++ b/internal/app/service/runtime_executor_registry_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	managementmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/internal/management/modelcatalog"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
@@ -135,6 +137,79 @@ func TestSyncDynamicConfigAuthModelsFallsBackWhenOnlyDirtyModelsRemain(t *testin
 	if hasSDKModelID(reg.models, "cline-pass/glm-5.2") {
 		t.Fatalf("registered dirty fallback model in %+v", reg.models)
 	}
+}
+
+func TestSyncConfigDerivedAuthsPublishesConfiguredProviderModelsToManagementAvailability(t *testing.T) {
+	cfg := &config.Config{
+		OpenCodeGoKey: []config.OpenCodeGoKey{{
+			APIKey: "go-key",
+			Name:   "OpenCode Go",
+			Models: []config.OpenCodeGoModel{{Name: "glm-5.2"}},
+		}},
+		ClineKey: []config.ClineKey{{
+			APIKey:  "cline-key",
+			Name:    "ClinePass",
+			BaseURL: config.DefaultClineBaseURL,
+			Models:  []config.ClineModel{{Name: "cline-pass/mimo-v2.5-pro", Alias: "mimo-v2.5-pro"}},
+		}},
+		OllamaCloudKey: []config.OllamaCloudKey{{
+			APIKey:  "ollama-key",
+			Name:    "Ollama Cloud",
+			BaseURL: config.DefaultOllamaCloudBaseURL,
+			Models:  []config.OllamaCloudModel{{Name: "gpt-oss:120b"}},
+		}},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+
+	SyncConfigDerivedAuths(cfg, manager)
+	for _, auth := range manager.List() {
+		if auth != nil {
+			t.Cleanup(func(id string) func() {
+				return func() { registry.GetGlobalRegistry().UnregisterClient(id) }
+			}(auth.ID))
+		}
+	}
+
+	result := managementmodelcatalog.New(cfg, manager).ConfiguredAvailability("", "")
+	data, ok := result["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v, want []map[string]any", result["data"])
+	}
+	available := make(map[string][]map[string]any, len(data))
+	for _, item := range data {
+		id, _ := item["id"].(string)
+		if id == "" {
+			continue
+		}
+		sources, _ := item["sources"].([]map[string]any)
+		available[id] = sources
+	}
+	for _, want := range []struct {
+		modelID  string
+		provider string
+	}{
+		{modelID: "glm-5.2", provider: "opencode-go"},
+		{modelID: "mimo-v2.5-pro", provider: "cline"},
+		{modelID: "gpt-oss:120b", provider: "ollama-cloud"},
+	} {
+		sources, ok := available[want.modelID]
+		if !ok {
+			t.Fatalf("configured availability missing %s; got models %#v", want.modelID, available)
+		}
+		if !hasSourceProvider(sources, want.provider) {
+			t.Fatalf("%s sources = %#v, want provider %s", want.modelID, sources, want.provider)
+		}
+	}
+}
+
+func hasSourceProvider(sources []map[string]any, provider string) bool {
+	for _, source := range sources {
+		sourceProvider, _ := source["provider"].(string)
+		if strings.EqualFold(strings.TrimSpace(sourceProvider), provider) {
+			return true
+		}
+	}
+	return false
 }
 
 func hasSDKModelID(models []*sdkmodelcatalog.ModelInfo, id string) bool {

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -17,7 +17,7 @@ import (
 // - Responsibility: turn registry state plus stored capabilities into management-facing availability DTOs.
 func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
 	modelRegistry := registry.GetGlobalRegistry()
-	allModels := s.effectiveModels(modelRegistry.GetAvailableModels("openai"), allowedChannelsRaw, allowedGroupsRaw)
+	allModels := s.effectiveModels(managementVisibleModels(modelRegistry), allowedChannelsRaw, allowedGroupsRaw)
 	authByID := s.authByID()
 	usesMappedOwners := false
 	var ownerMappings map[string]string
@@ -95,7 +95,7 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 
 func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
 	modelRegistry := registry.GetGlobalRegistry()
-	allModels := s.effectiveModels(modelRegistry.GetAvailableModels("openai"), allowedChannelsRaw, allowedGroupsRaw)
+	allModels := s.effectiveModels(managementVisibleModels(modelRegistry), allowedChannelsRaw, allowedGroupsRaw)
 
 	pricingMap := usage.GetAllModelPricing()
 	filteredModels := make([]map[string]any, len(allModels))
@@ -129,6 +129,71 @@ func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string) map[string
 		"object": "list",
 		"data":   filteredModels,
 	}
+}
+
+func managementVisibleModels(modelRegistry *registry.ModelRegistry) []map[string]any {
+	if modelRegistry == nil {
+		return nil
+	}
+	out := make([]map[string]any, 0)
+	seen := make(map[string]struct{})
+	add := func(model map[string]any) {
+		id, _ := model["id"].(string)
+		key := strings.ToLower(strings.TrimSpace(id))
+		if key == "" {
+			return
+		}
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, model)
+	}
+	for _, model := range modelRegistry.GetAvailableModels("openai") {
+		add(model)
+	}
+	for _, provider := range []string{"opencode-go", "cline", "ollama-cloud"} {
+		for _, info := range modelRegistry.GetAvailableModelsByProvider(provider) {
+			add(registryModelInfoAsOpenAIModel(info))
+		}
+	}
+	return out
+}
+
+func registryModelInfoAsOpenAIModel(info *registry.ModelInfo) map[string]any {
+	if info == nil {
+		return nil
+	}
+	model := map[string]any{
+		"id":       info.ID,
+		"object":   "model",
+		"owned_by": info.OwnedBy,
+	}
+	if info.Created > 0 {
+		model["created"] = info.Created
+	}
+	if info.Type != "" {
+		model["type"] = info.Type
+	}
+	if info.DisplayName != "" {
+		model["display_name"] = info.DisplayName
+	}
+	if info.Version != "" {
+		model["version"] = info.Version
+	}
+	if info.Description != "" {
+		model["description"] = info.Description
+	}
+	if info.ContextLength > 0 {
+		model["context_length"] = info.ContextLength
+	}
+	if info.MaxCompletionTokens > 0 {
+		model["max_completion_tokens"] = info.MaxCompletionTokens
+	}
+	if len(info.SupportedParameters) > 0 {
+		model["supported_parameters"] = info.SupportedParameters
+	}
+	return model
 }
 
 func (s *Service) effectiveModels(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string) []map[string]any {

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -333,6 +333,12 @@ func (s *ConfigSynthesizer) synthesizeOpenCodeGoKeys(ctx *SynthesisContext) []*c
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
+		if hash := diff.ComputeOpenCodeGoModelsHash(entry.Models); hash != "" {
+			attrs["models_hash"] = hash
+		}
+		if visionFallbackModel := strings.TrimSpace(entry.VisionFallbackModel); visionFallbackModel != "" {
+			attrs["vision_fallback_model"] = visionFallbackModel
+		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
 		label := strings.TrimSpace(entry.Name)
 		if label == "" {

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -375,8 +375,8 @@ func TestConfigSynthesizer_OpenCodeGoKeys(t *testing.T) {
 	if auth.Attributes["auth_kind"] != "apikey" || auth.Attributes["excluded_models"] != "minimax-m2.5" {
 		t.Fatalf("expected api key metadata, got %#v", auth.Attributes)
 	}
-	if auth.Attributes["models_hash"] != "" || auth.Attributes["vision_fallback_model"] != "" {
-		t.Fatalf("expected OpenCode Go per-key model metadata to be ignored, got %#v", auth.Attributes)
+	if auth.Attributes["models_hash"] == "" || auth.Attributes["vision_fallback_model"] != "qwen3.5-plus" {
+		t.Fatalf("expected OpenCode Go per-key model metadata, got %#v", auth.Attributes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- include configured OpenCode Go, ClinePass, and Ollama Cloud provider models in management model availability
- persist OpenCode Go configured models hash and vision fallback metadata like the other provider configs
- add regression coverage for config-derived provider models appearing in management availability

## Tests
- `rtk go test ./...`
- `rtk git diff --check`