### PR TITLE
perf: reduce safe request hot-path overhead

### DIFF
--- a/internal/runtime/executor/execution_context.go
+++ b/internal/runtime/executor/execution_context.go
@@ -103,6 +103,10 @@ type ExecutionContext struct {
 	OriginalPayload []byte
 	SourceFormat    sdktranslator.Format
 
+	// originalPayloadIsRequest records the exact no-override case so the request
+	// translator is not run twice over the same potentially multi-megabyte body.
+	originalPayloadIsRequest bool
+
 	clientFactory HTTPClientFactory
 	recorder      UpstreamRecorder
 }
@@ -151,23 +155,25 @@ func newExecutionContext(
 		ctx = context.Background()
 	}
 	originalPayload := req.Payload
-	if len(opts.OriginalRequest) > 0 {
+	originalPayloadIsRequest := len(opts.OriginalRequest) == 0
+	if !originalPayloadIsRequest {
 		originalPayload = opts.OriginalRequest
 	}
 	return &ExecutionContext{
-		Context:         ctx,
-		Provider:        provider,
-		Config:          cfg,
-		Auth:            auth,
-		Request:         req,
-		Options:         opts,
-		Execution:       execOpts,
-		BaseModel:       thinking.ParseSuffix(req.Model).ModelName,
-		RequestedModel:  payloadRequestedModel(opts, req.Model),
-		OriginalPayload: originalPayload,
-		SourceFormat:    opts.SourceFormat,
-		clientFactory:   newHTTPClientFactory(cfg),
-		recorder:        newUpstreamRecorder(ctx, cfg, provider, auth),
+		Context:                  ctx,
+		Provider:                 provider,
+		Config:                   cfg,
+		Auth:                     auth,
+		Request:                  req,
+		Options:                  opts,
+		Execution:                execOpts,
+		BaseModel:                thinking.ParseSuffix(req.Model).ModelName,
+		RequestedModel:           payloadRequestedModel(opts, req.Model),
+		OriginalPayload:          originalPayload,
+		SourceFormat:             opts.SourceFormat,
+		originalPayloadIsRequest: originalPayloadIsRequest,
+		clientFactory:            newHTTPClientFactory(cfg),
+		recorder:                 newUpstreamRecorder(ctx, cfg, provider, auth),
 	}
 }
 
@@ -216,6 +222,9 @@ func (ec *ExecutionContext) TranslateRequestPair(payload []byte) ([]byte, []byte
 		payload,
 		ec.Execution.TranslateAsStream,
 	)
+	if ec.originalPayloadIsRequest && samePayloadStorage(payload, ec.Request.Payload) {
+		return translated, translated
+	}
 	originalTranslated := sdktranslator.TranslateRequest(
 		ec.SourceFormat,
 		ec.Execution.TargetFormat,
@@ -224,6 +233,16 @@ func (ec *ExecutionContext) TranslateRequestPair(payload []byte) ([]byte, []byte
 		ec.Execution.TranslateAsStream,
 	)
 	return translated, originalTranslated
+}
+
+func samePayloadStorage(left, right []byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	if len(left) == 0 {
+		return true
+	}
+	return &left[0] == &right[0]
 }
 
 func (ec *ExecutionContext) ApplyPayloadConfig(payload, originalTranslated []byte) []byte {

--- a/internal/runtime/executor/execution_context_test.go
+++ b/internal/runtime/executor/execution_context_test.go
@@ -1,10 +1,14 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -56,6 +60,117 @@ func TestExecutionContextUsesOriginalRequestAndRequestedModel(t *testing.T) {
 	if got := gjson.GetBytes(originalTranslated, "messages.0.content").String(); got != "original" {
 		t.Fatalf("original translated content = %q, want %q", got, "original")
 	}
+}
+
+func TestExecutionContextTranslatesSharedRequestPayloadOnce(t *testing.T) {
+	var calls atomic.Int32
+	from := sdktranslator.FromString("execution-context-shared-source")
+	to := sdktranslator.FromString("execution-context-shared-target")
+	sdktranslator.Register(from, to, func(_ string, rawJSON []byte, _ bool) []byte {
+		calls.Add(1)
+		return bytes.Clone(rawJSON)
+	}, sdktranslator.ResponseTransform{})
+
+	req := cliproxyexecutor.Request{
+		Model:   "test-model",
+		Payload: []byte(`{"input":"shared"}`),
+	}
+	execCtx := newExecutionContext(
+		context.Background(),
+		"test-provider",
+		&config.Config{},
+		nil,
+		req,
+		cliproxyexecutor.Options{SourceFormat: from},
+		ExecutionOptions{TargetFormat: to},
+	)
+
+	translated, originalTranslated := execCtx.TranslateRequestPair(nil)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("translator calls = %d, want 1 for shared request payload", got)
+	}
+	if string(translated) != string(req.Payload) || string(originalTranslated) != string(req.Payload) {
+		t.Fatalf("translated payloads differ: translated=%q original=%q", translated, originalTranslated)
+	}
+	if len(translated) > 0 && &translated[0] != &originalTranslated[0] {
+		t.Fatal("shared request payload should reuse the single translated result")
+	}
+}
+
+func TestExecutionContextTranslatesDistinctOriginalRequestSeparately(t *testing.T) {
+	var calls atomic.Int32
+	from := sdktranslator.FromString("execution-context-distinct-source")
+	to := sdktranslator.FromString("execution-context-distinct-target")
+	sdktranslator.Register(from, to, func(_ string, rawJSON []byte, _ bool) []byte {
+		calls.Add(1)
+		return bytes.Clone(rawJSON)
+	}, sdktranslator.ResponseTransform{})
+
+	req := cliproxyexecutor.Request{
+		Model:   "test-model",
+		Payload: []byte(`{"input":"translated"}`),
+	}
+	execCtx := newExecutionContext(
+		context.Background(),
+		"test-provider",
+		&config.Config{},
+		nil,
+		req,
+		cliproxyexecutor.Options{
+			OriginalRequest: []byte(`{"input":"original"}`),
+			SourceFormat:    from,
+		},
+		ExecutionOptions{TargetFormat: to},
+	)
+
+	translated, originalTranslated := execCtx.TranslateRequestPair(nil)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("translator calls = %d, want 2 for distinct request payloads", got)
+	}
+	if string(translated) != string(req.Payload) {
+		t.Fatalf("translated payload = %q, want %q", translated, req.Payload)
+	}
+	if string(originalTranslated) != string(execCtx.OriginalPayload) {
+		t.Fatalf("original translated payload = %q, want %q", originalTranslated, execCtx.OriginalPayload)
+	}
+}
+
+func BenchmarkExecutionContextTranslateSharedRequestPayload(b *testing.B) {
+	from := sdktranslator.FromString("execution-context-benchmark-source")
+	to := sdktranslator.FromString("execution-context-benchmark-target")
+	sdktranslator.Register(from, to, func(_ string, rawJSON []byte, _ bool) []byte {
+		return bytes.Clone(rawJSON)
+	}, sdktranslator.ResponseTransform{})
+
+	for _, size := range []int{512 << 10, 2 << 20, 8 << 20, 16 << 20} {
+		b.Run(byteSizeLabel(size), func(b *testing.B) {
+			payload := bytes.Repeat([]byte("x"), size)
+			execCtx := newExecutionContext(
+				context.Background(),
+				"test-provider",
+				&config.Config{},
+				nil,
+				cliproxyexecutor.Request{Model: "test-model", Payload: payload},
+				cliproxyexecutor.Options{SourceFormat: from},
+				ExecutionOptions{TargetFormat: to},
+			)
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				translated, originalTranslated := execCtx.TranslateRequestPair(nil)
+				runtime.KeepAlive(translated)
+				runtime.KeepAlive(originalTranslated)
+			}
+		})
+	}
+}
+
+func byteSizeLabel(size int) string {
+	if size%(1<<20) == 0 {
+		return strconv.Itoa(size/(1<<20)) + "MiB"
+	}
+	return strconv.Itoa(size/(1<<10)) + "KiB"
 }
 
 func TestExecutionContextReporterKeepsVisionFallbackSeparateFromModelMapping(t *testing.T) {

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -195,6 +195,72 @@ func TestRequestDetailsCaptureUpstreamLogsWhenOnlyContentStorageEnabled(t *testi
 	}
 }
 
+func TestRequestDetailsRedactSensitiveHeadersAndOmitEmptyExchangeSections(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses?api_key=query-secret&safe=value", strings.NewReader(`{"input":"hi"}`))
+	req.Header.Set("Authorization", "Bearer downstream-secret")
+	req.Header.Set("Proxy-Authorization", "Basic proxy-secret")
+	req.Header.Set("Cookie", "session=browser-secret")
+	req.Header.Set("X-Api-Key", "api-key-secret")
+	req.Header.Set("X-Auth-Token", "token-secret")
+	req.Header.Set("X-Codex-Session-Id", "session-diagnostic")
+	req.Header.Set("User-Agent", "codex-cli-test")
+	ginCtx.Request = req
+	ctx := context.WithValue(req.Context(), util.ContextKeyGin, ginCtx)
+
+	var detail struct {
+		Client struct {
+			URL                string              `json:"url"`
+			Query              map[string][]string `json:"query"`
+			Headers            map[string][]string `json:"headers"`
+			FingerprintHeaders map[string][]string `json:"fingerprint_headers"`
+		} `json:"client"`
+		Upstream *struct {
+			RequestLog string `json:"request_log"`
+		} `json:"upstream"`
+		Response *struct {
+			UpstreamLog string `json:"upstream_log"`
+		} `json:"response"`
+	}
+	raw := buildRequestDetailContent(ctx, false)
+	if err := json.Unmarshal([]byte(raw), &detail); err != nil {
+		t.Fatalf("unmarshal request details: %v", err)
+	}
+	for _, key := range []string{"Authorization", "Proxy-Authorization", "Cookie", "X-Api-Key", "X-Auth-Token"} {
+		values := detail.Client.Headers[key]
+		if len(values) != 1 || values[0] != redactedRequestDetailHeaderValue {
+			t.Fatalf("client.headers[%q] = %#v, want redacted", key, values)
+		}
+	}
+	for _, key := range []string{"X-Api-Key", "X-Auth-Token"} {
+		values := detail.Client.FingerprintHeaders[key]
+		if len(values) != 1 || values[0] != redactedRequestDetailHeaderValue {
+			t.Fatalf("client.fingerprint_headers[%q] = %#v, want redacted", key, values)
+		}
+	}
+	if got := detail.Client.Headers["X-Codex-Session-Id"]; len(got) != 1 || got[0] != "session-diagnostic" {
+		t.Fatalf("non-sensitive diagnostic header = %#v, want preserved", got)
+	}
+	if got := detail.Client.Headers["User-Agent"]; len(got) != 1 || got[0] != "codex-cli-test" {
+		t.Fatalf("user-agent = %#v, want preserved", got)
+	}
+	if strings.Contains(detail.Client.URL, "query-secret") || strings.Contains(strings.Join(detail.Client.Query["api_key"], ""), "query-secret") {
+		t.Fatalf("request detail retained sensitive query value: url=%q query=%#v", detail.Client.URL, detail.Client.Query)
+	}
+	if got := detail.Client.Query["safe"]; len(got) != 1 || got[0] != "value" {
+		t.Fatalf("safe query value = %#v, want preserved", got)
+	}
+	for _, secret := range []string{"downstream-secret", "proxy-secret", "browser-secret", "api-key-secret", "token-secret", "query-secret"} {
+		if strings.Contains(raw, secret) {
+			t.Fatalf("request detail retained sensitive value %q", secret)
+		}
+	}
+	if detail.Upstream != nil || detail.Response != nil {
+		t.Fatalf("empty exchange sections should be omitted: upstream=%#v response=%#v", detail.Upstream, detail.Response)
+	}
+}
+
 func TestRequestDetailsPreferForwardedClientIPForCDNRequests(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ginCtx, engine := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/runtime/executor/usage_request_details.go
+++ b/internal/runtime/executor/usage_request_details.go
@@ -89,27 +89,35 @@ func buildRequestDetailContent(ctx context.Context, includeBodies ...bool) strin
 		apiResponse = logging.APIResponseSnapshot(ginCtx)
 	}
 	clientIP, clientIPSource := requestLogClientIP(ginCtx, req)
+	requestURL := *req.URL
+	requestURL.RawQuery = util.MaskSensitiveQuery(requestURL.RawQuery)
 
-	detail := map[string]any{
-		"client": map[string]any{
-			"ip":                  clientIP,
-			"ip_source":           clientIPSource,
-			"remote_addr":         req.RemoteAddr,
-			"method":              req.Method,
-			"url":                 req.URL.String(),
-			"path":                req.URL.Path,
-			"query":               req.URL.Query(),
-			"host":                req.Host,
-			"content_length":      req.ContentLength,
-			"headers":             cloneHeaderValues(req.Header),
-			"fingerprint_headers": extractFingerprintHeaders(req.Header),
-		},
-		"upstream": map[string]any{
-			"request_log": bytesToString(apiRequest),
-		},
-		"response": map[string]any{
-			"upstream_log": bytesToString(apiResponse),
-		},
+	client := map[string]any{
+		"ip":             clientIP,
+		"ip_source":      clientIPSource,
+		"remote_addr":    req.RemoteAddr,
+		"method":         req.Method,
+		"url":            requestURL.String(),
+		"path":           requestURL.Path,
+		"query":          requestURL.Query(),
+		"host":           req.Host,
+		"content_length": req.ContentLength,
+	}
+	if headers := cloneHeaderValues(req.Header); len(headers) > 0 {
+		client["headers"] = headers
+	}
+	if fingerprintHeaders := extractFingerprintHeaders(req.Header); len(fingerprintHeaders) > 0 {
+		client["fingerprint_headers"] = fingerprintHeaders
+	}
+
+	// Empty exchange sections add a compressed content row cost without carrying
+	// diagnostics, so only persist them when an upstream snapshot exists.
+	detail := map[string]any{"client": client}
+	if requestLog := bytesToString(apiRequest); requestLog != "" {
+		detail["upstream"] = map[string]any{"request_log": requestLog}
+	}
+	if responseLog := bytesToString(apiResponse); responseLog != "" {
+		detail["response"] = map[string]any{"upstream_log": responseLog}
 	}
 	if egress := requestLogEgressFromContext(ginCtx); len(egress) > 0 {
 		detail["egress"] = egress
@@ -170,17 +178,44 @@ func requestLogEgressFromContext(ginCtx *gin.Context) map[string]any {
 	return requestLogEgressRouteMap(route)
 }
 
+const redactedRequestDetailHeaderValue = "<redacted>"
+
 func cloneHeaderValues(headers http.Header) map[string][]string {
 	if len(headers) == 0 {
 		return map[string][]string{}
 	}
 	out := make(map[string][]string, len(headers))
 	for key, values := range headers {
-		copied := make([]string, len(values))
-		copy(copied, values)
-		out[key] = copied
+		out[key] = cloneRequestDetailHeaderValues(key, values)
 	}
 	return out
+}
+
+// Persisted request details use full redaction because even partially masked
+// credentials should not remain reusable from the request log database.
+func cloneRequestDetailHeaderValues(key string, values []string) []string {
+	copied := make([]string, len(values))
+	if isSensitiveRequestDetailHeader(key) {
+		for index := range copied {
+			copied[index] = redactedRequestDetailHeaderValue
+		}
+		return copied
+	}
+	copy(copied, values)
+	return copied
+}
+
+func isSensitiveRequestDetailHeader(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	switch normalized {
+	case "authorization", "proxy-authorization", "cookie", "set-cookie":
+		return true
+	}
+	return strings.Contains(normalized, "api-key") ||
+		strings.Contains(normalized, "apikey") ||
+		strings.Contains(normalized, "token") ||
+		strings.Contains(normalized, "secret") ||
+		strings.Contains(normalized, "credential")
 }
 
 func extractFingerprintHeaders(headers http.Header) map[string][]string {
@@ -198,9 +233,7 @@ func extractFingerprintHeaders(headers http.Header) map[string][]string {
 			strings.Contains(normalized, "claude") ||
 			strings.Contains(normalized, "gemini") ||
 			strings.HasPrefix(normalized, "x-") {
-			copied := make([]string, len(values))
-			copy(copied, values)
-			out[key] = copied
+			out[key] = cloneRequestDetailHeaderValues(key, values)
 		}
 	}
 	return out


### PR DESCRIPTION
## Summary

- avoid translating the same request payload twice when no distinct `OriginalRequest` override exists
- fully redact persisted sensitive request headers and mask sensitive query parameters
- omit empty upstream/response exchange sections from persisted request details
- add regression tests and large-payload benchmarks covering 512 KiB through 16 MiB

## Impact

- repository: `CliRelay`
- no API response, routing, authentication, model selection, billing, retry, or request-size behavior changes
- distinct original and translated payloads continue to be translated independently
- request-log diagnostic structure remains compatible; empty sections are now omitted and credentials are stored as `<redacted>`

## Validation

Executed locally with a temporary PostgreSQL 15 container matching the PR workflow service:

```bash
CLIRELAY_POSTGRES_TEST_DSN='postgres://cliproxy:cliproxy@localhost:55432/cliproxy?sslmode=disable' ./scripts/ci-pr.sh
```

This completed:

- vendored panel asset guard
- backend structure check
- `gofmt` check
- API-key pattern scan
- `go vet ./...`
- `go test ./...`
- `golangci-lint`
- `go build -o test-output ./cmd/server`

Additional targeted verification:

```bash
go test ./internal/runtime/executor -run 'TestExecutionContext|TestRequestDetails' -count=1
go test ./internal/runtime/executor -count=1
go test ./internal/usage -count=1
go test ./internal/api/... -run 'TestRegisterManagementRouteTable|TestRequest' -count=1
go test ./internal/runtime/executor -run '^$' -bench '^BenchmarkExecutionContextTranslateSharedRequestPayload$' -benchmem -benchtime=100ms -count=1
```
