### PR TITLE
fix: cut multi-MB body peak by single translate and tool-local strip

### DIFF
--- a/internal/runtime/executor/execution_context.go
+++ b/internal/runtime/executor/execution_context.go
@@ -155,7 +155,9 @@ func newExecutionContext(
 		ctx = context.Background()
 	}
 	originalPayload := req.Payload
-	originalPayloadIsRequest := len(opts.OriginalRequest) == 0
+	// Production handlers set OriginalRequest to the same slice as Payload.
+	// Treat shared storage as "same request" so TranslateRequestPair only runs once.
+	originalPayloadIsRequest := len(opts.OriginalRequest) == 0 || samePayloadStorage(opts.OriginalRequest, req.Payload)
 	if !originalPayloadIsRequest {
 		originalPayload = opts.OriginalRequest
 	}
@@ -222,7 +224,11 @@ func (ec *ExecutionContext) TranslateRequestPair(payload []byte) ([]byte, []byte
 		payload,
 		ec.Execution.TranslateAsStream,
 	)
-	if ec.originalPayloadIsRequest && samePayloadStorage(payload, ec.Request.Payload) {
+	// Skip second translate when original is the same request (empty override,
+	// shared storage with req.Payload, or payload already is OriginalPayload).
+	if ec.originalPayloadIsRequest ||
+		samePayloadStorage(payload, ec.OriginalPayload) ||
+		samePayloadStorage(payload, ec.Request.Payload) && samePayloadStorage(ec.OriginalPayload, ec.Request.Payload) {
 		return translated, translated
 	}
 	originalTranslated := sdktranslator.TranslateRequest(

--- a/internal/runtime/executor/execution_context_test.go
+++ b/internal/runtime/executor/execution_context_test.go
@@ -97,6 +97,46 @@ func TestExecutionContextTranslatesSharedRequestPayloadOnce(t *testing.T) {
 	}
 }
 
+func TestExecutionContextTranslatesSharedNonEmptyOriginalRequestOnce(t *testing.T) {
+	// Production handlers set OriginalRequest to the same slice as Payload (non-empty).
+	var calls atomic.Int32
+	from := sdktranslator.FromString("execution-context-shared-nonempty-source")
+	to := sdktranslator.FromString("execution-context-shared-nonempty-target")
+	sdktranslator.Register(from, to, func(_ string, rawJSON []byte, _ bool) []byte {
+		calls.Add(1)
+		return bytes.Clone(rawJSON)
+	}, sdktranslator.ResponseTransform{})
+
+	raw := []byte(`{"input":"production-shared"}`)
+	req := cliproxyexecutor.Request{
+		Model:   "test-model",
+		Payload: raw,
+	}
+	execCtx := newExecutionContext(
+		context.Background(),
+		"test-provider",
+		&config.Config{},
+		nil,
+		req,
+		cliproxyexecutor.Options{
+			OriginalRequest: raw,
+			SourceFormat:    from,
+		},
+		ExecutionOptions{TargetFormat: to},
+	)
+
+	translated, originalTranslated := execCtx.TranslateRequestPair(nil)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("translator calls = %d, want 1 for non-empty shared OriginalRequest", got)
+	}
+	if string(translated) != string(raw) || string(originalTranslated) != string(raw) {
+		t.Fatalf("translated payloads differ: translated=%q original=%q", translated, originalTranslated)
+	}
+	if len(translated) > 0 && &translated[0] != &originalTranslated[0] {
+		t.Fatal("shared non-empty OriginalRequest should reuse the single translated result")
+	}
+}
+
 func TestExecutionContextTranslatesDistinctOriginalRequestSeparately(t *testing.T) {
 	var calls atomic.Int32
 	from := sdktranslator.FromString("execution-context-distinct-source")

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -85,7 +85,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 	httpResp, err := httpClient.Do(httpReq) //nolint:bodyclose // body is closed by the defer below.
 	if err != nil {
 		recorder.RecordResponseError(err)
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, err.Error())
 		return resp, err
 	}
 	defer func() {
@@ -98,7 +98,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		b := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
 		recorder.AppendResponseChunk(b)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(b))
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, string(b))
 		// Parse 402 balance-exhausted into weekly quota cooldown metadata.
 		err = newXAIStatusErr(httpResp.StatusCode, b, httpResp.Header)
 		return resp, err
@@ -137,14 +137,14 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		}
 		payload = mergeCodexResponsesCompletedOutput(payload, pendingOutputItems, pendingOutputKeys)
 		if detail, ok := parseCodexUsage(payload); ok {
-			reporter.publishWithContent(execCtx.Context, detail, string(req.Payload), string(data))
+			reporter.publishWithContentBytes(execCtx.Context, detail, req.Payload, string(data))
 		}
 		var param any
 		out := sdktranslator.TranslateNonStream(execCtx.Context, execCtx.Execution.TargetFormat, execCtx.SourceFormat, req.Model, execCtx.OriginalPayload, body, payload, &param)
 		return cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}, nil
 	}
 	if streamErr != nil {
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), streamErr.Error())
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, streamErr.Error())
 		return resp, streamErr
 	}
 	err = statusErr{code: http.StatusRequestTimeout, msg: "xai stream error: stream disconnected before response.completed"}
@@ -176,7 +176,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 	httpResp, err := httpClient.Do(httpReq) //nolint:bodyclose // success body is consumed and closed by the stream goroutine below.
 	if err != nil {
 		recorder.RecordResponseError(err)
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), err.Error())
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, err.Error())
 		return nil, err
 	}
 	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
@@ -187,14 +187,14 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 		}
 		recorder.AppendResponseChunk(data)
 		logWithRequestID(execCtx.Context).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
-		reporter.publishFailureWithContent(execCtx.Context, string(req.Payload), string(data))
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, string(data))
 		// Parse 402 balance-exhausted into weekly quota cooldown metadata.
 		err = newXAIStatusErr(httpResp.StatusCode, data, httpResp.Header)
 		return nil, err
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
-	reporter.setInputContent(string(req.Payload))
+	reporter.setInputContentBytes(req.Payload)
 	go func() {
 		defer close(out)
 		defer func() {

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -208,19 +208,9 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	inputBuf.WriteByte(']')
 
 	// Convert tools declarations once.
+	// Codex rejects defer_loading without tools.tool_search; strip it on each tool
+	// fragment only — never N× sjson.DeleteBytes on the full multi-MB request.
 	toolsResult := rootResult.Get("tools")
-	// Codex validates deferred tools strictly: defer_loading requires tools.tool_search.
-	// Claude Code may set defer_loading on tools when tool schemas are deferred.
-	// The Codex endpoint we proxy to rejects defer_loading without tool_search, so strip the flag.
-	if toolsResult.IsArray() && toolsResult.Get("#(defer_loading=true)").Exists() {
-		toolsResult.ForEach(func(i, _ gjson.Result) bool {
-			// sjson only on original rawJSON (small tools array relative to messages).
-			rawJSON, _ = sjson.DeleteBytes(rawJSON, fmt.Sprintf("tools.%d.defer_loading", i.Int()))
-			return true
-		})
-		rootResult = gjson.ParseBytes(rawJSON)
-		toolsResult = rootResult.Get("tools")
-	}
 
 	var toolsBuf bytes.Buffer
 	toolsFirst := true
@@ -268,6 +258,10 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			tool, _ = sjson.SetRaw(tool, "parameters", normalizeToolParameters(toolResult.Get("input_schema").Raw))
 			tool, _ = sjson.Delete(tool, "input_schema")
 			tool, _ = sjson.Delete(tool, "parameters.$schema")
+			// Drop Claude deferred-tool flag from the small tool fragment only.
+			if toolResult.Get("defer_loading").Exists() {
+				tool, _ = sjson.Delete(tool, "defer_loading")
+			}
 			tool, _ = sjson.Set(tool, "strict", false)
 			appendTool(tool)
 		}

--- a/internal/translator/codex/claude/codex_claude_request_alloc_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_alloc_test.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -53,4 +54,65 @@ func TestConvertClaudeRequestToCodex_LargeHistoryAllocBound(t *testing.T) {
 		t.Fatalf("alloc/op=%d body=%d ratio=%.1f want <=12x", avg, len(in), float64(avg)/float64(len(in)))
 	}
 	t.Logf("body=%dB alloc/op=%d N=%d ratio=%.2f", len(in), avg, res.N, float64(avg)/float64(len(in)))
+}
+
+func TestConvertClaudeRequestToCodex_DeferLoadingToolsAllocNotLinearInBody(t *testing.T) {
+	// Many deferred tools must not copy the full multi-MB body once per tool.
+	chunk := strings.Repeat("y", 128*1024)
+	var b strings.Builder
+	b.WriteString(`{"model":"claude-sonnet-4-6","messages":[`)
+	for i := 0; i < 16; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		b.WriteString(`{"role":"`)
+		b.WriteString(role)
+		b.WriteString(`","content":[{"type":"text","text":"`)
+		b.WriteString(chunk)
+		b.WriteString(`"}]}`)
+	}
+	b.WriteString(`],"tools":[`)
+	for i := 0; i < 50; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"name":"Tool`)
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(`","description":"d","input_schema":{"type":"object"},"defer_loading":true}`)
+	}
+	b.WriteString(`]}`)
+	in := []byte(b.String())
+
+	out := ConvertClaudeRequestToCodex("gpt-5.4", in, true)
+	tools := gjson.GetBytes(out, "tools")
+	if !tools.IsArray() || len(tools.Array()) != 50 {
+		t.Fatalf("tools = %d, want 50", len(tools.Array()))
+	}
+	tools.ForEach(func(i, tool gjson.Result) bool {
+		if tool.Get("defer_loading").Exists() {
+			t.Fatalf("tool %d still has defer_loading", i.Int())
+		}
+		return true
+	})
+
+	res := testing.Benchmark(func(bb *testing.B) {
+		bb.ReportAllocs()
+		bb.SetBytes(int64(len(in)))
+		for i := 0; i < bb.N; i++ {
+			_ = ConvertClaudeRequestToCodex("gpt-5.4", in, true)
+		}
+	})
+	if res.N == 0 {
+		t.Fatal("benchmark did not run")
+	}
+	avg := res.AllocedBytesPerOp()
+	// Old path: ~toolCount full-body copies. Cap well below 50× body.
+	if avg > int64(len(in))*20 {
+		t.Fatalf("alloc/op=%d body=%d ratio=%.1f want <=20x with 50 deferred tools", avg, len(in), float64(avg)/float64(len(in)))
+	}
+	t.Logf("body=%dB tools=50 alloc/op=%d ratio=%.2f", len(in), avg, float64(avg)/float64(len(in)))
 }

--- a/sdk/cliproxy/auth/conductor_error_helpers.go
+++ b/sdk/cliproxy/auth/conductor_error_helpers.go
@@ -188,7 +188,21 @@ func isInvalidRequestSignal(raw string) bool {
 		// Upstream vision APIs reject undersized images with a stable message.
 		// This is request content, not auth/quota, so failover cannot help.
 		strings.Contains(signal, "below the minimum of") && strings.Contains(signal, "pixels"),
-		strings.Contains(signal, "total pixels") && strings.Contains(signal, "minimum"):
+		strings.Contains(signal, "total pixels") && strings.Contains(signal, "minimum"),
+		// Prompt/context length is a property of the request body. Retrying on
+		// another auth only re-runs multi-MB translation without fixing the body.
+		strings.Contains(signal, "context_length_exceeded"),
+		strings.Contains(signal, "prompt_too_long"),
+		strings.Contains(signal, "maximum context length"),
+		strings.Contains(signal, "maximum prompt length"),
+		strings.Contains(signal, "prompt is too long"),
+		strings.Contains(signal, "prompt too long"),
+		strings.Contains(signal, "too many tokens"),
+		strings.Contains(signal, "tokens > max"),
+		strings.Contains(signal, "tokens exceeds"),
+		// Observed Grok: "maximum prompt length is 500000 but the request contains 816381 tokens"
+		strings.Contains(signal, "maximum prompt") && strings.Contains(signal, "tokens"),
+		strings.Contains(signal, "prompt length") && strings.Contains(signal, "tokens"):
 		return true
 	default:
 		return false

--- a/sdk/cliproxy/auth/conductor_error_helpers_test.go
+++ b/sdk/cliproxy/auth/conductor_error_helpers_test.go
@@ -197,6 +197,31 @@ func TestIsRequestInvalidError_IgnoresGenericBadRequestWithoutInvalidSignal(t *t
 	}
 }
 
+func TestIsRequestInvalidError_RecognizesPromptTooLongText(t *testing.T) {
+	t.Parallel()
+
+	// Observed Grok/cli-chat-proxy rejection on multi-MB Claude→Codex traffic.
+	err := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    "This model's maximum prompt length is 500000 but the request contains 816381 tokens.",
+	}
+	if !isRequestInvalidError(err) {
+		t.Fatal("expected prompt-length 400 to be treated as invalid request (no auth failover)")
+	}
+}
+
+func TestIsRequestInvalidError_RecognizesContextLengthExceededCode(t *testing.T) {
+	t.Parallel()
+
+	err := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    `{"error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"too many tokens"}}`,
+	}
+	if !isRequestInvalidError(err) {
+		t.Fatal("expected context_length_exceeded payload to be treated as invalid request")
+	}
+}
+
 func TestMarkResult_RequestInvalidErrorDoesNotCooldownAuth(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Production path set `OriginalRequest` to the same slice as `Payload`; `TranslateRequestPair` still translated twice. Treat shared storage as one request.
- Claude→Codex `defer_loading` strip no longer N× `sjson.DeleteBytes` on the full multi-MB body; delete only on each tool fragment.
- Prompt/context-length 400s classified as request-invalid so auth failover does not re-run multi-MB translation.
- XAI usage path uses bytes APIs to avoid `string(req.Payload)` when store-content is off.

## Test plan
- [x] `go test ./internal/runtime/executor/ ./sdk/cliproxy/auth/ ./internal/translator/codex/claude/ -count=1`
- [x] `go build -o /dev/null .`
- [x] `./scripts/ci-pr.sh` (full suite; `TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal` also fails on current `origin/dev` with `daily_usage cost total = 0.01, want 0.013` — unrelated to this PR)

## Context
Online 2G host peak RSS ~1.1GB under few concurrent multi-MB Claude/Codex/Grok requests after #745–#747. RCA: double translate + tool-loop full-body copies + possible auth failover on prompt-too-long + Go heap/THP sticky RSS.