### PR TITLE
fix: sticky Grok sessions and tenant identity defaults

### DIFF
--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -139,6 +139,9 @@ func BuildTenantRuntimeConfig(base *config.Config, tenantID string) config.Confi
 	tenantCfg.VertexCompatAPIKey = nil
 	tenantCfg.ClaudeHeaderDefaults = config.ClaudeHeaderDefaults{}
 	tenantCfg.KimiHeaderDefaults = config.KimiHeaderDefaults{}
+	// Clear tenant identity presets so system custom UA/version never leak, but
+	// re-normalize after apply so missing runtime rows still default providers
+	// to enabled (otherwise XAI/Codex learn+apply is silently off for new tenants).
 	tenantCfg.IdentityFingerprint = config.IdentityFingerprintConfig{}
 	tenantCfg.CodexOAuthAdmission = config.CodexOAuthAdmissionConfig{}
 	tenantCfg.OAuthExcludedModels = nil
@@ -152,5 +155,6 @@ func BuildTenantRuntimeConfig(base *config.Config, tenantID string) config.Confi
 	}
 	tenantCfg.ProxyPool = ListProxyPoolForTenant(tenantID)
 	ApplyStoredRuntimeSettingsForTenant(tenantID, &tenantCfg)
+	tenantCfg.SanitizeIdentityFingerprint()
 	return tenantCfg
 }

--- a/internal/usage/runtime_settings_db_test.go
+++ b/internal/usage/runtime_settings_db_test.go
@@ -250,3 +250,58 @@ func TestBuildTenantRuntimeConfigDoesNotInheritSystemCredentials(t *testing.T) {
 		t.Fatalf("tenant runtime config = %+v", got)
 	}
 }
+
+func TestBuildTenantRuntimeConfigDefaultsIdentityFingerprintEnabledWithoutRuntimeRow(t *testing.T) {
+	cleanup := setupConfigMigrationTestDB(t)
+	defer cleanup()
+
+	// System may carry custom identity presets; tenants must not inherit them,
+	// but learn/apply must still be on by default when the tenant has no row.
+	base := &config.Config{}
+	base.IdentityFingerprint = config.NormalizeIdentityFingerprintConfig(config.IdentityFingerprintConfig{
+		XAI: config.XAIIdentityFingerprintConfig{
+			Enabled:          true,
+			UserAgent:        "system-custom-ua",
+			ClientIdentifier: "system-custom-id",
+			ClientVersion:    "9.9.9",
+		},
+	})
+	const tenantID = "00000000-0000-0000-0000-00000000000b"
+	got := BuildTenantRuntimeConfig(base, tenantID)
+	if !got.IdentityFingerprint.XAI.Enabled ||
+		!got.IdentityFingerprint.Codex.Enabled ||
+		!got.IdentityFingerprint.Claude.Enabled ||
+		!got.IdentityFingerprint.Gemini.Enabled {
+		t.Fatalf("IdentityFingerprint = %#v, want all providers enabled by default for tenant without runtime row", got.IdentityFingerprint)
+	}
+	if got.IdentityFingerprint.XAI.UserAgent == "system-custom-ua" ||
+		got.IdentityFingerprint.XAI.ClientIdentifier == "system-custom-id" ||
+		got.IdentityFingerprint.XAI.ClientVersion == "9.9.9" {
+		t.Fatalf("tenant inherited system identity presets: %#v", got.IdentityFingerprint.XAI)
+	}
+}
+
+func TestBuildTenantRuntimeConfigPreservesExplicitDisabledIdentityFingerprint(t *testing.T) {
+	cleanup := setupConfigMigrationTestDB(t)
+	defer cleanup()
+
+	const tenantID = "00000000-0000-0000-0000-00000000000c"
+	if err := UpsertRuntimeSettingForTenant(tenantID, RuntimeSettingIdentityFingerprint, map[string]any{
+		"runtime-setting-version": 2,
+		"xai": map[string]any{
+			"enabled": false,
+		},
+		"codex": map[string]any{
+			"enabled": true,
+		},
+	}); err != nil {
+		t.Fatalf("UpsertRuntimeSettingForTenant: %v", err)
+	}
+	got := BuildTenantRuntimeConfig(&config.Config{}, tenantID)
+	if got.IdentityFingerprint.XAI.Enabled {
+		t.Fatalf("XAI.Enabled = true, want explicit false preserved")
+	}
+	if !got.IdentityFingerprint.Codex.Enabled {
+		t.Fatalf("Codex.Enabled = false, want true from tenant runtime row")
+	}
+}

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -293,6 +293,37 @@ func TestRequestExecutionMetadata_CapturesSessionStickyHeader(t *testing.T) {
 	}
 }
 
+func TestRequestExecutionMetadata_CapturesGrokSessionStickyHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("session id", func(t *testing.T) {
+		ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ginCtx.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+		ginCtx.Request.Header.Set("X-Grok-Session-Id", "019f5a53-5c9c-7222-a74c-3dbab60349d3")
+		ginCtx.Request.Header.Set("X-Grok-Conv-Id", "should-not-win")
+
+		ctx := context.WithValue(context.Background(), util.ContextKeyGin, ginCtx)
+		meta := requestExecutionMetadata(ctx)
+		want := "header:x-grok-session-id:019f5a53-5c9c-7222-a74c-3dbab60349d3"
+		if got := meta[coreexecutor.SessionStickyMetadataKey]; got != want {
+			t.Fatalf("session sticky key = %v, want %s", got, want)
+		}
+	})
+
+	t.Run("conv id fallback", func(t *testing.T) {
+		ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ginCtx.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+		ginCtx.Request.Header.Set("X-Grok-Conv-Id", "019f5a53-5c9c-7222-a74c-3dbab60349d3")
+
+		ctx := context.WithValue(context.Background(), util.ContextKeyGin, ginCtx)
+		meta := requestExecutionMetadata(ctx)
+		want := "header:x-grok-conv-id:019f5a53-5c9c-7222-a74c-3dbab60349d3"
+		if got := meta[coreexecutor.SessionStickyMetadataKey]; got != want {
+			t.Fatalf("session sticky key = %v, want %s", got, want)
+		}
+	})
+}
+
 func TestRequestExecutionMetadata_UsesGinRequestContextPathRouteAfterHandleContextReset(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/api/handlers/session_sticky.go
+++ b/sdk/api/handlers/session_sticky.go
@@ -10,16 +10,21 @@ func requestSessionStickyHeaderKey(c *gin.Context) string {
 	if c == nil {
 		return ""
 	}
+	// Prefer stable client session / conversation headers. Grok/xAI clients send
+	// X-Grok-Session-Id / X-Grok-Conv-Id rather than generic Session-Id; without
+	// them session-sticky collapses many concurrent chats onto one auth binding.
 	for _, header := range []string{
 		"Session-Id",
 		"session_id",
 		"X-Session-Id",
 		"X-Codex-Session-Id",
 		"X-Claude-Code-Session-Id",
+		"X-Grok-Session-Id",
 		"Conversation-Id",
 		"conversation_id",
 		"X-Conversation-Id",
 		"OpenAI-Conversation-Id",
+		"X-Grok-Conv-Id",
 	} {
 		if value := strings.TrimSpace(c.GetHeader(header)); value != "" {
 			return "header:" + strings.ToLower(header) + ":" + value


### PR DESCRIPTION
## Summary
- Session-sticky now recognizes `X-Grok-Session-Id` / `X-Grok-Conv-Id`, so concurrent Grok chats no longer collapse onto a single auth binding.
- Tenants without an `identity-fingerprint` runtime row re-normalize provider defaults after config isolation, so XAI learn/apply is enabled by default instead of silently off.

## Root causes addressed
1. **Sticky monopoly (蹬的飞快 / Ginofk)**: Grok clients send session headers outside the previous sticky whitelist; empty/body-fallback keys bound most traffic to the first available auth.
2. **Identity 自学习:0**: `BuildTenantRuntimeConfig` cleared identity presets for business tenants and never re-normalized, so missing runtime rows left `XAI.Enabled=false` and observe never ran.

## Test plan
- [x] `./scripts/ci-pr.sh` (full local CI)
- [x] `go test` for sticky header capture (`X-Grok-Session-Id` / conv fallback)
- [x] `go test` for tenant identity defaults without runtime row
- [x] `go test` for explicit `xai.enabled: false` preserved
- [ ] After deploy to BWG: multi-session Grok traffic should spread across auths; `identity_fingerprints` should gain rows for accounts under 蹬的飞快 (e.g. `authsub_4ca6f5185e367ab2`)