### PR TITLE
feat: aggregate dashboard throughput for platform admins

### DIFF
--- a/internal/api/handlers/management/dashboard_summary.go
+++ b/internal/api/handlers/management/dashboard_summary.go
@@ -18,9 +18,14 @@ import (
 // the transfer of the full usage / config payloads.
 //
 // GET /v0/management/dashboard-summary?days=7
+//
+// Platform super-admins receive throughput_series aggregated across every
+// tenant (meta.throughput_scope = "all_tenants"); ordinary tenants stay scoped.
 func (h *Handler) GetDashboardSummary(c *gin.Context) {
 	cfg := h.cfg
 	tenantID := effectiveTenantID(c)
+	principal, hasPrincipal := principalFromContext(c)
+	allTenantThroughput := hasPrincipal && principal.PlatformAdmin
 
 	// ── Provider key counts ──
 	geminiCount := 0
@@ -62,6 +67,13 @@ func (h *Handler) GetDashboardSummary(c *gin.Context) {
 
 	kpi, _ := usage.QueryDashboardKPIForTenant(tenantID, days)
 	trends, _ := usage.QueryDashboardTrendsForTenant(tenantID, days)
+	throughputScope := "tenant"
+	if allTenantThroughput {
+		if series, err := usage.QueryDashboardThroughputAcrossTenants(); err == nil {
+			trends.ThroughputSeries = series
+			throughputScope = "all_tenants"
+		}
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"kpi": gin.H{
@@ -89,7 +101,8 @@ func (h *Handler) GetDashboardSummary(c *gin.Context) {
 		},
 		"trends": trends,
 		"meta": gin.H{
-			"generated_at": time.Now().UTC().Format(time.RFC3339),
+			"generated_at":     time.Now().UTC().Format(time.RFC3339),
+			"throughput_scope": throughputScope,
 		},
 		"days": days,
 	})

--- a/internal/api/handlers/management/dashboard_summary_test.go
+++ b/internal/api/handlers/management/dashboard_summary_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -163,5 +164,65 @@ func TestGetDashboardSummaryCountsAPIKeysFromSQLite(t *testing.T) {
 
 	if payload.Counts.APIKeys != 3 {
 		t.Fatalf("counts.api_keys = %d, want 3", payload.Counts.APIKeys)
+	}
+}
+
+func TestGetDashboardSummaryThroughputScopeByPrincipal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{StoreContent: false}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	h := &Handler{cfg: &config.Config{}}
+
+	// Ordinary tenant principal → tenant-scoped throughput.
+	recTenant := httptest.NewRecorder()
+	cTenant, _ := gin.CreateTestContext(recTenant)
+	cTenant.Request = httptest.NewRequest(http.MethodGet, "/dashboard-summary?days=1", nil)
+	cTenant.Set(managementPrincipalKey, identity.Principal{
+		PlatformAdmin:   false,
+		EffectiveTenant: identity.Tenant{ID: "00000000-0000-0000-0000-00000000000a"},
+	})
+	h.GetDashboardSummary(cTenant)
+	if recTenant.Code != http.StatusOK {
+		t.Fatalf("tenant status %d body=%s", recTenant.Code, recTenant.Body.String())
+	}
+	var tenantPayload struct {
+		Meta struct {
+			ThroughputScope string `json:"throughput_scope"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(recTenant.Body.Bytes(), &tenantPayload); err != nil {
+		t.Fatalf("unmarshal tenant: %v", err)
+	}
+	if tenantPayload.Meta.ThroughputScope != "tenant" {
+		t.Fatalf("tenant throughput_scope = %q, want tenant", tenantPayload.Meta.ThroughputScope)
+	}
+
+	// Platform super-admin → all-tenant throughput scope (aggregation covered in usage tests).
+	recAdmin := httptest.NewRecorder()
+	cAdmin, _ := gin.CreateTestContext(recAdmin)
+	cAdmin.Request = httptest.NewRequest(http.MethodGet, "/dashboard-summary?days=1", nil)
+	cAdmin.Set(managementPrincipalKey, identity.Principal{
+		PlatformAdmin:   true,
+		EffectiveTenant: identity.Tenant{ID: "00000000-0000-0000-0000-00000000000a"},
+	})
+	h.GetDashboardSummary(cAdmin)
+	if recAdmin.Code != http.StatusOK {
+		t.Fatalf("admin status %d body=%s", recAdmin.Code, recAdmin.Body.String())
+	}
+	var adminPayload struct {
+		Meta struct {
+			ThroughputScope string `json:"throughput_scope"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(recAdmin.Body.Bytes(), &adminPayload); err != nil {
+		t.Fatalf("unmarshal admin: %v", err)
+	}
+	if adminPayload.Meta.ThroughputScope != "all_tenants" {
+		t.Fatalf("admin throughput_scope = %q, want all_tenants", adminPayload.Meta.ThroughputScope)
 	}
 }

--- a/internal/usage/request_log_dashboard.go
+++ b/internal/usage/request_log_dashboard.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 )
@@ -166,7 +167,7 @@ func QueryDashboardTrendsForTenant(tenantID string, days int) (DashboardTrends, 
 		return DashboardTrends{}, fmt.Errorf("usage: iterate dashboard trends: %w", err)
 	}
 
-	throughputSeries, err := queryDashboardThroughputSeriesAt(tenantID, time.Now(), loc)
+	throughputSeries, err := queryDashboardThroughputSeriesAt(tenantID, time.Now(), loc, false)
 	if err != nil {
 		return DashboardTrends{}, err
 	}
@@ -174,6 +175,12 @@ func QueryDashboardTrendsForTenant(tenantID string, days int) (DashboardTrends, 
 	trends := dashboardTrendsFromBuckets(buckets)
 	trends.ThroughputSeries = throughputSeries
 	return trends, nil
+}
+
+// QueryDashboardThroughputAcrossTenants returns the recent 7 one-minute RPM/TPM
+// buckets aggregated across every tenant. Used by platform super-admins.
+func QueryDashboardThroughputAcrossTenants() ([]DashboardThroughputPoint, error) {
+	return queryDashboardThroughputSeriesAt("", time.Now(), getUsageLocation(), true)
 }
 
 func emptyDashboardTrends(days int) DashboardTrends {
@@ -241,7 +248,7 @@ func buildRecentThroughputBucketsAt(now time.Time, loc *time.Location) []dashboa
 	return buckets
 }
 
-func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.Location) ([]DashboardThroughputPoint, error) {
+func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.Location, allTenants bool) ([]DashboardThroughputPoint, error) {
 	db := getReadDB()
 	if db == nil {
 		return throughputSeriesFromBuckets(buildRecentThroughputBucketsAt(now, loc)), nil
@@ -257,11 +264,25 @@ func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.
 	}
 
 	start := now.In(loc).Truncate(time.Minute).Add(-time.Duration(dashboardThroughputBucketCount-1) * time.Minute)
-	rows, err := db.Query(`
-		SELECT timestamp, total_tokens
-		FROM request_logs
-		WHERE tenant_id = ? AND timestamp >= ?
-	`, normalizeTenantID(tenantID), start.UTC().Format(time.RFC3339))
+	startUTC := start.UTC().Format(time.RFC3339)
+
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if allTenants {
+		rows, err = db.Query(`
+			SELECT timestamp, total_tokens
+			FROM request_logs
+			WHERE timestamp >= ?
+		`, startUTC)
+	} else {
+		rows, err = db.Query(`
+			SELECT timestamp, total_tokens
+			FROM request_logs
+			WHERE tenant_id = ? AND timestamp >= ?
+		`, normalizeTenantID(tenantID), startUTC)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("usage: query dashboard throughput trends: %w", err)
 	}

--- a/internal/usage/request_log_dashboard_tenant_test.go
+++ b/internal/usage/request_log_dashboard_tenant_test.go
@@ -48,4 +48,38 @@ func TestDashboardQueriesAreTenantScoped(t *testing.T) {
 	if kpiB.TotalRequests != 2 || kpiB.TotalTokens != 45 || kpiB.FailedRequests != 1 {
 		t.Fatalf("tenant B KPI = %+v", kpiB)
 	}
+
+	// Per-tenant throughput stays isolated.
+	trendsA, err := QueryDashboardTrendsForTenant(tenantA, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trendsB, err := QueryDashboardTrendsForTenant(tenantB, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rpmA := latestThroughputRPM(trendsA.ThroughputSeries)
+	rpmB := latestThroughputRPM(trendsB.ThroughputSeries)
+	if rpmA != 1 {
+		t.Fatalf("tenant A latest RPM = %.0f, want 1", rpmA)
+	}
+	if rpmB != 2 {
+		t.Fatalf("tenant B latest RPM = %.0f, want 2", rpmB)
+	}
+
+	// Platform super-admin view aggregates every tenant.
+	allSeries, err := QueryDashboardThroughputAcrossTenants()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if latestThroughputRPM(allSeries) != 3 {
+		t.Fatalf("all-tenant latest RPM = %.0f, want 3", latestThroughputRPM(allSeries))
+	}
+}
+
+func latestThroughputRPM(series []DashboardThroughputPoint) float64 {
+	if len(series) == 0 {
+		return 0
+	}
+	return series[len(series)-1].RPM
 }


### PR DESCRIPTION
## Summary
- Platform super-admins get `throughput_series` aggregated across every tenant.
- Response `meta.throughput_scope` is `all_tenants` for platform admins and `tenant` for ordinary users.
- Ordinary tenant KPIs/trends stay effective-tenant scoped; only throughput widens for super-admins.

## Test plan
- [x] `go test ./internal/usage/ -run TestDashboardQueriesAreTenantScoped`
- [x] `go test ./internal/api/handlers/management/ -run TestGetDashboardSummary`