### PR TITLE
fix: stop N full-body sjson copies in Claude→Codex translation

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -119,6 +119,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	if opts.Alt == "responses/compact" {
 		return e.executeCompact(ctx, auth, req, opts)
 	}
+	req, opts = maybeStripCodexHistoryDataURLImagesOnRequest(req, opts)
 	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
 		TargetFormat: sdktranslator.FromString("codex"),
 	})
@@ -325,6 +326,9 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
 	}
+	// Shrink multi-MB Desktop history data URLs before translation/sanitize so later
+	// body-level passes never see the full base64 history.
+	req, opts = maybeStripCodexHistoryDataURLImagesOnRequest(req, opts)
 	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
 		TargetFormat:      sdktranslator.FromString("codex"),
 		TranslateAsStream: true,
@@ -553,6 +557,28 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	now := time.Now().Format(time.RFC3339)
 	auth.Metadata["last_refresh"] = now
 	return auth, nil
+}
+
+// maybeStripCodexHistoryDataURLImagesOnRequest shrinks multi-MB Desktop history
+// data:image payloads before translation. Only openai-response payloads carry
+// that history shape; other source formats are left untouched.
+func maybeStripCodexHistoryDataURLImagesOnRequest(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Request, cliproxyexecutor.Options) {
+	if opts.SourceFormat != sdktranslator.FormatOpenAIResponse {
+		return req, opts
+	}
+	if len(req.Payload) == 0 {
+		return req, opts
+	}
+	stripped := stripCodexHistoryDataURLImages(req.Payload)
+	if samePayloadStorage(stripped, req.Payload) {
+		return req, opts
+	}
+	// Keep Payload and OriginalRequest in lockstep when they shared storage.
+	if samePayloadStorage(opts.OriginalRequest, req.Payload) || len(opts.OriginalRequest) == 0 {
+		opts.OriginalRequest = stripped
+	}
+	req.Payload = stripped
+	return req, opts
 }
 
 func (e *CodexExecutor) cacheHelper(ctx context.Context, auth *cliproxyauth.Auth, from sdktranslator.Format, url string, req cliproxyexecutor.Request, rawJSON []byte) (*http.Request, error) {

--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -918,9 +918,10 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 		return fmt.Sprintf("![%s](cliproxy-image:%d)", alt, seq)
 	}
 
-	// Top-level string input (rare for Desktop).
-	if in := gjson.GetBytes(body, "input"); in.Type == gjson.String {
-		if next, ok := replaceCodexDataURLImagesInText(in.String(), nextPlaceholder, remember); ok {
+	// Single GetBytes("input") — gjson copies the matched raw, so never call it twice on multi-MB bodies.
+	input := gjson.GetBytes(body, "input")
+	if input.Type == gjson.String {
+		if next, ok := replaceCodexDataURLImagesInText(input.String(), nextPlaceholder, remember); ok {
 			return util.MutateTopLevelObject(body, map[string][]byte{
 				"input": util.JSONString(next),
 			}, nil)
@@ -928,95 +929,119 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 		// Cannot attach input_image to string input safely; placeholders only.
 		return body
 	}
-
-	input := gjson.GetBytes(body, "input")
 	if !input.IsArray() {
 		return body
 	}
 	items := input.Array()
-	rewrittenItems := make([][]byte, len(items))
+	// Keep original raw strings for unchanged fragments; only allocate rewritten ones.
+	itemRaws := make([]string, len(items))
 	changed := false
+	outLen := 2 // []
 	for itemIndex, item := range items {
+		itemRaws[itemIndex] = item.Raw
 		// Drop base64 from any re-sent image_generation_call history items; remember last.
 		if strings.TrimSpace(item.Get("type").String()) == "image_generation_call" {
-			if result := strings.TrimSpace(item.Get("result").String()); len(result) >= 256 {
-				mime := codexImageMIMEFromFormat(item.Get("output_format").String())
-				remember(fmt.Sprintf("data:%s;base64,%s", mime, result))
-				// sjson only on the small item fragment.
-				if next, err := sjson.Delete(item.Raw, "result"); err == nil {
-					rewrittenItems[itemIndex] = []byte(next)
-					changed = true
-					continue
+			if result := item.Get("result"); result.Exists() {
+				resultStr := strings.TrimSpace(result.String())
+				if len(resultStr) >= 256 {
+					// Only reattach if within soft cap; avoid building a huge data URL otherwise.
+					if len(resultStr) <= 8<<20 {
+						mime := codexImageMIMEFromFormat(item.Get("output_format").String())
+						remember(fmt.Sprintf("data:%s;base64,%s", mime, resultStr))
+					}
+					if next, err := sjson.Delete(item.Raw, "result"); err == nil {
+						itemRaws[itemIndex] = next
+						changed = true
+					}
 				}
 			}
-			rewrittenItems[itemIndex] = []byte(item.Raw)
+			if itemIndex > 0 {
+				outLen++
+			}
+			outLen += len(itemRaws[itemIndex])
 			continue
 		}
 		if !hasDataURL {
-			rewrittenItems[itemIndex] = []byte(item.Raw)
+			if itemIndex > 0 {
+				outLen++
+			}
+			outLen += len(itemRaws[itemIndex])
 			continue
 		}
 		// message / content text fields
 		if content := item.Get("content"); content.Type == gjson.String {
 			if next, ok := replaceCodexDataURLImagesInText(content.String(), nextPlaceholder, remember); ok {
 				if rewritten, err := sjson.Set(item.Raw, "content", next); err == nil {
-					rewrittenItems[itemIndex] = []byte(rewritten)
+					itemRaws[itemIndex] = rewritten
 					changed = true
-					continue
 				}
 			}
-			rewrittenItems[itemIndex] = []byte(item.Raw)
+			if itemIndex > 0 {
+				outLen++
+			}
+			outLen += len(itemRaws[itemIndex])
 			continue
 		}
 		if content := item.Get("content"); content.IsArray() {
 			parts := content.Array()
+			partRaws := make([]string, len(parts))
 			partChanged := false
-			newParts := make([][]byte, len(parts))
+			partOutLen := 2
 			for partIndex, part := range parts {
+				partRaws[partIndex] = part.Raw
 				partType := strings.TrimSpace(part.Get("type").String())
 				// Only rewrite text parts. Do not touch structured input_image (user uploads /
 				// vision) — those are intentional pixels, not Desktop session replay of our
 				// outbound markdown data URLs.
-				if partType != "input_text" && partType != "output_text" && partType != "text" {
-					newParts[partIndex] = []byte(part.Raw)
-					continue
-				}
-				text := part.Get("text").String()
-				if next, ok := replaceCodexDataURLImagesInText(text, nextPlaceholder, remember); ok {
-					if rewritten, err := sjson.Set(part.Raw, "text", next); err == nil {
-						newParts[partIndex] = []byte(rewritten)
-						partChanged = true
-						continue
+				if partType == "input_text" || partType == "output_text" || partType == "text" {
+					text := part.Get("text").String()
+					if next, ok := replaceCodexDataURLImagesInText(text, nextPlaceholder, remember); ok {
+						if rewritten, err := sjson.Set(part.Raw, "text", next); err == nil {
+							partRaws[partIndex] = rewritten
+							partChanged = true
+						}
 					}
 				}
-				newParts[partIndex] = []byte(part.Raw)
+				if partIndex > 0 {
+					partOutLen++
+				}
+				partOutLen += len(partRaws[partIndex])
 			}
 			if partChanged {
 				var contentBuf bytes.Buffer
-				contentBuf.Grow(len(content.Raw))
+				contentBuf.Grow(partOutLen)
 				contentBuf.WriteByte('[')
-				for i, p := range newParts {
+				for i, p := range partRaws {
 					if i > 0 {
 						contentBuf.WriteByte(',')
 					}
-					contentBuf.Write(p)
+					contentBuf.WriteString(p)
 				}
 				contentBuf.WriteByte(']')
 				if rewritten, err := sjson.SetRaw(item.Raw, "content", contentBuf.String()); err == nil {
-					rewrittenItems[itemIndex] = []byte(rewritten)
+					itemRaws[itemIndex] = rewritten
 					changed = true
-					continue
 				}
 			}
 		}
-		rewrittenItems[itemIndex] = []byte(item.Raw)
+		if itemIndex > 0 {
+			outLen++
+		}
+		outLen += len(itemRaws[itemIndex])
 	}
 
 	// Re-identify / edit: move last history image into structured input_image (not text tokens).
 	if lastImage != nil {
-		if nextItems, ok := attachCodexHistoryImageToItems(rewrittenItems, *lastImage); ok {
-			rewrittenItems = nextItems
+		if nextItems, ok := attachCodexHistoryImageToItemRaws(itemRaws, *lastImage); ok {
+			itemRaws = nextItems
 			changed = true
+			outLen = 2
+			for i, raw := range itemRaws {
+				if i > 0 {
+					outLen++
+				}
+				outLen += len(raw)
+			}
 		}
 	}
 	if !changed {
@@ -1024,13 +1049,13 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 	}
 
 	var inputBuf bytes.Buffer
-	inputBuf.Grow(len(input.Raw))
+	inputBuf.Grow(outLen)
 	inputBuf.WriteByte('[')
-	for i, item := range rewrittenItems {
+	for i, raw := range itemRaws {
 		if i > 0 {
 			inputBuf.WriteByte(',')
 		}
-		inputBuf.Write(item)
+		inputBuf.WriteString(raw)
 	}
 	inputBuf.WriteByte(']')
 	return util.MutateTopLevelObject(body, map[string][]byte{
@@ -1096,12 +1121,12 @@ func parseCodexDataURLImage(dataURL string) (codexHistoryImage, bool) {
 	return codexHistoryImage{MIME: mime, Result: payload}, true
 }
 
-// attachCodexHistoryImageToItems adds at most one input_image to the latest user message
+// attachCodexHistoryImageToItemRaws adds at most one input_image to the latest user message
 // inside a pre-rewritten input item list. Mutates only that item fragment.
-func attachCodexHistoryImageToItems(items [][]byte, img codexHistoryImage) ([][]byte, bool) {
+func attachCodexHistoryImageToItemRaws(items []string, img codexHistoryImage) ([]string, bool) {
 	lastUser := -1
 	for i := len(items) - 1; i >= 0; i-- {
-		if strings.TrimSpace(gjson.GetBytes(items[i], "role").String()) == "user" {
+		if strings.TrimSpace(gjson.Get(items[i], "role").String()) == "user" {
 			lastUser = i
 			break
 		}
@@ -1109,7 +1134,7 @@ func attachCodexHistoryImageToItems(items [][]byte, img codexHistoryImage) ([][]
 	if lastUser < 0 {
 		return items, false
 	}
-	itemRaw := string(items[lastUser])
+	itemRaw := items[lastUser]
 	item := gjson.Parse(itemRaw)
 	// Skip if this user turn already has an input_image (user-uploaded).
 	if content := item.Get("content"); content.IsArray() {
@@ -1159,8 +1184,8 @@ func attachCodexHistoryImageToItems(items [][]byte, img codexHistoryImage) ([][]
 			return items, false
 		}
 	}
-	out := make([][]byte, len(items))
+	out := make([]string, len(items))
 	copy(out, items)
-	out[lastUser] = []byte(rewritten)
+	out[lastUser] = rewritten
 	return out, true
 }

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -6,6 +6,8 @@
 package claude
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -35,11 +37,23 @@ import (
 //   - []byte: The transformed request data in internal client format
 func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := inputRawJSON
-
-	template := `{"model":"","instructions":"","input":[]}`
-
 	rootResult := gjson.ParseBytes(rawJSON)
-	template, _ = sjson.Set(template, "model", modelName)
+
+	// Build input/tools once. Never sjson.SetRaw(template, "input.-1") in a loop —
+	// that full-document-copies multi-MB histories on every message (production RSS spike).
+	var inputBuf bytes.Buffer
+	inputBuf.WriteByte('[')
+	inputFirst := true
+	appendInput := func(raw string) {
+		if raw == "" {
+			return
+		}
+		if !inputFirst {
+			inputBuf.WriteByte(',')
+		}
+		inputFirst = false
+		inputBuf.WriteString(raw)
+	}
 
 	// Process system messages and convert them to input content format.
 	systemsResult := rootResult.Get("system")
@@ -51,11 +65,18 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			systemTypeResult := systemResult.Get("type")
 			if systemTypeResult.String() == "text" {
 				message, _ = sjson.Set(message, fmt.Sprintf("content.%d.type", i), "input_text")
-				message, _ = sjson.Set(message, fmt.Sprintf("content.%d.text", i), systemResult.Get("text").String())
+				if textRaw := systemResult.Get("text").Raw; strings.HasPrefix(textRaw, `"`) {
+					message, _ = sjson.SetRaw(message, fmt.Sprintf("content.%d.text", i), textRaw)
+				} else {
+					message, _ = sjson.Set(message, fmt.Sprintf("content.%d.text", i), systemResult.Get("text").String())
+				}
 			}
 		}
-		template, _ = sjson.SetRaw(template, "input.-1", message)
+		appendInput(message)
 	}
+
+	// Build tool short-name map once for tool_use renames (avoid rescanning tools per call).
+	toolNameMap := buildReverseMapFromClaudeOriginalToShort(rawJSON)
 
 	// Process messages and transform their contents to appropriate formats.
 	messagesResult := rootResult.Get("messages")
@@ -66,41 +87,63 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			messageResult := messageResults[i]
 			messageRole := messageResult.Get("role").String()
 
-			newMessage := func() string {
-				msg := `{"type": "message","role":"","content":[]}`
-				msg, _ = sjson.Set(msg, "role", messageRole)
-				return msg
-			}
-
-			message := newMessage()
-			contentIndex := 0
+			var contentBuf bytes.Buffer
+			contentFirst := true
 			hasContent := false
+			appendContentPart := func(part string) {
+				if part == "" {
+					return
+				}
+				if !contentFirst {
+					contentBuf.WriteByte(',')
+				}
+				contentFirst = false
+				contentBuf.WriteString(part)
+				hasContent = true
+			}
 
 			flushMessage := func() {
-				if hasContent {
-					template, _ = sjson.SetRaw(template, "input.-1", message)
-					message = newMessage()
-					contentIndex = 0
-					hasContent = false
+				if !hasContent {
+					return
 				}
+				// Assemble message without sjson on large content text.
+				var msgBuf bytes.Buffer
+				msgBuf.WriteString(`{"type":"message","role":`)
+				msgBuf.Write(mustJSONString(messageRole))
+				msgBuf.WriteString(`,"content":[`)
+				msgBuf.Write(contentBuf.Bytes())
+				msgBuf.WriteString(`]}`)
+				appendInput(msgBuf.String())
+				contentBuf.Reset()
+				contentFirst = true
+				hasContent = false
 			}
 
-			appendTextContent := func(text string) {
+			appendTextContentRaw := func(textRaw string) {
+				// textRaw is gjson .Raw (quoted JSON string) when available — avoids re-escape copy.
 				partType := "input_text"
 				if messageRole == "assistant" {
 					partType = "output_text"
 				}
-				message, _ = sjson.Set(message, fmt.Sprintf("content.%d.type", contentIndex), partType)
-				message, _ = sjson.Set(message, fmt.Sprintf("content.%d.text", contentIndex), text)
-				contentIndex++
-				hasContent = true
+				var part bytes.Buffer
+				part.WriteString(`{"type":"`)
+				part.WriteString(partType)
+				part.WriteString(`","text":`)
+				if strings.HasPrefix(textRaw, `"`) {
+					part.WriteString(textRaw)
+				} else {
+					part.Write(mustJSONString(textRaw))
+				}
+				part.WriteByte('}')
+				appendContentPart(part.String())
 			}
 
 			appendImageContent := func(dataURL string) {
-				message, _ = sjson.Set(message, fmt.Sprintf("content.%d.type", contentIndex), "input_image")
-				message, _ = sjson.Set(message, fmt.Sprintf("content.%d.image_url", contentIndex), dataURL)
-				contentIndex++
-				hasContent = true
+				var part bytes.Buffer
+				part.WriteString(`{"type":"input_image","image_url":`)
+				part.Write(mustJSONString(dataURL))
+				part.WriteByte('}')
+				appendContentPart(part.String())
 			}
 
 			messageContentsResult := messageResult.Get("content")
@@ -112,7 +155,7 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 
 					switch contentType {
 					case "text":
-						appendTextContent(messageContentResult.Get("text").String())
+						appendTextContentRaw(messageContentResult.Get("text").Raw)
 					case "image":
 						sourceResult := messageContentResult.Get("source")
 						if sourceResult.Exists() {
@@ -138,8 +181,7 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 						functionCallMessage, _ = sjson.Set(functionCallMessage, "call_id", messageContentResult.Get("id").String())
 						{
 							name := messageContentResult.Get("name").String()
-							toolMap := buildReverseMapFromClaudeOriginalToShort(rawJSON)
-							if short, ok := toolMap[name]; ok {
+							if short, ok := toolNameMap[name]; ok {
 								name = short
 							} else {
 								name = shortenNameIfNeeded(name)
@@ -147,43 +189,56 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 							functionCallMessage, _ = sjson.Set(functionCallMessage, "name", name)
 						}
 						functionCallMessage, _ = sjson.Set(functionCallMessage, "arguments", messageContentResult.Get("input").Raw)
-						template, _ = sjson.SetRaw(template, "input.-1", functionCallMessage)
+						appendInput(functionCallMessage)
 					case "tool_result":
 						flushMessage()
 						functionCallOutputMessage := `{"type":"function_call_output"}`
 						functionCallOutputMessage, _ = sjson.Set(functionCallOutputMessage, "call_id", messageContentResult.Get("tool_use_id").String())
 						functionCallOutputMessage, _ = sjson.Set(functionCallOutputMessage, "output", messageContentResult.Get("content").String())
-						template, _ = sjson.SetRaw(template, "input.-1", functionCallOutputMessage)
+						appendInput(functionCallOutputMessage)
 					}
 				}
 				flushMessage()
 			} else if messageContentsResult.Type == gjson.String {
-				appendTextContent(messageContentsResult.String())
+				appendTextContentRaw(messageContentsResult.Raw)
 				flushMessage()
 			}
 		}
+	}
+	inputBuf.WriteByte(']')
 
+	// Convert tools declarations once.
+	toolsResult := rootResult.Get("tools")
+	// Codex validates deferred tools strictly: defer_loading requires tools.tool_search.
+	// Claude Code may set defer_loading on tools when tool schemas are deferred.
+	// The Codex endpoint we proxy to rejects defer_loading without tool_search, so strip the flag.
+	if toolsResult.IsArray() && toolsResult.Get("#(defer_loading=true)").Exists() {
+		toolsResult.ForEach(func(i, _ gjson.Result) bool {
+			// sjson only on original rawJSON (small tools array relative to messages).
+			rawJSON, _ = sjson.DeleteBytes(rawJSON, fmt.Sprintf("tools.%d.defer_loading", i.Int()))
+			return true
+		})
+		rootResult = gjson.ParseBytes(rawJSON)
+		toolsResult = rootResult.Get("tools")
 	}
 
-	// Convert tools declarations to the expected format for the Codex API.
-	toolsResult := rootResult.Get("tools")
-	if toolsResult.IsArray() && len(toolsResult.Array()) > 0 {
-		// Codex validates deferred tools strictly: defer_loading requires tools.tool_search.
-		// Claude Code may set defer_loading on tools when tool schemas are deferred.
-		// The Codex endpoint we proxy to rejects defer_loading without tool_search, so strip the flag.
-		if toolsResult.Get("#(defer_loading=true)").Exists() {
-			toolsResult.ForEach(func(i, _ gjson.Result) bool {
-				rawJSON, _ = sjson.DeleteBytes(rawJSON, fmt.Sprintf("tools.%d.defer_loading", i.Int()))
-				return true
-			})
-			rootResult = gjson.ParseBytes(rawJSON)
-			toolsResult = rootResult.Get("tools")
+	var toolsBuf bytes.Buffer
+	toolsFirst := true
+	hasTools := false
+	appendTool := func(raw string) {
+		if raw == "" {
+			return
 		}
-
-		template, _ = sjson.SetRaw(template, "tools", `[]`)
-		template, _ = sjson.Set(template, "tool_choice", `auto`)
+		if !toolsFirst {
+			toolsBuf.WriteByte(',')
+		}
+		toolsFirst = false
+		toolsBuf.WriteString(raw)
+		hasTools = true
+	}
+	if toolsResult.IsArray() && len(toolsResult.Array()) > 0 {
+		toolsBuf.WriteByte('[')
 		toolResults := toolsResult.Array()
-		// Build short name map from declared tools
 		var names []string
 		for i := 0; i < len(toolResults); i++ {
 			n := toolResults[i].Get("name").String()
@@ -196,13 +251,11 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			toolResult := toolResults[i]
 			// Special handling: map Claude web search tool to Codex web_search
 			if toolResult.Get("type").String() == "web_search_20250305" {
-				// Replace the tool content entirely with {"type":"web_search"}
-				template, _ = sjson.SetRaw(template, "tools.-1", `{"type":"web_search"}`)
+				appendTool(`{"type":"web_search"}`)
 				continue
 			}
 			tool := toolResult.Raw
 			tool, _ = sjson.Set(tool, "type", "function")
-			// Apply shortened name if needed
 			if v := toolResult.Get("name"); v.Exists() {
 				name := v.String()
 				if short, ok := shortMap[name]; ok {
@@ -216,12 +269,10 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			tool, _ = sjson.Delete(tool, "input_schema")
 			tool, _ = sjson.Delete(tool, "parameters.$schema")
 			tool, _ = sjson.Set(tool, "strict", false)
-			template, _ = sjson.SetRaw(template, "tools.-1", tool)
+			appendTool(tool)
 		}
+		toolsBuf.WriteByte(']')
 	}
-
-	// Add additional configuration parameters for the Codex API.
-	template, _ = sjson.Set(template, "parallel_tool_calls", true)
 
 	// Convert thinking.budget_tokens to reasoning.effort.
 	reasoningEffort := "medium"
@@ -244,13 +295,23 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			}
 		}
 	}
-	template, _ = sjson.Set(template, "reasoning.effort", reasoningEffort)
-	template, _ = sjson.Set(template, "reasoning.summary", "auto")
-	template, _ = sjson.Set(template, "stream", true)
-	template, _ = sjson.Set(template, "store", false)
-	template, _ = sjson.Set(template, "include", []string{"reasoning.encrypted_content"})
 
-	return []byte(template)
+	// Pure buffer envelope: never sjson.SetRaw the multi-MB input into a growing template.
+	var out bytes.Buffer
+	out.Grow(inputBuf.Len() + toolsBuf.Len() + 512)
+	out.WriteString(`{"model":`)
+	out.Write(mustJSONString(modelName))
+	out.WriteString(`,"instructions":"","input":`)
+	out.Write(inputBuf.Bytes())
+	if hasTools {
+		out.WriteString(`,"tools":`)
+		out.Write(toolsBuf.Bytes())
+		out.WriteString(`,"tool_choice":"auto"`)
+	}
+	out.WriteString(`,"parallel_tool_calls":true,"reasoning":{"effort":`)
+	out.Write(mustJSONString(reasoningEffort))
+	out.WriteString(`,"summary":"auto"},"stream":true,"store":false,"include":["reasoning.encrypted_content"]}`)
+	return out.Bytes()
 }
 
 // shortenNameIfNeeded applies a simple shortening rule for a single name.
@@ -345,6 +406,14 @@ func buildReverseMapFromClaudeOriginalToShort(original []byte) map[string]string
 		m = buildShortNameMap(names)
 	}
 	return m
+}
+
+func mustJSONString(s string) []byte {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return []byte(`""`)
+	}
+	return b
 }
 
 // normalizeToolParameters ensures object schemas contain at least an empty properties map.

--- a/internal/translator/codex/claude/codex_claude_request_alloc_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_alloc_test.go
@@ -1,0 +1,56 @@
+package claude
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertClaudeRequestToCodex_LargeHistoryAllocBound(t *testing.T) {
+	// Multi-MB multi-turn history: old path did sjson.SetRaw(template,"input.-1") per message.
+	var b strings.Builder
+	b.WriteString(`{"model":"claude-sonnet-4-6","messages":[`)
+	chunk := strings.Repeat("x", 64*1024)
+	for i := 0; i < 32; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		b.WriteString(`{"role":"`)
+		b.WriteString(role)
+		b.WriteString(`","content":[{"type":"text","text":"`)
+		b.WriteString(chunk)
+		b.WriteString(`"}]}`)
+	}
+	b.WriteString(`]}`)
+	in := []byte(b.String())
+
+	out := ConvertClaudeRequestToCodex("gpt-5.4", in, true)
+	if got := gjson.GetBytes(out, "input.#").Int(); got < 32 {
+		t.Fatalf("input items = %d, want >=32", got)
+	}
+	if !gjson.GetBytes(out, "stream").Bool() {
+		t.Fatalf("stream not set")
+	}
+
+	res := testing.Benchmark(func(bb *testing.B) {
+		bb.ReportAllocs()
+		bb.SetBytes(int64(len(in)))
+		for i := 0; i < bb.N; i++ {
+			_ = ConvertClaudeRequestToCodex("gpt-5.4", in, true)
+		}
+	})
+	if res.N == 0 {
+		t.Fatal("benchmark did not run")
+	}
+	avg := res.AllocedBytesPerOp()
+	// One pass rebuild (no growing-template SetRaw). Old N×full-body path was far higher.
+	if avg > int64(len(in))*12 {
+		t.Fatalf("alloc/op=%d body=%d ratio=%.1f want <=12x", avg, len(in), float64(avg)/float64(len(in)))
+	}
+	t.Logf("body=%dB alloc/op=%d N=%d ratio=%.2f", len(in), avg, res.N, float64(avg)/float64(len(in)))
+}

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -79,116 +79,190 @@ func (h *BaseAPIHandler) StartStreamWithAuthManager(ctx context.Context, handler
 	chunks := streamResult.Chunks
 	dataChan := make(chan []byte)
 	errChan := make(chan *StreamErrorMessage, 1)
-	go func() {
-		defer close(dataChan)
-		defer close(errChan)
-		sentPayload := false
-		bootstrapRetries := 0
-		maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
-
-		sendErr := func(msg *StreamErrorMessage) bool {
-			if ctx == nil {
-				errChan <- msg
-				return true
-			}
-			select {
-			case <-ctx.Done():
-				return false
-			case errChan <- msg:
-				return true
-			}
-		}
-
-		sendData := func(chunk []byte) bool {
-			if ctx == nil {
-				dataChan <- chunk
-				return true
-			}
-			select {
-			case <-ctx.Done():
-				return false
-			case dataChan <- chunk:
-				return true
-			}
-		}
-
-		bootstrapEligible := func(err error) bool {
-			status := statusFromError(err)
-			if status == 0 {
-				return true
-			}
-			switch status {
-			case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
-				http.StatusRequestTimeout, http.StatusTooManyRequests:
-				return true
-			default:
-				return status >= http.StatusInternalServerError
-			}
-		}
-
-	outer:
-		for {
-			for {
-				var chunk coreexecutor.StreamChunk
-				var ok bool
-				if ctx != nil {
-					select {
-					case <-ctx.Done():
-						return
-					case chunk, ok = <-chunks:
-					}
-				} else {
-					chunk, ok = <-chunks
-				}
-				if !ok {
-					return
-				}
-				if chunk.Err != nil {
-					streamErr := chunk.Err
-					// Safe bootstrap recovery: if the upstream fails before any payload bytes are sent,
-					// retry a few times (to allow auth rotation / transient recovery) and then attempt model fallback.
-					if !sentPayload && bootstrapRetries < maxBootstrapRetries && bootstrapEligible(streamErr) {
-						bootstrapRetries++
-						retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
-						if retryErr == nil {
-							if passthroughHeadersEnabled {
-								replaceHeader(upstreamHeaders, FilterUpstreamHeaders(retryResult.Headers))
-							}
-							chunks = retryResult.Chunks
-							continue outer
-						}
-						streamErr = retryErr
-					}
-
-					status := http.StatusInternalServerError
-					if se, ok := streamErr.(interface{ StatusCode() int }); ok && se != nil {
-						if code := se.StatusCode(); code > 0 {
-							status = code
-						}
-					}
-					var addon http.Header
-					if he, ok := streamErr.(interface{ Headers() http.Header }); ok && he != nil {
-						if hdr := he.Headers(); hdr != nil {
-							addon = hdr.Clone()
-						}
-					}
-					_ = sendErr(&StreamErrorMessage{StatusCode: status, Error: streamErr, Addon: addon})
-					return
-				}
-				if len(chunk.Payload) > 0 {
-					if handlerType == "openai-response" {
-						if err := validateSSEDataJSON(chunk.Payload); err != nil {
-							_ = sendErr(&StreamErrorMessage{StatusCode: http.StatusBadGateway, Error: err})
-							return
-						}
-					}
-					sentPayload = true
-					if okSendData := sendData(cloneBytes(chunk.Payload)); !okSendData {
-						return
-					}
-				}
-			}
-		}
-	}()
+	// Capture retry budget before the goroutine so the no-retry path does not close
+	// over req/opts (those hold multi-MB inbound bodies for the whole SSE lifetime).
+	maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
+	if maxBootstrapRetries <= 0 {
+		go forwardStreamWithoutBootstrapRetry(ctx, handlerType, chunks, dataChan, errChan)
+	} else {
+		go forwardStreamWithBootstrapRetry(
+			ctx,
+			h,
+			handlerType,
+			providers,
+			req,
+			opts,
+			passthroughHeadersEnabled,
+			upstreamHeaders,
+			chunks,
+			dataChan,
+			errChan,
+			maxBootstrapRetries,
+		)
+	}
 	return dataChan, upstreamHeaders, errChan, nil
+}
+
+func forwardStreamWithoutBootstrapRetry(
+	ctx context.Context,
+	handlerType string,
+	chunks <-chan coreexecutor.StreamChunk,
+	dataChan chan<- []byte,
+	errChan chan<- *StreamErrorMessage,
+) {
+	defer close(dataChan)
+	defer close(errChan)
+	for {
+		chunk, ok := recvStreamChunk(ctx, chunks)
+		if !ok {
+			return
+		}
+		if chunk.Err != nil {
+			_ = sendStreamErr(ctx, errChan, streamErrorMessageFromErr(chunk.Err))
+			return
+		}
+		if len(chunk.Payload) == 0 {
+			continue
+		}
+		if handlerType == "openai-response" {
+			if err := validateSSEDataJSON(chunk.Payload); err != nil {
+				_ = sendStreamErr(ctx, errChan, &StreamErrorMessage{StatusCode: http.StatusBadGateway, Error: err})
+				return
+			}
+		}
+		if !sendStreamData(ctx, dataChan, cloneBytes(chunk.Payload)) {
+			return
+		}
+	}
+}
+
+func forwardStreamWithBootstrapRetry(
+	ctx context.Context,
+	h *BaseAPIHandler,
+	handlerType string,
+	providers []string,
+	req coreexecutor.Request,
+	opts coreexecutor.Options,
+	passthroughHeadersEnabled bool,
+	upstreamHeaders http.Header,
+	chunks <-chan coreexecutor.StreamChunk,
+	dataChan chan<- []byte,
+	errChan chan<- *StreamErrorMessage,
+	maxBootstrapRetries int,
+) {
+	defer close(dataChan)
+	defer close(errChan)
+	sentPayload := false
+	bootstrapRetries := 0
+
+outer:
+	for {
+		for {
+			chunk, ok := recvStreamChunk(ctx, chunks)
+			if !ok {
+				return
+			}
+			if chunk.Err != nil {
+				streamErr := chunk.Err
+				// Safe bootstrap recovery: if the upstream fails before any payload bytes are sent,
+				// retry a few times (to allow auth rotation / transient recovery).
+				if !sentPayload && bootstrapRetries < maxBootstrapRetries && bootstrapEligibleStreamErr(streamErr) {
+					bootstrapRetries++
+					retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+					if retryErr == nil {
+						if passthroughHeadersEnabled {
+							replaceHeader(upstreamHeaders, FilterUpstreamHeaders(retryResult.Headers))
+						}
+						chunks = retryResult.Chunks
+						continue outer
+					}
+					streamErr = retryErr
+				}
+				_ = sendStreamErr(ctx, errChan, streamErrorMessageFromErr(streamErr))
+				return
+			}
+			if len(chunk.Payload) == 0 {
+				continue
+			}
+			if handlerType == "openai-response" {
+				if err := validateSSEDataJSON(chunk.Payload); err != nil {
+					_ = sendStreamErr(ctx, errChan, &StreamErrorMessage{StatusCode: http.StatusBadGateway, Error: err})
+					return
+				}
+			}
+			sentPayload = true
+			if !sendStreamData(ctx, dataChan, cloneBytes(chunk.Payload)) {
+				return
+			}
+		}
+	}
+}
+
+func recvStreamChunk(ctx context.Context, chunks <-chan coreexecutor.StreamChunk) (coreexecutor.StreamChunk, bool) {
+	if ctx == nil {
+		chunk, ok := <-chunks
+		return chunk, ok
+	}
+	select {
+	case <-ctx.Done():
+		return coreexecutor.StreamChunk{}, false
+	case chunk, ok := <-chunks:
+		return chunk, ok
+	}
+}
+
+func sendStreamErr(ctx context.Context, errChan chan<- *StreamErrorMessage, msg *StreamErrorMessage) bool {
+	if ctx == nil {
+		errChan <- msg
+		return true
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case errChan <- msg:
+		return true
+	}
+}
+
+func sendStreamData(ctx context.Context, dataChan chan<- []byte, chunk []byte) bool {
+	if ctx == nil {
+		dataChan <- chunk
+		return true
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case dataChan <- chunk:
+		return true
+	}
+}
+
+func bootstrapEligibleStreamErr(err error) bool {
+	status := statusFromError(err)
+	if status == 0 {
+		return true
+	}
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
+		http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true
+	default:
+		return status >= http.StatusInternalServerError
+	}
+}
+
+func streamErrorMessageFromErr(streamErr error) *StreamErrorMessage {
+	status := http.StatusInternalServerError
+	if se, ok := streamErr.(interface{ StatusCode() int }); ok && se != nil {
+		if code := se.StatusCode(); code > 0 {
+			status = code
+		}
+	}
+	var addon http.Header
+	if he, ok := streamErr.(interface{ Headers() http.Header }); ok && he != nil {
+		if hdr := he.Headers(); hdr != nil {
+			addon = hdr.Clone()
+		}
+	}
+	return &StreamErrorMessage{StatusCode: status, Error: streamErr, Addon: addon}
 }


### PR DESCRIPTION
## Summary
- Post-#746 pprof still showed ~134MB inuse in `sjson.appendRawPaths` and high alloc under `ConvertClaudeRequestToCodex`.
- Root cause: Claude→Codex translator repeatedly `sjson.SetRaw(template, "input.-1", …)` on a growing multi-MB document.
- Fix: assemble input/tools once via buffers; pure buffer envelope (no growing-template SetRaw).

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] existing Claude translator tests + large-history alloc bound
- [ ] after deploy: re-sample heap under Claude→Codex Desktop traffic