### PR TITLE
feat: seed Model Plaza menu under models group

### DIFF
--- a/internal/identity/menus.go
+++ b/internal/identity/menus.go
@@ -70,7 +70,7 @@ type MenuInput struct {
 // 仪表盘 — overview
 // 运行观测 — live health, request traces, runtime logs
 // 接入与凭证 — upstream providers, AI OAuth accounts, client API keys, key profiles
-// 模型与调度 — model catalog, image models, routing groups, outbound proxies
+// 模型与调度 — model plaza, catalog, image models, routing groups, outbound proxies
 // 组织与权限 — tenants, users, roles, audit
 // 系统设置 — global config, menu management
 // 系统信息 — host/runtime status (top-level leaf, pinned last)
@@ -98,6 +98,8 @@ var MenuCatalog = []MenuSeed{
 	// Must not use platform system.config.read, or ordinary tenants never see this menu.
 	{Code: "access.ccswitch", ParentCode: "group.access", Type: "menu", Path: "/access/ccswitch-import-settings", Component: "ccswitch-import-settings", LabelKey: "shell.nav_ccswitch_import_settings", Icon: "arrow-down-to-line", PermissionCode: "routing.read", SortOrder: 50},
 	// Models & routing
+	// Tenant-visible available models (same permission as former System Info model list).
+	{Code: "models.plaza", ParentCode: "group.models", Type: "menu", Path: "/models/plaza", Component: "model-plaza", LabelKey: "shell.nav_model_plaza", Icon: "store", PermissionCode: "system.status.read", SortOrder: 5},
 	{Code: "models.catalog", ParentCode: "group.models", Type: "menu", Path: "/models/catalog", Component: "models", LabelKey: "shell.nav_models", Icon: "cpu", PermissionCode: "models.read", SortOrder: 10},
 	{Code: "models.image-generation", ParentCode: "group.models", Type: "menu", Path: "/models/image-generation", Component: "image-generation", LabelKey: "shell.nav_image_generation", Icon: "image", PermissionCode: "system.config.read", SortOrder: 20},
 	{Code: "models.channel-groups", ParentCode: "group.models", Type: "menu", Path: "/models/channel-groups", Component: "channel-groups", LabelKey: "shell.nav_channel_groups", Icon: "layers", PermissionCode: "routing.read", SortOrder: 30},

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -125,6 +125,23 @@ func TestMenuCatalogReferencesExistingParents(t *testing.T) {
 	if systemInfo.SortOrder < seen["group.system"].SortOrder {
 		t.Fatalf("runtime.system sort_order %d must be after group.system %d", systemInfo.SortOrder, seen["group.system"].SortOrder)
 	}
+	// Model plaza is a tenant-facing available-models surface under models group.
+	plaza, ok := seen["models.plaza"]
+	if !ok {
+		t.Fatal("models.plaza menu is missing")
+	}
+	if plaza.ParentCode != "group.models" {
+		t.Fatalf("models.plaza parent = %q, want group.models", plaza.ParentCode)
+	}
+	if plaza.Path != "/models/plaza" {
+		t.Fatalf("models.plaza path = %q, want /models/plaza", plaza.Path)
+	}
+	if plaza.Component != "model-plaza" {
+		t.Fatalf("models.plaza component = %q, want model-plaza", plaza.Component)
+	}
+	if plaza.PermissionCode != "system.status.read" {
+		t.Fatalf("models.plaza permission = %q, want system.status.read", plaza.PermissionCode)
+	}
 }
 
 func TestGeneratedIdentifier(t *testing.T) {


### PR DESCRIPTION
## Summary
- Seed `models.plaza` in `MenuCatalog` under `group.models`.
- Path `/models/plaza`, component `model-plaza`, permission `system.status.read`.
- Keep System Info as a top-level leaf; available models move to the frontend Model Plaza page.

## Local verification
- `go test ./internal/identity/ -count=1`

## Notes
- Companion frontend PR in codeProxy adds the Model Plaza page and legacy menu fallback.