### PR TITLE
fix: bind Ollama Cloud to dedicated executor

### DIFF
--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -476,6 +476,11 @@ func openAICompatInfoFromAuth(auth *coreauth.Auth) (providerKey string, compatNa
 	if auth == nil {
 		return "", "", false
 	}
+	// Ollama Cloud keeps compat metadata for chat fallback, but its native
+	// Responses/Messages routes require the dedicated executor.
+	if strings.EqualFold(strings.TrimSpace(auth.Provider), "ollama-cloud") {
+		return "", "", false
+	}
 	if len(auth.Attributes) > 0 {
 		providerKey = strings.TrimSpace(auth.Attributes["provider_key"])
 		compatName = strings.TrimSpace(auth.Attributes["compat_name"])

--- a/internal/app/service/runtime_executor_registry_test.go
+++ b/internal/app/service/runtime_executor_registry_test.go
@@ -6,6 +6,7 @@ import (
 
 	managementmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/internal/management/modelcatalog"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
@@ -14,6 +15,31 @@ import (
 type testModelRegistry struct {
 	models       []*sdkmodelcatalog.ModelInfo
 	unregistered bool
+}
+
+func TestRegisterExecutorForAuthOllamaCloudUsesDedicatedExecutorWithCompatMetadata(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "ollama-cloud-auth",
+		Provider: "ollama-cloud",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":      "ollama-key",
+			"base_url":     config.DefaultOllamaCloudBaseURL,
+			"compat_name":  "Ollama Cloud",
+			"provider_key": "ollama-cloud",
+		},
+	}
+
+	RegisterExecutorForAuth(manager, &config.Config{}, auth, false, nil)
+
+	got, ok := manager.Executor("ollama-cloud")
+	if !ok || got == nil {
+		t.Fatal("expected ollama-cloud executor after bind")
+	}
+	if _, ok := got.(*executor.OllamaCloudExecutor); !ok {
+		t.Fatalf("executor = %T, want *executor.OllamaCloudExecutor", got)
+	}
 }
 
 func (r *testModelRegistry) RegisterClient(_ string, _ string, models []*sdkmodelcatalog.ModelInfo) {

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -1,6 +1,10 @@
 package auth
 
-import "time"
+import (
+	"net/http"
+	"strings"
+	"time"
+)
 
 func preserveRuntimeFields(dst *Auth, src *Auth) {
 	if dst == nil || src == nil {
@@ -38,6 +42,9 @@ func preserveAvailabilityRuntimeForUpdate(dst *Auth, src *Auth, now time.Time) {
 			if !shouldPreserveModelRuntimeState(dst.ModelStates[model], srcState, now) {
 				continue
 			}
+			if shouldDropOllamaCloudNotFoundRuntimeState(dst, srcState) {
+				continue
+			}
 			dst.ModelStates[model] = srcState.Clone()
 			preservedModelState = true
 		}
@@ -56,7 +63,7 @@ func preserveAvailabilityRuntimeForUpdate(dst *Auth, src *Auth, now time.Time) {
 		}
 	}
 
-	if !shouldPreserveAuthRuntimeState(dst, src, now) {
+	if shouldDropOllamaCloudNotFoundAuthRuntimeState(dst, src) || !shouldPreserveAuthRuntimeState(dst, src, now) {
 		return
 	}
 	dst.Unavailable = src.Unavailable
@@ -65,4 +72,26 @@ func preserveAvailabilityRuntimeForUpdate(dst *Auth, src *Auth, now time.Time) {
 	dst.LastError = cloneError(src.LastError)
 	dst.Quota = src.Quota
 	dst.NextRetryAfter = src.NextRetryAfter
+}
+
+func shouldDropOllamaCloudNotFoundRuntimeState(auth *Auth, state *ModelState) bool {
+	if auth == nil || state == nil || state.LastError == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "ollama-cloud") {
+		return false
+	}
+	// Older builds misrouted Ollama Cloud through OpenAI-compatible chat and
+	// persisted false 404 cooldowns; a real 404 will be recorded again.
+	return state.LastError.HTTPStatus == http.StatusNotFound
+}
+
+func shouldDropOllamaCloudNotFoundAuthRuntimeState(dst *Auth, src *Auth) bool {
+	if dst == nil || src == nil || src.LastError == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(dst.Provider), "ollama-cloud") {
+		return false
+	}
+	return src.LastError.HTTPStatus == http.StatusNotFound
 }

--- a/sdk/cliproxy/auth/conductor_runtime_quota_test.go
+++ b/sdk/cliproxy/auth/conductor_runtime_quota_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -117,6 +118,43 @@ func TestManagerUpdateDoesNotPreserveRuntimeQuotaWhenDisabled(t *testing.T) {
 	}
 	if !updated.Disabled || updated.Status != StatusDisabled {
 		t.Fatalf("expected disabled status to be preserved, got disabled=%v status=%q", updated.Disabled, updated.Status)
+	}
+}
+
+func TestManagerUpdateDropsOllamaCloudNotFoundRuntimeState(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(nil, nil, nil)
+	model := "glm-5.2"
+
+	if _, err := m.Register(ctx, &Auth{
+		ID:       "ollama-auth",
+		Provider: "ollama-cloud",
+		Status:   StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:   "ollama-auth",
+		Provider: "ollama-cloud",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{Message: "not found", HTTPStatus: http.StatusNotFound},
+	})
+
+	updated, err := m.Update(ctx, &Auth{
+		ID:       "ollama-auth",
+		Provider: "ollama-cloud",
+		Status:   StatusActive,
+	})
+	if err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("ollama-cloud 404 runtime state survived update: %#v", state)
+	}
+	if updated.Unavailable || updated.Status != StatusActive || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("ollama-cloud auth availability not reset: %#v", updated)
 	}
 }
 


### PR DESCRIPTION
## Summary
- bind Ollama Cloud auths to the dedicated executor even when compat metadata is present
- drop stale Ollama Cloud 404 runtime cooldowns created by the previous misrouting
- add regression coverage for executor binding and stale cooldown cleanup

## Tests
- rtk go test ./internal/app/service ./sdk/cliproxy ./sdk/cliproxy/auth ./internal/runtime/executor
- rtk go test ./...
- rtk go build ./...