### PR TITLE
fix: make migration timeout configurable and improve dirty errors

### DIFF
--- a/internal/storage/postgres/runtime.go
+++ b/internal/storage/postgres/runtime.go
@@ -13,7 +13,10 @@ import (
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres/compatdriver"
 )
 
-const driverName = "pgxq"
+const (
+	driverName           = "pgxq"
+	runtimeDBPingTimeout = 30 * time.Second
+)
 
 type Migration struct {
 	Version string
@@ -21,6 +24,19 @@ type Migration struct {
 }
 
 func OpenRuntimeDB(ctx context.Context, cfg config.PostgresConfig) (*sql.DB, error) {
+	return openRuntimeDB(ctx, cfg, 0)
+}
+
+// OpenRuntimeDBWithMigrationTimeout opens the runtime database with separate
+// budgets for the connection ping and migration phases.
+func OpenRuntimeDBWithMigrationTimeout(ctx context.Context, cfg config.PostgresConfig, migrationTimeout time.Duration) (*sql.DB, error) {
+	if migrationTimeout <= 0 {
+		return nil, errors.New("postgres: migration timeout must be greater than zero")
+	}
+	return openRuntimeDB(ctx, cfg, migrationTimeout)
+}
+
+func openRuntimeDB(ctx context.Context, cfg config.PostgresConfig, migrationTimeout time.Duration) (*sql.DB, error) {
 	dsn := strings.TrimSpace(cfg.DSN)
 	if dsn == "" {
 		return nil, errors.New("postgres dsn is required")
@@ -36,11 +52,26 @@ func OpenRuntimeDB(ctx context.Context, cfg config.PostgresConfig) (*sql.DB, err
 		db.SetMaxIdleConns(cfg.MaxIdleConns)
 	}
 	db.SetConnMaxLifetime(30 * time.Minute)
-	if err := db.PingContext(ctx); err != nil {
+
+	pingCtx := ctx
+	cancelPing := func() {}
+	if migrationTimeout > 0 {
+		pingCtx, cancelPing = context.WithTimeout(ctx, runtimeDBPingTimeout)
+	}
+	if err := db.PingContext(pingCtx); err != nil {
+		cancelPing()
 		_ = db.Close()
 		return nil, fmt.Errorf("postgres: ping: %w", err)
 	}
-	if err := ApplyMigrations(ctx, db, RuntimeMigrations()); err != nil {
+	cancelPing()
+
+	migrationCtx := ctx
+	cancelMigrations := func() {}
+	if migrationTimeout > 0 {
+		migrationCtx, cancelMigrations = context.WithTimeout(ctx, migrationTimeout)
+	}
+	defer cancelMigrations()
+	if err := ApplyMigrations(migrationCtx, db, RuntimeMigrations()); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -81,7 +112,7 @@ func applyMigration(ctx context.Context, db *sql.DB, migration Migration) error 
 	err := db.QueryRowContext(ctx, `SELECT checksum, dirty FROM schema_migrations WHERE version = ?`, version).Scan(&existingChecksum, &dirty)
 	switch {
 	case err == nil && dirty:
-		return fmt.Errorf("postgres: migration %s is dirty", version)
+		return fmt.Errorf("postgres: migration %s is dirty; compare the database schema with this migration's SQL and confirm whether the SQL committed before changing schema_migrations; if it did not commit, apply the SQL before marking the row clean; do not only clear dirty, and do not automatically replay SQL while the commit state is uncertain", version)
 	case err == nil && existingChecksum != checksum:
 		return fmt.Errorf("postgres: migration %s checksum mismatch", version)
 	case err == nil:

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -1,8 +1,12 @@
 package postgres
 
 import (
+	"context"
+	"database/sql"
 	"strings"
 	"testing"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
@@ -225,5 +229,49 @@ func TestMigrationChecksumChangesWithSQL(t *testing.T) {
 	second := migrationChecksum("SELECT 2")
 	if first == second {
 		t.Fatal("migrationChecksum returned identical values for different SQL")
+	}
+}
+
+func TestApplyMigrationDirtyErrorIncludesRemediation(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close sqlite db: %v", err)
+		}
+	})
+	if _, err := db.Exec(`
+		CREATE TABLE schema_migrations (
+			version TEXT PRIMARY KEY,
+			checksum TEXT NOT NULL,
+			dirty BOOLEAN NOT NULL
+		)
+	`); err != nil {
+		t.Fatal(err)
+	}
+	migration := Migration{Version: "202607210001_slow_ddl", SQL: "CREATE TABLE example (id INTEGER)"}
+	if _, err := db.Exec(
+		"INSERT INTO schema_migrations (version, checksum, dirty) VALUES (?, ?, true)",
+		migration.Version,
+		migrationChecksum(migration.SQL),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	err = applyMigration(context.Background(), db, migration)
+	if err == nil {
+		t.Fatal("applyMigration() error = nil, want dirty migration error")
+	}
+	for _, fragment := range []string{
+		"migration 202607210001_slow_ddl is dirty",
+		"confirm whether the SQL committed",
+		"do not only clear dirty",
+		"do not automatically replay SQL",
+	} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("applyMigration() error = %q, want %q", err, fragment)
+		}
 	}
 }

--- a/internal/usage/migration_timeout_test.go
+++ b/internal/usage/migration_timeout_test.go
@@ -1,0 +1,67 @@
+package usage
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPostgresMigrationTimeoutDefault(t *testing.T) {
+	unsetEnv(t, postgresMigrationTimeoutEnv)
+
+	got, err := postgresMigrationTimeout()
+	if err != nil {
+		t.Fatalf("postgresMigrationTimeout() error = %v", err)
+	}
+	if got != 30*time.Second {
+		t.Fatalf("postgresMigrationTimeout() = %s, want 30s", got)
+	}
+}
+
+func TestPostgresMigrationTimeoutFromEnv(t *testing.T) {
+	t.Setenv(postgresMigrationTimeoutEnv, " 5m ")
+
+	got, err := postgresMigrationTimeout()
+	if err != nil {
+		t.Fatalf("postgresMigrationTimeout() error = %v", err)
+	}
+	if got != 5*time.Minute {
+		t.Fatalf("postgresMigrationTimeout() = %s, want 5m", got)
+	}
+}
+
+func TestPostgresMigrationTimeoutRejectsInvalidValue(t *testing.T) {
+	for _, value := range []string{"not-a-duration", "0s", "-1s"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(postgresMigrationTimeoutEnv, value)
+
+			_, err := postgresMigrationTimeout()
+			if err == nil {
+				t.Fatal("postgresMigrationTimeout() error = nil, want invalid value error")
+			}
+			if !strings.Contains(err.Error(), postgresMigrationTimeoutEnv) {
+				t.Fatalf("postgresMigrationTimeout() error = %q, want env name", err)
+			}
+		})
+	}
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	value, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if ok {
+			if err := os.Setenv(key, value); err != nil {
+				t.Errorf("restore %s: %v", key, err)
+			}
+			return
+		}
+		if err := os.Unsetenv(key); err != nil {
+			t.Errorf("clear %s: %v", key, err)
+		}
+	})
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -658,7 +658,32 @@ func InitDB(dbPath string, storageCfg config.RequestLogStorageConfig, loc *time.
 	return initOpenedDBLocked(db, readDB, dbPath, "sqlite", storageCfg, loc, true)
 }
 
+const (
+	postgresMigrationTimeoutEnv     = "CLIRELAY_MIGRATION_TIMEOUT"
+	defaultPostgresMigrationTimeout = 30 * time.Second
+)
+
+func postgresMigrationTimeout() (time.Duration, error) {
+	raw, ok := os.LookupEnv(postgresMigrationTimeoutEnv)
+	if !ok {
+		return defaultPostgresMigrationTimeout, nil
+	}
+	timeout, err := time.ParseDuration(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("usage: invalid %s %q: %w", postgresMigrationTimeoutEnv, raw, err)
+	}
+	if timeout <= 0 {
+		return 0, fmt.Errorf("usage: invalid %s %q: duration must be greater than zero", postgresMigrationTimeoutEnv, raw)
+	}
+	return timeout, nil
+}
+
 func InitPostgres(pgCfg config.PostgresConfig, storageCfg config.RequestLogStorageConfig, loc *time.Location) error {
+	migrationTimeout, err := postgresMigrationTimeout()
+	if err != nil {
+		return err
+	}
+
 	usageDBLifecycleMu.Lock()
 	defer usageDBLifecycleMu.Unlock()
 
@@ -671,9 +696,7 @@ func InitPostgres(pgCfg config.PostgresConfig, storageCfg config.RequestLogStora
 	if loc == nil {
 		loc = time.Local
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	db, err := postgresstore.OpenRuntimeDB(ctx, pgCfg)
+	db, err := postgresstore.OpenRuntimeDBWithMigrationTimeout(context.Background(), pgCfg, migrationTimeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- add `CLIRELAY_MIGRATION_TIMEOUT` using Go duration syntax, with a default of `30s`
- fail startup on invalid or non-positive timeout values
- give PostgreSQL ping and migrations separate timeout budgets so the configured value applies to migrations
- expand dirty migration errors with safe remediation guidance without automatically clearing dirty state or replaying SQL

## Tests
- `go test ./internal/storage/postgres ./internal/usage`
- `go test ./...`

Refs #750
