### PR TITLE
fix: stop auth failover on client invalid-request errors

### DIFF
--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -198,6 +198,12 @@ func (s cooldownService) applyFailureLocked(auth *Auth, result Result, now time.
 	if auth == nil {
 		return
 	}
+	// Client request errors (400 invalid payload/image/etc.) are not auth health
+	// signals. Do not mark the credential unavailable or start any cooldown;
+	// failover is already suppressed by isRequestInvalidError.
+	if result.Error != nil && isRequestInvalidError(result.Error) {
+		return
+	}
 	if applyClaudeOAuthFailureLocked(auth, result, now, effects) {
 		return
 	}

--- a/sdk/cliproxy/auth/conductor_error_helpers.go
+++ b/sdk/cliproxy/auth/conductor_error_helpers.go
@@ -114,9 +114,9 @@ func statusCodeFromResult(err *Error) int {
 }
 
 // isRequestInvalidError returns true if the error represents a client request
-// error that should not be retried. Specifically, it checks for 400 Bad Request
-// with "invalid_request_error" in the message, indicating the request itself is
-// malformed and switching to a different auth will not help.
+// error that should not be retried or failed over to another auth. Switching
+// credentials cannot fix a malformed request body (for example an image that is
+// too small for the upstream vision API).
 func isRequestInvalidError(err error) bool {
 	if err == nil {
 		return false
@@ -125,18 +125,19 @@ func isRequestInvalidError(err error) bool {
 	if status != http.StatusBadRequest {
 		return false
 	}
+
+	var authErr *Error
+	if errors.As(err, &authErr) && authErr != nil {
+		if isInvalidRequestSignal(authErr.Code) || isInvalidRequestSignal(authErr.Message) {
+			return true
+		}
+	}
+
 	message := strings.TrimSpace(err.Error())
 	if message == "" {
 		return false
 	}
-	if strings.Contains(message, "invalid_request_error") {
-		return true
-	}
-	lowerMessage := strings.ToLower(message)
-	if strings.Contains(lowerMessage, "model is not supported") || strings.Contains(lowerMessage, "model not supported") {
-		return true
-	}
-	if strings.Contains(lowerMessage, "not supported when using codex with a chatgpt account") {
+	if isInvalidRequestSignal(message) {
 		return true
 	}
 
@@ -147,22 +148,51 @@ func isRequestInvalidError(err error) bool {
 	if errParse := json.Unmarshal([]byte(message), &payload); errParse != nil {
 		return false
 	}
-	lowerDetail := strings.ToLower(firstNonEmptyString(
+	// Providers use different shapes:
+	// - OpenAI-style: {"error":{"type":"invalid_request_error",...}}
+	// - xAI-style:    {"code":"invalid-argument","error":"..."}
+	// - Google-style: {"error":{"status":"INVALID_ARGUMENT","message":"..."}}
+	signals := []string{
+		stringValue(payload["code"]),
+		stringValue(payload["type"]),
+		stringValue(payload["status"]),
+		stringValue(payload["detail"]),
+		stringValue(payload["error"]),
+		stringValue(payload["message"]),
 		nestedString(payload, "error", "type"),
 		nestedString(payload, "error", "code"),
+		nestedString(payload, "error", "status"),
 		nestedString(payload, "error", "message"),
-		stringValue(payload["detail"]),
-	))
-	if strings.Contains(lowerDetail, "invalid_request_error") {
-		return true
 	}
-	if strings.Contains(lowerDetail, "model is not supported") || strings.Contains(lowerDetail, "model not supported") {
-		return true
-	}
-	if strings.Contains(lowerDetail, "not supported when using codex with a chatgpt account") {
-		return true
+	for _, signal := range signals {
+		if isInvalidRequestSignal(signal) {
+			return true
+		}
 	}
 	return false
+}
+
+func isInvalidRequestSignal(raw string) bool {
+	signal := strings.ToLower(strings.TrimSpace(raw))
+	if signal == "" {
+		return false
+	}
+	switch {
+	case strings.Contains(signal, "invalid_request_error"),
+		strings.Contains(signal, "invalid-argument"),
+		strings.Contains(signal, "invalid_argument"),
+		strings.Contains(signal, "invalid request"),
+		strings.Contains(signal, "model is not supported"),
+		strings.Contains(signal, "model not supported"),
+		strings.Contains(signal, "not supported when using codex with a chatgpt account"),
+		// Upstream vision APIs reject undersized images with a stable message.
+		// This is request content, not auth/quota, so failover cannot help.
+		strings.Contains(signal, "below the minimum of") && strings.Contains(signal, "pixels"),
+		strings.Contains(signal, "total pixels") && strings.Contains(signal, "minimum"):
+		return true
+	default:
+		return false
+	}
 }
 
 func nestedString(payload map[string]any, keys ...string) string {

--- a/sdk/cliproxy/auth/conductor_error_helpers_test.go
+++ b/sdk/cliproxy/auth/conductor_error_helpers_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -140,6 +141,35 @@ func TestIsRequestInvalidError_RecognizesUnsupportedCodexModelPayload(t *testing
 	}
 }
 
+func TestIsRequestInvalidError_RecognizesXAIInvalidArgumentImageTooSmall(t *testing.T) {
+	t.Parallel()
+
+	// xAI vision rejects undersized images with a top-level code/error payload.
+	// Failover to another auth cannot fix the request body.
+	err := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    `{"code":"invalid-argument","error":"Image has 420 total pixels (21x20), which is below the minimum of 512 pixels."}`,
+	}
+
+	if !isRequestInvalidError(err) {
+		t.Fatal("expected xAI invalid-argument image size payload to be treated as invalid request")
+	}
+}
+
+func TestIsRequestInvalidError_RecognizesInvalidArgumentCodeField(t *testing.T) {
+	t.Parallel()
+
+	err := &Error{
+		Code:       "invalid-argument",
+		HTTPStatus: http.StatusBadRequest,
+		Message:    "Image is too small",
+	}
+
+	if !isRequestInvalidError(err) {
+		t.Fatal("expected explicit invalid-argument code to be treated as invalid request")
+	}
+}
+
 func TestIsRequestInvalidError_IgnoresNonBadRequest(t *testing.T) {
 	t.Parallel()
 
@@ -150,5 +180,64 @@ func TestIsRequestInvalidError_IgnoresNonBadRequest(t *testing.T) {
 
 	if isRequestInvalidError(err) {
 		t.Fatal("expected non-400 upstream error to remain retryable/failover-eligible")
+	}
+}
+
+func TestIsRequestInvalidError_IgnoresGenericBadRequestWithoutInvalidSignal(t *testing.T) {
+	t.Parallel()
+
+	// Keep failover for ambiguous 400s that are not clearly request-shaped.
+	err := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    `{"error":{"message":"temporary provider rejection"}}`,
+	}
+
+	if isRequestInvalidError(err) {
+		t.Fatal("expected generic 400 without invalid-request signal to remain failover-eligible")
+	}
+}
+
+func TestMarkResult_RequestInvalidErrorDoesNotCooldownAuth(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "xai-1",
+		Provider: "xai",
+		Status:   StatusActive,
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "xai",
+		Model:    "grok-4.5",
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusBadRequest,
+			Message:    `{"code":"invalid-argument","error":"Image has 420 total pixels (21x20), which is below the minimum of 512 pixels."}`,
+		},
+	})
+
+	got, ok := m.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatal("auth missing after MarkResult")
+	}
+	if got.Status != StatusActive {
+		t.Fatalf("Status = %q, want %q", got.Status, StatusActive)
+	}
+	if got.Unavailable {
+		t.Fatal("Unavailable = true, want false for request-invalid error")
+	}
+	if got.Quota.Exceeded {
+		t.Fatal("Quota.Exceeded = true, want false")
+	}
+	if !got.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %v, want zero", got.NextRetryAfter)
+	}
+	if state := got.ModelStates["grok-4.5"]; state != nil {
+		t.Fatalf("ModelStates[grok-4.5] = %+v, want nil/unset for request-invalid error", state)
 	}
 }


### PR DESCRIPTION
## Summary
- Recognize xAI-style `400 invalid-argument` payloads (e.g. undersized images) as non-retryable client request errors.
- Skip auth failover/request retry for these errors, since switching credentials cannot fix request content.
- Avoid marking the selected account into `StatusError` / unavailable / quota cooldown when the failure is request-invalid.

## Context
Users saw “upstream API error” for images below 512 total pixels, then other accounts also failed. Root cause: the invalid request was failed over across auths. It was **not** a true 429 cooldown path.

## Test plan
- [x] `go test ./sdk/cliproxy/auth/ -count=1`
- [x] New unit coverage for xAI invalid-argument image payload, explicit code, ambiguous 400 still failover-eligible, and MarkResult not cooling the auth