### PR TITLE
fix(usage): stop stale shared cycle backfills

### DIFF
--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -128,7 +128,7 @@ func (s *Service) StartRefresh(tenantID string, req RefreshRequest) RefreshAccep
 	// Refresh boundary: allow stale cleanup without waiting for GET throttle alone.
 	s.maybeNormalizeStaleRefresh(tenantID)
 	auths := s.listAuths(tenantID)
-	// Best-effort: still start refresh even if some legacy bindings fail to reconcile.
+	// Best-effort: still start refresh even if some binding repairs fail.
 	_ = reconcileTenantBindings(auths)
 	byIndex := make(map[string]*coreauth.Auth, len(auths))
 	bySubject := make(map[string]*coreauth.Auth, len(auths))
@@ -552,7 +552,28 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		}
 	}
 
-	// Latest-status persistence is the trust boundary: write failure must not be reported as success.
+	// Persist the shared runtime truth before the legacy tenant mirror. Shared
+	// status/version must not depend on a legacy reload succeeding.
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID: subjectID, Provider: auth.Provider, LastProbeState: string(RefreshSuccess),
+		HealthStatus: healthStatus, PlanType: strings.TrimSpace(probe.PlanType),
+		SubscriptionStartedAt: probe.SubscriptionStartedAt, SubscriptionExpiresAt: probe.SubscriptionExpiresAt,
+		SubscriptionSource: probe.SubscriptionSource, RestrictionSummary: record.RestrictionSummary, Quotas: probe.Quotas,
+		ResetCreditCount: probe.ResetCreditCount, ResetCreditExpirations: probe.ResetCreditExpirations,
+		UpstreamCheckedAt: &checked, UpdatedAt: checked,
+	}); err != nil {
+		_ = usage.UpdateAIAccountRefreshFailure(tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status), "persist_failed", err.Error(), checked)
+		s.setResult(jobID, subjectID, func(r *AccountRefreshResult) {
+			r.State = RefreshError
+			r.ErrorCode = "persist_failed"
+			r.ErrorMessage = sanitizeMsg(err.Error())
+			r.UpdatedAt = checked
+			r.Result = nil
+		})
+		return
+	}
+
+	// Keep the legacy tenant mirror for compatibility while shared remains authoritative.
 	upsert := s.upsertStatus
 	if upsert == nil {
 		upsert = usage.UpsertAIAccountStatus
@@ -582,24 +603,6 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 			r.State = RefreshError
 			r.ErrorCode = "persist_reload_failed"
 			r.ErrorMessage = sanitizeMsg(msg)
-			r.UpdatedAt = checked
-			r.Result = nil
-		})
-		return
-	}
-	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
-		AuthSubjectID: subjectID, Provider: auth.Provider, LastProbeState: string(RefreshSuccess),
-		HealthStatus: healthStatus, PlanType: strings.TrimSpace(probe.PlanType),
-		SubscriptionStartedAt: probe.SubscriptionStartedAt, SubscriptionExpiresAt: probe.SubscriptionExpiresAt,
-		SubscriptionSource: probe.SubscriptionSource, RestrictionSummary: record.RestrictionSummary, Quotas: probe.Quotas,
-		ResetCreditCount: probe.ResetCreditCount, ResetCreditExpirations: probe.ResetCreditExpirations,
-		UpstreamCheckedAt: &checked, Version: legacyPersisted.Version, UpdatedAt: checked,
-	}); err != nil {
-		_ = usage.UpdateAIAccountRefreshFailure(tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status), "persist_failed", err.Error(), checked)
-		s.setResult(jobID, subjectID, func(r *AccountRefreshResult) {
-			r.State = RefreshError
-			r.ErrorCode = "persist_failed"
-			r.ErrorMessage = sanitizeMsg(err.Error())
 			r.UpdatedAt = checked
 			r.Result = nil
 		})
@@ -969,7 +972,7 @@ func reconcileTenantBindings(auths []*coreauth.Auth) error {
 	for _, row := range rows {
 		byID[row.AuthID] = row
 	}
-	// Best-effort per auth: one bad legacy row must not 500 the whole status list.
+	// Best-effort per auth: one bad binding row must not 500 the whole status list.
 	var firstErr error
 	for _, auth := range auths {
 		if auth == nil {

--- a/internal/management/aiaccountstatus/service_test.go
+++ b/internal/management/aiaccountstatus/service_test.go
@@ -225,9 +225,12 @@ func TestListStatusDoesNotReadRequestLogs(t *testing.T) {
 	}
 	pct := 65.0
 	now := time.Now().UTC()
-	if err := usage.UpsertAIAccountStatus(usage.AIAccountStatusRecord{
-		TenantID: "tenant-read-model", AuthSubjectID: identity.ID, AuthIndex: auth.EnsureIndex(), Provider: "codex",
-		RefreshState: "success", PlanType: "plus", Quotas: []usage.QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pct}}, UpdatedAt: now,
+	if err := usage.UpsertAIAccountSubject(identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID: identity.ID, Provider: "codex", LastProbeState: string(RefreshSuccess),
+		PlanType: "plus", Quotas: []usage.QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pct}}, UpdatedAt: now,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -418,20 +421,22 @@ func TestProgressiveSuccessResultUsesDBVersion(t *testing.T) {
 	if identity == nil {
 		t.Fatal("missing identity")
 	}
-	// Bump DB version well above 0.
+	if err := usage.UpsertAIAccountSubject(identity); err != nil {
+		t.Fatal(err)
+	}
+	// Bump shared DB version well above 0.
 	now := time.Now().UTC()
 	for i := 0; i < 3; i++ {
 		pct := float64(10 + i)
-		if err := usage.UpsertAIAccountStatus(usage.AIAccountStatusRecord{
-			TenantID: "tenant-ver", AuthSubjectID: identity.ID, AuthIndex: auth.EnsureIndex(), Provider: "codex",
-			RefreshState: "success", PlanType: "plus",
+		if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+			AuthSubjectID: identity.ID, Provider: "codex", LastProbeState: string(RefreshSuccess), PlanType: "plus",
 			Quotas:            []usage.QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pct}},
 			UpstreamCheckedAt: &now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	before, err := usage.ListAIAccountStatusForTenant("tenant-ver", []string{identity.ID})
+	before, err := usage.ListAIAccountSubjectStatus([]string{identity.ID})
 	if err != nil || len(before) != 1 {
 		t.Fatalf("before=%v err=%v", before, err)
 	}
@@ -457,7 +462,7 @@ func TestProgressiveSuccessResultUsesDBVersion(t *testing.T) {
 	if progressive == nil {
 		t.Fatalf("missing progressive result: %+v", snap.Results)
 	}
-	after, err := usage.ListAIAccountStatusForTenant("tenant-ver", []string{identity.ID})
+	after, err := usage.ListAIAccountSubjectStatus([]string{identity.ID})
 	if err != nil || len(after) != 1 {
 		t.Fatalf("after=%v err=%v", after, err)
 	}
@@ -585,9 +590,11 @@ func TestFreshSkipUsesBatchLoadNotPerAccountUnderLock(t *testing.T) {
 	now := time.Now().UTC()
 	for _, auth := range []*coreauth.Auth{a1, a2} {
 		id := usage.ResolveAuthSubjectIdentity(auth)
-		if err := usage.UpsertAIAccountStatus(usage.AIAccountStatusRecord{
-			TenantID: "tenant-fresh", AuthSubjectID: id.ID, AuthIndex: auth.EnsureIndex(), Provider: "codex",
-			RefreshState: "success", UpstreamCheckedAt: &now, UpdatedAt: now,
+		if err := usage.UpsertAIAccountSubject(id); err != nil {
+			t.Fatal(err)
+		}
+		if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+			AuthSubjectID: id.ID, Provider: "codex", LastProbeState: string(RefreshSuccess), UpstreamCheckedAt: &now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatal(err)
 		}
@@ -762,6 +769,13 @@ func TestPersistReloadFailedDoesNotReportSuccess(t *testing.T) {
 			t.Fatalf("Result must be nil, got %+v", r.Result)
 		}
 	}
+	shared, err := usage.ListAIAccountSubjectStatus([]string{identity.ID})
+	if err != nil || len(shared) != 1 {
+		t.Fatalf("shared status=%+v err=%v", shared, err)
+	}
+	if shared[0].LastProbeState != string(RefreshSuccess) || shared[0].PlanType != "team" || len(shared[0].Quotas) != 1 {
+		t.Fatalf("legacy reload failure blocked shared status: %+v", shared[0])
+	}
 }
 
 func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
@@ -800,6 +814,40 @@ func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	resetAt := checked.Add(48 * time.Hour)
+	cycleStart := resetAt.Add(-7 * 24 * time.Hour)
+	if err := usage.RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []usage.QuotaSnapshotPoint{{
+		RecordedAt: checked, Provider: "codex", QuotaKey: "code_week", QuotaLabel: "Week",
+		Percent: &pct, ResetAt: &resetAt, WindowSeconds: 604800,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	admin, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+	if _, err := admin.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets
+			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
+		VALUES (?, 'cycle', ?, 1, 1, 0, 1, ?, ?)
+	`, identity.ID, cycleStart.Format(time.RFC3339Nano), cycleStart.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec(`
+		INSERT INTO auth_subject_usage_daily
+			(tenant_id, auth_subject_id, day_key, request_count, success_count, failure_count, cost_total, updated_at)
+		VALUES (?, ?, ?, 9, 9, 0, 9, ?)
+	`, authA.TenantID, identity.ID, cycleStart.Format("2006-01-02"), checked.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec(`
+		INSERT INTO auth_subject_quota_cycles
+			(tenant_id, subject_id, auth_index, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, ?, ?, 'codex', 'code_week', ?, ?, 604800, ?)
+	`, authA.TenantID, identity.ID, authA.EnsureIndex(), cycleStart.Format(time.RFC3339Nano), resetAt.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
 
 	// Mounting the same physical account in tenant B repairs only B's missing binding,
 	// then immediately reads the already-populated shared subject snapshot.
@@ -817,6 +865,9 @@ func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
 	}
 	if item.CurrentTenantBindingCount != 1 || item.AuthIndex != authB.EnsureIndex() {
 		t.Fatalf("tenant B binding projection=%+v", item)
+	}
+	if !item.Usage.CycleKnown || item.Usage.CycleRequestTotal != 1 {
+		t.Fatalf("binding repair changed shared cycle usage: %+v", item.Usage)
 	}
 }
 

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -189,6 +189,13 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 	if dayRows != 1 || dayRequests != 2 {
 		t.Fatalf("day projection rows=%d requests=%d", dayRows, dayRequests)
 	}
+	var legacyRows int64
+	if err := getDB().QueryRow(`SELECT COUNT(*) FROM auth_subject_usage_daily WHERE auth_subject_id = ?`, identity.ID).Scan(&legacyRows); err != nil {
+		t.Fatal(err)
+	}
+	if legacyRows != 0 {
+		t.Fatalf("legacy daily rows=%d want 0", legacyRows)
+	}
 
 	start7 := time.Now().UTC().AddDate(0, 0, -6).Format("2006-01-02")
 	start30 := time.Now().UTC().AddDate(0, 0, -29).Format("2006-01-02")
@@ -363,8 +370,8 @@ func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 	cycleSummary := cycleSummaries[identity.ID]
-	if !cycleSummary.CycleKnown || cycleSummary.CycleRequestTotal != 2 || math.Abs(cycleSummary.CycleCostTotal-4) > 1e-9 {
-		t.Fatalf("backfilled current cycle=%+v", cycleSummary)
+	if !cycleSummary.CycleKnown || cycleSummary.CycleRequestTotal != 0 || cycleSummary.CycleCostTotal != 0 {
+		t.Fatalf("cycle usage must not be estimated from legacy days: %+v", cycleSummary)
 	}
 
 	second, err := RunAIAccountSharedSubjectBackfillAtInit()
@@ -377,6 +384,60 @@ func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
 	third, err := RunAIAccountSharedSubjectBackfillAtInit()
 	if err != nil || third.Checksum != report.Checksum || third.UsageRows != report.UsageRows || third.QuotaPoints != report.QuotaPoints {
 		t.Fatalf("pending rerun report=%+v err=%v first=%+v", third, err, report)
+	}
+}
+
+func TestProjectAIAccountSubjectUsageLoadsPrimaryCycleOnCacheMiss(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "cache-miss", "acct-cache-miss", "cache@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	primaryReset := now.Add(48 * time.Hour)
+	additionalReset := now.Add(96 * time.Hour)
+	pct := 50.0
+	if err := RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []QuotaSnapshotPoint{
+		{RecordedAt: now, Provider: "codex", QuotaKey: "code_week", QuotaLabel: "Week", Percent: &pct, ResetAt: &primaryReset, WindowSeconds: 604800},
+		{RecordedAt: now.Add(time.Second), Provider: "codex", QuotaKey: "other_week", QuotaLabel: "Other week", Percent: &pct, ResetAt: &additionalReset, WindowSeconds: 1209600},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	resetAIAccountSubjectCycleCache()
+
+	tx, err := getDB().Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 1.5, now); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	primaryStart := primaryReset.Add(-7 * 24 * time.Hour)
+	var bucketStart string
+	var requests int64
+	if err := getDB().QueryRow(`
+		SELECT bucket_start, request_count
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, identity.ID).Scan(&bucketStart, &requests); err != nil {
+		t.Fatal(err)
+	}
+	if bucketStart != formatAIAccountSubjectCycleBucketStart(primaryStart) || requests != 1 {
+		t.Fatalf("cycle bucket start=%q requests=%d want %q/1", bucketStart, requests, formatAIAccountSubjectCycleBucketStart(primaryStart))
+	}
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, map[string]time.Time{identity.ID: primaryStart})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := summaries[identity.ID]; !got.CycleKnown || got.CycleRequestTotal != 1 {
+		t.Fatalf("cycle summary=%+v", got)
 	}
 }
 

--- a/internal/usage/ai_account_status_store_test.go
+++ b/internal/usage/ai_account_status_store_test.go
@@ -78,7 +78,7 @@ func TestUpdateRefreshStatePreservesQuotas(t *testing.T) {
 	}
 }
 
-func TestAuthSubjectUsageDailySameTxProjection(t *testing.T) {
+func TestAIAccountSubjectUsageSameTxProjection(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "usage.db")
 	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
 		t.Fatalf("InitDB: %v", err)
@@ -97,13 +97,20 @@ func TestAuthSubjectUsageDailySameTxProjection(t *testing.T) {
 		true, ts.Add(time.Second), 10, 0, TokenStats{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
 		"", "", "",
 	)
-	sums, err := QueryAuthSubjectUsageSummaries(systemTenantID, []string{subject}, nil)
+	sums, err := QueryAIAccountSubjectUsageSummaries([]string{subject}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	s := sums[subject]
-	if s.RequestTotal30d != 2 || s.SuccessTotal30d != 1 || s.FailureTotal30d != 1 {
+	if s.RequestTotal != 2 || s.RequestTotal30d != 2 || s.SuccessTotal30d != 1 || s.FailureTotal30d != 1 {
 		t.Fatalf("summary=%+v", s)
+	}
+	var legacyRows int64
+	if err := getDB().QueryRow(`SELECT COUNT(*) FROM auth_subject_usage_daily WHERE auth_subject_id = ?`, subject).Scan(&legacyRows); err != nil {
+		t.Fatal(err)
+	}
+	if legacyRows != 0 {
+		t.Fatalf("legacy daily rows=%d want 0", legacyRows)
 	}
 }
 
@@ -293,7 +300,7 @@ func TestStaleRefreshNormalizationPreservesSnapshotPayload(t *testing.T) {
 	}
 }
 
-func TestUsageDailyProjectionUsesConfiguredTimezone(t *testing.T) {
+func TestAIAccountSubjectDayProjectionUsesConfiguredTimezone(t *testing.T) {
 	loc, err := time.LoadLocation("Asia/Singapore")
 	if err != nil {
 		t.Fatal(err)
@@ -313,7 +320,7 @@ func TestUsageDailyProjectionUsesConfiguredTimezone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := projectAuthSubjectUsageDailyTx(tx, systemTenantID, "sub-timezone", false, 1.25, at); err != nil {
+	if err := projectAIAccountSubjectUsageTx(tx, "sub-timezone", false, 1.25, at); err != nil {
 		_ = tx.Rollback()
 		t.Fatal(err)
 	}
@@ -321,7 +328,7 @@ func TestUsageDailyProjectionUsesConfiguredTimezone(t *testing.T) {
 		t.Fatal(err)
 	}
 	var dayKey string
-	if err := getDB().QueryRow(`SELECT day_key FROM auth_subject_usage_daily WHERE tenant_id = ? AND auth_subject_id = ?`, systemTenantID, "sub-timezone").Scan(&dayKey); err != nil {
+	if err := getDB().QueryRow(`SELECT bucket_start FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? AND bucket_kind = 'day'`, "sub-timezone").Scan(&dayKey); err != nil {
 		t.Fatal(err)
 	}
 	if want := at.In(loc).Format("2006-01-02"); dayKey != want {
@@ -452,7 +459,7 @@ func TestStatusReadsUseReadPoolWhileWriterBusy(t *testing.T) {
 			done <- fmt.Errorf("list status unexpected: %+v", rows)
 			return
 		}
-		sums, err := QueryAuthSubjectUsageSummaries(systemTenantID, []string{"sub-readpool"}, nil)
+		sums, err := QueryAIAccountSubjectUsageSummaries([]string{"sub-readpool"}, nil)
 		if err != nil {
 			done <- err
 			return

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -30,6 +30,7 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 	}
 	defer func() { _ = tx.Rollback() }()
 	now := time.Now().UTC()
+	cycles := make([]AIAccountSubjectQuotaCycle, 0, len(points))
 	for _, point := range points {
 		key := strings.TrimSpace(point.QuotaKey)
 		if key == "" {
@@ -67,7 +68,7 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 			if err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle); err != nil {
 				return err
 			}
-			setAIAccountSubjectActiveCycle(cycle)
+			cycles = append(cycles, cycle)
 		}
 		var latestAt sql.NullString
 		var latestPercent sql.NullFloat64
@@ -100,6 +101,9 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 	}
 	if err := tx.Commit(); err != nil {
 		return err
+	}
+	for _, cycle := range cycles {
+		setAIAccountSubjectActiveCycle(cycle)
 	}
 	return nil
 }
@@ -206,15 +210,16 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferred
 	if db == nil || len(ids) == 0 {
 		return out, nil
 	}
-	args := make([]any, 0, len(ids)+len(preferredKeys))
+	args := make([]any, 0, len(ids)+len(preferredKeys)+1)
 	for _, id := range ids {
 		args = append(args, id)
 	}
+	args = append(args, aiAccountSubjectWeeklyWindowSeconds)
 	query := `
 		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
 		FROM ai_account_subject_quota_cycles
 		WHERE auth_subject_id IN (` + strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + `)
-		  AND window_seconds >= 604800`
+		  AND window_seconds >= ?`
 	keys := dedupeExactStrings(preferredKeys)
 	if len(keys) > 0 {
 		query += ` AND quota_key IN (` + strings.TrimSuffix(strings.Repeat("?,", len(keys)), ",") + `)`
@@ -228,6 +233,7 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferred
 		return nil, fmt.Errorf("usage: query shared quota cycles: %w", err)
 	}
 	defer rows.Close()
+	cyclesBySubject := make(map[string][]AIAccountSubjectQuotaCycle)
 	for rows.Next() {
 		var cycle AIAccountSubjectQuotaCycle
 		var start, reset, verified storedTime
@@ -244,11 +250,17 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferred
 			cycle.LastVerifiedAt = verified.Time
 		}
 		setAIAccountSubjectActiveCycle(cycle)
-		if _, exists := out[cycle.AuthSubjectID]; !exists {
-			out[cycle.AuthSubjectID] = cycle.CycleStartAt
+		cyclesBySubject[cycle.AuthSubjectID] = append(cyclesBySubject[cycle.AuthSubjectID], cycle)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for subjectID, cycles := range cyclesBySubject {
+		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
+			out[subjectID] = cycle.CycleStartAt
 		}
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 func loadAIAccountSubjectCycleCache(db *sql.DB) error {
@@ -258,24 +270,19 @@ func loadAIAccountSubjectCycleCache(db *sql.DB) error {
 	}
 	rows, err := db.Query(`
 		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
-		FROM ai_account_subject_quota_cycles WHERE window_seconds > 0
+		FROM ai_account_subject_quota_cycles WHERE window_seconds >= ?
 		ORDER BY last_verified_at DESC
-	`)
+	`, aiAccountSubjectWeeklyWindowSeconds)
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
-	seen := map[string]struct{}{}
 	for rows.Next() {
 		var cycle AIAccountSubjectQuotaCycle
 		var start, reset, verified storedTime
 		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
 			return err
 		}
-		if _, ok := seen[cycle.AuthSubjectID]; ok {
-			continue
-		}
-		seen[cycle.AuthSubjectID] = struct{}{}
 		if start.Valid {
 			cycle.CycleStartAt = start.Time
 		}

--- a/internal/usage/ai_account_subject_store.go
+++ b/internal/usage/ai_account_subject_store.go
@@ -298,8 +298,7 @@ func UpsertAIAccountTenantBinding(auth *coreauth.Auth, identity *AuthSubjectIden
 	if err != nil {
 		return fmt.Errorf("usage: upsert ai account tenant binding: %w", err)
 	}
-	// Low-frequency lifecycle reconciliation may merge old small-table state.
-	return BackfillAIAccountSharedSubject(identity.ID)
+	return nil
 }
 
 func MarkAIAccountTenantBindingDeleted(tenantID, authID string) error {
@@ -601,7 +600,7 @@ func nullableTimeValue(value *time.Time) any {
 }
 
 // BackfillAIAccountSharedSubject merges only existing small projections. It
-// never reads request_logs; detail retention therefore cannot reset card data.
+// never writes cycle usage because legacy daily rows lack exact cycle timestamps.
 func BackfillAIAccountSharedSubject(subjectID string) error {
 	db := getDB()
 	subjectID = strings.TrimSpace(subjectID)
@@ -791,6 +790,8 @@ func backfillSharedLifetimeForSubject(db *sql.DB, subjectID string) error {
 	return err
 }
 
+// backfillSharedQuotaCyclesForSubject migrates cycle definitions only. Cycle
+// usage is projected from requests with exact timestamps.
 func backfillSharedQuotaCyclesForSubject(db *sql.DB, subjectID string) error {
 	rows, err := db.Query(`
 		SELECT provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
@@ -821,7 +822,6 @@ func backfillSharedQuotaCyclesForSubject(db *sql.DB, subjectID string) error {
 	if err := rows.Close(); err != nil {
 		return err
 	}
-	cycleStarts := make(map[string]struct{}, len(batch))
 	for _, row := range batch {
 		startValue, okStart := requiredStoredTimeArg(row.start)
 		resetValue, okReset := requiredStoredTimeArg(row.reset)
@@ -843,21 +843,8 @@ func backfillSharedQuotaCyclesForSubject(db *sql.DB, subjectID string) error {
 		`, subjectID, row.provider, row.key, startValue, resetValue, row.window, verifiedValue); err != nil {
 			return err
 		}
-		cycleStarts[startValue] = struct{}{}
-	}
-	for start := range cycleStarts {
-		if err := backfillSharedCycleUsageForSubject(db, subjectID, start); err != nil {
-			return err
-		}
 	}
 	return nil
-}
-
-func canonicalAIAccountSubjectTime(value string) string {
-	if parsed, ok := parseStoredTimeString(value); ok {
-		return parsed.UTC().Format(time.RFC3339Nano)
-	}
-	return strings.TrimSpace(value)
 }
 
 // nullableStoredTimeArg returns a canonical RFC3339Nano string or nil (SQL NULL).
@@ -880,47 +867,6 @@ func requiredStoredTimeArg(value string) (string, bool) {
 	}
 	s, ok := arg.(string)
 	return s, ok && s != ""
-}
-
-// Current-cycle migration is intentionally estimated from the legacy daily
-// projection. It never scans request_logs, so the first partial day may be
-// conservative until the next full provider cycle starts.
-func backfillSharedCycleUsageForSubject(db *sql.DB, subjectID, cycleStart string) error {
-	startAt, ok := parseStoredTimeString(cycleStart)
-	if !ok {
-		return nil
-	}
-	startDay := startAt.In(getUsageLocation()).Format("2006-01-02")
-	var req, success, failure int64
-	var cost float64
-	var updated sql.NullString
-	if err := db.QueryRow(`
-		SELECT COALESCE(SUM(request_count),0), COALESCE(SUM(success_count),0),
-			COALESCE(SUM(failure_count),0), COALESCE(SUM(cost_total),0), MAX(updated_at)
-		FROM auth_subject_usage_daily
-		WHERE auth_subject_id = ? AND day_key >= ?
-	`, subjectID, startDay).Scan(&req, &success, &failure, &cost, &updated); err != nil {
-		return fmt.Errorf("usage: backfill shared cycle usage: %w", err)
-	}
-	if req == 0 {
-		return nil
-	}
-	updatedValue := nullableStoredTimeArg(updated.String)
-	if updatedValue == nil {
-		updatedValue = cycleStart
-	}
-	_, err := db.Exec(`
-		INSERT INTO ai_account_subject_usage_buckets
-			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
-		VALUES (?, 'cycle', ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
-			request_count = CASE WHEN excluded.request_count > ai_account_subject_usage_buckets.request_count THEN excluded.request_count ELSE ai_account_subject_usage_buckets.request_count END,
-			success_count = CASE WHEN excluded.success_count > ai_account_subject_usage_buckets.success_count THEN excluded.success_count ELSE ai_account_subject_usage_buckets.success_count END,
-			failure_count = CASE WHEN excluded.failure_count > ai_account_subject_usage_buckets.failure_count THEN excluded.failure_count ELSE ai_account_subject_usage_buckets.failure_count END,
-			cost_total = CASE WHEN excluded.cost_total > ai_account_subject_usage_buckets.cost_total THEN excluded.cost_total ELSE ai_account_subject_usage_buckets.cost_total END,
-			updated_at = CASE WHEN excluded.updated_at > ai_account_subject_usage_buckets.updated_at THEN excluded.updated_at ELSE ai_account_subject_usage_buckets.updated_at END
-	`, subjectID, cycleStart, req, success, failure, cost, cycleStart, updatedValue)
-	return err
 }
 
 func backfillSharedQuotaPointsForSubject(db *sql.DB, subjectID string) error {

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -9,33 +9,126 @@ import (
 )
 
 const aiAccountSubjectDayRetention = 400 * 24 * time.Hour
+const aiAccountSubjectWeeklyWindowSeconds = int64(7 * 24 * time.Hour / time.Second)
 
+// Keep every (subject, quota key) cycle so additional weekly windows cannot
+// replace the provider's primary card cycle.
 var sharedCycleCache = struct {
 	sync.RWMutex
-	bySubject map[string]AIAccountSubjectQuotaCycle
-}{bySubject: make(map[string]AIAccountSubjectQuotaCycle)}
+	bySubjectQuota map[string]map[string]AIAccountSubjectQuotaCycle
+}{bySubjectQuota: make(map[string]map[string]AIAccountSubjectQuotaCycle)}
 
 func resetAIAccountSubjectCycleCache() {
 	sharedCycleCache.Lock()
-	sharedCycleCache.bySubject = make(map[string]AIAccountSubjectQuotaCycle)
+	sharedCycleCache.bySubjectQuota = make(map[string]map[string]AIAccountSubjectQuotaCycle)
 	sharedCycleCache.Unlock()
 }
 
 func setAIAccountSubjectActiveCycle(cycle AIAccountSubjectQuotaCycle) {
-	if strings.TrimSpace(cycle.AuthSubjectID) == "" || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() || cycle.WindowSeconds <= 0 {
+	subjectID := strings.TrimSpace(cycle.AuthSubjectID)
+	quotaKey := strings.TrimSpace(cycle.QuotaKey)
+	if subjectID == "" || quotaKey == "" || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() || cycle.WindowSeconds <= 0 {
 		return
 	}
 	sharedCycleCache.Lock()
-	sharedCycleCache.bySubject[cycle.AuthSubjectID] = cycle
+	byQuota := sharedCycleCache.bySubjectQuota[subjectID]
+	if byQuota == nil {
+		byQuota = make(map[string]AIAccountSubjectQuotaCycle)
+		sharedCycleCache.bySubjectQuota[subjectID] = byQuota
+	}
+	byQuota[quotaKey] = cycle
 	sharedCycleCache.Unlock()
 }
 
-func aiAccountSubjectCycleAt(subjectID string, at time.Time) (AIAccountSubjectQuotaCycle, bool) {
+func primaryAIAccountSubjectWeeklyQuotaKey(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return "seven_day"
+	case "codex", "kimi":
+		return "code_week"
+	case "xai", "grok":
+		return "weekly_limit"
+	default:
+		return ""
+	}
+}
+
+func selectAIAccountSubjectWeeklyCycle(cycles []AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, bool) {
+	var selected AIAccountSubjectQuotaCycle
+	for _, cycle := range cycles {
+		if cycle.WindowSeconds < aiAccountSubjectWeeklyWindowSeconds || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() {
+			continue
+		}
+		primaryKey := primaryAIAccountSubjectWeeklyQuotaKey(cycle.Provider)
+		if primaryKey != "" && strings.TrimSpace(cycle.QuotaKey) != primaryKey {
+			continue
+		}
+		if selected.AuthSubjectID == "" || cycle.LastVerifiedAt.After(selected.LastVerifiedAt) {
+			selected = cycle
+		}
+	}
+	return selected, selected.AuthSubjectID != ""
+}
+
+func cachedAIAccountSubjectWeeklyCycle(subjectID string) (AIAccountSubjectQuotaCycle, bool) {
+	subjectID = strings.TrimSpace(subjectID)
+	cycles := make([]AIAccountSubjectQuotaCycle, 0)
 	sharedCycleCache.RLock()
-	cycle, ok := sharedCycleCache.bySubject[strings.TrimSpace(subjectID)]
+	for _, cycle := range sharedCycleCache.bySubjectQuota[subjectID] {
+		cycles = append(cycles, cycle)
+	}
 	sharedCycleCache.RUnlock()
-	if !ok || cycle.WindowSeconds <= 0 || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() {
-		return AIAccountSubjectQuotaCycle{}, false
+	return selectAIAccountSubjectWeeklyCycle(cycles)
+}
+
+func loadAIAccountSubjectWeeklyCycleTx(tx *sql.Tx, subjectID string) (AIAccountSubjectQuotaCycle, bool, error) {
+	rows, err := tx.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND window_seconds >= ?
+		ORDER BY last_verified_at DESC, reset_at DESC
+	`, subjectID, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return AIAccountSubjectQuotaCycle{}, false, fmt.Errorf("usage: load shared subject quota cycle: %w", err)
+	}
+	defer rows.Close()
+	cycles := make([]AIAccountSubjectQuotaCycle, 0)
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			return AIAccountSubjectQuotaCycle{}, false, err
+		}
+		if start.Valid {
+			cycle.CycleStartAt = start.Time
+		}
+		if reset.Valid {
+			cycle.ResetAt = reset.Time
+		}
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time
+		}
+		setAIAccountSubjectActiveCycle(cycle)
+		cycles = append(cycles, cycle)
+	}
+	if err := rows.Err(); err != nil {
+		return AIAccountSubjectQuotaCycle{}, false, err
+	}
+	cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles)
+	return cycle, ok, nil
+}
+
+func aiAccountSubjectCycleAt(tx *sql.Tx, subjectID string, at time.Time) (AIAccountSubjectQuotaCycle, bool, error) {
+	cycle, ok := cachedAIAccountSubjectWeeklyCycle(subjectID)
+	if !ok {
+		var err error
+		cycle, ok, err = loadAIAccountSubjectWeeklyCycleTx(tx, strings.TrimSpace(subjectID))
+		if err != nil {
+			return AIAccountSubjectQuotaCycle{}, false, err
+		}
+	}
+	if !ok {
+		return AIAccountSubjectQuotaCycle{}, false, nil
 	}
 	at = at.UTC()
 	window := time.Duration(cycle.WindowSeconds) * time.Second
@@ -43,7 +136,11 @@ func aiAccountSubjectCycleAt(subjectID string, at time.Time) (AIAccountSubjectQu
 		cycle.CycleStartAt = cycle.ResetAt
 		cycle.ResetAt = cycle.ResetAt.Add(window)
 	}
-	return cycle, !at.Before(cycle.CycleStartAt)
+	return cycle, !at.Before(cycle.CycleStartAt), nil
+}
+
+func formatAIAccountSubjectCycleBucketStart(value time.Time) string {
+	return value.UTC().Format(time.RFC3339Nano)
 }
 
 // projectAIAccountSubjectUsageTx is the request-hot B-layer projection. It only
@@ -74,8 +171,12 @@ func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed boo
 		{kind: "day", start: at.In(loc).Format("2006-01-02")},
 		{kind: "lifetime", start: rollupLifetimeStart},
 	}
-	if cycle, ok := aiAccountSubjectCycleAt(authSubjectID, at); ok {
-		buckets = append(buckets, struct{ kind, start string }{kind: "cycle", start: cycle.CycleStartAt.UTC().Format(time.RFC3339Nano)})
+	cycle, cycleKnown, err := aiAccountSubjectCycleAt(tx, authSubjectID, at)
+	if err != nil {
+		return err
+	}
+	if cycleKnown {
+		buckets = append(buckets, struct{ kind, start string }{kind: "cycle", start: formatAIAccountSubjectCycleBucketStart(cycle.CycleStartAt)})
 	}
 	const upsert = `
 		INSERT INTO ai_account_subject_usage_buckets (
@@ -268,7 +369,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 		if _, ok := out[id]; !ok || start.IsZero() {
 			continue
 		}
-		startKey := start.UTC().Format(time.RFC3339Nano)
+		startKey := formatAIAccountSubjectCycleBucketStart(start)
 		s := out[id]
 		s.CycleKnown = true
 		s.CycleStart = start.UTC().Format(time.RFC3339)
@@ -310,7 +411,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 			return nil, err
 		}
 		expected, ok := cycleStartBySubject[id]
-		if !ok || bucketStart != expected.UTC().Format(time.RFC3339Nano) {
+		if !ok || bucketStart != formatAIAccountSubjectCycleBucketStart(expected) {
 			continue
 		}
 		s := out[id]

--- a/internal/usage/auth_subject_usage_daily.go
+++ b/internal/usage/auth_subject_usage_daily.go
@@ -33,58 +33,6 @@ type AuthSubjectUsageSummary struct {
 	UpdatedAt         time.Time  `json:"updated_at,omitempty"`
 }
 
-// commitLogWithAuthSubjectUsageDaily projects daily card counters then commits the request_log tx.
-func commitLogWithAuthSubjectUsageDaily(tx *sql.Tx, tenantID, authSubjectID string, failed bool, cost float64, at time.Time) error {
-	if authSubjectID != "" {
-		if err := projectAuthSubjectUsageDailyTx(tx, tenantID, authSubjectID, failed, cost, at); err != nil {
-			_ = tx.Rollback()
-			return fmt.Errorf("project auth subject usage daily: %w", err)
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// projectAuthSubjectUsageDailyTx increments the day projection inside the request_log write tx.
-func projectAuthSubjectUsageDailyTx(tx *sql.Tx, tenantID, authSubjectID string, failed bool, cost float64, at time.Time) error {
-	if tx == nil {
-		return nil
-	}
-	tenantID = normalizeTenantID(tenantID)
-	authSubjectID = strings.TrimSpace(authSubjectID)
-	if authSubjectID == "" {
-		return nil
-	}
-	if at.IsZero() {
-		at = time.Now()
-	}
-	// Avoid getUsageLocation() lock: may run under InitDB which already holds usageDBMu.
-	loc := usageLoc
-	if loc == nil {
-		loc = time.Local
-	}
-	dayKey := localDayKeyAtLocation(at, loc)
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	successInc, failureInc := int64(1), int64(0)
-	if failed {
-		successInc, failureInc = 0, 1
-	}
-	_, err := tx.Exec(`
-		INSERT INTO auth_subject_usage_daily (
-			tenant_id, auth_subject_id, day_key, request_count, success_count, failure_count, cost_total, updated_at
-		) VALUES (?, ?, ?, 1, ?, ?, ?, ?)
-		ON CONFLICT(tenant_id, auth_subject_id, day_key) DO UPDATE SET
-			request_count = auth_subject_usage_daily.request_count + 1,
-			success_count = auth_subject_usage_daily.success_count + excluded.success_count,
-			failure_count = auth_subject_usage_daily.failure_count + excluded.failure_count,
-			cost_total = auth_subject_usage_daily.cost_total + excluded.cost_total,
-			updated_at = excluded.updated_at
-	`, tenantID, authSubjectID, dayKey, successInc, failureInc, cost, now)
-	return err
-}
-
 func ensureUsageProjectionMarkerTable(db *sql.DB) {
 	if db == nil {
 		return

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -498,7 +498,7 @@ func resolveEndUserIDForKey(apiKey string) string {
 	return strings.TrimSpace(row.EndUserID)
 }
 
-// commitLogWithProjections writes tenant rollup, shared subject buckets, then legacy tenant daily and commits.
+// commitLogWithProjections writes tenant rollup and shared subject buckets, then commits.
 // Caller must already hold usageProjectionMu.RLock (see insertLogIdentity).
 func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 	if err := projectUsageRollupTx(tx, ev); err != nil {
@@ -509,10 +509,6 @@ func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 		if err := projectAIAccountSubjectUsageTx(tx, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.At); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("project shared auth subject usage: %w", err)
-		}
-		if err := projectAuthSubjectUsageDailyTx(tx, ev.TenantID, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.At); err != nil {
-			_ = tx.Rollback()
-			return fmt.Errorf("project auth subject usage daily: %w", err)
 		}
 	}
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
## Summary
- Stop steady-state `BackfillAIAccountSharedSubject` from binding upsert / ListStatus repair (no more day-truncated MAX cycle inflation).
- Request path no longer dual-writes `auth_subject_usage_daily`; cycle projection falls back to DB weekly cycles on cache miss, keyed by `(subject, quota_key)`.
- Probe writes shared status/quota without depending on legacy version for shared success.

## Test plan
- [x] `go test ./internal/usage/... ./internal/management/aiaccountstatus/...`
- [x] `go test ./internal/api/handlers/management/... ./internal/management/usagelogs/...`
- [ ] GHA `build` required check
- Note: existing inflated cycle buckets are not auto-corrected; needs a separate precise recompute job if desired.