### PR TITLE
fix: cut AI Accounts page CPU from usage query storms

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -15,6 +15,15 @@ import (
 
 const authFileGroupTrendCacheTTL = 30 * time.Second
 
+// Short TTL for per-account card trend payloads. Cards re-fetch on page/view
+// changes; without this, concurrent auth-file-trend queries can stampede
+// request_logs aggregation on every AI Accounts visit.
+const authFileTrendCacheTTL = 20 * time.Second
+
+// Entity-stats is requested on every AI Accounts list load (30-day GROUP BY over
+// request_logs). A short shared cache absorbs remounts and multi-tab reloads.
+const entityUsageStatsCacheTTL = 20 * time.Second
+
 type UsageLogsHandler struct {
 	*Handler
 }
@@ -225,17 +234,29 @@ func (h *UsageLogsHandler) GetUsageChartData(c *gin.Context) {
 
 // GetEntityUsageStats returns aggregated statistics grouped by source or auth_index
 func (h *UsageLogsHandler) GetEntityUsageStats(c *gin.Context) {
-	payload, err := h.service(c).EntityUsageStats(
-		strings.TrimSpace(c.Query("api_key")),
-		intQueryDefault(c, "days", 7),
-		queryStringList(c, "auth_index"),
-		queryStringList(c, "source"),
-	)
+	apiKey := strings.TrimSpace(c.Query("api_key"))
+	days := intQueryDefault(c, "days", 7)
+	authIndexes := queryStringList(c, "auth_index")
+	sources := queryStringList(c, "source")
+
+	tenantID := identity.SystemTenantID
+	if principal, ok := principalFromContext(c); ok && strings.TrimSpace(principal.EffectiveTenant.ID) != "" {
+		tenantID = principal.EffectiveTenant.ID
+	}
+	cacheKey := "entity-stats:" + tenantID + ":" + apiKey + ":" + strconv.Itoa(days) + ":" +
+		strings.Join(authIndexes, ",") + ":" + strings.Join(sources, ",")
+	if cached, ok := h.getAuthFileTrendCache(cacheKey); ok {
+		c.JSON(http.StatusOK, cached)
+		return
+	}
+
+	payload, err := h.service(c).EntityUsageStats(apiKey, days, authIndexes, sources)
 	if err != nil {
 		log.Warnf("management usage logs: entity usage stats failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	h.setTrendCacheWithTTL(cacheKey, payload, entityUsageStatsCacheTTL)
 	c.JSON(http.StatusOK, payload)
 }
 
@@ -331,6 +352,25 @@ func (h *UsageLogsHandler) GetAuthFileTrend(c *gin.Context) {
 	if hours > 24 {
 		hours = 24
 	}
+
+	tenantID := identity.SystemTenantID
+	if principal, ok := principalFromContext(c); ok && strings.TrimSpace(principal.EffectiveTenant.ID) != "" {
+		tenantID = principal.EffectiveTenant.ID
+	}
+	if authIndex != "" {
+		cacheKey := "auth-file-trend:" + tenantID + ":" + authIndex + ":" + strconv.Itoa(days) + ":" + strconv.Itoa(hours)
+		if cached, ok := h.getAuthFileTrendCache(cacheKey); ok {
+			c.JSON(http.StatusOK, cached)
+			return
+		}
+		status, payload := h.service(c).AuthFileTrend(authIndex, days, hours)
+		if status == http.StatusOK {
+			h.setAuthFileTrendCache(cacheKey, payload)
+		}
+		c.JSON(status, payload)
+		return
+	}
+
 	status, payload := h.service(c).AuthFileTrend(authIndex, days, hours)
 	c.JSON(status, payload)
 }
@@ -411,6 +451,56 @@ func (h *UsageLogsHandler) setTrendCache(key string, payload managementusagelogs
 		}
 	}
 	h.trendCache[key] = trendCacheEntry{expiresAt: now.Add(authFileGroupTrendCacheTTL), payload: payload}
+}
+
+func (h *UsageLogsHandler) getAuthFileTrendCache(key string) (any, bool) {
+	if h == nil {
+		return nil, false
+	}
+	h.trendCacheMu.Lock()
+	defer h.trendCacheMu.Unlock()
+	entry, ok := h.trendCache[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		if ok {
+			delete(h.trendCache, key)
+		}
+		return nil, false
+	}
+	return entry.payload, true
+}
+
+func (h *UsageLogsHandler) setAuthFileTrendCache(key string, payload any) {
+	h.setTrendCacheWithTTL(key, payload, authFileTrendCacheTTL)
+}
+
+func (h *UsageLogsHandler) setTrendCacheWithTTL(key string, payload any, ttl time.Duration) {
+	if h == nil || payload == nil {
+		return
+	}
+	if ttl <= 0 {
+		ttl = authFileTrendCacheTTL
+	}
+	h.trendCacheMu.Lock()
+	defer h.trendCacheMu.Unlock()
+	if h.trendCache == nil {
+		h.trendCache = make(map[string]trendCacheEntry)
+	}
+	now := time.Now()
+	// Bound memory: drop expired entries and cap total cached keys.
+	const maxTrendCacheEntries = 256
+	for k, entry := range h.trendCache {
+		if now.After(entry.expiresAt) {
+			delete(h.trendCache, k)
+		}
+	}
+	if len(h.trendCache) >= maxTrendCacheEntries {
+		// Best-effort: drop an arbitrary entry when full (map iteration order).
+		for k := range h.trendCache {
+			delete(h.trendCache, k)
+			break
+		}
+	}
+	h.trendCache[key] = trendCacheEntry{expiresAt: now.Add(ttl), payload: payload}
 }
 
 func (h *UsageLogsHandler) clearTrendCache() {

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -12,8 +12,19 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607120001_dynamic_menus", SQL: dynamicMenusSQL},
 		{Version: "202607120002_menu_management_v2", SQL: menuManagementV2SQL},
 		{Version: "202607130001_model_config_openrouter_metadata", SQL: modelConfigOpenRouterMetadataSQL},
+		// AI Accounts page fans out entity-stats + per-card auth-file-trend over
+		// request_logs; composite indexes avoid sequential scans under concurrent load.
+		{Version: "202607160001_request_logs_auth_lookup_indexes", SQL: requestLogsAuthLookupIndexesSQL},
 	}
 }
+
+const requestLogsAuthLookupIndexesSQL = `
+CREATE INDEX IF NOT EXISTS idx_request_logs_tenant_auth_index_time
+  ON request_logs(tenant_id, auth_index, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_request_logs_tenant_auth_subject_time_cost
+  ON request_logs(tenant_id, auth_subject_id, timestamp DESC)
+  INCLUDE (cost);
+`
 
 const runtimeSchemaSQL = `
 CREATE TABLE IF NOT EXISTS request_logs (

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -7,8 +7,18 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 10 {
-		t.Fatalf("RuntimeMigrations len = %d, want 10", len(migrations))
+	if len(migrations) != 11 {
+		t.Fatalf("RuntimeMigrations len = %d, want 11", len(migrations))
+	}
+	// Latest migration: AI Accounts request_logs auth lookup indexes.
+	authLookupSQL := migrations[10].SQL
+	for _, fragment := range []string{
+		"idx_request_logs_tenant_auth_index_time",
+		"idx_request_logs_tenant_auth_subject_time_cost",
+	} {
+		if !strings.Contains(authLookupSQL, fragment) {
+			t.Fatalf("auth lookup index migration missing %q", fragment)
+		}
 	}
 	sqlText := migrations[0].SQL
 	for _, table := range []string{

--- a/internal/usage/auth_subject_usage_query.go
+++ b/internal/usage/auth_subject_usage_query.go
@@ -2,7 +2,6 @@ package usage
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 )
@@ -38,51 +37,40 @@ func QueryDailyUsageByAuthSubjectForTenant(tenantID string, matcher AuthSubjectM
 		return []DailyUsagePoint{}, nil
 	}
 
+	// Aggregate in SQL instead of streaming every matching request_logs row into Go.
+	// date(timestamp, 'localtime') is rewritten by the postgres compat driver to a
+	// UTC day key; production keeps process TZ aligned with the configured usage zone.
 	args := make([]interface{}, 0, len(matchArgs)+2)
 	args = append(args, tenantID, CutoffStartUTC(days).Format(time.RFC3339))
 	args = append(args, matchArgs...)
 
 	rows, err := db.Query(fmt.Sprintf(`
-		SELECT timestamp, cost
+		SELECT date(timestamp, 'localtime') as d, COUNT(*), COALESCE(SUM(cost), 0)
 		FROM request_logs
 		WHERE tenant_id = ? AND timestamp >= ? AND (%s)
-		ORDER BY timestamp ASC
+		GROUP BY d
+		ORDER BY d
 	`, matchSQL), args...)
 	if err != nil {
 		return nil, fmt.Errorf("usage: daily usage by auth subject query: %w", err)
 	}
 	defer rows.Close()
 
-	byDate := make(map[string]*DailyUsagePoint, days)
+	result := make([]DailyUsagePoint, 0, days)
 	for rows.Next() {
-		var ts storedTime
-		var cost float64
-		if err := rows.Scan(&ts, &cost); err != nil {
+		var point DailyUsagePoint
+		if err := rows.Scan(&point.Date, &point.Requests, &point.Cost); err != nil {
 			return nil, fmt.Errorf("usage: daily usage by auth subject scan: %w", err)
 		}
-		if !ts.Valid {
+		point.Date = strings.TrimSpace(point.Date)
+		if point.Date == "" {
 			continue
 		}
-		key := localDayKeyAt(ts.Time)
-		point := byDate[key]
-		if point == nil {
-			point = &DailyUsagePoint{Date: key}
-			byDate[key] = point
-		}
-		point.Requests++
-		point.Cost += cost
+		result = append(result, point)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-
-	result := make([]DailyUsagePoint, 0, len(byDate))
-	for _, point := range byDate {
-		result = append(result, *point)
-	}
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Date < result[j].Date
-	})
 	return result, nil
 }
 
@@ -135,6 +123,10 @@ func QueryHourlyUsageByAuthSubjectForTenant(tenantID string, matcher AuthSubject
 	args = append(args, tenantID, start.UTC().Format(time.RFC3339))
 	args = append(args, matchArgs...)
 
+	// Keep a narrow row scan for hourly (≤24h). SQL strftime('localtime') follows
+	// process TZ, which can diverge from getUsageLocation() in tests and some
+	// deployments; Go-side bucketing preserves the project timezone contract.
+	// Daily aggregation above is the expensive 7d path and stays SQL-side.
 	rows, err := db.Query(fmt.Sprintf(`
 		SELECT timestamp, cost
 		FROM request_logs

--- a/internal/usage/auth_subject_usage_query_test.go
+++ b/internal/usage/auth_subject_usage_query_test.go
@@ -1,0 +1,84 @@
+package usage
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// Regression: AI Accounts card trend used to SELECT every matching request_logs
+// row for the 7-day daily series and aggregate in Go, which pegged CPU on large
+// tenants. Daily totals must stay correct after SQL-side GROUP BY.
+func TestQueryDailyUsageByAuthSubjectAggregatesInSQL(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	loc := getUsageLocation()
+	nowLocal := time.Now().In(loc)
+	// Place three requests: two on "today" local day, one on yesterday local day.
+	todayMorning := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 9, 15, 0, 0, loc)
+	todayAfternoon := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 14, 45, 0, 0, loc)
+	yesterday := todayMorning.AddDate(0, 0, -1)
+
+	if err := UpsertModelPricing("gpt-5.4", 1, 1, 0); err != nil {
+		t.Fatalf("UpsertModelPricing: %v", err)
+	}
+
+	matcher := AuthSubjectMatcher{AuthIndexes: []string{"auth-sql-agg"}}
+	InsertLog("", "", "gpt-5.4", "codex", "Codex", "auth-sql-agg", false, yesterday.UTC(), 10, 1, TokenStats{
+		InputTokens: 1000, OutputTokens: 0, TotalTokens: 1000,
+	}, "", "")
+	InsertLog("", "", "gpt-5.4", "codex", "Codex", "auth-sql-agg", false, todayMorning.UTC(), 10, 1, TokenStats{
+		InputTokens: 1000, OutputTokens: 0, TotalTokens: 1000,
+	}, "", "")
+	InsertLog("", "", "gpt-5.4", "codex", "Codex", "auth-sql-agg", false, todayAfternoon.UTC(), 10, 1, TokenStats{
+		InputTokens: 2000, OutputTokens: 0, TotalTokens: 2000,
+	}, "", "")
+	// Noise row for a different auth_index must not appear.
+	InsertLog("", "", "gpt-5.4", "codex", "Codex", "auth-other", false, todayMorning.UTC(), 10, 1, TokenStats{
+		InputTokens: 9999, OutputTokens: 0, TotalTokens: 9999,
+	}, "", "")
+
+	daily, err := QueryDailyUsageByAuthSubject(matcher, 3)
+	if err != nil {
+		t.Fatalf("QueryDailyUsageByAuthSubject: %v", err)
+	}
+	byDate := map[string]DailyUsagePoint{}
+	for _, point := range daily {
+		byDate[point.Date] = point
+	}
+	todayKey := todayMorning.Format("2006-01-02")
+	yesterdayKey := yesterday.Format("2006-01-02")
+	if got := byDate[todayKey]; got.Requests != 2 {
+		t.Fatalf("today requests = %d cost=%v, want 2 (points=%+v)", got.Requests, got.Cost, daily)
+	}
+	if got := byDate[yesterdayKey]; got.Requests != 1 {
+		t.Fatalf("yesterday requests = %d, want 1 (points=%+v)", got.Requests, daily)
+	}
+	// Pricing is $1 / 1M input tokens → 1000+2000 tokens today = 0.003
+	if math.Abs(byDate[todayKey].Cost-0.003) > 1e-9 {
+		t.Fatalf("today cost = %v, want ~0.003", byDate[todayKey].Cost)
+	}
+
+	// Hourly path remains a narrow window; just ensure it still sees recent rows.
+	recent := time.Now().Add(-30 * time.Minute)
+	InsertLog("", "", "gpt-5.4", "codex", "Codex", "auth-sql-agg", false, recent.UTC(), 10, 1, TokenStats{
+		InputTokens: 500, OutputTokens: 0, TotalTokens: 500,
+	}, "", "")
+
+	hourly, err := QueryHourlyUsageByAuthSubject(matcher, 5)
+	if err != nil {
+		t.Fatalf("QueryHourlyUsageByAuthSubject: %v", err)
+	}
+	if len(hourly) != 5 {
+		t.Fatalf("hourly len = %d, want 5", len(hourly))
+	}
+	var hourlyTotal int64
+	for _, point := range hourly {
+		hourlyTotal += point.Requests
+	}
+	if hourlyTotal < 1 {
+		t.Fatalf("hourly total requests = %d, want >= 1 (buckets=%+v)", hourlyTotal, hourly)
+	}
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -317,6 +317,9 @@ func ensureRequestLogLookupIndexes(db *sql.DB) {
 		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_timestamp ON request_logs(api_key_id, timestamp DESC)",
 		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_chart_cover ON request_logs(api_key, api_key_id, timestamp DESC, model, failed, input_tokens, output_tokens, total_tokens, cost, cached_tokens)",
 		"CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_chart_cover ON request_logs(api_key_id, timestamp DESC, model, failed, input_tokens, output_tokens, total_tokens, cost, cached_tokens)",
+		// AI Accounts entity-stats / auth-file-trend: tenant + auth identity + time.
+		"CREATE INDEX IF NOT EXISTS idx_logs_tenant_auth_index_timestamp ON request_logs(tenant_id, auth_index, timestamp DESC)",
+		"CREATE INDEX IF NOT EXISTS idx_logs_tenant_auth_subject_timestamp ON request_logs(tenant_id, auth_subject_id, timestamp DESC)",
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			log.Warnf("usage: create request log lookup index: %v", err)


### PR DESCRIPTION
## Summary
- Aggregate daily auth-subject usage in SQL instead of streaming every matching `request_logs` row into Go (main CPU sink on AI Accounts card loads).
- Add 20s in-memory TTL cache for `/usage/entity-stats` and `/usage/auth-file-trend` so remount/multi-tab reloads do not stampede Postgres.
- Add Postgres/SQLite indexes on `(tenant_id, auth_index, timestamp)` and `(tenant_id, auth_subject_id, timestamp)` for AI Accounts lookup paths.

## Context
Opening `/manage/access/ai-accounts` concurrent-fires entity-stats (30d GROUP BY) plus per-card auth-file-trend (each fans into multiple aggregates). Production `request_logs` is ~545k rows / 1.3GB; entity-stats was Parallel Seq Scan (~146ms). Unbounded fan-out pegged CPU.

Hourly series stays Go-side over a ≤24h window to preserve project timezone semantics.

## Test plan
- [x] `go test ./internal/usage/ -run 'TestQueryDailyUsageByAuthSubjectAggregatesInSQL|TestQueryUsageByAuthSubjectMatchesLegacyEmailRows|TestQueryEntityStatsFiltersByRequestedEntities'`
- [x] `go test ./internal/api/handlers/management/ -run 'TestGetAuthFileTrend|TestGetEntityUsageStats'`
- [x] `go test ./internal/storage/postgres/`
- [x] `go test ./internal/api/handlers/management/`
- [ ] After merge: open AI Accounts, confirm cards still show cycle usage; check CPU stays low on reload within cache TTL