### PR TITLE
feat: support CC Switch model context windows

### DIFF
--- a/internal/api/handlers/management/ccswitch_import_configs_public_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_public_test.go
@@ -140,7 +140,7 @@ func TestPublicCcSwitchImportConfigsIncludesCodexModelCatalog(t *testing.T) {
 			EndpointPath:         "/v1",
 			UsageAutoInterval:    30,
 			ModelMappings: []usage.CcSwitchModelMappingRow{
-				{RequestModel: "gpt-5.5", TargetModel: "gpt-5.5"},
+				{RequestModel: "gpt-5.5", TargetModel: "gpt-5.5", ContextWindow: 272000},
 				{RequestModel: "deepseek-v4-flash", TargetModel: "deepseek-chat"},
 				{RequestModel: "deepseek-v4-pro", TargetModel: "deepseek-reasoner"},
 			},
@@ -201,5 +201,12 @@ func TestPublicCcSwitchImportConfigsIncludesCodexModelCatalog(t *testing.T) {
 		if slugs[idx] != want[idx] {
 			t.Fatalf("catalog slug[%d] = %q, want %q; all=%#v", idx, slugs[idx], want[idx], slugs)
 		}
+	}
+	if item.CodexModelCatalog.Models[0].ContextWindow != 272000 ||
+		item.CodexModelCatalog.Models[0].ModelMessages.ContextWindow != 272000 {
+		t.Fatalf("first catalog context window = %#v, want 272000", item.CodexModelCatalog.Models[0])
+	}
+	if item.CodexModelCatalog.Models[1].ContextWindow != 128000 {
+		t.Fatalf("second catalog context window = %d, want 128000", item.CodexModelCatalog.Models[1].ContextWindow)
 	}
 }

--- a/internal/api/handlers/management/ccswitch_import_configs_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_test.go
@@ -124,3 +124,79 @@ func TestPutCcSwitchImportConfigsRejectsInvalidClientType(t *testing.T) {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
 }
+
+func TestCcSwitchImportConfigsPreservesCodexMappingContextWindow(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	body := []byte(`[
+  {
+    "id": "cfg-codex",
+    "client-type": "codex",
+    "provider-name": "Relay Codex",
+    "default-model": "gpt-5.5",
+    "allowed-channel-groups": ["codex"],
+    "endpoint-path": "/v1",
+    "usage-auto-interval": 30,
+    "model-mappings": [
+      {"request-model": "gpt-5.5", "target-model": "gpt-5.5", "context-window": 272000},
+      {"request-model": "kimi-k2", "target-model": "kimi-k2"}
+    ]
+  }
+]`)
+
+	h := NewHandler(&config.Config{}, "", nil)
+	putRec := httptest.NewRecorder()
+	putCtx, _ := gin.CreateTestContext(putRec)
+	putCtx.Request = httptest.NewRequest(http.MethodPut, "/ccswitch-import-configs", bytes.NewReader(body))
+
+	h.PutCcSwitchImportConfigs(putCtx)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d; body=%s", putRec.Code, http.StatusOK, putRec.Body.String())
+	}
+
+	getRec := httptest.NewRecorder()
+	getCtx, _ := gin.CreateTestContext(getRec)
+	getCtx.Request = httptest.NewRequest(http.MethodGet, "/ccswitch-import-configs", nil)
+
+	h.GetCcSwitchImportConfigs(getCtx)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d; body=%s", getRec.Code, http.StatusOK, getRec.Body.String())
+	}
+
+	var got struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal GET response: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(got.Items))
+	}
+	modelMappings, ok := got.Items[0]["model-mappings"].([]any)
+	if !ok || len(modelMappings) != 2 {
+		t.Fatalf("model-mappings = %#v, want 2 mappings", got.Items[0]["model-mappings"])
+	}
+	firstMapping, ok := modelMappings[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first model mapping = %#v, want object", modelMappings[0])
+	}
+	if firstMapping["context-window"] != float64(272000) {
+		t.Fatalf("first mapping context-window = %#v, want 272000", firstMapping["context-window"])
+	}
+	catalog, ok := got.Items[0]["codex-model-catalog"].(map[string]any)
+	if !ok {
+		t.Fatalf("codex-model-catalog = %#v, want object", got.Items[0]["codex-model-catalog"])
+	}
+	models, ok := catalog["models"].([]any)
+	if !ok || len(models) != 2 {
+		t.Fatalf("catalog models = %#v, want 2 models", catalog["models"])
+	}
+	firstModel, ok := models[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first catalog model = %#v, want object", models[0])
+	}
+	if firstModel["context_window"] != float64(272000) {
+		t.Fatalf("first catalog context_window = %#v, want 272000", firstModel["context_window"])
+	}
+}

--- a/internal/usage/ccswitch_codex_model_catalog.go
+++ b/internal/usage/ccswitch_codex_model_catalog.go
@@ -83,6 +83,11 @@ type CcSwitchCodexModelCatalogEntry struct {
 const ccSwitchCodexDefaultContextWindow = 128000
 const ccSwitchCodexBaseInstructions = "You are Codex, a coding agent."
 
+type ccSwitchCodexCatalogModelSpec struct {
+	Model         string
+	ContextWindow int
+}
+
 var ccSwitchCodexSupportedReasoningLevels = []CcSwitchCodexReasoningLevel{
 	{Effort: "low", Description: "Fast responses with lighter reasoning"},
 	{Effort: "medium", Description: "Balances speed and reasoning depth for everyday tasks"},
@@ -95,10 +100,7 @@ func BuildCcSwitchCodexModelCatalog(row CcSwitchImportConfigRow) *CcSwitchCodexM
 		return nil
 	}
 
-	models := make([]string, 0, len(row.ModelMappings)+1)
-	if model := strings.TrimSpace(row.DefaultModel); model != "" {
-		models = append(models, model)
-	}
+	models := make([]ccSwitchCodexCatalogModelSpec, 0, len(row.ModelMappings)+1)
 	for _, mapping := range row.ModelMappings {
 		if strings.TrimSpace(mapping.Role) != "" {
 			continue
@@ -108,23 +110,29 @@ func BuildCcSwitchCodexModelCatalog(row CcSwitchImportConfigRow) *CcSwitchCodexM
 			model = strings.TrimSpace(mapping.TargetModel)
 		}
 		if model != "" {
-			models = append(models, model)
+			models = append(models, ccSwitchCodexCatalogModelSpec{
+				Model:         model,
+				ContextWindow: normalizeCcSwitchCodexContextWindow(mapping.ContextWindow),
+			})
 		}
+	}
+	if model := strings.TrimSpace(row.DefaultModel); model != "" {
+		models = append(models, ccSwitchCodexCatalogModelSpec{Model: model})
 	}
 
 	seen := make(map[string]struct{}, len(models))
 	entries := make([]CcSwitchCodexModelCatalogEntry, 0, len(models))
-	for _, model := range models {
-		model = strings.TrimSpace(model)
-		key := strings.ToLower(model)
-		if model == "" {
+	for _, spec := range models {
+		spec.Model = strings.TrimSpace(spec.Model)
+		key := strings.ToLower(spec.Model)
+		if spec.Model == "" {
 			continue
 		}
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		entries = append(entries, buildCcSwitchCodexModelCatalogEntry(model, len(entries)))
+		entries = append(entries, buildCcSwitchCodexModelCatalogEntry(spec, len(entries)))
 	}
 	if len(entries) == 0 {
 		return nil
@@ -154,7 +162,16 @@ func AttachCcSwitchCodexModelCatalogs(rows []CcSwitchImportConfigRow) []CcSwitch
 	return out
 }
 
-func buildCcSwitchCodexModelCatalogEntry(model string, priority int) CcSwitchCodexModelCatalogEntry {
+func normalizeCcSwitchCodexContextWindow(value int) int {
+	if value <= 0 {
+		return ccSwitchCodexDefaultContextWindow
+	}
+	return value
+}
+
+func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, priority int) CcSwitchCodexModelCatalogEntry {
+	model := strings.TrimSpace(spec.Model)
+	contextWindow := normalizeCcSwitchCodexContextWindow(spec.ContextWindow)
 	messages := CcSwitchCodexModelMessages{
 		InstructionsTemplate:          ccSwitchCodexBaseInstructions,
 		InstructionsVariables:         map[string]string{},
@@ -167,8 +184,8 @@ func buildCcSwitchCodexModelCatalogEntry(model string, priority int) CcSwitchCod
 		TruncationPolicy:              CcSwitchCodexTruncationPolicy{Mode: "tokens", Limit: 10000},
 		SupportsParallelToolCalls:     true,
 		SupportsImageDetailOriginal:   true,
-		ContextWindow:                 ccSwitchCodexDefaultContextWindow,
-		MaxContextWindow:              ccSwitchCodexDefaultContextWindow,
+		ContextWindow:                 contextWindow,
+		MaxContextWindow:              contextWindow,
 		EffectiveContextWindowPercent: 95,
 		ExperimentalSupportedTools:    []string{},
 		InputModalities:               []string{"text", "image"},
@@ -202,8 +219,8 @@ func buildCcSwitchCodexModelCatalogEntry(model string, priority int) CcSwitchCod
 		TruncationPolicy:              CcSwitchCodexTruncationPolicy{Mode: "tokens", Limit: 10000},
 		SupportsParallelToolCalls:     true,
 		SupportsImageDetailOriginal:   true,
-		ContextWindow:                 ccSwitchCodexDefaultContextWindow,
-		MaxContextWindow:              ccSwitchCodexDefaultContextWindow,
+		ContextWindow:                 contextWindow,
+		MaxContextWindow:              contextWindow,
 		EffectiveContextWindowPercent: 95,
 		ExperimentalSupportedTools:    []string{},
 		InputModalities:               []string{"text", "image"},

--- a/internal/usage/ccswitch_codex_model_catalog_test.go
+++ b/internal/usage/ccswitch_codex_model_catalog_test.go
@@ -7,7 +7,7 @@ func TestBuildCcSwitchCodexModelCatalogUsesRequestModels(t *testing.T) {
 		ClientType:   "codex",
 		DefaultModel: "gpt-5.5",
 		ModelMappings: []CcSwitchModelMappingRow{
-			{RequestModel: "gpt-5.5", TargetModel: "gpt-5.5"},
+			{RequestModel: "gpt-5.5", TargetModel: "gpt-5.5", ContextWindow: 272000},
 			{RequestModel: "deepseek-v4-flash", TargetModel: "deepseek-chat"},
 			{RequestModel: "DeepSeek-V4-Flash", TargetModel: "deepseek-chat"},
 			{RequestModel: "deepseek-v4-pro", TargetModel: "deepseek-reasoner"},
@@ -31,6 +31,14 @@ func TestBuildCcSwitchCodexModelCatalogUsesRequestModels(t *testing.T) {
 		if got[idx] != want[idx] {
 			t.Fatalf("slug[%d] = %q, want %q; all=%#v", idx, got[idx], want[idx], got)
 		}
+	}
+
+	gpt := catalog.Models[0]
+	if gpt.ContextWindow != 272000 {
+		t.Fatalf("gpt-5.5 context_window = %d, want 272000", gpt.ContextWindow)
+	}
+	if gpt.ModelMessages.ContextWindow != 272000 {
+		t.Fatalf("gpt-5.5 model_messages.context_window = %d, want 272000", gpt.ModelMessages.ContextWindow)
 	}
 
 	deepseek := catalog.Models[1]

--- a/internal/usage/ccswitch_import_configs_db.go
+++ b/internal/usage/ccswitch_import_configs_db.go
@@ -12,9 +12,10 @@ import (
 )
 
 type CcSwitchModelMappingRow struct {
-	Role         string `json:"role,omitempty"`
-	RequestModel string `json:"request-model"`
-	TargetModel  string `json:"target-model"`
+	Role          string `json:"role,omitempty"`
+	RequestModel  string `json:"request-model"`
+	TargetModel   string `json:"target-model"`
+	ContextWindow int    `json:"context-window,omitempty"`
 }
 
 type CcSwitchImportConfigRow struct {
@@ -296,15 +297,23 @@ func normalizeCcSwitchModelMappings(values []CcSwitchModelMappingRow) []CcSwitch
 		}
 		seen[key] = struct{}{}
 		result = append(result, CcSwitchModelMappingRow{
-			Role:         role,
-			RequestModel: requestModel,
-			TargetModel:  targetModel,
+			Role:          role,
+			RequestModel:  requestModel,
+			TargetModel:   targetModel,
+			ContextWindow: normalizeCcSwitchContextWindow(value.ContextWindow),
 		})
 	}
 	if result == nil {
 		return []CcSwitchModelMappingRow{}
 	}
 	return result
+}
+
+func normalizeCcSwitchContextWindow(value int) int {
+	if value <= 0 {
+		return 0
+	}
+	return value
 }
 
 func normalizeCcSwitchModelRole(value string) string {

--- a/internal/usage/ccswitch_import_configs_db_test.go
+++ b/internal/usage/ccswitch_import_configs_db_test.go
@@ -25,7 +25,7 @@ func TestReplaceAllCcSwitchImportConfigsPersistsModelMappings(t *testing.T) {
 			APIKeyField:          "ANTHROPIC_API_KEY",
 			ModelMappings: []CcSwitchModelMappingRow{
 				{Role: "main", RequestModel: "kimi-k2.5", TargetModel: "kimi-k2.5"},
-				{Role: "haiku", RequestModel: "claude-3-5-haiku", TargetModel: "kimi-k2.5"},
+				{Role: "haiku", RequestModel: "claude-3-5-haiku", TargetModel: "kimi-k2.5", ContextWindow: 272000},
 			},
 		},
 	})
@@ -42,7 +42,8 @@ func TestReplaceAllCcSwitchImportConfigsPersistsModelMappings(t *testing.T) {
 	}
 	if rows[0].ModelMappings[1].Role != "haiku" ||
 		rows[0].ModelMappings[1].RequestModel != "claude-3-5-haiku" ||
-		rows[0].ModelMappings[1].TargetModel != "kimi-k2.5" {
+		rows[0].ModelMappings[1].TargetModel != "kimi-k2.5" ||
+		rows[0].ModelMappings[1].ContextWindow != 272000 {
 		t.Fatalf("model mapping not preserved: %#v", rows[0].ModelMappings[1])
 	}
 }


### PR DESCRIPTION
## Summary
- persist context-window on CC Switch model mappings
- generate Codex model catalogs from per-mapping context windows before default fallback dedupe
- cover management/public config and DB persistence paths

## Tests
- go test ./internal/usage ./internal/api/handlers/management