### PR TITLE
feat(models): safe Claude/Codex live discovery without registry wipe

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -41,9 +41,11 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 //
 // Query params:
 //   - name (required): auth file name or auth ID
-//   - refresh=1|true: re-fetch live models from upstream (xai/antigravity)
-//     and update the runtime registry when successful; falls back to registry on failure.
-//     Claude and Codex are intentionally not live-refreshed (static catalog only).
+//   - refresh=1|true: re-fetch live models from upstream for discovery.
+//     xai/antigravity: updates runtime registry when successful.
+//     claude/codex: returns upstream list with source=upstream but does NOT
+//     replace the static registry catalog (avoids incomplete-manifest wipe).
+//     Falls back to registry on failure.
 func (h *Handler) GetAuthFileModels(c *gin.Context) {
 	name := c.Query("name")
 	if name == "" {

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -441,6 +441,14 @@ func FetchXAIModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config
 	return executor.FetchXAIModels(ctx, auth, cfg)
 }
 
+func FetchClaudeModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return executor.FetchClaudeModels(ctx, auth, cfg)
+}
+
+func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return executor.FetchCodexModels(ctx, auth, cfg)
+}
+
 func RebindTenantExecutors(base *config.Config, coreManager *coreauth.Manager, tenantID string, gateway WebsocketGateway) {
 	if base == nil || coreManager == nil {
 		return

--- a/internal/management/authfiles/models.go
+++ b/internal/management/authfiles/models.go
@@ -73,10 +73,13 @@ func ListModelEntriesForTenant(manager *coreauth.Manager, source ModelSource, te
 }
 
 // ListModelEntriesLiveForTenant optionally re-fetches models from the upstream
-// provider for xai/antigravity (live-capable providers), updates the
-// registry when successful, then returns the public model payload.
-// Claude and Codex are never live-refreshed: incomplete upstream catalogs must
-// not replace the static channel definitions.
+// provider for discovery (refresh=1).
+//
+// Registry update policy:
+//   - xai / antigravity: live catalog is account-complete → update runtime registry
+//   - claude / codex: live is discovery-only (ChatGPT manifest / Anthropic /models
+//     can be a subset). Return upstream list with source=upstream but NEVER
+//     RegisterClient-replace the static channel catalog (regression #673/#674).
 //
 // When live fetch fails, falls back to the existing registry list so the UI
 // still shows known models.
@@ -99,13 +102,13 @@ func ListModelEntriesLiveForTenant(
 		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
 	}
 
-	live, provider := fetchLiveModelsForAuth(ctx, auth, cfg)
+	live, provider, updateRegistry := fetchLiveModelsForAuth(ctx, auth, cfg)
 	if len(live) == 0 {
 		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
 	}
 
 	sourceLabel = "upstream"
-	if registrar != nil {
+	if updateRegistry && registrar != nil {
 		providerKey := provider
 		if providerKey == "" {
 			providerKey = strings.ToLower(strings.TrimSpace(auth.Provider))
@@ -115,9 +118,9 @@ func ListModelEntriesLiveForTenant(
 	return modelEntriesFromRegistry(live), sourceLabel
 }
 
-func fetchLiveModelsForAuth(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) ([]*registry.ModelInfo, string) {
+func fetchLiveModelsForAuth(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) ([]*registry.ModelInfo, string, bool) {
 	if auth == nil {
-		return nil, ""
+		return nil, "", false
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -127,17 +130,24 @@ func fetchLiveModelsForAuth(ctx context.Context, auth *coreauth.Auth, cfg *confi
 
 	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 	var sdkModels []*sdkmodelcatalog.ModelInfo
+	updateRegistry := false
 	switch provider {
-	// claude/codex deliberately omitted: live upstream catalogs can be incomplete
-	// and overwrite the static registry (codex regression #674). Keep static.
+	case "claude":
+		// Discovery only — do not replace static registry.
+		sdkModels = executor.FetchClaudeModels(fetchCtx, auth, cfg)
+	case "codex":
+		// Discovery only — ChatGPT manifest is gated by client_version and is not a full catalog.
+		sdkModels = executor.FetchCodexModels(fetchCtx, auth, cfg)
 	case "xai":
 		sdkModels = executor.FetchXAIModels(fetchCtx, auth, cfg)
+		updateRegistry = true
 	case "antigravity":
 		sdkModels = executor.FetchAntigravityModels(fetchCtx, auth, cfg)
+		updateRegistry = true
 	default:
-		return nil, provider
+		return nil, provider, false
 	}
-	return cloneSDKModelsToRegistry(sdkModels), provider
+	return cloneSDKModelsToRegistry(sdkModels), provider, updateRegistry
 }
 
 func cloneSDKModelsToRegistry(models []*sdkmodelcatalog.ModelInfo) []*registry.ModelInfo {

--- a/internal/management/authfiles/models_test.go
+++ b/internal/management/authfiles/models_test.go
@@ -75,3 +75,77 @@ func TestListModelEntriesBuildsPublicPayload(t *testing.T) {
 		t.Fatalf("minimal id = %#v, want minimal", got[1]["id"])
 	}
 }
+
+type modelRegistrarStub struct {
+	calls int
+	last  struct {
+		clientID string
+		provider string
+		models   []*registry.ModelInfo
+	}
+}
+
+func (s *modelRegistrarStub) RegisterClient(clientID, clientProvider string, models []*registry.ModelInfo) {
+	s.calls++
+	s.last.clientID = clientID
+	s.last.provider = clientProvider
+	s.last.models = models
+}
+
+func TestListModelEntriesLiveForTenantCodexDoesNotReplaceRegistry(t *testing.T) {
+	// Without a real upstream, refresh falls back to registry; registrar must not be called
+	// when live is empty. When we inject via a custom path, codex updateRegistry is false.
+	// Here we only assert the empty-live path never registers.
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex-auth",
+		FileName: "codex.json",
+		Provider: "codex",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	source := &modelSourceStub{
+		models: []*registry.ModelInfo{{ID: "gpt-5.5", DisplayName: "GPT-5.5", Type: "codex"}},
+	}
+	reg := &modelRegistrarStub{}
+	models, label := ListModelEntriesLiveForTenant(
+		context.Background(),
+		manager,
+		source,
+		reg,
+		nil,
+		"",
+		"codex.json",
+		true,
+	)
+	if label != "registry" {
+		t.Fatalf("source label = %q, want registry (no live without credentials)", label)
+	}
+	if reg.calls != 0 {
+		t.Fatalf("RegisterClient calls = %d, want 0 for failed/empty codex live", reg.calls)
+	}
+	if len(models) != 1 || models[0]["id"] != "gpt-5.5" {
+		t.Fatalf("fallback models = %#v", models)
+	}
+}
+
+func TestListModelEntriesLiveWithoutRefreshUsesRegistry(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex-auth",
+		FileName: "codex.json",
+		Provider: "codex",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	source := &modelSourceStub{
+		models: []*registry.ModelInfo{{ID: "gpt-5.5"}},
+	}
+	reg := &modelRegistrarStub{}
+	models, label := ListModelEntriesLiveForTenant(
+		context.Background(), manager, source, reg, nil, "", "codex.json", false,
+	)
+	if label != "registry" || reg.calls != 0 || len(models) != 1 {
+		t.Fatalf("label=%q calls=%d models=%#v", label, reg.calls, models)
+	}
+}

--- a/internal/runtime/executor/claude_models.go
+++ b/internal/runtime/executor/claude_models.go
@@ -1,0 +1,255 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	claudeModelsPath          = "/v1/models"
+	defaultClaudeModelsBase   = "https://api.anthropic.com"
+	defaultClaudeAnthropicVer = "2023-06-01"
+)
+
+var claudeModelsCache struct {
+	mu     sync.RWMutex
+	models []*sdkmodelcatalog.ModelInfo
+}
+
+type claudeModelsResponse struct {
+	Data   []claudeModelPayload `json:"data"`
+	Models []claudeModelPayload `json:"models"`
+}
+
+type claudeModelPayload struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	DisplayName string `json:"display_name"`
+	CreatedAt   string `json:"created_at"`
+}
+
+func cloneClaudeModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		if len(model.SupportedGenerationMethods) > 0 {
+			clone.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedParameters) > 0 {
+			clone.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+		}
+		if model.Thinking != nil {
+			thinkingClone := *model.Thinking
+			if len(model.Thinking.Levels) > 0 {
+				thinkingClone.Levels = append([]string(nil), model.Thinking.Levels...)
+			}
+			clone.Thinking = &thinkingClone
+		}
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func storeClaudeModels(models []*sdkmodelcatalog.ModelInfo) bool {
+	cloned := cloneClaudeModels(models)
+	if len(cloned) == 0 {
+		return false
+	}
+	claudeModelsCache.mu.Lock()
+	claudeModelsCache.models = cloned
+	claudeModelsCache.mu.Unlock()
+	return true
+}
+
+func loadClaudeModels() []*sdkmodelcatalog.ModelInfo {
+	claudeModelsCache.mu.RLock()
+	cloned := cloneClaudeModels(claudeModelsCache.models)
+	claudeModelsCache.mu.RUnlock()
+	return cloned
+}
+
+func fallbackClaudeModels() []*sdkmodelcatalog.ModelInfo {
+	if models := loadClaudeModels(); len(models) > 0 {
+		log.Debugf("claude executor: using cached model list (%d models)", len(models))
+		return models
+	}
+	return nil
+}
+
+// FetchClaudeModels retrieves the live model list from Anthropic-compatible /v1/models.
+// Supports OAuth (Bearer access_token) and API key (x-api-key) auth, matching request
+// credential resolution used by Claude message forwarding.
+func FetchClaudeModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token, baseURL := claudeCreds(auth)
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fallbackClaudeModels()
+	}
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = defaultClaudeModelsBase
+	}
+	modelsURL := buildClaudeModelsURL(baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return fallbackClaudeModels()
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("anthropic-version", defaultClaudeAnthropicVer)
+
+	useAPIKey := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	isAnthropicBase := strings.Contains(strings.ToLower(baseURL), "api.anthropic.com")
+	if isAnthropicBase && useAPIKey {
+		req.Header.Set("x-api-key", token)
+	} else if useAPIKey {
+		// Custom Anthropic-compatible gateways usually accept x-api-key for API keys.
+		req.Header.Set("x-api-key", token)
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		// OAuth / setup-token style: Bearer access_token + oauth beta, aligned with sub2api.
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	}
+	if auth != nil {
+		util.ApplyCustomHeadersFromAttrs(req, auth.Attributes)
+	}
+
+	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Debugf("claude executor: models request failed: %v", err)
+		}
+		return fallbackClaudeModels()
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("claude executor: close models response body error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		log.Debugf("claude executor: models request failed with status %d", resp.StatusCode)
+		return fallbackClaudeModels()
+	}
+
+	body, err := readUpstreamResponseBody("claude", resp.Body)
+	if err != nil {
+		log.Debugf("claude executor: models response read failed: %v", err)
+		return fallbackClaudeModels()
+	}
+
+	models, ok := parseClaudeModels(body, time.Now().Unix())
+	if !ok {
+		log.Debug("claude executor: fetched empty or invalid model list; retaining cached model list")
+		return fallbackClaudeModels()
+	}
+	storeClaudeModels(models)
+	return models
+}
+
+func buildClaudeModelsURL(base string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(base), "/")
+	if strings.HasSuffix(strings.ToLower(normalized), "/v1/models") {
+		return normalized
+	}
+	if strings.HasSuffix(strings.ToLower(normalized), "/v1") {
+		return normalized + "/models"
+	}
+	return normalized + claudeModelsPath
+}
+
+func parseClaudeModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var decoded claudeModelsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		var arrayResponse []claudeModelPayload
+		if arrayErr := json.Unmarshal(body, &arrayResponse); arrayErr != nil {
+			return nil, false
+		}
+		decoded.Data = arrayResponse
+	}
+
+	entries := decoded.Data
+	if len(entries) == 0 {
+		entries = decoded.Models
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, item := range entries {
+		modelID := strings.TrimSpace(item.ID)
+		if modelID == "" {
+			continue
+		}
+		key := strings.ToLower(modelID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		displayName := strings.TrimSpace(item.DisplayName)
+		if displayName == "" {
+			displayName = modelID
+		}
+		object := strings.TrimSpace(item.Type)
+		if object == "" {
+			object = "model"
+		}
+		model := &sdkmodelcatalog.ModelInfo{
+			ID:          modelID,
+			Object:      object,
+			Created:     now,
+			OwnedBy:     "claude",
+			Type:        "claude",
+			DisplayName: displayName,
+			Name:        modelID,
+			Version:     modelID,
+		}
+		if static := sdkmodelcatalog.LookupStaticModelInfo(modelID); static != nil {
+			if strings.TrimSpace(static.Description) != "" {
+				model.Description = static.Description
+			}
+			if strings.TrimSpace(static.DisplayName) != "" {
+				model.DisplayName = static.DisplayName
+			}
+			if static.Thinking != nil {
+				thinkingClone := *static.Thinking
+				if len(static.Thinking.Levels) > 0 {
+					thinkingClone.Levels = append([]string(nil), static.Thinking.Levels...)
+				}
+				model.Thinking = &thinkingClone
+			}
+			if static.ContextLength > 0 {
+				model.ContextLength = static.ContextLength
+				model.InputTokenLimit = static.ContextLength
+			}
+			if static.MaxCompletionTokens > 0 {
+				model.MaxCompletionTokens = static.MaxCompletionTokens
+				model.OutputTokenLimit = static.MaxCompletionTokens
+			}
+		}
+		out = append(out, model)
+	}
+	return out, len(out) > 0
+}

--- a/internal/runtime/executor/claude_models_test.go
+++ b/internal/runtime/executor/claude_models_test.go
@@ -1,0 +1,138 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+func resetClaudeModelsCacheForTest() {
+	claudeModelsCache.mu.Lock()
+	claudeModelsCache.models = nil
+	claudeModelsCache.mu.Unlock()
+}
+
+func TestParseClaudeModelsFromDataArray(t *testing.T) {
+	body := []byte(`{
+		"data": [
+			{"id": "claude-sonnet-4-5", "type": "model", "display_name": "Claude Sonnet 4.5"},
+			{"id": "claude-opus-4", "display_name": "Claude Opus 4"},
+			{"id": "claude-sonnet-4-5"}
+		]
+	}`)
+	models, ok := parseClaudeModels(body, 1700000000)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models)=%d, want 2 (deduped)", len(models))
+	}
+	if models[0].ID != "claude-sonnet-4-5" {
+		t.Fatalf("models[0].ID=%q", models[0].ID)
+	}
+	if models[0].DisplayName != "Claude Sonnet 4.5" {
+		t.Fatalf("display name = %q", models[0].DisplayName)
+	}
+	if models[0].OwnedBy != "claude" || models[0].Type != "claude" {
+		t.Fatalf("owned/type = %q/%q", models[0].OwnedBy, models[0].Type)
+	}
+}
+
+func TestBuildClaudeModelsURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://api.anthropic.com", "https://api.anthropic.com/v1/models"},
+		{"https://api.anthropic.com/", "https://api.anthropic.com/v1/models"},
+		{"https://api.anthropic.com/v1", "https://api.anthropic.com/v1/models"},
+		{"https://gateway.example/v1/models", "https://gateway.example/v1/models"},
+		{"https://gateway.example/proxy", "https://gateway.example/proxy/v1/models"},
+	}
+	for _, tc := range cases {
+		if got := buildClaudeModelsURL(tc.in); got != tc.want {
+			t.Fatalf("buildClaudeModelsURL(%q)=%q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFetchClaudeModelsParsesLiveCatalog(t *testing.T) {
+	resetClaudeModelsCacheForTest()
+	t.Cleanup(resetClaudeModelsCacheForTest)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path=%q", r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "sk-ant-test" {
+			t.Fatalf("x-api-key=%q", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got == "" {
+			t.Fatal("missing anthropic-version")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"claude-live-1","display_name":"Live One"}]}`))
+	}))
+	defer srv.Close()
+
+	models := FetchClaudeModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "claude",
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-test",
+			"base_url": srv.URL,
+		},
+	}, nil)
+	if len(models) != 1 || models[0].ID != "claude-live-1" {
+		t.Fatalf("models=%v", models)
+	}
+}
+
+func TestFetchClaudeModelsFallsBackToCache(t *testing.T) {
+	resetClaudeModelsCacheForTest()
+	t.Cleanup(resetClaudeModelsCacheForTest)
+
+	if ok := storeClaudeModels([]*sdkmodelcatalog.ModelInfo{{ID: "cached-claude", OwnedBy: "claude", Type: "claude"}}); !ok {
+		t.Fatal("cache seed failed")
+	}
+	models := FetchClaudeModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "claude",
+		// no credentials → fallback
+	}, nil)
+	if len(models) != 1 || models[0].ID != "cached-claude" {
+		t.Fatalf("fallback models=%v", models)
+	}
+}
+
+func TestFetchClaudeModelsOAuthBearer(t *testing.T) {
+	resetClaudeModelsCacheForTest()
+	t.Cleanup(resetClaudeModelsCacheForTest)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Fatalf("Authorization=%q", got)
+		}
+		if got := r.Header.Get("anthropic-beta"); got == "" {
+			t.Fatal("expected oauth anthropic-beta")
+		}
+		if got := r.Header.Get("x-api-key"); got != "" {
+			t.Fatalf("unexpected x-api-key=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"claude-oauth-1"}]}`))
+	}))
+	defer srv.Close()
+
+	models := FetchClaudeModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "claude",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+		Attributes: map[string]string{
+			"base_url": srv.URL,
+		},
+	}, nil)
+	if len(models) != 1 || models[0].ID != "claude-oauth-1" {
+		t.Fatalf("models=%v", models)
+	}
+}

--- a/internal/runtime/executor/codex_models.go
+++ b/internal/runtime/executor/codex_models.go
@@ -1,0 +1,487 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// Official ChatGPT Codex models manifest (OAuth).
+	// https://chatgpt.com/backend-api/codex/models?client_version=...
+	// client_version gates which models ChatGPT returns (0.118 only had ~4 models;
+	// >=0.150 includes gpt-5.5 and gpt-5.6-*). Prefer fingerprint / config version when present.
+	defaultCodexModelsManifestBase = "https://chatgpt.com/backend-api/codex"
+	defaultCodexModelsClientVer    = "0.180.0"
+)
+
+var codexModelsCache struct {
+	mu     sync.RWMutex
+	models []*sdkmodelcatalog.ModelInfo
+}
+
+type codexModelsResponse struct {
+	Data   []codexModelPayload `json:"data"`
+	Models []codexModelPayload `json:"models"`
+	// Some Codex manifest revisions nest models under items/list.
+	Items []codexModelPayload `json:"items"`
+}
+
+type codexModelPayload struct {
+	ID          string `json:"id"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Title       string `json:"title"`
+	Object      string `json:"object"`
+	OwnedBy     string `json:"owned_by"`
+	Created     int64  `json:"created"`
+}
+
+func cloneCodexModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		if len(model.SupportedGenerationMethods) > 0 {
+			clone.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedParameters) > 0 {
+			clone.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+		}
+		if model.Thinking != nil {
+			thinkingClone := *model.Thinking
+			if len(model.Thinking.Levels) > 0 {
+				thinkingClone.Levels = append([]string(nil), model.Thinking.Levels...)
+			}
+			clone.Thinking = &thinkingClone
+		}
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func storeCodexModels(models []*sdkmodelcatalog.ModelInfo) bool {
+	cloned := cloneCodexModels(models)
+	if len(cloned) == 0 {
+		return false
+	}
+	codexModelsCache.mu.Lock()
+	codexModelsCache.models = cloned
+	codexModelsCache.mu.Unlock()
+	return true
+}
+
+func loadCodexModels() []*sdkmodelcatalog.ModelInfo {
+	codexModelsCache.mu.RLock()
+	cloned := cloneCodexModels(codexModelsCache.models)
+	codexModelsCache.mu.RUnlock()
+	return cloned
+}
+
+func fallbackCodexModels() []*sdkmodelcatalog.ModelInfo {
+	if models := loadCodexModels(); len(models) > 0 {
+		log.Debugf("codex executor: using cached model list (%d models)", len(models))
+		return models
+	}
+	return nil
+}
+
+// resolveCodexModelsClientVersion picks the client_version for the Codex models manifest.
+// Priority: cfg identity fingerprint Version / UA embedded version, then a modern fallback.
+// A stale fallback (e.g. 0.118) truncates the upstream list and must not be used.
+func resolveCodexModelsClientVersion(cfg *config.Config, auth *cliproxyauth.Auth) string {
+	candidate := ""
+	if cfg != nil {
+		fp := cfg.IdentityFingerprint.Codex
+		if v := strings.TrimSpace(fp.Version); v != "" {
+			candidate = v
+		} else if v := codexVersionFromUserAgent(fp.UserAgent); v != "" {
+			// Ignore the historical default UA (0.118) which truncates the manifest.
+			if !strings.HasPrefix(v, "0.118") {
+				candidate = v
+			}
+		}
+	}
+	_ = auth
+	if candidate == "" {
+		return defaultCodexModelsClientVer
+	}
+	// Prefer the newer of candidate vs modern floor so discovery never regresses
+	// to a pre-5.5/5.6 client_version gate.
+	if compareCodexClientVersion(candidate, defaultCodexModelsClientVer) < 0 {
+		return defaultCodexModelsClientVer
+	}
+	return candidate
+}
+
+// compareCodexClientVersion returns -1 if a<b, 0 if equal, 1 if a>b (numeric dotted).
+func compareCodexClientVersion(a, b string) int {
+	ap := strings.Split(strings.TrimSpace(a), ".")
+	bp := strings.Split(strings.TrimSpace(b), ".")
+	n := len(ap)
+	if len(bp) > n {
+		n = len(bp)
+	}
+	for i := 0; i < n; i++ {
+		ai := parseCodexVersionPart(ap, i)
+		bi := parseCodexVersionPart(bp, i)
+		if ai < bi {
+			return -1
+		}
+		if ai > bi {
+			return 1
+		}
+	}
+	return 0
+}
+
+func parseCodexVersionPart(parts []string, i int) int {
+	if i >= len(parts) {
+		return 0
+	}
+	// Take leading digits only (e.g. "180" from "180", ignore "0rc1" suffix as 0).
+	s := strings.TrimSpace(parts[i])
+	end := 0
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(s[:end])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func codexVersionFromUserAgent(ua string) string {
+	ua = strings.TrimSpace(ua)
+	if ua == "" {
+		return ""
+	}
+	// codex_cli_rs/0.150.0 ... or codex-tui/0.118.0 ...
+	for _, prefix := range []string{"codex_cli_rs/", "codex-tui/", "codex-cli/", "Codex Desktop/"} {
+		idx := strings.Index(strings.ToLower(ua), strings.ToLower(prefix))
+		if idx < 0 {
+			continue
+		}
+		rest := ua[idx+len(prefix):]
+		end := 0
+		for end < len(rest) {
+			c := rest[end]
+			if (c >= '0' && c <= '9') || c == '.' {
+				end++
+				continue
+			}
+			break
+		}
+		if end > 0 {
+			return rest[:end]
+		}
+	}
+	return ""
+}
+
+// FetchCodexModels retrieves the live model list for a Codex auth.
+//
+// - OAuth / ChatGPT backend base: GET {base}/models?client_version=... (manifest)
+// - API key with OpenAI-compatible base: GET {base}/v1/models or {base}/models
+//
+// Response body schema evolves with Codex client releases; parsing is intentionally
+// tolerant (id/slug/name fields, data/models/items arrays).
+func FetchCodexModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token, baseURL := codexCreds(auth)
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fallbackCodexModels()
+	}
+
+	useAPIKey := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	clientVer := resolveCodexModelsClientVersion(cfg, auth)
+	modelsURL, isManifest := buildCodexModelsURL(baseURL, useAPIKey, clientVer)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return fallbackCodexModels()
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	if isManifest {
+		// Align with Codex CLI manifest probe headers. Version gates the model list.
+		req.Header.Set("Originator", codexOriginator)
+		req.Header.Set("Version", clientVer)
+		req.Header.Set("User-Agent", "codex_cli_rs/"+clientVer)
+		if accountID := codexAccountID(auth); accountID != "" {
+			req.Header.Set("Chatgpt-Account-Id", accountID)
+		}
+	}
+
+	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Debugf("codex executor: models request failed: %v", err)
+		}
+		return fallbackCodexModels()
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codex executor: close models response body error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		log.Debugf("codex executor: models request failed with status %d", resp.StatusCode)
+		return fallbackCodexModels()
+	}
+
+	body, err := readUpstreamResponseBody("codex", resp.Body)
+	if err != nil {
+		log.Debugf("codex executor: models response read failed: %v", err)
+		return fallbackCodexModels()
+	}
+
+	models, ok := parseCodexModels(body, time.Now().Unix())
+	if !ok {
+		log.Debug("codex executor: fetched empty or invalid model list; retaining cached model list")
+		return fallbackCodexModels()
+	}
+	storeCodexModels(models)
+	return models
+}
+
+func codexAccountID(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if auth.Metadata != nil {
+		if accountID, ok := auth.Metadata["account_id"].(string); ok {
+			if v := strings.TrimSpace(accountID); v != "" {
+				return v
+			}
+		}
+	}
+	if auth.Attributes != nil {
+		if v := strings.TrimSpace(auth.Attributes["account_id"]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func buildCodexModelsURL(baseURL string, useAPIKey bool, clientVersion string) (string, bool) {
+	clientVersion = strings.TrimSpace(clientVersion)
+	if clientVersion == "" {
+		clientVersion = defaultCodexModelsClientVer
+	}
+	normalized := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if normalized == "" {
+		// OAuth default: ChatGPT Codex models manifest.
+		u := defaultCodexModelsManifestBase + "/models?client_version=" + url.QueryEscape(clientVersion)
+		return u, true
+	}
+
+	lower := strings.ToLower(normalized)
+	// Already a models endpoint.
+	if strings.HasSuffix(lower, "/models") || strings.Contains(lower, "/models?") {
+		return normalized, strings.Contains(lower, "backend-api/codex") || strings.Contains(lower, "chatgpt.com")
+	}
+
+	// ChatGPT / Codex backend style base.
+	if strings.Contains(lower, "backend-api/codex") || strings.Contains(lower, "chatgpt.com") {
+		if !strings.HasSuffix(lower, "/codex") && !strings.Contains(lower, "/codex/") {
+			// e.g. https://chatgpt.com/backend-api
+			if strings.HasSuffix(lower, "/backend-api") {
+				normalized = normalized + "/codex"
+			}
+		}
+		return normalized + "/models?client_version=" + url.QueryEscape(clientVersion), true
+	}
+
+	// API key / OpenAI-compatible base.
+	if useAPIKey || strings.Contains(lower, "api.openai.com") {
+		if strings.HasSuffix(lower, "/v1") {
+			return normalized + "/models", false
+		}
+		if strings.HasSuffix(lower, "/v1/models") {
+			return normalized, false
+		}
+		return normalized + "/v1/models", false
+	}
+
+	// Generic: treat as Codex-style base ending with /models.
+	return normalized + "/models", strings.Contains(lower, "codex")
+}
+
+func parseCodexModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var decoded codexModelsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		var arrayResponse []codexModelPayload
+		if arrayErr := json.Unmarshal(body, &arrayResponse); arrayErr != nil {
+			// Last resort: walk arbitrary JSON for objects with id/slug fields.
+			return parseCodexModelsLoose(body, now)
+		}
+		decoded.Data = arrayResponse
+	}
+
+	entries := decoded.Data
+	if len(entries) == 0 {
+		entries = decoded.Models
+	}
+	if len(entries) == 0 {
+		entries = decoded.Items
+	}
+	if len(entries) == 0 {
+		return parseCodexModelsLoose(body, now)
+	}
+
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, item := range entries {
+		// ChatGPT Codex manifest uses slug as the callable model id; prefer slug over opaque id.
+		modelID := firstNonEmptyString(item.Slug, item.ID, item.Name)
+		if modelID == "" {
+			continue
+		}
+		key := strings.ToLower(modelID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		displayName := firstNonEmptyString(item.DisplayName, item.Title, item.Name, modelID)
+		object := strings.TrimSpace(item.Object)
+		if object == "" {
+			object = "model"
+		}
+		ownedBy := strings.TrimSpace(item.OwnedBy)
+		if ownedBy == "" {
+			ownedBy = "openai"
+		}
+		created := item.Created
+		if created == 0 {
+			created = now
+		}
+		model := &sdkmodelcatalog.ModelInfo{
+			ID:          modelID,
+			Object:      object,
+			Created:     created,
+			OwnedBy:     ownedBy,
+			Type:        "codex",
+			DisplayName: displayName,
+			Name:        modelID,
+			Version:     modelID,
+		}
+		if static := sdkmodelcatalog.LookupStaticModelInfo(modelID); static != nil {
+			if strings.TrimSpace(static.Description) != "" {
+				model.Description = static.Description
+			}
+			if strings.TrimSpace(static.DisplayName) != "" {
+				model.DisplayName = static.DisplayName
+			}
+			if static.Thinking != nil {
+				thinkingClone := *static.Thinking
+				if len(static.Thinking.Levels) > 0 {
+					thinkingClone.Levels = append([]string(nil), static.Thinking.Levels...)
+				}
+				model.Thinking = &thinkingClone
+			}
+		}
+		out = append(out, model)
+	}
+	return out, len(out) > 0
+}
+
+// parseCodexModelsLoose walks nested JSON maps/arrays looking for model-like objects.
+// Codex manifests sometimes wrap the list under evolving keys.
+func parseCodexModelsLoose(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var root any
+	if err := json.Unmarshal(body, &root); err != nil {
+		return nil, false
+	}
+	seen := make(map[string]struct{})
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, 16)
+	var walk func(v any)
+	walk = func(v any) {
+		switch typed := v.(type) {
+		case map[string]any:
+			id := firstNonEmptyString(
+				stringFromAny(typed["slug"]),
+				stringFromAny(typed["id"]),
+				stringFromAny(typed["model"]),
+				stringFromAny(typed["name"]),
+			)
+			// Heuristic: model-like object when id looks like a model slug and not a nested container-only map.
+			if id != "" && (strings.Contains(id, "-") || strings.HasPrefix(strings.ToLower(id), "gpt") || strings.HasPrefix(strings.ToLower(id), "o")) {
+				key := strings.ToLower(id)
+				if _, exists := seen[key]; !exists {
+					// Skip obvious non-model containers.
+					if _, hasModels := typed["models"]; !hasModels {
+						if _, hasData := typed["data"]; !hasData {
+							seen[key] = struct{}{}
+							display := firstNonEmptyString(
+								stringFromAny(typed["display_name"]),
+								stringFromAny(typed["title"]),
+								stringFromAny(typed["name"]),
+								id,
+							)
+							ownedBy := firstNonEmptyString(stringFromAny(typed["owned_by"]), "openai")
+							out = append(out, &sdkmodelcatalog.ModelInfo{
+								ID:          id,
+								Object:      "model",
+								Created:     now,
+								OwnedBy:     ownedBy,
+								Type:        "codex",
+								DisplayName: display,
+								Name:        id,
+								Version:     id,
+							})
+						}
+					}
+				}
+			}
+			for _, child := range typed {
+				walk(child)
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(root)
+	return out, len(out) > 0
+}
+
+func stringFromAny(v any) string {
+	switch typed := v.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return ""
+	}
+}

--- a/internal/runtime/executor/codex_models_test.go
+++ b/internal/runtime/executor/codex_models_test.go
@@ -1,0 +1,179 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+func resetCodexModelsCacheForTest() {
+	codexModelsCache.mu.Lock()
+	codexModelsCache.models = nil
+	codexModelsCache.mu.Unlock()
+}
+
+func TestParseCodexModelsFromDataAndSlug(t *testing.T) {
+	body := []byte(`{
+		"data": [
+			{"id": "gpt-5.1-codex", "display_name": "GPT-5.1 Codex"},
+			{"slug": "o3-pro", "title": "o3 Pro"},
+			{"id": "gpt-5.1-codex"}
+		]
+	}`)
+	models, ok := parseCodexModels(body, 1700000000)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models)=%d, want 2", len(models))
+	}
+	if models[0].ID != "gpt-5.1-codex" || models[0].Type != "codex" {
+		t.Fatalf("models[0]=%+v", models[0])
+	}
+	if models[1].ID != "o3-pro" {
+		t.Fatalf("models[1].ID=%q", models[1].ID)
+	}
+}
+
+func TestParseCodexModelsLooseNested(t *testing.T) {
+	body := []byte(`{
+		"payload": {
+			"models": [
+				{"slug": "gpt-nested-1", "display_name": "Nested"},
+				{"id": "not-a-model", "models": []}
+			]
+		}
+	}`)
+	models, ok := parseCodexModels(body, 1700000000)
+	if !ok {
+		t.Fatal("expected loose parse success")
+	}
+	found := false
+	for _, m := range models {
+		if m != nil && m.ID == "gpt-nested-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing nested model, got %v", models)
+	}
+}
+
+func TestBuildCodexModelsURL(t *testing.T) {
+	url, isManifest := buildCodexModelsURL("", false, "")
+	if !isManifest || !strings.Contains(url, "chatgpt.com/backend-api/codex/models") {
+		t.Fatalf("default oauth url=%q isManifest=%v", url, isManifest)
+	}
+	if !strings.Contains(url, "client_version=") {
+		t.Fatalf("missing client_version in %q", url)
+	}
+
+	url, isManifest = buildCodexModelsURL("https://api.openai.com", true, "")
+	if isManifest || url != "https://api.openai.com/v1/models" {
+		t.Fatalf("api key openai url=%q isManifest=%v", url, isManifest)
+	}
+
+	url, isManifest = buildCodexModelsURL("https://gateway.example/v1", true, "")
+	if isManifest || url != "https://gateway.example/v1/models" {
+		t.Fatalf("compat url=%q isManifest=%v", url, isManifest)
+	}
+
+	url, isManifest = buildCodexModelsURL("https://chatgpt.com/backend-api", false, "0.180.0")
+	if !isManifest || !strings.Contains(url, "/codex/models") {
+		t.Fatalf("chatgpt backend url=%q isManifest=%v", url, isManifest)
+	}
+}
+
+func TestFetchCodexModelsAPIKeyCatalog(t *testing.T) {
+	resetCodexModelsCacheForTest()
+	t.Cleanup(resetCodexModelsCacheForTest)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path=%q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-test" {
+			t.Fatalf("Authorization=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"codex-live-1","owned_by":"openai"}]}`))
+	}))
+	defer srv.Close()
+
+	models := FetchCodexModels(context.Background(), &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":  "sk-test",
+			"base_url": srv.URL,
+		},
+	}, nil)
+	if len(models) != 1 || models[0].ID != "codex-live-1" {
+		t.Fatalf("models=%v", models)
+	}
+}
+
+func TestFetchCodexModelsFallsBackToCache(t *testing.T) {
+	resetCodexModelsCacheForTest()
+	t.Cleanup(resetCodexModelsCacheForTest)
+
+	if ok := storeCodexModels([]*sdkmodelcatalog.ModelInfo{{ID: "cached-codex", OwnedBy: "openai", Type: "codex"}}); !ok {
+		t.Fatal("cache seed failed")
+	}
+	models := FetchCodexModels(context.Background(), &cliproxyauth.Auth{Provider: "codex"}, nil)
+	if len(models) != 1 || models[0].ID != "cached-codex" {
+		t.Fatalf("fallback models=%v", models)
+	}
+}
+
+func TestResolveCodexModelsClientVersionFloorsStaleDefault(t *testing.T) {
+	got := resolveCodexModelsClientVersion(nil, nil)
+	if got != defaultCodexModelsClientVer {
+		t.Fatalf("nil cfg version=%q want %q", got, defaultCodexModelsClientVer)
+	}
+	got = resolveCodexModelsClientVersion(&config.Config{}, nil)
+	if got != defaultCodexModelsClientVer {
+		t.Fatalf("empty fp version=%q want %q", got, defaultCodexModelsClientVer)
+	}
+}
+
+func TestResolveCodexModelsClientVersionUsesConfiguredWhenNewer(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.IdentityFingerprint.Codex.Version = "0.201.0"
+	got := resolveCodexModelsClientVersion(cfg, nil)
+	if got != "0.201.0" {
+		t.Fatalf("got %q", got)
+	}
+	cfg.IdentityFingerprint.Codex.Version = "0.118.0"
+	got = resolveCodexModelsClientVersion(cfg, nil)
+	if got != defaultCodexModelsClientVer {
+		t.Fatalf("stale configured version should floor, got %q", got)
+	}
+}
+
+func TestBuildCodexModelsURLEmbedsClientVersion(t *testing.T) {
+	url, isManifest := buildCodexModelsURL("", false, "0.180.0")
+	if !isManifest || !strings.Contains(url, "client_version=0.180.0") {
+		t.Fatalf("url=%q", url)
+	}
+}
+
+func TestParseCodexModelsFromSlugManifest(t *testing.T) {
+	body := []byte(`{"models":[
+		{"slug":"gpt-5.6-sol","display_name":"GPT-5.6 Sol"},
+		{"slug":"gpt-5.5","display_name":"GPT-5.5"},
+		{"slug":"gpt-5.4","display_name":"GPT-5.4"}
+	]}`)
+	models, ok := parseCodexModels(body, 1700000000)
+	if !ok || len(models) != 3 {
+		t.Fatalf("ok=%v len=%d", ok, len(models))
+	}
+	if models[0].ID != "gpt-5.6-sol" {
+		t.Fatalf("models[0]=%+v", models[0])
+	}
+}

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -103,6 +103,14 @@ func FetchXAIModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config
 	return internalserviceapp.FetchXAIModels(ctx, auth, cfg)
 }
 
+func FetchClaudeModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.FetchClaudeModels(ctx, auth, cfg)
+}
+
+func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.FetchCodexModels(ctx, auth, cfg)
+}
+
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	internalserviceapp.RegisterExecutorForAuth(coreManager, cfg, auth, forceReplace, gateway)
 }


### PR DESCRIPTION
## Summary
- Restore live upstream model discovery for **Claude** (`GET /v1/models`) and **Codex** (ChatGPT `.../codex/models?client_version=` with modern floor `0.180.0`).
- **Discovery-only** for claude/codex: return `source=upstream` for pin-to-models UX, but **never** `RegisterClient`-replace the static channel catalog (avoids #673/#674 incomplete-manifest wipe).
- xai/antigravity still update the runtime registry on successful live fetch.
- Prefer Codex manifest `slug` as callable model id; floor stale identity fingerprint versions so discovery does not regress to ~4 models.

## Test plan
- [x] `go test ./internal/runtime/executor/ ./internal/management/authfiles/`
- [x] `golangci-lint run --config .golangci.yml`
- [x] `go build ./cmd/server`
- [x] `./scripts/ci-pr.sh` (tests + lint path; errcheck fixed)

Refs: #492