### PR TITLE
fix(usage): align request log stats filters

### DIFF
--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -319,22 +319,95 @@ func (params LogQueryParams) withoutFacet(facet string) LogQueryParams {
 	return params
 }
 
-// QueryStats returns aggregated statistics from usage rollup projection.
-// Does not scan request_logs so detail retention cleanup cannot zero stats.
+// QueryStats returns aggregated statistics for the same filters as QueryLogs.
+// It prefers usage rollups, falling back to request_logs only when the rollup
+// dimensions cannot express the requested filter without changing its meaning.
 func QueryStats(params LogQueryParams) (LogStats, error) {
 	if getReadDB() == nil {
 		return LogStats{CacheRate: 0}, nil
 	}
-	// Explicit empty multi-selects match no rows; rollup does not model "empty model".
+	params = normalizeLogQueryParams(params)
+	// Explicit empty multi-selects match no rows.
 	if params.MatchNoAPIKeys || params.MatchNoAPIKeyIDs || params.MatchNoModels || params.MatchNoStatuses || params.MatchNoChannels {
 		return LogStats{CacheRate: 0}, nil
 	}
-	stats, err := queryStatsFromRollup(params)
+
+	filter, ok := rollupIdentityFilter(params)
+	if !ok {
+		// Preserve fail-closed identity behavior before considering a detail fallback.
+		return LogStats{CacheRate: 0}, nil
+	}
+
+	var (
+		stats LogStats
+		err   error
+	)
+	if queryStatsRequiresDetailAggregation(params) {
+		stats, err = queryStatsFromDetails(params)
+	} else {
+		stats, err = queryStatsFromRollupFilter(params, filter)
+	}
 	if err != nil {
 		log.Warnf("usage: stats query failed: %v", err)
 		return LogStats{}, err
 	}
 	return stats, nil
+}
+
+func queryStatsRequiresDetailAggregation(params LogQueryParams) bool {
+	// auth_index is not a rollup dimension, and precise legacy channel pairs
+	// cannot be represented by the rollup dimensions.
+	if len(params.AuthIndexes) > 0 || len(params.AuthIndexChannelNames) > 0 {
+		return true
+	}
+
+	// QueryLogs combines channel selector kinds with OR, while rollup dimensions
+	// are conjunctive. A mixed selector therefore needs the shared detail WHERE.
+	channelSelectorKinds := 0
+	if len(dedupeExactStrings(params.AuthSubjectIDs)) > 0 {
+		channelSelectorKinds++
+	}
+	if len(dedupeLowerTrimmedStrings(params.ChannelNames)) > 0 {
+		channelSelectorKinds++
+	}
+	if channelSelectorKinds > 1 {
+		return true
+	}
+
+	// Rollup buckets keep status counts, but token/cost/cache totals are not split
+	// by status. Use details for an exact single-status aggregate.
+	hasSuccess, hasFailed := requestedStatusFilter(params.Statuses)
+	return hasSuccess != hasFailed
+}
+
+func queryStatsFromDetails(params LogQueryParams) (LogStats, error) {
+	db := getReadDB()
+	if db == nil {
+		return LogStats{CacheRate: 0}, nil
+	}
+	where, args := buildWhereClause(params)
+
+	var agg rollupAgg
+	query := `
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(CASE WHEN failed = 0 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(total_tokens), 0),
+			COALESCE(SUM(cost), 0),
+			COALESCE(SUM(cached_tokens), 0),
+			COALESCE(SUM(` + cacheRateEffectiveInputSQL + `), 0)
+		FROM request_logs` + where
+	if err := db.QueryRow(query, args...).Scan(
+		&agg.RequestCount,
+		&agg.SuccessCount,
+		&agg.TotalTokens,
+		&agg.CostTotal,
+		&agg.CachedTokens,
+		&agg.EffectiveInputTokens,
+	); err != nil {
+		return LogStats{}, fmt.Errorf("usage: detail stats aggregate: %w", err)
+	}
+	return agg.toLogStats(), nil
 }
 
 // DeleteLogsByAPIKey removes all request_logs and request_log_content entries
@@ -606,6 +679,18 @@ func normalizeStringList(values []string) []string {
 	return result
 }
 
+func requestedStatusFilter(statuses []string) (hasSuccess, hasFailed bool) {
+	for _, status := range statuses {
+		switch strings.ToLower(strings.TrimSpace(status)) {
+		case "success":
+			hasSuccess = true
+		case "failed":
+			hasFailed = true
+		}
+	}
+	return hasSuccess, hasFailed
+}
+
 func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 	params = normalizeLogQueryParams(params)
 	if params.MatchNoAPIKeys || params.MatchNoAPIKeyIDs || params.MatchNoModels || params.MatchNoStatuses || params.MatchNoChannels {
@@ -708,16 +793,7 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 
 	// Status multi-value filter
 	if len(params.Statuses) > 0 {
-		hasSuccess := false
-		hasFailed := false
-		for _, s := range params.Statuses {
-			switch strings.ToLower(s) {
-			case "success":
-				hasSuccess = true
-			case "failed":
-				hasFailed = true
-			}
-		}
+		hasSuccess, hasFailed := requestedStatusFilter(params.Statuses)
 		if hasSuccess && !hasFailed {
 			conditions = append(conditions, "failed = 0")
 		} else if hasFailed && !hasSuccess {

--- a/internal/usage/request_log_stats_filter_test.go
+++ b/internal/usage/request_log_stats_filter_test.go
@@ -1,0 +1,223 @@
+package usage
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestQueryStatsMatchesQueryLogsForMultiChannelSelectors(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	if err := UpsertModelPricing("model-target", 1, 2, 0.5); err != nil {
+		t.Fatalf("UpsertModelPricing(model-target): %v", err)
+	}
+	if err := UpsertModelPricing("model-other", 1, 2, 0.5); err != nil {
+		t.Fatalf("UpsertModelPricing(model-other): %v", err)
+	}
+
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model-target", "source", "Alpha", "auth-a", false, now, 10, 1, TokenStats{
+		InputTokens: 80, OutputTokens: 20, CachedTokens: 20, TotalTokens: 100,
+	}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model-other", "source", "Alpha", "auth-a", false, now.Add(time.Second), 10, 1, TokenStats{
+		InputTokens: 40, TotalTokens: 40,
+	}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-b", "subject-b", "", "model-target", "source", "Beta", "auth-b", true, now.Add(2*time.Second), 10, 1, TokenStats{
+		InputTokens: 10, OutputTokens: 250, CachedTokens: 40, TotalTokens: 300,
+	}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-c", "subject-c", "", "model-target", "source", "Gamma", "auth-c", false, now.Add(3*time.Second), 10, 1, TokenStats{
+		InputTokens: 10, TotalTokens: 10,
+	}, "", "", "")
+
+	tests := []struct {
+		name       string
+		params     LogQueryParams
+		wantDetail bool
+	}{
+		{
+			name:   "two auth subjects",
+			params: LogQueryParams{AuthSubjectIDs: []string{"subject-a", "subject-b"}},
+		},
+		{
+			name:   "two channel names",
+			params: LogQueryParams{ChannelNames: []string{" alpha ", "BETA"}},
+		},
+		{
+			name: "management subjects with legacy auth indexes",
+			params: LogQueryParams{
+				AuthSubjectIDs: []string{"subject-a", "subject-b"},
+				AuthIndexes:    []string{"auth-a", "auth-b"},
+			},
+			wantDetail: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := tt.params
+			params.Page = 1
+			params.Size = 10
+			params.Days = 1
+			gotDetail := queryStatsRequiresDetailAggregation(normalizeLogQueryParams(params))
+			if gotDetail != tt.wantDetail {
+				t.Fatalf("queryStatsRequiresDetailAggregation()=%v, want %v for %+v", gotDetail, tt.wantDetail, params)
+			}
+
+			logs, err := QueryLogs(params)
+			if err != nil {
+				t.Fatalf("QueryLogs(): %v", err)
+			}
+			stats, err := QueryStats(params)
+			if err != nil {
+				t.Fatalf("QueryStats(): %v", err)
+			}
+			if logs.Total != 3 || stats.Total != logs.Total {
+				t.Fatalf("logs.Total=%d stats.Total=%d, want both 3", logs.Total, stats.Total)
+			}
+			if stats.TotalTokens != 440 {
+				t.Fatalf("stats.TotalTokens=%d, want 440", stats.TotalTokens)
+			}
+			if math.Abs(stats.SuccessRate-(2.0/3.0*100)) > 1e-9 {
+				t.Fatalf("stats.SuccessRate=%v, want %v", stats.SuccessRate, 2.0/3.0*100)
+			}
+			if stats.TotalCost <= 0 {
+				t.Fatalf("stats.TotalCost=%v, want > 0", stats.TotalCost)
+			}
+			if stats.CacheRate <= 0 {
+				t.Fatalf("stats.CacheRate=%v, want > 0", stats.CacheRate)
+			}
+		})
+	}
+}
+
+func TestQueryStatsMatchesQueryLogsForChannelAndModel(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model-target", "source", "Alpha", "auth-a", false, now, 10, 1, TokenStats{TotalTokens: 11}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model-other", "source", "Alpha", "auth-a", false, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 22}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-b", "subject-b", "", "model-target", "source", "Beta", "auth-b", false, now.Add(2*time.Second), 10, 1, TokenStats{TotalTokens: 33}, "", "", "")
+
+	params := LogQueryParams{
+		Page:         1,
+		Size:         10,
+		Days:         1,
+		Models:       []string{"model-target"},
+		ChannelNames: []string{"alpha"},
+	}
+	logs, err := QueryLogs(params)
+	if err != nil {
+		t.Fatalf("QueryLogs(): %v", err)
+	}
+	stats, err := QueryStats(params)
+	if err != nil {
+		t.Fatalf("QueryStats(): %v", err)
+	}
+	if logs.Total != 1 || stats.Total != logs.Total || stats.TotalTokens != 11 {
+		t.Fatalf("logs.Total=%d stats=%+v, want one 11-token row", logs.Total, stats)
+	}
+}
+
+func TestQueryStatsMatchesQueryLogsForStatuses(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentitySubject("", "key-success", "subject-success", "", "model", "source", "Success", "auth-success", false, now, 10, 1, TokenStats{
+		InputTokens: 80, OutputTokens: 20, CachedTokens: 20, TotalTokens: 100,
+	}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-failed", "subject-failed", "", "model", "source", "Failed", "auth-failed", true, now.Add(time.Second), 10, 1, TokenStats{
+		InputTokens: 10, OutputTokens: 250, CachedTokens: 40, TotalTokens: 300,
+	}, "", "", "")
+	if _, err := getDB().Exec(`UPDATE request_logs SET cost = CASE WHEN failed = 0 THEN 1.25 ELSE 2.5 END`); err != nil {
+		t.Fatalf("set detail costs: %v", err)
+	}
+
+	tests := []struct {
+		status      string
+		tokens      int64
+		cost        float64
+		successRate float64
+		cacheRate   float64
+	}{
+		{status: "success", tokens: 100, cost: 1.25, successRate: 100, cacheRate: 25},
+		{status: "failed", tokens: 300, cost: 2.5, successRate: 0, cacheRate: 80},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			params := LogQueryParams{Page: 1, Size: 10, Days: 1, Statuses: []string{tt.status}}
+			logs, err := QueryLogs(params)
+			if err != nil {
+				t.Fatalf("QueryLogs(): %v", err)
+			}
+			stats, err := QueryStats(params)
+			if err != nil {
+				t.Fatalf("QueryStats(): %v", err)
+			}
+			if logs.Total != 1 || stats.Total != logs.Total {
+				t.Fatalf("logs.Total=%d stats.Total=%d, want both 1", logs.Total, stats.Total)
+			}
+			if stats.TotalTokens != tt.tokens || math.Abs(stats.TotalCost-tt.cost) > 1e-12 ||
+				math.Abs(stats.SuccessRate-tt.successRate) > 1e-12 || math.Abs(stats.CacheRate-tt.cacheRate) > 1e-12 {
+				t.Fatalf("stats=%+v, want tokens=%d cost=%v success=%v cache=%v", stats, tt.tokens, tt.cost, tt.successRate, tt.cacheRate)
+			}
+		})
+	}
+}
+
+func TestQueryStatsWithoutFiltersRemainsRollupBacked(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model", "source", "Alpha", "auth-a", false, time.Now().UTC(), 10, 1, TokenStats{TotalTokens: 17}, "", "", "")
+
+	params := LogQueryParams{Page: 1, Size: 10, Days: 1}
+	logs, err := QueryLogs(params)
+	if err != nil {
+		t.Fatalf("QueryLogs(): %v", err)
+	}
+	stats, err := QueryStats(params)
+	if err != nil {
+		t.Fatalf("QueryStats(): %v", err)
+	}
+	if logs.Total != 1 || stats.Total != logs.Total || stats.TotalTokens != 17 {
+		t.Fatalf("before detail delete logs.Total=%d stats=%+v", logs.Total, stats)
+	}
+	if _, err := getDB().Exec(`DELETE FROM request_logs`); err != nil {
+		t.Fatalf("delete request_logs: %v", err)
+	}
+	stats, err = QueryStats(params)
+	if err != nil {
+		t.Fatalf("QueryStats() after detail delete: %v", err)
+	}
+	if stats.Total != 1 || stats.TotalTokens != 17 {
+		t.Fatalf("stats after detail delete=%+v, want rollup total=1 tokens=17", stats)
+	}
+}
+
+func TestQueryStatsUnknownAPIKeyRemainsFailClosed(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	if err := UpsertAPIKey(APIKeyRow{ID: "known-key-id", Key: "sk-known", Name: "Known"}); err != nil {
+		t.Fatalf("UpsertAPIKey(): %v", err)
+	}
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentity("sk-known", "known-key-id", "Known", "model", "source", "Alpha", "auth-a", false, now, 10, 1, TokenStats{TotalTokens: 19}, "", "", "")
+	// This row deliberately has no api_keys registry entry. Even though the raw
+	// secret and auth_index match details, stats must keep the identity fail-closed.
+	InsertLogWithDetailsIdentity("sk-orphan", "orphan-key-id", "Orphan", "model", "source", "Beta", "auth-orphan", false, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 23}, "", "", "")
+
+	unfiltered, err := QueryStats(LogQueryParams{Days: 1})
+	if err != nil {
+		t.Fatalf("QueryStats(unfiltered): %v", err)
+	}
+	if unfiltered.Total != 2 {
+		t.Fatalf("unfiltered stats=%+v, want two tenant rows", unfiltered)
+	}
+	stats, err := QueryStats(LogQueryParams{
+		Days:        1,
+		APIKeys:     []string{"sk-orphan"},
+		AuthIndexes: []string{"auth-orphan"},
+	})
+	if err != nil {
+		t.Fatalf("QueryStats(unknown key): %v", err)
+	}
+	if stats != (LogStats{}) {
+		t.Fatalf("unknown-key stats=%+v, want all zero without tenant-wide fallback", stats)
+	}
+}

--- a/internal/usage/usage_rollup_query.go
+++ b/internal/usage/usage_rollup_query.go
@@ -55,16 +55,17 @@ func (a rollupAgg) toDashboardKPI() DashboardKPI {
 }
 
 type rollupFilter struct {
-	TenantID      string
-	BucketKind    string
-	BucketFrom    string // inclusive day/hour/minute key; empty = no lower bound
-	BucketTo      string // exclusive optional
-	APIKeyIDs     []string
-	EndUserID     string
-	AuthSubjectID string
-	Models        []string
-	Sources       []string
-	ChannelNames  []string
+	TenantID       string
+	BucketKind     string
+	BucketFrom     string // inclusive day/hour/minute key; empty = no lower bound
+	BucketTo       string // exclusive optional
+	APIKeyIDs      []string
+	EndUserID      string
+	AuthSubjectID  string
+	AuthSubjectIDs []string
+	Models         []string
+	Sources        []string
+	ChannelNames   []string
 }
 
 func queryRollupAgg(filter rollupFilter) (rollupAgg, error) {
@@ -115,9 +116,18 @@ func queryRollupAgg(filter rollupFilter) (rollupAgg, error) {
 		b.WriteString(` AND end_user_id = ?`)
 		args = append(args, eu)
 	}
+	subjects := append([]string{}, filter.AuthSubjectIDs...)
 	if sub := strings.TrimSpace(filter.AuthSubjectID); sub != "" {
+		subjects = append(subjects, sub)
+	}
+	if subjects = dedupeExactStrings(subjects); len(subjects) == 1 {
 		b.WriteString(` AND auth_subject_id = ?`)
-		args = append(args, sub)
+		args = append(args, subjects[0])
+	} else if len(subjects) > 1 {
+		b.WriteString(` AND auth_subject_id IN (` + placeholders(len(subjects)) + `)`)
+		for _, subject := range subjects {
+			args = append(args, subject)
+		}
 	}
 	if models := dedupeExactStrings(filter.Models); len(models) > 0 {
 		b.WriteString(` AND model IN (` + placeholders(len(models)) + `)`)
@@ -131,10 +141,10 @@ func queryRollupAgg(filter rollupFilter) (rollupAgg, error) {
 			args = append(args, s)
 		}
 	}
-	if channels := dedupeExactStrings(filter.ChannelNames); len(channels) > 0 {
-		b.WriteString(` AND channel_name IN (` + placeholders(len(channels)) + `)`)
-		for _, c := range channels {
-			args = append(args, c)
+	if channels := dedupeLowerTrimmedStrings(filter.ChannelNames); len(channels) > 0 {
+		b.WriteString(` AND lower(trim(channel_name)) IN (` + placeholders(len(channels)) + `)`)
+		for _, channel := range channels {
+			args = append(args, channel)
 		}
 	}
 
@@ -211,10 +221,8 @@ func rollupIdentityFilter(params LogQueryParams) (rollupFilter, bool) {
 	if tenantID == "" {
 		tenantID = systemTenantID
 	}
-	authSubjectID := ""
-	if len(params.AuthSubjectIDs) == 1 {
-		authSubjectID = strings.TrimSpace(params.AuthSubjectIDs[0])
-	}
+	authSubjectIDs := dedupeExactStrings(params.AuthSubjectIDs)
+	channelNames := dedupeLowerTrimmedStrings(params.ChannelNames)
 	keyIDs := resolveAPIKeyIDsForStats(params)
 	keysRequested := len(requestedAPIKeys(params)) > 0 || len(params.APIKeyIDs) > 0
 	endUserID := strings.TrimSpace(params.EndUserID)
@@ -222,27 +230,40 @@ func rollupIdentityFilter(params LogQueryParams) (rollupFilter, bool) {
 	if keysRequested && len(keyIDs) == 0 && endUserID == "" {
 		return rollupFilter{}, false
 	}
-	// Multi auth subjects are not modeled as OR on rollup yet; fail closed.
-	if len(params.AuthSubjectIDs) > 1 {
+	// A requested rollup-supported channel selector with no usable values must
+	// not widen to tenant-wide aggregates. Unsupported selectors use details.
+	if (len(params.AuthSubjectIDs) > 0 || len(params.ChannelNames) > 0) &&
+		len(authSubjectIDs) == 0 && len(channelNames) == 0 &&
+		len(params.AuthIndexes) == 0 && len(params.AuthIndexChannelNames) == 0 {
 		return rollupFilter{}, false
 	}
-	return rollupFilter{
-		TenantID:      tenantID,
-		BucketKind:    rollupBucketDay,
-		APIKeyIDs:     keyIDs,
-		EndUserID:     endUserID,
-		AuthSubjectID: authSubjectID,
-		Models:        params.Models,
-	}, true
+	filter := rollupFilter{
+		TenantID:       tenantID,
+		BucketKind:     rollupBucketDay,
+		APIKeyIDs:      keyIDs,
+		EndUserID:      endUserID,
+		AuthSubjectIDs: authSubjectIDs,
+		Models:         params.Models,
+		ChannelNames:   channelNames,
+	}
+	if len(authSubjectIDs) == 1 {
+		filter.AuthSubjectID = authSubjectIDs[0]
+		filter.AuthSubjectIDs = nil
+	}
+	return filter, true
 }
 
 func queryStatsFromRollup(params LogQueryParams) (LogStats, error) {
-	if params.Days < 1 {
-		params.Days = 7
-	}
 	filter, ok := rollupIdentityFilter(params)
 	if !ok {
 		return LogStats{CacheRate: 0}, nil
+	}
+	return queryStatsFromRollupFilter(params, filter)
+}
+
+func queryStatsFromRollupFilter(params LogQueryParams, filter rollupFilter) (LogStats, error) {
+	if params.Days < 1 {
+		params.Days = 7
 	}
 	filter.BucketFrom = dayBucketFromDays(params.Days)
 	agg, err := queryRollupAgg(filter)


### PR DESCRIPTION
## Summary
- Fix request-logs header stats showing all zeros while the table/pagination still show thousands of rows when multi-channel (multi AuthSubject) filters are applied.
- Root cause: `QueryStats` used rollup via `rollupIdentityFilter`, which fail-closed on `len(AuthSubjectIDs) > 1` and dropped channel/status filters; `QueryLogs` used detail rows, so totals diverged.
- Extend rollup for multi subject + channel; fallback to detail aggregation when rollup cannot express the filter (auth indexes / mixed OR / single status). Keep unknown API-key fail-closed.

## Test plan
- [x] `go test ./internal/usage/ -count=1 -run 'QueryStats|Rollup|UsageLogs|Channel'`
- [x] `go test ./internal/api/handlers/management/ -count=1 -run 'UsageLogs'`
- [x] `go test ./internal/usage ./internal/api/handlers/management -count=1`
- [ ] After merge/deploy: open 请求日志, select 2 channels, confirm header stats match table total (not 0).