### PR TITLE
feat(codex): per-account image_generation bridge

### DIFF
--- a/internal/management/authfiles/codex_image_generation_bridge.go
+++ b/internal/management/authfiles/codex_image_generation_bridge.go
@@ -1,0 +1,28 @@
+package authfiles
+
+import (
+	"fmt"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const metadataKeyCodexImageGenerationBridge = "codex_image_generation_bridge"
+
+// CodexImageGenerationBridgePayload returns the management-facing payload for
+// per-account Codex /responses image_generation tool injection.
+func CodexImageGenerationBridgePayload(auth *coreauth.Auth) map[string]any {
+	if !isCodexOAuthAdmissionAuth(auth) {
+		return nil
+	}
+	enabled, _ := auth.Metadata[metadataKeyCodexImageGenerationBridge].(bool)
+	return map[string]any{
+		"enabled": enabled,
+	}
+}
+
+func ensureCodexImageGenerationBridgeEditable(auth *coreauth.Auth) error {
+	if !isCodexOAuthAdmissionAuth(auth) {
+		return fmt.Errorf("codex image generation bridge is only supported for Codex OAuth auth files")
+	}
+	return nil
+}

--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -137,5 +137,8 @@ func BuildEntry(auth *coreauth.Auth, opts EntryOptions) map[string]any {
 		entry["codex_cli_only"] = admission["enabled"]
 		entry["codex_cli_only_allowed_clients"] = admission["allowed_clients"]
 	}
+	if bridge := CodexImageGenerationBridgePayload(auth); len(bridge) > 0 {
+		entry["codex_image_generation_bridge"] = bridge
+	}
 	return entry
 }

--- a/internal/management/authfiles/entry_test.go
+++ b/internal/management/authfiles/entry_test.go
@@ -160,6 +160,39 @@ func TestBuildEntryIncludesCodexOAuthAdmissionPayload(t *testing.T) {
 	if !ok || len(available) == 0 || available[0].ID != codexadmission.AllowedClientClaudeCode {
 		t.Fatalf("admission.available_allowed_clients = %#v, want claude_code preset info", admission["available_allowed_clients"])
 	}
+	bridge, ok := entry["codex_image_generation_bridge"].(map[string]any)
+	if !ok {
+		t.Fatalf("codex_image_generation_bridge = %#v, want map", entry["codex_image_generation_bridge"])
+	}
+	if enabled, _ := bridge["enabled"].(bool); enabled {
+		t.Fatalf("bridge.enabled = %#v, want false by default", bridge["enabled"])
+	}
+}
+
+func TestBuildEntryIncludesCodexImageGenerationBridgeEnabled(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-oauth",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+		Metadata: map[string]any{
+			"codex_image_generation_bridge": true,
+			"email":                         "codex@example.com",
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{})
+	if entry == nil {
+		t.Fatal("expected entry")
+	}
+	bridge, ok := entry["codex_image_generation_bridge"].(map[string]any)
+	if !ok {
+		t.Fatalf("codex_image_generation_bridge = %#v, want map", entry["codex_image_generation_bridge"])
+	}
+	if enabled, _ := bridge["enabled"].(bool); !enabled {
+		t.Fatalf("bridge.enabled = %#v, want true", bridge["enabled"])
+	}
 }
 
 func TestBuildEntryUsesInjectedStat(t *testing.T) {

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -26,6 +26,8 @@ type FieldPatch struct {
 	SubscriptionExpiresAt      *string   `json:"subscription_expires_at"`
 	CodexCLIOnly               *bool     `json:"codex_cli_only"`
 	CodexCLIOnlyAllowedClients *[]string `json:"codex_cli_only_allowed_clients"`
+	// CodexImageGenerationBridge injects Responses-native image_generation for Codex OAuth.
+	CodexImageGenerationBridge *bool `json:"codex_image_generation_bridge"`
 }
 
 type FieldPatchOptions struct {
@@ -241,6 +243,14 @@ func ApplyFieldPatch(auth *coreauth.Auth, patch FieldPatch, opts FieldPatchOptio
 		} else {
 			metadata["codex_cli_only_allowed_clients"] = allowedClients
 		}
+		changed = true
+	}
+	if patch.CodexImageGenerationBridge != nil {
+		if err := ensureCodexImageGenerationBridgeEditable(auth); err != nil {
+			return result, err
+		}
+		metadata := ensureMetadata(auth)
+		metadata[metadataKeyCodexImageGenerationBridge] = *patch.CodexImageGenerationBridge
 		changed = true
 	}
 

--- a/internal/management/authfiles/patch_test.go
+++ b/internal/management/authfiles/patch_test.go
@@ -297,6 +297,47 @@ func TestApplyFieldPatchRejectsCodexOAuthAdmissionForAPIKeyAuth(t *testing.T) {
 	}
 }
 
+func TestApplyFieldPatchUpdatesCodexImageGenerationBridge(t *testing.T) {
+	now := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+	enabled := true
+	auth := &coreauth.Auth{
+		ID:       "codex-oauth",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+	}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{
+		CodexImageGenerationBridge: &enabled,
+	}, FieldPatchOptions{Now: now})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if got, _ := auth.Metadata["codex_image_generation_bridge"].(bool); !got {
+		t.Fatalf("codex_image_generation_bridge = %#v, want true", auth.Metadata["codex_image_generation_bridge"])
+	}
+	if !auth.UpdatedAt.Equal(now) {
+		t.Fatalf("UpdatedAt = %v, want %v", auth.UpdatedAt, now)
+	}
+}
+
+func TestApplyFieldPatchRejectsCodexImageGenerationBridgeForAPIKeyAuth(t *testing.T) {
+	enabled := true
+	auth := &coreauth.Auth{
+		ID:       "codex-api-key",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key": "sk-test",
+		},
+	}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{CodexImageGenerationBridge: &enabled}, FieldPatchOptions{})
+	if err == nil || !strings.Contains(err.Error(), "only supported for Codex OAuth") {
+		t.Fatalf("ApplyFieldPatch() error = %v, want Codex OAuth restriction", err)
+	}
+}
+
 func TestApplyFieldPatchRejectsUnknownCodexAllowedClientPreset(t *testing.T) {
 	allowedClients := []string{"unknown_client"}
 	auth := &coreauth.Auth{

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -155,6 +155,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		sysContent := extractSystemMessagesAsInstructions(execCtx.Request.Payload)
 		body, _ = sjson.SetBytes(body, "instructions", sysContent)
 	}
+	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(execCtx.Context, auth, execCtx.SourceFormat, url, req, body)
@@ -349,6 +350,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		sysContent := extractSystemMessagesAsInstructions(execCtx.Request.Payload)
 		body, _ = sjson.SetBytes(body, "instructions", sysContent)
 	}
+	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(execCtx.Context, auth, execCtx.SourceFormat, url, req, body)

--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -1,0 +1,109 @@
+package executor
+
+import (
+	"net/http"
+	"strings"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	codexResponsesLiteHeader   = "X-OpenAI-Internal-Codex-Responses-Lite"
+	codexResponsesLiteMetadata = "client_metadata.ws_request_header_x_openai_internal_codex_responses_lite"
+)
+
+var (
+	imageGenToolJSON      = []byte(`{"type":"image_generation","output_format":"png"}`)
+	imageGenToolArrayJSON = []byte(`[{"type":"image_generation","output_format":"png"}]`)
+)
+
+// maybeEnsureCodexImageGenerationTool injects the Responses-native
+// image_generation tool when the Codex OAuth account has the bridge enabled.
+// Independent /v1/images/* paths already force the tool; this covers normal
+// Codex CLI /responses text turns that lack a local image_gen namespace.
+func maybeEnsureCodexImageGenerationTool(body []byte, auth *cliproxyauth.Auth, baseModel string, headers http.Header) []byte {
+	if !codexImageGenerationBridgeEnabled(auth) {
+		return body
+	}
+	return ensureCodexImageGenerationTool(body, baseModel, auth, headers)
+}
+
+func codexImageGenerationBridgeEnabled(auth *cliproxyauth.Auth) bool {
+	if auth == nil || auth.Metadata == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return false
+	}
+	enabled, _ := auth.Metadata["codex_image_generation_bridge"].(bool)
+	return enabled
+}
+
+func ensureCodexImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth, headers http.Header) []byte {
+	if isCodexResponsesLiteRequest(body, headers) {
+		return body
+	}
+	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(baseModel)), "spark") {
+		return body
+	}
+	if isCodexFreePlanAuth(auth) {
+		return body
+	}
+
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		body, _ = sjson.SetRawBytes(body, "tools", imageGenToolArrayJSON)
+		return body
+	}
+	for _, tool := range tools.Array() {
+		if tool.Get("type").String() == "image_generation" || isImageGenerationFunctionTool(tool) {
+			return body
+		}
+	}
+	body, _ = sjson.SetRawBytes(body, "tools.-1", imageGenToolJSON)
+	return body
+}
+
+func isImageGenerationFunctionTool(tool gjson.Result) bool {
+	switch tool.Get("type").String() {
+	case "function":
+		return tool.Get("name").String() == "image_gen.imagegen"
+	case "namespace":
+		if tool.Get("name").String() != "image_gen" {
+			return false
+		}
+		nested := tool.Get("tools")
+		if !nested.IsArray() {
+			return false
+		}
+		for _, nestedTool := range nested.Array() {
+			if nestedTool.Get("type").String() == "function" && nestedTool.Get("name").String() == "imagegen" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isCodexResponsesLiteRequest(body []byte, headers http.Header) bool {
+	if headers != nil && strings.EqualFold(strings.TrimSpace(headers.Get(codexResponsesLiteHeader)), "true") {
+		return true
+	}
+	value := gjson.GetBytes(body, codexResponsesLiteMetadata)
+	if !value.Exists() {
+		return false
+	}
+	return value.Type == gjson.True || (value.Type == gjson.String && strings.EqualFold(strings.TrimSpace(value.String()), "true"))
+}
+
+func isCodexFreePlanAuth(auth *cliproxyauth.Auth) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(auth.Attributes["plan_type"]), "free")
+}

--- a/internal/runtime/executor/codex_image_generation_bridge_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_test.go
@@ -1,0 +1,76 @@
+package executor
+
+import (
+	"net/http"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+)
+
+func TestMaybeEnsureCodexImageGenerationToolInjectsWhenEnabled(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{
+			"codex_image_generation_bridge": true,
+		},
+	}
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"shell"}]}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.4", nil)
+	if got := gjson.GetBytes(out, "tools.#").Int(); got != 2 {
+		t.Fatalf("tools count = %d, want 2; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "tools.1.type").String(); got != "image_generation" {
+		t.Fatalf("tools.1.type = %q, want image_generation; body=%s", got, out)
+	}
+}
+
+func TestMaybeEnsureCodexImageGenerationToolSkipsWhenDisabled(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{
+			"codex_image_generation_bridge": false,
+		},
+	}
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"shell"}]}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.4", nil)
+	if got := gjson.GetBytes(out, "tools.#").Int(); got != 1 {
+		t.Fatalf("tools count = %d, want 1; body=%s", got, out)
+	}
+}
+
+func TestMaybeEnsureCodexImageGenerationToolSkipsExistingImageGenNamespace(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{
+			"codex_image_generation_bridge": true,
+		},
+	}
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"namespace","name":"image_gen","tools":[{"type":"function","name":"imagegen"}]}]}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.4", nil)
+	if got := gjson.GetBytes(out, "tools.#").Int(); got != 1 {
+		t.Fatalf("tools count = %d, want 1; body=%s", got, out)
+	}
+}
+
+func TestMaybeEnsureCodexImageGenerationToolSkipsSparkAndLite(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{
+			"codex_image_generation_bridge": true,
+		},
+	}
+	body := []byte(`{"model":"gpt-5.3-codex-spark"}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.3-codex-spark", nil)
+	if gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("spark model should not inject tools; body=%s", out)
+	}
+
+	liteBody := []byte(`{"model":"gpt-5.4"}`)
+	headers := http.Header{}
+	headers.Set("X-OpenAI-Internal-Codex-Responses-Lite", "true")
+	out = maybeEnsureCodexImageGenerationTool(liteBody, auth, "gpt-5.4", headers)
+	if gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("responses-lite should not inject tools; body=%s", out)
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -117,6 +117,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if !gjson.GetBytes(body, "instructions").Exists() {
 		body, _ = sjson.SetBytes(body, "instructions", "")
 	}
+	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -312,6 +313,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 
 	body = execCtx.ApplyPayloadConfig(body, body)
+	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)


### PR DESCRIPTION
## Summary
- Add per-Codex-OAuth-account metadata `codex_image_generation_bridge` (default off).
- When enabled, inject Responses-native `{"type":"image_generation","output_format":"png"}` on `/responses` (HTTP + WebSocket) if the client lacks image tools.
- Skip spark / free plan / responses-lite / existing `image_generation` or `image_gen` namespace.

## Test plan
- [x] `./scripts/ci-pr.sh` (gofmt, structure, go test ./..., build)
- [x] `go test ./internal/management/authfiles/ ./internal/runtime/executor/ -run 'CodexImageGeneration|ImageGenerationBridge|MaybeEnsure|CodexOAuthAdmission'`

## Notes
Pairs with codeProxy PR for the fields-tab toggle UI.