### PR TITLE
fix: gofmt usage channel filter query files

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -154,9 +154,15 @@ func TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers(t *testing
 	var payload struct {
 		Items []struct {
 			ChannelName string `json:"channel_name"`
+			AuthIndex   string `json:"auth_index"`
 		} `json:"items"`
 		Filters struct {
-			Channels []string `json:"channels"`
+			Channels       []string `json:"channels"`
+			ChannelOptions []struct {
+				Value     string `json:"value"`
+				Label     string `json:"label"`
+				AuthIndex string `json:"auth_index"`
+			} `json:"channel_options"`
 		} `json:"filters"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
@@ -165,13 +171,27 @@ func TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers(t *testing
 	if len(payload.Items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(payload.Items))
 	}
+	// Historical rows keep the channel_name snapshot written at request time.
 	if payload.Items[0].ChannelName != "tabcode-plus" {
 		t.Fatalf("channel_name = %q, want %q", payload.Items[0].ChannelName, "tabcode-plus")
 	}
-	if len(payload.Filters.Channels) != 1 || payload.Filters.Channels[0] != "tabcode-plus" {
-		t.Fatalf("filters.channels = %#v, want [tabcode-plus]", payload.Filters.Channels)
+	// Filter facets use the live auth label / auth_index so renamed channels stay
+	// selectable as one account, while still matching historical rows by index.
+	if len(payload.Filters.ChannelOptions) != 1 {
+		t.Fatalf("channel_options = %#v, want one option", payload.Filters.ChannelOptions)
+	}
+	opt := payload.Filters.ChannelOptions[0]
+	if opt.Label != "tabcode-pro" {
+		t.Fatalf("channel_options[0].label = %q, want tabcode-pro", opt.Label)
+	}
+	if opt.Value != auth.Index || opt.AuthIndex != auth.Index {
+		t.Fatalf("channel_options[0] value/auth_index = %#v, want auth index %q", opt, auth.Index)
+	}
+	if len(payload.Filters.Channels) != 1 || payload.Filters.Channels[0] != "tabcode-pro" {
+		t.Fatalf("filters.channels = %#v, want [tabcode-pro]", payload.Filters.Channels)
 	}
 
+	// Legacy clients can still filter by the historical channel_name string.
 	rec = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50&channel=tabcode-plus", nil)
@@ -186,18 +206,34 @@ func TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers(t *testing
 		t.Fatalf("filtered items = %#v, want one tabcode-plus item", payload.Items)
 	}
 
+	// Selecting the live label resolves to auth_index and still returns history.
 	rec = httptest.NewRecorder()
 	c, _ = gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50&channel=tabcode-pro", nil)
 	h.UsageLogs().GetUsageLogs(c)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("mismatched filtered expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+		t.Fatalf("live-label filtered expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
-		t.Fatalf("unmarshal mismatched filtered response: %v", err)
+		t.Fatalf("unmarshal live-label filtered response: %v", err)
 	}
-	if len(payload.Items) != 0 {
-		t.Fatalf("mismatched filtered items = %#v, want none", payload.Items)
+	if len(payload.Items) != 1 || payload.Items[0].AuthIndex != auth.Index {
+		t.Fatalf("live-label filtered items = %#v, want one item for auth %q", payload.Items, auth.Index)
+	}
+
+	// Filtering by auth_index value (new clients) also returns the historical row.
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50&channel="+auth.Index, nil)
+	h.UsageLogs().GetUsageLogs(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("auth-index filtered expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal auth-index filtered response: %v", err)
+	}
+	if len(payload.Items) != 1 || payload.Items[0].ChannelName != "tabcode-plus" {
+		t.Fatalf("auth-index filtered items = %#v, want one tabcode-plus item", payload.Items)
 	}
 }
 

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -237,7 +237,6 @@ func QueryFiltersForLogs(params LogQueryParams) (FilterOptions, error) {
 	}, nil
 }
 
-
 func (params LogQueryParams) withoutFacet(facet string) LogQueryParams {
 	params.Page = 0
 	params.Size = 0
@@ -765,7 +764,6 @@ func guessProviderFromSource(source string) string {
 	}
 	return source
 }
-
 
 func queryDistinctStatuses(db *sql.DB, params LogQueryParams) ([]string, error) {
 	where, args := buildWhereClause(params)

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -42,7 +42,6 @@ type LogRow struct {
 	HasContent          bool      `json:"has_content"`
 }
 
-
 // LogQueryParams holds filter/pagination parameters for QueryLogs.
 type LogQueryParams struct {
 	Page            int      // 1-based
@@ -75,9 +74,9 @@ type LogQueryResult struct {
 
 // FilterOptions holds the available filter values for the UI.
 type FilterOptions struct {
-	APIKeys     []string              `json:"api_keys"`
-	APIKeyNames map[string]string     `json:"api_key_names"`
-	Models      []string              `json:"models"`
+	APIKeys     []string          `json:"api_keys"`
+	APIKeyNames map[string]string `json:"api_key_names"`
+	Models      []string          `json:"models"`
 	// Channels is a legacy plain-name list kept for older clients.
 	// Prefer ChannelOptions when both are present.
 	Channels       []string              `json:"channels"`
@@ -94,7 +93,6 @@ type ChannelFilterOption struct {
 	AuthType  string `json:"auth_type,omitempty"` // "oauth" | "api"
 	AuthIndex string `json:"auth_index,omitempty"`
 }
-
 
 // LogStats holds aggregated stats over the filtered result set.
 type LogStats struct {


### PR DESCRIPTION
## Summary
- Apply gofmt to `internal/usage/request_log_query.go` and `internal/usage/usage_db.go` so `pr-test-build` / `ci-pr.sh` pass after the channel filter change.
- No behavior change.

## Test plan
- [x] `gofmt -l` clean on the two files
- [x] `go test ./internal/usage/`
- [ ] GitHub Actions `pr-test-build` green
- [ ] Merge to `dev` triggers `Deploy CliRelay` success (relay.07230805.xyz)