### PR TITLE
fix: run stale spool cleanup periodically

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -114,11 +114,6 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 	if cfg == nil {
 		return errors.New("config is nil")
 	}
-	if removed, err := usage.CleanupStaleDeferredUsageContentFiles(); err != nil {
-		log.WithError(err).Warn("usage: stale deferred content cleanup completed with errors")
-	} else if removed > 0 {
-		log.Infof("usage: removed %d stale deferred content file(s)", removed)
-	}
 	if err := usage.InitPostgres(cfg.Postgres, cfg.RequestLogStorage, loc); err != nil {
 		return err
 	}

--- a/internal/usage/deferred_content_cleanup_test.go
+++ b/internal/usage/deferred_content_cleanup_test.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,5 +50,25 @@ func TestCleanupStaleDeferredUsageContentFilesKeepsRecentAndUnrelatedFiles(t *te
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("preserved file missing at %s: %v", path, err)
 		}
+	}
+}
+
+func TestRunRequestLogMaintenancePassCleansStaleDeferredUsageFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+
+	path := filepath.Join(tempDir, "cliproxy-usage-output-stale")
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatalf("write stale deferred file: %v", err)
+	}
+	staleTime := time.Now().Add(-staleDeferredUsageContentAge - time.Hour)
+	if err := os.Chtimes(path, staleTime, staleTime); err != nil {
+		t.Fatalf("set stale deferred file time: %v", err)
+	}
+
+	runRequestLogMaintenancePass(context.Background(), nil, "")
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("periodic maintenance left stale deferred file at %s: %v", path, err)
 	}
 }

--- a/internal/usage/log_content_store.go
+++ b/internal/usage/log_content_store.go
@@ -226,6 +226,11 @@ func stopRequestLogMaintenance() {
 }
 
 func runRequestLogMaintenancePass(ctx context.Context, db *sql.DB, driver string) {
+	if removed, err := CleanupStaleDeferredUsageContentFiles(); err != nil {
+		log.WithError(err).Warn("usage: stale deferred content cleanup completed with errors")
+	} else if removed > 0 {
+		log.Infof("usage: removed %d stale deferred content file(s)", removed)
+	}
 	if db == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

- move stale deferred usage spool cleanup into the existing request-log maintenance pass
- run cleanup immediately at startup and again on the configured maintenance interval
- add a regression test proving periodic maintenance removes only eligible stale spool files

## Business impact

- does not change model routing, streaming, quotas, billing, request metadata, or request-log retention
- preserves the 24-hour safety window so blue-green overlap cannot remove in-flight files owned by the previous instance
- avoids direct production changes; deployment remains PR -> dev only

## Verification

- `TZ=UTC go test ./internal/usage -run '^Test(RunRequestLogMaintenancePassCleansStaleDeferredUsageFiles|CleanupStaleDeferredUsageContentFilesKeepsRecentAndUnrelatedFiles)$' -count=1`\n- `TZ=UTC ./scripts/ci-pr.sh`\n- regression test verified to fail on the pre-fix commit and pass with this change\n