### PR TITLE
fix: reclaim request body storage

### DIFF
--- a/internal/api/handlers/management/request_log_storage.go
+++ b/internal/api/handlers/management/request_log_storage.go
@@ -63,7 +63,7 @@ func (h *Handler) PutRequestLogBodyStorage(c *gin.Context) {
 
 	response := gin.H{"enabled": enabled}
 	if !enabled {
-		result, err := usage.ClearRequestLogs(usage.ClearRequestLogsOptions{ClearBodyContent: true})
+		result, err := usage.PurgeStoredRequestBodies()
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error":   "cleanup_failed",

--- a/internal/usage/log_content_store.go
+++ b/internal/usage/log_content_store.go
@@ -142,7 +142,7 @@ func triggerRequestLogCompaction() {
 	}
 }
 
-func startRequestLogMaintenance(db *sql.DB) {
+func startRequestLogMaintenance(db *sql.DB, driver string) {
 	stopRequestLogMaintenance()
 	if db == nil {
 		return
@@ -159,7 +159,7 @@ func startRequestLogMaintenance(db *sql.DB) {
 	// - 清理方式: cancel 后等待 requestLogMaintenanceWG，确保协程退出
 	go func() {
 		defer requestLogMaintenanceWG.Done()
-		runRequestLogMaintenancePass(db)
+		runRequestLogMaintenancePass(db, driver)
 
 		ticker := time.NewTicker(time.Duration(requestLogStorage.CleanupIntervalMinutes) * time.Minute)
 		defer ticker.Stop()
@@ -174,7 +174,7 @@ func startRequestLogMaintenance(db *sql.DB) {
 				// and reclaiming free pages when appropriate.
 				compactLogContentStorageInternal(db, false)
 			case <-ticker.C:
-				runRequestLogMaintenancePass(db)
+				runRequestLogMaintenancePass(db, driver)
 			}
 		}
 	}()
@@ -189,9 +189,15 @@ func stopRequestLogMaintenance() {
 	requestLogMaintenanceWakeup.Store((chan struct{})(nil))
 }
 
-func runRequestLogMaintenancePass(db *sql.DB) {
+func runRequestLogMaintenancePass(db *sql.DB, driver string) {
 	if db == nil {
 		return
+	}
+	if !RequestLogBodyStorageEnabled() {
+		if _, err := purgeStoredRequestBodies(db, driver); err != nil {
+			log.Errorf("usage: purge disabled request log body storage: %v", err)
+			return
+		}
 	}
 
 	// Refresh the running total periodically so size-cap enforcement stays fast

--- a/internal/usage/request_log_body_purge.go
+++ b/internal/usage/request_log_body_purge.go
@@ -1,0 +1,170 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const requestDetailSanitizeBatchSize = 25
+
+var requestLogBodyPurgeMu sync.Mutex
+
+type RequestLogBodyPurgeResult struct {
+	ClearRequestLogsResult
+	SanitizedDetailRows int64 `json:"sanitized_detail_rows"`
+	RemovedDetailBytes  int64 `json:"removed_detail_bytes"`
+	ReclaimedStorage    bool  `json:"reclaimed_storage"`
+}
+
+type storedRequestDetailRow struct {
+	LogID       int64
+	Compression string
+	Content     []byte
+}
+
+// PurgeStoredRequestBodies removes direct request/response bodies, strips bodies
+// embedded in historical request details, and rewrites the physical content
+// table when rows changed so PostgreSQL returns the freed space to the OS.
+func PurgeStoredRequestBodies() (RequestLogBodyPurgeResult, error) {
+	usageDBMu.Lock()
+	db := usageDB
+	driver := usageDriver
+	usageDBMu.Unlock()
+	if db == nil {
+		return RequestLogBodyPurgeResult{}, fmt.Errorf("usage: database not initialised")
+	}
+	return purgeStoredRequestBodies(db, driver)
+}
+
+func purgeStoredRequestBodies(db *sql.DB, driver string) (RequestLogBodyPurgeResult, error) {
+	requestLogBodyPurgeMu.Lock()
+	defer requestLogBodyPurgeMu.Unlock()
+
+	if db == nil {
+		return RequestLogBodyPurgeResult{}, fmt.Errorf("usage: database not initialised")
+	}
+
+	cleared, err := clearRequestLogs(db, ClearRequestLogsOptions{ClearBodyContent: true})
+	if err != nil {
+		return RequestLogBodyPurgeResult{}, err
+	}
+	result := RequestLogBodyPurgeResult{ClearRequestLogsResult: cleared}
+
+	result.SanitizedDetailRows, result.RemovedDetailBytes, err = sanitizeHistoricalRequestDetails(db)
+	if err != nil {
+		return result, err
+	}
+	refreshRequestLogContentBytes(db)
+
+	changed := result.ClearedBodyRows > 0 || result.ClearedLegacyRows > 0 || result.SanitizedDetailRows > 0
+	if changed {
+		if err = reclaimRequestLogContentStorage(db, driver); err != nil {
+			return result, err
+		}
+		result.ReclaimedStorage = true
+	}
+
+	log.Infof(
+		"usage: purged request log bodies (body_rows=%d legacy_rows=%d sanitized_detail_rows=%d removed_detail_bytes=%d reclaimed=%t)",
+		result.ClearedBodyRows,
+		result.ClearedLegacyRows,
+		result.SanitizedDetailRows,
+		result.RemovedDetailBytes,
+		result.ReclaimedStorage,
+	)
+	return result, nil
+}
+
+func sanitizeHistoricalRequestDetails(db *sql.DB) (int64, int64, error) {
+	var sanitizedRows int64
+	var removedBytes int64
+	var lastLogID int64
+
+	for {
+		rows, err := db.Query(
+			`SELECT log_id, compression, detail_content
+			 FROM request_log_content
+			 WHERE log_id > ? AND length(detail_content) > 0
+			 ORDER BY log_id ASC
+			 LIMIT ?`,
+			lastLogID,
+			requestDetailSanitizeBatchSize,
+		)
+		if err != nil {
+			return sanitizedRows, removedBytes, fmt.Errorf("usage: query historical request details: %w", err)
+		}
+
+		batch := make([]storedRequestDetailRow, 0, requestDetailSanitizeBatchSize)
+		for rows.Next() {
+			var row storedRequestDetailRow
+			if err = rows.Scan(&row.LogID, &row.Compression, &row.Content); err != nil {
+				_ = rows.Close()
+				return sanitizedRows, removedBytes, fmt.Errorf("usage: scan historical request detail: %w", err)
+			}
+			batch = append(batch, row)
+			lastLogID = row.LogID
+		}
+		if err = rows.Err(); err != nil {
+			_ = rows.Close()
+			return sanitizedRows, removedBytes, fmt.Errorf("usage: iterate historical request details: %w", err)
+		}
+		_ = rows.Close()
+		if len(batch) == 0 {
+			break
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			return sanitizedRows, removedBytes, fmt.Errorf("usage: begin historical request detail cleanup: %w", err)
+		}
+		for _, row := range batch {
+			detail, errDecode := decompressLogContent(row.Compression, row.Content)
+			if errDecode != nil {
+				_ = tx.Rollback()
+				return sanitizedRows, removedBytes, fmt.Errorf("usage: decompress request detail log_id=%d: %w", row.LogID, errDecode)
+			}
+			sanitized, changed := sanitizeStoredRequestDetailBodies(detail)
+			if !changed {
+				continue
+			}
+			compressed, errCompress := compressLogContent(sanitized)
+			if errCompress != nil {
+				_ = tx.Rollback()
+				return sanitizedRows, removedBytes, fmt.Errorf("usage: compress request detail log_id=%d: %w", row.LogID, errCompress)
+			}
+			if _, err = tx.Exec(
+				"UPDATE request_log_content SET detail_content = ? WHERE log_id = ?",
+				compressed,
+				row.LogID,
+			); err != nil {
+				_ = tx.Rollback()
+				return sanitizedRows, removedBytes, fmt.Errorf("usage: update request detail log_id=%d: %w", row.LogID, err)
+			}
+			sanitizedRows++
+			if delta := int64(len(row.Content) - len(compressed)); delta > 0 {
+				removedBytes += delta
+			}
+		}
+		if err = tx.Commit(); err != nil {
+			return sanitizedRows, removedBytes, fmt.Errorf("usage: commit historical request detail cleanup: %w", err)
+		}
+	}
+	return sanitizedRows, removedBytes, nil
+}
+
+func reclaimRequestLogContentStorage(db *sql.DB, driver string) error {
+	switch driver {
+	case "postgres":
+		if _, err := db.Exec("VACUUM (FULL, ANALYZE) request_log_content"); err != nil {
+			return fmt.Errorf("usage: reclaim postgres request log content storage: %w", err)
+		}
+	case "sqlite":
+		if _, err := db.Exec("VACUUM"); err != nil {
+			return fmt.Errorf("usage: reclaim sqlite request log content storage: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/usage/request_log_body_purge_test.go
+++ b/internal/usage/request_log_body_purge_test.go
@@ -1,0 +1,122 @@
+package usage
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestPurgeStoredRequestBodiesSanitizesDetailsAndReclaimsStorage(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	details := `{"client":{"ip":"203.0.113.8"},"upstream":{"request_log":"=== API REQUEST 1 ===\nHeaders:\nX-Test: yes\nBody:\nsecret-request"},"response":{"upstream_log":"=== API RESPONSE 1 ===\nStatus: 200\nBody:\nsecret-response"}}`
+	InsertLogWithDetails("sk-test", "Primary", "gpt-test", "codex", "Codex", "auth-1", false, time.Now().UTC(), 100, 10, TokenStats{
+		InputTokens: 1, OutputTokens: 1, TotalTokens: 2,
+	}, `{"secret":"request"}`, `{"secret":"response"}`, details)
+
+	logs, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil || len(logs.Items) != 1 {
+		t.Fatalf("QueryLogs() result=%+v error=%v", logs, err)
+	}
+	SetRequestLogBodyStorageEnabled(false)
+	result, err := PurgeStoredRequestBodies()
+	if err != nil {
+		t.Fatalf("PurgeStoredRequestBodies() error = %v", err)
+	}
+	if result.ClearedBodyRows != 1 || result.SanitizedDetailRows != 1 || !result.ReclaimedStorage {
+		t.Fatalf("unexpected purge result: %+v", result)
+	}
+
+	input, err := QueryLogContentPart(logs.Items[0].ID, "input")
+	if err != nil || input.Content != "" {
+		t.Fatalf("input content=%q error=%v, want empty", input.Content, err)
+	}
+	detail, err := QueryLogContentPart(logs.Items[0].ID, "details")
+	if err != nil {
+		t.Fatalf("QueryLogContentPart(details) error = %v", err)
+	}
+	if !strings.Contains(detail.Content, "203.0.113.8") || !strings.Contains(detail.Content, "X-Test: yes") {
+		t.Fatalf("detail metadata was not preserved: %q", detail.Content)
+	}
+	if strings.Contains(detail.Content, "secret-request") || strings.Contains(detail.Content, "secret-response") {
+		t.Fatalf("detail bodies were not removed: %q", detail.Content)
+	}
+}
+
+func TestPurgeStoredRequestBodiesDropsMalformedHistoricalDetails(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	InsertLogWithDetails("sk-test", "Primary", "gpt-test", "codex", "Codex", "auth-1", false, time.Now().UTC(), 100, 10, TokenStats{
+		InputTokens: 1, OutputTokens: 1, TotalTokens: 2,
+	}, "input", "output", "malformed detail with possible body")
+	logs, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil || len(logs.Items) != 1 {
+		t.Fatalf("QueryLogs() result=%+v error=%v", logs, err)
+	}
+
+	SetRequestLogBodyStorageEnabled(false)
+	if _, err = PurgeStoredRequestBodies(); err != nil {
+		t.Fatalf("PurgeStoredRequestBodies() error = %v", err)
+	}
+	detail, err := QueryLogContentPart(logs.Items[0].ID, "details")
+	if err != nil {
+		t.Fatalf("QueryLogContentPart(details) error = %v", err)
+	}
+	if detail.Content != "" {
+		t.Fatalf("malformed detail content = %q, want empty", detail.Content)
+	}
+}
+
+func TestDisabledBodyStorageRepairsHistoricalDetailsOnStartup(t *testing.T) {
+	CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	enabled := config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	}
+	if err := InitDB(dbPath, enabled, time.UTC); err != nil {
+		t.Fatalf("InitDB(enabled): %v", err)
+	}
+	details := `{"client":{"ip":"203.0.113.8"},"upstream":{"request_log":"=== API REQUEST 1 ===\nBody:\nsecret-request"}}`
+	InsertLogWithDetails("sk-test", "Primary", "gpt-test", "codex", "Codex", "auth-1", false, time.Now().UTC(), 100, 10, TokenStats{
+		InputTokens: 1, OutputTokens: 1, TotalTokens: 2,
+	}, "input", "output", details)
+	logs, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil || len(logs.Items) != 1 {
+		t.Fatalf("QueryLogs() result=%+v error=%v", logs, err)
+	}
+	logID := logs.Items[0].ID
+	CloseDB()
+
+	disabled := enabled
+	disabled.StoreContent = false
+	if err = InitDB(dbPath, disabled, time.UTC); err != nil {
+		t.Fatalf("InitDB(disabled): %v", err)
+	}
+	t.Cleanup(CloseDB)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		input, inputErr := QueryLogContentPart(logID, "input")
+		detail, detailErr := QueryLogContentPart(logID, "details")
+		if inputErr == nil && detailErr == nil && input.Content == "" && !strings.Contains(detail.Content, "secret-request") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("startup repair timed out: input=%q inputErr=%v detail=%q detailErr=%v", input.Content, inputErr, detail.Content, detailErr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/usage/request_log_detail_sanitize.go
+++ b/internal/usage/request_log_detail_sanitize.go
@@ -9,20 +9,26 @@ import (
 // request/response bodies cannot be retained indirectly in detail_content when
 // full body storage is disabled.
 func stripStoredRequestDetailBodies(raw string) string {
+	sanitized, _ := sanitizeStoredRequestDetailBodies(raw)
+	return sanitized
+}
+
+func sanitizeStoredRequestDetailBodies(raw string) (string, bool) {
 	if strings.TrimSpace(raw) == "" {
-		return raw
+		return raw, false
 	}
 	var detail map[string]any
 	if err := json.Unmarshal([]byte(raw), &detail); err != nil {
-		return ""
+		return "", true
 	}
 	stripExchangeField(detail, "upstream", "request_log")
 	stripExchangeField(detail, "response", "upstream_log")
 	data, err := json.Marshal(detail)
 	if err != nil {
-		return ""
+		return "", true
 	}
-	return string(data)
+	sanitized := string(data)
+	return sanitized, sanitized != raw
 }
 
 func stripExchangeField(detail map[string]any, section, field string) {

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -358,6 +358,10 @@ func ClearRequestLogs(options ClearRequestLogsOptions) (ClearRequestLogsResult, 
 	if db == nil {
 		return ClearRequestLogsResult{}, fmt.Errorf("usage: database not initialised")
 	}
+	return clearRequestLogs(db, options)
+}
+
+func clearRequestLogs(db *sql.DB, options ClearRequestLogsOptions) (ClearRequestLogsResult, error) {
 	options, err := normalizeClearRequestLogsOptions(options)
 	if err != nil {
 		return ClearRequestLogsResult{}, err

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -675,7 +675,7 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 	initRuntimeSettingsTable(db)
 	log.Debugf("usage: initializing identity_fingerprints table")
 	initIdentityFingerprintsTable(db)
-	startRequestLogMaintenance(db)
+	startRequestLogMaintenance(db, driver)
 	log.Debugf("usage: request log content session_id backfill disabled during startup")
 	startRequestLogContentSessionIDBackfill(db)
 	log.Infof("usage: %s database initialised at %s", driver, dbPath)


### PR DESCRIPTION
## 根因

关闭正文存储只清空了 `input_content` 和 `output_content`：

- 历史 `detail_content` 仍嵌入约 506MB 的请求/响应 Body
- PostgreSQL 删除大字段后只把 TOAST 页面标记为可复用，物理文件没有缩小

因此日志存储仍约 506MB，数据库仍约 1.8GB。

## 修复

- 批量解压历史请求详情，移除其中嵌入的请求/响应 Body
- 保留请求详情元数据、请求记录、Token 和费用统计
- 执行针对 `request_log_content` 的 `VACUUM FULL ANALYZE`，回收 PostgreSQL 物理空间
- 正文关闭接口会等待完整清理和物理回收完成
- 升级后如果配置已经是关闭状态，后台维护任务会自动修复历史数据，无需重新打开再关闭
- 修复关闭数据库与后台清理之间的锁顺序，避免停机死锁

## 验证

- `rtk go test ./...`，2667 tests passed
- 新增正文清理、异常详情和升级后自动修复测试
- `rtk git diff --check`
