### PR TITLE
fix(enduser): reject duplicate API key names per account

### DIFF
--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -52,6 +52,8 @@ func endUserError(c *gin.Context, err error) {
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "tenant_expired", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrLastKey):
 		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "last_key", "message": err.Error()}})
+	case errors.Is(err, enduser.ErrDuplicateKeyName):
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "duplicate_key_name", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrNotFound):
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrValidation):

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -33,6 +33,7 @@ var (
 	ErrTenantSuspended    = errors.New("tenant suspended")
 	ErrTenantExpired      = errors.New("tenant expired")
 	ErrValidation         = errors.New("validation failed")
+	ErrDuplicateKeyName   = errors.New("duplicate key name")
 	ErrLastKey            = errors.New("cannot delete last api key")
 	ErrNotFound           = errors.New("not found")
 )
@@ -917,6 +918,9 @@ func (s *Service) CreateKey(ctx context.Context, tenantID, endUserID, name strin
 	if name == "" {
 		return result, fmt.Errorf("%w: key name is required", ErrValidation)
 	}
+	if err = ensureUniqueKeyName(ctx, tx, tenantID, endUserID, name, ""); err != nil {
+		return result, err
+	}
 	if _, err = tx.ExecContext(ctx, `
 		INSERT INTO api_keys (key, id, name, disabled, end_user_id, is_default, tenant_id, created_at, updated_at,
 			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
@@ -970,6 +974,18 @@ func (s *Service) UpdateKeyName(ctx context.Context, tenantID, endUserID, keyID,
 	if name == "" {
 		return fmt.Errorf("%w: name required", ErrValidation)
 	}
+	if err := requireUUID(tenantID); err != nil {
+		return err
+	}
+	if err := requireUUID(endUserID); err != nil {
+		return err
+	}
+	if err := requireUUID(keyID); err != nil {
+		return err
+	}
+	if err := ensureUniqueKeyName(ctx, s.db, tenantID, endUserID, name, keyID); err != nil {
+		return err
+	}
 	res, err := s.db.ExecContext(ctx, `UPDATE api_keys SET name = ?, updated_at = ? WHERE tenant_id = ? AND end_user_id = ? AND id = ?`,
 		name, time.Now().UTC().Format(time.RFC3339), tenantID, endUserID, keyID)
 	if err != nil {
@@ -979,6 +995,35 @@ func (s *Service) UpdateKeyName(ctx context.Context, tenantID, endUserID, keyID,
 		return ErrNotFound
 	}
 	return nil
+}
+
+// ensureUniqueKeyName rejects case-insensitive name collisions within one end user.
+// excludeKeyID is empty on create; on rename pass the current key id so it can keep its name.
+func ensureUniqueKeyName(ctx context.Context, q queryRower, tenantID, endUserID, name, excludeKeyID string) error {
+	var exists int
+	var err error
+	if excludeKeyID == "" {
+		err = q.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM api_keys
+			WHERE tenant_id = ? AND end_user_id = ? AND LOWER(name) = LOWER(?)
+		`, tenantID, endUserID, name).Scan(&exists)
+	} else {
+		err = q.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM api_keys
+			WHERE tenant_id = ? AND end_user_id = ? AND LOWER(name) = LOWER(?) AND id != ?
+		`, tenantID, endUserID, name, excludeKeyID).Scan(&exists)
+	}
+	if err != nil {
+		return err
+	}
+	if exists > 0 {
+		return fmt.Errorf("%w: key name %q already exists", ErrDuplicateKeyName, name)
+	}
+	return nil
+}
+
+type queryRower interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
 func (s *Service) RotateKey(ctx context.Context, tenantID, endUserID, keyID string) (CreateKeyResult, error) {

--- a/internal/enduser/service_sqlite_test.go
+++ b/internal/enduser/service_sqlite_test.go
@@ -124,6 +124,15 @@ func TestSetDefaultKeyOnSQLite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create b: %v", err)
 	}
+	if _, err := svc.CreateKey(ctx, tenantID, userID, "A"); !errors.Is(err, ErrDuplicateKeyName) {
+		t.Fatalf("duplicate name err = %v, want ErrDuplicateKeyName", err)
+	}
+	if err := svc.UpdateKeyName(ctx, tenantID, userID, b.APIKey.ID, "a"); !errors.Is(err, ErrDuplicateKeyName) {
+		t.Fatalf("rename to duplicate err = %v, want ErrDuplicateKeyName", err)
+	}
+	if err := svc.UpdateKeyName(ctx, tenantID, userID, a.APIKey.ID, "a"); err != nil {
+		t.Fatalf("keep same name: %v", err)
+	}
 	if err := svc.SetDefaultKey(ctx, tenantID, userID, b.APIKey.ID); err != nil {
 		t.Fatalf("set default: %v", err)
 	}


### PR DESCRIPTION
## Summary
- CreateKey / UpdateKeyName 拒绝同一 end user 下大小写不敏感的重名
- 返回 `duplicate_key_name`（HTTP 409）

## Test plan
- [x] `go test ./internal/enduser/ -count=1`
- [x] `go test ./internal/api/handlers/management/ -count=1 -run EndUser`