### PR TITLE
fix: close end-user residual usage and model risks

### DIFF
--- a/internal/api/handlers/management/api_key_permission_profiles_test.go
+++ b/internal/api/handlers/management/api_key_permission_profiles_test.go
@@ -32,6 +32,112 @@ func setupPermissionProfilesTestDB(t *testing.T) {
 	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
 		t.Fatalf("InitDB: %v", err)
 	}
+	if _, err := usage.RuntimeDB().Exec(`
+		CREATE TABLE IF NOT EXISTS end_users (
+			id TEXT PRIMARY KEY,
+			tenant_id TEXT NOT NULL,
+			permission_profile_id TEXT NOT NULL DEFAULT '',
+			daily_limit INTEGER NOT NULL DEFAULT 0,
+			total_quota INTEGER NOT NULL DEFAULT 0,
+			spending_limit REAL NOT NULL DEFAULT 0,
+			daily_spending_limit REAL NOT NULL DEFAULT 0,
+			concurrency_limit INTEGER NOT NULL DEFAULT 0,
+			rpm_limit INTEGER NOT NULL DEFAULT 0,
+			tpm_limit INTEGER NOT NULL DEFAULT 0,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			allowed_channels TEXT NOT NULL DEFAULT '[]',
+			allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL DEFAULT '',
+			updated_at TEXT NOT NULL DEFAULT '',
+			version INTEGER NOT NULL DEFAULT 1
+		)
+	`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+}
+
+func TestPutAPIKeyPermissionProfilesSyncsBoundAccountsAtomically(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupPermissionProfilesTestDB(t)
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	for _, row := range []struct {
+		id        string
+		profileID string
+	}{
+		{id: "user-a", profileID: "standard"},
+		{id: "user-b", profileID: "other"},
+		{id: "user-c", profileID: "standard"},
+	} {
+		if _, err := usage.RuntimeDB().Exec(`
+			INSERT INTO end_users (id, tenant_id, permission_profile_id, daily_limit, updated_at)
+			VALUES (?, ?, ?, 1, '2026-01-01T00:00:00Z')
+		`, row.id, tenantID, row.profileID); err != nil {
+			t.Fatalf("insert %s: %v", row.id, err)
+		}
+	}
+
+	body := []byte(`{
+	  "sync-accounts": true,
+	  "items": [{
+	    "id": "standard",
+	    "name": "Standard",
+	    "daily-limit": 16000,
+	    "total-quota": 32000,
+	    "daily-spending-limit": 50,
+	    "concurrency-limit": 2,
+	    "rpm-limit": 30,
+	    "tpm-limit": 40000,
+	    "allowed-models": ["gpt-5.4"],
+	    "allowed-channels": ["kimi-B"],
+	    "allowed-channel-groups": ["pro"],
+	    "system-prompt": "Account prompt"
+	  }]
+	}`)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "/api-key-permission-profiles", bytes.NewReader(body))
+	h := NewHandler(&config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{Name: "kimi-B", BaseURL: "https://example.invalid"}},
+		Routing:             config.RoutingConfig{ChannelGroups: []config.RoutingChannelGroup{{Name: "pro"}}},
+	}, "", nil)
+	h.PutAPIKeyPermissionProfiles(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		AppliedCount int64 `json:"applied_count"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.AppliedCount != 3 {
+		t.Fatalf("applied_count = %d, want 3 (two synced + one removed binding)", response.AppliedCount)
+	}
+
+	for _, userID := range []string{"user-a", "user-c"} {
+		var profileID, modelsJSON, groupsJSON, prompt string
+		var dailyLimit, totalQuota, concurrency, rpm, tpm int
+		var dailySpending float64
+		if err := usage.RuntimeDB().QueryRow(`
+			SELECT permission_profile_id, daily_limit, total_quota, daily_spending_limit,
+				concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channel_groups, system_prompt
+			FROM end_users WHERE id = ?
+		`, userID).Scan(&profileID, &dailyLimit, &totalQuota, &dailySpending, &concurrency, &rpm, &tpm, &modelsJSON, &groupsJSON, &prompt); err != nil {
+			t.Fatalf("query %s: %v", userID, err)
+		}
+		if profileID != "standard" || dailyLimit != 16000 || totalQuota != 32000 || dailySpending != 50 || concurrency != 2 || rpm != 30 || tpm != 40000 || modelsJSON != `["gpt-5.4"]` || groupsJSON != `["pro"]` || prompt != "Account prompt" {
+			t.Fatalf("synced %s = profile:%q daily:%d total:%d spend:%v concurrency:%d rpm:%d tpm:%d models:%s groups:%s prompt:%q", userID, profileID, dailyLimit, totalQuota, dailySpending, concurrency, rpm, tpm, modelsJSON, groupsJSON, prompt)
+		}
+	}
+	var removedProfileID string
+	if err := usage.RuntimeDB().QueryRow(`SELECT permission_profile_id FROM end_users WHERE id = 'user-b'`).Scan(&removedProfileID); err != nil {
+		t.Fatalf("query user-b: %v", err)
+	}
+	if removedProfileID != "" {
+		t.Fatalf("removed profile binding = %q, want empty", removedProfileID)
+	}
 }
 
 func TestAPIKeyPermissionProfilesManagementHandlersUseDatabase(t *testing.T) {

--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -157,18 +157,27 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 	}
 
 	var profiles []usage.APIKeyPermissionProfileRow
+	syncAccounts := false
 	if err = json.Unmarshal(data, &profiles); err != nil {
 		var obj struct {
-			Items []usage.APIKeyPermissionProfileRow `json:"items"`
+			Items        []usage.APIKeyPermissionProfileRow `json:"items"`
+			SyncAccounts bool                               `json:"sync-accounts"`
 		}
 		if err2 := json.Unmarshal(data, &obj); err2 != nil {
 			c.JSON(400, gin.H{"error": "invalid body"})
 			return
 		}
 		profiles = obj.Items
+		syncAccounts = obj.SyncAccounts
 	}
 
-	if err := h.apiKeySettings(c).ReplacePermissionProfiles(profiles); err != nil {
+	appliedCount := int64(0)
+	if syncAccounts {
+		appliedCount, err = h.apiKeySettings(c).ReplacePermissionProfilesAndSyncAccounts(profiles)
+	} else {
+		err = h.apiKeySettings(c).ReplacePermissionProfiles(profiles)
+	}
+	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -176,7 +185,7 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(200, gin.H{"status": "ok"})
+	c.JSON(200, gin.H{"status": "ok", "applied_count": appliedCount})
 }
 
 // api-key-entries: backed by SQLite api_keys table

--- a/internal/api/handlers/management/usage_public_test.go
+++ b/internal/api/handlers/management/usage_public_test.go
@@ -3,17 +3,226 @@ package management
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 )
+
+func setupOwnedPublicUsageDB(t *testing.T) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "owned-public-usage-*.db")
+	if err != nil {
+		t.Fatalf("create temp db: %v", err)
+	}
+	dbPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() {
+		enduser.SetDefault(nil)
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	db := usage.RuntimeDB()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS tenants (
+			id TEXT PRIMARY KEY, status TEXT NOT NULL, type TEXT NOT NULL, expires_at TIMESTAMP,
+			access_token_ttl_seconds INTEGER, refresh_token_ttl_seconds INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS end_users (
+			id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, username TEXT NOT NULL,
+			username_normalized TEXT NOT NULL UNIQUE, display_name TEXT NOT NULL, password_hash TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active', must_change_password INTEGER NOT NULL DEFAULT 0,
+			password_changed_at TIMESTAMP, last_login_at TIMESTAMP, failed_login_count INTEGER NOT NULL DEFAULT 0,
+			lock_stage INTEGER NOT NULL DEFAULT 0, locked_until TIMESTAMP, created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, version INTEGER NOT NULL DEFAULT 1,
+			permission_profile_id TEXT NOT NULL DEFAULT '', daily_limit INTEGER NOT NULL DEFAULT 0,
+			total_quota INTEGER NOT NULL DEFAULT 0, spending_limit REAL NOT NULL DEFAULT 0,
+			daily_spending_limit REAL NOT NULL DEFAULT 0, concurrency_limit INTEGER NOT NULL DEFAULT 0,
+			rpm_limit INTEGER NOT NULL DEFAULT 0, tpm_limit INTEGER NOT NULL DEFAULT 0,
+			allowed_models TEXT NOT NULL DEFAULT '[]', allowed_channels TEXT NOT NULL DEFAULT '[]',
+			allowed_channel_groups TEXT NOT NULL DEFAULT '[]', system_prompt TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE IF NOT EXISTS end_user_sessions (
+			id TEXT PRIMARY KEY, end_user_id TEXT NOT NULL, tenant_id TEXT NOT NULL,
+			access_token_hash TEXT NOT NULL UNIQUE, refresh_token_hash TEXT NOT NULL UNIQUE,
+			access_expires_at TIMESTAMP NOT NULL, refresh_expires_at TIMESTAMP NOT NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, last_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			revoked_at TIMESTAMP, revoke_reason TEXT NOT NULL DEFAULT '', user_agent_hash TEXT NOT NULL DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("create portal auth tables: %v", err)
+	}
+}
+
+func getPublicUsageSnapshot(t *testing.T, h *Handler, apiKey string) struct {
+	Found bool `json:"found"`
+	Usage struct {
+		APIs map[string]usage.APISnapshot `json:"apis"`
+	} `json:"usage"`
+} {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/public/usage", bytes.NewReader([]byte(`{"api_key":"`+apiKey+`"}`)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.GetPublicUsageByAPIKey(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Found bool `json:"found"`
+		Usage struct {
+			APIs map[string]usage.APISnapshot `json:"apis"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return response
+}
+
+func getPortalPublicUsageSnapshot(t *testing.T, h *Handler, bearer string) struct {
+	Found bool `json:"found"`
+	Usage struct {
+		APIs map[string]usage.APISnapshot `json:"apis"`
+	} `json:"usage"`
+} {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/public/usage", bytes.NewReader([]byte(`{}`)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Authorization", "Bearer "+bearer)
+	h.GetPublicUsageByAPIKey(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("portal status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Found bool `json:"found"`
+		Usage struct {
+			APIs map[string]usage.APISnapshot `json:"apis"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal portal response: %v", err)
+	}
+	return response
+}
+
+func TestGetPublicUsageByAPIKeyAggregatesOwnedCurrentSecrets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupOwnedPublicUsageDB(t)
+	tenantID := uuid.NewString()
+	endUserID := uuid.NewString()
+	keyA := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-memory-owned-a", Name: "A", EndUserID: endUserID}
+	keyB := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-memory-owned-b", Name: "B", EndUserID: endUserID}
+	standalone := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-memory-standalone", Name: "Standalone"}
+	for _, row := range []usage.APIKeyRow{keyA, keyB, standalone} {
+		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
+		}
+	}
+
+	stats := usage.NewRequestStatistics()
+	stats.MergeSnapshot(usage.StatisticsSnapshot{APIs: map[string]usage.APISnapshot{
+		keyA.Key: {
+			TotalRequests: 1,
+			TotalTokens:   10,
+			Models:        map[string]usage.ModelSnapshot{"gpt-5.4": {TotalRequests: 1, TotalTokens: 10}},
+		},
+		keyB.Key: {
+			TotalRequests: 2,
+			TotalTokens:   20,
+			Models:        map[string]usage.ModelSnapshot{"grok-4": {TotalRequests: 2, TotalTokens: 20}},
+		},
+		standalone.Key: {
+			TotalRequests: 4,
+			TotalTokens:   40,
+			Models:        map[string]usage.ModelSnapshot{"codex": {TotalRequests: 4, TotalTokens: 40}},
+		},
+	}})
+	h := NewHandler(&config.Config{}, "", nil)
+	h.SetUsageStatistics(stats)
+
+	if _, err := usage.RuntimeDB().Exec(`
+		INSERT INTO tenants (id, status, type) VALUES (?, 'active', 'standard')
+	`, tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if _, err := usage.RuntimeDB().Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status)
+		VALUES (?, ?, 'portal-user', 'portal-user', 'Portal User', 'unused', 'active')
+	`, endUserID, tenantID); err != nil {
+		t.Fatalf("insert portal user: %v", err)
+	}
+	portalToken := "cpt_portal-memory-test"
+	portalTokenSum := sha256.Sum256([]byte(portalToken))
+	if _, err := usage.RuntimeDB().Exec(`
+		INSERT INTO end_user_sessions (
+			id, end_user_id, tenant_id, access_token_hash, refresh_token_hash, access_expires_at, refresh_expires_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, uuid.NewString(), endUserID, tenantID, hex.EncodeToString(portalTokenSum[:]), "unused-refresh-hash",
+		time.Now().UTC().Add(time.Hour), time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatalf("insert portal session: %v", err)
+	}
+	enduser.SetDefault(enduser.NewService(usage.RuntimeDB()))
+
+	owned := getPublicUsageSnapshot(t, h, keyA.Key)
+	if !owned.Found || len(owned.Usage.APIs) != 1 {
+		t.Fatalf("owned response = %#v", owned)
+	}
+	for _, snapshot := range owned.Usage.APIs {
+		if snapshot.TotalRequests != 3 || snapshot.TotalTokens != 30 {
+			t.Fatalf("owned aggregate = %+v, want requests=3 tokens=30", snapshot)
+		}
+	}
+
+	portal := getPortalPublicUsageSnapshot(t, h, portalToken)
+	if !portal.Found || len(portal.Usage.APIs) != 1 {
+		t.Fatalf("portal response = %#v", portal)
+	}
+	for _, snapshot := range portal.Usage.APIs {
+		if snapshot.TotalRequests != 3 || snapshot.TotalTokens != 30 {
+			t.Fatalf("portal aggregate = %+v, want requests=3 tokens=30", snapshot)
+		}
+	}
+
+	standaloneResponse := getPublicUsageSnapshot(t, h, standalone.Key)
+	for _, snapshot := range standaloneResponse.Usage.APIs {
+		if snapshot.TotalRequests != 4 || snapshot.TotalTokens != 40 {
+			t.Fatalf("standalone aggregate = %+v, want requests=4 tokens=40", snapshot)
+		}
+	}
+
+	rotated := keyA
+	rotated.Key = "sk-memory-owned-a-rotated"
+	if err := usage.UpdateAPIKeyByIDForTenant(tenantID, rotated); err != nil {
+		t.Fatalf("UpdateAPIKeyByIDForTenant: %v", err)
+	}
+	afterRotate := getPublicUsageSnapshot(t, h, rotated.Key)
+	for _, snapshot := range afterRotate.Usage.APIs {
+		if snapshot.TotalRequests != 2 || snapshot.TotalTokens != 20 {
+			t.Fatalf("post-rotate current-secret aggregate = %+v, want surviving current key B only", snapshot)
+		}
+	}
+}
 
 func TestGetPublicUsageByAPIKeyMasksCredentialEverywhere(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/api/server_models_endpoint.go
+++ b/internal/api/server_models_endpoint.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -60,8 +61,9 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 		}
 
 		tenantID := requestTenantID(c)
+		tenantScoped := tenantID != identity.SystemTenantID
 		scopedRoutingRestricted := s.hasScopedRoutingModelRestrictionForTenant(tenantID, routeGroup, allowedChannelGroups)
-		needsScopeFilter := allowedModels != nil || allowedChannels != nil || allowedChannelGroups != nil || routeGroup != "" || scopedRoutingRestricted
+		needsScopeFilter := tenantScoped || allowedModels != nil || allowedChannels != nil || allowedChannelGroups != nil || routeGroup != "" || scopedRoutingRestricted
 
 		recorder := &responseRecorder{
 			ResponseWriter: c.Writer,
@@ -96,7 +98,7 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 							continue
 						}
 					}
-					if allowedChannels != nil || allowedChannelGroups != nil || routeGroup != "" {
+					if tenantScoped || allowedChannels != nil || allowedChannelGroups != nil || routeGroup != "" {
 						if s.handlers == nil || s.handlers.AuthManager == nil || !s.handlers.AuthManager.CanServeModelWithScopesForTenant(tenantID, id, allowedChannels, allowedChannelGroups, routeGroup) {
 							continue
 						}

--- a/internal/api/server_models_endpoint_test.go
+++ b/internal/api/server_models_endpoint_test.go
@@ -1,10 +1,124 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/claude"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/openai"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
+
+func TestUnifiedModelsHandlerScopesBusinessTenantAndAllowedModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const businessTenant = "cccccccc-dddd-eeee-ffff-000000000001"
+
+	modelRegistry := registry.GetGlobalRegistry()
+	businessAuthID := "models-business-tenant-auth"
+	systemAuthID := "models-system-tenant-auth"
+	modelRegistry.RegisterClient(businessAuthID, "openai", []*registry.ModelInfo{
+		{ID: "gpt-business-only"},
+		{ID: "codex-business-only"},
+		{ID: "grok-business-only"},
+	})
+	modelRegistry.RegisterClient(systemAuthID, "openai", []*registry.ModelInfo{
+		{ID: "gpt-system-only"},
+		{ID: "codex-system-only"},
+		{ID: "grok-system-only"},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(businessAuthID)
+		modelRegistry.UnregisterClient(systemAuthID)
+	})
+
+	authManager := coreauth.NewManager(nil, nil, nil)
+	authManager.SetConfigForTenant(businessTenant, &config.Config{})
+	authManager.SetConfigForTenant(identity.SystemTenantID, &config.Config{})
+	if _, err := authManager.Register(context.Background(), &coreauth.Auth{
+		ID: businessAuthID, TenantID: businessTenant, Provider: "openai", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register business auth: %v", err)
+	}
+	if _, err := authManager.Register(context.Background(), &coreauth.Auth{
+		ID: systemAuthID, TenantID: identity.SystemTenantID, Provider: "openai", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register system auth: %v", err)
+	}
+
+	cfg := &config.Config{}
+	base := handlers.NewBaseAPIHandlers(&cfg.SDKConfig, authManager)
+	server := &Server{handlers: base, cfg: cfg}
+	openaiHandler := openai.NewOpenAIAPIHandler(base)
+	claudeHandler := claude.NewClaudeCodeAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/models", func(c *gin.Context) {
+		c.Set("tenantID", businessTenant)
+		if c.Query("restricted") == "1" {
+			c.Set("accessMetadata", map[string]string{"allowed-models": "gpt-business-only,grok-business-only"})
+		}
+		server.unifiedModelsHandler(openaiHandler, claudeHandler)(c)
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	ids := modelIDs(response.Data)
+	for _, want := range []string{"gpt-business-only", "codex-business-only", "grok-business-only"} {
+		found := false
+		for _, id := range ids {
+			found = found || id == want
+		}
+		if !found {
+			t.Fatalf("business tenant models = %#v, missing %q", ids, want)
+		}
+	}
+	for _, forbidden := range []string{"gpt-system-only", "codex-system-only", "grok-system-only"} {
+		for _, id := range ids {
+			if id == forbidden {
+				t.Fatalf("business tenant response leaked system model %q: %#v", forbidden, ids)
+			}
+		}
+	}
+
+	restrictedRec := httptest.NewRecorder()
+	router.ServeHTTP(restrictedRec, httptest.NewRequest(http.MethodGet, "/v1/models?restricted=1", nil))
+	if restrictedRec.Code != http.StatusOK {
+		t.Fatalf("restricted status = %d, body=%s", restrictedRec.Code, restrictedRec.Body.String())
+	}
+	response.Data = nil
+	if err := json.Unmarshal(restrictedRec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal restricted response: %v", err)
+	}
+	ids = modelIDs(response.Data)
+	if !sameStrings(ids, []string{"gpt-business-only", "grok-business-only"}) &&
+		!sameStrings(ids, []string{"grok-business-only", "gpt-business-only"}) {
+		t.Fatalf("business tenant models = %#v, want allowed business GPT+Grok only", ids)
+	}
+	for _, forbidden := range []string{"gpt-system-only", "codex-system-only", "grok-system-only", "codex-business-only"} {
+		for _, id := range ids {
+			if id == forbidden {
+				t.Fatalf("business tenant response leaked forbidden model %q: %#v", forbidden, ids)
+			}
+		}
+	}
+}
 
 func TestFilterCodexModelsForCcSwitchRouteReturnsRequestModels(t *testing.T) {
 	models := []map[string]interface{}{

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -398,7 +400,7 @@ func (s *Service) ListUsers(ctx context.Context, actor identity.Principal, tenan
 func (s *Service) apiKeyCountsByUser(ctx context.Context, tenantID string) (map[string]int, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT end_user_id, COUNT(*) FROM api_keys
-		WHERE tenant_id = ? AND end_user_id IS NOT NULL
+		WHERE tenant_id = ? AND end_user_id IS NOT NULL AND disabled = 0
 		GROUP BY end_user_id
 	`, tenantID)
 	if err != nil {
@@ -827,7 +829,7 @@ func (s *Service) ListKeys(ctx context.Context, tenantID, endUserID string) ([]A
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, tenant_id, end_user_id, key, name, disabled, COALESCE(is_default, false),
 			COALESCE(created_at, ''), COALESCE(updated_at, '')
-		FROM api_keys WHERE tenant_id = ? AND end_user_id = ?
+		FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0
 		ORDER BY is_default DESC, created_at ASC
 	`, tenantID, endUserID)
 	if err != nil {
@@ -887,7 +889,7 @@ func (s *Service) CreateKey(ctx context.Context, tenantID, endUserID, name strin
 		return result, fmt.Errorf("%w: cannot create api key for non-active end user", ErrValidation)
 	}
 	var count int
-	_ = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ?`, tenantID, endUserID).Scan(&count)
+	_ = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0`, tenantID, endUserID).Scan(&count)
 	isDefault := count == 0
 	var plain string
 	for attempt := 0; attempt < 8; attempt++ {
@@ -948,7 +950,7 @@ func (s *Service) SetDefaultKey(ctx context.Context, tenantID, endUserID, keyID 
 	}
 	defer func() { _ = tx.Rollback() }()
 	var n int
-	if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ?`, tenantID, endUserID, keyID).Scan(&n); err != nil || n == 0 {
+	if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0`, tenantID, endUserID, keyID).Scan(&n); err != nil || n == 0 {
 		return ErrNotFound
 	}
 	if _, err = tx.ExecContext(ctx, `UPDATE api_keys SET is_default = false, updated_at = ? WHERE tenant_id = ? AND end_user_id = ?`, time.Now().UTC().Format(time.RFC3339), tenantID, endUserID); err != nil {
@@ -977,7 +979,7 @@ func (s *Service) UpdateKeyName(ctx context.Context, tenantID, endUserID, keyID,
 	if err := ensureUniqueKeyName(ctx, s.db, tenantID, endUserID, name, keyID); err != nil {
 		return err
 	}
-	res, err := s.db.ExecContext(ctx, `UPDATE api_keys SET name = ?, updated_at = ? WHERE tenant_id = ? AND end_user_id = ? AND id = ?`,
+	res, err := s.db.ExecContext(ctx, `UPDATE api_keys SET name = ?, updated_at = ? WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0`,
 		name, time.Now().UTC().Format(time.RFC3339), tenantID, endUserID, keyID)
 	if err != nil {
 		return err
@@ -996,12 +998,12 @@ func ensureUniqueKeyName(ctx context.Context, q queryRower, tenantID, endUserID,
 	if excludeKeyID == "" {
 		err = q.QueryRowContext(ctx, `
 			SELECT COUNT(*) FROM api_keys
-			WHERE tenant_id = ? AND end_user_id = ? AND LOWER(name) = LOWER(?)
+			WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0 AND LOWER(name) = LOWER(?)
 		`, tenantID, endUserID, name).Scan(&exists)
 	} else {
 		err = q.QueryRowContext(ctx, `
 			SELECT COUNT(*) FROM api_keys
-			WHERE tenant_id = ? AND end_user_id = ? AND LOWER(name) = LOWER(?) AND id != ?
+			WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0 AND LOWER(name) = LOWER(?) AND id != ?
 		`, tenantID, endUserID, name, excludeKeyID).Scan(&exists)
 	}
 	if err != nil {
@@ -1019,14 +1021,26 @@ type queryRower interface {
 
 func (s *Service) RotateKey(ctx context.Context, tenantID, endUserID, keyID string) (CreateKeyResult, error) {
 	var result CreateKeyResult
+	if err := requireUUID(tenantID); err != nil {
+		return result, err
+	}
+	if err := requireUUID(endUserID); err != nil {
+		return result, err
+	}
+	if err := requireUUID(keyID); err != nil {
+		return result, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return result, err
 	}
 	defer func() { _ = tx.Rollback() }()
-	var n int
-	if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ?`, tenantID, endUserID, keyID).Scan(&n); err != nil || n == 0 {
-		return result, ErrNotFound
+	var oldSecret string
+	if err = tx.QueryRowContext(ctx, `SELECT key FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0`, tenantID, endUserID, keyID).Scan(&oldSecret); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return result, ErrNotFound
+		}
+		return result, err
 	}
 	var plain string
 	for attempt := 0; attempt < 8; attempt++ {
@@ -1048,6 +1062,9 @@ func (s *Service) RotateKey(ctx context.Context, tenantID, endUserID, keyID stri
 	}
 	if err = tx.Commit(); err != nil {
 		return result, err
+	}
+	if _, backfillErr := usage.BackfillLegacyRequestLogsAPIKeyIDForTenant(context.Background(), tenantID, keyID, oldSecret); backfillErr != nil {
+		log.WithError(backfillErr).Warnf("enduser: legacy request log backfill failed after rotating key id %s in tenant %s", keyID, tenantID)
 	}
 	result.PlaintextKey = plain
 	result.APIKey = APIKey{ID: keyID, TenantID: tenantID, EndUserID: endUserID, KeyMasked: MaskAPIKey(plain), UpdatedAt: now}
@@ -1083,22 +1100,26 @@ func (s *Service) DeleteKey(ctx context.Context, tenantID, endUserID, keyID stri
 			return err2
 		}
 	}
-	var count int
-	if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ?`, tenantID, endUserID).Scan(&count); err != nil {
-		return err
-	}
-	if count <= 1 {
-		return ErrLastKey
-	}
 	var isDefault bool
-	err = tx.QueryRowContext(ctx, `SELECT COALESCE(is_default, false) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ?`, tenantID, endUserID, keyID).Scan(&isDefault)
+	err = tx.QueryRowContext(ctx, `SELECT COALESCE(is_default, false) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0`, tenantID, endUserID, keyID).Scan(&isDefault)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrNotFound
 	}
 	if err != nil {
 		return err
 	}
-	if _, err = tx.ExecContext(ctx, `DELETE FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ?`, tenantID, endUserID, keyID); err != nil {
+	var count int
+	if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0`, tenantID, endUserID).Scan(&count); err != nil {
+		return err
+	}
+	if count <= 1 {
+		return ErrLastKey
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE api_keys SET disabled = 1, is_default = false, updated_at = ?
+		WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0
+	`, now, tenantID, endUserID, keyID); err != nil {
 		return err
 	}
 	if isDefault {
@@ -1106,9 +1127,9 @@ func (s *Service) DeleteKey(ctx context.Context, tenantID, endUserID, keyID stri
 		if _, err = tx.ExecContext(ctx, `
 			UPDATE api_keys SET is_default = true, updated_at = ?
 			WHERE id = (
-				SELECT id FROM api_keys WHERE tenant_id = ? AND end_user_id = ? ORDER BY created_at ASC LIMIT 1
+				SELECT id FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0 ORDER BY created_at ASC LIMIT 1
 			)
-		`, time.Now().UTC().Format(time.RFC3339), tenantID, endUserID); err != nil {
+		`, now, tenantID, endUserID); err != nil {
 			return err
 		}
 	}

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -166,26 +166,42 @@ func (s *Service) PermissionProfiles() []usage.APIKeyPermissionProfileRow {
 }
 
 func (s *Service) ReplacePermissionProfiles(profiles []usage.APIKeyPermissionProfileRow) error {
+	normalized, err := s.normalizePermissionProfiles(profiles)
+	if err != nil {
+		return err
+	}
+	return usage.ReplaceAllAPIKeyPermissionProfilesForTenant(s.tenantID, normalized)
+}
+
+func (s *Service) ReplacePermissionProfilesAndSyncAccounts(profiles []usage.APIKeyPermissionProfileRow) (int64, error) {
+	normalized, err := s.normalizePermissionProfiles(profiles)
+	if err != nil {
+		return 0, err
+	}
+	return usage.ReplaceAllAPIKeyPermissionProfilesForTenantAndSyncEndUsers(s.tenantID, normalized)
+}
+
+func (s *Service) normalizePermissionProfiles(profiles []usage.APIKeyPermissionProfileRow) ([]usage.APIKeyPermissionProfileRow, error) {
 	normalized := make([]usage.APIKeyPermissionProfileRow, len(profiles))
 	copy(normalized, profiles)
 	for idx := range normalized {
 		normalized[idx].ID = strings.TrimSpace(normalized[idx].ID)
 		normalized[idx].Name = strings.TrimSpace(normalized[idx].Name)
 		if normalized[idx].ID == "" {
-			return ErrInvalidProfileID
+			return nil, ErrInvalidProfileID
 		}
 		if normalized[idx].Name == "" {
-			return ErrInvalidProfileName
+			return nil, ErrInvalidProfileName
 		}
 		if s != nil && s.sanitizeChannels != nil {
 			cleaned, err := s.sanitizeChannels(normalized[idx].AllowedChannels)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			normalized[idx].AllowedChannels = cleaned
 		}
 	}
-	return usage.ReplaceAllAPIKeyPermissionProfilesForTenant(s.tenantID, normalized)
+	return normalized, nil
 }
 
 func (s *Service) RenameAllowedChannelRestrictions(oldNameSet map[string]struct{}, newName string) error {

--- a/internal/storage/sqlite/apikey/permission_profiles.go
+++ b/internal/storage/sqlite/apikey/permission_profiles.go
@@ -13,8 +13,8 @@ import (
 
 const createAPIKeyPermissionProfilesTableSQL = `
 CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
-  id                     TEXT PRIMARY KEY NOT NULL,
   tenant_id              TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+  id                     TEXT NOT NULL,
   name                   TEXT NOT NULL DEFAULT '',
   daily_limit            INTEGER NOT NULL DEFAULT 0,
   total_quota            INTEGER NOT NULL DEFAULT 0,
@@ -27,7 +27,8 @@ CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
   allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
   system_prompt          TEXT NOT NULL DEFAULT '',
   created_at             TEXT NOT NULL DEFAULT '',
-  updated_at             TEXT NOT NULL DEFAULT ''
+  updated_at             TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (tenant_id, id)
 );
 `
 
@@ -62,6 +63,82 @@ func InitPermissionProfilesTable(db *sql.DB) {
 	if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN daily_spending_limit REAL NOT NULL DEFAULT 0"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
 		log.Warnf("sqlite/apikey: migrate api_key_permission_profiles daily_spending_limit: %v", err)
 	}
+	if err := migratePermissionProfilesTenantPrimaryKey(db); err != nil {
+		log.Errorf("sqlite/apikey: migrate api_key_permission_profiles tenant primary key: %v", err)
+	}
+}
+
+func migratePermissionProfilesTenantPrimaryKey(db *sql.DB) error {
+	driverType := strings.ToLower(fmt.Sprintf("%T", db.Driver()))
+	if strings.Contains(driverType, "postgres") || strings.Contains(driverType, "compatdriver") {
+		return nil
+	}
+	rows, err := db.Query("PRAGMA table_info(api_key_permission_profiles)")
+	if err != nil {
+		// PostgreSQL uses its own migration for the composite primary key.
+		return nil
+	}
+	defer rows.Close()
+	primaryKeyColumns := map[int]string{}
+	for rows.Next() {
+		var cid, notNull, primaryKeyOrder int
+		var name, columnType string
+		var defaultValue interface{}
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKeyOrder); err != nil {
+			return err
+		}
+		if primaryKeyOrder > 0 {
+			primaryKeyColumns[primaryKeyOrder] = strings.ToLower(strings.TrimSpace(name))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if primaryKeyColumns[1] == "tenant_id" && primaryKeyColumns[2] == "id" && len(primaryKeyColumns) == 2 {
+		return nil
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err = tx.Exec(`DROP TABLE IF EXISTS api_key_permission_profiles_tenant_pk`); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(`
+		CREATE TABLE api_key_permission_profiles_tenant_pk (
+			tenant_id TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+			id TEXT NOT NULL, name TEXT NOT NULL DEFAULT '', daily_limit INTEGER NOT NULL DEFAULT 0,
+			total_quota INTEGER NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+			concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0,
+			tpm_limit INTEGER NOT NULL DEFAULT 0, allowed_models TEXT NOT NULL DEFAULT '[]',
+			allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT '',
+			updated_at TEXT NOT NULL DEFAULT '', PRIMARY KEY (tenant_id, id)
+		)
+	`); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(`
+		INSERT INTO api_key_permission_profiles_tenant_pk (
+			tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
+			rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
+		)
+		SELECT CASE WHEN trim(coalesce(tenant_id, '')) = '' THEN ? ELSE tenant_id END,
+			id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
+			rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
+		FROM api_key_permission_profiles
+	`, systemTenantID); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(`DROP TABLE api_key_permission_profiles`); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(`ALTER TABLE api_key_permission_profiles_tenant_pk RENAME TO api_key_permission_profiles`); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s Store) ListPermissionProfiles() []PermissionProfileRow {
@@ -94,18 +171,27 @@ func (s Store) ListPermissionProfiles() []PermissionProfileRow {
 }
 
 func (s Store) ReplaceAllPermissionProfiles(profiles []PermissionProfileRow) error {
+	_, err := s.replaceAllPermissionProfiles(profiles, false)
+	return err
+}
+
+func (s Store) ReplaceAllPermissionProfilesAndSyncEndUsers(profiles []PermissionProfileRow) (int64, error) {
+	return s.replaceAllPermissionProfiles(profiles, true)
+}
+
+func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syncEndUsers bool) (int64, error) {
 	if s.db == nil {
-		return fmt.Errorf("database not initialised")
+		return 0, fmt.Errorf("database not initialised")
 	}
 
 	tx, err := s.db.Begin()
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if _, err := tx.Exec("DELETE FROM api_key_permission_profiles WHERE tenant_id = ?", s.tenantID); err != nil {
 		_ = tx.Rollback()
-		return err
+		return 0, err
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_key_permission_profiles
@@ -114,7 +200,7 @@ func (s Store) ReplaceAllPermissionProfiles(profiles []PermissionProfileRow) err
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
-		return err
+		return 0, err
 	}
 	defer stmt.Close()
 
@@ -124,15 +210,15 @@ func (s Store) ReplaceAllPermissionProfiles(profiles []PermissionProfileRow) err
 		profile = normalizePermissionProfile(profile)
 		if profile.ID == "" {
 			_ = tx.Rollback()
-			return fmt.Errorf("id is required")
+			return 0, fmt.Errorf("id is required")
 		}
 		if profile.Name == "" {
 			_ = tx.Rollback()
-			return fmt.Errorf("name is required")
+			return 0, fmt.Errorf("name is required")
 		}
 		if _, exists := seen[profile.ID]; exists {
 			_ = tx.Rollback()
-			return fmt.Errorf("duplicate id %q", profile.ID)
+			return 0, fmt.Errorf("duplicate id %q", profile.ID)
 		}
 		seen[profile.ID] = struct{}{}
 		if profile.CreatedAt == "" {
@@ -148,11 +234,61 @@ func (s Store) ReplaceAllPermissionProfiles(profiles []PermissionProfileRow) err
 			profile.CreatedAt, profile.UpdatedAt,
 		); err != nil {
 			_ = tx.Rollback()
-			return err
+			return 0, err
 		}
 	}
 
-	return tx.Commit()
+	appliedCount := int64(0)
+	if syncEndUsers {
+		for _, profile := range profiles {
+			profile = normalizePermissionProfile(profile)
+			result, syncErr := tx.Exec(`
+				UPDATE end_users SET
+					permission_profile_id = ?, daily_limit = ?, total_quota = ?, spending_limit = 0,
+					daily_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
+					allowed_models = ?, allowed_channels = ?, allowed_channel_groups = ?, system_prompt = ?,
+					updated_at = ?, version = version + 1
+				WHERE tenant_id = ? AND permission_profile_id = ?
+			`, profile.ID, profile.DailyLimit, profile.TotalQuota, profile.DailySpendingLimit,
+				profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
+				mustJSONStringList(profile.AllowedModels), mustJSONStringList(profile.AllowedChannels),
+				mustJSONStringList(profile.AllowedChannelGroups), profile.SystemPrompt,
+				now, s.tenantID, profile.ID)
+			if syncErr != nil {
+				_ = tx.Rollback()
+				return 0, syncErr
+			}
+			if rows, rowsErr := result.RowsAffected(); rowsErr == nil {
+				appliedCount += rows
+			}
+		}
+
+		unbindQuery := `
+			UPDATE end_users SET permission_profile_id = '', updated_at = ?, version = version + 1
+			WHERE tenant_id = ? AND permission_profile_id != ''`
+		unbindArgs := []interface{}{now, s.tenantID}
+		if len(seen) > 0 {
+			placeholders := make([]string, 0, len(seen))
+			for profileID := range seen {
+				placeholders = append(placeholders, "?")
+				unbindArgs = append(unbindArgs, profileID)
+			}
+			unbindQuery += ` AND permission_profile_id NOT IN (` + strings.Join(placeholders, ",") + `)`
+		}
+		result, syncErr := tx.Exec(unbindQuery, unbindArgs...)
+		if syncErr != nil {
+			_ = tx.Rollback()
+			return 0, syncErr
+		}
+		if rows, rowsErr := result.RowsAffected(); rowsErr == nil {
+			appliedCount += rows
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return appliedCount, nil
 }
 
 func normalizePermissionProfile(profile PermissionProfileRow) PermissionProfileRow {

--- a/internal/storage/sqlite/apikey/permission_profiles_tenant_test.go
+++ b/internal/storage/sqlite/apikey/permission_profiles_tenant_test.go
@@ -1,0 +1,98 @@
+package apikey
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestPermissionProfilesMigrateToTenantScopedPrimaryKeyAndSyncIsolatedAccounts(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`
+		CREATE TABLE api_key_permission_profiles (
+			id TEXT PRIMARY KEY NOT NULL,
+			tenant_id TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+			name TEXT NOT NULL DEFAULT '', daily_limit INTEGER NOT NULL DEFAULT 0,
+			total_quota INTEGER NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+			concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0,
+			tpm_limit INTEGER NOT NULL DEFAULT 0, allowed_models TEXT NOT NULL DEFAULT '[]',
+			allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT ''
+		);
+		INSERT INTO api_key_permission_profiles (tenant_id, id, name)
+		VALUES ('00000000-0000-0000-0000-000000000001', 'standard', 'Legacy system');
+		CREATE TABLE end_users (
+			id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, permission_profile_id TEXT NOT NULL DEFAULT '',
+			daily_limit INTEGER NOT NULL DEFAULT 0, total_quota INTEGER NOT NULL DEFAULT 0,
+			spending_limit REAL NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+			concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0,
+			tpm_limit INTEGER NOT NULL DEFAULT 0, allowed_models TEXT NOT NULL DEFAULT '[]',
+			allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '', version INTEGER NOT NULL DEFAULT 1
+		)
+	`); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+
+	InitPermissionProfilesTable(db)
+	const tenantA = "00000000-0000-0000-0000-00000000000a"
+	const tenantB = "00000000-0000-0000-0000-00000000000b"
+	for _, row := range []struct {
+		id       string
+		tenantID string
+	}{
+		{id: "user-a", tenantID: tenantA},
+		{id: "user-b", tenantID: tenantB},
+	} {
+		if _, err := db.Exec(`
+			INSERT INTO end_users (id, tenant_id, permission_profile_id)
+			VALUES (?, ?, 'standard')
+		`, row.id, row.tenantID); err != nil {
+			t.Fatalf("insert %s: %v", row.id, err)
+		}
+	}
+
+	storeA := NewTenantStore(db, tenantA)
+	storeB := NewTenantStore(db, tenantB)
+	if count, err := storeA.ReplaceAllPermissionProfilesAndSyncEndUsers([]PermissionProfileRow{
+		{ID: "standard", Name: "Tenant A", DailyLimit: 10},
+	}); err != nil || count != 1 {
+		t.Fatalf("tenant A replace+sync = count:%d err:%v", count, err)
+	}
+	if count, err := storeB.ReplaceAllPermissionProfilesAndSyncEndUsers([]PermissionProfileRow{
+		{ID: "standard", Name: "Tenant B", DailyLimit: 20},
+	}); err != nil || count != 1 {
+		t.Fatalf("tenant B replace+sync = count:%d err:%v", count, err)
+	}
+
+	if got := storeA.ListPermissionProfiles(); len(got) != 1 || got[0].Name != "Tenant A" || got[0].DailyLimit != 10 {
+		t.Fatalf("tenant A profiles = %#v", got)
+	}
+	if got := storeB.ListPermissionProfiles(); len(got) != 1 || got[0].Name != "Tenant B" || got[0].DailyLimit != 20 {
+		t.Fatalf("tenant B profiles = %#v", got)
+	}
+	if got := NewStore(db).ListPermissionProfiles(); len(got) != 1 || got[0].Name != "Legacy system" {
+		t.Fatalf("system profile was not preserved by migration: %#v", got)
+	}
+
+	for _, want := range []struct {
+		id    string
+		limit int
+	}{
+		{id: "user-a", limit: 10},
+		{id: "user-b", limit: 20},
+	} {
+		var limit int
+		if err := db.QueryRow(`SELECT daily_limit FROM end_users WHERE id = ?`, want.id).Scan(&limit); err != nil {
+			t.Fatalf("query %s: %v", want.id, err)
+		}
+		if limit != want.limit {
+			t.Fatalf("%s daily_limit = %d, want %d", want.id, limit, want.limit)
+		}
+	}
+}

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -448,15 +448,42 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 		return fmt.Errorf("key is required")
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339)
-	if existing := s.GetByID(entry.ID); existing != nil {
-		if entry.CreatedAt == "" && existing.CreatedAt != "" {
-			entry.CreatedAt = existing.CreatedAt
-		}
-		if strings.TrimSpace(entry.EndUserID) == "" {
-			entry.EndUserID = existing.EndUserID
-		}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
 	}
+	defer func() { _ = tx.Rollback() }()
+
+	var owner sql.NullString
+	var createdAt string
+	var wasDefault bool
+	if err = tx.QueryRow(`
+		SELECT end_user_id, created_at, COALESCE(is_default, false)
+		FROM api_keys WHERE tenant_id = ? AND id = ?
+	`, s.tenantID, entry.ID).Scan(&owner, &createdAt, &wasDefault); err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return err
+	}
+	ownerID := ""
+	if owner.Valid {
+		ownerID = strings.TrimSpace(owner.String)
+	}
+	if ownerID != "" {
+		if err = lockOwnedEndUser(tx, ownerID); err != nil {
+			return err
+		}
+		entry.EndUserID = ownerID
+		entry.IsDefault = wasDefault && !entry.Disabled
+	} else {
+		entry.EndUserID = ""
+		entry.IsDefault = false
+	}
+	if entry.CreatedAt == "" {
+		entry.CreatedAt = createdAt
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
 	if entry.CreatedAt == "" {
 		entry.CreatedAt = now
 	}
@@ -466,19 +493,91 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 	if entry.Disabled {
 		disabledInt = 1
 	}
-
-	_, err := s.db.Exec(`UPDATE api_keys SET
+	result, err := tx.Exec(`UPDATE api_keys SET
 		key = ?, name = ?, disabled = ?, permission_profile_id = ?, daily_limit = ?, total_quota = ?,
 		spending_limit = ?, daily_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
 		allowed_models = ?, allowed_channels = ?, allowed_channel_groups = ?, system_prompt = ?,
-		created_at = ?, updated_at = ?
+		created_at = ?, updated_at = ?, is_default = ?
 		WHERE tenant_id = ? AND id = ?`,
 		entry.Key, entry.Name, disabledInt, entry.PermissionProfileID, entry.DailyLimit, entry.TotalQuota,
 		entry.SpendingLimit, entry.DailySpendingLimit, entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
-		entry.CreatedAt, now, s.tenantID, entry.ID,
+		entry.CreatedAt, now, entry.IsDefault, s.tenantID, entry.ID,
 	)
+	if err != nil {
+		return err
+	}
+	if affected, _ := result.RowsAffected(); affected == 0 {
+		return nil
+	}
+	if ownerID != "" {
+		if err = ensureOwnedActiveKeyAndDefault(tx, s.tenantID, ownerID, now); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func lockOwnedEndUser(tx *sql.Tx, ownerID string) error {
+	if tx == nil || strings.TrimSpace(ownerID) == "" {
+		return nil
+	}
+	if _, err := tx.Exec(`SELECT id FROM end_users WHERE id = ? FOR UPDATE`, ownerID); err != nil {
+		msg := strings.ToLower(err.Error())
+		if strings.Contains(msg, "syntax") || strings.Contains(msg, "for update") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func ensureOwnedActiveKeyAndDefault(tx *sql.Tx, tenantID, ownerID, now string) error {
+	var activeCount int
+	if err := tx.QueryRow(`
+		SELECT COUNT(*) FROM api_keys
+		WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0
+	`, tenantID, ownerID).Scan(&activeCount); err != nil {
+		return err
+	}
+	if activeCount < 1 {
+		return fmt.Errorf("cannot disable last active api key for end user %s", ownerID)
+	}
+	if _, err := tx.Exec(`
+		UPDATE api_keys SET is_default = false, updated_at = ?
+		WHERE tenant_id = ? AND end_user_id = ? AND disabled != 0 AND is_default
+	`, now, tenantID, ownerID); err != nil {
+		return err
+	}
+
+	var keepID string
+	err := tx.QueryRow(`
+		SELECT id FROM api_keys
+		WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0 AND is_default
+		ORDER BY created_at ASC, id ASC LIMIT 1
+	`, tenantID, ownerID).Scan(&keepID)
+	if err == sql.ErrNoRows {
+		if err = tx.QueryRow(`
+			SELECT id FROM api_keys
+			WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0
+			ORDER BY created_at ASC, id ASC LIMIT 1
+		`, tenantID, ownerID).Scan(&keepID); err != nil {
+			return err
+		}
+		if _, err = tx.Exec(`
+			UPDATE api_keys SET is_default = true, updated_at = ?
+			WHERE tenant_id = ? AND id = ?
+		`, now, tenantID, keepID); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	_, err = tx.Exec(`
+		UPDATE api_keys SET is_default = false, updated_at = ?
+		WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0 AND is_default AND id <> ?
+	`, now, tenantID, ownerID, keepID)
 	return err
 }
 
@@ -498,8 +597,9 @@ func (s Store) deleteOwnedGuarded(where string, arg string) error {
 
 	var endUserID sql.NullString
 	var keyID string
-	q := `SELECT id, end_user_id FROM api_keys WHERE tenant_id = ? AND ` + where + ` LIMIT 1`
-	if err = tx.QueryRow(q, s.tenantID, arg).Scan(&keyID, &endUserID); err != nil {
+	var disabledInt int
+	q := `SELECT id, end_user_id, disabled FROM api_keys WHERE tenant_id = ? AND ` + where + ` LIMIT 1`
+	if err = tx.QueryRow(q, s.tenantID, arg).Scan(&keyID, &endUserID, &disabledInt); err != nil {
 		if err == sql.ErrNoRows {
 			return nil
 		}
@@ -509,56 +609,27 @@ func (s Store) deleteOwnedGuarded(where string, arg string) error {
 	if endUserID.Valid {
 		ownerID = strings.TrimSpace(endUserID.String)
 	}
-	wasDefault := false
 	if ownerID != "" {
-		// Best-effort row lock on owner (Postgres); SQLite ignores unsupported syntax via fallback.
-		if _, err = tx.Exec(`SELECT id FROM end_users WHERE id = ? FOR UPDATE`, ownerID); err != nil {
-			msg := strings.ToLower(err.Error())
-			if !strings.Contains(msg, "syntax") && !strings.Contains(msg, "for update") {
-				return err
-			}
+		if disabledInt != 0 {
+			return nil
 		}
-		var n int
-		if err = tx.QueryRow(
-			`SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ?`,
-			s.tenantID, ownerID,
-		).Scan(&n); err != nil {
+		if err = lockOwnedEndUser(tx, ownerID); err != nil {
 			return err
 		}
-		if n <= 1 {
-			return fmt.Errorf("cannot delete last api key owned by an end user")
-		}
-		_ = tx.QueryRow(
-			`SELECT COALESCE(is_default, false) FROM api_keys WHERE tenant_id = ? AND id = ?`,
-			s.tenantID, keyID,
-		).Scan(&wasDefault)
 	}
-	if _, err = tx.Exec(`DELETE FROM api_keys WHERE tenant_id = ? AND id = ?`, s.tenantID, keyID); err != nil {
-		return err
-	}
-	if ownerID != "" && wasDefault {
-		now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if ownerID != "" {
 		if _, err = tx.Exec(`
-			UPDATE api_keys SET is_default = true, updated_at = ?
-			 WHERE id = (
-				SELECT id FROM api_keys
-				 WHERE tenant_id = ? AND end_user_id = ?
-				 ORDER BY created_at ASC, id ASC LIMIT 1
-			 )
-		`, now, s.tenantID, ownerID); err != nil {
-			// Some engines disallow updating the same table as the subquery target.
-			var promoteID string
-			if err2 := tx.QueryRow(`
-				SELECT id FROM api_keys
-				 WHERE tenant_id = ? AND end_user_id = ?
-				 ORDER BY created_at ASC, id ASC LIMIT 1
-			`, s.tenantID, ownerID).Scan(&promoteID); err2 != nil {
-				return err
-			}
-			if _, err = tx.Exec(`UPDATE api_keys SET is_default = true, updated_at = ? WHERE tenant_id = ? AND id = ?`, now, s.tenantID, promoteID); err != nil {
-				return err
-			}
+			UPDATE api_keys SET disabled = 1, is_default = false, updated_at = ?
+			WHERE tenant_id = ? AND id = ?
+		`, now, s.tenantID, keyID); err != nil {
+			return err
 		}
+		if err = ensureOwnedActiveKeyAndDefault(tx, s.tenantID, ownerID, now); err != nil {
+			return err
+		}
+	} else if _, err = tx.Exec(`DELETE FROM api_keys WHERE tenant_id = ? AND id = ?`, s.tenantID, keyID); err != nil {
+		return err
 	}
 	return tx.Commit()
 }
@@ -616,7 +687,6 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 	resolved := make([]resolvedEntry, 0, len(entries))
 	seenIDs := make(map[string]struct{}, len(entries))
 	seenKeys := make(map[string]struct{}, len(entries))
-	finalOwnerCount := make(map[string]int)
 	for _, entry := range entries {
 		entry = normalizeRow(entry)
 		if entry.Key == "" {
@@ -652,9 +722,6 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 			entry.EndUserID = ""
 			entry.IsDefault = false
 		}
-		if entry.EndUserID != "" {
-			finalOwnerCount[entry.EndUserID]++
-		}
 		resolved = append(resolved, resolvedEntry{row: entry})
 	}
 	ownedBefore := make(map[string]struct{})
@@ -668,13 +735,6 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 			ownedBefore[prev.endUserID] = struct{}{}
 		}
 	}
-	for endUserID := range ownedBefore {
-		if finalOwnerCount[endUserID] < 1 {
-			_ = tx.Rollback()
-			return fmt.Errorf("cannot remove last api key for end user %s", endUserID)
-		}
-	}
-
 	if _, err := tx.Exec("DELETE FROM api_keys WHERE tenant_id = ?", s.tenantID); err != nil {
 		_ = tx.Rollback()
 		return err
@@ -719,98 +779,14 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 		}
 	}
 
-	// Portable rebalance (SQLite + Postgres): one default per owned user.
-	if err := promoteMissingDefaultsSQLite(tx, s.tenantID, now); err != nil {
-		_ = tx.Rollback()
-		return err
-	}
-	if err := demoteExtraDefaultsSQLite(tx, s.tenantID, now); err != nil {
-		_ = tx.Rollback()
-		return err
+	for endUserID := range ownedBefore {
+		if err := ensureOwnedActiveKeyAndDefault(tx, s.tenantID, endUserID, now); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
 	}
 
 	return tx.Commit()
-}
-
-func promoteMissingDefaultsSQLite(tx *sql.Tx, tenantID, now string) error {
-	// Portable across SQLite INTEGER and Postgres BOOLEAN is_default.
-	rows, err := tx.Query(`
-		SELECT end_user_id FROM api_keys
-		 WHERE tenant_id = ? AND end_user_id IS NOT NULL AND CAST(end_user_id AS TEXT) <> ''
-		 GROUP BY end_user_id
-		HAVING SUM(CASE WHEN is_default THEN 1 ELSE 0 END) = 0
-	`, tenantID)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-	var users []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return err
-		}
-		users = append(users, id)
-	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	for _, endUserID := range users {
-		var keyID string
-		if err := tx.QueryRow(`
-			SELECT id FROM api_keys
-			 WHERE tenant_id = ? AND end_user_id = ?
-			 ORDER BY created_at ASC, id ASC LIMIT 1
-		`, tenantID, endUserID).Scan(&keyID); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`UPDATE api_keys SET is_default = true, updated_at = ? WHERE tenant_id = ? AND id = ?`, now, tenantID, keyID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func demoteExtraDefaultsSQLite(tx *sql.Tx, tenantID, now string) error {
-	rows, err := tx.Query(`
-		SELECT end_user_id FROM api_keys
-		 WHERE tenant_id = ? AND end_user_id IS NOT NULL AND CAST(end_user_id AS TEXT) <> ''
-		   AND is_default
-		 GROUP BY end_user_id
-		HAVING COUNT(*) > 1
-	`, tenantID)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-	var users []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return err
-		}
-		users = append(users, id)
-	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	for _, endUserID := range users {
-		var keepID string
-		if err := tx.QueryRow(`
-			SELECT id FROM api_keys
-			 WHERE tenant_id = ? AND end_user_id = ? AND is_default
-			 ORDER BY created_at ASC, id ASC LIMIT 1
-		`, tenantID, endUserID).Scan(&keepID); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`
-			UPDATE api_keys SET is_default = false, updated_at = ?
-			 WHERE tenant_id = ? AND end_user_id = ? AND is_default AND id <> ?
-		`, now, tenantID, endUserID, keepID); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func EffectiveAPIKeyRowWithProfiles(row APIKeyRow, profiles []PermissionProfileSnapshot) APIKeyRow {

--- a/internal/storage/sqlite/apikey/store_tenant_test.go
+++ b/internal/storage/sqlite/apikey/store_tenant_test.go
@@ -131,3 +131,72 @@ func TestReplaceAllPreservesOwnershipAndRejectsLastKeyDrop(t *testing.T) {
 		t.Fatal("expected replace that drops eu-2 via id/key confusion to fail")
 	}
 }
+
+func TestOwnedKeyMutationsKeepOneActiveDefault(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	InitTable(db)
+	if _, err := db.Exec(`CREATE TABLE end_users (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+	for _, ownerID := range []string{"eu-last", "eu-default"} {
+		if _, err := db.Exec(`INSERT INTO end_users (id) VALUES (?)`, ownerID); err != nil {
+			t.Fatalf("insert %s: %v", ownerID, err)
+		}
+	}
+
+	store := NewTenantStore(db, "00000000-0000-0000-0000-00000000000a")
+	if err := store.Upsert(APIKeyRow{
+		ID: "last", Key: "sk-last", Name: "last", EndUserID: "eu-last", IsDefault: true,
+	}); err != nil {
+		t.Fatalf("seed last key: %v", err)
+	}
+	last := *store.GetByID("last")
+	last.Disabled = true
+	if err := store.UpdateByID(last); err == nil {
+		t.Fatal("disabling the last active owned key should fail")
+	}
+	if got := store.GetByID("last"); got == nil || got.Disabled || !got.IsDefault {
+		t.Fatalf("last key changed after rejected disable: %#v", got)
+	}
+
+	if err := store.Upsert(APIKeyRow{
+		ID: "default-a", Key: "sk-default-a", Name: "a", EndUserID: "eu-default", IsDefault: true,
+	}); err != nil {
+		t.Fatalf("seed default-a: %v", err)
+	}
+	if err := store.Upsert(APIKeyRow{
+		ID: "default-b", Key: "sk-default-b", Name: "b", EndUserID: "eu-default",
+	}); err != nil {
+		t.Fatalf("seed default-b: %v", err)
+	}
+	defaultA := *store.GetByID("default-a")
+	defaultA.Disabled = true
+	if err := store.UpdateByID(defaultA); err != nil {
+		t.Fatalf("disable one of two active keys: %v", err)
+	}
+	if got := store.GetByID("default-a"); got == nil || !got.Disabled || got.IsDefault {
+		t.Fatalf("disabled key retained default: %#v", got)
+	}
+	if got := store.GetByID("default-b"); got == nil || got.Disabled || !got.IsDefault {
+		t.Fatalf("remaining active key was not promoted: %#v", got)
+	}
+
+	rows := store.List()
+	for i := range rows {
+		if rows[i].EndUserID == "eu-default" {
+			rows[i].Disabled = true
+		}
+	}
+	if err := store.ReplaceAll(rows); err == nil {
+		t.Fatal("replace that disables every key for an owner should fail")
+	}
+	if got := store.GetByID("default-b"); got == nil || got.Disabled || !got.IsDefault {
+		t.Fatalf("failed replace changed active/default state: %#v", got)
+	}
+}

--- a/internal/usage/api_key_identity.go
+++ b/internal/usage/api_key_identity.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"context"
 	"database/sql"
 	"strings"
 
@@ -12,6 +13,32 @@ type APIKeyIdentity struct {
 	ID   string
 	Key  string
 	Name string
+}
+
+// BackfillLegacyRequestLogsAPIKeyIDForTenant preserves account ownership for
+// legacy rows that only recorded the raw secret before an owned key is rotated.
+func BackfillLegacyRequestLogsAPIKeyIDForTenant(ctx context.Context, tenantID, apiKeyID, oldSecret string) (int64, error) {
+	db := getDB()
+	if db == nil {
+		return 0, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	apiKeyID = strings.TrimSpace(apiKeyID)
+	oldSecret = strings.TrimSpace(oldSecret)
+	if apiKeyID == "" || oldSecret == "" {
+		return 0, nil
+	}
+	result, err := db.ExecContext(ctx, `
+		UPDATE request_logs
+		SET api_key_id = ?
+		WHERE tenant_id = ?
+		  AND trim(coalesce(api_key_id, '')) = ''
+		  AND api_key = ?
+	`, apiKeyID, tenantID, oldSecret)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 func ResolveAPIKeyIdentity(key string) *APIKeyIdentity {

--- a/internal/usage/api_key_permission_profiles_db.go
+++ b/internal/usage/api_key_permission_profiles_db.go
@@ -44,6 +44,10 @@ func ReplaceAllAPIKeyPermissionProfilesForTenant(tenantID string, profiles []API
 	return apiKeyPermissionProfileStoreForTenant(tenantID).ReplaceAllPermissionProfiles(profiles)
 }
 
+func ReplaceAllAPIKeyPermissionProfilesForTenantAndSyncEndUsers(tenantID string, profiles []APIKeyPermissionProfileRow) (int64, error) {
+	return apiKeyPermissionProfileStoreForTenant(tenantID).ReplaceAllPermissionProfilesAndSyncEndUsers(profiles)
+}
+
 func MigrateAPIKeyPermissionProfilesFromYAML(configFilePath string) int {
 	db := getDB()
 	if db == nil || strings.TrimSpace(configFilePath) == "" {

--- a/internal/usage/enduser_key_lifecycle_external_test.go
+++ b/internal/usage/enduser_key_lifecycle_external_test.go
@@ -1,0 +1,193 @@
+package usage_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func setupEndUserKeyLifecycleDB(t *testing.T) *sql.DB {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "enduser-key-lifecycle-*.db")
+	if err != nil {
+		t.Fatalf("create temp db: %v", err)
+	}
+	dbPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	db := usage.RuntimeDB()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS end_users (
+			id TEXT PRIMARY KEY,
+			tenant_id TEXT NOT NULL,
+			username TEXT NOT NULL,
+			username_normalized TEXT NOT NULL UNIQUE,
+			display_name TEXT NOT NULL,
+			password_hash TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active',
+			must_change_password INTEGER NOT NULL DEFAULT 0,
+			password_changed_at TEXT,
+			last_login_at TEXT,
+			failed_login_count INTEGER NOT NULL DEFAULT 0,
+			lock_stage INTEGER NOT NULL DEFAULT 0,
+			locked_until TEXT,
+			created_at TEXT NOT NULL DEFAULT '',
+			updated_at TEXT NOT NULL DEFAULT '',
+			version INTEGER NOT NULL DEFAULT 1
+		)
+	`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+	if err := usage.EnsureEndUserQuotaColumns(db); err != nil {
+		t.Fatalf("EnsureEndUserQuotaColumns: %v", err)
+	}
+	return db
+}
+
+func insertLifecycleUser(t *testing.T, db *sql.DB, tenantID, userID string) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (
+			id, tenant_id, username, username_normalized, display_name, password_hash,
+			status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, 'Lifecycle User', 'x', 'active', ?, ?)
+	`, userID, tenantID, userID, userID, time.Now().UTC().Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
+}
+
+func insertLifecycleLog(t *testing.T, db *sql.DB, tenantID, apiKey, apiKeyID string, cost float64) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO request_logs (
+			tenant_id, timestamp, api_key, api_key_id, api_key_name, model, source,
+			failed, total_tokens, cost
+		) VALUES (?, ?, ?, ?, 'Lifecycle Key', 'gpt-test', 'test', 0, 1, ?)
+	`, tenantID, usage.CutoffStartUTC(1).Add(time.Hour).Format(time.RFC3339), apiKey, apiKeyID, cost); err != nil {
+		t.Fatalf("insert request log: %v", err)
+	}
+}
+
+func TestSoftDeletedOwnedKeyKeepsAccountHistory(t *testing.T) {
+	db := setupEndUserKeyLifecycleDB(t)
+	tenantID := uuid.NewString()
+	userID := uuid.NewString()
+	insertLifecycleUser(t, db, tenantID, userID)
+
+	svc := enduser.NewService(db)
+	first, err := svc.CreateKey(context.Background(), tenantID, userID, "first")
+	if err != nil {
+		t.Fatalf("CreateKey first: %v", err)
+	}
+	second, err := svc.CreateKey(context.Background(), tenantID, userID, "second")
+	if err != nil {
+		t.Fatalf("CreateKey second: %v", err)
+	}
+	insertLifecycleLog(t, db, tenantID, first.PlaintextKey, first.APIKey.ID, 1)
+	insertLifecycleLog(t, db, tenantID, second.PlaintextKey, second.APIKey.ID, 2)
+
+	if err := svc.DeleteKey(context.Background(), tenantID, userID, first.APIKey.ID); err != nil {
+		t.Fatalf("DeleteKey: %v", err)
+	}
+	keys, err := svc.ListKeys(context.Background(), tenantID, userID)
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if len(keys) != 1 || keys[0].ID != second.APIKey.ID {
+		t.Fatalf("active keys after delete = %#v, want only %s", keys, second.APIKey.ID)
+	}
+	if err := svc.DeleteKey(context.Background(), tenantID, userID, second.APIKey.ID); !errors.Is(err, enduser.ErrLastKey) {
+		t.Fatalf("delete last active key err = %v, want ErrLastKey", err)
+	}
+
+	var disabled int
+	var ownerID, storedSecret string
+	if err := db.QueryRow(`SELECT disabled, end_user_id, key FROM api_keys WHERE tenant_id = ? AND id = ?`, tenantID, first.APIKey.ID).Scan(&disabled, &ownerID, &storedSecret); err != nil {
+		t.Fatalf("query soft-deleted key: %v", err)
+	}
+	if disabled != 1 || ownerID != userID || storedSecret != first.PlaintextKey {
+		t.Fatalf("soft-deleted row = disabled:%d owner:%q secret:%q", disabled, ownerID, storedSecret)
+	}
+
+	params := usage.LogQueryParams{TenantID: tenantID, EndUserID: userID, Page: 1, Size: 20, Days: 1}
+	logs, err := usage.QueryLogs(params)
+	if err != nil {
+		t.Fatalf("QueryLogs: %v", err)
+	}
+	if logs.Total != 2 {
+		t.Fatalf("account logs after soft delete = %d, want 2", logs.Total)
+	}
+	stats, err := usage.QueryStats(params)
+	if err != nil {
+		t.Fatalf("QueryStats: %v", err)
+	}
+	if stats.Total != 2 || stats.TotalCost != 3 {
+		t.Fatalf("account stats after soft delete = %+v, want total=2 cost=3", stats)
+	}
+	chart, err := usage.QueryPublicChartData(second.PlaintextKey, 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartData: %v", err)
+	}
+	if chart.Stats.Total != 2 || chart.Stats.TotalCost != 3 {
+		t.Fatalf("public chart after soft delete = %+v, want total=2 cost=3", chart.Stats)
+	}
+}
+
+func TestRotateBackfillsLegacyRequestLogIdentity(t *testing.T) {
+	db := setupEndUserKeyLifecycleDB(t)
+	tenantID := uuid.NewString()
+	userID := uuid.NewString()
+	insertLifecycleUser(t, db, tenantID, userID)
+
+	svc := enduser.NewService(db)
+	created, err := svc.CreateKey(context.Background(), tenantID, userID, "legacy")
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	insertLifecycleLog(t, db, tenantID, created.PlaintextKey, "", 4)
+
+	rotated, err := svc.RotateKey(context.Background(), tenantID, userID, created.APIKey.ID)
+	if err != nil {
+		t.Fatalf("RotateKey: %v", err)
+	}
+	var backfilledID string
+	if err := db.QueryRow(`SELECT api_key_id FROM request_logs WHERE tenant_id = ? AND api_key = ?`, tenantID, created.PlaintextKey).Scan(&backfilledID); err != nil {
+		t.Fatalf("query legacy request log: %v", err)
+	}
+	if backfilledID != created.APIKey.ID {
+		t.Fatalf("legacy api_key_id after rotate = %q, want %q", backfilledID, created.APIKey.ID)
+	}
+
+	params := usage.LogQueryParams{TenantID: tenantID, EndUserID: userID, Page: 1, Size: 20, Days: 1}
+	logs, err := usage.QueryLogs(params)
+	if err != nil {
+		t.Fatalf("QueryLogs after rotate: %v", err)
+	}
+	if logs.Total != 1 {
+		t.Fatalf("account logs after rotate = %d, want 1", logs.Total)
+	}
+	chart, err := usage.QueryPublicChartData(rotated.PlaintextKey, 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartData after rotate: %v", err)
+	}
+	if chart.Stats.Total != 1 || chart.Stats.TotalCost != 4 {
+		t.Fatalf("public chart after rotate = %+v, want total=1 cost=4", chart.Stats)
+	}
+}


### PR DESCRIPTION
## Summary

Close end-user account residual risks #3–#6 and portal models issue P1:

- soft-delete owned keys while retaining stable IDs/secrets for historical usage ownership
- backfill legacy raw-secret request logs on key rotation
- cover account-wide in-memory public usage for raw-key and portal bearer subjects
- atomically replace permission profiles and sync bound accounts, with tenant-scoped SQLite profile keys
- force business-tenant `/v1/models` through tenant/channel/scoped-routing availability
- enforce at least one active owned key across delete, patch, and full replace paths

## Verification

- `go test ./internal/usage/ ./internal/enduser/ ./internal/access/config_access/ ./internal/api/handlers/management/ ./internal/storage/postgres/ ./internal/api/routes/ -count=1`
- `go test ./internal/api/ ./internal/access/... ./internal/registry/ ./internal/storage/sqlite/apikey/ -count=1`
- `./scripts/ci-pr.sh`

No deployment or production database changes were performed.
