### PR TITLE
fix(codex): strip history data:image URLs to placeholders

### DIFF
--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -31,6 +31,12 @@ var (
 	// Only rewrite these when the same response already produced a hosted image_generation_call.
 	codexMntDataMarkdownRef = regexp.MustCompile(`!\[([^\]]*)\]\((?:sandbox:)?(/mnt/data/(\d+)\.([A-Za-z0-9]+))\)`)
 	codexMntDataBareRef     = regexp.MustCompile(`(?:sandbox:)?/mnt/data/(\d+)\.([A-Za-z0-9]+)`)
+
+	// Inbound history hygiene: Desktop re-sends prior assistant text that may contain multi-MB
+	// data:image URLs from our outbound display rewrite. Strip pixels, keep a short placeholder
+	// so the model still knows an image existed — zero server-side image storage.
+	codexMarkdownDataURLImage = regexp.MustCompile(`!\[([^\]]*)\]\(data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\r\n]{256,}\)`)
+	codexBareDataURLImage     = regexp.MustCompile(`data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\r\n]{256,}`)
 )
 
 // codexHostedImage is one completed hosted image_generation_call payload for Desktop rewrite.
@@ -806,4 +812,107 @@ func maybeWrapSSEData(hadSSEPrefix bool, body []byte) []byte {
 	out = append(out, ' ')
 	out = append(out, body...)
 	return out
+}
+
+// stripCodexHistoryDataURLImages removes multi-MB data:image payloads from request history
+// before upstream. Desktop keeps outbound data-url markdown for display, then re-sends it
+// on the next turn — that blows the model context (context_length_exceeded). Replace with
+// short placeholders only; do not cache image bytes on the server.
+func stripCodexHistoryDataURLImages(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	// Fast path: nothing to do when payload has neither markdown data URLs nor a large
+	// image_generation_call.result (Desktop usually only re-sends markdown data URLs).
+	hasDataURL := bytes.Contains(body, []byte("data:image/"))
+	hasIGResult := bytes.Contains(body, []byte(`"image_generation_call"`)) && bytes.Contains(body, []byte(`"result"`))
+	if !hasDataURL && !hasIGResult {
+		return body
+	}
+	seq := 0
+	nextPlaceholder := func(alt string) string {
+		seq++
+		alt = strings.TrimSpace(alt)
+		if alt == "" {
+			alt = "generated image"
+		}
+		// Keep alt for model semantics; URL is a stable non-pixel ref.
+		return fmt.Sprintf("![%s](cliproxy-image:%d)", alt, seq)
+	}
+
+	// Top-level string input (rare for Desktop).
+	if in := gjson.GetBytes(body, "input"); in.Type == gjson.String {
+		if next, ok := replaceCodexDataURLImagesInText(in.String(), nextPlaceholder); ok {
+			body, _ = sjson.SetBytes(body, "input", next)
+		}
+		return body
+	}
+
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body
+	}
+	for itemIndex, item := range input.Array() {
+		// Drop base64 from any re-sent image_generation_call history items.
+		if strings.TrimSpace(item.Get("type").String()) == "image_generation_call" {
+			if result := strings.TrimSpace(item.Get("result").String()); len(result) >= 256 {
+				path := fmt.Sprintf("input.%d.result", itemIndex)
+				body, _ = sjson.DeleteBytes(body, path)
+			}
+			continue
+		}
+		if !hasDataURL {
+			continue
+		}
+		// message / content text fields
+		if content := item.Get("content"); content.Type == gjson.String {
+			if next, ok := replaceCodexDataURLImagesInText(content.String(), nextPlaceholder); ok {
+				path := fmt.Sprintf("input.%d.content", itemIndex)
+				body, _ = sjson.SetBytes(body, path, next)
+			}
+			continue
+		}
+		if content := item.Get("content"); content.IsArray() {
+			for partIndex, part := range content.Array() {
+				partType := strings.TrimSpace(part.Get("type").String())
+				// Only rewrite text parts. Do not touch structured input_image (user uploads /
+				// vision) — those are intentional pixels, not Desktop session replay of our
+				// outbound markdown data URLs.
+				if partType != "input_text" && partType != "output_text" && partType != "text" {
+					continue
+				}
+				text := part.Get("text").String()
+				if next, ok := replaceCodexDataURLImagesInText(text, nextPlaceholder); ok {
+					path := fmt.Sprintf("input.%d.content.%d.text", itemIndex, partIndex)
+					body, _ = sjson.SetBytes(body, path, next)
+				}
+			}
+		}
+	}
+	return body
+}
+
+func replaceCodexDataURLImagesInText(text string, nextPlaceholder func(alt string) string) (string, bool) {
+	if text == "" || !strings.Contains(text, "data:image/") {
+		return text, false
+	}
+	out := text
+	out = codexMarkdownDataURLImage.ReplaceAllStringFunc(out, func(match string) string {
+		sub := codexMarkdownDataURLImage.FindStringSubmatch(match)
+		alt := ""
+		if len(sub) >= 2 {
+			alt = sub[1]
+		}
+		return nextPlaceholder(alt)
+	})
+	// Remaining bare data URLs (not wrapped in markdown).
+	if strings.Contains(out, "data:image/") {
+		out = codexBareDataURLImage.ReplaceAllStringFunc(out, func(string) string {
+			return nextPlaceholder("generated image")
+		})
+	}
+	if out == text {
+		return text, false
+	}
+	return out, true
 }

--- a/internal/runtime/executor/codex_image_generation_bridge_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_test.go
@@ -286,3 +286,73 @@ func TestMaybeEnsureDoesNotForceToolChoiceWithoutIntent(t *testing.T) {
 		t.Fatalf("tool_choice should not force image_generation without intent; body=%s", out)
 	}
 }
+
+func TestStripCodexHistoryDataURLImagesReplacesHugeMarkdown(t *testing.T) {
+	// ~2KB base64 payload (still above 256 threshold); real Desktop history is multi-MB.
+	b64 := strings.Repeat("A", 400)
+	body := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"画小猫"}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"给你画好了。\n\n![generated image](data:image/png;base64,` + b64 + `)"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"长什么样？"}]}
+		]
+	}`)
+	out := stripCodexHistoryDataURLImages(body)
+	asst := gjson.GetBytes(out, "input.1.content.0.text").String()
+	if strings.Contains(asst, "base64,") || strings.Contains(asst, strings.Repeat("A", 50)) {
+		preview := asst
+		if len(preview) > 200 {
+			preview = preview[:200]
+		}
+		t.Fatalf("base64 should be stripped; text_len=%d text=%q", len(asst), preview)
+	}
+	if !strings.Contains(asst, "![generated image](cliproxy-image:1)") {
+		t.Fatalf("want placeholder, got %q", asst)
+	}
+	if !strings.Contains(asst, "给你画好了") {
+		t.Fatalf("caption lost: %q", asst)
+	}
+	// Follow-up user text untouched.
+	if got := gjson.GetBytes(out, "input.2.content.0.text").String(); got != "长什么样？" {
+		t.Fatalf("user follow-up changed: %q", got)
+	}
+}
+
+func TestStripCodexHistoryDataURLImagesLeavesSmallDataURL(t *testing.T) {
+	// Tiny icons / test fixtures must not become placeholders.
+	body := []byte(`{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"see ![x](data:image/png;base64,aGVsbG8=)"}]}]}`)
+	out := stripCodexHistoryDataURLImages(body)
+	got := gjson.GetBytes(out, "input.0.content.0.text").String()
+	if !strings.Contains(got, "data:image/png;base64,aGVsbG8=") {
+		t.Fatalf("small data url should be kept: %q", got)
+	}
+}
+
+func TestSanitizeCodexResponsesRequestStripsHistoryDataURL(t *testing.T) {
+	b64 := strings.Repeat("B", 400)
+	body := []byte(`{"model":"gpt-5.4","max_tokens":99,"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"![cat](data:image/png;base64,` + b64 + `)"}]}]}`)
+	out := sanitizeCodexResponsesRequest(body)
+	if gjson.GetBytes(out, "max_tokens").Exists() {
+		t.Fatalf("max_tokens should still be stripped")
+	}
+	text := gjson.GetBytes(out, "input.0.content.0.text").String()
+	if strings.Contains(text, "base64,") {
+		t.Fatalf("history data url survived sanitize: %q", text)
+	}
+	if !strings.Contains(text, "cliproxy-image:") {
+		t.Fatalf("missing placeholder: %q", text)
+	}
+}
+
+func TestStripCodexHistoryDataURLImagesDropsImageGenerationCallResult(t *testing.T) {
+	b64 := strings.Repeat("C", 400)
+	body := []byte(`{"input":[{"type":"image_generation_call","id":"ig_1","result":"` + b64 + `","status":"completed"}]}`)
+	out := stripCodexHistoryDataURLImages(body)
+	if gjson.GetBytes(out, "input.0.result").Exists() {
+		t.Fatalf("image_generation_call.result should be deleted; payload=%s", out)
+	}
+	if got := gjson.GetBytes(out, "input.0.id").String(); got != "ig_1" {
+		t.Fatalf("id should remain, got %q", got)
+	}
+}

--- a/internal/runtime/executor/codex_responses.go
+++ b/internal/runtime/executor/codex_responses.go
@@ -28,6 +28,8 @@ func sanitizeCodexResponsesRequest(body []byte) []byte {
 		body, _ = sjson.DeleteBytes(body, field)
 	}
 	body = stripCodexResponsesImageGenerationSize(body)
+	// History hygiene: never forward multi-MB data:image blobs from Desktop session replay.
+	body = stripCodexHistoryDataURLImages(body)
 	return body
 }
 


### PR DESCRIPTION
## Summary
- Root cause of follow-up failures after image gen (`#1000205133`): Desktop re-sends assistant text containing multi-MB `data:image/...;base64,...` from our outbound display rewrite → upstream `context_length_exceeded` → UI shows `stream closed before response.completed`.
- **Inbound only**: before upstream `/responses`, strip huge history data-urls to `![alt](cliproxy-image:N)` placeholders.
- **No server image cache / storage** — zero memory-disk growth from this fix.
- Outbound Desktop display path unchanged (still works for first-turn render).

## Test plan
- [x] unit: huge markdown stripped; small data-url kept; image_generation_call.result dropped; sanitize path wired
- [x] `go test ./internal/runtime/executor/`
- [ ] after deploy: gen cat → ask “长什么样” succeeds without stream disconnect