### PR TITLE
Release: merge dev into main for v0.4.15

### DIFF
--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
@@ -37,25 +38,47 @@ func Register(cfg *sdkconfig.SDKConfig) {
 func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 	result := make(map[string]keyConfig)
 
-	// Primary: load every tenant-scoped API key. Keys remain globally unique so
-	// authentication can resolve the trusted tenant without client input.
-	for _, stored := range usage.ListAllAPIKeys() {
-		entry := usage.EffectiveAPIKeyRowForTenant(stored.TenantID, stored)
+	// Primary: preload tenant profiles and owned accounts once, then build every key.
+	storedRows := usage.ListAllAPIKeys()
+	profilesByTenant := make(map[string][]usage.APIKeyPermissionProfileRow)
+	endUserIDs := make([]string, 0)
+	for _, stored := range storedRows {
+		tenantID := strings.TrimSpace(stored.TenantID)
+		if _, ok := profilesByTenant[tenantID]; !ok {
+			profilesByTenant[tenantID] = usage.ListAPIKeyPermissionProfilesForTenant(tenantID)
+		}
+		if endUserID := strings.TrimSpace(stored.EndUserID); endUserID != "" {
+			endUserIDs = append(endUserIDs, endUserID)
+		}
+	}
+	accounts, _ := usage.ListEndUserQuotasByIDs(endUserIDs)
+	for _, stored := range storedRows {
+		profiles := profilesByTenant[strings.TrimSpace(stored.TenantID)]
+		entry := usage.EffectiveAPIKeyRowWithProfiles(stored, profiles)
 		trimmed := strings.TrimSpace(entry.Key)
 		if trimmed == "" || entry.Disabled {
 			continue
 		}
-		// Frozen/locked accounts stay out of the auth map even if individual keys are enabled.
+		var account *usage.EndUserQuota
 		if endUserID := strings.TrimSpace(entry.EndUserID); endUserID != "" {
-			q := usage.GetEndUserQuota(endUserID)
-			if q == nil || strings.TrimSpace(q.Status) != "active" {
+			loaded, ok := accounts[endUserID]
+			if !ok {
+				fallback := usage.GetEndUserQuota(endUserID)
+				if fallback == nil {
+					continue
+				}
+				loaded = *fallback
+			}
+			effective := usage.EffectiveEndUserQuotaWithProfiles(loaded, profiles)
+			if strings.TrimSpace(effective.Status) != "active" {
 				continue
 			}
+			account = &effective
 		}
 		if _, exists := result[trimmed]; exists {
 			continue
 		}
-		result[trimmed] = keyConfigFromRow(entry)
+		result[trimmed] = keyConfigFromRowWithAccount(entry, account)
 	}
 
 	// Fallback: YAML config (for backward compatibility during migration)
@@ -87,64 +110,69 @@ func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 // keyConfig holds the per-key configuration extracted from APIKeyEntry.
 // When endUserID is set, quota/permissions come from the end-user account pool.
 type keyConfig struct {
-	tenantID             string
-	apiKeyID             string
-	apiKeyName           string
-	endUserID            string
-	allowedModels        []string
-	allowedChannels      []string
-	allowedChannelGroups []string
-	dailyLimit           int
-	totalQuota           int
-	spendingLimit        float64
-	dailySpendingLimit   float64
-	concurrencyLimit     int
-	rpmLimit             int
-	tpmLimit             int
-	systemPrompt         string
+	tenantID                    string
+	apiKeyID                    string
+	apiKeyName                  string
+	endUserID                   string
+	allowedModels               []string
+	allowedChannels             []string
+	allowedChannelGroups        []string
+	dailyLimit                  int
+	totalQuota                  int
+	spendingLimit               float64
+	dailySpendingLimit          float64
+	accountPeriodSpendingLimits quota.PeriodSpendingLimits
+	keyPeriodSpendingLimits     quota.PeriodSpendingLimits
+	concurrencyLimit            int
+	rpmLimit                    int
+	tpmLimit                    int
+	systemPrompt                string
 }
 
 func keyConfigFromRow(row usage.APIKeyRow) keyConfig {
+	var account *usage.EndUserQuota
+	if endUserID := strings.TrimSpace(row.EndUserID); endUserID != "" {
+		if loaded := usage.GetEndUserQuota(endUserID); loaded != nil {
+			effective := usage.EffectiveEndUserQuota(*loaded)
+			account = &effective
+		}
+	}
+	return keyConfigFromRowWithAccount(row, account)
+}
+
+func keyConfigFromRowWithAccount(row usage.APIKeyRow, account *usage.EndUserQuota) keyConfig {
 	tenantID := strings.TrimSpace(row.TenantID)
 	if tenantID == "" {
 		tenantID = identity.SystemTenantID
 	}
 	kc := keyConfig{
-		tenantID:             tenantID,
-		apiKeyID:             strings.TrimSpace(row.ID),
-		apiKeyName:           strings.TrimSpace(row.Name),
-		endUserID:            strings.TrimSpace(row.EndUserID),
-		allowedModels:        row.AllowedModels,
-		allowedChannels:      row.AllowedChannels,
-		allowedChannelGroups: row.AllowedChannelGroups,
-		dailyLimit:           row.DailyLimit,
-		totalQuota:           row.TotalQuota,
-		spendingLimit:        row.SpendingLimit,
-		dailySpendingLimit:   row.DailySpendingLimit,
-		concurrencyLimit:     row.ConcurrencyLimit,
-		rpmLimit:             row.RPMLimit,
-		tpmLimit:             row.TPMLimit,
-		systemPrompt:         row.SystemPrompt,
+		tenantID: tenantID, apiKeyID: strings.TrimSpace(row.ID), apiKeyName: strings.TrimSpace(row.Name),
+		endUserID: strings.TrimSpace(row.EndUserID), allowedModels: row.AllowedModels,
+		allowedChannels: row.AllowedChannels, allowedChannelGroups: row.AllowedChannelGroups,
+		dailyLimit: row.DailyLimit, totalQuota: row.TotalQuota, spendingLimit: row.SpendingLimit,
+		dailySpendingLimit: row.DailySpendingLimit, keyPeriodSpendingLimits: row.PeriodSpendingLimits,
+		concurrencyLimit: row.ConcurrencyLimit, rpmLimit: row.RPMLimit, tpmLimit: row.TPMLimit, systemPrompt: row.SystemPrompt,
 	}
-	// Owned keys share the end-user account quota/permission pool.
-	if kc.endUserID != "" {
-		if q := usage.GetEndUserQuota(kc.endUserID); q != nil {
-			eq := usage.EffectiveEndUserQuota(*q)
-			if name := strings.TrimSpace(eq.DisplayName); name != "" {
-				kc.apiKeyName = name
-			}
-			kc.allowedModels = eq.AllowedModels
-			kc.allowedChannels = eq.AllowedChannels
-			kc.allowedChannelGroups = eq.AllowedChannelGroups
-			kc.dailyLimit = eq.DailyLimit
-			kc.totalQuota = eq.TotalQuota
-			kc.spendingLimit = eq.SpendingLimit
-			kc.dailySpendingLimit = eq.DailySpendingLimit
-			kc.concurrencyLimit = eq.ConcurrencyLimit
-			kc.rpmLimit = eq.RPMLimit
-			kc.tpmLimit = eq.TPMLimit
-			kc.systemPrompt = eq.SystemPrompt
+	if kc.endUserID != "" && account != nil {
+		if name := strings.TrimSpace(account.DisplayName); name != "" {
+			kc.apiKeyName = name
 		}
+		kc.allowedModels = account.AllowedModels
+		kc.allowedChannels = account.AllowedChannels
+		kc.allowedChannelGroups = account.AllowedChannelGroups
+		kc.dailyLimit = account.DailyLimit
+		kc.totalQuota = account.TotalQuota
+		kc.spendingLimit = account.SpendingLimit
+		kc.dailySpendingLimit = account.DailySpendingLimit
+		kc.accountPeriodSpendingLimits = account.PeriodSpendingLimits
+		kc.concurrencyLimit = account.ConcurrencyLimit
+		kc.rpmLimit = account.RPMLimit
+		kc.tpmLimit = account.TPMLimit
+		kc.systemPrompt = account.SystemPrompt
+	}
+	kc.keyPeriodSpendingLimits.Day = row.DailySpendingLimit
+	if kc.endUserID == "" {
+		kc.dailySpendingLimit = kc.keyPeriodSpendingLimits.Day
 	}
 	return kc
 }
@@ -208,7 +236,9 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 		}
 		if kc, ok := p.keys[candidate.value]; ok {
 			metadata := map[string]string{
-				"source": candidate.source,
+				"source":     candidate.source,
+				"tenant-id":  kc.tenantID,
+				"api-key-id": kc.apiKeyID,
 			}
 			if kc.endUserID != "" {
 				metadata["end-user-id"] = kc.endUserID
@@ -243,6 +273,8 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 			if kc.dailySpendingLimit > 0 {
 				metadata["daily-spending-limit"] = fmt.Sprintf("%f", kc.dailySpendingLimit)
 			}
+			addPeriodLimitMetadata(metadata, "account-period-spending-limit-", kc.accountPeriodSpendingLimits)
+			addPeriodLimitMetadata(metadata, "key-period-spending-limit-", kc.keyPeriodSpendingLimits)
 			if kc.systemPrompt != "" {
 				metadata["system-prompt"] = kc.systemPrompt
 			}
@@ -258,6 +290,14 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 	}
 
 	return nil, sdkaccess.NewInvalidCredentialError()
+}
+
+func addPeriodLimitMetadata(metadata map[string]string, prefix string, limits quota.PeriodSpendingLimits) {
+	for _, period := range quota.OrderedPeriods {
+		if value := limits.Value(period); value > 0 {
+			metadata[prefix+string(period)] = fmt.Sprintf("%f", value)
+		}
+	}
 }
 
 func extractBearerToken(header string) string {

--- a/internal/access/config_access/provider_test.go
+++ b/internal/access/config_access/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 )
 
 func TestProviderEmitsDailySpendingLimitMetadata(t *testing.T) {
@@ -25,5 +26,35 @@ func TestProviderEmitsDailySpendingLimitMetadata(t *testing.T) {
 	}
 	if got := res.Metadata["daily-spending-limit"]; got != "4.500000" {
 		t.Fatalf("daily-spending-limit metadata = %q, want 4.500000", got)
+	}
+}
+
+func TestProviderEmitsSeparateAccountAndKeyPeriodMetadata(t *testing.T) {
+	p := newProvider("test", map[string]keyConfig{
+		"sk-owned": {
+			tenantID: "tenant-a", apiKeyID: "key-a", endUserID: "user-a",
+			accountPeriodSpendingLimits: quota.PeriodSpendingLimits{FiveHour: 100, Day: 300, Week: 800, Month: 4000},
+			keyPeriodSpendingLimits:     quota.PeriodSpendingLimits{FiveHour: 50, Day: 100},
+		},
+	})
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-owned")
+	res, authErr := p.Authenticate(context.Background(), req)
+	if authErr != nil {
+		t.Fatalf("Authenticate: %v", authErr)
+	}
+	checks := map[string]string{
+		"tenant-id": "tenant-a", "api-key-id": "key-a", "end-user-id": "user-a",
+		"account-period-spending-limit-5h":    "100.000000",
+		"account-period-spending-limit-day":   "300.000000",
+		"account-period-spending-limit-week":  "800.000000",
+		"account-period-spending-limit-month": "4000.000000",
+		"key-period-spending-limit-5h":        "50.000000",
+		"key-period-spending-limit-day":       "100.000000",
+	}
+	for key, want := range checks {
+		if got := res.Metadata[key]; got != want {
+			t.Fatalf("metadata[%s]=%q, want %q", key, got, want)
+		}
 	}
 }

--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -11,7 +11,10 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/access"
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -155,6 +158,14 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "failed to read body"})
 		return
 	}
+	if err := validatePeriodPayloadJSON(data); err != nil {
+		if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_period_spending_limit", "message": err.Error()}})
+		}
+		return
+	}
 
 	var profiles []usage.APIKeyPermissionProfileRow
 	syncAccounts := false
@@ -171,21 +182,32 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 		syncAccounts = obj.SyncAccounts
 	}
 
-	appliedCount := int64(0)
-	if syncAccounts {
-		appliedCount, err = h.apiKeySettings(c).ReplacePermissionProfilesAndSyncAccounts(profiles)
-	} else {
-		err = h.apiKeySettings(c).ReplacePermissionProfiles(profiles)
-	}
+	result, err := h.apiKeySettings(c).ReplacePermissionProfilesWithCaps(profiles, syncAccounts)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		if errors.Is(err, enduser.ErrFiveHourProjectionWarming) {
+			c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
+		} else if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 		return
 	}
 	if err := h.refreshAPIKeyCache(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(200, gin.H{"status": "ok", "applied_count": appliedCount})
+	if len(result.CappedKeys) > 0 {
+		principal, _ := principalFromContext(c)
+		if audit := identity.Default(); audit != nil {
+			audit.RecordAudit(c.Request.Context(), identity.AuditEvent{
+				TenantID: effectiveTenantID(c), ActorKind: principal.Kind, ActorUserID: principal.User.ID, ActorSessionID: principal.SessionID,
+				Action: "permission_profile.period_quota.cap_keys", ResourceType: "api_key_permission_profiles", Result: "success",
+				Changes: map[string]any{"capped-keys": result.CappedKeys},
+			})
+		}
+	}
+	c.JSON(200, gin.H{"status": "ok", "applied_count": result.AppliedCount, "capped-keys": result.CappedKeys})
 }
 
 // api-key-entries: backed by SQLite api_keys table
@@ -284,6 +306,14 @@ func (h *Handler) PutAPIKeyEntries(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "failed to read body"})
 		return
 	}
+	if err := validatePeriodPayloadJSON(data); err != nil {
+		if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_period_spending_limit", "message": err.Error()}})
+		}
+		return
+	}
 	var arr []config.APIKeyEntry
 	if err = json.Unmarshal(data, &arr); err != nil {
 		var obj struct {
@@ -322,7 +352,20 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 		return
 	}
 	if err := h.apiKeySettings(c).PatchEntry(body.ID, body.Index, body.Match, *body.Value); err != nil {
+		var exceeds *quota.LimitExceedsAccountError
 		switch {
+		case errors.Is(err, quota.ErrPeriodDayLegacyConflict):
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+			return
+		case errors.Is(err, enduser.ErrFiveHourProjectionWarming):
+			c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
+			return
+		case errors.As(err, &exceeds):
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "key_period_limit_exceeds_account", "message": exceeds.Error(), "details": gin.H{"period": exceeds.Period, "key_limit": exceeds.KeyLimit, "account_limit": exceeds.AccountLimit}}})
+			return
+		case errors.Is(err, apikeysettings.ErrOwnedKeyAccountManagedField):
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "owned_key_account_managed_field", "message": err.Error()}})
+			return
 		case errors.Is(err, apikeysettings.ErrItemNotFound):
 			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
 			return

--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -39,11 +39,14 @@ func (h *Handler) refreshAPIKeyCache() error {
 }
 
 func (h *Handler) apiKeySettings(c *gin.Context) *apikeysettings.Service {
+	return h.apiKeySettingsForTenant(effectiveTenantID(c))
+}
+
+func (h *Handler) apiKeySettingsForTenant(tenantID string) *apikeysettings.Service {
 	if h == nil {
-		return apikeysettings.NewService(nil)
+		return apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID))
 	}
 
-	tenantID := effectiveTenantID(c)
 	var auths []*coreauth.Auth
 	if h.authManager != nil {
 		auths = h.authManager.ListForTenant(tenantID)

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -58,7 +58,7 @@ func endUserError(c *gin.Context, err error) {
 		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "last_key", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrDuplicateKeyName):
 		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "duplicate_key_name", "message": err.Error()}})
-	case errors.Is(err, enduser.ErrNotFound):
+	case errors.Is(err, enduser.ErrNotFound), errors.Is(err, apikeysettings.ErrItemNotFound):
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrPeriodDayLegacyConflict):
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
@@ -855,7 +855,7 @@ func (h *Handler) resetOwnedAPIKeyDailySpending(c *gin.Context, tenantID, endUse
 		endUserError(c, err)
 		return
 	}
-	result, err := h.apiKeySettings(c).ResetDailySpending(&keyID, nil, actor)
+	result, err := h.apiKeySettingsForTenant(tenantID).ResetDailySpending(&keyID, nil, actor)
 	if err != nil {
 		if errors.Is(err, apikeysettings.ErrDailySpendingLimitMissing) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "daily_spending_limit_missing", "message": "Key daily spending limit is unlimited"}})
@@ -878,7 +878,7 @@ func (h *Handler) ownedAPIKeyDailySpendingHistory(c *gin.Context, tenantID, endU
 			limit = parsed
 		}
 	}
-	events, err := h.apiKeySettings(c).ListDailySpendingResetHistory(&keyID, nil, limit)
+	events, err := h.apiKeySettingsForTenant(tenantID).ListDailySpendingResetHistory(&keyID, nil, limit)
 	if err != nil {
 		endUserError(c, err)
 		return

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -9,6 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -57,6 +60,17 @@ func endUserError(c *gin.Context, err error) {
 		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "duplicate_key_name", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrNotFound):
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": err.Error()}})
+	case errors.Is(err, enduser.ErrPeriodDayLegacyConflict):
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
+	case errors.Is(err, enduser.ErrFiveHourProjectionWarming):
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
+	case func() bool { var target *quota.LimitExceedsAccountError; return errors.As(err, &target) }():
+		var target *quota.LimitExceedsAccountError
+		_ = errors.As(err, &target)
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{
+			"code": "key_period_limit_exceeds_account", "message": target.Error(),
+			"details": gin.H{"period": target.Period, "key_limit": target.KeyLimit, "account_limit": target.AccountLimit},
+		}})
 	case errors.Is(err, enduser.ErrValidation):
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "validation_failed", "message": err.Error()}})
 	default:
@@ -76,24 +90,24 @@ func (h *Handler) GetEndUsers(c *gin.Context) {
 		endUserError(c, err)
 		return
 	}
-	// Group by tenant then batch-load today costs (avoids per-row N+1).
+	// Group by tenant and batch-load period/lifetime usage and reset counts.
 	byTenant := map[string][]string{}
 	for i := range items {
-		tid := items[i].TenantID
-		byTenant[tid] = append(byTenant[tid], items[i].ID)
+		byTenant[items[i].TenantID] = append(byTenant[items[i].TenantID], items[i].ID)
 	}
-	costs := map[string]float64{}
+	usageByID := map[string]quota.PeriodSpendingUsage{}
 	resetCounts := map[string]int{}
-	for tid, ids := range byTenant {
-		part, usageErr := usage.QueryTodayEffectiveCostsByEndUsersForTenant(tid, ids)
+	profilesByTenant := map[string]map[string]usage.APIKeyPermissionProfileRow{}
+	for tenantID, ids := range byTenant {
+		part, usageErr := usage.QueryPeriodSpendingByEndUsersForTenant(tenantID, ids)
 		if usageErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": usageErr.Error()})
 			return
 		}
 		for id, used := range part {
-			costs[id] = used
+			usageByID[id] = used
 		}
-		countPart, usageErr := usage.ListEndUserDailySpendingResetEventCounts(tid, ids)
+		countPart, usageErr := usage.ListEndUserDailySpendingResetEventCounts(tenantID, ids)
 		if usageErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": usageErr.Error()})
 			return
@@ -101,9 +115,24 @@ func (h *Handler) GetEndUsers(c *gin.Context) {
 		for id, count := range countPart {
 			resetCounts[id] = count
 		}
+		profiles := make(map[string]usage.APIKeyPermissionProfileRow)
+		for _, profile := range usage.ListAPIKeyPermissionProfilesForTenant(tenantID) {
+			profiles[profile.ID] = profile
+		}
+		profilesByTenant[tenantID] = profiles
 	}
 	for i := range items {
-		items[i].DailySpendingUsed = costs[items[i].ID]
+		limits := items[i].PeriodSpendingLimits
+		if profile, ok := profilesByTenant[items[i].TenantID][strings.TrimSpace(items[i].PermissionProfileID)]; ok {
+			limits = profile.PeriodSpendingLimits
+			items[i].DailySpendingLimit = profile.DailySpendingLimit
+		}
+		limits.Day = items[i].DailySpendingLimit
+		items[i].PeriodSpendingLimits = limits
+		used := usageByID[items[i].ID]
+		items[i].DailySpendingUsed = used.Day
+		items[i].LifetimeSpendingUsed = used.Lifetime
+		items[i].PeriodSpending = quota.BuildPeriodSpending(limits, used)
 		items[i].DailySpendingResetCount = resetCounts[items[i].ID]
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
@@ -145,33 +174,44 @@ func (h *Handler) PatchEndUser(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Username             *string   `json:"username"`
-		DisplayName          *string   `json:"display_name"`
-		Password             *string   `json:"password"`
-		Status               *string   `json:"status"`
-		PermissionProfileID  *string   `json:"permission-profile-id"`
-		DailyLimit           *int      `json:"daily-limit"`
-		TotalQuota           *int      `json:"total-quota"`
-		SpendingLimit        *float64  `json:"spending-limit"`
-		DailySpendingLimit   *float64  `json:"daily-spending-limit"`
-		ConcurrencyLimit     *int      `json:"concurrency-limit"`
-		RPMLimit             *int      `json:"rpm-limit"`
-		TPMLimit             *int      `json:"tpm-limit"`
-		AllowedModels        *[]string `json:"allowed-models"`
-		AllowedChannels      *[]string `json:"allowed-channels"`
-		AllowedChannelGroups *[]string `json:"allowed-channel-groups"`
-		SystemPrompt         *string   `json:"system-prompt"`
+		Username             *string                          `json:"username"`
+		DisplayName          *string                          `json:"display_name"`
+		Password             *string                          `json:"password"`
+		Status               *string                          `json:"status"`
+		PermissionProfileID  *string                          `json:"permission-profile-id"`
+		DailyLimit           *int                             `json:"daily-limit"`
+		TotalQuota           *int                             `json:"total-quota"`
+		SpendingLimit        *float64                         `json:"spending-limit"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
+		ConcurrencyLimit     *int                             `json:"concurrency-limit"`
+		RPMLimit             *int                             `json:"rpm-limit"`
+		TPMLimit             *int                             `json:"tpm-limit"`
+		AllowedModels        *[]string                        `json:"allowed-models"`
+		AllowedChannels      *[]string                        `json:"allowed-channels"`
+		AllowedChannelGroups *[]string                        `json:"allowed-channel-groups"`
+		SystemPrompt         *string                          `json:"system-prompt"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
-	quota := &enduser.QuotaPatch{
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
+	quotaPatch := &enduser.QuotaPatch{
 		PermissionProfileID:  body.PermissionProfileID,
 		DailyLimit:           body.DailyLimit,
 		TotalQuota:           body.TotalQuota,
 		SpendingLimit:        body.SpendingLimit,
-		DailySpendingLimit:   body.DailySpendingLimit,
+		DailySpendingLimit:   nil,
+		PeriodSpendingLimits: periodPatch,
 		ConcurrencyLimit:     body.ConcurrencyLimit,
 		RPMLimit:             body.RPMLimit,
 		TPMLimit:             body.TPMLimit,
@@ -182,13 +222,13 @@ func (h *Handler) PatchEndUser(c *gin.Context) {
 	}
 	// Only pass quota when at least one field is set (avoid no-op patch noise).
 	hasQuota := body.PermissionProfileID != nil || body.DailyLimit != nil || body.TotalQuota != nil ||
-		body.SpendingLimit != nil || body.DailySpendingLimit != nil || body.ConcurrencyLimit != nil ||
+		body.SpendingLimit != nil || periodPatch != nil || body.ConcurrencyLimit != nil ||
 		body.RPMLimit != nil || body.TPMLimit != nil || body.AllowedModels != nil ||
 		body.AllowedChannels != nil || body.AllowedChannelGroups != nil || body.SystemPrompt != nil
 	if !hasQuota {
-		quota = nil
+		quotaPatch = nil
 	}
-	user, err := svc.UpdateUser(c.Request.Context(), principal, effectiveTenantID(c), c.Param("id"), body.Username, body.DisplayName, body.Password, body.Status, quota)
+	user, err := svc.UpdateUser(c.Request.Context(), principal, effectiveTenantID(c), c.Param("id"), body.Username, body.DisplayName, body.Password, body.Status, quotaPatch)
 	if err != nil {
 		endUserError(c, err)
 		return
@@ -258,6 +298,11 @@ func (h *Handler) PostEndUserDailySpendingReset(c *gin.Context) {
 	user, err := svc.GetUser(c.Request.Context(), tenantID, c.Param("id"))
 	if err != nil {
 		endUserError(c, err)
+		return
+	}
+	accountQuota := usage.GetEndUserQuota(user.ID)
+	if accountQuota == nil || usage.EffectiveEndUserQuota(*accountQuota).DailySpendingLimit <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "daily_spending_limit_missing", "message": "Account daily spending limit is unlimited"}})
 		return
 	}
 	usedBefore, rawToday, err := usage.ResetTodayCostByEndUser(tenantID, user.ID)
@@ -390,10 +435,24 @@ func (h *Handler) PostEndUserAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name string `json:"name"`
+		Name                 string                           `json:"name"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
 	}
-	_ = c.ShouldBindJSON(&body)
-	result, err := svc.CreateKey(c.Request.Context(), effectiveTenantID(c), c.Param("id"), body.Name)
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
+	result, err := svc.CreateKeyWithPeriodLimits(c.Request.Context(), effectiveTenantID(c), c.Param("id"), body.Name, periodPatch)
 	if err != nil {
 		endUserError(c, err)
 		return
@@ -417,16 +476,31 @@ func (h *Handler) PatchEndUserAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name *string `json:"name"`
+		Name                 *string                          `json:"name"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
 	}
-	if err := c.ShouldBindJSON(&body); err != nil || body.Name == nil {
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
+	if body.Name == nil && periodPatch == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
 	tenantID := effectiveTenantID(c)
 	userID := c.Param("id")
 	keyID := c.Param("key_id")
-	if err := svc.UpdateKeyName(c.Request.Context(), tenantID, userID, keyID, *body.Name); err != nil {
+	if err := svc.UpdateKey(c.Request.Context(), tenantID, userID, keyID, body.Name, periodPatch); err != nil {
 		endUserError(c, err)
 		return
 	}
@@ -665,10 +739,24 @@ func (h *Handler) PostPortalAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name string `json:"name"`
+		Name                 string                           `json:"name"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
 	}
-	_ = c.ShouldBindJSON(&body)
-	result, err := h.endUserService().CreateKey(c.Request.Context(), user.TenantID, user.ID, body.Name)
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
+	result, err := h.endUserService().CreateKeyWithPeriodLimits(c.Request.Context(), user.TenantID, user.ID, body.Name, periodPatch)
 	if err != nil {
 		endUserError(c, err)
 		return
@@ -686,16 +774,27 @@ func (h *Handler) PatchPortalAPIKey(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name *string `json:"name"`
+		Name                 *string                          `json:"name"`
+		DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+		PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
+	periodPatch, err := quota.ResolveLegacyDay(body.DailySpendingLimit, body.PeriodSpendingLimits)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		endUserError(c, enduser.ErrPeriodDayLegacyConflict)
+		return
+	}
+	if err != nil {
+		endUserError(c, fmt.Errorf("%w: %v", enduser.ErrValidation, err))
+		return
+	}
 	keyID := c.Param("id")
 	svc := h.endUserService()
-	if body.Name != nil {
-		if err := svc.UpdateKeyName(c.Request.Context(), user.TenantID, user.ID, keyID, *body.Name); err != nil {
+	if body.Name != nil || periodPatch != nil {
+		if err := svc.UpdateKey(c.Request.Context(), user.TenantID, user.ID, keyID, body.Name, periodPatch); err != nil {
 			endUserError(c, err)
 			return
 		}
@@ -749,4 +848,83 @@ func (h *Handler) DeletePortalAPIKey(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) resetOwnedAPIKeyDailySpending(c *gin.Context, tenantID, endUserID, keyID string, actor apikeysettings.DailySpendingResetActor) {
+	if _, err := h.endUserService().ResolveOwnedKeySecret(c.Request.Context(), tenantID, endUserID, keyID); err != nil {
+		endUserError(c, err)
+		return
+	}
+	result, err := h.apiKeySettings(c).ResetDailySpending(&keyID, nil, actor)
+	if err != nil {
+		if errors.Is(err, apikeysettings.ErrDailySpendingLimitMissing) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "daily_spending_limit_missing", "message": "Key daily spending limit is unlimited"}})
+			return
+		}
+		endUserError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *Handler) ownedAPIKeyDailySpendingHistory(c *gin.Context, tenantID, endUserID, keyID string) {
+	if _, err := h.endUserService().ResolveOwnedKeySecret(c.Request.Context(), tenantID, endUserID, keyID); err != nil {
+		endUserError(c, err)
+		return
+	}
+	limit := 100
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil {
+			limit = parsed
+		}
+	}
+	events, err := h.apiKeySettings(c).ListDailySpendingResetHistory(&keyID, nil, limit)
+	if err != nil {
+		endUserError(c, err)
+		return
+	}
+	total, err := usage.CountDailySpendingResetEvents(tenantID, keyID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"items": events, "total": total})
+}
+
+func (h *Handler) PostEndUserAPIKeyDailySpendingReset(c *gin.Context) {
+	principal, _ := principalFromContext(c)
+	if !principal.Has("api_keys.write") && !principal.Has("end_users.write") && !principal.PlatformAdmin {
+		identityError(c, identity.ErrPermissionDenied)
+		return
+	}
+	h.resetOwnedAPIKeyDailySpending(c, effectiveTenantID(c), c.Param("id"), c.Param("key_id"), apikeysettings.DailySpendingResetActor{
+		UserID: principal.User.ID, Username: principal.User.Username, Kind: principal.Kind,
+	})
+}
+
+func (h *Handler) GetEndUserAPIKeyDailySpendingResetHistory(c *gin.Context) {
+	principal, _ := principalFromContext(c)
+	if !principal.Has("api_keys.read") && !principal.Has("end_users.read") && !principal.PlatformAdmin {
+		identityError(c, identity.ErrPermissionDenied)
+		return
+	}
+	h.ownedAPIKeyDailySpendingHistory(c, effectiveTenantID(c), c.Param("id"), c.Param("key_id"))
+}
+
+func (h *Handler) PostPortalAPIKeyDailySpendingReset(c *gin.Context) {
+	user, ok := h.portalKeyAccess(c)
+	if !ok {
+		return
+	}
+	h.resetOwnedAPIKeyDailySpending(c, user.TenantID, user.ID, c.Param("id"), apikeysettings.DailySpendingResetActor{
+		UserID: user.ID, Username: user.Username, Kind: "end_user",
+	})
+}
+
+func (h *Handler) GetPortalAPIKeyDailySpendingResetHistory(c *gin.Context) {
+	user, ok := h.portalKeyAccess(c)
+	if !ok {
+		return
+	}
+	h.ownedAPIKeyDailySpendingHistory(c, user.TenantID, user.ID, c.Param("id"))
 }

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -911,20 +911,3 @@ func (h *Handler) GetEndUserAPIKeyDailySpendingResetHistory(c *gin.Context) {
 	h.ownedAPIKeyDailySpendingHistory(c, effectiveTenantID(c), c.Param("id"), c.Param("key_id"))
 }
 
-func (h *Handler) PostPortalAPIKeyDailySpendingReset(c *gin.Context) {
-	user, ok := h.portalKeyAccess(c)
-	if !ok {
-		return
-	}
-	h.resetOwnedAPIKeyDailySpending(c, user.TenantID, user.ID, c.Param("id"), apikeysettings.DailySpendingResetActor{
-		UserID: user.ID, Username: user.Username, Kind: "end_user",
-	})
-}
-
-func (h *Handler) GetPortalAPIKeyDailySpendingResetHistory(c *gin.Context) {
-	user, ok := h.portalKeyAccess(c)
-	if !ok {
-		return
-	}
-	h.ownedAPIKeyDailySpendingHistory(c, user.TenantID, user.ID, c.Param("id"))
-}

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -910,4 +910,3 @@ func (h *Handler) GetEndUserAPIKeyDailySpendingResetHistory(c *gin.Context) {
 	}
 	h.ownedAPIKeyDailySpendingHistory(c, effectiveTenantID(c), c.Param("id"), c.Param("key_id"))
 }
-

--- a/internal/api/handlers/management/end_user_daily_spending_reset_test.go
+++ b/internal/api/handlers/management/end_user_daily_spending_reset_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,8 +67,8 @@ func setupEndUserDailySpendingHandlerTest(t *testing.T) (*Handler, identity.Prin
 	now := time.Now().UTC()
 	if _, err := db.Exec(`
 		INSERT INTO end_users (
-			id, tenant_id, username, username_normalized, display_name, password_hash, created_at, updated_at
-		) VALUES (?, ?, 'alice', 'alice', 'Alice', 'unused', ?, ?)
+			id, tenant_id, username, username_normalized, display_name, password_hash, daily_spending_limit, created_at, updated_at
+		) VALUES (?, ?, 'alice', 'alice', 'Alice', 'unused', 100, ?, ?)
 	`, endUserID, tenantID, now, now); err != nil {
 		t.Fatalf("insert end user: %v", err)
 	}
@@ -169,5 +170,21 @@ func TestEndUserDailySpendingResetWritesAndListsHistory(t *testing.T) {
 	}
 	if len(listBody.Items) != 1 || listBody.Items[0].DailySpendingResetCount != 1 || listBody.Items[0].DailySpendingUsed != 0 {
 		t.Fatalf("end-user list = %#v, want reset count=1 used=0", listBody.Items)
+	}
+}
+
+func TestEndUserDailySpendingResetRejectsUnlimitedAccount(t *testing.T) {
+	h, principal, _, endUserID := setupEndUserDailySpendingHandlerTest(t)
+	if _, err := usage.RuntimeDB().Exec(`UPDATE end_users SET daily_spending_limit = 0 WHERE id = ?`, endUserID); err != nil {
+		t.Fatalf("clear limit: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Set(managementPrincipalKey, principal)
+	ctx.Params = gin.Params{{Key: "id", Value: endUserID}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/end-users/"+endUserID+"/daily-spending/reset", nil)
+	h.PostEndUserDailySpendingReset(ctx)
+	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), `"code":"daily_spending_limit_missing"`) {
+		t.Fatalf("status/body = %d %s, want 400 daily_spending_limit_missing", recorder.Code, recorder.Body.String())
 	}
 }

--- a/internal/api/handlers/management/end_user_daily_spending_reset_test.go
+++ b/internal/api/handlers/management/end_user_daily_spending_reset_test.go
@@ -1,8 +1,6 @@
 package management
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -99,67 +97,6 @@ func setupEndUserDailySpendingHandlerTest(t *testing.T) (*Handler, identity.Prin
 	return &Handler{}, principal, tenantID, endUserID
 }
 
-func setupPortalAPIKeyDailySpendingHandlerTest(t *testing.T) (*Handler, string, string, string, string) {
-	t.Helper()
-	h, _, tenantID, endUserID := setupEndUserDailySpendingHandlerTest(t)
-	if tenantID == identity.SystemTenantID {
-		t.Fatal("portal tenant must differ from system tenant")
-	}
-	db := usage.RuntimeDB()
-	if _, err := db.Exec(`
-		CREATE TABLE IF NOT EXISTS tenants (
-			id TEXT PRIMARY KEY,
-			status TEXT NOT NULL,
-			type TEXT NOT NULL,
-			expires_at TIMESTAMP,
-			access_token_ttl_seconds INTEGER,
-			refresh_token_ttl_seconds INTEGER
-		);
-		CREATE TABLE IF NOT EXISTS end_user_sessions (
-			id TEXT PRIMARY KEY,
-			end_user_id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			access_token_hash TEXT NOT NULL UNIQUE,
-			refresh_token_hash TEXT NOT NULL UNIQUE,
-			access_expires_at TIMESTAMP NOT NULL,
-			refresh_expires_at TIMESTAMP NOT NULL,
-			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			last_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			revoked_at TIMESTAMP,
-			revoke_reason TEXT NOT NULL DEFAULT '',
-			user_agent_hash TEXT NOT NULL DEFAULT ''
-		)
-	`); err != nil {
-		t.Fatalf("create portal auth tables: %v", err)
-	}
-	if _, err := db.Exec(`INSERT INTO tenants (id, status, type) VALUES (?, 'active', 'standard')`, tenantID); err != nil {
-		t.Fatalf("insert tenant: %v", err)
-	}
-
-	keyID := uuid.NewString()
-	if err := usage.UpsertAPIKeyForTenant(tenantID, usage.APIKeyRow{
-		ID:                 keyID,
-		Key:                "sk-portal-reset-tenant",
-		Name:               "Portal reset tenant",
-		EndUserID:          endUserID,
-		DailySpendingLimit: 100,
-	}); err != nil {
-		t.Fatalf("insert owned API key: %v", err)
-	}
-
-	portalToken := "cpt_portal-reset-tenant-test"
-	portalTokenSum := sha256.Sum256([]byte(portalToken))
-	if _, err := db.Exec(`
-		INSERT INTO end_user_sessions (
-			id, end_user_id, tenant_id, access_token_hash, refresh_token_hash, access_expires_at, refresh_expires_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, uuid.NewString(), endUserID, tenantID, hex.EncodeToString(portalTokenSum[:]), "unused-portal-reset-refresh-hash",
-		time.Now().UTC().Add(time.Hour), time.Now().UTC().Add(2*time.Hour)); err != nil {
-		t.Fatalf("insert portal session: %v", err)
-	}
-	return h, tenantID, endUserID, keyID, portalToken
-}
-
 func TestEndUserDailySpendingResetWritesAndListsHistory(t *testing.T) {
 	h, principal, tenantID, endUserID := setupEndUserDailySpendingHandlerTest(t)
 
@@ -250,54 +187,6 @@ func TestEndUserDailySpendingResetRejectsUnlimitedAccount(t *testing.T) {
 	h.PostEndUserDailySpendingReset(ctx)
 	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), `"code":"daily_spending_limit_missing"`) {
 		t.Fatalf("status/body = %d %s, want 400 daily_spending_limit_missing", recorder.Code, recorder.Body.String())
-	}
-}
-
-func TestPortalAPIKeyDailySpendingResetAndHistoryUsePortalTenant(t *testing.T) {
-	h, tenantID, endUserID, keyID, portalToken := setupPortalAPIKeyDailySpendingHandlerTest(t)
-
-	historyRecorder := httptest.NewRecorder()
-	historyContext, _ := gin.CreateTestContext(historyRecorder)
-	historyContext.Params = gin.Params{{Key: "id", Value: keyID}}
-	historyContext.Request = httptest.NewRequest(http.MethodGet, "/v0/portal/api-keys/"+keyID+"/daily-spending/reset-history?limit=200", nil)
-	historyContext.Request.Header.Set("Authorization", "Bearer "+portalToken)
-	if got := effectiveTenantID(historyContext); got != identity.SystemTenantID {
-		t.Fatalf("effective tenant before portal auth = %q, want system tenant fallback", got)
-	}
-	h.GetPortalAPIKeyDailySpendingResetHistory(historyContext)
-	if historyRecorder.Code != http.StatusOK {
-		t.Fatalf("empty history status = %d, want %d; body=%s", historyRecorder.Code, http.StatusOK, historyRecorder.Body.String())
-	}
-	var emptyHistory struct {
-		Items []usage.APIKeyDailySpendingResetEvent `json:"items"`
-		Total int                                   `json:"total"`
-	}
-	if err := json.Unmarshal(historyRecorder.Body.Bytes(), &emptyHistory); err != nil {
-		t.Fatalf("decode empty history response: %v", err)
-	}
-	if emptyHistory.Total != 0 || len(emptyHistory.Items) != 0 {
-		t.Fatalf("empty history response = %#v, want no reset events", emptyHistory)
-	}
-
-	resetRecorder := httptest.NewRecorder()
-	resetContext, _ := gin.CreateTestContext(resetRecorder)
-	resetContext.Params = gin.Params{{Key: "id", Value: keyID}}
-	resetContext.Request = httptest.NewRequest(http.MethodPost, "/v0/portal/api-keys/"+keyID+"/daily-spending/reset", nil)
-	resetContext.Request.Header.Set("Authorization", "Bearer "+portalToken)
-	h.PostPortalAPIKeyDailySpendingReset(resetContext)
-	if resetRecorder.Code != http.StatusOK {
-		t.Fatalf("reset status = %d, want %d; body=%s", resetRecorder.Code, http.StatusOK, resetRecorder.Body.String())
-	}
-
-	events, err := usage.ListDailySpendingResetEvents(tenantID, keyID, 10)
-	if err != nil {
-		t.Fatalf("list portal key reset events: %v", err)
-	}
-	if len(events) != 1 {
-		t.Fatalf("reset events = %d, want 1", len(events))
-	}
-	if events[0].TenantID != tenantID || events[0].ActorUserID != endUserID || events[0].ActorKind != "end_user" {
-		t.Fatalf("reset event = %#v, want portal tenant/user actor", events[0])
 	}
 }
 

--- a/internal/api/handlers/management/end_user_daily_spending_reset_test.go
+++ b/internal/api/handlers/management/end_user_daily_spending_reset_test.go
@@ -1,6 +1,8 @@
 package management
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -94,6 +97,67 @@ func setupEndUserDailySpendingHandlerTest(t *testing.T) (*Handler, identity.Prin
 		},
 	}
 	return &Handler{}, principal, tenantID, endUserID
+}
+
+func setupPortalAPIKeyDailySpendingHandlerTest(t *testing.T) (*Handler, string, string, string, string) {
+	t.Helper()
+	h, _, tenantID, endUserID := setupEndUserDailySpendingHandlerTest(t)
+	if tenantID == identity.SystemTenantID {
+		t.Fatal("portal tenant must differ from system tenant")
+	}
+	db := usage.RuntimeDB()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS tenants (
+			id TEXT PRIMARY KEY,
+			status TEXT NOT NULL,
+			type TEXT NOT NULL,
+			expires_at TIMESTAMP,
+			access_token_ttl_seconds INTEGER,
+			refresh_token_ttl_seconds INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS end_user_sessions (
+			id TEXT PRIMARY KEY,
+			end_user_id TEXT NOT NULL,
+			tenant_id TEXT NOT NULL,
+			access_token_hash TEXT NOT NULL UNIQUE,
+			refresh_token_hash TEXT NOT NULL UNIQUE,
+			access_expires_at TIMESTAMP NOT NULL,
+			refresh_expires_at TIMESTAMP NOT NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			last_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			revoked_at TIMESTAMP,
+			revoke_reason TEXT NOT NULL DEFAULT '',
+			user_agent_hash TEXT NOT NULL DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("create portal auth tables: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO tenants (id, status, type) VALUES (?, 'active', 'standard')`, tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+
+	keyID := uuid.NewString()
+	if err := usage.UpsertAPIKeyForTenant(tenantID, usage.APIKeyRow{
+		ID:                 keyID,
+		Key:                "sk-portal-reset-tenant",
+		Name:               "Portal reset tenant",
+		EndUserID:          endUserID,
+		DailySpendingLimit: 100,
+	}); err != nil {
+		t.Fatalf("insert owned API key: %v", err)
+	}
+
+	portalToken := "cpt_portal-reset-tenant-test"
+	portalTokenSum := sha256.Sum256([]byte(portalToken))
+	if _, err := db.Exec(`
+		INSERT INTO end_user_sessions (
+			id, end_user_id, tenant_id, access_token_hash, refresh_token_hash, access_expires_at, refresh_expires_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, uuid.NewString(), endUserID, tenantID, hex.EncodeToString(portalTokenSum[:]), "unused-portal-reset-refresh-hash",
+		time.Now().UTC().Add(time.Hour), time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatalf("insert portal session: %v", err)
+	}
+	return h, tenantID, endUserID, keyID, portalToken
 }
 
 func TestEndUserDailySpendingResetWritesAndListsHistory(t *testing.T) {
@@ -186,5 +250,65 @@ func TestEndUserDailySpendingResetRejectsUnlimitedAccount(t *testing.T) {
 	h.PostEndUserDailySpendingReset(ctx)
 	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), `"code":"daily_spending_limit_missing"`) {
 		t.Fatalf("status/body = %d %s, want 400 daily_spending_limit_missing", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestPortalAPIKeyDailySpendingResetAndHistoryUsePortalTenant(t *testing.T) {
+	h, tenantID, endUserID, keyID, portalToken := setupPortalAPIKeyDailySpendingHandlerTest(t)
+
+	historyRecorder := httptest.NewRecorder()
+	historyContext, _ := gin.CreateTestContext(historyRecorder)
+	historyContext.Params = gin.Params{{Key: "id", Value: keyID}}
+	historyContext.Request = httptest.NewRequest(http.MethodGet, "/v0/portal/api-keys/"+keyID+"/daily-spending/reset-history?limit=200", nil)
+	historyContext.Request.Header.Set("Authorization", "Bearer "+portalToken)
+	if got := effectiveTenantID(historyContext); got != identity.SystemTenantID {
+		t.Fatalf("effective tenant before portal auth = %q, want system tenant fallback", got)
+	}
+	h.GetPortalAPIKeyDailySpendingResetHistory(historyContext)
+	if historyRecorder.Code != http.StatusOK {
+		t.Fatalf("empty history status = %d, want %d; body=%s", historyRecorder.Code, http.StatusOK, historyRecorder.Body.String())
+	}
+	var emptyHistory struct {
+		Items []usage.APIKeyDailySpendingResetEvent `json:"items"`
+		Total int                                   `json:"total"`
+	}
+	if err := json.Unmarshal(historyRecorder.Body.Bytes(), &emptyHistory); err != nil {
+		t.Fatalf("decode empty history response: %v", err)
+	}
+	if emptyHistory.Total != 0 || len(emptyHistory.Items) != 0 {
+		t.Fatalf("empty history response = %#v, want no reset events", emptyHistory)
+	}
+
+	resetRecorder := httptest.NewRecorder()
+	resetContext, _ := gin.CreateTestContext(resetRecorder)
+	resetContext.Params = gin.Params{{Key: "id", Value: keyID}}
+	resetContext.Request = httptest.NewRequest(http.MethodPost, "/v0/portal/api-keys/"+keyID+"/daily-spending/reset", nil)
+	resetContext.Request.Header.Set("Authorization", "Bearer "+portalToken)
+	h.PostPortalAPIKeyDailySpendingReset(resetContext)
+	if resetRecorder.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want %d; body=%s", resetRecorder.Code, http.StatusOK, resetRecorder.Body.String())
+	}
+
+	events, err := usage.ListDailySpendingResetEvents(tenantID, keyID, 10)
+	if err != nil {
+		t.Fatalf("list portal key reset events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("reset events = %d, want 1", len(events))
+	}
+	if events[0].TenantID != tenantID || events[0].ActorUserID != endUserID || events[0].ActorKind != "end_user" {
+		t.Fatalf("reset event = %#v, want portal tenant/user actor", events[0])
+	}
+}
+
+func TestEndUserErrorMapsAPIKeySettingsItemNotFoundToNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+
+	endUserError(ctx, apikeysettings.ErrItemNotFound)
+
+	if recorder.Code != http.StatusNotFound || !strings.Contains(recorder.Body.String(), `"code":"not_found"`) {
+		t.Fatalf("status/body = %d %s, want 404 not_found", recorder.Code, recorder.Body.String())
 	}
 }

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -392,8 +392,10 @@ func (h *Handler) GetUsers(c *gin.Context) {
 func (h *Handler) PostUser(c *gin.Context) {
 	principal, _ := principalFromContext(c)
 	var body struct {
-		Username, DisplayName, Password string
-		RoleIDs                         []string `json:"role_ids"`
+		Username    string   `json:"username"`
+		DisplayName string   `json:"display_name"`
+		Password    string   `json:"password"`
+		RoleIDs     []string `json:"role_ids"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -401,12 +401,18 @@ func (h *Handler) PostUser(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	user, err := h.identity().CreateUser(c.Request.Context(), principal, principal.EffectiveTenant.ID, body.Username, body.DisplayName, body.Password, body.RoleIDs)
+	user, initialPassword, err := h.identity().CreateUser(c.Request.Context(), principal, principal.EffectiveTenant.ID, body.Username, body.DisplayName, body.Password, body.RoleIDs)
 	if err != nil {
 		identityError(c, err)
 		return
 	}
-	c.JSON(http.StatusCreated, user)
+	c.JSON(http.StatusCreated, struct {
+		identity.User
+		InitialPassword string `json:"initial_password,omitempty"`
+	}{
+		User:            user,
+		InitialPassword: initialPassword,
+	})
 }
 
 func (h *Handler) PostUserResetPassword(c *gin.Context) {

--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -150,7 +150,7 @@ func TestPostUserBindsSnakeCaseDisplayName(t *testing.T) {
 		h.PostUser(c)
 	})
 
-	body := []byte(`{"username":"snake-case-user","display_name":"Snake Case User","password":"snake-case-password-123","role_ids":[]}`)
+	body := []byte(`{"username":"snake-case-user","display_name":"Snake Case User","password":"Snake-Case-Password-123!","role_ids":[]}`)
 	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v0/management/users", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -165,6 +165,99 @@ func TestPostUserBindsSnakeCaseDisplayName(t *testing.T) {
 	}
 	if user.DisplayName != "Snake Case User" {
 		t.Fatalf("display_name = %q, want %q", user.DisplayName, "Snake Case User")
+	}
+}
+
+func TestPostUserBlankPasswordReturnsInitialPassword(t *testing.T) {
+	ctx := context.Background()
+	service := newSQLiteIdentityTestService(t)
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	principal := identity.Principal{
+		Kind:            "user",
+		User:            identity.User{ID: identity.SystemUserID, TenantID: identity.SystemTenantID},
+		EffectiveTenant: identity.Tenant{ID: identity.SystemTenantID},
+		PlatformAdmin:   true,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/v0/management/users", func(c *gin.Context) {
+		c.Set(managementPrincipalKey, principal)
+		h.PostUser(c)
+	})
+
+	body := []byte(`{"username":"generated-admin-user","display_name":"Generated Admin User","password":"   ","role_ids":[]}`)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v0/management/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var response struct {
+		ID              string `json:"id"`
+		DisplayName     string `json:"display_name"`
+		InitialPassword string `json:"initial_password"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	if response.ID == "" {
+		t.Fatal("response id is empty")
+	}
+	if response.DisplayName != "Generated Admin User" {
+		t.Fatalf("display_name = %q, want %q", response.DisplayName, "Generated Admin User")
+	}
+	if response.InitialPassword == "" {
+		t.Fatalf("initial_password missing; body=%s", rec.Body.String())
+	}
+	if _, err := identity.HashPassword(response.InitialPassword); err != nil {
+		t.Fatalf("initial_password does not satisfy policy: %v", err)
+	}
+}
+
+func TestPostUserManualPasswordOmitsInitialPassword(t *testing.T) {
+	ctx := context.Background()
+	service := newSQLiteIdentityTestService(t)
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	principal := identity.Principal{
+		Kind:            "user",
+		User:            identity.User{ID: identity.SystemUserID, TenantID: identity.SystemTenantID},
+		EffectiveTenant: identity.Tenant{ID: identity.SystemTenantID},
+		PlatformAdmin:   true,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/v0/management/users", func(c *gin.Context) {
+		c.Set(managementPrincipalKey, principal)
+		h.PostUser(c)
+	})
+
+	body := []byte(`{"username":"manual-admin-user","display_name":"Manual Admin User","password":"Manual-Password-123!","role_ids":[]}`)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v0/management/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var response map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	if _, ok := response["initial_password"]; ok {
+		t.Fatalf("initial_password should be omitted for manual password; body=%s", rec.Body.String())
 	}
 }
 
@@ -227,7 +320,7 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 	})
 
 	service := identity.NewService(db)
-	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
 		t.Fatal(err)
 	}
 	// Pin the service on the handler so Middleware does not depend on process-global Default().
@@ -281,14 +374,14 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 
 	readToken := seedPlatformLogUser(logUserFixture{
 		username:    "log-reader",
-		password:    "reader-password-123",
+		password:    "Reader-Password-123!",
 		userID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 		roleID:      "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		permissions: []string{"system.logs.read"},
 	})
 	deleteToken := seedPlatformLogUser(logUserFixture{
 		username:    "log-deleter",
-		password:    "deleter-password-123",
+		password:    "Deleter-Password-123!",
 		userID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2",
 		roleID:      "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		permissions: []string{"system.logs.read", "system.logs.delete"},

--- a/internal/api/handlers/management/identity_auth_test.go
+++ b/internal/api/handlers/management/identity_auth_test.go
@@ -1,8 +1,10 @@
 package management
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +19,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres/compatdriver"
+	_ "modernc.org/sqlite"
 )
 
 func TestPermissionForManagementRequest(t *testing.T) {
@@ -122,6 +125,46 @@ func TestServiceCredentialCannotAccessTenantGovernance(t *testing.T) {
 	}
 	if reached {
 		t.Fatal("service credential reached tenant governance handler")
+	}
+}
+
+func TestPostUserBindsSnakeCaseDisplayName(t *testing.T) {
+	ctx := context.Background()
+	service := newSQLiteIdentityTestService(t)
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	principal := identity.Principal{
+		Kind:            "user",
+		User:            identity.User{ID: identity.SystemUserID, TenantID: identity.SystemTenantID},
+		EffectiveTenant: identity.Tenant{ID: identity.SystemTenantID},
+		PlatformAdmin:   true,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/v0/management/users", func(c *gin.Context) {
+		c.Set(managementPrincipalKey, principal)
+		h.PostUser(c)
+	})
+
+	body := []byte(`{"username":"snake-case-user","display_name":"Snake Case User","password":"snake-case-password-123","role_ids":[]}`)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v0/management/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var user identity.User
+	if err := json.Unmarshal(rec.Body.Bytes(), &user); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	if user.DisplayName != "Snake Case User" {
+		t.Fatalf("display_name = %q, want %q", user.DisplayName, "Snake Case User")
 	}
 }
 
@@ -281,6 +324,37 @@ func TestLogsDeleteMiddlewareRequiresExplicitPermission(t *testing.T) {
 	if code, reached := serve(http.MethodDelete, deleteToken); code != http.StatusOK || !reached {
 		t.Fatalf("delete-capable DELETE: status=%d reached=%v, want 200 and handler executed", code, reached)
 	}
+}
+
+func newSQLiteIdentityTestService(t *testing.T) *identity.Service {
+	t.Helper()
+	dsn := fmt.Sprintf("file:identity_post_user_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(4)
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("close sqlite identity db: %v", closeErr)
+		}
+	})
+	for _, statement := range []string{
+		`CREATE TABLE users (
+			id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, username TEXT NOT NULL, username_normalized TEXT NOT NULL,
+			display_name TEXT NOT NULL, password_hash TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+			must_change_password BOOLEAN NOT NULL DEFAULT false, last_login_at TIMESTAMP NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			version INTEGER NOT NULL DEFAULT 1, created_by TEXT
+		)`,
+		`CREATE TABLE roles (id TEXT PRIMARY KEY, code TEXT NOT NULL, name TEXT NOT NULL)`,
+		`CREATE TABLE user_roles (user_id TEXT NOT NULL, role_id TEXT NOT NULL, created_by TEXT)`,
+	} {
+		if _, err = db.Exec(statement); err != nil {
+			t.Fatalf("create sqlite identity schema: %v", err)
+		}
+	}
+	return identity.NewService(db)
 }
 
 func replacePostgresDatabaseForTest(dsn, dbName string) (string, error) {

--- a/internal/api/handlers/management/period_payload.go
+++ b/internal/api/handlers/management/period_payload.go
@@ -1,0 +1,81 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
+
+func validatePeriodPayloadJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var root any
+	if err := decoder.Decode(&root); err != nil {
+		return err
+	}
+	return validatePeriodPayloadValue(root)
+}
+
+func validatePeriodPayloadValue(value any) error {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			if err := validatePeriodPayloadValue(item); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		if items, ok := typed["items"]; ok {
+			if err := validatePeriodPayloadValue(items); err != nil {
+				return err
+			}
+		}
+		var legacy *float64
+		if raw, ok := typed["daily-spending-limit"]; ok {
+			value, err := jsonNumberFloat(raw)
+			if err != nil {
+				return fmt.Errorf("daily-spending-limit: %w", err)
+			}
+			legacy = &value
+		}
+		var patch *quota.PeriodSpendingLimitsPatch
+		if raw, ok := typed["period-spending-limits"]; ok {
+			object, ok := raw.(map[string]any)
+			if !ok {
+				return fmt.Errorf("period-spending-limits must be an object")
+			}
+			patch = &quota.PeriodSpendingLimitsPatch{}
+			for key, target := range map[string]**float64{
+				"5h": &patch.FiveHour, "day": &patch.Day, "week": &patch.Week, "month": &patch.Month,
+			} {
+				rawValue, exists := object[key]
+				if !exists {
+					continue
+				}
+				parsed, err := jsonNumberFloat(rawValue)
+				if err != nil {
+					return fmt.Errorf("period-spending-limits.%s: %w", key, err)
+				}
+				*target = &parsed
+			}
+		}
+		if _, err := quota.ResolveLegacyDay(legacy, patch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func jsonNumberFloat(value any) (float64, error) {
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("must be a number")
+	}
+	parsed, err := number.Float64()
+	if err != nil {
+		return 0, err
+	}
+	return parsed, nil
+}

--- a/internal/api/handlers/management/period_payload_test.go
+++ b/internal/api/handlers/management/period_payload_test.go
@@ -1,0 +1,20 @@
+package management
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
+
+func TestValidatePeriodPayloadJSONDetectsNormalizedDayConflict(t *testing.T) {
+	if err := validatePeriodPayloadJSON([]byte(`{"items":[{"daily-spending-limit":10.1,"period-spending-limits":{"day":11}}]}`)); err != nil {
+		t.Fatalf("same normalized day: %v", err)
+	}
+	if err := validatePeriodPayloadJSON([]byte(`{"items":[{"daily-spending-limit":10,"period-spending-limits":{"day":11}}]}`)); !errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		t.Fatalf("conflict err = %v", err)
+	}
+	if err := validatePeriodPayloadJSON([]byte(`{"period-spending-limits":{"week":-1}}`)); !errors.Is(err, quota.ErrInvalidSpendingLimit) {
+		t.Fatalf("negative err = %v", err)
+	}
+}

--- a/internal/api/handlers/management/period_quota_test.go
+++ b/internal/api/handlers/management/period_quota_test.go
@@ -1,0 +1,74 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestPatchEndUserRejectsLegacyPeriodDayConflict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, principal, _, endUserID := setupEndUserDailySpendingHandlerTest(t)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Set(managementPrincipalKey, principal)
+	ctx.Params = gin.Params{{Key: "id", Value: endUserID}}
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/end-users/"+endUserID, bytes.NewBufferString(`{
+		"daily-spending-limit":10,
+		"period-spending-limits":{"day":20}
+	}`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	h.PatchEndUser(ctx)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error.Code != "period_day_legacy_conflict" {
+		t.Fatalf("code = %q, want period_day_legacy_conflict", body.Error.Code)
+	}
+}
+
+func TestPostEndUserAPIKeyRejectsLimitAboveAccount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, principal, _, endUserID := setupEndUserDailySpendingHandlerTest(t)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Set(managementPrincipalKey, principal)
+	ctx.Params = gin.Params{{Key: "id", Value: endUserID}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/end-users/"+endUserID+"/api-keys", bytes.NewBufferString(`{
+		"name":"too-large",
+		"period-spending-limits":{"day":200}
+	}`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	h.PostEndUserAPIKey(ctx)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Details struct {
+				Period       string  `json:"period"`
+				KeyLimit     float64 `json:"key_limit"`
+				AccountLimit float64 `json:"account_limit"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error.Code != "key_period_limit_exceeds_account" || body.Error.Details.Period != "day" || body.Error.Details.KeyLimit != 200 || body.Error.Details.AccountLimit != 100 {
+		t.Fatalf("error = %+v", body.Error)
+	}
+}

--- a/internal/api/handlers/management/public_usage_subject.go
+++ b/internal/api/handlers/management/public_usage_subject.go
@@ -45,11 +45,12 @@ func (h *Handler) resolvePublicUsageSubject(c *gin.Context, apiKey string) (publ
 		return publicUsageSubject{}, false
 	}
 
+	// Raw secret lookup is key-scoped only. Do not promote to account-wide via
+	// end_user_id; portal cpt_ sessions above already use EndUserID without a secret.
 	subject := publicUsageSubject{APIKey: apiKey}
 	if row := usage.GetAPIKey(apiKey); row != nil {
 		subject.APIKeyRow = row
 		subject.TenantID = strings.TrimSpace(row.TenantID)
-		subject.EndUserID = strings.TrimSpace(row.EndUserID)
 	} else {
 		subject.TenantID = usage.ResolveAPIKeyTenant(apiKey)
 	}

--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -199,7 +199,9 @@ func (h *UsageLogsHandler) GetPublicUsageChartData(c *gin.Context) {
 	service := h.serviceForTenant(subject.TenantID)
 	var payload map[string]any
 	var err error
-	if subject.EndUserID != "" {
+	// Portal session has EndUserID without a presented secret → account label.
+	// Secret lookup (even when the key is owned) must keep key-own-name labeling.
+	if subject.EndUserID != "" && strings.TrimSpace(subject.APIKey) == "" {
 		payload, err = service.PublicChartDataForEndUser(subject.EndUserID, req.Days)
 	} else {
 		payload, err = service.PublicChartData(subject.APIKey, req.Days)

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -2149,8 +2149,9 @@ func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	var payload struct {
-		Total int64 `json:"total"`
-		Items []struct {
+		Total      int64  `json:"total"`
+		APIKeyName string `json:"api_key_name"`
+		Items      []struct {
 			APIKey        string `json:"api_key"`
 			APIKeyID      string `json:"api_key_id"`
 			APIKeyMasked  string `json:"api_key_masked"`
@@ -2162,6 +2163,10 @@ func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 	}
 	if payload.Total != 2 || len(payload.Items) != 2 {
 		t.Fatalf("public logs total/items = %d/%d, want 2/2", payload.Total, len(payload.Items))
+	}
+	// Top-level label must be the presented key's own name, never the end-user display name.
+	if payload.APIKeyName != "Automation" {
+		t.Fatalf("api_key_name = %q, want Automation (key own name), not end-user display", payload.APIKeyName)
 	}
 	for _, item := range payload.Items {
 		if item.APIKey != "" || item.APIKeyID != "" {

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -2109,7 +2109,7 @@ func TestGetUsageLogsFiltersByOrphanAuthIndexWithoutLiveMeta(t *testing.T) {
 	}
 }
 
-func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
+func TestGetPublicUsageLogs_RawSecretIsKeyScoped(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tmpDir := t.TempDir()
@@ -2161,23 +2161,22 @@ func TestGetPublicUsageLogs_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if payload.Total != 2 || len(payload.Items) != 2 {
-		t.Fatalf("public logs total/items = %d/%d, want 2/2", payload.Total, len(payload.Items))
+	// Raw secret lookup must stay key-scoped; sibling keys on the same account stay hidden.
+	if payload.Total != 1 || len(payload.Items) != 1 {
+		t.Fatalf("public logs total/items = %d/%d, want 1/1; body=%s", payload.Total, len(payload.Items), rec.Body.String())
 	}
-	// Top-level label must be the presented key's own name, never the end-user display name.
 	if payload.APIKeyName != "Automation" {
-		t.Fatalf("api_key_name = %q, want Automation (key own name), not end-user display", payload.APIKeyName)
+		t.Fatalf("api_key_name = %q, want Automation (presented key own name)", payload.APIKeyName)
 	}
-	for _, item := range payload.Items {
-		if item.APIKey != "" || item.APIKeyID != "" {
-			t.Fatalf("public item leaked raw key identity: %+v", item)
-		}
-		if item.APIKeyMasked == "" {
-			t.Fatalf("public item missing masked key fallback: %+v", item)
-		}
-		if item.APIKeyOwnName != "Laptop" && item.APIKeyOwnName != "Automation" {
-			t.Fatalf("api_key_own_name = %q, want concrete key name", item.APIKeyOwnName)
-		}
+	item := payload.Items[0]
+	if item.APIKey != "" || item.APIKeyID != "" {
+		t.Fatalf("public item leaked raw key identity: %+v", item)
+	}
+	if item.APIKeyMasked == "" {
+		t.Fatalf("public item missing masked key fallback: %+v", item)
+	}
+	if item.APIKeyOwnName != "Automation" {
+		t.Fatalf("api_key_own_name = %q, want Automation", item.APIKeyOwnName)
 	}
 }
 
@@ -2245,22 +2244,17 @@ func TestGetPublicUsageLogs_FiltersByAPIKeyIDs(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if payload.Total != 1 || len(payload.Items) != 1 {
-		t.Fatalf("filtered total/items = %d/%d, want 1/1; body=%s", payload.Total, len(payload.Items), rec.Body.String())
+	// Sibling key ids are not in the raw-secret allow-list; filter is rejected → empty.
+	if payload.Total != 0 || len(payload.Items) != 0 {
+		t.Fatalf("filtered total/items = %d/%d, want 0/0; body=%s", payload.Total, len(payload.Items), rec.Body.String())
 	}
-	if payload.Items[0].APIKeyOwnName != "Laptop" {
-		t.Fatalf("api_key_own_name = %q, want Laptop", payload.Items[0].APIKeyOwnName)
-	}
-	if len(payload.Filters.APIKeyIDs) != 2 {
-		t.Fatalf("filters.api_key_ids = %#v, want 2 options", payload.Filters.APIKeyIDs)
-	}
-	if payload.Filters.APIKeyIDNames[keyAID] != "Laptop" {
-		t.Fatalf("filters.api_key_id_names[%s] = %q, want Laptop", keyAID, payload.Filters.APIKeyIDNames[keyAID])
+	if len(payload.Filters.APIKeyIDs) != 1 || payload.Filters.APIKeyIDs[0] != keyBID {
+		t.Fatalf("filters.api_key_ids = %#v, want only presented key %s", payload.Filters.APIKeyIDs, keyBID)
 	}
 	if payload.Filters.APIKeyIDNames[keyBID] != "Automation" {
 		t.Fatalf("filters.api_key_id_names[%s] = %q, want Automation", keyBID, payload.Filters.APIKeyIDNames[keyBID])
 	}
-	if payload.Filters.APIKeyIDCounts[keyAID] != 1 || payload.Filters.APIKeyIDCounts[keyBID] != 1 {
-		t.Fatalf("filters.api_key_id_counts = %#v, want one request per owned key", payload.Filters.APIKeyIDCounts)
+	if payload.Filters.APIKeyIDNames[keyAID] != "" {
+		t.Fatalf("sibling key %s must not appear in filter options", keyAID)
 	}
 }

--- a/internal/api/handlers/management/usage_public_test.go
+++ b/internal/api/handlers/management/usage_public_test.go
@@ -282,3 +282,146 @@ func TestGetPublicUsageByAPIKeyMasksCredentialEverywhere(t *testing.T) {
 		t.Fatalf("usage.apis does not contain masked key %q: %#v", got.APIKey, got.Usage.APIs)
 	}
 }
+
+func TestGetPublicUsageChartDataReturnsPortalKeyDistributionWithoutSecrets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupOwnedPublicUsageDB(t)
+
+	tenantID := uuid.NewString()
+	endUserID := uuid.NewString()
+	otherUserID := uuid.NewString()
+	keyA := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-chart-secret-a", Name: "Laptop", EndUserID: endUserID}
+	keyB := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-chart-secret-b", Name: "Automation", EndUserID: endUserID}
+	otherKey := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-chart-secret-other", Name: "Other", EndUserID: otherUserID}
+	standalone := usage.APIKeyRow{ID: uuid.NewString(), Key: "sk-chart-secret-standalone", Name: "Standalone"}
+	for _, row := range []usage.APIKeyRow{keyA, keyB, otherKey, standalone} {
+		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Name, err)
+		}
+	}
+
+	db := usage.RuntimeDB()
+	if _, err := db.Exec(`INSERT INTO tenants (id, status, type) VALUES (?, 'active', 'standard')`, tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status)
+		VALUES (?, ?, 'chart-user', 'chart-user', 'Portal Chart User', 'unused', 'active')
+	`, endUserID, tenantID); err != nil {
+		t.Fatalf("insert portal user: %v", err)
+	}
+	portalToken := "cpt_portal-chart-test"
+	portalTokenSum := sha256.Sum256([]byte(portalToken))
+	if _, err := db.Exec(`
+		INSERT INTO end_user_sessions (
+			id, end_user_id, tenant_id, access_token_hash, refresh_token_hash, access_expires_at, refresh_expires_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, uuid.NewString(), endUserID, tenantID, hex.EncodeToString(portalTokenSum[:]), "unused-chart-refresh-hash",
+		time.Now().UTC().Add(time.Hour), time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatalf("insert portal session: %v", err)
+	}
+	enduser.SetDefault(enduser.NewService(db))
+
+	insert := func(row usage.APIKeyRow, tokens int64) {
+		usage.InsertLogWithDetailsIdentity(
+			row.Key, row.ID, row.Name, "gpt-test", "test", "channel", "auth", false,
+			time.Now().UTC(), 1, 0, usage.TokenStats{TotalTokens: tokens}, "", "", "",
+		)
+	}
+	insert(keyA, 3)
+	insert(keyB, 7)
+	insert(keyB, 11)
+	insert(otherKey, 100)
+	insert(standalone, 200)
+
+	h := NewHandler(&config.Config{}, "", nil)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/public/usage/chart-data", bytes.NewReader([]byte(`{"days":7}`)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Authorization", "Bearer "+portalToken)
+	h.UsageLogs().GetPublicUsageChartData(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("portal chart status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	for _, secret := range []string{keyA.Key, keyB.Key, otherKey.Key, standalone.Key} {
+		if strings.Contains(rec.Body.String(), secret) {
+			t.Fatalf("portal chart response leaked secret %q: %s", secret, rec.Body.String())
+		}
+	}
+	if strings.Contains(rec.Body.String(), `"api_key":`) {
+		t.Fatalf("portal chart response contains raw api_key field: %s", rec.Body.String())
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal portal chart response: %v", err)
+	}
+	var distribution []map[string]json.RawMessage
+	if err := json.Unmarshal(payload["api_key_distribution"], &distribution); err != nil {
+		t.Fatalf("unmarshal api_key_distribution: %v; body=%s", err, rec.Body.String())
+	}
+	if len(distribution) != 2 {
+		t.Fatalf("api_key_distribution len = %d, want 2; body=%s", len(distribution), rec.Body.String())
+	}
+	allowedFields := map[string]bool{"api_key_id": true, "name": true, "requests": true, "tokens": true}
+	points := make(map[string]struct {
+		Name     string
+		Requests int64
+		Tokens   int64
+	}, len(distribution))
+	for _, item := range distribution {
+		if len(item) != len(allowedFields) {
+			t.Fatalf("public distribution point fields = %v, want exactly %v", item, allowedFields)
+		}
+		for field := range item {
+			if !allowedFields[field] {
+				t.Fatalf("public distribution point contains unexpected field %q", field)
+			}
+		}
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			t.Fatalf("marshal distribution point: %v", err)
+		}
+		var point struct {
+			APIKeyID string `json:"api_key_id"`
+			Name     string `json:"name"`
+			Requests int64  `json:"requests"`
+			Tokens   int64  `json:"tokens"`
+		}
+		if err := json.Unmarshal(encoded, &point); err != nil {
+			t.Fatalf("unmarshal distribution point: %v", err)
+		}
+		points[point.APIKeyID] = struct {
+			Name     string
+			Requests int64
+			Tokens   int64
+		}{Name: point.Name, Requests: point.Requests, Tokens: point.Tokens}
+	}
+	if point := points[keyA.ID]; point.Name != keyA.Name || point.Requests != 1 || point.Tokens != 3 {
+		t.Fatalf("key A public point = %+v, want own name and requests/tokens 1/3", point)
+	}
+	if point := points[keyB.ID]; point.Name != keyB.Name || point.Requests != 2 || point.Tokens != 18 {
+		t.Fatalf("key B public point = %+v, want own name and requests/tokens 2/18", point)
+	}
+
+	standaloneRec := httptest.NewRecorder()
+	standaloneContext, _ := gin.CreateTestContext(standaloneRec)
+	standaloneContext.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/v0/management/public/usage/chart-data",
+		bytes.NewReader([]byte(`{"api_key":"`+standalone.Key+`","days":7}`)),
+	)
+	standaloneContext.Request.Header.Set("Content-Type", "application/json")
+	h.UsageLogs().GetPublicUsageChartData(standaloneContext)
+	if standaloneRec.Code != http.StatusOK {
+		t.Fatalf("standalone chart status = %d, want %d; body=%s", standaloneRec.Code, http.StatusOK, standaloneRec.Body.String())
+	}
+	var standalonePayload map[string]json.RawMessage
+	if err := json.Unmarshal(standaloneRec.Body.Bytes(), &standalonePayload); err != nil {
+		t.Fatalf("unmarshal standalone chart response: %v", err)
+	}
+	if got := string(standalonePayload["api_key_distribution"]); got != "[]" {
+		t.Fatalf("standalone api_key_distribution = %s, want []", got)
+	}
+}

--- a/internal/api/handlers/management/usage_public_test.go
+++ b/internal/api/handlers/management/usage_public_test.go
@@ -184,16 +184,18 @@ func TestGetPublicUsageByAPIKeyAggregatesOwnedCurrentSecrets(t *testing.T) {
 	}
 	enduser.SetDefault(enduser.NewService(usage.RuntimeDB()))
 
+	// Raw secret is key-scoped (key A only), not the sibling pool.
 	owned := getPublicUsageSnapshot(t, h, keyA.Key)
 	if !owned.Found || len(owned.Usage.APIs) != 1 {
 		t.Fatalf("owned response = %#v", owned)
 	}
 	for _, snapshot := range owned.Usage.APIs {
-		if snapshot.TotalRequests != 3 || snapshot.TotalTokens != 30 {
-			t.Fatalf("owned aggregate = %+v, want requests=3 tokens=30", snapshot)
+		if snapshot.TotalRequests != 1 || snapshot.TotalTokens != 10 {
+			t.Fatalf("owned key-scoped = %+v, want requests=1 tokens=10", snapshot)
 		}
 	}
 
+	// Portal cpt_ session remains account-wide across owned keys.
 	portal := getPortalPublicUsageSnapshot(t, h, portalToken)
 	if !portal.Found || len(portal.Usage.APIs) != 1 {
 		t.Fatalf("portal response = %#v", portal)
@@ -216,10 +218,17 @@ func TestGetPublicUsageByAPIKeyAggregatesOwnedCurrentSecrets(t *testing.T) {
 	if err := usage.UpdateAPIKeyByIDForTenant(tenantID, rotated); err != nil {
 		t.Fatalf("UpdateAPIKeyByIDForTenant: %v", err)
 	}
+	// Rotated secret has no in-memory snapshot under the new value; sibling key B stays independent.
 	afterRotate := getPublicUsageSnapshot(t, h, rotated.Key)
 	for _, snapshot := range afterRotate.Usage.APIs {
+		if snapshot.TotalRequests != 0 || snapshot.TotalTokens != 0 {
+			t.Fatalf("post-rotate rotated secret = %+v, want empty key-scoped snapshot", snapshot)
+		}
+	}
+	sibling := getPublicUsageSnapshot(t, h, keyB.Key)
+	for _, snapshot := range sibling.Usage.APIs {
 		if snapshot.TotalRequests != 2 || snapshot.TotalTokens != 20 {
-			t.Fatalf("post-rotate current-secret aggregate = %+v, want surviving current key B only", snapshot)
+			t.Fatalf("sibling key B = %+v, want requests=2 tokens=20", snapshot)
 		}
 	}
 }

--- a/internal/api/handlers/management/usage_summary_public.go
+++ b/internal/api/handlers/management/usage_summary_public.go
@@ -6,20 +6,29 @@ import (
 
 	"github.com/gin-gonic/gin"
 	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	log "github.com/sirupsen/logrus"
 )
 
 type usageSummaryResponse struct {
-	Found  bool             `json:"found"`
-	Range  string           `json:"range"`
-	Stats  usageStatsBody   `json:"stats"`
-	Limits *usageLimitsBody `json:"limits,omitempty"`
+	Found       bool             `json:"found"`
+	Range       string           `json:"range"`
+	Stats       usageStatsBody   `json:"stats"`
+	Limits      *usageLimitsBody `json:"limits,omitempty"`
+	QuotaScopes []quotaScopeBody `json:"quota-scopes,omitempty"`
 }
 
 type usageStatsBody struct {
 	TotalCalls int64   `json:"total_calls"`
 	QuotaCost  float64 `json:"quota_cost"`
+}
+
+type quotaScopeBody struct {
+	Scope                string                 `json:"scope"`
+	PeriodSpending       []quota.PeriodSpending `json:"period-spending"`
+	DailySpendingUsed    float64                `json:"daily-spending-used"`
+	LifetimeSpendingUsed float64                `json:"lifetime-spending-used"`
 }
 
 // usageLimitsBody exposes only limits that are configured (>0) plus live usage.
@@ -68,6 +77,12 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 	if subject.EndUserID != "" {
 		limits = buildEndUserUsageLimits(subject.EndUserID)
 	}
+	quotaScopes, err := buildPublicQuotaScopes(subject, row)
+	if err != nil {
+		log.Warnf("management usage summary quota scopes failed: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query quota usage"})
+		return
+	}
 
 	resp := usageSummaryResponse{
 		Found: found,
@@ -76,7 +91,8 @@ func (h *Handler) GetPublicUsageSummary(c *gin.Context) {
 			TotalCalls: stats.Total,
 			QuotaCost:  stats.TotalCost,
 		},
-		Limits: limits,
+		Limits:      limits,
+		QuotaScopes: quotaScopes,
 	}
 	c.JSON(http.StatusOK, resp)
 }
@@ -174,4 +190,33 @@ func buildPublicUsageLimits(apiKey string, row *usage.APIKeyRow) *usageLimitsBod
 		return nil
 	}
 	return out
+}
+
+func buildPublicQuotaScopes(subject publicUsageSubject, row *usage.APIKeyRow) ([]quotaScopeBody, error) {
+	out := make([]quotaScopeBody, 0, 2)
+	if subject.EndUserID != "" {
+		accountQuota := usage.GetEndUserQuota(subject.EndUserID)
+		if accountQuota != nil {
+			effective := usage.EffectiveEndUserQuota(*accountQuota)
+			used, err := usage.QueryPeriodSpendingByEndUserForTenant(subject.TenantID, subject.EndUserID)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, quotaScopeBody{Scope: "account", PeriodSpending: quota.BuildPeriodSpending(effective.PeriodSpendingLimits, used), DailySpendingUsed: used.Day, LifetimeSpendingUsed: used.Lifetime})
+		}
+		// Portal token requests represent the account only. Raw owned keys include both scopes.
+		if subject.APIKey == "" {
+			return out, nil
+		}
+	}
+	if row != nil && !row.Disabled {
+		keyLimits := row.PeriodSpendingLimits
+		keyLimits.Day = row.DailySpendingLimit
+		used, err := usage.QueryPeriodSpendingByAPIKeyIDForTenant(subject.TenantID, row.ID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, quotaScopeBody{Scope: "key", PeriodSpending: quota.BuildPeriodSpending(keyLimits, used), DailySpendingUsed: used.Day, LifetimeSpendingUsed: used.Lifetime})
+	}
+	return out, nil
 }

--- a/internal/api/handlers/management/usage_summary_public_test.go
+++ b/internal/api/handlers/management/usage_summary_public_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
@@ -392,9 +393,22 @@ func TestGetPublicUsageSummary_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 	keyA := "sk-business-owned-a"
 	keyB := "sk-business-owned-b"
 	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := usage.RuntimeDB().Exec(`CREATE TABLE IF NOT EXISTS end_users (
+		id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, display_name TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'active',
+		permission_profile_id TEXT NOT NULL DEFAULT '', daily_limit INTEGER NOT NULL DEFAULT 0, total_quota INTEGER NOT NULL DEFAULT 0,
+		spending_limit REAL NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+		five_hour_spending_limit REAL NOT NULL DEFAULT 0, weekly_spending_limit REAL NOT NULL DEFAULT 0, monthly_spending_limit REAL NOT NULL DEFAULT 0,
+		concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0, tpm_limit INTEGER NOT NULL DEFAULT 0,
+		allowed_models TEXT NOT NULL DEFAULT '[]', allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]', system_prompt TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create end_users: %v", err)
+	}
+	if _, err := usage.RuntimeDB().Exec(`INSERT INTO end_users(id,tenant_id,display_name,daily_spending_limit) VALUES(?,?,?,300)`, endUserID, tenantID, "Business"); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
 	for _, row := range []usage.APIKeyRow{
-		{ID: "00000000-0000-0000-0000-0000000000a1", Key: keyA, Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
-		{ID: "00000000-0000-0000-0000-0000000000b1", Key: keyB, Name: "Automation", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: "00000000-0000-0000-0000-0000000000a1", Key: keyA, Name: "Laptop", EndUserID: endUserID, DailySpendingLimit: 100, PeriodSpendingLimits: quota.PeriodSpendingLimits{Day: 100}, CreatedAt: now, UpdatedAt: now},
+		{ID: "00000000-0000-0000-0000-0000000000b1", Key: keyB, Name: "Automation", EndUserID: endUserID, DailySpendingLimit: 100, PeriodSpendingLimits: quota.PeriodSpendingLimits{Day: 100}, CreatedAt: now, UpdatedAt: now},
 	} {
 		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
 			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
@@ -419,11 +433,18 @@ func TestGetPublicUsageSummary_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 		Stats struct {
 			TotalCalls int64 `json:"total_calls"`
 		} `json:"stats"`
+		QuotaScopes []struct {
+			Scope          string                 `json:"scope"`
+			PeriodSpending []quota.PeriodSpending `json:"period-spending"`
+		} `json:"quota-scopes"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if !got.Found || got.Stats.TotalCalls != 2 {
 		t.Fatalf("summary = %+v, want found and two account calls", got)
+	}
+	if len(got.QuotaScopes) != 2 || got.QuotaScopes[0].Scope != "account" || got.QuotaScopes[1].Scope != "key" {
+		t.Fatalf("quota scopes = %+v, want account then key", got.QuotaScopes)
 	}
 }

--- a/internal/api/handlers/management/usage_summary_public_test.go
+++ b/internal/api/handlers/management/usage_summary_public_test.go
@@ -441,10 +441,12 @@ func TestGetPublicUsageSummary_AggregatesOwnedBusinessTenantKeys(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if !got.Found || got.Stats.TotalCalls != 2 {
-		t.Fatalf("summary = %+v, want found and two account calls", got)
+	// Raw secret summary is key-scoped for call stats (not whole account).
+	if !got.Found || got.Stats.TotalCalls != 1 {
+		t.Fatalf("summary = %+v, want found and one key call", got)
 	}
-	if len(got.QuotaScopes) != 2 || got.QuotaScopes[0].Scope != "account" || got.QuotaScopes[1].Scope != "key" {
-		t.Fatalf("quota scopes = %+v, want account then key", got.QuotaScopes)
+	// Raw secret no longer promotes to EndUserID, so only key-scope quota cards appear.
+	if len(got.QuotaScopes) != 1 || got.QuotaScopes[0].Scope != "key" {
+		t.Fatalf("quota scopes = %+v, want key only", got.QuotaScopes)
 	}
 }

--- a/internal/api/middleware/quota.go
+++ b/internal/api/middleware/quota.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -203,6 +205,10 @@ func QuotaMiddleware() gin.HandlerFunc {
 		tpmLimit := parseIntMetadata(metadata, "tpm-limit")
 		spendingLimit := parseFloatMetadata(metadata, "spending-limit")
 		dailySpendingLimit := parseFloatMetadata(metadata, "daily-spending-limit")
+		accountPeriodLimits := parsePeriodLimitsMetadata(metadata, "account-period-spending-limit-")
+		keyPeriodLimits := parsePeriodLimitsMetadata(metadata, "key-period-spending-limit-")
+		tenantID := strings.TrimSpace(metadata["tenant-id"])
+		apiKeyID := strings.TrimSpace(metadata["api-key-id"])
 		diagnostics.SetQuotaLimits(c, diagnostics.QuotaSnapshot{
 			DailyLimit:         dailyLimit,
 			TotalQuota:         totalQuota,
@@ -217,7 +223,7 @@ func QuotaMiddleware() gin.HandlerFunc {
 		UpdateKeyLimits(subject, rpmLimit, tpmLimit)
 
 		// No limits configured — skip all checks
-		if dailyLimit <= 0 && totalQuota <= 0 && concurrencyLimit <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 && dailySpendingLimit <= 0 {
+		if dailyLimit <= 0 && totalQuota <= 0 && concurrencyLimit <= 0 && rpmLimit <= 0 && tpmLimit <= 0 && spendingLimit <= 0 && dailySpendingLimit <= 0 && !hasPeriodLimits(accountPeriodLimits) && !hasPeriodLimits(keyPeriodLimits) {
 			c.Next()
 			return
 		}
@@ -258,7 +264,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if dailyLimit > 0 {
 			todayCount, err := countTodayUsage(apiKey, endUserID)
 			if err != nil {
-				log.Warnf("quota: failed to query daily usage for key %s: %v", maskKey(apiKey), err)
+				rejectQuotaUsageUnavailable(c, quotaScope(endUserID), "day", tenantID, stableQuotaSubject(apiKeyID, endUserID), err)
+				return
 			} else if todayCount >= int64(dailyLimit) {
 				rejectQuotaLimit(c, "daily", float64(dailyLimit), float64(todayCount), "daily_limit_exceeded",
 					fmt.Sprintf("Daily request limit exceeded: %d/%d requests used today. Raise the daily request limit in the permission profile, or wait until the next project day.", todayCount, dailyLimit))
@@ -270,7 +277,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if totalQuota > 0 {
 			totalCount, err := countTotalUsage(apiKey, endUserID)
 			if err != nil {
-				log.Warnf("quota: failed to query total usage for key %s: %v", maskKey(apiKey), err)
+				rejectQuotaUsageUnavailable(c, quotaScope(endUserID), "lifetime", tenantID, stableQuotaSubject(apiKeyID, endUserID), err)
+				return
 			} else if totalCount >= int64(totalQuota) {
 				rejectQuotaLimit(c, "total", float64(totalQuota), float64(totalCount), "total_quota_exceeded",
 					fmt.Sprintf("Total request quota exhausted: %d/%d lifetime requests used. Raise the total request quota in the permission profile to continue.", totalCount, totalQuota))
@@ -282,7 +290,8 @@ func QuotaMiddleware() gin.HandlerFunc {
 		if spendingLimit > 0 {
 			totalCost, err := queryTotalCostUsage(apiKey, endUserID)
 			if err != nil {
-				log.Warnf("quota: failed to query total cost for key %s: %v", maskKey(apiKey), err)
+				rejectQuotaUsageUnavailable(c, quotaScope(endUserID), "lifetime", tenantID, stableQuotaSubject(apiKeyID, endUserID), err)
+				return
 			} else if totalCost >= spendingLimit {
 				rejectQuotaLimit(c, "spending", spendingLimit, totalCost, "spending_limit_exceeded",
 					fmt.Sprintf("Lifetime spending limit exceeded: $%.2f of $%.2f used. Raise the spending limit to continue.", totalCost, spendingLimit))
@@ -291,10 +300,11 @@ func QuotaMiddleware() gin.HandlerFunc {
 		}
 
 		// --- Daily spending limit check (from usage DB) ---
-		if dailySpendingLimit > 0 {
+		if dailySpendingLimit > 0 && accountPeriodLimits.Day <= 0 && keyPeriodLimits.Day <= 0 {
 			todayCost, err := queryTodayCostUsage(apiKey, endUserID)
 			if err != nil {
-				log.Warnf("quota: failed to query today cost for key %s: %v", maskKey(apiKey), err)
+				rejectQuotaUsageUnavailable(c, quotaScope(endUserID), "day", tenantID, stableQuotaSubject(apiKeyID, endUserID), err)
+				return
 			} else if todayCost >= dailySpendingLimit {
 				rejectQuotaLimit(c, "daily_spending", dailySpendingLimit, todayCost, "daily_spending_limit_exceeded",
 					fmt.Sprintf("Daily spending limit exceeded: $%.2f of $%.2f used today. Raise the daily spending limit in the permission profile, reset today's spending, or wait until the next project day.", todayCost, dailySpendingLimit))
@@ -302,8 +312,99 @@ func QuotaMiddleware() gin.HandlerFunc {
 			}
 		}
 
+		if hasPeriodLimits(accountPeriodLimits) {
+			used, err := queryPeriodByEndUserFunc(tenantID, endUserID)
+			if err != nil {
+				rejectQuotaUsageUnavailable(c, "account", "period", tenantID, endUserID, err)
+				return
+			}
+			if rejectConfiguredPeriod(c, "account", accountPeriodLimits, used) {
+				return
+			}
+		}
+		if hasPeriodLimits(keyPeriodLimits) {
+			used, err := queryPeriodByKeyFunc(tenantID, apiKeyID)
+			if err != nil {
+				rejectQuotaUsageUnavailable(c, "key", "period", tenantID, apiKeyID, err)
+				return
+			}
+			if rejectConfiguredPeriod(c, "key", keyPeriodLimits, used) {
+				return
+			}
+		}
+
 		c.Next()
 	}
+}
+
+func rejectConfiguredPeriod(c *gin.Context, scope string, limits quota.PeriodSpendingLimits, used quota.PeriodSpendingUsage) bool {
+	for _, period := range quota.OrderedPeriods {
+		limit := limits.Value(period)
+		current := used.Value(period)
+		if limit <= 0 || current < limit {
+			continue
+		}
+		code := "period_spending_limit_exceeded"
+		if period == quota.PeriodDay {
+			code = "daily_spending_limit_exceeded"
+		}
+		scopeLabel := "Key"
+		if scope == "account" {
+			scopeLabel = "Account"
+		}
+		message := fmt.Sprintf("%s %s spending limit exceeded: $%.2f of $%.2f used.", scopeLabel, period, current, limit)
+		rejectPeriodQuotaLimit(c, scope, period, limit, current, code, message)
+		return true
+	}
+	return false
+}
+
+func rejectPeriodQuotaLimit(c *gin.Context, scope string, period quota.Period, limit, current float64, code, message string) {
+	const errType = "rate_limit_exceeded"
+	diagnostics.SetQuotaRejection(c, "period_spending", limit, current, code, errType, message)
+	c.Header("X-CliRelay-Quota-Code", code)
+	c.Header("X-CliRelay-Quota-Rejected-By", "period_spending")
+	c.Header("X-CliRelay-Quota-Scope", scope)
+	c.Header("X-CliRelay-Quota-Period", string(period))
+	c.Header("X-CliRelay-Quota-Limit", formatQuotaNumber(limit))
+	c.Header("X-CliRelay-Quota-Current", formatQuotaNumber(current))
+	c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": gin.H{
+		"message": message, "type": errType, "code": code, "scope": scope, "period": period,
+	}})
+}
+
+func rejectQuotaUsageUnavailable(c *gin.Context, scope, period, tenantID, subjectID string, err error) {
+	log.WithError(err).WithFields(log.Fields{"tenant": tenantID, "scope": scope, "period": period, "subject_id": subjectID}).Error("quota usage query unavailable")
+	c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{
+		"code": "quota_usage_unavailable", "message": "Quota usage is temporarily unavailable", "scope": scope, "period": period,
+	}})
+}
+
+func quotaScope(endUserID string) string {
+	if strings.TrimSpace(endUserID) != "" {
+		return "account"
+	}
+	return "key"
+}
+
+func stableQuotaSubject(apiKeyID, endUserID string) string {
+	if strings.TrimSpace(endUserID) != "" {
+		return strings.TrimSpace(endUserID)
+	}
+	return strings.TrimSpace(apiKeyID)
+}
+
+func parsePeriodLimitsMetadata(metadata map[string]string, prefix string) quota.PeriodSpendingLimits {
+	return quota.PeriodSpendingLimits{
+		FiveHour: parseFloatMetadata(metadata, prefix+"5h"),
+		Day:      parseFloatMetadata(metadata, prefix+"day"),
+		Week:     parseFloatMetadata(metadata, prefix+"week"),
+		Month:    parseFloatMetadata(metadata, prefix+"month"),
+	}
+}
+
+func hasPeriodLimits(limits quota.PeriodSpendingLimits) bool {
+	return limits.FiveHour > 0 || limits.Day > 0 || limits.Week > 0 || limits.Month > 0
 }
 
 // rejectQuotaLimit writes a 429 with a distinct code/message and diagnostic headers.
@@ -333,18 +434,26 @@ func formatQuotaNumber(v float64) string {
 
 // ─── Usage DB query functions (injected to avoid import cycle) ──────────────
 
+var errQuotaUsageUnavailable = errors.New("quota usage unavailable")
+
 // Key-scoped defaults; InitQuotaUsageFuncs wires real implementations.
 // When endUserID is set, InitQuotaUsageFuncs also wires account-scoped aggregators.
 var (
-	countTodayByKeyFunc     = func(string) (int64, error) { return 0, nil }
-	countTotalByKeyFunc     = func(string) (int64, error) { return 0, nil }
-	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
-	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+	countTodayByKeyFunc     = func(string) (int64, error) { return 0, errQuotaUsageUnavailable }
+	countTotalByKeyFunc     = func(string) (int64, error) { return 0, errQuotaUsageUnavailable }
+	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, errQuotaUsageUnavailable }
+	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, errQuotaUsageUnavailable }
 
-	countTodayByEndUserFunc     = func(string) (int64, error) { return 0, nil }
-	countTotalByEndUserFunc     = func(string) (int64, error) { return 0, nil }
-	queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
-	queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+	countTodayByEndUserFunc     = func(string) (int64, error) { return 0, errQuotaUsageUnavailable }
+	countTotalByEndUserFunc     = func(string) (int64, error) { return 0, errQuotaUsageUnavailable }
+	queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, errQuotaUsageUnavailable }
+	queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, errQuotaUsageUnavailable }
+	queryPeriodByKeyFunc        = func(string, string) (quota.PeriodSpendingUsage, error) {
+		return quota.PeriodSpendingUsage{}, errQuotaUsageUnavailable
+	}
+	queryPeriodByEndUserFunc = func(string, string) (quota.PeriodSpendingUsage, error) {
+		return quota.PeriodSpendingUsage{}, errQuotaUsageUnavailable
+	}
 )
 
 // InitQuotaUsageFuncs injects the usage DB query functions into the middleware.
@@ -373,6 +482,14 @@ func InitQuotaEndUserUsageFuncs(
 	countTotalByEndUserFunc = countTotal
 	queryTotalCostByEndUserFunc = totalCost
 	queryTodayCostByEndUserFunc = todayCost
+}
+
+func InitQuotaPeriodUsageFuncs(
+	keyUsage func(string, string) (quota.PeriodSpendingUsage, error),
+	endUserUsage func(string, string) (quota.PeriodSpendingUsage, error),
+) {
+	queryPeriodByKeyFunc = keyUsage
+	queryPeriodByEndUserFunc = endUserUsage
 }
 
 func countTodayUsage(apiKey, endUserID string) (int64, error) {

--- a/internal/api/middleware/quota_test.go
+++ b/internal/api/middleware/quota_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 )
 
 func TestQuotaMiddlewareEnforcesConcurrencyLimitPerKey(t *testing.T) {
@@ -245,10 +247,95 @@ func resetQuotaMiddlewareState(t *testing.T) {
 	countTotalByKeyFunc = func(string) (int64, error) { return 0, nil }
 	queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
 	queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+	countTodayByEndUserFunc = func(string) (int64, error) { return 0, nil }
+	countTotalByEndUserFunc = func(string) (int64, error) { return 0, nil }
+	queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+	queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+	queryPeriodByKeyFunc = func(string, string) (quota.PeriodSpendingUsage, error) { return quota.PeriodSpendingUsage{}, nil }
+	queryPeriodByEndUserFunc = func(string, string) (quota.PeriodSpendingUsage, error) { return quota.PeriodSpendingUsage{}, nil }
 	t.Cleanup(func() {
 		countTodayByKeyFunc = func(string) (int64, error) { return 0, nil }
 		countTotalByKeyFunc = func(string) (int64, error) { return 0, nil }
 		queryTotalCostByKeyFunc = func(string) (float64, error) { return 0, nil }
 		queryTodayCostByKeyFunc = func(string) (float64, error) { return 0, nil }
+		countTodayByEndUserFunc = func(string) (int64, error) { return 0, nil }
+		countTotalByEndUserFunc = func(string) (int64, error) { return 0, nil }
+		queryTotalCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+		queryTodayCostByEndUserFunc = func(string) (float64, error) { return 0, nil }
+		queryPeriodByKeyFunc = func(string, string) (quota.PeriodSpendingUsage, error) { return quota.PeriodSpendingUsage{}, nil }
+		queryPeriodByEndUserFunc = func(string, string) (quota.PeriodSpendingUsage, error) { return quota.PeriodSpendingUsage{}, nil }
 	})
+}
+
+func TestQuotaMiddlewareRejectsAccountAndKeyPeriodScopesSeparately(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cases := []struct {
+		name        string
+		accountUsed float64
+		keyUsed     float64
+		wantScope   string
+	}{
+		{name: "account ceiling", accountUsed: 100, keyUsed: 10, wantScope: "account"},
+		{name: "key sub quota", accountUsed: 10, keyUsed: 20, wantScope: "key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetQuotaMiddlewareState(t)
+			queryPeriodByEndUserFunc = func(tenantID, endUserID string) (quota.PeriodSpendingUsage, error) {
+				return quota.PeriodSpendingUsage{Day: tc.accountUsed}, nil
+			}
+			queryPeriodByKeyFunc = func(tenantID, apiKeyID string) (quota.PeriodSpendingUsage, error) {
+				return quota.PeriodSpendingUsage{Day: tc.keyUsed}, nil
+			}
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("apiKey", "sk-period")
+				c.Set("accessMetadata", map[string]string{
+					"tenant-id": "tenant-a", "end-user-id": "user-a", "api-key-id": "key-a",
+					"account-period-spending-limit-day": "100", "key-period-spending-limit-day": "20",
+				})
+				c.Next()
+			})
+			router.Use(QuotaMiddleware())
+			router.POST("/v1/chat/completions", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, newQuotaPostRequest("sk-period"))
+			if recorder.Code != http.StatusTooManyRequests {
+				t.Fatalf("status = %d, want 429; body=%s", recorder.Code, recorder.Body.String())
+			}
+			if got := recorder.Header().Get("X-CliRelay-Quota-Scope"); got != tc.wantScope {
+				t.Fatalf("scope = %q, want %q", got, tc.wantScope)
+			}
+			if got := recorder.Header().Get("X-CliRelay-Quota-Period"); got != "day" {
+				t.Fatalf("period = %q, want day", got)
+			}
+		})
+	}
+}
+
+func TestQuotaMiddlewareFailsClosedWhenUsageUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetQuotaMiddlewareState(t)
+	queryPeriodByEndUserFunc = func(string, string) (quota.PeriodSpendingUsage, error) {
+		return quota.PeriodSpendingUsage{}, errors.New("database unavailable")
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("apiKey", "sk-period")
+		c.Set("accessMetadata", map[string]string{
+			"tenant-id": "tenant-a", "end-user-id": "user-a", "api-key-id": "key-a",
+			"account-period-spending-limit-week": "100",
+		})
+		c.Next()
+	})
+	router.Use(QuotaMiddleware())
+	router.POST("/v1/chat/completions", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, newQuotaPostRequest("sk-period"))
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), `"code":"quota_usage_unavailable"`) {
+		t.Fatalf("body = %s, want quota_usage_unavailable", recorder.Body.String())
+	}
 }

--- a/internal/api/routes/management_identity_routes.go
+++ b/internal/api/routes/management_identity_routes.go
@@ -32,8 +32,6 @@ func registerIdentityAuthRoutes(engine *gin.Engine, h *managementhandlers.Handle
 	portal.GET("/api-keys/:id/secret", h.GetPortalAPIKeySecret)
 	portal.PATCH("/api-keys/:id", h.PatchPortalAPIKey)
 	portal.POST("/api-keys/:id/rotate", h.PostPortalAPIKeyRotate)
-	portal.POST("/api-keys/:id/daily-spending/reset", h.PostPortalAPIKeyDailySpendingReset)
-	portal.GET("/api-keys/:id/daily-spending/reset-history", h.GetPortalAPIKeyDailySpendingResetHistory)
 	portal.DELETE("/api-keys/:id", h.DeletePortalAPIKey)
 }
 

--- a/internal/api/routes/management_identity_routes.go
+++ b/internal/api/routes/management_identity_routes.go
@@ -32,6 +32,8 @@ func registerIdentityAuthRoutes(engine *gin.Engine, h *managementhandlers.Handle
 	portal.GET("/api-keys/:id/secret", h.GetPortalAPIKeySecret)
 	portal.PATCH("/api-keys/:id", h.PatchPortalAPIKey)
 	portal.POST("/api-keys/:id/rotate", h.PostPortalAPIKeyRotate)
+	portal.POST("/api-keys/:id/daily-spending/reset", h.PostPortalAPIKeyDailySpendingReset)
+	portal.GET("/api-keys/:id/daily-spending/reset-history", h.GetPortalAPIKeyDailySpendingResetHistory)
 	portal.DELETE("/api-keys/:id", h.DeletePortalAPIKey)
 }
 
@@ -59,6 +61,8 @@ func registerManagementIdentityRoutes(group *gin.RouterGroup, h *managementhandl
 	group.POST("/end-users/:id/api-keys", h.PostEndUserAPIKey)
 	group.PATCH("/end-users/:id/api-keys/:key_id", h.PatchEndUserAPIKey)
 	group.POST("/end-users/:id/api-keys/:key_id/rotate", h.PostEndUserAPIKeyRotate)
+	group.POST("/end-users/:id/api-keys/:key_id/daily-spending/reset", h.PostEndUserAPIKeyDailySpendingReset)
+	group.GET("/end-users/:id/api-keys/:key_id/daily-spending/reset-history", h.GetEndUserAPIKeyDailySpendingResetHistory)
 	group.DELETE("/end-users/:id/api-keys/:key_id", h.DeleteEndUserAPIKey)
 	group.POST("/end-users/:id/api-keys/:key_id/default", h.PostEndUserAPIKeyDefault)
 

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 298; got != want {
+	if got, want := len(routes), 296; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -46,8 +46,6 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"POST /v0/management/api-call",
 		"PATCH /v0/management/api-key-entries",
 		"GET /v0/management/end-users/:id/daily-spending/reset-history",
-		"POST /v0/portal/api-keys/:id/daily-spending/reset",
-		"GET /v0/portal/api-keys/:id/daily-spending/reset-history",
 		"POST /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset",
 		"GET /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset-history",
 		"POST /v0/management/opencode-go-api-key/usage",
@@ -190,8 +188,6 @@ func expectedManagementRoutes() []string {
 		"GET /v0/portal/api-keys/:id/secret",
 		"PATCH /v0/portal/api-keys/:id",
 		"POST /v0/portal/api-keys/:id/rotate",
-		"POST /v0/portal/api-keys/:id/daily-spending/reset",
-		"GET /v0/portal/api-keys/:id/daily-spending/reset-history",
 		"DELETE /v0/portal/api-keys/:id",
 		"POST /v0/portal/auth/login",
 		"POST /v0/portal/auth/logout",

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 294; got != want {
+	if got, want := len(routes), 298; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -46,6 +46,10 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"POST /v0/management/api-call",
 		"PATCH /v0/management/api-key-entries",
 		"GET /v0/management/end-users/:id/daily-spending/reset-history",
+		"POST /v0/portal/api-keys/:id/daily-spending/reset",
+		"GET /v0/portal/api-keys/:id/daily-spending/reset-history",
+		"POST /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset",
+		"GET /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset-history",
 		"POST /v0/management/opencode-go-api-key/usage",
 		"GET /v0/management/cline-api-key",
 		"PUT /v0/management/cline-api-key",
@@ -186,6 +190,8 @@ func expectedManagementRoutes() []string {
 		"GET /v0/portal/api-keys/:id/secret",
 		"PATCH /v0/portal/api-keys/:id",
 		"POST /v0/portal/api-keys/:id/rotate",
+		"POST /v0/portal/api-keys/:id/daily-spending/reset",
+		"GET /v0/portal/api-keys/:id/daily-spending/reset-history",
 		"DELETE /v0/portal/api-keys/:id",
 		"POST /v0/portal/auth/login",
 		"POST /v0/portal/auth/logout",
@@ -222,6 +228,8 @@ func expectedManagementRoutes() []string {
 		"POST /v0/management/end-users/:id/api-keys",
 		"PATCH /v0/management/end-users/:id/api-keys/:key_id",
 		"POST /v0/management/end-users/:id/api-keys/:key_id/rotate",
+		"POST /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset",
+		"GET /v0/management/end-users/:id/api-keys/:key_id/daily-spending/reset-history",
 		"DELETE /v0/management/end-users/:id/api-keys/:key_id",
 		"POST /v0/management/end-users/:id/api-keys/:key_id/default",
 		"GET /v0/management/audit-logs",

--- a/internal/auth/xai/quota.go
+++ b/internal/auth/xai/quota.go
@@ -1,0 +1,112 @@
+package xai
+
+import (
+	"math"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	// BillingWeeklyPath is the Grok Build weekly included-usage endpoint.
+	BillingWeeklyPath = "/billing?format=credits"
+	// CLIWeeklyBillingURL is the production Grok Build weekly included-usage URL.
+	CLIWeeklyBillingURL = CLIChatProxyBaseURL + BillingWeeklyPath
+)
+
+// WeeklyBilling describes the quota fields shared by runtime recovery probes and
+// the management account-status view.
+type WeeklyBilling struct {
+	RemainingPercent float64
+	ResetAt          time.Time
+	Products         []WeeklyProductBilling
+}
+
+// WeeklyProductBilling describes one product-specific weekly usage entry.
+type WeeklyProductBilling struct {
+	Name             string
+	RemainingPercent float64
+}
+
+// ParseWeeklyBilling parses the Grok Build billing response's weekly usage data.
+func ParseWeeklyBilling(body []byte) (WeeklyBilling, bool) {
+	cfg := gjson.GetBytes(body, "config")
+	if !cfg.Exists() {
+		return WeeklyBilling{}, false
+	}
+	current := firstBillingResult(cfg, "currentPeriod", "current_period")
+	periodType := strings.ToLower(strings.TrimSpace(current.Get("type").String()))
+	used := firstBillingResult(cfg, "creditUsagePercent", "credit_usage_percent")
+	products := firstBillingResult(cfg, "productUsage", "product_usage")
+	if !used.Exists() && !strings.Contains(periodType, "weekly") && !products.IsArray() {
+		return WeeklyBilling{}, false
+	}
+
+	weekly := WeeklyBilling{RemainingPercent: 100}
+	if used.Exists() {
+		weekly.RemainingPercent = math.Round(100 - clampBillingPercent(used.Float()))
+	}
+	reset := firstBillingResult(current, "end")
+	if !reset.Exists() {
+		reset = firstBillingResult(cfg, "billingPeriodEnd", "billing_period_end")
+	}
+	weekly.ResetAt = parseBillingTime(reset)
+
+	if products.IsArray() {
+		weekly.Products = make([]WeeklyProductBilling, 0)
+		products.ForEach(func(_, product gjson.Result) bool {
+			item := WeeklyProductBilling{
+				Name:             strings.TrimSpace(product.Get("product").String()),
+				RemainingPercent: 100,
+			}
+			if productUsed := firstBillingResult(product, "usagePercent", "usage_percent"); productUsed.Exists() {
+				item.RemainingPercent = math.Round(100 - clampBillingPercent(productUsed.Float()))
+			}
+			weekly.Products = append(weekly.Products, item)
+			return true
+		})
+	}
+	return weekly, true
+}
+
+func firstBillingResult(root gjson.Result, paths ...string) gjson.Result {
+	for _, path := range paths {
+		if value := root.Get(path); value.Exists() {
+			return value
+		}
+	}
+	return gjson.Result{}
+}
+
+func parseBillingTime(value gjson.Result) time.Time {
+	if !value.Exists() {
+		return time.Time{}
+	}
+	raw := strings.TrimSpace(value.String())
+	if raw != "" {
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if parsed, err := time.Parse(layout, raw); err == nil {
+				return parsed.UTC()
+			}
+		}
+	}
+	seconds := value.Float()
+	if seconds <= 0 {
+		return time.Time{}
+	}
+	if seconds > 1e12 {
+		seconds /= 1000
+	}
+	return time.Unix(int64(seconds), int64((seconds-float64(int64(seconds)))*float64(time.Second))).UTC()
+}
+
+func clampBillingPercent(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -45,6 +45,7 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
+		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 
 	ctxSignal, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -88,6 +89,7 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
+		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -166,17 +168,6 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 	} else if created > 0 {
 		log.Infof("enduser: backfilled %d end users from api keys", created)
 	}
-	// After keys + end-user ownership are stable, rebuild usage rollup once.
-	// Metadata cleanup is gated on this marker so detail retention cannot run first.
-	if err := usage.RunUsageRollupBackfillAtInit(); err != nil {
-		return fmt.Errorf("usage rollup backfill: %w", err)
-	}
-	if _, err := usage.RunAIAccountSharedSubjectBackfillAtInit(); err != nil {
-		return fmt.Errorf("ai account shared subject backfill: %w", err)
-	}
-	// Old blue-green slot may keep writing request_logs without rollup until drain.
-	// Catch-up absolute rebuilds after drain so those rows are not permanently missing.
-	usage.ScheduleUsageRollupBlueGreenCatchup()
 	usage.MigrateAPIKeyPermissionProfilesFromYAML(configPath)
 	usage.MigrateRoutingConfigFromConfig(cfg, configPath)
 	usage.ApplyStoredRoutingConfig(cfg)
@@ -195,6 +186,49 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 		middleware.RecordTokenUsageForRequest(apiKey, endUserID, totalTokens)
 	})
 	return nil
+}
+
+type runtimeDataStackMaintenanceOps struct {
+	runAIAccountSharedSubjectBackfill func() error
+	scheduleUsageRollupCatchup        func()
+}
+
+func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
+	return runtimeDataStackMaintenanceOps{
+		runAIAccountSharedSubjectBackfill: func() error {
+			_, err := usage.RunAIAccountSharedSubjectBackfillAtInit()
+			return err
+		},
+		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
+	}
+}
+
+func runtimeDataStackPostStartHooks(ops runtimeDataStackMaintenanceOps) cliproxy.Hooks {
+	return cliproxy.Hooks{OnAfterStart: func(*cliproxy.Service) {
+		go runRuntimeDataStackPostStartMaintenance(ops)
+	}}
+}
+
+func runRuntimeDataStackPostStartMaintenance(ops runtimeDataStackMaintenanceOps) {
+	startedAt := time.Now()
+	log.Info("usage: post-listen runtime data maintenance started")
+
+	if ops.runAIAccountSharedSubjectBackfill != nil {
+		stepStartedAt := time.Now()
+		if err := ops.runAIAccountSharedSubjectBackfill(); err != nil {
+			log.WithError(err).Error("usage: post-listen ai account shared subject backfill failed")
+		} else {
+			log.Infof("usage: post-listen ai account shared subject backfill completed in %s", time.Since(stepStartedAt).Round(time.Millisecond))
+		}
+	}
+	// Old blue-green slot may keep writing request_logs until drain. Run the one
+	// absolute rebuild only after the drain window so it includes both slots and
+	// cannot block the HTTP listener or deployment readiness.
+	if ops.scheduleUsageRollupCatchup != nil {
+		ops.scheduleUsageRollupCatchup()
+	}
+
+	log.Infof("usage: post-listen runtime data maintenance scheduled in %s", time.Since(startedAt).Round(time.Millisecond))
 }
 
 // WaitForCloudDeploy waits indefinitely for shutdown signals in cloud deploy mode

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -186,6 +186,7 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 	settingsstore.ApplyStoredRuntimeSettings(cfg)
 	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey, usage.QueryTodayCostByKey)
 	middleware.InitQuotaEndUserUsageFuncs(usage.CountTodayByEndUser, usage.CountTotalByEndUser, usage.QueryTotalCostByEndUser, usage.QueryTodayCostByEndUser)
+	middleware.InitQuotaPeriodUsageFuncs(usage.QueryPeriodSpendingByAPIKeyIDForTenant, usage.QueryPeriodSpendingByEndUserForTenant)
 	usage.SetTokenUsageCallback(func(apiKey string, totalTokens int64) {
 		endUserID := ""
 		if row := usage.GetAPIKey(apiKey); row != nil {

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
@@ -101,6 +102,65 @@ func TestBootstrapIdentityEmptyPasswordErrorIncludesConfigSource(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "remote-management.secret-key") {
 		t.Fatalf("bootstrapIdentity() error = %q, want config source", err)
+	}
+}
+
+func TestRuntimeDataStackPostStartHooksRunMaintenanceAsynchronously(t *testing.T) {
+	sharedBackfillStarted := make(chan struct{})
+	releaseSharedBackfill := make(chan struct{})
+	sharedBackfillRan := make(chan struct{}, 1)
+	catchupScheduled := make(chan struct{}, 1)
+
+	hooks := runtimeDataStackPostStartHooks(runtimeDataStackMaintenanceOps{
+		runAIAccountSharedSubjectBackfill: func() error {
+			close(sharedBackfillStarted)
+			<-releaseSharedBackfill
+			sharedBackfillRan <- struct{}{}
+			return nil
+		},
+		scheduleUsageRollupCatchup: func() {
+			catchupScheduled <- struct{}{}
+		},
+	})
+
+	select {
+	case <-sharedBackfillStarted:
+		t.Fatal("maintenance started before OnAfterStart")
+	default:
+	}
+
+	hookReturned := make(chan struct{})
+	go func() {
+		hooks.OnAfterStart(nil)
+		close(hookReturned)
+	}()
+
+	select {
+	case <-hookReturned:
+	case <-time.After(time.Second):
+		t.Fatal("OnAfterStart blocked on runtime data maintenance")
+	}
+	select {
+	case <-sharedBackfillStarted:
+	case <-time.After(time.Second):
+		t.Fatal("post-start shared subject backfill did not start")
+	}
+	select {
+	case <-sharedBackfillRan:
+		t.Fatal("shared subject backfill completed before it was released")
+	default:
+	}
+
+	close(releaseSharedBackfill)
+	select {
+	case <-sharedBackfillRan:
+	case <-time.After(time.Second):
+		t.Fatal("shared subject backfill did not complete after release")
+	}
+	select {
+	case <-catchupScheduled:
+	case <-time.After(time.Second):
+		t.Fatal("blue-green rollup catch-up was not scheduled")
 	}
 }
 

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -4,6 +4,8 @@
 // debug settings, proxy configuration, and API keys.
 package config
 
+import "github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+
 // SDKConfig represents the application's configuration, loaded from a YAML file.
 type SDKConfig struct {
 	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
@@ -148,6 +150,13 @@ type APIKeyEntry struct {
 	// unlimited. It resets at the project timezone day boundary. When permission-profile-id
 	// is set, the effective value comes from the permission profile.
 	DailySpendingLimit float64 `yaml:"daily-spending-limit,omitempty" json:"daily-spending-limit,omitempty"`
+
+	// PeriodSpendingLimits contains fixed 5h/day/week/month USD limits. Day mirrors DailySpendingLimit.
+	PeriodSpendingLimits quota.PeriodSpendingLimits `yaml:"period-spending-limits,omitempty" json:"period-spending-limits"`
+
+	// PeriodSpending and LifetimeSpendingUsed are management-list runtime facts.
+	PeriodSpending       []quota.PeriodSpending `yaml:"-" json:"period-spending"`
+	LifetimeSpendingUsed float64                `yaml:"-" json:"lifetime-spending-used"`
 
 	// DailySpendingUsed is the effective project-day USD cost for this key (management list only).
 	// After a same-day manual reset, only costs after the reset baseline count.

--- a/internal/enduser/period_quota.go
+++ b/internal/enduser/period_quota.go
@@ -1,0 +1,255 @@
+package enduser
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func (s *Service) CreateKeyWithPeriodLimits(ctx context.Context, tenantID, endUserID, name string, patch *quota.PeriodSpendingLimitsPatch) (CreateKeyResult, error) {
+	var result CreateKeyResult
+	if err := requireUUID(tenantID); err != nil {
+		return result, err
+	}
+	if err := requireUUID(endUserID); err != nil {
+		return result, err
+	}
+	patch, err := quota.NormalizePatch(patch)
+	if err != nil {
+		return result, fmt.Errorf("%w: %v", ErrValidation, err)
+	}
+	limits := quota.ApplyPatch(quota.PeriodSpendingLimits{}, patch)
+	if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+		return result, ErrFiveHourProjectionWarming
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	status, accountLimits, err := effectiveAccountPeriodLimitsTx(ctx, tx, tenantID, endUserID)
+	if err != nil {
+		return result, err
+	}
+	if status != "active" {
+		return result, fmt.Errorf("%w: cannot create api key for non-active end user", ErrValidation)
+	}
+	if err := quota.ValidateKeyWithinAccount(limits, accountLimits); err != nil {
+		return result, err
+	}
+	var count int
+	_ = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0`, tenantID, endUserID).Scan(&count)
+	isDefault := count == 0
+	var plain string
+	for attempt := 0; attempt < 8; attempt++ {
+		plain, err = GenerateAPIKey()
+		if err != nil {
+			return result, err
+		}
+		var exists int
+		if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE key = ?`, plain).Scan(&exists); err != nil {
+			return result, err
+		}
+		if exists == 0 {
+			break
+		}
+	}
+	id := uuid.NewString()
+	now := time.Now().UTC().Format(time.RFC3339)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return result, fmt.Errorf("%w: key name is required", ErrValidation)
+	}
+	if err = ensureUniqueKeyName(ctx, tx, tenantID, endUserID, name, ""); err != nil {
+		return result, err
+	}
+	if _, err = tx.ExecContext(ctx, `
+		INSERT INTO api_keys (key, id, name, disabled, end_user_id, is_default, tenant_id, created_at, updated_at,
+			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit,
+			concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt)
+		VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?,
+			'', 0, 0, 0, ?, ?, ?, ?, 0, 0, 0, '[]', '[]', '[]', '')
+	`, plain, id, name, endUserID, isDefault, tenantID, now, now,
+		limits.Day, limits.FiveHour, limits.Week, limits.Month); err != nil {
+		return result, err
+	}
+	if err = tx.Commit(); err != nil {
+		return result, err
+	}
+	result.APIKey = APIKey{
+		ID: id, TenantID: tenantID, EndUserID: endUserID, Name: name, IsDefault: isDefault,
+		KeyMasked: MaskAPIKey(plain), CreatedAt: now, UpdatedAt: now,
+		DailySpendingLimit: limits.Day, PeriodSpendingLimits: limits,
+	}
+	result.PlaintextKey = plain
+	return result, nil
+}
+
+func (s *Service) UpdateKey(ctx context.Context, tenantID, endUserID, keyID string, name *string, patch *quota.PeriodSpendingLimitsPatch) error {
+	if err := requireUUID(tenantID); err != nil {
+		return err
+	}
+	if err := requireUUID(endUserID); err != nil {
+		return err
+	}
+	if err := requireUUID(keyID); err != nil {
+		return err
+	}
+	patch, err := quota.NormalizePatch(patch)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrValidation, err)
+	}
+	if patch != nil && patch.FiveHour != nil && *patch.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+		return ErrFiveHourProjectionWarming
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	_, accountLimits, err := effectiveAccountPeriodLimitsTx(ctx, tx, tenantID, endUserID)
+	if err != nil {
+		return err
+	}
+	var currentName string
+	var current quota.PeriodSpendingLimits
+	if err := tx.QueryRowContext(ctx, `
+		SELECT name, COALESCE(daily_spending_limit,0), COALESCE(five_hour_spending_limit,0),
+		       COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0)
+		FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0
+	`, tenantID, endUserID, keyID).Scan(&currentName, &current.Day, &current.FiveHour, &current.Week, &current.Month); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+	updated := quota.ApplyPatch(current, patch)
+	if err := quota.ValidateKeyWithinAccount(updated, accountLimits); err != nil {
+		return err
+	}
+	if name != nil {
+		currentName = strings.TrimSpace(*name)
+		if currentName == "" {
+			return fmt.Errorf("%w: name required", ErrValidation)
+		}
+		if err := ensureUniqueKeyName(ctx, tx, tenantID, endUserID, currentName, keyID); err != nil {
+			return err
+		}
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE api_keys SET name = ?, daily_spending_limit = ?, five_hour_spending_limit = ?,
+		       weekly_spending_limit = ?, monthly_spending_limit = ?, updated_at = ?
+		WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0
+	`, currentName, updated.Day, updated.FiveHour, updated.Week, updated.Month,
+		time.Now().UTC().Format(time.RFC3339), tenantID, endUserID, keyID)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return tx.Commit()
+}
+
+func effectiveAccountPeriodLimitsTx(ctx context.Context, tx *sql.Tx, tenantID, endUserID string) (string, quota.PeriodSpendingLimits, error) {
+	var status, profileID string
+	var limits quota.PeriodSpendingLimits
+	query := `SELECT status, COALESCE(permission_profile_id,''), COALESCE(daily_spending_limit,0),
+	                 COALESCE(five_hour_spending_limit,0), COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0)
+	          FROM end_users WHERE id = ? AND tenant_id = ? FOR UPDATE`
+	err := tx.QueryRowContext(ctx, query, endUserID, tenantID).Scan(&status, &profileID, &limits.Day, &limits.FiveHour, &limits.Week, &limits.Month)
+	if err != nil {
+		err = tx.QueryRowContext(ctx, strings.TrimSuffix(query, " FOR UPDATE"), endUserID, tenantID).Scan(&status, &profileID, &limits.Day, &limits.FiveHour, &limits.Week, &limits.Month)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", quota.PeriodSpendingLimits{}, ErrNotFound
+	}
+	if err != nil {
+		return "", quota.PeriodSpendingLimits{}, err
+	}
+	if profileID != "" {
+		err = tx.QueryRowContext(ctx, `SELECT COALESCE(daily_spending_limit,0), COALESCE(five_hour_spending_limit,0),
+			COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0)
+			FROM api_key_permission_profiles WHERE tenant_id = ? AND id = ?`, tenantID, profileID).
+			Scan(&limits.Day, &limits.FiveHour, &limits.Week, &limits.Month)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return "", quota.PeriodSpendingLimits{}, err
+		}
+	}
+	return status, limits, nil
+}
+
+func capOwnedKeyPeriodLimitsTx(ctx context.Context, tx *sql.Tx, tenantID, endUserID string) ([]quota.CappedKey, error) {
+	_, account, err := effectiveAccountPeriodLimitsTx(ctx, tx, tenantID, endUserID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT id, COALESCE(daily_spending_limit,0), COALESCE(five_hour_spending_limit,0),
+		COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0)
+		FROM api_keys WHERE tenant_id = ? AND end_user_id = ? ORDER BY id ASC`, tenantID, endUserID)
+	if err != nil {
+		return nil, err
+	}
+	type keyLimits struct {
+		id     string
+		limits quota.PeriodSpendingLimits
+	}
+	keys := make([]keyLimits, 0)
+	for rows.Next() {
+		var item keyLimits
+		if err := rows.Scan(&item.id, &item.limits.Day, &item.limits.FiveHour, &item.limits.Week, &item.limits.Month); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		keys = append(keys, item)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	capped := make([]quota.CappedKey, 0)
+	for _, item := range keys {
+		updated := item.limits
+		for _, period := range quota.OrderedPeriods {
+			from, ceiling := updated.Value(period), account.Value(period)
+			if from <= 0 || ceiling <= 0 || from <= ceiling {
+				continue
+			}
+			switch period {
+			case quota.PeriodFiveHour:
+				updated.FiveHour = ceiling
+			case quota.PeriodDay:
+				updated.Day = ceiling
+			case quota.PeriodWeek:
+				updated.Week = ceiling
+			case quota.PeriodMonth:
+				updated.Month = ceiling
+			}
+			capped = append(capped, quota.CappedKey{ID: item.id, Period: period, From: from, To: ceiling})
+		}
+		if updated != item.limits {
+			if _, err := tx.ExecContext(ctx, `UPDATE api_keys SET daily_spending_limit=?, five_hour_spending_limit=?, weekly_spending_limit=?, monthly_spending_limit=?, updated_at=? WHERE tenant_id=? AND id=?`,
+				updated.Day, updated.FiveHour, updated.Week, updated.Month, time.Now().UTC().Format(time.RFC3339), tenantID, item.id); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return capped, nil
+}
+
+func quotaPkgResolveLegacyDay(legacy *float64, patch *quota.PeriodSpendingLimitsPatch) (*quota.PeriodSpendingLimitsPatch, error) {
+	resolved, err := quota.ResolveLegacyDay(legacy, patch)
+	if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		return nil, ErrPeriodDayLegacyConflict
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrValidation, err)
+	}
+	return resolved, nil
+}

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -17,27 +17,30 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 )
 
 var (
-	ErrInvalidCredentials = errors.New("invalid credentials")
-	ErrAccountDisabled    = errors.New("account disabled")
-	ErrAccountLocked      = errors.New("account locked")
-	ErrLoginCooldowned    = errors.New("login cooldown")
-	ErrMustChangePassword = errors.New("must change password")
-	ErrSessionExpired     = errors.New("session expired")
-	ErrSessionRevoked     = errors.New("session revoked")
-	ErrPermissionDenied   = errors.New("permission denied")
-	ErrTenantScope        = errors.New("tenant scope forbidden")
-	ErrTenantSuspended    = errors.New("tenant suspended")
-	ErrTenantExpired      = errors.New("tenant expired")
-	ErrValidation         = errors.New("validation failed")
-	ErrDuplicateKeyName   = errors.New("duplicate key name")
-	ErrLastKey            = errors.New("cannot delete last api key")
-	ErrNotFound           = errors.New("not found")
+	ErrInvalidCredentials        = errors.New("invalid credentials")
+	ErrAccountDisabled           = errors.New("account disabled")
+	ErrAccountLocked             = errors.New("account locked")
+	ErrLoginCooldowned           = errors.New("login cooldown")
+	ErrMustChangePassword        = errors.New("must change password")
+	ErrSessionExpired            = errors.New("session expired")
+	ErrSessionRevoked            = errors.New("session revoked")
+	ErrPermissionDenied          = errors.New("permission denied")
+	ErrTenantScope               = errors.New("tenant scope forbidden")
+	ErrTenantSuspended           = errors.New("tenant suspended")
+	ErrTenantExpired             = errors.New("tenant expired")
+	ErrValidation                = errors.New("validation failed")
+	ErrDuplicateKeyName          = errors.New("duplicate key name")
+	ErrLastKey                   = errors.New("cannot delete last api key")
+	ErrNotFound                  = errors.New("not found")
+	ErrFiveHourProjectionWarming = errors.New("five hour quota projection warming")
+	ErrPeriodDayLegacyConflict   = errors.New("period day legacy conflict")
 )
 
 const (
@@ -72,7 +75,20 @@ func Default() *Service {
 	return defaultService
 }
 
-func NewService(db *sql.DB) *Service { return &Service{db: db} }
+func NewService(db *sql.DB) *Service {
+	if db != nil {
+		_ = usage.EnsureEndUserQuotaColumns(db)
+		for _, column := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+			if _, err := db.Exec("ALTER TABLE api_keys ADD COLUMN " + column + " REAL NOT NULL DEFAULT 0"); err != nil {
+				message := strings.ToLower(err.Error())
+				if !strings.Contains(message, "duplicate") && !strings.Contains(message, "no such table") {
+					log.Warnf("enduser: migrate api_keys.%s: %v", column, err)
+				}
+			}
+		}
+	}
+	return &Service{db: db}
+}
 
 func NormalizeUsername(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
@@ -280,7 +296,7 @@ func scanUser(scanner interface{ Scan(dest ...any) error }) (User, error) {
 		&u.MustChangePassword, &lastLogin, &u.FailedLoginCount, &u.LockStage, &lockedUntil,
 		&u.CreatedAt, &u.UpdatedAt, &u.Version,
 		&u.PermissionProfileID, &u.DailyLimit, &u.TotalQuota, &u.SpendingLimit, &u.DailySpendingLimit,
-		&u.ConcurrencyLimit, &u.RPMLimit, &u.TPMLimit,
+		&u.PeriodSpendingLimits.FiveHour, &u.PeriodSpendingLimits.Week, &u.PeriodSpendingLimits.Month, &u.ConcurrencyLimit, &u.RPMLimit, &u.TPMLimit,
 		&modelsJSON, &channelsJSON, &groupsJSON, &u.SystemPrompt,
 	)
 	if err != nil {
@@ -294,6 +310,7 @@ func scanUser(scanner interface{ Scan(dest ...any) error }) (User, error) {
 		t := lockedUntil.Time
 		u.LockedUntil = &t
 	}
+	u.PeriodSpendingLimits.Day = u.DailySpendingLimit
 	u.AllowedModels = decodeJSONStringList(modelsJSON)
 	u.AllowedChannels = decodeJSONStringList(channelsJSON)
 	u.AllowedChannelGroups = decodeJSONStringList(groupsJSON)
@@ -341,6 +358,7 @@ const userSelect = `SELECT id, tenant_id, username, display_name, status, must_c
 	last_login_at, failed_login_count, lock_stage, locked_until, created_at, updated_at, version,
 	COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
 	COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+	COALESCE(five_hour_spending_limit, 0), COALESCE(weekly_spending_limit, 0), COALESCE(monthly_spending_limit, 0),
 	COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
 	COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
 	COALESCE(system_prompt, '')
@@ -475,10 +493,10 @@ func (s *Service) insertDefaultKey(ctx context.Context, tx *sql.Tx, tenantID, en
 	}
 	if _, err = tx.ExecContext(ctx, `
 		INSERT INTO api_keys (key, id, name, disabled, end_user_id, is_default, tenant_id, created_at, updated_at,
-			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
+			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit,
 			concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt)
 		VALUES (?, ?, ?, 0, ?, true, ?, ?, ?,
-			'', 0, 0, 0, 0, 0, 0, 0, '[]', '[]', '[]', '')
+			'', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '[]', '[]', '[]', '')
 	`, plain, id, name, endUserID, tenantID, now, now); err != nil {
 		return APIKey{}, "", err
 	}
@@ -554,7 +572,7 @@ func (s *Service) CreateUser(ctx context.Context, actor identity.Principal, tena
 	return result, nil
 }
 
-func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tenantID, userID string, username, displayName, password, status *string, quota *QuotaPatch) (User, error) {
+func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tenantID, userID string, username, displayName, password, status *string, accountQuotaPatch *QuotaPatch) (User, error) {
 	if !actor.Has("end_users.write") && !actor.PlatformAdmin {
 		return User{}, ErrPermissionDenied
 	}
@@ -574,6 +592,30 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 		return User{}, err
 	}
 	defer func() { _ = tx.Rollback() }()
+	var currentProfileID string
+	profileQuery := `SELECT COALESCE(permission_profile_id,'') FROM end_users WHERE id = ? AND tenant_id = ? FOR UPDATE`
+	if err := tx.QueryRowContext(ctx, profileQuery, userID, tenantID).Scan(&currentProfileID); err != nil {
+		if err = tx.QueryRowContext(ctx, strings.TrimSuffix(profileQuery, " FOR UPDATE"), userID, tenantID).Scan(&currentProfileID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return User{}, ErrNotFound
+			}
+			return User{}, err
+		}
+	}
+	var resolvedPeriodPatch *quota.PeriodSpendingLimitsPatch
+	if accountQuotaPatch != nil {
+		resolvedPeriodPatch, err = quotaPkgResolveLegacyDay(accountQuotaPatch.DailySpendingLimit, accountQuotaPatch.PeriodSpendingLimits)
+		if err != nil {
+			return User{}, err
+		}
+		targetProfileID := currentProfileID
+		if accountQuotaPatch.PermissionProfileID != nil {
+			targetProfileID = strings.TrimSpace(*accountQuotaPatch.PermissionProfileID)
+		}
+		if resolvedPeriodPatch != nil && targetProfileID != "" {
+			return User{}, fmt.Errorf("%w: period limits are managed by permission profile %s", ErrValidation, targetProfileID)
+		}
+	}
 
 	if username != nil {
 		base := NormalizeUsername(*username)
@@ -600,7 +642,7 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 		if err != nil {
 			return User{}, err
 		}
-		sets = append(sets, "password_hash = ?", "must_change_password = false", "password_changed_at = now()",
+		sets = append(sets, "password_hash = ?", "must_change_password = false", "password_changed_at = CURRENT_TIMESTAMP",
 			"failed_login_count = 0", "lock_stage = 0", "locked_until = NULL")
 		args = append(args, hash)
 	}
@@ -615,54 +657,71 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 			sets = append(sets, "failed_login_count = 0", "lock_stage = 0", "locked_until = NULL")
 		}
 	}
-	if quota != nil {
-		if quota.PermissionProfileID != nil {
+	if accountQuotaPatch != nil {
+		if accountQuotaPatch.PermissionProfileID != nil {
 			sets = append(sets, "permission_profile_id = ?")
-			args = append(args, strings.TrimSpace(*quota.PermissionProfileID))
+			args = append(args, strings.TrimSpace(*accountQuotaPatch.PermissionProfileID))
 		}
-		if quota.DailyLimit != nil {
+		if accountQuotaPatch.DailyLimit != nil {
 			sets = append(sets, "daily_limit = ?")
-			args = append(args, clampNonNegInt(*quota.DailyLimit))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.DailyLimit))
 		}
-		if quota.TotalQuota != nil {
+		if accountQuotaPatch.TotalQuota != nil {
 			sets = append(sets, "total_quota = ?")
-			args = append(args, clampNonNegInt(*quota.TotalQuota))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.TotalQuota))
 		}
-		if quota.SpendingLimit != nil {
+		if accountQuotaPatch.SpendingLimit != nil {
 			sets = append(sets, "spending_limit = ?")
-			args = append(args, clampNonNegFloat(*quota.SpendingLimit))
+			args = append(args, clampNonNegFloat(*accountQuotaPatch.SpendingLimit))
 		}
-		if quota.DailySpendingLimit != nil {
-			sets = append(sets, "daily_spending_limit = ?")
-			args = append(args, clampNonNegFloat(*quota.DailySpendingLimit))
+		if resolvedPeriodPatch != nil {
+			if resolvedPeriodPatch.FiveHour != nil {
+				if *resolvedPeriodPatch.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+					return User{}, ErrFiveHourProjectionWarming
+				}
+				sets = append(sets, "five_hour_spending_limit = ?")
+				args = append(args, *resolvedPeriodPatch.FiveHour)
+			}
+			if resolvedPeriodPatch.Day != nil {
+				sets = append(sets, "daily_spending_limit = ?")
+				args = append(args, *resolvedPeriodPatch.Day)
+			}
+			if resolvedPeriodPatch.Week != nil {
+				sets = append(sets, "weekly_spending_limit = ?")
+				args = append(args, *resolvedPeriodPatch.Week)
+			}
+			if resolvedPeriodPatch.Month != nil {
+				sets = append(sets, "monthly_spending_limit = ?")
+				args = append(args, *resolvedPeriodPatch.Month)
+			}
 		}
-		if quota.ConcurrencyLimit != nil {
+		if accountQuotaPatch.ConcurrencyLimit != nil {
 			sets = append(sets, "concurrency_limit = ?")
-			args = append(args, clampNonNegInt(*quota.ConcurrencyLimit))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.ConcurrencyLimit))
 		}
-		if quota.RPMLimit != nil {
+		if accountQuotaPatch.RPMLimit != nil {
 			sets = append(sets, "rpm_limit = ?")
-			args = append(args, clampNonNegInt(*quota.RPMLimit))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.RPMLimit))
 		}
-		if quota.TPMLimit != nil {
+		if accountQuotaPatch.TPMLimit != nil {
 			sets = append(sets, "tpm_limit = ?")
-			args = append(args, clampNonNegInt(*quota.TPMLimit))
+			args = append(args, clampNonNegInt(*accountQuotaPatch.TPMLimit))
 		}
-		if quota.AllowedModels != nil {
+		if accountQuotaPatch.AllowedModels != nil {
 			sets = append(sets, "allowed_models = ?")
-			args = append(args, encodeJSONStringList(*quota.AllowedModels))
+			args = append(args, encodeJSONStringList(*accountQuotaPatch.AllowedModels))
 		}
-		if quota.AllowedChannels != nil {
+		if accountQuotaPatch.AllowedChannels != nil {
 			sets = append(sets, "allowed_channels = ?")
-			args = append(args, encodeJSONStringList(*quota.AllowedChannels))
+			args = append(args, encodeJSONStringList(*accountQuotaPatch.AllowedChannels))
 		}
-		if quota.AllowedChannelGroups != nil {
+		if accountQuotaPatch.AllowedChannelGroups != nil {
 			sets = append(sets, "allowed_channel_groups = ?")
-			args = append(args, encodeJSONStringList(*quota.AllowedChannelGroups))
+			args = append(args, encodeJSONStringList(*accountQuotaPatch.AllowedChannelGroups))
 		}
-		if quota.SystemPrompt != nil {
+		if accountQuotaPatch.SystemPrompt != nil {
 			sets = append(sets, "system_prompt = ?")
-			args = append(args, *quota.SystemPrompt)
+			args = append(args, *accountQuotaPatch.SystemPrompt)
 		}
 	}
 	if len(sets) == 0 {
@@ -670,7 +729,7 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 		return s.GetUser(ctx, tenantID, userID)
 	}
 
-	sets = append(sets, "updated_at = now()", "version = version + 1")
+	sets = append(sets, "updated_at = CURRENT_TIMESTAMP", "version = version + 1")
 	args = append(args, userID, tenantID)
 	q := `UPDATE end_users SET ` + strings.Join(sets, ", ") + ` WHERE id = ? AND tenant_id = ?`
 	res, err := tx.ExecContext(ctx, q, args...)
@@ -682,7 +741,7 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 	}
 	if password != nil && strings.TrimSpace(*password) != "" {
 		if _, err = tx.ExecContext(ctx, `
-			UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'password_change'
+			UPDATE end_user_sessions SET revoked_at = CURRENT_TIMESTAMP, revoke_reason = 'password_change'
 			WHERE end_user_id = ? AND revoked_at IS NULL
 		`, userID); err != nil {
 			return User{}, err
@@ -692,16 +751,39 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 	// that would wipe per-key admin disables on re-activate. Auth refuses non-active accounts.
 	if status != nil && *status != "active" {
 		if _, err = tx.ExecContext(ctx, `
-				UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'status_change'
+				UPDATE end_user_sessions SET revoked_at = CURRENT_TIMESTAMP, revoke_reason = 'status_change'
 				WHERE end_user_id = ? AND revoked_at IS NULL
 			`, userID); err != nil {
 			return User{}, err
 		}
 	}
+	capped, err := capOwnedKeyPeriodLimitsTx(ctx, tx, tenantID, userID)
+	if err != nil {
+		return User{}, err
+	}
 	if err = tx.Commit(); err != nil {
 		return User{}, err
 	}
-	return s.GetUser(ctx, tenantID, userID)
+	updated, err := s.GetUser(ctx, tenantID, userID)
+	if err != nil {
+		return User{}, err
+	}
+	if loaded := usage.GetEndUserQuota(userID); loaded != nil {
+		effective := usage.EffectiveEndUserQuota(*loaded)
+		updated.DailySpendingLimit = effective.DailySpendingLimit
+		updated.PeriodSpendingLimits = effective.PeriodSpendingLimits
+	}
+	updated.CappedKeys = capped
+	if len(capped) > 0 {
+		if audit := identity.Default(); audit != nil {
+			audit.RecordAudit(ctx, identity.AuditEvent{
+				TenantID: tenantID, ActorKind: actor.Kind, ActorUserID: actor.User.ID, ActorSessionID: actor.SessionID,
+				Action: "end_user.period_quota.cap_keys", ResourceType: "end_user", ResourceID: userID, Result: "success",
+				Changes: map[string]any{"capped-keys": capped},
+			})
+		}
+	}
+	return updated, nil
 }
 
 func (s *Service) ResetPassword(ctx context.Context, actor identity.Principal, tenantID, userID, password string) (string, error) {
@@ -736,10 +818,10 @@ func (s *Service) ResetPassword(ctx context.Context, actor identity.Principal, t
 	}
 	defer func() { _ = tx.Rollback() }()
 	res, err := tx.ExecContext(ctx, `
-		UPDATE end_users SET password_hash = ?, must_change_password = true, password_changed_at = now(),
+		UPDATE end_users SET password_hash = ?, must_change_password = true, password_changed_at = CURRENT_TIMESTAMP,
 			failed_login_count = 0, lock_stage = 0, locked_until = NULL,
 			status = CASE WHEN status = 'locked' THEN 'active' ELSE status END,
-			updated_at = now(), version = version + 1
+			updated_at = CURRENT_TIMESTAMP, version = version + 1
 		WHERE id = ? AND tenant_id = ?
 	`, hash, userID, tenantID)
 	if err != nil {
@@ -749,7 +831,7 @@ func (s *Service) ResetPassword(ctx context.Context, actor identity.Principal, t
 		return "", ErrNotFound
 	}
 	if _, err = tx.ExecContext(ctx, `
-		UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'password_reset'
+		UPDATE end_user_sessions SET revoked_at = CURRENT_TIMESTAMP, revoke_reason = 'password_reset'
 		WHERE end_user_id = ? AND revoked_at IS NULL
 	`, userID); err != nil {
 		return "", err
@@ -787,7 +869,7 @@ func (s *Service) DeleteUser(ctx context.Context, actor identity.Principal, tena
 		return err
 	}
 	if _, err = tx.ExecContext(ctx, `
-		UPDATE end_user_sessions SET revoked_at = now(), revoke_reason = 'user_deleted'
+		UPDATE end_user_sessions SET revoked_at = CURRENT_TIMESTAMP, revoke_reason = 'user_deleted'
 		WHERE end_user_id = ? AND revoked_at IS NULL
 	`, userID); err != nil {
 		return err
@@ -838,7 +920,8 @@ func (s *Service) ListKeys(ctx context.Context, tenantID, endUserID string) ([]A
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, tenant_id, end_user_id, key, name, disabled, COALESCE(is_default, false),
-			COALESCE(created_at, ''), COALESCE(updated_at, '')
+			COALESCE(created_at, ''), COALESCE(updated_at, ''),
+			COALESCE(daily_spending_limit, 0), COALESCE(five_hour_spending_limit, 0), COALESCE(weekly_spending_limit, 0), COALESCE(monthly_spending_limit, 0)
 		FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0
 		ORDER BY is_default DESC, created_at ASC
 	`, tenantID, endUserID)
@@ -847,101 +930,52 @@ func (s *Service) ListKeys(ctx context.Context, tenantID, endUserID string) ([]A
 	}
 	defer rows.Close()
 	out := make([]APIKey, 0)
+	ids := make([]string, 0)
 	for rows.Next() {
 		var k APIKey
-		var endUserID sql.NullString
+		var ownerID sql.NullString
 		var disabledInt int
 		var isDefault bool
-		if err := rows.Scan(&k.ID, &k.TenantID, &endUserID, &k.Key, &k.Name, &disabledInt, &isDefault, &k.CreatedAt, &k.UpdatedAt); err != nil {
+		if err := rows.Scan(&k.ID, &k.TenantID, &ownerID, &k.Key, &k.Name, &disabledInt, &isDefault, &k.CreatedAt, &k.UpdatedAt, &k.DailySpendingLimit, &k.PeriodSpendingLimits.FiveHour, &k.PeriodSpendingLimits.Week, &k.PeriodSpendingLimits.Month); err != nil {
 			return nil, err
 		}
-		if endUserID.Valid {
-			k.EndUserID = endUserID.String
+		if ownerID.Valid {
+			k.EndUserID = ownerID.String
 		}
 		k.Disabled = disabledInt != 0
+		k.PeriodSpendingLimits.Day = k.DailySpendingLimit
 		k.IsDefault = isDefault
 		k.KeyMasked = MaskAPIKey(k.Key)
 		k.Key = "" // never list full secret
 		out = append(out, k)
+		ids = append(ids, k.ID)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if usage.RuntimeDB() == nil {
+		return out, nil
+	}
+	usedByID, err := usage.QueryPeriodSpendingByAPIKeyIDsForTenant(tenantID, ids)
+	if err != nil {
+		return nil, err
+	}
+	resetCounts, err := usage.ListDailySpendingResetEventCounts(tenantID, ids)
+	if err != nil {
+		return nil, err
+	}
+	for i := range out {
+		used := usedByID[out[i].ID]
+		out[i].DailySpendingUsed = used.Day
+		out[i].LifetimeSpendingUsed = used.Lifetime
+		out[i].PeriodSpending = quota.BuildPeriodSpending(out[i].PeriodSpendingLimits, used)
+		out[i].DailySpendingResetCount = resetCounts[out[i].ID]
+	}
+	return out, nil
 }
 
 func (s *Service) CreateKey(ctx context.Context, tenantID, endUserID, name string) (CreateKeyResult, error) {
-	var result CreateKeyResult
-	if err := requireUUID(tenantID); err != nil {
-		return result, err
-	}
-	if err := requireUUID(endUserID); err != nil {
-		return result, err
-	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return result, err
-	}
-	defer func() { _ = tx.Rollback() }()
-	var status string
-	if err = tx.QueryRowContext(ctx, `
-		SELECT status FROM end_users WHERE id = ? AND tenant_id = ? FOR UPDATE
-	`, endUserID, tenantID).Scan(&status); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return result, ErrNotFound
-		}
-		// SQLite may not support FOR UPDATE; retry without lock.
-		if err2 := tx.QueryRowContext(ctx, `SELECT status FROM end_users WHERE id = ? AND tenant_id = ?`, endUserID, tenantID).Scan(&status); err2 != nil {
-			if errors.Is(err2, sql.ErrNoRows) {
-				return result, ErrNotFound
-			}
-			return result, err2
-		}
-	}
-	if status != "active" {
-		return result, fmt.Errorf("%w: cannot create api key for non-active end user", ErrValidation)
-	}
-	var count int
-	_ = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE tenant_id = ? AND end_user_id = ? AND disabled = 0`, tenantID, endUserID).Scan(&count)
-	isDefault := count == 0
-	var plain string
-	for attempt := 0; attempt < 8; attempt++ {
-		plain, err = GenerateAPIKey()
-		if err != nil {
-			return result, err
-		}
-		var exists int
-		if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_keys WHERE key = ?`, plain).Scan(&exists); err != nil {
-			return result, err
-		}
-		if exists == 0 {
-			break
-		}
-	}
-	id := uuid.NewString()
-	now := time.Now().UTC().Format(time.RFC3339)
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return result, fmt.Errorf("%w: key name is required", ErrValidation)
-	}
-	if err = ensureUniqueKeyName(ctx, tx, tenantID, endUserID, name, ""); err != nil {
-		return result, err
-	}
-	if _, err = tx.ExecContext(ctx, `
-		INSERT INTO api_keys (key, id, name, disabled, end_user_id, is_default, tenant_id, created_at, updated_at,
-			permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
-			concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt)
-		VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?,
-			'', 0, 0, 0, 0, 0, 0, 0, '[]', '[]', '[]', '')
-	`, plain, id, name, endUserID, isDefault, tenantID, now, now); err != nil {
-		return result, err
-	}
-	if err = tx.Commit(); err != nil {
-		return result, err
-	}
-	result.APIKey = APIKey{
-		ID: id, TenantID: tenantID, EndUserID: endUserID, Name: name, IsDefault: isDefault,
-		KeyMasked: MaskAPIKey(plain), CreatedAt: now, UpdatedAt: now,
-	}
-	result.PlaintextKey = plain
-	return result, nil
+	return s.CreateKeyWithPeriodLimits(ctx, tenantID, endUserID, name, nil)
 }
 
 func (s *Service) SetDefaultKey(ctx context.Context, tenantID, endUserID, keyID string) error {
@@ -973,31 +1007,7 @@ func (s *Service) SetDefaultKey(ctx context.Context, tenantID, endUserID, keyID 
 }
 
 func (s *Service) UpdateKeyName(ctx context.Context, tenantID, endUserID, keyID, name string) error {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return fmt.Errorf("%w: name required", ErrValidation)
-	}
-	if err := requireUUID(tenantID); err != nil {
-		return err
-	}
-	if err := requireUUID(endUserID); err != nil {
-		return err
-	}
-	if err := requireUUID(keyID); err != nil {
-		return err
-	}
-	if err := ensureUniqueKeyName(ctx, s.db, tenantID, endUserID, name, keyID); err != nil {
-		return err
-	}
-	res, err := s.db.ExecContext(ctx, `UPDATE api_keys SET name = ?, updated_at = ? WHERE tenant_id = ? AND end_user_id = ? AND id = ? AND disabled = 0`,
-		name, time.Now().UTC().Format(time.RFC3339), tenantID, endUserID, keyID)
-	if err != nil {
-		return err
-	}
-	if n, _ := res.RowsAffected(); n == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return s.UpdateKey(ctx, tenantID, endUserID, keyID, &name, nil)
 }
 
 // ensureUniqueKeyName rejects case-insensitive name collisions within one end user.

--- a/internal/enduser/service_sqlite_test.go
+++ b/internal/enduser/service_sqlite_test.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	sqlapikey "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/sqlite/apikey"
 	_ "modernc.org/sqlite"
 )
@@ -35,8 +38,8 @@ func openEndUserTestDB(t *testing.T) *sql.DB {
 			failed_login_count INTEGER NOT NULL DEFAULT 0,
 			lock_stage INTEGER NOT NULL DEFAULT 0,
 			locked_until TEXT,
-			created_at TEXT NOT NULL DEFAULT '',
-			updated_at TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
 			version INTEGER NOT NULL DEFAULT 1,
 			permission_profile_id TEXT NOT NULL DEFAULT '',
 			daily_limit INTEGER NOT NULL DEFAULT 0,
@@ -165,4 +168,40 @@ func TestSetDefaultKeyOnSQLite(t *testing.T) {
 		t.Fatalf("default count = %d, want 1", defaultCount)
 	}
 	_ = a
+}
+
+func TestUpdateUserAutoCapsOwnedKeyPeriodLimits(t *testing.T) {
+	db := openEndUserTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	userID := uuid.NewString()
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status, daily_spending_limit, created_at, updated_at)
+		VALUES (?, ?, 'cap', 'cap', 'Cap', 'x', 'active', 200, ?, ?)
+	`, userID, tenantID, now, now); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	day := 150.0
+	created, err := svc.CreateKeyWithPeriodLimits(ctx, tenantID, userID, "limited", &quota.PeriodSpendingLimitsPatch{Day: &day})
+	if err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+	newDay := 100.0
+	actor := identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}, Permissions: map[string]bool{"end_users.write": true}}
+	updated, err := svc.UpdateUser(ctx, actor, tenantID, userID, nil, nil, nil, nil, &QuotaPatch{PeriodSpendingLimits: &quota.PeriodSpendingLimitsPatch{Day: &newDay}})
+	if err != nil {
+		t.Fatalf("UpdateUser: %v", err)
+	}
+	if len(updated.CappedKeys) != 1 || updated.CappedKeys[0].ID != created.APIKey.ID || updated.CappedKeys[0].Period != quota.PeriodDay || updated.CappedKeys[0].From != 150 || updated.CappedKeys[0].To != 100 {
+		t.Fatalf("capped keys = %+v", updated.CappedKeys)
+	}
+	var stored float64
+	if err := db.QueryRow(`SELECT daily_spending_limit FROM api_keys WHERE id = ?`, created.APIKey.ID).Scan(&stored); err != nil {
+		t.Fatalf("query key: %v", err)
+	}
+	if stored != 100 {
+		t.Fatalf("stored day = %v, want 100", stored)
+	}
 }

--- a/internal/enduser/types.go
+++ b/internal/enduser/types.go
@@ -1,6 +1,10 @@
 package enduser
 
-import "time"
+import (
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
 
 type User struct {
 	ID                 string     `json:"id"`
@@ -19,53 +23,64 @@ type User struct {
 	// APIKeyCount is filled on list; 0 means unknown/none.
 	APIKeyCount int `json:"api_key_count,omitempty"`
 	// DailySpendingUsed is the account-level effective spend for the current project day.
-	DailySpendingUsed float64 `json:"daily-spending-used"`
+	DailySpendingUsed    float64                `json:"daily-spending-used"`
+	LifetimeSpendingUsed float64                `json:"lifetime-spending-used"`
+	PeriodSpending       []quota.PeriodSpending `json:"period-spending"`
+	CappedKeys           []quota.CappedKey      `json:"capped-keys,omitempty"`
 	// DailySpendingResetCount is the number of persisted manual reset events.
 	DailySpendingResetCount int `json:"daily-spending-reset-count"`
 
 	// Account-level quota/permissions: shared by every API key under this user.
-	PermissionProfileID  string   `json:"permission-profile-id,omitempty"`
-	DailyLimit           int      `json:"daily-limit,omitempty"`
-	TotalQuota           int      `json:"total-quota,omitempty"`
-	SpendingLimit        float64  `json:"spending-limit,omitempty"`
-	DailySpendingLimit   float64  `json:"daily-spending-limit,omitempty"`
-	ConcurrencyLimit     int      `json:"concurrency-limit,omitempty"`
-	RPMLimit             int      `json:"rpm-limit,omitempty"`
-	TPMLimit             int      `json:"tpm-limit,omitempty"`
-	AllowedModels        []string `json:"allowed-models,omitempty"`
-	AllowedChannels      []string `json:"allowed-channels,omitempty"`
-	AllowedChannelGroups []string `json:"allowed-channel-groups,omitempty"`
-	SystemPrompt         string   `json:"system-prompt,omitempty"`
+	PermissionProfileID  string                     `json:"permission-profile-id,omitempty"`
+	DailyLimit           int                        `json:"daily-limit,omitempty"`
+	TotalQuota           int                        `json:"total-quota,omitempty"`
+	SpendingLimit        float64                    `json:"spending-limit,omitempty"`
+	DailySpendingLimit   float64                    `json:"daily-spending-limit,omitempty"`
+	PeriodSpendingLimits quota.PeriodSpendingLimits `json:"period-spending-limits"`
+	ConcurrencyLimit     int                        `json:"concurrency-limit,omitempty"`
+	RPMLimit             int                        `json:"rpm-limit,omitempty"`
+	TPMLimit             int                        `json:"tpm-limit,omitempty"`
+	AllowedModels        []string                   `json:"allowed-models,omitempty"`
+	AllowedChannels      []string                   `json:"allowed-channels,omitempty"`
+	AllowedChannelGroups []string                   `json:"allowed-channel-groups,omitempty"`
+	SystemPrompt         string                     `json:"system-prompt,omitempty"`
 }
 
 // QuotaPatch updates account-level limits. Nil field = leave unchanged.
 // Pointer to empty profile id or zero limit clears that field.
 type QuotaPatch struct {
-	PermissionProfileID  *string   `json:"permission-profile-id,omitempty"`
-	DailyLimit           *int      `json:"daily-limit,omitempty"`
-	TotalQuota           *int      `json:"total-quota,omitempty"`
-	SpendingLimit        *float64  `json:"spending-limit,omitempty"`
-	DailySpendingLimit   *float64  `json:"daily-spending-limit,omitempty"`
-	ConcurrencyLimit     *int      `json:"concurrency-limit,omitempty"`
-	RPMLimit             *int      `json:"rpm-limit,omitempty"`
-	TPMLimit             *int      `json:"tpm-limit,omitempty"`
-	AllowedModels        *[]string `json:"allowed-models,omitempty"`
-	AllowedChannels      *[]string `json:"allowed-channels,omitempty"`
-	AllowedChannelGroups *[]string `json:"allowed-channel-groups,omitempty"`
-	SystemPrompt         *string   `json:"system-prompt,omitempty"`
+	PermissionProfileID  *string                          `json:"permission-profile-id,omitempty"`
+	DailyLimit           *int                             `json:"daily-limit,omitempty"`
+	TotalQuota           *int                             `json:"total-quota,omitempty"`
+	SpendingLimit        *float64                         `json:"spending-limit,omitempty"`
+	DailySpendingLimit   *float64                         `json:"daily-spending-limit,omitempty"`
+	PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits,omitempty"`
+	ConcurrencyLimit     *int                             `json:"concurrency-limit,omitempty"`
+	RPMLimit             *int                             `json:"rpm-limit,omitempty"`
+	TPMLimit             *int                             `json:"tpm-limit,omitempty"`
+	AllowedModels        *[]string                        `json:"allowed-models,omitempty"`
+	AllowedChannels      *[]string                        `json:"allowed-channels,omitempty"`
+	AllowedChannelGroups *[]string                        `json:"allowed-channel-groups,omitempty"`
+	SystemPrompt         *string                          `json:"system-prompt,omitempty"`
 }
 
 type APIKey struct {
-	ID        string `json:"id"`
-	TenantID  string `json:"tenant_id"`
-	EndUserID string `json:"end_user_id"`
-	Key       string `json:"key,omitempty"`
-	KeyMasked string `json:"key_masked,omitempty"`
-	Name      string `json:"name"`
-	Disabled  bool   `json:"disabled"`
-	IsDefault bool   `json:"is_default"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	ID                      string                     `json:"id"`
+	TenantID                string                     `json:"tenant_id"`
+	EndUserID               string                     `json:"end_user_id"`
+	Key                     string                     `json:"key,omitempty"`
+	KeyMasked               string                     `json:"key_masked,omitempty"`
+	Name                    string                     `json:"name"`
+	Disabled                bool                       `json:"disabled"`
+	IsDefault               bool                       `json:"is_default"`
+	CreatedAt               string                     `json:"created_at,omitempty"`
+	UpdatedAt               string                     `json:"updated_at,omitempty"`
+	DailySpendingLimit      float64                    `json:"daily-spending-limit"`
+	PeriodSpendingLimits    quota.PeriodSpendingLimits `json:"period-spending-limits"`
+	PeriodSpending          []quota.PeriodSpending     `json:"period-spending"`
+	DailySpendingUsed       float64                    `json:"daily-spending-used"`
+	LifetimeSpendingUsed    float64                    `json:"lifetime-spending-used"`
+	DailySpendingResetCount int                        `json:"daily-spending-reset-count"`
 }
 
 type LoginResult struct {

--- a/internal/identity/password.go
+++ b/internal/identity/password.go
@@ -1,0 +1,96 @@
+package identity
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	generatedPasswordLength   = 16
+	passwordUpperCharacters   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	passwordLowerCharacters   = "abcdefghijklmnopqrstuvwxyz"
+	passwordDigitCharacters   = "0123456789"
+	passwordSpecialCharacters = "!@#$%^&*()-_=+[]{}:,.?"
+	passwordAllCharacters     = passwordUpperCharacters + passwordLowerCharacters + passwordDigitCharacters + passwordSpecialCharacters
+)
+
+func HashPassword(password string) (string, error) {
+	if len(password) < 12 {
+		return "", fmt.Errorf("%w: password must contain at least 12 characters", ErrValidation)
+	}
+
+	hasUpper := false
+	hasLower := false
+	hasSpecial := false
+	for i := 0; i < len(password); i++ {
+		switch c := password[i]; {
+		case c >= 'A' && c <= 'Z':
+			hasUpper = true
+		case c >= 'a' && c <= 'z':
+			hasLower = true
+		case c >= '0' && c <= '9':
+		default:
+			hasSpecial = true
+		}
+	}
+	if !hasUpper {
+		return "", fmt.Errorf("%w: password must contain at least one uppercase letter", ErrValidation)
+	}
+	if !hasLower {
+		return "", fmt.Errorf("%w: password must contain at least one lowercase letter", ErrValidation)
+	}
+	if !hasSpecial {
+		return "", fmt.Errorf("%w: password must contain at least one non-alphanumeric character", ErrValidation)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	return string(hash), err
+}
+
+func randomPassword() (string, error) {
+	password := make([]byte, 0, generatedPasswordLength)
+	for _, charset := range []string{passwordUpperCharacters, passwordLowerCharacters, passwordDigitCharacters, passwordSpecialCharacters} {
+		ch, err := randomPasswordCharacter(charset)
+		if err != nil {
+			return "", err
+		}
+		password = append(password, ch)
+	}
+	for len(password) < generatedPasswordLength {
+		ch, err := randomPasswordCharacter(passwordAllCharacters)
+		if err != nil {
+			return "", err
+		}
+		password = append(password, ch)
+	}
+	if err := shufflePasswordCharacters(password); err != nil {
+		return "", err
+	}
+	return string(password), nil
+}
+
+func randomPasswordCharacter(charset string) (byte, error) {
+	if charset == "" {
+		return 0, fmt.Errorf("identity: empty password charset")
+	}
+	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+	if err != nil {
+		return 0, err
+	}
+	return charset[idx.Int64()], nil
+}
+
+func shufflePasswordCharacters(password []byte) error {
+	for i := len(password) - 1; i > 0; i-- {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return err
+		}
+		j := int(idx.Int64())
+		password[i], password[j] = password[j], password[i]
+	}
+	return nil
+}

--- a/internal/identity/postgres_test.go
+++ b/internal/identity/postgres_test.go
@@ -200,6 +200,106 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	}
 }
 
+func TestPostgresTenantAdminUserProtection(t *testing.T) {
+	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
+	ctx := context.Background()
+	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err = db.Exec(`TRUNCATE audit_logs,user_sessions,user_roles,role_permissions,menus,users,roles,permissions,tenants CASCADE`); err != nil {
+		t.Fatal(err)
+	}
+
+	service := NewService(db)
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
+		t.Fatal(err)
+	}
+	login, err := service.Login(ctx, "admin", "Bootstrap-Password-123!", false, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	platformAdmin, err := service.Authenticate(ctx, login.AccessToken, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenant, _, err := service.CreateTenant(ctx, platformAdmin, CreateTenantInput{
+		Name:             "Protected Tenant",
+		ExpiresAt:        time.Now().Add(time.Hour),
+		AdminUsername:    "protected-tenant-admin",
+		AdminDisplayName: "Protected Tenant Admin",
+		AdminPassword:    "Tenant-Password-123!",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantLogin, err := service.Login(ctx, "protected-tenant-admin", "Tenant-Password-123!", false, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantAdmin, err := service.Authenticate(ctx, tenantLogin.AccessToken, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	roles, err := service.ListRoles(ctx, tenant.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tenantAdminRole Role
+	for _, role := range roles {
+		if role.Code == "tenant_admin" {
+			tenantAdminRole = role
+			break
+		}
+	}
+	if tenantAdminRole.ID == "" {
+		t.Fatal("tenant admin role not found")
+	}
+	customRole, err := service.CreateRole(ctx, tenantAdmin, tenant.ID, "Custom role", "", []string{"tenant.users.read"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createUser := func(username string, roleIDs []string) User {
+		t.Helper()
+		user, _, createErr := service.CreateUser(ctx, tenantAdmin, tenant.ID, username, username, "User-Password-123!", roleIDs)
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		return user
+	}
+	deleteProtectedAdmin := createUser("delete-protected-admin", []string{tenantAdminRole.ID})
+	rolesProtectedAdmin := createUser("roles-protected-admin", []string{tenantAdminRole.ID})
+	membershipProtectedAdmin := createUser("membership-protected-admin", []string{tenantAdminRole.ID, customRole.ID})
+	assignableUser := createUser("assignable-user", nil)
+	deletableUser := createUser("deletable-user", nil)
+
+	if err = service.AssignUserRoles(ctx, tenantAdmin, tenant.ID, assignableUser.ID, []string{customRole.ID}); err != nil {
+		t.Errorf("assign roles to non-admin user: %v", err)
+	}
+	if err = service.DeleteUser(ctx, tenantAdmin, tenant.ID, deletableUser.ID); err != nil {
+		t.Errorf("delete non-admin user: %v", err)
+	}
+	if err = service.DeleteUser(ctx, tenantAdmin, tenant.ID, deleteProtectedAdmin.ID); !errors.Is(err, ErrProtectedResource) {
+		t.Errorf("delete tenant admin err=%v, want ErrProtectedResource", err)
+	}
+	if err = service.AssignUserRoles(ctx, tenantAdmin, tenant.ID, rolesProtectedAdmin.ID, []string{customRole.ID}); !errors.Is(err, ErrProtectedResource) {
+		t.Errorf("assign tenant admin roles err=%v, want ErrProtectedResource", err)
+	}
+	if err = service.ReplaceRoleUsers(ctx, tenantAdmin, tenant.ID, customRole.ID, []string{assignableUser.ID}, customRole.Version); !errors.Is(err, ErrProtectedResource) {
+		t.Errorf("remove custom role from tenant admin err=%v, want ErrProtectedResource", err)
+	}
+	if err = service.ReplaceRoleUsers(ctx, tenantAdmin, tenant.ID, tenantAdminRole.ID, []string{tenantAdmin.User.ID, membershipProtectedAdmin.ID}, tenantAdminRole.Version); !errors.Is(err, ErrProtectedResource) {
+		t.Errorf("replace tenant admin membership err=%v, want ErrProtectedResource", err)
+	}
+}
+
 func containsMenu(menus []Menu, code string) bool {
 	for _, menu := range menus {
 		if menu.Code == code {

--- a/internal/identity/postgres_test.go
+++ b/internal/identity/postgres_test.go
@@ -34,7 +34,7 @@ func TestPostgresBootstrapFreshAdminRequiresPassword(t *testing.T) {
 	if !errors.Is(err, ErrValidation) {
 		t.Errorf("Bootstrap() error = %v, want ErrValidation", err)
 	}
-	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
 		t.Fatalf("restore shared postgres identity fixture: %v", err)
 	}
 }
@@ -55,7 +55,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	service := NewService(db)
-	if err = service.Bootstrap(ctx, "bootstrap-password-123"); err != nil {
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
 		t.Fatal(err)
 	}
 	if err = service.Bootstrap(ctx, ""); err != nil {
@@ -75,7 +75,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if len(systemRoles) != 1 || systemRoles[0].ID != SystemRoleID || systemRoles[0].Name != "Administrator" || !systemRoles[0].SystemProtected {
 		t.Fatalf("system roles=%+v", systemRoles)
 	}
-	login, err := service.Login(ctx, "admin", "bootstrap-password-123", false, "test")
+	login, err := service.Login(ctx, "admin", "Bootstrap-Password-123!", false, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tenant, admin, err := service.CreateTenant(ctx, principal, CreateTenantInput{Name: "Tenant A", ExpiresAt: time.Now().Add(time.Hour), AdminUsername: "tenant-admin", AdminDisplayName: "Tenant Admin", AdminPassword: "tenant-password-123"})
+	tenant, admin, err := service.CreateTenant(ctx, principal, CreateTenantInput{Name: "Tenant A", ExpiresAt: time.Now().Add(time.Hour), AdminUsername: "tenant-admin", AdminDisplayName: "Tenant Admin", AdminPassword: "Tenant-Password-123!"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,14 +99,14 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if !strings.HasPrefix(tenant.Slug, "tenant-") || len(tenant.Slug) != len("tenant-")+32 {
 		t.Fatalf("generated tenant slug = %q", tenant.Slug)
 	}
-	tenantAdminLogin, err := service.Login(ctx, "tenant-admin", "tenant-password-123", false, "test")
+	tenantAdminLogin, err := service.Login(ctx, "tenant-admin", "Tenant-Password-123!", false, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if containsMenu(tenantAdminLogin.Principal.Menus, MenuManagementCode) || !containsMenu(tenantAdminLogin.Principal.Menus, "governance.users") {
 		t.Fatalf("tenant admin menus=%+v", tenantAdminLogin.Principal.Menus)
 	}
-	if err = service.ChangePassword(ctx, tenantAdminLogin.Principal, "tenant-password-123", "tenant-password-456"); err != nil {
+	if err = service.ChangePassword(ctx, tenantAdminLogin.Principal, "Tenant-Password-123!", "Tenant-Password-456!"); err != nil {
 		t.Fatal(err)
 	}
 	tenantAdmin, err := service.Authenticate(ctx, tenantAdminLogin.AccessToken, "")
@@ -139,25 +139,25 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if !strings.HasPrefix(limitedRole.Code, "role_") || len(limitedRole.Code) != len("role_")+32 {
 		t.Fatalf("generated role code = %q", limitedRole.Code)
 	}
-	limitedUser, err := service.CreateUser(ctx, tenantAdmin, tenant.ID, "limited-manager", "Limited Manager", "limited-password-123", []string{limitedRole.ID})
+	limitedUser, _, err := service.CreateUser(ctx, tenantAdmin, tenant.ID, "limited-manager", "Limited Manager", "Limited-Password-123!", []string{limitedRole.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
-	limitedLogin, err := service.Login(ctx, "limited-manager", "limited-password-123", false, "test")
+	limitedLogin, err := service.Login(ctx, "limited-manager", "Limited-Password-123!", false, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = service.ChangePassword(ctx, limitedLogin.Principal, "limited-password-123", "limited-password-456"); err != nil {
+	if err = service.ChangePassword(ctx, limitedLogin.Principal, "Limited-Password-123!", "Limited-Password-456!"); err != nil {
 		t.Fatal(err)
 	}
 	limitedPrincipal, err := service.Authenticate(ctx, limitedLogin.AccessToken, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = service.CreateUser(ctx, limitedPrincipal, tenant.ID, "escalated-user", "Escalated User", "escalated-password-123", []string{tenantAdminRoleID}); !errors.Is(err, ErrPermissionDenied) {
+	if _, _, err = service.CreateUser(ctx, limitedPrincipal, tenant.ID, "escalated-user", "Escalated User", "Escalated-Password-123!", []string{tenantAdminRoleID}); !errors.Is(err, ErrPermissionDenied) {
 		t.Fatalf("create user with non-delegable role err=%v", err)
 	}
-	rolelessUser, err := service.CreateUser(ctx, limitedPrincipal, tenant.ID, "roleless-user", "Roleless User", "roleless-password-123", nil)
+	rolelessUser, _, err := service.CreateUser(ctx, limitedPrincipal, tenant.ID, "roleless-user", "Roleless User", "Roleless-Password-123!", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestPostgresIdentityLifecycle(t *testing.T) {
 	if _, err = service.UpdateTenant(ctx, principal, tenant.ID, "active", &past, tenant.Version); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = service.Login(ctx, "tenant-admin", "tenant-password-456", false, "test"); !errors.Is(err, ErrTenantExpired) {
+	if _, err = service.Login(ctx, "tenant-admin", "Tenant-Password-456!", false, "test"); !errors.Is(err, ErrTenantExpired) {
 		t.Fatalf("expired login err=%v", err)
 	}
 }

--- a/internal/identity/service.go
+++ b/internal/identity/service.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"sort"
 	"strings"
 	"sync"
@@ -33,7 +34,15 @@ var (
 	ErrValidation         = errors.New("validation failed")
 )
 
-const dummyPasswordHash = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7N5x5V7e"
+const (
+	dummyPasswordHash         = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7N5x5V7e"
+	generatedPasswordLength   = 16
+	passwordUpperCharacters   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	passwordLowerCharacters   = "abcdefghijklmnopqrstuvwxyz"
+	passwordDigitCharacters   = "0123456789"
+	passwordSpecialCharacters = "!@#$%^&*()-_=+[]{}:,.?"
+	passwordAllCharacters     = passwordUpperCharacters + passwordLowerCharacters + passwordDigitCharacters + passwordSpecialCharacters
+)
 
 type Service struct {
 	db *sql.DB
@@ -66,8 +75,78 @@ func HashPassword(password string) (string, error) {
 	if len(password) < 12 {
 		return "", fmt.Errorf("%w: password must contain at least 12 characters", ErrValidation)
 	}
+
+	hasUpper := false
+	hasLower := false
+	hasSpecial := false
+	for i := 0; i < len(password); i++ {
+		switch c := password[i]; {
+		case c >= 'A' && c <= 'Z':
+			hasUpper = true
+		case c >= 'a' && c <= 'z':
+			hasLower = true
+		case c >= '0' && c <= '9':
+		default:
+			hasSpecial = true
+		}
+	}
+	if !hasUpper {
+		return "", fmt.Errorf("%w: password must contain at least one uppercase letter", ErrValidation)
+	}
+	if !hasLower {
+		return "", fmt.Errorf("%w: password must contain at least one lowercase letter", ErrValidation)
+	}
+	if !hasSpecial {
+		return "", fmt.Errorf("%w: password must contain at least one non-alphanumeric character", ErrValidation)
+	}
+
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	return string(hash), err
+}
+
+func randomPassword() (string, error) {
+	password := make([]byte, 0, generatedPasswordLength)
+	for _, charset := range []string{passwordUpperCharacters, passwordLowerCharacters, passwordDigitCharacters, passwordSpecialCharacters} {
+		ch, err := randomPasswordCharacter(charset)
+		if err != nil {
+			return "", err
+		}
+		password = append(password, ch)
+	}
+	for len(password) < generatedPasswordLength {
+		ch, err := randomPasswordCharacter(passwordAllCharacters)
+		if err != nil {
+			return "", err
+		}
+		password = append(password, ch)
+	}
+	if err := shufflePasswordCharacters(password); err != nil {
+		return "", err
+	}
+	return string(password), nil
+}
+
+func randomPasswordCharacter(charset string) (byte, error) {
+	if charset == "" {
+		return 0, errors.New("identity: empty password charset")
+	}
+	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+	if err != nil {
+		return 0, err
+	}
+	return charset[idx.Int64()], nil
+}
+
+func shufflePasswordCharacters(password []byte) error {
+	for i := len(password) - 1; i > 0; i-- {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return err
+		}
+		j := int(idx.Int64())
+		password[i], password[j] = password[j], password[i]
+	}
+	return nil
 }
 
 func generatedIdentifier(prefix string) string {
@@ -893,56 +972,65 @@ func (s *Service) ListUsers(ctx context.Context, tenantID string) ([]User, error
 	return users, rows.Err()
 }
 
-func (s *Service) CreateUser(ctx context.Context, actor Principal, tenantID, username, displayName, password string, roleIDs []string) (User, error) {
+func (s *Service) CreateUser(ctx context.Context, actor Principal, tenantID, username, displayName, password string, roleIDs []string) (User, string, error) {
 	if !actor.Has("tenant.users.create") && !actor.Has("platform.users.manage") {
-		return User{}, ErrPermissionDenied
+		return User{}, "", ErrPermissionDenied
 	}
 	if err := ensureActorTenantScope(actor, tenantID); err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	if len(roleIDs) > 0 && !actor.Has("tenant.users.assign_roles") && !actor.Has("platform.users.manage") {
-		return User{}, ErrPermissionDenied
+		return User{}, "", ErrPermissionDenied
 	}
 	normalizedUsername := NormalizeUsername(username)
 	displayName = strings.TrimSpace(displayName)
 	if !validIdentifier(normalizedUsername, 128, true) || displayName == "" || len(displayName) > 128 {
-		return User{}, fmt.Errorf("%w: invalid user input", ErrValidation)
+		return User{}, "", fmt.Errorf("%w: invalid user input", ErrValidation)
+	}
+	generatedPassword := ""
+	if strings.TrimSpace(password) == "" {
+		var err error
+		generatedPassword, err = randomPassword()
+		if err != nil {
+			return User{}, "", err
+		}
+		password = generatedPassword
 	}
 	hash, err := HashPassword(password)
 	if err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	userID := uuid.NewString()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err = tx.ExecContext(ctx, `INSERT INTO users (id, tenant_id, username, username_normalized, display_name, password_hash, must_change_password, created_by) VALUES (?, ?, ?, ?, ?, ?, true, ?)`, userID, tenantID, strings.TrimSpace(username), normalizedUsername, displayName, hash, actor.User.ID); err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	if err = ensureRolesDelegable(ctx, tx, actor, tenantID, roleIDs); err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	for _, roleID := range roleIDs {
 		if _, err = tx.ExecContext(ctx, `INSERT INTO user_roles (user_id, role_id, created_by) VALUES (?, ?, ?)`, userID, roleID, actor.User.ID); err != nil {
-			return User{}, err
+			return User{}, "", err
 		}
 	}
 	if err = tx.Commit(); err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	s.RecordAudit(ctx, AuditEvent{TenantID: tenantID, ActorKind: actor.Kind, ActorUserID: actor.User.ID, ActorSessionID: actor.SessionID, Action: "user.create", ResourceType: "user", ResourceID: userID, Result: "success"})
 	users, err := s.ListUsers(ctx, tenantID)
 	if err != nil {
-		return User{}, err
+		return User{}, "", err
 	}
 	for _, user := range users {
 		if user.ID == userID {
-			return user, nil
+			return user, generatedPassword, nil
 		}
 	}
-	return User{}, sql.ErrNoRows
+	return User{}, "", sql.ErrNoRows
 }
 
 func (s *Service) ResetPassword(ctx context.Context, actor Principal, tenantID, userID, password string) error {

--- a/internal/identity/service.go
+++ b/internal/identity/service.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"sort"
 	"strings"
 	"sync"
@@ -34,15 +33,7 @@ var (
 	ErrValidation         = errors.New("validation failed")
 )
 
-const (
-	dummyPasswordHash         = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7N5x5V7e"
-	generatedPasswordLength   = 16
-	passwordUpperCharacters   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	passwordLowerCharacters   = "abcdefghijklmnopqrstuvwxyz"
-	passwordDigitCharacters   = "0123456789"
-	passwordSpecialCharacters = "!@#$%^&*()-_=+[]{}:,.?"
-	passwordAllCharacters     = passwordUpperCharacters + passwordLowerCharacters + passwordDigitCharacters + passwordSpecialCharacters
-)
+const dummyPasswordHash = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7N5x5V7e"
 
 type Service struct {
 	db *sql.DB
@@ -69,84 +60,6 @@ func NewService(db *sql.DB) *Service { return &Service{db: db} }
 
 func NormalizeUsername(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
-}
-
-func HashPassword(password string) (string, error) {
-	if len(password) < 12 {
-		return "", fmt.Errorf("%w: password must contain at least 12 characters", ErrValidation)
-	}
-
-	hasUpper := false
-	hasLower := false
-	hasSpecial := false
-	for i := 0; i < len(password); i++ {
-		switch c := password[i]; {
-		case c >= 'A' && c <= 'Z':
-			hasUpper = true
-		case c >= 'a' && c <= 'z':
-			hasLower = true
-		case c >= '0' && c <= '9':
-		default:
-			hasSpecial = true
-		}
-	}
-	if !hasUpper {
-		return "", fmt.Errorf("%w: password must contain at least one uppercase letter", ErrValidation)
-	}
-	if !hasLower {
-		return "", fmt.Errorf("%w: password must contain at least one lowercase letter", ErrValidation)
-	}
-	if !hasSpecial {
-		return "", fmt.Errorf("%w: password must contain at least one non-alphanumeric character", ErrValidation)
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	return string(hash), err
-}
-
-func randomPassword() (string, error) {
-	password := make([]byte, 0, generatedPasswordLength)
-	for _, charset := range []string{passwordUpperCharacters, passwordLowerCharacters, passwordDigitCharacters, passwordSpecialCharacters} {
-		ch, err := randomPasswordCharacter(charset)
-		if err != nil {
-			return "", err
-		}
-		password = append(password, ch)
-	}
-	for len(password) < generatedPasswordLength {
-		ch, err := randomPasswordCharacter(passwordAllCharacters)
-		if err != nil {
-			return "", err
-		}
-		password = append(password, ch)
-	}
-	if err := shufflePasswordCharacters(password); err != nil {
-		return "", err
-	}
-	return string(password), nil
-}
-
-func randomPasswordCharacter(charset string) (byte, error) {
-	if charset == "" {
-		return 0, errors.New("identity: empty password charset")
-	}
-	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
-	if err != nil {
-		return 0, err
-	}
-	return charset[idx.Int64()], nil
-}
-
-func shufflePasswordCharacters(password []byte) error {
-	for i := len(password) - 1; i > 0; i-- {
-		idx, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
-		if err != nil {
-			return err
-		}
-		j := int(idx.Int64())
-		password[i], password[j] = password[j], password[i]
-	}
-	return nil
 }
 
 func generatedIdentifier(prefix string) string {

--- a/internal/identity/service_admin.go
+++ b/internal/identity/service_admin.go
@@ -274,28 +274,11 @@ func (s *Service) AssignUserRoles(ctx context.Context, actor Principal, tenantID
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
-	var userTenant string
-	if err = tx.QueryRowContext(ctx, `SELECT tenant_id FROM users WHERE id=? FOR UPDATE`, userID).Scan(&userTenant); err != nil {
+	if err = ensureNotTenantAdmin(ctx, tx, tenantID, userID); err != nil {
 		return err
-	}
-	if userTenant != tenantID {
-		return ErrTenantScope
 	}
 	if err = ensureRolesDelegable(ctx, tx, actor, tenantID, roleIDs); err != nil {
 		return err
-	}
-	keepsAdmin := false
-	for _, roleID := range roleIDs {
-		var protected bool
-		if err = tx.QueryRowContext(ctx, `SELECT system_protected FROM roles WHERE id=? AND tenant_id=?`, roleID, tenantID).Scan(&protected); err != nil {
-			return err
-		}
-		keepsAdmin = keepsAdmin || protected
-	}
-	if !keepsAdmin {
-		if err = ensureNotLastTenantAdmin(ctx, tx, tenantID, userID); err != nil {
-			return err
-		}
 	}
 	if _, err = tx.ExecContext(ctx, `DELETE FROM user_roles WHERE user_id=?`, userID); err != nil {
 		return err
@@ -341,7 +324,7 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 	if currentVersion != version {
 		return ErrVersionConflict
 	}
-	if roleID == SystemRoleID {
+	if protected {
 		return ErrProtectedResource
 	}
 	if err = ensureRolesDelegable(ctx, tx, actor, tenantID, []string{roleID}); err != nil {
@@ -349,7 +332,6 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 	}
 
 	selected := make(map[string]struct{}, len(userIDs))
-	activeSelected := 0
 	for _, userID := range userIDs {
 		userID = strings.TrimSpace(userID)
 		if userID == "" {
@@ -361,22 +343,17 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 		if _, exists := selected[userID]; exists {
 			continue
 		}
-		var userTenant, status string
-		if err = tx.QueryRowContext(ctx, `SELECT tenant_id,status FROM users WHERE id=?`, userID).Scan(&userTenant, &status); err != nil {
+		var userTenant string
+		if err = tx.QueryRowContext(ctx, `SELECT tenant_id FROM users WHERE id=?`, userID).Scan(&userTenant); err != nil {
 			return err
 		}
 		if userTenant != tenantID {
 			return ErrTenantScope
 		}
 		selected[userID] = struct{}{}
-		if status == "active" {
-			activeSelected++
-		}
-	}
-	if protected && activeSelected == 0 {
-		return ErrProtectedResource
 	}
 
+	current := make(map[string]struct{})
 	affected := make(map[string]struct{}, len(selected))
 	rows, err := tx.QueryContext(ctx, `SELECT user_id FROM user_roles WHERE role_id=?`, roleID)
 	if err != nil {
@@ -388,6 +365,7 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 			_ = rows.Close()
 			return err
 		}
+		current[userID] = struct{}{}
 		affected[userID] = struct{}{}
 	}
 	if err = rows.Close(); err != nil {
@@ -396,8 +374,22 @@ func (s *Service) ReplaceRoleUsers(ctx context.Context, actor Principal, tenantI
 	if err = rows.Err(); err != nil {
 		return err
 	}
+	for userID := range current {
+		if _, remainsAssigned := selected[userID]; remainsAssigned {
+			continue
+		}
+		if err = ensureNotTenantAdmin(ctx, tx, tenantID, userID); err != nil {
+			return err
+		}
+	}
 	for userID := range selected {
 		affected[userID] = struct{}{}
+		if _, alreadyAssigned := current[userID]; alreadyAssigned {
+			continue
+		}
+		if err = ensureNotTenantAdmin(ctx, tx, tenantID, userID); err != nil {
+			return err
+		}
 	}
 
 	if _, err = tx.ExecContext(ctx, `DELETE FROM user_roles WHERE role_id=?`, roleID); err != nil {
@@ -490,7 +482,7 @@ func (s *Service) DeleteUser(ctx context.Context, actor Principal, tenantID, use
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
-	if err = ensureNotLastTenantAdmin(ctx, tx, tenantID, userID); err != nil {
+	if err = ensureNotTenantAdmin(ctx, tx, tenantID, userID); err != nil {
 		return err
 	}
 	res, err := tx.ExecContext(ctx, `DELETE FROM users WHERE id=? AND tenant_id=?`, userID, tenantID)
@@ -570,6 +562,24 @@ func (s *Service) DeleteTenant(ctx context.Context, actor Principal, tenantID st
 	}
 	s.RecordAudit(ctx, AuditEvent{TenantID: tenantID, ActorKind: actor.Kind, ActorUserID: actor.User.ID, ActorSessionID: actor.SessionID, Action: "tenant.disable", ResourceType: "tenant", ResourceID: tenantID, Result: "success"})
 	return s.GetTenant(ctx, tenantID)
+}
+
+func ensureNotTenantAdmin(ctx context.Context, tx *sql.Tx, tenantID, userID string) error {
+	var userTenant string
+	if err := tx.QueryRowContext(ctx, `SELECT tenant_id FROM users WHERE id=? FOR UPDATE`, userID).Scan(&userTenant); err != nil {
+		return err
+	}
+	if userTenant != tenantID {
+		return ErrTenantScope
+	}
+	var tenantAdmin bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM user_roles ur JOIN roles r ON r.id=ur.role_id WHERE ur.user_id=? AND r.tenant_id=? AND r.code='tenant_admin' AND r.scope='tenant' AND r.system_protected=true)`, userID, tenantID).Scan(&tenantAdmin); err != nil {
+		return err
+	}
+	if tenantAdmin {
+		return ErrProtectedResource
+	}
+	return nil
 }
 
 func ensureNotLastTenantAdmin(ctx context.Context, tx *sql.Tx, tenantID, userID string) error {

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -1,10 +1,16 @@
 package identity
 
 import (
+	"context"
+	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	_ "modernc.org/sqlite"
 )
 
 func TestNormalizeUsername(t *testing.T) {
@@ -17,9 +23,48 @@ func TestHashPasswordPolicyAndVerification(t *testing.T) {
 	if _, err := HashPassword("too-short"); err == nil {
 		t.Fatal("expected short password to be rejected")
 	}
-	hash, err := HashPassword("correct-horse-battery-staple")
+	if _, err := HashPassword("alllowercase!"); err == nil {
+		t.Fatal("expected password without uppercase and sufficient complexity to be rejected")
+	}
+	hash, err := HashPassword("Correct-Horse-1!")
 	if err != nil || hash == "" {
 		t.Fatalf("HashPassword() hash=%q err=%v", hash, err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte("Correct-Horse-1!")); err != nil {
+		t.Fatalf("CompareHashAndPassword() err=%v", err)
+	}
+}
+
+func TestCreateUserGeneratesInitialPasswordWhenBlank(t *testing.T) {
+	ctx := context.Background()
+	service, db := newSQLiteCreateUserTestService(t)
+	principal := Principal{
+		PlatformAdmin:   true,
+		Kind:            "user",
+		User:            User{ID: SystemUserID, TenantID: SystemTenantID},
+		EffectiveTenant: Tenant{ID: SystemTenantID},
+	}
+
+	user, initialPassword, err := service.CreateUser(ctx, principal, SystemTenantID, "generated-user", "Generated User", "   ", nil)
+	if err != nil {
+		t.Fatalf("CreateUser() err=%v", err)
+	}
+	if user.ID == "" {
+		t.Fatal("CreateUser() returned empty user id")
+	}
+	if initialPassword == "" {
+		t.Fatal("CreateUser() did not return generated password")
+	}
+	if _, err := HashPassword(initialPassword); err != nil {
+		t.Fatalf("generated password does not satisfy policy: %v", err)
+	}
+
+	var passwordHash string
+	if err := db.QueryRowContext(ctx, `SELECT password_hash FROM users WHERE id = ?`, user.ID).Scan(&passwordHash); err != nil {
+		t.Fatalf("query generated user hash: %v", err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(initialPassword)); err != nil {
+		t.Fatalf("generated password does not verify against stored hash: %v", err)
 	}
 }
 
@@ -199,6 +244,37 @@ func TestMenuCodeForPermission(t *testing.T) {
 	if len(tests) != 0 {
 		t.Fatalf("permissions missing from catalog: %v", tests)
 	}
+}
+
+func newSQLiteCreateUserTestService(t *testing.T) (*Service, *sql.DB) {
+	t.Helper()
+	dsn := fmt.Sprintf("file:identity_create_user_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(4)
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("close sqlite identity db: %v", closeErr)
+		}
+	})
+	for _, statement := range []string{
+		`CREATE TABLE users (
+			id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, username TEXT NOT NULL, username_normalized TEXT NOT NULL,
+			display_name TEXT NOT NULL, password_hash TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+			must_change_password BOOLEAN NOT NULL DEFAULT false, last_login_at TIMESTAMP NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			version INTEGER NOT NULL DEFAULT 1, created_by TEXT
+		)`,
+		`CREATE TABLE roles (id TEXT PRIMARY KEY, code TEXT NOT NULL, name TEXT NOT NULL)`,
+		`CREATE TABLE user_roles (user_id TEXT NOT NULL, role_id TEXT NOT NULL, created_by TEXT)`,
+	} {
+		if _, err = db.Exec(statement); err != nil {
+			t.Fatalf("create sqlite identity schema: %v", err)
+		}
+	}
+	return NewService(db), db
 }
 
 func ptrTime(value time.Time) *time.Time { return &value }

--- a/internal/management/aiaccountstatus/probe_xai.go
+++ b/internal/management/aiaccountstatus/probe_xai.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
+	"time"
 
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -13,7 +14,7 @@ import (
 )
 
 const (
-	xaiBillingWeeklyURL  = "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+	xaiBillingWeeklyURL  = xaiauth.CLIWeeklyBillingURL
 	xaiBillingMonthlyURL = "https://cli-chat-proxy.grok.com/v1/billing"
 )
 
@@ -107,49 +108,30 @@ func parseXAIBilling(body []byte, key, _ string, _ int64) []usage.QuotaWindowDTO
 }
 
 func parseXAIWeeklyBilling(body []byte) []usage.QuotaWindowDTO {
-	cfg := gjson.GetBytes(body, "config")
-	if !cfg.Exists() {
+	weekly, ok := xaiauth.ParseWeeklyBilling(body)
+	if !ok {
 		return nil
 	}
-	current := firstJSONResult(cfg, "currentPeriod", "current_period")
-	periodType := strings.ToLower(strings.TrimSpace(current.Get("type").String()))
-	used := firstJSONResult(cfg, "creditUsagePercent", "credit_usage_percent")
-	products := firstJSONResult(cfg, "productUsage", "product_usage")
-	if !used.Exists() && !strings.Contains(periodType, "weekly") && !products.IsArray() {
-		return nil
-	}
-
-	remaining := 100.0
-	if used.Exists() {
-		remaining = math.Round(100 - clampPct(used.Float()))
-	}
-	reset := firstJSONResult(current, "end")
-	if !reset.Exists() {
-		reset = firstJSONResult(cfg, "billingPeriodEnd", "billing_period_end")
+	var resetAt *time.Time
+	if !weekly.ResetAt.IsZero() {
+		reset := weekly.ResetAt
+		resetAt = &reset
 	}
 	// Weekly cards already show relative reset from ResetAt; keep Meta empty so the
 	// UI is not flooded with raw ISO period strings like "2026-07-16T06:45:51+00:00 - …".
 	out := []usage.QuotaWindowDTO{{
-		QuotaKey: "weekly_limit", QuotaLabel: "xai_quota.weekly_limit", Percent: &remaining,
-		Value: formatPercent(remaining), ResetAt: parseFlexibleTime(reset), WindowSeconds: 604800,
+		QuotaKey: "weekly_limit", QuotaLabel: "xai_quota.weekly_limit", Percent: &weekly.RemainingPercent,
+		Value: formatPercent(weekly.RemainingPercent), ResetAt: resetAt, WindowSeconds: 604800,
 	}}
-	if products.IsArray() {
-		index := 0
-		products.ForEach(func(_, product gjson.Result) bool {
-			index++
-			name := strings.TrimSpace(product.Get("product").String())
-			if name == "" {
-				name = fmt.Sprintf("Product %d", index)
-			}
-			productRemaining := 100.0
-			if productUsed := firstJSONResult(product, "usagePercent", "usage_percent"); productUsed.Exists() {
-				productRemaining = math.Round(100 - clampPct(productUsed.Float()))
-			}
-			out = append(out, usage.QuotaWindowDTO{
-				QuotaKey: "product:" + name, QuotaLabel: "xai_quota.product_usage_named::" + name,
-				Percent: &productRemaining, Value: formatPercent(productRemaining),
-			})
-			return true
+	for index, product := range weekly.Products {
+		name := product.Name
+		if name == "" {
+			name = fmt.Sprintf("Product %d", index+1)
+		}
+		remaining := product.RemainingPercent
+		out = append(out, usage.QuotaWindowDTO{
+			QuotaKey: "product:" + name, QuotaLabel: "xai_quota.product_usage_named::" + name,
+			Percent: &remaining, Value: formatPercent(remaining),
 		})
 	}
 	return out

--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -128,7 +128,7 @@ func (s *Service) StartRefresh(tenantID string, req RefreshRequest) RefreshAccep
 	// Refresh boundary: allow stale cleanup without waiting for GET throttle alone.
 	s.maybeNormalizeStaleRefresh(tenantID)
 	auths := s.listAuths(tenantID)
-	// Best-effort: still start refresh even if some legacy bindings fail to reconcile.
+	// Best-effort: still start refresh even if some binding repairs fail.
 	_ = reconcileTenantBindings(auths)
 	byIndex := make(map[string]*coreauth.Auth, len(auths))
 	bySubject := make(map[string]*coreauth.Auth, len(auths))
@@ -552,7 +552,28 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		}
 	}
 
-	// Latest-status persistence is the trust boundary: write failure must not be reported as success.
+	// Persist the shared runtime truth before the legacy tenant mirror. Shared
+	// status/version must not depend on a legacy reload succeeding.
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID: subjectID, Provider: auth.Provider, LastProbeState: string(RefreshSuccess),
+		HealthStatus: healthStatus, PlanType: strings.TrimSpace(probe.PlanType),
+		SubscriptionStartedAt: probe.SubscriptionStartedAt, SubscriptionExpiresAt: probe.SubscriptionExpiresAt,
+		SubscriptionSource: probe.SubscriptionSource, RestrictionSummary: record.RestrictionSummary, Quotas: probe.Quotas,
+		ResetCreditCount: probe.ResetCreditCount, ResetCreditExpirations: probe.ResetCreditExpirations,
+		UpstreamCheckedAt: &checked, UpdatedAt: checked,
+	}); err != nil {
+		_ = usage.UpdateAIAccountRefreshFailure(tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status), "persist_failed", err.Error(), checked)
+		s.setResult(jobID, subjectID, func(r *AccountRefreshResult) {
+			r.State = RefreshError
+			r.ErrorCode = "persist_failed"
+			r.ErrorMessage = sanitizeMsg(err.Error())
+			r.UpdatedAt = checked
+			r.Result = nil
+		})
+		return
+	}
+
+	// Keep the legacy tenant mirror for compatibility while shared remains authoritative.
 	upsert := s.upsertStatus
 	if upsert == nil {
 		upsert = usage.UpsertAIAccountStatus
@@ -582,24 +603,6 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 			r.State = RefreshError
 			r.ErrorCode = "persist_reload_failed"
 			r.ErrorMessage = sanitizeMsg(msg)
-			r.UpdatedAt = checked
-			r.Result = nil
-		})
-		return
-	}
-	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
-		AuthSubjectID: subjectID, Provider: auth.Provider, LastProbeState: string(RefreshSuccess),
-		HealthStatus: healthStatus, PlanType: strings.TrimSpace(probe.PlanType),
-		SubscriptionStartedAt: probe.SubscriptionStartedAt, SubscriptionExpiresAt: probe.SubscriptionExpiresAt,
-		SubscriptionSource: probe.SubscriptionSource, RestrictionSummary: record.RestrictionSummary, Quotas: probe.Quotas,
-		ResetCreditCount: probe.ResetCreditCount, ResetCreditExpirations: probe.ResetCreditExpirations,
-		UpstreamCheckedAt: &checked, Version: legacyPersisted.Version, UpdatedAt: checked,
-	}); err != nil {
-		_ = usage.UpdateAIAccountRefreshFailure(tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status), "persist_failed", err.Error(), checked)
-		s.setResult(jobID, subjectID, func(r *AccountRefreshResult) {
-			r.State = RefreshError
-			r.ErrorCode = "persist_failed"
-			r.ErrorMessage = sanitizeMsg(err.Error())
 			r.UpdatedAt = checked
 			r.Result = nil
 		})
@@ -969,7 +972,7 @@ func reconcileTenantBindings(auths []*coreauth.Auth) error {
 	for _, row := range rows {
 		byID[row.AuthID] = row
 	}
-	// Best-effort per auth: one bad legacy row must not 500 the whole status list.
+	// Best-effort per auth: one bad binding row must not 500 the whole status list.
 	var firstErr error
 	for _, auth := range auths {
 		if auth == nil {

--- a/internal/management/aiaccountstatus/service_test.go
+++ b/internal/management/aiaccountstatus/service_test.go
@@ -225,9 +225,12 @@ func TestListStatusDoesNotReadRequestLogs(t *testing.T) {
 	}
 	pct := 65.0
 	now := time.Now().UTC()
-	if err := usage.UpsertAIAccountStatus(usage.AIAccountStatusRecord{
-		TenantID: "tenant-read-model", AuthSubjectID: identity.ID, AuthIndex: auth.EnsureIndex(), Provider: "codex",
-		RefreshState: "success", PlanType: "plus", Quotas: []usage.QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pct}}, UpdatedAt: now,
+	if err := usage.UpsertAIAccountSubject(identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID: identity.ID, Provider: "codex", LastProbeState: string(RefreshSuccess),
+		PlanType: "plus", Quotas: []usage.QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pct}}, UpdatedAt: now,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -418,20 +421,22 @@ func TestProgressiveSuccessResultUsesDBVersion(t *testing.T) {
 	if identity == nil {
 		t.Fatal("missing identity")
 	}
-	// Bump DB version well above 0.
+	if err := usage.UpsertAIAccountSubject(identity); err != nil {
+		t.Fatal(err)
+	}
+	// Bump shared DB version well above 0.
 	now := time.Now().UTC()
 	for i := 0; i < 3; i++ {
 		pct := float64(10 + i)
-		if err := usage.UpsertAIAccountStatus(usage.AIAccountStatusRecord{
-			TenantID: "tenant-ver", AuthSubjectID: identity.ID, AuthIndex: auth.EnsureIndex(), Provider: "codex",
-			RefreshState: "success", PlanType: "plus",
+		if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+			AuthSubjectID: identity.ID, Provider: "codex", LastProbeState: string(RefreshSuccess), PlanType: "plus",
 			Quotas:            []usage.QuotaWindowDTO{{QuotaKey: "code_week", Percent: &pct}},
 			UpstreamCheckedAt: &now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	before, err := usage.ListAIAccountStatusForTenant("tenant-ver", []string{identity.ID})
+	before, err := usage.ListAIAccountSubjectStatus([]string{identity.ID})
 	if err != nil || len(before) != 1 {
 		t.Fatalf("before=%v err=%v", before, err)
 	}
@@ -457,7 +462,7 @@ func TestProgressiveSuccessResultUsesDBVersion(t *testing.T) {
 	if progressive == nil {
 		t.Fatalf("missing progressive result: %+v", snap.Results)
 	}
-	after, err := usage.ListAIAccountStatusForTenant("tenant-ver", []string{identity.ID})
+	after, err := usage.ListAIAccountSubjectStatus([]string{identity.ID})
 	if err != nil || len(after) != 1 {
 		t.Fatalf("after=%v err=%v", after, err)
 	}
@@ -585,9 +590,11 @@ func TestFreshSkipUsesBatchLoadNotPerAccountUnderLock(t *testing.T) {
 	now := time.Now().UTC()
 	for _, auth := range []*coreauth.Auth{a1, a2} {
 		id := usage.ResolveAuthSubjectIdentity(auth)
-		if err := usage.UpsertAIAccountStatus(usage.AIAccountStatusRecord{
-			TenantID: "tenant-fresh", AuthSubjectID: id.ID, AuthIndex: auth.EnsureIndex(), Provider: "codex",
-			RefreshState: "success", UpstreamCheckedAt: &now, UpdatedAt: now,
+		if err := usage.UpsertAIAccountSubject(id); err != nil {
+			t.Fatal(err)
+		}
+		if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+			AuthSubjectID: id.ID, Provider: "codex", LastProbeState: string(RefreshSuccess), UpstreamCheckedAt: &now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatal(err)
 		}
@@ -762,6 +769,13 @@ func TestPersistReloadFailedDoesNotReportSuccess(t *testing.T) {
 			t.Fatalf("Result must be nil, got %+v", r.Result)
 		}
 	}
+	shared, err := usage.ListAIAccountSubjectStatus([]string{identity.ID})
+	if err != nil || len(shared) != 1 {
+		t.Fatalf("shared status=%+v err=%v", shared, err)
+	}
+	if shared[0].LastProbeState != string(RefreshSuccess) || shared[0].PlanType != "team" || len(shared[0].Quotas) != 1 {
+		t.Fatalf("legacy reload failure blocked shared status: %+v", shared[0])
+	}
 }
 
 func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
@@ -800,6 +814,40 @@ func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	resetAt := checked.Add(48 * time.Hour)
+	cycleStart := resetAt.Add(-7 * 24 * time.Hour)
+	if err := usage.RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []usage.QuotaSnapshotPoint{{
+		RecordedAt: checked, Provider: "codex", QuotaKey: "code_week", QuotaLabel: "Week",
+		Percent: &pct, ResetAt: &resetAt, WindowSeconds: 604800,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	admin, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+	if _, err := admin.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets
+			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
+		VALUES (?, 'cycle', ?, 1, 1, 0, 1, ?, ?)
+	`, identity.ID, cycleStart.Format(time.RFC3339Nano), cycleStart.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec(`
+		INSERT INTO auth_subject_usage_daily
+			(tenant_id, auth_subject_id, day_key, request_count, success_count, failure_count, cost_total, updated_at)
+		VALUES (?, ?, ?, 9, 9, 0, 9, ?)
+	`, authA.TenantID, identity.ID, cycleStart.Format("2006-01-02"), checked.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec(`
+		INSERT INTO auth_subject_quota_cycles
+			(tenant_id, subject_id, auth_index, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, ?, ?, 'codex', 'code_week', ?, ?, 604800, ?)
+	`, authA.TenantID, identity.ID, authA.EnsureIndex(), cycleStart.Format(time.RFC3339Nano), resetAt.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
 
 	// Mounting the same physical account in tenant B repairs only B's missing binding,
 	// then immediately reads the already-populated shared subject snapshot.
@@ -817,6 +865,9 @@ func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
 	}
 	if item.CurrentTenantBindingCount != 1 || item.AuthIndex != authB.EnsureIndex() {
 		t.Fatalf("tenant B binding projection=%+v", item)
+	}
+	if !item.Usage.CycleKnown || item.Usage.CycleRequestTotal != 1 {
+		t.Fatalf("binding repair changed shared cycle usage: %+v", item.Usage)
 	}
 }
 

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -47,12 +47,14 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	// Live discovery models are appended AFTER CanServe filtering because they
 	// are intentionally not RegisterClient-written into the runtime registry.
 	ownerMappings := s.authGroupOwnerMappingMap()
+	managementAuthoritativeModelKeys := s.managementAuthoritativeModelKeys()
 	baseModels := dropStaticDiscoveryProviderModels(
 		managementVisibleModels(modelRegistry),
 		modelRegistry,
 		discoveryByProvider,
 		authByID,
 		ownerMappings,
+		managementAuthoritativeModelKeys,
 	)
 	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw, filterOpts)
 	usesMappedOwners := false
@@ -66,7 +68,7 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 	}
 	// Mapped-owner config rows can re-introduce the full openai/anthropic library;
 	// drop stale rows again, then append the live discovery list.
-	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings)
+	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings, managementAuthoritativeModelKeys)
 	// Live discovery models skip CanServe (not registry-backed). Still honor the
 	// tenant channel-group allowed-models list so plaza/catalog match the editor,
 	// unless the channel-group editor asks for the full channel-servable set.
@@ -151,15 +153,17 @@ func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string, opts ...Av
 	authByID := s.authByID()
 	discoveryByProvider := s.sharedDiscoveryByProvider(false)
 	ownerMappings := s.authGroupOwnerMappingMap()
+	managementAuthoritativeModelKeys := s.managementAuthoritativeModelKeys()
 	baseModels := dropStaticDiscoveryProviderModels(
 		managementVisibleModels(modelRegistry),
 		modelRegistry,
 		discoveryByProvider,
 		authByID,
 		ownerMappings,
+		managementAuthoritativeModelKeys,
 	)
 	allModels := s.effectiveModels(baseModels, allowedChannelsRaw, allowedGroupsRaw, filterOpts)
-	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings)
+	allModels = dropStaticDiscoveryProviderModels(allModels, modelRegistry, discoveryByProvider, authByID, ownerMappings, managementAuthoritativeModelKeys)
 	allModels = appendSharedDiscoveryModels(allModels, discoveryByProvider)
 	if !filterOpts.IgnoreGroupAllowedModels {
 		allModels = s.filterModelsByRoutingAllowedModels(allModels, allowedGroupsRaw)
@@ -273,13 +277,15 @@ func discoveryModelIDSet(discoveryByProvider map[string][]*registry.ModelInfo) m
 //     from those providers, when the model is not on the live list and has no
 //     non-discovery runtime source (e.g. opencode-go).
 //
-// Models still served by other providers are kept.
+// Models still served by other providers are kept. Enabled owner-mapped config
+// rows are authoritative; manifest absence is not negative availability evidence.
 func dropStaticDiscoveryProviderModels(
 	models []map[string]any,
 	modelRegistry *registry.ModelRegistry,
 	discoveryByProvider map[string][]*registry.ModelInfo,
 	authByID map[string]*coreauth.Auth,
 	ownerMappings map[string]string,
+	managementAuthoritativeModelKeys map[string]bool,
 ) []map[string]any {
 	liveProviders := liveDiscoveryProviders(discoveryByProvider)
 	if len(liveProviders) == 0 {
@@ -294,7 +300,8 @@ func dropStaticDiscoveryProviderModels(
 		if key == "" {
 			continue
 		}
-		if _, onLive := discoveryIDs[key]; onLive {
+		_, onLive := discoveryIDs[key]
+		if onLive || managementAuthoritativeModelKeys[key] {
 			out = append(out, model)
 			continue
 		}

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -2,7 +2,9 @@ package modelcatalog
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
@@ -10,6 +12,15 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
+
+func initModelCatalogTestDB(t *testing.T) {
+	t.Helper()
+	usage.CloseDB()
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+}
 
 func TestConfiguredAvailabilityIncludesModelSources(t *testing.T) {
 	const modelID = "source-test-model"
@@ -415,6 +426,102 @@ func TestConfiguredAvailabilityReplacesStaticCodexWithDiscovery(t *testing.T) {
 	}
 }
 
+func TestMappedOwnerConfigKeepsModelMissingFromCodexDiscovery(t *testing.T) {
+	const (
+		imageModelID     = "gpt-image-2"
+		liveModelID      = "gpt-5.6-sol"
+		staleChatModelID = "gpt-static-chat-only"
+		codexClientID    = "mapped-owner-keep-codex"
+		groupName        = "codex-editor"
+	)
+
+	initModelCatalogTestDB(t)
+	managementauthfiles.ResetDiscoveryCacheForTest()
+	t.Cleanup(managementauthfiles.ResetDiscoveryCacheForTest)
+
+	imageConfig, ok := usage.GetModelConfig(imageModelID)
+	if !ok {
+		t.Fatalf("seed config missing %q", imageModelID)
+	}
+	imageConfig.OwnedBy = "codex"
+	imageConfig.Enabled = true
+	if err := usage.UpsertModelConfig(imageConfig); err != nil {
+		t.Fatalf("upsert image config: %v", err)
+	}
+	if err := usage.UpsertAuthGroupOwnerMapping(usage.AuthGroupOwnerMappingRow{
+		AuthGroup: "codex",
+		Owner:     "codex",
+	}); err != nil {
+		t.Fatalf("upsert codex owner mapping: %v", err)
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(codexClientID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(codexClientID) })
+	modelRegistry.RegisterClient(codexClientID, "codex", []*registry.ModelInfo{
+		{ID: imageModelID, Object: "model", OwnedBy: "openai"},
+		{ID: liveModelID, Object: "model", OwnedBy: "openai"},
+		{ID: staleChatModelID, Object: "model", OwnedBy: "openai"},
+	})
+	managementauthfiles.StoreDiscoveryCacheForTest("", "codex", []*registry.ModelInfo{
+		{ID: liveModelID, Object: "model", OwnedBy: "openai"},
+	})
+
+	cfg := &config.Config{Routing: config.RoutingConfig{
+		ChannelGroups: []config.RoutingChannelGroup{{
+			Name:          groupName,
+			AllowedModels: []string{liveModelID},
+			Match: config.ChannelGroupMatch{
+				Channels: []string{"codex"},
+			},
+		}},
+	}}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: codexClientID, Provider: "codex", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register codex auth: %v", err)
+	}
+
+	svc := New(cfg, manager)
+	availabilityIDs := configuredAvailabilityIDs(svc.ConfiguredAvailability("", ""))
+	if !containsModelID(availabilityIDs, imageModelID) {
+		t.Fatalf("configured availability missing management-authoritative model %q", imageModelID)
+	}
+	if containsModelID(availabilityIDs, staleChatModelID) {
+		t.Fatalf("configured availability kept static-only chat model %q; ids=%v", staleChatModelID, availabilityIDs)
+	}
+
+	modelIDs := configuredAvailabilityIDs(svc.Models("", groupName, AvailabilityFilterOptions{IgnoreGroupAllowedModels: true}))
+	if !containsModelID(modelIDs, imageModelID) {
+		t.Fatalf("scoped models with ignore missing management-authoritative model %q; ids=%v", imageModelID, modelIDs)
+	}
+	if containsModelID(modelIDs, staleChatModelID) {
+		t.Fatalf("scoped models with ignore kept static-only chat model %q; ids=%v", staleChatModelID, modelIDs)
+	}
+
+	pathRows, ok := svc.PathAvailability()["data"].([]modelPathAvailabilityResponse)
+	if !ok {
+		t.Fatalf("path availability data has unexpected type")
+	}
+	for _, row := range pathRows {
+		if row.ID == staleChatModelID {
+			t.Fatalf("path availability kept static-only chat model %q", staleChatModelID)
+		}
+		if row.ID != imageModelID {
+			continue
+		}
+		for _, path := range row.Paths {
+			if path.Family == "openai-v1-images" {
+				return
+			}
+		}
+		t.Fatalf("path availability model %q missing image capability: %#v", imageModelID, row.Paths)
+	}
+	t.Fatalf("path availability missing management-authoritative model %q", imageModelID)
+}
+
 func TestDropStaticDiscoveryProviderModelsDropsMappedOwnerLibrary(t *testing.T) {
 	const (
 		staleLibraryID = "gpt-5-stale-library"
@@ -450,6 +557,7 @@ func TestDropStaticDiscoveryProviderModelsDropsMappedOwnerLibrary(t *testing.T) 
 			codexClientID: {ID: codexClientID, Provider: "codex", Status: coreauth.StatusActive},
 		},
 		map[string]string{"codex": "openai"},
+		nil,
 	)
 	ids := make(map[string]struct{}, len(got))
 	for _, m := range got {
@@ -663,4 +771,13 @@ func configuredAvailabilityIDs(result map[string]any) []string {
 		}
 	}
 	return out
+}
+
+func containsModelID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/management/modelcatalog/discovery_authority.go
+++ b/internal/management/modelcatalog/discovery_authority.go
@@ -1,0 +1,9 @@
+package modelcatalog
+
+func (s *Service) managementAuthoritativeModelKeys() map[string]bool {
+	rows, ownerKeys, _, ok := s.defaultMappedOwnerRows()
+	if !ok {
+		return nil
+	}
+	return mappedOwnerRowModelKeys(rows, ownerKeys)
+}

--- a/internal/management/modelcatalog/path_availability.go
+++ b/internal/management/modelcatalog/path_availability.go
@@ -26,12 +26,14 @@ func (s *Service) PathAvailability() map[string]any {
 	rootGeminiCapabilities := geminiV1BetaCapabilities("/")
 	authByID := s.authByID()
 	discoveryByProvider := s.sharedDiscoveryByProvider(false)
+	managementAuthoritativeModelKeys := s.managementAuthoritativeModelKeys()
 	openaiModels := dropStaticDiscoveryProviderModels(
 		modelRegistry.GetAvailableModels("openai"),
 		modelRegistry,
 		discoveryByProvider,
 		authByID,
 		s.authGroupOwnerMappingMap(),
+		managementAuthoritativeModelKeys,
 	)
 	openaiModels = s.modelRootRouteScopedModels(openaiModels, routingConfig)
 	// Live discovery is not registry-backed, so CanServe cannot enforce

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -1,25 +1,29 @@
 package apikey
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 var (
-	ErrInvalidProfileID          = errors.New("id is required")
-	ErrInvalidProfileName        = errors.New("name is required")
-	ErrMissingValue              = errors.New("missing value")
-	ErrInvalidEntry              = errors.New("invalid api key entry")
-	ErrItemNotFound              = errors.New("item not found")
-	ErrDuplicateKey              = errors.New("api key already exists")
-	ErrMissingKeyOrIndex         = errors.New("missing key or index")
-	ErrKeyRequired               = errors.New("key is required")
-	ErrDailySpendingLimitMissing = errors.New("daily spending limit is not set")
+	ErrInvalidProfileID            = errors.New("id is required")
+	ErrInvalidProfileName          = errors.New("name is required")
+	ErrMissingValue                = errors.New("missing value")
+	ErrInvalidEntry                = errors.New("invalid api key entry")
+	ErrItemNotFound                = errors.New("item not found")
+	ErrDuplicateKey                = errors.New("api key already exists")
+	ErrMissingKeyOrIndex           = errors.New("missing key or index")
+	ErrKeyRequired                 = errors.New("key is required")
+	ErrDailySpendingLimitMissing   = errors.New("daily spending limit is not set")
+	ErrOwnedKeyAccountManagedField = errors.New("owned key account-managed field cannot be changed")
 )
 
 type ChannelSanitizer func([]string) ([]string, error)
@@ -37,22 +41,23 @@ type Service struct {
 }
 
 type EntryPatch struct {
-	Key                  *string   `json:"key"`
-	Name                 *string   `json:"name"`
-	Disabled             *bool     `json:"disabled"`
-	PermissionProfileID  *string   `json:"permission-profile-id"`
-	DailyLimit           *int      `json:"daily-limit"`
-	TotalQuota           *int      `json:"total-quota"`
-	SpendingLimit        *float64  `json:"spending-limit"`
-	DailySpendingLimit   *float64  `json:"daily-spending-limit"`
-	ConcurrencyLimit     *int      `json:"concurrency-limit"`
-	RPMLimit             *int      `json:"rpm-limit"`
-	TPMLimit             *int      `json:"tpm-limit"`
-	AllowedModels        *[]string `json:"allowed-models"`
-	AllowedChannels      *[]string `json:"allowed-channels"`
-	AllowedChannelGroups *[]string `json:"allowed-channel-groups"`
-	SystemPrompt         *string   `json:"system-prompt"`
-	CreatedAt            *string   `json:"created-at"`
+	Key                  *string                          `json:"key"`
+	Name                 *string                          `json:"name"`
+	Disabled             *bool                            `json:"disabled"`
+	PermissionProfileID  *string                          `json:"permission-profile-id"`
+	DailyLimit           *int                             `json:"daily-limit"`
+	TotalQuota           *int                             `json:"total-quota"`
+	SpendingLimit        *float64                         `json:"spending-limit"`
+	DailySpendingLimit   *float64                         `json:"daily-spending-limit"`
+	PeriodSpendingLimits *quota.PeriodSpendingLimitsPatch `json:"period-spending-limits"`
+	ConcurrencyLimit     *int                             `json:"concurrency-limit"`
+	RPMLimit             *int                             `json:"rpm-limit"`
+	TPMLimit             *int                             `json:"tpm-limit"`
+	AllowedModels        *[]string                        `json:"allowed-models"`
+	AllowedChannels      *[]string                        `json:"allowed-channels"`
+	AllowedChannelGroups *[]string                        `json:"allowed-channel-groups"`
+	SystemPrompt         *string                          `json:"system-prompt"`
+	CreatedAt            *string                          `json:"created-at"`
 	// end_user_id / is_default are intentionally not patchable here; ownership
 	// changes go through end-user owner-scoped APIs only.
 }
@@ -174,11 +179,16 @@ func (s *Service) ReplacePermissionProfiles(profiles []usage.APIKeyPermissionPro
 }
 
 func (s *Service) ReplacePermissionProfilesAndSyncAccounts(profiles []usage.APIKeyPermissionProfileRow) (int64, error) {
+	result, err := s.ReplacePermissionProfilesWithCaps(profiles, true)
+	return result.AppliedCount, err
+}
+
+func (s *Service) ReplacePermissionProfilesWithCaps(profiles []usage.APIKeyPermissionProfileRow, syncAccounts bool) (usage.APIKeyPermissionProfileSyncResult, error) {
 	normalized, err := s.normalizePermissionProfiles(profiles)
 	if err != nil {
-		return 0, err
+		return usage.APIKeyPermissionProfileSyncResult{}, err
 	}
-	return usage.ReplaceAllAPIKeyPermissionProfilesForTenantAndSyncEndUsers(s.tenantID, normalized)
+	return usage.ReplaceAllAPIKeyPermissionProfilesForTenantWithCaps(s.tenantID, normalized, syncAccounts)
 }
 
 func (s *Service) normalizePermissionProfiles(profiles []usage.APIKeyPermissionProfileRow) ([]usage.APIKeyPermissionProfileRow, error) {
@@ -193,6 +203,26 @@ func (s *Service) normalizePermissionProfiles(profiles []usage.APIKeyPermissionP
 		if normalized[idx].Name == "" {
 			return nil, ErrInvalidProfileName
 		}
+		limits, err := quota.NormalizeLimits(normalized[idx].PeriodSpendingLimits)
+		if err != nil {
+			return nil, err
+		}
+		day, err := quota.NormalizeWholeUSD(normalized[idx].DailySpendingLimit)
+		if err != nil {
+			return nil, err
+		}
+		if limits.Day > 0 && day > 0 && limits.Day != day {
+			return nil, quota.ErrPeriodDayLegacyConflict
+		}
+		if day == 0 {
+			day = limits.Day
+		}
+		limits.Day = day
+		if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+			return nil, enduser.ErrFiveHourProjectionWarming
+		}
+		normalized[idx].DailySpendingLimit = day
+		normalized[idx].PeriodSpendingLimits = limits
 		if s != nil && s.sanitizeChannels != nil {
 			cleaned, err := s.sanitizeChannels(normalized[idx].AllowedChannels)
 			if err != nil {
@@ -301,17 +331,13 @@ func (s *Service) attachDailySpendingRuntime(entries []config.APIKeyEntry, rows 
 	if len(entries) == 0 || len(rows) == 0 {
 		return nil
 	}
-	rawCosts, err := usage.QueryRawTodayCostsByKeysForTenant(s.tenantID, rows)
-	if err != nil {
-		return err
-	}
 	ids := make([]string, 0, len(rows))
 	for _, row := range rows {
 		if id := strings.TrimSpace(row.ID); id != "" {
 			ids = append(ids, id)
 		}
 	}
-	baselines, err := usage.ListDailySpendingResetBaselines(s.tenantID, ids)
+	usedByID, err := usage.QueryPeriodSpendingByAPIKeyIDsForTenant(s.tenantID, ids)
 	if err != nil {
 		return err
 	}
@@ -321,30 +347,13 @@ func (s *Service) attachDailySpendingRuntime(entries []config.APIKeyEntry, rows 
 	}
 	for i := range entries {
 		id := strings.TrimSpace(rows[i].ID)
-		key := strings.TrimSpace(rows[i].Key)
-		raw := 0.0
-		if id != "" {
-			if v, ok := rawCosts[id]; ok {
-				raw = v
-			} else if v, ok := rawCosts[key]; ok {
-				raw = v
-			}
-		} else if v, ok := rawCosts[key]; ok {
-			raw = v
-		}
-		baseline := 0.0
-		if id != "" {
-			baseline = baselines[id]
-		}
-		used := raw - baseline
-		if used < 0 {
-			used = 0
-		}
-		entries[i].DailySpendingUsed = used
-		entries[i].DailySpendingRemaining = usage.DailySpendingRemaining(entries[i].DailySpendingLimit, used)
-		if id != "" {
-			entries[i].DailySpendingResetCount = counts[id]
-		}
+		used := usedByID[id]
+		entries[i].PeriodSpendingLimits.Day = entries[i].DailySpendingLimit
+		entries[i].DailySpendingUsed = used.Day
+		entries[i].LifetimeSpendingUsed = used.Lifetime
+		entries[i].PeriodSpending = quota.BuildPeriodSpending(entries[i].PeriodSpendingLimits, used)
+		entries[i].DailySpendingRemaining = usage.DailySpendingRemaining(entries[i].DailySpendingLimit, used.Day)
+		entries[i].DailySpendingResetCount = counts[id]
 	}
 	return nil
 }
@@ -424,6 +433,24 @@ func (s *Service) ListDailySpendingResetHistory(id *string, match *string, limit
 func (s *Service) ReplaceEntries(entries []config.APIKeyEntry) error {
 	rows := make([]usage.APIKeyRow, 0, len(entries))
 	for _, entry := range entries {
+		existing := usage.GetAPIKeyByIDForTenant(s.tenantID, strings.TrimSpace(entry.ID))
+		if existing == nil {
+			existing = usage.GetAPIKeyForTenant(s.tenantID, strings.TrimSpace(entry.Key))
+		}
+		if existing != nil && strings.TrimSpace(existing.EndUserID) != "" {
+			if entry.PermissionProfileID != "" || entry.DailyLimit != 0 || entry.TotalQuota != 0 || entry.SpendingLimit != 0 ||
+				entry.ConcurrencyLimit != 0 || entry.RPMLimit != 0 || entry.TPMLimit != 0 || len(entry.AllowedModels) != 0 ||
+				len(entry.AllowedChannels) != 0 || len(entry.AllowedChannelGroups) != 0 || entry.SystemPrompt != "" {
+				return ErrOwnedKeyAccountManagedField
+			}
+			incoming := entry.PeriodSpendingLimits
+			incoming.Day = entry.DailySpendingLimit
+			if incoming != existing.PeriodSpendingLimits {
+				return fmt.Errorf("%w: update owned key period limits with PATCH", ErrInvalidEntry)
+			}
+			entry.EndUserID = existing.EndUserID
+			entry.IsDefault = existing.IsDefault
+		}
 		normalized, err := s.prepareEntryForSave(entry)
 		if err != nil {
 			return err
@@ -439,6 +466,16 @@ func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryP
 		return ErrItemNotFound
 	}
 	entry := *existing
+	owned := strings.TrimSpace(existing.EndUserID) != ""
+	if owned && (patch.PermissionProfileID != nil || patch.DailyLimit != nil || patch.TotalQuota != nil ||
+		patch.SpendingLimit != nil || patch.ConcurrencyLimit != nil || patch.RPMLimit != nil || patch.TPMLimit != nil ||
+		patch.AllowedModels != nil || patch.AllowedChannels != nil || patch.AllowedChannelGroups != nil || patch.SystemPrompt != nil) {
+		return ErrOwnedKeyAccountManagedField
+	}
+	periodPatch, err := quota.ResolveLegacyDay(patch.DailySpendingLimit, patch.PeriodSpendingLimits)
+	if err != nil {
+		return err
+	}
 	originalKey := strings.TrimSpace(entry.Key)
 	originalID := strings.TrimSpace(entry.ID)
 
@@ -467,8 +504,9 @@ func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryP
 	if patch.SpendingLimit != nil {
 		entry.SpendingLimit = *patch.SpendingLimit
 	}
-	if patch.DailySpendingLimit != nil {
-		entry.DailySpendingLimit = *patch.DailySpendingLimit
+	if periodPatch != nil {
+		entry.PeriodSpendingLimits = quota.ApplyPatch(entry.PeriodSpendingLimits, periodPatch)
+		entry.DailySpendingLimit = entry.PeriodSpendingLimits.Day
 	}
 	if patch.ConcurrencyLimit != nil {
 		entry.ConcurrencyLimit = *patch.ConcurrencyLimit
@@ -493,6 +531,23 @@ func (s *Service) PatchEntry(id *string, index *int, match *string, patch EntryP
 	}
 	if patch.CreatedAt != nil {
 		entry.CreatedAt = strings.TrimSpace(*patch.CreatedAt)
+	}
+
+	if owned && (patch.Name != nil || periodPatch != nil) {
+		if patch.Key != nil || patch.Disabled != nil || patch.CreatedAt != nil {
+			return fmt.Errorf("%w: update owned key name/period separately from key state", ErrInvalidEntry)
+		}
+		svc := enduser.Default()
+		if svc == nil && usage.RuntimeDB() != nil {
+			svc = enduser.NewService(usage.RuntimeDB())
+		}
+		if svc == nil {
+			return fmt.Errorf("%w: end user service unavailable", ErrInvalidEntry)
+		}
+		if err := svc.UpdateKey(context.Background(), s.tenantID, existing.EndUserID, existing.ID, patch.Name, periodPatch); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	normalized, err := s.prepareEntryForSave(entry.ToConfigEntry())
@@ -543,6 +598,26 @@ func (s *Service) prepareEntryForSave(entry config.APIKeyEntry) (config.APIKeyEn
 	entry.PermissionProfileID = strings.TrimSpace(entry.PermissionProfileID)
 	entry.SystemPrompt = strings.TrimSpace(entry.SystemPrompt)
 	entry.CreatedAt = strings.TrimSpace(entry.CreatedAt)
+	limits, err := quota.NormalizeLimits(entry.PeriodSpendingLimits)
+	if err != nil {
+		return config.APIKeyEntry{}, err
+	}
+	day, err := quota.NormalizeWholeUSD(entry.DailySpendingLimit)
+	if err != nil {
+		return config.APIKeyEntry{}, err
+	}
+	if limits.Day > 0 && day > 0 && limits.Day != day {
+		return config.APIKeyEntry{}, quota.ErrPeriodDayLegacyConflict
+	}
+	if day == 0 {
+		day = limits.Day
+	}
+	limits.Day = day
+	if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
+		return config.APIKeyEntry{}, enduser.ErrFiveHourProjectionWarming
+	}
+	entry.DailySpendingLimit = day
+	entry.PeriodSpendingLimits = limits
 	entry.AllowedChannelGroups = normalizeChannelGroups(entry.AllowedChannelGroups)
 
 	if s != nil && s.sanitizeChannels != nil {

--- a/internal/management/settings/apikey/service_test.go
+++ b/internal/management/settings/apikey/service_test.go
@@ -521,6 +521,7 @@ func TestEffectiveRowAppliesProfileDailySpendingLimit(t *testing.T) {
 		ID:                  "key-1",
 		Key:                 "sk-profile",
 		PermissionProfileID: "p1",
+		SpendingLimit:       77,
 		DailySpendingLimit:  1, // stale key copy; profile wins
 	}); err != nil {
 		t.Fatalf("upsert: %v", err)

--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -9,10 +9,11 @@ func (s *Service) PublicChartData(apiKey string, days int) (map[string]any, erro
 	}
 
 	return map[string]any{
-		"daily_series":       chartData.DailySeries,
-		"heatmap_series":     chartData.HeatmapSeries,
-		"model_distribution": chartData.ModelDistribution,
-		"stats":              chartData.Stats,
+		"daily_series":         chartData.DailySeries,
+		"heatmap_series":       chartData.HeatmapSeries,
+		"model_distribution":   chartData.ModelDistribution,
+		"api_key_distribution": chartData.APIKeyDistribution,
+		"stats":                chartData.Stats,
 		// Key own name only — never end-user display name.
 		"api_key_name": s.publicAPIKeyName(apiKey),
 	}, nil
@@ -25,11 +26,12 @@ func (s *Service) PublicChartDataForEndUser(endUserID string, days int) (map[str
 	}
 
 	return map[string]any{
-		"daily_series":       chartData.DailySeries,
-		"heatmap_series":     chartData.HeatmapSeries,
-		"model_distribution": chartData.ModelDistribution,
-		"stats":              chartData.Stats,
-		"api_key_name":       usage.DisplayNameForEndUser(endUserID),
+		"daily_series":         chartData.DailySeries,
+		"heatmap_series":       chartData.HeatmapSeries,
+		"model_distribution":   chartData.ModelDistribution,
+		"api_key_distribution": chartData.APIKeyDistribution,
+		"stats":                chartData.Stats,
+		"api_key_name":         usage.DisplayNameForEndUser(endUserID),
 	}, nil
 }
 

--- a/internal/management/usagelogs/chart.go
+++ b/internal/management/usagelogs/chart.go
@@ -13,7 +13,8 @@ func (s *Service) PublicChartData(apiKey string, days int) (map[string]any, erro
 		"heatmap_series":     chartData.HeatmapSeries,
 		"model_distribution": chartData.ModelDistribution,
 		"stats":              chartData.Stats,
-		"api_key_name":       s.publicAPIKeyName(apiKey),
+		// Key own name only — never end-user display name.
+		"api_key_name": s.publicAPIKeyName(apiKey),
 	}, nil
 }
 

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -212,8 +212,18 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		filters.APIKeyIDCounts,
 	)
 
-	apiKeyName := s.publicAPIKeyName(input.APIKey)
-	if params.EndUserID != "" {
+	// Top-level api_key_name:
+	// - raw secret lookup (/apikey-usage): always the *presented key's own name*
+	// - portal session (no raw key, EndUserID only): account display name
+	// Never label a secret lookup with end-user display name (e.g. 张军宝).
+	presentedKey := strings.TrimSpace(input.APIKey)
+	apiKeyName := ""
+	if presentedKey != "" {
+		apiKeyName = usage.ResolveAPIKeyOwnName(presentedKey)
+		if apiKeyName == "" {
+			apiKeyName = s.publicAPIKeyName(presentedKey)
+		}
+	} else if params.EndUserID != "" {
 		apiKeyName = usage.DisplayNameForEndUser(params.EndUserID)
 	}
 	for i := range result.Items {
@@ -226,14 +236,12 @@ func (s *Service) PublicUsageLogs(input PublicLogQueryInput) (map[string]any, er
 		}
 		userName := strings.TrimSpace(result.Items[i].EndUserDisplayName)
 		if userName == "" && params.EndUserID != "" {
-			userName = apiKeyName
+			userName = usage.DisplayNameForEndUser(params.EndUserID)
 		}
 		if userName == "" {
 			userName = keyOwnName
 		}
-		if apiKeyName == "" {
-			apiKeyName = userName
-		}
+		// Do not overwrite top-level apiKeyName with per-row user/key labels.
 		channelName := displayChannelNameForLog(result.Items[i], maps.channelNameMap, maps.authIndexChannelMap, maps.ambiguousAuthIndexChannelMap)
 		result.Items[i].APIKeyMasked = maskPublicAPIKey(result.Items[i].APIKey)
 		result.Items[i].Source = ""
@@ -854,6 +862,11 @@ func normalizeAuthType(value string) string {
 }
 
 func (s *Service) publicAPIKeyName(apiKey string) string {
+	// Prefer any-tenant resolve first: public lookup already authenticated the secret,
+	// and tenant-scoped GetRow can miss when service tenant is empty/stale in tests.
+	if name := usage.ResolveAPIKeyOwnName(apiKey); name != "" {
+		return name
+	}
 	row := apikeysettings.NewService(nil, apikeysettings.WithTenantID(s.tenantID)).GetRow(apiKey)
 	if row == nil {
 		return ""

--- a/internal/quota/period.go
+++ b/internal/quota/period.go
@@ -1,0 +1,218 @@
+package quota
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+type Period string
+
+const (
+	PeriodFiveHour Period = "5h"
+	PeriodDay      Period = "day"
+	PeriodWeek     Period = "week"
+	PeriodMonth    Period = "month"
+)
+
+var OrderedPeriods = [...]Period{PeriodFiveHour, PeriodDay, PeriodWeek, PeriodMonth}
+
+var (
+	ErrInvalidSpendingLimit    = errors.New("invalid spending limit")
+	ErrPeriodDayLegacyConflict = errors.New("period day legacy conflict")
+)
+
+type PeriodSpendingLimits struct {
+	FiveHour float64 `json:"5h" yaml:"5h"`
+	Day      float64 `json:"day" yaml:"day"`
+	Week     float64 `json:"week" yaml:"week"`
+	Month    float64 `json:"month" yaml:"month"`
+}
+
+type PeriodSpendingLimitsPatch struct {
+	FiveHour *float64 `json:"5h"`
+	Day      *float64 `json:"day"`
+	Week     *float64 `json:"week"`
+	Month    *float64 `json:"month"`
+}
+
+type CappedKey struct {
+	ID     string  `json:"id"`
+	Period Period  `json:"period"`
+	From   float64 `json:"from"`
+	To     float64 `json:"to"`
+}
+
+type LimitExceedsAccountError struct {
+	Period       Period
+	KeyLimit     float64
+	AccountLimit float64
+}
+
+func (e *LimitExceedsAccountError) Error() string {
+	return fmt.Sprintf("Key %s quota $%.0f exceeds account %s quota $%.0f", e.Period, e.KeyLimit, e.Period, e.AccountLimit)
+}
+
+func ValidateKeyWithinAccount(keyLimits, accountLimits PeriodSpendingLimits) error {
+	for _, period := range OrderedPeriods {
+		keyLimit := keyLimits.Value(period)
+		accountLimit := accountLimits.Value(period)
+		if keyLimit > 0 && accountLimit > 0 && keyLimit > accountLimit {
+			return &LimitExceedsAccountError{Period: period, KeyLimit: keyLimit, AccountLimit: accountLimit}
+		}
+	}
+	return nil
+}
+
+type PeriodSpending struct {
+	Period    Period  `json:"period"`
+	Limit     float64 `json:"limit"`
+	Used      float64 `json:"used"`
+	Remaining float64 `json:"remaining"`
+}
+
+type PeriodSpendingUsage struct {
+	FiveHour float64
+	Day      float64
+	Week     float64
+	Month    float64
+	Lifetime float64
+}
+
+func NormalizeWholeUSD(value float64) (float64, error) {
+	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("%w: value must be a finite non-negative number", ErrInvalidSpendingLimit)
+	}
+	if value == 0 {
+		return 0, nil
+	}
+	return math.Ceil(value), nil
+}
+
+func NormalizeLimits(limits PeriodSpendingLimits) (PeriodSpendingLimits, error) {
+	var err error
+	if limits.FiveHour, err = NormalizeWholeUSD(limits.FiveHour); err != nil {
+		return PeriodSpendingLimits{}, fmt.Errorf("5h: %w", err)
+	}
+	if limits.Day, err = NormalizeWholeUSD(limits.Day); err != nil {
+		return PeriodSpendingLimits{}, fmt.Errorf("day: %w", err)
+	}
+	if limits.Week, err = NormalizeWholeUSD(limits.Week); err != nil {
+		return PeriodSpendingLimits{}, fmt.Errorf("week: %w", err)
+	}
+	if limits.Month, err = NormalizeWholeUSD(limits.Month); err != nil {
+		return PeriodSpendingLimits{}, fmt.Errorf("month: %w", err)
+	}
+	return limits, nil
+}
+
+func NormalizePatch(patch *PeriodSpendingLimitsPatch) (*PeriodSpendingLimitsPatch, error) {
+	if patch == nil {
+		return nil, nil
+	}
+	out := *patch
+	for period, ptr := range map[Period]**float64{
+		PeriodFiveHour: &out.FiveHour,
+		PeriodDay:      &out.Day,
+		PeriodWeek:     &out.Week,
+		PeriodMonth:    &out.Month,
+	} {
+		if *ptr == nil {
+			continue
+		}
+		value, err := NormalizeWholeUSD(**ptr)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", period, err)
+		}
+		*ptr = &value
+	}
+	return &out, nil
+}
+
+func ResolveLegacyDay(legacy *float64, patch *PeriodSpendingLimitsPatch) (*PeriodSpendingLimitsPatch, error) {
+	normalized, err := NormalizePatch(patch)
+	if err != nil {
+		return nil, err
+	}
+	if legacy == nil {
+		return normalized, nil
+	}
+	day, err := NormalizeWholeUSD(*legacy)
+	if err != nil {
+		return nil, fmt.Errorf("day: %w", err)
+	}
+	if normalized == nil {
+		normalized = &PeriodSpendingLimitsPatch{}
+	}
+	if normalized.Day != nil && *normalized.Day != day {
+		return nil, ErrPeriodDayLegacyConflict
+	}
+	normalized.Day = &day
+	return normalized, nil
+}
+
+func ApplyPatch(current PeriodSpendingLimits, patch *PeriodSpendingLimitsPatch) PeriodSpendingLimits {
+	if patch == nil {
+		return current
+	}
+	if patch.FiveHour != nil {
+		current.FiveHour = *patch.FiveHour
+	}
+	if patch.Day != nil {
+		current.Day = *patch.Day
+	}
+	if patch.Week != nil {
+		current.Week = *patch.Week
+	}
+	if patch.Month != nil {
+		current.Month = *patch.Month
+	}
+	return current
+}
+
+func (l PeriodSpendingLimits) Value(period Period) float64 {
+	switch period {
+	case PeriodFiveHour:
+		return l.FiveHour
+	case PeriodDay:
+		return l.Day
+	case PeriodWeek:
+		return l.Week
+	case PeriodMonth:
+		return l.Month
+	default:
+		return 0
+	}
+}
+
+func (u PeriodSpendingUsage) Value(period Period) float64 {
+	switch period {
+	case PeriodFiveHour:
+		return u.FiveHour
+	case PeriodDay:
+		return u.Day
+	case PeriodWeek:
+		return u.Week
+	case PeriodMonth:
+		return u.Month
+	default:
+		return 0
+	}
+}
+
+func BuildPeriodSpending(limits PeriodSpendingLimits, used PeriodSpendingUsage) []PeriodSpending {
+	out := make([]PeriodSpending, 0, len(OrderedPeriods))
+	for _, period := range OrderedPeriods {
+		limit := limits.Value(period)
+		if limit <= 0 {
+			continue
+		}
+		current := used.Value(period)
+		remaining := limit - current
+		if remaining < 0 {
+			remaining = 0
+		}
+		out = append(out, PeriodSpending{Period: period, Limit: limit, Used: current, Remaining: remaining})
+	}
+	return out
+}

--- a/internal/quota/period_test.go
+++ b/internal/quota/period_test.go
@@ -1,0 +1,31 @@
+package quota
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestResolveLegacyDayCompatibilityAndConflict(t *testing.T) {
+	legacy := 10.1
+	day := 11.0
+	patch, err := ResolveLegacyDay(&legacy, &PeriodSpendingLimitsPatch{Day: &day})
+	if err != nil || patch == nil || patch.Day == nil || *patch.Day != 11 {
+		t.Fatalf("same normalized day = %#v, err=%v", patch, err)
+	}
+	conflict := 12.0
+	if _, err := ResolveLegacyDay(&legacy, &PeriodSpendingLimitsPatch{Day: &conflict}); !errors.Is(err, ErrPeriodDayLegacyConflict) {
+		t.Fatalf("conflict err = %v, want ErrPeriodDayLegacyConflict", err)
+	}
+}
+
+func TestNormalizeWholeUSDRejectsInvalidAndCeilsPositive(t *testing.T) {
+	for _, value := range []float64{-1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		if _, err := NormalizeWholeUSD(value); !errors.Is(err, ErrInvalidSpendingLimit) {
+			t.Fatalf("NormalizeWholeUSD(%v) err=%v, want invalid", value, err)
+		}
+	}
+	if got, err := NormalizeWholeUSD(10.01); err != nil || got != 11 {
+		t.Fatalf("NormalizeWholeUSD = %v, %v; want 11,nil", got, err)
+	}
+}

--- a/internal/runtime/executor/xai_quota_recovery.go
+++ b/internal/runtime/executor/xai_quota_recovery.go
@@ -1,0 +1,107 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// ProbeQuotaRecovery checks Grok Build's weekly billing view without consuming a
+// user inference request.
+func (e *XAIExecutor) ProbeQuotaRecovery(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.QuotaProbeResult, error) {
+	if auth == nil {
+		return nil, fmt.Errorf("xai executor: auth is nil")
+	}
+	if xaiUsingAPI(auth) {
+		return nil, fmt.Errorf("xai executor: quota recovery probe requires Grok Build OAuth")
+	}
+	token, _ := xaiCreds(auth)
+	if token == "" {
+		return nil, fmt.Errorf("xai executor: missing access token")
+	}
+
+	endpoint := strings.TrimRight(xaiChatBaseURL(auth), "/") + xaiauth.BillingWeeklyPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	applyXAIChatHeaders(req, e.cfg, auth, token, false)
+	if userID := xaiQuotaProbeUserID(auth); userID != "" {
+		req.Header.Set("X-UserID", userID)
+	}
+
+	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("xai executor: close quota probe body error: %v", errClose)
+		}
+	}()
+
+	body, err := readUpstreamResponseBody(e.Identifier(), resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, newXAIStatusErr(resp.StatusCode, body, resp.Header)
+	}
+	result := parseXAIQuotaProbe(body, time.Now())
+	if result == nil {
+		return nil, fmt.Errorf("xai executor: invalid weekly billing response")
+	}
+	return result, nil
+}
+
+func parseXAIQuotaProbe(body []byte, now time.Time) *cliproxyauth.QuotaProbeResult {
+	weekly, ok := xaiauth.ParseWeeklyBilling(body)
+	if !ok {
+		return nil
+	}
+	if weekly.RemainingPercent > 0 {
+		return &cliproxyauth.QuotaProbeResult{Recovered: true}
+	}
+	result := &cliproxyauth.QuotaProbeResult{Recovered: false}
+	if weekly.ResetAt.After(now) {
+		result.NextRecoverAt = weekly.ResetAt
+	}
+	return result
+}
+
+func xaiQuotaProbeUserID(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	for _, key := range []string{"sub", "subject", "user_id", "userId", "x_userid"} {
+		if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+			return value
+		}
+		if value := xaiMetadataString(auth.Metadata, key); value != "" {
+			return value
+		}
+	}
+	for _, parent := range []string{"oauth", "user"} {
+		raw, ok := auth.Metadata[parent]
+		if !ok {
+			continue
+		}
+		nested, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"sub", "subject", "id", "user_id", "userId"} {
+			if value := xaiMetadataString(nested, key); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}

--- a/internal/runtime/executor/xai_quota_recovery_test.go
+++ b/internal/runtime/executor/xai_quota_recovery_test.go
@@ -1,0 +1,107 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestXAIExecutorProbeQuotaRecovery(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Now().Add(2 * time.Hour).UTC().Round(time.Second)
+	tests := []struct {
+		name            string
+		usedPercent     int
+		wantRecovered   bool
+		wantNextRecover bool
+	}{
+		{name: "recovered", usedPercent: 40, wantRecovered: true},
+		{name: "not recovered", usedPercent: 100, wantRecovered: false, wantNextRecover: true},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				if r.Method != http.MethodGet {
+					t.Fatalf("method = %s, want GET", r.Method)
+				}
+				if r.URL.String() != "https://cli-chat-proxy.grok.com/v1/billing?format=credits" {
+					t.Fatalf("url = %s, want Grok weekly billing endpoint", r.URL.String())
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer xai-token" {
+					t.Fatalf("Authorization = %q", got)
+				}
+				if got := r.Header.Get(xaiTokenAuthHeader); got != xaiTokenAuthValue {
+					t.Fatalf("%s = %q", xaiTokenAuthHeader, got)
+				}
+				if got := r.Header.Get("X-UserID"); got != "xai-user" {
+					t.Fatalf("X-UserID = %q, want xai-user", got)
+				}
+				body := fmt.Sprintf(`{"config":{"currentPeriod":{"type":"WEEKLY","end":%q},"creditUsagePercent":%d}}`, resetAt.Format(time.RFC3339), test.usedPercent)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Request:    r,
+				}, nil
+			}))
+
+			auth := &cliproxyauth.Auth{
+				ID:       "xai-auth",
+				Provider: "xai",
+				Status:   cliproxyauth.StatusActive,
+				Attributes: map[string]string{
+					"api_key":   "xai-token",
+					"using_api": "false",
+					"sub":       "xai-user",
+				},
+			}
+
+			result, err := NewXAIExecutor(nil).ProbeQuotaRecovery(ctx, auth)
+			if err != nil {
+				t.Fatalf("ProbeQuotaRecovery() error = %v", err)
+			}
+			if result == nil {
+				t.Fatal("ProbeQuotaRecovery() result = nil")
+			}
+			if result.Recovered != test.wantRecovered {
+				t.Fatalf("Recovered = %v, want %v", result.Recovered, test.wantRecovered)
+			}
+			if test.wantNextRecover {
+				if !result.NextRecoverAt.Equal(resetAt) {
+					t.Fatalf("NextRecoverAt = %v, want %v", result.NextRecoverAt, resetAt)
+				}
+			} else if !result.NextRecoverAt.IsZero() {
+				t.Fatalf("NextRecoverAt = %v, want zero", result.NextRecoverAt)
+			}
+		})
+	}
+}
+
+func TestParseXAIQuotaProbeExhaustedWithoutResetStaysBlocked(t *testing.T) {
+	t.Parallel()
+
+	result := parseXAIQuotaProbe([]byte(`{"config":{"currentPeriod":{"type":"WEEKLY"},"creditUsagePercent":100}}`), time.Now())
+	if result == nil {
+		t.Fatal("parseXAIQuotaProbe() result = nil")
+	}
+	if result.Recovered {
+		t.Fatal("Recovered = true, want false")
+	}
+	if !result.NextRecoverAt.IsZero() {
+		t.Fatalf("NextRecoverAt = %v, want zero without upstream reset", result.NextRecoverAt)
+	}
+}
+
+var _ cliproxyauth.QuotaRecoveryProber = (*XAIExecutor)(nil)

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -35,8 +35,25 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607200002_ai_account_shared_subjects", SQL: aiAccountSharedSubjectsSQL},
 		// Append-only history of manual account-level daily spending resets.
 		{Version: "202607210001_end_user_daily_spending_reset_events", SQL: endUserDailySpendingResetEventsSQL},
+		{Version: "202607220001_period_spending_limits", SQL: periodSpendingLimitsSQL},
 	}
 }
+
+const periodSpendingLimitsSQL = `
+ALTER TABLE api_key_permission_profiles ADD COLUMN IF NOT EXISTS five_hour_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_key_permission_profiles ADD COLUMN IF NOT EXISTS weekly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_key_permission_profiles ADD COLUMN IF NOT EXISTS monthly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS five_hour_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS weekly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS monthly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS five_hour_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS weekly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS monthly_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_usage_rollup_tenant_key_quota
+  ON usage_rollup_buckets(tenant_id, bucket_kind, api_key_id, bucket_start);
+CREATE INDEX IF NOT EXISTS idx_usage_rollup_tenant_user_quota
+  ON usage_rollup_buckets(tenant_id, bucket_kind, end_user_id, bucket_start);
+`
 
 const usageRollupBucketsSQL = `
 CREATE TABLE IF NOT EXISTS usage_rollup_buckets (

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,10 +11,17 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 21 {
-		t.Fatalf("RuntimeMigrations len = %d, want 21", len(migrations))
+	if len(migrations) != 22 {
+		t.Fatalf("RuntimeMigrations len = %d, want 22", len(migrations))
 	}
-	// Latest: append-only account-level daily spending reset history.
+	// Latest: fixed period spending columns.
+	periodSQL := migrations[21].SQL
+	for _, fragment := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+		if !strings.Contains(periodSQL, fragment) {
+			t.Fatalf("period migration missing %q", fragment)
+		}
+	}
+	// Prior: append-only account-level daily spending reset history.
 	endUserResetEventsSQL := migrations[20].SQL
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS end_user_daily_spending_reset_events",

--- a/internal/storage/sqlite/apikey/effective.go
+++ b/internal/storage/sqlite/apikey/effective.go
@@ -1,0 +1,48 @@
+package apikey
+
+import "strings"
+
+func EffectiveAPIKeyRowWithProfiles(row APIKeyRow, profiles []PermissionProfileSnapshot) APIKeyRow {
+	profileID := strings.TrimSpace(row.PermissionProfileID)
+	if profileID == "" {
+		return row
+	}
+
+	var matched *PermissionProfileSnapshot
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.ID) == profileID {
+			copy := profile
+			matched = &copy
+			break
+		}
+	}
+	if matched == nil {
+		return row
+	}
+
+	row.PermissionProfileID = profileID
+	row.DailyLimit = matched.DailyLimit
+	row.TotalQuota = matched.TotalQuota
+	row.DailySpendingLimit = matched.DailySpendingLimit
+	row.PeriodSpendingLimits = matched.PeriodSpendingLimits
+	row.PeriodSpendingLimits.Day = row.DailySpendingLimit
+	row.ConcurrencyLimit = matched.ConcurrencyLimit
+	row.RPMLimit = matched.RPMLimit
+	row.TPMLimit = matched.TPMLimit
+	row.AllowedModels = append([]string(nil), matched.AllowedModels...)
+	row.AllowedChannels = append([]string(nil), matched.AllowedChannels...)
+	row.AllowedChannelGroups = append([]string(nil), matched.AllowedChannelGroups...)
+	row.SystemPrompt = matched.SystemPrompt
+	return row
+}
+
+func EffectiveAPIKeyRowsWithProfiles(rows []APIKeyRow, profiles []PermissionProfileSnapshot) []APIKeyRow {
+	if len(rows) == 0 {
+		return rows
+	}
+	out := make([]APIKeyRow, len(rows))
+	for idx, row := range rows {
+		out[idx] = EffectiveAPIKeyRowWithProfiles(row, profiles)
+	}
+	return out
+}

--- a/internal/storage/sqlite/apikey/permission_profiles.go
+++ b/internal/storage/sqlite/apikey/permission_profiles.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,6 +20,9 @@ CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
   daily_limit            INTEGER NOT NULL DEFAULT 0,
   total_quota            INTEGER NOT NULL DEFAULT 0,
   daily_spending_limit   REAL NOT NULL DEFAULT 0,
+  five_hour_spending_limit REAL NOT NULL DEFAULT 0,
+  weekly_spending_limit  REAL NOT NULL DEFAULT 0,
+  monthly_spending_limit REAL NOT NULL DEFAULT 0,
   concurrency_limit      INTEGER NOT NULL DEFAULT 0,
   rpm_limit              INTEGER NOT NULL DEFAULT 0,
   tpm_limit              INTEGER NOT NULL DEFAULT 0,
@@ -33,21 +37,27 @@ CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
 `
 
 type PermissionProfileRow struct {
-	TenantID             string   `json:"tenant_id,omitempty" yaml:"tenant_id,omitempty"`
-	ID                   string   `json:"id" yaml:"id"`
-	Name                 string   `json:"name" yaml:"name"`
-	DailyLimit           int      `json:"daily-limit" yaml:"daily-limit"`
-	TotalQuota           int      `json:"total-quota" yaml:"total-quota"`
-	DailySpendingLimit   float64  `json:"daily-spending-limit" yaml:"daily-spending-limit"`
-	ConcurrencyLimit     int      `json:"concurrency-limit" yaml:"concurrency-limit"`
-	RPMLimit             int      `json:"rpm-limit" yaml:"rpm-limit"`
-	TPMLimit             int      `json:"tpm-limit" yaml:"tpm-limit"`
-	AllowedModels        []string `json:"allowed-models" yaml:"allowed-models"`
-	AllowedChannels      []string `json:"allowed-channels" yaml:"allowed-channels"`
-	AllowedChannelGroups []string `json:"allowed-channel-groups" yaml:"allowed-channel-groups"`
-	SystemPrompt         string   `json:"system-prompt" yaml:"system-prompt"`
-	CreatedAt            string   `json:"created-at,omitempty" yaml:"created-at,omitempty"`
-	UpdatedAt            string   `json:"updated-at,omitempty" yaml:"updated-at,omitempty"`
+	TenantID             string                     `json:"tenant_id,omitempty" yaml:"tenant_id,omitempty"`
+	ID                   string                     `json:"id" yaml:"id"`
+	Name                 string                     `json:"name" yaml:"name"`
+	DailyLimit           int                        `json:"daily-limit" yaml:"daily-limit"`
+	TotalQuota           int                        `json:"total-quota" yaml:"total-quota"`
+	DailySpendingLimit   float64                    `json:"daily-spending-limit" yaml:"daily-spending-limit"`
+	PeriodSpendingLimits quota.PeriodSpendingLimits `json:"period-spending-limits" yaml:"period-spending-limits"`
+	ConcurrencyLimit     int                        `json:"concurrency-limit" yaml:"concurrency-limit"`
+	RPMLimit             int                        `json:"rpm-limit" yaml:"rpm-limit"`
+	TPMLimit             int                        `json:"tpm-limit" yaml:"tpm-limit"`
+	AllowedModels        []string                   `json:"allowed-models" yaml:"allowed-models"`
+	AllowedChannels      []string                   `json:"allowed-channels" yaml:"allowed-channels"`
+	AllowedChannelGroups []string                   `json:"allowed-channel-groups" yaml:"allowed-channel-groups"`
+	SystemPrompt         string                     `json:"system-prompt" yaml:"system-prompt"`
+	CreatedAt            string                     `json:"created-at,omitempty" yaml:"created-at,omitempty"`
+	UpdatedAt            string                     `json:"updated-at,omitempty" yaml:"updated-at,omitempty"`
+}
+
+type PermissionProfileSyncResult struct {
+	AppliedCount int64             `json:"applied_count"`
+	CappedKeys   []quota.CappedKey `json:"capped-keys,omitempty"`
 }
 
 func InitPermissionProfilesTable(db *sql.DB) {
@@ -60,11 +70,23 @@ func InitPermissionProfilesTable(db *sql.DB) {
 	if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
 		log.Warnf("sqlite/apikey: migrate api_key_permission_profiles tenant_id: %v", err)
 	}
-	if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN daily_spending_limit REAL NOT NULL DEFAULT 0"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
-		log.Warnf("sqlite/apikey: migrate api_key_permission_profiles daily_spending_limit: %v", err)
+	for _, column := range []string{"daily_spending_limit", "five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+		if _, err := db.Exec("ALTER TABLE api_key_permission_profiles ADD COLUMN " + column + " REAL NOT NULL DEFAULT 0"); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+			log.Warnf("sqlite/apikey: migrate api_key_permission_profiles %s: %v", column, err)
+		}
 	}
 	if err := migratePermissionProfilesTenantPrimaryKey(db); err != nil {
 		log.Errorf("sqlite/apikey: migrate api_key_permission_profiles tenant primary key: %v", err)
+	}
+	for _, table := range []string{"end_users", "api_keys"} {
+		for _, column := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+			if _, err := db.Exec("ALTER TABLE " + table + " ADD COLUMN " + column + " REAL NOT NULL DEFAULT 0"); err != nil {
+				message := strings.ToLower(err.Error())
+				if !strings.Contains(message, "duplicate") && !strings.Contains(message, "no such table") {
+					log.Warnf("sqlite/apikey: migrate %s.%s: %v", table, column, err)
+				}
+			}
+		}
 	}
 }
 
@@ -111,6 +133,7 @@ func migratePermissionProfilesTenantPrimaryKey(db *sql.DB) error {
 			tenant_id TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
 			id TEXT NOT NULL, name TEXT NOT NULL DEFAULT '', daily_limit INTEGER NOT NULL DEFAULT 0,
 			total_quota INTEGER NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+			five_hour_spending_limit REAL NOT NULL DEFAULT 0, weekly_spending_limit REAL NOT NULL DEFAULT 0, monthly_spending_limit REAL NOT NULL DEFAULT 0,
 			concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0,
 			tpm_limit INTEGER NOT NULL DEFAULT 0, allowed_models TEXT NOT NULL DEFAULT '[]',
 			allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
@@ -122,11 +145,11 @@ func migratePermissionProfilesTenantPrimaryKey(db *sql.DB) error {
 	}
 	if _, err = tx.Exec(`
 		INSERT INTO api_key_permission_profiles_tenant_pk (
-			tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
+			tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit,
 			rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		)
 		SELECT CASE WHEN trim(coalesce(tenant_id, '')) = '' THEN ? ELSE tenant_id END,
-			id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
+			id, name, daily_limit, total_quota, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit,
 			rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at
 		FROM api_key_permission_profiles
 	`, systemTenantID); err != nil {
@@ -146,7 +169,7 @@ func (s Store) ListPermissionProfiles() []PermissionProfileRow {
 		return nil
 	}
 
-	rows, err := s.db.Query(`SELECT id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit,
+	rows, err := s.db.Query(`SELECT id, name, daily_limit, total_quota, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit,
 		rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups,
 		system_prompt, created_at, updated_at
 		FROM api_key_permission_profiles WHERE tenant_id = ? ORDER BY created_at ASC, id ASC`, s.tenantID)
@@ -176,31 +199,50 @@ func (s Store) ReplaceAllPermissionProfiles(profiles []PermissionProfileRow) err
 }
 
 func (s Store) ReplaceAllPermissionProfilesAndSyncEndUsers(profiles []PermissionProfileRow) (int64, error) {
-	return s.replaceAllPermissionProfiles(profiles, true)
+	result, err := s.replaceAllPermissionProfiles(profiles, true)
+	return result.AppliedCount, err
 }
 
-func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syncEndUsers bool) (int64, error) {
+func (s Store) ReplaceAllPermissionProfilesWithCaps(profiles []PermissionProfileRow, syncEndUsers bool) (PermissionProfileSyncResult, error) {
+	return s.replaceAllPermissionProfiles(profiles, syncEndUsers)
+}
+
+func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syncEndUsers bool) (PermissionProfileSyncResult, error) {
 	if s.db == nil {
-		return 0, fmt.Errorf("database not initialised")
+		return PermissionProfileSyncResult{}, fmt.Errorf("database not initialised")
+	}
+	for _, table := range []string{"end_users", "api_keys"} {
+		for _, column := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
+			if _, err := s.db.Exec("ALTER TABLE " + table + " ADD COLUMN " + column + " REAL NOT NULL DEFAULT 0"); err != nil {
+				message := strings.ToLower(err.Error())
+				if !strings.Contains(message, "duplicate") && !strings.Contains(message, "no such table") {
+					return PermissionProfileSyncResult{}, err
+				}
+			}
+		}
 	}
 
 	tx, err := s.db.Begin()
 	if err != nil {
-		return 0, err
+		return PermissionProfileSyncResult{}, err
+	}
+	if err := lockBoundEndUsersForProfileUpdate(tx, s.tenantID); err != nil {
+		_ = tx.Rollback()
+		return PermissionProfileSyncResult{}, err
 	}
 
 	if _, err := tx.Exec("DELETE FROM api_key_permission_profiles WHERE tenant_id = ?", s.tenantID); err != nil {
 		_ = tx.Rollback()
-		return 0, err
+		return PermissionProfileSyncResult{}, err
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_key_permission_profiles
-		(tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		(tenant_id, id, name, daily_limit, total_quota, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		 allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
-		return 0, err
+		return PermissionProfileSyncResult{}, err
 	}
 	defer stmt.Close()
 
@@ -210,15 +252,15 @@ func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syn
 		profile = normalizePermissionProfile(profile)
 		if profile.ID == "" {
 			_ = tx.Rollback()
-			return 0, fmt.Errorf("id is required")
+			return PermissionProfileSyncResult{}, fmt.Errorf("id is required")
 		}
 		if profile.Name == "" {
 			_ = tx.Rollback()
-			return 0, fmt.Errorf("name is required")
+			return PermissionProfileSyncResult{}, fmt.Errorf("name is required")
 		}
 		if _, exists := seen[profile.ID]; exists {
 			_ = tx.Rollback()
-			return 0, fmt.Errorf("duplicate id %q", profile.ID)
+			return PermissionProfileSyncResult{}, fmt.Errorf("duplicate id %q", profile.ID)
 		}
 		seen[profile.ID] = struct{}{}
 		if profile.CreatedAt == "" {
@@ -228,13 +270,13 @@ func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syn
 
 		if _, err := stmt.Exec(
 			s.tenantID, profile.ID, profile.Name, profile.DailyLimit, profile.TotalQuota, profile.DailySpendingLimit,
-			profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
+			profile.PeriodSpendingLimits.FiveHour, profile.PeriodSpendingLimits.Week, profile.PeriodSpendingLimits.Month, profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
 			mustJSONStringList(profile.AllowedModels), mustJSONStringList(profile.AllowedChannels),
 			mustJSONStringList(profile.AllowedChannelGroups), profile.SystemPrompt,
 			profile.CreatedAt, profile.UpdatedAt,
 		); err != nil {
 			_ = tx.Rollback()
-			return 0, err
+			return PermissionProfileSyncResult{}, err
 		}
 	}
 
@@ -244,19 +286,19 @@ func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syn
 			profile = normalizePermissionProfile(profile)
 			result, syncErr := tx.Exec(`
 				UPDATE end_users SET
-					permission_profile_id = ?, daily_limit = ?, total_quota = ?, spending_limit = 0,
-					daily_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
+					permission_profile_id = ?, daily_limit = ?, total_quota = ?,
+					daily_spending_limit = ?, five_hour_spending_limit = ?, weekly_spending_limit = ?, monthly_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
 					allowed_models = ?, allowed_channels = ?, allowed_channel_groups = ?, system_prompt = ?,
 					updated_at = ?, version = version + 1
 				WHERE tenant_id = ? AND permission_profile_id = ?
 			`, profile.ID, profile.DailyLimit, profile.TotalQuota, profile.DailySpendingLimit,
-				profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
+				profile.PeriodSpendingLimits.FiveHour, profile.PeriodSpendingLimits.Week, profile.PeriodSpendingLimits.Month, profile.ConcurrencyLimit, profile.RPMLimit, profile.TPMLimit,
 				mustJSONStringList(profile.AllowedModels), mustJSONStringList(profile.AllowedChannels),
 				mustJSONStringList(profile.AllowedChannelGroups), profile.SystemPrompt,
 				now, s.tenantID, profile.ID)
 			if syncErr != nil {
 				_ = tx.Rollback()
-				return 0, syncErr
+				return PermissionProfileSyncResult{}, syncErr
 			}
 			if rows, rowsErr := result.RowsAffected(); rowsErr == nil {
 				appliedCount += rows
@@ -278,17 +320,117 @@ func (s Store) replaceAllPermissionProfiles(profiles []PermissionProfileRow, syn
 		result, syncErr := tx.Exec(unbindQuery, unbindArgs...)
 		if syncErr != nil {
 			_ = tx.Rollback()
-			return 0, syncErr
+			return PermissionProfileSyncResult{}, syncErr
 		}
 		if rows, rowsErr := result.RowsAffected(); rowsErr == nil {
 			appliedCount += rows
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return 0, err
+	cappedKeys, err := capProfileOwnedKeysTx(tx, s.tenantID, profiles, now)
+	if err != nil {
+		_ = tx.Rollback()
+		return PermissionProfileSyncResult{}, err
 	}
-	return appliedCount, nil
+	if err := tx.Commit(); err != nil {
+		return PermissionProfileSyncResult{}, err
+	}
+	return PermissionProfileSyncResult{AppliedCount: appliedCount, CappedKeys: cappedKeys}, nil
+}
+
+func lockBoundEndUsersForProfileUpdate(tx *sql.Tx, tenantID string) error {
+	query := `SELECT id FROM end_users WHERE tenant_id = ? AND permission_profile_id != '' ORDER BY id ASC FOR UPDATE`
+	rows, err := tx.Query(query, tenantID)
+	if err != nil {
+		message := strings.ToLower(err.Error())
+		if strings.Contains(message, "no such table") {
+			return nil
+		}
+		if strings.Contains(message, "syntax") || strings.Contains(message, "for update") {
+			rows, err = tx.Query(strings.TrimSuffix(query, " FOR UPDATE"), tenantID)
+		}
+	}
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table") {
+			return nil
+		}
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func capProfileOwnedKeysTx(tx *sql.Tx, tenantID string, profiles []PermissionProfileRow, now string) ([]quota.CappedKey, error) {
+	ceilings := make(map[string]quota.PeriodSpendingLimits, len(profiles))
+	for _, profile := range profiles {
+		profile = normalizePermissionProfile(profile)
+		ceilings[profile.ID] = profile.PeriodSpendingLimits
+	}
+	rows, err := tx.Query(`SELECT k.id, e.permission_profile_id,
+		COALESCE(k.daily_spending_limit,0), COALESCE(k.five_hour_spending_limit,0),
+		COALESCE(k.weekly_spending_limit,0), COALESCE(k.monthly_spending_limit,0)
+		FROM api_keys k JOIN end_users e ON e.id = k.end_user_id AND e.tenant_id = k.tenant_id
+		WHERE k.tenant_id = ? AND e.permission_profile_id != '' ORDER BY k.id ASC`, tenantID)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	type item struct {
+		id, profileID string
+		limits        quota.PeriodSpendingLimits
+	}
+	items := make([]item, 0)
+	for rows.Next() {
+		var v item
+		if err := rows.Scan(&v.id, &v.profileID, &v.limits.Day, &v.limits.FiveHour, &v.limits.Week, &v.limits.Month); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		items = append(items, v)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	out := make([]quota.CappedKey, 0)
+	for _, v := range items {
+		ceiling, ok := ceilings[v.profileID]
+		if !ok {
+			continue
+		}
+		updated := v.limits
+		for _, period := range quota.OrderedPeriods {
+			from, to := updated.Value(period), ceiling.Value(period)
+			if from <= 0 || to <= 0 || from <= to {
+				continue
+			}
+			switch period {
+			case quota.PeriodFiveHour:
+				updated.FiveHour = to
+			case quota.PeriodDay:
+				updated.Day = to
+			case quota.PeriodWeek:
+				updated.Week = to
+			case quota.PeriodMonth:
+				updated.Month = to
+			}
+			out = append(out, quota.CappedKey{ID: v.id, Period: period, From: from, To: to})
+		}
+		if updated != v.limits {
+			if _, err := tx.Exec(`UPDATE api_keys SET daily_spending_limit=?, five_hour_spending_limit=?, weekly_spending_limit=?, monthly_spending_limit=?, updated_at=? WHERE tenant_id=? AND id=?`,
+				updated.Day, updated.FiveHour, updated.Week, updated.Month, now, tenantID, v.id); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
 }
 
 func normalizePermissionProfile(profile PermissionProfileRow) PermissionProfileRow {
@@ -296,7 +438,20 @@ func normalizePermissionProfile(profile PermissionProfileRow) PermissionProfileR
 	profile.Name = strings.TrimSpace(profile.Name)
 	profile.DailyLimit = normalizeNonNegativeInt(profile.DailyLimit)
 	profile.TotalQuota = normalizeNonNegativeInt(profile.TotalQuota)
-	profile.DailySpendingLimit = normalizeWholeUSD(profile.DailySpendingLimit)
+	limits, err := quota.NormalizeLimits(profile.PeriodSpendingLimits)
+	if err != nil {
+		limits = quota.PeriodSpendingLimits{}
+	}
+	day, err := quota.NormalizeWholeUSD(profile.DailySpendingLimit)
+	if err != nil {
+		day = 0
+	}
+	if limits.Day > 0 && day == 0 {
+		day = limits.Day
+	}
+	limits.Day = day
+	profile.DailySpendingLimit = day
+	profile.PeriodSpendingLimits = limits
 	profile.ConcurrencyLimit = normalizeNonNegativeInt(profile.ConcurrencyLimit)
 	profile.RPMLimit = normalizeNonNegativeInt(profile.RPMLimit)
 	profile.TPMLimit = normalizeNonNegativeInt(profile.TPMLimit)
@@ -313,7 +468,7 @@ func scanPermissionProfileRow(row scanner) (*PermissionProfileRow, bool) {
 	var channelsJSON string
 	var channelGroupsJSON string
 	if err := row.Scan(
-		&profile.ID, &profile.Name, &profile.DailyLimit, &profile.TotalQuota, &profile.DailySpendingLimit, &profile.ConcurrencyLimit,
+		&profile.ID, &profile.Name, &profile.DailyLimit, &profile.TotalQuota, &profile.DailySpendingLimit, &profile.PeriodSpendingLimits.FiveHour, &profile.PeriodSpendingLimits.Week, &profile.PeriodSpendingLimits.Month, &profile.ConcurrencyLimit,
 		&profile.RPMLimit, &profile.TPMLimit, &modelsJSON, &channelsJSON, &channelGroupsJSON,
 		&profile.SystemPrompt, &profile.CreatedAt, &profile.UpdatedAt,
 	); err != nil {
@@ -322,6 +477,7 @@ func scanPermissionProfileRow(row scanner) (*PermissionProfileRow, bool) {
 		}
 		return nil, false
 	}
+	profile.PeriodSpendingLimits.Day = profile.DailySpendingLimit
 	profile.AllowedModels = decodeJSONStringList(modelsJSON)
 	profile.AllowedChannels = decodeJSONStringList(channelsJSON)
 	profile.AllowedChannelGroups = decodeJSONStringList(channelGroupsJSON)

--- a/internal/storage/sqlite/apikey/permission_profiles_tenant_test.go
+++ b/internal/storage/sqlite/apikey/permission_profiles_tenant_test.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -94,5 +96,44 @@ func TestPermissionProfilesMigrateToTenantScopedPrimaryKeyAndSyncIsolatedAccount
 		if limit != want.limit {
 			t.Fatalf("%s daily_limit = %d, want %d", want.id, limit, want.limit)
 		}
+	}
+}
+
+func TestPermissionProfileSaveCapsBoundOwnedKeysWithoutSyncAccounts(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	InitTable(db)
+	if _, err := db.Exec(`CREATE TABLE end_users (
+		id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, permission_profile_id TEXT NOT NULL DEFAULT '',
+		daily_limit INTEGER NOT NULL DEFAULT 0, total_quota INTEGER NOT NULL DEFAULT 0,
+		spending_limit REAL NOT NULL DEFAULT 0, daily_spending_limit REAL NOT NULL DEFAULT 0,
+		five_hour_spending_limit REAL NOT NULL DEFAULT 0, weekly_spending_limit REAL NOT NULL DEFAULT 0, monthly_spending_limit REAL NOT NULL DEFAULT 0,
+		concurrency_limit INTEGER NOT NULL DEFAULT 0, rpm_limit INTEGER NOT NULL DEFAULT 0, tpm_limit INTEGER NOT NULL DEFAULT 0,
+		allowed_models TEXT NOT NULL DEFAULT '[]', allowed_channels TEXT NOT NULL DEFAULT '[]', allowed_channel_groups TEXT NOT NULL DEFAULT '[]', system_prompt TEXT NOT NULL DEFAULT '',
+		updated_at TEXT NOT NULL DEFAULT '', version INTEGER NOT NULL DEFAULT 1
+	)`); err != nil {
+		t.Fatalf("create users: %v", err)
+	}
+	InitPermissionProfilesTable(db)
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	if _, err := db.Exec(`INSERT INTO end_users(id,tenant_id,permission_profile_id,daily_spending_limit) VALUES('user-a',?,'standard',200)`, tenantID); err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	store := NewTenantStore(db, tenantID)
+	if err := store.Upsert(APIKeyRow{ID: "key-a", Key: "sk-a", EndUserID: "user-a", DailySpendingLimit: 200, PeriodSpendingLimits: quota.PeriodSpendingLimits{Day: 200}}); err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	result, err := store.ReplaceAllPermissionProfilesWithCaps([]PermissionProfileRow{{ID: "standard", Name: "Standard", DailySpendingLimit: 100}}, false)
+	if err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if result.AppliedCount != 0 || len(result.CappedKeys) != 1 || result.CappedKeys[0].ID != "key-a" || result.CappedKeys[0].Period != quota.PeriodDay || result.CappedKeys[0].From != 200 || result.CappedKeys[0].To != 100 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := store.GetByID("key-a"); got == nil || got.DailySpendingLimit != 100 {
+		t.Fatalf("stored key = %+v", got)
 	}
 }

--- a/internal/storage/sqlite/apikey/store.go
+++ b/internal/storage/sqlite/apikey/store.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -26,6 +27,9 @@ CREATE TABLE IF NOT EXISTS api_keys (
   total_quota       INTEGER NOT NULL DEFAULT 0,
   spending_limit    REAL NOT NULL DEFAULT 0,
   daily_spending_limit REAL NOT NULL DEFAULT 0,
+  five_hour_spending_limit REAL NOT NULL DEFAULT 0,
+  weekly_spending_limit REAL NOT NULL DEFAULT 0,
+  monthly_spending_limit REAL NOT NULL DEFAULT 0,
   concurrency_limit INTEGER NOT NULL DEFAULT 0,
   rpm_limit         INTEGER NOT NULL DEFAULT 0,
   tpm_limit         INTEGER NOT NULL DEFAULT 0,
@@ -42,27 +46,32 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);
 `
 
 type APIKeyRow struct {
-	TenantID             string   `json:"tenant_id,omitempty"`
-	ID                   string   `json:"id,omitempty"`
-	Key                  string   `json:"key"`
-	Name                 string   `json:"name,omitempty"`
-	Disabled             bool     `json:"disabled,omitempty"`
-	EndUserID            string   `json:"end_user_id,omitempty"`
-	IsDefault            bool     `json:"is_default,omitempty"`
-	PermissionProfileID  string   `json:"permission-profile-id,omitempty"`
-	DailyLimit           int      `json:"daily-limit,omitempty"`
-	TotalQuota           int      `json:"total-quota,omitempty"`
-	SpendingLimit        float64  `json:"spending-limit,omitempty"`
-	DailySpendingLimit   float64  `json:"daily-spending-limit,omitempty"`
-	ConcurrencyLimit     int      `json:"concurrency-limit,omitempty"`
-	RPMLimit             int      `json:"rpm-limit,omitempty"`
-	TPMLimit             int      `json:"tpm-limit,omitempty"`
-	AllowedModels        []string `json:"allowed-models,omitempty"`
-	AllowedChannels      []string `json:"allowed-channels,omitempty"`
-	AllowedChannelGroups []string `json:"allowed-channel-groups,omitempty"`
-	SystemPrompt         string   `json:"system-prompt,omitempty"`
-	CreatedAt            string   `json:"created-at,omitempty"`
-	UpdatedAt            string   `json:"updated_at,omitempty"`
+	TenantID                string                     `json:"tenant_id,omitempty"`
+	ID                      string                     `json:"id,omitempty"`
+	Key                     string                     `json:"key"`
+	Name                    string                     `json:"name,omitempty"`
+	Disabled                bool                       `json:"disabled,omitempty"`
+	EndUserID               string                     `json:"end_user_id,omitempty"`
+	IsDefault               bool                       `json:"is_default,omitempty"`
+	PermissionProfileID     string                     `json:"permission-profile-id,omitempty"`
+	DailyLimit              int                        `json:"daily-limit,omitempty"`
+	TotalQuota              int                        `json:"total-quota,omitempty"`
+	SpendingLimit           float64                    `json:"spending-limit,omitempty"`
+	DailySpendingLimit      float64                    `json:"daily-spending-limit,omitempty"`
+	PeriodSpendingLimits    quota.PeriodSpendingLimits `json:"period-spending-limits"`
+	PeriodSpending          []quota.PeriodSpending     `json:"period-spending,omitempty"`
+	LifetimeSpendingUsed    float64                    `json:"lifetime-spending-used"`
+	DailySpendingUsed       float64                    `json:"daily-spending-used"`
+	DailySpendingResetCount int                        `json:"daily-spending-reset-count,omitempty"`
+	ConcurrencyLimit        int                        `json:"concurrency-limit,omitempty"`
+	RPMLimit                int                        `json:"rpm-limit,omitempty"`
+	TPMLimit                int                        `json:"tpm-limit,omitempty"`
+	AllowedModels           []string                   `json:"allowed-models,omitempty"`
+	AllowedChannels         []string                   `json:"allowed-channels,omitempty"`
+	AllowedChannelGroups    []string                   `json:"allowed-channel-groups,omitempty"`
+	SystemPrompt            string                     `json:"system-prompt,omitempty"`
+	CreatedAt               string                     `json:"created-at,omitempty"`
+	UpdatedAt               string                     `json:"updated_at,omitempty"`
 }
 
 type PermissionProfileSnapshot struct {
@@ -70,6 +79,7 @@ type PermissionProfileSnapshot struct {
 	DailyLimit           int
 	TotalQuota           int
 	DailySpendingLimit   float64
+	PeriodSpendingLimits quota.PeriodSpendingLimits
 	ConcurrencyLimit     int
 	RPMLimit             int
 	TPMLimit             int
@@ -138,6 +148,9 @@ func (r APIKeyRow) ToConfigEntry() config.APIKeyEntry {
 		TotalQuota:           r.TotalQuota,
 		SpendingLimit:        r.SpendingLimit,
 		DailySpendingLimit:   r.DailySpendingLimit,
+		PeriodSpendingLimits: r.PeriodSpendingLimits,
+		PeriodSpending:       r.PeriodSpending,
+		LifetimeSpendingUsed: r.LifetimeSpendingUsed,
 		ConcurrencyLimit:     r.ConcurrencyLimit,
 		RPMLimit:             r.RPMLimit,
 		TPMLimit:             r.TPMLimit,
@@ -162,6 +175,7 @@ func APIKeyRowFromConfig(entry config.APIKeyEntry) APIKeyRow {
 		TotalQuota:           entry.TotalQuota,
 		SpendingLimit:        entry.SpendingLimit,
 		DailySpendingLimit:   entry.DailySpendingLimit,
+		PeriodSpendingLimits: entry.PeriodSpendingLimits,
 		ConcurrencyLimit:     entry.ConcurrencyLimit,
 		RPMLimit:             entry.RPMLimit,
 		TPMLimit:             entry.TPMLimit,
@@ -205,7 +219,7 @@ func (s Store) ListAll() []APIKeyRow {
 	}
 
 	rows, err := s.db.Query(`SELECT tenant_id, key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys ORDER BY tenant_id ASC, created_at ASC`)
@@ -234,7 +248,7 @@ func (s Store) List() []APIKeyRow {
 	}
 
 	rows, err := s.db.Query(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE tenant_id = ? ORDER BY created_at ASC`, s.tenantID)
@@ -262,7 +276,7 @@ func (s Store) Get(key string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE tenant_id = ? AND key = ?`, s.tenantID, trimmed)
@@ -288,7 +302,7 @@ func (s Store) GetAnyTenant(key string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT tenant_id, key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE key = ?`, trimmed)
@@ -310,7 +324,7 @@ func (s Store) GetByID(id string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE tenant_id = ? AND id = ?`, s.tenantID, trimmed)
@@ -335,7 +349,7 @@ func (s Store) GetByIDAnyTenant(id string) *APIKeyRow {
 	}
 
 	row := s.db.QueryRow(`SELECT tenant_id, key, name, disabled, id, daily_limit, total_quota,
-		permission_profile_id, spending_limit, daily_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
+		permission_profile_id, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit, concurrency_limit, rpm_limit, tpm_limit,
 		allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		end_user_id, is_default
 		FROM api_keys WHERE id = ?`, trimmed)
@@ -346,9 +360,9 @@ func (s Store) GetByIDAnyTenant(id string) *APIKeyRow {
 	return entry
 }
 
-// stripOwnedKeyQuota clears per-key limits for end-user-owned keys.
-// Account-level limits live on end_users; keeping key rows non-zero would re-open the multi-key budget hole.
-func stripOwnedKeyQuota(entry *APIKeyRow) {
+// stripOwnedKeyAccountManagedFields clears fields owned keys inherit from their account.
+// The four period spending limits remain key-scoped sub-quotas.
+func stripOwnedKeyAccountManagedFields(entry *APIKeyRow) {
 	if entry == nil || strings.TrimSpace(entry.EndUserID) == "" {
 		return
 	}
@@ -356,7 +370,6 @@ func stripOwnedKeyQuota(entry *APIKeyRow) {
 	entry.DailyLimit = 0
 	entry.TotalQuota = 0
 	entry.SpendingLimit = 0
-	entry.DailySpendingLimit = 0
 	entry.ConcurrencyLimit = 0
 	entry.RPMLimit = 0
 	entry.TPMLimit = 0
@@ -390,7 +403,7 @@ func (s Store) Upsert(entry APIKeyRow) error {
 			entry.EndUserID = existing.EndUserID
 		}
 	}
-	stripOwnedKeyQuota(&entry)
+	stripOwnedKeyAccountManagedFields(&entry)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	if entry.CreatedAt == "" {
@@ -409,16 +422,18 @@ func (s Store) Upsert(entry APIKeyRow) error {
 	}
 
 	result, err := s.db.Exec(`INSERT INTO api_keys
-		(tenant_id, key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
+		(tenant_id, key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		 end_user_id, is_default)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(key) DO UPDATE SET
 			id=excluded.id,
 			name=excluded.name, disabled=excluded.disabled,
 			permission_profile_id=excluded.permission_profile_id,
 			daily_limit=excluded.daily_limit, total_quota=excluded.total_quota,
-			spending_limit=excluded.spending_limit, daily_spending_limit=excluded.daily_spending_limit, concurrency_limit=excluded.concurrency_limit,
+			spending_limit=excluded.spending_limit, daily_spending_limit=excluded.daily_spending_limit,
+			five_hour_spending_limit=excluded.five_hour_spending_limit, weekly_spending_limit=excluded.weekly_spending_limit, monthly_spending_limit=excluded.monthly_spending_limit,
+			concurrency_limit=excluded.concurrency_limit,
 			rpm_limit=excluded.rpm_limit, tpm_limit=excluded.tpm_limit,
 			allowed_models=excluded.allowed_models, allowed_channels=excluded.allowed_channels,
 			allowed_channel_groups=excluded.allowed_channel_groups,
@@ -429,7 +444,7 @@ func (s Store) Upsert(entry APIKeyRow) error {
 		WHERE api_keys.tenant_id = excluded.tenant_id`,
 		s.tenantID, entry.Key, entry.ID, entry.Name, disabledInt, entry.PermissionProfileID,
 		entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit, entry.DailySpendingLimit,
-		entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
+		entry.PeriodSpendingLimits.FiveHour, entry.PeriodSpendingLimits.Week, entry.PeriodSpendingLimits.Month, entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
 		entry.CreatedAt, now, endUserID, isDefault,
@@ -482,6 +497,11 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 		if err = lockOwnedEndUser(tx, ownerID); err != nil {
 			return err
 		}
+		if err = tx.QueryRow(`SELECT COALESCE(daily_spending_limit,0), COALESCE(five_hour_spending_limit,0), COALESCE(weekly_spending_limit,0), COALESCE(monthly_spending_limit,0) FROM api_keys WHERE tenant_id = ? AND id = ?`, s.tenantID, entry.ID).
+			Scan(&entry.PeriodSpendingLimits.Day, &entry.PeriodSpendingLimits.FiveHour, &entry.PeriodSpendingLimits.Week, &entry.PeriodSpendingLimits.Month); err != nil {
+			return err
+		}
+		entry.DailySpendingLimit = entry.PeriodSpendingLimits.Day
 		entry.EndUserID = ownerID
 		entry.IsDefault = wasDefault && !entry.Disabled
 	} else {
@@ -495,7 +515,7 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 	if entry.CreatedAt == "" {
 		entry.CreatedAt = now
 	}
-	stripOwnedKeyQuota(&entry)
+	stripOwnedKeyAccountManagedFields(&entry)
 
 	disabledInt := 0
 	if entry.Disabled {
@@ -503,12 +523,13 @@ func (s Store) UpdateByID(entry APIKeyRow) error {
 	}
 	result, err := tx.Exec(`UPDATE api_keys SET
 		key = ?, name = ?, disabled = ?, permission_profile_id = ?, daily_limit = ?, total_quota = ?,
-		spending_limit = ?, daily_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
+		spending_limit = ?, daily_spending_limit = ?, five_hour_spending_limit = ?, weekly_spending_limit = ?, monthly_spending_limit = ?, concurrency_limit = ?, rpm_limit = ?, tpm_limit = ?,
 		allowed_models = ?, allowed_channels = ?, allowed_channel_groups = ?, system_prompt = ?,
 		created_at = ?, updated_at = ?, is_default = ?
 		WHERE tenant_id = ? AND id = ?`,
 		entry.Key, entry.Name, disabledInt, entry.PermissionProfileID, entry.DailyLimit, entry.TotalQuota,
-		entry.SpendingLimit, entry.DailySpendingLimit, entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
+		entry.SpendingLimit, entry.DailySpendingLimit, entry.PeriodSpendingLimits.FiveHour, entry.PeriodSpendingLimits.Week, entry.PeriodSpendingLimits.Month,
+		entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 		mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 		mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
 		entry.CreatedAt, now, entry.IsDefault, s.tenantID, entry.ID,
@@ -764,10 +785,10 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO api_keys
-		(tenant_id, key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit,
+		(tenant_id, key, id, name, disabled, permission_profile_id, daily_limit, total_quota, spending_limit, daily_spending_limit, five_hour_spending_limit, weekly_spending_limit, monthly_spending_limit,
 		 concurrency_limit, rpm_limit, tpm_limit, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at,
 		 end_user_id, is_default)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -792,6 +813,7 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 		if _, err := stmt.Exec(
 			s.tenantID, entry.Key, entry.ID, entry.Name, disabledInt, entry.PermissionProfileID,
 			entry.DailyLimit, entry.TotalQuota, entry.SpendingLimit, entry.DailySpendingLimit,
+			entry.PeriodSpendingLimits.FiveHour, entry.PeriodSpendingLimits.Week, entry.PeriodSpendingLimits.Month,
 			entry.ConcurrencyLimit, entry.RPMLimit, entry.TPMLimit,
 			mustJSONStringList(entry.AllowedModels), mustJSONStringList(entry.AllowedChannels),
 			mustJSONStringList(entry.AllowedChannelGroups), entry.SystemPrompt,
@@ -812,50 +834,6 @@ func (s Store) ReplaceAll(entries []APIKeyRow) error {
 	return tx.Commit()
 }
 
-func EffectiveAPIKeyRowWithProfiles(row APIKeyRow, profiles []PermissionProfileSnapshot) APIKeyRow {
-	profileID := strings.TrimSpace(row.PermissionProfileID)
-	if profileID == "" {
-		return row
-	}
-
-	var matched *PermissionProfileSnapshot
-	for _, profile := range profiles {
-		if strings.TrimSpace(profile.ID) == profileID {
-			copy := profile
-			matched = &copy
-			break
-		}
-	}
-	if matched == nil {
-		return row
-	}
-
-	row.PermissionProfileID = profileID
-	row.DailyLimit = matched.DailyLimit
-	row.TotalQuota = matched.TotalQuota
-	row.SpendingLimit = 0
-	row.DailySpendingLimit = matched.DailySpendingLimit
-	row.ConcurrencyLimit = matched.ConcurrencyLimit
-	row.RPMLimit = matched.RPMLimit
-	row.TPMLimit = matched.TPMLimit
-	row.AllowedModels = append([]string(nil), matched.AllowedModels...)
-	row.AllowedChannels = append([]string(nil), matched.AllowedChannels...)
-	row.AllowedChannelGroups = append([]string(nil), matched.AllowedChannelGroups...)
-	row.SystemPrompt = matched.SystemPrompt
-	return row
-}
-
-func EffectiveAPIKeyRowsWithProfiles(rows []APIKeyRow, profiles []PermissionProfileSnapshot) []APIKeyRow {
-	if len(rows) == 0 {
-		return rows
-	}
-	out := make([]APIKeyRow, len(rows))
-	for idx, row := range rows {
-		out[idx] = EffectiveAPIKeyRowWithProfiles(row, profiles)
-	}
-	return out
-}
-
 func migrateColumns(db *sql.DB) {
 	for _, col := range []struct {
 		name       string
@@ -867,6 +845,9 @@ func migrateColumns(db *sql.DB) {
 		{name: "allowed_channels", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "allowed_channel_groups", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "daily_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
+		{name: "five_hour_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
+		{name: "weekly_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
+		{name: "monthly_spending_limit", definition: "REAL NOT NULL DEFAULT 0"},
 		{name: "end_user_id", definition: "TEXT"},
 		{name: "is_default", definition: "INTEGER NOT NULL DEFAULT 0"},
 	} {
@@ -1053,7 +1034,20 @@ func normalizeRow(row APIKeyRow) APIKeyRow {
 	row.EndUserID = strings.TrimSpace(row.EndUserID)
 	row.PermissionProfileID = strings.TrimSpace(row.PermissionProfileID)
 	row.SpendingLimit = normalizeWholeUSD(row.SpendingLimit)
-	row.DailySpendingLimit = normalizeWholeUSD(row.DailySpendingLimit)
+	limits, err := quota.NormalizeLimits(row.PeriodSpendingLimits)
+	if err != nil {
+		limits = quota.PeriodSpendingLimits{}
+	}
+	day, err := quota.NormalizeWholeUSD(row.DailySpendingLimit)
+	if err != nil {
+		day = 0
+	}
+	if limits.Day > 0 && day == 0 {
+		day = limits.Day
+	}
+	limits.Day = day
+	row.DailySpendingLimit = day
+	row.PeriodSpendingLimits = limits
 	return row
 }
 
@@ -1094,7 +1088,7 @@ func scanAPIKeyRowWithTenant(row scanner) (*APIKeyRow, bool) {
 		&entry.TenantID, &entry.Key, &entry.Name, &disabledInt,
 		&entry.ID,
 		&entry.DailyLimit, &entry.TotalQuota, &entry.PermissionProfileID, &entry.SpendingLimit,
-		&entry.DailySpendingLimit, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
+		&entry.DailySpendingLimit, &entry.PeriodSpendingLimits.FiveHour, &entry.PeriodSpendingLimits.Week, &entry.PeriodSpendingLimits.Month, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
 		&modelsJSON, &channelsJSON, &channelGroupsJSON, &entry.SystemPrompt,
 		&entry.CreatedAt, &entry.UpdatedAt, &endUserID, &isDefault,
 	); err != nil {
@@ -1107,6 +1101,7 @@ func scanAPIKeyRowWithTenant(row scanner) (*APIKeyRow, bool) {
 		entry.EndUserID = endUserID.String
 	}
 	entry.IsDefault = boolish(isDefault)
+	entry.PeriodSpendingLimits.Day = entry.DailySpendingLimit
 	decodeAPIKeyRow(&entry, disabledInt, modelsJSON, channelsJSON, channelGroupsJSON)
 	return &entry, true
 }
@@ -1123,7 +1118,7 @@ func scanAPIKeyRow(row scanner) (*APIKeyRow, bool) {
 		&entry.Key, &entry.Name, &disabledInt,
 		&entry.ID,
 		&entry.DailyLimit, &entry.TotalQuota, &entry.PermissionProfileID, &entry.SpendingLimit,
-		&entry.DailySpendingLimit, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
+		&entry.DailySpendingLimit, &entry.PeriodSpendingLimits.FiveHour, &entry.PeriodSpendingLimits.Week, &entry.PeriodSpendingLimits.Month, &entry.ConcurrencyLimit, &entry.RPMLimit, &entry.TPMLimit,
 		&modelsJSON, &channelsJSON, &channelGroupsJSON, &entry.SystemPrompt,
 		&entry.CreatedAt, &entry.UpdatedAt, &endUserID, &isDefault,
 	); err != nil {
@@ -1136,6 +1131,7 @@ func scanAPIKeyRow(row scanner) (*APIKeyRow, bool) {
 		entry.EndUserID = endUserID.String
 	}
 	entry.IsDefault = boolish(isDefault)
+	entry.PeriodSpendingLimits.Day = entry.DailySpendingLimit
 	decodeAPIKeyRow(&entry, disabledInt, modelsJSON, channelsJSON, channelGroupsJSON)
 	return &entry, true
 }

--- a/internal/storage/sqlite/apikey/store_tenant_test.go
+++ b/internal/storage/sqlite/apikey/store_tenant_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -210,5 +212,33 @@ func TestOwnedKeyMutationsKeepOneActiveDefault(t *testing.T) {
 	}
 	if got := store.GetByID("default-b"); got == nil || got.Disabled || !got.IsDefault {
 		t.Fatalf("failed replace changed active/default state: %#v", got)
+	}
+}
+
+func TestOwnedKeyStripPreservesPeriodSpendingLimits(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	InitTable(db)
+	store := NewStore(db)
+	limits := quota.PeriodSpendingLimits{FiveHour: 5, Day: 10, Week: 20, Month: 30}
+	if err := store.Upsert(APIKeyRow{
+		ID: "owned-period", Key: "sk-owned-period", EndUserID: "user-a",
+		DailyLimit: 99, SpendingLimit: 1000, DailySpendingLimit: limits.Day, PeriodSpendingLimits: limits,
+		ConcurrencyLimit: 2, RPMLimit: 3, TPMLimit: 4,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got := store.Get("sk-owned-period")
+	if got == nil {
+		t.Fatal("missing owned key")
+	}
+	if got.DailyLimit != 0 || got.SpendingLimit != 0 || got.ConcurrencyLimit != 0 || got.RPMLimit != 0 || got.TPMLimit != 0 {
+		t.Fatalf("account-managed fields were not stripped: %+v", got)
+	}
+	if got.PeriodSpendingLimits != limits || got.DailySpendingLimit != limits.Day {
+		t.Fatalf("period limits = %+v/day=%v, want %+v", got.PeriodSpendingLimits, got.DailySpendingLimit, limits)
 	}
 }

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -189,6 +189,13 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 	if dayRows != 1 || dayRequests != 2 {
 		t.Fatalf("day projection rows=%d requests=%d", dayRows, dayRequests)
 	}
+	var legacyRows int64
+	if err := getDB().QueryRow(`SELECT COUNT(*) FROM auth_subject_usage_daily WHERE auth_subject_id = ?`, identity.ID).Scan(&legacyRows); err != nil {
+		t.Fatal(err)
+	}
+	if legacyRows != 0 {
+		t.Fatalf("legacy daily rows=%d want 0", legacyRows)
+	}
 
 	start7 := time.Now().UTC().AddDate(0, 0, -6).Format("2006-01-02")
 	start30 := time.Now().UTC().AddDate(0, 0, -29).Format("2006-01-02")
@@ -363,8 +370,8 @@ func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 	cycleSummary := cycleSummaries[identity.ID]
-	if !cycleSummary.CycleKnown || cycleSummary.CycleRequestTotal != 2 || math.Abs(cycleSummary.CycleCostTotal-4) > 1e-9 {
-		t.Fatalf("backfilled current cycle=%+v", cycleSummary)
+	if !cycleSummary.CycleKnown || cycleSummary.CycleRequestTotal != 0 || cycleSummary.CycleCostTotal != 0 {
+		t.Fatalf("cycle usage must not be estimated from legacy days: %+v", cycleSummary)
 	}
 
 	second, err := RunAIAccountSharedSubjectBackfillAtInit()
@@ -377,6 +384,60 @@ func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
 	third, err := RunAIAccountSharedSubjectBackfillAtInit()
 	if err != nil || third.Checksum != report.Checksum || third.UsageRows != report.UsageRows || third.QuotaPoints != report.QuotaPoints {
 		t.Fatalf("pending rerun report=%+v err=%v first=%+v", third, err, report)
+	}
+}
+
+func TestProjectAIAccountSubjectUsageLoadsPrimaryCycleOnCacheMiss(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "cache-miss", "acct-cache-miss", "cache@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	primaryReset := now.Add(48 * time.Hour)
+	additionalReset := now.Add(96 * time.Hour)
+	pct := 50.0
+	if err := RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []QuotaSnapshotPoint{
+		{RecordedAt: now, Provider: "codex", QuotaKey: "code_week", QuotaLabel: "Week", Percent: &pct, ResetAt: &primaryReset, WindowSeconds: 604800},
+		{RecordedAt: now.Add(time.Second), Provider: "codex", QuotaKey: "other_week", QuotaLabel: "Other week", Percent: &pct, ResetAt: &additionalReset, WindowSeconds: 1209600},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	resetAIAccountSubjectCycleCache()
+
+	tx, err := getDB().Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 1.5, now); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	primaryStart := primaryReset.Add(-7 * 24 * time.Hour)
+	var bucketStart string
+	var requests int64
+	if err := getDB().QueryRow(`
+		SELECT bucket_start, request_count
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, identity.ID).Scan(&bucketStart, &requests); err != nil {
+		t.Fatal(err)
+	}
+	if bucketStart != formatAIAccountSubjectCycleBucketStart(primaryStart) || requests != 1 {
+		t.Fatalf("cycle bucket start=%q requests=%d want %q/1", bucketStart, requests, formatAIAccountSubjectCycleBucketStart(primaryStart))
+	}
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, map[string]time.Time{identity.ID: primaryStart})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := summaries[identity.ID]; !got.CycleKnown || got.CycleRequestTotal != 1 {
+		t.Fatalf("cycle summary=%+v", got)
 	}
 }
 

--- a/internal/usage/ai_account_status_store_test.go
+++ b/internal/usage/ai_account_status_store_test.go
@@ -78,7 +78,7 @@ func TestUpdateRefreshStatePreservesQuotas(t *testing.T) {
 	}
 }
 
-func TestAuthSubjectUsageDailySameTxProjection(t *testing.T) {
+func TestAIAccountSubjectUsageSameTxProjection(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "usage.db")
 	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
 		t.Fatalf("InitDB: %v", err)
@@ -97,13 +97,20 @@ func TestAuthSubjectUsageDailySameTxProjection(t *testing.T) {
 		true, ts.Add(time.Second), 10, 0, TokenStats{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
 		"", "", "",
 	)
-	sums, err := QueryAuthSubjectUsageSummaries(systemTenantID, []string{subject}, nil)
+	sums, err := QueryAIAccountSubjectUsageSummaries([]string{subject}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	s := sums[subject]
-	if s.RequestTotal30d != 2 || s.SuccessTotal30d != 1 || s.FailureTotal30d != 1 {
+	if s.RequestTotal != 2 || s.RequestTotal30d != 2 || s.SuccessTotal30d != 1 || s.FailureTotal30d != 1 {
 		t.Fatalf("summary=%+v", s)
+	}
+	var legacyRows int64
+	if err := getDB().QueryRow(`SELECT COUNT(*) FROM auth_subject_usage_daily WHERE auth_subject_id = ?`, subject).Scan(&legacyRows); err != nil {
+		t.Fatal(err)
+	}
+	if legacyRows != 0 {
+		t.Fatalf("legacy daily rows=%d want 0", legacyRows)
 	}
 }
 
@@ -293,7 +300,7 @@ func TestStaleRefreshNormalizationPreservesSnapshotPayload(t *testing.T) {
 	}
 }
 
-func TestUsageDailyProjectionUsesConfiguredTimezone(t *testing.T) {
+func TestAIAccountSubjectDayProjectionUsesConfiguredTimezone(t *testing.T) {
 	loc, err := time.LoadLocation("Asia/Singapore")
 	if err != nil {
 		t.Fatal(err)
@@ -313,7 +320,7 @@ func TestUsageDailyProjectionUsesConfiguredTimezone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := projectAuthSubjectUsageDailyTx(tx, systemTenantID, "sub-timezone", false, 1.25, at); err != nil {
+	if err := projectAIAccountSubjectUsageTx(tx, "sub-timezone", false, 1.25, at); err != nil {
 		_ = tx.Rollback()
 		t.Fatal(err)
 	}
@@ -321,7 +328,7 @@ func TestUsageDailyProjectionUsesConfiguredTimezone(t *testing.T) {
 		t.Fatal(err)
 	}
 	var dayKey string
-	if err := getDB().QueryRow(`SELECT day_key FROM auth_subject_usage_daily WHERE tenant_id = ? AND auth_subject_id = ?`, systemTenantID, "sub-timezone").Scan(&dayKey); err != nil {
+	if err := getDB().QueryRow(`SELECT bucket_start FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? AND bucket_kind = 'day'`, "sub-timezone").Scan(&dayKey); err != nil {
 		t.Fatal(err)
 	}
 	if want := at.In(loc).Format("2006-01-02"); dayKey != want {
@@ -452,7 +459,7 @@ func TestStatusReadsUseReadPoolWhileWriterBusy(t *testing.T) {
 			done <- fmt.Errorf("list status unexpected: %+v", rows)
 			return
 		}
-		sums, err := QueryAuthSubjectUsageSummaries(systemTenantID, []string{"sub-readpool"}, nil)
+		sums, err := QueryAIAccountSubjectUsageSummaries([]string{"sub-readpool"}, nil)
 		if err != nil {
 			done <- err
 			return

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -30,6 +30,7 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 	}
 	defer func() { _ = tx.Rollback() }()
 	now := time.Now().UTC()
+	cycles := make([]AIAccountSubjectQuotaCycle, 0, len(points))
 	for _, point := range points {
 		key := strings.TrimSpace(point.QuotaKey)
 		if key == "" {
@@ -67,7 +68,7 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 			if err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle); err != nil {
 				return err
 			}
-			setAIAccountSubjectActiveCycle(cycle)
+			cycles = append(cycles, cycle)
 		}
 		var latestAt sql.NullString
 		var latestPercent sql.NullFloat64
@@ -100,6 +101,9 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 	}
 	if err := tx.Commit(); err != nil {
 		return err
+	}
+	for _, cycle := range cycles {
+		setAIAccountSubjectActiveCycle(cycle)
 	}
 	return nil
 }
@@ -206,15 +210,16 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferred
 	if db == nil || len(ids) == 0 {
 		return out, nil
 	}
-	args := make([]any, 0, len(ids)+len(preferredKeys))
+	args := make([]any, 0, len(ids)+len(preferredKeys)+1)
 	for _, id := range ids {
 		args = append(args, id)
 	}
+	args = append(args, aiAccountSubjectWeeklyWindowSeconds)
 	query := `
 		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
 		FROM ai_account_subject_quota_cycles
 		WHERE auth_subject_id IN (` + strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + `)
-		  AND window_seconds >= 604800`
+		  AND window_seconds >= ?`
 	keys := dedupeExactStrings(preferredKeys)
 	if len(keys) > 0 {
 		query += ` AND quota_key IN (` + strings.TrimSuffix(strings.Repeat("?,", len(keys)), ",") + `)`
@@ -228,6 +233,7 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferred
 		return nil, fmt.Errorf("usage: query shared quota cycles: %w", err)
 	}
 	defer rows.Close()
+	cyclesBySubject := make(map[string][]AIAccountSubjectQuotaCycle)
 	for rows.Next() {
 		var cycle AIAccountSubjectQuotaCycle
 		var start, reset, verified storedTime
@@ -244,11 +250,17 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferred
 			cycle.LastVerifiedAt = verified.Time
 		}
 		setAIAccountSubjectActiveCycle(cycle)
-		if _, exists := out[cycle.AuthSubjectID]; !exists {
-			out[cycle.AuthSubjectID] = cycle.CycleStartAt
+		cyclesBySubject[cycle.AuthSubjectID] = append(cyclesBySubject[cycle.AuthSubjectID], cycle)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for subjectID, cycles := range cyclesBySubject {
+		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
+			out[subjectID] = cycle.CycleStartAt
 		}
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 func loadAIAccountSubjectCycleCache(db *sql.DB) error {
@@ -258,24 +270,19 @@ func loadAIAccountSubjectCycleCache(db *sql.DB) error {
 	}
 	rows, err := db.Query(`
 		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
-		FROM ai_account_subject_quota_cycles WHERE window_seconds > 0
+		FROM ai_account_subject_quota_cycles WHERE window_seconds >= ?
 		ORDER BY last_verified_at DESC
-	`)
+	`, aiAccountSubjectWeeklyWindowSeconds)
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
-	seen := map[string]struct{}{}
 	for rows.Next() {
 		var cycle AIAccountSubjectQuotaCycle
 		var start, reset, verified storedTime
 		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
 			return err
 		}
-		if _, ok := seen[cycle.AuthSubjectID]; ok {
-			continue
-		}
-		seen[cycle.AuthSubjectID] = struct{}{}
 		if start.Valid {
 			cycle.CycleStartAt = start.Time
 		}

--- a/internal/usage/ai_account_subject_store.go
+++ b/internal/usage/ai_account_subject_store.go
@@ -298,8 +298,7 @@ func UpsertAIAccountTenantBinding(auth *coreauth.Auth, identity *AuthSubjectIden
 	if err != nil {
 		return fmt.Errorf("usage: upsert ai account tenant binding: %w", err)
 	}
-	// Low-frequency lifecycle reconciliation may merge old small-table state.
-	return BackfillAIAccountSharedSubject(identity.ID)
+	return nil
 }
 
 func MarkAIAccountTenantBindingDeleted(tenantID, authID string) error {
@@ -601,7 +600,7 @@ func nullableTimeValue(value *time.Time) any {
 }
 
 // BackfillAIAccountSharedSubject merges only existing small projections. It
-// never reads request_logs; detail retention therefore cannot reset card data.
+// never writes cycle usage because legacy daily rows lack exact cycle timestamps.
 func BackfillAIAccountSharedSubject(subjectID string) error {
 	db := getDB()
 	subjectID = strings.TrimSpace(subjectID)
@@ -791,6 +790,8 @@ func backfillSharedLifetimeForSubject(db *sql.DB, subjectID string) error {
 	return err
 }
 
+// backfillSharedQuotaCyclesForSubject migrates cycle definitions only. Cycle
+// usage is projected from requests with exact timestamps.
 func backfillSharedQuotaCyclesForSubject(db *sql.DB, subjectID string) error {
 	rows, err := db.Query(`
 		SELECT provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
@@ -821,7 +822,6 @@ func backfillSharedQuotaCyclesForSubject(db *sql.DB, subjectID string) error {
 	if err := rows.Close(); err != nil {
 		return err
 	}
-	cycleStarts := make(map[string]struct{}, len(batch))
 	for _, row := range batch {
 		startValue, okStart := requiredStoredTimeArg(row.start)
 		resetValue, okReset := requiredStoredTimeArg(row.reset)
@@ -843,21 +843,8 @@ func backfillSharedQuotaCyclesForSubject(db *sql.DB, subjectID string) error {
 		`, subjectID, row.provider, row.key, startValue, resetValue, row.window, verifiedValue); err != nil {
 			return err
 		}
-		cycleStarts[startValue] = struct{}{}
-	}
-	for start := range cycleStarts {
-		if err := backfillSharedCycleUsageForSubject(db, subjectID, start); err != nil {
-			return err
-		}
 	}
 	return nil
-}
-
-func canonicalAIAccountSubjectTime(value string) string {
-	if parsed, ok := parseStoredTimeString(value); ok {
-		return parsed.UTC().Format(time.RFC3339Nano)
-	}
-	return strings.TrimSpace(value)
 }
 
 // nullableStoredTimeArg returns a canonical RFC3339Nano string or nil (SQL NULL).
@@ -880,47 +867,6 @@ func requiredStoredTimeArg(value string) (string, bool) {
 	}
 	s, ok := arg.(string)
 	return s, ok && s != ""
-}
-
-// Current-cycle migration is intentionally estimated from the legacy daily
-// projection. It never scans request_logs, so the first partial day may be
-// conservative until the next full provider cycle starts.
-func backfillSharedCycleUsageForSubject(db *sql.DB, subjectID, cycleStart string) error {
-	startAt, ok := parseStoredTimeString(cycleStart)
-	if !ok {
-		return nil
-	}
-	startDay := startAt.In(getUsageLocation()).Format("2006-01-02")
-	var req, success, failure int64
-	var cost float64
-	var updated sql.NullString
-	if err := db.QueryRow(`
-		SELECT COALESCE(SUM(request_count),0), COALESCE(SUM(success_count),0),
-			COALESCE(SUM(failure_count),0), COALESCE(SUM(cost_total),0), MAX(updated_at)
-		FROM auth_subject_usage_daily
-		WHERE auth_subject_id = ? AND day_key >= ?
-	`, subjectID, startDay).Scan(&req, &success, &failure, &cost, &updated); err != nil {
-		return fmt.Errorf("usage: backfill shared cycle usage: %w", err)
-	}
-	if req == 0 {
-		return nil
-	}
-	updatedValue := nullableStoredTimeArg(updated.String)
-	if updatedValue == nil {
-		updatedValue = cycleStart
-	}
-	_, err := db.Exec(`
-		INSERT INTO ai_account_subject_usage_buckets
-			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
-		VALUES (?, 'cycle', ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
-			request_count = CASE WHEN excluded.request_count > ai_account_subject_usage_buckets.request_count THEN excluded.request_count ELSE ai_account_subject_usage_buckets.request_count END,
-			success_count = CASE WHEN excluded.success_count > ai_account_subject_usage_buckets.success_count THEN excluded.success_count ELSE ai_account_subject_usage_buckets.success_count END,
-			failure_count = CASE WHEN excluded.failure_count > ai_account_subject_usage_buckets.failure_count THEN excluded.failure_count ELSE ai_account_subject_usage_buckets.failure_count END,
-			cost_total = CASE WHEN excluded.cost_total > ai_account_subject_usage_buckets.cost_total THEN excluded.cost_total ELSE ai_account_subject_usage_buckets.cost_total END,
-			updated_at = CASE WHEN excluded.updated_at > ai_account_subject_usage_buckets.updated_at THEN excluded.updated_at ELSE ai_account_subject_usage_buckets.updated_at END
-	`, subjectID, cycleStart, req, success, failure, cost, cycleStart, updatedValue)
-	return err
 }
 
 func backfillSharedQuotaPointsForSubject(db *sql.DB, subjectID string) error {

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -9,33 +9,126 @@ import (
 )
 
 const aiAccountSubjectDayRetention = 400 * 24 * time.Hour
+const aiAccountSubjectWeeklyWindowSeconds = int64(7 * 24 * time.Hour / time.Second)
 
+// Keep every (subject, quota key) cycle so additional weekly windows cannot
+// replace the provider's primary card cycle.
 var sharedCycleCache = struct {
 	sync.RWMutex
-	bySubject map[string]AIAccountSubjectQuotaCycle
-}{bySubject: make(map[string]AIAccountSubjectQuotaCycle)}
+	bySubjectQuota map[string]map[string]AIAccountSubjectQuotaCycle
+}{bySubjectQuota: make(map[string]map[string]AIAccountSubjectQuotaCycle)}
 
 func resetAIAccountSubjectCycleCache() {
 	sharedCycleCache.Lock()
-	sharedCycleCache.bySubject = make(map[string]AIAccountSubjectQuotaCycle)
+	sharedCycleCache.bySubjectQuota = make(map[string]map[string]AIAccountSubjectQuotaCycle)
 	sharedCycleCache.Unlock()
 }
 
 func setAIAccountSubjectActiveCycle(cycle AIAccountSubjectQuotaCycle) {
-	if strings.TrimSpace(cycle.AuthSubjectID) == "" || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() || cycle.WindowSeconds <= 0 {
+	subjectID := strings.TrimSpace(cycle.AuthSubjectID)
+	quotaKey := strings.TrimSpace(cycle.QuotaKey)
+	if subjectID == "" || quotaKey == "" || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() || cycle.WindowSeconds <= 0 {
 		return
 	}
 	sharedCycleCache.Lock()
-	sharedCycleCache.bySubject[cycle.AuthSubjectID] = cycle
+	byQuota := sharedCycleCache.bySubjectQuota[subjectID]
+	if byQuota == nil {
+		byQuota = make(map[string]AIAccountSubjectQuotaCycle)
+		sharedCycleCache.bySubjectQuota[subjectID] = byQuota
+	}
+	byQuota[quotaKey] = cycle
 	sharedCycleCache.Unlock()
 }
 
-func aiAccountSubjectCycleAt(subjectID string, at time.Time) (AIAccountSubjectQuotaCycle, bool) {
+func primaryAIAccountSubjectWeeklyQuotaKey(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return "seven_day"
+	case "codex", "kimi":
+		return "code_week"
+	case "xai", "grok":
+		return "weekly_limit"
+	default:
+		return ""
+	}
+}
+
+func selectAIAccountSubjectWeeklyCycle(cycles []AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, bool) {
+	var selected AIAccountSubjectQuotaCycle
+	for _, cycle := range cycles {
+		if cycle.WindowSeconds < aiAccountSubjectWeeklyWindowSeconds || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() {
+			continue
+		}
+		primaryKey := primaryAIAccountSubjectWeeklyQuotaKey(cycle.Provider)
+		if primaryKey != "" && strings.TrimSpace(cycle.QuotaKey) != primaryKey {
+			continue
+		}
+		if selected.AuthSubjectID == "" || cycle.LastVerifiedAt.After(selected.LastVerifiedAt) {
+			selected = cycle
+		}
+	}
+	return selected, selected.AuthSubjectID != ""
+}
+
+func cachedAIAccountSubjectWeeklyCycle(subjectID string) (AIAccountSubjectQuotaCycle, bool) {
+	subjectID = strings.TrimSpace(subjectID)
+	cycles := make([]AIAccountSubjectQuotaCycle, 0)
 	sharedCycleCache.RLock()
-	cycle, ok := sharedCycleCache.bySubject[strings.TrimSpace(subjectID)]
+	for _, cycle := range sharedCycleCache.bySubjectQuota[subjectID] {
+		cycles = append(cycles, cycle)
+	}
 	sharedCycleCache.RUnlock()
-	if !ok || cycle.WindowSeconds <= 0 || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() {
-		return AIAccountSubjectQuotaCycle{}, false
+	return selectAIAccountSubjectWeeklyCycle(cycles)
+}
+
+func loadAIAccountSubjectWeeklyCycleTx(tx *sql.Tx, subjectID string) (AIAccountSubjectQuotaCycle, bool, error) {
+	rows, err := tx.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND window_seconds >= ?
+		ORDER BY last_verified_at DESC, reset_at DESC
+	`, subjectID, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return AIAccountSubjectQuotaCycle{}, false, fmt.Errorf("usage: load shared subject quota cycle: %w", err)
+	}
+	defer rows.Close()
+	cycles := make([]AIAccountSubjectQuotaCycle, 0)
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			return AIAccountSubjectQuotaCycle{}, false, err
+		}
+		if start.Valid {
+			cycle.CycleStartAt = start.Time
+		}
+		if reset.Valid {
+			cycle.ResetAt = reset.Time
+		}
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time
+		}
+		setAIAccountSubjectActiveCycle(cycle)
+		cycles = append(cycles, cycle)
+	}
+	if err := rows.Err(); err != nil {
+		return AIAccountSubjectQuotaCycle{}, false, err
+	}
+	cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles)
+	return cycle, ok, nil
+}
+
+func aiAccountSubjectCycleAt(tx *sql.Tx, subjectID string, at time.Time) (AIAccountSubjectQuotaCycle, bool, error) {
+	cycle, ok := cachedAIAccountSubjectWeeklyCycle(subjectID)
+	if !ok {
+		var err error
+		cycle, ok, err = loadAIAccountSubjectWeeklyCycleTx(tx, strings.TrimSpace(subjectID))
+		if err != nil {
+			return AIAccountSubjectQuotaCycle{}, false, err
+		}
+	}
+	if !ok {
+		return AIAccountSubjectQuotaCycle{}, false, nil
 	}
 	at = at.UTC()
 	window := time.Duration(cycle.WindowSeconds) * time.Second
@@ -43,7 +136,11 @@ func aiAccountSubjectCycleAt(subjectID string, at time.Time) (AIAccountSubjectQu
 		cycle.CycleStartAt = cycle.ResetAt
 		cycle.ResetAt = cycle.ResetAt.Add(window)
 	}
-	return cycle, !at.Before(cycle.CycleStartAt)
+	return cycle, !at.Before(cycle.CycleStartAt), nil
+}
+
+func formatAIAccountSubjectCycleBucketStart(value time.Time) string {
+	return value.UTC().Format(time.RFC3339Nano)
 }
 
 // projectAIAccountSubjectUsageTx is the request-hot B-layer projection. It only
@@ -74,8 +171,12 @@ func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed boo
 		{kind: "day", start: at.In(loc).Format("2006-01-02")},
 		{kind: "lifetime", start: rollupLifetimeStart},
 	}
-	if cycle, ok := aiAccountSubjectCycleAt(authSubjectID, at); ok {
-		buckets = append(buckets, struct{ kind, start string }{kind: "cycle", start: cycle.CycleStartAt.UTC().Format(time.RFC3339Nano)})
+	cycle, cycleKnown, err := aiAccountSubjectCycleAt(tx, authSubjectID, at)
+	if err != nil {
+		return err
+	}
+	if cycleKnown {
+		buckets = append(buckets, struct{ kind, start string }{kind: "cycle", start: formatAIAccountSubjectCycleBucketStart(cycle.CycleStartAt)})
 	}
 	const upsert = `
 		INSERT INTO ai_account_subject_usage_buckets (
@@ -268,7 +369,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 		if _, ok := out[id]; !ok || start.IsZero() {
 			continue
 		}
-		startKey := start.UTC().Format(time.RFC3339Nano)
+		startKey := formatAIAccountSubjectCycleBucketStart(start)
 		s := out[id]
 		s.CycleKnown = true
 		s.CycleStart = start.UTC().Format(time.RFC3339)
@@ -310,7 +411,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 			return nil, err
 		}
 		expected, ok := cycleStartBySubject[id]
-		if !ok || bucketStart != expected.UTC().Format(time.RFC3339Nano) {
+		if !ok || bucketStart != formatAIAccountSubjectCycleBucketStart(expected) {
 			continue
 		}
 		s := out[id]

--- a/internal/usage/api_key_permission_profiles_db.go
+++ b/internal/usage/api_key_permission_profiles_db.go
@@ -15,6 +15,7 @@ import (
 const apiKeyPermissionProfilesMigrationBackupSuffix = ".pre-api-key-permission-profiles-sqlite-migration"
 
 type APIKeyPermissionProfileRow = sqlapikey.PermissionProfileRow
+type APIKeyPermissionProfileSyncResult = sqlapikey.PermissionProfileSyncResult
 
 func initAPIKeyPermissionProfilesTable(db *sql.DB) {
 	sqlapikey.InitPermissionProfilesTable(db)
@@ -46,6 +47,10 @@ func ReplaceAllAPIKeyPermissionProfilesForTenant(tenantID string, profiles []API
 
 func ReplaceAllAPIKeyPermissionProfilesForTenantAndSyncEndUsers(tenantID string, profiles []APIKeyPermissionProfileRow) (int64, error) {
 	return apiKeyPermissionProfileStoreForTenant(tenantID).ReplaceAllPermissionProfilesAndSyncEndUsers(profiles)
+}
+
+func ReplaceAllAPIKeyPermissionProfilesForTenantWithCaps(tenantID string, profiles []APIKeyPermissionProfileRow, syncEndUsers bool) (sqlapikey.PermissionProfileSyncResult, error) {
+	return apiKeyPermissionProfileStoreForTenant(tenantID).ReplaceAllPermissionProfilesWithCaps(profiles, syncEndUsers)
 }
 
 func MigrateAPIKeyPermissionProfilesFromYAML(configFilePath string) int {

--- a/internal/usage/apikey_db.go
+++ b/internal/usage/apikey_db.go
@@ -250,6 +250,7 @@ func toPermissionProfileSnapshots(profiles []APIKeyPermissionProfileRow) []sqlap
 			DailyLimit:           profile.DailyLimit,
 			TotalQuota:           profile.TotalQuota,
 			DailySpendingLimit:   profile.DailySpendingLimit,
+			PeriodSpendingLimits: profile.PeriodSpendingLimits,
 			ConcurrencyLimit:     profile.ConcurrencyLimit,
 			RPMLimit:             profile.RPMLimit,
 			TPMLimit:             profile.TPMLimit,

--- a/internal/usage/auth_subject_usage_daily.go
+++ b/internal/usage/auth_subject_usage_daily.go
@@ -33,58 +33,6 @@ type AuthSubjectUsageSummary struct {
 	UpdatedAt         time.Time  `json:"updated_at,omitempty"`
 }
 
-// commitLogWithAuthSubjectUsageDaily projects daily card counters then commits the request_log tx.
-func commitLogWithAuthSubjectUsageDaily(tx *sql.Tx, tenantID, authSubjectID string, failed bool, cost float64, at time.Time) error {
-	if authSubjectID != "" {
-		if err := projectAuthSubjectUsageDailyTx(tx, tenantID, authSubjectID, failed, cost, at); err != nil {
-			_ = tx.Rollback()
-			return fmt.Errorf("project auth subject usage daily: %w", err)
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// projectAuthSubjectUsageDailyTx increments the day projection inside the request_log write tx.
-func projectAuthSubjectUsageDailyTx(tx *sql.Tx, tenantID, authSubjectID string, failed bool, cost float64, at time.Time) error {
-	if tx == nil {
-		return nil
-	}
-	tenantID = normalizeTenantID(tenantID)
-	authSubjectID = strings.TrimSpace(authSubjectID)
-	if authSubjectID == "" {
-		return nil
-	}
-	if at.IsZero() {
-		at = time.Now()
-	}
-	// Avoid getUsageLocation() lock: may run under InitDB which already holds usageDBMu.
-	loc := usageLoc
-	if loc == nil {
-		loc = time.Local
-	}
-	dayKey := localDayKeyAtLocation(at, loc)
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	successInc, failureInc := int64(1), int64(0)
-	if failed {
-		successInc, failureInc = 0, 1
-	}
-	_, err := tx.Exec(`
-		INSERT INTO auth_subject_usage_daily (
-			tenant_id, auth_subject_id, day_key, request_count, success_count, failure_count, cost_total, updated_at
-		) VALUES (?, ?, ?, 1, ?, ?, ?, ?)
-		ON CONFLICT(tenant_id, auth_subject_id, day_key) DO UPDATE SET
-			request_count = auth_subject_usage_daily.request_count + 1,
-			success_count = auth_subject_usage_daily.success_count + excluded.success_count,
-			failure_count = auth_subject_usage_daily.failure_count + excluded.failure_count,
-			cost_total = auth_subject_usage_daily.cost_total + excluded.cost_total,
-			updated_at = excluded.updated_at
-	`, tenantID, authSubjectID, dayKey, successInc, failureInc, cost, now)
-	return err
-}
-
 func ensureUsageProjectionMarkerTable(db *sql.DB) {
 	if db == nil {
 		return

--- a/internal/usage/enduser_account_usage_test.go
+++ b/internal/usage/enduser_account_usage_test.go
@@ -85,11 +85,14 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 	setupEndUserAccountUsageTestDB(t)
 
 	tenantID := uuid.NewString()
+	otherTenantID := uuid.NewString()
 	endUserID := uuid.NewString()
 	otherUserID := uuid.NewString()
 	keyAID := uuid.NewString()
 	keyBID := uuid.NewString()
 	otherKeyID := uuid.NewString()
+	crossTenantKeyID := uuid.NewString()
+	standaloneKeyID := uuid.NewString()
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	if _, err := getDB().Exec(`INSERT INTO end_users (id, tenant_id, display_name) VALUES (?, ?, ?)`, endUserID, tenantID, "Zhang Bolun"); err != nil {
@@ -99,10 +102,16 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 		{ID: keyAID, Key: "sk-business-a", Name: "Automation", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
 		{ID: keyBID, Key: "sk-business-b", Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
 		{ID: otherKeyID, Key: "sk-business-other", Name: "Other", EndUserID: otherUserID, CreatedAt: now, UpdatedAt: now},
+		{ID: standaloneKeyID, Key: "sk-business-standalone", Name: "Standalone", CreatedAt: now, UpdatedAt: now},
 	} {
 		if err := UpsertAPIKeyForTenant(tenantID, row); err != nil {
 			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
 		}
+	}
+	if err := UpsertAPIKeyForTenant(otherTenantID, APIKeyRow{
+		ID: crossTenantKeyID, Key: "sk-business-cross-tenant", Name: "Cross tenant", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertAPIKeyForTenant(cross tenant): %v", err)
 	}
 
 	if row := GetAPIKey("sk-business-a"); row == nil || row.TenantID != tenantID || row.ID != keyAID {
@@ -121,6 +130,8 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 	insertEndUserAccountLog(t, tenantID, "sk-business-b", keyBID, "old snapshot", 2)
 	insertEndUserAccountLog(t, tenantID, "sk-business-b", "", "legacy snapshot", 3)
 	insertEndUserAccountLog(t, tenantID, "sk-business-other", otherKeyID, "other", 50)
+	insertEndUserAccountLog(t, tenantID, "sk-business-standalone", standaloneKeyID, "standalone", 60)
+	insertEndUserAccountLog(t, otherTenantID, "sk-business-cross-tenant", crossTenantKeyID, "cross tenant", 70)
 
 	params := LogQueryParams{TenantID: tenantID, EndUserID: endUserID, Page: 1, Size: 20, Days: 1}
 	result, err := QueryLogs(params)
@@ -152,9 +163,46 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 	if chart.Stats.Total != 3 || chart.Stats.TotalCost != 6 {
 		t.Fatalf("public chart stats = %+v, want total=3 cost=6", chart.Stats)
 	}
+	distributionByID := make(map[string]PublicAPIKeyDistributionPoint, len(chart.APIKeyDistribution))
+	for _, point := range chart.APIKeyDistribution {
+		distributionByID[point.APIKeyID] = point
+	}
+	if len(distributionByID) != 2 {
+		t.Fatalf("api key distribution = %+v, want exactly key A and key B", chart.APIKeyDistribution)
+	}
+	if point := distributionByID[keyAID]; point.Name != "Automation" || point.Requests != 1 || point.Tokens != 2 {
+		t.Fatalf("key A distribution = %+v, want own name and requests/tokens 1/2", point)
+	}
+	if point := distributionByID[keyBID]; point.Name != "Laptop" || point.Requests != 1 || point.Tokens != 2 {
+		t.Fatalf("key B distribution = %+v, want stable-id rollup only and requests/tokens 1/2", point)
+	}
+	if _, exists := distributionByID[otherKeyID]; exists {
+		t.Fatalf("api key distribution included other end user: %+v", chart.APIKeyDistribution)
+	}
+	if _, exists := distributionByID[crossTenantKeyID]; exists {
+		t.Fatalf("api key distribution included other tenant: %+v", chart.APIKeyDistribution)
+	}
+	if _, exists := distributionByID[standaloneKeyID]; exists {
+		t.Fatalf("api key distribution included standalone key: %+v", chart.APIKeyDistribution)
+	}
+
+	emptyChart, err := QueryPublicChartDataForEndUser(tenantID, uuid.NewString(), 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartDataForEndUser(empty): %v", err)
+	}
+	if emptyChart.APIKeyDistribution == nil || len(emptyChart.APIKeyDistribution) != 0 {
+		t.Fatalf("empty api key distribution = %#v, want non-nil []", emptyChart.APIKeyDistribution)
+	}
+	standaloneChart, err := QueryPublicChartData("sk-business-standalone", 7)
+	if err != nil {
+		t.Fatalf("QueryPublicChartData(standalone): %v", err)
+	}
+	if standaloneChart.APIKeyDistribution == nil || len(standaloneChart.APIKeyDistribution) != 0 {
+		t.Fatalf("standalone api key distribution = %#v, want non-nil []", standaloneChart.APIKeyDistribution)
+	}
 
 	// Rotate changes only the secret. Stable-id rows remain in the account selector.
-	if _, err := getDB().Exec(`UPDATE api_keys SET key = ?, updated_at = ? WHERE tenant_id = ? AND id = ?`, "sk-business-a-rotated", now, tenantID, keyAID); err != nil {
+	if _, err := getDB().Exec(`UPDATE api_keys SET key = ?, name = ?, updated_at = ? WHERE tenant_id = ? AND id = ?`, "sk-business-a-rotated", "Automation Renamed", now, tenantID, keyAID); err != nil {
 		t.Fatalf("rotate key A: %v", err)
 	}
 	if row := GetAPIKey("sk-business-a-rotated"); row == nil || row.ID != keyAID {
@@ -173,6 +221,13 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 	}
 	if rotatedChart.Stats.Total != 3 || rotatedChart.Stats.TotalCost != 6 {
 		t.Fatalf("chart after rotate = %+v, want total=3 cost=6", rotatedChart.Stats)
+	}
+	rotatedDistributionByID := make(map[string]PublicAPIKeyDistributionPoint, len(rotatedChart.APIKeyDistribution))
+	for _, point := range rotatedChart.APIKeyDistribution {
+		rotatedDistributionByID[point.APIKeyID] = point
+	}
+	if point := rotatedDistributionByID[keyAID]; point.Name != "Automation Renamed" || point.Requests != 1 || point.Tokens != 2 {
+		t.Fatalf("rotated key distribution = %+v, want stable history with current own name", point)
 	}
 }
 

--- a/internal/usage/enduser_account_usage_test.go
+++ b/internal/usage/enduser_account_usage_test.go
@@ -112,8 +112,8 @@ func TestEndUserAccountUsageAggregatesBusinessTenantKeysAndSurvivesRotate(t *tes
 		t.Fatalf("GetAPIKeyByID = %#v, want business-tenant key B", row)
 	}
 	expanded := ExpandPublicLookupAPIKeys("sk-business-a")
-	if len(expanded) != 2 || !containsString(expanded, "sk-business-a") || !containsString(expanded, "sk-business-b") {
-		t.Fatalf("ExpandPublicLookupAPIKeys = %v, want both owned keys", expanded)
+	if len(expanded) != 1 || expanded[0] != "sk-business-a" {
+		t.Fatalf("ExpandPublicLookupAPIKeys = %v, want [sk-business-a] only", expanded)
 	}
 
 	// Modern rows match stable key ids; the legacy row matches the current raw secret.

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
 )
 
 // EndUserQuota is the account-level limit/permission snapshot used by auth + quota.
@@ -19,6 +21,7 @@ type EndUserQuota struct {
 	TotalQuota           int
 	SpendingLimit        float64
 	DailySpendingLimit   float64
+	PeriodSpendingLimits quota.PeriodSpendingLimits
 	ConcurrencyLimit     int
 	RPMLimit             int
 	TPMLimit             int
@@ -56,6 +59,7 @@ func GetEndUserQuota(endUserID string) *EndUserQuota {
 		SELECT id, tenant_id, display_name, COALESCE(status, 'active'),
 			COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
 			COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+			COALESCE(five_hour_spending_limit, 0), COALESCE(weekly_spending_limit, 0), COALESCE(monthly_spending_limit, 0),
 			COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
 			COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
 			COALESCE(system_prompt, '')
@@ -64,12 +68,30 @@ func GetEndUserQuota(endUserID string) *EndUserQuota {
 		&q.ID, &q.TenantID, &q.DisplayName, &q.Status,
 		&q.PermissionProfileID, &q.DailyLimit, &q.TotalQuota,
 		&q.SpendingLimit, &q.DailySpendingLimit,
-		&q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
+		&q.PeriodSpendingLimits.FiveHour, &q.PeriodSpendingLimits.Week, &q.PeriodSpendingLimits.Month, &q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
 		&modelsJSON, &channelsJSON, &groupsJSON, &q.SystemPrompt,
 	)
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "no such column") {
+		err = db.QueryRow(`
+			SELECT id, tenant_id, display_name, COALESCE(status, 'active'),
+				COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
+				COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+				COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
+				COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
+				COALESCE(system_prompt, '')
+			FROM end_users WHERE id = ?
+		`, endUserID).Scan(
+			&q.ID, &q.TenantID, &q.DisplayName, &q.Status,
+			&q.PermissionProfileID, &q.DailyLimit, &q.TotalQuota,
+			&q.SpendingLimit, &q.DailySpendingLimit,
+			&q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
+			&modelsJSON, &channelsJSON, &groupsJSON, &q.SystemPrompt,
+		)
+	}
 	if err != nil {
 		return nil
 	}
+	q.PeriodSpendingLimits.Day = q.DailySpendingLimit
 	q.AllowedModels = decodeQuotaStringList(modelsJSON)
 	q.AllowedChannels = decodeQuotaStringList(channelsJSON)
 	q.AllowedChannelGroups = decodeQuotaStringList(groupsJSON)
@@ -78,30 +100,7 @@ func GetEndUserQuota(endUserID string) *EndUserQuota {
 
 // EffectiveEndUserQuota merges a permission profile over the end-user row when set.
 func EffectiveEndUserQuota(q EndUserQuota) EndUserQuota {
-	profileID := strings.TrimSpace(q.PermissionProfileID)
-	if profileID == "" {
-		return q
-	}
-	profiles := ListAPIKeyPermissionProfilesForTenant(q.TenantID)
-	for _, profile := range profiles {
-		if strings.TrimSpace(profile.ID) != profileID {
-			continue
-		}
-		q.PermissionProfileID = profileID
-		q.DailyLimit = profile.DailyLimit
-		q.TotalQuota = profile.TotalQuota
-		q.SpendingLimit = 0
-		q.DailySpendingLimit = profile.DailySpendingLimit
-		q.ConcurrencyLimit = profile.ConcurrencyLimit
-		q.RPMLimit = profile.RPMLimit
-		q.TPMLimit = profile.TPMLimit
-		q.AllowedModels = append([]string(nil), profile.AllowedModels...)
-		q.AllowedChannels = append([]string(nil), profile.AllowedChannels...)
-		q.AllowedChannelGroups = append([]string(nil), profile.AllowedChannelGroups...)
-		q.SystemPrompt = profile.SystemPrompt
-		return q
-	}
-	return q
+	return EffectiveEndUserQuotaWithProfiles(q, ListAPIKeyPermissionProfilesForTenant(q.TenantID))
 }
 
 // ListAPIKeyIDsForEndUser returns stable key ids owned by the end user.
@@ -320,6 +319,9 @@ func EnsureEndUserQuotaColumns(db *sql.DB) error {
 		{"total_quota", "INTEGER NOT NULL DEFAULT 0"},
 		{"spending_limit", "REAL NOT NULL DEFAULT 0"},
 		{"daily_spending_limit", "REAL NOT NULL DEFAULT 0"},
+		{"five_hour_spending_limit", "REAL NOT NULL DEFAULT 0"},
+		{"weekly_spending_limit", "REAL NOT NULL DEFAULT 0"},
+		{"monthly_spending_limit", "REAL NOT NULL DEFAULT 0"},
 		{"concurrency_limit", "INTEGER NOT NULL DEFAULT 0"},
 		{"rpm_limit", "INTEGER NOT NULL DEFAULT 0"},
 		{"tpm_limit", "INTEGER NOT NULL DEFAULT 0"},
@@ -340,4 +342,90 @@ func EnsureEndUserQuotaColumns(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+// ListEndUserQuotasByIDs batch-loads account quota rows for provider cache rebuilds.
+func ListEndUserQuotasByIDs(endUserIDs []string) (map[string]EndUserQuota, error) {
+	db := getReadDB()
+	if db == nil {
+		return nil, fmt.Errorf("usage: end user quota database unavailable")
+	}
+	ids := dedupeExactStrings(endUserIDs)
+	out := make(map[string]EndUserQuota, len(ids))
+	const chunkSize = 400
+	for start := 0; start < len(ids); start += chunkSize {
+		end := start + chunkSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+		rows, err := db.Query(`
+			SELECT id, tenant_id, display_name, COALESCE(status, 'active'),
+				COALESCE(permission_profile_id, ''), COALESCE(daily_limit, 0), COALESCE(total_quota, 0),
+				COALESCE(spending_limit, 0), COALESCE(daily_spending_limit, 0),
+				COALESCE(five_hour_spending_limit, 0), COALESCE(weekly_spending_limit, 0), COALESCE(monthly_spending_limit, 0),
+				COALESCE(concurrency_limit, 0), COALESCE(rpm_limit, 0), COALESCE(tpm_limit, 0),
+				COALESCE(allowed_models, '[]'), COALESCE(allowed_channels, '[]'), COALESCE(allowed_channel_groups, '[]'),
+				COALESCE(system_prompt, '')
+			FROM end_users WHERE id IN (`+placeholders(len(chunk))+`)`, stringsToAny(chunk)...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var q EndUserQuota
+			var modelsJSON, channelsJSON, groupsJSON string
+			if err := rows.Scan(&q.ID, &q.TenantID, &q.DisplayName, &q.Status,
+				&q.PermissionProfileID, &q.DailyLimit, &q.TotalQuota, &q.SpendingLimit, &q.DailySpendingLimit,
+				&q.PeriodSpendingLimits.FiveHour, &q.PeriodSpendingLimits.Week, &q.PeriodSpendingLimits.Month,
+				&q.ConcurrencyLimit, &q.RPMLimit, &q.TPMLimit,
+				&modelsJSON, &channelsJSON, &groupsJSON, &q.SystemPrompt); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			q.PeriodSpendingLimits.Day = q.DailySpendingLimit
+			q.AllowedModels = decodeQuotaStringList(modelsJSON)
+			q.AllowedChannels = decodeQuotaStringList(channelsJSON)
+			q.AllowedChannelGroups = decodeQuotaStringList(groupsJSON)
+			out[q.ID] = q
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func stringsToAny(values []string) []any {
+	out := make([]any, len(values))
+	for i := range values {
+		out[i] = values[i]
+	}
+	return out
+}
+
+func EffectiveEndUserQuotaWithProfiles(q EndUserQuota, profiles []APIKeyPermissionProfileRow) EndUserQuota {
+	profileID := strings.TrimSpace(q.PermissionProfileID)
+	if profileID == "" {
+		return q
+	}
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.ID) != profileID {
+			continue
+		}
+		q.PermissionProfileID = profileID
+		q.DailyLimit = profile.DailyLimit
+		q.TotalQuota = profile.TotalQuota
+		q.DailySpendingLimit = profile.DailySpendingLimit
+		q.PeriodSpendingLimits = profile.PeriodSpendingLimits
+		q.PeriodSpendingLimits.Day = q.DailySpendingLimit
+		q.ConcurrencyLimit = profile.ConcurrencyLimit
+		q.RPMLimit = profile.RPMLimit
+		q.TPMLimit = profile.TPMLimit
+		q.AllowedModels = append([]string(nil), profile.AllowedModels...)
+		q.AllowedChannels = append([]string(nil), profile.AllowedChannels...)
+		q.AllowedChannelGroups = append([]string(nil), profile.AllowedChannelGroups...)
+		q.SystemPrompt = profile.SystemPrompt
+		return q
+	}
+	return q
 }

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -155,33 +155,20 @@ func ListAPIKeySecretsForEndUserForTenant(tenantID, endUserID string) []string {
 	return listAPIKeyValuesForEndUser(tenantID, endUserID, "key")
 }
 
-// ExpandPublicLookupAPIKeys expands a presented API key into the full account key pool
-// when the key is owned by an end user (shared quota / portal multi-key).
-// Standalone keys and unknown secrets stay single-key.
+// ExpandPublicLookupAPIKeys returns the presented API key only.
+// Account-wide multi-key views use portal EndUserID auth, not raw-secret expansion.
 func ExpandPublicLookupAPIKeys(apiKey string) []string {
 	trimmed := strings.TrimSpace(apiKey)
 	if trimmed == "" {
 		return nil
 	}
 	row := GetAPIKey(trimmed)
-	if row == nil {
-		return []string{trimmed}
-	}
-	endUserID := strings.TrimSpace(row.EndUserID)
-	if endUserID == "" {
+	if row != nil {
 		if k := strings.TrimSpace(row.Key); k != "" {
 			return []string{k}
 		}
-		return []string{trimmed}
 	}
-	secrets := ListAPIKeySecretsForEndUserForTenant(row.TenantID, endUserID)
-	if len(secrets) == 0 {
-		if k := strings.TrimSpace(row.Key); k != "" {
-			return []string{k}
-		}
-		return []string{trimmed}
-	}
-	return secrets
+	return []string{trimmed}
 }
 
 // ResolveAPIKeyOwnName returns the key's own name (not end-user account display name).

--- a/internal/usage/enduser_quota_test.go
+++ b/internal/usage/enduser_quota_test.go
@@ -174,15 +174,8 @@ func TestExpandPublicLookupAPIKeys_AggregatesOwnedKeys(t *testing.T) {
 	}
 
 	got := ExpandPublicLookupAPIKeys("sk-a")
-	if len(got) != 2 {
-		t.Fatalf("owned expand len=%d keys=%v, want 2", len(got), got)
-	}
-	set := map[string]bool{}
-	for _, k := range got {
-		set[k] = true
-	}
-	if !set["sk-a"] || !set["sk-b"] {
-		t.Fatalf("owned expand = %v, want sk-a and sk-b", got)
+	if len(got) != 1 || got[0] != "sk-a" {
+		t.Fatalf("owned expand = %v, want [sk-a] only (raw secret is key-scoped)", got)
 	}
 
 	solo := ExpandPublicLookupAPIKeys("sk-solo")

--- a/internal/usage/period_spending.go
+++ b/internal/usage/period_spending.go
@@ -1,0 +1,240 @@
+package usage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
+
+var ErrQuotaUsageUnavailable = errors.New("quota usage unavailable")
+
+type periodSubject string
+
+const (
+	periodSubjectAPIKey  periodSubject = "api_key_id"
+	periodSubjectEndUser periodSubject = "end_user_id"
+)
+
+type PeriodWindowKeys struct {
+	FiveHourFrom string
+	FiveHourTo   string
+	Day          string
+	WeekFrom     string
+	MonthFrom    string
+	DayTo        string
+}
+
+func PeriodWindowKeysAt(now time.Time, loc *time.Location) PeriodWindowKeys {
+	if loc == nil {
+		loc = time.Local
+	}
+	nowMinute := now.UTC().Truncate(time.Minute)
+	localNow := now.In(loc)
+	localMidnight := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, loc)
+	weekdayOffset := (int(localMidnight.Weekday()) + 6) % 7
+	weekStart := localMidnight.AddDate(0, 0, -weekdayOffset)
+	monthStart := time.Date(localNow.Year(), localNow.Month(), 1, 0, 0, 0, 0, loc)
+	return PeriodWindowKeys{
+		FiveHourFrom: nowMinute.Add(-5 * time.Hour).Format("2006-01-02T15:04"),
+		FiveHourTo:   nowMinute.Add(time.Minute).Format("2006-01-02T15:04"),
+		Day:          localDayKeyAtLocation(now, loc),
+		WeekFrom:     localDayKeyAtLocation(weekStart, loc),
+		MonthFrom:    localDayKeyAtLocation(monthStart, loc),
+		DayTo:        localDayKeyAtLocation(localMidnight.AddDate(0, 0, 1), loc),
+	}
+}
+
+func QueryPeriodSpendingByAPIKeyIDForTenant(tenantID, apiKeyID string) (quota.PeriodSpendingUsage, error) {
+	values, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(tenantID, []string{apiKeyID}, time.Now())
+	if err != nil {
+		return quota.PeriodSpendingUsage{}, err
+	}
+	return values[strings.TrimSpace(apiKeyID)], nil
+}
+
+func QueryPeriodSpendingByEndUserForTenant(tenantID, endUserID string) (quota.PeriodSpendingUsage, error) {
+	values, err := QueryPeriodSpendingByEndUsersForTenantAt(tenantID, []string{endUserID}, time.Now())
+	if err != nil {
+		return quota.PeriodSpendingUsage{}, err
+	}
+	return values[strings.TrimSpace(endUserID)], nil
+}
+
+func QueryPeriodSpendingByAPIKeyIDsForTenantAt(tenantID string, apiKeyIDs []string, now time.Time) (map[string]quota.PeriodSpendingUsage, error) {
+	return queryPeriodSpendingForSubjects(tenantID, periodSubjectAPIKey, apiKeyIDs, now)
+}
+
+func QueryPeriodSpendingByEndUsersForTenantAt(tenantID string, endUserIDs []string, now time.Time) (map[string]quota.PeriodSpendingUsage, error) {
+	return queryPeriodSpendingForSubjects(tenantID, periodSubjectEndUser, endUserIDs, now)
+}
+
+func QueryPeriodSpendingByAPIKeyIDsForTenant(tenantID string, apiKeyIDs []string) (map[string]quota.PeriodSpendingUsage, error) {
+	return QueryPeriodSpendingByAPIKeyIDsForTenantAt(tenantID, apiKeyIDs, time.Now())
+}
+
+func QueryPeriodSpendingByEndUsersForTenant(tenantID string, endUserIDs []string) (map[string]quota.PeriodSpendingUsage, error) {
+	return QueryPeriodSpendingByEndUsersForTenantAt(tenantID, endUserIDs, time.Now())
+}
+
+func queryPeriodSpendingForSubjects(tenantID string, subject periodSubject, ids []string, now time.Time) (map[string]quota.PeriodSpendingUsage, error) {
+	ids = dedupeExactStrings(ids)
+	out := make(map[string]quota.PeriodSpendingUsage, len(ids))
+	for _, id := range ids {
+		if id = strings.TrimSpace(id); id != "" {
+			out[id] = quota.PeriodSpendingUsage{}
+		}
+	}
+	if len(out) == 0 {
+		return out, nil
+	}
+	const subjectChunkSize = 300
+	if len(out) > subjectChunkSize {
+		cleanIDs := make([]string, 0, len(out))
+		for id := range out {
+			cleanIDs = append(cleanIDs, id)
+		}
+		combined := make(map[string]quota.PeriodSpendingUsage, len(cleanIDs))
+		for start := 0; start < len(cleanIDs); start += subjectChunkSize {
+			end := start + subjectChunkSize
+			if end > len(cleanIDs) {
+				end = len(cleanIDs)
+			}
+			part, err := queryPeriodSpendingForSubjects(tenantID, subject, cleanIDs[start:end], now)
+			if err != nil {
+				return nil, err
+			}
+			for id, used := range part {
+				combined[id] = used
+			}
+		}
+		return combined, nil
+	}
+	ids = ids[:0]
+	for id := range out {
+		ids = append(ids, id)
+	}
+	windows := PeriodWindowKeysAt(now, getUsageLocation())
+	queries := []struct {
+		kind string
+		from string
+		to   string
+		set  func(*quota.PeriodSpendingUsage, float64)
+	}{
+		{rollupBucketQuotaMinuteUTC, windows.FiveHourFrom, windows.FiveHourTo, func(v *quota.PeriodSpendingUsage, n float64) { v.FiveHour = n }},
+		{rollupBucketDay, windows.Day, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Day = n }},
+		{rollupBucketDay, windows.WeekFrom, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Week = n }},
+		{rollupBucketDay, windows.MonthFrom, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Month = n }},
+		{rollupBucketLifetime, "", "", func(v *quota.PeriodSpendingUsage, n float64) { v.Lifetime = n }},
+	}
+	for _, query := range queries {
+		values, err := queryGroupedPeriodCost(tenantID, subject, ids, query.kind, query.from, query.to)
+		if err != nil {
+			return nil, err
+		}
+		for id, value := range values {
+			current := out[id]
+			query.set(&current, value)
+			out[id] = current
+		}
+	}
+
+	var baselines map[string]float64
+	var err error
+	if subject == periodSubjectAPIKey {
+		baselines, err = ListDailySpendingResetBaselines(tenantID, ids)
+	} else {
+		baselines, err = listEndUserDailySpendingResetBaselines(tenantID, ids, windows.Day)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: day baselines: %v", ErrQuotaUsageUnavailable, err)
+	}
+	for id, baseline := range baselines {
+		current := out[id]
+		current.Day -= baseline
+		if current.Day < 0 {
+			current.Day = 0
+		}
+		out[id] = current
+	}
+	return out, nil
+}
+
+func queryGroupedPeriodCost(tenantID string, subject periodSubject, ids []string, kind, from, to string) (map[string]float64, error) {
+	db := getReadDB()
+	if db == nil {
+		return nil, ErrQuotaUsageUnavailable
+	}
+	column := string(subject)
+	if subject != periodSubjectAPIKey && subject != periodSubjectEndUser {
+		return nil, fmt.Errorf("%w: invalid subject", ErrQuotaUsageUnavailable)
+	}
+	var b strings.Builder
+	b.WriteString(`SELECT ` + column + `, COALESCE(SUM(cost_total), 0) FROM usage_rollup_buckets WHERE tenant_id = ? AND bucket_kind = ? AND ` + column + ` IN (` + placeholders(len(ids)) + `)`)
+	args := make([]any, 0, len(ids)+4)
+	args = append(args, normalizeTenantID(tenantID), kind)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	if from != "" {
+		b.WriteString(` AND bucket_start >= ?`)
+		args = append(args, from)
+	}
+	if to != "" {
+		b.WriteString(` AND bucket_start < ?`)
+		args = append(args, to)
+	}
+	b.WriteString(` GROUP BY ` + column)
+	rows, err := db.Query(b.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: query %s %s: %v", ErrQuotaUsageUnavailable, subject, kind, err)
+	}
+	defer rows.Close()
+	out := make(map[string]float64, len(ids))
+	for rows.Next() {
+		var id string
+		var value float64
+		if err := rows.Scan(&id, &value); err != nil {
+			return nil, fmt.Errorf("%w: scan %s %s: %v", ErrQuotaUsageUnavailable, subject, kind, err)
+		}
+		out[id] = value
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("%w: rows %s %s: %v", ErrQuotaUsageUnavailable, subject, kind, err)
+	}
+	return out, nil
+}
+
+func listEndUserDailySpendingResetBaselines(tenantID string, ids []string, dayKey string) (map[string]float64, error) {
+	db := getReadDB()
+	if db == nil {
+		return nil, ErrQuotaUsageUnavailable
+	}
+	query := `SELECT end_user_id, cost_baseline FROM end_user_daily_spending_resets WHERE tenant_id = ? AND day_key = ? AND end_user_id IN (` + placeholders(len(ids)) + `)`
+	args := make([]any, 0, len(ids)+2)
+	args = append(args, normalizeTenantID(tenantID), dayKey)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return map[string]float64{}, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]float64, len(ids))
+	for rows.Next() {
+		var id string
+		var baseline float64
+		if err := rows.Scan(&id, &baseline); err != nil {
+			return nil, err
+		}
+		out[id] = baseline
+	}
+	return out, rows.Err()
+}

--- a/internal/usage/period_spending_test.go
+++ b/internal/usage/period_spending_test.go
@@ -1,0 +1,88 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestPeriodWindowKeysAtUsesProjectTimezoneMondayWeek(t *testing.T) {
+	loc := time.FixedZone("UTC+8", 8*60*60)
+	now := time.Date(2026, 7, 22, 12, 30, 0, 0, time.UTC)
+	got := PeriodWindowKeysAt(now, loc)
+	if got.WeekFrom != "2026-07-20" || got.MonthFrom != "2026-07-01" || got.DayTo != "2026-07-23" {
+		t.Fatalf("windows = %+v, want Monday 2026-07-20, month 2026-07-01, tomorrow 2026-07-23", got)
+	}
+	if got.FiveHourFrom != "2026-07-22T07:30" || got.FiveHourTo != "2026-07-22T12:31" {
+		t.Fatalf("5h windows = [%s,%s), want [2026-07-22T07:30,2026-07-22T12:31)", got.FiveHourFrom, got.FiveHourTo)
+	}
+}
+
+func TestQueryPeriodSpendingWeekAndFiveHourBoundaries(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+	now := time.Date(2026, 7, 22, 12, 30, 45, 0, time.UTC)
+	keyID := "period-key"
+	insert := func(kind, start string, cost float64) {
+		t.Helper()
+		if _, err := db.Exec(`INSERT INTO usage_rollup_buckets
+			(tenant_id,bucket_kind,bucket_start,api_key_id,cost_total,updated_at)
+			VALUES (?,?,?,?,?,?)`, systemTenantID, kind, start, keyID, cost, now); err != nil {
+			t.Fatalf("insert %s %s: %v", kind, start, err)
+		}
+	}
+	insert(rollupBucketDay, "2026-07-19", 100) // previous Sunday: excluded from week
+	insert(rollupBucketDay, "2026-07-20", 10)  // Monday inclusive
+	insert(rollupBucketDay, "2026-07-22", 5)
+	insert(rollupBucketDay, "2026-07-23", 20) // tomorrow exclusive
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T07:29", 100)
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T07:30", 3)   // cutoff minute included
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T12:30", 4)   // current minute included
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T12:31", 100) // exclusive upper bound
+	insert(rollupBucketLifetime, rollupLifetimeStart, 999)
+
+	got, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(systemTenantID, []string{keyID}, now)
+	if err != nil {
+		t.Fatalf("QueryPeriodSpending: %v", err)
+	}
+	used := got[keyID]
+	if used.FiveHour != 7 || used.Day != 5 || used.Week != 15 || used.Month != 115 || used.Lifetime != 999 {
+		t.Fatalf("used = %+v, want 5h=7 day=5 week=15 month=115 lifetime=999", used)
+	}
+}
+
+func TestFiveHourQuotaProjectionReadinessRequiresFullCoverage(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	ensureUsageProjectionMarkerTable(db)
+	set := func(start time.Time) {
+		t.Helper()
+		if _, err := db.Exec(`INSERT INTO usage_projection_markers(marker_key,marker_value,updated_at)
+			VALUES(?,?,?) ON CONFLICT(marker_key) DO UPDATE SET marker_value=excluded.marker_value,updated_at=excluded.updated_at`,
+			quotaMinuteCoverageStartMarker, start.Format(time.RFC3339), now); err != nil {
+			t.Fatalf("set marker: %v", err)
+		}
+	}
+	set(now.Add(-4*time.Hour - 59*time.Minute))
+	if FiveHourQuotaProjectionReadyAt(now) {
+		t.Fatal("projection should still be warming before five hours")
+	}
+	set(now.Add(-5 * time.Hour))
+	if !FiveHourQuotaProjectionReadyAt(now) {
+		t.Fatal("projection should be ready at full five-hour coverage")
+	}
+}
+
+func TestRollupBucketStartsProjectsQuotaMinuteInUTC(t *testing.T) {
+	loc := time.FixedZone("UTC+8", 8*60*60)
+	at := time.Date(2026, 7, 22, 23, 59, 30, 0, loc)
+	starts := rollupBucketStarts(at, loc)
+	if starts[rollupBucketMinute] != "2026-07-22T23:59" {
+		t.Fatalf("local minute = %q", starts[rollupBucketMinute])
+	}
+	if starts[rollupBucketQuotaMinuteUTC] != "2026-07-22T15:59" {
+		t.Fatalf("quota UTC minute = %q, want 2026-07-22T15:59", starts[rollupBucketQuotaMinuteUTC])
+	}
+}

--- a/internal/usage/request_log_account_filter.go
+++ b/internal/usage/request_log_account_filter.go
@@ -260,14 +260,13 @@ func buildSingleAPIKeySelectorClauseForTenant(tenantID, selector string) (string
 		// Secret may resolve outside the tenant pin (legacy global lookup).
 		row = GetAPIKey(trimmed)
 	}
-	// Owned keys: selecting the account filter matches the whole key pool.
+	// Always key-scoped. Account-wide views use EndUserID on LogQueryParams, not secret expansion.
 	if row != nil {
-		if eu := strings.TrimSpace(row.EndUserID); eu != "" {
-			pred, args := buildEndUserAPIKeySelectorPredicate(tenantID, eu)
-			return " WHERE " + pred, args
-		}
 		if id := strings.TrimSpace(row.ID); id != "" {
 			return " WHERE (api_key_id = ? OR (api_key_id = '' AND api_key = ?))", []interface{}{id, strings.TrimSpace(row.Key)}
+		}
+		if k := strings.TrimSpace(row.Key); k != "" {
+			return " WHERE api_key = ?", []interface{}{k}
 		}
 	}
 	return " WHERE api_key = ?", []interface{}{trimmed}

--- a/internal/usage/request_log_series.go
+++ b/internal/usage/request_log_series.go
@@ -35,11 +35,20 @@ type ModelDistributionPoint struct {
 	Tokens   int64  `json:"tokens"`
 }
 
+// PublicAPIKeyDistributionPoint exposes stable per-key usage without secrets.
+type PublicAPIKeyDistributionPoint struct {
+	APIKeyID string `json:"api_key_id"`
+	Name     string `json:"name"`
+	Requests int64  `json:"requests"`
+	Tokens   int64  `json:"tokens"`
+}
+
 type PublicChartData struct {
-	DailySeries       []DailySeriesPoint
-	HeatmapSeries     []DailyHeatmapPoint
-	ModelDistribution []ModelDistributionPoint
-	Stats             LogStats
+	DailySeries        []DailySeriesPoint
+	HeatmapSeries      []DailyHeatmapPoint
+	ModelDistribution  []ModelDistributionPoint
+	APIKeyDistribution []PublicAPIKeyDistributionPoint
+	Stats              LogStats
 }
 
 // QueryPublicChartData aggregates the public API-key lookup charts in one indexed pass.
@@ -64,10 +73,11 @@ func QueryPublicChartDataForEndUser(tenantID, endUserID string, days int) (Publi
 func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, error) {
 	if getReadDB() == nil {
 		return PublicChartData{
-			DailySeries:       []DailySeriesPoint{},
-			HeatmapSeries:     []DailyHeatmapPoint{},
-			ModelDistribution: []ModelDistributionPoint{},
-			Stats:             LogStats{CacheRate: 0},
+			DailySeries:        []DailySeriesPoint{},
+			HeatmapSeries:      []DailyHeatmapPoint{},
+			ModelDistribution:  []ModelDistributionPoint{},
+			APIKeyDistribution: []PublicAPIKeyDistributionPoint{},
+			Stats:              LogStats{CacheRate: 0},
 		}, nil
 	}
 	if days < 1 {
@@ -81,10 +91,11 @@ func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, err
 	filter, ok := rollupIdentityFilter(params)
 	if !ok {
 		return PublicChartData{
-			DailySeries:       []DailySeriesPoint{},
-			HeatmapSeries:     []DailyHeatmapPoint{},
-			ModelDistribution: []ModelDistributionPoint{},
-			Stats:             LogStats{CacheRate: 0},
+			DailySeries:        []DailySeriesPoint{},
+			HeatmapSeries:      []DailyHeatmapPoint{},
+			ModelDistribution:  []ModelDistributionPoint{},
+			APIKeyDistribution: []PublicAPIKeyDistributionPoint{},
+			Stats:              LogStats{CacheRate: 0},
 		}, nil
 	}
 	filter.BucketKind = rollupBucketDay
@@ -139,6 +150,13 @@ func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, err
 	if err != nil {
 		return PublicChartData{}, err
 	}
+	apiKeyDistribution := []PublicAPIKeyDistributionPoint{}
+	if filter.EndUserID != "" {
+		apiKeyDistribution, err = queryRollupAPIKeyDistributionForEndUser(tenantID, filter.EndUserID, days)
+		if err != nil {
+			return PublicChartData{}, err
+		}
+	}
 	if stats.Total > 0 {
 		stats.SuccessRate = float64(successCount) / float64(stats.Total) * 100
 	}
@@ -160,10 +178,11 @@ func queryPublicChartData(params LogQueryParams, days int) (PublicChartData, err
 		stats.TotalSessions = int64(len(totalSessions))
 	}
 	return PublicChartData{
-		DailySeries:       sortedDailySeries(dailyByDate),
-		HeatmapSeries:     sortedHeatmapSeries(heatmapByDate),
-		ModelDistribution: models,
-		Stats:             stats,
+		DailySeries:        sortedDailySeries(dailyByDate),
+		HeatmapSeries:      sortedHeatmapSeries(heatmapByDate),
+		ModelDistribution:  models,
+		APIKeyDistribution: apiKeyDistribution,
+		Stats:              stats,
 	}, nil
 }
 

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1954,12 +1954,20 @@ func TestQueryFiltersCollapsesOwnedKeysToOneAccountOption(t *testing.T) {
 		}
 	}
 
+	// Selecting a concrete secret is key-scoped; account-wide needs EndUserID.
 	logs, err := QueryLogs(LogQueryParams{Page: 1, Size: 50, Days: 7, APIKeys: []string{"sk-kittors-default"}})
 	if err != nil {
-		t.Fatalf("QueryLogs(account filter) error = %v", err)
+		t.Fatalf("QueryLogs(key filter) error = %v", err)
 	}
-	if logs.Total != 2 {
-		t.Fatalf("QueryLogs total = %d, want 2 (both owned keys)", logs.Total)
+	if logs.Total != 1 {
+		t.Fatalf("QueryLogs total = %d, want 1 (presented key only)", logs.Total)
+	}
+	accountLogs, err := QueryLogs(LogQueryParams{Page: 1, Size: 50, Days: 7, EndUserID: endUserID})
+	if err != nil {
+		t.Fatalf("QueryLogs(end user) error = %v", err)
+	}
+	if accountLogs.Total != 2 {
+		t.Fatalf("QueryLogs(end user) total = %d, want 2 (both owned keys)", accountLogs.Total)
 	}
 
 	dist, err := QueryAPIKeyDistribution(7)

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -498,7 +498,7 @@ func resolveEndUserIDForKey(apiKey string) string {
 	return strings.TrimSpace(row.EndUserID)
 }
 
-// commitLogWithProjections writes tenant rollup, shared subject buckets, then legacy tenant daily and commits.
+// commitLogWithProjections writes tenant rollup and shared subject buckets, then commits.
 // Caller must already hold usageProjectionMu.RLock (see insertLogIdentity).
 func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 	if err := projectUsageRollupTx(tx, ev); err != nil {
@@ -509,10 +509,6 @@ func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 		if err := projectAIAccountSubjectUsageTx(tx, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.At); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("project shared auth subject usage: %w", err)
-		}
-		if err := projectAuthSubjectUsageDailyTx(tx, ev.TenantID, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.At); err != nil {
-			_ = tx.Rollback()
-			return fmt.Errorf("project auth subject usage daily: %w", err)
 		}
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -22,11 +22,12 @@ var (
 )
 
 const (
-	rollupBucketMinute   = "minute"
-	rollupBucketHour     = "hour"
-	rollupBucketDay      = "day"
-	rollupBucketLifetime = "lifetime"
-	rollupLifetimeStart  = "1970-01-01"
+	rollupBucketMinute         = "minute"
+	rollupBucketQuotaMinuteUTC = "quota_minute_utc"
+	rollupBucketHour           = "hour"
+	rollupBucketDay            = "day"
+	rollupBucketLifetime       = "lifetime"
+	rollupLifetimeStart        = "1970-01-01"
 	// minute: 24h, hour: 30d, day: 400d (covers 365d heatmap + buffer)
 	rollupMinuteRetention = 24 * time.Hour
 	rollupHourRetention   = 30 * 24 * time.Hour
@@ -74,9 +75,10 @@ CREATE INDEX IF NOT EXISTS idx_usage_rollup_tenant_subject_day
   ON usage_rollup_buckets(tenant_id, bucket_kind, auth_subject_id, bucket_start);
 `
 	// Bump marker when rebuild semantics change so upgrades re-run once.
-	usageRollupBackfillMarker = "usage_rollup_buckets_v3"
-	rollupMarkerPending       = "pending"
-	rollupMarkerDone          = "done"
+	usageRollupBackfillMarker      = "usage_rollup_buckets_v4"
+	quotaMinuteCoverageStartMarker = "quota_minute_utc_coverage_start"
+	rollupMarkerPending            = "pending"
+	rollupMarkerDone               = "done"
 )
 
 type rollupEvent struct {
@@ -256,6 +258,7 @@ func runUsageRollupBackfillAtInitDB(db *sql.DB, loc *time.Location, finalMarker 
 		       input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens,
 		       cost, timestamp, COALESCE(api_key,'')
 		FROM request_logs
+		ORDER BY timestamp ASC, id ASC
 	`)
 	if err != nil {
 		// Do not mark done on read failure — next startup must retry.
@@ -336,7 +339,16 @@ func runUsageRollupBackfillAtInitDB(db *sql.DB, loc *time.Location, finalMarker 
 			return err
 		}
 	}
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	nowTime := time.Now().UTC()
+	now := nowTime.Format(time.RFC3339Nano)
+	if _, err = tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO NOTHING
+	`, quotaMinuteCoverageStartMarker, nowTime.Truncate(time.Minute).Format(time.RFC3339), now); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("usage: quota minute coverage marker: %w", err)
+	}
 	if _, err = tx.Exec(`
 		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
 		VALUES (?, ?, ?)
@@ -359,10 +371,11 @@ func rollupBucketStarts(at time.Time, loc *time.Location) map[string]string {
 	}
 	local := at.In(loc)
 	return map[string]string{
-		rollupBucketMinute:   local.Format("2006-01-02T15:04"),
-		rollupBucketHour:     local.Format("2006-01-02T15"),
-		rollupBucketDay:      local.Format("2006-01-02"),
-		rollupBucketLifetime: rollupLifetimeStart,
+		rollupBucketMinute:         local.Format("2006-01-02T15:04"),
+		rollupBucketQuotaMinuteUTC: at.UTC().Format("2006-01-02T15:04"),
+		rollupBucketHour:           local.Format("2006-01-02T15"),
+		rollupBucketDay:            local.Format("2006-01-02"),
+		rollupBucketLifetime:       rollupLifetimeStart,
 	}
 }
 
@@ -449,8 +462,17 @@ func projectUsageRollupTx(tx *sql.Tx, ev rollupEvent) error {
 			updated_at = excluded.updated_at
 	`
 
+	coverageStart := ev.At.UTC().Truncate(time.Minute).Format(time.RFC3339)
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO NOTHING
+	`, quotaMinuteCoverageStartMarker, coverageStart, now); err != nil {
+		return fmt.Errorf("usage: record quota minute coverage start: %w", err)
+	}
+
 	// Fixed order avoids Postgres deadlocks when concurrent writers UPSERT the same key.
-	for _, kind := range []string{rollupBucketMinute, rollupBucketHour, rollupBucketDay, rollupBucketLifetime} {
+	for _, kind := range []string{rollupBucketMinute, rollupBucketQuotaMinuteUTC, rollupBucketHour, rollupBucketDay, rollupBucketLifetime} {
 		start := starts[kind]
 		if _, err := tx.Exec(upsertSQL,
 			ev.TenantID, kind, start,
@@ -515,6 +537,7 @@ func cleanupExpiredUsageRollupBuckets(db *sql.DB) (int64, error) {
 		from string
 	}{
 		{rollupBucketMinute, now.Add(-rollupMinuteRetention).Format("2006-01-02T15:04")},
+		{rollupBucketQuotaMinuteUTC, time.Now().UTC().Add(-rollupMinuteRetention).Format("2006-01-02T15:04")},
 		{rollupBucketHour, now.Add(-rollupHourRetention).Format("2006-01-02T15")},
 		{rollupBucketDay, now.Add(-rollupDayRetention).Format("2006-01-02")},
 	}
@@ -531,4 +554,24 @@ func cleanupExpiredUsageRollupBuckets(db *sql.DB) (int64, error) {
 		deleted += n
 	}
 	return deleted, nil
+}
+
+func FiveHourQuotaProjectionReadyAt(now time.Time) bool {
+	db := getReadDB()
+	if db == nil {
+		return false
+	}
+	raw := strings.TrimSpace(projectionMarkerValue(db, quotaMinuteCoverageStartMarker))
+	if raw == "" {
+		return false
+	}
+	started, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return false
+	}
+	return !started.After(now.UTC().Truncate(time.Minute).Add(-5 * time.Hour))
+}
+
+func FiveHourQuotaProjectionReady() bool {
+	return FiveHourQuotaProjectionReadyAt(time.Now())
 }

--- a/internal/usage/usage_rollup_query.go
+++ b/internal/usage/usage_rollup_query.go
@@ -491,3 +491,55 @@ func queryRollupModelDistribution(filter rollupFilter) ([]ModelDistributionPoint
 	}
 	return out, rows.Err()
 }
+
+func queryRollupAPIKeyDistributionForEndUser(tenantID, endUserID string, days int) ([]PublicAPIKeyDistributionPoint, error) {
+	db := getReadDB()
+	if db == nil {
+		return []PublicAPIKeyDistributionPoint{}, nil
+	}
+	tenantID = normalizeTenantID(tenantID)
+	endUserID = strings.TrimSpace(endUserID)
+	if endUserID == "" {
+		return []PublicAPIKeyDistributionPoint{}, nil
+	}
+	if days < 1 {
+		days = 7
+	}
+
+	rows, err := db.Query(`
+		SELECT api_key_id,
+			COALESCE(SUM(request_count), 0),
+			COALESCE(SUM(total_tokens), 0)
+		FROM usage_rollup_buckets
+		WHERE tenant_id = ?
+		  AND bucket_kind = ?
+		  AND bucket_start >= ?
+		  AND end_user_id = ?
+		  AND trim(api_key_id) != ''
+		GROUP BY api_key_id
+		ORDER BY 2 DESC, api_key_id
+	`, tenantID, rollupBucketDay, dayBucketFromDays(days), endUserID)
+	if err != nil {
+		return nil, fmt.Errorf("usage: public rollup apikey distribution: %w", err)
+	}
+	defer rows.Close()
+
+	currentByID := currentAPIKeyRowsByIDForTenant(tenantID)
+	out := make([]PublicAPIKeyDistributionPoint, 0)
+	for rows.Next() {
+		var point PublicAPIKeyDistributionPoint
+		if err := rows.Scan(&point.APIKeyID, &point.Requests, &point.Tokens); err != nil {
+			return nil, fmt.Errorf("usage: public rollup apikey distribution scan: %w", err)
+		}
+		point.APIKeyID = strings.TrimSpace(point.APIKeyID)
+		if row, ok := currentByID[point.APIKeyID]; ok {
+			// Public charts use the key's own current name, never the owner display name.
+			point.Name = strings.TrimSpace(row.Name)
+		}
+		out = append(out, point)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -285,18 +285,13 @@ func applyModelQuotaFailureLocked(auth *Auth, state *ModelState, result Result, 
 	if state == nil {
 		return
 	}
-	var next time.Time
 	backoffLevel := state.Quota.BackoffLevel
-	if result.RetryAfter != nil {
-		next = now.Add(*result.RetryAfter)
-	} else {
-		// WindowMinutes is window length metadata (e.g. week=10080), not remaining cooldown.
-		cooldown, nextLevel := nextQuotaCooldown(backoffLevel, quotaCooldownDisabledForAuth(auth))
-		if cooldown > 0 {
-			next = now.Add(cooldown)
-		}
-		backoffLevel = nextLevel
+	cooldown, nextLevel := quotaFailureCooldown(result.Error, result.RetryAfter, backoffLevel, quotaCooldownDisabledForAuth(auth))
+	var next time.Time
+	if cooldown > 0 {
+		next = now.Add(cooldown)
 	}
+	backoffLevel = nextLevel
 	var window string
 	var windowMinutes int
 	if result.Error != nil {

--- a/sdk/cliproxy/auth/conductor_failure_state.go
+++ b/sdk/cliproxy/auth/conductor_failure_state.go
@@ -1,6 +1,11 @@
 package auth
 
-import "time"
+import (
+	"strings"
+	"time"
+)
+
+const xaiWeekExhaustedDefaultCooldown = 6 * time.Hour
 
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
 	if auth == nil {
@@ -63,19 +68,34 @@ func applyAuthQuotaFailureState(auth *Auth, resultErr *Error, retryAfter *time.D
 		auth.Quota.Window = resultErr.QuotaWindow
 		auth.Quota.WindowMinutes = resultErr.QuotaWindowMinutes
 	}
+	cooldown, nextLevel := quotaFailureCooldown(resultErr, retryAfter, auth.Quota.BackoffLevel, quotaCooldownDisabledForAuth(auth))
 	var next time.Time
-	if retryAfter != nil {
-		next = now.Add(*retryAfter)
-	} else {
-		// WindowMinutes is window length metadata (e.g. week=10080), not remaining cooldown.
-		cooldown, nextLevel := nextQuotaCooldown(auth.Quota.BackoffLevel, quotaCooldownDisabledForAuth(auth))
-		if cooldown > 0 {
-			next = now.Add(cooldown)
-		}
-		auth.Quota.BackoffLevel = nextLevel
+	if cooldown > 0 {
+		next = now.Add(cooldown)
 	}
+	auth.Quota.BackoffLevel = nextLevel
 	auth.Quota.NextRecoverAt = next
 	auth.NextRetryAfter = next
+}
+
+func quotaFailureCooldown(resultErr *Error, retryAfter *time.Duration, prevLevel int, disableCooling bool) (time.Duration, int) {
+	if retryAfter != nil {
+		return *retryAfter, prevLevel
+	}
+	if disableCooling {
+		return 0, prevLevel
+	}
+	if isXAIWeekBalanceExhaustedError(resultErr) {
+		return xaiWeekExhaustedDefaultCooldown, prevLevel
+	}
+	return nextQuotaCooldown(prevLevel, false)
+}
+
+func isXAIWeekBalanceExhaustedError(resultErr *Error) bool {
+	if resultErr == nil || !isUsageBalanceExhaustedMessage(resultErr.Message) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(resultErr.QuotaWindow), "week") || resultErr.QuotaWindowMinutes == 10080
 }
 
 // nextQuotaCooldown returns the next cooldown duration and updated backoff level for repeated quota errors.

--- a/sdk/cliproxy/auth/xai_402_quota_test.go
+++ b/sdk/cliproxy/auth/xai_402_quota_test.go
@@ -33,11 +33,15 @@ func (e *retryAfterQuotaErrorStub) RetryAfter() *time.Duration {
 }
 
 type xaiQuotaExecutor struct {
-	err error
+	err     error
+	execute func(*Auth) (cliproxyexecutor.Response, error)
 }
 
 func (e *xaiQuotaExecutor) Identifier() string { return "xai" }
-func (e *xaiQuotaExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+func (e *xaiQuotaExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.execute != nil {
+		return e.execute(auth)
+	}
 	return cliproxyexecutor.Response{}, e.err
 }
 func (e *xaiQuotaExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
@@ -49,6 +53,9 @@ func (e *xaiQuotaExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.
 }
 func (e *xaiQuotaExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
 	return nil, e.err
+}
+func (e *xaiQuotaExecutor) ProbeQuotaRecovery(context.Context, *Auth) (*QuotaProbeResult, error) {
+	return &QuotaProbeResult{Recovered: false}, nil
 }
 
 func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testing.T) {
@@ -112,7 +119,7 @@ func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testi
 	}
 }
 
-func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryDoesNotUseWeekLength(t *testing.T) {
+func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesDefaultCooldown(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -158,12 +165,79 @@ func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryDoesNotUseWeekLengt
 	if !state.Quota.Exceeded || state.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", state.Quota)
 	}
-	// Must not treat WindowMinutes(10080) as remaining cooldown (~7d).
-	if state.NextRetryAfter.After(before.Add(time.Hour)) {
-		t.Fatalf("NextRetryAfter = %v, want short probe backoff not week length", state.NextRetryAfter)
+	minExpected := before.Add(xaiWeekExhaustedDefaultCooldown - time.Minute)
+	maxExpected := before.Add(xaiWeekExhaustedDefaultCooldown + time.Minute)
+	if state.NextRetryAfter.Before(minExpected) || state.NextRetryAfter.After(maxExpected) {
+		t.Fatalf("NextRetryAfter = %v, want ~%v", state.NextRetryAfter, before.Add(xaiWeekExhaustedDefaultCooldown))
 	}
-	if state.NextRetryAfter.Before(before) {
-		t.Fatalf("NextRetryAfter = %v, want after now", state.NextRetryAfter)
+	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
+		t.Fatalf("NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
+	}
+	if !got.Quota.Exceeded || got.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("aggregated auth quota = %#v, want exceeded with recovery time", got.Quota)
+	}
+}
+
+func TestManagerExecute_XAIWeekExhaustedSkipsAuthForHealthyPeer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := "grok-4.5"
+	calls := map[string]int{}
+	exhaustedErr := &retryAfterQuotaErrorStub{
+		message:      `{"error":"Grok Build usage balance exhausted"}`,
+		status:       http.StatusPaymentRequired,
+		quotaWindow:  "week",
+		quotaMinutes: 10080,
+	}
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		execute: func(auth *Auth) (cliproxyexecutor.Response, error) {
+			calls[auth.ID]++
+			if auth.ID == "xai-exhausted" {
+				return cliproxyexecutor.Response{}, exhaustedErr
+			}
+			return cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+		},
+	})
+	for _, auth := range []*Auth{
+		{ID: "xai-exhausted", Provider: "xai", Status: StatusActive, Attributes: map[string]string{"priority": "10"}},
+		{ID: "xai-healthy", Provider: "xai", Status: StatusActive, Attributes: map[string]string{"priority": "1"}},
+	} {
+		if _, err := manager.Register(ctx, auth); err != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, err)
+		}
+	}
+
+	request := cliproxyexecutor.Request{Model: model}
+	if _, err := manager.Execute(ctx, []string{"xai"}, request, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("first Execute() error = %v", err)
+	}
+	if calls["xai-exhausted"] != 1 || calls["xai-healthy"] != 1 {
+		t.Fatalf("first call counts = %#v, want exhausted=1 healthy=1", calls)
+	}
+
+	if _, err := manager.Execute(ctx, []string{"xai"}, request, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("second Execute() error = %v", err)
+	}
+	if calls["xai-exhausted"] != 1 || calls["xai-healthy"] != 2 {
+		t.Fatalf("second call counts = %#v, want exhausted still 1 and healthy=2", calls)
+	}
+
+	exhausted, ok := manager.GetByID("xai-exhausted")
+	if !ok || exhausted == nil {
+		t.Fatal("exhausted auth missing")
+	}
+	now := time.Now()
+	if !exhausted.Quota.Exceeded || !exhausted.Quota.NextRecoverAt.After(now.Add(time.Hour)) {
+		t.Fatalf("exhausted quota = %#v, want active long cooldown", exhausted.Quota)
+	}
+	if !manager.shouldProbeQuota(exhausted, now) {
+		t.Fatal("shouldProbeQuota() = false, want xAI cooldown eligible for recovery probe")
+	}
+	nextProbe := nextQuotaProbeTime(exhausted, now)
+	if !nextProbe.After(now) || !nextProbe.Before(exhausted.Quota.NextRecoverAt) {
+		t.Fatalf("nextQuotaProbeTime() = %v, want before cooldown recovery %v", nextProbe, exhausted.Quota.NextRecoverAt)
 	}
 }
 
@@ -240,7 +314,7 @@ func TestApplyAuthFailureState_XAI402BalanceExhausted(t *testing.T) {
 	}
 }
 
-func TestApplyAuthFailureState_XAI402WithoutRetryDoesNotUseWindowMinutes(t *testing.T) {
+func TestApplyAuthFailureState_XAI402WithoutRetryUsesDefaultCooldown(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
@@ -255,7 +329,10 @@ func TestApplyAuthFailureState_XAI402WithoutRetryDoesNotUseWindowMinutes(t *test
 	if !auth.Quota.Exceeded || auth.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", auth.Quota)
 	}
-	if auth.NextRetryAfter.Sub(now) >= time.Hour {
-		t.Fatalf("NextRetryAfter = %v, want short probe backoff not WindowMinutes", auth.NextRetryAfter)
+	if !auth.NextRetryAfter.Equal(now.Add(xaiWeekExhaustedDefaultCooldown)) {
+		t.Fatalf("NextRetryAfter = %v, want %v", auth.NextRetryAfter, now.Add(xaiWeekExhaustedDefaultCooldown))
+	}
+	if !auth.Quota.NextRecoverAt.Equal(auth.NextRetryAfter) {
+		t.Fatalf("NextRecoverAt = %v, want %v", auth.Quota.NextRecoverAt, auth.NextRetryAfter)
 	}
 }


### PR DESCRIPTION
## Summary
Promote verified `dev` to `main` for product release **v0.4.15**.

## Highlights
- End-user / API key **period spending quotas**
- Identity: **password policy + auto initial password**; **protect tenant admin** from role change/delete
- Portal/public usage: key-scoped lookup, chart `api_key_distribution`, remove portal daily reset endpoints
- Deploy: blue-green slot listens before projection maintenance; models keep non-manifest mapped entries after codex discovery drop
- Grok week-exhausted thrash fix; usage cycle backfill stop

## Test plan
- [x] `dev` is ahead of `main` with merged PRs only (no open related feature PRs)
- [ ] PR required checks (`build`, `ensure-no-translator-changes`) green
- [ ] Merge to `main`, tag `v0.4.15`, sync `main` → `dev`