### PR TITLE
feat(deploy): harden blue-green publish path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,20 @@ on:
       - '**/*.md'
       - 'docs/**'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Bypass required-check gate (emergency only)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 permissions:
   actions: write
   contents: read
+  checks: read
 
 concurrency:
   group: deploy-relay-backend
@@ -19,16 +29,33 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       SHOULD_DEPLOY: ${{ github.event_name == 'workflow_dispatch' || vars.CLIRELAY_DEV_AUTO_DEPLOY == 'true' }}
+      EXPECTED_SCRIPT_VERSION: '2026.07.14'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Reject vendored panel assets
         run: ./scripts/ensure-no-vendored-panel-assets.sh
 
-      - uses: actions/setup-go@v5
+      # Branch protection on dev requires green PR checks before merge.
+      # Merge commits themselves do not re-run pr-test-build, so we do not re-query
+      # check-runs on github.sha here (that would always fail-closed incorrectly).
+      - name: Record deploy mode
+        if: env.SHOULD_DEPLOY == 'true'
+        env:
+          FORCE_DEPLOY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "${FORCE_DEPLOY}" = "true" ]; then
+            echo "::warning::Forced deploy via workflow_dispatch"
+            echo "DEPLOY_MODE=forced" >> "$GITHUB_ENV"
+          else
+            echo "DEPLOY_MODE=deployed" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: '1.26.1'
           cache: true
@@ -49,6 +76,7 @@ jobs:
           VERSION="${{ github.ref_name }}-${SHORT_SHA}"
           echo "Build date: $BUILD_DATE"
           echo "Version: $VERSION"
+          echo "APP_VERSION=${VERSION}" >> "$GITHUB_ENV"
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
             -ldflags="-s -w \
               -X 'github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo.Version=${VERSION}' \
@@ -61,37 +89,86 @@ jobs:
         run: |
           echo "Built dev binary, but server deploy is disabled."
           echo "Run this workflow manually or set repository variable CLIRELAY_DEV_AUTO_DEPLOY=true after the target server data stack is ready."
+          echo "DEPLOY_MODE=built-only" >> "$GITHUB_ENV"
 
-      - name: Upload binary and deploy scripts
+      # Native ssh/scp only. Remote user is deploy (not root).
+      # Staging path is /opt/clirelay2/incoming; root-owned entrypoint installs + deploys.
+      - name: Configure SSH
         if: env.SHOULD_DEPLOY == 'true'
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          port: ${{ secrets.SERVER_PORT }}
-          username: root
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/cleanup-drained-slot.sh"
-          target: "/opt/clirelay2/"
-          overwrite: true
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_PORT: ${{ secrets.SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "${SERVER_HOST:-}"
+          test -n "${SSH_PRIVATE_KEY:-}"
+          test -n "${DEPLOY_SSH_KNOWN_HOSTS:-}"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${DEPLOY_SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          port="${SERVER_PORT:-22}"
+          {
+            echo "Host deploy-target"
+            echo "  HostName ${SERVER_HOST}"
+            echo "  Port ${port}"
+            echo "  User deploy"
+            echo "  IdentityFile ~/.ssh/deploy_key"
+            echo "  IdentitiesOnly yes"
+            echo "  UserKnownHostsFile ~/.ssh/known_hosts"
+            echo "  StrictHostKeyChecking yes"
+          } > ~/.ssh/config
+          chmod 600 ~/.ssh/config
 
-      - name: Blue-green deploy
+      - name: Upload binary to staging
         if: env.SHOULD_DEPLOY == 'true'
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          port: ${{ secrets.SERVER_PORT }}
-          username: root
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            SERVICE_CPU_QUOTA="${{ vars.CLIRELAY_SERVICE_CPU_QUOTA || '170%' }}" \
-            SERVICE_MEMORY_HIGH="${{ vars.CLIRELAY_SERVICE_MEMORY_HIGH || '1400M' }}" \
-            SERVICE_MEMORY_MAX="${{ vars.CLIRELAY_SERVICE_MEMORY_MAX || '1600M' }}" \
-            SERVICE_TASKS_MAX="${{ vars.CLIRELAY_SERVICE_TASKS_MAX || '512' }}" \
-            COMMIT_SHA="${{ github.sha }}" \
-            bash /opt/clirelay2/scripts/deploy-blue-green.sh
+        run: |
+          set -euo pipefail
+          # deploy may only write the binary into incoming/.
+          # Root-managed /opt/clirelay2/scripts/* are never overwritten by GHA (prevents sudo script injection).
+          ssh deploy-target 'mkdir -p /opt/clirelay2/incoming && rm -f /opt/clirelay2/incoming/cli-proxy-api-new'
+          scp cli-proxy-api-new deploy-target:/opt/clirelay2/incoming/cli-proxy-api-new
+
+      - name: Blue-green deploy via fixed root entrypoint
+        if: env.SHOULD_DEPLOY == 'true'
+        env:
+          SERVICE_CPU_QUOTA: ${{ vars.CLIRELAY_SERVICE_CPU_QUOTA || '170%' }}
+          SERVICE_MEMORY_HIGH: ${{ vars.CLIRELAY_SERVICE_MEMORY_HIGH || '1400M' }}
+          SERVICE_MEMORY_MAX: ${{ vars.CLIRELAY_SERVICE_MEMORY_MAX || '1600M' }}
+          SERVICE_TASKS_MAX: ${{ vars.CLIRELAY_SERVICE_TASKS_MAX || '512' }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Only /usr/local/sbin/clirelay-gha-deploy is sudo-allowed for deploy.
+          # It validates COMMIT_SHA in the staged binary, then runs root-managed deploy-blue-green.sh.
+          ssh deploy-target \
+            "sudo -n \
+             SERVICE_CPU_QUOTA=$(printf %q "${SERVICE_CPU_QUOTA}") \
+             SERVICE_MEMORY_HIGH=$(printf %q "${SERVICE_MEMORY_HIGH}") \
+             SERVICE_MEMORY_MAX=$(printf %q "${SERVICE_MEMORY_MAX}") \
+             SERVICE_TASKS_MAX=$(printf %q "${SERVICE_TASKS_MAX}") \
+             COMMIT_SHA=$(printf %q "${COMMIT_SHA}") \
+             EXPECTED_SCRIPT_VERSION=$(printf %q "${EXPECTED_SCRIPT_VERSION}") \
+             /usr/local/sbin/clirelay-gha-deploy"
+          echo "DEPLOY_MODE=${DEPLOY_MODE:-deployed}" >> "$GITHUB_ENV"
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## CliRelay deploy"
+            echo "- mode: \`${DEPLOY_MODE:-unknown}\`"
+            echo "- sha: \`${{ github.sha }}\`"
+            echo "- version: \`${APP_VERSION:-n/a}\`"
+            echo "- should_deploy: \`${SHOULD_DEPLOY}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Trigger dev Docker image build
-        if: success()
+        if: success() && env.SHOULD_DEPLOY == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -17,10 +17,12 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 	content := string(data)
 
 	for _, want := range []string{
-		`Upload binary and deploy scripts`,
-		`source: "cli-proxy-api-new,scripts/deploy-blue-green.sh,scripts/cleanup-drained-slot.sh"`,
-		`scripts/deploy-blue-green.sh`,
-		`target: "/opt/clirelay2/"`,
+		`Upload binary to staging`,
+		`/opt/clirelay2/incoming/cli-proxy-api-new`,
+		`User deploy`,
+		`/usr/local/sbin/clirelay-gha-deploy`,
+		`StrictHostKeyChecking yes`,
+		`DEPLOY_SSH_KNOWN_HOSTS`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("deploy workflow missing backend binary deployment marker %q", want)
@@ -36,9 +38,13 @@ func TestDeployWorkflowOnlyPublishesBackendBinary(t *testing.T) {
 		`PANEL_DIR=`,
 		`relay-panel`,
 		`/home/web/html`,
+		`appleboy/scp-action`,
+		`appleboy/ssh-action`,
+		`username: root`,
+		`StrictHostKeyChecking accept-new`,
 	} {
 		if strings.Contains(content, forbidden) {
-			t.Fatalf("backend deploy workflow must not publish frontend panel assets, found %q", forbidden)
+			t.Fatalf("backend deploy workflow must not publish frontend panel assets or use insecure deploy markers, found %q", forbidden)
 		}
 	}
 }
@@ -51,13 +57,14 @@ func TestDeployWorkflowUsesBlueGreenDeployment(t *testing.T) {
 	content := string(data)
 
 	for _, want := range []string{
-		`Blue-green deploy`,
-		`SERVICE_CPU_QUOTA="${{ vars.CLIRELAY_SERVICE_CPU_QUOTA || '170%' }}"`,
-		`SERVICE_MEMORY_HIGH="${{ vars.CLIRELAY_SERVICE_MEMORY_HIGH || '1400M' }}"`,
-		`SERVICE_MEMORY_MAX="${{ vars.CLIRELAY_SERVICE_MEMORY_MAX || '1600M' }}"`,
-		`SERVICE_TASKS_MAX="${{ vars.CLIRELAY_SERVICE_TASKS_MAX || '512' }}"`,
-		`COMMIT_SHA="${{ github.sha }}"`,
-		`bash /opt/clirelay2/scripts/deploy-blue-green.sh`,
+		`Blue-green deploy via fixed root entrypoint`,
+		`SERVICE_CPU_QUOTA: ${{ vars.CLIRELAY_SERVICE_CPU_QUOTA || '170%' }}`,
+		`SERVICE_MEMORY_HIGH: ${{ vars.CLIRELAY_SERVICE_MEMORY_HIGH || '1400M' }}`,
+		`SERVICE_MEMORY_MAX: ${{ vars.CLIRELAY_SERVICE_MEMORY_MAX || '1600M' }}`,
+		`SERVICE_TASKS_MAX: ${{ vars.CLIRELAY_SERVICE_TASKS_MAX || '512' }}`,
+		`COMMIT_SHA: ${{ github.sha }}`,
+		`/usr/local/sbin/clirelay-gha-deploy`,
+		`EXPECTED_SCRIPT_VERSION`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("deploy workflow missing blue-green marker %q", want)
@@ -92,10 +99,15 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 	}
 	content := string(data)
 	for _, want := range []string{
+		`/readyz`,
 		`/healthz`,
 		`CLIRELAY_PORT=`,
 		`.active-port`,
 		`HEALTH_TIMEOUT_SECONDS`,
+		`SMOKE_TIMEOUT_SECONDS`,
+		`PUBLIC_BASE_URL`,
+		`external smoke failed`,
+		`rolling nginx back`,
 		`MIN_AVAILABLE_MB`,
 		`NGINX_CONTAINER`,
 		`EnvironmentFile=`,
@@ -105,6 +117,7 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`systemd-run`,
 		`scripts/cleanup-drained-slot.sh`,
 		`grep -v '\.bak\.'`,
+		`SCRIPT_VERSION`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("deploy script missing guard %q", want)
@@ -187,10 +200,13 @@ func TestDeployCompletesBeforeDispatchingDevDockerBuild(t *testing.T) {
 		t.Fatalf("read deploy workflow: %v", err)
 	}
 	content := string(data)
-	deployIndex := strings.Index(content, `name: Blue-green deploy`)
+	deployIndex := strings.Index(content, `name: Blue-green deploy via fixed root entrypoint`)
 	dockerIndex := strings.Index(content, `name: Trigger dev Docker image build`)
 	if deployIndex < 0 || dockerIndex < 0 || dockerIndex <= deployIndex {
 		t.Fatalf("dev Docker build must be dispatched only after blue-green deployment")
+	}
+	if !strings.Contains(content, `if: success() && env.SHOULD_DEPLOY == 'true'`) {
+		t.Fatalf("docker publish must only run after a real deploy attempt")
 	}
 	for _, want := range []string{
 		`actions: write`,

--- a/internal/api/readyz.go
+++ b/internal/api/readyz.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// handleReadyz reports whether this process is ready to receive traffic.
+// Unlike /healthz (liveness), readiness fails when required dependencies are unavailable.
+func (s *Server) handleReadyz(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
+	defer cancel()
+
+	if s.cfg == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready", "reason": "config_not_loaded"})
+		return
+	}
+
+	if dsn := strings.TrimSpace(s.cfg.Postgres.DSN); dsn != "" {
+		if err := pingPostgres(ctx, dsn); err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready", "reason": "postgres"})
+			return
+		}
+	}
+
+	if s.cfg.Redis.Enable {
+		addr := strings.TrimSpace(s.cfg.Redis.Addr)
+		if addr == "" {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready", "reason": "redis_addr_missing"})
+			return
+		}
+		if err := pingRedis(ctx, addr, s.cfg.Redis.Password, s.cfg.Redis.DB); err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready", "reason": "redis"})
+			return
+		}
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+func pingPostgres(ctx context.Context, dsn string) error {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(time.Second)
+	return db.PingContext(ctx)
+}
+
+func pingRedis(ctx context.Context, addr, password string, db int) error {
+	client := redis.NewClient(&redis.Options{
+		Addr:         addr,
+		Password:     password,
+		DB:           db,
+		DialTimeout:  time.Second,
+		ReadTimeout:  time.Second,
+		WriteTimeout: time.Second,
+	})
+	defer client.Close()
+	return client.Ping(ctx).Err()
+}

--- a/internal/api/routes_public.go
+++ b/internal/api/routes_public.go
@@ -20,6 +20,7 @@ func (s *Server) setupRoutes() {
 	s.engine.GET("/healthz", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
+	s.engine.GET("/readyz", s.handleReadyz)
 
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
 	s.engine.GET("/manage", s.serveManagementControlPanel)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -117,6 +117,32 @@ func TestHealthzReturnsNoContent(t *testing.T) {
 	}
 }
 
+func TestReadyzReturnsNoContentWhenDependenciesOptionalOrUnset(t *testing.T) {
+	server := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+}
+
+func TestReadyzFailsWhenRedisEnabledButUnreachable(t *testing.T) {
+	server := newTestServer(t)
+	server.cfg.Redis.Enable = true
+	server.cfg.Redis.Addr = "127.0.0.1:1"
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+	}
+}
+
 func TestAmpProviderModelRoutes(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/scripts/clirelay-gha-deploy
+++ b/scripts/clirelay-gha-deploy
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Root-only GitHub Actions deploy entrypoint installed at /usr/local/sbin/clirelay-gha-deploy.
+# deploy stages ONLY the binary into /opt/clirelay2/incoming/cli-proxy-api-new, then sudo this path.
+# Scripts under /opt/clirelay2/scripts are root-managed and never overwritten by GHA.
+set -euo pipefail
+
+BASE=/opt/clirelay2
+IN="${BASE}/incoming"
+SCRIPTS="${BASE}/scripts"
+TEMP_BIN="${BASE}/cli-proxy-api-new"
+STAGED="${IN}/cli-proxy-api-new"
+
+[ -f "$STAGED" ] || { echo "missing staged binary: $STAGED" >&2; exit 1; }
+[ -x "${SCRIPTS}/deploy-blue-green.sh" ] || { echo "root-managed deploy-blue-green.sh missing" >&2; exit 1; }
+[ -x "${SCRIPTS}/cleanup-drained-slot.sh" ] || { echo "root-managed cleanup-drained-slot.sh missing" >&2; exit 1; }
+
+# Validate commit marker on the staged file BEFORE touching slot binaries.
+COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+if ! grep -a -q "$COMMIT_SHA" "$STAGED"; then
+	echo "staged binary does not contain expected commit SHA; refusing install" >&2
+	rm -f "$STAGED"
+	exit 1
+fi
+
+install -m 0755 -o root -g root "$STAGED" "$TEMP_BIN"
+rm -f "$STAGED"
+
+exec /bin/bash "${SCRIPTS}/deploy-blue-green.sh"

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
+# SCRIPT_VERSION must stay in sync with deploy gate expectations.
+SCRIPT_VERSION="${SCRIPT_VERSION:-2026.07.14}"
 set -euo pipefail
 
 SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
 BASE_DIR="${BASE_DIR:-/opt/clirelay2}"
 TEMP_BIN="${TEMP_BIN:-${BASE_DIR}/cli-proxy-api-new}"
 DOMAIN="${DOMAIN:-relay.07230805.xyz}"
+PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-https://${DOMAIN}}"
 PORT_A="${PORT_A:-8318}"
 PORT_B="${PORT_B:-8319}"
 DRAIN_SECONDS="${DRAIN_SECONDS:-35}"
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-90}"
+SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-30}"
 MIN_AVAILABLE_MB="${MIN_AVAILABLE_MB:-512}"
 NGINX_CONTAINER="${NGINX_CONTAINER:-nginx}"
 SERVICE_CPU_QUOTA="${SERVICE_CPU_QUOTA:-170%}"
@@ -18,6 +22,11 @@ SERVICE_TASKS_MAX="${SERVICE_TASKS_MAX:-512}"
 COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
 ACTIVE_PORT_FILE="${BASE_DIR}/.active-port"
 CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-${BASE_DIR}/scripts/cleanup-drained-slot.sh}"
+EXPECTED_SCRIPT_VERSION="${EXPECTED_SCRIPT_VERSION:-}"
+if [ -n "$EXPECTED_SCRIPT_VERSION" ] && [ "$SCRIPT_VERSION" != "$EXPECTED_SCRIPT_VERSION" ]; then
+	echo "deploy script version mismatch: have ${SCRIPT_VERSION}, want ${EXPECTED_SCRIPT_VERSION}" >&2
+	exit 1
+fi
 
 fail() {
 	echo "$*" >&2
@@ -112,12 +121,12 @@ if [ -n "$available_mb" ] && [ "$available_mb" -lt "$MIN_AVAILABLE_MB" ]; then
 	fail "not enough free memory for blue-green deploy: ${available_mb}MB available, need ${MIN_AVAILABLE_MB}MB"
 fi
 
-install -m 0755 "$TEMP_BIN" "$next_bin"
-rm -f "$TEMP_BIN"
-
-if ! grep -a -q "$COMMIT_SHA" "$next_bin"; then
+# Validate staged binary before replacing any slot binary (failed deploys must not clobber next_bin).
+if ! grep -a -q "$COMMIT_SHA" "$TEMP_BIN"; then
 	fail "uploaded binary does not contain expected commit SHA"
 fi
+install -m 0755 "$TEMP_BIN" "$next_bin"
+rm -f "$TEMP_BIN"
 
 working_dir="$(read_service_property WorkingDirectory)"
 working_dir="${working_dir:-$service_dir}"
@@ -166,17 +175,32 @@ http_ok() {
 	fi
 }
 
+# Prefer readiness; fall back to liveness only if /readyz is absent (old binary during rollout).
+ready_url="http://127.0.0.1:${next_port}/readyz"
 health_url="http://127.0.0.1:${next_port}/healthz"
+probe_url="$ready_url"
 for _ in $(seq 1 "$HEALTH_TIMEOUT_SECONDS"); do
-	if http_ok "$health_url"; then
+	if http_ok "$ready_url"; then
+		probe_url="$ready_url"
+		break
+	fi
+	# 404 means old binary without /readyz; accept /healthz for one release window.
+	if command -v curl >/dev/null 2>&1; then
+		code="$(curl -s -o /dev/null -w '%{http_code}' "$ready_url" || true)"
+		if [ "$code" = "404" ] && http_ok "$health_url"; then
+			probe_url="$health_url"
+			break
+		fi
+	elif http_ok "$health_url"; then
+		probe_url="$health_url"
 		break
 	fi
 	sleep 1
 done
-if ! http_ok "$health_url"; then
+if ! http_ok "$probe_url"; then
 	systemctl status "$next_unit" --no-pager -l >&2 || true
 	journalctl -u "$next_unit" --no-pager -n 80 >&2 || true
-	fail "new slot failed health check after ${HEALTH_TIMEOUT_SECONDS}s: $health_url"
+	fail "new slot failed readiness check after ${HEALTH_TIMEOUT_SECONDS}s: $ready_url (fallback $health_url)"
 fi
 
 ensure_host_body_size_conf() {
@@ -222,41 +246,78 @@ if [ -z "$nginx_conf" ]; then
 fi
 [ -n "$nginx_conf" ] || fail "nginx config for ${DOMAIN} not found on host or docker container ${NGINX_CONTAINER}; set NGINX_CONF/NGINX_CONTAINER"
 
+switch_nginx_port() {
+	from_port="$1"
+	to_port="$2"
+	if [ "$nginx_mode" = "container" ]; then
+		tmp_conf="$(mktemp)"
+		docker cp "${NGINX_CONTAINER}:${nginx_conf}" "$tmp_conf"
+		if ! grep -Eq ":${from_port}\\b" "$tmp_conf"; then
+			rm -f "$tmp_conf"
+			return 1
+		fi
+		perl -0pi -e "s/:${from_port}\\b/:${to_port}/g" "$tmp_conf"
+		ensure_container_body_size_conf
+		docker cp "$tmp_conf" "${NGINX_CONTAINER}:${nginx_conf}"
+		rm -f "$tmp_conf"
+		docker exec "$NGINX_CONTAINER" nginx -t
+		docker exec "$NGINX_CONTAINER" nginx -s reload
+	else
+		[ -f "$nginx_conf" ] || return 1
+		ensure_host_body_size_conf
+		if ! grep -Eq ":${from_port}\\b" "$nginx_conf"; then
+			return 1
+		fi
+		perl -0pi -e "s/:${from_port}\\b/:${to_port}/g" "$nginx_conf"
+		nginx -t
+		nginx -s reload || systemctl reload nginx
+	fi
+}
+
 if [ "$nginx_mode" = "container" ]; then
-	tmp_conf="$(mktemp)"
 	backup="${nginx_conf}.bak.$(date +%Y%m%d_%H%M%S)"
-	docker cp "${NGINX_CONTAINER}:${nginx_conf}" "$tmp_conf"
 	docker exec "$NGINX_CONTAINER" cp "$nginx_conf" "$backup"
-	if ! grep -Eq ":${active_port}\\b" "$tmp_conf"; then
-		fail "nginx config ${NGINX_CONTAINER}:${nginx_conf} does not reference active port ${active_port}"
-	fi
-	# Replace only the active backend port, leaving the existing nginx layout untouched.
-	perl -0pi -e "s/:${active_port}\\b/:${next_port}/g" "$tmp_conf"
-	ensure_container_body_size_conf
-	docker cp "$tmp_conf" "${NGINX_CONTAINER}:${nginx_conf}"
-	rm -f "$tmp_conf"
-	if ! docker exec "$NGINX_CONTAINER" nginx -t; then
-		docker exec "$NGINX_CONTAINER" cp "$backup" "$nginx_conf"
-		docker exec "$NGINX_CONTAINER" nginx -t || true
-		fail "nginx config test failed; reverted ${NGINX_CONTAINER}:${nginx_conf}"
-	fi
-	docker exec "$NGINX_CONTAINER" nginx -s reload
 else
 	[ -f "$nginx_conf" ] || fail "nginx config not found: $nginx_conf"
-	ensure_host_body_size_conf
 	backup="${nginx_conf}.bak.$(date +%Y%m%d_%H%M%S)"
 	cp "$nginx_conf" "$backup"
-	if ! grep -Eq ":${active_port}\\b" "$nginx_conf"; then
-		fail "nginx config $nginx_conf does not reference active port ${active_port}"
-	fi
-	# Replace only the active backend port, leaving the existing nginx layout untouched.
-	perl -0pi -e "s/:${active_port}\\b/:${next_port}/g" "$nginx_conf"
-	if ! nginx -t; then
-		cp "$backup" "$nginx_conf"
+fi
+
+if ! switch_nginx_port "$active_port" "$next_port"; then
+	if [ "$nginx_mode" = "container" ]; then
+		docker exec "$NGINX_CONTAINER" cp "$backup" "$nginx_conf" || true
+		docker exec "$NGINX_CONTAINER" nginx -t || true
+	else
+		cp "$backup" "$nginx_conf" || true
 		nginx -t || true
-		fail "nginx config test failed; reverted $nginx_conf"
 	fi
-	nginx -s reload || systemctl reload nginx
+	fail "nginx cutover failed; restored backup and kept active port ${active_port}"
+fi
+
+# External smoke before abandoning old slot. Failure rolls nginx back to active_port.
+smoke_ok=0
+public_ready="${PUBLIC_BASE_URL%/}/readyz"
+public_health="${PUBLIC_BASE_URL%/}/healthz"
+for _ in $(seq 1 "$SMOKE_TIMEOUT_SECONDS"); do
+	if http_ok "$public_ready" || http_ok "$public_health"; then
+		smoke_ok=1
+		break
+	fi
+	sleep 1
+done
+if [ "$smoke_ok" -ne 1 ]; then
+	echo "external smoke failed after cutover; rolling nginx back to ${active_port}" >&2
+	if ! switch_nginx_port "$next_port" "$active_port"; then
+		if [ "$nginx_mode" = "container" ]; then
+			docker exec "$NGINX_CONTAINER" cp "$backup" "$nginx_conf" || true
+			docker exec "$NGINX_CONTAINER" nginx -s reload || true
+		else
+			cp "$backup" "$nginx_conf" || true
+			nginx -s reload || systemctl reload nginx || true
+		fi
+	fi
+	systemctl disable --now "$next_unit" >/dev/null 2>&1 || true
+	fail "external HTTPS smoke failed for ${PUBLIC_BASE_URL}; traffic restored to ${active_port}"
 fi
 
 echo "$next_port" > "$ACTIVE_PORT_FILE"


### PR DESCRIPTION
## Summary
- Replace third-party appleboy SSH actions with native ssh as non-root `deploy` user
- Stage binary only under `/opt/clirelay2/incoming`; fixed sudo entrypoint
- Pin Action SHAs + SSH host keys (`DEPLOY_SSH_KNOWN_HOSTS`)
- Add `/readyz` (postgres/redis when configured)
- Blue-green: local readiness → cutover → external HTTPS smoke → rollback on failure → drain
- Align `deployment_workflow_test.go`

## Server prerequisites (already applied on deploy host)
- `deploy` user + restricted sudo for `/usr/local/sbin/clirelay-gha-deploy`
- Root-managed scripts with `SCRIPT_VERSION=2026.07.14`
- Secret `DEPLOY_SSH_KNOWN_HOSTS` set

## Test plan
- [x] `go test .` and `go test ./internal/api/ -run 'Healthz|Readyz'`
- [ ] PR CI green
- [ ] After merge: manual `workflow_dispatch` first deploy recommended

Refs: CliProxy `docs/plan/062-deploy-pipeline-hardening-20260714.md`