### PR TITLE
fix: expose built-in administrator identity

### DIFF
--- a/internal/identity/postgres_test.go
+++ b/internal/identity/postgres_test.go
@@ -29,6 +29,20 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
 		t.Fatal(err)
 	}
+	users, err := service.ListUsers(ctx, SystemTenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users) != 1 || users[0].ID != SystemUserID || users[0].DisplayName != "Super Administrator" || len(users[0].RoleCodes) != 1 || users[0].RoleCodes[0] != "platform_super_admin" {
+		t.Fatalf("system users=%+v", users)
+	}
+	systemRoles, err := service.ListRoles(ctx, SystemTenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(systemRoles) != 1 || systemRoles[0].ID != SystemRoleID || systemRoles[0].Name != "Administrator" || !systemRoles[0].SystemProtected {
+		t.Fatalf("system roles=%+v", systemRoles)
+	}
 	login, err := service.Login(ctx, "admin", "bootstrap-password-123", false, "test")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/identity/service.go
+++ b/internal/identity/service.go
@@ -175,8 +175,8 @@ func (s *Service) Bootstrap(ctx context.Context, initialPassword string) error {
 
 	if _, err = tx.ExecContext(ctx, `
 		INSERT INTO roles (id, tenant_id, code, name, description, scope, system_protected)
-		VALUES (?, ?, 'platform_super_admin', 'Platform Super Administrator',
-		        'Built-in role with every platform and tenant permission.', 'platform', true)
+		VALUES (?, ?, 'platform_super_admin', 'Administrator',
+		        'Built-in administrator role with every platform and tenant permission.', 'platform', true)
 		ON CONFLICT (id) DO UPDATE SET
 		  tenant_id = EXCLUDED.tenant_id, code = EXCLUDED.code, name = EXCLUDED.name,
 		  description = EXCLUDED.description, scope = EXCLUDED.scope,
@@ -223,6 +223,9 @@ func (s *Service) Bootstrap(ctx context.Context, initialPassword string) error {
 		`, SystemUserID, SystemTenantID, passwordHash); err != nil {
 			return fmt.Errorf("identity: seed admin: %w", err)
 		}
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE users SET display_name = 'Super Administrator', updated_at = now() WHERE id = ?`, SystemUserID); err != nil {
+		return fmt.Errorf("identity: update admin display name: %w", err)
 	}
 	if _, err = tx.ExecContext(ctx, `INSERT INTO user_roles (user_id, role_id) VALUES (?, ?) ON CONFLICT DO NOTHING`, SystemUserID, SystemRoleID); err != nil {
 		return fmt.Errorf("identity: seed admin role: %w", err)


### PR DESCRIPTION
## 变更说明

- 将系统内置角色的展示名称统一为 `Administrator`。
- 将默认 `admin` 账号的展示名称统一为 `Super Administrator`。
- Bootstrap 会修正已有默认管理员账号的展示名称，不只影响新数据库。
- 增加 PostgreSQL 回归断言，确保系统租户始终包含默认管理员账号、管理员角色及角色绑定。

## 验证

- `go test ./... -count=1 -timeout=300s`：2717 passed / 191 packages
- `go vet ./...`：通过
- PostgreSQL 16 `TestPostgresIdentityLifecycle`：通过
- `git diff --check`：通过
