### PR TITLE
fix: assign request IDs for management audit logs

### DIFF
--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -98,9 +98,18 @@ func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Princ
 	if result == "success" && !write && !sensitiveRead {
 		return
 	}
+	// Prefer middleware-assigned ID; fall back to generating one so audit rows stay correlatable
+	// even if request-id middleware skipped this path (e.g. older deployments / test routers).
 	requestID := logging.GetGinRequestID(c)
 	if requestID == "" {
 		requestID = logging.GetRequestID(c.Request.Context())
+	}
+	if requestID == "" {
+		requestID = logging.GenerateRequestID()
+		logging.SetGinRequestID(c, requestID)
+		if c.Request != nil {
+			c.Request = c.Request.WithContext(logging.WithRequestID(c.Request.Context(), requestID))
+		}
 	}
 	routePath := strings.TrimPrefix(c.Request.URL.Path, "/v0/management")
 	handlerName := c.Request.Method + " " + routePath

--- a/internal/identity/service_admin.go
+++ b/internal/identity/service_admin.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -48,6 +49,13 @@ func (s *Service) RecordAudit(ctx context.Context, event AuditEvent) {
 	if s == nil || s.db == nil {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Domain callers often omit RequestID; pull from request context when present.
+	if strings.TrimSpace(event.RequestID) == "" {
+		event.RequestID = logging.GetRequestID(ctx)
+	}
 	var tenantID, actorUserID, actorSessionID any
 	if event.TenantID != "" {
 		tenantID = event.TenantID
@@ -79,11 +87,7 @@ func (s *Service) RecordAudit(ctx context.Context, event AuditEvent) {
 	if err != nil {
 		changesJSON = []byte("{}")
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	} else {
-		ctx = context.WithoutCancel(ctx)
-	}
+	ctx = context.WithoutCancel(ctx)
 	auditCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	if _, err := s.db.ExecContext(auditCtx, `INSERT INTO audit_logs (tenant_id,actor_kind,actor_user_id,actor_session_id,action,resource_type,resource_id,result,request_id,changes) VALUES (?,?,?,?,?,?,?,?,?,?::jsonb)`, tenantID, event.ActorKind, actorUserID, actorSessionID, event.Action, event.ResourceType, event.ResourceID, event.Result, event.RequestID, string(changesJSON)); err != nil {

--- a/internal/logging/gin_logger.go
+++ b/internal/logging/gin_logger.go
@@ -30,10 +30,11 @@ const skipGinLogKey = "__gin_skip_request_logging__"
 
 // GinLogrusLogger returns a Gin middleware handler that logs HTTP requests and responses
 // using logrus. It captures request details including method, path, status code, latency,
-// client IP, and any error messages. Request ID is only added for AI API requests.
+// client IP, and any error messages. Request ID is generated for AI API and management
+// paths (management needs it for audit-log correlation).
 //
-// Output format (AI API): [2025-12-23 20:14:10] [info ] | a1b2c3d4 | 200 |       23.559s | ...
-// Output format (others): [2025-12-23 20:14:10] [info ] | -------- | 200 |       23.559s | ...
+// Output format (tracked): [2025-12-23 20:14:10] [info ] | a1b2c3d4 | 200 |       23.559s | ...
+// Output format (others):  [2025-12-23 20:14:10] [info ] | -------- | 200 |       23.559s | ...
 //
 // Returns:
 //   - gin.HandlerFunc: A middleware handler for request logging
@@ -43,9 +44,9 @@ func GinLogrusLogger() gin.HandlerFunc {
 		path := c.Request.URL.Path
 		raw := util.MaskSensitiveQuery(c.Request.URL.RawQuery)
 
-		// Only generate request ID for AI API paths
+		// AI API + management: attach request ID for log/audit correlation.
 		var requestID string
-		if isAIAPIPath(path) {
+		if shouldTrackRequestID(path) {
 			requestID = GenerateRequestID()
 			SetGinRequestID(c, requestID)
 			ctx := WithRequestID(c.Request.Context(), requestID)
@@ -106,6 +107,16 @@ func isAIAPIPath(path string) bool {
 		}
 	}
 	return false
+}
+
+// isManagementPath reports management console/API routes that need request IDs for audit logs.
+func isManagementPath(path string) bool {
+	return strings.HasPrefix(path, "/v0/management") || strings.HasPrefix(path, "/management")
+}
+
+// shouldTrackRequestID reports paths that receive a generated request ID.
+func shouldTrackRequestID(path string) bool {
+	return isAIAPIPath(path) || isManagementPath(path)
 }
 
 // GinLogrusRecovery returns a Gin middleware handler that recovers from panics and logs

--- a/internal/logging/gin_logger_test.go
+++ b/internal/logging/gin_logger_test.go
@@ -97,3 +97,50 @@ func TestGinLogrusLoggerPrefersForwardedClientIPForCDNRequests(t *testing.T) {
 		t.Fatalf("log line = %q, should not use proxy connection IP", line)
 	}
 }
+
+func TestGinLogrusLoggerAssignsRequestIDForManagementPaths(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var got string
+	engine := gin.New()
+	engine.Use(GinLogrusLogger())
+	engine.GET("/v0/management/request-log-storage/store-content", func(c *gin.Context) {
+		got = GetGinRequestID(c)
+		if ctxID := GetRequestID(c.Request.Context()); ctxID != got {
+			t.Errorf("context request id = %q, gin = %q", ctxID, got)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/request-log-storage/store-content", nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+	if got == "" {
+		t.Fatal("expected management path to receive a request ID")
+	}
+	if len(got) != 8 {
+		t.Fatalf("request ID length = %d, want 8 (got %q)", len(got), got)
+	}
+}
+
+func TestShouldTrackRequestID(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/v1/messages", true},
+		{"/v0/management/audit-logs", true},
+		{"/management/health", true},
+		{"/healthz", false},
+		{"/api/other", false},
+	}
+	for _, tc := range cases {
+		if got := shouldTrackRequestID(tc.path); got != tc.want {
+			t.Errorf("shouldTrackRequestID(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Generate request IDs for `/v0/management` and `/management` routes so audit logs can correlate with requests.
- Fall back to generating a request ID when recording management audits if middleware did not assign one.
- Fill `RequestID` from request context in `RecordAudit` for domain audit events that omit it.

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] `go test ./internal/identity/ ./internal/logging/ ./internal/api/handlers/management/ -count=1`
- [ ] After deploy: open a management action that writes an audit log and confirm detail shows a non-empty 请求 ID

Note: historical audit rows remain empty; only new requests after deploy get IDs.