### PR TITLE
fix: collapse channel options by shared auth_index without live subject

### DIFF
--- a/internal/management/usagelogs/channel_filter_options.go
+++ b/internal/management/usagelogs/channel_filter_options.go
@@ -1,0 +1,53 @@
+package usagelogs
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func canonicalChannelAuthIndex(authIndex string, authIndexGroup map[string][]string) string {
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return ""
+	}
+	if group := authIndexGroup[authIndex]; len(group) > 0 {
+		// buildNameMaps stores the live EnsureIndex() first.
+		return strings.TrimSpace(group[0])
+	}
+	return authIndex
+}
+
+// queryDistinctChannelRows groups by historical subject first. Record how many
+// distinct facet identities land on each canonical auth_index so a subject
+// rekey can collapse even when the live alias map no longer has it.
+func channelFacetIdentitiesByAuthIndex(
+	options []usage.ChannelFilterOption,
+	authIndexGroup map[string][]string,
+) map[string]map[string]struct{} {
+	identitiesByIndex := make(map[string]map[string]struct{})
+	for _, option := range options {
+		authIndex := strings.TrimSpace(option.AuthIndex)
+		if authIndex == "" && !looksLikeAuthSubjectID(option.Value) {
+			authIndex = strings.TrimSpace(option.Value)
+		}
+		authIndex = canonicalChannelAuthIndex(authIndex, authIndexGroup)
+		if authIndex == "" {
+			continue
+		}
+
+		identity := strings.TrimSpace(option.AuthSubjectID)
+		if identity == "" {
+			if value := strings.TrimSpace(option.Value); looksLikeAuthSubjectID(value) {
+				identity = value
+			} else {
+				identity = "<index-only>"
+			}
+		}
+		if identitiesByIndex[authIndex] == nil {
+			identitiesByIndex[authIndex] = make(map[string]struct{})
+		}
+		identitiesByIndex[authIndex][strings.ToLower(identity)] = struct{}{}
+	}
+	return identitiesByIndex
+}

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -595,23 +595,14 @@ func enrichChannelFilterOptions(
 		return make([]usage.ChannelFilterOption, 0)
 	}
 
-	// Prefer one option per auth_subject_id. Fall back to auth_index for orphans.
+	// Prefer one option per live auth_subject_id. When multiple facet rows share
+	// one canonical auth_index but no live subject mapping, use the auth_index as
+	// the option identity so selecting it matches every historical subject row.
 	// Collapse pure name-only rows when the same label already has auth-backed options.
 	out := make([]usage.ChannelFilterOption, 0, len(options))
 	seenValue := make(map[string]struct{}, len(options))
 	authBackedLabels := make(map[string]struct{})
 
-	canonicalAuthIndex := func(authIndex string) string {
-		authIndex = strings.TrimSpace(authIndex)
-		if authIndex == "" {
-			return ""
-		}
-		if group := authIndexGroup[authIndex]; len(group) > 0 {
-			// buildNameMaps stores the live EnsureIndex() first.
-			return strings.TrimSpace(group[0])
-		}
-		return authIndex
-	}
 	resolveSubject := func(option usage.ChannelFilterOption, authIndex string) string {
 		// Live auth metadata is the canonical subject. Persisted request-log rows
 		// may still carry an older subject ID after the identity seed changes.
@@ -627,12 +618,14 @@ func enrichChannelFilterOptions(
 		return ""
 	}
 
+	facetIdentitiesByAuthIndex := channelFacetIdentitiesByAuthIndex(options, authIndexGroup)
+
 	for _, option := range options {
 		authIndex := strings.TrimSpace(option.AuthIndex)
 		if authIndex == "" && !looksLikeAuthSubjectID(option.Value) {
 			authIndex = strings.TrimSpace(option.Value)
 		}
-		authIndex = canonicalAuthIndex(authIndex)
+		authIndex = canonicalChannelAuthIndex(authIndex, authIndexGroup)
 		subjectID := resolveSubject(option, authIndex)
 		if subjectID != "" {
 			if meta, ok := authMetaBySubject[subjectID]; ok && meta.label != "" {
@@ -655,7 +648,7 @@ func enrichChannelFilterOptions(
 		if authIndex == "" && !looksLikeAuthSubjectID(option.Value) {
 			authIndex = strings.TrimSpace(option.Value)
 		}
-		authIndex = canonicalAuthIndex(authIndex)
+		authIndex = canonicalChannelAuthIndex(authIndex, authIndexGroup)
 		subjectID := resolveSubject(option, authIndex)
 
 		if label == "" && authIndex != "" {
@@ -684,6 +677,12 @@ func enrichChannelFilterOptions(
 		authType := strings.TrimSpace(option.AuthType)
 		value := strings.TrimSpace(option.Value)
 		hasLiveMeta := false
+
+		// Without a live canonical subject, a repeated canonical auth_index is the
+		// only selector that covers every historical subject produced by the facet.
+		if authIndex != "" && strings.TrimSpace(authSubjectByIndex[authIndex]) == "" && len(facetIdentitiesByAuthIndex[authIndex]) > 1 {
+			subjectID = ""
+		}
 
 		if subjectID != "" {
 			value = subjectID

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -515,6 +515,54 @@ func TestEnrichChannelFilterOptionsCollapsesHistoricalSubjectRekeyByAuthIndex(t 
 	}
 }
 
+func TestEnrichChannelFilterOptionsCollapsesHistoricalSubjectsByAuthIndexWithoutLiveMap(t *testing.T) {
+	t.Parallel()
+
+	authIndex := "14c5636b41002b25"
+	oldSubject := "authsub_4ca6f5185e367ab2"
+	newSubject := "authsub_9ebad60f7efd0b3c"
+	label := "GinofkFerraiuolo@hotmail.com"
+
+	options := []usage.ChannelFilterOption{
+		{Value: oldSubject, Label: label, AuthIndex: authIndex, AuthSubjectID: oldSubject},
+		{Value: newSubject, Label: label, AuthIndex: authIndex, AuthSubjectID: newSubject},
+	}
+
+	// The production hole has no live auth_index -> subject alias to choose a
+	// canonical subject. The shared auth_index must therefore become the stable
+	// option value so the next request matches both historical subject rows.
+	got := enrichChannelFilterOptions(options, nil, nil, nil, nil, nil, nil)
+	if len(got) != 1 {
+		t.Fatalf("options = %#v, want one auth-index option", got)
+	}
+	if got[0].Value != authIndex || got[0].AuthIndex != authIndex || got[0].AuthSubjectID != "" {
+		t.Fatalf("option = %#v, want auth index %q without a non-canonical subject", got[0], authIndex)
+	}
+
+	subjects, authIndexes, channelNames, _ := channelFilterSelectors(
+		[]string{got[0].Value},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if len(subjects) != 0 || len(channelNames) != 0 {
+		t.Fatalf("subjects = %#v, channelNames = %#v, want auth-index-only filter", subjects, channelNames)
+	}
+	if !reflect.DeepEqual(authIndexes, []string{authIndex}) {
+		t.Fatalf("authIndexes = %#v, want [%s]", authIndexes, authIndex)
+	}
+	for _, row := range options {
+		if row.AuthIndex != authIndexes[0] {
+			t.Fatalf("historical subject %s was not covered by auth index %s", row.AuthSubjectID, authIndexes[0])
+		}
+	}
+}
+
 func TestEnrichChannelFilterOptionsInfersProviderAuthTypeWithoutLiveMeta(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- collapse request-log channel facets by canonical `auth_index` when multiple historical subjects share it and no live subject alias exists
- use the shared `auth_index` as the filter value in that fallback, so selecting one option matches every historical subject row
- preserve live-subject canonicalization and auth-index alias-group expansion

## Root cause
PR #790 only remapped a historical subject when `authSubjectByIndex[authIndex]` was populated. Without that live map, each facet row kept its own historical subject value and survived deduplication.

## Tests
- `go test ./internal/management/usagelogs -count=1`
- `./scripts/ci-pr.sh`