### PR TITLE
fix: resolve tenant for public usage summary

### DIFF
--- a/internal/api/handlers/management/usage_summary_public.go
+++ b/internal/api/handlers/management/usage_summary_public.go
@@ -54,14 +54,22 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 		return
 	}
 
-	stats, err := usage.QueryStats(usage.LogQueryParams{APIKey: apiKey, Days: 1})
+	// Public summary is unauthenticated and only receives the raw API key.
+	// Resolve the key's tenant first so multi-tenant deployments do not query
+	// the system catalog (which would always return found=false / zero stats).
+	tenantID := usage.ResolveAPIKeyTenant(apiKey)
+	stats, err := usage.QueryStats(usage.LogQueryParams{
+		TenantID: tenantID,
+		APIKey:   apiKey,
+		Days:     1,
+	})
 	if err != nil {
 		log.Warnf("management usage logs: public usage summary query failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query usage summary"})
 		return
 	}
 
-	row := apikeysettings.NewService(nil).GetRow(apiKey)
+	row := apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID)).GetRow(apiKey)
 	found := row != nil && !row.Disabled
 
 	resp := usageSummaryResponse{

--- a/internal/api/handlers/management/usage_summary_public_test.go
+++ b/internal/api/handlers/management/usage_summary_public_test.go
@@ -236,3 +236,73 @@ func TestGetPublicUsageSummary(t *testing.T) {
 		}
 	})
 }
+
+// Regression: multi-tenant keys must not be looked up under the system tenant.
+// CC Switch polls this endpoint with the raw API key only; without ResolveAPIKeyTenant
+// the card always shows 0 calls / $0 even when request_logs has real usage.
+func TestGetPublicUsageSummary_ResolvesBusinessTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupUsageSummaryTestDB(t)
+
+	const (
+		tenantID = "00000000-0000-0000-0000-0000000000aa"
+		apiKey   = "sk-business-tenant-usage"
+	)
+
+	if err := usage.UpsertAPIKeyForTenant(tenantID, usage.APIKeyRow{
+		Key:      apiKey,
+		Name:     "business-user",
+		Disabled: false,
+	}); err != nil {
+		t.Fatalf("UpsertAPIKeyForTenant: %v", err)
+	}
+
+	// InsertLog derives tenant from the API key row, so this lands in the business tenant.
+	usage.InsertLog(apiKey, "business-user", "gpt-5.4", "test", "chan", "idx", false, time.Now(), 100, 50,
+		usage.TokenStats{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+		"", "",
+	)
+	usage.InsertLog(apiKey, "business-user", "gpt-5.4", "test", "chan", "idx", false, time.Now(), 100, 50,
+		usage.TokenStats{InputTokens: 5, OutputTokens: 5, TotalTokens: 10},
+		"", "",
+	)
+
+	// Sanity: system-tenant lookup must not see this key (precondition of the bug).
+	if row := usage.GetAPIKey(apiKey); row != nil {
+		t.Fatalf("precondition failed: GetAPIKey (system tenant) unexpectedly found business key")
+	}
+	if row := usage.GetAPIKeyForTenant(tenantID, apiKey); row == nil {
+		t.Fatalf("precondition failed: business tenant key missing")
+	}
+
+	body := []byte(`{"api_key":"` + apiKey + `"}`)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage/summary", bytes.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.GetPublicUsageSummary(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got struct {
+		Found bool   `json:"found"`
+		Range string `json:"range"`
+		Stats struct {
+			TotalCalls int64   `json:"total_calls"`
+			QuotaCost  float64 `json:"quota_cost"`
+		} `json:"stats"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.Found {
+		t.Errorf("found = false, want true for business-tenant key")
+	}
+	if got.Stats.TotalCalls != 2 {
+		t.Errorf("total_calls = %d, want 2", got.Stats.TotalCalls)
+	}
+}


### PR DESCRIPTION
## Summary
- CC Switch 轮询 `/v0/management/public/usage/summary` 时只带原始 API Key；多租户后该接口默认查 system tenant，导致 `found=false` 且今日调用/费用恒为 0，尽管 `request_logs` 已有真实用量。
- 与 public usage logs 对齐：先 `ResolveAPIKeyTenant`，再 `QueryStats` / `GetRow`。
- 补充业务租户回归测试，防止再次回落到 system catalog。

## Test plan
- [x] `go test ./internal/api/handlers/management/ -run 'TestGetPublicUsageSummary|TestGetPublicUsageLogs' -count=1`
- [x] `go test ./internal/api/routes/ -run 'TestRegisterManagementRouteTable|postgres' -count=1`
- [ ] 合并部署后，用业务租户完整 `sk-...` 调 `POST /v0/management/public/usage/summary`，确认 `found=true` 且 `total_calls` 非 0
- [ ] CC Switch 卡片「已使用 / 今日消耗」不再恒为 0