### PR TITLE
feat: add GPT-5.6 Codex capabilities

### DIFF
--- a/internal/api/handlers/management/ccswitch_import_configs_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 func TestCcSwitchImportConfigsManagementHandlersUseDatabase(t *testing.T) {
@@ -198,5 +200,71 @@ func TestCcSwitchImportConfigsPreservesCodexMappingContextWindow(t *testing.T) {
 	}
 	if firstModel["context_window"] != float64(272000) {
 		t.Fatalf("first catalog context_window = %#v, want 272000", firstModel["context_window"])
+	}
+}
+
+func TestCcSwitchImportConfigsReturnsGPT56CapabilitiesAndClampsContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	body := []byte(`[
+  {
+    "id": "cfg-gpt56",
+    "client-type": "codex",
+    "provider-name": "Relay GPT-5.6",
+    "default-model": "gpt-5.6-sol",
+    "allowed-channel-groups": ["codex"],
+    "endpoint-path": "/v1",
+    "usage-auto-interval": 30,
+    "model-mappings": [
+      {"request-model": "gpt-5.6-sol", "target-model": "gpt-5.6-sol", "context-window": 2000000},
+      {"request-model": "deepseek-v4-flash", "target-model": "deepseek-chat"}
+    ]
+  }
+]`)
+
+	h := NewHandler(&config.Config{}, "", nil)
+	putRec := httptest.NewRecorder()
+	putCtx, _ := gin.CreateTestContext(putRec)
+	putCtx.Request = httptest.NewRequest(http.MethodPut, "/ccswitch-import-configs", bytes.NewReader(body))
+	h.PutCcSwitchImportConfigs(putCtx)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d; body=%s", putRec.Code, http.StatusOK, putRec.Body.String())
+	}
+
+	getRec := httptest.NewRecorder()
+	getCtx, _ := gin.CreateTestContext(getRec)
+	getCtx.Request = httptest.NewRequest(http.MethodGet, "/ccswitch-import-configs", nil)
+	h.GetCcSwitchImportConfigs(getCtx)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d; body=%s", getRec.Code, http.StatusOK, getRec.Body.String())
+	}
+
+	var got struct {
+		Items []usage.CcSwitchImportConfigRow `json:"items"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal GET response: %v", err)
+	}
+	if len(got.Items) != 1 || got.Items[0].CodexModelCatalog == nil {
+		t.Fatalf("items = %#v, want one generated catalog", got.Items)
+	}
+	if got.Items[0].ModelMappings[0].ContextWindow != 1050000 {
+		t.Fatalf("persisted context override = %d, want clamped 1050000", got.Items[0].ModelMappings[0].ContextWindow)
+	}
+	models := got.Items[0].CodexModelCatalog.Models
+	if models[0].ContextWindow != 1050000 || models[0].MaxContextWindow != 1050000 {
+		t.Fatalf("GPT-5.6 catalog context = (%d, %d), want (1050000, 1050000)", models[0].ContextWindow, models[0].MaxContextWindow)
+	}
+	gotEfforts := make([]string, 0, len(models[0].SupportedReasoningLevels))
+	for _, level := range models[0].SupportedReasoningLevels {
+		gotEfforts = append(gotEfforts, level.Effort)
+	}
+	wantEfforts := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+	if !reflect.DeepEqual(gotEfforts, wantEfforts) {
+		t.Fatalf("GPT-5.6 reasoning levels = %#v, want %#v", gotEfforts, wantEfforts)
+	}
+	if len(models[1].SupportedReasoningLevels) != 4 {
+		t.Fatalf("unknown model reasoning levels = %#v, want conservative four-level fallback", models[1].SupportedReasoningLevels)
 	}
 }

--- a/internal/registry/codex_model_capabilities.go
+++ b/internal/registry/codex_model_capabilities.go
@@ -1,0 +1,124 @@
+package registry
+
+import "strings"
+
+// CodexModelCapability is the shared source of truth for Codex-facing model
+// metadata. Catalog-only levels may include client modes such as ultra, while
+// RuntimeWireReasoningLevels contains only values accepted by the upstream API.
+type CodexModelCapability struct {
+	ModelID                    string
+	CanonicalTarget            string
+	DisplayName                string
+	Description                string
+	ContextWindow              int
+	MaxContextWindow           int
+	MaxCompletionTokens        int
+	DefaultReasoningLevel      string
+	CatalogReasoningLevels     []string
+	RuntimeWireReasoningLevels []string
+	CompatibilityAlias         bool
+}
+
+var gpt56CatalogReasoningLevels = []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+var gpt56RuntimeWireReasoningLevels = []string{"low", "medium", "high", "xhigh", "max"}
+
+var codexModelCapabilities = map[string]CodexModelCapability{
+	"gpt-5.6": {
+		ModelID:                    "gpt-5.6",
+		CanonicalTarget:            "gpt-5.6-sol",
+		DisplayName:                "GPT-5.6",
+		Description:                "GPT-5.6 family alias routed to GPT-5.6 Sol.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+	},
+	"gpt-5.6-sol": {
+		ModelID:                    "gpt-5.6-sol",
+		CanonicalTarget:            "gpt-5.6-sol",
+		DisplayName:                "GPT-5.6 Sol",
+		Description:                "Frontier GPT-5.6 model for complex professional work.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+	},
+	"gpt-5.6-terra": {
+		ModelID:                    "gpt-5.6-terra",
+		CanonicalTarget:            "gpt-5.6-terra",
+		DisplayName:                "GPT-5.6 Terra",
+		Description:                "Balanced GPT-5.6 model for everyday professional work.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+	},
+	"gpt-5.6-luna": {
+		ModelID:                    "gpt-5.6-luna",
+		CanonicalTarget:            "gpt-5.6-luna",
+		DisplayName:                "GPT-5.6 Luna",
+		Description:                "Fast and affordable GPT-5.6 model for high-volume work.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+	},
+	"gpt-5.6-ultra": {
+		ModelID:                    "gpt-5.6-ultra",
+		CanonicalTarget:            "gpt-5.6-sol",
+		DisplayName:                "GPT-5.6 Sol (Ultra compatibility alias)",
+		Description:                "Compatibility alias for GPT-5.6 Sol with Codex Ultra as the catalog default.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "ultra",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+		CompatibilityAlias:         true,
+	},
+}
+
+// GetCodexModelCapability returns an isolated copy so callers cannot mutate the
+// shared reasoning-level slices.
+func GetCodexModelCapability(modelID string) (CodexModelCapability, bool) {
+	capability, ok := codexModelCapabilities[strings.ToLower(strings.TrimSpace(modelID))]
+	if !ok {
+		return CodexModelCapability{}, false
+	}
+	capability.CatalogReasoningLevels = append([]string(nil), capability.CatalogReasoningLevels...)
+	capability.RuntimeWireReasoningLevels = append([]string(nil), capability.RuntimeWireReasoningLevels...)
+	return capability, true
+}
+
+func getGPT56ModelDefinitions() []*ModelInfo {
+	modelIDs := []string{"gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-ultra"}
+	models := make([]*ModelInfo, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		capability, _ := GetCodexModelCapability(modelID)
+		models = append(models, &ModelInfo{
+			ID:                  capability.ModelID,
+			Object:              "model",
+			OwnedBy:             "openai",
+			Type:                "openai",
+			Version:             capability.CanonicalTarget,
+			DisplayName:         capability.DisplayName,
+			UpstreamModelID:     capability.CanonicalTarget,
+			Description:         capability.Description,
+			ContextLength:       capability.ContextWindow,
+			MaxCompletionTokens: capability.MaxCompletionTokens,
+			SupportedParameters: []string{"tools"},
+			Thinking: &ThinkingSupport{
+				Levels: append([]string(nil), capability.RuntimeWireReasoningLevels...),
+			},
+		})
+	}
+	return models
+}

--- a/internal/registry/codex_model_capabilities_test.go
+++ b/internal/registry/codex_model_capabilities_test.go
@@ -1,0 +1,48 @@
+package registry
+
+import "testing"
+
+func TestGPT56CodexCapabilities(t *testing.T) {
+	for _, modelID := range []string{"gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		capability, ok := GetCodexModelCapability(modelID)
+		if !ok {
+			t.Fatalf("GetCodexModelCapability(%q) not found", modelID)
+		}
+		if capability.ContextWindow != 1050000 || capability.MaxContextWindow != 1050000 {
+			t.Fatalf("%s context = (%d, %d), want (1050000, 1050000)", modelID, capability.ContextWindow, capability.MaxContextWindow)
+		}
+		if capability.MaxCompletionTokens != 128000 {
+			t.Fatalf("%s max completion = %d, want 128000", modelID, capability.MaxCompletionTokens)
+		}
+		assertStringSlice(t, modelID+" catalog levels", capability.CatalogReasoningLevels, []string{"low", "medium", "high", "xhigh", "max", "ultra"})
+		assertStringSlice(t, modelID+" wire levels", capability.RuntimeWireReasoningLevels, []string{"low", "medium", "high", "xhigh", "max"})
+	}
+
+	alias, ok := GetCodexModelCapability("gpt-5.6-ultra")
+	if !ok || !alias.CompatibilityAlias || alias.CanonicalTarget != "gpt-5.6-sol" || alias.DefaultReasoningLevel != "ultra" {
+		t.Fatalf("ultra alias = %#v, found=%v", alias, ok)
+	}
+}
+
+func TestGPT56StaticRegistryUsesWireLevels(t *testing.T) {
+	info := LookupStaticModelInfo("gpt-5.6-sol")
+	if info == nil || info.Thinking == nil {
+		t.Fatal("gpt-5.6-sol registry metadata missing")
+	}
+	if info.ContextLength != 1050000 || info.MaxCompletionTokens != 128000 {
+		t.Fatalf("registry limits = (%d, %d), want (1050000, 128000)", info.ContextLength, info.MaxCompletionTokens)
+	}
+	assertStringSlice(t, "registry wire levels", info.Thinking.Levels, []string{"low", "medium", "high", "xhigh", "max"})
+}
+
+func assertStringSlice(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s len = %d, want %d: %#v", label, len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s[%d] = %q, want %q: %#v", label, i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -696,7 +696,7 @@ func GetAIStudioModels() []*ModelInfo {
 
 // GetOpenAIModels returns the standard OpenAI model definitions
 func GetOpenAIModels() []*ModelInfo {
-	models := []*ModelInfo{
+	return append([]*ModelInfo{
 		{
 			ID:                  "gpt-5",
 			Object:              "model",
@@ -917,8 +917,7 @@ func GetOpenAIModels() []*ModelInfo {
 			Description:         "Text-to-image generation model.",
 			SupportedParameters: []string{"prompt", "size", "n", "response_format"},
 		},
-	}
-	return append(models, getGPT56ModelDefinitions()...)
+	}, getGPT56ModelDefinitions()...)
 }
 
 func GetXAIModels() []*ModelInfo {

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -696,7 +696,7 @@ func GetAIStudioModels() []*ModelInfo {
 
 // GetOpenAIModels returns the standard OpenAI model definitions
 func GetOpenAIModels() []*ModelInfo {
-	return []*ModelInfo{
+	models := []*ModelInfo{
 		{
 			ID:                  "gpt-5",
 			Object:              "model",
@@ -918,6 +918,7 @@ func GetOpenAIModels() []*ModelInfo {
 			SupportedParameters: []string{"prompt", "size", "n", "response_format"},
 		},
 	}
+	return append(models, getGPT56ModelDefinitions()...)
 }
 
 func GetXAIModels() []*ModelInfo {

--- a/internal/thinking/provider/codex/apply_test.go
+++ b/internal/thinking/provider/codex/apply_test.go
@@ -1,0 +1,34 @@
+package codex
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyThinkingSupportsMaxButRejectsUltraWireEffort(t *testing.T) {
+	maxBody := []byte(`{"model":"gpt-5.6-sol","reasoning":{"effort":"max"}}`)
+	got, err := thinking.ApplyThinking(maxBody, "gpt-5.6-sol", "codex", "codex", "codex")
+	if err != nil {
+		t.Fatalf("ApplyThinking(max) error: %v", err)
+	}
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "max" {
+		t.Fatalf("reasoning.effort = %q, want max; body=%s", effort, got)
+	}
+
+	ultraBody := []byte(`{"model":"gpt-5.6-sol","reasoning":{"effort":"ultra"}}`)
+	if _, err := thinking.ApplyThinking(ultraBody, "gpt-5.6-sol", "codex", "codex", "codex"); err == nil {
+		t.Fatal("ApplyThinking(ultra) error = nil, want unsupported wire effort error")
+	}
+}
+
+func TestApplyThinkingMaxSuffix(t *testing.T) {
+	got, err := thinking.ApplyThinking([]byte(`{"model":"gpt-5.6-sol"}`), "gpt-5.6-sol(max)", "codex", "codex", "codex")
+	if err != nil {
+		t.Fatalf("ApplyThinking(max suffix) error: %v", err)
+	}
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "max" {
+		t.Fatalf("reasoning.effort = %q, want max; body=%s", effort, got)
+	}
+}

--- a/internal/thinking/suffix.go
+++ b/internal/thinking/suffix.go
@@ -197,7 +197,8 @@ func ParseSpecialSuffix(rawSuffix string) (mode ThinkingMode, ok bool) {
 //   - "none" -> level="", ok=false (special value, use ParseSpecialSuffix)
 //   - "auto" -> level="", ok=false (special value, use ParseSpecialSuffix)
 //   - "8192" -> level="", ok=false (numeric, use ParseNumericSuffix)
-//   - "ultra" -> level="", ok=false (unknown level)
+//   - "max" -> level=LevelMax, ok=true
+//   - "ultra" -> level="", ok=false (Codex client mode, not a wire effort)
 func ParseLevelSuffix(rawSuffix string) (level ThinkingLevel, ok bool) {
 	if rawSuffix == "" {
 		return "", false
@@ -215,6 +216,8 @@ func ParseLevelSuffix(rawSuffix string) (level ThinkingLevel, ok bool) {
 		return LevelHigh, true
 	case "xhigh":
 		return LevelXHigh, true
+	case "max":
+		return LevelMax, true
 	default:
 		return "", false
 	}

--- a/internal/thinking/suffix_test.go
+++ b/internal/thinking/suffix_test.go
@@ -146,3 +146,12 @@ func TestParseSuffix_BracketSuffix(t *testing.T) {
 		})
 	}
 }
+
+func TestParseLevelSuffixMaxButNotUltra(t *testing.T) {
+	if level, ok := ParseLevelSuffix("max"); !ok || level != LevelMax {
+		t.Fatalf("ParseLevelSuffix(max) = (%q, %v), want (%q, true)", level, ok, LevelMax)
+	}
+	if level, ok := ParseLevelSuffix("ultra"); ok || level != "" {
+		t.Fatalf("ParseLevelSuffix(ultra) = (%q, %v), want (\"\", false)", level, ok)
+	}
+}

--- a/internal/thinking/types.go
+++ b/internal/thinking/types.go
@@ -54,6 +54,8 @@ const (
 	LevelHigh ThinkingLevel = "high"
 	// LevelXHigh sets extra-high thinking effort
 	LevelXHigh ThinkingLevel = "xhigh"
+	// LevelMax sets the maximum upstream-supported thinking effort
+	LevelMax ThinkingLevel = "max"
 )
 
 // ThinkingConfig represents a unified thinking configuration.

--- a/internal/usage/ccswitch_codex_model_catalog.go
+++ b/internal/usage/ccswitch_codex_model_catalog.go
@@ -1,6 +1,10 @@
 package usage
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+)
 
 const CcSwitchCodexModelCatalogFilename = "cc-switch-model-catalog.json"
 
@@ -85,10 +89,11 @@ const ccSwitchCodexBaseInstructions = "You are Codex, a coding agent."
 
 type ccSwitchCodexCatalogModelSpec struct {
 	Model         string
+	TargetModel   string
 	ContextWindow int
 }
 
-var ccSwitchCodexSupportedReasoningLevels = []CcSwitchCodexReasoningLevel{
+var ccSwitchCodexFallbackReasoningLevels = []CcSwitchCodexReasoningLevel{
 	{Effort: "low", Description: "Fast responses with lighter reasoning"},
 	{Effort: "medium", Description: "Balances speed and reasoning depth for everyday tasks"},
 	{Effort: "high", Description: "Greater reasoning depth for complex problems"},
@@ -112,7 +117,8 @@ func BuildCcSwitchCodexModelCatalog(row CcSwitchImportConfigRow) *CcSwitchCodexM
 		if model != "" {
 			models = append(models, ccSwitchCodexCatalogModelSpec{
 				Model:         model,
-				ContextWindow: normalizeCcSwitchCodexContextWindow(mapping.ContextWindow),
+				TargetModel:   strings.TrimSpace(mapping.TargetModel),
+				ContextWindow: mapping.ContextWindow,
 			})
 		}
 	}
@@ -162,16 +168,69 @@ func AttachCcSwitchCodexModelCatalogs(rows []CcSwitchImportConfigRow) []CcSwitch
 	return out
 }
 
-func normalizeCcSwitchCodexContextWindow(value int) int {
-	if value <= 0 {
-		return ccSwitchCodexDefaultContextWindow
+func resolveCcSwitchCodexCapability(spec ccSwitchCodexCatalogModelSpec) (registry.CodexModelCapability, bool) {
+	if capability, ok := registry.GetCodexModelCapability(spec.Model); ok {
+		return capability, true
 	}
-	return value
+	return registry.GetCodexModelCapability(spec.TargetModel)
+}
+
+func resolveCcSwitchCodexContextWindows(spec ccSwitchCodexCatalogModelSpec) (int, int) {
+	capability, known := resolveCcSwitchCodexCapability(spec)
+	if !known {
+		contextWindow := spec.ContextWindow
+		if contextWindow <= 0 {
+			contextWindow = ccSwitchCodexDefaultContextWindow
+		}
+		return contextWindow, contextWindow
+	}
+
+	contextWindow := spec.ContextWindow
+	if contextWindow <= 0 {
+		contextWindow = capability.ContextWindow
+	}
+	if contextWindow > capability.MaxContextWindow {
+		contextWindow = capability.MaxContextWindow
+	}
+	return contextWindow, capability.MaxContextWindow
+}
+
+func ccSwitchCodexReasoningLevels(levels []string) []CcSwitchCodexReasoningLevel {
+	result := make([]CcSwitchCodexReasoningLevel, 0, len(levels))
+	for _, effort := range levels {
+		description := effort
+		switch effort {
+		case "low":
+			description = "Fast responses with lighter reasoning"
+		case "medium":
+			description = "Balances speed and reasoning depth for everyday tasks"
+		case "high":
+			description = "Greater reasoning depth for complex problems"
+		case "xhigh":
+			description = "Extra high reasoning depth for complex problems"
+		case "max":
+			description = "Maximum reasoning depth for the hardest problems"
+		case "ultra":
+			description = "Maximum reasoning with automatic task delegation"
+		}
+		result = append(result, CcSwitchCodexReasoningLevel{Effort: effort, Description: description})
+	}
+	return result
 }
 
 func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, priority int) CcSwitchCodexModelCatalogEntry {
 	model := strings.TrimSpace(spec.Model)
-	contextWindow := normalizeCcSwitchCodexContextWindow(spec.ContextWindow)
+	contextWindow, maxContextWindow := resolveCcSwitchCodexContextWindows(spec)
+	defaultReasoningLevel := "medium"
+	supportedReasoningLevels := append([]CcSwitchCodexReasoningLevel(nil), ccSwitchCodexFallbackReasoningLevels...)
+	displayName := model
+	description := model
+	if capability, ok := resolveCcSwitchCodexCapability(spec); ok {
+		defaultReasoningLevel = capability.DefaultReasoningLevel
+		supportedReasoningLevels = ccSwitchCodexReasoningLevels(capability.CatalogReasoningLevels)
+		displayName = capability.DisplayName
+		description = capability.Description
+	}
 	messages := CcSwitchCodexModelMessages{
 		InstructionsTemplate:          ccSwitchCodexBaseInstructions,
 		InstructionsVariables:         map[string]string{},
@@ -185,7 +244,7 @@ func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, pri
 		SupportsParallelToolCalls:     true,
 		SupportsImageDetailOriginal:   true,
 		ContextWindow:                 contextWindow,
-		MaxContextWindow:              contextWindow,
+		MaxContextWindow:              maxContextWindow,
 		EffectiveContextWindowPercent: 95,
 		ExperimentalSupportedTools:    []string{},
 		InputModalities:               []string{"text", "image"},
@@ -196,10 +255,10 @@ func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, pri
 	return CcSwitchCodexModelCatalogEntry{
 		Slug:                          model,
 		Model:                         model,
-		DisplayName:                   model,
-		Description:                   model,
-		DefaultReasoningLevel:         "medium",
-		SupportedReasoningLevels:      ccSwitchCodexSupportedReasoningLevels,
+		DisplayName:                   displayName,
+		Description:                   description,
+		DefaultReasoningLevel:         defaultReasoningLevel,
+		SupportedReasoningLevels:      supportedReasoningLevels,
 		ShellType:                     "shell_command",
 		Visibility:                    "list",
 		SupportedInAPI:                true,
@@ -220,7 +279,7 @@ func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, pri
 		SupportsParallelToolCalls:     true,
 		SupportsImageDetailOriginal:   true,
 		ContextWindow:                 contextWindow,
-		MaxContextWindow:              contextWindow,
+		MaxContextWindow:              maxContextWindow,
 		EffectiveContextWindowPercent: 95,
 		ExperimentalSupportedTools:    []string{},
 		InputModalities:               []string{"text", "image"},

--- a/internal/usage/ccswitch_codex_model_catalog_test.go
+++ b/internal/usage/ccswitch_codex_model_catalog_test.go
@@ -85,3 +85,61 @@ func TestBuildCcSwitchCodexModelCatalogSkipsNonCodex(t *testing.T) {
 		t.Fatalf("catalog = %#v, want nil", catalog)
 	}
 }
+
+func TestBuildCcSwitchCodexModelCatalogUsesGPT56Capabilities(t *testing.T) {
+	row := CcSwitchImportConfigRow{
+		ClientType:   "codex",
+		DefaultModel: "gpt-5.6-sol",
+		ModelMappings: []CcSwitchModelMappingRow{
+			{RequestModel: "gpt-5.6-sol", TargetModel: "gpt-5.6-sol"},
+			{RequestModel: "gpt-5.6-terra", TargetModel: "gpt-5.6-terra", ContextWindow: 400000},
+			{RequestModel: "gpt-5.6-luna", TargetModel: "gpt-5.6-luna", ContextWindow: 2000000},
+			{RequestModel: "legacy-sol", TargetModel: "gpt-5.6-sol"},
+			{RequestModel: "gpt-5.6-ultra", TargetModel: "gpt-5.6-sol"},
+		},
+	}
+
+	catalog := BuildCcSwitchCodexModelCatalog(row)
+	if catalog == nil || len(catalog.Models) != 5 {
+		t.Fatalf("catalog = %#v, want five GPT-5.6 entries", catalog)
+	}
+	bySlug := make(map[string]CcSwitchCodexModelCatalogEntry, len(catalog.Models))
+	for _, model := range catalog.Models {
+		bySlug[model.Slug] = model
+	}
+
+	for _, slug := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "legacy-sol"} {
+		entry := bySlug[slug]
+		if entry.MaxContextWindow != 1050000 || entry.ModelMessages.MaxContextWindow != 1050000 {
+			t.Fatalf("%s max context = (%d, %d), want 1050000", slug, entry.MaxContextWindow, entry.ModelMessages.MaxContextWindow)
+		}
+		assertCcSwitchReasoningEfforts(t, slug, entry.SupportedReasoningLevels, []string{"low", "medium", "high", "xhigh", "max", "ultra"})
+	}
+	if got := bySlug["gpt-5.6-sol"].ContextWindow; got != 1050000 {
+		t.Fatalf("sol context = %d, want 1050000", got)
+	}
+	if got := bySlug["gpt-5.6-terra"].ContextWindow; got != 400000 {
+		t.Fatalf("terra default override = %d, want 400000", got)
+	}
+	if got := bySlug["gpt-5.6-luna"].ContextWindow; got != 1050000 {
+		t.Fatalf("luna clamped context = %d, want 1050000", got)
+	}
+	if got := bySlug["legacy-sol"].ContextWindow; got != 1050000 {
+		t.Fatalf("target-derived legacy alias context = %d, want 1050000", got)
+	}
+	if got := bySlug["gpt-5.6-ultra"].DefaultReasoningLevel; got != "ultra" {
+		t.Fatalf("ultra alias default reasoning = %q, want ultra", got)
+	}
+}
+
+func assertCcSwitchReasoningEfforts(t *testing.T, label string, got []CcSwitchCodexReasoningLevel, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s reasoning len = %d, want %d: %#v", label, len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Effort != want[i] {
+			t.Fatalf("%s reasoning[%d] = %q, want %q: %#v", label, i, got[i].Effort, want[i], got)
+		}
+	}
+}

--- a/internal/usage/ccswitch_import_configs_db.go
+++ b/internal/usage/ccswitch_import_configs_db.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	log "github.com/sirupsen/logrus"
 )
@@ -300,7 +301,7 @@ func normalizeCcSwitchModelMappings(values []CcSwitchModelMappingRow) []CcSwitch
 			Role:          role,
 			RequestModel:  requestModel,
 			TargetModel:   targetModel,
-			ContextWindow: normalizeCcSwitchContextWindow(value.ContextWindow),
+			ContextWindow: normalizeCcSwitchContextWindowForModels(value.ContextWindow, requestModel, targetModel),
 		})
 	}
 	if result == nil {
@@ -314,6 +315,20 @@ func normalizeCcSwitchContextWindow(value int) int {
 		return 0
 	}
 	return value
+}
+
+func normalizeCcSwitchContextWindowForModels(value int, modelIDs ...string) int {
+	contextWindow := normalizeCcSwitchContextWindow(value)
+	if contextWindow == 0 {
+		return 0
+	}
+	for _, modelID := range modelIDs {
+		capability, ok := registry.GetCodexModelCapability(modelID)
+		if ok && contextWindow > capability.MaxContextWindow {
+			return capability.MaxContextWindow
+		}
+	}
+	return contextWindow
 }
 
 func normalizeCcSwitchModelRole(value string) string {

--- a/internal/usage/ccswitch_import_configs_db_test.go
+++ b/internal/usage/ccswitch_import_configs_db_test.go
@@ -129,3 +129,16 @@ func TestFindCcSwitchImportConfigByRoutePath(t *testing.T) {
 		t.Fatalf("row.ModelMappings = %#v, want kimi-k2.6 mapping", row.ModelMappings)
 	}
 }
+
+func TestNormalizeCcSwitchModelMappingsClampsKnownCodexContext(t *testing.T) {
+	mappings := normalizeCcSwitchModelMappings([]CcSwitchModelMappingRow{
+		{RequestModel: "gpt-5.6-luna", TargetModel: "gpt-5.6-luna", ContextWindow: 2000000},
+		{RequestModel: "unknown-model", TargetModel: "unknown-upstream", ContextWindow: 2000000},
+	})
+	if got := mappings[0].ContextWindow; got != 1050000 {
+		t.Fatalf("known GPT-5.6 context = %d, want 1050000", got)
+	}
+	if got := mappings[1].ContextWindow; got != 2000000 {
+		t.Fatalf("unknown model context = %d, want 2000000", got)
+	}
+}

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -2024,7 +2024,9 @@ func TestQueryStatsAndHeatmapCountSessionsFromDetails(t *testing.T) {
 		CleanupIntervalMinutes: 1440,
 	})
 
-	today := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	// Keep both samples inside the rolling query window instead of letting a
+	// hard-coded calendar date age out as the test suite advances.
+	today := CutoffStartUTC(1).Add(12 * time.Hour)
 	yesterday := today.AddDate(0, 0, -1)
 	InsertLogWithDetails("sk-heatmap", "Heatmap", "gpt-5.4", "codex", "Codex", "auth-1", false, today, 10, 5, TokenStats{
 		InputTokens: 10, OutputTokens: 20, TotalTokens: 30,


### PR DESCRIPTION
## Summary
- add shared per-model GPT-5.6 Codex capabilities and compatibility alias metadata
- generate CC Switch catalog context and reasoning levels per model while clamping overrides
- accept max as a runtime wire effort and suffix without sending ultra upstream
- stabilize the date-dependent usage heatmap test

## Verification
- `rtk go test ./...`
- targeted usage, thinking, registry, and management handler tests
- `rtk git diff --check`