### PR TITLE
feat: expose request log filter counts

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -389,10 +389,11 @@ func TestGetUsageLogs_EmptyDB_DoesNotReturnNullSlices(t *testing.T) {
 	var payload struct {
 		Items   []any `json:"items"`
 		Filters struct {
-			APIKeys     []string          `json:"api_keys"`
-			APIKeyNames map[string]string `json:"api_key_names"`
-			Models      []string          `json:"models"`
-			Channels    []string          `json:"channels"`
+			APIKeys      []string          `json:"api_keys"`
+			APIKeyNames  map[string]string `json:"api_key_names"`
+			APIKeyCounts map[string]int64  `json:"api_key_counts"`
+			Models       []string          `json:"models"`
+			Channels     []string          `json:"channels"`
 		} `json:"filters"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
@@ -413,6 +414,9 @@ func TestGetUsageLogs_EmptyDB_DoesNotReturnNullSlices(t *testing.T) {
 	}
 	if payload.Filters.APIKeyNames == nil {
 		t.Fatalf("filters.api_key_names is null; expected {}")
+	}
+	if payload.Filters.APIKeyCounts == nil {
+		t.Fatalf("filters.api_key_counts is null; expected {}")
 	}
 }
 
@@ -2228,8 +2232,9 @@ func TestGetPublicUsageLogs_FiltersByAPIKeyIDs(t *testing.T) {
 			APIKeyOwnName string `json:"api_key_own_name"`
 		} `json:"items"`
 		Filters struct {
-			APIKeyIDs     []string          `json:"api_key_ids"`
-			APIKeyIDNames map[string]string `json:"api_key_id_names"`
+			APIKeyIDs      []string          `json:"api_key_ids"`
+			APIKeyIDNames  map[string]string `json:"api_key_id_names"`
+			APIKeyIDCounts map[string]int64  `json:"api_key_id_counts"`
 		} `json:"filters"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
@@ -2249,5 +2254,8 @@ func TestGetPublicUsageLogs_FiltersByAPIKeyIDs(t *testing.T) {
 	}
 	if payload.Filters.APIKeyIDNames[keyBID] != "Automation" {
 		t.Fatalf("filters.api_key_id_names[%s] = %q, want Automation", keyBID, payload.Filters.APIKeyIDNames[keyBID])
+	}
+	if payload.Filters.APIKeyIDCounts[keyAID] != 1 || payload.Filters.APIKeyIDCounts[keyBID] != 1 {
+		t.Fatalf("filters.api_key_id_counts = %#v, want one request per owned key", payload.Filters.APIKeyIDCounts)
 	}
 }

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -76,6 +76,9 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	if filters.APIKeyNames == nil {
 		filters.APIKeyNames = make(map[string]string, len(filters.APIKeys))
 	}
+	if filters.APIKeyCounts == nil {
+		filters.APIKeyCounts = make(map[string]int64, len(filters.APIKeys))
+	}
 	// Prefer account display names already resolved by queryDistinctAPIKeys.
 	// Only fill gaps from keyNameMap; never overwrite end-user labels with key names.
 	for _, key := range filters.APIKeys {
@@ -117,6 +120,9 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	}
 	if filters.APIKeyNames == nil {
 		filters.APIKeyNames = make(map[string]string)
+	}
+	if filters.APIKeyCounts == nil {
+		filters.APIKeyCounts = make(map[string]int64)
 	}
 
 	return map[string]any{
@@ -199,10 +205,11 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		return nil, err
 	}
 	// Restrict public key facet options to keys owned by the lookup subject.
-	filters.APIKeyIDs, filters.APIKeyIDNames = filterPublicAPIKeyIDOptions(
+	filters.APIKeyIDs, filters.APIKeyIDNames, filters.APIKeyIDCounts = filterPublicAPIKeyIDOptions(
 		allowedKeyIDs,
 		filters.APIKeyIDs,
 		filters.APIKeyIDNames,
+		filters.APIKeyIDCounts,
 	)
 
 	apiKeyName := s.publicAPIKeyName(input.APIKey)
@@ -281,6 +288,9 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 	if filters.APIKeyIDNames == nil {
 		filters.APIKeyIDNames = make(map[string]string)
 	}
+	if filters.APIKeyIDCounts == nil {
+		filters.APIKeyIDCounts = make(map[string]int64)
+	}
 
 	return map[string]any{
 		"items":        result.Items,
@@ -290,12 +300,13 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		"stats":        stats,
 		"api_key_name": apiKeyName,
 		"filters": map[string]any{
-			"api_key_ids":      filters.APIKeyIDs,
-			"api_key_id_names": filters.APIKeyIDNames,
-			"models":           filters.Models,
-			"channels":         filters.Channels,
-			"channel_options":  filters.ChannelOptions,
-			"statuses":         filters.Statuses,
+			"api_key_ids":       filters.APIKeyIDs,
+			"api_key_id_names":  filters.APIKeyIDNames,
+			"api_key_id_counts": filters.APIKeyIDCounts,
+			"models":            filters.Models,
+			"channels":          filters.Channels,
+			"channel_options":   filters.ChannelOptions,
+			"statuses":          filters.Statuses,
 		},
 	}, nil
 }

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
 
@@ -535,5 +536,25 @@ func TestEnrichChannelFilterOptionsInfersProviderAuthTypeWithoutLiveMeta(t *test
 	orphanOpen := byValue["orphan-opencode"]
 	if orphanOpen.Provider != "opencode-go" || orphanOpen.AuthType != "api" {
 		t.Fatalf("orphan opencode = %#v, want opencode-go/api", orphanOpen)
+	}
+}
+
+func TestFilterPublicAPIKeyIDOptionsFiltersCountsWithNames(t *testing.T) {
+	allowed := map[string]struct{}{"key-a": {}, "key-b": {}}
+	ids, names, counts := filterPublicAPIKeyIDOptions(
+		allowed,
+		[]string{"key-a", "key-private", "key-b"},
+		map[string]string{"key-a": "Laptop", "key-private": "Hidden", "key-b": "Automation"},
+		map[string]int64{"key-a": 9, "key-private": 99, "key-b": 3},
+	)
+
+	if !slices.Equal(ids, []string{"key-a", "key-b"}) {
+		t.Fatalf("ids = %#v, want allowed ids only", ids)
+	}
+	if !reflect.DeepEqual(names, map[string]string{"key-a": "Laptop", "key-b": "Automation"}) {
+		t.Fatalf("names = %#v, want allowed names only", names)
+	}
+	if !reflect.DeepEqual(counts, map[string]int64{"key-a": 9, "key-b": 3}) {
+		t.Fatalf("counts = %#v, want allowed counts only", counts)
 	}
 }

--- a/internal/management/usagelogs/public_key_filter.go
+++ b/internal/management/usagelogs/public_key_filter.go
@@ -71,12 +71,14 @@ func filterPublicAPIKeyIDOptions(
 	allowed map[string]struct{},
 	ids []string,
 	names map[string]string,
-) ([]string, map[string]string) {
+	counts map[string]int64,
+) ([]string, map[string]string, map[string]int64) {
 	if len(allowed) == 0 {
-		return make([]string, 0), make(map[string]string)
+		return make([]string, 0), make(map[string]string), make(map[string]int64)
 	}
 	outIDs := make([]string, 0, len(ids))
 	outNames := make(map[string]string, len(ids))
+	outCounts := make(map[string]int64, len(ids))
 	for _, id := range ids {
 		id = strings.TrimSpace(id)
 		if id == "" {
@@ -89,6 +91,7 @@ func filterPublicAPIKeyIDOptions(
 		if name := strings.TrimSpace(names[id]); name != "" {
 			outNames[id] = name
 		}
+		outCounts[id] = counts[id]
 	}
-	return outIDs, outNames
+	return outIDs, outNames, outCounts
 }

--- a/internal/usage/request_log_account_filter.go
+++ b/internal/usage/request_log_account_filter.go
@@ -11,7 +11,7 @@ import (
 // queryDistinctAPIKeys returns one filter option per account (owned multi-key
 // end users collapse onto a representative secret + display name). Standalone
 // keys stay one option each so "测试 key" never sits next to "Kittors".
-func queryDistinctAPIKeys(db *sql.DB, params LogQueryParams) ([]string, map[string]string, error) {
+func queryDistinctAPIKeys(db *sql.DB, params LogQueryParams) ([]string, map[string]string, map[string]int64, error) {
 	tenantID := normalizeTenantID(params.TenantID)
 	currentByID := currentAPIKeyRowsByIDForTenant(tenantID)
 	currentByKey := currentAPIKeyRowsByKeyForTenant(tenantID)
@@ -30,7 +30,8 @@ func queryDistinctAPIKeys(db *sql.DB, params LogQueryParams) ([]string, map[stri
 			END AS logical_selector,
 			COALESCE(MAX(NULLIF(trim(coalesce(api_key_id, '')), '')), '') AS logical_id,
 			MAX(api_key) AS snapshot_key,
-			COALESCE(NULLIF(MAX(api_key_name), ''), '') AS snapshot_name
+			COALESCE(NULLIF(MAX(api_key_name), ''), '') AS snapshot_name,
+			COUNT(*) AS request_count
 		FROM request_logs
 		`+where+`
 		GROUP BY logical_selector
@@ -38,21 +39,23 @@ func queryDistinctAPIKeys(db *sql.DB, params LogQueryParams) ([]string, map[stri
 	`, args...)
 	if err != nil {
 		log.Warnf("usage: distinct api_key logical groups query failed: %v", err)
-		return nil, nil, fmt.Errorf("usage: distinct api_key logical groups: %w", err)
+		return nil, nil, nil, fmt.Errorf("usage: distinct api_key logical groups: %w", err)
 	}
 	defer rows.Close()
 
 	values := make([]string, 0)
 	names := make(map[string]string)
+	counts := make(map[string]int64)
 	seenAccount := make(map[string]struct{})
 	for rows.Next() {
 		var logicalSelector string
 		var logicalID sql.NullString
 		var snapshotKey string
 		var snapshotName string
-		if err := rows.Scan(&logicalSelector, &logicalID, &snapshotKey, &snapshotName); err != nil {
+		var requestCount int64
+		if err := rows.Scan(&logicalSelector, &logicalID, &snapshotKey, &snapshotName, &requestCount); err != nil {
 			log.Warnf("usage: distinct api_key scan failed: %v", err)
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		value := strings.TrimSpace(snapshotKey)
@@ -92,6 +95,9 @@ func queryDistinctAPIKeys(db *sql.DB, params LogQueryParams) ([]string, map[stri
 		if accountID != "" {
 			dedupeKey = "eu:" + accountID
 		}
+		// Legacy raw-key and stable-id groups can resolve to the same account.
+		// Sum before deduping so the UI count matches every retained log for that account.
+		counts[value] += requestCount
 		if _, ok := seenAccount[dedupeKey]; ok {
 			if name != "" && names[value] == "" {
 				names[value] = name
@@ -104,13 +110,13 @@ func queryDistinctAPIKeys(db *sql.DB, params LogQueryParams) ([]string, map[stri
 			names[value] = name
 		}
 	}
-	return values, names, rows.Err()
+	return values, names, counts, rows.Err()
 }
 
 // queryDistinctAPIKeyIDs returns one public-safe filter option per concrete key
 // (stable api_key_id + own name). Unlike queryDistinctAPIKeys it does not collapse
 // multi-key end-user accounts onto a representative secret.
-func queryDistinctAPIKeyIDs(db *sql.DB, params LogQueryParams) ([]string, map[string]string, error) {
+func queryDistinctAPIKeyIDs(db *sql.DB, params LogQueryParams) ([]string, map[string]string, map[string]int64, error) {
 	tenantID := normalizeTenantID(params.TenantID)
 	currentByID := currentAPIKeyRowsByIDForTenant(tenantID)
 	currentByKey := currentAPIKeyRowsByKeyForTenant(tenantID)
@@ -128,7 +134,8 @@ func queryDistinctAPIKeyIDs(db *sql.DB, params LogQueryParams) ([]string, map[st
 			END AS logical_selector,
 			COALESCE(MAX(NULLIF(trim(coalesce(api_key_id, '')), '')), '') AS logical_id,
 			MAX(api_key) AS snapshot_key,
-			COALESCE(NULLIF(MAX(api_key_name), ''), '') AS snapshot_name
+			COALESCE(NULLIF(MAX(api_key_name), ''), '') AS snapshot_name,
+			COUNT(*) AS request_count
 		FROM request_logs
 		`+where+`
 		GROUP BY logical_selector
@@ -136,21 +143,23 @@ func queryDistinctAPIKeyIDs(db *sql.DB, params LogQueryParams) ([]string, map[st
 	`, args...)
 	if err != nil {
 		log.Warnf("usage: distinct api_key_id logical groups query failed: %v", err)
-		return nil, nil, fmt.Errorf("usage: distinct api_key_id logical groups: %w", err)
+		return nil, nil, nil, fmt.Errorf("usage: distinct api_key_id logical groups: %w", err)
 	}
 	defer rows.Close()
 
 	values := make([]string, 0)
 	names := make(map[string]string)
+	counts := make(map[string]int64)
 	seen := make(map[string]struct{})
 	for rows.Next() {
 		var logicalSelector string
 		var logicalID sql.NullString
 		var snapshotKey string
 		var snapshotName string
-		if err := rows.Scan(&logicalSelector, &logicalID, &snapshotKey, &snapshotName); err != nil {
+		var requestCount int64
+		if err := rows.Scan(&logicalSelector, &logicalID, &snapshotKey, &snapshotName, &requestCount); err != nil {
 			log.Warnf("usage: distinct api_key_id scan failed: %v", err)
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		id := strings.TrimSpace(trimNullString(logicalID))
@@ -181,6 +190,8 @@ func queryDistinctAPIKeyIDs(db *sql.DB, params LogQueryParams) ([]string, map[st
 		if id == "" {
 			continue
 		}
+		// Stable-id and legacy raw-key groups can map to the same current key.
+		counts[id] += requestCount
 		if _, ok := seen[id]; ok {
 			if name != "" && names[id] == "" {
 				names[id] = name
@@ -193,7 +204,7 @@ func queryDistinctAPIKeyIDs(db *sql.DB, params LogQueryParams) ([]string, map[st
 			names[id] = name
 		}
 	}
-	return values, names, rows.Err()
+	return values, names, counts, rows.Err()
 }
 
 // accountFilterRepresentatives picks one filter value per end-user (prefer default key).

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -220,6 +220,10 @@ func QueryFiltersForLogs(params LogQueryParams) (FilterOptions, error) {
 		return FilterOptions{
 			APIKeys:        make([]string, 0),
 			APIKeyNames:    make(map[string]string),
+			APIKeyCounts:   make(map[string]int64),
+			APIKeyIDs:      make([]string, 0),
+			APIKeyIDNames:  make(map[string]string),
+			APIKeyIDCounts: make(map[string]int64),
 			Models:         make([]string, 0),
 			Channels:       make([]string, 0),
 			ChannelOptions: make([]ChannelFilterOption, 0),
@@ -228,12 +232,12 @@ func QueryFiltersForLogs(params LogQueryParams) (FilterOptions, error) {
 	}
 
 	params = normalizeLogQueryParams(params)
-	keys, keyNames, err := queryDistinctAPIKeys(db, params.withoutFacet("api_key"))
+	keys, keyNames, keyCounts, err := queryDistinctAPIKeys(db, params.withoutFacet("api_key"))
 	if err != nil {
 		log.Warnf("usage: query distinct api keys failed: %v", err)
 		return FilterOptions{}, err
 	}
-	keyIDs, keyIDNames, err := queryDistinctAPIKeyIDs(db, params.withoutFacet("api_key_id"))
+	keyIDs, keyIDNames, keyIDCounts, err := queryDistinctAPIKeyIDs(db, params.withoutFacet("api_key_id"))
 	if err != nil {
 		log.Warnf("usage: query distinct api key ids failed: %v", err)
 		return FilterOptions{}, err
@@ -275,8 +279,10 @@ func QueryFiltersForLogs(params LogQueryParams) (FilterOptions, error) {
 	return FilterOptions{
 		APIKeys:        keys,
 		APIKeyNames:    keyNames,
+		APIKeyCounts:   keyCounts,
 		APIKeyIDs:      keyIDs,
 		APIKeyIDNames:  keyIDNames,
+		APIKeyIDCounts: keyIDCounts,
 		Models:         models,
 		Channels:       channelNames,
 		ChannelOptions: channelRows,

--- a/internal/usage/request_log_types.go
+++ b/internal/usage/request_log_types.go
@@ -71,12 +71,14 @@ type LogQueryResult struct {
 
 // FilterOptions holds the available filter values for the UI.
 type FilterOptions struct {
-	APIKeys     []string          `json:"api_keys"`
-	APIKeyNames map[string]string `json:"api_key_names"`
-	// APIKeyIDs / APIKeyIDNames are public-safe key facets keyed by stable id.
-	APIKeyIDs     []string          `json:"api_key_ids,omitempty"`
-	APIKeyIDNames map[string]string `json:"api_key_id_names,omitempty"`
-	Models        []string          `json:"models"`
+	APIKeys      []string          `json:"api_keys"`
+	APIKeyNames  map[string]string `json:"api_key_names"`
+	APIKeyCounts map[string]int64  `json:"api_key_counts"`
+	// APIKeyIDs / APIKeyIDNames / APIKeyIDCounts are public-safe key facets keyed by stable id.
+	APIKeyIDs      []string          `json:"api_key_ids,omitempty"`
+	APIKeyIDNames  map[string]string `json:"api_key_id_names,omitempty"`
+	APIKeyIDCounts map[string]int64  `json:"api_key_id_counts,omitempty"`
+	Models         []string          `json:"models"`
 	// Channels is a legacy plain-name list kept for older clients.
 	// Prefer ChannelOptions when both are present.
 	Channels       []string              `json:"channels"`

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1827,6 +1827,9 @@ func TestQueryFiltersForLogsLinksFilterFacets(t *testing.T) {
 	if !slices.Equal(filters.APIKeys, []string{"sk-a", "sk-c"}) {
 		t.Fatalf("filters.APIKeys = %#v, want [sk-a sk-c]", filters.APIKeys)
 	}
+	if filters.APIKeyCounts["sk-a"] != 1 || filters.APIKeyCounts["sk-c"] != 1 {
+		t.Fatalf("filters.APIKeyCounts = %#v, want one matching request per key", filters.APIKeyCounts)
+	}
 	if !slices.Equal(filters.Channels, []string{"Anthropic", "OpenCode"}) {
 		t.Fatalf("filters.Channels = %#v, want [Anthropic OpenCode]", filters.Channels)
 	}
@@ -1938,6 +1941,12 @@ func TestQueryFiltersCollapsesOwnedKeysToOneAccountOption(t *testing.T) {
 	}
 	if filters.APIKeyNames["sk-kittors-default"] != "Kittors" {
 		t.Fatalf("filters.APIKeyNames[sk-kittors-default] = %q, want Kittors", filters.APIKeyNames["sk-kittors-default"])
+	}
+	if filters.APIKeyCounts["sk-kittors-default"] != 2 {
+		t.Fatalf("filters.APIKeyCounts[sk-kittors-default] = %d, want 2 account requests", filters.APIKeyCounts["sk-kittors-default"])
+	}
+	if filters.APIKeyCounts["sk-solo"] != 1 {
+		t.Fatalf("filters.APIKeyCounts[sk-solo] = %d, want 1", filters.APIKeyCounts["sk-solo"])
 	}
 	for _, name := range filters.APIKeyNames {
 		if name == "测试 key" {
@@ -2093,6 +2102,17 @@ func TestQueryAPIKeyDistributionMergesRawAndIDGroupsForSameKey(t *testing.T) {
 		t.Fatalf("UpsertAPIKey(other): %v", err)
 	}
 	InsertLogWithDetailsIdentity("sk-other", "other-id", "Other", "gpt-test", "source", "channel", "auth-2", false, now, 1, 1, TokenStats{TotalTokens: 5}, "", "", "")
+
+	filters, err := QueryFilters(7)
+	if err != nil {
+		t.Fatalf("QueryFilters() error = %v", err)
+	}
+	if filters.APIKeyCounts[rawKey] != 5 {
+		t.Fatalf("filters.APIKeyCounts[%s] = %d, want 5 merged requests", rawKey, filters.APIKeyCounts[rawKey])
+	}
+	if filters.APIKeyIDCounts[stableID] != 5 {
+		t.Fatalf("filters.APIKeyIDCounts[%s] = %d, want 5 merged requests", stableID, filters.APIKeyIDCounts[stableID])
+	}
 
 	dist, err := QueryAPIKeyDistribution(7)
 	if err != nil {


### PR DESCRIPTION
## Summary
- expose linked-facet request counts for management user filters
- expose public-safe per-key counts for API key lookup filters
- merge stable-id and legacy raw-key groups without double-listing, while preserving all retained request counts
- filter public names and counts through the same owned-key allowlist

## Validation
- `./scripts/ci-pr.sh`
- `go test ./internal/usage ./internal/management/usagelogs ./internal/api/handlers/management`
- targeted request-log facet and public API handler tests

## Scope
- CliRelay only
- additive response fields: `filters.api_key_counts` and `filters.api_key_id_counts`
- no database migration or persistent data changes