### PR TITLE
fix(auth-files): make tenant batch deletes durable

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -202,11 +202,16 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 	}
 	if managementauthfiles.IsDeleteAllValue(c.Query("all")) {
 		result, err := service.DeleteAll(ctx)
-		if err != nil {
+		if err != nil && result.Deleted == 0 {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
 		}
-		c.JSON(200, gin.H{"status": "ok", "deleted": result.Deleted})
+		payload := gin.H{"status": "ok", "deleted": result.Deleted}
+		if err != nil {
+			log.WithError(err).Warn("auth files deleted with cleanup warning")
+			payload["warning"] = err.Error()
+		}
+		c.JSON(200, payload)
 		return
 	}
 	name, errValidate := managementauthfiles.ValidateFileQueryName(c.Query("name"), false)
@@ -214,15 +219,21 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		c.JSON(400, gin.H{"error": errValidate.Error()})
 		return
 	}
-	if _, err := service.DeleteOne(ctx, name); err != nil {
-		if errors.Is(err, managementauthfiles.ErrAuthFileNotFound) {
+	result, errDelete := service.DeleteOne(ctx, name)
+	if errDelete != nil && result.Deleted == 0 {
+		if errors.Is(errDelete, managementauthfiles.ErrAuthFileNotFound) {
 			c.JSON(404, gin.H{"error": "file not found"})
 		} else {
-			c.JSON(500, gin.H{"error": err.Error()})
+			c.JSON(500, gin.H{"error": errDelete.Error()})
 		}
 		return
 	}
-	c.JSON(200, gin.H{"status": "ok"})
+	payload := gin.H{"status": "ok", "deleted": result.Deleted}
+	if errDelete != nil {
+		log.WithError(errDelete).Warnf("auth file %s deleted with cleanup warning", name)
+		payload["warning"] = errDelete.Error()
+	}
+	c.JSON(200, payload)
 }
 
 func newAuthFileUploadService(h *Handler, c *gin.Context) managementauthfiles.UploadService {

--- a/internal/management/authfiles/delete.go
+++ b/internal/management/authfiles/delete.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -24,60 +25,92 @@ type DeleteResult struct {
 }
 
 func (s DeleteService) DeleteAll(ctx context.Context) (DeleteResult, error) {
+	names := make(map[string]struct{})
+	if s.Manager != nil {
+		for _, auth := range s.Manager.ListForTenant(NormalizeTenantID(s.TenantID)) {
+			if auth == nil || IsRuntimeOnly(auth) {
+				continue
+			}
+			if name := PublicFileName(auth); name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	}
+
 	authDir := TenantAuthDir(s.AuthDir, s.TenantID)
 	entries, err := os.ReadDir(authDir)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return DeleteResult{}, fmt.Errorf("failed to read auth dir: %w", err)
 	}
-	result := DeleteResult{}
 	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if !IsJSONFileName(name) {
-			continue
-		}
-		full := FilePath(authDir, name)
-		target := FindByNameOrIDForTenant(s.Manager, s.TenantID, name)
-		deletedChannels := DeletedChannelIdentifiers(target)
-		if errRemove := os.Remove(full); errRemove != nil {
-			continue
-		}
-		if errDelete := s.Repository.Delete(ctx, full); errDelete != nil {
-			return result, errDelete
-		}
-		result.Deleted++
-		if target != nil {
-			_, _ = s.Manager.Delete(coreauth.WithSkipPersist(ctx), target.ID)
-		}
-		if errCleanup := s.removeChannelReferences(deletedChannels); errCleanup != nil {
-			return result, errCleanup
+		if !entry.IsDir() && IsJSONFileName(entry.Name()) {
+			names[entry.Name()] = struct{}{}
 		}
 	}
-	return result, nil
+
+	ordered := make([]string, 0, len(names))
+	for name := range names {
+		ordered = append(ordered, name)
+	}
+	sort.Strings(ordered)
+
+	result := DeleteResult{}
+	var cleanupErrors []error
+	for _, name := range ordered {
+		one, errDelete := s.DeleteOne(ctx, name)
+		result.Deleted += one.Deleted
+		if errDelete == nil {
+			continue
+		}
+		if one.Deleted > 0 {
+			cleanupErrors = append(cleanupErrors, errDelete)
+			continue
+		}
+		return result, errDelete
+	}
+	return result, errors.Join(cleanupErrors...)
 }
 
 func (s DeleteService) DeleteOne(ctx context.Context, name string) (DeleteResult, error) {
-	full := ExistingTenantFilePath(s.AuthDir, s.TenantID, name)
+	name, errValidate := ValidateFileQueryName(name, false)
+	if errValidate != nil {
+		return DeleteResult{}, errValidate
+	}
+
 	target := FindByNameOrIDForTenant(s.Manager, s.TenantID, name)
-	deletedChannels := DeletedChannelIdentifiers(target)
-	if err := os.Remove(full); err != nil {
-		if os.IsNotExist(err) {
+	full := ExistingTenantFilePath(s.AuthDir, s.TenantID, name)
+	if target != nil {
+		if path := Attribute(target, "path"); path != "" {
+			full = path
+		}
+	} else if _, errStat := os.Lstat(full); errStat != nil {
+		if os.IsNotExist(errStat) {
 			return DeleteResult{}, ErrAuthFileNotFound
 		}
-		return DeleteResult{}, fmt.Errorf("failed to remove file: %w", err)
+		return DeleteResult{}, fmt.Errorf("failed to inspect auth file: %w", errStat)
 	}
-	if err := s.Repository.Delete(ctx, full); err != nil {
-		return DeleteResult{}, err
+
+	// The store owns durable deletion (Git/PostgreSQL/object storage included).
+	// Removing the mirror first prevents stores such as GitTokenStore from seeing
+	// the deletion and committing it, so local cleanup intentionally happens last.
+	if errDelete := s.Repository.Delete(ctx, full); errDelete != nil {
+		return DeleteResult{}, errDelete
 	}
-	if target != nil {
+	if errRemove := os.Remove(full); errRemove != nil && !os.IsNotExist(errRemove) {
+		return DeleteResult{}, fmt.Errorf("failed to remove local auth file: %w", errRemove)
+	}
+
+	deletedChannels := DeletedChannelIdentifiers(target)
+	if target != nil && s.Manager != nil {
 		_, _ = s.Manager.Delete(coreauth.WithSkipPersist(ctx), target.ID)
 	}
-	if err := s.removeChannelReferences(deletedChannels); err != nil {
-		return DeleteResult{}, err
+	result := DeleteResult{Deleted: 1}
+	if errCleanup := s.removeChannelReferences(deletedChannels); errCleanup != nil {
+		// The credential is already durably deleted. Preserve that outcome so the
+		// caller can remove stale UI state while surfacing the cleanup warning.
+		return result, fmt.Errorf("auth file deleted but channel reference cleanup failed: %w", errCleanup)
 	}
-	return DeleteResult{Deleted: 1}, nil
+	return result, nil
 }
 
 func (s DeleteService) removeChannelReferences(channels []string) error {

--- a/internal/management/authfiles/delete_test.go
+++ b/internal/management/authfiles/delete_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -108,5 +109,79 @@ func TestDeleteServiceDeleteAllSkipsNonJSONAndCountsDeleted(t *testing.T) {
 	}
 	if _, ok := manager.GetByID("a.json"); ok {
 		t.Fatal("a.json still registered")
+	}
+}
+
+func TestDeleteServiceDeleteOneAllowsMissingMirrorForRegisteredAuth(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "stale.json")
+	store := &managerStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "stale.json",
+		FileName: "stale.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": path,
+		},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	result, err := (DeleteService{
+		AuthDir:    authDir,
+		Manager:    manager,
+		Repository: Repository{Store: store, BaseDir: authDir},
+	}).DeleteOne(context.Background(), "stale.json")
+	if err != nil {
+		t.Fatalf("DeleteOne() error = %v", err)
+	}
+	if result.Deleted != 1 {
+		t.Fatalf("Deleted = %d, want 1", result.Deleted)
+	}
+	if _, ok := manager.GetByID("stale.json"); ok {
+		t.Fatal("stale auth still registered")
+	}
+}
+
+func TestDeleteServiceDeleteOnePreservesDeletedResultWhenChannelCleanupFails(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "codex.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	store := &managerStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex.json",
+		FileName: "codex.json",
+		Provider: "codex",
+		Label:    "Team Codex",
+		Metadata: map[string]any{
+			"email": "codex@example.com",
+		},
+		Attributes: map[string]string{
+			"path": path,
+		},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	result, err := (DeleteService{
+		AuthDir:    authDir,
+		Manager:    manager,
+		Repository: Repository{Store: store, BaseDir: authDir},
+		RemoveChannels: func([]string) error {
+			return errors.New("cleanup unavailable")
+		},
+	}).DeleteOne(context.Background(), "codex.json")
+	if err == nil || !strings.Contains(err.Error(), "cleanup unavailable") {
+		t.Fatalf("DeleteOne() error = %v, want cleanup warning", err)
+	}
+	if result.Deleted != 1 {
+		t.Fatalf("Deleted = %d, want 1", result.Deleted)
+	}
+	if _, ok := manager.GetByID("codex.json"); ok {
+		t.Fatal("auth should stay deleted despite cleanup warning")
 	}
 }

--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -56,10 +56,7 @@ func BuildEntry(auth *coreauth.Auth, opts EntryOptions) map[string]any {
 	if path == "" && !runtimeOnly {
 		return nil
 	}
-	name := strings.TrimSpace(auth.FileName)
-	if name == "" {
-		name = auth.ID
-	}
+	name := PublicFileName(auth)
 	entry := map[string]any{
 		"id":             auth.ID,
 		"auth_index":     auth.Index,

--- a/internal/management/authfiles/entry_test.go
+++ b/internal/management/authfiles/entry_test.go
@@ -57,6 +57,29 @@ func TestListEntriesBuildsAndSortsAuthEntries(t *testing.T) {
 	}
 }
 
+func TestBuildEntryUsesTenantLocalPublicName(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "00000000-0000-0000-0000-00000000000a/account.json",
+		TenantID: "00000000-0000-0000-0000-00000000000a",
+		FileName: "00000000-0000-0000-0000-00000000000a/account.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{})
+	if entry == nil {
+		t.Fatal("expected entry")
+	}
+	if got := entry["id"]; got != auth.ID {
+		t.Fatalf("id = %v, want %q", got, auth.ID)
+	}
+	if got := entry["name"]; got != "account.json" {
+		t.Fatalf("name = %v, want account.json", got)
+	}
+}
+
 func TestBuildEntryAllowsRuntimeOnlyAuthWithoutPath(t *testing.T) {
 	auth := &coreauth.Auth{
 		ID:       "runtime",

--- a/internal/management/authfiles/manager.go
+++ b/internal/management/authfiles/manager.go
@@ -8,6 +8,20 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
+// PublicFileName returns the tenant-local filename exposed by management APIs.
+// Auth IDs stay tenant-scoped (for example <tenant-id>/account.json), while
+// mutation endpoints intentionally accept only a single safe filename.
+func PublicFileName(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	name := strings.TrimSpace(auth.FileName)
+	if name == "" {
+		name = strings.TrimSpace(auth.ID)
+	}
+	return singleFileBaseName(name)
+}
+
 func FindByNameOrID(manager *coreauth.Manager, name string) *coreauth.Auth {
 	return FindByNameOrIDForTenant(manager, "", name)
 }


### PR DESCRIPTION
## Summary
- expose tenant-local auth file names instead of leaking storage-prefixed paths to management clients
- make auth file deletion durable across repository-backed storage before cleaning the local mirror
- preserve successful deletion semantics when follow-up channel cleanup returns a warning
- cover tenant-local names, stale manager entries, repository deletion, and partial cleanup outcomes with regression tests

## Root cause
Tenant auth entries exposed the storage-level `<tenant UUID>/<file>` path as `name`, while the delete endpoint intentionally accepts only a single file name and rejects `/`. Batch delete therefore sent an invalid public identifier and received HTTP 400.

## Validation
- `./scripts/ci-pr.sh`
- `go test ./internal/management/authfiles ./internal/api/handlers/management ./internal/api/routes -count=1`

## Scope
- Repository: `CliRelay`
- Target: `dev`