### PR TITLE
fix: preserve ollama cloud model registry

### DIFF
--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -84,7 +84,9 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	}
 	provider := strings.ToLower(strings.TrimSpace(a.Provider))
 	compatProviderKey, compatDisplayName, compatDetected := openAICompatInfoFromAuth(a)
-	if compatDetected && provider != "cline" {
+	// Cline and Ollama Cloud use OpenAI-compatible transport metadata to pick
+	// executors, but their model lists are owned by their native config blocks.
+	if compatDetected && provider != "cline" && provider != "ollama-cloud" {
 		provider = "openai-compatibility"
 	}
 	excluded := s.oauthExcludedModels(provider, authKind)

--- a/sdk/cliproxy/service_ollama_cloud_test.go
+++ b/sdk/cliproxy/service_ollama_cloud_test.go
@@ -15,7 +15,7 @@ func TestRegisterModelsForAuth_OllamaCloudFiltersDirtyClinePassModels(t *testing
 			BaseURL: config.DefaultOllamaCloudBaseURL,
 			Models: []config.OllamaCloudModel{
 				{Name: "cline-pass/glm-5.2"},
-				{Name: "gpt-oss:120b"},
+				{Name: "glm-5.2"},
 			},
 		}},
 	}}
@@ -24,9 +24,11 @@ func TestRegisterModelsForAuth_OllamaCloudFiltersDirtyClinePassModels(t *testing
 		Provider: "ollama-cloud",
 		Status:   coreauth.StatusActive,
 		Attributes: map[string]string{
-			"auth_kind": "apikey",
-			"api_key":   "ollama-key-dirty",
-			"base_url":  config.DefaultOllamaCloudBaseURL,
+			"auth_kind":    "apikey",
+			"api_key":      "ollama-key-dirty",
+			"base_url":     config.DefaultOllamaCloudBaseURL,
+			"compat_name":  "Ollama Cloud",
+			"provider_key": "ollama-cloud",
 		},
 	}
 
@@ -39,10 +41,22 @@ func TestRegisterModelsForAuth_OllamaCloudFiltersDirtyClinePassModels(t *testing
 	service.registerModelsForAuth(context.Background(), auth)
 
 	models := registry.GetModelsForClient(auth.ID)
-	if len(models) != 1 || !hasModelID(models, "gpt-oss:120b") {
+	if len(models) != 1 || !hasModelID(models, "glm-5.2") {
 		t.Fatalf("expected only valid Ollama Cloud model after dirty filtering, got %+v", models)
 	}
 	if hasModelID(models, "cline-pass/glm-5.2") {
 		t.Fatalf("dirty ClinePass model should not be registered for Ollama Cloud; got %+v", models)
 	}
+	if !hasProvider(registry.GetModelProviders("glm-5.2"), "ollama-cloud") {
+		t.Fatalf("expected Ollama Cloud provider for glm-5.2, got %+v", registry.GetModelProviders("glm-5.2"))
+	}
+}
+
+func hasProvider(providers []string, want string) bool {
+	for _, provider := range providers {
+		if provider == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- keep Ollama Cloud model registration on the native provider even though it carries OpenAI-compatible transport metadata
- add regression coverage for glm-5.2 with Ollama Cloud compat_name/provider_key attributes

## Tests
- rtk go test ./sdk/cliproxy -run 'TestRegisterModelsForAuth_OllamaCloud'\n- rtk go test ./sdk/cliproxy ./sdk/requestdispatch ./internal/app/service ./internal/api\n- rtk go test ./...\n- rtk go build ./...