### PR TITLE
fix: allow platform admin global logs after tenant switch

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -413,9 +413,11 @@ func (h *Handler) authenticateSessionToken(c *gin.Context, token string) bool {
 		identityError(c, identity.ErrPermissionDenied)
 		return false
 	}
-	// Some runtime/config stores remain process-global. Non-system tenants may
-	// only use routes whose complete repository and scheduler paths are tenant-scoped.
-	if principal.EffectiveTenant.ID != identity.SystemTenantID && !isTenantScopedManagementPath(c.Request.URL.Path) {
+	// Some runtime/config stores remain process-global. Business-tenant sessions
+	// may only use fully tenant-scoped routes. Platform super-admins keep access
+	// after tenant switch so ops pages like /logs still work under an effective
+	// business tenant.
+	if deniesTenantResourceScope(principal, c.Request.URL.Path) {
 		h.recordManagementAudit(c, principal, "denied")
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "tenant_resource_scope_unavailable", "message": "tenant business resources are not enabled for this tenant"}})
 		return false

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -495,6 +495,17 @@ func isTenantGovernancePath(path string) bool {
 		relative == "/permissions" || relative == "/menus" || strings.HasPrefix(relative, "/menus/") || relative == "/audit-logs"
 }
 
+// deniesTenantResourceScope blocks process-global management routes when the
+// session is acting as a non-system tenant. Platform super-admins are exempt:
+// they may switch into a business tenant for ops without losing access to host
+// logs, global config, and other process-scoped surfaces.
+func deniesTenantResourceScope(principal identity.Principal, path string) bool {
+	if principal.PlatformAdmin || principal.EffectiveTenant.ID == identity.SystemTenantID {
+		return false
+	}
+	return !isTenantScopedManagementPath(path)
+}
+
 func isTenantScopedManagementPath(path string) bool {
 	if isTenantGovernancePath(path) {
 		return true

--- a/internal/api/handlers/management/tenant_scope_gate_test.go
+++ b/internal/api/handlers/management/tenant_scope_gate_test.go
@@ -1,6 +1,41 @@
 package management
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+)
+
+func TestDeniesTenantResourceScopeAllowsPlatformAdminOnGlobalLogs(t *testing.T) {
+	businessTenant := identity.Principal{
+		PlatformAdmin:   true,
+		EffectiveTenant: identity.Tenant{ID: "tenant-potato"},
+		HomeTenant:      identity.Tenant{ID: identity.SystemTenantID},
+	}
+	if deniesTenantResourceScope(businessTenant, "/v0/management/logs") {
+		t.Fatal("platform super-admin switched into a business tenant must still reach process-global /logs")
+	}
+
+	tenantOperator := identity.Principal{
+		PlatformAdmin:   false,
+		EffectiveTenant: identity.Tenant{ID: "tenant-potato"},
+		HomeTenant:      identity.Tenant{ID: "tenant-potato"},
+	}
+	if !deniesTenantResourceScope(tenantOperator, "/v0/management/logs") {
+		t.Fatal("non-platform tenant session must not reach process-global /logs")
+	}
+	if deniesTenantResourceScope(tenantOperator, "/v0/management/usage/logs") {
+		t.Fatal("tenant-scoped request logs must stay available to business tenants")
+	}
+
+	systemSession := identity.Principal{
+		PlatformAdmin:   false,
+		EffectiveTenant: identity.Tenant{ID: identity.SystemTenantID},
+	}
+	if deniesTenantResourceScope(systemSession, "/v0/management/logs") {
+		t.Fatal("system-tenant session must reach process-global /logs")
+	}
+}
 
 func TestTenantScopedManagementPathIncludesProviderRuntimeRoutes(t *testing.T) {
 	for _, path := range []string{


### PR DESCRIPTION
## Summary
- Platform super-admins who switch into a business tenant (via `X-Effective-Tenant-ID`) were blocked from process-global management routes such as `/v0/management/logs` with `tenant_resource_scope_unavailable`.
- Root cause: the tenant resource-scope gate only checked `EffectiveTenant != system` and ignored `PlatformAdmin`.
- Fix: extract `deniesTenantResourceScope` and exempt platform super-admins while keeping ordinary business-tenant sessions blocked from host-level resources.

## Test plan
- [x] `go test ./internal/api/handlers/management/ -run 'TestDeniesTenantResourceScope|TestTenantScopedManagementPath' -count=1`
- [ ] After deploy: as Super Administrator, switch to a business tenant and open `/manage/runtime/logs` — should load without the tenant-resource error.
- [ ] As a non-platform tenant user, `/logs` remains forbidden; `/usage/logs` still works.