### PR TITLE
feat: split same-email channel filters by auth_index

### DIFF
--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -51,7 +51,8 @@ func (s *Service) UsageChartData(apiKey string, days int) (map[string]any, error
 		if err != nil {
 			return nil, err
 		}
-		keyNameMap, _, _, _ := s.buildNameMaps()
+		keyNameMap, _, _, _, _ := s.buildNameMaps()
+
 		for i := range apikeyDist {
 			if apikeyDist[i].Name == "" {
 				if name, ok := keyNameMap[apikeyDist[i].APIKey]; ok {

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -9,11 +9,12 @@ import (
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any, error) {
-	keyNameMap, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap := s.buildNameMaps()
-	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap)
+	keyNameMap, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex := s.buildNameMaps()
+	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex)
 
 	params := usage.LogQueryParams{
 		Page:                  input.Page,
@@ -54,6 +55,7 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 		if channelName := displayChannelNameForLog(*item, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap); channelName != "" {
 			item.ChannelName = channelName
 		}
+		enrichLogRowChannelMeta(item, authMetaByIndex)
 	}
 
 	if filters.APIKeyNames == nil {
@@ -64,7 +66,8 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 			filters.APIKeyNames[key] = name
 		}
 	}
-	filters.Channels = displayChannelFilters(filters.Channels, channelNameMap)
+	filters.ChannelOptions = enrichChannelFilterOptions(filters.ChannelOptions, channelNameMap, authIndexChannelMap, authMetaByIndex)
+	filters.Channels = channelLabelsFromOptions(filters.ChannelOptions)
 
 	if result.Items == nil {
 		result.Items = make([]usage.LogRow, 0)
@@ -77,6 +80,9 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	}
 	if filters.Channels == nil {
 		filters.Channels = make([]string, 0)
+	}
+	if filters.ChannelOptions == nil {
+		filters.ChannelOptions = make([]usage.ChannelFilterOption, 0)
 	}
 	if filters.Statuses == nil {
 		filters.Statuses = make([]string, 0)
@@ -111,8 +117,8 @@ func (s *Service) ClearRequestLogs(options usage.ClearRequestLogsOptions) (int, 
 }
 
 func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, error) {
-	_, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap := s.buildNameMaps()
-	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap)
+	_, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex := s.buildNameMaps()
+	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex)
 	params := usage.LogQueryParams{
 		Page:                  input.Page,
 		Size:                  input.Size,
@@ -152,9 +158,18 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		result.Items[i].ChannelName = channelName
 		result.Items[i].APIKey = ""
 		result.Items[i].APIKeyName = ""
+		// Keep provider/auth_type for public UI badges, but strip identity keys above.
+		enrichLogRowChannelMeta(&result.Items[i], authMetaByIndex)
+		result.Items[i].AuthIndex = ""
 	}
 
-	filters.Channels = displayChannelFilters(filters.Channels, channelNameMap)
+	filters.ChannelOptions = enrichChannelFilterOptions(filters.ChannelOptions, channelNameMap, authIndexChannelMap, authMetaByIndex)
+	// Public responses keep opaque filter values (auth_index) so same-email
+	// multi-provider accounts stay selectable, but strip the auth_index field.
+	for i := range filters.ChannelOptions {
+		filters.ChannelOptions[i].AuthIndex = ""
+	}
+	filters.Channels = channelLabelsFromOptions(filters.ChannelOptions)
 	if result.Items == nil {
 		result.Items = make([]usage.LogRow, 0)
 	}
@@ -163,6 +178,9 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 	}
 	if filters.Channels == nil {
 		filters.Channels = make([]string, 0)
+	}
+	if filters.ChannelOptions == nil {
+		filters.ChannelOptions = make([]usage.ChannelFilterOption, 0)
 	}
 	if filters.Statuses == nil {
 		filters.Statuses = make([]string, 0)
@@ -176,39 +194,118 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		"stats":        stats,
 		"api_key_name": apiKeyName,
 		"filters": map[string]any{
-			"models":   filters.Models,
-			"channels": filters.Channels,
-			"statuses": filters.Statuses,
+			"models":          filters.Models,
+			"channels":        filters.Channels,
+			"channel_options": filters.ChannelOptions,
+			"statuses":        filters.Statuses,
 		},
 	}, nil
 }
 
-func channelFilterSelectors(channels []string, channelNameMap, authIndexChannelMap map[string]string, ambiguousAuthIndexChannelMap map[string][]string) ([]string, []string, map[string][]string) {
-	selectedChannelKeys := make(map[string]struct{})
+type authChannelMeta struct {
+	label    string
+	provider string
+	authType string
+}
+
+func channelFilterSelectors(
+	channels []string,
+	channelNameMap, authIndexChannelMap map[string]string,
+	ambiguousAuthIndexChannelMap map[string][]string,
+	authMetaByIndex map[string]authChannelMeta,
+) ([]string, []string, map[string][]string) {
+	// Preserve original selected values. Only use lower-case keys for label matching.
+	selectedRaw := make([]string, 0, len(channels))
+	selectedLabelKeys := make(map[string]struct{})
 	for _, part := range channels {
-		key := strings.ToLower(strings.TrimSpace(part))
-		if key == "" {
+		raw := strings.TrimSpace(part)
+		if raw == "" {
 			continue
 		}
-		selectedChannelKeys[key] = struct{}{}
+		selectedRaw = append(selectedRaw, raw)
+		selectedLabelKeys[strings.ToLower(raw)] = struct{}{}
 	}
-	if len(selectedChannelKeys) == 0 {
+	if len(selectedRaw) == 0 {
 		return nil, nil, nil
 	}
 
 	var authIndexes []string
 	var channelNames []string
 	authIndexChannelNames := make(map[string][]string)
-	for key := range selectedChannelKeys {
-		channelNames = append(channelNames, key)
+	seenAuthIndex := make(map[string]struct{})
+	seenChannelName := make(map[string]struct{})
+
+	appendAuthIndex := func(idx string) {
+		idx = strings.TrimSpace(idx)
+		if idx == "" {
+			return
+		}
+		if _, ok := seenAuthIndex[idx]; ok {
+			return
+		}
+		seenAuthIndex[idx] = struct{}{}
+		authIndexes = append(authIndexes, idx)
 	}
+	appendChannelName := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		key := strings.ToLower(name)
+		if _, ok := seenChannelName[key]; ok {
+			return
+		}
+		seenChannelName[key] = struct{}{}
+		channelNames = append(channelNames, name)
+	}
+
+	for _, raw := range selectedRaw {
+		// Prefer exact auth_index matches so multi-provider same-email accounts
+		// filter independently when clients send auth_index as the value.
+		if _, ok := authIndexChannelMap[raw]; ok {
+			appendAuthIndex(raw)
+			if legacyChannels := ambiguousAuthIndexChannelMap[raw]; len(legacyChannels) > 0 {
+				authIndexChannelNames[raw] = append(authIndexChannelNames[raw], legacyChannels...)
+			}
+			continue
+		}
+		if _, ok := authMetaByIndex[raw]; ok {
+			appendAuthIndex(raw)
+			continue
+		}
+		matchedAuthIndex := false
+		for idx := range authIndexChannelMap {
+			if strings.EqualFold(strings.TrimSpace(idx), raw) {
+				appendAuthIndex(idx)
+				if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
+					authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
+				}
+				matchedAuthIndex = true
+			}
+		}
+		if matchedAuthIndex {
+			continue
+		}
+		for idx := range authMetaByIndex {
+			if strings.EqualFold(strings.TrimSpace(idx), raw) {
+				appendAuthIndex(idx)
+				matchedAuthIndex = true
+			}
+		}
+		if matchedAuthIndex {
+			continue
+		}
+		// Legacy clients still send display labels / emails.
+		appendChannelName(raw)
+	}
+
 	for raw, name := range channelNameMap {
 		key := strings.ToLower(strings.TrimSpace(name))
 		if key == "" {
 			continue
 		}
-		if _, ok := selectedChannelKeys[key]; ok {
-			channelNames = append(channelNames, raw)
+		if _, ok := selectedLabelKeys[key]; ok {
+			appendChannelName(raw)
 		}
 	}
 	for idx, name := range authIndexChannelMap {
@@ -216,8 +313,8 @@ func channelFilterSelectors(channels []string, channelNameMap, authIndexChannelM
 		if key == "" {
 			continue
 		}
-		if _, ok := selectedChannelKeys[key]; ok {
-			authIndexes = append(authIndexes, idx)
+		if _, ok := selectedLabelKeys[key]; ok {
+			appendAuthIndex(idx)
 			if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
 				authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
 			}
@@ -229,29 +326,196 @@ func channelFilterSelectors(channels []string, channelNameMap, authIndexChannelM
 	return authIndexes, channelNames, authIndexChannelNames
 }
 
-func displayChannelFilters(values []string, channelNameMap map[string]string) []string {
-	if len(values) == 0 {
-		return values
+func enrichChannelFilterOptions(
+	options []usage.ChannelFilterOption,
+	channelNameMap, authIndexChannelMap map[string]string,
+	authMetaByIndex map[string]authChannelMeta,
+) []usage.ChannelFilterOption {
+	if len(options) == 0 {
+		return make([]usage.ChannelFilterOption, 0)
 	}
-	seen := make(map[string]struct{})
-	channels := make([]string, 0, len(values))
-	for _, value := range values {
-		trimmed := strings.TrimSpace(value)
-		if name, ok := channelNameMap[trimmed]; ok && strings.TrimSpace(name) != "" {
-			trimmed = strings.TrimSpace(name)
+
+	// Prefer one option per live auth_index. Collapse pure name-only rows when
+	// the same label already has auth-backed options.
+	out := make([]usage.ChannelFilterOption, 0, len(options))
+	seenValue := make(map[string]struct{}, len(options))
+	authBackedLabels := make(map[string]struct{})
+
+	for _, option := range options {
+		authIndex := strings.TrimSpace(option.AuthIndex)
+		if authIndex == "" {
+			authIndex = strings.TrimSpace(option.Value)
 		}
-		key := strings.ToLower(trimmed)
-		if key == "" {
+		if authIndex == "" {
 			continue
 		}
+		if _, ok := authIndexChannelMap[authIndex]; ok {
+			if name := strings.TrimSpace(authIndexChannelMap[authIndex]); name != "" {
+				authBackedLabels[strings.ToLower(name)] = struct{}{}
+			}
+		}
+		if meta, ok := authMetaByIndex[authIndex]; ok && meta.label != "" {
+			authBackedLabels[strings.ToLower(meta.label)] = struct{}{}
+		}
+	}
+
+	for _, option := range options {
+		label := strings.TrimSpace(option.Label)
+		authIndex := strings.TrimSpace(option.AuthIndex)
+		if authIndex == "" {
+			authIndex = strings.TrimSpace(option.Value)
+		}
+		if label == "" && authIndex != "" {
+			if name, ok := authIndexChannelMap[authIndex]; ok && strings.TrimSpace(name) != "" {
+				label = strings.TrimSpace(name)
+			}
+		}
+		if label == "" {
+			if name, ok := channelNameMap[strings.TrimSpace(option.Value)]; ok && strings.TrimSpace(name) != "" {
+				label = strings.TrimSpace(name)
+			}
+		}
+		if label == "" {
+			label = strings.TrimSpace(option.Value)
+		}
+		if label == "" {
+			continue
+		}
+
+		provider := strings.TrimSpace(option.Provider)
+		authType := strings.TrimSpace(option.AuthType)
+		value := strings.TrimSpace(option.Value)
+		if value == "" {
+			value = authIndex
+		}
+		if value == "" {
+			value = label
+		}
+
+		hasLiveMeta := false
+		if meta, ok := authMetaByIndex[authIndex]; ok {
+			hasLiveMeta = true
+			if meta.label != "" {
+				label = meta.label
+			}
+			if meta.provider != "" {
+				provider = meta.provider
+			}
+			if meta.authType != "" {
+				authType = meta.authType
+			}
+			value = authIndex
+		} else if authIndex != "" {
+			// Keep auth_index as the filter value even without live meta so
+			// historical rows for deleted auths stay independently selectable.
+			value = authIndex
+			if mapped, ok := authIndexChannelMap[authIndex]; ok && strings.TrimSpace(mapped) != "" {
+				label = strings.TrimSpace(mapped)
+			}
+		} else if mapped, ok := channelNameMap[label]; ok && strings.TrimSpace(mapped) != "" {
+			label = strings.TrimSpace(mapped)
+		}
+
+		// Drop name-only rows that would re-merge same-email multi-provider
+		// accounts already represented by auth_index-backed options.
+		if !hasLiveMeta && authIndex == "" {
+			if _, ok := authBackedLabels[strings.ToLower(label)]; ok {
+				continue
+			}
+		}
+
+		dedupeKey := strings.ToLower(value)
+		if _, ok := seenValue[dedupeKey]; ok {
+			continue
+		}
+		seenValue[dedupeKey] = struct{}{}
+
+		out = append(out, usage.ChannelFilterOption{
+			Value:     value,
+			Label:     label,
+			Provider:  provider,
+			AuthType:  normalizeAuthType(authType),
+			AuthIndex: authIndex,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		li := strings.ToLower(out[i].Label)
+		lj := strings.ToLower(out[j].Label)
+		if li != lj {
+			return li < lj
+		}
+		pi := strings.ToLower(out[i].Provider)
+		pj := strings.ToLower(out[j].Provider)
+		if pi != pj {
+			return pi < pj
+		}
+		return strings.ToLower(out[i].Value) < strings.ToLower(out[j].Value)
+	})
+	return out
+}
+
+func channelLabelsFromOptions(options []usage.ChannelFilterOption) []string {
+	if len(options) == 0 {
+		return make([]string, 0)
+	}
+	// Keep legacy channels as unique display labels (may collapse same-email providers).
+	// New clients should use channel_options.
+	seen := make(map[string]struct{}, len(options))
+	labels := make([]string, 0, len(options))
+	for _, option := range options {
+		label := strings.TrimSpace(option.Label)
+		if label == "" {
+			label = strings.TrimSpace(option.Value)
+		}
+		if label == "" {
+			continue
+		}
+		key := strings.ToLower(label)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		channels = append(channels, trimmed)
+		labels = append(labels, label)
 	}
-	sort.Slice(channels, func(i, j int) bool { return strings.ToLower(channels[i]) < strings.ToLower(channels[j]) })
-	return channels
+	return labels
+}
+
+func enrichLogRowChannelMeta(item *usage.LogRow, authMetaByIndex map[string]authChannelMeta) {
+	if item == nil {
+		return
+	}
+	if meta, ok := authMetaByIndex[strings.TrimSpace(item.AuthIndex)]; ok {
+		if meta.provider != "" {
+			item.Provider = meta.provider
+		}
+		if meta.authType != "" {
+			item.AuthType = normalizeAuthType(meta.authType)
+		}
+		return
+	}
+	if item.Provider == "" {
+		item.Provider = usageGuessProviderFromSource(item.Source)
+	}
+}
+
+func usageGuessProviderFromSource(source string) string {
+	source = strings.ToLower(strings.TrimSpace(source))
+	if source == "" || strings.Contains(source, "@") || strings.Contains(source, " ") || len(source) > 32 {
+		return ""
+	}
+	return source
+}
+
+func normalizeAuthType(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "oauth":
+		return "oauth"
+	case "api", "api_key", "apikey":
+		return "api"
+	default:
+		return ""
+	}
 }
 
 func (s *Service) publicAPIKeyName(apiKey string) string {
@@ -283,11 +547,16 @@ func displayChannelNameForLog(item usage.LogRow, channelNameMap, authIndexChanne
 	return ""
 }
 
-func (s *Service) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelMap map[string]string, ambiguousAuthIndexChannelMap map[string][]string) {
+func (s *Service) buildNameMaps() (
+	keyNameMap, channelNameMap, authIndexChannelMap map[string]string,
+	ambiguousAuthIndexChannelMap map[string][]string,
+	authMetaByIndex map[string]authChannelMeta,
+) {
 	keyNameMap = make(map[string]string)
 	channelNameMap = make(map[string]string)
 	authIndexChannelMap = make(map[string]string)
 	ambiguousAuthIndexChannelMap = make(map[string][]string)
+	authMetaByIndex = make(map[string]authChannelMeta)
 
 	for _, row := range apikeysettings.NewService(nil).ListRows() {
 		if row.Key != "" && row.Name != "" {
@@ -341,16 +610,22 @@ func (s *Service) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelM
 				continue
 			}
 			auth.EnsureIndex()
-			if idx := strings.TrimSpace(auth.Index); idx != "" {
+			idx := strings.TrimSpace(auth.Index)
+			if idx != "" {
 				authIndexChannelMap[idx] = channel
+				authMetaByIndex[idx] = authChannelMeta{
+					label:    channel,
+					provider: normalizeProviderKey(auth.Provider),
+					authType: resolveAuthType(auth),
+				}
 			}
 			if accountType, account := auth.AccountInfo(); strings.EqualFold(accountType, "oauth") {
 				if source := strings.TrimSpace(account); source != "" {
-					legacyCandidates = append(legacyCandidates, legacyChannelCandidate{key: source, channel: channel, authIndex: strings.TrimSpace(auth.Index)})
+					legacyCandidates = append(legacyCandidates, legacyChannelCandidate{key: source, channel: channel, authIndex: idx})
 				}
 			}
 			if email := strings.TrimSpace(managementauthfiles.Email(auth)); email != "" {
-				legacyCandidates = append(legacyCandidates, legacyChannelCandidate{key: email, channel: channel, authIndex: strings.TrimSpace(auth.Index)})
+				legacyCandidates = append(legacyCandidates, legacyChannelCandidate{key: email, channel: channel, authIndex: idx})
 			}
 		}
 	}
@@ -382,6 +657,18 @@ func (s *Service) buildNameMaps() (keyNameMap, channelNameMap, authIndexChannelM
 	}
 
 	return
+}
+
+func resolveAuthType(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	accountType, _ := auth.AccountInfo()
+	return normalizeAuthType(accountType)
+}
+
+func normalizeProviderKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }
 
 func containsFold(values []string, needle string) bool {

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -178,11 +178,12 @@ func QueryFiltersForLogs(params LogQueryParams) (FilterOptions, error) {
 	if db == nil {
 		// Ensure stable JSON shape: slices => [] (not null), maps => {} (not null).
 		return FilterOptions{
-			APIKeys:     make([]string, 0),
-			APIKeyNames: make(map[string]string),
-			Models:      make([]string, 0),
-			Channels:    make([]string, 0),
-			Statuses:    make([]string, 0),
+			APIKeys:        make([]string, 0),
+			APIKeyNames:    make(map[string]string),
+			Models:         make([]string, 0),
+			Channels:       make([]string, 0),
+			ChannelOptions: make([]ChannelFilterOption, 0),
+			Statuses:       make([]string, 0),
 		}, nil
 	}
 
@@ -197,7 +198,7 @@ func QueryFiltersForLogs(params LogQueryParams) (FilterOptions, error) {
 		log.Warnf("usage: query distinct models failed: %v", err)
 		return FilterOptions{}, err
 	}
-	channels, err := queryDistinct(db, "channel_name", params.withoutFacet("channel"))
+	channelRows, err := queryDistinctChannelRows(db, params.withoutFacet("channel"))
 	if err != nil {
 		log.Warnf("usage: query distinct channels failed: %v", err)
 		return FilterOptions{}, err
@@ -208,14 +209,34 @@ func QueryFiltersForLogs(params LogQueryParams) (FilterOptions, error) {
 		return FilterOptions{}, err
 	}
 
+	channelNames := make([]string, 0, len(channelRows))
+	seenNames := make(map[string]struct{}, len(channelRows))
+	for _, row := range channelRows {
+		name := strings.TrimSpace(row.Label)
+		if name == "" {
+			name = strings.TrimSpace(row.Value)
+		}
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seenNames[key]; ok {
+			continue
+		}
+		seenNames[key] = struct{}{}
+		channelNames = append(channelNames, name)
+	}
+
 	return FilterOptions{
-		APIKeys:     keys,
-		APIKeyNames: keyNames,
-		Models:      models,
-		Channels:    channels,
-		Statuses:    statuses,
+		APIKeys:        keys,
+		APIKeyNames:    keyNames,
+		Models:         models,
+		Channels:       channelNames,
+		ChannelOptions: channelRows,
+		Statuses:       statuses,
 	}, nil
 }
+
 
 func (params LogQueryParams) withoutFacet(facet string) LogQueryParams {
 	params.Page = 0
@@ -596,7 +617,9 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 			args = append(args, trimmed)
 		}
 		if len(authPlaceholders) > 0 {
-			filterConditions = append(filterConditions, "(auth_index IN ("+strings.Join(authPlaceholders, ",")+") AND trim(coalesce(channel_name, '')) = '')")
+			// Match by auth_index regardless of channel_name so multi-provider
+			// accounts that share a display email/label stay independently filterable.
+			filterConditions = append(filterConditions, "auth_index IN ("+strings.Join(authPlaceholders, ",")+")")
 		}
 
 		for idx, names := range params.AuthIndexChannelNames {
@@ -672,6 +695,77 @@ func queryDistinct(db *sql.DB, column string, params LogQueryParams) ([]string, 
 	}
 	return result, nil
 }
+
+// queryDistinctChannelRows returns distinct (channel_name, auth_index) pairs so
+// that two OAuth accounts sharing the same email/label (e.g. codex + xai)
+// remain separate filter options.
+func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilterOption, error) {
+	where, args := buildWhereClause(params)
+	q := `
+		SELECT
+			trim(coalesce(channel_name, '')) AS channel_name,
+			trim(coalesce(auth_index, '')) AS auth_index,
+			MAX(trim(coalesce(source, ''))) AS source
+		FROM request_logs` + where + `
+		GROUP BY trim(coalesce(channel_name, '')), trim(coalesce(auth_index, ''))
+		ORDER BY channel_name, auth_index`
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		log.Warnf("usage: distinct channel rows query failed: %v", err)
+		return nil, fmt.Errorf("usage: distinct channel rows: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]ChannelFilterOption, 0)
+	for rows.Next() {
+		var channelName, authIndex, source string
+		if err := rows.Scan(&channelName, &authIndex, &source); err != nil {
+			log.Warnf("usage: distinct channel rows scan failed: %v", err)
+			return nil, err
+		}
+		channelName = strings.TrimSpace(channelName)
+		authIndex = strings.TrimSpace(authIndex)
+		source = strings.TrimSpace(source)
+		if channelName == "" && authIndex == "" {
+			continue
+		}
+		label := channelName
+		if label == "" {
+			label = authIndex
+		}
+		// Prefer auth_index as the stable filter value when available so
+		// same-label multi-provider accounts stay independent.
+		value := authIndex
+		if value == "" {
+			value = channelName
+		}
+		result = append(result, ChannelFilterOption{
+			Value:     value,
+			Label:     label,
+			AuthIndex: authIndex,
+			// Provider/auth_type are filled by the management layer from live auth state.
+			// Source is a weak fallback only.
+			Provider: guessProviderFromSource(source),
+		})
+	}
+	return result, rows.Err()
+}
+
+func guessProviderFromSource(source string) string {
+	source = strings.ToLower(strings.TrimSpace(source))
+	if source == "" {
+		return ""
+	}
+	// Source may be an email or a provider id; only return known-looking short keys.
+	if strings.Contains(source, "@") || strings.Contains(source, " ") {
+		return ""
+	}
+	if len(source) > 32 {
+		return ""
+	}
+	return source
+}
+
 
 func queryDistinctStatuses(db *sql.DB, params LogQueryParams) ([]string, error) {
 	where, args := buildWhereClause(params)

--- a/internal/usage/request_log_query_builder_test.go
+++ b/internal/usage/request_log_query_builder_test.go
@@ -20,7 +20,7 @@ func TestBuildWhereClauseUsesParameterizedFilters(t *testing.T) {
 		ChannelNames:          []string{" Codex ", ""},
 	})
 
-	wantWhere := " WHERE timestamp >= ? AND (api_key = ? OR api_key = ?) AND model IN (?,?) AND failed = 1 AND ((auth_index IN (?) AND trim(coalesce(channel_name, '')) = '') OR (auth_index = ? AND lower(trim(channel_name)) IN (?)) OR lower(trim(channel_name)) IN (?))"
+	wantWhere := " WHERE timestamp >= ? AND (api_key = ? OR api_key = ?) AND model IN (?,?) AND failed = 1 AND (auth_index IN (?) OR (auth_index = ? AND lower(trim(channel_name)) IN (?)) OR lower(trim(channel_name)) IN (?))"
 	if where != wantWhere {
 		t.Fatalf("where = %q, want %q", where, wantWhere)
 	}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -26,6 +26,8 @@ type LogRow struct {
 	VisionFallbackModel string    `json:"vision_fallback_model,omitempty"`
 	Source              string    `json:"source"`
 	ChannelName         string    `json:"channel_name"`
+	Provider            string    `json:"provider,omitempty"`
+	AuthType            string    `json:"auth_type,omitempty"` // "oauth" | "api"
 	AuthIndex           string    `json:"auth_index"`
 	Failed              bool      `json:"failed"`
 	Streaming           bool      `json:"streaming"`
@@ -39,6 +41,7 @@ type LogRow struct {
 	Cost                float64   `json:"cost"`
 	HasContent          bool      `json:"has_content"`
 }
+
 
 // LogQueryParams holds filter/pagination parameters for QueryLogs.
 type LogQueryParams struct {
@@ -72,12 +75,26 @@ type LogQueryResult struct {
 
 // FilterOptions holds the available filter values for the UI.
 type FilterOptions struct {
-	APIKeys     []string          `json:"api_keys"`
-	APIKeyNames map[string]string `json:"api_key_names"`
-	Models      []string          `json:"models"`
-	Channels    []string          `json:"channels"`
-	Statuses    []string          `json:"statuses"`
+	APIKeys     []string              `json:"api_keys"`
+	APIKeyNames map[string]string     `json:"api_key_names"`
+	Models      []string              `json:"models"`
+	// Channels is a legacy plain-name list kept for older clients.
+	// Prefer ChannelOptions when both are present.
+	Channels       []string              `json:"channels"`
+	ChannelOptions []ChannelFilterOption `json:"channel_options,omitempty"`
+	Statuses       []string              `json:"statuses"`
 }
+
+// ChannelFilterOption is one selectable channel in request-log filters.
+// Value is stable for filtering (auth_index when known, otherwise the display name).
+type ChannelFilterOption struct {
+	Value     string `json:"value"`
+	Label     string `json:"label"`
+	Provider  string `json:"provider,omitempty"`
+	AuthType  string `json:"auth_type,omitempty"` // "oauth" | "api"
+	AuthIndex string `json:"auth_index,omitempty"`
+}
+
 
 // LogStats holds aggregated stats over the filtered result set.
 type LogStats struct {


### PR DESCRIPTION
## Summary
- Add `channel_options` for request-log filters keyed by `auth_index` so multi-provider OAuth accounts that share an email (e.g. codex + xai/grok) stay independent.
- Enrich options and log rows with live `provider` / `auth_type` metadata from auth manager.
- Fix auth_index filtering so it matches regardless of `channel_name`.

## Test plan
- [x] `go test ./internal/management/usagelogs/ ./internal/usage/`
- [ ] Manual: request logs channel filter shows two options for same-email codex/grok accounts and filters independently