### PR TITLE
fix(identity): move moderation menu under access

### DIFF
--- a/internal/identity/menus.go
+++ b/internal/identity/menus.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 )
 
-const MenuManagementCode = "system.menus"
+const (
+	MenuManagementCode        = "system.menus"
+	ContentModerationMenuCode = "runtime.content-moderation"
+)
 
 type Menu struct {
 	Code            string `json:"code"`
@@ -89,7 +92,6 @@ var MenuCatalog = []MenuSeed{
 	{Code: "runtime.monitor", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/monitor", Component: "monitor", LabelKey: "shell.nav_monitor", Icon: "activity", PermissionCode: "monitor.read", SortOrder: 10},
 	{Code: "runtime.request-logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/request-logs", Component: "request-logs", LabelKey: "shell.nav_request_logs", Icon: "scroll-text", PermissionCode: "request_logs.read", SortOrder: 20},
 	{Code: "runtime.logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/logs", Component: "logs", LabelKey: "shell.nav_logs", Icon: "file-text", PermissionCode: "system.logs.read", SortOrder: 30},
-	{Code: "runtime.content-moderation", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/content-moderation", Component: "content-moderation", LabelKey: "shell.nav_content_moderation", Icon: "shield-alert", PermissionCode: "content_moderation.read", SortOrder: 40},
 	// Access & credentials (upstream AI + client keys)
 	{Code: "access.providers", ParentCode: "group.access", Type: "menu", Path: "/access/ai-providers", Component: "providers", LabelKey: "shell.nav_ai_providers", Icon: "bot", PermissionCode: "providers.read", SortOrder: 10},
 	// Stable code kept for role/menu bindings; path lives under /access as AI OAuth accounts.
@@ -100,6 +102,8 @@ var MenuCatalog = []MenuSeed{
 	{Code: "access.end-users", ParentCode: "group.access", Type: "menu", Path: "/access/end-users", Component: "end-users", LabelKey: "shell.nav_end_users", Icon: "user-round", PermissionCode: "end_users.read", SortOrder: 25},
 	// Stable code kept; API Key permission profiles belong with client credentials.
 	{Code: "system.api-key-permissions", ParentCode: "group.access", Type: "menu", Path: "/access/api-key-permissions", Component: "api-key-permissions", LabelKey: "shell.nav_api_key_permissions", Icon: "shield-check", PermissionCode: "api_key_profiles.read", SortOrder: 40},
+	// Stable code kept for existing menu references; content moderation belongs with access credentials.
+	{Code: ContentModerationMenuCode, ParentCode: "group.access", Type: "menu", Path: "/access/content-moderation", Component: "content-moderation", LabelKey: "shell.nav_content_moderation", Icon: "shield-alert", PermissionCode: "content_moderation.read", SortOrder: 45},
 	// Tenant-scoped: matches /ccswitch-import-configs API auth (routing.read/write).
 	// Must not use platform system.config.read, or ordinary tenants never see this menu.
 	{Code: "access.ccswitch", ParentCode: "group.access", Type: "menu", Path: "/access/ccswitch-import-settings", Component: "ccswitch-import-settings", LabelKey: "shell.nav_ccswitch_import_settings", Icon: "arrow-down-to-line", PermissionCode: "routing.read", SortOrder: 50},

--- a/internal/identity/permissions.go
+++ b/internal/identity/permissions.go
@@ -102,7 +102,7 @@ func menuCodeForPermission(permission PermissionSeed) string {
 	case "request_logs":
 		return "runtime.request-logs"
 	case "content_moderation":
-		return "runtime.content-moderation"
+		return ContentModerationMenuCode
 	case "providers":
 		return "access.providers"
 	case "auth_files":

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -187,6 +187,20 @@ func TestMenuCatalogReferencesExistingParents(t *testing.T) {
 	if plaza.PermissionCode != "system.status.read" {
 		t.Fatalf("models.plaza permission = %q, want system.status.read", plaza.PermissionCode)
 	}
+	// Content moderation is an access/credential concern, while its stable code preserves existing references.
+	moderation, ok := seen[ContentModerationMenuCode]
+	if !ok {
+		t.Fatalf("%s menu is missing", ContentModerationMenuCode)
+	}
+	if moderation.ParentCode != "group.access" {
+		t.Fatalf("%s parent = %q, want group.access", ContentModerationMenuCode, moderation.ParentCode)
+	}
+	if moderation.Path != "/access/content-moderation" {
+		t.Fatalf("%s path = %q, want /access/content-moderation", ContentModerationMenuCode, moderation.Path)
+	}
+	if moderation.PermissionCode != "content_moderation.read" {
+		t.Fatalf("%s permission = %q, want content_moderation.read", ContentModerationMenuCode, moderation.PermissionCode)
+	}
 }
 
 func TestGeneratedIdentifier(t *testing.T) {
@@ -219,11 +233,12 @@ func TestMenuCodeForPermission(t *testing.T) {
 		menuCodes[menu.Code] = true
 	}
 	tests := map[string]string{
-		"tenant.users.update":   "governance.users",
-		"request_logs.delete":   "runtime.request-logs",
-		"system.logs.delete":    "runtime.logs",
-		"platform.menus.update": MenuManagementCode,
-		"proxies.test":          "models.proxies",
+		"tenant.users.update":     "governance.users",
+		"request_logs.delete":     "runtime.request-logs",
+		"system.logs.delete":      "runtime.logs",
+		"platform.menus.update":   MenuManagementCode,
+		"content_moderation.read": ContentModerationMenuCode,
+		"proxies.test":            "models.proxies",
 	}
 	for _, permission := range PermissionCatalog {
 		got := menuCodeForPermission(permission)


### PR DESCRIPTION
## Summary
- move the content moderation menu from `group.runtime` to `group.access`
- change the seeded route to `/access/content-moderation` with sort order 45
- retain stable menu code `runtime.content-moderation` for existing menu references
- bind `content_moderation.*` permissions through the shared stable menu-code constant
- add catalog and permission-mapping regression assertions

## Validation
- `go test ./internal/identity` — passed (11 tests)
- `./scripts/ci-pr.sh` — passed
