### PR TITLE
test: harden log delete middleware and published migration checksums

### DIFF
--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -1,12 +1,17 @@
 package management
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
 )
 
 func TestPermissionForManagementRequest(t *testing.T) {
@@ -91,36 +96,120 @@ func TestServiceCredentialCannotAccessTenantGovernance(t *testing.T) {
 	}
 }
 
-// TestLogsDeleteRequiresExplicitPermission mirrors authenticateSessionToken's
-// permission gate: read-only log viewers must not pass DELETE /logs.
-func TestLogsDeleteRequiresExplicitPermission(t *testing.T) {
-	readOnly := identity.Principal{
-		Permissions: map[string]bool{"system.logs.read": true},
+// TestLogsDeleteMiddlewareRequiresExplicitPermission drives real sessions
+// through Handler.Middleware(): read-only DELETE is 403 and never reaches the
+// handler; delete-capable DELETE and read-only GET both enter the handler.
+func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CLIRELAY_POSTGRES_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
-	deleter := identity.Principal{
-		Permissions: map[string]bool{
-			"system.logs.read":   true,
-			"system.logs.delete": true,
-		},
+	ctx := context.Background()
+	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	getPerm := permissionForManagementRequest(http.MethodGet, "/v0/management/logs")
-	deletePerm := permissionForManagementRequest(http.MethodDelete, "/v0/management/logs")
-	if getPerm != "system.logs.read" {
-		t.Fatalf("GET /logs permission = %q, want system.logs.read", getPerm)
-	}
-	if deletePerm != "system.logs.delete" {
-		t.Fatalf("DELETE /logs permission = %q, want system.logs.delete", deletePerm)
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err = db.ExecContext(ctx, `TRUNCATE audit_logs,user_sessions,user_roles,role_permissions,menus,users,roles,permissions,tenants CASCADE`); err != nil {
+		t.Fatal(err)
 	}
 
-	// Same condition as authenticateSessionToken after permission lookup.
-	if getPerm == "" || !readOnly.Has(getPerm) {
-		t.Fatal("read-only principal should pass GET /logs")
+	service := identity.NewService(db)
+	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
+		t.Fatal(err)
 	}
-	if deletePerm != "" && readOnly.Has(deletePerm) {
-		t.Fatal("read-only principal must not pass DELETE /logs")
+	// Pin the service on the handler so Middleware does not depend on process-global Default().
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	// Platform roles that grant only the log permissions under test. CreateRole
+	// rejects platform-scoped permissions, so seed via SQL like production would
+	// for a custom platform operator role.
+	type logUserFixture struct {
+		username, password, userID, roleID string
+		permissions                        []string
 	}
-	if deletePerm == "" || !deleter.Has(deletePerm) {
-		t.Fatal("principal with system.logs.delete should pass DELETE /logs")
+	seedPlatformLogUser := func(fx logUserFixture) string {
+		t.Helper()
+		hash, hashErr := identity.HashPassword(fx.password)
+		if hashErr != nil {
+			t.Fatal(hashErr)
+		}
+		if _, err = db.ExecContext(ctx, `
+			INSERT INTO roles (id, tenant_id, code, name, description, scope, system_protected)
+			VALUES (?, ?, ?, ?, '', 'platform', false)
+		`, fx.roleID, identity.SystemTenantID, "platform_"+fx.username, fx.username+" role"); err != nil {
+			t.Fatalf("seed role %s: %v", fx.username, err)
+		}
+		for _, perm := range fx.permissions {
+			if _, err = db.ExecContext(ctx, `
+				INSERT INTO role_permissions (role_id, permission_code) VALUES (?, ?)
+			`, fx.roleID, perm); err != nil {
+				t.Fatalf("seed role permission %s: %v", perm, err)
+			}
+		}
+		if _, err = db.ExecContext(ctx, `
+			INSERT INTO users (
+			  id, tenant_id, username, username_normalized, display_name, password_hash,
+			  status, must_change_password, password_changed_at, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, 'active', false, now(), now(), now())
+		`, fx.userID, identity.SystemTenantID, fx.username, fx.username, fx.username, hash); err != nil {
+			t.Fatalf("seed user %s: %v", fx.username, err)
+		}
+		if _, err = db.ExecContext(ctx, `INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)`, fx.userID, fx.roleID); err != nil {
+			t.Fatalf("seed user role %s: %v", fx.username, err)
+		}
+		login, loginErr := service.Login(ctx, fx.username, fx.password, false, "middleware-test")
+		if loginErr != nil {
+			t.Fatalf("login %s: %v", fx.username, loginErr)
+		}
+		return login.AccessToken
+	}
+
+	readToken := seedPlatformLogUser(logUserFixture{
+		username:    "log-reader",
+		password:    "reader-password-123",
+		userID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
+		roleID:      "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+		permissions: []string{"system.logs.read"},
+	})
+	deleteToken := seedPlatformLogUser(logUserFixture{
+		username:    "log-deleter",
+		password:    "deleter-password-123",
+		userID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2",
+		roleID:      "cccccccc-cccc-cccc-cccc-ccccccccccc2",
+		permissions: []string{"system.logs.read", "system.logs.delete"},
+	})
+
+	serve := func(method, token string) (int, bool) {
+		t.Helper()
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(h.Middleware())
+		reached := false
+		handler := func(c *gin.Context) {
+			reached = true
+			c.Status(http.StatusOK)
+		}
+		router.GET("/v0/management/logs", handler)
+		router.DELETE("/v0/management/logs", handler)
+
+		req := httptest.NewRequest(method, "/v0/management/logs", nil)
+		req.RemoteAddr = "127.0.0.1:4321"
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec.Code, reached
+	}
+
+	if code, reached := serve(http.MethodDelete, readToken); code != http.StatusForbidden || reached {
+		t.Fatalf("read-only DELETE: status=%d reached=%v, want 403 and handler not executed", code, reached)
+	}
+	if code, reached := serve(http.MethodGet, readToken); code != http.StatusOK || !reached {
+		t.Fatalf("read-only GET: status=%d reached=%v, want 200 and handler executed", code, reached)
+	}
+	if code, reached := serve(http.MethodDelete, deleteToken); code != http.StatusOK || !reached {
+		t.Fatalf("delete-capable DELETE: status=%d reached=%v, want 200 and handler executed", code, reached)
 	}
 }

--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -2,16 +2,21 @@ package management
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres/compatdriver"
 )
 
 func TestPermissionForManagementRequest(t *testing.T) {
@@ -99,20 +104,45 @@ func TestServiceCredentialCannotAccessTenantGovernance(t *testing.T) {
 // TestLogsDeleteMiddlewareRequiresExplicitPermission drives real sessions
 // through Handler.Middleware(): read-only DELETE is 403 and never reaches the
 // handler; delete-capable DELETE and read-only GET both enter the handler.
+//
+// Uses a disposable database so parallel package tests that TRUNCATE the shared
+// CLIRELAY_POSTGRES_TEST_DSN catalog cannot race this middleware fixture.
 func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 	dsn := strings.TrimSpace(os.Getenv("CLIRELAY_POSTGRES_TEST_DSN"))
 	if dsn == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
 	ctx := context.Background()
-	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
+
+	adminDB, err := sql.Open("pgxq", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer adminDB.Close()
+	if err = adminDB.PingContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+	dbName := fmt.Sprintf("logs_delete_mw_%d", time.Now().UnixNano())
+	if _, err = adminDB.ExecContext(ctx, "CREATE DATABASE "+dbName); err != nil {
+		t.Fatalf("create disposable db: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = adminDB.ExecContext(context.Background(), `
+			SELECT pg_terminate_backend(pid)
+			  FROM pg_stat_activity
+			 WHERE datname = $1 AND pid <> pg_backend_pid()
+		`, dbName)
+		_, _ = adminDB.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+dbName)
+	})
+	testDSN, err := replacePostgresDatabaseForTest(dsn, dbName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: testDSN, MaxOpenConns: 4, MaxIdleConns: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if _, err = db.ExecContext(ctx, `TRUNCATE audit_logs,user_sessions,user_roles,role_permissions,menus,users,roles,permissions,tenants CASCADE`); err != nil {
-		t.Fatal(err)
-	}
 
 	service := identity.NewService(db)
 	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
@@ -212,4 +242,30 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 	if code, reached := serve(http.MethodDelete, deleteToken); code != http.StatusOK || !reached {
 		t.Fatalf("delete-capable DELETE: status=%d reached=%v, want 200 and handler executed", code, reached)
 	}
+}
+
+func replacePostgresDatabaseForTest(dsn, dbName string) (string, error) {
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		u, err := url.Parse(dsn)
+		if err != nil {
+			return "", err
+		}
+		u.Path = "/" + dbName
+		return u.String(), nil
+	}
+	parts := strings.Fields(dsn)
+	out := make([]string, 0, len(parts))
+	replaced := false
+	for _, p := range parts {
+		if strings.HasPrefix(p, "dbname=") {
+			out = append(out, "dbname="+dbName)
+			replaced = true
+			continue
+		}
+		out = append(out, p)
+	}
+	if !replaced {
+		out = append(out, "dbname="+dbName)
+	}
+	return strings.Join(out, " "), nil
 }

--- a/internal/storage/postgres/migration_upgrade_test.go
+++ b/internal/storage/postgres/migration_upgrade_test.go
@@ -18,6 +18,15 @@ import (
 // drifts as new migrations land and stops testing the real production upgrade.
 const publishedBaselineVersion = "202607100001_identity_fingerprint_profiles"
 
+// publishedMigrationChecksums freezes the SHA-256 of each migration shipped on
+// origin/main. Fixture DBs derive checksums from current SQL; without these
+// constants, editing published SQL would still green the upgrade test while
+// production DBs that stored the original checksum would fail on restart.
+var publishedMigrationChecksums = map[string]string{
+	"202607050001_runtime_schema":                "317006f359fe24774669019d8bee978e1b7d8e0cfe65787299369fd6bad78943",
+	"202607100001_identity_fingerprint_profiles": "28c575b2828152d5ab2771119c5c7f5274e4524eb46ef506dc1362be6f89bdd5",
+}
+
 const systemTenantID = "00000000-0000-0000-0000-000000000001"
 
 // TestApplyMigrationsUpgradeFromPublishedSchema applies only the migrations
@@ -69,6 +78,7 @@ func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
 	}
 
 	all := RuntimeMigrations()
+	assertPublishedMigrationChecksums(t, all)
 	baseline := publishedBaselineMigrations(t, all)
 	if len(baseline) != 2 {
 		t.Fatalf("published baseline should be 2 migrations (runtime + fingerprint profiles), got %d", len(baseline))
@@ -106,6 +116,30 @@ func publishedBaselineMigrations(t *testing.T, all []Migration) []Migration {
 	}
 	t.Fatalf("published baseline version %q not found in RuntimeMigrations()", publishedBaselineVersion)
 	return nil
+}
+
+// TestPublishedMigrationChecksums locks the two origin/main migrations so a
+// silent edit to published SQL fails CI before it can poison upgrade fixtures.
+func TestPublishedMigrationChecksums(t *testing.T) {
+	assertPublishedMigrationChecksums(t, RuntimeMigrations())
+}
+
+func assertPublishedMigrationChecksums(t *testing.T, all []Migration) {
+	t.Helper()
+	byVersion := make(map[string]Migration, len(all))
+	for _, m := range all {
+		byVersion[m.Version] = m
+	}
+	for version, want := range publishedMigrationChecksums {
+		m, ok := byVersion[version]
+		if !ok {
+			t.Fatalf("published migration %q missing from RuntimeMigrations()", version)
+		}
+		got := migrationChecksum(m.SQL)
+		if got != want {
+			t.Fatalf("published migration %q checksum = %s, want %s (do not edit shipped SQL; add a new migration instead)", version, got, want)
+		}
+	}
 }
 
 func seedPublishedSchemaFixture(t *testing.T, ctx context.Context, db *sql.DB) {


### PR DESCRIPTION
## Summary
- Replace the white-box `TestLogsDeleteRequiresExplicitPermission` with a real session + `Handler.Middleware()` test: read-only DELETE → 403/`reached=false`, read-only GET → 200/`reached=true`, delete-capable DELETE → 200/`reached=true`.
- Freeze SHA-256 checksums for the two `origin/main` migrations and assert them before the published-schema upgrade fixture runs (`TestPublishedMigrationChecksums`).

Closes the two P3 residual items from `docs/review/016-grok-45-remediation-final-recheck-20260713.md`. No production code changes.

## Test plan
- [x] `gofmt` clean on touched files
- [x] `CLIRELAY_POSTGRES_TEST_DSN=... go test ./internal/api/handlers/management -count=1`
- [x] `CLIRELAY_POSTGRES_TEST_DSN=... go test ./internal/identity -count=1`
- [x] `CLIRELAY_POSTGRES_TEST_DSN=... go test ./internal/storage/postgres -count=1`
- [x] Targeted: `TestLogsDeleteMiddlewareRequiresExplicitPermission`, `TestPublishedMigrationChecksums`, `TestApplyMigrationsUpgradeFromPublishedSchema`