### PR TITLE
fix: restore full model list in channel-group editor picker

### DIFF
--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -68,12 +68,35 @@ func queryAlias(c *gin.Context, primary, fallback string) string {
 	return value
 }
 
+// queryIgnoreGroupAllowedModels is set by the channel-group editor so the picker
+// lists every model the group's channels can serve, not only the saved allow-list.
+// Plaza/catalog omit this flag and keep AllowedModels filtering.
+func queryIgnoreGroupAllowedModels(c *gin.Context) bool {
+	raw := strings.TrimSpace(queryAlias(c, "ignore_group_allowed_models", "ignore-group-allowed-models"))
+	if raw == "" {
+		return false
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func availabilityFilterOptionsFromQuery(c *gin.Context) modelcatalog.AvailabilityFilterOptions {
+	return modelcatalog.AvailabilityFilterOptions{
+		IgnoreGroupAllowedModels: queryIgnoreGroupAllowedModels(c),
+	}
+}
+
 // GetConfiguredModelAvailability returns the currently configured and serviceable
 // model IDs with pricing/metadata and active_metadata for owner/source filtering.
 func (h *ModelsHandler) GetConfiguredModelAvailability(c *gin.Context) {
 	c.JSON(http.StatusOK, h.service(c).ConfiguredAvailability(
 		queryAlias(c, "allowed_channels", "allowed-channels"),
 		queryAlias(c, "allowed_channel_groups", "allowed-channel-groups"),
+		availabilityFilterOptionsFromQuery(c),
 	))
 }
 
@@ -83,6 +106,7 @@ func (h *ModelsHandler) GetModels(c *gin.Context) {
 	c.JSON(http.StatusOK, h.service(c).Models(
 		queryAlias(c, "allowed_channels", "allowed-channels"),
 		queryAlias(c, "allowed_channel_groups", "allowed-channel-groups"),
+		availabilityFilterOptionsFromQuery(c),
 	))
 }
 

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -14,6 +14,21 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
+// AvailabilityFilterOptions tunes management model listing for specific UI paths.
+type AvailabilityFilterOptions struct {
+	// IgnoreGroupAllowedModels skips channel-group AllowedModels filtering so the
+	// channel-group editor can show every model the group's channels can serve.
+	// Plaza/catalog leave this false so AllowedModels still control display.
+	IgnoreGroupAllowedModels bool
+}
+
+func firstAvailabilityFilterOptions(opts []AvailabilityFilterOptions) AvailabilityFilterOptions {
+	if len(opts) > 0 {
+		return opts[0]
+	}
+	return AvailabilityFilterOptions{}
+}
+
 // Availability contract:
 // - Owner: model availability query boundary.
 // - Responsibility: turn registry state plus stored capabilities into management-facing availability DTOs.
@@ -23,7 +38,8 @@ import (
 // Management surfaces (plaza, catalog) still need the same live list as the
 // auth-file models panel, so we merge the provider discovery cache here on
 // every read (auto-warm on miss).
-func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
+func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw string, opts ...AvailabilityFilterOptions) map[string]any {
+	filterOpts := firstAvailabilityFilterOptions(opts)
 	modelRegistry := registry.GetGlobalRegistry()
 	authByID := s.authByID()
 	discoveryByProvider := s.sharedDiscoveryByProvider(false)
@@ -38,7 +54,7 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		authByID,
 		ownerMappings,
 	)
-	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw)
+	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw, filterOpts)
 	usesMappedOwners := false
 	var ownerKeys map[string]bool
 	if shouldUseDefaultMappedOwnerScope(allowedChannelsRaw, allowedGroupsRaw) {
@@ -52,11 +68,12 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	// drop stale rows again, then append the live discovery list.
 	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings)
 	// Live discovery models skip CanServe (not registry-backed). Still honor the
-	// tenant channel-group allowed-models list so plaza/catalog match the editor.
-	allModels = s.filterModelsByRoutingAllowedModels(
-		appendSharedDiscoveryModels(allModels, discoveryByProvider),
-		allowedGroupsRaw,
-	)
+	// tenant channel-group allowed-models list so plaza/catalog match the editor,
+	// unless the channel-group editor asks for the full channel-servable set.
+	allModels = appendSharedDiscoveryModels(allModels, discoveryByProvider)
+	if !filterOpts.IgnoreGroupAllowedModels {
+		allModels = s.filterModelsByRoutingAllowedModels(allModels, allowedGroupsRaw)
+	}
 
 	allConfigRows := modelconfigsettings.ListAllConfigsForTenant(s.tenantID)
 	configByID := make(map[string]usage.ModelConfigRow, len(allConfigRows))
@@ -128,7 +145,8 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	}
 }
 
-func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string) map[string]any {
+func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string, opts ...AvailabilityFilterOptions) map[string]any {
+	filterOpts := firstAvailabilityFilterOptions(opts)
 	modelRegistry := registry.GetGlobalRegistry()
 	authByID := s.authByID()
 	discoveryByProvider := s.sharedDiscoveryByProvider(false)
@@ -140,12 +158,12 @@ func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string) map[string
 		authByID,
 		ownerMappings,
 	)
-	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw)
+	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw, filterOpts)
 	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings)
-	allModels = s.filterModelsByRoutingAllowedModels(
-		appendSharedDiscoveryModels(allModels, discoveryByProvider),
-		allowedGroupsRaw,
-	)
+	allModels = appendSharedDiscoveryModels(allModels, discoveryByProvider)
+	if !filterOpts.IgnoreGroupAllowedModels {
+		allModels = s.filterModelsByRoutingAllowedModels(allModels, allowedGroupsRaw)
+	}
 
 	pricingMap := usage.GetAllModelPricingForTenant(s.tenantID)
 	filteredModels := make([]map[string]any, len(allModels))
@@ -513,12 +531,12 @@ func registryModelInfoAsOpenAIModel(info *registry.ModelInfo) map[string]any {
 	return model
 }
 
-func (s *Service) effectiveModels(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string) []map[string]any {
-	filtered := s.filterModelsByScopes(models, allowedChannelsRaw, allowedGroupsRaw)
+func (s *Service) effectiveModels(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string, opts AvailabilityFilterOptions) []map[string]any {
+	filtered := s.filterModelsByScopes(models, allowedChannelsRaw, allowedGroupsRaw, opts)
 	return s.withScopedModelConfigRows(filtered, allowedChannelsRaw, allowedGroupsRaw)
 }
 
-func (s *Service) filterModelsByScopes(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string) []map[string]any {
+func (s *Service) filterModelsByScopes(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string, opts AvailabilityFilterOptions) []map[string]any {
 	allowedChannelsRaw = strings.TrimSpace(allowedChannelsRaw)
 	allowedGroups := internalrouting.ParseNormalizedSet(strings.TrimSpace(allowedGroupsRaw), internalrouting.NormalizeGroupName)
 	if s == nil || s.authManager == nil {
@@ -543,13 +561,16 @@ func (s *Service) filterModelsByScopes(models []map[string]any, allowedChannelsR
 		}
 	}
 
+	serveOpts := coreauth.ServeModelScopeOptions{
+		IgnoreGroupAllowedModels: opts.IgnoreGroupAllowedModels,
+	}
 	filtered := make([]map[string]any, 0, len(models))
 	for _, model := range models {
 		id, _ := model["id"].(string)
 		if id == "" {
 			continue
 		}
-		if s.authManager.CanServeModelWithScopesForTenant(s.tenantID, id, allowedChannels, allowedGroups, "") {
+		if s.authManager.CanServeModelWithScopesForTenantOpts(s.tenantID, id, allowedChannels, allowedGroups, "", serveOpts) {
 			filtered = append(filtered, model)
 		}
 	}

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -328,7 +328,7 @@ func TestFilterModelsByScopesAlwaysScopesToTenantWithoutChannelFilters(t *testin
 		{"id": systemModelID},
 		{"id": tenantModelID},
 	}
-	filtered := svc.filterModelsByScopes(models, "", "")
+	filtered := svc.filterModelsByScopes(models, "", "", AvailabilityFilterOptions{})
 	if len(filtered) != 1 || filtered[0]["id"] != tenantModelID {
 		t.Fatalf("filtered = %#v, want only tenant model", filtered)
 	}
@@ -524,4 +524,87 @@ func TestFilterModelsByRoutingAllowedModelsHonorsNamedGroup(t *testing.T) {
 	if len(filtered) != 1 || filtered[0]["id"] != "gpt-5" {
 		t.Fatalf("filtered = %#v, want only gpt-5", filtered)
 	}
+}
+
+func TestConfiguredAvailabilityIgnoreGroupAllowedModelsKeepsFullChannelSet(t *testing.T) {
+	// Channel-group editor must list every channel-servable model for checkbox
+	// selection, even when AllowedModels already restricts plaza/catalog.
+	// Use a non-discovery provider so registry rows are not stripped as static
+	// claude/codex/xai discovery placeholders.
+	const (
+		authID   = "editor-picker-auth"
+		tenantID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+		modelA   = "editor-picker-model-a"
+		modelB   = "editor-picker-model-b"
+	)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(authID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(authID) })
+	modelRegistry.RegisterClient(authID, "opencode-go", []*registry.ModelInfo{
+		{ID: modelA, Object: "model", OwnedBy: "opencode"},
+		{ID: modelB, Object: "model", OwnedBy: "opencode"},
+	})
+
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:          "default",
+					AllowedModels: []string{modelA},
+				},
+			},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfigForTenant(tenantID, cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: authID, TenantID: tenantID, Provider: "opencode-go", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	svc := NewForTenant(tenantID, cfg, manager)
+
+	restricted := svc.ConfiguredAvailability("", "default")
+	restrictedIDs := configuredAvailabilityIDs(restricted)
+	if len(restrictedIDs) != 1 || restrictedIDs[0] != modelA {
+		t.Fatalf("restricted availability = %v, want only %s", restrictedIDs, modelA)
+	}
+
+	editor := svc.ConfiguredAvailability("", "default", AvailabilityFilterOptions{IgnoreGroupAllowedModels: true})
+	editorIDs := configuredAvailabilityIDs(editor)
+	if len(editorIDs) != 2 {
+		t.Fatalf("editor availability = %v, want both channel-servable models", editorIDs)
+	}
+	want := map[string]bool{modelA: true, modelB: true}
+	for _, id := range editorIDs {
+		if !want[id] {
+			t.Fatalf("editor availability unexpected id %q in %v", id, editorIDs)
+		}
+	}
+}
+
+func configuredAvailabilityIDs(result map[string]any) []string {
+	data, _ := result["data"].([]map[string]any)
+	if data == nil {
+		if raw, ok := result["data"].([]any); ok {
+			out := make([]string, 0, len(raw))
+			for _, item := range raw {
+				entry, _ := item.(map[string]any)
+				if id, _ := entry["id"].(string); id != "" {
+					out = append(out, id)
+				}
+			}
+			return out
+		}
+		return nil
+	}
+	out := make([]string, 0, len(data))
+	for _, entry := range data {
+		if id, _ := entry["id"].(string); id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
 }

--- a/sdk/cliproxy/auth/routing_groups.go
+++ b/sdk/cliproxy/auth/routing_groups.go
@@ -64,11 +64,23 @@ func (m *Manager) KnownChannelGroupsForTenant(tenantID string) map[string]struct
 	return out
 }
 
+// ServeModelScopeOptions tunes CanServeModelWithScopes* for management UI paths.
+type ServeModelScopeOptions struct {
+	// IgnoreGroupAllowedModels skips channel-group AllowedModels checks so the
+	// channel-group editor can list every model the group's channels can serve,
+	// not only models already on the saved allow-list.
+	IgnoreGroupAllowedModels bool
+}
+
 // CanServeModelWithScopes reports whether at least one active auth can serve the model under the given restrictions.
 func (m *Manager) CanServeModelWithScopes(modelID string, allowedChannels, allowedGroups map[string]struct{}, routeGroup string) bool {
 	return m.CanServeModelWithScopesForTenant(defaultTenantID, modelID, allowedChannels, allowedGroups, routeGroup)
 }
 func (m *Manager) CanServeModelWithScopesForTenant(tenantID, modelID string, allowedChannels, allowedGroups map[string]struct{}, routeGroup string) bool {
+	return m.CanServeModelWithScopesForTenantOpts(tenantID, modelID, allowedChannels, allowedGroups, routeGroup, ServeModelScopeOptions{})
+}
+
+func (m *Manager) CanServeModelWithScopesForTenantOpts(tenantID, modelID string, allowedChannels, allowedGroups map[string]struct{}, routeGroup string, opts ServeModelScopeOptions) bool {
 	tenantID = normalizedTenantID(tenantID)
 	modelID = strings.TrimSpace(modelID)
 	if modelID == "" || m == nil {
@@ -93,7 +105,7 @@ func (m *Manager) CanServeModelWithScopesForTenant(tenantID, modelID string, all
 		if !authInRouteGroup(cfg, candidate, selectionRouteGroup) {
 			continue
 		}
-		if candidateSupportsModel(cfg, registryRef, candidate, modelID, selectionRouteGroup, allowedGroups) {
+		if candidateSupportsModelOpts(cfg, registryRef, candidate, modelID, selectionRouteGroup, allowedGroups, opts) {
 			return true
 		}
 	}

--- a/sdk/cliproxy/auth/routing_groups_scope.go
+++ b/sdk/cliproxy/auth/routing_groups_scope.go
@@ -262,12 +262,16 @@ func prepareCandidateForSelection(cfg *runtimeConfigSnapshot, auth *Auth, routeG
 }
 
 func candidateSupportsModel(cfg *runtimeConfigSnapshot, registryRef ModelRegistry, auth *Auth, modelID string, routeGroup string, allowedGroups map[string]struct{}) bool {
+	return candidateSupportsModelOpts(cfg, registryRef, auth, modelID, routeGroup, allowedGroups, ServeModelScopeOptions{})
+}
+
+func candidateSupportsModelOpts(cfg *runtimeConfigSnapshot, registryRef ModelRegistry, auth *Auth, modelID string, routeGroup string, allowedGroups map[string]struct{}, opts ServeModelScopeOptions) bool {
 	modelID = strings.TrimSpace(modelID)
 	if auth == nil || modelID == "" {
 		return false
 	}
 	groups := authGroups(cfg, auth)
-	if !modelAllowedByRoutingGroupScopes(cfg, modelID, groups, routeGroup, allowedGroups) {
+	if !opts.IgnoreGroupAllowedModels && !modelAllowedByRoutingGroupScopes(cfg, modelID, groups, routeGroup, allowedGroups) {
 		return false
 	}
 	if registryRef == nil {


### PR DESCRIPTION
## Summary
- #680 correctly enforced channel-group `AllowedModels` for plaza/catalog, but the same filter also collapsed the **channel-group editor** model checkbox list to the saved allow-list (e.g. only `grok-4.5` after unchecking `grok-composer-2.5-fast`).
- Management `/models` and `/models/configured-availability` now accept `ignore_group_allowed_models=1` so the editor can list every model the group's channels can serve.
- Plaza/catalog omit the flag and keep `AllowedModels` enforcement (including live discovery post-filter).

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] `go test ./internal/management/modelcatalog/ ./sdk/cliproxy/auth/ ./internal/api/handlers/management/`
- [x] New unit test: editor ignore flag returns full channel set; restricted path still filters

## Deploy note
Frontend companion PR in codeProxy must ship together for the editor to pass the query flag.