### PR TITLE
fix: stop O(N) full-body sjson copies on large Codex requests

### DIFF
--- a/internal/runtime/executor/codex_responses.go
+++ b/internal/runtime/executor/codex_responses.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -15,18 +16,17 @@ func ensureTranslatedCodexModel(body []byte, fallback string) []byte {
 	if strings.TrimSpace(gjson.GetBytes(body, "model").String()) != "" {
 		return body
 	}
-	body, _ = sjson.SetBytes(body, "model", fallback)
-	return body
+	return util.MutateTopLevelObject(body, map[string][]byte{
+		"model": util.JSONString(fallback),
+	}, nil)
 }
 
 func sanitizeCodexResponsesRequest(body []byte) []byte {
-	for _, field := range []string{
+	body = util.MutateTopLevelObject(body, nil, []string{
 		"max_output_tokens",
 		"max_completion_tokens",
 		"max_tokens",
-	} {
-		body, _ = sjson.DeleteBytes(body, field)
-	}
+	})
 	body = stripCodexResponsesImageGenerationSize(body)
 	// History hygiene: never forward multi-MB data:image blobs from Desktop session replay.
 	body = stripCodexHistoryDataURLImages(body)

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -15,6 +15,7 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 )
 
 const usageReporterOutputMemoryLimit = 256 * 1024
@@ -140,13 +141,8 @@ func (r *usageReporter) setInputContent(content string) {
 }
 
 func isStreamingUsageRequest(content string) bool {
-	var payload struct {
-		Stream bool `json:"stream"`
-	}
-	if err := json.Unmarshal([]byte(content), &payload); err != nil {
-		return false
-	}
-	return payload.Stream
+	// Only read top-level "stream"; full Unmarshal on multi-MB bodies was a hot alloc path.
+	return gjson.Get(content, "stream").Bool()
 }
 
 // appendOutputChunk accumulates a streaming response line for inclusion in usage records.

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -19,7 +19,6 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 )
 
 const (
@@ -347,15 +346,18 @@ func (e *XAIExecutor) prepareResponsesRequest(ctx context.Context, auth *cliprox
 	body = execCtx.ApplyPayloadConfig(body, originalTranslated)
 	body = ensureTranslatedCodexModel(body, execCtx.BaseModel)
 	body = sanitizeCodexResponsesRequest(body)
-	body, _ = sjson.SetBytes(body, "stream", stream)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
-	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
-	body, _ = sjson.DeleteBytes(body, "safety_identifier")
-	body, _ = sjson.DeleteBytes(body, "stream_options")
-	if !gjson.GetBytes(body, "instructions").Exists() {
-		sysContent := extractSystemMessagesAsInstructions(execCtx.Request.Payload)
-		body, _ = sjson.SetBytes(body, "instructions", sysContent)
+	sets := map[string][]byte{
+		"stream": util.JSONBool(stream),
 	}
+	if !gjson.GetBytes(body, "instructions").Exists() {
+		sets["instructions"] = util.JSONString(extractSystemMessagesAsInstructions(execCtx.Request.Payload))
+	}
+	body = util.MutateTopLevelObject(body, sets, []string{
+		"previous_response_id",
+		"prompt_cache_retention",
+		"safety_identifier",
+		"stream_options",
+	})
 	return execCtx, body, originalTranslated, nil
 }
 

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -7,6 +7,7 @@
 package chat_completions
 
 import (
+	"bytes"
 	"strconv"
 	"strings"
 
@@ -28,43 +29,12 @@ import (
 //   - []byte: The transformed request data in OpenAI Responses API format
 func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
-	// Start with empty JSON object
-	out := `{"instructions":""}`
-
-	// Stream must be set to true
-	out, _ = sjson.Set(out, "stream", stream)
-
-	// Codex does not support the legacy sampling knobs or token limit fields on
-	// the Responses endpoint, so we intentionally do not forward them here.
-	// if v := gjson.GetBytes(rawJSON, "temperature"); v.Exists() {
-	// 	out, _ = sjson.Set(out, "temperature", v.Value())
-	// }
-	// if v := gjson.GetBytes(rawJSON, "top_p"); v.Exists() {
-	// 	out, _ = sjson.Set(out, "top_p", v.Value())
-	// }
-	// if v := gjson.GetBytes(rawJSON, "top_k"); v.Exists() {
-	// 	out, _ = sjson.Set(out, "top_k", v.Value())
-	// }
-
-	// Map reasoning effort
-	if v := gjson.GetBytes(rawJSON, "reasoning_effort"); v.Exists() {
-		out, _ = sjson.Set(out, "reasoning.effort", v.Value())
-	} else {
-		out, _ = sjson.Set(out, "reasoning.effort", "medium")
-	}
-	out, _ = sjson.Set(out, "parallel_tool_calls", true)
-	out, _ = sjson.Set(out, "reasoning.summary", "auto")
-	out, _ = sjson.Set(out, "include", []string{"reasoning.encrypted_content"})
-
-	// Model
-	out, _ = sjson.Set(out, "model", modelName)
 
 	// Build tool name shortening map from original tools (if any)
 	originalToolNameMap := map[string]string{}
 	{
 		tools := gjson.GetBytes(rawJSON, "tools")
 		if tools.IsArray() && len(tools.Array()) > 0 {
-			// Collect original tool names
 			var names []string
 			arr := tools.Array()
 			for i := 0; i < len(arr); i++ {
@@ -84,26 +54,22 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 		}
 	}
 
-	// Extract system instructions from first system message (string or text object)
-	messages := gjson.GetBytes(rawJSON, "messages")
-	// if messages.IsArray() {
-	// 	arr := messages.Array()
-	// 	for i := 0; i < len(arr); i++ {
-	// 		m := arr[i]
-	// 		if m.Get("role").String() == "system" {
-	// 			c := m.Get("content")
-	// 			if c.Type == gjson.String {
-	// 				out, _ = sjson.Set(out, "instructions", c.String())
-	// 			} else if c.IsObject() && c.Get("type").String() == "text" {
-	// 				out, _ = sjson.Set(out, "instructions", c.Get("text").String())
-	// 			}
-	// 			break
-	// 		}
-	// 	}
-	// }
+	// Build input array once (avoid N full-document sjson copies on large histories).
+	var inputBuf bytes.Buffer
+	inputBuf.WriteByte('[')
+	inputFirst := true
+	appendInput := func(raw string) {
+		if raw == "" {
+			return
+		}
+		if !inputFirst {
+			inputBuf.WriteByte(',')
+		}
+		inputFirst = false
+		inputBuf.WriteString(raw)
+	}
 
-	// Build input from messages, handling all message types including tool calls
-	out, _ = sjson.SetRaw(out, "input", `[]`)
+	messages := gjson.GetBytes(rawJSON, "messages")
 	if messages.IsArray() {
 		arr := messages.Array()
 		for i := 0; i < len(arr); i++ {
@@ -112,19 +78,15 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 
 			switch role {
 			case "tool":
-				// Handle tool response messages as top-level function_call_output objects
 				toolCallID := m.Get("tool_call_id").String()
 				content := m.Get("content").String()
-
-				// Create function_call_output object
 				funcOutput := `{}`
 				funcOutput, _ = sjson.Set(funcOutput, "type", "function_call_output")
 				funcOutput, _ = sjson.Set(funcOutput, "call_id", toolCallID)
 				funcOutput, _ = sjson.Set(funcOutput, "output", content)
-				out, _ = sjson.SetRaw(out, "input.-1", funcOutput)
+				appendInput(funcOutput)
 
 			default:
-				// Handle regular messages
 				msg := `{}`
 				msg, _ = sjson.Set(msg, "type", "message")
 				if role == "system" {
@@ -132,13 +94,10 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 				} else {
 					msg, _ = sjson.Set(msg, "role", role)
 				}
-
 				msg, _ = sjson.SetRaw(msg, "content", `[]`)
 
-				// Handle regular content
 				c := m.Get("content")
 				if c.Exists() && c.Type == gjson.String && c.String() != "" {
-					// Single string content
 					partType := "input_text"
 					if role == "assistant" {
 						partType = "output_text"
@@ -163,7 +122,6 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 							part, _ = sjson.Set(part, "text", it.Get("text").String())
 							msg, _ = sjson.SetRaw(msg, "content.-1", part)
 						case "image_url":
-							// Map image inputs to input_image for Responses API
 							if role == "user" {
 								part := `{}`
 								part, _ = sjson.Set(part, "type", "input_image")
@@ -190,9 +148,8 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 					}
 				}
 
-				out, _ = sjson.SetRaw(out, "input.-1", msg)
+				appendInput(msg)
 
-				// Handle tool calls for assistant messages as separate top-level objects
 				if role == "assistant" {
 					toolCalls := m.Get("tool_calls")
 					if toolCalls.Exists() && toolCalls.IsArray() {
@@ -200,7 +157,6 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 						for j := 0; j < len(toolCallsArr); j++ {
 							tc := toolCallsArr[j]
 							if tc.Get("type").String() == "function" {
-								// Create function_call as top-level object
 								funcCall := `{}`
 								funcCall, _ = sjson.Set(funcCall, "type", "function_call")
 								funcCall, _ = sjson.Set(funcCall, "call_id", tc.Get("id").String())
@@ -214,7 +170,7 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 									funcCall, _ = sjson.Set(funcCall, "name", name)
 								}
 								funcCall, _ = sjson.Set(funcCall, "arguments", tc.Get("function.arguments").String())
-								out, _ = sjson.SetRaw(out, "input.-1", funcCall)
+								appendInput(funcCall)
 							}
 						}
 					}
@@ -222,16 +178,30 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 			}
 		}
 	}
+	inputBuf.WriteByte(']')
+
+	// Small envelope first; heavy input/tools attached once.
+	out := `{"instructions":""}`
+	out, _ = sjson.Set(out, "stream", stream)
+	if v := gjson.GetBytes(rawJSON, "reasoning_effort"); v.Exists() {
+		out, _ = sjson.Set(out, "reasoning.effort", v.Value())
+	} else {
+		out, _ = sjson.Set(out, "reasoning.effort", "medium")
+	}
+	out, _ = sjson.Set(out, "parallel_tool_calls", true)
+	out, _ = sjson.Set(out, "reasoning.summary", "auto")
+	out, _ = sjson.Set(out, "include", []string{"reasoning.encrypted_content"})
+	out, _ = sjson.Set(out, "model", modelName)
+	out, _ = sjson.Set(out, "store", false)
+	out, _ = sjson.SetRaw(out, "input", inputBuf.String())
 
 	// Map response_format and text settings to Responses API text.format
 	rf := gjson.GetBytes(rawJSON, "response_format")
 	text := gjson.GetBytes(rawJSON, "text")
 	if rf.Exists() {
-		// Always create text object when response_format provided
 		if !gjson.Get(out, "text").Exists() {
 			out, _ = sjson.SetRaw(out, "text", `{}`)
 		}
-
 		rft := rf.Get("type").String()
 		switch rft {
 		case "text":
@@ -251,15 +221,12 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 				}
 			}
 		}
-
-		// Map verbosity if provided
 		if text.Exists() {
 			if v := text.Get("verbosity"); v.Exists() {
 				out, _ = sjson.Set(out, "text.verbosity", v.Value())
 			}
 		}
 	} else if text.Exists() {
-		// If only text.verbosity present (no response_format), map verbosity
 		if v := text.Get("verbosity"); v.Exists() {
 			if !gjson.Get(out, "text").Exists() {
 				out, _ = sjson.SetRaw(out, "text", `{}`)
@@ -268,21 +235,30 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 		}
 	}
 
-	// Map tools (flatten function fields)
+	// Map tools (flatten function fields) once.
 	tools := gjson.GetBytes(rawJSON, "tools")
 	if tools.IsArray() && len(tools.Array()) > 0 {
-		out, _ = sjson.SetRaw(out, "tools", `[]`)
+		var toolsBuf bytes.Buffer
+		toolsBuf.WriteByte('[')
+		toolsFirst := true
+		appendTool := func(raw string) {
+			if raw == "" {
+				return
+			}
+			if !toolsFirst {
+				toolsBuf.WriteByte(',')
+			}
+			toolsFirst = false
+			toolsBuf.WriteString(raw)
+		}
 		arr := tools.Array()
 		for i := 0; i < len(arr); i++ {
 			t := arr[i]
 			toolType := t.Get("type").String()
-			// Pass through built-in tools (e.g. {"type":"web_search"}) directly for the Responses API.
-			// Only "function" needs structural conversion because Chat Completions nests details under "function".
 			if toolType != "" && toolType != "function" && t.IsObject() {
-				out, _ = sjson.SetRaw(out, "tools.-1", t.Raw)
+				appendTool(t.Raw)
 				continue
 			}
-
 			if toolType == "function" {
 				item := `{}`
 				item, _ = sjson.Set(item, "type", "function")
@@ -307,14 +283,14 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 						item, _ = sjson.Set(item, "strict", v.Value())
 					}
 				}
-				out, _ = sjson.SetRaw(out, "tools.-1", item)
+				appendTool(item)
 			}
 		}
+		toolsBuf.WriteByte(']')
+		out, _ = sjson.SetRaw(out, "tools", toolsBuf.String())
 	}
 
 	// Map tool_choice when present.
-	// Chat Completions: "tool_choice" can be a string ("auto"/"none") or an object (e.g. {"type":"function","function":{"name":"..."}}).
-	// Responses API: keep built-in tool choices as-is; flatten function choice to {"type":"function","name":"..."}.
 	if tc := gjson.GetBytes(rawJSON, "tool_choice"); tc.Exists() {
 		switch {
 		case tc.Type == gjson.String:
@@ -337,13 +313,11 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 				}
 				out, _ = sjson.SetRaw(out, "tool_choice", choice)
 			} else if tcType != "" {
-				// Built-in tool choices (e.g. {"type":"web_search"}) are already Responses-compatible.
 				out, _ = sjson.SetRaw(out, "tool_choice", tc.Raw)
 			}
 		}
 	}
 
-	out, _ = sjson.Set(out, "store", false)
 	return []byte(out)
 }
 
@@ -356,7 +330,6 @@ func shortenNameIfNeeded(name string) string {
 		return name
 	}
 	if strings.HasPrefix(name, "mcp__") {
-		// Keep prefix and last segment after '__'
 		idx := strings.LastIndex(name, "__")
 		if idx > 0 {
 			candidate := "mcp__" + name[idx+2:]

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -1,9 +1,11 @@
 package responses
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -14,32 +16,36 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 	rawJSON := inputRawJSON
 	rawJSON = normalizeOpenAIResponsesImageRequest(rawJSON)
 
-	inputResult := gjson.GetBytes(rawJSON, "input")
-	if inputResult.Type == gjson.String {
-		input, _ := sjson.Set(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`, "0.content.0.text", inputResult.String())
-		rawJSON, _ = sjson.SetRawBytes(rawJSON, "input", []byte(input))
+	// One-pass top-level mutate: avoid N full-document sjson copies on large bodies.
+	sets := map[string][]byte{
+		"stream":              util.JSONBool(true),
+		"store":               util.JSONBool(false),
+		"parallel_tool_calls": util.JSONBool(true),
+		"include":             []byte(`["reasoning.encrypted_content"]`),
+	}
+	dels := []string{
+		"max_output_tokens",
+		"max_completion_tokens",
+		"temperature",
+		"top_p",
+		"service_tier",
+		"truncation",
+		"user",
+		"context_management",
 	}
 
-	rawJSON, _ = sjson.SetBytes(rawJSON, "stream", true)
-	rawJSON, _ = sjson.SetBytes(rawJSON, "store", false)
-	rawJSON, _ = sjson.SetBytes(rawJSON, "parallel_tool_calls", true)
-	rawJSON, _ = sjson.SetBytes(rawJSON, "include", []string{"reasoning.encrypted_content"})
-	// Codex Responses rejects token limit fields, so strip them out before forwarding.
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "max_output_tokens")
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "max_completion_tokens")
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "temperature")
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "top_p")
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "service_tier")
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "truncation")
-	rawJSON = applyResponsesCompactionCompatibility(rawJSON)
+	inputResult := gjson.GetBytes(rawJSON, "input")
+	switch {
+	case inputResult.Type == gjson.String:
+		input, _ := sjson.Set(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`, "0.content.0.text", inputResult.String())
+		sets["input"] = []byte(input)
+	case inputResult.IsArray():
+		if rewritten, ok := rewriteInputSystemRoles(inputResult); ok {
+			sets["input"] = rewritten
+		}
+	}
 
-	// Delete the user field as it is not supported by the Codex upstream.
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "user")
-
-	// Convert role "system" to "developer" in input array to comply with Codex API requirements.
-	rawJSON = convertSystemRoleToDeveloper(rawJSON)
-
-	return rawJSON
+	return util.MutateTopLevelObject(rawJSON, sets, dels)
 }
 
 func normalizeOpenAIResponsesImageRequest(rawJSON []byte) []byte {
@@ -52,6 +58,7 @@ func normalizeOpenAIResponsesImageRequest(rawJSON []byte) []byte {
 		return rawJSON
 	}
 
+	// Image-tool path is rare and body is usually small; keep sjson here.
 	if toolIndex < 0 {
 		rawJSON, _ = sjson.SetRawBytes(rawJSON, "tools", []byte(`[]`))
 		rawJSON, _ = sjson.SetRawBytes(rawJSON, "tools.-1", []byte(`{"type":"image_generation"}`))
@@ -103,9 +110,9 @@ func normalizeOpenAIResponsesPromptInput(rawJSON []byte) []byte {
 	if prompt == "" {
 		return rawJSON
 	}
-	rawJSON, _ = sjson.SetBytes(rawJSON, "input", prompt)
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "prompt")
-	return rawJSON
+	return util.MutateTopLevelObject(rawJSON, map[string][]byte{
+		"input": util.JSONString(prompt),
+	}, []string{"prompt"})
 }
 
 func firstImageGenerationToolIndex(rawJSON []byte) int {
@@ -125,21 +132,45 @@ func isOpenAIResponsesImageOnlyModel(model string) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "gpt-image-")
 }
 
-// applyResponsesCompactionCompatibility handles OpenAI Responses context_management.compaction
-// for Codex upstream compatibility.
-//
-// Codex /responses currently rejects context_management with:
-// {"detail":"Unsupported parameter: context_management"}.
-//
-// Compatibility strategy:
-// 1) Remove context_management before forwarding to Codex upstream.
-func applyResponsesCompactionCompatibility(rawJSON []byte) []byte {
-	if !gjson.GetBytes(rawJSON, "context_management").Exists() {
-		return rawJSON
+// rewriteInputSystemRoles rebuilds the input array once, converting role "system" -> "developer".
+// Returns ok=false when no change is needed so callers can skip the top-level rewrite.
+func rewriteInputSystemRoles(inputResult gjson.Result) ([]byte, bool) {
+	if !inputResult.IsArray() {
+		return nil, false
+	}
+	arr := inputResult.Array()
+	changed := false
+	for _, item := range arr {
+		if item.Get("role").String() == "system" {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return nil, false
 	}
 
-	rawJSON, _ = sjson.DeleteBytes(rawJSON, "context_management")
-	return rawJSON
+	var b bytes.Buffer
+	b.Grow(len(inputResult.Raw))
+	b.WriteByte('[')
+	for i, item := range arr {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if item.Get("role").String() != "system" {
+			b.WriteString(item.Raw)
+			continue
+		}
+		// Small object: one sjson on the item fragment only (not the whole request body).
+		rewritten, err := sjson.Set(item.Raw, "role", "developer")
+		if err != nil {
+			b.WriteString(item.Raw)
+			continue
+		}
+		b.WriteString(rewritten)
+	}
+	b.WriteByte(']')
+	return b.Bytes(), true
 }
 
 // convertSystemRoleToDeveloper traverses the input array and converts any message items
@@ -147,20 +178,9 @@ func applyResponsesCompactionCompatibility(rawJSON []byte) []byte {
 // accept "system" role in the input array.
 func convertSystemRoleToDeveloper(rawJSON []byte) []byte {
 	inputResult := gjson.GetBytes(rawJSON, "input")
-	if !inputResult.IsArray() {
+	rewritten, ok := rewriteInputSystemRoles(inputResult)
+	if !ok {
 		return rawJSON
 	}
-
-	inputArray := inputResult.Array()
-	result := rawJSON
-
-	// Directly modify role values for items with "system" role
-	for i := 0; i < len(inputArray); i++ {
-		rolePath := fmt.Sprintf("input.%d.role", i)
-		if gjson.GetBytes(result, rolePath).String() == "system" {
-			result, _ = sjson.SetBytes(result, rolePath, "developer")
-		}
-	}
-
-	return result
+	return util.MutateTopLevelObject(rawJSON, map[string][]byte{"input": rewritten}, nil)
 }

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_alloc_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_alloc_test.go
@@ -1,0 +1,52 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConvertOpenAIResponsesRequestToCodex_LargeBodyAllocBound(t *testing.T) {
+	// Multi-MB-ish history: old path did N full sjson copies; new path should stay O(body size).
+	var b strings.Builder
+	b.WriteString(`{"model":"gpt-5.4","stream":false,"user":"u","temperature":0.2,"max_output_tokens":100,"input":[`)
+	// ~2MB of text across messages
+	chunk := strings.Repeat("x", 64*1024)
+	for i := 0; i < 32; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		role := "user"
+		if i == 0 {
+			role = "system"
+		}
+		b.WriteString(`{"type":"message","role":"`)
+		b.WriteString(role)
+		b.WriteString(`","content":[{"type":"input_text","text":"`)
+		b.WriteString(chunk)
+		b.WriteString(`"}]}`)
+	}
+	b.WriteString(`]}`)
+	in := []byte(b.String())
+
+	var totalAlloc uint64
+	const N = 5
+	res := testing.Benchmark(func(bb *testing.B) {
+		bb.ReportAllocs()
+		bb.SetBytes(int64(len(in)))
+		for i := 0; i < bb.N; i++ {
+			out := ConvertOpenAIResponsesRequestToCodex("gpt-5.4", in, true)
+			if len(out) < len(in)/2 {
+				bb.Fatalf("output too small: %d", len(out))
+			}
+		}
+	})
+	// Rough ceiling: more than ~8 full body copies per op is a regression of the old N*sjson path.
+	if res.N > 0 {
+		avg := res.AllocedBytesPerOp()
+		totalAlloc = uint64(avg)
+		if avg > int64(len(in))*8 {
+			t.Fatalf("alloc/op=%d body=%d ratio=%.1f want <=8x body", avg, len(in), float64(avg)/float64(len(in)))
+		}
+	}
+	t.Logf("body=%dB alloc/op=%dN=%d", len(in), totalAlloc, res.N)
+}

--- a/internal/util/json_object.go
+++ b/internal/util/json_object.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/tidwall/gjson"
+)
+
+// MutateTopLevelObject rewrites a JSON object in one pass: apply top-level sets and deletes.
+// values in set must be raw JSON (e.g. true, "x", [1], {...}).
+// Nested paths are not supported; callers should mutate nested fragments first.
+//
+// This avoids N full-document copies from repeated sjson.Set/Delete on large bodies.
+func MutateTopLevelObject(src []byte, set map[string][]byte, del []string) []byte {
+	src = bytes.TrimSpace(src)
+	if len(src) == 0 {
+		src = []byte(`{}`)
+	}
+	root := gjson.ParseBytes(src)
+	if !root.IsObject() {
+		return src
+	}
+
+	delSet := make(map[string]struct{}, len(del))
+	for _, k := range del {
+		if k != "" {
+			delSet[k] = struct{}{}
+		}
+	}
+	pending := make(map[string][]byte, len(set))
+	for k, v := range set {
+		if k == "" {
+			continue
+		}
+		pending[k] = v
+	}
+
+	var b bytes.Buffer
+	b.Grow(len(src) + 256)
+	b.WriteByte('{')
+	first := true
+	writePair := func(key string, raw []byte) {
+		if len(raw) == 0 {
+			raw = []byte("null")
+		}
+		if !first {
+			b.WriteByte(',')
+		}
+		first = false
+		keyJSON, err := json.Marshal(key)
+		if err != nil {
+			return
+		}
+		b.Write(keyJSON)
+		b.WriteByte(':')
+		b.Write(raw)
+	}
+
+	root.ForEach(func(key, value gjson.Result) bool {
+		k := key.String()
+		if _, drop := delSet[k]; drop {
+			delete(pending, k)
+			return true
+		}
+		if raw, ok := pending[k]; ok {
+			writePair(k, raw)
+			delete(pending, k)
+			return true
+		}
+		writePair(k, []byte(value.Raw))
+		return true
+	})
+	for k, raw := range pending {
+		if _, drop := delSet[k]; drop {
+			continue
+		}
+		writePair(k, raw)
+	}
+	b.WriteByte('}')
+	return b.Bytes()
+}
+
+// JSONString returns a JSON string literal for s.
+func JSONString(s string) []byte {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return []byte(`""`)
+	}
+	return b
+}
+
+// JSONBool returns raw JSON true/false.
+func JSONBool(v bool) []byte {
+	if v {
+		return []byte("true")
+	}
+	return []byte("false")
+}

--- a/internal/util/json_object_test.go
+++ b/internal/util/json_object_test.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestMutateTopLevelObject_SetDeletePreserve(t *testing.T) {
+	src := []byte(`{"model":"gpt","input":[{"role":"user"}],"user":"u","temperature":0.2}`)
+	out := MutateTopLevelObject(src, map[string][]byte{
+		"stream":              []byte("true"),
+		"store":               []byte("false"),
+		"parallel_tool_calls": []byte("true"),
+		"include":             []byte(`["reasoning.encrypted_content"]`),
+	}, []string{"user", "temperature", "max_output_tokens"})
+
+	if gjson.GetBytes(out, "model").String() != "gpt" {
+		t.Fatalf("model lost: %s", out)
+	}
+	if !gjson.GetBytes(out, "stream").Bool() {
+		t.Fatalf("stream not set: %s", out)
+	}
+	if gjson.GetBytes(out, "store").Bool() {
+		t.Fatalf("store not false: %s", out)
+	}
+	if gjson.GetBytes(out, "user").Exists() || gjson.GetBytes(out, "temperature").Exists() {
+		t.Fatalf("deleted keys remain: %s", out)
+	}
+	if got := gjson.GetBytes(out, "input.0.role").String(); got != "user" {
+		t.Fatalf("input corrupted: %s", out)
+	}
+	if got := gjson.GetBytes(out, "include.0").String(); got != "reasoning.encrypted_content" {
+		t.Fatalf("include wrong: %s", out)
+	}
+}
+
+func TestMutateTopLevelObject_ReplaceExisting(t *testing.T) {
+	src := []byte(`{"stream":false,"input":[1,2,3]}`)
+	out := MutateTopLevelObject(src, map[string][]byte{
+		"stream": []byte("true"),
+		"input":  []byte(`[{"role":"developer"}]`),
+	}, nil)
+	if !gjson.GetBytes(out, "stream").Bool() {
+		t.Fatalf("stream: %s", out)
+	}
+	if got := gjson.GetBytes(out, "input.0.role").String(); got != "developer" {
+		t.Fatalf("input: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Production pprof: ~81% CPU in `gjson.parseSquash`, ~65% alloc in `sjson.set` under Codex/XAI Responses streaming with multi-MB bodies.
- Root cause: request translators did many full-document `sjson.Set/Delete` copies per request.
- Fix: one-pass top-level JSON mutate (`util.MutateTopLevelObject`), single-pass `input`/`tools` array rebuild, and `gjson` for stream flag instead of full `json.Unmarshal`.

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] Large-body alloc bound test on Responses converter (~2MB, ≤8× body alloc/op)
- [ ] After merge/deploy: re-check process CPU/RSS under same traffic; optional pprof re-sample