### PR TITLE
fix: stop inventing 7d cooldown for xAI weekly 402

### DIFF
--- a/internal/runtime/executor/xai_quota.go
+++ b/internal/runtime/executor/xai_quota.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	// xAI SuperGrok weekly included usage window (matches frontend XAI_WEEKLY_WINDOW_SECONDS).
-	xaiWeeklyWindowMinutes   = 10080
-	xaiWeeklyWindowLabel     = "week"
-	xaiWeeklyCooldownDefault = 7 * 24 * time.Hour
+	// xAI SuperGrok weekly included usage window label/metadata only.
+	// Do not treat this length as remaining cooldown when reset is unknown.
+	xaiWeeklyWindowMinutes = 10080
+	xaiWeeklyWindowLabel   = "week"
 )
 
 func newXAIStatusErr(statusCode int, body []byte, headers ...http.Header) statusErr {
@@ -72,12 +72,8 @@ func parseXAIRetryAfter(statusCode int, errorBody []byte, header http.Header, no
 			return &retryAfter
 		}
 	}
-	// Weekly balance exhausted without an explicit reset: cool down until the
-	// typical weekly window would roll rather than probing every 30 minutes.
-	if statusCode == http.StatusPaymentRequired && isXAIUsageBalanceExhausted(errorBody) {
-		retryAfter := xaiWeeklyCooldownDefault
-		return &retryAfter
-	}
+	// No explicit reset from upstream. Leave retryAfter unset so conductor uses
+	// short probe backoff instead of inventing now+7d (window length ≠ remaining).
 	return nil
 }
 

--- a/internal/runtime/executor/xai_quota_test.go
+++ b/internal/runtime/executor/xai_quota_test.go
@@ -19,12 +19,9 @@ func TestNewXAIStatusErr_BalanceExhaustedMapsToWeeklyQuota(t *testing.T) {
 	if window != "week" || minutes != 10080 {
 		t.Fatalf("QuotaWindow() = %q/%d, want week/10080", window, minutes)
 	}
-	retryAfter := err.RetryAfter()
-	if retryAfter == nil {
-		t.Fatal("RetryAfter() = nil, want weekly cooldown")
-	}
-	if *retryAfter != 7*24*time.Hour {
-		t.Fatalf("RetryAfter() = %v, want 7d", *retryAfter)
+	// Unknown remaining time: do not invent now+7d from window length.
+	if got := err.RetryAfter(); got != nil {
+		t.Fatalf("RetryAfter() = %v, want nil when upstream omits reset", *got)
 	}
 }
 
@@ -45,6 +42,20 @@ func TestNewXAIStatusErr_PrefersRetryAfterHeader(t *testing.T) {
 	window, minutes := err.QuotaWindow()
 	if window != "week" || minutes != 10080 {
 		t.Fatalf("QuotaWindow() = %q/%d, want week/10080", window, minutes)
+	}
+}
+
+func TestNewXAIStatusErr_UsesResetsInSeconds(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"error":{"message":"Grok Build usage balance exhausted","resets_in_seconds":7200}}`)
+	err := newXAIStatusErr(http.StatusPaymentRequired, body)
+	retryAfter := err.RetryAfter()
+	if retryAfter == nil {
+		t.Fatal("RetryAfter() = nil")
+	}
+	if *retryAfter != 2*time.Hour {
+		t.Fatalf("RetryAfter() = %v, want 2h", *retryAfter)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -289,10 +289,8 @@ func applyModelQuotaFailureLocked(auth *Auth, state *ModelState, result Result, 
 	backoffLevel := state.Quota.BackoffLevel
 	if result.RetryAfter != nil {
 		next = now.Add(*result.RetryAfter)
-	} else if result.Error != nil && result.Error.QuotaWindowMinutes > 0 {
-		// Prefer the full provider window when known (week/5h) over short exponential probes.
-		next = now.Add(time.Duration(result.Error.QuotaWindowMinutes) * time.Minute)
 	} else {
+		// WindowMinutes is window length metadata (e.g. week=10080), not remaining cooldown.
 		cooldown, nextLevel := nextQuotaCooldown(backoffLevel, quotaCooldownDisabledForAuth(auth))
 		if cooldown > 0 {
 			next = now.Add(cooldown)

--- a/sdk/cliproxy/auth/conductor_failure_state.go
+++ b/sdk/cliproxy/auth/conductor_failure_state.go
@@ -66,9 +66,8 @@ func applyAuthQuotaFailureState(auth *Auth, resultErr *Error, retryAfter *time.D
 	var next time.Time
 	if retryAfter != nil {
 		next = now.Add(*retryAfter)
-	} else if resultErr != nil && resultErr.QuotaWindowMinutes > 0 {
-		next = now.Add(time.Duration(resultErr.QuotaWindowMinutes) * time.Minute)
 	} else {
+		// WindowMinutes is window length metadata (e.g. week=10080), not remaining cooldown.
 		cooldown, nextLevel := nextQuotaCooldown(auth.Quota.BackoffLevel, quotaCooldownDisabledForAuth(auth))
 		if cooldown > 0 {
 			next = now.Add(cooldown)

--- a/sdk/cliproxy/auth/xai_402_quota_test.go
+++ b/sdk/cliproxy/auth/xai_402_quota_test.go
@@ -51,12 +51,12 @@ func (e *xaiQuotaExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*
 	return nil, e.err
 }
 
-func TestManagerMarkResult_XAI402BalanceExhaustedUsesWeeklyQuota(t *testing.T) {
+func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	model := "grok-4.5"
-	retryAfter := 7 * 24 * time.Hour
+	retryAfter := 47 * time.Hour
 	manager := NewManager(nil, &FillFirstSelector{}, nil)
 	manager.RegisterExecutor(&xaiQuotaExecutor{
 		err: &retryAfterQuotaErrorStub{
@@ -102,7 +102,6 @@ func TestManagerMarkResult_XAI402BalanceExhaustedUsesWeeklyQuota(t *testing.T) {
 	if state.Quota.Window != "week" || state.Quota.WindowMinutes != 10080 {
 		t.Fatalf("quota window = %q/%d, want week/10080", state.Quota.Window, state.Quota.WindowMinutes)
 	}
-	// Must not use the old hard-coded 30 minute payment_required cooldown.
 	minExpected := before.Add(retryAfter - time.Minute)
 	maxExpected := before.Add(retryAfter + time.Minute)
 	if state.NextRetryAfter.Before(minExpected) || state.NextRetryAfter.After(maxExpected) {
@@ -111,8 +110,60 @@ func TestManagerMarkResult_XAI402BalanceExhaustedUsesWeeklyQuota(t *testing.T) {
 	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
 		t.Fatalf("NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
 	}
-	if state.NextRetryAfter.Before(before.Add(24 * time.Hour)) {
-		t.Fatalf("NextRetryAfter = %v looks like short payment cooldown, want weekly", state.NextRetryAfter)
+}
+
+func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryDoesNotUseWeekLength(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "grok-4.5"
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		err: &retryAfterQuotaErrorStub{
+			message:      `{"error":"Grok Build usage balance exhausted"}`,
+			status:       http.StatusPaymentRequired,
+			quotaWindow:  "week",
+			quotaMinutes: 10080,
+		},
+	})
+	auth := &Auth{
+		ID:       "xai-weekly-no-reset",
+		Provider: "xai",
+		Status:   StatusActive,
+	}
+	if _, err := manager.Register(ctx, auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	_, err := manager.Execute(ctx, []string{"xai"}, cliproxyexecutor.Request{
+		Model: model,
+	}, cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SinglePickMetadataKey: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want upstream 402")
+	}
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if !state.Quota.Exceeded || state.Quota.Window != "week" {
+		t.Fatalf("quota = %#v, want week exceeded", state.Quota)
+	}
+	// Must not treat WindowMinutes(10080) as remaining cooldown (~7d).
+	if state.NextRetryAfter.After(before.Add(time.Hour)) {
+		t.Fatalf("NextRetryAfter = %v, want short probe backoff not week length", state.NextRetryAfter)
+	}
+	if state.NextRetryAfter.Before(before) {
+		t.Fatalf("NextRetryAfter = %v, want after now", state.NextRetryAfter)
 	}
 }
 
@@ -169,7 +220,7 @@ func TestApplyAuthFailureState_XAI402BalanceExhausted(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
-	retry := 7 * 24 * time.Hour
+	retry := 47 * time.Hour
 	auth := &Auth{ID: "auth", Provider: "xai", Status: StatusActive}
 	applyAuthFailureState(auth, &Error{
 		Message:            `{"error":"Grok Build usage balance exhausted"}`,
@@ -186,5 +237,25 @@ func TestApplyAuthFailureState_XAI402BalanceExhausted(t *testing.T) {
 	}
 	if auth.StatusMessage == "payment_required" {
 		t.Fatal("StatusMessage still payment_required, want balance exhausted / quota path")
+	}
+}
+
+func TestApplyAuthFailureState_XAI402WithoutRetryDoesNotUseWindowMinutes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	auth := &Auth{ID: "auth", Provider: "xai", Status: StatusActive}
+	applyAuthFailureState(auth, &Error{
+		Message:            `{"error":"Grok Build usage balance exhausted"}`,
+		HTTPStatus:         http.StatusPaymentRequired,
+		QuotaWindow:        "week",
+		QuotaWindowMinutes: 10080,
+	}, nil, now)
+
+	if !auth.Quota.Exceeded || auth.Quota.Window != "week" {
+		t.Fatalf("quota = %#v, want week exceeded", auth.Quota)
+	}
+	if auth.NextRetryAfter.Sub(now) >= time.Hour {
+		t.Fatalf("NextRetryAfter = %v, want short probe backoff not WindowMinutes", auth.NextRetryAfter)
 	}
 }


### PR DESCRIPTION
## Summary
- `WindowMinutes` is quota **window length** metadata (week=10080), not remaining cooldown.
- When xAI 402 omits `Retry-After` / `resets_at`, use short probe backoff instead of inventing `now+7d`.
- Keep using real remaining time when upstream provides it.

## Test plan
- [x] `./scripts/ci-pr.sh` (structure, gofmt, go vet, `go test ./...`, golangci-lint, build)
- [x] focused: `go test ./internal/runtime/executor/ -run XAI|xai` and `./sdk/cliproxy/auth/ -run XAI|xai|Quota|Cooldown`