### PR TITLE
fix: always store compact error detail for failed request logs

### DIFF
--- a/internal/usage/log_content_store.go
+++ b/internal/usage/log_content_store.go
@@ -260,16 +260,23 @@ func refreshRequestLogContentBytes(q logContentQuerier) {
 }
 
 func insertLogContentTx(tx *sql.Tx, logID int64, timestamp time.Time, inputContent, outputContent, detailContent string) error {
-	return insertLogContentTenantTx(tx, "00000000-0000-0000-0000-000000000001", logID, timestamp, inputContent, outputContent, detailContent)
+	return insertLogContentTenantTx(tx, "00000000-0000-0000-0000-000000000001", logID, timestamp, inputContent, outputContent, detailContent, false)
 }
 
-func insertLogContentTenantTx(tx *sql.Tx, tenantID string, logID int64, timestamp time.Time, inputContent, outputContent, detailContent string) error {
+func insertLogContentTenantTx(tx *sql.Tx, tenantID string, logID int64, timestamp time.Time, inputContent, outputContent, detailContent string, failed bool) error {
 	if tx == nil || logID < 1 {
 		return nil
 	}
 	if !RequestLogBodyStorageEnabled() {
+		// Privacy: do not keep full request/response bodies when body storage is off.
+		// Failed requests are an exception for output_content: the management UI
+		// error modal needs the compact upstream error payload (status/message JSON).
 		inputContent = ""
-		outputContent = ""
+		if !failed {
+			outputContent = ""
+		} else {
+			outputContent = compactFailedOutputContent(outputContent)
+		}
 		detailContent = stripStoredRequestDetailBodies(detailContent)
 	}
 	if inputContent == "" && outputContent == "" && detailContent == "" {

--- a/internal/usage/request_log_detail_sanitize.go
+++ b/internal/usage/request_log_detail_sanitize.go
@@ -3,7 +3,13 @@ package usage
 import (
 	"encoding/json"
 	"strings"
+	"unicode/utf8"
 )
+
+// Max compact error payload retained for failed requests when body storage is off.
+// Large enough for typical upstream JSON errors, small enough to avoid reintroducing
+// full conversation/response bodies through the failure path.
+const maxFailedOutputContentBytes = 8 * 1024
 
 // stripStoredRequestDetailBodies preserves diagnostic metadata while ensuring
 // request/response bodies cannot be retained indirectly in detail_content when
@@ -11,6 +17,40 @@ import (
 func stripStoredRequestDetailBodies(raw string) string {
 	sanitized, _ := sanitizeStoredRequestDetailBodies(raw)
 	return sanitized
+}
+
+// compactFailedOutputContent keeps a short upstream error payload for the
+// management UI when full body storage is disabled. Successful request/response
+// bodies must not pass through this path.
+func compactFailedOutputContent(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if len(raw) <= maxFailedOutputContentBytes {
+		return raw
+	}
+	// Prefer keeping valid JSON when possible; otherwise hard-truncate.
+	if json.Valid([]byte(raw)) {
+		// Truncate with a clear marker while remaining valid-ish text for the modal.
+		// Keep the leading portion which usually contains error.message/type.
+		cut := maxFailedOutputContentBytes
+		for cut > 0 && !utf8.ValidString(raw[:cut]) {
+			cut--
+		}
+		if cut <= 0 {
+			return raw[:maxFailedOutputContentBytes]
+		}
+		return raw[:cut] + "…[truncated]"
+	}
+	cut := maxFailedOutputContentBytes
+	for cut > 0 && !utf8.ValidString(raw[:cut]) {
+		cut--
+	}
+	if cut <= 0 {
+		return raw[:maxFailedOutputContentBytes]
+	}
+	return raw[:cut] + "…[truncated]"
 }
 
 func sanitizeStoredRequestDetailBodies(raw string) (string, bool) {

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -411,8 +411,23 @@ func clearRequestLogs(db *sql.DB, options ClearRequestLogsOptions) (ClearRequest
 		}
 	} else {
 		if options.ClearBodyContent {
+			// Always drop request bodies. Preserve failed-request output_content so the
+			// error-detail modal can still show the compact upstream error when
+			// store-content is disabled (maintenance purge must not erase those).
 			contentResult, err := tx.Exec(
-				"UPDATE request_log_content SET input_content = X'', output_content = X'' WHERE tenant_id = ? AND (length(input_content) > 0 OR length(output_content) > 0)",
+				`UPDATE request_log_content
+				 SET input_content = X'',
+				     output_content = CASE
+				       WHEN EXISTS (
+				         SELECT 1 FROM request_logs logs
+				         WHERE logs.tenant_id = request_log_content.tenant_id
+				           AND logs.id = request_log_content.log_id
+				           AND logs.failed = 1
+				       ) THEN output_content
+				       ELSE X''
+				     END
+				 WHERE tenant_id = ?
+				   AND (length(input_content) > 0 OR length(output_content) > 0)`,
 				options.TenantID,
 			)
 			if err != nil {
@@ -424,7 +439,11 @@ func clearRequestLogs(db *sql.DB, options ClearRequestLogsOptions) (ClearRequest
 			}
 
 			legacyResult, err := tx.Exec(
-				"UPDATE request_logs SET input_content = '', output_content = '' WHERE tenant_id = ? AND (length(input_content) > 0 OR length(output_content) > 0)",
+				`UPDATE request_logs
+				 SET input_content = '',
+				     output_content = CASE WHEN failed = 1 THEN output_content ELSE '' END
+				 WHERE tenant_id = ?
+				   AND (length(input_content) > 0 OR length(output_content) > 0)`,
 				options.TenantID,
 			)
 			if err != nil {

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -961,7 +961,14 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstr
 		tokens.CachedTokens, tokens.TotalTokens, cost,
 	}
 
-	if detailContent != "" || (RequestLogBodyStorageEnabled() && (inputContent != "" || outputContent != "")) {
+	// Failed requests always keep a compact error payload in output_content so the
+	// management UI error modal can show the upstream failure even when full body
+	// storage is disabled. Successful request/response bodies still follow the
+	// store-content toggle.
+	shouldStoreContent := detailContent != "" ||
+		(RequestLogBodyStorageEnabled() && (inputContent != "" || outputContent != "")) ||
+		(failed && strings.TrimSpace(outputContent) != "")
+	if shouldStoreContent {
 		var logID int64
 		if usageDriver == "postgres" {
 			if err := tx.QueryRow(insertSQL+" RETURNING id", insertArgs...).Scan(&logID); err != nil {
@@ -984,7 +991,7 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstr
 				return
 			}
 		}
-		if errStore := insertLogContentTenantTx(tx, tenantID, logID, timestamp, inputContent, outputContent, detailContent); errStore != nil {
+		if errStore := insertLogContentTenantTx(tx, tenantID, logID, timestamp, inputContent, outputContent, detailContent, failed); errStore != nil {
 			_ = tx.Rollback()
 			log.Errorf("usage: insert log content: %v", errStore)
 			return

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -660,6 +660,70 @@ func TestBodyStorageDisabledPreservesDetailsWithoutEmbeddedBodies(t *testing.T) 
 	}
 }
 
+func TestBodyStorageDisabledKeepsFailedOutputErrorPayload(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           false,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+	})
+
+	details := `{"client":{"ip":"203.0.113.8"},"diagnostic":{"upstream":{"status":429,"provider":"xai"}},"upstream":{"request_log":"=== API REQUEST 1 ===\nBody:\nsecret-request"},"response":{"upstream_log":"=== API RESPONSE 1 ===\nStatus: 429\nBody:\nsecret-response"}}`
+	errorBody := `{"error":{"message":"rate limited by upstream","type":"upstream_error","code":"rate_limit"}}`
+	InsertLogWithDetails("sk-test", "Primary", "grok-4.5", "xai", "xAI", "auth-1", true, time.Now().UTC(), 196, 0, TokenStats{},
+		`{"model":"grok-4.5","messages":[{"role":"user","content":"secret prompt"}]}`,
+		errorBody,
+		details,
+	)
+
+	result, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil || len(result.Items) != 1 {
+		t.Fatalf("QueryLogs() result=%+v error=%v", result, err)
+	}
+	if !result.Items[0].Failed {
+		t.Fatal("expected failed log row")
+	}
+
+	content, err := QueryLogContent(result.Items[0].ID)
+	if err != nil {
+		t.Fatalf("QueryLogContent() error = %v", err)
+	}
+	if content.InputContent != "" {
+		t.Fatalf("InputContent = %q, want empty when body storage is off", content.InputContent)
+	}
+	if content.OutputContent != errorBody {
+		t.Fatalf("OutputContent = %q, want failed error body preserved", content.OutputContent)
+	}
+
+	detail, err := QueryLogContentPart(result.Items[0].ID, "details")
+	if err != nil {
+		t.Fatalf("QueryLogContentPart(details) error = %v", err)
+	}
+	if strings.Contains(detail.Content, "secret-request") || strings.Contains(detail.Content, "secret-response") {
+		t.Fatalf("detail content retained request/response bodies: %q", detail.Content)
+	}
+	if !strings.Contains(detail.Content, `"status":429`) && !strings.Contains(detail.Content, `"status": 429`) {
+		// diagnostic may be re-marshaled with spaces; accept either encoding of status.
+		if !strings.Contains(detail.Content, "429") {
+			t.Fatalf("detail content lost diagnostic status: %q", detail.Content)
+		}
+	}
+
+	// Maintenance purge must not wipe failed error payloads.
+	if _, err = PurgeStoredRequestBodies(); err != nil {
+		t.Fatalf("PurgeStoredRequestBodies() error = %v", err)
+	}
+	contentAfter, err := QueryLogContent(result.Items[0].ID)
+	if err != nil {
+		t.Fatalf("QueryLogContent() after purge error = %v", err)
+	}
+	if contentAfter.OutputContent != errorBody {
+		t.Fatalf("OutputContent after purge = %q, want failed error body preserved", contentAfter.OutputContent)
+	}
+	if contentAfter.InputContent != "" {
+		t.Fatalf("InputContent after purge = %q, want empty", contentAfter.InputContent)
+	}
+}
+
 func TestInitDBMigratesFirstTokenAndStreamingColumns(t *testing.T) {
 	CloseDB()
 	dbPath := filepath.Join(t.TempDir(), "usage.db")


### PR DESCRIPTION
## Summary
- When `store-content` is off, failed request logs still persist a compact error body so the management UI is not empty.
- Reconstruct error text from log details on read when output content is missing.
- Cover the failed-log compact storage path with usage DB tests.

## Test plan
- [x] `go test ./internal/usage/ -count=1`
- [ ] Verify failed request log detail on relay management UI shows diagnostic text when body storage is disabled