### PR TITLE
fix: whole-dollar spending limits

### DIFF
--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -125,8 +125,9 @@ func TestPatchEntryUpdatesDailySpendingLimit(t *testing.T) {
 	if got == nil {
 		t.Fatal("expected patched key")
 	}
-	if got.DailySpendingLimit != limit {
-		t.Fatalf("DailySpendingLimit = %v, want %v", got.DailySpendingLimit, limit)
+	// Fractional USD is ceiled to a whole dollar on save.
+	if got.DailySpendingLimit != 5 {
+		t.Fatalf("DailySpendingLimit = %v, want 5 (ceil whole USD)", got.DailySpendingLimit)
 	}
 }
 
@@ -456,7 +457,7 @@ func TestEffectiveRowAppliesProfileDailySpendingLimit(t *testing.T) {
 		ID:                 "p1",
 		Name:               "P1",
 		DailyLimit:         5,
-		DailySpendingLimit: 12.5,
+		DailySpendingLimit: 12.5, // ceiled to whole USD on save
 	}}); err != nil {
 		t.Fatalf("profiles: %v", err)
 	}
@@ -473,8 +474,8 @@ func TestEffectiveRowAppliesProfileDailySpendingLimit(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("len = %d", len(entries))
 	}
-	if entries[0].DailySpendingLimit != 12.5 {
-		t.Fatalf("DailySpendingLimit = %v, want 12.5 from profile", entries[0].DailySpendingLimit)
+	if entries[0].DailySpendingLimit != 13 {
+		t.Fatalf("DailySpendingLimit = %v, want 13 from profile (ceil whole USD)", entries[0].DailySpendingLimit)
 	}
 	if entries[0].DailyLimit != 5 {
 		t.Fatalf("DailyLimit from profile = %v, want 5", entries[0].DailyLimit)

--- a/internal/storage/sqlite/apikey/permission_profiles.go
+++ b/internal/storage/sqlite/apikey/permission_profiles.go
@@ -160,9 +160,7 @@ func normalizePermissionProfile(profile PermissionProfileRow) PermissionProfileR
 	profile.Name = strings.TrimSpace(profile.Name)
 	profile.DailyLimit = normalizeNonNegativeInt(profile.DailyLimit)
 	profile.TotalQuota = normalizeNonNegativeInt(profile.TotalQuota)
-	if profile.DailySpendingLimit < 0 || math.IsNaN(profile.DailySpendingLimit) || math.IsInf(profile.DailySpendingLimit, 0) {
-		profile.DailySpendingLimit = 0
-	}
+	profile.DailySpendingLimit = normalizeWholeUSD(profile.DailySpendingLimit)
 	profile.ConcurrencyLimit = normalizeNonNegativeInt(profile.ConcurrencyLimit)
 	profile.RPMLimit = normalizeNonNegativeInt(profile.RPMLimit)
 	profile.TPMLimit = normalizeNonNegativeInt(profile.TPMLimit)
@@ -199,6 +197,14 @@ func normalizeNonNegativeInt(value int) int {
 		return 0
 	}
 	return value
+}
+
+// normalizeWholeUSD keeps spending limits as whole dollars (ceil partial input).
+func normalizeWholeUSD(value float64) float64 {
+	if value <= 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0
+	}
+	return math.Ceil(value)
 }
 
 func normalizeStringSlice(values []string) []string {

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -649,6 +649,8 @@ func normalizeRow(row APIKeyRow) APIKeyRow {
 	row.Key = strings.TrimSpace(row.Key)
 	row.Name = strings.TrimSpace(row.Name)
 	row.PermissionProfileID = strings.TrimSpace(row.PermissionProfileID)
+	row.SpendingLimit = normalizeWholeUSD(row.SpendingLimit)
+	row.DailySpendingLimit = normalizeWholeUSD(row.DailySpendingLimit)
 	return row
 }
 

--- a/internal/usage/api_key_permission_profiles_db.go
+++ b/internal/usage/api_key_permission_profiles_db.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"database/sql"
 	"encoding/json"
+	"math"
 	"os"
 	"strings"
 
@@ -109,8 +110,11 @@ func normalizeAPIKeyPermissionProfile(profile APIKeyPermissionProfileRow) APIKey
 	profile.Name = strings.TrimSpace(profile.Name)
 	profile.DailyLimit = normalizeNonNegativeInt(profile.DailyLimit)
 	profile.TotalQuota = normalizeNonNegativeInt(profile.TotalQuota)
-	if profile.DailySpendingLimit < 0 {
+	// Spending limits are whole USD dollars; ceil partial input.
+	if profile.DailySpendingLimit <= 0 || math.IsNaN(profile.DailySpendingLimit) || math.IsInf(profile.DailySpendingLimit, 0) {
 		profile.DailySpendingLimit = 0
+	} else {
+		profile.DailySpendingLimit = math.Ceil(profile.DailySpendingLimit)
 	}
 	profile.ConcurrencyLimit = normalizeNonNegativeInt(profile.ConcurrencyLimit)
 	profile.RPMLimit = normalizeNonNegativeInt(profile.RPMLimit)

--- a/internal/usage/apikey_db_test.go
+++ b/internal/usage/apikey_db_test.go
@@ -58,7 +58,7 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 		Name:                "Test Key",
 		PermissionProfileID: "standard",
 		DailyLimit:          100,
-		DailySpendingLimit:  12.5,
+		DailySpendingLimit:  12.5, // fractional input is ceiled to whole USD
 		SystemPrompt:        "You are a helpful assistant.\n### Special chars: # * ** ☢️",
 	}
 
@@ -76,8 +76,8 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 	if got.DailyLimit != 100 {
 		t.Errorf("daily_limit = %d, want 100", got.DailyLimit)
 	}
-	if got.DailySpendingLimit != 12.5 {
-		t.Errorf("daily_spending_limit = %v, want 12.5", got.DailySpendingLimit)
+	if got.DailySpendingLimit != 13 {
+		t.Errorf("daily_spending_limit = %v, want 13 (ceil whole USD)", got.DailySpendingLimit)
 	}
 	if got.PermissionProfileID != "standard" {
 		t.Errorf("permission_profile_id = %q, want %q", got.PermissionProfileID, "standard")
@@ -105,8 +105,8 @@ func TestAPIKeyUpsertAndGet(t *testing.T) {
 	if got.DailyLimit != 200 {
 		t.Errorf("daily_limit after update = %d, want 200", got.DailyLimit)
 	}
-	if got.DailySpendingLimit != 7.25 {
-		t.Errorf("daily_spending_limit after update = %v, want 7.25", got.DailySpendingLimit)
+	if got.DailySpendingLimit != 8 {
+		t.Errorf("daily_spending_limit after update = %v, want 8 (ceil whole USD)", got.DailySpendingLimit)
 	}
 	if got.PermissionProfileID != "strict" {
 		t.Errorf("permission_profile_id after update = %q, want %q", got.PermissionProfileID, "strict")


### PR DESCRIPTION
## Summary
- Normalize `spending-limit` / `daily-spending-limit` to whole USD (ceil) on save
- Profiles and API keys share the same rule

## Test plan
- [x] `go test` for usage / apikey service / handlers