### PR TITLE
fix: restore provider runtime settings from postgres

### DIFF
--- a/internal/storage/sqlite/settings/runtime_store.go
+++ b/internal/storage/sqlite/settings/runtime_store.go
@@ -42,7 +42,7 @@ func (s RuntimeSettingsStore) Payload(key string) (json.RawMessage, bool) {
 		return nil, false
 	}
 	var payload string
-	if err := s.db.QueryRow(`SELECT payload FROM runtime_settings WHERE setting_key = ?`, key).Scan(&payload); err != nil {
+	if err := s.db.QueryRow(`SELECT payload FROM runtime_settings WHERE setting_key = $1`, key).Scan(&payload); err != nil {
 		if err != sql.ErrNoRows {
 			log.Warnf("sqlite/settings: load runtime setting %s: %v", key, err)
 		}
@@ -74,7 +74,7 @@ func (s RuntimeSettingsStore) Upsert(key string, value any) error {
 	}
 	_, err = s.db.Exec(
 		`INSERT INTO runtime_settings (setting_key, payload, updated_at)
-		 VALUES (?, ?, ?)
+		 VALUES ($1, $2, $3)
 		 ON CONFLICT(setting_key) DO UPDATE SET payload = excluded.payload, updated_at = excluded.updated_at`,
 		key,
 		string(payload),

--- a/internal/usage/config_yaml_cleanup.go
+++ b/internal/usage/config_yaml_cleanup.go
@@ -102,6 +102,7 @@ func cleanRuntimeSettingsFromYAML(configFilePath string) {
 		"bedrock-api-key":        true,
 		"opencode-go-api-key":    true,
 		"cline-api-key":          true,
+		"ollama-cloud-api-key":   true,
 		"openai-compatibility":   true,
 		"vertex-api-key":         true,
 		"claude-header-defaults": true,

--- a/internal/usage/postgres_integration_test.go
+++ b/internal/usage/postgres_integration_test.go
@@ -374,6 +374,22 @@ func assertPostgresConfigCRUD(t *testing.T) {
 	if payload, ok := GetRuntimeSettingPayload(RuntimeSettingOAuthModelAlias); !ok || len(payload) == 0 {
 		t.Fatalf("GetRuntimeSettingPayload() payload=%s ok=%v", string(payload), ok)
 	}
+	if err := UpsertRuntimeSetting(RuntimeSettingClineKeys, []config.ClineKey{{
+		APIKey: "sk-cline-pg",
+		Models: []config.ClineModel{{
+			Name:  "cline-pass/qwen3.7-max",
+			Alias: "qwen3.7-max",
+		}},
+	}}); err != nil {
+		t.Fatalf("UpsertRuntimeSetting(ClineKey) error = %v", err)
+	}
+	cfg := &config.Config{}
+	if !ApplyStoredRuntimeSettings(cfg) {
+		t.Fatal("ApplyStoredRuntimeSettings returned false")
+	}
+	if len(cfg.ClineKey) != 1 || cfg.ClineKey[0].Models[0].Alias != "qwen3.7-max" {
+		t.Fatalf("ClineKey after postgres runtime apply = %#v", cfg.ClineKey)
+	}
 
 	imports := []CcSwitchImportConfigRow{{
 		ID:                   "cc-postgres-test",

--- a/internal/usage/runtime_settings_db_test.go
+++ b/internal/usage/runtime_settings_db_test.go
@@ -110,6 +110,23 @@ claude-api-key:
   - api-key: sk-claude-test
     name: claude-primary
     base-url: https://claude.example.com
+opencode-go-api-key:
+  - api-key: sk-opencode-test
+    models:
+      - name: deepseek-v4-flash
+        alias: deepseek-v4-flash
+cline-api-key:
+  - api-key: sk-cline-test
+    name: cline-primary
+    base-url: https://api.cline.bot/api/v1
+    models:
+      - name: cline-pass/qwen3.7-max
+        alias: qwen3.7-max
+ollama-cloud-api-key:
+  - api-key: sk-ollama-test
+    base-url: https://ollama.com
+    models:
+      - name: gpt-oss:120b
 debug: true
 `
 	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
@@ -122,14 +139,26 @@ debug: true
 		ClaudeKey: []config.ClaudeKey{
 			{APIKey: "sk-claude-test", Name: "claude-primary", BaseURL: "https://claude.example.com"},
 		},
+		OpenCodeGoKey: []config.OpenCodeGoKey{
+			{APIKey: "sk-opencode-test", Models: []config.OpenCodeGoModel{{Name: "deepseek-v4-flash", Alias: "deepseek-v4-flash"}}},
+		},
+		ClineKey: []config.ClineKey{
+			{APIKey: "sk-cline-test", Name: "cline-primary", BaseURL: "https://api.cline.bot/api/v1", Models: []config.ClineModel{{Name: "cline-pass/qwen3.7-max", Alias: "qwen3.7-max"}}},
+		},
+		OllamaCloudKey: []config.OllamaCloudKey{
+			{APIKey: "sk-ollama-test", BaseURL: "https://ollama.com", Models: []config.OllamaCloudModel{{Name: "gpt-oss:120b"}}},
+		},
 	}
 
-	if migrated := MigrateRuntimeSettingsFromConfig(cfg, configPath); migrated != 2 {
-		t.Fatalf("MigrateRuntimeSettingsFromConfig = %d, want 2", migrated)
+	if migrated := MigrateRuntimeSettingsFromConfig(cfg, configPath); migrated != 5 {
+		t.Fatalf("MigrateRuntimeSettingsFromConfig = %d, want 5", migrated)
 	}
 
 	cfg.CodexKey = nil
 	cfg.ClaudeKey = nil
+	cfg.OpenCodeGoKey = nil
+	cfg.ClineKey = nil
+	cfg.OllamaCloudKey = nil
 	if !ApplyStoredRuntimeSettings(cfg) {
 		t.Fatal("ApplyStoredRuntimeSettings returned false")
 	}
@@ -139,12 +168,21 @@ debug: true
 	if len(cfg.ClaudeKey) != 1 || cfg.ClaudeKey[0].APIKey != "sk-claude-test" || cfg.ClaudeKey[0].Name != "claude-primary" {
 		t.Fatalf("ClaudeKey after DB apply = %#v", cfg.ClaudeKey)
 	}
+	if len(cfg.OpenCodeGoKey) != 1 || cfg.OpenCodeGoKey[0].APIKey != "sk-opencode-test" || cfg.OpenCodeGoKey[0].Models[0].Name != "deepseek-v4-flash" {
+		t.Fatalf("OpenCodeGoKey after DB apply = %#v", cfg.OpenCodeGoKey)
+	}
+	if len(cfg.ClineKey) != 1 || cfg.ClineKey[0].APIKey != "sk-cline-test" || cfg.ClineKey[0].Models[0].Alias != "qwen3.7-max" {
+		t.Fatalf("ClineKey after DB apply = %#v", cfg.ClineKey)
+	}
+	if len(cfg.OllamaCloudKey) != 1 || cfg.OllamaCloudKey[0].APIKey != "sk-ollama-test" || cfg.OllamaCloudKey[0].Models[0].Name != "gpt-oss:120b" {
+		t.Fatalf("OllamaCloudKey after DB apply = %#v", cfg.OllamaCloudKey)
+	}
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}
-	for _, forbidden := range []string{"codex-api-key:", "claude-api-key:"} {
+	for _, forbidden := range []string{"codex-api-key:", "claude-api-key:", "opencode-go-api-key:", "cline-api-key:", "ollama-cloud-api-key:"} {
 		if strings.Contains(string(data), forbidden) {
 			t.Fatalf("%s should be removed from YAML after migration:\n%s", forbidden, string(data))
 		}


### PR DESCRIPTION
## Summary
- use Postgres-compatible placeholders in runtime_settings storage while preserving SQLite compatibility
- cover OpenCode Go, ClinePass, and Ollama Cloud runtime settings restore from DB
- remove ollama-cloud-api-key from YAML during runtime settings migration

## Tests
- go test ./internal/usage -run 'TestRuntimeSettings|TestPostgresRuntimeDataStackIntegration' -count=1
- go test ./sdk/cliproxy ./internal/openaicompat ./internal/translator/openai/claude ./internal/translator/openai/openai/responses ./internal/runtime/executor ./internal/api -count=1