### PR TITLE
fix: honor channel-group allowed-models on plaza and catalog

### DIFF
--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/modelcatalog"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -29,7 +30,20 @@ func (h *ModelsHandler) service(c *gin.Context) *modelcatalog.Service {
 	if h == nil {
 		return modelcatalog.NewForTenant(tenantID, nil, nil)
 	}
-	return modelcatalog.NewForTenant(tenantID, h.cfg, h.authManager)
+	// Overlay the effective tenant's routing onto the process cfg so channel-group
+	// allowed-models apply on plaza/catalog. Non-system tenants store routing in DB;
+	// system keeps h.cfg.Routing when no DB row exists.
+	cfgCopy := &config.Config{}
+	if h.cfg != nil {
+		copied := *h.cfg
+		cfgCopy = &copied
+	}
+	if routing := usage.GetRoutingConfigForTenant(tenantID); routing != nil {
+		cfgCopy.Routing = *routing
+	} else if tenantID != "" && tenantID != identity.SystemTenantID {
+		cfgCopy.Routing = config.RoutingConfig{IncludeDefaultGroup: true}
+	}
+	return modelcatalog.NewForTenant(tenantID, cfgCopy, h.authManager)
 }
 
 func modelConfigScope(c *gin.Context) string {

--- a/internal/api/server_model_restriction.go
+++ b/internal/api/server_model_restriction.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 func (s *Server) modelRestrictionMiddleware() gin.HandlerFunc {
@@ -49,7 +52,8 @@ func (s *Server) modelRestrictionMiddleware() gin.HandlerFunc {
 			}
 		}
 
-		hasScopedRestriction := s.hasScopedRoutingModelRestriction(routeGroup, allowedGroups)
+		tenantID := requestTenantID(c)
+		hasScopedRestriction := s.hasScopedRoutingModelRestrictionForTenant(tenantID, routeGroup, allowedGroups)
 		if allowedStr == "" && !hasScopedRestriction && ccSwitchAllowed == nil {
 			c.Next()
 			return
@@ -104,7 +108,7 @@ func (s *Server) modelRestrictionMiddleware() gin.HandlerFunc {
 			abortModelNotAllowed(c, requestedModel)
 			return
 		}
-		if !s.modelAllowedByScopedRoutingGroups(routingModel, routeGroup, allowedGroups) {
+		if !s.modelAllowedByScopedRoutingGroupsForTenant(tenantID, routingModel, routeGroup, allowedGroups) {
 			abortModelNotAllowed(c, requestedModel)
 			return
 		}
@@ -149,11 +153,19 @@ func mapCcSwitchRequestModelForRestriction(model string, route *internalrouting.
 }
 
 func (s *Server) hasScopedRoutingModelRestriction(routeGroup string, allowedGroups map[string]struct{}) bool {
-	return s.scopedRoutingAllowedModels(routeGroup, allowedGroups) != nil
+	return s.hasScopedRoutingModelRestrictionForTenant(identity.SystemTenantID, routeGroup, allowedGroups)
+}
+
+func (s *Server) hasScopedRoutingModelRestrictionForTenant(tenantID, routeGroup string, allowedGroups map[string]struct{}) bool {
+	return s.scopedRoutingAllowedModelsForTenant(tenantID, routeGroup, allowedGroups) != nil
 }
 
 func (s *Server) modelAllowedByScopedRoutingGroups(model string, routeGroup string, allowedGroups map[string]struct{}) bool {
-	allowedModels := s.scopedRoutingAllowedModels(routeGroup, allowedGroups)
+	return s.modelAllowedByScopedRoutingGroupsForTenant(identity.SystemTenantID, model, routeGroup, allowedGroups)
+}
+
+func (s *Server) modelAllowedByScopedRoutingGroupsForTenant(tenantID, model, routeGroup string, allowedGroups map[string]struct{}) bool {
+	allowedModels := s.scopedRoutingAllowedModelsForTenant(tenantID, routeGroup, allowedGroups)
 	if allowedModels == nil {
 		return true
 	}
@@ -161,7 +173,12 @@ func (s *Server) modelAllowedByScopedRoutingGroups(model string, routeGroup stri
 }
 
 func (s *Server) scopedRoutingAllowedModels(routeGroup string, allowedGroups map[string]struct{}) []string {
-	if s == nil || s.cfg == nil {
+	return s.scopedRoutingAllowedModelsForTenant(identity.SystemTenantID, routeGroup, allowedGroups)
+}
+
+func (s *Server) scopedRoutingAllowedModelsForTenant(tenantID, routeGroup string, allowedGroups map[string]struct{}) []string {
+	routing := s.routingConfigForTenant(tenantID)
+	if routing == nil {
 		return nil
 	}
 	scopedGroups := make(map[string]struct{})
@@ -175,7 +192,7 @@ func (s *Server) scopedRoutingAllowedModels(routeGroup string, allowedGroups map
 		}
 	}
 	if len(scopedGroups) == 0 {
-		if s.cfg.Routing.IncludeDefaultGroup {
+		if routing.IncludeDefaultGroup {
 			scopedGroups["default"] = struct{}{}
 		}
 	}
@@ -184,7 +201,7 @@ func (s *Server) scopedRoutingAllowedModels(routeGroup string, allowedGroups map
 	}
 
 	var allowedModels []string
-	for _, group := range s.cfg.Routing.ChannelGroups {
+	for _, group := range routing.ChannelGroups {
 		groupName := internalrouting.NormalizeGroupName(group.Name)
 		if _, ok := scopedGroups[groupName]; !ok {
 			continue
@@ -198,6 +215,23 @@ func (s *Server) scopedRoutingAllowedModels(routeGroup string, allowedGroups map
 		return nil
 	}
 	return allowedModels
+}
+
+// routingConfigForTenant prefers the tenant's DB-backed routing config so
+// channel-group allowed-models apply per tenant, not only on the system cfg.
+func (s *Server) routingConfigForTenant(tenantID string) *config.RoutingConfig {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		tenantID = identity.SystemTenantID
+	}
+	if stored := usage.GetRoutingConfigForTenant(tenantID); stored != nil {
+		return stored
+	}
+	if tenantID == identity.SystemTenantID && s != nil && s.cfg != nil {
+		routing := s.cfg.Routing
+		return &routing
+	}
+	return nil
 }
 
 func routeAllowedModelMatches(model string, allowedModels []string) bool {

--- a/internal/api/server_model_restriction_tenant_test.go
+++ b/internal/api/server_model_restriction_tenant_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+)
+
+func TestScopedRoutingAllowedModelsUsesSystemCfgWhenNoDB(t *testing.T) {
+	server := &Server{cfg: &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{Name: "default", AllowedModels: []string{"gpt-5.5"}},
+			},
+		},
+	}}
+	allowed := server.scopedRoutingAllowedModelsForTenant(identity.SystemTenantID, "", nil)
+	if len(allowed) != 1 || allowed[0] != "gpt-5.5" {
+		t.Fatalf("allowed = %#v, want [gpt-5.5]", allowed)
+	}
+	if server.modelAllowedByScopedRoutingGroupsForTenant(identity.SystemTenantID, "minimax-m2.7", "", nil) {
+		t.Fatal("expected minimax-m2.7 to be forbidden by default group allowed-models")
+	}
+	if !server.modelAllowedByScopedRoutingGroupsForTenant(identity.SystemTenantID, "gpt-5.5", "", nil) {
+		t.Fatal("expected gpt-5.5 to be allowed")
+	}
+}
+
+func TestScopedRoutingAllowedModelsDoesNotUseSystemCfgForOtherTenant(t *testing.T) {
+	server := &Server{cfg: &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{Name: "default", AllowedModels: []string{"gpt-5.5"}},
+			},
+		},
+	}}
+	// Non-system tenant without a DB routing row must not inherit system allowed-models.
+	other := "cccccccc-dddd-eeee-ffff-000000000001"
+	allowed := server.scopedRoutingAllowedModelsForTenant(other, "", nil)
+	if allowed != nil {
+		t.Fatalf("allowed = %#v, want nil (no tenant routing row)", allowed)
+	}
+	if !server.modelAllowedByScopedRoutingGroupsForTenant(other, "minimax-m2.7", "", nil) {
+		t.Fatal("expected unrestricted when tenant has no routing row")
+	}
+}

--- a/internal/api/server_models_endpoint.go
+++ b/internal/api/server_models_endpoint.go
@@ -57,7 +57,8 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 			}
 		}
 
-		scopedRoutingRestricted := s.hasScopedRoutingModelRestriction(routeGroup, allowedChannelGroups)
+		tenantID := requestTenantID(c)
+		scopedRoutingRestricted := s.hasScopedRoutingModelRestrictionForTenant(tenantID, routeGroup, allowedChannelGroups)
 		if allowedModels == nil && allowedChannels == nil && allowedChannelGroups == nil && routeGroup == "" && !scopedRoutingRestricted {
 			userAgent := c.GetHeader("User-Agent")
 			if strings.HasPrefix(userAgent, "claude-cli") {
@@ -100,11 +101,11 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 					}
 				}
 				if allowedChannels != nil || allowedChannelGroups != nil || routeGroup != "" {
-					if s.handlers == nil || s.handlers.AuthManager == nil || !s.handlers.AuthManager.CanServeModelWithScopes(id, allowedChannels, allowedChannelGroups, routeGroup) {
+					if s.handlers == nil || s.handlers.AuthManager == nil || !s.handlers.AuthManager.CanServeModelWithScopesForTenant(tenantID, id, allowedChannels, allowedChannelGroups, routeGroup) {
 						continue
 					}
 				}
-				if scopedRoutingRestricted && !s.modelAllowedByScopedRoutingGroups(id, routeGroup, allowedChannelGroups) {
+				if scopedRoutingRestricted && !s.modelAllowedByScopedRoutingGroupsForTenant(tenantID, id, routeGroup, allowedChannelGroups) {
 					continue
 				}
 				filtered = append(filtered, model)

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -51,7 +51,12 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	// Mapped-owner config rows can re-introduce the full openai/anthropic library;
 	// drop stale rows again, then append the live discovery list.
 	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings)
-	allModels = appendSharedDiscoveryModels(allModels, discoveryByProvider)
+	// Live discovery models skip CanServe (not registry-backed). Still honor the
+	// tenant channel-group allowed-models list so plaza/catalog match the editor.
+	allModels = s.filterModelsByRoutingAllowedModels(
+		appendSharedDiscoveryModels(allModels, discoveryByProvider),
+		allowedGroupsRaw,
+	)
 
 	allConfigRows := modelconfigsettings.ListAllConfigsForTenant(s.tenantID)
 	configByID := make(map[string]usage.ModelConfigRow, len(allConfigRows))
@@ -137,7 +142,10 @@ func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string) map[string
 	)
 	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw)
 	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings)
-	allModels = appendSharedDiscoveryModels(allModels, discoveryByProvider)
+	allModels = s.filterModelsByRoutingAllowedModels(
+		appendSharedDiscoveryModels(allModels, discoveryByProvider),
+		allowedGroupsRaw,
+	)
 
 	pricingMap := usage.GetAllModelPricingForTenant(s.tenantID)
 	filteredModels := make([]map[string]any, len(allModels))
@@ -956,8 +964,8 @@ func (s *Service) modelOwnerScope(channels []string, groups map[string]struct{})
 			addOwnersForChannel(channel)
 		}
 	}
-	if s.cfg != nil {
-		for _, group := range s.cfg.Routing.ChannelGroups {
+	if routing := tenantRoutingConfig(s.tenantID, s.cfg); routing != nil {
+		for _, group := range routing.ChannelGroups {
 			groupName := internalrouting.NormalizeGroupName(group.Name)
 			if _, ok := groups[groupName]; !ok {
 				continue

--- a/internal/management/modelcatalog/availability_routing_filter.go
+++ b/internal/management/modelcatalog/availability_routing_filter.go
@@ -1,0 +1,84 @@
+package modelcatalog
+
+import (
+	"strings"
+
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+)
+
+// filterModelsByRoutingAllowedModels drops models outside the effective channel
+// group's allowed-models list. Used after live-discovery merge: discovery models
+// are not registry-backed, so CanServe cannot enforce AllowedModels for them.
+func (s *Service) filterModelsByRoutingAllowedModels(models []map[string]any, allowedGroupsRaw string) []map[string]any {
+	allowed := s.routingAllowedModels(allowedGroupsRaw)
+	if allowed == nil {
+		return models
+	}
+	filtered := make([]map[string]any, 0, len(models))
+	for _, model := range models {
+		id, _ := model["id"].(string)
+		if routingAllowedModelMatches(id, allowed) {
+			filtered = append(filtered, model)
+		}
+	}
+	return filtered
+}
+
+// routingAllowedModels returns the union of AllowedModels for the scoped groups.
+// nil means unrestricted (empty AllowedModels on any matched group, or no groups).
+func (s *Service) routingAllowedModels(allowedGroupsRaw string) []string {
+	if s == nil {
+		return nil
+	}
+	routing := tenantRoutingConfig(s.tenantID, s.cfg)
+	if routing == nil {
+		return nil
+	}
+	scopedGroups := internalrouting.ParseNormalizedSet(strings.TrimSpace(allowedGroupsRaw), internalrouting.NormalizeGroupName)
+	if len(scopedGroups) == 0 {
+		if routing.IncludeDefaultGroup {
+			scopedGroups = map[string]struct{}{"default": {}}
+		}
+	}
+	if len(scopedGroups) == 0 {
+		return nil
+	}
+	var allowedModels []string
+	matched := false
+	for _, group := range routing.ChannelGroups {
+		groupName := internalrouting.NormalizeGroupName(group.Name)
+		if _, ok := scopedGroups[groupName]; !ok {
+			continue
+		}
+		matched = true
+		// Empty AllowedModels means the group can use every model its channels serve.
+		if len(group.AllowedModels) == 0 {
+			return nil
+		}
+		allowedModels = append(allowedModels, group.AllowedModels...)
+	}
+	if !matched || len(allowedModels) == 0 {
+		return nil
+	}
+	return allowedModels
+}
+
+func routingAllowedModelMatches(model string, allowedModels []string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	for _, allowed := range allowedModels {
+		allowed = strings.TrimSpace(allowed)
+		if allowed == "" {
+			continue
+		}
+		if strings.EqualFold(model, allowed) {
+			return true
+		}
+		if idx := strings.Index(model, "/"); idx >= 0 && strings.EqualFold(strings.TrimSpace(model[idx+1:]), allowed) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -465,3 +465,63 @@ func TestDropStaticDiscoveryProviderModelsDropsMappedOwnerLibrary(t *testing.T) 
 		t.Fatalf("unrelated owner model should remain; got=%v", ids)
 	}
 }
+
+func TestFilterModelsByRoutingAllowedModelsHonorsDefaultGroupList(t *testing.T) {
+	// Live discovery models are merged after CanServe and must still be filtered
+	// by the channel-group allowed-models list (default group when unscoped).
+	svc := NewForTenant("", &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:          "default",
+					AllowedModels: []string{"grok-4.5"},
+				},
+			},
+		},
+	}, nil)
+
+	models := []map[string]any{
+		{"id": "grok-4.5", "object": "model", "owned_by": "xAI"},
+		{"id": "grok-composer-2.5-fast", "object": "model", "owned_by": "xAI"},
+		{"id": "gpt-5.4", "object": "model", "owned_by": "openai"},
+	}
+	filtered := svc.filterModelsByRoutingAllowedModels(models, "")
+	if len(filtered) != 1 || filtered[0]["id"] != "grok-4.5" {
+		t.Fatalf("filtered = %#v, want only grok-4.5", filtered)
+	}
+}
+
+func TestFilterModelsByRoutingAllowedModelsEmptyMeansUnrestricted(t *testing.T) {
+	svc := NewForTenant("", &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{Name: "default", AllowedModels: nil},
+			},
+		},
+	}, nil)
+	models := []map[string]any{{"id": "a"}, {"id": "b"}}
+	filtered := svc.filterModelsByRoutingAllowedModels(models, "")
+	if len(filtered) != 2 {
+		t.Fatalf("filtered = %#v, want unrestricted", filtered)
+	}
+}
+
+func TestFilterModelsByRoutingAllowedModelsHonorsNamedGroup(t *testing.T) {
+	svc := NewForTenant("", &config.Config{
+		Routing: config.RoutingConfig{
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:          "team",
+					AllowedModels: []string{"gpt-5"},
+				},
+			},
+		},
+	}, nil)
+	models := []map[string]any{{"id": "gpt-5"}, {"id": "claude-opus"}}
+	filtered := svc.filterModelsByRoutingAllowedModels(models, "team")
+	if len(filtered) != 1 || filtered[0]["id"] != "gpt-5" {
+		t.Fatalf("filtered = %#v, want only gpt-5", filtered)
+	}
+}


### PR DESCRIPTION
## Summary
- After live discovery models are merged into management availability, filter them by the effective channel-group `allowed-models` list so plaza/catalog match the channel-groups editor.
- Load each tenant's DB-backed routing config for management model availability and public `/v1/models` / request restriction (previously only system `cfg.Routing` was used).
- Regression coverage for default-group filtering and tenant isolation of system routing.

## Root cause
On tenant **蹬的飞快**, default group only allowed `grok-4.5` (and related grok entries) in channel-groups, but plaza/catalog still showed `grok-composer-2.5-fast` because xAI live discovery is appended after `CanServe` and skipped `AllowedModels`.

## Test plan
- [x] `go test ./internal/management/modelcatalog/ ./internal/api/ ./internal/api/handlers/management/`
- [x] `./scripts/ci-pr.sh`
- [ ] After deploy: on tenant 蹬的飞快, channel-groups only checks one model → plaza/catalog show the same set only