### PR TITLE
fix(usage): inherit openrouter pricing for prefixed models

### DIFF
--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -749,7 +749,12 @@ func openRouterSyncExistingWrapperRows(tenantID, baseModelID string, model OpenR
 		if !exists {
 			continue
 		}
-		existing.OwnedBy = "cline"
+		switch {
+		case strings.HasPrefix(wrapperID, "cline-pass/"):
+			existing.OwnedBy = "cline"
+		case strings.HasPrefix(wrapperID, "ollama/"):
+			existing.OwnedBy = "ollama"
+		}
 		if description := openRouterModelDescription(model); description != "" && openRouterShouldSyncDescription(existing) {
 			existing.Description = description
 		}
@@ -766,7 +771,10 @@ func openRouterWrapperModelIDs(baseModelID string) []string {
 	if baseModelID == "" || strings.Contains(baseModelID, "/") {
 		return nil
 	}
-	return []string{"cline-pass/" + baseModelID}
+	return []string{
+		"cline-pass/" + baseModelID,
+		"ollama/" + baseModelID,
+	}
 }
 
 func openRouterStaticBaseModelRow(modelID string) (ModelConfigRow, bool) {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -304,6 +304,67 @@ func TestSyncOpenRouterModelsUpdatesExistingClinePassWrapperFromCanonicalModel(t
 	}
 }
 
+func TestSyncOpenRouterModelsUpdatesExistingOllamaWrapperFromCanonicalModel(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "ollama/deepseek-v4-flash",
+		OwnedBy:     "ollama",
+		Description: "",
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "user",
+		InputModalities: []string{
+			"text",
+		},
+		OutputModalities: []string{
+			"text",
+		},
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "deepseek/deepseek-v4-flash",
+			Description: "DeepSeek V4 Flash from OpenRouter",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality:         "text+image->text",
+				InputModalities:  []string{"text", "image"},
+				OutputModalities: []string{"text"},
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.0000003",
+				Completion:     "0.0000012",
+				InputCacheRead: "0.00000003",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	model, ok := GetModelConfig("ollama/deepseek-v4-flash")
+	if !ok {
+		t.Fatal("expected existing ollama wrapper to remain configured")
+	}
+	if model.OwnedBy != "ollama" || model.Source != "user" {
+		t.Fatalf("ollama wrapper identity should be preserved: %+v", model)
+	}
+	if model.Description != "DeepSeek V4 Flash from OpenRouter" {
+		t.Fatalf("ollama wrapper should inherit remote description, got %q", model.Description)
+	}
+	if model.InputPricePerMillion != 0.3 || model.OutputPricePerMillion != 1.2 || model.CachedPricePerMillion != 0.03 {
+		t.Fatalf("ollama wrapper should inherit canonical pricing: %+v", model)
+	}
+	if strings.Join(model.InputModalities, ",") != "text,image" || strings.Join(model.OutputModalities, ",") != "text" {
+		t.Fatalf("ollama wrapper should inherit canonical modalities: %+v -> %+v", model.InputModalities, model.OutputModalities)
+	}
+}
+
 func TestSyncOpenRouterModelsUpdatesExistingOpenRouterDescription(t *testing.T) {
 	initModelConfigTestDB(t)
 

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -352,21 +352,53 @@ func calculateTokenCostV2(inputTokens, outputTokens, cacheReadTokens, cacheWrite
 	return total
 }
 
+func modelPricingLookupModelIDs(modelID string) []string {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return nil
+	}
+	prefix, _, found := strings.Cut(modelID, "/")
+	providerlessID := openRouterProviderlessModelID(modelID)
+	if !found || strings.TrimSpace(prefix) == "" || providerlessID == "" || providerlessID == modelID {
+		return []string{modelID}
+	}
+	return []string{modelID, providerlessID}
+}
+
+// resolveModelPricingRowForTenant resolves exact pricing first, then retries once
+// without the first provider segment. Each candidate preserves tenant-over-system
+// inheritance and ModelConfigRow-over-legacy-pricing precedence.
+func resolveModelPricingRowForTenant(tenantID, modelID string) (ModelConfigRow, bool) {
+	for _, lookupID := range modelPricingLookupModelIDs(modelID) {
+		if row, ok := GetModelConfigForTenant(tenantID, lookupID); ok {
+			return row, true
+		}
+		if pricing, ok := GetModelPricingForTenant(tenantID, lookupID); ok {
+			return ModelConfigRow{
+				ModelID:                   pricing.ModelID,
+				Enabled:                   true,
+				PricingMode:               "token",
+				InputPricePerMillion:      pricing.InputPricePerMillion,
+				OutputPricePerMillion:     pricing.OutputPricePerMillion,
+				CachedPricePerMillion:     pricing.CachedPricePerMillion,
+				CacheReadPricePerMillion:  pricing.CacheReadPricePerMillion,
+				CacheWritePricePerMillion: pricing.CacheWritePricePerMillion,
+			}, true
+		}
+	}
+	return ModelConfigRow{}, false
+}
+
 // resolveModelPricing returns the effective pricing for a model from either
 // ModelConfigRow cache or ModelPricingRow cache, along with a boolean indicating
 // whether the model is enabled (or found at all).
 // Both lookups inherit system-tenant catalog prices when the business tenant has no override.
 func resolveModelPricingForTenant(tenantID, modelID string) (inputPrice, outputPrice, cachedPrice, cacheReadPrice, cacheWritePrice float64, enabled bool) {
-	if row, ok := GetModelConfigForTenant(tenantID, modelID); ok {
-		enabled = row.Enabled
-		return row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion, row.CacheReadPricePerMillion, row.CacheWritePricePerMillion, enabled
-	}
-
-	row, ok := GetModelPricingForTenant(tenantID, modelID)
+	row, ok := resolveModelPricingRowForTenant(tenantID, modelID)
 	if !ok {
 		return 0, 0, 0, 0, 0, false
 	}
-	return row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion, row.CacheReadPricePerMillion, row.CacheWritePricePerMillion, true
+	return row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion, row.CacheReadPricePerMillion, row.CacheWritePricePerMillion, row.Enabled
 }
 
 // CalculateCost computes the cost for a request based on the model's pricing.
@@ -376,19 +408,12 @@ func CalculateCost(modelID string, inputTokens, outputTokens, cachedTokens int64
 	return CalculateCostForTenant(systemTenantID, modelID, inputTokens, outputTokens, cachedTokens)
 }
 func CalculateCostForTenant(tenantID, modelID string, inputTokens, outputTokens, cachedTokens int64) float64 {
-	if row, ok := GetModelConfigForTenant(tenantID, modelID); ok {
-		if !row.Enabled {
-			return 0
-		}
-		if normalizePricingMode(row.PricingMode) == "call" {
-			return row.PricePerCall
-		}
-		return calculateTokenCost(inputTokens, outputTokens, cachedTokens, row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion)
-	}
-
-	row, ok := GetModelPricingForTenant(tenantID, modelID)
-	if !ok {
+	row, ok := resolveModelPricingRowForTenant(tenantID, modelID)
+	if !ok || !row.Enabled {
 		return 0
+	}
+	if normalizePricingMode(row.PricingMode) == "call" {
+		return row.PricePerCall
 	}
 	return calculateTokenCost(inputTokens, outputTokens, cachedTokens, row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion)
 }
@@ -397,7 +422,7 @@ func CalculateCostForTenant(tenantID, modelID string, inputTokens, outputTokens,
 // the per-call price if so, along with a boolean. This avoids re-checking the
 // model config cache directly in CalculateCostV2.
 func resolveCallPricingForTenant(tenantID, modelID string) (pricePerCall float64, isCall bool) {
-	if row, ok := GetModelConfigForTenant(tenantID, modelID); ok && row.Enabled && normalizePricingMode(row.PricingMode) == "call" {
+	if row, ok := resolveModelPricingRowForTenant(tenantID, modelID); ok && row.Enabled && normalizePricingMode(row.PricingMode) == "call" {
 		return row.PricePerCall, true
 	}
 	return 0, false

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -260,6 +260,101 @@ func TestCalculateCostV2FallbackLegacyWithModelPricingTable(t *testing.T) {
 	}
 }
 
+func TestCalculateCostFallsBackToProviderlessModelPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:                  "deepseek-v4-flash",
+		Enabled:                  true,
+		PricingMode:              "token",
+		InputPricePerMillion:     0.3,
+		OutputPricePerMillion:    1.2,
+		CacheReadPricePerMillion: 0.03,
+		Source:                   "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	const modelID = "ollama/deepseek-v4-flash"
+	legacyCost := CalculateCost(modelID, 1_000_000, 1_000_000, 0)
+	if legacyCost != 1.5 {
+		t.Fatalf("CalculateCost(%q) = %v, want 1.5", modelID, legacyCost)
+	}
+
+	v2Cost := CalculateCostV2(modelID, TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+	if v2Cost != 1.5 {
+		t.Fatalf("CalculateCostV2(%q) = %v, want 1.5", modelID, v2Cost)
+	}
+
+	if err := UpsertModelConfigForTenant(businessTenantID, ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  3,
+		OutputPricePerMillion: 12,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant() error = %v", err)
+	}
+	tenantCost := CalculateCostV2ForTenant(businessTenantID, "ollama/deepseek-v4-flash", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+	if tenantCost != 15 {
+		t.Fatalf("tenant providerless override cost = %v, want 15", tenantCost)
+	}
+}
+
+func TestCalculateCostProviderlessFallbackPreservesExactCustomPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfigForTenant(systemTenantID, ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant(base) error = %v", err)
+	}
+	if err := UpsertModelConfigForTenant(businessTenantID, ModelConfigRow{
+		ModelID:               "ollama/deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  3,
+		OutputPricePerMillion: 12,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant(exact) error = %v", err)
+	}
+
+	cost := CalculateCostV2ForTenant(businessTenantID, "ollama/deepseek-v4-flash", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+	if cost != 15 {
+		t.Fatalf("exact custom pricing cost = %v, want 15", cost)
+	}
+}
+
+func TestCalculateCostProviderlessFallbackSupportsCallPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:      "image-call-base",
+		Enabled:      true,
+		PricingMode:  "call",
+		PricePerCall: 0.04,
+		Source:       "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	for name, cost := range map[string]float64{
+		"legacy": CalculateCost("ollama/image-call-base", 0, 0, 0),
+		"v2":     CalculateCostV2("ollama/image-call-base", TokenStats{}),
+	} {
+		if cost != 0.04 {
+			t.Fatalf("%s call cost = %v, want 0.04", name, cost)
+		}
+	}
+}
+
 func TestQueryTodayCostByKeyResetsDaily(t *testing.T) {
 	initModelConfigTestDB(t)
 	db := getDB()


### PR DESCRIPTION
## Summary
- OpenRouter sync 现在会把 base 模型定价回填到已存在的 `ollama/<base>` wrapper（与既有 `cline-pass/` 对称）
- 计费/定价解析在精确 model_id miss 时，剥离第一段 provider 前缀回落到 base 定价
- 精确存在的自定义价优先，不覆盖用户配置

## Root cause
`ollama/deepseek-v4-flash` 与 OpenRouter 同步后的 `deepseek-v4-flash` 本是同一模型，但 wrapper 回填原先只覆盖 `cline-pass/`，且定价查找仅精确匹配，导致面板显示「未定价」且计费为 0。

## Test plan
- [x] `go test ./internal/usage/ -count=1 -run 'TestSyncOpenRouterModelsUpdatesExisting(Ollama|ClinePass)WrapperFromCanonicalModel|TestCalculateCost(FallsBackToProviderlessModelPricing|ProviderlessFallbackPreservesExactCustomPricing|ProviderlessFallbackSupportsCallPricing)'`
- [x] `go test ./internal/usage/ -count=1 -run 'OpenRouter|Pricing|Wrapper|ollama|Ollama|ModelConfig'`
- [x] `go test ./internal/usage/ -count=1`
- [x] `go vet ./internal/usage/...`
- [x] `./scripts/ci-pr.sh`