### PR TITLE
fix(model-catalog): resolve inherited library pricing

### DIFF
--- a/internal/management/modelcatalog/configs.go
+++ b/internal/management/modelcatalog/configs.go
@@ -18,9 +18,14 @@ var ErrAuthGroupRequired = errors.New("auth group is required")
 // - Responsibility: CRUD and response shaping for stored model catalog settings.
 func (s *Service) ListModelConfigs(scope string) map[string]any {
 	rows := modelconfigsettings.ListConfigsForTenant(s.tenantID, scope)
+	configByID, pricingByID := pricingLookupMapsForTenant(s.tenantID)
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
-		items = append(items, modelConfigResponse(row))
+		pricing := row
+		if resolved, ok := usage.ResolveModelPricingRow(row.ModelID, configByID, pricingByID); ok {
+			pricing = resolved
+		}
+		items = append(items, modelConfigResponse(row, pricing))
 	}
 	return map[string]any{"object": "list", "data": items}
 }
@@ -55,7 +60,12 @@ func (s *Service) UpsertModelConfig(payload ModelConfigPayload, originalID, scop
 		}
 		return nil, err
 	}
-	return modelConfigResponse(saved), nil
+	pricing := saved
+	configByID, pricingByID := pricingLookupMapsForTenant(s.tenantID)
+	if resolved, ok := usage.ResolveModelPricingRow(saved.ModelID, configByID, pricingByID); ok {
+		pricing = resolved
+	}
+	return modelConfigResponse(saved, pricing), nil
 }
 
 func (s *Service) DeleteModelConfig(modelID string) error {

--- a/internal/management/modelcatalog/configs_test.go
+++ b/internal/management/modelcatalog/configs_test.go
@@ -1,0 +1,68 @@
+package modelcatalog
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func TestListModelConfigsUsesEffectivePricing(t *testing.T) {
+	initModelCatalogTestDB(t)
+
+	const (
+		baseModelID    = "deepseek-v4-flash"
+		runtimeModelID = "ollama/deepseek-v4-flash"
+		variantModelID = "deepseek-v4-flash:free"
+	)
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:               baseModelID,
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.098,
+		OutputPricePerMillion: 0.196,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     runtimeModelID,
+		Description: "exact runtime row",
+		Enabled:     false,
+		PricingMode: "token",
+		Source:      "seed",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(runtime) error = %v", err)
+	}
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     variantModelID,
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(variant) error = %v", err)
+	}
+
+	result := New(nil, nil).ListModelConfigs("library")
+	data, ok := result["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v, want []map[string]any", result["data"])
+	}
+	found := make(map[string]bool, 2)
+	for _, item := range data {
+		modelID, _ := item["id"].(string)
+		if modelID != runtimeModelID && modelID != variantModelID {
+			continue
+		}
+		if modelID == runtimeModelID && (item["description"] != "exact runtime row" || item["enabled"] != false || item["source"] != "seed") {
+			t.Fatalf("exact identity fields changed: %#v", item)
+		}
+		pricing, _ := item["pricing"].(map[string]any)
+		if pricing["input_price_per_million"] != 0.098 || pricing["output_price_per_million"] != 0.196 {
+			t.Fatalf("pricing for %q = %#v, want inherited base pricing", modelID, pricing)
+		}
+		found[modelID] = true
+	}
+	if !found[runtimeModelID] || !found[variantModelID] {
+		t.Fatalf("library response missing effective pricing rows: found=%v", found)
+	}
+}

--- a/internal/management/modelcatalog/types.go
+++ b/internal/management/modelcatalog/types.go
@@ -82,23 +82,15 @@ type configuredModelPathRoute struct {
 	Group string
 }
 
-func modelConfigResponse(row usage.ModelConfigRow) map[string]any {
+func modelConfigResponse(row, pricing usage.ModelConfigRow) map[string]any {
 	response := map[string]any{
 		"id":          row.ModelID,
 		"owned_by":    row.OwnedBy,
 		"description": row.Description,
 		"enabled":     row.Enabled,
-		"pricing": map[string]any{
-			"mode":                          row.PricingMode,
-			"input_price_per_million":       row.InputPricePerMillion,
-			"output_price_per_million":      row.OutputPricePerMillion,
-			"cached_price_per_million":      row.CachedPricePerMillion,
-			"cache_read_price_per_million":  row.CacheReadPricePerMillion,
-			"cache_write_price_per_million": row.CacheWritePricePerMillion,
-			"price_per_call":                row.PricePerCall,
-		},
-		"source":     row.Source,
-		"updated_at": row.UpdatedAt,
+		"pricing":     modelPricingPayload(pricing),
+		"source":      row.Source,
+		"updated_at":  row.UpdatedAt,
 	}
 	if row.DisplayName != "" {
 		response["display_name"] = row.DisplayName

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -375,10 +375,15 @@ func modelPricingLookupModelIDs(modelID string) []string {
 		if strings.TrimSpace(prefix) != "" {
 			add(openRouterProviderlessModelID(modelID))
 		}
-		return lookupIDs
 	}
-	if prefix, suffix, found := strings.Cut(modelID, "-"); found && strings.TrimSpace(prefix) != "" {
-		add(suffix)
+	if variantSeparator := strings.LastIndex(modelID, ":"); variantSeparator > 0 {
+		add(modelID[:variantSeparator])
+	}
+	if !strings.Contains(modelID, "/") {
+		prefix, suffix, found := strings.Cut(modelID, "-")
+		if found && strings.TrimSpace(prefix) != "" {
+			add(suffix)
+		}
 	}
 	return lookupIDs
 }
@@ -435,10 +440,11 @@ func resolveModelPricingRow(modelID string, lookup func(string) (ModelConfigRow,
 	return firstFound, foundAny
 }
 
-// ResolveModelPricingRow resolves exact pricing first, then a single inherited
-// base candidate for slash- or dash-prefixed runtime model IDs. Config rows take
-// precedence over legacy pricing for each candidate; unpriced rows do not block
-// a later priced base candidate. Map keys must be normalized to lowercase IDs.
+// ResolveModelPricingRow resolves exact pricing first, then inherited base
+// candidates for provider-prefixed, tagged, or dash-prefixed runtime model IDs.
+// Config rows take precedence over legacy pricing for each candidate; unpriced
+// rows do not block a later priced base candidate. Map keys must be normalized
+// to lowercase IDs.
 func ResolveModelPricingRow(modelID string, configByID map[string]ModelConfigRow, pricingByID map[string]ModelPricingRow) (ModelConfigRow, bool) {
 	return resolveModelPricingRow(modelID, func(lookupID string) (ModelConfigRow, bool) {
 		key := strings.ToLower(strings.TrimSpace(lookupID))

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -338,6 +338,72 @@ func TestCalculateCostFallsBackPastExactUnpricedConfig(t *testing.T) {
 	}
 }
 
+func TestCalculateCostFallsBackPastUnpricedVariant(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.098,
+		OutputPricePerMillion: 0.196,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "deepseek-v4-flash:free",
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(variant) error = %v", err)
+	}
+
+	row, ok := resolveModelPricingRowForTenant(systemTenantID, "deepseek-v4-flash:free")
+	if !ok || row.InputPricePerMillion != 0.098 || row.OutputPricePerMillion != 0.196 {
+		t.Fatalf("resolved variant pricing = %+v ok=%v, want base pricing", row, ok)
+	}
+	wantCost := 0.098 + 0.196
+	for name, cost := range map[string]float64{
+		"legacy": CalculateCost("deepseek-v4-flash:free", 1_000_000, 1_000_000, 0),
+		"v2":     CalculateCostV2("deepseek-v4-flash:free", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000}),
+	} {
+		if math.Abs(cost-wantCost) > 1e-12 {
+			t.Fatalf("%s variant fallback cost = %v, want %v", name, cost, wantCost)
+		}
+	}
+}
+
+func TestCalculateCostVariantPreservesExactCustomPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.098,
+		OutputPricePerMillion: 0.196,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash:free",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  3,
+		OutputPricePerMillion: 12,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(variant) error = %v", err)
+	}
+
+	if cost := CalculateCostV2("deepseek-v4-flash:free", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000}); cost != 15 {
+		t.Fatalf("exact variant custom pricing cost = %v, want 15", cost)
+	}
+}
+
 func TestCalculateCostInheritedPricingRespectsExactDisabled(t *testing.T) {
 	initModelConfigTestDB(t)
 


### PR DESCRIPTION
## Summary
- `/model-configs` library/active responses now resolve pricing via `ResolveModelPricingRow` instead of raw stored prices
- Pricing lookup also strips `:variant` (`deepseek-v4-flash:free` → base)
- Zero-price exact shells inherit base; custom positive prices still win

## Why #798 still looked broken
User path was `GET /model-configs?scope=library` (全部模型库). That API still returned DB-stored prices. Runtime/path rows like `ollama/deepseek-v4-flash` and zero-price `:free` variants therefore stayed 未定价 even after availability/cost fallback landed.

Companion frontend PR inherits pricing for path-only rows in the models page merge.

## Test plan
- [x] usage / modelcatalog / modelconfig package tests
- [x] `./scripts/ci-pr.sh`