### PR TITLE
fix: resolve orphan auth_index channel filters

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -1833,3 +1833,137 @@ func TestDeleteUsageLogsSupportsSelectiveBodyCleanup(t *testing.T) {
 		t.Fatalf("HasContent = true, want false after selective cleanup")
 	}
 }
+
+func TestGetUsageLogsFiltersByOrphanAuthIndexWithoutLiveMeta(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	// Live auth uses the file: seed index (current EnsureIndex behavior).
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	liveAuth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "xai-asherandersenloqv@outlook.com.json",
+		FileName: "xai-asherandersenloqv@outlook.com.json",
+		Provider: "xai",
+		Label:    "asherandersenloqv@outlook.com",
+		Metadata: map[string]any{
+			"email":     "asherandersenloqv@outlook.com",
+			"auth_kind": "oauth",
+		},
+	})
+	if err != nil {
+		t.Fatalf("register live auth: %v", err)
+	}
+
+	// Historical rows were written under the id: seed index before FileName was
+	// consistently set. That orphan index no longer exists in live auth meta.
+	orphanIndex := "69e8946f1ffc2d23"
+	now := time.Now().UTC()
+	usage.InsertLog(
+		"", "", "grok-4.5", "asherandersenloqv@outlook.com", "asherandersenloqv@outlook.com", orphanIndex,
+		false, now.Add(-time.Minute), 100, 10,
+		usage.TokenStats{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+		"", "",
+	)
+	usage.InsertLog(
+		"", "", "grok-4.5", "asherandersenloqv@outlook.com", "asherandersenloqv@outlook.com", liveAuth.Index,
+		false, now, 100, 10,
+		usage.TokenStats{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+		"", "",
+	)
+
+	h := &Handler{
+		cfg:         &config.Config{},
+		authManager: manager,
+	}
+
+	// Facet list should expose both live and orphan options for the same email.
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50", nil)
+	h.UsageLogs().GetUsageLogs(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var listPayload struct {
+		Filters struct {
+			ChannelOptions []struct {
+				Value     string `json:"value"`
+				Label     string `json:"label"`
+				Provider  string `json:"provider"`
+				AuthType  string `json:"auth_type"`
+				AuthIndex string `json:"auth_index"`
+			} `json:"channel_options"`
+		} `json:"filters"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listPayload); err != nil {
+		t.Fatalf("unmarshal list response: %v", err)
+	}
+	if len(listPayload.Filters.ChannelOptions) != 2 {
+		t.Fatalf("channel_options = %#v, want 2 options (live + orphan)", listPayload.Filters.ChannelOptions)
+	}
+	var foundOrphan, foundLive bool
+	for _, opt := range listPayload.Filters.ChannelOptions {
+		switch opt.Value {
+		case orphanIndex:
+			foundOrphan = true
+			if opt.Label != "asherandersenloqv@outlook.com" {
+				t.Fatalf("orphan label = %q, want email", opt.Label)
+			}
+			// Orphan has no live meta → no provider / oauth badge.
+			if opt.Provider != "" || opt.AuthType != "" {
+				t.Fatalf("orphan option should have empty provider/auth_type, got %#v", opt)
+			}
+		case liveAuth.Index:
+			foundLive = true
+			if opt.AuthType != "oauth" {
+				t.Fatalf("live option auth_type = %q, want oauth", opt.AuthType)
+			}
+		}
+	}
+	if !foundOrphan || !foundLive {
+		t.Fatalf("channel_options missing live/orphan values: %#v", listPayload.Filters.ChannelOptions)
+	}
+
+	// Selecting the orphan auth_index must return the historical rows, not 0.
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/logs?days=7&page=1&size=50&channel="+orphanIndex, nil)
+	h.UsageLogs().GetUsageLogs(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("orphan filter expected status %d, got %d, body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var filtered struct {
+		Items []struct {
+			AuthIndex   string `json:"auth_index"`
+			ChannelName string `json:"channel_name"`
+			Model       string `json:"model"`
+		} `json:"items"`
+		Total int64 `json:"total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &filtered); err != nil {
+		t.Fatalf("unmarshal orphan filtered response: %v", err)
+	}
+	if filtered.Total != 1 || len(filtered.Items) != 1 {
+		t.Fatalf("orphan filtered total/items = %d/%d, want 1/1; body=%s", filtered.Total, len(filtered.Items), rec.Body.String())
+	}
+	if filtered.Items[0].AuthIndex != orphanIndex {
+		t.Fatalf("orphan filtered auth_index = %q, want %q", filtered.Items[0].AuthIndex, orphanIndex)
+	}
+	if filtered.Items[0].ChannelName != "asherandersenloqv@outlook.com" {
+		t.Fatalf("orphan filtered channel_name = %q", filtered.Items[0].ChannelName)
+	}
+}

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -298,6 +298,14 @@ func channelFilterSelectors(
 		if matchedAuthIndex {
 			continue
 		}
+		// Historical channel_options values are auth_index hashes even when the
+		// auth file was later reindexed (file: vs id: seed) or deleted. Treat
+		// stable auth_index tokens as AuthIndexes; never fall back to
+		// channel_name matching for them (that path yields 0 rows).
+		if looksLikeAuthIndex(raw) {
+			appendAuthIndex(raw)
+			continue
+		}
 		// Legacy clients still send display labels / emails.
 		appendChannelName(raw)
 	}
@@ -327,6 +335,28 @@ func channelFilterSelectors(
 		authIndexes = []string{""}
 	}
 	return authIndexes, channelNames, authIndexChannelNames
+}
+
+// looksLikeAuthIndex reports whether value matches the stable auth index format
+// produced by coreauth.stableAuthIndex (first 8 bytes of SHA-256 as 16 hex chars).
+// Channel facet values use this token so historical rows remain filterable after
+// live auth reindex or deletion.
+func looksLikeAuthIndex(value string) bool {
+	value = strings.TrimSpace(value)
+	if len(value) != 16 {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		case c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func enrichChannelFilterOptions(

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -1,0 +1,98 @@
+package usagelogs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLooksLikeAuthIndex(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "live file seed", value: "39a7982984e321e5", want: true},
+		{name: "orphan id seed", value: "69e8946f1ffc2d23", want: true},
+		{name: "uppercase hex", value: "69E8946F1FFC2D23", want: true},
+		{name: "email label", value: "asherandersenloqv@outlook.com", want: false},
+		{name: "display name", value: "Codex 主渠道", want: false},
+		{name: "too short", value: "39a7982984e321e", want: false},
+		{name: "too long", value: "39a7982984e321e5a", want: false},
+		{name: "non hex", value: "gggggggggggggggg", want: false},
+		{name: "empty", value: "", want: false},
+		{name: "spaces", value: "  39a7982984e321e5  ", want: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := looksLikeAuthIndex(tc.value); got != tc.want {
+				t.Fatalf("looksLikeAuthIndex(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChannelFilterSelectorsTreatsOrphanAuthIndexAsAuthIndex(t *testing.T) {
+	t.Parallel()
+
+	// Live auth currently uses the file: seed index; historical rows still use
+	// the id: seed index for the same OAuth email label.
+	liveIndex := "39a7982984e321e5"
+	orphanIndex := "69e8946f1ffc2d23"
+	label := "asherandersenloqv@outlook.com"
+
+	authIndexChannelMap := map[string]string{liveIndex: label}
+	authMetaByIndex := map[string]authChannelMeta{
+		liveIndex: {label: label, provider: "xai", authType: "oauth"},
+	}
+
+	// Selecting the orphan facet value must stay on AuthIndexes. The previous
+	// bug fell through to ChannelNames and queried channel_name = <hash>.
+	authIndexes, channelNames, _ := channelFilterSelectors(
+		[]string{orphanIndex},
+		nil,
+		authIndexChannelMap,
+		nil,
+		authMetaByIndex,
+	)
+	if !reflect.DeepEqual(authIndexes, []string{orphanIndex}) {
+		t.Fatalf("authIndexes = %#v, want [%s]", authIndexes, orphanIndex)
+	}
+	if len(channelNames) != 0 {
+		t.Fatalf("channelNames = %#v, want empty", channelNames)
+	}
+
+	// Live index still resolves normally.
+	authIndexes, channelNames, _ = channelFilterSelectors(
+		[]string{liveIndex},
+		nil,
+		authIndexChannelMap,
+		nil,
+		authMetaByIndex,
+	)
+	if !reflect.DeepEqual(authIndexes, []string{liveIndex}) {
+		t.Fatalf("live authIndexes = %#v, want [%s]", authIndexes, liveIndex)
+	}
+	if len(channelNames) != 0 {
+		t.Fatalf("live channelNames = %#v, want empty", channelNames)
+	}
+
+	// Email/display labels still use the legacy channel_name path (and may also
+	// expand to live auth indexes via authIndexChannelMap label matching).
+	authIndexes, channelNames, _ = channelFilterSelectors(
+		[]string{label},
+		map[string]string{label: label},
+		authIndexChannelMap,
+		nil,
+		authMetaByIndex,
+	)
+	if !reflect.DeepEqual(authIndexes, []string{liveIndex}) {
+		t.Fatalf("label authIndexes = %#v, want [%s]", authIndexes, liveIndex)
+	}
+	if !reflect.DeepEqual(channelNames, []string{label}) {
+		t.Fatalf("label channelNames = %#v, want [%s]", channelNames, label)
+	}
+}


### PR DESCRIPTION
## Summary
- Request log channel facets use `auth_index` hashes as filter values, including historical orphan indexes created when the same OAuth auth file was indexed under `id:` vs `file:` seeds.
- Selecting those no-icon / no-OAuth options previously fell through to `channel_name = <hash>`, which always returned 0 rows even though the logs still exist.
- `channelFilterSelectors` now treats 16-char hex auth_index tokens as `AuthIndexes`, so orphan facet selections query the correct column.

## Test plan
- [x] `go test ./internal/management/usagelogs/ -count=1`
- [x] `go test ./internal/api/handlers/management/ -run 'TestGetUsageLogsFiltersByOrphanAuthIndexWithoutLiveMeta|TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers|TestGetUsageLogsResolvesGenericKimiChannelByAuthIndex' -count=1`
- [ ] After deploy: open request logs, select a no-icon channel option for a duplicated OAuth email, confirm historical rows are returned instead of 0.