### PR TITLE
fix: public lookup api_key_name uses key own name

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -199,7 +199,9 @@ func (h *UsageLogsHandler) GetPublicUsageChartData(c *gin.Context) {
 	service := h.serviceForTenant(subject.TenantID)
 	var payload map[string]any
 	var err error
-	if subject.EndUserID != "" {
+	// Portal session has EndUserID without a presented secret → account label.
+	// Secret lookup (even when the key is owned) must keep key-own-name labeling.
+	if subject.EndUserID != "" && strings.TrimSpace(subject.APIKey) == "" {
 		payload, err = service.PublicChartDataForEndUser(subject.EndUserID, req.Days)
 	} else {
 		payload, err = service.PublicChartData(subject.APIKey, req.Days)

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -2149,8 +2149,9 @@ func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	var payload struct {
-		Total int64 `json:"total"`
-		Items []struct {
+		Total      int64  `json:"total"`
+		APIKeyName string `json:"api_key_name"`
+		Items      []struct {
 			APIKey        string `json:"api_key"`
 			APIKeyID      string `json:"api_key_id"`
 			APIKeyMasked  string `json:"api_key_masked"`
@@ -2162,6 +2163,10 @@ func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 	}
 	if payload.Total != 2 || len(payload.Items) != 2 {
 		t.Fatalf("public logs total/items = %d/%d, want 2/2", payload.Total, len(payload.Items))
+	}
+	// Top-level label must be the presented key's own name, never the end-user display name.
+	if payload.APIKeyName != "Automation" {
+		t.Fatalf("api_key_name = %q, want Automation (key own name), not end-user display", payload.APIKeyName)
 	}
 	for _, item := range payload.Items {
 		if item.APIKey != "" || item.APIKeyID != "" {

--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -13,7 +13,8 @@ func (s *Service) PublicChartData(apiKey string, days int) (map[string]any, erro
 		"heatmap_series":     chartData.HeatmapSeries,
 		"model_distribution": chartData.ModelDistribution,
 		"stats":              chartData.Stats,
-		"api_key_name":       s.publicAPIKeyName(apiKey),
+		// Key own name only — never end-user display name.
+		"api_key_name": s.publicAPIKeyName(apiKey),
 	}, nil
 }
 

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -212,8 +212,18 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		filters.APIKeyIDCounts,
 	)
 
-	apiKeyName := s.publicAPIKeyName(input.APIKey)
-	if params.EndUserID != "" {
+	// Top-level api_key_name:
+	// - raw secret lookup (/apikey-usage): always the *presented key's own name*
+	// - portal session (no raw key, EndUserID only): account display name
+	// Never label a secret lookup with end-user display name (e.g. 张军宝).
+	presentedKey := strings.TrimSpace(input.APIKey)
+	apiKeyName := ""
+	if presentedKey != "" {
+		apiKeyName = usage.ResolveAPIKeyOwnName(presentedKey)
+		if apiKeyName == "" {
+			apiKeyName = s.publicAPIKeyName(presentedKey)
+		}
+	} else if params.EndUserID != "" {
 		apiKeyName = usage.DisplayNameForEndUser(params.EndUserID)
 	}
 	for i := range result.Items {
@@ -226,14 +236,12 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		}
 		userName := strings.TrimSpace(result.Items[i].EndUserDisplayName)
 		if userName == "" && params.EndUserID != "" {
-			userName = apiKeyName
+			userName = usage.DisplayNameForEndUser(params.EndUserID)
 		}
 		if userName == "" {
 			userName = keyOwnName
 		}
-		if apiKeyName == "" {
-			apiKeyName = userName
-		}
+		// Do not overwrite top-level apiKeyName with per-row user/key labels.
 		channelName := displayChannelNameForLog(result.Items[i], maps.channelNameMap, maps.authIndexChannelMap, maps.ambiguousAuthIndexChannelMap)
 		result.Items[i].APIKeyMasked = maskPublicAPIKey(result.Items[i].APIKey)
 		result.Items[i].Source = ""
@@ -854,6 +862,11 @@ func normalizeAuthType(value string) string {
 }
 
 func (s *Service) publicAPIKeyName(apiKey string) string {
+	// Prefer any-tenant resolve first: public lookup already authenticated the secret,
+	// and tenant-scoped GetRow can miss when service tenant is empty/stale in tests.
+	if name := usage.ResolveAPIKeyOwnName(apiKey); name != "" {
+		return name
+	}
 	row := apikeysettings.NewService(nil, apikeysettings.WithTenantID(s.tenantID)).GetRow(apiKey)
 	if row == nil {
 		return ""


### PR DESCRIPTION
## Summary
- Root cause: public secret lookup set top-level api_key_name to end-user display name when the key was owned
- Fix: presented secret -> key own name; portal session (EndUserID only) -> account display name
- Same rule for public chart data path

## Test plan
- [x] go test management public usage log cases
- [ ] After deploy: query key on /manage/apikey-usage, header shows key name not account display name