### PR TITLE
fix: report postgres database stats

### DIFF
--- a/internal/api/handlers/management/system_stats.go
+++ b/internal/api/handlers/management/system_stats.go
@@ -22,9 +22,10 @@ import (
 // SystemStats is the JSON payload pushed via WebSocket and returned by HTTP.
 type SystemStats struct {
 	// Database
-	DBSizeBytes int64 `json:"db_size_bytes"`
+	DBSizeBytes int64  `json:"db_size_bytes"`
+	DBEngine    string `json:"db_engine"`
 
-	// Request log body storage inside SQLite.
+	// Request log body storage inside the runtime database.
 	LogContentStoreBytes int64 `json:"log_content_store_bytes"`
 
 	// Log directory size on disk.
@@ -92,18 +93,11 @@ func (h *Handler) collectSystemStats() SystemStats {
 	runtime.ReadMemStats(&m)
 	stats.GoHeapBytes = m.HeapAlloc
 
-	// ── DB file size ──
-	dbPath := usage.GetDBPath()
-	if dbPath != "" {
-		if info, err := os.Stat(dbPath); err == nil {
-			stats.DBSizeBytes = info.Size()
-		}
-		// Also check WAL and SHM files
-		for _, suffix := range []string{"-wal", "-shm"} {
-			if info, err := os.Stat(dbPath + suffix); err == nil {
-				stats.DBSizeBytes += info.Size()
-			}
-		}
+	dbStats, err := usage.GetDatabaseStats()
+	stats.DBEngine = dbStats.Driver
+	stats.DBSizeBytes = dbStats.SizeBytes
+	if err != nil {
+		log.Warnf("system-stats: failed to query database stats: %v", err)
 	}
 	if contentBytes, err := usage.GetRequestLogStorageBytes(); err == nil {
 		stats.LogContentStoreBytes = contentBytes

--- a/internal/usage/postgres_integration_test.go
+++ b/internal/usage/postgres_integration_test.go
@@ -33,6 +33,19 @@ func TestPostgresRuntimeDataStackIntegration(t *testing.T) {
 	if db == nil {
 		t.Fatal("postgres db is nil")
 	}
+	dbStats, err := GetDatabaseStats()
+	if err != nil {
+		t.Fatalf("GetDatabaseStats() error = %v", err)
+	}
+	if dbStats.Driver != "postgres" {
+		t.Fatalf("GetDatabaseStats().Driver = %q, want postgres", dbStats.Driver)
+	}
+	if dbStats.SizeBytes <= 0 {
+		t.Fatalf("GetDatabaseStats().SizeBytes = %d, want > 0", dbStats.SizeBytes)
+	}
+	if dbPath := GetDBPath(); dbPath != "" {
+		t.Fatalf("GetDBPath() = %q, want empty for postgres", dbPath)
+	}
 	if _, err := db.Exec(`
 		TRUNCATE
 			request_log_content,

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -137,6 +138,12 @@ var (
 	usageDriver string
 	usageLoc    *time.Location
 )
+
+// DatabaseStats summarizes the active runtime database for management telemetry.
+type DatabaseStats struct {
+	Driver    string
+	SizeBytes int64
+}
 
 const createTableSQL = `
 CREATE TABLE IF NOT EXISTS request_logs (
@@ -668,7 +675,7 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 	return nil
 }
 
-// CloseDB closes the SQLite database gracefully.
+// CloseDB closes the runtime database gracefully.
 func CloseDB() {
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()
@@ -687,7 +694,7 @@ func CloseDB() {
 	log.Info("usage: database closed")
 }
 
-// InsertLog writes a single request log entry into the SQLite database.
+// InsertLog writes a single request log entry into the runtime database.
 // It is safe to call concurrently.
 func InsertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
@@ -928,9 +935,64 @@ func getUsageLocation() *time.Location {
 	return usageLoc
 }
 
-// GetDBPath returns the file path of the SQLite database, or empty if not initialised.
+// GetDBPath returns the SQLite database file path, or empty for non-file databases.
 func GetDBPath() string {
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()
+	if usageDriver != "sqlite" {
+		return ""
+	}
 	return usageDBPath
+}
+
+// GetDatabaseStats returns runtime database engine and size telemetry.
+func GetDatabaseStats() (DatabaseStats, error) {
+	usageDBMu.Lock()
+	driver := usageDriver
+	path := usageDBPath
+	db := usageReadDB
+	if db == nil {
+		db = usageDB
+	}
+	usageDBMu.Unlock()
+
+	stats := DatabaseStats{Driver: driver}
+	switch driver {
+	case "postgres":
+		if db == nil {
+			return stats, nil
+		}
+		var size sql.NullInt64
+		if err := db.QueryRow("SELECT pg_database_size(current_database())").Scan(&size); err != nil {
+			return stats, fmt.Errorf("usage: query postgres database size: %w", err)
+		}
+		if size.Valid {
+			stats.SizeBytes = size.Int64
+		}
+	case "sqlite":
+		size, err := sqliteDatabaseSizeBytes(path)
+		if err != nil {
+			return stats, err
+		}
+		stats.SizeBytes = size
+	}
+	return stats, nil
+}
+
+func sqliteDatabaseSizeBytes(path string) (int64, error) {
+	if strings.TrimSpace(path) == "" {
+		return 0, nil
+	}
+	var size int64
+	for _, candidate := range []string{path, path + "-wal", path + "-shm"} {
+		info, err := os.Stat(candidate)
+		if err == nil {
+			size += info.Size()
+			continue
+		}
+		if !os.IsNotExist(err) {
+			return 0, fmt.Errorf("usage: stat sqlite database file %s: %w", candidate, err)
+		}
+	}
+	return size, nil
 }

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"math"
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -33,6 +34,30 @@ func initTestUsageDB(t *testing.T, cfg config.RequestLogStorageConfig) {
 	}
 	stopRequestLogMaintenance()
 	t.Cleanup(CloseDB)
+}
+
+func TestSQLiteDatabaseSizeBytesIncludesWALAndSHM(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	files := map[string]string{
+		dbPath:          "database",
+		dbPath + "-wal": "wal",
+		dbPath + "-shm": "shm",
+	}
+	var want int64
+	for path, content := range files {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		want += int64(len(content))
+	}
+
+	got, err := sqliteDatabaseSizeBytes(dbPath)
+	if err != nil {
+		t.Fatalf("sqliteDatabaseSizeBytes() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("sqliteDatabaseSizeBytes() = %d, want %d", got, want)
+	}
 }
 
 func TestCutoffStartUTCAtUsesProjectTimezoneForDayBoundaries(t *testing.T) {


### PR DESCRIPTION
## Summary
- report runtime database engine in system stats
- calculate PostgreSQL database size with pg_database_size(current_database())
- keep SQLite DB + WAL + SHM size accounting

## Tests
- rtk go test ./internal/usage ./internal/api/handlers/management