### PR TITLE
feat: content moderation multi-profile + channel bindings

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
@@ -198,6 +199,9 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		Repository: h.authFileRepository(),
 		RemoveChannels: func(channels []string) error {
 			return h.removeChannelReferencesForTenant(effectiveTenantID(c), channels)
+		},
+		RemoveAuthBindings: func(authIDs []string) error {
+			return h.deleteContentModerationBindings(ctx, effectiveTenantID(c), contentmoderation.ChannelTypeAuthFile, authIDs)
 		},
 	}
 	if managementauthfiles.IsDeleteAllValue(c.Query("all")) {

--- a/internal/api/handlers/management/auth_files_delete_test.go
+++ b/internal/api/handlers/management/auth_files_delete_test.go
@@ -2,14 +2,18 @@ package management
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -111,6 +115,22 @@ func TestDeleteAuthFileRemovesDeletedChannelReferences(t *testing.T) {
 		authManager: manager,
 		tokenStore:  store,
 	}
+	moderationStore := contentmoderation.NewStore(usage.RuntimeDB())
+	moderationProfile, err := contentmoderation.NewProfile(identity.SystemTenantID, "profile-auth-cleanup", contentmoderation.CreateProfileInput{Name: "auth cleanup"}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if err = moderationStore.CreateProfile(context.Background(), moderationProfile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	profileID := moderationProfile.ID
+	if err = moderationStore.PatchBindings(context.Background(), identity.SystemTenantID, false, []contentmoderation.BindingOperation{{
+		ChannelType: contentmoderation.ChannelTypeAuthFile,
+		ChannelID:   "kimi-a.json",
+		ProfileID:   &profileID,
+	}}); err != nil {
+		t.Fatalf("PatchBindings: %v", err)
+	}
 
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -126,6 +146,9 @@ func TestDeleteAuthFileRemovesDeletedChannelReferences(t *testing.T) {
 	}
 	if _, ok := manager.GetByID("kimi-b.json"); !ok {
 		t.Fatal("expected remaining auth to stay in manager")
+	}
+	if _, _, err = moderationStore.ResolveProfile(context.Background(), identity.SystemTenantID, "kimi-a.json", "", ""); !errors.Is(err, contentmoderation.ErrNotFound) {
+		t.Fatalf("ResolveProfile error=%v, want ErrNotFound", err)
 	}
 
 	profiles := usage.ListAPIKeyPermissionProfiles()

--- a/internal/api/handlers/management/content_moderation.go
+++ b/internal/api/handlers/management/content_moderation.go
@@ -1,0 +1,267 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type contentModerationProfileResponse struct {
+	contentmoderation.Profile
+	APIKeyConfigured bool           `json:"api_key_configured"`
+	APIKeyMasked     string         `json:"api_key_masked,omitempty"`
+	BindingCounts    map[string]int `json:"binding_counts"`
+}
+
+func (h *Handler) contentModerationStore() *contentmoderation.Store {
+	return contentmoderation.NewStore(usage.RuntimeDB())
+}
+
+func (h *Handler) deleteContentModerationBindings(ctx context.Context, tenantID, channelType string, channelIDs []string) error {
+	if usage.RuntimeDB() == nil || len(channelIDs) == 0 {
+		return nil
+	}
+	operations := make([]contentmoderation.BindingOperation, 0, len(channelIDs))
+	for _, channelID := range channelIDs {
+		if channelID = strings.TrimSpace(channelID); channelID != "" {
+			operations = append(operations, contentmoderation.BindingOperation{ChannelType: channelType, ChannelID: channelID})
+		}
+	}
+	if len(operations) == 0 {
+		return nil
+	}
+	return h.contentModerationStore().PatchBindings(ctx, tenantID, false, operations)
+}
+
+func (h *Handler) GetContentModerationProfiles(c *gin.Context) {
+	tenantID := effectiveTenantID(c)
+	profiles, err := h.contentModerationStore().ListProfiles(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	counts, err := h.contentModerationStore().BindingCounts(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	items := make([]contentModerationProfileResponse, 0, len(profiles))
+	for _, profile := range profiles {
+		items = append(items, contentModerationProfileView(profile, counts[profile.ID]))
+	}
+	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+func (h *Handler) PostContentModerationProfile(c *gin.Context) {
+	var input contentmoderation.CreateProfileInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		contentModerationBadRequest(c, err.Error())
+		return
+	}
+	profile, err := contentmoderation.NewProfile(effectiveTenantID(c), uuid.NewString(), input, time.Now())
+	if err != nil {
+		contentModerationBadRequest(c, err.Error())
+		return
+	}
+	if err = h.contentModerationStore().CreateProfile(c.Request.Context(), profile); err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, contentModerationProfileView(profile, map[string]int{}))
+}
+
+func (h *Handler) GetContentModerationProfile(c *gin.Context) {
+	tenantID := effectiveTenantID(c)
+	profile, err := h.contentModerationStore().GetProfile(c.Request.Context(), tenantID, c.Param("id"))
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	counts, err := h.contentModerationStore().BindingCounts(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, contentModerationProfileView(profile, counts[profile.ID]))
+}
+
+func (h *Handler) PatchContentModerationProfile(c *gin.Context) {
+	var input contentmoderation.PatchProfileInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		contentModerationBadRequest(c, err.Error())
+		return
+	}
+	store := h.contentModerationStore()
+	profile, err := store.GetProfile(c.Request.Context(), effectiveTenantID(c), c.Param("id"))
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	updated, err := contentmoderation.ApplyProfilePatch(profile, input, time.Now())
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	if err = store.UpdateProfile(c.Request.Context(), updated, profile.Version); err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	counts, err := store.BindingCounts(c.Request.Context(), updated.TenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, contentModerationProfileView(updated, counts[updated.ID]))
+}
+
+func (h *Handler) DeleteContentModerationProfile(c *gin.Context) {
+	if err := h.contentModerationStore().DeleteProfile(c.Request.Context(), effectiveTenantID(c), c.Param("id")); err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) GetContentModerationChannels(c *gin.Context) {
+	tenantID := effectiveTenantID(c)
+	bindings, err := h.contentModerationStore().ListBindings(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	cfg := h.providerConfigForTenant(c)
+	var auths []*coreauth.Auth
+	if h.authManager != nil {
+		auths = h.authManager.ListForTenant(tenantID)
+	}
+	page, pageSize := queryPositiveInt(c, "page", 1), queryPositiveInt(c, "page_size", 20)
+	tags := splitQueryValues(c.Query("tags"))
+	result := contentmoderation.ListChannels(cfg, auths, bindings, contentmoderation.ChannelQuery{
+		ChannelType: c.Query("channel_type"),
+		Query:       c.Query("query"),
+		Tags:        tags,
+		TagMode:     c.Query("tag_mode"),
+		Provider:    c.Query("provider"),
+		ProfileID:   c.Query("profile_id"),
+		Page:        page,
+		PageSize:    pageSize,
+	})
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *Handler) PatchContentModerationChannelBindings(c *gin.Context) {
+	var body struct {
+		AllowRebind bool                                 `json:"allow_rebind"`
+		Operations  []contentmoderation.BindingOperation `json:"operations"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || len(body.Operations) == 0 {
+		contentModerationBadRequest(c, "operations are required")
+		return
+	}
+	tenantID := effectiveTenantID(c)
+	cfg := h.providerConfigForTenant(c)
+	var auths []*coreauth.Auth
+	if h.authManager != nil {
+		auths = h.authManager.ListForTenant(tenantID)
+	}
+	for _, operation := range body.Operations {
+		if operation.ProfileID == nil || strings.TrimSpace(*operation.ProfileID) == "" {
+			continue
+		}
+		if !contentmoderation.ChannelExists(cfg, auths, operation.ChannelType, operation.ChannelID) {
+			contentModerationBadRequest(c, "channel does not exist in the effective tenant")
+			return
+		}
+	}
+	store := h.contentModerationStore()
+	if err := store.PatchBindings(c.Request.Context(), tenantID, body.AllowRebind, body.Operations); err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	bindings, err := store.ListBindings(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"bindings": bindings})
+}
+
+func contentModerationProfileView(profile contentmoderation.Profile, counts map[string]int) contentModerationProfileResponse {
+	if counts == nil {
+		counts = map[string]int{}
+	}
+	return contentModerationProfileResponse{
+		Profile:          profile,
+		APIKeyConfigured: strings.TrimSpace(profile.APIKeySecret) != "",
+		APIKeyMasked:     contentmoderation.MaskSecret(profile.APIKeySecret),
+		BindingCounts:    counts,
+	}
+}
+
+func contentModerationError(c *gin.Context, err error) {
+	status, code := http.StatusInternalServerError, "content_moderation_error"
+	extra := gin.H{}
+	switch {
+	case errors.Is(err, contentmoderation.ErrNotFound):
+		status, code = http.StatusNotFound, "content_moderation_not_found"
+	case errors.Is(err, contentmoderation.ErrNameConflict):
+		status, code = http.StatusConflict, "content_moderation_name_conflict"
+	case errors.Is(err, contentmoderation.ErrVersionConflict):
+		status, code = http.StatusConflict, "content_moderation_version_conflict"
+	case errors.Is(err, contentmoderation.ErrProfileBound):
+		status, code = http.StatusConflict, "content_moderation_profile_bound"
+		var bound *contentmoderation.ProfileBoundError
+		if errors.As(err, &bound) {
+			extra["binding_count"] = bound.Count
+		}
+	case errors.Is(err, contentmoderation.ErrBindingConflict):
+		status, code = http.StatusConflict, "content_moderation_binding_conflict"
+		var conflict *contentmoderation.BindingConflictError
+		if errors.As(err, &conflict) {
+			extra["channel_type"] = conflict.ChannelType
+			extra["channel_id"] = conflict.ChannelID
+			extra["existing_profile_id"] = conflict.ExistingProfileID
+		}
+	case errors.Is(err, contentmoderation.ErrInvalidChannel):
+		status, code = http.StatusBadRequest, "content_moderation_invalid_channel"
+	case errors.Is(err, contentmoderation.ErrUnavailable):
+		status, code = http.StatusServiceUnavailable, "content_moderation_unavailable"
+	}
+	payload := gin.H{"code": code, "message": err.Error()}
+	for key, value := range extra {
+		payload[key] = value
+	}
+	c.JSON(status, gin.H{"error": payload})
+}
+
+func contentModerationBadRequest(c *gin.Context, message string) {
+	c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "content_moderation_invalid_request", "message": message}})
+}
+
+func queryPositiveInt(c *gin.Context, key string, fallback int) int {
+	value, err := strconv.Atoi(strings.TrimSpace(c.Query(key)))
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+func splitQueryValues(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/internal/api/handlers/management/content_moderation_test.go
+++ b/internal/api/handlers/management/content_moderation_test.go
@@ -1,0 +1,126 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func setupContentModerationHandlerTest(t *testing.T) (*Handler, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	usage.CloseDB()
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+	const tenantID = "00000000-0000-0000-0000-0000000000ab"
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "auth-file-1",
+		TenantID: tenantID,
+		FileName: "auth-file-1.json",
+		Provider: "codex",
+		Label:    "Codex Account",
+		Status:   coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	cfg := &config.Config{GeminiKey: []config.GeminiKey{{ID: "11111111-1111-4111-8111-111111111111", Name: "Gemini Provider", APIKey: "provider-secret"}}}
+	if err := usage.UpsertRuntimeSettingForTenant(tenantID, usage.RuntimeSettingGeminiKeys, cfg.GeminiKey); err != nil {
+		t.Fatalf("persist tenant provider: %v", err)
+	}
+	return &Handler{cfg: cfg, authManager: manager}, tenantID
+}
+
+func moderationContext(tenantID, method, path, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set(managementPrincipalKey, identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}})
+	c.Request = httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	return c, rec
+}
+
+func TestContentModerationProfileUsesPrincipalTenantAndHidesSecret(t *testing.T) {
+	h, tenantID := setupContentModerationHandlerTest(t)
+	body := `{"tenant_id":"attacker-tenant","name":"primary","mode":"pre_block","keyword_mode":"api_only","api_key":"moderation-secret"}`
+	c, rec := moderationContext(tenantID, http.MethodPost, "/v0/management/content-moderation/profiles", body)
+	h.PostContentModerationProfile(c)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "moderation-secret") || strings.Contains(rec.Body.String(), "attacker-tenant") {
+		t.Fatalf("response leaked secret/body tenant: %s", rec.Body.String())
+	}
+	profiles, err := h.contentModerationStore().ListProfiles(context.Background(), tenantID)
+	if err != nil || len(profiles) != 1 || profiles[0].TenantID != tenantID {
+		t.Fatalf("stored profiles = %#v err=%v", profiles, err)
+	}
+	other, err := h.contentModerationStore().ListProfiles(context.Background(), "attacker-tenant")
+	if err != nil || len(other) != 0 {
+		t.Fatalf("attacker tenant profiles = %#v err=%v", other, err)
+	}
+}
+
+func TestContentModerationChannelsArePagedAndSecretFree(t *testing.T) {
+	h, tenantID := setupContentModerationHandlerTest(t)
+	c, rec := moderationContext(tenantID, http.MethodGet, "/v0/management/content-moderation/channels?page=1&page_size=1", "")
+	h.GetContentModerationChannels(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET channels status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "provider-secret") {
+		t.Fatalf("channel response leaked provider secret: %s", rec.Body.String())
+	}
+	var page contentmoderation.ChannelPage
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if page.PageSize != 1 || len(page.Items) != 1 || page.Total != 2 {
+		t.Fatalf("page = %#v", page)
+	}
+}
+
+func TestProviderDeleteRemovesContentModerationBindings(t *testing.T) {
+	h, tenantID := setupContentModerationHandlerTest(t)
+	store := h.contentModerationStore()
+	profile, err := contentmoderation.NewProfile(tenantID, "profile-provider-cleanup", contentmoderation.CreateProfileInput{Name: "provider cleanup"}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if err = store.CreateProfile(context.Background(), profile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	profileID := profile.ID
+	if err = store.PatchBindings(context.Background(), tenantID, false, []contentmoderation.BindingOperation{{
+		ChannelType: contentmoderation.ChannelTypeProviderKey,
+		ChannelID:   "11111111-1111-4111-8111-111111111111",
+		ProfileID:   &profileID,
+	}}); err != nil {
+		t.Fatalf("PatchBindings: %v", err)
+	}
+
+	c, rec := moderationContext(tenantID, http.MethodDelete, "/v0/management/gemini-api-key?index=0", "")
+	h.ProviderKeys().DeleteGeminiKey(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE provider status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, _, err = store.ResolveProfile(context.Background(), tenantID, "", "11111111-1111-4111-8111-111111111111", ""); !errors.Is(err, contentmoderation.ErrNotFound) {
+		t.Fatalf("ResolveProfile error=%v, want ErrNotFound", err)
+	}
+}

--- a/internal/api/handlers/management/content_moderation_test_endpoint.go
+++ b/internal/api/handlers/management/content_moderation_test_endpoint.go
@@ -1,0 +1,26 @@
+package management
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+)
+
+func (h *Handler) PostContentModerationProfileTest(c *gin.Context) {
+	var body struct {
+		Input string `json:"input"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || strings.TrimSpace(body.Input) == "" {
+		contentModerationBadRequest(c, "input is required")
+		return
+	}
+	profile, err := h.contentModerationStore().GetProfile(c.Request.Context(), effectiveTenantID(c), c.Param("id"))
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	decision := contentmoderation.NewEvaluator(nil).Evaluate(c.Request.Context(), profile, body.Input)
+	c.JSON(http.StatusOK, decision)
+}

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -589,6 +589,7 @@ func isTenantScopedManagementPath(path string) bool {
 	case relative == "/dashboard-summary", relative == "/config":
 		return true
 	case strings.HasPrefix(relative, "/auth-files"),
+		strings.HasPrefix(relative, "/content-moderation"),
 		strings.HasPrefix(relative, "/identity-fingerprint"),
 		strings.HasPrefix(relative, "/model-definitions/"),
 		strings.HasPrefix(relative, "/image-generation"),

--- a/internal/api/handlers/management/provider_content_moderation_bindings.go
+++ b/internal/api/handlers/management/provider_content_moderation_bindings.go
@@ -1,0 +1,52 @@
+package management
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+)
+
+const providerModerationBindingSnapshotKey = "management.provider_moderation_binding_snapshot"
+
+func captureProviderModerationBindingSnapshot(c *gin.Context, cfg *config.Config) {
+	if c == nil {
+		return
+	}
+	if _, exists := c.Get(providerModerationBindingSnapshotKey); exists {
+		return
+	}
+	refs := contentmoderation.ProviderChannelRefs(cfg)
+	c.Set(providerModerationBindingSnapshotKey, refs)
+}
+
+func (h *Handler) cleanupRemovedProviderModerationBindings(ctx context.Context, c *gin.Context, tenantID string, cfg *config.Config) error {
+	if c == nil {
+		return nil
+	}
+	value, exists := c.Get(providerModerationBindingSnapshotKey)
+	if !exists {
+		return nil
+	}
+	before, ok := value.([]contentmoderation.ChannelRef)
+	if !ok || len(before) == 0 {
+		return nil
+	}
+	after := make(map[string]struct{})
+	for _, ref := range contentmoderation.ProviderChannelRefs(cfg) {
+		after[ref.ChannelType+"\x00"+ref.ChannelID] = struct{}{}
+	}
+	byType := make(map[string][]string)
+	for _, ref := range before {
+		if _, exists := after[ref.ChannelType+"\x00"+ref.ChannelID]; !exists {
+			byType[ref.ChannelType] = append(byType[ref.ChannelType], ref.ChannelID)
+		}
+	}
+	for channelType, ids := range byType {
+		if err := h.deleteContentModerationBindings(ctx, tenantID, channelType, ids); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/api/handlers/management/provider_settings.go
+++ b/internal/api/handlers/management/provider_settings.go
@@ -35,6 +35,7 @@ func providerSettingsService(h *ProviderKeysHandler, c *gin.Context) *providerse
 		return providersettings.NewService(nil, nil)
 	}
 	cfg := h.providerConfigForTenant(c)
+	captureProviderModerationBindingSnapshot(c, cfg)
 	tenantID := effectiveTenantID(c)
 	return providersettings.NewService(cfg, func() error {
 		var auths []*coreauth.Auth
@@ -67,10 +68,26 @@ func (h *Handler) providerConfigForTenant(c *gin.Context) *config.Config {
 
 func (h *ProviderKeysHandler) persistProviderSettings(c *gin.Context) bool {
 	tenantID := effectiveTenantID(c)
-	if tenantID == identity.SystemTenantID {
-		return h.persist(c)
-	}
 	cfg := h.providerConfigForTenant(c)
+	if tenantID == identity.SystemTenantID {
+		h.mu.Lock()
+		err := settingsstore.SaveConfig(h.cfg, h.configFilePath)
+		mutated := h.onConfigMutated
+		h.mu.Unlock()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save config: %v", err)})
+			return false
+		}
+		payload := gin.H{"status": "ok"}
+		if errCleanup := h.cleanupRemovedProviderModerationBindings(c.Request.Context(), c, tenantID, cfg); errCleanup != nil {
+			payload["warning"] = fmt.Sprintf("provider saved but content moderation binding cleanup failed: %v", errCleanup)
+		}
+		c.JSON(http.StatusOK, payload)
+		if mutated != nil {
+			mutated(h.cfg)
+		}
+		return true
+	}
 	key, value := providerRuntimeSetting(c.Request.URL.Path, cfg)
 	if key == "" {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "unsupported provider setting"})
@@ -83,7 +100,11 @@ func (h *ProviderKeysHandler) persistProviderSettings(c *gin.Context) bool {
 	if h.authManager != nil {
 		serviceapp.SyncConfigDerivedAuthsForTenant(h.cfg, h.authManager, tenantID)
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	payload := gin.H{"status": "ok"}
+	if errCleanup := h.cleanupRemovedProviderModerationBindings(c.Request.Context(), c, tenantID, cfg); errCleanup != nil {
+		payload["warning"] = fmt.Sprintf("provider saved but content moderation binding cleanup failed: %v", errCleanup)
+	}
+	c.JSON(http.StatusOK, payload)
 	return true
 }
 

--- a/internal/api/handlers/management/route_permissions.go
+++ b/internal/api/handlers/management/route_permissions.go
@@ -157,6 +157,14 @@ func permissionForManagementRequest(method, path string) string {
 			return "models.write"
 		}
 		return "models.read"
+	case strings.HasPrefix(relative, "/content-moderation"):
+		if strings.HasSuffix(relative, "/test") {
+			return "content_moderation.test"
+		}
+		if write {
+			return "content_moderation.write"
+		}
+		return "content_moderation.read"
 	case strings.HasPrefix(relative, "/image-generation"):
 		if strings.Contains(relative, "/test") {
 			return "image_generation.test"

--- a/internal/api/routes/management.go
+++ b/internal/api/routes/management.go
@@ -44,6 +44,7 @@ func RegisterManagement(engine *gin.Engine, h *managementhandlers.Handler, opts 
 	registerManagementModelRoutes(mgmt, h)
 	registerManagementUsageRoutes(mgmt, h)
 	registerManagementSettingsRoutes(mgmt, h)
+	registerManagementContentModerationRoutes(mgmt, h)
 	registerManagementAPIKeyRoutes(mgmt, h)
 	registerManagementLogRoutes(mgmt, h)
 	registerManagementAmpRoutes(mgmt, h)

--- a/internal/api/routes/management_content_moderation_routes.go
+++ b/internal/api/routes/management_content_moderation_routes.go
@@ -1,0 +1,17 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+	managementhandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
+)
+
+func registerManagementContentModerationRoutes(group *gin.RouterGroup, h *managementhandlers.Handler) {
+	group.GET("/content-moderation/profiles", h.GetContentModerationProfiles)
+	group.POST("/content-moderation/profiles", h.PostContentModerationProfile)
+	group.GET("/content-moderation/profiles/:id", h.GetContentModerationProfile)
+	group.PATCH("/content-moderation/profiles/:id", h.PatchContentModerationProfile)
+	group.DELETE("/content-moderation/profiles/:id", h.DeleteContentModerationProfile)
+	group.POST("/content-moderation/profiles/:id/test", h.PostContentModerationProfileTest)
+	group.GET("/content-moderation/channels", h.GetContentModerationChannels)
+	group.PATCH("/content-moderation/channel-bindings", h.PatchContentModerationChannelBindings)
+}

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 296; got != want {
+	if got, want := len(routes), 304; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -34,6 +34,14 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 	}
 
 	required := []string{
+		"GET /v0/management/content-moderation/profiles",
+		"POST /v0/management/content-moderation/profiles",
+		"GET /v0/management/content-moderation/profiles/:id",
+		"PATCH /v0/management/content-moderation/profiles/:id",
+		"DELETE /v0/management/content-moderation/profiles/:id",
+		"POST /v0/management/content-moderation/profiles/:id/test",
+		"GET /v0/management/content-moderation/channels",
+		"PATCH /v0/management/content-moderation/channel-bindings",
 		"GET /v0/management/dashboard-summary",
 		"GET /v0/management/system-stats/ws",
 		"GET /v0/management/model-configs",
@@ -244,6 +252,7 @@ func expectedManagementRoutes() []string {
 		"DELETE /v0/management/claude-api-key",
 		"DELETE /v0/management/cline-api-key",
 		"DELETE /v0/management/codex-api-key",
+		"DELETE /v0/management/content-moderation/profiles/:id",
 		"DELETE /v0/management/gemini-api-key",
 		"DELETE /v0/management/identity-fingerprint/account/profile",
 		"DELETE /v0/management/identity-fingerprint/learned",
@@ -289,6 +298,9 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/codex-oauth-admission",
 		"GET /v0/management/config",
 		"GET /v0/management/config.yaml",
+		"GET /v0/management/content-moderation/channels",
+		"GET /v0/management/content-moderation/profiles",
+		"GET /v0/management/content-moderation/profiles/:id",
 		"GET /v0/management/dashboard-summary",
 		"GET /v0/management/debug",
 		"GET /v0/management/error-logs-max-files",
@@ -378,6 +390,8 @@ func expectedManagementRoutes() []string {
 		"PATCH /v0/management/claude-api-key",
 		"PATCH /v0/management/cline-api-key",
 		"PATCH /v0/management/codex-api-key",
+		"PATCH /v0/management/content-moderation/channel-bindings",
+		"PATCH /v0/management/content-moderation/profiles/:id",
 		"PATCH /v0/management/debug",
 		"PATCH /v0/management/error-logs-max-files",
 		"PATCH /v0/management/force-model-prefix",
@@ -402,6 +416,8 @@ func expectedManagementRoutes() []string {
 		"PATCH /v0/management/vertex-api-key",
 		"PATCH /v0/management/ws-auth",
 		"POST /v0/management/api-call",
+		"POST /v0/management/content-moderation/profiles",
+		"POST /v0/management/content-moderation/profiles/:id/test",
 		"POST /v0/management/api-key-entries/daily-spending/reset",
 		"POST /v0/management/auth-files",
 		"POST /v0/management/iflow-auth-url",

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
@@ -45,6 +46,7 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
+		WithRequestModerator(contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))).
 		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 
@@ -89,6 +91,7 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
+		WithRequestModerator(contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))).
 		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 

--- a/internal/config/bedrock.go
+++ b/internal/config/bedrock.go
@@ -11,6 +11,9 @@ const (
 // BedrockKey represents an AWS Bedrock Runtime credential.
 // It supports both AWS SigV4 credentials and Bedrock API key bearer auth.
 type BedrockKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// Name is a human-readable label for this channel.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -109,6 +109,14 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
+	// Provider IDs are a versioned one-time migration because moderation bindings
+	// reference them across credential rotation and process restarts.
+	if migrateProviderStableIDsV1(&cfg) && !optional && strings.TrimSpace(configFile) != "" {
+		if err = SaveConfigPreserveComments(configFile, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to persist provider stable ID migration: %w", err)
+		}
+	}
+
 	// Detect legacy keys but intentionally do not migrate/persist on startup.
 	// var legacy legacyConfigData
 	// if err = yaml.Unmarshal(data, &legacy); err == nil {

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -3,6 +3,9 @@ package config
 // ClaudeKey represents the configuration for a Claude API key,
 // including the API key itself and an optional base URL for the API endpoint.
 type ClaudeKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing Claude API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -63,6 +66,9 @@ func (m ClaudeModel) GetAlias() string { return m.Alias }
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
 type CodexKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing Codex API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -117,6 +123,9 @@ func (m CodexModel) GetAlias() string { return m.Alias }
 // GeminiKey represents the configuration for a Gemini API key,
 // including optional overrides for upstream base URL, proxy routing, and headers.
 type GeminiKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing Gemini API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -167,6 +176,9 @@ func (m GeminiModel) GetAlias() string { return m.Alias }
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
 type OpenAICompatibility struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// Name is the identifier for this OpenAI compatibility configuration.
 	Name string `yaml:"name" json:"name"`
 
@@ -195,6 +207,9 @@ type OpenAICompatibility struct {
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.
 type OpenAICompatibilityAPIKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing the external API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -224,6 +239,9 @@ func (m OpenAICompatibilityModel) GetAlias() string { return m.Alias }
 // OpenCodeGoKey represents an OpenCode Go plan API key.
 // The upstream endpoint is fixed to https://opencode.ai/zen/go/v1.
 type OpenCodeGoKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for OpenCode Go.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -278,6 +296,9 @@ const DefaultClineBaseURL = "https://api.cline.bot/api/v1"
 
 // ClineKey represents a ClinePass OpenAI-compatible API key.
 type ClineKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	APIKey string `yaml:"api-key" json:"api-key"`
 
 	// Name is a human-readable label for this channel.
@@ -329,6 +350,9 @@ const DefaultOllamaCloudBaseURL = "https://ollama.com"
 
 // OllamaCloudKey represents an Ollama Cloud API key.
 type OllamaCloudKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	APIKey string `yaml:"api-key" json:"api-key"`
 
 	// Name is a human-readable label for this channel.

--- a/internal/config/provider_stable_ids.go
+++ b/internal/config/provider_stable_ids.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const providerStableIDMigrationVersion = 1
+
+// migrateProviderStableIDsV1 is kept versioned so future identifier migrations can
+// be introduced without changing the persisted IDs created by this rollout.
+func migrateProviderStableIDsV1(cfg *Config) bool {
+	_ = providerStableIDMigrationVersion
+	return cfg.EnsureProviderStableIDs()
+}
+
+// EnsureProviderStableIDs assigns persistent UUIDs to every config-backed provider channel.
+// Existing valid IDs are never recomputed, so credential rotation does not move bindings.
+func (cfg *Config) EnsureProviderStableIDs() bool {
+	if cfg == nil {
+		return false
+	}
+	changed := false
+	seen := make(map[string]struct{})
+	ensure := func(id *string) {
+		trimmed := strings.TrimSpace(*id)
+		if parsed, err := uuid.Parse(trimmed); err == nil {
+			normalized := parsed.String()
+			if _, exists := seen[normalized]; !exists {
+				seen[normalized] = struct{}{}
+				if *id != normalized {
+					*id = normalized
+					changed = true
+				}
+				return
+			}
+		}
+		*id = uuid.NewString()
+		seen[*id] = struct{}{}
+		changed = true
+	}
+
+	for i := range cfg.GeminiKey {
+		ensure(&cfg.GeminiKey[i].ID)
+	}
+	for i := range cfg.CodexKey {
+		ensure(&cfg.CodexKey[i].ID)
+	}
+	for i := range cfg.ClaudeKey {
+		ensure(&cfg.ClaudeKey[i].ID)
+	}
+	for i := range cfg.BedrockKey {
+		ensure(&cfg.BedrockKey[i].ID)
+	}
+	for i := range cfg.OpenCodeGoKey {
+		ensure(&cfg.OpenCodeGoKey[i].ID)
+	}
+	for i := range cfg.ClineKey {
+		ensure(&cfg.ClineKey[i].ID)
+	}
+	for i := range cfg.OllamaCloudKey {
+		ensure(&cfg.OllamaCloudKey[i].ID)
+	}
+	for i := range cfg.OpenAICompatibility {
+		ensure(&cfg.OpenAICompatibility[i].ID)
+		for j := range cfg.OpenAICompatibility[i].APIKeyEntries {
+			ensure(&cfg.OpenAICompatibility[i].APIKeyEntries[j].ID)
+		}
+	}
+	for i := range cfg.VertexCompatAPIKey {
+		ensure(&cfg.VertexCompatAPIKey[i].ID)
+	}
+	return changed
+}
+
+// PreserveMissingProviderStableIDs keeps IDs across full-array management PUTs whose
+// clients predate the ID field. Explicit IDs from import/export remain authoritative.
+func PreserveMissingProviderStableIDs(previous, next *Config) {
+	if previous == nil || next == nil {
+		return
+	}
+	preserveIDs(previous.GeminiKey, next.GeminiKey, func(v *GeminiKey) *string { return &v.ID })
+	preserveIDs(previous.CodexKey, next.CodexKey, func(v *CodexKey) *string { return &v.ID })
+	preserveIDs(previous.ClaudeKey, next.ClaudeKey, func(v *ClaudeKey) *string { return &v.ID })
+	preserveIDs(previous.BedrockKey, next.BedrockKey, func(v *BedrockKey) *string { return &v.ID })
+	preserveIDs(previous.OpenCodeGoKey, next.OpenCodeGoKey, func(v *OpenCodeGoKey) *string { return &v.ID })
+	preserveIDs(previous.ClineKey, next.ClineKey, func(v *ClineKey) *string { return &v.ID })
+	preserveIDs(previous.OllamaCloudKey, next.OllamaCloudKey, func(v *OllamaCloudKey) *string { return &v.ID })
+	preserveIDs(previous.VertexCompatAPIKey, next.VertexCompatAPIKey, func(v *VertexCompatKey) *string { return &v.ID })
+	preserveIDs(previous.OpenAICompatibility, next.OpenAICompatibility, func(v *OpenAICompatibility) *string { return &v.ID })
+	for i := range next.OpenAICompatibility {
+		if i >= len(previous.OpenAICompatibility) {
+			break
+		}
+		preserveIDs(
+			previous.OpenAICompatibility[i].APIKeyEntries,
+			next.OpenAICompatibility[i].APIKeyEntries,
+			func(v *OpenAICompatibilityAPIKey) *string { return &v.ID },
+		)
+	}
+}
+
+func preserveIDs[T any](previous, next []T, id func(*T) *string) {
+	for i := range next {
+		if strings.TrimSpace(*id(&next[i])) != "" || i >= len(previous) {
+			continue
+		}
+		*id(&next[i]) = strings.TrimSpace(*id(&previous[i]))
+	}
+}

--- a/internal/config/provider_stable_ids_test.go
+++ b/internal/config/provider_stable_ids_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoadConfigBackfillsProviderStableIDsOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `gemini-api-key:
+  - api-key: gemini-secret
+openai-compatibility:
+  - name: compat
+    base-url: https://compat.example
+    api-key-entries:
+      - api-key: compat-secret
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	first, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig(first): %v", err)
+	}
+	ids := []string{
+		first.GeminiKey[0].ID,
+		first.OpenAICompatibility[0].ID,
+		first.OpenAICompatibility[0].APIKeyEntries[0].ID,
+	}
+	for _, id := range ids {
+		if _, err := uuid.Parse(id); err != nil {
+			t.Fatalf("backfilled ID %q is not UUID: %v", id, err)
+		}
+	}
+
+	persisted, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(persisted, &raw); err != nil {
+		t.Fatalf("parse migrated config: %v", err)
+	}
+	if len(persisted) == 0 {
+		t.Fatal("migrated config is empty")
+	}
+
+	second, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig(second): %v", err)
+	}
+	got := []string{
+		second.GeminiKey[0].ID,
+		second.OpenAICompatibility[0].ID,
+		second.OpenAICompatibility[0].APIKeyEntries[0].ID,
+	}
+	for i := range ids {
+		if got[i] != ids[i] {
+			t.Fatalf("ID changed on second load: first=%q second=%q", ids[i], got[i])
+		}
+	}
+}
+
+func TestEnsureProviderStableIDsRepairsDuplicates(t *testing.T) {
+	duplicate := uuid.NewString()
+	cfg := &Config{
+		GeminiKey: []GeminiKey{{ID: duplicate, APIKey: "one"}},
+		ClaudeKey: []ClaudeKey{{ID: duplicate, APIKey: "two"}},
+	}
+	if !cfg.EnsureProviderStableIDs() {
+		t.Fatal("EnsureProviderStableIDs returned false for duplicate IDs")
+	}
+	if cfg.GeminiKey[0].ID == cfg.ClaudeKey[0].ID {
+		t.Fatalf("duplicate IDs were not repaired: %q", duplicate)
+	}
+}

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -9,6 +9,9 @@ import "strings"
 //
 // Example services: zenmux.ai and similar Vertex-compatible providers.
 type VertexCompatKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing the Vertex-compatible API.
 	// Maps to the x-goog-api-key header.
 	APIKey string `yaml:"api-key" json:"api-key"`

--- a/internal/contentmoderation/catalog.go
+++ b/internal/contentmoderation/catalog.go
@@ -1,0 +1,344 @@
+package contentmoderation
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type Channel struct {
+	ChannelType string   `json:"channel_type"`
+	ChannelID   string   `json:"channel_id"`
+	Name        string   `json:"name"`
+	Provider    string   `json:"provider"`
+	Tags        []string `json:"tags"`
+	Disabled    bool     `json:"disabled"`
+	ProfileID   string   `json:"profile_id,omitempty"`
+}
+
+type ChannelRef struct {
+	ChannelType string
+	ChannelID   string
+}
+
+type ChannelQuery struct {
+	ChannelType string
+	Query       string
+	Tags        []string
+	TagMode     string
+	Provider    string
+	ProfileID   string
+	Page        int
+	PageSize    int
+}
+
+type ChannelPage struct {
+	Items    []Channel `json:"items"`
+	Page     int       `json:"page"`
+	PageSize int       `json:"page_size"`
+	Total    int       `json:"total"`
+}
+
+func ListChannels(cfg *config.Config, auths []*coreauth.Auth, bindings []Binding, query ChannelQuery) ChannelPage {
+	bindingByChannel := make(map[string]string, len(bindings))
+	for _, binding := range bindings {
+		bindingByChannel[binding.ChannelType+"\x00"+binding.ChannelID] = binding.ProfileID
+	}
+	channels := buildChannels(cfg, auths, bindingByChannel)
+	filtered := channels[:0]
+	for _, channel := range channels {
+		if channelMatches(channel, query) {
+			filtered = append(filtered, channel)
+		}
+	}
+	page := query.Page
+	if page < 1 {
+		page = 1
+	}
+	pageSize := query.PageSize
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	if pageSize > 50 {
+		pageSize = 50
+	}
+	start := (page - 1) * pageSize
+	if start > len(filtered) {
+		start = len(filtered)
+	}
+	end := start + pageSize
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	items := append([]Channel(nil), filtered[start:end]...)
+	return ChannelPage{Items: items, Page: page, PageSize: pageSize, Total: len(filtered)}
+}
+
+func ChannelExists(cfg *config.Config, auths []*coreauth.Auth, channelType, channelID string) bool {
+	channelType = strings.TrimSpace(channelType)
+	channelID = strings.TrimSpace(channelID)
+	if channelID == "" || !IsChannelType(channelType) {
+		return false
+	}
+	for _, channel := range buildChannels(cfg, auths, nil) {
+		if channel.ChannelType == channelType && channel.ChannelID == channelID {
+			return true
+		}
+	}
+	return false
+}
+
+func ProviderChannelRefs(cfg *config.Config) []ChannelRef {
+	if cfg == nil {
+		return nil
+	}
+	refs := make([]ChannelRef, 0, len(cfg.GeminiKey)+len(cfg.ClaudeKey)+len(cfg.BedrockKey)+len(cfg.CodexKey)+len(cfg.OpenCodeGoKey)+len(cfg.ClineKey)+len(cfg.OllamaCloudKey)+len(cfg.VertexCompatAPIKey)+len(cfg.OpenAICompatibility))
+	addKey := func(id string) {
+		if id = strings.TrimSpace(id); id != "" {
+			refs = append(refs, ChannelRef{ChannelType: ChannelTypeProviderKey, ChannelID: id})
+		}
+	}
+	for _, entry := range cfg.GeminiKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.ClaudeKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.BedrockKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.CodexKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.OpenCodeGoKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.ClineKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.OllamaCloudKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.VertexCompatAPIKey {
+		addKey(entry.ID)
+	}
+	for _, provider := range cfg.OpenAICompatibility {
+		if id := strings.TrimSpace(provider.ID); id != "" {
+			refs = append(refs, ChannelRef{ChannelType: ChannelTypeProvider, ChannelID: id})
+		}
+		for _, entry := range provider.APIKeyEntries {
+			addKey(entry.ID)
+		}
+	}
+	return refs
+}
+
+func NormalizeAuthFileChannelID(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if parent := strings.TrimSpace(auth.Attributes["gemini_virtual_parent"]); parent != "" {
+		return parent
+	}
+	return strings.TrimSpace(auth.ID)
+}
+
+func buildChannels(cfg *config.Config, auths []*coreauth.Auth, bindings map[string]string) []Channel {
+	channels := make([]Channel, 0, len(auths)+16)
+	seen := make(map[string]struct{})
+	add := func(channel Channel) {
+		channel.ChannelType = strings.TrimSpace(channel.ChannelType)
+		channel.ChannelID = strings.TrimSpace(channel.ChannelID)
+		if channel.ChannelID == "" || !IsChannelType(channel.ChannelType) {
+			return
+		}
+		key := channel.ChannelType + "\x00" + channel.ChannelID
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		channel.Name = strings.TrimSpace(channel.Name)
+		if channel.Name == "" {
+			channel.Name = channel.Provider
+		}
+		channel.Provider = strings.ToLower(strings.TrimSpace(channel.Provider))
+		if channel.Tags == nil {
+			channel.Tags = []string{}
+		}
+		channel.ProfileID = bindings[key]
+		channels = append(channels, channel)
+	}
+
+	for _, auth := range auths {
+		if auth == nil || (strings.TrimSpace(auth.FileName) == "" && strings.TrimSpace(auth.Attributes["path"]) == "") {
+			continue
+		}
+		channelID := NormalizeAuthFileChannelID(auth)
+		name := strings.TrimSpace(auth.Label)
+		if name == "" {
+			name = strings.TrimSpace(auth.FileName)
+		}
+		if name == "" {
+			name = channelID
+		}
+		add(Channel{
+			ChannelType: ChannelTypeAuthFile,
+			ChannelID:   channelID,
+			Name:        name,
+			Provider:    auth.Provider,
+			Tags:        authDisplayTags(auth),
+			Disabled:    auth.Disabled,
+		})
+	}
+	if cfg != nil {
+		for _, entry := range cfg.GeminiKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "gemini", false))
+		}
+		for _, entry := range cfg.ClaudeKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "claude", false))
+		}
+		for _, entry := range cfg.BedrockKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "bedrock", false))
+		}
+		for _, entry := range cfg.CodexKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "codex", false))
+		}
+		for _, entry := range cfg.OpenCodeGoKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "opencode-go", entry.Disabled))
+		}
+		for _, entry := range cfg.ClineKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "cline", entry.Disabled))
+		}
+		for _, entry := range cfg.OllamaCloudKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "ollama-cloud", entry.Disabled))
+		}
+		for _, entry := range cfg.VertexCompatAPIKey {
+			add(simpleProviderChannel(entry.ID, "vertex", "vertex", false))
+		}
+		for _, provider := range cfg.OpenAICompatibility {
+			providerName := strings.ToLower(strings.TrimSpace(provider.Name))
+			add(Channel{ChannelType: ChannelTypeProvider, ChannelID: provider.ID, Name: provider.Name, Provider: providerName, Tags: []string{}, Disabled: provider.Disabled})
+			for index, entry := range provider.APIKeyEntries {
+				name := fmt.Sprintf("%s key %d", strings.TrimSpace(provider.Name), index+1)
+				add(Channel{ChannelType: ChannelTypeProviderKey, ChannelID: entry.ID, Name: name, Provider: providerName, Tags: []string{}, Disabled: provider.Disabled || entry.Disabled})
+			}
+		}
+	}
+	sort.Slice(channels, func(i, j int) bool {
+		if channels[i].ChannelType != channels[j].ChannelType {
+			return channels[i].ChannelType < channels[j].ChannelType
+		}
+		left, right := strings.ToLower(channels[i].Name), strings.ToLower(channels[j].Name)
+		if left != right {
+			return left < right
+		}
+		return channels[i].ChannelID < channels[j].ChannelID
+	})
+	return channels
+}
+
+func simpleProviderChannel(id, name, provider string, disabled bool) Channel {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = provider
+	}
+	return Channel{ChannelType: ChannelTypeProviderKey, ChannelID: id, Name: name, Provider: provider, Tags: []string{}, Disabled: disabled}
+}
+
+func channelMatches(channel Channel, query ChannelQuery) bool {
+	if channelType := strings.TrimSpace(query.ChannelType); channelType != "" && channel.ChannelType != channelType {
+		return false
+	}
+	if provider := strings.ToLower(strings.TrimSpace(query.Provider)); provider != "" && channel.Provider != provider {
+		return false
+	}
+	if profileID := strings.TrimSpace(query.ProfileID); profileID != "" && channel.ProfileID != profileID {
+		return false
+	}
+	if needle := strings.ToLower(strings.TrimSpace(query.Query)); needle != "" {
+		haystack := strings.ToLower(channel.Name + "\n" + channel.Provider + "\n" + channel.ChannelID)
+		if !strings.Contains(haystack, needle) {
+			return false
+		}
+	}
+	if len(query.Tags) == 0 {
+		return true
+	}
+	tagSet := make(map[string]struct{}, len(channel.Tags))
+	for _, tag := range channel.Tags {
+		tagSet[strings.ToLower(strings.TrimSpace(tag))] = struct{}{}
+	}
+	matched := 0
+	for _, tag := range query.Tags {
+		if _, ok := tagSet[strings.ToLower(strings.TrimSpace(tag))]; ok {
+			matched++
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(query.TagMode), "all") {
+		return matched == len(query.Tags)
+	}
+	return matched > 0
+}
+
+func authDisplayTags(auth *coreauth.Auth) []string {
+	if auth == nil {
+		return []string{}
+	}
+	if tags, present := metadataStringSlice(auth.Metadata, "display_tags"); present {
+		return tags
+	}
+	values := []string{auth.Provider}
+	if plan, _ := auth.Metadata["plan_type"].(string); strings.TrimSpace(plan) != "" {
+		values = append(values, plan)
+	}
+	if custom, _ := metadataStringSlice(auth.Metadata, "custom_tags"); len(custom) > 0 {
+		values = append(values, custom...)
+	}
+	return normalizeTags(values)
+}
+
+func metadataStringSlice(metadata map[string]any, key string) ([]string, bool) {
+	if metadata == nil {
+		return nil, false
+	}
+	raw, exists := metadata[key]
+	if !exists {
+		return nil, false
+	}
+	switch value := raw.(type) {
+	case []string:
+		return normalizeTags(value), true
+	case []any:
+		items := make([]string, 0, len(value))
+		for _, item := range value {
+			if text, ok := item.(string); ok {
+				items = append(items, text)
+			}
+		}
+		return normalizeTags(items), true
+	case string:
+		return normalizeTags(strings.Split(value, ",")), true
+	default:
+		return []string{}, true
+	}
+}
+
+func normalizeTags(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/contentmoderation/catalog_test.go
+++ b/internal/contentmoderation/catalog_test.go
@@ -1,0 +1,48 @@
+package contentmoderation
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestListChannelsPaginatesAndNormalizesGeminiVirtualParent(t *testing.T) {
+	cfg := &config.Config{GeminiKey: []config.GeminiKey{{ID: "provider-key-1", Name: "Gemini Provider", APIKey: "secret"}}}
+	auths := []*coreauth.Auth{
+		{ID: "parent-auth", FileName: "gemini.json", Provider: "gemini-cli", Label: "Gemini Account", Metadata: map[string]any{"display_tags": []string{"team-a"}}},
+		{ID: "virtual-auth", Provider: "gemini-cli", Label: "Virtual", Attributes: map[string]string{"path": "gemini.json", "gemini_virtual_parent": "parent-auth"}},
+	}
+	page := ListChannels(cfg, auths, nil, ChannelQuery{Page: 1, PageSize: 1})
+	if page.Total != 2 || len(page.Items) != 1 {
+		t.Fatalf("page = %#v", page)
+	}
+	full := ListChannels(cfg, auths, nil, ChannelQuery{Page: 1, PageSize: 50})
+	authCount := 0
+	for _, channel := range full.Items {
+		if channel.ChannelType == ChannelTypeAuthFile {
+			authCount++
+			if channel.ChannelID != "parent-auth" {
+				t.Fatalf("auth channel id = %q, want parent-auth", channel.ChannelID)
+			}
+		}
+	}
+	if authCount != 1 {
+		t.Fatalf("auth channel count = %d, want 1", authCount)
+	}
+}
+
+func TestListChannelsFiltersTagsAndBindings(t *testing.T) {
+	auths := []*coreauth.Auth{{
+		ID:       "auth-1",
+		FileName: "auth.json",
+		Provider: "codex",
+		Label:    "Codex Team",
+		Metadata: map[string]any{"display_tags": []string{"team-a", "pro"}},
+	}}
+	bindings := []Binding{{ChannelType: ChannelTypeAuthFile, ChannelID: "auth-1", ProfileID: "profile-1"}}
+	page := ListChannels(&config.Config{}, auths, bindings, ChannelQuery{Tags: []string{"team-a", "pro"}, TagMode: "all", ProfileID: "profile-1"})
+	if page.Total != 1 || page.Items[0].ProfileID != "profile-1" {
+		t.Fatalf("filtered page = %#v", page)
+	}
+}

--- a/internal/contentmoderation/evaluator.go
+++ b/internal/contentmoderation/evaluator.go
@@ -1,0 +1,137 @@
+package contentmoderation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	ActionAllow        = "allow"
+	ActionKeywordBlock = "keyword_block"
+	ActionAPIBlock     = "api_block"
+	ActionAPIError     = "api_error"
+)
+
+type Decision struct {
+	WouldBlock      bool               `json:"would_block"`
+	Action          string             `json:"action"`
+	MatchedKeyword  string             `json:"matched_keyword,omitempty"`
+	HighestCategory string             `json:"highest_category,omitempty"`
+	HighestScore    float64            `json:"highest_score,omitempty"`
+	CategoryScores  map[string]float64 `json:"category_scores"`
+	Thresholds      map[string]float64 `json:"thresholds"`
+	LatencyMS       int64              `json:"latency_ms"`
+	ModerationError string             `json:"moderation_error,omitempty"`
+}
+
+type Evaluator struct {
+	httpClient *http.Client
+}
+
+func NewEvaluator(client *http.Client) *Evaluator {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Evaluator{httpClient: client}
+}
+
+func (e *Evaluator) Evaluate(ctx context.Context, profile Profile, input string) Decision {
+	decision := Decision{Action: ActionAllow, CategoryScores: map[string]float64{}, Thresholds: mergeThresholds(profile.Thresholds)}
+	input = strings.TrimSpace(input)
+	if profile.Mode != ModePreBlock || input == "" {
+		return decision
+	}
+	if profile.KeywordMode != KeywordModeAPIOnly {
+		if keyword, hit := matchKeyword(input, profile.BlockedKeywords); hit {
+			decision.WouldBlock = true
+			decision.Action = ActionKeywordBlock
+			decision.MatchedKeyword = keyword
+			return decision
+		}
+	}
+	if profile.KeywordMode == KeywordModeKeywordOnly {
+		return decision
+	}
+	start := time.Now()
+	scores, err := e.callModeration(ctx, profile, input)
+	decision.LatencyMS = time.Since(start).Milliseconds()
+	if err != nil {
+		decision.Action = ActionAPIError
+		decision.ModerationError = err.Error()
+		return decision
+	}
+	decision.CategoryScores = scores
+	for category, score := range scores {
+		if decision.HighestCategory == "" || score > decision.HighestScore {
+			decision.HighestCategory = category
+			decision.HighestScore = score
+		}
+		if threshold, ok := decision.Thresholds[category]; ok && score >= threshold {
+			decision.WouldBlock = true
+		}
+	}
+	if decision.WouldBlock {
+		decision.Action = ActionAPIBlock
+	}
+	return decision
+}
+
+func matchKeyword(input string, keywords []string) (string, bool) {
+	input = strings.ToLower(input)
+	for _, keyword := range keywords {
+		keyword = strings.TrimSpace(keyword)
+		if keyword != "" && strings.Contains(input, strings.ToLower(keyword)) {
+			return keyword, true
+		}
+	}
+	return "", false
+}
+
+func (e *Evaluator) callModeration(ctx context.Context, profile Profile, input string) (map[string]float64, error) {
+	endpoint, err := url.JoinPath(strings.TrimRight(profile.BaseURL, "/"), "v1/moderations")
+	if err != nil {
+		return nil, fmt.Errorf("invalid moderation base URL: %w", err)
+	}
+	payload, err := json.Marshal(struct {
+		Model string `json:"model"`
+		Input string `json:"input"`
+	}{Model: profile.Model, Input: input})
+	if err != nil {
+		return nil, fmt.Errorf("encode moderation request: %w", err)
+	}
+	timeout := time.Duration(profile.TimeoutMS) * time.Millisecond
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create moderation request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+profile.APIKeySecret)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("moderation request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("moderation API returned status %d", resp.StatusCode)
+	}
+	var result struct {
+		Results []struct {
+			CategoryScores map[string]float64 `json:"category_scores"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode moderation response: %w", err)
+	}
+	if len(result.Results) == 0 || result.Results[0].CategoryScores == nil {
+		return nil, fmt.Errorf("moderation response missing category scores")
+	}
+	return result.Results[0].CategoryScores, nil
+}

--- a/internal/contentmoderation/evaluator_test.go
+++ b/internal/contentmoderation/evaluator_test.go
@@ -1,0 +1,44 @@
+package contentmoderation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestEvaluatorKeywordAndAPIModes(t *testing.T) {
+	profile := testProfile(t, "tenant-a", "keywords", ModePreBlock, KeywordModeKeywordOnly)
+	profile.BlockedKeywords = []string{"forbidden"}
+	decision := NewEvaluator(nil).Evaluate(context.Background(), profile, "contains FORBIDDEN text")
+	if !decision.WouldBlock || decision.Action != ActionKeywordBlock || decision.MatchedKeyword != "forbidden" {
+		t.Fatalf("keyword decision = %#v", decision)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"category_scores":{"hate":0.9,"violence":0.1}}]}`))
+	}))
+	defer server.Close()
+	profile.BaseURL = server.URL
+	profile.KeywordMode = KeywordModeAPIOnly
+	decision = NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "test input")
+	if !decision.WouldBlock || decision.Action != ActionAPIBlock || decision.HighestCategory != "hate" {
+		t.Fatalf("api decision = %#v", decision)
+	}
+}
+
+func TestEvaluatorFailsOpenOnModerationError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	profile := testProfile(t, "tenant-a", "api", ModePreBlock, KeywordModeAPIOnly)
+	profile.BaseURL = server.URL
+	profile.TimeoutMS = int((100 * time.Millisecond) / time.Millisecond)
+	decision := NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "test input")
+	if decision.WouldBlock || decision.Action != ActionAPIError || decision.ModerationError == "" {
+		t.Fatalf("fail-open decision = %#v", decision)
+	}
+}

--- a/internal/contentmoderation/extractor.go
+++ b/internal/contentmoderation/extractor.go
@@ -30,14 +30,14 @@ func collectLastRoleContent(messages gjson.Result, role string, parts *[]string,
 		return
 	}
 	items := messages.Array()
-	if len(items) == 0 {
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		if !strings.EqualFold(strings.TrimSpace(item.Get("role").String()), role) {
+			continue
+		}
+		collectTextValue(item.Get("content"), parts, skipSystemReminder)
 		return
 	}
-	last := items[len(items)-1]
-	if !strings.EqualFold(strings.TrimSpace(last.Get("role").String()), role) {
-		return
-	}
-	collectTextValue(last.Get("content"), parts, skipSystemReminder)
 }
 
 func collectResponsesInput(input gjson.Result, parts *[]string) {
@@ -48,18 +48,18 @@ func collectResponsesInput(input gjson.Result, parts *[]string) {
 		addText(parts, input.String(), false)
 	case input.IsArray():
 		items := input.Array()
-		if len(items) == 0 {
+		for i := len(items) - 1; i >= 0; i-- {
+			item := items[i]
+			role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+			typeName := strings.ToLower(strings.TrimSpace(item.Get("type").String()))
+			if role != "user" && typeName != "input_text" {
+				continue
+			}
+			collectTextValue(item.Get("content"), parts, false)
+			if typeName == "input_text" || item.Get("text").Exists() {
+				collectTextValue(item, parts, false)
+			}
 			return
-		}
-		last := items[len(items)-1]
-		role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
-		typeName := strings.ToLower(strings.TrimSpace(last.Get("type").String()))
-		if role != "user" && typeName != "input_text" {
-			return
-		}
-		collectTextValue(last.Get("content"), parts, false)
-		if typeName == "input_text" || last.Get("text").Exists() {
-			collectTextValue(last, parts, false)
 		}
 	case input.IsObject():
 		role := strings.ToLower(strings.TrimSpace(input.Get("role").String()))
@@ -76,18 +76,18 @@ func collectLastGeminiContent(contents gjson.Result, parts *[]string) {
 		return
 	}
 	items := contents.Array()
-	if len(items) == 0 {
-		return
-	}
-	last := items[len(items)-1]
-	role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
-	if role != "" && role != "user" {
-		return
-	}
-	if values := last.Get("parts"); values.IsArray() {
-		for _, part := range values.Array() {
-			addText(parts, part.Get("text").String(), false)
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+		if role != "" && role != "user" {
+			continue
 		}
+		if values := item.Get("parts"); values.IsArray() {
+			for _, part := range values.Array() {
+				addText(parts, part.Get("text").String(), false)
+			}
+		}
+		return
 	}
 }
 

--- a/internal/contentmoderation/extractor.go
+++ b/internal/contentmoderation/extractor.go
@@ -1,0 +1,119 @@
+package contentmoderation
+
+import (
+	"strings"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func ExtractLastUserText(format sdktranslator.Format, payload []byte) string {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return ""
+	}
+	var parts []string
+	switch format {
+	case sdktranslator.FormatOpenAIResponse:
+		collectResponsesInput(gjson.GetBytes(payload, "input"), &parts)
+	case sdktranslator.FormatClaude:
+		collectLastRoleContent(gjson.GetBytes(payload, "messages"), "user", &parts, true)
+	case sdktranslator.FormatGemini, sdktranslator.FormatGeminiCLI:
+		collectLastGeminiContent(gjson.GetBytes(payload, "contents"), &parts)
+	default:
+		collectLastRoleContent(gjson.GetBytes(payload, "messages"), "user", &parts, false)
+	}
+	return strings.Join(strings.Fields(strings.Join(parts, "\n")), " ")
+}
+
+func collectLastRoleContent(messages gjson.Result, role string, parts *[]string, skipSystemReminder bool) {
+	if !messages.IsArray() {
+		return
+	}
+	items := messages.Array()
+	if len(items) == 0 {
+		return
+	}
+	last := items[len(items)-1]
+	if !strings.EqualFold(strings.TrimSpace(last.Get("role").String()), role) {
+		return
+	}
+	collectTextValue(last.Get("content"), parts, skipSystemReminder)
+}
+
+func collectResponsesInput(input gjson.Result, parts *[]string) {
+	switch {
+	case !input.Exists():
+		return
+	case input.Type == gjson.String:
+		addText(parts, input.String(), false)
+	case input.IsArray():
+		items := input.Array()
+		if len(items) == 0 {
+			return
+		}
+		last := items[len(items)-1]
+		role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
+		typeName := strings.ToLower(strings.TrimSpace(last.Get("type").String()))
+		if role != "user" && typeName != "input_text" {
+			return
+		}
+		collectTextValue(last.Get("content"), parts, false)
+		if typeName == "input_text" || last.Get("text").Exists() {
+			collectTextValue(last, parts, false)
+		}
+	case input.IsObject():
+		role := strings.ToLower(strings.TrimSpace(input.Get("role").String()))
+		typeName := strings.ToLower(strings.TrimSpace(input.Get("type").String()))
+		if role == "user" || typeName == "input_text" {
+			collectTextValue(input.Get("content"), parts, false)
+			collectTextValue(input, parts, false)
+		}
+	}
+}
+
+func collectLastGeminiContent(contents gjson.Result, parts *[]string) {
+	if !contents.IsArray() {
+		return
+	}
+	items := contents.Array()
+	if len(items) == 0 {
+		return
+	}
+	last := items[len(items)-1]
+	role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
+	if role != "" && role != "user" {
+		return
+	}
+	if values := last.Get("parts"); values.IsArray() {
+		for _, part := range values.Array() {
+			addText(parts, part.Get("text").String(), false)
+		}
+	}
+}
+
+func collectTextValue(value gjson.Result, parts *[]string, skipSystemReminder bool) {
+	switch {
+	case !value.Exists():
+		return
+	case value.Type == gjson.String:
+		addText(parts, value.String(), skipSystemReminder)
+	case value.IsArray():
+		for _, item := range value.Array() {
+			collectTextValue(item, parts, skipSystemReminder)
+		}
+	case value.IsObject():
+		typeName := strings.ToLower(strings.TrimSpace(value.Get("type").String()))
+		if typeName == "" || typeName == "text" || typeName == "input_text" || typeName == "message" {
+			addText(parts, value.Get("text").String(), skipSystemReminder)
+			collectTextValue(value.Get("content"), parts, skipSystemReminder)
+		}
+	}
+}
+
+func addText(parts *[]string, value string, skipSystemReminder bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || (skipSystemReminder && strings.HasPrefix(value, "<system-reminder>")) {
+		return
+	}
+	*parts = append(*parts, value)
+}

--- a/internal/contentmoderation/extractor_test.go
+++ b/internal/contentmoderation/extractor_test.go
@@ -17,6 +17,9 @@ func TestExtractLastUserText(t *testing.T) {
 		{"responses", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"assistant","content":[{"type":"output_text","text":"old"}]},{"role":"user","content":[{"type":"input_text","text":"response text"}]}]}`, "response text"},
 		{"claude", sdktranslator.FormatClaude, `{"messages":[{"role":"user","content":[{"type":"text","text":"claude text"}]}]}`, "claude text"},
 		{"gemini", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini text"}]}]}`, "gemini text"},
+		{"last user before assistant", sdktranslator.FormatOpenAI, `{"messages":[{"role":"user","content":"last user"},{"role":"assistant","content":"generated"}]}`, "last user"},
+		{"responses last user before output", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"user","content":[{"type":"input_text","text":"response user"}]},{"role":"assistant","content":[{"type":"output_text","text":"generated"}]}]}`, "response user"},
+		{"gemini last user before model", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini user"}]},{"role":"model","parts":[{"text":"generated"}]}]}`, "gemini user"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/contentmoderation/extractor_test.go
+++ b/internal/contentmoderation/extractor_test.go
@@ -1,0 +1,28 @@
+package contentmoderation
+
+import (
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+func TestExtractLastUserText(t *testing.T) {
+	tests := []struct {
+		name   string
+		format sdktranslator.Format
+		body   string
+		want   string
+	}{
+		{"openai chat", sdktranslator.FormatOpenAI, `{"messages":[{"role":"assistant","content":"old"},{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":"world"}]}]}`, "hello world"},
+		{"responses", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"assistant","content":[{"type":"output_text","text":"old"}]},{"role":"user","content":[{"type":"input_text","text":"response text"}]}]}`, "response text"},
+		{"claude", sdktranslator.FormatClaude, `{"messages":[{"role":"user","content":[{"type":"text","text":"claude text"}]}]}`, "claude text"},
+		{"gemini", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini text"}]}]}`, "gemini text"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractLastUserText(tt.format, []byte(tt.body)); got != tt.want {
+				t.Fatalf("ExtractLastUserText = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/contentmoderation/runtime.go
+++ b/internal/contentmoderation/runtime.go
@@ -1,0 +1,312 @@
+package contentmoderation
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+const requestDecisionCacheMetadataKey = "content_moderation_decision_cache"
+
+type ProfileResolver interface {
+	ResolveProfile(ctx context.Context, tenantID, authFileID, providerKeyID, providerID string) (Profile, string, error)
+}
+
+type DecisionEvaluator interface {
+	Evaluate(ctx context.Context, profile Profile, input string) Decision
+}
+
+type RuntimeModerator struct {
+	resolver  ProfileResolver
+	evaluator DecisionEvaluator
+
+	lastGoodMu sync.RWMutex
+	lastGood   map[resolutionKey]resolvedProfile
+
+	requests  atomic.Uint64
+	allows    atomic.Uint64
+	blocks    atomic.Uint64
+	errors    atomic.Uint64
+	cacheHits atomic.Uint64
+}
+
+type resolutionKey struct {
+	tenantID      string
+	authFileID    string
+	providerKeyID string
+	providerID    string
+}
+
+type resolvedProfile struct {
+	profile Profile
+	source  string
+}
+
+type requestDecisionCache struct {
+	mu        sync.Mutex
+	decisions map[string]Decision
+}
+
+type ModerationMetrics struct {
+	Requests  uint64 `json:"requests"`
+	Allows    uint64 `json:"allows"`
+	Blocks    uint64 `json:"blocks"`
+	Errors    uint64 `json:"errors"`
+	CacheHits uint64 `json:"cache_hits"`
+}
+
+func NewRequestModerator(resolver ProfileResolver, evaluator DecisionEvaluator) *RuntimeModerator {
+	if evaluator == nil {
+		evaluator = NewEvaluator(nil)
+	}
+	return &RuntimeModerator{
+		resolver:  resolver,
+		evaluator: evaluator,
+		lastGood:  make(map[resolutionKey]resolvedProfile),
+	}
+}
+
+func (m *RuntimeModerator) Metrics() ModerationMetrics {
+	if m == nil {
+		return ModerationMetrics{}
+	}
+	return ModerationMetrics{
+		Requests:  m.requests.Load(),
+		Allows:    m.allows.Load(),
+		Blocks:    m.blocks.Load(),
+		Errors:    m.errors.Load(),
+		CacheHits: m.cacheHits.Load(),
+	}
+}
+
+func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, opts cliproxyexecutor.Options) coreauth.RequestModerationResult {
+	if m == nil || auth == nil || m.resolver == nil || m.evaluator == nil {
+		return coreauth.RequestModerationResult{}
+	}
+	m.requests.Add(1)
+	tenantID := coreauth.NormalizedTenantID(metadataString(opts.Metadata, cliproxyexecutor.TenantMetadataKey))
+	if coreauth.NormalizedTenantID(auth.TenantID) != tenantID {
+		m.recordError(tenantID, auth, "", Profile{}, "tenant_mismatch", 0)
+		return coreauth.RequestModerationResult{}
+	}
+
+	authFileID, providerKeyID, providerID := runtimeChannelIDs(auth)
+	key := resolutionKey{tenantID: tenantID, authFileID: authFileID, providerKeyID: providerKeyID, providerID: providerID}
+	resolved, usedLastGood, err := m.resolve(ctx, key)
+	if errors.Is(err, ErrNotFound) {
+		m.allows.Add(1)
+		return coreauth.RequestModerationResult{}
+	}
+	if err != nil {
+		m.recordError(tenantID, auth, "", Profile{}, "store_error", 0)
+		return coreauth.RequestModerationResult{}
+	}
+	if usedLastGood {
+		m.recordError(tenantID, auth, resolved.source, resolved.profile, "store_error_last_good", 0)
+	}
+	profile := resolved.profile
+	if profile.Mode == ModeOff {
+		m.allows.Add(1)
+		m.logDecision(tenantID, auth, resolved.source, profile, Decision{Action: ActionAllow}, false)
+		return coreauth.RequestModerationResult{}
+	}
+
+	input := ExtractLastUserText(opts.SourceFormat, opts.OriginalRequest)
+	if input == "" {
+		m.allows.Add(1)
+		m.logDecision(tenantID, auth, resolved.source, profile, Decision{Action: ActionAllow}, false)
+		return coreauth.RequestModerationResult{}
+	}
+
+	cacheKey := decisionCacheKey(profile, input)
+	cache := decisionCacheFromMetadata(opts.Metadata)
+	if cache != nil {
+		if decision, ok := cache.get(cacheKey); ok {
+			m.cacheHits.Add(1)
+			return m.resultForDecision(tenantID, auth, resolved.source, profile, decision, true)
+		}
+	}
+	decision := m.evaluator.Evaluate(ctx, profile, input)
+	if cache != nil {
+		cache.put(cacheKey, decision)
+	}
+	return m.resultForDecision(tenantID, auth, resolved.source, profile, decision, false)
+}
+
+func (m *RuntimeModerator) resolve(ctx context.Context, key resolutionKey) (resolvedProfile, bool, error) {
+	profile, source, err := m.resolver.ResolveProfile(ctx, key.tenantID, key.authFileID, key.providerKeyID, key.providerID)
+	if err == nil {
+		resolved := resolvedProfile{profile: profile, source: source}
+		m.lastGoodMu.Lock()
+		m.lastGood[key] = resolved
+		m.lastGoodMu.Unlock()
+		return resolved, false, nil
+	}
+	if errors.Is(err, ErrNotFound) {
+		m.lastGoodMu.Lock()
+		delete(m.lastGood, key)
+		m.lastGoodMu.Unlock()
+		return resolvedProfile{}, false, ErrNotFound
+	}
+	m.lastGoodMu.RLock()
+	resolved, ok := m.lastGood[key]
+	m.lastGoodMu.RUnlock()
+	if ok {
+		return resolved, true, nil
+	}
+	return resolvedProfile{}, false, err
+}
+
+func (m *RuntimeModerator) resultForDecision(tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) coreauth.RequestModerationResult {
+	if decision.Action == ActionAPIError {
+		m.allows.Add(1)
+		m.recordError(tenantID, auth, source, profile, moderationErrorClass(decision.ModerationError), decision.LatencyMS)
+		return coreauth.RequestModerationResult{}
+	}
+	if decision.WouldBlock {
+		m.blocks.Add(1)
+		m.logDecision(tenantID, auth, source, profile, decision, cached)
+		return coreauth.RequestModerationResult{Blocked: true, Message: profile.BlockMessage, HTTPStatus: profile.BlockHTTPStatus}
+	}
+	m.allows.Add(1)
+	m.logDecision(tenantID, auth, source, profile, decision, cached)
+	return coreauth.RequestModerationResult{}
+}
+
+func (m *RuntimeModerator) recordError(tenantID string, auth *coreauth.Auth, source string, profile Profile, errorClass string, latencyMS int64) {
+	m.errors.Add(1)
+	fields := moderationLogFields(tenantID, auth, source, profile)
+	fields["action"] = ActionAPIError
+	fields["error_class"] = errorClass
+	fields["latency_ms"] = latencyMS
+	log.WithFields(fields).Warn("content moderation failed open")
+}
+
+func (m *RuntimeModerator) logDecision(tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) {
+	fields := moderationLogFields(tenantID, auth, source, profile)
+	fields["action"] = decision.Action
+	fields["latency_ms"] = decision.LatencyMS
+	fields["cache_hit"] = cached
+	if decision.Action == ActionKeywordBlock {
+		fields["category"] = "keyword"
+		fields["score"] = 1.0
+	} else if decision.HighestCategory != "" {
+		fields["category"] = decision.HighestCategory
+		fields["score"] = decision.HighestScore
+	}
+	entry := log.WithFields(fields)
+	if decision.WouldBlock {
+		entry.Warn("content moderation blocked request")
+	} else {
+		entry.Debug("content moderation allowed request")
+	}
+}
+
+func moderationLogFields(tenantID string, auth *coreauth.Auth, source string, profile Profile) log.Fields {
+	channelType, channelID := resolvedChannel(auth, source)
+	return log.Fields{
+		"tenant_id":         tenantID,
+		"profile_id":        profile.ID,
+		"profile_version":   profile.Version,
+		"resolution_source": source,
+		"channel_type":      channelType,
+		"channel_id":        channelID,
+	}
+}
+
+func resolvedChannel(auth *coreauth.Auth, source string) (string, string) {
+	authFileID, providerKeyID, providerID := runtimeChannelIDs(auth)
+	switch source {
+	case ChannelTypeAuthFile:
+		return source, authFileID
+	case ChannelTypeProviderKey:
+		return source, providerKeyID
+	case ChannelTypeProvider:
+		return source, providerID
+	default:
+		return "", ""
+	}
+}
+
+func runtimeChannelIDs(auth *coreauth.Auth) (authFileID, providerKeyID, providerID string) {
+	if auth == nil {
+		return "", "", ""
+	}
+	if strings.TrimSpace(auth.FileName) != "" || strings.TrimSpace(auth.Attributes["path"]) != "" {
+		authFileID = strings.TrimSpace(auth.Attributes["gemini_virtual_parent"])
+		if authFileID == "" {
+			authFileID = strings.TrimSpace(auth.ID)
+		}
+	}
+	providerKeyID = strings.TrimSpace(auth.Attributes["provider_key_id"])
+	providerID = strings.TrimSpace(auth.Attributes["provider_config_id"])
+	return authFileID, providerKeyID, providerID
+}
+
+func decisionCacheKey(profile Profile, input string) string {
+	hash := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("%s:%d:%x", profile.ID, profile.Version, hash)
+}
+
+func decisionCacheFromMetadata(metadata map[string]any) *requestDecisionCache {
+	if metadata == nil {
+		return nil
+	}
+	if cache, ok := metadata[requestDecisionCacheMetadataKey].(*requestDecisionCache); ok && cache != nil {
+		return cache
+	}
+	cache := &requestDecisionCache{decisions: make(map[string]Decision)}
+	metadata[requestDecisionCacheMetadataKey] = cache
+	return cache
+}
+
+func (c *requestDecisionCache) get(key string) (Decision, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	decision, ok := c.decisions[key]
+	return decision, ok
+}
+
+func (c *requestDecisionCache) put(key string, decision Decision) {
+	c.mu.Lock()
+	c.decisions[key] = decision
+	c.mu.Unlock()
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	switch value := metadata[key].(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []byte:
+		return strings.TrimSpace(string(value))
+	default:
+		return ""
+	}
+}
+
+func moderationErrorClass(message string) string {
+	message = strings.ToLower(strings.TrimSpace(message))
+	switch {
+	case strings.Contains(message, "deadline exceeded") || strings.Contains(message, "timeout"):
+		return "timeout"
+	case strings.Contains(message, "returned status"):
+		return "upstream_status"
+	case strings.Contains(message, "decode") || strings.Contains(message, "missing category scores"):
+		return "invalid_response"
+	case strings.Contains(message, "request failed"):
+		return "transport"
+	default:
+		return "moderation_error"
+	}
+}

--- a/internal/contentmoderation/runtime_test.go
+++ b/internal/contentmoderation/runtime_test.go
@@ -1,0 +1,334 @@
+package contentmoderation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+type runtimeEvaluatorStub struct {
+	calls    atomic.Int32
+	decision Decision
+}
+
+func (e *runtimeEvaluatorStub) Evaluate(context.Context, Profile, string) Decision {
+	e.calls.Add(1)
+	return e.decision
+}
+
+type runtimeResolverStub struct {
+	calls atomic.Int32
+	fn    func() (Profile, string, error)
+}
+
+func (r *runtimeResolverStub) ResolveProfile(context.Context, string, string, string, string) (Profile, string, error) {
+	r.calls.Add(1)
+	return r.fn()
+}
+
+type runtimeOrderedSelector struct{}
+
+func (runtimeOrderedSelector) Pick(_ context.Context, _ string, _ string, _ cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
+	if len(auths) == 0 {
+		return nil, errors.New("no auth")
+	}
+	sort.Slice(auths, func(i, j int) bool { return auths[i].ID < auths[j].ID })
+	return auths[0], nil
+}
+
+type runtimeExecutor struct {
+	mu         sync.Mutex
+	calls      map[string]int
+	failAuthID string
+}
+
+func (e *runtimeExecutor) Identifier() string { return "moderation-runtime" }
+
+func (e *runtimeExecutor) Execute(_ context.Context, auth *coreauth.Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.calls[auth.ID]++
+	e.mu.Unlock()
+	if auth.ID == e.failAuthID {
+		return cliproxyexecutor.Response{}, errors.New("upstream unavailable")
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *runtimeExecutor) ExecuteStream(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *runtimeExecutor) CountTokens(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *runtimeExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *runtimeExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func createRuntimeProfile(t *testing.T, store *Store, tenantID, id string, input CreateProfileInput) Profile {
+	t.Helper()
+	profile, err := NewProfile(tenantID, id, input, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if err = store.CreateProfile(context.Background(), profile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	return profile
+}
+
+func bindRuntimeChannel(t *testing.T, store *Store, tenantID, channelType, channelID, profileID string) {
+	t.Helper()
+	if err := store.PatchBindings(context.Background(), tenantID, false, []BindingOperation{{
+		ChannelType: channelType,
+		ChannelID:   channelID,
+		ProfileID:   &profileID,
+	}}); err != nil {
+		t.Fatalf("PatchBindings: %v", err)
+	}
+}
+
+func runtimeOptions(tenantID, text string) cliproxyexecutor.Options {
+	body, _ := json.Marshal(map[string]any{"messages": []map[string]any{{"role": "user", "content": text}}})
+	return cliproxyexecutor.Options{
+		OriginalRequest: body,
+		SourceFormat:    sdktranslator.FormatOpenAI,
+		Metadata:        map[string]any{cliproxyexecutor.TenantMetadataKey: tenantID},
+	}
+}
+
+func newRuntimeManager(t *testing.T, moderator coreauth.RequestModerator, executor *runtimeExecutor, auths ...*coreauth.Auth) *coreauth.Manager {
+	t.Helper()
+	manager := coreauth.NewManager(nil, runtimeOrderedSelector{}, nil)
+	manager.SetRequestModerator(moderator)
+	registeredTenants := make(map[string]struct{})
+	for _, auth := range auths {
+		tenantID := coreauth.NormalizedTenantID(auth.TenantID)
+		if _, exists := registeredTenants[tenantID]; !exists {
+			manager.RegisterExecutorForTenant(tenantID, executor)
+			registeredTenants[tenantID] = struct{}{}
+		}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s): %v", auth.ID, err)
+		}
+	}
+	return manager
+}
+
+func TestRuntimeModeratorAuthOffOverridesProviderBinding(t *testing.T) {
+	const tenantID = "tenant-auth-off"
+	store := newTestStore(t)
+	authProfile := createRuntimeProfile(t, store, tenantID, "profile-auth-off", CreateProfileInput{Name: "auth off", Mode: ModeOff})
+	providerProfile := createRuntimeProfile(t, store, tenantID, "profile-provider-block", CreateProfileInput{
+		Name:            "provider block",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"blocked"},
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeAuthFile, "auth-file", authProfile.ID)
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProvider, "provider-id", providerProfile.ID)
+	evaluator := &runtimeEvaluatorStub{decision: Decision{WouldBlock: true, Action: ActionKeywordBlock}}
+	moderator := NewRequestModerator(store, evaluator)
+	auth := &coreauth.Auth{
+		ID:       "auth-file",
+		TenantID: tenantID,
+		FileName: "auth-file.json",
+		Provider: "moderation-runtime",
+		Attributes: map[string]string{
+			"provider_config_id": "provider-id",
+		},
+	}
+
+	result := moderator.Moderate(context.Background(), auth, runtimeOptions(tenantID, "blocked"))
+	if result.Blocked {
+		t.Fatal("auth-specific off profile must allow without provider fallback")
+	}
+	if evaluator.calls.Load() != 0 {
+		t.Fatalf("evaluator calls = %d, want zero", evaluator.calls.Load())
+	}
+}
+
+func TestRuntimeModeratorTenantMismatchNeverQueriesResolver(t *testing.T) {
+	resolver := &runtimeResolverStub{fn: func() (Profile, string, error) {
+		return Profile{}, "", ErrNotFound
+	}}
+	moderator := NewRequestModerator(resolver, &runtimeEvaluatorStub{})
+	result := moderator.Moderate(context.Background(), &coreauth.Auth{ID: "auth", TenantID: "tenant-a"}, runtimeOptions("tenant-b", "hello"))
+	if result.Blocked {
+		t.Fatal("tenant mismatch must fail open")
+	}
+	if resolver.calls.Load() != 0 {
+		t.Fatalf("resolver calls = %d, want zero", resolver.calls.Load())
+	}
+	if moderator.Metrics().Errors != 1 {
+		t.Fatalf("metrics = %#v, want one error", moderator.Metrics())
+	}
+}
+
+func TestRuntimeModeratorModerationAPIFailureCallsExecutor(t *testing.T) {
+	const tenantID = "tenant-api-error"
+	var moderationCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		moderationCalls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	profile := createRuntimeProfile(t, store, tenantID, "profile-api", CreateProfileInput{
+		Name:        "api",
+		Mode:        ModePreBlock,
+		KeywordMode: KeywordModeAPIOnly,
+		APIKey:      "moderation-secret",
+		BaseURL:     server.URL,
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-a", profile.ID)
+	moderator := NewRequestModerator(store, NewEvaluator(server.Client()))
+	executor := &runtimeExecutor{calls: make(map[string]int)}
+	manager := newRuntimeManager(t, moderator, executor, &coreauth.Auth{
+		ID:       "auth-a",
+		TenantID: tenantID,
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"provider_key_id": "key-a",
+		},
+	})
+
+	if _, err := manager.Execute(context.Background(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: "model"}, runtimeOptions(tenantID, "hello")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if moderationCalls.Load() != 1 {
+		t.Fatalf("moderation calls = %d, want 1", moderationCalls.Load())
+	}
+	executor.mu.Lock()
+	calls := executor.calls["auth-a"]
+	executor.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("executor calls = %d, want 1", calls)
+	}
+	if metrics := moderator.Metrics(); metrics.Errors != 1 || metrics.Allows != 1 {
+		t.Fatalf("metrics = %#v, want fail-open allow", metrics)
+	}
+}
+
+func TestRuntimeModeratorFallbackReResolvesAndBlocksSecondCandidate(t *testing.T) {
+	const tenantID = "tenant-fallback"
+	store := newTestStore(t)
+	allowProfile := createRuntimeProfile(t, store, tenantID, "profile-allow", CreateProfileInput{
+		Name:            "allow",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"never-match"},
+	})
+	blockProfile := createRuntimeProfile(t, store, tenantID, "profile-block", CreateProfileInput{
+		Name:            "block",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"blocked"},
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-a", allowProfile.ID)
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-b", blockProfile.ID)
+	moderator := NewRequestModerator(store, NewEvaluator(nil))
+	executor := &runtimeExecutor{calls: make(map[string]int), failAuthID: "auth-a"}
+	manager := newRuntimeManager(t, moderator, executor,
+		&coreauth.Auth{ID: "auth-a", TenantID: tenantID, Provider: executor.Identifier(), Status: coreauth.StatusActive, Attributes: map[string]string{"provider_key_id": "key-a"}},
+		&coreauth.Auth{ID: "auth-b", TenantID: tenantID, Provider: executor.Identifier(), Status: coreauth.StatusActive, Attributes: map[string]string{"provider_key_id": "key-b"}},
+	)
+
+	_, err := manager.Execute(context.Background(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: "model"}, runtimeOptions(tenantID, "blocked"))
+	var authErr *coreauth.Error
+	if !errors.As(err, &authErr) || authErr.Code != "content_policy_violation" {
+		t.Fatalf("Execute error = %#v, want content policy violation", err)
+	}
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if executor.calls["auth-a"] != 1 || executor.calls["auth-b"] != 0 {
+		t.Fatalf("executor calls = %#v, want first called and blocked second skipped", executor.calls)
+	}
+}
+
+func TestRuntimeModeratorRequestCacheAvoidsDuplicateModerationCallOnFallback(t *testing.T) {
+	const tenantID = "tenant-cache"
+	var moderationCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		moderationCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"category_scores":{"violence":0.01}}]}`))
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	profile := createRuntimeProfile(t, store, tenantID, "profile-shared", CreateProfileInput{
+		Name:        "shared",
+		Mode:        ModePreBlock,
+		KeywordMode: KeywordModeAPIOnly,
+		APIKey:      "moderation-secret",
+		BaseURL:     server.URL,
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-a", profile.ID)
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-b", profile.ID)
+	moderator := NewRequestModerator(store, NewEvaluator(server.Client()))
+	executor := &runtimeExecutor{calls: make(map[string]int), failAuthID: "auth-a"}
+	manager := newRuntimeManager(t, moderator, executor,
+		&coreauth.Auth{ID: "auth-a", TenantID: tenantID, Provider: executor.Identifier(), Status: coreauth.StatusActive, Attributes: map[string]string{"provider_key_id": "key-a"}},
+		&coreauth.Auth{ID: "auth-b", TenantID: tenantID, Provider: executor.Identifier(), Status: coreauth.StatusActive, Attributes: map[string]string{"provider_key_id": "key-b"}},
+	)
+
+	if _, err := manager.Execute(context.Background(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: "model"}, runtimeOptions(tenantID, "safe")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if moderationCalls.Load() != 1 {
+		t.Fatalf("moderation calls = %d, want 1", moderationCalls.Load())
+	}
+	if moderator.Metrics().CacheHits != 1 {
+		t.Fatalf("metrics = %#v, want one cache hit", moderator.Metrics())
+	}
+}
+
+func TestRuntimeModeratorUsesLastGoodResolutionOnStoreError(t *testing.T) {
+	profile, err := NewProfile("tenant-last-good", "profile-last-good", CreateProfileInput{
+		Name:            "last good",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"blocked"},
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	var call atomic.Int32
+	resolver := &runtimeResolverStub{fn: func() (Profile, string, error) {
+		if call.Add(1) == 1 {
+			return profile, ChannelTypeProviderKey, nil
+		}
+		return Profile{}, "", errors.New("database unavailable")
+	}}
+	moderator := NewRequestModerator(resolver, NewEvaluator(nil))
+	auth := &coreauth.Auth{ID: "auth", TenantID: profile.TenantID, Attributes: map[string]string{"provider_key_id": "key"}}
+	for i := 0; i < 2; i++ {
+		if result := moderator.Moderate(context.Background(), auth, runtimeOptions(profile.TenantID, "blocked")); !result.Blocked {
+			t.Fatalf("call %d was not blocked", i+1)
+		}
+	}
+	if moderator.Metrics().Errors != 1 {
+		t.Fatalf("metrics = %#v, want last-good store error", moderator.Metrics())
+	}
+}

--- a/internal/contentmoderation/store.go
+++ b/internal/contentmoderation/store.go
@@ -1,0 +1,364 @@
+package contentmoderation
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const createTablesSQL = `
+CREATE TABLE IF NOT EXISTS content_moderation_profiles (
+  tenant_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  mode TEXT NOT NULL DEFAULT 'off',
+  base_url TEXT NOT NULL DEFAULT 'https://api.openai.com',
+  model TEXT NOT NULL DEFAULT 'omni-moderation-latest',
+  api_key_secret TEXT NOT NULL DEFAULT '',
+  timeout_ms INTEGER NOT NULL DEFAULT 3000,
+  keyword_mode TEXT NOT NULL DEFAULT 'api_only',
+  blocked_keywords_json TEXT NOT NULL DEFAULT '[]',
+  thresholds_json TEXT NOT NULL DEFAULT '{}',
+  block_http_status INTEGER NOT NULL DEFAULT 403,
+  block_message TEXT NOT NULL DEFAULT '',
+  version INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (tenant_id, id),
+  UNIQUE (tenant_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS content_moderation_channel_bindings (
+  tenant_id TEXT NOT NULL,
+  channel_type TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  profile_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (tenant_id, channel_type, channel_id),
+  FOREIGN KEY (tenant_id, profile_id)
+    REFERENCES content_moderation_profiles(tenant_id, id)
+    ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_moderation_bindings_profile
+  ON content_moderation_channel_bindings(tenant_id, profile_id);
+`
+
+func InitTables(db *sql.DB) error {
+	if db == nil {
+		return ErrUnavailable
+	}
+	if _, err := db.Exec(createTablesSQL); err != nil {
+		return fmt.Errorf("create content moderation tables: %w", err)
+	}
+	return nil
+}
+
+type Store struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+func (s *Store) ListProfiles(ctx context.Context, tenantID string) ([]Profile, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrUnavailable
+	}
+	rows, err := s.db.QueryContext(ctx, profileSelectSQL+` WHERE tenant_id = $1 ORDER BY lower(name), id`, strings.TrimSpace(tenantID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	profiles := make([]Profile, 0)
+	for rows.Next() {
+		profile, err := scanProfile(rows)
+		if err != nil {
+			return nil, err
+		}
+		profiles = append(profiles, profile)
+	}
+	return profiles, rows.Err()
+}
+
+func (s *Store) GetProfile(ctx context.Context, tenantID, id string) (Profile, error) {
+	if s == nil || s.db == nil {
+		return Profile{}, ErrUnavailable
+	}
+	profile, err := scanProfile(s.db.QueryRowContext(ctx, profileSelectSQL+` WHERE tenant_id = $1 AND id = $2`, strings.TrimSpace(tenantID), strings.TrimSpace(id)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Profile{}, ErrNotFound
+	}
+	return profile, err
+}
+
+func (s *Store) CreateProfile(ctx context.Context, profile Profile) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	keywords, thresholds, err := profileJSON(profile)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO content_moderation_profiles
+		(tenant_id,id,name,mode,base_url,model,api_key_secret,timeout_ms,keyword_mode,blocked_keywords_json,thresholds_json,block_http_status,block_message,version,created_at,updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+		profile.TenantID, profile.ID, profile.Name, profile.Mode, profile.BaseURL, profile.Model, profile.APIKeySecret,
+		profile.TimeoutMS, profile.KeywordMode, keywords, thresholds, profile.BlockHTTPStatus, profile.BlockMessage,
+		profile.Version, formatTime(profile.CreatedAt), formatTime(profile.UpdatedAt))
+	if isUniqueViolation(err) {
+		return ErrNameConflict
+	}
+	return err
+}
+
+func (s *Store) UpdateProfile(ctx context.Context, profile Profile, expectedVersion int64) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	keywords, thresholds, err := profileJSON(profile)
+	if err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE content_moderation_profiles SET
+		name=$1,mode=$2,base_url=$3,model=$4,api_key_secret=$5,timeout_ms=$6,keyword_mode=$7,
+		blocked_keywords_json=$8,thresholds_json=$9,block_http_status=$10,block_message=$11,version=$12,updated_at=$13
+		WHERE tenant_id=$14 AND id=$15 AND version=$16`,
+		profile.Name, profile.Mode, profile.BaseURL, profile.Model, profile.APIKeySecret, profile.TimeoutMS, profile.KeywordMode,
+		keywords, thresholds, profile.BlockHTTPStatus, profile.BlockMessage, profile.Version, formatTime(profile.UpdatedAt),
+		profile.TenantID, profile.ID, expectedVersion)
+	if isUniqueViolation(err) {
+		return ErrNameConflict
+	}
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		if _, getErr := s.GetProfile(ctx, profile.TenantID, profile.ID); errors.Is(getErr, ErrNotFound) {
+			return ErrNotFound
+		}
+		return ErrVersionConflict
+	}
+	return nil
+}
+
+func (s *Store) DeleteProfile(ctx context.Context, tenantID, id string) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var count int
+	if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_moderation_channel_bindings WHERE tenant_id=$1 AND profile_id=$2`, tenantID, id).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return &ProfileBoundError{Count: count}
+	}
+	result, err := tx.ExecContext(ctx, `DELETE FROM content_moderation_profiles WHERE tenant_id=$1 AND id=$2`, tenantID, id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return tx.Commit()
+}
+
+func (s *Store) BindingCounts(ctx context.Context, tenantID string) (map[string]map[string]int, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrUnavailable
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT profile_id, channel_type, COUNT(*) FROM content_moderation_channel_bindings WHERE tenant_id=$1 GROUP BY profile_id, channel_type`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]map[string]int)
+	for rows.Next() {
+		var profileID, channelType string
+		var count int
+		if err := rows.Scan(&profileID, &channelType, &count); err != nil {
+			return nil, err
+		}
+		if out[profileID] == nil {
+			out[profileID] = make(map[string]int)
+		}
+		out[profileID][channelType] = count
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) ListBindings(ctx context.Context, tenantID string) ([]Binding, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrUnavailable
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT tenant_id,channel_type,channel_id,profile_id,created_at,updated_at FROM content_moderation_channel_bindings WHERE tenant_id=$1`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	bindings := make([]Binding, 0)
+	for rows.Next() {
+		var binding Binding
+		var createdAt, updatedAt string
+		if err := rows.Scan(&binding.TenantID, &binding.ChannelType, &binding.ChannelID, &binding.ProfileID, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		binding.CreatedAt = parseTime(createdAt)
+		binding.UpdatedAt = parseTime(updatedAt)
+		bindings = append(bindings, binding)
+	}
+	return bindings, rows.Err()
+}
+
+func (s *Store) PatchBindings(ctx context.Context, tenantID string, allowRebind bool, operations []BindingOperation) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	now := formatTime(time.Now().UTC())
+	for _, operation := range operations {
+		channelType := strings.TrimSpace(operation.ChannelType)
+		channelID := strings.TrimSpace(operation.ChannelID)
+		if !IsChannelType(channelType) || channelID == "" {
+			return ErrInvalidChannel
+		}
+		if operation.ProfileID == nil || strings.TrimSpace(*operation.ProfileID) == "" {
+			if _, err = tx.ExecContext(ctx, `DELETE FROM content_moderation_channel_bindings WHERE tenant_id=$1 AND channel_type=$2 AND channel_id=$3`, tenantID, channelType, channelID); err != nil {
+				return err
+			}
+			continue
+		}
+		profileID := strings.TrimSpace(*operation.ProfileID)
+		var exists int
+		if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_moderation_profiles WHERE tenant_id=$1 AND id=$2`, tenantID, profileID).Scan(&exists); err != nil {
+			return err
+		}
+		if exists == 0 {
+			return ErrNotFound
+		}
+		var existing string
+		err = tx.QueryRowContext(ctx, `SELECT profile_id FROM content_moderation_channel_bindings WHERE tenant_id=$1 AND channel_type=$2 AND channel_id=$3`, tenantID, channelType, channelID).Scan(&existing)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if err == nil && existing != profileID && !allowRebind {
+			return &BindingConflictError{ChannelType: channelType, ChannelID: channelID, ExistingProfileID: existing}
+		}
+		if err == nil && existing == profileID {
+			continue
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO content_moderation_channel_bindings
+			(tenant_id,channel_type,channel_id,profile_id,created_at,updated_at) VALUES ($1,$2,$3,$4,$5,$5)
+			ON CONFLICT(tenant_id,channel_type,channel_id) DO UPDATE SET profile_id=excluded.profile_id,updated_at=excluded.updated_at`,
+			tenantID, channelType, channelID, profileID, now)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Store) DeleteChannelBinding(ctx context.Context, tenantID, channelType, channelID string) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM content_moderation_channel_bindings WHERE tenant_id=$1 AND channel_type=$2 AND channel_id=$3`, tenantID, channelType, channelID)
+	return err
+}
+
+func (s *Store) ResolveProfile(ctx context.Context, tenantID, authFileID, providerKeyID, providerID string) (Profile, string, error) {
+	lookups := []struct {
+		channelType string
+		channelID   string
+	}{
+		{ChannelTypeAuthFile, strings.TrimSpace(authFileID)},
+		{ChannelTypeProviderKey, strings.TrimSpace(providerKeyID)},
+		{ChannelTypeProvider, strings.TrimSpace(providerID)},
+	}
+	for _, lookup := range lookups {
+		if lookup.channelID == "" {
+			continue
+		}
+		profile, err := scanProfile(s.db.QueryRowContext(ctx, profileSelectSQL+`
+			JOIN content_moderation_channel_bindings b ON b.tenant_id=content_moderation_profiles.tenant_id AND b.profile_id=content_moderation_profiles.id
+			WHERE b.tenant_id=$1 AND b.channel_type=$2 AND b.channel_id=$3`, tenantID, lookup.channelType, lookup.channelID))
+		if err == nil {
+			return profile, lookup.channelType, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return Profile{}, "", err
+		}
+	}
+	return Profile{}, "", ErrNotFound
+}
+
+const profileSelectSQL = `SELECT content_moderation_profiles.tenant_id,content_moderation_profiles.id,content_moderation_profiles.name,content_moderation_profiles.mode,content_moderation_profiles.base_url,content_moderation_profiles.model,content_moderation_profiles.api_key_secret,content_moderation_profiles.timeout_ms,content_moderation_profiles.keyword_mode,content_moderation_profiles.blocked_keywords_json,content_moderation_profiles.thresholds_json,content_moderation_profiles.block_http_status,content_moderation_profiles.block_message,content_moderation_profiles.version,content_moderation_profiles.created_at,content_moderation_profiles.updated_at FROM content_moderation_profiles`
+
+func scanProfile(scanner interface{ Scan(...any) error }) (Profile, error) {
+	var profile Profile
+	var keywordsJSON, thresholdsJSON, createdAt, updatedAt string
+	if err := scanner.Scan(
+		&profile.TenantID, &profile.ID, &profile.Name, &profile.Mode, &profile.BaseURL, &profile.Model, &profile.APIKeySecret,
+		&profile.TimeoutMS, &profile.KeywordMode, &keywordsJSON, &thresholdsJSON, &profile.BlockHTTPStatus, &profile.BlockMessage,
+		&profile.Version, &createdAt, &updatedAt,
+	); err != nil {
+		return Profile{}, err
+	}
+	if err := json.Unmarshal([]byte(keywordsJSON), &profile.BlockedKeywords); err != nil {
+		return Profile{}, fmt.Errorf("decode blocked keywords: %w", err)
+	}
+	if err := json.Unmarshal([]byte(thresholdsJSON), &profile.Thresholds); err != nil {
+		return Profile{}, fmt.Errorf("decode thresholds: %w", err)
+	}
+	profile.CreatedAt = parseTime(createdAt)
+	profile.UpdatedAt = parseTime(updatedAt)
+	return profile, nil
+}
+
+func profileJSON(profile Profile) (string, string, error) {
+	keywords, err := json.Marshal(profile.BlockedKeywords)
+	if err != nil {
+		return "", "", err
+	}
+	thresholds, err := json.Marshal(profile.Thresholds)
+	if err != nil {
+		return "", "", err
+	}
+	return string(keywords), string(thresholds), nil
+}
+
+func formatTime(value time.Time) string { return value.UTC().Format(time.RFC3339Nano) }
+
+func parseTime(value string) time.Time {
+	parsed, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	return parsed.UTC()
+}
+
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "unique constraint") || strings.Contains(message, "duplicate key")
+}

--- a/internal/contentmoderation/store.go
+++ b/internal/contentmoderation/store.go
@@ -288,6 +288,9 @@ func (s *Store) DeleteChannelBinding(ctx context.Context, tenantID, channelType,
 }
 
 func (s *Store) ResolveProfile(ctx context.Context, tenantID, authFileID, providerKeyID, providerID string) (Profile, string, error) {
+	if s == nil || s.db == nil {
+		return Profile{}, "", ErrUnavailable
+	}
 	lookups := []struct {
 		channelType string
 		channelID   string

--- a/internal/contentmoderation/store_test.go
+++ b/internal/contentmoderation/store_test.go
@@ -1,0 +1,114 @@
+package contentmoderation
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "modernc.org/sqlite"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "moderation.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := InitTables(db); err != nil {
+		t.Fatalf("InitTables: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewStore(db)
+}
+
+func testProfile(t *testing.T, tenantID, name, mode, keywordMode string) Profile {
+	t.Helper()
+	profile, err := NewProfile(tenantID, uuid.NewString(), CreateProfileInput{
+		Name:        name,
+		Mode:        mode,
+		KeywordMode: keywordMode,
+		APIKey:      "moderation-secret",
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	return profile
+}
+
+func TestStoreTenantIsolation(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	profileA := testProfile(t, "tenant-a", "shared-name", ModeOff, KeywordModeAPIOnly)
+	profileB := testProfile(t, "tenant-b", "shared-name", ModeOff, KeywordModeAPIOnly)
+	profileB.ID = profileA.ID
+	if err := store.CreateProfile(ctx, profileA); err != nil {
+		t.Fatalf("create tenant A: %v", err)
+	}
+	if err := store.CreateProfile(ctx, profileB); err != nil {
+		t.Fatalf("create tenant B: %v", err)
+	}
+	got, err := store.GetProfile(ctx, "tenant-a", profileA.ID)
+	if err != nil || got.TenantID != "tenant-a" {
+		t.Fatalf("tenant A get = %#v, %v", got, err)
+	}
+	items, err := store.ListProfiles(ctx, "tenant-b")
+	if err != nil || len(items) != 1 || items[0].TenantID != "tenant-b" {
+		t.Fatalf("tenant B list = %#v, %v", items, err)
+	}
+}
+
+func TestStoreDeleteProfileRestrictsBindings(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	profile := testProfile(t, "tenant-a", "bound", ModeOff, KeywordModeAPIOnly)
+	if err := store.CreateProfile(ctx, profile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	profileID := profile.ID
+	if err := store.PatchBindings(ctx, profile.TenantID, false, []BindingOperation{{
+		ChannelType: ChannelTypeAuthFile,
+		ChannelID:   "auth-1",
+		ProfileID:   &profileID,
+	}}); err != nil {
+		t.Fatalf("PatchBindings: %v", err)
+	}
+	if err := store.DeleteProfile(ctx, profile.TenantID, profile.ID); !errors.Is(err, ErrProfileBound) {
+		t.Fatalf("DeleteProfile error = %v, want ErrProfileBound", err)
+	}
+	if err := store.PatchBindings(ctx, profile.TenantID, false, []BindingOperation{{ChannelType: ChannelTypeAuthFile, ChannelID: "auth-1"}}); err != nil {
+		t.Fatalf("unbind: %v", err)
+	}
+	if err := store.DeleteProfile(ctx, profile.TenantID, profile.ID); err != nil {
+		t.Fatalf("DeleteProfile after unbind: %v", err)
+	}
+}
+
+func TestStorePatchBindingsRequiresExplicitRebind(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	first := testProfile(t, "tenant-a", "first", ModeOff, KeywordModeAPIOnly)
+	second := testProfile(t, "tenant-a", "second", ModeOff, KeywordModeAPIOnly)
+	for _, profile := range []Profile{first, second} {
+		if err := store.CreateProfile(ctx, profile); err != nil {
+			t.Fatalf("CreateProfile: %v", err)
+		}
+	}
+	if err := store.PatchBindings(ctx, "tenant-a", false, []BindingOperation{{ChannelType: ChannelTypeProviderKey, ChannelID: "key-1", ProfileID: &first.ID}}); err != nil {
+		t.Fatalf("initial bind: %v", err)
+	}
+	if err := store.PatchBindings(ctx, "tenant-a", false, []BindingOperation{{ChannelType: ChannelTypeProviderKey, ChannelID: "key-1", ProfileID: &second.ID}}); !errors.Is(err, ErrBindingConflict) {
+		t.Fatalf("rebind error = %v, want conflict", err)
+	}
+	if err := store.PatchBindings(ctx, "tenant-a", true, []BindingOperation{{ChannelType: ChannelTypeProviderKey, ChannelID: "key-1", ProfileID: &second.ID}}); err != nil {
+		t.Fatalf("allowed rebind: %v", err)
+	}
+	resolved, source, err := store.ResolveProfile(ctx, "tenant-a", "", "key-1", "")
+	if err != nil || resolved.ID != second.ID || source != ChannelTypeProviderKey {
+		t.Fatalf("ResolveProfile = %#v source=%q err=%v", resolved, source, err)
+	}
+}

--- a/internal/contentmoderation/types.go
+++ b/internal/contentmoderation/types.go
@@ -1,0 +1,328 @@
+package contentmoderation
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	ModeOff      = "off"
+	ModePreBlock = "pre_block"
+
+	KeywordModeAPIOnly       = "api_only"
+	KeywordModeKeywordOnly   = "keyword_only"
+	KeywordModeKeywordAndAPI = "keyword_and_api"
+
+	ChannelTypeAuthFile    = "auth_file"
+	ChannelTypeProviderKey = "provider_key"
+	ChannelTypeProvider    = "provider"
+
+	DefaultBaseURL      = "https://api.openai.com"
+	DefaultModel        = "omni-moderation-latest"
+	DefaultTimeoutMS    = 3000
+	DefaultBlockStatus  = 403
+	DefaultBlockMessage = "Your request was blocked by the content moderation policy."
+)
+
+var (
+	ErrUnavailable     = errors.New("content moderation store unavailable")
+	ErrNotFound        = errors.New("content moderation profile not found")
+	ErrNameConflict    = errors.New("content moderation profile name already exists")
+	ErrVersionConflict = errors.New("content moderation profile version conflict")
+	ErrProfileBound    = errors.New("content moderation profile has channel bindings")
+	ErrBindingConflict = errors.New("content moderation channel is already bound")
+	ErrInvalidChannel  = errors.New("invalid content moderation channel")
+)
+
+type Profile struct {
+	TenantID        string             `json:"-"`
+	ID              string             `json:"id"`
+	Name            string             `json:"name"`
+	Mode            string             `json:"mode"`
+	BaseURL         string             `json:"base_url"`
+	Model           string             `json:"model"`
+	APIKeySecret    string             `json:"-"`
+	TimeoutMS       int                `json:"timeout_ms"`
+	KeywordMode     string             `json:"keyword_mode"`
+	BlockedKeywords []string           `json:"blocked_keywords"`
+	Thresholds      map[string]float64 `json:"thresholds"`
+	BlockHTTPStatus int                `json:"block_http_status"`
+	BlockMessage    string             `json:"block_message"`
+	Version         int64              `json:"version"`
+	CreatedAt       time.Time          `json:"created_at"`
+	UpdatedAt       time.Time          `json:"updated_at"`
+}
+
+type CreateProfileInput struct {
+	Name            string             `json:"name"`
+	Mode            string             `json:"mode"`
+	BaseURL         string             `json:"base_url"`
+	Model           string             `json:"model"`
+	APIKey          string             `json:"api_key"`
+	TimeoutMS       int                `json:"timeout_ms"`
+	KeywordMode     string             `json:"keyword_mode"`
+	BlockedKeywords []string           `json:"blocked_keywords"`
+	Thresholds      map[string]float64 `json:"thresholds"`
+	BlockHTTPStatus int                `json:"block_http_status"`
+	BlockMessage    string             `json:"block_message"`
+}
+
+type PatchProfileInput struct {
+	Name            *string             `json:"name"`
+	Mode            *string             `json:"mode"`
+	BaseURL         *string             `json:"base_url"`
+	Model           *string             `json:"model"`
+	APIKey          *string             `json:"api_key"`
+	ClearAPIKey     bool                `json:"clear_api_key"`
+	TimeoutMS       *int                `json:"timeout_ms"`
+	KeywordMode     *string             `json:"keyword_mode"`
+	BlockedKeywords *[]string           `json:"blocked_keywords"`
+	Thresholds      *map[string]float64 `json:"thresholds"`
+	BlockHTTPStatus *int                `json:"block_http_status"`
+	BlockMessage    *string             `json:"block_message"`
+	Version         int64               `json:"version"`
+}
+
+type Binding struct {
+	TenantID    string    `json:"-"`
+	ChannelType string    `json:"channel_type"`
+	ChannelID   string    `json:"channel_id"`
+	ProfileID   string    `json:"profile_id"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type BindingOperation struct {
+	ChannelType string  `json:"channel_type"`
+	ChannelID   string  `json:"channel_id"`
+	ProfileID   *string `json:"profile_id"`
+}
+
+type BindingConflictError struct {
+	ChannelType       string
+	ChannelID         string
+	ExistingProfileID string
+}
+
+func (e *BindingConflictError) Error() string {
+	return fmt.Sprintf("%s %s is already bound to profile %s", e.ChannelType, e.ChannelID, e.ExistingProfileID)
+}
+
+func (e *BindingConflictError) Unwrap() error { return ErrBindingConflict }
+
+type ProfileBoundError struct {
+	Count int
+}
+
+func (e *ProfileBoundError) Error() string {
+	return fmt.Sprintf("profile has %d channel binding(s)", e.Count)
+}
+
+func (e *ProfileBoundError) Unwrap() error { return ErrProfileBound }
+
+func DefaultThresholds() map[string]float64 {
+	return map[string]float64{
+		"harassment":             0.98,
+		"harassment/threatening": 0.90,
+		"hate":                   0.65,
+		"hate/threatening":       0.65,
+		"illicit":                0.95,
+		"illicit/violent":        0.95,
+		"self-harm":              0.65,
+		"self-harm/intent":       0.85,
+		"self-harm/instructions": 0.65,
+		"sexual":                 0.65,
+		"sexual/minors":          0.65,
+		"violence":               0.95,
+		"violence/graphic":       0.95,
+	}
+}
+
+func NewProfile(tenantID, id string, input CreateProfileInput, now time.Time) (Profile, error) {
+	profile := Profile{
+		TenantID:        strings.TrimSpace(tenantID),
+		ID:              strings.TrimSpace(id),
+		Name:            input.Name,
+		Mode:            input.Mode,
+		BaseURL:         input.BaseURL,
+		Model:           input.Model,
+		APIKeySecret:    input.APIKey,
+		TimeoutMS:       input.TimeoutMS,
+		KeywordMode:     input.KeywordMode,
+		BlockedKeywords: input.BlockedKeywords,
+		Thresholds:      input.Thresholds,
+		BlockHTTPStatus: input.BlockHTTPStatus,
+		BlockMessage:    input.BlockMessage,
+		Version:         1,
+		CreatedAt:       now.UTC(),
+		UpdatedAt:       now.UTC(),
+	}
+	applyProfileDefaults(&profile)
+	return profile, ValidateProfile(profile)
+}
+
+func ApplyProfilePatch(profile Profile, patch PatchProfileInput, now time.Time) (Profile, error) {
+	if patch.Version <= 0 || patch.Version != profile.Version {
+		return Profile{}, ErrVersionConflict
+	}
+	if patch.Name != nil {
+		profile.Name = *patch.Name
+	}
+	if patch.Mode != nil {
+		profile.Mode = *patch.Mode
+	}
+	if patch.BaseURL != nil {
+		profile.BaseURL = *patch.BaseURL
+	}
+	if patch.Model != nil {
+		profile.Model = *patch.Model
+	}
+	if patch.APIKey != nil {
+		if key := strings.TrimSpace(*patch.APIKey); key != "" {
+			profile.APIKeySecret = key
+		}
+	}
+	if patch.ClearAPIKey {
+		profile.APIKeySecret = ""
+	}
+	if patch.TimeoutMS != nil {
+		profile.TimeoutMS = *patch.TimeoutMS
+	}
+	if patch.KeywordMode != nil {
+		profile.KeywordMode = *patch.KeywordMode
+	}
+	if patch.BlockedKeywords != nil {
+		profile.BlockedKeywords = *patch.BlockedKeywords
+	}
+	if patch.Thresholds != nil {
+		profile.Thresholds = *patch.Thresholds
+	}
+	if patch.BlockHTTPStatus != nil {
+		profile.BlockHTTPStatus = *patch.BlockHTTPStatus
+	}
+	if patch.BlockMessage != nil {
+		profile.BlockMessage = *patch.BlockMessage
+	}
+	applyProfileDefaults(&profile)
+	profile.Version++
+	profile.UpdatedAt = now.UTC()
+	return profile, ValidateProfile(profile)
+}
+
+func applyProfileDefaults(profile *Profile) {
+	profile.Name = strings.TrimSpace(profile.Name)
+	profile.Mode = strings.ToLower(strings.TrimSpace(profile.Mode))
+	if profile.Mode == "" {
+		profile.Mode = ModeOff
+	}
+	profile.BaseURL = strings.TrimRight(strings.TrimSpace(profile.BaseURL), "/")
+	if profile.BaseURL == "" {
+		profile.BaseURL = DefaultBaseURL
+	}
+	profile.Model = strings.TrimSpace(profile.Model)
+	if profile.Model == "" {
+		profile.Model = DefaultModel
+	}
+	profile.APIKeySecret = strings.TrimSpace(profile.APIKeySecret)
+	if profile.TimeoutMS == 0 {
+		profile.TimeoutMS = DefaultTimeoutMS
+	}
+	profile.KeywordMode = strings.ToLower(strings.TrimSpace(profile.KeywordMode))
+	if profile.KeywordMode == "" {
+		profile.KeywordMode = KeywordModeAPIOnly
+	}
+	profile.BlockedKeywords = normalizeKeywords(profile.BlockedKeywords)
+	profile.Thresholds = mergeThresholds(profile.Thresholds)
+	if profile.BlockHTTPStatus == 0 {
+		profile.BlockHTTPStatus = DefaultBlockStatus
+	}
+	profile.BlockMessage = strings.TrimSpace(profile.BlockMessage)
+	if profile.BlockMessage == "" {
+		profile.BlockMessage = DefaultBlockMessage
+	}
+}
+
+func ValidateProfile(profile Profile) error {
+	if profile.TenantID == "" || profile.ID == "" {
+		return errors.New("tenant and profile id are required")
+	}
+	if profile.Name == "" {
+		return errors.New("name is required")
+	}
+	if profile.Mode != ModeOff && profile.Mode != ModePreBlock {
+		return errors.New("mode must be off or pre_block")
+	}
+	switch profile.KeywordMode {
+	case KeywordModeAPIOnly, KeywordModeKeywordOnly, KeywordModeKeywordAndAPI:
+	default:
+		return errors.New("keyword_mode must be api_only, keyword_only, or keyword_and_api")
+	}
+	if profile.TimeoutMS <= 0 || profile.TimeoutMS > 30000 {
+		return errors.New("timeout_ms must be between 1 and 30000")
+	}
+	if profile.BlockHTTPStatus < 400 || profile.BlockHTTPStatus > 599 {
+		return errors.New("block_http_status must be between 400 and 599")
+	}
+	if profile.Mode == ModePreBlock && profile.KeywordMode != KeywordModeKeywordOnly && profile.APIKeySecret == "" {
+		return errors.New("api_key is required for API moderation in pre_block mode")
+	}
+	for category, threshold := range profile.Thresholds {
+		if strings.TrimSpace(category) == "" || threshold < 0 || threshold > 1 {
+			return fmt.Errorf("invalid threshold for category %q", category)
+		}
+	}
+	return nil
+}
+
+func normalizeKeywords(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return strings.ToLower(out[i]) < strings.ToLower(out[j]) })
+	return out
+}
+
+func mergeThresholds(overrides map[string]float64) map[string]float64 {
+	out := DefaultThresholds()
+	for category, threshold := range overrides {
+		category = strings.TrimSpace(category)
+		if category != "" {
+			out[category] = threshold
+		}
+	}
+	return out
+}
+
+func IsChannelType(value string) bool {
+	switch strings.TrimSpace(value) {
+	case ChannelTypeAuthFile, ChannelTypeProviderKey, ChannelTypeProvider:
+		return true
+	default:
+		return false
+	}
+}
+
+func MaskSecret(secret string) string {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return ""
+	}
+	if len(secret) <= 8 {
+		return "****"
+	}
+	return secret[:4] + "****" + secret[len(secret)-4:]
+}

--- a/internal/identity/menus.go
+++ b/internal/identity/menus.go
@@ -89,6 +89,7 @@ var MenuCatalog = []MenuSeed{
 	{Code: "runtime.monitor", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/monitor", Component: "monitor", LabelKey: "shell.nav_monitor", Icon: "activity", PermissionCode: "monitor.read", SortOrder: 10},
 	{Code: "runtime.request-logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/request-logs", Component: "request-logs", LabelKey: "shell.nav_request_logs", Icon: "scroll-text", PermissionCode: "request_logs.read", SortOrder: 20},
 	{Code: "runtime.logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/logs", Component: "logs", LabelKey: "shell.nav_logs", Icon: "file-text", PermissionCode: "system.logs.read", SortOrder: 30},
+	{Code: "runtime.content-moderation", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/content-moderation", Component: "content-moderation", LabelKey: "shell.nav_content_moderation", Icon: "shield-alert", PermissionCode: "content_moderation.read", SortOrder: 40},
 	// Access & credentials (upstream AI + client keys)
 	{Code: "access.providers", ParentCode: "group.access", Type: "menu", Path: "/access/ai-providers", Component: "providers", LabelKey: "shell.nav_ai_providers", Icon: "bot", PermissionCode: "providers.read", SortOrder: 10},
 	// Stable code kept for role/menu bindings; path lives under /access as AI OAuth accounts.

--- a/internal/identity/permissions.go
+++ b/internal/identity/permissions.go
@@ -48,6 +48,9 @@ var PermissionCatalog = []PermissionSeed{
 	{Code: "request_logs.read", Name: "Read request logs", Scope: "tenant", Resource: "request_logs", Action: "read"},
 	{Code: "request_logs.content.read", Name: "Read request content", Scope: "tenant", Resource: "request_logs", Action: "read_content", Sensitive: true},
 	{Code: "request_logs.delete", Name: "Delete request logs", Scope: "tenant", Resource: "request_logs", Action: "delete", Sensitive: true},
+	{Code: "content_moderation.read", Name: "Read content moderation", Scope: "tenant", Resource: "content_moderation", Action: "read"},
+	{Code: "content_moderation.write", Name: "Write content moderation", Scope: "tenant", Resource: "content_moderation", Action: "write", Sensitive: true},
+	{Code: "content_moderation.test", Name: "Test content moderation", Scope: "tenant", Resource: "content_moderation", Action: "test", Sensitive: true},
 	{Code: "providers.read", Name: "Read providers", Scope: "tenant", Resource: "providers", Action: "read"},
 	{Code: "providers.write", Name: "Write providers", Scope: "tenant", Resource: "providers", Action: "write", Sensitive: true},
 	{Code: "providers.test", Name: "Test providers", Scope: "tenant", Resource: "providers", Action: "test", Sensitive: true},
@@ -98,6 +101,8 @@ func menuCodeForPermission(permission PermissionSeed) string {
 		return "runtime.monitor"
 	case "request_logs":
 		return "runtime.request-logs"
+	case "content_moderation":
+		return "runtime.content-moderation"
 	case "providers":
 		return "access.providers"
 	case "auth_files":

--- a/internal/management/authfiles/delete.go
+++ b/internal/management/authfiles/delete.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -13,11 +14,12 @@ import (
 var ErrAuthFileNotFound = errors.New("auth file not found")
 
 type DeleteService struct {
-	AuthDir        string
-	TenantID       string
-	Manager        *coreauth.Manager
-	Repository     Repository
-	RemoveChannels func([]string) error
+	AuthDir            string
+	TenantID           string
+	Manager            *coreauth.Manager
+	Repository         Repository
+	RemoveChannels     func([]string) error
+	RemoveAuthBindings func([]string) error
 }
 
 type DeleteResult struct {
@@ -101,11 +103,15 @@ func (s DeleteService) DeleteOne(ctx context.Context, name string) (DeleteResult
 	}
 
 	deletedChannels := DeletedChannelIdentifiers(target)
+	deletedAuthIDs := deletedAuthBindingIdentifiers(target)
 	if target != nil && s.Manager != nil {
 		_, _ = s.Manager.Delete(coreauth.WithSkipPersist(ctx), target.ID)
 	}
 	result := DeleteResult{Deleted: 1}
-	if errCleanup := s.removeChannelReferences(deletedChannels); errCleanup != nil {
+	if errCleanup := errors.Join(
+		s.removeChannelReferences(deletedChannels),
+		s.removeAuthBindingReferences(deletedAuthIDs),
+	); errCleanup != nil {
 		// The credential is already durably deleted. Preserve that outcome so the
 		// caller can remove stale UI state while surfacing the cleanup warning.
 		return result, fmt.Errorf("auth file deleted but channel reference cleanup failed: %w", errCleanup)
@@ -113,9 +119,29 @@ func (s DeleteService) DeleteOne(ctx context.Context, name string) (DeleteResult
 	return result, nil
 }
 
+func deletedAuthBindingIdentifiers(auth *coreauth.Auth) []string {
+	if auth == nil {
+		return nil
+	}
+	if parent := strings.TrimSpace(Attribute(auth, "gemini_virtual_parent")); parent != "" {
+		return []string{parent}
+	}
+	if id := strings.TrimSpace(auth.ID); id != "" {
+		return []string{id}
+	}
+	return nil
+}
+
 func (s DeleteService) removeChannelReferences(channels []string) error {
 	if len(channels) == 0 || s.RemoveChannels == nil {
 		return nil
 	}
 	return s.RemoveChannels(channels)
+}
+
+func (s DeleteService) removeAuthBindingReferences(authIDs []string) error {
+	if len(authIDs) == 0 || s.RemoveAuthBindings == nil {
+		return nil
+	}
+	return s.RemoveAuthBindings(authIDs)
 }

--- a/internal/management/settings/providers/compatibility.go
+++ b/internal/management/settings/providers/compatibility.go
@@ -35,7 +35,9 @@ func (s *Service) ReplaceOpenAICompatibility(entries []config.OpenAICompatibilit
 		}
 	}
 	prev := append([]config.OpenAICompatibility(nil), s.cfg.OpenAICompatibility...)
-	s.cfg.OpenAICompatibility = filtered
+	next := &config.Config{OpenAICompatibility: filtered}
+	prepareProviderStableIDs(&config.Config{OpenAICompatibility: prev}, next)
+	s.cfg.OpenAICompatibility = next.OpenAICompatibility
 	s.cfg.SanitizeOpenAICompatibility()
 	if err := s.runValidator(); err != nil {
 		s.cfg.OpenAICompatibility = prev
@@ -85,7 +87,10 @@ func (s *Service) PatchOpenAICompatibility(index *int, name *string, patch OpenA
 		entry.BaseURL = trimmed
 	}
 	if patch.APIKeyEntries != nil {
-		entry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), (*patch.APIKeyEntries)...)
+		next := &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{APIKeyEntries: append([]config.OpenAICompatibilityAPIKey(nil), (*patch.APIKeyEntries)...)}}}
+		previous := &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{APIKeyEntries: entry.APIKeyEntries}}}
+		prepareProviderStableIDs(previous, next)
+		entry.APIKeyEntries = next.OpenAICompatibility[0].APIKeyEntries
 	}
 	if patch.Models != nil {
 		entry.Models = append([]config.OpenAICompatibilityModel(nil), (*patch.Models)...)
@@ -151,7 +156,10 @@ func (s *Service) ReplaceVertexCompatKeys(entries []config.VertexCompatKey) {
 	for i := range entries {
 		NormalizeVertexCompatKey(&entries[i])
 	}
-	s.cfg.VertexCompatAPIKey = entries
+	prev := append([]config.VertexCompatKey(nil), s.cfg.VertexCompatAPIKey...)
+	next := &config.Config{VertexCompatAPIKey: entries}
+	prepareProviderStableIDs(&config.Config{VertexCompatAPIKey: prev}, next)
+	s.cfg.VertexCompatAPIKey = next.VertexCompatAPIKey
 	s.cfg.SanitizeVertexCompatKeys()
 }
 

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -48,7 +48,9 @@ func (s *Service) ReplaceBedrockKeys(entries []config.BedrockKey) error {
 		NormalizeBedrockKey(&normalized[i])
 	}
 	prev := append([]config.BedrockKey(nil), s.cfg.BedrockKey...)
-	s.cfg.BedrockKey = normalized
+	next := &config.Config{BedrockKey: normalized}
+	prepareProviderStableIDs(&config.Config{BedrockKey: prev}, next)
+	s.cfg.BedrockKey = next.BedrockKey
 	s.cfg.SanitizeBedrockKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.BedrockKey = prev
@@ -219,7 +221,9 @@ func (s *Service) ReplaceOpenCodeGoKeys(entries []config.OpenCodeGoKey) error {
 		return ErrProviderAPIKeyRequired
 	}
 	prev := append([]config.OpenCodeGoKey(nil), s.cfg.OpenCodeGoKey...)
-	s.cfg.OpenCodeGoKey = filtered
+	next := &config.Config{OpenCodeGoKey: filtered}
+	prepareProviderStableIDs(&config.Config{OpenCodeGoKey: prev}, next)
+	s.cfg.OpenCodeGoKey = next.OpenCodeGoKey
 	s.cfg.SanitizeOpenCodeGoKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.OpenCodeGoKey = prev
@@ -395,7 +399,9 @@ func (s *Service) ReplaceClineKeys(entries []config.ClineKey) error {
 		return ErrProviderAPIKeyRequired
 	}
 	prev := append([]config.ClineKey(nil), s.cfg.ClineKey...)
-	s.cfg.ClineKey = filtered
+	next := &config.Config{ClineKey: filtered}
+	prepareProviderStableIDs(&config.Config{ClineKey: prev}, next)
+	s.cfg.ClineKey = next.ClineKey
 	s.cfg.SanitizeClineKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.ClineKey = prev
@@ -571,7 +577,9 @@ func (s *Service) ReplaceOllamaCloudKeys(entries []config.OllamaCloudKey) error 
 		return ErrProviderAPIKeyRequired
 	}
 	prev := append([]config.OllamaCloudKey(nil), s.cfg.OllamaCloudKey...)
-	s.cfg.OllamaCloudKey = filtered
+	next := &config.Config{OllamaCloudKey: filtered}
+	prepareProviderStableIDs(&config.Config{OllamaCloudKey: prev}, next)
+	s.cfg.OllamaCloudKey = next.OllamaCloudKey
 	s.cfg.SanitizeOllamaCloudKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.OllamaCloudKey = prev

--- a/internal/management/settings/providers/provider_keys_primary.go
+++ b/internal/management/settings/providers/provider_keys_primary.go
@@ -28,7 +28,9 @@ func (s *Service) ReplaceGeminiKeys(entries []config.GeminiKey) error {
 		return nil
 	}
 	prev := append([]config.GeminiKey(nil), s.cfg.GeminiKey...)
-	s.cfg.GeminiKey = append([]config.GeminiKey(nil), entries...)
+	next := &config.Config{GeminiKey: append([]config.GeminiKey(nil), entries...)}
+	prepareProviderStableIDs(&config.Config{GeminiKey: prev}, next)
+	s.cfg.GeminiKey = next.GeminiKey
 	s.cfg.SanitizeGeminiKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.GeminiKey = prev
@@ -156,7 +158,9 @@ func (s *Service) ReplaceClaudeKeys(entries []config.ClaudeKey) error {
 		NormalizeClaudeKey(&normalized[i])
 	}
 	prev := append([]config.ClaudeKey(nil), s.cfg.ClaudeKey...)
-	s.cfg.ClaudeKey = normalized
+	next := &config.Config{ClaudeKey: normalized}
+	prepareProviderStableIDs(&config.Config{ClaudeKey: prev}, next)
+	s.cfg.ClaudeKey = next.ClaudeKey
 	s.cfg.SanitizeClaudeKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.ClaudeKey = prev
@@ -280,7 +284,9 @@ func (s *Service) ReplaceCodexKeys(entries []config.CodexKey) error {
 		filtered = append(filtered, entry)
 	}
 	prev := append([]config.CodexKey(nil), s.cfg.CodexKey...)
-	s.cfg.CodexKey = filtered
+	next := &config.Config{CodexKey: filtered}
+	prepareProviderStableIDs(&config.Config{CodexKey: prev}, next)
+	s.cfg.CodexKey = next.CodexKey
 	s.cfg.SanitizeCodexKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.CodexKey = prev

--- a/internal/management/settings/providers/service.go
+++ b/internal/management/settings/providers/service.go
@@ -25,3 +25,8 @@ func (s *Service) runValidator() error {
 	}
 	return s.validate()
 }
+
+func prepareProviderStableIDs(previous, next *config.Config) {
+	config.PreserveMissingProviderStableIDs(previous, next)
+	next.EnsureProviderStableIDs()
+}

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -685,3 +685,45 @@ func TestModelAccessProviderGetHidesStaleModelsWhenAllAccessDisabled(t *testing.
 func stringPtr(value string) *string {
 	return &value
 }
+
+func TestPatchProviderAPIKeyKeepsStableID(t *testing.T) {
+	cfg := &config.Config{}
+	svc := NewService(cfg, nil)
+	if err := svc.ReplaceGeminiKeys([]config.GeminiKey{{APIKey: "old-secret"}}); err != nil {
+		t.Fatalf("ReplaceGeminiKeys: %v", err)
+	}
+	id := cfg.GeminiKey[0].ID
+	rotated := "new-secret"
+	index := 0
+	if err := svc.PatchGeminiKey(&index, nil, GeminiKeyPatch{APIKey: &rotated}); err != nil {
+		t.Fatalf("PatchGeminiKey: %v", err)
+	}
+	if cfg.GeminiKey[0].ID != id {
+		t.Fatalf("stable ID changed after API key rotation: before=%q after=%q", id, cfg.GeminiKey[0].ID)
+	}
+}
+
+func TestReplaceOpenAICompatibilityPreservesMissingIDs(t *testing.T) {
+	cfg := &config.Config{}
+	svc := NewService(cfg, nil)
+	initial := []config.OpenAICompatibility{{
+		Name:    "compat",
+		BaseURL: "https://compat.example",
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+			APIKey: "old-secret",
+		}},
+	}}
+	if err := svc.ReplaceOpenAICompatibility(initial); err != nil {
+		t.Fatalf("ReplaceOpenAICompatibility(initial): %v", err)
+	}
+	providerID := cfg.OpenAICompatibility[0].ID
+	keyID := cfg.OpenAICompatibility[0].APIKeyEntries[0].ID
+
+	initial[0].APIKeyEntries[0].APIKey = "new-secret"
+	if err := svc.ReplaceOpenAICompatibility(initial); err != nil {
+		t.Fatalf("ReplaceOpenAICompatibility(rotated): %v", err)
+	}
+	if cfg.OpenAICompatibility[0].ID != providerID || cfg.OpenAICompatibility[0].APIKeyEntries[0].ID != keyID {
+		t.Fatalf("IDs changed after legacy PUT rotation: provider=%q/%q key=%q/%q", providerID, cfg.OpenAICompatibility[0].ID, keyID, cfg.OpenAICompatibility[0].APIKeyEntries[0].ID)
+	}
+}

--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -77,7 +77,13 @@ func ApplyStoredRuntimeSettings(cfg *config.Config) bool {
 	if cfg == nil || !ConfigStoreAvailable() {
 		return false
 	}
-	return runtimeSettingsStore().ApplyToConfig(cfg)
+	store := runtimeSettingsStore()
+	applied := store.ApplyToConfig(cfg)
+	if cfg.EnsureProviderStableIDs() {
+		persistProviderStableIDBackfill(store, cfg)
+		return true
+	}
+	return applied
 }
 
 func MigrateRuntimeSettingsFromConfig(cfg *config.Config, configFilePath string) int {
@@ -113,7 +119,38 @@ func ApplyStoredRuntimeSettingsForTenant(tenantID string, cfg *config.Config) bo
 	if cfg == nil || !ConfigStoreAvailable() {
 		return false
 	}
-	return runtimeSettingsStoreForTenant(tenantID).ApplyToConfig(cfg)
+	store := runtimeSettingsStoreForTenant(tenantID)
+	applied := store.ApplyToConfig(cfg)
+	if cfg.EnsureProviderStableIDs() {
+		persistProviderStableIDBackfill(store, cfg)
+		return true
+	}
+	return applied
+}
+
+func persistProviderStableIDBackfill(store sqlsettings.RuntimeSettingsStore, cfg *config.Config) {
+	settings := []struct {
+		key   string
+		value any
+	}{
+		{RuntimeSettingGeminiKeys, cfg.GeminiKey},
+		{RuntimeSettingCodexKeys, cfg.CodexKey},
+		{RuntimeSettingClaudeKeys, cfg.ClaudeKey},
+		{RuntimeSettingBedrockKeys, cfg.BedrockKey},
+		{RuntimeSettingOpenCodeGoKeys, cfg.OpenCodeGoKey},
+		{RuntimeSettingClineKeys, cfg.ClineKey},
+		{RuntimeSettingOllamaCloudKeys, cfg.OllamaCloudKey},
+		{RuntimeSettingOpenAICompatibility, cfg.OpenAICompatibility},
+		{RuntimeSettingVertexCompatKeys, cfg.VertexCompatAPIKey},
+	}
+	for _, setting := range settings {
+		if !store.Exists(setting.key) {
+			continue
+		}
+		if err := store.Upsert(setting.key, setting.value); err != nil {
+			continue
+		}
+	}
 }
 
 // BuildTenantRuntimeConfig returns an isolated runtime snapshot for one tenant.

--- a/internal/usage/runtime_settings_db_test.go
+++ b/internal/usage/runtime_settings_db_test.go
@@ -305,3 +305,21 @@ func TestBuildTenantRuntimeConfigPreservesExplicitDisabledIdentityFingerprint(t 
 		t.Fatalf("Codex.Enabled = false, want true from tenant runtime row")
 	}
 }
+
+func TestTenantRuntimeProviderStableIDBackfillPersistsOnce(t *testing.T) {
+	cleanup := setupConfigMigrationTestDB(t)
+	defer cleanup()
+
+	const tenantID = "00000000-0000-0000-0000-0000000000aa"
+	if err := UpsertRuntimeSettingForTenant(tenantID, RuntimeSettingGeminiKeys, []config.GeminiKey{{APIKey: "tenant-secret"}}); err != nil {
+		t.Fatalf("UpsertRuntimeSettingForTenant: %v", err)
+	}
+	first := BuildTenantRuntimeConfig(&config.Config{}, tenantID)
+	if len(first.GeminiKey) != 1 || first.GeminiKey[0].ID == "" {
+		t.Fatalf("first backfill = %#v", first.GeminiKey)
+	}
+	second := BuildTenantRuntimeConfig(&config.Config{}, tenantID)
+	if second.GeminiKey[0].ID != first.GeminiKey[0].ID {
+		t.Fatalf("tenant stable ID changed: first=%q second=%q", first.GeminiKey[0].ID, second.GeminiKey[0].ID)
+	}
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
 	log "github.com/sirupsen/logrus"
 	_ "modernc.org/sqlite"
@@ -813,6 +814,12 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 	initRuntimeSettingsTable(db)
 	log.Debugf("usage: initializing identity_fingerprints table")
 	initIdentityFingerprintsTable(db)
+	log.Debugf("usage: initializing content moderation tables")
+	if err := contentmoderation.InitTables(db); err != nil {
+		_ = db.Close()
+		usageDB, usageReadDB = nil, nil
+		return err
+	}
 	startRequestLogMaintenance(db, driver)
 	startRequestLogContentSessionIDBackfill(db)
 	log.Infof("usage: %s database initialised at %s", driver, dbPath)

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -84,6 +84,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeys(ctx *SynthesisContext) []*corea
 		if label == "" {
 			label = "gemini-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "gemini",
@@ -142,6 +143,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		if label == "" {
 			label = "claude-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", ck.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "claude",
@@ -227,6 +229,7 @@ func (s *ConfigSynthesizer) synthesizeBedrockKeys(ctx *SynthesisContext) []*core
 			attrs["models_hash"] = hash
 		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		id, token := idGen.Next("bedrock:apikey", idParts...)
 		attrs["source"] = fmt.Sprintf("config:bedrock[%s]", token)
 		label := strings.TrimSpace(entry.Name)
@@ -290,6 +293,7 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 		if label == "" {
 			label = "codex-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", ck.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "codex",
@@ -344,6 +348,7 @@ func (s *ConfigSynthesizer) synthesizeOpenCodeGoKeys(ctx *SynthesisContext) []*c
 		if label == "" {
 			label = "opencode-go-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "opencode-go",
@@ -406,6 +411,7 @@ func (s *ConfigSynthesizer) synthesizeClineKeys(ctx *SynthesisContext) []*coreau
 		if label == "" {
 			label = "cline-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "cline",
@@ -468,6 +474,7 @@ func (s *ConfigSynthesizer) synthesizeOllamaCloudKeys(ctx *SynthesisContext) []*
 		if label == "" {
 			label = "ollama-cloud-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "ollama-cloud",
@@ -534,6 +541,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				attrs["models_hash"] = hash
 			}
 			addConfigHeadersToAttrs(compat.Headers, attrs)
+			addProviderBindingAttrs(attrs, compat.ID, entry.ID)
 			a := &coreauth.Auth{
 				ID:         id,
 				Provider:   providerName,
@@ -565,6 +573,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				attrs["models_hash"] = hash
 			}
 			addConfigHeadersToAttrs(compat.Headers, attrs)
+			addProviderBindingAttrs(attrs, compat.ID, "")
 			a := &coreauth.Auth{
 				ID:         id,
 				Provider:   providerName,
@@ -614,6 +623,7 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 			attrs["models_hash"] = hash
 		}
 		addConfigHeadersToAttrs(compat.Headers, attrs)
+		addProviderBindingAttrs(attrs, "", compat.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   providerName,

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -963,3 +963,38 @@ func TestConfigSynthesizer_AllProviders(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigSynthesizerAddsProviderBindingIDs(t *testing.T) {
+	cfg := &config.Config{
+		GeminiKey: []config.GeminiKey{{ID: "11111111-1111-4111-8111-111111111111", APIKey: "gemini-secret"}},
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			ID:      "22222222-2222-4222-8222-222222222222",
+			Name:    "compat",
+			BaseURL: "https://compat.example",
+			APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+				ID:     "33333333-3333-4333-8333-333333333333",
+				APIKey: "compat-secret",
+			}},
+		}},
+	}
+	auths, err := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+		Config:      cfg,
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("auth count = %d, want 2", len(auths))
+	}
+	if got := auths[0].Attributes["provider_key_id"]; got != cfg.GeminiKey[0].ID {
+		t.Fatalf("gemini provider_key_id = %q", got)
+	}
+	if got := auths[1].Attributes["provider_config_id"]; got != cfg.OpenAICompatibility[0].ID {
+		t.Fatalf("compat provider_config_id = %q", got)
+	}
+	if got := auths[1].Attributes["provider_key_id"]; got != cfg.OpenAICompatibility[0].APIKeyEntries[0].ID {
+		t.Fatalf("compat provider_key_id = %q", got)
+	}
+}

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -142,3 +142,15 @@ func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string)
 		attrs["header:"+key] = val
 	}
 }
+
+func addProviderBindingAttrs(attrs map[string]string, providerConfigID, providerKeyID string) {
+	if attrs == nil {
+		return
+	}
+	if id := strings.TrimSpace(providerConfigID); id != "" {
+		attrs["provider_config_id"] = id
+	}
+	if id := strings.TrimSpace(providerKeyID); id != "" {
+		attrs["provider_key_id"] = id
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -186,6 +186,8 @@ type Manager struct {
 
 	modelRegistry ModelRegistry
 
+	requestModerator RequestModerator
+
 	// Auto refresh state
 	refreshCancel    context.CancelFunc
 	refreshSemaphore chan struct{}

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -127,6 +127,9 @@ func (s cooldownService) shouldRetryAfterError(err error, attempt int, providers
 	if isRequestInvalidError(err) {
 		return 0, false
 	}
+	if isContentPolicyViolation(err) {
+		return 0, false
+	}
 	wait, found := s.closestWait(providers, model, attempt)
 	if !found || wait > maxWait {
 		return 0, false

--- a/sdk/cliproxy/auth/conductor_execution_service.go
+++ b/sdk/cliproxy/auth/conductor_execution_service.go
@@ -53,6 +53,9 @@ func runExecutionWithRetry[T any](
 	executeOnce func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (T, error),
 ) (T, error) {
 	var zero T
+	if opts.Metadata == nil {
+		opts.Metadata = make(map[string]any)
+	}
 
 	normalized := manager.normalizeProviders(providers)
 	if len(normalized) == 0 {
@@ -93,6 +96,9 @@ func (s executionService) executeMixedOnce(ctx context.Context, providers []stri
 		candidate, errPick := s.nextMixedCandidate(ctx, &scope, req)
 		if errPick != nil {
 			return cliproxyexecutor.Response{}, resolveMixedPickError(lastErr, errPick)
+		}
+		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
+			return cliproxyexecutor.Response{}, errModeration
 		}
 
 		resp, errExec := candidate.executor.Execute(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
@@ -137,6 +143,9 @@ func (s executionService) executeCountMixedOnce(ctx context.Context, providers [
 		if errPick != nil {
 			return cliproxyexecutor.Response{}, resolveMixedPickError(lastErr, errPick)
 		}
+		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
+			return cliproxyexecutor.Response{}, errModeration
+		}
 
 		resp, errExec := candidate.executor.CountTokens(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
 		if errExec != nil {
@@ -165,6 +174,9 @@ func (s executionService) executeStreamMixedOnce(ctx context.Context, providers 
 		candidate, errPick := s.nextMixedCandidate(ctx, &scope, req)
 		if errPick != nil {
 			return nil, resolveMixedPickError(lastErr, errPick)
+		}
+		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
+			return nil, errModeration
 		}
 
 		streamResult, errStream := candidate.executor.ExecuteStream(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)

--- a/sdk/cliproxy/auth/request_moderator.go
+++ b/sdk/cliproxy/auth/request_moderator.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+const contentPolicyViolationCode = "content_policy_violation"
+
+// RequestModerationResult is the narrow SDK contract returned by a host-provided
+// request moderator. Dependency failures must be handled fail-open by the host.
+type RequestModerationResult struct {
+	Blocked    bool
+	Message    string
+	HTTPStatus int
+}
+
+// RequestModerator evaluates the original inbound request after an auth
+// candidate is selected and before any provider executor is called.
+type RequestModerator interface {
+	Moderate(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options) RequestModerationResult
+}
+
+func (m *Manager) SetRequestModerator(moderator RequestModerator) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.requestModerator = moderator
+	m.mu.Unlock()
+}
+
+func (m *Manager) moderateRequest(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	moderator := m.requestModerator
+	m.mu.RUnlock()
+	if moderator == nil {
+		return nil
+	}
+	result := moderator.Moderate(ctx, auth, opts)
+	if !result.Blocked {
+		return nil
+	}
+	status := result.HTTPStatus
+	if status < 400 || status > 599 {
+		status = http.StatusForbidden
+	}
+	message := strings.TrimSpace(result.Message)
+	if message == "" {
+		message = "Your request was blocked by the content moderation policy."
+	}
+	return &Error{Code: contentPolicyViolationCode, Message: message, HTTPStatus: status}
+}
+
+func isContentPolicyViolation(err error) bool {
+	var authErr *Error
+	return errors.As(err, &authErr) && authErr != nil && authErr.Code == contentPolicyViolationCode
+}

--- a/sdk/cliproxy/auth/request_moderator_test.go
+++ b/sdk/cliproxy/auth/request_moderator_test.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"sync"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+type requestModeratorFunc func(context.Context, *Auth, cliproxyexecutor.Options) RequestModerationResult
+
+func (f requestModeratorFunc) Moderate(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options) RequestModerationResult {
+	return f(ctx, auth, opts)
+}
+
+type moderationCountingExecutor struct {
+	mu          sync.Mutex
+	execute     int
+	stream      int
+	countTokens int
+	failAuthID  string
+}
+
+func (e *moderationCountingExecutor) Identifier() string { return "moderation-test" }
+
+func (e *moderationCountingExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.execute++
+	if auth != nil && auth.ID == e.failAuthID {
+		return cliproxyexecutor.Response{}, errors.New("upstream unavailable")
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *moderationCountingExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.stream++
+	e.mu.Unlock()
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *moderationCountingExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.countTokens++
+	e.mu.Unlock()
+	return cliproxyexecutor.Response{Payload: []byte("count")}, nil
+}
+
+func (e *moderationCountingExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *moderationCountingExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+type orderedAuthSelector struct{}
+
+func (orderedAuthSelector) Pick(_ context.Context, _ string, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if len(auths) == 0 {
+		return nil, errors.New("no auth")
+	}
+	sort.Slice(auths, func(i, j int) bool { return auths[i].ID < auths[j].ID })
+	return auths[0], nil
+}
+
+func newModerationTestManager(t *testing.T, executor *moderationCountingExecutor, auths ...*Auth) *Manager {
+	t.Helper()
+	manager := NewManager(nil, orderedAuthSelector{}, nil)
+	manager.RegisterExecutor(executor)
+	for _, auth := range auths {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s): %v", auth.ID, err)
+		}
+	}
+	return manager
+}
+
+func TestRequestModeratorBlocksBeforeEveryExecutorPath(t *testing.T) {
+	paths := []struct {
+		name string
+		run  func(*Manager) error
+	}{
+		{name: "execute", run: func(manager *Manager) error {
+			_, err := manager.Execute(context.Background(), []string{"moderation-test"}, cliproxyexecutor.Request{Model: "model"}, cliproxyexecutor.Options{})
+			return err
+		}},
+		{name: "stream", run: func(manager *Manager) error {
+			_, err := manager.ExecuteStream(context.Background(), []string{"moderation-test"}, cliproxyexecutor.Request{Model: "model"}, cliproxyexecutor.Options{})
+			return err
+		}},
+		{name: "count", run: func(manager *Manager) error {
+			_, err := manager.ExecuteCount(context.Background(), []string{"moderation-test"}, cliproxyexecutor.Request{Model: "model"}, cliproxyexecutor.Options{})
+			return err
+		}},
+	}
+	for _, tt := range paths {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &moderationCountingExecutor{}
+			manager := newModerationTestManager(t, executor, &Auth{ID: "auth-a", Provider: executor.Identifier(), Status: StatusActive})
+			manager.SetRequestModerator(requestModeratorFunc(func(context.Context, *Auth, cliproxyexecutor.Options) RequestModerationResult {
+				return RequestModerationResult{Blocked: true, Message: "blocked", HTTPStatus: http.StatusUnavailableForLegalReasons}
+			}))
+
+			err := tt.run(manager)
+			var authErr *Error
+			if !errors.As(err, &authErr) || authErr.Code != contentPolicyViolationCode || authErr.HTTPStatus != http.StatusUnavailableForLegalReasons {
+				t.Fatalf("error = %#v, want content policy violation", err)
+			}
+			executor.mu.Lock()
+			defer executor.mu.Unlock()
+			if executor.execute != 0 || executor.stream != 0 || executor.countTokens != 0 {
+				t.Fatalf("executor calls execute=%d stream=%d count=%d, want zero", executor.execute, executor.stream, executor.countTokens)
+			}
+		})
+	}
+}
+
+func TestRequestModeratorRunsAgainForFallbackCandidate(t *testing.T) {
+	executor := &moderationCountingExecutor{failAuthID: "auth-a"}
+	manager := newModerationTestManager(t, executor,
+		&Auth{ID: "auth-a", Provider: executor.Identifier(), Status: StatusActive},
+		&Auth{ID: "auth-b", Provider: executor.Identifier(), Status: StatusActive},
+	)
+	var mu sync.Mutex
+	var moderated []string
+	manager.SetRequestModerator(requestModeratorFunc(func(_ context.Context, auth *Auth, _ cliproxyexecutor.Options) RequestModerationResult {
+		mu.Lock()
+		moderated = append(moderated, auth.ID)
+		mu.Unlock()
+		return RequestModerationResult{}
+	}))
+
+	if _, err := manager.Execute(context.Background(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: "model"}, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(moderated) != 2 || moderated[0] != "auth-a" || moderated[1] != "auth-b" {
+		t.Fatalf("moderated candidates = %#v, want auth-a then auth-b", moderated)
+	}
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -121,6 +121,8 @@ type Builder struct {
 	// coreAuthHook observes credential lifecycle without entering request hot paths.
 	coreAuthHook coreauth.Hook
 
+	requestModerator coreauth.RequestModerator
+
 	// serverOptions contains additional server configuration options.
 	serverOptions []api.ServerOption
 }
@@ -201,6 +203,13 @@ func (b *Builder) WithCoreAuthManager(mgr *coreauth.Manager) *Builder {
 // WithCoreAuthHook configures lifecycle callbacks for bindings and related read models.
 func (b *Builder) WithCoreAuthHook(hook coreauth.Hook) *Builder {
 	b.coreAuthHook = hook
+	return b
+}
+
+// WithRequestModerator injects request-time content moderation without coupling
+// the SDK to the host's persistence implementation.
+func (b *Builder) WithRequestModerator(moderator coreauth.RequestModerator) *Builder {
+	b.requestModerator = moderator
 	return b
 }
 
@@ -293,6 +302,7 @@ func (b *Builder) Build() (*Service, error) {
 	if b.coreAuthHook != nil {
 		coreManager.SetHook(b.coreAuthHook)
 	}
+	coreManager.SetRequestModerator(b.requestModerator)
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
 	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
 	coreManager.SetConfig(b.cfg)


### PR DESCRIPTION
## Summary
Implements multi-profile content moderation (Phase 0–1B) per `docs/plan/079-content-moderation-profiles-20260722.md` in the monorepo root.

- **Phase 0:** Persistent stable UUIDs for provider/provider-key channels (binding-safe across key rotation).
- **Phase 1A:** Tenant-scoped `content_moderation_profiles` + `content_moderation_channel_bindings`, management APIs, RBAC, menu seed `/runtime/content-moderation`.
- **Phase 1B:** `RequestModerator` hook after candidate pick, before Execute/ExecuteStream/CountTokens; keyword + OpenAI Moderations; fail-open on API errors; auth > provider_key > provider resolution.

## API (for frontend consumers)
- `GET/POST /v0/management/content-moderation/profiles`
- `GET/PATCH/DELETE /v0/management/content-moderation/profiles/:id`
- `POST /v0/management/content-moderation/profiles/:id/test`
- `GET /v0/management/content-moderation/channels` (server-side pagination)
- `PATCH /v0/management/channel-bindings` → **`/content-moderation/channel-bindings`**

Permissions: `content_moderation.read|write|test`

## Non-goals (this PR)
Observe queue, auto-ban, email, hash cache, Qwen3Guard, image moderation, frontend UI (separate codeProxy PR).

## Verification
- Pre-rebase: full `./scripts/ci-pr.sh` PASS
- Post-rebase: `go test ./internal/contentmoderation ./sdk/cliproxy/auth ./internal/api/routes -count=1` PASS (218)

## Expand/contract
Safe to merge before frontend; default off, no behavior change without bindings + pre_block.