### PR TITLE
fix(codex): force image_generation tool_choice on draw intent

### DIFF
--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -34,6 +34,8 @@ var (
 //     strip hosted image_generation so Desktop uses /v1/images + disk save path.
 //  2. Else if account bridge is enabled, inject hosted image_generation + bridge instructions.
 //     API-key custom providers typically do not expose local image_gen, so hosted is required.
+//  3. When image intent is present and only hosted tool is available, force
+//     tool_choice=image_generation so the model cannot skip the tool and reply with text.
 func maybeEnsureCodexImageGenerationTool(body []byte, auth *cliproxyauth.Auth, baseModel string, headers http.Header) []byte {
 	if requestHasLocalImageGenTool(body) {
 		return stripHostedImageGenerationTools(body)
@@ -44,7 +46,114 @@ func maybeEnsureCodexImageGenerationTool(body []byte, auth *cliproxyauth.Auth, b
 	body = ensureCodexImageGenerationTool(body, baseModel, auth, headers)
 	if requestHasHostedImageGenerationTool(body) {
 		body = ensureCodexImageGenerationBridgeInstructions(body)
+		if requestLooksLikeImageGenerationIntent(body) {
+			body = forceCodexImageGenerationToolChoice(body)
+		}
 	}
+	return body
+}
+
+func requestLooksLikeImageGenerationIntent(body []byte) bool {
+	// Explicit Image Gen skill / slash-command markers from Codex Desktop.
+	markers := []string{
+		"[$imagegen]",
+		"<name>imagegen</name>",
+		"skills/.system/imagegen",
+		"$imagegen",
+		"image_gen.imagegen",
+		"built-in `image_gen`",
+		"built-in image_gen",
+	}
+	// Prefer scanning recent user text, not the whole body (tools/schema can be huge).
+	input := gjson.GetBytes(body, "input")
+	if input.Type == gjson.String {
+		lower := strings.ToLower(input.String())
+		for _, m := range markers {
+			if strings.Contains(lower, strings.ToLower(m)) {
+				return true
+			}
+		}
+		return looksLikeChineseImageRequest(lower) || looksLikeEnglishImageRequest(lower)
+	}
+	if input.IsArray() {
+		// Scan from the end: last user turn is decisive.
+		items := input.Array()
+		for i := len(items) - 1; i >= 0 && i >= len(items)-8; i-- {
+			item := items[i]
+			role := strings.TrimSpace(item.Get("role").String())
+			if role != "" && role != "user" {
+				continue
+			}
+			text := extractCodexInputItemText(item)
+			if text == "" {
+				continue
+			}
+			lower := strings.ToLower(text)
+			for _, m := range markers {
+				if strings.Contains(lower, strings.ToLower(m)) {
+					return true
+				}
+			}
+			if looksLikeChineseImageRequest(lower) || looksLikeEnglishImageRequest(lower) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func extractCodexInputItemText(item gjson.Result) string {
+	if item.Get("content").Type == gjson.String {
+		return item.Get("content").String()
+	}
+	content := item.Get("content")
+	if !content.IsArray() {
+		if t := item.Get("text"); t.Type == gjson.String {
+			return t.String()
+		}
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range content.Array() {
+		switch strings.TrimSpace(part.Get("type").String()) {
+		case "input_text", "output_text", "text":
+			if t := part.Get("text"); t.Type == gjson.String {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(t.String())
+			}
+		}
+	}
+	return b.String()
+}
+
+func looksLikeChineseImageRequest(lower string) bool {
+	// lower is already lowercased for ASCII; Chinese unchanged.
+	keys := []string{"画一", "画个", "画只", "画一张", "生成一张", "生成图片", "生图", "出图", "改图", "修图", "绘一张"}
+	for _, k := range keys {
+		if strings.Contains(lower, k) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeEnglishImageRequest(lower string) bool {
+	keys := []string{
+		"generate an image", "generate a image", "draw a ", "draw an ", "create an image",
+		"make an image", "edit this image", "image generation", "generate image",
+	}
+	for _, k := range keys {
+		if strings.Contains(lower, k) {
+			return true
+		}
+	}
+	return false
+}
+
+func forceCodexImageGenerationToolChoice(body []byte) []byte {
+	body, _ = sjson.SetRawBytes(body, "tool_choice", []byte(`{"type":"image_generation"}`))
 	return body
 }
 

--- a/internal/runtime/executor/codex_image_generation_bridge_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_test.go
@@ -161,3 +161,33 @@ func TestSynthesizeCodexImageDisplayMessageEvent(t *testing.T) {
 		t.Fatalf("display text missing data url: %s", text)
 	}
 }
+
+func TestMaybeEnsureForcesToolChoiceOnImageIntent(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"codex_image_generation_bridge": true},
+	}
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"shell"}],"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"[$imagegen] 给我画一个小猫"}]}]}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.4", nil)
+	if got := gjson.GetBytes(out, "tools.1.type").String(); got != "image_generation" {
+		t.Fatalf("tools.1.type = %q, want image_generation; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.type").String(); got != "image_generation" {
+		t.Fatalf("tool_choice.type = %q, want image_generation; body=%s", got, out)
+	}
+}
+
+func TestMaybeEnsureDoesNotForceToolChoiceWithoutIntent(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"codex_image_generation_bridge": true},
+	}
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"shell"}],"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"refactor this function"}]}]}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.4", nil)
+	if got := gjson.GetBytes(out, "tools.1.type").String(); got != "image_generation" {
+		t.Fatalf("tools.1.type = %q, want image_generation; body=%s", got, out)
+	}
+	if gjson.GetBytes(out, "tool_choice.type").String() == "image_generation" {
+		t.Fatalf("tool_choice should not force image_generation without intent; body=%s", out)
+	}
+}


### PR DESCRIPTION
## Root cause (this regression)
After restoring hosted bridge inject, Desktop still produced text-only turns:
- no `image_generation_call` in rollout
- no synthesized display message
- model said it drew a cat without calling any tool

Hosted tool was available but optional (`tool_choice` not forced), so the model skipped it.

## Fix
When bridge is enabled, no local `image_gen` is present, and the latest user turn looks like image intent (`[$imagegen]`, skill marker, 画/generate image phrases), set:
```json
"tool_choice": {"type":"image_generation"}
```
Keep existing:
- inject hosted tool + bridge instructions
- status=completed normalization
- markdown data-URL display synthesis

## Test plan
- [x] `go test ./internal/runtime/executor/ -count=1`
- [x] unit tests for force on intent / no force without intent