### PR TITLE
fix: route Ollama Cloud through native chat cache

### DIFF
--- a/internal/runtime/executor/ollama_cloud_executor.go
+++ b/internal/runtime/executor/ollama_cloud_executor.go
@@ -61,6 +61,9 @@ func (e *OllamaCloudExecutor) HttpRequest(ctx context.Context, auth *cliproxyaut
 }
 
 func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if opts.Alt != "responses/compact" && (opts.SourceFormat == sdktranslator.FormatOpenAIResponse || opts.SourceFormat == sdktranslator.FormatOpenAI) {
+		return e.executeNativeChat(ctx, auth, req, opts)
+	}
 	if opts.Alt != "responses/compact" {
 		switch opts.SourceFormat {
 		case sdktranslator.FormatOpenAIResponse:
@@ -73,6 +76,9 @@ func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 }
 
 func (e *OllamaCloudExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if opts.Alt != "responses/compact" && (opts.SourceFormat == sdktranslator.FormatOpenAIResponse || opts.SourceFormat == sdktranslator.FormatOpenAI) {
+		return e.executeNativeChatStream(ctx, auth, req, opts)
+	}
 	if opts.Alt != "responses/compact" {
 		switch opts.SourceFormat {
 		case sdktranslator.FormatOpenAIResponse:

--- a/internal/runtime/executor/ollama_cloud_executor_test.go
+++ b/internal/runtime/executor/ollama_cloud_executor_test.go
@@ -18,15 +18,17 @@ import (
 
 func TestOllamaCloudExecutorRoutesChatToOpenAICompatibleV1(t *testing.T) {
 	var gotPath string
+	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"gpt-oss:120b","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+		_, _ = w.Write([]byte(`{"model":"gpt-oss:120b","created_at":"2026-07-07T00:00:00Z","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`))
 	}))
 	defer server.Close()
 
 	exec := NewOllamaCloudExecutor(&config.Config{})
-	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL + "/v1"}}
 	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "gpt-oss:120b",
 		Payload: []byte(`{"model":"gpt-oss:120b","messages":[{"role":"user","content":"hi"}]}`),
@@ -34,22 +36,44 @@ func TestOllamaCloudExecutorRoutesChatToOpenAICompatibleV1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if gotPath != "/v1/chat/completions" {
-		t.Fatalf("path = %q, want /v1/chat/completions", gotPath)
+	if gotPath != "/api/chat" {
+		t.Fatalf("path = %q, want /api/chat", gotPath)
+	}
+	if got := gjson.GetBytes(gotBody, "keep_alive").String(); got != ollamaCloudNativeKeepAlive {
+		t.Fatalf("keep_alive = %q, want %q; body=%s", got, ollamaCloudNativeKeepAlive, gotBody)
 	}
 	if gotText := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); gotText != "ok" {
 		t.Fatalf("response text = %q, want ok; payload=%s", gotText, string(resp.Payload))
 	}
 }
 
-func TestOllamaCloudExecutorRoutesResponsesToOfficialEndpoint(t *testing.T) {
+func TestOllamaCloudNativeCacheKeyScopesExplicitPromptKey(t *testing.T) {
+	source := []byte(`{"model":"glm-5.2","prompt_cache_key":"shared-session","input":"hi"}`)
+	authA := &cliproxyauth.Auth{ID: "ollama-cloud:one"}
+	authB := &cliproxyauth.Auth{ID: "ollama-cloud:two"}
+
+	keyA := ollamaNativeCacheKey(authA, "glm-5.2", source, nil, cliproxyexecutor.Options{})
+	keyB := ollamaNativeCacheKey(authB, "glm-5.2", source, nil, cliproxyexecutor.Options{})
+
+	if keyA == "" || keyB == "" {
+		t.Fatalf("cache keys must be present: %q / %q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("cache key not isolated by auth: %q", keyA)
+	}
+	if strings.Contains(keyA, "shared-session") || strings.Contains(keyB, "shared-session") {
+		t.Fatalf("cache key leaked raw prompt key: %q / %q", keyA, keyB)
+	}
+}
+
+func TestOllamaCloudExecutorRoutesResponsesToNativeChat(t *testing.T) {
 	var gotPath string
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","created_at":1,"model":"gpt-oss:120b","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+		_, _ = w.Write([]byte(`{"model":"gpt-oss:120b","created_at":"2026-07-07T00:00:00Z","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`))
 	}))
 	defer server.Close()
 
@@ -62,56 +86,67 @@ func TestOllamaCloudExecutorRoutesResponsesToOfficialEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if gotPath != "/v1/responses" {
-		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	if gotPath != "/api/chat" {
+		t.Fatalf("path = %q, want /api/chat", gotPath)
 	}
 	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "gpt-oss:120b" {
 		t.Fatalf("upstream model = %q, want gpt-oss:120b; body=%s", gotModel, string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "prompt_cache_key").Exists() {
+		t.Fatalf("native Ollama body must not forward OpenAI prompt_cache_key: %s", gotBody)
 	}
 	if gotText := gjson.GetBytes(resp.Payload, "output.0.content.0.text").String(); gotText != "ok" {
 		t.Fatalf("response text = %q, want ok; payload=%s", gotText, string(resp.Payload))
 	}
 }
 
-func TestOllamaCloudExecutorResponsesAddsSessionPromptCacheKey(t *testing.T) {
-	var gotBody []byte
+func TestOllamaCloudExecutorNativeResponsesReportsEstimatedCacheHit(t *testing.T) {
+	calls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
+		calls++
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","created_at":1,"model":"glm-5.2","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":3},"output_tokens":1,"total_tokens":11}}`))
+		_, _ = w.Write([]byte(`{"model":"glm-5.2","created_at":"2026-07-07T00:00:00Z","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1000,"eval_count":1}`))
 	}))
 	defer server.Close()
 
 	exec := NewOllamaCloudExecutor(&config.Config{})
 	auth := &cliproxyauth.Auth{ID: "ollama-cloud:apikey:one", Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
-	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "glm-5.2",
-		Payload: []byte(`{"model":"glm-5.2","input":"hi"}`),
-	}, cliproxyexecutor.Options{
+	longPrompt := strings.Repeat("cached-prefix ", 500)
+	opts := cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FormatOpenAIResponse,
 		Metadata: map[string]any{
 			cliproxyexecutor.SessionStickyMetadataKey: "header:x-session-id:session-1",
 		},
-	})
+	}
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "glm-5.2",
+		Payload: []byte(`{"model":"glm-5.2","input":"` + longPrompt + `"}`),
+	}, opts)
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	key := gjson.GetBytes(gotBody, "prompt_cache_key").String()
-	if key == "" {
-		t.Fatalf("prompt_cache_key missing in upstream body: %s", gotBody)
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "glm-5.2",
+		Payload: []byte(`{"model":"glm-5.2","input":"` + longPrompt + ` plus one more turn"}`),
+	}, opts)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
 	}
-	if strings.Contains(key, "session-1") {
-		t.Fatalf("prompt_cache_key leaked raw session: %q", key)
+	if calls != 2 {
+		t.Fatalf("server calls = %d, want 2", calls)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens_details.cached_tokens").Int(); got <= 0 {
+		t.Fatalf("cached_tokens = %d, want positive cache estimate; payload=%s", got, resp.Payload)
 	}
 }
 
-func TestOllamaCloudExecutorStreamsResponsesFromOfficialEndpoint(t *testing.T) {
+func TestOllamaCloudExecutorStreamsResponsesFromNativeChat(t *testing.T) {
 	var gotPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte("event: response.created\n"))
-		_, _ = w.Write([]byte(`data: {"type":"response.created","response":{"id":"resp_1"}}` + "\n\n"))
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"model":"gpt-oss:120b","message":{"role":"assistant","content":"ok"},"done":false}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"gpt-oss:120b","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}` + "\n"))
 	}))
 	defer server.Close()
 
@@ -131,11 +166,11 @@ func TestOllamaCloudExecutorStreamsResponsesFromOfficialEndpoint(t *testing.T) {
 		}
 		chunks.Write(chunk.Payload)
 	}
-	if gotPath != "/v1/responses" {
-		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	if gotPath != "/api/chat" {
+		t.Fatalf("path = %q, want /api/chat", gotPath)
 	}
-	if got := chunks.String(); got != "event: response.created\n"+`data: {"type":"response.created","response":{"id":"resp_1"}}`+"\n\n" {
-		t.Fatalf("stream payload = %q", got)
+	if got := chunks.String(); !strings.Contains(got, "response.completed") || !strings.Contains(got, "ok") {
+		t.Fatalf("stream payload = %q, want responses stream with ok completion", got)
 	}
 }
 

--- a/internal/runtime/executor/ollama_cloud_native_chat.go
+++ b/internal/runtime/executor/ollama_cloud_native_chat.go
@@ -1,0 +1,539 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const ollamaCloudNativeKeepAlive = "30m"
+
+func (e *OllamaCloudExecutor) executeNativeChat(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	execCtx, translated, body, cacheKey, promptText, err := e.prepareNativeChat(ctx, auth, req, opts, false)
+	if err != nil {
+		return resp, err
+	}
+	reporter := execCtx.Reporter()
+	defer reporter.trackFailure(execCtx.Context, &err)
+
+	httpResp, err := e.doNativeChatJSON(execCtx, auth, body, false)
+	if err != nil {
+		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("ollama cloud native chat: close response body error: %v", errClose)
+		}
+	}()
+	recorder := execCtx.Recorder()
+	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+		recorder.AppendResponseChunk(b)
+		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
+		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
+		return resp, err
+	}
+	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
+	if err != nil {
+		recorder.RecordResponseError(err)
+		return resp, err
+	}
+	recorder.AppendResponseChunk(data)
+	openAIResponse := ollamaNativeChatToOpenAI(data, execCtx.BaseModel, cacheKey, promptText)
+	reporter.publishWithContent(execCtx.Context, parseOpenAIUsage(openAIResponse), string(req.Payload), string(openAIResponse))
+	reporter.ensurePublished(execCtx.Context)
+
+	var param any
+	out := sdktranslator.TranslateNonStream(execCtx.Context, sdktranslator.FormatOpenAI, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, openAIResponse, &param)
+	return cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}, nil
+}
+
+func (e *OllamaCloudExecutor) executeNativeChatStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	execCtx, translated, body, cacheKey, promptText, err := e.prepareNativeChat(ctx, auth, req, opts, true)
+	if err != nil {
+		return nil, err
+	}
+	reporter := execCtx.Reporter()
+	defer reporter.trackFailure(execCtx.Context, &err)
+
+	//nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
+	httpResp, err := e.doNativeChatJSON(execCtx, auth, body, true)
+	if err != nil {
+		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		return nil, err
+	}
+	recorder := execCtx.Recorder()
+	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+		recorder.AppendResponseChunk(b)
+		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("ollama cloud native chat: close response body error: %v", errClose)
+		}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
+		return nil, err
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	reporter.setInputContent(string(req.Payload))
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("ollama cloud native chat: close response body error: %v", errClose)
+			}
+		}()
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800)
+		var param any
+		var lastUsage coreusage.Detail
+		hasUsage := false
+		roleSent := false
+		responseID := fmt.Sprintf("chatcmpl_%x", time.Now().UnixNano())
+		var pendingResponsesCompleted []byte
+		for scanner.Scan() {
+			line := bytes.TrimSpace(scanner.Bytes())
+			if len(line) == 0 {
+				continue
+			}
+			recorder.AppendResponseChunk(line)
+			openAILines, usage, usageSeen := ollamaNativeStreamChunkToOpenAI(line, execCtx.BaseModel, responseID, cacheKey, promptText, &roleSent)
+			if usageSeen {
+				lastUsage = usage
+				hasUsage = true
+			}
+			for _, openAILine := range openAILines {
+				reporter.appendOutputChunk(openAILine)
+				if detail, ok := parseOpenAIStreamUsage(openAILine); ok {
+					lastUsage = detail
+					hasUsage = true
+					if len(pendingResponsesCompleted) > 0 && isOpenAIStreamUsageOnly(openAILine) {
+						out <- cliproxyexecutor.StreamChunk{Payload: patchResponsesCompletedUsage(pendingResponsesCompleted, lastUsage)}
+						pendingResponsesCompleted = nil
+					}
+				}
+				for _, chunk := range sdktranslator.TranslateStream(execCtx.Context, sdktranslator.FormatOpenAI, execCtx.SourceFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(openAILine), &param) {
+					if shouldHoldResponsesCompleted(execCtx.SourceFormat, openAILine, []byte(chunk)) {
+						pendingResponsesCompleted = []byte(chunk)
+						continue
+					}
+					out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunk)}
+				}
+			}
+		}
+		if len(pendingResponsesCompleted) > 0 {
+			if hasUsage {
+				pendingResponsesCompleted = patchResponsesCompletedUsage(pendingResponsesCompleted, lastUsage)
+			}
+			out <- cliproxyexecutor.StreamChunk{Payload: pendingResponsesCompleted}
+		}
+		if errScan := scanner.Err(); errScan != nil {
+			recorder.RecordResponseError(errScan)
+			reporter.publishFailure(execCtx.Context)
+			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			return
+		}
+		if hasUsage {
+			reporter.publish(execCtx.Context, lastUsage)
+		}
+		reporter.ensurePublished(execCtx.Context)
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func (e *OllamaCloudExecutor) prepareNativeChat(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*ExecutionContext, []byte, []byte, string, string, error) {
+	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
+		TargetFormat:      sdktranslator.FormatOpenAI,
+		TranslateAsStream: stream,
+	})
+	translated, originalTranslated := execCtx.TranslateRequestPair(req.Payload)
+	translated, _ = sjson.SetBytes(translated, "model", execCtx.BaseModel)
+	translated = execCtx.ApplyPayloadConfig(translated, originalTranslated)
+	updated, err := thinking.ApplyThinking(translated, req.Model, execCtx.SourceFormat.String(), sdktranslator.FormatOpenAI.String(), e.Identifier())
+	if err != nil {
+		return nil, nil, nil, "", "", err
+	}
+	updated = normalizeOpenAIChatToolCallMessages(updated)
+	updated = applyProviderPromptCaching(updated, req.Payload, auth, e.Identifier(), execCtx.BaseModel, sdktranslator.FormatOpenAI, opts)
+	body, promptText := ollamaNativeChatRequest(updated, stream)
+	cacheKey := ollamaNativeCacheKey(auth, execCtx.BaseModel, req.Payload, updated, opts)
+	return execCtx, updated, body, cacheKey, promptText, nil
+}
+
+func (e *OllamaCloudExecutor) doNativeChatJSON(execCtx *ExecutionContext, auth *cliproxyauth.Auth, body []byte, stream bool) (*http.Response, error) {
+	baseURL, apiKey := e.resolveCredentials(auth)
+	if baseURL == "" {
+		return nil, statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
+	}
+	url := ollamaCloudNativeBaseURL(baseURL) + "/api/chat"
+	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", "cli-proxy-ollama-cloud")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	if stream {
+		httpReq.Header.Set("Accept", "application/x-ndjson")
+		httpReq.Header.Set("Cache-Control", "no-cache")
+	} else {
+		httpReq.Header.Set("Accept", "application/json")
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	execCtx.Recorder().RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
+	resp, err := execCtx.HTTPClient(0).Do(httpReq) //nolint:bodyclose // stream bodies are closed by the stream goroutine.
+	if err != nil {
+		execCtx.Recorder().RecordResponseError(err)
+	}
+	return resp, err
+}
+
+func ollamaCloudNativeBaseURL(baseURL string) string {
+	base := strings.TrimSuffix(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		base = config.DefaultOllamaCloudBaseURL
+	}
+	if strings.HasSuffix(strings.ToLower(base), "/v1") {
+		return strings.TrimSuffix(base[:len(base)-len("/v1")], "/")
+	}
+	return base
+}
+
+func ollamaNativeChatRequest(openAIChat []byte, stream bool) ([]byte, string) {
+	var root map[string]any
+	if err := json.Unmarshal(openAIChat, &root); err != nil {
+		return openAIChat, ""
+	}
+	messages, promptText := ollamaNativeMessages(root["messages"])
+	out := map[string]any{
+		"model":      strings.TrimSpace(fmt.Sprint(root["model"])),
+		"messages":   messages,
+		"stream":     stream,
+		"keep_alive": ollamaCloudNativeKeepAlive,
+	}
+	if tools, ok := root["tools"]; ok {
+		out["tools"] = tools
+	}
+	if format, ok := ollamaNativeFormat(root["response_format"]); ok {
+		out["format"] = format
+	}
+	if options := ollamaNativeOptions(root); len(options) > 0 {
+		out["options"] = options
+	}
+	body, err := json.Marshal(out)
+	if err != nil {
+		return openAIChat, promptText
+	}
+	return body, promptText
+}
+
+func ollamaNativeCacheKey(auth *cliproxyauth.Auth, model string, source, translated []byte, opts cliproxyexecutor.Options) string {
+	seed := sessionPromptCacheSeed(opts, source)
+	if seed == "" {
+		seed = sessionPromptCacheSeed(opts, translated)
+	}
+	if seed == "" {
+		seed = strings.TrimSpace(gjson.GetBytes(source, "prompt_cache_key").String())
+	}
+	if seed == "" {
+		seed = strings.TrimSpace(gjson.GetBytes(translated, "prompt_cache_key").String())
+	}
+	return scopedPromptCacheKey(auth, model, seed)
+}
+
+func ollamaNativeMessages(raw any) ([]any, string) {
+	items, _ := raw.([]any)
+	messages := make([]any, 0, len(items))
+	var prompt strings.Builder
+	for _, item := range items {
+		msg, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		role := strings.TrimSpace(fmt.Sprint(msg["role"]))
+		if role == "developer" {
+			role = "system"
+		}
+		content, images := ollamaNativeContent(msg["content"])
+		next := map[string]any{"role": role, "content": content}
+		if len(images) > 0 {
+			next["images"] = images
+		}
+		if calls, ok := msg["tool_calls"]; ok {
+			next["tool_calls"] = calls
+		}
+		messages = append(messages, next)
+		prompt.WriteString(role)
+		prompt.WriteByte('\n')
+		prompt.WriteString(content)
+		prompt.WriteByte('\n')
+	}
+	return messages, prompt.String()
+}
+
+func ollamaNativeContent(raw any) (string, []string) {
+	switch value := raw.(type) {
+	case string:
+		return value, nil
+	case []any:
+		var text strings.Builder
+		var images []string
+		for _, item := range value {
+			part, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch strings.TrimSpace(fmt.Sprint(part["type"])) {
+			case "text", "input_text", "output_text":
+				if text.Len() > 0 {
+					text.WriteByte('\n')
+				}
+				text.WriteString(fmt.Sprint(part["text"]))
+			case "image_url":
+				if image := ollamaImageURLPayload(part["image_url"]); image != "" {
+					images = append(images, image)
+				}
+			}
+		}
+		return text.String(), images
+	default:
+		if raw == nil {
+			return "", nil
+		}
+		return strings.TrimSpace(fmt.Sprint(raw)), nil
+	}
+}
+
+func ollamaImageURLPayload(raw any) string {
+	switch value := raw.(type) {
+	case string:
+		return strings.TrimPrefix(value, "data:image/png;base64,")
+	case map[string]any:
+		url := strings.TrimSpace(fmt.Sprint(value["url"]))
+		if idx := strings.Index(url, ","); strings.HasPrefix(url, "data:") && idx >= 0 {
+			return url[idx+1:]
+		}
+		return url
+	default:
+		return ""
+	}
+}
+
+func ollamaNativeFormat(raw any) (any, bool) {
+	value, ok := raw.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	if value["type"] == "json_object" {
+		return "json", true
+	}
+	return nil, false
+}
+
+func ollamaNativeOptions(root map[string]any) map[string]any {
+	options := make(map[string]any)
+	if existing, ok := root["options"].(map[string]any); ok {
+		for key, value := range existing {
+			options[key] = value
+		}
+	}
+	if v, ok := root["temperature"]; ok {
+		options["temperature"] = v
+	}
+	if v, ok := root["top_p"]; ok {
+		options["top_p"] = v
+	}
+	for _, key := range []string{"max_tokens", "max_completion_tokens"} {
+		if v, ok := root[key]; ok {
+			options["num_predict"] = v
+			break
+		}
+	}
+	return options
+}
+
+func ollamaNativeChatToOpenAI(native []byte, model, cacheKey, promptText string) []byte {
+	root := gjson.ParseBytes(native)
+	promptTokens := root.Get("prompt_eval_count").Int()
+	outputTokens := root.Get("eval_count").Int()
+	cachedTokens := ollamaPromptCacheEstimateAndStore(cacheKey, promptText, promptTokens)
+	out := `{"id":"","object":"chat.completion","created":0,"model":"","choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"prompt_tokens_details":{"cached_tokens":0}}}`
+	out, _ = sjson.Set(out, "id", fmt.Sprintf("chatcmpl_%x", time.Now().UnixNano()))
+	out, _ = sjson.Set(out, "created", time.Now().Unix())
+	out, _ = sjson.Set(out, "model", model)
+	out, _ = sjson.Set(out, "choices.0.message.content", root.Get("message.content").String())
+	if calls := root.Get("message.tool_calls"); calls.Exists() {
+		out, _ = sjson.SetRaw(out, "choices.0.message.tool_calls", calls.Raw)
+	}
+	if doneReason := strings.TrimSpace(root.Get("done_reason").String()); doneReason != "" {
+		out, _ = sjson.Set(out, "choices.0.finish_reason", doneReason)
+	}
+	out, _ = sjson.Set(out, "usage.prompt_tokens", promptTokens)
+	out, _ = sjson.Set(out, "usage.completion_tokens", outputTokens)
+	out, _ = sjson.Set(out, "usage.total_tokens", promptTokens+outputTokens)
+	out, _ = sjson.Set(out, "usage.prompt_tokens_details.cached_tokens", cachedTokens)
+	return []byte(out)
+}
+
+func ollamaNativeStreamChunkToOpenAI(line []byte, model, responseID, cacheKey, promptText string, roleSent *bool) ([][]byte, coreusage.Detail, bool) {
+	root := gjson.ParseBytes(line)
+	created := time.Now().Unix()
+	var out [][]byte
+	if !*roleSent {
+		first := ollamaOpenAIStreamLine(responseID, model, created, map[string]any{"role": "assistant"}, nil)
+		out = append(out, first)
+		*roleSent = true
+	}
+	delta := make(map[string]any)
+	if content := root.Get("message.content").String(); content != "" {
+		delta["content"] = content
+	}
+	if calls := root.Get("message.tool_calls"); calls.Exists() {
+		delta["tool_calls"] = calls.Value()
+	}
+	if len(delta) > 0 {
+		out = append(out, ollamaOpenAIStreamLine(responseID, model, created, delta, nil))
+	}
+	if !root.Get("done").Bool() {
+		return out, coreusage.Detail{}, false
+	}
+	out = append(out, ollamaOpenAIStreamDoneLine(responseID, model, created, root.Get("done_reason").String()))
+	promptTokens := root.Get("prompt_eval_count").Int()
+	outputTokens := root.Get("eval_count").Int()
+	cachedTokens := ollamaPromptCacheEstimateAndStore(cacheKey, promptText, promptTokens)
+	usage := coreusage.Detail{
+		InputTokens:              promptTokens,
+		OutputTokens:             outputTokens,
+		TotalTokens:              promptTokens + outputTokens,
+		CacheReadTokens:          cachedTokens,
+		CachedTokens:             cachedTokens,
+		CacheReadIncludedInInput: true,
+	}
+	out = append(out, ollamaOpenAIStreamLine(responseID, model, created, nil, &usage))
+	out = append(out, []byte("data: [DONE]\n\n"))
+	return out, usage, true
+}
+
+func ollamaOpenAIStreamLine(id, model string, created int64, delta map[string]any, usage *coreusage.Detail) []byte {
+	chunk := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": created,
+		"model":   model,
+	}
+	if usage != nil {
+		chunk["choices"] = []any{}
+		chunk["usage"] = map[string]any{
+			"prompt_tokens":     usage.InputTokens,
+			"completion_tokens": usage.OutputTokens,
+			"total_tokens":      usage.TotalTokens,
+			"prompt_tokens_details": map[string]any{
+				"cached_tokens": usage.CachedTokens,
+			},
+		}
+	} else {
+		chunk["choices"] = []any{map[string]any{
+			"index":         0,
+			"delta":         delta,
+			"finish_reason": nil,
+		}}
+	}
+	payload, _ := json.Marshal(chunk)
+	return append(append([]byte("data: "), payload...), '\n', '\n')
+}
+
+func ollamaOpenAIStreamDoneLine(id, model string, created int64, reason string) []byte {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "stop"
+	}
+	chunk := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": created,
+		"model":   model,
+		"choices": []any{map[string]any{
+			"index":         0,
+			"delta":         map[string]any{},
+			"finish_reason": reason,
+		}},
+	}
+	payload, _ := json.Marshal(chunk)
+	return append(append([]byte("data: "), payload...), '\n', '\n')
+}
+
+type ollamaPromptCacheEntry struct {
+	prompt    string
+	expiresAt time.Time
+}
+
+var ollamaPromptCache sync.Map
+
+func ollamaPromptCacheEstimateAndStore(cacheKey, prompt string, inputTokens int64) int64 {
+	cacheKey = strings.TrimSpace(cacheKey)
+	if cacheKey == "" || strings.TrimSpace(prompt) == "" || inputTokens <= 0 {
+		return 0
+	}
+	now := time.Now()
+	var cached int64
+	if raw, ok := ollamaPromptCache.Load(cacheKey); ok {
+		entry, _ := raw.(ollamaPromptCacheEntry)
+		if now.Before(entry.expiresAt) {
+			common := commonPrefixLen(entry.prompt, prompt)
+			if common >= 4096 && len(prompt) > 0 {
+				cached = inputTokens * int64(common) / int64(len(prompt))
+				if cached > inputTokens {
+					cached = inputTokens
+				}
+			}
+		}
+	}
+	// Native Ollama exercises the real runner prefix cache via /api/chat +
+	// keep_alive, but its API reports prompt_eval_count, not cached token count.
+	// Expose an OpenAI-compatible cache read estimate from the stable session
+	// prefix so dashboards can show the hit without claiming provider reporting.
+	ollamaPromptCache.Store(cacheKey, ollamaPromptCacheEntry{
+		prompt:    prompt,
+		expiresAt: now.Add(30 * time.Minute),
+	})
+	return cached
+}
+
+func commonPrefixLen(a, b string) int {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	for i := 0; i < limit; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return limit
+}


### PR DESCRIPTION
## Summary
- route Ollama Cloud OpenAI chat/responses requests through native `/api/chat`
- keep the Ollama runner alive with `keep_alive` so repeated session prefixes can hit native prefix cache
- preserve OpenAI/Responses response shapes and add scoped cache-hit estimation for dashboards

## Tests
- `rtk go test ./internal/runtime/executor -run TestOllamaCloudExecutor`
- `rtk go test ./internal/runtime/executor`
- `rtk go test ./...`