### PR TITLE
feat(enduser): persist daily spending reset history

### DIFF
--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -3,6 +3,7 @@ package management
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -82,6 +83,7 @@ func (h *Handler) GetEndUsers(c *gin.Context) {
 		byTenant[tid] = append(byTenant[tid], items[i].ID)
 	}
 	costs := map[string]float64{}
+	resetCounts := map[string]int{}
 	for tid, ids := range byTenant {
 		part, usageErr := usage.QueryTodayEffectiveCostsByEndUsersForTenant(tid, ids)
 		if usageErr != nil {
@@ -91,9 +93,18 @@ func (h *Handler) GetEndUsers(c *gin.Context) {
 		for id, used := range part {
 			costs[id] = used
 		}
+		countPart, usageErr := usage.ListEndUserDailySpendingResetEventCounts(tid, ids)
+		if usageErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": usageErr.Error()})
+			return
+		}
+		for id, count := range countPart {
+			resetCounts[id] = count
+		}
 	}
 	for i := range items {
 		items[i].DailySpendingUsed = costs[items[i].ID]
+		items[i].DailySpendingResetCount = resetCounts[items[i].ID]
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
 }
@@ -254,12 +265,97 @@ func (h *Handler) PostEndUserDailySpendingReset(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	actorKind := "service_credential"
+	actorUserID := ""
+	actorUsername := ""
+	if kind := strings.TrimSpace(principal.Kind); kind != "" {
+		actorKind = kind
+	}
+	actorUserID = strings.TrimSpace(principal.User.ID)
+	actorUsername = strings.TrimSpace(principal.User.Username)
+	if actorUsername == "" {
+		actorUsername = strings.TrimSpace(principal.User.DisplayName)
+	}
+	if err := usage.InsertEndUserDailySpendingResetEvent(usage.EndUserDailySpendingResetEvent{
+		TenantID:            tenantID,
+		EndUserID:           user.ID,
+		CostBaseline:        rawToday,
+		EffectiveUsedBefore: usedBefore,
+		RawTodayCost:        rawToday,
+		ActorUserID:         actorUserID,
+		ActorUsername:       actorUsername,
+		ActorKind:           actorKind,
+	}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	resetCount, err := usage.CountEndUserDailySpendingResetEvents(tenantID, user.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{
-		"status":                "ok",
-		"end_user_id":           user.ID,
-		"daily-spending-used":   0,
-		"effective-used-before": usedBefore,
-		"raw-today-cost":        rawToday,
+		"status":                     "ok",
+		"end_user_id":                user.ID,
+		"daily-spending-used":        0,
+		"daily-spending-reset-count": resetCount,
+		"effective-used-before":      usedBefore,
+		"raw-today-cost":             rawToday,
+	})
+}
+
+// GetEndUserDailySpendingResetHistory lists all-time manual reset events newest-first.
+func (h *Handler) GetEndUserDailySpendingResetHistory(c *gin.Context) {
+	principal, _ := principalFromContext(c)
+	if !principal.Has("end_users.read") && !principal.Has("end_users.write") && !principal.PlatformAdmin {
+		identityError(c, identity.ErrPermissionDenied)
+		return
+	}
+	svc := h.endUserService()
+	if svc == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "end user service unavailable"})
+		return
+	}
+	tenantID := effectiveTenantID(c)
+	user, err := svc.GetUser(c.Request.Context(), tenantID, c.Param("id"))
+	if err != nil {
+		endUserError(c, err)
+		return
+	}
+	limit := 100
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		if n, parseErr := strconv.Atoi(raw); parseErr == nil {
+			limit = n
+		}
+	}
+	events, err := usage.ListEndUserDailySpendingResetEvents(tenantID, user.ID, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if events == nil {
+		events = []usage.EndUserDailySpendingResetEvent{}
+	}
+	total, err := usage.CountEndUserDailySpendingResetEvents(tenantID, user.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	rawToday, err := usage.QueryRawTodayCostByEndUserForTenant(tenantID, user.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	used, err := usage.QueryTodayEffectiveCostByEndUserForTenant(tenantID, user.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"items":               events,
+		"total":               total,
+		"raw-today-cost":      rawToday,
+		"daily-spending-used": used,
 	})
 }
 

--- a/internal/api/handlers/management/end_user_daily_spending_reset_test.go
+++ b/internal/api/handlers/management/end_user_daily_spending_reset_test.go
@@ -1,0 +1,173 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func setupEndUserDailySpendingHandlerTest(t *testing.T) (*Handler, identity.Principal, string, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		enduser.SetDefault(nil)
+		usage.CloseDB()
+	})
+	db := usage.RuntimeDB()
+	if _, err := db.Exec(`
+		CREATE TABLE end_users (
+			id TEXT PRIMARY KEY,
+			tenant_id TEXT NOT NULL,
+			username TEXT NOT NULL,
+			username_normalized TEXT NOT NULL UNIQUE,
+			display_name TEXT NOT NULL,
+			password_hash TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active',
+			must_change_password INTEGER NOT NULL DEFAULT 0,
+			password_changed_at TIMESTAMP,
+			last_login_at TIMESTAMP,
+			failed_login_count INTEGER NOT NULL DEFAULT 0,
+			lock_stage INTEGER NOT NULL DEFAULT 0,
+			locked_until TIMESTAMP,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL,
+			version INTEGER NOT NULL DEFAULT 1,
+			permission_profile_id TEXT NOT NULL DEFAULT '',
+			daily_limit INTEGER NOT NULL DEFAULT 0,
+			total_quota INTEGER NOT NULL DEFAULT 0,
+			spending_limit REAL NOT NULL DEFAULT 0,
+			daily_spending_limit REAL NOT NULL DEFAULT 0,
+			concurrency_limit INTEGER NOT NULL DEFAULT 0,
+			rpm_limit INTEGER NOT NULL DEFAULT 0,
+			tpm_limit INTEGER NOT NULL DEFAULT 0,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			allowed_channels TEXT NOT NULL DEFAULT '[]',
+			allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+	tenantID := uuid.NewString()
+	endUserID := uuid.NewString()
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (
+			id, tenant_id, username, username_normalized, display_name, password_hash, created_at, updated_at
+		) VALUES (?, ?, 'alice', 'alice', 'Alice', 'unused', ?, ?)
+	`, endUserID, tenantID, now, now); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO usage_rollup_buckets (
+			tenant_id, bucket_kind, bucket_start, end_user_id, model, source, cost_total, updated_at
+		) VALUES (?, 'day', ?, ?, 'test-model', 'test', 12.5, ?)
+	`, tenantID, usage.LocalDayKeyAt(now), endUserID, now); err != nil {
+		t.Fatalf("insert end-user rollup: %v", err)
+	}
+	enduser.SetDefault(enduser.NewService(db))
+	principal := identity.Principal{
+		Kind: "user",
+		User: identity.User{
+			ID:          uuid.NewString(),
+			Username:    "admin",
+			DisplayName: "Admin",
+		},
+		EffectiveTenant: identity.Tenant{ID: tenantID},
+		Permissions: map[string]bool{
+			"end_users.read":  true,
+			"end_users.write": true,
+		},
+	}
+	return &Handler{}, principal, tenantID, endUserID
+}
+
+func TestEndUserDailySpendingResetWritesAndListsHistory(t *testing.T) {
+	h, principal, tenantID, endUserID := setupEndUserDailySpendingHandlerTest(t)
+
+	resetRecorder := httptest.NewRecorder()
+	resetContext, _ := gin.CreateTestContext(resetRecorder)
+	resetContext.Set(managementPrincipalKey, principal)
+	resetContext.Params = gin.Params{{Key: "id", Value: endUserID}}
+	resetContext.Request = httptest.NewRequest(http.MethodPost, "/v0/management/end-users/"+endUserID+"/daily-spending/reset", nil)
+	h.PostEndUserDailySpendingReset(resetContext)
+	if resetRecorder.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want %d; body=%s", resetRecorder.Code, http.StatusOK, resetRecorder.Body.String())
+	}
+	var resetBody struct {
+		ResetCount int     `json:"daily-spending-reset-count"`
+		UsedBefore float64 `json:"effective-used-before"`
+		RawToday   float64 `json:"raw-today-cost"`
+	}
+	if err := json.Unmarshal(resetRecorder.Body.Bytes(), &resetBody); err != nil {
+		t.Fatalf("decode reset response: %v", err)
+	}
+	if resetBody.ResetCount != 1 || resetBody.UsedBefore != 12.5 || resetBody.RawToday != 12.5 {
+		t.Fatalf("reset response = %#v, want count=1 used/raw=12.5", resetBody)
+	}
+	events, err := usage.ListEndUserDailySpendingResetEvents(tenantID, endUserID, 10)
+	if err != nil {
+		t.Fatalf("list persisted reset events: %v", err)
+	}
+	if len(events) != 1 || events[0].ActorUserID != principal.User.ID || events[0].ActorUsername != "admin" || events[0].ActorKind != "user" {
+		t.Fatalf("persisted events = %#v, want actor from principal", events)
+	}
+
+	writeOnly := principal
+	writeOnly.Permissions = map[string]bool{"end_users.write": true}
+	historyRecorder := httptest.NewRecorder()
+	historyContext, _ := gin.CreateTestContext(historyRecorder)
+	historyContext.Set(managementPrincipalKey, writeOnly)
+	historyContext.Params = gin.Params{{Key: "id", Value: endUserID}}
+	historyContext.Request = httptest.NewRequest(http.MethodGet, "/v0/management/end-users/"+endUserID+"/daily-spending/reset-history?limit=1", nil)
+	h.GetEndUserDailySpendingResetHistory(historyContext)
+	if historyRecorder.Code != http.StatusOK {
+		t.Fatalf("history status = %d, want %d; body=%s", historyRecorder.Code, http.StatusOK, historyRecorder.Body.String())
+	}
+	var historyBody struct {
+		Items             []usage.EndUserDailySpendingResetEvent `json:"items"`
+		Total             int                                    `json:"total"`
+		RawTodayCost      float64                                `json:"raw-today-cost"`
+		DailySpendingUsed float64                                `json:"daily-spending-used"`
+	}
+	if err := json.Unmarshal(historyRecorder.Body.Bytes(), &historyBody); err != nil {
+		t.Fatalf("decode history response: %v", err)
+	}
+	if historyBody.Total != 1 || len(historyBody.Items) != 1 || historyBody.RawTodayCost != 12.5 || historyBody.DailySpendingUsed != 0 {
+		t.Fatalf("history response = %#v, want total/items=1 raw=12.5 used=0", historyBody)
+	}
+	if historyBody.Items[0].EffectiveUsedBefore != 12.5 || historyBody.Items[0].RawTodayCost != 12.5 {
+		t.Fatalf("history item = %#v, want reset costs 12.5", historyBody.Items[0])
+	}
+
+	listRecorder := httptest.NewRecorder()
+	listContext, _ := gin.CreateTestContext(listRecorder)
+	listContext.Set(managementPrincipalKey, principal)
+	listContext.Request = httptest.NewRequest(http.MethodGet, "/v0/management/end-users", nil)
+	h.GetEndUsers(listContext)
+	if listRecorder.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want %d; body=%s", listRecorder.Code, http.StatusOK, listRecorder.Body.String())
+	}
+	var listBody struct {
+		Items []enduser.User `json:"items"`
+	}
+	if err := json.Unmarshal(listRecorder.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listBody.Items) != 1 || listBody.Items[0].DailySpendingResetCount != 1 || listBody.Items[0].DailySpendingUsed != 0 {
+		t.Fatalf("end-user list = %#v, want reset count=1 used=0", listBody.Items)
+	}
+}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -428,7 +428,7 @@ func (h *Handler) authenticateSessionToken(c *gin.Context, token string) bool {
 		return false
 	}
 	permission := permissionForManagementRequest(c.Request.Method, c.Request.URL.Path)
-	if permission == "" || !principal.Has(permission) {
+	if !principalHasManagementRequestPermission(principal, c.Request.Method, c.Request.URL.Path, permission) {
 		h.recordManagementAudit(c, principal, "denied")
 		identityError(c, identity.ErrPermissionDenied)
 		return false

--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -28,6 +28,7 @@ func TestPermissionForManagementRequest(t *testing.T) {
 		{http.MethodPut, "/v0/management/roles/r/users", "tenant.users.assign_roles"},
 		{http.MethodPatch, "/v0/management/end-users/eu/api-keys/key", "api_keys.write"},
 		{http.MethodPost, "/v0/management/end-users/eu/api-keys/key/rotate", "api_keys.write"},
+		{http.MethodGet, "/v0/management/end-users/eu/daily-spending/reset-history", "end_users.read"},
 		{http.MethodGet, "/v0/management/menus", "platform.menus.read"},
 		{http.MethodPost, "/v0/management/menus", "platform.menus.update"},
 		{http.MethodPatch, "/v0/management/menus/system.config", "platform.menus.update"},
@@ -72,6 +73,23 @@ func TestPermissionForManagementRequest(t *testing.T) {
 		if got := permissionForManagementRequest(test.method, test.path); got != test.want {
 			t.Errorf("permissionForManagementRequest(%s,%s)=%q want %q", test.method, test.path, got, test.want)
 		}
+	}
+}
+
+func TestEndUserResetHistoryPermissionAllowsReadOrWrite(t *testing.T) {
+	path := "/v0/management/end-users/eu/daily-spending/reset-history"
+	permission := permissionForManagementRequest(http.MethodGet, path)
+	for _, permissions := range []map[string]bool{
+		{"end_users.read": true},
+		{"end_users.write": true},
+	} {
+		principal := identity.Principal{Permissions: permissions}
+		if !principalHasManagementRequestPermission(principal, http.MethodGet, path, permission) {
+			t.Fatalf("permissions %#v should allow reset history", permissions)
+		}
+	}
+	if principalHasManagementRequestPermission(identity.Principal{}, http.MethodGet, path, permission) {
+		t.Fatal("principal without end-user permissions should not allow reset history")
 	}
 }
 

--- a/internal/api/handlers/management/route_permissions.go
+++ b/internal/api/handlers/management/route_permissions.go
@@ -3,6 +3,8 @@ package management
 import (
 	"net/http"
 	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 )
 
 // ManagementRequestPermission returns the RBAC permission for a management
@@ -10,6 +12,17 @@ import (
 // Exported so package routes can assert every registered route is mapped.
 func ManagementRequestPermission(method, path string) string {
 	return permissionForManagementRequest(method, path)
+}
+
+func principalHasManagementRequestPermission(principal identity.Principal, method, path, permission string) bool {
+	if permission != "" && principal.Has(permission) {
+		return true
+	}
+	relative := strings.TrimSuffix(strings.TrimPrefix(path, "/v0/management"), "/")
+	return (method == http.MethodGet || method == http.MethodHead) &&
+		strings.HasPrefix(relative, "/end-users/") &&
+		strings.HasSuffix(relative, "/daily-spending/reset-history") &&
+		principal.Has("end_users.write")
 }
 
 // permissionForManagementRequest maps a management HTTP method+path to a

--- a/internal/api/routes/management_identity_routes.go
+++ b/internal/api/routes/management_identity_routes.go
@@ -54,6 +54,7 @@ func registerManagementIdentityRoutes(group *gin.RouterGroup, h *managementhandl
 	group.DELETE("/end-users/:id", h.DeleteEndUser)
 	group.POST("/end-users/:id/reset-password", h.PostEndUserResetPassword)
 	group.POST("/end-users/:id/daily-spending/reset", h.PostEndUserDailySpendingReset)
+	group.GET("/end-users/:id/daily-spending/reset-history", h.GetEndUserDailySpendingResetHistory)
 	group.GET("/end-users/:id/api-keys", h.GetEndUserAPIKeys)
 	group.POST("/end-users/:id/api-keys", h.PostEndUserAPIKey)
 	group.PATCH("/end-users/:id/api-keys/:key_id", h.PatchEndUserAPIKey)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 292; got != want {
+	if got, want := len(routes), 293; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -45,6 +45,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"POST /v0/management/ai-accounts/status-refresh",
 		"POST /v0/management/api-call",
 		"PATCH /v0/management/api-key-entries",
+		"GET /v0/management/end-users/:id/daily-spending/reset-history",
 		"POST /v0/management/opencode-go-api-key/usage",
 		"GET /v0/management/cline-api-key",
 		"PUT /v0/management/cline-api-key",
@@ -216,6 +217,7 @@ func expectedManagementRoutes() []string {
 		"DELETE /v0/management/end-users/:id",
 		"POST /v0/management/end-users/:id/reset-password",
 		"POST /v0/management/end-users/:id/daily-spending/reset",
+		"GET /v0/management/end-users/:id/daily-spending/reset-history",
 		"GET /v0/management/end-users/:id/api-keys",
 		"POST /v0/management/end-users/:id/api-keys",
 		"PATCH /v0/management/end-users/:id/api-keys/:key_id",

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -792,6 +792,16 @@ func (s *Service) DeleteUser(ctx context.Context, actor identity.Principal, tena
 	`, userID); err != nil {
 		return err
 	}
+	if _, err = tx.ExecContext(ctx, `
+		DELETE FROM end_user_daily_spending_resets WHERE tenant_id = ? AND end_user_id = ?
+	`, tenantID, userID); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, `
+		DELETE FROM end_user_daily_spending_reset_events WHERE tenant_id = ? AND end_user_id = ?
+	`, tenantID, userID); err != nil {
+		return err
+	}
 	res, err := tx.ExecContext(ctx, `DELETE FROM end_users WHERE id = ? AND tenant_id = ?`, userID, tenantID)
 	if err != nil {
 		return err

--- a/internal/enduser/types.go
+++ b/internal/enduser/types.go
@@ -20,6 +20,8 @@ type User struct {
 	APIKeyCount int `json:"api_key_count,omitempty"`
 	// DailySpendingUsed is the account-level effective spend for the current project day.
 	DailySpendingUsed float64 `json:"daily-spending-used"`
+	// DailySpendingResetCount is the number of persisted manual reset events.
+	DailySpendingResetCount int `json:"daily-spending-reset-count"`
 
 	// Account-level quota/permissions: shared by every API key under this user.
 	PermissionProfileID  string   `json:"permission-profile-id,omitempty"`

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -33,6 +33,8 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607200001_usage_rollup_buckets", SQL: usageRollupBucketsSQL},
 		// Shared physical AI-account subjects; credentials remain tenant-private bindings.
 		{Version: "202607200002_ai_account_shared_subjects", SQL: aiAccountSharedSubjectsSQL},
+		// Append-only history of manual account-level daily spending resets.
+		{Version: "202607210001_end_user_daily_spending_reset_events", SQL: endUserDailySpendingResetEventsSQL},
 	}
 }
 
@@ -104,6 +106,25 @@ CREATE TABLE IF NOT EXISTS end_user_daily_spending_resets (
 );
 CREATE INDEX IF NOT EXISTS idx_end_user_daily_spending_resets_day
   ON end_user_daily_spending_resets(tenant_id, day_key);
+`
+
+// BIGSERIAL for PG; SQLite bootstrap uses INTEGER PRIMARY KEY AUTOINCREMENT.
+const endUserDailySpendingResetEventsSQL = `
+CREATE TABLE IF NOT EXISTS end_user_daily_spending_reset_events (
+  id                     BIGSERIAL PRIMARY KEY,
+  tenant_id              UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+  end_user_id            UUID NOT NULL,
+  day_key                TEXT NOT NULL DEFAULT '',
+  reset_at               TIMESTAMPTZ NOT NULL,
+  actor_user_id          TEXT NOT NULL DEFAULT '',
+  actor_username         TEXT NOT NULL DEFAULT '',
+  actor_kind             TEXT NOT NULL DEFAULT '',
+  cost_baseline          DOUBLE PRECISION NOT NULL DEFAULT 0,
+  effective_used_before  DOUBLE PRECISION NOT NULL DEFAULT 0,
+  raw_today_cost         DOUBLE PRECISION NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_end_user_daily_spending_reset_events_user
+  ON end_user_daily_spending_reset_events(tenant_id, end_user_id, reset_at DESC);
 `
 
 // Quota + permission template live on end_users so multiple keys share one pool.

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -7,10 +7,22 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 20 {
-		t.Fatalf("RuntimeMigrations len = %d, want 20", len(migrations))
+	if len(migrations) != 21 {
+		t.Fatalf("RuntimeMigrations len = %d, want 21", len(migrations))
 	}
-	// Latest: usage rollup buckets for stats/limits isolation from request_logs.
+	// Latest: append-only account-level daily spending reset history.
+	endUserResetEventsSQL := migrations[20].SQL
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS end_user_daily_spending_reset_events",
+		"effective_used_before",
+		"raw_today_cost",
+		"actor_username",
+	} {
+		if !strings.Contains(endUserResetEventsSQL, fragment) {
+			t.Fatalf("end-user daily spending reset events migration missing %q", fragment)
+		}
+	}
+	// Prior: usage rollup buckets for stats/limits isolation from request_logs.
 	rollupSQL := migrations[18].SQL
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS usage_rollup_buckets",

--- a/internal/usage/enduser_account_usage_test.go
+++ b/internal/usage/enduser_account_usage_test.go
@@ -231,3 +231,88 @@ func containsString(values []string, want string) bool {
 	}
 	return false
 }
+
+func TestEndUserDailySpendingResetEventHistory(t *testing.T) {
+	setupEndUserAccountUsageTestDB(t)
+
+	tenantID := uuid.NewString()
+	endUserID := uuid.NewString()
+	otherUserID := uuid.NewString()
+	firstAt := time.Date(2026, time.July, 20, 8, 0, 0, 0, time.UTC)
+	secondAt := firstAt.Add(2 * time.Hour)
+	if err := InsertEndUserDailySpendingResetEvent(EndUserDailySpendingResetEvent{
+		TenantID:            tenantID,
+		EndUserID:           endUserID,
+		DayKey:              "2026-07-20",
+		ResetAt:             firstAt,
+		ActorUserID:         "actor-1",
+		ActorUsername:       "admin",
+		ActorKind:           "user",
+		CostBaseline:        12,
+		EffectiveUsedBefore: 7,
+		RawTodayCost:        12,
+	}); err != nil {
+		t.Fatalf("insert first event: %v", err)
+	}
+	if err := InsertEndUserDailySpendingResetEvent(EndUserDailySpendingResetEvent{
+		TenantID:            tenantID,
+		EndUserID:           endUserID,
+		DayKey:              "2026-07-20",
+		ResetAt:             secondAt,
+		EffectiveUsedBefore: 3,
+		RawTodayCost:        15,
+		CostBaseline:        15,
+	}); err != nil {
+		t.Fatalf("insert second event: %v", err)
+	}
+	if err := InsertEndUserDailySpendingResetEvent(EndUserDailySpendingResetEvent{
+		TenantID:  tenantID,
+		EndUserID: otherUserID,
+		ResetAt:   secondAt,
+	}); err != nil {
+		t.Fatalf("insert other-user event: %v", err)
+	}
+
+	count, err := CountEndUserDailySpendingResetEvents(tenantID, endUserID)
+	if err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count = %d, want 2", count)
+	}
+	counts, err := ListEndUserDailySpendingResetEventCounts(tenantID, []string{endUserID, otherUserID, "missing", endUserID})
+	if err != nil {
+		t.Fatalf("list counts: %v", err)
+	}
+	if counts[endUserID] != 2 || counts[otherUserID] != 1 || counts["missing"] != 0 {
+		t.Fatalf("counts = %#v, want user=2 other=1 missing=0", counts)
+	}
+
+	events, err := ListEndUserDailySpendingResetEvents(tenantID, endUserID, 1)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 || events[0].ResetAt.UnixNano() != secondAt.UnixNano() || events[0].RawTodayCost != 15 {
+		t.Fatalf("events = %#v, want newest second event", events)
+	}
+
+	if err := DeleteEndUserDailySpendingResetEvents(tenantID, endUserID); err != nil {
+		t.Fatalf("delete events: %v", err)
+	}
+	count, err = CountEndUserDailySpendingResetEvents(tenantID, endUserID)
+	if err != nil {
+		t.Fatalf("count after delete: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("count after delete = %d, want 0", count)
+	}
+}
+
+func TestEnsureEndUserDailySpendingResetEventsTableSQLHasNoDATETIME(t *testing.T) {
+	if strings.Contains(strings.ToUpper(endUserDailySpendingResetEventsTableSQL), "DATETIME") {
+		t.Fatalf("bootstrap SQL must not use DATETIME: %s", endUserDailySpendingResetEventsTableSQL)
+	}
+	if !strings.Contains(strings.ToUpper(endUserDailySpendingResetEventsTableSQL), "TIMESTAMP") {
+		t.Fatalf("bootstrap SQL should use TIMESTAMP: %s", endUserDailySpendingResetEventsTableSQL)
+	}
+}

--- a/internal/usage/enduser_daily_spending_reset_history.go
+++ b/internal/usage/enduser_daily_spending_reset_history.go
@@ -1,0 +1,254 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EndUserDailySpendingResetEvent is one manual account-level daily-spending reset action.
+type EndUserDailySpendingResetEvent struct {
+	ID            int64     `json:"id"`
+	TenantID      string    `json:"tenant_id"`
+	EndUserID     string    `json:"end_user_id"`
+	DayKey        string    `json:"day_key"`
+	ResetAt       time.Time `json:"reset_at"`
+	ActorUserID   string    `json:"actor_user_id,omitempty"`
+	ActorUsername string    `json:"actor_username,omitempty"`
+	ActorKind     string    `json:"actor_kind,omitempty"`
+	// CostBaseline is raw today cost at reset time.
+	CostBaseline float64 `json:"cost_baseline"`
+	// EffectiveUsedBefore is the effective daily used amount cleared by this reset.
+	EffectiveUsedBefore float64 `json:"effective_used_before"`
+	// RawTodayCost is the true project-day spend (no baseline) at reset time.
+	RawTodayCost float64 `json:"raw_today_cost"`
+}
+
+// TIMESTAMP for SQLite affinity + PG bootstrap compatibility (same as baseline table).
+const endUserDailySpendingResetEventsTableSQL = `
+CREATE TABLE IF NOT EXISTS end_user_daily_spending_reset_events (
+  id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+  tenant_id              TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+  end_user_id            TEXT NOT NULL,
+  day_key                TEXT NOT NULL DEFAULT '',
+  reset_at               TIMESTAMP NOT NULL,
+  actor_user_id          TEXT NOT NULL DEFAULT '',
+  actor_username         TEXT NOT NULL DEFAULT '',
+  actor_kind             TEXT NOT NULL DEFAULT '',
+  cost_baseline          REAL NOT NULL DEFAULT 0,
+  effective_used_before  REAL NOT NULL DEFAULT 0,
+  raw_today_cost         REAL NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_end_user_daily_spending_reset_events_user
+  ON end_user_daily_spending_reset_events(tenant_id, end_user_id, reset_at DESC);
+`
+
+func ensureEndUserDailySpendingResetEventsTable(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	if _, err := db.Exec(endUserDailySpendingResetEventsTableSQL); err != nil {
+		return fmt.Errorf("usage: ensure end_user_daily_spending_reset_events: %w", err)
+	}
+	return nil
+}
+
+func bootstrapEndUserDailySpendingResetEvents(db *sql.DB) error {
+	return ensureEndUserDailySpendingResetEventsTable(db)
+}
+
+// InsertEndUserDailySpendingResetEvent appends one reset history row.
+func InsertEndUserDailySpendingResetEvent(ev EndUserDailySpendingResetEvent) error {
+	db := getDB()
+	if db == nil {
+		return fmt.Errorf("usage: database not initialised")
+	}
+	tenantID := normalizeTenantID(ev.TenantID)
+	endUserID := strings.TrimSpace(ev.EndUserID)
+	if endUserID == "" {
+		return fmt.Errorf("usage: end_user_id is required")
+	}
+	resetAt := ev.ResetAt
+	if resetAt.IsZero() {
+		resetAt = time.Now().UTC()
+	}
+	dayKey := strings.TrimSpace(ev.DayKey)
+	if dayKey == "" {
+		dayKey = LocalDayKeyAt(resetAt)
+	}
+	baseline := ev.CostBaseline
+	if baseline < 0 {
+		baseline = 0
+	}
+	usedBefore := ev.EffectiveUsedBefore
+	if usedBefore < 0 {
+		usedBefore = 0
+	}
+	raw := ev.RawTodayCost
+	if raw < 0 {
+		raw = 0
+	}
+	_, err := db.Exec(
+		`INSERT INTO end_user_daily_spending_reset_events
+		 (tenant_id, end_user_id, day_key, reset_at, actor_user_id, actor_username, actor_kind,
+		  cost_baseline, effective_used_before, raw_today_cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		tenantID, endUserID, dayKey, resetAt.UTC().Format(time.RFC3339Nano),
+		strings.TrimSpace(ev.ActorUserID), strings.TrimSpace(ev.ActorUsername), strings.TrimSpace(ev.ActorKind),
+		baseline, usedBefore, raw,
+	)
+	if err != nil {
+		return fmt.Errorf("usage: insert end-user daily spending reset event: %w", err)
+	}
+	return nil
+}
+
+// CountEndUserDailySpendingResetEvents returns how many reset events exist for an end user.
+func CountEndUserDailySpendingResetEvents(tenantID, endUserID string) (int, error) {
+	db := getDB()
+	if db == nil {
+		return 0, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	endUserID = strings.TrimSpace(endUserID)
+	if endUserID == "" {
+		return 0, nil
+	}
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM end_user_daily_spending_reset_events WHERE tenant_id = ? AND end_user_id = ?`,
+		tenantID, endUserID,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("usage: count end-user daily spending reset events: %w", err)
+	}
+	return n, nil
+}
+
+// ListEndUserDailySpendingResetEventCounts returns reset counts keyed by end_user_id.
+func ListEndUserDailySpendingResetEventCounts(tenantID string, endUserIDs []string) (map[string]int, error) {
+	out := make(map[string]int)
+	if len(endUserIDs) == 0 {
+		return out, nil
+	}
+	db := getDB()
+	if db == nil {
+		return out, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	ids := make([]string, 0, len(endUserIDs))
+	seen := make(map[string]struct{}, len(endUserIDs))
+	for _, id := range endUserIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]interface{}, 0, len(ids)+1)
+	args = append(args, tenantID)
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	rows, err := db.Query(
+		`SELECT end_user_id, COUNT(*) FROM end_user_daily_spending_reset_events
+		 WHERE tenant_id = ? AND end_user_id IN (`+strings.Join(placeholders, ",")+`)
+		 GROUP BY end_user_id`,
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("usage: list end-user daily spending reset event counts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var n int
+		if err := rows.Scan(&id, &n); err != nil {
+			return nil, fmt.Errorf("usage: scan end-user reset event count: %w", err)
+		}
+		out[strings.TrimSpace(id)] = n
+	}
+	return out, rows.Err()
+}
+
+// ListEndUserDailySpendingResetEvents returns newest-first history for an end user.
+func ListEndUserDailySpendingResetEvents(tenantID, endUserID string, limit int) ([]EndUserDailySpendingResetEvent, error) {
+	db := getDB()
+	if db == nil {
+		return nil, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	endUserID = strings.TrimSpace(endUserID)
+	if endUserID == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	rows, err := db.Query(
+		`SELECT id, tenant_id, end_user_id, day_key, reset_at, actor_user_id, actor_username, actor_kind,
+		        cost_baseline, effective_used_before, raw_today_cost
+		 FROM end_user_daily_spending_reset_events
+		 WHERE tenant_id = ? AND end_user_id = ?
+		 ORDER BY reset_at DESC, id DESC
+		 LIMIT ?`,
+		tenantID, endUserID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("usage: list end-user daily spending reset events: %w", err)
+	}
+	defer rows.Close()
+	out := make([]EndUserDailySpendingResetEvent, 0)
+	for rows.Next() {
+		var ev EndUserDailySpendingResetEvent
+		var resetAt string
+		if err := rows.Scan(
+			&ev.ID, &ev.TenantID, &ev.EndUserID, &ev.DayKey, &resetAt,
+			&ev.ActorUserID, &ev.ActorUsername, &ev.ActorKind,
+			&ev.CostBaseline, &ev.EffectiveUsedBefore, &ev.RawTodayCost,
+		); err != nil {
+			return nil, fmt.Errorf("usage: scan end-user daily spending reset event: %w", err)
+		}
+		if ts, err := time.Parse(time.RFC3339Nano, resetAt); err == nil {
+			ev.ResetAt = ts
+		} else if ts, err := time.Parse(time.RFC3339, resetAt); err == nil {
+			ev.ResetAt = ts
+		}
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+// DeleteEndUserDailySpendingResetEvents removes history for an end user.
+func DeleteEndUserDailySpendingResetEvents(tenantID, endUserID string) error {
+	db := getDB()
+	if db == nil {
+		return nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	endUserID = strings.TrimSpace(endUserID)
+	if endUserID == "" {
+		return nil
+	}
+	_, err := db.Exec(
+		`DELETE FROM end_user_daily_spending_reset_events WHERE tenant_id = ? AND end_user_id = ?`,
+		tenantID, endUserID,
+	)
+	if err != nil {
+		return fmt.Errorf("usage: delete end-user daily spending reset events: %w", err)
+	}
+	return nil
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -758,6 +758,11 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 		usageDB, usageReadDB = nil, nil
 		return err
 	}
+	if err := bootstrapEndUserDailySpendingResetEvents(db); err != nil {
+		_ = db.Close()
+		usageDB, usageReadDB = nil, nil
+		return err
+	}
 	log.Debugf("usage: initializing pricing table")
 	initPricingTable(db)
 	log.Debugf("usage: initializing model config tables")


### PR DESCRIPTION
## Summary

- 新增 `end_user_daily_spending_reset_events`（SQLite bootstrap + PostgreSQL migration），持久化账号级每日消费手动重置事件。
- `GetEndUsers` 批量附加 `daily-spending-reset-count`，避免 N+1；重置接口写入 actor、baseline、重置前有效消耗和当日实际消耗。
- 新增账号重置历史接口，并在删除 end-user 时同步清理 baseline 与 events。
- 历史接口允许 `end_users.read`、`end_users.write` 或 platform admin，默认 limit 100、上限 500，按 `reset_at DESC, id DESC` 返回所有时间段的记录。

## API contract

```text
GET /v0/management/end-users
  items[].daily-spending-reset-count: number

POST /v0/management/end-users/:id/daily-spending/reset
  response:
  {
    status,
    end_user_id,
    daily-spending-used,
    daily-spending-reset-count,
    effective-used-before,
    raw-today-cost
  }

GET /v0/management/end-users/:id/daily-spending/reset-history?limit=
  response:
  {
    items: EndUserDailySpendingResetEvent[],
    total: number,
    raw-today-cost: number,
    daily-spending-used: number
  }

EndUserDailySpendingResetEvent:
  id, tenant_id, end_user_id, day_key, reset_at,
  actor_user_id?, actor_username?, actor_kind?,
  cost_baseline, effective_used_before, raw_today_cost
```

`total` 为该账号的全部历史事件数；`items` 受 limit 限制但不按 day 过滤。顶部 `raw-today-cost` 是当前项目日实际消耗，`daily-spending-used` 是应用 baseline 后的当前有效消耗。

## Verification

- `go test ./internal/usage ./internal/api/handlers/management ./internal/api/routes ./internal/storage/postgres ./internal/enduser`
- `go test ./internal/...`
- 结果：`2416 passed in 161 packages`
