### PR TITLE
fix: share auth-file-trend cycle usage across tenants

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -941,6 +942,130 @@ func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 	}
 	if len(payload.QuotaSeries[0].Points) != 1 || payload.QuotaSeries[0].Points[0].Percent == nil || *payload.QuotaSeries[0].Points[0].Percent != 93 {
 		t.Fatalf("quota point = %+v, want one 93%% point", payload.QuotaSeries[0].Points)
+	}
+}
+
+func TestGetAuthFileTrendSharesCycleAcrossTenantsForStableAccountID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+		_ = os.Remove(dbPath + "-wal")
+		_ = os.Remove(dbPath + "-shm")
+	})
+
+	const (
+		tenantA = "11111111-1111-1111-1111-111111111111"
+		tenantB = "22222222-2222-2222-2222-222222222222"
+	)
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	authA, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex-shared-a",
+		TenantID: tenantA,
+		FileName: "a.json",
+		Provider: "codex",
+		Label:    "Shared A",
+		Metadata: map[string]any{"account_id": "acct-shared-trend", "email": "tyktgyk@gmail.com"},
+	})
+	if err != nil {
+		t.Fatalf("register auth A: %v", err)
+	}
+	authB, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "codex-shared-b",
+		TenantID: tenantB,
+		FileName: "b.json",
+		Provider: "codex",
+		Label:    "Shared B",
+		Metadata: map[string]any{"account_id": "acct-shared-trend", "email": "tyktgyk@gmail.com"},
+	})
+	if err != nil {
+		t.Fatalf("register auth B: %v", err)
+	}
+	identityA := usage.ResolveAuthSubjectIdentity(authA)
+	identityB := usage.ResolveAuthSubjectIdentity(authB)
+	if identityA == nil || identityB == nil || identityA.ID != identityB.ID || !identityA.ShareEligible {
+		t.Fatalf("expected shared subject, got A=%+v B=%+v", identityA, identityB)
+	}
+	if err := usage.UpsertAIAccountTenantBinding(authA, identityA); err != nil {
+		t.Fatal(err)
+	}
+	if err := usage.UpsertAIAccountTenantBinding(authB, identityB); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	resetAt := now.Add(4 * 24 * time.Hour)
+	cycleStart := resetAt.Add(-7 * 24 * time.Hour)
+	if err := usage.UpsertModelPricing("gpt-5.4", 1, 2, 0); err != nil {
+		t.Fatalf("UpsertModelPricing: %v", err)
+	}
+	// Cycle cache must exist before request projection writes cycle buckets.
+	remaining := 93.0
+	if err := usage.RecordQuotaSnapshotPointsIdentityForTenant(tenantA, authA.Index, identityA.ID, "codex", []usage.QuotaSnapshotPoint{{
+		RecordedAt: now, QuotaKey: "code_week", QuotaLabel: "Weekly",
+		Percent: &remaining, ResetAt: &resetAt, WindowSeconds: 604800,
+	}}); err != nil {
+		t.Fatalf("record quota: %v", err)
+	}
+	// Only tenant A has request logs; B must still see shared cycle totals.
+	usage.InsertLogWithDetailsIdentitySubject("sk-a", "", identityA.ID, "A", "gpt-5.4", "codex", "A", authA.Index, false, cycleStart.Add(time.Hour), 1, 1, usage.TokenStats{
+		InputTokens: 1000, OutputTokens: 2000, TotalTokens: 3000,
+	}, "", "", "")
+	usage.InsertLogWithDetailsIdentitySubject("sk-a", "", identityA.ID, "A", "gpt-5.4", "codex", "A", authA.Index, false, now, 1, 1, usage.TokenStats{
+		InputTokens: 1000, OutputTokens: 1000, TotalTokens: 2000,
+	}, "", "", "")
+
+	h := &Handler{cfg: &config.Config{}, authManager: manager}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set(managementPrincipalKey, identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantB}})
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/auth-file-trend?auth_index="+authB.Index+"&days=7&hours=5", nil)
+	h.UsageLogs().GetAuthFileTrend(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		CycleRequestTotal int64    `json:"cycle_request_total"`
+		CycleCostTotal    float64  `json:"cycle_cost_total"`
+		RequestTotal      int64    `json:"request_total"`
+		WeeklyQuotaUsed   *float64 `json:"weekly_quota_used_percent"`
+		CycleKnown        bool     `json:"cycle_known"`
+		CycleStart        string   `json:"cycle_start"`
+		QuotaSeries       []struct {
+			QuotaKey string `json:"quota_key"`
+			Points   []struct {
+				Percent *float64 `json:"percent"`
+			} `json:"points"`
+		} `json:"quota_series"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !payload.CycleKnown || payload.CycleRequestTotal != 2 {
+		t.Fatalf("tenant B cycle = known=%v total=%d, want 2 shared requests", payload.CycleKnown, payload.CycleRequestTotal)
+	}
+	if math.Abs(payload.CycleCostTotal-0.008) > 1e-12 {
+		t.Fatalf("tenant B cycle_cost_total=%v, want 0.008", payload.CycleCostTotal)
+	}
+	if payload.RequestTotal != 2 {
+		t.Fatalf("tenant B request_total=%d, want 2", payload.RequestTotal)
+	}
+	if payload.CycleStart != cycleStart.Format(time.RFC3339) {
+		t.Fatalf("cycle_start=%q want %q", payload.CycleStart, cycleStart.Format(time.RFC3339))
+	}
+	if payload.WeeklyQuotaUsed == nil || math.Abs(*payload.WeeklyQuotaUsed-7) > 1e-12 {
+		t.Fatalf("weekly_quota_used=%v, want 7", payload.WeeklyQuotaUsed)
+	}
+	if len(payload.QuotaSeries) != 1 || len(payload.QuotaSeries[0].Points) != 1 {
+		t.Fatalf("quota_series=%+v", payload.QuotaSeries)
 	}
 }
 

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -40,6 +40,150 @@ func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any
 	if auth == nil {
 		return http.StatusNotFound, map[string]any{"error": "auth not found"}
 	}
+	// Always compute tenant-private logs (legacy empty-subject rows + same-tenant traffic).
+	status, payload := s.authFileTrendFromTenantLogs(authIndex, auth, days, hours)
+	if status != http.StatusOK {
+		return status, payload
+	}
+	tenantTrend, ok := payload.(AuthFileTrendResponse)
+	if !ok {
+		return status, payload
+	}
+	identity := usage.ResolveAuthSubjectIdentity(auth)
+	if identity == nil || !identity.ShareEligible || identity.ID == "" {
+		return status, tenantTrend
+	}
+	// Overlay shared subject projection so other tenants see the same physical account.
+	sharedStatus, sharedPayload := s.authFileTrendFromSharedSubject(authIndex, auth, identity.ID, days, hours)
+	if sharedStatus != http.StatusOK {
+		return status, tenantTrend
+	}
+	sharedTrend, ok := sharedPayload.(AuthFileTrendResponse)
+	if !ok {
+		return status, tenantTrend
+	}
+	return http.StatusOK, mergeAuthFileTrendShared(tenantTrend, sharedTrend)
+}
+
+// mergeAuthFileTrendShared prefers shared subject totals when they exceed tenant-private
+// logs (cross-tenant traffic), keeps richer tenant counts for same-tenant legacy aliases,
+// and always prefers non-empty shared quota series.
+func mergeAuthFileTrendShared(tenant, shared AuthFileTrendResponse) AuthFileTrendResponse {
+	out := tenant
+	if shared.CycleRequestTotal > tenant.CycleRequestTotal ||
+		(shared.CycleRequestTotal == tenant.CycleRequestTotal && shared.CycleCostTotal > tenant.CycleCostTotal) ||
+		(tenant.CycleRequestTotal == 0 && shared.RequestTotal > tenant.RequestTotal) {
+		out.CycleRequestTotal = shared.CycleRequestTotal
+		out.CycleCostTotal = shared.CycleCostTotal
+		if shared.RequestTotal > tenant.RequestTotal {
+			out.RequestTotal = shared.RequestTotal
+		}
+		if sumDailyRequests(shared.DailyUsage) > sumDailyRequests(tenant.DailyUsage) {
+			out.DailyUsage = shared.DailyUsage
+		}
+	}
+	if shared.CycleKnown && shared.CycleStart != "" {
+		out.CycleKnown = true
+		out.CycleStart = shared.CycleStart
+	}
+	if len(shared.QuotaSeries) > 0 {
+		out.QuotaSeries = shared.QuotaSeries
+		if shared.WeeklyQuotaUsed != nil {
+			out.WeeklyQuotaUsed = shared.WeeklyQuotaUsed
+		}
+	}
+	// Shared tables have no hourly buckets; keep tenant hourly when present.
+	if sumHourlyRequests(tenant.HourlyUsage) == 0 && sumHourlyRequests(shared.HourlyUsage) > 0 {
+		out.HourlyUsage = shared.HourlyUsage
+	}
+	return out
+}
+
+func sumDailyRequests(points []usage.DailyUsagePoint) int64 {
+	var total int64
+	for _, p := range points {
+		total += p.Requests
+	}
+	return total
+}
+
+func sumHourlyRequests(points []usage.HourlyUsagePoint) int64 {
+	var total int64
+	for _, p := range points {
+		total += p.Requests
+	}
+	return total
+}
+
+func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreauth.Auth, subjectID string, days, hours int) (int, any) {
+	preferredWeeklyQuotaKeys := primaryWeeklyQuotaKeysForProvider(auth.Provider)
+	trendStart := time.Now().AddDate(0, 0, -7)
+	trendEnd := time.Now().Add(time.Minute)
+
+	dailyRaw, err := usage.QueryAIAccountSubjectDailyUsage(subjectID, days)
+	if err != nil {
+		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
+	}
+	daily := fillDailyUsagePoints(dailyRaw, days)
+	// No shared hourly buckets; avoid cross-tenant request_logs scans.
+	hourly := usage.EmptyHourlyUsageBuckets(hours)
+
+	series, err := usage.QueryAIAccountSubjectQuotaSeries(subjectID, trendStart, trendEnd)
+	if err != nil {
+		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
+	}
+	if series == nil {
+		series = []usage.QuotaSnapshotSeries{}
+	}
+	weeklyQuotaUsed := latestWeeklyQuotaUsedPercent(series, preferredWeeklyQuotaKeys...)
+
+	cycleStarts, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID}, preferredWeeklyQuotaKeys)
+	if err != nil {
+		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
+	}
+	cycleStart := cycleStarts[subjectID]
+	if cycleStart.IsZero() {
+		if weeklyCycleStart, ok := latestWeeklyQuotaCycleStart(series, preferredWeeklyQuotaKeys...); ok {
+			cycleStart = weeklyCycleStart
+		}
+	}
+
+	summaries, err := usage.QueryAIAccountSubjectUsageSummaries([]string{subjectID}, map[string]time.Time{subjectID: cycleStart})
+	if err != nil {
+		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
+	}
+	summary := summaries[subjectID]
+	requestTotal := summary.RequestTotal7d
+	if days >= 30 {
+		requestTotal = summary.RequestTotal30d
+	}
+	cycleKnown := !cycleStart.IsZero() || summary.CycleKnown
+	cycleRequestTotal := summary.CycleRequestTotal
+	cycleCostTotal := summary.CycleCostTotal
+	cycleStartStr := ""
+	if !cycleStart.IsZero() {
+		cycleStartStr = cycleStart.UTC().Format(time.RFC3339)
+	} else if summary.CycleStart != "" {
+		cycleStartStr = summary.CycleStart
+	}
+
+	return http.StatusOK, AuthFileTrendResponse{
+		AuthIndex:         authIndex,
+		Days:              days,
+		Hours:             hours,
+		RequestTotal:      requestTotal,
+		CycleRequestTotal: cycleRequestTotal,
+		CycleCostTotal:    cycleCostTotal,
+		WeeklyQuotaUsed:   weeklyQuotaUsed,
+		CycleKnown:        cycleKnown,
+		CycleStart:        cycleStartStr,
+		DailyUsage:        daily,
+		HourlyUsage:       hourly,
+		QuotaSeries:       series,
+	}
+}
+
+func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.Auth, days, hours int) (int, any) {
 	matcher := s.authSubjectMatcher(auth)
 	preferredWeeklyQuotaKeys := primaryWeeklyQuotaKeysForProvider(auth.Provider)
 

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -135,6 +135,70 @@ func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 	return nil
 }
 
+// QueryAIAccountSubjectQuotaSeries loads shared quota history for the detail trend chart.
+func QueryAIAccountSubjectQuotaSeries(authSubjectID string, start, end time.Time) ([]QuotaSnapshotSeries, error) {
+	db := getReadDB()
+	authSubjectID = strings.TrimSpace(authSubjectID)
+	if db == nil || authSubjectID == "" {
+		return []QuotaSnapshotSeries{}, nil
+	}
+	if start.IsZero() {
+		start = time.Now().AddDate(0, 0, -7)
+	}
+	if end.IsZero() {
+		end = time.Now()
+	}
+	rows, err := db.Query(`
+		SELECT recorded_at, provider, quota_key, quota_label, percent, reset_at, window_seconds
+		FROM ai_account_subject_quota_points
+		WHERE auth_subject_id = ? AND recorded_at >= ? AND recorded_at <= ?
+		ORDER BY recorded_at ASC, quota_key ASC
+	`, authSubjectID, start.UTC().Format(time.RFC3339Nano), end.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return nil, fmt.Errorf("usage: shared subject quota series: %w", err)
+	}
+	defer rows.Close()
+
+	series := make([]QuotaSnapshotSeries, 0)
+	indexByKey := make(map[string]int)
+	for rows.Next() {
+		var recorded storedTime
+		var provider, quotaKey, quotaLabel string
+		var percent sql.NullFloat64
+		var reset storedTime
+		var windowSeconds int64
+		if err := rows.Scan(&recorded, &provider, &quotaKey, &quotaLabel, &percent, &reset, &windowSeconds); err != nil {
+			return nil, err
+		}
+		if !recorded.Valid {
+			continue
+		}
+		seriesKey := fmt.Sprintf("%s\x00%d", quotaKey, windowSeconds)
+		idx, ok := indexByKey[seriesKey]
+		if !ok {
+			idx = len(series)
+			series = append(series, QuotaSnapshotSeries{
+				QuotaKey:      quotaKey,
+				QuotaLabel:    quotaLabel,
+				WindowSeconds: windowSeconds,
+				Points:        []QuotaSnapshotSeriesPoint{},
+			})
+			indexByKey[seriesKey] = idx
+		}
+		point := QuotaSnapshotSeriesPoint{Timestamp: recorded.Time}
+		if percent.Valid {
+			v := percent.Float64
+			point.Percent = &v
+		}
+		if reset.Valid {
+			t := reset.Time
+			point.ResetAt = &t
+		}
+		series[idx].Points = append(series[idx].Points, point)
+	}
+	return series, rows.Err()
+}
+
 func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferredKeys []string) (map[string]time.Time, error) {
 	db := getReadDB()
 	ids := dedupeExactStrings(subjectIDs)

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -98,6 +98,64 @@ func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed boo
 	return nil
 }
 
+// QueryAIAccountSubjectDailyUsage returns day buckets for one shared subject (no tenant filter).
+func QueryAIAccountSubjectDailyUsage(authSubjectID string, days int) ([]DailyUsagePoint, error) {
+	db := getReadDB()
+	authSubjectID = strings.TrimSpace(authSubjectID)
+	if db == nil || authSubjectID == "" {
+		return []DailyUsagePoint{}, nil
+	}
+	if days < 1 {
+		days = 7
+	}
+	loc := getUsageLocation()
+	start := time.Now().In(loc).AddDate(0, 0, -(days - 1)).Format("2006-01-02")
+	rows, err := db.Query(`
+		SELECT bucket_start, request_count, cost_total
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'day' AND bucket_start >= ?
+		ORDER BY bucket_start ASC
+	`, authSubjectID, start)
+	if err != nil {
+		return nil, fmt.Errorf("usage: shared subject daily usage: %w", err)
+	}
+	defer rows.Close()
+	out := make([]DailyUsagePoint, 0, days)
+	for rows.Next() {
+		var point DailyUsagePoint
+		if err := rows.Scan(&point.Date, &point.Requests, &point.Cost); err != nil {
+			return nil, err
+		}
+		point.Date = strings.TrimSpace(point.Date)
+		if point.Date == "" {
+			continue
+		}
+		out = append(out, point)
+	}
+	return out, rows.Err()
+}
+
+// EmptyHourlyUsageBuckets returns a zero-filled hourly window in the usage timezone.
+// Shared subject tables have day/cycle/lifetime only; detail charts use zeros for hours.
+func EmptyHourlyUsageBuckets(hours int) []HourlyUsagePoint {
+	if hours < 1 {
+		hours = 5
+	}
+	if hours > 24 {
+		hours = 24
+	}
+	loc := getUsageLocation()
+	now := time.Now().In(loc).Truncate(time.Hour)
+	start := now.Add(-time.Duration(hours-1) * time.Hour)
+	out := make([]HourlyUsagePoint, 0, hours)
+	for i := 0; i < hours; i++ {
+		out = append(out, HourlyUsagePoint{
+			Hour: start.Add(time.Duration(i) * time.Hour).Format("2006-01-02 15:00"),
+		})
+	}
+	return out
+}
+
 func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubject map[string]time.Time) (map[string]AuthSubjectUsageSummary, error) {
 	db := getReadDB()
 	ids := dedupeExactStrings(subjectIDs)
@@ -173,7 +231,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 		var requestTotal, successTotal, failureTotal int64
 		var costTotal float64
 		var first, updated, projected sql.NullString
-		var complete bool
+		var complete sql.NullBool
 		if err := lifeRows.Scan(&id, &requestTotal, &successTotal, &failureTotal, &costTotal, &first, &updated, &projected, &complete); err != nil {
 			lifeRows.Close()
 			return nil, err
@@ -193,7 +251,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 		if s.ProjectedSince == nil {
 			s.ProjectedSince = parseNullableTime(first)
 		}
-		s.HistoryComplete = complete
+		s.HistoryComplete = complete.Valid && complete.Bool
 		if t, ok := parseStoredTimeString(updated.String); ok && t.After(s.UpdatedAt) {
 			s.UpdatedAt = t
 		}

--- a/internal/usage/auth_subject_quota_store.go
+++ b/internal/usage/auth_subject_quota_store.go
@@ -211,6 +211,10 @@ func RecordQuotaSnapshotPointsIdentityForTenant(tenantID, authIndex, authSubject
 		return fmt.Errorf("usage: quota snapshot points commit: %w", err)
 	}
 	maybePruneQuotaSnapshots(tenantID)
+	// Dual-write shared subject quota so cross-tenant detail trend sees the same windows.
+	if authSubjectID != "" {
+		_ = RecordAIAccountSubjectQuotaPoints(authSubjectID, provider, points)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Detail modal `/usage/auth-file-trend` now overlays shared subject usage/quota projections for stable `account_id` accounts, so the same physical Codex account no longer shows zero cycle/quota in other tenants.
- Dual-write quota snapshot points into `ai_account_subject_quota_*`.
- Regression: tenant B sees tenant A shared cycle totals without local request logs.

## Test plan
- [x] `go test ./internal/usage/ ./internal/management/usagelogs/ -count=1`
- [x] `go test ./internal/api/handlers/management/ -run TestGetAuthFileTrend -count=1` (cross-tenant share pass; pre-existing daily cost flake on origin/dev remains)