### PR TITLE
fix(usage): aggregate public lookup stats across end-user keys

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -1578,7 +1578,9 @@ func TestGetPublicUsageLogs_ReturnsChannelNameWithoutSensitiveFields(t *testing.
 	if item.ChannelName != "Codex 主渠道" {
 		t.Fatalf("channel_name = %q, want Codex 主渠道", item.ChannelName)
 	}
-	if item.APIKey != "" || item.APIKeyName != "" || item.Source != "" || item.AuthIndex != "" {
+	// api_key_name is non-secret and needed so multi-key portal users can tell keys apart.
+	// Raw api_key / source / auth_index must still be scrubbed.
+	if item.APIKey != "" || item.Source != "" || item.AuthIndex != "" {
 		t.Fatalf("sensitive fields not scrubbed: %+v", item)
 	}
 }

--- a/internal/api/handlers/management/usage_summary_public.go
+++ b/internal/api/handlers/management/usage_summary_public.go
@@ -71,10 +71,11 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 	// Public summary is unauthenticated and only receives the raw API key.
 	// Resolve the key's tenant first so multi-tenant deployments do not query
 	// the system catalog (which would always return found=false / zero stats).
+	// End-user-owned keys share one account pool — aggregate all keys of the owner.
 	tenantID := usage.ResolveAPIKeyTenant(apiKey)
 	stats, err := usage.QueryStats(usage.LogQueryParams{
 		TenantID: tenantID,
-		APIKey:   apiKey,
+		APIKeys:  usage.ExpandPublicLookupAPIKeys(apiKey),
 		Days:     1,
 	})
 	if err != nil {

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -915,7 +915,7 @@ func (s *Service) CreateKey(ctx context.Context, tenantID, endUserID, name strin
 	now := time.Now().UTC().Format(time.RFC3339)
 	name = strings.TrimSpace(name)
 	if name == "" {
-		name = "key"
+		return result, fmt.Errorf("%w: key name is required", ErrValidation)
 	}
 	if _, err = tx.ExecContext(ctx, `
 		INSERT INTO api_keys (key, id, name, disabled, end_user_id, is_default, tenant_id, created_at, updated_at,

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -153,12 +153,14 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		maps.authIndexesBySubject,
 		maps.authMetaBySubject,
 	)
+	// Portal multi-key accounts share one quota pool; public lookup aggregates all owned keys.
+	lookupKeys := usage.ExpandPublicLookupAPIKeys(input.APIKey)
 	params := usage.LogQueryParams{
 		TenantID:              usage.ResolveAPIKeyTenant(input.APIKey),
 		Page:                  input.Page,
 		Size:                  input.Size,
 		Days:                  input.Days,
-		APIKey:                input.APIKey,
+		APIKeys:               lookupKeys,
 		Models:                input.Models,
 		Statuses:              input.Statuses,
 		MatchNoModels:         input.MatchNoModels,
@@ -185,8 +187,13 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 
 	apiKeyName := s.publicAPIKeyName(input.APIKey)
 	for i := range result.Items {
+		// Prefer the key's own name so multi-key accounts can tell rows apart.
+		keyOwnName := usage.ResolveAPIKeyOwnName(result.Items[i].APIKey)
+		if keyOwnName == "" {
+			keyOwnName = strings.TrimSpace(result.Items[i].APIKeyName)
+		}
 		if apiKeyName == "" {
-			apiKeyName = strings.TrimSpace(result.Items[i].APIKeyName)
+			apiKeyName = keyOwnName
 		}
 		channelName := displayChannelNameForLog(result.Items[i], maps.channelNameMap, maps.authIndexChannelMap, maps.ambiguousAuthIndexChannelMap)
 		result.Items[i].Source = ""
@@ -194,7 +201,7 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		result.Items[i].AuthSubjectID = ""
 		result.Items[i].ChannelName = channelName
 		result.Items[i].APIKey = ""
-		result.Items[i].APIKeyName = ""
+		result.Items[i].APIKeyName = keyOwnName
 		// Keep provider/auth_type for public UI badges, but strip identity keys above.
 		enrichLogRowChannelMeta(&result.Items[i], maps.authMetaByIndex, maps.authMetaBySubject)
 		result.Items[i].AuthIndex = ""

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -161,6 +161,48 @@ func ListAPIKeySecretsForEndUser(endUserID string) []string {
 	return out
 }
 
+// ExpandPublicLookupAPIKeys expands a presented API key into the full account key pool
+// when the key is owned by an end user (shared quota / portal multi-key).
+// Standalone keys and unknown secrets stay single-key.
+func ExpandPublicLookupAPIKeys(apiKey string) []string {
+	trimmed := strings.TrimSpace(apiKey)
+	if trimmed == "" {
+		return nil
+	}
+	row := GetAPIKey(trimmed)
+	if row == nil {
+		return []string{trimmed}
+	}
+	endUserID := strings.TrimSpace(row.EndUserID)
+	if endUserID == "" {
+		if k := strings.TrimSpace(row.Key); k != "" {
+			return []string{k}
+		}
+		return []string{trimmed}
+	}
+	secrets := ListAPIKeySecretsForEndUser(endUserID)
+	if len(secrets) == 0 {
+		if k := strings.TrimSpace(row.Key); k != "" {
+			return []string{k}
+		}
+		return []string{trimmed}
+	}
+	return secrets
+}
+
+// ResolveAPIKeyOwnName returns the key's own name (not end-user account display name).
+func ResolveAPIKeyOwnName(apiKey string) string {
+	trimmed := strings.TrimSpace(apiKey)
+	if trimmed == "" {
+		return ""
+	}
+	row := GetAPIKey(trimmed)
+	if row == nil {
+		return ""
+	}
+	return strings.TrimSpace(row.Name)
+}
+
 // DisplayNameForEndUser returns display_name for request-log labeling.
 func DisplayNameForEndUser(endUserID string) string {
 	q := GetEndUserQuota(endUserID)

--- a/internal/usage/enduser_quota_test.go
+++ b/internal/usage/enduser_quota_test.go
@@ -123,3 +123,58 @@ func TestCountUsageByEndUserAggregatesAllKeys(t *testing.T) {
 		t.Fatalf("display name = %q, want 陈龙", name)
 	}
 }
+
+func TestExpandPublicLookupAPIKeys_AggregatesOwnedKeys(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "expand-keys-*.db")
+	if err != nil {
+		t.Fatalf("create temp db: %v", err)
+	}
+	dbPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() {
+		CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+
+	endUserID := uuid.NewString()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := UpsertAPIKey(APIKeyRow{TenantID: systemTenantID, ID: uuid.NewString(), Key: "sk-a", Name: "A", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("UpsertAPIKey A: %v", err)
+	}
+	if err := UpsertAPIKey(APIKeyRow{TenantID: systemTenantID, ID: uuid.NewString(), Key: "sk-b", Name: "B", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("UpsertAPIKey B: %v", err)
+	}
+	if err := UpsertAPIKey(APIKeyRow{TenantID: systemTenantID, ID: uuid.NewString(), Key: "sk-solo", Name: "Solo", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("UpsertAPIKey solo: %v", err)
+	}
+
+	got := ExpandPublicLookupAPIKeys("sk-a")
+	if len(got) != 2 {
+		t.Fatalf("owned expand len=%d keys=%v, want 2", len(got), got)
+	}
+	set := map[string]bool{}
+	for _, k := range got {
+		set[k] = true
+	}
+	if !set["sk-a"] || !set["sk-b"] {
+		t.Fatalf("owned expand = %v, want sk-a and sk-b", got)
+	}
+
+	solo := ExpandPublicLookupAPIKeys("sk-solo")
+	if len(solo) != 1 || solo[0] != "sk-solo" {
+		t.Fatalf("solo expand = %v, want [sk-solo]", solo)
+	}
+
+	unknown := ExpandPublicLookupAPIKeys("sk-unknown")
+	if len(unknown) != 1 || unknown[0] != "sk-unknown" {
+		t.Fatalf("unknown expand = %v, want [sk-unknown]", unknown)
+	}
+	if name := ResolveAPIKeyOwnName("sk-a"); name != "A" {
+		t.Fatalf("ResolveAPIKeyOwnName = %q, want A", name)
+	}
+}

--- a/internal/usage/request_log_content.go
+++ b/internal/usage/request_log_content.go
@@ -139,7 +139,7 @@ func QueryLogContentForKey(id int64, apiKey string) (LogContentResult, error) {
 	if db == nil {
 		return LogContentResult{}, fmt.Errorf("usage: database not initialised")
 	}
-	clause, args := buildSingleAPIKeySelectorClauseForTenant(tenantID, apiKey)
+	clause, args := buildPublicLookupAPIKeySelectorClause(tenantID, apiKey)
 	predicate := strings.TrimPrefix(clause, " WHERE ")
 	queryArgs := append([]interface{}{tenantID, id}, args...)
 
@@ -186,7 +186,7 @@ func QueryLogContentPartForKey(id int64, apiKey string, part string) (LogContent
 	} else if part == "details" {
 		column = "detail_content"
 	}
-	clause, args := buildSingleAPIKeySelectorClauseForTenant(tenantID, apiKey)
+	clause, args := buildPublicLookupAPIKeySelectorClause(tenantID, apiKey)
 	predicate := strings.TrimPrefix(clause, " WHERE ")
 	queryArgs := append([]interface{}{tenantID, id}, args...)
 

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -1120,6 +1120,26 @@ func buildSingleAPIKeySelectorClauseForTenant(tenantID, selector string) (string
 	return " WHERE api_key = ?", []interface{}{trimmed}
 }
 
+// buildPublicLookupAPIKeySelectorClause matches any key in the end-user account pool
+// (or a single standalone key). Used by public log content access checks.
+func buildPublicLookupAPIKeySelectorClause(tenantID, selector string) (string, []interface{}) {
+	keys := ExpandPublicLookupAPIKeys(selector)
+	if len(keys) == 0 {
+		return " WHERE 1 = 0", nil
+	}
+	if len(keys) == 1 {
+		return buildSingleAPIKeySelectorClauseForTenant(tenantID, keys[0])
+	}
+	conds := make([]string, 0, len(keys))
+	args := make([]interface{}, 0, len(keys)*2)
+	for _, k := range keys {
+		clause, clauseArgs := buildSingleAPIKeySelectorClauseForTenant(tenantID, k)
+		conds = append(conds, strings.TrimPrefix(clause, " WHERE "))
+		args = append(args, clauseArgs...)
+	}
+	return " WHERE (" + strings.Join(conds, " OR ") + ")", args
+}
+
 // QueryModelsForKey returns the distinct models used by a specific API key within the time range.
 func QueryModelsForKey(apiKey string, days int) ([]string, error) {
 	db := getReadDB()

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -65,7 +65,12 @@ func QueryPublicChartData(apiKey string, days int) (PublicChartData, error) {
 	statsCutoff := CutoffStartUTC(days).Format(time.RFC3339)
 	heatmapCutoff := CutoffStartUTC(heatmapDays).Format(time.RFC3339)
 
-	params := LogQueryParams{TenantID: ResolveAPIKeyTenant(apiKey), APIKey: apiKey, Days: scanDays}
+	// Expand end-user-owned keys so portal multi-key accounts see full account usage.
+	params := LogQueryParams{
+		TenantID: ResolveAPIKeyTenant(apiKey),
+		APIKeys:  ExpandPublicLookupAPIKeys(apiKey),
+		Days:     scanDays,
+	}
 	where, args := buildWhereClause(params)
 	queryArgs := make([]interface{}, 0, len(args)+2)
 	queryArgs = append(queryArgs, statsCutoff, heatmapCutoff)


### PR DESCRIPTION
## Summary
- Public usage/logs/chart/summary 对 end-user 归属 Key 展开为账号全部 Key 聚合查询
- Public logs 行内返回 Key 名称（非明文 secret），便于多 Key 区分
- 新建 Key 名称必填（不再默认 `key`）

## Root cause
用户页用量/日志按单把明文 Key 过滤；新建/切换 Key 后历史请求不在新 Key 上 → 统计与日志变空。账号额度本就共用，public lookup 应聚合同账号全部 Key。

## Test plan
- [x] `go test ./internal/usage/ ./internal/enduser/ ./internal/management/usagelogs/ ./internal/api/handlers/management/ ./internal/api/routes/`
- [x] `TestExpandPublicLookupAPIKeys_AggregatesOwnedKeys`
- [x] public usage logs / summary 相关测试

## Notes
- 需与 codeProxy `fix/portal-modals-and-multi-key-usage` 一并发布