### PR TITLE
feat: public chart api_key_distribution for portal keys

### DIFF
--- a/internal/api/handlers/management/usage_public_test.go
+++ b/internal/api/handlers/management/usage_public_test.go
@@ -282,3 +282,146 @@ func TestGetPublicUsageByAPIKeyMasksCredentialEverywhere(t *testing.T) {
 		t.Fatalf("usage.apis does not contain masked key %q: %#v", got.APIKey, got.Usage.APIs)
 	}
 }
+
+func TestGetPublicUsageChartDataReturnsPortalKeyDistributionWithoutSecrets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupOwnedPublicUsageDB(t)
+
+	tenantID := uuid.NewString()
+	endUserID := uuid.NewString()
+	otherUserID := uuid.NewString()
+	keyA := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-chart-secret-a", Name: "Laptop", EndUserID: endUserID}
+	keyB := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-chart-secret-b", Name: "Automation", EndUserID: endUserID}
+	otherKey := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-chart-secret-other", Name: "Other", EndUserID: otherUserID}
+	standalone := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-chart-secret-standalone", Name: "Standalone"}
+	for _, row := range []usage.APIKeyRow{keyA, keyB, otherKey, standalone} {
+		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Name, err)
+		}
+	}
+
+	db := usage.RuntimeDB()
+	if _, err := db.Exec(`INSERT INTO tenants (id, status, type) VALUES (?, 'active', 'standard')`, tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status)
+		VALUES (?, ?, 'chart-user', 'chart-user', 'Portal Chart User', 'unused', 'active')
+	`, endUserID, tenantID); err != nil {
+		t.Fatalf("insert portal user: %v", err)
+	}
+	portalToken := "cpt_portal-chart-test"
+	portalTokenSum := sha256.Sum256([]byte(portalToken))
+	if _, err := db.Exec(`
+		INSERT INTO end_user_sessions (
+			id, end_user_id, tenant_id, access_token_hash, refresh_token_hash, access_expires_at, refresh_expires_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, uuid.NewString(), endUserID, tenantID, hex.EncodeToString(portalTokenSum[:]), "unused-chart-refresh-hash",
+		time.Now().UTC().Add(time.Hour), time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatalf("insert portal session: %v", err)
+	}
+	enduser.SetDefault(enduser.NewService(db))
+
+	insert := func(row usage.APIKeyRow, tokens int64) {
+		usage.InsertLogWithDetailsIdentity(
+			row.Key, row.ID, row.Name, "gpt-test", "test", "channel", "auth", false,
+			time.Now().UTC(), 1, 0, usage.TokenStats{TotalTokens: tokens}, "", "", "",
+		)
+	}
+	insert(keyA, 3)
+	insert(keyB, 7)
+	insert(keyB, 11)
+	insert(otherKey, 100)
+	insert(standalone, 200)
+
+	h := NewHandler(&config.Config{}, "", nil)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/public/usage/chart-data", bytes.NewReader([]byte(`{"days":7}`)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Authorization", "Bearer "+portalToken)
+	h.UsageLogs().GetPublicUsageChartData(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("portal chart status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	for _, secret := range []string{keyA.Key, keyB.Key, otherKey.Key, standalone.Key} {
+		if strings.Contains(rec.Body.String(), secret) {
+			t.Fatalf("portal chart response leaked secret %q: %s", secret, rec.Body.String())
+		}
+	}
+	if strings.Contains(rec.Body.String(), `"api_key":`) {
+		t.Fatalf("portal chart response contains raw api_key field: %s", rec.Body.String())
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal portal chart response: %v", err)
+	}
+	var distribution []map[string]json.RawMessage
+	if err := json.Unmarshal(payload["api_key_distribution"], &distribution); err != nil {
+		t.Fatalf("unmarshal api_key_distribution: %v; body=%s", err, rec.Body.String())
+	}
+	if len(distribution) != 2 {
+		t.Fatalf("api_key_distribution len = %d, want 2; body=%s", len(distribution), rec.Body.String())
+	}
+	allowedFields := map[string]bool{"api_key_id": true, "name": true, "requests": true, "tokens": true}
+	points := make(map[string]struct {
+		Name     string
+		Requests int64
+		Tokens   int64
+	}, len(distribution))
+	for _, item := range distribution {
+		if len(item) != len(allowedFields) {
+			t.Fatalf("public distribution point fields = %v, want exactly %v", item, allowedFields)
+		}
+		for field := range item {
+			if !allowedFields[field] {
+				t.Fatalf("public distribution point contains unexpected field %q", field)
+			}
+		}
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			t.Fatalf("marshal distribution point: %v", err)
+		}
+		var point struct {
+			APIKeyID string `json:"api_key_id"`
+			Name     string `json:"name"`
+			Requests int64  `json:"requests"`
+			Tokens   int64  `json:"tokens"`
+		}
+		if err := json.Unmarshal(encoded, &point); err != nil {
+			t.Fatalf("unmarshal distribution point: %v", err)
+		}
+		points[point.APIKeyID] = struct {
+			Name     string
+			Requests int64
+			Tokens   int64
+		}{Name: point.Name, Requests: point.Requests, Tokens: point.Tokens}
+	}
+	if point := points[keyA.ID]; point.Name != keyA.Name || point.Requests != 1 || point.Tokens != 3 {
+		t.Fatalf("key A public point = %+v, want own name and requests/tokens 1/3", point)
+	}
+	if point := points[keyB.ID]; point.Name != keyB.Name || point.Requests != 2 || point.Tokens != 18 {
+		t.Fatalf("key B public point = %+v, want own name and requests/tokens 2/18", point)
+	}
+
+	standaloneRec := httptest.NewRecorder()
+	standaloneContext, _ := gin.CreateTestContext(standaloneRec)
+	standaloneContext.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/v0/management/public/usage/chart-data",
+		bytes.NewReader([]byte(`{"api_key":"`+standalone.Key+`","days":7}`)),
+	)
+	standaloneContext.Request.Header.Set("Content-Type", "application/json")
+	h.UsageLogs().GetPublicUsageChartData(standaloneContext)
+	if standaloneRec.Code != http.StatusOK {
+		t.Fatalf("standalone chart status = %d, want %d; body=%s", standaloneRec.Code, http.StatusOK, standaloneRec.Body.String())
+	}
+	var standalonePayload map[string]json.RawMessage
+	if err := json.Unmarshal(standaloneRec.Body.Bytes(), &standalonePayload); err != nil {
+		t.Fatalf("unmarshal standalone chart response: %v", err)
+	}
+	if got := string(standalonePayload["api_key_distribution"]); got != "[]" {
+		t.Fatalf("standalone api_key_distribution = %s, want []", got)
+	}
+}

--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -9,10 +9,11 @@ func (s *Service) PublicChartData(apiKey string, days int) (map[string]any, erro
 	}
 
 	return map[string]any{
-		"daily_series":       chartData.DailySeries,
-		"heatmap_series":     chartData.HeatmapSeries,
-		"model_distribution": chartData.ModelDistribution,
-		"stats":              chartData.Stats,
+		"daily_series":         chartData.DailySeries,
+		"heatmap_series":       chartData.HeatmapSeries,
+		"model_distribution":   chartData.ModelDistribution,
+		"api_key_distribution": chartData.APIKeyDistribution,
+		"stats":                chartData.Stats,
 		// Key own name only — never end-user display name.
 		"api_key_name": s.publicAPIKeyName(apiKey),
 	}, nil
@@ -25,11 +26,12 @@ func (s *Service) PublicChartDataForEndUser(endUserID string, days int) (map[str
 	}
 
 	return map[string]any{
-		"daily_series":       chartData.DailySeries,
-		"heatmap_series":     chartData.HeatmapSeries,
-		"model_distribution": chartData.ModelDistribution,
-		"stats":              chartData.Stats,
-		"api_key_name":       usage.DisplayNameForEndUser(endUserID),
+		"daily_series":         chartData.DailySeries,
+		"heatmap_series":       chartData.HeatmapSeries,
+		"model_distribution":   chartData.ModelDistribution,
+		"api_key_distribution": chartData.APIKeyDistribution,
+		"stats":                chartData.Stats,
+		"api_key_name":         usage.DisplayNameForEndUser(endUserID),
 	}, nil
 }
 

--- a/internal/usage/enduser_account_usage_test.go
+++ b/internal/usage/enduser_account_usage_test.go
@@ -85,11 +85,14 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 	setupEndUserAccountUsageTestDB(t)
 
 	tenantID := uuid.NewString()
+	otherTenantID := uuid.NewString()
 	endUserID := uuid.NewString()
 	otherUserID := uuid.NewString()
 	keyAID := uuid.NewString()
 	keyBID := uuid.NewString()
 	otherKeyID := uuid.NewString()
+	crossTenantKeyID := uuid.NewString()
+	standaloneKeyID := uuid.NewString()
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	if _, err := getDB().Exec(`INSERT INTO end_users (id, tenant_id, display_name) VALUES (?, ?, ?)`, endUserID, tenantID, "Zhang Bolun"); err != nil {
@@ -99,10 +102,16 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 		{ID: keyAID, Key: "sk-business-a", Name: "Automation", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
 		{ID: keyBID, Key: "sk-business-b", Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
 		{ID: otherKeyID, Key: "sk-business-other", Name: "Other", EndUserID: otherUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: standaloneKeyID, Key: "sk-business-standalone", Name: "Standalone", CreatedAt: now, UpdatedAt: now},
 	} {
 		if err := UpsertAPIKeyForTenant(tenantID, row); err != nil {
 			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
 		}
+	}
+	if err := UpsertAPIKeyForTenant(otherTenantID, APIKeyRow{
+		ID: crossTenantKeyID, Key: "sk-business-cross-tenant", Name: "Cross tenant", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertAPIKeyForTenant(cross tenant): %v", err)
 	}
 
 	if row := GetAPIKey("sk-business-a"); row == nil || row.TenantID != tenantID || row.ID != keyAID {
@@ -121,6 +130,8 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 	insertEndUserAccountLog(t, tenantID, "sk-business-b", keyBID, "old snapshot", 2)
 	insertEndUserAccountLog(t, tenantID, "sk-business-b", "", "legacy snapshot", 3)
 	insertEndUserAccountLog(t, tenantID, "sk-business-other", otherKeyID, "other", 50)
+	insertEndUserAccountLog(t, tenantID, "sk-business-standalone", standaloneKeyID, "standalone", 60)
+	insertEndUserAccountLog(t, otherTenantID, "sk-business-cross-tenant", crossTenantKeyID, "cross tenant", 70)
 
 	params := LogQueryParams{TenantID: tenantID, EndUserID: endUserID, Page: 1, Size: 20, Days: 1}
 	result, err := QueryLogs(params)
@@ -152,9 +163,46 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 	if chart.Stats.Total != 3 || chart.Stats.TotalCost != 6 {
 		t.Fatalf("public chart stats = %+v, want total=3 cost=6", chart.Stats)
 	}
+	distributionByID := make(map[string]PublicAPIKeyDistributionPoint, len(chart.APIKeyDistribution))
+	for _, point := range chart.APIKeyDistribution {
+		distributionByID[point.APIKeyID] = point
+	}
+	if len(distributionByID) != 2 {
+		t.Fatalf("api key distribution = %+v, want exactly key A and key B", chart.APIKeyDistribution)
+	}
+	if point := distributionByID[keyAID]; point.Name != "Automation" || point.Requests != 1 || point.Tokens != 2 {
+		t.Fatalf("key A distribution = %+v, want own name and requests/tokens 1/2", point)
+	}
+	if point := distributionByID[keyBID]; point.Name != "Laptop" || point.Requests != 1 || point.Tokens != 2 {
+		t.Fatalf("key B distribution = %+v, want stable-id rollup only and requests/tokens 1/2", point)
+	}
+	if _, exists := distributionByID[otherKeyID]; exists {
+		t.Fatalf("api key distribution included other end user: %+v", chart.APIKeyDistribution)
+	}
+	if _, exists := distributionByID[crossTenantKeyID]; exists {
+		t.Fatalf("api key distribution included other tenant: %+v", chart.APIKeyDistribution)
+	}
+	if _, exists := distributionByID[standaloneKeyID]; exists {
+		t.Fatalf("api key distribution included standalone key: %+v", chart.APIKeyDistribution)
+	}
+
+	emptyChart, err := QueryPublicChartDataForEndUser(tenantID, uuid.NewString(), 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartDataForEndUser(empty): %v", err)
+	}
+	if emptyChart.APIKeyDistribution == nil || len(emptyChart.APIKeyDistribution) != 0 {
+		t.Fatalf("empty api key distribution = %#v, want non-nil []", emptyChart.APIKeyDistribution)
+	}
+	standaloneChart, err := QueryPublicChartData("sk-business-standalone", 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartData(standalone): %v", err)
+	}
+	if standaloneChart.APIKeyDistribution == nil || len(standaloneChart.APIKeyDistribution) != 0 {
+		t.Fatalf("standalone api key distribution = %#v, want non-nil []", standaloneChart.APIKeyDistribution)
+	}
 
 	// Rotate changes only the secret. Stable-id rows remain in the account selector.
-	if _, err := getDB().Exec(`UPDATE api_keys SET key = ?, updated_at = ? WHERE tenant_id = ? AND id = ?`, "sk-business-a-rotated", now, tenantID, keyAID); err != nil {
+	if _, err := getDB().Exec(`UPDATE api_keys SET key = ?, name = ?, updated_at = ? WHERE tenant_id = ? AND id = ?`, "sk-business-a-rotated", "Automation Renamed", now, tenantID, keyAID); err != nil {
 		t.Fatalf("rotate key A: %v", err)
 	}
 	if row := GetAPIKey("sk-business-a-rotated"); row == nil || row.ID != keyAID {
@@ -173,6 +221,13 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 	}
 	if rotatedChart.Stats.Total != 3 || rotatedChart.Stats.TotalCost != 6 {
 		t.Fatalf("chart after rotate = %+v, want total=3 cost=6", rotatedChart.Stats)
+	}
+	rotatedDistributionByID := make(map[string]PublicAPIKeyDistributionPoint, len(rotatedChart.APIKeyDistribution))
+	for _, point := range rotatedChart.APIKeyDistribution {
+		rotatedDistributionByID[point.APIKeyID] = point
+	}
+	if point := rotatedDistributionByID[keyAID]; point.Name != "Automation Renamed" || point.Requests != 1 || point.Tokens != 2 {
+		t.Fatalf("rotated key distribution = %+v, want stable history with current own name", point)
 	}
 }
 

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -35,11 +35,20 @@ type ModelDistributionPoint struct {
 	Tokens   int64  `json:"tokens"`
 }
 
+// PublicAPIKeyDistributionPoint exposes stable per-key usage without secrets.
+type PublicAPIKeyDistributionPoint struct {
+	APIKeyID string `json:"api_key_id"`
+	Name     string `json:"name"`
+	Requests int64  `json:"requests"`
+	Tokens   int64  `json:"tokens"`
+}
+
 type PublicChartData struct {
-	DailySeries       []DailySeriesPoint
-	HeatmapSeries     []DailyHeatmapPoint
-	ModelDistribution []ModelDistributionPoint
-	Stats             LogStats
+	DailySeries        []DailySeriesPoint
+	HeatmapSeries      []DailyHeatmapPoint
+	ModelDistribution  []ModelDistributionPoint
+	APIKeyDistribution []PublicAPIKeyDistributionPoint
+	Stats              LogStats
 }
 
 // QueryPublicChartData aggregates the public API-key lookup charts in one indexed pass.
@@ -64,10 +73,11 @@ func QueryPublicChartDataForEndUser(tenantID, endUserID string, days int) (Publi
 func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, error) {
 	if getReadDB() == nil {
 		return PublicChartData{
-			DailySeries:       []DailySeriesPoint{},
-			HeatmapSeries:     []DailyHeatmapPoint{},
-			ModelDistribution: []ModelDistributionPoint{},
-			Stats:             LogStats{CacheRate: 0},
+			DailySeries:        []DailySeriesPoint{},
+			HeatmapSeries:      []DailyHeatmapPoint{},
+			ModelDistribution:  []ModelDistributionPoint{},
+			APIKeyDistribution: []PublicAPIKeyDistributionPoint{},
+			Stats:              LogStats{CacheRate: 0},
 		}, nil
 	}
 	if days < 1 {
@@ -81,10 +91,11 @@ func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, err
 	filter, ok := rollupIdentityFilter(params)
 	if !ok {
 		return PublicChartData{
-			DailySeries:       []DailySeriesPoint{},
-			HeatmapSeries:     []DailyHeatmapPoint{},
-			ModelDistribution: []ModelDistributionPoint{},
-			Stats:             LogStats{CacheRate: 0},
+			DailySeries:        []DailySeriesPoint{},
+			HeatmapSeries:      []DailyHeatmapPoint{},
+			ModelDistribution:  []ModelDistributionPoint{},
+			APIKeyDistribution: []PublicAPIKeyDistributionPoint{},
+			Stats:              LogStats{CacheRate: 0},
 		}, nil
 	}
 	filter.BucketKind = rollupBucketDay
@@ -139,6 +150,13 @@ func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, err
 	if err != nil {
 		return PublicChartData{}, err
 	}
+	apiKeyDistribution := []PublicAPIKeyDistributionPoint{}
+	if filter.EndUserID != "" {
+		apiKeyDistribution, err = queryRollupAPIKeyDistributionForEndUser(tenantID, filter.EndUserID, days)
+		if err != nil {
+			return PublicChartData{}, err
+		}
+	}
 	if stats.Total > 0 {
 		stats.SuccessRate = float64(successCount) / float64(stats.Total) * 100
 	}
@@ -160,10 +178,11 @@ func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, err
 		stats.TotalSessions = int64(len(totalSessions))
 	}
 	return PublicChartData{
-		DailySeries:       sortedDailySeries(dailyByDate),
-		HeatmapSeries:     sortedHeatmapSeries(heatmapByDate),
-		ModelDistribution: models,
-		Stats:             stats,
+		DailySeries:        sortedDailySeries(dailyByDate),
+		HeatmapSeries:      sortedHeatmapSeries(heatmapByDate),
+		ModelDistribution:  models,
+		APIKeyDistribution: apiKeyDistribution,
+		Stats:              stats,
 	}, nil
 }
 

--- a/internal/usage/usage_rollup_query.go
+++ b/internal/usage/usage_rollup_query.go
@@ -491,3 +491,55 @@ func queryRollupModelDistribution(filter rollupFilter) ([]ModelDistributionPoint
 	}
 	return out, rows.Err()
 }
+
+func queryRollupAPIKeyDistributionForEndUser(tenantID, endUserID string, days int) ([]PublicAPIKeyDistributionPoint, error) {
+	db := getReadDB()
+	if db == nil {
+		return []PublicAPIKeyDistributionPoint{}, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	endUserID = strings.TrimSpace(endUserID)
+	if endUserID == "" {
+		return []PublicAPIKeyDistributionPoint{}, nil
+	}
+	if days < 1 {
+		days = 7
+	}
+
+	rows, err := db.Query(`
+		SELECT api_key_id,
+			COALESCE(SUM(request_count), 0),
+			COALESCE(SUM(total_tokens), 0)
+		FROM usage_rollup_buckets
+		WHERE tenant_id = ?
+		  AND bucket_kind = ?
+		  AND bucket_start >= ?
+		  AND end_user_id = ?
+		  AND trim(api_key_id) != ''
+		GROUP BY api_key_id
+		ORDER BY 2 DESC, api_key_id
+	`, tenantID, rollupBucketDay, dayBucketFromDays(days), endUserID)
+	if err != nil {
+		return nil, fmt.Errorf("usage: public rollup apikey distribution: %w", err)
+	}
+	defer rows.Close()
+
+	currentByID := currentAPIKeyRowsByIDForTenant(tenantID)
+	out := make([]PublicAPIKeyDistributionPoint, 0)
+	for rows.Next() {
+		var point PublicAPIKeyDistributionPoint
+		if err := rows.Scan(&point.APIKeyID, &point.Requests, &point.Tokens); err != nil {
+			return nil, fmt.Errorf("usage: public rollup apikey distribution scan: %w", err)
+		}
+		point.APIKeyID = strings.TrimSpace(point.APIKeyID)
+		if row, ok := currentByID[point.APIKeyID]; ok {
+			// Public charts use the key's own current name, never the owner display name.
+			point.Name = strings.TrimSpace(row.Name)
+		}
+		out = append(out, point)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- Add public-safe `api_key_distribution` to portal `/usage/chart-data` (stable `api_key_id` + key own name + requests/tokens only).
- Aggregate via day rollup buckets filtered by `end_user_id`, grouped by `api_key_id` (no reuse of admin end-user collapse query).
- Tests cover multi-key split, isolation, rotate/rename stability, empty arrays, and secret non-leakage.

## Plan
- `docs/plan/078-portal-key-usage-charts-menu-rename-20260722.md` (root governance repo)

## Test plan
- [x] `go test ./internal/usage -run 'TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate' -count=1`
- [x] `go test ./internal/api/handlers/management -run 'TestGetPublicUsageChartDataReturnsPortalKeyDistributionWithoutSecrets' -count=1`
- [x] `./scripts/ci-pr.sh` (reported by implementer)
- [ ] GHA required `build` check

Merge first before codeProxy consumer PR.