### PR TITLE
fix: share auth-file-trend hourly chart across tenants

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -1039,7 +1039,12 @@ func TestGetAuthFileTrendSharesCycleAcrossTenantsForStableAccountID(t *testing.T
 		WeeklyQuotaUsed   *float64 `json:"weekly_quota_used_percent"`
 		CycleKnown        bool     `json:"cycle_known"`
 		CycleStart        string   `json:"cycle_start"`
-		QuotaSeries       []struct {
+		HourlyUsage       []struct {
+			Hour     string  `json:"hour"`
+			Requests int64   `json:"requests"`
+			Cost     float64 `json:"cost"`
+		} `json:"hourly_usage"`
+		QuotaSeries []struct {
 			QuotaKey string `json:"quota_key"`
 			Points   []struct {
 				Percent *float64 `json:"percent"`
@@ -1066,6 +1071,13 @@ func TestGetAuthFileTrendSharesCycleAcrossTenantsForStableAccountID(t *testing.T
 	}
 	if len(payload.QuotaSeries) != 1 || len(payload.QuotaSeries[0].Points) != 1 {
 		t.Fatalf("quota_series=%+v", payload.QuotaSeries)
+	}
+	var hourlyRequests int64
+	for _, point := range payload.HourlyUsage {
+		hourlyRequests += point.Requests
+	}
+	if hourlyRequests < 1 {
+		t.Fatalf("tenant B hourly_usage requests=%d, want shared recent hours from tenant A", hourlyRequests)
 	}
 }
 

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -92,8 +92,8 @@ func mergeAuthFileTrendShared(tenant, shared AuthFileTrendResponse) AuthFileTren
 			out.WeeklyQuotaUsed = shared.WeeklyQuotaUsed
 		}
 	}
-	// Shared tables have no hourly buckets; keep tenant hourly when present.
-	if sumHourlyRequests(tenant.HourlyUsage) == 0 && sumHourlyRequests(shared.HourlyUsage) > 0 {
+	// Prefer richer shared hourly (all tenants); keep tenant-only when shared empty.
+	if sumHourlyRequests(shared.HourlyUsage) > sumHourlyRequests(tenant.HourlyUsage) {
 		out.HourlyUsage = shared.HourlyUsage
 	}
 	return out
@@ -125,8 +125,14 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 	}
 	daily := fillDailyUsagePoints(dailyRaw, days)
-	// No shared hourly buckets; avoid cross-tenant request_logs scans.
-	hourly := usage.EmptyHourlyUsageBuckets(hours)
+	// Shared day buckets have no hour grain; aggregate recent hours by subject across tenants.
+	hourly, err := usage.QueryHourlyUsageByAuthSubjectAcrossTenants(usage.AuthSubjectMatcher{SubjectID: subjectID}, hours)
+	if err != nil {
+		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
+	}
+	if hourly == nil {
+		hourly = usage.EmptyHourlyUsageBuckets(hours)
+	}
 
 	series, err := usage.QueryAIAccountSubjectQuotaSeries(subjectID, trendStart, trendEnd)
 	if err != nil {

--- a/internal/usage/auth_subject_usage_query.go
+++ b/internal/usage/auth_subject_usage_query.go
@@ -91,7 +91,17 @@ func QueryHourlyUsageByAuthSubject(matcher AuthSubjectMatcher, hours int) ([]Hou
 }
 
 func QueryHourlyUsageByAuthSubjectForTenant(tenantID string, matcher AuthSubjectMatcher, hours int) ([]HourlyUsagePoint, error) {
-	tenantID = normalizeTenantID(tenantID)
+	return queryHourlyUsageByAuthSubject(normalizeTenantID(tenantID), matcher, hours, false)
+}
+
+// QueryHourlyUsageByAuthSubjectAcrossTenants aggregates the last N hours for one
+// physical account across all tenants. Only pass share-eligible subject matchers;
+// never use for tenant-scoped subjects or request-log list/detail.
+func QueryHourlyUsageByAuthSubjectAcrossTenants(matcher AuthSubjectMatcher, hours int) ([]HourlyUsagePoint, error) {
+	return queryHourlyUsageByAuthSubject("", matcher, hours, true)
+}
+
+func queryHourlyUsageByAuthSubject(tenantID string, matcher AuthSubjectMatcher, hours int, acrossTenants bool) ([]HourlyUsagePoint, error) {
 	db := getReadDB()
 	if db == nil {
 		return []HourlyUsagePoint{}, nil
@@ -101,6 +111,14 @@ func QueryHourlyUsageByAuthSubjectForTenant(tenantID string, matcher AuthSubject
 	}
 	if hours > 24 {
 		hours = 24
+	}
+	// Cross-tenant path must use stable subject id only (no email/index aliases).
+	if acrossTenants {
+		subjectID := strings.TrimSpace(matcher.SubjectID)
+		if subjectID == "" {
+			return EmptyHourlyUsageBuckets(hours), nil
+		}
+		matcher = AuthSubjectMatcher{SubjectID: subjectID}
 	}
 
 	matchSQL, matchArgs := buildAuthSubjectMatchClause(matcher, "source", "channel_name")
@@ -120,8 +138,17 @@ func QueryHourlyUsageByAuthSubjectForTenant(tenantID string, matcher AuthSubject
 	}
 
 	args := make([]interface{}, 0, len(matchArgs)+2)
-	args = append(args, tenantID, start.UTC().Format(time.RFC3339))
-	args = append(args, matchArgs...)
+	var where string
+	if acrossTenants {
+		args = append(args, start.UTC().Format(time.RFC3339))
+		args = append(args, matchArgs...)
+		// Narrow 5–24h scan by subject only; do not return bodies/content.
+		where = fmt.Sprintf(`timestamp >= ? AND (%s)`, matchSQL)
+	} else {
+		args = append(args, tenantID, start.UTC().Format(time.RFC3339))
+		args = append(args, matchArgs...)
+		where = fmt.Sprintf(`tenant_id = ? AND timestamp >= ? AND (%s)`, matchSQL)
+	}
 
 	// Keep a narrow row scan for hourly (≤24h). SQL strftime('localtime') follows
 	// process TZ, which can diverge from getUsageLocation() in tests and some
@@ -130,8 +157,8 @@ func QueryHourlyUsageByAuthSubjectForTenant(tenantID string, matcher AuthSubject
 	rows, err := db.Query(fmt.Sprintf(`
 		SELECT timestamp, cost
 		FROM request_logs
-		WHERE tenant_id = ? AND timestamp >= ? AND (%s)
-	`, matchSQL), args...)
+		WHERE %s
+	`, where), args...)
 	if err != nil {
 		return nil, fmt.Errorf("usage: hourly usage by auth subject query: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Secondary tenants already saw shared cycle totals, but the 5h chart stayed empty.
- Aggregate last N hours by `auth_subject_id` across tenants for share-eligible accounts only.
- Extend cross-tenant regression to assert non-zero shared hourly requests.

## Scope note
- **Identity fingerprint**: already shared (system catalog).
- **Fields tab**: proxy/label/disabled stay tenant-private by design; subscription probe fields come from shared status.
- **Models**: provider catalog, not per-account private config.

## Test plan
- [x] `go test ./internal/api/handlers/management/ -run TestGetAuthFileTrend -count=1` (share/cycle tests)
- [x] `go test ./internal/usage/ -run Hourly|AuthSubject -count=1`