### PR TITLE
fix: aggregate request-log channels by auth_subject_id

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -153,15 +153,17 @@ func TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers(t *testing
 
 	var payload struct {
 		Items []struct {
-			ChannelName string `json:"channel_name"`
-			AuthIndex   string `json:"auth_index"`
+			ChannelName   string `json:"channel_name"`
+			AuthIndex     string `json:"auth_index"`
+			AuthSubjectID string `json:"auth_subject_id"`
 		} `json:"items"`
 		Filters struct {
 			Channels       []string `json:"channels"`
 			ChannelOptions []struct {
-				Value     string `json:"value"`
-				Label     string `json:"label"`
-				AuthIndex string `json:"auth_index"`
+				Value         string `json:"value"`
+				Label         string `json:"label"`
+				AuthIndex     string `json:"auth_index"`
+				AuthSubjectID string `json:"auth_subject_id"`
 			} `json:"channel_options"`
 		} `json:"filters"`
 	}
@@ -175,8 +177,8 @@ func TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers(t *testing
 	if payload.Items[0].ChannelName != "tabcode-plus" {
 		t.Fatalf("channel_name = %q, want %q", payload.Items[0].ChannelName, "tabcode-plus")
 	}
-	// Filter facets use the live auth label / auth_index so renamed channels stay
-	// selectable as one account, while still matching historical rows by index.
+	// Filter facets use the live auth label / account subject so renamed channels
+	// stay selectable as one account, while still matching historical rows.
 	if len(payload.Filters.ChannelOptions) != 1 {
 		t.Fatalf("channel_options = %#v, want one option", payload.Filters.ChannelOptions)
 	}
@@ -184,8 +186,11 @@ func TestGetUsageLogsKeepsStoredChannelNameWhenCurrentAuthNameDiffers(t *testing
 	if opt.Label != "tabcode-pro" {
 		t.Fatalf("channel_options[0].label = %q, want tabcode-pro", opt.Label)
 	}
-	if opt.Value != auth.Index || opt.AuthIndex != auth.Index {
-		t.Fatalf("channel_options[0] value/auth_index = %#v, want auth index %q", opt, auth.Index)
+	if opt.AuthIndex != auth.Index {
+		t.Fatalf("channel_options[0].auth_index = %q, want %q", opt.AuthIndex, auth.Index)
+	}
+	if !strings.HasPrefix(opt.Value, "authsub_") || opt.AuthSubjectID != opt.Value {
+		t.Fatalf("channel_options[0] value/subject = %#v, want authsub_* subject", opt)
 	}
 	if len(payload.Filters.Channels) != 1 || payload.Filters.Channels[0] != "tabcode-pro" {
 		t.Fatalf("filters.channels = %#v, want [tabcode-pro]", payload.Filters.Channels)
@@ -1900,11 +1905,12 @@ func TestGetUsageLogsFiltersByOrphanAuthIndexWithoutLiveMeta(t *testing.T) {
 	var listPayload struct {
 		Filters struct {
 			ChannelOptions []struct {
-				Value     string `json:"value"`
-				Label     string `json:"label"`
-				Provider  string `json:"provider"`
-				AuthType  string `json:"auth_type"`
-				AuthIndex string `json:"auth_index"`
+				Value         string `json:"value"`
+				Label         string `json:"label"`
+				Provider      string `json:"provider"`
+				AuthType      string `json:"auth_type"`
+				AuthIndex     string `json:"auth_index"`
+				AuthSubjectID string `json:"auth_subject_id"`
 			} `json:"channel_options"`
 		} `json:"filters"`
 	}
@@ -1915,8 +1921,11 @@ func TestGetUsageLogsFiltersByOrphanAuthIndexWithoutLiveMeta(t *testing.T) {
 		t.Fatalf("channel_options = %#v, want one merged option", listPayload.Filters.ChannelOptions)
 	}
 	option := listPayload.Filters.ChannelOptions[0]
-	if option.Value != liveAuth.Index || option.AuthIndex != liveAuth.Index {
-		t.Fatalf("merged option value/auth_index = %#v, want live index %q", option, liveAuth.Index)
+	if option.AuthIndex != liveAuth.Index {
+		t.Fatalf("merged option auth_index = %q, want live index %q", option.AuthIndex, liveAuth.Index)
+	}
+	if !strings.HasPrefix(option.Value, "authsub_") || option.AuthSubjectID != option.Value {
+		t.Fatalf("merged option value/subject = %#v, want authsub_* subject", option)
 	}
 	if option.Label != "asherandersenloqv@outlook.com" || option.Provider != "xai" || option.AuthType != "oauth" {
 		t.Fatalf("merged option metadata = %#v", option)

--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -51,11 +51,11 @@ func (s *Service) UsageChartData(apiKey string, days int) (map[string]any, error
 		if err != nil {
 			return nil, err
 		}
-		keyNameMap, _, _, _, _, _ := s.buildNameMaps()
+		maps := s.buildNameMaps()
 
 		for i := range apikeyDist {
 			if apikeyDist[i].Name == "" {
-				if name, ok := keyNameMap[apikeyDist[i].APIKey]; ok {
+				if name, ok := maps.keyNameMap[apikeyDist[i].APIKey]; ok {
 					apikeyDist[i].Name = name
 				}
 			}

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -16,8 +16,18 @@ import (
 )
 
 func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any, error) {
-	keyNameMap, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex, authIndexGroup := s.buildNameMaps()
-	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex, authIndexGroup)
+	maps := s.buildNameMaps()
+	authSubjectIDs, authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(
+		input.Channels,
+		maps.channelNameMap,
+		maps.authIndexChannelMap,
+		maps.ambiguousAuthIndexChannelMap,
+		maps.authMetaByIndex,
+		maps.authIndexGroup,
+		maps.authSubjectByIndex,
+		maps.authIndexesBySubject,
+		maps.authMetaBySubject,
+	)
 
 	params := usage.LogQueryParams{
 		TenantID:              s.tenantID,
@@ -31,6 +41,7 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 		MatchNoModels:         input.MatchNoModels,
 		MatchNoStatuses:       input.MatchNoStatuses,
 		MatchNoChannels:       input.MatchNoChannels,
+		AuthSubjectIDs:        authSubjectIDs,
 		AuthIndexes:           authIndexes,
 		ChannelNames:          channelNames,
 		AuthIndexChannelNames: authIndexChannelNames,
@@ -52,25 +63,33 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	for i := range result.Items {
 		item := &result.Items[i]
 		if item.APIKeyName == "" {
-			if name, ok := keyNameMap[item.APIKey]; ok {
+			if name, ok := maps.keyNameMap[item.APIKey]; ok {
 				item.APIKeyName = name
 			}
 		}
-		if channelName := displayChannelNameForLog(*item, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap); channelName != "" {
+		if channelName := displayChannelNameForLog(*item, maps.channelNameMap, maps.authIndexChannelMap, maps.ambiguousAuthIndexChannelMap); channelName != "" {
 			item.ChannelName = channelName
 		}
-		enrichLogRowChannelMeta(item, authMetaByIndex)
+		enrichLogRowChannelMeta(item, maps.authMetaByIndex, maps.authMetaBySubject)
 	}
 
 	if filters.APIKeyNames == nil {
 		filters.APIKeyNames = make(map[string]string, len(filters.APIKeys))
 	}
 	for _, key := range filters.APIKeys {
-		if name, ok := keyNameMap[key]; ok {
+		if name, ok := maps.keyNameMap[key]; ok {
 			filters.APIKeyNames[key] = name
 		}
 	}
-	filters.ChannelOptions = enrichChannelFilterOptions(filters.ChannelOptions, channelNameMap, authIndexChannelMap, authMetaByIndex, authIndexGroup)
+	filters.ChannelOptions = enrichChannelFilterOptions(
+		filters.ChannelOptions,
+		maps.channelNameMap,
+		maps.authIndexChannelMap,
+		maps.authMetaByIndex,
+		maps.authIndexGroup,
+		maps.authSubjectByIndex,
+		maps.authMetaBySubject,
+	)
 	filters.Channels = channelLabelsFromOptions(filters.ChannelOptions)
 
 	if result.Items == nil {
@@ -122,8 +141,18 @@ func (s *Service) ClearRequestLogs(options usage.ClearRequestLogsOptions) (int, 
 }
 
 func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, error) {
-	_, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex, authIndexGroup := s.buildNameMaps()
-	authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(input.Channels, channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap, authMetaByIndex, authIndexGroup)
+	maps := s.buildNameMaps()
+	authSubjectIDs, authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(
+		input.Channels,
+		maps.channelNameMap,
+		maps.authIndexChannelMap,
+		maps.ambiguousAuthIndexChannelMap,
+		maps.authMetaByIndex,
+		maps.authIndexGroup,
+		maps.authSubjectByIndex,
+		maps.authIndexesBySubject,
+		maps.authMetaBySubject,
+	)
 	params := usage.LogQueryParams{
 		TenantID:              usage.ResolveAPIKeyTenant(input.APIKey),
 		Page:                  input.Page,
@@ -135,6 +164,7 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		MatchNoModels:         input.MatchNoModels,
 		MatchNoChannels:       input.MatchNoChannels,
 		MatchNoStatuses:       input.MatchNoStatuses,
+		AuthSubjectIDs:        authSubjectIDs,
 		AuthIndexes:           authIndexes,
 		ChannelNames:          channelNames,
 		AuthIndexChannelNames: authIndexChannelNames,
@@ -158,22 +188,33 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		if apiKeyName == "" {
 			apiKeyName = strings.TrimSpace(result.Items[i].APIKeyName)
 		}
-		channelName := displayChannelNameForLog(result.Items[i], channelNameMap, authIndexChannelMap, ambiguousAuthIndexChannelMap)
+		channelName := displayChannelNameForLog(result.Items[i], maps.channelNameMap, maps.authIndexChannelMap, maps.ambiguousAuthIndexChannelMap)
 		result.Items[i].Source = ""
 		result.Items[i].AuthIndex = ""
+		result.Items[i].AuthSubjectID = ""
 		result.Items[i].ChannelName = channelName
 		result.Items[i].APIKey = ""
 		result.Items[i].APIKeyName = ""
 		// Keep provider/auth_type for public UI badges, but strip identity keys above.
-		enrichLogRowChannelMeta(&result.Items[i], authMetaByIndex)
+		enrichLogRowChannelMeta(&result.Items[i], maps.authMetaByIndex, maps.authMetaBySubject)
 		result.Items[i].AuthIndex = ""
+		result.Items[i].AuthSubjectID = ""
 	}
 
-	filters.ChannelOptions = enrichChannelFilterOptions(filters.ChannelOptions, channelNameMap, authIndexChannelMap, authMetaByIndex, authIndexGroup)
-	// Public responses keep opaque filter values (auth_index) so same-email
-	// multi-provider accounts stay selectable, but strip the auth_index field.
+	filters.ChannelOptions = enrichChannelFilterOptions(
+		filters.ChannelOptions,
+		maps.channelNameMap,
+		maps.authIndexChannelMap,
+		maps.authMetaByIndex,
+		maps.authIndexGroup,
+		maps.authSubjectByIndex,
+		maps.authMetaBySubject,
+	)
+	// Public responses keep opaque filter values so same-email multi-provider
+	// accounts stay selectable, but strip explicit identity fields.
 	for i := range filters.ChannelOptions {
 		filters.ChannelOptions[i].AuthIndex = ""
+		filters.ChannelOptions[i].AuthSubjectID = ""
 	}
 	filters.Channels = channelLabelsFromOptions(filters.ChannelOptions)
 	if result.Items == nil {
@@ -214,13 +255,28 @@ type authChannelMeta struct {
 	authType string
 }
 
+type nameMaps struct {
+	keyNameMap                   map[string]string
+	channelNameMap               map[string]string
+	authIndexChannelMap          map[string]string
+	ambiguousAuthIndexChannelMap map[string][]string
+	authMetaByIndex              map[string]authChannelMeta
+	authIndexGroup               map[string][]string
+	authSubjectByIndex           map[string]string
+	authIndexesBySubject         map[string][]string
+	authMetaBySubject            map[string]authChannelMeta
+}
+
 func channelFilterSelectors(
 	channels []string,
 	channelNameMap, authIndexChannelMap map[string]string,
 	ambiguousAuthIndexChannelMap map[string][]string,
 	authMetaByIndex map[string]authChannelMeta,
 	authIndexGroup map[string][]string,
-) ([]string, []string, map[string][]string) {
+	authSubjectByIndex map[string]string,
+	authIndexesBySubject map[string][]string,
+	authMetaBySubject map[string]authChannelMeta,
+) ([]string, []string, []string, map[string][]string) {
 	// Preserve original selected values. Only use lower-case keys for label matching.
 	selectedRaw := make([]string, 0, len(channels))
 	selectedLabelKeys := make(map[string]struct{})
@@ -233,12 +289,14 @@ func channelFilterSelectors(
 		selectedLabelKeys[strings.ToLower(raw)] = struct{}{}
 	}
 	if len(selectedRaw) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
+	var authSubjectIDs []string
 	var authIndexes []string
 	var channelNames []string
 	authIndexChannelNames := make(map[string][]string)
+	seenSubject := make(map[string]struct{})
 	seenAuthIndex := make(map[string]struct{})
 	seenChannelName := make(map[string]struct{})
 
@@ -253,15 +311,38 @@ func channelFilterSelectors(
 		seenAuthIndex[idx] = struct{}{}
 		authIndexes = append(authIndexes, idx)
 	}
-	// Expand xAI OAuth historical aliases (id: vs file: seed) so one UI option
-	// returns logs written under either index.
-	appendAuthIndexGroup := func(idx string) {
+	appendSubject := func(subjectID string) {
+		subjectID = strings.TrimSpace(subjectID)
+		if subjectID == "" {
+			return
+		}
+		if _, ok := seenSubject[subjectID]; ok {
+			return
+		}
+		seenSubject[subjectID] = struct{}{}
+		authSubjectIDs = append(authSubjectIDs, subjectID)
+		// Also match historical credential-instance rows that predate subject
+		// population or still only carry auth_index.
+		for _, member := range authIndexesBySubject[subjectID] {
+			appendAuthIndex(member)
+		}
+	}
+	// Prefer subject when the index maps uniquely; otherwise expand known index groups.
+	appendAuthIndexOrSubject := func(idx string) {
 		idx = strings.TrimSpace(idx)
 		if idx == "" {
 			return
 		}
+		if subjectID := strings.TrimSpace(authSubjectByIndex[idx]); subjectID != "" {
+			appendSubject(subjectID)
+			return
+		}
 		if group := authIndexGroup[idx]; len(group) > 0 {
 			for _, member := range group {
+				if subjectID := strings.TrimSpace(authSubjectByIndex[member]); subjectID != "" {
+					appendSubject(subjectID)
+					continue
+				}
 				appendAuthIndex(member)
 			}
 			return
@@ -280,34 +361,46 @@ func channelFilterSelectors(
 		seenChannelName[key] = struct{}{}
 		channelNames = append(channelNames, name)
 	}
-
-	for _, raw := range selectedRaw {
-		// Prefer exact auth_index matches so multi-provider same-email accounts
-		// filter independently when clients send auth_index as the value.
-		if _, ok := authIndexChannelMap[raw]; ok {
-			appendAuthIndexGroup(raw)
-			if legacyChannels := ambiguousAuthIndexChannelMap[raw]; len(legacyChannels) > 0 {
-				authIndexChannelNames[raw] = append(authIndexChannelNames[raw], legacyChannels...)
+	attachLegacyNames := func(idx string) {
+		if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
+			authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
+		}
+		for _, member := range authIndexGroup[idx] {
+			if legacyChannels := ambiguousAuthIndexChannelMap[member]; len(legacyChannels) > 0 {
+				authIndexChannelNames[member] = append(authIndexChannelNames[member], legacyChannels...)
 			}
-			// Also attach legacy channel names for every expanded group member.
-			for _, member := range authIndexGroup[raw] {
+		}
+		if subjectID := strings.TrimSpace(authSubjectByIndex[idx]); subjectID != "" {
+			for _, member := range authIndexesBySubject[subjectID] {
 				if legacyChannels := ambiguousAuthIndexChannelMap[member]; len(legacyChannels) > 0 {
 					authIndexChannelNames[member] = append(authIndexChannelNames[member], legacyChannels...)
 				}
 			}
+		}
+	}
+
+	for _, raw := range selectedRaw {
+		// Account-level subject token from channel_options.value.
+		if _, ok := authMetaBySubject[raw]; ok || looksLikeAuthSubjectID(raw) {
+			appendSubject(raw)
+			continue
+		}
+		// Prefer exact auth_index matches so multi-provider same-email accounts
+		// filter independently when clients send auth_index as the value.
+		if _, ok := authIndexChannelMap[raw]; ok {
+			appendAuthIndexOrSubject(raw)
+			attachLegacyNames(raw)
 			continue
 		}
 		if _, ok := authMetaByIndex[raw]; ok {
-			appendAuthIndexGroup(raw)
+			appendAuthIndexOrSubject(raw)
 			continue
 		}
 		matchedAuthIndex := false
 		for idx := range authIndexChannelMap {
 			if strings.EqualFold(strings.TrimSpace(idx), raw) {
-				appendAuthIndexGroup(idx)
-				if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
-					authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
-				}
+				appendAuthIndexOrSubject(idx)
+				attachLegacyNames(idx)
 				matchedAuthIndex = true
 			}
 		}
@@ -316,7 +409,7 @@ func channelFilterSelectors(
 		}
 		for idx := range authMetaByIndex {
 			if strings.EqualFold(strings.TrimSpace(idx), raw) {
-				appendAuthIndexGroup(idx)
+				appendAuthIndexOrSubject(idx)
 				matchedAuthIndex = true
 			}
 		}
@@ -328,7 +421,7 @@ func channelFilterSelectors(
 		// stable auth_index tokens as AuthIndexes; never fall back to
 		// channel_name matching for them (that path yields 0 rows).
 		if looksLikeAuthIndex(raw) {
-			appendAuthIndexGroup(raw)
+			appendAuthIndexOrSubject(raw)
 			continue
 		}
 		// Legacy clients still send display labels / emails.
@@ -350,16 +443,14 @@ func channelFilterSelectors(
 			continue
 		}
 		if _, ok := selectedLabelKeys[key]; ok {
-			appendAuthIndexGroup(idx)
-			if legacyChannels := ambiguousAuthIndexChannelMap[idx]; len(legacyChannels) > 0 {
-				authIndexChannelNames[idx] = append(authIndexChannelNames[idx], legacyChannels...)
-			}
+			appendAuthIndexOrSubject(idx)
+			attachLegacyNames(idx)
 		}
 	}
-	if len(authIndexes) == 0 && len(channelNames) == 0 {
+	if len(authSubjectIDs) == 0 && len(authIndexes) == 0 && len(channelNames) == 0 {
 		authIndexes = []string{""}
 	}
-	return authIndexes, channelNames, authIndexChannelNames
+	return authSubjectIDs, authIndexes, channelNames, authIndexChannelNames
 }
 
 // looksLikeAuthIndex reports whether value matches the stable auth index format
@@ -384,19 +475,44 @@ func looksLikeAuthIndex(value string) bool {
 	return true
 }
 
+// looksLikeAuthSubjectID reports whether value matches stableAuthSubjectID output.
+func looksLikeAuthSubjectID(value string) bool {
+	value = strings.TrimSpace(value)
+	const prefix = "authsub_"
+	if !strings.HasPrefix(value, prefix) {
+		return false
+	}
+	hexPart := value[len(prefix):]
+	if len(hexPart) != 16 {
+		return false
+	}
+	for i := 0; i < len(hexPart); i++ {
+		c := hexPart[i]
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		case c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func enrichChannelFilterOptions(
 	options []usage.ChannelFilterOption,
 	channelNameMap, authIndexChannelMap map[string]string,
 	authMetaByIndex map[string]authChannelMeta,
 	authIndexGroup map[string][]string,
+	authSubjectByIndex map[string]string,
+	authMetaBySubject map[string]authChannelMeta,
 ) []usage.ChannelFilterOption {
 	if len(options) == 0 {
 		return make([]usage.ChannelFilterOption, 0)
 	}
 
-	// Prefer one option per live auth_index. Collapse pure name-only rows when
-	// the same label already has auth-backed options. For xAI OAuth, also
-	// collapse historical id:/file: seed aliases onto the canonical live index.
+	// Prefer one option per auth_subject_id. Fall back to auth_index for orphans.
+	// Collapse pure name-only rows when the same label already has auth-backed options.
 	out := make([]usage.ChannelFilterOption, 0, len(options))
 	seenValue := make(map[string]struct{}, len(options))
 	authBackedLabels := make(map[string]struct{})
@@ -412,38 +528,58 @@ func enrichChannelFilterOptions(
 		}
 		return authIndex
 	}
+	resolveSubject := func(option usage.ChannelFilterOption, authIndex string) string {
+		if subjectID := strings.TrimSpace(option.AuthSubjectID); subjectID != "" {
+			return subjectID
+		}
+		if subjectID := strings.TrimSpace(authSubjectByIndex[authIndex]); subjectID != "" {
+			return subjectID
+		}
+		if value := strings.TrimSpace(option.Value); looksLikeAuthSubjectID(value) {
+			return value
+		}
+		return ""
+	}
 
 	for _, option := range options {
 		authIndex := strings.TrimSpace(option.AuthIndex)
-		if authIndex == "" {
+		if authIndex == "" && !looksLikeAuthSubjectID(option.Value) {
 			authIndex = strings.TrimSpace(option.Value)
 		}
 		authIndex = canonicalAuthIndex(authIndex)
-		if authIndex == "" {
-			continue
+		subjectID := resolveSubject(option, authIndex)
+		if subjectID != "" {
+			if meta, ok := authMetaBySubject[subjectID]; ok && meta.label != "" {
+				authBackedLabels[strings.ToLower(meta.label)] = struct{}{}
+			}
 		}
-		if _, ok := authIndexChannelMap[authIndex]; ok {
+		if authIndex != "" {
 			if name := strings.TrimSpace(authIndexChannelMap[authIndex]); name != "" {
 				authBackedLabels[strings.ToLower(name)] = struct{}{}
 			}
-		}
-		if meta, ok := authMetaByIndex[authIndex]; ok && meta.label != "" {
-			authBackedLabels[strings.ToLower(meta.label)] = struct{}{}
+			if meta, ok := authMetaByIndex[authIndex]; ok && meta.label != "" {
+				authBackedLabels[strings.ToLower(meta.label)] = struct{}{}
+			}
 		}
 	}
 
 	for _, option := range options {
 		label := strings.TrimSpace(option.Label)
 		authIndex := strings.TrimSpace(option.AuthIndex)
-		if authIndex == "" {
+		if authIndex == "" && !looksLikeAuthSubjectID(option.Value) {
 			authIndex = strings.TrimSpace(option.Value)
 		}
-		// Fold xAI OAuth historical aliases onto the live index so the UI shows
-		// one Grok OAuth option with provider/auth_type badges.
 		authIndex = canonicalAuthIndex(authIndex)
+		subjectID := resolveSubject(option, authIndex)
+
 		if label == "" && authIndex != "" {
 			if name, ok := authIndexChannelMap[authIndex]; ok && strings.TrimSpace(name) != "" {
 				label = strings.TrimSpace(name)
+			}
+		}
+		if label == "" && subjectID != "" {
+			if meta, ok := authMetaBySubject[subjectID]; ok && meta.label != "" {
+				label = meta.label
 			}
 		}
 		if label == "" {
@@ -461,22 +597,31 @@ func enrichChannelFilterOptions(
 		provider := strings.TrimSpace(option.Provider)
 		authType := strings.TrimSpace(option.AuthType)
 		value := strings.TrimSpace(option.Value)
-		if value == "" {
-			value = authIndex
-		}
-		if value == "" {
-			value = label
-		}
-		// When we rewrote authIndex to the group canonical, filter value must
-		// match so clients select the live index (which expands server-side).
-		if authIndex != "" {
-			if group := authIndexGroup[authIndex]; len(group) > 0 {
-				value = authIndex
-			}
-		}
-
 		hasLiveMeta := false
-		if meta, ok := authMetaByIndex[authIndex]; ok {
+
+		if subjectID != "" {
+			value = subjectID
+			if meta, ok := authMetaBySubject[subjectID]; ok {
+				hasLiveMeta = true
+				if meta.label != "" {
+					label = meta.label
+				}
+				if meta.provider != "" {
+					provider = meta.provider
+				}
+				if meta.authType != "" {
+					authType = meta.authType
+				}
+			}
+			if authIndex == "" {
+				// keep representative from option if any
+			} else if meta, ok := authMetaByIndex[authIndex]; ok {
+				// Prefer live representative index for display/compat field.
+				if meta.label != "" && label == "" {
+					label = meta.label
+				}
+			}
+		} else if meta, ok := authMetaByIndex[authIndex]; ok {
 			hasLiveMeta = true
 			if meta.label != "" {
 				label = meta.label
@@ -499,9 +644,16 @@ func enrichChannelFilterOptions(
 			label = strings.TrimSpace(mapped)
 		}
 
+		if value == "" {
+			value = authIndex
+		}
+		if value == "" {
+			value = label
+		}
+
 		// Drop name-only rows that would re-merge same-email multi-provider
-		// accounts already represented by auth_index-backed options.
-		if !hasLiveMeta && authIndex == "" {
+		// accounts already represented by subject/index-backed options.
+		if !hasLiveMeta && subjectID == "" && authIndex == "" {
 			if _, ok := authBackedLabels[strings.ToLower(label)]; ok {
 				continue
 			}
@@ -514,11 +666,12 @@ func enrichChannelFilterOptions(
 		seenValue[dedupeKey] = struct{}{}
 
 		out = append(out, usage.ChannelFilterOption{
-			Value:     value,
-			Label:     label,
-			Provider:  provider,
-			AuthType:  normalizeAuthType(authType),
-			AuthIndex: authIndex,
+			Value:         value,
+			Label:         label,
+			Provider:      provider,
+			AuthType:      normalizeAuthType(authType),
+			AuthIndex:     authIndex,
+			AuthSubjectID: subjectID,
 		})
 	}
 
@@ -564,8 +717,17 @@ func channelLabelsFromOptions(options []usage.ChannelFilterOption) []string {
 	return labels
 }
 
-func enrichLogRowChannelMeta(item *usage.LogRow, authMetaByIndex map[string]authChannelMeta) {
+func enrichLogRowChannelMeta(item *usage.LogRow, authMetaByIndex, authMetaBySubject map[string]authChannelMeta) {
 	if item == nil {
+		return
+	}
+	if meta, ok := authMetaBySubject[strings.TrimSpace(item.AuthSubjectID)]; ok {
+		if meta.provider != "" {
+			item.Provider = meta.provider
+		}
+		if meta.authType != "" {
+			item.AuthType = normalizeAuthType(meta.authType)
+		}
 		return
 	}
 	if meta, ok := authMetaByIndex[strings.TrimSpace(item.AuthIndex)]; ok {
@@ -630,22 +792,22 @@ func displayChannelNameForLog(item usage.LogRow, channelNameMap, authIndexChanne
 	return ""
 }
 
-func (s *Service) buildNameMaps() (
-	keyNameMap, channelNameMap, authIndexChannelMap map[string]string,
-	ambiguousAuthIndexChannelMap map[string][]string,
-	authMetaByIndex map[string]authChannelMeta,
-	authIndexGroup map[string][]string,
-) {
-	keyNameMap = make(map[string]string)
-	channelNameMap = make(map[string]string)
-	authIndexChannelMap = make(map[string]string)
-	ambiguousAuthIndexChannelMap = make(map[string][]string)
-	authMetaByIndex = make(map[string]authChannelMeta)
-	authIndexGroup = make(map[string][]string)
+func (s *Service) buildNameMaps() nameMaps {
+	maps := nameMaps{
+		keyNameMap:                   make(map[string]string),
+		channelNameMap:               make(map[string]string),
+		authIndexChannelMap:          make(map[string]string),
+		ambiguousAuthIndexChannelMap: make(map[string][]string),
+		authMetaByIndex:              make(map[string]authChannelMeta),
+		authIndexGroup:               make(map[string][]string),
+		authSubjectByIndex:           make(map[string]string),
+		authIndexesBySubject:         make(map[string][]string),
+		authMetaBySubject:            make(map[string]authChannelMeta),
+	}
 
 	for _, row := range apikeysettings.NewService(nil, apikeysettings.WithTenantID(s.tenantID)).ListRows() {
 		if row.Key != "" && row.Name != "" {
-			keyNameMap[row.Key] = row.Name
+			maps.keyNameMap[row.Key] = row.Name
 		}
 	}
 
@@ -653,17 +815,17 @@ func (s *Service) buildNameMaps() (
 	if cfg != nil {
 		for _, k := range cfg.GeminiKey {
 			if k.APIKey != "" && k.Name != "" {
-				channelNameMap[k.APIKey] = k.Name
+				maps.channelNameMap[k.APIKey] = k.Name
 			}
 		}
 		for _, k := range cfg.ClaudeKey {
 			if k.APIKey != "" && k.Name != "" {
-				channelNameMap[k.APIKey] = k.Name
+				maps.channelNameMap[k.APIKey] = k.Name
 			}
 		}
 		for _, k := range cfg.CodexKey {
 			if k.APIKey != "" && k.Name != "" {
-				channelNameMap[k.APIKey] = k.Name
+				maps.channelNameMap[k.APIKey] = k.Name
 			}
 		}
 		for _, provider := range cfg.OpenAICompatibility {
@@ -672,7 +834,7 @@ func (s *Service) buildNameMaps() (
 			}
 			for _, entry := range provider.APIKeyEntries {
 				if entry.APIKey != "" {
-					channelNameMap[entry.APIKey] = provider.Name
+					maps.channelNameMap[entry.APIKey] = provider.Name
 				}
 			}
 		}
@@ -701,11 +863,16 @@ func (s *Service) buildNameMaps() (
 				provider: normalizeProviderKey(auth.Provider),
 				authType: resolveAuthType(auth),
 			}
+			subjectID := ""
+			if identity := usage.ResolveAuthSubjectIdentity(auth); identity != nil {
+				subjectID = strings.TrimSpace(identity.ID)
+			}
 			// xAI/Grok OAuth historically flipped between id: and file: seeds for
 			// the same credential. Register the full index group so filters and
 			// channel_options collapse onto one live option while still matching
-			// historical rows.
-			group := xaiOAuthAuthIndexGroup(auth)
+			// historical rows. Also expand basename/tenant-relative file seeds for
+			// all providers so path-format churn does not split one account.
+			group := authIndexAliasGroup(auth)
 			if len(group) == 0 && idx != "" {
 				group = []string{idx}
 			}
@@ -714,9 +881,25 @@ func (s *Service) buildNameMaps() (
 				if member == "" {
 					continue
 				}
-				authIndexChannelMap[member] = channel
-				authMetaByIndex[member] = meta
-				authIndexGroup[member] = group
+				maps.authIndexChannelMap[member] = channel
+				maps.authMetaByIndex[member] = meta
+				maps.authIndexGroup[member] = group
+				if subjectID != "" {
+					maps.authSubjectByIndex[member] = subjectID
+				}
+			}
+			if subjectID != "" {
+				if _, ok := maps.authMetaBySubject[subjectID]; !ok || !auth.Disabled {
+					// Prefer an enabled auth as the subject representative.
+					maps.authMetaBySubject[subjectID] = meta
+				}
+				for _, member := range group {
+					member = strings.TrimSpace(member)
+					if member == "" {
+						continue
+					}
+					maps.authIndexesBySubject[subjectID] = appendUniqueString(maps.authIndexesBySubject[subjectID], member)
+				}
 			}
 			if accountType, account := auth.AccountInfo(); strings.EqualFold(accountType, "oauth") {
 				if source := strings.TrimSpace(account); source != "" {
@@ -748,42 +931,40 @@ func (s *Service) buildNameMaps() (
 		}
 		if len(legacyChannelsByKey[key]) > 1 {
 			if candidate.authIndex != "" {
-				ambiguousAuthIndexChannelMap[candidate.authIndex] = append(ambiguousAuthIndexChannelMap[candidate.authIndex], key)
+				maps.ambiguousAuthIndexChannelMap[candidate.authIndex] = append(maps.ambiguousAuthIndexChannelMap[candidate.authIndex], key)
 			}
 			continue
 		}
-		channelNameMap[key] = strings.TrimSpace(candidate.channel)
+		maps.channelNameMap[key] = strings.TrimSpace(candidate.channel)
 	}
 
-	return
+	return maps
 }
 
-// xaiOAuthAuthIndexGroup returns the live EnsureIndex first, followed by known
-// historical seeds for the same xAI/Grok OAuth credential. Non-xAI auths return
-// only the live index (or nil when empty).
-//
-// Grok OAuth is special: the same account can log under both id:<file> and
-// file:<file> depending on whether FileName was populated at write time.
-func xaiOAuthAuthIndexGroup(auth *coreauth.Auth) []string {
+func appendUniqueString(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+// authIndexAliasGroup returns the live EnsureIndex first, followed by known
+// historical seeds for the same credential file. Path-format churn
+// (basename vs tenant-relative FileName, id: vs file: seed) must not split one
+// account across multiple channel options.
+func authIndexAliasGroup(auth *coreauth.Auth) []string {
 	if auth == nil {
 		return nil
 	}
 	primary := strings.TrimSpace(auth.EnsureIndex())
 	if primary == "" {
 		return nil
-	}
-	if !isXAIProvider(auth.Provider) {
-		return []string{primary}
-	}
-	accountType, _ := auth.AccountInfo()
-	// Only merge OAuth-style xAI credentials; API-key channels stay independent.
-	if !strings.EqualFold(strings.TrimSpace(accountType), "oauth") {
-		// AccountInfo may miss email when metadata shape differs; still merge when
-		// the channel looks like an email (typical OAuth label).
-		channel := strings.TrimSpace(auth.ChannelName())
-		if !strings.Contains(channel, "@") {
-			return []string{primary}
-		}
 	}
 
 	seen := map[string]struct{}{primary: {}}
@@ -807,23 +988,40 @@ func xaiOAuthAuthIndexGroup(auth *coreauth.Auth) []string {
 	fileName := strings.TrimSpace(auth.FileName)
 	if fileName != "" {
 		base := filepath.Base(fileName)
-		// Current seed path.
+		// Current and historical FileName forms.
 		addSeed("file:" + fileName)
 		addSeed("file:" + base)
 		// Historical path: ID was set to the auth file name (including .json)
 		// before FileName was populated, so EnsureIndex used id:<filename>.
 		addSeed("id:" + fileName)
 		addSeed("id:" + base)
+		// Path-format churn: basename <-> tenant-relative.
+		if tenantID := strings.TrimSpace(auth.TenantID); tenantID != "" && base != "" {
+			addSeed("file:" + tenantID + "/" + base)
+			addSeed("id:" + tenantID + "/" + base)
+		}
 	}
 	if id := strings.TrimSpace(auth.ID); id != "" {
 		addSeed("id:" + id)
-		// If ID is a bare filename, also cover file: variants.
-		if strings.HasSuffix(strings.ToLower(id), ".json") {
+		base := filepath.Base(id)
+		addSeed("id:" + base)
+		// If ID is a bare filename / tenant-relative path, also cover file: variants.
+		if strings.HasSuffix(strings.ToLower(base), ".json") {
 			addSeed("file:" + id)
-			addSeed("file:" + filepath.Base(id))
+			addSeed("file:" + base)
+			if tenantID := strings.TrimSpace(auth.TenantID); tenantID != "" {
+				addSeed("file:" + tenantID + "/" + base)
+				addSeed("id:" + tenantID + "/" + base)
+			}
 		}
 	}
 	return out
+}
+
+// xaiOAuthAuthIndexGroup is kept for tests that assert the historical xAI
+// id:/file: seed merge; production uses authIndexAliasGroup for all providers.
+func xaiOAuthAuthIndexGroup(auth *coreauth.Auth) []string {
+	return authIndexAliasGroup(auth)
 }
 
 func isXAIProvider(provider string) bool {

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -57,14 +57,20 @@ func TestChannelFilterSelectorsTreatsOrphanAuthIndexAsAuthIndex(t *testing.T) {
 
 	// Selecting the orphan facet value must stay on AuthIndexes. The previous
 	// bug fell through to ChannelNames and queried channel_name = <hash>.
-	authIndexes, channelNames, _ := channelFilterSelectors(
+	subjects, authIndexes, channelNames, _ := channelFilterSelectors(
 		[]string{orphanIndex},
 		nil,
 		authIndexChannelMap,
 		nil,
 		authMetaByIndex,
 		nil,
+		nil,
+		nil,
+		nil,
 	)
+	if len(subjects) != 0 {
+		t.Fatalf("subjects = %#v, want empty for unmapped orphan", subjects)
+	}
 	if !reflect.DeepEqual(authIndexes, []string{orphanIndex}) {
 		t.Fatalf("authIndexes = %#v, want [%s]", authIndexes, orphanIndex)
 	}
@@ -73,14 +79,20 @@ func TestChannelFilterSelectorsTreatsOrphanAuthIndexAsAuthIndex(t *testing.T) {
 	}
 
 	// Live index still resolves normally.
-	authIndexes, channelNames, _ = channelFilterSelectors(
+	subjects, authIndexes, channelNames, _ = channelFilterSelectors(
 		[]string{liveIndex},
 		nil,
 		authIndexChannelMap,
 		nil,
 		authMetaByIndex,
 		nil,
+		nil,
+		nil,
+		nil,
 	)
+	if len(subjects) != 0 {
+		t.Fatalf("live subjects = %#v, want empty without subject map", subjects)
+	}
 	if !reflect.DeepEqual(authIndexes, []string{liveIndex}) {
 		t.Fatalf("live authIndexes = %#v, want [%s]", authIndexes, liveIndex)
 	}
@@ -90,14 +102,20 @@ func TestChannelFilterSelectorsTreatsOrphanAuthIndexAsAuthIndex(t *testing.T) {
 
 	// Email/display labels still use the legacy channel_name path (and may also
 	// expand to live auth indexes via authIndexChannelMap label matching).
-	authIndexes, channelNames, _ = channelFilterSelectors(
+	subjects, authIndexes, channelNames, _ = channelFilterSelectors(
 		[]string{label},
 		map[string]string{label: label},
 		authIndexChannelMap,
 		nil,
 		authMetaByIndex,
 		nil,
+		nil,
+		nil,
+		nil,
 	)
+	if len(subjects) != 0 {
+		t.Fatalf("label subjects = %#v, want empty without subject map", subjects)
+	}
 	if !reflect.DeepEqual(authIndexes, []string{liveIndex}) {
 		t.Fatalf("label authIndexes = %#v, want [%s]", authIndexes, liveIndex)
 	}
@@ -144,21 +162,33 @@ func TestXaiOAuthAuthIndexGroupMergesIDAndFileSeeds(t *testing.T) {
 	}
 }
 
-func TestXaiOAuthAuthIndexGroupSkipsNonXAI(t *testing.T) {
+func TestAuthIndexAliasGroupIncludesBasenameAndTenantRelative(t *testing.T) {
 	t.Parallel()
 
-	fileName := "codex-yuan364299311@gmail.com-pro.json"
+	base := "codex-yuan364299311@gmail.com-pro.json"
+	tenantRelative := "9e003dfb-751f-4898-b186-45f765c763a6/" + base
 	auth := &coreauth.Auth{
 		Provider: "codex",
-		FileName: fileName,
-		ID:       fileName,
+		FileName: tenantRelative,
+		ID:       tenantRelative,
 		Label:    "yuan364299311@gmail.com",
 		Metadata: map[string]any{"email": "yuan364299311@gmail.com"},
 	}
-	group := xaiOAuthAuthIndexGroup(auth)
-	live := seedIndex("file:" + fileName)
-	if !reflect.DeepEqual(group, []string{live}) {
-		t.Fatalf("codex group = %#v, want only live [%s]", group, live)
+	group := authIndexAliasGroup(auth)
+	live := seedIndex("file:" + tenantRelative)
+	basename := seedIndex("file:" + base)
+	if group[0] != live {
+		t.Fatalf("canonical = %s, want live %s", group[0], live)
+	}
+	foundBase := false
+	for _, member := range group {
+		if member == basename {
+			foundBase = true
+			break
+		}
+	}
+	if !foundBase {
+		t.Fatalf("group %#v missing basename index %s", group, basename)
 	}
 }
 
@@ -184,14 +214,20 @@ func TestChannelFilterSelectorsExpandsXaiOAuthIndexGroup(t *testing.T) {
 	}
 
 	// Selecting the live option expands to both historical indexes.
-	authIndexes, channelNames, _ := channelFilterSelectors(
+	subjects, authIndexes, channelNames, _ := channelFilterSelectors(
 		[]string{liveIndex},
 		nil,
 		authIndexChannelMap,
 		nil,
 		authMetaByIndex,
 		authIndexGroup,
+		nil,
+		nil,
+		nil,
 	)
+	if len(subjects) != 0 {
+		t.Fatalf("subjects = %#v, want empty without subject map", subjects)
+	}
 	sort.Strings(authIndexes)
 	want := []string{liveIndex, orphanIndex}
 	sort.Strings(want)
@@ -203,14 +239,20 @@ func TestChannelFilterSelectorsExpandsXaiOAuthIndexGroup(t *testing.T) {
 	}
 
 	// Selecting the orphan index also expands (old clients / deep links).
-	authIndexes, _, _ = channelFilterSelectors(
+	subjects, authIndexes, _, _ = channelFilterSelectors(
 		[]string{orphanIndex},
 		nil,
 		authIndexChannelMap,
 		nil,
 		authMetaByIndex,
 		authIndexGroup,
+		nil,
+		nil,
+		nil,
 	)
+	if len(subjects) != 0 {
+		t.Fatalf("orphan subjects = %#v, want empty without subject map", subjects)
+	}
 	sort.Strings(authIndexes)
 	if !reflect.DeepEqual(authIndexes, want) {
 		t.Fatalf("orphan expand authIndexes = %#v, want %#v", authIndexes, want)
@@ -259,7 +301,7 @@ func TestEnrichChannelFilterOptionsCollapsesXaiOAuthAliases(t *testing.T) {
 		authType: "oauth",
 	}
 
-	got := enrichChannelFilterOptions(options, nil, authIndexChannelMap, authMetaByIndex, authIndexGroup)
+	got := enrichChannelFilterOptions(options, nil, authIndexChannelMap, authMetaByIndex, authIndexGroup, nil, nil)
 
 	var asher *usage.ChannelFilterOption
 	var codex *usage.ChannelFilterOption
@@ -291,5 +333,152 @@ func TestEnrichChannelFilterOptionsCollapsesXaiOAuthAliases(t *testing.T) {
 	}
 	if codex == nil {
 		t.Fatalf("codex option was dropped: %#v", got)
+	}
+}
+
+func TestChannelFilterSelectorsPrefersAuthSubject(t *testing.T) {
+	t.Parallel()
+
+	liveIndex := "c84aac6579358b75"
+	oldIndex := "a9757e6dce652490"
+	subject := "authsub_29b975703f03bde1"
+	label := "yuan364299311@gmail.com"
+
+	authIndexChannelMap := map[string]string{
+		liveIndex: label,
+		oldIndex:  label,
+	}
+	authMetaByIndex := map[string]authChannelMeta{
+		liveIndex: {label: label, provider: "codex", authType: "oauth"},
+		oldIndex:  {label: label, provider: "codex", authType: "oauth"},
+	}
+	authSubjectByIndex := map[string]string{
+		liveIndex: subject,
+		oldIndex:  subject,
+	}
+	authIndexesBySubject := map[string][]string{
+		subject: {liveIndex, oldIndex},
+	}
+	authMetaBySubject := map[string]authChannelMeta{
+		subject: {label: label, provider: "codex", authType: "oauth"},
+	}
+
+	// New clients send subject value.
+	subjects, authIndexes, channelNames, _ := channelFilterSelectors(
+		[]string{subject},
+		nil,
+		authIndexChannelMap,
+		nil,
+		authMetaByIndex,
+		nil,
+		authSubjectByIndex,
+		authIndexesBySubject,
+		authMetaBySubject,
+	)
+	if !reflect.DeepEqual(subjects, []string{subject}) {
+		t.Fatalf("subjects = %#v, want [%s]", subjects, subject)
+	}
+	sort.Strings(authIndexes)
+	wantIndexes := []string{liveIndex, oldIndex}
+	sort.Strings(wantIndexes)
+	if !reflect.DeepEqual(authIndexes, wantIndexes) {
+		t.Fatalf("authIndexes = %#v, want subject alias indexes %#v", authIndexes, wantIndexes)
+	}
+	if len(channelNames) != 0 {
+		t.Fatalf("channelNames = %#v, want empty", channelNames)
+	}
+
+	// Old clients / deep links still send historical auth_index; map to subject.
+	subjects, authIndexes, _, _ = channelFilterSelectors(
+		[]string{oldIndex},
+		nil,
+		authIndexChannelMap,
+		nil,
+		authMetaByIndex,
+		nil,
+		authSubjectByIndex,
+		authIndexesBySubject,
+		authMetaBySubject,
+	)
+	if !reflect.DeepEqual(subjects, []string{subject}) {
+		t.Fatalf("old index subjects = %#v, want [%s]", subjects, subject)
+	}
+	sort.Strings(authIndexes)
+	if !reflect.DeepEqual(authIndexes, wantIndexes) {
+		t.Fatalf("old index authIndexes = %#v, want %#v", authIndexes, wantIndexes)
+	}
+}
+
+func TestEnrichChannelFilterOptionsCollapsesByAuthSubject(t *testing.T) {
+	t.Parallel()
+
+	liveIndex := "c84aac6579358b75"
+	oldIndex := "a9757e6dce652490"
+	xaiIndex := "b789c5a3171aeaff"
+	codexSubject := "authsub_29b975703f03bde1"
+	xaiSubject := "authsub_50d3fdc60cf66318"
+	label := "yuan364299311@gmail.com"
+
+	options := []usage.ChannelFilterOption{
+		{Value: oldIndex, Label: label, AuthIndex: oldIndex, AuthSubjectID: codexSubject},
+		{Value: liveIndex, Label: label, AuthIndex: liveIndex, AuthSubjectID: codexSubject},
+		{Value: xaiIndex, Label: label, AuthIndex: xaiIndex, AuthSubjectID: xaiSubject},
+	}
+	authIndexChannelMap := map[string]string{
+		liveIndex: label,
+		oldIndex:  label,
+		xaiIndex:  label,
+	}
+	authMetaByIndex := map[string]authChannelMeta{
+		liveIndex: {label: label, provider: "codex", authType: "oauth"},
+		oldIndex:  {label: label, provider: "codex", authType: "oauth"},
+		xaiIndex:  {label: label, provider: "xai", authType: "oauth"},
+	}
+	authSubjectByIndex := map[string]string{
+		liveIndex: codexSubject,
+		oldIndex:  codexSubject,
+		xaiIndex:  xaiSubject,
+	}
+	authMetaBySubject := map[string]authChannelMeta{
+		codexSubject: {label: label, provider: "codex", authType: "oauth"},
+		xaiSubject:   {label: label, provider: "xai", authType: "oauth"},
+	}
+
+	got := enrichChannelFilterOptions(
+		options,
+		nil,
+		authIndexChannelMap,
+		authMetaByIndex,
+		nil,
+		authSubjectByIndex,
+		authMetaBySubject,
+	)
+	if len(got) != 2 {
+		t.Fatalf("options = %#v, want 2 (codex+xai)", got)
+	}
+
+	var codex, xai *usage.ChannelFilterOption
+	for i := range got {
+		switch got[i].AuthSubjectID {
+		case codexSubject:
+			codex = &got[i]
+		case xaiSubject:
+			xai = &got[i]
+		}
+	}
+	if codex == nil || xai == nil {
+		t.Fatalf("missing subject options: %#v", got)
+	}
+	if codex.Value != codexSubject {
+		t.Fatalf("codex value = %s, want %s", codex.Value, codexSubject)
+	}
+	if codex.Provider != "codex" {
+		t.Fatalf("codex provider = %q, want codex", codex.Provider)
+	}
+	if xai.Value != xaiSubject {
+		t.Fatalf("xai value = %s, want %s", xai.Value, xaiSubject)
+	}
+	if xai.Provider != "xai" {
+		t.Fatalf("xai provider = %q, want xai", xai.Provider)
 	}
 }

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -50,7 +50,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 
 	// Fetch page
 	offset := (params.Page - 1) * params.Size
-	querySQL := "SELECT id, timestamp, api_key, api_key_name, model, upstream_model, vision_fallback_model, source, channel_name, auth_index, " +
+	querySQL := "SELECT id, timestamp, api_key, api_key_name, model, upstream_model, vision_fallback_model, source, channel_name, auth_index, auth_subject_id, " +
 		"failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, " +
 		"cost, " +
 		"(CASE WHEN EXISTS (SELECT 1 FROM request_log_content content WHERE content.tenant_id = request_logs.tenant_id AND content.log_id = request_logs.id) " +
@@ -73,7 +73,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		var failedInt, streamingInt, hasContentInt int
 		if err := rows.Scan(
 			&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.UpstreamModel, &row.VisionFallbackModel, &row.Source, &row.ChannelName,
-			&row.AuthIndex, &failedInt, &streamingInt, &row.LatencyMs, &row.FirstTokenMs,
+			&row.AuthIndex, &row.AuthSubjectID, &failedInt, &streamingInt, &row.LatencyMs, &row.FirstTokenMs,
 			&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
 			&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,
 		); err != nil {
@@ -251,6 +251,7 @@ func (params LogQueryParams) withoutFacet(facet string) LogQueryParams {
 		params.Models = nil
 		params.MatchNoModels = false
 	case "channel":
+		params.AuthSubjectIDs = nil
 		params.AuthIndexes = nil
 		params.ChannelNames = nil
 		params.AuthIndexChannelNames = nil
@@ -647,8 +648,22 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 		}
 		// Both success and failed: no status filter needed (equivalent to "all")
 	}
-	if len(params.AuthIndexes) > 0 || len(params.ChannelNames) > 0 {
-		filterConditions := make([]string, 0, 2)
+	if len(params.AuthSubjectIDs) > 0 || len(params.AuthIndexes) > 0 || len(params.ChannelNames) > 0 {
+		filterConditions := make([]string, 0, 3)
+
+		subjectPlaceholders := make([]string, 0, len(params.AuthSubjectIDs))
+		for _, subjectID := range params.AuthSubjectIDs {
+			trimmed := strings.TrimSpace(subjectID)
+			if trimmed == "" {
+				continue
+			}
+			subjectPlaceholders = append(subjectPlaceholders, "?")
+			args = append(args, trimmed)
+		}
+		if len(subjectPlaceholders) > 0 {
+			// Account-level filter: one subject covers all credential-instance indexes.
+			filterConditions = append(filterConditions, "auth_subject_id IN ("+strings.Join(subjectPlaceholders, ",")+")")
+		}
 
 		authPlaceholders := make([]string, 0, len(params.AuthIndexes))
 		for _, idx := range params.AuthIndexes {
@@ -739,19 +754,31 @@ func queryDistinct(db *sql.DB, column string, params LogQueryParams) ([]string, 
 	return result, nil
 }
 
-// queryDistinctChannelRows returns distinct (channel_name, auth_index) pairs so
-// that two OAuth accounts sharing the same email/label (e.g. codex + xai)
-// remain separate filter options.
+// queryDistinctChannelRows returns account-level channel options.
+// Rows with auth_subject_id collapse onto one option (provider-scoped account).
+// Orphan rows without subject keep auth_index/channel_name legacy options.
 func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilterOption, error) {
 	where, args := buildWhereClause(params)
+	// Aggregate channel_name/auth_index with MAX so PostgreSQL accepts subject-level
+	// collapse (only subject is a real grouping key when subject is non-empty).
 	q := `
 		SELECT
-			trim(coalesce(channel_name, '')) AS channel_name,
-			trim(coalesce(auth_index, '')) AS auth_index,
+			trim(coalesce(auth_subject_id, '')) AS auth_subject_id,
+			MAX(trim(coalesce(channel_name, ''))) AS channel_name,
+			MAX(trim(coalesce(auth_index, ''))) AS auth_index,
 			MAX(trim(coalesce(source, ''))) AS source
 		FROM request_logs` + where + `
-		GROUP BY trim(coalesce(channel_name, '')), trim(coalesce(auth_index, ''))
-		ORDER BY channel_name, auth_index`
+		GROUP BY
+			trim(coalesce(auth_subject_id, '')),
+			CASE
+				WHEN trim(coalesce(auth_subject_id, '')) <> '' THEN ''
+				ELSE trim(coalesce(channel_name, ''))
+			END,
+			CASE
+				WHEN trim(coalesce(auth_subject_id, '')) <> '' THEN ''
+				ELSE trim(coalesce(auth_index, ''))
+			END
+		ORDER BY channel_name, auth_subject_id, auth_index`
 	rows, err := db.Query(q, args...)
 	if err != nil {
 		log.Warnf("usage: distinct channel rows query failed: %v", err)
@@ -760,24 +787,43 @@ func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilte
 	defer rows.Close()
 
 	result := make([]ChannelFilterOption, 0)
+	seenSubject := make(map[string]struct{})
 	for rows.Next() {
-		var channelName, authIndex, source string
-		if err := rows.Scan(&channelName, &authIndex, &source); err != nil {
+		var subjectID, channelName, authIndex, source string
+		if err := rows.Scan(&subjectID, &channelName, &authIndex, &source); err != nil {
 			log.Warnf("usage: distinct channel rows scan failed: %v", err)
 			return nil, err
 		}
+		subjectID = strings.TrimSpace(subjectID)
 		channelName = strings.TrimSpace(channelName)
 		authIndex = strings.TrimSpace(authIndex)
 		source = strings.TrimSpace(source)
-		if channelName == "" && authIndex == "" {
+		if subjectID == "" && channelName == "" && authIndex == "" {
+			continue
+		}
+		if subjectID != "" {
+			if _, ok := seenSubject[subjectID]; ok {
+				continue
+			}
+			seenSubject[subjectID] = struct{}{}
+			label := channelName
+			if label == "" {
+				label = subjectID
+			}
+			result = append(result, ChannelFilterOption{
+				Value:         subjectID,
+				Label:         label,
+				AuthIndex:     authIndex,
+				AuthSubjectID: subjectID,
+				// Provider/auth_type filled by management layer from live auth.
+				Provider: guessProviderFromSource(source),
+			})
 			continue
 		}
 		label := channelName
 		if label == "" {
 			label = authIndex
 		}
-		// Prefer auth_index as the stable filter value when available so
-		// same-label multi-provider accounts stay independent.
 		value := authIndex
 		if value == "" {
 			value = channelName
@@ -786,9 +832,7 @@ func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilte
 			Value:     value,
 			Label:     label,
 			AuthIndex: authIndex,
-			// Provider/auth_type are filled by the management layer from live auth state.
-			// Source is a weak fallback only.
-			Provider: guessProviderFromSource(source),
+			Provider:  guessProviderFromSource(source),
 		})
 	}
 	return result, rows.Err()

--- a/internal/usage/request_log_query_builder_test.go
+++ b/internal/usage/request_log_query_builder_test.go
@@ -15,12 +15,13 @@ func TestBuildWhereClauseUsesParameterizedFilters(t *testing.T) {
 		APIKeys:               []string{" sk-a ", "sk-b", "SK-B"},
 		Models:                []string{" gpt-5 ", "gpt-4"},
 		Statuses:              []string{"failed"},
+		AuthSubjectIDs:        []string{" authsub_29b975703f03bde1 ", ""},
 		AuthIndexes:           []string{" auth-1 ", ""},
 		AuthIndexChannelNames: map[string][]string{" auth-2 ": {" Legacy ", ""}},
 		ChannelNames:          []string{" Codex ", ""},
 	})
 
-	wantWhere := " WHERE tenant_id = ? AND timestamp >= ? AND (api_key = ? OR api_key = ?) AND model IN (?,?) AND failed = 1 AND (auth_index IN (?) OR (auth_index = ? AND lower(trim(channel_name)) IN (?)) OR lower(trim(channel_name)) IN (?))"
+	wantWhere := " WHERE tenant_id = ? AND timestamp >= ? AND (api_key = ? OR api_key = ?) AND model IN (?,?) AND failed = 1 AND (auth_subject_id IN (?) OR auth_index IN (?) OR (auth_index = ? AND lower(trim(channel_name)) IN (?)) OR lower(trim(channel_name)) IN (?))"
 	if where != wantWhere {
 		t.Fatalf("where = %q, want %q", where, wantWhere)
 	}
@@ -38,7 +39,7 @@ func TestBuildWhereClauseUsesParameterizedFilters(t *testing.T) {
 		t.Fatalf("cutoff arg %q is not RFC3339: %v", cutoff, err)
 	}
 
-	wantArgs := []interface{}{"sk-a", "sk-b", "gpt-5", "gpt-4", "auth-1", "auth-2", "legacy", "codex"}
+	wantArgs := []interface{}{"sk-a", "sk-b", "gpt-5", "gpt-4", "authsub_29b975703f03bde1", "auth-1", "auth-2", "legacy", "codex"}
 	if !reflect.DeepEqual(args[2:], wantArgs) {
 		t.Fatalf("args[2:] = %#v, want %#v", args[2:], wantArgs)
 	}

--- a/internal/usage/request_log_types.go
+++ b/internal/usage/request_log_types.go
@@ -1,0 +1,105 @@
+package usage
+
+import "time"
+
+// LogRow represents a single request log entry returned by QueryLogs.
+type LogRow struct {
+	ID                  int64     `json:"id"`
+	Timestamp           time.Time `json:"timestamp"`
+	APIKey              string    `json:"api_key"`
+	APIKeyName          string    `json:"api_key_name"`
+	Model               string    `json:"model"`
+	UpstreamModel       string    `json:"upstream_model,omitempty"`
+	VisionFallbackModel string    `json:"vision_fallback_model,omitempty"`
+	Source              string    `json:"source"`
+	ChannelName         string    `json:"channel_name"`
+	Provider            string    `json:"provider,omitempty"`
+	AuthType            string    `json:"auth_type,omitempty"` // "oauth" | "api"
+	AuthIndex           string    `json:"auth_index"`
+	AuthSubjectID       string    `json:"auth_subject_id,omitempty"`
+	Failed              bool      `json:"failed"`
+	Streaming           bool      `json:"streaming"`
+	LatencyMs           int64     `json:"latency_ms"`
+	FirstTokenMs        int64     `json:"first_token_ms"`
+	InputTokens         int64     `json:"input_tokens"`
+	OutputTokens        int64     `json:"output_tokens"`
+	ReasoningTokens     int64     `json:"reasoning_tokens"`
+	CachedTokens        int64     `json:"cached_tokens"`
+	TotalTokens         int64     `json:"total_tokens"`
+	Cost                float64   `json:"cost"`
+	HasContent          bool      `json:"has_content"`
+}
+
+// LogQueryParams holds filter/pagination parameters for QueryLogs.
+type LogQueryParams struct {
+	TenantID        string
+	Page            int      // 1-based
+	Size            int      // rows per page
+	Days            int      // time range in days
+	APIKey          string   // exact match filter (deprecated, use APIKeys)
+	Model           string   // exact match filter (deprecated, use Models)
+	Status          string   // "success", "failed", or "" (all) (deprecated, use Statuses)
+	APIKeys         []string // multi-value API key filter
+	Models          []string // multi-value model filter
+	Statuses        []string // multi-value status filter
+	MatchNoAPIKeys  bool     // explicit empty API key filter
+	MatchNoModels   bool     // explicit empty model filter
+	MatchNoStatuses bool     // explicit empty status filter
+	MatchNoChannels bool     // explicit empty channel filter
+	AuthSubjectIDs  []string // optional auth_subject_id IN (...) filter (account-level)
+	AuthIndexes     []string // optional auth_index IN (...) filter (credential instance)
+	ChannelNames    []string // optional channel_name IN (...) filter
+	// Optional precise legacy matches for renamed auth channels whose stored
+	// channel_name was a shared provider/source value.
+	AuthIndexChannelNames map[string][]string
+}
+
+// LogQueryResult holds the paginated query result.
+type LogQueryResult struct {
+	Items []LogRow `json:"items"`
+	Total int64    `json:"total"`
+	Page  int      `json:"page"`
+	Size  int      `json:"size"`
+}
+
+// FilterOptions holds the available filter values for the UI.
+type FilterOptions struct {
+	APIKeys     []string          `json:"api_keys"`
+	APIKeyNames map[string]string `json:"api_key_names"`
+	Models      []string          `json:"models"`
+	// Channels is a legacy plain-name list kept for older clients.
+	// Prefer ChannelOptions when both are present.
+	Channels       []string              `json:"channels"`
+	ChannelOptions []ChannelFilterOption `json:"channel_options,omitempty"`
+	Statuses       []string              `json:"statuses"`
+}
+
+// ChannelFilterOption is one selectable channel in request-log filters.
+// Value prefers auth_subject_id (account-level) when known; falls back to
+// auth_index (credential instance) or display name for orphans.
+type ChannelFilterOption struct {
+	Value         string `json:"value"`
+	Label         string `json:"label"`
+	Provider      string `json:"provider,omitempty"`
+	AuthType      string `json:"auth_type,omitempty"` // "oauth" | "api"
+	AuthIndex     string `json:"auth_index,omitempty"`
+	AuthSubjectID string `json:"auth_subject_id,omitempty"`
+}
+
+// LogStats holds aggregated stats over the filtered result set.
+type LogStats struct {
+	Total         int64   `json:"total"`
+	SuccessRate   float64 `json:"success_rate"`
+	TotalTokens   int64   `json:"total_tokens"`
+	TotalSessions int64   `json:"total_sessions"`
+	TotalCost     float64 `json:"total_cost"`
+	CacheRate     float64 `json:"cache_rate"`
+}
+
+type ClearRequestLogsResult struct {
+	DeletedLogs       int64 `json:"deleted_logs"`
+	DeletedContents   int64 `json:"deleted_contents"`
+	ClearedBodyRows   int64 `json:"cleared_body_rows"`
+	ClearedDetailRows int64 `json:"cleared_detail_rows"`
+	ClearedLegacyRows int64 `json:"cleared_legacy_rows"`
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -18,96 +18,6 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// LogRow represents a single request log entry returned by QueryLogs.
-type LogRow struct {
-	ID                  int64     `json:"id"`
-	Timestamp           time.Time `json:"timestamp"`
-	APIKey              string    `json:"api_key"`
-	APIKeyName          string    `json:"api_key_name"`
-	Model               string    `json:"model"`
-	UpstreamModel       string    `json:"upstream_model,omitempty"`
-	VisionFallbackModel string    `json:"vision_fallback_model,omitempty"`
-	Source              string    `json:"source"`
-	ChannelName         string    `json:"channel_name"`
-	Provider            string    `json:"provider,omitempty"`
-	AuthType            string    `json:"auth_type,omitempty"` // "oauth" | "api"
-	AuthIndex           string    `json:"auth_index"`
-	Failed              bool      `json:"failed"`
-	Streaming           bool      `json:"streaming"`
-	LatencyMs           int64     `json:"latency_ms"`
-	FirstTokenMs        int64     `json:"first_token_ms"`
-	InputTokens         int64     `json:"input_tokens"`
-	OutputTokens        int64     `json:"output_tokens"`
-	ReasoningTokens     int64     `json:"reasoning_tokens"`
-	CachedTokens        int64     `json:"cached_tokens"`
-	TotalTokens         int64     `json:"total_tokens"`
-	Cost                float64   `json:"cost"`
-	HasContent          bool      `json:"has_content"`
-}
-
-// LogQueryParams holds filter/pagination parameters for QueryLogs.
-type LogQueryParams struct {
-	TenantID        string
-	Page            int      // 1-based
-	Size            int      // rows per page
-	Days            int      // time range in days
-	APIKey          string   // exact match filter (deprecated, use APIKeys)
-	Model           string   // exact match filter (deprecated, use Models)
-	Status          string   // "success", "failed", or "" (all) (deprecated, use Statuses)
-	APIKeys         []string // multi-value API key filter
-	Models          []string // multi-value model filter
-	Statuses        []string // multi-value status filter
-	MatchNoAPIKeys  bool     // explicit empty API key filter
-	MatchNoModels   bool     // explicit empty model filter
-	MatchNoStatuses bool     // explicit empty status filter
-	MatchNoChannels bool     // explicit empty channel filter
-	AuthIndexes     []string // optional auth_index IN (...) filter
-	ChannelNames    []string // optional channel_name IN (...) filter
-	// Optional precise legacy matches for renamed auth channels whose stored
-	// channel_name was a shared provider/source value.
-	AuthIndexChannelNames map[string][]string
-}
-
-// LogQueryResult holds the paginated query result.
-type LogQueryResult struct {
-	Items []LogRow `json:"items"`
-	Total int64    `json:"total"`
-	Page  int      `json:"page"`
-	Size  int      `json:"size"`
-}
-
-// FilterOptions holds the available filter values for the UI.
-type FilterOptions struct {
-	APIKeys     []string          `json:"api_keys"`
-	APIKeyNames map[string]string `json:"api_key_names"`
-	Models      []string          `json:"models"`
-	// Channels is a legacy plain-name list kept for older clients.
-	// Prefer ChannelOptions when both are present.
-	Channels       []string              `json:"channels"`
-	ChannelOptions []ChannelFilterOption `json:"channel_options,omitempty"`
-	Statuses       []string              `json:"statuses"`
-}
-
-// ChannelFilterOption is one selectable channel in request-log filters.
-// Value is stable for filtering (auth_index when known, otherwise the display name).
-type ChannelFilterOption struct {
-	Value     string `json:"value"`
-	Label     string `json:"label"`
-	Provider  string `json:"provider,omitempty"`
-	AuthType  string `json:"auth_type,omitempty"` // "oauth" | "api"
-	AuthIndex string `json:"auth_index,omitempty"`
-}
-
-// LogStats holds aggregated stats over the filtered result set.
-type LogStats struct {
-	Total         int64   `json:"total"`
-	SuccessRate   float64 `json:"success_rate"`
-	TotalTokens   int64   `json:"total_tokens"`
-	TotalSessions int64   `json:"total_sessions"`
-	TotalCost     float64 `json:"total_cost"`
-	CacheRate     float64 `json:"cache_rate"`
-}
-
 const cacheRateEffectiveInputSQL = "CASE WHEN cached_tokens > input_tokens THEN input_tokens + cached_tokens ELSE input_tokens END"
 
 func cacheRateFromTokenTotals(effectiveInputTokens, cachedTokens int64) float64 {
@@ -115,14 +25,6 @@ func cacheRateFromTokenTotals(effectiveInputTokens, cachedTokens int64) float64 
 		return 0
 	}
 	return float64(cachedTokens) / float64(effectiveInputTokens) * 100
-}
-
-type ClearRequestLogsResult struct {
-	DeletedLogs       int64 `json:"deleted_logs"`
-	DeletedContents   int64 `json:"deleted_contents"`
-	ClearedBodyRows   int64 `json:"cleared_body_rows"`
-	ClearedDetailRows int64 `json:"cleared_detail_rows"`
-	ClearedLegacyRows int64 `json:"cleared_legacy_rows"`
 }
 
 type ClearRequestLogsOptions struct {


### PR DESCRIPTION
## Summary
- request-logs 渠道筛选改为按 `auth_subject_id`（账号级）聚合，避免同一 OAuth 账号因 basename / tenant-relative 路径 churn 出现多个同邮箱选项
- 旧 `auth_index` 深链仍可用，并映射到完整 subject 历史；同邮箱不同 provider 保持独立
- 未改 `EnsureIndex` 算法；`auth_index` 仍作凭据实例定位符

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] `go test ./internal/management/usagelogs/ ./internal/usage/ ./internal/api/handlers/management/`
- [ ] 土豆租户 request-logs：`yuan364299311@gmail.com` 显示 2 个账号（Codex + 历史 xAI），不再是 4 个