### PR TITLE
fix: distinct actionable API key quota error messages

### DIFF
--- a/internal/api/middleware/quota.go
+++ b/internal/api/middleware/quota.go
@@ -197,15 +197,9 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if concurrencyLimit > 0 {
 			release, ok := acquireKeyConcurrency(apiKey, concurrencyLimit)
 			if !ok {
-				message := fmt.Sprintf("concurrency limit (%d in-flight requests) exceeded for this API key", concurrencyLimit)
-				diagnostics.SetQuotaRejection(c, "concurrency", float64(concurrencyLimit), float64(keyConcurrencyCount(apiKey)), "concurrency_limit_exceeded", "rate_limit_exceeded", message)
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-					"error": map[string]interface{}{
-						"message": message,
-						"type":    "rate_limit_exceeded",
-						"code":    "concurrency_limit_exceeded",
-					},
-				})
+				current := keyConcurrencyCount(apiKey)
+				rejectQuotaLimit(c, "concurrency", float64(concurrencyLimit), float64(current), "concurrency_limit_exceeded",
+					fmt.Sprintf("Concurrent request limit exceeded: %d in-flight requests (limit %d). Wait for running requests to finish, or raise the concurrency limit in the permission profile.", current, concurrencyLimit))
 				return
 			}
 			defer release()
@@ -215,15 +209,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if rpmLimit > 0 {
 			currentRPM := rpmTracker.count()
 			if currentRPM > rpmLimit {
-				message := fmt.Sprintf("RPM limit (%d requests/min) exceeded for this API key", rpmLimit)
-				diagnostics.SetQuotaRejection(c, "rpm", float64(rpmLimit), float64(currentRPM), "rpm_limit_exceeded", "rate_limit_exceeded", message)
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-					"error": map[string]interface{}{
-						"message": message,
-						"type":    "rate_limit_exceeded",
-						"code":    "rpm_limit_exceeded",
-					},
-				})
+				rejectQuotaLimit(c, "rpm", float64(rpmLimit), float64(currentRPM), "rpm_limit_exceeded",
+					fmt.Sprintf("Requests-per-minute (RPM) limit exceeded: %d/%d requests in the last minute. Slow down, or raise the RPM limit in the permission profile.", currentRPM, rpmLimit))
 				return
 			}
 		}
@@ -233,15 +220,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 			tracker := getTPMTracker(apiKey)
 			currentTPM := tracker.sum()
 			if currentTPM >= int64(tpmLimit) {
-				message := fmt.Sprintf("TPM limit (%d tokens/min) exceeded for this API key", tpmLimit)
-				diagnostics.SetQuotaRejection(c, "tpm", float64(tpmLimit), float64(currentTPM), "tpm_limit_exceeded", "rate_limit_exceeded", message)
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-					"error": map[string]interface{}{
-						"message": message,
-						"type":    "rate_limit_exceeded",
-						"code":    "tpm_limit_exceeded",
-					},
-				})
+				rejectQuotaLimit(c, "tpm", float64(tpmLimit), float64(currentTPM), "tpm_limit_exceeded",
+					fmt.Sprintf("Tokens-per-minute (TPM) limit exceeded: %d/%d tokens in the last minute. Slow down, or raise the TPM limit in the permission profile.", currentTPM, tpmLimit))
 				return
 			}
 		}
@@ -252,15 +232,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 			if err != nil {
 				log.Warnf("quota: failed to query daily usage for key %s: %v", maskKey(apiKey), err)
 			} else if todayCount >= int64(dailyLimit) {
-				message := fmt.Sprintf("daily request limit (%d) exceeded for this API key", dailyLimit)
-				diagnostics.SetQuotaRejection(c, "daily", float64(dailyLimit), float64(todayCount), "daily_limit_exceeded", "rate_limit_exceeded", message)
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-					"error": map[string]interface{}{
-						"message": message,
-						"type":    "rate_limit_exceeded",
-						"code":    "daily_limit_exceeded",
-					},
-				})
+				rejectQuotaLimit(c, "daily", float64(dailyLimit), float64(todayCount), "daily_limit_exceeded",
+					fmt.Sprintf("Daily request limit exceeded: %d/%d requests used today. Raise the daily request limit in the permission profile, or wait until the next project day.", todayCount, dailyLimit))
 				return
 			}
 		}
@@ -271,15 +244,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 			if err != nil {
 				log.Warnf("quota: failed to query total usage for key %s: %v", maskKey(apiKey), err)
 			} else if totalCount >= int64(totalQuota) {
-				message := fmt.Sprintf("total request quota (%d) exhausted for this API key", totalQuota)
-				diagnostics.SetQuotaRejection(c, "total", float64(totalQuota), float64(totalCount), "total_quota_exceeded", "rate_limit_exceeded", message)
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-					"error": map[string]interface{}{
-						"message": message,
-						"type":    "rate_limit_exceeded",
-						"code":    "total_quota_exceeded",
-					},
-				})
+				rejectQuotaLimit(c, "total", float64(totalQuota), float64(totalCount), "total_quota_exceeded",
+					fmt.Sprintf("Total request quota exhausted: %d/%d lifetime requests used. Raise the total request quota in the permission profile to continue.", totalCount, totalQuota))
 				return
 			}
 		}
@@ -290,15 +256,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 			if err != nil {
 				log.Warnf("quota: failed to query total cost for key %s: %v", maskKey(apiKey), err)
 			} else if totalCost >= spendingLimit {
-				message := fmt.Sprintf("spending limit ($%.2f) exceeded for this API key (current: $%.2f)", spendingLimit, totalCost)
-				diagnostics.SetQuotaRejection(c, "spending", spendingLimit, totalCost, "spending_limit_exceeded", "rate_limit_exceeded", message)
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-					"error": map[string]interface{}{
-						"message": message,
-						"type":    "rate_limit_exceeded",
-						"code":    "spending_limit_exceeded",
-					},
-				})
+				rejectQuotaLimit(c, "spending", spendingLimit, totalCost, "spending_limit_exceeded",
+					fmt.Sprintf("Lifetime spending limit exceeded: $%.2f of $%.2f used. Raise the spending limit to continue.", totalCost, spendingLimit))
 				return
 			}
 		}
@@ -309,21 +268,39 @@ func QuotaMiddleware() gin.HandlerFunc {
 			if err != nil {
 				log.Warnf("quota: failed to query today cost for key %s: %v", maskKey(apiKey), err)
 			} else if todayCost >= dailySpendingLimit {
-				message := fmt.Sprintf("daily spending limit ($%.2f) exceeded for this API key (today: $%.2f)", dailySpendingLimit, todayCost)
-				diagnostics.SetQuotaRejection(c, "daily_spending", dailySpendingLimit, todayCost, "daily_spending_limit_exceeded", "rate_limit_exceeded", message)
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-					"error": map[string]interface{}{
-						"message": message,
-						"type":    "rate_limit_exceeded",
-						"code":    "daily_spending_limit_exceeded",
-					},
-				})
+				rejectQuotaLimit(c, "daily_spending", dailySpendingLimit, todayCost, "daily_spending_limit_exceeded",
+					fmt.Sprintf("Daily spending limit exceeded: $%.2f of $%.2f used today. Raise the daily spending limit in the permission profile, reset today's spending, or wait until the next project day.", todayCost, dailySpendingLimit))
 				return
 			}
 		}
 
 		c.Next()
 	}
+}
+
+// rejectQuotaLimit writes a 429 with a distinct code/message and diagnostic headers.
+// Headers help clients that only surface "429 Too Many Requests" after retries.
+func rejectQuotaLimit(c *gin.Context, rejectedBy string, limit, current float64, code, message string) {
+	const errType = "rate_limit_exceeded"
+	diagnostics.SetQuotaRejection(c, rejectedBy, limit, current, code, errType, message)
+	c.Header("X-CliRelay-Quota-Code", code)
+	c.Header("X-CliRelay-Quota-Limit", formatQuotaNumber(limit))
+	c.Header("X-CliRelay-Quota-Current", formatQuotaNumber(current))
+	c.Header("X-CliRelay-Quota-Rejected-By", rejectedBy)
+	c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+		"error": map[string]interface{}{
+			"message": message,
+			"type":    errType,
+			"code":    code,
+		},
+	})
+}
+
+func formatQuotaNumber(v float64) string {
+	if v == float64(int64(v)) {
+		return strconv.FormatInt(int64(v), 10)
+	}
+	return strconv.FormatFloat(v, 'f', -1, 64)
 }
 
 // ─── Usage DB query functions (injected to avoid import cycle) ──────────────

--- a/internal/api/middleware/quota_test.go
+++ b/internal/api/middleware/quota_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -50,6 +51,12 @@ func TestQuotaMiddlewareEnforcesConcurrencyLimitPerKey(t *testing.T) {
 	router.ServeHTTP(secondSameKey, newQuotaPostRequest("key-a"))
 	if secondSameKey.Code != http.StatusTooManyRequests {
 		t.Fatalf("same-key concurrent status = %d, want %d", secondSameKey.Code, http.StatusTooManyRequests)
+	}
+	if !strings.Contains(secondSameKey.Body.String(), "Concurrent request limit exceeded") {
+		t.Fatalf("concurrency body = %s, want clear concurrency wording", secondSameKey.Body.String())
+	}
+	if got := secondSameKey.Header().Get("X-CliRelay-Quota-Code"); got != "concurrency_limit_exceeded" {
+		t.Fatalf("concurrency header code = %q", got)
 	}
 
 	secondOtherKey := httptest.NewRecorder()
@@ -107,7 +114,8 @@ func TestQuotaMiddlewareDailySpendingLimit(t *testing.T) {
 
 	var body struct {
 		Error struct {
-			Code string `json:"code"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
 		} `json:"error"`
 	}
 	if err := json.Unmarshal(blocked.Body.Bytes(), &body); err != nil {
@@ -115,6 +123,106 @@ func TestQuotaMiddlewareDailySpendingLimit(t *testing.T) {
 	}
 	if body.Error.Code != "daily_spending_limit_exceeded" {
 		t.Fatalf("error code = %q, want daily_spending_limit_exceeded", body.Error.Code)
+	}
+	if !strings.Contains(body.Error.Message, "Daily spending limit exceeded") {
+		t.Fatalf("message = %q, want daily spending wording", body.Error.Message)
+	}
+	if got := blocked.Header().Get("X-CliRelay-Quota-Code"); got != "daily_spending_limit_exceeded" {
+		t.Fatalf("X-CliRelay-Quota-Code = %q", got)
+	}
+	if got := blocked.Header().Get("X-CliRelay-Quota-Rejected-By"); got != "daily_spending" {
+		t.Fatalf("X-CliRelay-Quota-Rejected-By = %q", got)
+	}
+}
+
+func TestQuotaMiddlewareDistinctLimitMessages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetQuotaMiddlewareState(t)
+
+	countTodayByKeyFunc = func(string) (int64, error) { return 10, nil }
+	countTotalByKeyFunc = func(string) (int64, error) { return 100, nil }
+	queryTotalCostByKeyFunc = func(string) (float64, error) { return 25, nil }
+
+	cases := []struct {
+		name       string
+		metadata   map[string]string
+		wantCode   string
+		wantPhrase string
+	}{
+		{
+			name:       "daily requests",
+			metadata:   map[string]string{"daily-limit": "10"},
+			wantCode:   "daily_limit_exceeded",
+			wantPhrase: "Daily request limit exceeded",
+		},
+		{
+			name:       "total quota",
+			metadata:   map[string]string{"total-quota": "100"},
+			wantCode:   "total_quota_exceeded",
+			wantPhrase: "Total request quota exhausted",
+		},
+		{
+			name:       "rpm",
+			metadata:   map[string]string{"rpm-limit": "1"},
+			wantCode:   "rpm_limit_exceeded",
+			wantPhrase: "Requests-per-minute (RPM) limit exceeded",
+		},
+		{
+			name:       "spending",
+			metadata:   map[string]string{"spending-limit": "25"},
+			wantCode:   "spending_limit_exceeded",
+			wantPhrase: "Lifetime spending limit exceeded",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetQuotaMiddlewareState(t)
+			countTodayByKeyFunc = func(string) (int64, error) { return 10, nil }
+			countTotalByKeyFunc = func(string) (int64, error) { return 100, nil }
+			queryTotalCostByKeyFunc = func(string) (float64, error) { return 25, nil }
+
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("apiKey", "key-a")
+				c.Set("accessMetadata", tc.metadata)
+				c.Next()
+			})
+			router.Use(QuotaMiddleware())
+			router.POST("/v1/chat/completions", func(c *gin.Context) {
+				c.Status(http.StatusNoContent)
+			})
+
+			// RPM needs two posts so the second exceeds limit 1.
+			if tc.wantCode == "rpm_limit_exceeded" {
+				first := httptest.NewRecorder()
+				router.ServeHTTP(first, newQuotaPostRequest("key-a"))
+			}
+
+			blocked := httptest.NewRecorder()
+			router.ServeHTTP(blocked, newQuotaPostRequest("key-a"))
+			if blocked.Code != http.StatusTooManyRequests {
+				t.Fatalf("status = %d, want 429; body=%s", blocked.Code, blocked.Body.String())
+			}
+			var body struct {
+				Error struct {
+					Code    string `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(blocked.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode: %v body=%s", err, blocked.Body.String())
+			}
+			if body.Error.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", body.Error.Code, tc.wantCode)
+			}
+			if !strings.Contains(body.Error.Message, tc.wantPhrase) {
+				t.Fatalf("message = %q, want phrase %q", body.Error.Message, tc.wantPhrase)
+			}
+			if got := blocked.Header().Get("X-CliRelay-Quota-Code"); got != tc.wantCode {
+				t.Fatalf("header code = %q, want %q", got, tc.wantCode)
+			}
+		})
 	}
 }
 

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -322,7 +322,7 @@ func TestRequestLoggingMiddlewarePreservesOriginalURLAcrossRewrite(t *testing.T)
 	r.POST("/v1/responses", func(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 			"error": map[string]any{
-				"message": "RPM limit (10 requests/min) exceeded for this API key",
+				"message": "Requests-per-minute (RPM) limit exceeded: 11/10 requests in the last minute. Slow down, or raise the RPM limit in the permission profile.",
 				"type":    "rate_limit_exceeded",
 				"code":    "rpm_limit_exceeded",
 			},

--- a/internal/logging/request_logger_test.go
+++ b/internal/logging/request_logger_test.go
@@ -109,13 +109,13 @@ func TestLogRequestWithDiagnosticsUsesOriginalURL(t *testing.T) {
 			Current:      11,
 			ErrorCode:    "rpm_limit_exceeded",
 			ErrorType:    "rate_limit_exceeded",
-			ErrorMessage: "RPM limit (10 requests/min) exceeded for this API key",
+			ErrorMessage: "Requests-per-minute (RPM) limit exceeded: 11/10 requests in the last minute. Slow down, or raise the RPM limit in the permission profile.",
 		},
 		Response: &diagnostics.ResponseSnapshot{
 			Status:       429,
 			ErrorCode:    "rpm_limit_exceeded",
 			ErrorType:    "rate_limit_exceeded",
-			ErrorMessage: "RPM limit (10 requests/min) exceeded for this API key",
+			ErrorMessage: "Requests-per-minute (RPM) limit exceeded: 11/10 requests in the last minute. Slow down, or raise the RPM limit in the permission profile.",
 			Source:       "local_quota",
 		},
 	}


### PR DESCRIPTION
## Summary
- Rewrite local quota middleware 429 messages so each permission-profile limit is obvious (daily requests, total quota, concurrency, RPM, TPM, spending, daily spending)
- Include current/limit values and next-step guidance in `error.message`
- Add `X-CliRelay-Quota-Code`, `X-CliRelay-Quota-Limit`, `X-CliRelay-Quota-Current`, `X-CliRelay-Quota-Rejected-By` headers for clients that collapse retries to "429 Too Many Requests"

## Test plan
- [x] `go test ./internal/api/middleware/ ./internal/logging/`
- Manual: set each limit on a permission profile, fire past the limit, confirm response body message + code differ per limit