### PR TITLE
fix: free grok week-exhausted thrash + PostUser display_name bind

### DIFF
--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -392,8 +392,10 @@ func (h *Handler) GetUsers(c *gin.Context) {
 func (h *Handler) PostUser(c *gin.Context) {
 	principal, _ := principalFromContext(c)
 	var body struct {
-		Username, DisplayName, Password string
-		RoleIDs                         []string `json:"role_ids"`
+		Username    string   `json:"username"`
+		DisplayName string   `json:"display_name"`
+		Password    string   `json:"password"`
+		RoleIDs     []string `json:"role_ids"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -1,8 +1,10 @@
 package management
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +19,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres/compatdriver"
+	_ "modernc.org/sqlite"
 )
 
 func TestPermissionForManagementRequest(t *testing.T) {
@@ -122,6 +125,46 @@ func TestServiceCredentialCannotAccessTenantGovernance(t *testing.T) {
 	}
 	if reached {
 		t.Fatal("service credential reached tenant governance handler")
+	}
+}
+
+func TestPostUserBindsSnakeCaseDisplayName(t *testing.T) {
+	ctx := context.Background()
+	service := newSQLiteIdentityTestService(t)
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	principal := identity.Principal{
+		Kind:            "user",
+		User:            identity.User{ID: identity.SystemUserID, TenantID: identity.SystemTenantID},
+		EffectiveTenant: identity.Tenant{ID: identity.SystemTenantID},
+		PlatformAdmin:   true,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/v0/management/users", func(c *gin.Context) {
+		c.Set(managementPrincipalKey, principal)
+		h.PostUser(c)
+	})
+
+	body := []byte(`{"username":"snake-case-user","display_name":"Snake Case User","password":"snake-case-password-123","role_ids":[]}`)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v0/management/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var user identity.User
+	if err := json.Unmarshal(rec.Body.Bytes(), &user); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	if user.DisplayName != "Snake Case User" {
+		t.Fatalf("display_name = %q, want %q", user.DisplayName, "Snake Case User")
 	}
 }
 
@@ -281,6 +324,37 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 	if code, reached := serve(http.MethodDelete, deleteToken); code != http.StatusOK || !reached {
 		t.Fatalf("delete-capable DELETE: status=%d reached=%v, want 200 and handler executed", code, reached)
 	}
+}
+
+func newSQLiteIdentityTestService(t *testing.T) *identity.Service {
+	t.Helper()
+	dsn := fmt.Sprintf("file:identity_post_user_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(4)
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("close sqlite identity db: %v", closeErr)
+		}
+	})
+	for _, statement := range []string{
+		`CREATE TABLE users (
+			id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, username TEXT NOT NULL, username_normalized TEXT NOT NULL,
+			display_name TEXT NOT NULL, password_hash TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+			must_change_password BOOLEAN NOT NULL DEFAULT false, last_login_at TIMESTAMP NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			version INTEGER NOT NULL DEFAULT 1, created_by TEXT
+		)`,
+		`CREATE TABLE roles (id TEXT PRIMARY KEY, code TEXT NOT NULL, name TEXT NOT NULL)`,
+		`CREATE TABLE user_roles (user_id TEXT NOT NULL, role_id TEXT NOT NULL, created_by TEXT)`,
+	} {
+		if _, err = db.Exec(statement); err != nil {
+			t.Fatalf("create sqlite identity schema: %v", err)
+		}
+	}
+	return identity.NewService(db)
 }
 
 func replacePostgresDatabaseForTest(dsn, dbName string) (string, error) {

--- a/internal/auth/xai/quota.go
+++ b/internal/auth/xai/quota.go
@@ -1,0 +1,112 @@
+package xai
+
+import (
+	"math"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	// BillingWeeklyPath is the Grok Build weekly included-usage endpoint.
+	BillingWeeklyPath = "/billing?format=credits"
+	// CLIWeeklyBillingURL is the production Grok Build weekly included-usage URL.
+	CLIWeeklyBillingURL = CLIChatProxyBaseURL + BillingWeeklyPath
+)
+
+// WeeklyBilling describes the quota fields shared by runtime recovery probes and
+// the management account-status view.
+type WeeklyBilling struct {
+	RemainingPercent float64
+	ResetAt          time.Time
+	Products         []WeeklyProductBilling
+}
+
+// WeeklyProductBilling describes one product-specific weekly usage entry.
+type WeeklyProductBilling struct {
+	Name             string
+	RemainingPercent float64
+}
+
+// ParseWeeklyBilling parses the Grok Build billing response's weekly usage data.
+func ParseWeeklyBilling(body []byte) (WeeklyBilling, bool) {
+	cfg := gjson.GetBytes(body, "config")
+	if !cfg.Exists() {
+		return WeeklyBilling{}, false
+	}
+	current := firstBillingResult(cfg, "currentPeriod", "current_period")
+	periodType := strings.ToLower(strings.TrimSpace(current.Get("type").String()))
+	used := firstBillingResult(cfg, "creditUsagePercent", "credit_usage_percent")
+	products := firstBillingResult(cfg, "productUsage", "product_usage")
+	if !used.Exists() && !strings.Contains(periodType, "weekly") && !products.IsArray() {
+		return WeeklyBilling{}, false
+	}
+
+	weekly := WeeklyBilling{RemainingPercent: 100}
+	if used.Exists() {
+		weekly.RemainingPercent = math.Round(100 - clampBillingPercent(used.Float()))
+	}
+	reset := firstBillingResult(current, "end")
+	if !reset.Exists() {
+		reset = firstBillingResult(cfg, "billingPeriodEnd", "billing_period_end")
+	}
+	weekly.ResetAt = parseBillingTime(reset)
+
+	if products.IsArray() {
+		weekly.Products = make([]WeeklyProductBilling, 0)
+		products.ForEach(func(_, product gjson.Result) bool {
+			item := WeeklyProductBilling{
+				Name:             strings.TrimSpace(product.Get("product").String()),
+				RemainingPercent: 100,
+			}
+			if productUsed := firstBillingResult(product, "usagePercent", "usage_percent"); productUsed.Exists() {
+				item.RemainingPercent = math.Round(100 - clampBillingPercent(productUsed.Float()))
+			}
+			weekly.Products = append(weekly.Products, item)
+			return true
+		})
+	}
+	return weekly, true
+}
+
+func firstBillingResult(root gjson.Result, paths ...string) gjson.Result {
+	for _, path := range paths {
+		if value := root.Get(path); value.Exists() {
+			return value
+		}
+	}
+	return gjson.Result{}
+}
+
+func parseBillingTime(value gjson.Result) time.Time {
+	if !value.Exists() {
+		return time.Time{}
+	}
+	raw := strings.TrimSpace(value.String())
+	if raw != "" {
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if parsed, err := time.Parse(layout, raw); err == nil {
+				return parsed.UTC()
+			}
+		}
+	}
+	seconds := value.Float()
+	if seconds <= 0 {
+		return time.Time{}
+	}
+	if seconds > 1e12 {
+		seconds /= 1000
+	}
+	return time.Unix(int64(seconds), int64((seconds-float64(int64(seconds)))*float64(time.Second))).UTC()
+}
+
+func clampBillingPercent(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}

--- a/internal/management/aiaccountstatus/probe_xai.go
+++ b/internal/management/aiaccountstatus/probe_xai.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
+	"time"
 
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -13,7 +14,7 @@ import (
 )
 
 const (
-	xaiBillingWeeklyURL  = "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+	xaiBillingWeeklyURL  = xaiauth.CLIWeeklyBillingURL
 	xaiBillingMonthlyURL = "https://cli-chat-proxy.grok.com/v1/billing"
 )
 
@@ -107,49 +108,30 @@ func parseXAIBilling(body []byte, key, _ string, _ int64) []usage.QuotaWindowDTO
 }
 
 func parseXAIWeeklyBilling(body []byte) []usage.QuotaWindowDTO {
-	cfg := gjson.GetBytes(body, "config")
-	if !cfg.Exists() {
+	weekly, ok := xaiauth.ParseWeeklyBilling(body)
+	if !ok {
 		return nil
 	}
-	current := firstJSONResult(cfg, "currentPeriod", "current_period")
-	periodType := strings.ToLower(strings.TrimSpace(current.Get("type").String()))
-	used := firstJSONResult(cfg, "creditUsagePercent", "credit_usage_percent")
-	products := firstJSONResult(cfg, "productUsage", "product_usage")
-	if !used.Exists() && !strings.Contains(periodType, "weekly") && !products.IsArray() {
-		return nil
-	}
-
-	remaining := 100.0
-	if used.Exists() {
-		remaining = math.Round(100 - clampPct(used.Float()))
-	}
-	reset := firstJSONResult(current, "end")
-	if !reset.Exists() {
-		reset = firstJSONResult(cfg, "billingPeriodEnd", "billing_period_end")
+	var resetAt *time.Time
+	if !weekly.ResetAt.IsZero() {
+		reset := weekly.ResetAt
+		resetAt = &reset
 	}
 	// Weekly cards already show relative reset from ResetAt; keep Meta empty so the
 	// UI is not flooded with raw ISO period strings like "2026-07-16T06:45:51+00:00 - …".
 	out := []usage.QuotaWindowDTO{{
-		QuotaKey: "weekly_limit", QuotaLabel: "xai_quota.weekly_limit", Percent: &remaining,
-		Value: formatPercent(remaining), ResetAt: parseFlexibleTime(reset), WindowSeconds: 604800,
+		QuotaKey: "weekly_limit", QuotaLabel: "xai_quota.weekly_limit", Percent: &weekly.RemainingPercent,
+		Value: formatPercent(weekly.RemainingPercent), ResetAt: resetAt, WindowSeconds: 604800,
 	}}
-	if products.IsArray() {
-		index := 0
-		products.ForEach(func(_, product gjson.Result) bool {
-			index++
-			name := strings.TrimSpace(product.Get("product").String())
-			if name == "" {
-				name = fmt.Sprintf("Product %d", index)
-			}
-			productRemaining := 100.0
-			if productUsed := firstJSONResult(product, "usagePercent", "usage_percent"); productUsed.Exists() {
-				productRemaining = math.Round(100 - clampPct(productUsed.Float()))
-			}
-			out = append(out, usage.QuotaWindowDTO{
-				QuotaKey: "product:" + name, QuotaLabel: "xai_quota.product_usage_named::" + name,
-				Percent: &productRemaining, Value: formatPercent(productRemaining),
-			})
-			return true
+	for index, product := range weekly.Products {
+		name := product.Name
+		if name == "" {
+			name = fmt.Sprintf("Product %d", index+1)
+		}
+		remaining := product.RemainingPercent
+		out = append(out, usage.QuotaWindowDTO{
+			QuotaKey: "product:" + name, QuotaLabel: "xai_quota.product_usage_named::" + name,
+			Percent: &remaining, Value: formatPercent(remaining),
 		})
 	}
 	return out

--- a/internal/runtime/executor/xai_quota_recovery.go
+++ b/internal/runtime/executor/xai_quota_recovery.go
@@ -1,0 +1,107 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// ProbeQuotaRecovery checks Grok Build's weekly billing view without consuming a
+// user inference request.
+func (e *XAIExecutor) ProbeQuotaRecovery(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.QuotaProbeResult, error) {
+	if auth == nil {
+		return nil, fmt.Errorf("xai executor: auth is nil")
+	}
+	if xaiUsingAPI(auth) {
+		return nil, fmt.Errorf("xai executor: quota recovery probe requires Grok Build OAuth")
+	}
+	token, _ := xaiCreds(auth)
+	if token == "" {
+		return nil, fmt.Errorf("xai executor: missing access token")
+	}
+
+	endpoint := strings.TrimRight(xaiChatBaseURL(auth), "/") + xaiauth.BillingWeeklyPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	applyXAIChatHeaders(req, e.cfg, auth, token, false)
+	if userID := xaiQuotaProbeUserID(auth); userID != "" {
+		req.Header.Set("X-UserID", userID)
+	}
+
+	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("xai executor: close quota probe body error: %v", errClose)
+		}
+	}()
+
+	body, err := readUpstreamResponseBody(e.Identifier(), resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, newXAIStatusErr(resp.StatusCode, body, resp.Header)
+	}
+	result := parseXAIQuotaProbe(body, time.Now())
+	if result == nil {
+		return nil, fmt.Errorf("xai executor: invalid weekly billing response")
+	}
+	return result, nil
+}
+
+func parseXAIQuotaProbe(body []byte, now time.Time) *cliproxyauth.QuotaProbeResult {
+	weekly, ok := xaiauth.ParseWeeklyBilling(body)
+	if !ok {
+		return nil
+	}
+	if weekly.RemainingPercent > 0 {
+		return &cliproxyauth.QuotaProbeResult{Recovered: true}
+	}
+	result := &cliproxyauth.QuotaProbeResult{Recovered: false}
+	if weekly.ResetAt.After(now) {
+		result.NextRecoverAt = weekly.ResetAt
+	}
+	return result
+}
+
+func xaiQuotaProbeUserID(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	for _, key := range []string{"sub", "subject", "user_id", "userId", "x_userid"} {
+		if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+			return value
+		}
+		if value := xaiMetadataString(auth.Metadata, key); value != "" {
+			return value
+		}
+	}
+	for _, parent := range []string{"oauth", "user"} {
+		raw, ok := auth.Metadata[parent]
+		if !ok {
+			continue
+		}
+		nested, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"sub", "subject", "id", "user_id", "userId"} {
+			if value := xaiMetadataString(nested, key); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}

--- a/internal/runtime/executor/xai_quota_recovery_test.go
+++ b/internal/runtime/executor/xai_quota_recovery_test.go
@@ -1,0 +1,107 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestXAIExecutorProbeQuotaRecovery(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Now().Add(2 * time.Hour).UTC().Round(time.Second)
+	tests := []struct {
+		name            string
+		usedPercent     int
+		wantRecovered   bool
+		wantNextRecover bool
+	}{
+		{name: "recovered", usedPercent: 40, wantRecovered: true},
+		{name: "not recovered", usedPercent: 100, wantRecovered: false, wantNextRecover: true},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				if r.Method != http.MethodGet {
+					t.Fatalf("method = %s, want GET", r.Method)
+				}
+				if r.URL.String() != "https://cli-chat-proxy.grok.com/v1/billing?format=credits" {
+					t.Fatalf("url = %s, want Grok weekly billing endpoint", r.URL.String())
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer xai-token" {
+					t.Fatalf("Authorization = %q", got)
+				}
+				if got := r.Header.Get(xaiTokenAuthHeader); got != xaiTokenAuthValue {
+					t.Fatalf("%s = %q", xaiTokenAuthHeader, got)
+				}
+				if got := r.Header.Get("X-UserID"); got != "xai-user" {
+					t.Fatalf("X-UserID = %q, want xai-user", got)
+				}
+				body := fmt.Sprintf(`{"config":{"currentPeriod":{"type":"WEEKLY","end":%q},"creditUsagePercent":%d}}`, resetAt.Format(time.RFC3339), test.usedPercent)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Request:    r,
+				}, nil
+			}))
+
+			auth := &cliproxyauth.Auth{
+				ID:       "xai-auth",
+				Provider: "xai",
+				Status:   cliproxyauth.StatusActive,
+				Attributes: map[string]string{
+					"api_key":   "xai-token",
+					"using_api": "false",
+					"sub":       "xai-user",
+				},
+			}
+
+			result, err := NewXAIExecutor(nil).ProbeQuotaRecovery(ctx, auth)
+			if err != nil {
+				t.Fatalf("ProbeQuotaRecovery() error = %v", err)
+			}
+			if result == nil {
+				t.Fatal("ProbeQuotaRecovery() result = nil")
+			}
+			if result.Recovered != test.wantRecovered {
+				t.Fatalf("Recovered = %v, want %v", result.Recovered, test.wantRecovered)
+			}
+			if test.wantNextRecover {
+				if !result.NextRecoverAt.Equal(resetAt) {
+					t.Fatalf("NextRecoverAt = %v, want %v", result.NextRecoverAt, resetAt)
+				}
+			} else if !result.NextRecoverAt.IsZero() {
+				t.Fatalf("NextRecoverAt = %v, want zero", result.NextRecoverAt)
+			}
+		})
+	}
+}
+
+func TestParseXAIQuotaProbeExhaustedWithoutResetStaysBlocked(t *testing.T) {
+	t.Parallel()
+
+	result := parseXAIQuotaProbe([]byte(`{"config":{"currentPeriod":{"type":"WEEKLY"},"creditUsagePercent":100}}`), time.Now())
+	if result == nil {
+		t.Fatal("parseXAIQuotaProbe() result = nil")
+	}
+	if result.Recovered {
+		t.Fatal("Recovered = true, want false")
+	}
+	if !result.NextRecoverAt.IsZero() {
+		t.Fatalf("NextRecoverAt = %v, want zero without upstream reset", result.NextRecoverAt)
+	}
+}
+
+var _ cliproxyauth.QuotaRecoveryProber = (*XAIExecutor)(nil)

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -285,18 +285,13 @@ func applyModelQuotaFailureLocked(auth *Auth, state *ModelState, result Result, 
 	if state == nil {
 		return
 	}
-	var next time.Time
 	backoffLevel := state.Quota.BackoffLevel
-	if result.RetryAfter != nil {
-		next = now.Add(*result.RetryAfter)
-	} else {
-		// WindowMinutes is window length metadata (e.g. week=10080), not remaining cooldown.
-		cooldown, nextLevel := nextQuotaCooldown(backoffLevel, quotaCooldownDisabledForAuth(auth))
-		if cooldown > 0 {
-			next = now.Add(cooldown)
-		}
-		backoffLevel = nextLevel
+	cooldown, nextLevel := quotaFailureCooldown(result.Error, result.RetryAfter, backoffLevel, quotaCooldownDisabledForAuth(auth))
+	var next time.Time
+	if cooldown > 0 {
+		next = now.Add(cooldown)
 	}
+	backoffLevel = nextLevel
 	var window string
 	var windowMinutes int
 	if result.Error != nil {

--- a/sdk/cliproxy/auth/conductor_failure_state.go
+++ b/sdk/cliproxy/auth/conductor_failure_state.go
@@ -1,6 +1,11 @@
 package auth
 
-import "time"
+import (
+	"strings"
+	"time"
+)
+
+const xaiWeekExhaustedDefaultCooldown = 6 * time.Hour
 
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
 	if auth == nil {
@@ -63,19 +68,34 @@ func applyAuthQuotaFailureState(auth *Auth, resultErr *Error, retryAfter *time.D
 		auth.Quota.Window = resultErr.QuotaWindow
 		auth.Quota.WindowMinutes = resultErr.QuotaWindowMinutes
 	}
+	cooldown, nextLevel := quotaFailureCooldown(resultErr, retryAfter, auth.Quota.BackoffLevel, quotaCooldownDisabledForAuth(auth))
 	var next time.Time
-	if retryAfter != nil {
-		next = now.Add(*retryAfter)
-	} else {
-		// WindowMinutes is window length metadata (e.g. week=10080), not remaining cooldown.
-		cooldown, nextLevel := nextQuotaCooldown(auth.Quota.BackoffLevel, quotaCooldownDisabledForAuth(auth))
-		if cooldown > 0 {
-			next = now.Add(cooldown)
-		}
-		auth.Quota.BackoffLevel = nextLevel
+	if cooldown > 0 {
+		next = now.Add(cooldown)
 	}
+	auth.Quota.BackoffLevel = nextLevel
 	auth.Quota.NextRecoverAt = next
 	auth.NextRetryAfter = next
+}
+
+func quotaFailureCooldown(resultErr *Error, retryAfter *time.Duration, prevLevel int, disableCooling bool) (time.Duration, int) {
+	if retryAfter != nil {
+		return *retryAfter, prevLevel
+	}
+	if disableCooling {
+		return 0, prevLevel
+	}
+	if isXAIWeekBalanceExhaustedError(resultErr) {
+		return xaiWeekExhaustedDefaultCooldown, prevLevel
+	}
+	return nextQuotaCooldown(prevLevel, false)
+}
+
+func isXAIWeekBalanceExhaustedError(resultErr *Error) bool {
+	if resultErr == nil || !isUsageBalanceExhaustedMessage(resultErr.Message) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(resultErr.QuotaWindow), "week") || resultErr.QuotaWindowMinutes == 10080
 }
 
 // nextQuotaCooldown returns the next cooldown duration and updated backoff level for repeated quota errors.

--- a/sdk/cliproxy/auth/xai_402_quota_test.go
+++ b/sdk/cliproxy/auth/xai_402_quota_test.go
@@ -33,11 +33,15 @@ func (e *retryAfterQuotaErrorStub) RetryAfter() *time.Duration {
 }
 
 type xaiQuotaExecutor struct {
-	err error
+	err     error
+	execute func(*Auth) (cliproxyexecutor.Response, error)
 }
 
 func (e *xaiQuotaExecutor) Identifier() string { return "xai" }
-func (e *xaiQuotaExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+func (e *xaiQuotaExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.execute != nil {
+		return e.execute(auth)
+	}
 	return cliproxyexecutor.Response{}, e.err
 }
 func (e *xaiQuotaExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
@@ -49,6 +53,9 @@ func (e *xaiQuotaExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.
 }
 func (e *xaiQuotaExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
 	return nil, e.err
+}
+func (e *xaiQuotaExecutor) ProbeQuotaRecovery(context.Context, *Auth) (*QuotaProbeResult, error) {
+	return &QuotaProbeResult{Recovered: false}, nil
 }
 
 func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testing.T) {
@@ -112,7 +119,7 @@ func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testi
 	}
 }
 
-func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryDoesNotUseWeekLength(t *testing.T) {
+func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesDefaultCooldown(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -158,12 +165,79 @@ func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryDoesNotUseWeekLengt
 	if !state.Quota.Exceeded || state.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", state.Quota)
 	}
-	// Must not treat WindowMinutes(10080) as remaining cooldown (~7d).
-	if state.NextRetryAfter.After(before.Add(time.Hour)) {
-		t.Fatalf("NextRetryAfter = %v, want short probe backoff not week length", state.NextRetryAfter)
+	minExpected := before.Add(xaiWeekExhaustedDefaultCooldown - time.Minute)
+	maxExpected := before.Add(xaiWeekExhaustedDefaultCooldown + time.Minute)
+	if state.NextRetryAfter.Before(minExpected) || state.NextRetryAfter.After(maxExpected) {
+		t.Fatalf("NextRetryAfter = %v, want ~%v", state.NextRetryAfter, before.Add(xaiWeekExhaustedDefaultCooldown))
 	}
-	if state.NextRetryAfter.Before(before) {
-		t.Fatalf("NextRetryAfter = %v, want after now", state.NextRetryAfter)
+	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
+		t.Fatalf("NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
+	}
+	if !got.Quota.Exceeded || got.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("aggregated auth quota = %#v, want exceeded with recovery time", got.Quota)
+	}
+}
+
+func TestManagerExecute_XAIWeekExhaustedSkipsAuthForHealthyPeer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "grok-4.5"
+	calls := map[string]int{}
+	exhaustedErr := &retryAfterQuotaErrorStub{
+		message:      `{"error":"Grok Build usage balance exhausted"}`,
+		status:       http.StatusPaymentRequired,
+		quotaWindow:  "week",
+		quotaMinutes: 10080,
+	}
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		execute: func(auth *Auth) (cliproxyexecutor.Response, error) {
+			calls[auth.ID]++
+			if auth.ID == "xai-exhausted" {
+				return cliproxyexecutor.Response{}, exhaustedErr
+			}
+			return cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+		},
+	})
+	for _, auth := range []*Auth{
+		{ID: "xai-exhausted", Provider: "xai", Status: StatusActive, Attributes: map[string]string{"priority": "10"}},
+		{ID: "xai-healthy", Provider: "xai", Status: StatusActive, Attributes: map[string]string{"priority": "1"}},
+	} {
+		if _, err := manager.Register(ctx, auth); err != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, err)
+		}
+	}
+
+	request := cliproxyexecutor.Request{Model: model}
+	if _, err := manager.Execute(ctx, []string{"xai"}, request, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("first Execute() error = %v", err)
+	}
+	if calls["xai-exhausted"] != 1 || calls["xai-healthy"] != 1 {
+		t.Fatalf("first call counts = %#v, want exhausted=1 healthy=1", calls)
+	}
+
+	if _, err := manager.Execute(ctx, []string{"xai"}, request, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("second Execute() error = %v", err)
+	}
+	if calls["xai-exhausted"] != 1 || calls["xai-healthy"] != 2 {
+		t.Fatalf("second call counts = %#v, want exhausted still 1 and healthy=2", calls)
+	}
+
+	exhausted, ok := manager.GetByID("xai-exhausted")
+	if !ok || exhausted == nil {
+		t.Fatal("exhausted auth missing")
+	}
+	now := time.Now()
+	if !exhausted.Quota.Exceeded || !exhausted.Quota.NextRecoverAt.After(now.Add(time.Hour)) {
+		t.Fatalf("exhausted quota = %#v, want active long cooldown", exhausted.Quota)
+	}
+	if !manager.shouldProbeQuota(exhausted, now) {
+		t.Fatal("shouldProbeQuota() = false, want xAI cooldown eligible for recovery probe")
+	}
+	nextProbe := nextQuotaProbeTime(exhausted, now)
+	if !nextProbe.After(now) || !nextProbe.Before(exhausted.Quota.NextRecoverAt) {
+		t.Fatalf("nextQuotaProbeTime() = %v, want before cooldown recovery %v", nextProbe, exhausted.Quota.NextRecoverAt)
 	}
 }
 
@@ -240,7 +314,7 @@ func TestApplyAuthFailureState_XAI402BalanceExhausted(t *testing.T) {
 	}
 }
 
-func TestApplyAuthFailureState_XAI402WithoutRetryDoesNotUseWindowMinutes(t *testing.T) {
+func TestApplyAuthFailureState_XAI402WithoutRetryUsesDefaultCooldown(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
@@ -255,7 +329,10 @@ func TestApplyAuthFailureState_XAI402WithoutRetryDoesNotUseWindowMinutes(t *test
 	if !auth.Quota.Exceeded || auth.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", auth.Quota)
 	}
-	if auth.NextRetryAfter.Sub(now) >= time.Hour {
-		t.Fatalf("NextRetryAfter = %v, want short probe backoff not WindowMinutes", auth.NextRetryAfter)
+	if !auth.NextRetryAfter.Equal(now.Add(xaiWeekExhaustedDefaultCooldown)) {
+		t.Fatalf("NextRetryAfter = %v, want %v", auth.NextRetryAfter, now.Add(xaiWeekExhaustedDefaultCooldown))
+	}
+	if !auth.Quota.NextRecoverAt.Equal(auth.NextRetryAfter) {
+		t.Fatalf("NextRecoverAt = %v, want %v", auth.Quota.NextRecoverAt, auth.NextRetryAfter)
 	}
 }


### PR DESCRIPTION
## Summary
- Fix admin backend user create: `PostUser` now binds snake_case `display_name` (was always empty → 400 validation_failed).
- Fix free Grok thrash: week balance exhausted without reset uses 6h production cooldown; `XAIExecutor` implements `ProbeQuotaRecovery` via weekly billing so user traffic is no longer the probe.

## Plan
Root-governance plan: `docs/plan/074-free-grok-quota-admin-user-create-20260722.md` (CliProxy root).

## Commits
- `4cea889b` fix(identity): bind display_name on PostUser
- `a908b026` fix(auth): stop free grok week-exhausted thrash

## Test plan
- [x] `go test ./sdk/cliproxy/auth ./internal/runtime/executor ./internal/api/handlers/management -count=1`
- [x] `go test ./internal/identity ./internal/api/... ./sdk/cliproxy/auth ./internal/runtime/executor -count=1`
- [x] `./scripts/ci-pr.sh` (full local CI green)

## Notes
- No frontend changes required for PostUser.
- Runtime quota persistence across restarts intentionally out of scope.