### PR TITLE
fix: nest system menus under directory route prefixes

### DIFF
--- a/internal/identity/menus.go
+++ b/internal/identity/menus.go
@@ -62,32 +62,35 @@ type MenuInput struct {
 	Version        int64  `json:"version"`
 }
 
+// MenuCatalog is the system menu seed.
+// Directories carry a route prefix (path) and Layout component so nested children form
+// secondary routes under that prefix (e.g. /runtime/monitor under /runtime).
 var MenuCatalog = []MenuSeed{
 	{Code: "dashboard", Type: "menu", Path: "/dashboard", Component: "dashboard", LabelKey: "shell.nav_dashboard", Icon: "layout-dashboard", PermissionCode: "dashboard.read", SortOrder: 10},
-	{Code: "group.runtime", Type: "directory", LabelKey: "shell.nav_group_runtime", Icon: "activity", SortOrder: 20},
-	{Code: "group.access", Type: "directory", LabelKey: "shell.nav_group_access", Icon: "bot", SortOrder: 30},
-	{Code: "group.models", Type: "directory", LabelKey: "shell.nav_group_models", Icon: "layers", SortOrder: 40},
-	{Code: "group.governance", Type: "directory", LabelKey: "shell.nav_group_governance", Icon: "users-round", SortOrder: 50},
-	{Code: "group.system", Type: "directory", LabelKey: "shell.nav_group_system", Icon: "settings", SortOrder: 60},
-	{Code: "runtime.monitor", ParentCode: "group.runtime", Type: "menu", Path: "/monitor", Component: "monitor", LabelKey: "shell.nav_monitor", Icon: "activity", PermissionCode: "monitor.read", SortOrder: 10},
-	{Code: "runtime.request-logs", ParentCode: "group.runtime", Type: "menu", Path: "/monitor/request-logs", Component: "request-logs", LabelKey: "shell.nav_request_logs", Icon: "scroll-text", PermissionCode: "request_logs.read", SortOrder: 20},
-	{Code: "runtime.logs", ParentCode: "group.runtime", Type: "menu", Path: "/logs", Component: "logs", LabelKey: "shell.nav_logs", Icon: "file-text", PermissionCode: "system.logs.read", SortOrder: 30},
-	{Code: "runtime.system", ParentCode: "group.runtime", Type: "menu", Path: "/system", Component: "system", LabelKey: "shell.nav_system", Icon: "info", PermissionCode: "system.status.read", SortOrder: 40},
-	{Code: "access.providers", ParentCode: "group.access", Type: "menu", Path: "/ai-providers", Component: "providers", LabelKey: "shell.nav_ai_providers", Icon: "bot", PermissionCode: "providers.read", SortOrder: 10},
-	{Code: "access.api-keys", ParentCode: "group.access", Type: "menu", Path: "/api-keys", Component: "api-keys", LabelKey: "shell.nav_api_keys", Icon: "sparkles", PermissionCode: "api_keys.read", SortOrder: 20},
-	{Code: "access.ccswitch", ParentCode: "group.access", Type: "menu", Path: "/ccswitch-import-settings", Component: "ccswitch-import-settings", LabelKey: "shell.nav_ccswitch_import_settings", Icon: "arrow-down-to-line", PermissionCode: "system.config.read", SortOrder: 30},
-	{Code: "models.catalog", ParentCode: "group.models", Type: "menu", Path: "/models", Component: "models", LabelKey: "shell.nav_models", Icon: "cpu", PermissionCode: "models.read", SortOrder: 10},
-	{Code: "models.image-generation", ParentCode: "group.models", Type: "menu", Path: "/image-generation", Component: "image-generation", LabelKey: "shell.nav_image_generation", Icon: "image", PermissionCode: "system.config.read", SortOrder: 20},
-	{Code: "models.channel-groups", ParentCode: "group.models", Type: "menu", Path: "/channel-groups", Component: "channel-groups", LabelKey: "shell.nav_channel_groups", Icon: "layers", PermissionCode: "routing.read", SortOrder: 30},
-	{Code: "models.proxies", ParentCode: "group.models", Type: "menu", Path: "/proxies", Component: "proxies", LabelKey: "shell.nav_proxies", Icon: "network", PermissionCode: "proxies.read", SortOrder: 40},
-	{Code: "governance.tenants", ParentCode: "group.governance", Type: "menu", Path: "/tenants", Component: "tenants", LabelKey: "shell.nav_tenants", Icon: "building-2", PermissionCode: "platform.tenants.read", SortOrder: 10},
-	{Code: "governance.users", ParentCode: "group.governance", Type: "menu", Path: "/users", Component: "users", LabelKey: "shell.nav_users", Icon: "user-round", PermissionCode: "tenant.users.read", SortOrder: 20},
-	{Code: "governance.roles", ParentCode: "group.governance", Type: "menu", Path: "/roles", Component: "roles", LabelKey: "shell.nav_roles", Icon: "shield-check", PermissionCode: "tenant.roles.read", SortOrder: 30},
-	{Code: "governance.audit", ParentCode: "group.governance", Type: "menu", Path: "/audit-logs", Component: "audit-logs", LabelKey: "shell.nav_audit_logs", Icon: "file-text", PermissionCode: "tenant.audit.read", SortOrder: 40},
-	{Code: "system.account-security", ParentCode: "group.system", Type: "menu", Path: "/account-security", Component: "account-security", LabelKey: "shell.nav_account_security", Icon: "shield-check", PermissionCode: "auth_files.read", SortOrder: 10},
-	{Code: "system.api-key-permissions", ParentCode: "group.system", Type: "menu", Path: "/api-key-permissions", Component: "api-key-permissions", LabelKey: "shell.nav_api_key_permissions", Icon: "shield-check", PermissionCode: "api_key_profiles.read", SortOrder: 20},
-	{Code: "system.config", ParentCode: "group.system", Type: "menu", Path: "/config", Component: "config", LabelKey: "shell.nav_config", Icon: "settings", PermissionCode: "system.config.read", SortOrder: 30},
-	{Code: MenuManagementCode, ParentCode: "group.system", Type: "menu", Path: "/menu-management", Component: "menu-management", LabelKey: "shell.nav_menu_management", Icon: "menu", PermissionCode: "platform.menus.read", SortOrder: 40},
+	{Code: "group.runtime", Type: "directory", Path: "/runtime", Component: "Layout", LabelKey: "shell.nav_group_runtime", Icon: "activity", SortOrder: 20},
+	{Code: "group.access", Type: "directory", Path: "/access", Component: "Layout", LabelKey: "shell.nav_group_access", Icon: "bot", SortOrder: 30},
+	{Code: "group.models", Type: "directory", Path: "/models", Component: "Layout", LabelKey: "shell.nav_group_models", Icon: "layers", SortOrder: 40},
+	{Code: "group.governance", Type: "directory", Path: "/governance", Component: "Layout", LabelKey: "shell.nav_group_governance", Icon: "users-round", SortOrder: 50},
+	{Code: "group.system", Type: "directory", Path: "/system", Component: "Layout", LabelKey: "shell.nav_group_system", Icon: "settings", SortOrder: 60},
+	{Code: "runtime.monitor", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/monitor", Component: "monitor", LabelKey: "shell.nav_monitor", Icon: "activity", PermissionCode: "monitor.read", SortOrder: 10},
+	{Code: "runtime.request-logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/request-logs", Component: "request-logs", LabelKey: "shell.nav_request_logs", Icon: "scroll-text", PermissionCode: "request_logs.read", SortOrder: 20},
+	{Code: "runtime.logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/logs", Component: "logs", LabelKey: "shell.nav_logs", Icon: "file-text", PermissionCode: "system.logs.read", SortOrder: 30},
+	{Code: "runtime.system", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/system", Component: "system", LabelKey: "shell.nav_system", Icon: "info", PermissionCode: "system.status.read", SortOrder: 40},
+	{Code: "access.providers", ParentCode: "group.access", Type: "menu", Path: "/access/ai-providers", Component: "providers", LabelKey: "shell.nav_ai_providers", Icon: "bot", PermissionCode: "providers.read", SortOrder: 10},
+	{Code: "access.api-keys", ParentCode: "group.access", Type: "menu", Path: "/access/api-keys", Component: "api-keys", LabelKey: "shell.nav_api_keys", Icon: "sparkles", PermissionCode: "api_keys.read", SortOrder: 20},
+	{Code: "access.ccswitch", ParentCode: "group.access", Type: "menu", Path: "/access/ccswitch-import-settings", Component: "ccswitch-import-settings", LabelKey: "shell.nav_ccswitch_import_settings", Icon: "arrow-down-to-line", PermissionCode: "system.config.read", SortOrder: 30},
+	{Code: "models.catalog", ParentCode: "group.models", Type: "menu", Path: "/models/catalog", Component: "models", LabelKey: "shell.nav_models", Icon: "cpu", PermissionCode: "models.read", SortOrder: 10},
+	{Code: "models.image-generation", ParentCode: "group.models", Type: "menu", Path: "/models/image-generation", Component: "image-generation", LabelKey: "shell.nav_image_generation", Icon: "image", PermissionCode: "system.config.read", SortOrder: 20},
+	{Code: "models.channel-groups", ParentCode: "group.models", Type: "menu", Path: "/models/channel-groups", Component: "channel-groups", LabelKey: "shell.nav_channel_groups", Icon: "layers", PermissionCode: "routing.read", SortOrder: 30},
+	{Code: "models.proxies", ParentCode: "group.models", Type: "menu", Path: "/models/proxies", Component: "proxies", LabelKey: "shell.nav_proxies", Icon: "network", PermissionCode: "proxies.read", SortOrder: 40},
+	{Code: "governance.tenants", ParentCode: "group.governance", Type: "menu", Path: "/governance/tenants", Component: "tenants", LabelKey: "shell.nav_tenants", Icon: "building-2", PermissionCode: "platform.tenants.read", SortOrder: 10},
+	{Code: "governance.users", ParentCode: "group.governance", Type: "menu", Path: "/governance/users", Component: "users", LabelKey: "shell.nav_users", Icon: "user-round", PermissionCode: "tenant.users.read", SortOrder: 20},
+	{Code: "governance.roles", ParentCode: "group.governance", Type: "menu", Path: "/governance/roles", Component: "roles", LabelKey: "shell.nav_roles", Icon: "shield-check", PermissionCode: "tenant.roles.read", SortOrder: 30},
+	{Code: "governance.audit", ParentCode: "group.governance", Type: "menu", Path: "/governance/audit-logs", Component: "audit-logs", LabelKey: "shell.nav_audit_logs", Icon: "file-text", PermissionCode: "tenant.audit.read", SortOrder: 40},
+	{Code: "system.account-security", ParentCode: "group.system", Type: "menu", Path: "/system/account-security", Component: "account-security", LabelKey: "shell.nav_account_security", Icon: "shield-check", PermissionCode: "auth_files.read", SortOrder: 10},
+	{Code: "system.api-key-permissions", ParentCode: "group.system", Type: "menu", Path: "/system/api-key-permissions", Component: "api-key-permissions", LabelKey: "shell.nav_api_key_permissions", Icon: "shield-check", PermissionCode: "api_key_profiles.read", SortOrder: 20},
+	{Code: "system.config", ParentCode: "group.system", Type: "menu", Path: "/system/config", Component: "config", LabelKey: "shell.nav_config", Icon: "settings", PermissionCode: "system.config.read", SortOrder: 30},
+	{Code: MenuManagementCode, ParentCode: "group.system", Type: "menu", Path: "/system/menu-management", Component: "menu-management", LabelKey: "shell.nav_menu_management", Icon: "menu", PermissionCode: "platform.menus.read", SortOrder: 40},
 }
 
 const menuSelectSQL = `SELECT code,parent_code,menu_type,path,component,link_url,label_key,title,icon,permission_code,sort_order,visible,enabled,badge_type,badge_content,hide_menu,system_protected,version FROM menus`
@@ -220,12 +223,24 @@ func normalizeMenuInput(input MenuInput, create bool) (MenuInput, error) {
 	}
 	switch input.Type {
 	case "directory":
-		input.Path = ""
-		input.Component = ""
+		// Directory is a route-prefix node: path is the secondary-route base (e.g. /runtime).
+		// Component defaults to Layout so the admin table shows a real binding, not blank.
+		if input.Path == "" {
+			return MenuInput{}, fmt.Errorf("%w: directory path required", ErrValidation)
+		}
+		if !strings.HasPrefix(input.Path, "/") {
+			return MenuInput{}, fmt.Errorf("%w: path must start with /", ErrValidation)
+		}
+		if input.Component == "" {
+			input.Component = "Layout"
+		}
 		input.LinkURL = ""
 	case "menu":
 		if input.Path == "" {
 			return MenuInput{}, fmt.Errorf("%w: menu path required", ErrValidation)
+		}
+		if !strings.HasPrefix(input.Path, "/") {
+			return MenuInput{}, fmt.Errorf("%w: path must start with /", ErrValidation)
 		}
 	case "button":
 		input.Path = ""
@@ -234,6 +249,9 @@ func normalizeMenuInput(input MenuInput, create bool) (MenuInput, error) {
 	case "embed", "link":
 		if input.Path == "" || input.LinkURL == "" {
 			return MenuInput{}, fmt.Errorf("%w: path and link_url required", ErrValidation)
+		}
+		if !strings.HasPrefix(input.Path, "/") {
+			return MenuInput{}, fmt.Errorf("%w: path must start with /", ErrValidation)
 		}
 		input.Component = ""
 	default:
@@ -259,6 +277,15 @@ func (s *Service) validateMenuRelations(ctx context.Context, input MenuInput, ex
 		}
 		if parent.Type == "button" || parent.Type == "link" {
 			return fmt.Errorf("%w: invalid parent type", ErrValidation)
+		}
+		// Nested page/embed/link under a directory must use a secondary path under the parent prefix.
+		if parent.Type == "directory" && parent.Path != "" &&
+			(input.Type == "menu" || input.Type == "embed" || input.Type == "link") &&
+			input.Path != "" {
+			prefix := strings.TrimRight(parent.Path, "/")
+			if input.Path != prefix && !strings.HasPrefix(input.Path, prefix+"/") {
+				return fmt.Errorf("%w: child path must be nested under parent path %s", ErrValidation, prefix)
+			}
 		}
 		// prevent cycles when reparenting
 		if existingCode != "" {

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -72,17 +72,41 @@ func TestEnsureActorTenantScope(t *testing.T) {
 }
 
 func TestMenuCatalogReferencesExistingParents(t *testing.T) {
-	seen := make(map[string]bool, len(MenuCatalog))
+	seen := make(map[string]MenuSeed, len(MenuCatalog))
 	for _, menu := range MenuCatalog {
-		if menu.Code == "" || seen[menu.Code] {
-			t.Fatalf("invalid or duplicate menu code %q", menu.Code)
+		if menu.Code == "" {
+			t.Fatalf("invalid menu code %q", menu.Code)
 		}
-		if menu.ParentCode != "" && !seen[menu.ParentCode] {
-			t.Fatalf("menu %s references parent %s before it is declared", menu.Code, menu.ParentCode)
+		if _, ok := seen[menu.Code]; ok {
+			t.Fatalf("duplicate menu code %q", menu.Code)
 		}
-		seen[menu.Code] = true
+		if menu.ParentCode != "" {
+			parent, ok := seen[menu.ParentCode]
+			if !ok {
+				t.Fatalf("menu %s references parent %s before it is declared", menu.Code, menu.ParentCode)
+			}
+			// Nested menus under directories must form secondary routes under the parent path.
+			if parent.Type == "directory" && parent.Path != "" && menu.Type == "menu" {
+				prefix := strings.TrimRight(parent.Path, "/")
+				if menu.Path != prefix && !strings.HasPrefix(menu.Path, prefix+"/") {
+					t.Fatalf("menu %s path %q is not nested under parent path %q", menu.Code, menu.Path, prefix)
+				}
+			}
+		}
+		if menu.Type == "directory" {
+			if menu.Path == "" {
+				t.Fatalf("directory %s missing path prefix", menu.Code)
+			}
+			if menu.Component == "" {
+				t.Fatalf("directory %s missing component", menu.Code)
+			}
+		}
+		if menu.Type == "menu" && menu.Path == "" {
+			t.Fatalf("menu %s missing path", menu.Code)
+		}
+		seen[menu.Code] = menu
 	}
-	if !seen[MenuManagementCode] {
+	if _, ok := seen[MenuManagementCode]; !ok {
 		t.Fatal("menu management entry is missing")
 	}
 }


### PR DESCRIPTION
## Summary
- Directory menu seeds now carry route prefixes (`/runtime`, `/access`, `/models`, `/governance`, `/system`) and `Layout` component metadata.
- Child system menus use secondary paths under their parent directory prefix (e.g. `/runtime/monitor`, `/access/ai-providers`).
- Validation requires directory path and enforces nested child paths under the parent prefix.
- Catalog test asserts nested secondary route structure.

## Test plan
- [x] `go test ./internal/identity/ -count=1`
- [ ] Restart CliRelay so `seedMenus` rewrites protected menu paths
- [ ] Open menu management and confirm directory rows show path/component instead of `—`
- [ ] Confirm child menus show nested secondary paths