### PR TITLE
fix(codex): Desktop prefer local image_gen over hosted injection

### DIFF
--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -23,13 +23,60 @@ var (
 
 // maybeEnsureCodexImageGenerationTool injects the Responses-native
 // image_generation tool when the Codex OAuth account has the bridge enabled.
-// Independent /v1/images/* paths already force the tool; this covers normal
-// Codex CLI /responses text turns that lack a local image_gen namespace.
+//
+// Codex Desktop must keep the local image_gen extension path (Images API +
+// generated_images disk save). Hosted image_generation returns base64-only
+// image_generation_call items that Desktop does not render, so Desktop
+// requests never inject and any hosted tool is stripped.
 func maybeEnsureCodexImageGenerationTool(body []byte, auth *cliproxyauth.Auth, baseModel string, headers http.Header) []byte {
+	if isCodexDesktopClient(headers) {
+		return stripHostedImageGenerationTools(body)
+	}
 	if !codexImageGenerationBridgeEnabled(auth) {
 		return body
 	}
 	return ensureCodexImageGenerationTool(body, baseModel, auth, headers)
+}
+
+func isCodexDesktopClient(headers http.Header) bool {
+	if headers == nil {
+		return false
+	}
+	originator := strings.ToLower(strings.TrimSpace(headers.Get("Originator")))
+	if strings.Contains(originator, "codex desktop") || strings.Contains(originator, "codex_desktop") {
+		return true
+	}
+	ua := strings.ToLower(strings.TrimSpace(headers.Get("User-Agent")))
+	return strings.Contains(ua, "codex desktop")
+}
+
+// stripHostedImageGenerationTools removes Responses-native image_generation tools
+// so the model falls back to the client's local image_gen namespace when present.
+func stripHostedImageGenerationTools(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if tools.IsArray() {
+		kept := make([]any, 0, len(tools.Array()))
+		removed := false
+		for _, tool := range tools.Array() {
+			if strings.TrimSpace(tool.Get("type").String()) == "image_generation" {
+				removed = true
+				continue
+			}
+			kept = append(kept, tool.Value())
+		}
+		if removed {
+			if len(kept) == 0 {
+				body, _ = sjson.DeleteBytes(body, "tools")
+			} else {
+				body, _ = sjson.SetBytes(body, "tools", kept)
+			}
+		}
+	}
+	choiceType := strings.TrimSpace(gjson.GetBytes(body, "tool_choice.type").String())
+	if choiceType == "image_generation" {
+		body, _ = sjson.SetBytes(body, "tool_choice", "auto")
+	}
+	return body
 }
 
 func codexImageGenerationBridgeEnabled(auth *cliproxyauth.Auth) bool {

--- a/internal/runtime/executor/codex_image_generation_bridge_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_test.go
@@ -105,3 +105,41 @@ func TestNormalizeCodexImageGenerationCallStatusSkipsWithoutResult(t *testing.T)
 		t.Fatalf("payload changed without result: %s", out)
 	}
 }
+
+func TestMaybeEnsureCodexImageGenerationToolSkipsInjectForDesktop(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"codex_image_generation_bridge": true},
+	}
+	headers := http.Header{}
+	headers.Set("Originator", "Codex Desktop")
+	headers.Set("User-Agent", "Codex Desktop/0.144.2 (Mac OS 26.5.2; arm64)")
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"shell"}]}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.4", headers)
+	if gjson.GetBytes(out, "tools.#").Int() != 1 {
+		t.Fatalf("tools count = %d, want 1 (no inject); body=%s", gjson.GetBytes(out, "tools.#").Int(), out)
+	}
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "function" {
+		t.Fatalf("tools.0.type = %q, want function; body=%s", got, out)
+	}
+}
+
+func TestMaybeEnsureCodexImageGenerationToolStripsHostedForDesktop(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"codex_image_generation_bridge": true},
+	}
+	headers := http.Header{}
+	headers.Set("User-Agent", "Codex Desktop/0.144.2")
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"image_generation","output_format":"png"},{"type":"namespace","name":"image_gen","tools":[{"type":"function","name":"imagegen"}]}],"tool_choice":{"type":"image_generation"}}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.4", headers)
+	if gjson.GetBytes(out, "tools.#").Int() != 1 {
+		t.Fatalf("tools count = %d, want 1; body=%s", gjson.GetBytes(out, "tools.#").Int(), out)
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "image_gen" {
+		t.Fatalf("remaining tool = %q, want image_gen; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "tool_choice").String(); got != "auto" {
+		t.Fatalf("tool_choice = %q, want auto; body=%s", got, out)
+	}
+}


### PR DESCRIPTION
## Summary
- Codex Desktop renders images only when the local `image_gen` extension saves files under `generated_images` via `/v1/images/*`.
- Hosted `tools:[{type:image_generation}]` injection produces `image_generation_call{result:base64}` that Desktop stores in rollout but does not display (`saved_path` stays empty).
- For Desktop Originator/User-Agent: do not inject hosted tool; strip any hosted `image_generation` tool/tool_choice so the model uses local `image_gen` instead.

## Evidence
- User session after status=completed fix still had full PNG result but empty `generated_images` / no UI preview.
- Official Codex extension path saves to disk; hosted path maps `saved_path: None`.

## Test plan
- [x] `go test ./internal/runtime/executor/ -count=1`
- [x] unit tests: Desktop no-inject, Desktop strip hosted while keeping `image_gen` namespace