### PR TITLE
fix: restore rolling 60s dashboard throughput at minute boundary

### DIFF
--- a/internal/usage/dashboard_trends_test.go
+++ b/internal/usage/dashboard_trends_test.go
@@ -178,10 +178,10 @@ func TestQueryDashboardThroughputLatestPointUsesRollingMinuteWindow(t *testing.T
 	if latest.Label != "15:05" {
 		t.Fatalf("latest label = %q, want 15:05", latest.Label)
 	}
-	// Throughput now uses minute rollup buckets (not sub-minute request_logs scan).
-	// At 15:05:05 the current minute bucket is still empty.
-	if latest.RPM != 0 || latest.TPM != 0 {
-		t.Fatalf("latest minute throughput = (%.0f, %.0f), want (0, 0)", latest.RPM, latest.TPM)
+	// Rolling last-60s window [15:04:05, 15:05:05] includes two 15:04 late requests,
+	// not the empty in-progress calendar minute 15:05.
+	if latest.RPM != 2 || latest.TPM != 300 {
+		t.Fatalf("latest rolling throughput = (%.0f, %.0f), want (2, 300)", latest.RPM, latest.TPM)
 	}
 
 	// Completed previous calendar minute reports full-minute rollup totals (3 requests).

--- a/internal/usage/request_log_dashboard.go
+++ b/internal/usage/request_log_dashboard.go
@@ -262,14 +262,12 @@ func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.
 		byKey[buckets[i].key] = &buckets[i]
 	}
 
-	// Completed minute points stay calendar-aligned; the latest point is filled
-	// from a rolling 60s window so the dashboard value does not drop to zero at
-	// each minute boundary.
+	// Completed minute points stay calendar-aligned via minute rollup.
+	// The latest point is a real rolling last-60s aggregate from request_logs so
+	// RPM/TPM do not drop to zero at each calendar-minute boundary (rollup alone
+	// only has the in-progress minute bucket, which is empty early in the minute).
 	windowStart := now.Add(-time.Minute)
 	start := now.Truncate(time.Minute).Add(-time.Duration(dashboardThroughputBucketCount-1) * time.Minute)
-	if windowStart.Before(start) {
-		start = windowStart
-	}
 
 	var (
 		rows *sql.Rows
@@ -302,11 +300,6 @@ func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.
 	}
 	defer rows.Close()
 
-	var (
-		windowRequests int64
-		windowTokens   int64
-	)
-	latestKey := now.Truncate(time.Minute).Format("2006-01-02 15:04")
 	for rows.Next() {
 		var bucketStart string
 		var requests, totalTokens int64
@@ -319,17 +312,15 @@ func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.
 			bucket.requests += requests
 			bucket.totalToken += totalTokens
 		}
-		// Approximate rolling last-minute window with the current minute bucket.
-		if key == latestKey {
-			windowRequests += requests
-			windowTokens += totalTokens
-		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("usage: iterate dashboard throughput rows: %w", err)
 	}
-	_ = windowStart
 
+	windowRequests, windowTokens, err := queryRollingThroughputWindow(db, tenantID, windowStart, now, allTenants)
+	if err != nil {
+		return nil, err
+	}
 	if len(buckets) > 0 {
 		// Replace the in-progress calendar minute with the rolling window so the
 		// rightmost chart point and headline RPM/TPM stay continuous.
@@ -338,6 +329,30 @@ func queryDashboardThroughputSeriesAt(tenantID string, now time.Time, loc *time.
 	}
 
 	return throughputSeriesFromBuckets(buckets), nil
+}
+
+// queryRollingThroughputWindow aggregates the last ~60s from request_logs.
+// Bounded timestamp range only — avoids the multi-day dashboard poll storm.
+func queryRollingThroughputWindow(db *sql.DB, tenantID string, windowStart, now time.Time, allTenants bool) (requests int64, totalTokens int64, err error) {
+	fromUTC := windowStart.UTC().Format(time.RFC3339Nano)
+	toUTC := now.UTC().Format(time.RFC3339Nano)
+	if allTenants {
+		err = db.QueryRow(`
+			SELECT COALESCE(COUNT(*), 0), COALESCE(SUM(total_tokens), 0)
+			FROM request_logs
+			WHERE timestamp >= ? AND timestamp <= ?
+		`, fromUTC, toUTC).Scan(&requests, &totalTokens)
+	} else {
+		err = db.QueryRow(`
+			SELECT COALESCE(COUNT(*), 0), COALESCE(SUM(total_tokens), 0)
+			FROM request_logs
+			WHERE tenant_id = ? AND timestamp >= ? AND timestamp <= ?
+		`, normalizeTenantID(tenantID), fromUTC, toUTC).Scan(&requests, &totalTokens)
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("usage: query rolling throughput window: %w", err)
+	}
+	return requests, totalTokens, nil
 }
 
 func dashboardTrendsFromBuckets(buckets []dashboardBucket) DashboardTrends {


### PR DESCRIPTION
## Summary
- Dashboard 吞吐图在整分钟边界（如 05:20）会把最新点画成 0，卡片 RPM/TPM 也显示 0。
- 根因：rollup 迁移后最新点只读「当前日历分钟」bucket，分钟初 bucket 为空。
- 修复：历史分钟仍走 `usage_rollup_buckets`；最新点改回 `request_logs` 上 **bounded 最近 60s** 聚合（不扫多日明细）。

## Test plan
- [x] `go test ./internal/usage/ -run 'TestQueryDashboardTrendsReturnsRecentMinuteThroughputBuckets|TestQueryDashboardThroughputLatestPointUsesRollingMinuteWindow|TestQueryDashboardTrendsReturnsFixedDailyBuckets'`
- [x] `go test ./internal/usage/ ./internal/api/handlers/management/ -run 'Dashboard|Throughput'`
- [ ] 合入 dev 后看 dashboard 在分钟切换时 RPM/TPM 不再归零