### PR TITLE
feat: add Cline and Ollama usage queries

### DIFF
--- a/internal/api/handlers/management/cline_config_test.go
+++ b/internal/api/handlers/management/cline_config_test.go
@@ -21,7 +21,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	h := &Handler{cfg: &config.Config{}, configFilePath: configPath}
 
-	putBody := []byte(`[{"api-key":" cline-key ","name":" primary ","prefix":" team ","base-url":" https://api.cline.bot/api/v1/ ","headers":{"X-Test":" yes "},"models":[{"name":" cline-pass/glm-5.2 "}],"excluded-models":[" cline-pass/minimax-m3 "],"vision-fallback-model":" cline-pass/mimo-v2.5-pro "}]`)
+	putBody := []byte(`[{"api-key":" cline-key ","name":" primary ","prefix":" team ","base-url":" https://api.cline.bot/api/v1/ ","headers":{"X-Test":" yes "},"models":[{"name":" cline-pass/glm-5.2 "}],"excluded-models":[" cline-pass/minimax-m3 "],"vision-fallback-model":" cline-pass/mimo-v2.5-pro ","auth-cookie":" session=cline "}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/cline-api-key", bytes.NewReader(putBody))
@@ -41,8 +41,11 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/mimo-v2.5-pro" {
 		t.Fatalf("ClineKey vision fallback after PUT = %+v", h.cfg.ClineKey[0])
 	}
+	if h.cfg.ClineKey[0].AuthCookie != "session=cline" {
+		t.Fatalf("ClineKey auth cookie after PUT = %+v", h.cfg.ClineKey[0])
+	}
 
-	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"cline-pass/qwen3.7-max"}],"excluded-models":[" cline-pass/deepseek-v4-flash ","*"],"vision-fallback-model":" cline-pass/qwen3.7-vl "}}`)
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"cline-pass/qwen3.7-max"}],"excluded-models":[" cline-pass/deepseek-v4-flash ","*"],"vision-fallback-model":" cline-pass/qwen3.7-vl ","auth-cookie":" session=next "}}`)
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/cline-api-key", bytes.NewReader(patchBody))
@@ -50,7 +53,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 0 || len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if h.cfg.ClineKey[0].Name != "secondary" || h.cfg.ClineKey[0].BaseURL != config.DefaultClineBaseURL || len(h.cfg.ClineKey[0].Models) != 0 || len(h.cfg.ClineKey[0].ExcludedModels) != 1 || h.cfg.ClineKey[0].ExcludedModels[0] != "*" || h.cfg.ClineKey[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" || h.cfg.ClineKey[0].AuthCookie != "session=next" {
 		t.Fatalf("ClineKey after PATCH = %+v", h.cfg.ClineKey[0])
 	}
 
@@ -67,7 +70,7 @@ func TestClineKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultClineBaseURL || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "cline-pass/qwen3.7-vl" || getBody.Items[0].AuthCookie != "session=next" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -151,6 +151,7 @@ func sanitizeConfigForAPI(cfg *config.Config) *config.Config {
 		copy.ClineKey[i].Name = maskName(copy.ClineKey[i].Name)
 		copy.ClineKey[i].BaseURL = maskBaseURL(copy.ClineKey[i].BaseURL)
 		copy.ClineKey[i].ProxyURL = maskBaseURL(copy.ClineKey[i].ProxyURL)
+		copy.ClineKey[i].AuthCookie = maskKey(copy.ClineKey[i].AuthCookie)
 		copy.ClineKey[i].ExcludedModels = nil
 	}
 
@@ -160,6 +161,7 @@ func sanitizeConfigForAPI(cfg *config.Config) *config.Config {
 		copy.OllamaCloudKey[i].Name = maskName(copy.OllamaCloudKey[i].Name)
 		copy.OllamaCloudKey[i].BaseURL = maskBaseURL(copy.OllamaCloudKey[i].BaseURL)
 		copy.OllamaCloudKey[i].ProxyURL = maskBaseURL(copy.OllamaCloudKey[i].ProxyURL)
+		copy.OllamaCloudKey[i].AuthCookie = maskKey(copy.OllamaCloudKey[i].AuthCookie)
 		copy.OllamaCloudKey[i].ExcludedModels = nil
 	}
 

--- a/internal/api/handlers/management/config_basic_test.go
+++ b/internal/api/handlers/management/config_basic_test.go
@@ -131,6 +131,24 @@ func TestSanitizeConfigForAPI(t *testing.T) {
 				ExcludedModels: []string{"minimax-m2.5"},
 			},
 		},
+		ClineKey: []config.ClineKey{
+			{
+				APIKey:         "sk-clineXXXX1234000000",
+				Name:           "ClinePass 渠道",
+				BaseURL:        "https://api.cline.bot/api/v1",
+				AuthCookie:     "cline-cookie-secret",
+				ExcludedModels: []string{"cline-pass/old-model"},
+			},
+		},
+		OllamaCloudKey: []config.OllamaCloudKey{
+			{
+				APIKey:         "sk-ollamaXXXX1234000000",
+				Name:           "Ollama Cloud 渠道",
+				BaseURL:        "https://ollama.com",
+				AuthCookie:     "ollama-cookie-secret",
+				ExcludedModels: []string{"old-model"},
+			},
+		},
 		OAuthModelAlias: map[string][]config.OAuthModelAlias{
 			"antigravity": {
 				{Name: "rev19-uic3-1p", Alias: "gemini-2.5-computer-use-preview"},
@@ -219,6 +237,17 @@ func TestSanitizeConfigForAPI(t *testing.T) {
 		}
 		if c.AuthCookie == "auth-cookie-secret" {
 			t.Error("OpenCodeGoKey: auth-cookie not masked")
+		}
+	}
+
+	for _, c := range sanitized.ClineKey {
+		if c.AuthCookie == "cline-cookie-secret" {
+			t.Error("ClineKey: auth-cookie not masked")
+		}
+	}
+	for _, c := range sanitized.OllamaCloudKey {
+		if c.AuthCookie == "ollama-cookie-secret" {
+			t.Error("OllamaCloudKey: auth-cookie not masked")
 		}
 	}
 

--- a/internal/api/handlers/management/ollama_cloud_config_test.go
+++ b/internal/api/handlers/management/ollama_cloud_config_test.go
@@ -21,7 +21,7 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	}
 	h := &Handler{cfg: &config.Config{}, configFilePath: configPath}
 
-	putBody := []byte(`[{"api-key":" ollama-key ","name":" primary ","prefix":" team ","base-url":" https://ollama.com/ ","headers":{"X-Test":" yes "},"models":[{"name":" gpt-oss:120b "}],"excluded-models":[" gpt-oss:20b "],"vision-fallback-model":" gpt-oss:120b "}]`)
+	putBody := []byte(`[{"api-key":" ollama-key ","name":" primary ","prefix":" team ","base-url":" https://ollama.com/ ","headers":{"X-Test":" yes "},"models":[{"name":" gpt-oss:120b "}],"excluded-models":[" gpt-oss:20b "],"vision-fallback-model":" gpt-oss:120b ","auth-cookie":" ollama_session=ok "}]`)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/ollama-cloud-api-key", bytes.NewReader(putBody))
@@ -41,8 +41,11 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	if h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:120b" {
 		t.Fatalf("OllamaCloudKey vision fallback after PUT = %+v", h.cfg.OllamaCloudKey[0])
 	}
+	if h.cfg.OllamaCloudKey[0].AuthCookie != "ollama_session=ok" {
+		t.Fatalf("OllamaCloudKey auth cookie after PUT = %+v", h.cfg.OllamaCloudKey[0])
+	}
 
-	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"gpt-oss:20b"}],"excluded-models":[" gpt-oss:120b ","*"],"vision-fallback-model":" gpt-oss:20b "}}`)
+	patchBody := []byte(`{"index":0,"value":{"name":"secondary","base-url":"","models":[{"name":"gpt-oss:20b"}],"excluded-models":[" gpt-oss:120b ","*"],"vision-fallback-model":" gpt-oss:20b ","auth-cookie":" ollama_session=next "}}`)
 	w = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/ollama-cloud-api-key", bytes.NewReader(patchBody))
@@ -50,7 +53,7 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
 	}
-	if h.cfg.OllamaCloudKey[0].Name != "secondary" || h.cfg.OllamaCloudKey[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(h.cfg.OllamaCloudKey[0].Models) != 0 || len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 1 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "*" || h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:20b" {
+	if h.cfg.OllamaCloudKey[0].Name != "secondary" || h.cfg.OllamaCloudKey[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(h.cfg.OllamaCloudKey[0].Models) != 0 || len(h.cfg.OllamaCloudKey[0].ExcludedModels) != 1 || h.cfg.OllamaCloudKey[0].ExcludedModels[0] != "*" || h.cfg.OllamaCloudKey[0].VisionFallbackModel != "gpt-oss:20b" || h.cfg.OllamaCloudKey[0].AuthCookie != "ollama_session=next" {
 		t.Fatalf("OllamaCloudKey after PATCH = %+v", h.cfg.OllamaCloudKey[0])
 	}
 
@@ -67,7 +70,7 @@ func TestOllamaCloudKeyManagementPutGetPatchDelete(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &getBody); err != nil {
 		t.Fatalf("decode GET body: %v", err)
 	}
-	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "gpt-oss:20b" {
+	if len(getBody.Items) != 1 || getBody.Items[0].Name != "secondary" || getBody.Items[0].BaseURL != config.DefaultOllamaCloudBaseURL || len(getBody.Items[0].Models) != 0 || len(getBody.Items[0].ExcludedModels) != 1 || getBody.Items[0].ExcludedModels[0] != "*" || getBody.Items[0].VisionFallbackModel != "gpt-oss:20b" || getBody.Items[0].AuthCookie != "ollama_session=next" {
 		t.Fatalf("GET body = %+v", getBody)
 	}
 

--- a/internal/api/handlers/management/opencode_go_usage.go
+++ b/internal/api/handlers/management/opencode_go_usage.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 	"html"
 	"io"
 	"math"
@@ -19,8 +20,11 @@ import (
 
 var (
 	openCodeGoConsoleBaseURL = "https://opencode.ai"
-	openCodeGoUsagePattern   = regexp.MustCompile(`(?i)(Rolling|Weekly|Monthly)\s+Usage\s+([0-9]{1,3})%\s+Resets\s+in\s+`)
+	clineUsageAPIBaseURL     = "https://api.cline.bot"
+	ollamaCloudSettingsURL   = "https://ollama.com/settings"
 	openCodeGoNumberPattern  = `(-?\d+(?:\.\d+)?)`
+	openCodeGoUsagePattern   = regexp.MustCompile(`(?i)(Rolling|Weekly|Monthly)\s+Usage\s+([0-9]{1,3})%\s+Resets\s+in\s+`)
+	ollamaCloudUsagePattern  = regexp.MustCompile(`(?i)(Session|Weekly)\s+usage\s+` + openCodeGoNumberPattern + `%\s+used\s+Resets\s+in\s+([^\.]+)`)
 	openCodeGoUsageWindows   = []openCodeGoUsageWindowPattern{
 		{usageType: "rolling", label: "Rolling", pctFirst: regexp.MustCompile(`rollingUsage:\$R\[\d+\]=\{[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*\}`), resetFirst: regexp.MustCompile(`rollingUsage:\$R\[\d+\]=\{[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*\}`)},
 		{usageType: "weekly", label: "Weekly", pctFirst: regexp.MustCompile(`weeklyUsage:\$R\[\d+\]=\{[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*\}`), resetFirst: regexp.MustCompile(`weeklyUsage:\$R\[\d+\]=\{[^}]*resetInSec:` + openCodeGoNumberPattern + `[^}]*usagePercent:` + openCodeGoNumberPattern + `[^}]*\}`)},
@@ -34,10 +38,10 @@ var (
 const openCodeGoWorkspaceIDHint = "OpenCode Go workspace-id must be the /workspace/{id}/go URL segment from the dashboard address bar, usually starting with wrk_; workspace names like Default and server id hashes are not valid"
 
 type openCodeGoUsageItem struct {
-	Type       string `json:"type"`
-	Label      string `json:"label"`
-	Percentage int    `json:"percentage"`
-	ResetsIn   string `json:"resets_in"`
+	Type       string  `json:"type"`
+	Label      string  `json:"label"`
+	Percentage float64 `json:"percentage"`
+	ResetsIn   string  `json:"resets_in"`
 }
 
 type openCodeGoUsageWindowPattern struct {
@@ -56,6 +60,17 @@ type openCodeGoUsageRequest struct {
 	ProxyID     string  `json:"proxy-id"`
 	ProxyURL    string  `json:"proxy-url"`
 	TimeoutSec  float64 `json:"timeout_sec"`
+}
+
+type clineUsageResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Limits []struct {
+			Type        string  `json:"type"`
+			PercentUsed float64 `json:"percentUsed"`
+			ResetsAt    string  `json:"resetsAt"`
+		} `json:"limits"`
+	} `json:"data"`
 }
 
 // QueryOpenCodeGoUsage fetches the OpenCode Go dashboard page and parses usage limits.
@@ -121,6 +136,80 @@ func (h *Handler) QueryOpenCodeGoUsage(c *gin.Context) {
 	})
 }
 
+// QueryClineUsage fetches ClinePass usage limits from the dashboard API.
+func (h *Handler) QueryClineUsage(c *gin.Context) {
+	var body openCodeGoUsageRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+
+	entry := h.findClineEntry(body)
+	authCookie := strings.TrimSpace(body.AuthCookie)
+	proxyID := strings.TrimSpace(body.ProxyID)
+	proxyURL := strings.TrimSpace(body.ProxyURL)
+	if entry != nil {
+		if authCookie == "" {
+			authCookie = strings.TrimSpace(entry.AuthCookie)
+		}
+		if proxyID == "" {
+			proxyID = strings.TrimSpace(entry.ProxyID)
+		}
+		if proxyURL == "" {
+			proxyURL = strings.TrimSpace(entry.ProxyURL)
+		}
+	}
+	authCookie = normalizeDashboardCookie(authCookie)
+	if authCookie == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth-cookie is required"})
+		return
+	}
+
+	items, err := h.fetchClineUsage(c.Request.Context(), authCookie, proxyID, proxyURL, resolveUsageTimeout(body.TimeoutSec))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"usage": items})
+}
+
+// QueryOllamaCloudUsage fetches Ollama Cloud usage from the settings page.
+func (h *Handler) QueryOllamaCloudUsage(c *gin.Context) {
+	var body openCodeGoUsageRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+
+	entry := h.findOllamaCloudEntry(body)
+	authCookie := strings.TrimSpace(body.AuthCookie)
+	proxyID := strings.TrimSpace(body.ProxyID)
+	proxyURL := strings.TrimSpace(body.ProxyURL)
+	if entry != nil {
+		if authCookie == "" {
+			authCookie = strings.TrimSpace(entry.AuthCookie)
+		}
+		if proxyID == "" {
+			proxyID = strings.TrimSpace(entry.ProxyID)
+		}
+		if proxyURL == "" {
+			proxyURL = strings.TrimSpace(entry.ProxyURL)
+		}
+	}
+	authCookie = normalizeDashboardCookie(authCookie)
+	if authCookie == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth-cookie is required"})
+		return
+	}
+
+	items, err := h.fetchOllamaCloudUsage(c.Request.Context(), authCookie, proxyID, proxyURL, resolveUsageTimeout(body.TimeoutSec))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"usage": items})
+}
+
 func (h *Handler) findOpenCodeGoEntry(body openCodeGoUsageRequest) *config.OpenCodeGoKey {
 	if h == nil || h.cfg == nil {
 		return nil
@@ -147,16 +236,60 @@ func (h *Handler) findOpenCodeGoEntry(body openCodeGoUsageRequest) *config.OpenC
 	return nil
 }
 
-func (h *Handler) fetchOpenCodeGoUsage(ctx context.Context, workspaceID, authCookie, proxyID, proxyURL string, timeout time.Duration) ([]openCodeGoUsageItem, error) {
-	client := util.NewHTTPClient(timeout)
-	if h != nil && h.cfg != nil {
-		if resolved := strings.TrimSpace(h.cfg.ResolveProxyURL(proxyID, proxyURL)); resolved != "" {
-			if transport := util.BuildProxyTransport(resolved, h.cfg.PreferIPv4); transport != nil {
-				client.Transport = transport
+func (h *Handler) findClineEntry(body openCodeGoUsageRequest) *config.ClineKey {
+	if h == nil || h.cfg == nil {
+		return nil
+	}
+	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.ClineKey) {
+		return &h.cfg.ClineKey[*body.Index]
+	}
+	apiKey := strings.TrimSpace(body.APIKey)
+	if apiKey != "" {
+		for i := range h.cfg.ClineKey {
+			if strings.TrimSpace(h.cfg.ClineKey[i].APIKey) == apiKey {
+				return &h.cfg.ClineKey[i]
 			}
 		}
 	}
+	name := strings.TrimSpace(body.Name)
+	if name != "" {
+		for i := range h.cfg.ClineKey {
+			if strings.TrimSpace(h.cfg.ClineKey[i].Name) == name {
+				return &h.cfg.ClineKey[i]
+			}
+		}
+	}
+	return nil
+}
 
+func (h *Handler) findOllamaCloudEntry(body openCodeGoUsageRequest) *config.OllamaCloudKey {
+	if h == nil || h.cfg == nil {
+		return nil
+	}
+	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.OllamaCloudKey) {
+		return &h.cfg.OllamaCloudKey[*body.Index]
+	}
+	apiKey := strings.TrimSpace(body.APIKey)
+	if apiKey != "" {
+		for i := range h.cfg.OllamaCloudKey {
+			if strings.TrimSpace(h.cfg.OllamaCloudKey[i].APIKey) == apiKey {
+				return &h.cfg.OllamaCloudKey[i]
+			}
+		}
+	}
+	name := strings.TrimSpace(body.Name)
+	if name != "" {
+		for i := range h.cfg.OllamaCloudKey {
+			if strings.TrimSpace(h.cfg.OllamaCloudKey[i].Name) == name {
+				return &h.cfg.OllamaCloudKey[i]
+			}
+		}
+	}
+	return nil
+}
+
+func (h *Handler) fetchOpenCodeGoUsage(ctx context.Context, workspaceID, authCookie, proxyID, proxyURL string, timeout time.Duration) ([]openCodeGoUsageItem, error) {
+	client := h.usageHTTPClient(timeout, proxyID, proxyURL)
 	pageURL := strings.TrimRight(openCodeGoConsoleBaseURL, "/") + "/workspace/" + url.PathEscape(workspaceID) + "/go"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
 	if err != nil {
@@ -190,6 +323,94 @@ func (h *Handler) fetchOpenCodeGoUsage(ctx context.Context, workspaceID, authCoo
 	return items, nil
 }
 
+func (h *Handler) fetchClineUsage(ctx context.Context, authCookie, proxyID, proxyURL string, timeout time.Duration) ([]openCodeGoUsageItem, error) {
+	reqURL := strings.TrimRight(clineUsageAPIBaseURL, "/") + "/api/v1/users/me/plan/usage-limits"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Cookie", authCookie)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Origin", "https://app.cline.bot")
+	req.Header.Set("Referer", "https://app.cline.bot/")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; CliRelay Cline usage checker)")
+
+	resp, err := h.usageHTTPClient(timeout, proxyID, proxyURL).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, openCodeGoUsageError("Cline dashboard auth cookie is invalid or expired")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, openCodeGoUsageError("Cline usage API returned HTTP " + resp.Status)
+	}
+
+	var payload clineUsageResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	items := parseClineUsageLimits(payload)
+	if len(items) == 0 {
+		return nil, openCodeGoUsageError("Cline usage data was not found")
+	}
+	return items, nil
+}
+
+func (h *Handler) fetchOllamaCloudUsage(ctx context.Context, authCookie, proxyID, proxyURL string, timeout time.Duration) ([]openCodeGoUsageItem, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ollamaCloudSettingsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Cookie", authCookie)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; CliRelay Ollama usage checker)")
+
+	resp, err := h.usageHTTPClient(timeout, proxyID, proxyURL).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, openCodeGoUsageError("Ollama dashboard auth cookie is invalid or expired")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, openCodeGoUsageError("Ollama settings page returned HTTP " + resp.Status)
+	}
+	items := parseOllamaCloudUsageHTML(string(body))
+	if len(items) == 0 {
+		text := strings.ToLower(stripOpenCodeGoHTML(string(body)))
+		if strings.Contains(text, "sign in") || strings.Contains(text, "log in") {
+			return nil, openCodeGoUsageError("Ollama dashboard auth cookie is invalid or expired")
+		}
+		return nil, openCodeGoUsageError("Ollama usage data was not found on the settings page")
+	}
+	return items, nil
+}
+
+func (h *Handler) usageHTTPClient(timeout time.Duration, proxyID, proxyURL string) *http.Client {
+	client := util.NewHTTPClient(timeout)
+	if h != nil && h.cfg != nil {
+		if resolved := strings.TrimSpace(h.cfg.ResolveProxyURL(proxyID, proxyURL)); resolved != "" {
+			if transport := util.BuildProxyTransport(resolved, h.cfg.PreferIPv4); transport != nil {
+				client.Transport = transport
+			}
+		}
+	}
+	return client
+}
+
 type openCodeGoUsageError string
 
 func (e openCodeGoUsageError) Error() string { return string(e) }
@@ -213,6 +434,31 @@ func normalizeOpenCodeGoAuthCookie(raw string) string {
 		return ""
 	}
 	return raw
+}
+
+func normalizeDashboardCookie(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsAny(raw, "\r\n") {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(raw), "cookie:") {
+		raw = strings.TrimSpace(raw[len("cookie:"):])
+	}
+	return raw
+}
+
+func resolveUsageTimeout(timeoutSec float64) time.Duration {
+	timeout := 20 * time.Second
+	if timeoutSec > 0 {
+		timeout = time.Duration(timeoutSec * float64(time.Second))
+		if timeout < 3*time.Second {
+			timeout = 3 * time.Second
+		}
+		if timeout > 60*time.Second {
+			timeout = 60 * time.Second
+		}
+	}
+	return timeout
 }
 
 func normalizeOpenCodeGoWorkspaceID(raw string) (string, error) {
@@ -284,7 +530,7 @@ func parseOpenCodeGoUsageHTML(body string) []openCodeGoUsageItem {
 		items = append(items, openCodeGoUsageItem{
 			Type:       strings.ToLower(label),
 			Label:      label,
-			Percentage: percentage,
+			Percentage: float64(percentage),
 			ResetsIn:   strings.TrimSpace(text[match[1]:resetEnd]),
 		})
 	}
@@ -301,7 +547,7 @@ func parseOpenCodeGoHydrationUsage(body string) []openCodeGoUsageItem {
 		items = append(items, openCodeGoUsageItem{
 			Type:       window.usageType,
 			Label:      window.label,
-			Percentage: percentage,
+			Percentage: float64(percentage),
 			ResetsIn:   formatOpenCodeGoResetIn(resetInSec),
 		})
 	}
@@ -309,6 +555,84 @@ func parseOpenCodeGoHydrationUsage(body string) []openCodeGoUsageItem {
 		return nil
 	}
 	return items
+}
+
+func parseClineUsageLimits(payload clineUsageResponse) []openCodeGoUsageItem {
+	items := make([]openCodeGoUsageItem, 0, len(payload.Data.Limits))
+	for _, limit := range payload.Data.Limits {
+		usageType := strings.ToLower(strings.TrimSpace(limit.Type))
+		if usageType == "" {
+			continue
+		}
+		items = append(items, openCodeGoUsageItem{
+			Type:       usageType,
+			Label:      labelClineUsageType(usageType),
+			Percentage: clampUsagePercentage(limit.PercentUsed),
+			ResetsIn:   formatResetAt(limit.ResetsAt),
+		})
+	}
+	return items
+}
+
+func labelClineUsageType(usageType string) string {
+	switch usageType {
+	case "five_hour":
+		return "5-Hour"
+	case "weekly":
+		return "Weekly"
+	case "monthly":
+		return "Monthly"
+	default:
+		return strings.ReplaceAll(usageType, "_", " ")
+	}
+}
+
+func parseOllamaCloudUsageHTML(body string) []openCodeGoUsageItem {
+	text := stripOpenCodeGoHTML(body)
+	matches := ollamaCloudUsagePattern.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	items := make([]openCodeGoUsageItem, 0, len(matches))
+	for _, match := range matches {
+		if len(match) != 4 {
+			continue
+		}
+		percentage, err := strconv.ParseFloat(match[2], 64)
+		if err != nil {
+			continue
+		}
+		label := strings.TrimSpace(match[1])
+		items = append(items, openCodeGoUsageItem{
+			Type:       strings.ToLower(label),
+			Label:      label,
+			Percentage: clampUsagePercentage(percentage),
+			ResetsIn:   strings.TrimSpace(match[3]),
+		})
+	}
+	return items
+}
+
+func clampUsagePercentage(value float64) float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}
+
+func formatResetAt(raw string) string {
+	resetAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	seconds := int64(math.Round(time.Until(resetAt).Seconds()))
+	if seconds < 0 {
+		seconds = 0
+	}
+	return formatOpenCodeGoResetIn(seconds)
 }
 
 func parseOpenCodeGoHydrationWindow(body string, window openCodeGoUsageWindowPattern) (int, int64, bool) {

--- a/internal/api/handlers/management/opencode_go_usage_test.go
+++ b/internal/api/handlers/management/opencode_go_usage_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -101,6 +102,24 @@ func TestNormalizeOpenCodeGoWorkspaceIDRejectsNamesAndServerIDs(t *testing.T) {
 	}
 }
 
+func TestParseOllamaCloudUsageHTML(t *testing.T) {
+	html := `<html><body>
+		<div>Session usage <strong>0% used</strong><span>Resets in 4 hours.</span></div>
+		<div>Weekly usage <strong>1.6% used</strong><span>Resets in 4 days.</span></div>
+	</body></html>`
+
+	items := parseOllamaCloudUsageHTML(html)
+	if len(items) != 2 {
+		t.Fatalf("usage item count = %d, want 2: %+v", len(items), items)
+	}
+	if items[0].Type != "session" || items[0].Percentage != 0 || items[0].ResetsIn != "4 hours" {
+		t.Fatalf("session item = %+v", items[0])
+	}
+	if items[1].Type != "weekly" || items[1].Percentage != 1.6 || items[1].ResetsIn != "4 days" {
+		t.Fatalf("weekly item = %+v", items[1])
+	}
+}
+
 func TestQueryOpenCodeGoUsageFetchesDashboard(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -192,6 +211,102 @@ func TestQueryOpenCodeGoUsageFetchesHydrationDashboard(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 	if len(decoded.Usage) != 3 || decoded.Usage[0].Percentage != 7 || decoded.Usage[2].ResetsIn != "1 day" {
+		t.Fatalf("response = %+v", decoded)
+	}
+}
+
+func TestQueryClineUsageFetchesDashboardAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	resetAt := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339Nano)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/users/me/plan/usage-limits" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Cookie"); got != "session=cline" {
+			t.Fatalf("cookie = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"limits":[{"type":"five_hour","percentUsed":2,"resetsAt":"` + resetAt + `"},{"type":"weekly","percentUsed":3,"resetsAt":"` + resetAt + `"},{"type":"monthly","percentUsed":39,"resetsAt":"` + resetAt + `"}]},"success":true}`))
+	}))
+	defer upstream.Close()
+
+	prevBaseURL := clineUsageAPIBaseURL
+	clineUsageAPIBaseURL = upstream.URL
+	defer func() { clineUsageAPIBaseURL = prevBaseURL }()
+
+	h := &Handler{cfg: &config.Config{
+		ClineKey: []config.ClineKey{{
+			APIKey:     "sk-cline",
+			Name:       "ClinePass",
+			AuthCookie: "Cookie: session=cline",
+		}},
+	}}
+
+	body := []byte(`{"index":0}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/cline-api-key/usage", bytes.NewReader(body))
+
+	h.QueryClineUsage(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var decoded struct {
+		Usage []openCodeGoUsageItem `json:"usage"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(decoded.Usage) != 3 || decoded.Usage[0].Type != "five_hour" || decoded.Usage[2].Percentage != 39 {
+		t.Fatalf("response = %+v", decoded)
+	}
+}
+
+func TestQueryOllamaCloudUsageFetchesSettingsPage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/settings" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Cookie"); got != "ollama_session=ok" {
+			t.Fatalf("cookie = %q", got)
+		}
+		_, _ = w.Write([]byte(`Session usage 0% used Resets in 4 hours. Weekly usage 1.6% used Resets in 4 days.`))
+	}))
+	defer upstream.Close()
+
+	prevSettingsURL := ollamaCloudSettingsURL
+	ollamaCloudSettingsURL = upstream.URL + "/settings"
+	defer func() { ollamaCloudSettingsURL = prevSettingsURL }()
+
+	h := &Handler{cfg: &config.Config{
+		OllamaCloudKey: []config.OllamaCloudKey{{
+			APIKey:     "sk-ollama",
+			Name:       "Ollama Cloud",
+			AuthCookie: "ollama_session=ok",
+		}},
+	}}
+
+	body := []byte(`{"index":0}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/ollama-cloud-api-key/usage", bytes.NewReader(body))
+
+	h.QueryOllamaCloudUsage(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var decoded struct {
+		Usage []openCodeGoUsageItem `json:"usage"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(decoded.Usage) != 2 || decoded.Usage[0].Type != "session" || decoded.Usage[1].Percentage != 1.6 {
 		t.Fatalf("response = %+v", decoded)
 	}
 }

--- a/internal/api/routes/management_keys_routes.go
+++ b/internal/api/routes/management_keys_routes.go
@@ -48,11 +48,13 @@ func registerManagementProviderRoutes(group *gin.RouterGroup, h *managementhandl
 	group.PUT("/cline-api-key", keys.PutClineKeys)
 	group.PATCH("/cline-api-key", keys.PatchClineKey)
 	group.DELETE("/cline-api-key", keys.DeleteClineKey)
+	group.POST("/cline-api-key/usage", h.QueryClineUsage)
 
 	group.GET("/ollama-cloud-api-key", keys.GetOllamaCloudKeys)
 	group.PUT("/ollama-cloud-api-key", keys.PutOllamaCloudKeys)
 	group.PATCH("/ollama-cloud-api-key", keys.PatchOllamaCloudKey)
 	group.DELETE("/ollama-cloud-api-key", keys.DeleteOllamaCloudKey)
+	group.POST("/ollama-cloud-api-key/usage", h.QueryOllamaCloudUsage)
 
 	group.GET("/codex-api-key", keys.GetCodexKeys)
 	group.PUT("/codex-api-key", keys.PutCodexKeys)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -25,7 +25,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 226; got != want {
+	if got, want := len(routes), 228; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -48,10 +48,12 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"PUT /v0/management/cline-api-key",
 		"PATCH /v0/management/cline-api-key",
 		"DELETE /v0/management/cline-api-key",
+		"POST /v0/management/cline-api-key/usage",
 		"GET /v0/management/ollama-cloud-api-key",
 		"PUT /v0/management/ollama-cloud-api-key",
 		"PATCH /v0/management/ollama-cloud-api-key",
 		"DELETE /v0/management/ollama-cloud-api-key",
+		"POST /v0/management/ollama-cloud-api-key/usage",
 		"GET /v0/management/auth-files/models",
 		"GET /v0/management/image-generation/size-presets",
 		"PUT /v0/management/image-generation/size-presets",
@@ -263,6 +265,8 @@ func expectedManagementRoutes() []string {
 		"POST /v0/management/model-configs",
 		"POST /v0/management/model-openrouter-sync/run",
 		"POST /v0/management/oauth-callback",
+		"POST /v0/management/cline-api-key/usage",
+		"POST /v0/management/ollama-cloud-api-key/usage",
 		"POST /v0/management/opencode-go-api-key/usage",
 		"POST /v0/management/proxy-pool/check",
 		"POST /v0/management/public/ccswitch-import-configs",

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -289,6 +289,7 @@ func (cfg *Config) SanitizeClineKeys() {
 			entry.Models = nil
 		}
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+		entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
 		out = append(out, entry)
 	}
 	cfg.ClineKey = out
@@ -354,6 +355,7 @@ func (cfg *Config) SanitizeOllamaCloudKeys() {
 			entry.Models = nil
 		}
 		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+		entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
 		out = append(out, entry)
 	}
 	cfg.OllamaCloudKey = out

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -312,6 +312,9 @@ type ClineKey struct {
 
 	// VisionFallbackModel is used for image requests whose requested model lacks vision support.
 	VisionFallbackModel string `yaml:"vision-fallback-model,omitempty" json:"vision-fallback-model,omitempty"`
+
+	// AuthCookie stores the Cline dashboard cookie used for usage checks.
+	AuthCookie string `yaml:"-" json:"auth-cookie,omitempty"`
 }
 
 type ClineModel struct {
@@ -361,6 +364,9 @@ type OllamaCloudKey struct {
 
 	// VisionFallbackModel is used for image requests whose requested model lacks vision support.
 	VisionFallbackModel string `yaml:"vision-fallback-model,omitempty" json:"vision-fallback-model,omitempty"`
+
+	// AuthCookie stores the Ollama dashboard cookie used for usage checks.
+	AuthCookie string `yaml:"-" json:"auth-cookie,omitempty"`
 }
 
 func (k OllamaCloudKey) GetAPIKey() string  { return k.APIKey }

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -367,6 +367,7 @@ type ClinePatch struct {
 	Models         *[]config.ClineModel `json:"models"`
 	ExcludedModels *[]string            `json:"excluded-models"`
 	VisionFallback *string              `json:"vision-fallback-model"`
+	AuthCookie     *string              `json:"auth-cookie"`
 }
 
 func (s *Service) ClineKeys() []config.ClineKey {
@@ -470,6 +471,9 @@ func (s *Service) PatchClineKey(index *int, apiKey *string, name *string, patch 
 	if patch.VisionFallback != nil {
 		entry.VisionFallbackModel = strings.TrimSpace(*patch.VisionFallback)
 	}
+	if patch.AuthCookie != nil {
+		entry.AuthCookie = strings.TrimSpace(*patch.AuthCookie)
+	}
 	NormalizeClineKey(&entry)
 	if entry.APIKey == "" {
 		return ErrProviderAPIKeyRequired
@@ -539,6 +543,7 @@ type OllamaCloudPatch struct {
 	Models         *[]config.OllamaCloudModel `json:"models"`
 	ExcludedModels *[]string                  `json:"excluded-models"`
 	VisionFallback *string                    `json:"vision-fallback-model"`
+	AuthCookie     *string                    `json:"auth-cookie"`
 }
 
 func (s *Service) OllamaCloudKeys() []config.OllamaCloudKey {
@@ -641,6 +646,9 @@ func (s *Service) PatchOllamaCloudKey(index *int, apiKey *string, name *string, 
 	}
 	if patch.VisionFallback != nil {
 		entry.VisionFallbackModel = strings.TrimSpace(*patch.VisionFallback)
+	}
+	if patch.AuthCookie != nil {
+		entry.AuthCookie = strings.TrimSpace(*patch.AuthCookie)
 	}
 	NormalizeOllamaCloudKey(&entry)
 	if entry.APIKey == "" {
@@ -784,6 +792,7 @@ func NormalizeClineKey(entry *config.ClineKey) {
 	entry.Models = config.NormalizeClineModels(entry.Models)
 	entry.ExcludedModels = config.NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+	entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
 }
 
 func NormalizedClineKeyEntries(entries []config.ClineKey) []config.ClineKey {
@@ -818,6 +827,7 @@ func NormalizeOllamaCloudKey(entry *config.OllamaCloudKey) {
 	entry.Models = config.NormalizeOllamaCloudModels(entry.Models)
 	entry.ExcludedModels = config.NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
 	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+	entry.AuthCookie = strings.TrimSpace(entry.AuthCookie)
 }
 
 func NormalizedOllamaCloudKeyEntries(entries []config.OllamaCloudKey) []config.OllamaCloudKey {


### PR DESCRIPTION
## Summary
- add management usage endpoints for ClinePass and Ollama Cloud
- persist dashboard auth-cookie for Cline/Ollama runtime config without writing it to static YAML
- mask dashboard cookies in config preview and cover save/query behavior with tests

## Verification
- rtk go test ./internal/api/handlers/management ./internal/api/routes ./internal/config ./internal/management/settings/providers
- isolated temp worktree: git diff --check + same targeted Go test command