### PR TITLE
fix(models): persist Claude/Codex discovery cache across auth files

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -41,10 +41,11 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 //
 // Query params:
 //   - name (required): auth file name or auth ID
-//   - refresh=1|true: re-fetch live models from upstream for discovery.
+//   - refresh=1|true: force re-fetch live models from upstream.
 //     xai/antigravity: updates runtime registry when successful.
-//     claude/codex: returns upstream list with source=upstream but does NOT
-//     replace the static registry catalog (avoids incomplete-manifest wipe).
+//     claude/codex: provider-level discovery cache (shared by same-type accounts);
+//     open auto-warms once and subsequent opens reuse cache; force refreshes
+//     cache. Does NOT RegisterClient-replace the static channel catalog.
 //     Falls back to registry on failure.
 func (h *Handler) GetAuthFileModels(c *gin.Context) {
 	name := c.Query("name")

--- a/internal/management/authfiles/models.go
+++ b/internal/management/authfiles/models.go
@@ -3,6 +3,7 @@ package authfiles
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -18,6 +19,81 @@ type ModelSource interface {
 
 type ModelRegistrar interface {
 	RegisterClient(clientID, clientProvider string, models []*registry.ModelInfo)
+}
+
+// Provider-level discovery cache for claude/codex.
+// Live manifests are shared across accounts of the same provider+tenant so we
+// only hit upstream once (or on force refresh), then every auth-file models
+// panel reuses the same list without RegisterClient-replacing the static catalog.
+const discoveryCacheTTL = 24 * time.Hour
+
+type discoveryCacheEntry struct {
+	models    []*registry.ModelInfo
+	fetchedAt time.Time
+}
+
+type discoveryInflight struct {
+	done   chan struct{}
+	models []*registry.ModelInfo
+	ok     bool
+}
+
+var (
+	discoveryCacheMu   sync.Mutex
+	discoveryCache     = map[string]discoveryCacheEntry{}
+	discoveryInflightM = map[string]*discoveryInflight{}
+)
+
+// ResetDiscoveryCacheForTest clears provider discovery cache (tests only).
+func ResetDiscoveryCacheForTest() {
+	discoveryCacheMu.Lock()
+	discoveryCache = map[string]discoveryCacheEntry{}
+	discoveryInflightM = map[string]*discoveryInflight{}
+	discoveryCacheMu.Unlock()
+}
+
+func discoveryCacheKey(tenantID, provider string) string {
+	return NormalizeTenantID(tenantID) + "|" + strings.ToLower(strings.TrimSpace(provider))
+}
+
+func supportsSharedDiscovery(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "claude", "codex":
+		return true
+	default:
+		return false
+	}
+}
+
+func loadDiscoveryCache(tenantID, provider string) []*registry.ModelInfo {
+	if !supportsSharedDiscovery(provider) {
+		return nil
+	}
+	key := discoveryCacheKey(tenantID, provider)
+	discoveryCacheMu.Lock()
+	defer discoveryCacheMu.Unlock()
+	entry, ok := discoveryCache[key]
+	if !ok || len(entry.models) == 0 {
+		return nil
+	}
+	if time.Since(entry.fetchedAt) > discoveryCacheTTL {
+		delete(discoveryCache, key)
+		return nil
+	}
+	return cloneRegistryModels(entry.models)
+}
+
+func storeDiscoveryCache(tenantID, provider string, models []*registry.ModelInfo) {
+	if !supportsSharedDiscovery(provider) || len(models) == 0 {
+		return
+	}
+	key := discoveryCacheKey(tenantID, provider)
+	discoveryCacheMu.Lock()
+	discoveryCache[key] = discoveryCacheEntry{
+		models:    cloneRegistryModels(models),
+		fetchedAt: time.Now(),
+	}
+	discoveryCacheMu.Unlock()
 }
 
 func ModelLookupAuthID(manager *coreauth.Manager, name string) string {
@@ -72,14 +148,18 @@ func ListModelEntriesForTenant(manager *coreauth.Manager, source ModelSource, te
 	return modelEntriesFromRegistry(models)
 }
 
-// ListModelEntriesLiveForTenant optionally re-fetches models from the upstream
-// provider for discovery (refresh=1).
+// ListModelEntriesLiveForTenant returns models for an auth file panel.
 //
-// Registry update policy:
-//   - xai / antigravity: live catalog is account-complete → update runtime registry
-//   - claude / codex: live is discovery-only (ChatGPT manifest / Anthropic /models
-//     can be a subset). Return upstream list with source=upstream but NEVER
-//     RegisterClient-replace the static channel catalog (regression #673/#674).
+// Behaviour:
+//   - claude / codex (shared discovery):
+//     open (refresh=false): serve provider discovery cache if present; otherwise
+//     auto-warm once from upstream using this auth, store under provider+tenant,
+//     return source=upstream. Never RegisterClient-replace the static catalog.
+//     force (refresh=true): re-fetch upstream, refresh provider cache, return
+//     source=upstream. Same-type accounts reuse the cache without re-hitting
+//     upstream until TTL or the next force.
+//   - xai / antigravity:
+//     refresh=true updates runtime registry when live succeeds; open uses registry.
 //
 // When live fetch fails, falls back to the existing registry list so the UI
 // still shows known models.
@@ -93,29 +173,125 @@ func ListModelEntriesLiveForTenant(
 	refresh bool,
 ) (models []map[string]any, sourceLabel string) {
 	sourceLabel = "registry"
-	if !refresh {
-		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
-	}
 
 	auth := FindAuthForTenant(manager, tenantID, name)
 	if auth == nil {
 		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
 	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 
-	live, provider, updateRegistry := fetchLiveModelsForAuth(ctx, auth, cfg)
+	// Shared discovery path for Claude / Codex: prefer provider cache on open,
+	// auto-warm on first miss, force re-fetch only when refresh=1.
+	if supportsSharedDiscovery(provider) {
+		if !refresh {
+			if cached := loadDiscoveryCache(tenantID, provider); len(cached) > 0 {
+				return modelEntriesFromRegistry(cached), "upstream"
+			}
+		}
+		live, ok := warmSharedDiscovery(ctx, auth, cfg, tenantID, provider, refresh)
+		if ok && len(live) > 0 {
+			return modelEntriesFromRegistry(live), "upstream"
+		}
+		// Live miss/fail: keep last good discovery list if any (do not snap back to static).
+		if cached := loadDiscoveryCache(tenantID, provider); len(cached) > 0 {
+			return modelEntriesFromRegistry(cached), "upstream"
+		}
+		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
+	}
+
+	if !refresh {
+		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
+	}
+
+	live, liveProvider, updateRegistry := fetchLiveModelsForAuth(ctx, auth, cfg)
 	if len(live) == 0 {
 		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
 	}
 
 	sourceLabel = "upstream"
 	if updateRegistry && registrar != nil {
-		providerKey := provider
+		providerKey := liveProvider
 		if providerKey == "" {
-			providerKey = strings.ToLower(strings.TrimSpace(auth.Provider))
+			providerKey = provider
 		}
 		registrar.RegisterClient(auth.ID, providerKey, live)
 	}
 	return modelEntriesFromRegistry(live), sourceLabel
+}
+
+// warmSharedDiscovery fetches live models for claude/codex and stores them in
+// the provider-level cache. Concurrent warmers for the same key single-flight.
+// When force is false and another warmer already populated the cache, waiters
+// receive that result without a second upstream call.
+func warmSharedDiscovery(
+	ctx context.Context,
+	auth *coreauth.Auth,
+	cfg *config.Config,
+	tenantID, provider string,
+	force bool,
+) ([]*registry.ModelInfo, bool) {
+	if auth == nil || !supportsSharedDiscovery(provider) {
+		return nil, false
+	}
+	key := discoveryCacheKey(tenantID, provider)
+
+	if !force {
+		if cached := loadDiscoveryCache(tenantID, provider); len(cached) > 0 {
+			return cached, true
+		}
+	}
+
+	discoveryCacheMu.Lock()
+	if !force {
+		if entry, ok := discoveryCache[key]; ok && len(entry.models) > 0 && time.Since(entry.fetchedAt) <= discoveryCacheTTL {
+			models := cloneRegistryModels(entry.models)
+			discoveryCacheMu.Unlock()
+			return models, true
+		}
+	}
+	if inflight, ok := discoveryInflightM[key]; ok {
+		discoveryCacheMu.Unlock()
+		<-inflight.done
+		if inflight.ok {
+			return cloneRegistryModels(inflight.models), true
+		}
+		// Leader failed; if we are not force, do not stampede — fall back.
+		if !force {
+			return nil, false
+		}
+		// Force path: try again as a new leader below.
+		discoveryCacheMu.Lock()
+		if inflight2, ok2 := discoveryInflightM[key]; ok2 {
+			discoveryCacheMu.Unlock()
+			<-inflight2.done
+			if inflight2.ok {
+				return cloneRegistryModels(inflight2.models), true
+			}
+			return nil, false
+		}
+	}
+
+	inflight := &discoveryInflight{done: make(chan struct{})}
+	discoveryInflightM[key] = inflight
+	discoveryCacheMu.Unlock()
+
+	live, _, _ := fetchLiveModelsForAuth(ctx, auth, cfg)
+	ok := len(live) > 0
+	if ok {
+		storeDiscoveryCache(tenantID, provider, live)
+	}
+
+	discoveryCacheMu.Lock()
+	inflight.models = cloneRegistryModels(live)
+	inflight.ok = ok
+	delete(discoveryInflightM, key)
+	close(inflight.done)
+	discoveryCacheMu.Unlock()
+
+	if !ok {
+		return nil, false
+	}
+	return cloneRegistryModels(live), true
 }
 
 func fetchLiveModelsForAuth(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) ([]*registry.ModelInfo, string, bool) {
@@ -176,6 +352,21 @@ func cloneSDKModelsToRegistry(models []*sdkmodelcatalog.ModelInfo) []*registry.M
 			MaxCompletionTokens: model.MaxCompletionTokens,
 			UserDefined:         model.UserDefined,
 		})
+	}
+	return out
+}
+
+func cloneRegistryModels(models []*registry.ModelInfo) []*registry.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		out = append(out, &clone)
 	}
 	return out
 }

--- a/internal/management/authfiles/models_test.go
+++ b/internal/management/authfiles/models_test.go
@@ -93,6 +93,7 @@ func (s *modelRegistrarStub) RegisterClient(clientID, clientProvider string, mod
 }
 
 func TestListModelEntriesLiveForTenantCodexDoesNotReplaceRegistry(t *testing.T) {
+	ResetDiscoveryCacheForTest()
 	// Without a real upstream, refresh falls back to registry; registrar must not be called
 	// when live is empty. When we inject via a custom path, codex updateRegistry is false.
 	// Here we only assert the empty-live path never registers.
@@ -129,23 +130,106 @@ func TestListModelEntriesLiveForTenantCodexDoesNotReplaceRegistry(t *testing.T) 
 	}
 }
 
-func TestListModelEntriesLiveWithoutRefreshUsesRegistry(t *testing.T) {
+func TestListModelEntriesLiveWithoutRefreshUsesRegistryWhenNoDiscoveryCache(t *testing.T) {
+	ResetDiscoveryCacheForTest()
 	manager := coreauth.NewManager(nil, nil, nil)
 	if _, err := manager.Register(context.Background(), &coreauth.Auth{
 		ID:       "codex-auth",
 		FileName: "codex.json",
 		Provider: "codex",
+		// no credentials → warm fails → registry fallback
 	}); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 	source := &modelSourceStub{
-		models: []*registry.ModelInfo{{ID: "gpt-5.5"}},
+		models: []*registry.ModelInfo{{ID: "gpt-static"}},
 	}
 	reg := &modelRegistrarStub{}
 	models, label := ListModelEntriesLiveForTenant(
 		context.Background(), manager, source, reg, nil, "", "codex.json", false,
 	)
-	if label != "registry" || reg.calls != 0 || len(models) != 1 {
+	if label != "registry" || reg.calls != 0 || len(models) != 1 || models[0]["id"] != "gpt-static" {
 		t.Fatalf("label=%q calls=%d models=%#v", label, reg.calls, models)
+	}
+}
+
+func TestDiscoveryCacheSharedAcrossSameProviderAccounts(t *testing.T) {
+	ResetDiscoveryCacheForTest()
+	storeDiscoveryCache("", "codex", []*registry.ModelInfo{
+		{ID: "gpt-5.6-sol", DisplayName: "GPT-5.6 Sol", Type: "codex", OwnedBy: "openai"},
+		{ID: "gpt-5.5", DisplayName: "GPT-5.5", Type: "codex", OwnedBy: "openai"},
+	})
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	for _, auth := range []*coreauth.Auth{
+		{ID: "codex-a", FileName: "codex-a.json", Provider: "codex"},
+		{ID: "codex-b", FileName: "codex-b.json", Provider: "codex"},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register %s: %v", auth.ID, err)
+		}
+	}
+	source := &modelSourceStub{
+		models: []*registry.ModelInfo{{ID: "gpt-static-only"}},
+	}
+	reg := &modelRegistrarStub{}
+
+	// Open without refresh must serve discovery cache, not static registry.
+	for _, name := range []string{"codex-a.json", "codex-b.json"} {
+		models, label := ListModelEntriesLiveForTenant(
+			context.Background(), manager, source, reg, nil, "", name, false,
+		)
+		if label != "upstream" {
+			t.Fatalf("%s source=%q, want upstream", name, label)
+		}
+		if reg.calls != 0 {
+			t.Fatalf("RegisterClient must not run for shared discovery, calls=%d", reg.calls)
+		}
+		if len(models) != 2 || models[0]["id"] != "gpt-5.6-sol" {
+			t.Fatalf("%s models=%#v", name, models)
+		}
+	}
+
+	// Claude cache must not leak into codex and vice versa.
+	storeDiscoveryCache("", "claude", []*registry.ModelInfo{
+		{ID: "claude-sonnet-4", Type: "claude"},
+	})
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: "claude-a", FileName: "claude-a.json", Provider: "claude",
+	}); err != nil {
+		t.Fatalf("Register claude: %v", err)
+	}
+	claudeModels, claudeLabel := ListModelEntriesLiveForTenant(
+		context.Background(), manager, source, reg, nil, "", "claude-a.json", false,
+	)
+	if claudeLabel != "upstream" || len(claudeModels) != 1 || claudeModels[0]["id"] != "claude-sonnet-4" {
+		t.Fatalf("claude models=%#v label=%q", claudeModels, claudeLabel)
+	}
+	// codex still its own cache
+	codexModels, codexLabel := ListModelEntriesLiveForTenant(
+		context.Background(), manager, source, reg, nil, "", "codex-a.json", false,
+	)
+	if codexLabel != "upstream" || len(codexModels) != 2 {
+		t.Fatalf("codex still shared cache: %#v label=%q", codexModels, codexLabel)
+	}
+}
+
+func TestDiscoveryCacheDoesNotReplaceRegistrar(t *testing.T) {
+	ResetDiscoveryCacheForTest()
+	storeDiscoveryCache("", "codex", []*registry.ModelInfo{{ID: "gpt-5.6-terra"}})
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: "codex-auth", FileName: "codex.json", Provider: "codex",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	source := &modelSourceStub{models: []*registry.ModelInfo{{ID: "static"}}}
+	reg := &modelRegistrarStub{}
+	_, _ = ListModelEntriesLiveForTenant(
+		context.Background(), manager, source, reg, nil, "", "codex.json", true,
+	)
+	// force with no credentials fails warm; registrar still never called
+	if reg.calls != 0 {
+		t.Fatalf("RegisterClient calls=%d want 0", reg.calls)
 	}
 }


### PR DESCRIPTION
## Summary
- Claude/Codex auth-file models panel now **auto-warms** a provider+tenant discovery cache on open (and after deploy restart when cache is empty).
- Same-type accounts **reuse** the cached upstream list — no repeated ChatGPT/Anthropic hits until TTL or force refresh.
- Manual **刷新模型** (`refresh=1`) re-fetches upstream and updates the shared cache.
- Reopening the modal keeps showing the live discovery list (`source=upstream`), not the static registry snap-back.
- Still **never** `RegisterClient`-replaces the static channel catalog (avoids #673/#674 wipe).

## Test plan
- [x] `go test ./internal/management/authfiles/`
- [x] `golangci-lint` (authfiles + full)
- [x] `go build ./cmd/server`