### PR TITLE
fix(usage): inherit base pricing for prefixed runtime models

### DIFF
--- a/internal/api/server_models_endpoint.go
+++ b/internal/api/server_models_endpoint.go
@@ -154,6 +154,16 @@ func enrichOpenAIModelsWithCatalog(tenantID string, models []map[string]interfac
 	if len(models) == 0 {
 		return
 	}
+	configRows := modelconfigsettings.ListAllConfigsForTenant(tenantID)
+	configByID := make(map[string]usage.ModelConfigRow, len(configRows))
+	for _, row := range configRows {
+		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
+	}
+	pricingRows := usage.GetAllModelPricingForTenant(tenantID)
+	pricingByID := make(map[string]usage.ModelPricingRow, len(pricingRows))
+	for modelID, row := range pricingRows {
+		pricingByID[strings.ToLower(strings.TrimSpace(modelID))] = row
+	}
 	for _, model := range models {
 		if model == nil {
 			continue
@@ -163,7 +173,7 @@ func enrichOpenAIModelsWithCatalog(tenantID string, models []map[string]interfac
 		if id == "" {
 			continue
 		}
-		if row, ok := modelconfigsettings.GetConfigForTenant(tenantID, id); ok {
+		if row, ok := configByID[strings.ToLower(id)]; ok {
 			if ownedBy := strings.TrimSpace(row.OwnedBy); ownedBy != "" {
 				if existing, _ := model["owned_by"].(string); strings.TrimSpace(existing) == "" {
 					model["owned_by"] = ownedBy
@@ -191,27 +201,16 @@ func enrichOpenAIModelsWithCatalog(tenantID string, models []map[string]interfac
 				}
 			}
 			model["supports_vision"] = supportsVision
-			model["pricing"] = map[string]any{
-				"mode":                          row.PricingMode,
-				"input_price_per_million":       row.InputPricePerMillion,
-				"output_price_per_million":      row.OutputPricePerMillion,
-				"cached_price_per_million":      row.CachedPricePerMillion,
-				"cache_read_price_per_million":  row.CacheReadPricePerMillion,
-				"cache_write_price_per_million": row.CacheWritePricePerMillion,
-				"price_per_call":                row.PricePerCall,
-			}
-			continue
 		}
-		// Fallback: legacy model_pricing table when no model_config row exists.
-		if pricing, ok := usage.GetModelPricingForTenant(tenantID, id); ok {
+		if pricing, ok := usage.ResolveModelPricingRow(id, configByID, pricingByID); ok {
 			model["pricing"] = map[string]any{
-				"mode":                          "token",
+				"mode":                          pricing.PricingMode,
 				"input_price_per_million":       pricing.InputPricePerMillion,
 				"output_price_per_million":      pricing.OutputPricePerMillion,
 				"cached_price_per_million":      pricing.CachedPricePerMillion,
 				"cache_read_price_per_million":  pricing.CacheReadPricePerMillion,
 				"cache_write_price_per_million": pricing.CacheWritePricePerMillion,
-				"price_per_call":                0,
+				"price_per_call":                pricing.PricePerCall,
 			}
 		}
 	}

--- a/internal/api/server_models_endpoint_test.go
+++ b/internal/api/server_models_endpoint_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -13,6 +15,7 @@ import (
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/openai"
@@ -224,6 +227,38 @@ func TestEnrichOpenAIModelsWithCatalogLeavesUnknownModels(t *testing.T) {
 	}
 	if _, hasDesc := models[0]["description"]; hasDesc {
 		t.Fatal("unexpected description for unknown model")
+	}
+}
+
+func TestEnrichOpenAIModelsWithCatalogInheritsPrefixedPricing(t *testing.T) {
+	usage.CloseDB()
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("usage.InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	models := []map[string]interface{}{{
+		"id":     "ollama/deepseek-v4-flash",
+		"object": "model",
+	}}
+	enrichOpenAIModelsWithCatalog("", models)
+	pricing, ok := models[0]["pricing"].(map[string]any)
+	if !ok {
+		t.Fatalf("pricing = %#v, want inherited pricing map", models[0]["pricing"])
+	}
+	if pricing["input_price_per_million"] != 0.3 || pricing["output_price_per_million"] != 1.2 {
+		t.Fatalf("pricing = %#v, want input=0.3 output=1.2", pricing)
 	}
 }
 

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -77,11 +77,7 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		allModels = s.filterModelsByRoutingAllowedModels(allModels, allowedGroupsRaw)
 	}
 
-	allConfigRows := modelconfigsettings.ListAllConfigsForTenant(s.tenantID)
-	configByID := make(map[string]usage.ModelConfigRow, len(allConfigRows))
-	for _, row := range allConfigRows {
-		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
-	}
+	configByID, pricingByID := pricingLookupMapsForTenant(s.tenantID)
 	data := make([]map[string]any, 0, len(allModels))
 	activeMetadata := make([]map[string]any, 0, len(allModels))
 	for _, model := range allModels {
@@ -111,15 +107,6 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		}
 		if row, ok := configByID[strings.ToLower(id)]; ok {
 			attachModelConfigCapabilities(entry, row)
-			entry["pricing"] = map[string]any{
-				"mode":                          row.PricingMode,
-				"input_price_per_million":       row.InputPricePerMillion,
-				"output_price_per_million":      row.OutputPricePerMillion,
-				"cached_price_per_million":      row.CachedPricePerMillion,
-				"cache_read_price_per_million":  row.CacheReadPricePerMillion,
-				"cache_write_price_per_million": row.CacheWritePricePerMillion,
-				"price_per_call":                row.PricePerCall,
-			}
 			if row.Description != "" {
 				entry["description"] = row.Description
 			}
@@ -134,6 +121,9 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 					"enabled":  row.Enabled,
 				})
 			}
+		}
+		if pricing, ok := usage.ResolveModelPricingRow(id, configByID, pricingByID); ok {
+			entry["pricing"] = modelPricingPayload(pricing)
 		}
 		data = append(data, entry)
 	}
@@ -169,7 +159,7 @@ func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string, opts ...Av
 		allModels = s.filterModelsByRoutingAllowedModels(allModels, allowedGroupsRaw)
 	}
 
-	pricingMap := usage.GetAllModelPricingForTenant(s.tenantID)
+	configByID, pricingByID := pricingLookupMapsForTenant(s.tenantID)
 	filteredModels := make([]map[string]any, len(allModels))
 	for i, model := range allModels {
 		filteredModel := map[string]any{
@@ -183,10 +173,10 @@ func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string, opts ...Av
 			filteredModel["owned_by"] = ownedBy
 		}
 		if modelID, ok := model["id"].(string); ok {
-			if row, exists := modelconfigsettings.GetConfigForTenant(s.tenantID, modelID); exists {
+			if row, exists := configByID[strings.ToLower(strings.TrimSpace(modelID))]; exists {
 				attachModelConfigCapabilities(filteredModel, row)
 			}
-			if pricing, exists := pricingMap[modelID]; exists {
+			if pricing, exists := usage.ResolveModelPricingRow(modelID, configByID, pricingByID); exists {
 				filteredModel["pricing"] = map[string]any{
 					"input_price_per_million":  pricing.InputPricePerMillion,
 					"output_price_per_million": pricing.OutputPricePerMillion,

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -22,6 +22,73 @@ func initModelCatalogTestDB(t *testing.T) {
 	t.Cleanup(usage.CloseDB)
 }
 
+func TestRuntimePrefixedModelInheritsBasePricing(t *testing.T) {
+	initModelCatalogTestDB(t)
+
+	const (
+		baseModelID    = "deepseek-v4-flash"
+		runtimeModelID = "ollama/deepseek-v4-flash"
+		clientID       = "pricing-fallback-ollama"
+	)
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:               baseModelID,
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(clientID)
+	modelRegistry.RegisterClient(clientID, "ollama-cloud", []*registry.ModelInfo{{
+		ID:      runtimeModelID,
+		Object:  "model",
+		OwnedBy: "ollama",
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	service := New(&config.Config{}, nil)
+	assertInheritedPricing := func(stage string) {
+		t.Helper()
+		for name, result := range map[string]map[string]any{
+			"configured availability": service.ConfiguredAvailability("", ""),
+			"models":                  service.Models("", ""),
+		} {
+			data, ok := result["data"].([]map[string]any)
+			if !ok {
+				t.Fatalf("%s %s data = %#v, want []map[string]any", stage, name, result["data"])
+			}
+			var pricing map[string]any
+			for _, item := range data {
+				if item["id"] == runtimeModelID {
+					pricing, _ = item["pricing"].(map[string]any)
+					break
+				}
+			}
+			if pricing == nil {
+				t.Fatalf("%s %s missing inherited pricing for %q", stage, name, runtimeModelID)
+			}
+			if pricing["input_price_per_million"] != 0.3 || pricing["output_price_per_million"] != 1.2 {
+				t.Fatalf("%s %s pricing = %#v, want input=0.3 output=1.2", stage, name, pricing)
+			}
+		}
+	}
+
+	assertInheritedPricing("missing exact row")
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     runtimeModelID,
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(exact zero price) error = %v", err)
+	}
+	assertInheritedPricing("unpriced exact row")
+}
+
 func TestConfiguredAvailabilityIncludesModelSources(t *testing.T) {
 	const modelID = "source-test-model"
 	const codexClientID = "source-test-codex"

--- a/internal/management/modelcatalog/pricing.go
+++ b/internal/management/modelcatalog/pricing.go
@@ -1,0 +1,34 @@
+package modelcatalog
+
+import (
+	"strings"
+
+	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func pricingLookupMapsForTenant(tenantID string) (map[string]usage.ModelConfigRow, map[string]usage.ModelPricingRow) {
+	configRows := modelconfigsettings.ListAllConfigsForTenant(tenantID)
+	configByID := make(map[string]usage.ModelConfigRow, len(configRows))
+	for _, row := range configRows {
+		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
+	}
+	pricingRows := usage.GetAllModelPricingForTenant(tenantID)
+	pricingByID := make(map[string]usage.ModelPricingRow, len(pricingRows))
+	for modelID, row := range pricingRows {
+		pricingByID[strings.ToLower(strings.TrimSpace(modelID))] = row
+	}
+	return configByID, pricingByID
+}
+
+func modelPricingPayload(row usage.ModelConfigRow) map[string]any {
+	return map[string]any{
+		"mode":                          row.PricingMode,
+		"input_price_per_million":       row.InputPricePerMillion,
+		"output_price_per_million":      row.OutputPricePerMillion,
+		"cached_price_per_million":      row.CachedPricePerMillion,
+		"cache_read_price_per_million":  row.CacheReadPricePerMillion,
+		"cache_write_price_per_million": row.CacheWritePricePerMillion,
+		"price_per_call":                row.PricePerCall,
+	}
+}

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -357,36 +357,113 @@ func modelPricingLookupModelIDs(modelID string) []string {
 	if modelID == "" {
 		return nil
 	}
-	prefix, _, found := strings.Cut(modelID, "/")
-	providerlessID := openRouterProviderlessModelID(modelID)
-	if !found || strings.TrimSpace(prefix) == "" || providerlessID == "" || providerlessID == modelID {
-		return []string{modelID}
+	lookupIDs := []string{modelID}
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || candidate == modelID {
+			return
+		}
+		for _, existing := range lookupIDs {
+			if existing == candidate {
+				return
+			}
+		}
+		lookupIDs = append(lookupIDs, candidate)
 	}
-	return []string{modelID, providerlessID}
+
+	if prefix, _, found := strings.Cut(modelID, "/"); found {
+		if strings.TrimSpace(prefix) != "" {
+			add(openRouterProviderlessModelID(modelID))
+		}
+		return lookupIDs
+	}
+	if prefix, suffix, found := strings.Cut(modelID, "-"); found && strings.TrimSpace(prefix) != "" {
+		add(suffix)
+	}
+	return lookupIDs
 }
 
-// resolveModelPricingRowForTenant resolves exact pricing first, then retries once
-// without the first provider segment. Each candidate preserves tenant-over-system
-// inheritance and ModelConfigRow-over-legacy-pricing precedence.
+func hasEffectiveModelPricing(row ModelConfigRow) bool {
+	if normalizePricingMode(row.PricingMode) == "call" {
+		return row.PricePerCall > 0
+	}
+	return row.InputPricePerMillion > 0 ||
+		row.OutputPricePerMillion > 0 ||
+		row.CachedPricePerMillion > 0 ||
+		row.CacheReadPricePerMillion > 0 ||
+		row.CacheWritePricePerMillion > 0
+}
+
+func modelConfigRowFromLegacyPricing(pricing ModelPricingRow) ModelConfigRow {
+	return ModelConfigRow{
+		ModelID:                   pricing.ModelID,
+		Enabled:                   true,
+		PricingMode:               "token",
+		InputPricePerMillion:      pricing.InputPricePerMillion,
+		OutputPricePerMillion:     pricing.OutputPricePerMillion,
+		CachedPricePerMillion:     pricing.CachedPricePerMillion,
+		CacheReadPricePerMillion:  pricing.CacheReadPricePerMillion,
+		CacheWritePricePerMillion: pricing.CacheWritePricePerMillion,
+	}
+}
+
+func resolveModelPricingRow(modelID string, lookup func(string) (ModelConfigRow, bool)) (ModelConfigRow, bool) {
+	var firstFound ModelConfigRow
+	foundAny := false
+	exactEnabled := true
+	exactExists := false
+	for i, lookupID := range modelPricingLookupModelIDs(modelID) {
+		row, ok := lookup(lookupID)
+		if !ok {
+			continue
+		}
+		if !foundAny {
+			firstFound = row
+			foundAny = true
+		}
+		if i == 0 {
+			exactEnabled = row.Enabled
+			exactExists = true
+		}
+		if hasEffectiveModelPricing(row) {
+			if exactExists && i > 0 {
+				row.Enabled = row.Enabled && exactEnabled
+			}
+			return row, true
+		}
+	}
+	return firstFound, foundAny
+}
+
+// ResolveModelPricingRow resolves exact pricing first, then a single inherited
+// base candidate for slash- or dash-prefixed runtime model IDs. Config rows take
+// precedence over legacy pricing for each candidate; unpriced rows do not block
+// a later priced base candidate. Map keys must be normalized to lowercase IDs.
+func ResolveModelPricingRow(modelID string, configByID map[string]ModelConfigRow, pricingByID map[string]ModelPricingRow) (ModelConfigRow, bool) {
+	return resolveModelPricingRow(modelID, func(lookupID string) (ModelConfigRow, bool) {
+		key := strings.ToLower(strings.TrimSpace(lookupID))
+		if row, ok := configByID[key]; ok {
+			return row, true
+		}
+		if pricing, ok := pricingByID[key]; ok {
+			return modelConfigRowFromLegacyPricing(pricing), true
+		}
+		return ModelConfigRow{}, false
+	})
+}
+
+// resolveModelPricingRowForTenant preserves tenant-over-system inheritance and
+// ModelConfigRow-over-legacy-pricing precedence for every lookup candidate.
 func resolveModelPricingRowForTenant(tenantID, modelID string) (ModelConfigRow, bool) {
-	for _, lookupID := range modelPricingLookupModelIDs(modelID) {
+	return resolveModelPricingRow(modelID, func(lookupID string) (ModelConfigRow, bool) {
 		if row, ok := GetModelConfigForTenant(tenantID, lookupID); ok {
 			return row, true
 		}
 		if pricing, ok := GetModelPricingForTenant(tenantID, lookupID); ok {
-			return ModelConfigRow{
-				ModelID:                   pricing.ModelID,
-				Enabled:                   true,
-				PricingMode:               "token",
-				InputPricePerMillion:      pricing.InputPricePerMillion,
-				OutputPricePerMillion:     pricing.OutputPricePerMillion,
-				CachedPricePerMillion:     pricing.CachedPricePerMillion,
-				CacheReadPricePerMillion:  pricing.CacheReadPricePerMillion,
-				CacheWritePricePerMillion: pricing.CacheWritePricePerMillion,
-			}, true
+			return modelConfigRowFromLegacyPricing(pricing), true
 		}
-	}
-	return ModelConfigRow{}, false
+		return ModelConfigRow{}, false
+	})
 }
 
 // resolveModelPricing returns the effective pricing for a model from either

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -275,15 +275,19 @@ func TestCalculateCostFallsBackToProviderlessModelPricing(t *testing.T) {
 		t.Fatalf("UpsertModelConfig() error = %v", err)
 	}
 
-	const modelID = "ollama/deepseek-v4-flash"
-	legacyCost := CalculateCost(modelID, 1_000_000, 1_000_000, 0)
-	if legacyCost != 1.5 {
-		t.Fatalf("CalculateCost(%q) = %v, want 1.5", modelID, legacyCost)
-	}
+	for _, modelID := range []string{
+		"ollama/deepseek-v4-flash",
+		"foo-deepseek-v4-flash",
+	} {
+		legacyCost := CalculateCost(modelID, 1_000_000, 1_000_000, 0)
+		if legacyCost != 1.5 {
+			t.Fatalf("CalculateCost(%q) = %v, want 1.5", modelID, legacyCost)
+		}
 
-	v2Cost := CalculateCostV2(modelID, TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
-	if v2Cost != 1.5 {
-		t.Fatalf("CalculateCostV2(%q) = %v, want 1.5", modelID, v2Cost)
+		v2Cost := CalculateCostV2(modelID, TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+		if v2Cost != 1.5 {
+			t.Fatalf("CalculateCostV2(%q) = %v, want 1.5", modelID, v2Cost)
+		}
 	}
 
 	if err := UpsertModelConfigForTenant(businessTenantID, ModelConfigRow{
@@ -299,6 +303,72 @@ func TestCalculateCostFallsBackToProviderlessModelPricing(t *testing.T) {
 	tenantCost := CalculateCostV2ForTenant(businessTenantID, "ollama/deepseek-v4-flash", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
 	if tenantCost != 15 {
 		t.Fatalf("tenant providerless override cost = %v, want 15", tenantCost)
+	}
+}
+
+func TestCalculateCostFallsBackPastExactUnpricedConfig(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "ollama/deepseek-v4-flash",
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(exact) error = %v", err)
+	}
+
+	for name, cost := range map[string]float64{
+		"legacy": CalculateCost("ollama/deepseek-v4-flash", 1_000_000, 1_000_000, 0),
+		"v2":     CalculateCostV2("ollama/deepseek-v4-flash", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000}),
+	} {
+		if cost != 1.5 {
+			t.Fatalf("%s exact-unpriced fallback cost = %v, want 1.5", name, cost)
+		}
+	}
+}
+
+func TestCalculateCostInheritedPricingRespectsExactDisabled(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "ollama/deepseek-v4-flash",
+		Enabled:     false,
+		PricingMode: "token",
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(exact) error = %v", err)
+	}
+
+	row, ok := resolveModelPricingRowForTenant(systemTenantID, "ollama/deepseek-v4-flash")
+	if !ok || !hasEffectiveModelPricing(row) {
+		t.Fatalf("resolved pricing = %+v ok=%v, want inherited base pricing", row, ok)
+	}
+	if row.Enabled {
+		t.Fatalf("resolved pricing = %+v, want exact disabled state preserved", row)
+	}
+	if cost := CalculateCost("ollama/deepseek-v4-flash", 1_000_000, 1_000_000, 0); cost != 0 {
+		t.Fatalf("disabled exact model cost = %v, want 0", cost)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Unify pricing resolve for runtime model IDs: exact → strip first `/` provider → strip first `-` prefix once
- Prefer effective pricing: zero-price exact shell no longer blocks base inheritance; custom positive price still wins
- Management catalog (`ConfiguredAvailability` / `Models`) and public `/v1/models` now use the same resolver so UI no longer shows 未定价 for `ollama/deepseek-v4-flash`, `foo-deepseek-v4-flash`, etc.

## Why #797 was not enough
#797 fixed cost calculation for `ollama/` wrappers and sync-backfill for existing DB rows, but:
1. List APIs still exact-matched full runtime IDs against `model_configs` / pricing maps
2. Auth `applyModelPrefixes` creates `prefix/base` runtime IDs without catalog rows
3. Zero-price exact rows still short-circuited fallback
4. Hyphen variants like `xxx-deepseek-v4-flash` were unsupported

## Test plan
- [x] `go test ./internal/usage/ -count=1 -run 'Pricing|OpenRouter|CalculateCost|Providerless|Wrapper|Ollama'`
- [x] `go test ./internal/management/modelcatalog/ -count=1`
- [x] `go test ./internal/api/ -count=1`
- [x] `go vet ./internal/usage/... ./internal/management/modelcatalog/...`
- [x] `./scripts/ci-pr.sh`