### PR TITLE
fix: keep dashboard RPM/TPM continuous across minute boundaries

### DIFF
--- a/internal/usage/dashboard_trends_test.go
+++ b/internal/usage/dashboard_trends_test.go
@@ -72,39 +72,41 @@ func TestQueryDashboardTrendsReturnsFixedDailyBuckets(t *testing.T) {
 func TestQueryDashboardTrendsReturnsRecentMinuteThroughputBuckets(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{StoreContent: false})
 
-	now := time.Now().UTC().Truncate(time.Minute)
+	// Fixed query time so the rolling latest window is deterministic.
+	now := time.Date(2026, 7, 13, 15, 5, 40, 0, time.UTC)
 	twoMinutesAgo := now.Add(-2 * time.Minute)
 	sixMinutesAgo := now.Add(-6 * time.Minute)
 	eightMinutesAgo := now.Add(-8 * time.Minute)
 
-	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, now.Add(15*time.Second), 100, 20, TokenStats{
+	// Latest point uses last-60s window: request at :15 is inside [15:04:40, 15:05:40].
+	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, now.Truncate(time.Minute).Add(15*time.Second), 100, 20, TokenStats{
 		InputTokens:  40,
 		OutputTokens: 50,
 		TotalTokens:  90,
 	}, "", "")
-	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, twoMinutesAgo.Add(25*time.Second), 90, 20, TokenStats{
+	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, twoMinutesAgo.Truncate(time.Minute).Add(25*time.Second), 90, 20, TokenStats{
 		InputTokens:  10,
 		OutputTokens: 20,
 		TotalTokens:  30,
 	}, "", "")
-	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, sixMinutesAgo.Add(35*time.Second), 80, 20, TokenStats{
+	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, sixMinutesAgo.Truncate(time.Minute).Add(35*time.Second), 80, 20, TokenStats{
 		InputTokens:  20,
 		OutputTokens: 30,
 		TotalTokens:  50,
 	}, "", "")
-	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, eightMinutesAgo.Add(45*time.Second), 70, 20, TokenStats{
+	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, eightMinutesAgo.Truncate(time.Minute).Add(45*time.Second), 70, 20, TokenStats{
 		InputTokens:  30,
 		OutputTokens: 40,
 		TotalTokens:  70,
 	}, "", "")
 
-	trends, err := QueryDashboardTrends(7)
+	series, err := queryDashboardThroughputSeriesAt(systemTenantID, now, time.UTC, false)
 	if err != nil {
-		t.Fatalf("QueryDashboardTrends() error = %v", err)
+		t.Fatalf("queryDashboardThroughputSeriesAt() error = %v", err)
 	}
 
-	if len(trends.ThroughputSeries) != 7 {
-		t.Fatalf("throughput_series buckets = %d, want 7", len(trends.ThroughputSeries))
+	if len(series) != 7 {
+		t.Fatalf("throughput_series buckets = %d, want 7", len(series))
 	}
 
 	nowLabel := now.In(time.UTC).Format("15:04")
@@ -112,12 +114,12 @@ func TestQueryDashboardTrendsReturnsRecentMinuteThroughputBuckets(t *testing.T) 
 	sixMinutesAgoLabel := sixMinutesAgo.In(time.UTC).Format("15:04")
 	eightMinutesAgoLabel := eightMinutesAgo.In(time.UTC).Format("15:04")
 
-	nowRPM, nowTPM := findThroughputValues(t, trends.ThroughputSeries, nowLabel)
-	twoMinutesAgoRPM, twoMinutesAgoTPM := findThroughputValues(t, trends.ThroughputSeries, twoMinutesAgoLabel)
-	sixMinutesAgoRPM, sixMinutesAgoTPM := findThroughputValues(t, trends.ThroughputSeries, sixMinutesAgoLabel)
+	nowRPM, nowTPM := findThroughputValues(t, series, nowLabel)
+	twoMinutesAgoRPM, twoMinutesAgoTPM := findThroughputValues(t, series, twoMinutesAgoLabel)
+	sixMinutesAgoRPM, sixMinutesAgoTPM := findThroughputValues(t, series, sixMinutesAgoLabel)
 
 	if nowRPM != 1 || nowTPM != 90 {
-		t.Fatalf("current minute throughput = (%.0f, %.0f), want (1, 90)", nowRPM, nowTPM)
+		t.Fatalf("current rolling throughput = (%.0f, %.0f), want (1, 90)", nowRPM, nowTPM)
 	}
 	if twoMinutesAgoRPM != 1 || twoMinutesAgoTPM != 30 {
 		t.Fatalf("two minutes ago throughput = (%.0f, %.0f), want (1, 30)", twoMinutesAgoRPM, twoMinutesAgoTPM)
@@ -125,10 +127,72 @@ func TestQueryDashboardTrendsReturnsRecentMinuteThroughputBuckets(t *testing.T) 
 	if sixMinutesAgoRPM != 1 || sixMinutesAgoTPM != 50 {
 		t.Fatalf("six minutes ago throughput = (%.0f, %.0f), want (1, 50)", sixMinutesAgoRPM, sixMinutesAgoTPM)
 	}
-	for _, point := range trends.ThroughputSeries {
+	for _, point := range series {
 		if point.Label == eightMinutesAgoLabel {
 			t.Fatalf("unexpected throughput bucket for %s outside the last 7 minutes", eightMinutesAgoLabel)
 		}
+	}
+}
+
+func TestQueryDashboardThroughputLatestPointUsesRollingMinuteWindow(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{StoreContent: false})
+
+	// Early in a new calendar minute: calendar-bucket semantics would show RPM=0,
+	// but the rolling window still counts requests from the previous minute.
+	now := time.Date(2026, 7, 13, 15, 5, 5, 0, time.UTC)
+	prevMinuteLate := time.Date(2026, 7, 13, 15, 4, 30, 0, time.UTC)
+	// Window is [15:04:05, 15:05:05]; 15:03:50 is outside last 60s but still in 15:03/series history.
+	prevMinuteEarlier := time.Date(2026, 7, 13, 15, 4, 0, 0, time.UTC) // outside last 60s
+	twoMinutesAgo := time.Date(2026, 7, 13, 15, 3, 20, 0, time.UTC)
+
+	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, prevMinuteLate, 100, 20, TokenStats{
+		InputTokens:  10,
+		OutputTokens: 20,
+		TotalTokens:  100,
+	}, "", "")
+	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, prevMinuteLate.Add(5*time.Second), 100, 20, TokenStats{
+		InputTokens:  20,
+		OutputTokens: 30,
+		TotalTokens:  200,
+	}, "", "")
+	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, prevMinuteEarlier, 100, 20, TokenStats{
+		InputTokens:  5,
+		OutputTokens: 5,
+		TotalTokens:  50,
+	}, "", "")
+	InsertLog("", "", "gpt-test", "codex", "codex", "auth-1", false, twoMinutesAgo, 100, 20, TokenStats{
+		InputTokens:  1,
+		OutputTokens: 1,
+		TotalTokens:  10,
+	}, "", "")
+
+	series, err := queryDashboardThroughputSeriesAt(systemTenantID, now, time.UTC, false)
+	if err != nil {
+		t.Fatalf("queryDashboardThroughputSeriesAt() error = %v", err)
+	}
+	if len(series) != 7 {
+		t.Fatalf("throughput_series buckets = %d, want 7", len(series))
+	}
+
+	latest := series[len(series)-1]
+	if latest.Label != "15:05" {
+		t.Fatalf("latest label = %q, want 15:05", latest.Label)
+	}
+	// Rolling window [15:04:05, 15:05:05] includes two late 15:04 requests, not the early one.
+	if latest.RPM != 2 || latest.TPM != 300 {
+		t.Fatalf("latest rolling throughput = (%.0f, %.0f), want (2, 300)", latest.RPM, latest.TPM)
+	}
+
+	// Completed previous calendar minute still reports full-minute totals (3 requests).
+	prevRPM, prevTPM := findThroughputValues(t, series, "15:04")
+	if prevRPM != 3 || prevTPM != 350 {
+		t.Fatalf("previous minute throughput = (%.0f, %.0f), want (3, 350)", prevRPM, prevTPM)
+	}
+
+	// Older completed minute is unchanged.
+	olderRPM, olderTPM := findThroughputValues(t, series, "15:03")
+	if olderRPM != 1 || olderTPM != 10 {
+		t.Fatalf("15:03 throughput = (%.0f, %.0f), want (1, 10)", olderRPM, olderTPM)
 	}
 }
 

--- a/internal/usage/request_log_dashboard.go
+++ b/internal/usage/request_log_dashboard.go
@@ -109,7 +109,9 @@ func QueryDashboardKPIForTenant(tenantID string, days int) (DashboardKPI, error)
 
 // QueryDashboardTrends returns fixed-width trend buckets used by the dashboard.
 // KPI trends follow the selected day range, while throughput always shows the
-// most recent 7 one-minute buckets.
+// most recent 7 points: completed minutes use calendar-minute totals, and the
+// latest point is a rolling last-60-seconds window so RPM/TPM stay continuous
+// across minute boundaries.
 func QueryDashboardTrends(days int) (DashboardTrends, error) {
 	return QueryDashboardTrendsForTenant(systemTenantID, days)
 }
@@ -177,8 +179,9 @@ func QueryDashboardTrendsForTenant(tenantID string, days int) (DashboardTrends, 
 	return trends, nil
 }
 
-// QueryDashboardThroughputAcrossTenants returns the recent 7 one-minute RPM/TPM
-// buckets aggregated across every tenant. Used by platform super-admins.
+// QueryDashboardThroughputAcrossTenants returns the recent 7 RPM/TPM points
+// aggregated across every tenant (same continuous latest-window semantics as
+// tenant trends). Used by platform super-admins.
 func QueryDashboardThroughputAcrossTenants() ([]DashboardThroughputPoint, error) {
 	return queryDashboardThroughputSeriesAt("", time.Now(), getUsageLocation(), true)
 }
@@ -257,13 +260,21 @@ func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.
 		loc = time.Local
 	}
 
+	now = now.In(loc)
 	buckets := buildRecentThroughputBucketsAt(now, loc)
 	byKey := make(map[string]*dashboardBucket, len(buckets))
 	for i := range buckets {
 		byKey[buckets[i].key] = &buckets[i]
 	}
 
-	start := now.In(loc).Truncate(time.Minute).Add(-time.Duration(dashboardThroughputBucketCount-1) * time.Minute)
+	// Completed minute points stay calendar-aligned; the latest point is filled
+	// from a rolling 60s window so the dashboard value does not drop to zero at
+	// each minute boundary.
+	windowStart := now.Add(-time.Minute)
+	start := now.Truncate(time.Minute).Add(-time.Duration(dashboardThroughputBucketCount-1) * time.Minute)
+	if windowStart.Before(start) {
+		start = windowStart
+	}
 	startUTC := start.UTC().Format(time.RFC3339)
 
 	var (
@@ -288,6 +299,10 @@ func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.
 	}
 	defer rows.Close()
 
+	var (
+		windowRequests int64
+		windowTokens   int64
+	)
 	for rows.Next() {
 		var ts storedTime
 		var totalTokens int64
@@ -297,16 +312,28 @@ func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.
 		if !ts.Valid {
 			continue
 		}
-		key := ts.Time.In(loc).Truncate(time.Minute).Format("2006-01-02 15:04")
-		bucket := byKey[key]
-		if bucket == nil {
-			continue
+		at := ts.Time.In(loc)
+		// Historical points: full calendar minute.
+		key := at.Truncate(time.Minute).Format("2006-01-02 15:04")
+		if bucket := byKey[key]; bucket != nil {
+			bucket.requests++
+			bucket.totalToken += totalTokens
 		}
-		bucket.requests++
-		bucket.totalToken += totalTokens
+		// Latest point: requests that finished in the last 60 seconds.
+		if !at.Before(windowStart) && !at.After(now) {
+			windowRequests++
+			windowTokens += totalTokens
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("usage: iterate dashboard throughput rows: %w", err)
+	}
+
+	if len(buckets) > 0 {
+		// Replace the in-progress calendar minute with the rolling window so the
+		// rightmost chart point and headline RPM/TPM stay continuous.
+		buckets[len(buckets)-1].requests = windowRequests
+		buckets[len(buckets)-1].totalToken = windowTokens
 	}
 
 	return throughputSeriesFromBuckets(buckets), nil


### PR DESCRIPTION
## Summary
- Latest dashboard throughput point now uses a **rolling last-60s window** instead of the incomplete current calendar minute.
- Completed historical minutes still use full calendar-minute totals.
- Prevents the “RPM drops to 0 every new minute” cliff on the request-throughput chart and headline metrics.
- Adds regression test for early-minute continuity.

## Test plan
- [x] `go test ./internal/usage/ -count=1 -run 'Dashboard|Throughput'`
- [x] `go test ./internal/usage/ -count=1`
- [ ] After deploy: open dashboard near a minute boundary and confirm RPM/TPM do not reset to ~0

## Notes
Frontend only needs API behavior; companion comment-only PR in codeProxy.