### PR TITLE
fix(usage): keep raw-secret public lookup key-scoped

### DIFF
--- a/internal/api/handlers/management/public_usage_subject.go
+++ b/internal/api/handlers/management/public_usage_subject.go
@@ -45,11 +45,12 @@ func (h *Handler) resolvePublicUsageSubject(c *gin.Context, apiKey string) (publ
 		return publicUsageSubject{}, false
 	}
 
+	// Raw secret lookup is key-scoped only. Do not promote to account-wide via
+	// end_user_id; portal cpt_ sessions above already use EndUserID without a secret.
 	subject := publicUsageSubject{APIKey: apiKey}
 	if row := usage.GetAPIKey(apiKey); row != nil {
 		subject.APIKeyRow = row
 		subject.TenantID = strings.TrimSpace(row.TenantID)
-		subject.EndUserID = strings.TrimSpace(row.EndUserID)
 	} else {
 		subject.TenantID = usage.ResolveAPIKeyTenant(apiKey)
 	}

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -2109,7 +2109,7 @@ func TestGetUsageLogsFiltersByOrphanAuthIndexWithoutLiveMeta(t *testing.T) {
 	}
 }
 
-func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
+func TestGetPublicUsageLogs_RawSecretIsKeyScoped(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tmpDir := t.TempDir()
@@ -2161,23 +2161,22 @@ func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if payload.Total != 2 || len(payload.Items) != 2 {
-		t.Fatalf("public logs total/items = %d/%d, want 2/2", payload.Total, len(payload.Items))
+	// Raw secret lookup must stay key-scoped; sibling keys on the same account stay hidden.
+	if payload.Total != 1 || len(payload.Items) != 1 {
+		t.Fatalf("public logs total/items = %d/%d, want 1/1; body=%s", payload.Total, len(payload.Items), rec.Body.String())
 	}
-	// Top-level label must be the presented key's own name, never the end-user display name.
 	if payload.APIKeyName != "Automation" {
-		t.Fatalf("api_key_name = %q, want Automation (key own name), not end-user display", payload.APIKeyName)
+		t.Fatalf("api_key_name = %q, want Automation (presented key own name)", payload.APIKeyName)
 	}
-	for _, item := range payload.Items {
-		if item.APIKey != "" || item.APIKeyID != "" {
-			t.Fatalf("public item leaked raw key identity: %+v", item)
-		}
-		if item.APIKeyMasked == "" {
-			t.Fatalf("public item missing masked key fallback: %+v", item)
-		}
-		if item.APIKeyOwnName != "Laptop" && item.APIKeyOwnName != "Automation" {
-			t.Fatalf("api_key_own_name = %q, want concrete key name", item.APIKeyOwnName)
-		}
+	item := payload.Items[0]
+	if item.APIKey != "" || item.APIKeyID != "" {
+		t.Fatalf("public item leaked raw key identity: %+v", item)
+	}
+	if item.APIKeyMasked == "" {
+		t.Fatalf("public item missing masked key fallback: %+v", item)
+	}
+	if item.APIKeyOwnName != "Automation" {
+		t.Fatalf("api_key_own_name = %q, want Automation", item.APIKeyOwnName)
 	}
 }
 
@@ -2245,22 +2244,17 @@ func TestGetPublicUsageLogs_FiltersByAPIKeyIDs(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if payload.Total != 1 || len(payload.Items) != 1 {
-		t.Fatalf("filtered total/items = %d/%d, want 1/1; body=%s", payload.Total, len(payload.Items), rec.Body.String())
+	// Sibling key ids are not in the raw-secret allow-list; filter is rejected → empty.
+	if payload.Total != 0 || len(payload.Items) != 0 {
+		t.Fatalf("filtered total/items = %d/%d, want 0/0; body=%s", payload.Total, len(payload.Items), rec.Body.String())
 	}
-	if payload.Items[0].APIKeyOwnName != "Laptop" {
-		t.Fatalf("api_key_own_name = %q, want Laptop", payload.Items[0].APIKeyOwnName)
-	}
-	if len(payload.Filters.APIKeyIDs) != 2 {
-		t.Fatalf("filters.api_key_ids = %#v, want 2 options", payload.Filters.APIKeyIDs)
-	}
-	if payload.Filters.APIKeyIDNames[keyAID] != "Laptop" {
-		t.Fatalf("filters.api_key_id_names[%s] = %q, want Laptop", keyAID, payload.Filters.APIKeyIDNames[keyAID])
+	if len(payload.Filters.APIKeyIDs) != 1 || payload.Filters.APIKeyIDs[0] != keyBID {
+		t.Fatalf("filters.api_key_ids = %#v, want only presented key %s", payload.Filters.APIKeyIDs, keyBID)
 	}
 	if payload.Filters.APIKeyIDNames[keyBID] != "Automation" {
 		t.Fatalf("filters.api_key_id_names[%s] = %q, want Automation", keyBID, payload.Filters.APIKeyIDNames[keyBID])
 	}
-	if payload.Filters.APIKeyIDCounts[keyAID] != 1 || payload.Filters.APIKeyIDCounts[keyBID] != 1 {
-		t.Fatalf("filters.api_key_id_counts = %#v, want one request per owned key", payload.Filters.APIKeyIDCounts)
+	if payload.Filters.APIKeyIDNames[keyAID] != "" {
+		t.Fatalf("sibling key %s must not appear in filter options", keyAID)
 	}
 }

--- a/internal/api/handlers/management/usage_public_test.go
+++ b/internal/api/handlers/management/usage_public_test.go
@@ -184,16 +184,18 @@ func TestGetPublicUsageByAPIKeyAggregatesOwnedCurrentSecrets(t *testing.T) {
 	}
 	enduser.SetDefault(enduser.NewService(usage.RuntimeDB()))
 
+	// Raw secret is key-scoped (key A only), not the sibling pool.
 	owned := getPublicUsageSnapshot(t, h, keyA.Key)
 	if !owned.Found || len(owned.Usage.APIs) != 1 {
 		t.Fatalf("owned response = %#v", owned)
 	}
 	for _, snapshot := range owned.Usage.APIs {
-		if snapshot.TotalRequests != 3 || snapshot.TotalTokens != 30 {
-			t.Fatalf("owned aggregate = %+v, want requests=3 tokens=30", snapshot)
+		if snapshot.TotalRequests != 1 || snapshot.TotalTokens != 10 {
+			t.Fatalf("owned key-scoped = %+v, want requests=1 tokens=10", snapshot)
 		}
 	}
 
+	// Portal cpt_ session remains account-wide across owned keys.
 	portal := getPortalPublicUsageSnapshot(t, h, portalToken)
 	if !portal.Found || len(portal.Usage.APIs) != 1 {
 		t.Fatalf("portal response = %#v", portal)
@@ -216,10 +218,17 @@ func TestGetPublicUsageByAPIKeyAggregatesOwnedCurrentSecrets(t *testing.T) {
 	if err := usage.UpdateAPIKeyByIDForTenant(tenantID, rotated); err != nil {
 		t.Fatalf("UpdateAPIKeyByIDForTenant: %v", err)
 	}
+	// Rotated secret has no in-memory snapshot under the new value; sibling key B stays independent.
 	afterRotate := getPublicUsageSnapshot(t, h, rotated.Key)
 	for _, snapshot := range afterRotate.Usage.APIs {
+		if snapshot.TotalRequests != 0 || snapshot.TotalTokens != 0 {
+			t.Fatalf("post-rotate rotated secret = %+v, want empty key-scoped snapshot", snapshot)
+		}
+	}
+	sibling := getPublicUsageSnapshot(t, h, keyB.Key)
+	for _, snapshot := range sibling.Usage.APIs {
 		if snapshot.TotalRequests != 2 || snapshot.TotalTokens != 20 {
-			t.Fatalf("post-rotate current-secret aggregate = %+v, want surviving current key B only", snapshot)
+			t.Fatalf("sibling key B = %+v, want requests=2 tokens=20", snapshot)
 		}
 	}
 }

--- a/internal/api/handlers/management/usage_summary_public_test.go
+++ b/internal/api/handlers/management/usage_summary_public_test.go
@@ -441,10 +441,12 @@ func TestGetPublicUsageSummary_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if !got.Found || got.Stats.TotalCalls != 2 {
-		t.Fatalf("summary = %+v, want found and two account calls", got)
+	// Raw secret summary is key-scoped for call stats (not whole account).
+	if !got.Found || got.Stats.TotalCalls != 1 {
+		t.Fatalf("summary = %+v, want found and one key call", got)
 	}
-	if len(got.QuotaScopes) != 2 || got.QuotaScopes[0].Scope != "account" || got.QuotaScopes[1].Scope != "key" {
-		t.Fatalf("quota scopes = %+v, want account then key", got.QuotaScopes)
+	// Raw secret no longer promotes to EndUserID, so only key-scope quota cards appear.
+	if len(got.QuotaScopes) != 1 || got.QuotaScopes[0].Scope != "key" {
+		t.Fatalf("quota scopes = %+v, want key only", got.QuotaScopes)
 	}
 }

--- a/internal/usage/enduser_account_usage_test.go
+++ b/internal/usage/enduser_account_usage_test.go
@@ -112,8 +112,8 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 		t.Fatalf("GetAPIKeyByID = %#v, want business-tenant key B", row)
 	}
 	expanded := ExpandPublicLookupAPIKeys("sk-business-a")
-	if len(expanded) != 2 || !containsString(expanded, "sk-business-a") || !containsString(expanded, "sk-business-b") {
-		t.Fatalf("ExpandPublicLookupAPIKeys = %v, want both owned keys", expanded)
+	if len(expanded) != 1 || expanded[0] != "sk-business-a" {
+		t.Fatalf("ExpandPublicLookupAPIKeys = %v, want [sk-business-a] only", expanded)
 	}
 
 	// Modern rows match stable key ids; the legacy row matches the current raw secret.

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -155,33 +155,20 @@ func ListAPIKeySecretsForEndUserForTenant(tenantID, endUserID string) []string {
 	return listAPIKeyValuesForEndUser(tenantID, endUserID, "key")
 }
 
-// ExpandPublicLookupAPIKeys expands a presented API key into the full account key pool
-// when the key is owned by an end user (shared quota / portal multi-key).
-// Standalone keys and unknown secrets stay single-key.
+// ExpandPublicLookupAPIKeys returns the presented API key only.
+// Account-wide multi-key views use portal EndUserID auth, not raw-secret expansion.
 func ExpandPublicLookupAPIKeys(apiKey string) []string {
 	trimmed := strings.TrimSpace(apiKey)
 	if trimmed == "" {
 		return nil
 	}
 	row := GetAPIKey(trimmed)
-	if row == nil {
-		return []string{trimmed}
-	}
-	endUserID := strings.TrimSpace(row.EndUserID)
-	if endUserID == "" {
+	if row != nil {
 		if k := strings.TrimSpace(row.Key); k != "" {
 			return []string{k}
 		}
-		return []string{trimmed}
 	}
-	secrets := ListAPIKeySecretsForEndUserForTenant(row.TenantID, endUserID)
-	if len(secrets) == 0 {
-		if k := strings.TrimSpace(row.Key); k != "" {
-			return []string{k}
-		}
-		return []string{trimmed}
-	}
-	return secrets
+	return []string{trimmed}
 }
 
 // ResolveAPIKeyOwnName returns the key's own name (not end-user account display name).

--- a/internal/usage/enduser_quota_test.go
+++ b/internal/usage/enduser_quota_test.go
@@ -174,15 +174,8 @@ func TestExpandPublicLookupAPIKeys_AggregatesOwnedKeys(t *testing.T) {
 	}
 
 	got := ExpandPublicLookupAPIKeys("sk-a")
-	if len(got) != 2 {
-		t.Fatalf("owned expand len=%d keys=%v, want 2", len(got), got)
-	}
-	set := map[string]bool{}
-	for _, k := range got {
-		set[k] = true
-	}
-	if !set["sk-a"] || !set["sk-b"] {
-		t.Fatalf("owned expand = %v, want sk-a and sk-b", got)
+	if len(got) != 1 || got[0] != "sk-a" {
+		t.Fatalf("owned expand = %v, want [sk-a] only (raw secret is key-scoped)", got)
 	}
 
 	solo := ExpandPublicLookupAPIKeys("sk-solo")

--- a/internal/usage/request_log_account_filter.go
+++ b/internal/usage/request_log_account_filter.go
@@ -260,14 +260,13 @@ func buildSingleAPIKeySelectorClauseForTenant(tenantID, selector string) (string
 		// Secret may resolve outside the tenant pin (legacy global lookup).
 		row = GetAPIKey(trimmed)
 	}
-	// Owned keys: selecting the account filter matches the whole key pool.
+	// Always key-scoped. Account-wide views use EndUserID on LogQueryParams, not secret expansion.
 	if row != nil {
-		if eu := strings.TrimSpace(row.EndUserID); eu != "" {
-			pred, args := buildEndUserAPIKeySelectorPredicate(tenantID, eu)
-			return " WHERE " + pred, args
-		}
 		if id := strings.TrimSpace(row.ID); id != "" {
 			return " WHERE (api_key_id = ? OR (api_key_id = '' AND api_key = ?))", []interface{}{id, strings.TrimSpace(row.Key)}
+		}
+		if k := strings.TrimSpace(row.Key); k != "" {
+			return " WHERE api_key = ?", []interface{}{k}
 		}
 	}
 	return " WHERE api_key = ?", []interface{}{trimmed}

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1954,12 +1954,20 @@ func TestQueryFiltersCollapsesOwnedKeysToOneAccountOption(t *testing.T) {
 		}
 	}
 
+	// Selecting a concrete secret is key-scoped; account-wide needs EndUserID.
 	logs, err := QueryLogs(LogQueryParams{Page: 1, Size: 50, Days: 7, APIKeys: []string{"sk-kittors-default"}})
 	if err != nil {
-		t.Fatalf("QueryLogs(account filter) error = %v", err)
+		t.Fatalf("QueryLogs(key filter) error = %v", err)
 	}
-	if logs.Total != 2 {
-		t.Fatalf("QueryLogs total = %d, want 2 (both owned keys)", logs.Total)
+	if logs.Total != 1 {
+		t.Fatalf("QueryLogs total = %d, want 1 (presented key only)", logs.Total)
+	}
+	accountLogs, err := QueryLogs(LogQueryParams{Page: 1, Size: 50, Days: 7, EndUserID: endUserID})
+	if err != nil {
+		t.Fatalf("QueryLogs(end user) error = %v", err)
+	}
+	if accountLogs.Total != 2 {
+		t.Fatalf("QueryLogs(end user) total = %d, want 2 (both owned keys)", accountLogs.Total)
 	}
 
 	dist, err := QueryAPIKeyDistribution(7)


### PR DESCRIPTION
## Summary
- raw API key 查询仅返回该 key 日志，不再扩展到同 end-user 下全部 key
- portal `cpt_` 会话仍按 EndUserID 看账号全量
- 同步修正相关单测

## Root cause
`buildSingleAPIKeySelectorClauseForTenant` / `ExpandPublicLookupAPIKeys` 把 owned key 提升为账号范围。

## Test
- [x] `go test ./internal/usage/ -run ExpandPublicLookup|EndUserAccount`
- [x] `go test ./internal/api/handlers/management/ -run PublicUsageLogs_RawSecret|PublicUsageLogs_FiltersByAPIKeyIDs|PublicUsageSummary_Aggregates`
- [ ] GHA build