### PR TITLE
fix(updater): skip SQLite migration during online updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ auto-update:
 
 CliRelay uses PostgreSQL 15+ as the runtime primary database through Ent ORM. Redis 7+ is intentionally limited to cache, locks, limits, queues, and rebuildable snapshots. The bundled Docker Compose file starts both services and injects container-local connection settings automatically through the generated `.env`.
 
-For old Docker deployments that still have a SQLite-only compose file, update from `/manage/system` can upgrade `docker-compose.yml` and `.env` before it restarts the application container. The updater adds the `clirelay-init`, `clirelay-migrate`, PostgreSQL, Redis, and updater services, keeps the existing application service running, starts PostgreSQL/Redis, streams the SQLite migration progress, and only recreates the application container after migration succeeds. SQLite is left in place.
+For old Docker deployments that still have a SQLite-only compose file, update from `/manage/system` can upgrade `docker-compose.yml` and `.env` before it restarts the application container. The updater adds the `clirelay-init`, PostgreSQL, Redis, and updater services, starts PostgreSQL/Redis, and recreates the application container. SQLite is left in place; use the manual migration commands below only when legacy data actually needs to be imported.
 
 If the updater cannot write the deployment files because the old container was mounted without access to the project directory, replace `docker-compose.yml` with the latest one from this repository and run `docker compose up -d` once. After that, future online updates can update the compose file automatically.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -262,7 +262,7 @@ auto-update:
 
 CliRelay 通过 Ent ORM 使用 PostgreSQL 15+ 作为运行时主数据库。Redis 7+ 只负责缓存、锁、限流、队列和可重建快照。仓库内的 Docker Compose 会自动启动这两个服务，并通过生成的 `.env` 注入容器内连接地址。
 
-如果旧 Docker 部署还停留在 SQLite-only compose，在 `/manage/system` 里触发在线更新时，updater 会先升级 `docker-compose.yml` 和 `.env`，但不会立刻重启业务容器。升级会补上 `clirelay-init`、`clirelay-migrate`、PostgreSQL、Redis 和 updater 服务，保留原应用服务继续运行，先启动 PostgreSQL/Redis，实时输出 SQLite 迁移进度，并且只在迁移成功后才重建业务容器。SQLite 文件会原样保留。
+如果旧 Docker 部署还停留在 SQLite-only compose，在 `/manage/system` 里触发在线更新时，updater 会先升级 `docker-compose.yml` 和 `.env`，补上 `clirelay-init`、PostgreSQL、Redis 和 updater 服务，然后启动 PostgreSQL/Redis 并重建业务容器。SQLite 文件会原样保留；如确实需要导入旧库，请使用下面的手工迁移命令。
 
 如果旧容器因为挂载方式太老，导致 updater 无法写回部署文件，请先把 `docker-compose.yml` 替换成仓库最新版，再执行一次 `docker compose up -d`。完成后，后续在线更新就可以自动更新 compose 文件。
 

--- a/cmd/updater/compose_migrate.go
+++ b/cmd/updater/compose_migrate.go
@@ -2,23 +2,6 @@ package main
 
 import "os"
 
-func migrateComposeService(target map[string]any, image string) map[string]any {
-	return map[string]any{
-		"image":       "${CLI_PROXY_IMAGE:-" + image + "}",
-		"command":     []any{"migrate-sqlite-to-postgres.sh"},
-		"entrypoint":  sourceEnvEntrypoint(),
-		"environment": withoutEnvKeys(target["environment"], "CLIRELAY_SQLITE_AUTO_MIGRATE"),
-		"volumes":     target["volumes"],
-		"depends_on": map[string]any{
-			"clirelay-init": map[string]any{"condition": "service_completed_successfully"},
-			"postgres":      map[string]any{"condition": "service_healthy"},
-			"redis":         map[string]any{"condition": "service_healthy"},
-		},
-		"healthcheck": map[string]any{"disable": true},
-		"restart":     "no",
-	}
-}
-
 func composeFileHasService(path string, service string) bool {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -579,16 +579,11 @@ func runComposeUpdate(ctx context.Context, composeFile string, envFile string, p
 	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "pull", service); err != nil {
 		return err
 	}
-	if composeFileHasService(composeFile, "clirelay-migrate") {
-		reporter.Stage("migrating", "starting PostgreSQL/Redis before data migration check")
+	if composeFileHasService(composeFile, "postgres") && composeFileHasService(composeFile, "redis") {
+		reporter.Stage("restarting", "starting runtime dependencies")
 		if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "postgres", "redis"); err != nil {
 			return err
 		}
-		reporter.Stage("migrating", "checking runtime data migration before service restart")
-		if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "run", "--rm", "clirelay-migrate"); err != nil {
-			return err
-		}
-		reporter.Stage("migrating", "runtime data migration check finished before service restart")
 	}
 	reporter.Stage("restarting", "recreating service container without restarting dependencies")
 	if err := runDockerCompose(ctx, composeFile, envFile, projectName, reporter, "up", "-d", "--no-deps", "--remove-orphans", service); err != nil {
@@ -611,7 +606,8 @@ func ensureRuntimeDataStackConfig(ctx context.Context, composeFile string, envFi
 	}
 	projectDir := deploymentProjectDir(ctx, composeFile)
 	composeText := string(composeData)
-	if hasComposeService(composeText, "postgres") && hasComposeService(composeText, "redis") && hasComposeService(composeText, "clirelay-init") && hasComposeService(composeText, "clirelay-migrate") {
+	hasRuntimeStack := hasComposeService(composeText, "postgres") && hasComposeService(composeText, "redis") && hasComposeService(composeText, "clirelay-init")
+	if hasRuntimeStack && !hasComposeService(composeText, "clirelay-migrate") {
 		if err := ensureRuntimeEnvFile(ctx, envFile, projectDir, service, composeAppImage(composeText, service), reporter); err != nil {
 			return envFile, err
 		}
@@ -669,18 +665,17 @@ func upgradeComposeRuntimeStack(composeText string, projectDir string, service s
 	target["volumes"] = appendVolume(target["volumes"], "${CLIRELAY_PROJECT_DIR:-"+projectDir+"}:/clirelay-deploy")
 	targetNetworks := target["networks"]
 	target["depends_on"] = map[string]any{
-		"clirelay-init":    map[string]any{"condition": "service_completed_successfully"},
-		"clirelay-migrate": map[string]any{"condition": "service_completed_successfully"},
-		"postgres":         map[string]any{"condition": "service_healthy"},
-		"redis":            map[string]any{"condition": "service_healthy"},
+		"clirelay-init": map[string]any{"condition": "service_completed_successfully"},
+		"postgres":      map[string]any{"condition": "service_healthy"},
+		"redis":         map[string]any{"condition": "service_healthy"},
 	}
 	services["clirelay-init"] = initComposeService(projectDir, targetName, appImage)
-	services["clirelay-migrate"] = migrateComposeService(target, appImage)
 	services["postgres"] = postgresComposeService()
 	services["redis"] = redisComposeService()
 	services["clirelay-updater"] = updaterComposeService(projectDir, targetName, appImage)
+	delete(services, "clirelay-migrate")
 	if targetNetworks != nil {
-		for _, name := range []string{"clirelay-init", "clirelay-migrate", "postgres", "redis", "clirelay-updater"} {
+		for _, name := range []string{"clirelay-init", "postgres", "redis", "clirelay-updater"} {
 			if generated, ok := stringMap(services[name]); ok {
 				generated["networks"] = targetNetworks
 			}
@@ -717,7 +712,7 @@ func composeAppImage(composeText string, service string) string {
 
 func firstApplicationService(services map[string]any) string {
 	for name := range services {
-		if name != "postgres" && name != "redis" && name != "clirelay-init" && !strings.Contains(name, "updater") {
+		if name != "postgres" && name != "redis" && name != "clirelay-init" && name != "clirelay-migrate" && !strings.Contains(name, "updater") {
 			return name
 		}
 	}

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -636,7 +636,6 @@ func TestRunComposeUpdateRecreatesOnlyTargetService(t *testing.T) {
 	want := []string{
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " pull clirelay",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d postgres redis",
-		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " run --rm clirelay-migrate",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --no-deps --remove-orphans clirelay",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -675,7 +674,6 @@ func TestRunComposeUpdateUsesEnvFileNextToComposeWhenUnset(t *testing.T) {
 	want := []string{
 		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " pull clirelay",
 		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " up -d postgres redis",
-		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " run --rm clirelay-migrate",
 		"compose --project-name cliproxy --env-file " + inferredEnvPath + " -f " + composePath + " up -d --no-deps --remove-orphans clirelay",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -713,7 +711,6 @@ func TestRunComposeUpdateUpgradesLegacySQLiteComposeWithRuntimeStack(t *testing.
 	composeText := string(composeData)
 	for _, want := range []string{
 		"clirelay-init:",
-		"clirelay-migrate:",
 		"postgres:",
 		"redis:",
 		"clirelay-updater:",
@@ -725,6 +722,7 @@ func TestRunComposeUpdateUpgradesLegacySQLiteComposeWithRuntimeStack(t *testing.
 		}
 	}
 	for _, forbidden := range []string{
+		"clirelay-migrate:",
 		"CLIRELAY_UPDATER_TOKEN is required",
 		"POSTGRES_PASSWORD: ${CLIRELAY_POSTGRES_PASSWORD:-cliproxy}",
 	} {
@@ -756,7 +754,6 @@ func TestRunComposeUpdateUpgradesLegacySQLiteComposeWithRuntimeStack(t *testing.
 	want := []string{
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " pull clirelay",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d postgres redis",
-		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " run --rm clirelay-migrate",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --no-deps --remove-orphans clirelay",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -819,10 +816,13 @@ func TestRunComposeUpdateBootstrapsProductionLegacySQLiteStack(t *testing.T) {
 		t.Fatalf("read upgraded compose: %v", err)
 	}
 	upgraded := string(composeData)
-	for _, want := range []string{"cli-proxy-api:", "clirelay-updater:", "clirelay-init:", "clirelay-migrate:", "postgres:", "redis:"} {
+	for _, want := range []string{"cli-proxy-api:", "clirelay-updater:", "clirelay-init:", "postgres:", "redis:"} {
 		if !strings.Contains(upgraded, want) {
 			t.Fatalf("upgraded compose missing %q:\n%s", want, upgraded)
 		}
+	}
+	if strings.Contains(upgraded, "clirelay-migrate:") {
+		t.Fatalf("upgraded compose still contains SQLite migration service:\n%s", upgraded)
 	}
 	if strings.Contains(upgraded, "${CLI_PROXY_IMAGE:-${CLI_PROXY_IMAGE:-") {
 		t.Fatalf("upgraded compose contains nested CLI_PROXY_IMAGE fallback:\n%s", upgraded)
@@ -855,17 +855,6 @@ func TestRunComposeUpdateBootstrapsProductionLegacySQLiteStack(t *testing.T) {
 	}
 	if targetEnv["CLIRELAY_SQLITE_AUTO_MIGRATE"] != "false" {
 		t.Fatalf("target CLIRELAY_SQLITE_AUTO_MIGRATE = %#v, want false", targetEnv["CLIRELAY_SQLITE_AUTO_MIGRATE"])
-	}
-	migrate, ok := stringMap(services["clirelay-migrate"])
-	if !ok {
-		t.Fatalf("migrate service missing:\n%s", upgraded)
-	}
-	migrateEnv, ok := stringMap(migrate["environment"])
-	if !ok {
-		t.Fatalf("migrate environment is not a map:\n%s", upgraded)
-	}
-	if _, ok := migrateEnv["CLIRELAY_SQLITE_AUTO_MIGRATE"]; ok {
-		t.Fatalf("migrate service must not disable SQLite import: %#v", migrateEnv)
 	}
 	updater, ok := stringMap(services["clirelay-updater"])
 	if !ok {
@@ -907,7 +896,6 @@ func TestRunComposeUpdateBootstrapsProductionLegacySQLiteStack(t *testing.T) {
 	want := []string{
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " pull cli-proxy-api",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d postgres redis",
-		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " run --rm clirelay-migrate",
 		"compose --project-name cliproxy --env-file " + envPath + " -f " + composePath + " up -d --no-deps --remove-orphans cli-proxy-api",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -970,19 +958,15 @@ services:
 	if !ok || !containsAnyString(volumes, "${CLIRELAY_PROJECT_DIR:-/opt/clirelay}:/clirelay-deploy") {
 		t.Fatalf("clirelay service missing /clirelay-deploy volume: %#v\n%s", clirelay["volumes"], upgraded)
 	}
-	for _, name := range []string{"clirelay-init", "clirelay-migrate", "postgres", "redis", "clirelay-updater"} {
+	for _, name := range []string{"clirelay-init", "postgres", "redis", "clirelay-updater"} {
 		if _, ok := services[name]; !ok {
 			t.Fatalf("upgraded compose missing service %s:\n%s", name, upgraded)
 		}
 	}
-	migrate, ok := stringMap(services["clirelay-migrate"])
-	if !ok {
-		t.Fatalf("clirelay-migrate service not found:\n%s", upgraded)
+	if _, ok := services["clirelay-migrate"]; ok {
+		t.Fatalf("upgraded compose still contains SQLite migration service:\n%s", upgraded)
 	}
-	if !reflect.DeepEqual(migrate["command"], []any{"migrate-sqlite-to-postgres.sh"}) {
-		t.Fatalf("clirelay-migrate command = %#v, want migrate script\n%s", migrate["command"], upgraded)
-	}
-	for _, name := range []string{"clirelay-init", "clirelay-migrate", "clirelay-updater"} {
+	for _, name := range []string{"clirelay-init", "clirelay-updater"} {
 		service, ok := stringMap(services[name])
 		if !ok {
 			t.Fatalf("%s service not found:\n%s", name, upgraded)
@@ -1029,7 +1013,7 @@ networks:
 		t.Fatalf("target service missing:\n%s", upgraded)
 	}
 	wantNetworks := target["networks"]
-	for _, name := range []string{"postgres", "redis", "clirelay-migrate", "clirelay-updater"} {
+	for _, name := range []string{"postgres", "redis", "clirelay-updater"} {
 		service, ok := stringMap(services[name])
 		if !ok {
 			t.Fatalf("service %s missing:\n%s", name, upgraded)
@@ -1070,10 +1054,13 @@ func TestEnsureRuntimeDataStackConfigUpgradesStackWithoutInitService(t *testing.
 		t.Fatalf("read compose: %v", err)
 	}
 	upgraded := string(upgradedData)
-	for _, want := range []string{"clirelay-init:", "clirelay-migrate:", "/clirelay-deploy/.env", "service_completed_successfully"} {
+	for _, want := range []string{"clirelay-init:", "/clirelay-deploy/.env", "service_completed_successfully"} {
 		if !strings.Contains(upgraded, want) {
 			t.Fatalf("compose missing %q:\n%s", want, upgraded)
 		}
+	}
+	if strings.Contains(upgraded, "clirelay-migrate:") {
+		t.Fatalf("compose still contains SQLite migration service:\n%s", upgraded)
 	}
 	if strings.Contains(upgraded, "CLIRELAY_UPDATER_TOKEN is required") {
 		t.Fatalf("compose still requires updater token:\n%s", upgraded)
@@ -1086,6 +1073,47 @@ func TestEnsureRuntimeDataStackConfigUpgradesStackWithoutInitService(t *testing.
 		if !strings.Contains(string(envData), want) {
 			t.Fatalf("env missing %q:\n%s", want, envData)
 		}
+	}
+}
+
+func TestEnsureRuntimeDataStackConfigRemovesLegacyMigrationService(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	envPath := filepath.Join(dir, ".env")
+	composeText := `services:
+  clirelay:
+    image: ghcr.io/kittors/clirelay:dev
+    depends_on:
+      clirelay-migrate:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+  clirelay-init:
+    image: ghcr.io/kittors/clirelay:dev
+  clirelay-migrate:
+    image: ghcr.io/kittors/clirelay:dev
+    command: ["migrate-sqlite-to-postgres.sh"]
+  postgres:
+    image: postgres:15-alpine
+  redis:
+    image: redis:7-alpine
+`
+	if err := os.WriteFile(composePath, []byte(composeText), 0o644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+
+	if _, err := ensureRuntimeDataStackConfig(context.Background(), composePath, envPath, "clirelay", updaterRunReporter{}); err != nil {
+		t.Fatalf("ensureRuntimeDataStackConfig failed: %v", err)
+	}
+	upgradedData, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("read compose: %v", err)
+	}
+	upgraded := string(upgradedData)
+	if strings.Contains(upgraded, "clirelay-migrate") || strings.Contains(upgraded, "migrate-sqlite-to-postgres.sh") {
+		t.Fatalf("compose still contains legacy SQLite migration wiring:\n%s", upgraded)
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,41 +56,11 @@ services:
     depends_on:
       clirelay-init:
         condition: service_completed_successfully
-      clirelay-migrate:
-        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
     restart: unless-stopped
-
-  clirelay-migrate:
-    image: ${CLI_PROXY_IMAGE:-ghcr.io/kittors/clirelay:latest}
-    pull_policy: ${CLI_PROXY_PULL_POLICY:-always}
-    command: ["migrate-sqlite-to-postgres.sh"]
-    entrypoint: ["sh", "-c", "set -a; . /clirelay-deploy/.env; set +a; exec docker-entrypoint.sh \"$@\"", "--"]
-    environment:
-      DEPLOY: ${DEPLOY:-}
-      CLIRELAY_LOCALE: ${CLIRELAY_LOCALE:-zh}
-      CLIRELAY_UPDATE_CHANNEL: ${CLIRELAY_UPDATE_CHANNEL:-main}
-      AUTH_PATH: ${AUTH_PATH:-/CLIProxyAPI/auths}
-      LANG: ${CLIRELAY_LANG:-C.UTF-8}
-      LANGUAGE: ${CLIRELAY_LANGUAGE:-en_US:en}
-      LC_ALL: ${CLIRELAY_LANG:-C.UTF-8}
-    volumes:
-      - ${CLI_PROXY_CONFIG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/config.yaml}:/CLIProxyAPI/config.yaml
-      - ${CLI_PROXY_AUTH_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/auths}:${AUTH_PATH:-/CLIProxyAPI/auths}
-      - ${CLI_PROXY_LOG_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/logs}:/CLIProxyAPI/logs
-      - ${CLI_PROXY_DATA_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/data}:/CLIProxyAPI/data
-      - ${CLIRELAY_PROJECT_DIR:-${PWD:-.}}:/clirelay-deploy
-    depends_on:
-      clirelay-init:
-        condition: service_completed_successfully
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    restart: "no"
 
   clirelay-updater:
     image: ${CLI_PROXY_IMAGE:-ghcr.io/kittors/clirelay:latest}


### PR DESCRIPTION
## Summary
- remove clirelay-migrate from the normal Docker Compose/update path
- clean legacy clirelay-migrate wiring when the updater rewrites compose files
- keep manual SQLite import documented for true legacy imports

## Verification
- rtk go test ./cmd/updater
- rtk go test .