### PR TITLE
fix(identity): cache fingerprint request hot path

### DIFF
--- a/internal/identityfingerprint/extract.go
+++ b/internal/identityfingerprint/extract.go
@@ -300,6 +300,37 @@ func MergeObservation(existing *LearnedRecord, obs Observation) MergeResult {
 	return MergeResult{Record: record, Changed: true, Reason: "merged_profile"}
 }
 
+func MergeObservationChangedExceptLastSeen(existing, merged *LearnedRecord) bool {
+	if existing == nil || merged == nil {
+		return existing != merged
+	}
+	if existing.Provider != merged.Provider ||
+		strings.TrimSpace(existing.AccountKey) != strings.TrimSpace(merged.AccountKey) ||
+		strings.TrimSpace(existing.ProfileKey) != strings.TrimSpace(merged.ProfileKey) ||
+		strings.TrimSpace(existing.ProfileFamily) != strings.TrimSpace(merged.ProfileFamily) ||
+		strings.TrimSpace(existing.AuthSubjectID) != strings.TrimSpace(merged.AuthSubjectID) ||
+		strings.TrimSpace(existing.ClientProduct) != strings.TrimSpace(merged.ClientProduct) ||
+		strings.TrimSpace(existing.ClientVariant) != strings.TrimSpace(merged.ClientVariant) ||
+		strings.TrimSpace(existing.Version) != strings.TrimSpace(merged.Version) ||
+		!sameStringMap(existing.Fields, merged.Fields) ||
+		!sameStringMap(existing.ObservedHeaders, merged.ObservedHeaders) {
+		return true
+	}
+	return false
+}
+
+func sameStringMap(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, leftValue := range left {
+		if right[key] != leftValue {
+			return false
+		}
+	}
+	return true
+}
+
 func codexProductVersion(ua string) (string, string) {
 	ua = strings.TrimSpace(ua)
 	if ua == "" {

--- a/internal/runtime/executor/codex_identity_fingerprint.go
+++ b/internal/runtime/executor/codex_identity_fingerprint.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -18,6 +19,29 @@ var (
 	codexServerSessionOnce sync.Once
 	codexServerSessionID   string
 )
+
+const codexIdentityFingerprintSelectionCacheTTL = 30 * time.Second
+
+type codexIdentityFingerprintSelectionEntry struct {
+	selection identityfingerprint.ProfileSelection
+	expiresAt time.Time
+}
+
+var codexIdentityFingerprintSelectionCache = struct {
+	sync.Mutex
+	entries map[string]codexIdentityFingerprintSelectionEntry
+}{
+	entries: map[string]codexIdentityFingerprintSelectionEntry{},
+}
+
+func init() {
+	usage.RegisterIdentityFingerprintInvalidationHook(func(provider identityfingerprint.Provider, accountKey string) {
+		if provider != identityfingerprint.ProviderCodex {
+			return
+		}
+		invalidateCachedCodexIdentityFingerprintSelection(accountKey)
+	})
+}
 
 func codexServerStableSessionID() string {
 	codexServerSessionOnce.Do(func() {
@@ -39,6 +63,14 @@ func codexIdentityFingerprint(cfg *config.Config, auth *cliproxyauth.Auth, ctx c
 	// client variant can immediately use its own complete identity bundle.
 	_ = observeRuntimeIdentityFingerprint(identityfingerprint.ProviderCodex, auth, ctx)
 	accountKey, _ := identityFingerprintAccount(auth)
+	if selection, ok := getCachedCodexIdentityFingerprintSelection(accountKey); ok {
+		if selection.Profile != nil {
+			resolved, _ := identityfingerprint.ResolveCodexProfile(cfg.IdentityFingerprint.Codex, selection.Profile)
+			return resolved, true
+		}
+		resolved, _ := identityfingerprint.ResolveCodexSafeFallback(cfg.IdentityFingerprint.Codex)
+		return resolved, true
+	}
 	profiles, err := usage.ListIdentityFingerprintProfiles(identityfingerprint.ProviderCodex, accountKey)
 	if err != nil {
 		log.WithError(err).Warn("identity fingerprint: list Codex profiles")
@@ -50,12 +82,61 @@ func codexIdentityFingerprint(cfg *config.Config, auth *cliproxyauth.Auth, ctx c
 		log.WithError(err).Warn("identity fingerprint: load Codex account policy")
 	}
 	selection := identityfingerprint.SelectCodexProfile(profiles, policy)
+	setCachedCodexIdentityFingerprintSelection(accountKey, selection)
 	if selection.Profile != nil {
 		resolved, _ := identityfingerprint.ResolveCodexProfile(cfg.IdentityFingerprint.Codex, selection.Profile)
 		return resolved, true
 	}
 	resolved, _ := identityfingerprint.ResolveCodexSafeFallback(cfg.IdentityFingerprint.Codex)
 	return resolved, true
+}
+
+func getCachedCodexIdentityFingerprintSelection(accountKey string) (identityfingerprint.ProfileSelection, bool) {
+	accountKey = strings.TrimSpace(accountKey)
+	if accountKey == "" {
+		return identityfingerprint.ProfileSelection{}, false
+	}
+	now := time.Now()
+	codexIdentityFingerprintSelectionCache.Lock()
+	entry, ok := codexIdentityFingerprintSelectionCache.entries[accountKey]
+	if !ok || now.After(entry.expiresAt) {
+		if ok {
+			delete(codexIdentityFingerprintSelectionCache.entries, accountKey)
+		}
+		codexIdentityFingerprintSelectionCache.Unlock()
+		return identityfingerprint.ProfileSelection{}, false
+	}
+	selection := cloneCodexIdentityFingerprintSelection(entry.selection)
+	codexIdentityFingerprintSelectionCache.Unlock()
+	return selection, true
+}
+
+func setCachedCodexIdentityFingerprintSelection(accountKey string, selection identityfingerprint.ProfileSelection) {
+	accountKey = strings.TrimSpace(accountKey)
+	if accountKey == "" {
+		return
+	}
+	codexIdentityFingerprintSelectionCache.Lock()
+	codexIdentityFingerprintSelectionCache.entries[accountKey] = codexIdentityFingerprintSelectionEntry{
+		selection: cloneCodexIdentityFingerprintSelection(selection),
+		expiresAt: time.Now().Add(codexIdentityFingerprintSelectionCacheTTL),
+	}
+	codexIdentityFingerprintSelectionCache.Unlock()
+}
+
+func invalidateCachedCodexIdentityFingerprintSelection(accountKey string) {
+	accountKey = strings.TrimSpace(accountKey)
+	if accountKey == "" {
+		return
+	}
+	codexIdentityFingerprintSelectionCache.Lock()
+	delete(codexIdentityFingerprintSelectionCache.entries, accountKey)
+	codexIdentityFingerprintSelectionCache.Unlock()
+}
+
+func cloneCodexIdentityFingerprintSelection(selection identityfingerprint.ProfileSelection) identityfingerprint.ProfileSelection {
+	selection.Profile = cloneRuntimeIdentityFingerprintRecord(selection.Profile)
+	return selection
 }
 
 func codexFingerprintSessionID(fp config.CodexIdentityFingerprintConfig) string {

--- a/internal/runtime/executor/identity_fingerprint_runtime.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime.go
@@ -2,8 +2,12 @@ package executor
 
 import (
 	"context"
+	"fmt"
+	"hash/fnv"
 	"net/http"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
@@ -11,6 +15,30 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
 )
+
+const (
+	identityFingerprintReadCacheTTL  = 30 * time.Second
+	identityFingerprintWriteCacheTTL = 5 * time.Minute
+)
+
+type identityFingerprintCacheEntry struct {
+	record    *identityfingerprint.LearnedRecord
+	signature string
+	expiresAt time.Time
+}
+
+var runtimeIdentityFingerprintCache = struct {
+	sync.Mutex
+	records map[string]identityFingerprintCacheEntry
+}{
+	records: map[string]identityFingerprintCacheEntry{},
+}
+
+func init() {
+	usage.RegisterIdentityFingerprintInvalidationHook(func(provider identityfingerprint.Provider, accountKey string) {
+		invalidateCachedRuntimeIdentityFingerprint(provider, accountKey)
+	})
+}
 
 func identityFingerprintHeadersFromContext(ctx context.Context) http.Header {
 	ginCtx := ginContextFrom(ctx)
@@ -43,10 +71,32 @@ func observeRuntimeIdentityFingerprint(provider identityfingerprint.Provider, au
 	}
 	headers := identityFingerprintHeadersFromContext(ctx)
 	if len(headers) == 0 {
+		if record := getCachedRuntimeIdentityFingerprint(provider, accountKey, "", ""); record != nil {
+			return record
+		}
 		record, err := usage.GetIdentityFingerprint(provider, accountKey)
 		if err != nil {
 			log.WithError(err).Warn("identity fingerprint: load learned record")
 		}
+		setCachedRuntimeIdentityFingerprint(provider, accountKey, "", "", record, identityFingerprintReadCacheTTL)
+		return record
+	}
+	obs, ok := identityfingerprint.ExtractObservation(identityfingerprint.LearnInput{
+		Provider:      provider,
+		AccountKey:    accountKey,
+		AuthSubjectID: authSubjectID,
+		Headers:       headers,
+		ObservedAt:    time.Now().UTC(),
+	})
+	if !ok {
+		return nil
+	}
+	profileKey := strings.TrimSpace(obs.ProfileKey)
+	if profileKey == "" {
+		profileKey = identityfingerprint.DefaultProfileKey(provider)
+	}
+	signature := runtimeIdentityFingerprintObservationSignature(obs)
+	if record := getCachedRuntimeIdentityFingerprint(provider, accountKey, profileKey, signature); record != nil {
 		return record
 	}
 	record, _, err := usage.ObserveIdentityFingerprint(identityfingerprint.LearnInput{
@@ -60,5 +110,111 @@ func observeRuntimeIdentityFingerprint(provider identityfingerprint.Provider, au
 		log.WithError(err).Warn("identity fingerprint: observe learned record")
 		return nil
 	}
+	setCachedRuntimeIdentityFingerprint(provider, accountKey, profileKey, signature, record, identityFingerprintWriteCacheTTL)
+	setCachedRuntimeIdentityFingerprint(provider, accountKey, "", "", record, identityFingerprintReadCacheTTL)
 	return record
+}
+
+func runtimeIdentityFingerprintCacheKey(provider identityfingerprint.Provider, accountKey, profileKey string) string {
+	return string(provider) + "\x00" + strings.TrimSpace(accountKey) + "\x00" + strings.TrimSpace(profileKey)
+}
+
+func getCachedRuntimeIdentityFingerprint(provider identityfingerprint.Provider, accountKey, profileKey, signature string) *identityfingerprint.LearnedRecord {
+	now := time.Now()
+	key := runtimeIdentityFingerprintCacheKey(provider, accountKey, profileKey)
+	runtimeIdentityFingerprintCache.Lock()
+	entry, ok := runtimeIdentityFingerprintCache.records[key]
+	if !ok || now.After(entry.expiresAt) || (signature != "" && entry.signature != signature) {
+		if ok {
+			delete(runtimeIdentityFingerprintCache.records, key)
+		}
+		runtimeIdentityFingerprintCache.Unlock()
+		return nil
+	}
+	record := cloneRuntimeIdentityFingerprintRecord(entry.record)
+	runtimeIdentityFingerprintCache.Unlock()
+	return record
+}
+
+func setCachedRuntimeIdentityFingerprint(provider identityfingerprint.Provider, accountKey, profileKey, signature string, record *identityfingerprint.LearnedRecord, ttl time.Duration) {
+	if record == nil || ttl <= 0 {
+		return
+	}
+	key := runtimeIdentityFingerprintCacheKey(provider, accountKey, profileKey)
+	entry := identityFingerprintCacheEntry{
+		record:    cloneRuntimeIdentityFingerprintRecord(record),
+		signature: signature,
+		expiresAt: time.Now().Add(ttl),
+	}
+	runtimeIdentityFingerprintCache.Lock()
+	runtimeIdentityFingerprintCache.records[key] = entry
+	runtimeIdentityFingerprintCache.Unlock()
+}
+
+func invalidateCachedRuntimeIdentityFingerprint(provider identityfingerprint.Provider, accountKey string) {
+	prefix := string(provider) + "\x00" + strings.TrimSpace(accountKey) + "\x00"
+	runtimeIdentityFingerprintCache.Lock()
+	for key := range runtimeIdentityFingerprintCache.records {
+		if strings.HasPrefix(key, prefix) {
+			delete(runtimeIdentityFingerprintCache.records, key)
+		}
+	}
+	runtimeIdentityFingerprintCache.Unlock()
+}
+
+func runtimeIdentityFingerprintObservationSignature(obs identityfingerprint.Observation) string {
+	h := fnv.New64a()
+	writeFingerprintHashPart(h, string(obs.Provider))
+	writeFingerprintHashPart(h, obs.ProfileKey)
+	writeFingerprintHashPart(h, obs.ClientProduct)
+	writeFingerprintHashPart(h, obs.ClientVariant)
+	writeFingerprintHashPart(h, obs.Version)
+	for _, key := range sortedRuntimeFingerprintKeys(obs.Fields) {
+		writeFingerprintHashPart(h, key)
+		writeFingerprintHashPart(h, obs.Fields[key])
+	}
+	for _, key := range sortedRuntimeFingerprintKeys(obs.ObservedHeaders) {
+		writeFingerprintHashPart(h, key)
+		writeFingerprintHashPart(h, obs.ObservedHeaders[key])
+	}
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+type fingerprintHash interface {
+	Write([]byte) (int, error)
+}
+
+func writeFingerprintHashPart(h fingerprintHash, value string) {
+	_, _ = h.Write([]byte(strings.TrimSpace(value)))
+	_, _ = h.Write([]byte{0})
+}
+
+func sortedRuntimeFingerprintKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func cloneRuntimeIdentityFingerprintRecord(record *identityfingerprint.LearnedRecord) *identityfingerprint.LearnedRecord {
+	if record == nil {
+		return nil
+	}
+	out := *record
+	out.Fields = cloneRuntimeStringMap(record.Fields)
+	out.ObservedHeaders = cloneRuntimeStringMap(record.ObservedHeaders)
+	return &out
+}
+
+func cloneRuntimeStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }

--- a/internal/runtime/executor/identity_fingerprint_runtime_test.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime_test.go
@@ -273,6 +273,57 @@ func TestCodexHeadersReplayLearnedFingerprintWithoutInboundHeaders(t *testing.T)
 	}
 }
 
+func TestCodexFingerprintRepeatedRequestUsesHotPathCache(t *testing.T) {
+	initIdentityFingerprintRuntimeDB(t)
+
+	cfg := &config.Config{
+		IdentityFingerprint: config.IdentityFingerprintConfig{
+			Codex: config.CodexIdentityFingerprintConfig{Enabled: true},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "codex-cache-auth",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"access_token": "codex-token",
+			"account_id":   "codex-cache-account-id",
+		},
+	}
+	inbound := http.Header{}
+	inbound.Set("User-Agent", "codex_cli_rs/0.144.1 (Mac OS 26.5.2; arm64) iTerm.app/3.6.9")
+	inbound.Set("Version", "0.144.1")
+	inbound.Set("Originator", "codex_cli_rs")
+	ctx := contextWithInboundHeaders(http.MethodPost, "/v1/responses", inbound)
+
+	firstReq := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+	firstReq = firstReq.WithContext(ctx)
+	applyCodexHeaders(firstReq, cfg, auth, "codex-token", false)
+
+	accountKey := authSubjectKey(t, auth)
+	firstRecord, err := usage.GetIdentityFingerprintProfile(identityfingerprint.ProviderCodex, accountKey, "codex_cli_rs")
+	if err != nil {
+		t.Fatalf("GetIdentityFingerprintProfile first returned error: %v", err)
+	}
+	if firstRecord == nil {
+		t.Fatal("first learned record is nil")
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+	secondReq = secondReq.WithContext(ctx)
+	applyCodexHeaders(secondReq, cfg, auth, "codex-token", false)
+
+	secondRecord, err := usage.GetIdentityFingerprintProfile(identityfingerprint.ProviderCodex, accountKey, "codex_cli_rs")
+	if err != nil {
+		t.Fatalf("GetIdentityFingerprintProfile second returned error: %v", err)
+	}
+	if secondRecord == nil {
+		t.Fatal("second learned record is nil")
+	}
+	if !secondRecord.LastSeenAt.Equal(firstRecord.LastSeenAt) {
+		t.Fatalf("LastSeenAt changed on repeated cached request: first=%s second=%s", firstRecord.LastSeenAt, secondRecord.LastSeenAt)
+	}
+}
+
 func TestCodexWebsocketHeadersReplayLearnedFingerprintWithoutInboundHeaders(t *testing.T) {
 	initIdentityFingerprintRuntimeDB(t)
 

--- a/internal/usage/identity_fingerprint_db.go
+++ b/internal/usage/identity_fingerprint_db.go
@@ -12,6 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const identityFingerprintLastSeenMinInterval = 5 * time.Minute
+
 const createIdentityFingerprintsTableSQL = `
 CREATE TABLE IF NOT EXISTS identity_fingerprints (
   provider          TEXT NOT NULL,
@@ -94,12 +96,24 @@ func ObserveIdentityFingerprint(input identityfingerprint.LearnInput) (*identity
 		}
 		return result.Record, result, nil
 	}
+	if existing != nil && !identityfingerprint.MergeObservationChangedExceptLastSeen(existing, result.Record) &&
+		result.Record.LastSeenAt.Sub(existing.LastSeenAt) < identityFingerprintLastSeenMinInterval {
+		if err := tx.Commit(); err != nil {
+			return existing, result, err
+		}
+		return existing, identityfingerprint.MergeResult{
+			Record:  existing,
+			Changed: false,
+			Reason:  "unchanged_recently_seen",
+		}, nil
+	}
 	if err := upsertIdentityFingerprintWith(tx, result.Record); err != nil {
 		return existing, result, err
 	}
 	if err := tx.Commit(); err != nil {
 		return existing, result, err
 	}
+	notifyIdentityFingerprintInvalidated(result.Record.Provider, result.Record.AccountKey)
 	return result.Record, result, nil
 }
 
@@ -239,7 +253,11 @@ func UpsertIdentityFingerprint(record *identityfingerprint.LearnedRecord) error 
 	if db == nil || record == nil {
 		return nil
 	}
-	return upsertIdentityFingerprintWith(db, record)
+	if err := upsertIdentityFingerprintWith(db, record); err != nil {
+		return err
+	}
+	notifyIdentityFingerprintInvalidated(record.Provider, record.AccountKey)
+	return nil
 }
 
 func upsertIdentityFingerprintWith(execer fingerprintExecer, record *identityfingerprint.LearnedRecord) error {
@@ -298,7 +316,11 @@ func DeleteIdentityFingerprint(provider identityfingerprint.Provider, accountKey
 	if err != nil {
 		return 0, err
 	}
-	return res.RowsAffected()
+	deleted, err := res.RowsAffected()
+	if err == nil && deleted > 0 {
+		notifyIdentityFingerprintInvalidated(provider, accountKey)
+	}
+	return deleted, err
 }
 
 func DeleteIdentityFingerprintProfile(provider identityfingerprint.Provider, accountKey, profileKey string) (int64, error) {
@@ -316,7 +338,11 @@ func DeleteIdentityFingerprintProfile(provider identityfingerprint.Provider, acc
 	if err != nil {
 		return 0, err
 	}
-	return res.RowsAffected()
+	deleted, err := res.RowsAffected()
+	if err == nil && deleted > 0 {
+		notifyIdentityFingerprintInvalidated(provider, accountKey)
+	}
+	return deleted, err
 }
 
 type fingerprintScanner interface {

--- a/internal/usage/identity_fingerprint_db_test.go
+++ b/internal/usage/identity_fingerprint_db_test.go
@@ -202,3 +202,59 @@ func TestObserveIdentityFingerprintLearnsGeminiCLIHeaders(t *testing.T) {
 		t.Fatalf("X-Goog-Api-Client = %q, want learned", record.Fields[identityfingerprint.FieldGeminiAPIClient])
 	}
 }
+
+func TestObserveIdentityFingerprintSkipsRecentUnchangedLastSeenWrite(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	accountKey := "codex-unchanged-account"
+	headers := http.Header{}
+	headers.Set("User-Agent", "codex_cli_rs/0.144.1 (Mac OS 26.5.2; arm64) iTerm.app/3.6.9")
+	headers.Set("Version", "0.144.1")
+	headers.Set("Originator", "codex_cli_rs")
+
+	firstSeen := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	record, result, err := ObserveIdentityFingerprint(identityfingerprint.LearnInput{
+		Provider:   identityfingerprint.ProviderCodex,
+		AccountKey: accountKey,
+		Headers:    headers,
+		ObservedAt: firstSeen,
+	})
+	if err != nil {
+		t.Fatalf("ObserveIdentityFingerprint first returned error: %v", err)
+	}
+	if result.Reason != "created" || record == nil {
+		t.Fatalf("first result = %+v, record=%#v, want created", result, record)
+	}
+
+	record, result, err = ObserveIdentityFingerprint(identityfingerprint.LearnInput{
+		Provider:   identityfingerprint.ProviderCodex,
+		AccountKey: accountKey,
+		Headers:    headers,
+		ObservedAt: firstSeen.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("ObserveIdentityFingerprint repeated returned error: %v", err)
+	}
+	if result.Changed || result.Reason != "unchanged_recently_seen" {
+		t.Fatalf("repeated result = %+v, want unchanged_recently_seen without write", result)
+	}
+	if !record.LastSeenAt.Equal(firstSeen) {
+		t.Fatalf("LastSeenAt = %s, want original %s", record.LastSeenAt, firstSeen)
+	}
+
+	record, result, err = ObserveIdentityFingerprint(identityfingerprint.LearnInput{
+		Provider:   identityfingerprint.ProviderCodex,
+		AccountKey: accountKey,
+		Headers:    headers,
+		ObservedAt: firstSeen.Add(identityFingerprintLastSeenMinInterval + time.Second),
+	})
+	if err != nil {
+		t.Fatalf("ObserveIdentityFingerprint later returned error: %v", err)
+	}
+	if !result.Changed || result.Reason != "merged_profile" {
+		t.Fatalf("later result = %+v, want throttled window elapsed update", result)
+	}
+	if !record.LastSeenAt.After(firstSeen) {
+		t.Fatalf("LastSeenAt = %s, want refreshed after %s", record.LastSeenAt, firstSeen)
+	}
+}

--- a/internal/usage/identity_fingerprint_events.go
+++ b/internal/usage/identity_fingerprint_events.go
@@ -1,0 +1,43 @@
+package usage
+
+import (
+	"sync"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+)
+
+var identityFingerprintInvalidationHooks = struct {
+	sync.RWMutex
+	nextID int
+	hooks  map[int]func(identityfingerprint.Provider, string)
+}{
+	hooks: map[int]func(identityfingerprint.Provider, string){},
+}
+
+func RegisterIdentityFingerprintInvalidationHook(hook func(identityfingerprint.Provider, string)) func() {
+	if hook == nil {
+		return func() {}
+	}
+	identityFingerprintInvalidationHooks.Lock()
+	identityFingerprintInvalidationHooks.nextID++
+	id := identityFingerprintInvalidationHooks.nextID
+	identityFingerprintInvalidationHooks.hooks[id] = hook
+	identityFingerprintInvalidationHooks.Unlock()
+	return func() {
+		identityFingerprintInvalidationHooks.Lock()
+		delete(identityFingerprintInvalidationHooks.hooks, id)
+		identityFingerprintInvalidationHooks.Unlock()
+	}
+}
+
+func notifyIdentityFingerprintInvalidated(provider identityfingerprint.Provider, accountKey string) {
+	identityFingerprintInvalidationHooks.RLock()
+	hooks := make([]func(identityfingerprint.Provider, string), 0, len(identityFingerprintInvalidationHooks.hooks))
+	for _, hook := range identityFingerprintInvalidationHooks.hooks {
+		hooks = append(hooks, hook)
+	}
+	identityFingerprintInvalidationHooks.RUnlock()
+	for _, hook := range hooks {
+		hook(provider, accountKey)
+	}
+}

--- a/internal/usage/identity_fingerprint_policy_db.go
+++ b/internal/usage/identity_fingerprint_policy_db.go
@@ -94,6 +94,7 @@ func SaveIdentityFingerprintAccountPolicy(policy identityfingerprint.AccountPoli
 	if err := tx.Commit(); err != nil {
 		return identityfingerprint.AccountPolicy{}, err
 	}
+	notifyIdentityFingerprintInvalidated(policy.Provider, policy.AccountKey)
 	return policy, nil
 }
 
@@ -144,6 +145,9 @@ func DeleteIdentityFingerprintProfileAndRepairPolicy(provider identityfingerprin
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, identityfingerprint.AccountPolicy{}, err
+	}
+	if deleted > 0 {
+		notifyIdentityFingerprintInvalidated(provider, accountKey)
 	}
 	return deleted, policy, nil
 }


### PR DESCRIPTION
## Summary
- cache identity fingerprint learning/replay on the request hot path
- throttle unchanged last_seen writes so repeated traffic does not continuously update Postgres
- cache Codex profile selection with invalidation on profile/policy changes

## Verification
- rtk go test ./internal/config ./internal/identityfingerprint ./internal/usage ./internal/runtime/executor ./internal/management/settings/runtimeconfig -count=1
- rtk go test ./... -count=1