### PR TITLE
fix: merge xAI OAuth id/file auth_index channel options

### DIFF
--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -51,7 +51,7 @@ func (s *Service) UsageChartData(apiKey string, days int) (map[string]any, error
 		if err != nil {
 			return nil, err
 		}
-		keyNameMap, _, _, _, _ := s.buildNameMaps()
+		keyNameMap, _, _, _, _, _ := s.buildNameMaps()
 
 		for i := range apikeyDist {
 			if apikeyDist[i].Name == "" {

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -1,7 +1,10 @@
 package usagelogs
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -13,8 +16,8 @@ import (
 )
 
 func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any, error) {
-	keyNameMap, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex := s.buildNameMaps()
-	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex)
+	keyNameMap, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex, authIndexGroup := s.buildNameMaps()
+	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex, authIndexGroup)
 
 	params := usage.LogQueryParams{
 		TenantID:              s.tenantID,
@@ -67,7 +70,7 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 			filters.APIKeyNames[key] = name
 		}
 	}
-	filters.ChannelOptions = enrichChannelFilterOptions(filters.ChannelOptions, channelNameMap, authIndexChannelMap, authMetaByIndex)
+	filters.ChannelOptions = enrichChannelFilterOptions(filters.ChannelOptions, channelNameMap, authIndexChannelMap, authMetaByIndex, authIndexGroup)
 	filters.Channels = channelLabelsFromOptions(filters.ChannelOptions)
 
 	if result.Items == nil {
@@ -119,8 +122,8 @@ func (s *Service) ClearRequestLogs(options usage.ClearRequestLogsOptions) (int, 
 }
 
 func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, error) {
-	_, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex := s.buildNameMaps()
-	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex)
+	_, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex, authIndexGroup := s.buildNameMaps()
+	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex, authIndexGroup)
 	params := usage.LogQueryParams{
 		TenantID:              usage.ResolveAPIKeyTenant(input.APIKey),
 		Page:                  input.Page,
@@ -166,7 +169,7 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		result.Items[i].AuthIndex = ""
 	}
 
-	filters.ChannelOptions = enrichChannelFilterOptions(filters.ChannelOptions, channelNameMap, authIndexChannelMap, authMetaByIndex)
+	filters.ChannelOptions = enrichChannelFilterOptions(filters.ChannelOptions, channelNameMap, authIndexChannelMap, authMetaByIndex, authIndexGroup)
 	// Public responses keep opaque filter values (auth_index) so same-email
 	// multi-provider accounts stay selectable, but strip the auth_index field.
 	for i := range filters.ChannelOptions {
@@ -216,6 +219,7 @@ func channelFilterSelectors(
 	channelNameMap, authIndexChannelMap map[string]string,
 	ambiguousAuthIndexChannelMap map[string][]string,
 	authMetaByIndex map[string]authChannelMeta,
+	authIndexGroup map[string][]string,
 ) ([]string, []string, map[string][]string) {
 	// Preserve original selected values. Only use lower-case keys for label matching.
 	selectedRaw := make([]string, 0, len(channels))
@@ -249,6 +253,21 @@ func channelFilterSelectors(
 		seenAuthIndex[idx] = struct{}{}
 		authIndexes = append(authIndexes, idx)
 	}
+	// Expand xAI OAuth historical aliases (id: vs file: seed) so one UI option
+	// returns logs written under either index.
+	appendAuthIndexGroup := func(idx string) {
+		idx = strings.TrimSpace(idx)
+		if idx == "" {
+			return
+		}
+		if group := authIndexGroup[idx]; len(group) > 0 {
+			for _, member := range group {
+				appendAuthIndex(member)
+			}
+			return
+		}
+		appendAuthIndex(idx)
+	}
 	appendChannelName := func(name string) {
 		name = strings.TrimSpace(name)
 		if name == "" {
@@ -266,20 +285,26 @@ func channelFilterSelectors(
 		// Prefer exact auth_index matches so multi-provider same-email accounts
 		// filter independently when clients send auth_index as the value.
 		if _, ok := authIndexChannelMap[raw]; ok {
-			appendAuthIndex(raw)
+			appendAuthIndexGroup(raw)
 			if legacyChannels := ambiguousAuthIndexChannelMap[raw]; len(legacyChannels) > 0 {
 				authIndexChannelNames[raw] = append(authIndexChannelNames[raw], legacyChannels...)
+			}
+			// Also attach legacy channel names for every expanded group member.
+			for _, member := range authIndexGroup[raw] {
+				if legacyChannels := ambiguousAuthIndexChannelMap[member]; len(legacyChannels) > 0 {
+					authIndexChannelNames[member] = append(authIndexChannelNames[member], legacyChannels...)
+				}
 			}
 			continue
 		}
 		if _, ok := authMetaByIndex[raw]; ok {
-			appendAuthIndex(raw)
+			appendAuthIndexGroup(raw)
 			continue
 		}
 		matchedAuthIndex := false
 		for idx := range authIndexChannelMap {
 			if strings.EqualFold(strings.TrimSpace(idx), raw) {
-				appendAuthIndex(idx)
+				appendAuthIndexGroup(idx)
 				if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
 					authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
 				}
@@ -291,7 +316,7 @@ func channelFilterSelectors(
 		}
 		for idx := range authMetaByIndex {
 			if strings.EqualFold(strings.TrimSpace(idx), raw) {
-				appendAuthIndex(idx)
+				appendAuthIndexGroup(idx)
 				matchedAuthIndex = true
 			}
 		}
@@ -303,7 +328,7 @@ func channelFilterSelectors(
 		// stable auth_index tokens as AuthIndexes; never fall back to
 		// channel_name matching for them (that path yields 0 rows).
 		if looksLikeAuthIndex(raw) {
-			appendAuthIndex(raw)
+			appendAuthIndexGroup(raw)
 			continue
 		}
 		// Legacy clients still send display labels / emails.
@@ -325,7 +350,7 @@ func channelFilterSelectors(
 			continue
 		}
 		if _, ok := selectedLabelKeys[key]; ok {
-			appendAuthIndex(idx)
+			appendAuthIndexGroup(idx)
 			if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
 				authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
 			}
@@ -363,22 +388,37 @@ func enrichChannelFilterOptions(
 	options []usage.ChannelFilterOption,
 	channelNameMap, authIndexChannelMap map[string]string,
 	authMetaByIndex map[string]authChannelMeta,
+	authIndexGroup map[string][]string,
 ) []usage.ChannelFilterOption {
 	if len(options) == 0 {
 		return make([]usage.ChannelFilterOption, 0)
 	}
 
 	// Prefer one option per live auth_index. Collapse pure name-only rows when
-	// the same label already has auth-backed options.
+	// the same label already has auth-backed options. For xAI OAuth, also
+	// collapse historical id:/file: seed aliases onto the canonical live index.
 	out := make([]usage.ChannelFilterOption, 0, len(options))
 	seenValue := make(map[string]struct{}, len(options))
 	authBackedLabels := make(map[string]struct{})
+
+	canonicalAuthIndex := func(authIndex string) string {
+		authIndex = strings.TrimSpace(authIndex)
+		if authIndex == "" {
+			return ""
+		}
+		if group := authIndexGroup[authIndex]; len(group) > 0 {
+			// buildNameMaps stores the live EnsureIndex() first.
+			return strings.TrimSpace(group[0])
+		}
+		return authIndex
+	}
 
 	for _, option := range options {
 		authIndex := strings.TrimSpace(option.AuthIndex)
 		if authIndex == "" {
 			authIndex = strings.TrimSpace(option.Value)
 		}
+		authIndex = canonicalAuthIndex(authIndex)
 		if authIndex == "" {
 			continue
 		}
@@ -398,6 +438,9 @@ func enrichChannelFilterOptions(
 		if authIndex == "" {
 			authIndex = strings.TrimSpace(option.Value)
 		}
+		// Fold xAI OAuth historical aliases onto the live index so the UI shows
+		// one Grok OAuth option with provider/auth_type badges.
+		authIndex = canonicalAuthIndex(authIndex)
 		if label == "" && authIndex != "" {
 			if name, ok := authIndexChannelMap[authIndex]; ok && strings.TrimSpace(name) != "" {
 				label = strings.TrimSpace(name)
@@ -423,6 +466,13 @@ func enrichChannelFilterOptions(
 		}
 		if value == "" {
 			value = label
+		}
+		// When we rewrote authIndex to the group canonical, filter value must
+		// match so clients select the live index (which expands server-side).
+		if authIndex != "" {
+			if group := authIndexGroup[authIndex]; len(group) > 0 {
+				value = authIndex
+			}
 		}
 
 		hasLiveMeta := false
@@ -584,12 +634,14 @@ func (s *Service) buildNameMaps() (
 	keyNameMap, channelNameMap, authIndexChannelMap map[string]string,
 	ambiguousAuthIndexChannelMap map[string][]string,
 	authMetaByIndex map[string]authChannelMeta,
+	authIndexGroup map[string][]string,
 ) {
 	keyNameMap = make(map[string]string)
 	channelNameMap = make(map[string]string)
 	authIndexChannelMap = make(map[string]string)
 	ambiguousAuthIndexChannelMap = make(map[string][]string)
 	authMetaByIndex = make(map[string]authChannelMeta)
+	authIndexGroup = make(map[string][]string)
 
 	for _, row := range apikeysettings.NewService(nil, apikeysettings.WithTenantID(s.tenantID)).ListRows() {
 		if row.Key != "" && row.Name != "" {
@@ -644,13 +696,27 @@ func (s *Service) buildNameMaps() (
 			}
 			auth.EnsureIndex()
 			idx := strings.TrimSpace(auth.Index)
-			if idx != "" {
-				authIndexChannelMap[idx] = channel
-				authMetaByIndex[idx] = authChannelMeta{
-					label:    channel,
-					provider: normalizeProviderKey(auth.Provider),
-					authType: resolveAuthType(auth),
+			meta := authChannelMeta{
+				label:    channel,
+				provider: normalizeProviderKey(auth.Provider),
+				authType: resolveAuthType(auth),
+			}
+			// xAI/Grok OAuth historically flipped between id: and file: seeds for
+			// the same credential. Register the full index group so filters and
+			// channel_options collapse onto one live option while still matching
+			// historical rows.
+			group := xaiOAuthAuthIndexGroup(auth)
+			if len(group) == 0 && idx != "" {
+				group = []string{idx}
+			}
+			for _, member := range group {
+				member = strings.TrimSpace(member)
+				if member == "" {
+					continue
 				}
+				authIndexChannelMap[member] = channel
+				authMetaByIndex[member] = meta
+				authIndexGroup[member] = group
 			}
 			if accountType, account := auth.AccountInfo(); strings.EqualFold(accountType, "oauth") {
 				if source := strings.TrimSpace(account); source != "" {
@@ -690,6 +756,93 @@ func (s *Service) buildNameMaps() (
 	}
 
 	return
+}
+
+// xaiOAuthAuthIndexGroup returns the live EnsureIndex first, followed by known
+// historical seeds for the same xAI/Grok OAuth credential. Non-xAI auths return
+// only the live index (or nil when empty).
+//
+// Grok OAuth is special: the same account can log under both id:<file> and
+// file:<file> depending on whether FileName was populated at write time.
+func xaiOAuthAuthIndexGroup(auth *coreauth.Auth) []string {
+	if auth == nil {
+		return nil
+	}
+	primary := strings.TrimSpace(auth.EnsureIndex())
+	if primary == "" {
+		return nil
+	}
+	if !isXAIProvider(auth.Provider) {
+		return []string{primary}
+	}
+	accountType, _ := auth.AccountInfo()
+	// Only merge OAuth-style xAI credentials; API-key channels stay independent.
+	if !strings.EqualFold(strings.TrimSpace(accountType), "oauth") {
+		// AccountInfo may miss email when metadata shape differs; still merge when
+		// the channel looks like an email (typical OAuth label).
+		channel := strings.TrimSpace(auth.ChannelName())
+		if !strings.Contains(channel, "@") {
+			return []string{primary}
+		}
+	}
+
+	seen := map[string]struct{}{primary: {}}
+	out := []string{primary}
+	addSeed := func(seed string) {
+		seed = strings.TrimSpace(seed)
+		if seed == "" {
+			return
+		}
+		idx := authIndexFromSeed(seed)
+		if idx == "" {
+			return
+		}
+		if _, ok := seen[idx]; ok {
+			return
+		}
+		seen[idx] = struct{}{}
+		out = append(out, idx)
+	}
+
+	fileName := strings.TrimSpace(auth.FileName)
+	if fileName != "" {
+		base := filepath.Base(fileName)
+		// Current seed path.
+		addSeed("file:" + fileName)
+		addSeed("file:" + base)
+		// Historical path: ID was set to the auth file name (including .json)
+		// before FileName was populated, so EnsureIndex used id:<filename>.
+		addSeed("id:" + fileName)
+		addSeed("id:" + base)
+	}
+	if id := strings.TrimSpace(auth.ID); id != "" {
+		addSeed("id:" + id)
+		// If ID is a bare filename, also cover file: variants.
+		if strings.HasSuffix(strings.ToLower(id), ".json") {
+			addSeed("file:" + id)
+			addSeed("file:" + filepath.Base(id))
+		}
+	}
+	return out
+}
+
+func isXAIProvider(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "xai", "grok":
+		return true
+	default:
+		return false
+	}
+}
+
+// authIndexFromSeed mirrors coreauth.stableAuthIndex (sha256 first 8 bytes hex).
+func authIndexFromSeed(seed string) string {
+	seed = strings.TrimSpace(seed)
+	if seed == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(seed))
+	return hex.EncodeToString(sum[:8])
 }
 
 func resolveAuthType(auth *coreauth.Auth) string {

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -1,8 +1,14 @@
 package usagelogs
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"reflect"
+	"sort"
 	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 func TestLooksLikeAuthIndex(t *testing.T) {
@@ -57,6 +63,7 @@ func TestChannelFilterSelectorsTreatsOrphanAuthIndexAsAuthIndex(t *testing.T) {
 		authIndexChannelMap,
 		nil,
 		authMetaByIndex,
+		nil,
 	)
 	if !reflect.DeepEqual(authIndexes, []string{orphanIndex}) {
 		t.Fatalf("authIndexes = %#v, want [%s]", authIndexes, orphanIndex)
@@ -72,6 +79,7 @@ func TestChannelFilterSelectorsTreatsOrphanAuthIndexAsAuthIndex(t *testing.T) {
 		authIndexChannelMap,
 		nil,
 		authMetaByIndex,
+		nil,
 	)
 	if !reflect.DeepEqual(authIndexes, []string{liveIndex}) {
 		t.Fatalf("live authIndexes = %#v, want [%s]", authIndexes, liveIndex)
@@ -88,11 +96,200 @@ func TestChannelFilterSelectorsTreatsOrphanAuthIndexAsAuthIndex(t *testing.T) {
 		authIndexChannelMap,
 		nil,
 		authMetaByIndex,
+		nil,
 	)
 	if !reflect.DeepEqual(authIndexes, []string{liveIndex}) {
 		t.Fatalf("label authIndexes = %#v, want [%s]", authIndexes, liveIndex)
 	}
 	if !reflect.DeepEqual(channelNames, []string{label}) {
 		t.Fatalf("label channelNames = %#v, want [%s]", channelNames, label)
+	}
+}
+
+func seedIndex(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	return hex.EncodeToString(sum[:8])
+}
+
+func TestXaiOAuthAuthIndexGroupMergesIDAndFileSeeds(t *testing.T) {
+	t.Parallel()
+
+	fileName := "xai-asherandersenloqv@outlook.com.json"
+	live := seedIndex("file:" + fileName)
+	orphan := seedIndex("id:" + fileName)
+
+	auth := &coreauth.Auth{
+		Provider: "xai",
+		FileName: fileName,
+		ID:       fileName,
+		Label:    "asherandersenloqv@outlook.com",
+		Metadata: map[string]any{"email": "asherandersenloqv@outlook.com"},
+	}
+	group := xaiOAuthAuthIndexGroup(auth)
+	if len(group) < 2 {
+		t.Fatalf("group = %#v, want at least live+orphan", group)
+	}
+	if group[0] != live {
+		t.Fatalf("canonical = %s, want live %s", group[0], live)
+	}
+	foundOrphan := false
+	for _, member := range group {
+		if member == orphan {
+			foundOrphan = true
+			break
+		}
+	}
+	if !foundOrphan {
+		t.Fatalf("group %#v missing orphan %s", group, orphan)
+	}
+}
+
+func TestXaiOAuthAuthIndexGroupSkipsNonXAI(t *testing.T) {
+	t.Parallel()
+
+	fileName := "codex-yuan364299311@gmail.com-pro.json"
+	auth := &coreauth.Auth{
+		Provider: "codex",
+		FileName: fileName,
+		ID:       fileName,
+		Label:    "yuan364299311@gmail.com",
+		Metadata: map[string]any{"email": "yuan364299311@gmail.com"},
+	}
+	group := xaiOAuthAuthIndexGroup(auth)
+	live := seedIndex("file:" + fileName)
+	if !reflect.DeepEqual(group, []string{live}) {
+		t.Fatalf("codex group = %#v, want only live [%s]", group, live)
+	}
+}
+
+func TestChannelFilterSelectorsExpandsXaiOAuthIndexGroup(t *testing.T) {
+	t.Parallel()
+
+	liveIndex := "39a7982984e321e5"
+	orphanIndex := "69e8946f1ffc2d23"
+	label := "asherandersenloqv@outlook.com"
+	group := []string{liveIndex, orphanIndex}
+
+	authIndexChannelMap := map[string]string{
+		liveIndex:   label,
+		orphanIndex: label,
+	}
+	authMetaByIndex := map[string]authChannelMeta{
+		liveIndex:   {label: label, provider: "xai", authType: "oauth"},
+		orphanIndex: {label: label, provider: "xai", authType: "oauth"},
+	}
+	authIndexGroup := map[string][]string{
+		liveIndex:   group,
+		orphanIndex: group,
+	}
+
+	// Selecting the live option expands to both historical indexes.
+	authIndexes, channelNames, _ := channelFilterSelectors(
+		[]string{liveIndex},
+		nil,
+		authIndexChannelMap,
+		nil,
+		authMetaByIndex,
+		authIndexGroup,
+	)
+	sort.Strings(authIndexes)
+	want := []string{liveIndex, orphanIndex}
+	sort.Strings(want)
+	if !reflect.DeepEqual(authIndexes, want) {
+		t.Fatalf("live expand authIndexes = %#v, want %#v", authIndexes, want)
+	}
+	if len(channelNames) != 0 {
+		t.Fatalf("channelNames = %#v, want empty", channelNames)
+	}
+
+	// Selecting the orphan index also expands (old clients / deep links).
+	authIndexes, _, _ = channelFilterSelectors(
+		[]string{orphanIndex},
+		nil,
+		authIndexChannelMap,
+		nil,
+		authMetaByIndex,
+		authIndexGroup,
+	)
+	sort.Strings(authIndexes)
+	if !reflect.DeepEqual(authIndexes, want) {
+		t.Fatalf("orphan expand authIndexes = %#v, want %#v", authIndexes, want)
+	}
+}
+
+func TestEnrichChannelFilterOptionsCollapsesXaiOAuthAliases(t *testing.T) {
+	t.Parallel()
+
+	liveIndex := "39a7982984e321e5"
+	orphanIndex := "69e8946f1ffc2d23"
+	label := "asherandersenloqv@outlook.com"
+	group := []string{liveIndex, orphanIndex}
+
+	authIndexChannelMap := map[string]string{
+		liveIndex:   label,
+		orphanIndex: label,
+	}
+	authMetaByIndex := map[string]authChannelMeta{
+		liveIndex:   {label: label, provider: "xai", authType: "oauth"},
+		orphanIndex: {label: label, provider: "xai", authType: "oauth"},
+	}
+	authIndexGroup := map[string][]string{
+		liveIndex:   group,
+		orphanIndex: group,
+	}
+
+	// SQL facet still returns both historical (channel_name, auth_index) pairs.
+	// codex same-email must remain a separate option.
+	codexIndex := "a9757e6dce652490"
+	options := []usage.ChannelFilterOption{
+		{Value: orphanIndex, Label: label, AuthIndex: orphanIndex},
+		{Value: liveIndex, Label: label, AuthIndex: liveIndex},
+		{
+			Value:     codexIndex,
+			Label:     "yuan364299311@gmail.com",
+			AuthIndex: codexIndex,
+			Provider:  "codex",
+			AuthType:  "oauth",
+		},
+	}
+	authIndexChannelMap[codexIndex] = "yuan364299311@gmail.com"
+	authMetaByIndex[codexIndex] = authChannelMeta{
+		label:    "yuan364299311@gmail.com",
+		provider: "codex",
+		authType: "oauth",
+	}
+
+	got := enrichChannelFilterOptions(options, nil, authIndexChannelMap, authMetaByIndex, authIndexGroup)
+
+	var asher *usage.ChannelFilterOption
+	var codex *usage.ChannelFilterOption
+	for i := range got {
+		switch got[i].AuthIndex {
+		case liveIndex, orphanIndex:
+			if asher != nil {
+				t.Fatalf("expected one asher option, got multiple: %#v", got)
+			}
+			asher = &got[i]
+		case codexIndex:
+			codex = &got[i]
+		}
+	}
+	if asher == nil {
+		t.Fatalf("missing merged asher option: %#v", got)
+	}
+	if asher.AuthIndex != liveIndex {
+		t.Fatalf("asher AuthIndex = %s, want live %s", asher.AuthIndex, liveIndex)
+	}
+	if asher.Value != liveIndex {
+		t.Fatalf("asher Value = %s, want live %s", asher.Value, liveIndex)
+	}
+	if asher.Provider != "xai" {
+		t.Fatalf("asher Provider = %q, want xai", asher.Provider)
+	}
+	if asher.AuthType != "oauth" {
+		t.Fatalf("asher AuthType = %q, want oauth", asher.AuthType)
+	}
+	if codex == nil {
+		t.Fatalf("codex option was dropped: %#v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Grok (xAI) OAuth 同一账号会因 `EnsureIndex` seed 在 `id:<file>` / `file:<file>` 间切换，请求日志筛选项出现两条（一条无图标、无 OAuth 标签）。
- 仅对 **xAI/Grok OAuth** 注册历史 `auth_index` 组：UI 折叠为 live index 并补齐 `provider`/`auth_type`；筛选时展开为组内全部 index。
- 同邮箱多 provider（如 codex + xai）仍保持独立选项，不受影响。

## Test plan
- [x] `go test ./internal/management/usagelogs/ -count=1`
- [ ] 部署后：asher 邮箱渠道筛选项应为 1 条，带 Grok 图标 + OAuth
- [ ] 勾选该选项应同时命中 `69e8946f…` 与 `39a79829…` 历史日志
- [ ] yuan 的 codex/xai 等同邮箱多 provider 仍为多条