### PR TITLE
fix: treat xAI 402 balance exhausted as weekly quota cooldown

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -100,7 +100,8 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		recorder.AppendResponseChunk(b)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b), headers: httpResp.Header.Clone()}
+		// Parse 402 balance-exhausted into weekly quota cooldown metadata.
+		err = newXAIStatusErr(httpResp.StatusCode, b, httpResp.Header)
 		return resp, err
 	}
 	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
@@ -188,7 +189,8 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 		recorder.AppendResponseChunk(data)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
 		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(data))
-		err = statusErr{code: httpResp.StatusCode, msg: string(data), headers: httpResp.Header.Clone()}
+		// Parse 402 balance-exhausted into weekly quota cooldown metadata.
+		err = newXAIStatusErr(httpResp.StatusCode, data, httpResp.Header)
 		return nil, err
 	}
 

--- a/internal/runtime/executor/xai_quota.go
+++ b/internal/runtime/executor/xai_quota.go
@@ -1,0 +1,126 @@
+package executor
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	// xAI SuperGrok weekly included usage window (matches frontend XAI_WEEKLY_WINDOW_SECONDS).
+	xaiWeeklyWindowMinutes = 10080
+	xaiWeeklyWindowLabel   = "week"
+	xaiWeeklyCooldownDefault = 7 * 24 * time.Hour
+)
+
+func newXAIStatusErr(statusCode int, body []byte, headers ...http.Header) statusErr {
+	err := statusErr{
+		code:         statusCode,
+		msg:          string(body),
+		upstreamBody: append([]byte(nil), body...),
+	}
+	var header http.Header
+	if len(headers) > 0 && headers[0] != nil {
+		header = headers[0].Clone()
+		err.headers = header
+	}
+	if window, minutes := parseXAIQuotaWindow(statusCode, body); window != "" {
+		err.quotaWindow = window
+		err.quotaWindowMinutes = minutes
+	}
+	if retryAfter := parseXAIRetryAfter(statusCode, body, header, time.Now()); retryAfter != nil {
+		err.retryAfter = retryAfter
+	}
+	return err
+}
+
+// parseXAIQuotaWindow maps known xAI balance-exhausted 402s onto the weekly
+// included-usage window. Grok Build returns HTTP 402 with
+// {"error":"Grok Build usage balance exhausted"} when the weekly allowance is
+// spent; treating that as a generic 30m payment_required cooldown causes
+// thrashing until the real weekly reset.
+func parseXAIQuotaWindow(statusCode int, errorBody []byte) (string, int) {
+	if statusCode != http.StatusPaymentRequired {
+		return "", 0
+	}
+	if !isXAIUsageBalanceExhausted(errorBody) {
+		return "", 0
+	}
+	return xaiWeeklyWindowLabel, xaiWeeklyWindowMinutes
+}
+
+func parseXAIRetryAfter(statusCode int, errorBody []byte, header http.Header, now time.Time) *time.Duration {
+	if statusCode != http.StatusPaymentRequired && statusCode != http.StatusTooManyRequests {
+		return nil
+	}
+	if retryAfter := parseHTTPRetryAfterHeader(header, now); retryAfter != nil {
+		return retryAfter
+	}
+	if len(errorBody) > 0 {
+		if resetsAt := gjson.GetBytes(errorBody, "error.resets_at").Int(); resetsAt > 0 {
+			resetAtTime := time.Unix(resetsAt, 0)
+			if resetAtTime.After(now) {
+				retryAfter := resetAtTime.Sub(now)
+				return &retryAfter
+			}
+		}
+		if resetsInSeconds := gjson.GetBytes(errorBody, "error.resets_in_seconds").Int(); resetsInSeconds > 0 {
+			retryAfter := time.Duration(resetsInSeconds) * time.Second
+			return &retryAfter
+		}
+	}
+	// Weekly balance exhausted without an explicit reset: cool down until the
+	// typical weekly window would roll rather than probing every 30 minutes.
+	if statusCode == http.StatusPaymentRequired && isXAIUsageBalanceExhausted(errorBody) {
+		retryAfter := xaiWeeklyCooldownDefault
+		return &retryAfter
+	}
+	return nil
+}
+
+func isXAIUsageBalanceExhausted(errorBody []byte) bool {
+	if len(errorBody) == 0 {
+		return false
+	}
+	if msg := strings.TrimSpace(gjson.GetBytes(errorBody, "error").String()); isXAIUsageBalanceExhaustedText(msg) {
+		return true
+	}
+	if msg := strings.TrimSpace(gjson.GetBytes(errorBody, "error.message").String()); isXAIUsageBalanceExhaustedText(msg) {
+		return true
+	}
+	return isXAIUsageBalanceExhaustedText(string(errorBody))
+}
+
+func isXAIUsageBalanceExhaustedText(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "" {
+		return false
+	}
+	return strings.Contains(lower, "usage balance exhausted") ||
+		strings.Contains(lower, "balance exhausted")
+}
+
+func parseHTTPRetryAfterHeader(header http.Header, now time.Time) *time.Duration {
+	if header == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(header.Get("Retry-After"))
+	if raw == "" {
+		return nil
+	}
+	if seconds, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		if seconds <= 0 {
+			return nil
+		}
+		retryAfter := time.Duration(seconds) * time.Second
+		return &retryAfter
+	}
+	if when, err := http.ParseTime(raw); err == nil && when.After(now) {
+		retryAfter := when.Sub(now)
+		return &retryAfter
+	}
+	return nil
+}

--- a/internal/runtime/executor/xai_quota_test.go
+++ b/internal/runtime/executor/xai_quota_test.go
@@ -1,0 +1,72 @@
+package executor
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewXAIStatusErr_BalanceExhaustedMapsToWeeklyQuota(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"error":"Grok Build usage balance exhausted"}`)
+	err := newXAIStatusErr(http.StatusPaymentRequired, body)
+
+	if err.StatusCode() != http.StatusPaymentRequired {
+		t.Fatalf("StatusCode() = %d, want %d", err.StatusCode(), http.StatusPaymentRequired)
+	}
+	window, minutes := err.QuotaWindow()
+	if window != "week" || minutes != 10080 {
+		t.Fatalf("QuotaWindow() = %q/%d, want week/10080", window, minutes)
+	}
+	retryAfter := err.RetryAfter()
+	if retryAfter == nil {
+		t.Fatal("RetryAfter() = nil, want weekly cooldown")
+	}
+	if *retryAfter != 7*24*time.Hour {
+		t.Fatalf("RetryAfter() = %v, want 7d", *retryAfter)
+	}
+}
+
+func TestNewXAIStatusErr_PrefersRetryAfterHeader(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"error":"Grok Build usage balance exhausted"}`)
+	headers := http.Header{"Retry-After": []string{"3600"}}
+	err := newXAIStatusErr(http.StatusPaymentRequired, body, headers)
+
+	retryAfter := err.RetryAfter()
+	if retryAfter == nil {
+		t.Fatal("RetryAfter() = nil")
+	}
+	if *retryAfter != time.Hour {
+		t.Fatalf("RetryAfter() = %v, want 1h from header", *retryAfter)
+	}
+	window, minutes := err.QuotaWindow()
+	if window != "week" || minutes != 10080 {
+		t.Fatalf("QuotaWindow() = %q/%d, want week/10080", window, minutes)
+	}
+}
+
+func TestNewXAIStatusErr_Generic402HasNoWeeklyQuota(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"error":"payment required"}`)
+	err := newXAIStatusErr(http.StatusPaymentRequired, body)
+	window, minutes := err.QuotaWindow()
+	if window != "" || minutes != 0 {
+		t.Fatalf("QuotaWindow() = %q/%d, want empty", window, minutes)
+	}
+	if got := err.RetryAfter(); got != nil {
+		t.Fatalf("RetryAfter() = %v, want nil for generic 402", *got)
+	}
+}
+
+func TestIsXAIUsageBalanceExhausted_NestedMessage(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"error":{"message":"Grok Build usage balance exhausted","type":"usage_balance"}}`)
+	if !isXAIUsageBalanceExhausted(body) {
+		t.Fatal("expected nested error.message to match")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -235,54 +235,39 @@ func (s cooldownService) applyModelFailureLocked(auth *Auth, result Result, now 
 	}
 
 	statusCode := statusCodeFromResult(result.Error)
-	switch statusCode {
-	case 401:
-		next := now.Add(30 * time.Minute)
-		state.NextRetryAfter = next
-		effects.suspendReason = "unauthorized"
-		effects.shouldSuspendModel = true
-	case 402, 403:
-		next := now.Add(30 * time.Minute)
-		state.NextRetryAfter = next
-		effects.suspendReason = "payment_required"
-		effects.shouldSuspendModel = true
-	case 404:
-		next := now.Add(12 * time.Hour)
-		state.NextRetryAfter = next
-		effects.suspendReason = "not_found"
-		effects.shouldSuspendModel = true
-	case 429:
-		var next time.Time
-		backoffLevel := state.Quota.BackoffLevel
-		if result.RetryAfter != nil {
-			next = now.Add(*result.RetryAfter)
-		} else {
-			cooldown, nextLevel := nextQuotaCooldown(backoffLevel, quotaCooldownDisabledForAuth(auth))
-			if cooldown > 0 {
-				next = now.Add(cooldown)
+	// xAI Grok Build returns HTTP 402 for weekly usage balance exhaustion.
+	// Route those as quota cooldowns (window/retry metadata from executor),
+	// not the generic 30m payment_required probe loop.
+	if statusCode == 402 && isQuotaExhaustionError(result.Error, result.RetryAfter) {
+		applyModelQuotaFailureLocked(auth, state, result, now, effects)
+	} else {
+		switch statusCode {
+		case 401:
+			next := now.Add(30 * time.Minute)
+			state.NextRetryAfter = next
+			effects.suspendReason = "unauthorized"
+			effects.shouldSuspendModel = true
+		case 402, 403:
+			next := now.Add(30 * time.Minute)
+			state.NextRetryAfter = next
+			effects.suspendReason = "payment_required"
+			effects.shouldSuspendModel = true
+		case 404:
+			next := now.Add(12 * time.Hour)
+			state.NextRetryAfter = next
+			effects.suspendReason = "not_found"
+			effects.shouldSuspendModel = true
+		case 429:
+			applyModelQuotaFailureLocked(auth, state, result, now, effects)
+		case 408, 500, 502, 503, 504:
+			if quotaCooldownDisabledForAuth(auth) {
+				state.NextRetryAfter = time.Time{}
+			} else {
+				state.NextRetryAfter = now.Add(1 * time.Minute)
 			}
-			backoffLevel = nextLevel
-		}
-		state.NextRetryAfter = next
-		state.Quota = QuotaState{
-			Exceeded:      true,
-			Reason:        "quota",
-			Window:        result.Error.QuotaWindow,
-			WindowMinutes: result.Error.QuotaWindowMinutes,
-			NextRecoverAt: next,
-			BackoffLevel:  backoffLevel,
-		}
-		effects.suspendReason = "quota"
-		effects.shouldSuspendModel = true
-		effects.setModelQuota = true
-	case 408, 500, 502, 503, 504:
-		if quotaCooldownDisabledForAuth(auth) {
+		default:
 			state.NextRetryAfter = time.Time{}
-		} else {
-			state.NextRetryAfter = now.Add(1 * time.Minute)
 		}
-	default:
-		state.NextRetryAfter = time.Time{}
 	}
 
 	auth.Status = StatusError
@@ -292,6 +277,75 @@ func (s cooldownService) applyModelFailureLocked(auth *Auth, result Result, now 
 
 func isResponseStreamIncompleteError(err *Error) bool {
 	return err != nil && strings.TrimSpace(err.Code) == "response_stream_incomplete"
+}
+
+// applyModelQuotaFailureLocked records a provider quota exhaustion against a model.
+// Used for classic 429s and for quota-like 402s (e.g. xAI weekly balance exhausted).
+func applyModelQuotaFailureLocked(auth *Auth, state *ModelState, result Result, now time.Time, effects *resultStateEffects) {
+	if state == nil {
+		return
+	}
+	var next time.Time
+	backoffLevel := state.Quota.BackoffLevel
+	if result.RetryAfter != nil {
+		next = now.Add(*result.RetryAfter)
+	} else if result.Error != nil && result.Error.QuotaWindowMinutes > 0 {
+		// Prefer the full provider window when known (week/5h) over short exponential probes.
+		next = now.Add(time.Duration(result.Error.QuotaWindowMinutes) * time.Minute)
+	} else {
+		cooldown, nextLevel := nextQuotaCooldown(backoffLevel, quotaCooldownDisabledForAuth(auth))
+		if cooldown > 0 {
+			next = now.Add(cooldown)
+		}
+		backoffLevel = nextLevel
+	}
+	var window string
+	var windowMinutes int
+	if result.Error != nil {
+		window = result.Error.QuotaWindow
+		windowMinutes = result.Error.QuotaWindowMinutes
+	}
+	state.NextRetryAfter = next
+	state.Quota = QuotaState{
+		Exceeded:      true,
+		Reason:        "quota",
+		Window:        window,
+		WindowMinutes: windowMinutes,
+		NextRecoverAt: next,
+		BackoffLevel:  backoffLevel,
+	}
+	if result.Error != nil && result.Error.Message != "" {
+		state.StatusMessage = result.Error.Message
+	} else {
+		state.StatusMessage = "quota exhausted"
+	}
+	effects.suspendReason = "quota"
+	effects.shouldSuspendModel = true
+	effects.setModelQuota = true
+}
+
+// isQuotaExhaustionError reports whether a non-429 failure should still be treated
+// as quota exhaustion (window metadata and/or balance-exhausted body).
+func isQuotaExhaustionError(err *Error, retryAfter *time.Duration) bool {
+	if err == nil {
+		return false
+	}
+	if err.QuotaWindow != "" || err.QuotaWindowMinutes > 0 {
+		return true
+	}
+	if retryAfter != nil && *retryAfter > 0 && isUsageBalanceExhaustedMessage(err.Message) {
+		return true
+	}
+	return isUsageBalanceExhaustedMessage(err.Message)
+}
+
+func isUsageBalanceExhaustedMessage(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if lower == "" {
+		return false
+	}
+	return strings.Contains(lower, "usage balance exhausted") ||
+		strings.Contains(lower, "balance exhausted")
 }
 
 func (s cooldownService) applyRegistryEffects(result Result, effects resultStateEffects) {

--- a/sdk/cliproxy/auth/conductor_failure_state.go
+++ b/sdk/cliproxy/auth/conductor_failure_state.go
@@ -16,6 +16,12 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		}
 	}
 	statusCode := statusCodeFromResult(resultErr)
+	// 402 weekly balance exhausted (xAI Grok Build) is a quota event, not a
+	// short-lived payment_required probe. Keep generic 402/403 on 30m.
+	if statusCode == 402 && isQuotaExhaustionError(resultErr, retryAfter) {
+		applyAuthQuotaFailureState(auth, resultErr, retryAfter, now)
+		return
+	}
 	switch statusCode {
 	case 401:
 		auth.StatusMessage = "unauthorized"
@@ -27,25 +33,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.StatusMessage = "not_found"
 		auth.NextRetryAfter = now.Add(12 * time.Hour)
 	case 429:
-		auth.StatusMessage = "quota exhausted"
-		auth.Quota.Exceeded = true
-		auth.Quota.Reason = "quota"
-		if resultErr != nil {
-			auth.Quota.Window = resultErr.QuotaWindow
-			auth.Quota.WindowMinutes = resultErr.QuotaWindowMinutes
-		}
-		var next time.Time
-		if retryAfter != nil {
-			next = now.Add(*retryAfter)
-		} else {
-			cooldown, nextLevel := nextQuotaCooldown(auth.Quota.BackoffLevel, quotaCooldownDisabledForAuth(auth))
-			if cooldown > 0 {
-				next = now.Add(cooldown)
-			}
-			auth.Quota.BackoffLevel = nextLevel
-		}
-		auth.Quota.NextRecoverAt = next
-		auth.NextRetryAfter = next
+		applyAuthQuotaFailureState(auth, resultErr, retryAfter, now)
 	case 408, 500, 502, 503, 504:
 		auth.StatusMessage = "transient upstream error"
 		if quotaCooldownDisabledForAuth(auth) {
@@ -59,6 +47,38 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		}
 	}
 }
+
+func applyAuthQuotaFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
+	if auth == nil {
+		return
+	}
+	if resultErr != nil && resultErr.Message != "" {
+		auth.StatusMessage = resultErr.Message
+	} else {
+		auth.StatusMessage = "quota exhausted"
+	}
+	auth.Quota.Exceeded = true
+	auth.Quota.Reason = "quota"
+	if resultErr != nil {
+		auth.Quota.Window = resultErr.QuotaWindow
+		auth.Quota.WindowMinutes = resultErr.QuotaWindowMinutes
+	}
+	var next time.Time
+	if retryAfter != nil {
+		next = now.Add(*retryAfter)
+	} else if resultErr != nil && resultErr.QuotaWindowMinutes > 0 {
+		next = now.Add(time.Duration(resultErr.QuotaWindowMinutes) * time.Minute)
+	} else {
+		cooldown, nextLevel := nextQuotaCooldown(auth.Quota.BackoffLevel, quotaCooldownDisabledForAuth(auth))
+		if cooldown > 0 {
+			next = now.Add(cooldown)
+		}
+		auth.Quota.BackoffLevel = nextLevel
+	}
+	auth.Quota.NextRecoverAt = next
+	auth.NextRetryAfter = next
+}
+
 
 // nextQuotaCooldown returns the next cooldown duration and updated backoff level for repeated quota errors.
 func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) {

--- a/sdk/cliproxy/auth/quota_reconcile.go
+++ b/sdk/cliproxy/auth/quota_reconcile.go
@@ -486,16 +486,18 @@ func hasQuotaRuntimeState(statusMessage string, lastError *Error, unavailable bo
 		return true
 	}
 	if lastError != nil {
-		if lastError.HTTPStatus == http.StatusTooManyRequests {
+		// 429 and quota-like 402 (xAI weekly balance exhausted) are both local quota runtime.
+		if lastError.HTTPStatus == http.StatusTooManyRequests ||
+			(lastError.HTTPStatus == http.StatusPaymentRequired && (lastError.QuotaWindow != "" || isUsageBalanceExhaustedMessage(lastError.Message))) {
 			return true
 		}
 		text := strings.ToLower(strings.TrimSpace(lastError.Code + " " + lastError.Message))
-		if strings.Contains(text, "quota") || strings.Contains(text, "rate limit") || strings.Contains(text, "429") || strings.Contains(text, "cooldown") {
+		if strings.Contains(text, "quota") || strings.Contains(text, "rate limit") || strings.Contains(text, "429") || strings.Contains(text, "cooldown") || strings.Contains(text, "balance exhausted") {
 			return true
 		}
 	}
 	text := strings.ToLower(strings.TrimSpace(statusMessage))
-	return strings.Contains(text, "quota") || strings.Contains(text, "rate limit") || strings.Contains(text, "429") || strings.Contains(text, "cooldown")
+	return strings.Contains(text, "quota") || strings.Contains(text, "rate limit") || strings.Contains(text, "429") || strings.Contains(text, "cooldown") || strings.Contains(text, "balance exhausted")
 }
 
 func updateQuotaAuthRecoverAt(auth *Auth, next time.Time, now time.Time) bool {

--- a/sdk/cliproxy/auth/xai_402_quota_test.go
+++ b/sdk/cliproxy/auth/xai_402_quota_test.go
@@ -1,0 +1,190 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+type retryAfterQuotaErrorStub struct {
+	message      string
+	status       int
+	quotaWindow  string
+	quotaMinutes int
+	retryAfter   time.Duration
+}
+
+func (e *retryAfterQuotaErrorStub) Error() string { return e.message }
+func (e *retryAfterQuotaErrorStub) StatusCode() int {
+	return e.status
+}
+func (e *retryAfterQuotaErrorStub) QuotaWindow() (string, int) {
+	return e.quotaWindow, e.quotaMinutes
+}
+func (e *retryAfterQuotaErrorStub) RetryAfter() *time.Duration {
+	if e.retryAfter <= 0 {
+		return nil
+	}
+	d := e.retryAfter
+	return &d
+}
+
+type xaiQuotaExecutor struct {
+	err error
+}
+
+func (e *xaiQuotaExecutor) Identifier() string { return "xai" }
+func (e *xaiQuotaExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, e.err
+}
+func (e *xaiQuotaExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, e.err
+}
+func (e *xaiQuotaExecutor) Refresh(context.Context, *Auth) (*Auth, error) { return nil, nil }
+func (e *xaiQuotaExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, e.err
+}
+func (e *xaiQuotaExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, e.err
+}
+
+func TestManagerMarkResult_XAI402BalanceExhaustedUsesWeeklyQuota(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "grok-4.5"
+	retryAfter := 7 * 24 * time.Hour
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		err: &retryAfterQuotaErrorStub{
+			message:      `{"error":"Grok Build usage balance exhausted"}`,
+			status:       http.StatusPaymentRequired,
+			quotaWindow:  "week",
+			quotaMinutes: 10080,
+			retryAfter:   retryAfter,
+		},
+	})
+	auth := &Auth{
+		ID:       "xai-weekly",
+		Provider: "xai",
+		Status:   StatusActive,
+	}
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	_, err := manager.Execute(ctx, []string{"xai"}, cliproxyexecutor.Request{
+		Model: model,
+	}, cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SinglePickMetadataKey: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want upstream 402")
+	}
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if !state.Quota.Exceeded || state.Quota.Reason != "quota" {
+		t.Fatalf("quota = %#v, want exceeded quota", state.Quota)
+	}
+	if state.Quota.Window != "week" || state.Quota.WindowMinutes != 10080 {
+		t.Fatalf("quota window = %q/%d, want week/10080", state.Quota.Window, state.Quota.WindowMinutes)
+	}
+	// Must not use the old hard-coded 30 minute payment_required cooldown.
+	minExpected := before.Add(retryAfter - time.Minute)
+	maxExpected := before.Add(retryAfter + time.Minute)
+	if state.NextRetryAfter.Before(minExpected) || state.NextRetryAfter.After(maxExpected) {
+		t.Fatalf("NextRetryAfter = %v, want ~%v", state.NextRetryAfter, before.Add(retryAfter))
+	}
+	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
+		t.Fatalf("NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
+	}
+	if state.NextRetryAfter.Before(before.Add(24 * time.Hour)) {
+		t.Fatalf("NextRetryAfter = %v looks like short payment cooldown, want weekly", state.NextRetryAfter)
+	}
+}
+
+func TestManagerMarkResult_Generic402KeepsThirtyMinuteCooldown(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "grok-4.5"
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		err: &statusQuotaErrorStub{
+			message: "payment required",
+			status:  http.StatusPaymentRequired,
+		},
+	})
+	auth := &Auth{
+		ID:       "xai-generic-402",
+		Provider: "xai",
+		Status:   StatusActive,
+	}
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	_, err := manager.Execute(ctx, []string{"xai"}, cliproxyexecutor.Request{
+		Model: model,
+	}, cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SinglePickMetadataKey: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want upstream 402")
+	}
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.Quota.Exceeded {
+		t.Fatalf("quota exceeded = true for generic 402, want payment_required path")
+	}
+	if state.NextRetryAfter.Before(before.Add(29*time.Minute)) || state.NextRetryAfter.After(before.Add(31*time.Minute)) {
+		t.Fatalf("NextRetryAfter = %v, want ~30m payment_required", state.NextRetryAfter)
+	}
+}
+
+func TestApplyAuthFailureState_XAI402BalanceExhausted(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	retry := 7 * 24 * time.Hour
+	auth := &Auth{ID: "auth", Provider: "xai", Status: StatusActive}
+	applyAuthFailureState(auth, &Error{
+		Message:            `{"error":"Grok Build usage balance exhausted"}`,
+		HTTPStatus:         http.StatusPaymentRequired,
+		QuotaWindow:        "week",
+		QuotaWindowMinutes: 10080,
+	}, &retry, now)
+
+	if !auth.Quota.Exceeded || auth.Quota.Window != "week" || auth.Quota.WindowMinutes != 10080 {
+		t.Fatalf("quota = %#v, want week exceeded", auth.Quota)
+	}
+	if !auth.NextRetryAfter.Equal(now.Add(retry)) {
+		t.Fatalf("NextRetryAfter = %v, want %v", auth.NextRetryAfter, now.Add(retry))
+	}
+	if auth.StatusMessage == "payment_required" {
+		t.Fatal("StatusMessage still payment_required, want balance exhausted / quota path")
+	}
+}


### PR DESCRIPTION
## Summary
- Parse xAI Grok Build HTTP 402 `usage balance exhausted` into weekly quota metadata (`week` / 10080 minutes) with Retry-After / resets_at preference and a 7-day default cooldown.
- Route quota-like 402 failures through the same model/auth quota exhaustion path as 429s so UI recovery reflects the weekly window instead of a fixed 30-minute `payment_required` probe loop.
- Keep generic 402/403 payment errors on the existing 30-minute cooldown.

## Context
On tenant `蹬的飞快`, SuperGrok accounts returned upstream `{"error":"Grok Build usage balance exhausted"}` with HTTP 402 while the auth-files UI showed weekly remaining 0% and reset in days. Local cooldown still auto-recovered every ~30 minutes, causing repeated failures.

## Test plan
- [x] `go test ./sdk/cliproxy/auth/ -count=1`
- [x] `go test ./internal/runtime/executor/ -count=1`
- [ ] After merge/deploy: 402 balance-exhausted accounts show week-window recovery, not 30m auto-recover loops