### PR TITLE
fix: reject empty strings for PG timestamptz backfill

### DIFF
--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -128,9 +128,8 @@ func (s *Service) StartRefresh(tenantID string, req RefreshRequest) RefreshAccep
 	// Refresh boundary: allow stale cleanup without waiting for GET throttle alone.
 	s.maybeNormalizeStaleRefresh(tenantID)
 	auths := s.listAuths(tenantID)
-	if err := reconcileTenantBindings(auths); err != nil {
-		return RefreshAccepted{Skipped: []string{"binding_reconciliation_failed"}}
-	}
+	// Best-effort: still start refresh even if some legacy bindings fail to reconcile.
+	_ = reconcileTenantBindings(auths)
 	byIndex := make(map[string]*coreauth.Auth, len(auths))
 	bySubject := make(map[string]*coreauth.Auth, len(auths))
 	for _, auth := range auths {
@@ -730,9 +729,8 @@ func (s *Service) ListStatus(tenantID string, authIndexes, authSubjectIDs []stri
 	tenantID = strings.TrimSpace(tenantID)
 	s.maybeNormalizeStaleRefresh(tenantID)
 	auths := s.listAuths(tenantID)
-	if err := reconcileTenantBindings(auths); err != nil {
-		return StatusListResponse{}, err
-	}
+	// Binding reconcile is best-effort; never fail the read path for legacy write noise.
+	_ = reconcileTenantBindings(auths)
 	indexFilter := make(map[string]struct{})
 	for _, idx := range authIndexes {
 		if v := strings.TrimSpace(idx); v != "" {
@@ -971,6 +969,8 @@ func reconcileTenantBindings(auths []*coreauth.Auth) error {
 	for _, row := range rows {
 		byID[row.AuthID] = row
 	}
+	// Best-effort per auth: one bad legacy row must not 500 the whole status list.
+	var firstErr error
 	for _, auth := range auths {
 		if auth == nil {
 			continue
@@ -984,10 +984,12 @@ func reconcileTenantBindings(auths []*coreauth.Auth) error {
 			continue
 		}
 		if err := usage.UpsertAIAccountTenantBinding(auth, identity); err != nil {
-			return err
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func sanitizeMsg(msg string) string {

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -462,3 +462,21 @@ func TestFingerprintPolicyUsesSharedSubjectKeyAndTenantFallbackIsolation(t *test
 		t.Fatalf("tenant B fallback saw tenant A policy: %+v err=%v", fallbackBPolicy, err)
 	}
 }
+
+func TestNullableStoredTimeArgNeverReturnsEmptyString(t *testing.T) {
+	if got := nullableStoredTimeArg(""); got != nil {
+		t.Fatalf("empty -> %v, want nil", got)
+	}
+	if got := nullableStoredTimeArg("   "); got != nil {
+		t.Fatalf("blank -> %v, want nil", got)
+	}
+	if _, ok := requiredStoredTimeArg(""); ok {
+		t.Fatal("required empty should fail")
+	}
+	raw := "2026-07-20 16:01:43.169028+00"
+	got := nullableStoredTimeArg(raw)
+	s, ok := got.(string)
+	if !ok || s == "" {
+		t.Fatalf("parseable time -> %v", got)
+	}
+}

--- a/internal/usage/ai_account_subject_store.go
+++ b/internal/usage/ai_account_subject_store.go
@@ -704,6 +704,14 @@ func backfillSharedDailyUsageForSubject(db *sql.DB, subjectID string) error {
 		return err
 	}
 	for _, row := range batch {
+		firstValue := nullableStoredTimeArg(row.first)
+		updatedValue := nullableStoredTimeArg(row.updated)
+		if firstValue == nil {
+			firstValue = time.Now().UTC().Format(time.RFC3339Nano)
+		}
+		if updatedValue == nil {
+			updatedValue = firstValue
+		}
 		if _, err := db.Exec(`
 			INSERT INTO ai_account_subject_usage_buckets
 				(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
@@ -714,7 +722,7 @@ func backfillSharedDailyUsageForSubject(db *sql.DB, subjectID string) error {
 				failure_count = CASE WHEN excluded.failure_count > ai_account_subject_usage_buckets.failure_count THEN excluded.failure_count ELSE ai_account_subject_usage_buckets.failure_count END,
 				cost_total = CASE WHEN excluded.cost_total > ai_account_subject_usage_buckets.cost_total THEN excluded.cost_total ELSE ai_account_subject_usage_buckets.cost_total END,
 				updated_at = CASE WHEN excluded.updated_at > ai_account_subject_usage_buckets.updated_at THEN excluded.updated_at ELSE ai_account_subject_usage_buckets.updated_at END
-		`, subjectID, row.day, row.req, row.success, row.failure, row.cost, row.first, row.updated); err != nil {
+		`, subjectID, row.day, row.req, row.success, row.failure, row.cost, firstValue, updatedValue); err != nil {
 			return err
 		}
 	}
@@ -801,9 +809,13 @@ func backfillSharedQuotaCyclesForSubject(db *sql.DB, subjectID string) error {
 	}
 	cycleStarts := make(map[string]struct{}, len(batch))
 	for _, row := range batch {
-		startValue := canonicalAIAccountSubjectTime(row.start)
-		resetValue := canonicalAIAccountSubjectTime(row.reset)
-		verifiedValue := canonicalAIAccountSubjectTime(row.verified)
+		startValue, okStart := requiredStoredTimeArg(row.start)
+		resetValue, okReset := requiredStoredTimeArg(row.reset)
+		verifiedValue, okVerified := requiredStoredTimeArg(row.verified)
+		// Postgres rejects empty strings for timestamptz; skip unusable legacy rows.
+		if !okStart || !okReset || !okVerified {
+			continue
+		}
 		if _, err := db.Exec(`
 			INSERT INTO ai_account_subject_quota_cycles
 				(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
@@ -834,6 +846,28 @@ func canonicalAIAccountSubjectTime(value string) string {
 	return strings.TrimSpace(value)
 }
 
+// nullableStoredTimeArg returns a canonical RFC3339Nano string or nil (SQL NULL).
+// Never returns "" — Postgres timestamptz rejects empty strings (SQLSTATE 22007).
+func nullableStoredTimeArg(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if parsed, ok := parseStoredTimeString(value); ok {
+		return parsed.UTC().Format(time.RFC3339Nano)
+	}
+	return nil
+}
+
+func requiredStoredTimeArg(value string) (string, bool) {
+	arg := nullableStoredTimeArg(value)
+	if arg == nil {
+		return "", false
+	}
+	s, ok := arg.(string)
+	return s, ok && s != ""
+}
+
 // Current-cycle migration is intentionally estimated from the legacy daily
 // projection. It never scans request_logs, so the first partial day may be
 // conservative until the next full provider cycle starts.
@@ -857,8 +891,8 @@ func backfillSharedCycleUsageForSubject(db *sql.DB, subjectID, cycleStart string
 	if req == 0 {
 		return nil
 	}
-	updatedValue := canonicalAIAccountSubjectTime(updated.String)
-	if updatedValue == "" {
+	updatedValue := nullableStoredTimeArg(updated.String)
+	if updatedValue == nil {
 		updatedValue = cycleStart
 	}
 	_, err := db.Exec(`
@@ -908,9 +942,14 @@ func backfillSharedQuotaPointsForSubject(db *sql.DB, subjectID string) error {
 		if row.percent.Valid {
 			percentValue = row.percent.Float64
 		}
-		var resetValue any
-		if row.reset.Valid && strings.TrimSpace(row.reset.String) != "" {
-			resetValue = row.reset.String
+		// NULL, not "": PG timestamptz + COALESCE(reset_at, '') raises SQLSTATE 22007.
+		resetValue := nullableStoredTimeArg("")
+		if row.reset.Valid {
+			resetValue = nullableStoredTimeArg(row.reset.String)
+		}
+		recordedValue, okRecorded := requiredStoredTimeArg(row.recorded)
+		if !okRecorded {
+			continue
 		}
 		if _, err := db.Exec(`
 			INSERT INTO ai_account_subject_quota_points
@@ -920,11 +959,11 @@ func backfillSharedQuotaPointsForSubject(db *sql.DB, subjectID string) error {
 				SELECT 1 FROM ai_account_subject_quota_points
 				WHERE auth_subject_id = ? AND provider = ? AND quota_key = ? AND quota_label = ?
 				  AND COALESCE(percent, -1) = COALESCE(?, -1)
-				  AND COALESCE(reset_at, '') = COALESCE(?, '')
+				  AND ((reset_at IS NULL AND ? IS NULL) OR reset_at = ?)
 				  AND window_seconds = ? AND recorded_at = ?
 			)
-		`, subjectID, row.provider, row.key, row.label, percentValue, resetValue, row.window, row.recorded,
-			subjectID, row.provider, row.key, row.label, percentValue, resetValue, row.window, row.recorded); err != nil {
+		`, subjectID, row.provider, row.key, row.label, percentValue, resetValue, row.window, recordedValue,
+			subjectID, row.provider, row.key, row.label, percentValue, resetValue, resetValue, row.window, recordedValue); err != nil {
 			return err
 		}
 	}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -1008,7 +1008,17 @@ func parseStoredTimeString(value string) (time.Time, bool) {
 	if value == "" {
 		return time.Time{}, false
 	}
-	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+	// Include Postgres text forms of timestamptz (space separator, +00 / -07 offsets).
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999-07",
+		"2006-01-02 15:04:05Z07:00",
+		"2006-01-02 15:04:05-07",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
 		if parsed, err := time.Parse(layout, value); err == nil {
 			return parsed.UTC(), true
 		}


### PR DESCRIPTION
## Summary
- Follow-up to #754: after bool fix, reconcile still failed with `SQLSTATE 22007` empty timestamptz and some `23505` binding index collisions.
- Never bind `""` into timestamptz columns; parse PG text timestamps; make status list reconcile best-effort.

## Test plan
- [x] `go test ./internal/usage/ -run 'TestNullableStoredTimeArg|TestUpsertAIAccountSubject|TestAIAccountTenantBindings|TestRequestProjectionSharesUsage' -count=1`
- [x] `go test ./internal/management/aiaccountstatus/ -count=1`
- [ ] Deploy: open AI accounts cards — no 500, status-refresh returns job_id, 本周期 no longer stuck on reconcile errors