### PR TITLE
fix(usage): skip startup session backfill scan

### DIFF
--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -413,13 +413,21 @@ func ensureRequestLogDetailIndexes(db *sql.DB) {
 	}
 }
 
+const (
+	requestLogSessionBackfillMaxRows        = 50
+	requestLogSessionBackfillMaxContentSize = 1 << 20
+)
+
 func backfillRequestLogContentSessionIDs(db *sql.DB) {
 	rows, err := db.Query(`
 		SELECT log_id, compression, detail_content
 		  FROM request_log_content
 		 WHERE session_id = ''
 		   AND length(detail_content) > 0
-	`)
+		   AND length(detail_content) <= ?
+		 ORDER BY timestamp DESC
+		 LIMIT ?
+	`, requestLogSessionBackfillMaxContentSize, requestLogSessionBackfillMaxRows)
 	if err != nil {
 		log.Warnf("usage: query request log session_id backfill rows: %v", err)
 		return
@@ -497,11 +505,9 @@ func startRequestLogContentSessionIDBackfill(db *sql.DB) {
 	if db == nil {
 		return
 	}
-	requestLogMaintenanceWG.Add(1)
-	go func() {
-		defer requestLogMaintenanceWG.Done()
-		backfillRequestLogContentSessionIDs(db)
-	}()
+	// Historical detail_content can be very large; production databases have
+	// reached gigabytes here. New writes already populate session_id inline, so
+	// startup must not read/decompress old rows on the request-serving process.
 }
 
 // InitDB opens (or creates) the SQLite database at the given path and creates
@@ -669,7 +675,7 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 	log.Debugf("usage: initializing identity_fingerprints table")
 	initIdentityFingerprintsTable(db)
 	startRequestLogMaintenance(db)
-	log.Debugf("usage: scheduling request log content session_id backfill")
+	log.Debugf("usage: request log content session_id backfill disabled during startup")
 	startRequestLogContentSessionIDBackfill(db)
 	log.Infof("usage: %s database initialised at %s", driver, dbPath)
 	return nil

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -2111,6 +2111,41 @@ func TestQueryStatsAndHeatmapCountSessionsFromDetails(t *testing.T) {
 	}
 }
 
+func TestStartRequestLogContentSessionIDBackfillDoesNotScanHistoricalContent(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	compressed, err := compressLogContent(`{"session_id":"historical-session"}`)
+	if err != nil {
+		t.Fatalf("compressLogContent() error = %v", err)
+	}
+	if _, err := getDB().Exec(
+		`INSERT INTO request_log_content (log_id, timestamp, compression, input_content, output_content, detail_content, session_id)
+		 VALUES (?, ?, ?, ?, ?, ?, '')`,
+		int64(9001),
+		time.Now().UTC().Format(time.RFC3339Nano),
+		requestLogContentCompression,
+		[]byte{},
+		[]byte{},
+		compressed,
+	); err != nil {
+		t.Fatalf("insert historical request_log_content: %v", err)
+	}
+
+	startRequestLogContentSessionIDBackfill(getDB())
+
+	var sessionID string
+	if err := getDB().QueryRow("SELECT session_id FROM request_log_content WHERE log_id = ?", int64(9001)).Scan(&sessionID); err != nil {
+		t.Fatalf("query session_id: %v", err)
+	}
+	if sessionID != "" {
+		t.Fatalf("session_id = %q, want unchanged empty historical value", sessionID)
+	}
+}
+
 func TestClearRequestLogsAllowsNewContentAfterSizeCapCleanup(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,


### PR DESCRIPTION
## Summary
- disable startup request_log_content session_id backfill on the serving process
- cap the direct backfill query so any future/manual use cannot scan unbounded large detail content
- keep new request log writes populating session_id inline

## Root cause
Production request_log_content has grown to ~1.4GB. Startup backfill read and decompressed historical detail_content rows, causing Postgres I/O wait and memory pressure.

## Verification
- rtk go test ./internal/usage -run 'Session|Backfill|Heatmap|RequestLogContent|QueryStats' -count=1
- rtk go test ./internal/usage -count=1
- rtk go test ./... -count=1