### PR TITLE
feat: fetch xAI models dynamically

### DIFF
--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -403,6 +403,10 @@ func FetchAntigravityModels(ctx context.Context, auth *coreauth.Auth, cfg *confi
 	return executor.FetchAntigravityModels(ctx, auth, cfg)
 }
 
+func FetchXAIModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return executor.FetchXAIModels(ctx, auth, cfg)
+}
+
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	if coreManager == nil || auth == nil {
 		return

--- a/internal/runtime/executor/xai_models.go
+++ b/internal/runtime/executor/xai_models.go
@@ -1,0 +1,280 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	xaiModelsPath                  = "/models"
+	xaiGrokBuildClientModelAlias   = "grok-build"
+	xaiGrokBuildUpstreamModelAlias = "grok-build-0.1"
+)
+
+var xaiModelsCache struct {
+	mu     sync.RWMutex
+	models []*sdkmodelcatalog.ModelInfo
+}
+
+type xaiModelsResponse struct {
+	Data []xaiModelPayload `json:"data"`
+}
+
+type xaiModelPayload struct {
+	ID                  string   `json:"id"`
+	Aliases             []string `json:"aliases"`
+	Object              string   `json:"object"`
+	Created             int64    `json:"created"`
+	OwnedBy             string   `json:"owned_by"`
+	ContextLength       int      `json:"context_length"`
+	MaxCompletionTokens int      `json:"max_completion_tokens"`
+}
+
+func cloneXAIModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		if len(model.SupportedGenerationMethods) > 0 {
+			clone.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedParameters) > 0 {
+			clone.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+		}
+		if model.Thinking != nil {
+			thinkingClone := *model.Thinking
+			if len(model.Thinking.Levels) > 0 {
+				thinkingClone.Levels = append([]string(nil), model.Thinking.Levels...)
+			}
+			clone.Thinking = &thinkingClone
+		}
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func storeXAIModels(models []*sdkmodelcatalog.ModelInfo) bool {
+	cloned := cloneXAIModels(models)
+	if len(cloned) == 0 {
+		return false
+	}
+	xaiModelsCache.mu.Lock()
+	xaiModelsCache.models = cloned
+	xaiModelsCache.mu.Unlock()
+	return true
+}
+
+func loadXAIModels() []*sdkmodelcatalog.ModelInfo {
+	xaiModelsCache.mu.RLock()
+	cloned := cloneXAIModels(xaiModelsCache.models)
+	xaiModelsCache.mu.RUnlock()
+	return cloned
+}
+
+func fallbackXAIModels() []*sdkmodelcatalog.ModelInfo {
+	if models := loadXAIModels(); len(models) > 0 {
+		log.Debugf("xai executor: using cached model list (%d models)", len(models))
+		return models
+	}
+	return nil
+}
+
+// FetchXAIModels retrieves the OAuth account's live model list from xAI.
+func FetchXAIModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token, baseURL := xaiCreds(auth)
+	if strings.TrimSpace(token) == "" {
+		return fallbackXAIModels()
+	}
+	if baseURL == "" {
+		baseURL = xaiauth.DefaultAPIBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+xaiModelsPath, nil)
+	if err != nil {
+		return fallbackXAIModels()
+	}
+	applyXAIHeaders(req, cfg, auth, token, false)
+
+	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Debugf("xai executor: models request failed: %v", err)
+		}
+		return fallbackXAIModels()
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("xai executor: close models response body error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		log.Debugf("xai executor: models request failed with status %d", resp.StatusCode)
+		return fallbackXAIModels()
+	}
+
+	body, err := readUpstreamResponseBody("xai", resp.Body)
+	if err != nil {
+		log.Debugf("xai executor: models response read failed: %v", err)
+		return fallbackXAIModels()
+	}
+
+	models, ok := parseXAIModels(body, time.Now().Unix())
+	if !ok {
+		log.Debug("xai executor: fetched empty or invalid model list; retaining cached model list")
+		return fallbackXAIModels()
+	}
+	storeXAIModels(models)
+	return models
+}
+
+func parseXAIModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var decoded xaiModelsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, false
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(decoded.Data))
+	seen := make(map[string]struct{}, len(decoded.Data))
+	for _, item := range decoded.Data {
+		modelID := strings.TrimSpace(item.ID)
+		if modelID == "" {
+			continue
+		}
+		model := xaiModelInfoFromPayload(item, modelID, now)
+		addXAIModel(&out, seen, model)
+		for _, alias := range item.Aliases {
+			alias = strings.TrimSpace(alias)
+			if alias == "" || strings.EqualFold(alias, modelID) {
+				continue
+			}
+			clone := *model
+			clone.ID = alias
+			clone.Name = alias
+			clone.UpstreamModelID = modelID
+			addXAIModel(&out, seen, &clone)
+		}
+	}
+	out = withXAIGrokBuildCompatibilityAlias(out)
+	return out, len(out) > 0
+}
+
+func xaiModelInfoFromPayload(item xaiModelPayload, modelID string, now int64) *sdkmodelcatalog.ModelInfo {
+	object := strings.TrimSpace(item.Object)
+	if object == "" {
+		object = "model"
+	}
+	ownedBy := strings.TrimSpace(item.OwnedBy)
+	if ownedBy == "" {
+		ownedBy = "xai"
+	}
+	created := item.Created
+	if created == 0 {
+		created = now
+	}
+	model := &sdkmodelcatalog.ModelInfo{
+		ID:                  modelID,
+		Object:              object,
+		Created:             created,
+		OwnedBy:             ownedBy,
+		Type:                "xai",
+		DisplayName:         modelID,
+		Name:                modelID,
+		Version:             modelID,
+		ContextLength:       item.ContextLength,
+		InputTokenLimit:     item.ContextLength,
+		MaxCompletionTokens: item.MaxCompletionTokens,
+		OutputTokenLimit:    item.MaxCompletionTokens,
+	}
+	if static := sdkmodelcatalog.LookupStaticModelInfo(modelID); static != nil {
+		model.Description = static.Description
+		model.DisplayName = firstNonEmptyString(static.DisplayName, model.DisplayName)
+		model.Thinking = cloneXAIThinking(static.Thinking)
+	}
+	return model
+}
+
+func addXAIModel(models *[]*sdkmodelcatalog.ModelInfo, seen map[string]struct{}, model *sdkmodelcatalog.ModelInfo) {
+	if model == nil {
+		return
+	}
+	id := strings.TrimSpace(model.ID)
+	if id == "" {
+		return
+	}
+	key := strings.ToLower(id)
+	if _, exists := seen[key]; exists {
+		return
+	}
+	seen[key] = struct{}{}
+	*models = append(*models, model)
+}
+
+func withXAIGrokBuildCompatibilityAlias(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return models
+	}
+	var upstream *sdkmodelcatalog.ModelInfo
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		id := strings.TrimSpace(model.ID)
+		if strings.EqualFold(id, xaiGrokBuildClientModelAlias) {
+			return models
+		}
+		if strings.EqualFold(id, xaiGrokBuildUpstreamModelAlias) {
+			upstream = model
+		}
+	}
+	if upstream == nil {
+		return models
+	}
+	clone := *upstream
+	clone.ID = xaiGrokBuildClientModelAlias
+	clone.Name = xaiGrokBuildClientModelAlias
+	clone.UpstreamModelID = strings.TrimSpace(upstream.ID)
+	clone.DisplayName = "Grok Build"
+	return append(models, &clone)
+}
+
+func cloneXAIThinking(thinking *sdkmodelcatalog.ThinkingSupport) *sdkmodelcatalog.ThinkingSupport {
+	if thinking == nil {
+		return nil
+	}
+	clone := *thinking
+	if len(thinking.Levels) > 0 {
+		clone.Levels = append([]string(nil), thinking.Levels...)
+	}
+	return &clone
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/runtime/executor/xai_models_test.go
+++ b/internal/runtime/executor/xai_models_test.go
@@ -1,0 +1,104 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+func resetXAIModelsCacheForTest() {
+	xaiModelsCache.mu.Lock()
+	xaiModelsCache.models = nil
+	xaiModelsCache.mu.Unlock()
+}
+
+func TestFetchXAIModelsParsesLiveCatalogAndAliases(t *testing.T) {
+	resetXAIModelsCacheForTest()
+	t.Cleanup(resetXAIModelsCacheForTest)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != xaiModelsPath {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, xaiModelsPath)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer xai-token" {
+			t.Fatalf("authorization header = %q, want bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{
+					"id": "grok-build-0.1",
+					"aliases": ["grok-code-fast-1", "grok-code-fast"],
+					"object": "model",
+					"created": 1776297600,
+					"owned_by": "xai",
+					"context_length": 256000,
+					"max_completion_tokens": 128000
+				},
+				{
+					"id": "grok-4.5",
+					"aliases": ["grok-build-latest"],
+					"object": "model",
+					"created": 1782691200,
+					"owned_by": "xai",
+					"context_length": 500000
+				}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	models := FetchXAIModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"api_key":  "xai-token",
+			"base_url": srv.URL,
+		},
+	}, nil)
+
+	byID := make(map[string]*sdkmodelcatalog.ModelInfo, len(models))
+	for _, model := range models {
+		if model != nil {
+			byID[model.ID] = model
+		}
+	}
+	if byID["grok-build-0.1"] == nil {
+		t.Fatal("missing upstream grok-build-0.1 model")
+	}
+	if got := byID["grok-build-0.1"].ContextLength; got != 256000 {
+		t.Fatalf("grok-build-0.1 context length = %d, want 256000", got)
+	}
+	if got := byID["grok-code-fast-1"].UpstreamModelID; got != "grok-build-0.1" {
+		t.Fatalf("grok-code-fast-1 upstream = %q, want grok-build-0.1", got)
+	}
+	if got := byID["grok-build-latest"].UpstreamModelID; got != "grok-4.5" {
+		t.Fatalf("grok-build-latest upstream = %q, want grok-4.5", got)
+	}
+	if got := byID["grok-build"].UpstreamModelID; got != "grok-build-0.1" {
+		t.Fatalf("grok-build compatibility upstream = %q, want grok-build-0.1", got)
+	}
+}
+
+func TestFetchXAIModelsFallsBackToCachedCatalog(t *testing.T) {
+	resetXAIModelsCacheForTest()
+	t.Cleanup(resetXAIModelsCacheForTest)
+
+	if ok := storeXAIModels([]*sdkmodelcatalog.ModelInfo{{ID: "cached-xai-model", OwnedBy: "xai", Type: "xai"}}); !ok {
+		t.Fatal("expected cache seed to store")
+	}
+
+	models := FetchXAIModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"api_key":  "xai-token",
+			"base_url": "http://127.0.0.1:1",
+		},
+	}, nil)
+	if len(models) != 1 || models[0].ID != "cached-xai-model" {
+		t.Fatalf("fallback models = %+v, want cached-xai-model", models)
+	}
+}

--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -19,6 +19,8 @@ type oauthModelAliasTable struct {
 const (
 	codexAutoReviewModel         = "codex-auto-review"
 	codexAutoReviewUpstreamModel = "gpt-5.5"
+	xaiGrokBuildModel            = "grok-build"
+	xaiGrokBuildUpstreamModel    = "grok-build-0.1"
 )
 
 func compileOAuthModelAliasTable(aliases map[string][]sdkconfig.OAuthModelAlias) *oauthModelAliasTable {
@@ -83,6 +85,9 @@ func (m *Manager) applyOAuthModelAlias(auth *Auth, requestedModel string) string
 			if builtIn := resolveBuiltInCodexModelAlias(auth, requestedModel); builtIn != "" {
 				return builtIn
 			}
+			if builtIn := resolveBuiltInXAIModelAlias(auth, requestedModel); builtIn != "" {
+				return builtIn
+			}
 		}
 		return requestedModel
 	}
@@ -105,6 +110,24 @@ func resolveBuiltInCodexModelAlias(auth *Auth, requestedModel string) string {
 		return codexAutoReviewUpstreamModel + "(" + parsed.RawSuffix + ")"
 	}
 	return codexAutoReviewUpstreamModel
+}
+
+func resolveBuiltInXAIModelAlias(auth *Auth, requestedModel string) string {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "xai") {
+		return ""
+	}
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return ""
+	}
+	parsed := parseModelSuffix(requestedModel)
+	if !strings.EqualFold(strings.TrimSpace(parsed.ModelName), xaiGrokBuildModel) {
+		return ""
+	}
+	if parsed.HasSuffix && parsed.RawSuffix != "" {
+		return xaiGrokBuildUpstreamModel + "(" + parsed.RawSuffix + ")"
+	}
+	return xaiGrokBuildUpstreamModel
 }
 
 func resolveModelAliasFromConfigModels(requestedModel string, models []modelAliasEntry) string {
@@ -244,7 +267,7 @@ func modelAliasChannel(auth *Auth) string {
 // and auth kind. Returns empty string if the provider/authKind combination doesn't support
 // OAuth model alias (e.g., API key authentication).
 //
-// Supported channels: gemini-cli, vertex, aistudio, antigravity, claude, codex, qwen, iflow, kimi.
+// Supported channels: gemini-cli, vertex, aistudio, antigravity, claude, codex, qwen, xai, iflow, kimi.
 func OAuthModelAliasChannel(provider, authKind string) string {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	authKind = strings.ToLower(strings.TrimSpace(authKind))
@@ -268,7 +291,7 @@ func OAuthModelAliasChannel(provider, authKind string) string {
 			return ""
 		}
 		return "codex"
-	case "gemini-cli", "aistudio", "antigravity", "qwen", "iflow", "kimi":
+	case "gemini-cli", "aistudio", "antigravity", "qwen", "xai", "iflow", "kimi":
 		return provider
 	default:
 		return ""

--- a/sdk/cliproxy/auth/oauth_model_alias_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_test.go
@@ -163,8 +163,18 @@ func createAuthForChannel(channel string) *Auth {
 		return &Auth{Provider: "iflow"}
 	case "kimi":
 		return &Auth{Provider: "kimi"}
+	case "xai":
+		return &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth"}}
 	default:
 		return &Auth{Provider: channel}
+	}
+}
+
+func TestOAuthModelAliasChannel_XAI(t *testing.T) {
+	t.Parallel()
+
+	if got := OAuthModelAliasChannel("xai", "oauth"); got != "xai" {
+		t.Fatalf("OAuthModelAliasChannel() = %q, want %q", got, "xai")
 	}
 }
 
@@ -215,5 +225,27 @@ func TestApplyOAuthModelAlias_BuiltInCodexAutoReview(t *testing.T) {
 	resolvedModel := mgr.applyOAuthModelAlias(auth, "codex-auto-review")
 	if resolvedModel != "gpt-5.5" {
 		t.Errorf("applyOAuthModelAlias() model = %q, want %q", resolvedModel, "gpt-5.5")
+	}
+}
+
+func TestApplyOAuthModelAlias_BuiltInXAIGrokBuild(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+
+	auth := &Auth{
+		ID:       "xai-oauth",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+	}
+
+	if got := mgr.applyOAuthModelAlias(auth, "grok-build"); got != "grok-build-0.1" {
+		t.Fatalf("applyOAuthModelAlias() = %q, want grok-build-0.1", got)
+	}
+	if got := mgr.applyOAuthModelAlias(auth, "grok-build(high)"); got != "grok-build-0.1(high)" {
+		t.Fatalf("applyOAuthModelAlias() with suffix = %q, want grok-build-0.1(high)", got)
 	}
 }

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -192,8 +192,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("qwen")
 		models = applyExcludedModels(models, excluded)
 	case "xai":
-		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("xai")
-		models = applyExcludedModels(models, excluded)
+		models = s.fetchXAIRegistryModels(ctx, a, excluded)
 	case "iflow":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("iflow")
 		models = applyExcludedModels(models, excluded)

--- a/sdk/cliproxy/service_model_xai.go
+++ b/sdk/cliproxy/service_model_xai.go
@@ -1,0 +1,20 @@
+package cliproxy
+
+import (
+	"context"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
+)
+
+func (s *Service) fetchXAIRegistryModels(ctx context.Context, auth *coreauth.Auth, excluded []string) []*ModelInfo {
+	fetchCtx := ctx
+	if fetchCtx == nil {
+		fetchCtx = context.Background()
+	}
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(fetchCtx), 15*time.Second)
+	defer cancel()
+	models := serviceapp.FetchXAIModels(fetchCtx, auth, s.cfg)
+	return applyExcludedModels(models, excluded)
+}

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -95,6 +95,10 @@ func FetchAntigravityModels(ctx context.Context, auth *coreauth.Auth, cfg *confi
 	return internalserviceapp.FetchAntigravityModels(ctx, auth, cfg)
 }
 
+func FetchXAIModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.FetchXAIModels(ctx, auth, cfg)
+}
+
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	internalserviceapp.RegisterExecutorForAuth(coreManager, cfg, auth, forceReplace, gateway)
 }


### PR DESCRIPTION
## Summary
- fetch xAI/Grok model list from the OAuth account via `/models` during registry registration
- register live `aliases` as routable model IDs and keep the last successful dynamic list as fallback
- add xAI alias-channel support and `grok-build -> grok-build-0.1` execution compatibility for Grok CLI

## Verification
- relay.07230805.xyz live xAI OAuth `/models`: HTTP 200, count=10, includes `grok-build-0.1` aliases `grok-code-fast-1,grok-code-fast,grok-code-fast-1-0825`
- `rtk go test ./internal/runtime/executor ./sdk/cliproxy/auth ./sdk/cliproxy`
- `rtk go test ./...`