### PR TITLE
feat: generate governance codes and map permissions to menus

### DIFF
--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -269,7 +269,6 @@ func (h *Handler) GetTenants(c *gin.Context) {
 func (h *Handler) PostTenant(c *gin.Context) {
 	principal, _ := principalFromContext(c)
 	var body struct {
-		Slug             string    `json:"slug"`
 		Name             string    `json:"name"`
 		Description      string    `json:"description"`
 		ExpiresAt        time.Time `json:"expires_at"`
@@ -282,7 +281,7 @@ func (h *Handler) PostTenant(c *gin.Context) {
 		return
 	}
 	tenant, admin, err := h.identity().CreateTenant(c.Request.Context(), principal, identity.CreateTenantInput{
-		Slug: body.Slug, Name: body.Name, Description: body.Description, ExpiresAt: body.ExpiresAt,
+		Name: body.Name, Description: body.Description, ExpiresAt: body.ExpiresAt,
 		AdminUsername: body.AdminUsername, AdminDisplayName: body.AdminDisplayName, AdminPassword: body.AdminPassword,
 	})
 	if err != nil {
@@ -412,7 +411,6 @@ func (h *Handler) GetPermissions(c *gin.Context) {
 func (h *Handler) PostRole(c *gin.Context) {
 	principal, _ := principalFromContext(c)
 	var body struct {
-		Code        string   `json:"code"`
 		Name        string   `json:"name"`
 		Description string   `json:"description"`
 		Permissions []string `json:"permissions"`
@@ -421,7 +419,7 @@ func (h *Handler) PostRole(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	role, err := h.identity().CreateRole(c.Request.Context(), principal, principal.EffectiveTenant.ID, body.Code, body.Name, body.Description, body.Permissions)
+	role, err := h.identity().CreateRole(c.Request.Context(), principal, principal.EffectiveTenant.ID, body.Name, body.Description, body.Permissions)
 	if err != nil {
 		identityError(c, err)
 		return

--- a/internal/identity/permissions.go
+++ b/internal/identity/permissions.go
@@ -6,6 +6,7 @@ type PermissionSeed struct {
 	Scope     string `json:"scope"`
 	Resource  string `json:"resource"`
 	Action    string `json:"action"`
+	MenuCode  string `json:"menu_code"`
 	Sensitive bool   `json:"sensitive"`
 }
 
@@ -65,4 +66,49 @@ var PermissionCatalog = []PermissionSeed{
 	{Code: "proxies.test", Name: "Test proxies", Scope: "tenant", Resource: "proxies", Action: "test", Sensitive: true},
 	{Code: "tenant_settings.read", Name: "Read tenant settings", Scope: "tenant", Resource: "tenant_settings", Action: "read"},
 	{Code: "tenant_settings.write", Name: "Write tenant settings", Scope: "tenant", Resource: "tenant_settings", Action: "write", Sensitive: true},
+}
+
+func menuCodeForPermission(permission PermissionSeed) string {
+	switch permission.Resource {
+	case "tenants", "tenant_profile":
+		return "governance.tenants"
+	case "users":
+		return "governance.users"
+	case "roles":
+		return "governance.roles"
+	case "audit":
+		return "governance.audit"
+	case "menus":
+		return MenuManagementCode
+	case "system":
+		return "runtime.system"
+	case "system_logs":
+		return "runtime.logs"
+	case "system_config", "system_update", "tenant_settings":
+		return "system.config"
+	case "dashboard":
+		return "dashboard"
+	case "monitor":
+		return "runtime.monitor"
+	case "request_logs":
+		return "runtime.request-logs"
+	case "providers":
+		return "access.providers"
+	case "auth_files":
+		return "system.account-security"
+	case "api_keys":
+		return "access.api-keys"
+	case "api_key_profiles":
+		return "system.api-key-permissions"
+	case "models":
+		return "models.catalog"
+	case "image_generation":
+		return "models.image-generation"
+	case "routing":
+		return "models.channel-groups"
+	case "proxies":
+		return "models.proxies"
+	default:
+		return ""
+	}
 }

--- a/internal/identity/postgres_test.go
+++ b/internal/identity/postgres_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,12 +58,15 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tenant, admin, err := service.CreateTenant(ctx, principal, CreateTenantInput{Slug: "tenant-a", Name: "Tenant A", ExpiresAt: time.Now().Add(time.Hour), AdminUsername: "tenant-admin", AdminDisplayName: "Tenant Admin", AdminPassword: "tenant-password-123"})
+	tenant, admin, err := service.CreateTenant(ctx, principal, CreateTenantInput{Name: "Tenant A", ExpiresAt: time.Now().Add(time.Hour), AdminUsername: "tenant-admin", AdminDisplayName: "Tenant Admin", AdminPassword: "tenant-password-123"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if tenant.ID == "" || admin.TenantID != tenant.ID {
 		t.Fatalf("tenant=%+v admin=%+v", tenant, admin)
+	}
+	if !strings.HasPrefix(tenant.Slug, "tenant-") || len(tenant.Slug) != len("tenant-")+32 {
+		t.Fatalf("generated tenant slug = %q", tenant.Slug)
 	}
 	tenantAdminLogin, err := service.Login(ctx, "tenant-admin", "tenant-password-123", false, "test")
 	if err != nil {
@@ -93,13 +97,16 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if tenantAdminRoleID == "" {
 		t.Fatal("tenant admin role not found")
 	}
-	limitedRole, err := service.CreateRole(ctx, tenantAdmin, tenant.ID, "limited_user_manager", "Limited user manager", "", []string{
+	limitedRole, err := service.CreateRole(ctx, tenantAdmin, tenant.ID, "Limited user manager", "", []string{
 		"tenant.users.read",
 		"tenant.users.create",
 		"tenant.users.assign_roles",
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !strings.HasPrefix(limitedRole.Code, "role_") || len(limitedRole.Code) != len("role_")+32 {
+		t.Fatalf("generated role code = %q", limitedRole.Code)
 	}
 	limitedUser, err := service.CreateUser(ctx, tenantAdmin, tenant.ID, "limited-manager", "Limited Manager", "limited-password-123", []string{limitedRole.ID})
 	if err != nil {

--- a/internal/identity/service.go
+++ b/internal/identity/service.go
@@ -70,6 +70,10 @@ func HashPassword(password string) (string, error) {
 	return string(hash), err
 }
 
+func generatedIdentifier(prefix string) string {
+	return prefix + strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
 func validIdentifier(value string, maxLength int, allowAt bool) bool {
 	value = strings.TrimSpace(value)
 	if value == "" || len(value) > maxLength {
@@ -597,8 +601,8 @@ func (s *Service) ListTenants(ctx context.Context) ([]Tenant, error) {
 }
 
 type CreateTenantInput struct {
-	Slug, Name, Description, AdminUsername, AdminDisplayName, AdminPassword string
-	ExpiresAt                                                               time.Time
+	Name, Description, AdminUsername, AdminDisplayName, AdminPassword string
+	ExpiresAt                                                         time.Time
 }
 
 func (s *Service) CreateTenant(ctx context.Context, actor Principal, input CreateTenantInput) (Tenant, User, error) {
@@ -607,11 +611,11 @@ func (s *Service) CreateTenant(ctx context.Context, actor Principal, input Creat
 	if !actor.Has("platform.tenants.create") {
 		return tenant, admin, ErrPermissionDenied
 	}
-	slug := strings.ToLower(strings.TrimSpace(input.Slug))
+	slug := generatedIdentifier("tenant-")
 	name := strings.TrimSpace(input.Name)
 	adminUsername := NormalizeUsername(input.AdminUsername)
 	adminDisplayName := strings.TrimSpace(input.AdminDisplayName)
-	if !validIdentifier(slug, 64, false) || strings.Contains(slug, ".") || strings.Contains(slug, "_") || name == "" || len(name) > 128 || len(strings.TrimSpace(input.Description)) > 1000 || !validIdentifier(adminUsername, 128, true) || adminDisplayName == "" || len(adminDisplayName) > 128 || input.ExpiresAt.IsZero() || !input.ExpiresAt.After(time.Now()) {
+	if name == "" || len(name) > 128 || len(strings.TrimSpace(input.Description)) > 1000 || !validIdentifier(adminUsername, 128, true) || adminDisplayName == "" || len(adminDisplayName) > 128 || input.ExpiresAt.IsZero() || !input.ExpiresAt.After(time.Now()) {
 		return tenant, admin, fmt.Errorf("%w: invalid tenant input", ErrValidation)
 	}
 	passwordHash, err := HashPassword(input.AdminPassword)
@@ -884,19 +888,20 @@ func (s *Service) ListPermissions(ctx context.Context) ([]PermissionSeed, error)
 		if err = rows.Scan(&item.Code, &item.Name, &item.Scope, &item.Resource, &item.Action, &item.Sensitive); err != nil {
 			return nil, err
 		}
+		item.MenuCode = menuCodeForPermission(item)
 		items = append(items, item)
 	}
 	return items, rows.Err()
 }
 
-func (s *Service) CreateRole(ctx context.Context, actor Principal, tenantID, code, name, description string, permissions []string) (Role, error) {
+func (s *Service) CreateRole(ctx context.Context, actor Principal, tenantID, name, description string, permissions []string) (Role, error) {
 	if !actor.Has("tenant.roles.create") && !actor.Has("platform.roles.manage") {
 		return Role{}, ErrPermissionDenied
 	}
 	if err := ensureActorTenantScope(actor, tenantID); err != nil {
 		return Role{}, err
 	}
-	code = strings.ToLower(strings.TrimSpace(code))
+	code := generatedIdentifier("role_")
 	name = strings.TrimSpace(name)
 	description = strings.TrimSpace(description)
 	if !validIdentifier(code, 64, false) || name == "" || len(name) > 128 || len(description) > 1000 {

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -83,6 +84,46 @@ func TestMenuCatalogReferencesExistingParents(t *testing.T) {
 	}
 	if !seen[MenuManagementCode] {
 		t.Fatal("menu management entry is missing")
+	}
+}
+
+func TestGeneratedIdentifier(t *testing.T) {
+	first := generatedIdentifier("tenant-")
+	second := generatedIdentifier("tenant-")
+	if !strings.HasPrefix(first, "tenant-") || len(first) != len("tenant-")+32 || first == second {
+		t.Fatalf("generated identifiers first=%q second=%q", first, second)
+	}
+}
+
+func TestMenuCodeForPermission(t *testing.T) {
+	menuCodes := make(map[string]bool, len(MenuCatalog))
+	for _, menu := range MenuCatalog {
+		menuCodes[menu.Code] = true
+	}
+	tests := map[string]string{
+		"tenant.users.update":   "governance.users",
+		"request_logs.delete":   "runtime.request-logs",
+		"platform.menus.update": MenuManagementCode,
+		"proxies.test":          "models.proxies",
+	}
+	for _, permission := range PermissionCatalog {
+		got := menuCodeForPermission(permission)
+		if got == "" {
+			t.Errorf("permission %s has no menu mapping", permission.Code)
+		} else if !menuCodes[got] {
+			t.Errorf("permission %s references unknown menu %s", permission.Code, got)
+		}
+		want, ok := tests[permission.Code]
+		if !ok {
+			continue
+		}
+		if got != want {
+			t.Errorf("menuCodeForPermission(%s)=%q want %q", permission.Code, got, want)
+		}
+		delete(tests, permission.Code)
+	}
+	if len(tests) != 0 {
+		t.Fatalf("permissions missing from catalog: %v", tests)
 	}
 }
 


### PR DESCRIPTION
## 修改内容

- 租户标识与自定义角色编码改为后端 UUID 自动生成
- 创建租户和角色接口不再接受调用方提供的编码
- 为权限响应补充对应菜单编码，建立目录、页面与按钮权限树关系
- 增加生成编码及权限菜单映射测试

## 安全与一致性

- 编码由后端可信边界生成，数据库唯一约束继续保证最终一致性
- 权限仍是唯一授权事实来源，菜单编码仅用于组织权限树，不新增重复授权模型

## 验证

- `go test ./...`，2737 passed
- `go vet ./...`，通过
