### PR TITLE
fix: surface process-global runtime toggles for platform admins in tenant config

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -59,7 +59,36 @@ func (h *Handler) GetConfig(c *gin.Context) {
 		OAuthModelAlias:      runtimeCfg.OAuthModelAlias,
 		Payload:              runtimeCfg.Payload,
 	}
+	// Platform super-admins often switch into a business tenant for ops. The
+	// tenant-scoped provider view must not leak other tenants' secrets, but
+	// process-global runtime toggles (request-log, logging-to-file, …) still
+	// apply to the host. Omitting them made the management UI default those
+	// booleans to false while the process kept writing full request files.
+	if principal, ok := principalFromContext(c); ok && principal.PlatformAdmin {
+		copyProcessGlobalRuntimeToggles(h.cfg, tenantView)
+	}
 	c.JSON(200, sanitizeConfigForAPI(tenantView))
+}
+
+// copyProcessGlobalRuntimeToggles copies host-wide runtime switches that the
+// config panel reads/writes. Provider credentials stay tenant-scoped.
+func copyProcessGlobalRuntimeToggles(src, dst *config.Config) {
+	if src == nil || dst == nil {
+		return
+	}
+	dst.SDKConfig.RequestLog = src.SDKConfig.RequestLog
+	dst.SDKConfig.RequestLogStorage = src.SDKConfig.RequestLogStorage
+	dst.Debug = src.Debug
+	dst.LoggingToFile = src.LoggingToFile
+	dst.LogsMaxTotalSizeMB = src.LogsMaxTotalSizeMB
+	dst.ErrorLogsMaxFiles = src.ErrorLogsMaxFiles
+	dst.UsageStatisticsEnabled = src.UsageStatisticsEnabled
+	dst.WebsocketAuth = src.WebsocketAuth
+	dst.RequestRetry = src.RequestRetry
+	dst.MaxRetryInterval = src.MaxRetryInterval
+	dst.QuotaExceeded = src.QuotaExceeded
+	dst.ForceModelPrefix = src.ForceModelPrefix
+	dst.ProxyURL = src.ProxyURL
 }
 
 // maskKey masks an API key / secret, preserving first 6 and last 4 characters.

--- a/internal/api/handlers/management/provider_settings_tenant_test.go
+++ b/internal/api/handlers/management/provider_settings_tenant_test.go
@@ -113,17 +113,82 @@ func TestGetConfigReturnsOnlyTenantRuntimeView(t *testing.T) {
 	}
 	t.Cleanup(usage.CloseDB)
 
-	h := &Handler{cfg: &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "system-secret"}}, Debug: true}}
+	h := &Handler{cfg: &config.Config{
+		SDKConfig: config.SDKConfig{RequestLog: true},
+		GeminiKey: []config.GeminiKey{{APIKey: "system-secret"}},
+		Debug:     true,
+	}}
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
-	c.Set(managementPrincipalKey, identity.Principal{EffectiveTenant: identity.Tenant{ID: "00000000-0000-0000-0000-00000000000a"}})
+	c.Set(managementPrincipalKey, identity.Principal{
+		PlatformAdmin:   false,
+		EffectiveTenant: identity.Tenant{ID: "00000000-0000-0000-0000-00000000000a"},
+	})
 	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/config", nil)
 	h.GetConfig(c)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
-	if strings.Contains(rec.Body.String(), "system-secret") || strings.Contains(rec.Body.String(), "debug\":true") {
-		t.Fatalf("tenant config leaked system settings: %s", rec.Body.String())
+	body := rec.Body.String()
+	if strings.Contains(body, "system-secret") || strings.Contains(body, `"debug":true`) {
+		t.Fatalf("tenant config leaked system settings: %s", body)
+	}
+	// Non-platform tenants still must not receive host runtime toggles via /config
+	// (they reach dedicated endpoints only when authorized).
+	if strings.Contains(body, `"request-log":true`) {
+		t.Fatalf("non-platform tenant config leaked process-global request-log: %s", body)
+	}
+}
+
+func TestGetConfigIncludesProcessGlobalTogglesForPlatformAdminInTenantContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	usage.CloseDB()
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	h := &Handler{cfg: &config.Config{
+		SDKConfig: config.SDKConfig{
+			RequestLog:       true,
+			ForceModelPrefix: true,
+			ProxyURL:         "http://host-proxy.example:7890",
+		},
+		GeminiKey:              []config.GeminiKey{{APIKey: "system-secret"}},
+		Debug:                  true,
+		LoggingToFile:          true,
+		UsageStatisticsEnabled: true,
+		WebsocketAuth:          true,
+		QuotaExceeded:          config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true},
+	}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set(managementPrincipalKey, identity.Principal{
+		PlatformAdmin:   true,
+		EffectiveTenant: identity.Tenant{ID: "00000000-0000-0000-0000-00000000000a"},
+		HomeTenant:      identity.Tenant{ID: identity.SystemTenantID},
+	})
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/config", nil)
+	h.GetConfig(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "system-secret") {
+		t.Fatalf("platform-admin tenant view leaked provider secrets: %s", body)
+	}
+	for _, want := range []string{
+		`"request-log":true`,
+		`"logging-to-file":true`,
+		`"debug":true`,
+		`"usage-statistics-enabled":true`,
+		`"ws-auth":true`,
+		`"force-model-prefix":true`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("platform-admin tenant view missing %s: %s", want, body)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Platform super-admins switched into a business tenant received a tenant-scoped `GET /config` without process-global toggles (`request-log`, `logging-to-file`, etc.).
- The management UI treated missing booleans as `false` while the host kept writing full request/response files to disk.
- Copy host-wide runtime toggles into the platform-admin tenant view; keep provider secrets tenant-scoped.

## Test plan
- [x] `go test ./internal/api/handlers/management/ -run 'TestGetConfig'`
- [x] `go test ./internal/api/routes/ -run 'TestRegisterManagementRouteTable'`
- [x] `go test ./internal/api/... ./internal/management/...`