### PR TITLE
fix: enforce logs-max-total-size-mb on spool tmp files

### DIFF
--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -167,6 +167,11 @@ func (w *ResponseWriterWrapper) WriteHeader(statusCode int) {
 	contentType := w.ResponseWriter.Header().Get("Content-Type")
 	w.isStreaming = w.detectStreaming(contentType)
 
+	// WriteHeader can run more than once (status rewrite / error path). Always
+	// tear down any existing stream spool first so request-body-*.tmp files are
+	// never orphaned when the final response is non-streaming.
+	w.closeStreamingLogWriter()
+
 	// If streaming, initialize streaming log writer
 	if w.isStreaming && w.logger.IsEnabled() {
 		requestBody := w.extractRequestBody(w.ginCtx)
@@ -302,41 +307,72 @@ func (w *ResponseWriterWrapper) Finalize(c *gin.Context) error {
 	hasAPIError := len(slicesAPIResponseError) > 0 || finalStatusCode >= http.StatusBadRequest
 	diagnostics.RecordResponse(c, finalStatusCode, w.body.Bytes())
 	forceLog := w.logOnErrorOnly && hasAPIError && !w.logger.IsEnabled()
+	// Stream writers create request-body-*.tmp / response-body-*.tmp as soon as
+	// WriteHeader runs. Always close them even when request-log is later disabled
+	// mid-request, otherwise the logs dir fills with orphaned spool files that
+	// historically bypassed logs-max-total-size-mb.
+	if w.streamWriter != nil {
+		return w.finalizeStreamingLog(c, forceLog)
+	}
 	if !w.logger.IsEnabled() && !forceLog {
 		return nil
 	}
 
-	if w.isStreaming && w.streamWriter != nil {
-		if w.chunkChannel != nil {
-			close(w.chunkChannel)
-			w.chunkChannel = nil
-		}
+	return w.logRequest(w.extractRequestBody(c), finalStatusCode, w.cloneHeaders(), w.body.Bytes(), w.extractAPIRequest(c), w.extractAPIResponse(c), w.extractAPIResponseTimestamp(c), slicesAPIResponseError, forceLog)
+}
 
-		if w.streamDone != nil {
-			<-w.streamDone
-			w.streamDone = nil
-		}
-
-		w.streamWriter.SetFirstChunkTimestamp(w.firstChunkTimestamp)
-
-		// Write API Request and Response to the streaming log before closing
-		apiRequest := w.extractAPIRequest(c)
-		if len(apiRequest) > 0 {
-			_ = w.streamWriter.WriteAPIRequest(apiRequest)
-		}
-		apiResponse := w.extractAPIResponse(c)
-		if len(apiResponse) > 0 {
-			_ = w.streamWriter.WriteAPIResponse(apiResponse)
-		}
-		if err := w.streamWriter.Close(); err != nil {
-			w.streamWriter = nil
-			return err
-		}
-		w.streamWriter = nil
+func (w *ResponseWriterWrapper) finalizeStreamingLog(c *gin.Context, forceLog bool) error {
+	writer := w.streamWriter
+	if writer == nil {
+		w.closeStreamingLogWriter()
 		return nil
 	}
 
-	return w.logRequest(w.extractRequestBody(c), finalStatusCode, w.cloneHeaders(), w.body.Bytes(), w.extractAPIRequest(c), w.extractAPIResponse(c), w.extractAPIResponseTimestamp(c), slicesAPIResponseError, forceLog)
+	// Drop spool temps without writing a final request log when logging is off.
+	if !w.logger.IsEnabled() && !forceLog {
+		w.closeStreamingLogWriter()
+		return nil
+	}
+
+	if w.chunkChannel != nil {
+		close(w.chunkChannel)
+		w.chunkChannel = nil
+	}
+	if w.streamDone != nil {
+		<-w.streamDone
+		w.streamDone = nil
+	}
+
+	w.streamWriter = nil
+	writer.SetFirstChunkTimestamp(w.firstChunkTimestamp)
+
+	apiRequest := w.extractAPIRequest(c)
+	if len(apiRequest) > 0 {
+		_ = writer.WriteAPIRequest(apiRequest)
+	}
+	apiResponse := w.extractAPIResponse(c)
+	if len(apiResponse) > 0 {
+		_ = writer.WriteAPIResponse(apiResponse)
+	}
+	return writer.Close()
+}
+
+func (w *ResponseWriterWrapper) closeStreamingLogWriter() {
+	if w == nil {
+		return
+	}
+	if w.chunkChannel != nil {
+		close(w.chunkChannel)
+		w.chunkChannel = nil
+	}
+	if w.streamDone != nil {
+		<-w.streamDone
+		w.streamDone = nil
+	}
+	if w.streamWriter != nil {
+		_ = w.streamWriter.Close()
+		w.streamWriter = nil
+	}
 }
 
 func (w *ResponseWriterWrapper) cloneHeaders() map[string][]string {

--- a/internal/logging/log_dir_cleaner.go
+++ b/internal/logging/log_dir_cleaner.go
@@ -115,7 +115,7 @@ func enforceLogDirSizeLimit(logDir string, maxBytes int64, protectedPath string)
 			continue
 		}
 		name := entry.Name()
-		if !isLogFileName(name) {
+		if !isLogDirManagedFileName(name) {
 			continue
 		}
 		info, errInfo := entry.Info()
@@ -138,7 +138,14 @@ func enforceLogDirSizeLimit(logDir string, maxBytes int64, protectedPath string)
 		return 0, nil
 	}
 
+	// Prefer deleting orphaned spool temps before request/main logs so a
+	// leaked *.tmp storm cannot pin the directory above the configured cap.
 	sort.Slice(files, func(i, j int) bool {
+		iTmp := isLogSpoolTempFileName(filepath.Base(files[i].path))
+		jTmp := isLogSpoolTempFileName(filepath.Base(files[j].path))
+		if iTmp != jTmp {
+			return iTmp
+		}
 		return files[i].modTime.Before(files[j].modTime)
 	})
 
@@ -151,6 +158,10 @@ func enforceLogDirSizeLimit(logDir string, maxBytes int64, protectedPath string)
 			continue
 		}
 		if errRemove := os.Remove(file.path); errRemove != nil {
+			// Active stream may still hold the spool file open; skip and retry next cycle.
+			if isLogSpoolTempFileName(filepath.Base(file.path)) && !os.IsNotExist(errRemove) {
+				continue
+			}
 			log.WithError(errRemove).Warnf("logging: failed to remove old log file: %s", filepath.Base(file.path))
 			continue
 		}
@@ -168,4 +179,23 @@ func isLogFileName(name string) bool {
 	}
 	lower := strings.ToLower(trimmed)
 	return strings.HasSuffix(lower, ".log") || strings.HasSuffix(lower, ".log.gz")
+}
+
+// isLogSpoolTempFileName matches request/response body spool files written into
+// the logs directory while assembling per-request logs. These used to escape
+// logs-max-total-size-mb because only *.log / *.log.gz were counted.
+func isLogSpoolTempFileName(name string) bool {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return false
+	}
+	lower := strings.ToLower(trimmed)
+	if !strings.HasSuffix(lower, ".tmp") {
+		return false
+	}
+	return strings.HasPrefix(lower, "request-body-") || strings.HasPrefix(lower, "response-body-")
+}
+
+func isLogDirManagedFileName(name string) bool {
+	return isLogFileName(name) || isLogSpoolTempFileName(name)
 }

--- a/internal/logging/log_dir_cleaner_test.go
+++ b/internal/logging/log_dir_cleaner_test.go
@@ -57,6 +57,53 @@ func TestEnforceLogDirSizeLimitSkipsProtected(t *testing.T) {
 	}
 }
 
+func TestEnforceLogDirSizeLimitCountsAndDeletesSpoolTemps(t *testing.T) {
+	dir := t.TempDir()
+
+	// Orphaned stream spool temps must count toward the cap and be deleted first.
+	writeLogFile(t, filepath.Join(dir, "request-body-aaaa.tmp"), 80, time.Unix(1, 0))
+	writeLogFile(t, filepath.Join(dir, "response-body-bbbb.tmp"), 80, time.Unix(2, 0))
+	writeLogFile(t, filepath.Join(dir, "request-abc.log"), 40, time.Unix(3, 0))
+	writeLogFile(t, filepath.Join(dir, "unrelated.tmp"), 200, time.Unix(0, 0))
+
+	deleted, err := enforceLogDirSizeLimit(dir, 50, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted < 2 {
+		t.Fatalf("expected at least 2 spool temps deleted, got %d", deleted)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "request-body-aaaa.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("expected request-body temp removed, stat error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "response-body-bbbb.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("expected response-body temp removed, stat error: %v", err)
+	}
+	// Unrelated *.tmp files are not managed by the log dir cleaner.
+	if _, err := os.Stat(filepath.Join(dir, "unrelated.tmp")); err != nil {
+		t.Fatalf("expected unrelated.tmp to remain, stat error: %v", err)
+	}
+}
+
+func TestIsLogDirManagedFileName(t *testing.T) {
+	cases := map[string]bool{
+		"main.log":              true,
+		"main.log.gz":           true,
+		"v1-responses-x.log":    true,
+		"request-body-123.tmp":  true,
+		"response-body-456.tmp": true,
+		"REQUEST-BODY-789.TMP":  true,
+		"unrelated.tmp":         false,
+		"notes.txt":             false,
+		"":                      false,
+	}
+	for name, want := range cases {
+		if got := isLogDirManagedFileName(name); got != want {
+			t.Fatalf("isLogDirManagedFileName(%q)=%v want %v", name, got, want)
+		}
+	}
+}
+
 func writeLogFile(t *testing.T, path string, size int, modTime time.Time) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Root cause: `logs-max-total-size-mb` only counted `*.log` / `*.log.gz`, so orphaned stream spool files (`request-body-*.tmp` / `response-body-*.tmp`) grew unbounded (prod: ~5.3GB).
- Cleaner now counts spool temps, prefers deleting them first, and skips busy temps for the next cycle.
- Response writer always closes stream writers on WriteHeader rewrite / Finalize even when logging is disabled mid-request.

## Test plan
- [x] `./scripts/ci-pr.sh` (gofmt, structure check, `go test ./...`, golangci-lint, build)
- [x] `go test ./internal/logging/ ./internal/api/middleware/`
- [x] Online: deleted orphaned `*.tmp` older than 10m → logs `5.3G → 311M`

## Ops note
Already cleaned prod orphaned temps. After merge/deploy, cleaner will keep total under configured cap including spool files.