### PR TITLE
fix(xai): discover models via CLI chat proxy when using_api=false

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -403,8 +403,9 @@ func xaiUsingAPI(auth *cliproxyauth.Auth) bool {
 	return !strings.EqualFold(xaiMetadataString(auth.Metadata, "auth_kind"), "oauth")
 }
 
-// xaiChatBaseURL switches only Responses HTTP traffic. Model listing and generic
-// HTTP requests continue using the configured API base URL.
+// xaiChatBaseURL selects the base URL for non-media HTTP chat and model listing.
+// using_api=false (Grok Build OAuth) uses CLIChatProxyBaseURL; using_api=true
+// and generic media/PrepareRequest paths keep the configured API base URL.
 func xaiChatBaseURL(auth *cliproxyauth.Auth) string {
 	_, baseURL := xaiCreds(auth)
 	if xaiUsingAPI(auth) {

--- a/internal/runtime/executor/xai_models.go
+++ b/internal/runtime/executor/xai_models.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
@@ -97,24 +96,25 @@ func fallbackXAIModels() []*sdkmodelcatalog.ModelInfo {
 }
 
 // FetchXAIModels retrieves the OAuth account's live model list from xAI.
+// Base URL follows the same using_api routing as chat/Responses traffic so
+// Grok Build OAuth (using_api=false) discovers models via CLIChatProxyBaseURL
+// instead of api.x.ai, which may reject personal-team tokens with 403.
 func FetchXAIModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	token, baseURL := xaiCreds(auth)
+	token, _ := xaiCreds(auth)
 	if strings.TrimSpace(token) == "" {
 		return fallbackXAIModels()
 	}
-	if baseURL == "" {
-		baseURL = xaiauth.DefaultAPIBaseURL
-	}
-	baseURL = strings.TrimRight(baseURL, "/")
+	baseURL := strings.TrimRight(xaiChatBaseURL(auth), "/")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+xaiModelsPath, nil)
 	if err != nil {
 		return fallbackXAIModels()
 	}
-	applyXAIHeaders(req, cfg, auth, token, false)
+	// CLI chat proxy needs the same identity headers as Responses; official API keeps plain Bearer.
+	applyXAIChatHeaders(req, cfg, auth, token, false)
 
 	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
 	if err != nil {

--- a/internal/runtime/executor/xai_models_test.go
+++ b/internal/runtime/executor/xai_models_test.go
@@ -2,10 +2,15 @@ package executor
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
 )
@@ -100,5 +105,118 @@ func TestFetchXAIModelsFallsBackToCachedCatalog(t *testing.T) {
 	}, nil)
 	if len(models) != 1 || models[0].ID != "cached-xai-model" {
 		t.Fatalf("fallback models = %+v, want cached-xai-model", models)
+	}
+}
+
+type captureRoundTripper struct {
+	req *http.Request
+}
+
+func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.req = req
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"data":[{"id":"grok-4.5","object":"model","owned_by":"xai"}]}`)),
+		Request:    req,
+	}, nil
+}
+
+func TestFetchXAIModelsUsesCLIChatProxyWhenUsingAPIFalse(t *testing.T) {
+	resetXAIModelsCacheForTest()
+	t.Cleanup(resetXAIModelsCacheForTest)
+
+	rt := &captureRoundTripper{}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+
+	models := FetchXAIModels(ctx, &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"api_key":   "oauth-token",
+			"base_url":  xaiauth.DefaultAPIBaseURL,
+			"using_api": "false",
+		},
+	}, nil)
+
+	if rt.req == nil {
+		t.Fatal("expected models request to be issued")
+	}
+	wantURL := strings.TrimRight(xaiauth.CLIChatProxyBaseURL, "/") + xaiModelsPath
+	if got := rt.req.URL.String(); got != wantURL {
+		t.Fatalf("models URL = %q, want %q", got, wantURL)
+	}
+	if got := rt.req.Header.Get("Authorization"); got != "Bearer oauth-token" {
+		t.Fatalf("Authorization = %q, want Bearer oauth-token", got)
+	}
+	if got := rt.req.Header.Get(xaiTokenAuthHeader); got != xaiTokenAuthValue {
+		t.Fatalf("%s = %q, want %q", xaiTokenAuthHeader, got, xaiTokenAuthValue)
+	}
+	if got := rt.req.Header.Get("X-Grok-Client-Version"); got != config.DefaultXAIFingerprintClientVersion {
+		t.Fatalf("X-Grok-Client-Version = %q, want %q", got, config.DefaultXAIFingerprintClientVersion)
+	}
+	if len(models) == 0 || models[0].ID != "grok-4.5" {
+		t.Fatalf("models = %+v, want grok-4.5", models)
+	}
+}
+
+func TestFetchXAIModelsKeepsOfficialAPIWhenUsingAPITrue(t *testing.T) {
+	resetXAIModelsCacheForTest()
+	t.Cleanup(resetXAIModelsCacheForTest)
+
+	rt := &captureRoundTripper{}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+
+	_ = FetchXAIModels(ctx, &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"api_key":   "oauth-token",
+			"base_url":  xaiauth.DefaultAPIBaseURL,
+			"using_api": "true",
+		},
+	}, nil)
+
+	if rt.req == nil {
+		t.Fatal("expected models request to be issued")
+	}
+	wantURL := strings.TrimRight(xaiauth.DefaultAPIBaseURL, "/") + xaiModelsPath
+	if got := rt.req.URL.String(); got != wantURL {
+		t.Fatalf("models URL = %q, want %q", got, wantURL)
+	}
+	if got := rt.req.Header.Get(xaiTokenAuthHeader); got != "" {
+		t.Fatalf("%s = %q, want empty for official API", xaiTokenAuthHeader, got)
+	}
+	if got := rt.req.Header.Get("X-Grok-Client-Version"); got != "" {
+		t.Fatalf("X-Grok-Client-Version = %q, want empty for official API", got)
+	}
+}
+
+func TestFetchXAIModelsKeepsCustomGatewayBaseURL(t *testing.T) {
+	resetXAIModelsCacheForTest()
+	t.Cleanup(resetXAIModelsCacheForTest)
+
+	rt := &captureRoundTripper{}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+	customBase := "https://gateway.example.com/v1"
+
+	_ = FetchXAIModels(ctx, &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"api_key":   "oauth-token",
+			"base_url":  customBase,
+			"using_api": "false",
+		},
+	}, nil)
+
+	if rt.req == nil {
+		t.Fatal("expected models request to be issued")
+	}
+	wantURL := strings.TrimRight(customBase, "/") + xaiModelsPath
+	if got := rt.req.URL.String(); got != wantURL {
+		t.Fatalf("models URL = %q, want %q", got, wantURL)
+	}
+	if got := rt.req.Header.Get(xaiTokenAuthHeader); got != "" {
+		t.Fatalf("%s = %q, want empty for custom gateway", xaiTokenAuthHeader, got)
 	}
 }


### PR DESCRIPTION
## Summary
- Align xAI model discovery (`FetchXAIModels`) with chat/Responses base URL routing so Grok Build OAuth (`using_api=false`) lists models from `cli-chat-proxy.grok.com` instead of `api.x.ai`.
- Apply CLI identity headers on model listing when using the chat proxy (same as Responses).
- Add regression tests for `using_api=false`, `using_api=true`, and custom gateway base URLs.

Fixes #631

## Test plan
- [x] `go test ./internal/runtime/executor/ -count=1`
- [x] Focused tests: `TestFetchXAIModels*`, `TestXAIChatBaseURL`, `TestApplyXAIChatHeaders`

## Notes
Local CI-equivalent validation: full `internal/runtime/executor` package tests passed.