### PR TITLE
fix: log delete permission and published-schema migration fixture

### DIFF
--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 )
 
 func TestPermissionForManagementRequest(t *testing.T) {
@@ -29,6 +30,8 @@ func TestPermissionForManagementRequest(t *testing.T) {
 		{http.MethodGet, "/v0/management/request-error-logs/err.log", "system.logs.read"},
 		{http.MethodGet, "/v0/management/request-log-by-id/abc", "system.logs.read"},
 		{http.MethodGet, "/v0/management/logs", "system.logs.read"},
+		// Clearing file logs requires an explicit delete permission.
+		{http.MethodDelete, "/v0/management/logs", "system.logs.delete"},
 		// Usage writes must not use monitor.read.
 		{http.MethodPost, "/v0/management/usage/import", "system.config.write"},
 		{http.MethodPost, "/v0/management/usage/auth-file-quota-snapshot", "auth_files.write"},
@@ -85,5 +88,39 @@ func TestServiceCredentialCannotAccessTenantGovernance(t *testing.T) {
 	}
 	if reached {
 		t.Fatal("service credential reached tenant governance handler")
+	}
+}
+
+// TestLogsDeleteRequiresExplicitPermission mirrors authenticateSessionToken's
+// permission gate: read-only log viewers must not pass DELETE /logs.
+func TestLogsDeleteRequiresExplicitPermission(t *testing.T) {
+	readOnly := identity.Principal{
+		Permissions: map[string]bool{"system.logs.read": true},
+	}
+	deleter := identity.Principal{
+		Permissions: map[string]bool{
+			"system.logs.read":   true,
+			"system.logs.delete": true,
+		},
+	}
+
+	getPerm := permissionForManagementRequest(http.MethodGet, "/v0/management/logs")
+	deletePerm := permissionForManagementRequest(http.MethodDelete, "/v0/management/logs")
+	if getPerm != "system.logs.read" {
+		t.Fatalf("GET /logs permission = %q, want system.logs.read", getPerm)
+	}
+	if deletePerm != "system.logs.delete" {
+		t.Fatalf("DELETE /logs permission = %q, want system.logs.delete", deletePerm)
+	}
+
+	// Same condition as authenticateSessionToken after permission lookup.
+	if getPerm == "" || !readOnly.Has(getPerm) {
+		t.Fatal("read-only principal should pass GET /logs")
+	}
+	if deletePerm != "" && readOnly.Has(deletePerm) {
+		t.Fatal("read-only principal must not pass DELETE /logs")
+	}
+	if deletePerm == "" || !deleter.Has(deletePerm) {
+		t.Fatal("principal with system.logs.delete should pass DELETE /logs")
 	}
 }

--- a/internal/api/handlers/management/route_permissions.go
+++ b/internal/api/handlers/management/route_permissions.go
@@ -62,7 +62,11 @@ func permissionForManagementRequest(method, path string) string {
 	case strings.HasPrefix(relative, "/request-error-logs"), strings.HasPrefix(relative, "/request-log-by-id"):
 		return "system.logs.read"
 	// Exact /logs only: /logs-max-total-size-mb is a config knob below.
+	// DELETE clears rotated logs and truncates main.log — not a read capability.
 	case relative == "/logs" || strings.HasPrefix(relative, "/logs/"):
+		if method == http.MethodDelete {
+			return "system.logs.delete"
+		}
 		return "system.logs.read"
 	case strings.HasPrefix(relative, "/usage/logs"):
 		if method == http.MethodDelete {

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -103,9 +103,9 @@ func TestManagementRoutePermissionsComplete(t *testing.T) {
 		if perm == "" {
 			missing = append(missing, route.Method+" "+route.Path)
 		}
-		// Write methods must not land on pure-read monitor permission.
-		if route.Method != http.MethodGet && route.Method != http.MethodHead && perm == "monitor.read" {
-			t.Errorf("%s %s maps write method to monitor.read", route.Method, route.Path)
+		// Non-read methods must never map to a *.read capability.
+		if route.Method != http.MethodGet && route.Method != http.MethodHead && strings.HasSuffix(perm, ".read") {
+			t.Errorf("%s %s maps write method to read permission %q", route.Method, route.Path, perm)
 		}
 	}
 	if len(missing) > 0 {
@@ -120,6 +120,8 @@ func TestManagementRoutePermissionsComplete(t *testing.T) {
 		{http.MethodGet, "/v0/management/request-error-logs", "system.logs.read"},
 		{http.MethodGet, "/v0/management/request-error-logs/err.log", "system.logs.read"},
 		{http.MethodGet, "/v0/management/request-log-by-id/req-1", "system.logs.read"},
+		{http.MethodGet, "/v0/management/logs", "system.logs.read"},
+		{http.MethodDelete, "/v0/management/logs", "system.logs.delete"},
 		{http.MethodPost, "/v0/management/usage/import", "system.config.write"},
 		{http.MethodPost, "/v0/management/usage/auth-file-quota-snapshot", "auth_files.write"},
 		{http.MethodGet, "/v0/management/totally-unknown-route", ""},

--- a/internal/identity/permissions.go
+++ b/internal/identity/permissions.go
@@ -24,6 +24,8 @@ var PermissionCatalog = []PermissionSeed{
 	{Code: "platform.menus.update", Name: "Update menu configuration", Scope: "platform", Resource: "menus", Action: "update", Sensitive: true},
 	{Code: "system.status.read", Name: "Read system status", Scope: "platform", Resource: "system", Action: "read"},
 	{Code: "system.logs.read", Name: "Read system logs", Scope: "platform", Resource: "system_logs", Action: "read", Sensitive: true},
+	// Destroying rotated/active file logs is a separate capability from reading them.
+	{Code: "system.logs.delete", Name: "Delete system logs", Scope: "platform", Resource: "system_logs", Action: "delete", Sensitive: true},
 	{Code: "system.config.read", Name: "Read system configuration", Scope: "platform", Resource: "system_config", Action: "read", Sensitive: true},
 	{Code: "system.config.write", Name: "Write system configuration", Scope: "platform", Resource: "system_config", Action: "write", Sensitive: true},
 	{Code: "system.update.manage", Name: "Manage system updates", Scope: "platform", Resource: "system_update", Action: "manage", Sensitive: true},

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -152,6 +152,22 @@ func TestGeneratedIdentifier(t *testing.T) {
 	}
 }
 
+func TestSystemLogsDeletePermissionCatalog(t *testing.T) {
+	var found *PermissionSeed
+	for i := range PermissionCatalog {
+		if PermissionCatalog[i].Code == "system.logs.delete" {
+			found = &PermissionCatalog[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("system.logs.delete missing from PermissionCatalog")
+	}
+	if found.Scope != "platform" || found.Resource != "system_logs" || found.Action != "delete" || !found.Sensitive {
+		t.Fatalf("system.logs.delete seed = %+v, want platform/system_logs/delete/sensitive", *found)
+	}
+}
+
 func TestMenuCodeForPermission(t *testing.T) {
 	menuCodes := make(map[string]bool, len(MenuCatalog))
 	for _, menu := range MenuCatalog {
@@ -160,6 +176,7 @@ func TestMenuCodeForPermission(t *testing.T) {
 	tests := map[string]string{
 		"tenant.users.update":   "governance.users",
 		"request_logs.delete":   "runtime.request-logs",
+		"system.logs.delete":    "runtime.logs",
 		"platform.menus.update": MenuManagementCode,
 		"proxies.test":          "models.proxies",
 	}

--- a/internal/storage/postgres/migration_upgrade_test.go
+++ b/internal/storage/postgres/migration_upgrade_test.go
@@ -13,10 +13,17 @@ import (
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres/compatdriver"
 )
 
-// TestApplyMigrationsUpgradeFromPublishedSchema applies only the first N
-// migrations (simulating a previously published schema), seeds tenant-scoped
-// rows, then upgrades to the full current set and verifies every migration
-// version is recorded cleanly and seed data remains readable.
+// publishedBaselineVersion is the last migration shipped on origin/main before
+// the multi-tenant upgrade series. Do not replace this with len(all)-1 — that
+// drifts as new migrations land and stops testing the real production upgrade.
+const publishedBaselineVersion = "202607100001_identity_fingerprint_profiles"
+
+const systemTenantID = "00000000-0000-0000-0000-000000000001"
+
+// TestApplyMigrationsUpgradeFromPublishedSchema applies only the migrations
+// present on the currently published schema, seeds legacy (pre multi-tenant)
+// rows, upgrades through the full RuntimeMigrations set, and asserts data
+// retention, system-tenant backfill, composite keys, and idempotent re-apply.
 //
 // Uses a disposable database so parallel Postgres tests are not disrupted.
 func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
@@ -40,7 +47,6 @@ func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
 		t.Fatalf("create disposable db: %v", err)
 	}
 	t.Cleanup(func() {
-		// Terminate residual connections then drop.
 		_, _ = adminDB.ExecContext(context.Background(), `
 			SELECT pg_terminate_backend(pid)
 			  FROM pg_stat_activity
@@ -63,38 +69,144 @@ func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
 	}
 
 	all := RuntimeMigrations()
-	if len(all) < 3 {
-		t.Fatalf("expected at least 3 migrations, got %d", len(all))
+	baseline := publishedBaselineMigrations(t, all)
+	if len(baseline) != 2 {
+		t.Fatalf("published baseline should be 2 migrations (runtime + fingerprint profiles), got %d", len(baseline))
 	}
-	// "Published" baseline: everything before the latest migration.
-	baseline := all[:len(all)-1]
 	if err := ApplyMigrations(ctx, db, baseline); err != nil {
-		t.Fatalf("apply baseline migrations: %v", err)
+		t.Fatalf("apply published baseline migrations: %v", err)
 	}
 
-	// Seed a standard tenant that later migrations must preserve.
-	// UUID required; standard tenants require expires_at.
-	seedID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-	expires := time.Now().UTC().Add(30 * 24 * time.Hour)
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO tenants (id, slug, name, type, status, expires_at, description, created_at, updated_at, version)
-		VALUES (?, ?, ?, 'standard', 'active', ?, '', now(), now(), 1)
-		ON CONFLICT (id) DO NOTHING
-	`, seedID, "seed-tenant", "Seed Tenant", expires); err != nil {
-		t.Fatalf("seed tenant: %v", err)
-	}
-	var count int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM tenants WHERE id = ?`, seedID).Scan(&count); err != nil {
-		t.Fatalf("read seed tenant: %v", err)
-	}
-	if count != 1 {
-		t.Fatalf("seed tenant count = %d", count)
-	}
+	// Seed while multi-tenant tables (tenants, tenant_id columns) do not exist yet.
+	seedPublishedSchemaFixture(t, ctx, db)
 
 	if err := ApplyMigrations(ctx, db, all); err != nil {
 		t.Fatalf("upgrade to current schema: %v", err)
 	}
+	assertAllMigrationsClean(t, ctx, db, all)
+	assertMigratedFixture(t, ctx, db)
 
+	// Re-apply must stay idempotent: no dirty rows, no data mutation.
+	if err := ApplyMigrations(ctx, db, all); err != nil {
+		t.Fatalf("second ApplyMigrations: %v", err)
+	}
+	assertAllMigrationsClean(t, ctx, db, all)
+	assertMigratedFixture(t, ctx, db)
+}
+
+// publishedBaselineMigrations returns migrations up to and including
+// publishedBaselineVersion. Fails immediately if that version is missing so a
+// reordered/removed migration cannot silently change the baseline.
+func publishedBaselineMigrations(t *testing.T, all []Migration) []Migration {
+	t.Helper()
+	for i, m := range all {
+		if m.Version == publishedBaselineVersion {
+			return all[:i+1]
+		}
+	}
+	t.Fatalf("published baseline version %q not found in RuntimeMigrations()", publishedBaselineVersion)
+	return nil
+}
+
+func seedPublishedSchemaFixture(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	// Guard: multi-tenant tables must not exist yet on the published schema.
+	var tenantsExists bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.tables
+			 WHERE table_schema = 'public' AND table_name = 'tenants'
+		)
+	`).Scan(&tenantsExists); err != nil {
+		t.Fatalf("check tenants table: %v", err)
+	}
+	if tenantsExists {
+		t.Fatal("tenants table exists before multi-tenant migrations; baseline is not the published schema")
+	}
+
+	ts := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO request_logs (
+			timestamp, api_key, api_key_id, model, source, failed, streaming,
+			latency_ms, input_tokens, output_tokens, total_tokens, cost
+		) VALUES (?, 'legacy-key', 'legacy-key-id', 'gpt-test', 'seed', 0, 0, 10, 1, 2, 3, 0.01)
+	`, ts); err != nil {
+		t.Fatalf("seed request_logs: %v", err)
+	}
+	var logID int64
+	if err := db.QueryRowContext(ctx, `SELECT id FROM request_logs WHERE api_key_id = ?`, "legacy-key-id").Scan(&logID); err != nil {
+		t.Fatalf("read seeded request_logs id: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO request_log_content (log_id, timestamp, compression, session_id)
+		VALUES (?, ?, 'none', 'sess-legacy')
+	`, logID, ts); err != nil {
+		t.Fatalf("seed request_log_content: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO model_configs (
+			model_id, owned_by, description, enabled, pricing_mode, source, updated_at
+		) VALUES ('gpt-test', 'openai', 'legacy model', 1, 'token', 'user', ?)
+	`, ts); err != nil {
+		t.Fatalf("seed model_configs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO model_pricing (model_id, input_price_per_million, output_price_per_million, updated_at)
+		VALUES ('gpt-test', 1.5, 2.5, ?)
+	`, ts); err != nil {
+		t.Fatalf("seed model_pricing: %v", err)
+	}
+
+	// identity_fingerprint_profiles already applied: PK is (provider, account_key, profile_key).
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO identity_fingerprints (
+			provider, account_key, profile_key, auth_subject_id, client_product, client_variant,
+			version, fields_json, observed_headers_json, created_at, updated_at, last_seen_at
+		) VALUES (
+			'codex', 'acct-legacy', 'codex_cli_rs', 'subj-legacy', 'codex_cli_rs', 'codex_cli_rs',
+			'1.0.0', '{"ua":"cli"}', '{}', ?, ?, ?
+		)
+	`, ts.Format(time.RFC3339), ts.Format(time.RFC3339), ts.Format(time.RFC3339)); err != nil {
+		t.Fatalf("seed identity_fingerprints: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO identity_fingerprint_account_policies (
+			provider, account_key, strategy, active_profile_key, revision, updated_at
+		) VALUES ('codex', 'acct-legacy', 'cli_preferred', '', 1, ?)
+	`, ts.Format(time.RFC3339)); err != nil {
+		t.Fatalf("seed identity_fingerprint_account_policies: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO proxy_pool (id, name, url, enabled, description, created_at, updated_at)
+		VALUES ('proxy-legacy', 'Legacy Proxy', 'http://127.0.0.1:18080', 1, 'seed', ?, ?)
+	`, ts.Format(time.RFC3339), ts.Format(time.RFC3339)); err != nil {
+		t.Fatalf("seed proxy_pool: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO routing_config (id, payload, updated_at)
+		VALUES (1, '{"strategy":"round_robin"}', ?)
+	`, ts.Format(time.RFC3339)); err != nil {
+		t.Fatalf("seed routing_config: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO ccswitch_import_configs (
+			id, client_type, provider_name, note, default_model, model_mappings,
+			allowed_channel_groups, route_path, endpoint_path, usage_auto_interval,
+			api_key_field, created_at, updated_at
+		) VALUES (
+			'ccswitch-legacy', 'claude', 'anthropic', 'seed', 'claude-3', '[]',
+			'[]', '/import/legacy', '/v1/messages', 30, 'x-api-key', ?, ?
+		)
+	`, ts.Format(time.RFC3339), ts.Format(time.RFC3339)); err != nil {
+		t.Fatalf("seed ccswitch_import_configs: %v", err)
+	}
+}
+
+func assertAllMigrationsClean(t *testing.T, ctx context.Context, db *sql.DB, all []Migration) {
+	t.Helper()
 	rows, err := db.QueryContext(ctx, `SELECT version, dirty FROM schema_migrations ORDER BY version`)
 	if err != nil {
 		t.Fatal(err)
@@ -120,13 +232,131 @@ func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
 			t.Fatalf("migration %s not applied after upgrade", m.Version)
 		}
 	}
+}
 
-	var tenantCount int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM tenants WHERE id = ?`, seedID).Scan(&tenantCount); err != nil {
-		t.Fatalf("read seed after upgrade: %v", err)
+func assertMigratedFixture(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	// System tenant is seeded by multi_tenant_identity.
+	var systemCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM tenants WHERE id = ? AND type = 'system'`, systemTenantID).Scan(&systemCount); err != nil {
+		t.Fatalf("read system tenant: %v", err)
 	}
-	if tenantCount != 1 {
-		t.Fatalf("tenant seed lost after upgrade: count=%d", tenantCount)
+	if systemCount != 1 {
+		t.Fatalf("system tenant count = %d", systemCount)
+	}
+
+	assertTenantBackfill(t, ctx, db, "request_logs", `api_key_id = 'legacy-key-id'`)
+	assertTenantBackfill(t, ctx, db, "model_configs", `model_id = 'gpt-test'`)
+	assertTenantBackfill(t, ctx, db, "model_pricing", `model_id = 'gpt-test'`)
+	assertTenantBackfill(t, ctx, db, "proxy_pool", `id = 'proxy-legacy'`)
+	assertTenantBackfill(t, ctx, db, "routing_config", `id = 1`)
+	assertTenantBackfill(t, ctx, db, "ccswitch_import_configs", `id = 'ccswitch-legacy'`)
+	assertTenantBackfill(t, ctx, db, "identity_fingerprints", `provider = 'codex' AND account_key = 'acct-legacy' AND profile_key = 'codex_cli_rs'`)
+	assertTenantBackfill(t, ctx, db, "identity_fingerprint_account_policies", `provider = 'codex' AND account_key = 'acct-legacy'`)
+
+	var contentTenant string
+	var logID int64
+	if err := db.QueryRowContext(ctx, `
+		SELECT c.tenant_id, c.log_id
+		  FROM request_log_content c
+		  JOIN request_logs l ON l.tenant_id = c.tenant_id AND l.id = c.log_id
+		 WHERE l.api_key_id = 'legacy-key-id'
+	`).Scan(&contentTenant, &logID); err != nil {
+		t.Fatalf("read request_log_content after upgrade: %v", err)
+	}
+	if contentTenant != systemTenantID {
+		t.Fatalf("request_log_content.tenant_id = %q, want system", contentTenant)
+	}
+
+	var provider, account, profile, subject string
+	if err := db.QueryRowContext(ctx, `
+		SELECT provider, account_key, profile_key, auth_subject_id
+		  FROM identity_fingerprints
+		 WHERE tenant_id = ? AND provider = 'codex' AND account_key = 'acct-legacy' AND profile_key = 'codex_cli_rs'
+	`, systemTenantID).Scan(&provider, &account, &profile, &subject); err != nil {
+		t.Fatalf("identity fingerprint lost after upgrade: %v", err)
+	}
+	if provider != "codex" || account != "acct-legacy" || profile != "codex_cli_rs" || subject != "subj-legacy" {
+		t.Fatalf("fingerprint row unexpected: provider=%s account=%s profile=%s subject=%s", provider, account, profile, subject)
+	}
+
+	var strategy string
+	if err := db.QueryRowContext(ctx, `
+		SELECT strategy FROM identity_fingerprint_account_policies
+		 WHERE tenant_id = ? AND provider = 'codex' AND account_key = 'acct-legacy'
+	`, systemTenantID).Scan(&strategy); err != nil {
+		t.Fatalf("identity policy lost after upgrade: %v", err)
+	}
+	if strategy != "cli_preferred" {
+		t.Fatalf("policy strategy = %q", strategy)
+	}
+
+	// Composite PK: same business key allowed for another tenant, rejected within system tenant.
+	// ON CONFLICT keeps this assertion idempotent when assertMigratedFixture runs twice.
+	otherTenant := "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+	expires := time.Now().UTC().Add(30 * 24 * time.Hour)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO tenants (id, slug, name, type, status, expires_at, description, created_at, updated_at, version)
+		VALUES (?, 'other-tenant', 'Other Tenant', 'standard', 'active', ?, '', now(), now(), 1)
+		ON CONFLICT (id) DO NOTHING
+	`, otherTenant, expires); err != nil {
+		t.Fatalf("insert other tenant: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO model_configs (
+			tenant_id, model_id, owned_by, description, enabled, pricing_mode, source, updated_at
+		) VALUES (?, 'gpt-test', 'openai', 'other tenant model', 1, 'token', 'user', now())
+		ON CONFLICT (tenant_id, model_id) DO NOTHING
+	`, otherTenant); err != nil {
+		t.Fatalf("composite PK should allow same model_id for different tenant: %v", err)
+	}
+	var crossTenantCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM model_configs WHERE model_id = 'gpt-test'
+	`).Scan(&crossTenantCount); err != nil {
+		t.Fatalf("count model_configs by model_id: %v", err)
+	}
+	if crossTenantCount != 2 {
+		t.Fatalf("expected gpt-test for system + other tenant, count=%d", crossTenantCount)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO model_configs (
+			tenant_id, model_id, owned_by, description, enabled, pricing_mode, source, updated_at
+		) VALUES (?, 'gpt-test', 'openai', 'dup', 1, 'token', 'user', now())
+	`, systemTenantID); err == nil {
+		t.Fatal("expected duplicate model_id within same tenant to fail")
+	}
+
+	// Idempotency of fixture data: still exactly one legacy proxy / fingerprint under system tenant.
+	var proxyCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM proxy_pool WHERE id = 'proxy-legacy'`).Scan(&proxyCount); err != nil {
+		t.Fatalf("count proxy_pool: %v", err)
+	}
+	if proxyCount != 1 {
+		t.Fatalf("proxy_pool legacy count = %d", proxyCount)
+	}
+	var fpCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM identity_fingerprints
+		 WHERE provider = 'codex' AND account_key = 'acct-legacy'
+	`).Scan(&fpCount); err != nil {
+		t.Fatalf("count fingerprints: %v", err)
+	}
+	if fpCount != 1 {
+		t.Fatalf("identity_fingerprints legacy count = %d", fpCount)
+	}
+}
+
+func assertTenantBackfill(t *testing.T, ctx context.Context, db *sql.DB, table, where string) {
+	t.Helper()
+	query := fmt.Sprintf(`SELECT tenant_id FROM %s WHERE %s`, table, where)
+	var tenantID string
+	if err := db.QueryRowContext(ctx, query).Scan(&tenantID); err != nil {
+		t.Fatalf("read %s after upgrade: %v", table, err)
+	}
+	if tenantID != systemTenantID {
+		t.Fatalf("%s.tenant_id = %q, want system tenant", table, tenantID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add platform-sensitive `system.logs.delete` and map `DELETE /v0/management/logs` to it so log readers cannot clear rotated/active file logs.
- Strengthen management route permission invariants so non-GET/HEAD routes never map to `*.read`.
- Rewrite the Postgres upgrade fixture to start from published `origin/main` baseline `202607100001_identity_fingerprint_profiles`, seed legacy multi-table data, then assert system-tenant backfill, composite keys, and idempotent re-apply.

Closes residual findings from review `docs/review/015-grok-45-remediation-recheck-20260713.md` / plan `docs/plan/061-grok-45-remediation-round-2-20260713.md`.

## Test plan
- [x] `go test ./internal/api/handlers/management ./internal/api/routes ./internal/identity`
- [x] `CLIRELAY_POSTGRES_TEST_DSN=... go test ./internal/storage/postgres -run TestApplyMigrationsUpgradeFromPublishedSchema -count=1 -v`
- [x] `./scripts/ci-pr.sh`
- [x] `golangci-lint run --config .golangci.yml`
- [x] `go build ./cmd/server`
- [ ] Remote PR CI: Postgres service healthy and `TestApplyMigrationsUpgradeFromPublishedSchema` not skipped