### PR TITLE
feat: add xai identity fingerprint support

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -35,6 +35,7 @@ func (h *Handler) GetIdentityFingerprint(c *gin.Context) {
 			Codex:  config.DefaultCodexIdentityFingerprint(),
 			Claude: config.DefaultClaudeIdentityFingerprint(),
 			Gemini: config.DefaultGeminiIdentityFingerprint(),
+			XAI:    config.DefaultXAIIdentityFingerprint(),
 		},
 		Learned:   learned,
 		Effective: effective,
@@ -42,6 +43,7 @@ func (h *Handler) GetIdentityFingerprint(c *gin.Context) {
 			"claude": {Enabled: current.Claude.Enabled, LearnedCount: len(learned["claude"])},
 			"codex":  {Enabled: current.Codex.Enabled, LearnedCount: len(learned["codex"])},
 			"gemini": {Enabled: current.Gemini.Enabled, LearnedCount: len(learned["gemini"])},
+			"xai":    {Enabled: current.XAI.Enabled, LearnedCount: len(learned["xai"])},
 		},
 	})
 }
@@ -56,6 +58,7 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 	body.Codex = config.CleanCodexIdentityFingerprint(body.Codex)
 	body.Claude = config.CleanClaudeIdentityFingerprint(body.Claude)
 	body.Gemini = config.CleanGeminiIdentityFingerprint(body.Gemini)
+	body.XAI = config.CleanXAIIdentityFingerprint(body.XAI)
 	if err := validateCodexIdentityFingerprint(body.Codex); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -65,6 +68,10 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 		return
 	}
 	if err := validateGeminiIdentityFingerprint(body.Gemini); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := validateXAIIdentityFingerprint(body.XAI); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -125,13 +132,15 @@ func (h *Handler) identityFingerprintState(current config.IdentityFingerprintCon
 		"claude": {},
 		"codex":  {},
 		"gemini": {},
+		"xai":    {},
 	}
 	effective := map[string][]identityfingerprint.EffectiveFingerprint{
 		"claude": {},
 		"codex":  {},
 		"gemini": {},
+		"xai":    {},
 	}
-	for _, provider := range []identityfingerprint.Provider{identityfingerprint.ProviderClaude, identityfingerprint.ProviderCodex, identityfingerprint.ProviderGemini} {
+	for _, provider := range []identityfingerprint.Provider{identityfingerprint.ProviderClaude, identityfingerprint.ProviderCodex, identityfingerprint.ProviderGemini, identityfingerprint.ProviderXAI} {
 		records, err := usage.ListIdentityFingerprints(provider, 200)
 		if err != nil {
 			continue
@@ -149,6 +158,9 @@ func (h *Handler) identityFingerprintState(current config.IdentityFingerprintCon
 				effective[key] = append(effective[key], eff)
 			case identityfingerprint.ProviderGemini:
 				_, eff := identityfingerprint.ResolveGemini(current.Gemini, &record)
+				effective[key] = append(effective[key], eff)
+			case identityfingerprint.ProviderXAI:
+				_, eff := identityfingerprint.ResolveXAI(current.XAI, &record)
 				effective[key] = append(effective[key], eff)
 			}
 		}
@@ -232,6 +244,29 @@ func validateGeminiIdentityFingerprint(fp config.GeminiIdentityFingerprintConfig
 	return nil
 }
 
+func validateXAIIdentityFingerprint(fp config.XAIIdentityFingerprintConfig) error {
+	if containsHeaderLineBreak(fp.UserAgent) || containsHeaderLineBreak(fp.GrokConversationID) {
+		return fmt.Errorf("identity fingerprint fields must not contain line breaks")
+	}
+	for key, value := range fp.CustomHeaders {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return fmt.Errorf("custom header name cannot be empty")
+		}
+		if !isHTTPHeaderToken(key) {
+			return fmt.Errorf("invalid custom header name: %s", key)
+		}
+		if isIdentityFingerprintBlockedHeader(key) || isXAIIdentityFingerprintBlockedHeader(key) {
+			return fmt.Errorf("custom header %s is managed by the system", key)
+		}
+		if containsHeaderLineBreak(value) {
+			return fmt.Errorf("custom header %s must not contain line breaks", key)
+		}
+	}
+	return nil
+}
+
 func containsHeaderLineBreak(value string) bool {
 	return strings.ContainsAny(value, "\r\n")
 }
@@ -263,6 +298,15 @@ func isClaudeIdentityFingerprintBlockedHeader(key string) bool {
 func isGeminiIdentityFingerprintBlockedHeader(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
 	case "x-goog-api-client", "client-metadata":
+		return true
+	default:
+		return false
+	}
+}
+
+func isXAIIdentityFingerprintBlockedHeader(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "x-grok-conv-id":
 		return true
 	default:
 		return false

--- a/internal/api/handlers/management/identity_fingerprint_account.go
+++ b/internal/api/handlers/management/identity_fingerprint_account.go
@@ -40,7 +40,7 @@ type identityFingerprintAccountDetail struct {
 func (h *Handler) GetIdentityFingerprintAccount(c *gin.Context) {
 	provider, ok := normalizeIdentityFingerprintProvider(c.Query("provider"))
 	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "provider must be one of claude, codex, gemini"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "provider must be one of claude, codex, gemini, xai"})
 		return
 	}
 	accountKey := strings.TrimSpace(c.Query("account_key"))
@@ -141,6 +141,7 @@ func (h *Handler) currentIdentityFingerprintConfig() config.IdentityFingerprintC
 	current.Codex = config.CleanCodexIdentityFingerprint(current.Codex)
 	current.Claude = config.CleanClaudeIdentityFingerprint(current.Claude)
 	current.Gemini = config.CleanGeminiIdentityFingerprint(current.Gemini)
+	current.XAI = config.CleanXAIIdentityFingerprint(current.XAI)
 	return current
 }
 
@@ -155,6 +156,9 @@ func resolveIdentityFingerprint(current config.IdentityFingerprintConfig, provid
 	case identityfingerprint.ProviderGemini:
 		_, effective := identityfingerprint.ResolveGemini(current.Gemini, learned)
 		return effective, current.Gemini, config.DefaultGeminiIdentityFingerprint()
+	case identityfingerprint.ProviderXAI:
+		_, effective := identityfingerprint.ResolveXAI(current.XAI, learned)
+		return effective, current.XAI, config.DefaultXAIIdentityFingerprint()
 	default:
 		return identityfingerprint.EffectiveFingerprint{}, nil, nil
 	}
@@ -207,6 +211,8 @@ func identityFingerprintSummaryVersion(provider identityfingerprint.Provider, ef
 		if value := identityFingerprintEffectiveField(effective, identityfingerprint.FieldCodexVersion); value != "" {
 			return value
 		}
+	case identityfingerprint.ProviderXAI:
+		return strings.TrimSpace(effective.Version)
 	}
 	return strings.TrimSpace(effective.Version)
 }
@@ -284,6 +290,8 @@ func normalizeIdentityFingerprintProvider(value string) (identityfingerprint.Pro
 		return identityfingerprint.ProviderCodex, true
 	case string(identityfingerprint.ProviderGemini), "google":
 		return identityfingerprint.ProviderGemini, true
+	case string(identityfingerprint.ProviderXAI), "grok":
+		return identityfingerprint.ProviderXAI, true
 	default:
 		return "", false
 	}

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -30,6 +30,7 @@ type IdentityFingerprintConfig struct {
 	Codex  CodexIdentityFingerprintConfig  `yaml:"codex,omitempty" json:"codex,omitempty"`
 	Claude ClaudeIdentityFingerprintConfig `yaml:"claude,omitempty" json:"claude,omitempty"`
 	Gemini GeminiIdentityFingerprintConfig `yaml:"gemini,omitempty" json:"gemini,omitempty"`
+	XAI    XAIIdentityFingerprintConfig    `yaml:"xai,omitempty" json:"xai,omitempty"`
 }
 
 // CodexIdentityFingerprintConfig configures Codex upstream identity headers.
@@ -84,6 +85,14 @@ type GeminiIdentityFingerprintConfig struct {
 	CustomHeaders  map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
 }
 
+// XAIIdentityFingerprintConfig configures Grok/xAI upstream identity headers.
+type XAIIdentityFingerprintConfig struct {
+	Enabled            bool              `yaml:"enabled" json:"enabled"`
+	UserAgent          string            `yaml:"user-agent,omitempty" json:"user-agent,omitempty"`
+	GrokConversationID string            `yaml:"x-grok-conv-id,omitempty" json:"x-grok-conv-id,omitempty"`
+	CustomHeaders      map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+}
+
 // DefaultClaudeIdentityFingerprint returns the recommended Claude Code identity template.
 func DefaultClaudeIdentityFingerprint() ClaudeIdentityFingerprintConfig {
 	cliVersion := DefaultClaudeFingerprintCLIVersion
@@ -113,6 +122,14 @@ func DefaultGeminiIdentityFingerprint() GeminiIdentityFingerprintConfig {
 	}
 }
 
+// DefaultXAIIdentityFingerprint returns the conservative Grok identity template.
+func DefaultXAIIdentityFingerprint() XAIIdentityFingerprintConfig {
+	return XAIIdentityFingerprintConfig{
+		Enabled:       false,
+		CustomHeaders: map[string]string{},
+	}
+}
+
 // SanitizeIdentityFingerprint normalizes provider identity fingerprint config.
 func (cfg *Config) SanitizeIdentityFingerprint() {
 	if cfg == nil {
@@ -121,6 +138,7 @@ func (cfg *Config) SanitizeIdentityFingerprint() {
 	cfg.IdentityFingerprint.Codex = CleanCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex)
 	cfg.IdentityFingerprint.Claude = CleanClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude)
 	cfg.IdentityFingerprint.Gemini = CleanGeminiIdentityFingerprint(cfg.IdentityFingerprint.Gemini)
+	cfg.IdentityFingerprint.XAI = CleanXAIIdentityFingerprint(cfg.IdentityFingerprint.XAI)
 }
 
 // NormalizeCodexIdentityFingerprint trims user input and applies safe defaults
@@ -265,6 +283,21 @@ func CleanGeminiIdentityFingerprint(in GeminiIdentityFingerprintConfig) GeminiId
 	out.UserAgent = strings.TrimSpace(out.UserAgent)
 	out.APIClient = strings.TrimSpace(out.APIClient)
 	out.ClientMetadata = strings.TrimSpace(out.ClientMetadata)
+	out.CustomHeaders = cleanIdentityFingerprintHeaders(out.CustomHeaders)
+	return out
+}
+
+// NormalizeXAIIdentityFingerprint trims user input while preserving empty fields
+// as "automatic learning" markers. xAI has no stable public CLI defaults here.
+func NormalizeXAIIdentityFingerprint(in XAIIdentityFingerprintConfig) XAIIdentityFingerprintConfig {
+	return CleanXAIIdentityFingerprint(in)
+}
+
+// CleanXAIIdentityFingerprint trims explicit overrides while preserving empty fields.
+func CleanXAIIdentityFingerprint(in XAIIdentityFingerprintConfig) XAIIdentityFingerprintConfig {
+	out := in
+	out.UserAgent = strings.TrimSpace(out.UserAgent)
+	out.GrokConversationID = strings.TrimSpace(out.GrokConversationID)
 	out.CustomHeaders = cleanIdentityFingerprintHeaders(out.CustomHeaders)
 	return out
 }

--- a/internal/identityfingerprint/extract.go
+++ b/internal/identityfingerprint/extract.go
@@ -22,6 +22,7 @@ const (
 	FieldCodexBetaFeatures      = "x-codex-beta-features"
 	FieldGeminiAPIClient        = "x-goog-api-client"
 	FieldGeminiClientMetadata   = "client-metadata"
+	FieldXAIGrokConversationID  = "x-grok-conv-id"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 	codexDesktopUARe = regexp.MustCompile(`(?i)\bcodex\s+desktop/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
 	tokenVerRe       = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*codex[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
 	geminiUARe       = regexp.MustCompile(`(?i)^google-api-nodejs-client/([0-9]+(?:\.[0-9]+){0,3})`)
+	xaiTokenVerRe    = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*(?:grok|xai)[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
 )
 
 func ExtractObservation(input LearnInput) (Observation, bool) {
@@ -44,6 +46,8 @@ func ExtractObservation(input LearnInput) (Observation, bool) {
 		return extractCodexObservation(input, headers, observedAt)
 	case ProviderGemini:
 		return extractGeminiObservation(input, headers, observedAt)
+	case ProviderXAI:
+		return extractXAIObservation(input, headers, observedAt)
 	default:
 		return Observation{}, false
 	}
@@ -167,6 +171,39 @@ func extractGeminiObservation(input LearnInput, headers http.Header, observedAt 
 	}, true
 }
 
+func extractXAIObservation(input LearnInput, headers http.Header, observedAt time.Time) (Observation, bool) {
+	ua := strings.TrimSpace(headers.Get("User-Agent"))
+	grokConversationID := strings.TrimSpace(headers.Get("X-Grok-Conv-Id"))
+	product, version := xaiProductVersion(ua)
+	if product == "" && grokConversationID != "" {
+		product = "grok-cli"
+	}
+	if product == "" {
+		return Observation{}, false
+	}
+	fields := map[string]string{}
+	if ua != "" {
+		fields[FieldUserAgent] = ua
+	}
+	if grokConversationID != "" {
+		fields[FieldXAIGrokConversationID] = grokConversationID
+	}
+	if len(fields) == 0 {
+		return Observation{}, false
+	}
+	return Observation{
+		Provider:        ProviderXAI,
+		AccountKey:      strings.TrimSpace(input.AccountKey),
+		AuthSubjectID:   strings.TrimSpace(input.AuthSubjectID),
+		ClientProduct:   product,
+		ClientVariant:   "cli",
+		Version:         version,
+		Fields:          fields,
+		ObservedHeaders: observedHeaders(headers, []string{"User-Agent", "X-Grok-Conv-Id"}),
+		ObservedAt:      observedAt.UTC(),
+	}, true
+}
+
 func MergeObservation(existing *LearnedRecord, obs Observation) MergeResult {
 	if strings.TrimSpace(obs.AccountKey) == "" {
 		return MergeResult{Reason: "missing_account_key"}
@@ -248,6 +285,24 @@ func codexProductVersion(ua string) (string, string) {
 
 	if strings.Contains(strings.ToLower(ua), "codex") {
 		return "codex", ""
+	}
+	return "", ""
+}
+
+func xaiProductVersion(ua string) (string, string) {
+	ua = strings.TrimSpace(ua)
+	if ua == "" {
+		return "", ""
+	}
+	if matches := xaiTokenVerRe.FindStringSubmatch(ua); len(matches) > 0 {
+		return strings.ToLower(matches[1]), matches[2]
+	}
+	lower := strings.ToLower(ua)
+	if strings.Contains(lower, "grok") {
+		return "grok-cli", ""
+	}
+	if strings.Contains(lower, "xai") {
+		return "xai-cli", ""
 	}
 	return "", ""
 }

--- a/internal/identityfingerprint/extract_resolve_test.go
+++ b/internal/identityfingerprint/extract_resolve_test.go
@@ -95,6 +95,28 @@ func TestExtractCodexObservationVersionHeaderOverridesUserAgentVersion(t *testin
 	}
 }
 
+func TestExtractXAIObservationFromGrokHeaders(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("User-Agent", "grok-cli/0.3.1 (darwin arm64)")
+	headers.Set("X-Grok-Conv-Id", "conv-123")
+
+	obs, ok := ExtractObservation(LearnInput{
+		Provider:   ProviderXAI,
+		AccountKey: "acct",
+		Headers:    headers,
+		ObservedAt: time.Date(2026, 7, 9, 1, 2, 3, 0, time.UTC),
+	})
+	if !ok {
+		t.Fatal("ExtractObservation returned false")
+	}
+	if obs.ClientProduct != "grok-cli" || obs.Version != "0.3.1" {
+		t.Fatalf("product/version = %s/%s, want grok-cli/0.3.1", obs.ClientProduct, obs.Version)
+	}
+	if got := obs.Fields[FieldXAIGrokConversationID]; got != "conv-123" {
+		t.Fatalf("x-grok-conv-id = %q, want conv-123", got)
+	}
+}
+
 func TestMergeObservationUpdatesOnlyNewerSameProductAndPreservesMissingFields(t *testing.T) {
 	existing := &LearnedRecord{
 		Provider:      ProviderClaude,
@@ -278,5 +300,29 @@ func TestResolveGeminiUsesLearnedWhenPresetEmpty(t *testing.T) {
 	}
 	if got := effective.Fields[FieldGeminiClientMetadata].Source; got != FieldSourceLearned {
 		t.Fatalf("metadata source = %q, want learned", got)
+	}
+}
+
+func TestResolveXAIUsesLearnedWhenPresetEmpty(t *testing.T) {
+	learned := &LearnedRecord{
+		Provider:      ProviderXAI,
+		AccountKey:    "acct",
+		ClientProduct: "grok-cli",
+		Version:       "0.3.1",
+		Fields: map[string]string{
+			FieldUserAgent:             "grok-cli/0.3.1 (darwin arm64)",
+			FieldXAIGrokConversationID: "conv-123",
+		},
+	}
+
+	fp, effective := ResolveXAI(config.XAIIdentityFingerprintConfig{Enabled: true}, learned)
+	if fp.UserAgent != "grok-cli/0.3.1 (darwin arm64)" || fp.GrokConversationID != "conv-123" {
+		t.Fatalf("resolved xAI fingerprint = %#v, want learned fields", fp)
+	}
+	if effective.Version != "0.3.1" {
+		t.Fatalf("effective version = %q, want learned version", effective.Version)
+	}
+	if got := effective.Fields[FieldUserAgent].Source; got != FieldSourceLearned {
+		t.Fatalf("User-Agent source = %q, want learned", got)
 	}
 }

--- a/internal/identityfingerprint/resolve.go
+++ b/internal/identityfingerprint/resolve.go
@@ -104,6 +104,29 @@ func ResolveGemini(cfg config.GeminiIdentityFingerprintConfig, learned *LearnedR
 	return resolved, effective(ProviderGemini, clean.Enabled, learned, fields)
 }
 
+func ResolveXAI(cfg config.XAIIdentityFingerprintConfig, learned *LearnedRecord) (config.XAIIdentityFingerprintConfig, EffectiveFingerprint) {
+	clean := config.CleanXAIIdentityFingerprint(cfg)
+	defaults := config.DefaultXAIIdentityFingerprint()
+	fields := make(map[string]FieldValue)
+	pick := func(field, preset, learnedValue, defaultValue string) string {
+		value, source := pickField(preset, learnedValue, defaultValue)
+		fields[field] = FieldValue{Value: value, Source: source}
+		return value
+	}
+
+	resolved := config.XAIIdentityFingerprintConfig{
+		Enabled:            clean.Enabled,
+		UserAgent:          pick(FieldUserAgent, clean.UserAgent, learnedField(learned, FieldUserAgent), defaults.UserAgent),
+		GrokConversationID: pick(FieldXAIGrokConversationID, clean.GrokConversationID, learnedField(learned, FieldXAIGrokConversationID), defaults.GrokConversationID),
+		CustomHeaders:      clean.CustomHeaders,
+	}
+	effective := effective(ProviderXAI, clean.Enabled, learned, fields)
+	if learned != nil {
+		effective.Version = strings.TrimSpace(learned.Version)
+	}
+	return resolved, effective
+}
+
 func pickField(preset, learned, fallback string) (string, FieldSource) {
 	if value := strings.TrimSpace(learned); value != "" {
 		return value, FieldSourceLearned

--- a/internal/identityfingerprint/types.go
+++ b/internal/identityfingerprint/types.go
@@ -8,6 +8,7 @@ const (
 	ProviderClaude Provider = "claude"
 	ProviderCodex  Provider = "codex"
 	ProviderGemini Provider = "gemini"
+	ProviderXAI    Provider = "xai"
 )
 
 type FieldSource string

--- a/internal/management/settings/runtimeconfig/spec.go
+++ b/internal/management/settings/runtimeconfig/spec.go
@@ -296,13 +296,15 @@ func Specs() []Spec {
 			Meaningful: func(cfg *config.Config) bool {
 				return codexIdentityFingerprintMeaningful(cfg.IdentityFingerprint.Codex) ||
 					claudeIdentityFingerprintMeaningful(cfg.IdentityFingerprint.Claude) ||
-					geminiIdentityFingerprintMeaningful(cfg.IdentityFingerprint.Gemini)
+					geminiIdentityFingerprintMeaningful(cfg.IdentityFingerprint.Gemini) ||
+					xaiIdentityFingerprintMeaningful(cfg.IdentityFingerprint.XAI)
 			},
 			Value: func(cfg *config.Config) any {
 				return config.IdentityFingerprintConfig{
 					Codex:  config.CleanCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex),
 					Claude: config.CleanClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude),
 					Gemini: config.CleanGeminiIdentityFingerprint(cfg.IdentityFingerprint.Gemini),
+					XAI:    config.CleanXAIIdentityFingerprint(cfg.IdentityFingerprint.XAI),
 				}
 			},
 			Apply: func(cfg *config.Config, raw json.RawMessage) bool {
@@ -314,6 +316,7 @@ func Specs() []Spec {
 				value.Codex = config.CleanCodexIdentityFingerprint(value.Codex)
 				value.Claude = config.CleanClaudeIdentityFingerprint(value.Claude)
 				value.Gemini = config.CleanGeminiIdentityFingerprint(value.Gemini)
+				value.XAI = config.CleanXAIIdentityFingerprint(value.XAI)
 				cfg.IdentityFingerprint = value
 				return true
 			},
@@ -431,6 +434,14 @@ func geminiIdentityFingerprintMeaningful(fp config.GeminiIdentityFingerprintConf
 		strings.TrimSpace(clean.UserAgent) != "" ||
 		strings.TrimSpace(clean.APIClient) != "" ||
 		strings.TrimSpace(clean.ClientMetadata) != "" ||
+		len(clean.CustomHeaders) > 0
+}
+
+func xaiIdentityFingerprintMeaningful(fp config.XAIIdentityFingerprintConfig) bool {
+	clean := config.CleanXAIIdentityFingerprint(fp)
+	return clean.Enabled ||
+		strings.TrimSpace(clean.UserAgent) != "" ||
+		strings.TrimSpace(clean.GrokConversationID) != "" ||
 		len(clean.CustomHeaders) > 0
 }
 

--- a/internal/runtime/executor/identity_fingerprint_runtime_test.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime_test.go
@@ -367,6 +367,47 @@ func TestGeminiCLIHeadersReplayLearnedFingerprintWithoutInboundHeaders(t *testin
 	}
 }
 
+func TestXAIHeadersReplayLearnedFingerprintWithoutInboundHeaders(t *testing.T) {
+	initIdentityFingerprintRuntimeDB(t)
+
+	cfg := &config.Config{
+		IdentityFingerprint: config.IdentityFingerprintConfig{
+			XAI: config.XAIIdentityFingerprintConfig{Enabled: true},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "xai-auth",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"email": "xai-user@example.com",
+			"sub":   "xai-subject",
+		},
+	}
+	inbound := http.Header{}
+	inbound.Set("User-Agent", "grok-cli/0.3.1 (darwin arm64)")
+	inbound.Set("X-Grok-Conv-Id", "conv-123")
+	ctx := contextWithInboundHeaders(http.MethodPost, "/v1/responses", inbound)
+
+	req := httptest.NewRequest(http.MethodPost, "https://api.x.ai/v1/responses", nil)
+	req = req.WithContext(ctx)
+	applyXAIHeaders(req, cfg, auth, "xai-token", true)
+	if got := req.Header.Get("User-Agent"); got != "grok-cli/0.3.1 (darwin arm64)" {
+		t.Fatalf("User-Agent = %q, want learned xAI UA", got)
+	}
+	if got := req.Header.Get("X-Grok-Conv-Id"); got != "conv-123" {
+		t.Fatalf("X-Grok-Conv-Id = %q, want learned xAI conversation id", got)
+	}
+
+	replayReq := httptest.NewRequest(http.MethodPost, "https://api.x.ai/v1/responses", nil)
+	applyXAIHeaders(replayReq, cfg, auth, "xai-token", true)
+	if got := replayReq.Header.Get("User-Agent"); got != "grok-cli/0.3.1 (darwin arm64)" {
+		t.Fatalf("replayed User-Agent = %q, want stored learned xAI UA", got)
+	}
+	if got := replayReq.Header.Get("X-Grok-Conv-Id"); got != "conv-123" {
+		t.Fatalf("replayed X-Grok-Conv-Id = %q, want stored learned xAI conversation id", got)
+	}
+}
+
 func containsAll(value string, needles ...string) bool {
 	for _, needle := range needles {
 		if !strings.Contains(value, needle) {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -35,14 +35,7 @@ func (e *XAIExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth)
 		return nil
 	}
 	token, _ := xaiCreds(auth)
-	if strings.TrimSpace(token) != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	var attrs map[string]string
-	if auth != nil {
-		attrs = auth.Attributes
-	}
-	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	applyXAIHeaders(req, e.cfg, auth, token, false)
 	return nil
 }
 
@@ -81,7 +74,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 	if err != nil {
 		return resp, err
 	}
-	applyXAIHeaders(httpReq, auth, token, true)
+	applyXAIHeaders(httpReq, e.cfg, auth, token, true)
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(endpoint, http.MethodPost, httpReq.Header.Clone(), body)
 
@@ -174,7 +167,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 	if err != nil {
 		return nil, err
 	}
-	applyXAIHeaders(httpReq, auth, token, true)
+	applyXAIHeaders(httpReq, e.cfg, auth, token, true)
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(endpoint, http.MethodPost, httpReq.Header.Clone(), body)
 
@@ -382,7 +375,7 @@ func xaiCreds(auth *cliproxyauth.Auth) (token, baseURL string) {
 	return token, baseURL
 }
 
-func applyXAIHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool) {
+func applyXAIHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.Auth, token string, stream bool) {
 	r.Header.Set("Content-Type", "application/json")
 	if strings.TrimSpace(token) != "" {
 		r.Header.Set("Authorization", "Bearer "+token)
@@ -398,6 +391,9 @@ func applyXAIHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, str
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(r, attrs)
+	if fp, ok := xaiIdentityFingerprint(cfg, auth, r.Context()); ok {
+		applyXAIIdentityFingerprintHeaders(r.Header, fp)
+	}
 }
 
 func xaiMetadataString(meta map[string]any, key string) string {

--- a/internal/runtime/executor/xai_identity_fingerprint.go
+++ b/internal/runtime/executor/xai_identity_fingerprint.go
@@ -1,0 +1,49 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func xaiIdentityFingerprint(cfg *config.Config, auth *cliproxyauth.Auth, ctx context.Context) (config.XAIIdentityFingerprintConfig, bool) {
+	if cfg == nil || !cfg.IdentityFingerprint.XAI.Enabled {
+		return config.XAIIdentityFingerprintConfig{}, false
+	}
+	learned := observeRuntimeIdentityFingerprint(identityfingerprint.ProviderXAI, auth, ctx)
+	resolved, _ := identityfingerprint.ResolveXAI(cfg.IdentityFingerprint.XAI, learned)
+	return resolved, true
+}
+
+func applyXAIIdentityFingerprintHeaders(headers http.Header, fp config.XAIIdentityFingerprintConfig) {
+	if headers == nil {
+		return
+	}
+	if strings.TrimSpace(fp.UserAgent) != "" {
+		headers.Set("User-Agent", fp.UserAgent)
+	}
+	if strings.TrimSpace(fp.GrokConversationID) != "" {
+		headers.Set("X-Grok-Conv-Id", fp.GrokConversationID)
+	}
+	for key, value := range fp.CustomHeaders {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || isXAIFingerprintRuntimeBlockedHeader(key) {
+			continue
+		}
+		headers.Set(key, value)
+	}
+}
+
+func isXAIFingerprintRuntimeBlockedHeader(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "authorization", "content-type", "accept", "connection", "user-agent", "x-grok-conv-id":
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Summary
- add xAI identity fingerprint config/defaults/runtime settings
- learn Grok User-Agent and X-Grok-Conv-Id from real inbound requests
- replay learned xAI identity fields in upstream requests and expose management summaries

Tests
- rtk go test ./internal/identityfingerprint ./internal/runtime/executor ./internal/api/handlers/management
- rtk git diff --check