### PR TITLE
fix: filter path-availability by channel-group AllowedModels

### DIFF
--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -492,6 +492,62 @@ func TestFilterModelsByRoutingAllowedModelsHonorsDefaultGroupList(t *testing.T) 
 	}
 }
 
+func TestPathAvailabilityFiltersLiveDiscoveryByDefaultAllowedModels(t *testing.T) {
+	// Path availability used to append xAI/codex/claude live discovery after
+	// CanServe without AllowedModels, so plaza/catalog re-introduced blocked
+	// models via path merge. Discovery rows must be filtered the same way.
+	// Use empty tenant so tenantRoutingConfig falls back to cfg.Routing (no DB).
+	const (
+		allowedModelID = "grok-4.5"
+		blockedModelID = "grok-composer-2.5-fast"
+		authID         = "path-allowed-xai-auth"
+	)
+	managementauthfiles.ResetDiscoveryCacheForTest()
+	t.Cleanup(managementauthfiles.ResetDiscoveryCacheForTest)
+	managementauthfiles.StoreDiscoveryCacheForTest("", "xai", []*registry.ModelInfo{
+		{ID: allowedModelID, Object: "model", OwnedBy: "xAI", Type: "xai"},
+		{ID: blockedModelID, Object: "model", OwnedBy: "xAI", Type: "xai"},
+	})
+
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:          "default",
+					AllowedModels: []string{allowedModelID},
+				},
+			},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: authID, Provider: "xai", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register xai auth: %v", err)
+	}
+
+	result := New(cfg, manager).PathAvailability()
+	// PathAvailability returns typed rows, not map[string]any.
+	rows, ok := result["data"].([]modelPathAvailabilityResponse)
+	if !ok {
+		t.Fatalf("data type = %T, want []modelPathAvailabilityResponse", result["data"])
+	}
+	ids := make(map[string]struct{}, len(rows))
+	for _, item := range rows {
+		if item.ID != "" {
+			ids[item.ID] = struct{}{}
+		}
+	}
+	if _, ok := ids[allowedModelID]; !ok {
+		t.Fatalf("path availability missing allowed model %q; ids=%v", allowedModelID, ids)
+	}
+	if _, ok := ids[blockedModelID]; ok {
+		t.Fatalf("path availability leaked blocked model %q; ids=%v", blockedModelID, ids)
+	}
+}
+
 func TestFilterModelsByRoutingAllowedModelsEmptyMeansUnrestricted(t *testing.T) {
 	svc := NewForTenant("", &config.Config{
 		Routing: config.RoutingConfig{

--- a/internal/management/modelcatalog/path_availability.go
+++ b/internal/management/modelcatalog/path_availability.go
@@ -34,9 +34,18 @@ func (s *Service) PathAvailability() map[string]any {
 		s.authGroupOwnerMappingMap(),
 	)
 	openaiModels = s.modelRootRouteScopedModels(openaiModels, routingConfig)
-	openaiModels = appendSharedDiscoveryModels(openaiModels, discoveryByProvider)
+	// Live discovery is not registry-backed, so CanServe cannot enforce
+	// channel-group AllowedModels for those rows. Filter after merge so plaza
+	// and catalog path enrichment match configured-availability.
+	openaiModels = s.filterModelsByRoutingAllowedModels(
+		appendSharedDiscoveryModels(openaiModels, discoveryByProvider),
+		"",
+	)
 	appendModelPaths(items, openaiModels, "/", rootOpenAICapabilities)
-	appendModelPaths(items, s.modelRootRouteScopedModels(modelRegistry.GetAvailableModels("gemini"), routingConfig), "/", rootGeminiCapabilities)
+	appendModelPaths(items, s.filterModelsByRoutingAllowedModels(
+		s.modelRootRouteScopedModels(modelRegistry.GetAvailableModels("gemini"), routingConfig),
+		"",
+	), "/", rootGeminiCapabilities)
 
 	routes := []modelPathRouteResponse{
 		{
@@ -58,8 +67,14 @@ func (s *Service) PathAvailability() map[string]any {
 			ReadOnly:     false,
 			Capabilities: capabilities,
 		})
-		appendModelPaths(items, s.modelPathRouteScopedModels(modelRegistry.GetAvailableModels("openai"), route.Group), route.Path, openAIV1Capabilities(route.Path))
-		appendModelPaths(items, s.modelPathRouteScopedModels(modelRegistry.GetAvailableModels("gemini"), route.Group), route.Path, geminiV1BetaCapabilities(route.Path))
+		appendModelPaths(items, s.filterModelsByRoutingAllowedModels(
+			s.modelPathRouteScopedModels(modelRegistry.GetAvailableModels("openai"), route.Group),
+			route.Group,
+		), route.Path, openAIV1Capabilities(route.Path))
+		appendModelPaths(items, s.filterModelsByRoutingAllowedModels(
+			s.modelPathRouteScopedModels(modelRegistry.GetAvailableModels("gemini"), route.Group),
+			route.Group,
+		), route.Path, geminiV1BetaCapabilities(route.Path))
 	}
 
 	return map[string]any{


### PR DESCRIPTION
## Summary
- Live discovery models (xAI / codex / claude) were appended into path-availability after `CanServe`, which does not enforce channel-group `AllowedModels` for non-registry rows.
- Root and path-route lists are now filtered with `filterModelsByRoutingAllowedModels` after discovery merge so plaza/catalog path enrichment matches configured-availability.
- Adds `TestPathAvailabilityFiltersLiveDiscoveryByDefaultAllowedModels`.

## Test plan
- [x] `go test ./internal/management/modelcatalog/ -count=1`
- [x] `go test ./internal/api/handlers/management/ -count=1`
- [x] `go test ./internal/api/routes/ -count=1 -run TestRegisterManagementRouteTable`