### PR TITLE
fix: keep extended provider configs available

### DIFF
--- a/internal/api/handlers/management/ollama_cloud_config_test.go
+++ b/internal/api/handlers/management/ollama_cloud_config_test.go
@@ -1,0 +1,84 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	h := &Handler{cfg: &config.Config{}, configFilePath: configPath}
+
+	putBody := []byte(`[{"api-key":" ollama-key ","name":" primary ","prefix":" team ","base-url":" https://ollama.com/ ","headers":{"X-Test":" yes "},"models":[{"name":" gpt-oss:120b "}],"excluded-models":[" gpt-oss:20b "],"vision-fallback-model":" gpt-oss:120b "}]`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/ollama-cloud-api-key", bytes.NewReader(putBody))
+	h.ProviderKeys().PutOllamaCloudKeys(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
+	}
+	if len(h.cfg.OllamaCloudKey) != 1 || h.cfg.OllamaCloudKey[0].APIKey != "ollama-key" || h.cfg.OllamaCloudKey[0].Prefix != "team" || h.cfg.OllamaCloudKey[0].BaseURL != config.DefaultOllamaCloudBaseURL {
+		t.Fatalf("OllamaCloudKey after PUT = %+v", h.cfg.OllamaCloudKey)
+	}
+	if len(h.cfg.OllamaCloudKey[0].Models) != 1 || h.cfg.OllamaCloudKey[0].Models[0].Name != "gpt-oss:120b" {
+		t.Fatalf("OllamaCloudKey models after PUT = %+v, want sanitized model", h.cfg.OllamaCloudKey[0].Models)
+	}
+	if len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 1 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "gpt-oss:20b" {
+		t.Fatalf("OllamaCloudKey excluded models after PUT = %+v", h.cfg.OllamaCloudKey[0].ExcludedModels)
+	}
+	if h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:120b" {
+		t.Fatalf("OllamaCloudKey vision fallback after PUT = %+v", h.cfg.OllamaCloudKey[0])
+	}
+
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"gpt-oss:20b"}],"excluded-models":[" gpt-oss:120b ","*"],"vision-fallback-model":" gpt-oss:20b "}}`)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/ollama-cloud-api-key", bytes.NewReader(patchBody))
+	h.ProviderKeys().PatchOllamaCloudKey(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
+	}
+	if h.cfg.OllamaCloudKey[0].Name != "secondary" || h.cfg.OllamaCloudKey[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(h.cfg.OllamaCloudKey[0].Models) != 1 || h.cfg.OllamaCloudKey[0].Models[0].Name != "gpt-oss:20b" || len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 2 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "gpt-oss:120b" || h.cfg.OllamaCloudKey[0].ExcludedModels[1] != "*" || h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:20b" {
+		t.Fatalf("OllamaCloudKey after PATCH = %+v", h.cfg.OllamaCloudKey[0])
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/ollama-cloud-api-key", nil)
+	h.ProviderKeys().GetOllamaCloudKeys(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET status = %d body=%s", w.Code, w.Body.String())
+	}
+	var getBody struct {
+		Items []config.OllamaCloudKey `json:"ollama-cloud-api-key"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
+		t.Fatalf("decode GET body: %v", err)
+	}
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "gpt-oss:20b" || len(getBody.Items[0].ExcludedModels) != 2 || getBody.Items[0].ExcludedModels[0] != "gpt-oss:120b" || getBody.Items[0].ExcludedModels[1] != "*" || getBody.Items[0].VisionFallbackModel != "gpt-oss:20b" {
+		t.Fatalf("GET body = %+v", getBody)
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/v0/management/ollama-cloud-api-key?name=secondary", nil)
+	h.ProviderKeys().DeleteOllamaCloudKey(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DELETE status = %d body=%s", w.Code, w.Body.String())
+	}
+	if len(h.cfg.OllamaCloudKey) != 0 {
+		t.Fatalf("OllamaCloudKey after DELETE = %+v", h.cfg.OllamaCloudKey)
+	}
+}

--- a/internal/api/handlers/management/provider_empty_key_guard_test.go
+++ b/internal/api/handlers/management/provider_empty_key_guard_test.go
@@ -1,0 +1,100 @@
+package management
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestExtendedProviderManagementRejectsEmptyAPIKeyPayloads(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("opencode go", func(t *testing.T) {
+		h := newProviderKeysTestHandler(t, &config.Config{
+			OpenCodeGoKey: []config.OpenCodeGoKey{{APIKey: "existing", Name: "go"}},
+		})
+
+		w := performProviderKeysRequest(http.MethodPut, "/v0/management/opencode-go-api-key", `[{"name":"empty"}]`, h.ProviderKeys().PutOpenCodeGoKeys)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PUT status = %d body=%s, want 400", w.Code, w.Body.String())
+		}
+		if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("OpenCodeGoKey after rejected PUT = %+v, want unchanged", got)
+		}
+
+		w = performProviderKeysRequest(http.MethodPatch, "/v0/management/opencode-go-api-key", `{"index":0,"value":{"api-key":" "}}`, h.ProviderKeys().PatchOpenCodeGoKey)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PATCH status = %d body=%s, want 400", w.Code, w.Body.String())
+		}
+		if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("OpenCodeGoKey after rejected PATCH = %+v, want unchanged", got)
+		}
+	})
+
+	t.Run("cline", func(t *testing.T) {
+		h := newProviderKeysTestHandler(t, &config.Config{
+			ClineKey: []config.ClineKey{{APIKey: "existing", Name: "cline"}},
+		})
+
+		w := performProviderKeysRequest(http.MethodPut, "/v0/management/cline-api-key", `[{"name":"empty"}]`, h.ProviderKeys().PutClineKeys)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PUT status = %d body=%s, want 400", w.Code, w.Body.String())
+		}
+		if got := h.cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("ClineKey after rejected PUT = %+v, want unchanged", got)
+		}
+
+		w = performProviderKeysRequest(http.MethodPatch, "/v0/management/cline-api-key", `{"index":0,"value":{"api-key":" "}}`, h.ProviderKeys().PatchClineKey)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PATCH status = %d body=%s, want 400", w.Code, w.Body.String())
+		}
+		if got := h.cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("ClineKey after rejected PATCH = %+v, want unchanged", got)
+		}
+	})
+
+	t.Run("ollama cloud", func(t *testing.T) {
+		h := newProviderKeysTestHandler(t, &config.Config{
+			OllamaCloudKey: []config.OllamaCloudKey{{APIKey: "existing", Name: "ollama"}},
+		})
+
+		w := performProviderKeysRequest(http.MethodPut, "/v0/management/ollama-cloud-api-key", `[{"name":"empty"}]`, h.ProviderKeys().PutOllamaCloudKeys)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PUT status = %d body=%s, want 400", w.Code, w.Body.String())
+		}
+		if got := h.cfg.OllamaCloudKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("OllamaCloudKey after rejected PUT = %+v, want unchanged", got)
+		}
+
+		w = performProviderKeysRequest(http.MethodPatch, "/v0/management/ollama-cloud-api-key", `{"index":0,"value":{"api-key":" "}}`, h.ProviderKeys().PatchOllamaCloudKey)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PATCH status = %d body=%s, want 400", w.Code, w.Body.String())
+		}
+		if got := h.cfg.OllamaCloudKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("OllamaCloudKey after rejected PATCH = %+v, want unchanged", got)
+		}
+	})
+}
+
+func newProviderKeysTestHandler(t *testing.T, cfg *config.Config) *Handler {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return &Handler{cfg: cfg, configFilePath: configPath}
+}
+
+func performProviderKeysRequest(method string, path string, body string, handler gin.HandlerFunc) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(method, path, bytes.NewReader([]byte(body)))
+	handler(c)
+	return w
+}

--- a/internal/api/provider_config_availability_test.go
+++ b/internal/api/provider_config_availability_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+
+	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestManagementProviderConfigSaveUpdatesConfiguredAvailability(t *testing.T) {
+	const managementKey = "management-test-key"
+	hashed, err := bcrypt.GenerateFromPassword([]byte(managementKey), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hash management key: %v", err)
+	}
+
+	server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
+		cfg.RemoteManagement.SecretKey = string(hashed)
+		cfg.RemoteManagement.AllowRemote = true
+	})
+	if err := os.WriteFile(server.configFilePath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	putProviderConfig(t, server, managementKey, "/v0/management/opencode-go-api-key", `[{
+		"api-key":"go-key",
+		"name":"OpenCode Go",
+		"models":[{"name":"glm-5.2"}]
+	}]`)
+	assertAvailabilityHasModel(t, server, managementKey, "glm-5.2", "opencode-go", "opencode-go · OpenCode Go")
+
+	putProviderConfig(t, server, managementKey, "/v0/management/cline-api-key", `[{
+		"api-key":"cline-key",
+		"name":"ClinePass",
+		"models":[{"name":"cline-pass/mimo-v2.5-pro","alias":"mimo-v2.5-pro"}]
+	}]`)
+	assertAvailabilityHasModel(t, server, managementKey, "mimo-v2.5-pro", "cline", "cline · ClinePass")
+	assertAvailabilityMissingModel(t, server, managementKey, "cline-pass/mimo-v2.5-pro")
+
+	putProviderConfig(t, server, managementKey, "/v0/management/ollama-cloud-api-key", `[{
+		"api-key":"ollama-key",
+		"name":"Ollama Cloud",
+		"models":[{"name":"gpt-oss:120b"}]
+	}]`)
+	assertAvailabilityHasModel(t, server, managementKey, "gpt-oss:120b", "ollama-cloud", "ollama-cloud · Ollama Cloud")
+
+	patchProviderConfig(t, server, managementKey, "/v0/management/ollama-cloud-api-key", `{
+		"index":0,
+		"value":{"excluded-models":["gpt-oss:120b"]}
+	}`)
+	assertAvailabilityMissingModel(t, server, managementKey, "gpt-oss:120b")
+}
+
+func putProviderConfig(t *testing.T, server *Server, managementKey, path, body string) {
+	t.Helper()
+	managementRequest(t, server, managementKey, http.MethodPut, path, body, http.StatusOK)
+}
+
+func patchProviderConfig(t *testing.T, server *Server, managementKey, path, body string) {
+	t.Helper()
+	managementRequest(t, server, managementKey, http.MethodPatch, path, body, http.StatusOK)
+}
+
+func managementRequest(t *testing.T, server *Server, managementKey, method, path, body string, wantStatus int) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+managementKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.engine.ServeHTTP(rec, req)
+	if rec.Code != wantStatus {
+		t.Fatalf("%s %s status = %d body=%s, want %d", method, path, rec.Code, rec.Body.String(), wantStatus)
+	}
+	return rec
+}
+
+func configuredAvailability(t *testing.T, server *Server, managementKey string) configuredAvailabilityPayload {
+	t.Helper()
+	rec := managementRequest(t, server, managementKey, http.MethodGet, "/v0/management/models/configured-availability", "", http.StatusOK)
+	var payload configuredAvailabilityPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode configured availability: %v; body=%s", err, rec.Body.String())
+	}
+	return payload
+}
+
+type configuredAvailabilityPayload struct {
+	Data []configuredAvailabilityModel `json:"data"`
+}
+
+type configuredAvailabilityModel struct {
+	ID      string `json:"id"`
+	OwnedBy string `json:"owned_by"`
+	Sources []struct {
+		Label    string `json:"label"`
+		Provider string `json:"provider"`
+	} `json:"sources"`
+}
+
+func assertAvailabilityHasModel(t *testing.T, server *Server, managementKey, modelID, provider, sourceLabel string) {
+	t.Helper()
+	payload := configuredAvailability(t, server, managementKey)
+	for _, model := range payload.Data {
+		if !strings.EqualFold(model.ID, modelID) {
+			continue
+		}
+		for _, source := range model.Sources {
+			if source.Provider == provider && source.Label == sourceLabel {
+				return
+			}
+		}
+		t.Fatalf("model %q sources = %+v, want provider %q label %q", modelID, model.Sources, provider, sourceLabel)
+	}
+	t.Fatalf("missing configured model %q; ids=%v", modelID, availabilityIDs(payload))
+}
+
+func assertAvailabilityMissingModel(t *testing.T, server *Server, managementKey, modelID string) {
+	t.Helper()
+	payload := configuredAvailability(t, server, managementKey)
+	for _, model := range payload.Data {
+		if strings.EqualFold(model.ID, modelID) {
+			t.Fatalf("unexpected configured model %q in availability; model=%+v", modelID, model)
+		}
+	}
+}
+
+func availabilityIDs(payload configuredAvailabilityPayload) []string {
+	ids := make([]string, 0, len(payload.Data))
+	for _, model := range payload.Data {
+		ids = append(ids, model.ID)
+	}
+	return ids
+}

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -11,6 +11,8 @@ import (
 
 var openCodeGoServerIDPattern = regexp.MustCompile(`(?i)^[a-f0-9]{64}$`)
 
+var ErrProviderAPIKeyRequired = errors.New("api-key is required")
+
 type BedrockKeyPatch struct {
 	Name            *string                `json:"name"`
 	Priority        *int                   `json:"priority"`
@@ -212,6 +214,9 @@ func (s *Service) ReplaceOpenCodeGoKeys(entries []config.OpenCodeGoKey) error {
 			filtered = append(filtered, entries[i])
 		}
 	}
+	if len(entries) > 0 && len(filtered) == 0 {
+		return ErrProviderAPIKeyRequired
+	}
 	prev := append([]config.OpenCodeGoKey(nil), s.cfg.OpenCodeGoKey...)
 	s.cfg.OpenCodeGoKey = filtered
 	s.cfg.SanitizeOpenCodeGoKeys()
@@ -291,8 +296,7 @@ func (s *Service) PatchOpenCodeGoKey(index *int, apiKey *string, name *string, p
 	}
 	NormalizeOpenCodeGoKey(&entry)
 	if entry.APIKey == "" {
-		s.deleteOpenCodeGoKeyByIndex(targetIndex)
-		return nil
+		return ErrProviderAPIKeyRequired
 	}
 	if err := validateOpenCodeGoKeyModels(entry); err != nil {
 		return err
@@ -381,6 +385,9 @@ func (s *Service) ReplaceClineKeys(entries []config.ClineKey) error {
 			filtered = append(filtered, entries[i])
 		}
 	}
+	if len(entries) > 0 && len(filtered) == 0 {
+		return ErrProviderAPIKeyRequired
+	}
 	prev := append([]config.ClineKey(nil), s.cfg.ClineKey...)
 	s.cfg.ClineKey = filtered
 	s.cfg.SanitizeClineKeys()
@@ -457,8 +464,7 @@ func (s *Service) PatchClineKey(index *int, apiKey *string, name *string, patch 
 	}
 	NormalizeClineKey(&entry)
 	if entry.APIKey == "" {
-		s.deleteClineKeyByIndex(targetIndex)
-		return nil
+		return ErrProviderAPIKeyRequired
 	}
 	if err := validateClineKeyModels(entry); err != nil {
 		return err
@@ -547,6 +553,9 @@ func (s *Service) ReplaceOllamaCloudKeys(entries []config.OllamaCloudKey) error 
 			filtered = append(filtered, entries[i])
 		}
 	}
+	if len(entries) > 0 && len(filtered) == 0 {
+		return ErrProviderAPIKeyRequired
+	}
 	prev := append([]config.OllamaCloudKey(nil), s.cfg.OllamaCloudKey...)
 	s.cfg.OllamaCloudKey = filtered
 	s.cfg.SanitizeOllamaCloudKeys()
@@ -623,8 +632,7 @@ func (s *Service) PatchOllamaCloudKey(index *int, apiKey *string, name *string, 
 	}
 	NormalizeOllamaCloudKey(&entry)
 	if entry.APIKey == "" {
-		s.deleteOllamaCloudKeyByIndex(targetIndex)
-		return nil
+		return ErrProviderAPIKeyRequired
 	}
 	if err := validateOllamaCloudKeyModels(entry); err != nil {
 		return err

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -415,6 +415,114 @@ func TestOpenCodeGoKeysKeepPerKeyModels(t *testing.T) {
 	}
 }
 
+func TestExtendedProviderReplaceRejectsNonEmptyPayloadWithoutAPIKeys(t *testing.T) {
+	t.Run("opencode go", func(t *testing.T) {
+		cfg := &config.Config{OpenCodeGoKey: []config.OpenCodeGoKey{{APIKey: "existing"}}}
+		svc := NewService(cfg, nil)
+
+		err := svc.ReplaceOpenCodeGoKeys([]config.OpenCodeGoKey{{Name: "empty"}})
+		if !errors.Is(err, ErrProviderAPIKeyRequired) {
+			t.Fatalf("ReplaceOpenCodeGoKeys() error = %v, want api-key required", err)
+		}
+		if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("OpenCodeGoKey after rejected replace = %#v, want unchanged", got)
+		}
+
+		if err := svc.ReplaceOpenCodeGoKeys(nil); err != nil {
+			t.Fatalf("ReplaceOpenCodeGoKeys(nil) error = %v, want nil", err)
+		}
+		if len(cfg.OpenCodeGoKey) != 0 {
+			t.Fatalf("OpenCodeGoKey after explicit clear = %#v, want empty", cfg.OpenCodeGoKey)
+		}
+	})
+
+	t.Run("cline", func(t *testing.T) {
+		cfg := &config.Config{ClineKey: []config.ClineKey{{APIKey: "existing"}}}
+		svc := NewService(cfg, nil)
+
+		err := svc.ReplaceClineKeys([]config.ClineKey{{Name: "empty"}})
+		if !errors.Is(err, ErrProviderAPIKeyRequired) {
+			t.Fatalf("ReplaceClineKeys() error = %v, want api-key required", err)
+		}
+		if got := cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("ClineKey after rejected replace = %#v, want unchanged", got)
+		}
+
+		if err := svc.ReplaceClineKeys(nil); err != nil {
+			t.Fatalf("ReplaceClineKeys(nil) error = %v, want nil", err)
+		}
+		if len(cfg.ClineKey) != 0 {
+			t.Fatalf("ClineKey after explicit clear = %#v, want empty", cfg.ClineKey)
+		}
+	})
+
+	t.Run("ollama cloud", func(t *testing.T) {
+		cfg := &config.Config{OllamaCloudKey: []config.OllamaCloudKey{{APIKey: "existing"}}}
+		svc := NewService(cfg, nil)
+
+		err := svc.ReplaceOllamaCloudKeys([]config.OllamaCloudKey{{Name: "empty"}})
+		if !errors.Is(err, ErrProviderAPIKeyRequired) {
+			t.Fatalf("ReplaceOllamaCloudKeys() error = %v, want api-key required", err)
+		}
+		if got := cfg.OllamaCloudKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("OllamaCloudKey after rejected replace = %#v, want unchanged", got)
+		}
+
+		if err := svc.ReplaceOllamaCloudKeys(nil); err != nil {
+			t.Fatalf("ReplaceOllamaCloudKeys(nil) error = %v, want nil", err)
+		}
+		if len(cfg.OllamaCloudKey) != 0 {
+			t.Fatalf("OllamaCloudKey after explicit clear = %#v, want empty", cfg.OllamaCloudKey)
+		}
+	})
+}
+
+func TestExtendedProviderPatchRejectsEmptyAPIKeyWithoutDeleting(t *testing.T) {
+	empty := " "
+
+	t.Run("opencode go", func(t *testing.T) {
+		cfg := &config.Config{OpenCodeGoKey: []config.OpenCodeGoKey{{APIKey: "existing", Name: "go"}}}
+		svc := NewService(cfg, nil)
+		index := 0
+
+		err := svc.PatchOpenCodeGoKey(&index, nil, nil, OpenCodeGoPatch{APIKey: &empty})
+		if !errors.Is(err, ErrProviderAPIKeyRequired) {
+			t.Fatalf("PatchOpenCodeGoKey() error = %v, want api-key required", err)
+		}
+		if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("OpenCodeGoKey after rejected patch = %#v, want unchanged", got)
+		}
+	})
+
+	t.Run("cline", func(t *testing.T) {
+		cfg := &config.Config{ClineKey: []config.ClineKey{{APIKey: "existing", Name: "cline"}}}
+		svc := NewService(cfg, nil)
+		index := 0
+
+		err := svc.PatchClineKey(&index, nil, nil, ClinePatch{APIKey: &empty})
+		if !errors.Is(err, ErrProviderAPIKeyRequired) {
+			t.Fatalf("PatchClineKey() error = %v, want api-key required", err)
+		}
+		if got := cfg.ClineKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("ClineKey after rejected patch = %#v, want unchanged", got)
+		}
+	})
+
+	t.Run("ollama cloud", func(t *testing.T) {
+		cfg := &config.Config{OllamaCloudKey: []config.OllamaCloudKey{{APIKey: "existing", Name: "ollama"}}}
+		svc := NewService(cfg, nil)
+		index := 0
+
+		err := svc.PatchOllamaCloudKey(&index, nil, nil, OllamaCloudPatch{APIKey: &empty})
+		if !errors.Is(err, ErrProviderAPIKeyRequired) {
+			t.Fatalf("PatchOllamaCloudKey() error = %v, want api-key required", err)
+		}
+		if got := cfg.OllamaCloudKey; len(got) != 1 || got[0].APIKey != "existing" {
+			t.Fatalf("OllamaCloudKey after rejected patch = %#v, want unchanged", got)
+		}
+	})
+}
+
 func TestClineKeysRejectNonClinePassModelsButAllowCrossProviderFallback(t *testing.T) {
 	cfg := &config.Config{
 		ClineKey: []config.ClineKey{{


### PR DESCRIPTION
## Summary\n- reject empty API-key writes for OpenCode Go, ClinePass, and Ollama Cloud so edits cannot erase existing keys\n- add management API coverage proving provider saves refresh configured availability immediately\n- cover Ollama Cloud config PUT/PATCH/GET/DELETE and empty-key guard behavior\n\n## Tests\n- rtk go test ./internal/management/settings/providers ./internal/api/handlers/management ./internal/app/service ./internal/runtime/executor ./internal/api -count=1