### PR TITLE
fix(auth): keep week-exhausted credentials blocked until recovered

### DIFF
--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -323,12 +323,18 @@ func needsRuntimeQuotaReconcile(auth *coreauth.Auth) bool {
 		return false
 	}
 	now := time.Now()
+	if auth.Quota.Exceeded && auth.Quota.RecoveryRequired {
+		return true
+	}
 	if auth.Unavailable && auth.Quota.Exceeded && auth.NextRetryAfter.After(now) {
 		return true
 	}
 	for _, state := range auth.ModelStates {
 		if state == nil {
 			continue
+		}
+		if state.Quota.Exceeded && state.Quota.RecoveryRequired {
+			return true
 		}
 		if state.Unavailable && state.Quota.Exceeded && state.NextRetryAfter.After(now) {
 			return true
@@ -499,6 +505,7 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		})
 		return
 	}
+	s.applyRuntimeQuotaProbe(ctx, auth, probe)
 
 	healthStatus := strings.TrimSpace(probe.Health)
 	if healthStatus == "" {
@@ -641,6 +648,32 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		r.UpdatedAt = checked
 		r.Result = view
 	})
+}
+
+func (s *Service) applyRuntimeQuotaProbe(ctx context.Context, auth *coreauth.Auth, probe ProbeResult) {
+	if s == nil || s.authManager == nil || auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if provider != "xai" && provider != "x-ai" && provider != "grok" {
+		return
+	}
+	for _, quota := range probe.Quotas {
+		if quota.QuotaKey != "weekly_limit" || quota.Percent == nil {
+			continue
+		}
+		result := &coreauth.QuotaProbeResult{
+			Recovered:       *quota.Percent > 0,
+			WindowExhausted: *quota.Percent <= 0,
+			Window:          "week",
+			WindowMinutes:   10080,
+		}
+		if quota.ResetAt != nil && quota.ResetAt.After(time.Now()) {
+			result.NextRecoverAt = *quota.ResetAt
+		}
+		_, _ = s.authManager.UpdateQuotaFromProbe(ctx, auth.ID, result)
+		return
+	}
 }
 
 func (s *Service) loadLegacyPersistedStatus(tenantID, subjectID string) (*usage.AIAccountStatusRecord, error) {

--- a/internal/management/aiaccountstatus/service_test.go
+++ b/internal/management/aiaccountstatus/service_test.go
@@ -13,6 +13,7 @@ import (
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	_ "modernc.org/sqlite"
 )
 
@@ -573,6 +574,52 @@ func TestNeedsRuntimeQuotaReconcile(t *testing.T) {
 	}
 	if !needsRuntimeQuotaReconcile(cool) {
 		t.Fatal("cooldown should reconcile")
+	}
+}
+
+func TestApplyRuntimeQuotaProbe_XAIWeeklyZeroBlocksUntilRecovered(t *testing.T) {
+	t.Parallel()
+
+	auth := &coreauth.Auth{
+		ID:       "xai-weekly-zero",
+		Provider: "xai",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"type": "xai", "sub": "xai-user"},
+	}
+	manager := newTestManager(t, "tenant-xai", auth)
+	svc := New(&config.Config{}, manager, nil, nil)
+	zero := 0.0
+	svc.applyRuntimeQuotaProbe(context.Background(), auth, ProbeResult{Quotas: []usage.QuotaWindowDTO{{
+		QuotaKey: "weekly_limit",
+		Percent:  &zero,
+	}}})
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatal("updated auth missing")
+	}
+	if !got.Quota.Exceeded || !got.Quota.RecoveryRequired || got.Quota.Window != "week" {
+		t.Fatalf("quota = %#v, want weekly confirmed-recovery gate", got.Quota)
+	}
+	selector := &coreauth.RoundRobinSelector{}
+	if picked, err := selector.Pick(context.Background(), "xai", "grok-4.5", cliproxyexecutor.Options{}, []*coreauth.Auth{got}); err == nil || picked != nil {
+		t.Fatalf("Pick() = %#v, %v; want blocked auth", picked, err)
+	}
+
+	remaining := 25.0
+	svc.applyRuntimeQuotaProbe(context.Background(), auth, ProbeResult{Quotas: []usage.QuotaWindowDTO{{
+		QuotaKey: "weekly_limit",
+		Percent:  &remaining,
+	}}})
+	got, _ = manager.GetByID(auth.ID)
+	if got.Quota.Exceeded || got.Quota.RecoveryRequired {
+		t.Fatalf("quota = %#v, want recovered", got.Quota)
+	}
+	if _, exists := got.Metadata["_cli_proxy_runtime_quota"]; exists {
+		t.Fatal("recovered auth retained persisted quota runtime metadata")
+	}
+	if picked, err := selector.Pick(context.Background(), "xai", "grok-4.5", cliproxyexecutor.Options{}, []*coreauth.Auth{got}); err != nil || picked == nil {
+		t.Fatalf("Pick() = %#v, %v; want recovered auth", picked, err)
 	}
 }
 

--- a/internal/runtime/executor/xai_quota_recovery.go
+++ b/internal/runtime/executor/xai_quota_recovery.go
@@ -69,7 +69,12 @@ func parseXAIQuotaProbe(body []byte, now time.Time) *cliproxyauth.QuotaProbeResu
 	if weekly.RemainingPercent > 0 {
 		return &cliproxyauth.QuotaProbeResult{Recovered: true}
 	}
-	result := &cliproxyauth.QuotaProbeResult{Recovered: false}
+	result := &cliproxyauth.QuotaProbeResult{
+		Recovered:       false,
+		WindowExhausted: true,
+		Window:          xaiWeeklyWindowLabel,
+		WindowMinutes:   xaiWeeklyWindowMinutes,
+	}
 	if weekly.ResetAt.After(now) {
 		result.NextRecoverAt = weekly.ResetAt
 	}

--- a/internal/runtime/executor/xai_quota_recovery_test.go
+++ b/internal/runtime/executor/xai_quota_recovery_test.go
@@ -78,6 +78,9 @@ func TestXAIExecutorProbeQuotaRecovery(t *testing.T) {
 			if result.Recovered != test.wantRecovered {
 				t.Fatalf("Recovered = %v, want %v", result.Recovered, test.wantRecovered)
 			}
+			if !test.wantRecovered && (!result.WindowExhausted || result.Window != "week" || result.WindowMinutes != 10080) {
+				t.Fatalf("quota window = exhausted:%v %q/%d, want weekly exhausted", result.WindowExhausted, result.Window, result.WindowMinutes)
+			}
 			if test.wantNextRecover {
 				if !result.NextRecoverAt.Equal(resetAt) {
 					t.Fatalf("NextRecoverAt = %v, want %v", result.NextRecoverAt, resetAt)

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -153,6 +153,13 @@ func (s cooldownService) markResult(ctx context.Context, result Result) {
 
 	s.applyRegistryEffects(result, effects)
 	s.manager.hook.OnResult(ctx, result)
+	if !result.Success && result.RetryAfter == nil && isXAIWeekBalanceExhaustedError(result.Error) {
+		probeCtx := context.Background()
+		if ctx != nil {
+			probeCtx = context.WithoutCancel(ctx)
+		}
+		go s.manager.probeQuotaRecoveryWithLimit(probeCtx, result.AuthID, false)
+	}
 }
 
 func (s cooldownService) applyResultLocked(auth *Auth, result Result, now time.Time) resultStateEffects {
@@ -172,7 +179,7 @@ func (s cooldownService) applySuccessLocked(auth *Auth, result Result, now time.
 	markClaudeOAuthHealthSuccessLocked(auth, result, now)
 	if result.Model != "" {
 		state := ensureModelState(auth, result.Model)
-		if activeModelQuotaCooldown(state, now) {
+		if activeModelQuotaCooldown(state, now) && !quotaNeedsConfirmedRecovery(state.Quota) {
 			updateAggregatedAvailability(auth, now)
 			auth.UpdatedAt = now
 			return
@@ -189,7 +196,7 @@ func (s cooldownService) applySuccessLocked(auth *Auth, result Result, now time.
 		effects.clearModelQuota = true
 		return
 	}
-	if activeAuthQuotaCooldown(auth, now) {
+	if activeAuthQuotaCooldown(auth, now) && !quotaNeedsConfirmedRecovery(auth.Quota) {
 		updateAggregatedAvailability(auth, now)
 		auth.UpdatedAt = now
 		return
@@ -303,12 +310,13 @@ func applyModelQuotaFailureLocked(auth *Auth, state *ModelState, result Result, 
 	}
 	state.NextRetryAfter = next
 	state.Quota = QuotaState{
-		Exceeded:      true,
-		Reason:        "quota",
-		Window:        window,
-		WindowMinutes: windowMinutes,
-		NextRecoverAt: next,
-		BackoffLevel:  backoffLevel,
+		Exceeded:         true,
+		RecoveryRequired: isXAIWeekBalanceExhaustedError(result.Error),
+		Reason:           "quota",
+		Window:           window,
+		WindowMinutes:    windowMinutes,
+		NextRecoverAt:    next,
+		BackoffLevel:     backoffLevel,
 	}
 	if result.Error != nil && result.Error.Message != "" {
 		state.StatusMessage = result.Error.Message

--- a/sdk/cliproxy/auth/conductor_failure_state.go
+++ b/sdk/cliproxy/auth/conductor_failure_state.go
@@ -5,8 +5,6 @@ import (
 	"time"
 )
 
-const xaiWeekExhaustedDefaultCooldown = 6 * time.Hour
-
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
 	if auth == nil {
 		return
@@ -63,6 +61,7 @@ func applyAuthQuotaFailureState(auth *Auth, resultErr *Error, retryAfter *time.D
 		auth.StatusMessage = "quota exhausted"
 	}
 	auth.Quota.Exceeded = true
+	auth.Quota.RecoveryRequired = isXAIWeekBalanceExhaustedError(resultErr)
 	auth.Quota.Reason = "quota"
 	if resultErr != nil {
 		auth.Quota.Window = resultErr.QuotaWindow
@@ -86,7 +85,7 @@ func quotaFailureCooldown(resultErr *Error, retryAfter *time.Duration, prevLevel
 		return 0, prevLevel
 	}
 	if isXAIWeekBalanceExhaustedError(resultErr) {
-		return xaiWeekExhaustedDefaultCooldown, prevLevel
+		return 0, prevLevel
 	}
 	return nextQuotaCooldown(prevLevel, false)
 }

--- a/sdk/cliproxy/auth/conductor_persistence.go
+++ b/sdk/cliproxy/auth/conductor_persistence.go
@@ -29,6 +29,7 @@ func (s persistenceService) save(ctx context.Context, auth *Auth) error {
 	if !s.shouldPersist(ctx, auth) {
 		return nil
 	}
+	syncPersistedQuotaRuntime(auth)
 	_, err := s.manager.store.Save(ctx, auth)
 	return err
 }
@@ -47,7 +48,14 @@ func (s persistenceService) list(ctx context.Context) ([]*Auth, error) {
 	if s.manager == nil || s.manager.store == nil {
 		return nil, nil
 	}
-	return s.manager.store.List(ctx)
+	auths, err := s.manager.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, auth := range auths {
+		restorePersistedQuotaRuntime(auth)
+	}
+	return auths, nil
 }
 
 func (s persistenceService) shouldPersist(ctx context.Context, auth *Auth) bool {

--- a/sdk/cliproxy/auth/conductor_result_state.go
+++ b/sdk/cliproxy/auth/conductor_result_state.go
@@ -42,6 +42,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	quotaRecover := time.Time{}
 	quotaWindow := ""
 	quotaWindowMinutes := 0
+	quotaRecoveryRequired := false
 	maxBackoffLevel := 0
 	for _, state := range auth.ModelStates {
 		if state == nil {
@@ -50,6 +51,12 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		stateUnavailable := false
 		if state.Status == StatusDisabled {
 			stateUnavailable = true
+		} else if quotaNeedsConfirmedRecovery(state.Quota) {
+			stateUnavailable = true
+			state.Unavailable = true
+			if state.NextRetryAfter.After(now) && (earliestRetry.IsZero() || state.NextRetryAfter.Before(earliestRetry)) {
+				earliestRetry = state.NextRetryAfter
+			}
 		} else if state.Unavailable {
 			if state.NextRetryAfter.IsZero() {
 				stateUnavailable = false
@@ -68,6 +75,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		}
 		if state.Quota.Exceeded {
 			quotaExceeded = true
+			quotaRecoveryRequired = quotaRecoveryRequired || state.Quota.RecoveryRequired
 			if quotaRecover.IsZero() || (!state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.Before(quotaRecover)) {
 				quotaRecover = state.Quota.NextRecoverAt
 				quotaWindow = state.Quota.Window
@@ -89,6 +97,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	}
 	if quotaExceeded {
 		auth.Quota.Exceeded = true
+		auth.Quota.RecoveryRequired = quotaRecoveryRequired
 		auth.Quota.Reason = "quota"
 		auth.Quota.Window = quotaWindow
 		auth.Quota.WindowMinutes = quotaWindowMinutes
@@ -96,6 +105,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		auth.Quota.BackoffLevel = maxBackoffLevel
 	} else {
 		auth.Quota.Exceeded = false
+		auth.Quota.RecoveryRequired = false
 		auth.Quota.Reason = ""
 		auth.Quota.Window = ""
 		auth.Quota.WindowMinutes = 0
@@ -122,10 +132,17 @@ func activeQuotaCooldown(quota QuotaState, retryAfter time.Time, now time.Time) 
 	if !quota.Exceeded {
 		return false
 	}
+	if quotaNeedsConfirmedRecovery(quota) {
+		return true
+	}
 	if !quota.NextRecoverAt.IsZero() {
 		return quota.NextRecoverAt.After(now)
 	}
 	return !retryAfter.IsZero() && retryAfter.After(now)
+}
+
+func quotaNeedsConfirmedRecovery(quota QuotaState) bool {
+	return quota.Exceeded && quota.RecoveryRequired
 }
 
 func activeModelRuntimeState(state *ModelState, now time.Time) bool {
@@ -172,7 +189,7 @@ func hasModelError(auth *Auth, now time.Time) bool {
 			return true
 		}
 		if state.Status == StatusError {
-			if state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now)) {
+			if quotaNeedsConfirmedRecovery(state.Quota) || (state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now))) {
 				return true
 			}
 		}
@@ -188,6 +205,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Status = StatusActive
 	auth.StatusMessage = ""
 	auth.Quota.Exceeded = false
+	auth.Quota.RecoveryRequired = false
 	auth.Quota.Reason = ""
 	auth.Quota.Window = ""
 	auth.Quota.WindowMinutes = 0

--- a/sdk/cliproxy/auth/conductor_runtime_quota_test.go
+++ b/sdk/cliproxy/auth/conductor_runtime_quota_test.go
@@ -47,6 +47,9 @@ func TestManagerUpdatePreservesRuntimeQuotaState(t *testing.T) {
 	if beforeState == nil || !beforeState.Quota.Exceeded {
 		t.Fatalf("test setup failed: expected model quota to be exceeded")
 	}
+	if beforeState.Quota.RecoveryRequired {
+		t.Fatal("ordinary 429 unexpectedly requires confirmed recovery")
+	}
 
 	updated, err := m.Update(ctx, &Auth{
 		ID:       "auth-1",

--- a/sdk/cliproxy/auth/quota_persistence.go
+++ b/sdk/cliproxy/auth/quota_persistence.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const persistedQuotaRuntimeMetadataKey = "_cli_proxy_runtime_quota"
+
+type persistedQuotaRuntime struct {
+	Status         Status                                `json:"status,omitempty"`
+	StatusMessage  string                                `json:"status_message,omitempty"`
+	NextRetryAfter time.Time                             `json:"next_retry_after,omitempty"`
+	Quota          QuotaState                            `json:"quota"`
+	ModelStates    map[string]persistedQuotaModelRuntime `json:"model_states,omitempty"`
+}
+
+type persistedQuotaModelRuntime struct {
+	Status         Status     `json:"status,omitempty"`
+	StatusMessage  string     `json:"status_message,omitempty"`
+	NextRetryAfter time.Time  `json:"next_retry_after,omitempty"`
+	Quota          QuotaState `json:"quota"`
+}
+
+func syncPersistedQuotaRuntime(auth *Auth) {
+	if auth == nil || auth.Metadata == nil {
+		return
+	}
+
+	runtime := persistedQuotaRuntime{
+		Status:         auth.Status,
+		StatusMessage:  auth.StatusMessage,
+		NextRetryAfter: auth.NextRetryAfter,
+		Quota:          auth.Quota,
+	}
+	for model, state := range auth.ModelStates {
+		if state == nil || !quotaNeedsConfirmedRecovery(state.Quota) {
+			continue
+		}
+		if runtime.ModelStates == nil {
+			runtime.ModelStates = make(map[string]persistedQuotaModelRuntime)
+		}
+		runtime.ModelStates[model] = persistedQuotaModelRuntime{
+			Status:         state.Status,
+			StatusMessage:  state.StatusMessage,
+			NextRetryAfter: state.NextRetryAfter,
+			Quota:          state.Quota,
+		}
+	}
+
+	if !quotaNeedsConfirmedRecovery(runtime.Quota) && len(runtime.ModelStates) == 0 {
+		delete(auth.Metadata, persistedQuotaRuntimeMetadataKey)
+		return
+	}
+	auth.Metadata[persistedQuotaRuntimeMetadataKey] = runtime
+}
+
+func restorePersistedQuotaRuntime(auth *Auth) {
+	if auth == nil || auth.Metadata == nil || auth.Disabled || auth.Status == StatusDisabled {
+		return
+	}
+	raw, ok := auth.Metadata[persistedQuotaRuntimeMetadataKey]
+	if !ok || raw == nil {
+		return
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return
+	}
+	var runtime persistedQuotaRuntime
+	if err = json.Unmarshal(data, &runtime); err != nil {
+		return
+	}
+	if !quotaNeedsConfirmedRecovery(runtime.Quota) && len(runtime.ModelStates) == 0 {
+		return
+	}
+
+	if quotaNeedsConfirmedRecovery(runtime.Quota) {
+		auth.Quota = runtime.Quota
+		auth.NextRetryAfter = runtime.NextRetryAfter
+		auth.Unavailable = true
+		auth.Status = runtime.Status
+		if auth.Status == "" || auth.Status == StatusActive || auth.Status == StatusUnknown {
+			auth.Status = StatusError
+		}
+		auth.StatusMessage = runtime.StatusMessage
+		if auth.StatusMessage == "" {
+			auth.StatusMessage = "quota exhausted"
+		}
+	}
+	if len(runtime.ModelStates) == 0 {
+		return
+	}
+	if auth.ModelStates == nil {
+		auth.ModelStates = make(map[string]*ModelState, len(runtime.ModelStates))
+	}
+	for model, persisted := range runtime.ModelStates {
+		if !quotaNeedsConfirmedRecovery(persisted.Quota) {
+			continue
+		}
+		state := &ModelState{
+			Status:         persisted.Status,
+			StatusMessage:  persisted.StatusMessage,
+			Unavailable:    true,
+			NextRetryAfter: persisted.NextRetryAfter,
+			Quota:          persisted.Quota,
+		}
+		if state.Status == "" || state.Status == StatusActive || state.Status == StatusUnknown {
+			state.Status = StatusError
+		}
+		if state.StatusMessage == "" {
+			state.StatusMessage = "quota exhausted"
+		}
+		auth.ModelStates[model] = state
+	}
+	updateAggregatedAvailability(auth, time.Now())
+}

--- a/sdk/cliproxy/auth/quota_persistence_test.go
+++ b/sdk/cliproxy/auth/quota_persistence_test.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+type quotaRuntimeStore struct {
+	mu   sync.Mutex
+	auth *Auth
+}
+
+func (s *quotaRuntimeStore) List(context.Context) ([]*Auth, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.auth == nil {
+		return nil, nil
+	}
+	return []*Auth{s.auth.Clone()}, nil
+}
+
+func (s *quotaRuntimeStore) Save(_ context.Context, auth *Auth) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := json.Marshal(auth.Metadata)
+	if err != nil {
+		return "", err
+	}
+	metadata := make(map[string]any)
+	if err = json.Unmarshal(data, &metadata); err != nil {
+		return "", err
+	}
+	s.auth = &Auth{
+		ID:       auth.ID,
+		TenantID: auth.TenantID,
+		Provider: auth.Provider,
+		Status:   StatusActive,
+		Metadata: metadata,
+	}
+	return auth.ID, nil
+}
+
+func (s *quotaRuntimeStore) Delete(context.Context, string) error { return nil }
+
+func TestManagerLoadRestoresWindowExhaustedGate(t *testing.T) {
+	store := &quotaRuntimeStore{}
+	manager := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "xai-auth",
+		Provider: "xai",
+		Status:   StatusActive,
+		Metadata: map[string]any{"type": "xai"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "grok-4.5",
+		Error: &Error{
+			Message:            `{"error":"Grok Build usage balance exhausted"}`,
+			HTTPStatus:         http.StatusPaymentRequired,
+			QuotaWindow:        "week",
+			QuotaWindowMinutes: 10080,
+		},
+	})
+
+	reloaded := NewManager(store, nil, nil)
+	if err := reloaded.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	got, ok := reloaded.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatal("loaded auth missing")
+	}
+	if !got.Quota.Exceeded || !got.Quota.RecoveryRequired {
+		t.Fatalf("loaded quota = %#v, want confirmed-recovery gate", got.Quota)
+	}
+	blocked, _, _ := isAuthBlockedForModel(got, "grok-4.5", got.UpdatedAt)
+	if !blocked {
+		t.Fatal("loaded week-exhausted auth is selectable")
+	}
+}

--- a/sdk/cliproxy/auth/quota_reconcile.go
+++ b/sdk/cliproxy/auth/quota_reconcile.go
@@ -15,11 +15,14 @@ const (
 )
 
 // QuotaProbeResult describes the latest quota status for a credential.
-// When Models is empty, the result applies to every quota-blocked model state on the auth.
+// When Models is empty, the result applies auth-wide or to every quota-blocked model state.
 type QuotaProbeResult struct {
-	Recovered     bool
-	NextRecoverAt time.Time
-	Models        map[string]QuotaProbeModelResult
+	Recovered       bool
+	WindowExhausted bool
+	Window          string
+	WindowMinutes   int
+	NextRecoverAt   time.Time
+	Models          map[string]QuotaProbeModelResult
 }
 
 // QuotaProbeModelResult describes the latest quota status for a specific model.
@@ -37,6 +40,55 @@ type QuotaRecoveryProber interface {
 // ReconcileQuota forces an immediate quota reconciliation for the given auth entry.
 func (m *Manager) ReconcileQuota(ctx context.Context, id string) (bool, error) {
 	return m.probeQuotaRecovery(ctx, id, true)
+}
+
+// UpdateQuotaFromProbe applies an already-fetched upstream quota result without
+// issuing another provider request.
+func (m *Manager) UpdateQuotaFromProbe(ctx context.Context, id string, result *QuotaProbeResult) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	id = strings.TrimSpace(id)
+	if id == "" || result == nil {
+		return false, nil
+	}
+
+	now := time.Now()
+	var (
+		updated         *Auth
+		recoveredModels []string
+	)
+
+	m.mu.Lock()
+	current, ok := m.auths[id]
+	if !ok || current == nil {
+		delete(m.quotaProbeAfter, id)
+		m.mu.Unlock()
+		return false, nil
+	}
+	changed, models := applyQuotaProbeResult(current, result, now)
+	recoveredModels = models
+	if authHasActiveQuotaCooldown(current, now) {
+		m.quotaProbeAfter[id] = nextQuotaProbeTime(current, now)
+	} else {
+		delete(m.quotaProbeAfter, id)
+	}
+	if changed {
+		current.UpdatedAt = now
+		syncPersistedQuotaRuntime(current)
+		updated = current.Clone()
+		m.auths[id] = current
+	}
+	m.mu.Unlock()
+
+	if updated != nil {
+		if errPersist := m.persist(ctx, updated); errPersist != nil {
+			return true, errPersist
+		}
+		m.hook.OnAuthUpdated(ctx, updated.Clone())
+	}
+	m.resumeRecoveredQuotaModels(id, recoveredModels)
+	return updated != nil, nil
 }
 
 // ClearQuotaStatus manually clears local quota/cooldown runtime state for an auth entry.
@@ -68,6 +120,7 @@ func (m *Manager) ClearQuotaStatus(ctx context.Context, id string) (bool, error)
 	delete(m.quotaProbeAfter, id)
 	if changed {
 		current.UpdatedAt = now
+		syncPersistedQuotaRuntime(current)
 		updated = current.Clone()
 		m.auths[id] = current
 	}
@@ -180,42 +233,7 @@ func (m *Manager) probeQuotaRecovery(ctx context.Context, id string, force bool)
 		return false, nil
 	}
 
-	now = time.Now()
-	var (
-		updated         *Auth
-		recoveredModels []string
-	)
-
-	m.mu.Lock()
-	current, ok := m.auths[id]
-	if !ok || current == nil {
-		delete(m.quotaProbeAfter, id)
-		m.mu.Unlock()
-		return false, nil
-	}
-
-	changed, models := applyQuotaProbeResult(current, result, now)
-	recoveredModels = models
-	if authHasActiveQuotaCooldown(current, now) {
-		m.quotaProbeAfter[id] = nextQuotaProbeTime(current, now)
-	} else {
-		delete(m.quotaProbeAfter, id)
-	}
-	if changed {
-		current.UpdatedAt = now
-		updated = current.Clone()
-		m.auths[id] = current
-	}
-	m.mu.Unlock()
-
-	if updated != nil {
-		if errPersist := m.persist(ctx, updated); errPersist != nil {
-			return true, errPersist
-		}
-		m.hook.OnAuthUpdated(ctx, updated.Clone())
-	}
-	m.resumeRecoveredQuotaModels(id, recoveredModels)
-	return updated != nil, nil
+	return m.UpdateQuotaFromProbe(ctx, id, result)
 }
 
 func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) (bool, []string) {
@@ -227,8 +245,28 @@ func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) 
 	recoveredModels := make([]string, 0)
 	modelResults := normalizeQuotaProbeModels(result.Models)
 	authWide := QuotaProbeModelResult{Recovered: result.Recovered, NextRecoverAt: result.NextRecoverAt}
+	if result.WindowExhausted && !hasQuotaExceededModel(auth) {
+		changed := !auth.Unavailable || auth.Status != StatusError || auth.StatusMessage != "quota exhausted" ||
+			!auth.NextRetryAfter.Equal(result.NextRecoverAt) || !auth.Quota.Exceeded || !auth.Quota.RecoveryRequired ||
+			auth.Quota.Reason != "quota" || auth.Quota.Window != result.Window ||
+			auth.Quota.WindowMinutes != result.WindowMinutes || !auth.Quota.NextRecoverAt.Equal(result.NextRecoverAt)
+		auth.Unavailable = true
+		auth.Status = StatusError
+		auth.StatusMessage = "quota exhausted"
+		auth.NextRetryAfter = result.NextRecoverAt
+		auth.Quota = QuotaState{
+			Exceeded:         true,
+			RecoveryRequired: true,
+			Reason:           "quota",
+			Window:           result.Window,
+			WindowMinutes:    result.WindowMinutes,
+			NextRecoverAt:    result.NextRecoverAt,
+		}
+		auth.UpdatedAt = now
+		return changed, nil
+	}
 
-	if len(auth.ModelStates) > 0 {
+	if hasQuotaExceededModel(auth) {
 		beforeUnavailable := auth.Unavailable
 		beforeNextRetry := auth.NextRetryAfter
 		beforeQuota := auth.Quota
@@ -255,6 +293,15 @@ func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) 
 				}
 				recoveredModels = append(recoveredModels, modelID)
 				continue
+			}
+			if result.WindowExhausted {
+				if !state.Quota.RecoveryRequired || state.Quota.Window != result.Window || state.Quota.WindowMinutes != result.WindowMinutes {
+					state.Quota.RecoveryRequired = true
+					state.Quota.Window = result.Window
+					state.Quota.WindowMinutes = result.WindowMinutes
+					state.UpdatedAt = now
+					changed = true
+				}
 			}
 			if updateQuotaModelRecoverAt(state, outcome.NextRecoverAt, now) {
 				changed = true
@@ -289,6 +336,18 @@ func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) 
 		changed = true
 	}
 	return changed, nil
+}
+
+func hasQuotaExceededModel(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	for _, state := range auth.ModelStates {
+		if state != nil && state.Quota.Exceeded {
+			return true
+		}
+	}
+	return false
 }
 
 func clearQuotaStatusForAuth(auth *Auth, now time.Time) (bool, []string) {
@@ -340,14 +399,14 @@ func authHasActiveQuotaCooldown(auth *Auth, now time.Time) bool {
 	if auth == nil || auth.Disabled {
 		return false
 	}
-	if auth.Unavailable && auth.Quota.Exceeded && auth.NextRetryAfter.After(now) {
+	if activeAuthQuotaCooldown(auth, now) {
 		return true
 	}
 	for _, state := range auth.ModelStates {
 		if state == nil {
 			continue
 		}
-		if state.Unavailable && state.Quota.Exceeded && state.NextRetryAfter.After(now) {
+		if activeModelQuotaCooldown(state, now) {
 			return true
 		}
 	}
@@ -359,21 +418,26 @@ func nextQuotaProbeTime(auth *Auth, now time.Time) time.Time {
 	if auth == nil {
 		return now.Add(quotaProbeMinInterval)
 	}
-	if auth.Unavailable && auth.Quota.Exceeded && auth.NextRetryAfter.After(now) {
-		nextRecover = auth.NextRetryAfter
-		if !auth.Quota.NextRecoverAt.IsZero() && auth.Quota.NextRecoverAt.After(now) && auth.Quota.NextRecoverAt.Before(nextRecover) {
+	if activeAuthQuotaCooldown(auth, now) {
+		if auth.NextRetryAfter.After(now) {
+			nextRecover = auth.NextRetryAfter
+		}
+		if auth.Quota.NextRecoverAt.After(now) && (nextRecover.IsZero() || auth.Quota.NextRecoverAt.Before(nextRecover)) {
 			nextRecover = auth.Quota.NextRecoverAt
 		}
 	}
 	for _, state := range auth.ModelStates {
-		if state == nil || !state.Unavailable || !state.Quota.Exceeded || !state.NextRetryAfter.After(now) {
+		if state == nil || !activeModelQuotaCooldown(state, now) {
 			continue
 		}
-		candidate := state.NextRetryAfter
-		if !state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.After(now) && state.Quota.NextRecoverAt.Before(candidate) {
+		candidate := time.Time{}
+		if state.NextRetryAfter.After(now) {
+			candidate = state.NextRetryAfter
+		}
+		if state.Quota.NextRecoverAt.After(now) && (candidate.IsZero() || state.Quota.NextRecoverAt.Before(candidate)) {
 			candidate = state.Quota.NextRecoverAt
 		}
-		if nextRecover.IsZero() || candidate.Before(nextRecover) {
+		if !candidate.IsZero() && (nextRecover.IsZero() || candidate.Before(nextRecover)) {
 			nextRecover = candidate
 		}
 	}
@@ -432,8 +496,17 @@ func clearQuotaModelRuntimeState(state *ModelState, now time.Time) bool {
 }
 
 func updateQuotaModelRecoverAt(state *ModelState, next time.Time, now time.Time) bool {
-	if state == nil || next.IsZero() {
+	if state == nil {
 		return false
+	}
+	if next.IsZero() {
+		if !quotaNeedsConfirmedRecovery(state.Quota) {
+			return false
+		}
+		changed := !state.Unavailable
+		state.Unavailable = true
+		state.UpdatedAt = now
+		return changed
 	}
 	changed := !state.NextRetryAfter.Equal(next) || !state.Quota.NextRecoverAt.Equal(next) || !state.Unavailable || !state.Quota.Exceeded || state.Quota.Reason != "quota"
 	state.Unavailable = true
@@ -501,8 +574,17 @@ func hasQuotaRuntimeState(statusMessage string, lastError *Error, unavailable bo
 }
 
 func updateQuotaAuthRecoverAt(auth *Auth, next time.Time, now time.Time) bool {
-	if auth == nil || next.IsZero() {
+	if auth == nil {
 		return false
+	}
+	if next.IsZero() {
+		if !quotaNeedsConfirmedRecovery(auth.Quota) {
+			return false
+		}
+		changed := !auth.Unavailable
+		auth.Unavailable = true
+		auth.UpdatedAt = now
+		return changed
 	}
 	changed := !auth.NextRetryAfter.Equal(next) || !auth.Quota.NextRecoverAt.Equal(next) || !auth.Unavailable || !auth.Quota.Exceeded || auth.Quota.Reason != "quota"
 	auth.Unavailable = true

--- a/sdk/cliproxy/auth/quota_reconcile_test.go
+++ b/sdk/cliproxy/auth/quota_reconcile_test.go
@@ -61,9 +61,10 @@ func TestManagerReconcileQuota_ClearsRecoveredModelCooldown(t *testing.T) {
 		Status:      StatusError,
 		Unavailable: true,
 		Quota: QuotaState{
-			Exceeded:      true,
-			Reason:        "quota",
-			NextRecoverAt: next,
+			Exceeded:         true,
+			RecoveryRequired: true,
+			Reason:           "quota",
+			NextRecoverAt:    next,
 		},
 		ModelStates: map[string]*ModelState{
 			"gpt-5-codex": {
@@ -73,9 +74,10 @@ func TestManagerReconcileQuota_ClearsRecoveredModelCooldown(t *testing.T) {
 				NextRetryAfter: next,
 				LastError:      &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
 				Quota: QuotaState{
-					Exceeded:      true,
-					Reason:        "quota",
-					NextRecoverAt: next,
+					Exceeded:         true,
+					RecoveryRequired: true,
+					Reason:           "quota",
+					NextRecoverAt:    next,
 				},
 			},
 		},
@@ -117,6 +119,54 @@ func TestManagerReconcileQuota_ClearsRecoveredModelCooldown(t *testing.T) {
 	}
 	if updated.Status != StatusActive {
 		t.Fatalf("auth.Status = %q, want %q", updated.Status, StatusActive)
+	}
+}
+
+func TestApplyQuotaProbeResult_NotRecoveredWithoutResetKeepsWindowGate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := &Auth{
+		ID:          "xai-auth",
+		Provider:    "xai",
+		Status:      StatusError,
+		Unavailable: true,
+		Quota: QuotaState{
+			Exceeded:         true,
+			RecoveryRequired: true,
+			Reason:           "quota",
+			Window:           "week",
+			WindowMinutes:    10080,
+			NextRecoverAt:    now.Add(-time.Hour),
+		},
+		NextRetryAfter: now.Add(-time.Hour),
+		ModelStates: map[string]*ModelState{
+			"grok-4.5": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: now.Add(-time.Hour),
+				Quota: QuotaState{
+					Exceeded:         true,
+					RecoveryRequired: true,
+					Reason:           "quota",
+					Window:           "week",
+					WindowMinutes:    10080,
+					NextRecoverAt:    now.Add(-time.Hour),
+				},
+			},
+		},
+	}
+
+	applyQuotaProbeResult(auth, &QuotaProbeResult{Recovered: false}, now)
+	blocked, _, _ := isAuthBlockedForModel(auth, "grok-4.5", now)
+	if !blocked {
+		t.Fatal("not-recovered zero-reset probe released the credential")
+	}
+	if !authHasActiveQuotaCooldown(auth, now) {
+		t.Fatal("window gate no longer schedules recovery probes")
+	}
+	if next := nextQuotaProbeTime(auth, now); !next.After(now) || next.After(now.Add(2*quotaProbeMinInterval)) {
+		t.Fatalf("nextQuotaProbeTime() = %v, want prompt follow-up probe", next)
 	}
 }
 

--- a/sdk/cliproxy/auth/selector_availability.go
+++ b/sdk/cliproxy/auth/selector_availability.go
@@ -306,12 +306,12 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	// requests by switching models during the same quota window.
 	if auth.Quota.Exceeded {
 		next := auth.Quota.NextRecoverAt
-		if !next.IsZero() && next.After(now) {
+		if quotaNeedsConfirmedRecovery(auth.Quota) || (!next.IsZero() && next.After(now)) {
 			if auth.NextRetryAfter.After(now) && (next.IsZero() || auth.NextRetryAfter.Before(next)) {
 				next = auth.NextRetryAfter
 			}
-			if next.Before(now) {
-				next = now
+			if !next.After(now) {
+				next = time.Time{}
 			}
 			return true, blockReasonCooldown, next
 		}
@@ -329,6 +329,16 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 			if ok && state != nil {
 				if state.Status == StatusDisabled {
 					return true, blockReasonDisabled, time.Time{}
+				}
+				if quotaNeedsConfirmedRecovery(state.Quota) {
+					next := state.Quota.NextRecoverAt
+					if state.NextRetryAfter.After(now) && (next.IsZero() || state.NextRetryAfter.Before(next)) {
+						next = state.NextRetryAfter
+					}
+					if !next.After(now) {
+						next = time.Time{}
+					}
+					return true, blockReasonCooldown, next
 				}
 				if state.Unavailable {
 					if state.NextRetryAfter.IsZero() {

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -705,6 +705,35 @@ func TestIsAuthBlockedForModel_AuthQuotaCooldownBlocksAllModels(t *testing.T) {
 	}
 }
 
+func TestIsAuthBlockedForModel_WindowExhaustedRemainsBlockedAfterRecoverAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := &Auth{
+		ID: "xai-week-exhausted",
+		Quota: QuotaState{
+			Exceeded:         true,
+			RecoveryRequired: true,
+			Reason:           "quota",
+			Window:           "week",
+			WindowMinutes:    10080,
+			NextRecoverAt:    now.Add(-time.Hour),
+		},
+		NextRetryAfter: now.Add(-time.Hour),
+	}
+
+	blocked, reason, next := isAuthBlockedForModel(auth, "grok-4.5", now)
+	if !blocked {
+		t.Fatal("blocked = false, want true until recovery is confirmed")
+	}
+	if reason != blockReasonCooldown {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonCooldown)
+	}
+	if !next.IsZero() {
+		t.Fatalf("next = %v, want zero for an expired unconfirmed reset", next)
+	}
+}
+
 func TestFillFirstSelectorPick_ThinkingSuffixFallsBackToBaseModelState(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -101,6 +101,9 @@ type Auth struct {
 type QuotaState struct {
 	// Exceeded indicates the credential recently hit a quota error.
 	Exceeded bool `json:"exceeded"`
+	// RecoveryRequired keeps a confirmed quota window exhausted until an
+	// upstream probe or successful request confirms recovery.
+	RecoveryRequired bool `json:"recovery_required,omitempty"`
 	// Reason provides an optional provider specific human readable description.
 	Reason string `json:"reason,omitempty"`
 	// Window identifies the provider quota window that was exhausted, such as

--- a/sdk/cliproxy/auth/xai_402_quota_test.go
+++ b/sdk/cliproxy/auth/xai_402_quota_test.go
@@ -35,6 +35,7 @@ func (e *retryAfterQuotaErrorStub) RetryAfter() *time.Duration {
 type xaiQuotaExecutor struct {
 	err     error
 	execute func(*Auth) (cliproxyexecutor.Response, error)
+	probe   func(context.Context, *Auth) (*QuotaProbeResult, error)
 }
 
 func (e *xaiQuotaExecutor) Identifier() string { return "xai" }
@@ -54,7 +55,10 @@ func (e *xaiQuotaExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.
 func (e *xaiQuotaExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
 	return nil, e.err
 }
-func (e *xaiQuotaExecutor) ProbeQuotaRecovery(context.Context, *Auth) (*QuotaProbeResult, error) {
+func (e *xaiQuotaExecutor) ProbeQuotaRecovery(ctx context.Context, auth *Auth) (*QuotaProbeResult, error) {
+	if e.probe != nil {
+		return e.probe(ctx, auth)
+	}
 	return &QuotaProbeResult{Recovered: false}, nil
 }
 
@@ -103,7 +107,7 @@ func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testi
 	if state == nil {
 		t.Fatal("model state missing")
 	}
-	if !state.Quota.Exceeded || state.Quota.Reason != "quota" {
+	if !state.Quota.Exceeded || !state.Quota.RecoveryRequired || state.Quota.Reason != "quota" {
 		t.Fatalf("quota = %#v, want exceeded quota", state.Quota)
 	}
 	if state.Quota.Window != "week" || state.Quota.WindowMinutes != 10080 {
@@ -119,7 +123,7 @@ func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testi
 	}
 }
 
-func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesDefaultCooldown(t *testing.T) {
+func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesRecoveryGate(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -165,16 +169,18 @@ func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesDefaultCooldown
 	if !state.Quota.Exceeded || state.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", state.Quota)
 	}
-	minExpected := before.Add(xaiWeekExhaustedDefaultCooldown - time.Minute)
-	maxExpected := before.Add(xaiWeekExhaustedDefaultCooldown + time.Minute)
-	if state.NextRetryAfter.Before(minExpected) || state.NextRetryAfter.After(maxExpected) {
-		t.Fatalf("NextRetryAfter = %v, want ~%v", state.NextRetryAfter, before.Add(xaiWeekExhaustedDefaultCooldown))
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %v, want zero without upstream reset", state.NextRetryAfter)
 	}
-	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
-		t.Fatalf("NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
+	if !state.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("NextRecoverAt = %v, want zero without upstream reset", state.Quota.NextRecoverAt)
 	}
-	if !got.Quota.Exceeded || got.Quota.NextRecoverAt.IsZero() {
-		t.Fatalf("aggregated auth quota = %#v, want exceeded with recovery time", got.Quota)
+	if !got.Quota.Exceeded || !got.Quota.RecoveryRequired {
+		t.Fatalf("aggregated auth quota = %#v, want confirmed-recovery gate", got.Quota)
+	}
+	blocked, _, _ := isAuthBlockedForModel(got, model, before.Add(7*time.Hour))
+	if !blocked {
+		t.Fatal("week-exhausted auth became selectable after the old 6h cooldown")
 	}
 }
 
@@ -229,15 +235,15 @@ func TestManagerExecute_XAIWeekExhaustedSkipsAuthForHealthyPeer(t *testing.T) {
 		t.Fatal("exhausted auth missing")
 	}
 	now := time.Now()
-	if !exhausted.Quota.Exceeded || !exhausted.Quota.NextRecoverAt.After(now.Add(time.Hour)) {
-		t.Fatalf("exhausted quota = %#v, want active long cooldown", exhausted.Quota)
+	if !exhausted.Quota.Exceeded || !exhausted.Quota.RecoveryRequired {
+		t.Fatalf("exhausted quota = %#v, want confirmed-recovery gate", exhausted.Quota)
 	}
-	if !manager.shouldProbeQuota(exhausted, now) {
-		t.Fatal("shouldProbeQuota() = false, want xAI cooldown eligible for recovery probe")
+	if !authHasActiveQuotaCooldown(exhausted, now) {
+		t.Fatal("authHasActiveQuotaCooldown() = false, want xAI gate eligible for recovery probes")
 	}
 	nextProbe := nextQuotaProbeTime(exhausted, now)
-	if !nextProbe.After(now) || !nextProbe.Before(exhausted.Quota.NextRecoverAt) {
-		t.Fatalf("nextQuotaProbeTime() = %v, want before cooldown recovery %v", nextProbe, exhausted.Quota.NextRecoverAt)
+	if !nextProbe.After(now) || nextProbe.After(now.Add(2*quotaProbeMinInterval)) {
+		t.Fatalf("nextQuotaProbeTime() = %v, want prompt follow-up probe", nextProbe)
 	}
 }
 
@@ -314,7 +320,7 @@ func TestApplyAuthFailureState_XAI402BalanceExhausted(t *testing.T) {
 	}
 }
 
-func TestApplyAuthFailureState_XAI402WithoutRetryUsesDefaultCooldown(t *testing.T) {
+func TestApplyAuthFailureState_XAI402WithoutRetryUsesRecoveryGate(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
@@ -326,13 +332,125 @@ func TestApplyAuthFailureState_XAI402WithoutRetryUsesDefaultCooldown(t *testing.
 		QuotaWindowMinutes: 10080,
 	}, nil, now)
 
-	if !auth.Quota.Exceeded || auth.Quota.Window != "week" {
+	if !auth.Quota.Exceeded || !auth.Quota.RecoveryRequired || auth.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", auth.Quota)
 	}
-	if !auth.NextRetryAfter.Equal(now.Add(xaiWeekExhaustedDefaultCooldown)) {
-		t.Fatalf("NextRetryAfter = %v, want %v", auth.NextRetryAfter, now.Add(xaiWeekExhaustedDefaultCooldown))
+	if !auth.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %v, want zero without upstream reset", auth.NextRetryAfter)
 	}
-	if !auth.Quota.NextRecoverAt.Equal(auth.NextRetryAfter) {
-		t.Fatalf("NextRecoverAt = %v, want %v", auth.Quota.NextRecoverAt, auth.NextRetryAfter)
+	if !auth.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("NextRecoverAt = %v, want zero without upstream reset", auth.Quota.NextRecoverAt)
+	}
+}
+
+func TestManagerMarkResult_XAIWeekExhaustedProbesImmediately(t *testing.T) {
+	t.Parallel()
+
+	probed := make(chan struct{}, 1)
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		err: &retryAfterQuotaErrorStub{
+			message:      `{"error":"Grok Build usage balance exhausted"}`,
+			status:       http.StatusPaymentRequired,
+			quotaWindow:  "week",
+			quotaMinutes: 10080,
+		},
+		probe: func(context.Context, *Auth) (*QuotaProbeResult, error) {
+			probed <- struct{}{}
+			return &QuotaProbeResult{Recovered: false}, nil
+		},
+	})
+	if _, err := manager.Register(context.Background(), &Auth{ID: "xai-probe", Provider: "xai", Status: StatusActive}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, _ = manager.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: "grok-4.5"}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.SinglePickMetadataKey: true},
+	})
+
+	select {
+	case <-probed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("billing recovery probe was not started after week-exhausted 402")
+	}
+}
+
+func TestManagerMarkResult_XAIWeekExhaustedProbePinsBillingReset(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Now().Add(3 * time.Hour).Round(time.Second)
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		err: &retryAfterQuotaErrorStub{
+			message:      `{"error":"Grok Build usage balance exhausted"}`,
+			status:       http.StatusPaymentRequired,
+			quotaWindow:  "week",
+			quotaMinutes: 10080,
+		},
+		probe: func(context.Context, *Auth) (*QuotaProbeResult, error) {
+			return &QuotaProbeResult{
+				Recovered:       false,
+				WindowExhausted: true,
+				Window:          "week",
+				WindowMinutes:   10080,
+				NextRecoverAt:   resetAt,
+			}, nil
+		},
+	})
+	auth := &Auth{ID: "xai-reset", Provider: "xai", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, _ = manager.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: "grok-4.5"}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.SinglePickMetadataKey: true},
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, _ := manager.GetByID(auth.ID)
+		if got != nil {
+			if state := got.ModelStates["grok-4.5"]; state != nil && state.Quota.NextRecoverAt.Equal(resetAt) {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	got, _ := manager.GetByID(auth.ID)
+	t.Fatalf("billing reset was not applied: %#v", got)
+}
+
+func TestManagerMarkResult_SuccessClearsWindowExhaustedGate(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "xai-success", Provider: "xai", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "grok-4.5",
+		Error: &Error{
+			Message:            `{"error":"Grok Build usage balance exhausted"}`,
+			HTTPStatus:         http.StatusPaymentRequired,
+			QuotaWindow:        "week",
+			QuotaWindowMinutes: 10080,
+		},
+	})
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "grok-4.5",
+		Success:  true,
+	})
+
+	got, _ := manager.GetByID(auth.ID)
+	if got.Quota.Exceeded || got.Quota.RecoveryRequired {
+		t.Fatalf("quota = %#v, want success-confirmed recovery", got.Quota)
+	}
+	if state := got.ModelStates["grok-4.5"]; state == nil || state.Quota.Exceeded || state.Unavailable {
+		t.Fatalf("model state = %#v, want recovered", state)
 	}
 }


### PR DESCRIPTION
## Summary
- Grok/xAI 周额度耗尽改为 **recovered 门闩**：`NextRecoverAt` 为空或到期后仍不可进入 RR，直到 probe recovered / 成功请求 / 管理员 ClearQuota。
- xAI 402 无 Retry-After 时异步 billing probe 写入真实 ResetAt；0% 无 reset 时保持 block 并续 probe。
- 最小持久化 `_cli_proxy_runtime_quota`，`Manager.Load` 后仍 block，避免重启 thrash。
- 管理端 weekly_limit=0% 反哺 runtime 调度门闩。

关联调查：`docs/plan/080-exhausted-credential-still-selected-20260724.md`（根仓）。

## Test plan
- [x] `go test ./sdk/cliproxy/auth/ ./internal/runtime/executor/ -count=1` (580)
- [x] `go test ./internal/management/aiaccountstatus/ -count=1` (45)
- [x] `go test ./sdk/cliproxy/... -count=1` (245)
- [x] race 定向 + `go vet` 相关包

## Risk / follow-up
- 同账号多 Auth.ID 状态传播、首失败并发过冲上限未做
- credential metadata 新增 `_cli_proxy_runtime_quota`（旧版本忽略未知字段）