### PR TITLE
feat(usage): track AI account cycle tokens

### DIFF
--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -874,6 +874,7 @@ func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 		RequestTotal      int64    `json:"request_total"`
 		CycleRequestTotal int64    `json:"cycle_request_total"`
 		CycleCostTotal    float64  `json:"cycle_cost_total"`
+		CycleTotalTokens  int64    `json:"cycle_total_tokens"`
 		WeeklyQuotaUsed   *float64 `json:"weekly_quota_used_percent"`
 		CycleStart        string   `json:"cycle_start"`
 		DailyUsage        []struct {
@@ -911,6 +912,9 @@ func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 	}
 	if math.Abs(payload.CycleCostTotal-0.008) > 1e-12 {
 		t.Fatalf("cycle_cost_total = %v, want 0.008", payload.CycleCostTotal)
+	}
+	if payload.CycleTotalTokens != 5000 {
+		t.Fatalf("cycle_total_tokens = %d, want 5000", payload.CycleTotalTokens)
 	}
 	if payload.WeeklyQuotaUsed == nil || math.Abs(*payload.WeeklyQuotaUsed-7) > 1e-12 {
 		t.Fatalf("weekly_quota_used_percent = %v, want 7", payload.WeeklyQuotaUsed)
@@ -1039,6 +1043,7 @@ func TestGetAuthFileTrendSharesCycleAcrossTenantsForStableAccountID(t *testing.T
 	var payload struct {
 		CycleRequestTotal int64    `json:"cycle_request_total"`
 		CycleCostTotal    float64  `json:"cycle_cost_total"`
+		CycleTotalTokens  int64    `json:"cycle_total_tokens"`
 		RequestTotal      int64    `json:"request_total"`
 		WeeklyQuotaUsed   *float64 `json:"weekly_quota_used_percent"`
 		CycleKnown        bool     `json:"cycle_known"`
@@ -1063,6 +1068,9 @@ func TestGetAuthFileTrendSharesCycleAcrossTenantsForStableAccountID(t *testing.T
 	}
 	if math.Abs(payload.CycleCostTotal-0.008) > 1e-12 {
 		t.Fatalf("tenant B cycle_cost_total=%v, want 0.008", payload.CycleCostTotal)
+	}
+	if payload.CycleTotalTokens != 5000 {
+		t.Fatalf("cycle_total_tokens = %d, want 5000", payload.CycleTotalTokens)
 	}
 	if payload.RequestTotal != 2 {
 		t.Fatalf("tenant B request_total=%d, want 2", payload.RequestTotal)
@@ -1175,6 +1183,7 @@ func TestGetAuthFileTrendKeepsWeeklyCycleAcrossCodexPlanRename(t *testing.T) {
 		RequestTotal      int64   `json:"request_total"`
 		CycleRequestTotal int64   `json:"cycle_request_total"`
 		CycleCostTotal    float64 `json:"cycle_cost_total"`
+		CycleTotalTokens  int64   `json:"cycle_total_tokens"`
 		CycleKnown        bool    `json:"cycle_known"`
 		CycleStart        string  `json:"cycle_start"`
 	}
@@ -1189,6 +1198,9 @@ func TestGetAuthFileTrendKeepsWeeklyCycleAcrossCodexPlanRename(t *testing.T) {
 	}
 	if math.Abs(payload.CycleCostTotal-0.008) > 1e-12 {
 		t.Fatalf("cycle_cost_total = %v, want 0.008", payload.CycleCostTotal)
+	}
+	if payload.CycleTotalTokens != 5000 {
+		t.Fatalf("cycle_total_tokens = %d, want 5000", payload.CycleTotalTokens)
 	}
 	if !payload.CycleKnown {
 		t.Fatalf("cycle_known = false, want true")

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -203,8 +203,10 @@ type runtimeDataStackMaintenanceOps struct {
 func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 	return runtimeDataStackMaintenanceOps{
 		runAIAccountSharedSubjectBackfill: func() error {
-			_, err := usage.RunAIAccountSharedSubjectBackfillAtInit()
-			return err
+			if _, err := usage.RunAIAccountSharedSubjectBackfillAtInit(); err != nil {
+				return err
+			}
+			return usage.RunAIAccountSubjectUsageTokensBackfillAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/management/aiaccountstatus/service_test.go
+++ b/internal/management/aiaccountstatus/service_test.go
@@ -876,8 +876,8 @@ func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
 	defer admin.Close()
 	if _, err := admin.Exec(`
 		INSERT INTO ai_account_subject_usage_buckets
-			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
-		VALUES (?, 'cycle', ?, 1, 1, 0, 1, ?, ?)
+			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at)
+		VALUES (?, 'cycle', ?, 1, 1, 0, 1, 456, ?, ?)
 	`, identity.ID, cycleStart.Format(time.RFC3339Nano), cycleStart.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
 		t.Fatal(err)
 	}
@@ -913,7 +913,7 @@ func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
 	if item.CurrentTenantBindingCount != 1 || item.AuthIndex != authB.EnsureIndex() {
 		t.Fatalf("tenant B binding projection=%+v", item)
 	}
-	if !item.Usage.CycleKnown || item.Usage.CycleRequestTotal != 1 {
+	if !item.Usage.CycleKnown || item.Usage.CycleRequestTotal != 1 || item.Usage.CycleTotalTokens != 456 {
 		t.Fatalf("binding repair changed shared cycle usage: %+v", item.Usage)
 	}
 }

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -72,9 +72,11 @@ func mergeAuthFileTrendShared(tenant, shared AuthFileTrendResponse) AuthFileTren
 	out := tenant
 	if shared.CycleRequestTotal > tenant.CycleRequestTotal ||
 		(shared.CycleRequestTotal == tenant.CycleRequestTotal && shared.CycleCostTotal > tenant.CycleCostTotal) ||
+		(shared.CycleRequestTotal == tenant.CycleRequestTotal && shared.CycleCostTotal == tenant.CycleCostTotal && shared.CycleTotalTokens > tenant.CycleTotalTokens) ||
 		(tenant.CycleRequestTotal == 0 && shared.RequestTotal > tenant.RequestTotal) {
 		out.CycleRequestTotal = shared.CycleRequestTotal
 		out.CycleCostTotal = shared.CycleCostTotal
+		out.CycleTotalTokens = shared.CycleTotalTokens
 		if shared.RequestTotal > tenant.RequestTotal {
 			out.RequestTotal = shared.RequestTotal
 		}
@@ -166,6 +168,7 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 	cycleKnown := !cycleStart.IsZero() || summary.CycleKnown
 	cycleRequestTotal := summary.CycleRequestTotal
 	cycleCostTotal := summary.CycleCostTotal
+	cycleTotalTokens := summary.CycleTotalTokens
 	cycleStartStr := ""
 	if !cycleStart.IsZero() {
 		cycleStartStr = cycleStart.UTC().Format(time.RFC3339)
@@ -180,6 +183,7 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 		RequestTotal:      requestTotal,
 		CycleRequestTotal: cycleRequestTotal,
 		CycleCostTotal:    cycleCostTotal,
+		CycleTotalTokens:  cycleTotalTokens,
 		WeeklyQuotaUsed:   weeklyQuotaUsed,
 		CycleKnown:        cycleKnown,
 		CycleStart:        cycleStartStr,
@@ -240,7 +244,7 @@ func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.A
 		}
 	}
 
-	var cycleRequestTotal int64
+	var cycleRequestTotal, cycleTotalTokens int64
 	var cycleCostTotal float64
 	cycleKnown := !cycleStart.IsZero()
 	if cycleKnown {
@@ -249,6 +253,10 @@ func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.A
 			return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 		}
 		cycleCostTotal, err = usage.QueryCostByAuthSubjectSinceForTenant(s.tenantID, matcher, cycleStart)
+		if err != nil {
+			return http.StatusInternalServerError, map[string]any{"error": err.Error()}
+		}
+		cycleTotalTokens, err = usage.QueryTotalTokensByAuthSubjectSinceForTenant(s.tenantID, matcher, cycleStart)
 		if err != nil {
 			return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 		}
@@ -265,6 +273,7 @@ func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.A
 		RequestTotal:      requestTotal,
 		CycleRequestTotal: cycleRequestTotal,
 		CycleCostTotal:    cycleCostTotal,
+		CycleTotalTokens:  cycleTotalTokens,
 		WeeklyQuotaUsed:   weeklyQuotaUsed,
 		CycleKnown:        cycleKnown,
 		CycleStart:        cycleStartStr,

--- a/internal/management/usagelogs/types.go
+++ b/internal/management/usagelogs/types.go
@@ -54,6 +54,7 @@ type AuthFileTrendResponse struct {
 	RequestTotal      int64                       `json:"request_total"`
 	CycleRequestTotal int64                       `json:"cycle_request_total"`
 	CycleCostTotal    float64                     `json:"cycle_cost_total"`
+	CycleTotalTokens  int64                       `json:"cycle_total_tokens"`
 	WeeklyQuotaUsed   *float64                    `json:"weekly_quota_used_percent"`
 	CycleKnown        bool                        `json:"cycle_known"`
 	CycleStart        string                      `json:"cycle_start"`

--- a/internal/storage/postgres/migration_upgrade_test.go
+++ b/internal/storage/postgres/migration_upgrade_test.go
@@ -139,6 +139,19 @@ func assertAIAccountSharedSubjectTables(t *testing.T, ctx context.Context, db *s
 			t.Fatalf("shared AI account table %s missing after upgrade", table)
 		}
 	}
+	var dataType string
+	if err := db.QueryRowContext(ctx, `
+		SELECT data_type
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name = 'ai_account_subject_usage_buckets'
+		  AND column_name = 'total_tokens'
+	`).Scan(&dataType); err != nil {
+		t.Fatalf("shared AI account total_tokens column missing after upgrade: %v", err)
+	}
+	if dataType != "bigint" {
+		t.Fatalf("shared AI account total_tokens data_type = %q, want bigint", dataType)
+	}
 }
 
 // publishedBaselineMigrations returns migrations up to and including

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -36,8 +36,14 @@ func RuntimeMigrations() []Migration {
 		// Append-only history of manual account-level daily spending resets.
 		{Version: "202607210001_end_user_daily_spending_reset_events", SQL: endUserDailySpendingResetEventsSQL},
 		{Version: "202607220001_period_spending_limits", SQL: periodSpendingLimitsSQL},
+		{Version: "202607240001_ai_account_subject_usage_tokens", SQL: aiAccountSubjectUsageTokensSQL},
 	}
 }
+
+const aiAccountSubjectUsageTokensSQL = `
+ALTER TABLE ai_account_subject_usage_buckets
+ADD COLUMN IF NOT EXISTS total_tokens BIGINT NOT NULL DEFAULT 0;
+`
 
 const periodSpendingLimitsSQL = `
 ALTER TABLE api_key_permission_profiles ADD COLUMN IF NOT EXISTS five_hour_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,10 +11,20 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 22 {
-		t.Fatalf("RuntimeMigrations len = %d, want 22", len(migrations))
+	if len(migrations) != 23 {
+		t.Fatalf("RuntimeMigrations len = %d, want 23", len(migrations))
 	}
-	// Latest: fixed period spending columns.
+	// Latest: shared AI-account cycle token projection.
+	if migrations[22].Version != "202607240001_ai_account_subject_usage_tokens" {
+		t.Fatalf("latest migration version = %q", migrations[22].Version)
+	}
+	tokenSQL := migrations[22].SQL
+	for _, fragment := range []string{"ALTER TABLE ai_account_subject_usage_buckets", "total_tokens BIGINT NOT NULL DEFAULT 0"} {
+		if !strings.Contains(tokenSQL, fragment) {
+			t.Fatalf("AI account subject token migration missing %q", fragment)
+		}
+	}
+	// Prior: fixed period spending columns.
 	periodSQL := migrations[21].SQL
 	for _, fragment := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
 		if !strings.Contains(periodSQL, fragment) {

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"database/sql"
 	"math"
 	"path/filepath"
 	"testing"
@@ -24,6 +25,63 @@ func initSharedSubjectTestDB(t *testing.T) {
 		t.Fatalf("InitDB: %v", err)
 	}
 	t.Cleanup(CloseDB)
+}
+
+func TestInitDBAddsTotalTokensToExistingSharedUsageBuckets(t *testing.T) {
+	CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE ai_account_subject_usage_buckets (
+			auth_subject_id TEXT NOT NULL,
+			bucket_kind TEXT NOT NULL,
+			bucket_start TEXT NOT NULL,
+			request_count INTEGER NOT NULL DEFAULT 0,
+			success_count INTEGER NOT NULL DEFAULT 0,
+			failure_count INTEGER NOT NULL DEFAULT 0,
+			cost_total REAL NOT NULL DEFAULT 0,
+			first_event_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (auth_subject_id, bucket_kind, bucket_start)
+		)
+	`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(CloseDB)
+
+	rows, err := getDB().Query(`PRAGMA table_info(ai_account_subject_usage_buckets)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatal(err)
+		}
+		if name == "total_tokens" {
+			found = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("total_tokens column missing after SQLite additive migration")
+	}
 }
 
 func sharedSubjectTestAuth(tenantID, authID, accountID, email string) *coreauth.Auth {
@@ -179,15 +237,15 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
 		}
 	}
-	InsertLogWithDetailsIdentitySubject(keyA, "", identity.ID, "A", "gpt-5.4", "codex", "A", authA.EnsureIndex(), false, now, 10, 1, TokenStats{TotalTokens: 1}, "", "", "")
-	InsertLogWithDetailsIdentitySubject(keyB, "", identity.ID, "B", "gpt-5.4", "codex", "B", authB.EnsureIndex(), true, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 1}, "", "", "")
+	InsertLogWithDetailsIdentitySubject(keyA, "", identity.ID, "A", "gpt-5.4", "codex", "A", authA.EnsureIndex(), false, now, 10, 1, TokenStats{TotalTokens: 111}, "", "", "")
+	InsertLogWithDetailsIdentitySubject(keyB, "", identity.ID, "B", "gpt-5.4", "codex", "B", authB.EnsureIndex(), true, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 222}, "", "", "")
 
-	var dayRows, dayRequests int64
-	if err := getDB().QueryRow(`SELECT COUNT(*), COALESCE(SUM(request_count), 0) FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? AND bucket_kind = 'day'`, identity.ID).Scan(&dayRows, &dayRequests); err != nil {
+	var dayRows, dayRequests, dayTokens int64
+	if err := getDB().QueryRow(`SELECT COUNT(*), COALESCE(SUM(request_count), 0), COALESCE(SUM(total_tokens), 0) FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? AND bucket_kind = 'day'`, identity.ID).Scan(&dayRows, &dayRequests, &dayTokens); err != nil {
 		t.Fatal(err)
 	}
-	if dayRows != 1 || dayRequests != 2 {
-		t.Fatalf("day projection rows=%d requests=%d", dayRows, dayRequests)
+	if dayRows != 1 || dayRequests != 2 || dayTokens != 333 {
+		t.Fatalf("day projection rows=%d requests=%d tokens=%d", dayRows, dayRequests, dayTokens)
 	}
 	var legacyRows int64
 	if err := getDB().QueryRow(`SELECT COUNT(*) FROM auth_subject_usage_daily WHERE auth_subject_id = ?`, identity.ID).Scan(&legacyRows); err != nil {
@@ -217,7 +275,7 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 		t.Fatal(err)
 	}
 	got := summaries[identity.ID]
-	if got.RequestTotal != 2 || got.SuccessTotal != 1 || got.FailureTotal != 1 || got.RequestTotal30d != 2 || got.CycleRequestTotal != 2 || !got.CycleKnown {
+	if got.RequestTotal != 2 || got.SuccessTotal != 1 || got.FailureTotal != 1 || got.RequestTotal30d != 2 || got.CycleRequestTotal != 2 || got.CycleTotalTokens != 333 || !got.CycleKnown {
 		t.Fatalf("shared usage=%+v", got)
 	}
 	if got.SuccessRate == nil || math.Abs(*got.SuccessRate-0.5) > 1e-9 {
@@ -246,7 +304,7 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 		t.Fatal(err)
 	}
 	clean := afterCleanup[identity.ID]
-	if clean.RequestTotal != got.RequestTotal || clean.SuccessTotal != got.SuccessTotal || clean.FailureTotal != got.FailureTotal || clean.CycleRequestTotal != got.CycleRequestTotal {
+	if clean.RequestTotal != got.RequestTotal || clean.SuccessTotal != got.SuccessTotal || clean.FailureTotal != got.FailureTotal || clean.CycleRequestTotal != got.CycleRequestTotal || clean.CycleTotalTokens != got.CycleTotalTokens {
 		t.Fatalf("shared usage reset after request_logs cleanup: before=%+v after=%+v", got, clean)
 	}
 }
@@ -406,12 +464,17 @@ func TestProjectAIAccountSubjectUsageLoadsPrimaryCycleOnCacheMiss(t *testing.T) 
 		t.Fatal(err)
 	}
 	resetAIAccountSubjectCycleCache()
+	primaryStart := primaryReset.Add(-7 * 24 * time.Hour)
 
 	tx, err := getDB().Begin()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 1.5, now); err != nil {
+	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 0.5, 111, primaryStart.Add(-time.Second)); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 1.5, 321, now); err != nil {
 		_ = tx.Rollback()
 		t.Fatal(err)
 	}
@@ -419,26 +482,121 @@ func TestProjectAIAccountSubjectUsageLoadsPrimaryCycleOnCacheMiss(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	primaryStart := primaryReset.Add(-7 * 24 * time.Hour)
 	var bucketStart string
-	var requests int64
+	var requests, totalTokens int64
 	if err := getDB().QueryRow(`
-		SELECT bucket_start, request_count
+		SELECT bucket_start, request_count, total_tokens
 		FROM ai_account_subject_usage_buckets
 		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
-	`, identity.ID).Scan(&bucketStart, &requests); err != nil {
+	`, identity.ID).Scan(&bucketStart, &requests, &totalTokens); err != nil {
 		t.Fatal(err)
 	}
-	if bucketStart != formatAIAccountSubjectCycleBucketStart(primaryStart) || requests != 1 {
-		t.Fatalf("cycle bucket start=%q requests=%d want %q/1", bucketStart, requests, formatAIAccountSubjectCycleBucketStart(primaryStart))
+	if bucketStart != formatAIAccountSubjectCycleBucketStart(primaryStart) || requests != 1 || totalTokens != 321 {
+		t.Fatalf("cycle bucket start=%q requests=%d tokens=%d want %q/1/321", bucketStart, requests, totalTokens, formatAIAccountSubjectCycleBucketStart(primaryStart))
 	}
 	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, map[string]time.Time{identity.ID: primaryStart})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := summaries[identity.ID]; !got.CycleKnown || got.CycleRequestTotal != 1 {
+	if got := summaries[identity.ID]; !got.CycleKnown || got.CycleRequestTotal != 1 || got.CycleTotalTokens != 321 {
 		t.Fatalf("cycle summary=%+v", got)
 	}
+}
+
+func TestAIAccountSubjectUsageTokensBackfillUsesRollupsAndExactCycle(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "token-backfill", "acct-token-backfill", "tokens@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	cycleStart := now.Add(-48 * time.Hour)
+	resetAt := cycleStart.Add(7 * 24 * time.Hour)
+	pct := 50.0
+	if err := RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "codex", QuotaKey: "code_week", QuotaLabel: "Week",
+		Percent: &pct, ResetAt: &resetAt, WindowSeconds: 604800,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	beforeCycle := cycleStart.Add(-time.Hour)
+	insideCycle := cycleStart.Add(time.Hour)
+	for _, event := range []struct {
+		at     time.Time
+		tokens int64
+	}{{beforeCycle, 100}, {insideCycle, 200}} {
+		tx, err := getDB().Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := projectUsageRollupTx(tx, rollupEvent{
+			TenantID: sharedSubjectTenantA, AuthSubjectID: identity.ID, At: event.at,
+			Tokens: TokenStats{TotalTokens: event.tokens},
+		}); err != nil {
+			_ = tx.Rollback()
+			t.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := getDB().Exec(`
+			INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, total_tokens)
+			VALUES (?, ?, ?, ?)
+		`, sharedSubjectTenantA, event.at.Format(time.RFC3339Nano), identity.ID, event.tokens); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	assertTotals := func(wantDay, wantLifetime, wantCycle int64) {
+		t.Helper()
+		var day, lifetime, cycle int64
+		if err := getDB().QueryRow(`
+			SELECT COALESCE(SUM(total_tokens), 0)
+			FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'day'
+		`, identity.ID).Scan(&day); err != nil {
+			t.Fatal(err)
+		}
+		if err := getDB().QueryRow(`
+			SELECT total_tokens
+			FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'lifetime' AND bucket_start = '1970-01-01'
+		`, identity.ID).Scan(&lifetime); err != nil {
+			t.Fatal(err)
+		}
+		if err := getDB().QueryRow(`
+			SELECT total_tokens
+			FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+		`, identity.ID, formatAIAccountSubjectCycleBucketStart(cycleStart)).Scan(&cycle); err != nil {
+			t.Fatal(err)
+		}
+		if day != wantDay || lifetime != wantLifetime || cycle != wantCycle {
+			t.Fatalf("backfilled tokens day=%d lifetime=%d cycle=%d want %d/%d/%d", day, lifetime, cycle, wantDay, wantLifetime, wantCycle)
+		}
+	}
+
+	if err := RunAIAccountSubjectUsageTokensBackfillAtInit(); err != nil {
+		t.Fatal(err)
+	}
+	assertTotals(300, 300, 200)
+	if got := projectionMarkerValue(getDB(), aiAccountSubjectUsageTokensBackfillMarker); got != rollupMarkerDone {
+		t.Fatalf("token backfill marker=%q want %q", got, rollupMarkerDone)
+	}
+
+	if _, err := getDB().Exec(`UPDATE ai_account_subject_usage_buckets SET total_tokens = 999 WHERE auth_subject_id = ?`, identity.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getDB().Exec(`DELETE FROM usage_projection_markers WHERE marker_key = ?`, aiAccountSubjectUsageTokensBackfillMarker); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunAIAccountSubjectUsageTokensBackfillAtInit(); err != nil {
+		t.Fatal(err)
+	}
+	assertTotals(300, 300, 200)
 }
 
 func TestAIAccountBindingHookTracksAuthLifecycle(t *testing.T) {

--- a/internal/usage/ai_account_status_store_test.go
+++ b/internal/usage/ai_account_status_store_test.go
@@ -320,7 +320,7 @@ func TestAIAccountSubjectDayProjectionUsesConfiguredTimezone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := projectAIAccountSubjectUsageTx(tx, "sub-timezone", false, 1.25, at); err != nil {
+	if err := projectAIAccountSubjectUsageTx(tx, "sub-timezone", false, 1.25, 123, at); err != nil {
 		_ = tx.Rollback()
 		t.Fatal(err)
 	}

--- a/internal/usage/ai_account_subject_store.go
+++ b/internal/usage/ai_account_subject_store.go
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS ai_account_subject_usage_buckets (
   success_count INTEGER NOT NULL DEFAULT 0,
   failure_count INTEGER NOT NULL DEFAULT 0,
   cost_total REAL NOT NULL DEFAULT 0,
+  total_tokens INTEGER NOT NULL DEFAULT 0,
   first_event_at DATETIME NOT NULL,
   updated_at DATETIME NOT NULL,
   PRIMARY KEY (auth_subject_id, bucket_kind, bucket_start)
@@ -195,6 +196,8 @@ func ensureAIAccountSharedSubjectTables(db *sql.DB) error {
 		if _, err := db.Exec(aiAccountSharedSubjectTablesSQL); err != nil {
 			return fmt.Errorf("usage: ensure ai account shared subject tables: %w", err)
 		}
+		// Additive migration for SQLite databases created before cycle token projection.
+		_, _ = db.Exec(`ALTER TABLE ai_account_subject_usage_buckets ADD COLUMN total_tokens INTEGER NOT NULL DEFAULT 0`)
 	}
 	ensureUsageProjectionMarkerTable(db)
 	if err := setProjectionMarker(db, aiAccountSharedSchemaMarker, "done"); err != nil {

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -146,7 +146,7 @@ func formatAIAccountSubjectCycleBucketStart(value time.Time) string {
 // projectAIAccountSubjectUsageTx is the request-hot B-layer projection. It only
 // uses the server-computed subject already captured by usageReporter; it never
 // reads or upserts the low-frequency tenant binding table.
-func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed bool, cost float64, at time.Time) error {
+func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed bool, cost float64, totalTokens int64, at time.Time) error {
 	if tx == nil {
 		return nil
 	}
@@ -181,18 +181,19 @@ func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed boo
 	const upsert = `
 		INSERT INTO ai_account_subject_usage_buckets (
 			auth_subject_id, bucket_kind, bucket_start, request_count,
-			success_count, failure_count, cost_total, first_event_at, updated_at
-		) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
 			request_count = ai_account_subject_usage_buckets.request_count + 1,
 			success_count = ai_account_subject_usage_buckets.success_count + excluded.success_count,
 			failure_count = ai_account_subject_usage_buckets.failure_count + excluded.failure_count,
 			cost_total = ai_account_subject_usage_buckets.cost_total + excluded.cost_total,
+			total_tokens = ai_account_subject_usage_buckets.total_tokens + excluded.total_tokens,
 			updated_at = excluded.updated_at
 	`
 	// The fixed day -> lifetime -> cycle order is shared by every writer.
 	for _, bucket := range buckets {
-		if _, err := tx.Exec(upsert, authSubjectID, bucket.kind, bucket.start, successInc, failureInc, cost, first, now); err != nil {
+		if _, err := tx.Exec(upsert, authSubjectID, bucket.kind, bucket.start, successInc, failureInc, cost, totalTokens, first, now); err != nil {
 			return fmt.Errorf("usage: project shared subject %s: %w", bucket.kind, err)
 		}
 	}
@@ -392,7 +393,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 		cycleArgs = append(cycleArgs, start)
 	}
 	cycleRows, err := db.Query(`
-		SELECT auth_subject_id, bucket_start, request_count, cost_total, updated_at
+		SELECT auth_subject_id, bucket_start, request_count, cost_total, total_tokens, updated_at
 		FROM ai_account_subject_usage_buckets
 		WHERE bucket_kind = 'cycle'
 		  AND auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(cycleIDs)), ",")+`)
@@ -403,10 +404,10 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 	}
 	for cycleRows.Next() {
 		var id, bucketStart string
-		var req int64
+		var req, totalTokens int64
 		var cost float64
 		var updated sql.NullString
-		if err := cycleRows.Scan(&id, &bucketStart, &req, &cost, &updated); err != nil {
+		if err := cycleRows.Scan(&id, &bucketStart, &req, &cost, &totalTokens, &updated); err != nil {
 			cycleRows.Close()
 			return nil, err
 		}
@@ -415,7 +416,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 			continue
 		}
 		s := out[id]
-		s.CycleRequestTotal, s.CycleCostTotal = req, cost
+		s.CycleRequestTotal, s.CycleCostTotal, s.CycleTotalTokens = req, cost, totalTokens
 		if t, ok := parseStoredTimeString(updated.String); ok && t.After(s.UpdatedAt) {
 			s.UpdatedAt = t
 		}

--- a/internal/usage/ai_account_subject_usage_tokens_backfill.go
+++ b/internal/usage/ai_account_subject_usage_tokens_backfill.go
@@ -1,0 +1,226 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const aiAccountSubjectUsageTokensBackfillMarker = "ai_account_subject_usage_tokens_backfill_v1"
+
+type aiAccountSubjectTokenBucket struct {
+	subjectID  string
+	kind       string
+	start      string
+	total      int64
+	firstEvent time.Time
+}
+
+// RunAIAccountSubjectUsageTokensBackfillAtInit fills the new token projection
+// from durable rollups and exact surviving cycle logs once per marker version.
+func RunAIAccountSubjectUsageTokensBackfillAtInit() error {
+	return runAIAccountSubjectUsageTokensBackfillAtInitDB(getDB())
+}
+
+func runAIAccountSubjectUsageTokensBackfillAtInitDB(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+
+	usageProjectionMu.Lock()
+	defer usageProjectionMu.Unlock()
+
+	ensureUsageProjectionMarkerTable(db)
+	if projectionMarkerValue(db, aiAccountSubjectUsageTokensBackfillMarker) == rollupMarkerDone {
+		return nil
+	}
+	if err := setProjectionMarker(db, aiAccountSubjectUsageTokensBackfillMarker, rollupMarkerPending); err != nil {
+		return fmt.Errorf("usage: mark shared subject token backfill pending: %w", err)
+	}
+
+	buckets, err := loadAIAccountSubjectDayAndLifetimeTokenBuckets(db)
+	if err != nil {
+		return err
+	}
+	cycleBuckets, err := loadAIAccountSubjectCycleTokenBuckets(db)
+	if err != nil {
+		return err
+	}
+	buckets = append(buckets, cycleBuckets...)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin shared subject token backfill: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UTC()
+	updatedAt := now.Format(time.RFC3339Nano)
+	const upsert = `
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?)
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			total_tokens = excluded.total_tokens,
+			updated_at = excluded.updated_at
+	`
+	for _, bucket := range buckets {
+		firstEvent := bucket.firstEvent
+		if firstEvent.IsZero() {
+			firstEvent = now
+		}
+		if _, err := tx.Exec(upsert, bucket.subjectID, bucket.kind, bucket.start, bucket.total, firstEvent.UTC().Format(time.RFC3339Nano), updatedAt); err != nil {
+			return fmt.Errorf("usage: backfill shared subject %s tokens: %w", bucket.kind, err)
+		}
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO UPDATE SET
+			marker_value = excluded.marker_value,
+			updated_at = excluded.updated_at
+	`, aiAccountSubjectUsageTokensBackfillMarker, rollupMarkerDone, updatedAt); err != nil {
+		return fmt.Errorf("usage: mark shared subject token backfill: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit shared subject token backfill: %w", err)
+	}
+	return nil
+}
+
+func loadAIAccountSubjectDayAndLifetimeTokenBuckets(db *sql.DB) ([]aiAccountSubjectTokenBucket, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, bucket_kind, bucket_start,
+			COALESCE(SUM(total_tokens), 0), MIN(updated_at)
+		FROM usage_rollup_buckets
+		WHERE bucket_kind IN ('day', 'lifetime')
+		  AND trim(coalesce(auth_subject_id, '')) <> ''
+		GROUP BY auth_subject_id, bucket_kind, bucket_start
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared subject token rollups: %w", err)
+	}
+	defer rows.Close()
+
+	buckets := make([]aiAccountSubjectTokenBucket, 0)
+	for rows.Next() {
+		var bucket aiAccountSubjectTokenBucket
+		var first storedTime
+		if err := rows.Scan(&bucket.subjectID, &bucket.kind, &bucket.start, &bucket.total, &first); err != nil {
+			return nil, fmt.Errorf("usage: scan shared subject token rollup: %w", err)
+		}
+		bucket.subjectID = strings.TrimSpace(bucket.subjectID)
+		if bucket.subjectID == "" {
+			continue
+		}
+		if first.Valid {
+			bucket.firstEvent = first.Time
+		}
+		buckets = append(buckets, bucket)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return buckets, nil
+}
+
+func loadAIAccountSubjectCycleTokenBuckets(db *sql.DB) ([]aiAccountSubjectTokenBucket, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE window_seconds >= ?
+		ORDER BY auth_subject_id, last_verified_at DESC, reset_at DESC
+	`, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared subject token cycles: %w", err)
+	}
+
+	bySubject := make(map[string][]AIAccountSubjectQuotaCycle)
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("usage: scan shared subject token cycle: %w", err)
+		}
+		cycle.AuthSubjectID = strings.TrimSpace(cycle.AuthSubjectID)
+		if cycle.AuthSubjectID == "" || !start.Valid || !reset.Valid {
+			continue
+		}
+		cycle.CycleStartAt = start.Time
+		cycle.ResetAt = reset.Time
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time
+		}
+		bySubject[cycle.AuthSubjectID] = append(bySubject[cycle.AuthSubjectID], cycle)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	selected := make(map[string]AIAccountSubjectQuotaCycle, len(bySubject))
+	var earliest time.Time
+	for subjectID, cycles := range bySubject {
+		cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles)
+		if !ok {
+			continue
+		}
+		selected[subjectID] = cycle
+		if earliest.IsZero() || cycle.CycleStartAt.Before(earliest) {
+			earliest = cycle.CycleStartAt
+		}
+	}
+	if len(selected) == 0 {
+		return []aiAccountSubjectTokenBucket{}, nil
+	}
+
+	totals := make(map[string]int64, len(selected))
+	firstEvents := make(map[string]time.Time, len(selected))
+	logRows, err := db.Query(`
+		SELECT auth_subject_id, timestamp, total_tokens
+		FROM request_logs
+		WHERE timestamp >= ?
+		  AND trim(coalesce(auth_subject_id, '')) <> ''
+	`, earliest.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared subject cycle tokens: %w", err)
+	}
+	defer logRows.Close()
+	for logRows.Next() {
+		var subjectID string
+		var at storedTime
+		var totalTokens int64
+		if err := logRows.Scan(&subjectID, &at, &totalTokens); err != nil {
+			return nil, fmt.Errorf("usage: scan shared subject cycle tokens: %w", err)
+		}
+		cycle, ok := selected[strings.TrimSpace(subjectID)]
+		if !ok || !at.Valid || at.Time.Before(cycle.CycleStartAt) {
+			continue
+		}
+		totals[cycle.AuthSubjectID] += totalTokens
+		if first := firstEvents[cycle.AuthSubjectID]; first.IsZero() || at.Time.Before(first) {
+			firstEvents[cycle.AuthSubjectID] = at.Time
+		}
+	}
+	if err := logRows.Close(); err != nil {
+		return nil, err
+	}
+
+	buckets := make([]aiAccountSubjectTokenBucket, 0, len(selected))
+	for subjectID, cycle := range selected {
+		firstEvent := firstEvents[subjectID]
+		if firstEvent.IsZero() {
+			firstEvent = cycle.CycleStartAt
+		}
+		buckets = append(buckets, aiAccountSubjectTokenBucket{
+			subjectID:  subjectID,
+			kind:       "cycle",
+			start:      formatAIAccountSubjectCycleBucketStart(cycle.CycleStartAt),
+			total:      totals[subjectID],
+			firstEvent: firstEvent,
+		})
+	}
+	return buckets, nil
+}

--- a/internal/usage/auth_subject_usage_daily.go
+++ b/internal/usage/auth_subject_usage_daily.go
@@ -25,6 +25,7 @@ type AuthSubjectUsageSummary struct {
 	FailureTotal30d   int64      `json:"failure_total_30d"`
 	CycleRequestTotal int64      `json:"cycle_request_total"`
 	CycleCostTotal    float64    `json:"cycle_cost_total"`
+	CycleTotalTokens  int64      `json:"cycle_total_tokens"`
 	CycleKnown        bool       `json:"cycle_known"`
 	CycleStart        string     `json:"cycle_start,omitempty"`
 	ProjectedSince    *time.Time `json:"projected_since,omitempty"`

--- a/internal/usage/auth_subject_usage_query.go
+++ b/internal/usage/auth_subject_usage_query.go
@@ -187,7 +187,15 @@ func QueryRequestCountByAuthSubjectSince(matcher AuthSubjectMatcher, since time.
 }
 
 func QueryRequestCountByAuthSubjectSinceForTenant(tenantID string, matcher AuthSubjectMatcher, since time.Time) (int64, error) {
-	return queryCountByAuthSubjectSince(tenantID, matcher, since, "COUNT(*)")
+	return queryInt64ByAuthSubjectSince(tenantID, matcher, since, "COUNT(*)", "count")
+}
+
+func QueryTotalTokensByAuthSubjectSince(matcher AuthSubjectMatcher, since time.Time) (int64, error) {
+	return QueryTotalTokensByAuthSubjectSinceForTenant(systemTenantID, matcher, since)
+}
+
+func QueryTotalTokensByAuthSubjectSinceForTenant(tenantID string, matcher AuthSubjectMatcher, since time.Time) (int64, error) {
+	return queryInt64ByAuthSubjectSince(tenantID, matcher, since, "COALESCE(SUM(total_tokens), 0)", "total tokens")
 }
 
 func QueryCostByAuthSubjectSince(matcher AuthSubjectMatcher, since time.Time) (float64, error) {
@@ -222,7 +230,7 @@ func QueryCostByAuthSubjectSinceForTenant(tenantID string, matcher AuthSubjectMa
 	return total, nil
 }
 
-func queryCountByAuthSubjectSince(tenantID string, matcher AuthSubjectMatcher, since time.Time, aggregate string) (int64, error) {
+func queryInt64ByAuthSubjectSince(tenantID string, matcher AuthSubjectMatcher, since time.Time, aggregate, label string) (int64, error) {
 	db := getReadDB()
 	if db == nil {
 		return 0, nil
@@ -244,7 +252,7 @@ func queryCountByAuthSubjectSince(tenantID string, matcher AuthSubjectMatcher, s
 		WHERE tenant_id = ? AND timestamp >= ? AND (%s)
 	`, aggregate, matchSQL), args...).Scan(&total)
 	if err != nil {
-		return 0, fmt.Errorf("usage: request count by auth subject query: %w", err)
+		return 0, fmt.Errorf("usage: request %s by auth subject query: %w", label, err)
 	}
 	return total, nil
 }

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -506,7 +506,7 @@ func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 		return err
 	}
 	if ev.AuthSubjectID != "" {
-		if err := projectAIAccountSubjectUsageTx(tx, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.At); err != nil {
+		if err := projectAIAccountSubjectUsageTx(tx, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.Tokens.TotalTokens, ev.At); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("project shared auth subject usage: %w", err)
 		}


### PR DESCRIPTION
## 改动
- 为 `ai_account_subject_usage_buckets` 增加 `total_tokens`，SQLite 使用 additive ALTER，Postgres 追加 `202607240001_ai_account_subject_usage_tokens` migration
- 请求日志事务内把 `TokenStats.TotalTokens` 投影到 day/lifetime/cycle bucket，并在 summary/status 暴露 `cycle_total_tokens`
- `/usage/auth-file-trend` 的 tenant-private、shared 与 merge 路径返回周期 Token
- 增加独立 `ai_account_subject_usage_tokens_backfill_v1` 回填：day/lifetime 来自 rollup，cycle 按精确 `cycle_start` 从 surviving request logs 聚合

## 验证
- `go test ./internal/usage ./internal/management/aiaccountstatus ./internal/api/handlers/management ./internal/storage/postgres -count=1`
- `./scripts/ci-pr.sh`
- `go vet ./internal/usage ./internal/management/aiaccountstatus ./internal/management/usagelogs ./internal/storage/postgres ./internal/cmd`

## 范围
- 未新增表
- 未增加 7d/30d token、token breakdown 或 trend token 点序列
- 未修改已发布 Postgres migration SQL