### PR TITLE
fix: restore shared identity fingerprints for tenant AI accounts

### DIFF
--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -626,9 +626,10 @@ func permissionForManagementRequest(method, path string) string {
 			return "auth_files.write"
 		}
 		return "auth_files.read"
-	// Account/profile fingerprint APIs are auth-file scoped. Global preset PUT
-	// (/identity-fingerprint) still uses process runtime settings; tenants can
-	// read learned state but only platform admins rewrite the shared preset.
+	// Account/profile fingerprint APIs are auth-file scoped and read the shared
+	// AI-account catalog (same account_key → same fingerprints). Global preset
+	// PUT (/identity-fingerprint) still uses process runtime settings; tenants
+	// can read learned state but only platform admins rewrite the shared preset.
 	case relative == "/identity-fingerprint" && write:
 		return "system.config.write"
 	case strings.HasPrefix(relative, "/identity-fingerprint"):

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -504,6 +504,7 @@ func isTenantScopedManagementPath(path string) bool {
 	case relative == "/dashboard-summary", relative == "/config":
 		return true
 	case strings.HasPrefix(relative, "/auth-files"),
+		strings.HasPrefix(relative, "/identity-fingerprint"),
 		strings.HasPrefix(relative, "/model-definitions/"),
 		strings.HasPrefix(relative, "/image-generation"),
 		relative == "/vertex/import",
@@ -621,6 +622,16 @@ func permissionForManagementRequest(method, path string) string {
 		if relative == "/get-auth-status" || strings.Contains(relative, "auth-url") || strings.Contains(relative, "oauth") {
 			return "auth_files.oauth"
 		}
+		if write {
+			return "auth_files.write"
+		}
+		return "auth_files.read"
+	// Account/profile fingerprint APIs are auth-file scoped. Global preset PUT
+	// (/identity-fingerprint) still uses process runtime settings; tenants can
+	// read learned state but only platform admins rewrite the shared preset.
+	case relative == "/identity-fingerprint" && write:
+		return "system.config.write"
+	case strings.HasPrefix(relative, "/identity-fingerprint"):
 		if write {
 			return "auth_files.write"
 		}

--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -24,6 +24,14 @@ func TestPermissionForManagementRequest(t *testing.T) {
 		{http.MethodGet, "/v0/management/get-auth-status", "auth_files.oauth"},
 		{http.MethodPost, "/v0/management/proxy-pool/check", "proxies.test"},
 		{http.MethodPut, "/v0/management/config.yaml", "system.config.write"},
+		// Account fingerprint APIs are auth-file scoped; global preset PUT stays platform-only.
+		{http.MethodGet, "/v0/management/identity-fingerprint", "auth_files.read"},
+		{http.MethodGet, "/v0/management/identity-fingerprint/account", "auth_files.read"},
+		{http.MethodGet, "/v0/management/identity-fingerprint/codex/recommendations", "auth_files.read"},
+		{http.MethodPut, "/v0/management/identity-fingerprint/account/policy", "auth_files.write"},
+		{http.MethodDelete, "/v0/management/identity-fingerprint/account/profile", "auth_files.write"},
+		{http.MethodDelete, "/v0/management/identity-fingerprint/learned", "auth_files.write"},
+		{http.MethodPut, "/v0/management/identity-fingerprint", "system.config.write"},
 	}
 	for _, test := range tests {
 		if got := permissionForManagementRequest(test.method, test.path); got != test.want {

--- a/internal/api/handlers/management/tenant_scope_gate_test.go
+++ b/internal/api/handlers/management/tenant_scope_gate_test.go
@@ -17,6 +17,12 @@ func TestTenantScopedManagementPathIncludesProviderRuntimeRoutes(t *testing.T) {
 		"/v0/management/codex-oauth-admission",
 		// Auth-file quota preview for tenant-imported OAuth credentials.
 		"/v0/management/api-call",
+		// Per-account identity fingerprints must stay readable by tenant admins
+		// after credentials migrate off the system tenant.
+		"/v0/management/identity-fingerprint",
+		"/v0/management/identity-fingerprint/account",
+		"/v0/management/identity-fingerprint/account/policy",
+		"/v0/management/identity-fingerprint/codex/recommendations",
 	} {
 		if !isTenantScopedManagementPath(path) {
 			t.Errorf("isTenantScopedManagementPath(%q) = false", path)

--- a/internal/runtime/executor/codex_identity_fingerprint.go
+++ b/internal/runtime/executor/codex_identity_fingerprint.go
@@ -75,7 +75,7 @@ func codexIdentityFingerprint(cfg *config.Config, auth *cliproxyauth.Auth, ctx c
 	if cfg == nil || !cfg.IdentityFingerprint.Codex.Enabled {
 		return config.CodexIdentityFingerprintConfig{}, false
 	}
-	if !isCodexOAuthAdmissionAuth(auth) || !usesSystemIdentityFingerprint(auth) {
+	if !isCodexOAuthAdmissionAuth(auth) {
 		resolved, _ := identityfingerprint.ResolveCodexSafeFallback(cfg.IdentityFingerprint.Codex)
 		return resolved, true
 	}

--- a/internal/runtime/executor/identity_fingerprint_runtime.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime.go
@@ -94,9 +94,10 @@ func identityFingerprintAccount(auth *cliproxyauth.Auth) (accountKey string, aut
 }
 
 func observeRuntimeIdentityFingerprint(provider identityfingerprint.Provider, auth *cliproxyauth.Auth, ctx context.Context) *identityfingerprint.LearnedRecord {
-	// Learned fingerprints live in the shared usage store (systemTenantID today).
-	// Business tenants must still read/learn by auth subject so migrated OAuth
-	// accounts keep the same UA/version bundles that upstreams enforce.
+	// Same AI account (account_key / auth subject) shares one fingerprint catalog
+	// across tenants. Storage is keyed under the platform system tenant so a
+	// credential that moved from system → business tenant keeps the learned
+	// UA/version bundles; business tenants still observe and apply them.
 	accountKey, authSubjectID := identityFingerprintAccount(auth)
 	if accountKey == "" {
 		return nil

--- a/internal/runtime/executor/identity_fingerprint_runtime.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime.go
@@ -19,7 +19,6 @@ import (
 const (
 	identityFingerprintReadCacheTTL  = 30 * time.Second
 	identityFingerprintWriteCacheTTL = 5 * time.Minute
-	identityFingerprintSystemTenant  = "00000000-0000-0000-0000-000000000001"
 )
 
 var (
@@ -78,14 +77,6 @@ func identityFingerprintHeadersFromContext(ctx context.Context) http.Header {
 	return ginCtx.Request.Header
 }
 
-func usesSystemIdentityFingerprint(auth *cliproxyauth.Auth) bool {
-	if auth == nil {
-		return true
-	}
-	tenantID := strings.TrimSpace(auth.TenantID)
-	return tenantID == "" || tenantID == identityFingerprintSystemTenant
-}
-
 func identityFingerprintAccount(auth *cliproxyauth.Auth) (accountKey string, authSubjectID string) {
 	identity := usage.ResolveAuthSubjectIdentity(auth)
 	if identity != nil {
@@ -103,9 +94,9 @@ func identityFingerprintAccount(auth *cliproxyauth.Auth) (accountKey string, aut
 }
 
 func observeRuntimeIdentityFingerprint(provider identityfingerprint.Provider, auth *cliproxyauth.Auth, ctx context.Context) *identityfingerprint.LearnedRecord {
-	if !usesSystemIdentityFingerprint(auth) {
-		return nil
-	}
+	// Learned fingerprints live in the shared usage store (systemTenantID today).
+	// Business tenants must still read/learn by auth subject so migrated OAuth
+	// accounts keep the same UA/version bundles that upstreams enforce.
 	accountKey, authSubjectID := identityFingerprintAccount(auth)
 	if accountKey == "" {
 		return nil

--- a/internal/runtime/executor/identity_fingerprint_runtime_test.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime_test.go
@@ -878,22 +878,12 @@ func BenchmarkCodexIdentityFingerprintHotPathCached(b *testing.B) {
 	}
 }
 
-func TestTenantCredentialCannotUseLearnedIdentityFingerprints(t *testing.T) {
+func TestTenantCredentialCanObserveLearnedIdentityFingerprints(t *testing.T) {
+	// After multi-tenant migrations, business-tenant OAuth accounts still share
+	// the system-tenant fingerprint catalog by account_key. Runtime must learn
+	// and apply those profiles for non-system tenants, not only the platform tenant.
 	resetIdentityFingerprintRuntimeStateForTest()
 	t.Cleanup(resetIdentityFingerprintRuntimeStateForTest)
-
-	var observeCalls atomic.Int32
-	var listCalls atomic.Int32
-	runtimeIdentityFingerprintStoreFuncMu.Lock()
-	runtimeObserveIdentityFingerprint = func(input identityfingerprint.LearnInput) (*identityfingerprint.LearnedRecord, identityfingerprint.MergeResult, error) {
-		observeCalls.Add(1)
-		return nil, identityfingerprint.MergeResult{}, nil
-	}
-	runtimeListCodexIdentityFingerprintProfiles = func(provider identityfingerprint.Provider, accountKey string) ([]identityfingerprint.LearnedRecord, error) {
-		listCalls.Add(1)
-		return nil, nil
-	}
-	runtimeIdentityFingerprintStoreFuncMu.Unlock()
 
 	auth := &cliproxyauth.Auth{
 		ID:       "tenant-codex-auth",
@@ -910,19 +900,21 @@ func TestTenantCredentialCannotUseLearnedIdentityFingerprints(t *testing.T) {
 		"Originator": {"codex_cli_rs"},
 	}
 	ctx := contextWithInboundHeaders(http.MethodPost, "/v1/responses", inbound)
-	if got := observeRuntimeIdentityFingerprint(identityfingerprint.ProviderCodex, auth, ctx); got != nil {
-		t.Fatalf("observeRuntimeIdentityFingerprint() = %#v, want nil", got)
+	got := observeRuntimeIdentityFingerprint(identityfingerprint.ProviderCodex, auth, ctx)
+	if got == nil {
+		t.Fatal("observeRuntimeIdentityFingerprint() = nil, want learned record for tenant credential")
+	}
+	if got.Version != "0.200.0" {
+		t.Fatalf("learned version = %q, want 0.200.0", got.Version)
 	}
 	cfg := &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
 		Codex: config.CodexIdentityFingerprintConfig{Enabled: true},
 	}}
-	if _, enabled := codexIdentityFingerprint(cfg, auth, ctx); !enabled {
-		t.Fatal("codexIdentityFingerprint() disabled safe fallback")
+	resolved, enabled := codexIdentityFingerprint(cfg, auth, ctx)
+	if !enabled {
+		t.Fatal("codexIdentityFingerprint() disabled for tenant credential")
 	}
-	if got := observeCalls.Load(); got != 0 {
-		t.Fatalf("identity fingerprint observe calls = %d, want 0", got)
-	}
-	if got := listCalls.Load(); got != 0 {
-		t.Fatalf("identity fingerprint list calls = %d, want 0", got)
+	if resolved.UserAgent == "" && resolved.Version == "" {
+		t.Fatalf("codexIdentityFingerprint() returned empty resolved config: %#v", resolved)
 	}
 }

--- a/internal/usage/identity_fingerprint_db.go
+++ b/internal/usage/identity_fingerprint_db.go
@@ -162,6 +162,11 @@ func migrateIdentityFingerprintPolicyTable(db *sql.DB) error {
 	return nil
 }
 
+// ObserveIdentityFingerprint learns/merges fingerprints in the shared AI-account
+// catalog. Rows are stored under systemTenantID as an implementation detail; the
+// logical key is (provider, account_key, profile_key). The same OAuth account
+// keeps one fingerprint set whether its credential currently lives on the
+// platform tenant or a business tenant.
 func ObserveIdentityFingerprint(input identityfingerprint.LearnInput) (*identityfingerprint.LearnedRecord, identityfingerprint.MergeResult, error) {
 	if !ConfigStoreAvailable() {
 		return nil, identityfingerprint.MergeResult{Reason: "store_unavailable"}, nil
@@ -223,6 +228,9 @@ func ObserveIdentityFingerprint(input identityfingerprint.LearnInput) (*identity
 	return result.Record, result, nil
 }
 
+// GetIdentityFingerprint returns the most recently seen shared fingerprint for
+// the AI account (provider + account_key), independent of which business tenant
+// currently owns the credential file.
 func GetIdentityFingerprint(provider identityfingerprint.Provider, accountKey string) (*identityfingerprint.LearnedRecord, error) {
 	db := getDB()
 	if db == nil {

--- a/internal/usage/identity_fingerprint_db_test.go
+++ b/internal/usage/identity_fingerprint_db_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 func TestObserveIdentityFingerprintLearnsAndMergesClaudeAccount(t *testing.T) {
@@ -260,7 +261,10 @@ func TestObserveIdentityFingerprintSkipsRecentUnchangedLastSeenWrite(t *testing.
 	}
 }
 
-func TestIdentityFingerprintStoreIsScopedToSystemTenant(t *testing.T) {
+func TestIdentityFingerprintSharedCatalogUsesSystemTenantStorage(t *testing.T) {
+	// Fingerprints are shared by AI account_key. Storage tenant_id is always the
+	// platform system catalog — a row written only under a business tenant_id is
+	// not part of the shared catalog and must not be returned.
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 	db := getDB()
 	if db == nil {
@@ -272,13 +276,74 @@ func TestIdentityFingerprintStoreIsScopedToSystemTenant(t *testing.T) {
 			created_at, updated_at, last_seen_at
 		) VALUES (?, ?, ?, ?, '{}', '{}', ?, ?, ?)
 	`, "11111111-1111-1111-1111-111111111111", string(identityfingerprint.ProviderCodex), "shared-account", "codex_cli_rs", time.Now(), time.Now(), time.Now()); err != nil {
-		t.Fatalf("insert foreign tenant fingerprint: %v", err)
+		t.Fatalf("insert business-tenant-only fingerprint: %v", err)
 	}
 	if record, err := GetIdentityFingerprint(identityfingerprint.ProviderCodex, "shared-account"); err != nil || record != nil {
-		t.Fatalf("GetIdentityFingerprint() record=%#v err=%v, want no cross-tenant result", record, err)
+		t.Fatalf("GetIdentityFingerprint() record=%#v err=%v, want nil for non-shared-catalog row", record, err)
 	}
 	if records, err := ListIdentityFingerprints(identityfingerprint.ProviderCodex, 10); err != nil || len(records) != 0 {
-		t.Fatalf("ListIdentityFingerprints() records=%#v err=%v, want no cross-tenant results", records, err)
+		t.Fatalf("ListIdentityFingerprints() records=%#v err=%v, want empty shared catalog", records, err)
+	}
+}
+
+func TestIdentityFingerprintSharedByAccountKeyAcrossBusinessTenants(t *testing.T) {
+	// Same OAuth account_id resolves to one account_key; learning once must be
+	// visible for credentials that later live under a different business tenant.
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	authA := &coreauth.Auth{
+		ID:       "auth-on-tenant-a",
+		TenantID: "11111111-1111-1111-1111-111111111111",
+		Provider: "codex",
+		Metadata: map[string]any{"account_id": "chatgpt-shared-account"},
+	}
+	authB := &coreauth.Auth{
+		ID:       "auth-on-tenant-b",
+		TenantID: "22222222-2222-2222-2222-222222222222",
+		Provider: "codex",
+		Metadata: map[string]any{"account_id": "chatgpt-shared-account"},
+	}
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA == nil || identityB == nil || identityA.ID == "" || identityA.ID != identityB.ID {
+		t.Fatalf("expected same account_key for shared OAuth account, got A=%#v B=%#v", identityA, identityB)
+	}
+	accountKey := identityA.ID
+
+	headers := http.Header{}
+	headers.Set("User-Agent", "codex_cli_rs/0.201.0 (Mac OS; arm64)")
+	headers.Set("Version", "0.201.0")
+	headers.Set("Originator", "codex_cli_rs")
+	if _, result, err := ObserveIdentityFingerprint(identityfingerprint.LearnInput{
+		Provider:      identityfingerprint.ProviderCodex,
+		AccountKey:    accountKey,
+		AuthSubjectID: accountKey,
+		Headers:       headers,
+		ObservedAt:    time.Now().UTC(),
+	}); err != nil || !result.Changed {
+		t.Fatalf("ObserveIdentityFingerprint: result=%+v err=%v", result, err)
+	}
+
+	stored, err := GetIdentityFingerprint(identityfingerprint.ProviderCodex, accountKey)
+	if err != nil || stored == nil {
+		t.Fatalf("GetIdentityFingerprint: %#v err=%v", stored, err)
+	}
+	if stored.Version != "0.201.0" {
+		t.Fatalf("shared fingerprint version = %q, want 0.201.0", stored.Version)
+	}
+	// Business-tenant-only duplicate must not shadow the shared catalog entry.
+	db := getDB()
+	if _, err := db.Exec(`
+		INSERT INTO identity_fingerprints (
+			tenant_id, provider, account_key, profile_key, version, fields_json, observed_headers_json,
+			created_at, updated_at, last_seen_at
+		) VALUES (?, ?, ?, ?, '9.9.9', '{}', '{}', ?, ?, ?)
+	`, authB.TenantID, string(identityfingerprint.ProviderCodex), accountKey, "codex_cli_rs", time.Now(), time.Now(), time.Now()); err != nil {
+		t.Fatalf("insert tenant-b shadow row: %v", err)
+	}
+	again, err := GetIdentityFingerprint(identityfingerprint.ProviderCodex, accountKey)
+	if err != nil || again == nil || again.Version != "0.201.0" {
+		t.Fatalf("shared catalog should still return 0.201.0, got %#v err=%v", again, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Business tenants can access identity-fingerprint management APIs again (`auth_files` RBAC + tenant-scoped path whitelist).
- Runtime no longer skips learned fingerprints for non-system tenant OAuth credentials.
- Same AI account (`provider + account_key`) keeps one shared fingerprint catalog across tenants (storage under system catalog is an implementation detail).

## Why
After migrating credentials from the system tenant to business tenants (e.g. 土豆服务器), identity fingerprint UI spun forever (403) and runtime stopped applying learned UA/version bundles because the code treated fingerprints as system-tenant-only.

## Test plan
- [x] `go test ./internal/api/handlers/management/ -run 'PermissionForManagement|TenantScopedManagement'`
- [x] `go test ./internal/runtime/executor/ -run 'TenantCredential|IdentityFingerprint'`
- [x] `go test ./internal/usage/ -run 'IdentityFingerprint'`
- [x] Online (relay): potato tenant session GET `/v0/management/identity-fingerprint/account` for shared account keys returns 200 with `learned=true`