### PR TITLE
fix: inject release version into buildinfo ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,8 +11,9 @@ builds:
       - arm64
     main: ./cmd/server/
     binary: cli-proxy-api
+    # Inject into internal/buildinfo (cmd/server reads these; main.Version is unused).
     ldflags:
-      - -s -w -X 'main.Version={{.Version}}' -X 'main.Commit={{.ShortCommit}}' -X 'main.BuildDate={{.Date}}'
+      - -s -w -X 'github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo.Version={{.Version}}' -X 'github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo.Commit={{.ShortCommit}}' -X 'github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo.BuildDate={{.Date}}'
 archives:
   - id: "cli-proxy-api"
     format: tar.gz


### PR DESCRIPTION
## Summary

- Fixes `.goreleaser.yml` ldflags to inject `internal/buildinfo.Version/Commit/BuildDate` instead of unused `main.Version/*`.
- Matches the path already used by `.github/workflows/deploy.yml`.
- Related to #608: this corrects release binary version metadata; the reporter's "prints version then exits" symptom on SQLite-only native deploy is still expected without PostgreSQL (`postgres.dsn` / `CLIRELAY_POSTGRES_DSN`).

## Test plan

- [x] Diff-reviewed against `deploy.yml` ldflags package path
- [ ] Next tag release binary should print real Version/Commit/BuiltAt (not `dev`/`none`/`unknown`)
- [ ] Native upgrade still requires PostgreSQL for runtime data stack (unchanged)