### PR TITLE
fix(translator): guard xai/claude content blocks to stop Content block not found

### DIFF
--- a/internal/runtime/executor/xai_executor_stream_test.go
+++ b/internal/runtime/executor/xai_executor_stream_test.go
@@ -1,0 +1,157 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type xaiStreamRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f xaiStreamRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestXAIExecutorClaudeStreamMaintainsAnthropicContentBlockLifecycle(t *testing.T) {
+	claudeRequest := []byte(`{
+		"model":"grok-composer-2.5-fast",
+		"stream":true,
+		"messages":[{"role":"user","content":"Inspect the repo"}],
+		"tools":[{"name":"Read","description":"Read a file","input_schema":{"type":"object","properties":{"path":{"type":"string"}}}}]
+	}`)
+	upstreamEvents := []string{
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-composer-2.5-fast"}}`,
+		`data: {"type":"response.output_item.added","item":{"type":"message","status":"in_progress"},"output_index":1}`,
+		`data: {"type":"response.content_part.added","part":{"type":"output_text"},"content_index":0,"output_index":1}`,
+		`data: {"type":"response.output_text.delta","delta":"inspect repo","output_index":1}`,
+		`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_a","call_id":"call_a","name":"Read","status":"in_progress"},"output_index":2}`,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_a","delta":"{\"path\":\"README.md\"}","output_index":2}`,
+		`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_a","call_id":"call_a","name":"Read","arguments":"{\"path\":\"README.md\"}"},"output_index":2}`,
+		`data: {"type":"response.content_part.done","part":{"type":"output_text"},"content_index":0,"output_index":1}`,
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":11,"output_tokens":7}}}`,
+	}
+
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, xaiStreamRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		wantURL := strings.TrimRight(xaiauth.CLIChatProxyBaseURL, "/") + "/responses"
+		if got := req.URL.String(); got != wantURL {
+			t.Fatalf("upstream URL = %q, want %q", got, wantURL)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read translated request: %v", err)
+		}
+		if got := gjson.GetBytes(body, "tools.0.name").String(); got != "Read" {
+			t.Fatalf("translated tool name = %q, want Read: %s", got, body)
+		}
+		if got := gjson.GetBytes(body, "tool_choice").String(); got != "auto" {
+			t.Fatalf("translated tool_choice = %q, want auto: %s", got, body)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(strings.Join(upstreamEvents, "\n\n") + "\n\n")),
+			Request:    req,
+		}, nil
+	}))
+
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"api_key":   "oauth-token",
+			"base_url":  xaiauth.DefaultAPIBaseURL,
+			"using_api": "false",
+		},
+	}
+	result, err := NewXAIExecutor(&config.Config{}).ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "grok-composer-2.5-fast",
+		Payload: claudeRequest,
+	}, cliproxyexecutor.Options{
+		Stream:          true,
+		OriginalRequest: claudeRequest,
+		SourceFormat:    sdktranslator.FormatClaude,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream returned error: %v", err)
+	}
+
+	var output strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		output.Write(chunk.Payload)
+	}
+	assertXAIClaudeBlockLifecycle(t, output.String())
+}
+
+func TestXAIPrepareResponsesRequestEmptyToolsOmitsToolChoice(t *testing.T) {
+	payload := []byte(`{
+		"model":"grok-4",
+		"messages":[{"role":"user","content":"Create a title"}],
+		"tools":[],
+		"tool_choice":{"type":"auto"}
+	}`)
+
+	_, body, _, err := NewXAIExecutor(&config.Config{}).prepareResponsesRequest(
+		context.Background(),
+		&cliproxyauth.Auth{Provider: "xai"},
+		cliproxyexecutor.Request{Model: "grok-4", Payload: payload},
+		cliproxyexecutor.Options{OriginalRequest: payload, SourceFormat: sdktranslator.FormatClaude},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest returned error: %v", err)
+	}
+	if gjson.GetBytes(body, "tool_choice").Exists() {
+		t.Fatalf("empty tools must not reach xAI with tool_choice: %s", body)
+	}
+	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && len(tools.Array()) != 0 {
+		t.Fatalf("unexpected tools in xAI request: %s", body)
+	}
+}
+
+func assertXAIClaudeBlockLifecycle(t *testing.T, output string) {
+	t.Helper()
+	open := map[int]bool{}
+	started := map[int]bool{}
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := gjson.Parse(strings.TrimPrefix(line, "data: "))
+		index := int(payload.Get("index").Int())
+		switch payload.Get("type").String() {
+		case "content_block_start":
+			if started[index] {
+				t.Fatalf("content block index %d was started more than once: %s", index, output)
+			}
+			started[index] = true
+			open[index] = true
+		case "content_block_delta":
+			if !open[index] {
+				t.Fatalf("content block delta for unopened index %d: %s", index, output)
+			}
+		case "content_block_stop":
+			if !open[index] {
+				t.Fatalf("content block stop for unopened index %d: %s", index, output)
+			}
+			delete(open, index)
+		case "message_stop":
+			if len(open) != 0 {
+				t.Fatalf("message_stop with open content blocks %v: %s", open, output)
+			}
+		}
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -167,7 +167,7 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 
 	// Convert tools declarations to the expected format for the Codex API.
 	toolsResult := rootResult.Get("tools")
-	if toolsResult.IsArray() {
+	if toolsResult.IsArray() && len(toolsResult.Array()) > 0 {
 		// Codex validates deferred tools strictly: defer_loading requires tools.tool_search.
 		// Claude Code may set defer_loading on tools when tool schemas are deferred.
 		// The Codex endpoint we proxy to rejects defer_loading without tool_search, so strip the flag.

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -30,3 +30,20 @@ func TestConvertClaudeRequestToCodex_StripsDeferLoading(t *testing.T) {
 		return true
 	})
 }
+
+func TestConvertClaudeRequestToCodex_EmptyToolsOmitsToolChoice(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-haiku-4-5",
+		"messages":[{"role":"user","content":"Create a title"}],
+		"tools":[],
+		"tool_choice":{"type":"auto"}
+	}`)
+
+	out := ConvertClaudeRequestToCodex("grok-4", input, false)
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("empty tools must not emit tool_choice: %s", out)
+	}
+	if tools := gjson.GetBytes(out, "tools"); tools.Exists() && len(tools.Array()) != 0 {
+		t.Fatalf("unexpected translated tools: %s", out)
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -25,7 +25,17 @@ type ConvertCodexResponseToClaudeParams struct {
 	HasToolCall               bool
 	BlockIndex                int
 	HasReceivedArgumentsDelta bool
+	OpenBlockType             string
+	OpenBlockIndex            int
+	ActiveFunctionCallKeys    map[string]struct{}
+	MessageCompleted          bool
 }
+
+const (
+	codexClaudeThinkingBlock = "thinking"
+	codexClaudeTextBlock     = "text"
+	codexClaudeToolBlock     = "tool_use"
+)
 
 // ConvertCodexResponseToClaude performs sophisticated streaming response format conversion.
 // This function implements a complex state machine that translates Codex API responses
@@ -50,6 +60,10 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 			BlockIndex:  0,
 		}
 	}
+	params := (*param).(*ConvertCodexResponseToClaudeParams)
+	if params.MessageCompleted {
+		return []string{}
+	}
 
 	// log.Debugf("rawJSON: %s", string(rawJSON))
 	if !bytes.HasPrefix(rawJSON, dataTag) {
@@ -70,49 +84,76 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		output = "event: message_start\n"
 		output += fmt.Sprintf("data: %s\n\n", template)
 	} else if typeStr == "response.reasoning_summary_part.added" {
+		if params.OpenBlockType == codexClaudeThinkingBlock {
+			return []string{output}
+		}
+		output += closeCodexClaudeContentBlock(params)
 		template = `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`
-		template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
+		template, _ = sjson.Set(template, "index", params.BlockIndex)
+		openCodexClaudeContentBlock(params, codexClaudeThinkingBlock)
 
-		output = "event: content_block_start\n"
+		output += "event: content_block_start\n"
 		output += fmt.Sprintf("data: %s\n\n", template)
 	} else if typeStr == "response.reasoning_summary_text.delta" {
+		if params.OpenBlockType == "" {
+			template = `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`
+			template, _ = sjson.Set(template, "index", params.BlockIndex)
+			openCodexClaudeContentBlock(params, codexClaudeThinkingBlock)
+			output += "event: content_block_start\n"
+			output += fmt.Sprintf("data: %s\n\n", template)
+		}
+		if params.OpenBlockType != codexClaudeThinkingBlock {
+			return []string{output}
+		}
 		template = `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}`
-		template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
+		template, _ = sjson.Set(template, "index", params.OpenBlockIndex)
 		template, _ = sjson.Set(template, "delta.thinking", rootResult.Get("delta").String())
 
-		output = "event: content_block_delta\n"
+		output += "event: content_block_delta\n"
 		output += fmt.Sprintf("data: %s\n\n", template)
 	} else if typeStr == "response.reasoning_summary_part.done" {
-		template = `{"type":"content_block_stop","index":0}`
-		template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
-		(*param).(*ConvertCodexResponseToClaudeParams).BlockIndex++
-
-		output = "event: content_block_stop\n"
-		output += fmt.Sprintf("data: %s\n\n", template)
-
+		if params.OpenBlockType == codexClaudeThinkingBlock {
+			output += closeCodexClaudeContentBlock(params)
+		}
 	} else if typeStr == "response.content_part.added" {
+		if params.OpenBlockType == codexClaudeTextBlock {
+			return []string{output}
+		}
+		output += closeCodexClaudeContentBlock(params)
 		template = `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`
-		template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
+		template, _ = sjson.Set(template, "index", params.BlockIndex)
+		openCodexClaudeContentBlock(params, codexClaudeTextBlock)
 
-		output = "event: content_block_start\n"
+		output += "event: content_block_start\n"
 		output += fmt.Sprintf("data: %s\n\n", template)
 	} else if typeStr == "response.output_text.delta" {
+		if params.OpenBlockType == codexClaudeThinkingBlock {
+			output += closeCodexClaudeContentBlock(params)
+		}
+		if params.OpenBlockType == "" {
+			template = `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`
+			template, _ = sjson.Set(template, "index", params.BlockIndex)
+			openCodexClaudeContentBlock(params, codexClaudeTextBlock)
+			output += "event: content_block_start\n"
+			output += fmt.Sprintf("data: %s\n\n", template)
+		}
+		if params.OpenBlockType != codexClaudeTextBlock {
+			return []string{output}
+		}
 		template = `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`
-		template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
+		template, _ = sjson.Set(template, "index", params.OpenBlockIndex)
 		template, _ = sjson.Set(template, "delta.text", rootResult.Get("delta").String())
 
-		output = "event: content_block_delta\n"
+		output += "event: content_block_delta\n"
 		output += fmt.Sprintf("data: %s\n\n", template)
 	} else if typeStr == "response.content_part.done" {
-		template = `{"type":"content_block_stop","index":0}`
-		template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
-		(*param).(*ConvertCodexResponseToClaudeParams).BlockIndex++
-
-		output = "event: content_block_stop\n"
-		output += fmt.Sprintf("data: %s\n\n", template)
+		if params.OpenBlockType == codexClaudeTextBlock {
+			output += closeCodexClaudeContentBlock(params)
+		}
 	} else if typeStr == "response.completed" {
+		output += closeCodexClaudeContentBlock(params)
 		template = `{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`
-		p := (*param).(*ConvertCodexResponseToClaudeParams).HasToolCall
+		p := params.HasToolCall
 		stopReason := rootResult.Get("response.stop_reason").String()
 		if p {
 			template, _ = sjson.Set(template, "delta.stop_reason", "tool_use")
@@ -128,35 +169,48 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 			template, _ = sjson.Set(template, "usage.cache_read_input_tokens", cachedTokens)
 		}
 
-		output = "event: message_delta\n"
+		output += "event: message_delta\n"
 		output += fmt.Sprintf("data: %s\n\n", template)
 		output += "event: message_stop\n"
 		output += `data: {"type":"message_stop"}`
 		output += "\n\n"
+		params.MessageCompleted = true
 	} else if typeStr == "response.output_item.added" {
 		itemResult := rootResult.Get("item")
 		itemType := itemResult.Get("type").String()
 		if itemType == "function_call" {
-			(*param).(*ConvertCodexResponseToClaudeParams).HasToolCall = true
-			(*param).(*ConvertCodexResponseToClaudeParams).HasReceivedArgumentsDelta = false
-			template = `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"","name":"","input":{}}}`
-			template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
-			template, _ = sjson.Set(template, "content_block.id", itemResult.Get("call_id").String())
-			{
-				// Restore original tool name if shortened
-				name := itemResult.Get("name").String()
-				rev := buildReverseMapFromClaudeOriginalShortToOriginal(originalRequestRawJSON)
-				if orig, ok := rev[name]; ok {
-					name = orig
-				}
-				template, _ = sjson.Set(template, "content_block.name", name)
+			name := strings.TrimSpace(itemResult.Get("name").String())
+			rev := buildReverseMapFromClaudeOriginalShortToOriginal(originalRequestRawJSON)
+			if orig, ok := rev[name]; ok {
+				name = strings.TrimSpace(orig)
+			}
+			callID := strings.TrimSpace(itemResult.Get("call_id").String())
+			if callID == "" {
+				callID = strings.TrimSpace(itemResult.Get("id").String())
+			}
+			if name == "" || callID == "" {
+				return []string{output}
 			}
 
-			output = "event: content_block_start\n"
+			keys := codexClaudeFunctionCallKeys(rootResult, itemResult)
+			if params.OpenBlockType == codexClaudeToolBlock && codexClaudeFunctionCallMatches(params, keys) {
+				return []string{output}
+			}
+			output += closeCodexClaudeContentBlock(params)
+			params.HasToolCall = true
+			params.HasReceivedArgumentsDelta = false
+			template = `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"","name":"","input":{}}}`
+			template, _ = sjson.Set(template, "index", params.BlockIndex)
+			template, _ = sjson.Set(template, "content_block.id", callID)
+			template, _ = sjson.Set(template, "content_block.name", name)
+			openCodexClaudeContentBlock(params, codexClaudeToolBlock)
+			params.ActiveFunctionCallKeys = keys
+
+			output += "event: content_block_start\n"
 			output += fmt.Sprintf("data: %s\n\n", template)
 
 			template = `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
-			template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
+			template, _ = sjson.Set(template, "index", params.OpenBlockIndex)
 
 			output += "event: content_block_delta\n"
 			output += fmt.Sprintf("data: %s\n\n", template)
@@ -165,40 +219,108 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		itemResult := rootResult.Get("item")
 		itemType := itemResult.Get("type").String()
 		if itemType == "function_call" {
-			template = `{"type":"content_block_stop","index":0}`
-			template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
-			(*param).(*ConvertCodexResponseToClaudeParams).BlockIndex++
-
-			output = "event: content_block_stop\n"
-			output += fmt.Sprintf("data: %s\n\n", template)
+			if params.OpenBlockType != codexClaudeToolBlock || !codexClaudeFunctionCallMatches(params, codexClaudeFunctionCallKeys(rootResult, itemResult)) {
+				return []string{output}
+			}
+			if !params.HasReceivedArgumentsDelta {
+				if args := itemResult.Get("arguments").String(); args != "" {
+					output += codexClaudeFunctionArgumentsDelta(params.OpenBlockIndex, args)
+					params.HasReceivedArgumentsDelta = true
+				}
+			}
+			output += closeCodexClaudeContentBlock(params)
 		}
 	} else if typeStr == "response.function_call_arguments.delta" {
-		(*param).(*ConvertCodexResponseToClaudeParams).HasReceivedArgumentsDelta = true
-		template = `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
-		template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
-		template, _ = sjson.Set(template, "delta.partial_json", rootResult.Get("delta").String())
-
-		output += "event: content_block_delta\n"
-		output += fmt.Sprintf("data: %s\n\n", template)
+		if params.OpenBlockType == codexClaudeToolBlock && codexClaudeFunctionCallMatches(params, codexClaudeFunctionCallKeys(rootResult, gjson.Result{})) {
+			params.HasReceivedArgumentsDelta = true
+			output += codexClaudeFunctionArgumentsDelta(params.OpenBlockIndex, rootResult.Get("delta").String())
+		}
 	} else if typeStr == "response.function_call_arguments.done" {
 		// Some models (e.g. gpt-5.3-codex-spark) send function call arguments
 		// in a single "done" event without preceding "delta" events.
 		// Emit the full arguments as a single input_json_delta so the
 		// downstream Claude client receives the complete tool input.
 		// When delta events were already received, skip to avoid duplicating arguments.
-		if !(*param).(*ConvertCodexResponseToClaudeParams).HasReceivedArgumentsDelta {
+		if params.OpenBlockType == codexClaudeToolBlock && codexClaudeFunctionCallMatches(params, codexClaudeFunctionCallKeys(rootResult, gjson.Result{})) && !params.HasReceivedArgumentsDelta {
 			if args := rootResult.Get("arguments").String(); args != "" {
-				template = `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
-				template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
-				template, _ = sjson.Set(template, "delta.partial_json", args)
-
-				output += "event: content_block_delta\n"
-				output += fmt.Sprintf("data: %s\n\n", template)
+				output += codexClaudeFunctionArgumentsDelta(params.OpenBlockIndex, args)
+				params.HasReceivedArgumentsDelta = true
 			}
 		}
 	}
 
 	return []string{output}
+}
+
+func openCodexClaudeContentBlock(params *ConvertCodexResponseToClaudeParams, blockType string) {
+	params.OpenBlockType = blockType
+	params.OpenBlockIndex = params.BlockIndex
+}
+
+func closeCodexClaudeContentBlock(params *ConvertCodexResponseToClaudeParams) string {
+	if params.OpenBlockType == "" {
+		return ""
+	}
+	template := `{"type":"content_block_stop","index":0}`
+	template, _ = sjson.Set(template, "index", params.OpenBlockIndex)
+	if params.BlockIndex <= params.OpenBlockIndex {
+		params.BlockIndex = params.OpenBlockIndex + 1
+	}
+	params.OpenBlockType = ""
+	params.OpenBlockIndex = 0
+	params.ActiveFunctionCallKeys = nil
+	params.HasReceivedArgumentsDelta = false
+	return "event: content_block_stop\n" + fmt.Sprintf("data: %s\n\n", template)
+}
+
+func codexClaudeFunctionArgumentsDelta(blockIndex int, arguments string) string {
+	template := `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
+	template, _ = sjson.Set(template, "index", blockIndex)
+	template, _ = sjson.Set(template, "delta.partial_json", arguments)
+	return "event: content_block_delta\n" + fmt.Sprintf("data: %s\n\n", template)
+}
+
+func codexClaudeFunctionCallKeys(rootResult, itemResult gjson.Result) map[string]struct{} {
+	keys := make(map[string]struct{}, 4)
+	if outputIndex := strings.TrimSpace(rootResult.Get("output_index").String()); outputIndex != "" {
+		keys["output:"+outputIndex] = struct{}{}
+	}
+	if itemID := strings.TrimSpace(rootResult.Get("item_id").String()); itemID != "" {
+		keys["item:"+itemID] = struct{}{}
+	}
+	if itemID := strings.TrimSpace(itemResult.Get("id").String()); itemID != "" {
+		keys["item:"+itemID] = struct{}{}
+	}
+	if callID := strings.TrimSpace(rootResult.Get("call_id").String()); callID != "" {
+		keys["call:"+callID] = struct{}{}
+	}
+	if callID := strings.TrimSpace(itemResult.Get("call_id").String()); callID != "" {
+		keys["call:"+callID] = struct{}{}
+	}
+	return keys
+}
+
+func codexClaudeFunctionCallMatches(params *ConvertCodexResponseToClaudeParams, eventKeys map[string]struct{}) bool {
+	if len(params.ActiveFunctionCallKeys) == 0 || len(eventKeys) == 0 {
+		return true
+	}
+	for _, prefix := range []string{"output:", "item:", "call:"} {
+		activeValue, activeOK := codexClaudeFunctionCallKeyValue(params.ActiveFunctionCallKeys, prefix)
+		eventValue, eventOK := codexClaudeFunctionCallKeyValue(eventKeys, prefix)
+		if activeOK && eventOK && activeValue != eventValue {
+			return false
+		}
+	}
+	return true
+}
+
+func codexClaudeFunctionCallKeyValue(keys map[string]struct{}, prefix string) (string, bool) {
+	for key := range keys {
+		if strings.HasPrefix(key, prefix) {
+			return key, true
+		}
+	}
+	return "", false
 }
 
 // ConvertCodexResponseToClaudeNonStream converts a non-streaming Codex response to a non-streaming Claude Code response.
@@ -303,14 +425,21 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 					}
 				}
 			case "function_call":
-				hasToolCall = true
-				name := item.Get("name").String()
+				name := strings.TrimSpace(item.Get("name").String())
 				if original, ok := revNames[name]; ok {
-					name = original
+					name = strings.TrimSpace(original)
 				}
+				callID := strings.TrimSpace(item.Get("call_id").String())
+				if callID == "" {
+					callID = strings.TrimSpace(item.Get("id").String())
+				}
+				if name == "" || callID == "" {
+					return true
+				}
+				hasToolCall = true
 
 				toolBlock := `{"type":"tool_use","id":"","name":"","input":{}}`
-				toolBlock, _ = sjson.Set(toolBlock, "id", item.Get("call_id").String())
+				toolBlock, _ = sjson.Set(toolBlock, "id", callID)
 				toolBlock, _ = sjson.Set(toolBlock, "name", name)
 				inputRaw := "{}"
 				if argsStr := item.Get("arguments").String(); argsStr != "" && gjson.Valid(argsStr) {
@@ -327,7 +456,11 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 	}
 
 	if stopReason := responseData.Get("stop_reason"); stopReason.Exists() && stopReason.String() != "" {
-		out, _ = sjson.Set(out, "stop_reason", stopReason.String())
+		if stopReason.String() == "tool_use" && !hasToolCall {
+			out, _ = sjson.Set(out, "stop_reason", "end_turn")
+		} else {
+			out, _ = sjson.Set(out, "stop_reason", stopReason.String())
+		}
 	} else if hasToolCall {
 		out, _ = sjson.Set(out, "stop_reason", "tool_use")
 	} else {

--- a/internal/translator/codex/claude/codex_claude_response_test.go
+++ b/internal/translator/codex/claude/codex_claude_response_test.go
@@ -1,0 +1,322 @@
+package claude
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertCodexResponseToClaude_GrokInterleavedTextAndToolCalls(t *testing.T) {
+	originalRequest := []byte(`{"tools":[{"name":"Read"}]}`)
+	chunks := []string{
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-composer-2.5-fast"}}`,
+		`data: {"type":"response.output_item.added","item":{"type":"message","status":"in_progress"},"output_index":1}`,
+		`data: {"type":"response.content_part.added","part":{"type":"output_text"},"content_index":0,"output_index":1}`,
+		`data: {"type":"response.output_text.delta","delta":"inspect repo","output_index":1}`,
+		`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_a","call_id":"call_a","name":"Read","status":"in_progress"},"output_index":2}`,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_a","delta":"{\"path\":\"README.md\"}","output_index":2}`,
+		`data: {"type":"response.function_call_arguments.done","item_id":"fc_a","arguments":"{\"path\":\"README.md\"}","output_index":2}`,
+		`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_a","call_id":"call_a","name":"Read","arguments":"{\"path\":\"README.md\"}"},"output_index":2}`,
+		`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_b","call_id":"call_b","name":"Read","status":"in_progress"},"output_index":3}`,
+		`data: {"type":"response.function_call_arguments.done","item_id":"fc_b","arguments":"{\"path\":\"main.go\"}","output_index":3}`,
+		`data: {"type":"response.content_part.done","part":{"type":"output_text"},"content_index":0,"output_index":1}`,
+		`data: {"type":"response.output_item.done","item":{"type":"message","status":"completed"},"output_index":1}`,
+		`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_b","call_id":"call_b","name":"Read","arguments":"{\"path\":\"main.go\"}"},"output_index":3}`,
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":11,"output_tokens":7}}}`,
+	}
+
+	outputs := convertCodexClaudeStream(t, originalRequest, chunks)
+	assertClaudeContentBlockLifecycle(t, outputs)
+
+	joined := strings.Join(outputs, "")
+	if got := strings.Count(joined, `"type":"tool_use"`); got != 2 {
+		t.Fatalf("tool_use count = %d, want 2\n%s", got, joined)
+	}
+	for _, want := range []string{`"index":0,"content_block":{"type":"text"`, `"index":1,"content_block":{"type":"tool_use"`, `"index":2,"content_block":{"type":"tool_use"`, `README.md`, `main.go`} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("stream output missing %q\n%s", want, joined)
+		}
+	}
+}
+
+func TestConvertCodexResponseToClaude_MalformedAndOutOfOrderEventsNeverOrphanBlocks(t *testing.T) {
+	tests := []struct {
+		name   string
+		chunks []string
+		check  func(*testing.T, string)
+	}{
+		{
+			name: "reasoning delta and stop without start",
+			chunks: []string{
+				`data: {"type":"response.reasoning_summary_text.delta","delta":"late"}`,
+				`data: {"type":"response.reasoning_summary_part.done"}`,
+			},
+		},
+		{
+			name: "text delta without added is started lazily",
+			chunks: []string{
+				`data: {"type":"response.output_text.delta","delta":"hello"}`,
+				`data: {"type":"response.content_part.done","part":{"type":"output_text"}}`,
+			},
+		},
+		{
+			name: "text stop without start",
+			chunks: []string{
+				`data: {"type":"response.content_part.done","part":{"type":"output_text"}}`,
+			},
+		},
+		{
+			name: "function argument events without function start",
+			chunks: []string{
+				`data: {"type":"response.function_call_arguments.delta","delta":"{}","output_index":2}`,
+				`data: {"type":"response.function_call_arguments.done","arguments":"{}","output_index":2}`,
+				`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_missing","name":"Read"},"output_index":2}`,
+			},
+		},
+		{
+			name: "empty tool name is ignored",
+			chunks: []string{
+				`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_empty","name":"   "},"output_index":2}`,
+				`data: {"type":"response.function_call_arguments.delta","delta":"{}","output_index":2}`,
+				`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_empty","name":"   "},"output_index":2}`,
+				`data: {"type":"response.completed","response":{"usage":{}}}`,
+			},
+			check: func(t *testing.T, joined string) {
+				if strings.Contains(joined, `"type":"tool_use"`) {
+					t.Fatalf("empty tool name emitted tool_use\n%s", joined)
+				}
+				if !strings.Contains(joined, `"stop_reason":"end_turn"`) {
+					t.Fatalf("invalid tool call forced tool_use stop reason\n%s", joined)
+				}
+			},
+		},
+		{
+			name: "missing call id uses item id",
+			chunks: []string{
+				`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_only","name":"Read"},"output_index":2}`,
+				`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_only","name":"Read","arguments":"{}"},"output_index":2}`,
+			},
+			check: func(t *testing.T, joined string) {
+				if !strings.Contains(joined, `"id":"fc_only"`) {
+					t.Fatalf("item id was not used as tool_use id\n%s", joined)
+				}
+			},
+		},
+		{
+			name: "missing all tool ids is ignored",
+			chunks: []string{
+				`data: {"type":"response.output_item.added","item":{"type":"function_call","name":"Read"},"output_index":2}`,
+				`data: {"type":"response.output_item.done","item":{"type":"function_call","name":"Read"},"output_index":2}`,
+			},
+			check: func(t *testing.T, joined string) {
+				if strings.Contains(joined, `"type":"tool_use"`) {
+					t.Fatalf("tool call without an id emitted tool_use\n%s", joined)
+				}
+			},
+		},
+		{
+			name: "double function stop",
+			chunks: []string{
+				`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read"},"output_index":2}`,
+				`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read","arguments":"{}"},"output_index":2}`,
+				`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read","arguments":"{}"},"output_index":2}`,
+			},
+		},
+		{
+			name: "late arguments after function stop",
+			chunks: []string{
+				`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read"},"output_index":2}`,
+				`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read","arguments":"{}"},"output_index":2}`,
+				`data: {"type":"response.function_call_arguments.done","item_id":"fc_1","arguments":"{\"late\":true}","output_index":2}`,
+			},
+			check: func(t *testing.T, joined string) {
+				if strings.Contains(joined, `late`) {
+					t.Fatalf("late arguments were emitted after tool block stop\n%s", joined)
+				}
+			},
+		},
+		{
+			name: "mismatched function argument index",
+			chunks: []string{
+				`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read"},"output_index":2}`,
+				`data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"wrong\":true}","output_index":3}`,
+				`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read","arguments":"{}"},"output_index":2}`,
+			},
+			check: func(t *testing.T, joined string) {
+				if strings.Contains(joined, `wrong`) {
+					t.Fatalf("arguments for another output item were attached to the open tool block\n%s", joined)
+				}
+			},
+		},
+		{
+			name: "terminal response closes open block",
+			chunks: []string{
+				`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read"},"output_index":2}`,
+				`data: {"type":"response.completed","response":{"usage":{}}}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputs := convertCodexClaudeStream(t, []byte(`{"tools":[{"name":"Read"}]}`), tt.chunks)
+			assertClaudeContentBlockLifecycle(t, outputs)
+			joined := strings.Join(outputs, "")
+			assertNoInvalidClaudeToolUse(t, joined)
+			if tt.check != nil {
+				tt.check(t, joined)
+			}
+		})
+	}
+}
+
+func TestConvertCodexResponseToClaude_ValidOrderedStreamRemainsStable(t *testing.T) {
+	chunks := []string{
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4"}}`,
+		`data: {"type":"response.reasoning_summary_part.added"}`,
+		`data: {"type":"response.reasoning_summary_text.delta","delta":"think"}`,
+		`data: {"type":"response.reasoning_summary_part.done"}`,
+		`data: {"type":"response.content_part.added","part":{"type":"output_text"}}`,
+		`data: {"type":"response.output_text.delta","delta":"answer"}`,
+		`data: {"type":"response.content_part.done","part":{"type":"output_text"}}`,
+		`data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read"},"output_index":2}`,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{}","output_index":2}`,
+		`data: {"type":"response.function_call_arguments.done","item_id":"fc_1","arguments":"{}","output_index":2}`,
+		`data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"Read","arguments":"{}"},"output_index":2}`,
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":3,"output_tokens":4}}}`,
+	}
+
+	outputs := convertCodexClaudeStream(t, []byte(`{"tools":[{"name":"Read"}]}`), chunks)
+	assertClaudeContentBlockLifecycle(t, outputs)
+
+	got := claudeContentEventSummary(outputs)
+	want := []string{
+		"start:0:thinking",
+		"delta:0:thinking_delta",
+		"stop:0",
+		"start:1:text",
+		"delta:1:text_delta",
+		"stop:1",
+		"start:2:tool_use",
+		"delta:2:input_json_delta",
+		"delta:2:input_json_delta",
+		"stop:2",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("content event summary changed\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestConvertCodexResponseToClaudeNonStream_SkipsInvalidToolCalls(t *testing.T) {
+	response := []byte(`{
+		"type":"response.completed",
+		"response":{
+			"id":"resp_1",
+			"model":"grok-4",
+			"stop_reason":"tool_use",
+			"usage":{},
+			"output":[
+				{"type":"function_call","call_id":"call_empty","name":"   ","arguments":"{}"},
+				{"type":"function_call","name":"Read","arguments":"{}"}
+			]
+		}
+	}`)
+
+	out := ConvertCodexResponseToClaudeNonStream(context.Background(), "", []byte(`{"tools":[{"name":"Read"}]}`), nil, response, nil)
+	if strings.Contains(out, `"type":"tool_use"`) {
+		t.Fatalf("invalid function calls emitted tool_use: %s", out)
+	}
+	if got := gjson.Get(out, "stop_reason").String(); got != "end_turn" {
+		t.Fatalf("stop_reason = %q, want end_turn: %s", got, out)
+	}
+}
+
+func convertCodexClaudeStream(t *testing.T, originalRequest []byte, chunks []string) []string {
+	t.Helper()
+	var param any
+	outputs := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		outputs = append(outputs, ConvertCodexResponseToClaude(context.Background(), "", originalRequest, nil, []byte(chunk), &param)...)
+	}
+	return outputs
+}
+
+func assertClaudeContentBlockLifecycle(t *testing.T, outputs []string) {
+	t.Helper()
+	open := map[int]bool{}
+	started := map[int]bool{}
+	for outputIndex, output := range outputs {
+		for _, line := range strings.Split(output, "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := gjson.Parse(strings.TrimPrefix(line, "data: "))
+			index := int(payload.Get("index").Int())
+			switch payload.Get("type").String() {
+			case "content_block_start":
+				if started[index] {
+					t.Fatalf("output %d reused content block index %d: %s", outputIndex, index, line)
+				}
+				started[index] = true
+				open[index] = true
+			case "content_block_delta":
+				if !open[index] {
+					t.Fatalf("output %d emitted delta without an open start for index %d: %s", outputIndex, index, line)
+				}
+			case "content_block_stop":
+				if !open[index] {
+					t.Fatalf("output %d emitted stop without an open start for index %d: %s", outputIndex, index, line)
+				}
+				delete(open, index)
+			case "message_stop":
+				if len(open) != 0 {
+					t.Fatalf("message_stop emitted with open content blocks %v", open)
+				}
+			}
+		}
+	}
+}
+
+func assertNoInvalidClaudeToolUse(t *testing.T, output string) {
+	t.Helper()
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := gjson.Parse(strings.TrimPrefix(line, "data: "))
+		if payload.Get("type").String() != "content_block_start" || payload.Get("content_block.type").String() != "tool_use" {
+			continue
+		}
+		if strings.TrimSpace(payload.Get("content_block.name").String()) == "" {
+			t.Fatalf("tool_use has empty name: %s", line)
+		}
+		if strings.TrimSpace(payload.Get("content_block.id").String()) == "" {
+			t.Fatalf("tool_use has empty id: %s", line)
+		}
+	}
+}
+
+func claudeContentEventSummary(outputs []string) []string {
+	var summary []string
+	for _, output := range outputs {
+		for _, line := range strings.Split(output, "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := gjson.Parse(strings.TrimPrefix(line, "data: "))
+			index := int(payload.Get("index").Int())
+			switch payload.Get("type").String() {
+			case "content_block_start":
+				summary = append(summary, fmt.Sprintf("start:%d:%s", index, payload.Get("content_block.type").String()))
+			case "content_block_delta":
+				summary = append(summary, fmt.Sprintf("delta:%d:%s", index, payload.Get("delta.type").String()))
+			case "content_block_stop":
+				summary = append(summary, fmt.Sprintf("stop:%d", index))
+			}
+		}
+	}
+	return summary
+}


### PR DESCRIPTION
## Summary
- Fix Paseo/Claude Agent SDK `API Error: Content block not found` on Grok/xAI path by enforcing open content-block lifecycle in `ConvertCodexResponseToClaude`.
- Never emit Anthropic `content_block_delta`/`content_block_stop` without a matching start; close open blocks before starting a new one; skip empty tool names / missing ids.
- Also fix title-generation 400: do not send `tool_choice` when Claude request has `tools: []`.

## Root cause
`codex_claude_response.go` used an unchecked global `BlockIndex`. Out-of-order Grok Responses events could emit orphan stop/delta (or reuse index), which Claude SDK rejects with `RangeError: Content block not found`.

## Test plan
- [x] `./scripts/ci-pr.sh` (local full CI gate)
- [x] `go test ./...`
- [x] `golangci-lint` + `go build ./cmd/server`
- Regression: Grok-style text/tool interleave, missing starts, empty tool name, wrong output_index, terminal cleanup; xAI executor stream integration; empty tools without tool_choice

## Local verification
```bash
./scripts/ci-pr.sh
```