### PR TITLE
fix: inherit system model pricing for business tenants

### DIFF
--- a/internal/usage/model_config_db.go
+++ b/internal/usage/model_config_db.go
@@ -73,14 +73,68 @@ func upsertLegacyPricingIntoModelConfigForTenant(db *sql.DB, tenantID, modelID s
 }
 
 func ListModelConfigs() []ModelConfigRow { return ListModelConfigsForTenant(systemTenantID) }
+
+// ListModelConfigsForTenant returns tenant model configs with system-catalog inheritance.
+// Business tenants inherit the system tenant's OpenRouter/seed catalog; tenant-owned rows override by model_id.
 func ListModelConfigsForTenant(tenantID string) []ModelConfigRow {
-	return modelConfigStoreForTenant(tenantID).ListModelConfigs()
+	tenantID = normalizeTenantID(tenantID)
+	tenantRows := modelConfigStoreForTenant(tenantID).ListModelConfigs()
+	if isSystemTenant(tenantID) {
+		return tenantRows
+	}
+
+	systemRows := modelConfigStoreForTenant(systemTenantID).ListModelConfigs()
+	if len(systemRows) == 0 {
+		return tenantRows
+	}
+	if len(tenantRows) == 0 {
+		return systemRows
+	}
+
+	// Tenant overrides win for the same model_id (case-insensitive).
+	merged := make([]ModelConfigRow, 0, len(systemRows)+len(tenantRows))
+	indexByID := make(map[string]int, len(systemRows)+len(tenantRows))
+	for _, row := range systemRows {
+		key := strings.ToLower(strings.TrimSpace(row.ModelID))
+		if key == "" {
+			continue
+		}
+		indexByID[key] = len(merged)
+		merged = append(merged, row)
+	}
+	for _, row := range tenantRows {
+		key := strings.ToLower(strings.TrimSpace(row.ModelID))
+		if key == "" {
+			continue
+		}
+		if idx, ok := indexByID[key]; ok {
+			merged[idx] = row
+			continue
+		}
+		indexByID[key] = len(merged)
+		merged = append(merged, row)
+	}
+	return merged
 }
+
 func GetModelConfig(modelID string) (ModelConfigRow, bool) {
 	return GetModelConfigForTenant(systemTenantID, modelID)
 }
+
+// GetModelConfigForTenant returns the tenant's model config, falling back to the system catalog.
 func GetModelConfigForTenant(tenantID, modelID string) (ModelConfigRow, bool) {
-	return modelConfigStoreForTenant(tenantID).GetModelConfig(modelID)
+	tenantID = normalizeTenantID(tenantID)
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return ModelConfigRow{}, false
+	}
+	if row, ok := modelConfigStoreForTenant(tenantID).GetModelConfig(modelID); ok {
+		return row, true
+	}
+	if isSystemTenant(tenantID) {
+		return ModelConfigRow{}, false
+	}
+	return modelConfigStoreForTenant(systemTenantID).GetModelConfig(modelID)
 }
 
 func UpsertModelConfig(row ModelConfigRow) error {

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -218,10 +218,24 @@ func UpsertModelPricingV2ForTenant(tenantID, modelID string, input, output, cach
 func GetModelPricing(modelID string) (ModelPricingRow, bool) {
 	return GetModelPricingForTenant(systemTenantID, modelID)
 }
+
+// GetModelPricingForTenant returns tenant pricing, falling back to the system catalog when absent.
+// OpenRouter sync writes prices to the system tenant; business tenants inherit them unless overridden.
 func GetModelPricingForTenant(tenantID, modelID string) (ModelPricingRow, bool) {
+	tenantID = normalizeTenantID(tenantID)
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return ModelPricingRow{}, false
+	}
 	pricingCacheMu.RLock()
 	defer pricingCacheMu.RUnlock()
-	row, ok := pricingCache[normalizeTenantID(tenantID)][modelID]
+	if row, ok := pricingCache[tenantID][modelID]; ok {
+		return row, true
+	}
+	if isSystemTenant(tenantID) {
+		return ModelPricingRow{}, false
+	}
+	row, ok := pricingCache[systemTenantID][modelID]
 	return row, ok
 }
 
@@ -229,12 +243,29 @@ func GetModelPricingForTenant(tenantID, modelID string) (ModelPricingRow, bool) 
 func GetAllModelPricing() map[string]ModelPricingRow {
 	return GetAllModelPricingForTenant(systemTenantID)
 }
+
+// GetAllModelPricingForTenant returns tenant pricing merged with system-catalog inheritance.
+// Tenant-owned rows override system rows for the same model_id.
 func GetAllModelPricingForTenant(tenantID string) map[string]ModelPricingRow {
+	tenantID = normalizeTenantID(tenantID)
 	pricingCacheMu.RLock()
 	defer pricingCacheMu.RUnlock()
-	cache := pricingCache[normalizeTenantID(tenantID)]
-	result := make(map[string]ModelPricingRow, len(cache))
-	for k, v := range cache {
+
+	tenantCache := pricingCache[tenantID]
+	if isSystemTenant(tenantID) {
+		result := make(map[string]ModelPricingRow, len(tenantCache))
+		for k, v := range tenantCache {
+			result[k] = v
+		}
+		return result
+	}
+
+	systemCache := pricingCache[systemTenantID]
+	result := make(map[string]ModelPricingRow, len(systemCache)+len(tenantCache))
+	for k, v := range systemCache {
+		result[k] = v
+	}
+	for k, v := range tenantCache {
 		result[k] = v
 	}
 	return result
@@ -324,15 +355,14 @@ func calculateTokenCostV2(inputTokens, outputTokens, cacheReadTokens, cacheWrite
 // resolveModelPricing returns the effective pricing for a model from either
 // ModelConfigRow cache or ModelPricingRow cache, along with a boolean indicating
 // whether the model is enabled (or found at all).
+// Both lookups inherit system-tenant catalog prices when the business tenant has no override.
 func resolveModelPricingForTenant(tenantID, modelID string) (inputPrice, outputPrice, cachedPrice, cacheReadPrice, cacheWritePrice float64, enabled bool) {
 	if row, ok := GetModelConfigForTenant(tenantID, modelID); ok {
 		enabled = row.Enabled
 		return row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion, row.CacheReadPricePerMillion, row.CacheWritePricePerMillion, enabled
 	}
 
-	pricingCacheMu.RLock()
-	row, ok := pricingCache[normalizeTenantID(tenantID)][modelID]
-	pricingCacheMu.RUnlock()
+	row, ok := GetModelPricingForTenant(tenantID, modelID)
 	if !ok {
 		return 0, 0, 0, 0, 0, false
 	}
@@ -356,9 +386,7 @@ func CalculateCostForTenant(tenantID, modelID string, inputTokens, outputTokens,
 		return calculateTokenCost(inputTokens, outputTokens, cachedTokens, row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion)
 	}
 
-	pricingCacheMu.RLock()
-	row, ok := pricingCache[normalizeTenantID(tenantID)][modelID]
-	pricingCacheMu.RUnlock()
+	row, ok := GetModelPricingForTenant(tenantID, modelID)
 	if !ok {
 		return 0
 	}

--- a/internal/usage/tenant_catalog_inherit_test.go
+++ b/internal/usage/tenant_catalog_inherit_test.go
@@ -1,0 +1,127 @@
+package usage
+
+import (
+	"math"
+	"testing"
+)
+
+const businessTenantID = "00000000-0000-0000-0000-0000000000aa"
+
+func TestListModelConfigsForTenantInheritsSystemCatalog(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfigForTenant(systemTenantID, ModelConfigRow{
+		ModelID:               "openrouter-inherited",
+		OwnedBy:               "openrouter",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  1.5,
+		OutputPricePerMillion: 6,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant(system) error = %v", err)
+	}
+
+	rows := ListModelConfigsForTenant(businessTenantID)
+	var found ModelConfigRow
+	var ok bool
+	for _, row := range rows {
+		if row.ModelID == "openrouter-inherited" {
+			found = row
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		t.Fatal("expected business tenant to inherit system model config")
+	}
+	if found.InputPricePerMillion != 1.5 || found.OutputPricePerMillion != 6 {
+		t.Fatalf("inherited pricing = %+v", found)
+	}
+	if found.Source != "openrouter" {
+		t.Fatalf("inherited source = %q", found.Source)
+	}
+}
+
+func TestGetModelConfigForTenantPrefersTenantOverride(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfigForTenant(systemTenantID, ModelConfigRow{
+		ModelID:               "override-me",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  1,
+		OutputPricePerMillion: 2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("system upsert: %v", err)
+	}
+	if err := UpsertModelConfigForTenant(businessTenantID, ModelConfigRow{
+		ModelID:               "override-me",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  9,
+		OutputPricePerMillion: 18,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("tenant upsert: %v", err)
+	}
+
+	row, ok := GetModelConfigForTenant(businessTenantID, "override-me")
+	if !ok {
+		t.Fatal("expected tenant override")
+	}
+	if row.InputPricePerMillion != 9 || row.Source != "user" {
+		t.Fatalf("got %+v, want tenant override", row)
+	}
+}
+
+func TestGetAllModelPricingForTenantInheritsSystem(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelPricingV2ForTenant(systemTenantID, "priced-system", 2, 4, 0.5, 0.25, 0.75); err != nil {
+		t.Fatalf("system pricing upsert: %v", err)
+	}
+	if err := UpsertModelPricingV2ForTenant(businessTenantID, "priced-tenant", 3, 6, 0, 0, 0); err != nil {
+		t.Fatalf("tenant pricing upsert: %v", err)
+	}
+
+	all := GetAllModelPricingForTenant(businessTenantID)
+	if _, ok := all["priced-system"]; !ok {
+		t.Fatal("expected inherited system pricing")
+	}
+	if _, ok := all["priced-tenant"]; !ok {
+		t.Fatal("expected tenant-owned pricing")
+	}
+
+	// Tenant override wins over system for same model id.
+	if err := UpsertModelPricingV2ForTenant(systemTenantID, "priced-tenant", 1, 1, 0, 0, 0); err != nil {
+		t.Fatalf("system conflict upsert: %v", err)
+	}
+	all = GetAllModelPricingForTenant(businessTenantID)
+	if got := all["priced-tenant"].InputPricePerMillion; got != 3 {
+		t.Fatalf("tenant override lost: input=%v", got)
+	}
+}
+
+func TestCalculateCostForTenantUsesSystemPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfigForTenant(systemTenantID, ModelConfigRow{
+		ModelID:               "cost-inherit",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  10,
+		OutputPricePerMillion: 20,
+		CachedPricePerMillion: 1,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("system upsert: %v", err)
+	}
+
+	cost := CalculateCostForTenant(businessTenantID, "cost-inherit", 1000, 500, 0)
+	want := (float64(1000)*10 + float64(500)*20) / 1_000_000
+	if math.Abs(cost-want) > 1e-12 {
+		t.Fatalf("cost = %v, want %v", cost, want)
+	}
+}

--- a/internal/usage/tenant_scope.go
+++ b/internal/usage/tenant_scope.go
@@ -11,3 +11,9 @@ func normalizeTenantID(tenantID string) string {
 	}
 	return tenantID
 }
+
+// isSystemTenant reports whether tenantID resolves to the shared system catalog tenant.
+// OpenRouter pricing/model metadata is written there and inherited by business tenants on read.
+func isSystemTenant(tenantID string) bool {
+	return normalizeTenantID(tenantID) == systemTenantID
+}


### PR DESCRIPTION
## Summary
- OpenRouter 同步只写入系统租户的 `model_configs` / `model_pricing`，业务租户读路径此前严格按 `tenant_id` 过滤，导致模型页全部显示「未定价」。
- 读路径改为：业务租户继承系统目录，同 `model_id` 时租户自有行覆盖。
- 覆盖 `List/GetModelConfig`、`Get/GetAllModelPricing`、计费 `CalculateCost*`。

## Test plan
- [x] `go test ./internal/usage/ -run 'TestListModelConfigsForTenantInheritsSystemCatalog|TestGetModelConfigForTenantPrefersTenantOverride|TestGetAllModelPricingForTenantInheritsSystem|TestCalculateCostForTenantUsesSystemPricing'`
- [x] `go test ./internal/usage/ ./internal/management/settings/modelconfig/ ./internal/api/handlers/management/`
- [ ] 部署后业务租户「蹬的飞快」模型页应显示系统已同步价格，不再全部未定价