### PR TITLE
fix: hide unserviceable mapped owner models

### DIFF
--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -369,6 +369,9 @@ func withDefaultMappedOwnerRows(
 		if key == "" {
 			continue
 		}
+		if !mappedOwnerRowHasRuntimeSource(modelRegistry, row) {
+			continue
+		}
 		if _, exists := seen[key]; exists {
 			continue
 		}
@@ -376,6 +379,13 @@ func withDefaultMappedOwnerRows(
 		out = append(out, modelConfigRowAsOpenAIModel(row))
 	}
 	return out
+}
+
+func mappedOwnerRowHasRuntimeSource(modelRegistry *registry.ModelRegistry, row usage.ModelConfigRow) bool {
+	if modelRegistry == nil {
+		return false
+	}
+	return len(modelRegistry.GetModelClientSources(row.ModelID)) > 0
 }
 
 func mappedOwnerRowModelKeys(rows []usage.ModelConfigRow, ownerKeys map[string]bool) map[string]bool {

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -171,6 +171,32 @@ func TestDefaultMappedOwnerRowsReplaceProviderModelWhenConfigRowExists(t *testin
 	}
 }
 
+func TestDefaultMappedOwnerRowsSkipConfigRowWithoutRuntimeSource(t *testing.T) {
+	const modelID = "gpt-5.6-sol"
+
+	ownerMappings := map[string]string{"codex": "codex"}
+	ownerKeys := map[string]bool{"codex": true}
+	rows := []usage.ModelConfigRow{{
+		ModelID: modelID,
+		OwnedBy: "codex",
+		Enabled: true,
+		Source:  "seed",
+	}}
+
+	got := withDefaultMappedOwnerRows(
+		registry.GetGlobalRegistry(),
+		nil,
+		rows,
+		ownerKeys,
+		map[string]bool{modelID: true},
+		map[string]*coreauth.Auth{},
+		ownerMappings,
+	)
+	if len(got) != 0 {
+		t.Fatalf("models = %#v, want unserviceable mapped-owner config row hidden", got)
+	}
+}
+
 func TestModelSourceEntriesKeepMappedProviderSourceForRetainedRegistryModel(t *testing.T) {
 	const modelID = "glm-5.2"
 	const clientID = "source-test-ollama-cloud-source"


### PR DESCRIPTION
## Summary\n- do not expose mapped-owner DB model rows as available unless the runtime model registry has a serviceable source for that model\n- keep DB metadata replacement for models that are actually present in runtime registry\n- add regression coverage for stale enabled model config rows such as gpt-5.6-sol appearing as callable\n\n## Tests\n- rtk go test ./internal/management/settings/providers ./internal/management/modelcatalog ./internal/api/handlers/management ./internal/app/service ./internal/runtime/executor ./internal/api -count=1