### PR TITLE
fix: accept cps_ session tokens on system-stats WebSocket

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -221,36 +221,12 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		c.Header("X-CPA-UI-VERSION", currentUIVersion)
 		c.Header("X-CPA-UI-COMMIT", currentUICommit)
 
-		if token := bearerToken(c); strings.HasPrefix(token, "cps_") {
-			service := h.identity()
-			if service == nil {
-				c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{"code": "identity_unavailable", "message": "identity service unavailable"}})
-				return
-			}
-			principal, err := service.Authenticate(c.Request.Context(), token, c.GetHeader("X-Effective-Tenant-ID"))
-			if err != nil {
-				identityError(c, err)
-				return
-			}
-			if principal.User.MustChangePassword {
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "password_change_required", "message": "password change required"}})
-				return
-			}
-			permission := permissionForManagementRequest(c.Request.Method, c.Request.URL.Path)
-			if permission == "" || !principal.Has(permission) {
-				h.recordManagementAudit(c, principal, "denied")
-				identityError(c, identity.ErrPermissionDenied)
-				return
-			}
-			// Some runtime/config stores remain process-global. Non-system tenants may
-			// only use routes whose complete repository and scheduler paths are tenant-scoped.
-			if principal.EffectiveTenant.ID != identity.SystemTenantID && !isTenantScopedManagementPath(c.Request.URL.Path) {
-				h.recordManagementAudit(c, principal, "denied")
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "tenant_resource_scope_unavailable", "message": "tenant business resources are not enabled for this tenant"}})
-				return
-			}
-			c.Set(managementPrincipalKey, principal)
-			h.nextWithManagementAudit(c)
+		// Session tokens (cps_*) come from Authorization: Bearer on normal HTTP, or from
+		// ?token= on the system-stats WebSocket handshake (browsers cannot set WS headers).
+		// Resolve the session token before falling through to management-key auth so a
+		// valid user session is never bcrypt-compared against the remote management secret.
+		if token := resolveSessionToken(c); strings.HasPrefix(token, "cps_") {
+			_ = h.authenticateSessionToken(c, token)
 			return
 		}
 
@@ -341,8 +317,12 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		}
 		// Fallback: ?token= query param is accepted only for WebSocket handshakes;
 		// normal HTTP requests must not carry credentials in URLs.
+		// Session tokens (cps_*) were already handled above; remaining query tokens are
+		// treated as management keys (legacy panel / service credential).
 		if provided == "" && shouldReadManagementTokenFromQuery(c) {
-			provided = c.Query("token")
+			if queryToken := strings.TrimSpace(c.Query("token")); !strings.HasPrefix(queryToken, "cps_") {
+				provided = queryToken
+			}
 		}
 
 		if provided == "" {
@@ -393,6 +373,56 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 
 		h.nextWithManagementAudit(c)
 	}
+}
+
+// resolveSessionToken returns a user-session token for management auth.
+// Prefer Authorization Bearer; for WebSocket handshakes only, also accept ?token=cps_*.
+func resolveSessionToken(c *gin.Context) string {
+	if token := bearerToken(c); strings.HasPrefix(token, "cps_") {
+		return token
+	}
+	if !shouldReadManagementTokenFromQuery(c) {
+		return ""
+	}
+	if token := strings.TrimSpace(c.Query("token")); strings.HasPrefix(token, "cps_") {
+		return token
+	}
+	return ""
+}
+
+// authenticateSessionToken validates a cps_* identity session and enforces RBAC + tenant scope.
+// Returns false when the request was already aborted with an error response.
+func (h *Handler) authenticateSessionToken(c *gin.Context, token string) bool {
+	service := h.identity()
+	if service == nil {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{"code": "identity_unavailable", "message": "identity service unavailable"}})
+		return false
+	}
+	principal, err := service.Authenticate(c.Request.Context(), token, c.GetHeader("X-Effective-Tenant-ID"))
+	if err != nil {
+		identityError(c, err)
+		return false
+	}
+	if principal.User.MustChangePassword {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "password_change_required", "message": "password change required"}})
+		return false
+	}
+	permission := permissionForManagementRequest(c.Request.Method, c.Request.URL.Path)
+	if permission == "" || !principal.Has(permission) {
+		h.recordManagementAudit(c, principal, "denied")
+		identityError(c, identity.ErrPermissionDenied)
+		return false
+	}
+	// Some runtime/config stores remain process-global. Non-system tenants may
+	// only use routes whose complete repository and scheduler paths are tenant-scoped.
+	if principal.EffectiveTenant.ID != identity.SystemTenantID && !isTenantScopedManagementPath(c.Request.URL.Path) {
+		h.recordManagementAudit(c, principal, "denied")
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "tenant_resource_scope_unavailable", "message": "tenant business resources are not enabled for this tenant"}})
+		return false
+	}
+	c.Set(managementPrincipalKey, principal)
+	h.nextWithManagementAudit(c)
+	return true
 }
 
 // persist saves the current in-memory config to disk.

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -172,3 +172,112 @@ func TestMiddlewareAllowsQueryTokenOnlyForSystemStatsWebSocket(t *testing.T) {
 		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
 	}
 }
+
+func TestMiddlewareRoutesQuerySessionTokenForSystemStatsWebSocket(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const managementKey = "correct-management-key"
+	hashed, err := bcrypt.GenerateFromPassword([]byte(managementKey), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash test management key: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		RemoteManagement: config.RemoteManagement{
+			AllowRemote: true,
+			SecretKey:   string(hashed),
+		},
+	}, nil)
+	defer h.Close()
+
+	router := gin.New()
+	router.Use(h.Middleware())
+	router.GET("/v0/management/system-stats/ws", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	// cps_* query tokens must enter the identity-session path, not bcrypt management-key
+	// comparison. Without an identity service this surfaces as identity_unavailable (503),
+	// not invalid management key (401).
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/system-stats/ws?token=cps_test-session-token", nil)
+	req.RemoteAddr = "203.0.113.22:4321"
+	req.Header.Set("Upgrade", "websocket")
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "identity_unavailable") {
+		t.Fatalf("expected session-token routing into identity auth, got body=%s", rr.Body.String())
+	}
+}
+
+func TestMiddlewareIgnoresQuerySessionTokenOnNormalHTTP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const managementKey = "correct-management-key"
+	hashed, err := bcrypt.GenerateFromPassword([]byte(managementKey), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash test management key: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		RemoteManagement: config.RemoteManagement{
+			AllowRemote: true,
+			SecretKey:   string(hashed),
+		},
+	}, nil)
+	defer h.Close()
+
+	router := gin.New()
+	router.Use(h.Middleware())
+	router.GET("/v0/management/system-stats", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/system-stats?token=cps_test-session-token", nil)
+	req.RemoteAddr = "203.0.113.23:4321"
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusUnauthorized, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "missing management key") {
+		t.Fatalf("expected query session token ignored on normal HTTP, got body=%s", rr.Body.String())
+	}
+}
+
+func TestResolveSessionToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("bearer session token", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/system-stats", nil)
+		c.Request.Header.Set("Authorization", "Bearer cps_from_header")
+		if got := resolveSessionToken(c); got != "cps_from_header" {
+			t.Fatalf("resolveSessionToken = %q, want cps_from_header", got)
+		}
+	})
+
+	t.Run("websocket query session token", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/system-stats/ws?token=cps_from_query", nil)
+		c.Request.Header.Set("Upgrade", "websocket")
+		c.Params = nil
+		// FullPath is empty in unit tests; shouldReadManagementTokenFromQuery falls back to URL.Path.
+		if got := resolveSessionToken(c); got != "cps_from_query" {
+			t.Fatalf("resolveSessionToken = %q, want cps_from_query", got)
+		}
+	})
+
+	t.Run("non-session query token ignored for session resolution", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/system-stats/ws?token=mgmt-key", nil)
+		c.Request.Header.Set("Upgrade", "websocket")
+		if got := resolveSessionToken(c); got != "" {
+			t.Fatalf("resolveSessionToken = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Dashboard `system-stats/ws` put user session tokens (`cps_*`) in the query string because browsers cannot set WebSocket Authorization headers.
- Management middleware only recognized `cps_*` from Bearer, then bcrypt-compared the query token as a management key → continuous 401/403 reconnect storms.
- Resolve session tokens from Bearer **or** WebSocket `?token=cps_*`, then enforce the same RBAC + tenant-scope checks.
- Non-session query tokens still work as management keys for legacy clients.

## Test plan
- [x] `go test ./internal/api/handlers/management/ ./internal/api/routes/ -count=1`
- [ ] Open `/manage/dashboard` as `admin` with a `cps_` session; WS should connect without 401 loop
- [ ] Tenant admin without `system.status.read` still gets 403 (no infinite storm once frontend halt lands)

## Related
Pairs with codeProxy PR that stops 401/403 reconnect/quota auto-refresh storms.