### PR TITLE
fix: rebuild Codex history strip without N full-body sjson copies

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -145,16 +145,17 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body = execCtx.ApplyPayloadConfig(body, originalTranslated)
 	body = ensureTranslatedCodexModel(body, execCtx.BaseModel)
 	body = sanitizeCodexResponsesRequest(body)
-	body, _ = sjson.SetBytes(body, "stream", true)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
-	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
-	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	sets := map[string][]byte{"stream": util.JSONBool(true)}
 	if !gjson.GetBytes(body, "instructions").Exists() {
 		// Extract system messages from original OpenAI-format payload to use as instructions.
 		// This preserves system prompts injected by SystemPromptMiddleware.
-		sysContent := extractSystemMessagesAsInstructions(execCtx.Request.Payload)
-		body, _ = sjson.SetBytes(body, "instructions", sysContent)
+		sets["instructions"] = util.JSONString(extractSystemMessagesAsInstructions(execCtx.Request.Payload))
 	}
+	body = util.MutateTopLevelObject(body, sets, []string{
+		"previous_response_id",
+		"prompt_cache_retention",
+		"safety_identifier",
+	})
 	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
@@ -169,7 +170,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	httpResp, err := httpClient.Do(httpReq) //nolint:bodyclose // body is closed by the defer below.
 	if err != nil {
 		recorder.RecordResponseError(err)
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, err.Error())
 		return resp, err
 	}
 	defer func() {
@@ -182,7 +183,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
 		recorder.AppendResponseChunk(b)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, string(b))
 		err = newCodexStatusErr(httpResp.StatusCode, b, httpResp.Header)
 		return resp, err
 	}
@@ -231,7 +232,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		line = imageStream.rewriteAssistantMarkdown(line)
 
 		if detail, ok := parseCodexUsage(line); ok {
-			reporter.publishWithContent(execCtx.Context, detail, string(req.Payload), string(data))
+			reporter.publishWithContentBytes(execCtx.Context, detail, req.Payload, string(data))
 		}
 
 		var param any
@@ -240,7 +241,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		return resp, nil
 	}
 	if streamErr != nil {
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), streamErr.Error())
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, streamErr.Error())
 		return resp, streamErr
 	}
 	err = statusErr{code: 408, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
@@ -289,7 +290,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, err.Error())
 		return resp, err
 	}
 	defer func() {
@@ -302,7 +303,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
 		recorder.AppendResponseChunk(b)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, string(b))
 		err = newCodexStatusErr(httpResp.StatusCode, b, httpResp.Header)
 		return resp, err
 	}
@@ -312,7 +313,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	recorder.AppendResponseChunk(data)
-	reporter.publishWithContent(execCtx.Context, parseOpenAIUsage(data), string(req.Payload), string(data))
+	reporter.publishWithContentBytes(execCtx.Context, parseOpenAIUsage(data), req.Payload, string(data))
 	reporter.ensurePublished(execCtx.Context)
 	var param any
 	out := sdktranslator.TranslateNonStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, execCtx.OriginalPayload, body, data, &param)
@@ -350,14 +351,16 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 
 	body = execCtx.ApplyPayloadConfig(body, originalTranslated)
 	body = sanitizeCodexResponsesRequest(body)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
-	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
-	body, _ = sjson.DeleteBytes(body, "safety_identifier")
-	body = ensureTranslatedCodexModel(body, execCtx.BaseModel)
+	sets := map[string][]byte{}
 	if !gjson.GetBytes(body, "instructions").Exists() {
-		sysContent := extractSystemMessagesAsInstructions(execCtx.Request.Payload)
-		body, _ = sjson.SetBytes(body, "instructions", sysContent)
+		sets["instructions"] = util.JSONString(extractSystemMessagesAsInstructions(execCtx.Request.Payload))
 	}
+	body = util.MutateTopLevelObject(body, sets, []string{
+		"previous_response_id",
+		"prompt_cache_retention",
+		"safety_identifier",
+	})
+	body = ensureTranslatedCodexModel(body, execCtx.BaseModel)
 	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
@@ -373,7 +376,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		recorder.RecordResponseError(err)
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, err.Error())
 		return nil, err
 	}
 	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
@@ -388,12 +391,12 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 		recorder.AppendResponseChunk(data)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(data))
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, string(data))
 		err = newCodexStatusErr(httpResp.StatusCode, data, httpResp.Header)
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
-	reporter.setInputContent(string(req.Payload))
+	reporter.setInputContentBytes(req.Payload)
 	go func() {
 		defer close(out)
 		defer func() {
@@ -488,14 +491,15 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 
 	body = ensureTranslatedCodexModel(body, execCtx.BaseModel)
 	body = sanitizeCodexResponsesRequest(body)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
-	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
-	body, _ = sjson.DeleteBytes(body, "safety_identifier")
-	body, _ = sjson.SetBytes(body, "stream", false)
+	sets := map[string][]byte{"stream": util.JSONBool(false)}
 	if !gjson.GetBytes(body, "instructions").Exists() {
-		sysContent := extractSystemMessagesAsInstructions(execCtx.Request.Payload)
-		body, _ = sjson.SetBytes(body, "instructions", sysContent)
+		sets["instructions"] = util.JSONString(extractSystemMessagesAsInstructions(execCtx.Request.Payload))
 	}
+	body = util.MutateTopLevelObject(body, sets, []string{
+		"previous_response_id",
+		"prompt_cache_retention",
+		"safety_identifier",
+	})
 
 	enc, err := tokenizerForCodexModel(execCtx.BaseModel)
 	if err != nil {

--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -884,6 +885,9 @@ func maybeWrapSSEData(hadSSEPrefix bool, body []byte) []byte {
 //  2. Re-attach at most the last extracted image as a structured input_image on the latest
 //     user turn so the model can re-identify / edit without keeping base64-as-text history
 //  3. All image bytes come from the current request body and die with the request
+//
+// Implementation rebuilds the input array once. Never call sjson.Set/Delete on the full
+// multi-MB body for each history item — that was the production RSS spike path.
 func stripCodexHistoryDataURLImages(body []byte) []byte {
 	if len(body) == 0 {
 		return body
@@ -917,7 +921,9 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 	// Top-level string input (rare for Desktop).
 	if in := gjson.GetBytes(body, "input"); in.Type == gjson.String {
 		if next, ok := replaceCodexDataURLImagesInText(in.String(), nextPlaceholder, remember); ok {
-			body, _ = sjson.SetBytes(body, "input", next)
+			return util.MutateTopLevelObject(body, map[string][]byte{
+				"input": util.JSONString(next),
+			}, nil)
 		}
 		// Cannot attach input_image to string input safely; placeholders only.
 		return body
@@ -927,50 +933,109 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 	if !input.IsArray() {
 		return body
 	}
-	for itemIndex, item := range input.Array() {
+	items := input.Array()
+	rewrittenItems := make([][]byte, len(items))
+	changed := false
+	for itemIndex, item := range items {
 		// Drop base64 from any re-sent image_generation_call history items; remember last.
 		if strings.TrimSpace(item.Get("type").String()) == "image_generation_call" {
 			if result := strings.TrimSpace(item.Get("result").String()); len(result) >= 256 {
 				mime := codexImageMIMEFromFormat(item.Get("output_format").String())
 				remember(fmt.Sprintf("data:%s;base64,%s", mime, result))
-				path := fmt.Sprintf("input.%d.result", itemIndex)
-				body, _ = sjson.DeleteBytes(body, path)
+				// sjson only on the small item fragment.
+				if next, err := sjson.Delete(item.Raw, "result"); err == nil {
+					rewrittenItems[itemIndex] = []byte(next)
+					changed = true
+					continue
+				}
 			}
+			rewrittenItems[itemIndex] = []byte(item.Raw)
 			continue
 		}
 		if !hasDataURL {
+			rewrittenItems[itemIndex] = []byte(item.Raw)
 			continue
 		}
 		// message / content text fields
 		if content := item.Get("content"); content.Type == gjson.String {
 			if next, ok := replaceCodexDataURLImagesInText(content.String(), nextPlaceholder, remember); ok {
-				path := fmt.Sprintf("input.%d.content", itemIndex)
-				body, _ = sjson.SetBytes(body, path, next)
+				if rewritten, err := sjson.Set(item.Raw, "content", next); err == nil {
+					rewrittenItems[itemIndex] = []byte(rewritten)
+					changed = true
+					continue
+				}
 			}
+			rewrittenItems[itemIndex] = []byte(item.Raw)
 			continue
 		}
 		if content := item.Get("content"); content.IsArray() {
-			for partIndex, part := range content.Array() {
+			parts := content.Array()
+			partChanged := false
+			newParts := make([][]byte, len(parts))
+			for partIndex, part := range parts {
 				partType := strings.TrimSpace(part.Get("type").String())
 				// Only rewrite text parts. Do not touch structured input_image (user uploads /
 				// vision) — those are intentional pixels, not Desktop session replay of our
 				// outbound markdown data URLs.
 				if partType != "input_text" && partType != "output_text" && partType != "text" {
+					newParts[partIndex] = []byte(part.Raw)
 					continue
 				}
 				text := part.Get("text").String()
 				if next, ok := replaceCodexDataURLImagesInText(text, nextPlaceholder, remember); ok {
-					path := fmt.Sprintf("input.%d.content.%d.text", itemIndex, partIndex)
-					body, _ = sjson.SetBytes(body, path, next)
+					if rewritten, err := sjson.Set(part.Raw, "text", next); err == nil {
+						newParts[partIndex] = []byte(rewritten)
+						partChanged = true
+						continue
+					}
+				}
+				newParts[partIndex] = []byte(part.Raw)
+			}
+			if partChanged {
+				var contentBuf bytes.Buffer
+				contentBuf.Grow(len(content.Raw))
+				contentBuf.WriteByte('[')
+				for i, p := range newParts {
+					if i > 0 {
+						contentBuf.WriteByte(',')
+					}
+					contentBuf.Write(p)
+				}
+				contentBuf.WriteByte(']')
+				if rewritten, err := sjson.SetRaw(item.Raw, "content", contentBuf.String()); err == nil {
+					rewrittenItems[itemIndex] = []byte(rewritten)
+					changed = true
+					continue
 				}
 			}
 		}
+		rewrittenItems[itemIndex] = []byte(item.Raw)
 	}
+
 	// Re-identify / edit: move last history image into structured input_image (not text tokens).
 	if lastImage != nil {
-		body = attachCodexHistoryImageToLastUser(body, *lastImage)
+		if nextItems, ok := attachCodexHistoryImageToItems(rewrittenItems, *lastImage); ok {
+			rewrittenItems = nextItems
+			changed = true
+		}
 	}
-	return body
+	if !changed {
+		return body
+	}
+
+	var inputBuf bytes.Buffer
+	inputBuf.Grow(len(input.Raw))
+	inputBuf.WriteByte('[')
+	for i, item := range rewrittenItems {
+		if i > 0 {
+			inputBuf.WriteByte(',')
+		}
+		inputBuf.Write(item)
+	}
+	inputBuf.WriteByte(']')
+	return util.MutateTopLevelObject(body, map[string][]byte{
+		"input": inputBuf.Bytes(),
+	}, nil)
 }
 
 func replaceCodexDataURLImagesInText(text string, nextPlaceholder func(alt string) string, remember func(dataURL string)) (string, bool) {
@@ -1031,57 +1096,71 @@ func parseCodexDataURLImage(dataURL string) (codexHistoryImage, bool) {
 	return codexHistoryImage{MIME: mime, Result: payload}, true
 }
 
-// attachCodexHistoryImageToLastUser adds at most one input_image to the latest user message.
-// Image bytes are already in this request; we only restructure them for vision-capable models.
-func attachCodexHistoryImageToLastUser(body []byte, img codexHistoryImage) []byte {
-	input := gjson.GetBytes(body, "input")
-	if !input.IsArray() {
-		return body
-	}
-	items := input.Array()
+// attachCodexHistoryImageToItems adds at most one input_image to the latest user message
+// inside a pre-rewritten input item list. Mutates only that item fragment.
+func attachCodexHistoryImageToItems(items [][]byte, img codexHistoryImage) ([][]byte, bool) {
 	lastUser := -1
 	for i := len(items) - 1; i >= 0; i-- {
-		if strings.TrimSpace(items[i].Get("role").String()) == "user" {
+		if strings.TrimSpace(gjson.GetBytes(items[i], "role").String()) == "user" {
 			lastUser = i
 			break
 		}
 	}
 	if lastUser < 0 {
-		return body
+		return items, false
 	}
-	item := items[lastUser]
+	itemRaw := string(items[lastUser])
+	item := gjson.Parse(itemRaw)
 	// Skip if this user turn already has an input_image (user-uploaded).
 	if content := item.Get("content"); content.IsArray() {
 		for _, part := range content.Array() {
 			if strings.TrimSpace(part.Get("type").String()) == "input_image" {
-				return body
+				return items, false
 			}
 		}
 	}
 	dataURL := fmt.Sprintf("data:%s;base64,%s", img.MIME, img.Result)
-	imagePart := map[string]any{
-		"type":      "input_image",
-		"image_url": dataURL,
+	imagePartJSON, err := sjson.Set(`{"type":"input_image"}`, "image_url", dataURL)
+	if err != nil {
+		return items, false
 	}
 
 	content := item.Get("content")
-	if content.Type == gjson.String {
+	var rewritten string
+	switch {
+	case content.Type == gjson.String:
 		// Promote string content to multipart so we can attach the image.
-		parts := []any{
-			map[string]any{"type": "input_text", "text": content.String()},
-			imagePart,
+		textPart, err := sjson.Set(`{"type":"input_text"}`, "text", content.String())
+		if err != nil {
+			return items, false
 		}
-		path := fmt.Sprintf("input.%d.content", lastUser)
-		body, _ = sjson.SetBytes(body, path, parts)
-		return body
+		var contentBuf bytes.Buffer
+		contentBuf.WriteByte('[')
+		contentBuf.WriteString(textPart)
+		contentBuf.WriteByte(',')
+		contentBuf.WriteString(imagePartJSON)
+		contentBuf.WriteByte(']')
+		rewritten, err = sjson.SetRaw(itemRaw, "content", contentBuf.String())
+		if err != nil {
+			return items, false
+		}
+	case content.IsArray():
+		rewritten, err = sjson.SetRaw(itemRaw, "content.-1", imagePartJSON)
+		if err != nil {
+			return items, false
+		}
+	default:
+		var contentBuf bytes.Buffer
+		contentBuf.WriteByte('[')
+		contentBuf.WriteString(imagePartJSON)
+		contentBuf.WriteByte(']')
+		rewritten, err = sjson.SetRaw(itemRaw, "content", contentBuf.String())
+		if err != nil {
+			return items, false
+		}
 	}
-	if content.IsArray() {
-		path := fmt.Sprintf("input.%d.content.-1", lastUser)
-		body, _ = sjson.SetBytes(body, path, imagePart)
-		return body
-	}
-	// No content yet — create multipart.
-	path := fmt.Sprintf("input.%d.content", lastUser)
-	body, _ = sjson.SetBytes(body, path, []any{imagePart})
-	return body
+	out := make([][]byte, len(items))
+	copy(out, items)
+	out[lastUser] = []byte(rewritten)
+	return out, true
 }

--- a/internal/runtime/executor/codex_image_generation_bridge_alloc_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_alloc_test.go
@@ -1,0 +1,65 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestStripCodexHistoryDataURLImages_LargeBodyAllocBound(t *testing.T) {
+	// Multi-MB assistant history with one huge data URL — old path did N sjson copies of whole body.
+	b64 := strings.Repeat("A", 2*1024*1024) // ~2MB base64
+	var b strings.Builder
+	b.WriteString(`{"model":"gpt-5.4","input":[`)
+	for i := 0; i < 8; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if i == 3 {
+			b.WriteString(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done\n\n![img](data:image/png;base64,`)
+			b.WriteString(b64)
+			b.WriteString(`)"}]}`)
+			continue
+		}
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		b.WriteString(`{"type":"message","role":"`)
+		b.WriteString(role)
+		b.WriteString(`","content":[{"type":"input_text","text":"`)
+		b.WriteString(strings.Repeat("x", 4096))
+		b.WriteString(`"}]}`)
+	}
+	b.WriteString(`]}`)
+	in := []byte(b.String())
+
+	// Correctness once (reattach may keep one structured image; assistant text must be stripped).
+	out := stripCodexHistoryDataURLImages(in)
+	asst := gjson.GetBytes(out, "input.3.content.0.text").String()
+	if strings.Contains(asst, "base64,") {
+		t.Fatalf("assistant text still has base64; len=%d", len(asst))
+	}
+	if !strings.Contains(asst, "cliproxy-image:") {
+		t.Fatalf("placeholder missing: %q", asst)
+	}
+
+	res := testing.Benchmark(func(bb *testing.B) {
+		bb.ReportAllocs()
+		bb.SetBytes(int64(len(in)))
+		for i := 0; i < bb.N; i++ {
+			_ = stripCodexHistoryDataURLImages(in)
+		}
+	})
+	if res.N == 0 {
+		t.Fatal("benchmark did not run")
+	}
+	avg := res.AllocedBytesPerOp()
+	// Rebuild + extract + reattach keep a few body-sized buffers (image lives in lastImage +
+	// structured input_image). Bound is intentionally loose vs old N×full-body sjson copies.
+	if avg > int64(len(in))*20 {
+		t.Fatalf("alloc/op=%d body=%d ratio=%.1f want <=20x", avg, len(in), float64(avg)/float64(len(in)))
+	}
+	t.Logf("body=%dB alloc/op=%d N=%d ratio=%.2f", len(in), avg, res.N, float64(avg)/float64(len(in)))
+}

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -80,13 +80,17 @@ func (r *usageReporter) publish(ctx context.Context, detail coreusage.Detail) {
 }
 
 func (r *usageReporter) publishWithContent(ctx context.Context, detail coreusage.Detail, inputContent, outputContent string) {
+	r.publishWithContentBytes(ctx, detail, []byte(inputContent), outputContent)
+}
+
+func (r *usageReporter) publishWithContentBytes(ctx context.Context, detail coreusage.Detail, inputContent []byte, outputContent string) {
 	if r == nil {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequest(inputContent)
+	r.streamingRequest = isStreamingUsageRequestBytes(inputContent)
 	if r.captureFullContent {
 		r.contentMu.Lock()
-		r.setInputContentLocked(inputContent)
+		r.setInputContentLocked(string(inputContent))
 		r.outputContent = outputContent
 		r.contentMu.Unlock()
 	}
@@ -128,21 +132,31 @@ func (r *usageReporter) setVisionFallbackModel(model string) {
 // setInputContent stores the request payload for inclusion in usage records.
 // Call before starting the streaming goroutine.
 func (r *usageReporter) setInputContent(content string) {
+	r.setInputContentBytes([]byte(content))
+}
+
+// setInputContentBytes is the hot-path form: never force a string(payload) copy when
+// store-content is off and we only need the stream flag.
+func (r *usageReporter) setInputContentBytes(content []byte) {
 	if r == nil {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequest(content)
+	r.streamingRequest = isStreamingUsageRequestBytes(content)
 	if !r.captureFullContent {
 		return
 	}
 	r.contentMu.Lock()
 	defer r.contentMu.Unlock()
-	r.setInputContentLocked(content)
+	r.setInputContentLocked(string(content))
 }
 
 func isStreamingUsageRequest(content string) bool {
+	return isStreamingUsageRequestBytes([]byte(content))
+}
+
+func isStreamingUsageRequestBytes(content []byte) bool {
 	// Only read top-level "stream"; full Unmarshal on multi-MB bodies was a hot alloc path.
-	return gjson.Get(content, "stream").Bool()
+	return gjson.GetBytes(content, "stream").Bool()
 }
 
 // appendOutputChunk accumulates a streaming response line for inclusion in usage records.
@@ -208,16 +222,20 @@ func (r *usageReporter) publishFailure(ctx context.Context) {
 // request payload and the upstream error response body so that the error
 // is visible in the management UI error-detail modal.
 func (r *usageReporter) publishFailureWithContent(ctx context.Context, inputContent, outputContent string) {
+	r.publishFailureWithContentBytes(ctx, []byte(inputContent), outputContent)
+}
+
+func (r *usageReporter) publishFailureWithContentBytes(ctx context.Context, inputContent []byte, outputContent string) {
 	if r == nil {
 		return
 	}
 	if shouldSuppressUsageFailure(nil, outputContent) {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequest(inputContent)
+	r.streamingRequest = isStreamingUsageRequestBytes(inputContent)
 	r.contentMu.Lock()
 	if r.captureFullContent {
-		r.setInputContentLocked(inputContent)
+		r.setInputContentLocked(string(inputContent))
 		r.outputContent = outputContent
 	} else {
 		r.outputContent = internalusage.CompactFailedOutputContent(outputContent)


### PR DESCRIPTION
## Summary
- After #745, live pprof still showed ~200MB inuse under `sanitizeCodexResponsesRequest` → `stripCodexHistoryDataURLImages`.
- Root cause: history hygiene rewrote multi-MB bodies with per-field `sjson.Set/Delete` (full document copies).
- Fix: rebuild `input` once; only `sjson` on small item fragments; top-level swap via `MutateTopLevelObject`.

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] existing strip/sanitize tests + large-body alloc bound
- [ ] after deploy: RSS should no longer climb to ~800MB–1GB on normal Desktop history traffic