### PR TITLE
fix: harden blue-green active slot failover

### DIFF
--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -86,6 +86,7 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 	for _, path := range []string{
 		"scripts/deploy-blue-green.sh",
 		"scripts/cleanup-drained-slot.sh",
+		"scripts/reconcile-active-slot.sh",
 	} {
 		cmd := exec.Command("bash", "-n", path)
 		if out, err := cmd.CombinedOutput(); err != nil {
@@ -103,6 +104,7 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`/healthz`,
 		`CLIRELAY_PORT=`,
 		`.active-port`,
+		`reconcile-active-slot.sh`,
 		`HEALTH_TIMEOUT_SECONDS`,
 		`SMOKE_TIMEOUT_SECONDS`,
 		`PUBLIC_BASE_URL`,
@@ -118,6 +120,7 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`scripts/cleanup-drained-slot.sh`,
 		`grep -v '\.bak\.'`,
 		`SCRIPT_VERSION`,
+		`TimeoutStopSec=90`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("deploy script missing guard %q", want)
@@ -143,13 +146,26 @@ func TestCleanupDrainedSlotStopsOnlyTheExpectedInactiveSlot(t *testing.T) {
 		t.Fatalf("create fake bin dir: %v", err)
 	}
 	logPath := tmp + "/systemctl.log"
-	fakeSystemctl := "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$SYSTEMCTL_LOG\"\n"
+	activeUnitPath := tmp + "/active-unit"
+	fakeSystemctl := `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+if [ "$1" = "is-active" ] && [ "$2" = "--quiet" ]; then
+  active="$(cat "$SYSTEMCTL_ACTIVE_UNIT" 2>/dev/null || true)"
+  if [ "${3:-}" = "$active" ]; then
+    exit 0
+  fi
+  exit 3
+fi
+`
 	if err := os.WriteFile(binDir+"/systemctl", []byte(fakeSystemctl), 0o755); err != nil {
 		t.Fatalf("write fake systemctl: %v", err)
 	}
 	activePortFile := tmp + "/.active-port"
 	if err := os.WriteFile(activePortFile, []byte("8319\n"), 0o644); err != nil {
 		t.Fatalf("write active port: %v", err)
+	}
+	if err := os.WriteFile(activeUnitPath, []byte("clirelay2-8319\n"), 0o644); err != nil {
+		t.Fatalf("write active unit: %v", err)
 	}
 
 	runCleanup := func() string {
@@ -158,6 +174,7 @@ func TestCleanupDrainedSlotStopsOnlyTheExpectedInactiveSlot(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"PATH="+binDir+":"+os.Getenv("PATH"),
 			"SYSTEMCTL_LOG="+logPath,
+			"SYSTEMCTL_ACTIVE_UNIT="+activeUnitPath,
 			"BASE_DIR="+tmp,
 			"ACTIVE_PORT_FILE="+activePortFile,
 		)
@@ -191,6 +208,59 @@ func TestCleanupDrainedSlotStopsOnlyTheExpectedInactiveSlot(t *testing.T) {
 	}
 	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
 		t.Fatalf("stale cleanup must not call systemctl, stat err = %v", err)
+	}
+}
+
+func TestReconcileActiveSlotRepairsStaleMarker(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := tmp + "/bin"
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create fake bin dir: %v", err)
+	}
+	statePath := tmp + "/active-unit"
+	activePortFile := tmp + "/.active-port"
+	fakeSystemctl := `#!/usr/bin/env bash
+if [ "$1" = "is-active" ] && [ "$2" = "--quiet" ]; then
+  active="$(cat "$SYSTEMCTL_ACTIVE_UNIT" 2>/dev/null || true)"
+  if [ "${3:-}" = "$active" ]; then
+    exit 0
+  fi
+  exit 3
+fi
+exit 1
+`
+	if err := os.WriteFile(binDir+"/systemctl", []byte(fakeSystemctl), 0o755); err != nil {
+		t.Fatalf("write fake systemctl: %v", err)
+	}
+	if err := os.WriteFile(activePortFile, []byte("8318\n"), 0o644); err != nil {
+		t.Fatalf("write active port: %v", err)
+	}
+	if err := os.WriteFile(statePath, []byte("clirelay2-8319\n"), 0o644); err != nil {
+		t.Fatalf("write active unit: %v", err)
+	}
+
+	cmd := exec.Command("bash", "scripts/reconcile-active-slot.sh")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"BASE_DIR="+tmp,
+		"ACTIVE_PORT_FILE="+activePortFile,
+		"SYSTEMCTL_ACTIVE_UNIT="+statePath,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("reconcile active slot: %v\n%s", err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	got := strings.TrimSpace(lines[len(lines)-1])
+	if got != "8319" {
+		t.Fatalf("reconciled slot = %q, want 8319", got)
+	}
+	data, err := os.ReadFile(activePortFile)
+	if err != nil {
+		t.Fatalf("read active port file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "8319" {
+		t.Fatalf("active port file = %q, want 8319", got)
 	}
 }
 

--- a/internal/api/readyz.go
+++ b/internal/api/readyz.go
@@ -16,6 +16,15 @@ import (
 // handleReadyz reports whether this process is ready to receive traffic.
 // Unlike /healthz (liveness), readiness fails when required dependencies are unavailable.
 func (s *Server) handleReadyz(c *gin.Context) {
+	if s != nil && s.draining.Load() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"status":          "not_ready",
+			"reason":          "draining",
+			"in_flight_count": s.inFlightRequests.Load(),
+		})
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
 	defer cancel()
 

--- a/internal/api/routes/management_postgres_regression_test.go
+++ b/internal/api/routes/management_postgres_regression_test.go
@@ -17,6 +17,7 @@ import (
 	managementhandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/testutil/postgrestest"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -146,6 +147,7 @@ func setupPostgresManagementClient(t *testing.T) postgresManagementClient {
 	if strings.TrimSpace(dsn) == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
 
 	usage.CloseDB()
 	t.Cleanup(usage.CloseDB)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -94,6 +94,9 @@ type Server struct {
 	proxyWarmMu        sync.Mutex
 	proxyWarmManager   interface{ Stop() }
 	proxyWarmSignature string
+
+	draining         atomic.Bool
+	inFlightRequests atomic.Int64
 }
 
 // Start begins listening for and serving HTTP or HTTPS requests.
@@ -129,6 +132,9 @@ func (s *Server) Start() error {
 // active connections and closes the management handler before the HTTP server.
 func (s *Server) Stop(ctx context.Context) error {
 	log.Debug("Stopping API server...")
+	s.draining.Store(true)
+	s.server.SetKeepAlivesEnabled(false)
+	log.Infof("API server entering draining mode with %d in-flight request(s)", s.inFlightRequests.Load())
 
 	if s.keepAliveEnabled {
 		select {
@@ -144,6 +150,7 @@ func (s *Server) Stop(ctx context.Context) error {
 
 	// Shutdown the HTTP server.
 	if err := s.server.Shutdown(ctx); err != nil {
+		log.Errorf("API server shutdown timed out with %d in-flight request(s)", s.inFlightRequests.Load())
 		return fmt.Errorf("failed to shutdown HTTP server: %v", err)
 	}
 

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -129,6 +129,11 @@ func (s *Server) installDynamicMiddleware(configFilePath string) {
 	if s == nil || s.engine == nil {
 		return
 	}
+	s.engine.Use(func(c *gin.Context) {
+		s.inFlightRequests.Add(1)
+		defer s.inFlightRequests.Add(-1)
+		c.Next()
+	})
 	s.engine.Use(corsMiddleware(func() *config.Config {
 		if s.cfg != nil {
 			return s.cfg

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -143,6 +143,23 @@ func TestReadyzFailsWhenRedisEnabledButUnreachable(t *testing.T) {
 	}
 }
 
+func TestReadyzFailsWhenServerIsDraining(t *testing.T) {
+	server := newTestServer(t)
+	server.inFlightRequests.Store(3)
+	server.draining.Store(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"reason":"draining"`) {
+		t.Fatalf("expected draining response, got body=%s", rr.Body.String())
+	}
+}
+
 func TestAmpProviderModelRoutes(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/internal/identity/postgres_test.go
+++ b/internal/identity/postgres_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/testutil/postgrestest"
 )
 
 func TestPostgresIdentityLifecycle(t *testing.T) {
@@ -17,6 +18,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if dsn == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
 	ctx := context.Background()
 	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
 	if err != nil {

--- a/internal/storage/postgres/sqliteinventory/import_test.go
+++ b/internal/storage/postgres/sqliteinventory/import_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/testutil/postgrestest"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	_ "modernc.org/sqlite"
@@ -22,6 +23,7 @@ func TestImportSQLiteDryRunAndApply(t *testing.T) {
 	if dsn == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
 	ctx := context.Background()
 	pgDB, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
 	if err != nil {
@@ -179,6 +181,7 @@ func TestImportSQLiteApplyUsesPostgresLockAndCompletionMarker(t *testing.T) {
 	if dsn == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
 	ctx := context.Background()
 	pgDB, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
 	if err != nil {
@@ -286,6 +289,7 @@ func TestImportSQLiteUsesSingleSourceSnapshot(t *testing.T) {
 	if dsn == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
 	ctx := context.Background()
 	pgDB, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
 	if err != nil {

--- a/internal/testutil/postgrestest/shared_runtime_lock.go
+++ b/internal/testutil/postgrestest/shared_runtime_lock.go
@@ -1,0 +1,53 @@
+package postgrestest
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres/compatdriver"
+)
+
+const sharedRuntimeLockSQL = `SELECT pg_advisory_lock(hashtext('clirelay_shared_runtime_test_db')::bigint)`
+const sharedRuntimeUnlockSQL = `SELECT pg_advisory_unlock(hashtext('clirelay_shared_runtime_test_db')::bigint)`
+
+// LockSharedRuntimeDB serializes tests that mutate the shared
+// CLIRELAY_POSTGRES_TEST_DSN runtime catalog. CI runs packages in parallel,
+// so tests that TRUNCATE the same runtime tables must coordinate explicitly.
+func LockSharedRuntimeDB(t *testing.T, dsn string) {
+	t.Helper()
+
+	if strings.TrimSpace(dsn) == "" {
+		t.Fatal("postgres test dsn is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	db, err := sql.Open(compatdriver.DriverName, dsn)
+	if err != nil {
+		cancel()
+		t.Fatalf("open postgres test lock db: %v", err)
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		_ = db.Close()
+		cancel()
+		t.Fatalf("open postgres test lock conn: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, sharedRuntimeLockSQL); err != nil {
+		_ = conn.Close()
+		_ = db.Close()
+		cancel()
+		t.Fatalf("acquire postgres shared runtime test lock: %v", err)
+	}
+
+	t.Cleanup(func() {
+		unlockCtx, unlockCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer unlockCancel()
+		_, _ = conn.ExecContext(unlockCtx, sharedRuntimeUnlockSQL)
+		_ = conn.Close()
+		_ = db.Close()
+		cancel()
+	})
+}

--- a/internal/usage/postgres_integration_test.go
+++ b/internal/usage/postgres_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/testutil/postgrestest"
 )
 
 func TestPostgresRuntimeDataStackIntegration(t *testing.T) {
@@ -18,6 +19,7 @@ func TestPostgresRuntimeDataStackIntegration(t *testing.T) {
 	if dsn == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
 	CloseDB()
 	t.Cleanup(CloseDB)
 
@@ -137,6 +139,7 @@ func TestPostgresRuntimeDataStackConcurrencyConstraintsAndHotPaths(t *testing.T)
 	if dsn == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
 	CloseDB()
 	t.Cleanup(CloseDB)
 

--- a/internal/usage/redis_runtime_test.go
+++ b/internal/usage/redis_runtime_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/testutil/postgrestest"
 )
 
 func TestRedisRuntimeLockAndQueue(t *testing.T) {
@@ -81,6 +82,7 @@ func TestRedisUnavailableDoesNotBlockPostgresCRUD(t *testing.T) {
 	if dsn == "" {
 		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
 	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
 	CloseDB()
 	t.Cleanup(CloseDB)
 	if err := InitPostgres(config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1}, config.RequestLogStorageConfig{}, time.UTC); err != nil {

--- a/scripts/cleanup-drained-slot.sh
+++ b/scripts/cleanup-drained-slot.sh
@@ -24,6 +24,11 @@ if [ "$current_active_port" != "$expected_active_port" ]; then
 	exit 0
 fi
 
+if ! systemctl is-active --quiet "${SERVICE_NAME}-${expected_active_port}"; then
+	echo "Refusing to drain ${old_port}: expected active slot ${expected_active_port} is not running."
+	exit 1
+fi
+
 for old_unit in "$SERVICE_NAME" "${SERVICE_NAME}-${old_port}"; do
 	if [ "$old_unit" != "${SERVICE_NAME}-${expected_active_port}" ]; then
 		systemctl disable --now "$old_unit" 2>/dev/null || systemctl stop "$old_unit" 2>/dev/null || true

--- a/scripts/clirelay-gha-deploy
+++ b/scripts/clirelay-gha-deploy
@@ -13,6 +13,7 @@ STAGED="${IN}/cli-proxy-api-new"
 [ -f "$STAGED" ] || { echo "missing staged binary: $STAGED" >&2; exit 1; }
 [ -x "${SCRIPTS}/deploy-blue-green.sh" ] || { echo "root-managed deploy-blue-green.sh missing" >&2; exit 1; }
 [ -x "${SCRIPTS}/cleanup-drained-slot.sh" ] || { echo "root-managed cleanup-drained-slot.sh missing" >&2; exit 1; }
+[ -x "${SCRIPTS}/reconcile-active-slot.sh" ] || { echo "root-managed reconcile-active-slot.sh missing" >&2; exit 1; }
 
 # Validate commit marker on the staged file BEFORE touching slot binaries.
 COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SCRIPT_VERSION must stay in sync with deploy gate expectations.
-SCRIPT_VERSION="${SCRIPT_VERSION:-2026.07.14}"
+SCRIPT_VERSION="${SCRIPT_VERSION:-2026.07.16}"
 set -euo pipefail
 
 SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
@@ -22,6 +22,7 @@ SERVICE_TASKS_MAX="${SERVICE_TASKS_MAX:-512}"
 COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
 ACTIVE_PORT_FILE="${BASE_DIR}/.active-port"
 CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-${BASE_DIR}/scripts/cleanup-drained-slot.sh}"
+RECONCILE_SCRIPT="${RECONCILE_SCRIPT:-${BASE_DIR}/scripts/reconcile-active-slot.sh}"
 EXPECTED_SCRIPT_VERSION="${EXPECTED_SCRIPT_VERSION:-}"
 if [ -n "$EXPECTED_SCRIPT_VERSION" ] && [ "$SCRIPT_VERSION" != "$EXPECTED_SCRIPT_VERSION" ]; then
 	echo "deploy script version mismatch: have ${SCRIPT_VERSION}, want ${EXPECTED_SCRIPT_VERSION}" >&2
@@ -52,6 +53,7 @@ config_path="${config_path:-${service_dir}/config.yaml}"
 
 [ -f "$TEMP_BIN" ] || fail "uploaded temp binary not found: $TEMP_BIN"
 [ -f "$CLEANUP_SCRIPT" ] || fail "drain cleanup script not found: $CLEANUP_SCRIPT"
+[ -f "$RECONCILE_SCRIPT" ] || fail "active slot reconcile script not found: $RECONCILE_SCRIPT"
 [ -f "$config_path" ] || fail "config file not found: $config_path"
 
 read_config_scalar() {
@@ -95,7 +97,7 @@ case "${redis_enable,,}" in
 esac
 
 config_port="$(awk '/^port:[[:space:]]*[0-9]+/ {print $2; exit}' "$config_path" 2>/dev/null || true)"
-active_port="$(cat "$ACTIVE_PORT_FILE" 2>/dev/null || true)"
+active_port="$("$RECONCILE_SCRIPT")"
 active_port="${active_port:-${config_port:-$PORT_A}}"
 # Alternate between two local ports so nginx can cut over only after the new slot is healthy.
 case "$active_port" in
@@ -153,7 +155,7 @@ unit_file="/etc/systemd/system/${next_unit}.service"
 	echo "Restart=always"
 	echo "RestartSec=3"
 	echo "KillSignal=SIGTERM"
-	echo "TimeoutStopSec=45"
+	echo "TimeoutStopSec=90"
 	[ -n "$SERVICE_CPU_QUOTA" ] && echo "CPUQuota=${SERVICE_CPU_QUOTA}"
 	[ -n "$SERVICE_MEMORY_HIGH" ] && echo "MemoryHigh=${SERVICE_MEMORY_HIGH}"
 	[ -n "$SERVICE_MEMORY_MAX" ] && echo "MemoryMax=${SERVICE_MEMORY_MAX}"

--- a/scripts/reconcile-active-slot.sh
+++ b/scripts/reconcile-active-slot.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
+BASE_DIR="${BASE_DIR:-/opt/clirelay2}"
+PORT_A="${PORT_A:-8318}"
+PORT_B="${PORT_B:-8319}"
+ACTIVE_PORT_FILE="${ACTIVE_PORT_FILE:-${BASE_DIR}/.active-port}"
+
+trim_port() {
+	printf '%s' "${1:-}" | tr -d '[:space:]'
+}
+
+service_is_active() {
+	systemctl is-active --quiet "${SERVICE_NAME}-$1"
+}
+
+write_active_port() {
+	printf '%s\n' "$1" > "$ACTIVE_PORT_FILE"
+}
+
+recorded_port="$(trim_port "$(cat "$ACTIVE_PORT_FILE" 2>/dev/null || true)")"
+
+port_a_active=0
+port_b_active=0
+if service_is_active "$PORT_A"; then
+	port_a_active=1
+fi
+if service_is_active "$PORT_B"; then
+	port_b_active=1
+fi
+
+case "$recorded_port" in
+	"$PORT_A")
+		if [ "$port_a_active" -eq 1 ]; then
+			printf '%s\n' "$PORT_A"
+			exit 0
+		fi
+		;;
+	"$PORT_B")
+		if [ "$port_b_active" -eq 1 ]; then
+			printf '%s\n' "$PORT_B"
+			exit 0
+		fi
+		;;
+esac
+
+if [ "$port_a_active" -eq 1 ] && [ "$port_b_active" -eq 0 ]; then
+	write_active_port "$PORT_A"
+	echo "reconciled stale active slot from ${recorded_port:-unknown} to ${PORT_A}" >&2
+	printf '%s\n' "$PORT_A"
+	exit 0
+fi
+
+if [ "$port_b_active" -eq 1 ] && [ "$port_a_active" -eq 0 ]; then
+	write_active_port "$PORT_B"
+	echo "reconciled stale active slot from ${recorded_port:-unknown} to ${PORT_B}" >&2
+	printf '%s\n' "$PORT_B"
+	exit 0
+fi
+
+if [ "$port_a_active" -eq 1 ] && [ "$port_b_active" -eq 1 ]; then
+	case "$recorded_port" in
+		"$PORT_A"|"$PORT_B")
+			printf '%s\n' "$recorded_port"
+			exit 0
+			;;
+	esac
+	echo "both deploy slots are active but ${ACTIVE_PORT_FILE} is missing or invalid; refusing to guess active slot" >&2
+	exit 1
+fi
+
+echo "no active deploy slot is running; recorded active slot ${recorded_port:-unknown} is stale" >&2
+exit 1


### PR DESCRIPTION
## Summary
- add active slot reconciliation before blue-green cutover and block draining when the new active slot is not actually running
- make readiness fail immediately during shutdown and log in-flight request counts for drain diagnostics
- extend deployment workflow tests to cover stale `.active-port` recovery and the stronger deploy script guards

## Validation
- `bash -n scripts/deploy-blue-green.sh`
- `bash -n scripts/cleanup-drained-slot.sh`
- `bash -n scripts/reconcile-active-slot.sh`
- `bash -n scripts/clirelay-gha-deploy`
- `go test ./... -run 'Test(BlueGreenDeployScriptSyntaxAndGuards|CleanupDrainedSlotStopsOnlyTheExpectedInactiveSlot|ReconcileActiveSlotRepairsStaleMarker|Readyz(FailsWhenRedisEnabledButUnreachable|FailsWhenServerIsDraining)|HealthzReturnsNoContent|ReadyzReturnsNoContentWhenDependenciesOptionalOrUnset)$'`
