### PR TITLE
fix: align AUTH_PATH with auth volume after OTA upgrades

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -481,6 +481,8 @@ func main() {
 	} else {
 		cfg.AuthDir = resolvedAuthDir
 	}
+	// Surface AuthDir vs legacy Docker mount mismatches early (empty panel after OTA).
+	util.LogResolvedAuthDir(cfg.AuthDir)
 	managementasset.SetCurrentConfig(cfg)
 
 	// Create login options to be used in authentication flows.

--- a/cmd/updater/auth_path_align.go
+++ b/cmd/updater/auth_path_align.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// alignAuthPathWithVolumes ensures AUTH_PATH matches the container-side destination
+// of the auth bind mount. Older compose files used /root/.cli-proxy-api; newer
+// templates default to /CLIProxyAPI/auths. When both disagree after an upgrade,
+// the host auths directory can still have files while the process reads an empty dir.
+func alignAuthPathWithVolumes(env map[string]any, volumes any) (map[string]any, any) {
+	if env == nil {
+		env = map[string]any{}
+	}
+	rawAuth := strings.TrimSpace(stringValue(env["AUTH_PATH"]))
+	authPath := normalizeAuthPathValue(rawAuth)
+	dest, destIsAuthPathDriven, ok := findAuthVolumeDestination(volumes)
+	if ok && !destIsAuthPathDriven {
+		// Concrete mount target (e.g. /root/.cli-proxy-api) is authoritative.
+		env["AUTH_PATH"] = dest
+		return env, volumes
+	}
+	if ok && destIsAuthPathDriven {
+		// Volume dest is ${AUTH_PATH:-...}; after compose interpolation the mount
+		// target equals AUTH_PATH. Keep a concrete AUTH_PATH, prefer existing value.
+		if authPath != "" && !strings.HasPrefix(authPath, "${") {
+			env["AUTH_PATH"] = authPath
+			return env, volumes
+		}
+		if dest != "" {
+			env["AUTH_PATH"] = dest
+			return env, volumes
+		}
+	}
+	if authPath == "" || strings.HasPrefix(authPath, "${") {
+		env["AUTH_PATH"] = "/CLIProxyAPI/auths"
+		return env, volumes
+	}
+	env["AUTH_PATH"] = authPath
+	return env, volumes
+}
+
+// findAuthVolumeDestination returns the container-side auth mount destination.
+// destIsAuthPathDriven is true when dest is ${AUTH_PATH...} so the real path
+// is whatever AUTH_PATH resolves to at compose time.
+func findAuthVolumeDestination(volumes any) (dest string, destIsAuthPathDriven bool, ok bool) {
+	for _, item := range volumeItems(volumes) {
+		source, volumeDest, splitOK := splitBindVolume(stringValue(item))
+		if !splitOK {
+			continue
+		}
+		if !isAuthVolumeSource(source) && !isAuthVolumeDestination(volumeDest) {
+			continue
+		}
+		if isAuthPathInterpolation(volumeDest) {
+			// Prefer the default inside ${AUTH_PATH:-/path} when AUTH_PATH is unset.
+			if literal, litOK := composeDefaultLiteral(volumeDest); litOK && literal != "" {
+				return literal, true, true
+			}
+			return "", true, true
+		}
+		normalized := normalizeAuthPathValue(volumeDest)
+		if normalized == "" || strings.HasPrefix(normalized, "${") {
+			continue
+		}
+		return normalized, false, true
+	}
+	return "", false, false
+}
+
+func isAuthPathInterpolation(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	return strings.HasPrefix(trimmed, "${AUTH_PATH") || strings.HasPrefix(trimmed, "${auth_path")
+}
+
+func volumeItems(volumes any) []any {
+	if current, ok := volumes.([]any); ok {
+		return current
+	}
+	if current, ok := volumes.([]string); ok {
+		out := make([]any, 0, len(current))
+		for _, item := range current {
+			out = append(out, item)
+		}
+		return out
+	}
+	return nil
+}
+
+func splitBindVolume(spec string) (source string, dest string, ok bool) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", "", false
+	}
+	// Short syntax "src:dst[:mode]" must not split on colons inside ${VAR:-default}.
+	parts := splitComposeVolumeParts(spec)
+	if len(parts) < 2 {
+		return "", "", false
+	}
+	source = strings.TrimSpace(parts[0])
+	dest = strings.TrimSpace(parts[1])
+	if source == "" || dest == "" {
+		return "", "", false
+	}
+	if dest == "ro" || dest == "rw" || dest == "z" || dest == "Z" {
+		return "", "", false
+	}
+	return source, dest, true
+}
+
+// splitComposeVolumeParts splits docker compose short volume specs on ':' while
+// ignoring colons that appear inside ${...} interpolations.
+func splitComposeVolumeParts(spec string) []string {
+	var parts []string
+	var b strings.Builder
+	depth := 0
+	for i := 0; i < len(spec); i++ {
+		c := spec[i]
+		switch {
+		case c == '$' && i+1 < len(spec) && spec[i+1] == '{':
+			depth++
+			b.WriteString("${")
+			i++
+		case c == '}' && depth > 0:
+			depth--
+			b.WriteByte(c)
+		case c == ':' && depth == 0:
+			parts = append(parts, b.String())
+			b.Reset()
+		default:
+			b.WriteByte(c)
+		}
+	}
+	if b.Len() > 0 {
+		parts = append(parts, b.String())
+	}
+	return parts
+}
+
+func isAuthVolumeSource(source string) bool {
+	lower := strings.ToLower(source)
+	return strings.Contains(lower, "auth") ||
+		strings.Contains(source, "CLI_PROXY_AUTH_PATH") ||
+		strings.Contains(source, "${AUTH_PATH")
+}
+
+func isAuthVolumeDestination(dest string) bool {
+	literal := normalizeAuthPathValue(dest)
+	clean := filepath.Clean(literal)
+	switch clean {
+	case "/root/.cli-proxy-api", "/CLIProxyAPI/auths":
+		return true
+	default:
+		return strings.HasSuffix(clean, "/auths") || strings.HasSuffix(clean, "/.cli-proxy-api")
+	}
+}
+
+func normalizeAuthPathValue(value string) string {
+	value = strings.TrimSpace(value)
+	if literal, ok := composeDefaultLiteral(value); ok {
+		return literal
+	}
+	return value
+}
+
+func composeDefaultLiteral(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	// ${VAR:-default} or ${VAR-default}
+	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
+		inner := value[2 : len(value)-1]
+		if idx := strings.Index(inner, ":-"); idx >= 0 {
+			return strings.TrimSpace(inner[idx+2:]), true
+		}
+		if idx := strings.Index(inner, "-"); idx >= 0 {
+			return strings.TrimSpace(inner[idx+1:]), true
+		}
+	}
+	return "", false
+}
+
+// ensureRuntimeEnvAuthPath pins AUTH_PATH in .env so entrypoint and compose
+// interpolation share one destination after stack upgrades.
+// force=true means preferredAuthPath comes from a concrete volume destination
+// and must override a stale .env AUTH_PATH. force=false only fills a missing value.
+func ensureRuntimeEnvAuthPath(lines *[]string, values map[string]string, preferredAuthPath string, force bool) {
+	preferredAuthPath = strings.TrimSpace(preferredAuthPath)
+	if preferredAuthPath == "" {
+		preferredAuthPath = "/CLIProxyAPI/auths"
+	}
+	if force {
+		setEnvValue(lines, values, "AUTH_PATH", preferredAuthPath)
+		return
+	}
+	setEnvDefault(lines, values, "AUTH_PATH", preferredAuthPath)
+}
+
+func setEnvValue(lines *[]string, values map[string]string, key string, value string) {
+	for i, line := range *lines {
+		currentKey, _, ok := strings.Cut(line, "=")
+		if ok && strings.TrimSpace(currentKey) == key {
+			(*lines)[i] = key + "=" + value
+			values[key] = value
+			return
+		}
+	}
+	*lines = append(*lines, key+"="+value)
+	values[key] = value
+}
+
+// preferredAuthPathFromCompose returns the AUTH_PATH that matches the target service
+// auth volume destination. force is true only when the volume destination is a
+// concrete path that must override a stale AUTH_PATH in .env.
+func preferredAuthPathFromCompose(composeText string, service string) (path string, force bool) {
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(composeText), &doc); err != nil {
+		return "", false
+	}
+	services, ok := stringMap(doc["services"])
+	if !ok {
+		return "", false
+	}
+	targetName := strings.TrimSpace(service)
+	if _, ok := services[targetName]; !ok {
+		targetName = firstApplicationService(services)
+	}
+	target, ok := stringMap(services[targetName])
+	if !ok {
+		return "", false
+	}
+	dest, destIsAuthPathDriven, found := findAuthVolumeDestination(target["volumes"])
+	if found && !destIsAuthPathDriven && dest != "" {
+		return dest, true
+	}
+	env := mergeEnv(target["environment"], nil)
+	env, _ = alignAuthPathWithVolumes(env, target["volumes"])
+	return normalizeAuthPathValue(stringValue(env["AUTH_PATH"])), false
+}

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -550,7 +550,8 @@ func ensureRuntimeDataStackConfig(ctx context.Context, composeFile string, envFi
 	composeText := string(composeData)
 	hasRuntimeStack := hasComposeService(composeText, "postgres") && hasComposeService(composeText, "redis") && hasComposeService(composeText, "clirelay-init")
 	if hasRuntimeStack && !hasComposeService(composeText, "clirelay-migrate") {
-		if err := ensureRuntimeEnvFile(ctx, envFile, projectDir, service, composeAppImage(composeText, service), reporter); err != nil {
+		preferredAuth, forceAuth := preferredAuthPathFromCompose(composeText, service)
+		if err := ensureRuntimeEnvFile(ctx, envFile, projectDir, service, composeAppImage(composeText, service), preferredAuth, forceAuth, reporter); err != nil {
 			return envFile, err
 		}
 		return envFile, nil
@@ -561,7 +562,8 @@ func ensureRuntimeDataStackConfig(ctx context.Context, composeFile string, envFi
 	if err != nil {
 		return envFile, err
 	}
-	if err := ensureRuntimeEnvFile(ctx, envFile, projectDir, service, appImage, reporter); err != nil {
+	preferredAuth, forceAuth := preferredAuthPathFromCompose(nextCompose, service)
+	if err := ensureRuntimeEnvFile(ctx, envFile, projectDir, service, appImage, preferredAuth, forceAuth, reporter); err != nil {
 		return envFile, err
 	}
 	if err := writeDeploymentFile(ctx, composeFile, []byte(nextCompose), 0o644, reporter); err != nil {
@@ -602,6 +604,9 @@ func upgradeComposeRuntimeStack(composeText string, projectDir string, service s
 		target["command"] = []any{"./CLIProxyAPI"}
 	}
 	targetEnv := withoutEnvKeys(target["environment"], runtimeStackEnvKeys()...)
+	// Keep AUTH_PATH aligned with the existing auth volume destination so OTA
+	// upgrades do not leave host auth files mounted at a path the process no longer reads.
+	targetEnv, target["volumes"] = alignAuthPathWithVolumes(targetEnv, target["volumes"])
 	target["environment"] = targetEnv
 	target["volumes"] = appendVolume(target["volumes"], "${CLIRELAY_PROJECT_DIR:-"+projectDir+"}:/clirelay-deploy")
 	targetNetworks := target["networks"]
@@ -872,7 +877,7 @@ func stringValue(value any) string {
 	return ""
 }
 
-func ensureRuntimeEnvFile(ctx context.Context, envFile string, projectDir string, service string, image string, reporter updateReporter) error {
+func ensureRuntimeEnvFile(ctx context.Context, envFile string, projectDir string, service string, image string, preferredAuthPath string, forceAuthPath bool, reporter updateReporter) error {
 	data, err := os.ReadFile(envFile)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read docker env file: %w", err)
@@ -896,6 +901,9 @@ func ensureRuntimeEnvFile(ctx context.Context, envFile string, projectDir string
 	setEnvDefault(&lines, values, "CLIRELAY_REDIS_ADDR", "redis:6379")
 	setEnvDefault(&lines, values, "CLIRELAY_REDIS_DB", "0")
 	setEnvDefaultOrReplaceWorkspace(&lines, values, "CLIRELAY_REDIS_DATA_PATH", filepath.Join(projectDir, "redis-data"))
+	// Align AUTH_PATH with a concrete compose auth volume destination when forced;
+	// otherwise only fill a missing AUTH_PATH so existing .env values stay valid.
+	ensureRuntimeEnvAuthPath(&lines, values, preferredAuthPath, forceAuthPath)
 	content := strings.Join(lines, "\n") + "\n"
 	if err := writeDeploymentFile(ctx, envFile, []byte(content), 0o600, reporter); err != nil {
 		return fmt.Errorf("write docker env file: %w", err)

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -1189,7 +1189,7 @@ func TestEnsureRuntimeEnvFileReplacesWorkspaceProjectDir(t *testing.T) {
 		t.Fatalf("write env: %v", err)
 	}
 
-	if err := ensureRuntimeEnvFile(context.Background(), envPath, "/root/cliproxy", "cli-proxy-api", "ghcr.io/kittors/clirelay:dev", updaterRunReporter{}); err != nil {
+	if err := ensureRuntimeEnvFile(context.Background(), envPath, "/root/cliproxy", "cli-proxy-api", "ghcr.io/kittors/clirelay:dev", "", false, updaterRunReporter{}); err != nil {
 		t.Fatalf("ensureRuntimeEnvFile failed: %v", err)
 	}
 
@@ -1202,10 +1202,126 @@ func TestEnsureRuntimeEnvFileReplacesWorkspaceProjectDir(t *testing.T) {
 		"CLIRELAY_PROJECT_DIR=/root/cliproxy\n",
 		"CLIRELAY_POSTGRES_DATA_PATH=/root/cliproxy/postgres-data\n",
 		"CLIRELAY_REDIS_DATA_PATH=/root/cliproxy/redis-data\n",
+		"AUTH_PATH=/CLIProxyAPI/auths\n",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("env missing %q:\n%s", want, content)
 		}
+	}
+}
+
+func TestEnsureRuntimeEnvFileAlignsStaleAuthPath(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envPath, []byte("AUTH_PATH=/CLIProxyAPI/auths\n"), 0o600); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+	// Preferred path comes from a concrete volume destination (legacy default).
+	if err := ensureRuntimeEnvFile(context.Background(), envPath, "/root/cliproxy", "cli-proxy-api", "ghcr.io/kittors/clirelay:dev", "/root/.cli-proxy-api", true, updaterRunReporter{}); err != nil {
+		t.Fatalf("ensureRuntimeEnvFile failed: %v", err)
+	}
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read env: %v", err)
+	}
+	if !strings.Contains(string(data), "AUTH_PATH=/root/.cli-proxy-api\n") {
+		t.Fatalf("stale AUTH_PATH was not realigned:\n%s", data)
+	}
+}
+
+func TestEnsureRuntimeEnvFileKeepsExistingAuthPathWhenNotForced(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envPath, []byte("AUTH_PATH=/root/.cli-proxy-api\n"), 0o600); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+	if err := ensureRuntimeEnvFile(context.Background(), envPath, "/root/cliproxy", "cli-proxy-api", "ghcr.io/kittors/clirelay:dev", "/CLIProxyAPI/auths", false, updaterRunReporter{}); err != nil {
+		t.Fatalf("ensureRuntimeEnvFile failed: %v", err)
+	}
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read env: %v", err)
+	}
+	if !strings.Contains(string(data), "AUTH_PATH=/root/.cli-proxy-api\n") {
+		t.Fatalf("existing AUTH_PATH should be preserved when not forced:\n%s", data)
+	}
+}
+
+func TestUpgradeComposeRuntimeStackAlignsAuthPathWithLegacyVolume(t *testing.T) {
+	upgraded, _, err := upgradeComposeRuntimeStack(`
+services:
+  cli-proxy-api:
+    image: ghcr.io/kittors/clirelay:dev
+    environment:
+      AUTH_PATH: ${AUTH_PATH:-/CLIProxyAPI/auths}
+    volumes:
+      - ${CLI_PROXY_AUTH_PATH:-./auths}:/root/.cli-proxy-api
+`, "/opt/clirelay", "cli-proxy-api")
+	if err != nil {
+		t.Fatalf("upgradeComposeRuntimeStack failed: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(upgraded), &doc); err != nil {
+		t.Fatalf("parse upgraded compose: %v", err)
+	}
+	services, ok := stringMap(doc["services"])
+	if !ok {
+		t.Fatalf("services missing:\n%s", upgraded)
+	}
+	target, ok := stringMap(services["cli-proxy-api"])
+	if !ok {
+		t.Fatalf("target missing:\n%s", upgraded)
+	}
+	env, ok := stringMap(target["environment"])
+	if !ok {
+		t.Fatalf("environment missing:\n%s", upgraded)
+	}
+	if env["AUTH_PATH"] != "/root/.cli-proxy-api" {
+		t.Fatalf("AUTH_PATH = %v, want /root/.cli-proxy-api\n%s", env["AUTH_PATH"], upgraded)
+	}
+}
+
+func TestAlignAuthPathWithVolumesUsesInterpolationAwareSplit(t *testing.T) {
+	// Volume dest is driven by AUTH_PATH itself; keep existing concrete AUTH_PATH.
+	env, _ := alignAuthPathWithVolumes(map[string]any{
+		"AUTH_PATH": "/root/.cli-proxy-api",
+	}, []any{
+		"${CLI_PROXY_AUTH_PATH:-${CLIRELAY_PROJECT_DIR:-${PWD:-.}}/auths}:${AUTH_PATH:-/CLIProxyAPI/auths}",
+	})
+	if env["AUTH_PATH"] != "/root/.cli-proxy-api" {
+		t.Fatalf("AUTH_PATH = %v, want preserved /root/.cli-proxy-api", env["AUTH_PATH"])
+	}
+
+	// Unset AUTH_PATH with AUTH_PATH-driven volume uses the volume default.
+	env, _ = alignAuthPathWithVolumes(map[string]any{}, []any{
+		"${CLI_PROXY_AUTH_PATH:-./auths}:${AUTH_PATH:-/root/.cli-proxy-api}",
+	})
+	if env["AUTH_PATH"] != "/root/.cli-proxy-api" {
+		t.Fatalf("AUTH_PATH = %v, want default from volume dest", env["AUTH_PATH"])
+	}
+
+	// Concrete volume destination overrides a mismatched AUTH_PATH.
+	env, _ = alignAuthPathWithVolumes(map[string]any{
+		"AUTH_PATH": "/CLIProxyAPI/auths",
+	}, []any{
+		"./auths:/root/.cli-proxy-api",
+	})
+	if env["AUTH_PATH"] != "/root/.cli-proxy-api" {
+		t.Fatalf("AUTH_PATH = %v, want concrete volume dest", env["AUTH_PATH"])
+	}
+}
+
+func TestSplitComposeVolumePartsIgnoresColonsInInterpolation(t *testing.T) {
+	parts := splitComposeVolumeParts("${CLI_PROXY_AUTH_PATH:-${PWD:-.}/auths}:${AUTH_PATH:-/CLIProxyAPI/auths}:ro")
+	if len(parts) != 3 {
+		t.Fatalf("parts = %#v, want 3 segments", parts)
+	}
+	if parts[0] != "${CLI_PROXY_AUTH_PATH:-${PWD:-.}/auths}" {
+		t.Fatalf("source = %q", parts[0])
+	}
+	if parts[1] != "${AUTH_PATH:-/CLIProxyAPI/auths}" {
+		t.Fatalf("dest = %q", parts[1])
+	}
+	if parts[2] != "ro" {
+		t.Fatalf("mode = %q", parts[2])
 	}
 }
 

--- a/internal/management/imagegeneration/service_test.go
+++ b/internal/management/imagegeneration/service_test.go
@@ -10,9 +10,7 @@ import (
 func TestServiceStartAndGetLifecycle(t *testing.T) {
 	t.Parallel()
 
-	done := make(chan struct{})
 	svc := NewService(func(ctx context.Context, tenantID string, payload []byte, alt string) ([]byte, error) {
-		close(done)
 		return []byte(`{"data":[{"b64_json":"abc"}]}`), nil
 	}, "test")
 
@@ -21,19 +19,7 @@ func TestServiceStartAndGetLifecycle(t *testing.T) {
 		t.Fatalf("Start() returned empty task id")
 	}
 
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("task did not finish in time")
-	}
-
-	got, ok := svc.Get("tenant-a", snapshot.ID)
-	if !ok {
-		t.Fatalf("Get(%q) returned not found", snapshot.ID)
-	}
-	if got.Status != "succeeded" {
-		t.Fatalf("task status = %q, want succeeded", got.Status)
-	}
+	got := waitTaskStatus(t, svc, "tenant-a", snapshot.ID, "succeeded")
 	if got.Result == nil {
 		t.Fatalf("task result is nil")
 	}
@@ -55,26 +41,14 @@ func (e fakeStatusError) StatusCode() int {
 func TestServiceCapturesStatusError(t *testing.T) {
 	t.Parallel()
 
-	done := make(chan struct{})
 	svc := NewService(func(ctx context.Context, tenantID string, payload []byte, alt string) ([]byte, error) {
-		close(done)
 		return nil, fakeStatusError{code: 429, err: errors.New("rate limited")}
 	}, "test")
 
 	snapshot := svc.Start("tenant-a", []byte(`{"prompt":"hello"}`), "images/generations")
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("task did not finish in time")
-	}
-
-	got, ok := svc.Get("tenant-a", snapshot.ID)
-	if !ok {
-		t.Fatalf("Get(%q) returned not found", snapshot.ID)
-	}
-	if got.Status != "failed" {
-		t.Fatalf("task status = %q, want failed", got.Status)
-	}
+	// Wait for the terminal status update after execute returns; closing a channel
+	// inside execute races the status write and can still observe "running".
+	got := waitTaskStatus(t, svc, "tenant-a", snapshot.ID, "failed")
 	if got.Error == nil {
 		t.Fatalf("task error is nil")
 	}
@@ -86,21 +60,41 @@ func TestServiceCapturesStatusError(t *testing.T) {
 func TestServiceTaskIsTenantScoped(t *testing.T) {
 	t.Parallel()
 
-	done := make(chan struct{})
 	svc := NewService(func(_ context.Context, tenantID string, _ []byte, _ string) ([]byte, error) {
 		if tenantID != "tenant-a" {
 			t.Errorf("tenantID = %q", tenantID)
 		}
-		close(done)
 		return []byte(`{"data":[]}`), nil
 	}, "test")
 
 	task := svc.Start("tenant-a", []byte(`{"prompt":"hello"}`), "images/generations")
-	<-done
+	_ = waitTaskStatus(t, svc, "tenant-a", task.ID, "succeeded")
 	if _, ok := svc.Get("tenant-b", task.ID); ok {
 		t.Fatal("tenant B can read tenant A task")
 	}
 	if _, ok := svc.Get("tenant-a", task.ID); !ok {
 		t.Fatal("tenant A task missing")
 	}
+}
+
+// waitTaskStatus polls until the async task reaches wantStatus or the timeout fires.
+// Execute callbacks finish before Service.run writes the terminal status, so tests
+// must wait on the stored status rather than a channel closed inside execute.
+func waitTaskStatus(t *testing.T, svc *Service, tenantID, taskID, wantStatus string) Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var last Snapshot
+	for time.Now().Before(deadline) {
+		got, ok := svc.Get(tenantID, taskID)
+		if !ok {
+			t.Fatalf("Get(%q) returned not found", taskID)
+		}
+		last = got
+		if got.Status == wantStatus {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("task status = %q, want %q", last.Status, wantStatus)
+	return Snapshot{}
 }

--- a/internal/util/auth_dir_test.go
+++ b/internal/util/auth_dir_test.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCountJSONAuthFilesCountsNonEmptyJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.json"), []byte(`{"id":"a"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "empty.json"), []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "skip.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(dir, "tenant")
+	if err := os.MkdirAll(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b.json"), []byte(`{"id":"b"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := CountJSONAuthFiles(dir)
+	if err != nil {
+		t.Fatalf("CountJSONAuthFiles: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count = %d, want 2", count)
+	}
+}
+
+func TestCountJSONAuthFilesMissingDir(t *testing.T) {
+	count, err := CountJSONAuthFiles(filepath.Join(t.TempDir(), "missing"))
+	if err != nil {
+		t.Fatalf("CountJSONAuthFiles missing: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("count = %d, want 0", count)
+	}
+}
+
+func TestLegacyDockerAuthDirs(t *testing.T) {
+	dirs := LegacyDockerAuthDirs()
+	if len(dirs) < 2 {
+		t.Fatalf("expected at least two legacy paths, got %#v", dirs)
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -93,6 +93,99 @@ func ResolveAuthDir(authDir string) (string, error) {
 	return filepath.Clean(authDir), nil
 }
 
+// LegacyDockerAuthDirs are container paths used by older Compose defaults.
+// They remain candidates when diagnosing empty AuthDir after upgrades.
+func LegacyDockerAuthDirs() []string {
+	return []string{
+		"/root/.cli-proxy-api",
+		"/CLIProxyAPI/auths",
+	}
+}
+
+// CountJSONAuthFiles counts non-empty .json files under dir (recursive).
+// Missing directories return 0 without error so callers can treat "empty" uniformly.
+func CountJSONAuthFiles(dir string) (int, error) {
+	trimmed := strings.TrimSpace(dir)
+	if trimmed == "" {
+		return 0, nil
+	}
+	info, err := os.Stat(trimmed)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if !info.IsDir() {
+		return 0, fmt.Errorf("auth dir is not a directory: %s", trimmed)
+	}
+	count := 0
+	err = filepath.WalkDir(trimmed, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".json") {
+			return nil
+		}
+		fi, errInfo := d.Info()
+		if errInfo != nil {
+			return nil
+		}
+		if fi.Size() > 0 {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		return count, err
+	}
+	return count, nil
+}
+
+// LogResolvedAuthDir logs the effective auth directory and file count.
+// When the resolved directory is empty but a known legacy Docker auth path still
+// has JSON files, it warns about AUTH_PATH / volume misalignment (issue #542).
+func LogResolvedAuthDir(authDir string) {
+	trimmed := strings.TrimSpace(authDir)
+	if trimmed == "" {
+		log.Warn("auth directory is empty; file-based credentials will not load")
+		return
+	}
+	authEnv := strings.TrimSpace(os.Getenv("AUTH_PATH"))
+	if authEnv != "" {
+		log.Infof("auth directory resolved to %s (AUTH_PATH=%s)", trimmed, authEnv)
+	} else {
+		log.Infof("auth directory resolved to %s", trimmed)
+	}
+	count, err := CountJSONAuthFiles(trimmed)
+	if err != nil {
+		log.Warnf("auth directory %s is not fully readable: %v", trimmed, err)
+		return
+	}
+	log.Infof("auth directory %s contains %d non-empty .json file(s)", trimmed, count)
+	if count > 0 {
+		return
+	}
+	resolvedClean := filepath.Clean(trimmed)
+	for _, candidate := range LegacyDockerAuthDirs() {
+		if filepath.Clean(candidate) == resolvedClean {
+			continue
+		}
+		legacyCount, legacyErr := CountJSONAuthFiles(candidate)
+		if legacyErr != nil || legacyCount == 0 {
+			continue
+		}
+		log.Warnf(
+			"auth directory %s is empty, but %s still has %d .json file(s); "+
+				"check AUTH_PATH and the docker auth volume destination so the process reads the mounted directory",
+			trimmed, candidate, legacyCount,
+		)
+	}
+}
+
 // CountAuthFiles returns the number of auth records available through the provided Store.
 // For filesystem-backed stores, this reflects the number of JSON auth files under the configured directory.
 func CountAuthFiles[T any](ctx context.Context, store interface {

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -239,9 +239,9 @@ func (w *Watcher) loadFileClients(cfg *config.Config) int {
 	})
 
 	if errWalk != nil {
-		log.Errorf("error walking auth directory: %v", errWalk)
+		log.Errorf("error walking auth directory %s: %v", authDir, errWalk)
 	}
-	log.Debugf("auth directory scan complete - found %d .json files, %d readable", authFileCount, successfulAuthCount)
+	log.Infof("auth directory scan complete - path=%s found %d .json files, %d readable", authDir, authFileCount, successfulAuthCount)
 	return authFileCount
 }
 


### PR DESCRIPTION
## Summary
- Align `AUTH_PATH` with the concrete Docker auth volume destination during compose/OTA runtime-stack upgrades so host `auths` files remain visible after path default changes (`/root/.cli-proxy-api` → `/CLIProxyAPI/auths`).
- Log resolved AuthDir, non-empty `.json` count, and warn when the active auth dir is empty but a known legacy Docker path still has files (issue #542).
- Keep `.env AUTH_PATH` when the volume destination is `${AUTH_PATH:-...}`-driven; only force-override when the volume destination is a concrete path.

## Related
- Fixes upgrade symptom described in https://github.com/kittors/CliRelay/issues/542

## Test plan
- [x] `./scripts/ci-pr.sh` (structure scan, gofmt, secret scan, `go vet`, full `go test ./...`, golangci-lint, `go build ./cmd/server`)
- [x] Focused: `go test ./cmd/updater ./internal/util ./internal/watcher -count=1`

## Notes
- `cmd/updater` AUTH_PATH helpers live in `auth_path_align.go` so `main.go` stays under the structure-scan 1200-line block.