### PR TITLE
feat(identity): password policy + auto initial password

### DIFF
--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -401,12 +401,18 @@ func (h *Handler) PostUser(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	user, err := h.identity().CreateUser(c.Request.Context(), principal, principal.EffectiveTenant.ID, body.Username, body.DisplayName, body.Password, body.RoleIDs)
+	user, initialPassword, err := h.identity().CreateUser(c.Request.Context(), principal, principal.EffectiveTenant.ID, body.Username, body.DisplayName, body.Password, body.RoleIDs)
 	if err != nil {
 		identityError(c, err)
 		return
 	}
-	c.JSON(http.StatusCreated, user)
+	c.JSON(http.StatusCreated, struct {
+		identity.User
+		InitialPassword string `json:"initial_password,omitempty"`
+	}{
+		User:            user,
+		InitialPassword: initialPassword,
+	})
 }
 
 func (h *Handler) PostUserResetPassword(c *gin.Context) {

--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -150,7 +150,7 @@ func TestPostUserBindsSnakeCaseDisplayName(t *testing.T) {
 		h.PostUser(c)
 	})
 
-	body := []byte(`{"username":"snake-case-user","display_name":"Snake Case User","password":"snake-case-password-123","role_ids":[]}`)
+	body := []byte(`{"username":"snake-case-user","display_name":"Snake Case User","password":"Snake-Case-Password-123!","role_ids":[]}`)
 	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v0/management/users", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -165,6 +165,99 @@ func TestPostUserBindsSnakeCaseDisplayName(t *testing.T) {
 	}
 	if user.DisplayName != "Snake Case User" {
 		t.Fatalf("display_name = %q, want %q", user.DisplayName, "Snake Case User")
+	}
+}
+
+func TestPostUserBlankPasswordReturnsInitialPassword(t *testing.T) {
+	ctx := context.Background()
+	service := newSQLiteIdentityTestService(t)
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	principal := identity.Principal{
+		Kind:            "user",
+		User:            identity.User{ID: identity.SystemUserID, TenantID: identity.SystemTenantID},
+		EffectiveTenant: identity.Tenant{ID: identity.SystemTenantID},
+		PlatformAdmin:   true,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/v0/management/users", func(c *gin.Context) {
+		c.Set(managementPrincipalKey, principal)
+		h.PostUser(c)
+	})
+
+	body := []byte(`{"username":"generated-admin-user","display_name":"Generated Admin User","password":"   ","role_ids":[]}`)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v0/management/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var response struct {
+		ID              string `json:"id"`
+		DisplayName     string `json:"display_name"`
+		InitialPassword string `json:"initial_password"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	if response.ID == "" {
+		t.Fatal("response id is empty")
+	}
+	if response.DisplayName != "Generated Admin User" {
+		t.Fatalf("display_name = %q, want %q", response.DisplayName, "Generated Admin User")
+	}
+	if response.InitialPassword == "" {
+		t.Fatalf("initial_password missing; body=%s", rec.Body.String())
+	}
+	if _, err := identity.HashPassword(response.InitialPassword); err != nil {
+		t.Fatalf("initial_password does not satisfy policy: %v", err)
+	}
+}
+
+func TestPostUserManualPasswordOmitsInitialPassword(t *testing.T) {
+	ctx := context.Background()
+	service := newSQLiteIdentityTestService(t)
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	principal := identity.Principal{
+		Kind:            "user",
+		User:            identity.User{ID: identity.SystemUserID, TenantID: identity.SystemTenantID},
+		EffectiveTenant: identity.Tenant{ID: identity.SystemTenantID},
+		PlatformAdmin:   true,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/v0/management/users", func(c *gin.Context) {
+		c.Set(managementPrincipalKey, principal)
+		h.PostUser(c)
+	})
+
+	body := []byte(`{"username":"manual-admin-user","display_name":"Manual Admin User","password":"Manual-Password-123!","role_ids":[]}`)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v0/management/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var response map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	if _, ok := response["initial_password"]; ok {
+		t.Fatalf("initial_password should be omitted for manual password; body=%s", rec.Body.String())
 	}
 }
 
@@ -227,7 +320,7 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 	})
 
 	service := identity.NewService(db)
-	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
 		t.Fatal(err)
 	}
 	// Pin the service on the handler so Middleware does not depend on process-global Default().
@@ -281,14 +374,14 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 
 	readToken := seedPlatformLogUser(logUserFixture{
 		username:    "log-reader",
-		password:    "reader-password-123",
+		password:    "Reader-Password-123!",
 		userID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 		roleID:      "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		permissions: []string{"system.logs.read"},
 	})
 	deleteToken := seedPlatformLogUser(logUserFixture{
 		username:    "log-deleter",
-		password:    "deleter-password-123",
+		password:    "Deleter-Password-123!",
 		userID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2",
 		roleID:      "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		permissions: []string{"system.logs.read", "system.logs.delete"},

--- a/internal/identity/password.go
+++ b/internal/identity/password.go
@@ -1,0 +1,96 @@
+package identity
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	generatedPasswordLength   = 16
+	passwordUpperCharacters   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	passwordLowerCharacters   = "abcdefghijklmnopqrstuvwxyz"
+	passwordDigitCharacters   = "0123456789"
+	passwordSpecialCharacters = "!@#$%^&*()-_=+[]{}:,.?"
+	passwordAllCharacters     = passwordUpperCharacters + passwordLowerCharacters + passwordDigitCharacters + passwordSpecialCharacters
+)
+
+func HashPassword(password string) (string, error) {
+	if len(password) < 12 {
+		return "", fmt.Errorf("%w: password must contain at least 12 characters", ErrValidation)
+	}
+
+	hasUpper := false
+	hasLower := false
+	hasSpecial := false
+	for i := 0; i < len(password); i++ {
+		switch c := password[i]; {
+		case c >= 'A' && c <= 'Z':
+			hasUpper = true
+		case c >= 'a' && c <= 'z':
+			hasLower = true
+		case c >= '0' && c <= '9':
+		default:
+			hasSpecial = true
+		}
+	}
+	if !hasUpper {
+		return "", fmt.Errorf("%w: password must contain at least one uppercase letter", ErrValidation)
+	}
+	if !hasLower {
+		return "", fmt.Errorf("%w: password must contain at least one lowercase letter", ErrValidation)
+	}
+	if !hasSpecial {
+		return "", fmt.Errorf("%w: password must contain at least one non-alphanumeric character", ErrValidation)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	return string(hash), err
+}
+
+func randomPassword() (string, error) {
+	password := make([]byte, 0, generatedPasswordLength)
+	for _, charset := range []string{passwordUpperCharacters, passwordLowerCharacters, passwordDigitCharacters, passwordSpecialCharacters} {
+		ch, err := randomPasswordCharacter(charset)
+		if err != nil {
+			return "", err
+		}
+		password = append(password, ch)
+	}
+	for len(password) < generatedPasswordLength {
+		ch, err := randomPasswordCharacter(passwordAllCharacters)
+		if err != nil {
+			return "", err
+		}
+		password = append(password, ch)
+	}
+	if err := shufflePasswordCharacters(password); err != nil {
+		return "", err
+	}
+	return string(password), nil
+}
+
+func randomPasswordCharacter(charset string) (byte, error) {
+	if charset == "" {
+		return 0, fmt.Errorf("identity: empty password charset")
+	}
+	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+	if err != nil {
+		return 0, err
+	}
+	return charset[idx.Int64()], nil
+}
+
+func shufflePasswordCharacters(password []byte) error {
+	for i := len(password) - 1; i > 0; i-- {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return err
+		}
+		j := int(idx.Int64())
+		password[i], password[j] = password[j], password[i]
+	}
+	return nil
+}

--- a/internal/identity/postgres_test.go
+++ b/internal/identity/postgres_test.go
@@ -34,7 +34,7 @@ func TestPostgresBootstrapFreshAdminRequiresPassword(t *testing.T) {
 	if !errors.Is(err, ErrValidation) {
 		t.Errorf("Bootstrap() error = %v, want ErrValidation", err)
 	}
-	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
 		t.Fatalf("restore shared postgres identity fixture: %v", err)
 	}
 }
@@ -55,7 +55,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	service := NewService(db)
-	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
 		t.Fatal(err)
 	}
 	if err = service.Bootstrap(ctx, ""); err != nil {
@@ -75,7 +75,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if len(systemRoles) != 1 || systemRoles[0].ID != SystemRoleID || systemRoles[0].Name != "Administrator" || !systemRoles[0].SystemProtected {
 		t.Fatalf("system roles=%+v", systemRoles)
 	}
-	login, err := service.Login(ctx, "admin", "bootstrap-password-123", false, "test")
+	login, err := service.Login(ctx, "admin", "Bootstrap-Password-123!", false, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tenant, admin, err := service.CreateTenant(ctx, principal, CreateTenantInput{Name: "Tenant A", ExpiresAt: time.Now().Add(time.Hour), AdminUsername: "tenant-admin", AdminDisplayName: "Tenant Admin", AdminPassword: "tenant-password-123"})
+	tenant, admin, err := service.CreateTenant(ctx, principal, CreateTenantInput{Name: "Tenant A", ExpiresAt: time.Now().Add(time.Hour), AdminUsername: "tenant-admin", AdminDisplayName: "Tenant Admin", AdminPassword: "Tenant-Password-123!"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,14 +99,14 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if !strings.HasPrefix(tenant.Slug, "tenant-") || len(tenant.Slug) != len("tenant-")+32 {
 		t.Fatalf("generated tenant slug = %q", tenant.Slug)
 	}
-	tenantAdminLogin, err := service.Login(ctx, "tenant-admin", "tenant-password-123", false, "test")
+	tenantAdminLogin, err := service.Login(ctx, "tenant-admin", "Tenant-Password-123!", false, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if containsMenu(tenantAdminLogin.Principal.Menus, MenuManagementCode) || !containsMenu(tenantAdminLogin.Principal.Menus, "governance.users") {
 		t.Fatalf("tenant admin menus=%+v", tenantAdminLogin.Principal.Menus)
 	}
-	if err = service.ChangePassword(ctx, tenantAdminLogin.Principal, "tenant-password-123", "tenant-password-456"); err != nil {
+	if err = service.ChangePassword(ctx, tenantAdminLogin.Principal, "Tenant-Password-123!", "Tenant-Password-456!"); err != nil {
 		t.Fatal(err)
 	}
 	tenantAdmin, err := service.Authenticate(ctx, tenantAdminLogin.AccessToken, "")
@@ -139,25 +139,25 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if !strings.HasPrefix(limitedRole.Code, "role_") || len(limitedRole.Code) != len("role_")+32 {
 		t.Fatalf("generated role code = %q", limitedRole.Code)
 	}
-	limitedUser, err := service.CreateUser(ctx, tenantAdmin, tenant.ID, "limited-manager", "Limited Manager", "limited-password-123", []string{limitedRole.ID})
+	limitedUser, _, err := service.CreateUser(ctx, tenantAdmin, tenant.ID, "limited-manager", "Limited Manager", "Limited-Password-123!", []string{limitedRole.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
-	limitedLogin, err := service.Login(ctx, "limited-manager", "limited-password-123", false, "test")
+	limitedLogin, err := service.Login(ctx, "limited-manager", "Limited-Password-123!", false, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = service.ChangePassword(ctx, limitedLogin.Principal, "limited-password-123", "limited-password-456"); err != nil {
+	if err = service.ChangePassword(ctx, limitedLogin.Principal, "Limited-Password-123!", "Limited-Password-456!"); err != nil {
 		t.Fatal(err)
 	}
 	limitedPrincipal, err := service.Authenticate(ctx, limitedLogin.AccessToken, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = service.CreateUser(ctx, limitedPrincipal, tenant.ID, "escalated-user", "Escalated User", "escalated-password-123", []string{tenantAdminRoleID}); !errors.Is(err, ErrPermissionDenied) {
+	if _, _, err = service.CreateUser(ctx, limitedPrincipal, tenant.ID, "escalated-user", "Escalated User", "Escalated-Password-123!", []string{tenantAdminRoleID}); !errors.Is(err, ErrPermissionDenied) {
 		t.Fatalf("create user with non-delegable role err=%v", err)
 	}
-	rolelessUser, err := service.CreateUser(ctx, limitedPrincipal, tenant.ID, "roleless-user", "Roleless User", "roleless-password-123", nil)
+	rolelessUser, _, err := service.CreateUser(ctx, limitedPrincipal, tenant.ID, "roleless-user", "Roleless User", "Roleless-Password-123!", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if _, err = service.UpdateTenant(ctx, principal, tenant.ID, "active", &past, tenant.Version); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = service.Login(ctx, "tenant-admin", "tenant-password-456", false, "test"); !errors.Is(err, ErrTenantExpired) {
+	if _, err = service.Login(ctx, "tenant-admin", "Tenant-Password-456!", false, "test"); !errors.Is(err, ErrTenantExpired) {
 		t.Fatalf("expired login err=%v", err)
 	}
 }

--- a/internal/identity/service.go
+++ b/internal/identity/service.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"sort"
 	"strings"
 	"sync"
@@ -33,7 +34,15 @@ var (
 	ErrValidation         = errors.New("validation failed")
 )
 
-const dummyPasswordHash = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7N5x5V7e"
+const (
+	dummyPasswordHash         = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7N5x5V7e"
+	generatedPasswordLength   = 16
+	passwordUpperCharacters   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	passwordLowerCharacters   = "abcdefghijklmnopqrstuvwxyz"
+	passwordDigitCharacters   = "0123456789"
+	passwordSpecialCharacters = "!@#$%^&*()-_=+[]{}:,.?"
+	passwordAllCharacters     = passwordUpperCharacters + passwordLowerCharacters + passwordDigitCharacters + passwordSpecialCharacters
+)
 
 type Service struct {
 	db *sql.DB
@@ -66,8 +75,78 @@ func HashPassword(password string) (string, error) {
 	if len(password) < 12 {
 		return "", fmt.Errorf("%w: password must contain at least 12 characters", ErrValidation)
 	}
+
+	hasUpper := false
+	hasLower := false
+	hasSpecial := false
+	for i := 0; i < len(password); i++ {
+		switch c := password[i]; {
+		case c >= 'A' && c <= 'Z':
+			hasUpper = true
+		case c >= 'a' && c <= 'z':
+			hasLower = true
+		case c >= '0' && c <= '9':
+		default:
+			hasSpecial = true
+		}
+	}
+	if !hasUpper {
+		return "", fmt.Errorf("%w: password must contain at least one uppercase letter", ErrValidation)
+	}
+	if !hasLower {
+		return "", fmt.Errorf("%w: password must contain at least one lowercase letter", ErrValidation)
+	}
+	if !hasSpecial {
+		return "", fmt.Errorf("%w: password must contain at least one non-alphanumeric character", ErrValidation)
+	}
+
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	return string(hash), err
+}
+
+func randomPassword() (string, error) {
+	password := make([]byte, 0, generatedPasswordLength)
+	for _, charset := range []string{passwordUpperCharacters, passwordLowerCharacters, passwordDigitCharacters, passwordSpecialCharacters} {
+		ch, err := randomPasswordCharacter(charset)
+		if err != nil {
+			return "", err
+		}
+		password = append(password, ch)
+	}
+	for len(password) < generatedPasswordLength {
+		ch, err := randomPasswordCharacter(passwordAllCharacters)
+		if err != nil {
+			return "", err
+		}
+		password = append(password, ch)
+	}
+	if err := shufflePasswordCharacters(password); err != nil {
+		return "", err
+	}
+	return string(password), nil
+}
+
+func randomPasswordCharacter(charset string) (byte, error) {
+	if charset == "" {
+		return 0, errors.New("identity: empty password charset")
+	}
+	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+	if err != nil {
+		return 0, err
+	}
+	return charset[idx.Int64()], nil
+}
+
+func shufflePasswordCharacters(password []byte) error {
+	for i := len(password) - 1; i > 0; i-- {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return err
+		}
+		j := int(idx.Int64())
+		password[i], password[j] = password[j], password[i]
+	}
+	return nil
 }
 
 func generatedIdentifier(prefix string) string {
@@ -893,56 +972,65 @@ func (s *Service) ListUsers(ctx context.Context, tenantID string) ([]User, error
 	return users, rows.Err()
 }
 
-func (s *Service) CreateUser(ctx context.Context, actor Principal, tenantID, username, displayName, password string, roleIDs []string) (User, error) {
+func (s *Service) CreateUser(ctx context.Context, actor Principal, tenantID, username, displayName, password string, roleIDs []string) (User, string, error) {
 	if !actor.Has("tenant.users.create") && !actor.Has("platform.users.manage") {
-		return User{}, ErrPermissionDenied
+		return User{}, "", ErrPermissionDenied
 	}
 	if err := ensureActorTenantScope(actor, tenantID); err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	if len(roleIDs) > 0 && !actor.Has("tenant.users.assign_roles") && !actor.Has("platform.users.manage") {
-		return User{}, ErrPermissionDenied
+		return User{}, "", ErrPermissionDenied
 	}
 	normalizedUsername := NormalizeUsername(username)
 	displayName = strings.TrimSpace(displayName)
 	if !validIdentifier(normalizedUsername, 128, true) || displayName == "" || len(displayName) > 128 {
-		return User{}, fmt.Errorf("%w: invalid user input", ErrValidation)
+		return User{}, "", fmt.Errorf("%w: invalid user input", ErrValidation)
+	}
+	generatedPassword := ""
+	if strings.TrimSpace(password) == "" {
+		var err error
+		generatedPassword, err = randomPassword()
+		if err != nil {
+			return User{}, "", err
+		}
+		password = generatedPassword
 	}
 	hash, err := HashPassword(password)
 	if err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	userID := uuid.NewString()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err = tx.ExecContext(ctx, `INSERT INTO users (id, tenant_id, username, username_normalized, display_name, password_hash, must_change_password, created_by) VALUES (?, ?, ?, ?, ?, ?, true, ?)`, userID, tenantID, strings.TrimSpace(username), normalizedUsername, displayName, hash, actor.User.ID); err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	if err = ensureRolesDelegable(ctx, tx, actor, tenantID, roleIDs); err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	for _, roleID := range roleIDs {
 		if _, err = tx.ExecContext(ctx, `INSERT INTO user_roles (user_id, role_id, created_by) VALUES (?, ?, ?)`, userID, roleID, actor.User.ID); err != nil {
-			return User{}, err
+			return User{}, "", err
 		}
 	}
 	if err = tx.Commit(); err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	s.RecordAudit(ctx, AuditEvent{TenantID: tenantID, ActorKind: actor.Kind, ActorUserID: actor.User.ID, ActorSessionID: actor.SessionID, Action: "user.create", ResourceType: "user", ResourceID: userID, Result: "success"})
 	users, err := s.ListUsers(ctx, tenantID)
 	if err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	for _, user := range users {
 		if user.ID == userID {
-			return user, nil
+			return user, generatedPassword, nil
 		}
 	}
-	return User{}, sql.ErrNoRows
+	return User{}, "", sql.ErrNoRows
 }
 
 func (s *Service) ResetPassword(ctx context.Context, actor Principal, tenantID, userID, password string) error {

--- a/internal/identity/service.go
+++ b/internal/identity/service.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"sort"
 	"strings"
 	"sync"
@@ -34,15 +33,7 @@ var (
 	ErrValidation         = errors.New("validation failed")
 )
 
-const (
-	dummyPasswordHash         = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7N5x5V7e"
-	generatedPasswordLength   = 16
-	passwordUpperCharacters   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	passwordLowerCharacters   = "abcdefghijklmnopqrstuvwxyz"
-	passwordDigitCharacters   = "0123456789"
-	passwordSpecialCharacters = "!@#$%^&*()-_=+[]{}:,.?"
-	passwordAllCharacters     = passwordUpperCharacters + passwordLowerCharacters + passwordDigitCharacters + passwordSpecialCharacters
-)
+const dummyPasswordHash = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7N5x5V7e"
 
 type Service struct {
 	db *sql.DB
@@ -69,84 +60,6 @@ func NewService(db *sql.DB) *Service { return &Service{db: db} }
 
 func NormalizeUsername(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
-}
-
-func HashPassword(password string) (string, error) {
-	if len(password) < 12 {
-		return "", fmt.Errorf("%w: password must contain at least 12 characters", ErrValidation)
-	}
-
-	hasUpper := false
-	hasLower := false
-	hasSpecial := false
-	for i := 0; i < len(password); i++ {
-		switch c := password[i]; {
-		case c >= 'A' && c <= 'Z':
-			hasUpper = true
-		case c >= 'a' && c <= 'z':
-			hasLower = true
-		case c >= '0' && c <= '9':
-		default:
-			hasSpecial = true
-		}
-	}
-	if !hasUpper {
-		return "", fmt.Errorf("%w: password must contain at least one uppercase letter", ErrValidation)
-	}
-	if !hasLower {
-		return "", fmt.Errorf("%w: password must contain at least one lowercase letter", ErrValidation)
-	}
-	if !hasSpecial {
-		return "", fmt.Errorf("%w: password must contain at least one non-alphanumeric character", ErrValidation)
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	return string(hash), err
-}
-
-func randomPassword() (string, error) {
-	password := make([]byte, 0, generatedPasswordLength)
-	for _, charset := range []string{passwordUpperCharacters, passwordLowerCharacters, passwordDigitCharacters, passwordSpecialCharacters} {
-		ch, err := randomPasswordCharacter(charset)
-		if err != nil {
-			return "", err
-		}
-		password = append(password, ch)
-	}
-	for len(password) < generatedPasswordLength {
-		ch, err := randomPasswordCharacter(passwordAllCharacters)
-		if err != nil {
-			return "", err
-		}
-		password = append(password, ch)
-	}
-	if err := shufflePasswordCharacters(password); err != nil {
-		return "", err
-	}
-	return string(password), nil
-}
-
-func randomPasswordCharacter(charset string) (byte, error) {
-	if charset == "" {
-		return 0, errors.New("identity: empty password charset")
-	}
-	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
-	if err != nil {
-		return 0, err
-	}
-	return charset[idx.Int64()], nil
-}
-
-func shufflePasswordCharacters(password []byte) error {
-	for i := len(password) - 1; i > 0; i-- {
-		idx, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
-		if err != nil {
-			return err
-		}
-		j := int(idx.Int64())
-		password[i], password[j] = password[j], password[i]
-	}
-	return nil
 }
 
 func generatedIdentifier(prefix string) string {

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -1,10 +1,16 @@
 package identity
 
 import (
+	"context"
+	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	_ "modernc.org/sqlite"
 )
 
 func TestNormalizeUsername(t *testing.T) {
@@ -17,9 +23,48 @@ func TestHashPasswordPolicyAndVerification(t *testing.T) {
 	if _, err := HashPassword("too-short"); err == nil {
 		t.Fatal("expected short password to be rejected")
 	}
-	hash, err := HashPassword("correct-horse-battery-staple")
+	if _, err := HashPassword("alllowercase!"); err == nil {
+		t.Fatal("expected password without uppercase and sufficient complexity to be rejected")
+	}
+	hash, err := HashPassword("Correct-Horse-1!")
 	if err != nil || hash == "" {
 		t.Fatalf("HashPassword() hash=%q err=%v", hash, err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte("Correct-Horse-1!")); err != nil {
+		t.Fatalf("CompareHashAndPassword() err=%v", err)
+	}
+}
+
+func TestCreateUserGeneratesInitialPasswordWhenBlank(t *testing.T) {
+	ctx := context.Background()
+	service, db := newSQLiteCreateUserTestService(t)
+	principal := Principal{
+		PlatformAdmin:   true,
+		Kind:            "user",
+		User:            User{ID: SystemUserID, TenantID: SystemTenantID},
+		EffectiveTenant: Tenant{ID: SystemTenantID},
+	}
+
+	user, initialPassword, err := service.CreateUser(ctx, principal, SystemTenantID, "generated-user", "Generated User", "   ", nil)
+	if err != nil {
+		t.Fatalf("CreateUser() err=%v", err)
+	}
+	if user.ID == "" {
+		t.Fatal("CreateUser() returned empty user id")
+	}
+	if initialPassword == "" {
+		t.Fatal("CreateUser() did not return generated password")
+	}
+	if _, err := HashPassword(initialPassword); err != nil {
+		t.Fatalf("generated password does not satisfy policy: %v", err)
+	}
+
+	var passwordHash string
+	if err := db.QueryRowContext(ctx, `SELECT password_hash FROM users WHERE id = ?`, user.ID).Scan(&passwordHash); err != nil {
+		t.Fatalf("query generated user hash: %v", err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(initialPassword)); err != nil {
+		t.Fatalf("generated password does not verify against stored hash: %v", err)
 	}
 }
 
@@ -199,6 +244,37 @@ func TestMenuCodeForPermission(t *testing.T) {
 	if len(tests) != 0 {
 		t.Fatalf("permissions missing from catalog: %v", tests)
 	}
+}
+
+func newSQLiteCreateUserTestService(t *testing.T) (*Service, *sql.DB) {
+	t.Helper()
+	dsn := fmt.Sprintf("file:identity_create_user_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(4)
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("close sqlite identity db: %v", closeErr)
+		}
+	})
+	for _, statement := range []string{
+		`CREATE TABLE users (
+			id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, username TEXT NOT NULL, username_normalized TEXT NOT NULL,
+			display_name TEXT NOT NULL, password_hash TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+			must_change_password BOOLEAN NOT NULL DEFAULT false, last_login_at TIMESTAMP NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			version INTEGER NOT NULL DEFAULT 1, created_by TEXT
+		)`,
+		`CREATE TABLE roles (id TEXT PRIMARY KEY, code TEXT NOT NULL, name TEXT NOT NULL)`,
+		`CREATE TABLE user_roles (user_id TEXT NOT NULL, role_id TEXT NOT NULL, created_by TEXT)`,
+	} {
+		if _, err = db.Exec(statement); err != nil {
+			t.Fatalf("create sqlite identity schema: %v", err)
+		}
+	}
+	return NewService(db), db
 }
 
 func ptrTime(value time.Time) *time.Time { return &value }


### PR DESCRIPTION
## Summary
- Strengthen `HashPassword`: ≥12 chars, uppercase, lowercase, non-alphanumeric
- `CreateUser` blank password → server generates 16-char password; returns `initial_password` only on create
- `POST /users` response embeds optional `initial_password` (list/get never include it)
- Update identity tests / fixtures for new policy

Pairs with codeProxy PR for governance users form pilot (077).

## Test plan
- [x] `go test ./internal/identity/ -count=1`
- [x] `go test ./internal/api/handlers/management/ -count=1 -run 'User|Password|Identity|Hash|Create'`