### PR TITLE
fix: write usage_history_complete as bool for Postgres

### DIFF
--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -77,6 +77,34 @@ func TestResolveAuthSubjectIdentitySharesOnlyStableAccountID(t *testing.T) {
 	}
 }
 
+func TestUpsertAIAccountSubjectWritesBooleanHistoryComplete(t *testing.T) {
+	// Regression: PG column usage_history_complete is BOOLEAN; integer 0 fails SQLSTATE 42804
+	// and empties shared subject tables, which 500s /ai-accounts/status and blanks status-refresh job_id.
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "auth-bool", "acct-bool", "bool@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountSubject(identity); err != nil {
+		t.Fatalf("UpsertAIAccountSubject: %v", err)
+	}
+	var complete bool
+	if err := getDB().QueryRow(
+		`SELECT usage_history_complete FROM ai_account_subjects WHERE auth_subject_id = ?`,
+		identity.ID,
+	).Scan(&complete); err != nil {
+		t.Fatalf("scan usage_history_complete: %v", err)
+	}
+	if complete {
+		t.Fatalf("usage_history_complete = true, want false on insert")
+	}
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatalf("UpsertAIAccountTenantBinding: %v", err)
+	}
+	subjects, err := ListAIAccountSubjects([]string{identity.ID})
+	if err != nil || subjects[identity.ID].AuthSubjectID == "" {
+		t.Fatalf("subject missing after binding upsert: %+v err=%v", subjects, err)
+	}
+}
+
 func TestAIAccountTenantBindingsDeleteOneTenantOnly(t *testing.T) {
 	initSharedSubjectTestDB(t)
 	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "auth-a", "acct-bind", "a@example.com")

--- a/internal/usage/ai_account_subject_store.go
+++ b/internal/usage/ai_account_subject_store.go
@@ -222,11 +222,12 @@ func UpsertAIAccountSubject(identity *AuthSubjectIdentity) error {
 		return nil
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
+	// Use bool (not integer 0/1): Postgres column is BOOLEAN; integer literals fail with SQLSTATE 42804.
 	_, err := db.Exec(`
 		INSERT INTO ai_account_subjects (
 			auth_subject_id, provider, subject_scope, seed_kind, seed_hash,
 			share_eligible, usage_history_complete, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(auth_subject_id) DO UPDATE SET
 			provider = excluded.provider,
 			subject_scope = excluded.subject_scope,
@@ -235,7 +236,7 @@ func UpsertAIAccountSubject(identity *AuthSubjectIdentity) error {
 			share_eligible = excluded.share_eligible,
 			updated_at = excluded.updated_at
 	`, strings.TrimSpace(identity.ID), strings.TrimSpace(identity.Provider), identity.SubjectScope,
-		identity.SeedKind, identity.SeedHash, identity.ShareEligible, now, now)
+		identity.SeedKind, identity.SeedHash, identity.ShareEligible, false, now, now)
 	if err != nil {
 		return fmt.Errorf("usage: upsert ai account subject: %w", err)
 	}


### PR DESCRIPTION
## Summary
- AI 账号卡片全挂、`本周期 --`、前端 `invalid_status_refresh_job_id`。
- 根因：`UpsertAIAccountSubject` 往 PG `BOOLEAN` 列 `usage_history_complete` 写了整型 `0`（SQLSTATE 42804），共享 subject/binding 写不进 → `GET /ai-accounts/status` 500 → refresh 返回空 `job_id`。
- 修复：绑定参数改为 `false`；补回归测试。

## Test plan
- [x] `go test ./internal/usage/ -run 'TestUpsertAIAccountSubjectWritesBooleanHistoryComplete|TestAIAccountTenantBindings|TestRequestProjectionSharesUsage' -count=1`
- [x] `go test ./internal/management/aiaccountstatus/ -count=1`
- [ ] 合并部署后打开管理端 AI 账号页：卡片不再 500/报错，本周期可显示；status-refresh 有 job_id

## Deploy note
上线后首次打开页面会 reconcile binding 并 backfill 共享 status/usage/quota；无需手工 SQL。