### PR TITLE
fix: bind portal usage to end-user accounts across keys

### DIFF
--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -45,6 +45,13 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 		if trimmed == "" || entry.Disabled {
 			continue
 		}
+		// Frozen/locked accounts stay out of the auth map even if individual keys are enabled.
+		if endUserID := strings.TrimSpace(entry.EndUserID); endUserID != "" {
+			q := usage.GetEndUserQuota(endUserID)
+			if q == nil || strings.TrimSpace(q.Status) != "active" {
+				continue
+			}
+		}
 		if _, exists := result[trimmed]; exists {
 			continue
 		}

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -75,6 +75,14 @@ func (h *Handler) GetEndUsers(c *gin.Context) {
 		endUserError(c, err)
 		return
 	}
+	for i := range items {
+		used, usageErr := usage.QueryTodayEffectiveCostByEndUserForTenant(items[i].TenantID, items[i].ID)
+		if usageErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": usageErr.Error()})
+			return
+		}
+		items[i].DailySpendingUsed = used
+	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
 }
 
@@ -210,6 +218,37 @@ func (h *Handler) PostEndUserResetPassword(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"generated_password": generated})
+}
+
+func (h *Handler) PostEndUserDailySpendingReset(c *gin.Context) {
+	principal, _ := principalFromContext(c)
+	svc := h.endUserService()
+	if svc == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "end user service unavailable"})
+		return
+	}
+	if !principal.Has("end_users.write") && !principal.PlatformAdmin {
+		identityError(c, identity.ErrPermissionDenied)
+		return
+	}
+	tenantID := effectiveTenantID(c)
+	user, err := svc.GetUser(c.Request.Context(), tenantID, c.Param("id"))
+	if err != nil {
+		endUserError(c, err)
+		return
+	}
+	usedBefore, rawToday, err := usage.ResetTodayCostByEndUser(tenantID, user.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"status":                "ok",
+		"end_user_id":           user.ID,
+		"daily-spending-used":   0,
+		"effective-used-before": usedBefore,
+		"raw-today-cost":        rawToday,
+	})
 }
 
 func (h *Handler) GetEndUserAPIKeys(c *gin.Context) {
@@ -473,8 +512,7 @@ func (h *Handler) PatchPortalAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name      *string `json:"name"`
-		IsDefault *bool   `json:"is_default"`
+		Name *string `json:"name"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
@@ -484,12 +522,6 @@ func (h *Handler) PatchPortalAPIKey(c *gin.Context) {
 	svc := h.endUserService()
 	if body.Name != nil {
 		if err := svc.UpdateKeyName(c.Request.Context(), user.TenantID, user.ID, keyID, *body.Name); err != nil {
-			endUserError(c, err)
-			return
-		}
-	}
-	if body.IsDefault != nil && *body.IsDefault {
-		if err := svc.SetDefaultKey(c.Request.Context(), user.TenantID, user.ID, keyID); err != nil {
 			endUserError(c, err)
 			return
 		}

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -75,13 +75,25 @@ func (h *Handler) GetEndUsers(c *gin.Context) {
 		endUserError(c, err)
 		return
 	}
+	// Group by tenant then batch-load today costs (avoids per-row N+1).
+	byTenant := map[string][]string{}
 	for i := range items {
-		used, usageErr := usage.QueryTodayEffectiveCostByEndUserForTenant(items[i].TenantID, items[i].ID)
+		tid := items[i].TenantID
+		byTenant[tid] = append(byTenant[tid], items[i].ID)
+	}
+	costs := map[string]float64{}
+	for tid, ids := range byTenant {
+		part, usageErr := usage.QueryTodayEffectiveCostsByEndUsersForTenant(tid, ids)
 		if usageErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": usageErr.Error()})
 			return
 		}
-		items[i].DailySpendingUsed = used
+		for id, used := range part {
+			costs[id] = used
+		}
+	}
+	for i := range items {
+		items[i].DailySpendingUsed = costs[items[i].ID]
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
 }

--- a/internal/api/handlers/management/public_usage_subject.go
+++ b/internal/api/handlers/management/public_usage_subject.go
@@ -1,0 +1,57 @@
+package management
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+type publicUsageSubject struct {
+	TenantID  string
+	EndUserID string
+	APIKey    string
+	APIKeyRow *usage.APIKeyRow
+}
+
+func (s publicUsageSubject) logQueryParams(days int) usage.LogQueryParams {
+	params := usage.LogQueryParams{TenantID: s.TenantID, Days: days}
+	if strings.TrimSpace(s.EndUserID) != "" {
+		params.EndUserID = s.EndUserID
+	} else if strings.TrimSpace(s.APIKey) != "" {
+		params.APIKeys = []string{s.APIKey}
+	}
+	return params
+}
+
+// resolvePublicUsageSubject binds portal requests to the authenticated end user.
+// Raw-secret callers remain supported for CC Switch and legacy public lookup.
+func (h *Handler) resolvePublicUsageSubject(c *gin.Context, apiKey string) (publicUsageSubject, bool) {
+	if token := bearerToken(c); strings.HasPrefix(token, "cpt_") {
+		user, _, ok := h.authenticatePortal(c)
+		if !ok {
+			return publicUsageSubject{}, false
+		}
+		return publicUsageSubject{
+			TenantID:  strings.TrimSpace(user.TenantID),
+			EndUserID: strings.TrimSpace(user.ID),
+		}, true
+	}
+
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+		return publicUsageSubject{}, false
+	}
+
+	subject := publicUsageSubject{APIKey: apiKey}
+	if row := usage.GetAPIKey(apiKey); row != nil {
+		subject.APIKeyRow = row
+		subject.TenantID = strings.TrimSpace(row.TenantID)
+		subject.EndUserID = strings.TrimSpace(row.EndUserID)
+	} else {
+		subject.TenantID = usage.ResolveAPIKeyTenant(apiKey)
+	}
+	return subject, true
+}

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -54,9 +54,8 @@ func (h *Handler) GetPublicUsageByAPIKey(c *gin.Context) {
 		return
 	}
 
-	apiKey := req.APIKey
-	if apiKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+	subject, ok := h.resolvePublicUsageSubject(c, req.APIKey)
+	if !ok {
 		return
 	}
 
@@ -65,9 +64,21 @@ func (h *Handler) GetPublicUsageByAPIKey(c *gin.Context) {
 		snapshot = h.usageStats.Snapshot()
 	}
 
-	// Find the matching API key entry
-	apiData, found := snapshot.APIs[apiKey]
-	maskedAPIKey := maskKey(apiKey)
+	keys := []string{subject.APIKey}
+	if subject.EndUserID != "" {
+		keys = usage.ListAPIKeySecretsForEndUserForTenant(subject.TenantID, subject.EndUserID)
+	}
+	apiData, hasUsage := aggregatePublicAPISnapshots(snapshot.APIs, keys)
+	found := hasUsage
+	if subject.EndUserID != "" && subject.APIKey == "" {
+		found = true
+	} else if subject.APIKeyRow != nil {
+		// A persisted disabled key must not be revived merely because the in-memory
+		// snapshot still contains older usage. Unknown legacy keys remain supported
+		// when the snapshot itself proves that the presented secret has usage.
+		found = !subject.APIKeyRow.Disabled
+	}
+	maskedAPIKey := maskKey(subject.APIKey)
 	if !found {
 		c.JSON(http.StatusOK, gin.H{
 			"usage": usage.StatisticsSnapshot{
@@ -78,6 +89,9 @@ func (h *Handler) GetPublicUsageByAPIKey(c *gin.Context) {
 			"found":          false,
 		})
 		return
+	}
+	if !hasUsage {
+		apiData.Models = map[string]usage.ModelSnapshot{}
 	}
 
 	// Return only the matched API key's data. Use the masked key as the public
@@ -98,6 +112,27 @@ func (h *Handler) GetPublicUsageByAPIKey(c *gin.Context) {
 		"api_key_masked": maskedAPIKey,
 		"found":          true,
 	})
+}
+
+func aggregatePublicAPISnapshots(items map[string]usage.APISnapshot, keys []string) (usage.APISnapshot, bool) {
+	result := usage.APISnapshot{Models: make(map[string]usage.ModelSnapshot)}
+	found := false
+	for _, key := range keys {
+		item, ok := items[key]
+		if !ok {
+			continue
+		}
+		found = true
+		result.TotalRequests += item.TotalRequests
+		result.TotalTokens += item.TotalTokens
+		for model, stats := range item.Models {
+			merged := result.Models[model]
+			merged.TotalRequests += stats.TotalRequests
+			merged.TotalTokens += stats.TotalTokens
+			result.Models[model] = merged
+		}
+	}
+	return result, found
 }
 
 // ImportUsageStatistics merges a previously exported usage snapshot into memory.

--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -158,12 +158,13 @@ func (h *UsageLogsHandler) GetPublicUsageLogs(c *gin.Context) {
 		c.JSON(status, gin.H{"error": message})
 		return
 	}
-	if req.APIKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+	subject, ok := h.resolvePublicUsageSubject(c, req.APIKey)
+	if !ok {
 		return
 	}
-	payload, err := h.serviceForTenant(usage.ResolveAPIKeyTenant(req.APIKey)).PublicUsageLogs(managementusagelogs.PublicLogQueryInput{
-		APIKey:          req.APIKey,
+	payload, err := h.serviceForTenant(subject.TenantID).PublicUsageLogs(managementusagelogs.PublicLogQueryInput{
+		APIKey:          subject.APIKey,
+		EndUserID:       subject.EndUserID,
 		Models:          req.Models,
 		Channels:        req.Channels,
 		Statuses:        req.Statuses,
@@ -189,11 +190,18 @@ func (h *UsageLogsHandler) GetPublicUsageChartData(c *gin.Context) {
 		c.JSON(status, gin.H{"error": message})
 		return
 	}
-	if req.APIKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+	subject, ok := h.resolvePublicUsageSubject(c, req.APIKey)
+	if !ok {
 		return
 	}
-	payload, err := h.serviceForTenant(usage.ResolveAPIKeyTenant(req.APIKey)).PublicChartData(req.APIKey, req.Days)
+	service := h.serviceForTenant(subject.TenantID)
+	var payload map[string]any
+	var err error
+	if subject.EndUserID != "" {
+		payload, err = service.PublicChartDataForEndUser(subject.EndUserID, req.Days)
+	} else {
+		payload, err = service.PublicChartData(subject.APIKey, req.Days)
+	}
 	if err != nil {
 		log.Warnf("management usage logs: public chart data failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -210,15 +218,20 @@ func (h *UsageLogsHandler) GetPublicLogContent(c *gin.Context) {
 		c.JSON(status, gin.H{"error": message})
 		return
 	}
-	if req.APIKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+	subject, ok := h.resolvePublicUsageSubject(c, req.APIKey)
+	if !ok {
 		return
 	}
 	id, ok := parseLogID(c)
 	if !ok {
 		return
 	}
-	renderLogContentResponse(c, h.serviceForTenant(usage.ResolveAPIKeyTenant(req.APIKey)).PublicLogContent(id, req.APIKey, req.Part, req.Format))
+	service := h.serviceForTenant(subject.TenantID)
+	if subject.EndUserID != "" {
+		renderLogContentResponse(c, service.PublicLogContentForEndUser(id, subject.EndUserID, req.Part, req.Format))
+		return
+	}
+	renderLogContentResponse(c, service.PublicLogContent(id, subject.APIKey, req.Part, req.Format))
 }
 
 // GetUsageChartData returns pre-aggregated chart data for the management portal.

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -1967,3 +1967,70 @@ func TestGetUsageLogsFiltersByOrphanAuthIndexWithoutLiveMeta(t *testing.T) {
 		t.Fatalf("orphan filter missing alias rows: %#v", filtered.Items)
 	}
 }
+
+func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	tenantID := "00000000-0000-0000-0000-0000000000ac"
+	endUserID := "00000000-0000-0000-0000-0000000000bd"
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, row := range []usage.APIKeyRow{
+		{ID: "00000000-0000-0000-0000-0000000000a2", Key: "sk-owned-log-a", Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: "00000000-0000-0000-0000-0000000000b2", Key: "sk-owned-log-b", Name: "Automation", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
+		}
+		usage.InsertLog(row.Key, row.Name, "gpt-test", "test", "channel", "auth", false, time.Now().UTC(), 1, 0, usage.TokenStats{TotalTokens: 1}, "", "")
+	}
+
+	h := &Handler{cfg: &config.Config{}}
+	body := []byte(`{"api_key":"sk-owned-log-b","days":7,"page":1,"size":50}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/public/usage/logs", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.UsageLogs().GetPublicUsageLogs(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload struct {
+		Total int64 `json:"total"`
+		Items []struct {
+			APIKey        string `json:"api_key"`
+			APIKeyID      string `json:"api_key_id"`
+			APIKeyMasked  string `json:"api_key_masked"`
+			APIKeyOwnName string `json:"api_key_own_name"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload.Total != 2 || len(payload.Items) != 2 {
+		t.Fatalf("public logs total/items = %d/%d, want 2/2", payload.Total, len(payload.Items))
+	}
+	for _, item := range payload.Items {
+		if item.APIKey != "" || item.APIKeyID != "" {
+			t.Fatalf("public item leaked raw key identity: %+v", item)
+		}
+		if item.APIKeyMasked == "" {
+			t.Fatalf("public item missing masked key fallback: %+v", item)
+		}
+		if item.APIKeyOwnName != "Laptop" && item.APIKeyOwnName != "Automation" {
+			t.Fatalf("api_key_own_name = %q, want concrete key name", item.APIKeyOwnName)
+		}
+	}
+}

--- a/internal/api/handlers/management/usage_summary_public.go
+++ b/internal/api/handlers/management/usage_summary_public.go
@@ -1,12 +1,10 @@
 package management
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
 	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	log "github.com/sirupsen/logrus"
@@ -41,51 +39,35 @@ type usageLimitsBody struct {
 // `found` reflects API Key existence (not disabled), not whether it was used today.
 // When the key has daily/total/spending limits, `limits` includes only those fields.
 func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
-	apiKey := ""
-	var req publicLookupRequest
-
-	if c.Request.Method == http.MethodPost {
-		body, err := bodyutil.ReadRequestBody(c, publicLookupBodyLimit)
-		if err != nil {
-			if bodyutil.IsTooLarge(err) {
-				c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
-				return
-			}
-			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
-			return
-		}
-		if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
-			if err := json.Unmarshal(body, &req); err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json body"})
-				return
-			}
-		}
-		apiKey = strings.TrimSpace(req.APIKey)
+	req, status, message := readPublicLookupRequest(c)
+	if message != "" {
+		c.JSON(status, gin.H{"error": message})
+		return
 	}
-
-	if apiKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key parameter is required"})
+	subject, ok := h.resolvePublicUsageSubject(c, req.APIKey)
+	if !ok {
 		return
 	}
 
-	// Public summary is unauthenticated and only receives the raw API key.
-	// Resolve the key's tenant first so multi-tenant deployments do not query
-	// the system catalog (which would always return found=false / zero stats).
-	// End-user-owned keys share one account pool — aggregate all keys of the owner.
-	tenantID := usage.ResolveAPIKeyTenant(apiKey)
-	stats, err := usage.QueryStats(usage.LogQueryParams{
-		TenantID: tenantID,
-		APIKeys:  usage.ExpandPublicLookupAPIKeys(apiKey),
-		Days:     1,
-	})
+	stats, err := usage.QueryStats(subject.logQueryParams(1))
 	if err != nil {
 		log.Warnf("management usage logs: public usage summary query failed: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query usage summary"})
 		return
 	}
 
-	row := apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID)).GetRow(apiKey)
-	found := row != nil && !row.Disabled
+	row := subject.APIKeyRow
+	if row == nil && subject.APIKey != "" {
+		row = apikeysettings.NewService(nil, apikeysettings.WithTenantID(subject.TenantID)).GetRow(subject.APIKey)
+	}
+	found := subject.EndUserID != "" && subject.APIKey == ""
+	if subject.APIKey != "" {
+		found = row != nil && !row.Disabled
+	}
+	limits := buildPublicUsageLimits(subject.APIKey, row)
+	if subject.EndUserID != "" {
+		limits = buildEndUserUsageLimits(subject.EndUserID)
+	}
 
 	resp := usageSummaryResponse{
 		Found: found,
@@ -94,9 +76,55 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 			TotalCalls: stats.Total,
 			QuotaCost:  stats.TotalCost,
 		},
-		Limits: buildPublicUsageLimits(apiKey, row),
+		Limits: limits,
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+func buildEndUserUsageLimits(endUserID string) *usageLimitsBody {
+	quota := usage.GetEndUserQuota(endUserID)
+	if quota == nil {
+		return nil
+	}
+	effective := usage.EffectiveEndUserQuota(*quota)
+	out := &usageLimitsBody{}
+	has := false
+	if effective.DailyLimit > 0 {
+		has = true
+		limit := effective.DailyLimit
+		out.DailyLimit = &limit
+		if n, err := usage.CountTodayByEndUser(endUserID); err == nil {
+			out.DailyUsed = &n
+		}
+	}
+	if effective.TotalQuota > 0 {
+		has = true
+		limit := effective.TotalQuota
+		out.TotalQuota = &limit
+		if n, err := usage.CountTotalByEndUser(endUserID); err == nil {
+			out.TotalUsed = &n
+		}
+	}
+	if effective.SpendingLimit > 0 {
+		has = true
+		limit := effective.SpendingLimit
+		out.SpendingLimit = &limit
+		if n, err := usage.QueryTotalCostByEndUser(endUserID); err == nil {
+			out.SpendingUsed = &n
+		}
+	}
+	if effective.DailySpendingLimit > 0 {
+		has = true
+		limit := effective.DailySpendingLimit
+		out.DailySpendingLimit = &limit
+		if n, err := usage.QueryTodayCostByEndUser(endUserID); err == nil {
+			out.DailySpendingUsed = &n
+		}
+	}
+	if !has {
+		return nil
+	}
+	return out
 }
 
 func buildPublicUsageLimits(apiKey string, row *usage.APIKeyRow) *usageLimitsBody {

--- a/internal/api/handlers/management/usage_summary_public_test.go
+++ b/internal/api/handlers/management/usage_summary_public_test.go
@@ -337,12 +337,13 @@ func TestGetPublicUsageSummary_ResolvesBusinessTenant(t *testing.T) {
 		"", "",
 	)
 
-	// Sanity: system-tenant lookup must not see this key (precondition of the bug).
-	if row := usage.GetAPIKey(apiKey); row != nil {
-		t.Fatalf("precondition failed: GetAPIKey (system tenant) unexpectedly found business key")
+	// Regression guard: public secret lookup discovers the owning tenant globally,
+	// while the explicit tenant-scoped lookup still resolves the same row.
+	if row := usage.GetAPIKey(apiKey); row == nil || row.TenantID != tenantID {
+		t.Fatalf("GetAPIKey = %#v, want business tenant key", row)
 	}
 	if row := usage.GetAPIKeyForTenant(tenantID, apiKey); row == nil {
-		t.Fatalf("precondition failed: business tenant key missing")
+		t.Fatalf("business tenant key missing")
 	}
 
 	body := []byte(`{"api_key":"` + apiKey + `"}`)
@@ -374,5 +375,50 @@ func TestGetPublicUsageSummary_ResolvesBusinessTenant(t *testing.T) {
 	}
 	if got.Stats.TotalCalls != 2 {
 		t.Errorf("total_calls = %d, want 2", got.Stats.TotalCalls)
+	}
+}
+
+func TestGetPublicUsageSummary_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupUsageSummaryTestDB(t)
+
+	tenantID := "00000000-0000-0000-0000-0000000000ab"
+	endUserID := "00000000-0000-0000-0000-0000000000bc"
+	keyA := "sk-business-owned-a"
+	keyB := "sk-business-owned-b"
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, row := range []usage.APIKeyRow{
+		{ID: "00000000-0000-0000-0000-0000000000a1", Key: keyA, Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: "00000000-0000-0000-0000-0000000000b1", Key: keyB, Name: "Automation", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
+		}
+		insertTestLog(t, row.Key)
+	}
+
+	body := []byte(`{"api_key":"` + keyB + `"}`)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/public/usage/summary", bytes.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h := NewHandler(&config.Config{}, "", nil)
+	h.GetPublicUsageSummary(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var got struct {
+		Found bool `json:"found"`
+		Stats struct {
+			TotalCalls int64 `json:"total_calls"`
+		} `json:"stats"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.Found || got.Stats.TotalCalls != 2 {
+		t.Fatalf("summary = %+v, want found and two account calls", got)
 	}
 }

--- a/internal/api/routes/management_identity_routes.go
+++ b/internal/api/routes/management_identity_routes.go
@@ -53,6 +53,7 @@ func registerManagementIdentityRoutes(group *gin.RouterGroup, h *managementhandl
 	group.PATCH("/end-users/:id", h.PatchEndUser)
 	group.DELETE("/end-users/:id", h.DeleteEndUser)
 	group.POST("/end-users/:id/reset-password", h.PostEndUserResetPassword)
+	group.POST("/end-users/:id/daily-spending/reset", h.PostEndUserDailySpendingReset)
 	group.GET("/end-users/:id/api-keys", h.GetEndUserAPIKeys)
 	group.POST("/end-users/:id/api-keys", h.PostEndUserAPIKey)
 	group.DELETE("/end-users/:id/api-keys/:key_id", h.DeleteEndUserAPIKey)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 288; got != want {
+	if got, want := len(routes), 289; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -215,6 +215,7 @@ func expectedManagementRoutes() []string {
 		"PATCH /v0/management/end-users/:id",
 		"DELETE /v0/management/end-users/:id",
 		"POST /v0/management/end-users/:id/reset-password",
+		"POST /v0/management/end-users/:id/daily-spending/reset",
 		"GET /v0/management/end-users/:id/api-keys",
 		"POST /v0/management/end-users/:id/api-keys",
 		"DELETE /v0/management/end-users/:id/api-keys/:key_id",

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -686,21 +686,25 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 			return User{}, err
 		}
 	}
-	if status != nil && *status != "active" {
-		if _, err = tx.ExecContext(ctx, `
-			UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'status_change'
-			WHERE end_user_id = ? AND revoked_at IS NULL
-		`, userID); err != nil {
-			return User{}, err
+	if status != nil {
+		if *status != "active" {
+			if _, err = tx.ExecContext(ctx, `
+					UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'status_change'
+					WHERE end_user_id = ? AND revoked_at IS NULL
+				`, userID); err != nil {
+				return User{}, err
+			}
 		}
-		// Disable owned keys while user is disabled/locked. Key-level disabled is not
-		// restored automatically on re-enable (admin re-enables keys explicitly if needed).
-		if *status == "disabled" || *status == "locked" {
+		if *status == "active" || *status == "disabled" || *status == "locked" {
+			disabled := 1
+			if *status == "active" {
+				disabled = 0
+			}
 			now := time.Now().UTC().Format(time.RFC3339)
 			if _, err = tx.ExecContext(ctx, `
-				UPDATE api_keys SET disabled = 1, updated_at = ?
-				WHERE tenant_id = ? AND end_user_id = ?
-			`, now, tenantID, userID); err != nil {
+					UPDATE api_keys SET disabled = ?, updated_at = ?
+					WHERE tenant_id = ? AND end_user_id = ?
+				`, disabled, now, tenantID, userID); err != nil {
 				return User{}, err
 			}
 		}

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -686,27 +686,14 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 			return User{}, err
 		}
 	}
-	if status != nil {
-		if *status != "active" {
-			if _, err = tx.ExecContext(ctx, `
-					UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'status_change'
-					WHERE end_user_id = ? AND revoked_at IS NULL
-				`, userID); err != nil {
-				return User{}, err
-			}
-		}
-		if *status == "active" || *status == "disabled" || *status == "locked" {
-			disabled := 1
-			if *status == "active" {
-				disabled = 0
-			}
-			now := time.Now().UTC().Format(time.RFC3339)
-			if _, err = tx.ExecContext(ctx, `
-					UPDATE api_keys SET disabled = ?, updated_at = ?
-					WHERE tenant_id = ? AND end_user_id = ?
-				`, disabled, now, tenantID, userID); err != nil {
-				return User{}, err
-			}
+	// Account freeze/activate is end_users.status only. Do not bulk-toggle api_keys.disabled:
+	// that would wipe per-key admin disables on re-activate. Auth refuses non-active accounts.
+	if status != nil && *status != "active" {
+		if _, err = tx.ExecContext(ctx, `
+				UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'status_change'
+				WHERE end_user_id = ? AND revoked_at IS NULL
+			`, userID); err != nil {
+			return User{}, err
 		}
 	}
 	if err = tx.Commit(); err != nil {

--- a/internal/enduser/types.go
+++ b/internal/enduser/types.go
@@ -18,6 +18,8 @@ type User struct {
 	Version            int64      `json:"version"`
 	// APIKeyCount is filled on list; 0 means unknown/none.
 	APIKeyCount int `json:"api_key_count,omitempty"`
+	// DailySpendingUsed is the account-level effective spend for the current project day.
+	DailySpendingUsed float64 `json:"daily-spending-used"`
 
 	// Account-level quota/permissions: shared by every API key under this user.
 	PermissionProfileID  string   `json:"permission-profile-id,omitempty"`

--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -17,6 +17,21 @@ func (s *Service) PublicChartData(apiKey string, days int) (map[string]any, erro
 	}, nil
 }
 
+func (s *Service) PublicChartDataForEndUser(endUserID string, days int) (map[string]any, error) {
+	chartData, err := usage.QueryPublicChartDataForEndUser(s.tenantID, endUserID, days)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"daily_series":       chartData.DailySeries,
+		"heatmap_series":     chartData.HeatmapSeries,
+		"model_distribution": chartData.ModelDistribution,
+		"stats":              chartData.Stats,
+		"api_key_name":       usage.DisplayNameForEndUser(endUserID),
+	}, nil
+}
+
 func (s *Service) UsageChartData(apiKey string, days int) (map[string]any, error) {
 	daily, err := usage.QueryDailySeriesForTenant(s.tenantID, apiKey, days)
 	if err != nil {

--- a/internal/management/usagelogs/content.go
+++ b/internal/management/usagelogs/content.go
@@ -120,3 +120,46 @@ func (s *Service) PublicLogContent(id int64, apiKey, part, format string) LogCon
 
 	return LogContentResponse{Status: http.StatusOK, Payload: result}
 }
+
+func (s *Service) PublicLogContentForEndUser(id int64, endUserID, part, format string) LogContentResponse {
+	if part == "details" {
+		return LogContentResponse{Status: http.StatusForbidden, Payload: map[string]any{"error": "request details are only available in the management API"}}
+	}
+	if format == "text" && part == "both" {
+		return LogContentResponse{Status: http.StatusBadRequest, Payload: map[string]any{"error": "format=text requires part=input or part=output"}}
+	}
+	if part == "both" {
+		result, err := usage.QueryLogContentForEndUser(s.tenantID, endUserID, id)
+		if err != nil {
+			if strings.Contains(err.Error(), "no rows") {
+				return LogContentResponse{Status: http.StatusNotFound, Payload: map[string]any{"error": "log entry not found"}}
+			}
+			return LogContentResponse{Status: http.StatusInternalServerError, Payload: map[string]any{"error": err.Error()}}
+		}
+		return LogContentResponse{Status: http.StatusOK, Payload: result}
+	}
+
+	result, err := usage.QueryLogContentPartForEndUser(s.tenantID, endUserID, id, part)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return LogContentResponse{Status: http.StatusNotFound, Payload: map[string]any{"error": "log entry not found"}}
+		}
+		return LogContentResponse{Status: http.StatusInternalServerError, Payload: map[string]any{"error": err.Error()}}
+	}
+	if format == "text" {
+		headers := map[string]string{
+			"X-Log-Id":   strconv.FormatInt(result.ID, 10),
+			"X-Log-Part": result.Part,
+		}
+		if strings.TrimSpace(result.Model) != "" {
+			headers["X-Model"] = result.Model
+		}
+		return LogContentResponse{
+			Status:      http.StatusOK,
+			ContentType: "text/plain; charset=utf-8",
+			Headers:     headers,
+			Text:        result.Content,
+		}
+	}
+	return LogContentResponse{Status: http.StatusOK, Payload: result}
+}

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -153,14 +153,12 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		maps.authIndexesBySubject,
 		maps.authMetaBySubject,
 	)
-	// Portal multi-key accounts share one quota pool; public lookup aggregates all owned keys.
-	lookupKeys := usage.ExpandPublicLookupAPIKeys(input.APIKey)
 	params := usage.LogQueryParams{
-		TenantID:              usage.ResolveAPIKeyTenant(input.APIKey),
+		TenantID:              s.tenantID,
+		EndUserID:             strings.TrimSpace(input.EndUserID),
 		Page:                  input.Page,
 		Size:                  input.Size,
 		Days:                  input.Days,
-		APIKeys:               lookupKeys,
 		Models:                input.Models,
 		Statuses:              input.Statuses,
 		MatchNoModels:         input.MatchNoModels,
@@ -170,6 +168,10 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		AuthIndexes:           authIndexes,
 		ChannelNames:          channelNames,
 		AuthIndexChannelNames: authIndexChannelNames,
+	}
+	if params.EndUserID == "" {
+		params.TenantID = usage.ResolveAPIKeyTenant(input.APIKey)
+		params.APIKeys = usage.ExpandPublicLookupAPIKeys(input.APIKey)
 	}
 
 	result, err := usage.QueryLogs(params)
@@ -186,22 +188,38 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 	}
 
 	apiKeyName := s.publicAPIKeyName(input.APIKey)
+	if params.EndUserID != "" {
+		apiKeyName = usage.DisplayNameForEndUser(params.EndUserID)
+	}
 	for i := range result.Items {
-		// Prefer the key's own name so multi-key accounts can tell rows apart.
-		keyOwnName := usage.ResolveAPIKeyOwnName(result.Items[i].APIKey)
+		keyOwnName := strings.TrimSpace(result.Items[i].APIKeyOwnName)
+		if keyOwnName == "" {
+			keyOwnName = usage.ResolveAPIKeyOwnName(result.Items[i].APIKey)
+		}
 		if keyOwnName == "" {
 			keyOwnName = strings.TrimSpace(result.Items[i].APIKeyName)
 		}
+		userName := strings.TrimSpace(result.Items[i].EndUserDisplayName)
+		if userName == "" && params.EndUserID != "" {
+			userName = apiKeyName
+		}
+		if userName == "" {
+			userName = keyOwnName
+		}
 		if apiKeyName == "" {
-			apiKeyName = keyOwnName
+			apiKeyName = userName
 		}
 		channelName := displayChannelNameForLog(result.Items[i], maps.channelNameMap, maps.authIndexChannelMap, maps.ambiguousAuthIndexChannelMap)
+		result.Items[i].APIKeyMasked = maskPublicAPIKey(result.Items[i].APIKey)
 		result.Items[i].Source = ""
 		result.Items[i].AuthIndex = ""
 		result.Items[i].AuthSubjectID = ""
 		result.Items[i].ChannelName = channelName
 		result.Items[i].APIKey = ""
-		result.Items[i].APIKeyName = keyOwnName
+		result.Items[i].APIKeyID = ""
+		result.Items[i].APIKeyName = userName
+		result.Items[i].EndUserDisplayName = userName
+		result.Items[i].APIKeyOwnName = keyOwnName
 		// Keep provider/auth_type for public UI badges, but strip identity keys above.
 		enrichLogRowChannelMeta(&result.Items[i], maps.authMetaByIndex, maps.authMetaBySubject)
 		result.Items[i].AuthIndex = ""
@@ -254,6 +272,20 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 			"statuses":        filters.Statuses,
 		},
 	}, nil
+}
+
+func maskPublicAPIKey(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if len(value) <= 10 {
+		if len(value) <= 4 {
+			return "***"
+		}
+		return value[:2] + "***" + value[len(value)-2:]
+	}
+	return value[:6] + "***" + value[len(value)-4:]
 }
 
 type authChannelMeta struct {

--- a/internal/management/usagelogs/types.go
+++ b/internal/management/usagelogs/types.go
@@ -18,6 +18,7 @@ type ManagementLogQueryInput struct {
 
 type PublicLogQueryInput struct {
 	APIKey          string
+	EndUserID       string
 	Models          []string
 	Channels        []string
 	Statuses        []string

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -27,8 +27,23 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607170003_end_users_and_tokens", SQL: endUsersAndTokensSQL},
 		// Account-level quota/permissions: shared across all API keys of an end user.
 		{Version: "202607190001_end_user_account_quota", SQL: endUserAccountQuotaSQL},
+		// Account-level same-day spending reset baseline for end-user quota pools.
+		{Version: "202607190002_end_user_daily_spending_resets", SQL: endUserDailySpendingResetsSQL},
 	}
 }
+
+const endUserDailySpendingResetsSQL = `
+CREATE TABLE IF NOT EXISTS end_user_daily_spending_resets (
+  tenant_id     UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+  end_user_id   UUID NOT NULL,
+  day_key       TEXT NOT NULL DEFAULT '',
+  cost_baseline DOUBLE PRECISION NOT NULL DEFAULT 0,
+  reset_at      TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (tenant_id, end_user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_end_user_daily_spending_resets_day
+  ON end_user_daily_spending_resets(tenant_id, day_key);
+`
 
 // Quota + permission template live on end_users so multiple keys share one pool.
 // Backfill from each user's default key (or earliest key) then zero owned key limits

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -7,10 +7,21 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 17 {
-		t.Fatalf("RuntimeMigrations len = %d, want 17", len(migrations))
+	if len(migrations) != 18 {
+		t.Fatalf("RuntimeMigrations len = %d, want 18", len(migrations))
 	}
-	// Latest: account-level quota on end_users.
+	// Latest: account-level daily spending reset baselines.
+	endUserResetSQL := migrations[17].SQL
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS end_user_daily_spending_resets",
+		"cost_baseline",
+		"day_key",
+	} {
+		if !strings.Contains(endUserResetSQL, fragment) {
+			t.Fatalf("end-user daily spending reset migration missing %q", fragment)
+		}
+	}
+	// Prior: account-level quota on end_users.
 	accountQuotaSQL := migrations[16].SQL
 	for _, fragment := range []string{
 		"end_users ADD COLUMN IF NOT EXISTS permission_profile_id",

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -266,6 +266,31 @@ func (s Store) Get(key string) *APIKeyRow {
 	return entry
 }
 
+// GetAnyTenant resolves a globally unique API key secret without assuming the
+// system tenant. Public authentication starts from the presented secret, so
+// tenant scope can only be applied after this lookup succeeds.
+func (s Store) GetAnyTenant(key string) *APIKeyRow {
+	if s.db == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return nil
+	}
+
+	row := s.db.QueryRow(`SELECT tenant_id, key, name, disabled, id, daily_limit, total_quota,
+		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
+		end_user_id, is_default
+		FROM api_keys WHERE key = ?`, trimmed)
+	entry, ok := scanAPIKeyRowWithTenant(row)
+	if !ok {
+		return nil
+	}
+	return entry
+}
+
 func (s Store) GetByID(id string) *APIKeyRow {
 	if s.db == nil {
 		return nil
@@ -286,6 +311,30 @@ func (s Store) GetByID(id string) *APIKeyRow {
 		return nil
 	}
 	entry.TenantID = s.tenantID
+	return entry
+}
+
+// GetByIDAnyTenant resolves a globally unique stable key id without assuming
+// the system tenant.
+func (s Store) GetByIDAnyTenant(id string) *APIKeyRow {
+	if s.db == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return nil
+	}
+
+	row := s.db.QueryRow(`SELECT tenant_id, key, name, disabled, id, daily_limit, total_quota,
+		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
+		end_user_id, is_default
+		FROM api_keys WHERE id = ?`, trimmed)
+	entry, ok := scanAPIKeyRowWithTenant(row)
+	if !ok {
+		return nil
+	}
 	return entry
 }
 

--- a/internal/storage/sqlite/apikey/store_tenant_test.go
+++ b/internal/storage/sqlite/apikey/store_tenant_test.go
@@ -39,6 +39,34 @@ func TestStoreTenantIsolation(t *testing.T) {
 	}
 }
 
+func TestStoreAnyTenantLookupFindsGloballyUniqueKeyAndID(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	InitTable(db)
+
+	const tenantID = "00000000-0000-0000-0000-00000000000a"
+	business := NewTenantStore(db, tenantID)
+	if err := business.Upsert(APIKeyRow{ID: "business-id", Key: "sk-business", Name: "Business"}); err != nil {
+		t.Fatalf("business upsert: %v", err)
+	}
+
+	system := NewStore(db)
+	if got := system.Get("sk-business"); got != nil {
+		t.Fatalf("tenant-scoped system lookup leaked business key: %#v", got)
+	}
+	if got := system.GetAnyTenant("sk-business"); got == nil || got.TenantID != tenantID || got.ID != "business-id" {
+		t.Fatalf("GetAnyTenant = %#v, want business tenant row", got)
+	}
+	if got := system.GetByIDAnyTenant("business-id"); got == nil || got.TenantID != tenantID || got.Key != "sk-business" {
+		t.Fatalf("GetByIDAnyTenant = %#v, want business tenant row", got)
+	}
+}
+
 func TestReplaceAllPreservesOwnershipAndRejectsLastKeyDrop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usage/api_key_identity.go
+++ b/internal/usage/api_key_identity.go
@@ -19,11 +19,10 @@ func ResolveAPIKeyIdentity(key string) *APIKeyIdentity {
 	if row == nil || strings.TrimSpace(row.ID) == "" {
 		return nil
 	}
-	name := ResolveAPIKeyDisplayName(row, row.Name)
 	return &APIKeyIdentity{
 		ID:   strings.TrimSpace(row.ID),
 		Key:  strings.TrimSpace(row.Key),
-		Name: name,
+		Name: strings.TrimSpace(row.Name),
 	}
 }
 

--- a/internal/usage/apikey_db.go
+++ b/internal/usage/apikey_db.go
@@ -171,14 +171,16 @@ func ListAllAPIKeys() []APIKeyRow {
 	return apiKeyStore().ListAll()
 }
 
-// GetAPIKey retrieves a single API key entry by key string.
+// GetAPIKey retrieves a single API key entry by globally unique key string.
+// The secret is the input used to discover tenant scope, so this lookup must
+// not be pinned to the system tenant.
 func GetAPIKey(key string) *APIKeyRow {
-	return apiKeyStore().Get(key)
+	return apiKeyStore().GetAnyTenant(key)
 }
 
-// GetAPIKeyByID retrieves a single API key entry by stable id.
+// GetAPIKeyByID retrieves a single API key entry by globally unique stable id.
 func GetAPIKeyByID(id string) *APIKeyRow {
-	return apiKeyStore().GetByID(id)
+	return apiKeyStore().GetByIDAnyTenant(id)
 }
 
 // UpsertAPIKey inserts or updates an API key entry.

--- a/internal/usage/enduser_account_usage_test.go
+++ b/internal/usage/enduser_account_usage_test.go
@@ -1,0 +1,206 @@
+package usage
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func setupEndUserAccountUsageTestDB(t *testing.T) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "enduser-account-usage-*.db")
+	if err != nil {
+		t.Fatalf("create temp db: %v", err)
+	}
+	dbPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() {
+		CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	if _, err := getDB().Exec(`
+		CREATE TABLE IF NOT EXISTS end_users (
+			id TEXT PRIMARY KEY,
+			tenant_id TEXT NOT NULL,
+			display_name TEXT NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+	if err := EnsureEndUserQuotaColumns(getDB()); err != nil {
+		t.Fatalf("EnsureEndUserQuotaColumns: %v", err)
+	}
+}
+
+func insertEndUserAccountLog(t *testing.T, tenantID, apiKey, apiKeyID, apiKeyName string, cost float64) {
+	t.Helper()
+	_, err := getDB().Exec(`
+		INSERT INTO request_logs (
+			tenant_id, timestamp, api_key, api_key_id, api_key_name, model, source,
+			failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens,
+			reasoning_tokens, cached_tokens, total_tokens, cost
+		) VALUES (?, ?, ?, ?, ?, 'gpt-test', 'test', 0, 0, 1, 0, 1, 1, 0, 0, 2, ?)
+	`, tenantID, CutoffStartUTC(1).Add(time.Hour).Format(time.RFC3339), apiKey, apiKeyID, apiKeyName, cost)
+	if err != nil {
+		t.Fatalf("insert request log: %v", err)
+	}
+}
+
+func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *testing.T) {
+	setupEndUserAccountUsageTestDB(t)
+
+	tenantID := uuid.NewString()
+	endUserID := uuid.NewString()
+	otherUserID := uuid.NewString()
+	keyAID := uuid.NewString()
+	keyBID := uuid.NewString()
+	otherKeyID := uuid.NewString()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	if _, err := getDB().Exec(`INSERT INTO end_users (id, tenant_id, display_name) VALUES (?, ?, ?)`, endUserID, tenantID, "Zhang Bolun"); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
+	for _, row := range []APIKeyRow{
+		{ID: keyAID, Key: "sk-business-a", Name: "Automation", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: keyBID, Key: "sk-business-b", Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: otherKeyID, Key: "sk-business-other", Name: "Other", EndUserID: otherUserID, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
+		}
+	}
+
+	if row := GetAPIKey("sk-business-a"); row == nil || row.TenantID != tenantID || row.ID != keyAID {
+		t.Fatalf("GetAPIKey = %#v, want business-tenant key A", row)
+	}
+	if row := GetAPIKeyByID(keyBID); row == nil || row.TenantID != tenantID || row.Key != "sk-business-b" {
+		t.Fatalf("GetAPIKeyByID = %#v, want business-tenant key B", row)
+	}
+	expanded := ExpandPublicLookupAPIKeys("sk-business-a")
+	if len(expanded) != 2 || !containsString(expanded, "sk-business-a") || !containsString(expanded, "sk-business-b") {
+		t.Fatalf("ExpandPublicLookupAPIKeys = %v, want both owned keys", expanded)
+	}
+
+	// Modern rows match stable key ids; the legacy row matches the current raw secret.
+	insertEndUserAccountLog(t, tenantID, "sk-business-a", keyAID, "old snapshot", 1)
+	insertEndUserAccountLog(t, tenantID, "sk-business-b", keyBID, "old snapshot", 2)
+	insertEndUserAccountLog(t, tenantID, "sk-business-b", "", "legacy snapshot", 3)
+	insertEndUserAccountLog(t, tenantID, "sk-business-other", otherKeyID, "other", 50)
+
+	params := LogQueryParams{TenantID: tenantID, EndUserID: endUserID, Page: 1, Size: 20, Days: 1}
+	result, err := QueryLogs(params)
+	if err != nil {
+		t.Fatalf("QueryLogs: %v", err)
+	}
+	if result.Total != 3 || len(result.Items) != 3 {
+		t.Fatalf("account logs total/items = %d/%d, want 3/3", result.Total, len(result.Items))
+	}
+	for _, item := range result.Items {
+		if item.EndUserDisplayName != "Zhang Bolun" {
+			t.Fatalf("end_user_display_name = %q, want Zhang Bolun", item.EndUserDisplayName)
+		}
+		if item.APIKeyOwnName != "Automation" && item.APIKeyOwnName != "Laptop" {
+			t.Fatalf("api_key_own_name = %q, want live key own name", item.APIKeyOwnName)
+		}
+	}
+	stats, err := QueryStats(params)
+	if err != nil {
+		t.Fatalf("QueryStats: %v", err)
+	}
+	if stats.Total != 3 || stats.TotalCost != 6 {
+		t.Fatalf("account stats = %+v, want total=3 cost=6", stats)
+	}
+	chart, err := QueryPublicChartData("sk-business-a", 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartData: %v", err)
+	}
+	if chart.Stats.Total != 3 || chart.Stats.TotalCost != 6 {
+		t.Fatalf("public chart stats = %+v, want total=3 cost=6", chart.Stats)
+	}
+
+	// Rotate changes only the secret. Stable-id rows remain in the account selector.
+	if _, err := getDB().Exec(`UPDATE api_keys SET key = ?, updated_at = ? WHERE tenant_id = ? AND id = ?`, "sk-business-a-rotated", now, tenantID, keyAID); err != nil {
+		t.Fatalf("rotate key A: %v", err)
+	}
+	if row := GetAPIKey("sk-business-a-rotated"); row == nil || row.ID != keyAID {
+		t.Fatalf("rotated lookup = %#v, want stable id %s", row, keyAID)
+	}
+	rotatedResult, err := QueryLogs(params)
+	if err != nil {
+		t.Fatalf("QueryLogs after rotate: %v", err)
+	}
+	if rotatedResult.Total != 3 {
+		t.Fatalf("account logs after rotate = %d, want 3", rotatedResult.Total)
+	}
+	rotatedChart, err := QueryPublicChartData("sk-business-a-rotated", 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartData after rotate: %v", err)
+	}
+	if rotatedChart.Stats.Total != 3 || rotatedChart.Stats.TotalCost != 6 {
+		t.Fatalf("chart after rotate = %+v, want total=3 cost=6", rotatedChart.Stats)
+	}
+}
+
+func TestResetTodayCostByEndUserUsesAccountBaselineWithoutDeletingLogs(t *testing.T) {
+	setupEndUserAccountUsageTestDB(t)
+
+	tenantID := uuid.NewString()
+	endUserID := uuid.NewString()
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, row := range []APIKeyRow{
+		{ID: uuid.NewString(), Key: "sk-reset-a", Name: "A", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.NewString(), Key: "sk-reset-b", Name: "B", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("upsert %s: %v", row.Key, err)
+		}
+		insertEndUserAccountLog(t, tenantID, row.Key, row.ID, row.Name, 2.5)
+	}
+
+	before, err := QueryTodayEffectiveCostByEndUserForTenant(tenantID, endUserID)
+	if err != nil || before != 5 {
+		t.Fatalf("effective before reset = %v, %v; want 5, nil", before, err)
+	}
+	usedBefore, rawToday, err := ResetTodayCostByEndUser(tenantID, endUserID)
+	if err != nil {
+		t.Fatalf("ResetTodayCostByEndUser: %v", err)
+	}
+	if usedBefore != 5 || rawToday != 5 {
+		t.Fatalf("reset result used/raw = %v/%v, want 5/5", usedBefore, rawToday)
+	}
+	after, err := QueryTodayEffectiveCostByEndUserForTenant(tenantID, endUserID)
+	if err != nil || after != 0 {
+		t.Fatalf("effective after reset = %v, %v; want 0, nil", after, err)
+	}
+	var logCount int
+	if err := getDB().QueryRow(`SELECT COUNT(*) FROM request_logs WHERE tenant_id = ?`, tenantID).Scan(&logCount); err != nil {
+		t.Fatalf("count logs: %v", err)
+	}
+	if logCount != 2 {
+		t.Fatalf("logs after reset = %d, want 2 (baseline must not delete history)", logCount)
+	}
+
+	row := GetAPIKey("sk-reset-a")
+	insertEndUserAccountLog(t, tenantID, row.Key, row.ID, row.Name, 1.25)
+	incremental, err := QueryTodayEffectiveCostByEndUserForTenant(tenantID, endUserID)
+	if err != nil || incremental != 1.25 {
+		t.Fatalf("effective after new request = %v, %v; want 1.25, nil", incremental, err)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/usage/enduser_account_usage_test.go
+++ b/internal/usage/enduser_account_usage_test.go
@@ -30,7 +30,8 @@ func setupEndUserAccountUsageTestDB(t *testing.T) {
 		CREATE TABLE IF NOT EXISTS end_users (
 			id TEXT PRIMARY KEY,
 			tenant_id TEXT NOT NULL,
-			display_name TEXT NOT NULL
+			display_name TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active'
 		)
 	`); err != nil {
 		t.Fatalf("create end_users: %v", err)

--- a/internal/usage/enduser_daily_spending_reset.go
+++ b/internal/usage/enduser_daily_spending_reset.go
@@ -1,0 +1,118 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const endUserDailySpendingResetsTableSQL = `
+CREATE TABLE IF NOT EXISTS end_user_daily_spending_resets (
+  tenant_id     TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+  end_user_id   TEXT NOT NULL,
+  day_key       TEXT NOT NULL DEFAULT '',
+  cost_baseline REAL NOT NULL DEFAULT 0,
+  reset_at      TIMESTAMP NOT NULL,
+  PRIMARY KEY (tenant_id, end_user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_end_user_daily_spending_resets_day
+  ON end_user_daily_spending_resets(tenant_id, day_key);
+`
+
+func bootstrapEndUserDailySpendingResets(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	if _, err := db.Exec(endUserDailySpendingResetsTableSQL); err != nil {
+		return fmt.Errorf("usage: ensure end_user_daily_spending_resets: %w", err)
+	}
+	return nil
+}
+
+func QueryRawTodayCostByEndUserForTenant(tenantID, endUserID string) (float64, error) {
+	db := getReadDB()
+	if db == nil {
+		return 0, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	endUserID = strings.TrimSpace(endUserID)
+	predicate, args := buildEndUserAPIKeySelectorPredicate(tenantID, endUserID)
+	queryArgs := append([]interface{}{tenantID, CutoffStartUTC(1).Format(time.RFC3339)}, args...)
+	var total float64
+	if err := db.QueryRow(
+		"SELECT COALESCE(SUM(cost), 0) FROM request_logs WHERE tenant_id = ? AND timestamp >= ? AND "+predicate,
+		queryArgs...,
+	).Scan(&total); err != nil {
+		return 0, fmt.Errorf("usage: query raw today cost by end user: %w", err)
+	}
+	return total, nil
+}
+
+func getEndUserDailySpendingResetBaseline(tenantID, endUserID string) (float64, bool, error) {
+	db := getReadDB()
+	if db == nil {
+		return 0, false, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	endUserID = strings.TrimSpace(endUserID)
+	var dayKey string
+	var baseline float64
+	err := db.QueryRow(
+		`SELECT day_key, cost_baseline FROM end_user_daily_spending_resets WHERE tenant_id = ? AND end_user_id = ?`,
+		tenantID, endUserID,
+	).Scan(&dayKey, &baseline)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("usage: get end-user daily spending baseline: %w", err)
+	}
+	if dayKey != LocalDayKeyAt(time.Now()) {
+		return 0, false, nil
+	}
+	return baseline, true, nil
+}
+
+func QueryTodayEffectiveCostByEndUserForTenant(tenantID, endUserID string) (float64, error) {
+	raw, err := QueryRawTodayCostByEndUserForTenant(tenantID, endUserID)
+	if err != nil {
+		return 0, err
+	}
+	baseline, ok, err := getEndUserDailySpendingResetBaseline(tenantID, endUserID)
+	if err != nil || !ok {
+		return raw, err
+	}
+	return effectiveTodayCost(raw, baseline), nil
+}
+
+// ResetTodayCostByEndUser sets an account-level baseline without deleting logs.
+func ResetTodayCostByEndUser(tenantID, endUserID string) (usedBefore float64, rawToday float64, err error) {
+	db := getDB()
+	if db == nil {
+		return 0, 0, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	endUserID = strings.TrimSpace(endUserID)
+	usedBefore, err = QueryTodayEffectiveCostByEndUserForTenant(tenantID, endUserID)
+	if err != nil {
+		return 0, 0, err
+	}
+	rawToday, err = QueryRawTodayCostByEndUserForTenant(tenantID, endUserID)
+	if err != nil {
+		return 0, 0, err
+	}
+	now := time.Now().UTC()
+	_, err = db.Exec(`
+		INSERT INTO end_user_daily_spending_resets (tenant_id, end_user_id, day_key, cost_baseline, reset_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (tenant_id, end_user_id) DO UPDATE SET
+			day_key = excluded.day_key,
+			cost_baseline = excluded.cost_baseline,
+			reset_at = excluded.reset_at
+	`, tenantID, endUserID, LocalDayKeyAt(now), rawToday, now.Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, 0, fmt.Errorf("usage: reset today cost by end user: %w", err)
+	}
+	return usedBefore, rawToday, nil
+}

--- a/internal/usage/enduser_daily_spending_reset.go
+++ b/internal/usage/enduser_daily_spending_reset.go
@@ -86,6 +86,99 @@ func QueryTodayEffectiveCostByEndUserForTenant(tenantID, endUserID string) (floa
 	return effectiveTodayCost(raw, baseline), nil
 }
 
+// QueryTodayEffectiveCostsByEndUsersForTenant batch-loads account-level today costs
+// for many end users in a few queries (avoids per-row N+1 on GetEndUsers).
+func QueryTodayEffectiveCostsByEndUsersForTenant(tenantID string, endUserIDs []string) (map[string]float64, error) {
+	out := make(map[string]float64, len(endUserIDs))
+	tenantID = normalizeTenantID(tenantID)
+	ids := make([]string, 0, len(endUserIDs))
+	seen := make(map[string]struct{}, len(endUserIDs))
+	for _, id := range endUserIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+		out[id] = 0
+	}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	db := getReadDB()
+	if db == nil {
+		return out, nil
+	}
+
+	// Sum today's cost per end_user via owned keys (stable id or legacy secret).
+	// Arg order: join tenant, end_user ids..., log tenant, cutoff.
+	ph := make([]string, len(ids))
+	queryArgs := make([]interface{}, 0, 3+len(ids))
+	queryArgs = append(queryArgs, tenantID)
+	for i, id := range ids {
+		ph[i] = "?"
+		queryArgs = append(queryArgs, id)
+	}
+	queryArgs = append(queryArgs, tenantID, CutoffStartUTC(1).Format(time.RFC3339))
+	rows, err := db.Query(`
+		SELECT k.end_user_id, COALESCE(SUM(r.cost), 0)
+		FROM request_logs r
+		INNER JOIN api_keys k ON k.tenant_id = ?
+			AND k.end_user_id IN (`+strings.Join(ph, ",")+`)
+			AND (
+				(trim(coalesce(r.api_key_id, '')) <> '' AND r.api_key_id = k.id)
+				OR (trim(coalesce(r.api_key_id, '')) = '' AND r.api_key = k.key)
+			)
+		WHERE r.tenant_id = ? AND r.timestamp >= ?
+		GROUP BY k.end_user_id
+	`, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: batch today cost by end users: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var endUserID string
+		var total float64
+		if err := rows.Scan(&endUserID, &total); err != nil {
+			return nil, fmt.Errorf("usage: scan batch today cost: %w", err)
+		}
+		out[strings.TrimSpace(endUserID)] = total
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Apply same-day account baselines.
+	bph := make([]string, len(ids))
+	bargs := make([]interface{}, 0, 2+len(ids))
+	bargs = append(bargs, tenantID, LocalDayKeyAt(time.Now()))
+	for i, id := range ids {
+		bph[i] = "?"
+		bargs = append(bargs, id)
+	}
+	brows, err := db.Query(`
+		SELECT end_user_id, cost_baseline FROM end_user_daily_spending_resets
+		WHERE tenant_id = ? AND day_key = ? AND end_user_id IN (`+strings.Join(bph, ",")+`)
+	`, bargs...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: batch end-user baselines: %w", err)
+	}
+	defer brows.Close()
+	for brows.Next() {
+		var endUserID string
+		var baseline float64
+		if err := brows.Scan(&endUserID, &baseline); err != nil {
+			return nil, err
+		}
+		endUserID = strings.TrimSpace(endUserID)
+		out[endUserID] = effectiveTodayCost(out[endUserID], baseline)
+	}
+	return out, brows.Err()
+}
+
 // ResetTodayCostByEndUser sets an account-level baseline without deleting logs.
 func ResetTodayCostByEndUser(tenantID, endUserID string) (usedBefore float64, rawToday float64, err error) {
 	db := getDB()

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -10,9 +10,9 @@ import (
 
 // EndUserQuota is the account-level limit/permission snapshot used by auth + quota.
 type EndUserQuota struct {
-	ID                   string
-	TenantID             string
-	DisplayName          string
+	ID          string
+	TenantID    string
+	DisplayName string
 	// Status is end_users.status (active/disabled/locked). Auth must refuse non-active accounts.
 	Status               string
 	PermissionProfileID  string

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -105,6 +105,14 @@ func EffectiveEndUserQuota(q EndUserQuota) EndUserQuota {
 
 // ListAPIKeyIDsForEndUser returns stable key ids owned by the end user.
 func ListAPIKeyIDsForEndUser(endUserID string) []string {
+	return listAPIKeyValuesForEndUser("", endUserID, "id")
+}
+
+func ListAPIKeyIDsForEndUserForTenant(tenantID, endUserID string) []string {
+	return listAPIKeyValuesForEndUser(tenantID, endUserID, "id")
+}
+
+func listAPIKeyValuesForEndUser(tenantID, endUserID, column string) []string {
 	db := getReadDB()
 	if db == nil {
 		return nil
@@ -113,7 +121,13 @@ func ListAPIKeyIDsForEndUser(endUserID string) []string {
 	if endUserID == "" {
 		return nil
 	}
-	rows, err := db.Query(`SELECT id FROM api_keys WHERE end_user_id = ? AND id != ''`, endUserID)
+	query := `SELECT ` + column + ` FROM api_keys WHERE end_user_id = ? AND ` + column + ` != ''`
+	args := []interface{}{endUserID}
+	if strings.TrimSpace(tenantID) != "" {
+		query += ` AND tenant_id = ?`
+		args = append(args, normalizeTenantID(tenantID))
+	}
+	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil
 	}
@@ -134,31 +148,11 @@ func ListAPIKeyIDsForEndUser(endUserID string) []string {
 
 // ListAPIKeySecretsForEndUser returns raw key secrets owned by the end user (legacy log rows).
 func ListAPIKeySecretsForEndUser(endUserID string) []string {
-	db := getReadDB()
-	if db == nil {
-		return nil
-	}
-	endUserID = strings.TrimSpace(endUserID)
-	if endUserID == "" {
-		return nil
-	}
-	rows, err := db.Query(`SELECT key FROM api_keys WHERE end_user_id = ? AND key != ''`, endUserID)
-	if err != nil {
-		return nil
-	}
-	defer rows.Close()
-	out := make([]string, 0)
-	for rows.Next() {
-		var key string
-		if err := rows.Scan(&key); err != nil {
-			return out
-		}
-		key = strings.TrimSpace(key)
-		if key != "" {
-			out = append(out, key)
-		}
-	}
-	return out
+	return listAPIKeyValuesForEndUser("", endUserID, "key")
+}
+
+func ListAPIKeySecretsForEndUserForTenant(tenantID, endUserID string) []string {
+	return listAPIKeyValuesForEndUser(tenantID, endUserID, "key")
 }
 
 // ExpandPublicLookupAPIKeys expands a presented API key into the full account key pool
@@ -180,7 +174,7 @@ func ExpandPublicLookupAPIKeys(apiKey string) []string {
 		}
 		return []string{trimmed}
 	}
-	secrets := ListAPIKeySecretsForEndUser(endUserID)
+	secrets := ListAPIKeySecretsForEndUserForTenant(row.TenantID, endUserID)
 	if len(secrets) == 0 {
 		if k := strings.TrimSpace(row.Key); k != "" {
 			return []string{k}
@@ -225,12 +219,12 @@ func ResolveAPIKeyDisplayName(row *APIKeyRow, fallback string) string {
 	return strings.TrimSpace(fallback)
 }
 
-func buildEndUserAPIKeySelectorClause(endUserID string) (string, []interface{}) {
-	ids := ListAPIKeyIDsForEndUser(endUserID)
-	secrets := ListAPIKeySecretsForEndUser(endUserID)
+func buildEndUserAPIKeySelectorPredicate(tenantID, endUserID string) (string, []interface{}) {
+	ids := ListAPIKeyIDsForEndUserForTenant(tenantID, endUserID)
+	secrets := ListAPIKeySecretsForEndUserForTenant(tenantID, endUserID)
 	if len(ids) == 0 && len(secrets) == 0 {
 		// No keys yet: match nothing.
-		return " WHERE 1 = 0", nil
+		return "1 = 0", nil
 	}
 	parts := make([]string, 0, 2)
 	args := make([]interface{}, 0, len(ids)+len(secrets))
@@ -249,9 +243,19 @@ func buildEndUserAPIKeySelectorClause(endUserID string) (string, []interface{}) 
 			args = append(args, key)
 		}
 		// Include legacy rows that only stored the raw secret.
-		parts = append(parts, `(api_key_id = '' AND api_key IN (`+strings.Join(ph, ",")+`))`)
+		parts = append(parts, `(trim(coalesce(api_key_id, '')) = '' AND api_key IN (`+strings.Join(ph, ",")+`))`)
 	}
-	return " WHERE (" + strings.Join(parts, " OR ") + ")", args
+	return "(" + strings.Join(parts, " OR ") + ")", args
+}
+
+func buildEndUserAPIKeySelectorClause(endUserID string) (string, []interface{}) {
+	quota := GetEndUserQuota(endUserID)
+	tenantID := ""
+	if quota != nil {
+		tenantID = quota.TenantID
+	}
+	predicate, args := buildEndUserAPIKeySelectorPredicate(tenantID, endUserID)
+	return " WHERE " + predicate, args
 }
 
 // CountTodayByEndUser counts requests across all keys of the end user today.
@@ -315,28 +319,13 @@ func QueryTotalCostByEndUser(endUserID string) (float64, error) {
 	return total, nil
 }
 
-// QueryTodayCostByEndUser sums project-day cost across all keys of the end user.
-// Daily spending reset remains per-key for now; account pool uses raw day sum.
-// ponytail: no end-user-level daily spending reset yet; add when product needs account-wide reset.
+// QueryTodayCostByEndUser returns account-level project-day spend after the latest same-day reset baseline.
 func QueryTodayCostByEndUser(endUserID string) (float64, error) {
-	db := getDB()
-	if db == nil {
+	quota := GetEndUserQuota(endUserID)
+	if quota == nil {
 		return 0, nil
 	}
-	clause, args := buildEndUserAPIKeySelectorClause(endUserID)
-	if clause == "" {
-		return 0, nil
-	}
-	queryArgs := append(args, CutoffStartUTC(1).Format(time.RFC3339))
-	var total float64
-	err := db.QueryRow(
-		"SELECT COALESCE(SUM(cost), 0) FROM request_logs"+clause+" AND timestamp >= ?",
-		queryArgs...,
-	).Scan(&total)
-	if err != nil {
-		return 0, fmt.Errorf("usage: query today cost by end user: %w", err)
-	}
-	return total, nil
+	return QueryTodayEffectiveCostByEndUserForTenant(quota.TenantID, endUserID)
 }
 
 // EnsureEndUserQuotaColumns adds account quota columns on SQLite bootstraps / tests.

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -13,6 +13,8 @@ type EndUserQuota struct {
 	ID                   string
 	TenantID             string
 	DisplayName          string
+	// Status is end_users.status (active/disabled/locked). Auth must refuse non-active accounts.
+	Status               string
 	PermissionProfileID  string
 	DailyLimit           int
 	TotalQuota           int
@@ -52,7 +54,7 @@ func GetEndUserQuota(endUserID string) *EndUserQuota {
 	var q EndUserQuota
 	var modelsJSON, channelsJSON, groupsJSON string
 	err := db.QueryRow(`
-		SELECT id, tenant_id, display_name,
+		SELECT id, tenant_id, display_name, COALESCE(status, 'active'),
 			COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
 			COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
 			COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
@@ -60,7 +62,7 @@ func GetEndUserQuota(endUserID string) *EndUserQuota {
 			COALESCE(system_prompt, '')
 		FROM end_users WHERE id = ?
 	`, endUserID).Scan(
-		&q.ID, &q.TenantID, &q.DisplayName,
+		&q.ID, &q.TenantID, &q.DisplayName, &q.Status,
 		&q.PermissionProfileID, &q.DailyLimit, &q.TotalQuota,
 		&q.SpendingLimit, &q.DailySpendingLimit,
 		&q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -367,8 +367,9 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	apiKeyName := strings.TrimSpace(record.APIKeyName)
 	if statsKey != "" {
 		if row := GetAPIKey(statsKey); row != nil {
-			// Prefer account display name for owned keys so logs show end-user, not key label.
-			if name := ResolveAPIKeyDisplayName(row, apiKeyName); name != "" {
+			// Persist the key's own name. Account display name is resolved separately
+			// at read time so the UI can show both user and key identity.
+			if name := strings.TrimSpace(row.Name); name != "" {
 				apiKeyName = name
 			}
 		}

--- a/internal/usage/request_log_content.go
+++ b/internal/usage/request_log_content.go
@@ -166,6 +166,26 @@ func QueryLogContentForKey(id int64, apiKey string) (LogContentResult, error) {
 	return fallback, nil
 }
 
+// QueryLogContentForEndUser retrieves one log only when it belongs to the
+// authenticated end-user account's stable key-id / legacy-secret pool.
+func QueryLogContentForEndUser(tenantID, endUserID string, id int64) (LogContentResult, error) {
+	tenantID = normalizeTenantID(tenantID)
+	db := getReadDB()
+	if db == nil {
+		return LogContentResult{}, fmt.Errorf("usage: database not initialised")
+	}
+	predicate, args := buildEndUserAPIKeySelectorPredicate(tenantID, endUserID)
+	queryArgs := append([]interface{}{tenantID, id}, args...)
+	var matched int
+	if err := db.QueryRow(
+		"SELECT 1 FROM request_logs WHERE tenant_id = ? AND id = ? AND "+predicate,
+		queryArgs...,
+	).Scan(&matched); err != nil {
+		return LogContentResult{}, fmt.Errorf("usage: query log content: %w", err)
+	}
+	return QueryLogContentForTenant(tenantID, id)
+}
+
 // QueryLogContentPartForKey retrieves only one side (input/output) of the stored request/response content
 // for a single entry, but only if it belongs to the given API key.
 func QueryLogContentPartForKey(id int64, apiKey string, part string) (LogContentPartResult, error) {
@@ -226,4 +246,22 @@ func QueryLogContentPartForKey(id int64, apiKey string, part string) (LogContent
 		return LogContentPartResult{}, fmt.Errorf("usage: query log content part: %w", err)
 	}
 	return fallback, nil
+}
+
+func QueryLogContentPartForEndUser(tenantID, endUserID string, id int64, part string) (LogContentPartResult, error) {
+	tenantID = normalizeTenantID(tenantID)
+	db := getReadDB()
+	if db == nil {
+		return LogContentPartResult{}, fmt.Errorf("usage: database not initialised")
+	}
+	predicate, args := buildEndUserAPIKeySelectorPredicate(tenantID, endUserID)
+	queryArgs := append([]interface{}{tenantID, id}, args...)
+	var matched int
+	if err := db.QueryRow(
+		"SELECT 1 FROM request_logs WHERE tenant_id = ? AND id = ? AND "+predicate,
+		queryArgs...,
+	).Scan(&matched); err != nil {
+		return LogContentPartResult{}, fmt.Errorf("usage: query log content part: %w", err)
+	}
+	return QueryLogContentPartForTenant(tenantID, id, part)
 }

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -50,7 +50,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 
 	// Fetch page
 	offset := (params.Page - 1) * params.Size
-	querySQL := "SELECT id, timestamp, api_key, api_key_name, model, upstream_model, vision_fallback_model, source, channel_name, auth_index, auth_subject_id, " +
+	querySQL := "SELECT id, timestamp, api_key, api_key_id, api_key_name, model, upstream_model, vision_fallback_model, source, channel_name, auth_index, auth_subject_id, " +
 		"failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, " +
 		"cost, " +
 		"(CASE WHEN EXISTS (SELECT 1 FROM request_log_content content WHERE content.tenant_id = request_logs.tenant_id AND content.log_id = request_logs.id) " +
@@ -72,7 +72,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		var ts storedTime
 		var failedInt, streamingInt, hasContentInt int
 		if err := rows.Scan(
-			&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.UpstreamModel, &row.VisionFallbackModel, &row.Source, &row.ChannelName,
+			&row.ID, &ts, &row.APIKey, &row.APIKeyID, &row.APIKeyName, &row.Model, &row.UpstreamModel, &row.VisionFallbackModel, &row.Source, &row.ChannelName,
 			&row.AuthIndex, &row.AuthSubjectID, &failedInt, &streamingInt, &row.LatencyMs, &row.FirstTokenMs,
 			&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
 			&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,
@@ -99,7 +99,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 	}, nil
 }
 
-// hydrateAPIKeyDisplayNames prefers live end-user account names for owned keys.
+// hydrateAPIKeyDisplayNames keeps account and credential identity separate.
 func hydrateAPIKeyDisplayNames(tenantID string, items []LogRow) {
 	if len(items) == 0 {
 		return
@@ -108,7 +108,10 @@ func hydrateAPIKeyDisplayNames(tenantID string, items []LogRow) {
 	byKey := currentAPIKeyRowsByKeyForTenant(tenantID)
 	for i := range items {
 		var row *APIKeyRow
-		if r, ok := byKey[strings.TrimSpace(items[i].APIKey)]; ok {
+		if r, ok := byID[strings.TrimSpace(items[i].APIKeyID)]; ok {
+			copy := r
+			row = &copy
+		} else if r, ok := byKey[strings.TrimSpace(items[i].APIKey)]; ok {
 			copy := r
 			row = &copy
 		} else {
@@ -117,17 +120,19 @@ func hydrateAPIKeyDisplayNames(tenantID string, items []LogRow) {
 				row = live
 			}
 		}
-		// Prefer id map when we can match key to id via byKey first.
 		if row != nil {
-			if id := strings.TrimSpace(row.ID); id != "" {
-				if r, ok := byID[id]; ok {
-					copy := r
-					row = &copy
-				}
+			items[i].APIKeyID = strings.TrimSpace(row.ID)
+			items[i].APIKeyOwnName = strings.TrimSpace(row.Name)
+			items[i].EndUserDisplayName = DisplayNameForEndUser(row.EndUserID)
+			if items[i].EndUserDisplayName != "" {
+				items[i].APIKeyName = items[i].EndUserDisplayName
+			} else if items[i].APIKeyOwnName != "" {
+				items[i].APIKeyName = items[i].APIKeyOwnName
 			}
-			if label := ResolveAPIKeyDisplayName(row, items[i].APIKeyName); label != "" {
-				items[i].APIKeyName = label
-			}
+		} else {
+			// Legacy rows have only one snapshot label. Preserve it as the key name;
+			// no account identity is inferred without a trusted ownership row.
+			items[i].APIKeyOwnName = strings.TrimSpace(items[i].APIKeyName)
 		}
 	}
 }
@@ -560,6 +565,7 @@ func ClearAllRequestLogsForTenant(tenantID string) (ClearRequestLogsResult, erro
 // multi-value counterparts. It trims spaces, deduplicates, and removes empties.
 func normalizeLogQueryParams(params LogQueryParams) LogQueryParams {
 	params.TenantID = normalizeTenantID(params.TenantID)
+	params.EndUserID = strings.TrimSpace(params.EndUserID)
 	if params.APIKey != "" {
 		params.APIKeys = append(params.APIKeys, params.APIKey)
 		params.APIKey = ""
@@ -612,6 +618,12 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 	// Time range: days=1 means "today", days=7 means "last 7 days", etc.
 	conditions = append(conditions, "timestamp >= ?")
 	args = append(args, CutoffStartUTC(params.Days).Format(time.RFC3339))
+
+	if params.EndUserID != "" {
+		predicate, selectorArgs := buildEndUserAPIKeySelectorPredicate(params.TenantID, params.EndUserID)
+		conditions = append(conditions, predicate)
+		args = append(args, selectorArgs...)
+	}
 
 	// API Key multi-value filter
 	if len(params.APIKeys) > 0 {

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -44,6 +44,24 @@ type PublicChartData struct {
 
 // QueryPublicChartData aggregates the public API-key lookup charts in one indexed pass.
 func QueryPublicChartData(apiKey string, days int) (PublicChartData, error) {
+	row := GetAPIKey(apiKey)
+	if row != nil && strings.TrimSpace(row.EndUserID) != "" {
+		return QueryPublicChartDataForEndUser(row.TenantID, row.EndUserID, days)
+	}
+	return queryPublicChartData(LogQueryParams{
+		TenantID: ResolveAPIKeyTenant(apiKey),
+		APIKeys:  ExpandPublicLookupAPIKeys(apiKey),
+	}, days)
+}
+
+func QueryPublicChartDataForEndUser(tenantID, endUserID string, days int) (PublicChartData, error) {
+	return queryPublicChartData(LogQueryParams{
+		TenantID:  tenantID,
+		EndUserID: endUserID,
+	}, days)
+}
+
+func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, error) {
 	db := getReadDB()
 	if db == nil {
 		return PublicChartData{
@@ -65,12 +83,7 @@ func QueryPublicChartData(apiKey string, days int) (PublicChartData, error) {
 	statsCutoff := CutoffStartUTC(days).Format(time.RFC3339)
 	heatmapCutoff := CutoffStartUTC(heatmapDays).Format(time.RFC3339)
 
-	// Expand end-user-owned keys so portal multi-key accounts see full account usage.
-	params := LogQueryParams{
-		TenantID: ResolveAPIKeyTenant(apiKey),
-		APIKeys:  ExpandPublicLookupAPIKeys(apiKey),
-		Days:     scanDays,
-	}
+	params.Days = scanDays
 	where, args := buildWhereClause(params)
 	queryArgs := make([]interface{}, 0, len(args)+2)
 	queryArgs = append(queryArgs, statsCutoff, heatmapCutoff)

--- a/internal/usage/request_log_types.go
+++ b/internal/usage/request_log_types.go
@@ -7,7 +7,11 @@ type LogRow struct {
 	ID                  int64     `json:"id"`
 	Timestamp           time.Time `json:"timestamp"`
 	APIKey              string    `json:"api_key"`
+	APIKeyID            string    `json:"api_key_id,omitempty"`
+	APIKeyMasked        string    `json:"api_key_masked,omitempty"`
 	APIKeyName          string    `json:"api_key_name"`
+	APIKeyOwnName       string    `json:"api_key_own_name,omitempty"`
+	EndUserDisplayName  string    `json:"end_user_display_name,omitempty"`
 	Model               string    `json:"model"`
 	UpstreamModel       string    `json:"upstream_model,omitempty"`
 	VisionFallbackModel string    `json:"vision_fallback_model,omitempty"`
@@ -33,6 +37,7 @@ type LogRow struct {
 // LogQueryParams holds filter/pagination parameters for QueryLogs.
 type LogQueryParams struct {
 	TenantID        string
+	EndUserID       string   // stable account owner; matches all current key ids plus legacy raw-secret rows
 	Page            int      // 1-based
 	Size            int      // rows per page
 	Days            int      // time range in days

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -737,6 +737,11 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 		usageDB, usageReadDB = nil, nil
 		return err
 	}
+	if err := bootstrapEndUserDailySpendingResets(db); err != nil {
+		_ = db.Close()
+		usageDB, usageReadDB = nil, nil
+		return err
+	}
 	log.Debugf("usage: initializing pricing table")
 	initPricingTable(db)
 	log.Debugf("usage: initializing model config tables")
@@ -851,7 +856,8 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstr
 		if apiKeyID == "" {
 			apiKeyID = identity.ID
 		}
-		// Always prefer live identity label (end-user display name when owned).
+		// Always prefer the live key's own name. End-user display name is hydrated
+		// independently on reads so account and credential identity are not conflated.
 		if name := strings.TrimSpace(identity.Name); name != "" {
 			apiKeyName = name
 		} else if apiKeyName == "" {


### PR DESCRIPTION
## Summary
- Portal public usage/logs/chart resolve authenticated end users to account-level aggregation across all owned keys (not a single secret).
- `GetAPIKey` looks up secrets across tenants (`GetAnyTenant`); rotate keeps stable `api_key_id` for history.
- Request logs split `end_user_display_name` vs `api_key_own_name`; end-user daily spending reset is account-scoped.

## Test plan
- [x] `go test ./internal/usage/ ./internal/enduser/ ./internal/storage/sqlite/apikey/ ./internal/api/handlers/management/ ./internal/api/routes/ -count=1`
- [ ] CI required checks on PR
- [ ] After merge: portal login → create empty key → usage still shows account history

## Notes
Pairs with codeProxy PR (account-scoped portal UI / request-logs / end-users UX).