### PR TITLE
fix: stop dashboard-summary request_logs poll storms

### DIFF
--- a/internal/api/handlers/management/dashboard_summary.go
+++ b/internal/api/handlers/management/dashboard_summary.go
@@ -3,6 +3,7 @@ package management
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -12,6 +13,17 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	log "github.com/sirupsen/logrus"
 )
+
+// dashboardSummaryCacheTTL absorbs multi-tab and 5–20s frontend poll storms so
+// request_logs aggregation is not re-run on every refresh. Counts (API keys /
+// auth files) stay live; only KPI + trends payloads are cached.
+const dashboardSummaryCacheTTL = 15 * time.Second
+
+type dashboardSummaryUsageCache struct {
+	kpi             usage.DashboardKPI
+	trends          usage.DashboardTrends
+	throughputScope string
+}
 
 // GetDashboardSummary is a lightweight endpoint that returns only the
 // counts and KPIs needed by the frontend dashboard page, avoiding
@@ -65,14 +77,41 @@ func (h *Handler) GetDashboardSummary(c *gin.Context) {
 		days = v
 	}
 
-	kpi, _ := usage.QueryDashboardKPIForTenant(tenantID, days)
-	trends, _ := usage.QueryDashboardTrendsForTenant(tenantID, days)
-	throughputScope := "tenant"
+	scopeKey := "tenant"
 	if allTenantThroughput {
-		if series, err := usage.QueryDashboardThroughputAcrossTenants(); err == nil {
-			trends.ThroughputSeries = series
-			throughputScope = "all_tenants"
+		scopeKey = "all_tenants"
+	}
+	cacheKey := "dashboard-summary:" + tenantID + ":" + strconv.Itoa(days) + ":" + scopeKey
+
+	var (
+		kpi             usage.DashboardKPI
+		trends          usage.DashboardTrends
+		throughputScope string
+		fromCache       bool
+	)
+	if cached, ok := h.getDashboardSummaryCache(cacheKey); ok {
+		if payload, ok := cached.(dashboardSummaryUsageCache); ok {
+			kpi = payload.kpi
+			trends = payload.trends
+			throughputScope = payload.throughputScope
+			fromCache = true
 		}
+	}
+	if !fromCache {
+		kpi, _ = usage.QueryDashboardKPIForTenant(tenantID, days)
+		trends, _ = usage.QueryDashboardTrendsForTenant(tenantID, days)
+		throughputScope = "tenant"
+		if allTenantThroughput {
+			if series, err := usage.QueryDashboardThroughputAcrossTenants(); err == nil {
+				trends.ThroughputSeries = series
+				throughputScope = "all_tenants"
+			}
+		}
+		h.setDashboardSummaryCache(cacheKey, dashboardSummaryUsageCache{
+			kpi:             kpi,
+			trends:          trends,
+			throughputScope: throughputScope,
+		})
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -106,6 +145,47 @@ func (h *Handler) GetDashboardSummary(c *gin.Context) {
 		},
 		"days": days,
 	})
+}
+
+func (h *Handler) getDashboardSummaryCache(key string) (any, bool) {
+	if h == nil {
+		return nil, false
+	}
+	h.trendCacheMu.Lock()
+	defer h.trendCacheMu.Unlock()
+	entry, ok := h.trendCache[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		if ok {
+			delete(h.trendCache, key)
+		}
+		return nil, false
+	}
+	return entry.payload, true
+}
+
+func (h *Handler) setDashboardSummaryCache(key string, payload any) {
+	if h == nil || payload == nil {
+		return
+	}
+	h.trendCacheMu.Lock()
+	defer h.trendCacheMu.Unlock()
+	if h.trendCache == nil {
+		h.trendCache = make(map[string]trendCacheEntry)
+	}
+	now := time.Now()
+	const maxEntries = 256
+	for k, entry := range h.trendCache {
+		if now.After(entry.expiresAt) {
+			delete(h.trendCache, k)
+		}
+	}
+	if len(h.trendCache) >= maxEntries {
+		for k := range h.trendCache {
+			delete(h.trendCache, k)
+			break
+		}
+	}
+	h.trendCache[key] = trendCacheEntry{expiresAt: now.Add(dashboardSummaryCacheTTL), payload: payload}
 }
 
 func parsePositiveInt(s string) (int, error) {

--- a/internal/usage/request_log_dashboard.go
+++ b/internal/usage/request_log_dashboard.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -132,37 +133,59 @@ func QueryDashboardTrendsForTenant(tenantID string, days int) (DashboardTrends, 
 		byKey[buckets[i].key] = &buckets[i]
 	}
 
-	rows, err := db.Query(`
-		SELECT timestamp, failed, total_tokens
-		FROM request_logs
-		WHERE tenant_id = ? AND timestamp >= ?
-	`, normalizeTenantID(tenantID), CutoffStartUTC(days).Format(time.RFC3339))
+	// Aggregate in SQL instead of streaming every matching request_logs row into Go.
+	// Dashboard polls this path every few seconds; a full-row scan over multi-day
+	// windows was the 2026-07-16 load-incident root cause behind nginx 503 guards.
+	// date()/strftime(..., 'localtime') is rewritten by the postgres compat driver
+	// to a UTC day/hour key; production keeps process TZ aligned with the usage zone.
+	cutoff := CutoffStartUTC(days).Format(time.RFC3339)
+	tenantID = normalizeTenantID(tenantID)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if days == 1 {
+		// Hourly buckets: key shape is "2006-01-02 15" (no minutes).
+		rows, err = db.Query(`
+			SELECT strftime('%Y-%m-%d %H:00', timestamp, 'localtime') as h,
+			       failed, COUNT(*), COALESCE(SUM(total_tokens), 0)
+			FROM request_logs
+			WHERE tenant_id = ? AND timestamp >= ?
+			GROUP BY h, failed
+		`, tenantID, cutoff)
+	} else {
+		rows, err = db.Query(`
+			SELECT date(timestamp, 'localtime') as d,
+			       failed, COUNT(*), COALESCE(SUM(total_tokens), 0)
+			FROM request_logs
+			WHERE tenant_id = ? AND timestamp >= ?
+			GROUP BY d, failed
+		`, tenantID, cutoff)
+	}
 	if err != nil {
 		return DashboardTrends{}, fmt.Errorf("usage: query dashboard trends: %w", err)
 	}
 	defer rows.Close()
 
 	for rows.Next() {
-		var ts storedTime
+		var bucketKey string
 		var failedInt int
+		var requests int64
 		var totalTokens int64
-		if err := rows.Scan(&ts, &failedInt, &totalTokens); err != nil {
+		if err := rows.Scan(&bucketKey, &failedInt, &requests, &totalTokens); err != nil {
 			return DashboardTrends{}, fmt.Errorf("usage: scan dashboard trend row: %w", err)
 		}
-		if !ts.Valid {
-			continue
-		}
-		key := dashboardBucketKey(ts.Time.In(loc), days)
+		key := normalizeDashboardSQLBucketKey(bucketKey, days)
 		bucket := byKey[key]
 		if bucket == nil {
 			continue
 		}
-		bucket.requests++
+		bucket.requests += requests
 		bucket.totalToken += totalTokens
 		if failedInt != 0 {
-			bucket.failed++
+			bucket.failed += requests
 		} else {
-			bucket.success++
+			bucket.success += requests
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -177,6 +200,25 @@ func QueryDashboardTrendsForTenant(tenantID string, days int) (DashboardTrends, 
 	trends := dashboardTrendsFromBuckets(buckets)
 	trends.ThroughputSeries = throughputSeries
 	return trends, nil
+}
+
+// normalizeDashboardSQLBucketKey maps SQL group keys onto dashboardBucketKey shapes.
+// Hourly SQL uses "YYYY-MM-DD HH:00"; Go keys drop the trailing ":00".
+func normalizeDashboardSQLBucketKey(raw string, days int) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if days == 1 {
+		if strings.HasSuffix(raw, ":00") {
+			return strings.TrimSuffix(raw, ":00")
+		}
+		// Accept already-normalized "YYYY-MM-DD HH".
+		if len(raw) == len("2006-01-02 15") {
+			return raw
+		}
+	}
+	return raw
 }
 
 // QueryDashboardThroughputAcrossTenants returns the recent 7 RPM/TPM points


### PR DESCRIPTION
## Summary
- Aggregate dashboard trend buckets in SQL (`GROUP BY` day/hour + failed) instead of streaming every matching `request_logs` row into Go.
- Cache KPI + trends for 15s per tenant/days/scope so multi-tab dashboard polls no longer re-scan `request_logs` on every refresh. Live counts (API keys / auth files) stay uncached.
- Root cause of prod `/manage/dashboard` failure: nginx temporary incident guard returning `503 {"error":"temporarily disabled for load incident"}` on `/v0/management/dashboard-summary` after the poll storm.

## Test plan
- [x] `go test ./internal/usage/ ./internal/api/handlers/management/ ./internal/api/routes/ -count=1`
- [ ] After merge + deploy: remove nginx `location = /v0/management/dashboard-summary` 503 block and verify dashboard loads