### PR TITLE
fix: enforce empty model access

### DIFF
--- a/internal/api/handlers/management/cline_config_test.go
+++ b/internal/api/handlers/management/cline_config_test.go
@@ -50,7 +50,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 1 || h.cfg.ClineKey[0].Models[0].Name != "cline-pass/qwen3.7-max" || len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 0 || len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
 		t.Fatalf("ClineKey after PATCH = %+v", h.cfg.ClineKey[0])
 	}
 
@@ -67,7 +67,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "cline-pass/qwen3.7-max" || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/api/handlers/management/ollama_cloud_config_test.go
+++ b/internal/api/handlers/management/ollama_cloud_config_test.go
@@ -50,7 +50,7 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.OllamaCloudKey[0].Name != "secondary" || h.cfg.OllamaCloudKey[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(h.cfg.OllamaCloudKey[0].Models) != 1 || h.cfg.OllamaCloudKey[0].Models[0].Name != "gpt-oss:20b" || len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 1 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "*" || h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:20b" {
+	if h.cfg.OllamaCloudKey[0].Name != "secondary" || h.cfg.OllamaCloudKey[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(h.cfg.OllamaCloudKey[0].Models) != 0 || len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 1 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "*" || h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:20b" {
 		t.Fatalf("OllamaCloudKey after PATCH = %+v", h.cfg.OllamaCloudKey[0])
 	}
 
@@ -67,7 +67,7 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "gpt-oss:20b" || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "gpt-oss:20b" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "gpt-oss:20b" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/api/handlers/management/opencode_go_config_test.go
+++ b/internal/api/handlers/management/opencode_go_config_test.go
@@ -29,7 +29,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 1 || h.cfg.OpenCodeGoKey[0].Models[0].Name != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 1 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "*" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
+	if len(h.cfg.OpenCodeGoKey) != 1 || h.cfg.OpenCodeGoKey[0].APIKey != "go-key" || h.cfg.OpenCodeGoKey[0].Prefix != "team" || h.cfg.OpenCodeGoKey[0].VisionFallbackModel != "qwen3.5-plus" || len(h.cfg.OpenCodeGoKey[0].Models) != 0 || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 1 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "*" || h.cfg.OpenCodeGoKey[0].WorkspaceID != "wrk_123" || h.cfg.OpenCodeGoKey[0].AuthCookie != "auth-token" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v", h.cfg.OpenCodeGoKey)
 	}
 
@@ -45,6 +45,18 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 		t.Fatalf("OpenCodeGoKey after PATCH = %+v", h.cfg.OpenCodeGoKey[0])
 	}
 
+	patchBody = []byte(`{"index":0,"value":{"excluded-models":["*"]}}`)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/opencode-go-api-key", bytes.NewReader(patchBody))
+	h.ProviderKeys().PatchOpenCodeGoKey(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH disable all status = %d body=%s", w.Code, w.Body.String())
+	}
+	if len(h.cfg.OpenCodeGoKey[0].Models) != 0 || len(h.cfg.OpenCodeGoKey[0].ExcludedModels) != 1 || h.cfg.OpenCodeGoKey[0].ExcludedModels[0] != "*" {
+		t.Fatalf("OpenCodeGoKey after disable-all PATCH = %+v", h.cfg.OpenCodeGoKey[0])
+	}
+
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/opencode-go-api-key", nil)
@@ -58,7 +70,7 @@ func TestOpenCodeGoKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" || len(getBody.Items[0].Models) != 1 || getBody.Items[0].Models[0].Name != "qwen3.7-max" || len(getBody.Items[0].ExcludedModels) != 0 || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].VisionFallbackModel != "qwen3.6-plus" || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].WorkspaceID != "wrk_456" || getBody.Items[0].AuthCookie != "auth-next" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 
@@ -93,7 +105,7 @@ func TestOpenCodeGoKeyManagementKeepsPerKeyModels(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d body=%s", w.Code, w.Body.String())
 	}
-	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || len(got[0].ExcludedModels) != 1 || got[0].ExcludedModels[0] != "*" {
+	if got := h.cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 0 || got[0].VisionFallbackModel != "qwen3.5-plus" || len(got[0].ExcludedModels) != 1 || got[0].ExcludedModels[0] != "*" {
 		t.Fatalf("OpenCodeGoKey after PUT = %+v, want sanitized entry", got)
 	}
 }

--- a/internal/api/provider_config_availability_test.go
+++ b/internal/api/provider_config_availability_test.go
@@ -56,6 +56,9 @@ func TestManagementProviderConfigSaveUpdatesConfiguredAvailability(t *testing.T)
 		"value":{"excluded-models":["*"]}
 	}`)
 	assertAvailabilityMissingModel(t, server, managementKey, "gpt-oss:120b")
+	if server.handlers.AuthManager.CanServeModelWithScopes("gpt-oss:120b", nil, nil, "") {
+		t.Fatal("expected disabled Ollama Cloud model access not to serve gpt-oss:120b")
+	}
 }
 
 func putProviderConfig(t *testing.T, server *Server, managementKey, path, body string) {

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -227,6 +227,9 @@ func (cfg *Config) SanitizeOpenCodeGoKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeOpenCodeGoModels(entry.Models)
 		entry.ExcludedModels = NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
+		if IsProviderModelAccessDisabledAll(entry.ExcludedModels) {
+			entry.Models = nil
+		}
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		entry.WorkspaceID = strings.TrimSpace(entry.WorkspaceID)
 		entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
@@ -282,6 +285,9 @@ func (cfg *Config) SanitizeClineKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeClineModels(entry.Models)
 		entry.ExcludedModels = NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
+		if IsProviderModelAccessDisabledAll(entry.ExcludedModels) {
+			entry.Models = nil
+		}
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
@@ -344,6 +350,9 @@ func (cfg *Config) SanitizeOllamaCloudKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.Models = NormalizeOllamaCloudModels(entry.Models)
 		entry.ExcludedModels = NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
+		if IsProviderModelAccessDisabledAll(entry.ExcludedModels) {
+			entry.Models = nil
+		}
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
 		out = append(out, entry)
 	}
@@ -525,6 +534,16 @@ func NormalizeProviderModelAccessExcludedModels(models []string) []string {
 		}
 	}
 	return nil
+}
+
+// IsProviderModelAccessDisabledAll reports whether a dynamic provider has no allowed models.
+func IsProviderModelAccessDisabledAll(models []string) bool {
+	for _, model := range models {
+		if strings.TrimSpace(model) == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 // NormalizeOAuthExcludedModels cleans provider -> excluded models mappings by normalizing provider keys

--- a/internal/config/ollama_cloud_test.go
+++ b/internal/config/ollama_cloud_test.go
@@ -2,7 +2,7 @@ package config
 
 import "testing"
 
-func TestSanitizeOllamaCloudKeysPreservesModels(t *testing.T) {
+func TestSanitizeOllamaCloudKeysClearsModelsWhenAllAccessDisabled(t *testing.T) {
 	cfg := &Config{OllamaCloudKey: []OllamaCloudKey{{
 		APIKey:         " sk-ollama ",
 		BaseURL:        "https://ollama.com/",
@@ -16,8 +16,8 @@ func TestSanitizeOllamaCloudKeysPreservesModels(t *testing.T) {
 		t.Fatalf("keys len = %d", len(cfg.OllamaCloudKey))
 	}
 	got := cfg.OllamaCloudKey[0]
-	if len(got.Models) != 1 || got.Models[0].Name != "gpt-oss:120b" {
-		t.Fatalf("models = %#v, want normalized per-key models", got.Models)
+	if len(got.Models) != 0 {
+		t.Fatalf("models = %#v, want empty when all model access is disabled", got.Models)
 	}
 	if len(got.ExcludedModels) != 1 || got.ExcludedModels[0] != "*" {
 		t.Fatalf("excluded models = %#v, want disable-all marker only", got.ExcludedModels)

--- a/internal/config/opencode_go_test.go
+++ b/internal/config/opencode_go_test.go
@@ -50,8 +50,8 @@ opencode-go-api-key:
 	if len(got.ExcludedModels) != 1 || got.ExcludedModels[0] != "*" {
 		t.Fatalf("excluded models = %#v", got.ExcludedModels)
 	}
-	if len(got.Models) != 2 || got.Models[0].Name != "qwen3.7-max" || got.Models[1].Name != "kimi-k2.7-code" {
-		t.Fatalf("models = %#v, want normalized unique models", got.Models)
+	if len(got.Models) != 0 {
+		t.Fatalf("models = %#v, want empty when all model access is disabled", got.Models)
 	}
 	if got.VisionFallbackModel != "qwen3.5-plus" {
 		t.Fatalf("vision fallback model = %q, want qwen3.5-plus", got.VisionFallbackModel)
@@ -82,8 +82,8 @@ func TestSanitizeOpenCodeGoKeysDropsEmptyAndDeduplicates(t *testing.T) {
 	if cfg.OpenCodeGoKey[1].VisionFallbackModel != "qwen3.6-plus" {
 		t.Fatalf("vision fallback model = %q, want qwen3.6-plus", cfg.OpenCodeGoKey[1].VisionFallbackModel)
 	}
-	if len(cfg.OpenCodeGoKey[1].Models) != 1 || cfg.OpenCodeGoKey[1].Models[0].Name != "glm-5.2" {
-		t.Fatalf("models = %#v, want normalized unique model", cfg.OpenCodeGoKey[1].Models)
+	if len(cfg.OpenCodeGoKey[1].Models) != 0 {
+		t.Fatalf("models = %#v, want empty when all model access is disabled", cfg.OpenCodeGoKey[1].Models)
 	}
 	if len(cfg.OpenCodeGoKey[1].ExcludedModels) != 1 || cfg.OpenCodeGoKey[1].ExcludedModels[0] != "*" {
 		t.Fatalf("excluded models = %#v, want disable-all marker only", cfg.OpenCodeGoKey[1].ExcludedModels)

--- a/internal/config/provider_model_access_normalize_test.go
+++ b/internal/config/provider_model_access_normalize_test.go
@@ -35,3 +35,37 @@ func TestSanitizeProviderModelAccessRemovesConfiguredModelExclusions(t *testing.
 		t.Fatalf("Ollama Cloud excluded models = %#v, want empty", cfg.OllamaCloudKey[0].ExcludedModels)
 	}
 }
+
+func TestSanitizeProviderModelAccessClearsModelsWhenAllAccessDisabled(t *testing.T) {
+	cfg := &Config{
+		OpenCodeGoKey: []OpenCodeGoKey{{
+			APIKey:         "go-key",
+			Models:         []OpenCodeGoModel{{Name: "qwen3.7-max"}},
+			ExcludedModels: []string{"*"},
+		}},
+		ClineKey: []ClineKey{{
+			APIKey:         "cline-key",
+			Models:         []ClineModel{{Name: "cline-pass/qwen3.7-max"}},
+			ExcludedModels: []string{"*"},
+		}},
+		OllamaCloudKey: []OllamaCloudKey{{
+			APIKey:         "ollama-key",
+			Models:         []OllamaCloudModel{{Name: "gpt-oss:120b"}},
+			ExcludedModels: []string{"*"},
+		}},
+	}
+
+	cfg.SanitizeOpenCodeGoKeys()
+	cfg.SanitizeClineKeys()
+	cfg.SanitizeOllamaCloudKeys()
+
+	if len(cfg.OpenCodeGoKey[0].Models) != 0 {
+		t.Fatalf("OpenCode Go models = %#v, want empty", cfg.OpenCodeGoKey[0].Models)
+	}
+	if len(cfg.ClineKey[0].Models) != 0 {
+		t.Fatalf("ClinePass models = %#v, want empty", cfg.ClineKey[0].Models)
+	}
+	if len(cfg.OllamaCloudKey[0].Models) != 0 {
+		t.Fatalf("Ollama Cloud models = %#v, want empty", cfg.OllamaCloudKey[0].Models)
+	}
+}

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -760,6 +760,9 @@ func NormalizedOpenCodeGoKeyEntries(entries []config.OpenCodeGoKey) []config.Ope
 	for i := range entries {
 		out[i] = entries[i]
 		NormalizeOpenCodeGoKey(&out[i])
+		if config.IsProviderModelAccessDisabledAll(out[i].ExcludedModels) {
+			out[i].Models = nil
+		}
 	}
 	return out
 }
@@ -791,6 +794,9 @@ func NormalizedClineKeyEntries(entries []config.ClineKey) []config.ClineKey {
 	for i := range entries {
 		out[i] = entries[i]
 		NormalizeClineKey(&out[i])
+		if config.IsProviderModelAccessDisabledAll(out[i].ExcludedModels) {
+			out[i].Models = nil
+		}
 	}
 	return out
 }
@@ -822,6 +828,9 @@ func NormalizedOllamaCloudKeyEntries(entries []config.OllamaCloudKey) []config.O
 	for i := range entries {
 		out[i] = entries[i]
 		NormalizeOllamaCloudKey(&out[i])
+		if config.IsProviderModelAccessDisabledAll(out[i].ExcludedModels) {
+			out[i].Models = nil
+		}
 	}
 	return out
 }

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -373,7 +373,7 @@ func TestOpenCodeGoKeysReplacePatchDeleteAndRollback(t *testing.T) {
 	}
 }
 
-func TestOpenCodeGoKeysKeepPerKeyModels(t *testing.T) {
+func TestOpenCodeGoKeysKeepPerKeyModelsAndClearWhenDisabledAll(t *testing.T) {
 	cfg := &config.Config{
 		OpenCodeGoKey: []config.OpenCodeGoKey{{
 			APIKey: "existing",
@@ -389,13 +389,13 @@ func TestOpenCodeGoKeysKeepPerKeyModels(t *testing.T) {
 		Models: []config.OpenCodeGoModel{{
 			Name: " glm-5.2 ",
 		}},
-		ExcludedModels:      []string{"minimax-m2.5", "*"},
+		ExcludedModels:      []string{"minimax-m2.5"},
 		VisionFallbackModel: "qwen3.5-plus",
 	}})
 	if err != nil {
 		t.Fatalf("ReplaceOpenCodeGoKeys() error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || !reflect.DeepEqual(got[0].ExcludedModels, []string{"*"}) {
+	if got := cfg.OpenCodeGoKey; len(got) != 1 || got[0].APIKey != "go-key" || len(got[0].Models) != 1 || got[0].Models[0].Name != "glm-5.2" || got[0].VisionFallbackModel != "qwen3.5-plus" || len(got[0].ExcludedModels) != 0 {
 		t.Fatalf("OpenCodeGoKey after replace = %#v, want sanitized entry", got)
 	}
 
@@ -410,7 +410,7 @@ func TestOpenCodeGoKeysKeepPerKeyModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PatchOpenCodeGoKey(valid models) error = %v, want nil", err)
 	}
-	if got := cfg.OpenCodeGoKey[0]; len(got.Models) != 1 || got.Models[0].Name != "glm-5.2" || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) || got.VisionFallbackModel != "qwen3.5-plus" {
+	if got := cfg.OpenCodeGoKey[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) || got.VisionFallbackModel != "qwen3.5-plus" {
 		t.Fatalf("OpenCodeGoKey after valid patch = %#v", got)
 	}
 }
@@ -601,7 +601,7 @@ func TestClineKeysRejectNonClinePassModelsButAllowCrossProviderFallback(t *testi
 	if err != nil {
 		t.Fatalf("PatchClineKey(valid models) error = %v, want nil", err)
 	}
-	if got := cfg.ClineKey[0]; len(got.Models) != 1 || got.Models[0].Name != "cline-pass/qwen3.7-max" || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) || got.VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
+	if got := cfg.ClineKey[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) || got.VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
 		t.Fatalf("ClineKey after valid patch = %#v", got)
 	}
 }
@@ -648,6 +648,37 @@ func TestModelAccessProviderPatchDisabledAndClearExcludedModels(t *testing.T) {
 	}
 	if got := cfg.OllamaCloudKey[0]; !got.Disabled || len(got.ExcludedModels) != 0 {
 		t.Fatalf("OllamaCloudKey after patch = %#v, want disabled with cleared excluded models", got)
+	}
+}
+
+func TestModelAccessProviderGetHidesStaleModelsWhenAllAccessDisabled(t *testing.T) {
+	cfg := &config.Config{
+		OpenCodeGoKey: []config.OpenCodeGoKey{{
+			APIKey:         "sk-opencode",
+			Models:         []config.OpenCodeGoModel{{Name: "qwen3.5-plus"}},
+			ExcludedModels: []string{"*"},
+		}},
+		ClineKey: []config.ClineKey{{
+			APIKey:         "sk-cline",
+			Models:         []config.ClineModel{{Name: "cline-pass/glm-5.2"}},
+			ExcludedModels: []string{"*"},
+		}},
+		OllamaCloudKey: []config.OllamaCloudKey{{
+			APIKey:         "sk-ollama",
+			Models:         []config.OllamaCloudModel{{Name: "gpt-oss:120b"}},
+			ExcludedModels: []string{"*"},
+		}},
+	}
+	svc := NewService(cfg, nil)
+
+	if got := svc.OpenCodeGoKeys()[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) {
+		t.Fatalf("OpenCodeGoKeys()[0] = %#v, want no stale models", got)
+	}
+	if got := svc.ClineKeys()[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) {
+		t.Fatalf("ClineKeys()[0] = %#v, want no stale models", got)
+	}
+	if got := svc.OllamaCloudKeys()[0]; len(got.Models) != 0 || !reflect.DeepEqual(got.ExcludedModels, []string{"*"}) {
+		t.Fatalf("OllamaCloudKeys()[0] = %#v, want no stale models", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/routing_groups_scope.go
+++ b/sdk/cliproxy/auth/routing_groups_scope.go
@@ -274,7 +274,7 @@ func candidateSupportsModel(cfg *runtimeConfigSnapshot, registryRef ModelRegistr
 		return true
 	}
 	if len(registryRef.GetModelsForClient(auth.ID)) == 0 {
-		return true
+		return !authHasDisableAllModelsRule(auth)
 	}
 	if registryRef.ClientSupportsModel(auth.ID, modelID) {
 		return true
@@ -306,6 +306,20 @@ func candidateSupportsModel(cfg *runtimeConfigSnapshot, registryRef ModelRegistr
 		}
 		if registryRef.ClientSupportsModel(auth.ID, group+"/"+modelID) {
 			return true
+		}
+	}
+	return false
+}
+
+func authHasDisableAllModelsRule(auth *Auth) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	for _, key := range []string{"excluded_models", "excluded-models"} {
+		for _, raw := range strings.Split(auth.Attributes[key], ",") {
+			if strings.TrimSpace(raw) == "*" {
+				return true
+			}
 		}
 	}
 	return false

--- a/sdk/cliproxy/auth/routing_groups_test.go
+++ b/sdk/cliproxy/auth/routing_groups_test.go
@@ -95,6 +95,24 @@ func TestCanServeModelWithScopesHonorsGroupAllowedModels(t *testing.T) {
 	}
 }
 
+func TestCanServeModelWithScopesHonorsDisableAllModelsMetadata(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{})
+	if _, err := manager.Register(context.Background(), &Auth{
+		ID:         "model-access-disabled-auth",
+		Provider:   "opencode-go",
+		Attributes: map[string]string{"excluded_models": "*"},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	if manager.CanServeModelWithScopes("qwen3.7-max", nil, nil, "") {
+		t.Fatal("expected excluded_models=* auth not to serve any model")
+	}
+}
+
 func TestAuthGroupsMatchesLegacyOAuthEmailAfterRename(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- clear stale dynamic-provider model allowlists when excluded-models contains *
- prevent active auths with excluded_models=* from serving arbitrary models when registry has no models
- cover OpenCode Go, ClinePass, and Ollama Cloud with management/runtime tests

## Tests
- rtk go test ./...
