### PR TITLE
perf(deploy): prioritize relay rollout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,11 +3,23 @@ name: Deploy CliRelay
 on:
   push:
     branches: [dev]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: deploy-relay-backend
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       SHOULD_DEPLOY: ${{ github.event_name == 'workflow_dispatch' || vars.CLIRELAY_DEV_AUTO_DEPLOY == 'true' }}
     steps:
@@ -19,6 +31,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26.1'
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Build linux/amd64 binary
         env:
@@ -48,7 +62,7 @@ jobs:
           echo "Built dev binary, but server deploy is disabled."
           echo "Run this workflow manually or set repository variable CLIRELAY_DEV_AUTO_DEPLOY=true after the target server data stack is ready."
 
-      - name: Upload binary and deploy script
+      - name: Upload binary and deploy scripts
         if: env.SHOULD_DEPLOY == 'true'
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -56,7 +70,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh"
+          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/cleanup-drained-slot.sh"
           target: "/opt/clirelay2/"
           overwrite: true
 
@@ -75,3 +89,14 @@ jobs:
             SERVICE_TASKS_MAX="${{ vars.CLIRELAY_SERVICE_TASKS_MAX || '512' }}" \
             COMMIT_SHA="${{ github.sha }}" \
             bash /opt/clirelay2/scripts/deploy-blue-green.sh
+
+      - name: Trigger dev Docker image build
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run docker-publish.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref dev
+          echo "Triggered Docker image build after relay deployment completed."

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,12 +2,16 @@ name: Build & Push Docker Image
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     tags:
       - 'v*'
   schedule:
     - cron: '17 3 * * *'
   workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 env:
   REGISTRY: ghcr.io

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -17,8 +17,8 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 	content := string(data)
 
 	for _, want := range []string{
-		`Upload binary and deploy script`,
-		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh"`,
+		`Upload binary and deploy scripts`,
+		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/cleanup-drained-slot.sh"`,
 		`scripts/deploy-blue-green.sh`,
 		`target: "/opt/clirelay2/"`,
 	} {
@@ -76,9 +76,14 @@ func TestDeployWorkflowUsesBlueGreenDeployment(t *testing.T) {
 }
 
 func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
-	cmd := exec.Command("bash", "-n", "scripts/deploy-blue-green.sh")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("deploy script syntax failed: %v\n%s", err, out)
+	for _, path := range []string{
+		"scripts/deploy-blue-green.sh",
+		"scripts/cleanup-drained-slot.sh",
+	} {
+		cmd := exec.Command("bash", "-n", path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s syntax failed: %v\n%s", path, err, out)
+		}
 	}
 
 	data, err := os.ReadFile("scripts/deploy-blue-green.sh")
@@ -97,6 +102,8 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`docker exec "$NGINX_CONTAINER" nginx -t`,
 		`nginx -t`,
 		`DRAIN_SECONDS`,
+		`systemd-run`,
+		`scripts/cleanup-drained-slot.sh`,
 		`grep -v '\.bak\.'`,
 	} {
 		if !strings.Contains(content, want) {
@@ -112,6 +119,86 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 	} {
 		if strings.Contains(content, forbidden) {
 			t.Fatalf("deploy script must not run legacy SQLite migration during blue-green deploy, found %q", forbidden)
+		}
+	}
+}
+
+func TestCleanupDrainedSlotStopsOnlyTheExpectedInactiveSlot(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := tmp + "/bin"
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create fake bin dir: %v", err)
+	}
+	logPath := tmp + "/systemctl.log"
+	fakeSystemctl := "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$SYSTEMCTL_LOG\"\n"
+	if err := os.WriteFile(binDir+"/systemctl", []byte(fakeSystemctl), 0o755); err != nil {
+		t.Fatalf("write fake systemctl: %v", err)
+	}
+	activePortFile := tmp + "/.active-port"
+	if err := os.WriteFile(activePortFile, []byte("8319\n"), 0o644); err != nil {
+		t.Fatalf("write active port: %v", err)
+	}
+
+	runCleanup := func() string {
+		t.Helper()
+		cmd := exec.Command("bash", "scripts/cleanup-drained-slot.sh", "8318", "8319")
+		cmd.Env = append(os.Environ(),
+			"PATH="+binDir+":"+os.Getenv("PATH"),
+			"SYSTEMCTL_LOG="+logPath,
+			"BASE_DIR="+tmp,
+			"ACTIVE_PORT_FILE="+activePortFile,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("cleanup drained slot: %v\n%s", err, out)
+		}
+		return string(out)
+	}
+
+	runCleanup()
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read systemctl log: %v", err)
+	}
+	logText := string(logData)
+	for _, want := range []string{"disable --now clirelay2", "disable --now clirelay2-8318"} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("cleanup log missing %q: %s", want, logText)
+		}
+	}
+
+	if err := os.WriteFile(activePortFile, []byte("8318\n"), 0o644); err != nil {
+		t.Fatalf("move active port back: %v", err)
+	}
+	if err := os.Remove(logPath); err != nil {
+		t.Fatalf("clear systemctl log: %v", err)
+	}
+	if out := runCleanup(); !strings.Contains(out, "Skip draining 8318") {
+		t.Fatalf("expected stale cleanup to be skipped, got: %s", out)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("stale cleanup must not call systemctl, stat err = %v", err)
+	}
+}
+
+func TestDeployCompletesBeforeDispatchingDevDockerBuild(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/deploy.yml")
+	if err != nil {
+		t.Fatalf("read deploy workflow: %v", err)
+	}
+	content := string(data)
+	deployIndex := strings.Index(content, `name: Blue-green deploy`)
+	dockerIndex := strings.Index(content, `name: Trigger dev Docker image build`)
+	if deployIndex < 0 || dockerIndex < 0 || dockerIndex <= deployIndex {
+		t.Fatalf("dev Docker build must be dispatched only after blue-green deployment")
+	}
+	for _, want := range []string{
+		`actions: write`,
+		`cancel-in-progress: false`,
+		`gh workflow run docker-publish.yml`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("deploy workflow missing deployment-priority marker %q", want)
 		}
 	}
 }
@@ -167,6 +254,8 @@ func TestDockerPublishWorkflowUsesGHCRForBranchesAndReleaseTags(t *testing.T) {
 		`VERSION="${REF_NAME}"`,
 		"type=ref,event=tag",
 		"github.ref_name == 'main' || github.ref_type == 'tag'",
+		"branches: [main]",
+		"group: docker-publish-${{ github.ref }}",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("Docker publish workflow missing GHCR release marker %q", want)
@@ -174,6 +263,7 @@ func TestDockerPublishWorkflowUsesGHCRForBranchesAndReleaseTags(t *testing.T) {
 	}
 
 	for _, forbidden := range []string{
+		"branches: [main, dev]",
 		"DOCKERHUB_USERNAME",
 		"DOCKERHUB_TOKEN",
 		"eceasy/cli-proxy-api",

--- a/scripts/cleanup-drained-slot.sh
+++ b/scripts/cleanup-drained-slot.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
+BASE_DIR="${BASE_DIR:-/opt/clirelay2}"
+PORT_A="${PORT_A:-8318}"
+PORT_B="${PORT_B:-8319}"
+ACTIVE_PORT_FILE="${ACTIVE_PORT_FILE:-${BASE_DIR}/.active-port}"
+
+old_port="${1:?old port is required}"
+expected_active_port="${2:?expected active port is required}"
+
+case "${old_port}:${expected_active_port}" in
+	"${PORT_A}:${PORT_B}"|"${PORT_B}:${PORT_A}") ;;
+	*)
+		echo "refusing invalid drain transition ${old_port} -> ${expected_active_port}" >&2
+		exit 1
+		;;
+esac
+
+current_active_port="$(cat "$ACTIVE_PORT_FILE" 2>/dev/null || true)"
+if [ "$current_active_port" != "$expected_active_port" ]; then
+	echo "Skip draining ${old_port}: active port moved from ${expected_active_port} to ${current_active_port:-unknown}."
+	exit 0
+fi
+
+for old_unit in "$SERVICE_NAME" "${SERVICE_NAME}-${old_port}"; do
+	if [ "$old_unit" != "${SERVICE_NAME}-${expected_active_port}" ]; then
+		systemctl disable --now "$old_unit" 2>/dev/null || systemctl stop "$old_unit" 2>/dev/null || true
+	fi
+done
+
+active_bin="${BASE_DIR}/${SERVICE_NAME}-${expected_active_port}"
+find "$BASE_DIR" -maxdepth 1 -type f -name "${SERVICE_NAME}-*" ! -name "$(basename "$active_bin")" -mtime +7 -delete 2>/dev/null || true
+echo "Drain complete: stopped ${SERVICE_NAME}-${old_port}; active port is ${expected_active_port}."

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -17,6 +17,7 @@ SERVICE_MEMORY_MAX="${SERVICE_MEMORY_MAX:-1600M}"
 SERVICE_TASKS_MAX="${SERVICE_TASKS_MAX:-512}"
 COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
 ACTIVE_PORT_FILE="${BASE_DIR}/.active-port"
+CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-${BASE_DIR}/scripts/cleanup-drained-slot.sh}"
 
 fail() {
 	echo "$*" >&2
@@ -41,6 +42,7 @@ config_path="$(printf '%s\n' "$service_exec" | sed -nE 's/.* -config[= ]([^ ;]+)
 config_path="${config_path:-${service_dir}/config.yaml}"
 
 [ -f "$TEMP_BIN" ] || fail "uploaded temp binary not found: $TEMP_BIN"
+[ -f "$CLEANUP_SCRIPT" ] || fail "drain cleanup script not found: $CLEANUP_SCRIPT"
 [ -f "$config_path" ] || fail "config file not found: $config_path"
 
 read_config_scalar() {
@@ -259,14 +261,28 @@ fi
 
 echo "$next_port" > "$ACTIVE_PORT_FILE"
 cutover_done=1
-echo "CliRelay is serving on ${next_unit} (${next_port}); draining ${active_port} for ${DRAIN_SECONDS}s"
-sleep "$DRAIN_SECONDS"
 
-for old_unit in "$SERVICE_NAME" "${SERVICE_NAME}-${active_port}"; do
-	if [ "$old_unit" != "$next_unit" ]; then
-		systemctl disable --now "$old_unit" 2>/dev/null || systemctl stop "$old_unit" 2>/dev/null || true
-	fi
-done
-
-find "$BASE_DIR" -maxdepth 1 -type f -name "${SERVICE_NAME}-*" ! -name "$(basename "$next_bin")" -mtime +7 -delete 2>/dev/null || true
-echo "Deploy complete: ${next_unit}"
+cleanup_unit="${SERVICE_NAME}-drain-${active_port}-$(date +%s)"
+if systemd-run \
+	--unit="$cleanup_unit" \
+	--collect \
+	--on-active="${DRAIN_SECONDS}s" \
+	env \
+		SERVICE_NAME="$SERVICE_NAME" \
+		BASE_DIR="$BASE_DIR" \
+		PORT_A="$PORT_A" \
+		PORT_B="$PORT_B" \
+		ACTIVE_PORT_FILE="$ACTIVE_PORT_FILE" \
+		bash "$CLEANUP_SCRIPT" "$active_port" "$next_port"; then
+	echo "Deploy complete: ${next_unit} (${next_port}) is serving ${COMMIT_SHA}; ${active_port} will drain for ${DRAIN_SECONDS}s in ${cleanup_unit}."
+else
+	echo "Failed to schedule ${cleanup_unit}; draining ${active_port} synchronously." >&2
+	sleep "$DRAIN_SECONDS"
+	SERVICE_NAME="$SERVICE_NAME" \
+		BASE_DIR="$BASE_DIR" \
+		PORT_A="$PORT_A" \
+		PORT_B="$PORT_B" \
+		ACTIVE_PORT_FILE="$ACTIVE_PORT_FILE" \
+		bash "$CLEANUP_SCRIPT" "$active_port" "$next_port"
+	echo "Deploy complete after synchronous drain: ${next_unit} (${next_port}) is serving ${COMMIT_SHA}."
+fi


### PR DESCRIPTION
## 修改内容

- 让 `relay.07230805.xyz` 蓝绿部署完成后再异步触发 dev Docker 镜像构建，避免多架构构建与关键部署争抢 Runner
- 将固定 35 秒旧实例 drain 改为 `systemd-run` 延迟清理，nginx 切流后即可完成部署 Workflow
- 增加过期 drain 防误杀校验、同步安全回退、部署与 Docker concurrency、文档路径过滤及 Go 缓存配置
- 增加部署工作流与延迟清理脚本的漂移/行为测试

## 根因

实际 Go 构建和切流耗时很短，但 Docker dev 构建与部署同时触发，且蓝绿脚本在切流后同步等待 35 秒，导致用户看到的部署完成时间被非关键任务和 drain 放大。

## 影响

- 新后端版本会优先切流到 `relay.07230805.xyz`
- Docker 镜像仍会构建，但在 relay 部署成功后独立运行
- 旧连接继续保留 35 秒排空语义，不中断流式请求

## 验证

- `go test ./...`：2664 tests passed / 182 packages
- `go test .`：21 tests passed
- `bash -n scripts/deploy-blue-green.sh scripts/cleanup-drained-slot.sh`
- `actionlint`：修改的 workflows 通过
- `git diff --check`
