### PR TITLE
feat: reduce request logging and monitoring overhead

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -143,6 +143,10 @@ error-logs-max-files: 10
 # When false, disable in-memory usage statistics aggregation
 usage-statistics-enabled: false
 
+# Cache expensive management system-stat fields (database sizes, log directory scan,
+# and channel latency) for this many seconds. CPU, memory, network, and concurrency stay live.
+system-stats-cache-seconds: 60
+
 # Detailed request/response body retention settings for PostgreSQL request-log storage.
 request-log-storage:
   # When true, persist full request and response bodies in PostgreSQL.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -63,6 +63,8 @@ type Handler struct {
 	accessManager        *sdkaccess.Manager
 	trendCacheMu         sync.Mutex
 	trendCache           map[string]trendCacheEntry
+	systemStatsCacheMu   sync.Mutex
+	systemStatsCache     systemStatsCacheEntry
 	imageGeneration      *imagegeneration.Service
 	identityService      *identity.Service
 	aiAccountStatus      *aiaccountstatus.Service

--- a/internal/api/handlers/management/system_stats.go
+++ b/internal/api/handlers/management/system_stats.go
@@ -73,6 +73,72 @@ type SystemStats struct {
 	TotalTPM          int64                            `json:"total_tpm"`
 }
 
+type expensiveSystemStats struct {
+	DBSizeBytes          int64
+	DBEngine             string
+	LogContentStoreBytes int64
+	LogDirSizeBytes      int64
+	ChannelLatency       []usage.ChannelLatency
+}
+
+type systemStatsCacheEntry struct {
+	cachedAt time.Time
+	value    expensiveSystemStats
+}
+
+const defaultSystemStatsCacheSeconds = 60
+
+func (h *Handler) systemStatsCacheTTL() time.Duration {
+	seconds := defaultSystemStatsCacheSeconds
+	if h != nil {
+		h.mu.Lock()
+		if h.cfg != nil && h.cfg.SystemStatsCacheSeconds > 0 {
+			seconds = h.cfg.SystemStatsCacheSeconds
+		}
+		h.mu.Unlock()
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func (h *Handler) collectExpensiveSystemStats() expensiveSystemStats {
+	stats := expensiveSystemStats{}
+	dbStats, err := usage.GetDatabaseStats()
+	stats.DBEngine = dbStats.Driver
+	stats.DBSizeBytes = dbStats.SizeBytes
+	if err != nil {
+		log.Warnf("system-stats: failed to query database stats: %v", err)
+	}
+	if contentBytes, err := usage.GetRequestLogStorageBytes(); err == nil {
+		stats.LogContentStoreBytes = contentBytes
+	} else {
+		log.Warnf("system-stats: failed to query request log storage bytes: %v", err)
+	}
+	if h != nil && h.logDir != "" {
+		stats.LogDirSizeBytes = dirSize(h.logDir)
+	}
+	if latency, err := usage.GetChannelAvgLatency(7); err == nil {
+		stats.ChannelLatency = latency
+	}
+	return stats
+}
+
+func (h *Handler) cachedExpensiveSystemStats() expensiveSystemStats {
+	if h == nil {
+		return expensiveSystemStats{}
+	}
+	h.systemStatsCacheMu.Lock()
+	defer h.systemStatsCacheMu.Unlock()
+
+	now := time.Now()
+	ttl := h.systemStatsCacheTTL()
+	if !h.systemStatsCache.cachedAt.IsZero() && now.Sub(h.systemStatsCache.cachedAt) < ttl {
+		return h.systemStatsCache.value
+	}
+	value := h.collectExpensiveSystemStats()
+	h.systemStatsCache = systemStatsCacheEntry{cachedAt: now, value: value}
+	return value
+}
+
 // network baseline for rate calculation
 var (
 	netMu         sync.Mutex
@@ -93,23 +159,13 @@ func (h *Handler) collectSystemStats() SystemStats {
 	runtime.ReadMemStats(&m)
 	stats.GoHeapBytes = m.HeapAlloc
 
-	dbStats, err := usage.GetDatabaseStats()
-	stats.DBEngine = dbStats.Driver
-	stats.DBSizeBytes = dbStats.SizeBytes
-	if err != nil {
-		log.Warnf("system-stats: failed to query database stats: %v", err)
-	}
-	if contentBytes, err := usage.GetRequestLogStorageBytes(); err == nil {
-		stats.LogContentStoreBytes = contentBytes
-	} else {
-		log.Warnf("system-stats: failed to query request log storage bytes: %v", err)
-	}
-
-	// ── Log directory size ──
-	if h.logDir != "" {
-		stats.LogDirSizeBytes = dirSize(h.logDir)
-		stats.LogSizeBytes = stats.LogDirSizeBytes
-	}
+	expensive := h.cachedExpensiveSystemStats()
+	stats.DBEngine = expensive.DBEngine
+	stats.DBSizeBytes = expensive.DBSizeBytes
+	stats.LogContentStoreBytes = expensive.LogContentStoreBytes
+	stats.LogDirSizeBytes = expensive.LogDirSizeBytes
+	stats.LogSizeBytes = expensive.LogDirSizeBytes
+	stats.ChannelLatency = expensive.ChannelLatency
 
 	// ── Process CPU/Memory (gopsutil) ──
 	if proc, err := process.NewProcess(int32(os.Getpid())); err == nil {
@@ -163,11 +219,6 @@ func (h *Handler) collectSystemStats() SystemStats {
 		stats.DiskUsed = du.Used
 		stats.DiskFree = du.Free
 		stats.DiskPct = du.UsedPercent
-	}
-
-	// ── Channel latency (from DB) ──
-	if cl, err := usage.GetChannelAvgLatency(7); err == nil {
-		stats.ChannelLatency = cl
 	}
 
 	// ── Concurrency snapshot ──

--- a/internal/api/handlers/management/system_stats_test.go
+++ b/internal/api/handlers/management/system_stats_test.go
@@ -1,0 +1,40 @@
+package management
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestCachedExpensiveSystemStatsAvoidsRepeatedLogDirectoryWalks(t *testing.T) {
+	logDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(logDir, "first.log"), []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write first log: %v", err)
+	}
+	h := NewHandler(&config.Config{SystemStatsCacheSeconds: 3600}, filepath.Join(t.TempDir(), "config.yaml"), nil)
+	t.Cleanup(h.Close)
+	h.logDir = logDir
+
+	first := h.cachedExpensiveSystemStats()
+	if first.LogDirSizeBytes != 3 {
+		t.Fatalf("first log size = %d, want 3", first.LogDirSizeBytes)
+	}
+	if err := os.WriteFile(filepath.Join(logDir, "second.log"), []byte("defgh"), 0o600); err != nil {
+		t.Fatalf("write second log: %v", err)
+	}
+	cached := h.cachedExpensiveSystemStats()
+	if cached.LogDirSizeBytes != first.LogDirSizeBytes {
+		t.Fatalf("cached log size = %d, want %d", cached.LogDirSizeBytes, first.LogDirSizeBytes)
+	}
+
+	h.systemStatsCacheMu.Lock()
+	h.systemStatsCache.cachedAt = time.Now().Add(-2 * time.Hour)
+	h.systemStatsCacheMu.Unlock()
+	refreshed := h.cachedExpensiveSystemStats()
+	if refreshed.LogDirSizeBytes != 8 {
+		t.Fatalf("refreshed log size = %d, want 8", refreshed.LogDirSizeBytes)
+	}
+}

--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -63,7 +63,7 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 		loggerEnabled := logger.IsEnabled()
 
 		// Capture request information
-		requestInfo, err := captureRequestInfo(c, shouldCaptureRequestBody(loggerEnabled, c.Request))
+		requestInfo, err := captureRequestInfo(c, loggerEnabled, shouldCaptureRequestBody(loggerEnabled, c.Request))
 		if err != nil {
 			if bodyutil.IsTooLarge(err) {
 				c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
@@ -185,7 +185,7 @@ func shouldCaptureRequestBody(loggerEnabled bool, req *http.Request) bool {
 // captureRequestInfo extracts relevant information from the incoming HTTP request.
 // It captures the URL, method, headers, and body. The request body is read and then
 // restored so that it can be processed by subsequent handlers.
-func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) {
+func captureRequestInfo(c *gin.Context, captureHeaders, captureBody bool) (*RequestInfo, error) {
 	// Capture URL with sensitive query parameters masked
 	maskedQuery := util.MaskSensitiveQuery(c.Request.URL.RawQuery)
 	url := c.Request.URL.Path
@@ -201,10 +201,9 @@ func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) 
 	// Capture method
 	method := c.Request.Method
 
-	// Capture headers
-	headers := make(map[string][]string)
-	for key, values := range c.Request.Header {
-		headers[key] = values
+	var headers map[string][]string
+	if captureHeaders {
+		headers = cloneHTTPHeader(c.Request.Header)
 	}
 
 	// Capture request body
@@ -225,6 +224,17 @@ func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) 
 		RequestID: logging.GetGinRequestID(c),
 		Timestamp: time.Now(),
 	}, nil
+}
+
+func cloneHTTPHeader(headers http.Header) map[string][]string {
+	if len(headers) == 0 {
+		return map[string][]string{}
+	}
+	cloned := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		cloned[key] = append([]string(nil), values...)
+	}
+	return cloned
 }
 
 // shouldLogRequest determines whether the request should be logged.

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -372,3 +372,42 @@ func TestRequestLoggingMiddlewarePreservesOriginalURLAcrossRewrite(t *testing.T)
 		t.Fatalf("diagnostic response = %#v", logger.diagnostic.Response)
 	}
 }
+
+func TestRequestLoggingDisabledSuccessSkipsHeaderAndResponseCapture(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := &diagnosticRequestLogger{}
+	var wrapper *ResponseWriterWrapper
+	router := gin.New()
+	router.Use(RequestLoggingMiddleware(logger))
+	router.POST("/v1/responses", func(c *gin.Context) {
+		wrapper, _ = c.Writer.(*ResponseWriterWrapper)
+		c.Header("Content-Type", "text/event-stream")
+		c.Status(http.StatusOK)
+		_, _ = c.Writer.Write([]byte("data: ok\n\n"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Test", "must-not-be-cloned-on-success")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if wrapper == nil {
+		t.Fatal("request logging wrapper was not installed")
+	}
+	if wrapper.requestInfo.Headers != nil {
+		t.Fatalf("successful error-only request captured headers: %#v", wrapper.requestInfo.Headers)
+	}
+	if wrapper.headersCaptured || wrapper.body.Len() != 0 {
+		t.Fatalf("successful stream captured response data: headers=%t body=%d", wrapper.headersCaptured, wrapper.body.Len())
+	}
+	if logger.calls != 0 {
+		t.Fatalf("error-only logger calls = %d, want 0", logger.calls)
+	}
+	if wrapper.firstChunkTimestamp.IsZero() {
+		t.Fatal("first-response timing was not preserved")
+	}
+}

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -43,6 +43,7 @@ type ResponseWriterWrapper struct {
 	ginCtx              *gin.Context               // ginCtx allows propagating first-response timing into usage records.
 	statusCode          int                        // statusCode stores the HTTP status code of the response.
 	headers             map[string][]string        // headers stores the response headers.
+	headersCaptured     bool                       // headersCaptured avoids cloning immutable response headers per stream chunk.
 	logOnErrorOnly      bool                       // logOnErrorOnly enables logging only when an error response is detected.
 	firstChunkTimestamp time.Time                  // firstChunkTimestamp captures TTFB for streaming responses.
 }
@@ -79,31 +80,30 @@ func (w *ResponseWriterWrapper) Unwrap() http.ResponseWriter {
 // CRITICAL: This method prioritizes writing to the client to ensure zero latency,
 // handling logging operations subsequently.
 func (w *ResponseWriterWrapper) Write(data []byte) (int, error) {
-	// Ensure headers are captured before first write
-	// This is critical because Write() may trigger WriteHeader() internally
-	w.ensureHeadersCaptured()
+	loggingEnabled := w.loggingEnabled()
+	if loggingEnabled {
+		w.ensureHeadersCaptured()
+	}
 
-	// CRITICAL: Write to client first (zero latency)
 	n, err := w.ResponseWriter.Write(data)
-
 	if n > 0 {
 		w.markFirstResponseWrite()
 	}
 
-	// THEN: Handle logging based on response type
-	if w.isStreaming && w.chunkChannel != nil {
-		// For streaming responses: Send to async logging channel (non-blocking)
+	if loggingEnabled && w.isStreaming && w.chunkChannel != nil {
 		select {
-		case w.chunkChannel <- append([]byte(nil), data...): // Non-blocking send with copy
-		default: // Channel full, skip logging to avoid blocking
+		case w.chunkChannel <- append([]byte(nil), data...):
+		default:
 		}
 		return n, err
 	}
 
 	if w.shouldBufferResponseBody() {
+		if !loggingEnabled {
+			w.ensureHeadersCaptured()
+		}
 		w.body.Write(data)
 	}
-
 	return n, err
 }
 
@@ -129,17 +129,17 @@ func (w *ResponseWriterWrapper) shouldBufferResponseBody() bool {
 // Some handlers (and fmt/io helpers) write via io.StringWriter; without this override, those writes
 // bypass Write() and would be missing from request logs.
 func (w *ResponseWriterWrapper) WriteString(data string) (int, error) {
-	w.ensureHeadersCaptured()
+	loggingEnabled := w.loggingEnabled()
+	if loggingEnabled {
+		w.ensureHeadersCaptured()
+	}
 
-	// CRITICAL: Write to client first (zero latency)
 	n, err := w.ResponseWriter.WriteString(data)
-
 	if n > 0 {
 		w.markFirstResponseWrite()
 	}
 
-	// THEN: Capture for logging
-	if w.isStreaming && w.chunkChannel != nil {
+	if loggingEnabled && w.isStreaming && w.chunkChannel != nil {
 		select {
 		case w.chunkChannel <- []byte(data):
 		default:
@@ -148,6 +148,9 @@ func (w *ResponseWriterWrapper) WriteString(data string) (int, error) {
 	}
 
 	if w.shouldBufferResponseBody() {
+		if !loggingEnabled {
+			w.ensureHeadersCaptured()
+		}
 		w.body.WriteString(data)
 	}
 	return n, err
@@ -158,45 +161,38 @@ func (w *ResponseWriterWrapper) WriteString(data string) (int, error) {
 // and initializes the appropriate logging mechanism (standard or streaming).
 func (w *ResponseWriterWrapper) WriteHeader(statusCode int) {
 	w.statusCode = statusCode
-
-	// Capture response headers using the new method
-	w.captureCurrentHeaders()
-	w.hydrateRequestInfoBody(w.ginCtx)
-
-	// Detect streaming based on Content-Type
-	contentType := w.ResponseWriter.Header().Get("Content-Type")
-	w.isStreaming = w.detectStreaming(contentType)
-
-	// WriteHeader can run more than once (status rewrite / error path). Always
-	// tear down any existing stream spool first so request-body-*.tmp files are
-	// never orphaned when the final response is non-streaming.
+	loggingEnabled := w.loggingEnabled()
+	captureError := w.logOnErrorOnly && statusCode >= http.StatusBadRequest
 	w.closeStreamingLogWriter()
+	if loggingEnabled || captureError {
+		w.ensureHeadersCaptured()
+		w.hydrateRequestInfoBody(w.ginCtx)
+		if captureError {
+			w.hydrateRequestInfoHeaders(w.ginCtx)
+		}
 
-	// If streaming, initialize streaming log writer
-	if w.isStreaming && w.logger.IsEnabled() {
-		requestBody := w.extractRequestBody(w.ginCtx)
-		streamWriter, err := w.logger.LogStreamingRequest(
-			w.requestInfo.URL,
-			w.requestInfo.Method,
-			w.requestInfo.Headers,
-			requestBody,
-			w.requestInfo.RequestID,
-		)
-		if err == nil {
-			w.streamWriter = streamWriter
-			w.chunkChannel = make(chan []byte, 100) // Buffered channel for async writes
-			doneChan := make(chan struct{})
-			w.streamDone = doneChan
+		contentType := w.ResponseWriter.Header().Get("Content-Type")
+		w.isStreaming = loggingEnabled && w.detectStreaming(contentType)
 
-			// Start async chunk processor
-			go w.processStreamingChunks(doneChan, streamWriter, w.chunkChannel)
-
-			// Write status immediately
-			_ = streamWriter.WriteStatus(statusCode, w.headers)
+		if w.isStreaming {
+			requestBody := w.extractRequestBody(w.ginCtx)
+			streamWriter, err := w.logger.LogStreamingRequest(
+				w.requestInfo.URL,
+				w.requestInfo.Method,
+				w.requestInfo.Headers,
+				requestBody,
+				w.requestInfo.RequestID,
+			)
+			if err == nil {
+				w.streamWriter = streamWriter
+				w.chunkChannel = make(chan []byte, 100)
+				doneChan := make(chan struct{})
+				w.streamDone = doneChan
+				go w.processStreamingChunks(doneChan, streamWriter, w.chunkChannel)
+				_ = streamWriter.WriteStatus(statusCode, w.headers)
+			}
 		}
 	}
-
-	// Call original WriteHeader
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
@@ -204,8 +200,14 @@ func (w *ResponseWriterWrapper) WriteHeader(statusCode int) {
 // It is safe to call this method multiple times; it will always refresh the headers
 // with the latest state from the underlying ResponseWriter.
 func (w *ResponseWriterWrapper) ensureHeadersCaptured() {
-	// Always capture the current headers to ensure we have the latest state
+	if w == nil || w.headersCaptured {
+		return
+	}
 	w.captureCurrentHeaders()
+}
+
+func (w *ResponseWriterWrapper) loggingEnabled() bool {
+	return w != nil && w.logger != nil && w.logger.IsEnabled()
 }
 
 // captureCurrentHeaders reads all headers from the underlying ResponseWriter and stores them
@@ -218,11 +220,9 @@ func (w *ResponseWriterWrapper) captureCurrentHeaders() {
 
 	// Capture all current headers from the underlying ResponseWriter
 	for key, values := range w.ResponseWriter.Header() {
-		// Make a copy of the values slice to avoid reference issues
-		headerValues := make([]string, len(values))
-		copy(headerValues, values)
-		w.headers[key] = headerValues
+		w.headers[key] = append([]string(nil), values...)
 	}
+	w.headersCaptured = true
 }
 
 func (w *ResponseWriterWrapper) markFirstResponseWrite() {
@@ -307,6 +307,11 @@ func (w *ResponseWriterWrapper) Finalize(c *gin.Context) error {
 	hasAPIError := len(slicesAPIResponseError) > 0 || finalStatusCode >= http.StatusBadRequest
 	diagnostics.RecordResponse(c, finalStatusCode, w.body.Bytes())
 	forceLog := w.logOnErrorOnly && hasAPIError && !w.logger.IsEnabled()
+	if forceLog {
+		w.hydrateRequestInfoHeaders(c)
+		w.hydrateRequestInfoBody(c)
+		w.ensureHeadersCaptured()
+	}
 	// Stream writers create request-body-*.tmp / response-body-*.tmp as soon as
 	// WriteHeader runs. Always close them even when request-log is later disabled
 	// mid-request, otherwise the logs dir fills with orphaned spool files that
@@ -429,6 +434,21 @@ func (w *ResponseWriterWrapper) extractRequestBody(c *gin.Context) []byte {
 		return w.requestInfo.Body
 	}
 	return nil
+}
+
+func (w *ResponseWriterWrapper) hydrateRequestInfoHeaders(c *gin.Context) map[string][]string {
+	if w == nil || w.requestInfo == nil {
+		return nil
+	}
+	if w.requestInfo.Headers != nil {
+		return w.requestInfo.Headers
+	}
+	if c == nil || c.Request == nil {
+		w.requestInfo.Headers = map[string][]string{}
+		return w.requestInfo.Headers
+	}
+	w.requestInfo.Headers = cloneHTTPHeader(c.Request.Header)
+	return w.requestInfo.Headers
 }
 
 func (w *ResponseWriterWrapper) hydrateRequestInfoBody(c *gin.Context) []byte {

--- a/internal/api/server_config_reload.go
+++ b/internal/api/server_config_reload.go
@@ -48,7 +48,7 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	s.applyRequestLoggerConfig(oldCfg, cfg)
 	s.applyProcessLoggingConfig(oldCfg, cfg)
 	s.applyUsageStatisticsConfig(oldCfg, cfg)
-	usage.SetRequestLogBodyStorageEnabled(cfg.RequestLogStorage.StoreContent)
+	usage.ApplyRequestLogStorageConfig(cfg.RequestLogStorage)
 	s.applyAuthRuntimeConfig(oldCfg, cfg)
 	s.applyRequestBodyConfig(oldCfg, cfg)
 	s.applyRuntimeLogLevel(oldCfg, cfg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,11 @@ type Config struct {
 	// metadata is still persisted so monitoring/history pages keep working.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
 
+	// SystemStatsCacheSeconds controls how long expensive management system-stat
+	// fields (database sizes, log directory walk, latency aggregation) are cached.
+	// Lightweight CPU, memory, network and concurrency values remain live.
+	SystemStatsCacheSeconds int `yaml:"system-stats-cache-seconds" json:"system-stats-cache-seconds"`
+
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -426,3 +426,19 @@ func TestSaveConfigPreserveCommentsKeepsDisableControlPanelTrue(t *testing.T) {
 		t.Fatalf("saved config missing explicit true override:\n%s", rendered)
 	}
 }
+
+func TestLoadConfigDefaultsSystemStatsCacheToSixtySeconds(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8317\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if cfg.SystemStatsCacheSeconds != 60 {
+		t.Fatalf("SystemStatsCacheSeconds = %d, want 60", cfg.SystemStatsCacheSeconds)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -70,6 +70,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.RequestBody.ModelMaxMB = DefaultModelRequestBodyMB
 	cfg.RequestBody.DiskThresholdMB = DefaultRequestBodyDiskThresholdMB
 	cfg.UsageStatisticsEnabled = false
+	cfg.SystemStatsCacheSeconds = 60
 	cfg.RequestLogStorage.StoreContent = false
 	cfg.RequestLogStorage.ContentRetentionDays = 30
 	cfg.RequestLogStorage.CleanupIntervalMinutes = 1440
@@ -183,6 +184,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	}
 	if cfg.ErrorLogsMaxFiles < 0 {
 		cfg.ErrorLogsMaxFiles = 0
+	}
+	if cfg.SystemStatsCacheSeconds <= 0 {
+		cfg.SystemStatsCacheSeconds = 60
 	}
 	if cfg.Streaming.KeepAliveSeconds == 0 {
 		cfg.Streaming.KeepAliveSeconds = 15

--- a/internal/logging/gin_logger.go
+++ b/internal/logging/gin_logger.go
@@ -4,6 +4,7 @@
 package logging
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -28,6 +29,8 @@ var aiAPIPrefixes = []string{
 
 const skipGinLogKey = "__gin_skip_request_logging__"
 
+type ginRequestLoggingContextKey struct{}
+
 // GinLogrusLogger returns a Gin middleware handler that logs HTTP requests and responses
 // using logrus. It captures request details including method, path, status code, latency,
 // client IP, and any error messages. Request ID is generated for AI API and management
@@ -40,18 +43,19 @@ const skipGinLogKey = "__gin_skip_request_logging__"
 //   - gin.HandlerFunc: A middleware handler for request logging
 func GinLogrusLogger() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if ginRequestLoggingActive(c) {
+			ensureGinRequestID(c)
+			c.Next()
+			return
+		}
+		c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), ginRequestLoggingContextKey{}, true))
+
 		start := time.Now()
 		path := c.Request.URL.Path
 		raw := util.MaskSensitiveQuery(c.Request.URL.RawQuery)
 
 		// AI API + management: attach request ID for log/audit correlation.
-		var requestID string
-		if shouldTrackRequestID(path) {
-			requestID = GenerateRequestID()
-			SetGinRequestID(c, requestID)
-			ctx := WithRequestID(c.Request.Context(), requestID)
-			c.Request = c.Request.WithContext(ctx)
-		}
+		requestID := ensureGinRequestID(c)
 
 		c.Next()
 
@@ -79,6 +83,9 @@ func GinLogrusLogger() gin.HandlerFunc {
 		errorMessage := c.Errors.ByType(gin.ErrorTypePrivate).String()
 
 		if requestID == "" {
+			requestID = GetGinRequestID(c)
+		}
+		if requestID == "" {
 			requestID = "--------"
 		}
 		logLine := fmt.Sprintf("%3d | %13v | %15s | %-7s \"%s\"", statusCode, latency, clientIP, method, path)
@@ -97,6 +104,30 @@ func GinLogrusLogger() gin.HandlerFunc {
 			entry.Info(logLine)
 		}
 	}
+}
+
+func ensureGinRequestID(c *gin.Context) string {
+	if c == nil || c.Request == nil {
+		return ""
+	}
+	if requestID := GetGinRequestID(c); requestID != "" {
+		return requestID
+	}
+	if !shouldTrackRequestID(c.Request.URL.Path) {
+		return ""
+	}
+	requestID := GenerateRequestID()
+	SetGinRequestID(c, requestID)
+	c.Request = c.Request.WithContext(WithRequestID(c.Request.Context(), requestID))
+	return requestID
+}
+
+func ginRequestLoggingActive(c *gin.Context) bool {
+	if c == nil || c.Request == nil {
+		return false
+	}
+	active, _ := c.Request.Context().Value(ginRequestLoggingContextKey{}).(bool)
+	return active
 }
 
 // isAIAPIPath checks if the given path is an AI API endpoint that should have request ID tracking.

--- a/internal/logging/gin_logger_test.go
+++ b/internal/logging/gin_logger_test.go
@@ -127,6 +127,50 @@ func TestGinLogrusLoggerAssignsRequestIDForManagementPaths(t *testing.T) {
 	}
 }
 
+func TestGinLogrusLoggerLogsNestedRouteRewriteOnce(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var buf bytes.Buffer
+	originalOutput := log.StandardLogger().Out
+	defer log.SetOutput(originalOutput)
+	log.SetOutput(&buf)
+
+	engine := gin.New()
+	engine.Use(GinLogrusLogger())
+	engine.POST("/v1/responses", func(c *gin.Context) {
+		if GetGinRequestID(c) == "" {
+			t.Error("rewritten AI route should receive a request ID")
+		}
+		c.Status(http.StatusNoContent)
+	})
+	engine.NoRoute(func(c *gin.Context) {
+		if _, rewritten := c.Get("test.rewritten"); rewritten {
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+		c.Set("test.rewritten", true)
+		c.Request.URL.Path = "/v1/responses"
+		c.Request.RequestURI = "/v1/responses"
+		engine.HandleContext(c)
+		c.Abort()
+	})
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/deepseek/group/v1/responses", nil)
+	engine.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("gin log lines = %d, want 1: %q", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], "/deepseek/group/v1/responses") {
+		t.Fatalf("log line = %q, want original public path", lines[0])
+	}
+}
+
 func TestShouldTrackRequestID(t *testing.T) {
 	cases := []struct {
 		path string

--- a/internal/runtime/executor/antigravity_usage_content_test.go
+++ b/internal/runtime/executor/antigravity_usage_content_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestAntigravityExecutePublishesUsageContent(t *testing.T) {
+	setUsageBodyCaptureForTest(t, true)
 	const input = `{"request":{"contents":[{"role":"user","parts":[{"text":"ag input marker"}]}]}}`
 	const output = `{"response":{"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":3,"totalTokenCount":5}}}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -51,6 +52,7 @@ func TestAntigravityExecutePublishesUsageContent(t *testing.T) {
 }
 
 func TestAntigravityExecuteStreamPublishesUsageContent(t *testing.T) {
+	setUsageBodyCaptureForTest(t, true)
 	const input = `{"request":{"contents":[{"role":"user","parts":[{"text":"ag stream marker"}]}]}}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != antigravityStreamPath {

--- a/internal/runtime/executor/codex_executor_image_test.go
+++ b/internal/runtime/executor/codex_executor_image_test.go
@@ -33,6 +33,7 @@ func (p *usageCapturePlugin) HandleUsage(ctx context.Context, record cliproxyusa
 }
 
 func TestCodexExecutorExecuteImageGeneration(t *testing.T) {
+	setUsageBodyCaptureForTest(t, true)
 	const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+XgnUAAAAASUVORK5CYII="
 	pngBytes := []byte{
 		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
@@ -691,6 +692,7 @@ func TestCodexExecutorExecuteImageGenerationReturnsResponsesFailedRateLimit(t *t
 }
 
 func TestUsageReporterTrackFailureStoresErrorContent(t *testing.T) {
+	setUsageBodyCaptureForTest(t, true)
 	const model = "gpt-image-failure-content"
 	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
 	cliproxyusage.RegisterPlugin(usagePlugin)

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -14,8 +14,16 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
+
+func setUsageBodyCaptureForTest(t *testing.T, enabled bool) {
+	t.Helper()
+	previous := internalusage.RequestLogBodyStorageEnabled()
+	internalusage.SetRequestLogBodyStorageEnabled(enabled)
+	t.Cleanup(func() { internalusage.SetRequestLogBodyStorageEnabled(previous) })
+}
 
 func TestParseOpenAIUsageChatCompletions(t *testing.T) {
 	data := []byte(`{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":5}}}`)
@@ -84,6 +92,7 @@ func TestParseOpenAIResponseModel(t *testing.T) {
 }
 
 func TestUsageReporterSpillsLargeStreamingOutputToTempFile(t *testing.T) {
+	setUsageBodyCaptureForTest(t, true)
 	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
 	chunk := bytes.Repeat([]byte("x"), usageReporterOutputMemoryLimit/2)
 
@@ -230,6 +239,7 @@ func TestFirstTokenLatencyMsFromContext(t *testing.T) {
 }
 
 func TestUsageReporterPreservesDirectContentBeforeSpilledChunks(t *testing.T) {
+	setUsageBodyCaptureForTest(t, true)
 	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
 	chunk := bytes.Repeat([]byte("x"), usageReporterOutputMemoryLimit+1)
 	reporter.appendOutputChunk(chunk)
@@ -253,6 +263,7 @@ func TestUsageReporterPreservesDirectContentBeforeSpilledChunks(t *testing.T) {
 }
 
 func TestUsageReporterDefersLargeInputContent(t *testing.T) {
+	setUsageBodyCaptureForTest(t, true)
 	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
 	input := strings.Repeat("i", usageReporterOutputMemoryLimit+1)
 	reporter.setInputContent(input)
@@ -268,6 +279,19 @@ func TestUsageReporterDefersLargeInputContent(t *testing.T) {
 	}
 	if string(data) != input {
 		t.Fatalf("deferred input content mismatch")
+	}
+}
+
+func TestUsageReporterPreservesStreamingClassificationWithoutBodyCapture(t *testing.T) {
+	setUsageBodyCaptureForTest(t, false)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
+	reporter.setInputContent(`{"model":"gpt-5.4","stream":true}`)
+
+	if !reporter.streamingRequest {
+		t.Fatal("streaming request classification should survive disabled body storage")
+	}
+	if reporter.inputContent != "" || reporter.inputPath != "" {
+		t.Fatal("request body must not be retained when body storage is disabled")
 	}
 }
 

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -34,6 +35,9 @@ type usageReporter struct {
 	requestedAt         time.Time
 	once                sync.Once
 	contentMu           sync.Mutex
+	captureFullContent  bool
+	streamingRequest    bool
+	compactOutputFull   atomic.Bool
 
 	// Content captured for log detail viewer
 	inputContent  string
@@ -47,12 +51,13 @@ type usageReporter struct {
 func newUsageReporter(ctx context.Context, provider, model, upstreamModel string, auth *cliproxyauth.Auth) *usageReporter {
 	apiKey := apiKeyFromContext(ctx)
 	reporter := &usageReporter{
-		provider:      provider,
-		model:         model,
-		upstreamModel: upstreamModel,
-		requestedAt:   time.Now(),
-		apiKey:        apiKey,
-		source:        resolveUsageSource(auth, apiKey),
+		provider:           provider,
+		model:              model,
+		upstreamModel:      upstreamModel,
+		requestedAt:        time.Now(),
+		apiKey:             apiKey,
+		source:             resolveUsageSource(auth, apiKey),
+		captureFullContent: internalusage.RequestLogBodyStorageEnabled(),
 	}
 	if identity := internalusage.ResolveAPIKeyIdentity(apiKey); identity != nil {
 		reporter.apiKeyID = identity.ID
@@ -74,10 +79,16 @@ func (r *usageReporter) publish(ctx context.Context, detail coreusage.Detail) {
 }
 
 func (r *usageReporter) publishWithContent(ctx context.Context, detail coreusage.Detail, inputContent, outputContent string) {
-	r.contentMu.Lock()
-	r.setInputContentLocked(inputContent)
-	r.outputContent = outputContent
-	r.contentMu.Unlock()
+	if r == nil {
+		return
+	}
+	r.streamingRequest = isStreamingUsageRequest(inputContent)
+	if r.captureFullContent {
+		r.contentMu.Lock()
+		r.setInputContentLocked(inputContent)
+		r.outputContent = outputContent
+		r.contentMu.Unlock()
+	}
 	r.publishWithOutcome(ctx, detail, false)
 }
 
@@ -119,9 +130,23 @@ func (r *usageReporter) setInputContent(content string) {
 	if r == nil {
 		return
 	}
+	r.streamingRequest = isStreamingUsageRequest(content)
+	if !r.captureFullContent {
+		return
+	}
 	r.contentMu.Lock()
 	defer r.contentMu.Unlock()
 	r.setInputContentLocked(content)
+}
+
+func isStreamingUsageRequest(content string) bool {
+	var payload struct {
+		Stream bool `json:"stream"`
+	}
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		return false
+	}
+	return payload.Stream
 }
 
 // appendOutputChunk accumulates a streaming response line for inclusion in usage records.
@@ -129,8 +154,32 @@ func (r *usageReporter) appendOutputChunk(chunk []byte) {
 	if r == nil || len(chunk) == 0 {
 		return
 	}
+	if !r.captureFullContent && r.compactOutputFull.Load() {
+		return
+	}
+
 	r.contentMu.Lock()
 	defer r.contentMu.Unlock()
+
+	if !r.captureFullContent {
+		const compactLimit = internalusage.MaxFailedOutputContentBytes
+		remaining := compactLimit - r.outputBuilder.Len()
+		if remaining <= 0 {
+			r.compactOutputFull.Store(true)
+			return
+		}
+		if len(chunk) > remaining {
+			chunk = chunk[:remaining]
+		}
+		r.outputBuilder.Write(chunk)
+		if r.outputBuilder.Len() < compactLimit {
+			r.outputBuilder.WriteByte('\n')
+		}
+		if r.outputBuilder.Len() >= compactLimit {
+			r.compactOutputFull.Store(true)
+		}
+		return
+	}
 
 	if r.outputFile == nil && r.outputBuilder.Len()+len(chunk)+1 > usageReporterOutputMemoryLimit {
 		if err := r.spillOutputBuilderToFileLocked(); err != nil {
@@ -169,9 +218,14 @@ func (r *usageReporter) publishFailureWithContent(ctx context.Context, inputCont
 	if shouldSuppressUsageFailure(nil, outputContent) {
 		return
 	}
+	r.streamingRequest = isStreamingUsageRequest(inputContent)
 	r.contentMu.Lock()
-	r.setInputContentLocked(inputContent)
-	r.outputContent = outputContent
+	if r.captureFullContent {
+		r.setInputContentLocked(inputContent)
+		r.outputContent = outputContent
+	} else {
+		r.outputContent = internalusage.CompactFailedOutputContent(outputContent)
+	}
 	r.contentMu.Unlock()
 	r.publishWithOutcome(ctx, coreusage.Detail{}, true)
 }
@@ -186,7 +240,11 @@ func (r *usageReporter) trackFailure(ctx context.Context, errPtr *error) {
 		}
 		r.contentMu.Lock()
 		if r.outputContent == "" && r.outputBuilder.Len() == 0 && r.outputFile == nil {
-			r.outputContent = structuredUpstreamErrorJSON(*errPtr)
+			output := structuredUpstreamErrorJSON(*errPtr)
+			if !r.captureFullContent {
+				output = internalusage.CompactFailedOutputContent(output)
+			}
+			r.outputContent = output
 		}
 		r.contentMu.Unlock()
 		r.publishFailure(ctx)
@@ -254,8 +312,8 @@ func (r *usageReporter) publishWithOutcome(ctx context.Context, detail coreusage
 		return
 	}
 	r.once.Do(func() {
-		inputContent, outputContent, inputPath, outputPath := r.finalizeContent()
-		detailContent, detailPath := deferLargeContent("cliproxy-usage-detail-*", buildRequestDetailContent(ctx))
+		inputContent, outputContent, inputPath, outputPath := r.finalizeContentForOutcome(failed)
+		detailContent, detailPath := deferLargeContent("cliproxy-usage-detail-*", buildRequestDetailContent(ctx, r.captureFullContent))
 		latencyMs := time.Since(r.requestedAt).Milliseconds()
 		if latencyMs < 0 {
 			latencyMs = 0
@@ -282,6 +340,7 @@ func (r *usageReporter) publishWithOutcome(ctx context.Context, detail coreusage
 			APIIdentifier:       apiIdentifier,
 			RequestID:           requestID,
 			ResponseStatus:      responseStatus,
+			Streaming:           r.streamingRequest,
 			Detail:              detail,
 			InputContent:        inputContent,
 			OutputContent:       outputContent,
@@ -302,8 +361,8 @@ func (r *usageReporter) ensurePublished(ctx context.Context) {
 		return
 	}
 	r.once.Do(func() {
-		inputContent, outputContent, inputPath, outputPath := r.finalizeContent()
-		detailContent, detailPath := deferLargeContent("cliproxy-usage-detail-*", buildRequestDetailContent(ctx))
+		inputContent, outputContent, inputPath, outputPath := r.finalizeContentForOutcome(false)
+		detailContent, detailPath := deferLargeContent("cliproxy-usage-detail-*", buildRequestDetailContent(ctx, r.captureFullContent))
 		latencyMs := time.Since(r.requestedAt).Milliseconds()
 		if latencyMs < 0 {
 			latencyMs = 0
@@ -330,6 +389,7 @@ func (r *usageReporter) ensurePublished(ctx context.Context) {
 			APIIdentifier:       apiIdentifier,
 			RequestID:           requestID,
 			ResponseStatus:      responseStatus,
+			Streaming:           r.streamingRequest,
 			Detail:              coreusage.Detail{},
 			InputContent:        inputContent,
 			OutputContent:       outputContent,
@@ -360,6 +420,49 @@ func (r *usageReporter) spillOutputBuilderToFileLocked() error {
 	r.outputFile = file
 	r.outputPath = file.Name()
 	return nil
+}
+
+func (r *usageReporter) finalizeContentForOutcome(failed bool) (string, string, string, string) {
+	if r == nil {
+		return "", "", "", ""
+	}
+	if r.captureFullContent || failed {
+		input, output, inputPath, outputPath := r.finalizeContent()
+		if !r.captureFullContent {
+			input = ""
+			if inputPath != "" {
+				_ = os.Remove(inputPath)
+				inputPath = ""
+			}
+			output = internalusage.CompactFailedOutputContent(output)
+		}
+		return input, output, inputPath, outputPath
+	}
+	r.discardContent()
+	return "", "", "", ""
+}
+
+func (r *usageReporter) discardContent() {
+	if r == nil {
+		return
+	}
+	r.contentMu.Lock()
+	defer r.contentMu.Unlock()
+	if r.inputPath != "" {
+		_ = os.Remove(r.inputPath)
+	}
+	if r.outputFile != nil {
+		_ = r.outputFile.Close()
+	}
+	if r.outputPath != "" {
+		_ = os.Remove(r.outputPath)
+	}
+	r.inputContent = ""
+	r.inputPath = ""
+	r.outputContent = ""
+	r.outputBuilder.Reset()
+	r.outputFile = nil
+	r.outputPath = ""
 }
 
 func (r *usageReporter) finalizeContent() (string, string, string, string) {

--- a/internal/runtime/executor/usage_request_details.go
+++ b/internal/runtime/executor/usage_request_details.go
@@ -71,7 +71,7 @@ func usageRequestMetadata(ctx context.Context) (identifier, requestID string, re
 	return identifier, requestID, responseStatus
 }
 
-func buildRequestDetailContent(ctx context.Context) string {
+func buildRequestDetailContent(ctx context.Context, includeBodies ...bool) string {
 	if ctx == nil {
 		return ""
 	}
@@ -81,8 +81,13 @@ func buildRequestDetailContent(ctx context.Context) string {
 	}
 
 	req := ginCtx.Request
-	apiRequest := logging.APIRequestSnapshot(ginCtx)
-	apiResponse := logging.APIResponseSnapshot(ginCtx)
+	includeExchangeBodies := len(includeBodies) == 0 || includeBodies[0]
+	var apiRequest any
+	var apiResponse any
+	if includeExchangeBodies {
+		apiRequest = logging.APIRequestSnapshot(ginCtx)
+		apiResponse = logging.APIResponseSnapshot(ginCtx)
+	}
 	clientIP, clientIPSource := requestLogClientIP(ginCtx, req)
 
 	detail := map[string]any{

--- a/internal/usage/log_content_cleanup.go
+++ b/internal/usage/log_content_cleanup.go
@@ -272,7 +272,7 @@ func compactLogContentStorageInternal(db *sql.DB, allowOptimize bool) {
 
 	didVacuum := false
 	now := time.Now()
-	if requestLogStorage.VacuumOnCleanup && shouldVacuum(stats) && vacuumAllowedNow(now) {
+	if currentRequestLogStorageConfig().VacuumOnCleanup && shouldVacuum(stats) && vacuumAllowedNow(now) {
 		freeBytes := reclaimableBytes(stats)
 		log.Infof("usage: reclaimable sqlite free space detected (freelist=%d pages, approx=%d bytes), running VACUUM", stats.FreeListCount, freeBytes)
 		if _, err := db.Exec("VACUUM"); err != nil {

--- a/internal/usage/log_content_store.go
+++ b/internal/usage/log_content_store.go
@@ -38,12 +38,7 @@ type requestLogStorageRuntime struct {
 }
 
 var (
-	requestLogStorage = requestLogStorageRuntime{
-		ContentRetentionDays:   30,
-		CleanupIntervalMinutes: 1440,
-		MaxTotalSizeMB:         1024,
-		VacuumOnCleanup:        true,
-	}
+	requestLogStorage atomic.Value // requestLogStorageRuntime
 
 	requestLogMaintenanceCancel context.CancelFunc
 	requestLogMaintenanceWG     sync.WaitGroup
@@ -74,14 +69,34 @@ var (
 )
 
 func init() {
+	requestLogStorage.Store(requestLogStorageRuntime{
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+		MaxTotalSizeMB:         1024,
+		VacuumOnCleanup:        true,
+	})
 	requestLogContentBytes.Store(-1)
 	requestLogBodiesEnabled.Store(false)
 	// Initialize atomic.Value type so subsequent stores can use typed nil safely.
 	requestLogMaintenanceWakeup.Store((chan struct{})(nil))
 }
 
+func currentRequestLogStorageConfig() requestLogStorageRuntime {
+	value := requestLogStorage.Load()
+	if value == nil {
+		return requestLogStorageRuntime{
+			ContentRetentionDays:   30,
+			CleanupIntervalMinutes: 1440,
+			MaxTotalSizeMB:         1024,
+			VacuumOnCleanup:        true,
+		}
+	}
+	runtimeCfg, _ := value.(requestLogStorageRuntime)
+	return runtimeCfg
+}
+
 func contentRetentionUnlimited() bool {
-	return requestLogStorage.ContentRetentionDays <= 0
+	return currentRequestLogStorageConfig().ContentRetentionDays <= 0
 }
 
 // RequestLogBodyStorageEnabled reports whether full request and response bodies
@@ -94,6 +109,15 @@ func RequestLogBodyStorageEnabled() bool {
 // without requiring a process restart.
 func SetRequestLogBodyStorageEnabled(enabled bool) {
 	requestLogBodiesEnabled.Store(enabled)
+}
+
+// ApplyRequestLogStorageConfig applies the complete request-log body policy at
+// runtime. The maintenance loop reads the atomic snapshot on each pass, so YAML
+// changes do not require a process restart.
+func ApplyRequestLogStorageConfig(cfg config.RequestLogStorageConfig) {
+	requestLogStorage.Store(normalizeRequestLogStorageConfig(cfg))
+	SetRequestLogBodyStorageEnabled(cfg.StoreContent)
+	triggerRequestLogCompaction()
 }
 
 func normalizeRequestLogStorageConfig(cfg config.RequestLogStorageConfig) requestLogStorageRuntime {
@@ -116,10 +140,11 @@ func normalizeRequestLogStorageConfig(cfg config.RequestLogStorageConfig) reques
 }
 
 func maxLogContentBytes() int64 {
-	if requestLogStorage.MaxTotalSizeMB <= 0 {
+	runtimeCfg := currentRequestLogStorageConfig()
+	if runtimeCfg.MaxTotalSizeMB <= 0 {
 		return 0
 	}
-	return int64(requestLogStorage.MaxTotalSizeMB) * 1024 * 1024
+	return int64(runtimeCfg.MaxTotalSizeMB) * 1024 * 1024
 }
 
 func requestLogMaintenanceWakeupChan() chan struct{} {
@@ -161,19 +186,29 @@ func startRequestLogMaintenance(db *sql.DB, driver string) {
 		defer requestLogMaintenanceWG.Done()
 		runRequestLogMaintenancePass(db, driver)
 
-		ticker := time.NewTicker(time.Duration(requestLogStorage.CleanupIntervalMinutes) * time.Minute)
-		defer ticker.Stop()
-
 		for {
+			interval := time.Duration(currentRequestLogStorageConfig().CleanupIntervalMinutes) * time.Minute
+			timer := time.NewTimer(interval)
 			select {
 			case <-ctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
 				return
 			case <-wakeup:
-				// Compaction wakeup (triggered by size-cap pruning during inserts).
-				// Avoid running the full cleanup pass; this is mainly for shrinking WAL
-				// and reclaiming free pages when appropriate.
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				// Compaction/config wakeups should remain lightweight. The next
+				// timer is rebuilt from the latest runtime policy.
 				compactLogContentStorageInternal(db, false)
-			case <-ticker.C:
+			case <-timer.C:
 				runRequestLogMaintenancePass(db, driver)
 			}
 		}
@@ -472,7 +507,7 @@ func withinContentRetention(timestamp time.Time) bool {
 	if contentRetentionUnlimited() {
 		return true
 	}
-	cutoff := time.Now().UTC().AddDate(0, 0, -requestLogStorage.ContentRetentionDays)
+	cutoff := time.Now().UTC().AddDate(0, 0, -currentRequestLogStorageConfig().ContentRetentionDays)
 	return !timestamp.Before(cutoff)
 }
 
@@ -481,7 +516,7 @@ func cleanupExpiredLogContent(db *sql.DB) (int64, error) {
 		return 0, nil
 	}
 
-	cutoff := time.Now().UTC().AddDate(0, 0, -requestLogStorage.ContentRetentionDays).Format(time.RFC3339Nano)
+	cutoff := time.Now().UTC().AddDate(0, 0, -currentRequestLogStorageConfig().ContentRetentionDays).Format(time.RFC3339Nano)
 	result, err := db.Exec("DELETE FROM request_log_content WHERE timestamp < ?", cutoff)
 	if err != nil {
 		return 0, fmt.Errorf("usage: delete expired content: %w", err)

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -377,9 +377,9 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	inputContent := resolveDeferredUsageContent(record.InputContent, record.InputContentPath)
 	outputContent := resolveDeferredUsageContent(record.OutputContent, record.OutputContentPath)
 	detailContent := resolveDeferredUsageContent(record.DetailContent, record.DetailContentPath)
-	InsertLogWithDetailsIdentitySubjectUpstreamVision(statsKey, apiKeyID, record.AuthSubjectID, apiKeyName, modelName, record.UpstreamModel, record.VisionFallbackModel, record.Source, record.ChannelName,
+	InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(statsKey, apiKeyID, record.AuthSubjectID, apiKeyName, modelName, record.UpstreamModel, record.VisionFallbackModel, record.Source, record.ChannelName,
 		record.AuthIndex, failed, timestamp, record.LatencyMs, record.FirstTokenMs, detail,
-		inputContent, outputContent, detailContent)
+		inputContent, outputContent, detailContent, record.Streaming)
 }
 
 func resolveDeferredUsageContent(inline, path string) string {

--- a/internal/usage/request_log_body_purge.go
+++ b/internal/usage/request_log_body_purge.go
@@ -14,9 +14,10 @@ var requestLogBodyPurgeMu sync.Mutex
 
 type RequestLogBodyPurgeResult struct {
 	ClearRequestLogsResult
-	SanitizedDetailRows int64 `json:"sanitized_detail_rows"`
-	RemovedDetailBytes  int64 `json:"removed_detail_bytes"`
-	ReclaimedStorage    bool  `json:"reclaimed_storage"`
+	SanitizedDetailRows     int64 `json:"sanitized_detail_rows"`
+	RemovedDetailBytes      int64 `json:"removed_detail_bytes"`
+	ReclaimedStorage        bool  `json:"reclaimed_storage"`
+	PhysicalReclaimDeferred bool  `json:"physical_reclaim_deferred"`
 }
 
 type storedRequestDetailRow struct {
@@ -25,9 +26,9 @@ type storedRequestDetailRow struct {
 	Content     []byte
 }
 
-// PurgeStoredRequestBodies removes direct request/response bodies, strips bodies
-// embedded in historical request details, and rewrites the physical content
-// table when rows changed so PostgreSQL returns the freed space to the OS.
+// PurgeStoredRequestBodies removes direct request/response bodies and strips
+// bodies embedded in historical request details. It deliberately avoids blocking
+// physical rewrite operations such as PostgreSQL VACUUM FULL on the live API path.
 func PurgeStoredRequestBodies() (RequestLogBodyPurgeResult, error) {
 	usageDBMu.Lock()
 	db := usageDB
@@ -39,7 +40,7 @@ func PurgeStoredRequestBodies() (RequestLogBodyPurgeResult, error) {
 	return purgeStoredRequestBodies(db, driver)
 }
 
-func purgeStoredRequestBodies(db *sql.DB, driver string) (RequestLogBodyPurgeResult, error) {
+func purgeStoredRequestBodies(db *sql.DB, _ string) (RequestLogBodyPurgeResult, error) {
 	requestLogBodyPurgeMu.Lock()
 	defer requestLogBodyPurgeMu.Unlock()
 
@@ -60,20 +61,15 @@ func purgeStoredRequestBodies(db *sql.DB, driver string) (RequestLogBodyPurgeRes
 	refreshRequestLogContentBytes(db)
 
 	changed := result.ClearedBodyRows > 0 || result.ClearedLegacyRows > 0 || result.SanitizedDetailRows > 0
-	if changed {
-		if err = reclaimRequestLogContentStorage(db, driver); err != nil {
-			return result, err
-		}
-		result.ReclaimedStorage = true
-	}
+	result.PhysicalReclaimDeferred = changed
 
 	log.Infof(
-		"usage: purged request log bodies (body_rows=%d legacy_rows=%d sanitized_detail_rows=%d removed_detail_bytes=%d reclaimed=%t)",
+		"usage: purged request log bodies (body_rows=%d legacy_rows=%d sanitized_detail_rows=%d removed_detail_bytes=%d physical_reclaim_deferred=%t)",
 		result.ClearedBodyRows,
 		result.ClearedLegacyRows,
 		result.SanitizedDetailRows,
 		result.RemovedDetailBytes,
-		result.ReclaimedStorage,
+		result.PhysicalReclaimDeferred,
 	)
 	return result, nil
 }
@@ -153,18 +149,4 @@ func sanitizeHistoricalRequestDetails(db *sql.DB) (int64, int64, error) {
 		}
 	}
 	return sanitizedRows, removedBytes, nil
-}
-
-func reclaimRequestLogContentStorage(db *sql.DB, driver string) error {
-	switch driver {
-	case "postgres":
-		if _, err := db.Exec("VACUUM (FULL, ANALYZE) request_log_content"); err != nil {
-			return fmt.Errorf("usage: reclaim postgres request log content storage: %w", err)
-		}
-	case "sqlite":
-		if _, err := db.Exec("VACUUM"); err != nil {
-			return fmt.Errorf("usage: reclaim sqlite request log content storage: %w", err)
-		}
-	}
-	return nil
 }

--- a/internal/usage/request_log_body_purge_test.go
+++ b/internal/usage/request_log_body_purge_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 )
 
-func TestPurgeStoredRequestBodiesSanitizesDetailsAndReclaimsStorage(t *testing.T) {
+func TestPurgeStoredRequestBodiesSanitizesDetailsWithoutBlockingPhysicalRewrite(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,
 		ContentRetentionDays:   30,
@@ -30,7 +30,7 @@ func TestPurgeStoredRequestBodiesSanitizesDetailsAndReclaimsStorage(t *testing.T
 	if err != nil {
 		t.Fatalf("PurgeStoredRequestBodies() error = %v", err)
 	}
-	if result.ClearedBodyRows != 1 || result.SanitizedDetailRows != 1 || !result.ReclaimedStorage {
+	if result.ClearedBodyRows != 1 || result.SanitizedDetailRows != 1 || result.ReclaimedStorage || !result.PhysicalReclaimDeferred {
 		t.Fatalf("unexpected purge result: %+v", result)
 	}
 

--- a/internal/usage/request_log_detail_sanitize.go
+++ b/internal/usage/request_log_detail_sanitize.go
@@ -6,10 +6,9 @@ import (
 	"unicode/utf8"
 )
 
-// Max compact error payload retained for failed requests when body storage is off.
-// Large enough for typical upstream JSON errors, small enough to avoid reintroducing
-// full conversation/response bodies through the failure path.
-const maxFailedOutputContentBytes = 8 * 1024
+// MaxFailedOutputContentBytes is the compact error payload retained for failed
+// requests when body storage is off.
+const MaxFailedOutputContentBytes = 8 * 1024
 
 // stripStoredRequestDetailBodies preserves diagnostic metadata while ensuring
 // request/response bodies cannot be retained indirectly in detail_content when
@@ -19,36 +18,40 @@ func stripStoredRequestDetailBodies(raw string) string {
 	return sanitized
 }
 
-// compactFailedOutputContent keeps a short upstream error payload for the
-// management UI when full body storage is disabled. Successful request/response
-// bodies must not pass through this path.
+// CompactFailedOutputContent bounds the error payload kept when full body
+// storage is disabled. Executors use the same persistence boundary limit so a
+// successful stream never spills an unbounded payload only to discard it later.
+func CompactFailedOutputContent(raw string) string {
+	return compactFailedOutputContent(raw)
+}
+
 func compactFailedOutputContent(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return ""
 	}
-	if len(raw) <= maxFailedOutputContentBytes {
+	if len(raw) <= MaxFailedOutputContentBytes {
 		return raw
 	}
 	// Prefer keeping valid JSON when possible; otherwise hard-truncate.
 	if json.Valid([]byte(raw)) {
 		// Truncate with a clear marker while remaining valid-ish text for the modal.
 		// Keep the leading portion which usually contains error.message/type.
-		cut := maxFailedOutputContentBytes
+		cut := MaxFailedOutputContentBytes
 		for cut > 0 && !utf8.ValidString(raw[:cut]) {
 			cut--
 		}
 		if cut <= 0 {
-			return raw[:maxFailedOutputContentBytes]
+			return raw[:MaxFailedOutputContentBytes]
 		}
 		return raw[:cut] + "…[truncated]"
 	}
-	cut := maxFailedOutputContentBytes
+	cut := MaxFailedOutputContentBytes
 	for cut > 0 && !utf8.ValidString(raw[:cut]) {
 		cut--
 	}
 	if cut <= 0 {
-		return raw[:maxFailedOutputContentBytes]
+		return raw[:MaxFailedOutputContentBytes]
 	}
 	return raw[:cut] + "…[truncated]"
 }

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -690,8 +690,7 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 	usageReadDB = readDB
 	usageDBPath = dbPath
 	usageDriver = driver
-	requestLogStorage = normalizeRequestLogStorageConfig(storageCfg)
-	SetRequestLogBodyStorageEnabled(storageCfg.StoreContent)
+	ApplyRequestLogStorageConfig(storageCfg)
 	if runSQLiteBootstrap {
 		log.Debugf("usage: running tenant scope column migration")
 		migrateRequestLogTenantColumns(db)
@@ -792,42 +791,50 @@ func CloseDB() {
 func InsertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent string) {
-	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "")
+	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "", isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetails(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentity(apiKey, apiKeyID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, apiKeyID, "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubject(apiKey, apiKeyID, authSubjectID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubjectUpstream(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubjectUpstreamVision(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent)
+	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+}
+
+// InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming persists an
+// explicit streaming classification even when request body storage is disabled.
+func InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
+	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
+	inputContent, outputContent, detailContent string, streaming bool) {
+	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, streaming)
 }
 
 func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
-	inputContent, outputContent, detailContent string) {
+	inputContent, outputContent, detailContent string, streaming bool) {
 	db := getDB()
 	if db == nil {
 		return
@@ -838,7 +845,7 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstr
 		failedInt = 1
 	}
 	streamingInt := 0
-	if isStreamingRequestContent(inputContent) {
+	if streaming {
 		streamingInt = 1
 	}
 

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -37,12 +37,13 @@ type ClearRequestLogsOptions struct {
 const systemRequestLogFilterValue = "__system__"
 
 var (
-	usageDB     *sql.DB
-	usageReadDB *sql.DB
-	usageDBMu   sync.Mutex
-	usageDBPath string
-	usageDriver string
-	usageLoc    *time.Location
+	usageDBLifecycleMu sync.Mutex
+	usageDB            *sql.DB
+	usageReadDB        *sql.DB
+	usageDBMu          sync.Mutex
+	usageDBPath        string
+	usageDriver        string
+	usageLoc           *time.Location
 )
 
 // DatabaseStats summarizes the active runtime database for management telemetry.
@@ -578,6 +579,9 @@ func startRequestLogContentSessionIDBackfill(db *sql.DB) {
 // InitDB opens (or creates) the SQLite database at the given path and creates
 // the request_logs table if it doesn't exist.
 func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.Location) error {
+	usageDBLifecycleMu.Lock()
+	defer usageDBLifecycleMu.Unlock()
+
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()
 
@@ -655,6 +659,9 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 }
 
 func InitPostgres(pgCfg config.PostgresConfig, storageCfg config.RequestLogStorageConfig, loc *time.Location) error {
+	usageDBLifecycleMu.Lock()
+	defer usageDBLifecycleMu.Unlock()
+
 	usageDBMu.Lock()
 	defer usageDBMu.Unlock()
 
@@ -769,20 +776,32 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 
 // CloseDB closes the runtime database gracefully.
 func CloseDB() {
-	usageDBMu.Lock()
-	defer usageDBMu.Unlock()
+	usageDBLifecycleMu.Lock()
+	defer usageDBLifecycleMu.Unlock()
 
+	// Maintenance and in-flight SQLite writes can read usageLoc under usageDBMu.
+	// Stop the worker, then detach the handles under the mutex before waiting for
+	// database/sql to drain them, otherwise shutdown can deadlock on that mutex.
 	stopRequestLogMaintenance()
-	if usageDB != nil {
-		_ = usageDB.Close()
-		usageDB = nil
+
+	usageDBMu.Lock()
+	db := usageDB
+	readDB := usageReadDB
+	usageDB = nil
+	usageReadDB = nil
+	usageDBMu.Unlock()
+
+	if db != nil {
+		_ = db.Close()
 	}
-	if usageReadDB != nil {
-		_ = usageReadDB.Close()
-		usageReadDB = nil
+	if readDB != nil && readDB != db {
+		_ = readDB.Close()
 	}
+
+	usageDBMu.Lock()
 	usageLoc = nil
 	usageDriver = ""
+	usageDBMu.Unlock()
 	log.Info("usage: database closed")
 }
 

--- a/internal/usage/usage_db_close_test.go
+++ b/internal/usage/usage_db_close_test.go
@@ -1,0 +1,34 @@
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCloseDBStopsMaintenanceBeforeLockingUsageDB(t *testing.T) {
+	CloseDB()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	requestLogMaintenanceCancel = cancel
+	requestLogMaintenanceWG.Add(1)
+	go func() {
+		defer requestLogMaintenanceWG.Done()
+		<-ctx.Done()
+		usageDBMu.Lock()
+		_ = usageLoc
+		usageDBMu.Unlock()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		CloseDB()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CloseDB deadlocked while maintenance waited for usageDBMu")
+	}
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -39,6 +39,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.UsageStatisticsEnabled != newCfg.UsageStatisticsEnabled {
 		changes = append(changes, fmt.Sprintf("usage-statistics-enabled: %t -> %t", oldCfg.UsageStatisticsEnabled, newCfg.UsageStatisticsEnabled))
 	}
+	if oldCfg.SystemStatsCacheSeconds != newCfg.SystemStatsCacheSeconds {
+		changes = append(changes, fmt.Sprintf("system-stats-cache-seconds: %d -> %d", oldCfg.SystemStatsCacheSeconds, newCfg.SystemStatsCacheSeconds))
+	}
 	if oldCfg.DisableCooling != newCfg.DisableCooling {
 		changes = append(changes, fmt.Sprintf("disable-cooling: %t -> %t", oldCfg.DisableCooling, newCfg.DisableCooling))
 	}

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -30,6 +30,7 @@ type Record struct {
 	APIIdentifier       string
 	RequestID           string
 	ResponseStatus      int
+	Streaming           bool
 	Detail              Detail
 
 	// Optional: request/response content for log detail viewer.


### PR DESCRIPTION
## Summary
- avoid success-path header and response-body capture when request logging is disabled while preserving compact error diagnostics and first-response timing
- keep streaming classification without retaining full request bodies, cap failed-stream candidates, and hot-reload the full request-log storage policy
- emit one Gin access line for grouped route rewrites, cache expensive system stats, and defer blocking physical database rewrites to a maintenance window
- preserve request metadata, quota, spending, token, cost, and routing semantics

## Validation
- `./scripts/ci-pr.sh`
- `go test -race ./internal/api/middleware ./internal/logging ./internal/runtime/executor ./internal/usage ./internal/api/handlers/management`
- `git diff --check`

## Notes
- no translator package changes
- disabling body storage clears historical request and response bodies but does not delete request metadata