### PR TITLE
fix(models): merge Claude/Codex live discovery into plaza and catalog

### DIFF
--- a/internal/management/authfiles/models.go
+++ b/internal/management/authfiles/models.go
@@ -52,6 +52,11 @@ func ResetDiscoveryCacheForTest() {
 	discoveryCacheMu.Unlock()
 }
 
+// StoreDiscoveryCacheForTest seeds the provider discovery cache (tests only).
+func StoreDiscoveryCacheForTest(tenantID, provider string, models []*registry.ModelInfo) {
+	storeDiscoveryCache(tenantID, provider, models)
+}
+
 func discoveryCacheKey(tenantID, provider string) string {
 	return NormalizeTenantID(tenantID) + "|" + strings.ToLower(strings.TrimSpace(provider))
 }
@@ -63,6 +68,11 @@ func supportsSharedDiscovery(provider string) bool {
 	default:
 		return false
 	}
+}
+
+// SupportsSharedDiscovery reports whether provider uses the shared live-discovery cache.
+func SupportsSharedDiscovery(provider string) bool {
+	return supportsSharedDiscovery(provider)
 }
 
 func loadDiscoveryCache(tenantID, provider string) []*registry.ModelInfo {
@@ -94,6 +104,89 @@ func storeDiscoveryCache(tenantID, provider string, models []*registry.ModelInfo
 		fetchedAt: time.Now(),
 	}
 	discoveryCacheMu.Unlock()
+}
+
+// EnsureProviderDiscovery returns the shared live model list for claude/codex.
+// Cache hit is preferred; on miss it warms once from the first active auth of
+// that provider in the tenant (same single-flight path as the auth-file panel).
+// force re-fetches upstream even when the cache is warm.
+func EnsureProviderDiscovery(
+	ctx context.Context,
+	manager *coreauth.Manager,
+	cfg *config.Config,
+	tenantID, provider string,
+	force bool,
+) []*registry.ModelInfo {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if !supportsSharedDiscovery(provider) {
+		return nil
+	}
+	if !force {
+		if cached := loadDiscoveryCache(tenantID, provider); len(cached) > 0 {
+			return cached
+		}
+	}
+	auth := firstActiveAuthForProvider(manager, tenantID, provider)
+	if auth == nil {
+		return loadDiscoveryCache(tenantID, provider)
+	}
+	live, ok := warmSharedDiscovery(ctx, auth, cfg, tenantID, provider, force)
+	if ok && len(live) > 0 {
+		return live
+	}
+	return loadDiscoveryCache(tenantID, provider)
+}
+
+// EnsureSharedDiscoveryForTenant warms/returns discovery lists for every
+// shared-discovery provider that has at least one active auth in the tenant.
+// Used by model plaza / catalog so they show the same live list as the
+// auth-file models panel (not the static registry catalog).
+func EnsureSharedDiscoveryForTenant(
+	ctx context.Context,
+	manager *coreauth.Manager,
+	cfg *config.Config,
+	tenantID string,
+	force bool,
+) map[string][]*registry.ModelInfo {
+	out := make(map[string][]*registry.ModelInfo)
+	if manager == nil {
+		return out
+	}
+	seen := make(map[string]struct{})
+	for _, auth := range manager.ListForTenant(NormalizeTenantID(tenantID)) {
+		if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+			continue
+		}
+		provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+		if !supportsSharedDiscovery(provider) {
+			continue
+		}
+		if _, ok := seen[provider]; ok {
+			continue
+		}
+		seen[provider] = struct{}{}
+		models := EnsureProviderDiscovery(ctx, manager, cfg, tenantID, provider, force)
+		if len(models) > 0 {
+			out[provider] = models
+		}
+	}
+	return out
+}
+
+func firstActiveAuthForProvider(manager *coreauth.Manager, tenantID, provider string) *coreauth.Auth {
+	if manager == nil {
+		return nil
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	for _, auth := range manager.ListForTenant(NormalizeTenantID(tenantID)) {
+		if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(auth.Provider), provider) {
+			return auth
+		}
+	}
+	return nil
 }
 
 func ModelLookupAuthID(manager *coreauth.Manager, name string) string {

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -1,7 +1,9 @@
 package modelcatalog
 
 import (
+	"context"
 	"strings"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
@@ -15,21 +17,40 @@ import (
 // Availability contract:
 // - Owner: model availability query boundary.
 // - Responsibility: turn registry state plus stored capabilities into management-facing availability DTOs.
+//
+// Claude/Codex live discovery is intentionally NOT RegisterClient-written into
+// the runtime registry (subset risk, #673/#674). Management surfaces (plaza,
+// catalog) still need the same live list as the auth-file models panel, so we
+// merge the provider discovery cache here on every read (auto-warm on miss).
 func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
 	modelRegistry := registry.GetGlobalRegistry()
-	allModels := s.effectiveModels(managementVisibleModels(modelRegistry), allowedChannelsRaw, allowedGroupsRaw)
 	authByID := s.authByID()
+	discoveryByProvider := s.sharedDiscoveryByProvider(false)
+	// Strip static-only claude/codex registry rows first, then scope-filter.
+	// Live discovery models are appended AFTER CanServe filtering because they
+	// are intentionally not RegisterClient-written into the runtime registry.
+	ownerMappings := s.authGroupOwnerMappingMap()
+	baseModels := dropStaticDiscoveryProviderModels(
+		managementVisibleModels(modelRegistry),
+		modelRegistry,
+		discoveryByProvider,
+		authByID,
+		ownerMappings,
+	)
+	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw)
 	usesMappedOwners := false
-	var ownerMappings map[string]string
 	var ownerKeys map[string]bool
 	if shouldUseDefaultMappedOwnerScope(allowedChannelsRaw, allowedGroupsRaw) {
 		if rows, keys, configuredModelKeys, ok := s.defaultMappedOwnerRows(); ok {
 			usesMappedOwners = true
 			ownerKeys = keys
-			ownerMappings = s.authGroupOwnerMappingMap()
 			allModels = withDefaultMappedOwnerRows(modelRegistry, allModels, rows, ownerKeys, configuredModelKeys, authByID, ownerMappings)
 		}
 	}
+	// Mapped-owner config rows can re-introduce the full openai/anthropic library;
+	// drop stale rows again, then append the live discovery list.
+	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings)
+	allModels = appendSharedDiscoveryModels(allModels, discoveryByProvider)
 
 	allConfigRows := modelconfigsettings.ListAllConfigsForTenant(s.tenantID)
 	configByID := make(map[string]usage.ModelConfigRow, len(allConfigRows))
@@ -49,11 +70,19 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 			"object": "model",
 			"source": "registry",
 		}
+		if src, _ := model["source"].(string); strings.TrimSpace(src) != "" {
+			entry["source"] = src
+		}
 		if ownedBy, exists := model["owned_by"]; exists {
 			entry["owned_by"] = ownedBy
 		}
 		if sources := s.modelSourceEntries(modelRegistry, id, authByID, ownerMappings, ownerKeys); len(sources) > 0 {
 			entry["sources"] = sources
+		} else if discoveryProvider, _ := model["discovery_provider"].(string); strings.TrimSpace(discoveryProvider) != "" {
+			// Discovery-only rows have no registry sources; synthesize from active auths.
+			if sources := s.discoverySourceEntries(discoveryProvider, id, authByID); len(sources) > 0 {
+				entry["sources"] = sources
+			}
 		}
 		if row, ok := configByID[strings.ToLower(id)]; ok {
 			attachModelConfigCapabilities(entry, row)
@@ -95,7 +124,19 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 
 func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
 	modelRegistry := registry.GetGlobalRegistry()
-	allModels := s.effectiveModels(managementVisibleModels(modelRegistry), allowedChannelsRaw, allowedGroupsRaw)
+	authByID := s.authByID()
+	discoveryByProvider := s.sharedDiscoveryByProvider(false)
+	ownerMappings := s.authGroupOwnerMappingMap()
+	baseModels := dropStaticDiscoveryProviderModels(
+		managementVisibleModels(modelRegistry),
+		modelRegistry,
+		discoveryByProvider,
+		authByID,
+		ownerMappings,
+	)
+	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw)
+	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings)
+	allModels = appendSharedDiscoveryModels(allModels, discoveryByProvider)
 
 	pricingMap := usage.GetAllModelPricingForTenant(s.tenantID)
 	filteredModels := make([]map[string]any, len(allModels))
@@ -156,6 +197,273 @@ func managementVisibleModels(modelRegistry *registry.ModelRegistry) []map[string
 		for _, info := range modelRegistry.GetAvailableModelsByProvider(provider) {
 			add(registryModelInfoAsOpenAIModel(info))
 		}
+	}
+	return out
+}
+
+// sharedDiscoveryByProvider auto-warms (or reads) the claude/codex provider
+// discovery cache for the current tenant. force is reserved for future refresh
+// query support; management list endpoints currently always use force=false.
+func (s *Service) sharedDiscoveryByProvider(force bool) map[string][]*registry.ModelInfo {
+	if s == nil || s.authManager == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	return managementauthfiles.EnsureSharedDiscoveryForTenant(ctx, s.authManager, s.cfg, s.tenantID, force)
+}
+
+func liveDiscoveryProviders(discoveryByProvider map[string][]*registry.ModelInfo) map[string]struct{} {
+	out := make(map[string]struct{}, len(discoveryByProvider))
+	for provider, list := range discoveryByProvider {
+		if len(list) == 0 {
+			continue
+		}
+		out[strings.ToLower(strings.TrimSpace(provider))] = struct{}{}
+	}
+	return out
+}
+
+func discoveryModelIDSet(discoveryByProvider map[string][]*registry.ModelInfo) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, list := range discoveryByProvider {
+		for _, info := range list {
+			if info == nil {
+				continue
+			}
+			if id := strings.ToLower(strings.TrimSpace(info.ID)); id != "" {
+				out[id] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+// dropStaticDiscoveryProviderModels removes models that would otherwise keep the
+// stale static Claude/Codex catalog visible after live discovery is warm:
+//  1. Registry rows only served by live-discovery providers and not on the live list.
+//  2. Owner-mapped library rows (openai/anthropic catalog) for owners that map
+//     from those providers, when the model is not on the live list and has no
+//     non-discovery runtime source (e.g. opencode-go).
+//
+// Models still served by other providers are kept.
+func dropStaticDiscoveryProviderModels(
+	models []map[string]any,
+	modelRegistry *registry.ModelRegistry,
+	discoveryByProvider map[string][]*registry.ModelInfo,
+	authByID map[string]*coreauth.Auth,
+	ownerMappings map[string]string,
+) []map[string]any {
+	liveProviders := liveDiscoveryProviders(discoveryByProvider)
+	if len(liveProviders) == 0 {
+		return models
+	}
+	discoveryIDs := discoveryModelIDSet(discoveryByProvider)
+	discoveryOwners := ownersMappedFromProviders(ownerMappings, liveProviders)
+	out := make([]map[string]any, 0, len(models))
+	for _, model := range models {
+		id, _ := model["id"].(string)
+		key := strings.ToLower(strings.TrimSpace(id))
+		if key == "" {
+			continue
+		}
+		if _, onLive := discoveryIDs[key]; onLive {
+			out = append(out, model)
+			continue
+		}
+		if modelOnlyServedByDiscoveryProviders(modelRegistry, id, authByID, liveProviders) {
+			continue
+		}
+		if modelIsStaleMappedOwnerLibraryRow(model, modelRegistry, id, authByID, liveProviders, discoveryOwners) {
+			continue
+		}
+		out = append(out, model)
+	}
+	return out
+}
+
+// ownersMappedFromProviders returns owner keys that map from any auth-group in liveProviders.
+func ownersMappedFromProviders(ownerMappings map[string]string, liveProviders map[string]struct{}) map[string]bool {
+	if len(ownerMappings) == 0 || len(liveProviders) == 0 {
+		return nil
+	}
+	out := make(map[string]bool)
+	for authGroup, owner := range ownerMappings {
+		if _, ok := liveProviders[normalizeAuthGroupKey(authGroup)]; !ok {
+			continue
+		}
+		if key := normalizeModelOwnerKey(owner); key != "" {
+			out[key] = true
+		}
+	}
+	return out
+}
+
+// modelIsStaleMappedOwnerLibraryRow drops owner-mapped catalog rows that only
+// exist because of a codex→openai / claude→anthropic mapping, once live
+// discovery has replaced that provider's callable set.
+func modelIsStaleMappedOwnerLibraryRow(
+	model map[string]any,
+	modelRegistry *registry.ModelRegistry,
+	modelID string,
+	authByID map[string]*coreauth.Auth,
+	liveProviders map[string]struct{},
+	discoveryOwners map[string]bool,
+) bool {
+	if len(discoveryOwners) == 0 {
+		return false
+	}
+	ownedBy, _ := model["owned_by"].(string)
+	ownerKey := normalizeModelOwnerKey(ownedBy)
+	if ownerKey == "" || !discoveryOwners[ownerKey] {
+		return false
+	}
+	// If any non-discovery provider still serves this model, keep it.
+	if modelRegistry != nil {
+		sources := modelRegistry.GetModelClientSources(modelID)
+		for _, source := range sources {
+			provider := strings.ToLower(strings.TrimSpace(source.Provider))
+			if auth := authByID[strings.TrimSpace(source.ClientID)]; auth != nil && strings.TrimSpace(auth.Provider) != "" {
+				provider = strings.ToLower(strings.TrimSpace(auth.Provider))
+			}
+			if _, isLiveProvider := liveProviders[provider]; !isLiveProvider {
+				return false
+			}
+		}
+		// Has only discovery-provider sources (or none): stale library row for this owner.
+		if len(sources) > 0 {
+			return true
+		}
+	}
+	// No registry sources: pure mapped-owner library row for a discovery-backed owner.
+	return true
+}
+
+// appendSharedDiscoveryModels adds live discovery models that are not already
+// present. Called AFTER tenant/channel scope filtering because discovery models
+// are not RegisterClient-written into the runtime registry (so CanServe would
+// drop them). Tenant ownership is already enforced by EnsureSharedDiscoveryForTenant
+// which only warms providers with active auths in this tenant.
+func appendSharedDiscoveryModels(
+	models []map[string]any,
+	discoveryByProvider map[string][]*registry.ModelInfo,
+) []map[string]any {
+	if len(discoveryByProvider) == 0 {
+		return models
+	}
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		id, _ := model["id"].(string)
+		if key := strings.ToLower(strings.TrimSpace(id)); key != "" {
+			seen[key] = struct{}{}
+		}
+	}
+	out := models
+	for provider, list := range discoveryByProvider {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		for _, info := range list {
+			entry := registryModelInfoAsOpenAIModel(info)
+			if entry == nil {
+				continue
+			}
+			id, _ := entry["id"].(string)
+			key := strings.ToLower(strings.TrimSpace(id))
+			if key == "" {
+				continue
+			}
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			entry["source"] = "upstream-discovery"
+			entry["discovery_provider"] = provider
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// modelOnlyServedByDiscoveryProviders reports whether every registry source for
+// modelID belongs to a provider that has an active live discovery overlay.
+// If so, the static catalog row should be replaced by the discovery list.
+func modelOnlyServedByDiscoveryProviders(
+	modelRegistry *registry.ModelRegistry,
+	modelID string,
+	authByID map[string]*coreauth.Auth,
+	liveProviders map[string]struct{},
+) bool {
+	if modelRegistry == nil || len(liveProviders) == 0 {
+		return false
+	}
+	sources := modelRegistry.GetModelClientSources(modelID)
+	if len(sources) == 0 {
+		return false
+	}
+	for _, source := range sources {
+		provider := strings.ToLower(strings.TrimSpace(source.Provider))
+		if auth := authByID[strings.TrimSpace(source.ClientID)]; auth != nil && strings.TrimSpace(auth.Provider) != "" {
+			provider = strings.ToLower(strings.TrimSpace(auth.Provider))
+		}
+		if _, ok := liveProviders[provider]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// discoverySourceEntries builds synthetic source labels for discovery-only
+// models so plaza cards can still show which codex/claude accounts serve them.
+func (s *Service) discoverySourceEntries(
+	provider string,
+	modelID string,
+	authByID map[string]*coreauth.Auth,
+) []map[string]any {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	modelID = strings.TrimSpace(modelID)
+	if provider == "" || modelID == "" {
+		return nil
+	}
+	out := make([]map[string]any, 0)
+	seen := make(map[string]struct{})
+	for _, auth := range authByID {
+		if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(auth.Provider), provider) {
+			continue
+		}
+		clientID := strings.TrimSpace(auth.ID)
+		channel := strings.TrimSpace(auth.ChannelName())
+		label := provider
+		if channel != "" {
+			label = channel
+			if provider != "" && !strings.EqualFold(provider, channel) {
+				label = provider + " · " + channel
+			}
+		}
+		if label == "" {
+			label = clientID
+		}
+		key := clientID + "\x00" + label
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		entry := map[string]any{
+			"label":     label,
+			"provider":  provider,
+			"client_id": clientID,
+			"model_id":  modelID,
+		}
+		if channel != "" {
+			entry["channel"] = channel
+		}
+		if auth.Attributes != nil {
+			if src := strings.TrimSpace(auth.Attributes["source"]); src != "" {
+				entry["source"] = src
+			}
+		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -330,5 +331,137 @@ func TestFilterModelsByScopesAlwaysScopesToTenantWithoutChannelFilters(t *testin
 	filtered := svc.filterModelsByScopes(models, "", "")
 	if len(filtered) != 1 || filtered[0]["id"] != tenantModelID {
 		t.Fatalf("filtered = %#v, want only tenant model", filtered)
+	}
+}
+
+func TestConfiguredAvailabilityReplacesStaticCodexWithDiscovery(t *testing.T) {
+	const (
+		staticModelID    = "gpt-5.1-static-only"
+		liveModelID      = "gpt-5.6-sol"
+		bothModelID      = "gpt-5.4" // on static registry AND discovery — must remain
+		codexClientID    = "plaza-discovery-codex"
+		openCodeClientID = "plaza-discovery-opencode"
+		openCodeModelID  = "opencode-keep-model"
+	)
+
+	managementauthfiles.ResetDiscoveryCacheForTest()
+	t.Cleanup(managementauthfiles.ResetDiscoveryCacheForTest)
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(codexClientID)
+	modelRegistry.UnregisterClient(openCodeClientID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(codexClientID)
+		modelRegistry.UnregisterClient(openCodeClientID)
+	})
+
+	// Static codex catalog rows (what RegisterClient does at startup).
+	modelRegistry.RegisterClient(codexClientID, "codex", []*registry.ModelInfo{
+		{ID: staticModelID, Object: "model", OwnedBy: "openai"},
+		{ID: bothModelID, Object: "model", OwnedBy: "openai"},
+	})
+	// Non-codex provider must not be stripped.
+	modelRegistry.RegisterClient(openCodeClientID, "opencode-go", []*registry.ModelInfo{
+		{ID: openCodeModelID, Object: "model", OwnedBy: "opencode"},
+	})
+
+	// Seed live discovery with modern models (not registered into runtime registry).
+	managementauthfiles.StoreDiscoveryCacheForTest("", "codex", []*registry.ModelInfo{
+		{ID: liveModelID, Object: "model", OwnedBy: "openai", DisplayName: "GPT-5.6 Sol"},
+		{ID: bothModelID, Object: "model", OwnedBy: "openai", DisplayName: "GPT 5.4"},
+	})
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: codexClientID, Provider: "codex", Label: "Codex Pro", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register codex: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: openCodeClientID, Provider: "opencode-go", Label: "OpenCode", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register opencode: %v", err)
+	}
+
+	result := New(&config.Config{}, manager).ConfiguredAvailability("", "")
+	data, ok := result["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v", result["data"])
+	}
+	ids := make(map[string]struct{}, len(data))
+	var liveSources []map[string]any
+	for _, item := range data {
+		id, _ := item["id"].(string)
+		ids[id] = struct{}{}
+		if id == liveModelID {
+			liveSources, _ = item["sources"].([]map[string]any)
+		}
+	}
+
+	if _, ok := ids[liveModelID]; !ok {
+		t.Fatalf("missing live discovery model %q; ids=%v", liveModelID, ids)
+	}
+	if _, ok := ids[bothModelID]; !ok {
+		t.Fatalf("missing overlap model %q; ids=%v", bothModelID, ids)
+	}
+	if _, ok := ids[openCodeModelID]; !ok {
+		t.Fatalf("opencode model %q was stripped; ids=%v", openCodeModelID, ids)
+	}
+	if _, ok := ids[staticModelID]; ok {
+		t.Fatalf("static-only codex model %q should be replaced by discovery; ids=%v", staticModelID, ids)
+	}
+	if len(liveSources) == 0 {
+		t.Fatalf("live discovery model should have synthesized sources")
+	}
+}
+
+func TestDropStaticDiscoveryProviderModelsDropsMappedOwnerLibrary(t *testing.T) {
+	const (
+		staleLibraryID = "gpt-5-stale-library"
+		liveModelID    = "gpt-5.6-sol"
+		codexClientID  = "mapped-owner-drop-codex"
+	)
+	managementauthfiles.ResetDiscoveryCacheForTest()
+	t.Cleanup(managementauthfiles.ResetDiscoveryCacheForTest)
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(codexClientID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(codexClientID) })
+
+	modelRegistry.RegisterClient(codexClientID, "codex", []*registry.ModelInfo{
+		{ID: staleLibraryID, Object: "model", OwnedBy: "openai"},
+	})
+	managementauthfiles.StoreDiscoveryCacheForTest("", "codex", []*registry.ModelInfo{
+		{ID: liveModelID, Object: "model", OwnedBy: "openai"},
+	})
+
+	models := []map[string]any{
+		{"id": staleLibraryID, "object": "model", "owned_by": "openai"},
+		{"id": liveModelID, "object": "model", "owned_by": "openai"},
+		{"id": "unrelated-model", "object": "model", "owned_by": "deepseek"},
+	}
+	got := dropStaticDiscoveryProviderModels(
+		models,
+		modelRegistry,
+		map[string][]*registry.ModelInfo{
+			"codex": {{ID: liveModelID, Object: "model", OwnedBy: "openai"}},
+		},
+		map[string]*coreauth.Auth{
+			codexClientID: {ID: codexClientID, Provider: "codex", Status: coreauth.StatusActive},
+		},
+		map[string]string{"codex": "openai"},
+	)
+	ids := make(map[string]struct{}, len(got))
+	for _, m := range got {
+		ids[m["id"].(string)] = struct{}{}
+	}
+	if _, ok := ids[staleLibraryID]; ok {
+		t.Fatalf("stale mapped-owner library row should be dropped; got=%v", ids)
+	}
+	if _, ok := ids[liveModelID]; !ok {
+		t.Fatalf("live model should remain; got=%v", ids)
+	}
+	if _, ok := ids["unrelated-model"]; !ok {
+		t.Fatalf("unrelated owner model should remain; got=%v", ids)
 	}
 }

--- a/internal/management/modelcatalog/path_availability.go
+++ b/internal/management/modelcatalog/path_availability.go
@@ -14,6 +14,9 @@ import (
 // Path availability contract:
 // - Owner: model path capability boundary.
 // - Responsibility: expose routing/path-specific model availability derived from registry metadata.
+//
+// Claude/Codex live discovery is merged into the root OpenAI path so the model
+// catalog "path-only" enrichment matches the auth-file models panel.
 func (s *Service) PathAvailability() map[string]any {
 	modelRegistry := registry.GetGlobalRegistry()
 	items := make(map[string]*modelPathAvailabilityResponse)
@@ -21,7 +24,18 @@ func (s *Service) PathAvailability() map[string]any {
 	routingConfig := tenantRoutingConfig(s.tenantID, s.cfg)
 	rootOpenAICapabilities := openAIV1Capabilities("/")
 	rootGeminiCapabilities := geminiV1BetaCapabilities("/")
-	appendModelPaths(items, s.modelRootRouteScopedModels(modelRegistry.GetAvailableModels("openai"), routingConfig), "/", rootOpenAICapabilities)
+	authByID := s.authByID()
+	discoveryByProvider := s.sharedDiscoveryByProvider(false)
+	openaiModels := dropStaticDiscoveryProviderModels(
+		modelRegistry.GetAvailableModels("openai"),
+		modelRegistry,
+		discoveryByProvider,
+		authByID,
+		s.authGroupOwnerMappingMap(),
+	)
+	openaiModels = s.modelRootRouteScopedModels(openaiModels, routingConfig)
+	openaiModels = appendSharedDiscoveryModels(openaiModels, discoveryByProvider)
+	appendModelPaths(items, openaiModels, "/", rootOpenAICapabilities)
 	appendModelPaths(items, s.modelRootRouteScopedModels(modelRegistry.GetAvailableModels("gemini"), routingConfig), "/", rootGeminiCapabilities)
 
 	routes := []modelPathRouteResponse{


### PR DESCRIPTION
## Summary
账号模型弹窗已经能显示 live discovery（gpt-5.6-sol 等），但**模型广场 / 模型目录**仍走静态 registry + mapped-owner 库（gpt-5 / gpt-5.1…）。

本 PR 把 provider-level discovery cache 合并进管理端可见列表：

- `/models/configured-availability`、`/models`、`/model-path-availability`
- discovery 就绪时：去掉仅由 claude/codex 静态目录贡献、且不在 live 列表中的模型
- 去掉 mapped-owner 回灌的整库 openai/anthropic 静态行（同条件）
- 追加 live discovery 模型，并为 discovery-only 行合成 sources
- **不** `RegisterClient` 覆盖运行时静态目录（继续遵守 #673/#674）
- 同类型账号共享缓存，不重复打上游

## Test plan
- [x] `go test ./internal/management/authfiles/ ./internal/management/modelcatalog/ ./internal/api/handlers/management/`
- [ ] Deploy 后打开模型广场 / 模型目录：应出现 gpt-5.6-* / gpt-5.5 等，与账号弹窗一致；旧 gpt-5 / gpt-5.1 静态项在仅有 codex 源时消失
- [ ] 手动刷新账号模型后，广场再刷新应命中同一 provider cache

## Why not frontend-only
广场/目录主路径是后端 `configured-availability`；前端 fallback 的 per-auth live 在 mapped-owner 场景下不会走到。必须后端 overlay。