### PR TITLE
fix: bind quota and permissions to end-user accounts

### DIFF
--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -78,10 +78,12 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 }
 
 // keyConfig holds the per-key configuration extracted from APIKeyEntry.
+// When endUserID is set, quota/permissions come from the end-user account pool.
 type keyConfig struct {
 	tenantID             string
 	apiKeyID             string
 	apiKeyName           string
+	endUserID            string
 	allowedModels        []string
 	allowedChannels      []string
 	allowedChannelGroups []string
@@ -100,10 +102,11 @@ func keyConfigFromRow(row usage.APIKeyRow) keyConfig {
 	if tenantID == "" {
 		tenantID = identity.SystemTenantID
 	}
-	return keyConfig{
+	kc := keyConfig{
 		tenantID:             tenantID,
 		apiKeyID:             strings.TrimSpace(row.ID),
 		apiKeyName:           strings.TrimSpace(row.Name),
+		endUserID:            strings.TrimSpace(row.EndUserID),
 		allowedModels:        row.AllowedModels,
 		allowedChannels:      row.AllowedChannels,
 		allowedChannelGroups: row.AllowedChannelGroups,
@@ -116,6 +119,27 @@ func keyConfigFromRow(row usage.APIKeyRow) keyConfig {
 		tpmLimit:             row.TPMLimit,
 		systemPrompt:         row.SystemPrompt,
 	}
+	// Owned keys share the end-user account quota/permission pool.
+	if kc.endUserID != "" {
+		if q := usage.GetEndUserQuota(kc.endUserID); q != nil {
+			eq := usage.EffectiveEndUserQuota(*q)
+			if name := strings.TrimSpace(eq.DisplayName); name != "" {
+				kc.apiKeyName = name
+			}
+			kc.allowedModels = eq.AllowedModels
+			kc.allowedChannels = eq.AllowedChannels
+			kc.allowedChannelGroups = eq.AllowedChannelGroups
+			kc.dailyLimit = eq.DailyLimit
+			kc.totalQuota = eq.TotalQuota
+			kc.spendingLimit = eq.SpendingLimit
+			kc.dailySpendingLimit = eq.DailySpendingLimit
+			kc.concurrencyLimit = eq.ConcurrencyLimit
+			kc.rpmLimit = eq.RPMLimit
+			kc.tpmLimit = eq.TPMLimit
+			kc.systemPrompt = eq.SystemPrompt
+		}
+	}
+	return kc
 }
 
 type provider struct {
@@ -178,6 +202,9 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 		if kc, ok := p.keys[candidate.value]; ok {
 			metadata := map[string]string{
 				"source": candidate.source,
+			}
+			if kc.endUserID != "" {
+				metadata["end-user-id"] = kc.endUserID
 			}
 			if len(kc.allowedModels) > 0 {
 				metadata["allowed-models"] = strings.Join(kc.allowedModels, ",")

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -112,21 +112,56 @@ func (h *Handler) PatchEndUser(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Username    *string `json:"username"`
-		DisplayName *string `json:"display_name"`
-		Password    *string `json:"password"`
-		Status      *string `json:"status"`
+		Username             *string   `json:"username"`
+		DisplayName          *string   `json:"display_name"`
+		Password             *string   `json:"password"`
+		Status               *string   `json:"status"`
+		PermissionProfileID  *string   `json:"permission-profile-id"`
+		DailyLimit           *int      `json:"daily-limit"`
+		TotalQuota           *int      `json:"total-quota"`
+		SpendingLimit        *float64  `json:"spending-limit"`
+		DailySpendingLimit   *float64  `json:"daily-spending-limit"`
+		ConcurrencyLimit     *int      `json:"concurrency-limit"`
+		RPMLimit             *int      `json:"rpm-limit"`
+		TPMLimit             *int      `json:"tpm-limit"`
+		AllowedModels        *[]string `json:"allowed-models"`
+		AllowedChannels      *[]string `json:"allowed-channels"`
+		AllowedChannelGroups *[]string `json:"allowed-channel-groups"`
+		SystemPrompt         *string   `json:"system-prompt"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
-	user, err := svc.UpdateUser(c.Request.Context(), principal, effectiveTenantID(c), c.Param("id"), body.Username, body.DisplayName, body.Password, body.Status)
+	quota := &enduser.QuotaPatch{
+		PermissionProfileID:  body.PermissionProfileID,
+		DailyLimit:           body.DailyLimit,
+		TotalQuota:           body.TotalQuota,
+		SpendingLimit:        body.SpendingLimit,
+		DailySpendingLimit:   body.DailySpendingLimit,
+		ConcurrencyLimit:     body.ConcurrencyLimit,
+		RPMLimit:             body.RPMLimit,
+		TPMLimit:             body.TPMLimit,
+		AllowedModels:        body.AllowedModels,
+		AllowedChannels:      body.AllowedChannels,
+		AllowedChannelGroups: body.AllowedChannelGroups,
+		SystemPrompt:         body.SystemPrompt,
+	}
+	// Only pass quota when at least one field is set (avoid no-op patch noise).
+	hasQuota := body.PermissionProfileID != nil || body.DailyLimit != nil || body.TotalQuota != nil ||
+		body.SpendingLimit != nil || body.DailySpendingLimit != nil || body.ConcurrencyLimit != nil ||
+		body.RPMLimit != nil || body.TPMLimit != nil || body.AllowedModels != nil ||
+		body.AllowedChannels != nil || body.AllowedChannelGroups != nil || body.SystemPrompt != nil
+	if !hasQuota {
+		quota = nil
+	}
+	user, err := svc.UpdateUser(c.Request.Context(), principal, effectiveTenantID(c), c.Param("id"), body.Username, body.DisplayName, body.Password, body.Status, quota)
 	if err != nil {
 		endUserError(c, err)
 		return
 	}
-	if body.Status != nil {
+	// Status or account quota changes affect auth metadata for owned keys.
+	if body.Status != nil || hasQuota {
 		if err := h.refreshAPIKeyCache(); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{
 				"code":    "cache_refresh_failed",

--- a/internal/api/middleware/quota.go
+++ b/internal/api/middleware/quota.go
@@ -84,7 +84,9 @@ func (w *tokenWindow) sum() int64 {
 	return w.total.Load()
 }
 
-// ─── Per-key tracker registry ───────────────────────────────────────────────
+// ─── Per-subject tracker registry ───────────────────────────────────────────
+// Tracker keys are end-user ids when present, else the API key secret.
+// Owned keys therefore share one RPM/TPM/concurrency pool per account.
 
 var (
 	rpmTrackers sync.Map // map[string]*slidingWindow
@@ -94,31 +96,53 @@ var (
 	inFlightByKey = map[string]int{}
 )
 
-func getRPMTracker(apiKey string) *slidingWindow {
-	if v, ok := rpmTrackers.Load(apiKey); ok {
+func quotaSubjectKey(apiKey string, metadata map[string]string) string {
+	if metadata != nil {
+		if id := strings.TrimSpace(metadata["end-user-id"]); id != "" {
+			return "eu:" + id
+		}
+	}
+	return apiKey
+}
+
+func getRPMTracker(subject string) *slidingWindow {
+	if v, ok := rpmTrackers.Load(subject); ok {
 		return v.(*slidingWindow)
 	}
 	w := &slidingWindow{}
-	actual, _ := rpmTrackers.LoadOrStore(apiKey, w)
+	actual, _ := rpmTrackers.LoadOrStore(subject, w)
 	return actual.(*slidingWindow)
 }
 
-func getTPMTracker(apiKey string) *tokenWindow {
-	if v, ok := tpmTrackers.Load(apiKey); ok {
+func getTPMTracker(subject string) *tokenWindow {
+	if v, ok := tpmTrackers.Load(subject); ok {
 		return v.(*tokenWindow)
 	}
 	w := &tokenWindow{}
-	actual, _ := tpmTrackers.LoadOrStore(apiKey, w)
+	actual, _ := tpmTrackers.LoadOrStore(subject, w)
 	return actual.(*tokenWindow)
 }
 
 // RecordTokenUsage records token consumption for TPM tracking.
 // This should be called by the usage reporter after a request completes.
-func RecordTokenUsage(apiKey string, totalTokens int64) {
-	if apiKey == "" || totalTokens <= 0 {
+// subject should be the same key used by QuotaMiddleware (eu:<id> or api key).
+func RecordTokenUsage(subject string, totalTokens int64) {
+	if subject == "" || totalTokens <= 0 {
 		return
 	}
-	getTPMTracker(apiKey).add(totalTokens)
+	getTPMTracker(subject).add(totalTokens)
+}
+
+// RecordTokenUsageForRequest records TPM against the end-user pool when known.
+func RecordTokenUsageForRequest(apiKey, endUserID string, totalTokens int64) {
+	if totalTokens <= 0 {
+		return
+	}
+	if id := strings.TrimSpace(endUserID); id != "" {
+		RecordTokenUsage("eu:"+id, totalTokens)
+		return
+	}
+	RecordTokenUsage(apiKey, totalTokens)
 }
 
 // ─── Quota Middleware ───────────────────────────────────────────────────────
@@ -149,20 +173,24 @@ func QuotaMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		// Get access metadata containing limits (needed for end-user subject).
+		var metadata map[string]string
+		if metadataVal, ok := c.Get("accessMetadata"); ok {
+			metadata, _ = metadataVal.(map[string]string)
+		}
+		subject := quotaSubjectKey(apiKey, metadata)
+		endUserID := ""
+		if metadata != nil {
+			endUserID = strings.TrimSpace(metadata["end-user-id"])
+		}
+
 		// ── Always record this request for system-wide RPM tracking ──
 		// This must happen before any metadata checks so ALL authenticated
 		// POST requests are counted for the dashboard RPM display.
-		rpmTracker := getRPMTracker(apiKey)
+		rpmTracker := getRPMTracker(subject)
 		rpmTracker.add()
 
-		// Get access metadata containing limits
-		metadataVal, exists := c.Get("accessMetadata")
-		if !exists {
-			c.Next()
-			return
-		}
-		metadata, ok := metadataVal.(map[string]string)
-		if !ok {
+		if metadata == nil {
 			c.Next()
 			return
 		}
@@ -186,7 +214,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 		})
 
 		// Cache limits for dashboard snapshot
-		UpdateKeyLimits(apiKey, rpmLimit, tpmLimit)
+		UpdateKeyLimits(subject, rpmLimit, tpmLimit)
 
 		// No limits configured — skip all checks
 		if dailyLimit <= 0 && totalQuota <= 0 && concurrencyLimit <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 && dailySpendingLimit <= 0 {
@@ -195,9 +223,9 @@ func QuotaMiddleware() gin.HandlerFunc {
 		}
 
 		if concurrencyLimit > 0 {
-			release, ok := acquireKeyConcurrency(apiKey, concurrencyLimit)
+			release, ok := acquireKeyConcurrency(subject, concurrencyLimit)
 			if !ok {
-				current := keyConcurrencyCount(apiKey)
+				current := keyConcurrencyCount(subject)
 				rejectQuotaLimit(c, "concurrency", float64(concurrencyLimit), float64(current), "concurrency_limit_exceeded",
 					fmt.Sprintf("Concurrent request limit exceeded: %d in-flight requests (limit %d). Wait for running requests to finish, or raise the concurrency limit in the permission profile.", current, concurrencyLimit))
 				return
@@ -217,7 +245,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 
 		// --- TPM check (sliding window, in-memory) ---
 		if tpmLimit > 0 {
-			tracker := getTPMTracker(apiKey)
+			tracker := getTPMTracker(subject)
 			currentTPM := tracker.sum()
 			if currentTPM >= int64(tpmLimit) {
 				rejectQuotaLimit(c, "tpm", float64(tpmLimit), float64(currentTPM), "tpm_limit_exceeded",
@@ -228,7 +256,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 
 		// --- Daily limit check (from usage DB) ---
 		if dailyLimit > 0 {
-			todayCount, err := countTodayByKeyFunc(apiKey)
+			todayCount, err := countTodayUsage(apiKey, endUserID)
 			if err != nil {
 				log.Warnf("quota: failed to query daily usage for key %s: %v", maskKey(apiKey), err)
 			} else if todayCount >= int64(dailyLimit) {
@@ -240,7 +268,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 
 		// --- Total quota check (from usage DB) ---
 		if totalQuota > 0 {
-			totalCount, err := countTotalByKeyFunc(apiKey)
+			totalCount, err := countTotalUsage(apiKey, endUserID)
 			if err != nil {
 				log.Warnf("quota: failed to query total usage for key %s: %v", maskKey(apiKey), err)
 			} else if totalCount >= int64(totalQuota) {
@@ -252,7 +280,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 
 		// --- Spending limit check (from usage DB) ---
 		if spendingLimit > 0 {
-			totalCost, err := queryTotalCostByKeyFunc(apiKey)
+			totalCost, err := queryTotalCostUsage(apiKey, endUserID)
 			if err != nil {
 				log.Warnf("quota: failed to query total cost for key %s: %v", maskKey(apiKey), err)
 			} else if totalCost >= spendingLimit {
@@ -264,7 +292,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 
 		// --- Daily spending limit check (from usage DB) ---
 		if dailySpendingLimit > 0 {
-			todayCost, err := queryTodayCostByKeyFunc(apiKey)
+			todayCost, err := queryTodayCostUsage(apiKey, endUserID)
 			if err != nil {
 				log.Warnf("quota: failed to query today cost for key %s: %v", maskKey(apiKey), err)
 			} else if todayCost >= dailySpendingLimit {
@@ -305,13 +333,18 @@ func formatQuotaNumber(v float64) string {
 
 // ─── Usage DB query functions (injected to avoid import cycle) ──────────────
 
-// countTodayByKeyFunc and countTotalByKeyFunc are set by InitQuotaUsageFuncs.
-// They default to no-ops that always return 0 (no limit enforced) until set.
+// Key-scoped defaults; InitQuotaUsageFuncs wires real implementations.
+// When endUserID is set, InitQuotaUsageFuncs also wires account-scoped aggregators.
 var (
 	countTodayByKeyFunc     = func(string) (int64, error) { return 0, nil }
 	countTotalByKeyFunc     = func(string) (int64, error) { return 0, nil }
 	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
 	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+
+	countTodayByEndUserFunc     = func(string) (int64, error) { return 0, nil }
+	countTotalByEndUserFunc     = func(string) (int64, error) { return 0, nil }
+	queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+	queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
 )
 
 // InitQuotaUsageFuncs injects the usage DB query functions into the middleware.
@@ -326,6 +359,48 @@ func InitQuotaUsageFuncs(
 	countTotalByKeyFunc = countTotal
 	queryTotalCostByKeyFunc = totalCost
 	queryTodayCostByKeyFunc = todayCost
+}
+
+// InitQuotaEndUserUsageFuncs injects end-user-scoped usage aggregators.
+// Owned keys share one account pool for daily/total/spending checks.
+func InitQuotaEndUserUsageFuncs(
+	countToday func(string) (int64, error),
+	countTotal func(string) (int64, error),
+	totalCost func(string) (float64, error),
+	todayCost func(string) (float64, error),
+) {
+	countTodayByEndUserFunc = countToday
+	countTotalByEndUserFunc = countTotal
+	queryTotalCostByEndUserFunc = totalCost
+	queryTodayCostByEndUserFunc = todayCost
+}
+
+func countTodayUsage(apiKey, endUserID string) (int64, error) {
+	if endUserID != "" {
+		return countTodayByEndUserFunc(endUserID)
+	}
+	return countTodayByKeyFunc(apiKey)
+}
+
+func countTotalUsage(apiKey, endUserID string) (int64, error) {
+	if endUserID != "" {
+		return countTotalByEndUserFunc(endUserID)
+	}
+	return countTotalByKeyFunc(apiKey)
+}
+
+func queryTotalCostUsage(apiKey, endUserID string) (float64, error) {
+	if endUserID != "" {
+		return queryTotalCostByEndUserFunc(endUserID)
+	}
+	return queryTotalCostByKeyFunc(apiKey)
+}
+
+func queryTodayCostUsage(apiKey, endUserID string) (float64, error) {
+	if endUserID != "" {
+		return queryTodayCostByEndUserFunc(endUserID)
+	}
+	return queryTodayCostByKeyFunc(apiKey)
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -149,7 +149,14 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 	settingsstore.MigrateRuntimeSettingsFromConfig(cfg, configPath)
 	settingsstore.ApplyStoredRuntimeSettings(cfg)
 	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey, usage.QueryTodayCostByKey)
-	usage.SetTokenUsageCallback(middleware.RecordTokenUsage)
+	middleware.InitQuotaEndUserUsageFuncs(usage.CountTodayByEndUser, usage.CountTotalByEndUser, usage.QueryTotalCostByEndUser, usage.QueryTodayCostByEndUser)
+	usage.SetTokenUsageCallback(func(apiKey string, totalTokens int64) {
+		endUserID := ""
+		if row := usage.GetAPIKey(apiKey); row != nil {
+			endUserID = row.EndUserID
+		}
+		middleware.RecordTokenUsageForRequest(apiKey, endUserID, totalTokens)
+	})
 	return nil
 }
 

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -270,10 +271,14 @@ func requireUUID(id string) error {
 func scanUser(scanner interface{ Scan(dest ...any) error }) (User, error) {
 	var u User
 	var lastLogin, lockedUntil sql.NullTime
+	var modelsJSON, channelsJSON, groupsJSON string
 	err := scanner.Scan(
 		&u.ID, &u.TenantID, &u.Username, &u.DisplayName, &u.Status,
 		&u.MustChangePassword, &lastLogin, &u.FailedLoginCount, &u.LockStage, &lockedUntil,
 		&u.CreatedAt, &u.UpdatedAt, &u.Version,
+		&u.PermissionProfileID, &u.DailyLimit, &u.TotalQuota, &u.SpendingLimit, &u.DailySpendingLimit,
+		&u.ConcurrencyLimit, &u.RPMLimit, &u.TPMLimit,
+		&modelsJSON, &channelsJSON, &groupsJSON, &u.SystemPrompt,
 	)
 	if err != nil {
 		return u, err
@@ -286,11 +291,57 @@ func scanUser(scanner interface{ Scan(dest ...any) error }) (User, error) {
 		t := lockedUntil.Time
 		u.LockedUntil = &t
 	}
+	u.AllowedModels = decodeJSONStringList(modelsJSON)
+	u.AllowedChannels = decodeJSONStringList(channelsJSON)
+	u.AllowedChannelGroups = decodeJSONStringList(groupsJSON)
 	return u, nil
 }
 
+func decodeJSONStringList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "[]" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func encodeJSONStringList(values []string) string {
+	if len(values) == 0 {
+		return "[]"
+	}
+	b, err := json.Marshal(values)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
+func clampNonNegInt(v int) int {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func clampNonNegFloat(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
 const userSelect = `SELECT id, tenant_id, username, display_name, status, must_change_password,
-	last_login_at, failed_login_count, lock_stage, locked_until, created_at, updated_at, version FROM end_users`
+	last_login_at, failed_login_count, lock_stage, locked_until, created_at, updated_at, version,
+	COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
+	COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+	COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
+	COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
+	COALESCE(system_prompt, '')
+	FROM end_users`
 
 func (s *Service) GetUser(ctx context.Context, tenantID, userID string) (User, error) {
 	if err := requireUUID(tenantID); err != nil {
@@ -500,7 +551,7 @@ func (s *Service) CreateUser(ctx context.Context, actor identity.Principal, tena
 	return result, nil
 }
 
-func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tenantID, userID string, username, displayName, password, status *string) (User, error) {
+func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tenantID, userID string, username, displayName, password, status *string, quota *QuotaPatch) (User, error) {
 	if !actor.Has("end_users.write") && !actor.PlatformAdmin {
 		return User{}, ErrPermissionDenied
 	}
@@ -513,8 +564,8 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 	if err := requireUUID(userID); err != nil {
 		return User{}, err
 	}
-	sets := make([]string, 0, 8)
-	args := make([]any, 0, 10)
+	sets := make([]string, 0, 20)
+	args := make([]any, 0, 24)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return User{}, err
@@ -559,6 +610,56 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 		args = append(args, st)
 		if st == "active" {
 			sets = append(sets, "failed_login_count = 0", "lock_stage = 0", "locked_until = NULL")
+		}
+	}
+	if quota != nil {
+		if quota.PermissionProfileID != nil {
+			sets = append(sets, "permission_profile_id = ?")
+			args = append(args, strings.TrimSpace(*quota.PermissionProfileID))
+		}
+		if quota.DailyLimit != nil {
+			sets = append(sets, "daily_limit = ?")
+			args = append(args, clampNonNegInt(*quota.DailyLimit))
+		}
+		if quota.TotalQuota != nil {
+			sets = append(sets, "total_quota = ?")
+			args = append(args, clampNonNegInt(*quota.TotalQuota))
+		}
+		if quota.SpendingLimit != nil {
+			sets = append(sets, "spending_limit = ?")
+			args = append(args, clampNonNegFloat(*quota.SpendingLimit))
+		}
+		if quota.DailySpendingLimit != nil {
+			sets = append(sets, "daily_spending_limit = ?")
+			args = append(args, clampNonNegFloat(*quota.DailySpendingLimit))
+		}
+		if quota.ConcurrencyLimit != nil {
+			sets = append(sets, "concurrency_limit = ?")
+			args = append(args, clampNonNegInt(*quota.ConcurrencyLimit))
+		}
+		if quota.RPMLimit != nil {
+			sets = append(sets, "rpm_limit = ?")
+			args = append(args, clampNonNegInt(*quota.RPMLimit))
+		}
+		if quota.TPMLimit != nil {
+			sets = append(sets, "tpm_limit = ?")
+			args = append(args, clampNonNegInt(*quota.TPMLimit))
+		}
+		if quota.AllowedModels != nil {
+			sets = append(sets, "allowed_models = ?")
+			args = append(args, encodeJSONStringList(*quota.AllowedModels))
+		}
+		if quota.AllowedChannels != nil {
+			sets = append(sets, "allowed_channels = ?")
+			args = append(args, encodeJSONStringList(*quota.AllowedChannels))
+		}
+		if quota.AllowedChannelGroups != nil {
+			sets = append(sets, "allowed_channel_groups = ?")
+			args = append(args, encodeJSONStringList(*quota.AllowedChannelGroups))
+		}
+		if quota.SystemPrompt != nil {
+			sets = append(sets, "system_prompt = ?")
+			args = append(args, *quota.SystemPrompt)
 		}
 	}
 	if len(sets) == 0 {

--- a/internal/enduser/service_sqlite_test.go
+++ b/internal/enduser/service_sqlite_test.go
@@ -36,7 +36,19 @@ func openEndUserTestDB(t *testing.T) *sql.DB {
 			locked_until TEXT,
 			created_at TEXT NOT NULL DEFAULT '',
 			updated_at TEXT NOT NULL DEFAULT '',
-			version INTEGER NOT NULL DEFAULT 1
+			version INTEGER NOT NULL DEFAULT 1,
+			permission_profile_id TEXT NOT NULL DEFAULT '',
+			daily_limit INTEGER NOT NULL DEFAULT 0,
+			total_quota INTEGER NOT NULL DEFAULT 0,
+			spending_limit REAL NOT NULL DEFAULT 0,
+			daily_spending_limit REAL NOT NULL DEFAULT 0,
+			concurrency_limit INTEGER NOT NULL DEFAULT 0,
+			rpm_limit INTEGER NOT NULL DEFAULT 0,
+			tpm_limit INTEGER NOT NULL DEFAULT 0,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			allowed_channels TEXT NOT NULL DEFAULT '[]',
+			allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT ''
 		)
 	`); err != nil {
 		t.Fatalf("create end_users: %v", err)

--- a/internal/enduser/types.go
+++ b/internal/enduser/types.go
@@ -18,6 +18,37 @@ type User struct {
 	Version            int64      `json:"version"`
 	// APIKeyCount is filled on list; 0 means unknown/none.
 	APIKeyCount int `json:"api_key_count,omitempty"`
+
+	// Account-level quota/permissions: shared by every API key under this user.
+	PermissionProfileID  string   `json:"permission-profile-id,omitempty"`
+	DailyLimit           int      `json:"daily-limit,omitempty"`
+	TotalQuota           int      `json:"total-quota,omitempty"`
+	SpendingLimit        float64  `json:"spending-limit,omitempty"`
+	DailySpendingLimit   float64  `json:"daily-spending-limit,omitempty"`
+	ConcurrencyLimit     int      `json:"concurrency-limit,omitempty"`
+	RPMLimit             int      `json:"rpm-limit,omitempty"`
+	TPMLimit             int      `json:"tpm-limit,omitempty"`
+	AllowedModels        []string `json:"allowed-models,omitempty"`
+	AllowedChannels      []string `json:"allowed-channels,omitempty"`
+	AllowedChannelGroups []string `json:"allowed-channel-groups,omitempty"`
+	SystemPrompt         string   `json:"system-prompt,omitempty"`
+}
+
+// QuotaPatch updates account-level limits. Nil field = leave unchanged.
+// Pointer to empty profile id or zero limit clears that field.
+type QuotaPatch struct {
+	PermissionProfileID  *string   `json:"permission-profile-id,omitempty"`
+	DailyLimit           *int      `json:"daily-limit,omitempty"`
+	TotalQuota           *int      `json:"total-quota,omitempty"`
+	SpendingLimit        *float64  `json:"spending-limit,omitempty"`
+	DailySpendingLimit   *float64  `json:"daily-spending-limit,omitempty"`
+	ConcurrencyLimit     *int      `json:"concurrency-limit,omitempty"`
+	RPMLimit             *int      `json:"rpm-limit,omitempty"`
+	TPMLimit             *int      `json:"tpm-limit,omitempty"`
+	AllowedModels        *[]string `json:"allowed-models,omitempty"`
+	AllowedChannels      *[]string `json:"allowed-channels,omitempty"`
+	AllowedChannelGroups *[]string `json:"allowed-channel-groups,omitempty"`
+	SystemPrompt         *string   `json:"system-prompt,omitempty"`
 }
 
 type APIKey struct {

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -25,8 +25,83 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607170002_api_key_daily_spending_reset_events", SQL: apiKeyDailySpendingResetEventsSQL},
 		// End-user portal accounts (isolated from admin users) + multi-key ownership + refresh tokens.
 		{Version: "202607170003_end_users_and_tokens", SQL: endUsersAndTokensSQL},
+		// Account-level quota/permissions: shared across all API keys of an end user.
+		{Version: "202607190001_end_user_account_quota", SQL: endUserAccountQuotaSQL},
 	}
 }
+
+// Quota + permission template live on end_users so multiple keys share one pool.
+// Backfill from each user's default key (or earliest key) then zero owned key limits
+// so creating extra keys cannot mint independent budgets.
+const endUserAccountQuotaSQL = `
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS permission_profile_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS daily_limit INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS total_quota INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS daily_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS concurrency_limit INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS rpm_limit INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS tpm_limit INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS allowed_models TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS allowed_channels TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS allowed_channel_groups TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS system_prompt TEXT NOT NULL DEFAULT '';
+
+UPDATE end_users AS eu
+SET
+  permission_profile_id = COALESCE(NULLIF(src.permission_profile_id, ''), eu.permission_profile_id),
+  daily_limit = CASE WHEN src.daily_limit > 0 THEN src.daily_limit ELSE eu.daily_limit END,
+  total_quota = CASE WHEN src.total_quota > 0 THEN src.total_quota ELSE eu.total_quota END,
+  spending_limit = CASE WHEN src.spending_limit > 0 THEN src.spending_limit ELSE eu.spending_limit END,
+  daily_spending_limit = CASE WHEN src.daily_spending_limit > 0 THEN src.daily_spending_limit ELSE eu.daily_spending_limit END,
+  concurrency_limit = CASE WHEN src.concurrency_limit > 0 THEN src.concurrency_limit ELSE eu.concurrency_limit END,
+  rpm_limit = CASE WHEN src.rpm_limit > 0 THEN src.rpm_limit ELSE eu.rpm_limit END,
+  tpm_limit = CASE WHEN src.tpm_limit > 0 THEN src.tpm_limit ELSE eu.tpm_limit END,
+  allowed_models = CASE WHEN src.allowed_models IS NOT NULL AND src.allowed_models <> '' AND src.allowed_models <> '[]'
+    THEN src.allowed_models ELSE eu.allowed_models END,
+  allowed_channels = CASE WHEN src.allowed_channels IS NOT NULL AND src.allowed_channels <> '' AND src.allowed_channels <> '[]'
+    THEN src.allowed_channels ELSE eu.allowed_channels END,
+  allowed_channel_groups = CASE WHEN src.allowed_channel_groups IS NOT NULL AND src.allowed_channel_groups <> '' AND src.allowed_channel_groups <> '[]'
+    THEN src.allowed_channel_groups ELSE eu.allowed_channel_groups END,
+  system_prompt = CASE WHEN src.system_prompt IS NOT NULL AND src.system_prompt <> ''
+    THEN src.system_prompt ELSE eu.system_prompt END
+FROM (
+  SELECT DISTINCT ON (end_user_id)
+    end_user_id,
+    permission_profile_id,
+    daily_limit,
+    total_quota,
+    spending_limit,
+    daily_spending_limit,
+    concurrency_limit,
+    rpm_limit,
+    tpm_limit,
+    allowed_models,
+    allowed_channels,
+    allowed_channel_groups,
+    system_prompt
+  FROM api_keys
+  WHERE end_user_id IS NOT NULL
+  ORDER BY end_user_id, is_default DESC, created_at ASC NULLS LAST, id ASC
+) AS src
+WHERE eu.id = src.end_user_id;
+
+UPDATE api_keys
+SET
+  permission_profile_id = '',
+  daily_limit = 0,
+  total_quota = 0,
+  spending_limit = 0,
+  daily_spending_limit = 0,
+  concurrency_limit = 0,
+  rpm_limit = 0,
+  tpm_limit = 0,
+  allowed_models = '[]',
+  allowed_channels = '[]',
+  allowed_channel_groups = '[]',
+  system_prompt = ''
+WHERE end_user_id IS NOT NULL;
+`
 
 const endUsersAndTokensSQL = `
 ALTER TABLE tenants ADD COLUMN IF NOT EXISTS access_token_ttl_seconds INTEGER NOT NULL DEFAULT 43200;

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -7,10 +7,21 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 16 {
-		t.Fatalf("RuntimeMigrations len = %d, want 16", len(migrations))
+	if len(migrations) != 17 {
+		t.Fatalf("RuntimeMigrations len = %d, want 17", len(migrations))
 	}
-	// Latest: end users + refresh tokens.
+	// Latest: account-level quota on end_users.
+	accountQuotaSQL := migrations[16].SQL
+	for _, fragment := range []string{
+		"end_users ADD COLUMN IF NOT EXISTS permission_profile_id",
+		"end_users ADD COLUMN IF NOT EXISTS daily_limit",
+		"WHERE end_user_id IS NOT NULL",
+	} {
+		if !strings.Contains(accountQuotaSQL, fragment) {
+			t.Fatalf("end user account quota migration missing %q", fragment)
+		}
+	}
+	// Prior: end users + refresh tokens.
 	endUsersSQL := migrations[15].SQL
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS end_users",

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -289,6 +289,26 @@ func (s Store) GetByID(id string) *APIKeyRow {
 	return entry
 }
 
+// stripOwnedKeyQuota clears per-key limits for end-user-owned keys.
+// Account-level limits live on end_users; keeping key rows non-zero would re-open the multi-key budget hole.
+func stripOwnedKeyQuota(entry *APIKeyRow) {
+	if entry == nil || strings.TrimSpace(entry.EndUserID) == "" {
+		return
+	}
+	entry.PermissionProfileID = ""
+	entry.DailyLimit = 0
+	entry.TotalQuota = 0
+	entry.SpendingLimit = 0
+	entry.DailySpendingLimit = 0
+	entry.ConcurrencyLimit = 0
+	entry.RPMLimit = 0
+	entry.TPMLimit = 0
+	entry.AllowedModels = nil
+	entry.AllowedChannels = nil
+	entry.AllowedChannelGroups = nil
+	entry.SystemPrompt = ""
+}
+
 func (s Store) Upsert(entry APIKeyRow) error {
 	if s.db == nil {
 		return fmt.Errorf("database not initialised")
@@ -305,6 +325,15 @@ func (s Store) Upsert(entry APIKeyRow) error {
 			entry.ID = uuid.NewString()
 		}
 	}
+	// Preserve ownership if caller omitted end_user_id, then force account-level quota semantics.
+	if strings.TrimSpace(entry.EndUserID) == "" {
+		if existing := s.GetByID(entry.ID); existing != nil && existing.EndUserID != "" {
+			entry.EndUserID = existing.EndUserID
+		} else if existing := s.Get(entry.Key); existing != nil && existing.EndUserID != "" {
+			entry.EndUserID = existing.EndUserID
+		}
+	}
+	stripOwnedKeyQuota(&entry)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	if entry.CreatedAt == "" {
@@ -371,13 +400,18 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if entry.CreatedAt == "" {
-		if existing := s.GetByID(entry.ID); existing != nil && existing.CreatedAt != "" {
+	if existing := s.GetByID(entry.ID); existing != nil {
+		if entry.CreatedAt == "" && existing.CreatedAt != "" {
 			entry.CreatedAt = existing.CreatedAt
-		} else {
-			entry.CreatedAt = now
+		}
+		if strings.TrimSpace(entry.EndUserID) == "" {
+			entry.EndUserID = existing.EndUserID
 		}
 	}
+	if entry.CreatedAt == "" {
+		entry.CreatedAt = now
+	}
+	stripOwnedKeyQuota(&entry)
 
 	disabledInt := 0
 	if entry.Disabled {

--- a/internal/usage/api_key_identity.go
+++ b/internal/usage/api_key_identity.go
@@ -19,10 +19,11 @@ func ResolveAPIKeyIdentity(key string) *APIKeyIdentity {
 	if row == nil || strings.TrimSpace(row.ID) == "" {
 		return nil
 	}
+	name := ResolveAPIKeyDisplayName(row, row.Name)
 	return &APIKeyIdentity{
 		ID:   strings.TrimSpace(row.ID),
 		Key:  strings.TrimSpace(row.Key),
-		Name: strings.TrimSpace(row.Name),
+		Name: name,
 	}
 }
 

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -1,0 +1,334 @@
+package usage
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EndUserQuota is the account-level limit/permission snapshot used by auth + quota.
+type EndUserQuota struct {
+	ID                   string
+	TenantID             string
+	DisplayName          string
+	PermissionProfileID  string
+	DailyLimit           int
+	TotalQuota           int
+	SpendingLimit        float64
+	DailySpendingLimit   float64
+	ConcurrencyLimit     int
+	RPMLimit             int
+	TPMLimit             int
+	AllowedModels        []string
+	AllowedChannels      []string
+	AllowedChannelGroups []string
+	SystemPrompt         string
+}
+
+func decodeQuotaStringList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "[]" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// GetEndUserQuota loads account-level quota for an end user. nil when missing.
+func GetEndUserQuota(endUserID string) *EndUserQuota {
+	db := getReadDB()
+	if db == nil {
+		return nil
+	}
+	endUserID = strings.TrimSpace(endUserID)
+	if endUserID == "" {
+		return nil
+	}
+	var q EndUserQuota
+	var modelsJSON, channelsJSON, groupsJSON string
+	err := db.QueryRow(`
+		SELECT id, tenant_id, display_name,
+			COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
+			COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+			COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
+			COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
+			COALESCE(system_prompt, '')
+		FROM end_users WHERE id = ?
+	`, endUserID).Scan(
+		&q.ID, &q.TenantID, &q.DisplayName,
+		&q.PermissionProfileID, &q.DailyLimit, &q.TotalQuota,
+		&q.SpendingLimit, &q.DailySpendingLimit,
+		&q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
+		&modelsJSON, &channelsJSON, &groupsJSON, &q.SystemPrompt,
+	)
+	if err != nil {
+		return nil
+	}
+	q.AllowedModels = decodeQuotaStringList(modelsJSON)
+	q.AllowedChannels = decodeQuotaStringList(channelsJSON)
+	q.AllowedChannelGroups = decodeQuotaStringList(groupsJSON)
+	return &q
+}
+
+// EffectiveEndUserQuota merges a permission profile over the end-user row when set.
+func EffectiveEndUserQuota(q EndUserQuota) EndUserQuota {
+	profileID := strings.TrimSpace(q.PermissionProfileID)
+	if profileID == "" {
+		return q
+	}
+	profiles := ListAPIKeyPermissionProfilesForTenant(q.TenantID)
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.ID) != profileID {
+			continue
+		}
+		q.PermissionProfileID = profileID
+		q.DailyLimit = profile.DailyLimit
+		q.TotalQuota = profile.TotalQuota
+		q.SpendingLimit = 0
+		q.DailySpendingLimit = profile.DailySpendingLimit
+		q.ConcurrencyLimit = profile.ConcurrencyLimit
+		q.RPMLimit = profile.RPMLimit
+		q.TPMLimit = profile.TPMLimit
+		q.AllowedModels = append([]string(nil), profile.AllowedModels...)
+		q.AllowedChannels = append([]string(nil), profile.AllowedChannels...)
+		q.AllowedChannelGroups = append([]string(nil), profile.AllowedChannelGroups...)
+		q.SystemPrompt = profile.SystemPrompt
+		return q
+	}
+	return q
+}
+
+// ListAPIKeyIDsForEndUser returns stable key ids owned by the end user.
+func ListAPIKeyIDsForEndUser(endUserID string) []string {
+	db := getReadDB()
+	if db == nil {
+		return nil
+	}
+	endUserID = strings.TrimSpace(endUserID)
+	if endUserID == "" {
+		return nil
+	}
+	rows, err := db.Query(`SELECT id FROM api_keys WHERE end_user_id = ? AND id != ''`, endUserID)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	out := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return out
+		}
+		id = strings.TrimSpace(id)
+		if id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// ListAPIKeySecretsForEndUser returns raw key secrets owned by the end user (legacy log rows).
+func ListAPIKeySecretsForEndUser(endUserID string) []string {
+	db := getReadDB()
+	if db == nil {
+		return nil
+	}
+	endUserID = strings.TrimSpace(endUserID)
+	if endUserID == "" {
+		return nil
+	}
+	rows, err := db.Query(`SELECT key FROM api_keys WHERE end_user_id = ? AND key != ''`, endUserID)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	out := make([]string, 0)
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return out
+		}
+		key = strings.TrimSpace(key)
+		if key != "" {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+// DisplayNameForEndUser returns display_name for request-log labeling.
+func DisplayNameForEndUser(endUserID string) string {
+	q := GetEndUserQuota(endUserID)
+	if q == nil {
+		return ""
+	}
+	return strings.TrimSpace(q.DisplayName)
+}
+
+// ResolveAPIKeyDisplayName prefers end-user display name when the key is owned.
+func ResolveAPIKeyDisplayName(row *APIKeyRow, fallback string) string {
+	if row != nil {
+		if name := DisplayNameForEndUser(row.EndUserID); name != "" {
+			return name
+		}
+		if n := strings.TrimSpace(row.Name); n != "" {
+			return n
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func buildEndUserAPIKeySelectorClause(endUserID string) (string, []interface{}) {
+	ids := ListAPIKeyIDsForEndUser(endUserID)
+	secrets := ListAPIKeySecretsForEndUser(endUserID)
+	if len(ids) == 0 && len(secrets) == 0 {
+		// No keys yet: match nothing.
+		return " WHERE 1 = 0", nil
+	}
+	parts := make([]string, 0, 2)
+	args := make([]interface{}, 0, len(ids)+len(secrets))
+	if len(ids) > 0 {
+		ph := make([]string, len(ids))
+		for i, id := range ids {
+			ph[i] = "?"
+			args = append(args, id)
+		}
+		parts = append(parts, `api_key_id IN (`+strings.Join(ph, ",")+`)`)
+	}
+	if len(secrets) > 0 {
+		ph := make([]string, len(secrets))
+		for i, key := range secrets {
+			ph[i] = "?"
+			args = append(args, key)
+		}
+		// Include legacy rows that only stored the raw secret.
+		parts = append(parts, `(api_key_id = '' AND api_key IN (`+strings.Join(ph, ",")+`))`)
+	}
+	return " WHERE (" + strings.Join(parts, " OR ") + ")", args
+}
+
+// CountTodayByEndUser counts requests across all keys of the end user today.
+func CountTodayByEndUser(endUserID string) (int64, error) {
+	db := getReadDB()
+	if db == nil {
+		return 0, nil
+	}
+	clause, args := buildEndUserAPIKeySelectorClause(endUserID)
+	if clause == "" {
+		return 0, nil
+	}
+	queryArgs := append(args, CutoffStartUTC(1).Format(time.RFC3339))
+	var count int64
+	err := db.QueryRow(
+		"SELECT COUNT(*) FROM request_logs"+clause+" AND timestamp >= ?",
+		queryArgs...,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("usage: count today by end user: %w", err)
+	}
+	return count, nil
+}
+
+// CountTotalByEndUser counts lifetime requests across all keys of the end user.
+func CountTotalByEndUser(endUserID string) (int64, error) {
+	db := getReadDB()
+	if db == nil {
+		return 0, nil
+	}
+	clause, args := buildEndUserAPIKeySelectorClause(endUserID)
+	if clause == "" {
+		return 0, nil
+	}
+	var count int64
+	err := db.QueryRow("SELECT COUNT(*) FROM request_logs"+clause, args...).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("usage: count total by end user: %w", err)
+	}
+	return count, nil
+}
+
+// QueryTotalCostByEndUser sums lifetime cost across all keys of the end user.
+func QueryTotalCostByEndUser(endUserID string) (float64, error) {
+	db := getDB()
+	if db == nil {
+		return 0, nil
+	}
+	clause, args := buildEndUserAPIKeySelectorClause(endUserID)
+	if clause == "" {
+		return 0, nil
+	}
+	var total float64
+	err := db.QueryRow(
+		"SELECT COALESCE(SUM(cost), 0) FROM request_logs"+clause,
+		args...,
+	).Scan(&total)
+	if err != nil {
+		return 0, fmt.Errorf("usage: query total cost by end user: %w", err)
+	}
+	return total, nil
+}
+
+// QueryTodayCostByEndUser sums project-day cost across all keys of the end user.
+// Daily spending reset remains per-key for now; account pool uses raw day sum.
+// ponytail: no end-user-level daily spending reset yet; add when product needs account-wide reset.
+func QueryTodayCostByEndUser(endUserID string) (float64, error) {
+	db := getDB()
+	if db == nil {
+		return 0, nil
+	}
+	clause, args := buildEndUserAPIKeySelectorClause(endUserID)
+	if clause == "" {
+		return 0, nil
+	}
+	queryArgs := append(args, CutoffStartUTC(1).Format(time.RFC3339))
+	var total float64
+	err := db.QueryRow(
+		"SELECT COALESCE(SUM(cost), 0) FROM request_logs"+clause+" AND timestamp >= ?",
+		queryArgs...,
+	).Scan(&total)
+	if err != nil {
+		return 0, fmt.Errorf("usage: query today cost by end user: %w", err)
+	}
+	return total, nil
+}
+
+// EnsureEndUserQuotaColumns adds account quota columns on SQLite bootstraps / tests.
+func EnsureEndUserQuotaColumns(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	for _, col := range []struct {
+		name string
+		def  string
+	}{
+		{"permission_profile_id", "TEXT NOT NULL DEFAULT ''"},
+		{"daily_limit", "INTEGER NOT NULL DEFAULT 0"},
+		{"total_quota", "INTEGER NOT NULL DEFAULT 0"},
+		{"spending_limit", "REAL NOT NULL DEFAULT 0"},
+		{"daily_spending_limit", "REAL NOT NULL DEFAULT 0"},
+		{"concurrency_limit", "INTEGER NOT NULL DEFAULT 0"},
+		{"rpm_limit", "INTEGER NOT NULL DEFAULT 0"},
+		{"tpm_limit", "INTEGER NOT NULL DEFAULT 0"},
+		{"allowed_models", "TEXT NOT NULL DEFAULT '[]'"},
+		{"allowed_channels", "TEXT NOT NULL DEFAULT '[]'"},
+		{"allowed_channel_groups", "TEXT NOT NULL DEFAULT '[]'"},
+		{"system_prompt", "TEXT NOT NULL DEFAULT ''"},
+	} {
+		if _, err := db.Exec("ALTER TABLE end_users ADD COLUMN " + col.name + " " + col.def); err != nil {
+			if !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+				// table may not exist yet in pure-key tests
+				msg := strings.ToLower(err.Error())
+				if strings.Contains(msg, "no such table") {
+					return nil
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/usage/enduser_quota_test.go
+++ b/internal/usage/enduser_quota_test.go
@@ -1,0 +1,125 @@
+package usage
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestCountUsageByEndUserAggregatesAllKeys(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "enduser-quota-*.db")
+	if err != nil {
+		t.Fatalf("create temp db: %v", err)
+	}
+	dbPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() {
+		CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+
+	db := getDB()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS end_users (
+			id TEXT PRIMARY KEY,
+			tenant_id TEXT NOT NULL,
+			username TEXT NOT NULL,
+			username_normalized TEXT NOT NULL,
+			display_name TEXT NOT NULL,
+			password_hash TEXT NOT NULL DEFAULT 'x',
+			status TEXT NOT NULL DEFAULT 'active',
+			permission_profile_id TEXT NOT NULL DEFAULT '',
+			daily_limit INTEGER NOT NULL DEFAULT 0,
+			total_quota INTEGER NOT NULL DEFAULT 0,
+			spending_limit REAL NOT NULL DEFAULT 0,
+			daily_spending_limit REAL NOT NULL DEFAULT 0,
+			concurrency_limit INTEGER NOT NULL DEFAULT 0,
+			rpm_limit INTEGER NOT NULL DEFAULT 0,
+			tpm_limit INTEGER NOT NULL DEFAULT 0,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			allowed_channels TEXT NOT NULL DEFAULT '[]',
+			allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+
+	endUserID := uuid.NewString()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, daily_limit)
+		VALUES (?, ?, 'u1', 'u1', '陈龙', 10)
+	`, endUserID, systemTenantID); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
+
+	keyA := "sk-enduser-a"
+	keyB := "sk-enduser-b"
+	idA := uuid.NewString()
+	idB := uuid.NewString()
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, row := range []struct {
+		key, id string
+	}{{keyA, idA}, {keyB, idB}} {
+		if err := UpsertAPIKey(APIKeyRow{
+			TenantID:   systemTenantID,
+			ID:         row.id,
+			Key:        row.key,
+			Name:       "k",
+			EndUserID:  endUserID,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+			DailyLimit: 999, // stripOwnedKeyQuota must clear this
+		}); err != nil {
+			t.Fatalf("upsert key: %v", err)
+		}
+	}
+	if got := GetAPIKey(keyA); got == nil || got.DailyLimit != 0 {
+		t.Fatalf("owned key daily_limit = %#v, want 0", got)
+	}
+
+	ts := CutoffStartUTC(1).Add(time.Hour).Format(time.RFC3339)
+	for _, row := range []struct {
+		key, id string
+	}{{keyA, idA}, {keyB, idB}} {
+		if _, err := db.Exec(
+			`INSERT INTO request_logs
+			 (tenant_id, timestamp, api_key, api_key_id, model, source, failed, latency_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+			 VALUES (?, ?, ?, ?, ?, ?, 0, 1, 0, 0, 0, 0, 1, 0)`,
+			systemTenantID, ts, row.key, row.id, "model", "test",
+		); err != nil {
+			t.Fatalf("insert log: %v", err)
+		}
+	}
+
+	today, err := CountTodayByEndUser(endUserID)
+	if err != nil {
+		t.Fatalf("CountTodayByEndUser: %v", err)
+	}
+	if today != 2 {
+		t.Fatalf("CountTodayByEndUser = %d, want 2 (shared pool)", today)
+	}
+	total, err := CountTotalByEndUser(endUserID)
+	if err != nil {
+		t.Fatalf("CountTotalByEndUser: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("CountTotalByEndUser = %d, want 2", total)
+	}
+
+	q := GetEndUserQuota(endUserID)
+	if q == nil || q.DisplayName != "陈龙" || q.DailyLimit != 10 {
+		t.Fatalf("GetEndUserQuota = %#v", q)
+	}
+	if name := ResolveAPIKeyDisplayName(GetAPIKey(keyA), "fallback"); name != "陈龙" {
+		t.Fatalf("display name = %q, want 陈龙", name)
+	}
+}

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -365,9 +365,12 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	// during in-flight requests do not orphan log records.
 	apiKeyID := strings.TrimSpace(record.APIKeyID)
 	apiKeyName := strings.TrimSpace(record.APIKeyName)
-	if apiKeyName == "" && statsKey != "" {
-		if row := GetAPIKey(statsKey); row != nil && row.Name != "" {
-			apiKeyName = row.Name
+	if statsKey != "" {
+		if row := GetAPIKey(statsKey); row != nil {
+			// Prefer account display name for owned keys so logs show end-user, not key label.
+			if name := ResolveAPIKeyDisplayName(row, apiKeyName); name != "" {
+				apiKeyName = name
+			}
 		}
 	}
 	inputContent := resolveDeferredUsageContent(record.InputContent, record.InputContentPath)

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -89,6 +89,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		items = append(items, row)
 	}
 	hydrateStreamingFromContent(db, params.TenantID, items)
+	hydrateAPIKeyDisplayNames(params.TenantID, items)
 
 	return LogQueryResult{
 		Items: items,
@@ -96,6 +97,39 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		Page:  params.Page,
 		Size:  params.Size,
 	}, nil
+}
+
+// hydrateAPIKeyDisplayNames prefers live end-user account names for owned keys.
+func hydrateAPIKeyDisplayNames(tenantID string, items []LogRow) {
+	if len(items) == 0 {
+		return
+	}
+	byID := currentAPIKeyRowsByIDForTenant(tenantID)
+	byKey := currentAPIKeyRowsByKeyForTenant(tenantID)
+	for i := range items {
+		var row *APIKeyRow
+		if r, ok := byKey[strings.TrimSpace(items[i].APIKey)]; ok {
+			copy := r
+			row = &copy
+		} else {
+			// Fall back: resolve via secret lookup when tenant maps miss.
+			if live := GetAPIKey(items[i].APIKey); live != nil {
+				row = live
+			}
+		}
+		// Prefer id map when we can match key to id via byKey first.
+		if row != nil {
+			if id := strings.TrimSpace(row.ID); id != "" {
+				if r, ok := byID[id]; ok {
+					copy := r
+					row = &copy
+				}
+			}
+			if label := ResolveAPIKeyDisplayName(row, items[i].APIKeyName); label != "" {
+				items[i].APIKeyName = label
+			}
+		}
+	}
 }
 
 func hydrateStreamingFromContent(db *sql.DB, tenantID string, items []LogRow) {
@@ -1041,8 +1075,9 @@ func queryDistinctAPIKeys(db *sql.DB, params LogQueryParams) ([]string, map[stri
 			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
 				value = trimmed
 			}
-			if trimmed := strings.TrimSpace(row.Name); trimmed != "" {
-				name = trimmed
+			// Owned keys: show end-user account name in filters / labels.
+			if label := ResolveAPIKeyDisplayName(&row, name); label != "" {
+				name = label
 			}
 		}
 		if value == "" {

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -574,15 +574,15 @@ func QueryAPIKeyDistributionForTenant(tenantID string, days int) ([]APIKeyDistri
 			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
 				p.APIKey = trimmed
 			}
-			if trimmed := strings.TrimSpace(row.Name); trimmed != "" {
-				p.Name = trimmed
+			if label := ResolveAPIKeyDisplayName(&row, p.Name); label != "" {
+				p.Name = label
 			}
 		} else if row, ok := currentByKey[p.APIKey]; ok {
 			if trimmed := strings.TrimSpace(row.Key); trimmed != "" {
 				p.APIKey = trimmed
 			}
-			if trimmed := strings.TrimSpace(row.Name); trimmed != "" {
-				p.Name = trimmed
+			if label := ResolveAPIKeyDisplayName(&row, p.Name); label != "" {
+				p.Name = label
 			}
 		}
 		if p.APIKey == "" {

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -851,7 +851,10 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstr
 		if apiKeyID == "" {
 			apiKeyID = identity.ID
 		}
-		if apiKeyName == "" {
+		// Always prefer live identity label (end-user display name when owned).
+		if name := strings.TrimSpace(identity.Name); name != "" {
+			apiKeyName = name
+		} else if apiKeyName == "" {
 			apiKeyName = identity.Name
 		}
 	}


### PR DESCRIPTION
## Summary
- Move daily/total/spending/RPM/TPM and permission profile from per-API-key to **end-user account** so multiple keys share one quota pool
- Migration backfills limits from default key and zeroes owned-key limit columns
- Auth metadata + QuotaMiddleware aggregate usage/RPM/TPM/concurrency by `end_user_id`; strip per-key limits on owned key upsert
- Request log labels prefer end-user `display_name`

## Local verification
- `./scripts/ci-pr.sh`
- `go test` for enduser, usage, middleware, config_access, management handlers, routes, postgres

## Test plan
- [ ] Create end user with permission profile / daily limit on account
- [ ] Create second key under same user; confirm both keys share the same daily/total/spending pool
- [ ] Confirm owned key update cannot re-attach independent daily-limit
- [ ] Request logs show account display name for owned keys