### PR TITLE
feat: support Grok identity fingerprints

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -245,7 +245,10 @@ func validateGeminiIdentityFingerprint(fp config.GeminiIdentityFingerprintConfig
 }
 
 func validateXAIIdentityFingerprint(fp config.XAIIdentityFingerprintConfig) error {
-	if containsHeaderLineBreak(fp.UserAgent) || containsHeaderLineBreak(fp.GrokConversationID) {
+	if containsHeaderLineBreak(fp.UserAgent) ||
+		containsHeaderLineBreak(fp.ClientIdentifier) ||
+		containsHeaderLineBreak(fp.ClientVersion) ||
+		containsHeaderLineBreak(fp.GrokConversationID) {
 		return fmt.Errorf("identity fingerprint fields must not contain line breaks")
 	}
 	for key, value := range fp.CustomHeaders {
@@ -306,7 +309,7 @@ func isGeminiIdentityFingerprintBlockedHeader(key string) bool {
 
 func isXAIIdentityFingerprintBlockedHeader(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "x-grok-conv-id":
+	case "x-grok-client-identifier", "x-grok-client-version", "x-grok-conv-id":
 		return true
 	default:
 		return false

--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -309,6 +309,72 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 	}
 }
 
+func TestGetIdentityFingerprintAccountReturnsXAIBuiltinDefaultFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	h := &Handler{cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
+		XAI: config.XAIIdentityFingerprintConfig{Enabled: true},
+	}}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/identity-fingerprint/account?provider=xai&account_key=authsub_xai_test", nil)
+
+	h.GetIdentityFingerprintAccount(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload struct {
+		Summary struct {
+			PrimarySource   string         `json:"primary_source"`
+			SourceCounts    map[string]int `json:"source_counts"`
+			EffectiveFields int            `json:"effective_fields"`
+			Learned         bool           `json:"learned"`
+			Version         string         `json:"version"`
+		} `json:"summary"`
+		Effective struct {
+			Fields map[string]struct {
+				Value  string `json:"value"`
+				Source string `json:"source"`
+			} `json:"fields"`
+		} `json:"effective"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload.Summary.Learned {
+		t.Fatalf("summary learned = true, want false")
+	}
+	if payload.Summary.PrimarySource != "builtin_default" || payload.Summary.EffectiveFields != 3 {
+		t.Fatalf("summary = %+v, want three builtin default fields", payload.Summary)
+	}
+	if payload.Summary.Version != config.DefaultXAIFingerprintClientVersion {
+		t.Fatalf("summary version = %q, want %q", payload.Summary.Version, config.DefaultXAIFingerprintClientVersion)
+	}
+	if payload.Summary.SourceCounts["builtin_default"] != 3 {
+		t.Fatalf("source counts = %#v, want three builtin default fields", payload.Summary.SourceCounts)
+	}
+	if got := payload.Effective.Fields[identityfingerprint.FieldUserAgent]; got.Value != config.DefaultXAIFingerprintUserAgent || got.Source != "builtin_default" {
+		t.Fatalf("user-agent field = %+v, want xAI builtin default", got)
+	}
+	if got := payload.Effective.Fields[identityfingerprint.FieldXAIClientIdentifier]; got.Value != config.DefaultXAIFingerprintClientIdentifier || got.Source != "builtin_default" {
+		t.Fatalf("client identifier field = %+v, want xAI builtin default", got)
+	}
+	if got := payload.Effective.Fields[identityfingerprint.FieldXAIClientVersion]; got.Value != config.DefaultXAIFingerprintClientVersion || got.Source != "builtin_default" {
+		t.Fatalf("client version field = %+v, want xAI builtin default", got)
+	}
+}
+
 func TestBuildIdentityFingerprintSummaryUsesCodexPresetVersionWhenLearnedVersionMissing(t *testing.T) {
 	learned := &identityfingerprint.LearnedRecord{
 		Provider:      identityfingerprint.ProviderCodex,

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -23,6 +23,10 @@ const (
 	DefaultGeminiFingerprintUserAgent      = "google-api-nodejs-client/9.15.1"
 	DefaultGeminiFingerprintAPIClient      = "gl-node/22.17.0"
 	DefaultGeminiFingerprintClientMetadata = "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI"
+
+	DefaultXAIFingerprintUserAgent        = "grok-shell/0.2.93 (macos; aarch64)"
+	DefaultXAIFingerprintClientIdentifier = "grok-shell"
+	DefaultXAIFingerprintClientVersion    = "0.2.93"
 )
 
 // IdentityFingerprintConfig groups provider-specific upstream identity settings.
@@ -89,6 +93,8 @@ type GeminiIdentityFingerprintConfig struct {
 type XAIIdentityFingerprintConfig struct {
 	Enabled            bool              `yaml:"enabled" json:"enabled"`
 	UserAgent          string            `yaml:"user-agent,omitempty" json:"user-agent,omitempty"`
+	ClientIdentifier   string            `yaml:"x-grok-client-identifier,omitempty" json:"x-grok-client-identifier,omitempty"`
+	ClientVersion      string            `yaml:"x-grok-client-version,omitempty" json:"x-grok-client-version,omitempty"`
 	GrokConversationID string            `yaml:"x-grok-conv-id,omitempty" json:"x-grok-conv-id,omitempty"`
 	CustomHeaders      map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
 }
@@ -125,8 +131,11 @@ func DefaultGeminiIdentityFingerprint() GeminiIdentityFingerprintConfig {
 // DefaultXAIIdentityFingerprint returns the conservative Grok identity template.
 func DefaultXAIIdentityFingerprint() XAIIdentityFingerprintConfig {
 	return XAIIdentityFingerprintConfig{
-		Enabled:       false,
-		CustomHeaders: map[string]string{},
+		Enabled:          false,
+		UserAgent:        DefaultXAIFingerprintUserAgent,
+		ClientIdentifier: DefaultXAIFingerprintClientIdentifier,
+		ClientVersion:    DefaultXAIFingerprintClientVersion,
+		CustomHeaders:    map[string]string{},
 	}
 }
 
@@ -288,7 +297,7 @@ func CleanGeminiIdentityFingerprint(in GeminiIdentityFingerprintConfig) GeminiId
 }
 
 // NormalizeXAIIdentityFingerprint trims user input while preserving empty fields
-// as "automatic learning" markers. xAI has no stable public CLI defaults here.
+// as "automatic learning" markers.
 func NormalizeXAIIdentityFingerprint(in XAIIdentityFingerprintConfig) XAIIdentityFingerprintConfig {
 	return CleanXAIIdentityFingerprint(in)
 }
@@ -297,6 +306,8 @@ func NormalizeXAIIdentityFingerprint(in XAIIdentityFingerprintConfig) XAIIdentit
 func CleanXAIIdentityFingerprint(in XAIIdentityFingerprintConfig) XAIIdentityFingerprintConfig {
 	out := in
 	out.UserAgent = strings.TrimSpace(out.UserAgent)
+	out.ClientIdentifier = strings.TrimSpace(out.ClientIdentifier)
+	out.ClientVersion = strings.TrimSpace(out.ClientVersion)
 	out.GrokConversationID = strings.TrimSpace(out.GrokConversationID)
 	out.CustomHeaders = cleanIdentityFingerprintHeaders(out.CustomHeaders)
 	return out

--- a/internal/identityfingerprint/extract.go
+++ b/internal/identityfingerprint/extract.go
@@ -23,6 +23,8 @@ const (
 	FieldGeminiAPIClient        = "x-goog-api-client"
 	FieldGeminiClientMetadata   = "client-metadata"
 	FieldXAIGrokConversationID  = "x-grok-conv-id"
+	FieldXAIClientIdentifier    = "x-grok-client-identifier"
+	FieldXAIClientVersion       = "x-grok-client-version"
 )
 
 var (
@@ -173,10 +175,14 @@ func extractGeminiObservation(input LearnInput, headers http.Header, observedAt 
 
 func extractXAIObservation(input LearnInput, headers http.Header, observedAt time.Time) (Observation, bool) {
 	ua := strings.TrimSpace(headers.Get("User-Agent"))
-	grokConversationID := strings.TrimSpace(headers.Get("X-Grok-Conv-Id"))
+	clientIdentifier := strings.TrimSpace(headers.Get("X-Grok-Client-Identifier"))
+	clientVersion := strings.TrimSpace(headers.Get("X-Grok-Client-Version"))
 	product, version := xaiProductVersion(ua)
-	if product == "" && grokConversationID != "" {
-		product = "grok-cli"
+	if product == "" && clientIdentifier != "" {
+		product = clientIdentifier
+	}
+	if version == "" {
+		version = clientVersion
 	}
 	if product == "" {
 		return Observation{}, false
@@ -185,8 +191,11 @@ func extractXAIObservation(input LearnInput, headers http.Header, observedAt tim
 	if ua != "" {
 		fields[FieldUserAgent] = ua
 	}
-	if grokConversationID != "" {
-		fields[FieldXAIGrokConversationID] = grokConversationID
+	if clientIdentifier != "" {
+		fields[FieldXAIClientIdentifier] = clientIdentifier
+	}
+	if clientVersion != "" {
+		fields[FieldXAIClientVersion] = clientVersion
 	}
 	if len(fields) == 0 {
 		return Observation{}, false
@@ -199,7 +208,7 @@ func extractXAIObservation(input LearnInput, headers http.Header, observedAt tim
 		ClientVariant:   "cli",
 		Version:         version,
 		Fields:          fields,
-		ObservedHeaders: observedHeaders(headers, []string{"User-Agent", "X-Grok-Conv-Id"}),
+		ObservedHeaders: observedHeaders(headers, []string{"User-Agent", "X-Grok-Client-Identifier", "X-Grok-Client-Version"}),
 		ObservedAt:      observedAt.UTC(),
 	}, true
 }

--- a/internal/identityfingerprint/extract_resolve_test.go
+++ b/internal/identityfingerprint/extract_resolve_test.go
@@ -97,7 +97,9 @@ func TestExtractCodexObservationVersionHeaderOverridesUserAgentVersion(t *testin
 
 func TestExtractXAIObservationFromGrokHeaders(t *testing.T) {
 	headers := http.Header{}
-	headers.Set("User-Agent", "grok-cli/0.3.1 (darwin arm64)")
+	headers.Set("User-Agent", "grok-shell/0.2.93 (macos; aarch64)")
+	headers.Set("X-Grok-Client-Identifier", "grok-shell")
+	headers.Set("X-Grok-Client-Version", "0.2.93")
 	headers.Set("X-Grok-Conv-Id", "conv-123")
 
 	obs, ok := ExtractObservation(LearnInput{
@@ -109,11 +111,17 @@ func TestExtractXAIObservationFromGrokHeaders(t *testing.T) {
 	if !ok {
 		t.Fatal("ExtractObservation returned false")
 	}
-	if obs.ClientProduct != "grok-cli" || obs.Version != "0.3.1" {
-		t.Fatalf("product/version = %s/%s, want grok-cli/0.3.1", obs.ClientProduct, obs.Version)
+	if obs.ClientProduct != "grok-shell" || obs.Version != "0.2.93" {
+		t.Fatalf("product/version = %s/%s, want grok-shell/0.2.93", obs.ClientProduct, obs.Version)
 	}
-	if got := obs.Fields[FieldXAIGrokConversationID]; got != "conv-123" {
-		t.Fatalf("x-grok-conv-id = %q, want conv-123", got)
+	if got := obs.Fields[FieldXAIClientIdentifier]; got != "grok-shell" {
+		t.Fatalf("x-grok-client-identifier = %q, want grok-shell", got)
+	}
+	if got := obs.Fields[FieldXAIClientVersion]; got != "0.2.93" {
+		t.Fatalf("x-grok-client-version = %q, want 0.2.93", got)
+	}
+	if got := obs.Fields[FieldXAIGrokConversationID]; got != "" {
+		t.Fatalf("x-grok-conv-id learned = %q, want dynamic field ignored", got)
 	}
 }
 
@@ -307,19 +315,22 @@ func TestResolveXAIUsesLearnedWhenPresetEmpty(t *testing.T) {
 	learned := &LearnedRecord{
 		Provider:      ProviderXAI,
 		AccountKey:    "acct",
-		ClientProduct: "grok-cli",
-		Version:       "0.3.1",
+		ClientProduct: "grok-shell",
+		Version:       "0.2.93",
 		Fields: map[string]string{
-			FieldUserAgent:             "grok-cli/0.3.1 (darwin arm64)",
-			FieldXAIGrokConversationID: "conv-123",
+			FieldUserAgent:           "grok-shell/0.2.93 (macos; aarch64)",
+			FieldXAIClientIdentifier: "grok-shell",
+			FieldXAIClientVersion:    "0.2.93",
 		},
 	}
 
 	fp, effective := ResolveXAI(config.XAIIdentityFingerprintConfig{Enabled: true}, learned)
-	if fp.UserAgent != "grok-cli/0.3.1 (darwin arm64)" || fp.GrokConversationID != "conv-123" {
+	if fp.UserAgent != "grok-shell/0.2.93 (macos; aarch64)" ||
+		fp.ClientIdentifier != "grok-shell" ||
+		fp.ClientVersion != "0.2.93" {
 		t.Fatalf("resolved xAI fingerprint = %#v, want learned fields", fp)
 	}
-	if effective.Version != "0.3.1" {
+	if effective.Version != "0.2.93" {
 		t.Fatalf("effective version = %q, want learned version", effective.Version)
 	}
 	if got := effective.Fields[FieldUserAgent].Source; got != FieldSourceLearned {

--- a/internal/identityfingerprint/resolve.go
+++ b/internal/identityfingerprint/resolve.go
@@ -117,12 +117,14 @@ func ResolveXAI(cfg config.XAIIdentityFingerprintConfig, learned *LearnedRecord)
 	resolved := config.XAIIdentityFingerprintConfig{
 		Enabled:            clean.Enabled,
 		UserAgent:          pick(FieldUserAgent, clean.UserAgent, learnedField(learned, FieldUserAgent), defaults.UserAgent),
-		GrokConversationID: pick(FieldXAIGrokConversationID, clean.GrokConversationID, learnedField(learned, FieldXAIGrokConversationID), defaults.GrokConversationID),
+		ClientIdentifier:   pick(FieldXAIClientIdentifier, clean.ClientIdentifier, learnedField(learned, FieldXAIClientIdentifier), defaults.ClientIdentifier),
+		ClientVersion:      pick(FieldXAIClientVersion, clean.ClientVersion, learnedFieldOrVersion(learned, FieldXAIClientVersion), defaults.ClientVersion),
+		GrokConversationID: strings.TrimSpace(clean.GrokConversationID),
 		CustomHeaders:      clean.CustomHeaders,
 	}
 	effective := effective(ProviderXAI, clean.Enabled, learned, fields)
-	if learned != nil {
-		effective.Version = strings.TrimSpace(learned.Version)
+	if value := strings.TrimSpace(resolved.ClientVersion); value != "" {
+		effective.Version = value
 	}
 	return resolved, effective
 }

--- a/internal/management/settings/runtimeconfig/spec.go
+++ b/internal/management/settings/runtimeconfig/spec.go
@@ -441,6 +441,8 @@ func xaiIdentityFingerprintMeaningful(fp config.XAIIdentityFingerprintConfig) bo
 	clean := config.CleanXAIIdentityFingerprint(fp)
 	return clean.Enabled ||
 		strings.TrimSpace(clean.UserAgent) != "" ||
+		strings.TrimSpace(clean.ClientIdentifier) != "" ||
+		strings.TrimSpace(clean.ClientVersion) != "" ||
 		strings.TrimSpace(clean.GrokConversationID) != "" ||
 		len(clean.CustomHeaders) > 0
 }

--- a/internal/runtime/executor/identity_fingerprint_runtime_test.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime_test.go
@@ -384,27 +384,41 @@ func TestXAIHeadersReplayLearnedFingerprintWithoutInboundHeaders(t *testing.T) {
 		},
 	}
 	inbound := http.Header{}
-	inbound.Set("User-Agent", "grok-cli/0.3.1 (darwin arm64)")
+	inbound.Set("User-Agent", "grok-shell/0.2.93 (macos; aarch64)")
+	inbound.Set("X-Grok-Client-Identifier", "grok-shell")
+	inbound.Set("X-Grok-Client-Version", "0.2.93")
 	inbound.Set("X-Grok-Conv-Id", "conv-123")
 	ctx := contextWithInboundHeaders(http.MethodPost, "/v1/responses", inbound)
 
 	req := httptest.NewRequest(http.MethodPost, "https://api.x.ai/v1/responses", nil)
 	req = req.WithContext(ctx)
 	applyXAIHeaders(req, cfg, auth, "xai-token", true)
-	if got := req.Header.Get("User-Agent"); got != "grok-cli/0.3.1 (darwin arm64)" {
+	if got := req.Header.Get("User-Agent"); got != "grok-shell/0.2.93 (macos; aarch64)" {
 		t.Fatalf("User-Agent = %q, want learned xAI UA", got)
 	}
+	if got := req.Header.Get("X-Grok-Client-Identifier"); got != "grok-shell" {
+		t.Fatalf("X-Grok-Client-Identifier = %q, want learned xAI client identifier", got)
+	}
+	if got := req.Header.Get("X-Grok-Client-Version"); got != "0.2.93" {
+		t.Fatalf("X-Grok-Client-Version = %q, want learned xAI client version", got)
+	}
 	if got := req.Header.Get("X-Grok-Conv-Id"); got != "conv-123" {
-		t.Fatalf("X-Grok-Conv-Id = %q, want learned xAI conversation id", got)
+		t.Fatalf("X-Grok-Conv-Id = %q, want passthrough xAI conversation id", got)
 	}
 
 	replayReq := httptest.NewRequest(http.MethodPost, "https://api.x.ai/v1/responses", nil)
 	applyXAIHeaders(replayReq, cfg, auth, "xai-token", true)
-	if got := replayReq.Header.Get("User-Agent"); got != "grok-cli/0.3.1 (darwin arm64)" {
+	if got := replayReq.Header.Get("User-Agent"); got != "grok-shell/0.2.93 (macos; aarch64)" {
 		t.Fatalf("replayed User-Agent = %q, want stored learned xAI UA", got)
 	}
-	if got := replayReq.Header.Get("X-Grok-Conv-Id"); got != "conv-123" {
-		t.Fatalf("replayed X-Grok-Conv-Id = %q, want stored learned xAI conversation id", got)
+	if got := replayReq.Header.Get("X-Grok-Client-Identifier"); got != "grok-shell" {
+		t.Fatalf("replayed X-Grok-Client-Identifier = %q, want stored learned xAI client identifier", got)
+	}
+	if got := replayReq.Header.Get("X-Grok-Client-Version"); got != "0.2.93" {
+		t.Fatalf("replayed X-Grok-Client-Version = %q, want stored learned xAI client version", got)
+	}
+	if got := replayReq.Header.Get("X-Grok-Conv-Id"); got != "" {
+		t.Fatalf("replayed X-Grok-Conv-Id = %q, want dynamic value omitted without inbound header", got)
 	}
 }
 

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -391,6 +391,7 @@ func applyXAIHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.Aut
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(r, attrs)
+	applyXAIPassthroughHeaders(r.Header, identityFingerprintHeadersFromContext(r.Context()))
 	if fp, ok := xaiIdentityFingerprint(cfg, auth, r.Context()); ok {
 		applyXAIIdentityFingerprintHeaders(r.Header, fp)
 	}

--- a/internal/runtime/executor/xai_identity_fingerprint.go
+++ b/internal/runtime/executor/xai_identity_fingerprint.go
@@ -26,8 +26,11 @@ func applyXAIIdentityFingerprintHeaders(headers http.Header, fp config.XAIIdenti
 	if strings.TrimSpace(fp.UserAgent) != "" {
 		headers.Set("User-Agent", fp.UserAgent)
 	}
-	if strings.TrimSpace(fp.GrokConversationID) != "" {
-		headers.Set("X-Grok-Conv-Id", fp.GrokConversationID)
+	if strings.TrimSpace(fp.ClientIdentifier) != "" {
+		headers.Set("X-Grok-Client-Identifier", fp.ClientIdentifier)
+	}
+	if strings.TrimSpace(fp.ClientVersion) != "" {
+		headers.Set("X-Grok-Client-Version", fp.ClientVersion)
 	}
 	for key, value := range fp.CustomHeaders {
 		key = strings.TrimSpace(key)
@@ -39,9 +42,27 @@ func applyXAIIdentityFingerprintHeaders(headers http.Header, fp config.XAIIdenti
 	}
 }
 
+func applyXAIPassthroughHeaders(headers, inbound http.Header) {
+	if headers == nil || inbound == nil {
+		return
+	}
+	for _, key := range []string{
+		"X-Grok-Agent-Id",
+		"X-Grok-Session-Id",
+		"X-Grok-Req-Id",
+		"X-Grok-Conv-Id",
+		"X-Grok-Model-Override",
+	} {
+		if value := strings.TrimSpace(inbound.Get(key)); value != "" {
+			headers.Set(key, value)
+		}
+	}
+}
+
 func isXAIFingerprintRuntimeBlockedHeader(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "authorization", "content-type", "accept", "connection", "user-agent", "x-grok-conv-id":
+	case "authorization", "content-type", "accept", "connection", "user-agent",
+		"x-grok-client-identifier", "x-grok-client-version", "x-grok-conv-id":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
- learn stable Grok OAuth identity headers: User-Agent, X-Grok-Client-Identifier, X-Grok-Client-Version
- add xAI system default fingerprint fields for account-security details before learning
- pass through dynamic Grok headers like X-Grok-Conv-Id without storing them as unified identity

## Verification
- rtk go test ./internal/identityfingerprint ./internal/runtime/executor ./internal/api/handlers/management -run 'IdentityFingerprint|XAI'
- rtk go test ./internal/identityfingerprint ./internal/runtime/executor