### PR TITLE
fix: scope models availability to effective tenant auths

### DIFF
--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -207,40 +207,32 @@ func (s *Service) filterModelsByScopes(models []map[string]any, allowedChannelsR
 	if s == nil || s.authManager == nil {
 		return models
 	}
+
+	// Always scope the global registry to models this tenant can actually serve.
+	// Without this, non-system tenants inherit every system-tenant client model
+	// whenever no channel/group restriction is present (the models page default).
+	var allowedChannels map[string]struct{}
 	if allowedChannelsRaw != "" && allowedChannelsRaw != "*" && !strings.EqualFold(allowedChannelsRaw, "all") {
-		allowed := make(map[string]struct{})
+		allowedChannels = make(map[string]struct{})
 		for _, part := range strings.Split(allowedChannelsRaw, ",") {
 			key := strings.ToLower(strings.TrimSpace(part))
 			if key == "" {
 				continue
 			}
-			allowed[key] = struct{}{}
+			allowedChannels[key] = struct{}{}
 		}
-		if len(allowed) == 0 {
-			return models
+		if len(allowedChannels) == 0 {
+			allowedChannels = nil
 		}
-		filtered := make([]map[string]any, 0, len(models))
-		for _, model := range models {
-			id, _ := model["id"].(string)
-			if id == "" {
-				continue
-			}
-			if s.authManager.CanServeModelWithScopesForTenant(s.tenantID, id, allowed, allowedGroups, "") {
-				filtered = append(filtered, model)
-			}
-		}
-		return filtered
 	}
-	if len(allowedGroups) == 0 {
-		return models
-	}
+
 	filtered := make([]map[string]any, 0, len(models))
 	for _, model := range models {
 		id, _ := model["id"].(string)
 		if id == "" {
 			continue
 		}
-		if s.authManager.CanServeModelWithScopesForTenant(s.tenantID, id, nil, allowedGroups, "") {
+		if s.authManager.CanServeModelWithScopesForTenant(s.tenantID, id, allowedChannels, allowedGroups, "") {
 			filtered = append(filtered, model)
 		}
 	}

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -227,3 +227,108 @@ func TestModelSourceEntriesKeepMappedProviderSourceForRetainedRegistryModel(t *t
 		t.Fatalf("sources = %#v, want retained registry model to show mapped provider source", sources)
 	}
 }
+
+func TestConfiguredAvailabilityDoesNotLeakSystemRegistryModelsToOtherTenant(t *testing.T) {
+	const (
+		systemModelID = "tenant-isolation-system-model"
+		tenantModelID = "tenant-isolation-tenant-model"
+		systemAuthID  = "tenant-isolation-system-auth"
+		tenantAuthID  = "tenant-isolation-tenant-auth"
+		tenantID      = "14b1ee9a-6177-4f5f-b5d4-4fba60ad24fa"
+	)
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(systemAuthID)
+	modelRegistry.UnregisterClient(tenantAuthID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(systemAuthID)
+		modelRegistry.UnregisterClient(tenantAuthID)
+	})
+
+	// System tenant clients remain visible in the process-global registry.
+	modelRegistry.RegisterClient(systemAuthID, "codex", []*registry.ModelInfo{
+		{ID: systemModelID, Object: "model", OwnedBy: "openai"},
+	})
+	modelRegistry.RegisterClient(tenantAuthID, "codex", []*registry.ModelInfo{
+		{ID: tenantModelID, Object: "model", OwnedBy: "openai"},
+	})
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       systemAuthID,
+		TenantID: "",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register system auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       tenantAuthID,
+		TenantID: tenantID,
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register tenant auth: %v", err)
+	}
+
+	// Default models page path: no channel/group filters.
+	result := NewForTenant(tenantID, &config.Config{}, manager).ConfiguredAvailability("", "")
+	data, ok := result["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v, want []map[string]any", result["data"])
+	}
+	ids := make(map[string]struct{}, len(data))
+	for _, item := range data {
+		if id, _ := item["id"].(string); id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	if _, ok := ids[tenantModelID]; !ok {
+		t.Fatalf("missing tenant-owned model %q; ids=%v", tenantModelID, ids)
+	}
+	if _, ok := ids[systemModelID]; ok {
+		t.Fatalf("system registry model %q leaked into tenant availability; ids=%v", systemModelID, ids)
+	}
+}
+
+func TestFilterModelsByScopesAlwaysScopesToTenantWithoutChannelFilters(t *testing.T) {
+	const (
+		systemModelID = "filter-scope-system-model"
+		tenantModelID = "filter-scope-tenant-model"
+		systemAuthID  = "filter-scope-system-auth"
+		tenantAuthID  = "filter-scope-tenant-auth"
+		tenantID      = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(systemAuthID)
+	modelRegistry.UnregisterClient(tenantAuthID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(systemAuthID)
+		modelRegistry.UnregisterClient(tenantAuthID)
+	})
+	modelRegistry.RegisterClient(systemAuthID, "codex", []*registry.ModelInfo{{ID: systemModelID}})
+	modelRegistry.RegisterClient(tenantAuthID, "codex", []*registry.ModelInfo{{ID: tenantModelID}})
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: systemAuthID, Provider: "codex", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register system auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: tenantAuthID, TenantID: tenantID, Provider: "codex", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register tenant auth: %v", err)
+	}
+
+	svc := NewForTenant(tenantID, &config.Config{}, manager)
+	models := []map[string]any{
+		{"id": systemModelID},
+		{"id": tenantModelID},
+	}
+	filtered := svc.filterModelsByScopes(models, "", "")
+	if len(filtered) != 1 || filtered[0]["id"] != tenantModelID {
+		t.Fatalf("filtered = %#v, want only tenant model", filtered)
+	}
+}

--- a/internal/management/modelcatalog/path_availability.go
+++ b/internal/management/modelcatalog/path_availability.go
@@ -73,10 +73,13 @@ func (s *Service) modelPathRouteScopedModels(models []map[string]any, routeGroup
 	return filtered
 }
 
-func (s *Service) modelRootRouteScopedModels(models []map[string]any, routingConfig *config.RoutingConfig) []map[string]any {
-	if s == nil || s.authManager == nil || routingConfig == nil || !routingConfig.IncludeDefaultGroup {
+func (s *Service) modelRootRouteScopedModels(models []map[string]any, _ *config.RoutingConfig) []map[string]any {
+	if s == nil || s.authManager == nil {
 		return models
 	}
+	// Always scope root path models to auths owned by the effective tenant.
+	// IncludeDefaultGroup used to skip this filter entirely, which leaked the
+	// process-global registry into non-system tenants (models page + path list).
 	filtered := make([]map[string]any, 0, len(models))
 	for _, model := range models {
 		id := strings.TrimSpace(modelPathStringValue(model["id"]))


### PR DESCRIPTION
## Summary
- Models page (`/manage/models`) loads `/models/configured-availability` without channel/group filters.
- `filterModelsByScopes` previously returned the process-global model registry in that path, so a non-system tenant (e.g. wujin / 无境科技) saw the system admin’s active models (~94).
- Always filter by `CanServeModelWithScopesForTenant`, and apply the same tenant scoping to root path availability.
- Regression tests cover tenant isolation for configured-availability and the unscoped filter path.

## Test plan
- [x] `go test ./internal/management/modelcatalog/ -count=1`
- [x] `go test ./internal/api/handlers/management/ -count=1 -run 'Model|PathAvailability|Configured'`
- [ ] Log in as wujin tenant on relay and confirm `/manage/models` no longer shows system models when the tenant has no own auths/models