### PR TITLE
Release: merge dev into main for v0.4.7

### DIFF
--- a/internal/api/handlers/management/ccswitch_import_configs_test.go
+++ b/internal/api/handlers/management/ccswitch_import_configs_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 func TestCcSwitchImportConfigsManagementHandlersUseDatabase(t *testing.T) {
@@ -198,5 +200,71 @@ func TestCcSwitchImportConfigsPreservesCodexMappingContextWindow(t *testing.T) {
 	}
 	if firstModel["context_window"] != float64(272000) {
 		t.Fatalf("first catalog context_window = %#v, want 272000", firstModel["context_window"])
+	}
+}
+
+func TestCcSwitchImportConfigsReturnsGPT56CapabilitiesAndClampsContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+
+	body := []byte(`[
+  {
+    "id": "cfg-gpt56",
+    "client-type": "codex",
+    "provider-name": "Relay GPT-5.6",
+    "default-model": "gpt-5.6-sol",
+    "allowed-channel-groups": ["codex"],
+    "endpoint-path": "/v1",
+    "usage-auto-interval": 30,
+    "model-mappings": [
+      {"request-model": "gpt-5.6-sol", "target-model": "gpt-5.6-sol", "context-window": 2000000},
+      {"request-model": "deepseek-v4-flash", "target-model": "deepseek-chat"}
+    ]
+  }
+]`)
+
+	h := NewHandler(&config.Config{}, "", nil)
+	putRec := httptest.NewRecorder()
+	putCtx, _ := gin.CreateTestContext(putRec)
+	putCtx.Request = httptest.NewRequest(http.MethodPut, "/ccswitch-import-configs", bytes.NewReader(body))
+	h.PutCcSwitchImportConfigs(putCtx)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d; body=%s", putRec.Code, http.StatusOK, putRec.Body.String())
+	}
+
+	getRec := httptest.NewRecorder()
+	getCtx, _ := gin.CreateTestContext(getRec)
+	getCtx.Request = httptest.NewRequest(http.MethodGet, "/ccswitch-import-configs", nil)
+	h.GetCcSwitchImportConfigs(getCtx)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d; body=%s", getRec.Code, http.StatusOK, getRec.Body.String())
+	}
+
+	var got struct {
+		Items []usage.CcSwitchImportConfigRow `json:"items"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal GET response: %v", err)
+	}
+	if len(got.Items) != 1 || got.Items[0].CodexModelCatalog == nil {
+		t.Fatalf("items = %#v, want one generated catalog", got.Items)
+	}
+	if got.Items[0].ModelMappings[0].ContextWindow != 1050000 {
+		t.Fatalf("persisted context override = %d, want clamped 1050000", got.Items[0].ModelMappings[0].ContextWindow)
+	}
+	models := got.Items[0].CodexModelCatalog.Models
+	if models[0].ContextWindow != 1050000 || models[0].MaxContextWindow != 1050000 {
+		t.Fatalf("GPT-5.6 catalog context = (%d, %d), want (1050000, 1050000)", models[0].ContextWindow, models[0].MaxContextWindow)
+	}
+	gotEfforts := make([]string, 0, len(models[0].SupportedReasoningLevels))
+	for _, level := range models[0].SupportedReasoningLevels {
+		gotEfforts = append(gotEfforts, level.Effort)
+	}
+	wantEfforts := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+	if !reflect.DeepEqual(gotEfforts, wantEfforts) {
+		t.Fatalf("GPT-5.6 reasoning levels = %#v, want %#v", gotEfforts, wantEfforts)
+	}
+	if len(models[1].SupportedReasoningLevels) != 4 {
+		t.Fatalf("unknown model reasoning levels = %#v, want conservative four-level fallback", models[1].SupportedReasoningLevels)
 	}
 }

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -39,27 +39,28 @@ const attemptMaxIdleTime = 2 * time.Hour
 
 // Handler aggregates config reference, persistence path and helpers.
 type Handler struct {
-	cfg                 *config.Config
-	configFilePath      string
-	mu                  sync.Mutex
-	attemptsMu          sync.Mutex
-	failedAttempts      map[string]*attemptInfo // keyed by client IP
-	authManager         *coreauth.Manager
-	usageStats          *usage.RequestStatistics
-	tokenStore          coreauth.Store
-	localPassword       string
-	allowRemoteOverride bool
-	envSecret           string
-	logDir              string
-	postAuthHook        coreauth.PostAuthHook
-	onConfigMutated     func(*config.Config)
-	startTime           time.Time
-	attemptCleanupStop  chan struct{}
-	attemptCleanupOnce  sync.Once
-	accessManager       *sdkaccess.Manager
-	trendCacheMu        sync.Mutex
-	trendCache          map[string]trendCacheEntry
-	imageGeneration     *imagegeneration.Service
+	cfg                  *config.Config
+	configFilePath       string
+	mu                   sync.Mutex
+	attemptsMu           sync.Mutex
+	failedAttempts       map[string]*attemptInfo // keyed by client IP
+	authManager          *coreauth.Manager
+	usageStats           *usage.RequestStatistics
+	tokenStore           coreauth.Store
+	localPassword        string
+	allowRemoteOverride  bool
+	envSecret            string
+	logDir               string
+	postAuthHook         coreauth.PostAuthHook
+	onConfigMutated      func(*config.Config)
+	onModelConfigMutated func()
+	startTime            time.Time
+	attemptCleanupStop   chan struct{}
+	attemptCleanupOnce   sync.Once
+	accessManager        *sdkaccess.Manager
+	trendCacheMu         sync.Mutex
+	trendCache           map[string]trendCacheEntry
+	imageGeneration      *imagegeneration.Service
 }
 
 type trendCacheEntry struct {
@@ -171,6 +172,8 @@ func (h *Handler) SetAuthManager(manager *coreauth.Manager) {
 }
 
 func (h *Handler) SetConfigMutatedHook(fn func(*config.Config)) { h.onConfigMutated = fn }
+
+func (h *Handler) SetModelConfigMutatedHook(fn func()) { h.onModelConfigMutated = fn }
 
 // SetAccessManager wires the request authentication access manager so management writes
 // (such as API key channel/model restrictions) can be applied immediately at runtime.

--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/runtimeconfig"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
@@ -31,14 +32,9 @@ func (h *Handler) GetIdentityFingerprint(c *gin.Context) {
 	learned, effective := h.identityFingerprintState(current)
 	c.JSON(http.StatusOK, identityFingerprintResponse{
 		IdentityFingerprint: current,
-		Defaults: config.IdentityFingerprintConfig{
-			Codex:  config.DefaultCodexIdentityFingerprint(),
-			Claude: config.DefaultClaudeIdentityFingerprint(),
-			Gemini: config.DefaultGeminiIdentityFingerprint(),
-			XAI:    config.DefaultXAIIdentityFingerprint(),
-		},
-		Learned:   learned,
-		Effective: effective,
+		Defaults:            config.DefaultIdentityFingerprintConfig(),
+		Learned:             learned,
+		Effective:           effective,
 		Status: map[string]identityFingerprintProviderStatus{
 			"claude": {Enabled: current.Claude.Enabled, LearnedCount: len(learned["claude"])},
 			"codex":  {Enabled: current.Codex.Enabled, LearnedCount: len(learned["codex"])},
@@ -55,10 +51,7 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 		return
 	}
 
-	body.Codex = config.CleanCodexIdentityFingerprint(body.Codex)
-	body.Claude = config.CleanClaudeIdentityFingerprint(body.Claude)
-	body.Gemini = config.CleanGeminiIdentityFingerprint(body.Gemini)
-	body.XAI = config.CleanXAIIdentityFingerprint(body.XAI)
+	body = config.NormalizeIdentityFingerprintConfig(body)
 	if err := validateCodexIdentityFingerprint(body.Codex); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -90,7 +83,7 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 	h.cfg.IdentityFingerprint = body
 	h.mu.Unlock()
 
-	if !h.persistRuntimeSetting(c, settingsstore.RuntimeSettingIdentityFingerprint, body) {
+	if !h.persistRuntimeSetting(c, settingsstore.RuntimeSettingIdentityFingerprint, runtimeconfig.IdentityFingerprintRuntimeSettingValue(body)) {
 		h.mu.Lock()
 		if h.cfg != nil {
 			h.cfg.IdentityFingerprint = previous

--- a/internal/api/handlers/management/identity_fingerprint_account.go
+++ b/internal/api/handlers/management/identity_fingerprint_account.go
@@ -138,11 +138,7 @@ func (h *Handler) currentIdentityFingerprintConfig() config.IdentityFingerprintC
 		}
 		h.mu.Unlock()
 	}
-	current.Codex = config.CleanCodexIdentityFingerprint(current.Codex)
-	current.Claude = config.CleanClaudeIdentityFingerprint(current.Claude)
-	current.Gemini = config.CleanGeminiIdentityFingerprint(current.Gemini)
-	current.XAI = config.CleanXAIIdentityFingerprint(current.XAI)
-	return current
+	return config.NormalizeIdentityFingerprintConfig(current)
 }
 
 func resolveIdentityFingerprint(current config.IdentityFingerprintConfig, provider identityfingerprint.Provider, learned *identityfingerprint.LearnedRecord) (identityfingerprint.EffectiveFingerprint, any, any) {

--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -97,6 +97,7 @@ func (h *ModelsHandler) PostModelConfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	h.notifyModelConfigMutated()
 	c.JSON(http.StatusOK, saved)
 }
 
@@ -116,6 +117,7 @@ func (h *ModelsHandler) PutModelConfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	h.notifyModelConfigMutated()
 	c.JSON(http.StatusOK, saved)
 }
 
@@ -129,6 +131,7 @@ func (h *ModelsHandler) DeleteModelConfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	h.notifyModelConfigMutated()
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
@@ -240,5 +243,13 @@ func (h *ModelsHandler) PostOpenRouterModelSyncRun(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error(), "state": state})
 		return
 	}
+	h.notifyModelConfigMutated()
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "result": result, "state": state})
+}
+
+func (h *ModelsHandler) notifyModelConfigMutated() {
+	if h == nil || h.Handler == nil || h.onModelConfigMutated == nil {
+		return
+	}
+	h.onModelConfigMutated()
 }

--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -110,6 +110,45 @@ func TestModelConfigHandlersCreateListAndDelete(t *testing.T) {
 	}
 }
 
+func TestModelConfigHandlersNotifyModelConfigMutation(t *testing.T) {
+	initManagementModelsTestDB(t)
+	h := NewHandler(&config.Config{}, "", nil)
+	notifications := 0
+	h.SetModelConfigMutatedHook(func() { notifications++ })
+
+	createBody := []byte(`{"id":"notify-model","owned_by":"codex","enabled":true}`)
+	createRec := performModelsRequest(http.MethodPost, "/model-configs", createBody, h.Models().PostModelConfig)
+	if createRec.Code != http.StatusOK {
+		t.Fatalf("PostModelConfig status = %d body = %s", createRec.Code, createRec.Body.String())
+	}
+	if notifications != 1 {
+		t.Fatalf("notifications after create = %d, want 1", notifications)
+	}
+
+	updateBody := []byte(`{"id":"notify-model","owned_by":"codex","enabled":false}`)
+	updateRec := performModelsRequest(http.MethodPut, "/model-configs/notify-model", updateBody, func(c *gin.Context) {
+		c.Params = gin.Params{{Key: "id", Value: "notify-model"}}
+		h.Models().PutModelConfig(c)
+	})
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("PutModelConfig status = %d body = %s", updateRec.Code, updateRec.Body.String())
+	}
+	if notifications != 2 {
+		t.Fatalf("notifications after update = %d, want 2", notifications)
+	}
+
+	deleteRec := performModelsRequest(http.MethodDelete, "/model-configs/notify-model", nil, func(c *gin.Context) {
+		c.Params = gin.Params{{Key: "id", Value: "notify-model"}}
+		h.Models().DeleteModelConfig(c)
+	})
+	if deleteRec.Code != http.StatusOK {
+		t.Fatalf("DeleteModelConfig status = %d body = %s", deleteRec.Code, deleteRec.Body.String())
+	}
+	if notifications != 3 {
+		t.Fatalf("notifications after delete = %d, want 3", notifications)
+	}
+}
+
 func TestModelConfigHandlersScopeFiltering(t *testing.T) {
 	initManagementModelsTestDB(t)
 	h := NewHandler(&config.Config{}, "", nil)

--- a/internal/api/handlers/management/runtime_settings_test.go
+++ b/internal/api/handlers/management/runtime_settings_test.go
@@ -53,6 +53,16 @@ func TestPutIdentityFingerprintPersistsToSQLite(t *testing.T) {
 		stored.IdentityFingerprint.Claude.SessionMode != "server-stable" {
 		t.Fatalf("stored claude identity fingerprint = %#v", stored.IdentityFingerprint.Claude)
 	}
+	if !stored.IdentityFingerprint.Gemini.Enabled {
+		t.Fatalf("stored gemini identity fingerprint = %#v, want enabled by default", stored.IdentityFingerprint.Gemini)
+	}
+	if !stored.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("stored xai identity fingerprint = %#v, want enabled by default", stored.IdentityFingerprint.XAI)
+	}
+	payload, ok := settingsstore.GetRuntimeSettingPayload(settingsstore.RuntimeSettingIdentityFingerprint)
+	if !ok || !strings.Contains(string(payload), `"runtime-setting-version":2`) {
+		t.Fatalf("identity fingerprint runtime payload = %s, want versioned payload", string(payload))
+	}
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {

--- a/internal/api/handlers/management/system_stats.go
+++ b/internal/api/handlers/management/system_stats.go
@@ -22,9 +22,10 @@ import (
 // SystemStats is the JSON payload pushed via WebSocket and returned by HTTP.
 type SystemStats struct {
 	// Database
-	DBSizeBytes int64 `json:"db_size_bytes"`
+	DBSizeBytes int64  `json:"db_size_bytes"`
+	DBEngine    string `json:"db_engine"`
 
-	// Request log body storage inside SQLite.
+	// Request log body storage inside the runtime database.
 	LogContentStoreBytes int64 `json:"log_content_store_bytes"`
 
 	// Log directory size on disk.
@@ -92,18 +93,11 @@ func (h *Handler) collectSystemStats() SystemStats {
 	runtime.ReadMemStats(&m)
 	stats.GoHeapBytes = m.HeapAlloc
 
-	// ── DB file size ──
-	dbPath := usage.GetDBPath()
-	if dbPath != "" {
-		if info, err := os.Stat(dbPath); err == nil {
-			stats.DBSizeBytes = info.Size()
-		}
-		// Also check WAL and SHM files
-		for _, suffix := range []string{"-wal", "-shm"} {
-			if info, err := os.Stat(dbPath + suffix); err == nil {
-				stats.DBSizeBytes += info.Size()
-			}
-		}
+	dbStats, err := usage.GetDatabaseStats()
+	stats.DBEngine = dbStats.Driver
+	stats.DBSizeBytes = dbStats.SizeBytes
+	if err != nil {
+		log.Warnf("system-stats: failed to query database stats: %v", err)
 	}
 	if contentBytes, err := usage.GetRequestLogStorageBytes(); err == nil {
 		stats.LogContentStoreBytes = contentBytes

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -13,16 +13,17 @@ import (
 )
 
 type serverOptionConfig struct {
-	extraMiddleware       []gin.HandlerFunc
-	engineConfigurator    func(*gin.Engine)
-	routerConfigurator    func(*gin.Engine, *handlers.BaseAPIHandler, *config.Config)
-	requestLoggerFactory  func(*config.Config, string) logging.RequestLogger
-	localPassword         string
-	keepAliveEnabled      bool
-	keepAliveTimeout      time.Duration
-	keepAliveOnTimeout    func()
-	postAuthHook          auth.PostAuthHook
-	configMutatedCallback func(*config.Config)
+	extraMiddleware            []gin.HandlerFunc
+	engineConfigurator         func(*gin.Engine)
+	routerConfigurator         func(*gin.Engine, *handlers.BaseAPIHandler, *config.Config)
+	requestLoggerFactory       func(*config.Config, string) logging.RequestLogger
+	localPassword              string
+	keepAliveEnabled           bool
+	keepAliveTimeout           time.Duration
+	keepAliveOnTimeout         func()
+	postAuthHook               auth.PostAuthHook
+	configMutatedCallback      func(*config.Config)
+	modelConfigMutatedCallback func()
 }
 
 // ServerOption customises HTTP server construction.
@@ -93,5 +94,11 @@ func WithPostAuthHook(hook auth.PostAuthHook) ServerOption {
 func WithConfigMutatedCallback(fn func(*config.Config)) ServerOption {
 	return func(cfg *serverOptionConfig) {
 		cfg.configMutatedCallback = fn
+	}
+}
+
+func WithModelConfigMutatedCallback(fn func()) ServerOption {
+	return func(cfg *serverOptionConfig) {
+		cfg.modelConfigMutatedCallback = fn
 	}
 }

--- a/internal/api/sdkbridge/bridge.go
+++ b/internal/api/sdkbridge/bridge.go
@@ -88,6 +88,10 @@ func WithConfigMutatedCallback(fn func(*sdkconfig.Config)) ServerOption {
 	return coreapi.WithConfigMutatedCallback(fn)
 }
 
+func WithModelConfigMutatedCallback(fn func()) ServerOption {
+	return coreapi.WithModelConfigMutatedCallback(fn)
+}
+
 func WithKeepAliveEndpoint(timeout time.Duration, onTimeout func()) ServerOption {
 	return coreapi.WithKeepAliveEndpoint(timeout, onTimeout)
 }

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -205,6 +205,9 @@ func (s *Server) configureManagementHandler(
 	if optionState != nil && optionState.postAuthHook != nil {
 		s.mgmt.SetPostAuthHook(optionState.postAuthHook)
 	}
+	if optionState != nil && optionState.modelConfigMutatedCallback != nil {
+		s.mgmt.SetModelConfigMutatedHook(optionState.modelConfigMutatedCallback)
+	}
 }
 
 func (s *Server) registerBuiltinModules(cfg *config.Config, accessManager *sdkaccess.Manager) {

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -403,6 +403,10 @@ func FetchAntigravityModels(ctx context.Context, auth *coreauth.Auth, cfg *confi
 	return executor.FetchAntigravityModels(ctx, auth, cfg)
 }
 
+func FetchXAIModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return executor.FetchXAIModels(ctx, auth, cfg)
+}
+
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	if coreManager == nil || auth == nil {
 		return

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -271,6 +271,12 @@ func TestLoadConfigDefaultsAutoUpdateEnabled(t *testing.T) {
 	if cfg.AutoUpdate.UpdaterURL != DefaultAutoUpdateUpdaterURL {
 		t.Fatalf("AutoUpdate.UpdaterURL = %q, want %q", cfg.AutoUpdate.UpdaterURL, DefaultAutoUpdateUpdaterURL)
 	}
+	if !cfg.IdentityFingerprint.Codex.Enabled ||
+		!cfg.IdentityFingerprint.Claude.Enabled ||
+		!cfg.IdentityFingerprint.Gemini.Enabled ||
+		!cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want all providers enabled by default", cfg.IdentityFingerprint)
+	}
 }
 
 func TestLoadConfigReadsDisabledAutoUpdate(t *testing.T) {
@@ -308,6 +314,34 @@ auto-update:
 	}
 	if cfg.AutoUpdate.UpdaterURL != "http://updater.local:8320" {
 		t.Fatalf("AutoUpdate.UpdaterURL = %q, want http://updater.local:8320", cfg.AutoUpdate.UpdaterURL)
+	}
+}
+
+func TestLoadConfigIdentityFingerprintDefaultsAndExplicitDisabled(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`port: 8317
+identity-fingerprint:
+  xai:
+    enabled: false
+`)
+	if err := os.WriteFile(configPath, content, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if !cfg.IdentityFingerprint.Codex.Enabled ||
+		!cfg.IdentityFingerprint.Claude.Enabled ||
+		!cfg.IdentityFingerprint.Gemini.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want omitted providers enabled by default", cfg.IdentityFingerprint)
+	}
+	if cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("XAI.Enabled = true, want explicit false from config")
 	}
 }
 

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -1,6 +1,11 @@
 package config
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
 
 const (
 	// Defaults are intentionally aligned with upstream CLIProxyAPI's codex-tui behavior.
@@ -48,12 +53,13 @@ type CodexIdentityFingerprintConfig struct {
 	SessionMode   string            `yaml:"session-mode,omitempty" json:"session-mode,omitempty"`
 	SessionID     string            `yaml:"session-id,omitempty" json:"session-id,omitempty"`
 	CustomHeaders map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet    bool
 }
 
 // DefaultCodexIdentityFingerprint returns the recommended Codex identity template.
 func DefaultCodexIdentityFingerprint() CodexIdentityFingerprintConfig {
 	return CodexIdentityFingerprintConfig{
-		Enabled:       false,
+		Enabled:       true,
 		UserAgent:     DefaultCodexFingerprintUserAgent,
 		Version:       DefaultCodexFingerprintVersion,
 		Originator:    DefaultCodexFingerprintOriginator,
@@ -78,6 +84,7 @@ type ClaudeIdentityFingerprintConfig struct {
 	SessionID               string            `yaml:"session-id,omitempty" json:"session-id,omitempty"`
 	DeviceID                string            `yaml:"device-id,omitempty" json:"device-id,omitempty"`
 	CustomHeaders           map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet              bool
 }
 
 // GeminiIdentityFingerprintConfig configures Gemini CLI upstream identity headers.
@@ -87,6 +94,7 @@ type GeminiIdentityFingerprintConfig struct {
 	APIClient      string            `yaml:"x-goog-api-client,omitempty" json:"x-goog-api-client,omitempty"`
 	ClientMetadata string            `yaml:"client-metadata,omitempty" json:"client-metadata,omitempty"`
 	CustomHeaders  map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet     bool
 }
 
 // XAIIdentityFingerprintConfig configures Grok/xAI upstream identity headers.
@@ -97,6 +105,7 @@ type XAIIdentityFingerprintConfig struct {
 	ClientVersion      string            `yaml:"x-grok-client-version,omitempty" json:"x-grok-client-version,omitempty"`
 	GrokConversationID string            `yaml:"x-grok-conv-id,omitempty" json:"x-grok-conv-id,omitempty"`
 	CustomHeaders      map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet         bool
 }
 
 // DefaultClaudeIdentityFingerprint returns the recommended Claude Code identity template.
@@ -104,7 +113,7 @@ func DefaultClaudeIdentityFingerprint() ClaudeIdentityFingerprintConfig {
 	cliVersion := DefaultClaudeFingerprintCLIVersion
 	entrypoint := DefaultClaudeFingerprintEntrypoint
 	return ClaudeIdentityFingerprintConfig{
-		Enabled:                 false,
+		Enabled:                 true,
 		CLIVersion:              cliVersion,
 		Entrypoint:              entrypoint,
 		UserAgent:               BuildClaudeFingerprintUserAgent(cliVersion, entrypoint),
@@ -120,7 +129,7 @@ func DefaultClaudeIdentityFingerprint() ClaudeIdentityFingerprintConfig {
 // DefaultGeminiIdentityFingerprint returns the recommended Gemini CLI identity template.
 func DefaultGeminiIdentityFingerprint() GeminiIdentityFingerprintConfig {
 	return GeminiIdentityFingerprintConfig{
-		Enabled:        false,
+		Enabled:        true,
 		UserAgent:      DefaultGeminiFingerprintUserAgent,
 		APIClient:      DefaultGeminiFingerprintAPIClient,
 		ClientMetadata: DefaultGeminiFingerprintClientMetadata,
@@ -131,11 +140,22 @@ func DefaultGeminiIdentityFingerprint() GeminiIdentityFingerprintConfig {
 // DefaultXAIIdentityFingerprint returns the conservative Grok identity template.
 func DefaultXAIIdentityFingerprint() XAIIdentityFingerprintConfig {
 	return XAIIdentityFingerprintConfig{
-		Enabled:          false,
+		Enabled:          true,
 		UserAgent:        DefaultXAIFingerprintUserAgent,
 		ClientIdentifier: DefaultXAIFingerprintClientIdentifier,
 		ClientVersion:    DefaultXAIFingerprintClientVersion,
 		CustomHeaders:    map[string]string{},
+	}
+}
+
+// DefaultIdentityFingerprintConfig returns provider templates exposed to the
+// management UI and used as builtin fallbacks by resolvers.
+func DefaultIdentityFingerprintConfig() IdentityFingerprintConfig {
+	return IdentityFingerprintConfig{
+		Codex:  DefaultCodexIdentityFingerprint(),
+		Claude: DefaultClaudeIdentityFingerprint(),
+		Gemini: DefaultGeminiIdentityFingerprint(),
+		XAI:    DefaultXAIIdentityFingerprint(),
 	}
 }
 
@@ -144,16 +164,55 @@ func (cfg *Config) SanitizeIdentityFingerprint() {
 	if cfg == nil {
 		return
 	}
-	cfg.IdentityFingerprint.Codex = CleanCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex)
-	cfg.IdentityFingerprint.Claude = CleanClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude)
-	cfg.IdentityFingerprint.Gemini = CleanGeminiIdentityFingerprint(cfg.IdentityFingerprint.Gemini)
-	cfg.IdentityFingerprint.XAI = CleanXAIIdentityFingerprint(cfg.IdentityFingerprint.XAI)
+	cfg.IdentityFingerprint = NormalizeIdentityFingerprintConfig(cfg.IdentityFingerprint)
+}
+
+// CleanIdentityFingerprintConfig trims provider identity fingerprint config
+// without changing explicit enablement.
+func CleanIdentityFingerprintConfig(in IdentityFingerprintConfig) IdentityFingerprintConfig {
+	return IdentityFingerprintConfig{
+		Codex:  CleanCodexIdentityFingerprint(in.Codex),
+		Claude: CleanClaudeIdentityFingerprint(in.Claude),
+		Gemini: CleanGeminiIdentityFingerprint(in.Gemini),
+		XAI:    CleanXAIIdentityFingerprint(in.XAI),
+	}
+}
+
+// NormalizeIdentityFingerprintConfig trims providers and enables them by
+// default unless the input explicitly supplied enabled: false.
+func NormalizeIdentityFingerprintConfig(in IdentityFingerprintConfig) IdentityFingerprintConfig {
+	out := CleanIdentityFingerprintConfig(in)
+	out.Codex = defaultCodexIdentityFingerprintEnabled(out.Codex)
+	out.Claude = defaultClaudeIdentityFingerprintEnabled(out.Claude)
+	out.Gemini = defaultGeminiIdentityFingerprintEnabled(out.Gemini)
+	out.XAI = defaultXAIIdentityFingerprintEnabled(out.XAI)
+	return out
+}
+
+// NormalizeLegacyIdentityFingerprintRuntimeConfig treats old runtime payloads
+// that stored the previous empty disabled defaults as absent provider config.
+func NormalizeLegacyIdentityFingerprintRuntimeConfig(in IdentityFingerprintConfig) IdentityFingerprintConfig {
+	out := CleanIdentityFingerprintConfig(in)
+	if codexLegacyDefaultDisabled(out.Codex) {
+		out.Codex.enabledSet = false
+	}
+	if claudeLegacyDefaultDisabled(out.Claude) {
+		out.Claude.enabledSet = false
+	}
+	if geminiLegacyDefaultDisabled(out.Gemini) {
+		out.Gemini.enabledSet = false
+	}
+	if xaiLegacyDefaultDisabled(out.XAI) {
+		out.XAI.enabledSet = false
+	}
+	return NormalizeIdentityFingerprintConfig(out)
 }
 
 // NormalizeCodexIdentityFingerprint trims user input and applies safe defaults
 // for fields that participate in Codex upstream identity.
 func NormalizeCodexIdentityFingerprint(in CodexIdentityFingerprintConfig) CodexIdentityFingerprintConfig {
 	out := CleanCodexIdentityFingerprint(in)
+	out = defaultCodexIdentityFingerprintEnabled(out)
 
 	if out.UserAgent == "" {
 		out.UserAgent = DefaultCodexFingerprintUserAgent
@@ -216,6 +275,7 @@ func BuildClaudeFingerprintUserAgent(cliVersion, entrypoint string) string {
 // for fields that participate in Claude Code-style Anthropic OAuth identity.
 func NormalizeClaudeIdentityFingerprint(in ClaudeIdentityFingerprintConfig) ClaudeIdentityFingerprintConfig {
 	out := CleanClaudeIdentityFingerprint(in)
+	out = defaultClaudeIdentityFingerprintEnabled(out)
 
 	if out.CLIVersion == "" {
 		out.CLIVersion = DefaultClaudeFingerprintCLIVersion
@@ -273,6 +333,7 @@ func CleanClaudeIdentityFingerprint(in ClaudeIdentityFingerprintConfig) ClaudeId
 // for fields that participate in Gemini CLI upstream identity.
 func NormalizeGeminiIdentityFingerprint(in GeminiIdentityFingerprintConfig) GeminiIdentityFingerprintConfig {
 	out := CleanGeminiIdentityFingerprint(in)
+	out = defaultGeminiIdentityFingerprintEnabled(out)
 	if out.UserAgent == "" {
 		out.UserAgent = DefaultGeminiFingerprintUserAgent
 	}
@@ -299,7 +360,7 @@ func CleanGeminiIdentityFingerprint(in GeminiIdentityFingerprintConfig) GeminiId
 // NormalizeXAIIdentityFingerprint trims user input while preserving empty fields
 // as "automatic learning" markers.
 func NormalizeXAIIdentityFingerprint(in XAIIdentityFingerprintConfig) XAIIdentityFingerprintConfig {
-	return CleanXAIIdentityFingerprint(in)
+	return defaultXAIIdentityFingerprintEnabled(CleanXAIIdentityFingerprint(in))
 }
 
 // CleanXAIIdentityFingerprint trims explicit overrides while preserving empty fields.
@@ -327,4 +388,195 @@ func cleanIdentityFingerprintHeaders(in map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+func defaultCodexIdentityFingerprintEnabled(in CodexIdentityFingerprintConfig) CodexIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func defaultClaudeIdentityFingerprintEnabled(in ClaudeIdentityFingerprintConfig) ClaudeIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func defaultGeminiIdentityFingerprintEnabled(in GeminiIdentityFingerprintConfig) GeminiIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func defaultXAIIdentityFingerprintEnabled(in XAIIdentityFingerprintConfig) XAIIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func codexLegacyDefaultDisabled(fp CodexIdentityFingerprintConfig) bool {
+	if fp.Enabled || strings.TrimSpace(fp.SessionID) != "" || len(fp.CustomHeaders) > 0 {
+		return false
+	}
+	defaults := DefaultCodexIdentityFingerprint()
+	return emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.Version, defaults.Version) &&
+		emptyOrEqual(fp.Originator, defaults.Originator) &&
+		emptyOrEqual(fp.WebsocketBeta, defaults.WebsocketBeta) &&
+		emptyOrEqual(fp.BetaFeatures, defaults.BetaFeatures) &&
+		emptyOrEqual(fp.SessionMode, defaults.SessionMode)
+}
+
+func claudeLegacyDefaultDisabled(fp ClaudeIdentityFingerprintConfig) bool {
+	if fp.Enabled || strings.TrimSpace(fp.SessionID) != "" ||
+		strings.TrimSpace(fp.DeviceID) != "" || len(fp.CustomHeaders) > 0 {
+		return false
+	}
+	defaults := DefaultClaudeIdentityFingerprint()
+	return emptyOrEqual(fp.CLIVersion, defaults.CLIVersion) &&
+		emptyOrEqual(fp.Entrypoint, defaults.Entrypoint) &&
+		emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.AnthropicBeta, defaults.AnthropicBeta) &&
+		emptyOrEqual(fp.StainlessPackageVersion, defaults.StainlessPackageVersion) &&
+		emptyOrEqual(fp.StainlessRuntimeVersion, defaults.StainlessRuntimeVersion) &&
+		emptyOrEqual(fp.StainlessTimeout, defaults.StainlessTimeout) &&
+		emptyOrEqual(fp.SessionMode, defaults.SessionMode)
+}
+
+func geminiLegacyDefaultDisabled(fp GeminiIdentityFingerprintConfig) bool {
+	if fp.Enabled || len(fp.CustomHeaders) > 0 {
+		return false
+	}
+	defaults := DefaultGeminiIdentityFingerprint()
+	return emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.APIClient, defaults.APIClient) &&
+		emptyOrEqual(fp.ClientMetadata, defaults.ClientMetadata)
+}
+
+func xaiLegacyDefaultDisabled(fp XAIIdentityFingerprintConfig) bool {
+	if fp.Enabled || strings.TrimSpace(fp.GrokConversationID) != "" || len(fp.CustomHeaders) > 0 {
+		return false
+	}
+	defaults := DefaultXAIIdentityFingerprint()
+	return emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.ClientIdentifier, defaults.ClientIdentifier) &&
+		emptyOrEqual(fp.ClientVersion, defaults.ClientVersion)
+}
+
+func emptyOrEqual(value, expected string) bool {
+	value = strings.TrimSpace(value)
+	return value == "" || value == strings.TrimSpace(expected)
+}
+
+func (fp *CodexIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias CodexIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = CodexIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *ClaudeIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias ClaudeIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = ClaudeIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *GeminiIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias GeminiIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = GeminiIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *XAIIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias XAIIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = XAIIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *CodexIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias CodexIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = CodexIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}
+
+func (fp *ClaudeIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias ClaudeIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = ClaudeIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}
+
+func (fp *GeminiIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias GeminiIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = GeminiIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}
+
+func (fp *XAIIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias XAIIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = XAIIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}
+
+func jsonObjectHasKey(data []byte, key string) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return false
+	}
+	_, ok := fields[key]
+	return ok
+}
+
+func yamlMappingHasKey(node *yaml.Node, key string) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i] != nil && strings.TrimSpace(node.Content[i].Value) == key {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/identity_fingerprint_test.go
+++ b/internal/config/identity_fingerprint_test.go
@@ -1,14 +1,17 @@
 package config
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestDefaultCodexIdentityFingerprintUsesCurrentVersionAndDynamicSessions(t *testing.T) {
 	t.Parallel()
 
 	got := DefaultCodexIdentityFingerprint()
 
-	if got.Enabled {
-		t.Fatalf("Enabled = true, want false by default")
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true by default")
 	}
 	if got.Version != "" {
 		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
@@ -26,6 +29,9 @@ func TestNormalizeCodexIdentityFingerprintAppliesCurrentDefaults(t *testing.T) {
 
 	got := NormalizeCodexIdentityFingerprint(CodexIdentityFingerprintConfig{})
 
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true by default")
+	}
 	if got.Version != "" {
 		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
 	}
@@ -69,8 +75,8 @@ func TestDefaultClaudeIdentityFingerprintMirrorsClaudeCode(t *testing.T) {
 
 	got := DefaultClaudeIdentityFingerprint()
 
-	if got.Enabled {
-		t.Fatalf("Enabled = true, want false by default")
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true by default")
 	}
 	if got.CLIVersion != "2.1.161" {
 		t.Fatalf("CLIVersion = %q, want 2.1.161", got.CLIVersion)
@@ -158,8 +164,8 @@ func TestDefaultGeminiIdentityFingerprint(t *testing.T) {
 
 	got := DefaultGeminiIdentityFingerprint()
 
-	if got.Enabled {
-		t.Fatal("Enabled = true, want false by default")
+	if !got.Enabled {
+		t.Fatal("Enabled = false, want true by default")
 	}
 	if got.UserAgent != "google-api-nodejs-client/9.15.1" {
 		t.Fatalf("UserAgent = %q, want Gemini CLI default", got.UserAgent)
@@ -169,5 +175,59 @@ func TestDefaultGeminiIdentityFingerprint(t *testing.T) {
 	}
 	if got.ClientMetadata != "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI" {
 		t.Fatalf("ClientMetadata = %q, want Gemini CLI metadata", got.ClientMetadata)
+	}
+}
+
+func TestDefaultXAIIdentityFingerprint(t *testing.T) {
+	t.Parallel()
+
+	got := DefaultXAIIdentityFingerprint()
+
+	if !got.Enabled {
+		t.Fatal("Enabled = false, want true by default")
+	}
+	if got.UserAgent != "grok-shell/0.2.93 (macos; aarch64)" {
+		t.Fatalf("UserAgent = %q, want Grok shell default", got.UserAgent)
+	}
+	if got.ClientIdentifier != "grok-shell" {
+		t.Fatalf("ClientIdentifier = %q, want grok-shell", got.ClientIdentifier)
+	}
+	if got.ClientVersion != "0.2.93" {
+		t.Fatalf("ClientVersion = %q, want 0.2.93", got.ClientVersion)
+	}
+}
+
+func TestSanitizeIdentityFingerprintDefaultsProvidersEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{}
+	cfg.SanitizeIdentityFingerprint()
+
+	if !cfg.IdentityFingerprint.Codex.Enabled ||
+		!cfg.IdentityFingerprint.Claude.Enabled ||
+		!cfg.IdentityFingerprint.Gemini.Enabled ||
+		!cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want all providers enabled by default", cfg.IdentityFingerprint)
+	}
+}
+
+func TestNormalizeIdentityFingerprintConfigPreservesExplicitDisabledProvider(t *testing.T) {
+	t.Parallel()
+
+	var cfg IdentityFingerprintConfig
+	if err := json.Unmarshal([]byte(`{"xai":{"enabled":false},"gemini":{}}`), &cfg); err != nil {
+		t.Fatalf("Unmarshal identity fingerprint: %v", err)
+	}
+
+	got := NormalizeIdentityFingerprintConfig(cfg)
+
+	if got.XAI.Enabled {
+		t.Fatalf("XAI.Enabled = true, want explicit false preserved")
+	}
+	if !got.Gemini.Enabled {
+		t.Fatalf("Gemini.Enabled = false, want missing enabled to default true")
+	}
+	if !got.Codex.Enabled || !got.Claude.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want omitted providers enabled by default", got)
 	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -45,7 +45,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		if optional {
 			if os.IsNotExist(err) || errors.Is(err, syscall.EISDIR) {
 				// Missing and optional: return empty config (cloud deploy standby).
-				return &Config{}, nil
+				cfg := &Config{}
+				cfg.SanitizeIdentityFingerprint()
+				return cfg, nil
 			}
 		}
 		return nil, fmt.Errorf("failed to read config file: %w", err)
@@ -53,7 +55,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// In cloud deploy mode (optional=true), if file is empty or contains only whitespace, return empty config.
 	if optional && len(data) == 0 {
-		return &Config{}, nil
+		cfg := &Config{}
+		cfg.SanitizeIdentityFingerprint()
+		return cfg, nil
 	}
 
 	// Unmarshal the YAML data into the Config struct.
@@ -88,7 +92,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		if optional {
 			// In cloud deploy mode, if YAML parsing fails, return empty config instead of error.
-			return &Config{}, nil
+			cfg := &Config{}
+			cfg.SanitizeIdentityFingerprint()
+			return cfg, nil
 		}
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}

--- a/internal/management/settings/runtimeconfig/spec.go
+++ b/internal/management/settings/runtimeconfig/spec.go
@@ -300,23 +300,14 @@ func Specs() []Spec {
 					xaiIdentityFingerprintMeaningful(cfg.IdentityFingerprint.XAI)
 			},
 			Value: func(cfg *config.Config) any {
-				return config.IdentityFingerprintConfig{
-					Codex:  config.CleanCodexIdentityFingerprint(cfg.IdentityFingerprint.Codex),
-					Claude: config.CleanClaudeIdentityFingerprint(cfg.IdentityFingerprint.Claude),
-					Gemini: config.CleanGeminiIdentityFingerprint(cfg.IdentityFingerprint.Gemini),
-					XAI:    config.CleanXAIIdentityFingerprint(cfg.IdentityFingerprint.XAI),
-				}
+				return IdentityFingerprintRuntimeSettingValue(cfg.IdentityFingerprint)
 			},
 			Apply: func(cfg *config.Config, raw json.RawMessage) bool {
-				var value config.IdentityFingerprintConfig
-				if err := json.Unmarshal(raw, &value); err != nil {
+				value, err := identityFingerprintRuntimeSettingConfig(raw)
+				if err != nil {
 					log.Warnf("runtimeconfig: decode %s: %v", RuntimeSettingIdentityFingerprint, err)
 					return false
 				}
-				value.Codex = config.CleanCodexIdentityFingerprint(value.Codex)
-				value.Claude = config.CleanClaudeIdentityFingerprint(value.Claude)
-				value.Gemini = config.CleanGeminiIdentityFingerprint(value.Gemini)
-				value.XAI = config.CleanXAIIdentityFingerprint(value.XAI)
 				cfg.IdentityFingerprint = value
 				return true
 			},
@@ -445,6 +436,44 @@ func xaiIdentityFingerprintMeaningful(fp config.XAIIdentityFingerprintConfig) bo
 		strings.TrimSpace(clean.ClientVersion) != "" ||
 		strings.TrimSpace(clean.GrokConversationID) != "" ||
 		len(clean.CustomHeaders) > 0
+}
+
+const identityFingerprintRuntimeSettingVersion = 2
+
+type identityFingerprintRuntimePayload struct {
+	RuntimeSettingVersion int                                    `json:"runtime-setting-version,omitempty"`
+	Codex                 config.CodexIdentityFingerprintConfig  `json:"codex,omitempty"`
+	Claude                config.ClaudeIdentityFingerprintConfig `json:"claude,omitempty"`
+	Gemini                config.GeminiIdentityFingerprintConfig `json:"gemini,omitempty"`
+	XAI                   config.XAIIdentityFingerprintConfig    `json:"xai,omitempty"`
+}
+
+func IdentityFingerprintRuntimeSettingValue(value config.IdentityFingerprintConfig) any {
+	normalized := config.NormalizeIdentityFingerprintConfig(value)
+	return identityFingerprintRuntimePayload{
+		RuntimeSettingVersion: identityFingerprintRuntimeSettingVersion,
+		Codex:                 normalized.Codex,
+		Claude:                normalized.Claude,
+		Gemini:                normalized.Gemini,
+		XAI:                   normalized.XAI,
+	}
+}
+
+func identityFingerprintRuntimeSettingConfig(raw json.RawMessage) (config.IdentityFingerprintConfig, error) {
+	var payload identityFingerprintRuntimePayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return config.IdentityFingerprintConfig{}, err
+	}
+	value := config.IdentityFingerprintConfig{
+		Codex:  payload.Codex,
+		Claude: payload.Claude,
+		Gemini: payload.Gemini,
+		XAI:    payload.XAI,
+	}
+	if payload.RuntimeSettingVersion >= identityFingerprintRuntimeSettingVersion {
+		return config.NormalizeIdentityFingerprintConfig(value), nil
+	}
+	return config.NormalizeLegacyIdentityFingerprintRuntimeConfig(value), nil
 }
 
 func normalizeOAuthModelAliasSetting(entries map[string][]config.OAuthModelAlias) map[string][]config.OAuthModelAlias {

--- a/internal/management/settings/runtimeconfig/spec_test.go
+++ b/internal/management/settings/runtimeconfig/spec_test.go
@@ -1,0 +1,86 @@
+package runtimeconfig
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestIdentityFingerprintRuntimeSettingMigratesLegacyEmptyDisabledProviders(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	spec := identityFingerprintSpec(t)
+	raw := json.RawMessage(`{
+		"codex": {"enabled": true},
+		"claude": {"enabled": false},
+		"gemini": {"enabled": false}
+	}`)
+
+	if !spec.Apply(cfg, raw) {
+		t.Fatal("Apply returned false")
+	}
+
+	if !cfg.IdentityFingerprint.Codex.Enabled ||
+		!cfg.IdentityFingerprint.Claude.Enabled ||
+		!cfg.IdentityFingerprint.Gemini.Enabled ||
+		!cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want legacy empty disabled providers defaulted on", cfg.IdentityFingerprint)
+	}
+}
+
+func TestIdentityFingerprintRuntimeSettingVersionedPayloadPreservesExplicitDisabledProviders(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	spec := identityFingerprintSpec(t)
+	raw := json.RawMessage(`{
+		"runtime-setting-version": 2,
+		"codex": {"enabled": true},
+		"claude": {"enabled": false},
+		"gemini": {"enabled": false},
+		"xai": {"enabled": false}
+	}`)
+
+	if !spec.Apply(cfg, raw) {
+		t.Fatal("Apply returned false")
+	}
+
+	if !cfg.IdentityFingerprint.Codex.Enabled {
+		t.Fatalf("Codex.Enabled = false, want true")
+	}
+	if cfg.IdentityFingerprint.Claude.Enabled ||
+		cfg.IdentityFingerprint.Gemini.Enabled ||
+		cfg.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want versioned explicit false preserved", cfg.IdentityFingerprint)
+	}
+}
+
+func TestIdentityFingerprintRuntimeSettingValueWritesVersionedPayload(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(IdentityFingerprintRuntimeSettingValue(config.IdentityFingerprintConfig{}))
+	if err != nil {
+		t.Fatalf("Marshal IdentityFingerprintRuntimeSettingValue: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("Unmarshal payload: %v", err)
+	}
+	if payload["runtime-setting-version"] != float64(identityFingerprintRuntimeSettingVersion) {
+		t.Fatalf("runtime-setting-version = %#v, want %d", payload["runtime-setting-version"], identityFingerprintRuntimeSettingVersion)
+	}
+}
+
+func identityFingerprintSpec(t *testing.T) Spec {
+	t.Helper()
+	for _, spec := range Specs() {
+		if spec.Key == RuntimeSettingIdentityFingerprint {
+			return spec
+		}
+	}
+	t.Fatal("identity-fingerprint spec not found")
+	return Spec{}
+}

--- a/internal/registry/codex_model_capabilities.go
+++ b/internal/registry/codex_model_capabilities.go
@@ -1,0 +1,124 @@
+package registry
+
+import "strings"
+
+// CodexModelCapability is the shared source of truth for Codex-facing model
+// metadata. Catalog-only levels may include client modes such as ultra, while
+// RuntimeWireReasoningLevels contains only values accepted by the upstream API.
+type CodexModelCapability struct {
+	ModelID                    string
+	CanonicalTarget            string
+	DisplayName                string
+	Description                string
+	ContextWindow              int
+	MaxContextWindow           int
+	MaxCompletionTokens        int
+	DefaultReasoningLevel      string
+	CatalogReasoningLevels     []string
+	RuntimeWireReasoningLevels []string
+	CompatibilityAlias         bool
+}
+
+var gpt56CatalogReasoningLevels = []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+var gpt56RuntimeWireReasoningLevels = []string{"low", "medium", "high", "xhigh", "max"}
+
+var codexModelCapabilities = map[string]CodexModelCapability{
+	"gpt-5.6": {
+		ModelID:                    "gpt-5.6",
+		CanonicalTarget:            "gpt-5.6-sol",
+		DisplayName:                "GPT-5.6",
+		Description:                "GPT-5.6 family alias routed to GPT-5.6 Sol.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+	},
+	"gpt-5.6-sol": {
+		ModelID:                    "gpt-5.6-sol",
+		CanonicalTarget:            "gpt-5.6-sol",
+		DisplayName:                "GPT-5.6 Sol",
+		Description:                "Frontier GPT-5.6 model for complex professional work.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+	},
+	"gpt-5.6-terra": {
+		ModelID:                    "gpt-5.6-terra",
+		CanonicalTarget:            "gpt-5.6-terra",
+		DisplayName:                "GPT-5.6 Terra",
+		Description:                "Balanced GPT-5.6 model for everyday professional work.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+	},
+	"gpt-5.6-luna": {
+		ModelID:                    "gpt-5.6-luna",
+		CanonicalTarget:            "gpt-5.6-luna",
+		DisplayName:                "GPT-5.6 Luna",
+		Description:                "Fast and affordable GPT-5.6 model for high-volume work.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+	},
+	"gpt-5.6-ultra": {
+		ModelID:                    "gpt-5.6-ultra",
+		CanonicalTarget:            "gpt-5.6-sol",
+		DisplayName:                "GPT-5.6 Sol (Ultra compatibility alias)",
+		Description:                "Compatibility alias for GPT-5.6 Sol with Codex Ultra as the catalog default.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "ultra",
+		CatalogReasoningLevels:     gpt56CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
+		CompatibilityAlias:         true,
+	},
+}
+
+// GetCodexModelCapability returns an isolated copy so callers cannot mutate the
+// shared reasoning-level slices.
+func GetCodexModelCapability(modelID string) (CodexModelCapability, bool) {
+	capability, ok := codexModelCapabilities[strings.ToLower(strings.TrimSpace(modelID))]
+	if !ok {
+		return CodexModelCapability{}, false
+	}
+	capability.CatalogReasoningLevels = append([]string(nil), capability.CatalogReasoningLevels...)
+	capability.RuntimeWireReasoningLevels = append([]string(nil), capability.RuntimeWireReasoningLevels...)
+	return capability, true
+}
+
+func getGPT56ModelDefinitions() []*ModelInfo {
+	modelIDs := []string{"gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-ultra"}
+	models := make([]*ModelInfo, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		capability, _ := GetCodexModelCapability(modelID)
+		models = append(models, &ModelInfo{
+			ID:                  capability.ModelID,
+			Object:              "model",
+			OwnedBy:             "openai",
+			Type:                "openai",
+			Version:             capability.CanonicalTarget,
+			DisplayName:         capability.DisplayName,
+			UpstreamModelID:     capability.CanonicalTarget,
+			Description:         capability.Description,
+			ContextLength:       capability.ContextWindow,
+			MaxCompletionTokens: capability.MaxCompletionTokens,
+			SupportedParameters: []string{"tools"},
+			Thinking: &ThinkingSupport{
+				Levels: append([]string(nil), capability.RuntimeWireReasoningLevels...),
+			},
+		})
+	}
+	return models
+}

--- a/internal/registry/codex_model_capabilities_test.go
+++ b/internal/registry/codex_model_capabilities_test.go
@@ -1,0 +1,48 @@
+package registry
+
+import "testing"
+
+func TestGPT56CodexCapabilities(t *testing.T) {
+	for _, modelID := range []string{"gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		capability, ok := GetCodexModelCapability(modelID)
+		if !ok {
+			t.Fatalf("GetCodexModelCapability(%q) not found", modelID)
+		}
+		if capability.ContextWindow != 1050000 || capability.MaxContextWindow != 1050000 {
+			t.Fatalf("%s context = (%d, %d), want (1050000, 1050000)", modelID, capability.ContextWindow, capability.MaxContextWindow)
+		}
+		if capability.MaxCompletionTokens != 128000 {
+			t.Fatalf("%s max completion = %d, want 128000", modelID, capability.MaxCompletionTokens)
+		}
+		assertStringSlice(t, modelID+" catalog levels", capability.CatalogReasoningLevels, []string{"low", "medium", "high", "xhigh", "max", "ultra"})
+		assertStringSlice(t, modelID+" wire levels", capability.RuntimeWireReasoningLevels, []string{"low", "medium", "high", "xhigh", "max"})
+	}
+
+	alias, ok := GetCodexModelCapability("gpt-5.6-ultra")
+	if !ok || !alias.CompatibilityAlias || alias.CanonicalTarget != "gpt-5.6-sol" || alias.DefaultReasoningLevel != "ultra" {
+		t.Fatalf("ultra alias = %#v, found=%v", alias, ok)
+	}
+}
+
+func TestGPT56StaticRegistryUsesWireLevels(t *testing.T) {
+	info := LookupStaticModelInfo("gpt-5.6-sol")
+	if info == nil || info.Thinking == nil {
+		t.Fatal("gpt-5.6-sol registry metadata missing")
+	}
+	if info.ContextLength != 1050000 || info.MaxCompletionTokens != 128000 {
+		t.Fatalf("registry limits = (%d, %d), want (1050000, 128000)", info.ContextLength, info.MaxCompletionTokens)
+	}
+	assertStringSlice(t, "registry wire levels", info.Thinking.Levels, []string{"low", "medium", "high", "xhigh", "max"})
+}
+
+func assertStringSlice(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s len = %d, want %d: %#v", label, len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s[%d] = %q, want %q: %#v", label, i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -696,7 +696,7 @@ func GetAIStudioModels() []*ModelInfo {
 
 // GetOpenAIModels returns the standard OpenAI model definitions
 func GetOpenAIModels() []*ModelInfo {
-	models := []*ModelInfo{
+	return append([]*ModelInfo{
 		{
 			ID:                  "gpt-5",
 			Object:              "model",
@@ -917,8 +917,7 @@ func GetOpenAIModels() []*ModelInfo {
 			Description:         "Text-to-image generation model.",
 			SupportedParameters: []string{"prompt", "size", "n", "response_format"},
 		},
-	}
-	return append(models, getGPT56ModelDefinitions()...)
+	}, getGPT56ModelDefinitions()...)
 }
 
 func GetXAIModels() []*ModelInfo {

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -696,7 +696,7 @@ func GetAIStudioModels() []*ModelInfo {
 
 // GetOpenAIModels returns the standard OpenAI model definitions
 func GetOpenAIModels() []*ModelInfo {
-	return []*ModelInfo{
+	models := []*ModelInfo{
 		{
 			ID:                  "gpt-5",
 			Object:              "model",
@@ -918,6 +918,7 @@ func GetOpenAIModels() []*ModelInfo {
 			SupportedParameters: []string{"prompt", "size", "n", "response_format"},
 		},
 	}
+	return append(models, getGPT56ModelDefinitions()...)
 }
 
 func GetXAIModels() []*ModelInfo {

--- a/internal/runtime/executor/xai_models.go
+++ b/internal/runtime/executor/xai_models.go
@@ -1,0 +1,280 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	xaiModelsPath                  = "/models"
+	xaiGrokBuildClientModelAlias   = "grok-build"
+	xaiGrokBuildUpstreamModelAlias = "grok-build-0.1"
+)
+
+var xaiModelsCache struct {
+	mu     sync.RWMutex
+	models []*sdkmodelcatalog.ModelInfo
+}
+
+type xaiModelsResponse struct {
+	Data []xaiModelPayload `json:"data"`
+}
+
+type xaiModelPayload struct {
+	ID                  string   `json:"id"`
+	Aliases             []string `json:"aliases"`
+	Object              string   `json:"object"`
+	Created             int64    `json:"created"`
+	OwnedBy             string   `json:"owned_by"`
+	ContextLength       int      `json:"context_length"`
+	MaxCompletionTokens int      `json:"max_completion_tokens"`
+}
+
+func cloneXAIModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		if len(model.SupportedGenerationMethods) > 0 {
+			clone.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedParameters) > 0 {
+			clone.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+		}
+		if model.Thinking != nil {
+			thinkingClone := *model.Thinking
+			if len(model.Thinking.Levels) > 0 {
+				thinkingClone.Levels = append([]string(nil), model.Thinking.Levels...)
+			}
+			clone.Thinking = &thinkingClone
+		}
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func storeXAIModels(models []*sdkmodelcatalog.ModelInfo) bool {
+	cloned := cloneXAIModels(models)
+	if len(cloned) == 0 {
+		return false
+	}
+	xaiModelsCache.mu.Lock()
+	xaiModelsCache.models = cloned
+	xaiModelsCache.mu.Unlock()
+	return true
+}
+
+func loadXAIModels() []*sdkmodelcatalog.ModelInfo {
+	xaiModelsCache.mu.RLock()
+	cloned := cloneXAIModels(xaiModelsCache.models)
+	xaiModelsCache.mu.RUnlock()
+	return cloned
+}
+
+func fallbackXAIModels() []*sdkmodelcatalog.ModelInfo {
+	if models := loadXAIModels(); len(models) > 0 {
+		log.Debugf("xai executor: using cached model list (%d models)", len(models))
+		return models
+	}
+	return nil
+}
+
+// FetchXAIModels retrieves the OAuth account's live model list from xAI.
+func FetchXAIModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token, baseURL := xaiCreds(auth)
+	if strings.TrimSpace(token) == "" {
+		return fallbackXAIModels()
+	}
+	if baseURL == "" {
+		baseURL = xaiauth.DefaultAPIBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+xaiModelsPath, nil)
+	if err != nil {
+		return fallbackXAIModels()
+	}
+	applyXAIHeaders(req, cfg, auth, token, false)
+
+	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Debugf("xai executor: models request failed: %v", err)
+		}
+		return fallbackXAIModels()
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("xai executor: close models response body error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		log.Debugf("xai executor: models request failed with status %d", resp.StatusCode)
+		return fallbackXAIModels()
+	}
+
+	body, err := readUpstreamResponseBody("xai", resp.Body)
+	if err != nil {
+		log.Debugf("xai executor: models response read failed: %v", err)
+		return fallbackXAIModels()
+	}
+
+	models, ok := parseXAIModels(body, time.Now().Unix())
+	if !ok {
+		log.Debug("xai executor: fetched empty or invalid model list; retaining cached model list")
+		return fallbackXAIModels()
+	}
+	storeXAIModels(models)
+	return models
+}
+
+func parseXAIModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var decoded xaiModelsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, false
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(decoded.Data))
+	seen := make(map[string]struct{}, len(decoded.Data))
+	for _, item := range decoded.Data {
+		modelID := strings.TrimSpace(item.ID)
+		if modelID == "" {
+			continue
+		}
+		model := xaiModelInfoFromPayload(item, modelID, now)
+		addXAIModel(&out, seen, model)
+		for _, alias := range item.Aliases {
+			alias = strings.TrimSpace(alias)
+			if alias == "" || strings.EqualFold(alias, modelID) {
+				continue
+			}
+			clone := *model
+			clone.ID = alias
+			clone.Name = alias
+			clone.UpstreamModelID = modelID
+			addXAIModel(&out, seen, &clone)
+		}
+	}
+	out = withXAIGrokBuildCompatibilityAlias(out)
+	return out, len(out) > 0
+}
+
+func xaiModelInfoFromPayload(item xaiModelPayload, modelID string, now int64) *sdkmodelcatalog.ModelInfo {
+	object := strings.TrimSpace(item.Object)
+	if object == "" {
+		object = "model"
+	}
+	ownedBy := strings.TrimSpace(item.OwnedBy)
+	if ownedBy == "" {
+		ownedBy = "xai"
+	}
+	created := item.Created
+	if created == 0 {
+		created = now
+	}
+	model := &sdkmodelcatalog.ModelInfo{
+		ID:                  modelID,
+		Object:              object,
+		Created:             created,
+		OwnedBy:             ownedBy,
+		Type:                "xai",
+		DisplayName:         modelID,
+		Name:                modelID,
+		Version:             modelID,
+		ContextLength:       item.ContextLength,
+		InputTokenLimit:     item.ContextLength,
+		MaxCompletionTokens: item.MaxCompletionTokens,
+		OutputTokenLimit:    item.MaxCompletionTokens,
+	}
+	if static := sdkmodelcatalog.LookupStaticModelInfo(modelID); static != nil {
+		model.Description = static.Description
+		model.DisplayName = firstNonEmptyString(static.DisplayName, model.DisplayName)
+		model.Thinking = cloneXAIThinking(static.Thinking)
+	}
+	return model
+}
+
+func addXAIModel(models *[]*sdkmodelcatalog.ModelInfo, seen map[string]struct{}, model *sdkmodelcatalog.ModelInfo) {
+	if model == nil {
+		return
+	}
+	id := strings.TrimSpace(model.ID)
+	if id == "" {
+		return
+	}
+	key := strings.ToLower(id)
+	if _, exists := seen[key]; exists {
+		return
+	}
+	seen[key] = struct{}{}
+	*models = append(*models, model)
+}
+
+func withXAIGrokBuildCompatibilityAlias(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return models
+	}
+	var upstream *sdkmodelcatalog.ModelInfo
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		id := strings.TrimSpace(model.ID)
+		if strings.EqualFold(id, xaiGrokBuildClientModelAlias) {
+			return models
+		}
+		if strings.EqualFold(id, xaiGrokBuildUpstreamModelAlias) {
+			upstream = model
+		}
+	}
+	if upstream == nil {
+		return models
+	}
+	clone := *upstream
+	clone.ID = xaiGrokBuildClientModelAlias
+	clone.Name = xaiGrokBuildClientModelAlias
+	clone.UpstreamModelID = strings.TrimSpace(upstream.ID)
+	clone.DisplayName = "Grok Build"
+	return append(models, &clone)
+}
+
+func cloneXAIThinking(thinking *sdkmodelcatalog.ThinkingSupport) *sdkmodelcatalog.ThinkingSupport {
+	if thinking == nil {
+		return nil
+	}
+	clone := *thinking
+	if len(thinking.Levels) > 0 {
+		clone.Levels = append([]string(nil), thinking.Levels...)
+	}
+	return &clone
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/runtime/executor/xai_models_test.go
+++ b/internal/runtime/executor/xai_models_test.go
@@ -1,0 +1,104 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+func resetXAIModelsCacheForTest() {
+	xaiModelsCache.mu.Lock()
+	xaiModelsCache.models = nil
+	xaiModelsCache.mu.Unlock()
+}
+
+func TestFetchXAIModelsParsesLiveCatalogAndAliases(t *testing.T) {
+	resetXAIModelsCacheForTest()
+	t.Cleanup(resetXAIModelsCacheForTest)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != xaiModelsPath {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, xaiModelsPath)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer xai-token" {
+			t.Fatalf("authorization header = %q, want bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{
+					"id": "grok-build-0.1",
+					"aliases": ["grok-code-fast-1", "grok-code-fast"],
+					"object": "model",
+					"created": 1776297600,
+					"owned_by": "xai",
+					"context_length": 256000,
+					"max_completion_tokens": 128000
+				},
+				{
+					"id": "grok-4.5",
+					"aliases": ["grok-build-latest"],
+					"object": "model",
+					"created": 1782691200,
+					"owned_by": "xai",
+					"context_length": 500000
+				}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	models := FetchXAIModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"api_key":  "xai-token",
+			"base_url": srv.URL,
+		},
+	}, nil)
+
+	byID := make(map[string]*sdkmodelcatalog.ModelInfo, len(models))
+	for _, model := range models {
+		if model != nil {
+			byID[model.ID] = model
+		}
+	}
+	if byID["grok-build-0.1"] == nil {
+		t.Fatal("missing upstream grok-build-0.1 model")
+	}
+	if got := byID["grok-build-0.1"].ContextLength; got != 256000 {
+		t.Fatalf("grok-build-0.1 context length = %d, want 256000", got)
+	}
+	if got := byID["grok-code-fast-1"].UpstreamModelID; got != "grok-build-0.1" {
+		t.Fatalf("grok-code-fast-1 upstream = %q, want grok-build-0.1", got)
+	}
+	if got := byID["grok-build-latest"].UpstreamModelID; got != "grok-4.5" {
+		t.Fatalf("grok-build-latest upstream = %q, want grok-4.5", got)
+	}
+	if got := byID["grok-build"].UpstreamModelID; got != "grok-build-0.1" {
+		t.Fatalf("grok-build compatibility upstream = %q, want grok-build-0.1", got)
+	}
+}
+
+func TestFetchXAIModelsFallsBackToCachedCatalog(t *testing.T) {
+	resetXAIModelsCacheForTest()
+	t.Cleanup(resetXAIModelsCacheForTest)
+
+	if ok := storeXAIModels([]*sdkmodelcatalog.ModelInfo{{ID: "cached-xai-model", OwnedBy: "xai", Type: "xai"}}); !ok {
+		t.Fatal("expected cache seed to store")
+	}
+
+	models := FetchXAIModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"api_key":  "xai-token",
+			"base_url": "http://127.0.0.1:1",
+		},
+	}, nil)
+	if len(models) != 1 || models[0].ID != "cached-xai-model" {
+		t.Fatalf("fallback models = %+v, want cached-xai-model", models)
+	}
+}

--- a/internal/thinking/provider/codex/apply_test.go
+++ b/internal/thinking/provider/codex/apply_test.go
@@ -1,0 +1,34 @@
+package codex
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyThinkingSupportsMaxButRejectsUltraWireEffort(t *testing.T) {
+	maxBody := []byte(`{"model":"gpt-5.6-sol","reasoning":{"effort":"max"}}`)
+	got, err := thinking.ApplyThinking(maxBody, "gpt-5.6-sol", "codex", "codex", "codex")
+	if err != nil {
+		t.Fatalf("ApplyThinking(max) error: %v", err)
+	}
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "max" {
+		t.Fatalf("reasoning.effort = %q, want max; body=%s", effort, got)
+	}
+
+	ultraBody := []byte(`{"model":"gpt-5.6-sol","reasoning":{"effort":"ultra"}}`)
+	if _, err := thinking.ApplyThinking(ultraBody, "gpt-5.6-sol", "codex", "codex", "codex"); err == nil {
+		t.Fatal("ApplyThinking(ultra) error = nil, want unsupported wire effort error")
+	}
+}
+
+func TestApplyThinkingMaxSuffix(t *testing.T) {
+	got, err := thinking.ApplyThinking([]byte(`{"model":"gpt-5.6-sol"}`), "gpt-5.6-sol(max)", "codex", "codex", "codex")
+	if err != nil {
+		t.Fatalf("ApplyThinking(max suffix) error: %v", err)
+	}
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "max" {
+		t.Fatalf("reasoning.effort = %q, want max; body=%s", effort, got)
+	}
+}

--- a/internal/thinking/suffix.go
+++ b/internal/thinking/suffix.go
@@ -197,7 +197,8 @@ func ParseSpecialSuffix(rawSuffix string) (mode ThinkingMode, ok bool) {
 //   - "none" -> level="", ok=false (special value, use ParseSpecialSuffix)
 //   - "auto" -> level="", ok=false (special value, use ParseSpecialSuffix)
 //   - "8192" -> level="", ok=false (numeric, use ParseNumericSuffix)
-//   - "ultra" -> level="", ok=false (unknown level)
+//   - "max" -> level=LevelMax, ok=true
+//   - "ultra" -> level="", ok=false (Codex client mode, not a wire effort)
 func ParseLevelSuffix(rawSuffix string) (level ThinkingLevel, ok bool) {
 	if rawSuffix == "" {
 		return "", false
@@ -215,6 +216,8 @@ func ParseLevelSuffix(rawSuffix string) (level ThinkingLevel, ok bool) {
 		return LevelHigh, true
 	case "xhigh":
 		return LevelXHigh, true
+	case "max":
+		return LevelMax, true
 	default:
 		return "", false
 	}

--- a/internal/thinking/suffix_test.go
+++ b/internal/thinking/suffix_test.go
@@ -146,3 +146,12 @@ func TestParseSuffix_BracketSuffix(t *testing.T) {
 		})
 	}
 }
+
+func TestParseLevelSuffixMaxButNotUltra(t *testing.T) {
+	if level, ok := ParseLevelSuffix("max"); !ok || level != LevelMax {
+		t.Fatalf("ParseLevelSuffix(max) = (%q, %v), want (%q, true)", level, ok, LevelMax)
+	}
+	if level, ok := ParseLevelSuffix("ultra"); ok || level != "" {
+		t.Fatalf("ParseLevelSuffix(ultra) = (%q, %v), want (\"\", false)", level, ok)
+	}
+}

--- a/internal/thinking/types.go
+++ b/internal/thinking/types.go
@@ -54,6 +54,8 @@ const (
 	LevelHigh ThinkingLevel = "high"
 	// LevelXHigh sets extra-high thinking effort
 	LevelXHigh ThinkingLevel = "xhigh"
+	// LevelMax sets the maximum upstream-supported thinking effort
+	LevelMax ThinkingLevel = "max"
 )
 
 // ThinkingConfig represents a unified thinking configuration.

--- a/internal/usage/ccswitch_codex_model_catalog.go
+++ b/internal/usage/ccswitch_codex_model_catalog.go
@@ -1,6 +1,10 @@
 package usage
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+)
 
 const CcSwitchCodexModelCatalogFilename = "cc-switch-model-catalog.json"
 
@@ -85,10 +89,11 @@ const ccSwitchCodexBaseInstructions = "You are Codex, a coding agent."
 
 type ccSwitchCodexCatalogModelSpec struct {
 	Model         string
+	TargetModel   string
 	ContextWindow int
 }
 
-var ccSwitchCodexSupportedReasoningLevels = []CcSwitchCodexReasoningLevel{
+var ccSwitchCodexFallbackReasoningLevels = []CcSwitchCodexReasoningLevel{
 	{Effort: "low", Description: "Fast responses with lighter reasoning"},
 	{Effort: "medium", Description: "Balances speed and reasoning depth for everyday tasks"},
 	{Effort: "high", Description: "Greater reasoning depth for complex problems"},
@@ -112,7 +117,8 @@ func BuildCcSwitchCodexModelCatalog(row CcSwitchImportConfigRow) *CcSwitchCodexM
 		if model != "" {
 			models = append(models, ccSwitchCodexCatalogModelSpec{
 				Model:         model,
-				ContextWindow: normalizeCcSwitchCodexContextWindow(mapping.ContextWindow),
+				TargetModel:   strings.TrimSpace(mapping.TargetModel),
+				ContextWindow: mapping.ContextWindow,
 			})
 		}
 	}
@@ -162,16 +168,69 @@ func AttachCcSwitchCodexModelCatalogs(rows []CcSwitchImportConfigRow) []CcSwitch
 	return out
 }
 
-func normalizeCcSwitchCodexContextWindow(value int) int {
-	if value <= 0 {
-		return ccSwitchCodexDefaultContextWindow
+func resolveCcSwitchCodexCapability(spec ccSwitchCodexCatalogModelSpec) (registry.CodexModelCapability, bool) {
+	if capability, ok := registry.GetCodexModelCapability(spec.Model); ok {
+		return capability, true
 	}
-	return value
+	return registry.GetCodexModelCapability(spec.TargetModel)
+}
+
+func resolveCcSwitchCodexContextWindows(spec ccSwitchCodexCatalogModelSpec) (int, int) {
+	capability, known := resolveCcSwitchCodexCapability(spec)
+	if !known {
+		contextWindow := spec.ContextWindow
+		if contextWindow <= 0 {
+			contextWindow = ccSwitchCodexDefaultContextWindow
+		}
+		return contextWindow, contextWindow
+	}
+
+	contextWindow := spec.ContextWindow
+	if contextWindow <= 0 {
+		contextWindow = capability.ContextWindow
+	}
+	if contextWindow > capability.MaxContextWindow {
+		contextWindow = capability.MaxContextWindow
+	}
+	return contextWindow, capability.MaxContextWindow
+}
+
+func ccSwitchCodexReasoningLevels(levels []string) []CcSwitchCodexReasoningLevel {
+	result := make([]CcSwitchCodexReasoningLevel, 0, len(levels))
+	for _, effort := range levels {
+		description := effort
+		switch effort {
+		case "low":
+			description = "Fast responses with lighter reasoning"
+		case "medium":
+			description = "Balances speed and reasoning depth for everyday tasks"
+		case "high":
+			description = "Greater reasoning depth for complex problems"
+		case "xhigh":
+			description = "Extra high reasoning depth for complex problems"
+		case "max":
+			description = "Maximum reasoning depth for the hardest problems"
+		case "ultra":
+			description = "Maximum reasoning with automatic task delegation"
+		}
+		result = append(result, CcSwitchCodexReasoningLevel{Effort: effort, Description: description})
+	}
+	return result
 }
 
 func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, priority int) CcSwitchCodexModelCatalogEntry {
 	model := strings.TrimSpace(spec.Model)
-	contextWindow := normalizeCcSwitchCodexContextWindow(spec.ContextWindow)
+	contextWindow, maxContextWindow := resolveCcSwitchCodexContextWindows(spec)
+	defaultReasoningLevel := "medium"
+	supportedReasoningLevels := append([]CcSwitchCodexReasoningLevel(nil), ccSwitchCodexFallbackReasoningLevels...)
+	displayName := model
+	description := model
+	if capability, ok := resolveCcSwitchCodexCapability(spec); ok {
+		defaultReasoningLevel = capability.DefaultReasoningLevel
+		supportedReasoningLevels = ccSwitchCodexReasoningLevels(capability.CatalogReasoningLevels)
+		displayName = capability.DisplayName
+		description = capability.Description
+	}
 	messages := CcSwitchCodexModelMessages{
 		InstructionsTemplate:          ccSwitchCodexBaseInstructions,
 		InstructionsVariables:         map[string]string{},
@@ -185,7 +244,7 @@ func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, pri
 		SupportsParallelToolCalls:     true,
 		SupportsImageDetailOriginal:   true,
 		ContextWindow:                 contextWindow,
-		MaxContextWindow:              contextWindow,
+		MaxContextWindow:              maxContextWindow,
 		EffectiveContextWindowPercent: 95,
 		ExperimentalSupportedTools:    []string{},
 		InputModalities:               []string{"text", "image"},
@@ -196,10 +255,10 @@ func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, pri
 	return CcSwitchCodexModelCatalogEntry{
 		Slug:                          model,
 		Model:                         model,
-		DisplayName:                   model,
-		Description:                   model,
-		DefaultReasoningLevel:         "medium",
-		SupportedReasoningLevels:      ccSwitchCodexSupportedReasoningLevels,
+		DisplayName:                   displayName,
+		Description:                   description,
+		DefaultReasoningLevel:         defaultReasoningLevel,
+		SupportedReasoningLevels:      supportedReasoningLevels,
 		ShellType:                     "shell_command",
 		Visibility:                    "list",
 		SupportedInAPI:                true,
@@ -220,7 +279,7 @@ func buildCcSwitchCodexModelCatalogEntry(spec ccSwitchCodexCatalogModelSpec, pri
 		SupportsParallelToolCalls:     true,
 		SupportsImageDetailOriginal:   true,
 		ContextWindow:                 contextWindow,
-		MaxContextWindow:              contextWindow,
+		MaxContextWindow:              maxContextWindow,
 		EffectiveContextWindowPercent: 95,
 		ExperimentalSupportedTools:    []string{},
 		InputModalities:               []string{"text", "image"},

--- a/internal/usage/ccswitch_codex_model_catalog_test.go
+++ b/internal/usage/ccswitch_codex_model_catalog_test.go
@@ -85,3 +85,61 @@ func TestBuildCcSwitchCodexModelCatalogSkipsNonCodex(t *testing.T) {
 		t.Fatalf("catalog = %#v, want nil", catalog)
 	}
 }
+
+func TestBuildCcSwitchCodexModelCatalogUsesGPT56Capabilities(t *testing.T) {
+	row := CcSwitchImportConfigRow{
+		ClientType:   "codex",
+		DefaultModel: "gpt-5.6-sol",
+		ModelMappings: []CcSwitchModelMappingRow{
+			{RequestModel: "gpt-5.6-sol", TargetModel: "gpt-5.6-sol"},
+			{RequestModel: "gpt-5.6-terra", TargetModel: "gpt-5.6-terra", ContextWindow: 400000},
+			{RequestModel: "gpt-5.6-luna", TargetModel: "gpt-5.6-luna", ContextWindow: 2000000},
+			{RequestModel: "legacy-sol", TargetModel: "gpt-5.6-sol"},
+			{RequestModel: "gpt-5.6-ultra", TargetModel: "gpt-5.6-sol"},
+		},
+	}
+
+	catalog := BuildCcSwitchCodexModelCatalog(row)
+	if catalog == nil || len(catalog.Models) != 5 {
+		t.Fatalf("catalog = %#v, want five GPT-5.6 entries", catalog)
+	}
+	bySlug := make(map[string]CcSwitchCodexModelCatalogEntry, len(catalog.Models))
+	for _, model := range catalog.Models {
+		bySlug[model.Slug] = model
+	}
+
+	for _, slug := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "legacy-sol"} {
+		entry := bySlug[slug]
+		if entry.MaxContextWindow != 1050000 || entry.ModelMessages.MaxContextWindow != 1050000 {
+			t.Fatalf("%s max context = (%d, %d), want 1050000", slug, entry.MaxContextWindow, entry.ModelMessages.MaxContextWindow)
+		}
+		assertCcSwitchReasoningEfforts(t, slug, entry.SupportedReasoningLevels, []string{"low", "medium", "high", "xhigh", "max", "ultra"})
+	}
+	if got := bySlug["gpt-5.6-sol"].ContextWindow; got != 1050000 {
+		t.Fatalf("sol context = %d, want 1050000", got)
+	}
+	if got := bySlug["gpt-5.6-terra"].ContextWindow; got != 400000 {
+		t.Fatalf("terra default override = %d, want 400000", got)
+	}
+	if got := bySlug["gpt-5.6-luna"].ContextWindow; got != 1050000 {
+		t.Fatalf("luna clamped context = %d, want 1050000", got)
+	}
+	if got := bySlug["legacy-sol"].ContextWindow; got != 1050000 {
+		t.Fatalf("target-derived legacy alias context = %d, want 1050000", got)
+	}
+	if got := bySlug["gpt-5.6-ultra"].DefaultReasoningLevel; got != "ultra" {
+		t.Fatalf("ultra alias default reasoning = %q, want ultra", got)
+	}
+}
+
+func assertCcSwitchReasoningEfforts(t *testing.T, label string, got []CcSwitchCodexReasoningLevel, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s reasoning len = %d, want %d: %#v", label, len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Effort != want[i] {
+			t.Fatalf("%s reasoning[%d] = %q, want %q: %#v", label, i, got[i].Effort, want[i], got)
+		}
+	}
+}

--- a/internal/usage/ccswitch_import_configs_db.go
+++ b/internal/usage/ccswitch_import_configs_db.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	log "github.com/sirupsen/logrus"
 )
@@ -300,7 +301,7 @@ func normalizeCcSwitchModelMappings(values []CcSwitchModelMappingRow) []CcSwitch
 			Role:          role,
 			RequestModel:  requestModel,
 			TargetModel:   targetModel,
-			ContextWindow: normalizeCcSwitchContextWindow(value.ContextWindow),
+			ContextWindow: normalizeCcSwitchContextWindowForModels(value.ContextWindow, requestModel, targetModel),
 		})
 	}
 	if result == nil {
@@ -314,6 +315,20 @@ func normalizeCcSwitchContextWindow(value int) int {
 		return 0
 	}
 	return value
+}
+
+func normalizeCcSwitchContextWindowForModels(value int, modelIDs ...string) int {
+	contextWindow := normalizeCcSwitchContextWindow(value)
+	if contextWindow == 0 {
+		return 0
+	}
+	for _, modelID := range modelIDs {
+		capability, ok := registry.GetCodexModelCapability(modelID)
+		if ok && contextWindow > capability.MaxContextWindow {
+			return capability.MaxContextWindow
+		}
+	}
+	return contextWindow
 }
 
 func normalizeCcSwitchModelRole(value string) string {

--- a/internal/usage/ccswitch_import_configs_db_test.go
+++ b/internal/usage/ccswitch_import_configs_db_test.go
@@ -129,3 +129,16 @@ func TestFindCcSwitchImportConfigByRoutePath(t *testing.T) {
 		t.Fatalf("row.ModelMappings = %#v, want kimi-k2.6 mapping", row.ModelMappings)
 	}
 }
+
+func TestNormalizeCcSwitchModelMappingsClampsKnownCodexContext(t *testing.T) {
+	mappings := normalizeCcSwitchModelMappings([]CcSwitchModelMappingRow{
+		{RequestModel: "gpt-5.6-luna", TargetModel: "gpt-5.6-luna", ContextWindow: 2000000},
+		{RequestModel: "unknown-model", TargetModel: "unknown-upstream", ContextWindow: 2000000},
+	})
+	if got := mappings[0].ContextWindow; got != 1050000 {
+		t.Fatalf("known GPT-5.6 context = %d, want 1050000", got)
+	}
+	if got := mappings[1].ContextWindow; got != 2000000 {
+		t.Fatalf("unknown model context = %d, want 2000000", got)
+	}
+}

--- a/internal/usage/postgres_integration_test.go
+++ b/internal/usage/postgres_integration_test.go
@@ -33,6 +33,19 @@ func TestPostgresRuntimeDataStackIntegration(t *testing.T) {
 	if db == nil {
 		t.Fatal("postgres db is nil")
 	}
+	dbStats, err := GetDatabaseStats()
+	if err != nil {
+		t.Fatalf("GetDatabaseStats() error = %v", err)
+	}
+	if dbStats.Driver != "postgres" {
+		t.Fatalf("GetDatabaseStats().Driver = %q, want postgres", dbStats.Driver)
+	}
+	if dbStats.SizeBytes <= 0 {
+		t.Fatalf("GetDatabaseStats().SizeBytes = %d, want > 0", dbStats.SizeBytes)
+	}
+	if dbPath := GetDBPath(); dbPath != "" {
+		t.Fatalf("GetDBPath() = %q, want empty for postgres", dbPath)
+	}
 	if _, err := db.Exec(`
 		TRUNCATE
 			request_log_content,

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -137,6 +138,12 @@ var (
 	usageDriver string
 	usageLoc    *time.Location
 )
+
+// DatabaseStats summarizes the active runtime database for management telemetry.
+type DatabaseStats struct {
+	Driver    string
+	SizeBytes int64
+}
 
 const createTableSQL = `
 CREATE TABLE IF NOT EXISTS request_logs (
@@ -668,7 +675,7 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 	return nil
 }
 
-// CloseDB closes the SQLite database gracefully.
+// CloseDB closes the runtime database gracefully.
 func CloseDB() {
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()
@@ -687,7 +694,7 @@ func CloseDB() {
 	log.Info("usage: database closed")
 }
 
-// InsertLog writes a single request log entry into the SQLite database.
+// InsertLog writes a single request log entry into the runtime database.
 // It is safe to call concurrently.
 func InsertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
@@ -928,9 +935,64 @@ func getUsageLocation() *time.Location {
 	return usageLoc
 }
 
-// GetDBPath returns the file path of the SQLite database, or empty if not initialised.
+// GetDBPath returns the SQLite database file path, or empty for non-file databases.
 func GetDBPath() string {
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()
+	if usageDriver != "sqlite" {
+		return ""
+	}
 	return usageDBPath
+}
+
+// GetDatabaseStats returns runtime database engine and size telemetry.
+func GetDatabaseStats() (DatabaseStats, error) {
+	usageDBMu.Lock()
+	driver := usageDriver
+	path := usageDBPath
+	db := usageReadDB
+	if db == nil {
+		db = usageDB
+	}
+	usageDBMu.Unlock()
+
+	stats := DatabaseStats{Driver: driver}
+	switch driver {
+	case "postgres":
+		if db == nil {
+			return stats, nil
+		}
+		var size sql.NullInt64
+		if err := db.QueryRow("SELECT pg_database_size(current_database())").Scan(&size); err != nil {
+			return stats, fmt.Errorf("usage: query postgres database size: %w", err)
+		}
+		if size.Valid {
+			stats.SizeBytes = size.Int64
+		}
+	case "sqlite":
+		size, err := sqliteDatabaseSizeBytes(path)
+		if err != nil {
+			return stats, err
+		}
+		stats.SizeBytes = size
+	}
+	return stats, nil
+}
+
+func sqliteDatabaseSizeBytes(path string) (int64, error) {
+	if strings.TrimSpace(path) == "" {
+		return 0, nil
+	}
+	var size int64
+	for _, candidate := range []string{path, path + "-wal", path + "-shm"} {
+		info, err := os.Stat(candidate)
+		if err == nil {
+			size += info.Size()
+			continue
+		}
+		if !os.IsNotExist(err) {
+			return 0, fmt.Errorf("usage: stat sqlite database file %s: %w", candidate, err)
+		}
+	}
+	return size, nil
 }

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"math"
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -33,6 +34,30 @@ func initTestUsageDB(t *testing.T, cfg config.RequestLogStorageConfig) {
 	}
 	stopRequestLogMaintenance()
 	t.Cleanup(CloseDB)
+}
+
+func TestSQLiteDatabaseSizeBytesIncludesWALAndSHM(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	files := map[string]string{
+		dbPath:          "database",
+		dbPath + "-wal": "wal",
+		dbPath + "-shm": "shm",
+	}
+	var want int64
+	for path, content := range files {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		want += int64(len(content))
+	}
+
+	got, err := sqliteDatabaseSizeBytes(dbPath)
+	if err != nil {
+		t.Fatalf("sqliteDatabaseSizeBytes() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("sqliteDatabaseSizeBytes() = %d, want %d", got, want)
+	}
 }
 
 func TestCutoffStartUTCAtUsesProjectTimezoneForDayBoundaries(t *testing.T) {

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -2024,7 +2024,9 @@ func TestQueryStatsAndHeatmapCountSessionsFromDetails(t *testing.T) {
 		CleanupIntervalMinutes: 1440,
 	})
 
-	today := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	// Keep both samples inside the rolling query window instead of letting a
+	// hard-coded calendar date age out as the test suite advances.
+	today := CutoffStartUTC(1).Add(12 * time.Hour)
 	yesterday := today.AddDate(0, 0, -1)
 	InsertLogWithDetails("sk-heatmap", "Heatmap", "gpt-5.4", "codex", "Codex", "auth-1", false, today, 10, 5, TokenStats{
 		InputTokens: 10, OutputTokens: 20, TotalTokens: 30,

--- a/sdk/api/options.go
+++ b/sdk/api/options.go
@@ -102,6 +102,11 @@ func WithConfigMutatedCallback(fn func(*config.Config)) ServerOption {
 	return apisdkbridge.WithConfigMutatedCallback(fn)
 }
 
+// WithModelConfigMutatedCallback registers a callback invoked after management-side model catalog mutations.
+func WithModelConfigMutatedCallback(fn func()) ServerOption {
+	return apisdkbridge.WithModelConfigMutatedCallback(fn)
+}
+
 // WithKeepAliveEndpoint enables a keep-alive endpoint with the provided timeout and callback.
 func WithKeepAliveEndpoint(timeout time.Duration, onTimeout func()) ServerOption {
 	return apisdkbridge.WithKeepAliveEndpoint(timeout, onTimeout)

--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -19,6 +19,8 @@ type oauthModelAliasTable struct {
 const (
 	codexAutoReviewModel         = "codex-auto-review"
 	codexAutoReviewUpstreamModel = "gpt-5.5"
+	xaiGrokBuildModel            = "grok-build"
+	xaiGrokBuildUpstreamModel    = "grok-build-0.1"
 )
 
 func compileOAuthModelAliasTable(aliases map[string][]sdkconfig.OAuthModelAlias) *oauthModelAliasTable {
@@ -83,6 +85,9 @@ func (m *Manager) applyOAuthModelAlias(auth *Auth, requestedModel string) string
 			if builtIn := resolveBuiltInCodexModelAlias(auth, requestedModel); builtIn != "" {
 				return builtIn
 			}
+			if builtIn := resolveBuiltInXAIModelAlias(auth, requestedModel); builtIn != "" {
+				return builtIn
+			}
 		}
 		return requestedModel
 	}
@@ -105,6 +110,24 @@ func resolveBuiltInCodexModelAlias(auth *Auth, requestedModel string) string {
 		return codexAutoReviewUpstreamModel + "(" + parsed.RawSuffix + ")"
 	}
 	return codexAutoReviewUpstreamModel
+}
+
+func resolveBuiltInXAIModelAlias(auth *Auth, requestedModel string) string {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "xai") {
+		return ""
+	}
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return ""
+	}
+	parsed := parseModelSuffix(requestedModel)
+	if !strings.EqualFold(strings.TrimSpace(parsed.ModelName), xaiGrokBuildModel) {
+		return ""
+	}
+	if parsed.HasSuffix && parsed.RawSuffix != "" {
+		return xaiGrokBuildUpstreamModel + "(" + parsed.RawSuffix + ")"
+	}
+	return xaiGrokBuildUpstreamModel
 }
 
 func resolveModelAliasFromConfigModels(requestedModel string, models []modelAliasEntry) string {
@@ -244,7 +267,7 @@ func modelAliasChannel(auth *Auth) string {
 // and auth kind. Returns empty string if the provider/authKind combination doesn't support
 // OAuth model alias (e.g., API key authentication).
 //
-// Supported channels: gemini-cli, vertex, aistudio, antigravity, claude, codex, qwen, iflow, kimi.
+// Supported channels: gemini-cli, vertex, aistudio, antigravity, claude, codex, qwen, xai, iflow, kimi.
 func OAuthModelAliasChannel(provider, authKind string) string {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	authKind = strings.ToLower(strings.TrimSpace(authKind))
@@ -268,7 +291,7 @@ func OAuthModelAliasChannel(provider, authKind string) string {
 			return ""
 		}
 		return "codex"
-	case "gemini-cli", "aistudio", "antigravity", "qwen", "iflow", "kimi":
+	case "gemini-cli", "aistudio", "antigravity", "qwen", "xai", "iflow", "kimi":
 		return provider
 	default:
 		return ""

--- a/sdk/cliproxy/auth/oauth_model_alias_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_test.go
@@ -163,8 +163,18 @@ func createAuthForChannel(channel string) *Auth {
 		return &Auth{Provider: "iflow"}
 	case "kimi":
 		return &Auth{Provider: "kimi"}
+	case "xai":
+		return &Auth{Provider: "xai", Attributes: map[string]string{"auth_kind": "oauth"}}
 	default:
 		return &Auth{Provider: channel}
+	}
+}
+
+func TestOAuthModelAliasChannel_XAI(t *testing.T) {
+	t.Parallel()
+
+	if got := OAuthModelAliasChannel("xai", "oauth"); got != "xai" {
+		t.Fatalf("OAuthModelAliasChannel() = %q, want %q", got, "xai")
 	}
 }
 
@@ -215,5 +225,27 @@ func TestApplyOAuthModelAlias_BuiltInCodexAutoReview(t *testing.T) {
 	resolvedModel := mgr.applyOAuthModelAlias(auth, "codex-auto-review")
 	if resolvedModel != "gpt-5.5" {
 		t.Errorf("applyOAuthModelAlias() model = %q, want %q", resolvedModel, "gpt-5.5")
+	}
+}
+
+func TestApplyOAuthModelAlias_BuiltInXAIGrokBuild(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+
+	auth := &Auth{
+		ID:       "xai-oauth",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+	}
+
+	if got := mgr.applyOAuthModelAlias(auth, "grok-build"); got != "grok-build-0.1" {
+		t.Fatalf("applyOAuthModelAlias() = %q, want grok-build-0.1", got)
+	}
+	if got := mgr.applyOAuthModelAlias(auth, "grok-build(high)"); got != "grok-build-0.1(high)" {
+		t.Fatalf("applyOAuthModelAlias() with suffix = %q, want grok-build-0.1(high)", got)
 	}
 }

--- a/sdk/cliproxy/service_config_reload.go
+++ b/sdk/cliproxy/service_config_reload.go
@@ -90,9 +90,7 @@ func (s *Service) applyConfigReload(newCfg *config.Config, refreshRegisteredMode
 	}
 	s.rebindExecutors()
 	if refreshRegisteredModels && s.coreManager != nil {
-		for _, auth := range s.coreManager.List() {
-			s.registerModelsForAuth(context.Background(), auth)
-		}
+		s.refreshRegisteredModels(context.Background())
 	}
 }
 

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -290,6 +290,106 @@ func TestRegisterModelsForAuth_AddsUserModelConfigsForOAuthProvider(t *testing.T
 	}
 }
 
+func TestRefreshRegisteredModels_AddsCodexOwnedModelConfigsForCodexOAuth(t *testing.T) {
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	const modelID = "gpt-codex-user-defined"
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     modelID,
+		OwnedBy:     "codex",
+		Description: "User-defined Codex OAuth model",
+		Enabled:     true,
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := &coreauth.Auth{
+		ID:       "codex-oauth-user-models",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.refreshRegisteredModels(context.Background())
+	if !hasModelID(registry.GetModelsForClient(auth.ID), modelID) {
+		t.Fatal("expected Codex-owned model config to be registered for Codex OAuth auth")
+	}
+
+	if err := usage.DeleteModelConfig(modelID); err != nil {
+		t.Fatalf("DeleteModelConfig() error = %v", err)
+	}
+	service.refreshRegisteredModels(context.Background())
+	if hasModelID(registry.GetModelsForClient(auth.ID), modelID) {
+		t.Fatal("expected deleted Codex-owned model config to be removed after registry refresh")
+	}
+}
+
+func TestRegisterModelsForAuth_DoesNotAddOpenAIOwnedModelConfigsForCodexOAuth(t *testing.T) {
+	usage.CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	const modelID = "openai-owned-not-codex"
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     modelID,
+		OwnedBy:     "openai",
+		Description: "OpenAI model library entry",
+		Enabled:     true,
+		Source:      "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "codex-oauth-openai-owned-models",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+	}
+
+	registry := GlobalModelRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+	if hasModelID(registry.GetModelsForClient(auth.ID), modelID) {
+		t.Fatal("did not expect OpenAI-owned model config to be registered as Codex OAuth model")
+	}
+}
+
 func TestRegisterModelsForAuth_ClaudeOAuthStaticMaxModelIsRouteableWithoutModelConfig(t *testing.T) {
 	usage.CloseDB()
 	dbPath := filepath.Join(t.TempDir(), "usage.db")

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -187,6 +187,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 				excluded = entry.ExcludedModels
 			}
 		}
+		models = appendOAuthProviderModelConfigs(models, provider, authKind, listOAuthProviderModelConfigRows())
 		models = applyExcludedModels(models, excluded)
 	case "qwen":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("qwen")
@@ -218,4 +219,16 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	}
 
 	GlobalModelRegistry().UnregisterClient(a.ID)
+}
+
+func (s *Service) refreshRegisteredModels(ctx context.Context) {
+	if s == nil || s.coreManager == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for _, auth := range s.coreManager.List() {
+		s.registerModelsForAuth(ctx, auth)
+	}
 }

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -192,8 +192,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("qwen")
 		models = applyExcludedModels(models, excluded)
 	case "xai":
-		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("xai")
-		models = applyExcludedModels(models, excluded)
+		models = s.fetchXAIRegistryModels(ctx, a, excluded)
 	case "iflow":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("iflow")
 		models = applyExcludedModels(models, excluded)

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -323,8 +323,6 @@ func modelConfigOwnerAliases(provider string) map[string]struct{} {
 		values = append(values, "anthropic", "claude-code")
 	case "gemini", "gemini-cli", "vertex":
 		values = append(values, "google")
-	case "codex":
-		values = append(values, "openai")
 	}
 	out := make(map[string]struct{}, len(values))
 	for _, value := range values {

--- a/sdk/cliproxy/service_model_xai.go
+++ b/sdk/cliproxy/service_model_xai.go
@@ -1,0 +1,20 @@
+package cliproxy
+
+import (
+	"context"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
+)
+
+func (s *Service) fetchXAIRegistryModels(ctx context.Context, auth *coreauth.Auth, excluded []string) []*ModelInfo {
+	fetchCtx := ctx
+	if fetchCtx == nil {
+		fetchCtx = context.Background()
+	}
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(fetchCtx), 15*time.Second)
+	defer cancel()
+	models := serviceapp.FetchXAIModels(fetchCtx, auth, s.cfg)
+	return applyExcludedModels(models, excluded)
+}

--- a/sdk/cliproxy/service_server_factory.go
+++ b/sdk/cliproxy/service_server_factory.go
@@ -12,6 +12,9 @@ func (s *Service) buildServerOptions() []api.ServerOption {
 	serverOptions = append(serverOptions, api.WithConfigMutatedCallback(func(updated *config.Config) {
 		s.applyConfigReload(updated, true)
 	}))
+	serverOptions = append(serverOptions, api.WithModelConfigMutatedCallback(func() {
+		s.refreshRegisteredModels(context.Background())
+	}))
 	return serverOptions
 }
 

--- a/sdkbridge/api/bridge.go
+++ b/sdkbridge/api/bridge.go
@@ -45,6 +45,10 @@ func WithConfigMutatedCallback(fn func(*sdkconfig.Config)) ServerOption {
 	return internalapisdkbridge.WithConfigMutatedCallback(fn)
 }
 
+func WithModelConfigMutatedCallback(fn func()) ServerOption {
+	return internalapisdkbridge.WithModelConfigMutatedCallback(fn)
+}
+
 func WithKeepAliveEndpoint(timeout time.Duration, onTimeout func()) ServerOption {
 	return internalapisdkbridge.WithKeepAliveEndpoint(timeout, onTimeout)
 }

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -95,6 +95,10 @@ func FetchAntigravityModels(ctx context.Context, auth *coreauth.Auth, cfg *confi
 	return internalserviceapp.FetchAntigravityModels(ctx, auth, cfg)
 }
 
+func FetchXAIModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.FetchXAIModels(ctx, auth, cfg)
+}
+
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	internalserviceapp.RegisterExecutorForAuth(coreManager, cfg, auth, forceReplace, gateway)
 }


### PR DESCRIPTION
## Release summary

Promotes the verified `dev` snapshot `ce646af0` to `main` for CliRelay v0.4.7.

### Highlights

- Adds dynamic xAI/Grok OAuth model discovery, live aliases, cached fallback, and Grok CLI compatibility.
- Enables identity fingerprint providers by default and migrates legacy empty-disabled runtime settings.
- Reports PostgreSQL-backed database statistics correctly through the management system-stats API.
- Refreshes the Codex OAuth runtime model registry after catalog mutations.
- Adds shared GPT-5.6 Codex context/reasoning capabilities, CC Switch catalog metadata, and `max`/`ultra` compatibility handling.

### Verification

- `rtk go test ./...` — 181 packages / 2615 tests passed.
- `rtk git diff --check origin/main...HEAD` — passed.
- Source `origin/dev` check runs `build` and `ensure-no-translator-changes` passed.

### Release workflow note

- The GitHub Release/tag step remains gated on DockerHub credential verification because `v*` tags trigger `.github/workflows/docker-image.yml`.
