### PR TITLE
fix: make OAuth auth import usable across tenants

### DIFF
--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -383,6 +383,153 @@ func TestResolveTokenForAuth_Claude_SkipsRefreshWhenTokenValid(t *testing.T) {
 	}
 }
 
+func TestResolveTokenForAuth_XAI_RefreshesExpiredToken(t *testing.T) {
+	var callCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
+			t.Fatalf("unexpected content-type: %s", ct)
+		}
+		bodyBytes, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		values, err := url.ParseQuery(string(bodyBytes))
+		if err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if values.Get("grant_type") != "refresh_token" {
+			t.Fatalf("unexpected grant_type: %s", values.Get("grant_type"))
+		}
+		if values.Get("refresh_token") != "xai-refresh" {
+			t.Fatalf("unexpected refresh_token: %s", values.Get("refresh_token"))
+		}
+		if values.Get("client_id") == "" {
+			t.Fatal("expected client_id")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-xai-token",
+			"refresh_token": "xai-refresh-2",
+			"expires_in":    int64(3600),
+			"token_type":    "Bearer",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "xai-test.json",
+		FileName: "xai-test.json",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"type":           "xai",
+			"auth_kind":      "oauth",
+			"access_token":   "old-xai-token",
+			"refresh_token":  "xai-refresh",
+			"token_endpoint": srv.URL,
+			"expired":        time.Now().Add(-time.Hour).Format(time.RFC3339),
+			"email":          "old@example.com",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{cfg: &config.Config{}, authManager: manager}
+	token, err := h.APITools().resolveTokenForAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("resolveTokenForAuth: %v", err)
+	}
+	if token != "new-xai-token" {
+		t.Fatalf("expected refreshed token, got %q", token)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 refresh call, got %d", callCount)
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected auth in manager after update")
+	}
+	if got := tokenValueFromMetadata(updated.Metadata); got != "new-xai-token" {
+		t.Fatalf("expected manager metadata updated, got %q", got)
+	}
+	if updated.Metadata["auth_kind"] != "oauth" {
+		t.Fatalf("auth_kind = %#v", updated.Metadata["auth_kind"])
+	}
+}
+
+func TestResolveTokenForAuth_XAI_SkipsRefreshWhenTokenValid(t *testing.T) {
+	var callCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	auth := &coreauth.Auth{
+		ID:       "xai-valid.json",
+		FileName: "xai-valid.json",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"type":           "xai",
+			"auth_kind":      "oauth",
+			"access_token":   "ok-xai-token",
+			"refresh_token":  "xai-refresh",
+			"token_endpoint": srv.URL,
+			"expired":        time.Now().Add(30 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	h := &Handler{cfg: &config.Config{}}
+	token, err := h.APITools().resolveTokenForAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("resolveTokenForAuth: %v", err)
+	}
+	if token != "ok-xai-token" {
+		t.Fatalf("expected existing token, got %q", token)
+	}
+	if callCount != 0 {
+		t.Fatalf("expected no refresh calls, got %d", callCount)
+	}
+}
+
+func TestResolveTokenForAuth_XAI_APIKeyDoesNotRefresh(t *testing.T) {
+	var callCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	auth := &coreauth.Auth{
+		ID:       "xai-key.json",
+		FileName: "xai-key.json",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"api_key": "xai-api-key-value",
+		},
+		Metadata: map[string]any{
+			"type":      "xai",
+			"auth_kind": "api_key",
+			"api_key":   "xai-api-key-value",
+		},
+	}
+	h := &Handler{cfg: &config.Config{}}
+	token, err := h.APITools().resolveTokenForAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("resolveTokenForAuth: %v", err)
+	}
+	if token != "xai-api-key-value" {
+		t.Fatalf("expected api key, got %q", token)
+	}
+	if callCount != 0 {
+		t.Fatalf("expected no refresh calls, got %d", callCount)
+	}
+}
+
 func TestAPICallReconcilesCodexWhamUsagePlanType(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/management/apitools/token_refresh.go
+++ b/internal/management/apitools/token_refresh.go
@@ -12,6 +12,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	claudeauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/claude"
 	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -56,9 +57,142 @@ func (s *Service) ResolveTokenForAuth(ctx context.Context, auth *coreauth.Auth) 
 		return s.refreshClaudeOAuthAccessToken(ctx, auth)
 	case "kimi":
 		return s.refreshKimiOAuthAccessToken(ctx, auth)
+	case "xai", "x-ai", "grok":
+		return s.refreshXAIOAuthAccessToken(ctx, auth)
 	default:
 		return TokenValueForAuth(auth), nil
 	}
+}
+
+// refreshXAIOAuthAccessToken keeps management api-call / quota probes usable after
+// cross-tenant OAuth file import. Without refresh, expired access tokens surface as
+// "错误 / --" on auth-file cards even when refresh_token is still valid.
+func (s *Service) refreshXAIOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if auth == nil {
+		return "", nil
+	}
+
+	// API-key credentials never go through the OAuth refresh endpoint.
+	if authKind := strings.ToLower(stringValue(auth.Metadata, "auth_kind")); authKind == "api_key" {
+		return TokenValueForAuth(auth), nil
+	}
+	if apiKey := strings.TrimSpace(TokenValueForAuth(auth)); apiKey != "" {
+		if stringValue(auth.Metadata, "refresh_token") == "" && stringValue(auth.Metadata, "access_token") == "" {
+			return apiKey, nil
+		}
+	}
+
+	metadata := auth.Metadata
+	if len(metadata) == 0 {
+		return "", fmt.Errorf("xai oauth metadata missing")
+	}
+
+	current := strings.TrimSpace(TokenValueFromMetadata(metadata))
+	if current != "" && !xaiTokenNeedsRefresh(metadata) {
+		return current, nil
+	}
+
+	refreshToken := stringValue(metadata, "refresh_token")
+	if refreshToken == "" {
+		if current != "" {
+			return current, nil
+		}
+		return "", fmt.Errorf("xai refresh token missing")
+	}
+
+	tokenEndpoint := stringValue(metadata, "token_endpoint")
+	cfg := s.cfg
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	svc := xaiauth.NewXAIAuthWithProxyURL(cfg, auth.ProxyURL)
+	tokenData, errRefresh := svc.RefreshTokens(ctx, refreshToken, tokenEndpoint)
+	if errRefresh != nil {
+		return "", errRefresh
+	}
+	if tokenData == nil || strings.TrimSpace(tokenData.AccessToken) == "" {
+		return "", fmt.Errorf("xai oauth token refresh returned empty access_token")
+	}
+
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	now := time.Now()
+	auth.Metadata["type"] = "xai"
+	auth.Metadata["auth_kind"] = "oauth"
+	auth.Metadata["access_token"] = strings.TrimSpace(tokenData.AccessToken)
+	if strings.TrimSpace(tokenData.RefreshToken) != "" {
+		auth.Metadata["refresh_token"] = strings.TrimSpace(tokenData.RefreshToken)
+	}
+	if strings.TrimSpace(tokenData.IDToken) != "" {
+		auth.Metadata["id_token"] = strings.TrimSpace(tokenData.IDToken)
+	}
+	if strings.TrimSpace(tokenData.TokenType) != "" {
+		auth.Metadata["token_type"] = strings.TrimSpace(tokenData.TokenType)
+	}
+	if tokenData.ExpiresIn > 0 {
+		auth.Metadata["expires_in"] = tokenData.ExpiresIn
+	}
+	if strings.TrimSpace(tokenData.Expire) != "" {
+		auth.Metadata["expired"] = strings.TrimSpace(tokenData.Expire)
+	}
+	if strings.TrimSpace(tokenData.Email) != "" {
+		auth.Metadata["email"] = strings.TrimSpace(tokenData.Email)
+	}
+	if strings.TrimSpace(tokenData.Subject) != "" {
+		auth.Metadata["sub"] = strings.TrimSpace(tokenData.Subject)
+	}
+	if tokenEndpoint != "" {
+		auth.Metadata["token_endpoint"] = tokenEndpoint
+	}
+	if stringValue(auth.Metadata, "base_url") == "" {
+		auth.Metadata["base_url"] = xaiauth.DefaultAPIBaseURL
+	}
+	auth.Metadata["last_refresh"] = now.UTC().Format(time.RFC3339)
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	auth.Attributes["auth_kind"] = "oauth"
+	if strings.TrimSpace(auth.Attributes["base_url"]) == "" {
+		auth.Attributes["base_url"] = xaiauth.DefaultAPIBaseURL
+	}
+	if email := stringValue(auth.Metadata, "email"); email != "" {
+		auth.Attributes["email"] = email
+	}
+
+	if s != nil && s.authManager != nil {
+		auth.LastRefreshedAt = now
+		auth.UpdatedAt = now
+		_, _ = s.authManager.Update(ctx, auth)
+	}
+
+	return strings.TrimSpace(tokenData.AccessToken), nil
+}
+
+func xaiTokenNeedsRefresh(metadata map[string]any) bool {
+	const skew = 30 * time.Second
+	if metadata == nil {
+		return true
+	}
+	for _, key := range []string{"expired", "expiry", "expires_at", "expiresAt"} {
+		if expStr, ok := metadata[key].(string); ok {
+			if ts, errParse := time.Parse(time.RFC3339, strings.TrimSpace(expStr)); errParse == nil {
+				return !ts.After(time.Now().Add(skew))
+			}
+		}
+	}
+	expiresIn := int64Value(metadata["expires_in"])
+	timestampMs := int64Value(metadata["timestamp"])
+	if expiresIn > 0 && timestampMs > 0 {
+		exp := time.UnixMilli(timestampMs).Add(time.Duration(expiresIn) * time.Second)
+		return !exp.After(time.Now().Add(skew))
+	}
+	// No parseable expiry: keep current access_token (same as claude). Refresh only
+	// when the probe fails or metadata explicitly marks the token expired.
+	return false
 }
 
 func (s *Service) refreshClaudeOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {

--- a/internal/management/authfiles/record.go
+++ b/internal/management/authfiles/record.go
@@ -27,11 +27,22 @@ func BuildRecord(opts RecordOptions) *coreauth.Auth {
 	if now.IsZero() {
 		now = time.Now()
 	}
+	// FileName must match FileTokenStore.idFor / readAuthFile so EnsureIndex seeds stay
+	// stable across upload-register and disk-reload paths (tenant-relative IDs included).
 	authID := AuthIDForPath(opts.AuthDir, path)
 	if authID == "" {
 		authID = path
 	}
+	fileName := strings.TrimSpace(authID)
+	if fileName == "" {
+		fileName = filepath.Base(path)
+	}
 	lastRefresh, hasLastRefresh := ExtractLastRefreshTimestamp(opts.Metadata)
+	disabled := MetadataBool(opts.Metadata, "disabled")
+	status := coreauth.StatusActive
+	if disabled {
+		status = coreauth.StatusDisabled
+	}
 	auth := &coreauth.Auth{
 		ID:       authID,
 		TenantID: NormalizeTenantID(opts.TenantID),
@@ -39,16 +50,14 @@ func BuildRecord(opts RecordOptions) *coreauth.Auth {
 		Prefix:   MetadataString(opts.Metadata, "prefix"),
 		ProxyURL: MetadataString(opts.Metadata, "proxy_url", "proxy-url", "proxyUrl"),
 		ProxyID:  MetadataString(opts.Metadata, "proxy_id", "proxy-id", "proxyId"),
-		FileName: filepath.Base(path),
+		FileName: fileName,
 		Label:    ChannelLabelFromMetadata(opts.Metadata, opts.Provider),
-		Status:   coreauth.StatusActive,
-		Attributes: map[string]string{
-			"path":   path,
-			"source": path,
-		},
-		Metadata:  opts.Metadata,
-		CreatedAt: now,
-		UpdatedAt: now,
+		Status:   status,
+		Disabled: disabled,
+		Attributes: buildRecordAttributes(path, opts.Metadata),
+		Metadata:   opts.Metadata,
+		CreatedAt:  now,
+		UpdatedAt:  now,
 	}
 	if hasLastRefresh {
 		auth.LastRefreshedAt = lastRefresh
@@ -62,6 +71,74 @@ func BuildRecord(opts RecordOptions) *coreauth.Auth {
 		auth.Runtime = opts.Existing.Runtime
 	}
 	return auth
+}
+
+// buildRecordAttributes mirrors the attribute surface FileTokenStore and OAuth
+// login flows persist so imported credentials behave like freshly logged-in ones.
+func buildRecordAttributes(path string, metadata map[string]any) map[string]string {
+	attrs := map[string]string{
+		"path":   path,
+		"source": path,
+	}
+	if email := MetadataString(metadata, "email"); email != "" {
+		attrs["email"] = email
+	}
+	if authKind := MetadataString(metadata, "auth_kind", "authKind"); authKind != "" {
+		attrs["auth_kind"] = authKind
+	}
+	if baseURL := MetadataString(metadata, "base_url", "base-url", "baseUrl"); baseURL != "" {
+		attrs["base_url"] = baseURL
+	}
+	if apiKey := MetadataString(metadata, "api_key", "api-key", "apiKey"); apiKey != "" {
+		attrs["api_key"] = apiKey
+	}
+	if usingAPI, ok := MetadataBoolPresence(metadata, "using_api", "using-api", "usingApi"); ok {
+		if usingAPI {
+			attrs["using_api"] = "true"
+		} else {
+			attrs["using_api"] = "false"
+		}
+	}
+	return attrs
+}
+
+func MetadataBool(metadata map[string]any, keys ...string) bool {
+	value, ok := MetadataBoolPresence(metadata, keys...)
+	return ok && value
+}
+
+func MetadataBoolPresence(metadata map[string]any, keys ...string) (bool, bool) {
+	if len(metadata) == 0 {
+		return false, false
+	}
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		raw, ok := metadata[key]
+		if !ok || raw == nil {
+			continue
+		}
+		switch value := raw.(type) {
+		case bool:
+			return value, true
+		case string:
+			trimmed := strings.TrimSpace(strings.ToLower(value))
+			if trimmed == "true" || trimmed == "1" || trimmed == "yes" {
+				return true, true
+			}
+			if trimmed == "false" || trimmed == "0" || trimmed == "no" {
+				return false, true
+			}
+		case float64:
+			return value != 0, true
+		case int:
+			return value != 0, true
+		case int64:
+			return value != 0, true
+		}
+	}
+	return false, false
 }
 
 func ChannelLabelFromMetadata(metadata map[string]any, provider string) string {

--- a/internal/management/authfiles/record_test.go
+++ b/internal/management/authfiles/record_test.go
@@ -126,3 +126,78 @@ func TestChannelLabelFromMetadataFallbacks(t *testing.T) {
 		t.Fatalf("provider fallback = %q, want codex", got)
 	}
 }
+
+func TestBuildRecordXAIImportMapsOAuthAttributes(t *testing.T) {
+	authDir := t.TempDir()
+	tenantDir := filepath.Join(authDir, "tenant-b")
+	if err := os.MkdirAll(tenantDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(tenantDir, "xai-user.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	metadata := map[string]any{
+		"type":          "xai",
+		"email":         "grok@example.com",
+		"auth_kind":     "oauth",
+		"base_url":      "https://api.x.ai/v1",
+		"using_api":     false,
+		"access_token":  "access",
+		"refresh_token": "refresh",
+		"sub":           "principal-1",
+	}
+
+	auth := BuildRecord(RecordOptions{
+		AuthDir:  authDir,
+		TenantID: "tenant-b",
+		Path:     path,
+		Provider: "xai",
+		Metadata: metadata,
+	})
+	if auth == nil {
+		t.Fatal("BuildRecord() = nil")
+	}
+	// FileName must be tenant-relative so EnsureIndex matches disk reload / quota probes.
+	if auth.ID != "tenant-b/xai-user.json" || auth.FileName != "tenant-b/xai-user.json" {
+		t.Fatalf("ID/FileName = %q/%q, want tenant-b/xai-user.json", auth.ID, auth.FileName)
+	}
+	if auth.Disabled {
+		t.Fatal("Disabled = true, want false")
+	}
+	if auth.Attributes["auth_kind"] != "oauth" {
+		t.Fatalf("auth_kind attribute = %q", auth.Attributes["auth_kind"])
+	}
+	if auth.Attributes["base_url"] != "https://api.x.ai/v1" {
+		t.Fatalf("base_url attribute = %q", auth.Attributes["base_url"])
+	}
+	if auth.Attributes["using_api"] != "false" {
+		t.Fatalf("using_api attribute = %q", auth.Attributes["using_api"])
+	}
+	if auth.Attributes["email"] != "grok@example.com" {
+		t.Fatalf("email attribute = %q", auth.Attributes["email"])
+	}
+	if auth.Label != "grok@example.com" {
+		t.Fatalf("Label = %q", auth.Label)
+	}
+}
+
+func TestBuildRecordDisabledStatusFromMetadata(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "disabled.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	auth := BuildRecord(RecordOptions{
+		AuthDir:  authDir,
+		Path:     path,
+		Provider: "claude",
+		Metadata: map[string]any{"disabled": true, "email": "off@example.com"},
+	})
+	if auth == nil {
+		t.Fatal("BuildRecord() = nil")
+	}
+	if !auth.Disabled || auth.Status != coreauth.StatusDisabled {
+		t.Fatalf("disabled/status = %v/%q", auth.Disabled, auth.Status)
+	}
+}

--- a/internal/management/authfiles/register_test.go
+++ b/internal/management/authfiles/register_test.go
@@ -174,3 +174,125 @@ func makeRegisterJWT(t *testing.T, claims map[string]any) string {
 	}
 	return encode(map[string]any{"alg": "none", "typ": "JWT"}) + "." + encode(claims) + ".sig"
 }
+
+func TestRegistrarRegisterFileNormalizesXAIImport(t *testing.T) {
+	authDir := t.TempDir()
+	manager := coreauth.NewManager(nil, nil, nil)
+	// Minimal exported xAI OAuth file (missing auth_kind/base_url/using_api).
+	path := filepath.Join(authDir, "xai-import.json")
+	data, err := json.Marshal(map[string]any{
+		"type":          "xai",
+		"email":         "import@example.com",
+		"access_token":  "access-token",
+		"refresh_token": "refresh-token",
+		"sub":           "sub-import",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err = Registrar{Manager: manager, AuthDir: authDir}.RegisterFile(context.Background(), path, data)
+	if err != nil {
+		t.Fatalf("RegisterFile() error = %v", err)
+	}
+	auth, ok := manager.GetByID("xai-import.json")
+	if !ok || auth == nil {
+		t.Fatal("registered auth not found")
+	}
+	if auth.Provider != "xai" || auth.FileName != "xai-import.json" {
+		t.Fatalf("provider/FileName = %q/%q", auth.Provider, auth.FileName)
+	}
+	if auth.Attributes["auth_kind"] != "oauth" {
+		t.Fatalf("auth_kind = %q, want oauth", auth.Attributes["auth_kind"])
+	}
+	if auth.Attributes["base_url"] != "https://api.x.ai/v1" {
+		t.Fatalf("base_url = %q", auth.Attributes["base_url"])
+	}
+	if auth.Attributes["using_api"] != "false" {
+		t.Fatalf("using_api = %q, want false", auth.Attributes["using_api"])
+	}
+	if auth.Metadata["auth_kind"] != "oauth" {
+		t.Fatalf("metadata auth_kind = %#v", auth.Metadata["auth_kind"])
+	}
+	if auth.Metadata["base_url"] != "https://api.x.ai/v1" {
+		t.Fatalf("metadata base_url = %#v", auth.Metadata["base_url"])
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var persisted map[string]any
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if persisted["auth_kind"] != "oauth" || persisted["base_url"] != "https://api.x.ai/v1" {
+		t.Fatalf("persisted xai fields = %#v", persisted)
+	}
+}
+
+func TestRegistrarRegisterFileNormalizesClaudeAndKimiOAuth(t *testing.T) {
+	authDir := t.TempDir()
+	manager := coreauth.NewManager(nil, nil, nil)
+
+	cases := []struct {
+		name     string
+		file     string
+		provider string
+		payload  map[string]any
+	}{
+		{
+			name:     "claude",
+			file:     "claude-import.json",
+			provider: "claude",
+			payload: map[string]any{
+				"type":          "claude",
+				"email":         "claude@import.example",
+				"access_token":  "claude-access",
+				"refresh_token": "claude-refresh",
+			},
+		},
+		{
+			name:     "kimi",
+			file:     "kimi-import.json",
+			provider: "kimi",
+			payload: map[string]any{
+				"type":          "kimi",
+				"access_token":  "kimi-access",
+				"refresh_token": "kimi-refresh",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(authDir, tc.file)
+			data, err := json.Marshal(tc.payload)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if err := (Registrar{Manager: manager, AuthDir: authDir}).RegisterFile(context.Background(), path, data); err != nil {
+				t.Fatalf("RegisterFile: %v", err)
+			}
+			auth, ok := manager.GetByID(tc.file)
+			if !ok || auth == nil {
+				t.Fatal("auth not found")
+			}
+			if auth.Provider != tc.provider {
+				t.Fatalf("provider = %q, want %q", auth.Provider, tc.provider)
+			}
+			if auth.Attributes["auth_kind"] != "oauth" {
+				t.Fatalf("auth_kind attribute = %q", auth.Attributes["auth_kind"])
+			}
+			if auth.Metadata["auth_kind"] != "oauth" {
+				t.Fatalf("metadata auth_kind = %#v", auth.Metadata["auth_kind"])
+			}
+		})
+	}
+}

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -192,15 +192,15 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		return nil, fmt.Errorf("unmarshal auth json: %w", err)
 	}
 	provider := InferAuthProvider(metadata)
-	if provider == "codex" {
-		normalized := NormalizeAuthMetadata(metadata, provider)
-		if !reflect.DeepEqual(metadata, normalized) {
-			metadata = normalized
-			if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
-				if file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); errOpen == nil {
-					_, _ = file.Write(raw)
-					_ = file.Close()
-				}
+	// Normalize on every disk load so imported OAuth JSON (xai/claude/kimi/gemini/codex)
+	// converges to the same shape as a fresh login after restart or cross-tenant copy.
+	normalized := NormalizeAuthMetadata(metadata, provider)
+	if !reflect.DeepEqual(metadata, normalized) {
+		metadata = normalized
+		if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
+			if file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); errOpen == nil {
+				_, _ = file.Write(raw)
+				_ = file.Close()
 			}
 		}
 	}
@@ -255,17 +255,47 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		Label:            s.labelFor(metadata),
 		Status:           status,
 		Disabled:         disabled,
-		Attributes:       map[string]string{"path": path},
+		Attributes:       buildFileAuthAttributes(path, metadata),
 		Metadata:         metadata,
 		CreatedAt:        info.ModTime(),
 		UpdatedAt:        info.ModTime(),
 		LastRefreshedAt:  time.Time{},
 		NextRefreshAfter: time.Time{},
 	}
-	if email, ok := metadata["email"].(string); ok && email != "" {
-		auth.Attributes["email"] = email
-	}
 	return auth, nil
+}
+
+// buildFileAuthAttributes keeps disk-loaded credentials aligned with OAuth login
+// and management upload registration (auth_kind/base_url/using_api/email).
+func buildFileAuthAttributes(path string, metadata map[string]any) map[string]string {
+	attrs := map[string]string{"path": path}
+	if email := metadataString(metadata, "email"); email != "" {
+		attrs["email"] = email
+	}
+	if authKind := metadataString(metadata, "auth_kind", "authKind"); authKind != "" {
+		attrs["auth_kind"] = authKind
+	}
+	if baseURL := metadataString(metadata, "base_url", "base-url", "baseUrl"); baseURL != "" {
+		attrs["base_url"] = baseURL
+	}
+	if apiKey := metadataString(metadata, "api_key", "api-key", "apiKey"); apiKey != "" {
+		attrs["api_key"] = apiKey
+	}
+	if raw, ok := metadata["using_api"]; ok {
+		switch value := raw.(type) {
+		case bool:
+			if value {
+				attrs["using_api"] = "true"
+			} else {
+				attrs["using_api"] = "false"
+			}
+		case string:
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				attrs["using_api"] = trimmed
+			}
+		}
+	}
+	return attrs
 }
 
 func metadataString(metadata map[string]any, keys ...string) string {
@@ -314,15 +344,151 @@ func isCodexOAuthMetadata(metadata map[string]any) bool {
 
 // NormalizeAuthMetadata fills canonical fields expected by provider executors
 // while preserving any source-specific metadata that may be useful later.
+// Imported OAuth JSON (cross-tenant upload) must produce the same shape as a
+// fresh login, otherwise executors and management quota calls fail silently.
 func NormalizeAuthMetadata(metadata map[string]any, provider string) map[string]any {
 	if len(metadata) == 0 {
 		return metadata
 	}
 	normalized := maps.Clone(metadata)
-	if strings.EqualFold(strings.TrimSpace(provider), "codex") {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "codex":
 		normalizeCodexAuthMetadata(normalized)
+	case "xai", "x-ai", "grok":
+		normalizeXAIAuthMetadata(normalized)
+	case "claude", "anthropic":
+		normalizeClaudeAuthMetadata(normalized)
+	case "kimi":
+		normalizeKimiAuthMetadata(normalized)
+	case "gemini-cli", "gemini", "antigravity":
+		normalizeGeminiFamilyAuthMetadata(normalized, provider)
 	}
 	return normalized
+}
+
+func normalizeXAIAuthMetadata(metadata map[string]any) {
+	if metadata == nil {
+		return
+	}
+	metadata["type"] = "xai"
+	if metadataString(metadata, "auth_kind", "authKind") == "" {
+		// OAuth credential files always carry refresh_token; API-key files use api_key.
+		if metadataString(metadata, "refresh_token", "refreshToken") != "" ||
+			metadataString(metadata, "access_token", "accessToken") != "" {
+			metadata["auth_kind"] = "oauth"
+		} else if metadataString(metadata, "api_key", "apiKey") != "" {
+			metadata["auth_kind"] = "api_key"
+		}
+	} else if kind := metadataString(metadata, "auth_kind", "authKind"); kind != "" {
+		metadata["auth_kind"] = kind
+	}
+	if metadataString(metadata, "base_url", "baseUrl") == "" {
+		metadata["base_url"] = "https://api.x.ai/v1"
+	} else if baseURL := metadataString(metadata, "base_url", "baseUrl"); baseURL != "" {
+		metadata["base_url"] = baseURL
+	}
+	if metadataString(metadata, "token_endpoint", "tokenEndpoint") == "" {
+		metadata["token_endpoint"] = "https://auth.x.ai/oauth2/token"
+	}
+	if email := metadataString(metadata, "email"); email != "" {
+		metadata["email"] = email
+	}
+	if sub := metadataString(metadata, "sub", "subject", "user_id", "userId"); sub != "" {
+		metadata["sub"] = sub
+	}
+	// Prefer JWT claims when local fields are missing or stale after export/import.
+	normalizeXAIMetadataFromJWT(metadataString(metadata, "access_token", "accessToken"), metadata)
+	normalizeXAIMetadataFromJWT(metadataString(metadata, "id_token", "idToken"), metadata)
+	// OAuth credentials default to Grok Build (using_api=false) when unset.
+	if _, ok := metadata["using_api"]; !ok {
+		if strings.EqualFold(metadataString(metadata, "auth_kind"), "oauth") {
+			metadata["using_api"] = false
+		}
+	}
+}
+
+func normalizeXAIMetadataFromJWT(token string, metadata map[string]any) {
+	claims, ok := parseJWTClaimsMap(token)
+	if !ok {
+		return
+	}
+	if metadataString(metadata, "sub") == "" {
+		if sub, ok := claims["sub"].(string); ok && strings.TrimSpace(sub) != "" {
+			metadata["sub"] = strings.TrimSpace(sub)
+		} else if principal, ok := claims["principal_id"].(string); ok && strings.TrimSpace(principal) != "" {
+			metadata["sub"] = strings.TrimSpace(principal)
+		}
+	}
+	if metadataString(metadata, "email") == "" {
+		if email, ok := claims["email"].(string); ok && strings.TrimSpace(email) != "" {
+			metadata["email"] = strings.TrimSpace(email)
+		}
+	}
+	if metadataString(metadata, "expired") == "" {
+		if exp, ok := jwtNumericClaim(claims, "exp"); ok && exp > 0 {
+			metadata["expired"] = time.Unix(exp, 0).UTC().Format(time.RFC3339)
+		}
+	}
+}
+
+func normalizeClaudeAuthMetadata(metadata map[string]any) {
+	if metadata == nil {
+		return
+	}
+	if metadataString(metadata, "type") == "" {
+		metadata["type"] = "claude"
+	}
+	if email := metadataString(metadata, "email"); email != "" {
+		metadata["email"] = email
+	}
+	if metadataString(metadata, "auth_kind", "authKind") == "" {
+		if metadataString(metadata, "refresh_token", "refreshToken") != "" ||
+			metadataString(metadata, "access_token", "accessToken") != "" {
+			metadata["auth_kind"] = "oauth"
+		}
+	}
+}
+
+func normalizeKimiAuthMetadata(metadata map[string]any) {
+	if metadata == nil {
+		return
+	}
+	if metadataString(metadata, "type") == "" {
+		metadata["type"] = "kimi"
+	}
+	if metadataString(metadata, "auth_kind", "authKind") == "" {
+		if metadataString(metadata, "refresh_token", "refreshToken") != "" ||
+			metadataString(metadata, "access_token", "accessToken") != "" {
+			metadata["auth_kind"] = "oauth"
+		}
+	}
+}
+
+func normalizeGeminiFamilyAuthMetadata(metadata map[string]any, provider string) {
+	if metadata == nil {
+		return
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		provider = "gemini"
+	}
+	if metadataString(metadata, "type") == "" {
+		metadata["type"] = provider
+	}
+	if metadataString(metadata, "auth_kind", "authKind") == "" {
+		if metadataString(metadata, "refresh_token", "refreshToken") != "" ||
+			hasNestedRefreshToken(metadata) {
+			metadata["auth_kind"] = "oauth"
+		}
+	}
+}
+
+func hasNestedRefreshToken(metadata map[string]any) bool {
+	tokenRaw, ok := metadata["token"].(map[string]any)
+	if !ok || tokenRaw == nil {
+		return false
+	}
+	return metadataString(tokenRaw, "refresh_token", "refreshToken") != ""
 }
 
 func normalizeCodexAuthMetadata(metadata map[string]any) {

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -220,6 +220,97 @@ func TestFileTokenStoreListNormalizesOpenAIBundleJSONForCodex(t *testing.T) {
 	}
 }
 
+func TestFileTokenStoreListNormalizesXAIImportMetadata(t *testing.T) {
+	dir := t.TempDir()
+	fileName := "xai-import.json"
+	// Simulate a cross-tenant downloaded file missing runtime fields.
+	data, err := json.Marshal(map[string]any{
+		"type":          "xai",
+		"email":         "disk@example.com",
+		"access_token":  "access",
+		"refresh_token": "refresh",
+		"sub":           "sub-disk",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	path := filepath.Join(dir, fileName)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	auth := auths[0]
+	if auth.Provider != "xai" || auth.FileName != fileName {
+		t.Fatalf("provider/FileName = %q/%q", auth.Provider, auth.FileName)
+	}
+	if auth.Attributes["auth_kind"] != "oauth" {
+		t.Fatalf("auth_kind = %q", auth.Attributes["auth_kind"])
+	}
+	if auth.Attributes["base_url"] != "https://api.x.ai/v1" {
+		t.Fatalf("base_url = %q", auth.Attributes["base_url"])
+	}
+	if auth.Attributes["using_api"] != "false" {
+		t.Fatalf("using_api = %q", auth.Attributes["using_api"])
+	}
+	if auth.Metadata["auth_kind"] != "oauth" || auth.Metadata["base_url"] != "https://api.x.ai/v1" {
+		t.Fatalf("metadata = %#v", auth.Metadata)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var persisted map[string]any
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if persisted["auth_kind"] != "oauth" || persisted["type"] != "xai" {
+		t.Fatalf("persisted = %#v", persisted)
+	}
+}
+
+func TestNormalizeAuthMetadataXAIAndClaude(t *testing.T) {
+	t.Parallel()
+	xai := NormalizeAuthMetadata(map[string]any{
+		"type":          "xai",
+		"access_token":  "a",
+		"refresh_token": "r",
+	}, "xai")
+	if xai["auth_kind"] != "oauth" || xai["base_url"] != "https://api.x.ai/v1" {
+		t.Fatalf("xai normalize = %#v", xai)
+	}
+	if xai["using_api"] != false {
+		t.Fatalf("xai using_api = %#v, want false", xai["using_api"])
+	}
+	if xai["token_endpoint"] != "https://auth.x.ai/oauth2/token" {
+		t.Fatalf("token_endpoint = %#v", xai["token_endpoint"])
+	}
+
+	claude := NormalizeAuthMetadata(map[string]any{
+		"access_token":  "a",
+		"refresh_token": "r",
+		"email":         "c@example.com",
+	}, "claude")
+	if claude["type"] != "claude" || claude["auth_kind"] != "oauth" {
+		t.Fatalf("claude normalize = %#v", claude)
+	}
+
+	kimi := NormalizeAuthMetadata(map[string]any{
+		"refresh_token": "r",
+	}, "kimi")
+	if kimi["type"] != "kimi" || kimi["auth_kind"] != "oauth" {
+		t.Fatalf("kimi normalize = %#v", kimi)
+	}
+}
+
 func TestFileTokenStoreSavePersistsRoutingMetadata(t *testing.T) {
 	dir := t.TempDir()
 	fileName := "claude-pro.json"


### PR DESCRIPTION
## Summary
- Normalize imported OAuth metadata/attributes on upload and disk reload (xAI, Claude, Kimi, Gemini family, Codex).
- Keep `FileName` / auth_index stable under tenant-relative paths so quota probes and management lookups match after import.
- Refresh xAI OAuth tokens in management `api-call` so cross-tenant imported Grok credentials no longer show as unusable error cards.

## Test plan
- [x] `go test ./internal/management/authfiles/ ./sdk/auth/ ./internal/api/handlers/management/ -count=1`
- [ ] Import a downloaded xAI OAuth file into another tenant and confirm quota/status loads
- [ ] Spot-check Claude/Kimi/Codex import still registers and works