### PR TITLE
fix: merge raw and id API key distribution groups

### DIFF
--- a/internal/usage/api_key_identity.go
+++ b/internal/usage/api_key_identity.go
@@ -51,6 +51,21 @@ func currentAPIKeyRowsByIDForTenant(tenantID string) map[string]APIKeyRow {
 	return result
 }
 
+// currentAPIKeyRowsByKeyForTenant indexes live API keys by raw secret so
+// legacy request_logs rows missing api_key_id can still resolve to the same
+// identity as rows that already carry the stable id.
+func currentAPIKeyRowsByKeyForTenant(tenantID string) map[string]APIKeyRow {
+	rows := ListAPIKeysForTenant(tenantID)
+	result := make(map[string]APIKeyRow, len(rows))
+	for _, row := range rows {
+		key := strings.TrimSpace(row.Key)
+		if key != "" {
+			result[key] = row
+		}
+	}
+	return result
+}
+
 func uniqueAPIKeyIDByName() map[string]string {
 	return uniqueAPIKeyIDByNameFromRows(ListAPIKeys())
 }

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -522,7 +522,13 @@ func QueryAPIKeyDistributionForTenant(tenantID string, days int) ([]APIKeyDistri
 	params := LogQueryParams{TenantID: tenantID, Days: days}
 	where, args := buildWhereClause(params)
 	currentByID := currentAPIKeyRowsByIDForTenant(tenantID)
+	currentByKey := currentAPIKeyRowsByKeyForTenant(tenantID)
 
+	// Group by id-or-raw so logs that predate api_key_id still contribute.
+	// Post-scan we resolve raw secrets via the live key table and merge
+	// id-group + raw-group of the same key into one distribution point.
+	// Without that merge, monitor "API Key usage" shows duplicate names
+	// (e.g. 袁蔚 16.1k + 袁蔚 177) for a single key.
 	q := `SELECT
 	             CASE
 	               WHEN trim(coalesce(api_key_id, '')) <> '' THEN api_key_id
@@ -543,7 +549,8 @@ func QueryAPIKeyDistributionForTenant(tenantID string, days int) ([]APIKeyDistri
 	}
 	defer rows.Close()
 
-	var result []APIKeyDistributionPoint
+	merged := make(map[string]*APIKeyDistributionPoint)
+	order := make([]string, 0)
 	for rows.Next() {
 		var logicalSelector string
 		var logicalID sql.NullString
@@ -555,7 +562,17 @@ func QueryAPIKeyDistributionForTenant(tenantID string, days int) ([]APIKeyDistri
 		}
 		p.APIKey = strings.TrimSpace(snapshotKey)
 		p.Name = strings.TrimSpace(snapshotName)
+
+		// Prefer stable id identity; fall back to exact raw-key match for
+		// legacy rows that never received api_key_id backfill.
 		if row, ok := currentByID[trimNullString(logicalID)]; ok {
+			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
+				p.APIKey = trimmed
+			}
+			if trimmed := strings.TrimSpace(row.Name); trimmed != "" {
+				p.Name = trimmed
+			}
+		} else if row, ok := currentByKey[p.APIKey]; ok {
 			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
 				p.APIKey = trimmed
 			}
@@ -566,9 +583,34 @@ func QueryAPIKeyDistributionForTenant(tenantID string, days int) ([]APIKeyDistri
 		if p.APIKey == "" {
 			continue
 		}
-		result = append(result, p)
+
+		if existing, ok := merged[p.APIKey]; ok {
+			existing.Requests += p.Requests
+			existing.Tokens += p.Tokens
+			if existing.Name == "" && p.Name != "" {
+				existing.Name = p.Name
+			}
+			continue
+		}
+		point := p
+		merged[p.APIKey] = &point
+		order = append(order, p.APIKey)
 	}
-	return result, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	result := make([]APIKeyDistributionPoint, 0, len(order))
+	for _, key := range order {
+		result = append(result, *merged[key])
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].Requests != result[j].Requests {
+			return result[i].Requests > result[j].Requests
+		}
+		return result[i].APIKey < result[j].APIKey
+	})
+	return result, nil
 }
 
 // HourlyTokenPoint holds token usage per hour for the last N hours.

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1856,6 +1856,81 @@ func TestQueryFiltersForLogsLinksFilterFacets(t *testing.T) {
 	}
 }
 
+func TestQueryAPIKeyDistributionMergesRawAndIDGroupsForSameKey(t *testing.T) {
+	// Production shape: some request_logs carry api_key_id, older rows for the
+	// same secret only have api_key. Distribution must merge into one point so
+	// the monitor donut does not list the same name twice.
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	const (
+		stableID = "16332427-2510-48e4-9c42-dcc148008ea0"
+		rawKey   = "sk-bai8v0z1hoytg4wopcyxz9t9t0yvx0zb"
+		name     = "袁蔚"
+	)
+	if err := UpsertAPIKey(APIKeyRow{ID: stableID, Key: rawKey, Name: name}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentity(rawKey, stableID, name, "gpt-test", "source", "channel", "auth-1", false, now, 10, 10, TokenStats{TotalTokens: 100}, "", "", "")
+	InsertLogWithDetailsIdentity(rawKey, stableID, name, "gpt-test", "source", "channel", "auth-1", false, now.Add(time.Second), 10, 10, TokenStats{TotalTokens: 50}, "", "", "")
+
+	db := getDB()
+	// Legacy rows: same raw key, empty api_key_id (and often empty name snapshot).
+	for i := 0; i < 3; i++ {
+		ts := now.Add(time.Duration(i+2) * time.Second).Format(time.RFC3339Nano)
+		if _, err := db.Exec(
+			`INSERT INTO request_logs
+				(timestamp, api_key, api_key_id, api_key_name, model, source, channel_name, auth_index,
+				 failed, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			ts, rawKey, "", "", "gpt-test", "source", "channel", "auth-1",
+			0, 10, 1, 1, 1, 0, 0, 10, 0,
+		); err != nil {
+			t.Fatalf("insert legacy request_log %d: %v", i, err)
+		}
+	}
+
+	// Unrelated key must remain a separate slice entry.
+	if err := UpsertAPIKey(APIKeyRow{ID: "other-id", Key: "sk-other", Name: "Other"}); err != nil {
+		t.Fatalf("UpsertAPIKey(other): %v", err)
+	}
+	InsertLogWithDetailsIdentity("sk-other", "other-id", "Other", "gpt-test", "source", "channel", "auth-2", false, now, 1, 1, TokenStats{TotalTokens: 5}, "", "", "")
+
+	dist, err := QueryAPIKeyDistribution(7)
+	if err != nil {
+		t.Fatalf("QueryAPIKeyDistribution() error = %v", err)
+	}
+	if len(dist) != 2 {
+		t.Fatalf("distribution len = %d, want 2 (merged primary + other): %#v", len(dist), dist)
+	}
+
+	var primary *APIKeyDistributionPoint
+	for i := range dist {
+		if dist[i].APIKey == rawKey {
+			primary = &dist[i]
+			break
+		}
+	}
+	if primary == nil {
+		t.Fatalf("missing merged point for %q in %#v", rawKey, dist)
+	}
+	if primary.Name != name {
+		t.Fatalf("merged name = %q, want %q", primary.Name, name)
+	}
+	// 2 id-backed + 3 raw-only rows
+	if primary.Requests != 5 {
+		t.Fatalf("merged requests = %d, want 5", primary.Requests)
+	}
+	// 100 + 50 + 3*10
+	if primary.Tokens != 180 {
+		t.Fatalf("merged tokens = %d, want 180", primary.Tokens)
+	}
+	if dist[0].APIKey != rawKey {
+		t.Fatalf("expected primary key first by request count, got %#v", dist)
+	}
+}
+
 func TestRequestStatisticsPersistsAPIKeyIdentitySnapshotAcrossRename(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1863,9 +1863,10 @@ func TestQueryAPIKeyDistributionMergesRawAndIDGroupsForSameKey(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{})
 
 	const (
-		stableID = "16332427-2510-48e4-9c42-dcc148008ea0"
-		rawKey   = "sk-bai8v0z1hoytg4wopcyxz9t9t0yvx0zb"
-		name     = "袁蔚"
+		stableID = "stable-dist-merge-1"
+		// Placeholder shape only; must not look like a live secret to secret-scan.
+		rawKey = "sk-test-dist-merge-legacy-raw"
+		name   = "袁蔚"
 	)
 	if err := UpsertAPIKey(APIKeyRow{ID: stableID, Key: rawKey, Name: name}); err != nil {
 		t.Fatalf("UpsertAPIKey: %v", err)


### PR DESCRIPTION
## Summary
- Monitor「API Key 使用占比」会把同一 key 拆成两条图例（如 袁蔚 / Kittors / 张军宝 重复），因为 `request_logs` 同时存在带 `api_key_id` 与仅 raw secret 的历史行，SQL 按 `logical_selector` 分组后未合并。
- 解析 raw key 到当前 `api_keys` 身份后，按稳定 key 合并 requests/tokens，再按请求数排序返回。
- 增加回归测试覆盖 id 组 + raw 组合并场景。

## Test plan
- [x] `go test ./internal/usage/ -count=1 -run 'TestQueryAPIKey|TestBackfillRequestLogAPIKey|TestRequestStatisticsPersistsAPIKey'`
- [x] `go test ./internal/management/usagelogs/ -count=1`
- [ ] 合并部署后打开 `/manage/runtime/monitor`，确认同一 name 只出现一条图例且请求数已合并