### PR TITLE
fix(usage): recognize Grok session headers in request logs

### DIFF
--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -448,9 +448,14 @@ func sessionDetailString(value gjson.Result) string {
 func sessionDetailKeyRank(key string) int {
 	normalized := strings.NewReplacer("-", "_", " ", "_").Replace(strings.ToLower(strings.TrimSpace(key)))
 	switch normalized {
-	case "session_id", "sessionid", "x_session_id", "x_sessionid":
+	// Rank 0: stable client session ids. Grok/xAI clients send X-Grok-Session-Id
+	// rather than generic Session-Id; without it request_log_content.session_id
+	// stays empty for the bulk of Grok traffic and session-level analytics break.
+	case "session_id", "sessionid", "x_session_id", "x_sessionid",
+		"x_grok_session_id", "x_grok_sessionid":
 		return 0
-	case "conversation_id", "conversationid", "x_conversation_id", "x_conversationid", "openai_conversation_id":
+	case "conversation_id", "conversationid", "x_conversation_id", "x_conversationid",
+		"openai_conversation_id", "x_grok_conv_id", "x_grok_convid":
 		return 1
 	default:
 		return 99

--- a/internal/usage/request_log_series_test.go
+++ b/internal/usage/request_log_series_test.go
@@ -8,3 +8,28 @@ func TestExtractSessionIDFromDetailsRecognizesXSessionID(t *testing.T) {
 		t.Fatalf("session_id = %q, want zcode-session", got)
 	}
 }
+
+func TestExtractSessionIDFromDetailsRecognizesGrokSessionHeaders(t *testing.T) {
+	t.Run("x-grok-session-id", func(t *testing.T) {
+		detail := `{"client":{"headers":{"X-Grok-Session-Id":["019f5a53-5c9c-7222-a74c-3dbab60349d3"],"X-Grok-Conv-Id":["should-not-win"]}}}`
+		want := "019f5a53-5c9c-7222-a74c-3dbab60349d3"
+		if got := extractSessionIDFromDetails(detail); got != want {
+			t.Fatalf("session_id = %q, want %s", got, want)
+		}
+	})
+
+	t.Run("x-grok-conv-id fallback", func(t *testing.T) {
+		detail := `{"client":{"fingerprint_headers":{"X-Grok-Conv-Id":["019f5a53-5c9c-7222-a74c-3dbab60349d3"]}}}`
+		want := "019f5a53-5c9c-7222-a74c-3dbab60349d3"
+		if got := extractSessionIDFromDetails(detail); got != want {
+			t.Fatalf("session_id = %q, want %s", got, want)
+		}
+	})
+
+	t.Run("generic session still beats grok conv", func(t *testing.T) {
+		detail := `{"client":{"headers":{"Session-Id":["generic-session"],"X-Grok-Conv-Id":["grok-conv"]}}}`
+		if got := extractSessionIDFromDetails(detail); got != "generic-session" {
+			t.Fatalf("session_id = %q, want generic-session", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Session-sticky already binds Grok traffic on `X-Grok-Session-Id` / `X-Grok-Conv-Id` (deployed).
- `request_log_content.session_id` extraction still ignored those keys, so Grok request logs left `session_id` empty and sticky skew was hard to audit from the management UI / DB.
- Teach `sessionDetailKeyRank` to treat Grok session headers as rank-0 / rank-1 session keys, with tests.

## Test plan

- [x] `go test ./internal/usage/ -count=1 -run TestExtractSessionIDFromDetails`
- [x] `go test ./sdk/api/handlers/ -count=1 -run 'SessionSticky|GrokSession'`
- [x] `go test ./sdk/cliproxy/auth/ -count=1 -run SessionSticky`
- [ ] After deploy: Grok traffic for tenant 蹬的飞快 should populate `request_log_content.session_id` from `X-Grok-Session-Id`