### PR TITLE
test: drop disposable Postgres DBs after fixture cleanup

### DIFF
--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -118,21 +118,32 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer adminDB.Close()
 	if err = adminDB.PingContext(ctx); err != nil {
+		_ = adminDB.Close()
 		t.Fatal(err)
 	}
 	dbName := fmt.Sprintf("logs_delete_mw_%d", time.Now().UnixNano())
 	if _, err = adminDB.ExecContext(ctx, "CREATE DATABASE "+dbName); err != nil {
+		_ = adminDB.Close()
 		t.Fatalf("create disposable db: %v", err)
 	}
+	// Register admin teardown first so LIFO runs: runtime close → drop → admin close.
+	// Do not defer adminDB.Close(); that runs before t.Cleanup and leaves the DB behind.
 	t.Cleanup(func() {
-		_, _ = adminDB.ExecContext(context.Background(), `
+		cleanupCtx := context.Background()
+		if _, err := adminDB.ExecContext(cleanupCtx, `
 			SELECT pg_terminate_backend(pid)
 			  FROM pg_stat_activity
 			 WHERE datname = $1 AND pid <> pg_backend_pid()
-		`, dbName)
-		_, _ = adminDB.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+dbName)
+		`, dbName); err != nil {
+			t.Errorf("terminate connections on disposable db %s: %v", dbName, err)
+		}
+		if _, err := adminDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+dbName); err != nil {
+			t.Errorf("drop disposable db %s: %v", dbName, err)
+		}
+		if err := adminDB.Close(); err != nil {
+			t.Errorf("close admin db: %v", err)
+		}
 	})
 	testDSN, err := replacePostgresDatabaseForTest(dsn, dbName)
 	if err != nil {
@@ -142,7 +153,11 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close runtime db: %v", err)
+		}
+	})
 
 	service := identity.NewService(db)
 	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {

--- a/internal/storage/postgres/migration_upgrade_test.go
+++ b/internal/storage/postgres/migration_upgrade_test.go
@@ -46,22 +46,33 @@ func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer adminDB.Close()
 	if err := adminDB.PingContext(ctx); err != nil {
+		_ = adminDB.Close()
 		t.Fatal(err)
 	}
 
 	dbName := fmt.Sprintf("mig_upgrade_%d", time.Now().UnixNano())
 	if _, err := adminDB.ExecContext(ctx, "CREATE DATABASE "+dbName); err != nil {
+		_ = adminDB.Close()
 		t.Fatalf("create disposable db: %v", err)
 	}
+	// Register admin teardown first so LIFO runs: runtime close → drop → admin close.
+	// Do not defer adminDB.Close(); that runs before t.Cleanup and leaves the DB behind.
 	t.Cleanup(func() {
-		_, _ = adminDB.ExecContext(context.Background(), `
+		cleanupCtx := context.Background()
+		if _, err := adminDB.ExecContext(cleanupCtx, `
 			SELECT pg_terminate_backend(pid)
 			  FROM pg_stat_activity
 			 WHERE datname = $1 AND pid <> pg_backend_pid()
-		`, dbName)
-		_, _ = adminDB.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+dbName)
+		`, dbName); err != nil {
+			t.Errorf("terminate connections on disposable db %s: %v", dbName, err)
+		}
+		if _, err := adminDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+dbName); err != nil {
+			t.Errorf("drop disposable db %s: %v", dbName, err)
+		}
+		if err := adminDB.Close(); err != nil {
+			t.Errorf("close admin db: %v", err)
+		}
 	})
 
 	testDSN, err := replacePostgresDatabase(dsn, dbName)
@@ -72,7 +83,11 @@ func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close runtime db: %v", err)
+		}
+	})
 	if err := db.PingContext(ctx); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Fix P2 from `docs/review/017-grok-45-test-hardening-recheck-20260713.md`: `defer adminDB.Close()` ran before `t.Cleanup`, so `DROP DATABASE` failed with `sql: database is closed` and leftover `logs_delete_mw_*` / `mig_upgrade_*` databases remained.
- Register admin teardown via `t.Cleanup` only (LIFO: runtime close → terminate/drop → admin close) and surface cleanup errors with `t.Errorf`.

No production code changes.

## Test plan
- [x] `go test ./internal/api/handlers/management -run TestLogsDeleteMiddlewareRequiresExplicitPermission -count=1`
- [x] `go test ./internal/storage/postgres -run 'TestApplyMigrationsUpgradeFromPublishedSchema|TestPublishedMigrationChecksums' -count=1`
- [x] After two full runs: `SELECT datname FROM pg_database WHERE datname LIKE 'logs_delete_mw_%' OR datname LIKE 'mig_upgrade_%'` → 0 rows