### PR TITLE
fix: allow tenant auth-file quota probes via /api-call

### DIFF
--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -542,6 +542,12 @@ func isTenantScopedManagementPath(path string) bool {
 		relative == "/proxy-pool",
 		strings.HasPrefix(relative, "/proxy-pool/"):
 		return true
+	// Tenant auth-file quota/connectivity probes use /api-call with a
+	// tenant-scoped auth_index (AuthByIndex + ListForTenant). Blocking this
+	// path leaves imported OAuth cards stuck on "错误 / --" even when the
+	// credential file itself is valid.
+	case relative == "/api-call":
+		return true
 	case relative == "/usage/logs",
 		(strings.HasSuffix(relative, "/content") || strings.HasSuffix(relative, "/egress")) && strings.HasPrefix(relative, "/usage/logs/"),
 		relative == "/usage/chart-data",

--- a/internal/api/handlers/management/tenant_scope_gate_test.go
+++ b/internal/api/handlers/management/tenant_scope_gate_test.go
@@ -15,6 +15,8 @@ func TestTenantScopedManagementPathIncludesProviderRuntimeRoutes(t *testing.T) {
 		"/v0/management/openai-compatibility",
 		"/v0/management/oauth-model-alias",
 		"/v0/management/codex-oauth-admission",
+		// Auth-file quota preview for tenant-imported OAuth credentials.
+		"/v0/management/api-call",
 	} {
 		if !isTenantScopedManagementPath(path) {
 			t.Errorf("isTenantScopedManagementPath(%q) = false", path)
@@ -26,7 +28,6 @@ func TestTenantScopedManagementPathKeepsGlobalRuntimeRoutesBlocked(t *testing.T)
 	for _, path := range []string{
 		"/v0/management/config.yaml",
 		"/v0/management/oauth-excluded-models",
-		"/v0/management/api-call",
 		"/v0/management/proxy-url",
 		"/v0/management/request-retry",
 		"/v0/management/update/apply",


### PR DESCRIPTION
## Summary
- Root cause: non-system tenants hit `tenant_resource_scope_unavailable` on `POST /v0/management/api-call`, so auth-files quota preview (xAI billing and other OAuth probes) always failed after import.
- Fix: mark `/api-call` as a tenant-scoped management path. Auth lookup remains tenant-isolated via `AuthByIndex` + `ListForTenant`.
- Update gate tests so `/api-call` is allowed for tenants while global runtime routes stay blocked.

## Test plan
- [x] `go test ./internal/api/handlers/management/ -count=1`
- [x] `go test ./internal/api/handlers/management/ -count=1 -run 'TenantScoped|PermissionFor|Identity'`
- [ ] After merge/deploy: in tenant **蹬的飞快**, open AI accounts and refresh quota for the imported xAI cards; error badge should clear and weekly/monthly bars should render.