### PR TITLE
fix(moderation): inspect OpenAI image prompts for gpt-image-2

### DIFF
--- a/internal/api/handlers/management/image_generation.go
+++ b/internal/api/handlers/management/image_generation.go
@@ -266,8 +266,9 @@ func (h *Handler) executeImageGenerationTestForTenant(ctx context.Context, tenan
 			Payload: execPayload,
 			Format:  sdktranslator.FromString("openai"),
 		}, coreexecutor.Options{
-			Alt:          alt,
-			SourceFormat: sdktranslator.FromString("openai"),
+			Alt:             alt,
+			OriginalRequest: payload,
+			SourceFormat:    sdktranslator.FromString("openai"),
 			Metadata: map[string]any{
 				coreexecutor.SinglePickMetadataKey: true,
 				coreexecutor.TenantMetadataKey:     coreauth.NormalizedTenantID(tenantID),

--- a/internal/api/handlers/management/image_generation_test.go
+++ b/internal/api/handlers/management/image_generation_test.go
@@ -21,13 +21,14 @@ import (
 )
 
 type managementImageExecutor struct {
-	alt      string
-	model    string
-	payload  string
-	payloads []string
-	metadata map[string]any
-	calls    int
-	err      error
+	alt             string
+	model           string
+	payload         string
+	payloads        []string
+	originalRequest string
+	metadata        map[string]any
+	calls           int
+	err             error
 }
 
 type managementUpstreamStatusError struct {
@@ -50,6 +51,7 @@ func (e *managementImageExecutor) Execute(ctx context.Context, auth *coreauth.Au
 	e.model = req.Model
 	e.payload = string(req.Payload)
 	e.payloads = append(e.payloads, e.payload)
+	e.originalRequest = string(opts.OriginalRequest)
 	e.metadata = opts.Metadata
 	if e.err != nil {
 		return coreexecutor.Response{}, e.err
@@ -224,6 +226,9 @@ func TestPostImageGenerationTestExecutesCodexImageAlt(t *testing.T) {
 	}
 	if executor.metadata[coreexecutor.SinglePickMetadataKey] != true {
 		t.Fatalf("single-pick metadata = %#v, want true", executor.metadata[coreexecutor.SinglePickMetadataKey])
+	}
+	if executor.originalRequest != `{"model":"gpt-image-2","prompt":"test prompt"}` {
+		t.Fatalf("original request = %q, want image request payload", executor.originalRequest)
 	}
 }
 

--- a/internal/contentmoderation/extractor.go
+++ b/internal/contentmoderation/extractor.go
@@ -21,6 +21,12 @@ func ExtractLastUserText(format sdktranslator.Format, payload []byte) string {
 		collectLastGeminiContent(gjson.GetBytes(payload, "contents"), &parts)
 	default:
 		collectLastRoleContent(gjson.GetBytes(payload, "messages"), "user", &parts, false)
+		if len(parts) == 0 {
+			prompt := gjson.GetBytes(payload, "prompt")
+			if prompt.Type == gjson.String {
+				addText(&parts, prompt.String(), false)
+			}
+		}
 	}
 	return strings.Join(strings.Fields(strings.Join(parts, "\n")), " ")
 }

--- a/internal/contentmoderation/extractor_test.go
+++ b/internal/contentmoderation/extractor_test.go
@@ -14,12 +14,15 @@ func TestExtractLastUserText(t *testing.T) {
 		want   string
 	}{
 		{"openai chat", sdktranslator.FormatOpenAI, `{"messages":[{"role":"assistant","content":"old"},{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":"world"}]}]}`, "hello world"},
+		{"openai image prompt", sdktranslator.FormatOpenAI, `{"model":"gpt-image-2","prompt":"bad word"}`, "bad word"},
 		{"responses", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"assistant","content":[{"type":"output_text","text":"old"}]},{"role":"user","content":[{"type":"input_text","text":"response text"}]}]}`, "response text"},
 		{"claude", sdktranslator.FormatClaude, `{"messages":[{"role":"user","content":[{"type":"text","text":"claude text"}]}]}`, "claude text"},
 		{"gemini", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini text"}]}]}`, "gemini text"},
 		{"last user before assistant", sdktranslator.FormatOpenAI, `{"messages":[{"role":"user","content":"last user"},{"role":"assistant","content":"generated"}]}`, "last user"},
 		{"responses last user before output", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"user","content":[{"type":"input_text","text":"response user"}]},{"role":"assistant","content":[{"type":"output_text","text":"generated"}]}]}`, "response user"},
 		{"gemini last user before model", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini user"}]},{"role":"model","parts":[{"text":"generated"}]}]}`, "gemini user"},
+		{"openai empty body", sdktranslator.FormatOpenAI, `{}`, ""},
+		{"openai no prompt", sdktranslator.FormatOpenAI, `{"model":"gpt-image-2"}`, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/contentmoderation/runtime_test.go
+++ b/internal/contentmoderation/runtime_test.go
@@ -195,6 +195,36 @@ func TestRuntimeModeratorTenantMismatchNeverQueriesResolver(t *testing.T) {
 	}
 }
 
+func TestRuntimeModeratorBlocksOpenAIImagePrompt(t *testing.T) {
+	const tenantID = "tenant-image-prompt"
+	store := newTestStore(t)
+	profile := createRuntimeProfile(t, store, tenantID, "profile-image-prompt", CreateProfileInput{
+		Name:            "image prompt block",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"bad word"},
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "image-key", profile.ID)
+	moderator := NewRequestModerator(store, NewEvaluator(nil))
+	auth := &coreauth.Auth{
+		ID:       "image-auth",
+		TenantID: tenantID,
+		Provider: "moderation-runtime",
+		Attributes: map[string]string{
+			"provider_key_id": "image-key",
+		},
+	}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"model":"gpt-image-2","prompt":"bad word"}`),
+		SourceFormat:    sdktranslator.FormatOpenAI,
+		Metadata:        map[string]any{cliproxyexecutor.TenantMetadataKey: tenantID},
+	}
+
+	if result := moderator.Moderate(context.Background(), auth, opts); !result.Blocked {
+		t.Fatal("images-style prompt was not blocked")
+	}
+}
+
 func TestRuntimeModeratorMetricsAreTenantScoped(t *testing.T) {
 	profileA, err := NewProfile("tenant-a", "profile-a", CreateProfileInput{
 		Name: "a", Mode: ModePreBlock, KeywordMode: KeywordModeKeywordOnly,


### PR DESCRIPTION
## Summary
- Content moderation already hooks `AuthManager.Execute` before image generation, but `ExtractLastUserText` only read chat `messages`, so `/v1/images/generations` bodies with top-level `prompt` (e.g. `gpt-image-2`) extracted empty text and were always allowed.
- Fall back to top-level `prompt` when no last-user message text is present.
- Management image test path now passes `OriginalRequest` so the same moderation path can see the prompt.

## Test plan
- [x] `go test ./internal/contentmoderation -count=1` (27 passed)
- [x] `go test ./internal/api/handlers/management -run Image -count=1` (16 passed)

## Risk
Low: text extractor fallback only; chat/messages path unchanged when messages exist.