### PR TITLE
fix: normalize provider model access

### DIFF
--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -227,6 +227,7 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeOpenCodeGoModels(entry.Models)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		entry.ExcludedModels = removeConfiguredOpenCodeGoModelExclusions(entry.ExcludedModels, entry.Models)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
 		entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
@@ -282,6 +283,7 @@ func (cfg *Config) SanitizeClineKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeClineModels(entry.Models)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		entry.ExcludedModels = removeConfiguredClineModelExclusions(entry.ExcludedModels, entry.Models)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
@@ -344,6 +346,7 @@ func (cfg *Config) SanitizeOllamaCloudKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeOllamaCloudModels(entry.Models)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		entry.ExcludedModels = removeConfiguredOllamaCloudModelExclusions(entry.ExcludedModels, entry.Models)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
@@ -368,6 +371,74 @@ func NormalizeOllamaCloudModels(models []OllamaCloudModel) []OllamaCloudModel {
 		}
 		seen[key] = struct{}{}
 		out = append(out, OllamaCloudModel{Name: name, Alias: alias})
+	}
+	return out
+}
+
+func removeConfiguredOpenCodeGoModelExclusions(excluded []string, models []OpenCodeGoModel) []string {
+	names := make([]string, 0, len(models))
+	for _, model := range models {
+		names = append(names, model.Name)
+	}
+	return NormalizeExcludedModelsForConfiguredModels(excluded, names)
+}
+
+func removeConfiguredClineModelExclusions(excluded []string, models []ClineModel) []string {
+	names := make([]string, 0, len(models))
+	for _, model := range models {
+		names = append(names, model.Name)
+	}
+	return NormalizeExcludedModelsForConfiguredModels(excluded, names)
+}
+
+func removeConfiguredOllamaCloudModelExclusions(excluded []string, models []OllamaCloudModel) []string {
+	names := make([]string, 0, len(models))
+	for _, model := range models {
+		names = append(names, model.Name)
+	}
+	return NormalizeExcludedModelsForConfiguredModels(excluded, names)
+}
+
+// NormalizeExcludedModelsForConfiguredModels repairs legacy data where every
+// explicitly configured model is also excluded, leaving the key unusable.
+func NormalizeExcludedModelsForConfiguredModels(excluded []string, modelNames []string) []string {
+	if len(excluded) == 0 || len(modelNames) == 0 {
+		return excluded
+	}
+	configured := make(map[string]struct{}, len(modelNames))
+	for _, name := range modelNames {
+		key := strings.ToLower(strings.TrimSpace(name))
+		if key != "" {
+			configured[key] = struct{}{}
+		}
+	}
+	if len(configured) < 2 {
+		return excluded
+	}
+	excludedSet := make(map[string]struct{}, len(excluded))
+	for _, model := range excluded {
+		key := strings.ToLower(strings.TrimSpace(model))
+		if key == "*" {
+			return excluded
+		}
+		if key != "" {
+			excludedSet[key] = struct{}{}
+		}
+	}
+	for model := range configured {
+		if _, exists := excludedSet[model]; !exists {
+			return excluded
+		}
+	}
+	out := excluded[:0]
+	for _, model := range excluded {
+		if _, exists := configured[strings.ToLower(strings.TrimSpace(model))]; exists {
+			continue
+		}
+		out = append(out, model)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/config/provider_model_access_normalize_test.go
+++ b/internal/config/provider_model_access_normalize_test.go
@@ -1,0 +1,37 @@
+package config
+
+import "testing"
+
+func TestSanitizeProviderModelAccessRemovesConfiguredModelExclusions(t *testing.T) {
+	cfg := &Config{
+		OpenCodeGoKey: []OpenCodeGoKey{{
+			APIKey:         "go-key",
+			Models:         []OpenCodeGoModel{{Name: "qwen3.7-max"}, {Name: "kimi-k2.6"}},
+			ExcludedModels: []string{"qwen3.7-max", "kimi-k2.6"},
+		}},
+		ClineKey: []ClineKey{{
+			APIKey:         "cline-key",
+			Models:         []ClineModel{{Name: "cline-pass/qwen3.7-max"}, {Name: "cline-pass/kimi-k2.6"}},
+			ExcludedModels: []string{"cline-pass/qwen3.7-max", "cline-pass/kimi-k2.6"},
+		}},
+		OllamaCloudKey: []OllamaCloudKey{{
+			APIKey:         "ollama-key",
+			Models:         []OllamaCloudModel{{Name: "gpt-oss:120b"}, {Name: "gpt-oss:20b"}},
+			ExcludedModels: []string{"gpt-oss:120b", "gpt-oss:20b"},
+		}},
+	}
+
+	cfg.SanitizeOpenCodeGoKeys()
+	cfg.SanitizeClineKeys()
+	cfg.SanitizeOllamaCloudKeys()
+
+	if len(cfg.OpenCodeGoKey[0].ExcludedModels) != 0 {
+		t.Fatalf("OpenCode Go excluded models = %#v, want empty", cfg.OpenCodeGoKey[0].ExcludedModels)
+	}
+	if len(cfg.ClineKey[0].ExcludedModels) != 0 {
+		t.Fatalf("ClinePass excluded models = %#v, want empty", cfg.ClineKey[0].ExcludedModels)
+	}
+	if len(cfg.OllamaCloudKey[0].ExcludedModels) != 0 {
+		t.Fatalf("Ollama Cloud excluded models = %#v, want empty", cfg.OllamaCloudKey[0].ExcludedModels)
+	}
+}

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -369,9 +369,10 @@ func withDefaultMappedOwnerRows(
 		if key == "" {
 			continue
 		}
-		if !mappedOwnerRowHasRuntimeSource(modelRegistry, row) {
-			continue
-		}
+		// DB-backed model catalog rows are management-authoritative. A newly
+		// added owner-mapped model may not have a runtime registry source until a
+		// provider advertises it, but the management UI still needs it in default
+		// availability so system/default model lists and route editors can select it.
 		if _, exists := seen[key]; exists {
 			continue
 		}
@@ -379,13 +380,6 @@ func withDefaultMappedOwnerRows(
 		out = append(out, modelConfigRowAsOpenAIModel(row))
 	}
 	return out
-}
-
-func mappedOwnerRowHasRuntimeSource(modelRegistry *registry.ModelRegistry, row usage.ModelConfigRow) bool {
-	if modelRegistry == nil {
-		return false
-	}
-	return len(modelRegistry.GetModelClientSources(row.ModelID)) > 0
 }
 
 func mappedOwnerRowModelKeys(rows []usage.ModelConfigRow, ownerKeys map[string]bool) map[string]bool {

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -171,7 +171,7 @@ func TestDefaultMappedOwnerRowsReplaceProviderModelWhenConfigRowExists(t *testin
 	}
 }
 
-func TestDefaultMappedOwnerRowsSkipConfigRowWithoutRuntimeSource(t *testing.T) {
+func TestDefaultMappedOwnerRowsIncludeConfigRowWithoutRuntimeSource(t *testing.T) {
 	const modelID = "gpt-5.6-sol"
 
 	ownerMappings := map[string]string{"codex": "codex"}
@@ -192,8 +192,8 @@ func TestDefaultMappedOwnerRowsSkipConfigRowWithoutRuntimeSource(t *testing.T) {
 		map[string]*coreauth.Auth{},
 		ownerMappings,
 	)
-	if len(got) != 0 {
-		t.Fatalf("models = %#v, want unserviceable mapped-owner config row hidden", got)
+	if len(got) != 1 || got[0]["id"] != modelID {
+		t.Fatalf("models = %#v, want owner-mapped config row kept without runtime source", got)
 	}
 }
 

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -731,6 +731,10 @@ func NormalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.Models = config.NormalizeOpenCodeGoModels(entry.Models)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.ExcludedModels = config.NormalizeExcludedModelsForConfiguredModels(
+		entry.ExcludedModels,
+		openCodeGoModelNames(entry.Models),
+	)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 	if workspaceID, err := normalizeOpenCodeGoWorkspaceID(entry.WorkspaceID); err == nil {
 		entry.WorkspaceID = workspaceID
@@ -768,6 +772,10 @@ func NormalizeClineKey(entry *config.ClineKey) {
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.Models = config.NormalizeClineModels(entry.Models)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.ExcludedModels = config.NormalizeExcludedModelsForConfiguredModels(
+		entry.ExcludedModels,
+		clineModelNames(entry.Models),
+	)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 }
 
@@ -799,6 +807,10 @@ func NormalizeOllamaCloudKey(entry *config.OllamaCloudKey) {
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.Models = config.NormalizeOllamaCloudModels(entry.Models)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.ExcludedModels = config.NormalizeExcludedModelsForConfiguredModels(
+		entry.ExcludedModels,
+		ollamaCloudModelNames(entry.Models),
+	)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 }
 
@@ -812,6 +824,30 @@ func NormalizedOllamaCloudKeyEntries(entries []config.OllamaCloudKey) []config.O
 		NormalizeOllamaCloudKey(&out[i])
 	}
 	return out
+}
+
+func openCodeGoModelNames(models []config.OpenCodeGoModel) []string {
+	names := make([]string, 0, len(models))
+	for _, model := range models {
+		names = append(names, model.Name)
+	}
+	return names
+}
+
+func clineModelNames(models []config.ClineModel) []string {
+	names := make([]string, 0, len(models))
+	for _, model := range models {
+		names = append(names, model.Name)
+	}
+	return names
+}
+
+func ollamaCloudModelNames(models []config.OllamaCloudModel) []string {
+	names := make([]string, 0, len(models))
+	for _, model := range models {
+		names = append(names, model.Name)
+	}
+	return names
 }
 
 func normalizeOpenCodeGoWorkspaceID(raw string) (string, error) {

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -415,6 +415,38 @@ func TestOpenCodeGoKeysKeepPerKeyModels(t *testing.T) {
 	}
 }
 
+func TestPatchClineKeyRepairsConfiguredModelExclusions(t *testing.T) {
+	cfg := &config.Config{
+		ClineKey: []config.ClineKey{{
+			APIKey: "cline-key",
+			Name:   "old",
+			Models: []config.ClineModel{
+				{Name: "cline-pass/qwen3.7-max"},
+				{Name: "cline-pass/kimi-k2.6"},
+			},
+			ExcludedModels: []string{
+				"cline-pass/qwen3.7-max",
+				"cline-pass/kimi-k2.6",
+			},
+		}},
+	}
+	name := "new"
+
+	err := NewService(cfg, nil).PatchClineKey(nil, nil, &name, ClinePatch{Name: &name})
+	if !errors.Is(err, ErrItemNotFound) {
+		t.Fatalf("PatchClineKey unmatched error = %v, want ErrItemNotFound", err)
+	}
+
+	index := 0
+	err = NewService(cfg, nil).PatchClineKey(&index, nil, nil, ClinePatch{Name: &name})
+	if err != nil {
+		t.Fatalf("PatchClineKey() error = %v, want nil", err)
+	}
+	if len(cfg.ClineKey[0].ExcludedModels) != 0 {
+		t.Fatalf("excluded models = %#v, want repaired empty list", cfg.ClineKey[0].ExcludedModels)
+	}
+}
+
 func TestExtendedProviderReplaceRejectsNonEmptyPayloadWithoutAPIKeys(t *testing.T) {
 	t.Run("opencode go", func(t *testing.T) {
 		cfg := &config.Config{OpenCodeGoKey: []config.OpenCodeGoKey{{APIKey: "existing"}}}


### PR DESCRIPTION
## Summary
- repair multi-model provider configs where every configured model is also excluded
- keep management GET normalization aligned with runtime sanitization
- keep owner-mapped configured availability rows visible for management model selectors

## Tests
- go test ./internal/config ./internal/management/settings/providers ./internal/api ./internal/runtime/executor -count=1
- go test ./internal/management/modelcatalog ./internal/api -count=1