### PR TITLE
fix: unwrap provider OpenAI response envelopes

### DIFF
--- a/internal/openaicompat/response.go
+++ b/internal/openaicompat/response.go
@@ -1,0 +1,20 @@
+package openaicompat
+
+import "github.com/tidwall/gjson"
+
+// ResponseRoot unwraps provider envelopes such as ClinePass
+// {"success":true,"data":{...openai response...}}.
+func ResponseRoot(root gjson.Result) gjson.Result {
+	data := root.Get("data")
+	if !data.Exists() || !data.IsObject() {
+		return root
+	}
+	if data.Get("choices").Exists() || data.Get("usage").Exists() || data.Get("output").Exists() || data.Get("model").Exists() || data.Get("id").Exists() {
+		return data
+	}
+	return root
+}
+
+func ParseResponseRoot(data []byte) gjson.Result {
+	return ResponseRoot(gjson.ParseBytes(data))
+}

--- a/internal/runtime/executor/openai_compat_cline_test.go
+++ b/internal/runtime/executor/openai_compat_cline_test.go
@@ -55,3 +55,37 @@ func TestOpenAICompatExecutorClineUsesVisionFallbackForImageRequests(t *testing.
 		t.Fatalf("response model = %q, want cline-pass/deepseek-v4-flash; payload=%s", gotModel, string(resp.Payload))
 	}
 }
+
+func TestOpenAICompatExecutorClineUnwrapsDataEnvelopeForClaudeMessages(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"chatcmpl_wrapped","object":"chat.completion","created":1,"model":"cline-pass/qwen3.7-max","choices":[{"index":0,"message":{"role":"assistant","content":"cline wrapped ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":5,"total_tokens":14}}}`))
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("cline", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/api/v1",
+		"api_key":  "test-key",
+	}}
+	payload := []byte(`{"model":"qwen3.7-max","max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/qwen3.7-max",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gotPath != "/api/v1/chat/completions" {
+		t.Fatalf("path = %q, want /api/v1/chat/completions", gotPath)
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "content.0.text").String(); gotText != "cline wrapped ok" {
+		t.Fatalf("Claude message text = %q, want cline wrapped ok; payload=%s", gotText, string(resp.Payload))
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 5 {
+		t.Fatalf("output tokens = %d, want 5; payload=%s", got, string(resp.Payload))
+	}
+}

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -57,9 +57,26 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIUsageUnwrapsProviderDataEnvelope(t *testing.T) {
+	data := []byte(`{"success":true,"data":{"usage":{"prompt_tokens":9,"completion_tokens":5,"total_tokens":14}}}`)
+	detail := parseOpenAIUsage(data)
+	if detail.InputTokens != 9 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 9)
+	}
+	if detail.OutputTokens != 5 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 5)
+	}
+	if detail.TotalTokens != 14 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 14)
+	}
+}
+
 func TestParseOpenAIResponseModel(t *testing.T) {
 	if got := parseOpenAIResponseModel([]byte(`{"model":"gpt-5.4","usage":{"total_tokens":1}}`)); got != "gpt-5.4" {
 		t.Fatalf("model = %q, want gpt-5.4", got)
+	}
+	if got := parseOpenAIResponseModel([]byte(`{"success":true,"data":{"model":"cline-pass/qwen3.7-max","usage":{"total_tokens":1}}}`)); got != "cline-pass/qwen3.7-max" {
+		t.Fatalf("wrapped model = %q, want cline-pass/qwen3.7-max", got)
 	}
 	if got := parseOpenAIStreamModel([]byte(`data: {"model":"gpt-5.4-mini-2026-03-17","usage":{"total_tokens":1}}`)); got != "gpt-5.4-mini-2026-03-17" {
 		t.Fatalf("stream model = %q, want gpt-5.4-mini-2026-03-17", got)

--- a/internal/runtime/executor/usage_parsers.go
+++ b/internal/runtime/executor/usage_parsers.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/openaicompat"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	"github.com/tidwall/gjson"
 )
@@ -29,7 +30,7 @@ func parseCodexUsage(data []byte) (usage.Detail, bool) {
 }
 
 func parseOpenAIUsage(data []byte) usage.Detail {
-	usageNode := gjson.ParseBytes(data).Get("usage")
+	usageNode := openaicompat.ParseResponseRoot(data).Get("usage")
 	if !usageNode.Exists() {
 		return usage.Detail{}
 	}
@@ -69,7 +70,7 @@ func parseOpenAIResponseModel(data []byte) string {
 	if len(data) == 0 || !gjson.ValidBytes(data) {
 		return ""
 	}
-	return strings.TrimSpace(gjson.GetBytes(data, "model").String())
+	return strings.TrimSpace(openaicompat.ParseResponseRoot(data).Get("model").String())
 }
 
 func parseOpenAIStreamModel(line []byte) string {
@@ -77,7 +78,7 @@ func parseOpenAIStreamModel(line []byte) string {
 	if len(payload) == 0 || !gjson.ValidBytes(payload) {
 		return ""
 	}
-	return strings.TrimSpace(gjson.GetBytes(payload, "model").String())
+	return strings.TrimSpace(openaicompat.ParseResponseRoot(payload).Get("model").String())
 }
 
 func parseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
@@ -85,7 +86,7 @@ func parseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
 	if len(payload) == 0 || !gjson.ValidBytes(payload) {
 		return usage.Detail{}, false
 	}
-	usageNode := gjson.GetBytes(payload, "usage")
+	usageNode := openaicompat.ParseResponseRoot(payload).Get("usage")
 	if !usageNode.Exists() {
 		return usage.Detail{}, false
 	}

--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/openaicompat"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -119,7 +120,7 @@ func ConvertOpenAIResponseToClaude(_ context.Context, _ string, originalRequestR
 
 // convertOpenAIStreamingChunkToAnthropic converts OpenAI streaming chunk to Anthropic streaming events
 func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAIResponseToAnthropicParams) []string {
-	root := gjson.ParseBytes(rawJSON)
+	root := openaicompat.ParseResponseRoot(rawJSON)
 	var results []string
 
 	// Initialize parameters if needed
@@ -339,7 +340,7 @@ func convertOpenAIDoneToAnthropic(param *ConvertOpenAIResponseToAnthropicParams)
 
 // convertOpenAINonStreamingToAnthropic converts OpenAI non-streaming response to Anthropic format
 func convertOpenAINonStreamingToAnthropic(rawJSON []byte) []string {
-	root := gjson.ParseBytes(rawJSON)
+	root := openaicompat.ParseResponseRoot(rawJSON)
 
 	out := `{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`
 	out, _ = sjson.Set(out, "id", root.Get("id").String())
@@ -571,7 +572,7 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 	_ = originalRequestRawJSON
 	_ = requestRawJSON
 
-	root := gjson.ParseBytes(rawJSON)
+	root := openaicompat.ParseResponseRoot(rawJSON)
 	out := `{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`
 	out, _ = sjson.Set(out, "id", root.Get("id").String())
 	out, _ = sjson.Set(out, "model", root.Get("model").String())

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -565,6 +565,21 @@ func TestOpenAINonStreamingEmptyToolNameSkippedAndStopReasonEndTurn(t *testing.T
 	}
 }
 
+func TestOpenAINonStreamingUnwrapsProviderDataEnvelope(t *testing.T) {
+	raw := []byte(`{"success":true,"data":{"id":"chatcmpl_wrapped","object":"chat.completion","created":1,"model":"cline-pass/qwen3.7-max","choices":[{"index":0,"message":{"role":"assistant","content":"wrapped ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}}`)
+
+	out := ConvertOpenAIResponseToClaudeNonStream(context.Background(), "m", nil, nil, raw, nil)
+	if got := gjson.Get(out, "content.0.text").String(); got != "wrapped ok" {
+		t.Fatalf("text = %q, want wrapped ok; payload=%s", got, out)
+	}
+	if got := gjson.Get(out, "usage.input_tokens").Int(); got != 11 {
+		t.Fatalf("input tokens = %d, want 11; payload=%s", got, out)
+	}
+	if got := gjson.Get(out, "usage.output_tokens").Int(); got != 7 {
+		t.Fatalf("output tokens = %d, want 7; payload=%s", got, out)
+	}
+}
+
 func TestOpenAINonStreamingContentArrayEmptyToolNameSkipped(t *testing.T) {
 	raw := []byte(`{"id":"chatcmpl-empty-tool-array","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":[{"type":"tool_calls","tool_calls":[{"id":"call_empty","type":"function","function":{"name":"","arguments":"{\"path\":\"x\"}"}}]}]},"finish_reason":"tool_calls"}]}`)
 

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/openaicompat"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -85,7 +86,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		return []string{}
 	}
 
-	root := gjson.ParseBytes(rawJSON)
+	root := openaicompat.ParseResponseRoot(rawJSON)
 	obj := root.Get("object")
 	if obj.Exists() && obj.String() != "" && obj.String() != "chat.completion.chunk" {
 		return []string{}
@@ -609,7 +610,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 // ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream builds a single Responses JSON
 // from a non-streaming OpenAI Chat Completions response.
 func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) string {
-	root := gjson.ParseBytes(rawJSON)
+	root := openaicompat.ParseResponseRoot(rawJSON)
 
 	// Basic response scaffold
 	resp := `{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null,"incomplete_details":null}`
@@ -706,7 +707,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 	// Build output list from choices[...]
 	outputsWrapper := `{"arr":[]}`
 	// Detect and capture reasoning content if present
-	rcText := gjson.GetBytes(rawJSON, "choices.0.message.reasoning_content").String()
+	rcText := root.Get("choices.0.message.reasoning_content").String()
 	includeReasoning := rcText != ""
 	if !includeReasoning && len(requestRawJSON) > 0 {
 		includeReasoning = gjson.GetBytes(requestRawJSON, "reasoning").Exists()

--- a/internal/translator/openai/openai/responses/openai_openai_responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai_responses_response_test.go
@@ -38,3 +38,20 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesPreservesParallelT
 		}
 	}
 }
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesUnwrapsProviderDataEnvelope(t *testing.T) {
+	raw := []byte(`{"success":true,"data":{"id":"chatcmpl_wrapped","object":"chat.completion","created":1,"model":"cline-pass/qwen3.7-max","choices":[{"index":0,"message":{"role":"assistant","content":"wrapped response ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}}`)
+
+	out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "m", nil, nil, raw, nil)
+	for _, want := range []string{
+		`"model":"cline-pass/qwen3.7-max"`,
+		`"text":"wrapped response ok"`,
+		`"input_tokens":3`,
+		`"output_tokens":4`,
+		`"total_tokens":7`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %s in converted response:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- unwrap provider responses shaped as { success, data } before OpenAI-compatible translation
- fix Claude Messages and Responses conversions for wrapped ClinePass responses
- parse usage/model from wrapped OpenAI-compatible responses so successful calls are not logged with zero tokens

## Tests
- go test ./internal/openaicompat ./internal/translator/openai/claude ./internal/translator/openai/openai/responses ./internal/runtime/executor ./internal/api -count=1