### PR TITLE
fix: invalidate soft-deleted owned keys and stop leaking key names as users

### DIFF
--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -1101,12 +1101,39 @@ func (s *Service) DeleteKey(ctx context.Context, tenantID, endUserID, keyID stri
 		}
 	}
 	var isDefault bool
-	err = tx.QueryRowContext(ctx, `SELECT COALESCE(is_default, false) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0`, tenantID, endUserID, keyID).Scan(&isDefault)
+	var disabledInt int
+	var currentKey string
+	err = tx.QueryRowContext(ctx, `
+		SELECT COALESCE(is_default, false), disabled, key
+		FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ?
+	`, tenantID, endUserID, keyID).Scan(&isDefault, &disabledInt, &currentKey)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrNotFound
 	}
 	if err != nil {
 		return err
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	// Soft-delete keeps the row (stable id → request_logs ownership) but
+	// permanently invalidates the secret so the deleted key can never auth
+	// again, including via accidental re-enable in management UI.
+	needTombstone := !strings.HasPrefix(strings.TrimSpace(currentKey), "sk-deleted-")
+	if disabledInt != 0 {
+		// Already soft-deleted/disabled: only ensure secret is tombstoned.
+		if needTombstone {
+			tombstone, genErr := GenerateAPIKey()
+			if genErr != nil {
+				return genErr
+			}
+			tombstone = "sk-deleted-" + strings.TrimPrefix(tombstone, "sk-")
+			if _, err = tx.ExecContext(ctx, `
+				UPDATE api_keys SET key = ?, is_default = false, updated_at = ?
+				WHERE tenant_id = ? AND end_user_id = ? AND id = ?
+			`, tombstone, now, tenantID, endUserID, keyID); err != nil {
+				return err
+			}
+		}
+		return tx.Commit()
 	}
 	var count int
 	if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0`, tenantID, endUserID).Scan(&count); err != nil {
@@ -1115,11 +1142,16 @@ func (s *Service) DeleteKey(ctx context.Context, tenantID, endUserID, keyID stri
 	if count <= 1 {
 		return ErrLastKey
 	}
-	now := time.Now().UTC().Format(time.RFC3339)
+	tombstone, genErr := GenerateAPIKey()
+	if genErr != nil {
+		return genErr
+	}
+	// Prefix makes tombstones obvious in DB; still unique via random suffix.
+	tombstone = "sk-deleted-" + strings.TrimPrefix(tombstone, "sk-")
 	if _, err = tx.ExecContext(ctx, `
-		UPDATE api_keys SET disabled = 1, is_default = false, updated_at = ?
+		UPDATE api_keys SET key = ?, disabled = 1, is_default = false, updated_at = ?
 		WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0
-	`, now, tenantID, endUserID, keyID); err != nil {
+	`, tombstone, now, tenantID, endUserID, keyID); err != nil {
 		return err
 	}
 	if isDefault {

--- a/internal/enduser/service_sqlite_test.go
+++ b/internal/enduser/service_sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -97,6 +98,17 @@ func TestDeleteKeyPromotesDefaultOnSQLite(t *testing.T) {
 	}
 	if !keys[0].IsDefault {
 		t.Fatal("remaining key must be promoted to default")
+	}
+	var disabled int
+	var storedSecret string
+	if err := db.QueryRow(`SELECT disabled, key FROM api_keys WHERE tenant_id = ? AND id = ?`, tenantID, first.APIKey.ID).Scan(&disabled, &storedSecret); err != nil {
+		t.Fatalf("query soft-deleted key: %v", err)
+	}
+	if disabled != 1 {
+		t.Fatalf("disabled = %d, want 1", disabled)
+	}
+	if storedSecret == first.PlaintextKey || !strings.HasPrefix(storedSecret, "sk-deleted-") {
+		t.Fatalf("soft-deleted secret not invalidated: %q", storedSecret)
 	}
 	if err := svc.DeleteKey(ctx, tenantID, userID, keys[0].ID); !errors.Is(err, ErrLastKey) {
 		t.Fatalf("delete last key err = %v, want ErrLastKey", err)

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -274,7 +274,18 @@ func (s *Service) ListEntries() []config.APIKeyEntry {
 // ListEntriesWithDailySpending lists keys and attaches effective daily spending fields.
 // Query failures return an error so management handlers do not silently show $0.
 func (s *Service) ListEntriesWithDailySpending() ([]config.APIKeyEntry, error) {
-	rows := usage.EffectiveAPIKeyRowsForTenant(s.tenantID, usage.ListAPIKeysForTenant(s.tenantID))
+	all := usage.ListAPIKeysForTenant(s.tenantID)
+	// Soft-deleted owned keys keep a sk-deleted-* tombstone secret for log
+	// ownership; hide them from management lists. Intentional disable (same
+	// secret, disabled=1) still appears so operators can re-enable.
+	visible := make([]usage.APIKeyRow, 0, len(all))
+	for _, row := range all {
+		if row.Disabled && strings.TrimSpace(row.EndUserID) != "" && strings.HasPrefix(strings.TrimSpace(row.Key), "sk-deleted-") {
+			continue
+		}
+		visible = append(visible, row)
+	}
+	rows := usage.EffectiveAPIKeyRowsForTenant(s.tenantID, visible)
 	entries := make([]config.APIKeyEntry, 0, len(rows))
 	for _, row := range rows {
 		entries = append(entries, row.ToConfigEntry())
@@ -438,6 +449,10 @@ func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryP
 		entry.Name = strings.TrimSpace(*patch.Name)
 	}
 	if patch.Disabled != nil {
+		// Tombstoned owned secrets are permanently revoked; never re-enable them.
+		if !*patch.Disabled && strings.HasPrefix(strings.TrimSpace(existing.Key), "sk-deleted-") {
+			return ErrItemNotFound
+		}
 		entry.Disabled = *patch.Disabled
 	}
 	if patch.PermissionProfileID != nil {

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -332,6 +332,56 @@ func TestDeleteEntryByIndexDeletesLogsWhenRequested(t *testing.T) {
 	}
 }
 
+func TestListEntriesHidesSoftDeletedOwnedKeys(t *testing.T) {
+	setupTestDB(t)
+	svc := NewService(nil)
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{
+		ID: "owned-active", Key: "sk-owned-active", Name: "active", EndUserID: "eu-1",
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey(active): %v", err)
+	}
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{
+		ID: "owned-tombstone", Key: "sk-deleted-abc", Name: "dead", EndUserID: "eu-1", Disabled: true,
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey(tombstone): %v", err)
+	}
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{
+		ID: "owned-disabled", Key: "sk-owned-disabled", Name: "paused", EndUserID: "eu-1", Disabled: true,
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey(disabled): %v", err)
+	}
+	if err := usage.UpsertAPIKey(usage.APIKeyRow{
+		ID: "solo-disabled", Key: "sk-solo-disabled", Name: "solo", Disabled: true,
+	}); err != nil {
+		t.Fatalf("UpsertAPIKey(solo): %v", err)
+	}
+
+	entries, err := svc.ListEntriesWithDailySpending()
+	if err != nil {
+		t.Fatalf("ListEntriesWithDailySpending: %v", err)
+	}
+	foundTombstone, foundDisabled, foundActive, foundSolo := false, false, false, false
+	for _, e := range entries {
+		switch e.Key {
+		case "sk-deleted-abc":
+			foundTombstone = true
+		case "sk-owned-disabled":
+			foundDisabled = true
+		case "sk-owned-active":
+			foundActive = true
+		case "sk-solo-disabled":
+			foundSolo = true
+		}
+	}
+	if foundTombstone {
+		t.Fatalf("ListEntries leaked tombstoned owned key: %#v", entries)
+	}
+	if !foundDisabled || !foundActive || !foundSolo {
+		t.Fatalf("ListEntries missing expected keys: disabled=%v active=%v solo=%v entries=%#v",
+			foundDisabled, foundActive, foundSolo, entries)
+	}
+}
+
 func TestListEntriesAttachesDailySpendingRuntime(t *testing.T) {
 	setupTestDB(t)
 	svc := NewService(nil)

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -76,7 +76,12 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	if filters.APIKeyNames == nil {
 		filters.APIKeyNames = make(map[string]string, len(filters.APIKeys))
 	}
+	// Prefer account display names already resolved by queryDistinctAPIKeys.
+	// Only fill gaps from keyNameMap; never overwrite end-user labels with key names.
 	for _, key := range filters.APIKeys {
+		if strings.TrimSpace(filters.APIKeyNames[key]) != "" {
+			continue
+		}
 		if name, ok := maps.keyNameMap[key]; ok {
 			filters.APIKeyNames[key] = name
 		}
@@ -859,8 +864,20 @@ func (s *Service) buildNameMaps() nameMaps {
 	}
 
 	for _, row := range apikeysettings.NewService(nil, apikeysettings.WithTenantID(s.tenantID)).ListRows() {
-		if row.Key != "" && row.Name != "" {
-			maps.keyNameMap[row.Key] = row.Name
+		key := strings.TrimSpace(row.Key)
+		if key == "" {
+			continue
+		}
+		// Owned multi-key accounts: filter/list labels are end-user display names,
+		// never the individual key name (e.g. LYDing1 must not appear as a user).
+		if eu := strings.TrimSpace(row.EndUserID); eu != "" {
+			if label := usage.DisplayNameForEndUser(eu); label != "" {
+				maps.keyNameMap[key] = label
+				continue
+			}
+		}
+		if name := strings.TrimSpace(row.Name); name != "" {
+			maps.keyNameMap[key] = name
 		}
 	}
 

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -1,7 +1,9 @@
 package apikey
 
 import (
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -110,6 +112,12 @@ func InitTable(db *sql.DB) {
 	migrateColumns(db)
 	backfillIDs(db)
 	backfillNames(db)
+	// One-time repair: soft-delete used to leave the original secret in place.
+	// Tombstone those rows so deleted keys cannot be re-enabled and reused.
+	// Intentional disable (power toggle) is the same disabled=1 bit; after this
+	// repair, only DELETE path tombstones. Operators who only disabled a key
+	// lose re-enable-with-same-secret once — create a new key instead.
+	tombstoneStaleDisabledOwnedSecrets(db)
 }
 
 func BackfillNames(db *sql.DB) {
@@ -610,19 +618,24 @@ func (s Store) deleteOwnedGuarded(where string, arg string) error {
 		ownerID = strings.TrimSpace(endUserID.String)
 	}
 	if ownerID != "" {
-		if disabledInt != 0 {
-			return nil
-		}
 		if err = lockOwnedEndUser(tx, ownerID); err != nil {
 			return err
 		}
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	if ownerID != "" {
+		// Soft-delete keeps the row (stable id → request_logs ownership) but
+		// permanently invalidates the secret so the deleted key can never auth
+		// again, including via accidental re-enable. Also covers "disabled then
+		// deleted" so a prior toggle-disable cannot leave a reusable secret.
+		tombstone, genErr := newTombstoneSecret()
+		if genErr != nil {
+			return genErr
+		}
 		if _, err = tx.Exec(`
-			UPDATE api_keys SET disabled = 1, is_default = false, updated_at = ?
+			UPDATE api_keys SET key = ?, disabled = 1, is_default = false, updated_at = ?
 			WHERE tenant_id = ? AND id = ?
-		`, now, s.tenantID, keyID); err != nil {
+		`, tombstone, now, s.tenantID, keyID); err != nil {
 			return err
 		}
 		if err = ensureOwnedActiveKeyAndDefault(tx, s.tenantID, ownerID, now); err != nil {
@@ -632,6 +645,16 @@ func (s Store) deleteOwnedGuarded(where string, arg string) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+// newTombstoneSecret returns a unique unusable secret for soft-deleted owned keys.
+// api_keys.key is globally UNIQUE, so each tombstone must differ.
+func newTombstoneSecret() (string, error) {
+	raw := make([]byte, 24)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return "sk-deleted-" + hex.EncodeToString(raw), nil
 }
 
 func (s Store) Delete(key string) error {
@@ -858,6 +881,68 @@ func migrateColumns(db *sql.DB) {
 	}
 	if _, err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key)"); err != nil {
 		log.Warnf("sqlite/apikey: ensure api_keys key index: %v", err)
+	}
+}
+
+// tombstoneStaleDisabledOwnedSecrets invalidates secrets for already soft-deleted
+// owned keys that still hold their original plaintext (pre-fix rows).
+func tombstoneStaleDisabledOwnedSecrets(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	rows, err := db.Query(`
+		SELECT id FROM api_keys
+		WHERE disabled != 0
+		  AND end_user_id IS NOT NULL AND trim(end_user_id) != ''
+		  AND key NOT LIKE 'sk-deleted-%'
+	`)
+	if err != nil {
+		log.Warnf("sqlite/apikey: list stale disabled owned secrets: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	ids := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			log.Warnf("sqlite/apikey: scan stale disabled owned secret: %v", err)
+			return
+		}
+		id = strings.TrimSpace(id)
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		log.Warnf("sqlite/apikey: iterate stale disabled owned secrets: %v", err)
+		return
+	}
+	if len(ids) == 0 {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	fixed := 0
+	for _, id := range ids {
+		tombstone, genErr := newTombstoneSecret()
+		if genErr != nil {
+			log.Warnf("sqlite/apikey: tombstone secret: %v", genErr)
+			return
+		}
+		res, execErr := db.Exec(`
+			UPDATE api_keys SET key = ?, is_default = false, updated_at = ?
+			WHERE id = ? AND disabled != 0 AND key NOT LIKE 'sk-deleted-%'
+		`, tombstone, now, id)
+		if execErr != nil {
+			log.Warnf("sqlite/apikey: tombstone owned secret id=%s: %v", id, execErr)
+			continue
+		}
+		if n, _ := res.RowsAffected(); n > 0 {
+			fixed++
+		}
+	}
+	if fixed > 0 {
+		log.Infof("sqlite/apikey: invalidated secrets for %d soft-deleted owned keys", fixed)
 	}
 }
 

--- a/internal/storage/sqlite/apikey/store_tenant_test.go
+++ b/internal/storage/sqlite/apikey/store_tenant_test.go
@@ -2,6 +2,7 @@ package apikey
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -185,6 +186,17 @@ func TestOwnedKeyMutationsKeepOneActiveDefault(t *testing.T) {
 	}
 	if got := store.GetByID("default-b"); got == nil || got.Disabled || !got.IsDefault {
 		t.Fatalf("remaining active key was not promoted: %#v", got)
+	}
+
+	// DeleteByID on owned key soft-deletes and invalidates the secret.
+	if err := store.DeleteByID("default-a"); err != nil {
+		t.Fatalf("DeleteByID owned: %v", err)
+	}
+	if got := store.GetByID("default-a"); got == nil || !got.Disabled || got.Key == "sk-default-a" || !strings.HasPrefix(got.Key, "sk-deleted-") {
+		t.Fatalf("soft-deleted owned key secret not invalidated: %#v", got)
+	}
+	if got := store.Get("sk-default-a"); got != nil {
+		t.Fatalf("old secret still resolvable after soft delete: %#v", got)
 	}
 
 	rows := store.List()

--- a/internal/usage/enduser_key_lifecycle_external_test.go
+++ b/internal/usage/enduser_key_lifecycle_external_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -122,8 +123,15 @@ func TestSoftDeletedOwnedKeyKeepsAccountHistory(t *testing.T) {
 	if err := db.QueryRow(`SELECT disabled, end_user_id, key FROM api_keys WHERE tenant_id = ? AND id = ?`, tenantID, first.APIKey.ID).Scan(&disabled, &ownerID, &storedSecret); err != nil {
 		t.Fatalf("query soft-deleted key: %v", err)
 	}
-	if disabled != 1 || ownerID != userID || storedSecret != first.PlaintextKey {
-		t.Fatalf("soft-deleted row = disabled:%d owner:%q secret:%q", disabled, ownerID, storedSecret)
+	if disabled != 1 || ownerID != userID {
+		t.Fatalf("soft-deleted row = disabled:%d owner:%q", disabled, ownerID)
+	}
+	// Deleted secret must be permanently invalidated (not the original plaintext).
+	if storedSecret == first.PlaintextKey {
+		t.Fatalf("soft-deleted secret still equals original plaintext")
+	}
+	if !strings.HasPrefix(storedSecret, "sk-deleted-") {
+		t.Fatalf("soft-deleted secret = %q, want sk-deleted- prefix", storedSecret)
 	}
 
 	params := usage.LogQueryParams{TenantID: tenantID, EndUserID: userID, Page: 1, Size: 20, Days: 1}

--- a/internal/usage/request_log_account_filter.go
+++ b/internal/usage/request_log_account_filter.go
@@ -114,6 +114,11 @@ func accountFilterRepresentatives(tenantID string) (repByEndUser map[string]stri
 	nameByEndUser = make(map[string]string)
 	defaultPicked := make(map[string]bool)
 	for _, row := range rows {
+		if row.Disabled {
+			// Soft-deleted keys retain ownership for log collapse, but must not
+			// become the account filter representative value.
+			continue
+		}
 		eu := strings.TrimSpace(row.EndUserID)
 		if eu == "" {
 			continue

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1978,6 +1978,80 @@ func TestQueryFiltersCollapsesOwnedKeysToOneAccountOption(t *testing.T) {
 	}
 }
 
+func TestQueryFiltersUsesActiveRepAfterSoftDeletedOwnedKey(t *testing.T) {
+	// Soft-deleted owned keys stay in api_keys for log ownership, but the
+	// account filter representative must be an active secret, never a tombstone.
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS end_users (
+			id TEXT PRIMARY KEY,
+			tenant_id TEXT NOT NULL,
+			username TEXT NOT NULL,
+			username_normalized TEXT NOT NULL,
+			display_name TEXT NOT NULL,
+			password_hash TEXT NOT NULL DEFAULT 'x',
+			status TEXT NOT NULL DEFAULT 'active',
+			permission_profile_id TEXT NOT NULL DEFAULT '',
+			daily_limit INTEGER NOT NULL DEFAULT 0,
+			total_quota INTEGER NOT NULL DEFAULT 0,
+			spending_limit REAL NOT NULL DEFAULT 0,
+			daily_spending_limit REAL NOT NULL DEFAULT 0,
+			concurrency_limit INTEGER NOT NULL DEFAULT 0,
+			rpm_limit INTEGER NOT NULL DEFAULT 0,
+			tpm_limit INTEGER NOT NULL DEFAULT 0,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			allowed_channels TEXT NOT NULL DEFAULT '[]',
+			allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+	endUserID := "eu-soft-del"
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name)
+		VALUES (?, ?, 'lyding', 'lyding', 'LYDing')
+	`, endUserID, systemTenantID); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := UpsertAPIKey(APIKeyRow{
+		TenantID: systemTenantID, ID: "key-dead", Key: "sk-deleted-old", Name: "LYDing",
+		EndUserID: endUserID, Disabled: true, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert dead: %v", err)
+	}
+	if err := UpsertAPIKey(APIKeyRow{
+		TenantID: systemTenantID, ID: "key-live", Key: "sk-live-new", Name: "LYDing1",
+		EndUserID: endUserID, IsDefault: true, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert live: %v", err)
+	}
+	ts := time.Now().UTC()
+	InsertLogWithDetailsIdentity("sk-old-plain", "key-dead", "LYDing", "gpt-a", "src", "ch", "a1", false, ts, 1, 1, TokenStats{TotalTokens: 1}, "", "", "")
+	InsertLogWithDetailsIdentity("sk-live-new", "key-live", "LYDing1", "gpt-b", "src", "ch", "a2", false, ts.Add(time.Second), 1, 1, TokenStats{TotalTokens: 1}, "", "", "")
+
+	filters, err := QueryFilters(7)
+	if err != nil {
+		t.Fatalf("QueryFilters: %v", err)
+	}
+	if len(filters.APIKeys) != 1 {
+		t.Fatalf("filters.APIKeys = %#v, want one account option", filters.APIKeys)
+	}
+	if filters.APIKeys[0] != "sk-live-new" {
+		t.Fatalf("representative = %q, want sk-live-new (active)", filters.APIKeys[0])
+	}
+	if filters.APIKeyNames["sk-live-new"] != "LYDing" {
+		t.Fatalf("filter name = %q, want account display LYDing not key name", filters.APIKeyNames["sk-live-new"])
+	}
+	for _, name := range filters.APIKeyNames {
+		if name == "LYDing1" {
+			t.Fatalf("filters leaked key name LYDing1: %#v", filters.APIKeyNames)
+		}
+	}
+}
+
 func TestQueryAPIKeyDistributionMergesRawAndIDGroupsForSameKey(t *testing.T) {
 	// Production shape: some request_logs carry api_key_id, older rows for the
 	// same secret only have api_key. Distribution must merge into one point so


### PR DESCRIPTION
## Summary
- Soft-delete owned API keys now **tombstones the secret** (`sk-deleted-*`) so deleted keys cannot authenticate or be re-enabled, while keeping the row for request-log ownership via stable `api_key_id`.
- Management list hides tombstoned owned keys (intentional disable without tombstone still visible).
- Request-log **user** filter labels prefer end-user `display_name` and never overwrite with per-key names (fixes `LYDing1` appearing as a user).
- Startup one-time repair invalidates secrets on already soft-deleted owned rows that still hold plaintext.

## Root cause
1. **Deleted key still usable**: `DeleteKey` only set `disabled=1` and kept the original secret; management list still showed it and re-enable restored auth.
2. **Key name in user filter**: `buildNameMaps` overwrote account display names with `api_keys.name`.

## Test plan
- [x] `go test ./internal/usage/ ./internal/enduser/ ./internal/storage/sqlite/apikey/ ./internal/management/settings/apikey/ ./internal/management/usagelogs/ ./internal/access/config_access/`
- [ ] After deploy: LYDing manage-keys shows only active keys; deleted secret rejects auth; request-logs user filter shows `LYDing` once (not `LYDing1`)