### PR TITLE
fix: default identity fingerprint providers on

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/runtimeconfig"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
@@ -31,14 +32,9 @@ func (h *Handler) GetIdentityFingerprint(c *gin.Context) {
 	learned, effective := h.identityFingerprintState(current)
 	c.JSON(http.StatusOK, identityFingerprintResponse{
 		IdentityFingerprint: current,
-		Defaults: config.IdentityFingerprintConfig{
-			Codex:  config.DefaultCodexIdentityFingerprint(),
-			Claude: config.DefaultClaudeIdentityFingerprint(),
-			Gemini: config.DefaultGeminiIdentityFingerprint(),
-			XAI:    config.DefaultXAIIdentityFingerprint(),
-		},
-		Learned:   learned,
-		Effective: effective,
+		Defaults:            config.DefaultIdentityFingerprintConfig(),
+		Learned:             learned,
+		Effective:           effective,
 		Status: map[string]identityFingerprintProviderStatus{
 			"claude": {Enabled: current.Claude.Enabled, LearnedCount: len(learned["claude"])},
 			"codex":  {Enabled: current.Codex.Enabled, LearnedCount: len(learned["codex"])},
@@ -55,10 +51,7 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 		return
 	}
 
-	body.Codex = config.CleanCodexIdentityFingerprint(body.Codex)
-	body.Claude = config.CleanClaudeIdentityFingerprint(body.Claude)
-	body.Gemini = config.CleanGeminiIdentityFingerprint(body.Gemini)
-	body.XAI = config.CleanXAIIdentityFingerprint(body.XAI)
+	body = config.NormalizeIdentityFingerprintConfig(body)
 	if err := validateCodexIdentityFingerprint(body.Codex); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -90,7 +83,7 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 	h.cfg.IdentityFingerprint = body
 	h.mu.Unlock()
 
-	if !h.persistRuntimeSetting(c, settingsstore.RuntimeSettingIdentityFingerprint, body) {
+	if !h.persistRuntimeSetting(c, settingsstore.RuntimeSettingIdentityFingerprint, runtimeconfig.IdentityFingerprintRuntimeSettingValue(body)) {
 		h.mu.Lock()
 		if h.cfg != nil {
 			h.cfg.IdentityFingerprint = previous

--- a/internal/api/handlers/management/identity_fingerprint_account.go
+++ b/internal/api/handlers/management/identity_fingerprint_account.go
@@ -138,11 +138,7 @@ func (h *Handler) currentIdentityFingerprintConfig() config.IdentityFingerprintC
 		}
 		h.mu.Unlock()
 	}
-	current.Codex = config.CleanCodexIdentityFingerprint(current.Codex)
-	current.Claude = config.CleanClaudeIdentityFingerprint(current.Claude)
-	current.Gemini = config.CleanGeminiIdentityFingerprint(current.Gemini)
-	current.XAI = config.CleanXAIIdentityFingerprint(current.XAI)
-	return current
+	return config.NormalizeIdentityFingerprintConfig(current)
 }
 
 func resolveIdentityFingerprint(current config.IdentityFingerprintConfig, provider identityfingerprint.Provider, learned *identityfingerprint.LearnedRecord) (identityfingerprint.EffectiveFingerprint, any, any) {

--- a/internal/api/handlers/management/runtime_settings_test.go
+++ b/internal/api/handlers/management/runtime_settings_test.go
@@ -53,6 +53,16 @@ func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
 		stored.IdentityFingerprint.Claude.SessionMode != "server-stable" {
 		t.Fatalf("stored claude identity fingerprint = %#v", stored.IdentityFingerprint.Claude)
 	}
+	if !stored.IdentityFingerprint.Gemini.Enabled {
+		t.Fatalf("stored gemini identity fingerprint = %#v, want enabled by default", stored.IdentityFingerprint.Gemini)
+	}
+	if !stored.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("stored xai identity fingerprint = %#v, want enabled by default", stored.IdentityFingerprint.XAI)
+	}
+	payload, ok := settingsstore.GetRuntimeSettingPayload(settingsstore.RuntimeSettingIdentityFingerprint)
+	if !ok || !strings.Contains(string(payload), `"runtime-setting-version":2`) {
+		t.Fatalf("identity fingerprint runtime payload = %s, want versioned payload", string(payload))
+	}
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -271,6 +271,12 @@ func TestLoadConfigDefaultsAutoUpdateEnabled(t *testing.T) {
 	if cfg.AutoUpdate.UpdaterURL != DefaultAutoUpdateUpdaterURL {
 		t.Fatalf("AutoUpdate.UpdaterURL = %q, want %q", cfg.AutoUpdate.UpdaterURL, DefaultAutoUpdateUpdaterURL)
 	}
+	if !cfg.IdentityFingerprint.Codex.Enabled ||
+		!cfg.IdentityFingerprint.Claude.Enabled ||
+		!cfg.IdentityFingerprint.Gemini.Enabled ||
+		!cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want all providers enabled by default", cfg.IdentityFingerprint)
+	}
 }
 
 func TestLoadConfigReadsDisabledAutoUpdate(t *testing.T) {
@@ -308,6 +314,34 @@ auto-update:
 	}
 	if cfg.AutoUpdate.UpdaterURL != "http://updater.local:8320" {
 		t.Fatalf("AutoUpdate.UpdaterURL = %q, want http://updater.local:8320", cfg.AutoUpdate.UpdaterURL)
+	}
+}
+
+func TestLoadConfigIdentityFingerprintDefaultsAndExplicitDisabled(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`port: 8317
+identity-fingerprint:
+  xai:
+    enabled: false
+`)
+	if err := os.WriteFile(configPath, content, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if !cfg.IdentityFingerprint.Codex.Enabled ||
+		!cfg.IdentityFingerprint.Claude.Enabled ||
+		!cfg.IdentityFingerprint.Gemini.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want omitted providers enabled by default", cfg.IdentityFingerprint)
+	}
+	if cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("XAI.Enabled = true, want explicit false from config")
 	}
 }
 

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -1,6 +1,11 @@
 package config
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
 
 const (
 	// Defaults are intentionally aligned with upstream CLIProxyAPI's codex-tui behavior.
@@ -48,12 +53,13 @@ type CodexIdentityFingerprintConfig struct {
 	SessionMode   string            `yaml:"session-mode,omitempty" json:"session-mode,omitempty"`
 	SessionID     string            `yaml:"session-id,omitempty" json:"session-id,omitempty"`
 	CustomHeaders map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet    bool
 }
 
 // DefaultCodexIdentityFingerprint returns the recommended Codex identity template.
 func DefaultCodexIdentityFingerprint() CodexIdentityFingerprintConfig {
 	return CodexIdentityFingerprintConfig{
-		Enabled:       false,
+		Enabled:       true,
 		UserAgent:     DefaultCodexFingerprintUserAgent,
 		Version:       DefaultCodexFingerprintVersion,
 		Originator:    DefaultCodexFingerprintOriginator,
@@ -78,6 +84,7 @@ type ClaudeIdentityFingerprintConfig struct {
 	SessionID               string            `yaml:"session-id,omitempty" json:"session-id,omitempty"`
 	DeviceID                string            `yaml:"device-id,omitempty" json:"device-id,omitempty"`
 	CustomHeaders           map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet              bool
 }
 
 // GeminiIdentityFingerprintConfig configures Gemini CLI upstream identity headers.
@@ -87,6 +94,7 @@ type GeminiIdentityFingerprintConfig struct {
 	APIClient      string            `yaml:"x-goog-api-client,omitempty" json:"x-goog-api-client,omitempty"`
 	ClientMetadata string            `yaml:"client-metadata,omitempty" json:"client-metadata,omitempty"`
 	CustomHeaders  map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet     bool
 }
 
 // XAIIdentityFingerprintConfig configures Grok/xAI upstream identity headers.
@@ -97,6 +105,7 @@ type XAIIdentityFingerprintConfig struct {
 	ClientVersion      string            `yaml:"x-grok-client-version,omitempty" json:"x-grok-client-version,omitempty"`
 	GrokConversationID string            `yaml:"x-grok-conv-id,omitempty" json:"x-grok-conv-id,omitempty"`
 	CustomHeaders      map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet         bool
 }
 
 // DefaultClaudeIdentityFingerprint returns the recommended Claude Code identity template.
@@ -104,7 +113,7 @@ func DefaultClaudeIdentityFingerprint() ClaudeIdentityFingerprintConfig {
 	cliVersion := DefaultClaudeFingerprintCLIVersion
 	entrypoint := DefaultClaudeFingerprintEntrypoint
 	return ClaudeIdentityFingerprintConfig{
-		Enabled:                 false,
+		Enabled:                 true,
 		CLIVersion:              cliVersion,
 		Entrypoint:              entrypoint,
 		UserAgent:               BuildClaudeFingerprintUserAgent(cliVersion, entrypoint),
@@ -120,7 +129,7 @@ func DefaultClaudeIdentityFingerprint() ClaudeIdentityFingerprintConfig {
 // DefaultGeminiIdentityFingerprint returns the recommended Gemini CLI identity template.
 func DefaultGeminiIdentityFingerprint() GeminiIdentityFingerprintConfig {
 	return GeminiIdentityFingerprintConfig{
-		Enabled:        false,
+		Enabled:        true,
 		UserAgent:      DefaultGeminiFingerprintUserAgent,
 		APIClient:      DefaultGeminiFingerprintAPIClient,
 		ClientMetadata: DefaultGeminiFingerprintClientMetadata,
@@ -131,11 +140,22 @@ func DefaultGeminiIdentityFingerprint() GeminiIdentityFingerprintConfig {
 // DefaultXAIIdentityFingerprint returns the conservative Grok identity template.
 func DefaultXAIIdentityFingerprint() XAIIdentityFingerprintConfig {
 	return XAIIdentityFingerprintConfig{
-		Enabled:          false,
+		Enabled:          true,
 		UserAgent:        DefaultXAIFingerprintUserAgent,
 		ClientIdentifier: DefaultXAIFingerprintClientIdentifier,
 		ClientVersion:    DefaultXAIFingerprintClientVersion,
 		CustomHeaders:    map[string]string{},
+	}
+}
+
+// DefaultIdentityFingerprintConfig returns provider templates exposed to the
+// management UI and used as builtin fallbacks by resolvers.
+func DefaultIdentityFingerprintConfig() IdentityFingerprintConfig {
+	return IdentityFingerprintConfig{
+		Codex:  DefaultCodexIdentityFingerprint(),
+		Claude: DefaultClaudeIdentityFingerprint(),
+		Gemini: DefaultGeminiIdentityFingerprint(),
+		XAI:    DefaultXAIIdentityFingerprint(),
 	}
 }
 
@@ -144,16 +164,55 @@ func (cfg *Config) SanitizeIdentityFingerprint() {
 	if cfg == nil {
 		return
 	}
-	cfg.IdentityFingerprint.Codex = CleanCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex)
-	cfg.IdentityFingerprint.Claude = CleanClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude)
-	cfg.IdentityFingerprint.Gemini = CleanGeminiIdentityFingerprint(cfg.IdentityFingerprint.Gemini)
-	cfg.IdentityFingerprint.XAI = CleanXAIIdentityFingerprint(cfg.IdentityFingerprint.XAI)
+	cfg.IdentityFingerprint = NormalizeIdentityFingerprintConfig(cfg.IdentityFingerprint)
+}
+
+// CleanIdentityFingerprintConfig trims provider identity fingerprint config
+// without changing explicit enablement.
+func CleanIdentityFingerprintConfig(in IdentityFingerprintConfig) IdentityFingerprintConfig {
+	return IdentityFingerprintConfig{
+		Codex:  CleanCodexIdentityFingerprint(in.Codex),
+		Claude: CleanClaudeIdentityFingerprint(in.Claude),
+		Gemini: CleanGeminiIdentityFingerprint(in.Gemini),
+		XAI:    CleanXAIIdentityFingerprint(in.XAI),
+	}
+}
+
+// NormalizeIdentityFingerprintConfig trims providers and enables them by
+// default unless the input explicitly supplied enabled: false.
+func NormalizeIdentityFingerprintConfig(in IdentityFingerprintConfig) IdentityFingerprintConfig {
+	out := CleanIdentityFingerprintConfig(in)
+	out.Codex = defaultCodexIdentityFingerprintEnabled(out.Codex)
+	out.Claude = defaultClaudeIdentityFingerprintEnabled(out.Claude)
+	out.Gemini = defaultGeminiIdentityFingerprintEnabled(out.Gemini)
+	out.XAI = defaultXAIIdentityFingerprintEnabled(out.XAI)
+	return out
+}
+
+// NormalizeLegacyIdentityFingerprintRuntimeConfig treats old runtime payloads
+// that stored the previous empty disabled defaults as absent provider config.
+func NormalizeLegacyIdentityFingerprintRuntimeConfig(in IdentityFingerprintConfig) IdentityFingerprintConfig {
+	out := CleanIdentityFingerprintConfig(in)
+	if codexLegacyDefaultDisabled(out.Codex) {
+		out.Codex.enabledSet = false
+	}
+	if claudeLegacyDefaultDisabled(out.Claude) {
+		out.Claude.enabledSet = false
+	}
+	if geminiLegacyDefaultDisabled(out.Gemini) {
+		out.Gemini.enabledSet = false
+	}
+	if xaiLegacyDefaultDisabled(out.XAI) {
+		out.XAI.enabledSet = false
+	}
+	return NormalizeIdentityFingerprintConfig(out)
 }
 
 // NormalizeCodexIdentityFingerprint trims user input and applies safe defaults
 // for fields that participate in Codex upstream identity.
 func NormalizeCodexIdentityFingerprint(in CodexIdentityFingerprintConfig) CodexIdentityFingerprintConfig {
 	out := CleanCodexIdentityFingerprint(in)
+	out = defaultCodexIdentityFingerprintEnabled(out)
 
 	if out.UserAgent == "" {
 		out.UserAgent = DefaultCodexFingerprintUserAgent
@@ -216,6 +275,7 @@ func BuildClaudeFingerprintUserAgent(cliVersion, entrypoint string) string {
 // for fields that participate in Claude Code-style Anthropic OAuth identity.
 func NormalizeClaudeIdentityFingerprint(in ClaudeIdentityFingerprintConfig) ClaudeIdentityFingerprintConfig {
 	out := CleanClaudeIdentityFingerprint(in)
+	out = defaultClaudeIdentityFingerprintEnabled(out)
 
 	if out.CLIVersion == "" {
 		out.CLIVersion = DefaultClaudeFingerprintCLIVersion
@@ -273,6 +333,7 @@ func CleanClaudeIdentityFingerprint(in ClaudeIdentityFingerprintConfig) ClaudeId
 // for fields that participate in Gemini CLI upstream identity.
 func NormalizeGeminiIdentityFingerprint(in GeminiIdentityFingerprintConfig) GeminiIdentityFingerprintConfig {
 	out := CleanGeminiIdentityFingerprint(in)
+	out = defaultGeminiIdentityFingerprintEnabled(out)
 	if out.UserAgent == "" {
 		out.UserAgent = DefaultGeminiFingerprintUserAgent
 	}
@@ -299,7 +360,7 @@ func CleanGeminiIdentityFingerprint(in GeminiIdentityFingerprintConfig) GeminiId
 // NormalizeXAIIdentityFingerprint trims user input while preserving empty fields
 // as "automatic learning" markers.
 func NormalizeXAIIdentityFingerprint(in XAIIdentityFingerprintConfig) XAIIdentityFingerprintConfig {
-	return CleanXAIIdentityFingerprint(in)
+	return defaultXAIIdentityFingerprintEnabled(CleanXAIIdentityFingerprint(in))
 }
 
 // CleanXAIIdentityFingerprint trims explicit overrides while preserving empty fields.
@@ -327,4 +388,195 @@ func cleanIdentityFingerprintHeaders(in map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+func defaultCodexIdentityFingerprintEnabled(in CodexIdentityFingerprintConfig) CodexIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func defaultClaudeIdentityFingerprintEnabled(in ClaudeIdentityFingerprintConfig) ClaudeIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func defaultGeminiIdentityFingerprintEnabled(in GeminiIdentityFingerprintConfig) GeminiIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func defaultXAIIdentityFingerprintEnabled(in XAIIdentityFingerprintConfig) XAIIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func codexLegacyDefaultDisabled(fp CodexIdentityFingerprintConfig) bool {
+	if fp.Enabled || strings.TrimSpace(fp.SessionID) != "" || len(fp.CustomHeaders) > 0 {
+		return false
+	}
+	defaults := DefaultCodexIdentityFingerprint()
+	return emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.Version, defaults.Version) &&
+		emptyOrEqual(fp.Originator, defaults.Originator) &&
+		emptyOrEqual(fp.WebsocketBeta, defaults.WebsocketBeta) &&
+		emptyOrEqual(fp.BetaFeatures, defaults.BetaFeatures) &&
+		emptyOrEqual(fp.SessionMode, defaults.SessionMode)
+}
+
+func claudeLegacyDefaultDisabled(fp ClaudeIdentityFingerprintConfig) bool {
+	if fp.Enabled || strings.TrimSpace(fp.SessionID) != "" ||
+		strings.TrimSpace(fp.DeviceID) != "" || len(fp.CustomHeaders) > 0 {
+		return false
+	}
+	defaults := DefaultClaudeIdentityFingerprint()
+	return emptyOrEqual(fp.CLIVersion, defaults.CLIVersion) &&
+		emptyOrEqual(fp.Entrypoint, defaults.Entrypoint) &&
+		emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.AnthropicBeta, defaults.AnthropicBeta) &&
+		emptyOrEqual(fp.StainlessPackageVersion, defaults.StainlessPackageVersion) &&
+		emptyOrEqual(fp.StainlessRuntimeVersion, defaults.StainlessRuntimeVersion) &&
+		emptyOrEqual(fp.StainlessTimeout, defaults.StainlessTimeout) &&
+		emptyOrEqual(fp.SessionMode, defaults.SessionMode)
+}
+
+func geminiLegacyDefaultDisabled(fp GeminiIdentityFingerprintConfig) bool {
+	if fp.Enabled || len(fp.CustomHeaders) > 0 {
+		return false
+	}
+	defaults := DefaultGeminiIdentityFingerprint()
+	return emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.APIClient, defaults.APIClient) &&
+		emptyOrEqual(fp.ClientMetadata, defaults.ClientMetadata)
+}
+
+func xaiLegacyDefaultDisabled(fp XAIIdentityFingerprintConfig) bool {
+	if fp.Enabled || strings.TrimSpace(fp.GrokConversationID) != "" || len(fp.CustomHeaders) > 0 {
+		return false
+	}
+	defaults := DefaultXAIIdentityFingerprint()
+	return emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.ClientIdentifier, defaults.ClientIdentifier) &&
+		emptyOrEqual(fp.ClientVersion, defaults.ClientVersion)
+}
+
+func emptyOrEqual(value, expected string) bool {
+	value = strings.TrimSpace(value)
+	return value == "" || value == strings.TrimSpace(expected)
+}
+
+func (fp *CodexIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias CodexIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = CodexIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *ClaudeIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias ClaudeIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = ClaudeIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *GeminiIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias GeminiIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = GeminiIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *XAIIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias XAIIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = XAIIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *CodexIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias CodexIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = CodexIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}
+
+func (fp *ClaudeIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias ClaudeIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = ClaudeIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}
+
+func (fp *GeminiIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias GeminiIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = GeminiIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}
+
+func (fp *XAIIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias XAIIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = XAIIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}
+
+func jsonObjectHasKey(data []byte, key string) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return false
+	}
+	_, ok := fields[key]
+	return ok
+}
+
+func yamlMappingHasKey(node *yaml.Node, key string) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i] != nil && strings.TrimSpace(node.Content[i].Value) == key {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/identity_fingerprint_test.go
+++ b/internal/config/identity_fingerprint_test.go
@@ -1,14 +1,17 @@
 package config
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestDefaultCodexIdentityFingerprintUsesCurrentVersionAndDynamicSessions(t *testing.T) {
 	t.Parallel()
 
 	got := DefaultCodexIdentityFingerprint()
 
-	if got.Enabled {
-		t.Fatalf("Enabled = true, want false by default")
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true by default")
 	}
 	if got.Version != "" {
 		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
@@ -26,6 +29,9 @@ func TestNormalizeCodexIdentityFingerprintAppliesCurrentDefaults(t *testing.T) {
 
 	got := NormalizeCodexIdentityFingerprint(CodexIdentityFingerprintConfig{})
 
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true by default")
+	}
 	if got.Version != "" {
 		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
 	}
@@ -69,8 +75,8 @@ func TestDefaultClaudeIdentityFingerprintMirrorsClaudeCode(t *testing.T) {
 
 	got := DefaultClaudeIdentityFingerprint()
 
-	if got.Enabled {
-		t.Fatalf("Enabled = true, want false by default")
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true by default")
 	}
 	if got.CLIVersion != "2.1.161" {
 		t.Fatalf("CLIVersion = %q, want 2.1.161", got.CLIVersion)
@@ -158,8 +164,8 @@ func TestDefaultGeminiIdentityFingerprint(t *testing.T) {
 
 	got := DefaultGeminiIdentityFingerprint()
 
-	if got.Enabled {
-		t.Fatal("Enabled = true, want false by default")
+	if !got.Enabled {
+		t.Fatal("Enabled = false, want true by default")
 	}
 	if got.UserAgent != "google-api-nodejs-client/9.15.1" {
 		t.Fatalf("UserAgent = %q, want Gemini CLI default", got.UserAgent)
@@ -169,5 +175,59 @@ func TestDefaultGeminiIdentityFingerprint(t *testing.T) {
 	}
 	if got.ClientMetadata != "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI" {
 		t.Fatalf("ClientMetadata = %q, want Gemini CLI metadata", got.ClientMetadata)
+	}
+}
+
+func TestDefaultXAIIdentityFingerprint(t *testing.T) {
+	t.Parallel()
+
+	got := DefaultXAIIdentityFingerprint()
+
+	if !got.Enabled {
+		t.Fatal("Enabled = false, want true by default")
+	}
+	if got.UserAgent != "grok-shell/0.2.93 (macos; aarch64)" {
+		t.Fatalf("UserAgent = %q, want Grok shell default", got.UserAgent)
+	}
+	if got.ClientIdentifier != "grok-shell" {
+		t.Fatalf("ClientIdentifier = %q, want grok-shell", got.ClientIdentifier)
+	}
+	if got.ClientVersion != "0.2.93" {
+		t.Fatalf("ClientVersion = %q, want 0.2.93", got.ClientVersion)
+	}
+}
+
+func TestSanitizeIdentityFingerprintDefaultsProvidersEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{}
+	cfg.SanitizeIdentityFingerprint()
+
+	if !cfg.IdentityFingerprint.Codex.Enabled ||
+		!cfg.IdentityFingerprint.Claude.Enabled ||
+		!cfg.IdentityFingerprint.Gemini.Enabled ||
+		!cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want all providers enabled by default", cfg.IdentityFingerprint)
+	}
+}
+
+func TestNormalizeIdentityFingerprintConfigPreservesExplicitDisabledProvider(t *testing.T) {
+	t.Parallel()
+
+	var cfg IdentityFingerprintConfig
+	if err := json.Unmarshal([]byte(`{"xai":{"enabled":false},"gemini":{}}`), &cfg); err != nil {
+		t.Fatalf("Unmarshal identity fingerprint: %v", err)
+	}
+
+	got := NormalizeIdentityFingerprintConfig(cfg)
+
+	if got.XAI.Enabled {
+		t.Fatalf("XAI.Enabled = true, want explicit false preserved")
+	}
+	if !got.Gemini.Enabled {
+		t.Fatalf("Gemini.Enabled = false, want missing enabled to default true")
+	}
+	if !got.Codex.Enabled || !got.Claude.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want omitted providers enabled by default", got)
 	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -45,7 +45,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		if optional {
 			if os.IsNotExist(err) || errors.Is(err, syscall.EISDIR) {
 				// Missing and optional: return empty config (cloud deploy standby).
-				return &Config{}, nil
+				cfg := &Config{}
+				cfg.SanitizeIdentityFingerprint()
+				return cfg, nil
 			}
 		}
 		return nil, fmt.Errorf("failed to read config file: %w", err)
@@ -53,7 +55,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// In cloud deploy mode (optional=true), if file is empty or contains only whitespace, return empty config.
 	if optional && len(data) == 0 {
-		return &Config{}, nil
+		cfg := &Config{}
+		cfg.SanitizeIdentityFingerprint()
+		return cfg, nil
 	}
 
 	// Unmarshal the YAML data into the Config struct.
@@ -88,7 +92,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		if optional {
 			// In cloud deploy mode, if YAML parsing fails, return empty config instead of error.
-			return &Config{}, nil
+			cfg := &Config{}
+			cfg.SanitizeIdentityFingerprint()
+			return cfg, nil
 		}
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}

--- a/internal/management/settings/runtimeconfig/spec.go
+++ b/internal/management/settings/runtimeconfig/spec.go
@@ -300,23 +300,14 @@ func Specs() []Spec {
 					xaiIdentityFingerprintMeaningful(cfg.IdentityFingerprint.XAI)
 			},
 			Value: func(cfg *config.Config) any {
-				return config.IdentityFingerprintConfig{
-					Codex:  config.CleanCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex),
-					Claude: config.CleanClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude),
-					Gemini: config.CleanGeminiIdentityFingerprint(cfg.IdentityFingerprint.Gemini),
-					XAI:    config.CleanXAIIdentityFingerprint(cfg.IdentityFingerprint.XAI),
-				}
+				return IdentityFingerprintRuntimeSettingValue(cfg.IdentityFingerprint)
 			},
 			Apply: func(cfg *config.Config, raw json.RawMessage) bool {
-				var value config.IdentityFingerprintConfig
-				if err := json.Unmarshal(raw, &value); err != nil {
+				value, err := identityFingerprintRuntimeSettingConfig(raw)
+				if err != nil {
 					log.Warnf("runtimeconfig: decode %s: %v", RuntimeSettingIdentityFingerprint, err)
 					return false
 				}
-				value.Codex = config.CleanCodexIdentityFingerprint(value.Codex)
-				value.Claude = config.CleanClaudeIdentityFingerprint(value.Claude)
-				value.Gemini = config.CleanGeminiIdentityFingerprint(value.Gemini)
-				value.XAI = config.CleanXAIIdentityFingerprint(value.XAI)
 				cfg.IdentityFingerprint = value
 				return true
 			},
@@ -445,6 +436,44 @@ func xaiIdentityFingerprintMeaningful(fp config.XAIIdentityFingerprintConfig) bo
 		strings.TrimSpace(clean.ClientVersion) != "" ||
 		strings.TrimSpace(clean.GrokConversationID) != "" ||
 		len(clean.CustomHeaders) > 0
+}
+
+const identityFingerprintRuntimeSettingVersion = 2
+
+type identityFingerprintRuntimePayload struct {
+	RuntimeSettingVersion int                                    `json:"runtime-setting-version,omitempty"`
+	Codex                 config.CodexIdentityFingerprintConfig  `json:"codex,omitempty"`
+	Claude                config.ClaudeIdentityFingerprintConfig `json:"claude,omitempty"`
+	Gemini                config.GeminiIdentityFingerprintConfig `json:"gemini,omitempty"`
+	XAI                   config.XAIIdentityFingerprintConfig    `json:"xai,omitempty"`
+}
+
+func IdentityFingerprintRuntimeSettingValue(value config.IdentityFingerprintConfig) any {
+	normalized := config.NormalizeIdentityFingerprintConfig(value)
+	return identityFingerprintRuntimePayload{
+		RuntimeSettingVersion: identityFingerprintRuntimeSettingVersion,
+		Codex:                 normalized.Codex,
+		Claude:                normalized.Claude,
+		Gemini:                normalized.Gemini,
+		XAI:                   normalized.XAI,
+	}
+}
+
+func identityFingerprintRuntimeSettingConfig(raw json.RawMessage) (config.IdentityFingerprintConfig, error) {
+	var payload identityFingerprintRuntimePayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return config.IdentityFingerprintConfig{}, err
+	}
+	value := config.IdentityFingerprintConfig{
+		Codex:  payload.Codex,
+		Claude: payload.Claude,
+		Gemini: payload.Gemini,
+		XAI:    payload.XAI,
+	}
+	if payload.RuntimeSettingVersion >= identityFingerprintRuntimeSettingVersion {
+		return config.NormalizeIdentityFingerprintConfig(value), nil
+	}
+	return config.NormalizeLegacyIdentityFingerprintRuntimeConfig(value), nil
 }
 
 func normalizeOAuthModelAliasSetting(entries map[string][]config.OAuthModelAlias) map[string][]config.OAuthModelAlias {

--- a/internal/management/settings/runtimeconfig/spec_test.go
+++ b/internal/management/settings/runtimeconfig/spec_test.go
@@ -1,0 +1,86 @@
+package runtimeconfig
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestIdentityFingerprintRuntimeSettingMigratesLegacyEmptyDisabledProviders(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	spec := identityFingerprintSpec(t)
+	raw := json.RawMessage(`{
+		"codex": {"enabled": true},
+		"claude": {"enabled": false},
+		"gemini": {"enabled": false}
+	}`)
+
+	if !spec.Apply(cfg, raw) {
+		t.Fatal("Apply returned false")
+	}
+
+	if !cfg.IdentityFingerprint.Codex.Enabled ||
+		!cfg.IdentityFingerprint.Claude.Enabled ||
+		!cfg.IdentityFingerprint.Gemini.Enabled ||
+		!cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want legacy empty disabled providers defaulted on", cfg.IdentityFingerprint)
+	}
+}
+
+func TestIdentityFingerprintRuntimeSettingVersionedPayloadPreservesExplicitDisabledProviders(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	spec := identityFingerprintSpec(t)
+	raw := json.RawMessage(`{
+		"runtime-setting-version": 2,
+		"codex": {"enabled": true},
+		"claude": {"enabled": false},
+		"gemini": {"enabled": false},
+		"xai": {"enabled": false}
+	}`)
+
+	if !spec.Apply(cfg, raw) {
+		t.Fatal("Apply returned false")
+	}
+
+	if !cfg.IdentityFingerprint.Codex.Enabled {
+		t.Fatalf("Codex.Enabled = false, want true")
+	}
+	if cfg.IdentityFingerprint.Claude.Enabled ||
+		cfg.IdentityFingerprint.Gemini.Enabled ||
+		cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want versioned explicit false preserved", cfg.IdentityFingerprint)
+	}
+}
+
+func TestIdentityFingerprintRuntimeSettingValueWritesVersionedPayload(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(IdentityFingerprintRuntimeSettingValue(config.IdentityFingerprintConfig{}))
+	if err != nil {
+		t.Fatalf("Marshal IdentityFingerprintRuntimeSettingValue: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("Unmarshal payload: %v", err)
+	}
+	if payload["runtime-setting-version"] != float64(identityFingerprintRuntimeSettingVersion) {
+		t.Fatalf("runtime-setting-version = %#v, want %d", payload["runtime-setting-version"], identityFingerprintRuntimeSettingVersion)
+	}
+}
+
+func identityFingerprintSpec(t *testing.T) Spec {
+	t.Helper()
+	for _, spec := range Specs() {
+		if spec.Key == RuntimeSettingIdentityFingerprint {
+			return spec
+		}
+	}
+	t.Fatal("identity-fingerprint spec not found")
+	return Spec{}
+}


### PR DESCRIPTION
## Summary
- default Codex, Claude, Gemini, and xAI identity fingerprint providers to enabled
- normalize legacy runtime settings so old empty disabled payloads no longer keep providers off
- keep explicit disabled values in versioned runtime settings

## Tests
- rtk go test ./internal/config ./internal/management/settings/runtimeconfig ./internal/api/handlers/management ./internal/runtime/executor -count=1
- rtk go test ./internal/usage ./internal/storage/sqlite/settings -count=1
- rtk go test ./internal/identityfingerprint -count=1
- rtk go test ./... -count=1