### PR TITLE
ci: speed up CliRelay PR checks

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -6,6 +6,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pr-test-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.26.1'
+  GOLANGCI_LINT_VERSION: v1.64.5
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -31,7 +39,23 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: ${{ env.GO_VERSION }}
           cache: true
+      # v1.64.5 release binaries were built with Go 1.24 and reject this repo's Go 1.26 target.
+      # Cache the fixed-version binary compiled by the configured toolchain instead.
+      - name: Cache golangci-lint
+        id: cache-golangci-lint
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/clirelay/golangci-lint/${{ env.GO_VERSION }}-${{ env.GOLANGCI_LINT_VERSION }}/golangci-lint
+          key: golangci-lint-${{ runner.os }}-${{ runner.arch }}-${{ env.GO_VERSION }}-${{ env.GOLANGCI_LINT_VERSION }}
+      - name: Install golangci-lint
+        if: steps.cache-golangci-lint.outputs.cache-hit != 'true'
+        run: |
+          tool_dir="$HOME/.cache/clirelay/golangci-lint/${GO_VERSION}-${GOLANGCI_LINT_VERSION}"
+          mkdir -p "$tool_dir"
+          GOBIN="$tool_dir" go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
       - name: PR checks
-        run: ./scripts/ci-pr.sh
+        run: |
+          export GOLANGCI_LINT_BIN="$HOME/.cache/clirelay/golangci-lint/${GO_VERSION}-${GOLANGCI_LINT_VERSION}/golangci-lint"
+          ./scripts/ci-pr.sh

--- a/scripts/ci-pr.sh
+++ b/scripts/ci-pr.sh
@@ -56,8 +56,32 @@ PY
 go vet ./...
 go test ./...
 
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
-"$(go env GOPATH)/bin/golangci-lint" run --config .golangci.yml
+required_golangci_lint_version="v1.64.5"
+golangci_lint_bin="${GOLANGCI_LINT_BIN:-}"
+if [ -z "${golangci_lint_bin}" ]; then
+  if command -v golangci-lint >/dev/null 2>&1; then
+    golangci_lint_bin="$(command -v golangci-lint)"
+  elif [ -x "$(go env GOPATH)/bin/golangci-lint" ]; then
+    golangci_lint_bin="$(go env GOPATH)/bin/golangci-lint"
+  else
+    echo "golangci-lint ${required_golangci_lint_version} is required." >&2
+    echo "Install it once with: go install github.com/golangci/golangci-lint/cmd/golangci-lint@${required_golangci_lint_version}" >&2
+    exit 1
+  fi
+fi
+
+if [ ! -x "${golangci_lint_bin}" ]; then
+  echo "golangci-lint is not executable: ${golangci_lint_bin}" >&2
+  exit 1
+fi
+
+golangci_lint_version="$("${golangci_lint_bin}" version)"
+if ! grep -Eq 'version v?1\.64\.5([[:space:]]|$)' <<<"${golangci_lint_version}"; then
+  echo "golangci-lint ${required_golangci_lint_version} is required; found: ${golangci_lint_version}" >&2
+  exit 1
+fi
+
+"${golangci_lint_bin}" run --config .golangci.yml
 
 trap 'rm -f test-output' EXIT
 go build -o test-output ./cmd/server


### PR DESCRIPTION
## Summary
- cancel superseded `pr-test-build` runs while preserving the required `build` job
- cache a Go 1.26.1-built `golangci-lint` v1.64.5 binary instead of compiling it on every run
- keep `scripts/ci-pr.sh` responsible for version-checked lint, vet, full tests, and build

The official v1.64.5 release binary cannot be used directly because it was built with Go 1.24 and rejects this repository's Go 1.26.1 target, so the workflow caches the fixed-version binary compiled by the configured toolchain.

## Validation
- `bash -n scripts/ci-pr.sh`
- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/pr-test-build.yml")'`
- `TZ=UTC ./scripts/ci-pr.sh` (passed; matches GitHub-hosted runner timezone)
- `"$(go env GOPATH)/bin/golangci-lint" run --config .golangci.yml`
- `go build -o <temporary-file> ./cmd/server`

## Local environment note
- `./scripts/ci-pr.sh` without `TZ=UTC` hit the existing date-sensitive `TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal` failure in the local Asia/Singapore timezone.
- The same targeted failure reproduced on the unchanged `dev` checkout, so it is not caused by this PR.

## Scope
- no Deploy workflow changes
- no E2E or required-check weakening
- no Docker changes
