### PR TITLE
fix(portal): scope API key spending resets to tenant

### DIFF
--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -39,11 +39,14 @@ func (h *Handler) refreshAPIKeyCache() error {
 }
 
 func (h *Handler) apiKeySettings(c *gin.Context) *apikeysettings.Service {
+	return h.apiKeySettingsForTenant(effectiveTenantID(c))
+}
+
+func (h *Handler) apiKeySettingsForTenant(tenantID string) *apikeysettings.Service {
 	if h == nil {
-		return apikeysettings.NewService(nil)
+		return apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID))
 	}
 
-	tenantID := effectiveTenantID(c)
 	var auths []*coreauth.Auth
 	if h.authManager != nil {
 		auths = h.authManager.ListForTenant(tenantID)

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -58,7 +58,7 @@ func endUserError(c *gin.Context, err error) {
 		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "last_key", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrDuplicateKeyName):
 		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "duplicate_key_name", "message": err.Error()}})
-	case errors.Is(err, enduser.ErrNotFound):
+	case errors.Is(err, enduser.ErrNotFound), errors.Is(err, apikeysettings.ErrItemNotFound):
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrPeriodDayLegacyConflict):
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
@@ -855,7 +855,7 @@ func (h *Handler) resetOwnedAPIKeyDailySpending(c *gin.Context, tenantID, endUse
 		endUserError(c, err)
 		return
 	}
-	result, err := h.apiKeySettings(c).ResetDailySpending(&keyID, nil, actor)
+	result, err := h.apiKeySettingsForTenant(tenantID).ResetDailySpending(&keyID, nil, actor)
 	if err != nil {
 		if errors.Is(err, apikeysettings.ErrDailySpendingLimitMissing) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "daily_spending_limit_missing", "message": "Key daily spending limit is unlimited"}})
@@ -878,7 +878,7 @@ func (h *Handler) ownedAPIKeyDailySpendingHistory(c *gin.Context, tenantID, endU
 			limit = parsed
 		}
 	}
-	events, err := h.apiKeySettings(c).ListDailySpendingResetHistory(&keyID, nil, limit)
+	events, err := h.apiKeySettingsForTenant(tenantID).ListDailySpendingResetHistory(&keyID, nil, limit)
 	if err != nil {
 		endUserError(c, err)
 		return

--- a/internal/api/handlers/management/end_user_daily_spending_reset_test.go
+++ b/internal/api/handlers/management/end_user_daily_spending_reset_test.go
@@ -1,6 +1,8 @@
 package management
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -94,6 +97,67 @@ func setupEndUserDailySpendingHandlerTest(t *testing.T) (*Handler, identity.Prin
 		},
 	}
 	return &Handler{}, principal, tenantID, endUserID
+}
+
+func setupPortalAPIKeyDailySpendingHandlerTest(t *testing.T) (*Handler, string, string, string, string) {
+	t.Helper()
+	h, _, tenantID, endUserID := setupEndUserDailySpendingHandlerTest(t)
+	if tenantID == identity.SystemTenantID {
+		t.Fatal("portal tenant must differ from system tenant")
+	}
+	db := usage.RuntimeDB()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS tenants (
+			id TEXT PRIMARY KEY,
+			status TEXT NOT NULL,
+			type TEXT NOT NULL,
+			expires_at TIMESTAMP,
+			access_token_ttl_seconds INTEGER,
+			refresh_token_ttl_seconds INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS end_user_sessions (
+			id TEXT PRIMARY KEY,
+			end_user_id TEXT NOT NULL,
+			tenant_id TEXT NOT NULL,
+			access_token_hash TEXT NOT NULL UNIQUE,
+			refresh_token_hash TEXT NOT NULL UNIQUE,
+			access_expires_at TIMESTAMP NOT NULL,
+			refresh_expires_at TIMESTAMP NOT NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			last_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			revoked_at TIMESTAMP,
+			revoke_reason TEXT NOT NULL DEFAULT '',
+			user_agent_hash TEXT NOT NULL DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("create portal auth tables: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO tenants (id, status, type) VALUES (?, 'active', 'standard')`, tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+
+	keyID := uuid.NewString()
+	if err := usage.UpsertAPIKeyForTenant(tenantID, usage.APIKeyRow{
+		ID:                 keyID,
+		Key:                "sk-portal-reset-tenant",
+		Name:               "Portal reset tenant",
+		EndUserID:          endUserID,
+		DailySpendingLimit: 100,
+	}); err != nil {
+		t.Fatalf("insert owned API key: %v", err)
+	}
+
+	portalToken := "cpt_portal-reset-tenant-test"
+	portalTokenSum := sha256.Sum256([]byte(portalToken))
+	if _, err := db.Exec(`
+		INSERT INTO end_user_sessions (
+			id, end_user_id, tenant_id, access_token_hash, refresh_token_hash, access_expires_at, refresh_expires_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, uuid.NewString(), endUserID, tenantID, hex.EncodeToString(portalTokenSum[:]), "unused-portal-reset-refresh-hash",
+		time.Now().UTC().Add(time.Hour), time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatalf("insert portal session: %v", err)
+	}
+	return h, tenantID, endUserID, keyID, portalToken
 }
 
 func TestEndUserDailySpendingResetWritesAndListsHistory(t *testing.T) {
@@ -186,5 +250,65 @@ func TestEndUserDailySpendingResetRejectsUnlimitedAccount(t *testing.T) {
 	h.PostEndUserDailySpendingReset(ctx)
 	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), `"code":"daily_spending_limit_missing"`) {
 		t.Fatalf("status/body = %d %s, want 400 daily_spending_limit_missing", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestPortalAPIKeyDailySpendingResetAndHistoryUsePortalTenant(t *testing.T) {
+	h, tenantID, endUserID, keyID, portalToken := setupPortalAPIKeyDailySpendingHandlerTest(t)
+
+	historyRecorder := httptest.NewRecorder()
+	historyContext, _ := gin.CreateTestContext(historyRecorder)
+	historyContext.Params = gin.Params{{Key: "id", Value: keyID}}
+	historyContext.Request = httptest.NewRequest(http.MethodGet, "/v0/portal/api-keys/"+keyID+"/daily-spending/reset-history?limit=200", nil)
+	historyContext.Request.Header.Set("Authorization", "Bearer "+portalToken)
+	if got := effectiveTenantID(historyContext); got != identity.SystemTenantID {
+		t.Fatalf("effective tenant before portal auth = %q, want system tenant fallback", got)
+	}
+	h.GetPortalAPIKeyDailySpendingResetHistory(historyContext)
+	if historyRecorder.Code != http.StatusOK {
+		t.Fatalf("empty history status = %d, want %d; body=%s", historyRecorder.Code, http.StatusOK, historyRecorder.Body.String())
+	}
+	var emptyHistory struct {
+		Items []usage.APIKeyDailySpendingResetEvent `json:"items"`
+		Total int                                   `json:"total"`
+	}
+	if err := json.Unmarshal(historyRecorder.Body.Bytes(), &emptyHistory); err != nil {
+		t.Fatalf("decode empty history response: %v", err)
+	}
+	if emptyHistory.Total != 0 || len(emptyHistory.Items) != 0 {
+		t.Fatalf("empty history response = %#v, want no reset events", emptyHistory)
+	}
+
+	resetRecorder := httptest.NewRecorder()
+	resetContext, _ := gin.CreateTestContext(resetRecorder)
+	resetContext.Params = gin.Params{{Key: "id", Value: keyID}}
+	resetContext.Request = httptest.NewRequest(http.MethodPost, "/v0/portal/api-keys/"+keyID+"/daily-spending/reset", nil)
+	resetContext.Request.Header.Set("Authorization", "Bearer "+portalToken)
+	h.PostPortalAPIKeyDailySpendingReset(resetContext)
+	if resetRecorder.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want %d; body=%s", resetRecorder.Code, http.StatusOK, resetRecorder.Body.String())
+	}
+
+	events, err := usage.ListDailySpendingResetEvents(tenantID, keyID, 10)
+	if err != nil {
+		t.Fatalf("list portal key reset events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("reset events = %d, want 1", len(events))
+	}
+	if events[0].TenantID != tenantID || events[0].ActorUserID != endUserID || events[0].ActorKind != "end_user" {
+		t.Fatalf("reset event = %#v, want portal tenant/user actor", events[0])
+	}
+}
+
+func TestEndUserErrorMapsAPIKeySettingsItemNotFoundToNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+
+	endUserError(ctx, apikeysettings.ErrItemNotFound)
+
+	if recorder.Code != http.StatusNotFound || !strings.Contains(recorder.Body.String(), `"code":"not_found"`) {
+		t.Fatalf("status/body = %d %s, want 404 not_found", recorder.Code, recorder.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

- add an explicit-tenant API key settings factory and use it for owned-key reset/history handlers
- keep portal ownership checks tenant-scoped without relying on a management principal
- map `apikeysettings.ErrItemNotFound` to HTTP 404
- add portal-session regression coverage for non-system tenants, reset history, reset writes, and error mapping

## Root cause

The portal handler verified ownership with the portal user tenant, then called `apiKeySettings(c)`. Portal auth does not set a management principal, so `effectiveTenantID(c)` fell back to the system tenant and the API key lookup returned `item not found`.

## Verification

- [x] regression test fails before the fix with history 500 and `ErrItemNotFound` mapped to 500
- [x] `go test ./internal/api/handlers/management/ -count=1`
- [x] `go test ./internal/management/settings/apikey/ -count=1`
- [x] `go test ./internal/api/routes/ -run TestRegisterManagementRouteTable -count=1`
- [x] `./scripts/ci-pr.sh`

## Branch Checklist

- [x] PR targets `dev`, not `main`
- [x] Branch is based on the latest `origin/dev`
- [x] Only files related to this change are included
