### PR TITLE
fix(updater): bound update events proxy load

### DIFF
--- a/internal/api/handlers/management/update_test.go
+++ b/internal/api/handlers/management/update_test.go
@@ -800,6 +800,34 @@ func TestStreamUpdateProgressProxiesUpdaterSSE(t *testing.T) {
 	}
 }
 
+func TestStreamUpdateProgressTimesOutWhenUpdaterDoesNotStartStream(t *testing.T) {
+	updater := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/events" {
+			t.Fatalf("path = %q, want /v1/events", r.URL.Path)
+		}
+		time.Sleep(4 * time.Second)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"status\":\"idle\"}\n\n")
+	}))
+	t.Cleanup(updater.Close)
+	t.Setenv("CLIRELAY_UPDATER_URL", updater.URL)
+	t.Setenv("CLIRELAY_UPDATER_TOKEN", "test-token")
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/update/events", nil)
+	started := time.Now()
+	(&Handler{cfg: &config.Config{}}).StreamUpdateProgress(ctx)
+
+	if elapsed := time.Since(started); elapsed > 3500*time.Millisecond {
+		t.Fatalf("StreamUpdateProgress elapsed = %s, want fast timeout", elapsed)
+	}
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func branchCommitAt(sha string, at time.Time) branchCommitInfo {
 	info := branchCommitInfo{SHA: sha}
 	info.Commit.Committer.Date = at

--- a/internal/management/updateflow/service.go
+++ b/internal/management/updateflow/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -218,7 +219,16 @@ func (s *Service) OpenProgressStream(ctx context.Context, lastEventID string) (*
 	if id := strings.TrimSpace(lastEventID); id != "" {
 		req.Header.Set("Last-Event-ID", id)
 	}
-	resp, err := (&http.Client{}).Do(req)
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   UpdateStreamDialTimeout,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ResponseHeaderTimeout: UpdateStreamDialTimeout,
+		},
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/management/updateflow/types.go
+++ b/internal/management/updateflow/types.go
@@ -3,14 +3,15 @@ package updateflow
 import "time"
 
 const (
-	UpdateHTTPTimeout     = 10 * time.Second
-	UpdaterHealthTimeout  = 2 * time.Second
-	UpdaterTokenEnv       = "CLIRELAY_UPDATER_TOKEN"
-	GitHubTokenEnv        = "CLIRELAY_GITHUB_TOKEN"
-	AutoUpdateChannelEnv  = "CLIRELAY_UPDATE_CHANNEL"
-	DefaultUpdaterService = "clirelay"
-	DockerPublishWorkflow = "docker-publish.yml"
-	GitHubUserAgent       = "CLIProxyAPI"
+	UpdateHTTPTimeout       = 10 * time.Second
+	UpdaterHealthTimeout    = 2 * time.Second
+	UpdateStreamDialTimeout = 3 * time.Second
+	UpdaterTokenEnv         = "CLIRELAY_UPDATER_TOKEN"
+	GitHubTokenEnv          = "CLIRELAY_GITHUB_TOKEN"
+	AutoUpdateChannelEnv    = "CLIRELAY_UPDATE_CHANNEL"
+	DefaultUpdaterService   = "clirelay"
+	DockerPublishWorkflow   = "docker-publish.yml"
+	GitHubUserAgent         = "CLIProxyAPI"
 )
 
 const (


### PR DESCRIPTION
## Summary
- add bounded dial/header timeout for proxied updater SSE event streams
- keep successful SSE streams open while failing fast when updater does not start a stream
- cover slow updater event startup with a regression test

## Root cause
The management API proxied /update/events to the updater sidecar without connection/header bounds. When the updater was unavailable or slow to start streaming, repeated frontend reconnects could keep creating expensive upstream attempts and amplify 502 traffic.

## Verification
- rtk go test ./internal/management/updateflow ./internal/api/handlers/management -run 'Test(StreamUpdateProgress|TriggerUpdate|FetchUpdateProgress|Updater|CurrentUpdate)' -count=1