### PR TITLE
feat: API key daily spending reset history

### DIFF
--- a/internal/api/handlers/management/api_key_entries_test.go
+++ b/internal/api/handlers/management/api_key_entries_test.go
@@ -263,6 +263,25 @@ func TestResetAPIKeyDailySpendingSuccessAndGuards(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("missing status = %d, want 404; body=%s", rec.Code, rec.Body.String())
 	}
+
+	// history endpoint after successful reset
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(
+		http.MethodGet,
+		"/api-key-entries/daily-spending/reset-history?id=reset-id-1",
+		nil,
+	)
+	h.GetAPIKeyDailySpendingResetHistory(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("history status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`"items"`)) {
+		t.Fatalf("history body missing items: %s", rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`effective_used_before`)) {
+		t.Fatalf("history body missing effective_used_before: %s", rec.Body.String())
+	}
 }
 
 func TestGetAPIKeyEntriesIncludesDailySpendingFields(t *testing.T) {

--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -184,7 +184,19 @@ func (h *Handler) ResetAPIKeyDailySpending(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
-	result, err := h.apiKeySettings(c).ResetDailySpending(body.ID, body.Key)
+	actor := apikeysettings.DailySpendingResetActor{Kind: "service_credential"}
+	if principal, ok := principalFromContext(c); ok {
+		actor.Kind = strings.TrimSpace(principal.Kind)
+		if actor.Kind == "" {
+			actor.Kind = "service_credential"
+		}
+		actor.UserID = strings.TrimSpace(principal.User.ID)
+		actor.Username = strings.TrimSpace(principal.User.Username)
+		if actor.Username == "" {
+			actor.Username = strings.TrimSpace(principal.User.DisplayName)
+		}
+	}
+	result, err := h.apiKeySettings(c).ResetDailySpending(body.ID, body.Key, actor)
 	if err != nil {
 		switch {
 		case errors.Is(err, apikeysettings.ErrItemNotFound):
@@ -198,13 +210,47 @@ func (h *Handler) ResetAPIKeyDailySpending(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{
-		"status":                   "ok",
-		"id":                       result.ID,
-		"key":                      result.Key,
-		"daily-spending-limit":     result.DailySpendingLimit,
-		"daily-spending-used":      result.DailySpendingUsed,
-		"daily-spending-remaining": result.DailySpendingRemaining,
+		"status":                     "ok",
+		"id":                         result.ID,
+		"key":                        result.Key,
+		"daily-spending-limit":       result.DailySpendingLimit,
+		"daily-spending-used":        result.DailySpendingUsed,
+		"daily-spending-remaining":   result.DailySpendingRemaining,
+		"daily-spending-reset-count": result.DailySpendingResetCount,
 	})
+}
+
+// GetAPIKeyDailySpendingResetHistory lists manual reset events for a key.
+// GET /v0/management/api-key-entries/daily-spending/reset-history?id=... or ?key=...
+func (h *Handler) GetAPIKeyDailySpendingResetHistory(c *gin.Context) {
+	id := strings.TrimSpace(c.Query("id"))
+	key := strings.TrimSpace(c.Query("key"))
+	var idPtr, keyPtr *string
+	if id != "" {
+		idPtr = &id
+	}
+	if key != "" {
+		keyPtr = &key
+	}
+	limit := 100
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil {
+			limit = n
+		}
+	}
+	events, err := h.apiKeySettings(c).ListDailySpendingResetHistory(idPtr, keyPtr, limit)
+	if err != nil {
+		if errors.Is(err, apikeysettings.ErrItemNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if events == nil {
+		events = []usage.APIKeyDailySpendingResetEvent{}
+	}
+	c.JSON(http.StatusOK, gin.H{"items": events, "total": len(events)})
 }
 
 func (h *Handler) PutAPIKeyEntries(c *gin.Context) {

--- a/internal/api/handlers/management/usage_summary_public.go
+++ b/internal/api/handlers/management/usage_summary_public.go
@@ -13,9 +13,10 @@ import (
 )
 
 type usageSummaryResponse struct {
-	Found bool           `json:"found"`
-	Range string         `json:"range"`
-	Stats usageStatsBody `json:"stats"`
+	Found  bool             `json:"found"`
+	Range  string           `json:"range"`
+	Stats  usageStatsBody   `json:"stats"`
+	Limits *usageLimitsBody `json:"limits,omitempty"`
 }
 
 type usageStatsBody struct {
@@ -23,9 +24,22 @@ type usageStatsBody struct {
 	QuotaCost  float64 `json:"quota_cost"`
 }
 
+// usageLimitsBody exposes only limits that are configured (>0) plus live usage.
+type usageLimitsBody struct {
+	DailyLimit         *int     `json:"daily-limit,omitempty"`
+	DailyUsed          *int64   `json:"daily-used,omitempty"`
+	TotalQuota         *int     `json:"total-quota,omitempty"`
+	TotalUsed          *int64   `json:"total-used,omitempty"`
+	SpendingLimit      *float64 `json:"spending-limit,omitempty"`
+	SpendingUsed       *float64 `json:"spending-used,omitempty"`
+	DailySpendingLimit *float64 `json:"daily-spending-limit,omitempty"`
+	DailySpendingUsed  *float64 `json:"daily-spending-used,omitempty"`
+}
+
 // GetPublicUsageSummary returns today's call count and quota cost for an API key.
 // This is a lightweight endpoint designed for CC Switch Provider card polling.
 // `found` reflects API Key existence (not disabled), not whether it was used today.
+// When the key has daily/total/spending limits, `limits` includes only those fields.
 func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 	apiKey := ""
 	var req publicLookupRequest
@@ -79,6 +93,56 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 			TotalCalls: stats.Total,
 			QuotaCost:  stats.TotalCost,
 		},
+		Limits: buildPublicUsageLimits(apiKey, row),
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+func buildPublicUsageLimits(apiKey string, row *usage.APIKeyRow) *usageLimitsBody {
+	if row == nil || row.Disabled {
+		return nil
+	}
+	tenantID := strings.TrimSpace(row.TenantID)
+	if tenantID == "" {
+		tenantID = usage.ResolveAPIKeyTenant(apiKey)
+	}
+	effective := usage.EffectiveAPIKeyRowForTenant(tenantID, *row)
+	out := &usageLimitsBody{}
+	has := false
+	if effective.DailyLimit > 0 {
+		has = true
+		limit := effective.DailyLimit
+		out.DailyLimit = &limit
+		if n, err := usage.CountTodayByKey(apiKey); err == nil {
+			out.DailyUsed = &n
+		}
+	}
+	if effective.TotalQuota > 0 {
+		has = true
+		limit := effective.TotalQuota
+		out.TotalQuota = &limit
+		if n, err := usage.CountTotalByKey(apiKey); err == nil {
+			out.TotalUsed = &n
+		}
+	}
+	if effective.SpendingLimit > 0 {
+		has = true
+		limit := effective.SpendingLimit
+		out.SpendingLimit = &limit
+		if n, err := usage.QueryTotalCostByKey(apiKey); err == nil {
+			out.SpendingUsed = &n
+		}
+	}
+	if effective.DailySpendingLimit > 0 {
+		has = true
+		limit := effective.DailySpendingLimit
+		out.DailySpendingLimit = &limit
+		if n, err := usage.QueryTodayCostByKey(apiKey); err == nil {
+			out.DailySpendingUsed = &n
+		}
+	}
+	if !has {
+		return nil
+	}
+	return out
 }

--- a/internal/api/handlers/management/usage_summary_public_test.go
+++ b/internal/api/handlers/management/usage_summary_public_test.go
@@ -51,15 +51,18 @@ func TestGetPublicUsageSummary(t *testing.T) {
 		keyNoUsage  = "sk-test-key-no-usage"
 		keyDisabled = "sk-test-key-disabled"
 		keyUnknown  = "sk-test-key-unknown"
+		keyLimited  = "sk-test-key-limited"
 	)
 
 	insertTestLog(t, keyWithData)
 	insertTestLog(t, keyWithData)
+	insertTestLog(t, keyLimited)
 
 	if err := usage.ReplaceAllAPIKeys([]usage.APIKeyRow{
 		{Key: keyWithData, Disabled: false},
 		{Key: keyNoUsage, Disabled: false},
 		{Key: keyDisabled, Disabled: true},
+		{Key: keyLimited, Disabled: false, DailyLimit: 10, TotalQuota: 100, SpendingLimit: 50, DailySpendingLimit: 5},
 	}); err != nil {
 		t.Fatalf("ReplaceAllAPIKeys: %v", err)
 	}
@@ -233,6 +236,73 @@ func TestGetPublicUsageSummary(t *testing.T) {
 
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("status = %d, want 400 (query param api_key must be rejected); body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("includes limits only when configured", func(t *testing.T) {
+		body := []byte(`{"api_key":"` + keyLimited + `"}`)
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage/summary", bytes.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+
+		h := NewHandler(&config.Config{}, "", nil)
+		h.GetPublicUsageSummary(ctx)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+		}
+		var got struct {
+			Limits *struct {
+				DailyLimit         *int     `json:"daily-limit"`
+				DailyUsed          *int64   `json:"daily-used"`
+				TotalQuota         *int     `json:"total-quota"`
+				TotalUsed          *int64   `json:"total-used"`
+				SpendingLimit      *float64 `json:"spending-limit"`
+				SpendingUsed       *float64 `json:"spending-used"`
+				DailySpendingLimit *float64 `json:"daily-spending-limit"`
+				DailySpendingUsed  *float64 `json:"daily-spending-used"`
+			} `json:"limits"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Limits == nil {
+			t.Fatal("limits = nil, want configured limits")
+		}
+		if got.Limits.DailyLimit == nil || *got.Limits.DailyLimit != 10 {
+			t.Fatalf("daily-limit = %v, want 10", got.Limits.DailyLimit)
+		}
+		if got.Limits.DailyUsed == nil || *got.Limits.DailyUsed != 1 {
+			t.Fatalf("daily-used = %v, want 1", got.Limits.DailyUsed)
+		}
+		if got.Limits.TotalQuota == nil || *got.Limits.TotalQuota != 100 {
+			t.Fatalf("total-quota = %v, want 100", got.Limits.TotalQuota)
+		}
+		if got.Limits.SpendingLimit == nil || *got.Limits.SpendingLimit != 50 {
+			t.Fatalf("spending-limit = %v, want 50", got.Limits.SpendingLimit)
+		}
+		if got.Limits.DailySpendingLimit == nil || *got.Limits.DailySpendingLimit != 5 {
+			t.Fatalf("daily-spending-limit = %v, want 5", got.Limits.DailySpendingLimit)
+		}
+
+		// unlimited key omits limits
+		body = []byte(`{"api_key":"` + keyWithData + `"}`)
+		rec = httptest.NewRecorder()
+		ctx, _ = gin.CreateTestContext(rec)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage/summary", bytes.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+		h.GetPublicUsageSummary(ctx)
+		var unlimited struct {
+			Limits *struct {
+				DailyLimit *int `json:"daily-limit"`
+			} `json:"limits"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &unlimited); err != nil {
+			t.Fatalf("unmarshal unlimited: %v", err)
+		}
+		if unlimited.Limits != nil {
+			t.Fatalf("limits = %+v, want nil for unlimited key", unlimited.Limits)
 		}
 	})
 }

--- a/internal/api/routes/management_keys_routes.go
+++ b/internal/api/routes/management_keys_routes.go
@@ -20,6 +20,7 @@ func registerManagementAPIKeyRoutes(group *gin.RouterGroup, h *managementhandler
 	group.PATCH("/api-key-entries", h.PatchAPIKeyEntry)
 	group.DELETE("/api-key-entries", h.DeleteAPIKeyEntry)
 	group.POST("/api-key-entries/daily-spending/reset", h.ResetAPIKeyDailySpending)
+	group.GET("/api-key-entries/daily-spending/reset-history", h.GetAPIKeyDailySpendingResetHistory)
 
 	group.GET("/gemini-api-key", keys.GetGeminiKeys)
 	group.PUT("/gemini-api-key", keys.PutGeminiKeys)

--- a/internal/api/routes/management_postgres_regression_test.go
+++ b/internal/api/routes/management_postgres_regression_test.go
@@ -299,11 +299,12 @@ func postgresSmokeBody(method, routePath string) string {
 
 func postgresSmokeAllowsStatus(routePath string, status int, body string) bool {
 	if status == http.StatusNotFound {
-		// The generic smoke sends an empty JSON object. This body-targeted route
-		// therefore has no key to resolve; dedicated handler tests cover its success path.
-		bodyTargetedLookup := routePath == "/v0/management/api-key-entries/daily-spending/reset"
+		// The generic smoke sends an empty JSON object / no query target. These
+		// routes therefore have no key to resolve; dedicated handler tests cover success.
+		targetedLookup := routePath == "/v0/management/api-key-entries/daily-spending/reset" ||
+			routePath == "/v0/management/api-key-entries/daily-spending/reset-history"
 		return strings.Contains(body, "not found") &&
-			(strings.Contains(routePath, ":") || strings.Contains(routePath, "*") || bodyTargetedLookup)
+			(strings.Contains(routePath, ":") || strings.Contains(routePath, "*") || targetedLookup)
 	}
 	if status == http.StatusBadGateway {
 		return routePath == "/v0/management/update/progress" && strings.Contains(body, "update_progress_failed") ||

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 266; got != want {
+	if got, want := len(routes), 267; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -239,6 +239,7 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/antigravity-auth-url",
 		"GET /v0/management/anthropic-auth-url",
 		"GET /v0/management/api-key-entries",
+		"GET /v0/management/api-key-entries/daily-spending/reset-history",
 		"GET /v0/management/api-key-permission-profiles",
 		"GET /v0/management/api-keys",
 		"GET /v0/management/auth-files",

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -137,6 +137,10 @@ type APIKeyEntry struct {
 	// Management list only; not persisted.
 	DailySpendingRemaining *float64 `yaml:"-" json:"daily-spending-remaining"`
 
+	// DailySpendingResetCount is how many times this key's daily spending was manually reset.
+	// Management list only; not persisted.
+	DailySpendingResetCount int `yaml:"-" json:"daily-spending-reset-count,omitempty"`
+
 	// ConcurrencyLimit is the maximum number of concurrent requests. 0 means unlimited.
 	ConcurrencyLimit int `yaml:"concurrency-limit,omitempty" json:"concurrency-limit,omitempty"`
 

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -285,6 +285,10 @@ func (s *Service) attachDailySpendingRuntime(entries []config.APIKeyEntry, rows 
 	if err != nil {
 		return err
 	}
+	counts, err := usage.ListDailySpendingResetEventCounts(s.tenantID, ids)
+	if err != nil {
+		return err
+	}
 	for i := range entries {
 		id := strings.TrimSpace(rows[i].ID)
 		key := strings.TrimSpace(rows[i].Key)
@@ -308,47 +312,83 @@ func (s *Service) attachDailySpendingRuntime(entries []config.APIKeyEntry, rows 
 		}
 		entries[i].DailySpendingUsed = used
 		entries[i].DailySpendingRemaining = usage.DailySpendingRemaining(entries[i].DailySpendingLimit, used)
+		if id != "" {
+			entries[i].DailySpendingResetCount = counts[id]
+		}
 	}
 	return nil
 }
 
+type DailySpendingResetActor struct {
+	UserID   string
+	Username string
+	Kind     string
+}
+
 type DailySpendingResetResult struct {
-	ID                     string   `json:"id"`
-	Key                    string   `json:"key,omitempty"`
-	DailySpendingLimit     float64  `json:"daily-spending-limit"`
-	DailySpendingUsed      float64  `json:"daily-spending-used"`
-	DailySpendingRemaining *float64 `json:"daily-spending-remaining"`
+	ID                      string   `json:"id"`
+	Key                     string   `json:"key,omitempty"`
+	DailySpendingLimit      float64  `json:"daily-spending-limit"`
+	DailySpendingUsed       float64  `json:"daily-spending-used"`
+	DailySpendingRemaining  *float64 `json:"daily-spending-remaining"`
+	DailySpendingResetCount int      `json:"daily-spending-reset-count"`
 }
 
 // ResetDailySpending sets today's cost baseline to the current raw today cost so effective used becomes 0.
-func (s *Service) ResetDailySpending(id *string, match *string) (DailySpendingResetResult, error) {
+func (s *Service) ResetDailySpending(id *string, match *string, actor DailySpendingResetActor) (DailySpendingResetResult, error) {
 	row := s.resolvePatchTargetRow(id, nil, match)
 	if row == nil {
 		return DailySpendingResetResult{}, ErrItemNotFound
 	}
-	// Use stored row (not profile-effective) for the key-owned daily spending limit.
-	stored := usage.GetAPIKeyByIDForTenant(s.tenantID, row.ID)
-	if stored == nil {
-		stored = row
-	}
-	if stored.DailySpendingLimit <= 0 {
+	// Effective row includes permission-profile daily spending limit.
+	effective := usage.EffectiveAPIKeyRowForTenant(s.tenantID, *row)
+	if effective.DailySpendingLimit <= 0 {
 		return DailySpendingResetResult{}, ErrDailySpendingLimitMissing
 	}
-	raw, err := usage.QueryRawTodayCostByKeyForTenant(s.tenantID, stored.Key)
+	raw, err := usage.QueryRawTodayCostByKeyForTenant(s.tenantID, effective.Key)
 	if err != nil {
 		return DailySpendingResetResult{}, err
 	}
-	if err := usage.UpsertDailySpendingReset(s.tenantID, stored.ID, raw); err != nil {
+	baselineBefore, _, err := usage.GetDailySpendingResetBaseline(s.tenantID, effective.ID)
+	if err != nil {
 		return DailySpendingResetResult{}, err
 	}
+	usedBefore := raw - baselineBefore
+	if usedBefore < 0 {
+		usedBefore = 0
+	}
+	if err := usage.UpsertDailySpendingReset(s.tenantID, effective.ID, raw); err != nil {
+		return DailySpendingResetResult{}, err
+	}
+	_ = usage.InsertDailySpendingResetEvent(usage.APIKeyDailySpendingResetEvent{
+		TenantID:            s.tenantID,
+		APIKeyID:            effective.ID,
+		CostBaseline:        raw,
+		EffectiveUsedBefore: usedBefore,
+		RawTodayCost:        raw,
+		ActorUserID:         actor.UserID,
+		ActorUsername:       actor.Username,
+		ActorKind:           actor.Kind,
+	})
+	count, _ := usage.CountDailySpendingResetEvents(s.tenantID, effective.ID)
 	used := 0.0
 	return DailySpendingResetResult{
-		ID:                     stored.ID,
-		Key:                    stored.Key,
-		DailySpendingLimit:     stored.DailySpendingLimit,
-		DailySpendingUsed:      used,
-		DailySpendingRemaining: usage.DailySpendingRemaining(stored.DailySpendingLimit, used),
+		ID:                      effective.ID,
+		Key:                     effective.Key,
+		DailySpendingLimit:      effective.DailySpendingLimit,
+		DailySpendingUsed:       used,
+		DailySpendingRemaining:  usage.DailySpendingRemaining(effective.DailySpendingLimit, used),
+		DailySpendingResetCount: count,
 	}, nil
+}
+
+// ListDailySpendingResetHistory returns newest-first reset events for a key.
+func (s *Service) ListDailySpendingResetHistory(id *string, match *string, limit int) ([]usage.APIKeyDailySpendingResetEvent, error) {
+	row := s.resolvePatchTargetRow(id, nil, match)
+	if row == nil {
+		return nil, ErrItemNotFound
+	}
+	return usage.ListDailySpendingResetEvents(s.tenantID, row.ID, limit)
 }
 
 func (s *Service) ReplaceEntries(entries []config.APIKeyEntry) error {
@@ -445,6 +485,7 @@ func (s *Service) DeleteEntry(key string, id *string, index *int, deleteLogs boo
 		return DeleteEntryResult{}, err
 	}
 	_ = usage.DeleteDailySpendingReset(s.tenantID, apiKeyID)
+	_ = usage.DeleteDailySpendingResetEvents(s.tenantID, apiKeyID)
 
 	result := DeleteEntryResult{}
 	if deleteLogs && s != nil && s.deleteLogs != nil {

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -394,7 +394,8 @@ func TestResetDailySpendingAndRejectsUnlimited(t *testing.T) {
 	}
 
 	id := "key-1"
-	result, err := svc.ResetDailySpending(&id, nil)
+	actor := DailySpendingResetActor{UserID: "u1", Username: "alice", Kind: "user"}
+	result, err := svc.ResetDailySpending(&id, nil, actor)
 	if err != nil {
 		t.Fatalf("ResetDailySpending: %v", err)
 	}
@@ -403,6 +404,9 @@ func TestResetDailySpendingAndRejectsUnlimited(t *testing.T) {
 	}
 	if result.DailySpendingRemaining == nil || *result.DailySpendingRemaining != 100 {
 		t.Fatalf("remaining after reset = %v", result.DailySpendingRemaining)
+	}
+	if result.DailySpendingResetCount != 1 {
+		t.Fatalf("reset count = %d, want 1", result.DailySpendingResetCount)
 	}
 
 	// request logs must remain
@@ -422,12 +426,26 @@ func TestResetDailySpendingAndRejectsUnlimited(t *testing.T) {
 		t.Fatalf("middleware-facing cost = %v, want 0", got)
 	}
 
+	events, err := svc.ListDailySpendingResetHistory(&id, nil, 10)
+	if err != nil {
+		t.Fatalf("ListDailySpendingResetHistory: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].ActorUsername != "alice" || events[0].EffectiveUsedBefore != 20 {
+		t.Fatalf("event = %+v", events[0])
+	}
+	if events[0].RawTodayCost != 20 {
+		t.Fatalf("raw_today_cost = %v, want 20", events[0].RawTodayCost)
+	}
+
 	// unlimited rejects reset
 	zero := 0.0
 	if err := svc.PatchEntry(&id, nil, nil, EntryPatch{DailySpendingLimit: &zero}); err != nil {
 		t.Fatalf("clear limit: %v", err)
 	}
-	if _, err := svc.ResetDailySpending(&id, nil); !errors.Is(err, ErrDailySpendingLimitMissing) {
+	if _, err := svc.ResetDailySpending(&id, nil, actor); !errors.Is(err, ErrDailySpendingLimitMissing) {
 		t.Fatalf("err = %v, want ErrDailySpendingLimitMissing", err)
 	}
 }

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -21,6 +21,8 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607160003_api_key_daily_spending_resets", SQL: apiKeyDailySpendingResetsSQL},
 		// Daily USD spending limit belongs on reusable permission profiles.
 		{Version: "202607170001_profile_daily_spending_limit", SQL: profileDailySpendingLimitSQL},
+		// Append-only history of manual daily spending resets (who/when/amount).
+		{Version: "202607170002_api_key_daily_spending_reset_events", SQL: apiKeyDailySpendingResetEventsSQL},
 	}
 }
 
@@ -41,6 +43,25 @@ CREATE TABLE IF NOT EXISTS api_key_daily_spending_resets (
 );
 CREATE INDEX IF NOT EXISTS idx_api_key_daily_spending_resets_day
   ON api_key_daily_spending_resets(tenant_id, day_key);
+`
+
+// BIGSERIAL for PG; SQLite bootstrap uses INTEGER PRIMARY KEY AUTOINCREMENT.
+const apiKeyDailySpendingResetEventsSQL = `
+CREATE TABLE IF NOT EXISTS api_key_daily_spending_reset_events (
+  id                     BIGSERIAL PRIMARY KEY,
+  tenant_id              UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+  api_key_id             TEXT NOT NULL,
+  day_key                TEXT NOT NULL DEFAULT '',
+  reset_at               TIMESTAMPTZ NOT NULL,
+  actor_user_id          TEXT NOT NULL DEFAULT '',
+  actor_username         TEXT NOT NULL DEFAULT '',
+  actor_kind             TEXT NOT NULL DEFAULT '',
+  cost_baseline          DOUBLE PRECISION NOT NULL DEFAULT 0,
+  effective_used_before  DOUBLE PRECISION NOT NULL DEFAULT 0,
+  raw_today_cost         DOUBLE PRECISION NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_api_key_daily_spending_reset_events_key
+  ON api_key_daily_spending_reset_events(tenant_id, api_key_id, reset_at DESC);
 `
 
 const requestLogsAuthLookupIndexesSQL = `

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -7,10 +7,22 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 14 {
-		t.Fatalf("RuntimeMigrations len = %d, want 14", len(migrations))
+	if len(migrations) != 15 {
+		t.Fatalf("RuntimeMigrations len = %d, want 15", len(migrations))
 	}
-	// Latest migration: daily spending limit on permission profiles.
+	// Latest: append-only daily spending reset history.
+	resetEventsSQL := migrations[14].SQL
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS api_key_daily_spending_reset_events",
+		"effective_used_before",
+		"raw_today_cost",
+		"actor_username",
+	} {
+		if !strings.Contains(resetEventsSQL, fragment) {
+			t.Fatalf("daily spending reset events migration missing %q", fragment)
+		}
+	}
+	// Prior: daily spending limit on permission profiles.
 	profileSpendSQL := migrations[13].SQL
 	if !strings.Contains(profileSpendSQL, "daily_spending_limit") {
 		t.Fatalf("profile daily spending migration missing daily_spending_limit")

--- a/internal/usage/api_key_daily_spending_reset_history.go
+++ b/internal/usage/api_key_daily_spending_reset_history.go
@@ -1,0 +1,254 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// APIKeyDailySpendingResetEvent is one manual daily-spending reset action.
+type APIKeyDailySpendingResetEvent struct {
+	ID            int64     `json:"id"`
+	TenantID      string    `json:"tenant_id"`
+	APIKeyID      string    `json:"api_key_id"`
+	DayKey        string    `json:"day_key"`
+	ResetAt       time.Time `json:"reset_at"`
+	ActorUserID   string    `json:"actor_user_id,omitempty"`
+	ActorUsername string    `json:"actor_username,omitempty"`
+	ActorKind     string    `json:"actor_kind,omitempty"`
+	// CostBaseline is raw today cost at reset time (SUM request_logs.cost for the day).
+	CostBaseline float64 `json:"cost_baseline"`
+	// EffectiveUsedBefore is the effective daily used amount cleared by this reset.
+	EffectiveUsedBefore float64 `json:"effective_used_before"`
+	// RawTodayCost is the true project-day spend (no baseline) at reset time.
+	RawTodayCost float64 `json:"raw_today_cost"`
+}
+
+// TIMESTAMP for SQLite affinity + PG bootstrap compatibility (same as baseline table).
+const apiKeyDailySpendingResetEventsTableSQL = `
+CREATE TABLE IF NOT EXISTS api_key_daily_spending_reset_events (
+  id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+  tenant_id              TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+  api_key_id             TEXT NOT NULL,
+  day_key                TEXT NOT NULL DEFAULT '',
+  reset_at               TIMESTAMP NOT NULL,
+  actor_user_id          TEXT NOT NULL DEFAULT '',
+  actor_username         TEXT NOT NULL DEFAULT '',
+  actor_kind             TEXT NOT NULL DEFAULT '',
+  cost_baseline          REAL NOT NULL DEFAULT 0,
+  effective_used_before  REAL NOT NULL DEFAULT 0,
+  raw_today_cost         REAL NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_api_key_daily_spending_reset_events_key
+  ON api_key_daily_spending_reset_events(tenant_id, api_key_id, reset_at DESC);
+`
+
+func ensureAPIKeyDailySpendingResetEventsTable(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	if _, err := db.Exec(apiKeyDailySpendingResetEventsTableSQL); err != nil {
+		return fmt.Errorf("usage: ensure api_key_daily_spending_reset_events: %w", err)
+	}
+	return nil
+}
+
+func bootstrapAPIKeyDailySpendingResetEvents(db *sql.DB) error {
+	return ensureAPIKeyDailySpendingResetEventsTable(db)
+}
+
+// InsertDailySpendingResetEvent appends one reset history row.
+func InsertDailySpendingResetEvent(ev APIKeyDailySpendingResetEvent) error {
+	db := getDB()
+	if db == nil {
+		return fmt.Errorf("usage: database not initialised")
+	}
+	tenantID := normalizeTenantID(ev.TenantID)
+	apiKeyID := strings.TrimSpace(ev.APIKeyID)
+	if apiKeyID == "" {
+		return fmt.Errorf("usage: api_key_id is required")
+	}
+	resetAt := ev.ResetAt
+	if resetAt.IsZero() {
+		resetAt = time.Now().UTC()
+	}
+	dayKey := strings.TrimSpace(ev.DayKey)
+	if dayKey == "" {
+		dayKey = LocalDayKeyAt(resetAt)
+	}
+	baseline := ev.CostBaseline
+	if baseline < 0 {
+		baseline = 0
+	}
+	usedBefore := ev.EffectiveUsedBefore
+	if usedBefore < 0 {
+		usedBefore = 0
+	}
+	raw := ev.RawTodayCost
+	if raw < 0 {
+		raw = 0
+	}
+	_, err := db.Exec(
+		`INSERT INTO api_key_daily_spending_reset_events
+		 (tenant_id, api_key_id, day_key, reset_at, actor_user_id, actor_username, actor_kind,
+		  cost_baseline, effective_used_before, raw_today_cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		tenantID, apiKeyID, dayKey, resetAt.UTC().Format(time.RFC3339Nano),
+		strings.TrimSpace(ev.ActorUserID), strings.TrimSpace(ev.ActorUsername), strings.TrimSpace(ev.ActorKind),
+		baseline, usedBefore, raw,
+	)
+	if err != nil {
+		return fmt.Errorf("usage: insert daily spending reset event: %w", err)
+	}
+	return nil
+}
+
+// CountDailySpendingResetEvents returns how many reset events exist for a key.
+func CountDailySpendingResetEvents(tenantID, apiKeyID string) (int, error) {
+	db := getDB()
+	if db == nil {
+		return 0, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	apiKeyID = strings.TrimSpace(apiKeyID)
+	if apiKeyID == "" {
+		return 0, nil
+	}
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM api_key_daily_spending_reset_events WHERE tenant_id = ? AND api_key_id = ?`,
+		tenantID, apiKeyID,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("usage: count daily spending reset events: %w", err)
+	}
+	return n, nil
+}
+
+// ListDailySpendingResetEventCounts returns reset counts keyed by api_key_id.
+func ListDailySpendingResetEventCounts(tenantID string, apiKeyIDs []string) (map[string]int, error) {
+	out := make(map[string]int)
+	if len(apiKeyIDs) == 0 {
+		return out, nil
+	}
+	db := getDB()
+	if db == nil {
+		return out, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	ids := make([]string, 0, len(apiKeyIDs))
+	seen := make(map[string]struct{}, len(apiKeyIDs))
+	for _, id := range apiKeyIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]interface{}, 0, len(ids)+1)
+	args = append(args, tenantID)
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	rows, err := db.Query(
+		`SELECT api_key_id, COUNT(*) FROM api_key_daily_spending_reset_events
+		 WHERE tenant_id = ? AND api_key_id IN (`+strings.Join(placeholders, ",")+`)
+		 GROUP BY api_key_id`,
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("usage: list daily spending reset event counts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var n int
+		if err := rows.Scan(&id, &n); err != nil {
+			return nil, fmt.Errorf("usage: scan reset event count: %w", err)
+		}
+		out[strings.TrimSpace(id)] = n
+	}
+	return out, rows.Err()
+}
+
+// ListDailySpendingResetEvents returns newest-first history for a key.
+func ListDailySpendingResetEvents(tenantID, apiKeyID string, limit int) ([]APIKeyDailySpendingResetEvent, error) {
+	db := getDB()
+	if db == nil {
+		return nil, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	apiKeyID = strings.TrimSpace(apiKeyID)
+	if apiKeyID == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	rows, err := db.Query(
+		`SELECT id, tenant_id, api_key_id, day_key, reset_at, actor_user_id, actor_username, actor_kind,
+		        cost_baseline, effective_used_before, raw_today_cost
+		 FROM api_key_daily_spending_reset_events
+		 WHERE tenant_id = ? AND api_key_id = ?
+		 ORDER BY reset_at DESC, id DESC
+		 LIMIT ?`,
+		tenantID, apiKeyID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("usage: list daily spending reset events: %w", err)
+	}
+	defer rows.Close()
+	out := make([]APIKeyDailySpendingResetEvent, 0)
+	for rows.Next() {
+		var ev APIKeyDailySpendingResetEvent
+		var resetAt string
+		if err := rows.Scan(
+			&ev.ID, &ev.TenantID, &ev.APIKeyID, &ev.DayKey, &resetAt,
+			&ev.ActorUserID, &ev.ActorUsername, &ev.ActorKind,
+			&ev.CostBaseline, &ev.EffectiveUsedBefore, &ev.RawTodayCost,
+		); err != nil {
+			return nil, fmt.Errorf("usage: scan daily spending reset event: %w", err)
+		}
+		if ts, err := time.Parse(time.RFC3339Nano, resetAt); err == nil {
+			ev.ResetAt = ts
+		} else if ts, err := time.Parse(time.RFC3339, resetAt); err == nil {
+			ev.ResetAt = ts
+		}
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+// DeleteDailySpendingResetEvents removes history for a key (e.g. on key delete).
+func DeleteDailySpendingResetEvents(tenantID, apiKeyID string) error {
+	db := getDB()
+	if db == nil {
+		return nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	apiKeyID = strings.TrimSpace(apiKeyID)
+	if apiKeyID == "" {
+		return nil
+	}
+	_, err := db.Exec(
+		`DELETE FROM api_key_daily_spending_reset_events WHERE tenant_id = ? AND api_key_id = ?`,
+		tenantID, apiKeyID,
+	)
+	if err != nil {
+		return fmt.Errorf("usage: delete daily spending reset events: %w", err)
+	}
+	return nil
+}

--- a/internal/usage/api_key_daily_spending_reset_test.go
+++ b/internal/usage/api_key_daily_spending_reset_test.go
@@ -269,3 +269,66 @@ func TestEnsureAPIKeyDailySpendingResetsTableSQLHasNoDATETIME(t *testing.T) {
 		t.Fatalf("ensure table: %v", err)
 	}
 }
+
+func TestDailySpendingResetEventHistory(t *testing.T) {
+	setupDailySpendingResetDB(t)
+	if err := UpsertAPIKey(APIKeyRow{ID: "key-1", Key: "sk-hist", DailySpendingLimit: 50}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+	if err := InsertDailySpendingResetEvent(APIKeyDailySpendingResetEvent{
+		TenantID:            systemTenantID,
+		APIKeyID:            "key-1",
+		CostBaseline:        12,
+		EffectiveUsedBefore: 5,
+		RawTodayCost:        12,
+		ActorUsername:       "bob",
+		ActorKind:           "user",
+	}); err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	if err := InsertDailySpendingResetEvent(APIKeyDailySpendingResetEvent{
+		TenantID:            systemTenantID,
+		APIKeyID:            "key-1",
+		CostBaseline:        18,
+		EffectiveUsedBefore: 6,
+		RawTodayCost:        18,
+		ActorUsername:       "carol",
+		ActorKind:           "user",
+	}); err != nil {
+		t.Fatalf("insert event 2: %v", err)
+	}
+	n, err := CountDailySpendingResetEvents(systemTenantID, "key-1")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("count = %d, want 2", n)
+	}
+	counts, err := ListDailySpendingResetEventCounts(systemTenantID, []string{"key-1", "missing"})
+	if err != nil {
+		t.Fatalf("counts: %v", err)
+	}
+	if counts["key-1"] != 2 {
+		t.Fatalf("counts[key-1] = %d, want 2", counts["key-1"])
+	}
+	events, err := ListDailySpendingResetEvents(systemTenantID, "key-1", 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len events = %d, want 2", len(events))
+	}
+	if events[0].ActorUsername != "carol" {
+		t.Fatalf("newest actor = %q, want carol", events[0].ActorUsername)
+	}
+	if err := DeleteDailySpendingResetEvents(systemTenantID, "key-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	n, err = CountDailySpendingResetEvents(systemTenantID, "key-1")
+	if err != nil {
+		t.Fatalf("count after delete: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("count after delete = %d, want 0", n)
+	}
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -732,6 +732,11 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 		usageDB, usageReadDB = nil, nil
 		return err
 	}
+	if err := bootstrapAPIKeyDailySpendingResetEvents(db); err != nil {
+		_ = db.Close()
+		usageDB, usageReadDB = nil, nil
+		return err
+	}
 	log.Debugf("usage: initializing pricing table")
 	initPricingTable(db)
 	log.Debugf("usage: initializing model config tables")


### PR DESCRIPTION
## Summary
- Append-only `api_key_daily_spending_reset_events` with operator, cleared amount, raw day cost
- Management list field `daily-spending-reset-count` + `GET .../daily-spending/reset-history`
- Public `usage/summary` returns configured limits + live usage only when set

## Test plan
- [x] `go test ./internal/usage/ ./internal/management/settings/apikey/ ./internal/api/routes/ -count=1`
- [x] `go test ./internal/api/handlers/management/ -count=1 -run 'GetPublicUsageSummary|ResetAPIKeyDaily|GetAPIKeyEntriesIncludes'`