### PR TITLE
feat: allow switching Grok OAuth endpoint after login

### DIFF
--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -145,5 +145,8 @@ func BuildEntry(auth *coreauth.Auth, opts EntryOptions) map[string]any {
 	if bridge := CodexImageGenerationBridgePayload(auth); len(bridge) > 0 {
 		entry["codex_image_generation_bridge"] = bridge
 	}
+	if xaiEndpoint := XAIEndpointPayload(auth); len(xaiEndpoint) > 0 {
+		entry["using_api"] = xaiEndpoint["using_api"]
+	}
 	return entry
 }

--- a/internal/management/authfiles/entry_test.go
+++ b/internal/management/authfiles/entry_test.go
@@ -175,6 +175,75 @@ func TestBuildEntryIncludesCodexOAuthAdmissionPayload(t *testing.T) {
 	}
 }
 
+func TestBuildEntryIncludesXAIUsingAPI(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "xai-oauth",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"runtime_only": "true",
+			"auth_kind":    "oauth",
+			"using_api":    "true",
+		},
+		Metadata: map[string]any{
+			"email":     "grok@example.com",
+			"auth_kind": "oauth",
+			"using_api": true,
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{})
+	if entry == nil {
+		t.Fatal("expected entry")
+	}
+	if got, _ := entry["using_api"].(bool); !got {
+		t.Fatalf("using_api = %#v, want true", entry["using_api"])
+	}
+}
+
+func TestBuildEntryDefaultsXAIUsingAPIToBuild(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "xai-oauth",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"runtime_only": "true",
+			"auth_kind":    "oauth",
+		},
+		Metadata: map[string]any{
+			"email":     "grok@example.com",
+			"auth_kind": "oauth",
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{})
+	if entry == nil {
+		t.Fatal("expected entry")
+	}
+	if got, ok := entry["using_api"].(bool); !ok || got {
+		t.Fatalf("using_api = %#v, want false", entry["using_api"])
+	}
+}
+
+func TestBuildEntryOmitsUsingAPIForNonXAI(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-oauth",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{})
+	if entry == nil {
+		t.Fatal("expected entry")
+	}
+	if _, ok := entry["using_api"]; ok {
+		t.Fatalf("using_api should be omitted for non-xAI: %#v", entry["using_api"])
+	}
+}
+
 func TestBuildEntryIncludesCodexImageGenerationBridgeEnabled(t *testing.T) {
 	auth := &coreauth.Auth{
 		ID:       "codex-oauth",

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -28,6 +28,8 @@ type FieldPatch struct {
 	CodexCLIOnlyAllowedClients *[]string `json:"codex_cli_only_allowed_clients"`
 	// CodexImageGenerationBridge injects Responses-native image_generation for Codex OAuth.
 	CodexImageGenerationBridge *bool `json:"codex_image_generation_bridge"`
+	// UsingAPI selects xAI official API vs Grok Build/CLI for OAuth accounts.
+	UsingAPI *bool `json:"using_api"`
 }
 
 type FieldPatchOptions struct {
@@ -251,6 +253,20 @@ func ApplyFieldPatch(auth *coreauth.Auth, patch FieldPatch, opts FieldPatchOptio
 		}
 		metadata := ensureMetadata(auth)
 		metadata[metadataKeyCodexImageGenerationBridge] = *patch.CodexImageGenerationBridge
+		changed = true
+	}
+	if patch.UsingAPI != nil {
+		if err := ensureXAIEndpointEditable(auth); err != nil {
+			return result, err
+		}
+		metadata := ensureMetadata(auth)
+		metadata["using_api"] = *patch.UsingAPI
+		attrs := ensureAttributes(auth)
+		if *patch.UsingAPI {
+			attrs["using_api"] = "true"
+		} else {
+			attrs["using_api"] = "false"
+		}
 		changed = true
 	}
 

--- a/internal/management/authfiles/patch_test.go
+++ b/internal/management/authfiles/patch_test.go
@@ -356,6 +356,69 @@ func TestApplyFieldPatchRejectsUnknownCodexAllowedClientPreset(t *testing.T) {
 	}
 }
 
+func TestApplyFieldPatchUpdatesXAIUsingAPI(t *testing.T) {
+	now := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+	usingAPI := true
+	auth := &coreauth.Auth{
+		ID:       "xai-oauth",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"using_api": "false",
+		},
+		Metadata: map[string]any{
+			"email":     "grok@example.com",
+			"auth_kind": "oauth",
+			"using_api": false,
+		},
+	}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{UsingAPI: &usingAPI}, FieldPatchOptions{Now: now})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if got, _ := auth.Metadata["using_api"].(bool); !got {
+		t.Fatalf("metadata using_api = %#v, want true", auth.Metadata["using_api"])
+	}
+	if auth.Attributes["using_api"] != "true" {
+		t.Fatalf("attributes using_api = %q, want true", auth.Attributes["using_api"])
+	}
+	if !auth.UpdatedAt.Equal(now) {
+		t.Fatalf("UpdatedAt = %v, want %v", auth.UpdatedAt, now)
+	}
+}
+
+func TestApplyFieldPatchRejectsUsingAPIForNonXAI(t *testing.T) {
+	usingAPI := true
+	auth := &coreauth.Auth{
+		ID:       "codex-oauth",
+		Provider: "codex",
+		Metadata: map[string]any{"email": "codex@example.com"},
+	}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{UsingAPI: &usingAPI}, FieldPatchOptions{})
+	if err == nil || !strings.Contains(err.Error(), "only supported for xAI OAuth") {
+		t.Fatalf("ApplyFieldPatch() error = %v, want xAI OAuth restriction", err)
+	}
+}
+
+func TestApplyFieldPatchRejectsUsingAPIForXAIAPIKey(t *testing.T) {
+	usingAPI := false
+	auth := &coreauth.Auth{
+		ID:       "xai-api-key",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"api_key":   "xai-key",
+			"auth_kind": "api_key",
+		},
+	}
+
+	_, err := ApplyFieldPatch(auth, FieldPatch{UsingAPI: &usingAPI}, FieldPatchOptions{})
+	if err == nil || !strings.Contains(err.Error(), "only supported for xAI OAuth") {
+		t.Fatalf("ApplyFieldPatch() error = %v, want xAI OAuth restriction", err)
+	}
+}
+
 func TestApplyFieldPatchRejectsNoFields(t *testing.T) {
 	auth := &coreauth.Auth{ID: "empty", Provider: "codex"}
 

--- a/internal/management/authfiles/xai_endpoint.go
+++ b/internal/management/authfiles/xai_endpoint.go
@@ -1,0 +1,70 @@
+package authfiles
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// XAIEndpointPayload returns the management-facing Grok endpoint mode for
+// xAI OAuth auth files (using_api: false=Build/CLI, true=official API).
+func XAIEndpointPayload(auth *coreauth.Auth) map[string]any {
+	if !isXAIEndpointEditableAuth(auth) {
+		return nil
+	}
+	return map[string]any{
+		"using_api": xaiUsingAPIFromAuth(auth),
+	}
+}
+
+func ensureXAIEndpointEditable(auth *coreauth.Auth) error {
+	if !isXAIEndpointEditableAuth(auth) {
+		return fmt.Errorf("using_api is only supported for xAI OAuth auth files")
+	}
+	return nil
+}
+
+func isXAIEndpointEditableAuth(auth *coreauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if provider != "xai" && provider != "grok" && provider != "x-ai" {
+		return false
+	}
+	if accountType, _ := auth.AccountInfo(); strings.EqualFold(accountType, "oauth") {
+		return true
+	}
+	if auth.Attributes != nil && strings.EqualFold(strings.TrimSpace(auth.Attributes["auth_kind"]), "oauth") {
+		return true
+	}
+	return strings.EqualFold(MetadataString(auth.Metadata, "auth_kind", "authKind"), "oauth")
+}
+
+// xaiUsingAPIFromAuth mirrors runtime routing defaults: attributes first,
+// then metadata; OAuth without a value defaults to Build (false).
+func xaiUsingAPIFromAuth(auth *coreauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.Attributes != nil {
+		if raw := strings.TrimSpace(auth.Attributes["using_api"]); raw != "" {
+			if usingAPI, err := strconv.ParseBool(raw); err == nil {
+				return usingAPI
+			}
+		}
+	}
+	if value, ok := MetadataBoolPresence(auth.Metadata, "using_api", "using-api", "usingApi"); ok {
+		return value
+	}
+	return false
+}
+
+func ensureAttributes(auth *coreauth.Auth) map[string]string {
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	return auth.Attributes
+}


### PR DESCRIPTION
## Summary
- Expose `using_api` on auth-file list entries for xAI OAuth accounts
- Accept `using_api` in `PATCH /auth-files/fields` (metadata + attributes dual-write)
- Enables management UI to switch Build/CLI vs official API without re-OAuth

## Test plan
- [x] `go test ./internal/management/authfiles/ ./internal/api/handlers/management/`
- [ ] PR CI green
- [ ] After deploy: open xAI OAuth card detail → switch endpoint → save → next request uses new base