### PR TITLE
fix: always fill channel option provider and auth-type badges

### DIFF
--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -613,12 +613,20 @@ func enrichChannelFilterOptions(
 					authType = meta.authType
 				}
 			}
-			if authIndex == "" {
-				// keep representative from option if any
-			} else if meta, ok := authMetaByIndex[authIndex]; ok {
-				// Prefer live representative index for display/compat field.
-				if meta.label != "" && label == "" {
-					label = meta.label
+			if authIndex != "" {
+				if meta, ok := authMetaByIndex[authIndex]; ok {
+					if !hasLiveMeta {
+						hasLiveMeta = true
+					}
+					if provider == "" && meta.provider != "" {
+						provider = meta.provider
+					}
+					if authType == "" && meta.authType != "" {
+						authType = meta.authType
+					}
+					if meta.label != "" && label == "" {
+						label = meta.label
+					}
 				}
 			}
 		} else if meta, ok := authMetaByIndex[authIndex]; ok {
@@ -649,6 +657,17 @@ func enrichChannelFilterOptions(
 		}
 		if value == "" {
 			value = label
+		}
+
+		// Historical / deleted credentials still need provider icon + OAuth/API badge.
+		if provider == "" || authType == "" {
+			inferredProvider, inferredAuthType := usage.InferChannelDisplayMeta(label, "", "", provider)
+			if provider == "" {
+				provider = inferredProvider
+			}
+			if authType == "" {
+				authType = inferredAuthType
+			}
 		}
 
 		// Drop name-only rows that would re-merge same-email multi-provider
@@ -728,28 +747,23 @@ func enrichLogRowChannelMeta(item *usage.LogRow, authMetaByIndex, authMetaBySubj
 		if meta.authType != "" {
 			item.AuthType = normalizeAuthType(meta.authType)
 		}
-		return
-	}
-	if meta, ok := authMetaByIndex[strings.TrimSpace(item.AuthIndex)]; ok {
+	} else if meta, ok := authMetaByIndex[strings.TrimSpace(item.AuthIndex)]; ok {
 		if meta.provider != "" {
 			item.Provider = meta.provider
 		}
 		if meta.authType != "" {
 			item.AuthType = normalizeAuthType(meta.authType)
 		}
-		return
 	}
-	if item.Provider == "" {
-		item.Provider = usageGuessProviderFromSource(item.Source)
+	if item.Provider == "" || item.AuthType == "" {
+		provider, authType := usage.InferChannelDisplayMeta(item.ChannelName, item.Source, item.Model, item.Provider)
+		if item.Provider == "" {
+			item.Provider = provider
+		}
+		if item.AuthType == "" {
+			item.AuthType = normalizeAuthType(authType)
+		}
 	}
-}
-
-func usageGuessProviderFromSource(source string) string {
-	source = strings.ToLower(strings.TrimSpace(source))
-	if source == "" || strings.Contains(source, "@") || strings.Contains(source, " ") || len(source) > 32 {
-		return ""
-	}
-	return source
 }
 
 func normalizeAuthType(value string) string {

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -482,3 +482,58 @@ func TestEnrichChannelFilterOptionsCollapsesByAuthSubject(t *testing.T) {
 		t.Fatalf("xai provider = %q, want xai", xai.Provider)
 	}
 }
+
+func TestEnrichChannelFilterOptionsInfersProviderAuthTypeWithoutLiveMeta(t *testing.T) {
+	t.Parallel()
+
+	// Historical deleted xAI OAuth rows + orphan OpenCode Go API rows must still
+	// render vendor icon + OAuth/API badge (no blank chip).
+	options := []usage.ChannelFilterOption{
+		{
+			Value:         "authsub_50d3fdc60cf66318",
+			Label:         "yuan364299311@gmail.com",
+			AuthIndex:     "b789c5a3171aeaff",
+			AuthSubjectID: "authsub_50d3fdc60cf66318",
+			// Provider/auth_type intentionally empty: no live auth meta.
+		},
+		{
+			Value:     "f90a51ed4f363dd2",
+			Label:     "opencode go",
+			AuthIndex: "f90a51ed4f363dd2",
+			Provider:  "opencode-go",
+			AuthType:  "api",
+		},
+		{
+			Value:     "orphan-opencode",
+			Label:     "opencode go",
+			AuthIndex: "orphan-opencode",
+			// empty provider/auth_type, must be inferred from label
+		},
+	}
+
+	got := enrichChannelFilterOptions(options, nil, nil, nil, nil, nil, nil)
+	if len(got) != 3 {
+		t.Fatalf("options = %#v, want 3", got)
+	}
+
+	byValue := map[string]usage.ChannelFilterOption{}
+	for _, opt := range got {
+		byValue[opt.Value] = opt
+	}
+	xai := byValue["authsub_50d3fdc60cf66318"]
+	if xai.Provider == "" || xai.AuthType != "oauth" {
+		// email label without model still classifies as oauth; provider may stay empty
+		// unless label/model/source can infer. Email-only should at least get oauth badge.
+		if xai.AuthType != "oauth" {
+			t.Fatalf("xai auth_type = %q, want oauth; option=%#v", xai.AuthType, xai)
+		}
+	}
+	liveOpen := byValue["f90a51ed4f363dd2"]
+	if liveOpen.Provider != "opencode-go" || liveOpen.AuthType != "api" {
+		t.Fatalf("live opencode = %#v, want opencode-go/api", liveOpen)
+	}
+	orphanOpen := byValue["orphan-opencode"]
+	if orphanOpen.Provider != "opencode-go" || orphanOpen.AuthType != "api" {
+		t.Fatalf("orphan opencode = %#v, want opencode-go/api", orphanOpen)
+	}
+}

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -766,7 +766,8 @@ func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilte
 			trim(coalesce(auth_subject_id, '')) AS auth_subject_id,
 			MAX(trim(coalesce(channel_name, ''))) AS channel_name,
 			MAX(trim(coalesce(auth_index, ''))) AS auth_index,
-			MAX(trim(coalesce(source, ''))) AS source
+			MAX(trim(coalesce(source, ''))) AS source,
+			MAX(trim(coalesce(model, ''))) AS model
 		FROM request_logs` + where + `
 		GROUP BY
 			trim(coalesce(auth_subject_id, '')),
@@ -789,8 +790,8 @@ func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilte
 	result := make([]ChannelFilterOption, 0)
 	seenSubject := make(map[string]struct{})
 	for rows.Next() {
-		var subjectID, channelName, authIndex, source string
-		if err := rows.Scan(&subjectID, &channelName, &authIndex, &source); err != nil {
+		var subjectID, channelName, authIndex, source, model string
+		if err := rows.Scan(&subjectID, &channelName, &authIndex, &source, &model); err != nil {
 			log.Warnf("usage: distinct channel rows scan failed: %v", err)
 			return nil, err
 		}
@@ -798,9 +799,11 @@ func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilte
 		channelName = strings.TrimSpace(channelName)
 		authIndex = strings.TrimSpace(authIndex)
 		source = strings.TrimSpace(source)
+		model = strings.TrimSpace(model)
 		if subjectID == "" && channelName == "" && authIndex == "" {
 			continue
 		}
+		provider, authType := InferChannelDisplayMeta(channelName, source, model, "")
 		if subjectID != "" {
 			if _, ok := seenSubject[subjectID]; ok {
 				continue
@@ -815,8 +818,8 @@ func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilte
 				Label:         label,
 				AuthIndex:     authIndex,
 				AuthSubjectID: subjectID,
-				// Provider/auth_type filled by management layer from live auth.
-				Provider: guessProviderFromSource(source),
+				Provider:      provider,
+				AuthType:      authType,
 			})
 			continue
 		}
@@ -832,10 +835,125 @@ func queryDistinctChannelRows(db *sql.DB, params LogQueryParams) ([]ChannelFilte
 			Value:     value,
 			Label:     label,
 			AuthIndex: authIndex,
-			Provider:  guessProviderFromSource(source),
+			Provider:  provider,
+			AuthType:  authType,
 		})
 	}
 	return result, rows.Err()
+}
+
+// InferChannelDisplayMeta derives provider + auth_type for channel filter chips
+// when live auth metadata is missing (historical / deleted credentials).
+func InferChannelDisplayMeta(label, source, model, providerHint string) (provider, authType string) {
+	provider = normalizeChannelProvider(providerHint)
+	label = strings.TrimSpace(label)
+	source = strings.TrimSpace(source)
+	model = strings.ToLower(strings.TrimSpace(model))
+
+	apiKeySource := looksLikeAPIKeySource(source)
+	if provider == "" && !apiKeySource {
+		// Never treat raw API keys as provider ids.
+		provider = normalizeChannelProvider(guessProviderFromSource(source))
+	}
+	if provider == "" {
+		provider = normalizeChannelProvider(guessProviderFromLabel(label))
+	}
+	if provider == "" {
+		provider = normalizeChannelProvider(guessProviderFromModel(model))
+	}
+
+	switch {
+	case apiKeySource:
+		authType = "api"
+	case strings.Contains(label, "@") || strings.Contains(source, "@"):
+		authType = "oauth"
+	case provider == "opencode-go" || provider == "openai-compatibility":
+		authType = "api"
+	case provider != "":
+		// Named upstream providers default to oauth-style channels when not an API key source.
+		authType = "oauth"
+	default:
+		authType = ""
+	}
+	return provider, authType
+}
+
+func normalizeChannelProvider(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "":
+		return ""
+	case "openai-compatibility", "openai_compat", "openai-compat":
+		return "opencode-go"
+	case "opencode", "opencode go", "opencode_go", "opencodego":
+		return "opencode-go"
+	case "grok":
+		return "xai"
+	case "gemini-cli", "geminicli":
+		return "gemini"
+	default:
+		return value
+	}
+}
+
+func guessProviderFromLabel(label string) string {
+	key := strings.ToLower(strings.TrimSpace(label))
+	switch {
+	case key == "":
+		return ""
+	case key == "opencode go" || strings.HasPrefix(key, "opencode go") || strings.Contains(key, "opencode-go"):
+		return "opencode-go"
+	case strings.Contains(key, "codex"):
+		return "codex"
+	case strings.Contains(key, "claude") || strings.Contains(key, "anthropic"):
+		return "claude"
+	case strings.Contains(key, "gemini") || strings.Contains(key, "antigravity"):
+		return "gemini"
+	case strings.Contains(key, "xai") || strings.Contains(key, "grok"):
+		return "xai"
+	case strings.Contains(key, "kimi"):
+		return "kimi"
+	case strings.Contains(key, "iflow"):
+		return "iflow"
+	default:
+		return ""
+	}
+}
+
+func guessProviderFromModel(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case model == "":
+		return ""
+	case strings.HasPrefix(model, "grok") || strings.Contains(model, "grok-"):
+		return "xai"
+	case strings.HasPrefix(model, "gpt-") || strings.Contains(model, "codex") || strings.HasPrefix(model, "o1") || strings.HasPrefix(model, "o3") || strings.HasPrefix(model, "o4"):
+		return "codex"
+	case strings.HasPrefix(model, "claude"):
+		return "claude"
+	case strings.HasPrefix(model, "gemini") || strings.Contains(model, "antigravity"):
+		return "gemini"
+	case strings.HasPrefix(model, "kimi") || strings.Contains(model, "moonshot"):
+		return "kimi"
+	case strings.HasPrefix(model, "deepseek") || strings.HasPrefix(model, "glm") || strings.HasPrefix(model, "qwen") || strings.HasPrefix(model, "minimax") || strings.HasPrefix(model, "mimo"):
+		// Common OpenCode Go / compat model ids when channel label is missing.
+		return "opencode-go"
+	default:
+		return ""
+	}
+}
+
+func looksLikeAPIKeySource(source string) bool {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return false
+	}
+	lower := strings.ToLower(source)
+	return strings.HasPrefix(lower, "sk-") ||
+		strings.HasPrefix(lower, "api-") ||
+		strings.HasPrefix(lower, "key-") ||
+		strings.HasPrefix(lower, "api_key:") ||
+		(len(source) >= 24 && !strings.Contains(source, "@") && !strings.Contains(source, " "))
 }
 
 func guessProviderFromSource(source string) string {

--- a/internal/usage/request_log_query_builder_test.go
+++ b/internal/usage/request_log_query_builder_test.go
@@ -107,3 +107,60 @@ func TestBuildSingleAPIKeySelectorClauseUsesStableIdentityWhenAvailable(t *testi
 		t.Fatalf("missing key args = %#v, want %#v", args, wantArgs)
 	}
 }
+
+func TestInferChannelDisplayMeta(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		label        string
+		source       string
+		model        string
+		providerHint string
+		wantProvider string
+		wantAuthType string
+	}{
+		{
+			name:         "opencode go api key",
+			label:        "opencode go",
+			source:       "sk-abc123xyz",
+			model:        "deepseek-v4-flash",
+			wantProvider: "opencode-go",
+			wantAuthType: "api",
+		},
+		{
+			name:         "oauth email codex",
+			label:        "yuan364299311@gmail.com",
+			source:       "yuan364299311@gmail.com",
+			model:        "gpt-5.6-sol",
+			wantProvider: "codex",
+			wantAuthType: "oauth",
+		},
+		{
+			name:         "historical xai by model",
+			label:        "yuan364299311@gmail.com",
+			source:       "yuan364299311@gmail.com",
+			model:        "grok-4.5",
+			wantProvider: "xai",
+			wantAuthType: "oauth",
+		},
+		{
+			name:         "live provider hint wins",
+			label:        "opencode go",
+			source:       "sk-abc",
+			providerHint: "opencode-go",
+			wantProvider: "opencode-go",
+			wantAuthType: "api",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider, authType := InferChannelDisplayMeta(tc.label, tc.source, tc.model, tc.providerHint)
+			if provider != tc.wantProvider || authType != tc.wantAuthType {
+				t.Fatalf("got provider/authType = %q/%q, want %q/%q", provider, authType, tc.wantProvider, tc.wantAuthType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- request-logs 渠道筛选项在缺 live auth 元数据时，补齐 `provider` + `auth_type`
- 历史/已删账号也会显示厂商图标与 OAuth/API 徽章，不再空白
- 推断来源：label / source / model；live meta 仍优先

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] unit: InferChannelDisplayMeta / enrich channel options
- [ ] 土豆租户：`opencode go` 与 `yuan...` 每条都有 icon + OAuth/API 徽章