### PR TITLE
fix: add Grok OAuth endpoint mode

### DIFF
--- a/internal/api/handlers/management/auth_oauth.go
+++ b/internal/api/handlers/management/auth_oauth.go
@@ -266,6 +266,7 @@ func (h *Handler) RequestXAIToken(c *gin.Context) {
 	result, err := xaiprovider.StartOAuthLogin(ctx, xaiprovider.OAuthLoginOptions{
 		Config:              h.cfg,
 		WebUI:               isWebUIRequest(c),
+		UsingAPI:            queryBool(c, "using_api"),
 		CallbackTarget:      h.managementCallbackURL,
 		WaitCallback:        WaitOAuthCallbackFile,
 		CallbackWaitTimeout: oauthCallbackWaitTimeout,

--- a/internal/auth/xai/types.go
+++ b/internal/auth/xai/types.go
@@ -4,14 +4,17 @@ package xai
 import "time"
 
 const (
+	// DefaultAPIBaseURL is the official xAI API base URL.
 	DefaultAPIBaseURL = "https://api.x.ai/v1"
-	Issuer            = "https://auth.x.ai"
-	DiscoveryURL      = Issuer + "/.well-known/openid-configuration"
-	ClientID          = "b1a00492-073a-47ea-816f-4c329264a828"
-	Scope             = "openid profile email offline_access grok-cli:access api:access"
-	RedirectHost      = "127.0.0.1"
-	CallbackPort      = 56121
-	RedirectPath      = "/callback"
+	// CLIChatProxyBaseURL is the Grok Build/CLI endpoint for non-media HTTP chat.
+	CLIChatProxyBaseURL = "https://cli-chat-proxy.grok.com/v1"
+	Issuer              = "https://auth.x.ai"
+	DiscoveryURL        = Issuer + "/.well-known/openid-configuration"
+	ClientID            = "b1a00492-073a-47ea-816f-4c329264a828"
+	Scope               = "openid profile email offline_access grok-cli:access api:access"
+	RedirectHost        = "127.0.0.1"
+	CallbackPort        = 56121
+	RedirectPath        = "/callback"
 )
 
 var refreshLead = 5 * time.Minute

--- a/internal/management/oauth/providers/xai/flow.go
+++ b/internal/management/oauth/providers/xai/flow.go
@@ -52,6 +52,7 @@ type OAuthLoginOptions struct {
 	Auth                OAuthAuth
 	AuthDir             string
 	WebUI               bool
+	UsingAPI            bool
 	CallbackPort        int
 	CallbackWaitTimeout time.Duration
 	CallbackTarget      CallbackTargetFunc
@@ -180,7 +181,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 			return
 		}
 		tokenStorage := auth.CreateTokenStorage(bundle)
-		record := RecordFromTokenStorage(tokenStorage, now())
+		record := RecordFromTokenStorage(tokenStorage, now(), opts.UsingAPI)
 		if record == nil {
 			log.Error("xai token exchange returned empty access token")
 			opts.Sessions.setError(state, "Failed to exchange token")

--- a/internal/management/oauth/providers/xai/flow_test.go
+++ b/internal/management/oauth/providers/xai/flow_test.go
@@ -118,6 +118,12 @@ func TestStartOAuthLoginStartsForwarderAndCompletesProvider(t *testing.T) {
 			if record == nil {
 				t.Fatal("record is nil")
 			}
+			if got := record.Attributes["using_api"]; got != "false" {
+				t.Fatalf("attributes[using_api] = %q, want false", got)
+			}
+			if got, ok := record.Metadata["using_api"].(bool); !ok || got {
+				t.Fatalf("metadata[using_api] = %#v, want false", record.Metadata["using_api"])
+			}
 			savedProvider = record.Provider
 			return "/tmp/xai.json", nil
 		},

--- a/internal/management/oauth/providers/xai/record.go
+++ b/internal/management/oauth/providers/xai/record.go
@@ -1,6 +1,7 @@
 package xai
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -8,7 +9,9 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
-func RecordFromTokenStorage(tokenStorage *internalxai.TokenStorage, now time.Time) *coreauth.Auth {
+const xaiUsingAPIKey = "using_api"
+
+func RecordFromTokenStorage(tokenStorage *internalxai.TokenStorage, now time.Time, usingAPI bool) *coreauth.Auth {
 	if tokenStorage == nil || strings.TrimSpace(tokenStorage.AccessToken) == "" {
 		return nil
 	}
@@ -22,14 +25,19 @@ func RecordFromTokenStorage(tokenStorage *internalxai.TokenStorage, now time.Tim
 		label = "xAI"
 	}
 
+	metadata := MetadataFromTokenStorage(tokenStorage, now)
+	metadata[xaiUsingAPIKey] = usingAPI
+	attributes := AttributesFromTokenStorage(tokenStorage)
+	attributes[xaiUsingAPIKey] = strconv.FormatBool(usingAPI)
+
 	return &coreauth.Auth{
 		ID:         fileName,
 		Provider:   "xai",
 		FileName:   fileName,
 		Label:      label,
 		Storage:    tokenStorage,
-		Metadata:   MetadataFromTokenStorage(tokenStorage, now),
-		Attributes: AttributesFromTokenStorage(tokenStorage),
+		Metadata:   metadata,
+		Attributes: attributes,
 	}
 }
 

--- a/internal/management/oauth/providers/xai/record_test.go
+++ b/internal/management/oauth/providers/xai/record_test.go
@@ -24,7 +24,7 @@ func TestRecordFromTokenStorageBuildsPersistableRecord(t *testing.T) {
 		TokenEndpoint: "https://auth.x.ai/token",
 	}
 
-	record := RecordFromTokenStorage(storage, now)
+	record := RecordFromTokenStorage(storage, now, true)
 	if record == nil {
 		t.Fatal("RecordFromTokenStorage() = nil")
 	}
@@ -36,6 +36,12 @@ func TestRecordFromTokenStorageBuildsPersistableRecord(t *testing.T) {
 	}
 	if got := record.Attributes["auth_kind"]; got != "oauth" {
 		t.Fatalf("attributes[auth_kind] = %q, want oauth", got)
+	}
+	if got := record.Attributes["using_api"]; got != "true" {
+		t.Fatalf("attributes[using_api] = %q, want true", got)
+	}
+	if got, ok := record.Metadata["using_api"].(bool); !ok || !got {
+		t.Fatalf("metadata[using_api] = %#v, want true", record.Metadata["using_api"])
 	}
 	for key, want := range map[string]string{
 		"type":           "xai",
@@ -62,10 +68,10 @@ func TestRecordFromTokenStorageBuildsPersistableRecord(t *testing.T) {
 }
 
 func TestRecordFromTokenStorageHandlesNilOrEmptyAccessToken(t *testing.T) {
-	if record := RecordFromTokenStorage(nil, time.Time{}); record != nil {
+	if record := RecordFromTokenStorage(nil, time.Time{}, false); record != nil {
 		t.Fatalf("RecordFromTokenStorage(nil) = %#v, want nil", record)
 	}
-	if record := RecordFromTokenStorage(&internalxai.TokenStorage{}, time.Time{}); record != nil {
+	if record := RecordFromTokenStorage(&internalxai.TokenStorage{}, time.Time{}, false); record != nil {
 		t.Fatalf("RecordFromTokenStorage(empty token) = %#v, want nil", record)
 	}
 }

--- a/internal/runtime/executor/xai_endpoint_test.go
+++ b/internal/runtime/executor/xai_endpoint_test.go
@@ -1,0 +1,140 @@
+package executor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestXAIChatBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *cliproxyauth.Auth
+		want string
+	}{
+		{name: "nil auth uses api", want: xaiauth.DefaultAPIBaseURL},
+		{name: "non oauth uses api", auth: &cliproxyauth.Auth{Provider: "xai"}, want: xaiauth.DefaultAPIBaseURL},
+		{
+			name: "historical oauth defaults to cli",
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{
+				"auth_kind": "oauth",
+				"base_url":  xaiauth.DefaultAPIBaseURL + "/",
+			}},
+			want: xaiauth.CLIChatProxyBaseURL,
+		},
+		{
+			name: "metadata oauth defaults to cli",
+			auth: &cliproxyauth.Auth{Metadata: map[string]any{
+				"auth_kind": "oauth",
+				"base_url":  xaiauth.DefaultAPIBaseURL,
+			}},
+			want: xaiauth.CLIChatProxyBaseURL,
+		},
+		{
+			name: "using api true keeps official api",
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{
+				"auth_kind": "oauth",
+				"base_url":  xaiauth.DefaultAPIBaseURL,
+				"using_api": "true",
+			}},
+			want: xaiauth.DefaultAPIBaseURL,
+		},
+		{
+			name: "using api false selects cli",
+			auth: &cliproxyauth.Auth{Metadata: map[string]any{
+				"base_url":  xaiauth.DefaultAPIBaseURL,
+				"using_api": false,
+			}},
+			want: xaiauth.CLIChatProxyBaseURL,
+		},
+		{
+			name: "custom gateway remains custom",
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{
+				"base_url":  "https://gateway.example.com/v1",
+				"using_api": "false",
+			}},
+			want: "https://gateway.example.com/v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := xaiChatBaseURL(tt.auth); got != tt.want {
+				t.Fatalf("xaiChatBaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyXAIChatHeaders(t *testing.T) {
+	t.Run("cli endpoint receives cli identity headers", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, xaiauth.CLIChatProxyBaseURL+"/responses", nil)
+		auth := &cliproxyauth.Auth{Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"base_url":  xaiauth.DefaultAPIBaseURL,
+		}}
+
+		applyXAIChatHeaders(req, nil, auth, "oauth-token", true)
+
+		if got := req.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Fatalf("Authorization = %q, want Bearer oauth-token", got)
+		}
+		if got := req.Header.Get(xaiTokenAuthHeader); got != xaiTokenAuthValue {
+			t.Fatalf("%s = %q, want %q", xaiTokenAuthHeader, got, xaiTokenAuthValue)
+		}
+		if got := req.Header.Get("X-Grok-Client-Version"); got != config.DefaultXAIFingerprintClientVersion {
+			t.Fatalf("X-Grok-Client-Version = %q, want %q", got, config.DefaultXAIFingerprintClientVersion)
+		}
+	})
+
+	t.Run("api endpoint omits cli identity headers", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, xaiauth.DefaultAPIBaseURL+"/responses", nil)
+		auth := &cliproxyauth.Auth{Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"base_url":  xaiauth.DefaultAPIBaseURL,
+			"using_api": "true",
+		}}
+
+		applyXAIChatHeaders(req, nil, auth, "oauth-token", false)
+
+		if got := req.Header.Get(xaiTokenAuthHeader); got != "" {
+			t.Fatalf("%s = %q, want empty", xaiTokenAuthHeader, got)
+		}
+		if got := req.Header.Get("X-Grok-Client-Version"); got != "" {
+			t.Fatalf("X-Grok-Client-Version = %q, want empty", got)
+		}
+	})
+
+	t.Run("custom gateway omits cli identity headers", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "https://gateway.example.com/v1/responses", nil)
+		auth := &cliproxyauth.Auth{Attributes: map[string]string{
+			"base_url":  "https://gateway.example.com/v1",
+			"using_api": "false",
+		}}
+
+		applyXAIChatHeaders(req, nil, auth, "oauth-token", false)
+
+		if got := req.Header.Get(xaiTokenAuthHeader); got != "" {
+			t.Fatalf("%s = %q, want empty", xaiTokenAuthHeader, got)
+		}
+	})
+}
+
+func TestXAIPrepareRequestKeepsGenericRequestsOnAPIHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, xaiauth.DefaultAPIBaseURL+"/images/generations", nil)
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"auth_kind": "oauth",
+		"base_url":  xaiauth.DefaultAPIBaseURL,
+	}}
+
+	if err := NewXAIExecutor(nil).PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+	if got := req.Header.Get(xaiTokenAuthHeader); got != "" {
+		t.Fatalf("%s = %q, want empty for generic API request", xaiTokenAuthHeader, got)
+	}
+}

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +20,12 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+)
+
+const (
+	xaiUsingAPIAttr    = "using_api"
+	xaiTokenAuthHeader = "X-XAI-Token-Auth"
+	xaiTokenAuthValue  = "xai-grok-cli"
 )
 
 // XAIExecutor executes Grok requests through xAI's Responses API.
@@ -65,16 +72,13 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 	reporter := execCtx.Reporter()
 	defer reporter.trackFailure(execCtx.Context, &err)
 
-	token, baseURL := xaiCreds(auth)
-	if baseURL == "" {
-		baseURL = xaiauth.DefaultAPIBaseURL
-	}
-	endpoint := strings.TrimSuffix(baseURL, "/") + "/responses"
+	token, _ := xaiCreds(auth)
+	endpoint := strings.TrimSuffix(xaiChatBaseURL(auth), "/") + "/responses"
 	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return resp, err
 	}
-	applyXAIHeaders(httpReq, e.cfg, auth, token, true)
+	applyXAIChatHeaders(httpReq, e.cfg, auth, token, true)
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(endpoint, http.MethodPost, httpReq.Header.Clone(), body)
 
@@ -158,16 +162,13 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 	reporter := execCtx.Reporter()
 	defer reporter.trackFailure(execCtx.Context, &err)
 
-	token, baseURL := xaiCreds(auth)
-	if baseURL == "" {
-		baseURL = xaiauth.DefaultAPIBaseURL
-	}
-	endpoint := strings.TrimSuffix(baseURL, "/") + "/responses"
+	token, _ := xaiCreds(auth)
+	endpoint := strings.TrimSuffix(xaiChatBaseURL(auth), "/") + "/responses"
 	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
-	applyXAIHeaders(httpReq, e.cfg, auth, token, true)
+	applyXAIChatHeaders(httpReq, e.cfg, auth, token, true)
 	recorder := execCtx.Recorder()
 	recorder.RecordRequest(endpoint, http.MethodPost, httpReq.Header.Clone(), body)
 
@@ -375,6 +376,56 @@ func xaiCreds(auth *cliproxyauth.Auth) (token, baseURL string) {
 	return token, baseURL
 }
 
+// xaiUsingAPI reports whether non-media HTTP chat should use the official API.
+// OAuth credentials default to Grok Build when using_api is not persisted yet.
+func xaiUsingAPI(auth *cliproxyauth.Auth) bool {
+	if auth == nil {
+		return true
+	}
+	if raw := strings.TrimSpace(auth.Attributes[xaiUsingAPIAttr]); raw != "" {
+		if usingAPI, err := strconv.ParseBool(raw); err == nil {
+			return usingAPI
+		}
+	}
+	if raw, ok := auth.Metadata[xaiUsingAPIAttr]; ok {
+		switch value := raw.(type) {
+		case bool:
+			return value
+		case string:
+			if usingAPI, err := strconv.ParseBool(strings.TrimSpace(value)); err == nil {
+				return usingAPI
+			}
+		}
+	}
+	if authKind := strings.TrimSpace(auth.Attributes["auth_kind"]); authKind != "" {
+		return !strings.EqualFold(authKind, "oauth")
+	}
+	return !strings.EqualFold(xaiMetadataString(auth.Metadata, "auth_kind"), "oauth")
+}
+
+// xaiChatBaseURL switches only Responses HTTP traffic. Model listing and generic
+// HTTP requests continue using the configured API base URL.
+func xaiChatBaseURL(auth *cliproxyauth.Auth) string {
+	_, baseURL := xaiCreds(auth)
+	if xaiUsingAPI(auth) {
+		if baseURL == "" {
+			return xaiauth.DefaultAPIBaseURL
+		}
+		return baseURL
+	}
+	if baseURL != "" && !xaiIsBaseURL(baseURL, xaiauth.DefaultAPIBaseURL) {
+		return baseURL
+	}
+	return xaiauth.CLIChatProxyBaseURL
+}
+
+func xaiIsBaseURL(baseURL, target string) bool {
+	normalize := func(value string) string {
+		return strings.TrimRight(strings.TrimSpace(value), "/")
+	}
+	return normalize(baseURL) == normalize(target)
+}
+
 func applyXAIHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.Auth, token string, stream bool) {
 	r.Header.Set("Content-Type", "application/json")
 	if strings.TrimSpace(token) != "" {
@@ -395,6 +446,15 @@ func applyXAIHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.Aut
 	if fp, ok := xaiIdentityFingerprint(cfg, auth, r.Context()); ok {
 		applyXAIIdentityFingerprintHeaders(r.Header, fp)
 	}
+}
+
+func applyXAIChatHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.Auth, token string, stream bool) {
+	applyXAIHeaders(r, cfg, auth, token, stream)
+	if xaiUsingAPI(auth) || !xaiIsBaseURL(xaiChatBaseURL(auth), xaiauth.CLIChatProxyBaseURL) {
+		return
+	}
+	r.Header.Set(xaiTokenAuthHeader, xaiTokenAuthValue)
+	r.Header.Set("X-Grok-Client-Version", config.DefaultXAIFingerprintClientVersion)
 }
 
 func xaiMetadataString(meta map[string]any, key string) string {


### PR DESCRIPTION
## Summary
- add `using_api` to xAI OAuth records and management authorization requests
- route OAuth Responses traffic to Grok Build/CLI by default, while allowing the official xAI API path
- add the Grok CLI authentication headers only for the CLI chat endpoint
- keep model listing and generic/media HTTP paths on the API endpoint

## Root cause
OAuth chat requests were always sent to `api.x.ai`, so xAI classified them as API usage even when the OAuth credential and model came from Grok CLI/Grok Build.

## Validation
- `go test ./...` (182 packages, 2680 tests)
