### PR TITLE
fix: align deploy EXPECTED_SCRIPT_VERSION with host scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 15
     env:
       SHOULD_DEPLOY: ${{ github.event_name == 'workflow_dispatch' || vars.CLIRELAY_DEV_AUTO_DEPLOY == 'true' }}
-      EXPECTED_SCRIPT_VERSION: '2026.07.14'
+      EXPECTED_SCRIPT_VERSION: '2026.07.16'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
## Summary
- Host root-managed `deploy-blue-green.sh` is already `SCRIPT_VERSION=2026.07.16`.
- Workflow still sent `EXPECTED_SCRIPT_VERSION=2026.07.14`, so force deploy failed closed after PR #705.
- Align the gate so future `dev` / `workflow_dispatch` deploys can cut over.

## Test plan
- [ ] Next Deploy CliRelay run should not fail with `deploy script version mismatch`