### PR TITLE
fix: separate model access disabled state

### DIFF
--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -230,6 +230,9 @@ type OpenCodeGoKey struct {
 	// Name is a human-readable label for this channel.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
+	// Disabled prevents this credential from serving requests without changing its model allowlist.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -280,6 +283,9 @@ type ClineKey struct {
 	// Name is a human-readable label for this channel.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
+	// Disabled prevents this credential from serving requests without changing its model allowlist.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
@@ -324,6 +330,9 @@ type OllamaCloudKey struct {
 
 	// Name is a human-readable label for this channel.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
+	// Disabled prevents this credential from serving requests without changing its model allowlist.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -181,6 +181,7 @@ func (s *Service) deleteBedrockKeys(match func(config.BedrockKey) bool) bool {
 type OpenCodeGoPatch struct {
 	APIKey         *string                   `json:"api-key"`
 	Name           *string                   `json:"name"`
+	Disabled       *bool                     `json:"disabled"`
 	Priority       *int                      `json:"priority"`
 	Prefix         *string                   `json:"prefix"`
 	ProxyURL       *string                   `json:"proxy-url"`
@@ -263,6 +264,9 @@ func (s *Service) PatchOpenCodeGoKey(index *int, apiKey *string, name *string, p
 	}
 	if patch.Name != nil {
 		entry.Name = strings.TrimSpace(*patch.Name)
+	}
+	if patch.Disabled != nil {
+		entry.Disabled = *patch.Disabled
 	}
 	if patch.Priority != nil {
 		entry.Priority = *patch.Priority
@@ -353,6 +357,7 @@ func (s *Service) deleteOpenCodeGoKeyByIndex(index int) {
 type ClinePatch struct {
 	APIKey         *string              `json:"api-key"`
 	Name           *string              `json:"name"`
+	Disabled       *bool                `json:"disabled"`
 	Priority       *int                 `json:"priority"`
 	Prefix         *string              `json:"prefix"`
 	BaseURL        *string              `json:"base-url"`
@@ -434,6 +439,9 @@ func (s *Service) PatchClineKey(index *int, apiKey *string, name *string, patch 
 	}
 	if patch.Name != nil {
 		entry.Name = strings.TrimSpace(*patch.Name)
+	}
+	if patch.Disabled != nil {
+		entry.Disabled = *patch.Disabled
 	}
 	if patch.Priority != nil {
 		entry.Priority = *patch.Priority
@@ -521,6 +529,7 @@ func (s *Service) deleteClineKeyByIndex(index int) {
 type OllamaCloudPatch struct {
 	APIKey         *string                    `json:"api-key"`
 	Name           *string                    `json:"name"`
+	Disabled       *bool                      `json:"disabled"`
 	Priority       *int                       `json:"priority"`
 	Prefix         *string                    `json:"prefix"`
 	BaseURL        *string                    `json:"base-url"`
@@ -602,6 +611,9 @@ func (s *Service) PatchOllamaCloudKey(index *int, apiKey *string, name *string, 
 	}
 	if patch.Name != nil {
 		entry.Name = strings.TrimSpace(*patch.Name)
+	}
+	if patch.Disabled != nil {
+		entry.Disabled = *patch.Disabled
 	}
 	if patch.Priority != nil {
 		entry.Priority = *patch.Priority

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -606,6 +606,51 @@ func TestClineKeysRejectNonClinePassModelsButAllowCrossProviderFallback(t *testi
 	}
 }
 
+func TestModelAccessProviderPatchDisabledAndClearExcludedModels(t *testing.T) {
+	cfg := &config.Config{
+		OpenCodeGoKey: []config.OpenCodeGoKey{{
+			APIKey:         "sk-opencode",
+			ExcludedModels: []string{"*"},
+			Models:         []config.OpenCodeGoModel{{Name: "qwen3.5-plus"}},
+		}},
+		ClineKey: []config.ClineKey{{
+			APIKey:         "sk-cline",
+			ExcludedModels: []string{"*"},
+			Models:         []config.ClineModel{{Name: "cline-pass/glm-5.2"}},
+		}},
+		OllamaCloudKey: []config.OllamaCloudKey{{
+			APIKey:         "sk-ollama",
+			ExcludedModels: []string{"*"},
+			Models:         []config.OllamaCloudModel{{Name: "gpt-oss:120b"}},
+		}},
+	}
+	svc := NewService(cfg, nil)
+	index := 0
+	disabled := true
+	clearExcluded := []string{}
+
+	if err := svc.PatchOpenCodeGoKey(&index, nil, nil, OpenCodeGoPatch{Disabled: &disabled, ExcludedModels: &clearExcluded}); err != nil {
+		t.Fatalf("PatchOpenCodeGoKey() error = %v, want nil", err)
+	}
+	if got := cfg.OpenCodeGoKey[0]; !got.Disabled || len(got.ExcludedModels) != 0 {
+		t.Fatalf("OpenCodeGoKey after patch = %#v, want disabled with cleared excluded models", got)
+	}
+
+	if err := svc.PatchClineKey(&index, nil, nil, ClinePatch{Disabled: &disabled, ExcludedModels: &clearExcluded}); err != nil {
+		t.Fatalf("PatchClineKey() error = %v, want nil", err)
+	}
+	if got := cfg.ClineKey[0]; !got.Disabled || len(got.ExcludedModels) != 0 {
+		t.Fatalf("ClineKey after patch = %#v, want disabled with cleared excluded models", got)
+	}
+
+	if err := svc.PatchOllamaCloudKey(&index, nil, nil, OllamaCloudPatch{Disabled: &disabled, ExcludedModels: &clearExcluded}); err != nil {
+		t.Fatalf("PatchOllamaCloudKey() error = %v, want nil", err)
+	}
+	if got := cfg.OllamaCloudKey[0]; !got.Disabled || len(got.ExcludedModels) != 0 {
+		t.Fatalf("OllamaCloudKey after patch = %#v, want disabled with cleared excluded models", got)
+	}
+}
+
 func stringPtr(value string) *string {
 	return &value
 }

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -357,7 +357,7 @@ func (s *ConfigSynthesizer) synthesizeOpenCodeGoKeys(ctx *SynthesisContext) []*c
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
-		ApplyDisableAllModelsState(a, entry.ExcludedModels)
+		ApplyConfigDisabledState(a, entry.Disabled)
 		out = append(out, a)
 	}
 	return out
@@ -419,7 +419,7 @@ func (s *ConfigSynthesizer) synthesizeClineKeys(ctx *SynthesisContext) []*coreau
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
-		ApplyDisableAllModelsState(a, entry.ExcludedModels)
+		ApplyConfigDisabledState(a, entry.Disabled)
 		out = append(out, a)
 	}
 	return out
@@ -481,7 +481,7 @@ func (s *ConfigSynthesizer) synthesizeOllamaCloudKeys(ctx *SynthesisContext) []*
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
-		ApplyDisableAllModelsState(a, entry.ExcludedModels)
+		ApplyConfigDisabledState(a, entry.Disabled)
 		out = append(out, a)
 	}
 	return out

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -266,6 +266,73 @@ func TestConfigSynthesizer_ClaudeKeyDisableAllModelsMarksAuthDisabled(t *testing
 	}
 }
 
+func TestConfigSynthesizer_ModelAccessWildcardDoesNotDisableAuth(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			OpenCodeGoKey: []config.OpenCodeGoKey{{
+				APIKey:         "sk-opencode",
+				ExcludedModels: []string{"*"},
+				Models:         []config.OpenCodeGoModel{{Name: "qwen3.5-plus"}},
+			}},
+			ClineKey: []config.ClineKey{{
+				APIKey:         "sk-cline",
+				ExcludedModels: []string{"*"},
+				Models:         []config.ClineModel{{Name: "cline-pass/glm-5.2"}},
+			}},
+			OllamaCloudKey: []config.OllamaCloudKey{{
+				APIKey:         "sk-ollama",
+				ExcludedModels: []string{"*"},
+				Models:         []config.OllamaCloudModel{{Name: "gpt-oss:120b"}},
+			}},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 3 {
+		t.Fatalf("expected 3 auths, got %d", len(auths))
+	}
+	for _, auth := range auths {
+		if auth.Disabled || auth.Status != coreauth.StatusActive {
+			t.Fatalf("%s disabled=%t status=%s, want active auth", auth.Provider, auth.Disabled, auth.Status)
+		}
+		if auth.Attributes["excluded_models"] != "*" {
+			t.Fatalf("%s excluded_models = %q, want wildcard metadata", auth.Provider, auth.Attributes["excluded_models"])
+		}
+	}
+}
+
+func TestConfigSynthesizer_ModelAccessDisabledFieldDisablesAuth(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			OpenCodeGoKey:  []config.OpenCodeGoKey{{APIKey: "sk-opencode", Disabled: true}},
+			ClineKey:       []config.ClineKey{{APIKey: "sk-cline", Disabled: true}},
+			OllamaCloudKey: []config.OllamaCloudKey{{APIKey: "sk-ollama", Disabled: true}},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 3 {
+		t.Fatalf("expected 3 auths, got %d", len(auths))
+	}
+	for _, auth := range auths {
+		if !auth.Disabled || auth.Status != coreauth.StatusDisabled || auth.StatusMessage != "disabled via config" {
+			t.Fatalf("%s disabled=%t status=%s message=%q, want config-disabled auth", auth.Provider, auth.Disabled, auth.Status, auth.StatusMessage)
+		}
+	}
+}
+
 func TestConfigSynthesizer_CodexKeys(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -118,6 +118,15 @@ func ApplyDisableAllModelsState(auth *coreauth.Auth, excludedModels []string) {
 	}
 }
 
+func ApplyConfigDisabledState(auth *coreauth.Auth, disabled bool) {
+	if auth == nil || !disabled {
+		return
+	}
+	auth.Disabled = true
+	auth.Status = coreauth.StatusDisabled
+	auth.StatusMessage = "disabled via config"
+}
+
 // addConfigHeadersToAttrs adds header configuration to auth attributes.
 // Headers are prefixed with "header:" in the attributes map.
 func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string) {


### PR DESCRIPTION
## Summary
- add explicit disabled state for OpenCode Go, ClinePass, and Ollama Cloud provider keys
- keep excluded-models wildcard as model access metadata instead of disabling auth
- cover PATCH clearing and synthesizer disabled semantics with tests

## Tests
- rtk go test ./...