### PR TITLE
fix: update management route table for menu CRUD

### DIFF
--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -25,7 +25,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 258; got != want {
+	if got, want := len(routes), 260; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -108,7 +108,9 @@ func expectedManagementRoutes() []string {
 		"POST /v0/auth/logout",
 		"PUT /v0/auth/password",
 		"GET /v0/management/menus",
+		"POST /v0/management/menus",
 		"PATCH /v0/management/menus/:code",
+		"DELETE /v0/management/menus/:code",
 		"GET /v0/management/permissions",
 		"GET /v0/management/roles",
 		"POST /v0/management/roles",


### PR DESCRIPTION
## Summary
- Add POST/DELETE menu routes to route snapshot
- Bump expected management route count 258 → 260

## Test plan
- [x] `go test ./internal/api/routes/ -run TestRegisterManagementRouteTable`