### PR TITLE
fix(identity): 禁止修改或删除租户管理员

### DIFF
--- a/internal/identity/postgres_test.go
+++ b/internal/identity/postgres_test.go
@@ -200,6 +200,106 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	}
 }
 
+func TestPostgresTenantAdminUserProtection(t *testing.T) {
+	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
+	ctx := context.Background()
+	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err = db.Exec(`TRUNCATE audit_logs,user_sessions,user_roles,role_permissions,menus,users,roles,permissions,tenants CASCADE`); err != nil {
+		t.Fatal(err)
+	}
+
+	service := NewService(db)
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
+		t.Fatal(err)
+	}
+	login, err := service.Login(ctx, "admin", "Bootstrap-Password-123!", false, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	platformAdmin, err := service.Authenticate(ctx, login.AccessToken, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenant, _, err := service.CreateTenant(ctx, platformAdmin, CreateTenantInput{
+		Name:             "Protected Tenant",
+		ExpiresAt:        time.Now().Add(time.Hour),
+		AdminUsername:    "protected-tenant-admin",
+		AdminDisplayName: "Protected Tenant Admin",
+		AdminPassword:    "Tenant-Password-123!",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantLogin, err := service.Login(ctx, "protected-tenant-admin", "Tenant-Password-123!", false, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantAdmin, err := service.Authenticate(ctx, tenantLogin.AccessToken, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	roles, err := service.ListRoles(ctx, tenant.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tenantAdminRole Role
+	for _, role := range roles {
+		if role.Code == "tenant_admin" {
+			tenantAdminRole = role
+			break
+		}
+	}
+	if tenantAdminRole.ID == "" {
+		t.Fatal("tenant admin role not found")
+	}
+	customRole, err := service.CreateRole(ctx, tenantAdmin, tenant.ID, "Custom role", "", []string{"tenant.users.read"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createUser := func(username string, roleIDs []string) User {
+		t.Helper()
+		user, _, createErr := service.CreateUser(ctx, tenantAdmin, tenant.ID, username, username, "User-Password-123!", roleIDs)
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		return user
+	}
+	deleteProtectedAdmin := createUser("delete-protected-admin", []string{tenantAdminRole.ID})
+	rolesProtectedAdmin := createUser("roles-protected-admin", []string{tenantAdminRole.ID})
+	membershipProtectedAdmin := createUser("membership-protected-admin", []string{tenantAdminRole.ID, customRole.ID})
+	assignableUser := createUser("assignable-user", nil)
+	deletableUser := createUser("deletable-user", nil)
+
+	if err = service.AssignUserRoles(ctx, tenantAdmin, tenant.ID, assignableUser.ID, []string{customRole.ID}); err != nil {
+		t.Errorf("assign roles to non-admin user: %v", err)
+	}
+	if err = service.DeleteUser(ctx, tenantAdmin, tenant.ID, deletableUser.ID); err != nil {
+		t.Errorf("delete non-admin user: %v", err)
+	}
+	if err = service.DeleteUser(ctx, tenantAdmin, tenant.ID, deleteProtectedAdmin.ID); !errors.Is(err, ErrProtectedResource) {
+		t.Errorf("delete tenant admin err=%v, want ErrProtectedResource", err)
+	}
+	if err = service.AssignUserRoles(ctx, tenantAdmin, tenant.ID, rolesProtectedAdmin.ID, []string{customRole.ID}); !errors.Is(err, ErrProtectedResource) {
+		t.Errorf("assign tenant admin roles err=%v, want ErrProtectedResource", err)
+	}
+	if err = service.ReplaceRoleUsers(ctx, tenantAdmin, tenant.ID, customRole.ID, []string{assignableUser.ID}, customRole.Version); !errors.Is(err, ErrProtectedResource) {
+		t.Errorf("remove custom role from tenant admin err=%v, want ErrProtectedResource", err)
+	}
+	if err = service.ReplaceRoleUsers(ctx, tenantAdmin, tenant.ID, tenantAdminRole.ID, []string{tenantAdmin.User.ID, membershipProtectedAdmin.ID}, tenantAdminRole.Version); !errors.Is(err, ErrProtectedResource) {
+		t.Errorf("replace tenant admin membership err=%v, want ErrProtectedResource", err)
+	}
+}
+
 func containsMenu(menus []Menu, code string) bool {
 	for _, menu := range menus {
 		if menu.Code == code {

--- a/internal/identity/service_admin.go
+++ b/internal/identity/service_admin.go
@@ -274,28 +274,11 @@ func (s *Service) AssignUserRoles(ctx context.Context, actor Principal, tenantID
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
-	var userTenant string
-	if err = tx.QueryRowContext(ctx, `SELECT tenant_id FROM users WHERE id=? FOR UPDATE`, userID).Scan(&userTenant); err != nil {
+	if err = ensureNotTenantAdmin(ctx, tx, tenantID, userID); err != nil {
 		return err
-	}
-	if userTenant != tenantID {
-		return ErrTenantScope
 	}
 	if err = ensureRolesDelegable(ctx, tx, actor, tenantID, roleIDs); err != nil {
 		return err
-	}
-	keepsAdmin := false
-	for _, roleID := range roleIDs {
-		var protected bool
-		if err = tx.QueryRowContext(ctx, `SELECT system_protected FROM roles WHERE id=? AND tenant_id=?`, roleID, tenantID).Scan(&protected); err != nil {
-			return err
-		}
-		keepsAdmin = keepsAdmin || protected
-	}
-	if !keepsAdmin {
-		if err = ensureNotLastTenantAdmin(ctx, tx, tenantID, userID); err != nil {
-			return err
-		}
 	}
 	if _, err = tx.ExecContext(ctx, `DELETE FROM user_roles WHERE user_id=?`, userID); err != nil {
 		return err
@@ -341,7 +324,7 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 	if currentVersion != version {
 		return ErrVersionConflict
 	}
-	if roleID == SystemRoleID {
+	if protected {
 		return ErrProtectedResource
 	}
 	if err = ensureRolesDelegable(ctx, tx, actor, tenantID, []string{roleID}); err != nil {
@@ -349,7 +332,6 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 	}
 
 	selected := make(map[string]struct{}, len(userIDs))
-	activeSelected := 0
 	for _, userID := range userIDs {
 		userID = strings.TrimSpace(userID)
 		if userID == "" {
@@ -361,22 +343,17 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 		if _, exists := selected[userID]; exists {
 			continue
 		}
-		var userTenant, status string
-		if err = tx.QueryRowContext(ctx, `SELECT tenant_id,status FROM users WHERE id=?`, userID).Scan(&userTenant, &status); err != nil {
+		var userTenant string
+		if err = tx.QueryRowContext(ctx, `SELECT tenant_id FROM users WHERE id=?`, userID).Scan(&userTenant); err != nil {
 			return err
 		}
 		if userTenant != tenantID {
 			return ErrTenantScope
 		}
 		selected[userID] = struct{}{}
-		if status == "active" {
-			activeSelected++
-		}
-	}
-	if protected && activeSelected == 0 {
-		return ErrProtectedResource
 	}
 
+	current := make(map[string]struct{})
 	affected := make(map[string]struct{}, len(selected))
 	rows, err := tx.QueryContext(ctx, `SELECT user_id FROM user_roles WHERE role_id=?`, roleID)
 	if err != nil {
@@ -388,6 +365,7 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 			_ = rows.Close()
 			return err
 		}
+		current[userID] = struct{}{}
 		affected[userID] = struct{}{}
 	}
 	if err = rows.Close(); err != nil {
@@ -396,8 +374,22 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 	if err = rows.Err(); err != nil {
 		return err
 	}
+	for userID := range current {
+		if _, remainsAssigned := selected[userID]; remainsAssigned {
+			continue
+		}
+		if err = ensureNotTenantAdmin(ctx, tx, tenantID, userID); err != nil {
+			return err
+		}
+	}
 	for userID := range selected {
 		affected[userID] = struct{}{}
+		if _, alreadyAssigned := current[userID]; alreadyAssigned {
+			continue
+		}
+		if err = ensureNotTenantAdmin(ctx, tx, tenantID, userID); err != nil {
+			return err
+		}
 	}
 
 	if _, err = tx.ExecContext(ctx, `DELETE FROM user_roles WHERE role_id=?`, roleID); err != nil {
@@ -490,7 +482,7 @@ func (s *Service) DeleteUser(ctx context.Context, actor Principal, tenantID, use
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
-	if err = ensureNotLastTenantAdmin(ctx, tx, tenantID, userID); err != nil {
+	if err = ensureNotTenantAdmin(ctx, tx, tenantID, userID); err != nil {
 		return err
 	}
 	res, err := tx.ExecContext(ctx, `DELETE FROM users WHERE id=? AND tenant_id=?`, userID, tenantID)
@@ -570,6 +562,24 @@ func (s *Service) DeleteTenant(ctx context.Context, actor Principal, tenantID st
 	}
 	s.RecordAudit(ctx, AuditEvent{TenantID: tenantID, ActorKind: actor.Kind, ActorUserID: actor.User.ID, ActorSessionID: actor.SessionID, Action: "tenant.disable", ResourceType: "tenant", ResourceID: tenantID, Result: "success"})
 	return s.GetTenant(ctx, tenantID)
+}
+
+func ensureNotTenantAdmin(ctx context.Context, tx *sql.Tx, tenantID, userID string) error {
+	var userTenant string
+	if err := tx.QueryRowContext(ctx, `SELECT tenant_id FROM users WHERE id=? FOR UPDATE`, userID).Scan(&userTenant); err != nil {
+		return err
+	}
+	if userTenant != tenantID {
+		return ErrTenantScope
+	}
+	var tenantAdmin bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM user_roles ur JOIN roles r ON r.id=ur.role_id WHERE ur.user_id=? AND r.tenant_id=? AND r.code='tenant_admin' AND r.scope='tenant' AND r.system_protected=true)`, userID, tenantID).Scan(&tenantAdmin); err != nil {
+		return err
+	}
+	if tenantAdmin {
+		return ErrProtectedResource
+	}
+	return nil
 }
 
 func ensureNotLastTenantAdmin(ctx context.Context, tx *sql.Tx, tenantID, userID string) error {


### PR DESCRIPTION
## 变更

- `AssignUserRoles` 对当前持有内置 `tenant_admin` 角色的目标账号始终返回 `ErrProtectedResource`。
- `DeleteUser` 对任意租户管理员账号始终返回 `ErrProtectedResource`，不再仅保护最后一个活跃管理员。
- `ReplaceRoleUsers` 禁止批量替换 system-protected 角色成员，并阻止通过自定义角色成员替换增删租户管理员的角色关系。
- 保留 `UpdateUserStatus` 的既有 last-active-tenant-admin 保护逻辑，未扩大到状态或密码操作。
- 增加 PostgreSQL service 回归测试，覆盖多管理员删除、角色替换、批量成员绕过与普通用户正常路径。

## 本地验证

- `CLIRELAY_POSTGRES_TEST_DSN=postgres://cliproxy:cliproxy@127.0.0.1:55432/cliproxy?sslmode=disable go test ./internal/identity/... -run TestPostgresTenantAdminUserProtection -count=1` — passed
- `CLIRELAY_POSTGRES_TEST_DSN=postgres://cliproxy:cliproxy@127.0.0.1:55432/cliproxy?sslmode=disable go test ./internal/identity/... -count=1` — passed（14 tests）
- `go vet ./...` — passed
- `golangci-lint run --config .golangci.yml` — passed（v1.64.5）
- `go build -o <temp> ./cmd/server` — passed
- `CLIRELAY_POSTGRES_TEST_DSN=... ./scripts/ci-pr.sh` — 未完整通过：结构检查、gofmt 与绝大多数 `go test ./...` 包（含 `internal/identity`）通过；`internal/api/routes/TestManagementAPIPostgresAllRoutesSmoke/GET_/v0/management/latest-version` 因 GitHub API rate limit 返回 403，测试观测为 502，脚本在全量测试阶段退出，后续 lint/build 已按上方命令单独通过。

等待 PR required checks 在 GitHub Actions 环境执行完整门禁。

## 契约

与 codeProxy 前端 PR 配套：前端禁用租户管理员的角色设置/删除入口，并封堵 RolesPage 成员编辑绕过；后端为最终 authority boundary。
