### PR TITLE
feat: add end-user and API key period spending quotas

### DIFF
--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
@@ -37,25 +38,47 @@ func Register(cfg *sdkconfig.SDKConfig) {
 func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 	result := make(map[string]keyConfig)
 
-	// Primary: load every tenant-scoped API key. Keys remain globally unique so
-	// authentication can resolve the trusted tenant without client input.
-	for _, stored := range usage.ListAllAPIKeys() {
-		entry := usage.EffectiveAPIKeyRowForTenant(stored.TenantID, stored)
+	// Primary: preload tenant profiles and owned accounts once, then build every key.
+	storedRows := usage.ListAllAPIKeys()
+	profilesByTenant := make(map[string][]usage.APIKeyPermissionProfileRow)
+	endUserIDs := make([]string, 0)
+	for _, stored := range storedRows {
+		tenantID := strings.TrimSpace(stored.TenantID)
+		if _, ok := profilesByTenant[tenantID]; !ok {
+			profilesByTenant[tenantID] = usage.ListAPIKeyPermissionProfilesForTenant(tenantID)
+		}
+		if endUserID := strings.TrimSpace(stored.EndUserID); endUserID != "" {
+			endUserIDs = append(endUserIDs, endUserID)
+		}
+	}
+	accounts, _ := usage.ListEndUserQuotasByIDs(endUserIDs)
+	for _, stored := range storedRows {
+		profiles := profilesByTenant[strings.TrimSpace(stored.TenantID)]
+		entry := usage.EffectiveAPIKeyRowWithProfiles(stored, profiles)
 		trimmed := strings.TrimSpace(entry.Key)
 		if trimmed == "" || entry.Disabled {
 			continue
 		}
-		// Frozen/locked accounts stay out of the auth map even if individual keys are enabled.
+		var account *usage.EndUserQuota
 		if endUserID := strings.TrimSpace(entry.EndUserID); endUserID != "" {
-			q := usage.GetEndUserQuota(endUserID)
-			if q == nil || strings.TrimSpace(q.Status) != "active" {
+			loaded, ok := accounts[endUserID]
+			if !ok {
+				fallback := usage.GetEndUserQuota(endUserID)
+				if fallback == nil {
+					continue
+				}
+				loaded = *fallback
+			}
+			effective := usage.EffectiveEndUserQuotaWithProfiles(loaded, profiles)
+			if strings.TrimSpace(effective.Status) != "active" {
 				continue
 			}
+			account = &effective
 		}
 		if _, exists := result[trimmed]; exists {
 			continue
 		}
-		result[trimmed] = keyConfigFromRow(entry)
+		result[trimmed] = keyConfigFromRowWithAccount(entry, account)
 	}
 
 	// Fallback: YAML config (for backward compatibility during migration)
@@ -87,64 +110,69 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 // keyConfig holds the per-key configuration extracted from APIKeyEntry.
 // When endUserID is set, quota/permissions come from the end-user account pool.
 type keyConfig struct {
-	tenantID             string
-	apiKeyID             string
-	apiKeyName           string
-	endUserID            string
-	allowedModels        []string
-	allowedChannels      []string
-	allowedChannelGroups []string
-	dailyLimit           int
-	totalQuota           int
-	spendingLimit        float64
-	dailySpendingLimit   float64
-	concurrencyLimit     int
-	rpmLimit             int
-	tpmLimit             int
-	systemPrompt         string
+	tenantID                    string
+	apiKeyID                    string
+	apiKeyName                  string
+	endUserID                   string
+	allowedModels               []string
+	allowedChannels             []string
+	allowedChannelGroups        []string
+	dailyLimit                  int
+	totalQuota                  int
+	spendingLimit               float64
+	dailySpendingLimit          float64
+	accountPeriodSpendingLimits quota.PeriodSpendingLimits
+	keyPeriodSpendingLimits     quota.PeriodSpendingLimits
+	concurrencyLimit            int
+	rpmLimit                    int
+	tpmLimit                    int
+	systemPrompt                string
 }
 
 func keyConfigFromRow(row usage.APIKeyRow) keyConfig {
+	var account *usage.EndUserQuota
+	if endUserID := strings.TrimSpace(row.EndUserID); endUserID != "" {
+		if loaded := usage.GetEndUserQuota(endUserID); loaded != nil {
+			effective := usage.EffectiveEndUserQuota(*loaded)
+			account = &effective
+		}
+	}
+	return keyConfigFromRowWithAccount(row, account)
+}
+
+func keyConfigFromRowWithAccount(row usage.APIKeyRow, account *usage.EndUserQuota) keyConfig {
 	tenantID := strings.TrimSpace(row.TenantID)
 	if tenantID == "" {
 		tenantID = identity.SystemTenantID
 	}
 	kc := keyConfig{
-		tenantID:             tenantID,
-		apiKeyID:             strings.TrimSpace(row.ID),
-		apiKeyName:           strings.TrimSpace(row.Name),
-		endUserID:            strings.TrimSpace(row.EndUserID),
-		allowedModels:        row.AllowedModels,
-		allowedChannels:      row.AllowedChannels,
-		allowedChannelGroups: row.AllowedChannelGroups,
-		dailyLimit:           row.DailyLimit,
-		totalQuota:           row.TotalQuota,
-		spendingLimit:        row.SpendingLimit,
-		dailySpendingLimit:   row.DailySpendingLimit,
-		concurrencyLimit:     row.ConcurrencyLimit,
-		rpmLimit:             row.RPMLimit,
-		tpmLimit:             row.TPMLimit,
-		systemPrompt:         row.SystemPrompt,
+		tenantID: tenantID, apiKeyID: strings.TrimSpace(row.ID), apiKeyName: strings.TrimSpace(row.Name),
+		endUserID: strings.TrimSpace(row.EndUserID), allowedModels: row.AllowedModels,
+		allowedChannels: row.AllowedChannels, allowedChannelGroups: row.AllowedChannelGroups,
+		dailyLimit: row.DailyLimit, totalQuota: row.TotalQuota, spendingLimit: row.SpendingLimit,
+		dailySpendingLimit: row.DailySpendingLimit, keyPeriodSpendingLimits: row.PeriodSpendingLimits,
+		concurrencyLimit: row.ConcurrencyLimit, rpmLimit: row.RPMLimit, tpmLimit: row.TPMLimit, systemPrompt: row.SystemPrompt,
 	}
-	// Owned keys share the end-user account quota/permission pool.
-	if kc.endUserID != "" {
-		if q := usage.GetEndUserQuota(kc.endUserID); q != nil {
-			eq := usage.EffectiveEndUserQuota(*q)
-			if name := strings.TrimSpace(eq.DisplayName); name != "" {
-				kc.apiKeyName = name
-			}
-			kc.allowedModels = eq.AllowedModels
-			kc.allowedChannels = eq.AllowedChannels
-			kc.allowedChannelGroups = eq.AllowedChannelGroups
-			kc.dailyLimit = eq.DailyLimit
-			kc.totalQuota = eq.TotalQuota
-			kc.spendingLimit = eq.SpendingLimit
-			kc.dailySpendingLimit = eq.DailySpendingLimit
-			kc.concurrencyLimit = eq.ConcurrencyLimit
-			kc.rpmLimit = eq.RPMLimit
-			kc.tpmLimit = eq.TPMLimit
-			kc.systemPrompt = eq.SystemPrompt
+	if kc.endUserID != "" && account != nil {
+		if name := strings.TrimSpace(account.DisplayName); name != "" {
+			kc.apiKeyName = name
 		}
+		kc.allowedModels = account.AllowedModels
+		kc.allowedChannels = account.AllowedChannels
+		kc.allowedChannelGroups = account.AllowedChannelGroups
+		kc.dailyLimit = account.DailyLimit
+		kc.totalQuota = account.TotalQuota
+		kc.spendingLimit = account.SpendingLimit
+		kc.dailySpendingLimit = account.DailySpendingLimit
+		kc.accountPeriodSpendingLimits = account.PeriodSpendingLimits
+		kc.concurrencyLimit = account.ConcurrencyLimit
+		kc.rpmLimit = account.RPMLimit
+		kc.tpmLimit = account.TPMLimit
+		kc.systemPrompt = account.SystemPrompt
+	}
+	kc.keyPeriodSpendingLimits.Day = row.DailySpendingLimit
+	if kc.endUserID == "" {
+		kc.dailySpendingLimit = kc.keyPeriodSpendingLimits.Day
 	}
 	return kc
 }
@@ -208,7 +236,9 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 		}
 		if kc, ok := p.keys[candidate.value]; ok {
 			metadata := map[string]string{
-				"source": candidate.source,
+				"source":     candidate.source,
+				"tenant-id":  kc.tenantID,
+				"api-key-id": kc.apiKeyID,
 			}
 			if kc.endUserID != "" {
 				metadata["end-user-id"] = kc.endUserID
@@ -243,6 +273,8 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 			if kc.dailySpendingLimit > 0 {
 				metadata["daily-spending-limit"] = fmt.Sprintf("%f", kc.dailySpendingLimit)
 			}
+			addPeriodLimitMetadata(metadata, "account-period-spending-limit-", kc.accountPeriodSpendingLimits)
+			addPeriodLimitMetadata(metadata, "key-period-spending-limit-", kc.keyPeriodSpendingLimits)
 			if kc.systemPrompt != "" {
 				metadata["system-prompt"] = kc.systemPrompt
 			}
@@ -258,6 +290,14 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 	}
 
 	return nil, sdkaccess.NewInvalidCredentialError()
+}
+
+func addPeriodLimitMetadata(metadata map[string]string, prefix string, limits quota.PeriodSpendingLimits) {
+	for _, period := range quota.OrderedPeriods {
+		if value := limits.Value(period); value > 0 {
+			metadata[prefix+string(period)] = fmt.Sprintf("%f", value)
+		}
+	}
 }
 
 func extractBearerToken(header string) string {

--- a/internal/access/config_access/provider_test.go
+++ b/internal/access/config_access/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 )
 
 func TestProviderEmitsDailySpendingLimitMetadata(t *testing.T) {
@@ -25,5 +26,35 @@ func TestProviderEmitsDailySpendingLimitMetadata(t *testing.T) {
 	}
 	if got := res.Metadata["daily-spending-limit"]; got != "4.500000" {
 		t.Fatalf("daily-spending-limit metadata = %q, want 4.500000", got)
+	}
+}
+
+func TestProviderEmitsSeparateAccountAndKeyPeriodMetadata(t *testing.T) {
+	p := newProvider("test", map[string]keyConfig{
+		"sk-owned": {
+			tenantID: "tenant-a", apiKeyID: "key-a", endUserID: "user-a",
+			accountPeriodSpendingLimits: quota.PeriodSpendingLimits{FiveHour: 100, Day: 300, Week: 800, Month: 4000},
+			keyPeriodSpendingLimits:     quota.PeriodSpendingLimits{FiveHour: 50, Day: 100},
+		},
+	})
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-owned")
+	res, authErr := p.Authenticate(context.Background(), req)
+	if authErr != nil {
+		t.Fatalf("Authenticate: %v", authErr)
+	}
+	checks := map[string]string{
+		"tenant-id": "tenant-a", "api-key-id": "key-a", "end-user-id": "user-a",
+		"account-period-spending-limit-5h":    "100.000000",
+		"account-period-spending-limit-day":   "300.000000",
+		"account-period-spending-limit-week":  "800.000000",
+		"account-period-spending-limit-month": "4000.000000",
+		"key-period-spending-limit-5h":        "50.000000",
+		"key-period-spending-limit-day":       "100.000000",
+	}
+	for key, want := range checks {
+		if got := res.Metadata[key]; got != want {
+			t.Fatalf("metadata[%s]=%q, want %q", key, got, want)
+		}
 	}
 }

--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -11,7 +11,10 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/access"
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -155,6 +158,14 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "failed to read body"})
 		return
 	}
+	if err := validatePeriodPayloadJSON(data); err != nil {
+		if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_period_spending_limit", "message": err.Error()}})
+		}
+		return
+	}
 
 	var profiles []usage.APIKeyPermissionProfileRow
 	syncAccounts := false
@@ -171,21 +182,32 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 		syncAccounts = obj.SyncAccounts
 	}
 
-	appliedCount := int64(0)
-	if syncAccounts {
-		appliedCount, err = h.apiKeySettings(c).ReplacePermissionProfilesAndSyncAccounts(profiles)
-	} else {
-		err = h.apiKeySettings(c).ReplacePermissionProfiles(profiles)
-	}
+	result, err := h.apiKeySettings(c).ReplacePermissionProfilesWithCaps(profiles, syncAccounts)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		if errors.Is(err, enduser.ErrFiveHourProjectionWarming) {
+			c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
+		} else if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 		return
 	}
 	if err := h.refreshAPIKeyCache(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(200, gin.H{"status": "ok", "applied_count": appliedCount})
+	if len(result.CappedKeys) > 0 {
+		principal, _ := principalFromContext(c)
+		if audit := identity.Default(); audit != nil {
+			audit.RecordAudit(c.Request.Context(), identity.AuditEvent{
+				TenantID: effectiveTenantID(c), ActorKind: principal.Kind, ActorUserID: principal.User.ID, ActorSessionID: principal.SessionID,
+				Action: "permission_profile.period_quota.cap_keys", ResourceType: "api_key_permission_profiles", Result: "success",
+				Changes: map[string]any{"capped-keys": result.CappedKeys},
+			})
+		}
+	}
+	c.JSON(200, gin.H{"status": "ok", "applied_count": result.AppliedCount, "capped-keys": result.CappedKeys})
 }
 
 // api-key-entries: backed by SQLite api_keys table
@@ -284,6 +306,14 @@ func (h *Handler) PutAPIKeyEntries(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "failed to read body"})
 		return
 	}
+	if err := validatePeriodPayloadJSON(data); err != nil {
+		if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_period_spending_limit", "message": err.Error()}})
+		}
+		return
+	}
 	var arr []config.APIKeyEntry
 	if err = json.Unmarshal(data, &arr); err != nil {
 		var obj struct {
@@ -322,7 +352,20 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 		return
 	}
 	if err := h.apiKeySettings(c).PatchEntry(body.ID, body.Index, body.Match, *body.Value); err != nil {
+		var exceeds *quota.LimitExceedsAccountError
 		switch {
+		case errors.Is(err, quota.ErrPeriodDayLegacyConflict):
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+			return
+		case errors.Is(err, enduser.ErrFiveHourProjectionWarming):
+			c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
+			return
+		case errors.As(err, &exceeds):
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "key_period_limit_exceeds_account", "message": exceeds.Error(), "details": gin.H{"period": exceeds.Period, "key_limit": exceeds.KeyLimit, "account_limit": exceeds.AccountLimit}}})
+			return
+		case errors.Is(err, apikeysettings.ErrOwnedKeyAccountManagedField):
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "owned_key_account_managed_field", "message": err.Error()}})
+			return
 		case errors.Is(err, apikeysettings.ErrItemNotFound):
 			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
 			return

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -9,6 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -57,6 +60,17 @@ func endUserError(c *gin.Context, err error) {
 		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "duplicate_key_name", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrNotFound):
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": err.Error()}})
+	case errors.Is(err, enduser.ErrPeriodDayLegacyConflict):
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+	case errors.Is(err, enduser.ErrFiveHourProjectionWarming):
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
+	case func() bool { var target *quota.LimitExceedsAccountError; return errors.As(err, &target) }():
+		var target *quota.LimitExceedsAccountError
+		_ = errors.As(err, &target)
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{
+			"code": "key_period_limit_exceeds_account", "message": target.Error(),
+			"details": gin.H{"period": target.Period, "key_limit": target.KeyLimit, "account_limit": target.AccountLimit},
+		}})
 	case errors.Is(err, enduser.ErrValidation):
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "validation_failed", "message": err.Error()}})
 	default:
@@ -76,24 +90,24 @@ func (h *Handler) GetEndUsers(c *gin.Context) {
 		endUserError(c, err)
 		return
 	}
-	// Group by tenant then batch-load today costs (avoids per-row N+1).
+	// Group by tenant and batch-load period/lifetime usage and reset counts.
 	byTenant := map[string][]string{}
 	for i := range items {
-		tid := items[i].TenantID
-		byTenant[tid] = append(byTenant[tid], items[i].ID)
+		byTenant[items[i].TenantID] = append(byTenant[items[i].TenantID], items[i].ID)
 	}
-	costs := map[string]float64{}
+	usageByID := map[string]quota.PeriodSpendingUsage{}
 	resetCounts := map[string]int{}
-	for tid, ids := range byTenant {
-		part, usageErr := usage.QueryTodayEffectiveCostsByEndUsersForTenant(tid, ids)
+	profilesByTenant := map[string]map[string]usage.APIKeyPermissionProfileRow{}
+	for tenantID, ids := range byTenant {
+		part, usageErr := usage.QueryPeriodSpendingByEndUsersForTenant(tenantID, ids)
 		if usageErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": usageErr.Error()})
 			return
 		}
 		for id, used := range part {
-			costs[id] = used
+			usageByID[id] = used
 		}
-		countPart, usageErr := usage.ListEndUserDailySpendingResetEventCounts(tid, ids)
+		countPart, usageErr := usage.ListEndUserDailySpendingResetEventCounts(tenantID, ids)
 		if usageErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": usageErr.Error()})
 			return
@@ -101,9 +115,24 @@ func (h *Handler) GetEndUsers(c *gin.Context) {
 		for id, count := range countPart {
 			resetCounts[id] = count
 		}
+		profiles := make(map[string]usage.APIKeyPermissionProfileRow)
+		for _, profile := range usage.ListAPIKeyPermissionProfilesForTenant(tenantID) {
+			profiles[profile.ID] = profile
+		}
+		profilesByTenant[tenantID] = profiles
 	}
 	for i := range items {
-		items[i].DailySpendingUsed = costs[items[i].ID]
+		limits := items[i].PeriodSpendingLimits
+		if profile, ok := profilesByTenant[items[i].TenantID][strings.TrimSpace(items[i].PermissionProfileID)]; ok {
+			limits = profile.PeriodSpendingLimits
+			items[i].DailySpendingLimit = profile.DailySpendingLimit
+		}
+		limits.Day = items[i].DailySpendingLimit
+		items[i].PeriodSpendingLimits = limits
+		used := usageByID[items[i].ID]
+		items[i].DailySpendingUsed = used.Day
+		items[i].LifetimeSpendingUsed = used.Lifetime
+		items[i].PeriodSpending = quota.BuildPeriodSpending(limits, used)
 		items[i].DailySpendingResetCount = resetCounts[items[i].ID]
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
@@ -145,33 +174,44 @@ func (h *Handler) PatchEndUser(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Username             *string   `json:"username"`
-		DisplayName          *string   `json:"display_name"`
-		Password             *string   `json:"password"`
-		Status               *string   `json:"status"`
-		PermissionProfileID  *string   `json:"permission-profile-id"`
-		DailyLimit           *int      `json:"daily-limit"`
-		TotalQuota           *int      `json:"total-quota"`
-		SpendingLimit        *float64  `json:"spending-limit"`
-		DailySpendingLimit   *float64  `json:"daily-spending-limit"`
-		ConcurrencyLimit     *int      `json:"concurrency-limit"`
-		RPMLimit             *int      `json:"rpm-limit"`
-		TPMLimit             *int      `json:"tpm-limit"`
-		AllowedModels        *[]string `json:"allowed-models"`
-		AllowedChannels      *[]string `json:"allowed-channels"`
-		AllowedChannelGroups *[]string `json:"allowed-channel-groups"`
-		SystemPrompt         *string   `json:"system-prompt"`
+		Username             *string                          `json:"username"`
+		DisplayName          *string                          `json:"display_name"`
+		Password             *string                          `json:"password"`
+		Status               *string                          `json:"status"`
+		PermissionProfileID  *string                          `json:"permission-profile-id"`
+		DailyLimit           *int                             `json:"daily-limit"`
+		TotalQuota           *int                             `json:"total-quota"`
+		SpendingLimit        *float64                         `json:"spending-limit"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
+		ConcurrencyLimit     *int                             `json:"concurrency-limit"`
+		RPMLimit             *int                             `json:"rpm-limit"`
+		TPMLimit             *int                             `json:"tpm-limit"`
+		AllowedModels        *[]string                        `json:"allowed-models"`
+		AllowedChannels      *[]string                        `json:"allowed-channels"`
+		AllowedChannelGroups *[]string                        `json:"allowed-channel-groups"`
+		SystemPrompt         *string                          `json:"system-prompt"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
-	quota := &enduser.QuotaPatch{
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
+	quotaPatch := &enduser.QuotaPatch{
 		PermissionProfileID:  body.PermissionProfileID,
 		DailyLimit:           body.DailyLimit,
 		TotalQuota:           body.TotalQuota,
 		SpendingLimit:        body.SpendingLimit,
-		DailySpendingLimit:   body.DailySpendingLimit,
+		DailySpendingLimit:   nil,
+		PeriodSpendingLimits: periodPatch,
 		ConcurrencyLimit:     body.ConcurrencyLimit,
 		RPMLimit:             body.RPMLimit,
 		TPMLimit:             body.TPMLimit,
@@ -182,13 +222,13 @@ func (h *Handler) PatchEndUser(c *gin.Context) {
 	}
 	// Only pass quota when at least one field is set (avoid no-op patch noise).
 	hasQuota := body.PermissionProfileID != nil || body.DailyLimit != nil || body.TotalQuota != nil ||
-		body.SpendingLimit != nil || body.DailySpendingLimit != nil || body.ConcurrencyLimit != nil ||
+		body.SpendingLimit != nil || periodPatch != nil || body.ConcurrencyLimit != nil ||
 		body.RPMLimit != nil || body.TPMLimit != nil || body.AllowedModels != nil ||
 		body.AllowedChannels != nil || body.AllowedChannelGroups != nil || body.SystemPrompt != nil
 	if !hasQuota {
-		quota = nil
+		quotaPatch = nil
 	}
-	user, err := svc.UpdateUser(c.Request.Context(), principal, effectiveTenantID(c), c.Param("id"), body.Username, body.DisplayName, body.Password, body.Status, quota)
+	user, err := svc.UpdateUser(c.Request.Context(), principal, effectiveTenantID(c), c.Param("id"), body.Username, body.DisplayName, body.Password, body.Status, quotaPatch)
 	if err != nil {
 		endUserError(c, err)
 		return
@@ -258,6 +298,11 @@ func (h *Handler) PostEndUserDailySpendingReset(c *gin.Context) {
 	user, err := svc.GetUser(c.Request.Context(), tenantID, c.Param("id"))
 	if err != nil {
 		endUserError(c, err)
+		return
+	}
+	accountQuota := usage.GetEndUserQuota(user.ID)
+	if accountQuota == nil || usage.EffectiveEndUserQuota(*accountQuota).DailySpendingLimit <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "daily_spending_limit_missing", "message": "Account daily spending limit is unlimited"}})
 		return
 	}
 	usedBefore, rawToday, err := usage.ResetTodayCostByEndUser(tenantID, user.ID)
@@ -390,10 +435,24 @@ func (h *Handler) PostEndUserAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name string `json:"name"`
+		Name                 string                           `json:"name"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
 	}
-	_ = c.ShouldBindJSON(&body)
-	result, err := svc.CreateKey(c.Request.Context(), effectiveTenantID(c), c.Param("id"), body.Name)
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
+	result, err := svc.CreateKeyWithPeriodLimits(c.Request.Context(), effectiveTenantID(c), c.Param("id"), body.Name, periodPatch)
 	if err != nil {
 		endUserError(c, err)
 		return
@@ -417,16 +476,31 @@ func (h *Handler) PatchEndUserAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name *string `json:"name"`
+		Name                 *string                          `json:"name"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
 	}
-	if err := c.ShouldBindJSON(&body); err != nil || body.Name == nil {
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
+	if body.Name == nil && periodPatch == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
 	tenantID := effectiveTenantID(c)
 	userID := c.Param("id")
 	keyID := c.Param("key_id")
-	if err := svc.UpdateKeyName(c.Request.Context(), tenantID, userID, keyID, *body.Name); err != nil {
+	if err := svc.UpdateKey(c.Request.Context(), tenantID, userID, keyID, body.Name, periodPatch); err != nil {
 		endUserError(c, err)
 		return
 	}
@@ -665,10 +739,24 @@ func (h *Handler) PostPortalAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name string `json:"name"`
+		Name                 string                           `json:"name"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
 	}
-	_ = c.ShouldBindJSON(&body)
-	result, err := h.endUserService().CreateKey(c.Request.Context(), user.TenantID, user.ID, body.Name)
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
+	result, err := h.endUserService().CreateKeyWithPeriodLimits(c.Request.Context(), user.TenantID, user.ID, body.Name, periodPatch)
 	if err != nil {
 		endUserError(c, err)
 		return
@@ -686,16 +774,27 @@ func (h *Handler) PatchPortalAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name *string `json:"name"`
+		Name                 *string                          `json:"name"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
 	keyID := c.Param("id")
 	svc := h.endUserService()
-	if body.Name != nil {
-		if err := svc.UpdateKeyName(c.Request.Context(), user.TenantID, user.ID, keyID, *body.Name); err != nil {
+	if body.Name != nil || periodPatch != nil {
+		if err := svc.UpdateKey(c.Request.Context(), user.TenantID, user.ID, keyID, body.Name, periodPatch); err != nil {
 			endUserError(c, err)
 			return
 		}
@@ -749,4 +848,83 @@ func (h *Handler) DeletePortalAPIKey(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) resetOwnedAPIKeyDailySpending(c *gin.Context, tenantID, endUserID, keyID string, actor apikeysettings.DailySpendingResetActor) {
+	if _, err := h.endUserService().ResolveOwnedKeySecret(c.Request.Context(), tenantID, endUserID, keyID); err != nil {
+		endUserError(c, err)
+		return
+	}
+	result, err := h.apiKeySettings(c).ResetDailySpending(&keyID, nil, actor)
+	if err != nil {
+		if errors.Is(err, apikeysettings.ErrDailySpendingLimitMissing) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "daily_spending_limit_missing", "message": "Key daily spending limit is unlimited"}})
+			return
+		}
+		endUserError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *Handler) ownedAPIKeyDailySpendingHistory(c *gin.Context, tenantID, endUserID, keyID string) {
+	if _, err := h.endUserService().ResolveOwnedKeySecret(c.Request.Context(), tenantID, endUserID, keyID); err != nil {
+		endUserError(c, err)
+		return
+	}
+	limit := 100
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil {
+			limit = parsed
+		}
+	}
+	events, err := h.apiKeySettings(c).ListDailySpendingResetHistory(&keyID, nil, limit)
+	if err != nil {
+		endUserError(c, err)
+		return
+	}
+	total, err := usage.CountDailySpendingResetEvents(tenantID, keyID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"items": events, "total": total})
+}
+
+func (h *Handler) PostEndUserAPIKeyDailySpendingReset(c *gin.Context) {
+	principal, _ := principalFromContext(c)
+	if !principal.Has("api_keys.write") && !principal.Has("end_users.write") && !principal.PlatformAdmin {
+		identityError(c, identity.ErrPermissionDenied)
+		return
+	}
+	h.resetOwnedAPIKeyDailySpending(c, effectiveTenantID(c), c.Param("id"), c.Param("key_id"), apikeysettings.DailySpendingResetActor{
+		UserID: principal.User.ID, Username: principal.User.Username, Kind: principal.Kind,
+	})
+}
+
+func (h *Handler) GetEndUserAPIKeyDailySpendingResetHistory(c *gin.Context) {
+	principal, _ := principalFromContext(c)
+	if !principal.Has("api_keys.read") && !principal.Has("end_users.read") && !principal.PlatformAdmin {
+		identityError(c, identity.ErrPermissionDenied)
+		return
+	}
+	h.ownedAPIKeyDailySpendingHistory(c, effectiveTenantID(c), c.Param("id"), c.Param("key_id"))
+}
+
+func (h *Handler) PostPortalAPIKeyDailySpendingReset(c *gin.Context) {
+	user, ok := h.portalKeyAccess(c)
+	if !ok {
+		return
+	}
+	h.resetOwnedAPIKeyDailySpending(c, user.TenantID, user.ID, c.Param("id"), apikeysettings.DailySpendingResetActor{
+		UserID: user.ID, Username: user.Username, Kind: "end_user",
+	})
+}
+
+func (h *Handler) GetPortalAPIKeyDailySpendingResetHistory(c *gin.Context) {
+	user, ok := h.portalKeyAccess(c)
+	if !ok {
+		return
+	}
+	h.ownedAPIKeyDailySpendingHistory(c, user.TenantID, user.ID, c.Param("id"))
 }

--- a/internal/api/handlers/management/end_user_daily_spending_reset_test.go
+++ b/internal/api/handlers/management/end_user_daily_spending_reset_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,8 +67,8 @@ func setupEndUserDailySpendingHandlerTest(t *testing.T) (*Handler, identity.Prin
 	now := time.Now().UTC()
 	if _, err := db.Exec(`
 		INSERT INTO end_users (
-			id, tenant_id, username, username_normalized, display_name, password_hash, created_at, updated_at
-		) VALUES (?, ?, 'alice', 'alice', 'Alice', 'unused', ?, ?)
+			id, tenant_id, username, username_normalized, display_name, password_hash, daily_spending_limit, created_at, updated_at
+		) VALUES (?, ?, 'alice', 'alice', 'Alice', 'unused', 100, ?, ?)
 	`, endUserID, tenantID, now, now); err != nil {
 		t.Fatalf("insert end user: %v", err)
 	}
@@ -169,5 +170,21 @@ func TestEndUserDailySpendingResetWritesAndListsHistory(t *testing.T) {
 	}
 	if len(listBody.Items) != 1 || listBody.Items[0].DailySpendingResetCount != 1 || listBody.Items[0].DailySpendingUsed != 0 {
 		t.Fatalf("end-user list = %#v, want reset count=1 used=0", listBody.Items)
+	}
+}
+
+func TestEndUserDailySpendingResetRejectsUnlimitedAccount(t *testing.T) {
+	h, principal, _, endUserID := setupEndUserDailySpendingHandlerTest(t)
+	if _, err := usage.RuntimeDB().Exec(`UPDATE end_users SET daily_spending_limit = 0 WHERE id = ?`, endUserID); err != nil {
+		t.Fatalf("clear limit: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Set(managementPrincipalKey, principal)
+	ctx.Params = gin.Params{{Key: "id", Value: endUserID}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/end-users/"+endUserID+"/daily-spending/reset", nil)
+	h.PostEndUserDailySpendingReset(ctx)
+	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), `"code":"daily_spending_limit_missing"`) {
+		t.Fatalf("status/body = %d %s, want 400 daily_spending_limit_missing", recorder.Code, recorder.Body.String())
 	}
 }

--- a/internal/api/handlers/management/period_payload.go
+++ b/internal/api/handlers/management/period_payload.go
@@ -1,0 +1,81 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
+
+func validatePeriodPayloadJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var root any
+	if err := decoder.Decode(&root); err != nil {
+		return err
+	}
+	return validatePeriodPayloadValue(root)
+}
+
+func validatePeriodPayloadValue(value any) error {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			if err := validatePeriodPayloadValue(item); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		if items, ok := typed["items"]; ok {
+			if err := validatePeriodPayloadValue(items); err != nil {
+				return err
+			}
+		}
+		var legacy *float64
+		if raw, ok := typed["daily-spending-limit"]; ok {
+			value, err := jsonNumberFloat(raw)
+			if err != nil {
+				return fmt.Errorf("daily-spending-limit: %w", err)
+			}
+			legacy = &value
+		}
+		var patch *quota.PeriodSpendingLimitsPatch
+		if raw, ok := typed["period-spending-limits"]; ok {
+			object, ok := raw.(map[string]any)
+			if !ok {
+				return fmt.Errorf("period-spending-limits must be an object")
+			}
+			patch = &quota.PeriodSpendingLimitsPatch{}
+			for key, target := range map[string]**float64{
+				"5h": &patch.FiveHour, "day": &patch.Day, "week": &patch.Week, "month": &patch.Month,
+			} {
+				rawValue, exists := object[key]
+				if !exists {
+					continue
+				}
+				parsed, err := jsonNumberFloat(rawValue)
+				if err != nil {
+					return fmt.Errorf("period-spending-limits.%s: %w", key, err)
+				}
+				*target = &parsed
+			}
+		}
+		if _, err := quota.ResolveLegacyDay(legacy, patch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func jsonNumberFloat(value any) (float64, error) {
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("must be a number")
+	}
+	parsed, err := number.Float64()
+	if err != nil {
+		return 0, err
+	}
+	return parsed, nil
+}

--- a/internal/api/handlers/management/period_payload_test.go
+++ b/internal/api/handlers/management/period_payload_test.go
@@ -1,0 +1,20 @@
+package management
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
+
+func TestValidatePeriodPayloadJSONDetectsNormalizedDayConflict(t *testing.T) {
+	if err := validatePeriodPayloadJSON([]byte(`{"items":[{"daily-spending-limit":10.1,"period-spending-limits":{"day":11}}]}`)); err != nil {
+		t.Fatalf("same normalized day: %v", err)
+	}
+	if err := validatePeriodPayloadJSON([]byte(`{"items":[{"daily-spending-limit":10,"period-spending-limits":{"day":11}}]}`)); !errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		t.Fatalf("conflict err = %v", err)
+	}
+	if err := validatePeriodPayloadJSON([]byte(`{"period-spending-limits":{"week":-1}}`)); !errors.Is(err, quota.ErrInvalidSpendingLimit) {
+		t.Fatalf("negative err = %v", err)
+	}
+}

--- a/internal/api/handlers/management/period_quota_test.go
+++ b/internal/api/handlers/management/period_quota_test.go
@@ -1,0 +1,74 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestPatchEndUserRejectsLegacyPeriodDayConflict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, principal, _, endUserID := setupEndUserDailySpendingHandlerTest(t)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Set(managementPrincipalKey, principal)
+	ctx.Params = gin.Params{{Key: "id", Value: endUserID}}
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/end-users/"+endUserID, bytes.NewBufferString(`{
+		"daily-spending-limit":10,
+		"period-spending-limits":{"day":20}
+	}`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	h.PatchEndUser(ctx)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error.Code != "period_day_legacy_conflict" {
+		t.Fatalf("code = %q, want period_day_legacy_conflict", body.Error.Code)
+	}
+}
+
+func TestPostEndUserAPIKeyRejectsLimitAboveAccount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, principal, _, endUserID := setupEndUserDailySpendingHandlerTest(t)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Set(managementPrincipalKey, principal)
+	ctx.Params = gin.Params{{Key: "id", Value: endUserID}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/end-users/"+endUserID+"/api-keys", bytes.NewBufferString(`{
+		"name":"too-large",
+		"period-spending-limits":{"day":200}
+	}`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	h.PostEndUserAPIKey(ctx)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Details struct {
+				Period       string  `json:"period"`
+				KeyLimit     float64 `json:"key_limit"`
+				AccountLimit float64 `json:"account_limit"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error.Code != "key_period_limit_exceeds_account" || body.Error.Details.Period != "day" || body.Error.Details.KeyLimit != 200 || body.Error.Details.AccountLimit != 100 {
+		t.Fatalf("error = %+v", body.Error)
+	}
+}

--- a/internal/api/handlers/management/usage_summary_public.go
+++ b/internal/api/handlers/management/usage_summary_public.go
@@ -6,20 +6,29 @@ import (
 
 	"github.com/gin-gonic/gin"
 	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	log "github.com/sirupsen/logrus"
 )
 
 type usageSummaryResponse struct {
-	Found  bool             `json:"found"`
-	Range  string           `json:"range"`
-	Stats  usageStatsBody   `json:"stats"`
-	Limits *usageLimitsBody `json:"limits,omitempty"`
+	Found       bool             `json:"found"`
+	Range       string           `json:"range"`
+	Stats       usageStatsBody   `json:"stats"`
+	Limits      *usageLimitsBody `json:"limits,omitempty"`
+	QuotaScopes []quotaScopeBody `json:"quota-scopes,omitempty"`
 }
 
 type usageStatsBody struct {
 	TotalCalls int64   `json:"total_calls"`
 	QuotaCost  float64 `json:"quota_cost"`
+}
+
+type quotaScopeBody struct {
+	Scope                string                 `json:"scope"`
+	PeriodSpending       []quota.PeriodSpending `json:"period-spending"`
+	DailySpendingUsed    float64                `json:"daily-spending-used"`
+	LifetimeSpendingUsed float64                `json:"lifetime-spending-used"`
 }
 
 // usageLimitsBody exposes only limits that are configured (>0) plus live usage.
@@ -68,6 +77,12 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 	if subject.EndUserID != "" {
 		limits = buildEndUserUsageLimits(subject.EndUserID)
 	}
+	quotaScopes, err := buildPublicQuotaScopes(subject, row)
+	if err != nil {
+		log.Warnf("management usage summary quota scopes failed: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query quota usage"})
+		return
+	}
 
 	resp := usageSummaryResponse{
 		Found: found,
@@ -76,7 +91,8 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 			TotalCalls: stats.Total,
 			QuotaCost:  stats.TotalCost,
 		},
-		Limits: limits,
+		Limits:      limits,
+		QuotaScopes: quotaScopes,
 	}
 	c.JSON(http.StatusOK, resp)
 }
@@ -174,4 +190,33 @@ func buildPublicUsageLimits(apiKey string, row *usage.APIKeyRow) *usageLimitsBod
 		return nil
 	}
 	return out
+}
+
+func buildPublicQuotaScopes(subject publicUsageSubject, row *usage.APIKeyRow) ([]quotaScopeBody, error) {
+	out := make([]quotaScopeBody, 0, 2)
+	if subject.EndUserID != "" {
+		accountQuota := usage.GetEndUserQuota(subject.EndUserID)
+		if accountQuota != nil {
+			effective := usage.EffectiveEndUserQuota(*accountQuota)
+			used, err := usage.QueryPeriodSpendingByEndUserForTenant(subject.TenantID, subject.EndUserID)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, quotaScopeBody{Scope: "account", PeriodSpending: quota.BuildPeriodSpending(effective.PeriodSpendingLimits, used), DailySpendingUsed: used.Day, LifetimeSpendingUsed: used.Lifetime})
+		}
+		// Portal token requests represent the account only. Raw owned keys include both scopes.
+		if subject.APIKey == "" {
+			return out, nil
+		}
+	}
+	if row != nil && !row.Disabled {
+		keyLimits := row.PeriodSpendingLimits
+		keyLimits.Day = row.DailySpendingLimit
+		used, err := usage.QueryPeriodSpendingByAPIKeyIDForTenant(subject.TenantID, row.ID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, quotaScopeBody{Scope: "key", PeriodSpending: quota.BuildPeriodSpending(keyLimits, used), DailySpendingUsed: used.Day, LifetimeSpendingUsed: used.Lifetime})
+	}
+	return out, nil
 }

--- a/internal/api/handlers/management/usage_summary_public_test.go
+++ b/internal/api/handlers/management/usage_summary_public_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -392,9 +393,22 @@ func TestGetPublicUsageSummary_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 	keyA := "sk-business-owned-a"
 	keyB := "sk-business-owned-b"
 	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := usage.RuntimeDB().Exec(`CREATE TABLE IF NOT EXISTS end_users (
+		id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, display_name TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'active',
+		permission_profile_id TEXT NOT NULL DEFAULT '', daily_limit INTEGER NOT NULL DEFAULT 0, total_quota INTEGER NOT NULL DEFAULT 0,
+		spending_limit REAL NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+		five_hour_spending_limit REAL NOT NULL DEFAULT 0, weekly_spending_limit REAL NOT NULL DEFAULT 0, monthly_spending_limit REAL NOT NULL DEFAULT 0,
+		concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0, tpm_limit INTEGER NOT NULL DEFAULT 0,
+		allowed_models TEXT NOT NULL DEFAULT '[]', allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]', system_prompt TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+	if _, err := usage.RuntimeDB().Exec(`INSERT INTO end_users(id,tenant_id,display_name,daily_spending_limit) VALUES(?,?,?,300)`, endUserID, tenantID, "Business"); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
 	for _, row := range []usage.APIKeyRow{
-		{ID: "00000000-0000-0000-0000-0000000000a1", Key: keyA, Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
-		{ID: "00000000-0000-0000-0000-0000000000b1", Key: keyB, Name: "Automation", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: "00000000-0000-0000-0000-0000000000a1", Key: keyA, Name: "Laptop", EndUserID: endUserID, DailySpendingLimit: 100, PeriodSpendingLimits: quota.PeriodSpendingLimits{Day: 100}, CreatedAt: now, UpdatedAt: now},
+		{ID: "00000000-0000-0000-0000-0000000000b1", Key: keyB, Name: "Automation", EndUserID: endUserID, DailySpendingLimit: 100, PeriodSpendingLimits: quota.PeriodSpendingLimits{Day: 100}, CreatedAt: now, UpdatedAt: now},
 	} {
 		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
 			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
@@ -419,11 +433,18 @@ func TestGetPublicUsageSummary_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 		Stats struct {
 			TotalCalls int64 `json:"total_calls"`
 		} `json:"stats"`
+		QuotaScopes []struct {
+			Scope          string                 `json:"scope"`
+			PeriodSpending []quota.PeriodSpending `json:"period-spending"`
+		} `json:"quota-scopes"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if !got.Found || got.Stats.TotalCalls != 2 {
 		t.Fatalf("summary = %+v, want found and two account calls", got)
+	}
+	if len(got.QuotaScopes) != 2 || got.QuotaScopes[0].Scope != "account" || got.QuotaScopes[1].Scope != "key" {
+		t.Fatalf("quota scopes = %+v, want account then key", got.QuotaScopes)
 	}
 }

--- a/internal/api/middleware/quota.go
+++ b/internal/api/middleware/quota.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -203,6 +205,10 @@ func QuotaMiddleware() gin.HandlerFunc {
 		tpmLimit := parseIntMetadata(metadata, "tpm-limit")
 		spendingLimit := parseFloatMetadata(metadata, "spending-limit")
 		dailySpendingLimit := parseFloatMetadata(metadata, "daily-spending-limit")
+		accountPeriodLimits := parsePeriodLimitsMetadata(metadata, "account-period-spending-limit-")
+		keyPeriodLimits := parsePeriodLimitsMetadata(metadata, "key-period-spending-limit-")
+		tenantID := strings.TrimSpace(metadata["tenant-id"])
+		apiKeyID := strings.TrimSpace(metadata["api-key-id"])
 		diagnostics.SetQuotaLimits(c, diagnostics.QuotaSnapshot{
 			DailyLimit:         dailyLimit,
 			TotalQuota:         totalQuota,
@@ -217,7 +223,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 		UpdateKeyLimits(subject, rpmLimit, tpmLimit)
 
 		// No limits configured — skip all checks
-		if dailyLimit <= 0 && totalQuota <= 0 && concurrencyLimit <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 && dailySpendingLimit <= 0 {
+		if dailyLimit <= 0 && totalQuota <= 0 && concurrencyLimit <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 && dailySpendingLimit <= 0 && !hasPeriodLimits(accountPeriodLimits) && !hasPeriodLimits(keyPeriodLimits) {
 			c.Next()
 			return
 		}
@@ -258,7 +264,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if dailyLimit > 0 {
 			todayCount, err := countTodayUsage(apiKey, endUserID)
 			if err != nil {
-				log.Warnf("quota: failed to query daily usage for key %s: %v", maskKey(apiKey), err)
+				rejectQuotaUsageUnavailable(c, quotaScope(endUserID), "day", tenantID, stableQuotaSubject(apiKeyID, endUserID), err)
+				return
 			} else if todayCount >= int64(dailyLimit) {
 				rejectQuotaLimit(c, "daily", float64(dailyLimit), float64(todayCount), "daily_limit_exceeded",
 					fmt.Sprintf("Daily request limit exceeded: %d/%d requests used today. Raise the daily request limit in the permission profile, or wait until the next project day.", todayCount, dailyLimit))
@@ -270,7 +277,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if totalQuota > 0 {
 			totalCount, err := countTotalUsage(apiKey, endUserID)
 			if err != nil {
-				log.Warnf("quota: failed to query total usage for key %s: %v", maskKey(apiKey), err)
+				rejectQuotaUsageUnavailable(c, quotaScope(endUserID), "lifetime", tenantID, stableQuotaSubject(apiKeyID, endUserID), err)
+				return
 			} else if totalCount >= int64(totalQuota) {
 				rejectQuotaLimit(c, "total", float64(totalQuota), float64(totalCount), "total_quota_exceeded",
 					fmt.Sprintf("Total request quota exhausted: %d/%d lifetime requests used. Raise the total request quota in the permission profile to continue.", totalCount, totalQuota))
@@ -282,7 +290,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if spendingLimit > 0 {
 			totalCost, err := queryTotalCostUsage(apiKey, endUserID)
 			if err != nil {
-				log.Warnf("quota: failed to query total cost for key %s: %v", maskKey(apiKey), err)
+				rejectQuotaUsageUnavailable(c, quotaScope(endUserID), "lifetime", tenantID, stableQuotaSubject(apiKeyID, endUserID), err)
+				return
 			} else if totalCost >= spendingLimit {
 				rejectQuotaLimit(c, "spending", spendingLimit, totalCost, "spending_limit_exceeded",
 					fmt.Sprintf("Lifetime spending limit exceeded: $%.2f of $%.2f used. Raise the spending limit to continue.", totalCost, spendingLimit))
@@ -291,10 +300,11 @@ func QuotaMiddleware() gin.HandlerFunc {
 		}
 
 		// --- Daily spending limit check (from usage DB) ---
-		if dailySpendingLimit > 0 {
+		if dailySpendingLimit > 0 && accountPeriodLimits.Day <= 0 && keyPeriodLimits.Day <= 0 {
 			todayCost, err := queryTodayCostUsage(apiKey, endUserID)
 			if err != nil {
-				log.Warnf("quota: failed to query today cost for key %s: %v", maskKey(apiKey), err)
+				rejectQuotaUsageUnavailable(c, quotaScope(endUserID), "day", tenantID, stableQuotaSubject(apiKeyID, endUserID), err)
+				return
 			} else if todayCost >= dailySpendingLimit {
 				rejectQuotaLimit(c, "daily_spending", dailySpendingLimit, todayCost, "daily_spending_limit_exceeded",
 					fmt.Sprintf("Daily spending limit exceeded: $%.2f of $%.2f used today. Raise the daily spending limit in the permission profile, reset today's spending, or wait until the next project day.", todayCost, dailySpendingLimit))
@@ -302,8 +312,99 @@ func QuotaMiddleware() gin.HandlerFunc {
 			}
 		}
 
+		if hasPeriodLimits(accountPeriodLimits) {
+			used, err := queryPeriodByEndUserFunc(tenantID, endUserID)
+			if err != nil {
+				rejectQuotaUsageUnavailable(c, "account", "period", tenantID, endUserID, err)
+				return
+			}
+			if rejectConfiguredPeriod(c, "account", accountPeriodLimits, used) {
+				return
+			}
+		}
+		if hasPeriodLimits(keyPeriodLimits) {
+			used, err := queryPeriodByKeyFunc(tenantID, apiKeyID)
+			if err != nil {
+				rejectQuotaUsageUnavailable(c, "key", "period", tenantID, apiKeyID, err)
+				return
+			}
+			if rejectConfiguredPeriod(c, "key", keyPeriodLimits, used) {
+				return
+			}
+		}
+
 		c.Next()
 	}
+}
+
+func rejectConfiguredPeriod(c *gin.Context, scope string, limits quota.PeriodSpendingLimits, used quota.PeriodSpendingUsage) bool {
+	for _, period := range quota.OrderedPeriods {
+		limit := limits.Value(period)
+		current := used.Value(period)
+		if limit <= 0 || current < limit {
+			continue
+		}
+		code := "period_spending_limit_exceeded"
+		if period == quota.PeriodDay {
+			code = "daily_spending_limit_exceeded"
+		}
+		scopeLabel := "Key"
+		if scope == "account" {
+			scopeLabel = "Account"
+		}
+		message := fmt.Sprintf("%s %s spending limit exceeded: $%.2f of $%.2f used.", scopeLabel, period, current, limit)
+		rejectPeriodQuotaLimit(c, scope, period, limit, current, code, message)
+		return true
+	}
+	return false
+}
+
+func rejectPeriodQuotaLimit(c *gin.Context, scope string, period quota.Period, limit, current float64, code, message string) {
+	const errType = "rate_limit_exceeded"
+	diagnostics.SetQuotaRejection(c, "period_spending", limit, current, code, errType, message)
+	c.Header("X-CliRelay-Quota-Code", code)
+	c.Header("X-CliRelay-Quota-Rejected-By", "period_spending")
+	c.Header("X-CliRelay-Quota-Scope", scope)
+	c.Header("X-CliRelay-Quota-Period", string(period))
+	c.Header("X-CliRelay-Quota-Limit", formatQuotaNumber(limit))
+	c.Header("X-CliRelay-Quota-Current", formatQuotaNumber(current))
+	c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": gin.H{
+		"message": message, "type": errType, "code": code, "scope": scope, "period": period,
+	}})
+}
+
+func rejectQuotaUsageUnavailable(c *gin.Context, scope, period, tenantID, subjectID string, err error) {
+	log.WithError(err).WithFields(log.Fields{"tenant": tenantID, "scope": scope, "period": period, "subject_id": subjectID}).Error("quota usage query unavailable")
+	c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{
+		"code": "quota_usage_unavailable", "message": "Quota usage is temporarily unavailable", "scope": scope, "period": period,
+	}})
+}
+
+func quotaScope(endUserID string) string {
+	if strings.TrimSpace(endUserID) != "" {
+		return "account"
+	}
+	return "key"
+}
+
+func stableQuotaSubject(apiKeyID, endUserID string) string {
+	if strings.TrimSpace(endUserID) != "" {
+		return strings.TrimSpace(endUserID)
+	}
+	return strings.TrimSpace(apiKeyID)
+}
+
+func parsePeriodLimitsMetadata(metadata map[string]string, prefix string) quota.PeriodSpendingLimits {
+	return quota.PeriodSpendingLimits{
+		FiveHour: parseFloatMetadata(metadata, prefix+"5h"),
+		Day:      parseFloatMetadata(metadata, prefix+"day"),
+		Week:     parseFloatMetadata(metadata, prefix+"week"),
+		Month:    parseFloatMetadata(metadata, prefix+"month"),
+	}
+}
+
+func hasPeriodLimits(limits quota.PeriodSpendingLimits) bool {
+	return limits.FiveHour > 0 || limits.Day > 0 || limits.Week > 0 || limits.Month > 0
 }
 
 // rejectQuotaLimit writes a 429 with a distinct code/message and diagnostic headers.
@@ -333,18 +434,26 @@ func formatQuotaNumber(v float64) string {
 
 // ─── Usage DB query functions (injected to avoid import cycle) ──────────────
 
+var errQuotaUsageUnavailable = errors.New("quota usage unavailable")
+
 // Key-scoped defaults; InitQuotaUsageFuncs wires real implementations.
 // When endUserID is set, InitQuotaUsageFuncs also wires account-scoped aggregators.
 var (
-	countTodayByKeyFunc     = func(string) (int64, error) { return 0, nil }
-	countTotalByKeyFunc     = func(string) (int64, error) { return 0, nil }
-	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
-	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+	countTodayByKeyFunc     = func(string) (int64, error) { return 0, errQuotaUsageUnavailable }
+	countTotalByKeyFunc     = func(string) (int64, error) { return 0, errQuotaUsageUnavailable }
+	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, errQuotaUsageUnavailable }
+	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, errQuotaUsageUnavailable }
 
-	countTodayByEndUserFunc     = func(string) (int64, error) { return 0, nil }
-	countTotalByEndUserFunc     = func(string) (int64, error) { return 0, nil }
-	queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
-	queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+	countTodayByEndUserFunc     = func(string) (int64, error) { return 0, errQuotaUsageUnavailable }
+	countTotalByEndUserFunc     = func(string) (int64, error) { return 0, errQuotaUsageUnavailable }
+	queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, errQuotaUsageUnavailable }
+	queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, errQuotaUsageUnavailable }
+	queryPeriodByKeyFunc        = func(string, string) (quota.PeriodSpendingUsage, error) {
+		return quota.PeriodSpendingUsage{}, errQuotaUsageUnavailable
+	}
+	queryPeriodByEndUserFunc = func(string, string) (quota.PeriodSpendingUsage, error) {
+		return quota.PeriodSpendingUsage{}, errQuotaUsageUnavailable
+	}
 )
 
 // InitQuotaUsageFuncs injects the usage DB query functions into the middleware.
@@ -373,6 +482,14 @@ func InitQuotaEndUserUsageFuncs(
 	countTotalByEndUserFunc = countTotal
 	queryTotalCostByEndUserFunc = totalCost
 	queryTodayCostByEndUserFunc = todayCost
+}
+
+func InitQuotaPeriodUsageFuncs(
+	keyUsage func(string, string) (quota.PeriodSpendingUsage, error),
+	endUserUsage func(string, string) (quota.PeriodSpendingUsage, error),
+) {
+	queryPeriodByKeyFunc = keyUsage
+	queryPeriodByEndUserFunc = endUserUsage
 }
 
 func countTodayUsage(apiKey, endUserID string) (int64, error) {

--- a/internal/api/middleware/quota_test.go
+++ b/internal/api/middleware/quota_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 )
 
 func TestQuotaMiddlewareEnforcesConcurrencyLimitPerKey(t *testing.T) {
@@ -245,10 +247,95 @@ func resetQuotaMiddlewareState(t *testing.T) {
 	countTotalByKeyFunc = func(string) (int64, error) { return 0, nil }
 	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
 	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+	countTodayByEndUserFunc = func(string) (int64, error) { return 0, nil }
+	countTotalByEndUserFunc = func(string) (int64, error) { return 0, nil }
+	queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+	queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+	queryPeriodByKeyFunc = func(string, string) (quota.PeriodSpendingUsage, error) { return quota.PeriodSpendingUsage{}, nil }
+	queryPeriodByEndUserFunc = func(string, string) (quota.PeriodSpendingUsage, error) { return quota.PeriodSpendingUsage{}, nil }
 	t.Cleanup(func() {
 		countTodayByKeyFunc = func(string) (int64, error) { return 0, nil }
 		countTotalByKeyFunc = func(string) (int64, error) { return 0, nil }
 		queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
 		queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+		countTodayByEndUserFunc = func(string) (int64, error) { return 0, nil }
+		countTotalByEndUserFunc = func(string) (int64, error) { return 0, nil }
+		queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+		queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+		queryPeriodByKeyFunc = func(string, string) (quota.PeriodSpendingUsage, error) { return quota.PeriodSpendingUsage{}, nil }
+		queryPeriodByEndUserFunc = func(string, string) (quota.PeriodSpendingUsage, error) { return quota.PeriodSpendingUsage{}, nil }
 	})
+}
+
+func TestQuotaMiddlewareRejectsAccountAndKeyPeriodScopesSeparately(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cases := []struct {
+		name        string
+		accountUsed float64
+		keyUsed     float64
+		wantScope   string
+	}{
+		{name: "account ceiling", accountUsed: 100, keyUsed: 10, wantScope: "account"},
+		{name: "key sub quota", accountUsed: 10, keyUsed: 20, wantScope: "key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetQuotaMiddlewareState(t)
+			queryPeriodByEndUserFunc = func(tenantID, endUserID string) (quota.PeriodSpendingUsage, error) {
+				return quota.PeriodSpendingUsage{Day: tc.accountUsed}, nil
+			}
+			queryPeriodByKeyFunc = func(tenantID, apiKeyID string) (quota.PeriodSpendingUsage, error) {
+				return quota.PeriodSpendingUsage{Day: tc.keyUsed}, nil
+			}
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("apiKey", "sk-period")
+				c.Set("accessMetadata", map[string]string{
+					"tenant-id": "tenant-a", "end-user-id": "user-a", "api-key-id": "key-a",
+					"account-period-spending-limit-day": "100", "key-period-spending-limit-day": "20",
+				})
+				c.Next()
+			})
+			router.Use(QuotaMiddleware())
+			router.POST("/v1/chat/completions", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, newQuotaPostRequest("sk-period"))
+			if recorder.Code != http.StatusTooManyRequests {
+				t.Fatalf("status = %d, want 429; body=%s", recorder.Code, recorder.Body.String())
+			}
+			if got := recorder.Header().Get("X-CliRelay-Quota-Scope"); got != tc.wantScope {
+				t.Fatalf("scope = %q, want %q", got, tc.wantScope)
+			}
+			if got := recorder.Header().Get("X-CliRelay-Quota-Period"); got != "day" {
+				t.Fatalf("period = %q, want day", got)
+			}
+		})
+	}
+}
+
+func TestQuotaMiddlewareFailsClosedWhenUsageUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetQuotaMiddlewareState(t)
+	queryPeriodByEndUserFunc = func(string, string) (quota.PeriodSpendingUsage, error) {
+		return quota.PeriodSpendingUsage{}, errors.New("database unavailable")
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("apiKey", "sk-period")
+		c.Set("accessMetadata", map[string]string{
+			"tenant-id": "tenant-a", "end-user-id": "user-a", "api-key-id": "key-a",
+			"account-period-spending-limit-week": "100",
+		})
+		c.Next()
+	})
+	router.Use(QuotaMiddleware())
+	router.POST("/v1/chat/completions", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, newQuotaPostRequest("sk-period"))
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), `"code":"quota_usage_unavailable"`) {
+		t.Fatalf("body = %s, want quota_usage_unavailable", recorder.Body.String())
+	}
 }

--- a/internal/api/routes/management_identity_routes.go
+++ b/internal/api/routes/management_identity_routes.go
@@ -32,6 +32,8 @@ func registerIdentityAuthRoutes(engine *gin.Engine, h *managementhandlers.Handle
 	portal.GET("/api-keys/:id/secret", h.GetPortalAPIKeySecret)
 	portal.PATCH("/api-keys/:id", h.PatchPortalAPIKey)
 	portal.POST("/api-keys/:id/rotate", h.PostPortalAPIKeyRotate)
+	portal.POST("/api-keys/:id/daily-spending/reset", h.PostPortalAPIKeyDailySpendingReset)
+	portal.GET("/api-keys/:id/daily-spending/reset-history", h.GetPortalAPIKeyDailySpendingResetHistory)
 	portal.DELETE("/api-keys/:id", h.DeletePortalAPIKey)
 }
 
@@ -59,6 +61,8 @@ func registerManagementIdentityRoutes(group *gin.RouterGroup, h *managementhandl
 	group.POST("/end-users/:id/api-keys", h.PostEndUserAPIKey)
 	group.PATCH("/end-users/:id/api-keys/:key_id", h.PatchEndUserAPIKey)
 	group.POST("/end-users/:id/api-keys/:key_id/rotate", h.PostEndUserAPIKeyRotate)
+	group.POST("/end-users/:id/api-keys/:key_id/daily-spending/reset", h.PostEndUserAPIKeyDailySpendingReset)
+	group.GET("/end-users/:id/api-keys/:key_id/daily-spending/reset-history", h.GetEndUserAPIKeyDailySpendingResetHistory)
 	group.DELETE("/end-users/:id/api-keys/:key_id", h.DeleteEndUserAPIKey)
 	group.POST("/end-users/:id/api-keys/:key_id/default", h.PostEndUserAPIKeyDefault)
 

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 294; got != want {
+	if got, want := len(routes), 298; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -46,6 +46,10 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"POST /v0/management/api-call",
 		"PATCH /v0/management/api-key-entries",
 		"GET /v0/management/end-users/:id/daily-spending/reset-history",
+		"POST /v0/portal/api-keys/:id/daily-spending/reset",
+		"GET /v0/portal/api-keys/:id/daily-spending/reset-history",
+		"POST /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset",
+		"GET /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset-history",
 		"POST /v0/management/opencode-go-api-key/usage",
 		"GET /v0/management/cline-api-key",
 		"PUT /v0/management/cline-api-key",
@@ -186,6 +190,8 @@ func expectedManagementRoutes() []string {
 		"GET /v0/portal/api-keys/:id/secret",
 		"PATCH /v0/portal/api-keys/:id",
 		"POST /v0/portal/api-keys/:id/rotate",
+		"POST /v0/portal/api-keys/:id/daily-spending/reset",
+		"GET /v0/portal/api-keys/:id/daily-spending/reset-history",
 		"DELETE /v0/portal/api-keys/:id",
 		"POST /v0/portal/auth/login",
 		"POST /v0/portal/auth/logout",
@@ -222,6 +228,8 @@ func expectedManagementRoutes() []string {
 		"POST /v0/management/end-users/:id/api-keys",
 		"PATCH /v0/management/end-users/:id/api-keys/:key_id",
 		"POST /v0/management/end-users/:id/api-keys/:key_id/rotate",
+		"POST /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset",
+		"GET /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset-history",
 		"DELETE /v0/management/end-users/:id/api-keys/:key_id",
 		"POST /v0/management/end-users/:id/api-keys/:key_id/default",
 		"GET /v0/management/audit-logs",

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -186,6 +186,7 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 	settingsstore.ApplyStoredRuntimeSettings(cfg)
 	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey, usage.QueryTodayCostByKey)
 	middleware.InitQuotaEndUserUsageFuncs(usage.CountTodayByEndUser, usage.CountTotalByEndUser, usage.QueryTotalCostByEndUser, usage.QueryTodayCostByEndUser)
+	middleware.InitQuotaPeriodUsageFuncs(usage.QueryPeriodSpendingByAPIKeyIDForTenant, usage.QueryPeriodSpendingByEndUserForTenant)
 	usage.SetTokenUsageCallback(func(apiKey string, totalTokens int64) {
 		endUserID := ""
 		if row := usage.GetAPIKey(apiKey); row != nil {

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -4,6 +4,8 @@
 // debug settings, proxy configuration, and API keys.
 package config
 
+import "github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+
 // SDKConfig represents the application's configuration, loaded from a YAML file.
 type SDKConfig struct {
 	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
@@ -148,6 +150,13 @@ type APIKeyEntry struct {
 	// unlimited. It resets at the project timezone day boundary. When permission-profile-id
 	// is set, the effective value comes from the permission profile.
 	DailySpendingLimit float64 `yaml:"daily-spending-limit,omitempty" json:"daily-spending-limit,omitempty"`
+
+	// PeriodSpendingLimits contains fixed 5h/day/week/month USD limits. Day mirrors DailySpendingLimit.
+	PeriodSpendingLimits quota.PeriodSpendingLimits `yaml:"period-spending-limits,omitempty" json:"period-spending-limits"`
+
+	// PeriodSpending and LifetimeSpendingUsed are management-list runtime facts.
+	PeriodSpending       []quota.PeriodSpending `yaml:"-" json:"period-spending"`
+	LifetimeSpendingUsed float64                `yaml:"-" json:"lifetime-spending-used"`
 
 	// DailySpendingUsed is the effective project-day USD cost for this key (management list only).
 	// After a same-day manual reset, only costs after the reset baseline count.

--- a/internal/enduser/period_quota.go
+++ b/internal/enduser/period_quota.go
@@ -1,0 +1,255 @@
+package enduser
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func (s *Service) CreateKeyWithPeriodLimits(ctx context.Context, tenantID, endUserID, name string, patch *quota.PeriodSpendingLimitsPatch) (CreateKeyResult, error) {
+	var result CreateKeyResult
+	if err := requireUUID(tenantID); err != nil {
+		return result, err
+	}
+	if err := requireUUID(endUserID); err != nil {
+		return result, err
+	}
+	patch, err := quota.NormalizePatch(patch)
+	if err != nil {
+		return result, fmt.Errorf("%w: %v", ErrValidation, err)
+	}
+	limits := quota.ApplyPatch(quota.PeriodSpendingLimits{}, patch)
+	if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+		return result, ErrFiveHourProjectionWarming
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	status, accountLimits, err := effectiveAccountPeriodLimitsTx(ctx, tx, tenantID, endUserID)
+	if err != nil {
+		return result, err
+	}
+	if status != "active" {
+		return result, fmt.Errorf("%w: cannot create api key for non-active end user", ErrValidation)
+	}
+	if err := quota.ValidateKeyWithinAccount(limits, accountLimits); err != nil {
+		return result, err
+	}
+	var count int
+	_ = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0`, tenantID, endUserID).Scan(&count)
+	isDefault := count == 0
+	var plain string
+	for attempt := 0; attempt < 8; attempt++ {
+		plain, err = GenerateAPIKey()
+		if err != nil {
+			return result, err
+		}
+		var exists int
+		if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE key = ?`, plain).Scan(&exists); err != nil {
+			return result, err
+		}
+		if exists == 0 {
+			break
+		}
+	}
+	id := uuid.NewString()
+	now := time.Now().UTC().Format(time.RFC3339)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return result, fmt.Errorf("%w: key name is required", ErrValidation)
+	}
+	if err = ensureUniqueKeyName(ctx, tx, tenantID, endUserID, name, ""); err != nil {
+		return result, err
+	}
+	if _, err = tx.ExecContext(ctx, `
+		INSERT INTO api_keys (key, id, name, disabled, end_user_id, is_default, tenant_id, created_at, updated_at,
+			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit,
+			concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt)
+		VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?,
+			'', 0, 0, 0, ?, ?, ?, ?, 0, 0, 0, '[]', '[]', '[]', '')
+	`, plain, id, name, endUserID, isDefault, tenantID, now, now,
+		limits.Day, limits.FiveHour, limits.Week, limits.Month); err != nil {
+		return result, err
+	}
+	if err = tx.Commit(); err != nil {
+		return result, err
+	}
+	result.APIKey = APIKey{
+		ID: id, TenantID: tenantID, EndUserID: endUserID, Name: name, IsDefault: isDefault,
+		KeyMasked: MaskAPIKey(plain), CreatedAt: now, UpdatedAt: now,
+		DailySpendingLimit: limits.Day, PeriodSpendingLimits: limits,
+	}
+	result.PlaintextKey = plain
+	return result, nil
+}
+
+func (s *Service) UpdateKey(ctx context.Context, tenantID, endUserID, keyID string, name *string, patch *quota.PeriodSpendingLimitsPatch) error {
+	if err := requireUUID(tenantID); err != nil {
+		return err
+	}
+	if err := requireUUID(endUserID); err != nil {
+		return err
+	}
+	if err := requireUUID(keyID); err != nil {
+		return err
+	}
+	patch, err := quota.NormalizePatch(patch)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrValidation, err)
+	}
+	if patch != nil && patch.FiveHour != nil && *patch.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+		return ErrFiveHourProjectionWarming
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	_, accountLimits, err := effectiveAccountPeriodLimitsTx(ctx, tx, tenantID, endUserID)
+	if err != nil {
+		return err
+	}
+	var currentName string
+	var current quota.PeriodSpendingLimits
+	if err := tx.QueryRowContext(ctx, `
+		SELECT name, COALESCE(daily_spending_limit,0), COALESCE(five_hour_spending_limit,0),
+		       COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0)
+		FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0
+	`, tenantID, endUserID, keyID).Scan(&currentName, &current.Day, &current.FiveHour, &current.Week, &current.Month); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+	updated := quota.ApplyPatch(current, patch)
+	if err := quota.ValidateKeyWithinAccount(updated, accountLimits); err != nil {
+		return err
+	}
+	if name != nil {
+		currentName = strings.TrimSpace(*name)
+		if currentName == "" {
+			return fmt.Errorf("%w: name required", ErrValidation)
+		}
+		if err := ensureUniqueKeyName(ctx, tx, tenantID, endUserID, currentName, keyID); err != nil {
+			return err
+		}
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE api_keys SET name = ?, daily_spending_limit = ?, five_hour_spending_limit = ?,
+		       weekly_spending_limit = ?, monthly_spending_limit = ?, updated_at = ?
+		WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0
+	`, currentName, updated.Day, updated.FiveHour, updated.Week, updated.Month,
+		time.Now().UTC().Format(time.RFC3339), tenantID, endUserID, keyID)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return tx.Commit()
+}
+
+func effectiveAccountPeriodLimitsTx(ctx context.Context, tx *sql.Tx, tenantID, endUserID string) (string, quota.PeriodSpendingLimits, error) {
+	var status, profileID string
+	var limits quota.PeriodSpendingLimits
+	query := `SELECT status, COALESCE(permission_profile_id,''), COALESCE(daily_spending_limit,0),
+	                 COALESCE(five_hour_spending_limit,0), COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0)
+	          FROM end_users WHERE id = ? AND tenant_id = ? FOR UPDATE`
+	err := tx.QueryRowContext(ctx, query, endUserID, tenantID).Scan(&status, &profileID, &limits.Day, &limits.FiveHour, &limits.Week, &limits.Month)
+	if err != nil {
+		err = tx.QueryRowContext(ctx, strings.TrimSuffix(query, " FOR UPDATE"), endUserID, tenantID).Scan(&status, &profileID, &limits.Day, &limits.FiveHour, &limits.Week, &limits.Month)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", quota.PeriodSpendingLimits{}, ErrNotFound
+	}
+	if err != nil {
+		return "", quota.PeriodSpendingLimits{}, err
+	}
+	if profileID != "" {
+		err = tx.QueryRowContext(ctx, `SELECT COALESCE(daily_spending_limit,0), COALESCE(five_hour_spending_limit,0),
+			COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0)
+			FROM api_key_permission_profiles WHERE tenant_id = ? AND id = ?`, tenantID, profileID).
+			Scan(&limits.Day, &limits.FiveHour, &limits.Week, &limits.Month)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return "", quota.PeriodSpendingLimits{}, err
+		}
+	}
+	return status, limits, nil
+}
+
+func capOwnedKeyPeriodLimitsTx(ctx context.Context, tx *sql.Tx, tenantID, endUserID string) ([]quota.CappedKey, error) {
+	_, account, err := effectiveAccountPeriodLimitsTx(ctx, tx, tenantID, endUserID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT id, COALESCE(daily_spending_limit,0), COALESCE(five_hour_spending_limit,0),
+		COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0)
+		FROM api_keys WHERE tenant_id = ? AND end_user_id = ? ORDER BY id ASC`, tenantID, endUserID)
+	if err != nil {
+		return nil, err
+	}
+	type keyLimits struct {
+		id     string
+		limits quota.PeriodSpendingLimits
+	}
+	keys := make([]keyLimits, 0)
+	for rows.Next() {
+		var item keyLimits
+		if err := rows.Scan(&item.id, &item.limits.Day, &item.limits.FiveHour, &item.limits.Week, &item.limits.Month); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		keys = append(keys, item)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	capped := make([]quota.CappedKey, 0)
+	for _, item := range keys {
+		updated := item.limits
+		for _, period := range quota.OrderedPeriods {
+			from, ceiling := updated.Value(period), account.Value(period)
+			if from <= 0 || ceiling <= 0 || from <= ceiling {
+				continue
+			}
+			switch period {
+			case quota.PeriodFiveHour:
+				updated.FiveHour = ceiling
+			case quota.PeriodDay:
+				updated.Day = ceiling
+			case quota.PeriodWeek:
+				updated.Week = ceiling
+			case quota.PeriodMonth:
+				updated.Month = ceiling
+			}
+			capped = append(capped, quota.CappedKey{ID: item.id, Period: period, From: from, To: ceiling})
+		}
+		if updated != item.limits {
+			if _, err := tx.ExecContext(ctx, `UPDATE api_keys SET daily_spending_limit=?, five_hour_spending_limit=?, weekly_spending_limit=?, monthly_spending_limit=?, updated_at=? WHERE tenant_id=? AND id=?`,
+				updated.Day, updated.FiveHour, updated.Week, updated.Month, time.Now().UTC().Format(time.RFC3339), tenantID, item.id); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return capped, nil
+}
+
+func quotaPkgResolveLegacyDay(legacy *float64, patch *quota.PeriodSpendingLimitsPatch) (*quota.PeriodSpendingLimitsPatch, error) {
+	resolved, err := quota.ResolveLegacyDay(legacy, patch)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		return nil, ErrPeriodDayLegacyConflict
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrValidation, err)
+	}
+	return resolved, nil
+}

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -17,27 +17,30 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 )
 
 var (
-	ErrInvalidCredentials = errors.New("invalid credentials")
-	ErrAccountDisabled    = errors.New("account disabled")
-	ErrAccountLocked      = errors.New("account locked")
-	ErrLoginCooldowned    = errors.New("login cooldown")
-	ErrMustChangePassword = errors.New("must change password")
-	ErrSessionExpired     = errors.New("session expired")
-	ErrSessionRevoked     = errors.New("session revoked")
-	ErrPermissionDenied   = errors.New("permission denied")
-	ErrTenantScope        = errors.New("tenant scope forbidden")
-	ErrTenantSuspended    = errors.New("tenant suspended")
-	ErrTenantExpired      = errors.New("tenant expired")
-	ErrValidation         = errors.New("validation failed")
-	ErrDuplicateKeyName   = errors.New("duplicate key name")
-	ErrLastKey            = errors.New("cannot delete last api key")
-	ErrNotFound           = errors.New("not found")
+	ErrInvalidCredentials        = errors.New("invalid credentials")
+	ErrAccountDisabled           = errors.New("account disabled")
+	ErrAccountLocked             = errors.New("account locked")
+	ErrLoginCooldowned           = errors.New("login cooldown")
+	ErrMustChangePassword        = errors.New("must change password")
+	ErrSessionExpired            = errors.New("session expired")
+	ErrSessionRevoked            = errors.New("session revoked")
+	ErrPermissionDenied          = errors.New("permission denied")
+	ErrTenantScope               = errors.New("tenant scope forbidden")
+	ErrTenantSuspended           = errors.New("tenant suspended")
+	ErrTenantExpired             = errors.New("tenant expired")
+	ErrValidation                = errors.New("validation failed")
+	ErrDuplicateKeyName          = errors.New("duplicate key name")
+	ErrLastKey                   = errors.New("cannot delete last api key")
+	ErrNotFound                  = errors.New("not found")
+	ErrFiveHourProjectionWarming = errors.New("five hour quota projection warming")
+	ErrPeriodDayLegacyConflict   = errors.New("period day legacy conflict")
 )
 
 const (
@@ -72,7 +75,20 @@ func Default() *Service {
 	return defaultService
 }
 
-func NewService(db *sql.DB) *Service { return &Service{db: db} }
+func NewService(db *sql.DB) *Service {
+	if db != nil {
+		_ = usage.EnsureEndUserQuotaColumns(db)
+		for _, column := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+			if _, err := db.Exec("ALTER TABLE api_keys ADD COLUMN " + column + " REAL NOT NULL DEFAULT 0"); err != nil {
+				message := strings.ToLower(err.Error())
+				if !strings.Contains(message, "duplicate") && !strings.Contains(message, "no such table") {
+					log.Warnf("enduser: migrate api_keys.%s: %v", column, err)
+				}
+			}
+		}
+	}
+	return &Service{db: db}
+}
 
 func NormalizeUsername(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
@@ -280,7 +296,7 @@ func scanUser(scanner interface{ Scan(dest ...any) error }) (User, error) {
 		&u.MustChangePassword, &lastLogin, &u.FailedLoginCount, &u.LockStage, &lockedUntil,
 		&u.CreatedAt, &u.UpdatedAt, &u.Version,
 		&u.PermissionProfileID, &u.DailyLimit, &u.TotalQuota, &u.SpendingLimit, &u.DailySpendingLimit,
-		&u.ConcurrencyLimit, &u.RPMLimit, &u.TPMLimit,
+		&u.PeriodSpendingLimits.FiveHour, &u.PeriodSpendingLimits.Week, &u.PeriodSpendingLimits.Month, &u.ConcurrencyLimit, &u.RPMLimit, &u.TPMLimit,
 		&modelsJSON, &channelsJSON, &groupsJSON, &u.SystemPrompt,
 	)
 	if err != nil {
@@ -294,6 +310,7 @@ func scanUser(scanner interface{ Scan(dest ...any) error }) (User, error) {
 		t := lockedUntil.Time
 		u.LockedUntil = &t
 	}
+	u.PeriodSpendingLimits.Day = u.DailySpendingLimit
 	u.AllowedModels = decodeJSONStringList(modelsJSON)
 	u.AllowedChannels = decodeJSONStringList(channelsJSON)
 	u.AllowedChannelGroups = decodeJSONStringList(groupsJSON)
@@ -341,6 +358,7 @@ const userSelect = `SELECT id, tenant_id, username, display_name, status, must_c
 	last_login_at, failed_login_count, lock_stage, locked_until, created_at, updated_at, version,
 	COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
 	COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+	COALESCE(five_hour_spending_limit, 0), COALESCE(weekly_spending_limit, 0), COALESCE(monthly_spending_limit, 0),
 	COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
 	COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
 	COALESCE(system_prompt, '')
@@ -475,10 +493,10 @@ func (s *Service) insertDefaultKey(ctx context.Context, tx *sql.Tx, tenantID, en
 	}
 	if _, err = tx.ExecContext(ctx, `
 		INSERT INTO api_keys (key, id, name, disabled, end_user_id, is_default, tenant_id, created_at, updated_at,
-			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
+			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit,
 			concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt)
 		VALUES (?, ?, ?, 0, ?, true, ?, ?, ?,
-			'', 0, 0, 0, 0, 0, 0, 0, '[]', '[]', '[]', '')
+			'', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '[]', '[]', '[]', '')
 	`, plain, id, name, endUserID, tenantID, now, now); err != nil {
 		return APIKey{}, "", err
 	}
@@ -554,7 +572,7 @@ func (s *Service) CreateUser(ctx context.Context, actor identity.Principal, tena
 	return result, nil
 }
 
-func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tenantID, userID string, username, displayName, password, status *string, quota *QuotaPatch) (User, error) {
+func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tenantID, userID string, username, displayName, password, status *string, accountQuotaPatch *QuotaPatch) (User, error) {
 	if !actor.Has("end_users.write") && !actor.PlatformAdmin {
 		return User{}, ErrPermissionDenied
 	}
@@ -574,6 +592,30 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 		return User{}, err
 	}
 	defer func() { _ = tx.Rollback() }()
+	var currentProfileID string
+	profileQuery := `SELECT COALESCE(permission_profile_id,'') FROM end_users WHERE id = ? AND tenant_id = ? FOR UPDATE`
+	if err := tx.QueryRowContext(ctx, profileQuery, userID, tenantID).Scan(&currentProfileID); err != nil {
+		if err = tx.QueryRowContext(ctx, strings.TrimSuffix(profileQuery, " FOR UPDATE"), userID, tenantID).Scan(&currentProfileID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return User{}, ErrNotFound
+			}
+			return User{}, err
+		}
+	}
+	var resolvedPeriodPatch *quota.PeriodSpendingLimitsPatch
+	if accountQuotaPatch != nil {
+		resolvedPeriodPatch, err = quotaPkgResolveLegacyDay(accountQuotaPatch.DailySpendingLimit, accountQuotaPatch.PeriodSpendingLimits)
+		if err != nil {
+			return User{}, err
+		}
+		targetProfileID := currentProfileID
+		if accountQuotaPatch.PermissionProfileID != nil {
+			targetProfileID = strings.TrimSpace(*accountQuotaPatch.PermissionProfileID)
+		}
+		if resolvedPeriodPatch != nil && targetProfileID != "" {
+			return User{}, fmt.Errorf("%w: period limits are managed by permission profile %s", ErrValidation, targetProfileID)
+		}
+	}
 
 	if username != nil {
 		base := NormalizeUsername(*username)
@@ -600,7 +642,7 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 		if err != nil {
 			return User{}, err
 		}
-		sets = append(sets, "password_hash = ?", "must_change_password = false", "password_changed_at = now()",
+		sets = append(sets, "password_hash = ?", "must_change_password = false", "password_changed_at = CURRENT_TIMESTAMP",
 			"failed_login_count = 0", "lock_stage = 0", "locked_until = NULL")
 		args = append(args, hash)
 	}
@@ -615,54 +657,71 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 			sets = append(sets, "failed_login_count = 0", "lock_stage = 0", "locked_until = NULL")
 		}
 	}
-	if quota != nil {
-		if quota.PermissionProfileID != nil {
+	if accountQuotaPatch != nil {
+		if accountQuotaPatch.PermissionProfileID != nil {
 			sets = append(sets, "permission_profile_id = ?")
-			args = append(args, strings.TrimSpace(*quota.PermissionProfileID))
+			args = append(args, strings.TrimSpace(*accountQuotaPatch.PermissionProfileID))
 		}
-		if quota.DailyLimit != nil {
+		if accountQuotaPatch.DailyLimit != nil {
 			sets = append(sets, "daily_limit = ?")
-			args = append(args, clampNonNegInt(*quota.DailyLimit))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.DailyLimit))
 		}
-		if quota.TotalQuota != nil {
+		if accountQuotaPatch.TotalQuota != nil {
 			sets = append(sets, "total_quota = ?")
-			args = append(args, clampNonNegInt(*quota.TotalQuota))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.TotalQuota))
 		}
-		if quota.SpendingLimit != nil {
+		if accountQuotaPatch.SpendingLimit != nil {
 			sets = append(sets, "spending_limit = ?")
-			args = append(args, clampNonNegFloat(*quota.SpendingLimit))
+			args = append(args, clampNonNegFloat(*accountQuotaPatch.SpendingLimit))
 		}
-		if quota.DailySpendingLimit != nil {
-			sets = append(sets, "daily_spending_limit = ?")
-			args = append(args, clampNonNegFloat(*quota.DailySpendingLimit))
+		if resolvedPeriodPatch != nil {
+			if resolvedPeriodPatch.FiveHour != nil {
+				if *resolvedPeriodPatch.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+					return User{}, ErrFiveHourProjectionWarming
+				}
+				sets = append(sets, "five_hour_spending_limit = ?")
+				args = append(args, *resolvedPeriodPatch.FiveHour)
+			}
+			if resolvedPeriodPatch.Day != nil {
+				sets = append(sets, "daily_spending_limit = ?")
+				args = append(args, *resolvedPeriodPatch.Day)
+			}
+			if resolvedPeriodPatch.Week != nil {
+				sets = append(sets, "weekly_spending_limit = ?")
+				args = append(args, *resolvedPeriodPatch.Week)
+			}
+			if resolvedPeriodPatch.Month != nil {
+				sets = append(sets, "monthly_spending_limit = ?")
+				args = append(args, *resolvedPeriodPatch.Month)
+			}
 		}
-		if quota.ConcurrencyLimit != nil {
+		if accountQuotaPatch.ConcurrencyLimit != nil {
 			sets = append(sets, "concurrency_limit = ?")
-			args = append(args, clampNonNegInt(*quota.ConcurrencyLimit))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.ConcurrencyLimit))
 		}
-		if quota.RPMLimit != nil {
+		if accountQuotaPatch.RPMLimit != nil {
 			sets = append(sets, "rpm_limit = ?")
-			args = append(args, clampNonNegInt(*quota.RPMLimit))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.RPMLimit))
 		}
-		if quota.TPMLimit != nil {
+		if accountQuotaPatch.TPMLimit != nil {
 			sets = append(sets, "tpm_limit = ?")
-			args = append(args, clampNonNegInt(*quota.TPMLimit))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.TPMLimit))
 		}
-		if quota.AllowedModels != nil {
+		if accountQuotaPatch.AllowedModels != nil {
 			sets = append(sets, "allowed_models = ?")
-			args = append(args, encodeJSONStringList(*quota.AllowedModels))
+			args = append(args, encodeJSONStringList(*accountQuotaPatch.AllowedModels))
 		}
-		if quota.AllowedChannels != nil {
+		if accountQuotaPatch.AllowedChannels != nil {
 			sets = append(sets, "allowed_channels = ?")
-			args = append(args, encodeJSONStringList(*quota.AllowedChannels))
+			args = append(args, encodeJSONStringList(*accountQuotaPatch.AllowedChannels))
 		}
-		if quota.AllowedChannelGroups != nil {
+		if accountQuotaPatch.AllowedChannelGroups != nil {
 			sets = append(sets, "allowed_channel_groups = ?")
-			args = append(args, encodeJSONStringList(*quota.AllowedChannelGroups))
+			args = append(args, encodeJSONStringList(*accountQuotaPatch.AllowedChannelGroups))
 		}
-		if quota.SystemPrompt != nil {
+		if accountQuotaPatch.SystemPrompt != nil {
 			sets = append(sets, "system_prompt = ?")
-			args = append(args, *quota.SystemPrompt)
+			args = append(args, *accountQuotaPatch.SystemPrompt)
 		}
 	}
 	if len(sets) == 0 {
@@ -670,7 +729,7 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 		return s.GetUser(ctx, tenantID, userID)
 	}
 
-	sets = append(sets, "updated_at = now()", "version = version + 1")
+	sets = append(sets, "updated_at = CURRENT_TIMESTAMP", "version = version + 1")
 	args = append(args, userID, tenantID)
 	q := `UPDATE end_users SET ` + strings.Join(sets, ", ") + ` WHERE id = ? AND tenant_id = ?`
 	res, err := tx.ExecContext(ctx, q, args...)
@@ -682,7 +741,7 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 	}
 	if password != nil && strings.TrimSpace(*password) != "" {
 		if _, err = tx.ExecContext(ctx, `
-			UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'password_change'
+			UPDATE end_user_sessions SET revoked_at = CURRENT_TIMESTAMP, revoke_reason = 'password_change'
 			WHERE end_user_id = ? AND revoked_at IS NULL
 		`, userID); err != nil {
 			return User{}, err
@@ -692,16 +751,39 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 	// that would wipe per-key admin disables on re-activate. Auth refuses non-active accounts.
 	if status != nil && *status != "active" {
 		if _, err = tx.ExecContext(ctx, `
-				UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'status_change'
+				UPDATE end_user_sessions SET revoked_at = CURRENT_TIMESTAMP, revoke_reason = 'status_change'
 				WHERE end_user_id = ? AND revoked_at IS NULL
 			`, userID); err != nil {
 			return User{}, err
 		}
 	}
+	capped, err := capOwnedKeyPeriodLimitsTx(ctx, tx, tenantID, userID)
+	if err != nil {
+		return User{}, err
+	}
 	if err = tx.Commit(); err != nil {
 		return User{}, err
 	}
-	return s.GetUser(ctx, tenantID, userID)
+	updated, err := s.GetUser(ctx, tenantID, userID)
+	if err != nil {
+		return User{}, err
+	}
+	if loaded := usage.GetEndUserQuota(userID); loaded != nil {
+		effective := usage.EffectiveEndUserQuota(*loaded)
+		updated.DailySpendingLimit = effective.DailySpendingLimit
+		updated.PeriodSpendingLimits = effective.PeriodSpendingLimits
+	}
+	updated.CappedKeys = capped
+	if len(capped) > 0 {
+		if audit := identity.Default(); audit != nil {
+			audit.RecordAudit(ctx, identity.AuditEvent{
+				TenantID: tenantID, ActorKind: actor.Kind, ActorUserID: actor.User.ID, ActorSessionID: actor.SessionID,
+				Action: "end_user.period_quota.cap_keys", ResourceType: "end_user", ResourceID: userID, Result: "success",
+				Changes: map[string]any{"capped-keys": capped},
+			})
+		}
+	}
+	return updated, nil
 }
 
 func (s *Service) ResetPassword(ctx context.Context, actor identity.Principal, tenantID, userID, password string) (string, error) {
@@ -736,10 +818,10 @@ func (s *Service) ResetPassword(ctx context.Context, actor identity.Principal, t
 	}
 	defer func() { _ = tx.Rollback() }()
 	res, err := tx.ExecContext(ctx, `
-		UPDATE end_users SET password_hash = ?, must_change_password = true, password_changed_at = now(),
+		UPDATE end_users SET password_hash = ?, must_change_password = true, password_changed_at = CURRENT_TIMESTAMP,
 			failed_login_count = 0, lock_stage = 0, locked_until = NULL,
 			status = CASE WHEN status = 'locked' THEN 'active' ELSE status END,
-			updated_at = now(), version = version + 1
+			updated_at = CURRENT_TIMESTAMP, version = version + 1
 		WHERE id = ? AND tenant_id = ?
 	`, hash, userID, tenantID)
 	if err != nil {
@@ -749,7 +831,7 @@ func (s *Service) ResetPassword(ctx context.Context, actor identity.Principal, t
 		return "", ErrNotFound
 	}
 	if _, err = tx.ExecContext(ctx, `
-		UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'password_reset'
+		UPDATE end_user_sessions SET revoked_at = CURRENT_TIMESTAMP, revoke_reason = 'password_reset'
 		WHERE end_user_id = ? AND revoked_at IS NULL
 	`, userID); err != nil {
 		return "", err
@@ -787,7 +869,7 @@ func (s *Service) DeleteUser(ctx context.Context, actor identity.Principal, tena
 		return err
 	}
 	if _, err = tx.ExecContext(ctx, `
-		UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'user_deleted'
+		UPDATE end_user_sessions SET revoked_at = CURRENT_TIMESTAMP, revoke_reason = 'user_deleted'
 		WHERE end_user_id = ? AND revoked_at IS NULL
 	`, userID); err != nil {
 		return err
@@ -838,7 +920,8 @@ func (s *Service) ListKeys(ctx context.Context, tenantID, endUserID string) ([]A
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, tenant_id, end_user_id, key, name, disabled, COALESCE(is_default, false),
-			COALESCE(created_at, ''), COALESCE(updated_at, '')
+			COALESCE(created_at, ''), COALESCE(updated_at, ''),
+			COALESCE(daily_spending_limit, 0), COALESCE(five_hour_spending_limit, 0), COALESCE(weekly_spending_limit, 0), COALESCE(monthly_spending_limit, 0)
 		FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0
 		ORDER BY is_default DESC, created_at ASC
 	`, tenantID, endUserID)
@@ -847,101 +930,52 @@ func (s *Service) ListKeys(ctx context.Context, tenantID, endUserID string) ([]A
 	}
 	defer rows.Close()
 	out := make([]APIKey, 0)
+	ids := make([]string, 0)
 	for rows.Next() {
 		var k APIKey
-		var endUserID sql.NullString
+		var ownerID sql.NullString
 		var disabledInt int
 		var isDefault bool
-		if err := rows.Scan(&k.ID, &k.TenantID, &endUserID, &k.Key, &k.Name, &disabledInt, &isDefault, &k.CreatedAt, &k.UpdatedAt); err != nil {
+		if err := rows.Scan(&k.ID, &k.TenantID, &ownerID, &k.Key, &k.Name, &disabledInt, &isDefault, &k.CreatedAt, &k.UpdatedAt, &k.DailySpendingLimit, &k.PeriodSpendingLimits.FiveHour, &k.PeriodSpendingLimits.Week, &k.PeriodSpendingLimits.Month); err != nil {
 			return nil, err
 		}
-		if endUserID.Valid {
-			k.EndUserID = endUserID.String
+		if ownerID.Valid {
+			k.EndUserID = ownerID.String
 		}
 		k.Disabled = disabledInt != 0
+		k.PeriodSpendingLimits.Day = k.DailySpendingLimit
 		k.IsDefault = isDefault
 		k.KeyMasked = MaskAPIKey(k.Key)
 		k.Key = "" // never list full secret
 		out = append(out, k)
+		ids = append(ids, k.ID)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if usage.RuntimeDB() == nil {
+		return out, nil
+	}
+	usedByID, err := usage.QueryPeriodSpendingByAPIKeyIDsForTenant(tenantID, ids)
+	if err != nil {
+		return nil, err
+	}
+	resetCounts, err := usage.ListDailySpendingResetEventCounts(tenantID, ids)
+	if err != nil {
+		return nil, err
+	}
+	for i := range out {
+		used := usedByID[out[i].ID]
+		out[i].DailySpendingUsed = used.Day
+		out[i].LifetimeSpendingUsed = used.Lifetime
+		out[i].PeriodSpending = quota.BuildPeriodSpending(out[i].PeriodSpendingLimits, used)
+		out[i].DailySpendingResetCount = resetCounts[out[i].ID]
+	}
+	return out, nil
 }
 
 func (s *Service) CreateKey(ctx context.Context, tenantID, endUserID, name string) (CreateKeyResult, error) {
-	var result CreateKeyResult
-	if err := requireUUID(tenantID); err != nil {
-		return result, err
-	}
-	if err := requireUUID(endUserID); err != nil {
-		return result, err
-	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return result, err
-	}
-	defer func() { _ = tx.Rollback() }()
-	var status string
-	if err = tx.QueryRowContext(ctx, `
-		SELECT status FROM end_users WHERE id = ? AND tenant_id = ? FOR UPDATE
-	`, endUserID, tenantID).Scan(&status); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return result, ErrNotFound
-		}
-		// SQLite may not support FOR UPDATE; retry without lock.
-		if err2 := tx.QueryRowContext(ctx, `SELECT status FROM end_users WHERE id = ? AND tenant_id = ?`, endUserID, tenantID).Scan(&status); err2 != nil {
-			if errors.Is(err2, sql.ErrNoRows) {
-				return result, ErrNotFound
-			}
-			return result, err2
-		}
-	}
-	if status != "active" {
-		return result, fmt.Errorf("%w: cannot create api key for non-active end user", ErrValidation)
-	}
-	var count int
-	_ = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0`, tenantID, endUserID).Scan(&count)
-	isDefault := count == 0
-	var plain string
-	for attempt := 0; attempt < 8; attempt++ {
-		plain, err = GenerateAPIKey()
-		if err != nil {
-			return result, err
-		}
-		var exists int
-		if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE key = ?`, plain).Scan(&exists); err != nil {
-			return result, err
-		}
-		if exists == 0 {
-			break
-		}
-	}
-	id := uuid.NewString()
-	now := time.Now().UTC().Format(time.RFC3339)
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return result, fmt.Errorf("%w: key name is required", ErrValidation)
-	}
-	if err = ensureUniqueKeyName(ctx, tx, tenantID, endUserID, name, ""); err != nil {
-		return result, err
-	}
-	if _, err = tx.ExecContext(ctx, `
-		INSERT INTO api_keys (key, id, name, disabled, end_user_id, is_default, tenant_id, created_at, updated_at,
-			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
-			concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt)
-		VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?,
-			'', 0, 0, 0, 0, 0, 0, 0, '[]', '[]', '[]', '')
-	`, plain, id, name, endUserID, isDefault, tenantID, now, now); err != nil {
-		return result, err
-	}
-	if err = tx.Commit(); err != nil {
-		return result, err
-	}
-	result.APIKey = APIKey{
-		ID: id, TenantID: tenantID, EndUserID: endUserID, Name: name, IsDefault: isDefault,
-		KeyMasked: MaskAPIKey(plain), CreatedAt: now, UpdatedAt: now,
-	}
-	result.PlaintextKey = plain
-	return result, nil
+	return s.CreateKeyWithPeriodLimits(ctx, tenantID, endUserID, name, nil)
 }
 
 func (s *Service) SetDefaultKey(ctx context.Context, tenantID, endUserID, keyID string) error {
@@ -973,31 +1007,7 @@ func (s *Service) SetDefaultKey(ctx context.Context, tenantID, endUserID, keyID 
 }
 
 func (s *Service) UpdateKeyName(ctx context.Context, tenantID, endUserID, keyID, name string) error {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return fmt.Errorf("%w: name required", ErrValidation)
-	}
-	if err := requireUUID(tenantID); err != nil {
-		return err
-	}
-	if err := requireUUID(endUserID); err != nil {
-		return err
-	}
-	if err := requireUUID(keyID); err != nil {
-		return err
-	}
-	if err := ensureUniqueKeyName(ctx, s.db, tenantID, endUserID, name, keyID); err != nil {
-		return err
-	}
-	res, err := s.db.ExecContext(ctx, `UPDATE api_keys SET name = ?, updated_at = ? WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0`,
-		name, time.Now().UTC().Format(time.RFC3339), tenantID, endUserID, keyID)
-	if err != nil {
-		return err
-	}
-	if n, _ := res.RowsAffected(); n == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return s.UpdateKey(ctx, tenantID, endUserID, keyID, &name, nil)
 }
 
 // ensureUniqueKeyName rejects case-insensitive name collisions within one end user.

--- a/internal/enduser/service_sqlite_test.go
+++ b/internal/enduser/service_sqlite_test.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	sqlapikey "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/sqlite/apikey"
 	_ "modernc.org/sqlite"
 )
@@ -35,8 +38,8 @@ func openEndUserTestDB(t *testing.T) *sql.DB {
 			failed_login_count INTEGER NOT NULL DEFAULT 0,
 			lock_stage INTEGER NOT NULL DEFAULT 0,
 			locked_until TEXT,
-			created_at TEXT NOT NULL DEFAULT '',
-			updated_at TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
 			version INTEGER NOT NULL DEFAULT 1,
 			permission_profile_id TEXT NOT NULL DEFAULT '',
 			daily_limit INTEGER NOT NULL DEFAULT 0,
@@ -165,4 +168,40 @@ func TestSetDefaultKeyOnSQLite(t *testing.T) {
 		t.Fatalf("default count = %d, want 1", defaultCount)
 	}
 	_ = a
+}
+
+func TestUpdateUserAutoCapsOwnedKeyPeriodLimits(t *testing.T) {
+	db := openEndUserTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	userID := uuid.NewString()
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status, daily_spending_limit, created_at, updated_at)
+		VALUES (?, ?, 'cap', 'cap', 'Cap', 'x', 'active', 200, ?, ?)
+	`, userID, tenantID, now, now); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	day := 150.0
+	created, err := svc.CreateKeyWithPeriodLimits(ctx, tenantID, userID, "limited", &quota.PeriodSpendingLimitsPatch{Day: &day})
+	if err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+	newDay := 100.0
+	actor := identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}, Permissions: map[string]bool{"end_users.write": true}}
+	updated, err := svc.UpdateUser(ctx, actor, tenantID, userID, nil, nil, nil, nil, &QuotaPatch{PeriodSpendingLimits: &quota.PeriodSpendingLimitsPatch{Day: &newDay}})
+	if err != nil {
+		t.Fatalf("UpdateUser: %v", err)
+	}
+	if len(updated.CappedKeys) != 1 || updated.CappedKeys[0].ID != created.APIKey.ID || updated.CappedKeys[0].Period != quota.PeriodDay || updated.CappedKeys[0].From != 150 || updated.CappedKeys[0].To != 100 {
+		t.Fatalf("capped keys = %+v", updated.CappedKeys)
+	}
+	var stored float64
+	if err := db.QueryRow(`SELECT daily_spending_limit FROM api_keys WHERE id = ?`, created.APIKey.ID).Scan(&stored); err != nil {
+		t.Fatalf("query key: %v", err)
+	}
+	if stored != 100 {
+		t.Fatalf("stored day = %v, want 100", stored)
+	}
 }

--- a/internal/enduser/types.go
+++ b/internal/enduser/types.go
@@ -1,6 +1,10 @@
 package enduser
 
-import "time"
+import (
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
 
 type User struct {
 	ID                 string     `json:"id"`
@@ -19,53 +23,64 @@ type User struct {
 	// APIKeyCount is filled on list; 0 means unknown/none.
 	APIKeyCount int `json:"api_key_count,omitempty"`
 	// DailySpendingUsed is the account-level effective spend for the current project day.
-	DailySpendingUsed float64 `json:"daily-spending-used"`
+	DailySpendingUsed    float64                `json:"daily-spending-used"`
+	LifetimeSpendingUsed float64                `json:"lifetime-spending-used"`
+	PeriodSpending       []quota.PeriodSpending `json:"period-spending"`
+	CappedKeys           []quota.CappedKey      `json:"capped-keys,omitempty"`
 	// DailySpendingResetCount is the number of persisted manual reset events.
 	DailySpendingResetCount int `json:"daily-spending-reset-count"`
 
 	// Account-level quota/permissions: shared by every API key under this user.
-	PermissionProfileID  string   `json:"permission-profile-id,omitempty"`
-	DailyLimit           int      `json:"daily-limit,omitempty"`
-	TotalQuota           int      `json:"total-quota,omitempty"`
-	SpendingLimit        float64  `json:"spending-limit,omitempty"`
-	DailySpendingLimit   float64  `json:"daily-spending-limit,omitempty"`
-	ConcurrencyLimit     int      `json:"concurrency-limit,omitempty"`
-	RPMLimit             int      `json:"rpm-limit,omitempty"`
-	TPMLimit             int      `json:"tpm-limit,omitempty"`
-	AllowedModels        []string `json:"allowed-models,omitempty"`
-	AllowedChannels      []string `json:"allowed-channels,omitempty"`
-	AllowedChannelGroups []string `json:"allowed-channel-groups,omitempty"`
-	SystemPrompt         string   `json:"system-prompt,omitempty"`
+	PermissionProfileID  string                     `json:"permission-profile-id,omitempty"`
+	DailyLimit           int                        `json:"daily-limit,omitempty"`
+	TotalQuota           int                        `json:"total-quota,omitempty"`
+	SpendingLimit        float64                    `json:"spending-limit,omitempty"`
+	DailySpendingLimit   float64                    `json:"daily-spending-limit,omitempty"`
+	PeriodSpendingLimits quota.PeriodSpendingLimits `json:"period-spending-limits"`
+	ConcurrencyLimit     int                        `json:"concurrency-limit,omitempty"`
+	RPMLimit             int                        `json:"rpm-limit,omitempty"`
+	TPMLimit             int                        `json:"tpm-limit,omitempty"`
+	AllowedModels        []string                   `json:"allowed-models,omitempty"`
+	AllowedChannels      []string                   `json:"allowed-channels,omitempty"`
+	AllowedChannelGroups []string                   `json:"allowed-channel-groups,omitempty"`
+	SystemPrompt         string                     `json:"system-prompt,omitempty"`
 }
 
 // QuotaPatch updates account-level limits. Nil field = leave unchanged.
 // Pointer to empty profile id or zero limit clears that field.
 type QuotaPatch struct {
-	PermissionProfileID  *string   `json:"permission-profile-id,omitempty"`
-	DailyLimit           *int      `json:"daily-limit,omitempty"`
-	TotalQuota           *int      `json:"total-quota,omitempty"`
-	SpendingLimit        *float64  `json:"spending-limit,omitempty"`
-	DailySpendingLimit   *float64  `json:"daily-spending-limit,omitempty"`
-	ConcurrencyLimit     *int      `json:"concurrency-limit,omitempty"`
-	RPMLimit             *int      `json:"rpm-limit,omitempty"`
-	TPMLimit             *int      `json:"tpm-limit,omitempty"`
-	AllowedModels        *[]string `json:"allowed-models,omitempty"`
-	AllowedChannels      *[]string `json:"allowed-channels,omitempty"`
-	AllowedChannelGroups *[]string `json:"allowed-channel-groups,omitempty"`
-	SystemPrompt         *string   `json:"system-prompt,omitempty"`
+	PermissionProfileID  *string                          `json:"permission-profile-id,omitempty"`
+	DailyLimit           *int                             `json:"daily-limit,omitempty"`
+	TotalQuota           *int                             `json:"total-quota,omitempty"`
+	SpendingLimit        *float64                         `json:"spending-limit,omitempty"`
+	DailySpendingLimit   *float64                         `json:"daily-spending-limit,omitempty"`
+	PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits,omitempty"`
+	ConcurrencyLimit     *int                             `json:"concurrency-limit,omitempty"`
+	RPMLimit             *int                             `json:"rpm-limit,omitempty"`
+	TPMLimit             *int                             `json:"tpm-limit,omitempty"`
+	AllowedModels        *[]string                        `json:"allowed-models,omitempty"`
+	AllowedChannels      *[]string                        `json:"allowed-channels,omitempty"`
+	AllowedChannelGroups *[]string                        `json:"allowed-channel-groups,omitempty"`
+	SystemPrompt         *string                          `json:"system-prompt,omitempty"`
 }
 
 type APIKey struct {
-	ID        string `json:"id"`
-	TenantID  string `json:"tenant_id"`
-	EndUserID string `json:"end_user_id"`
-	Key       string `json:"key,omitempty"`
-	KeyMasked string `json:"key_masked,omitempty"`
-	Name      string `json:"name"`
-	Disabled  bool   `json:"disabled"`
-	IsDefault bool   `json:"is_default"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	ID                      string                     `json:"id"`
+	TenantID                string                     `json:"tenant_id"`
+	EndUserID               string                     `json:"end_user_id"`
+	Key                     string                     `json:"key,omitempty"`
+	KeyMasked               string                     `json:"key_masked,omitempty"`
+	Name                    string                     `json:"name"`
+	Disabled                bool                       `json:"disabled"`
+	IsDefault               bool                       `json:"is_default"`
+	CreatedAt               string                     `json:"created_at,omitempty"`
+	UpdatedAt               string                     `json:"updated_at,omitempty"`
+	DailySpendingLimit      float64                    `json:"daily-spending-limit"`
+	PeriodSpendingLimits    quota.PeriodSpendingLimits `json:"period-spending-limits"`
+	PeriodSpending          []quota.PeriodSpending     `json:"period-spending"`
+	DailySpendingUsed       float64                    `json:"daily-spending-used"`
+	LifetimeSpendingUsed    float64                    `json:"lifetime-spending-used"`
+	DailySpendingResetCount int                        `json:"daily-spending-reset-count"`
 }
 
 type LoginResult struct {

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -1,25 +1,29 @@
 package apikey
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 var (
-	ErrInvalidProfileID          = errors.New("id is required")
-	ErrInvalidProfileName        = errors.New("name is required")
-	ErrMissingValue              = errors.New("missing value")
-	ErrInvalidEntry              = errors.New("invalid api key entry")
-	ErrItemNotFound              = errors.New("item not found")
-	ErrDuplicateKey              = errors.New("api key already exists")
-	ErrMissingKeyOrIndex         = errors.New("missing key or index")
-	ErrKeyRequired               = errors.New("key is required")
-	ErrDailySpendingLimitMissing = errors.New("daily spending limit is not set")
+	ErrInvalidProfileID            = errors.New("id is required")
+	ErrInvalidProfileName          = errors.New("name is required")
+	ErrMissingValue                = errors.New("missing value")
+	ErrInvalidEntry                = errors.New("invalid api key entry")
+	ErrItemNotFound                = errors.New("item not found")
+	ErrDuplicateKey                = errors.New("api key already exists")
+	ErrMissingKeyOrIndex           = errors.New("missing key or index")
+	ErrKeyRequired                 = errors.New("key is required")
+	ErrDailySpendingLimitMissing   = errors.New("daily spending limit is not set")
+	ErrOwnedKeyAccountManagedField = errors.New("owned key account-managed field cannot be changed")
 )
 
 type ChannelSanitizer func([]string) ([]string, error)
@@ -37,22 +41,23 @@ type Service struct {
 }
 
 type EntryPatch struct {
-	Key                  *string   `json:"key"`
-	Name                 *string   `json:"name"`
-	Disabled             *bool     `json:"disabled"`
-	PermissionProfileID  *string   `json:"permission-profile-id"`
-	DailyLimit           *int      `json:"daily-limit"`
-	TotalQuota           *int      `json:"total-quota"`
-	SpendingLimit        *float64  `json:"spending-limit"`
-	DailySpendingLimit   *float64  `json:"daily-spending-limit"`
-	ConcurrencyLimit     *int      `json:"concurrency-limit"`
-	RPMLimit             *int      `json:"rpm-limit"`
-	TPMLimit             *int      `json:"tpm-limit"`
-	AllowedModels        *[]string `json:"allowed-models"`
-	AllowedChannels      *[]string `json:"allowed-channels"`
-	AllowedChannelGroups *[]string `json:"allowed-channel-groups"`
-	SystemPrompt         *string   `json:"system-prompt"`
-	CreatedAt            *string   `json:"created-at"`
+	Key                  *string                          `json:"key"`
+	Name                 *string                          `json:"name"`
+	Disabled             *bool                            `json:"disabled"`
+	PermissionProfileID  *string                          `json:"permission-profile-id"`
+	DailyLimit           *int                             `json:"daily-limit"`
+	TotalQuota           *int                             `json:"total-quota"`
+	SpendingLimit        *float64                         `json:"spending-limit"`
+	DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+	PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
+	ConcurrencyLimit     *int                             `json:"concurrency-limit"`
+	RPMLimit             *int                             `json:"rpm-limit"`
+	TPMLimit             *int                             `json:"tpm-limit"`
+	AllowedModels        *[]string                        `json:"allowed-models"`
+	AllowedChannels      *[]string                        `json:"allowed-channels"`
+	AllowedChannelGroups *[]string                        `json:"allowed-channel-groups"`
+	SystemPrompt         *string                          `json:"system-prompt"`
+	CreatedAt            *string                          `json:"created-at"`
 	// end_user_id / is_default are intentionally not patchable here; ownership
 	// changes go through end-user owner-scoped APIs only.
 }
@@ -174,11 +179,16 @@ func (s *Service) ReplacePermissionProfiles(profiles []usage.APIKeyPermissionPro
 }
 
 func (s *Service) ReplacePermissionProfilesAndSyncAccounts(profiles []usage.APIKeyPermissionProfileRow) (int64, error) {
+	result, err := s.ReplacePermissionProfilesWithCaps(profiles, true)
+	return result.AppliedCount, err
+}
+
+func (s *Service) ReplacePermissionProfilesWithCaps(profiles []usage.APIKeyPermissionProfileRow, syncAccounts bool) (usage.APIKeyPermissionProfileSyncResult, error) {
 	normalized, err := s.normalizePermissionProfiles(profiles)
 	if err != nil {
-		return 0, err
+		return usage.APIKeyPermissionProfileSyncResult{}, err
 	}
-	return usage.ReplaceAllAPIKeyPermissionProfilesForTenantAndSyncEndUsers(s.tenantID, normalized)
+	return usage.ReplaceAllAPIKeyPermissionProfilesForTenantWithCaps(s.tenantID, normalized, syncAccounts)
 }
 
 func (s *Service) normalizePermissionProfiles(profiles []usage.APIKeyPermissionProfileRow) ([]usage.APIKeyPermissionProfileRow, error) {
@@ -193,6 +203,26 @@ func (s *Service) normalizePermissionProfiles(profiles []usage.APIKeyPermissionP
 		if normalized[idx].Name == "" {
 			return nil, ErrInvalidProfileName
 		}
+		limits, err := quota.NormalizeLimits(normalized[idx].PeriodSpendingLimits)
+		if err != nil {
+			return nil, err
+		}
+		day, err := quota.NormalizeWholeUSD(normalized[idx].DailySpendingLimit)
+		if err != nil {
+			return nil, err
+		}
+		if limits.Day > 0 && day > 0 && limits.Day != day {
+			return nil, quota.ErrPeriodDayLegacyConflict
+		}
+		if day == 0 {
+			day = limits.Day
+		}
+		limits.Day = day
+		if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+			return nil, enduser.ErrFiveHourProjectionWarming
+		}
+		normalized[idx].DailySpendingLimit = day
+		normalized[idx].PeriodSpendingLimits = limits
 		if s != nil && s.sanitizeChannels != nil {
 			cleaned, err := s.sanitizeChannels(normalized[idx].AllowedChannels)
 			if err != nil {
@@ -301,17 +331,13 @@ func (s *Service) attachDailySpendingRuntime(entries []config.APIKeyEntry, rows 
 	if len(entries) == 0 || len(rows) == 0 {
 		return nil
 	}
-	rawCosts, err := usage.QueryRawTodayCostsByKeysForTenant(s.tenantID, rows)
-	if err != nil {
-		return err
-	}
 	ids := make([]string, 0, len(rows))
 	for _, row := range rows {
 		if id := strings.TrimSpace(row.ID); id != "" {
 			ids = append(ids, id)
 		}
 	}
-	baselines, err := usage.ListDailySpendingResetBaselines(s.tenantID, ids)
+	usedByID, err := usage.QueryPeriodSpendingByAPIKeyIDsForTenant(s.tenantID, ids)
 	if err != nil {
 		return err
 	}
@@ -321,30 +347,13 @@ func (s *Service) attachDailySpendingRuntime(entries []config.APIKeyEntry, rows 
 	}
 	for i := range entries {
 		id := strings.TrimSpace(rows[i].ID)
-		key := strings.TrimSpace(rows[i].Key)
-		raw := 0.0
-		if id != "" {
-			if v, ok := rawCosts[id]; ok {
-				raw = v
-			} else if v, ok := rawCosts[key]; ok {
-				raw = v
-			}
-		} else if v, ok := rawCosts[key]; ok {
-			raw = v
-		}
-		baseline := 0.0
-		if id != "" {
-			baseline = baselines[id]
-		}
-		used := raw - baseline
-		if used < 0 {
-			used = 0
-		}
-		entries[i].DailySpendingUsed = used
-		entries[i].DailySpendingRemaining = usage.DailySpendingRemaining(entries[i].DailySpendingLimit, used)
-		if id != "" {
-			entries[i].DailySpendingResetCount = counts[id]
-		}
+		used := usedByID[id]
+		entries[i].PeriodSpendingLimits.Day = entries[i].DailySpendingLimit
+		entries[i].DailySpendingUsed = used.Day
+		entries[i].LifetimeSpendingUsed = used.Lifetime
+		entries[i].PeriodSpending = quota.BuildPeriodSpending(entries[i].PeriodSpendingLimits, used)
+		entries[i].DailySpendingRemaining = usage.DailySpendingRemaining(entries[i].DailySpendingLimit, used.Day)
+		entries[i].DailySpendingResetCount = counts[id]
 	}
 	return nil
 }
@@ -424,6 +433,24 @@ func (s *Service) ListDailySpendingResetHistory(id *string, match *string, limit
 func (s *Service) ReplaceEntries(entries []config.APIKeyEntry) error {
 	rows := make([]usage.APIKeyRow, 0, len(entries))
 	for _, entry := range entries {
+		existing := usage.GetAPIKeyByIDForTenant(s.tenantID, strings.TrimSpace(entry.ID))
+		if existing == nil {
+			existing = usage.GetAPIKeyForTenant(s.tenantID, strings.TrimSpace(entry.Key))
+		}
+		if existing != nil && strings.TrimSpace(existing.EndUserID) != "" {
+			if entry.PermissionProfileID != "" || entry.DailyLimit != 0 || entry.TotalQuota != 0 || entry.SpendingLimit != 0 ||
+				entry.ConcurrencyLimit != 0 || entry.RPMLimit != 0 || entry.TPMLimit != 0 || len(entry.AllowedModels) != 0 ||
+				len(entry.AllowedChannels) != 0 || len(entry.AllowedChannelGroups) != 0 || entry.SystemPrompt != "" {
+				return ErrOwnedKeyAccountManagedField
+			}
+			incoming := entry.PeriodSpendingLimits
+			incoming.Day = entry.DailySpendingLimit
+			if incoming != existing.PeriodSpendingLimits {
+				return fmt.Errorf("%w: update owned key period limits with PATCH", ErrInvalidEntry)
+			}
+			entry.EndUserID = existing.EndUserID
+			entry.IsDefault = existing.IsDefault
+		}
 		normalized, err := s.prepareEntryForSave(entry)
 		if err != nil {
 			return err
@@ -439,6 +466,16 @@ func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryP
 		return ErrItemNotFound
 	}
 	entry := *existing
+	owned := strings.TrimSpace(existing.EndUserID) != ""
+	if owned && (patch.PermissionProfileID != nil || patch.DailyLimit != nil || patch.TotalQuota != nil ||
+		patch.SpendingLimit != nil || patch.ConcurrencyLimit != nil || patch.RPMLimit != nil || patch.TPMLimit != nil ||
+		patch.AllowedModels != nil || patch.AllowedChannels != nil || patch.AllowedChannelGroups != nil || patch.SystemPrompt != nil) {
+		return ErrOwnedKeyAccountManagedField
+	}
+	periodPatch, err := quota.ResolveLegacyDay(patch.DailySpendingLimit, patch.PeriodSpendingLimits)
+	if err != nil {
+		return err
+	}
 	originalKey := strings.TrimSpace(entry.Key)
 	originalID := strings.TrimSpace(entry.ID)
 
@@ -467,8 +504,9 @@ func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryP
 	if patch.SpendingLimit != nil {
 		entry.SpendingLimit = *patch.SpendingLimit
 	}
-	if patch.DailySpendingLimit != nil {
-		entry.DailySpendingLimit = *patch.DailySpendingLimit
+	if periodPatch != nil {
+		entry.PeriodSpendingLimits = quota.ApplyPatch(entry.PeriodSpendingLimits, periodPatch)
+		entry.DailySpendingLimit = entry.PeriodSpendingLimits.Day
 	}
 	if patch.ConcurrencyLimit != nil {
 		entry.ConcurrencyLimit = *patch.ConcurrencyLimit
@@ -493,6 +531,23 @@ func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryP
 	}
 	if patch.CreatedAt != nil {
 		entry.CreatedAt = strings.TrimSpace(*patch.CreatedAt)
+	}
+
+	if owned && (patch.Name != nil || periodPatch != nil) {
+		if patch.Key != nil || patch.Disabled != nil || patch.CreatedAt != nil {
+			return fmt.Errorf("%w: update owned key name/period separately from key state", ErrInvalidEntry)
+		}
+		svc := enduser.Default()
+		if svc == nil && usage.RuntimeDB() != nil {
+			svc = enduser.NewService(usage.RuntimeDB())
+		}
+		if svc == nil {
+			return fmt.Errorf("%w: end user service unavailable", ErrInvalidEntry)
+		}
+		if err := svc.UpdateKey(context.Background(), s.tenantID, existing.EndUserID, existing.ID, patch.Name, periodPatch); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	normalized, err := s.prepareEntryForSave(entry.ToConfigEntry())
@@ -543,6 +598,26 @@ func (s *Service) prepareEntryForSave(entry config.APIKeyEntry) (config.APIKeyEn
 	entry.PermissionProfileID = strings.TrimSpace(entry.PermissionProfileID)
 	entry.SystemPrompt = strings.TrimSpace(entry.SystemPrompt)
 	entry.CreatedAt = strings.TrimSpace(entry.CreatedAt)
+	limits, err := quota.NormalizeLimits(entry.PeriodSpendingLimits)
+	if err != nil {
+		return config.APIKeyEntry{}, err
+	}
+	day, err := quota.NormalizeWholeUSD(entry.DailySpendingLimit)
+	if err != nil {
+		return config.APIKeyEntry{}, err
+	}
+	if limits.Day > 0 && day > 0 && limits.Day != day {
+		return config.APIKeyEntry{}, quota.ErrPeriodDayLegacyConflict
+	}
+	if day == 0 {
+		day = limits.Day
+	}
+	limits.Day = day
+	if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+		return config.APIKeyEntry{}, enduser.ErrFiveHourProjectionWarming
+	}
+	entry.DailySpendingLimit = day
+	entry.PeriodSpendingLimits = limits
 	entry.AllowedChannelGroups = normalizeChannelGroups(entry.AllowedChannelGroups)
 
 	if s != nil && s.sanitizeChannels != nil {

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -521,6 +521,7 @@ func TestEffectiveRowAppliesProfileDailySpendingLimit(t *testing.T) {
 		ID:                  "key-1",
 		Key:                 "sk-profile",
 		PermissionProfileID: "p1",
+		SpendingLimit:       77,
 		DailySpendingLimit:  1, // stale key copy; profile wins
 	}); err != nil {
 		t.Fatalf("upsert: %v", err)

--- a/internal/quota/period.go
+++ b/internal/quota/period.go
@@ -1,0 +1,218 @@
+package quota
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+type Period string
+
+const (
+	PeriodFiveHour Period = "5h"
+	PeriodDay      Period = "day"
+	PeriodWeek     Period = "week"
+	PeriodMonth    Period = "month"
+)
+
+var OrderedPeriods = [...]Period{PeriodFiveHour, PeriodDay, PeriodWeek, PeriodMonth}
+
+var (
+	ErrInvalidSpendingLimit    = errors.New("invalid spending limit")
+	ErrPeriodDayLegacyConflict = errors.New("period day legacy conflict")
+)
+
+type PeriodSpendingLimits struct {
+	FiveHour float64 `json:"5h" yaml:"5h"`
+	Day      float64 `json:"day" yaml:"day"`
+	Week     float64 `json:"week" yaml:"week"`
+	Month    float64 `json:"month" yaml:"month"`
+}
+
+type PeriodSpendingLimitsPatch struct {
+	FiveHour *float64 `json:"5h"`
+	Day      *float64 `json:"day"`
+	Week     *float64 `json:"week"`
+	Month    *float64 `json:"month"`
+}
+
+type CappedKey struct {
+	ID     string  `json:"id"`
+	Period Period  `json:"period"`
+	From   float64 `json:"from"`
+	To     float64 `json:"to"`
+}
+
+type LimitExceedsAccountError struct {
+	Period       Period
+	KeyLimit     float64
+	AccountLimit float64
+}
+
+func (e *LimitExceedsAccountError) Error() string {
+	return fmt.Sprintf("Key %s quota $%.0f exceeds account %s quota $%.0f", e.Period, e.KeyLimit, e.Period, e.AccountLimit)
+}
+
+func ValidateKeyWithinAccount(keyLimits, accountLimits PeriodSpendingLimits) error {
+	for _, period := range OrderedPeriods {
+		keyLimit := keyLimits.Value(period)
+		accountLimit := accountLimits.Value(period)
+		if keyLimit > 0 && accountLimit > 0 && keyLimit > accountLimit {
+			return &LimitExceedsAccountError{Period: period, KeyLimit: keyLimit, AccountLimit: accountLimit}
+		}
+	}
+	return nil
+}
+
+type PeriodSpending struct {
+	Period    Period  `json:"period"`
+	Limit     float64 `json:"limit"`
+	Used      float64 `json:"used"`
+	Remaining float64 `json:"remaining"`
+}
+
+type PeriodSpendingUsage struct {
+	FiveHour float64
+	Day      float64
+	Week     float64
+	Month    float64
+	Lifetime float64
+}
+
+func NormalizeWholeUSD(value float64) (float64, error) {
+	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("%w: value must be a finite non-negative number", ErrInvalidSpendingLimit)
+	}
+	if value == 0 {
+		return 0, nil
+	}
+	return math.Ceil(value), nil
+}
+
+func NormalizeLimits(limits PeriodSpendingLimits) (PeriodSpendingLimits, error) {
+	var err error
+	if limits.FiveHour, err = NormalizeWholeUSD(limits.FiveHour); err != nil {
+		return PeriodSpendingLimits{}, fmt.Errorf("5h: %w", err)
+	}
+	if limits.Day, err = NormalizeWholeUSD(limits.Day); err != nil {
+		return PeriodSpendingLimits{}, fmt.Errorf("day: %w", err)
+	}
+	if limits.Week, err = NormalizeWholeUSD(limits.Week); err != nil {
+		return PeriodSpendingLimits{}, fmt.Errorf("week: %w", err)
+	}
+	if limits.Month, err = NormalizeWholeUSD(limits.Month); err != nil {
+		return PeriodSpendingLimits{}, fmt.Errorf("month: %w", err)
+	}
+	return limits, nil
+}
+
+func NormalizePatch(patch *PeriodSpendingLimitsPatch) (*PeriodSpendingLimitsPatch, error) {
+	if patch == nil {
+		return nil, nil
+	}
+	out := *patch
+	for period, ptr := range map[Period]**float64{
+		PeriodFiveHour: &out.FiveHour,
+		PeriodDay:      &out.Day,
+		PeriodWeek:     &out.Week,
+		PeriodMonth:    &out.Month,
+	} {
+		if *ptr == nil {
+			continue
+		}
+		value, err := NormalizeWholeUSD(**ptr)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", period, err)
+		}
+		*ptr = &value
+	}
+	return &out, nil
+}
+
+func ResolveLegacyDay(legacy *float64, patch *PeriodSpendingLimitsPatch) (*PeriodSpendingLimitsPatch, error) {
+	normalized, err := NormalizePatch(patch)
+	if err != nil {
+		return nil, err
+	}
+	if legacy == nil {
+		return normalized, nil
+	}
+	day, err := NormalizeWholeUSD(*legacy)
+	if err != nil {
+		return nil, fmt.Errorf("day: %w", err)
+	}
+	if normalized == nil {
+		normalized = &PeriodSpendingLimitsPatch{}
+	}
+	if normalized.Day != nil && *normalized.Day != day {
+		return nil, ErrPeriodDayLegacyConflict
+	}
+	normalized.Day = &day
+	return normalized, nil
+}
+
+func ApplyPatch(current PeriodSpendingLimits, patch *PeriodSpendingLimitsPatch) PeriodSpendingLimits {
+	if patch == nil {
+		return current
+	}
+	if patch.FiveHour != nil {
+		current.FiveHour = *patch.FiveHour
+	}
+	if patch.Day != nil {
+		current.Day = *patch.Day
+	}
+	if patch.Week != nil {
+		current.Week = *patch.Week
+	}
+	if patch.Month != nil {
+		current.Month = *patch.Month
+	}
+	return current
+}
+
+func (l PeriodSpendingLimits) Value(period Period) float64 {
+	switch period {
+	case PeriodFiveHour:
+		return l.FiveHour
+	case PeriodDay:
+		return l.Day
+	case PeriodWeek:
+		return l.Week
+	case PeriodMonth:
+		return l.Month
+	default:
+		return 0
+	}
+}
+
+func (u PeriodSpendingUsage) Value(period Period) float64 {
+	switch period {
+	case PeriodFiveHour:
+		return u.FiveHour
+	case PeriodDay:
+		return u.Day
+	case PeriodWeek:
+		return u.Week
+	case PeriodMonth:
+		return u.Month
+	default:
+		return 0
+	}
+}
+
+func BuildPeriodSpending(limits PeriodSpendingLimits, used PeriodSpendingUsage) []PeriodSpending {
+	out := make([]PeriodSpending, 0, len(OrderedPeriods))
+	for _, period := range OrderedPeriods {
+		limit := limits.Value(period)
+		if limit <= 0 {
+			continue
+		}
+		current := used.Value(period)
+		remaining := limit - current
+		if remaining < 0 {
+			remaining = 0
+		}
+		out = append(out, PeriodSpending{Period: period, Limit: limit, Used: current, Remaining: remaining})
+	}
+	return out
+}

--- a/internal/quota/period_test.go
+++ b/internal/quota/period_test.go
@@ -1,0 +1,31 @@
+package quota
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestResolveLegacyDayCompatibilityAndConflict(t *testing.T) {
+	legacy := 10.1
+	day := 11.0
+	patch, err := ResolveLegacyDay(&legacy, &PeriodSpendingLimitsPatch{Day: &day})
+	if err != nil || patch == nil || patch.Day == nil || *patch.Day != 11 {
+		t.Fatalf("same normalized day = %#v, err=%v", patch, err)
+	}
+	conflict := 12.0
+	if _, err := ResolveLegacyDay(&legacy, &PeriodSpendingLimitsPatch{Day: &conflict}); !errors.Is(err, ErrPeriodDayLegacyConflict) {
+		t.Fatalf("conflict err = %v, want ErrPeriodDayLegacyConflict", err)
+	}
+}
+
+func TestNormalizeWholeUSDRejectsInvalidAndCeilsPositive(t *testing.T) {
+	for _, value := range []float64{-1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		if _, err := NormalizeWholeUSD(value); !errors.Is(err, ErrInvalidSpendingLimit) {
+			t.Fatalf("NormalizeWholeUSD(%v) err=%v, want invalid", value, err)
+		}
+	}
+	if got, err := NormalizeWholeUSD(10.01); err != nil || got != 11 {
+		t.Fatalf("NormalizeWholeUSD = %v, %v; want 11,nil", got, err)
+	}
+}

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -35,8 +35,25 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607200002_ai_account_shared_subjects", SQL: aiAccountSharedSubjectsSQL},
 		// Append-only history of manual account-level daily spending resets.
 		{Version: "202607210001_end_user_daily_spending_reset_events", SQL: endUserDailySpendingResetEventsSQL},
+		{Version: "202607220001_period_spending_limits", SQL: periodSpendingLimitsSQL},
 	}
 }
+
+const periodSpendingLimitsSQL = `
+ALTER TABLE api_key_permission_profiles ADD COLUMN IF NOT EXISTS five_hour_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_key_permission_profiles ADD COLUMN IF NOT EXISTS weekly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_key_permission_profiles ADD COLUMN IF NOT EXISTS monthly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS five_hour_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS weekly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS monthly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS five_hour_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS weekly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS monthly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_usage_rollup_tenant_key_quota
+  ON usage_rollup_buckets(tenant_id, bucket_kind, api_key_id, bucket_start);
+CREATE INDEX IF NOT EXISTS idx_usage_rollup_tenant_user_quota
+  ON usage_rollup_buckets(tenant_id, bucket_kind, end_user_id, bucket_start);
+`
 
 const usageRollupBucketsSQL = `
 CREATE TABLE IF NOT EXISTS usage_rollup_buckets (

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,10 +11,17 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 21 {
-		t.Fatalf("RuntimeMigrations len = %d, want 21", len(migrations))
+	if len(migrations) != 22 {
+		t.Fatalf("RuntimeMigrations len = %d, want 22", len(migrations))
 	}
-	// Latest: append-only account-level daily spending reset history.
+	// Latest: fixed period spending columns.
+	periodSQL := migrations[21].SQL
+	for _, fragment := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+		if !strings.Contains(periodSQL, fragment) {
+			t.Fatalf("period migration missing %q", fragment)
+		}
+	}
+	// Prior: append-only account-level daily spending reset history.
 	endUserResetEventsSQL := migrations[20].SQL
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS end_user_daily_spending_reset_events",

--- a/internal/storage/sqlite/apikey/effective.go
+++ b/internal/storage/sqlite/apikey/effective.go
@@ -1,0 +1,48 @@
+package apikey
+
+import "strings"
+
+func EffectiveAPIKeyRowWithProfiles(row APIKeyRow, profiles []PermissionProfileSnapshot) APIKeyRow {
+	profileID := strings.TrimSpace(row.PermissionProfileID)
+	if profileID == "" {
+		return row
+	}
+
+	var matched *PermissionProfileSnapshot
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.ID) == profileID {
+			copy := profile
+			matched = &copy
+			break
+		}
+	}
+	if matched == nil {
+		return row
+	}
+
+	row.PermissionProfileID = profileID
+	row.DailyLimit = matched.DailyLimit
+	row.TotalQuota = matched.TotalQuota
+	row.DailySpendingLimit = matched.DailySpendingLimit
+	row.PeriodSpendingLimits = matched.PeriodSpendingLimits
+	row.PeriodSpendingLimits.Day = row.DailySpendingLimit
+	row.ConcurrencyLimit = matched.ConcurrencyLimit
+	row.RPMLimit = matched.RPMLimit
+	row.TPMLimit = matched.TPMLimit
+	row.AllowedModels = append([]string(nil), matched.AllowedModels...)
+	row.AllowedChannels = append([]string(nil), matched.AllowedChannels...)
+	row.AllowedChannelGroups = append([]string(nil), matched.AllowedChannelGroups...)
+	row.SystemPrompt = matched.SystemPrompt
+	return row
+}
+
+func EffectiveAPIKeyRowsWithProfiles(rows []APIKeyRow, profiles []PermissionProfileSnapshot) []APIKeyRow {
+	if len(rows) == 0 {
+		return rows
+	}
+	out := make([]APIKeyRow, len(rows))
+	for idx, row := range rows {
+		out[idx] = EffectiveAPIKeyRowWithProfiles(row, profiles)
+	}
+	return out
+}

--- a/internal/storage/sqlite/apikey/permission_profiles.go
+++ b/internal/storage/sqlite/apikey/permission_profiles.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,6 +20,9 @@ CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
   daily_limit            INTEGER NOT NULL DEFAULT 0,
   total_quota            INTEGER NOT NULL DEFAULT 0,
   daily_spending_limit   REAL NOT NULL DEFAULT 0,
+  five_hour_spending_limit REAL NOT NULL DEFAULT 0,
+  weekly_spending_limit  REAL NOT NULL DEFAULT 0,
+  monthly_spending_limit REAL NOT NULL DEFAULT 0,
   concurrency_limit      INTEGER NOT NULL DEFAULT 0,
   rpm_limit              INTEGER NOT NULL DEFAULT 0,
   tpm_limit              INTEGER NOT NULL DEFAULT 0,
@@ -33,21 +37,27 @@ CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
 `
 
 type PermissionProfileRow struct {
-	TenantID             string   `json:"tenant_id,omitempty" yaml:"tenant_id,omitempty"`
-	ID                   string   `json:"id" yaml:"id"`
-	Name                 string   `json:"name" yaml:"name"`
-	DailyLimit           int      `json:"daily-limit" yaml:"daily-limit"`
-	TotalQuota           int      `json:"total-quota" yaml:"total-quota"`
-	DailySpendingLimit   float64  `json:"daily-spending-limit" yaml:"daily-spending-limit"`
-	ConcurrencyLimit     int      `json:"concurrency-limit" yaml:"concurrency-limit"`
-	RPMLimit             int      `json:"rpm-limit" yaml:"rpm-limit"`
-	TPMLimit             int      `json:"tpm-limit" yaml:"tpm-limit"`
-	AllowedModels        []string `json:"allowed-models" yaml:"allowed-models"`
-	AllowedChannels      []string `json:"allowed-channels" yaml:"allowed-channels"`
-	AllowedChannelGroups []string `json:"allowed-channel-groups" yaml:"allowed-channel-groups"`
-	SystemPrompt         string   `json:"system-prompt" yaml:"system-prompt"`
-	CreatedAt            string   `json:"created-at,omitempty" yaml:"created-at,omitempty"`
-	UpdatedAt            string   `json:"updated-at,omitempty" yaml:"updated-at,omitempty"`
+	TenantID             string                     `json:"tenant_id,omitempty" yaml:"tenant_id,omitempty"`
+	ID                   string                     `json:"id" yaml:"id"`
+	Name                 string                     `json:"name" yaml:"name"`
+	DailyLimit           int                        `json:"daily-limit" yaml:"daily-limit"`
+	TotalQuota           int                        `json:"total-quota" yaml:"total-quota"`
+	DailySpendingLimit   float64                    `json:"daily-spending-limit" yaml:"daily-spending-limit"`
+	PeriodSpendingLimits quota.PeriodSpendingLimits `json:"period-spending-limits" yaml:"period-spending-limits"`
+	ConcurrencyLimit     int                        `json:"concurrency-limit" yaml:"concurrency-limit"`
+	RPMLimit             int                        `json:"rpm-limit" yaml:"rpm-limit"`
+	TPMLimit             int                        `json:"tpm-limit" yaml:"tpm-limit"`
+	AllowedModels        []string                   `json:"allowed-models" yaml:"allowed-models"`
+	AllowedChannels      []string                   `json:"allowed-channels" yaml:"allowed-channels"`
+	AllowedChannelGroups []string                   `json:"allowed-channel-groups" yaml:"allowed-channel-groups"`
+	SystemPrompt         string                     `json:"system-prompt" yaml:"system-prompt"`
+	CreatedAt            string                     `json:"created-at,omitempty" yaml:"created-at,omitempty"`
+	UpdatedAt            string                     `json:"updated-at,omitempty" yaml:"updated-at,omitempty"`
+}
+
+type PermissionProfileSyncResult struct {
+	AppliedCount int64             `json:"applied_count"`
+	CappedKeys   []quota.CappedKey `json:"capped-keys,omitempty"`
 }
 
 func InitPermissionProfilesTable(db *sql.DB) {
@@ -60,11 +70,23 @@ func InitPermissionProfilesTable(db *sql.DB) {
 	if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
 		log.Warnf("sqlite/apikey: migrate api_key_permission_profiles tenant_id: %v", err)
 	}
-	if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN daily_spending_limit REAL NOT NULL DEFAULT 0"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
-		log.Warnf("sqlite/apikey: migrate api_key_permission_profiles daily_spending_limit: %v", err)
+	for _, column := range []string{"daily_spending_limit", "five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+		if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN " + column + " REAL NOT NULL DEFAULT 0"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+			log.Warnf("sqlite/apikey: migrate api_key_permission_profiles %s: %v", column, err)
+		}
 	}
 	if err := migratePermissionProfilesTenantPrimaryKey(db); err != nil {
 		log.Errorf("sqlite/apikey: migrate api_key_permission_profiles tenant primary key: %v", err)
+	}
+	for _, table := range []string{"end_users", "api_keys"} {
+		for _, column := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+			if _, err := db.Exec("ALTER TABLE " + table + " ADD COLUMN " + column + " REAL NOT NULL DEFAULT 0"); err != nil {
+				message := strings.ToLower(err.Error())
+				if !strings.Contains(message, "duplicate") && !strings.Contains(message, "no such table") {
+					log.Warnf("sqlite/apikey: migrate %s.%s: %v", table, column, err)
+				}
+			}
+		}
 	}
 }
 
@@ -111,6 +133,7 @@ func migratePermissionProfilesTenantPrimaryKey(db *sql.DB) error {
 			tenant_id TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
 			id TEXT NOT NULL, name TEXT NOT NULL DEFAULT '', daily_limit INTEGER NOT NULL DEFAULT 0,
 			total_quota INTEGER NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+			five_hour_spending_limit REAL NOT NULL DEFAULT 0, weekly_spending_limit REAL NOT NULL DEFAULT 0, monthly_spending_limit REAL NOT NULL DEFAULT 0,
 			concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0,
 			tpm_limit INTEGER NOT NULL DEFAULT 0, allowed_models TEXT NOT NULL DEFAULT '[]',
 			allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
@@ -122,11 +145,11 @@ func migratePermissionProfilesTenantPrimaryKey(db *sql.DB) error {
 	}
 	if _, err = tx.Exec(`
 		INSERT INTO api_key_permission_profiles_tenant_pk (
-			tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
+			tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit,
 			rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		)
 		SELECT CASE WHEN trim(coalesce(tenant_id, '')) = '' THEN ? ELSE tenant_id END,
-			id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
+			id, name, daily_limit, total_quota, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit,
 			rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_key_permission_profiles
 	`, systemTenantID); err != nil {
@@ -146,7 +169,7 @@ func (s Store) ListPermissionProfiles() []PermissionProfileRow {
 		return nil
 	}
 
-	rows, err := s.db.Query(`SELECT id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
+	rows, err := s.db.Query(`SELECT id, name, daily_limit, total_quota, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit,
 		rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups,
 		system_prompt, created_at, updated_at
 		FROM api_key_permission_profiles WHERE tenant_id = ? ORDER BY created_at ASC, id ASC`, s.tenantID)
@@ -176,31 +199,50 @@ func (s Store) ReplaceAllPermissionProfiles(profiles []PermissionProfileRow) err
 }
 
 func (s Store) ReplaceAllPermissionProfilesAndSyncEndUsers(profiles []PermissionProfileRow) (int64, error) {
-	return s.replaceAllPermissionProfiles(profiles, true)
+	result, err := s.replaceAllPermissionProfiles(profiles, true)
+	return result.AppliedCount, err
 }
 
-func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syncEndUsers bool) (int64, error) {
+func (s Store) ReplaceAllPermissionProfilesWithCaps(profiles []PermissionProfileRow, syncEndUsers bool) (PermissionProfileSyncResult, error) {
+	return s.replaceAllPermissionProfiles(profiles, syncEndUsers)
+}
+
+func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syncEndUsers bool) (PermissionProfileSyncResult, error) {
 	if s.db == nil {
-		return 0, fmt.Errorf("database not initialised")
+		return PermissionProfileSyncResult{}, fmt.Errorf("database not initialised")
+	}
+	for _, table := range []string{"end_users", "api_keys"} {
+		for _, column := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+			if _, err := s.db.Exec("ALTER TABLE " + table + " ADD COLUMN " + column + " REAL NOT NULL DEFAULT 0"); err != nil {
+				message := strings.ToLower(err.Error())
+				if !strings.Contains(message, "duplicate") && !strings.Contains(message, "no such table") {
+					return PermissionProfileSyncResult{}, err
+				}
+			}
+		}
 	}
 
 	tx, err := s.db.Begin()
 	if err != nil {
-		return 0, err
+		return PermissionProfileSyncResult{}, err
+	}
+	if err := lockBoundEndUsersForProfileUpdate(tx, s.tenantID); err != nil {
+		_ = tx.Rollback()
+		return PermissionProfileSyncResult{}, err
 	}
 
 	if _, err := tx.Exec("DELETE FROM api_key_permission_profiles WHERE tenant_id = ?", s.tenantID); err != nil {
 		_ = tx.Rollback()
-		return 0, err
+		return PermissionProfileSyncResult{}, err
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_key_permission_profiles
-		(tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		(tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		 allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
-		return 0, err
+		return PermissionProfileSyncResult{}, err
 	}
 	defer stmt.Close()
 
@@ -210,15 +252,15 @@ func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syn
 		profile = normalizePermissionProfile(profile)
 		if profile.ID == "" {
 			_ = tx.Rollback()
-			return 0, fmt.Errorf("id is required")
+			return PermissionProfileSyncResult{}, fmt.Errorf("id is required")
 		}
 		if profile.Name == "" {
 			_ = tx.Rollback()
-			return 0, fmt.Errorf("name is required")
+			return PermissionProfileSyncResult{}, fmt.Errorf("name is required")
 		}
 		if _, exists := seen[profile.ID]; exists {
 			_ = tx.Rollback()
-			return 0, fmt.Errorf("duplicate id %q", profile.ID)
+			return PermissionProfileSyncResult{}, fmt.Errorf("duplicate id %q", profile.ID)
 		}
 		seen[profile.ID] = struct{}{}
 		if profile.CreatedAt == "" {
@@ -228,13 +270,13 @@ func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syn
 
 		if _, err := stmt.Exec(
 			s.tenantID, profile.ID, profile.Name, profile.DailyLimit, profile.TotalQuota, profile.DailySpendingLimit,
-			profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
+			profile.PeriodSpendingLimits.FiveHour, profile.PeriodSpendingLimits.Week, profile.PeriodSpendingLimits.Month, profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
 			mustJSONStringList(profile.AllowedModels), mustJSONStringList(profile.AllowedChannels),
 			mustJSONStringList(profile.AllowedChannelGroups), profile.SystemPrompt,
 			profile.CreatedAt, profile.UpdatedAt,
 		); err != nil {
 			_ = tx.Rollback()
-			return 0, err
+			return PermissionProfileSyncResult{}, err
 		}
 	}
 
@@ -244,19 +286,19 @@ func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syn
 			profile = normalizePermissionProfile(profile)
 			result, syncErr := tx.Exec(`
 				UPDATE end_users SET
-					permission_profile_id = ?, daily_limit = ?, total_quota = ?, spending_limit = 0,
-					daily_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
+					permission_profile_id = ?, daily_limit = ?, total_quota = ?,
+					daily_spending_limit = ?, five_hour_spending_limit = ?, weekly_spending_limit = ?, monthly_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
 					allowed_models = ?, allowed_channels = ?, allowed_channel_groups = ?, system_prompt = ?,
 					updated_at = ?, version = version + 1
 				WHERE tenant_id = ? AND permission_profile_id = ?
 			`, profile.ID, profile.DailyLimit, profile.TotalQuota, profile.DailySpendingLimit,
-				profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
+				profile.PeriodSpendingLimits.FiveHour, profile.PeriodSpendingLimits.Week, profile.PeriodSpendingLimits.Month, profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
 				mustJSONStringList(profile.AllowedModels), mustJSONStringList(profile.AllowedChannels),
 				mustJSONStringList(profile.AllowedChannelGroups), profile.SystemPrompt,
 				now, s.tenantID, profile.ID)
 			if syncErr != nil {
 				_ = tx.Rollback()
-				return 0, syncErr
+				return PermissionProfileSyncResult{}, syncErr
 			}
 			if rows, rowsErr := result.RowsAffected(); rowsErr == nil {
 				appliedCount += rows
@@ -278,17 +320,117 @@ func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syn
 		result, syncErr := tx.Exec(unbindQuery, unbindArgs...)
 		if syncErr != nil {
 			_ = tx.Rollback()
-			return 0, syncErr
+			return PermissionProfileSyncResult{}, syncErr
 		}
 		if rows, rowsErr := result.RowsAffected(); rowsErr == nil {
 			appliedCount += rows
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return 0, err
+	cappedKeys, err := capProfileOwnedKeysTx(tx, s.tenantID, profiles, now)
+	if err != nil {
+		_ = tx.Rollback()
+		return PermissionProfileSyncResult{}, err
 	}
-	return appliedCount, nil
+	if err := tx.Commit(); err != nil {
+		return PermissionProfileSyncResult{}, err
+	}
+	return PermissionProfileSyncResult{AppliedCount: appliedCount, CappedKeys: cappedKeys}, nil
+}
+
+func lockBoundEndUsersForProfileUpdate(tx *sql.Tx, tenantID string) error {
+	query := `SELECT id FROM end_users WHERE tenant_id = ? AND permission_profile_id != '' ORDER BY id ASC FOR UPDATE`
+	rows, err := tx.Query(query, tenantID)
+	if err != nil {
+		message := strings.ToLower(err.Error())
+		if strings.Contains(message, "no such table") {
+			return nil
+		}
+		if strings.Contains(message, "syntax") || strings.Contains(message, "for update") {
+			rows, err = tx.Query(strings.TrimSuffix(query, " FOR UPDATE"), tenantID)
+		}
+	}
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table") {
+			return nil
+		}
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func capProfileOwnedKeysTx(tx *sql.Tx, tenantID string, profiles []PermissionProfileRow, now string) ([]quota.CappedKey, error) {
+	ceilings := make(map[string]quota.PeriodSpendingLimits, len(profiles))
+	for _, profile := range profiles {
+		profile = normalizePermissionProfile(profile)
+		ceilings[profile.ID] = profile.PeriodSpendingLimits
+	}
+	rows, err := tx.Query(`SELECT k.id, e.permission_profile_id,
+		COALESCE(k.daily_spending_limit,0), COALESCE(k.five_hour_spending_limit,0),
+		COALESCE(k.weekly_spending_limit,0), COALESCE(k.monthly_spending_limit,0)
+		FROM api_keys k JOIN end_users e ON e.id = k.end_user_id AND e.tenant_id = k.tenant_id
+		WHERE k.tenant_id = ? AND e.permission_profile_id != '' ORDER BY k.id ASC`, tenantID)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	type item struct {
+		id, profileID string
+		limits        quota.PeriodSpendingLimits
+	}
+	items := make([]item, 0)
+	for rows.Next() {
+		var v item
+		if err := rows.Scan(&v.id, &v.profileID, &v.limits.Day, &v.limits.FiveHour, &v.limits.Week, &v.limits.Month); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		items = append(items, v)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	out := make([]quota.CappedKey, 0)
+	for _, v := range items {
+		ceiling, ok := ceilings[v.profileID]
+		if !ok {
+			continue
+		}
+		updated := v.limits
+		for _, period := range quota.OrderedPeriods {
+			from, to := updated.Value(period), ceiling.Value(period)
+			if from <= 0 || to <= 0 || from <= to {
+				continue
+			}
+			switch period {
+			case quota.PeriodFiveHour:
+				updated.FiveHour = to
+			case quota.PeriodDay:
+				updated.Day = to
+			case quota.PeriodWeek:
+				updated.Week = to
+			case quota.PeriodMonth:
+				updated.Month = to
+			}
+			out = append(out, quota.CappedKey{ID: v.id, Period: period, From: from, To: to})
+		}
+		if updated != v.limits {
+			if _, err := tx.Exec(`UPDATE api_keys SET daily_spending_limit=?, five_hour_spending_limit=?, weekly_spending_limit=?, monthly_spending_limit=?, updated_at=? WHERE tenant_id=? AND id=?`,
+				updated.Day, updated.FiveHour, updated.Week, updated.Month, now, tenantID, v.id); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
 }
 
 func normalizePermissionProfile(profile PermissionProfileRow) PermissionProfileRow {
@@ -296,7 +438,20 @@ func normalizePermissionProfile(profile PermissionProfileRow) PermissionProfileR
 	profile.Name = strings.TrimSpace(profile.Name)
 	profile.DailyLimit = normalizeNonNegativeInt(profile.DailyLimit)
 	profile.TotalQuota = normalizeNonNegativeInt(profile.TotalQuota)
-	profile.DailySpendingLimit = normalizeWholeUSD(profile.DailySpendingLimit)
+	limits, err := quota.NormalizeLimits(profile.PeriodSpendingLimits)
+	if err != nil {
+		limits = quota.PeriodSpendingLimits{}
+	}
+	day, err := quota.NormalizeWholeUSD(profile.DailySpendingLimit)
+	if err != nil {
+		day = 0
+	}
+	if limits.Day > 0 && day == 0 {
+		day = limits.Day
+	}
+	limits.Day = day
+	profile.DailySpendingLimit = day
+	profile.PeriodSpendingLimits = limits
 	profile.ConcurrencyLimit = normalizeNonNegativeInt(profile.ConcurrencyLimit)
 	profile.RPMLimit = normalizeNonNegativeInt(profile.RPMLimit)
 	profile.TPMLimit = normalizeNonNegativeInt(profile.TPMLimit)
@@ -313,7 +468,7 @@ func scanPermissionProfileRow(row scanner) (*PermissionProfileRow, bool) {
 	var channelsJSON string
 	var channelGroupsJSON string
 	if err := row.Scan(
-		&profile.ID, &profile.Name, &profile.DailyLimit, &profile.TotalQuota, &profile.DailySpendingLimit, &profile.ConcurrencyLimit,
+		&profile.ID, &profile.Name, &profile.DailyLimit, &profile.TotalQuota, &profile.DailySpendingLimit, &profile.PeriodSpendingLimits.FiveHour, &profile.PeriodSpendingLimits.Week, &profile.PeriodSpendingLimits.Month, &profile.ConcurrencyLimit,
 		&profile.RPMLimit, &profile.TPMLimit, &modelsJSON, &channelsJSON, &channelGroupsJSON,
 		&profile.SystemPrompt, &profile.CreatedAt, &profile.UpdatedAt,
 	); err != nil {
@@ -322,6 +477,7 @@ func scanPermissionProfileRow(row scanner) (*PermissionProfileRow, bool) {
 		}
 		return nil, false
 	}
+	profile.PeriodSpendingLimits.Day = profile.DailySpendingLimit
 	profile.AllowedModels = decodeJSONStringList(modelsJSON)
 	profile.AllowedChannels = decodeJSONStringList(channelsJSON)
 	profile.AllowedChannelGroups = decodeJSONStringList(channelGroupsJSON)

--- a/internal/storage/sqlite/apikey/permission_profiles_tenant_test.go
+++ b/internal/storage/sqlite/apikey/permission_profiles_tenant_test.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -94,5 +96,44 @@ func TestPermissionProfilesMigrateToTenantScopedPrimaryKeyAndSyncIsolatedAccount
 		if limit != want.limit {
 			t.Fatalf("%s daily_limit = %d, want %d", want.id, limit, want.limit)
 		}
+	}
+}
+
+func TestPermissionProfileSaveCapsBoundOwnedKeysWithoutSyncAccounts(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	InitTable(db)
+	if _, err := db.Exec(`CREATE TABLE end_users (
+		id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, permission_profile_id TEXT NOT NULL DEFAULT '',
+		daily_limit INTEGER NOT NULL DEFAULT 0, total_quota INTEGER NOT NULL DEFAULT 0,
+		spending_limit REAL NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+		five_hour_spending_limit REAL NOT NULL DEFAULT 0, weekly_spending_limit REAL NOT NULL DEFAULT 0, monthly_spending_limit REAL NOT NULL DEFAULT 0,
+		concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0, tpm_limit INTEGER NOT NULL DEFAULT 0,
+		allowed_models TEXT NOT NULL DEFAULT '[]', allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]', system_prompt TEXT NOT NULL DEFAULT '',
+		updated_at TEXT NOT NULL DEFAULT '', version INTEGER NOT NULL DEFAULT 1
+	)`); err != nil {
+		t.Fatalf("create users: %v", err)
+	}
+	InitPermissionProfilesTable(db)
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	if _, err := db.Exec(`INSERT INTO end_users(id,tenant_id,permission_profile_id,daily_spending_limit) VALUES('user-a',?,'standard',200)`, tenantID); err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	store := NewTenantStore(db, tenantID)
+	if err := store.Upsert(APIKeyRow{ID: "key-a", Key: "sk-a", EndUserID: "user-a", DailySpendingLimit: 200, PeriodSpendingLimits: quota.PeriodSpendingLimits{Day: 200}}); err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	result, err := store.ReplaceAllPermissionProfilesWithCaps([]PermissionProfileRow{{ID: "standard", Name: "Standard", DailySpendingLimit: 100}}, false)
+	if err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if result.AppliedCount != 0 || len(result.CappedKeys) != 1 || result.CappedKeys[0].ID != "key-a" || result.CappedKeys[0].Period != quota.PeriodDay || result.CappedKeys[0].From != 200 || result.CappedKeys[0].To != 100 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := store.GetByID("key-a"); got == nil || got.DailySpendingLimit != 100 {
+		t.Fatalf("stored key = %+v", got)
 	}
 }

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -26,6 +27,9 @@ CREATE TABLE IF NOT EXISTS api_keys (
   total_quota       INTEGER NOT NULL DEFAULT 0,
   spending_limit    REAL NOT NULL DEFAULT 0,
   daily_spending_limit REAL NOT NULL DEFAULT 0,
+  five_hour_spending_limit REAL NOT NULL DEFAULT 0,
+  weekly_spending_limit REAL NOT NULL DEFAULT 0,
+  monthly_spending_limit REAL NOT NULL DEFAULT 0,
   concurrency_limit INTEGER NOT NULL DEFAULT 0,
   rpm_limit         INTEGER NOT NULL DEFAULT 0,
   tpm_limit         INTEGER NOT NULL DEFAULT 0,
@@ -42,27 +46,32 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);
 `
 
 type APIKeyRow struct {
-	TenantID             string   `json:"tenant_id,omitempty"`
-	ID                   string   `json:"id,omitempty"`
-	Key                  string   `json:"key"`
-	Name                 string   `json:"name,omitempty"`
-	Disabled             bool     `json:"disabled,omitempty"`
-	EndUserID            string   `json:"end_user_id,omitempty"`
-	IsDefault            bool     `json:"is_default,omitempty"`
-	PermissionProfileID  string   `json:"permission-profile-id,omitempty"`
-	DailyLimit           int      `json:"daily-limit,omitempty"`
-	TotalQuota           int      `json:"total-quota,omitempty"`
-	SpendingLimit        float64  `json:"spending-limit,omitempty"`
-	DailySpendingLimit   float64  `json:"daily-spending-limit,omitempty"`
-	ConcurrencyLimit     int      `json:"concurrency-limit,omitempty"`
-	RPMLimit             int      `json:"rpm-limit,omitempty"`
-	TPMLimit             int      `json:"tpm-limit,omitempty"`
-	AllowedModels        []string `json:"allowed-models,omitempty"`
-	AllowedChannels      []string `json:"allowed-channels,omitempty"`
-	AllowedChannelGroups []string `json:"allowed-channel-groups,omitempty"`
-	SystemPrompt         string   `json:"system-prompt,omitempty"`
-	CreatedAt            string   `json:"created-at,omitempty"`
-	UpdatedAt            string   `json:"updated_at,omitempty"`
+	TenantID                string                     `json:"tenant_id,omitempty"`
+	ID                      string                     `json:"id,omitempty"`
+	Key                     string                     `json:"key"`
+	Name                    string                     `json:"name,omitempty"`
+	Disabled                bool                       `json:"disabled,omitempty"`
+	EndUserID               string                     `json:"end_user_id,omitempty"`
+	IsDefault               bool                       `json:"is_default,omitempty"`
+	PermissionProfileID     string                     `json:"permission-profile-id,omitempty"`
+	DailyLimit              int                        `json:"daily-limit,omitempty"`
+	TotalQuota              int                        `json:"total-quota,omitempty"`
+	SpendingLimit           float64                    `json:"spending-limit,omitempty"`
+	DailySpendingLimit      float64                    `json:"daily-spending-limit,omitempty"`
+	PeriodSpendingLimits    quota.PeriodSpendingLimits `json:"period-spending-limits"`
+	PeriodSpending          []quota.PeriodSpending     `json:"period-spending,omitempty"`
+	LifetimeSpendingUsed    float64                    `json:"lifetime-spending-used"`
+	DailySpendingUsed       float64                    `json:"daily-spending-used"`
+	DailySpendingResetCount int                        `json:"daily-spending-reset-count,omitempty"`
+	ConcurrencyLimit        int                        `json:"concurrency-limit,omitempty"`
+	RPMLimit                int                        `json:"rpm-limit,omitempty"`
+	TPMLimit                int                        `json:"tpm-limit,omitempty"`
+	AllowedModels           []string                   `json:"allowed-models,omitempty"`
+	AllowedChannels         []string                   `json:"allowed-channels,omitempty"`
+	AllowedChannelGroups    []string                   `json:"allowed-channel-groups,omitempty"`
+	SystemPrompt            string                     `json:"system-prompt,omitempty"`
+	CreatedAt               string                     `json:"created-at,omitempty"`
+	UpdatedAt               string                     `json:"updated_at,omitempty"`
 }
 
 type PermissionProfileSnapshot struct {
@@ -70,6 +79,7 @@ type PermissionProfileSnapshot struct {
 	DailyLimit           int
 	TotalQuota           int
 	DailySpendingLimit   float64
+	PeriodSpendingLimits quota.PeriodSpendingLimits
 	ConcurrencyLimit     int
 	RPMLimit             int
 	TPMLimit             int
@@ -138,6 +148,9 @@ func (r APIKeyRow) ToConfigEntry() config.APIKeyEntry {
 		TotalQuota:           r.TotalQuota,
 		SpendingLimit:        r.SpendingLimit,
 		DailySpendingLimit:   r.DailySpendingLimit,
+		PeriodSpendingLimits: r.PeriodSpendingLimits,
+		PeriodSpending:       r.PeriodSpending,
+		LifetimeSpendingUsed: r.LifetimeSpendingUsed,
 		ConcurrencyLimit:     r.ConcurrencyLimit,
 		RPMLimit:             r.RPMLimit,
 		TPMLimit:             r.TPMLimit,
@@ -162,6 +175,7 @@ func APIKeyRowFromConfig(entry config.APIKeyEntry) APIKeyRow {
 		TotalQuota:           entry.TotalQuota,
 		SpendingLimit:        entry.SpendingLimit,
 		DailySpendingLimit:   entry.DailySpendingLimit,
+		PeriodSpendingLimits: entry.PeriodSpendingLimits,
 		ConcurrencyLimit:     entry.ConcurrencyLimit,
 		RPMLimit:             entry.RPMLimit,
 		TPMLimit:             entry.TPMLimit,
@@ -205,7 +219,7 @@ func (s Store) ListAll() []APIKeyRow {
 	}
 
 	rows, err := s.db.Query(`SELECT tenant_id, key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys ORDER BY tenant_id ASC, created_at ASC`)
@@ -234,7 +248,7 @@ func (s Store) List() []APIKeyRow {
 	}
 
 	rows, err := s.db.Query(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE tenant_id = ? ORDER BY created_at ASC`, s.tenantID)
@@ -262,7 +276,7 @@ func (s Store) Get(key string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE tenant_id = ? AND key = ?`, s.tenantID, trimmed)
@@ -288,7 +302,7 @@ func (s Store) GetAnyTenant(key string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT tenant_id, key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE key = ?`, trimmed)
@@ -310,7 +324,7 @@ func (s Store) GetByID(id string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE tenant_id = ? AND id = ?`, s.tenantID, trimmed)
@@ -335,7 +349,7 @@ func (s Store) GetByIDAnyTenant(id string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT tenant_id, key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE id = ?`, trimmed)
@@ -346,9 +360,9 @@ func (s Store) GetByIDAnyTenant(id string) *APIKeyRow {
 	return entry
 }
 
-// stripOwnedKeyQuota clears per-key limits for end-user-owned keys.
-// Account-level limits live on end_users; keeping key rows non-zero would re-open the multi-key budget hole.
-func stripOwnedKeyQuota(entry *APIKeyRow) {
+// stripOwnedKeyAccountManagedFields clears fields owned keys inherit from their account.
+// The four period spending limits remain key-scoped sub-quotas.
+func stripOwnedKeyAccountManagedFields(entry *APIKeyRow) {
 	if entry == nil || strings.TrimSpace(entry.EndUserID) == "" {
 		return
 	}
@@ -356,7 +370,6 @@ func stripOwnedKeyQuota(entry *APIKeyRow) {
 	entry.DailyLimit = 0
 	entry.TotalQuota = 0
 	entry.SpendingLimit = 0
-	entry.DailySpendingLimit = 0
 	entry.ConcurrencyLimit = 0
 	entry.RPMLimit = 0
 	entry.TPMLimit = 0
@@ -390,7 +403,7 @@ func (s Store) Upsert(entry APIKeyRow) error {
 			entry.EndUserID = existing.EndUserID
 		}
 	}
-	stripOwnedKeyQuota(&entry)
+	stripOwnedKeyAccountManagedFields(&entry)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	if entry.CreatedAt == "" {
@@ -409,16 +422,18 @@ func (s Store) Upsert(entry APIKeyRow) error {
 	}
 
 	result, err := s.db.Exec(`INSERT INTO api_keys
-		(tenant_id, key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
+		(tenant_id, key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		 end_user_id, is_default)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(key) DO UPDATE SET
 			id=excluded.id,
 			name=excluded.name, disabled=excluded.disabled,
 			permission_profile_id=excluded.permission_profile_id,
 			daily_limit=excluded.daily_limit, total_quota=excluded.total_quota,
-			spending_limit=excluded.spending_limit, daily_spending_limit=excluded.daily_spending_limit, concurrency_limit=excluded.concurrency_limit,
+			spending_limit=excluded.spending_limit, daily_spending_limit=excluded.daily_spending_limit,
+			five_hour_spending_limit=excluded.five_hour_spending_limit, weekly_spending_limit=excluded.weekly_spending_limit, monthly_spending_limit=excluded.monthly_spending_limit,
+			concurrency_limit=excluded.concurrency_limit,
 			rpm_limit=excluded.rpm_limit, tpm_limit=excluded.tpm_limit,
 			allowed_models=excluded.allowed_models, allowed_channels=excluded.allowed_channels,
 			allowed_channel_groups=excluded.allowed_channel_groups,
@@ -429,7 +444,7 @@ func (s Store) Upsert(entry APIKeyRow) error {
 		WHERE api_keys.tenant_id = excluded.tenant_id`,
 		s.tenantID, entry.Key, entry.ID, entry.Name, disabledInt, entry.PermissionProfileID,
 		entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit, entry.DailySpendingLimit,
-		entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
+		entry.PeriodSpendingLimits.FiveHour, entry.PeriodSpendingLimits.Week, entry.PeriodSpendingLimits.Month, entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
 		entry.CreatedAt, now, endUserID, isDefault,
@@ -482,6 +497,11 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 		if err = lockOwnedEndUser(tx, ownerID); err != nil {
 			return err
 		}
+		if err = tx.QueryRow(`SELECT COALESCE(daily_spending_limit,0), COALESCE(five_hour_spending_limit,0), COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0) FROM api_keys WHERE tenant_id = ? AND id = ?`, s.tenantID, entry.ID).
+			Scan(&entry.PeriodSpendingLimits.Day, &entry.PeriodSpendingLimits.FiveHour, &entry.PeriodSpendingLimits.Week, &entry.PeriodSpendingLimits.Month); err != nil {
+			return err
+		}
+		entry.DailySpendingLimit = entry.PeriodSpendingLimits.Day
 		entry.EndUserID = ownerID
 		entry.IsDefault = wasDefault && !entry.Disabled
 	} else {
@@ -495,7 +515,7 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 	if entry.CreatedAt == "" {
 		entry.CreatedAt = now
 	}
-	stripOwnedKeyQuota(&entry)
+	stripOwnedKeyAccountManagedFields(&entry)
 
 	disabledInt := 0
 	if entry.Disabled {
@@ -503,12 +523,13 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 	}
 	result, err := tx.Exec(`UPDATE api_keys SET
 		key = ?, name = ?, disabled = ?, permission_profile_id = ?, daily_limit = ?, total_quota = ?,
-		spending_limit = ?, daily_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
+		spending_limit = ?, daily_spending_limit = ?, five_hour_spending_limit = ?, weekly_spending_limit = ?, monthly_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
 		allowed_models = ?, allowed_channels = ?, allowed_channel_groups = ?, system_prompt = ?,
 		created_at = ?, updated_at = ?, is_default = ?
 		WHERE tenant_id = ? AND id = ?`,
 		entry.Key, entry.Name, disabledInt, entry.PermissionProfileID, entry.DailyLimit, entry.TotalQuota,
-		entry.SpendingLimit, entry.DailySpendingLimit, entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
+		entry.SpendingLimit, entry.DailySpendingLimit, entry.PeriodSpendingLimits.FiveHour, entry.PeriodSpendingLimits.Week, entry.PeriodSpendingLimits.Month,
+		entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
 		entry.CreatedAt, now, entry.IsDefault, s.tenantID, entry.ID,
@@ -764,10 +785,10 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_keys
-		(tenant_id, key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
+		(tenant_id, key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		 end_user_id, is_default)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -792,6 +813,7 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 		if _, err := stmt.Exec(
 			s.tenantID, entry.Key, entry.ID, entry.Name, disabledInt, entry.PermissionProfileID,
 			entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit, entry.DailySpendingLimit,
+			entry.PeriodSpendingLimits.FiveHour, entry.PeriodSpendingLimits.Week, entry.PeriodSpendingLimits.Month,
 			entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 			mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 			mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
@@ -812,50 +834,6 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 	return tx.Commit()
 }
 
-func EffectiveAPIKeyRowWithProfiles(row APIKeyRow, profiles []PermissionProfileSnapshot) APIKeyRow {
-	profileID := strings.TrimSpace(row.PermissionProfileID)
-	if profileID == "" {
-		return row
-	}
-
-	var matched *PermissionProfileSnapshot
-	for _, profile := range profiles {
-		if strings.TrimSpace(profile.ID) == profileID {
-			copy := profile
-			matched = &copy
-			break
-		}
-	}
-	if matched == nil {
-		return row
-	}
-
-	row.PermissionProfileID = profileID
-	row.DailyLimit = matched.DailyLimit
-	row.TotalQuota = matched.TotalQuota
-	row.SpendingLimit = 0
-	row.DailySpendingLimit = matched.DailySpendingLimit
-	row.ConcurrencyLimit = matched.ConcurrencyLimit
-	row.RPMLimit = matched.RPMLimit
-	row.TPMLimit = matched.TPMLimit
-	row.AllowedModels = append([]string(nil), matched.AllowedModels...)
-	row.AllowedChannels = append([]string(nil), matched.AllowedChannels...)
-	row.AllowedChannelGroups = append([]string(nil), matched.AllowedChannelGroups...)
-	row.SystemPrompt = matched.SystemPrompt
-	return row
-}
-
-func EffectiveAPIKeyRowsWithProfiles(rows []APIKeyRow, profiles []PermissionProfileSnapshot) []APIKeyRow {
-	if len(rows) == 0 {
-		return rows
-	}
-	out := make([]APIKeyRow, len(rows))
-	for idx, row := range rows {
-		out[idx] = EffectiveAPIKeyRowWithProfiles(row, profiles)
-	}
-	return out
-}
-
 func migrateColumns(db *sql.DB) {
 	for _, col := range []struct {
 		name       string
@@ -867,6 +845,9 @@ func migrateColumns(db *sql.DB) {
 		{name: "allowed_channels", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "allowed_channel_groups", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "daily_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
+		{name: "five_hour_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
+		{name: "weekly_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
+		{name: "monthly_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
 		{name: "end_user_id", definition: "TEXT"},
 		{name: "is_default", definition: "INTEGER NOT NULL DEFAULT 0"},
 	} {
@@ -1053,7 +1034,20 @@ func normalizeRow(row APIKeyRow) APIKeyRow {
 	row.EndUserID = strings.TrimSpace(row.EndUserID)
 	row.PermissionProfileID = strings.TrimSpace(row.PermissionProfileID)
 	row.SpendingLimit = normalizeWholeUSD(row.SpendingLimit)
-	row.DailySpendingLimit = normalizeWholeUSD(row.DailySpendingLimit)
+	limits, err := quota.NormalizeLimits(row.PeriodSpendingLimits)
+	if err != nil {
+		limits = quota.PeriodSpendingLimits{}
+	}
+	day, err := quota.NormalizeWholeUSD(row.DailySpendingLimit)
+	if err != nil {
+		day = 0
+	}
+	if limits.Day > 0 && day == 0 {
+		day = limits.Day
+	}
+	limits.Day = day
+	row.DailySpendingLimit = day
+	row.PeriodSpendingLimits = limits
 	return row
 }
 
@@ -1094,7 +1088,7 @@ func scanAPIKeyRowWithTenant(row scanner) (*APIKeyRow, bool) {
 		&entry.TenantID, &entry.Key, &entry.Name, &disabledInt,
 		&entry.ID,
 		&entry.DailyLimit, &entry.TotalQuota, &entry.PermissionProfileID, &entry.SpendingLimit,
-		&entry.DailySpendingLimit, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
+		&entry.DailySpendingLimit, &entry.PeriodSpendingLimits.FiveHour, &entry.PeriodSpendingLimits.Week, &entry.PeriodSpendingLimits.Month, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
 		&modelsJSON, &channelsJSON, &channelGroupsJSON, &entry.SystemPrompt,
 		&entry.CreatedAt, &entry.UpdatedAt, &endUserID, &isDefault,
 	); err != nil {
@@ -1107,6 +1101,7 @@ func scanAPIKeyRowWithTenant(row scanner) (*APIKeyRow, bool) {
 		entry.EndUserID = endUserID.String
 	}
 	entry.IsDefault = boolish(isDefault)
+	entry.PeriodSpendingLimits.Day = entry.DailySpendingLimit
 	decodeAPIKeyRow(&entry, disabledInt, modelsJSON, channelsJSON, channelGroupsJSON)
 	return &entry, true
 }
@@ -1123,7 +1118,7 @@ func scanAPIKeyRow(row scanner) (*APIKeyRow, bool) {
 		&entry.Key, &entry.Name, &disabledInt,
 		&entry.ID,
 		&entry.DailyLimit, &entry.TotalQuota, &entry.PermissionProfileID, &entry.SpendingLimit,
-		&entry.DailySpendingLimit, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
+		&entry.DailySpendingLimit, &entry.PeriodSpendingLimits.FiveHour, &entry.PeriodSpendingLimits.Week, &entry.PeriodSpendingLimits.Month, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
 		&modelsJSON, &channelsJSON, &channelGroupsJSON, &entry.SystemPrompt,
 		&entry.CreatedAt, &entry.UpdatedAt, &endUserID, &isDefault,
 	); err != nil {
@@ -1136,6 +1131,7 @@ func scanAPIKeyRow(row scanner) (*APIKeyRow, bool) {
 		entry.EndUserID = endUserID.String
 	}
 	entry.IsDefault = boolish(isDefault)
+	entry.PeriodSpendingLimits.Day = entry.DailySpendingLimit
 	decodeAPIKeyRow(&entry, disabledInt, modelsJSON, channelsJSON, channelGroupsJSON)
 	return &entry, true
 }

--- a/internal/storage/sqlite/apikey/store_tenant_test.go
+++ b/internal/storage/sqlite/apikey/store_tenant_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -210,5 +212,33 @@ func TestOwnedKeyMutationsKeepOneActiveDefault(t *testing.T) {
 	}
 	if got := store.GetByID("default-b"); got == nil || got.Disabled || !got.IsDefault {
 		t.Fatalf("failed replace changed active/default state: %#v", got)
+	}
+}
+
+func TestOwnedKeyStripPreservesPeriodSpendingLimits(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	InitTable(db)
+	store := NewStore(db)
+	limits := quota.PeriodSpendingLimits{FiveHour: 5, Day: 10, Week: 20, Month: 30}
+	if err := store.Upsert(APIKeyRow{
+		ID: "owned-period", Key: "sk-owned-period", EndUserID: "user-a",
+		DailyLimit: 99, SpendingLimit: 1000, DailySpendingLimit: limits.Day, PeriodSpendingLimits: limits,
+		ConcurrencyLimit: 2, RPMLimit: 3, TPMLimit: 4,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got := store.Get("sk-owned-period")
+	if got == nil {
+		t.Fatal("missing owned key")
+	}
+	if got.DailyLimit != 0 || got.SpendingLimit != 0 || got.ConcurrencyLimit != 0 || got.RPMLimit != 0 || got.TPMLimit != 0 {
+		t.Fatalf("account-managed fields were not stripped: %+v", got)
+	}
+	if got.PeriodSpendingLimits != limits || got.DailySpendingLimit != limits.Day {
+		t.Fatalf("period limits = %+v/day=%v, want %+v", got.PeriodSpendingLimits, got.DailySpendingLimit, limits)
 	}
 }

--- a/internal/usage/api_key_permission_profiles_db.go
+++ b/internal/usage/api_key_permission_profiles_db.go
@@ -15,6 +15,7 @@ import (
 const apiKeyPermissionProfilesMigrationBackupSuffix = ".pre-api-key-permission-profiles-sqlite-migration"
 
 type APIKeyPermissionProfileRow = sqlapikey.PermissionProfileRow
+type APIKeyPermissionProfileSyncResult = sqlapikey.PermissionProfileSyncResult
 
 func initAPIKeyPermissionProfilesTable(db *sql.DB) {
 	sqlapikey.InitPermissionProfilesTable(db)
@@ -46,6 +47,10 @@ func ReplaceAllAPIKeyPermissionProfilesForTenant(tenantID string, profiles []API
 
 func ReplaceAllAPIKeyPermissionProfilesForTenantAndSyncEndUsers(tenantID string, profiles []APIKeyPermissionProfileRow) (int64, error) {
 	return apiKeyPermissionProfileStoreForTenant(tenantID).ReplaceAllPermissionProfilesAndSyncEndUsers(profiles)
+}
+
+func ReplaceAllAPIKeyPermissionProfilesForTenantWithCaps(tenantID string, profiles []APIKeyPermissionProfileRow, syncEndUsers bool) (sqlapikey.PermissionProfileSyncResult, error) {
+	return apiKeyPermissionProfileStoreForTenant(tenantID).ReplaceAllPermissionProfilesWithCaps(profiles, syncEndUsers)
 }
 
 func MigrateAPIKeyPermissionProfilesFromYAML(configFilePath string) int {

--- a/internal/usage/apikey_db.go
+++ b/internal/usage/apikey_db.go
@@ -250,6 +250,7 @@ func toPermissionProfileSnapshots(profiles []APIKeyPermissionProfileRow) []sqlap
 			DailyLimit:           profile.DailyLimit,
 			TotalQuota:           profile.TotalQuota,
 			DailySpendingLimit:   profile.DailySpendingLimit,
+			PeriodSpendingLimits: profile.PeriodSpendingLimits,
 			ConcurrencyLimit:     profile.ConcurrencyLimit,
 			RPMLimit:             profile.RPMLimit,
 			TPMLimit:             profile.TPMLimit,

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 )
 
 // EndUserQuota is the account-level limit/permission snapshot used by auth + quota.
@@ -19,6 +21,7 @@ type EndUserQuota struct {
 	TotalQuota           int
 	SpendingLimit        float64
 	DailySpendingLimit   float64
+	PeriodSpendingLimits quota.PeriodSpendingLimits
 	ConcurrencyLimit     int
 	RPMLimit             int
 	TPMLimit             int
@@ -56,6 +59,7 @@ func GetEndUserQuota(endUserID string) *EndUserQuota {
 		SELECT id, tenant_id, display_name, COALESCE(status, 'active'),
 			COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
 			COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+			COALESCE(five_hour_spending_limit, 0), COALESCE(weekly_spending_limit, 0), COALESCE(monthly_spending_limit, 0),
 			COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
 			COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
 			COALESCE(system_prompt, '')
@@ -64,12 +68,30 @@ func GetEndUserQuota(endUserID string) *EndUserQuota {
 		&q.ID, &q.TenantID, &q.DisplayName, &q.Status,
 		&q.PermissionProfileID, &q.DailyLimit, &q.TotalQuota,
 		&q.SpendingLimit, &q.DailySpendingLimit,
-		&q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
+		&q.PeriodSpendingLimits.FiveHour, &q.PeriodSpendingLimits.Week, &q.PeriodSpendingLimits.Month, &q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
 		&modelsJSON, &channelsJSON, &groupsJSON, &q.SystemPrompt,
 	)
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "no such column") {
+		err = db.QueryRow(`
+			SELECT id, tenant_id, display_name, COALESCE(status, 'active'),
+				COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
+				COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+				COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
+				COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
+				COALESCE(system_prompt, '')
+			FROM end_users WHERE id = ?
+		`, endUserID).Scan(
+			&q.ID, &q.TenantID, &q.DisplayName, &q.Status,
+			&q.PermissionProfileID, &q.DailyLimit, &q.TotalQuota,
+			&q.SpendingLimit, &q.DailySpendingLimit,
+			&q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
+			&modelsJSON, &channelsJSON, &groupsJSON, &q.SystemPrompt,
+		)
+	}
 	if err != nil {
 		return nil
 	}
+	q.PeriodSpendingLimits.Day = q.DailySpendingLimit
 	q.AllowedModels = decodeQuotaStringList(modelsJSON)
 	q.AllowedChannels = decodeQuotaStringList(channelsJSON)
 	q.AllowedChannelGroups = decodeQuotaStringList(groupsJSON)
@@ -78,30 +100,7 @@ func GetEndUserQuota(endUserID string) *EndUserQuota {
 
 // EffectiveEndUserQuota merges a permission profile over the end-user row when set.
 func EffectiveEndUserQuota(q EndUserQuota) EndUserQuota {
-	profileID := strings.TrimSpace(q.PermissionProfileID)
-	if profileID == "" {
-		return q
-	}
-	profiles := ListAPIKeyPermissionProfilesForTenant(q.TenantID)
-	for _, profile := range profiles {
-		if strings.TrimSpace(profile.ID) != profileID {
-			continue
-		}
-		q.PermissionProfileID = profileID
-		q.DailyLimit = profile.DailyLimit
-		q.TotalQuota = profile.TotalQuota
-		q.SpendingLimit = 0
-		q.DailySpendingLimit = profile.DailySpendingLimit
-		q.ConcurrencyLimit = profile.ConcurrencyLimit
-		q.RPMLimit = profile.RPMLimit
-		q.TPMLimit = profile.TPMLimit
-		q.AllowedModels = append([]string(nil), profile.AllowedModels...)
-		q.AllowedChannels = append([]string(nil), profile.AllowedChannels...)
-		q.AllowedChannelGroups = append([]string(nil), profile.AllowedChannelGroups...)
-		q.SystemPrompt = profile.SystemPrompt
-		return q
-	}
-	return q
+	return EffectiveEndUserQuotaWithProfiles(q, ListAPIKeyPermissionProfilesForTenant(q.TenantID))
 }
 
 // ListAPIKeyIDsForEndUser returns stable key ids owned by the end user.
@@ -320,6 +319,9 @@ func EnsureEndUserQuotaColumns(db *sql.DB) error {
 		{"total_quota", "INTEGER NOT NULL DEFAULT 0"},
 		{"spending_limit", "REAL NOT NULL DEFAULT 0"},
 		{"daily_spending_limit", "REAL NOT NULL DEFAULT 0"},
+		{"five_hour_spending_limit", "REAL NOT NULL DEFAULT 0"},
+		{"weekly_spending_limit", "REAL NOT NULL DEFAULT 0"},
+		{"monthly_spending_limit", "REAL NOT NULL DEFAULT 0"},
 		{"concurrency_limit", "INTEGER NOT NULL DEFAULT 0"},
 		{"rpm_limit", "INTEGER NOT NULL DEFAULT 0"},
 		{"tpm_limit", "INTEGER NOT NULL DEFAULT 0"},
@@ -340,4 +342,90 @@ func EnsureEndUserQuotaColumns(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+// ListEndUserQuotasByIDs batch-loads account quota rows for provider cache rebuilds.
+func ListEndUserQuotasByIDs(endUserIDs []string) (map[string]EndUserQuota, error) {
+	db := getReadDB()
+	if db == nil {
+		return nil, fmt.Errorf("usage: end user quota database unavailable")
+	}
+	ids := dedupeExactStrings(endUserIDs)
+	out := make(map[string]EndUserQuota, len(ids))
+	const chunkSize = 400
+	for start := 0; start < len(ids); start += chunkSize {
+		end := start + chunkSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+		rows, err := db.Query(`
+			SELECT id, tenant_id, display_name, COALESCE(status, 'active'),
+				COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
+				COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+				COALESCE(five_hour_spending_limit, 0), COALESCE(weekly_spending_limit, 0), COALESCE(monthly_spending_limit, 0),
+				COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
+				COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
+				COALESCE(system_prompt, '')
+			FROM end_users WHERE id IN (`+placeholders(len(chunk))+`)`, stringsToAny(chunk)...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var q EndUserQuota
+			var modelsJSON, channelsJSON, groupsJSON string
+			if err := rows.Scan(&q.ID, &q.TenantID, &q.DisplayName, &q.Status,
+				&q.PermissionProfileID, &q.DailyLimit, &q.TotalQuota, &q.SpendingLimit, &q.DailySpendingLimit,
+				&q.PeriodSpendingLimits.FiveHour, &q.PeriodSpendingLimits.Week, &q.PeriodSpendingLimits.Month,
+				&q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
+				&modelsJSON, &channelsJSON, &groupsJSON, &q.SystemPrompt); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			q.PeriodSpendingLimits.Day = q.DailySpendingLimit
+			q.AllowedModels = decodeQuotaStringList(modelsJSON)
+			q.AllowedChannels = decodeQuotaStringList(channelsJSON)
+			q.AllowedChannelGroups = decodeQuotaStringList(groupsJSON)
+			out[q.ID] = q
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func stringsToAny(values []string) []any {
+	out := make([]any, len(values))
+	for i := range values {
+		out[i] = values[i]
+	}
+	return out
+}
+
+func EffectiveEndUserQuotaWithProfiles(q EndUserQuota, profiles []APIKeyPermissionProfileRow) EndUserQuota {
+	profileID := strings.TrimSpace(q.PermissionProfileID)
+	if profileID == "" {
+		return q
+	}
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.ID) != profileID {
+			continue
+		}
+		q.PermissionProfileID = profileID
+		q.DailyLimit = profile.DailyLimit
+		q.TotalQuota = profile.TotalQuota
+		q.DailySpendingLimit = profile.DailySpendingLimit
+		q.PeriodSpendingLimits = profile.PeriodSpendingLimits
+		q.PeriodSpendingLimits.Day = q.DailySpendingLimit
+		q.ConcurrencyLimit = profile.ConcurrencyLimit
+		q.RPMLimit = profile.RPMLimit
+		q.TPMLimit = profile.TPMLimit
+		q.AllowedModels = append([]string(nil), profile.AllowedModels...)
+		q.AllowedChannels = append([]string(nil), profile.AllowedChannels...)
+		q.AllowedChannelGroups = append([]string(nil), profile.AllowedChannelGroups...)
+		q.SystemPrompt = profile.SystemPrompt
+		return q
+	}
+	return q
 }

--- a/internal/usage/period_spending.go
+++ b/internal/usage/period_spending.go
@@ -1,0 +1,240 @@
+package usage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
+
+var ErrQuotaUsageUnavailable = errors.New("quota usage unavailable")
+
+type periodSubject string
+
+const (
+	periodSubjectAPIKey  periodSubject = "api_key_id"
+	periodSubjectEndUser periodSubject = "end_user_id"
+)
+
+type PeriodWindowKeys struct {
+	FiveHourFrom string
+	FiveHourTo   string
+	Day          string
+	WeekFrom     string
+	MonthFrom    string
+	DayTo        string
+}
+
+func PeriodWindowKeysAt(now time.Time, loc *time.Location) PeriodWindowKeys {
+	if loc == nil {
+		loc = time.Local
+	}
+	nowMinute := now.UTC().Truncate(time.Minute)
+	localNow := now.In(loc)
+	localMidnight := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, loc)
+	weekdayOffset := (int(localMidnight.Weekday()) + 6) % 7
+	weekStart := localMidnight.AddDate(0, 0, -weekdayOffset)
+	monthStart := time.Date(localNow.Year(), localNow.Month(), 1, 0, 0, 0, 0, loc)
+	return PeriodWindowKeys{
+		FiveHourFrom: nowMinute.Add(-5 * time.Hour).Format("2006-01-02T15:04"),
+		FiveHourTo:   nowMinute.Add(time.Minute).Format("2006-01-02T15:04"),
+		Day:          localDayKeyAtLocation(now, loc),
+		WeekFrom:     localDayKeyAtLocation(weekStart, loc),
+		MonthFrom:    localDayKeyAtLocation(monthStart, loc),
+		DayTo:        localDayKeyAtLocation(localMidnight.AddDate(0, 0, 1), loc),
+	}
+}
+
+func QueryPeriodSpendingByAPIKeyIDForTenant(tenantID, apiKeyID string) (quota.PeriodSpendingUsage, error) {
+	values, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(tenantID, []string{apiKeyID}, time.Now())
+	if err != nil {
+		return quota.PeriodSpendingUsage{}, err
+	}
+	return values[strings.TrimSpace(apiKeyID)], nil
+}
+
+func QueryPeriodSpendingByEndUserForTenant(tenantID, endUserID string) (quota.PeriodSpendingUsage, error) {
+	values, err := QueryPeriodSpendingByEndUsersForTenantAt(tenantID, []string{endUserID}, time.Now())
+	if err != nil {
+		return quota.PeriodSpendingUsage{}, err
+	}
+	return values[strings.TrimSpace(endUserID)], nil
+}
+
+func QueryPeriodSpendingByAPIKeyIDsForTenantAt(tenantID string, apiKeyIDs []string, now time.Time) (map[string]quota.PeriodSpendingUsage, error) {
+	return queryPeriodSpendingForSubjects(tenantID, periodSubjectAPIKey, apiKeyIDs, now)
+}
+
+func QueryPeriodSpendingByEndUsersForTenantAt(tenantID string, endUserIDs []string, now time.Time) (map[string]quota.PeriodSpendingUsage, error) {
+	return queryPeriodSpendingForSubjects(tenantID, periodSubjectEndUser, endUserIDs, now)
+}
+
+func QueryPeriodSpendingByAPIKeyIDsForTenant(tenantID string, apiKeyIDs []string) (map[string]quota.PeriodSpendingUsage, error) {
+	return QueryPeriodSpendingByAPIKeyIDsForTenantAt(tenantID, apiKeyIDs, time.Now())
+}
+
+func QueryPeriodSpendingByEndUsersForTenant(tenantID string, endUserIDs []string) (map[string]quota.PeriodSpendingUsage, error) {
+	return QueryPeriodSpendingByEndUsersForTenantAt(tenantID, endUserIDs, time.Now())
+}
+
+func queryPeriodSpendingForSubjects(tenantID string, subject periodSubject, ids []string, now time.Time) (map[string]quota.PeriodSpendingUsage, error) {
+	ids = dedupeExactStrings(ids)
+	out := make(map[string]quota.PeriodSpendingUsage, len(ids))
+	for _, id := range ids {
+		if id = strings.TrimSpace(id); id != "" {
+			out[id] = quota.PeriodSpendingUsage{}
+		}
+	}
+	if len(out) == 0 {
+		return out, nil
+	}
+	const subjectChunkSize = 300
+	if len(out) > subjectChunkSize {
+		cleanIDs := make([]string, 0, len(out))
+		for id := range out {
+			cleanIDs = append(cleanIDs, id)
+		}
+		combined := make(map[string]quota.PeriodSpendingUsage, len(cleanIDs))
+		for start := 0; start < len(cleanIDs); start += subjectChunkSize {
+			end := start + subjectChunkSize
+			if end > len(cleanIDs) {
+				end = len(cleanIDs)
+			}
+			part, err := queryPeriodSpendingForSubjects(tenantID, subject, cleanIDs[start:end], now)
+			if err != nil {
+				return nil, err
+			}
+			for id, used := range part {
+				combined[id] = used
+			}
+		}
+		return combined, nil
+	}
+	ids = ids[:0]
+	for id := range out {
+		ids = append(ids, id)
+	}
+	windows := PeriodWindowKeysAt(now, getUsageLocation())
+	queries := []struct {
+		kind string
+		from string
+		to   string
+		set  func(*quota.PeriodSpendingUsage, float64)
+	}{
+		{rollupBucketQuotaMinuteUTC, windows.FiveHourFrom, windows.FiveHourTo, func(v *quota.PeriodSpendingUsage, n float64) { v.FiveHour = n }},
+		{rollupBucketDay, windows.Day, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Day = n }},
+		{rollupBucketDay, windows.WeekFrom, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Week = n }},
+		{rollupBucketDay, windows.MonthFrom, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Month = n }},
+		{rollupBucketLifetime, "", "", func(v *quota.PeriodSpendingUsage, n float64) { v.Lifetime = n }},
+	}
+	for _, query := range queries {
+		values, err := queryGroupedPeriodCost(tenantID, subject, ids, query.kind, query.from, query.to)
+		if err != nil {
+			return nil, err
+		}
+		for id, value := range values {
+			current := out[id]
+			query.set(&current, value)
+			out[id] = current
+		}
+	}
+
+	var baselines map[string]float64
+	var err error
+	if subject == periodSubjectAPIKey {
+		baselines, err = ListDailySpendingResetBaselines(tenantID, ids)
+	} else {
+		baselines, err = listEndUserDailySpendingResetBaselines(tenantID, ids, windows.Day)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: day baselines: %v", ErrQuotaUsageUnavailable, err)
+	}
+	for id, baseline := range baselines {
+		current := out[id]
+		current.Day -= baseline
+		if current.Day < 0 {
+			current.Day = 0
+		}
+		out[id] = current
+	}
+	return out, nil
+}
+
+func queryGroupedPeriodCost(tenantID string, subject periodSubject, ids []string, kind, from, to string) (map[string]float64, error) {
+	db := getReadDB()
+	if db == nil {
+		return nil, ErrQuotaUsageUnavailable
+	}
+	column := string(subject)
+	if subject != periodSubjectAPIKey && subject != periodSubjectEndUser {
+		return nil, fmt.Errorf("%w: invalid subject", ErrQuotaUsageUnavailable)
+	}
+	var b strings.Builder
+	b.WriteString(`SELECT ` + column + `, COALESCE(SUM(cost_total), 0) FROM usage_rollup_buckets WHERE tenant_id = ? AND bucket_kind = ? AND ` + column + ` IN (` + placeholders(len(ids)) + `)`)
+	args := make([]any, 0, len(ids)+4)
+	args = append(args, normalizeTenantID(tenantID), kind)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	if from != "" {
+		b.WriteString(` AND bucket_start >= ?`)
+		args = append(args, from)
+	}
+	if to != "" {
+		b.WriteString(` AND bucket_start < ?`)
+		args = append(args, to)
+	}
+	b.WriteString(` GROUP BY ` + column)
+	rows, err := db.Query(b.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: query %s %s: %v", ErrQuotaUsageUnavailable, subject, kind, err)
+	}
+	defer rows.Close()
+	out := make(map[string]float64, len(ids))
+	for rows.Next() {
+		var id string
+		var value float64
+		if err := rows.Scan(&id, &value); err != nil {
+			return nil, fmt.Errorf("%w: scan %s %s: %v", ErrQuotaUsageUnavailable, subject, kind, err)
+		}
+		out[id] = value
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("%w: rows %s %s: %v", ErrQuotaUsageUnavailable, subject, kind, err)
+	}
+	return out, nil
+}
+
+func listEndUserDailySpendingResetBaselines(tenantID string, ids []string, dayKey string) (map[string]float64, error) {
+	db := getReadDB()
+	if db == nil {
+		return nil, ErrQuotaUsageUnavailable
+	}
+	query := `SELECT end_user_id, cost_baseline FROM end_user_daily_spending_resets WHERE tenant_id = ? AND day_key = ? AND end_user_id IN (` + placeholders(len(ids)) + `)`
+	args := make([]any, 0, len(ids)+2)
+	args = append(args, normalizeTenantID(tenantID), dayKey)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return map[string]float64{}, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]float64, len(ids))
+	for rows.Next() {
+		var id string
+		var baseline float64
+		if err := rows.Scan(&id, &baseline); err != nil {
+			return nil, err
+		}
+		out[id] = baseline
+	}
+	return out, rows.Err()
+}

--- a/internal/usage/period_spending_test.go
+++ b/internal/usage/period_spending_test.go
@@ -1,0 +1,88 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestPeriodWindowKeysAtUsesProjectTimezoneMondayWeek(t *testing.T) {
+	loc := time.FixedZone("UTC+8", 8*60*60)
+	now := time.Date(2026, 7, 22, 12, 30, 0, 0, time.UTC)
+	got := PeriodWindowKeysAt(now, loc)
+	if got.WeekFrom != "2026-07-20" || got.MonthFrom != "2026-07-01" || got.DayTo != "2026-07-23" {
+		t.Fatalf("windows = %+v, want Monday 2026-07-20, month 2026-07-01, tomorrow 2026-07-23", got)
+	}
+	if got.FiveHourFrom != "2026-07-22T07:30" || got.FiveHourTo != "2026-07-22T12:31" {
+		t.Fatalf("5h windows = [%s,%s), want [2026-07-22T07:30,2026-07-22T12:31)", got.FiveHourFrom, got.FiveHourTo)
+	}
+}
+
+func TestQueryPeriodSpendingWeekAndFiveHourBoundaries(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+	now := time.Date(2026, 7, 22, 12, 30, 45, 0, time.UTC)
+	keyID := "period-key"
+	insert := func(kind, start string, cost float64) {
+		t.Helper()
+		if _, err := db.Exec(`INSERT INTO usage_rollup_buckets
+			(tenant_id,bucket_kind,bucket_start,api_key_id,cost_total,updated_at)
+			VALUES (?,?,?,?,?,?)`, systemTenantID, kind, start, keyID, cost, now); err != nil {
+			t.Fatalf("insert %s %s: %v", kind, start, err)
+		}
+	}
+	insert(rollupBucketDay, "2026-07-19", 100) // previous Sunday: excluded from week
+	insert(rollupBucketDay, "2026-07-20", 10)  // Monday inclusive
+	insert(rollupBucketDay, "2026-07-22", 5)
+	insert(rollupBucketDay, "2026-07-23", 20) // tomorrow exclusive
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T07:29", 100)
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T07:30", 3)   // cutoff minute included
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T12:30", 4)   // current minute included
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T12:31", 100) // exclusive upper bound
+	insert(rollupBucketLifetime, rollupLifetimeStart, 999)
+
+	got, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(systemTenantID, []string{keyID}, now)
+	if err != nil {
+		t.Fatalf("QueryPeriodSpending: %v", err)
+	}
+	used := got[keyID]
+	if used.FiveHour != 7 || used.Day != 5 || used.Week != 15 || used.Month != 115 || used.Lifetime != 999 {
+		t.Fatalf("used = %+v, want 5h=7 day=5 week=15 month=115 lifetime=999", used)
+	}
+}
+
+func TestFiveHourQuotaProjectionReadinessRequiresFullCoverage(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	ensureUsageProjectionMarkerTable(db)
+	set := func(start time.Time) {
+		t.Helper()
+		if _, err := db.Exec(`INSERT INTO usage_projection_markers(marker_key,marker_value,updated_at)
+			VALUES(?,?,?) ON CONFLICT(marker_key) DO UPDATE SET marker_value=excluded.marker_value,updated_at=excluded.updated_at`,
+			quotaMinuteCoverageStartMarker, start.Format(time.RFC3339), now); err != nil {
+			t.Fatalf("set marker: %v", err)
+		}
+	}
+	set(now.Add(-4*time.Hour - 59*time.Minute))
+	if FiveHourQuotaProjectionReadyAt(now) {
+		t.Fatal("projection should still be warming before five hours")
+	}
+	set(now.Add(-5 * time.Hour))
+	if !FiveHourQuotaProjectionReadyAt(now) {
+		t.Fatal("projection should be ready at full five-hour coverage")
+	}
+}
+
+func TestRollupBucketStartsProjectsQuotaMinuteInUTC(t *testing.T) {
+	loc := time.FixedZone("UTC+8", 8*60*60)
+	at := time.Date(2026, 7, 22, 23, 59, 30, 0, loc)
+	starts := rollupBucketStarts(at, loc)
+	if starts[rollupBucketMinute] != "2026-07-22T23:59" {
+		t.Fatalf("local minute = %q", starts[rollupBucketMinute])
+	}
+	if starts[rollupBucketQuotaMinuteUTC] != "2026-07-22T15:59" {
+		t.Fatalf("quota UTC minute = %q, want 2026-07-22T15:59", starts[rollupBucketQuotaMinuteUTC])
+	}
+}

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -22,11 +22,12 @@ var (
 )
 
 const (
-	rollupBucketMinute   = "minute"
-	rollupBucketHour     = "hour"
-	rollupBucketDay      = "day"
-	rollupBucketLifetime = "lifetime"
-	rollupLifetimeStart  = "1970-01-01"
+	rollupBucketMinute         = "minute"
+	rollupBucketQuotaMinuteUTC = "quota_minute_utc"
+	rollupBucketHour           = "hour"
+	rollupBucketDay            = "day"
+	rollupBucketLifetime       = "lifetime"
+	rollupLifetimeStart        = "1970-01-01"
 	// minute: 24h, hour: 30d, day: 400d (covers 365d heatmap + buffer)
 	rollupMinuteRetention = 24 * time.Hour
 	rollupHourRetention   = 30 * 24 * time.Hour
@@ -74,9 +75,10 @@ CREATE INDEX IF NOT EXISTS idx_usage_rollup_tenant_subject_day
   ON usage_rollup_buckets(tenant_id, bucket_kind, auth_subject_id, bucket_start);
 `
 	// Bump marker when rebuild semantics change so upgrades re-run once.
-	usageRollupBackfillMarker = "usage_rollup_buckets_v3"
-	rollupMarkerPending       = "pending"
-	rollupMarkerDone          = "done"
+	usageRollupBackfillMarker      = "usage_rollup_buckets_v4"
+	quotaMinuteCoverageStartMarker = "quota_minute_utc_coverage_start"
+	rollupMarkerPending            = "pending"
+	rollupMarkerDone               = "done"
 )
 
 type rollupEvent struct {
@@ -256,6 +258,7 @@ func runUsageRollupBackfillAtInitDB(db *sql.DB, loc *time.Location, finalMarker 
 		       input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens,
 		       cost, timestamp, COALESCE(api_key,'')
 		FROM request_logs
+		ORDER BY timestamp ASC, id ASC
 	`)
 	if err != nil {
 		// Do not mark done on read failure — next startup must retry.
@@ -336,7 +339,16 @@ func runUsageRollupBackfillAtInitDB(db *sql.DB, loc *time.Location, finalMarker 
 			return err
 		}
 	}
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	nowTime := time.Now().UTC()
+	now := nowTime.Format(time.RFC3339Nano)
+	if _, err = tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO NOTHING
+	`, quotaMinuteCoverageStartMarker, nowTime.Truncate(time.Minute).Format(time.RFC3339), now); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("usage: quota minute coverage marker: %w", err)
+	}
 	if _, err = tx.Exec(`
 		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
 		VALUES (?, ?, ?)
@@ -359,10 +371,11 @@ func rollupBucketStarts(at time.Time, loc *time.Location) map[string]string {
 	}
 	local := at.In(loc)
 	return map[string]string{
-		rollupBucketMinute:   local.Format("2006-01-02T15:04"),
-		rollupBucketHour:     local.Format("2006-01-02T15"),
-		rollupBucketDay:      local.Format("2006-01-02"),
-		rollupBucketLifetime: rollupLifetimeStart,
+		rollupBucketMinute:         local.Format("2006-01-02T15:04"),
+		rollupBucketQuotaMinuteUTC: at.UTC().Format("2006-01-02T15:04"),
+		rollupBucketHour:           local.Format("2006-01-02T15"),
+		rollupBucketDay:            local.Format("2006-01-02"),
+		rollupBucketLifetime:       rollupLifetimeStart,
 	}
 }
 
@@ -449,8 +462,17 @@ func projectUsageRollupTx(tx *sql.Tx, ev rollupEvent) error {
 			updated_at = excluded.updated_at
 	`
 
+	coverageStart := ev.At.UTC().Truncate(time.Minute).Format(time.RFC3339)
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO NOTHING
+	`, quotaMinuteCoverageStartMarker, coverageStart, now); err != nil {
+		return fmt.Errorf("usage: record quota minute coverage start: %w", err)
+	}
+
 	// Fixed order avoids Postgres deadlocks when concurrent writers UPSERT the same key.
-	for _, kind := range []string{rollupBucketMinute, rollupBucketHour, rollupBucketDay, rollupBucketLifetime} {
+	for _, kind := range []string{rollupBucketMinute, rollupBucketQuotaMinuteUTC, rollupBucketHour, rollupBucketDay, rollupBucketLifetime} {
 		start := starts[kind]
 		if _, err := tx.Exec(upsertSQL,
 			ev.TenantID, kind, start,
@@ -515,6 +537,7 @@ func cleanupExpiredUsageRollupBuckets(db *sql.DB) (int64, error) {
 		from string
 	}{
 		{rollupBucketMinute, now.Add(-rollupMinuteRetention).Format("2006-01-02T15:04")},
+		{rollupBucketQuotaMinuteUTC, time.Now().UTC().Add(-rollupMinuteRetention).Format("2006-01-02T15:04")},
 		{rollupBucketHour, now.Add(-rollupHourRetention).Format("2006-01-02T15")},
 		{rollupBucketDay, now.Add(-rollupDayRetention).Format("2006-01-02")},
 	}
@@ -531,4 +554,24 @@ func cleanupExpiredUsageRollupBuckets(db *sql.DB) (int64, error) {
 		deleted += n
 	}
 	return deleted, nil
+}
+
+func FiveHourQuotaProjectionReadyAt(now time.Time) bool {
+	db := getReadDB()
+	if db == nil {
+		return false
+	}
+	raw := strings.TrimSpace(projectionMarkerValue(db, quotaMinuteCoverageStartMarker))
+	if raw == "" {
+		return false
+	}
+	started, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return false
+	}
+	return !started.After(now.UTC().Truncate(time.Minute).Add(-5 * time.Hour))
+}
+
+func FiveHourQuotaProjectionReady() bool {
+	return FiveHourQuotaProjectionReadyAt(time.Now())
 }


### PR DESCRIPTION
## Summary

- add SQLite bootstrap and PostgreSQL migrations for 5h/week/month USD limits on end users, API keys, and permission profiles while keeping `daily_spending_limit` as the day source of truth
- add fixed period quota types, legacy day compatibility/conflict validation, owner-scoped and generic API-key write paths, transactional Key<=account validation, and account/profile auto-cap responses with audit integration
- add UTC `quota_minute_utc` projection with 24h retention and 5h coverage warming protection, plus batched account/key period usage queries
- emit separate account/key provider metadata and enforce both scopes in middleware with fail-closed 503 behavior and scope/period headers
- extend reset/history routes, route-table coverage, list DTOs, permission-profile sync behavior, and public additive `quota-scopes`

## Scope

Phase 1 backend only, following plan 072. This PR does not include codeProxy/frontend changes and does not remove legacy quota fields.

## Tests

- `./scripts/ci-pr.sh` (backend structure scan, gofmt check, secret scan, `go vet ./...`, `go test ./...`, golangci-lint v1.64.5, server build)
- `go test -count=1 ./internal/quota ./internal/usage ./internal/enduser ./internal/storage/sqlite/apikey ./internal/management/settings/apikey ./internal/access/config_access ./internal/api/middleware ./internal/api/handlers/management ./internal/api/routes` (642 tests passed)
- `go test ./internal/api/middleware` (29 tests passed after the staticcheck fix)
- `git diff --check`