### PR TITLE
feat: share AI account subjects across tenants

### DIFF
--- a/internal/api/handlers/management/ai_account_status.go
+++ b/internal/api/handlers/management/ai_account_status.go
@@ -127,7 +127,7 @@ func (h *Handler) GetAIAccountStatusRefreshJob(c *gin.Context) {
 }
 
 // GetAIAccountStatus returns latest status + lightweight usage summary.
-// Does not scan request_logs; reads ai_account_status + auth_subject_usage_daily.
+// Does not scan request_logs; reads current-tenant bindings and shared subject small tables.
 func (h *Handler) GetAIAccountStatus(c *gin.Context) {
 	svc := h.aiAccountStatusService()
 	if svc == nil {

--- a/internal/api/handlers/management/identity_fingerprint_account.go
+++ b/internal/api/handlers/management/identity_fingerprint_account.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -41,15 +42,19 @@ type identityFingerprintProfileDetail struct {
 }
 
 type identityFingerprintAccountDetail struct {
-	Summary            identityFingerprintAccountSummary        `json:"summary"`
-	Effective          identityfingerprint.EffectiveFingerprint `json:"effective"`
-	Learned            *identityfingerprint.LearnedRecord       `json:"learned,omitempty"`
-	Profiles           []identityFingerprintProfileDetail       `json:"profiles"`
-	Policy             identityfingerprint.AccountPolicy        `json:"policy"`
-	SelectedProfileKey string                                   `json:"selected_profile_key,omitempty"`
-	SelectionReason    string                                   `json:"selection_reason"`
-	Preset             any                                      `json:"preset"`
-	BuiltinDefault     any                                      `json:"builtin_default"`
+	StatusScope               string                                   `json:"status_scope"`
+	SubjectScope              string                                   `json:"subject_scope"`
+	ShareEligible             bool                                     `json:"share_eligible"`
+	CurrentTenantBindingCount int                                      `json:"current_tenant_binding_count"`
+	Summary                   identityFingerprintAccountSummary        `json:"summary"`
+	Effective                 identityfingerprint.EffectiveFingerprint `json:"effective"`
+	Learned                   *identityfingerprint.LearnedRecord       `json:"learned,omitempty"`
+	Profiles                  []identityFingerprintProfileDetail       `json:"profiles"`
+	Policy                    identityfingerprint.AccountPolicy        `json:"policy"`
+	SelectedProfileKey        string                                   `json:"selected_profile_key,omitempty"`
+	SelectionReason           string                                   `json:"selection_reason"`
+	Preset                    any                                      `json:"preset"`
+	BuiltinDefault            any                                      `json:"builtin_default"`
 }
 
 func (h *Handler) GetIdentityFingerprintAccount(c *gin.Context) {
@@ -63,11 +68,17 @@ func (h *Handler) GetIdentityFingerprintAccount(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "account_key is required"})
 		return
 	}
+	identity, bindingCount, ok := h.identityFingerprintScopeForTenant(effectiveTenantID(c), accountKey)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "account subject is not bound to the current tenant"})
+		return
+	}
 	detail, err := h.identityFingerprintAccountDetail(provider, accountKey, strings.TrimSpace(c.Query("auth_subject_id")))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	applyIdentityFingerprintScope(&detail, identity, bindingCount)
 	c.JSON(http.StatusOK, detail)
 }
 
@@ -93,6 +104,11 @@ func (h *Handler) PutIdentityFingerprintAccountPolicy(c *gin.Context) {
 	accountKey := strings.TrimSpace(body.AccountKey)
 	if accountKey == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "account_key is required"})
+		return
+	}
+	identity, bindingCount, bound := h.identityFingerprintScopeForTenant(effectiveTenantID(c), accountKey)
+	if !bound {
+		c.JSON(http.StatusNotFound, gin.H{"error": "account subject is not bound to the current tenant"})
 		return
 	}
 	strategy := identityfingerprint.AccountStrategy(strings.TrimSpace(body.Strategy))
@@ -136,6 +152,8 @@ func (h *Handler) PutIdentityFingerprintAccountPolicy(c *gin.Context) {
 		return
 	}
 	detail.Policy = policy
+	applyIdentityFingerprintScope(&detail, identity, bindingCount)
+	h.recordAIAccountIdentityAudit(c, "ai_account.identity_policy.update", accountKey, provider, policy.ActiveProfileKey, policy.Revision)
 	c.JSON(http.StatusOK, detail)
 }
 
@@ -151,7 +169,12 @@ func (h *Handler) DeleteIdentityFingerprintAccountProfile(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "account_key and profile_key are required"})
 		return
 	}
-	deleted, _, err := usage.DeleteIdentityFingerprintProfileAndRepairPolicy(provider, accountKey, profileKey)
+	identity, bindingCount, bound := h.identityFingerprintScopeForTenant(effectiveTenantID(c), accountKey)
+	if !bound {
+		c.JSON(http.StatusNotFound, gin.H{"error": "account subject is not bound to the current tenant"})
+		return
+	}
+	deleted, policy, err := usage.DeleteIdentityFingerprintProfileAndRepairPolicy(provider, accountKey, profileKey)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -161,7 +184,35 @@ func (h *Handler) DeleteIdentityFingerprintAccountProfile(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	applyIdentityFingerprintScope(&detail, identity, bindingCount)
+	if deleted > 0 {
+		h.recordAIAccountIdentityAudit(c, "ai_account.identity_profile.delete", accountKey, provider, profileKey, policy.Revision)
+	}
 	c.JSON(http.StatusOK, gin.H{"deleted": deleted, "detail": detail})
+}
+
+func (h *Handler) recordAIAccountIdentityAudit(c *gin.Context, action, accountKey string, provider identityfingerprint.Provider, profileKey string, revision int64) {
+	principal, ok := principalFromContext(c)
+	service := h.identity()
+	if !ok || service == nil || c == nil || c.Request == nil {
+		return
+	}
+	service.RecordAudit(c.Request.Context(), identity.AuditEvent{
+		TenantID:       principal.EffectiveTenant.ID,
+		ActorKind:      principal.Kind,
+		ActorUserID:    principal.User.ID,
+		ActorSessionID: principal.SessionID,
+		Action:         action,
+		ResourceType:   "ai_account_subject",
+		ResourceID:     accountKey,
+		Result:         "success",
+		Changes: map[string]any{
+			"provider":       string(provider),
+			"profile_key":    strings.TrimSpace(profileKey),
+			"revision":       revision,
+			"tenant_context": principal.EffectiveTenant.ID,
+		},
+	})
 }
 
 func (h *Handler) enrichAuthFileIdentityFingerprintSummaries(files []map[string]any, auths []*coreauth.Auth) {
@@ -208,6 +259,14 @@ func (h *Handler) identityFingerprintSummaryForAuth(auth *coreauth.Auth) *identi
 	if err != nil {
 		return nil
 	}
+	identity := usage.ResolveAuthSubjectIdentity(auth)
+	count := 1
+	if auth != nil {
+		if counts, err := usage.CountAIAccountTenantBindings(auth.TenantID, []string{accountKey}); err == nil && counts[accountKey] > 0 {
+			count = counts[accountKey]
+		}
+	}
+	applyIdentityFingerprintScope(&detail, identity, count)
 	return &detail.Summary
 }
 
@@ -297,6 +356,70 @@ func (h *Handler) identityFingerprintAccountDetail(provider identityfingerprint.
 		Preset:          preset,
 		BuiltinDefault:  builtinDefault,
 	}, nil
+}
+
+func (h *Handler) identityFingerprintScopeForTenant(tenantID, accountKey string) (*usage.AuthSubjectIdentity, int, bool) {
+	if h == nil || h.authManager == nil {
+		return nil, 0, false
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	accountKey = strings.TrimSpace(accountKey)
+	matchedAuths := make([]*coreauth.Auth, 0)
+	authIDs := make([]string, 0)
+	var matched *usage.AuthSubjectIdentity
+	for _, auth := range h.authManager.ListForTenant(tenantID) {
+		identity := usage.ResolveAuthSubjectIdentity(auth)
+		if identity == nil || identity.ID != accountKey {
+			continue
+		}
+		matched = identity
+		matchedAuths = append(matchedAuths, auth)
+		if authID := strings.TrimSpace(auth.ID); authID != "" {
+			authIDs = append(authIDs, authID)
+		}
+	}
+	if matched == nil || len(matchedAuths) == 0 {
+		return nil, 0, false
+	}
+
+	rows, err := usage.ListAIAccountBindingsForTenantAuths(tenantID, authIDs)
+	if err != nil {
+		return nil, 0, false
+	}
+	byAuthID := make(map[string]usage.AIAccountTenantBinding, len(rows))
+	for _, row := range rows {
+		byAuthID[row.AuthID] = row
+	}
+	count := 0
+	for _, auth := range matchedAuths {
+		identity := usage.ResolveAuthSubjectIdentity(auth)
+		if identity == nil {
+			continue
+		}
+		row, exists := byAuthID[auth.ID]
+		bindingCurrent := exists && row.BindingState == "active" &&
+			row.AuthSubjectID == identity.ID && row.AuthIndex == auth.EnsureIndex() &&
+			row.BindingSeedHash == identity.SeedHash
+		if !bindingCurrent {
+			// Management reads may repair a missing/stale lifecycle binding, but a
+			// healthy binding remains read-only and never becomes a per-request UPSERT.
+			if err := usage.UpsertAIAccountTenantBinding(auth, identity); err != nil {
+				return nil, 0, false
+			}
+		}
+		count++
+	}
+	return matched, count, count > 0
+}
+
+func applyIdentityFingerprintScope(detail *identityFingerprintAccountDetail, identity *usage.AuthSubjectIdentity, bindingCount int) {
+	if detail == nil || identity == nil {
+		return
+	}
+	detail.StatusScope = usage.AIAccountStatusScopeShared
+	detail.SubjectScope = identity.SubjectScope
+	detail.ShareEligible = identity.ShareEligible
+	detail.CurrentTenantBindingCount = bindingCount
 }
 
 func (h *Handler) currentIdentityFingerprintConfig() config.IdentityFingerprintConfig {

--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	identitypkg "github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -225,7 +226,7 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 	}
 	t.Cleanup(usage.CloseDB)
 
-	accountKey := "authsub_codex_test"
+	manager, accountKey := registerIdentityFingerprintTestAuth(t, "codex", "codex-test-account")
 	if err := usage.UpsertIdentityFingerprint(&identityfingerprint.LearnedRecord{
 		Provider:      identityfingerprint.ProviderCodex,
 		AccountKey:    accountKey,
@@ -249,7 +250,7 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 		t.Fatalf("UpsertIdentityFingerprint: %v", err)
 	}
 
-	h := &Handler{cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
+	h := &Handler{authManager: manager, cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
 		Codex: config.CodexIdentityFingerprintConfig{
 			Enabled:       true,
 			UserAgent:     "codex-tui/0.118.0 (Mac OS 26.3.1; arm64)",
@@ -323,12 +324,13 @@ func TestGetIdentityFingerprintAccountReturnsXAIBuiltinDefaultFields(t *testing.
 	}
 	t.Cleanup(usage.CloseDB)
 
-	h := &Handler{cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
+	manager, accountKey := registerIdentityFingerprintTestAuth(t, "xai", "xai-test-account")
+	h := &Handler{authManager: manager, cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
 		XAI: config.XAIIdentityFingerprintConfig{Enabled: true},
 	}}}
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodGet, "/identity-fingerprint/account?provider=xai&account_key=authsub_xai_test", nil)
+	c.Request = httptest.NewRequest(http.MethodGet, "/identity-fingerprint/account?provider=xai&account_key="+accountKey, nil)
 
 	h.GetIdentityFingerprintAccount(c)
 
@@ -441,6 +443,25 @@ func TestBuildIdentityFingerprintSummaryUsesClaudeLearnedCLIVersion(t *testing.T
 	}
 }
 
+func registerIdentityFingerprintTestAuth(t *testing.T, provider, accountID string) (*coreauth.Manager, string) {
+	t.Helper()
+	manager := coreauth.NewManager(nil, nil, nil)
+	registered, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       provider + "-" + accountID,
+		TenantID: identitypkg.SystemTenantID,
+		Provider: provider,
+		Metadata: map[string]any{"account_id": accountID},
+	})
+	if err != nil {
+		t.Fatalf("Register identity fingerprint auth: %v", err)
+	}
+	resolved := usage.ResolveAuthSubjectIdentity(registered)
+	if resolved == nil || resolved.ID == "" {
+		t.Fatal("registered auth did not resolve an account subject")
+	}
+	return manager, resolved.ID
+}
+
 func writeTestAuthFile(path string) error {
 	return os.WriteFile(path, []byte(`{"type":"claude"}`), 0o600)
 }
@@ -452,7 +473,7 @@ func TestCodexIdentityFingerprintAccountProfilesAndPolicy(t *testing.T) {
 	}
 	t.Cleanup(usage.CloseDB)
 
-	accountKey := "codex-account-profiles"
+	manager, accountKey := registerIdentityFingerprintTestAuth(t, "codex", "codex-profile-account")
 	now := time.Now().UTC()
 	for _, record := range []*identityfingerprint.LearnedRecord{
 		{
@@ -492,7 +513,7 @@ func TestCodexIdentityFingerprintAccountProfilesAndPolicy(t *testing.T) {
 		}
 	}
 
-	h := &Handler{cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
+	h := &Handler{authManager: manager, cfg: &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
 		Codex: config.CodexIdentityFingerprintConfig{
 			Enabled:      true,
 			UserAgent:    "Codex Desktop/global-preset",
@@ -541,5 +562,37 @@ func TestCodexIdentityFingerprintAccountProfilesAndPolicy(t *testing.T) {
 	}
 	if got := detail.Effective.Fields[identityfingerprint.FieldUserAgent].Value; got != "Codex Desktop/0.144.0-alpha.4" {
 		t.Fatalf("active Desktop User-Agent = %q", got)
+	}
+}
+
+func TestIdentityFingerprintScopeDoesNotRewriteCurrentBinding(t *testing.T) {
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	manager, accountKey := registerIdentityFingerprintTestAuth(t, "codex", "binding-idempotent")
+	h := &Handler{authManager: manager}
+	identity, count, ok := h.identityFingerprintScopeForTenant(identitypkg.SystemTenantID, accountKey)
+	if !ok || identity == nil || count != 1 {
+		t.Fatalf("initial scope identity=%+v count=%d ok=%v", identity, count, ok)
+	}
+	authID := "codex-binding-idempotent"
+	before, err := usage.ListAIAccountBindingsForTenantAuths(identitypkg.SystemTenantID, []string{authID})
+	if err != nil || len(before) != 1 {
+		t.Fatalf("initial binding rows=%+v err=%v", before, err)
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	identity, count, ok = h.identityFingerprintScopeForTenant(identitypkg.SystemTenantID, accountKey)
+	if !ok || identity == nil || count != 1 {
+		t.Fatalf("second scope identity=%+v count=%d ok=%v", identity, count, ok)
+	}
+	after, err := usage.ListAIAccountBindingsForTenantAuths(identitypkg.SystemTenantID, []string{authID})
+	if err != nil || len(after) != 1 {
+		t.Fatalf("second binding rows=%+v err=%v", after, err)
+	}
+	if !after[0].LastSeenAt.Equal(before[0].LastSeenAt) {
+		t.Fatalf("current binding was rewritten: before=%s after=%s", before[0].LastSeenAt, after[0].LastSeenAt)
 	}
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -44,6 +44,7 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 	builder := cliproxy.NewBuilder().
 		WithConfig(cfg).
 		WithConfigPath(configPath).
+		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
 		WithLocalManagementPassword(localPassword)
 
 	ctxSignal, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -86,6 +87,7 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 	builder := cliproxy.NewBuilder().
 		WithConfig(cfg).
 		WithConfigPath(configPath).
+		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
 		WithLocalManagementPassword(localPassword)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -145,6 +147,9 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 	// Metadata cleanup is gated on this marker so detail retention cannot run first.
 	if err := usage.RunUsageRollupBackfillAtInit(); err != nil {
 		return fmt.Errorf("usage rollup backfill: %w", err)
+	}
+	if _, err := usage.RunAIAccountSharedSubjectBackfillAtInit(); err != nil {
+		return fmt.Errorf("ai account shared subject backfill: %w", err)
 	}
 	// Old blue-green slot may keep writing request_logs without rollup until drain.
 	// Catch-up absolute rebuilds after drain so those rows are not permanently missing.

--- a/internal/management/aiaccountstatus/probe.go
+++ b/internal/management/aiaccountstatus/probe.go
@@ -21,6 +21,9 @@ import (
 // ProbeResult is the typed output of a provider-specific upstream status probe.
 type ProbeResult struct {
 	PlanType               string
+	SubscriptionStartedAt  *time.Time
+	SubscriptionExpiresAt  *time.Time
+	SubscriptionSource     string
 	Quotas                 []usage.QuotaWindowDTO
 	ResetCreditCount       *int64
 	ResetCreditExpirations []string

--- a/internal/management/aiaccountstatus/provider_asserted_subscription.go
+++ b/internal/management/aiaccountstatus/provider_asserted_subscription.go
@@ -1,0 +1,127 @@
+package aiaccountstatus
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type providerAssertedAccountFacts struct {
+	PlanType            string
+	SubscriptionStarted *time.Time
+	SubscriptionExpires *time.Time
+	SubscriptionSource  string
+}
+
+// readProviderAssertedAccountFacts only consumes provider token claims. Auth-file
+// subscription fields are tenant-private manual overrides and must never enter
+// the shared subject status table. Stored OAuth tokens were obtained through the
+// provider authentication flow; this helper only decodes their already-issued
+// claims and never persists token material.
+func readProviderAssertedAccountFacts(auth *coreauth.Auth) providerAssertedAccountFacts {
+	if auth == nil || normalizeProvider(auth.Provider) != "codex" {
+		return providerAssertedAccountFacts{}
+	}
+	identity := usage.ResolveAuthSubjectIdentity(auth)
+	if identity == nil || !identity.ShareEligible || strings.TrimSpace(identity.AccountID) == "" {
+		return providerAssertedAccountFacts{}
+	}
+	for _, token := range []string{
+		metadataString(auth, "id_token", "idToken"),
+		metadataString(auth, "access_token", "accessToken"),
+	} {
+		claims, ok := decodeProviderJWTClaims(token)
+		if !ok {
+			continue
+		}
+		authClaims, _ := claims["https://api.openai.com/auth"].(map[string]any)
+		if len(authClaims) == 0 {
+			continue
+		}
+		accountID := strings.TrimSpace(readClaimString(authClaims, "chatgpt_account_id", "account_id"))
+		if accountID == "" || accountID != strings.TrimSpace(identity.AccountID) {
+			continue
+		}
+		facts := providerAssertedAccountFacts{
+			PlanType: strings.ToLower(strings.TrimSpace(readClaimString(authClaims, "chatgpt_plan_type", "plan_type"))),
+		}
+		facts.SubscriptionStarted = parseProviderClaimTime(authClaims["chatgpt_subscription_active_start"])
+		facts.SubscriptionExpires = parseProviderClaimTime(authClaims["chatgpt_subscription_active_until"])
+		if facts.SubscriptionStarted != nil || facts.SubscriptionExpires != nil {
+			facts.SubscriptionSource = "signed_claims"
+		}
+		return facts
+	}
+	return providerAssertedAccountFacts{}
+}
+
+func decodeProviderJWTClaims(token string) (map[string]any, bool) {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) != 3 {
+		return nil, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+	}
+	if err != nil {
+		return nil, false
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, false
+	}
+	return claims, true
+}
+
+func readClaimString(claims map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := claims[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func parseProviderClaimTime(value any) *time.Time {
+	var parsed time.Time
+	switch v := value.(type) {
+	case string:
+		text := strings.TrimSpace(v)
+		if text == "" {
+			return nil
+		}
+		if unix, err := strconv.ParseInt(text, 10, 64); err == nil && unix > 0 {
+			parsed = time.Unix(unix, 0).UTC()
+		} else if t, err := time.Parse(time.RFC3339Nano, text); err == nil {
+			parsed = t.UTC()
+		} else if t, err := time.Parse(time.RFC3339, text); err == nil {
+			parsed = t.UTC()
+		}
+	case float64:
+		if v > 0 {
+			parsed = time.Unix(int64(v), 0).UTC()
+		}
+	case json.Number:
+		if unix, err := v.Int64(); err == nil && unix > 0 {
+			parsed = time.Unix(unix, 0).UTC()
+		}
+	case int64:
+		if v > 0 {
+			parsed = time.Unix(v, 0).UTC()
+		}
+	case int:
+		if v > 0 {
+			parsed = time.Unix(int64(v), 0).UTC()
+		}
+	}
+	if parsed.IsZero() {
+		return nil
+	}
+	return &parsed
+}

--- a/internal/management/aiaccountstatus/provider_asserted_subscription_test.go
+++ b/internal/management/aiaccountstatus/provider_asserted_subscription_test.go
@@ -1,0 +1,91 @@
+package aiaccountstatus
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func makeProviderJWTForTest(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return "e30." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+func TestRefreshPersistsOnlyProviderAssertedSubscription(t *testing.T) {
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { usage.CloseDB(); _ = os.Remove(usage.GetDBPath()) })
+
+	started := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	expires := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	token := makeProviderJWTForTest(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id":                "acct-asserted",
+			"chatgpt_plan_type":                 "PLUS",
+			"chatgpt_subscription_active_start": started.Format(time.RFC3339),
+			"chatgpt_subscription_active_until": expires.Unix(),
+		},
+	})
+	auth := &coreauth.Auth{
+		ID: "asserted-auth", TenantID: "tenant-asserted", Provider: "codex", FileName: "asserted.json",
+		Metadata: map[string]any{
+			"account_id":              "acct-asserted",
+			"id_token":                token,
+			"subscription_started_at": "2099-01-01T00:00:00Z", // tenant-private manual override; ignored here
+			"subscription_expires_at": "2099-02-01T00:00:00Z",
+		},
+	}
+	manager := newTestManager(t, "tenant-asserted", auth)
+	svc := New(&config.Config{}, manager, func(tenantID string) *managementapitools.Service {
+		return managementapitools.NewForTenant(tenantID, &config.Config{}, manager, managementapitools.Dependencies{})
+	}, nil)
+	svc.SetProbeFunc(func(context.Context, *managementapitools.Service, *config.Config, *coreauth.Auth) (ProbeResult, error) {
+		return ProbeResult{Quotas: []usage.QuotaWindowDTO{}}, nil
+	})
+
+	accepted := svc.StartRefresh("tenant-asserted", RefreshRequest{Force: true})
+	if accepted.Accepted != 1 {
+		t.Fatalf("accepted=%+v", accepted)
+	}
+	waitJob(t, svc, "tenant-asserted", accepted.JobID)
+	response, err := svc.ListStatus("tenant-asserted", nil, nil)
+	if err != nil || len(response.Items) != 1 {
+		t.Fatalf("response=%+v err=%v", response, err)
+	}
+	item := response.Items[0]
+	if item.PlanType != "plus" || item.SubscriptionSource != "signed_claims" {
+		t.Fatalf("shared asserted fields=%+v", item)
+	}
+	if item.SubscriptionStartedAt == nil || !item.SubscriptionStartedAt.Equal(started) || item.SubscriptionExpiresAt == nil || !item.SubscriptionExpiresAt.Equal(expires) {
+		t.Fatalf("subscription start=%v expires=%v", item.SubscriptionStartedAt, item.SubscriptionExpiresAt)
+	}
+}
+
+func TestProviderClaimsMustMatchStableAccountID(t *testing.T) {
+	token := makeProviderJWTForTest(t, map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id":                "different-account",
+			"chatgpt_plan_type":                 "plus",
+			"chatgpt_subscription_active_until": "2026-08-01T00:00:00Z",
+		},
+	})
+	auth := &coreauth.Auth{Provider: "codex", TenantID: "tenant-a", Metadata: map[string]any{"account_id": "expected-account", "id_token": token}}
+	facts := readProviderAssertedAccountFacts(auth)
+	if facts.PlanType != "" || facts.SubscriptionStarted != nil || facts.SubscriptionExpires != nil || facts.SubscriptionSource != "" {
+		t.Fatalf("mismatched claims were trusted: %+v", facts)
+	}
+}

--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -49,8 +49,8 @@ type Service struct {
 
 	mu            sync.Mutex
 	jobs          map[string]*job
-	inFlight      map[string]string    // tenant|subject -> jobID owning the flight
-	lastSuccess   map[string]time.Time // tenant|subject -> last successful probe (closes force=false TOCTOU)
+	inFlight      map[string]string    // shared subject -> owning job ID (job visibility stays tenant-private)
+	lastSuccess   map[string]time.Time // shared subject -> last successful probe (closes force=false TOCTOU)
 	staleNormMu   sync.Mutex
 	lastStaleNorm map[string]time.Time
 }
@@ -128,6 +128,9 @@ func (s *Service) StartRefresh(tenantID string, req RefreshRequest) RefreshAccep
 	// Refresh boundary: allow stale cleanup without waiting for GET throttle alone.
 	s.maybeNormalizeStaleRefresh(tenantID)
 	auths := s.listAuths(tenantID)
+	if err := reconcileTenantBindings(auths); err != nil {
+		return RefreshAccepted{Skipped: []string{"binding_reconciliation_failed"}}
+	}
 	byIndex := make(map[string]*coreauth.Auth, len(auths))
 	bySubject := make(map[string]*coreauth.Auth, len(auths))
 	for _, auth := range auths {
@@ -177,10 +180,10 @@ func (s *Service) StartRefresh(tenantID string, req RefreshRequest) RefreshAccep
 	// by N small-table queries under the service lock.
 	recentBySubject := map[string]time.Time{}
 	if !req.Force && len(subjectIDs) > 0 {
-		if rows, err := usage.ListAIAccountStatusForTenant(tenantID, subjectIDs); err == nil {
+		if rows, err := usage.ListAIAccountSubjectStatus(subjectIDs); err == nil {
 			nowCheck := time.Now()
 			for _, rec := range rows {
-				if rec.RefreshState != string(RefreshSuccess) || rec.UpstreamCheckedAt == nil {
+				if rec.LastProbeState != string(RefreshSuccess) || rec.UpstreamCheckedAt == nil {
 					continue
 				}
 				if nowCheck.Sub(*rec.UpstreamCheckedAt) < accountRefreshMinGap {
@@ -229,14 +232,14 @@ func (s *Service) StartRefresh(tenantID string, req RefreshRequest) RefreshAccep
 		}
 
 		// force never bypasses in-flight singleflight/dedupe.
-		if existingJob, busy := s.inFlight[key]; busy {
+		if _, busy := s.inFlight[key]; busy {
 			deduped++
 			j.Results[subjectID] = &AccountRefreshResult{
 				AuthIndex:     auth.Index,
 				AuthSubjectID: subjectID,
 				State:         RefreshError,
 				ErrorCode:     "deduplicated",
-				ErrorMessage:  "refresh already in progress for job " + existingJob,
+				ErrorMessage:  "shared refresh already in progress",
 				UpdatedAt:     now,
 			}
 			j.order = append(j.order, subjectID)
@@ -459,7 +462,17 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 	}
 
 	checked := time.Now().UTC()
+	if probeErr == nil {
+		asserted := readProviderAssertedAccountFacts(auth)
+		if strings.TrimSpace(probe.PlanType) == "" {
+			probe.PlanType = asserted.PlanType
+		}
+		probe.SubscriptionStartedAt = asserted.SubscriptionStarted
+		probe.SubscriptionExpiresAt = asserted.SubscriptionExpires
+		probe.SubscriptionSource = asserted.SubscriptionSource
+	}
 	if probeErr != nil {
+		_ = usage.UpdateAIAccountSubjectProbeFailure(subjectID, auth.Provider, "probe_failed", probeErr.Error(), checked)
 		_ = usage.UpdateAIAccountRefreshFailure(
 			tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status),
 			"probe_failed", probeErr.Error(), checked,
@@ -474,6 +487,7 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 	}
 
 	if probe.Unsupported {
+		_ = usage.UpdateAIAccountSubjectProbeFailure(subjectID, auth.Provider, "unsupported_probe", probe.UnsupportedReason, checked)
 		_ = usage.UpdateAIAccountRefreshFailure(
 			tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status),
 			"unsupported_probe", probe.UnsupportedReason, checked,
@@ -488,8 +502,8 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 	}
 
 	healthStatus := strings.TrimSpace(probe.Health)
-	if healthStatus == "" || healthStatus == "ok" {
-		healthStatus = string(auth.Status)
+	if healthStatus == "" {
+		healthStatus = "ok"
 	}
 	record := usage.AIAccountStatusRecord{
 		TenantID:               tenantID,
@@ -498,11 +512,12 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		Provider:               auth.Provider,
 		RefreshState:           string(RefreshSuccess),
 		HealthStatus:           healthStatus,
-		PlanType:               firstNonEmpty(probe.PlanType, metadataString(auth, "plan_type", "planType")),
+		PlanType:               strings.TrimSpace(probe.PlanType),
 		Quotas:                 probe.Quotas,
 		ResetCreditCount:       probe.ResetCreditCount,
 		ResetCreditExpirations: probe.ResetCreditExpirations,
 		UpstreamCheckedAt:      &checked,
+		ExpiresAt:              probe.SubscriptionExpiresAt,
 		UpdatedAt:              checked,
 	}
 	if len(probe.Quotas) > 0 {
@@ -526,6 +541,16 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		}
 		_ = usage.RecordDailyQuotaSnapshotIdentityForTenant(tenantID, auth.Index, subjectID, auth.Provider, daily)
 		_ = usage.RecordQuotaSnapshotPointsIdentityForTenant(tenantID, auth.Index, subjectID, auth.Provider, points)
+		if err := usage.RecordAIAccountSubjectQuotaPoints(subjectID, auth.Provider, points); err != nil {
+			_ = usage.UpdateAIAccountSubjectProbeFailure(subjectID, auth.Provider, "persist_failed", err.Error(), checked)
+			s.setResult(jobID, subjectID, func(r *AccountRefreshResult) {
+				r.State = RefreshError
+				r.ErrorCode = "persist_failed"
+				r.ErrorMessage = sanitizeMsg(err.Error())
+				r.UpdatedAt = checked
+			})
+			return
+		}
 	}
 
 	// Latest-status persistence is the trust boundary: write failure must not be reported as success.
@@ -547,8 +572,42 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		})
 		return
 	}
+	legacyPersisted, err := s.loadLegacyPersistedStatus(tenantID, subjectID)
+	if err != nil || legacyPersisted == nil {
+		msg := "persisted status reload failed"
+		if err != nil {
+			msg = err.Error()
+		}
+		_ = usage.UpdateAIAccountRefreshFailure(tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status), "persist_reload_failed", msg, checked)
+		s.setResult(jobID, subjectID, func(r *AccountRefreshResult) {
+			r.State = RefreshError
+			r.ErrorCode = "persist_reload_failed"
+			r.ErrorMessage = sanitizeMsg(msg)
+			r.UpdatedAt = checked
+			r.Result = nil
+		})
+		return
+	}
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID: subjectID, Provider: auth.Provider, LastProbeState: string(RefreshSuccess),
+		HealthStatus: healthStatus, PlanType: strings.TrimSpace(probe.PlanType),
+		SubscriptionStartedAt: probe.SubscriptionStartedAt, SubscriptionExpiresAt: probe.SubscriptionExpiresAt,
+		SubscriptionSource: probe.SubscriptionSource, RestrictionSummary: record.RestrictionSummary, Quotas: probe.Quotas,
+		ResetCreditCount: probe.ResetCreditCount, ResetCreditExpirations: probe.ResetCreditExpirations,
+		UpstreamCheckedAt: &checked, Version: legacyPersisted.Version, UpdatedAt: checked,
+	}); err != nil {
+		_ = usage.UpdateAIAccountRefreshFailure(tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status), "persist_failed", err.Error(), checked)
+		s.setResult(jobID, subjectID, func(r *AccountRefreshResult) {
+			r.State = RefreshError
+			r.ErrorCode = "persist_failed"
+			r.ErrorMessage = sanitizeMsg(err.Error())
+			r.UpdatedAt = checked
+			r.Result = nil
+		})
+		return
+	}
 	// DB assigns version = previous+1 on conflict; never invent version from the in-memory draft.
-	persisted, err := s.loadPersistedStatus(tenantID, subjectID)
+	persisted, err := s.loadPersistedStatus(subjectID)
 	if err != nil || persisted == nil {
 		msg := "persisted status reload failed"
 		if err != nil {
@@ -582,7 +641,7 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 	})
 }
 
-func (s *Service) loadPersistedStatus(tenantID, subjectID string) (*usage.AIAccountStatusRecord, error) {
+func (s *Service) loadLegacyPersistedStatus(tenantID, subjectID string) (*usage.AIAccountStatusRecord, error) {
 	rows, err := usage.ListAIAccountStatusForTenant(tenantID, []string{subjectID})
 	if err != nil {
 		return nil, err
@@ -594,10 +653,24 @@ func (s *Service) loadPersistedStatus(tenantID, subjectID string) (*usage.AIAcco
 	return &rec, nil
 }
 
-func (s *Service) viewFromPersistedRecord(tenantID string, auth *coreauth.Auth, record usage.AIAccountStatusRecord) *AccountStatusView {
-	cycleStarts, _ := usage.QueryLatestWeeklyQuotaCyclesBatch(tenantID, []string{record.AuthSubjectID}, primaryWeeklyKeys(auth.Provider))
-	summaries, _ := usage.QueryAuthSubjectUsageSummaries(tenantID, []string{record.AuthSubjectID}, cycleStarts)
-	view := statusViewFromRecord(record, auth, summaries[record.AuthSubjectID])
+func (s *Service) loadPersistedStatus(subjectID string) (*usage.AIAccountSubjectStatusRecord, error) {
+	rows, err := usage.ListAIAccountSubjectStatus([]string{subjectID})
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("status row missing after upsert")
+	}
+	rec := rows[0]
+	return &rec, nil
+}
+
+func (s *Service) viewFromPersistedRecord(tenantID string, auth *coreauth.Auth, record usage.AIAccountSubjectStatusRecord) *AccountStatusView {
+	cycleStarts, _ := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{record.AuthSubjectID}, primaryWeeklyKeys(auth.Provider))
+	summaries, _ := usage.QueryAIAccountSubjectUsageSummaries([]string{record.AuthSubjectID}, cycleStarts)
+	subjects, _ := usage.ListAIAccountSubjects([]string{record.AuthSubjectID})
+	counts, _ := usage.CountAIAccountTenantBindings(tenantID, []string{record.AuthSubjectID})
+	view := statusViewFromSharedRecord(record, auth, summaries[record.AuthSubjectID], subjects[record.AuthSubjectID], counts[record.AuthSubjectID])
 	return &view
 }
 
@@ -655,10 +728,11 @@ func (s *Service) GetJob(tenantID, jobID string) (JobSnapshot, bool) {
 
 func (s *Service) ListStatus(tenantID string, authIndexes, authSubjectIDs []string) (StatusListResponse, error) {
 	tenantID = strings.TrimSpace(tenantID)
-	// Best-effort stale cleanup: throttled per tenant so GET stays read-mostly.
 	s.maybeNormalizeStaleRefresh(tenantID)
-
 	auths := s.listAuths(tenantID)
+	if err := reconcileTenantBindings(auths); err != nil {
+		return StatusListResponse{}, err
+	}
 	indexFilter := make(map[string]struct{})
 	for _, idx := range authIndexes {
 		if v := strings.TrimSpace(idx); v != "" {
@@ -672,7 +746,6 @@ func (s *Service) ListStatus(tenantID string, authIndexes, authSubjectIDs []stri
 		}
 	}
 	filterOn := len(indexFilter) > 0 || len(subjectFilter) > 0
-
 	wanted := make(map[string]*coreauth.Auth)
 	for _, auth := range auths {
 		if auth == nil {
@@ -690,105 +763,94 @@ func (s *Service) ListStatus(tenantID string, authIndexes, authSubjectIDs []stri
 				continue
 			}
 		}
-		// Prefer enabled/usable alias when multiple credentials share one subject.
 		wanted[identity.ID] = preferAuthRepresentative(wanted[identity.ID], auth)
 	}
 	subjectIDs := make([]string, 0, len(wanted))
 	for sid := range wanted {
 		subjectIDs = append(subjectIDs, sid)
 	}
-	// Empty filter match / empty tenant catalog: do not call store with empty IDs
-	// (empty means "all subjects for tenant" and would scan the whole status table).
 	if len(subjectIDs) == 0 {
 		return StatusListResponse{Items: []AccountStatusView{}}, nil
 	}
 
-	statusRows, err := usage.ListAIAccountStatusForTenant(tenantID, subjectIDs)
+	statusRows, err := usage.ListAIAccountSubjectStatus(subjectIDs)
 	if err != nil {
 		return StatusListResponse{}, err
 	}
-	statusBySubject := make(map[string]usage.AIAccountStatusRecord, len(statusRows))
+	statusBySubject := make(map[string]usage.AIAccountSubjectStatusRecord, len(statusRows))
 	for _, row := range statusRows {
 		statusBySubject[row.AuthSubjectID] = row
 	}
-
-	// One batch cycle query for all preferred weekly keys used by present providers.
+	subjectRows, err := usage.ListAIAccountSubjects(subjectIDs)
+	if err != nil {
+		return StatusListResponse{}, err
+	}
+	bindingCounts, err := usage.CountAIAccountTenantBindings(tenantID, subjectIDs)
+	if err != nil {
+		return StatusListResponse{}, err
+	}
 	prefKeys := make([]string, 0)
 	prefSeen := map[string]struct{}{}
 	for _, auth := range wanted {
-		for _, k := range primaryWeeklyKeys(auth.Provider) {
-			if _, ok := prefSeen[k]; ok {
-				continue
+		for _, key := range primaryWeeklyKeys(auth.Provider) {
+			if _, ok := prefSeen[key]; !ok {
+				prefSeen[key] = struct{}{}
+				prefKeys = append(prefKeys, key)
 			}
-			prefSeen[k] = struct{}{}
-			prefKeys = append(prefKeys, k)
 		}
 	}
-	cycleStart, err := usage.QueryLatestWeeklyQuotaCyclesBatch(tenantID, subjectIDs, prefKeys)
+	cycleStart, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs, prefKeys)
 	if err != nil {
 		return StatusListResponse{}, err
 	}
-	summaries, err := usage.QueryAuthSubjectUsageSummaries(tenantID, subjectIDs, cycleStart)
+	summaries, err := usage.QueryAIAccountSubjectUsageSummaries(subjectIDs, cycleStart)
 	if err != nil {
 		return StatusListResponse{}, err
 	}
 
-	items := make([]AccountStatusView, 0, len(wanted))
+	items := make([]AccountStatusView, 0, len(subjectIDs))
 	for _, sid := range subjectIDs {
 		auth := wanted[sid]
+		identity := usage.ResolveAuthSubjectIdentity(auth)
+		subject := subjectRows[sid]
+		if subject.AuthSubjectID == "" && identity != nil {
+			subject = usage.AIAccountSubjectRecord{AuthSubjectID: sid, Provider: identity.Provider, SubjectScope: identity.SubjectScope, SeedKind: identity.SeedKind, ShareEligible: identity.ShareEligible}
+		}
 		row, has := statusBySubject[sid]
 		if !has {
 			items = append(items, AccountStatusView{
-				AuthSubjectID: sid,
-				AuthIndex:     auth.Index,
-				Provider:      auth.Provider,
-				RefreshState:  string(RefreshIdle),
-				HealthStatus:  string(auth.Status),
-				PlanType:      metadataString(auth, "plan_type", "planType"),
-				Quotas:        []usage.QuotaWindowDTO{},
-				Usage:         summaries[sid],
+				AuthSubjectID: sid, AuthIndex: auth.Index, Provider: auth.Provider,
+				StatusScope: usage.AIAccountStatusScopeShared, SubjectScope: subject.SubjectScope,
+				ShareEligible: subject.ShareEligible, SubjectSeedKind: subject.SeedKind,
+				CurrentTenantBindingCount: bindingCounts[sid], RefreshState: string(RefreshIdle),
+				HealthStatus: string(auth.Status), Quotas: []usage.QuotaWindowDTO{}, Usage: summaries[sid],
 			})
 			continue
 		}
-		items = append(items, statusViewFromRecord(row, auth, summaries[sid]))
+		items = append(items, statusViewFromSharedRecord(row, auth, summaries[sid], subject, bindingCounts[sid]))
 	}
 	return StatusListResponse{Items: items}, nil
 }
 
-func statusViewFromRecord(row usage.AIAccountStatusRecord, auth *coreauth.Auth, summary usage.AuthSubjectUsageSummary) AccountStatusView {
+func statusViewFromSharedRecord(row usage.AIAccountSubjectStatusRecord, auth *coreauth.Auth, summary usage.AuthSubjectUsageSummary, subject usage.AIAccountSubjectRecord, bindingCount int) AccountStatusView {
 	view := AccountStatusView{
-		AuthSubjectID:          row.AuthSubjectID,
-		AuthIndex:              row.AuthIndex,
-		Provider:               row.Provider,
-		RefreshState:           row.RefreshState,
-		HealthStatus:           row.HealthStatus,
-		PlanType:               row.PlanType,
-		RestrictionSummary:     row.RestrictionSummary,
-		ErrorSummary:           row.ErrorSummary,
-		ErrorCode:              row.ErrorCode,
-		ErrorMessage:           row.ErrorMessage,
-		Quotas:                 row.Quotas,
-		ResetCreditCount:       row.ResetCreditCount,
-		ResetCreditExpirations: row.ResetCreditExpirations,
-		Usage:                  summary,
-		UpstreamCheckedAt:      row.UpstreamCheckedAt,
-		UsageUpdatedAt:         row.UsageUpdatedAt,
-		ExpiresAt:              row.ExpiresAt,
-		Version:                row.Version,
-		UpdatedAt:              timePointer(row.UpdatedAt),
+		AuthSubjectID: row.AuthSubjectID, Provider: row.Provider, StatusScope: usage.AIAccountStatusScopeShared,
+		SubjectScope: subject.SubjectScope, ShareEligible: subject.ShareEligible, SubjectSeedKind: subject.SeedKind,
+		CurrentTenantBindingCount: bindingCount, RefreshState: row.LastProbeState, HealthStatus: row.HealthStatus,
+		PlanType: row.PlanType, RestrictionSummary: row.RestrictionSummary, ErrorSummary: row.ErrorSummary,
+		ErrorCode: row.ErrorCode, Quotas: row.Quotas, ResetCreditCount: row.ResetCreditCount,
+		ResetCreditExpirations: row.ResetCreditExpirations, Usage: summary,
+		SubscriptionStartedAt: row.SubscriptionStartedAt, SubscriptionExpiresAt: row.SubscriptionExpiresAt,
+		SubscriptionSource: row.SubscriptionSource, UpstreamCheckedAt: row.UpstreamCheckedAt,
+		ExpiresAt: row.SubscriptionExpiresAt, Version: row.Version, UpdatedAt: timePointer(row.UpdatedAt),
 	}
 	if auth != nil {
-		if view.AuthIndex == "" {
-			view.AuthIndex = auth.Index
-		}
+		view.AuthIndex = auth.Index
 		if view.Provider == "" {
 			view.Provider = auth.Provider
 		}
 		if view.HealthStatus == "" {
 			view.HealthStatus = string(auth.Status)
-		}
-		if view.PlanType == "" {
-			view.PlanType = metadataString(auth, "plan_type", "planType")
 		}
 	}
 	if view.Quotas == nil {
@@ -797,7 +859,7 @@ func statusViewFromRecord(row usage.AIAccountStatusRecord, auth *coreauth.Auth, 
 	if view.Usage.AuthSubjectID == "" {
 		view.Usage.AuthSubjectID = row.AuthSubjectID
 	}
-	if view.UsageUpdatedAt == nil && !summary.UpdatedAt.IsZero() {
+	if !summary.UpdatedAt.IsZero() {
 		view.UsageUpdatedAt = timePointer(summary.UpdatedAt)
 	}
 	if view.Usage.WeeklyQuotaUsed == nil && auth != nil {
@@ -883,8 +945,49 @@ func (s *Service) purgeExpiredJobs() {
 	}
 }
 
-func flightKey(tenantID, subjectID string) string {
-	return strings.TrimSpace(tenantID) + "|" + strings.TrimSpace(subjectID)
+func flightKey(_ string, subjectID string) string {
+	return strings.TrimSpace(subjectID)
+}
+
+func reconcileTenantBindings(auths []*coreauth.Auth) error {
+	if len(auths) == 0 {
+		return nil
+	}
+	tenantID := ""
+	authIDs := make([]string, 0, len(auths))
+	for _, auth := range auths {
+		if auth != nil {
+			tenantID = auth.TenantID
+			if id := strings.TrimSpace(auth.ID); id != "" {
+				authIDs = append(authIDs, id)
+			}
+		}
+	}
+	rows, err := usage.ListAIAccountBindingsForTenantAuths(tenantID, authIDs)
+	if err != nil {
+		return err
+	}
+	byID := make(map[string]usage.AIAccountTenantBinding, len(rows))
+	for _, row := range rows {
+		byID[row.AuthID] = row
+	}
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		identity := usage.ResolveAuthSubjectIdentity(auth)
+		if identity == nil {
+			continue
+		}
+		row, ok := byID[auth.ID]
+		if ok && row.BindingState == "active" && row.AuthSubjectID == identity.ID && row.AuthIndex == auth.EnsureIndex() && row.BindingSeedHash == identity.SeedHash {
+			continue
+		}
+		if err := usage.UpsertAIAccountTenantBinding(auth, identity); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func sanitizeMsg(msg string) string {

--- a/internal/management/aiaccountstatus/service_test.go
+++ b/internal/management/aiaccountstatus/service_test.go
@@ -763,3 +763,157 @@ func TestPersistReloadFailedDoesNotReportSuccess(t *testing.T) {
 		}
 	}
 }
+
+func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { usage.CloseDB(); _ = os.Remove(dbPath) })
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	authA := &coreauth.Auth{ID: "shared-a", TenantID: "tenant-a", Provider: "codex", FileName: "a.json", Metadata: map[string]any{"account_id": "physical-account"}}
+	authB := &coreauth.Auth{ID: "shared-b", TenantID: "tenant-b", Provider: "codex", FileName: "b.json", Metadata: map[string]any{"account_id": "physical-account"}}
+	for _, auth := range []*coreauth.Auth{authA, authB} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatal(err)
+		}
+	}
+	identity := usage.ResolveAuthSubjectIdentity(authA)
+	if identity == nil || identity.ID != usage.ResolveAuthSubjectIdentity(authB).ID {
+		t.Fatal("expected shared account subject")
+	}
+	if err := usage.UpsertAIAccountTenantBinding(authA, identity); err != nil {
+		t.Fatal(err)
+	}
+	checked := time.Now().UTC()
+	pct := 68.0
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID:     identity.ID,
+		Provider:          "codex",
+		LastProbeState:    string(RefreshSuccess),
+		HealthStatus:      "ok",
+		PlanType:          "plus",
+		Quotas:            []usage.QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pct}},
+		UpstreamCheckedAt: &checked,
+		UpdatedAt:         checked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mounting the same physical account in tenant B repairs only B's missing binding,
+	// then immediately reads the already-populated shared subject snapshot.
+	svc := New(&config.Config{}, manager, nil, nil)
+	response, err := svc.ListStatus("tenant-b", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Items) != 1 {
+		t.Fatalf("items=%+v", response.Items)
+	}
+	item := response.Items[0]
+	if item.AuthSubjectID != identity.ID || item.PlanType != "plus" || item.StatusScope != usage.AIAccountStatusScopeShared || item.SubjectScope != usage.AIAccountSubjectScopeShared || !item.ShareEligible {
+		t.Fatalf("shared status=%+v", item)
+	}
+	if item.CurrentTenantBindingCount != 1 || item.AuthIndex != authB.EnsureIndex() {
+		t.Fatalf("tenant B binding projection=%+v", item)
+	}
+}
+
+func TestListStatusRejectsGuessedSubjectWithoutCurrentTenantBinding(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { usage.CloseDB(); _ = os.Remove(dbPath) })
+
+	authA := &coreauth.Auth{ID: "only-a", TenantID: "tenant-a", Provider: "codex", FileName: "a.json", Metadata: map[string]any{"account_id": "secret-account"}}
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), authA); err != nil {
+		t.Fatal(err)
+	}
+	identity := usage.ResolveAuthSubjectIdentity(authA)
+	if err := usage.UpsertAIAccountTenantBinding(authA, identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID: identity.ID, Provider: "codex", LastProbeState: string(RefreshSuccess), PlanType: "plus", UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := New(&config.Config{}, manager, nil, nil).ListStatus("tenant-b", nil, []string{identity.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Items) != 0 {
+		t.Fatalf("guessed subject leaked shared status: %+v", response.Items)
+	}
+}
+
+func TestCrossTenantRefreshSingleflightDoesNotLeakForeignJobID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { usage.CloseDB(); _ = os.Remove(dbPath) })
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	authA := &coreauth.Auth{ID: "refresh-a", TenantID: "tenant-a", Provider: "codex", FileName: "a.json", Metadata: map[string]any{"account_id": "refresh-physical"}}
+	authB := &coreauth.Auth{ID: "refresh-b", TenantID: "tenant-b", Provider: "codex", FileName: "b.json", Metadata: map[string]any{"account_id": "refresh-physical"}}
+	for _, auth := range []*coreauth.Auth{authA, authB} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var probes atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	svc := New(&config.Config{}, manager, func(tenantID string) *managementapitools.Service {
+		return managementapitools.NewForTenant(tenantID, &config.Config{}, manager, managementapitools.Dependencies{})
+	}, nil)
+	svc.SetProbeFunc(func(ctx context.Context, _ *managementapitools.Service, _ *config.Config, _ *coreauth.Auth) (ProbeResult, error) {
+		if probes.Add(1) == 1 {
+			close(started)
+		}
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return ProbeResult{Quotas: []usage.QuotaWindowDTO{}}, nil
+	})
+
+	first := svc.StartRefresh("tenant-a", RefreshRequest{Force: true})
+	if first.Accepted != 1 {
+		t.Fatalf("first=%+v", first)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first probe did not start")
+	}
+	second := svc.StartRefresh("tenant-b", RefreshRequest{Force: true})
+	if second.Accepted != 0 || second.Deduplicated != 1 {
+		t.Fatalf("second=%+v", second)
+	}
+	secondJob, ok := svc.GetJob("tenant-b", second.JobID)
+	if !ok || len(secondJob.Results) != 1 {
+		t.Fatalf("tenant B job=%+v ok=%v", secondJob, ok)
+	}
+	result := secondJob.Results[0]
+	if result.ErrorCode != "deduplicated" || result.ErrorMessage != "shared refresh already in progress" {
+		t.Fatalf("dedupe result=%+v", result)
+	}
+	if first.JobID != "" && (result.ErrorMessage == first.JobID || result.ErrorCode == first.JobID) {
+		t.Fatalf("foreign job ID leaked: first=%s result=%+v", first.JobID, result)
+	}
+	if _, ok := svc.GetJob("tenant-b", first.JobID); ok {
+		t.Fatal("tenant B can read tenant A job")
+	}
+	close(release)
+	waitJob(t, svc, "tenant-a", first.JobID)
+	if probes.Load() != 1 {
+		t.Fatalf("cross-tenant shared subject probed %d times", probes.Load())
+	}
+}

--- a/internal/management/aiaccountstatus/types.go
+++ b/internal/management/aiaccountstatus/types.go
@@ -54,25 +54,33 @@ type JobSnapshot struct {
 }
 
 type AccountStatusView struct {
-	AuthSubjectID          string                        `json:"auth_subject_id"`
-	AuthIndex              string                        `json:"auth_index"`
-	Provider               string                        `json:"provider"`
-	RefreshState           string                        `json:"refresh_state"`
-	HealthStatus           string                        `json:"health_status"`
-	PlanType               string                        `json:"plan_type,omitempty"`
-	RestrictionSummary     string                        `json:"restriction_summary,omitempty"`
-	ErrorSummary           string                        `json:"error_summary,omitempty"`
-	ErrorCode              string                        `json:"error_code,omitempty"`
-	ErrorMessage           string                        `json:"error_message,omitempty"`
-	Quotas                 []usage.QuotaWindowDTO        `json:"quotas"`
-	ResetCreditCount       *int64                        `json:"reset_credit_count,omitempty"`
-	ResetCreditExpirations []string                      `json:"reset_credit_expirations,omitempty"`
-	Usage                  usage.AuthSubjectUsageSummary `json:"usage"`
-	UpstreamCheckedAt      *time.Time                    `json:"upstream_checked_at,omitempty"`
-	UsageUpdatedAt         *time.Time                    `json:"usage_updated_at,omitempty"`
-	ExpiresAt              *time.Time                    `json:"expires_at,omitempty"`
-	Version                int64                         `json:"version"`
-	UpdatedAt              *time.Time                    `json:"updated_at,omitempty"`
+	AuthSubjectID             string                        `json:"auth_subject_id"`
+	AuthIndex                 string                        `json:"auth_index"`
+	Provider                  string                        `json:"provider"`
+	StatusScope               string                        `json:"status_scope"`
+	SubjectScope              string                        `json:"subject_scope"`
+	ShareEligible             bool                          `json:"share_eligible"`
+	SubjectSeedKind           string                        `json:"subject_seed_kind"`
+	CurrentTenantBindingCount int                           `json:"current_tenant_binding_count"`
+	RefreshState              string                        `json:"refresh_state"`
+	HealthStatus              string                        `json:"health_status"`
+	PlanType                  string                        `json:"plan_type,omitempty"`
+	RestrictionSummary        string                        `json:"restriction_summary,omitempty"`
+	ErrorSummary              string                        `json:"error_summary,omitempty"`
+	ErrorCode                 string                        `json:"error_code,omitempty"`
+	ErrorMessage              string                        `json:"error_message,omitempty"`
+	Quotas                    []usage.QuotaWindowDTO        `json:"quotas"`
+	ResetCreditCount          *int64                        `json:"reset_credit_count,omitempty"`
+	ResetCreditExpirations    []string                      `json:"reset_credit_expirations,omitempty"`
+	Usage                     usage.AuthSubjectUsageSummary `json:"usage"`
+	SubscriptionStartedAt     *time.Time                    `json:"subscription_started_at,omitempty"`
+	SubscriptionExpiresAt     *time.Time                    `json:"subscription_expires_at,omitempty"`
+	SubscriptionSource        string                        `json:"subscription_source,omitempty"`
+	UpstreamCheckedAt         *time.Time                    `json:"upstream_checked_at,omitempty"`
+	UsageUpdatedAt            *time.Time                    `json:"usage_updated_at,omitempty"`
+	ExpiresAt                 *time.Time                    `json:"expires_at,omitempty"`
+	Version                   int64                         `json:"version"`
+	UpdatedAt                 *time.Time                    `json:"updated_at,omitempty"`
 }
 
 type StatusListResponse struct {

--- a/internal/storage/postgres/migration_upgrade_test.go
+++ b/internal/storage/postgres/migration_upgrade_test.go
@@ -110,6 +110,7 @@ func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
 	}
 	assertAllMigrationsClean(t, ctx, db, all)
 	assertMigratedFixture(t, ctx, db)
+	assertAIAccountSharedSubjectTables(t, ctx, db)
 
 	// Re-apply must stay idempotent: no dirty rows, no data mutation.
 	if err := ApplyMigrations(ctx, db, all); err != nil {
@@ -117,6 +118,27 @@ func TestApplyMigrationsUpgradeFromPublishedSchema(t *testing.T) {
 	}
 	assertAllMigrationsClean(t, ctx, db, all)
 	assertMigratedFixture(t, ctx, db)
+	assertAIAccountSharedSubjectTables(t, ctx, db)
+}
+
+func assertAIAccountSharedSubjectTables(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	for _, table := range []string{
+		"ai_account_subjects",
+		"ai_account_tenant_bindings",
+		"ai_account_subject_status",
+		"ai_account_subject_usage_buckets",
+		"ai_account_subject_quota_cycles",
+		"ai_account_subject_quota_points",
+	} {
+		var exists bool
+		if err := db.QueryRowContext(ctx, `SELECT to_regclass(?) IS NOT NULL`, "public."+table).Scan(&exists); err != nil {
+			t.Fatalf("check shared AI account table %s: %v", table, err)
+		}
+		if !exists {
+			t.Fatalf("shared AI account table %s missing after upgrade", table)
+		}
+	}
 }
 
 // publishedBaselineMigrations returns migrations up to and including

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -31,6 +31,8 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607190002_end_user_daily_spending_resets", SQL: endUserDailySpendingResetsSQL},
 		// Small usage rollup so stats/limits stop scanning request_logs.
 		{Version: "202607200001_usage_rollup_buckets", SQL: usageRollupBucketsSQL},
+		// Shared physical AI-account subjects; credentials remain tenant-private bindings.
+		{Version: "202607200002_ai_account_shared_subjects", SQL: aiAccountSharedSubjectsSQL},
 	}
 }
 
@@ -960,4 +962,115 @@ ALTER TABLE model_configs ADD COLUMN IF NOT EXISTS max_completion_tokens INTEGER
 ALTER TABLE model_configs ADD COLUMN IF NOT EXISTS supported_parameters TEXT NOT NULL DEFAULT '';
 ALTER TABLE model_configs ADD COLUMN IF NOT EXISTS reasoning TEXT NOT NULL DEFAULT '';
 ALTER TABLE model_configs ADD COLUMN IF NOT EXISTS knowledge_cutoff TEXT NOT NULL DEFAULT '';
+`
+
+const aiAccountSharedSubjectsSQL = `
+CREATE TABLE IF NOT EXISTS ai_account_subjects (
+  auth_subject_id          TEXT PRIMARY KEY,
+  provider                 TEXT NOT NULL,
+  subject_scope            TEXT NOT NULL CHECK (subject_scope IN ('shared', 'tenant')),
+  seed_kind                TEXT NOT NULL,
+  seed_hash                TEXT NOT NULL,
+  share_eligible           BOOLEAN NOT NULL DEFAULT false,
+  usage_projected_since    TIMESTAMPTZ,
+  usage_history_complete   BOOLEAN NOT NULL DEFAULT false,
+  created_at               TIMESTAMPTZ NOT NULL,
+  updated_at               TIMESTAMPTZ NOT NULL,
+  UNIQUE (provider, subject_scope, seed_kind, seed_hash)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_account_subjects_provider_scope
+  ON ai_account_subjects(provider, subject_scope, updated_at);
+
+CREATE TABLE IF NOT EXISTS ai_account_tenant_bindings (
+  tenant_id                UUID NOT NULL,
+  auth_id                  TEXT NOT NULL,
+  auth_index               TEXT NOT NULL,
+  provider                 TEXT NOT NULL,
+  auth_subject_id          TEXT NOT NULL,
+  binding_seed_kind        TEXT NOT NULL,
+  binding_seed_hash        TEXT NOT NULL,
+  share_eligible           BOOLEAN NOT NULL DEFAULT false,
+  binding_state            TEXT NOT NULL DEFAULT 'active'
+                           CHECK (binding_state IN ('active', 'deleted')),
+  binding_revision         BIGINT NOT NULL DEFAULT 1,
+  bound_at                 TIMESTAMPTZ NOT NULL,
+  last_seen_at             TIMESTAMPTZ NOT NULL,
+  deleted_at               TIMESTAMPTZ,
+  PRIMARY KEY (tenant_id, auth_id),
+  FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_account_binding_active_index
+  ON ai_account_tenant_bindings(tenant_id, auth_index)
+  WHERE binding_state = 'active';
+CREATE INDEX IF NOT EXISTS idx_ai_account_binding_subject
+  ON ai_account_tenant_bindings(auth_subject_id, binding_state);
+CREATE INDEX IF NOT EXISTS idx_ai_account_binding_tenant_subject
+  ON ai_account_tenant_bindings(tenant_id, auth_subject_id, binding_state);
+
+CREATE TABLE IF NOT EXISTS ai_account_subject_status (
+  auth_subject_id           TEXT PRIMARY KEY,
+  provider                  TEXT NOT NULL,
+  last_probe_state          TEXT NOT NULL DEFAULT 'idle'
+                            CHECK (last_probe_state IN ('idle', 'success', 'error')),
+  health_status             TEXT NOT NULL DEFAULT '',
+  plan_type                 TEXT NOT NULL DEFAULT '',
+  subscription_started_at   TIMESTAMPTZ,
+  subscription_expires_at   TIMESTAMPTZ,
+  subscription_source       TEXT NOT NULL DEFAULT ''
+                            CHECK (subscription_source IN ('', 'probe', 'signed_claims', 'migration')),
+  restriction_summary       TEXT NOT NULL DEFAULT '',
+  error_code                TEXT NOT NULL DEFAULT '',
+  error_summary             TEXT NOT NULL DEFAULT '',
+  quota_json                TEXT NOT NULL DEFAULT '[]',
+  reset_credit_count        BIGINT,
+  reset_credit_expirations  TEXT NOT NULL DEFAULT '[]',
+  upstream_checked_at       TIMESTAMPTZ,
+  version                   BIGINT NOT NULL DEFAULT 1,
+  updated_at                TIMESTAMPTZ NOT NULL,
+  FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_account_subject_status_checked
+  ON ai_account_subject_status(upstream_checked_at, updated_at);
+
+CREATE TABLE IF NOT EXISTS ai_account_subject_usage_buckets (
+  auth_subject_id   TEXT NOT NULL,
+  bucket_kind       TEXT NOT NULL CHECK (bucket_kind IN ('day', 'lifetime', 'cycle')),
+  bucket_start      TEXT NOT NULL,
+  request_count     BIGINT NOT NULL DEFAULT 0,
+  success_count     BIGINT NOT NULL DEFAULT 0,
+  failure_count     BIGINT NOT NULL DEFAULT 0,
+  cost_total        DOUBLE PRECISION NOT NULL DEFAULT 0,
+  first_event_at    TIMESTAMPTZ NOT NULL,
+  updated_at        TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (auth_subject_id, bucket_kind, bucket_start)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_account_subject_usage_day
+  ON ai_account_subject_usage_buckets(bucket_kind, bucket_start, auth_subject_id);
+
+CREATE TABLE IF NOT EXISTS ai_account_subject_quota_cycles (
+  auth_subject_id    TEXT NOT NULL,
+  provider           TEXT NOT NULL,
+  quota_key          TEXT NOT NULL,
+  cycle_start_at     TIMESTAMPTZ NOT NULL,
+  reset_at           TIMESTAMPTZ NOT NULL,
+  window_seconds     BIGINT NOT NULL DEFAULT 0,
+  last_verified_at   TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (auth_subject_id, quota_key),
+  FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_account_subject_quota_points (
+  id                 BIGSERIAL PRIMARY KEY,
+  auth_subject_id    TEXT NOT NULL,
+  provider           TEXT NOT NULL,
+  quota_key          TEXT NOT NULL,
+  quota_label        TEXT NOT NULL DEFAULT '',
+  percent            DOUBLE PRECISION,
+  reset_at           TIMESTAMPTZ,
+  window_seconds     BIGINT NOT NULL DEFAULT 0,
+  recorded_at        TIMESTAMPTZ NOT NULL,
+  FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_account_subject_quota_points_key_time
+  ON ai_account_subject_quota_points(auth_subject_id, quota_key, recorded_at DESC);
 `

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 19 {
-		t.Fatalf("RuntimeMigrations len = %d, want 19", len(migrations))
+	if len(migrations) != 20 {
+		t.Fatalf("RuntimeMigrations len = %d, want 20", len(migrations))
 	}
 	// Latest: usage rollup buckets for stats/limits isolation from request_logs.
 	rollupSQL := migrations[18].SQL
@@ -96,6 +96,20 @@ func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 			t.Fatalf("ai account status migration missing %q", fragment)
 		}
 	}
+	sharedSQL := migrations[19].SQL
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS ai_account_subjects",
+		"CREATE TABLE IF NOT EXISTS ai_account_tenant_bindings",
+		"CREATE TABLE IF NOT EXISTS ai_account_subject_status",
+		"CREATE TABLE IF NOT EXISTS ai_account_subject_usage_buckets",
+		"CREATE TABLE IF NOT EXISTS ai_account_subject_quota_cycles",
+		"CREATE TABLE IF NOT EXISTS ai_account_subject_quota_points",
+	} {
+		if !strings.Contains(sharedSQL, fragment) {
+			t.Fatalf("shared AI account migration missing %q", fragment)
+		}
+	}
+
 	authLookupSQL := migrations[10].SQL
 	for _, fragment := range []string{
 		"idx_request_logs_tenant_auth_index_time",

--- a/internal/usage/ai_account_binding_hook.go
+++ b/internal/usage/ai_account_binding_hook.go
@@ -1,0 +1,49 @@
+package usage
+
+import (
+	"context"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// AIAccountBindingHook owns only the low-frequency A-layer binding path. The
+// per-request usage projection receives auth_subject_id directly from the
+// selected auth and must never call this hook or query the binding table.
+type AIAccountBindingHook struct {
+	coreauth.NoopHook
+}
+
+func NewAIAccountBindingHook() coreauth.Hook { return AIAccountBindingHook{} }
+
+func (AIAccountBindingHook) OnAuthRegistered(_ context.Context, auth *coreauth.Auth) {
+	reconcileAIAccountBinding(auth)
+}
+func (AIAccountBindingHook) OnAuthUpdated(_ context.Context, auth *coreauth.Auth) {
+	reconcileAIAccountBinding(auth)
+}
+func (AIAccountBindingHook) OnAuthLoaded(_ context.Context, auth *coreauth.Auth) {
+	reconcileAIAccountBinding(auth)
+}
+
+func (AIAccountBindingHook) OnAuthDeleted(_ context.Context, auth *coreauth.Auth) {
+	if auth == nil {
+		return
+	}
+	if err := MarkAIAccountTenantBindingDeleted(auth.TenantID, auth.ID); err != nil {
+		log.WithError(err).WithField("tenant_id", normalizeTenantID(auth.TenantID)).Warn("usage: soft-delete ai account binding")
+	}
+}
+
+func reconcileAIAccountBinding(auth *coreauth.Auth) {
+	identity := ResolveAuthSubjectIdentity(auth)
+	if identity == nil {
+		return
+	}
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"tenant_id": normalizeTenantID(auth.TenantID), "provider": identity.Provider,
+			"auth_subject_id": identity.ID,
+		}).Warn("usage: reconcile ai account binding")
+	}
+}

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -1,0 +1,436 @@
+package usage
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const (
+	sharedSubjectTenantA = "11111111-1111-1111-1111-111111111111"
+	sharedSubjectTenantB = "22222222-2222-2222-2222-222222222222"
+)
+
+func initSharedSubjectTestDB(t *testing.T) {
+	t.Helper()
+	CloseDB()
+	if err := InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(CloseDB)
+}
+
+func sharedSubjectTestAuth(tenantID, authID, accountID, email string) *coreauth.Auth {
+	metadata := map[string]any{}
+	if accountID != "" {
+		metadata["account_id"] = accountID
+	}
+	if email != "" {
+		metadata["email"] = email
+	}
+	return &coreauth.Auth{
+		ID:       authID,
+		TenantID: tenantID,
+		Provider: "codex",
+		FileName: authID + ".json",
+		Metadata: metadata,
+	}
+}
+
+func TestResolveAuthSubjectIdentitySharesOnlyStableAccountID(t *testing.T) {
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "auth-a", "acct-shared", "a@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "auth-b", "acct-shared", "b@example.com")
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA == nil || identityB == nil {
+		t.Fatal("expected account identities")
+	}
+	if identityA.ID != identityB.ID {
+		t.Fatalf("stable account_id subjects differ: %q != %q", identityA.ID, identityB.ID)
+	}
+	if identityA.SubjectScope != AIAccountSubjectScopeShared || !identityA.ShareEligible || identityA.SeedKind != "account_id" {
+		t.Fatalf("shared identity contract = %+v", identityA)
+	}
+	// Fingerprint account_key uses this exact ID; no second account key exists.
+	if identityA.ID == "" {
+		t.Fatal("account_key/auth_subject_id must be non-empty")
+	}
+
+	fallbackA := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantA, "fallback-a", "", "same@example.com"))
+	fallbackB := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantB, "fallback-b", "", "same@example.com"))
+	if fallbackA == nil || fallbackB == nil {
+		t.Fatal("expected fallback identities")
+	}
+	if fallbackA.ID == fallbackB.ID {
+		t.Fatalf("email fallback crossed tenant boundary: %q", fallbackA.ID)
+	}
+	for _, identity := range []*AuthSubjectIdentity{fallbackA, fallbackB} {
+		if identity.SubjectScope != AIAccountSubjectScopeTenant || identity.ShareEligible || identity.SeedKind != "email" {
+			t.Fatalf("tenant fallback contract = %+v", identity)
+		}
+	}
+}
+
+func TestAIAccountTenantBindingsDeleteOneTenantOnly(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "auth-a", "acct-bind", "a@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "auth-b", "acct-bind", "b@example.com")
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if err := UpsertAIAccountTenantBinding(authA, identityA); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertAIAccountTenantBinding(authB, identityB); err != nil {
+		t.Fatal(err)
+	}
+	if identityA.ID != identityB.ID {
+		t.Fatalf("subject mismatch: %q != %q", identityA.ID, identityB.ID)
+	}
+	if err := MarkAIAccountTenantBindingDeleted(sharedSubjectTenantA, authA.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	rowsA, err := ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{authA.ID})
+	if err != nil || len(rowsA) != 1 || rowsA[0].BindingState != "deleted" || rowsA[0].BindingRevision != 2 {
+		t.Fatalf("tenant A binding=%+v err=%v", rowsA, err)
+	}
+	rowsB, err := ListAIAccountBindingsForTenantAuths(sharedSubjectTenantB, []string{authB.ID})
+	if err != nil || len(rowsB) != 1 || rowsB[0].BindingState != "active" || rowsB[0].BindingRevision != 1 {
+		t.Fatalf("tenant B binding=%+v err=%v", rowsB, err)
+	}
+	countsB, err := CountAIAccountTenantBindings(sharedSubjectTenantB, []string{identityB.ID})
+	if err != nil || countsB[identityB.ID] != 1 {
+		t.Fatalf("tenant B counts=%v err=%v", countsB, err)
+	}
+	subjects, err := ListAIAccountSubjects([]string{identityB.ID})
+	if err != nil || subjects[identityB.ID].AuthSubjectID == "" {
+		t.Fatalf("shared subject deleted with tenant A binding: %+v err=%v", subjects, err)
+	}
+}
+
+func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "auth-a", "acct-usage", "a@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "auth-b", "acct-usage", "b@example.com")
+	identity := ResolveAuthSubjectIdentity(authA)
+	if err := UpsertAIAccountTenantBinding(authA, identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertAIAccountTenantBinding(authB, ResolveAuthSubjectIdentity(authB)); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{authA.ID})
+	if err != nil || len(before) != 1 {
+		t.Fatalf("binding before=%+v err=%v", before, err)
+	}
+
+	now := time.Now().UTC()
+	resetAt := now.Add(48 * time.Hour)
+	pct := 40.0
+	if err := RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "codex", QuotaKey: "code_week", QuotaLabel: "Week",
+		Percent: &pct, ResetAt: &resetAt, WindowSeconds: int64((7 * 24 * time.Hour) / time.Second),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	keyA := "sk-shared-a"
+	keyB := "sk-shared-b"
+	for _, row := range []APIKeyRow{
+		{TenantID: sharedSubjectTenantA, ID: uuid.NewString(), Key: keyA, Name: "A", CreatedAt: now.Format(time.RFC3339), UpdatedAt: now.Format(time.RFC3339)},
+		{TenantID: sharedSubjectTenantB, ID: uuid.NewString(), Key: keyB, Name: "B", CreatedAt: now.Format(time.RFC3339), UpdatedAt: now.Format(time.RFC3339)},
+	} {
+		if err := UpsertAPIKeyForTenant(row.TenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
+		}
+	}
+	InsertLogWithDetailsIdentitySubject(keyA, "", identity.ID, "A", "gpt-5.4", "codex", "A", authA.EnsureIndex(), false, now, 10, 1, TokenStats{TotalTokens: 1}, "", "", "")
+	InsertLogWithDetailsIdentitySubject(keyB, "", identity.ID, "B", "gpt-5.4", "codex", "B", authB.EnsureIndex(), true, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 1}, "", "", "")
+
+	var dayRows, dayRequests int64
+	if err := getDB().QueryRow(`SELECT COUNT(*), COALESCE(SUM(request_count), 0) FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? AND bucket_kind = 'day'`, identity.ID).Scan(&dayRows, &dayRequests); err != nil {
+		t.Fatal(err)
+	}
+	if dayRows != 1 || dayRequests != 2 {
+		t.Fatalf("day projection rows=%d requests=%d", dayRows, dayRequests)
+	}
+
+	start7 := time.Now().UTC().AddDate(0, 0, -6).Format("2006-01-02")
+	start30 := time.Now().UTC().AddDate(0, 0, -29).Format("2006-01-02")
+	var directID string
+	var direct7, direct30 int64
+	if err := getDB().QueryRow(`SELECT auth_subject_id, SUM(CASE WHEN bucket_start >= ? THEN request_count ELSE 0 END), SUM(request_count) FROM ai_account_subject_usage_buckets WHERE bucket_kind='day' AND bucket_start >= ? AND auth_subject_id IN (?) GROUP BY auth_subject_id`, start7, start30, identity.ID).Scan(&directID, &direct7, &direct30); err != nil {
+		t.Fatal(err)
+	}
+	if direct7 != 2 || direct30 != 2 {
+		t.Fatalf("direct day summary id=%s 7d=%d 30d=%d start7=%s start30=%s", directID, direct7, direct30, start7, start30)
+	}
+
+	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID}, []string{"code_week"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, cycleStarts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := summaries[identity.ID]
+	if got.RequestTotal != 2 || got.SuccessTotal != 1 || got.FailureTotal != 1 || got.RequestTotal30d != 2 || got.CycleRequestTotal != 2 || !got.CycleKnown {
+		t.Fatalf("shared usage=%+v", got)
+	}
+	if got.SuccessRate == nil || math.Abs(*got.SuccessRate-0.5) > 1e-9 {
+		t.Fatalf("success rate=%v", got.SuccessRate)
+	}
+	for tenantID, want := range map[string]int64{sharedSubjectTenantA: 1, sharedSubjectTenantB: 1} {
+		stats, err := QueryStats(LogQueryParams{TenantID: tenantID, Days: 30})
+		if err != nil || stats.Total != want {
+			t.Fatalf("tenant %s generic rollup total=%d err=%v", tenantID, stats.Total, err)
+		}
+	}
+
+	after, err := ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{authA.ID})
+	if err != nil || len(after) != 1 {
+		t.Fatalf("binding after=%+v err=%v", after, err)
+	}
+	if after[0].BindingRevision != before[0].BindingRevision || !after[0].LastSeenAt.Equal(before[0].LastSeenAt) {
+		t.Fatalf("request path mutated binding: before=%+v after=%+v", before[0], after[0])
+	}
+
+	if _, err := getDB().Exec(`DELETE FROM request_logs`); err != nil {
+		t.Fatal(err)
+	}
+	afterCleanup, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, cycleStarts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clean := afterCleanup[identity.ID]
+	if clean.RequestTotal != got.RequestTotal || clean.SuccessTotal != got.SuccessTotal || clean.FailureTotal != got.FailureTotal || clean.CycleRequestTotal != got.CycleRequestTotal {
+		t.Fatalf("shared usage reset after request_logs cleanup: before=%+v after=%+v", got, clean)
+	}
+}
+
+func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "backfill-a", "acct-backfill", "a@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "backfill-b", "acct-backfill", "b@example.com")
+	identity := ResolveAuthSubjectIdentity(authA)
+	if err := UpsertAIAccountTenantBinding(authA, identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertAIAccountTenantBinding(authB, ResolveAuthSubjectIdentity(authB)); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	older := now.Add(-time.Hour)
+	pctOld, pctNew := 25.0, 75.0
+	if err := UpsertAIAccountStatus(AIAccountStatusRecord{
+		TenantID: sharedSubjectTenantA, AuthSubjectID: identity.ID, AuthIndex: authA.EnsureIndex(), Provider: "codex",
+		RefreshState: "success", PlanType: "plus", Quotas: []QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pctOld}},
+		UpstreamCheckedAt: &older, UpdatedAt: older,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertAIAccountStatus(AIAccountStatusRecord{
+		TenantID: sharedSubjectTenantB, AuthSubjectID: identity.ID, AuthIndex: authB.EnsureIndex(), Provider: "codex",
+		RefreshState: "success", PlanType: "pro", Quotas: []QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pctNew}},
+		UpstreamCheckedAt: &now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	day := now.Format("2006-01-02")
+	for _, row := range []struct {
+		tenant  string
+		success int
+		failure int
+		cost    float64
+	}{
+		{sharedSubjectTenantA, 1, 0, 1.25},
+		{sharedSubjectTenantB, 0, 1, 2.75},
+	} {
+		if _, err := getDB().Exec(`
+			INSERT INTO auth_subject_usage_daily
+				(tenant_id, auth_subject_id, day_key, request_count, success_count, failure_count, cost_total, updated_at)
+			VALUES (?, ?, ?, 1, ?, ?, ?, ?)
+		`, row.tenant, identity.ID, day, row.success, row.failure, row.cost, now.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tenantID := range []string{sharedSubjectTenantA, sharedSubjectTenantB} {
+		tx, err := getDB().Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := projectUsageRollupTx(tx, rollupEvent{
+			TenantID: tenantID, AuthSubjectID: identity.ID, Model: "gpt-5.4", Source: tenantID,
+			ChannelName: tenantID, At: now, Cost: 2, Tokens: TokenStats{TotalTokens: 1},
+		}); err != nil {
+			_ = tx.Rollback()
+			t.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	resetOld := now.Add(24 * time.Hour)
+	resetNew := now.Add(48 * time.Hour)
+	if err := RecordQuotaSnapshotPointsIdentityForTenant(sharedSubjectTenantA, authA.EnsureIndex(), identity.ID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: older, QuotaKey: "code_week", QuotaLabel: "Week", Percent: &pctOld, ResetAt: &resetOld, WindowSeconds: 604800,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordQuotaSnapshotPointsIdentityForTenant(sharedSubjectTenantB, authB.EnsureIndex(), identity.ID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: now, QuotaKey: "code_week", QuotaLabel: "Week", Percent: &pctNew, ResetAt: &resetNew, WindowSeconds: 604800,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := setProjectionMarker(getDB(), usageRollupBackfillMarker, rollupMarkerDone); err != nil {
+		t.Fatal(err)
+	}
+	// A missing request_logs table proves the migration path never falls back to detail scans.
+	if _, err := getDB().Exec(`ALTER TABLE request_logs RENAME TO request_logs_hidden`); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := RunAIAccountSharedSubjectBackfillAtInit()
+	if err != nil {
+		t.Fatalf("RunAIAccountSharedSubjectBackfillAtInit: %v", err)
+	}
+	if report.Subjects != 1 || report.Bindings != 2 || report.StatusRows != 1 || report.StatusPayloadConflicts != 1 || report.QuotaCycles != 1 || report.QuotaPoints != 2 || report.Checksum == "" {
+		t.Fatalf("report=%+v", report)
+	}
+	statuses, err := ListAIAccountSubjectStatus([]string{identity.ID})
+	if err != nil || len(statuses) != 1 || statuses[0].PlanType != "pro" {
+		t.Fatalf("status winner=%+v err=%v", statuses, err)
+	}
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, map[string]time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	summary := summaries[identity.ID]
+	if summary.RequestTotal != 2 || summary.SuccessTotal != 2 || summary.FailureTotal != 0 || summary.RequestTotal30d != 2 || summary.SuccessTotal30d != 1 || summary.FailureTotal30d != 1 || math.Abs(summary.CostTotal-4) > 1e-9 || !summary.HistoryComplete {
+		t.Fatalf("backfilled summary=%+v", summary)
+	}
+	var cycleReset string
+	if err := getDB().QueryRow(`SELECT reset_at FROM ai_account_subject_quota_cycles WHERE auth_subject_id = ? AND quota_key = 'code_week'`, identity.ID).Scan(&cycleReset); err != nil {
+		t.Fatal(err)
+	}
+	parsedReset, ok := parseStoredTimeString(cycleReset)
+	if !ok || !parsedReset.Equal(resetNew) {
+		t.Fatalf("cycle reset=%q want %s", cycleReset, resetNew)
+	}
+	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID}, []string{"code_week"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycleSummaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, cycleStarts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycleSummary := cycleSummaries[identity.ID]
+	if !cycleSummary.CycleKnown || cycleSummary.CycleRequestTotal != 2 || math.Abs(cycleSummary.CycleCostTotal-4) > 1e-9 {
+		t.Fatalf("backfilled current cycle=%+v", cycleSummary)
+	}
+
+	second, err := RunAIAccountSharedSubjectBackfillAtInit()
+	if err != nil || second.Checksum != report.Checksum || second.UsageRows != report.UsageRows || second.QuotaPoints != report.QuotaPoints {
+		t.Fatalf("done marker rerun report=%+v err=%v first=%+v", second, err, report)
+	}
+	if err := setProjectionMarker(getDB(), aiAccountSharedBackfillMarker, "pending"); err != nil {
+		t.Fatal(err)
+	}
+	third, err := RunAIAccountSharedSubjectBackfillAtInit()
+	if err != nil || third.Checksum != report.Checksum || third.UsageRows != report.UsageRows || third.QuotaPoints != report.QuotaPoints {
+		t.Fatalf("pending rerun report=%+v err=%v first=%+v", third, err, report)
+	}
+}
+
+func TestAIAccountBindingHookTracksAuthLifecycle(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	manager := coreauth.NewManager(nil, nil, NewAIAccountBindingHook())
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "hook-auth", "acct-hook-a", "hook@example.com")
+	registered, err := manager.Register(t.Context(), auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{auth.ID})
+	if err != nil || len(rows) != 1 || rows[0].BindingState != "active" || rows[0].BindingRevision != 1 {
+		t.Fatalf("registered binding=%+v err=%v", rows, err)
+	}
+	firstSubject := rows[0].AuthSubjectID
+
+	registered.Metadata["account_id"] = "acct-hook-b"
+	if _, err := manager.Update(t.Context(), registered); err != nil {
+		t.Fatal(err)
+	}
+	rows, err = ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{auth.ID})
+	if err != nil || len(rows) != 1 || rows[0].BindingRevision != 2 || rows[0].AuthSubjectID == firstSubject {
+		t.Fatalf("updated binding=%+v err=%v", rows, err)
+	}
+
+	if _, err := manager.Delete(t.Context(), auth.ID); err != nil {
+		t.Fatal(err)
+	}
+	rows, err = ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{auth.ID})
+	if err != nil || len(rows) != 1 || rows[0].BindingState != "deleted" || rows[0].BindingRevision != 3 {
+		t.Fatalf("deleted binding=%+v err=%v", rows, err)
+	}
+}
+
+func TestFingerprintPolicyUsesSharedSubjectKeyAndTenantFallbackIsolation(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "fp-a", "acct-fingerprint", "a@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "fp-b", "acct-fingerprint", "b@example.com")
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA == nil || identityB == nil || identityA.ID != identityB.ID {
+		t.Fatalf("shared identities A=%+v B=%+v", identityA, identityB)
+	}
+	invalidations := 0
+	invalidatedKey := ""
+	unregister := RegisterIdentityFingerprintInvalidationHook(func(provider identityfingerprint.Provider, accountKey string) {
+		if provider == identityfingerprint.ProviderCodex {
+			invalidations++
+			invalidatedKey = accountKey
+		}
+	})
+	defer unregister()
+
+	saved, err := SaveIdentityFingerprintAccountPolicy(identityfingerprint.AccountPolicy{
+		Provider: identityfingerprint.ProviderCodex, AccountKey: identityA.ID,
+		Strategy: identityfingerprint.AccountStrategyCLIPreferred,
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readByTenantBKey, err := GetIdentityFingerprintAccountPolicy(identityfingerprint.ProviderCodex, identityB.ID)
+	if err != nil || readByTenantBKey.Revision != saved.Revision || readByTenantBKey.AccountKey != identityA.ID {
+		t.Fatalf("tenant B policy=%+v saved=%+v err=%v", readByTenantBKey, saved, err)
+	}
+	if invalidations != 1 || invalidatedKey != identityA.ID {
+		t.Fatalf("invalidation count=%d key=%q", invalidations, invalidatedKey)
+	}
+
+	fallbackA := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantA, "fp-email-a", "", "same@example.com"))
+	fallbackB := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantB, "fp-email-b", "", "same@example.com"))
+	if fallbackA.ID == fallbackB.ID {
+		t.Fatal("tenant-scoped fingerprint fallback merged across tenants")
+	}
+	if _, err := SaveIdentityFingerprintAccountPolicy(identityfingerprint.AccountPolicy{
+		Provider: identityfingerprint.ProviderCodex, AccountKey: fallbackA.ID,
+		Strategy: identityfingerprint.AccountStrategyCLIPreferred,
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+	fallbackBPolicy, err := GetIdentityFingerprintAccountPolicy(identityfingerprint.ProviderCodex, fallbackB.ID)
+	if err != nil || fallbackBPolicy.Revision != 0 {
+		t.Fatalf("tenant B fallback saw tenant A policy: %+v err=%v", fallbackBPolicy, err)
+	}
+}

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -1,0 +1,239 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type AIAccountSubjectQuotaCycle struct {
+	AuthSubjectID  string
+	Provider       string
+	QuotaKey       string
+	CycleStartAt   time.Time
+	ResetAt        time.Time
+	WindowSeconds  int64
+	LastVerifiedAt time.Time
+}
+
+func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []QuotaSnapshotPoint) error {
+	db := getDB()
+	authSubjectID = strings.TrimSpace(authSubjectID)
+	provider = strings.TrimSpace(provider)
+	if db == nil || authSubjectID == "" || len(points) == 0 {
+		return nil
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: shared quota begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	now := time.Now().UTC()
+	for _, point := range points {
+		key := strings.TrimSpace(point.QuotaKey)
+		if key == "" {
+			continue
+		}
+		recordedAt := point.RecordedAt
+		if recordedAt.IsZero() {
+			recordedAt = now
+		}
+		recordedAt = recordedAt.UTC()
+		pointProvider := strings.TrimSpace(point.Provider)
+		if pointProvider == "" {
+			pointProvider = provider
+		}
+		label := strings.TrimSpace(point.QuotaLabel)
+		if label == "" {
+			label = key
+		}
+		if point.Percent != nil {
+			v := *point.Percent
+			if v < 0 {
+				v = 0
+			}
+			if v > 100 {
+				v = 100
+			}
+			point.Percent = &v
+		}
+		if point.ResetAt != nil && !point.ResetAt.IsZero() && point.WindowSeconds > 0 {
+			cycle := AIAccountSubjectQuotaCycle{
+				AuthSubjectID: authSubjectID, Provider: pointProvider, QuotaKey: key,
+				CycleStartAt: point.ResetAt.UTC().Add(-time.Duration(point.WindowSeconds) * time.Second),
+				ResetAt:      point.ResetAt.UTC(), WindowSeconds: point.WindowSeconds, LastVerifiedAt: recordedAt,
+			}
+			if err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle); err != nil {
+				return err
+			}
+			setAIAccountSubjectActiveCycle(cycle)
+		}
+		var latestAt sql.NullString
+		var latestPercent sql.NullFloat64
+		var latestReset sql.NullString
+		var latestWindow int64
+		err := tx.QueryRow(`
+			SELECT recorded_at, percent, reset_at, window_seconds
+			FROM ai_account_subject_quota_points
+			WHERE auth_subject_id = ? AND quota_key = ?
+			ORDER BY recorded_at DESC LIMIT 1
+		`, authSubjectID, key).Scan(&latestAt, &latestPercent, &latestReset, &latestWindow)
+		if err != nil && err != sql.ErrNoRows {
+			return err
+		}
+		if err == nil {
+			latest, _ := parseStoredTimeString(latestAt.String)
+			samePercent := (!latestPercent.Valid && point.Percent == nil) || (latestPercent.Valid && point.Percent != nil && latestPercent.Float64 == *point.Percent)
+			sameReset := nullableStoredTimeEqual(latestReset, point.ResetAt)
+			if recordedAt.Sub(latest) < quotaSnapshotHeartbeatInterval && samePercent && sameReset && latestWindow == point.WindowSeconds {
+				continue
+			}
+		}
+		if _, err := tx.Exec(`
+			INSERT INTO ai_account_subject_quota_points
+				(auth_subject_id, provider, quota_key, quota_label, percent, reset_at, window_seconds, recorded_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`, authSubjectID, pointProvider, key, label, point.Percent, nullableTimeValue(point.ResetAt), point.WindowSeconds, recordedAt.Format(time.RFC3339Nano)); err != nil {
+			return fmt.Errorf("usage: insert shared quota point: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func nullableStoredTimeEqual(stored sql.NullString, value *time.Time) bool {
+	if !stored.Valid || strings.TrimSpace(stored.String) == "" {
+		return value == nil || value.IsZero()
+	}
+	if value == nil || value.IsZero() {
+		return false
+	}
+	parsed, ok := parseStoredTimeString(stored.String)
+	return ok && parsed.Equal(value.UTC())
+}
+
+func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) error {
+	_, err := tx.Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(auth_subject_id, quota_key) DO UPDATE SET
+			provider = excluded.provider,
+			cycle_start_at = excluded.cycle_start_at,
+			reset_at = excluded.reset_at,
+			window_seconds = excluded.window_seconds,
+			last_verified_at = excluded.last_verified_at
+	`, cycle.AuthSubjectID, cycle.Provider, cycle.QuotaKey,
+		cycle.CycleStartAt.UTC().Format(time.RFC3339Nano), cycle.ResetAt.UTC().Format(time.RFC3339Nano),
+		cycle.WindowSeconds, cycle.LastVerifiedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("usage: upsert shared quota cycle: %w", err)
+	}
+	return nil
+}
+
+func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferredKeys []string) (map[string]time.Time, error) {
+	db := getReadDB()
+	ids := dedupeExactStrings(subjectIDs)
+	out := make(map[string]time.Time)
+	if db == nil || len(ids) == 0 {
+		return out, nil
+	}
+	args := make([]any, 0, len(ids)+len(preferredKeys))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	query := `
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id IN (` + strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + `)
+		  AND window_seconds >= 604800`
+	keys := dedupeExactStrings(preferredKeys)
+	if len(keys) > 0 {
+		query += ` AND quota_key IN (` + strings.TrimSuffix(strings.Repeat("?,", len(keys)), ",") + `)`
+		for _, key := range keys {
+			args = append(args, key)
+		}
+	}
+	query += ` ORDER BY last_verified_at DESC, reset_at DESC`
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared quota cycles: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			return nil, err
+		}
+		if start.Valid {
+			cycle.CycleStartAt = start.Time
+		}
+		if reset.Valid {
+			cycle.ResetAt = reset.Time
+		}
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time
+		}
+		setAIAccountSubjectActiveCycle(cycle)
+		if _, exists := out[cycle.AuthSubjectID]; !exists {
+			out[cycle.AuthSubjectID] = cycle.CycleStartAt
+		}
+	}
+	return out, rows.Err()
+}
+
+func loadAIAccountSubjectCycleCache(db *sql.DB) error {
+	resetAIAccountSubjectCycleCache()
+	if db == nil {
+		return nil
+	}
+	rows, err := db.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles WHERE window_seconds > 0
+		ORDER BY last_verified_at DESC
+	`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	seen := map[string]struct{}{}
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			return err
+		}
+		if _, ok := seen[cycle.AuthSubjectID]; ok {
+			continue
+		}
+		seen[cycle.AuthSubjectID] = struct{}{}
+		if start.Valid {
+			cycle.CycleStartAt = start.Time
+		}
+		if reset.Valid {
+			cycle.ResetAt = reset.Time
+		}
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time
+		}
+		setAIAccountSubjectActiveCycle(cycle)
+	}
+	return rows.Err()
+}
+
+func cleanupExpiredAIAccountSubjectQuotaPoints(db *sql.DB) (int64, error) {
+	if db == nil {
+		return 0, nil
+	}
+	cutoff := time.Now().AddDate(0, 0, -8).UTC().Format(time.RFC3339Nano)
+	res, err := db.Exec(`DELETE FROM ai_account_subject_quota_points WHERE recorded_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}

--- a/internal/usage/ai_account_subject_store.go
+++ b/internal/usage/ai_account_subject_store.go
@@ -1,0 +1,1051 @@
+package usage
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const (
+	AIAccountStatusScopeShared  = "shared_subject"
+	AIAccountSubjectScopeShared = "shared"
+	AIAccountSubjectScopeTenant = "tenant"
+
+	aiAccountSharedSchemaMarker   = "ai_account_shared_subject_schema_v1"
+	aiAccountSharedBackfillMarker = "ai_account_shared_subject_backfill_v1"
+	aiAccountSharedReadMarker     = "ai_account_shared_subject_read_v1"
+	aiAccountSharedOldWriteMarker = "ai_account_shared_subject_old_write_v1"
+)
+
+// SQLite mirrors the PostgreSQL migration semantics. The high-frequency usage
+// table deliberately has no subject FK so request logging cannot fail because a
+// low-frequency binding reconciliation was temporarily unavailable.
+const aiAccountSharedSubjectTablesSQL = `
+CREATE TABLE IF NOT EXISTS ai_account_subjects (
+  auth_subject_id TEXT PRIMARY KEY,
+  provider TEXT NOT NULL,
+  subject_scope TEXT NOT NULL CHECK (subject_scope IN ('shared', 'tenant')),
+  seed_kind TEXT NOT NULL,
+  seed_hash TEXT NOT NULL,
+  share_eligible INTEGER NOT NULL DEFAULT 0,
+  usage_projected_since DATETIME,
+  usage_history_complete INTEGER NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  UNIQUE (provider, subject_scope, seed_kind, seed_hash)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_account_subjects_provider_scope
+  ON ai_account_subjects(provider, subject_scope, updated_at);
+CREATE TABLE IF NOT EXISTS ai_account_tenant_bindings (
+  tenant_id TEXT NOT NULL,
+  auth_id TEXT NOT NULL,
+  auth_index TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  auth_subject_id TEXT NOT NULL,
+  binding_seed_kind TEXT NOT NULL,
+  binding_seed_hash TEXT NOT NULL,
+  share_eligible INTEGER NOT NULL DEFAULT 0,
+  binding_state TEXT NOT NULL DEFAULT 'active' CHECK (binding_state IN ('active', 'deleted')),
+  binding_revision INTEGER NOT NULL DEFAULT 1,
+  bound_at DATETIME NOT NULL,
+  last_seen_at DATETIME NOT NULL,
+  deleted_at DATETIME,
+  PRIMARY KEY (tenant_id, auth_id),
+  FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_account_binding_active_index
+  ON ai_account_tenant_bindings(tenant_id, auth_index) WHERE binding_state = 'active';
+CREATE INDEX IF NOT EXISTS idx_ai_account_binding_subject
+  ON ai_account_tenant_bindings(auth_subject_id, binding_state);
+CREATE INDEX IF NOT EXISTS idx_ai_account_binding_tenant_subject
+  ON ai_account_tenant_bindings(tenant_id, auth_subject_id, binding_state);
+CREATE TABLE IF NOT EXISTS ai_account_subject_status (
+  auth_subject_id TEXT PRIMARY KEY,
+  provider TEXT NOT NULL,
+  last_probe_state TEXT NOT NULL DEFAULT 'idle' CHECK (last_probe_state IN ('idle', 'success', 'error')),
+  health_status TEXT NOT NULL DEFAULT '',
+  plan_type TEXT NOT NULL DEFAULT '',
+  subscription_started_at DATETIME,
+  subscription_expires_at DATETIME,
+  subscription_source TEXT NOT NULL DEFAULT '' CHECK (subscription_source IN ('', 'probe', 'signed_claims', 'migration')),
+  restriction_summary TEXT NOT NULL DEFAULT '',
+  error_code TEXT NOT NULL DEFAULT '',
+  error_summary TEXT NOT NULL DEFAULT '',
+  quota_json TEXT NOT NULL DEFAULT '[]',
+  reset_credit_count INTEGER,
+  reset_credit_expirations TEXT NOT NULL DEFAULT '[]',
+  upstream_checked_at DATETIME,
+  version INTEGER NOT NULL DEFAULT 1,
+  updated_at DATETIME NOT NULL,
+  FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_account_subject_status_checked
+  ON ai_account_subject_status(upstream_checked_at, updated_at);
+CREATE TABLE IF NOT EXISTS ai_account_subject_usage_buckets (
+  auth_subject_id TEXT NOT NULL,
+  bucket_kind TEXT NOT NULL CHECK (bucket_kind IN ('day', 'lifetime', 'cycle')),
+  bucket_start TEXT NOT NULL,
+  request_count INTEGER NOT NULL DEFAULT 0,
+  success_count INTEGER NOT NULL DEFAULT 0,
+  failure_count INTEGER NOT NULL DEFAULT 0,
+  cost_total REAL NOT NULL DEFAULT 0,
+  first_event_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (auth_subject_id, bucket_kind, bucket_start)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_account_subject_usage_day
+  ON ai_account_subject_usage_buckets(bucket_kind, bucket_start, auth_subject_id);
+CREATE TABLE IF NOT EXISTS ai_account_subject_quota_cycles (
+  auth_subject_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  quota_key TEXT NOT NULL,
+  cycle_start_at DATETIME NOT NULL,
+  reset_at DATETIME NOT NULL,
+  window_seconds INTEGER NOT NULL DEFAULT 0,
+  last_verified_at DATETIME NOT NULL,
+  PRIMARY KEY (auth_subject_id, quota_key),
+  FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
+);
+CREATE TABLE IF NOT EXISTS ai_account_subject_quota_points (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  auth_subject_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  quota_key TEXT NOT NULL,
+  quota_label TEXT NOT NULL DEFAULT '',
+  percent REAL,
+  reset_at DATETIME,
+  window_seconds INTEGER NOT NULL DEFAULT 0,
+  recorded_at DATETIME NOT NULL,
+  FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_account_subject_quota_points_key_time
+  ON ai_account_subject_quota_points(auth_subject_id, quota_key, recorded_at DESC);
+`
+
+type AIAccountSubjectRecord struct {
+	AuthSubjectID        string
+	Provider             string
+	SubjectScope         string
+	SeedKind             string
+	SeedHash             string
+	ShareEligible        bool
+	UsageProjectedSince  *time.Time
+	UsageHistoryComplete bool
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+type AIAccountTenantBinding struct {
+	TenantID        string
+	AuthID          string
+	AuthIndex       string
+	Provider        string
+	AuthSubjectID   string
+	BindingSeedKind string
+	BindingSeedHash string
+	ShareEligible   bool
+	BindingState    string
+	BindingRevision int64
+	BoundAt         time.Time
+	LastSeenAt      time.Time
+	DeletedAt       *time.Time
+}
+
+type AIAccountSubjectStatusRecord struct {
+	AuthSubjectID          string
+	Provider               string
+	LastProbeState         string
+	HealthStatus           string
+	PlanType               string
+	SubscriptionStartedAt  *time.Time
+	SubscriptionExpiresAt  *time.Time
+	SubscriptionSource     string
+	RestrictionSummary     string
+	ErrorCode              string
+	ErrorSummary           string
+	Quotas                 []QuotaWindowDTO
+	ResetCreditCount       *int64
+	ResetCreditExpirations []string
+	UpstreamCheckedAt      *time.Time
+	Version                int64
+	UpdatedAt              time.Time
+}
+
+type AIAccountSharedBackfillReport struct {
+	Subjects               int64
+	Bindings               int64
+	StatusRows             int64
+	UsageRows              int64
+	QuotaCycles            int64
+	QuotaPoints            int64
+	UnboundLegacySubjects  int64
+	StatusPayloadConflicts int64
+	Checksum               string
+}
+
+func ensureAIAccountSharedSubjectTables(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	if usageDriver != "postgres" {
+		if _, err := db.Exec(aiAccountSharedSubjectTablesSQL); err != nil {
+			return fmt.Errorf("usage: ensure ai account shared subject tables: %w", err)
+		}
+	}
+	ensureUsageProjectionMarkerTable(db)
+	if err := setProjectionMarker(db, aiAccountSharedSchemaMarker, "done"); err != nil {
+		return err
+	}
+	for key, value := range map[string]string{
+		aiAccountSharedReadMarker:     "shared",
+		aiAccountSharedOldWriteMarker: "enabled",
+	} {
+		if projectionMarkerValue(db, key) == "" {
+			if err := setProjectionMarker(db, key, value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func UpsertAIAccountSubject(identity *AuthSubjectIdentity) error {
+	if identity == nil || strings.TrimSpace(identity.ID) == "" {
+		return nil
+	}
+	db := getDB()
+	if db == nil {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := db.Exec(`
+		INSERT INTO ai_account_subjects (
+			auth_subject_id, provider, subject_scope, seed_kind, seed_hash,
+			share_eligible, usage_history_complete, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+		ON CONFLICT(auth_subject_id) DO UPDATE SET
+			provider = excluded.provider,
+			subject_scope = excluded.subject_scope,
+			seed_kind = excluded.seed_kind,
+			seed_hash = excluded.seed_hash,
+			share_eligible = excluded.share_eligible,
+			updated_at = excluded.updated_at
+	`, strings.TrimSpace(identity.ID), strings.TrimSpace(identity.Provider), identity.SubjectScope,
+		identity.SeedKind, identity.SeedHash, identity.ShareEligible, now, now)
+	if err != nil {
+		return fmt.Errorf("usage: upsert ai account subject: %w", err)
+	}
+	return nil
+}
+
+func UpsertAIAccountTenantBinding(auth *coreauth.Auth, identity *AuthSubjectIdentity) error {
+	if auth == nil || identity == nil || strings.TrimSpace(auth.ID) == "" || strings.TrimSpace(identity.ID) == "" {
+		return nil
+	}
+	if err := UpsertAIAccountSubject(identity); err != nil {
+		return err
+	}
+	db := getDB()
+	if db == nil {
+		return nil
+	}
+	tenantID := normalizeTenantID(auth.TenantID)
+	authIndex := strings.TrimSpace(auth.EnsureIndex())
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := db.Exec(`
+		INSERT INTO ai_account_tenant_bindings (
+			tenant_id, auth_id, auth_index, provider, auth_subject_id,
+			binding_seed_kind, binding_seed_hash, share_eligible,
+			binding_state, binding_revision, bound_at, last_seen_at, deleted_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', 1, ?, ?, NULL)
+		ON CONFLICT(tenant_id, auth_id) DO UPDATE SET
+			auth_index = excluded.auth_index,
+			provider = excluded.provider,
+			auth_subject_id = excluded.auth_subject_id,
+			binding_seed_kind = excluded.binding_seed_kind,
+			binding_seed_hash = excluded.binding_seed_hash,
+			share_eligible = excluded.share_eligible,
+			binding_state = 'active',
+			binding_revision = CASE
+				WHEN ai_account_tenant_bindings.auth_subject_id <> excluded.auth_subject_id
+				  OR ai_account_tenant_bindings.binding_state <> 'active'
+				THEN ai_account_tenant_bindings.binding_revision + 1
+				ELSE ai_account_tenant_bindings.binding_revision
+			END,
+			last_seen_at = excluded.last_seen_at,
+			deleted_at = NULL
+	`, tenantID, strings.TrimSpace(auth.ID), authIndex, identity.Provider, identity.ID,
+		identity.SeedKind, identity.SeedHash, identity.ShareEligible, now, now)
+	if err != nil {
+		return fmt.Errorf("usage: upsert ai account tenant binding: %w", err)
+	}
+	// Low-frequency lifecycle reconciliation may merge old small-table state.
+	return BackfillAIAccountSharedSubject(identity.ID)
+}
+
+func MarkAIAccountTenantBindingDeleted(tenantID, authID string) error {
+	db := getDB()
+	if db == nil || strings.TrimSpace(authID) == "" {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := db.Exec(`
+		UPDATE ai_account_tenant_bindings
+		SET binding_state = 'deleted', binding_revision = binding_revision + 1,
+			deleted_at = ?, last_seen_at = ?
+		WHERE tenant_id = ? AND auth_id = ? AND binding_state <> 'deleted'
+	`, now, now, normalizeTenantID(tenantID), strings.TrimSpace(authID))
+	if err != nil {
+		return fmt.Errorf("usage: mark ai account binding deleted: %w", err)
+	}
+	return nil
+}
+
+func ListAIAccountBindingsForTenantAuths(tenantID string, authIDs []string) ([]AIAccountTenantBinding, error) {
+	db := getReadDB()
+	if db == nil {
+		return []AIAccountTenantBinding{}, nil
+	}
+	ids := dedupeExactStrings(authIDs)
+	if len(ids) == 0 {
+		return []AIAccountTenantBinding{}, nil
+	}
+	args := []any{normalizeTenantID(tenantID)}
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(`
+		SELECT tenant_id, auth_id, auth_index, provider, auth_subject_id,
+			binding_seed_kind, binding_seed_hash, share_eligible, binding_state,
+			binding_revision, bound_at, last_seen_at, deleted_at
+		FROM ai_account_tenant_bindings
+		WHERE tenant_id = ? AND auth_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")+`)
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: list ai account bindings: %w", err)
+	}
+	defer rows.Close()
+	out := make([]AIAccountTenantBinding, 0, len(ids))
+	for rows.Next() {
+		var row AIAccountTenantBinding
+		var share bool
+		var bound, seen, deleted sql.NullString
+		if err := rows.Scan(&row.TenantID, &row.AuthID, &row.AuthIndex, &row.Provider, &row.AuthSubjectID,
+			&row.BindingSeedKind, &row.BindingSeedHash, &share, &row.BindingState, &row.BindingRevision,
+			&bound, &seen, &deleted); err != nil {
+			return nil, err
+		}
+		row.ShareEligible = share
+		if t, ok := parseStoredTimeString(bound.String); ok {
+			row.BoundAt = t
+		}
+		if t, ok := parseStoredTimeString(seen.String); ok {
+			row.LastSeenAt = t
+		}
+		row.DeletedAt = parseNullableTime(deleted)
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func CountAIAccountTenantBindings(tenantID string, subjectIDs []string) (map[string]int, error) {
+	db := getReadDB()
+	out := make(map[string]int)
+	ids := dedupeExactStrings(subjectIDs)
+	if db == nil || len(ids) == 0 {
+		return out, nil
+	}
+	args := []any{normalizeTenantID(tenantID)}
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(`
+		SELECT auth_subject_id, COUNT(*)
+		FROM ai_account_tenant_bindings
+		WHERE tenant_id = ? AND binding_state = 'active'
+		  AND auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")+`)
+		GROUP BY auth_subject_id
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var count int
+		if err := rows.Scan(&id, &count); err != nil {
+			return nil, err
+		}
+		out[id] = count
+	}
+	return out, rows.Err()
+}
+
+func ListAIAccountSubjects(subjectIDs []string) (map[string]AIAccountSubjectRecord, error) {
+	db := getReadDB()
+	out := make(map[string]AIAccountSubjectRecord)
+	ids := dedupeExactStrings(subjectIDs)
+	if db == nil || len(ids) == 0 {
+		return out, nil
+	}
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(`
+		SELECT auth_subject_id, provider, subject_scope, seed_kind, seed_hash,
+			share_eligible, usage_projected_since, usage_history_complete, created_at, updated_at
+		FROM ai_account_subjects
+		WHERE auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")+`)
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var row AIAccountSubjectRecord
+		var projected, created, updated sql.NullString
+		if err := rows.Scan(&row.AuthSubjectID, &row.Provider, &row.SubjectScope, &row.SeedKind, &row.SeedHash,
+			&row.ShareEligible, &projected, &row.UsageHistoryComplete, &created, &updated); err != nil {
+			return nil, err
+		}
+		row.UsageProjectedSince = parseNullableTime(projected)
+		if t, ok := parseStoredTimeString(created.String); ok {
+			row.CreatedAt = t
+		}
+		if t, ok := parseStoredTimeString(updated.String); ok {
+			row.UpdatedAt = t
+		}
+		out[row.AuthSubjectID] = row
+	}
+	return out, rows.Err()
+}
+
+func UpsertAIAccountSubjectStatus(record AIAccountSubjectStatusRecord) error {
+	db := getDB()
+	if db == nil || strings.TrimSpace(record.AuthSubjectID) == "" {
+		return nil
+	}
+	if record.LastProbeState == "" {
+		record.LastProbeState = "idle"
+	}
+	if record.UpdatedAt.IsZero() {
+		record.UpdatedAt = time.Now().UTC()
+	}
+	if record.Version < 1 {
+		record.Version = 1
+	}
+	quotaJSON, err := json.Marshal(record.Quotas)
+	if err != nil {
+		return err
+	}
+	expJSON, err := json.Marshal(record.ResetCreditExpirations)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(`
+		INSERT INTO ai_account_subject_status (
+			auth_subject_id, provider, last_probe_state, health_status, plan_type,
+			subscription_started_at, subscription_expires_at, subscription_source,
+			restriction_summary, error_code, error_summary, quota_json,
+			reset_credit_count, reset_credit_expirations, upstream_checked_at, version, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(auth_subject_id) DO UPDATE SET
+			provider = excluded.provider,
+			last_probe_state = excluded.last_probe_state,
+			health_status = excluded.health_status,
+			plan_type = excluded.plan_type,
+			subscription_started_at = CASE WHEN excluded.subscription_source <> ''
+				THEN excluded.subscription_started_at ELSE ai_account_subject_status.subscription_started_at END,
+			subscription_expires_at = CASE WHEN excluded.subscription_source <> ''
+				THEN excluded.subscription_expires_at ELSE ai_account_subject_status.subscription_expires_at END,
+			subscription_source = CASE WHEN excluded.subscription_source <> ''
+				THEN excluded.subscription_source ELSE ai_account_subject_status.subscription_source END,
+			restriction_summary = excluded.restriction_summary,
+			error_code = excluded.error_code,
+			error_summary = excluded.error_summary,
+			quota_json = excluded.quota_json,
+			reset_credit_count = excluded.reset_credit_count,
+			reset_credit_expirations = excluded.reset_credit_expirations,
+			upstream_checked_at = excluded.upstream_checked_at,
+			version = CASE WHEN excluded.version > ai_account_subject_status.version
+				THEN excluded.version ELSE ai_account_subject_status.version + 1 END,
+			updated_at = excluded.updated_at
+	`, record.AuthSubjectID, record.Provider, record.LastProbeState, record.HealthStatus, record.PlanType,
+		nullableTimeValue(record.SubscriptionStartedAt), nullableTimeValue(record.SubscriptionExpiresAt), record.SubscriptionSource,
+		record.RestrictionSummary, record.ErrorCode, record.ErrorSummary, string(quotaJSON), record.ResetCreditCount,
+		string(expJSON), nullableTimeValue(record.UpstreamCheckedAt), record.Version, record.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("usage: upsert shared ai account status: %w", err)
+	}
+	return nil
+}
+
+func UpdateAIAccountSubjectProbeFailure(subjectID, provider, errorCode, errorSummary string, checked time.Time) error {
+	db := getDB()
+	if db == nil || strings.TrimSpace(subjectID) == "" {
+		return nil
+	}
+	if checked.IsZero() {
+		checked = time.Now().UTC()
+	}
+	_, err := db.Exec(`
+		INSERT INTO ai_account_subject_status (
+			auth_subject_id, provider, last_probe_state, error_code, error_summary,
+			upstream_checked_at, version, updated_at
+		) VALUES (?, ?, 'error', ?, ?, ?, 1, ?)
+		ON CONFLICT(auth_subject_id) DO UPDATE SET
+			provider = excluded.provider,
+			last_probe_state = 'error',
+			error_code = excluded.error_code,
+			error_summary = excluded.error_summary,
+			upstream_checked_at = excluded.upstream_checked_at,
+			version = ai_account_subject_status.version + 1,
+			updated_at = excluded.updated_at
+	`, subjectID, provider, strings.TrimSpace(errorCode), sanitizeSharedStatusError(errorSummary),
+		checked.UTC().Format(time.RFC3339Nano), checked.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("usage: update shared ai account failure: %w", err)
+	}
+	return nil
+}
+
+func sanitizeSharedStatusError(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case strings.Contains(value, "timeout"), strings.Contains(value, "deadline"):
+		return "upstream status probe timed out"
+	case strings.Contains(value, "unauthorized"), strings.Contains(value, "http 401"):
+		return "upstream authorization failed"
+	case strings.Contains(value, "forbidden"), strings.Contains(value, "http 403"):
+		return "upstream access was denied"
+	default:
+		return "upstream status probe failed"
+	}
+}
+
+func ListAIAccountSubjectStatus(subjectIDs []string) ([]AIAccountSubjectStatusRecord, error) {
+	db := getReadDB()
+	ids := dedupeExactStrings(subjectIDs)
+	if db == nil || len(ids) == 0 {
+		return []AIAccountSubjectStatusRecord{}, nil
+	}
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(`
+		SELECT auth_subject_id, provider, last_probe_state, health_status, plan_type,
+			subscription_started_at, subscription_expires_at, subscription_source,
+			restriction_summary, error_code, error_summary, quota_json,
+			reset_credit_count, reset_credit_expirations, upstream_checked_at, version, updated_at
+		FROM ai_account_subject_status
+		WHERE auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")+`)
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: list shared ai account status: %w", err)
+	}
+	defer rows.Close()
+	out := make([]AIAccountSubjectStatusRecord, 0, len(ids))
+	for rows.Next() {
+		var row AIAccountSubjectStatusRecord
+		var started, expires, checked, updated sql.NullString
+		var reset sql.NullInt64
+		var quotaJSON, expJSON string
+		if err := rows.Scan(&row.AuthSubjectID, &row.Provider, &row.LastProbeState, &row.HealthStatus, &row.PlanType,
+			&started, &expires, &row.SubscriptionSource, &row.RestrictionSummary, &row.ErrorCode, &row.ErrorSummary,
+			&quotaJSON, &reset, &expJSON, &checked, &row.Version, &updated); err != nil {
+			return nil, err
+		}
+		row.SubscriptionStartedAt = parseNullableTime(started)
+		row.SubscriptionExpiresAt = parseNullableTime(expires)
+		row.UpstreamCheckedAt = parseNullableTime(checked)
+		row.Quotas = decodeQuotaWindows(quotaJSON)
+		row.ResetCreditExpirations = decodeStringSlice(expJSON)
+		if reset.Valid {
+			v := reset.Int64
+			row.ResetCreditCount = &v
+		}
+		if t, ok := parseStoredTimeString(updated.String); ok {
+			row.UpdatedAt = t
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func nullableTimeValue(value *time.Time) any {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+// BackfillAIAccountSharedSubject merges only existing small projections. It
+// never reads request_logs; detail retention therefore cannot reset card data.
+func BackfillAIAccountSharedSubject(subjectID string) error {
+	db := getDB()
+	subjectID = strings.TrimSpace(subjectID)
+	if db == nil || subjectID == "" {
+		return nil
+	}
+	if err := backfillSharedStatusForSubject(db, subjectID); err != nil {
+		return err
+	}
+	if err := backfillSharedDailyUsageForSubject(db, subjectID); err != nil {
+		return err
+	}
+	if err := backfillSharedLifetimeForSubject(db, subjectID); err != nil {
+		return err
+	}
+	if err := backfillSharedQuotaCyclesForSubject(db, subjectID); err != nil {
+		return err
+	}
+	return backfillSharedQuotaPointsForSubject(db, subjectID)
+}
+
+func backfillSharedStatusForSubject(db *sql.DB, subjectID string) error {
+	var row AIAccountStatusRecord
+	var quotaJSON, expJSON string
+	var reset sql.NullInt64
+	var upstream, usageUpdated, expires, updated sql.NullString
+	err := db.QueryRow(`
+		SELECT tenant_id, auth_subject_id, auth_index, provider, refresh_state, health_status, plan_type,
+			restriction_summary, error_summary, error_code, error_message, quota_json,
+			reset_credit_count, reset_credit_expirations, upstream_checked_at, usage_updated_at,
+			expires_at, version, updated_at
+		FROM ai_account_status WHERE auth_subject_id = ?
+		ORDER BY COALESCE(upstream_checked_at, updated_at) DESC, updated_at DESC, version DESC LIMIT 1
+	`, subjectID).Scan(&row.TenantID, &row.AuthSubjectID, &row.AuthIndex, &row.Provider, &row.RefreshState,
+		&row.HealthStatus, &row.PlanType, &row.RestrictionSummary, &row.ErrorSummary, &row.ErrorCode,
+		&row.ErrorMessage, &quotaJSON, &reset, &expJSON, &upstream, &usageUpdated, &expires, &row.Version, &updated)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("usage: backfill shared status: %w", err)
+	}
+	row.Quotas = decodeQuotaWindows(quotaJSON)
+	row.ResetCreditExpirations = decodeStringSlice(expJSON)
+	if reset.Valid {
+		v := reset.Int64
+		row.ResetCreditCount = &v
+	}
+	row.UpstreamCheckedAt = parseNullableTime(upstream)
+	row.ExpiresAt = parseNullableTime(expires)
+	if t, ok := parseStoredTimeString(updated.String); ok {
+		row.UpdatedAt = t
+	}
+	var sharedUpdated sql.NullString
+	if err := db.QueryRow(`SELECT updated_at FROM ai_account_subject_status WHERE auth_subject_id = ?`, subjectID).Scan(&sharedUpdated); err == nil {
+		if t, ok := parseStoredTimeString(sharedUpdated.String); ok && !row.UpdatedAt.After(t) {
+			return nil
+		}
+	} else if err != sql.ErrNoRows {
+		return err
+	}
+	errorSummary := ""
+	if normalizeProbeState(row.RefreshState) == "error" {
+		errorSummary = sanitizeSharedStatusError(row.ErrorSummary)
+	}
+	subscriptionSource := ""
+	if row.ExpiresAt != nil {
+		subscriptionSource = "migration"
+	}
+	return UpsertAIAccountSubjectStatus(AIAccountSubjectStatusRecord{
+		AuthSubjectID: row.AuthSubjectID, Provider: row.Provider, LastProbeState: normalizeProbeState(row.RefreshState),
+		HealthStatus: row.HealthStatus, PlanType: row.PlanType, SubscriptionExpiresAt: row.ExpiresAt,
+		SubscriptionSource: subscriptionSource, RestrictionSummary: row.RestrictionSummary, ErrorCode: row.ErrorCode,
+		ErrorSummary: errorSummary, Quotas: row.Quotas, ResetCreditCount: row.ResetCreditCount,
+		ResetCreditExpirations: row.ResetCreditExpirations, UpstreamCheckedAt: row.UpstreamCheckedAt, UpdatedAt: row.UpdatedAt,
+	})
+}
+
+func normalizeProbeState(value string) string {
+	switch strings.TrimSpace(value) {
+	case "success":
+		return "success"
+	case "error":
+		return "error"
+	default:
+		return "idle"
+	}
+}
+
+func backfillSharedDailyUsageForSubject(db *sql.DB, subjectID string) error {
+	rows, err := db.Query(`
+		SELECT day_key, SUM(request_count), SUM(success_count), SUM(failure_count), SUM(cost_total), MIN(updated_at), MAX(updated_at)
+		FROM auth_subject_usage_daily WHERE auth_subject_id = ? GROUP BY day_key
+	`, subjectID)
+	if err != nil {
+		return fmt.Errorf("usage: backfill shared daily usage: %w", err)
+	}
+	type dailyRow struct {
+		day                   string
+		req, success, failure int64
+		cost                  float64
+		first, updated        string
+	}
+	batch := make([]dailyRow, 0)
+	for rows.Next() {
+		var row dailyRow
+		if err := rows.Scan(&row.day, &row.req, &row.success, &row.failure, &row.cost, &row.first, &row.updated); err != nil {
+			rows.Close()
+			return err
+		}
+		batch = append(batch, row)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	for _, row := range batch {
+		if _, err := db.Exec(`
+			INSERT INTO ai_account_subject_usage_buckets
+				(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
+			VALUES (?, 'day', ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+				request_count = CASE WHEN excluded.request_count > ai_account_subject_usage_buckets.request_count THEN excluded.request_count ELSE ai_account_subject_usage_buckets.request_count END,
+				success_count = CASE WHEN excluded.success_count > ai_account_subject_usage_buckets.success_count THEN excluded.success_count ELSE ai_account_subject_usage_buckets.success_count END,
+				failure_count = CASE WHEN excluded.failure_count > ai_account_subject_usage_buckets.failure_count THEN excluded.failure_count ELSE ai_account_subject_usage_buckets.failure_count END,
+				cost_total = CASE WHEN excluded.cost_total > ai_account_subject_usage_buckets.cost_total THEN excluded.cost_total ELSE ai_account_subject_usage_buckets.cost_total END,
+				updated_at = CASE WHEN excluded.updated_at > ai_account_subject_usage_buckets.updated_at THEN excluded.updated_at ELSE ai_account_subject_usage_buckets.updated_at END
+		`, subjectID, row.day, row.req, row.success, row.failure, row.cost, row.first, row.updated); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func backfillSharedLifetimeForSubject(db *sql.DB, subjectID string) error {
+	var req, success, failure int64
+	var cost float64
+	var first, updated sql.NullString
+	err := db.QueryRow(`
+		SELECT COALESCE(SUM(request_count),0), COALESCE(SUM(success_count),0),
+			COALESCE(SUM(failure_count),0), COALESCE(SUM(cost_total),0),
+			MIN(updated_at), MAX(updated_at)
+		FROM usage_rollup_buckets
+		WHERE bucket_kind = 'lifetime' AND auth_subject_id = ?
+	`, subjectID).Scan(&req, &success, &failure, &cost, &first, &updated)
+	if err != nil {
+		return fmt.Errorf("usage: backfill shared lifetime: %w", err)
+	}
+	if req == 0 {
+		return nil
+	}
+	firstValue := first.String
+	if firstValue == "" {
+		firstValue = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	updatedValue := updated.String
+	if updatedValue == "" {
+		updatedValue = firstValue
+	}
+	if _, err := db.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets
+			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
+		VALUES (?, 'lifetime', '1970-01-01', ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			request_count = CASE WHEN excluded.request_count > ai_account_subject_usage_buckets.request_count THEN excluded.request_count ELSE ai_account_subject_usage_buckets.request_count END,
+			success_count = CASE WHEN excluded.success_count > ai_account_subject_usage_buckets.success_count THEN excluded.success_count ELSE ai_account_subject_usage_buckets.success_count END,
+			failure_count = CASE WHEN excluded.failure_count > ai_account_subject_usage_buckets.failure_count THEN excluded.failure_count ELSE ai_account_subject_usage_buckets.failure_count END,
+			cost_total = CASE WHEN excluded.cost_total > ai_account_subject_usage_buckets.cost_total THEN excluded.cost_total ELSE ai_account_subject_usage_buckets.cost_total END,
+			updated_at = CASE WHEN excluded.updated_at > ai_account_subject_usage_buckets.updated_at THEN excluded.updated_at ELSE ai_account_subject_usage_buckets.updated_at END
+	`, subjectID, req, success, failure, cost, firstValue, updatedValue); err != nil {
+		return err
+	}
+	complete := projectionMarkerValue(db, usageRollupBackfillMarker) == rollupMarkerDone
+	_, err = db.Exec(`
+		UPDATE ai_account_subjects
+		SET usage_projected_since = COALESCE(usage_projected_since, ?),
+			usage_history_complete = ?, updated_at = ?
+		WHERE auth_subject_id = ?
+	`, firstValue, complete, time.Now().UTC().Format(time.RFC3339Nano), subjectID)
+	return err
+}
+
+func backfillSharedQuotaCyclesForSubject(db *sql.DB, subjectID string) error {
+	rows, err := db.Query(`
+		SELECT provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM auth_subject_quota_cycles WHERE subject_id = ?
+		ORDER BY last_verified_at DESC
+	`, subjectID)
+	if err != nil {
+		return fmt.Errorf("usage: backfill shared quota cycles: %w", err)
+	}
+	type cycleRow struct {
+		provider, key, start, reset, verified string
+		window                                int64
+	}
+	batch := make([]cycleRow, 0)
+	seen := map[string]struct{}{}
+	for rows.Next() {
+		var row cycleRow
+		if err := rows.Scan(&row.provider, &row.key, &row.start, &row.reset, &row.window, &row.verified); err != nil {
+			rows.Close()
+			return err
+		}
+		if _, ok := seen[row.key]; ok {
+			continue
+		}
+		seen[row.key] = struct{}{}
+		batch = append(batch, row)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	cycleStarts := make(map[string]struct{}, len(batch))
+	for _, row := range batch {
+		startValue := canonicalAIAccountSubjectTime(row.start)
+		resetValue := canonicalAIAccountSubjectTime(row.reset)
+		verifiedValue := canonicalAIAccountSubjectTime(row.verified)
+		if _, err := db.Exec(`
+			INSERT INTO ai_account_subject_quota_cycles
+				(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(auth_subject_id, quota_key) DO UPDATE SET
+				provider = CASE WHEN excluded.last_verified_at > ai_account_subject_quota_cycles.last_verified_at THEN excluded.provider ELSE ai_account_subject_quota_cycles.provider END,
+				cycle_start_at = CASE WHEN excluded.last_verified_at > ai_account_subject_quota_cycles.last_verified_at THEN excluded.cycle_start_at ELSE ai_account_subject_quota_cycles.cycle_start_at END,
+				reset_at = CASE WHEN excluded.last_verified_at > ai_account_subject_quota_cycles.last_verified_at THEN excluded.reset_at ELSE ai_account_subject_quota_cycles.reset_at END,
+				window_seconds = CASE WHEN excluded.last_verified_at > ai_account_subject_quota_cycles.last_verified_at THEN excluded.window_seconds ELSE ai_account_subject_quota_cycles.window_seconds END,
+				last_verified_at = CASE WHEN excluded.last_verified_at > ai_account_subject_quota_cycles.last_verified_at THEN excluded.last_verified_at ELSE ai_account_subject_quota_cycles.last_verified_at END
+		`, subjectID, row.provider, row.key, startValue, resetValue, row.window, verifiedValue); err != nil {
+			return err
+		}
+		cycleStarts[startValue] = struct{}{}
+	}
+	for start := range cycleStarts {
+		if err := backfillSharedCycleUsageForSubject(db, subjectID, start); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func canonicalAIAccountSubjectTime(value string) string {
+	if parsed, ok := parseStoredTimeString(value); ok {
+		return parsed.UTC().Format(time.RFC3339Nano)
+	}
+	return strings.TrimSpace(value)
+}
+
+// Current-cycle migration is intentionally estimated from the legacy daily
+// projection. It never scans request_logs, so the first partial day may be
+// conservative until the next full provider cycle starts.
+func backfillSharedCycleUsageForSubject(db *sql.DB, subjectID, cycleStart string) error {
+	startAt, ok := parseStoredTimeString(cycleStart)
+	if !ok {
+		return nil
+	}
+	startDay := startAt.In(getUsageLocation()).Format("2006-01-02")
+	var req, success, failure int64
+	var cost float64
+	var updated sql.NullString
+	if err := db.QueryRow(`
+		SELECT COALESCE(SUM(request_count),0), COALESCE(SUM(success_count),0),
+			COALESCE(SUM(failure_count),0), COALESCE(SUM(cost_total),0), MAX(updated_at)
+		FROM auth_subject_usage_daily
+		WHERE auth_subject_id = ? AND day_key >= ?
+	`, subjectID, startDay).Scan(&req, &success, &failure, &cost, &updated); err != nil {
+		return fmt.Errorf("usage: backfill shared cycle usage: %w", err)
+	}
+	if req == 0 {
+		return nil
+	}
+	updatedValue := canonicalAIAccountSubjectTime(updated.String)
+	if updatedValue == "" {
+		updatedValue = cycleStart
+	}
+	_, err := db.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets
+			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
+		VALUES (?, 'cycle', ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			request_count = CASE WHEN excluded.request_count > ai_account_subject_usage_buckets.request_count THEN excluded.request_count ELSE ai_account_subject_usage_buckets.request_count END,
+			success_count = CASE WHEN excluded.success_count > ai_account_subject_usage_buckets.success_count THEN excluded.success_count ELSE ai_account_subject_usage_buckets.success_count END,
+			failure_count = CASE WHEN excluded.failure_count > ai_account_subject_usage_buckets.failure_count THEN excluded.failure_count ELSE ai_account_subject_usage_buckets.failure_count END,
+			cost_total = CASE WHEN excluded.cost_total > ai_account_subject_usage_buckets.cost_total THEN excluded.cost_total ELSE ai_account_subject_usage_buckets.cost_total END,
+			updated_at = CASE WHEN excluded.updated_at > ai_account_subject_usage_buckets.updated_at THEN excluded.updated_at ELSE ai_account_subject_usage_buckets.updated_at END
+	`, subjectID, cycleStart, req, success, failure, cost, cycleStart, updatedValue)
+	return err
+}
+
+func backfillSharedQuotaPointsForSubject(db *sql.DB, subjectID string) error {
+	rows, err := db.Query(`
+		SELECT provider, quota_key, quota_label, percent, reset_at, window_seconds, recorded_at
+		FROM auth_file_quota_snapshot_points
+		WHERE auth_subject_id = ?
+		ORDER BY recorded_at, quota_key
+	`, subjectID)
+	if err != nil {
+		return fmt.Errorf("usage: backfill shared quota points: %w", err)
+	}
+	type pointRow struct {
+		provider, key, label, recorded string
+		percent                        sql.NullFloat64
+		reset                          sql.NullString
+		window                         int64
+	}
+	batch := make([]pointRow, 0)
+	for rows.Next() {
+		var row pointRow
+		if err := rows.Scan(&row.provider, &row.key, &row.label, &row.percent, &row.reset, &row.window, &row.recorded); err != nil {
+			rows.Close()
+			return err
+		}
+		batch = append(batch, row)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	for _, row := range batch {
+		var percentValue any
+		if row.percent.Valid {
+			percentValue = row.percent.Float64
+		}
+		var resetValue any
+		if row.reset.Valid && strings.TrimSpace(row.reset.String) != "" {
+			resetValue = row.reset.String
+		}
+		if _, err := db.Exec(`
+			INSERT INTO ai_account_subject_quota_points
+				(auth_subject_id, provider, quota_key, quota_label, percent, reset_at, window_seconds, recorded_at)
+			SELECT ?, ?, ?, ?, ?, ?, ?, ?
+			WHERE NOT EXISTS (
+				SELECT 1 FROM ai_account_subject_quota_points
+				WHERE auth_subject_id = ? AND provider = ? AND quota_key = ? AND quota_label = ?
+				  AND COALESCE(percent, -1) = COALESCE(?, -1)
+				  AND COALESCE(reset_at, '') = COALESCE(?, '')
+				  AND window_seconds = ? AND recorded_at = ?
+			)
+		`, subjectID, row.provider, row.key, row.label, percentValue, resetValue, row.window, row.recorded,
+			subjectID, row.provider, row.key, row.label, percentValue, resetValue, row.window, row.recorded); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RunAIAccountSharedSubjectBackfillAtInit() (AIAccountSharedBackfillReport, error) {
+	db := getDB()
+	if db == nil {
+		return AIAccountSharedBackfillReport{}, nil
+	}
+	if projectionMarkerValue(db, aiAccountSharedBackfillMarker) == "done" {
+		return collectAIAccountSharedBackfillReport(db)
+	}
+	if err := setProjectionMarker(db, aiAccountSharedBackfillMarker, "pending"); err != nil {
+		return AIAccountSharedBackfillReport{}, err
+	}
+	rows, err := db.Query(`SELECT auth_subject_id FROM ai_account_subjects ORDER BY auth_subject_id`)
+	if err != nil {
+		return AIAccountSharedBackfillReport{}, err
+	}
+	ids := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return AIAccountSharedBackfillReport{}, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Close(); err != nil {
+		return AIAccountSharedBackfillReport{}, err
+	}
+	for _, id := range ids {
+		if err := BackfillAIAccountSharedSubject(id); err != nil {
+			return AIAccountSharedBackfillReport{}, err
+		}
+	}
+	report, err := collectAIAccountSharedBackfillReport(db)
+	if err != nil {
+		return AIAccountSharedBackfillReport{}, err
+	}
+	if err := setProjectionMarker(db, aiAccountSharedBackfillMarker, "done"); err != nil {
+		return AIAccountSharedBackfillReport{}, err
+	}
+	return report, nil
+}
+
+func collectAIAccountSharedBackfillReport(db *sql.DB) (AIAccountSharedBackfillReport, error) {
+	var report AIAccountSharedBackfillReport
+	for _, item := range []struct {
+		query  string
+		target *int64
+	}{
+		{`SELECT COUNT(*) FROM ai_account_subjects`, &report.Subjects},
+		{`SELECT COUNT(*) FROM ai_account_tenant_bindings WHERE binding_state='active'`, &report.Bindings},
+		{`SELECT COUNT(*) FROM ai_account_subject_status`, &report.StatusRows},
+		{`SELECT COUNT(*) FROM ai_account_subject_usage_buckets`, &report.UsageRows},
+		{`SELECT COUNT(*) FROM ai_account_subject_quota_cycles`, &report.QuotaCycles},
+		{`SELECT COUNT(*) FROM ai_account_subject_quota_points`, &report.QuotaPoints},
+	} {
+		if err := db.QueryRow(item.query).Scan(item.target); err != nil {
+			return report, err
+		}
+	}
+	if err := db.QueryRow(`SELECT COUNT(DISTINCT auth_subject_id) FROM ai_account_status WHERE auth_subject_id NOT IN (SELECT auth_subject_id FROM ai_account_subjects)`).Scan(&report.UnboundLegacySubjects); err != nil {
+		return report, err
+	}
+	conflicts, err := countAIAccountLegacyStatusPayloadConflicts(db)
+	if err != nil {
+		return report, err
+	}
+	report.StatusPayloadConflicts = conflicts
+	checksumParts := []string{
+		fmt.Sprint(report.Subjects), fmt.Sprint(report.Bindings), fmt.Sprint(report.StatusRows),
+		fmt.Sprint(report.UsageRows), fmt.Sprint(report.QuotaCycles), fmt.Sprint(report.QuotaPoints),
+		fmt.Sprint(report.UnboundLegacySubjects), fmt.Sprint(report.StatusPayloadConflicts),
+	}
+	report.Checksum = stableSeedHash(strings.Join(checksumParts, "|"))
+	return report, nil
+}
+
+func countAIAccountLegacyStatusPayloadConflicts(db *sql.DB) (int64, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, plan_type, restriction_summary, quota_json,
+			reset_credit_count, reset_credit_expirations, expires_at
+		FROM ai_account_status
+		WHERE trim(auth_subject_id) <> ''
+		ORDER BY auth_subject_id
+	`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	seen := make(map[string]map[string]struct{})
+	for rows.Next() {
+		var subjectID, planType, restriction, quotaJSON, expirations string
+		var reset sql.NullInt64
+		var expires sql.NullString
+		if err := rows.Scan(&subjectID, &planType, &restriction, &quotaJSON, &reset, &expirations, &expires); err != nil {
+			return 0, err
+		}
+		resetValue := ""
+		if reset.Valid {
+			resetValue = fmt.Sprint(reset.Int64)
+		}
+		payloadHash := stableSeedHash(strings.Join([]string{
+			planType, restriction, quotaJSON, resetValue, expirations, expires.String,
+		}, "\x1f"))
+		if seen[subjectID] == nil {
+			seen[subjectID] = make(map[string]struct{})
+		}
+		seen[subjectID][payloadHash] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	var conflicts int64
+	for _, hashes := range seen {
+		if len(hashes) > 1 {
+			conflicts++
+		}
+	}
+	return conflicts, nil
+}

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -1,0 +1,281 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const aiAccountSubjectDayRetention = 400 * 24 * time.Hour
+
+var sharedCycleCache = struct {
+	sync.RWMutex
+	bySubject map[string]AIAccountSubjectQuotaCycle
+}{bySubject: make(map[string]AIAccountSubjectQuotaCycle)}
+
+func resetAIAccountSubjectCycleCache() {
+	sharedCycleCache.Lock()
+	sharedCycleCache.bySubject = make(map[string]AIAccountSubjectQuotaCycle)
+	sharedCycleCache.Unlock()
+}
+
+func setAIAccountSubjectActiveCycle(cycle AIAccountSubjectQuotaCycle) {
+	if strings.TrimSpace(cycle.AuthSubjectID) == "" || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() || cycle.WindowSeconds <= 0 {
+		return
+	}
+	sharedCycleCache.Lock()
+	sharedCycleCache.bySubject[cycle.AuthSubjectID] = cycle
+	sharedCycleCache.Unlock()
+}
+
+func aiAccountSubjectCycleAt(subjectID string, at time.Time) (AIAccountSubjectQuotaCycle, bool) {
+	sharedCycleCache.RLock()
+	cycle, ok := sharedCycleCache.bySubject[strings.TrimSpace(subjectID)]
+	sharedCycleCache.RUnlock()
+	if !ok || cycle.WindowSeconds <= 0 || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() {
+		return AIAccountSubjectQuotaCycle{}, false
+	}
+	at = at.UTC()
+	window := time.Duration(cycle.WindowSeconds) * time.Second
+	for !at.Before(cycle.ResetAt) {
+		cycle.CycleStartAt = cycle.ResetAt
+		cycle.ResetAt = cycle.ResetAt.Add(window)
+	}
+	return cycle, !at.Before(cycle.CycleStartAt)
+}
+
+// projectAIAccountSubjectUsageTx is the request-hot B-layer projection. It only
+// uses the server-computed subject already captured by usageReporter; it never
+// reads or upserts the low-frequency tenant binding table.
+func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed bool, cost float64, at time.Time) error {
+	if tx == nil {
+		return nil
+	}
+	authSubjectID = strings.TrimSpace(authSubjectID)
+	if authSubjectID == "" {
+		return nil
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	loc := usageLoc
+	if loc == nil {
+		loc = time.Local
+	}
+	successInc, failureInc := int64(1), int64(0)
+	if failed {
+		successInc, failureInc = 0, 1
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	first := at.UTC().Format(time.RFC3339Nano)
+	buckets := []struct{ kind, start string }{
+		{kind: "day", start: at.In(loc).Format("2006-01-02")},
+		{kind: "lifetime", start: rollupLifetimeStart},
+	}
+	if cycle, ok := aiAccountSubjectCycleAt(authSubjectID, at); ok {
+		buckets = append(buckets, struct{ kind, start string }{kind: "cycle", start: cycle.CycleStartAt.UTC().Format(time.RFC3339Nano)})
+	}
+	const upsert = `
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, first_event_at, updated_at
+		) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			request_count = ai_account_subject_usage_buckets.request_count + 1,
+			success_count = ai_account_subject_usage_buckets.success_count + excluded.success_count,
+			failure_count = ai_account_subject_usage_buckets.failure_count + excluded.failure_count,
+			cost_total = ai_account_subject_usage_buckets.cost_total + excluded.cost_total,
+			updated_at = excluded.updated_at
+	`
+	// The fixed day -> lifetime -> cycle order is shared by every writer.
+	for _, bucket := range buckets {
+		if _, err := tx.Exec(upsert, authSubjectID, bucket.kind, bucket.start, successInc, failureInc, cost, first, now); err != nil {
+			return fmt.Errorf("usage: project shared subject %s: %w", bucket.kind, err)
+		}
+	}
+	return nil
+}
+
+func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubject map[string]time.Time) (map[string]AuthSubjectUsageSummary, error) {
+	db := getReadDB()
+	ids := dedupeExactStrings(subjectIDs)
+	out := make(map[string]AuthSubjectUsageSummary, len(ids))
+	for _, id := range ids {
+		out[id] = AuthSubjectUsageSummary{AuthSubjectID: id}
+	}
+	if db == nil || len(ids) == 0 {
+		return out, nil
+	}
+
+	loc := getUsageLocation()
+	now := time.Now().In(loc)
+	start7 := now.AddDate(0, 0, -6).Format("2006-01-02")
+	start30 := now.AddDate(0, 0, -29).Format("2006-01-02")
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, start30)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(`
+		SELECT auth_subject_id,
+			SUM(CASE WHEN bucket_start >= ? THEN request_count ELSE 0 END),
+			SUM(CASE WHEN bucket_start >= ? THEN cost_total ELSE 0 END),
+			SUM(request_count), SUM(success_count), SUM(failure_count), MAX(updated_at)
+		FROM ai_account_subject_usage_buckets
+		WHERE bucket_kind = 'day' AND bucket_start >= ?
+		  AND auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")+`)
+		GROUP BY auth_subject_id
+	`, append([]any{start7, start7}, args...)...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared subject day summaries: %w", err)
+	}
+	for rows.Next() {
+		var id string
+		var r7 int64
+		var c7 float64
+		var r30, s30, f30 int64
+		var updated sql.NullString
+		if err := rows.Scan(&id, &r7, &c7, &r30, &s30, &f30, &updated); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		s := out[id]
+		s.RequestTotal7d, s.CostTotal7d = r7, c7
+		s.RequestTotal30d, s.SuccessTotal30d, s.FailureTotal30d = r30, s30, f30
+		if t, ok := parseStoredTimeString(updated.String); ok {
+			s.UpdatedAt = t
+		}
+		out[id] = s
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	lifeArgs := make([]any, 0, len(ids))
+	for _, id := range ids {
+		lifeArgs = append(lifeArgs, id)
+	}
+	lifeRows, err := db.Query(`
+		SELECT u.auth_subject_id, u.request_count, u.success_count, u.failure_count, u.cost_total,
+			u.first_event_at, u.updated_at, s.usage_projected_since, s.usage_history_complete
+		FROM ai_account_subject_usage_buckets u
+		LEFT JOIN ai_account_subjects s ON s.auth_subject_id = u.auth_subject_id
+		WHERE u.bucket_kind = 'lifetime' AND u.bucket_start = '1970-01-01'
+		  AND u.auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")+`)
+	`, lifeArgs...)
+	if err != nil {
+		return nil, err
+	}
+	for lifeRows.Next() {
+		var id string
+		var requestTotal, successTotal, failureTotal int64
+		var costTotal float64
+		var first, updated, projected sql.NullString
+		var complete bool
+		if err := lifeRows.Scan(&id, &requestTotal, &successTotal, &failureTotal, &costTotal, &first, &updated, &projected, &complete); err != nil {
+			lifeRows.Close()
+			return nil, err
+		}
+		s := out[id]
+		s.AuthSubjectID = id
+		s.RequestTotal = requestTotal
+		s.SuccessTotal = successTotal
+		s.FailureTotal = failureTotal
+		s.CostTotal = costTotal
+		denom := s.SuccessTotal + s.FailureTotal
+		if denom > 0 {
+			rate := float64(s.SuccessTotal) / float64(denom)
+			s.SuccessRate = &rate
+		}
+		s.ProjectedSince = parseNullableTime(projected)
+		if s.ProjectedSince == nil {
+			s.ProjectedSince = parseNullableTime(first)
+		}
+		s.HistoryComplete = complete
+		if t, ok := parseStoredTimeString(updated.String); ok && t.After(s.UpdatedAt) {
+			s.UpdatedAt = t
+		}
+		out[id] = s
+	}
+	if err := lifeRows.Close(); err != nil {
+		return nil, err
+	}
+
+	cycleIDs := make([]string, 0, len(cycleStartBySubject))
+	cycleStarts := make([]string, 0, len(cycleStartBySubject))
+	startSeen := make(map[string]struct{}, len(cycleStartBySubject))
+	for id, start := range cycleStartBySubject {
+		if _, ok := out[id]; !ok || start.IsZero() {
+			continue
+		}
+		startKey := start.UTC().Format(time.RFC3339Nano)
+		s := out[id]
+		s.CycleKnown = true
+		s.CycleStart = start.UTC().Format(time.RFC3339)
+		out[id] = s
+		cycleIDs = append(cycleIDs, id)
+		if _, ok := startSeen[startKey]; !ok {
+			startSeen[startKey] = struct{}{}
+			cycleStarts = append(cycleStarts, startKey)
+		}
+	}
+	if len(cycleIDs) == 0 {
+		return out, nil
+	}
+
+	cycleArgs := make([]any, 0, len(cycleIDs)+len(cycleStarts))
+	for _, id := range cycleIDs {
+		cycleArgs = append(cycleArgs, id)
+	}
+	for _, start := range cycleStarts {
+		cycleArgs = append(cycleArgs, start)
+	}
+	cycleRows, err := db.Query(`
+		SELECT auth_subject_id, bucket_start, request_count, cost_total, updated_at
+		FROM ai_account_subject_usage_buckets
+		WHERE bucket_kind = 'cycle'
+		  AND auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(cycleIDs)), ",")+`)
+		  AND bucket_start IN (`+strings.TrimSuffix(strings.Repeat("?,", len(cycleStarts)), ",")+`)
+	`, cycleArgs...)
+	if err != nil {
+		return nil, err
+	}
+	for cycleRows.Next() {
+		var id, bucketStart string
+		var req int64
+		var cost float64
+		var updated sql.NullString
+		if err := cycleRows.Scan(&id, &bucketStart, &req, &cost, &updated); err != nil {
+			cycleRows.Close()
+			return nil, err
+		}
+		expected, ok := cycleStartBySubject[id]
+		if !ok || bucketStart != expected.UTC().Format(time.RFC3339Nano) {
+			continue
+		}
+		s := out[id]
+		s.CycleRequestTotal, s.CycleCostTotal = req, cost
+		if t, ok := parseStoredTimeString(updated.String); ok && t.After(s.UpdatedAt) {
+			s.UpdatedAt = t
+		}
+		out[id] = s
+	}
+	if err := cycleRows.Close(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func cleanupExpiredAIAccountSubjectUsageBuckets(db *sql.DB) (int64, error) {
+	if db == nil {
+		return 0, nil
+	}
+	cutoff := time.Now().Add(-aiAccountSubjectDayRetention).In(getUsageLocation()).Format("2006-01-02")
+	res, err := db.Exec(`DELETE FROM ai_account_subject_usage_buckets WHERE bucket_kind = 'day' AND bucket_start < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}

--- a/internal/usage/auth_subject_identity.go
+++ b/internal/usage/auth_subject_identity.go
@@ -8,11 +8,20 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
+// AuthSubjectIdentity is the single account identity contract used by status,
+// usage, quota and identity fingerprints. AccountKey must always equal ID.
+// Only provider-stable account_id seeds are eligible for cross-tenant sharing;
+// all fallbacks include tenant_id in the seed and remain tenant scoped.
 type AuthSubjectIdentity struct {
-	ID        string
-	Provider  string
-	AccountID string
-	Email     string
+	ID            string
+	Provider      string
+	AccountID     string
+	Email         string
+	SeedKind      string
+	SeedHash      string
+	SubjectScope  string
+	ShareEligible bool
+	ShareReason   string
 }
 
 type AuthSubjectMatcher struct {
@@ -31,18 +40,25 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 	if provider == "" {
 		provider = "unknown"
 	}
+	tenantID := coreauth.NormalizedTenantID(auth.TenantID)
 	accountID := authMetadataString(auth.Metadata, "account_id", "accountId", "chatgpt_account_id")
-	email := authEmail(auth)
+	email := strings.ToLower(authEmail(auth))
 
 	seedKind := ""
 	seedValue := ""
+	shareEligible := false
+	subjectScope := "tenant"
+	shareReason := "fallback_identity_is_tenant_scoped"
 	switch {
 	case accountID != "":
 		seedKind = "account_id"
 		seedValue = accountID
+		shareEligible = true
+		subjectScope = "shared"
+		shareReason = "stable_provider_account_id"
 	case email != "":
 		seedKind = "email"
-		seedValue = strings.ToLower(email)
+		seedValue = email
 	case strings.TrimSpace(auth.ID) != "":
 		seedKind = "auth_id"
 		seedValue = strings.TrimSpace(auth.ID)
@@ -55,11 +71,23 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 		seedValue = authIndex
 	}
 
+	subjectSeed := []string{provider, seedKind, seedValue}
+	seedHashValue := seedValue
+	if !shareEligible {
+		subjectSeed = []string{provider, seedKind, tenantID, seedValue}
+		seedHashValue = tenantID + "\x1f" + seedValue
+	}
+
 	return &AuthSubjectIdentity{
-		ID:        stableAuthSubjectID(provider, seedKind, seedValue),
-		Provider:  provider,
-		AccountID: accountID,
-		Email:     strings.ToLower(email),
+		ID:            stableAuthSubjectID(subjectSeed...),
+		Provider:      provider,
+		AccountID:     accountID,
+		Email:         email,
+		SeedKind:      seedKind,
+		SeedHash:      stableSeedHash(seedHashValue),
+		SubjectScope:  subjectScope,
+		ShareEligible: shareEligible,
+		ShareReason:   shareReason,
 	}
 }
 
@@ -168,6 +196,11 @@ func authMetadataString(metadata map[string]any, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+func stableSeedHash(value string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	return hex.EncodeToString(sum[:])
 }
 
 func stableAuthSubjectID(parts ...string) string {

--- a/internal/usage/auth_subject_usage_daily.go
+++ b/internal/usage/auth_subject_usage_daily.go
@@ -12,18 +12,25 @@ const authSubjectUsageDailyBackfillDays = 30
 
 // AuthSubjectUsageSummary is the lightweight cycle/window summary for cards.
 type AuthSubjectUsageSummary struct {
-	AuthSubjectID     string    `json:"auth_subject_id"`
-	RequestTotal7d    int64     `json:"request_total_7d"`
-	CostTotal7d       float64   `json:"cost_total_7d"`
-	RequestTotal30d   int64     `json:"request_total_30d"`
-	SuccessTotal30d   int64     `json:"success_total_30d"`
-	FailureTotal30d   int64     `json:"failure_total_30d"`
-	CycleRequestTotal int64     `json:"cycle_request_total"`
-	CycleCostTotal    float64   `json:"cycle_cost_total"`
-	CycleKnown        bool      `json:"cycle_known"`
-	CycleStart        string    `json:"cycle_start,omitempty"`
-	WeeklyQuotaUsed   *float64  `json:"weekly_quota_used_percent,omitempty"`
-	UpdatedAt         time.Time `json:"updated_at,omitempty"`
+	AuthSubjectID     string     `json:"auth_subject_id"`
+	RequestTotal      int64      `json:"request_total"`
+	SuccessTotal      int64      `json:"success_total"`
+	FailureTotal      int64      `json:"failure_total"`
+	CostTotal         float64    `json:"cost_total"`
+	SuccessRate       *float64   `json:"success_rate,omitempty"`
+	RequestTotal7d    int64      `json:"request_total_7d"`
+	CostTotal7d       float64    `json:"cost_total_7d"`
+	RequestTotal30d   int64      `json:"request_total_30d"`
+	SuccessTotal30d   int64      `json:"success_total_30d"`
+	FailureTotal30d   int64      `json:"failure_total_30d"`
+	CycleRequestTotal int64      `json:"cycle_request_total"`
+	CycleCostTotal    float64    `json:"cycle_cost_total"`
+	CycleKnown        bool       `json:"cycle_known"`
+	CycleStart        string     `json:"cycle_start,omitempty"`
+	ProjectedSince    *time.Time `json:"projected_since,omitempty"`
+	HistoryComplete   bool       `json:"history_complete"`
+	WeeklyQuotaUsed   *float64   `json:"weekly_quota_used_percent,omitempty"`
+	UpdatedAt         time.Time  `json:"updated_at,omitempty"`
 }
 
 // commitLogWithAuthSubjectUsageDaily projects daily card counters then commits the request_log tx.

--- a/internal/usage/log_content_store.go
+++ b/internal/usage/log_content_store.go
@@ -308,6 +308,16 @@ func runRequestLogMaintenancePass(ctx context.Context, db *sql.DB, driver string
 	} else if n > 0 {
 		log.Infof("usage: pruned %d expired usage_rollup_buckets rows", n)
 	}
+	if n, err := cleanupExpiredAIAccountSubjectUsageBuckets(db); err != nil {
+		log.Errorf("usage: prune shared AI account day buckets: %v", err)
+	} else if n > 0 {
+		log.Infof("usage: pruned %d expired shared AI account day rows", n)
+	}
+	if n, err := cleanupExpiredAIAccountSubjectQuotaPoints(db); err != nil {
+		log.Errorf("usage: prune shared AI account quota points: %v", err)
+	} else if n > 0 {
+		log.Infof("usage: pruned %d expired shared AI account quota point rows", n)
+	}
 
 	// cleanup-enabled gates metadata and content retention/size cleanup only.
 	// Body purge when store-content=false still runs above (privacy, not retention).

--- a/internal/usage/request_log_metadata_cleanup.go
+++ b/internal/usage/request_log_metadata_cleanup.go
@@ -10,7 +10,8 @@ import (
 )
 
 // cleanupExpiredRequestLogMetadata deletes oldest request_logs past retention
-// or hard caps. Cascade removes content. Never touches usage_rollup_buckets.
+// or hard caps. Cascade removes content. Never touches usage_rollup_buckets or
+// ai_account_subject_usage_buckets; shared card totals survive detail retention.
 // Skips while rollup backfill marker is incomplete so first upgrade cannot
 // prune historical detail before lifetime projection is rebuilt.
 func cleanupExpiredRequestLogMetadata(ctx context.Context, db *sql.DB) (int64, error) {

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -733,6 +733,16 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 		ensureRequestLogDetailIndexes(db)
 	}
 	bootstrapAIAccountStatusReadModels(db, loc)
+	if err := ensureAIAccountSharedSubjectTables(db); err != nil {
+		_ = db.Close()
+		usageDB, usageReadDB = nil, nil
+		return err
+	}
+	if err := loadAIAccountSubjectCycleCache(db); err != nil {
+		_ = db.Close()
+		usageDB, usageReadDB = nil, nil
+		return fmt.Errorf("usage: load shared ai account cycles: %w", err)
+	}
 	if err := bootstrapAPIKeyDailySpendingResets(db); err != nil {
 		_ = db.Close()
 		usageDB, usageReadDB = nil, nil
@@ -809,6 +819,7 @@ func CloseDB() {
 	usageLoc = nil
 	usageDriver = ""
 	usageDBMu.Unlock()
+	resetAIAccountSubjectCycleCache()
 	log.Info("usage: database closed")
 }
 

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -476,7 +476,7 @@ func resolveEndUserIDForKey(apiKey string) string {
 	return strings.TrimSpace(row.EndUserID)
 }
 
-// commitLogWithProjections writes AI-account daily + generic rollup then commits.
+// commitLogWithProjections writes tenant rollup, shared subject buckets, then legacy tenant daily and commits.
 // Caller must already hold usageProjectionMu.RLock (see insertLogIdentity).
 func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 	if err := projectUsageRollupTx(tx, ev); err != nil {
@@ -484,6 +484,10 @@ func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 		return err
 	}
 	if ev.AuthSubjectID != "" {
+		if err := projectAIAccountSubjectUsageTx(tx, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.At); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("project shared auth subject usage: %w", err)
+		}
 		if err := projectAuthSubjectUsageDailyTx(tx, ev.TenantID, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.At); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("project auth subject usage daily: %w", err)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -129,6 +129,16 @@ type Hook interface {
 	OnResult(ctx context.Context, result Result)
 }
 
+// AuthLoadedHook and AuthDeletedHook are optional lifecycle extensions. Keeping
+// them separate preserves compatibility with existing Hook implementations.
+type AuthLoadedHook interface {
+	OnAuthLoaded(ctx context.Context, auth *Auth)
+}
+
+type AuthDeletedHook interface {
+	OnAuthDeleted(ctx context.Context, auth *Auth)
+}
+
 // NoopHook provides optional hook defaults.
 type NoopHook struct{}
 
@@ -221,6 +231,20 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
 	AttachDefaultModelRegistry(manager)
 	return manager
+}
+
+// SetHook replaces lifecycle callbacks. It is intended for host wiring before
+// Load/Register traffic starts.
+func (m *Manager) SetHook(hook Hook) {
+	if m == nil {
+		return
+	}
+	if hook == nil {
+		hook = NoopHook{}
+	}
+	m.mu.Lock()
+	m.hook = hook
+	m.mu.Unlock()
 }
 
 func (m *Manager) SetModelRegistry(registry ModelRegistry) {

--- a/sdk/cliproxy/auth/conductor_registry.go
+++ b/sdk/cliproxy/auth/conductor_registry.go
@@ -188,25 +188,38 @@ func (m *Manager) Delete(ctx context.Context, id string) (*Auth, error) {
 		return nil, err
 	}
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	if hook, ok := m.hook.(AuthDeletedHook); ok {
+		hook.OnAuthDeleted(ctx, snapshot.Clone())
+	}
 	return snapshot.Clone(), nil
 }
 
-// Load resets manager state from the backing store.
+// Load resets manager state from the backing store. Lifecycle callbacks run
+// after releasing the manager lock so database-backed hooks cannot deadlock auth
+// selection or refresh paths.
 func (m *Manager) Load(ctx context.Context) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	items, err := m.loadPersistedAuths(ctx)
 	if err != nil {
 		return err
 	}
+	loaded := make([]*Auth, 0, len(items))
+	m.mu.Lock()
 	m.auths = make(map[string]*Auth, len(items))
 	for _, auth := range items {
 		if auth == nil || auth.ID == "" {
 			continue
 		}
 		auth.EnsureIndex()
-		m.auths[auth.ID] = auth.Clone()
+		snapshot := auth.Clone()
+		m.auths[auth.ID] = snapshot
+		loaded = append(loaded, snapshot.Clone())
 	}
 	m.rebuildAPIKeyModelAliasLocked()
+	m.mu.Unlock()
+	if hook, ok := m.hook.(AuthLoadedHook); ok {
+		for _, auth := range loaded {
+			hook.OnAuthLoaded(ctx, auth)
+		}
+	}
 	return nil
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -78,6 +78,8 @@ type Service struct {
 
 	// coreManager handles core authentication and execution.
 	coreManager *coreauth.Manager
+	// coreAuthHook observes credential lifecycle without entering request hot paths.
+	coreAuthHook coreauth.Hook
 
 	// shutdownOnce ensures shutdown is called only once.
 	shutdownOnce sync.Once
@@ -116,6 +118,8 @@ type Builder struct {
 
 	// coreManager handles core authentication and execution.
 	coreManager *coreauth.Manager
+	// coreAuthHook observes credential lifecycle without entering request hot paths.
+	coreAuthHook coreauth.Hook
 
 	// serverOptions contains additional server configuration options.
 	serverOptions []api.ServerOption
@@ -191,6 +195,12 @@ func (b *Builder) WithRequestAccessManager(mgr *sdkaccess.Manager) *Builder {
 // WithCoreAuthManager overrides the runtime auth manager responsible for request execution.
 func (b *Builder) WithCoreAuthManager(mgr *coreauth.Manager) *Builder {
 	b.coreManager = mgr
+	return b
+}
+
+// WithCoreAuthHook configures lifecycle callbacks for bindings and related read models.
+func (b *Builder) WithCoreAuthHook(hook coreauth.Hook) *Builder {
+	b.coreAuthHook = hook
 	return b
 }
 
@@ -278,7 +288,10 @@ func (b *Builder) Build() (*Service, error) {
 			selector = &coreauth.RoundRobinSelector{}
 		}
 
-		coreManager = coreauth.NewManager(tokenStore, selector, nil)
+		coreManager = coreauth.NewManager(tokenStore, selector, b.coreAuthHook)
+	}
+	if b.coreAuthHook != nil {
+		coreManager.SetHook(b.coreAuthHook)
 	}
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
 	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())


### PR DESCRIPTION
## Summary
- add shared AI account subjects, tenant credential bindings, shared status/usage/quota tables, and idempotent small-table backfill
- project shared day/lifetime/active-cycle usage in the request transaction without querying or upserting bindings on the hot path
- read AI account status and identity fingerprint scope through current-tenant bindings and shared subject tables
- keep fallback identities tenant-scoped and cross-tenant refresh jobs isolated

## Verification
- `go test ./internal/api/routes -run TestRegisterManagementRouteTable -count=1`
- `go test ./internal/usage ./internal/management/aiaccountstatus ./sdk/cliproxy/auth ./internal/storage/postgres ./internal/api/handlers/management ./internal/runtime/executor ./internal/api/routes -count=1`
- `./scripts/ci-pr.sh`
