### PR TITLE
fix: refresh codex oauth model registry

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -39,27 +39,28 @@ const attemptMaxIdleTime = 2 * time.Hour
 
 // Handler aggregates config reference, persistence path and helpers.
 type Handler struct {
-	cfg                 *config.Config
-	configFilePath      string
-	mu                  sync.Mutex
-	attemptsMu          sync.Mutex
-	failedAttempts      map[string]*attemptInfo // keyed by client IP
-	authManager         *coreauth.Manager
-	usageStats          *usage.RequestStatistics
-	tokenStore          coreauth.Store
-	localPassword       string
-	allowRemoteOverride bool
-	envSecret           string
-	logDir              string
-	postAuthHook        coreauth.PostAuthHook
-	onConfigMutated     func(*config.Config)
-	startTime           time.Time
-	attemptCleanupStop  chan struct{}
-	attemptCleanupOnce  sync.Once
-	accessManager       *sdkaccess.Manager
-	trendCacheMu        sync.Mutex
-	trendCache          map[string]trendCacheEntry
-	imageGeneration     *imagegeneration.Service
+	cfg                  *config.Config
+	configFilePath       string
+	mu                   sync.Mutex
+	attemptsMu           sync.Mutex
+	failedAttempts       map[string]*attemptInfo // keyed by client IP
+	authManager          *coreauth.Manager
+	usageStats           *usage.RequestStatistics
+	tokenStore           coreauth.Store
+	localPassword        string
+	allowRemoteOverride  bool
+	envSecret            string
+	logDir               string
+	postAuthHook         coreauth.PostAuthHook
+	onConfigMutated      func(*config.Config)
+	onModelConfigMutated func()
+	startTime            time.Time
+	attemptCleanupStop   chan struct{}
+	attemptCleanupOnce   sync.Once
+	accessManager        *sdkaccess.Manager
+	trendCacheMu         sync.Mutex
+	trendCache           map[string]trendCacheEntry
+	imageGeneration      *imagegeneration.Service
 }
 
 type trendCacheEntry struct {
@@ -171,6 +172,8 @@ func (h *Handler) SetAuthManager(manager *coreauth.Manager) {
 }
 
 func (h *Handler) SetConfigMutatedHook(fn func(*config.Config)) { h.onConfigMutated = fn }
+
+func (h *Handler) SetModelConfigMutatedHook(fn func()) { h.onModelConfigMutated = fn }
 
 // SetAccessManager wires the request authentication access manager so management writes
 // (such as API key channel/model restrictions) can be applied immediately at runtime.

--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -97,6 +97,7 @@ func (h *ModelsHandler) PostModelConfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	h.notifyModelConfigMutated()
 	c.JSON(http.StatusOK, saved)
 }
 
@@ -116,6 +117,7 @@ func (h *ModelsHandler) PutModelConfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	h.notifyModelConfigMutated()
 	c.JSON(http.StatusOK, saved)
 }
 
@@ -129,6 +131,7 @@ func (h *ModelsHandler) DeleteModelConfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	h.notifyModelConfigMutated()
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
@@ -240,5 +243,13 @@ func (h *ModelsHandler) PostOpenRouterModelSyncRun(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error(), "state": state})
 		return
 	}
+	h.notifyModelConfigMutated()
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "result": result, "state": state})
+}
+
+func (h *ModelsHandler) notifyModelConfigMutated() {
+	if h == nil || h.Handler == nil || h.onModelConfigMutated == nil {
+		return
+	}
+	h.onModelConfigMutated()
 }

--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -110,6 +110,45 @@ func TestModelConfigHandlersCreateListAndDelete(t *testing.T) {
 	}
 }
 
+func TestModelConfigHandlersNotifyModelConfigMutation(t *testing.T) {
+	initManagementModelsTestDB(t)
+	h := NewHandler(&config.Config{}, "", nil)
+	notifications := 0
+	h.SetModelConfigMutatedHook(func() { notifications++ })
+
+	createBody := []byte(`{"id":"notify-model","owned_by":"codex","enabled":true}`)
+	createRec := performModelsRequest(http.MethodPost, "/model-configs", createBody, h.Models().PostModelConfig)
+	if createRec.Code != http.StatusOK {
+		t.Fatalf("PostModelConfig status = %d body = %s", createRec.Code, createRec.Body.String())
+	}
+	if notifications != 1 {
+		t.Fatalf("notifications after create = %d, want 1", notifications)
+	}
+
+	updateBody := []byte(`{"id":"notify-model","owned_by":"codex","enabled":false}`)
+	updateRec := performModelsRequest(http.MethodPut, "/model-configs/notify-model", updateBody, func(c *gin.Context) {
+		c.Params = gin.Params{{Key: "id", Value: "notify-model"}}
+		h.Models().PutModelConfig(c)
+	})
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("PutModelConfig status = %d body = %s", updateRec.Code, updateRec.Body.String())
+	}
+	if notifications != 2 {
+		t.Fatalf("notifications after update = %d, want 2", notifications)
+	}
+
+	deleteRec := performModelsRequest(http.MethodDelete, "/model-configs/notify-model", nil, func(c *gin.Context) {
+		c.Params = gin.Params{{Key: "id", Value: "notify-model"}}
+		h.Models().DeleteModelConfig(c)
+	})
+	if deleteRec.Code != http.StatusOK {
+		t.Fatalf("DeleteModelConfig status = %d body = %s", deleteRec.Code, deleteRec.Body.String())
+	}
+	if notifications != 3 {
+		t.Fatalf("notifications after delete = %d, want 3", notifications)
+	}
+}
+
 func TestModelConfigHandlersScopeFiltering(t *testing.T) {
 	initManagementModelsTestDB(t)
 	h := NewHandler(&config.Config{}, "", nil)

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -13,16 +13,17 @@ import (
 )
 
 type serverOptionConfig struct {
-	extraMiddleware       []gin.HandlerFunc
-	engineConfigurator    func(*gin.Engine)
-	routerConfigurator    func(*gin.Engine, *handlers.BaseAPIHandler, *config.Config)
-	requestLoggerFactory  func(*config.Config, string) logging.RequestLogger
-	localPassword         string
-	keepAliveEnabled      bool
-	keepAliveTimeout      time.Duration
-	keepAliveOnTimeout    func()
-	postAuthHook          auth.PostAuthHook
-	configMutatedCallback func(*config.Config)
+	extraMiddleware            []gin.HandlerFunc
+	engineConfigurator         func(*gin.Engine)
+	routerConfigurator         func(*gin.Engine, *handlers.BaseAPIHandler, *config.Config)
+	requestLoggerFactory       func(*config.Config, string) logging.RequestLogger
+	localPassword              string
+	keepAliveEnabled           bool
+	keepAliveTimeout           time.Duration
+	keepAliveOnTimeout         func()
+	postAuthHook               auth.PostAuthHook
+	configMutatedCallback      func(*config.Config)
+	modelConfigMutatedCallback func()
 }
 
 // ServerOption customises HTTP server construction.
@@ -93,5 +94,11 @@ func WithPostAuthHook(hook auth.PostAuthHook) ServerOption {
 func WithConfigMutatedCallback(fn func(*config.Config)) ServerOption {
 	return func(cfg *serverOptionConfig) {
 		cfg.configMutatedCallback = fn
+	}
+}
+
+func WithModelConfigMutatedCallback(fn func()) ServerOption {
+	return func(cfg *serverOptionConfig) {
+		cfg.modelConfigMutatedCallback = fn
 	}
 }

--- a/internal/api/sdkbridge/bridge.go
+++ b/internal/api/sdkbridge/bridge.go
@@ -88,6 +88,10 @@ func WithConfigMutatedCallback(fn func(*sdkconfig.Config)) ServerOption {
 	return coreapi.WithConfigMutatedCallback(fn)
 }
 
+func WithModelConfigMutatedCallback(fn func()) ServerOption {
+	return coreapi.WithModelConfigMutatedCallback(fn)
+}
+
 func WithKeepAliveEndpoint(timeout time.Duration, onTimeout func()) ServerOption {
 	return coreapi.WithKeepAliveEndpoint(timeout, onTimeout)
 }

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -205,6 +205,9 @@ func (s *Server) configureManagementHandler(
 	if optionState != nil && optionState.postAuthHook != nil {
 		s.mgmt.SetPostAuthHook(optionState.postAuthHook)
 	}
+	if optionState != nil && optionState.modelConfigMutatedCallback != nil {
+		s.mgmt.SetModelConfigMutatedHook(optionState.modelConfigMutatedCallback)
+	}
 }
 
 func (s *Server) registerBuiltinModules(cfg *config.Config, accessManager *sdkaccess.Manager) {

--- a/sdk/api/options.go
+++ b/sdk/api/options.go
@@ -102,6 +102,11 @@ func WithConfigMutatedCallback(fn func(*config.Config)) ServerOption {
 	return apisdkbridge.WithConfigMutatedCallback(fn)
 }
 
+// WithModelConfigMutatedCallback registers a callback invoked after management-side model catalog mutations.
+func WithModelConfigMutatedCallback(fn func()) ServerOption {
+	return apisdkbridge.WithModelConfigMutatedCallback(fn)
+}
+
 // WithKeepAliveEndpoint enables a keep-alive endpoint with the provided timeout and callback.
 func WithKeepAliveEndpoint(timeout time.Duration, onTimeout func()) ServerOption {
 	return apisdkbridge.WithKeepAliveEndpoint(timeout, onTimeout)

--- a/sdk/cliproxy/service_config_reload.go
+++ b/sdk/cliproxy/service_config_reload.go
@@ -90,9 +90,7 @@ func (s *Service) applyConfigReload(newCfg *config.Config, refreshRegisteredMode
 	}
 	s.rebindExecutors()
 	if refreshRegisteredModels && s.coreManager != nil {
-		for _, auth := range s.coreManager.List() {
-			s.registerModelsForAuth(context.Background(), auth)
-		}
+		s.refreshRegisteredModels(context.Background())
 	}
 }
 

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -290,6 +290,106 @@ func TestRegisterModelsForAuth_AddsUserModelConfigsForOAuthProvider(t *testing.T
 	}
 }
 
+func TestRefreshRegisteredModels_AddsCodexOwnedModelConfigsForCodexOAuth(t *testing.T) {
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	const modelID = "gpt-codex-user-defined"
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     modelID,
+		OwnedBy:     "codex",
+		Description: "User-defined Codex OAuth model",
+		Enabled:     true,
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := &coreauth.Auth{
+		ID:       "codex-oauth-user-models",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.refreshRegisteredModels(context.Background())
+	if !hasModelID(registry.GetModelsForClient(auth.ID), modelID) {
+		t.Fatal("expected Codex-owned model config to be registered for Codex OAuth auth")
+	}
+
+	if err := usage.DeleteModelConfig(modelID); err != nil {
+		t.Fatalf("DeleteModelConfig() error = %v", err)
+	}
+	service.refreshRegisteredModels(context.Background())
+	if hasModelID(registry.GetModelsForClient(auth.ID), modelID) {
+		t.Fatal("expected deleted Codex-owned model config to be removed after registry refresh")
+	}
+}
+
+func TestRegisterModelsForAuth_DoesNotAddOpenAIOwnedModelConfigsForCodexOAuth(t *testing.T) {
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	const modelID = "openai-owned-not-codex"
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     modelID,
+		OwnedBy:     "openai",
+		Description: "OpenAI model library entry",
+		Enabled:     true,
+		Source:      "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "codex-oauth-openai-owned-models",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+	if hasModelID(registry.GetModelsForClient(auth.ID), modelID) {
+		t.Fatal("did not expect OpenAI-owned model config to be registered as Codex OAuth model")
+	}
+}
+
 func TestRegisterModelsForAuth_ClaudeOAuthStaticMaxModelIsRouteableWithoutModelConfig(t *testing.T) {
 	usage.CloseDB()
 	dbPath := filepath.Join(t.TempDir(), "usage.db")

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -187,6 +187,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 				excluded = entry.ExcludedModels
 			}
 		}
+		models = appendOAuthProviderModelConfigs(models, provider, authKind, listOAuthProviderModelConfigRows())
 		models = applyExcludedModels(models, excluded)
 	case "qwen":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("qwen")
@@ -218,4 +219,16 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	}
 
 	GlobalModelRegistry().UnregisterClient(a.ID)
+}
+
+func (s *Service) refreshRegisteredModels(ctx context.Context) {
+	if s == nil || s.coreManager == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for _, auth := range s.coreManager.List() {
+		s.registerModelsForAuth(ctx, auth)
+	}
 }

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -323,8 +323,6 @@ func modelConfigOwnerAliases(provider string) map[string]struct{} {
 		values = append(values, "anthropic", "claude-code")
 	case "gemini", "gemini-cli", "vertex":
 		values = append(values, "google")
-	case "codex":
-		values = append(values, "openai")
 	}
 	out := make(map[string]struct{}, len(values))
 	for _, value := range values {

--- a/sdk/cliproxy/service_server_factory.go
+++ b/sdk/cliproxy/service_server_factory.go
@@ -12,6 +12,9 @@ func (s *Service) buildServerOptions() []api.ServerOption {
 	serverOptions = append(serverOptions, api.WithConfigMutatedCallback(func(updated *config.Config) {
 		s.applyConfigReload(updated, true)
 	}))
+	serverOptions = append(serverOptions, api.WithModelConfigMutatedCallback(func() {
+		s.refreshRegisteredModels(context.Background())
+	}))
 	return serverOptions
 }
 

--- a/sdkbridge/api/bridge.go
+++ b/sdkbridge/api/bridge.go
@@ -45,6 +45,10 @@ func WithConfigMutatedCallback(fn func(*sdkconfig.Config)) ServerOption {
 	return internalapisdkbridge.WithConfigMutatedCallback(fn)
 }
 
+func WithModelConfigMutatedCallback(fn func()) ServerOption {
+	return internalapisdkbridge.WithModelConfigMutatedCallback(fn)
+}
+
 func WithKeepAliveEndpoint(timeout time.Duration, onTimeout func()) ServerOption {
 	return internalapisdkbridge.WithKeepAliveEndpoint(timeout, onTimeout)
 }


### PR DESCRIPTION
## Summary
- register Codex OAuth model-config rows in the runtime model registry
- refresh registered models after management model catalog mutations
- keep Codex owner matching scoped to codex-owned rows

## Tests
- rtk go test ./sdk/cliproxy ./internal/api/handlers/management