### PR TITLE
fix(codex): complete image_generation_call status when result exists

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -221,6 +221,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 			continue
 		}
 		line = mergeCodexResponsesCompletedOutput(line, pendingOutputItems, pendingOutputKeys)
+		line = normalizeCodexImageGenerationCallStatus(line)
 
 		if detail, ok := parseCodexUsage(line); ok {
 			reporter.publishWithContent(execCtx.Context, detail, string(req.Payload), string(data))
@@ -399,13 +400,14 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		completed := false
 		for scanner.Scan() {
 			line := scanner.Bytes()
+			line = normalizeCodexImageGenerationCallStatus(bytes.Clone(line))
 			recorder.AppendResponseChunk(line)
 			reporter.appendOutputChunk(line)
 
 			var terminalErr error
 
 			if bytes.HasPrefix(line, dataTag) {
-				data := bytes.TrimSpace(line[5:])
+				data := bytes.TrimSpace(line[len(dataTag):])
 				switch gjson.GetBytes(data, "type").String() {
 				case "response.completed":
 					completed = true
@@ -417,7 +419,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				}
 			}
 
-			chunks := sdktranslator.TranslateStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, execCtx.OriginalPayload, body, bytes.Clone(line), &param)
+			chunks := sdktranslator.TranslateStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, execCtx.OriginalPayload, body, line, &param)
 			for i := range chunks {
 				out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
 			}

--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -1,7 +1,9 @@
 package executor
 
 import (
+	"bytes"
 	"net/http"
+	"strconv"
 	"strings"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -106,4 +108,88 @@ func isCodexFreePlanAuth(auth *cliproxyauth.Auth) bool {
 		return false
 	}
 	return strings.EqualFold(strings.TrimSpace(auth.Attributes["plan_type"]), "free")
+}
+
+// normalizeCodexImageGenerationCallStatus upgrades image_generation_call items that already
+// carry a finished image payload but remain status=generating. Codex Desktop skips rendering
+// and local persistence unless status is completed.
+func normalizeCodexImageGenerationCallStatus(payload []byte) []byte {
+	if len(payload) == 0 {
+		return payload
+	}
+	hadSSEPrefix := bytes.HasPrefix(payload, dataTag)
+	body := payload
+	if hadSSEPrefix {
+		body = bytes.TrimSpace(payload[len(dataTag):])
+	}
+	if !gjson.ValidBytes(body) {
+		return payload
+	}
+
+	eventType := gjson.GetBytes(body, "type").String()
+	switch eventType {
+	case "response.output_item.done", "response.output_item.added":
+		if !shouldCompleteImageGenerationCall(gjson.GetBytes(body, "item")) {
+			return payload
+		}
+		updated, err := sjson.SetBytes(body, "item.status", "completed")
+		if err != nil {
+			return payload
+		}
+		return maybeWrapSSEData(hadSSEPrefix, updated)
+	case "response.completed", "response.done":
+		output := gjson.GetBytes(body, "response.output")
+		if !output.IsArray() {
+			return payload
+		}
+		updated := body
+		changed := false
+		for index, item := range output.Array() {
+			if !shouldCompleteImageGenerationCall(item) {
+				continue
+			}
+			path := "response.output." + strconv.Itoa(index) + ".status"
+			next, err := sjson.SetBytes(updated, path, "completed")
+			if err != nil {
+				return payload
+			}
+			updated = next
+			changed = true
+		}
+		if !changed {
+			return payload
+		}
+		return maybeWrapSSEData(hadSSEPrefix, updated)
+	default:
+		return payload
+	}
+}
+
+func shouldCompleteImageGenerationCall(item gjson.Result) bool {
+	if !item.Exists() || !item.IsObject() {
+		return false
+	}
+	if strings.TrimSpace(item.Get("type").String()) != "image_generation_call" {
+		return false
+	}
+	if strings.TrimSpace(item.Get("result").String()) == "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(item.Get("status").String())) {
+	case "", "generating", "in_progress", "incomplete":
+		return true
+	default:
+		return false
+	}
+}
+
+func maybeWrapSSEData(hadSSEPrefix bool, body []byte) []byte {
+	if !hadSSEPrefix {
+		return body
+	}
+	out := make([]byte, 0, len(dataTag)+1+len(body))
+	out = append(out, dataTag...)
+	out = append(out, ' ')
+	out = append(out, body...)
+	return out
 }

--- a/internal/runtime/executor/codex_image_generation_bridge_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"net/http"
 	"testing"
 
@@ -72,5 +73,35 @@ func TestMaybeEnsureCodexImageGenerationToolSkipsSparkAndLite(t *testing.T) {
 	out = maybeEnsureCodexImageGenerationTool(liteBody, auth, "gpt-5.4", headers)
 	if gjson.GetBytes(out, "tools").Exists() {
 		t.Fatalf("responses-lite should not inject tools; body=%s", out)
+	}
+}
+
+func TestNormalizeCodexImageGenerationCallStatusCompletesGeneratingWithResult(t *testing.T) {
+	in := []byte(`data: {"type":"response.output_item.done","item":{"id":"ig_1","type":"image_generation_call","status":"generating","result":"iVBORw0KGgo="}}`)
+	out := normalizeCodexImageGenerationCallStatus(in)
+	if got := gjson.GetBytes(bytes.TrimSpace(out[5:]), "item.status").String(); got != "completed" {
+		t.Fatalf("item.status = %q, want completed; out=%s", got, out)
+	}
+	if !bytes.HasPrefix(out, dataTag) {
+		t.Fatalf("expected SSE data prefix, got %s", out)
+	}
+}
+
+func TestNormalizeCodexImageGenerationCallStatusCompletesResponseOutput(t *testing.T) {
+	in := []byte(`{"type":"response.completed","response":{"output":[{"type":"image_generation_call","status":"generating","result":"ZmFrZQ=="},{"type":"message","status":"completed"}]}}`)
+	out := normalizeCodexImageGenerationCallStatus(in)
+	if got := gjson.GetBytes(out, "response.output.0.status").String(); got != "completed" {
+		t.Fatalf("output.0.status = %q, want completed; out=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.output.1.status").String(); got != "completed" {
+		t.Fatalf("output.1.status = %q, want completed; out=%s", got, out)
+	}
+}
+
+func TestNormalizeCodexImageGenerationCallStatusSkipsWithoutResult(t *testing.T) {
+	in := []byte(`{"type":"response.output_item.done","item":{"type":"image_generation_call","status":"generating"}}`)
+	out := normalizeCodexImageGenerationCallStatus(in)
+	if !bytes.Equal(in, out) {
+		t.Fatalf("payload changed without result: %s", out)
 	}
 }

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -510,6 +510,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 
 			payload = normalizeCodexWebsocketCompletion(payload)
+			payload = normalizeCodexImageGenerationCallStatus(payload)
 			eventType := gjson.GetBytes(payload, "type").String()
 			if eventType == "response.completed" || eventType == "response.done" {
 				if detail, ok := parseCodexUsage(payload); ok {


### PR DESCRIPTION
## Summary
- Upstream/ChatGPT sometimes returns `image_generation_call` with a full `result` PNG while `status` stays `generating`.
- Codex Desktop then skips image rendering and does not write `~/.codex/generated_images`.
- Normalize outbound HTTP SSE and WebSocket events: if `result` is present and status is empty/`generating`/`in_progress`/`incomplete`, set `status=completed`.

## Test plan
- [x] `go test ./internal/runtime/executor/ -count=1`
- [x] unit tests for SSE item.done, response.completed output[], and no-result skip

## Evidence
Local rollout for session `019f64b9-...` had `result` (~2.8MB PNG) with `status=generating`; UI showed text only.