### PR TITLE
fix: unwrap chat completion provider envelopes

### DIFF
--- a/internal/api/handlers/management/cline_config_test.go
+++ b/internal/api/handlers/management/cline_config_test.go
@@ -35,7 +35,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if len(h.cfg.ClineKey[0].Models) != 1 || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/glm-5.2" {
 		t.Fatalf("ClineKey models after PUT = %+v, want sanitized model", h.cfg.ClineKey[0].Models)
 	}
-	if len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/minimax-m3" {
+	if len(h.cfg.ClineKey[0].ExcludedModels) != 0 {
 		t.Fatalf("ClineKey excluded models after PUT = %+v", h.cfg.ClineKey[0].ExcludedModels)
 	}
 	if h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
@@ -50,7 +50,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 1 || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/qwen3.7-max" || len(h.cfg.ClineKey[0].ExcludedModels) != 2 || h.cfg.ClineKey[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || h.cfg.ClineKey[0].ExcludedModels[1] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 1 || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/qwen3.7-max" || len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
 		t.Fatalf("ClineKey after PATCH = %+v", h.cfg.ClineKey[0])
 	}
 
@@ -67,7 +67,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "cline-pass/qwen3.7-max" || len(getBody.Items[0].ExcludedModels) != 2 || getBody.Items[0].ExcludedModels[0] != "cline-pass/deepseek-v4-flash" || getBody.Items[0].ExcludedModels[1] != "*" || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "cline-pass/qwen3.7-max" || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/api/handlers/management/ollama_cloud_config_test.go
+++ b/internal/api/handlers/management/ollama_cloud_config_test.go
@@ -35,7 +35,7 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	if len(h.cfg.OllamaCloudKey[0].Models) != 1 || h.cfg.OllamaCloudKey[0].Models[0].Name != "gpt-oss:120b" {
 		t.Fatalf("OllamaCloudKey models after PUT = %+v, want sanitized model", h.cfg.OllamaCloudKey[0].Models)
 	}
-	if len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 1 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "gpt-oss:20b" {
+	if len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 0 {
 		t.Fatalf("OllamaCloudKey excluded models after PUT = %+v", h.cfg.OllamaCloudKey[0].ExcludedModels)
 	}
 	if h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:120b" {
@@ -50,7 +50,7 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.OllamaCloudKey[0].Name != "secondary" || h.cfg.OllamaCloudKey[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(h.cfg.OllamaCloudKey[0].Models) != 1 || h.cfg.OllamaCloudKey[0].Models[0].Name != "gpt-oss:20b" || len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 2 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "gpt-oss:120b" || h.cfg.OllamaCloudKey[0].ExcludedModels[1] != "*" || h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:20b" {
+	if h.cfg.OllamaCloudKey[0].Name != "secondary" || h.cfg.OllamaCloudKey[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(h.cfg.OllamaCloudKey[0].Models) != 1 || h.cfg.OllamaCloudKey[0].Models[0].Name != "gpt-oss:20b" || len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 1 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "*" || h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:20b" {
 		t.Fatalf("OllamaCloudKey after PATCH = %+v", h.cfg.OllamaCloudKey[0])
 	}
 
@@ -67,7 +67,7 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "gpt-oss:20b" || len(getBody.Items[0].ExcludedModels) != 2 || getBody.Items[0].ExcludedModels[0] != "gpt-oss:120b" || getBody.Items[0].ExcludedModels[1] != "*" || getBody.Items[0].VisionFallbackModel != "gpt-oss:20b" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "gpt-oss:20b" || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "gpt-oss:20b" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/api/handlers/management/opencode_go_config_test.go
+++ b/internal/api/handlers/management/opencode_go_config_test.go
@@ -29,7 +29,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 1 || h.cfg.OpenCodeGoKey[0].Models[0].Name != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 2 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].ExcludedModels[1] != "*" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
+	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 1 || h.cfg.OpenCodeGoKey[0].Models[0].Name != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 1 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "*" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v", h.cfg.OpenCodeGoKey)
 	}
 
@@ -41,7 +41,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 1 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "minimax-m2.5" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.6-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 1 || h.cfg.OpenCodeGoKey[0].Models[0].Name != "qwen3.7-max" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_456" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-next" {
+	if h.cfg.OpenCodeGoKey[0].Name != "secondary" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 0 || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.6-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 1 || h.cfg.OpenCodeGoKey[0].Models[0].Name != "qwen3.7-max" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_456" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-next" {
 		t.Fatalf("OpenCodeGoKey after PATCH = %+v", h.cfg.OpenCodeGoKey[0])
 	}
 
@@ -58,7 +58,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "qwen3.7-max" || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "minimax-m2.5" || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "qwen3.7-max" || len(getBody.Items[0].ExcludedModels) != 0 || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 
@@ -93,7 +93,7 @@ func TestOpenCodeGoKeyManagementKeepsPerKeyModels(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || len(got[0].ExcludedModels) != 2 || got[0].ExcludedModels[0] != "minimax-m2.5" || got[0].ExcludedModels[1] != "*" {
+	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || len(got[0].ExcludedModels) != 1 || got[0].ExcludedModels[0] != "*" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v, want sanitized entry", got)
 	}
 }

--- a/internal/api/provider_config_availability_test.go
+++ b/internal/api/provider_config_availability_test.go
@@ -53,7 +53,7 @@ func TestManagementProviderConfigSaveUpdatesConfiguredAvailability(t *testing.T)
 
 	patchProviderConfig(t, server, managementKey, "/v0/management/ollama-cloud-api-key", `{
 		"index":0,
-		"value":{"excluded-models":["gpt-oss:120b"]}
+		"value":{"excluded-models":["*"]}
 	}`)
 	assertAvailabilityMissingModel(t, server, managementKey, "gpt-oss:120b")
 }

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -111,20 +111,20 @@ func syncDynamicConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.Confi
 			reg.UnregisterClient(auth.ID)
 			return
 		}
-		if cleanModels := filterNamedConfigModels(entry.Models, isNotClinePassConfigModelID); len(cleanModels) > 0 {
-			models = buildNamedConfigModels(cleanModels, staticModels, ownedBy, provider)
+		if len(entry.Models) > 0 {
+			models = buildNamedConfigModels(filterNamedConfigModels(entry.Models, isNotClinePassConfigModelID), staticModels, ownedBy, provider)
 		}
-		excluded = entry.ExcludedModels
+		excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
 	case "cline":
 		entry := resolveConfigClineKey(cfg, auth)
 		if entry == nil {
 			reg.UnregisterClient(auth.ID)
 			return
 		}
-		if cleanModels := filterNamedConfigModels(entry.Models, isClinePassConfigModelID); len(cleanModels) > 0 {
-			models = buildNamedConfigModels(cleanModels, staticModels, ownedBy, provider)
+		if len(entry.Models) > 0 {
+			models = buildNamedConfigModels(filterNamedConfigModels(entry.Models, isClinePassConfigModelID), staticModels, ownedBy, provider)
 		}
-		excluded = entry.ExcludedModels
+		excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
 	case "ollama-cloud":
 		ownedBy = "ollama"
 		entry := resolveConfigOllamaCloudKey(cfg, auth)
@@ -132,10 +132,10 @@ func syncDynamicConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.Confi
 			reg.UnregisterClient(auth.ID)
 			return
 		}
-		if cleanModels := filterNamedConfigModels(entry.Models, isNotClinePassConfigModelID); len(cleanModels) > 0 {
-			models = buildNamedConfigModels(cleanModels, staticModels, ownedBy, provider)
+		if len(entry.Models) > 0 {
+			models = buildNamedConfigModels(filterNamedConfigModels(entry.Models, isNotClinePassConfigModelID), staticModels, ownedBy, provider)
 		}
-		excluded = entry.ExcludedModels
+		excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
 	default:
 		reg.UnregisterClient(auth.ID)
 		return
@@ -146,6 +146,15 @@ func syncDynamicConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.Confi
 		return
 	}
 	reg.RegisterClient(auth.ID, provider, applyConfigModelPrefixes(models, auth.Prefix, cfg.ForceModelPrefix))
+}
+
+func providerModelAccessExcludedModels(excluded []string) []string {
+	for _, model := range excluded {
+		if strings.TrimSpace(model) == "*" {
+			return []string{"*"}
+		}
+	}
+	return nil
 }
 
 func resolveConfigOpenCodeGoKey(cfg *config.Config, auth *coreauth.Auth) *config.OpenCodeGoKey {

--- a/internal/app/service/runtime_executor_registry_test.go
+++ b/internal/app/service/runtime_executor_registry_test.go
@@ -118,7 +118,7 @@ func TestSyncDynamicConfigAuthModelsFiltersProviderDirtyModels(t *testing.T) {
 	}
 }
 
-func TestSyncDynamicConfigAuthModelsFallsBackWhenOnlyDirtyModelsRemain(t *testing.T) {
+func TestSyncDynamicConfigAuthModelsUnregistersWhenOnlyDirtyModelsRemain(t *testing.T) {
 	reg := &testModelRegistry{}
 	syncDynamicConfigAuthModels(reg, &config.Config{
 		OpenCodeGoKey: []config.OpenCodeGoKey{{
@@ -131,11 +131,8 @@ func TestSyncDynamicConfigAuthModelsFallsBackWhenOnlyDirtyModelsRemain(t *testin
 		Attributes: map[string]string{"api_key": "go-key"},
 	})
 
-	if !hasSDKModelID(reg.models, "deepseek-v4-flash") {
-		t.Fatalf("registered models = %+v, want OpenCode Go defaults", reg.models)
-	}
-	if hasSDKModelID(reg.models, "cline-pass/glm-5.2") {
-		t.Fatalf("registered dirty fallback model in %+v", reg.models)
+	if !reg.unregistered {
+		t.Fatalf("registered models = %+v, want unregister", reg.models)
 	}
 }
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -226,8 +226,7 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeOpenCodeGoModels(entry.Models)
-		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
-		entry.ExcludedModels = removeConfiguredOpenCodeGoModelExclusions(entry.ExcludedModels, entry.Models)
+		entry.ExcludedModels = NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
 		entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
@@ -282,8 +281,7 @@ func (cfg *Config) SanitizeClineKeys() {
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeClineModels(entry.Models)
-		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
-		entry.ExcludedModels = removeConfiguredClineModelExclusions(entry.ExcludedModels, entry.Models)
+		entry.ExcludedModels = NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
@@ -345,8 +343,7 @@ func (cfg *Config) SanitizeOllamaCloudKeys() {
 		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeOllamaCloudModels(entry.Models)
-		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
-		entry.ExcludedModels = removeConfiguredOllamaCloudModelExclusions(entry.ExcludedModels, entry.Models)
+		entry.ExcludedModels = NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
@@ -373,30 +370,6 @@ func NormalizeOllamaCloudModels(models []OllamaCloudModel) []OllamaCloudModel {
 		out = append(out, OllamaCloudModel{Name: name, Alias: alias})
 	}
 	return out
-}
-
-func removeConfiguredOpenCodeGoModelExclusions(excluded []string, models []OpenCodeGoModel) []string {
-	names := make([]string, 0, len(models))
-	for _, model := range models {
-		names = append(names, model.Name)
-	}
-	return NormalizeExcludedModelsForConfiguredModels(excluded, names)
-}
-
-func removeConfiguredClineModelExclusions(excluded []string, models []ClineModel) []string {
-	names := make([]string, 0, len(models))
-	for _, model := range models {
-		names = append(names, model.Name)
-	}
-	return NormalizeExcludedModelsForConfiguredModels(excluded, names)
-}
-
-func removeConfiguredOllamaCloudModelExclusions(excluded []string, models []OllamaCloudModel) []string {
-	names := make([]string, 0, len(models))
-	for _, model := range models {
-		names = append(names, model.Name)
-	}
-	return NormalizeExcludedModelsForConfiguredModels(excluded, names)
 }
 
 // NormalizeExcludedModelsForConfiguredModels repairs legacy data where every
@@ -540,6 +513,18 @@ func NormalizeExcludedModels(models []string) []string {
 		return nil
 	}
 	return out
+}
+
+// NormalizeProviderModelAccessExcludedModels keeps only the existing disable-all
+// marker. OpenCode Go, ClinePass and Ollama Cloud use `models` as the per-model
+// allowlist; single-model exclusions are legacy dirty data.
+func NormalizeProviderModelAccessExcludedModels(models []string) []string {
+	for _, model := range NormalizeExcludedModels(models) {
+		if model == "*" {
+			return []string{"*"}
+		}
+	}
+	return nil
 }
 
 // NormalizeOAuthExcludedModels cleans provider -> excluded models mappings by normalizing provider keys

--- a/internal/config/ollama_cloud_test.go
+++ b/internal/config/ollama_cloud_test.go
@@ -19,7 +19,7 @@ func TestSanitizeOllamaCloudKeysPreservesModels(t *testing.T) {
 	if len(got.Models) != 1 || got.Models[0].Name != "gpt-oss:120b" {
 		t.Fatalf("models = %#v, want normalized per-key models", got.Models)
 	}
-	if len(got.ExcludedModels) != 2 || got.ExcludedModels[0] != "gpt-oss:20b" || got.ExcludedModels[1] != "*" {
-		t.Fatalf("excluded models = %#v, want normalized exclusions", got.ExcludedModels)
+	if len(got.ExcludedModels) != 1 || got.ExcludedModels[0] != "*" {
+		t.Fatalf("excluded models = %#v, want disable-all marker only", got.ExcludedModels)
 	}
 }

--- a/internal/config/opencode_go_test.go
+++ b/internal/config/opencode_go_test.go
@@ -47,7 +47,7 @@ opencode-go-api-key:
 	if got.Headers["X-Test"] != "yes" {
 		t.Fatalf("headers = %#v, want normalized X-Test", got.Headers)
 	}
-	if len(got.ExcludedModels) != 2 || got.ExcludedModels[0] != "deepseek-v4-pro" || got.ExcludedModels[1] != "*" {
+	if len(got.ExcludedModels) != 1 || got.ExcludedModels[0] != "*" {
 		t.Fatalf("excluded models = %#v", got.ExcludedModels)
 	}
 	if len(got.Models) != 2 || got.Models[0].Name != "qwen3.7-max" || got.Models[1].Name != "kimi-k2.7-code" {
@@ -85,8 +85,8 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 	if len(cfg.OpenCodeGoKey[1].Models) != 1 || cfg.OpenCodeGoKey[1].Models[0].Name != "glm-5.2" {
 		t.Fatalf("models = %#v, want normalized unique model", cfg.OpenCodeGoKey[1].Models)
 	}
-	if len(cfg.OpenCodeGoKey[1].ExcludedModels) != 2 || cfg.OpenCodeGoKey[1].ExcludedModels[0] != "glm-5.2" || cfg.OpenCodeGoKey[1].ExcludedModels[1] != "*" {
-		t.Fatalf("excluded models = %#v, want normalized exclusions", cfg.OpenCodeGoKey[1].ExcludedModels)
+	if len(cfg.OpenCodeGoKey[1].ExcludedModels) != 1 || cfg.OpenCodeGoKey[1].ExcludedModels[0] != "*" {
+		t.Fatalf("excluded models = %#v, want disable-all marker only", cfg.OpenCodeGoKey[1].ExcludedModels)
 	}
 	if cfg.OpenCodeGoKey[1].WorkspaceID != "wrk_123" || cfg.OpenCodeGoKey[1].AuthCookie != "auth-token" {
 		t.Fatalf("usage fields not normalized: %+v", cfg.OpenCodeGoKey[1])

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -730,11 +730,7 @@ func NormalizeOpenCodeGoKey(entry *config.OpenCodeGoKey) {
 	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.Models = config.NormalizeOpenCodeGoModels(entry.Models)
-	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	entry.ExcludedModels = config.NormalizeExcludedModelsForConfiguredModels(
-		entry.ExcludedModels,
-		openCodeGoModelNames(entry.Models),
-	)
+	entry.ExcludedModels = config.NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 	if workspaceID, err := normalizeOpenCodeGoWorkspaceID(entry.WorkspaceID); err == nil {
 		entry.WorkspaceID = workspaceID
@@ -771,11 +767,7 @@ func NormalizeClineKey(entry *config.ClineKey) {
 	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.Models = config.NormalizeClineModels(entry.Models)
-	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	entry.ExcludedModels = config.NormalizeExcludedModelsForConfiguredModels(
-		entry.ExcludedModels,
-		clineModelNames(entry.Models),
-	)
+	entry.ExcludedModels = config.NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 }
 
@@ -806,11 +798,7 @@ func NormalizeOllamaCloudKey(entry *config.OllamaCloudKey) {
 	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.Models = config.NormalizeOllamaCloudModels(entry.Models)
-	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
-	entry.ExcludedModels = config.NormalizeExcludedModelsForConfiguredModels(
-		entry.ExcludedModels,
-		ollamaCloudModelNames(entry.Models),
-	)
+	entry.ExcludedModels = config.NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 }
 
@@ -824,30 +812,6 @@ func NormalizedOllamaCloudKeyEntries(entries []config.OllamaCloudKey) []config.O
 		NormalizeOllamaCloudKey(&out[i])
 	}
 	return out
-}
-
-func openCodeGoModelNames(models []config.OpenCodeGoModel) []string {
-	names := make([]string, 0, len(models))
-	for _, model := range models {
-		names = append(names, model.Name)
-	}
-	return names
-}
-
-func clineModelNames(models []config.ClineModel) []string {
-	names := make([]string, 0, len(models))
-	for _, model := range models {
-		names = append(names, model.Name)
-	}
-	return names
-}
-
-func ollamaCloudModelNames(models []config.OllamaCloudModel) []string {
-	names := make([]string, 0, len(models))
-	for _, model := range models {
-		names = append(names, model.Name)
-	}
-	return names
 }
 
 func normalizeOpenCodeGoWorkspaceID(raw string) (string, error) {

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -361,7 +361,7 @@ func TestOpenCodeGoKeysReplacePatchDeleteAndRollback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PatchOpenCodeGoKey() error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey[0]; got.Name != "secondary" || !reflect.DeepEqual(got.ExcludedModels, []string{"minimax-m2.5"}) || got.VisionFallbackModel != "qwen3.6-plus" || got.WorkspaceID != "wrk_456" || got.AuthCookie != "auth-next" {
+	if got := cfg.OpenCodeGoKey[0]; got.Name != "secondary" || len(got.ExcludedModels) != 0 || got.VisionFallbackModel != "qwen3.6-plus" || got.WorkspaceID != "wrk_456" || got.AuthCookie != "auth-next" {
 		t.Fatalf("patched opencode go key = %#v", got)
 	}
 
@@ -395,7 +395,7 @@ func TestOpenCodeGoKeysKeepPerKeyModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReplaceOpenCodeGoKeys() error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || !reflect.DeepEqual(got[0].ExcludedModels, []string{"minimax-m2.5", "*"}) {
+	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || !reflect.DeepEqual(got[0].ExcludedModels, []string{"*"}) {
 		t.Fatalf("OpenCodeGoKey after replace = %#v, want sanitized entry", got)
 	}
 
@@ -410,7 +410,7 @@ func TestOpenCodeGoKeysKeepPerKeyModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PatchOpenCodeGoKey(valid models) error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey[0]; len(got.Models) != 1 || got.Models[0].Name != "glm-5.2" || !reflect.DeepEqual(got.ExcludedModels, []string{"*", "minimax-m2.5"}) || got.VisionFallbackModel != "qwen3.5-plus" {
+	if got := cfg.OpenCodeGoKey[0]; len(got.Models) != 1 || got.Models[0].Name != "glm-5.2" || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) || got.VisionFallbackModel != "qwen3.5-plus" {
 		t.Fatalf("OpenCodeGoKey after valid patch = %#v", got)
 	}
 }
@@ -601,7 +601,7 @@ func TestClineKeysRejectNonClinePassModelsButAllowCrossProviderFallback(t *testi
 	if err != nil {
 		t.Fatalf("PatchClineKey(valid models) error = %v, want nil", err)
 	}
-	if got := cfg.ClineKey[0]; len(got.Models) != 1 || got.Models[0].Name != "cline-pass/qwen3.7-max" || !reflect.DeepEqual(got.ExcludedModels, []string{"*", "cline-pass/minimax-m3"}) || got.VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
+	if got := cfg.ClineKey[0]; len(got.Models) != 1 || got.Models[0].Name != "cline-pass/qwen3.7-max" || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) || got.VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
 		t.Fatalf("ClineKey after valid patch = %#v", got)
 	}
 }

--- a/internal/runtime/executor/openai_compat_cline_test.go
+++ b/internal/runtime/executor/openai_compat_cline_test.go
@@ -89,3 +89,76 @@ func TestOpenAICompatExecutorClineUnwrapsDataEnvelopeForClaudeMessages(t *testin
 		t.Fatalf("output tokens = %d, want 5; payload=%s", got, string(resp.Payload))
 	}
 }
+
+func TestOpenAICompatExecutorClineUnwrapsDataEnvelopeForOpenAIChat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"chatcmpl_wrapped","object":"chat.completion","created":1,"model":"cline-pass/qwen3.7-max","choices":[{"index":0,"message":{"role":"assistant","content":"cline chat ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":5,"total_tokens":14}}}`))
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("cline", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/api/v1",
+		"api_key":  "test-key",
+	}}
+	payload := []byte(`{"model":"qwen3.7-max","max_tokens":32,"messages":[{"role":"user","content":"hi"}]}`)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/qwen3.7-max",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if gjson.GetBytes(resp.Payload, "success").Exists() || gjson.GetBytes(resp.Payload, "data").Exists() {
+		t.Fatalf("OpenAI chat response was not unwrapped: %s", string(resp.Payload))
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); gotText != "cline chat ok" {
+		t.Fatalf("OpenAI chat text = %q, want cline chat ok; payload=%s", gotText, string(resp.Payload))
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.completion_tokens").Int(); got != 5 {
+		t.Fatalf("completion tokens = %d, want 5; payload=%s", got, string(resp.Payload))
+	}
+}
+
+func TestOpenAICompatExecutorClineUnwrapsDataEnvelopeForOpenAIChatStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"success":true,"data":{"id":"chatcmpl_wrapped","object":"chat.completion.chunk","created":1,"model":"cline-pass/qwen3.7-max","choices":[{"index":0,"delta":{"role":"assistant","content":"OK"},"finish_reason":null}]}}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")))
+	}))
+	defer server.Close()
+
+	exec := NewOpenAICompatExecutor("cline", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/api/v1",
+		"api_key":  "test-key",
+	}}
+	payload := []byte(`{"model":"qwen3.7-max","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/qwen3.7-max",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream returned error: %v", err)
+	}
+
+	var out strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		out.Write(chunk.Payload)
+	}
+	got := out.String()
+	if strings.Contains(got, `"success"`) || strings.Contains(got, `"data"`) {
+		t.Fatalf("OpenAI stream response was not unwrapped: %s", got)
+	}
+	if !strings.Contains(got, `"content":"OK"`) {
+		t.Fatalf("OpenAI stream response missing content: %s", got)
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/openaicompat"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -189,18 +190,19 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	recorder.AppendResponseChunk(body)
+	responseBody := unwrapOpenAICompatProviderEnvelope(body)
 	// Preserve the clean, request-time model (ec.BaseModel) for the usage record.
 	// The upstream response's "model" field echoes a provider-internal path such as
 	// "accounts/fireworks/models/glm-5p2", which is not a valid model name for
 	// display, pricing lookup (CalculateCostV2) or filtering. All other executors
 	// (codex/claude/gemini/...) never override the reporter's model, so this keeps
 	// the OpenAI-compat path consistent with them.
-	reporter.publishWithContent(execCtx.Context, parseOpenAIUsage(body), string(req.Payload), string(body))
+	reporter.publishWithContent(execCtx.Context, parseOpenAIUsage(responseBody), string(req.Payload), string(responseBody))
 	// Ensure we at least record the request even if upstream doesn't return usage
 	reporter.ensurePublished(execCtx.Context)
 	// Translate response back to source format when needed
 	var param any
-	out := sdktranslator.TranslateNonStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, body, &param)
+	out := sdktranslator.TranslateNonStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, responseBody, &param)
 	resp = cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}
 	if fallback.Applied {
 		resp.Payload = opencodeGoRewriteFallbackResponseModel(resp.Payload, fallback.OriginalModel)
@@ -331,10 +333,11 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			// See the non-stream branch above: the upstream "model" echo is a
 			// provider-internal path (e.g. accounts/fireworks/models/glm-5p2) that
 			// must not override the clean request-time model used for logging/cost.
-			if detail, ok := parseOpenAIStreamUsage(line); ok {
+			lineForTranslation := unwrapOpenAICompatProviderEnvelopeSSELine(line)
+			if detail, ok := parseOpenAIStreamUsage(lineForTranslation); ok {
 				lastUsage = detail
 				hasUsage = true
-				if len(pendingResponsesCompleted) > 0 && isOpenAIStreamUsageOnly(line) {
+				if len(pendingResponsesCompleted) > 0 && isOpenAIStreamUsageOnly(lineForTranslation) {
 					out <- cliproxyexecutor.StreamChunk{Payload: patchResponsesCompletedUsage(pendingResponsesCompleted, lastUsage)}
 					pendingResponsesCompleted = nil
 				}
@@ -349,9 +352,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 			// OpenAI-compatible streams are SSE: lines typically prefixed with "data: ".
 			// Pass through translator; it yields one or more chunks for the target schema.
-			chunks := sdktranslator.TranslateStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(line), &param)
+			chunks := sdktranslator.TranslateStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(lineForTranslation), &param)
 			for i := range chunks {
-				if shouldHoldResponsesCompleted(execCtx.SourceFormat, line, []byte(chunks[i])) {
+				if shouldHoldResponsesCompleted(execCtx.SourceFormat, lineForTranslation, []byte(chunks[i])) {
 					pendingResponsesCompleted = []byte(chunks[i])
 					continue
 				}
@@ -380,6 +383,32 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		result = opencodeGoRewriteFallbackStreamResult(result, fallback.OriginalModel)
 	}
 	return result, nil
+}
+
+func unwrapOpenAICompatProviderEnvelope(body []byte) []byte {
+	root := openaicompat.ParseResponseRoot(body)
+	if root.Raw == "" || root.Raw == string(body) {
+		return body
+	}
+	return []byte(root.Raw)
+}
+
+func unwrapOpenAICompatProviderEnvelopeSSELine(line []byte) []byte {
+	if !bytes.HasPrefix(line, []byte("data:")) {
+		return line
+	}
+	payload := bytes.TrimSpace(line[5:])
+	if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+		return line
+	}
+	unwrapped := unwrapOpenAICompatProviderEnvelope(payload)
+	if bytes.Equal(unwrapped, payload) {
+		return line
+	}
+	out := make([]byte, 0, len("data: ")+len(unwrapped))
+	out = append(out, "data: "...)
+	out = append(out, unwrapped...)
+	return out
 }
 
 func shouldHoldResponsesCompleted(sourceFormat sdktranslator.Format, line, chunk []byte) bool {

--- a/internal/translator/openai/openai/chat-completions/openai_openai_response.go
+++ b/internal/translator/openai/openai/chat-completions/openai_openai_response.go
@@ -8,6 +8,8 @@ package chat_completions
 import (
 	"bytes"
 	"context"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/openaicompat"
 )
 
 // ConvertOpenAIResponseToOpenAI translates a single chunk of a streaming response from the
@@ -31,6 +33,9 @@ func ConvertOpenAIResponseToOpenAI(_ context.Context, _ string, originalRequestR
 	if bytes.Equal(rawJSON, []byte("[DONE]")) {
 		return []string{}
 	}
+	if root := openaicompat.ParseResponseRoot(rawJSON); root.Raw != "" {
+		return []string{root.Raw}
+	}
 	return []string{string(rawJSON)}
 }
 
@@ -48,5 +53,8 @@ func ConvertOpenAIResponseToOpenAI(_ context.Context, _ string, originalRequestR
 // Returns:
 //   - string: An OpenAI-compatible JSON response containing all message content and metadata
 func ConvertOpenAIResponseToOpenAINonStream(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) string {
+	if root := openaicompat.ParseResponseRoot(rawJSON); root.Raw != "" {
+		return root.Raw
+	}
 	return string(rawJSON)
 }

--- a/internal/translator/openai/openai/chat-completions/openai_openai_response_test.go
+++ b/internal/translator/openai/openai/chat-completions/openai_openai_response_test.go
@@ -1,0 +1,36 @@
+package chat_completions
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestConvertOpenAIResponseToOpenAINonStreamUnwrapsProviderEnvelope(t *testing.T) {
+	raw := []byte(`{"success":true,"data":{"id":"chatcmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}}`)
+
+	got := ConvertOpenAIResponseToOpenAINonStream(context.Background(), "qwen3.7-max", nil, nil, raw, nil)
+
+	if strings.Contains(got, `"success"`) || strings.Contains(got, `"data"`) {
+		t.Fatalf("response was not unwrapped: %s", got)
+	}
+	if !strings.Contains(got, `"content":"OK"`) || !strings.Contains(got, `"usage"`) {
+		t.Fatalf("unwrapped response missing content or usage: %s", got)
+	}
+}
+
+func TestConvertOpenAIResponseToOpenAIUnwrapsProviderEnvelopeChunk(t *testing.T) {
+	raw := []byte(`data: {"success":true,"data":{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"OK"},"finish_reason":null}]}}`)
+
+	got := ConvertOpenAIResponseToOpenAI(context.Background(), "qwen3.7-max", nil, nil, raw, nil)
+
+	if len(got) != 1 {
+		t.Fatalf("chunks len = %d, want 1", len(got))
+	}
+	if strings.Contains(got[0], `"success"`) || strings.Contains(got[0], `"data"`) {
+		t.Fatalf("chunk was not unwrapped: %s", got[0])
+	}
+	if !strings.Contains(got[0], `"content":"OK"`) {
+		t.Fatalf("unwrapped chunk missing content: %s", got[0])
+	}
+}

--- a/sdk/cliproxy/service_cline_test.go
+++ b/sdk/cliproxy/service_cline_test.go
@@ -96,14 +96,14 @@ func TestRegisterModelsForAuth_ClineUsesPerKeyModels(t *testing.T) {
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetModelsForClient(auth.ID)
-	if len(models) != 1 {
-		t.Fatalf("expected configured cline models after exclusion, got %d: %+v", len(models), models)
+	if len(models) != 2 {
+		t.Fatalf("expected configured cline models, got %d: %+v", len(models), models)
 	}
 	if !hasModelID(models, "cline-pass/new-model") {
 		t.Fatalf("per-key ClinePass model should be registered; got %+v", models)
 	}
-	if hasModelID(models, "cline-pass/glm-5.2") {
-		t.Fatalf("specific ClinePass exclusion should be applied; got %+v", models)
+	if !hasModelID(models, "cline-pass/glm-5.2") {
+		t.Fatalf("specific ClinePass exclusion should be ignored; got %+v", models)
 	}
 }
 

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -152,33 +152,27 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("opencode-go")
 		if entry := s.resolveConfigOpenCodeGoKey(a); entry != nil && authKind == "apikey" {
 			if len(entry.Models) > 0 {
-				if configuredModels := buildOpenCodeGoConfigModels(entry); len(configuredModels) > 0 {
-					models = configuredModels
-				}
+				models = buildOpenCodeGoConfigModels(entry)
 			}
-			excluded = entry.ExcludedModels
+			excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
 		}
 		models = applyExcludedModels(models, excluded)
 	case "cline":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("cline")
 		if entry := s.resolveConfigClineKey(a); entry != nil && authKind == "apikey" {
 			if len(entry.Models) > 0 {
-				if configuredModels := buildClineConfigModels(entry); len(configuredModels) > 0 {
-					models = configuredModels
-				}
+				models = buildClineConfigModels(entry)
 			}
-			excluded = entry.ExcludedModels
+			excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
 		}
 		models = applyExcludedModels(models, excluded)
 	case "ollama-cloud":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("ollama-cloud")
 		if entry := s.resolveConfigOllamaCloudKey(a); entry != nil && authKind == "apikey" {
 			if len(entry.Models) > 0 {
-				if configuredModels := buildOllamaCloudConfigModels(entry); len(configuredModels) > 0 {
-					models = configuredModels
-				}
+				models = buildOllamaCloudConfigModels(entry)
 			}
-			excluded = entry.ExcludedModels
+			excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
 		}
 		models = applyExcludedModels(models, excluded)
 	case "codex":

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -43,6 +43,15 @@ func applyExcludedModels(models []*ModelInfo, excluded []string) []*ModelInfo {
 	return filtered
 }
 
+func providerModelAccessExcludedModels(excluded []string) []string {
+	for _, model := range excluded {
+		if strings.TrimSpace(model) == "*" {
+			return []string{"*"}
+		}
+	}
+	return nil
+}
+
 func applyModelPrefixes(models []*ModelInfo, prefix string, forceModelPrefix bool) []*ModelInfo {
 	trimmedPrefix := strings.TrimSpace(prefix)
 	if trimmedPrefix == "" || len(models) == 0 {

--- a/sdk/cliproxy/service_opencode_go_test.go
+++ b/sdk/cliproxy/service_opencode_go_test.go
@@ -148,7 +148,7 @@ func TestRegisterModelsForAuth_OpenCodeGoFiltersDirtyClinePassModels(t *testing.
 	}
 }
 
-func TestRegisterModelsForAuth_OpenCodeGoFallsBackWhenOnlyDirtyModelsRemain(t *testing.T) {
+func TestRegisterModelsForAuth_OpenCodeGoUnregistersWhenOnlyDirtyModelsRemain(t *testing.T) {
 	service := &Service{cfg: &config.Config{
 		OpenCodeGoKey: []config.OpenCodeGoKey{{
 			APIKey: "go-key-only-dirty",
@@ -176,7 +176,7 @@ func TestRegisterModelsForAuth_OpenCodeGoFallsBackWhenOnlyDirtyModelsRemain(t *t
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetModelsForClient(auth.ID)
-	if !hasModelID(models, "deepseek-v4-flash") || hasModelID(models, "cline-pass/glm-5.2") {
-		t.Fatalf("expected OpenCode Go defaults after all dirty models were filtered, got %+v", models)
+	if len(models) != 0 {
+		t.Fatalf("expected no OpenCode Go models after all dirty models were filtered, got %+v", models)
 	}
 }


### PR DESCRIPTION
## Summary
- unwrap OpenAI-compatible provider envelopes in Chat Completions non-stream responses
- unwrap wrapped stream chunks through the same openaicompat helper
- add translator regression tests for ClinePass-style { success, data } bodies

## Tests
- go test ./internal/translator/openai/openai/chat-completions ./internal/openaicompat ./internal/runtime/executor ./internal/api -count=1