### PR TITLE
fix: stop wiring reasoning_effort none for grok-4.5

### DIFF
--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -945,7 +945,8 @@ func GetXAIModels() []*ModelInfo {
 			Description:         "SpaceXAI's intelligent coding model for agentic software, engineering, and workflow tasks.",
 			ContextLength:       500000,
 			MaxCompletionTokens: 65536,
-			Thinking:            &ThinkingSupport{ZeroAllowed: true, Levels: []string{"low", "medium", "high"}},
+			// Upstream rejects reasoning.effort="none"; disable by omitting the field.
+			Thinking: &ThinkingSupport{ZeroAllowed: false, Levels: []string{"low", "medium", "high"}},
 		},
 		{
 			ID:                  "grok-4.3",

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -945,8 +945,7 @@ func GetXAIModels() []*ModelInfo {
 			Description:         "SpaceXAI's intelligent coding model for agentic software, engineering, and workflow tasks.",
 			ContextLength:       500000,
 			MaxCompletionTokens: 65536,
-			// Upstream rejects reasoning.effort="none"; disable by omitting the field.
-			Thinking: &ThinkingSupport{ZeroAllowed: false, Levels: []string{"low", "medium", "high"}},
+			Thinking:            &ThinkingSupport{ZeroAllowed: false, Levels: []string{"low", "medium", "high"}},
 		},
 		{
 			ID:                  "grok-4.3",

--- a/internal/thinking/provider/codex/apply.go
+++ b/internal/thinking/provider/codex/apply.go
@@ -65,25 +65,39 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 		return result, nil
 	}
 
-	effort := ""
+	// ModeNone: only wire "none" when the model actually accepts it.
+	// ZeroAllowed alone must not force "none" when Levels omit "none"
+	// (e.g. grok-4.5 rejects reasoning.effort="none"); fall back to lowest level.
 	support := modelInfo.Thinking
-	if config.Budget == 0 {
-		if support.ZeroAllowed || hasLevel(support.Levels, string(thinking.LevelNone)) {
-			effort = string(thinking.LevelNone)
-		}
-	}
-	if effort == "" && config.Level != "" {
+	effort := ""
+	if supportsNoneEffort(support) {
+		effort = string(thinking.LevelNone)
+	} else if config.Level != "" {
 		effort = string(config.Level)
-	}
-	if effort == "" && len(support.Levels) > 0 {
+	} else if len(support.Levels) > 0 {
 		effort = support.Levels[0]
 	}
 	if effort == "" {
-		return body, nil
+		result, err := sjson.DeleteBytes(body, "reasoning.effort")
+		if err != nil {
+			return body, nil
+		}
+		return result, nil
 	}
-
 	result, _ := sjson.SetBytes(body, "reasoning.effort", effort)
 	return result, nil
+}
+
+// supportsNoneEffort reports whether the model accepts reasoning.effort="none".
+// Explicit Levels win: if the list omits "none", do not emit it even when ZeroAllowed.
+func supportsNoneEffort(support *registry.ThinkingSupport) bool {
+	if support == nil {
+		return false
+	}
+	if hasLevel(support.Levels, string(thinking.LevelNone)) {
+		return true
+	}
+	return support.ZeroAllowed && len(support.Levels) == 0
 }
 
 func applyCompatibleCodex(body []byte, config thinking.ThinkingConfig) ([]byte, error) {

--- a/internal/thinking/provider/openai/apply.go
+++ b/internal/thinking/provider/openai/apply.go
@@ -62,25 +62,39 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 		return result, nil
 	}
 
-	effort := ""
+	// ModeNone: only wire "none" when the model actually accepts it.
+	// ZeroAllowed alone must not force "none" when Levels omit "none";
+	// fall back to lowest level so upstream does not 400 on "none".
 	support := modelInfo.Thinking
-	if config.Budget == 0 {
-		if support.ZeroAllowed || hasLevel(support.Levels, string(thinking.LevelNone)) {
-			effort = string(thinking.LevelNone)
-		}
-	}
-	if effort == "" && config.Level != "" {
+	effort := ""
+	if supportsNoneEffort(support) {
+		effort = string(thinking.LevelNone)
+	} else if config.Level != "" {
 		effort = string(config.Level)
-	}
-	if effort == "" && len(support.Levels) > 0 {
+	} else if len(support.Levels) > 0 {
 		effort = support.Levels[0]
 	}
 	if effort == "" {
-		return body, nil
+		result, err := sjson.DeleteBytes(body, "reasoning_effort")
+		if err != nil {
+			return body, nil
+		}
+		return result, nil
 	}
-
 	result, _ := sjson.SetBytes(body, "reasoning_effort", effort)
 	return result, nil
+}
+
+// supportsNoneEffort reports whether the model accepts reasoning_effort="none".
+// Explicit Levels win: if the list omits "none", do not emit it even when ZeroAllowed.
+func supportsNoneEffort(support *registry.ThinkingSupport) bool {
+	if support == nil {
+		return false
+	}
+	if hasLevel(support.Levels, string(thinking.LevelNone)) {
+		return true
+	}
+	return support.ZeroAllowed && len(support.Levels) == 0
 }
 
 func applyCompatibleOpenAI(body []byte, config thinking.ThinkingConfig) ([]byte, error) {

--- a/internal/thinking/xai_test.go
+++ b/internal/thinking/xai_test.go
@@ -31,3 +31,28 @@ func TestXAIThinkingStripsUnsupportedModelConfig(t *testing.T) {
 		t.Fatalf("reasoning.effort should be stripped; body=%s", got)
 	}
 }
+
+// grok-4.5 rejects effort=none; clamp disable to lowest supported level (low).
+func TestXAIGrok45ModeNoneClampsToLowestLevel(t *testing.T) {
+	body := []byte(`{"model":"grok-4.5","input":[{"role":"user","content":"hi"}],"reasoning":{"effort":"none"}}`)
+
+	got, err := thinking.ApplyThinking(body, "grok-4.5", "xai", "xai", "xai")
+	if err != nil {
+		t.Fatalf("ApplyThinking() error = %v", err)
+	}
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "low" {
+		t.Fatalf("reasoning.effort = %q, want low; body=%s", effort, got)
+	}
+}
+
+func TestXAIGrok43ModeNoneKeepsNoneEffort(t *testing.T) {
+	body := []byte(`{"model":"grok-4.3","input":[{"role":"user","content":"hi"}],"reasoning":{"effort":"none"}}`)
+
+	got, err := thinking.ApplyThinking(body, "grok-4.3", "xai", "xai", "xai")
+	if err != nil {
+		t.Fatalf("ApplyThinking() error = %v", err)
+	}
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "none" {
+		t.Fatalf("reasoning.effort = %q, want none; body=%s", effort, got)
+	}
+}


### PR DESCRIPTION
## Summary
- Claude disable maps to ModeNone; grok-4.5 upstream rejects `reasoning.effort="none"` (request #1000246067).
- Only emit `none` when model Levels include it (or ZeroAllowed with no Levels); otherwise fall back to lowest level.
- Mark grok-4.5 `ZeroAllowed: false` so catalog matches upstream.

## Test plan
- [x] `go test ./internal/thinking/ ./test/ -run 'TestXAI|TestThinkingE2EMatrix' -count=1`
- [x] New cases: grok-4.5 ModeNone → `low`; grok-4.3 ModeNone → `none`