### PR TITLE
fix: stop storing raw ISO strings in xAI weekly quota meta

### DIFF
--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -229,6 +229,9 @@ func TestParseXAIBillingFullSummaryAndPlan(t *testing.T) {
 	if weeklyLimit == nil || weeklyLimit.Percent == nil || *weeklyLimit.Percent != 70 || weeklyLimit.WindowSeconds != 604800 || weeklyLimit.ResetAt == nil {
 		t.Fatalf("weekly=%+v", weeklyLimit)
 	}
+	if weeklyLimit.Meta != "" {
+		t.Fatalf("weekly meta should be empty, got %q", weeklyLimit.Meta)
+	}
 	product := quotaByKey(weeklyItems, "product:grok-code")
 	if product == nil || product.Percent == nil || *product.Percent != 80 {
 		t.Fatalf("product=%+v", product)

--- a/internal/management/aiaccountstatus/probe_xai.go
+++ b/internal/management/aiaccountstatus/probe_xai.go
@@ -127,20 +127,11 @@ func parseXAIWeeklyBilling(body []byte) []usage.QuotaWindowDTO {
 	if !reset.Exists() {
 		reset = firstJSONResult(cfg, "billingPeriodEnd", "billing_period_end")
 	}
-	start := strings.TrimSpace(firstJSONResult(current, "start").String())
-	if start == "" {
-		start = strings.TrimSpace(firstJSONResult(cfg, "billingPeriodStart", "billing_period_start").String())
-	}
-	end := strings.TrimSpace(reset.String())
-	meta := ""
-	if start != "" && end != "" {
-		meta = start + " - " + end
-	} else {
-		meta = firstNonEmpty(end, start)
-	}
+	// Weekly cards already show relative reset from ResetAt; keep Meta empty so the
+	// UI is not flooded with raw ISO period strings like "2026-07-16T06:45:51+00:00 - …".
 	out := []usage.QuotaWindowDTO{{
 		QuotaKey: "weekly_limit", QuotaLabel: "xai_quota.weekly_limit", Percent: &remaining,
-		Value: formatPercent(remaining), ResetAt: parseFlexibleTime(reset), WindowSeconds: 604800, Meta: meta,
+		Value: formatPercent(remaining), ResetAt: parseFlexibleTime(reset), WindowSeconds: 604800,
 	}}
 	if products.IsArray() {
 		index := 0


### PR DESCRIPTION
## Summary
- xAI weekly_limit 不再写入原始 ISO period 到 `Meta`
- 前端卡片用 `ResetAt` 显示相对重置时间

## Test plan
- [x] `go test ./internal/management/aiaccountstatus/ -count=1`（39 passed）