### PR TITLE
feat: move daily spending limit into permission profiles

### DIFF
--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -125,7 +125,8 @@ type APIKeyEntry struct {
 	SpendingLimit float64 `yaml:"spending-limit,omitempty" json:"spending-limit,omitempty"`
 
 	// DailySpendingLimit is the maximum allowed spending in US dollars per day. 0 means
-	// unlimited. It resets at the project timezone day boundary.
+	// unlimited. It resets at the project timezone day boundary. When permission-profile-id
+	// is set, the effective value comes from the permission profile.
 	DailySpendingLimit float64 `yaml:"daily-spending-limit,omitempty" json:"daily-spending-limit,omitempty"`
 
 	// DailySpendingUsed is the effective project-day USD cost for this key (management list only).

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -432,12 +432,13 @@ func TestResetDailySpendingAndRejectsUnlimited(t *testing.T) {
 	}
 }
 
-func TestEffectiveRowKeepsKeyDailySpendingLimitWithProfile(t *testing.T) {
+func TestEffectiveRowAppliesProfileDailySpendingLimit(t *testing.T) {
 	setupTestDB(t)
 	if err := usage.ReplaceAllAPIKeyPermissionProfiles([]usage.APIKeyPermissionProfileRow{{
-		ID:         "p1",
-		Name:       "P1",
-		DailyLimit: 5,
+		ID:                 "p1",
+		Name:               "P1",
+		DailyLimit:         5,
+		DailySpendingLimit: 12.5,
 	}}); err != nil {
 		t.Fatalf("profiles: %v", err)
 	}
@@ -445,7 +446,7 @@ func TestEffectiveRowKeepsKeyDailySpendingLimitWithProfile(t *testing.T) {
 		ID:                  "key-1",
 		Key:                 "sk-profile",
 		PermissionProfileID: "p1",
-		DailySpendingLimit:  12.5,
+		DailySpendingLimit:  1, // stale key copy; profile wins
 	}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
@@ -455,7 +456,7 @@ func TestEffectiveRowKeepsKeyDailySpendingLimitWithProfile(t *testing.T) {
 		t.Fatalf("len = %d", len(entries))
 	}
 	if entries[0].DailySpendingLimit != 12.5 {
-		t.Fatalf("DailySpendingLimit = %v, want 12.5 (key-owned, not cleared by profile)", entries[0].DailySpendingLimit)
+		t.Fatalf("DailySpendingLimit = %v, want 12.5 from profile", entries[0].DailySpendingLimit)
 	}
 	if entries[0].DailyLimit != 5 {
 		t.Fatalf("DailyLimit from profile = %v, want 5", entries[0].DailyLimit)

--- a/internal/storage/postgres/ent/migrate/schema.go
+++ b/internal/storage/postgres/ent/migrate/schema.go
@@ -44,6 +44,7 @@ var (
 		{Name: "name", Type: field.TypeString, Default: ""},
 		{Name: "daily_limit", Type: field.TypeInt, Default: 0},
 		{Name: "total_quota", Type: field.TypeInt, Default: 0},
+		{Name: "daily_spending_limit", Type: field.TypeFloat64, Default: 0},
 		{Name: "concurrency_limit", Type: field.TypeInt, Default: 0},
 		{Name: "rpm_limit", Type: field.TypeInt, Default: 0},
 		{Name: "tpm_limit", Type: field.TypeInt, Default: 0},

--- a/internal/storage/postgres/ent/schema/runtime.go
+++ b/internal/storage/postgres/ent/schema/runtime.go
@@ -179,6 +179,7 @@ func (APIKeyPermissionProfile) Fields() []ent.Field {
 		field.String("name").Default(""),
 		field.Int("daily_limit").Default(0),
 		field.Int("total_quota").Default(0),
+		field.Float("daily_spending_limit").Default(0),
 		field.Int("concurrency_limit").Default(0),
 		field.Int("rpm_limit").Default(0),
 		field.Int("tpm_limit").Default(0),

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -19,8 +19,15 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607160002_ai_account_status_read_model", SQL: aiAccountStatusReadModelSQL},
 		// Manual same-day daily spending reset baseline per API key (does not delete request_logs).
 		{Version: "202607160003_api_key_daily_spending_resets", SQL: apiKeyDailySpendingResetsSQL},
+		// Daily USD spending limit belongs on reusable permission profiles.
+		{Version: "202607170001_profile_daily_spending_limit", SQL: profileDailySpendingLimitSQL},
 	}
 }
+
+const profileDailySpendingLimitSQL = `
+ALTER TABLE api_key_permission_profiles
+  ADD COLUMN IF NOT EXISTS daily_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+`
 
 // TIMESTAMPTZ matches other PG runtime tables; SQLite bootstrap uses TIMESTAMP (see usage package).
 const apiKeyDailySpendingResetsSQL = `

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -7,10 +7,15 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 13 {
-		t.Fatalf("RuntimeMigrations len = %d, want 13", len(migrations))
+	if len(migrations) != 14 {
+		t.Fatalf("RuntimeMigrations len = %d, want 14", len(migrations))
 	}
-	// Latest migration: API key daily spending reset baselines.
+	// Latest migration: daily spending limit on permission profiles.
+	profileSpendSQL := migrations[13].SQL
+	if !strings.Contains(profileSpendSQL, "daily_spending_limit") {
+		t.Fatalf("profile daily spending migration missing daily_spending_limit")
+	}
+	// Prior: API key daily spending reset baselines.
 	resetSQL := migrations[12].SQL
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS api_key_daily_spending_resets",

--- a/internal/storage/sqlite/apikey/permission_profiles.go
+++ b/internal/storage/sqlite/apikey/permission_profiles.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
   name                   TEXT NOT NULL DEFAULT '',
   daily_limit            INTEGER NOT NULL DEFAULT 0,
   total_quota            INTEGER NOT NULL DEFAULT 0,
+  daily_spending_limit   REAL NOT NULL DEFAULT 0,
   concurrency_limit      INTEGER NOT NULL DEFAULT 0,
   rpm_limit              INTEGER NOT NULL DEFAULT 0,
   tpm_limit              INTEGER NOT NULL DEFAULT 0,
@@ -35,6 +37,7 @@ type PermissionProfileRow struct {
 	Name                 string   `json:"name" yaml:"name"`
 	DailyLimit           int      `json:"daily-limit" yaml:"daily-limit"`
 	TotalQuota           int      `json:"total-quota" yaml:"total-quota"`
+	DailySpendingLimit   float64  `json:"daily-spending-limit" yaml:"daily-spending-limit"`
 	ConcurrencyLimit     int      `json:"concurrency-limit" yaml:"concurrency-limit"`
 	RPMLimit             int      `json:"rpm-limit" yaml:"rpm-limit"`
 	TPMLimit             int      `json:"tpm-limit" yaml:"tpm-limit"`
@@ -56,6 +59,9 @@ func InitPermissionProfilesTable(db *sql.DB) {
 	if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
 		log.Warnf("sqlite/apikey: migrate api_key_permission_profiles tenant_id: %v", err)
 	}
+	if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN daily_spending_limit REAL NOT NULL DEFAULT 0"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+		log.Warnf("sqlite/apikey: migrate api_key_permission_profiles daily_spending_limit: %v", err)
+	}
 }
 
 func (s Store) ListPermissionProfiles() []PermissionProfileRow {
@@ -63,7 +69,7 @@ func (s Store) ListPermissionProfiles() []PermissionProfileRow {
 		return nil
 	}
 
-	rows, err := s.db.Query(`SELECT id, name, daily_limit, total_quota, concurrency_limit,
+	rows, err := s.db.Query(`SELECT id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
 		rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups,
 		system_prompt, created_at, updated_at
 		FROM api_key_permission_profiles WHERE tenant_id = ? ORDER BY created_at ASC, id ASC`, s.tenantID)
@@ -103,9 +109,9 @@ func (s Store) ReplaceAllPermissionProfiles(profiles []PermissionProfileRow) err
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_key_permission_profiles
-		(tenant_id, id, name, daily_limit, total_quota, concurrency_limit, rpm_limit, tpm_limit,
+		(tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		 allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -135,7 +141,7 @@ func (s Store) ReplaceAllPermissionProfiles(profiles []PermissionProfileRow) err
 		profile.UpdatedAt = now
 
 		if _, err := stmt.Exec(
-			s.tenantID, profile.ID, profile.Name, profile.DailyLimit, profile.TotalQuota,
+			s.tenantID, profile.ID, profile.Name, profile.DailyLimit, profile.TotalQuota, profile.DailySpendingLimit,
 			profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
 			mustJSONStringList(profile.AllowedModels), mustJSONStringList(profile.AllowedChannels),
 			mustJSONStringList(profile.AllowedChannelGroups), profile.SystemPrompt,
@@ -154,6 +160,9 @@ func normalizePermissionProfile(profile PermissionProfileRow) PermissionProfileR
 	profile.Name = strings.TrimSpace(profile.Name)
 	profile.DailyLimit = normalizeNonNegativeInt(profile.DailyLimit)
 	profile.TotalQuota = normalizeNonNegativeInt(profile.TotalQuota)
+	if profile.DailySpendingLimit < 0 || math.IsNaN(profile.DailySpendingLimit) || math.IsInf(profile.DailySpendingLimit, 0) {
+		profile.DailySpendingLimit = 0
+	}
 	profile.ConcurrencyLimit = normalizeNonNegativeInt(profile.ConcurrencyLimit)
 	profile.RPMLimit = normalizeNonNegativeInt(profile.RPMLimit)
 	profile.TPMLimit = normalizeNonNegativeInt(profile.TPMLimit)
@@ -170,7 +179,7 @@ func scanPermissionProfileRow(row scanner) (*PermissionProfileRow, bool) {
 	var channelsJSON string
 	var channelGroupsJSON string
 	if err := row.Scan(
-		&profile.ID, &profile.Name, &profile.DailyLimit, &profile.TotalQuota, &profile.ConcurrencyLimit,
+		&profile.ID, &profile.Name, &profile.DailyLimit, &profile.TotalQuota, &profile.DailySpendingLimit, &profile.ConcurrencyLimit,
 		&profile.RPMLimit, &profile.TPMLimit, &modelsJSON, &channelsJSON, &channelGroupsJSON,
 		&profile.SystemPrompt, &profile.CreatedAt, &profile.UpdatedAt,
 	); err != nil {

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -65,6 +65,7 @@ type PermissionProfileSnapshot struct {
 	ID                   string
 	DailyLimit           int
 	TotalQuota           int
+	DailySpendingLimit   float64
 	ConcurrencyLimit     int
 	RPMLimit             int
 	TPMLimit             int
@@ -495,7 +496,7 @@ func EffectiveAPIKeyRowWithProfiles(row APIKeyRow, profiles []PermissionProfileS
 	row.DailyLimit = matched.DailyLimit
 	row.TotalQuota = matched.TotalQuota
 	row.SpendingLimit = 0
-	// daily-spending-limit is key-owned and independent of permission profiles.
+	row.DailySpendingLimit = matched.DailySpendingLimit
 	row.ConcurrencyLimit = matched.ConcurrencyLimit
 	row.RPMLimit = matched.RPMLimit
 	row.TPMLimit = matched.TPMLimit

--- a/internal/usage/api_key_permission_profiles_db.go
+++ b/internal/usage/api_key_permission_profiles_db.go
@@ -109,6 +109,9 @@ func normalizeAPIKeyPermissionProfile(profile APIKeyPermissionProfileRow) APIKey
 	profile.Name = strings.TrimSpace(profile.Name)
 	profile.DailyLimit = normalizeNonNegativeInt(profile.DailyLimit)
 	profile.TotalQuota = normalizeNonNegativeInt(profile.TotalQuota)
+	if profile.DailySpendingLimit < 0 {
+		profile.DailySpendingLimit = 0
+	}
 	profile.ConcurrencyLimit = normalizeNonNegativeInt(profile.ConcurrencyLimit)
 	profile.RPMLimit = normalizeNonNegativeInt(profile.RPMLimit)
 	profile.TPMLimit = normalizeNonNegativeInt(profile.TPMLimit)

--- a/internal/usage/apikey_db.go
+++ b/internal/usage/apikey_db.go
@@ -247,6 +247,7 @@ func toPermissionProfileSnapshots(profiles []APIKeyPermissionProfileRow) []sqlap
 			ID:                   profile.ID,
 			DailyLimit:           profile.DailyLimit,
 			TotalQuota:           profile.TotalQuota,
+			DailySpendingLimit:   profile.DailySpendingLimit,
 			ConcurrencyLimit:     profile.ConcurrencyLimit,
 			RPMLimit:             profile.RPMLimit,
 			TPMLimit:             profile.TPMLimit,


### PR DESCRIPTION
## Summary
- Permission profiles store `daily-spending-limit` (USD)
- Effective API key rows inherit the limit from the bound profile
- SQLite + Postgres migration for profile column

## Test plan
- [x] `go test ./internal/storage/sqlite/apikey/ ./internal/usage/ ./internal/management/settings/apikey/ ./internal/storage/postgres/ ./internal/api/handlers/management/`
- Manual: set daily spending on a permission profile, bind keys, confirm list shows limit and reset works