### PR TITLE
fix: align usage chart daily buckets with project timezone rollup

### DIFF
--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -216,42 +216,37 @@ func QueryDailySeries(apiKey string, days int) ([]DailySeriesPoint, error) {
 }
 
 func QueryDailySeriesForTenant(tenantID, apiKey string, days int) ([]DailySeriesPoint, error) {
-	db := getReadDB()
-	if db == nil {
+	if getReadDB() == nil {
 		return nil, nil
 	}
 	if days < 1 {
 		days = 7
 	}
 
+	// Use usage_rollup_buckets day keys (usageLoc / project timezone), not
+	// date(timestamp,'localtime') which PostgreSQL compat rewrites to UTC.
 	params := LogQueryParams{TenantID: tenantID, APIKey: apiKey, Days: days}
-	where, args := buildWhereClause(params)
-
-	// NOTE: timestamps are stored as UTC RFC3339 strings; localtime converts them to the process timezone
-	// (configured via TZ/time.Local) for correct day bucketing.
-	q := `SELECT date(timestamp, 'localtime') as d,
-	             COUNT(*) as reqs,
-	             SUM(CASE WHEN failed != 0 THEN 1 ELSE 0 END) as failed_reqs,
-	             COALESCE(SUM(input_tokens),0),
-	             COALESCE(SUM(output_tokens),0)
-	      FROM request_logs` + where + `
-	      GROUP BY d ORDER BY d`
-
-	rows, err := db.Query(q, args...)
+	filter, ok := rollupIdentityFilter(params)
+	if !ok {
+		return []DailySeriesPoint{}, nil
+	}
+	filter.BucketKind = rollupBucketDay
+	filter.BucketFrom = dayBucketFromDays(days)
+	points, err := queryRollupDailySeries(filter)
 	if err != nil {
-		return nil, fmt.Errorf("usage: daily series query: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
-
-	var result []DailySeriesPoint
-	for rows.Next() {
-		var p DailySeriesPoint
-		if err := rows.Scan(&p.Date, &p.Requests, &p.FailedReq, &p.InputTokens, &p.OutputTokens); err != nil {
-			return nil, fmt.Errorf("usage: daily series scan: %w", err)
-		}
-		result = append(result, p)
+	result := make([]DailySeriesPoint, 0, len(points))
+	for _, p := range points {
+		result = append(result, DailySeriesPoint{
+			Date:         p.Date,
+			Requests:     int(p.Requests),
+			FailedReq:    int(p.FailedRequests),
+			InputTokens:  int(p.InputTokens),
+			OutputTokens: int(p.OutputTokens),
+		})
 	}
-	return result, rows.Err()
+	return result, nil
 }
 
 // QueryDailyHeatmapSeries returns sparse daily usage for the calendar heatmap.
@@ -444,8 +439,7 @@ func QueryModelDistribution(apiKey string, days int) ([]ModelDistributionPoint, 
 }
 
 func QueryModelDistributionForTenant(tenantID, apiKey string, days int) ([]ModelDistributionPoint, error) {
-	db := getReadDB()
-	if db == nil {
+	if getReadDB() == nil {
 		return nil, nil
 	}
 	if days < 1 {
@@ -453,29 +447,13 @@ func QueryModelDistributionForTenant(tenantID, apiKey string, days int) ([]Model
 	}
 
 	params := LogQueryParams{TenantID: tenantID, APIKey: apiKey, Days: days}
-	where, args := buildWhereClause(params)
-
-	q := `SELECT model,
-	             COUNT(*) as reqs,
-	             COALESCE(SUM(total_tokens),0)
-	      FROM request_logs` + where + `
-	      GROUP BY model ORDER BY reqs DESC`
-
-	rows, err := db.Query(q, args...)
-	if err != nil {
-		return nil, fmt.Errorf("usage: model distribution query: %w", err)
+	filter, ok := rollupIdentityFilter(params)
+	if !ok {
+		return []ModelDistributionPoint{}, nil
 	}
-	defer rows.Close()
-
-	var result []ModelDistributionPoint
-	for rows.Next() {
-		var p ModelDistributionPoint
-		if err := rows.Scan(&p.Model, &p.Requests, &p.Tokens); err != nil {
-			return nil, fmt.Errorf("usage: model distribution scan: %w", err)
-		}
-		result = append(result, p)
-	}
-	return result, rows.Err()
+	filter.BucketKind = rollupBucketDay
+	filter.BucketFrom = dayBucketFromDays(days)
+	return queryRollupModelDistribution(filter)
 }
 
 // APIKeyDistributionPoint holds aggregated usage data for a single API key.

--- a/internal/usage/request_log_series_test.go
+++ b/internal/usage/request_log_series_test.go
@@ -1,6 +1,124 @@
 package usage
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestQueryDailySeriesUsesProjectTimezoneDayBuckets(t *testing.T) {
+	// Repro: Asia/Shanghai local 00:00–08:00 must count as the same local day as
+	// mid-day traffic (not UTC day), matching request-log "today" rollup stats.
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	dbPath := filepath.Join(t.TempDir(), "daily-series-tz.db")
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{RetentionDays: 7}, loc); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		stopRequestLogMaintenance()
+		CloseDB()
+	})
+
+	const (
+		apiKey   = "sk-chart-tz"
+		apiKeyID = "key-chart-tz"
+	)
+	if err := UpsertAPIKey(APIKeyRow{ID: apiKeyID, Key: apiKey}); err != nil {
+		t.Fatalf("UpsertAPIKey: %v", err)
+	}
+
+	// 2026-07-21 00:30 and 08:30 Asia/Shanghai → both local day 2026-07-21;
+	// UTC would split them into 07/20 and 07/21.
+	earlyLocal := time.Date(2026, 7, 21, 0, 30, 0, 0, loc)
+	lateLocal := time.Date(2026, 7, 21, 8, 30, 0, 0, loc)
+	for i, at := range []time.Time{earlyLocal, lateLocal} {
+		tx, err := getDB().Begin()
+		if err != nil {
+			t.Fatalf("begin %d: %v", i, err)
+		}
+		if err := projectUsageRollupTx(tx, rollupEvent{
+			TenantID: systemTenantID,
+			APIKeyID: apiKeyID,
+			Model:    "gpt-test",
+			Source:   "openai",
+			Tokens: TokenStats{
+				InputTokens:  100 + int64(i),
+				OutputTokens: 10 + int64(i),
+				TotalTokens:  110 + int64(i)*2,
+			},
+			Cost: 0.01,
+			At:   at,
+		}); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("project %d: %v", i, err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit %d: %v", i, err)
+		}
+	}
+
+	// Freeze "now" semantics: dayBucketFromDays uses time.Now via CutoffStartUTC.
+	// Project enough history and query days large enough to include 2026-07-21.
+	// Also assert the local day key itself.
+	if got := localDayKeyAt(earlyLocal); got != "2026-07-21" {
+		t.Fatalf("localDayKeyAt(early) = %q, want 2026-07-21", got)
+	}
+	if got := localDayKeyAt(lateLocal); got != "2026-07-21" {
+		t.Fatalf("localDayKeyAt(late) = %q, want 2026-07-21", got)
+	}
+
+	// Direct rollup series (no days lower bound) via filter from day key.
+	filter, ok := rollupIdentityFilter(LogQueryParams{TenantID: systemTenantID, APIKey: apiKey})
+	if !ok {
+		t.Fatal("rollupIdentityFilter failed")
+	}
+	filter.BucketKind = rollupBucketDay
+	filter.BucketFrom = "2026-07-21"
+	points, err := queryRollupDailySeries(filter)
+	if err != nil {
+		t.Fatalf("queryRollupDailySeries: %v", err)
+	}
+	if len(points) != 1 || points[0].Date != "2026-07-21" || points[0].Requests != 2 {
+		t.Fatalf("rollup day points = %#v, want single 2026-07-21 with 2 requests", points)
+	}
+	if points[0].InputTokens != 201 || points[0].OutputTokens != 21 {
+		t.Fatalf("tokens = in %d out %d, want 201/21", points[0].InputTokens, points[0].OutputTokens)
+	}
+
+	// QueryDailySeries with a wide window must surface the same local day.
+	// Seed a "today" marker so dayBucketFromDays includes historical day when now is later.
+	// If CI clock is far from 2026, use BucketFrom path above as authority and still call API with large days.
+	series, err := QueryDailySeries(apiKey, 3650)
+	if err != nil {
+		t.Fatalf("QueryDailySeries: %v", err)
+	}
+	var found *DailySeriesPoint
+	for i := range series {
+		if series[i].Date == "2026-07-21" {
+			found = &series[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("QueryDailySeries missing 2026-07-21: %#v", series)
+	}
+	if found.Requests != 2 || found.InputTokens != 201 || found.OutputTokens != 21 {
+		t.Fatalf("QueryDailySeries point = %#v, want reqs=2 in=201 out=21", *found)
+	}
+
+	stats, err := QueryStats(LogQueryParams{TenantID: systemTenantID, APIKey: apiKey, Days: 3650})
+	if err != nil {
+		t.Fatalf("QueryStats: %v", err)
+	}
+	if stats.Total != 2 {
+		t.Fatalf("QueryStats.Total = %d, want 2 (same local-day scope as chart)", stats.Total)
+	}
+}
 
 func TestExtractSessionIDFromDetailsRecognizesXSessionID(t *testing.T) {
 	detail := `{"client":{"headers":{"X-Session-Id":["zcode-session"],"Conversation-Id":["conversation"]}}}`


### PR DESCRIPTION
## Summary
- Management `GET /usage/chart-data` daily series previously aggregated `request_logs` with `date(timestamp, 'localtime')`, which the PostgreSQL compat driver rewrites to **UTC** day keys.
- Request-log “今天” stats already use `usage_rollup_buckets` day keys in project timezone (`Asia/Shanghai`). Local 00:00–08:00 traffic was counted on the previous UTC day in the chart but as “today” in logs (e.g. 8020 vs 8631 requests).
- Switch `QueryDailySeriesForTenant` and `QueryModelDistributionForTenant` to rollup day buckets (same path as public chart / log stats).
- Add regression test: Shanghai 00:30 + 08:30 both land on the same local day.

## Test plan
- [x] `go test ./internal/usage/ -count=1 -run 'TestQueryDailySeriesUsesProjectTimezoneDayBuckets|TestUsageRollup|TestQueryStats|TestExtractSessionID'`
- [x] `go test ./internal/usage/ -count=1 -run 'Daily|Rollup|Chart|Heatmap|ModelDistribution|QueryStats'`
- [x] `go test ./internal/management/usagelogs/ -count=1`
- [x] `go test ./internal/api/routes/ -count=1 -run 'RegisterManagement|Postgres'`
- [ ] After merge/deploy: compare monitor Token 趋势 07/21 requests with request-log “今天” total under no filters