### PR TITLE
fix: gofmt xAI 402 weekly quota cooldown files

### DIFF
--- a/internal/runtime/executor/xai_quota.go
+++ b/internal/runtime/executor/xai_quota.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	// xAI SuperGrok weekly included usage window (matches frontend XAI_WEEKLY_WINDOW_SECONDS).
-	xaiWeeklyWindowMinutes = 10080
-	xaiWeeklyWindowLabel   = "week"
+	xaiWeeklyWindowMinutes   = 10080
+	xaiWeeklyWindowLabel     = "week"
 	xaiWeeklyCooldownDefault = 7 * 24 * time.Hour
 )
 

--- a/sdk/cliproxy/auth/conductor_failure_state.go
+++ b/sdk/cliproxy/auth/conductor_failure_state.go
@@ -79,7 +79,6 @@ func applyAuthQuotaFailureState(auth *Auth, resultErr *Error, retryAfter *time.D
 	auth.NextRetryAfter = next
 }
 
-
 // nextQuotaCooldown returns the next cooldown duration and updated backoff level for repeated quota errors.
 func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) {
 	if prevLevel < 0 {


### PR DESCRIPTION
## Summary
- Apply `gofmt` to the files introduced/changed by #689 that caused `pr-test-build` to fail.

## Context
#689 already merged to `dev`, but CI reported:
- `internal/runtime/executor/xai_quota.go`
- `sdk/cliproxy/auth/conductor_failure_state.go`

## Test plan
- [x] `gofmt -l` clean on touched files
- [x] focused package tests for xAI 402 / auth path