### PR TITLE
feat(models): live upstream /models for Claude and Codex

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -37,7 +37,12 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 	c.JSON(200, gin.H{"files": files})
 }
 
-// GetAuthFileModels returns the models supported by a specific auth file
+// GetAuthFileModels returns the models supported by a specific auth file.
+//
+// Query params:
+//   - name (required): auth file name or auth ID
+//   - refresh=1|true: re-fetch live models from upstream (claude/codex/xai/antigravity)
+//     and update the runtime registry when successful; falls back to registry on failure.
 func (h *Handler) GetAuthFileModels(c *gin.Context) {
 	name := c.Query("name")
 	if name == "" {
@@ -45,8 +50,25 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 		return
 	}
 
-	models := managementauthfiles.ListModelEntriesForTenant(h.authManager, registry.GetGlobalRegistry(), effectiveTenantID(c), name)
-	c.JSON(200, gin.H{"models": models})
+	refresh := false
+	switch strings.ToLower(strings.TrimSpace(c.Query("refresh"))) {
+	case "1", "true", "yes", "force":
+		refresh = true
+	}
+
+	reg := registry.GetGlobalRegistry()
+	tenantID := effectiveTenantID(c)
+	models, source := managementauthfiles.ListModelEntriesLiveForTenant(
+		c.Request.Context(),
+		h.authManager,
+		reg,
+		reg,
+		h.cfg,
+		tenantID,
+		name,
+		refresh,
+	)
+	c.JSON(200, gin.H{"models": models, "source": source})
 }
 
 // List auth files from disk when the auth manager is unavailable.

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -441,6 +441,14 @@ func FetchXAIModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config
 	return executor.FetchXAIModels(ctx, auth, cfg)
 }
 
+func FetchClaudeModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return executor.FetchClaudeModels(ctx, auth, cfg)
+}
+
+func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return executor.FetchCodexModels(ctx, auth, cfg)
+}
+
 func RebindTenantExecutors(base *config.Config, coreManager *coreauth.Manager, tenantID string, gateway WebsocketGateway) {
 	if base == nil || coreManager == nil {
 		return

--- a/internal/management/authfiles/models.go
+++ b/internal/management/authfiles/models.go
@@ -1,14 +1,23 @@
 package authfiles
 
 import (
+	"context"
 	"strings"
+	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
 )
 
 type ModelSource interface {
 	GetModelsForClient(clientID string) []*registry.ModelInfo
+}
+
+type ModelRegistrar interface {
+	RegisterClient(clientID, clientProvider string, models []*registry.ModelInfo)
 }
 
 func ModelLookupAuthID(manager *coreauth.Manager, name string) string {
@@ -33,6 +42,23 @@ func ModelLookupAuthIDForTenant(manager *coreauth.Manager, tenantID, name string
 	return name
 }
 
+// FindAuthForTenant resolves an auth by file name or ID within a tenant.
+func FindAuthForTenant(manager *coreauth.Manager, tenantID, name string) *coreauth.Auth {
+	name = strings.TrimSpace(name)
+	if name == "" || manager == nil {
+		return nil
+	}
+	for _, auth := range manager.ListForTenant(NormalizeTenantID(tenantID)) {
+		if auth == nil {
+			continue
+		}
+		if auth.FileName == name || auth.ID == name {
+			return auth
+		}
+	}
+	return nil
+}
+
 func ListModelEntries(manager *coreauth.Manager, source ModelSource, name string) []map[string]any {
 	return ListModelEntriesForTenant(manager, source, "", name)
 }
@@ -43,6 +69,108 @@ func ListModelEntriesForTenant(manager *coreauth.Manager, source ModelSource, te
 	}
 	authID := ModelLookupAuthIDForTenant(manager, tenantID, name)
 	models := source.GetModelsForClient(authID)
+	return modelEntriesFromRegistry(models)
+}
+
+// ListModelEntriesLiveForTenant optionally re-fetches models from the upstream
+// provider for claude/codex (and other live-capable providers), updates the
+// registry when successful, then returns the public model payload.
+//
+// When live fetch fails, falls back to the existing registry list so the UI
+// still shows known models.
+func ListModelEntriesLiveForTenant(
+	ctx context.Context,
+	manager *coreauth.Manager,
+	source ModelSource,
+	registrar ModelRegistrar,
+	cfg *config.Config,
+	tenantID, name string,
+	refresh bool,
+) (models []map[string]any, sourceLabel string) {
+	sourceLabel = "registry"
+	if !refresh {
+		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
+	}
+
+	auth := FindAuthForTenant(manager, tenantID, name)
+	if auth == nil {
+		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
+	}
+
+	live, provider := fetchLiveModelsForAuth(ctx, auth, cfg)
+	if len(live) == 0 {
+		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
+	}
+
+	sourceLabel = "upstream"
+	if registrar != nil {
+		providerKey := provider
+		if providerKey == "" {
+			providerKey = strings.ToLower(strings.TrimSpace(auth.Provider))
+		}
+		registrar.RegisterClient(auth.ID, providerKey, live)
+	}
+	return modelEntriesFromRegistry(live), sourceLabel
+}
+
+func fetchLiveModelsForAuth(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) ([]*registry.ModelInfo, string) {
+	if auth == nil {
+		return nil, ""
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	var sdkModels []*sdkmodelcatalog.ModelInfo
+	switch provider {
+	case "claude":
+		sdkModels = executor.FetchClaudeModels(fetchCtx, auth, cfg)
+	case "codex":
+		sdkModels = executor.FetchCodexModels(fetchCtx, auth, cfg)
+	case "xai":
+		sdkModels = executor.FetchXAIModels(fetchCtx, auth, cfg)
+	case "antigravity":
+		sdkModels = executor.FetchAntigravityModels(fetchCtx, auth, cfg)
+	default:
+		return nil, provider
+	}
+	return cloneSDKModelsToRegistry(sdkModels), provider
+}
+
+func cloneSDKModelsToRegistry(models []*sdkmodelcatalog.ModelInfo) []*registry.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		out = append(out, &registry.ModelInfo{
+			ID:                  model.ID,
+			Object:              model.Object,
+			Created:             model.Created,
+			OwnedBy:             model.OwnedBy,
+			Type:                model.Type,
+			DisplayName:         model.DisplayName,
+			UpstreamModelID:     model.UpstreamModelID,
+			Name:                model.Name,
+			Version:             model.Version,
+			Description:         model.Description,
+			InputTokenLimit:     model.InputTokenLimit,
+			OutputTokenLimit:    model.OutputTokenLimit,
+			ContextLength:       model.ContextLength,
+			MaxCompletionTokens: model.MaxCompletionTokens,
+			UserDefined:         model.UserDefined,
+		})
+	}
+	return out
+}
+
+func modelEntriesFromRegistry(models []*registry.ModelInfo) []map[string]any {
 	result := make([]map[string]any, 0, len(models))
 	for _, model := range models {
 		if model == nil {

--- a/internal/runtime/executor/claude_models.go
+++ b/internal/runtime/executor/claude_models.go
@@ -1,0 +1,255 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	claudeModelsPath          = "/v1/models"
+	defaultClaudeModelsBase   = "https://api.anthropic.com"
+	defaultClaudeAnthropicVer = "2023-06-01"
+)
+
+var claudeModelsCache struct {
+	mu     sync.RWMutex
+	models []*sdkmodelcatalog.ModelInfo
+}
+
+type claudeModelsResponse struct {
+	Data   []claudeModelPayload `json:"data"`
+	Models []claudeModelPayload `json:"models"`
+}
+
+type claudeModelPayload struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	DisplayName string `json:"display_name"`
+	CreatedAt   string `json:"created_at"`
+}
+
+func cloneClaudeModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		if len(model.SupportedGenerationMethods) > 0 {
+			clone.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedParameters) > 0 {
+			clone.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+		}
+		if model.Thinking != nil {
+			thinkingClone := *model.Thinking
+			if len(model.Thinking.Levels) > 0 {
+				thinkingClone.Levels = append([]string(nil), model.Thinking.Levels...)
+			}
+			clone.Thinking = &thinkingClone
+		}
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func storeClaudeModels(models []*sdkmodelcatalog.ModelInfo) bool {
+	cloned := cloneClaudeModels(models)
+	if len(cloned) == 0 {
+		return false
+	}
+	claudeModelsCache.mu.Lock()
+	claudeModelsCache.models = cloned
+	claudeModelsCache.mu.Unlock()
+	return true
+}
+
+func loadClaudeModels() []*sdkmodelcatalog.ModelInfo {
+	claudeModelsCache.mu.RLock()
+	cloned := cloneClaudeModels(claudeModelsCache.models)
+	claudeModelsCache.mu.RUnlock()
+	return cloned
+}
+
+func fallbackClaudeModels() []*sdkmodelcatalog.ModelInfo {
+	if models := loadClaudeModels(); len(models) > 0 {
+		log.Debugf("claude executor: using cached model list (%d models)", len(models))
+		return models
+	}
+	return nil
+}
+
+// FetchClaudeModels retrieves the live model list from Anthropic-compatible /v1/models.
+// Supports OAuth (Bearer access_token) and API key (x-api-key) auth, matching request
+// credential resolution used by Claude message forwarding.
+func FetchClaudeModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token, baseURL := claudeCreds(auth)
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fallbackClaudeModels()
+	}
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = defaultClaudeModelsBase
+	}
+	modelsURL := buildClaudeModelsURL(baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return fallbackClaudeModels()
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("anthropic-version", defaultClaudeAnthropicVer)
+
+	useAPIKey := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	isAnthropicBase := strings.Contains(strings.ToLower(baseURL), "api.anthropic.com")
+	if isAnthropicBase && useAPIKey {
+		req.Header.Set("x-api-key", token)
+	} else if useAPIKey {
+		// Custom Anthropic-compatible gateways usually accept x-api-key for API keys.
+		req.Header.Set("x-api-key", token)
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		// OAuth / setup-token style: Bearer access_token + oauth beta, aligned with sub2api.
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	}
+	if auth != nil {
+		util.ApplyCustomHeadersFromAttrs(req, auth.Attributes)
+	}
+
+	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Debugf("claude executor: models request failed: %v", err)
+		}
+		return fallbackClaudeModels()
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("claude executor: close models response body error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		log.Debugf("claude executor: models request failed with status %d", resp.StatusCode)
+		return fallbackClaudeModels()
+	}
+
+	body, err := readUpstreamResponseBody("claude", resp.Body)
+	if err != nil {
+		log.Debugf("claude executor: models response read failed: %v", err)
+		return fallbackClaudeModels()
+	}
+
+	models, ok := parseClaudeModels(body, time.Now().Unix())
+	if !ok {
+		log.Debug("claude executor: fetched empty or invalid model list; retaining cached model list")
+		return fallbackClaudeModels()
+	}
+	storeClaudeModels(models)
+	return models
+}
+
+func buildClaudeModelsURL(base string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(base), "/")
+	if strings.HasSuffix(strings.ToLower(normalized), "/v1/models") {
+		return normalized
+	}
+	if strings.HasSuffix(strings.ToLower(normalized), "/v1") {
+		return normalized + "/models"
+	}
+	return normalized + claudeModelsPath
+}
+
+func parseClaudeModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var decoded claudeModelsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		var arrayResponse []claudeModelPayload
+		if arrayErr := json.Unmarshal(body, &arrayResponse); arrayErr != nil {
+			return nil, false
+		}
+		decoded.Data = arrayResponse
+	}
+
+	entries := decoded.Data
+	if len(entries) == 0 {
+		entries = decoded.Models
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, item := range entries {
+		modelID := strings.TrimSpace(item.ID)
+		if modelID == "" {
+			continue
+		}
+		key := strings.ToLower(modelID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		displayName := strings.TrimSpace(item.DisplayName)
+		if displayName == "" {
+			displayName = modelID
+		}
+		object := strings.TrimSpace(item.Type)
+		if object == "" {
+			object = "model"
+		}
+		model := &sdkmodelcatalog.ModelInfo{
+			ID:          modelID,
+			Object:      object,
+			Created:     now,
+			OwnedBy:     "claude",
+			Type:        "claude",
+			DisplayName: displayName,
+			Name:        modelID,
+			Version:     modelID,
+		}
+		if static := sdkmodelcatalog.LookupStaticModelInfo(modelID); static != nil {
+			if strings.TrimSpace(static.Description) != "" {
+				model.Description = static.Description
+			}
+			if strings.TrimSpace(static.DisplayName) != "" {
+				model.DisplayName = static.DisplayName
+			}
+			if static.Thinking != nil {
+				thinkingClone := *static.Thinking
+				if len(static.Thinking.Levels) > 0 {
+					thinkingClone.Levels = append([]string(nil), static.Thinking.Levels...)
+				}
+				model.Thinking = &thinkingClone
+			}
+			if static.ContextLength > 0 {
+				model.ContextLength = static.ContextLength
+				model.InputTokenLimit = static.ContextLength
+			}
+			if static.MaxCompletionTokens > 0 {
+				model.MaxCompletionTokens = static.MaxCompletionTokens
+				model.OutputTokenLimit = static.MaxCompletionTokens
+			}
+		}
+		out = append(out, model)
+	}
+	return out, len(out) > 0
+}

--- a/internal/runtime/executor/claude_models_test.go
+++ b/internal/runtime/executor/claude_models_test.go
@@ -1,0 +1,138 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+func resetClaudeModelsCacheForTest() {
+	claudeModelsCache.mu.Lock()
+	claudeModelsCache.models = nil
+	claudeModelsCache.mu.Unlock()
+}
+
+func TestParseClaudeModelsFromDataArray(t *testing.T) {
+	body := []byte(`{
+		"data": [
+			{"id": "claude-sonnet-4-5", "type": "model", "display_name": "Claude Sonnet 4.5"},
+			{"id": "claude-opus-4", "display_name": "Claude Opus 4"},
+			{"id": "claude-sonnet-4-5"}
+		]
+	}`)
+	models, ok := parseClaudeModels(body, 1700000000)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models)=%d, want 2 (deduped)", len(models))
+	}
+	if models[0].ID != "claude-sonnet-4-5" {
+		t.Fatalf("models[0].ID=%q", models[0].ID)
+	}
+	if models[0].DisplayName != "Claude Sonnet 4.5" {
+		t.Fatalf("display name = %q", models[0].DisplayName)
+	}
+	if models[0].OwnedBy != "claude" || models[0].Type != "claude" {
+		t.Fatalf("owned/type = %q/%q", models[0].OwnedBy, models[0].Type)
+	}
+}
+
+func TestBuildClaudeModelsURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://api.anthropic.com", "https://api.anthropic.com/v1/models"},
+		{"https://api.anthropic.com/", "https://api.anthropic.com/v1/models"},
+		{"https://api.anthropic.com/v1", "https://api.anthropic.com/v1/models"},
+		{"https://gateway.example/v1/models", "https://gateway.example/v1/models"},
+		{"https://gateway.example/proxy", "https://gateway.example/proxy/v1/models"},
+	}
+	for _, tc := range cases {
+		if got := buildClaudeModelsURL(tc.in); got != tc.want {
+			t.Fatalf("buildClaudeModelsURL(%q)=%q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFetchClaudeModelsParsesLiveCatalog(t *testing.T) {
+	resetClaudeModelsCacheForTest()
+	t.Cleanup(resetClaudeModelsCacheForTest)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path=%q", r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "sk-ant-test" {
+			t.Fatalf("x-api-key=%q", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got == "" {
+			t.Fatal("missing anthropic-version")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"claude-live-1","display_name":"Live One"}]}`))
+	}))
+	defer srv.Close()
+
+	models := FetchClaudeModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "claude",
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-test",
+			"base_url": srv.URL,
+		},
+	}, nil)
+	if len(models) != 1 || models[0].ID != "claude-live-1" {
+		t.Fatalf("models=%v", models)
+	}
+}
+
+func TestFetchClaudeModelsFallsBackToCache(t *testing.T) {
+	resetClaudeModelsCacheForTest()
+	t.Cleanup(resetClaudeModelsCacheForTest)
+
+	if ok := storeClaudeModels([]*sdkmodelcatalog.ModelInfo{{ID: "cached-claude", OwnedBy: "claude", Type: "claude"}}); !ok {
+		t.Fatal("cache seed failed")
+	}
+	models := FetchClaudeModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "claude",
+		// no credentials → fallback
+	}, nil)
+	if len(models) != 1 || models[0].ID != "cached-claude" {
+		t.Fatalf("fallback models=%v", models)
+	}
+}
+
+func TestFetchClaudeModelsOAuthBearer(t *testing.T) {
+	resetClaudeModelsCacheForTest()
+	t.Cleanup(resetClaudeModelsCacheForTest)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Fatalf("Authorization=%q", got)
+		}
+		if got := r.Header.Get("anthropic-beta"); got == "" {
+			t.Fatal("expected oauth anthropic-beta")
+		}
+		if got := r.Header.Get("x-api-key"); got != "" {
+			t.Fatalf("unexpected x-api-key=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"claude-oauth-1"}]}`))
+	}))
+	defer srv.Close()
+
+	models := FetchClaudeModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "claude",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+		Attributes: map[string]string{
+			"base_url": srv.URL,
+		},
+	}, nil)
+	if len(models) != 1 || models[0].ID != "claude-oauth-1" {
+		t.Fatalf("models=%v", models)
+	}
+}

--- a/internal/runtime/executor/codex_models.go
+++ b/internal/runtime/executor/codex_models.go
@@ -1,0 +1,364 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// Official ChatGPT Codex models manifest (OAuth). Aligned with sub2api:
+	// https://chatgpt.com/backend-api/codex/models?client_version=...
+	defaultCodexModelsManifestBase = "https://chatgpt.com/backend-api/codex"
+	defaultCodexModelsClientVer    = "0.118.0"
+)
+
+var codexModelsCache struct {
+	mu     sync.RWMutex
+	models []*sdkmodelcatalog.ModelInfo
+}
+
+type codexModelsResponse struct {
+	Data   []codexModelPayload `json:"data"`
+	Models []codexModelPayload `json:"models"`
+	// Some Codex manifest revisions nest models under items/list.
+	Items []codexModelPayload `json:"items"`
+}
+
+type codexModelPayload struct {
+	ID          string `json:"id"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Title       string `json:"title"`
+	Object      string `json:"object"`
+	OwnedBy     string `json:"owned_by"`
+	Created     int64  `json:"created"`
+}
+
+func cloneCodexModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		if len(model.SupportedGenerationMethods) > 0 {
+			clone.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedParameters) > 0 {
+			clone.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+		}
+		if model.Thinking != nil {
+			thinkingClone := *model.Thinking
+			if len(model.Thinking.Levels) > 0 {
+				thinkingClone.Levels = append([]string(nil), model.Thinking.Levels...)
+			}
+			clone.Thinking = &thinkingClone
+		}
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func storeCodexModels(models []*sdkmodelcatalog.ModelInfo) bool {
+	cloned := cloneCodexModels(models)
+	if len(cloned) == 0 {
+		return false
+	}
+	codexModelsCache.mu.Lock()
+	codexModelsCache.models = cloned
+	codexModelsCache.mu.Unlock()
+	return true
+}
+
+func loadCodexModels() []*sdkmodelcatalog.ModelInfo {
+	codexModelsCache.mu.RLock()
+	cloned := cloneCodexModels(codexModelsCache.models)
+	codexModelsCache.mu.RUnlock()
+	return cloned
+}
+
+func fallbackCodexModels() []*sdkmodelcatalog.ModelInfo {
+	if models := loadCodexModels(); len(models) > 0 {
+		log.Debugf("codex executor: using cached model list (%d models)", len(models))
+		return models
+	}
+	return nil
+}
+
+// FetchCodexModels retrieves the live model list for a Codex auth.
+//
+// - OAuth / ChatGPT backend base: GET {base}/models?client_version=... (manifest)
+// - API key with OpenAI-compatible base: GET {base}/v1/models or {base}/models
+//
+// Response body schema evolves with Codex client releases; parsing is intentionally
+// tolerant (id/slug/name fields, data/models/items arrays).
+func FetchCodexModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token, baseURL := codexCreds(auth)
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fallbackCodexModels()
+	}
+
+	useAPIKey := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	modelsURL, isManifest := buildCodexModelsURL(baseURL, useAPIKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return fallbackCodexModels()
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	if isManifest {
+		// Align with Codex CLI / sub2api manifest probe headers.
+		req.Header.Set("Originator", codexOriginator)
+		req.Header.Set("Version", defaultCodexModelsClientVer)
+		req.Header.Set("User-Agent", codexUserAgent)
+		if auth != nil && auth.Metadata != nil {
+			if accountID, ok := auth.Metadata["account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+				req.Header.Set("Chatgpt-Account-Id", strings.TrimSpace(accountID))
+			}
+		}
+	}
+
+	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Debugf("codex executor: models request failed: %v", err)
+		}
+		return fallbackCodexModels()
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codex executor: close models response body error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		log.Debugf("codex executor: models request failed with status %d", resp.StatusCode)
+		return fallbackCodexModels()
+	}
+
+	body, err := readUpstreamResponseBody("codex", resp.Body)
+	if err != nil {
+		log.Debugf("codex executor: models response read failed: %v", err)
+		return fallbackCodexModels()
+	}
+
+	models, ok := parseCodexModels(body, time.Now().Unix())
+	if !ok {
+		log.Debug("codex executor: fetched empty or invalid model list; retaining cached model list")
+		return fallbackCodexModels()
+	}
+	storeCodexModels(models)
+	return models
+}
+
+func buildCodexModelsURL(baseURL string, useAPIKey bool) (string, bool) {
+	normalized := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if normalized == "" {
+		// OAuth default: ChatGPT Codex models manifest.
+		u := defaultCodexModelsManifestBase + "/models?client_version=" + url.QueryEscape(defaultCodexModelsClientVer)
+		return u, true
+	}
+
+	lower := strings.ToLower(normalized)
+	// Already a models endpoint.
+	if strings.HasSuffix(lower, "/models") || strings.Contains(lower, "/models?") {
+		return normalized, strings.Contains(lower, "backend-api/codex") || strings.Contains(lower, "chatgpt.com")
+	}
+
+	// ChatGPT / Codex backend style base.
+	if strings.Contains(lower, "backend-api/codex") || strings.Contains(lower, "chatgpt.com") {
+		if !strings.HasSuffix(lower, "/codex") && !strings.Contains(lower, "/codex/") {
+			// e.g. https://chatgpt.com/backend-api
+			if strings.HasSuffix(lower, "/backend-api") {
+				normalized = normalized + "/codex"
+			}
+		}
+		return normalized + "/models?client_version=" + url.QueryEscape(defaultCodexModelsClientVer), true
+	}
+
+	// API key / OpenAI-compatible base.
+	if useAPIKey || strings.Contains(lower, "api.openai.com") {
+		if strings.HasSuffix(lower, "/v1") {
+			return normalized + "/models", false
+		}
+		if strings.HasSuffix(lower, "/v1/models") {
+			return normalized, false
+		}
+		return normalized + "/v1/models", false
+	}
+
+	// Generic: treat as Codex-style base ending with /models.
+	return normalized + "/models", strings.Contains(lower, "codex")
+}
+
+func parseCodexModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var decoded codexModelsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		var arrayResponse []codexModelPayload
+		if arrayErr := json.Unmarshal(body, &arrayResponse); arrayErr != nil {
+			// Last resort: walk arbitrary JSON for objects with id/slug fields.
+			return parseCodexModelsLoose(body, now)
+		}
+		decoded.Data = arrayResponse
+	}
+
+	entries := decoded.Data
+	if len(entries) == 0 {
+		entries = decoded.Models
+	}
+	if len(entries) == 0 {
+		entries = decoded.Items
+	}
+	if len(entries) == 0 {
+		return parseCodexModelsLoose(body, now)
+	}
+
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, item := range entries {
+		modelID := firstNonEmptyString(item.ID, item.Slug, item.Name)
+		if modelID == "" {
+			continue
+		}
+		key := strings.ToLower(modelID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		displayName := firstNonEmptyString(item.DisplayName, item.Title, item.Name, modelID)
+		object := strings.TrimSpace(item.Object)
+		if object == "" {
+			object = "model"
+		}
+		ownedBy := strings.TrimSpace(item.OwnedBy)
+		if ownedBy == "" {
+			ownedBy = "openai"
+		}
+		created := item.Created
+		if created == 0 {
+			created = now
+		}
+		model := &sdkmodelcatalog.ModelInfo{
+			ID:          modelID,
+			Object:      object,
+			Created:     created,
+			OwnedBy:     ownedBy,
+			Type:        "codex",
+			DisplayName: displayName,
+			Name:        modelID,
+			Version:     modelID,
+		}
+		if static := sdkmodelcatalog.LookupStaticModelInfo(modelID); static != nil {
+			if strings.TrimSpace(static.Description) != "" {
+				model.Description = static.Description
+			}
+			if strings.TrimSpace(static.DisplayName) != "" {
+				model.DisplayName = static.DisplayName
+			}
+			if static.Thinking != nil {
+				thinkingClone := *static.Thinking
+				if len(static.Thinking.Levels) > 0 {
+					thinkingClone.Levels = append([]string(nil), static.Thinking.Levels...)
+				}
+				model.Thinking = &thinkingClone
+			}
+		}
+		out = append(out, model)
+	}
+	return out, len(out) > 0
+}
+
+// parseCodexModelsLoose walks nested JSON maps/arrays looking for model-like objects.
+// Codex manifests sometimes wrap the list under evolving keys.
+func parseCodexModelsLoose(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var root any
+	if err := json.Unmarshal(body, &root); err != nil {
+		return nil, false
+	}
+	seen := make(map[string]struct{})
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, 16)
+	var walk func(v any)
+	walk = func(v any) {
+		switch typed := v.(type) {
+		case map[string]any:
+			id := firstNonEmptyString(
+				stringFromAny(typed["id"]),
+				stringFromAny(typed["slug"]),
+				stringFromAny(typed["model"]),
+				stringFromAny(typed["name"]),
+			)
+			// Heuristic: model-like object when id looks like a model slug and not a nested container-only map.
+			if id != "" && (strings.Contains(id, "-") || strings.HasPrefix(strings.ToLower(id), "gpt") || strings.HasPrefix(strings.ToLower(id), "o")) {
+				key := strings.ToLower(id)
+				if _, exists := seen[key]; !exists {
+					// Skip obvious non-model containers.
+					if _, hasModels := typed["models"]; !hasModels {
+						if _, hasData := typed["data"]; !hasData {
+							seen[key] = struct{}{}
+							display := firstNonEmptyString(
+								stringFromAny(typed["display_name"]),
+								stringFromAny(typed["title"]),
+								stringFromAny(typed["name"]),
+								id,
+							)
+							ownedBy := firstNonEmptyString(stringFromAny(typed["owned_by"]), "openai")
+							out = append(out, &sdkmodelcatalog.ModelInfo{
+								ID:          id,
+								Object:      "model",
+								Created:     now,
+								OwnedBy:     ownedBy,
+								Type:        "codex",
+								DisplayName: display,
+								Name:        id,
+								Version:     id,
+							})
+						}
+					}
+				}
+			}
+			for _, child := range typed {
+				walk(child)
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(root)
+	return out, len(out) > 0
+}
+
+func stringFromAny(v any) string {
+	switch typed := v.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return ""
+	}
+}

--- a/internal/runtime/executor/codex_models_test.go
+++ b/internal/runtime/executor/codex_models_test.go
@@ -1,0 +1,131 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+func resetCodexModelsCacheForTest() {
+	codexModelsCache.mu.Lock()
+	codexModelsCache.models = nil
+	codexModelsCache.mu.Unlock()
+}
+
+func TestParseCodexModelsFromDataAndSlug(t *testing.T) {
+	body := []byte(`{
+		"data": [
+			{"id": "gpt-5.1-codex", "display_name": "GPT-5.1 Codex"},
+			{"slug": "o3-pro", "title": "o3 Pro"},
+			{"id": "gpt-5.1-codex"}
+		]
+	}`)
+	models, ok := parseCodexModels(body, 1700000000)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models)=%d, want 2", len(models))
+	}
+	if models[0].ID != "gpt-5.1-codex" || models[0].Type != "codex" {
+		t.Fatalf("models[0]=%+v", models[0])
+	}
+	if models[1].ID != "o3-pro" {
+		t.Fatalf("models[1].ID=%q", models[1].ID)
+	}
+}
+
+func TestParseCodexModelsLooseNested(t *testing.T) {
+	body := []byte(`{
+		"payload": {
+			"models": [
+				{"slug": "gpt-nested-1", "display_name": "Nested"},
+				{"id": "not-a-model", "models": []}
+			]
+		}
+	}`)
+	models, ok := parseCodexModels(body, 1700000000)
+	if !ok {
+		t.Fatal("expected loose parse success")
+	}
+	found := false
+	for _, m := range models {
+		if m != nil && m.ID == "gpt-nested-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing nested model, got %v", models)
+	}
+}
+
+func TestBuildCodexModelsURL(t *testing.T) {
+	url, isManifest := buildCodexModelsURL("", false)
+	if !isManifest || !strings.Contains(url, "chatgpt.com/backend-api/codex/models") {
+		t.Fatalf("default oauth url=%q isManifest=%v", url, isManifest)
+	}
+	if !strings.Contains(url, "client_version=") {
+		t.Fatalf("missing client_version in %q", url)
+	}
+
+	url, isManifest = buildCodexModelsURL("https://api.openai.com", true)
+	if isManifest || url != "https://api.openai.com/v1/models" {
+		t.Fatalf("api key openai url=%q isManifest=%v", url, isManifest)
+	}
+
+	url, isManifest = buildCodexModelsURL("https://gateway.example/v1", true)
+	if isManifest || url != "https://gateway.example/v1/models" {
+		t.Fatalf("compat url=%q isManifest=%v", url, isManifest)
+	}
+
+	url, isManifest = buildCodexModelsURL("https://chatgpt.com/backend-api", false)
+	if !isManifest || !strings.Contains(url, "/codex/models") {
+		t.Fatalf("chatgpt backend url=%q isManifest=%v", url, isManifest)
+	}
+}
+
+func TestFetchCodexModelsAPIKeyCatalog(t *testing.T) {
+	resetCodexModelsCacheForTest()
+	t.Cleanup(resetCodexModelsCacheForTest)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path=%q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-test" {
+			t.Fatalf("Authorization=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"codex-live-1","owned_by":"openai"}]}`))
+	}))
+	defer srv.Close()
+
+	models := FetchCodexModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":  "sk-test",
+			"base_url": srv.URL,
+		},
+	}, nil)
+	if len(models) != 1 || models[0].ID != "codex-live-1" {
+		t.Fatalf("models=%v", models)
+	}
+}
+
+func TestFetchCodexModelsFallsBackToCache(t *testing.T) {
+	resetCodexModelsCacheForTest()
+	t.Cleanup(resetCodexModelsCacheForTest)
+
+	if ok := storeCodexModels([]*sdkmodelcatalog.ModelInfo{{ID: "cached-codex", OwnedBy: "openai", Type: "codex"}}); !ok {
+		t.Fatal("cache seed failed")
+	}
+	models := FetchCodexModels(context.Background(), &cliproxyauth.Auth{Provider: "codex"}, nil)
+	if len(models) != 1 || models[0].ID != "cached-codex" {
+		t.Fatalf("fallback models=%v", models)
+	}
+}

--- a/sdk/cliproxy/service_model_claude.go
+++ b/sdk/cliproxy/service_model_claude.go
@@ -1,0 +1,22 @@
+package cliproxy
+
+import (
+	"context"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
+)
+
+func (s *Service) fetchClaudeRegistryModels(ctx context.Context, auth *coreauth.Auth, excluded []string) []*ModelInfo {
+	fetchCtx := ctx
+	if fetchCtx == nil {
+		fetchCtx = context.Background()
+	}
+	// Model registration should not be aborted by unrelated caller cancellation
+	// once the service has committed to refreshing the registry.
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(fetchCtx), 15*time.Second)
+	defer cancel()
+	models := serviceapp.FetchClaudeModels(fetchCtx, auth, s.cfg)
+	return applyExcludedModels(models, excluded)
+}

--- a/sdk/cliproxy/service_model_codex.go
+++ b/sdk/cliproxy/service_model_codex.go
@@ -1,0 +1,20 @@
+package cliproxy
+
+import (
+	"context"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
+)
+
+func (s *Service) fetchCodexRegistryModels(ctx context.Context, auth *coreauth.Auth, excluded []string) []*ModelInfo {
+	fetchCtx := ctx
+	if fetchCtx == nil {
+		fetchCtx = context.Background()
+	}
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(fetchCtx), 15*time.Second)
+	defer cancel()
+	models := serviceapp.FetchCodexModels(fetchCtx, auth, s.cfg)
+	return applyExcludedModels(models, excluded)
+}

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -128,9 +128,16 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	case "antigravity":
 		models = s.fetchAntigravityRegistryModels(ctx, a, excluded)
 	case "claude":
-		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("claude")
+		// Prefer live Anthropic /v1/models (OAuth or API key) when credentials work;
+		// fall back to static catalog + optional config models, matching xAI/antigravity.
+		if live := s.fetchClaudeRegistryModels(ctx, a, nil); len(live) > 0 {
+			models = live
+		} else {
+			models = sdkmodelcatalog.StaticModelDefinitionsByChannel("claude")
+		}
 		if entry := s.resolveConfigClaudeKey(a); entry != nil {
 			if len(entry.Models) > 0 {
+				// Explicit config models still win for API-key channels that pin a list.
 				models = buildClaudeConfigModels(entry, lookupStaticModelThinking)
 			}
 			if authKind == "apikey" {
@@ -178,7 +185,12 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		}
 		models = applyExcludedModels(models, excluded)
 	case "codex":
-		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("codex")
+		// Prefer live Codex models manifest / OpenAI-compatible /models when credentials work.
+		if live := s.fetchCodexRegistryModels(ctx, a, nil); len(live) > 0 {
+			models = live
+		} else {
+			models = sdkmodelcatalog.StaticModelDefinitionsByChannel("codex")
+		}
 		if entry := s.resolveConfigCodexKey(a); entry != nil {
 			if len(entry.Models) > 0 {
 				models = buildCodexConfigModels(entry, lookupStaticModelThinking)

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -103,6 +103,14 @@ func FetchXAIModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config
 	return internalserviceapp.FetchXAIModels(ctx, auth, cfg)
 }
 
+func FetchClaudeModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.FetchClaudeModels(ctx, auth, cfg)
+}
+
+func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.FetchCodexModels(ctx, auth, cfg)
+}
+
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	internalserviceapp.RegisterExecutorForAuth(coreManager, cfg, auth, forceReplace, gateway)
 }


### PR DESCRIPTION
## Summary

- Align Claude/Codex model registration with sub2api-style **live upstream** discovery:
  - Claude: `GET {base}/v1/models` (OAuth Bearer + `anthropic-beta`, or API key `x-api-key`)
  - Codex: ChatGPT OAuth manifest `GET chatgpt.com/backend-api/codex/models?client_version=...`, or OpenAI-compatible `GET {base}/v1/models` for API keys
- Prefer live results at auth registration; fall back to static catalog / config models when live fetch fails
- Management `GET /v0/management/auth-files/models?name=...&refresh=1` re-fetches live models, updates the runtime registry, and returns `{ models, source }` (`upstream` | `registry`)

Fixes provider half of #492 (backend). Panel UI is in codeProxy PR.

## Test plan

- [x] `./scripts/ci-pr.sh` (gofmt, structure check, `go vet`, `go test ./...`, golangci-lint, build)
- [x] Unit tests: `claude_models_test.go`, `codex_models_test.go` (parse, URL build, live fetch mock, cache fallback, OAuth headers)

## Related

- Issue: https://github.com/kittors/CliRelay/issues/492
- Frontend: codeProxy `feat/live-upstream-models-claude-codex`