### PR TITLE
fix: map xAI weekly_limit for auth-file cycle trends

### DIFF
--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -244,6 +244,9 @@ func primaryWeeklyQuotaKeysForProvider(provider string) []string {
 		return []string{"seven_day"}
 	case "codex", "kimi":
 		return []string{"code_week"}
+	case "xai", "grok":
+		// Matches frontend quota-xai weekly_limit snapshot key.
+		return []string{"weekly_limit"}
 	default:
 		return nil
 	}

--- a/internal/management/usagelogs/trends_provider_keys_test.go
+++ b/internal/management/usagelogs/trends_provider_keys_test.go
@@ -1,0 +1,35 @@
+package usagelogs
+
+import "testing"
+
+func TestPrimaryWeeklyQuotaKeysForProvider(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		provider string
+		want     []string
+	}{
+		{provider: "xai", want: []string{"weekly_limit"}},
+		{provider: "Grok", want: []string{"weekly_limit"}},
+		{provider: "codex", want: []string{"code_week"}},
+		{provider: "kimi", want: []string{"code_week"}},
+		{provider: "claude", want: []string{"seven_day"}},
+		{provider: "unknown", want: nil},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.provider, func(t *testing.T) {
+			t.Parallel()
+			got := primaryWeeklyQuotaKeysForProvider(tc.provider)
+			if len(got) != len(tc.want) {
+				t.Fatalf("keys len = %d, want %d (%v vs %v)", len(got), len(tc.want), got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("keys[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Map `xai` / `grok` providers to primary weekly quota key `weekly_limit`.
- Aligns backend cycle start / cycle request totals with frontend xAI weekly quota snapshots.
- Add unit coverage for provider weekly key mapping.

## Test plan
- [x] `go test ./internal/management/usagelogs/ -run TestPrimaryWeeklyQuotaKeysForProvider`
- [ ] Deploy CliRelay on `dev` after merge (relay.07230805.xyz)