### PR TITLE
feat: content moderation observability

### DIFF
--- a/internal/api/handlers/management/content_moderation.go
+++ b/internal/api/handlers/management/content_moderation.go
@@ -42,6 +42,15 @@ func (h *Handler) deleteContentModerationBindings(ctx context.Context, tenantID,
 	return h.contentModerationStore().PatchBindings(ctx, tenantID, false, operations)
 }
 
+func (h *Handler) GetContentModerationMetrics(c *gin.Context) {
+	runtime := contentmoderation.Runtime()
+	if runtime == nil {
+		c.JSON(http.StatusOK, contentmoderation.ModerationMetrics{})
+		return
+	}
+	c.JSON(http.StatusOK, runtime.Metrics())
+}
+
 func (h *Handler) GetContentModerationProfiles(c *gin.Context) {
 	tenantID := effectiveTenantID(c)
 	profiles, err := h.contentModerationStore().ListProfiles(c.Request.Context(), tenantID)

--- a/internal/api/handlers/management/content_moderation_test.go
+++ b/internal/api/handlers/management/content_moderation_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 )
 
 func setupContentModerationHandlerTest(t *testing.T) (*Handler, string) {
@@ -54,6 +56,62 @@ func moderationContext(tenantID, method, path, body string) (*gin.Context, *http
 	c.Request = httptest.NewRequest(method, path, bytes.NewBufferString(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 	return c, rec
+}
+
+type managementMetricsResolver struct {
+	profile contentmoderation.Profile
+}
+
+func (r managementMetricsResolver) ResolveProfile(context.Context, string, string, string, string) (contentmoderation.Profile, string, error) {
+	return r.profile, contentmoderation.ChannelTypeProviderKey, nil
+}
+
+type managementMetricsEvaluator struct{}
+
+func (managementMetricsEvaluator) Evaluate(context.Context, contentmoderation.Profile, string) contentmoderation.Decision {
+	return contentmoderation.Decision{Action: contentmoderation.ActionAllow}
+}
+
+func TestContentModerationMetricsUseLiveRuntime(t *testing.T) {
+	const tenantID = "tenant-metrics"
+	profile, err := contentmoderation.NewProfile(tenantID, "profile-metrics", contentmoderation.CreateProfileInput{
+		Name:        "metrics",
+		Mode:        contentmoderation.ModePreBlock,
+		KeywordMode: contentmoderation.KeywordModeKeywordOnly,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	runtime := contentmoderation.NewRequestModerator(managementMetricsResolver{profile: profile}, managementMetricsEvaluator{})
+	previous := contentmoderation.Runtime()
+	contentmoderation.SetRuntime(runtime)
+	t.Cleanup(func() { contentmoderation.SetRuntime(previous) })
+	body, _ := json.Marshal(map[string]any{"messages": []map[string]any{{"role": "user", "content": "safe"}}})
+	runtime.Moderate(context.Background(), &coreauth.Auth{
+		ID:       "auth-metrics",
+		TenantID: tenantID,
+		Attributes: map[string]string{
+			"provider_key_id": "provider-key-metrics",
+		},
+	}, cliproxyexecutor.Options{
+		OriginalRequest: body,
+		SourceFormat:    sdktranslator.FormatOpenAI,
+		Metadata:        map[string]any{cliproxyexecutor.TenantMetadataKey: tenantID},
+	})
+
+	h := &Handler{}
+	c, rec := moderationContext(tenantID, http.MethodGet, "/v0/management/content-moderation/metrics", "")
+	h.GetContentModerationMetrics(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET metrics status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var metrics contentmoderation.ModerationMetrics
+	if err = json.Unmarshal(rec.Body.Bytes(), &metrics); err != nil {
+		t.Fatalf("decode metrics: %v", err)
+	}
+	if metrics.Requests != 1 || metrics.Allows != 1 {
+		t.Fatalf("metrics = %#v", metrics)
+	}
 }
 
 func TestContentModerationProfileUsesPrincipalTenantAndHidesSecret(t *testing.T) {

--- a/internal/api/routes/management_content_moderation_routes.go
+++ b/internal/api/routes/management_content_moderation_routes.go
@@ -6,6 +6,7 @@ import (
 )
 
 func registerManagementContentModerationRoutes(group *gin.RouterGroup, h *managementhandlers.Handler) {
+	group.GET("/content-moderation/metrics", h.GetContentModerationMetrics)
 	group.GET("/content-moderation/profiles", h.GetContentModerationProfiles)
 	group.POST("/content-moderation/profiles", h.PostContentModerationProfile)
 	group.GET("/content-moderation/profiles/:id", h.GetContentModerationProfile)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 304; got != want {
+	if got, want := len(routes), 305; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -34,6 +34,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 	}
 
 	required := []string{
+		"GET /v0/management/content-moderation/metrics",
 		"GET /v0/management/content-moderation/profiles",
 		"POST /v0/management/content-moderation/profiles",
 		"GET /v0/management/content-moderation/profiles/:id",
@@ -299,6 +300,7 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/config",
 		"GET /v0/management/config.yaml",
 		"GET /v0/management/content-moderation/channels",
+		"GET /v0/management/content-moderation/metrics",
 		"GET /v0/management/content-moderation/profiles",
 		"GET /v0/management/content-moderation/profiles/:id",
 		"GET /v0/management/dashboard-summary",

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -42,11 +42,13 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 	usage.InitRedis(cfg.Redis)
 	defer usage.StopRedis()
 
+	moderator := contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))
+	contentmoderation.SetRuntime(moderator)
 	builder := cliproxy.NewBuilder().
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
-		WithRequestModerator(contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))).
+		WithRequestModerator(moderator).
 		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 
@@ -87,11 +89,13 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 	}
 	usage.InitRedis(cfg.Redis)
 
+	moderator := contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))
+	contentmoderation.SetRuntime(moderator)
 	builder := cliproxy.NewBuilder().
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
-		WithRequestModerator(contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))).
+		WithRequestModerator(moderator).
 		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 

--- a/internal/contentmoderation/runtime.go
+++ b/internal/contentmoderation/runtime.go
@@ -31,11 +31,14 @@ type RuntimeModerator struct {
 	lastGoodMu sync.RWMutex
 	lastGood   map[resolutionKey]resolvedProfile
 
-	requests  atomic.Uint64
-	allows    atomic.Uint64
-	blocks    atomic.Uint64
-	errors    atomic.Uint64
-	cacheHits atomic.Uint64
+	requests       atomic.Uint64
+	allows         atomic.Uint64
+	blocks         atomic.Uint64
+	errors         atomic.Uint64
+	cacheHits      atomic.Uint64
+	inFlight       atomic.Int64
+	latencyTotalMS atomic.Uint64
+	latencySamples atomic.Uint64
 }
 
 type resolutionKey struct {
@@ -56,11 +59,27 @@ type requestDecisionCache struct {
 }
 
 type ModerationMetrics struct {
-	Requests  uint64 `json:"requests"`
-	Allows    uint64 `json:"allows"`
-	Blocks    uint64 `json:"blocks"`
-	Errors    uint64 `json:"errors"`
-	CacheHits uint64 `json:"cache_hits"`
+	Requests       uint64  `json:"requests"`
+	Allows         uint64  `json:"allows"`
+	Blocks         uint64  `json:"blocks"`
+	Errors         uint64  `json:"errors"`
+	CacheHits      uint64  `json:"cache_hits"`
+	InFlight       int64   `json:"in_flight"`
+	LatencyTotalMS uint64  `json:"latency_total_ms"`
+	LatencySamples uint64  `json:"latency_samples"`
+	AvgLatencyMS   float64 `json:"avg_latency_ms"`
+}
+
+var runtimeModerator atomic.Pointer[RuntimeModerator]
+
+// SetRuntime exposes the live proxy moderator to process-local management metrics.
+func SetRuntime(moderator *RuntimeModerator) {
+	runtimeModerator.Store(moderator)
+}
+
+// Runtime returns the moderator used by the live proxy process.
+func Runtime() *RuntimeModerator {
+	return runtimeModerator.Load()
 }
 
 func NewRequestModerator(resolver ProfileResolver, evaluator DecisionEvaluator) *RuntimeModerator {
@@ -78,13 +97,22 @@ func (m *RuntimeModerator) Metrics() ModerationMetrics {
 	if m == nil {
 		return ModerationMetrics{}
 	}
-	return ModerationMetrics{
-		Requests:  m.requests.Load(),
-		Allows:    m.allows.Load(),
-		Blocks:    m.blocks.Load(),
-		Errors:    m.errors.Load(),
-		CacheHits: m.cacheHits.Load(),
+	latencyTotalMS := m.latencyTotalMS.Load()
+	latencySamples := m.latencySamples.Load()
+	metrics := ModerationMetrics{
+		Requests:       m.requests.Load(),
+		Allows:         m.allows.Load(),
+		Blocks:         m.blocks.Load(),
+		Errors:         m.errors.Load(),
+		CacheHits:      m.cacheHits.Load(),
+		InFlight:       m.inFlight.Load(),
+		LatencyTotalMS: latencyTotalMS,
+		LatencySamples: latencySamples,
 	}
+	if latencySamples > 0 {
+		metrics.AvgLatencyMS = float64(latencyTotalMS) / float64(latencySamples)
+	}
+	return metrics
 }
 
 func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, opts cliproxyexecutor.Options) coreauth.RequestModerationResult {
@@ -94,7 +122,7 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 	m.requests.Add(1)
 	tenantID := coreauth.NormalizedTenantID(metadataString(opts.Metadata, cliproxyexecutor.TenantMetadataKey))
 	if coreauth.NormalizedTenantID(auth.TenantID) != tenantID {
-		m.recordError(tenantID, auth, "", Profile{}, "tenant_mismatch", 0)
+		m.recordError(tenantID, auth, "", Profile{}, "tenant_mismatch", 0, false)
 		return coreauth.RequestModerationResult{}
 	}
 
@@ -106,23 +134,27 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 		return coreauth.RequestModerationResult{}
 	}
 	if err != nil {
-		m.recordError(tenantID, auth, "", Profile{}, "store_error", 0)
+		m.recordError(tenantID, auth, "", Profile{}, "store_error", 0, false)
 		return coreauth.RequestModerationResult{}
 	}
 	if usedLastGood {
-		m.recordError(tenantID, auth, resolved.source, resolved.profile, "store_error_last_good", 0)
+		m.recordError(tenantID, auth, resolved.source, resolved.profile, "store_error_last_good", 0, false)
 	}
 	profile := resolved.profile
 	if profile.Mode == ModeOff {
 		m.allows.Add(1)
-		m.logDecision(tenantID, auth, resolved.source, profile, Decision{Action: ActionAllow}, false)
+		decision := Decision{Action: ActionAllow}
+		m.setSnapshot(ctx, auth, resolved.source, profile, decision, false, false)
+		m.logDecision(tenantID, auth, resolved.source, profile, decision, false)
 		return coreauth.RequestModerationResult{}
 	}
 
 	input := ExtractLastUserText(opts.SourceFormat, opts.OriginalRequest)
 	if input == "" {
 		m.allows.Add(1)
-		m.logDecision(tenantID, auth, resolved.source, profile, Decision{Action: ActionAllow}, false)
+		decision := Decision{Action: ActionAllow}
+		m.setSnapshot(ctx, auth, resolved.source, profile, decision, false, false)
+		m.logDecision(tenantID, auth, resolved.source, profile, decision, false)
 		return coreauth.RequestModerationResult{}
 	}
 
@@ -131,14 +163,25 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 	if cache != nil {
 		if decision, ok := cache.get(cacheKey); ok {
 			m.cacheHits.Add(1)
-			return m.resultForDecision(tenantID, auth, resolved.source, profile, decision, true)
+			return m.resultForDecision(ctx, tenantID, auth, resolved.source, profile, decision, true)
 		}
 	}
+	apiPath := moderationAPIPath(profile, input)
+	if apiPath {
+		m.inFlight.Add(1)
+	}
 	decision := m.evaluator.Evaluate(ctx, profile, input)
+	if apiPath {
+		m.inFlight.Add(-1)
+		if decision.LatencyMS >= 0 {
+			m.latencyTotalMS.Add(uint64(decision.LatencyMS))
+			m.latencySamples.Add(1)
+		}
+	}
 	if cache != nil {
 		cache.put(cacheKey, decision)
 	}
-	return m.resultForDecision(tenantID, auth, resolved.source, profile, decision, false)
+	return m.resultForDecision(ctx, tenantID, auth, resolved.source, profile, decision, false)
 }
 
 func (m *RuntimeModerator) resolve(ctx context.Context, key resolutionKey) (resolvedProfile, bool, error) {
@@ -165,12 +208,15 @@ func (m *RuntimeModerator) resolve(ctx context.Context, key resolutionKey) (reso
 	return resolvedProfile{}, false, err
 }
 
-func (m *RuntimeModerator) resultForDecision(tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) coreauth.RequestModerationResult {
+func (m *RuntimeModerator) resultForDecision(ctx context.Context, tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) coreauth.RequestModerationResult {
 	if decision.Action == ActionAPIError {
 		m.allows.Add(1)
-		m.recordError(tenantID, auth, source, profile, moderationErrorClass(decision.ModerationError), decision.LatencyMS)
+		errorClass := moderationErrorClass(decision.ModerationError)
+		m.setSnapshot(ctx, auth, source, profile, decision, true, cached)
+		m.recordError(tenantID, auth, source, profile, errorClass, decision.LatencyMS, cached)
 		return coreauth.RequestModerationResult{}
 	}
+	m.setSnapshot(ctx, auth, source, profile, decision, true, cached)
 	if decision.WouldBlock {
 		m.blocks.Add(1)
 		m.logDecision(tenantID, auth, source, profile, decision, cached)
@@ -181,12 +227,13 @@ func (m *RuntimeModerator) resultForDecision(tenantID string, auth *coreauth.Aut
 	return coreauth.RequestModerationResult{}
 }
 
-func (m *RuntimeModerator) recordError(tenantID string, auth *coreauth.Auth, source string, profile Profile, errorClass string, latencyMS int64) {
+func (m *RuntimeModerator) recordError(tenantID string, auth *coreauth.Auth, source string, profile Profile, errorClass string, latencyMS int64, cached bool) {
 	m.errors.Add(1)
 	fields := moderationLogFields(tenantID, auth, source, profile)
 	fields["action"] = ActionAPIError
 	fields["error_class"] = errorClass
 	fields["latency_ms"] = latencyMS
+	fields["cache_hit"] = cached
 	log.WithFields(fields).Warn("content moderation failed open")
 }
 
@@ -249,6 +296,17 @@ func runtimeChannelIDs(auth *coreauth.Auth) (authFileID, providerKeyID, provider
 	providerKeyID = strings.TrimSpace(auth.Attributes["provider_key_id"])
 	providerID = strings.TrimSpace(auth.Attributes["provider_config_id"])
 	return authFileID, providerKeyID, providerID
+}
+
+func moderationAPIPath(profile Profile, input string) bool {
+	if profile.Mode != ModePreBlock || profile.KeywordMode == KeywordModeKeywordOnly || strings.TrimSpace(input) == "" {
+		return false
+	}
+	if profile.KeywordMode == KeywordModeKeywordAndAPI {
+		_, keywordHit := matchKeyword(input, profile.BlockedKeywords)
+		return !keywordHit
+	}
+	return true
 }
 
 func decisionCacheKey(profile Profile, input string) string {

--- a/internal/contentmoderation/runtime_snapshot.go
+++ b/internal/contentmoderation/runtime_snapshot.go
@@ -1,0 +1,98 @@
+package contentmoderation
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const ginRuntimeSnapshotKey = "content_moderation_runtime_snapshot"
+
+// RuntimeSnapshot is the secret-free moderation outcome persisted with request details.
+type RuntimeSnapshot struct {
+	Evaluated        bool     `json:"evaluated"`
+	ProfileID        string   `json:"profile_id"`
+	ProfileName      string   `json:"profile_name"`
+	ProfileVersion   int64    `json:"profile_version"`
+	ResolutionSource string   `json:"resolution_source"`
+	ChannelType      string   `json:"channel_type"`
+	ChannelID        string   `json:"channel_id"`
+	Action           string   `json:"action"`
+	WouldBlock       bool     `json:"would_block"`
+	MatchedKeyword   string   `json:"matched_keyword,omitempty"`
+	HighestCategory  string   `json:"highest_category,omitempty"`
+	HighestScore     *float64 `json:"highest_score,omitempty"`
+	LatencyMS        int64    `json:"latency_ms"`
+	CacheHit         bool     `json:"cache_hit"`
+	ErrorClass       string   `json:"error_class,omitempty"`
+	ModerationError  string   `json:"moderation_error,omitempty"`
+}
+
+// SetRuntimeSnapshot attaches a moderation outcome to the request's Gin context.
+func SetRuntimeSnapshot(ctx context.Context, snapshot RuntimeSnapshot) {
+	if ctx == nil {
+		return
+	}
+	ginCtx, _ := ctx.Value(util.ContextKeyGin).(*gin.Context)
+	if ginCtx != nil {
+		ginCtx.Set(ginRuntimeSnapshotKey, snapshot)
+	}
+}
+
+// RuntimeSnapshotFromGin returns the request-scoped moderation outcome, if any.
+func RuntimeSnapshotFromGin(ginCtx *gin.Context) (RuntimeSnapshot, bool) {
+	if ginCtx == nil {
+		return RuntimeSnapshot{}, false
+	}
+	value, exists := ginCtx.Get(ginRuntimeSnapshotKey)
+	if !exists {
+		return RuntimeSnapshot{}, false
+	}
+	snapshot, ok := value.(RuntimeSnapshot)
+	return snapshot, ok
+}
+
+func (m *RuntimeModerator) setSnapshot(ctx context.Context, auth *coreauth.Auth, source string, profile Profile, decision Decision, evaluated, cached bool) {
+	channelType, channelID := resolvedChannel(auth, source)
+	snapshot := RuntimeSnapshot{
+		Evaluated:        evaluated,
+		ProfileID:        profile.ID,
+		ProfileName:      profile.Name,
+		ProfileVersion:   profile.Version,
+		ResolutionSource: source,
+		ChannelType:      channelType,
+		ChannelID:        channelID,
+		Action:           decision.Action,
+		WouldBlock:       decision.WouldBlock,
+		MatchedKeyword:   decision.MatchedKeyword,
+		HighestCategory:  decision.HighestCategory,
+		LatencyMS:        decision.LatencyMS,
+		CacheHit:         cached,
+	}
+	if decision.HighestCategory != "" {
+		score := decision.HighestScore
+		snapshot.HighestScore = &score
+	}
+	if decision.Action == ActionAPIError {
+		snapshot.ErrorClass = moderationErrorClass(decision.ModerationError)
+		snapshot.ModerationError = moderationErrorSummary(snapshot.ErrorClass)
+	}
+	SetRuntimeSnapshot(ctx, snapshot)
+}
+
+func moderationErrorSummary(errorClass string) string {
+	switch errorClass {
+	case "timeout":
+		return "moderation API request timed out"
+	case "upstream_status":
+		return "moderation API returned a non-success status"
+	case "invalid_response":
+		return "moderation API returned an invalid response"
+	case "transport":
+		return "moderation API transport failed"
+	default:
+		return "moderation API evaluation failed"
+	}
+}

--- a/internal/contentmoderation/runtime_test.go
+++ b/internal/contentmoderation/runtime_test.go
@@ -27,6 +27,18 @@ func (e *runtimeEvaluatorStub) Evaluate(context.Context, Profile, string) Decisi
 	return e.decision
 }
 
+type blockingRuntimeEvaluator struct {
+	started  chan struct{}
+	release  chan struct{}
+	decision Decision
+}
+
+func (e *blockingRuntimeEvaluator) Evaluate(context.Context, Profile, string) Decision {
+	close(e.started)
+	<-e.release
+	return e.decision
+}
+
 type runtimeResolverStub struct {
 	calls atomic.Int32
 	fn    func() (Profile, string, error)
@@ -180,6 +192,59 @@ func TestRuntimeModeratorTenantMismatchNeverQueriesResolver(t *testing.T) {
 	}
 	if moderator.Metrics().Errors != 1 {
 		t.Fatalf("metrics = %#v, want one error", moderator.Metrics())
+	}
+}
+
+func TestRuntimeModeratorMetricsTrackAPILatencyAndInFlight(t *testing.T) {
+	const tenantID = "tenant-metrics"
+	profile, err := NewProfile(tenantID, "profile-metrics", CreateProfileInput{
+		Name:        "metrics",
+		Mode:        ModePreBlock,
+		KeywordMode: KeywordModeAPIOnly,
+		APIKey:      "moderation-secret",
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	resolver := &runtimeResolverStub{fn: func() (Profile, string, error) {
+		return profile, ChannelTypeProviderKey, nil
+	}}
+	evaluator := &blockingRuntimeEvaluator{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		decision: Decision{Action: ActionAllow, LatencyMS: 24},
+	}
+	moderator := NewRequestModerator(resolver, evaluator)
+	auth := &coreauth.Auth{
+		ID:       "auth-metrics",
+		TenantID: tenantID,
+		Attributes: map[string]string{
+			"provider_key_id": "key-metrics",
+		},
+	}
+	resultCh := make(chan coreauth.RequestModerationResult, 1)
+	go func() {
+		resultCh <- moderator.Moderate(context.Background(), auth, runtimeOptions(tenantID, "safe"))
+	}()
+
+	select {
+	case <-evaluator.started:
+	case <-time.After(time.Second):
+		t.Fatal("moderation evaluator did not start")
+	}
+	if metrics := moderator.Metrics(); metrics.Requests != 1 || metrics.InFlight != 1 {
+		t.Fatalf("metrics during evaluation = %#v", metrics)
+	}
+	close(evaluator.release)
+	if result := <-resultCh; result.Blocked {
+		t.Fatal("allow decision unexpectedly blocked")
+	}
+	metrics := moderator.Metrics()
+	if metrics.Requests != 1 || metrics.Allows != 1 || metrics.Blocks != 0 || metrics.Errors != 0 || metrics.InFlight != 0 {
+		t.Fatalf("metrics after evaluation = %#v", metrics)
+	}
+	if metrics.LatencyTotalMS != 24 || metrics.LatencySamples != 1 || metrics.AvgLatencyMS != 24 {
+		t.Fatalf("latency metrics = %#v", metrics)
 	}
 }
 

--- a/internal/logging/global_logger.go
+++ b/internal/logging/global_logger.go
@@ -30,7 +30,7 @@ var (
 type LogFormatter struct{}
 
 // logFieldOrder defines the display order for common log fields.
-var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error"}
+var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error_class", "profile_id", "profile_version", "resolution_source", "channel_type", "channel_id", "action", "latency_ms", "cache_hit", "category", "score", "error"}
 
 // Format renders a single log entry with custom formatting.
 func (m *LogFormatter) Format(entry *log.Entry) ([]byte, error) {

--- a/internal/logging/global_logger_test.go
+++ b/internal/logging/global_logger_test.go
@@ -1,0 +1,53 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestLogFormatterIncludesModerationFields(t *testing.T) {
+	entry := &log.Entry{
+		Logger:  log.New(),
+		Time:    time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC),
+		Level:   log.WarnLevel,
+		Message: "content moderation failed open",
+		Data: log.Fields{
+			"error_class":       "timeout",
+			"profile_id":        "profile-1",
+			"profile_version":   3,
+			"resolution_source": "provider_key",
+			"channel_type":      "provider_key",
+			"channel_id":        "key-1",
+			"action":            "api_error",
+			"latency_ms":        3000,
+			"cache_hit":         false,
+			"category":          "violence",
+			"score":             0.91,
+		},
+	}
+	formatted, err := (&LogFormatter{}).Format(entry)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	output := string(formatted)
+	for _, field := range []string{
+		"error_class=timeout",
+		"profile_id=profile-1",
+		"profile_version=3",
+		"resolution_source=provider_key",
+		"channel_type=provider_key",
+		"channel_id=key-1",
+		"action=api_error",
+		"latency_ms=3000",
+		"cache_hit=false",
+		"category=violence",
+		"score=0.91",
+	} {
+		if !strings.Contains(output, field) {
+			t.Fatalf("formatted log missing %q: %s", field, output)
+		}
+	}
+}

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
@@ -192,6 +193,43 @@ func TestRequestDetailsCaptureUpstreamLogsWhenOnlyContentStorageEnabled(t *testi
 	}
 	if !strings.Contains(detail.Response.UpstreamLog, `{"id":"resp-test"}`) {
 		t.Fatalf("upstream response log missing body: %q", detail.Response.UpstreamLog)
+	}
+}
+
+func TestRequestDetailsIncludeModerationSnapshot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"input":"not persisted"}`))
+	ginCtx.Request = req
+	ctx := context.WithValue(req.Context(), util.ContextKeyGin, ginCtx)
+	highestScore := 0.91
+	contentmoderation.SetRuntimeSnapshot(ctx, contentmoderation.RuntimeSnapshot{
+		Evaluated:        true,
+		ProfileID:        "profile-1",
+		ProfileName:      "Strict prompts",
+		ProfileVersion:   3,
+		ResolutionSource: contentmoderation.ChannelTypeProviderKey,
+		ChannelType:      contentmoderation.ChannelTypeProviderKey,
+		ChannelID:        "provider-key-1",
+		Action:           contentmoderation.ActionAPIBlock,
+		WouldBlock:       true,
+		HighestCategory:  "violence",
+		HighestScore:     &highestScore,
+		LatencyMS:        18,
+		CacheHit:         false,
+	})
+
+	var detail struct {
+		Moderation contentmoderation.RuntimeSnapshot `json:"moderation"`
+	}
+	if err := json.Unmarshal([]byte(buildRequestDetailContent(ctx, false)), &detail); err != nil {
+		t.Fatalf("unmarshal request details: %v", err)
+	}
+	if detail.Moderation.ProfileID != "profile-1" || detail.Moderation.ChannelID != "provider-key-1" || detail.Moderation.Action != contentmoderation.ActionAPIBlock {
+		t.Fatalf("moderation detail = %#v", detail.Moderation)
+	}
+	if detail.Moderation.HighestScore == nil || *detail.Moderation.HighestScore != highestScore {
+		t.Fatalf("moderation highest score = %#v", detail.Moderation.HighestScore)
 	}
 }
 

--- a/internal/runtime/executor/usage_request_details.go
+++ b/internal/runtime/executor/usage_request_details.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -129,6 +130,9 @@ func buildRequestDetailContent(ctx context.Context, includeBodies ...bool) strin
 		if snapshot := diagnostic.Snapshot(); !snapshot.IsZero() {
 			detail["diagnostic"] = snapshot
 		}
+	}
+	if moderation, ok := contentmoderation.RuntimeSnapshotFromGin(ginCtx); ok {
+		detail["moderation"] = moderation
 	}
 
 	data, err := json.Marshal(detail)


### PR DESCRIPTION
## Summary
- Persist secret-free `moderation` snapshot into request log `detail_content` (profile/channel/action/latency/error_class).
- Expose process-local live metrics via `GET /v0/management/content-moderation/metrics` from the same RuntimeModerator singleton set in `run.go`.
- Expand logrus field whitelist so fail-open warnings include `error_class`, `profile_id`, channel binding fields, latency.

## Why
Operators could not see whether channel bindings were applied in request-log details, and failed-open moderation logs lost structured fields.

## Test plan
- [x] `go test ./internal/contentmoderation/... ./internal/logging/... ./internal/runtime/executor/ ./internal/api/handlers/management/ ./internal/api/routes/ -run 'ContentModeration|RegisterManagement'`
- Local focused packages green.

## Notes
Frontend companion PR depends on this metrics endpoint.