### PR TITLE
fix(codex): avoid stored item lookup 404 with store=false

### DIFF
--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -879,24 +879,34 @@ func maybeWrapSSEData(hadSSEPrefix bool, body []byte) []byte {
 // stripCodexHistoryDataURLImages removes multi-MB data:image payloads from request history
 // before upstream. Desktop keeps outbound data-url markdown for display, then re-sends it
 // on the next turn as text — that blows the model context (context_length_exceeded).
+func stripCodexHistoryDataURLImages(body []byte) []byte {
+	store := gjson.GetBytes(body, "store")
+	return stripCodexHistoryDataURLImagesForStore(body, store.Exists() && !store.Bool())
+}
+
+// stripCodexHistoryDataURLImagesForStore also strips server-issued history item IDs when
+// store is disabled. Those IDs otherwise make upstream attempt to resolve items that were
+// never persisted, while the remaining inline payload is sufficient for stateless replay.
 //
 // Strategy (no server storage / no global cache):
 //  1. Replace huge data URLs in history text with short cliproxy-image:N placeholders
 //  2. Re-attach at most the last extracted image as a structured input_image on the latest
 //     user turn so the model can re-identify / edit without keeping base64-as-text history
-//  3. All image bytes come from the current request body and die with the request
+//  3. With store=false, strip top-level item IDs and drop reference-only history shells
+//  4. All image bytes come from the current request body and die with the request
 //
 // Implementation rebuilds the input array once. Never call sjson.Set/Delete on the full
 // multi-MB body for each history item — that was the production RSS spike path.
-func stripCodexHistoryDataURLImages(body []byte) []byte {
+func stripCodexHistoryDataURLImagesForStore(body []byte, stripStoredItemIDs bool) []byte {
 	if len(body) == 0 {
 		return body
 	}
 	// Fast path: nothing to do when payload has neither markdown data URLs nor a large
-	// image_generation_call.result (Desktop usually only re-sends markdown data URLs).
+	// image_generation_call.result nor stored history item IDs.
 	hasDataURL := bytes.Contains(body, []byte("data:image/"))
 	hasIGResult := bytes.Contains(body, []byte(`"image_generation_call"`)) && bytes.Contains(body, []byte(`"result"`))
-	if !hasDataURL && !hasIGResult {
+	hasStoredItemID := stripStoredItemIDs && bytes.Contains(body, []byte(`"id"`))
+	if !hasDataURL && !hasIGResult && !hasStoredItemID {
 		return body
 	}
 	seq := 0
@@ -934,11 +944,18 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 	}
 	items := input.Array()
 	// Keep original raw strings for unchanged fragments; only allocate rewritten ones.
-	itemRaws := make([]string, len(items))
+	itemRaws := make([]string, 0, len(items))
 	changed := false
 	outLen := 2 // []
-	for itemIndex, item := range items {
-		itemRaws[itemIndex] = item.Raw
+	appendItem := func(raw string) {
+		if len(itemRaws) > 0 {
+			outLen++
+		}
+		itemRaws = append(itemRaws, raw)
+		outLen += len(raw)
+	}
+	for _, item := range items {
+		itemRaw := item.Raw
 		// Drop base64 from any re-sent image_generation_call history items; remember last.
 		if strings.TrimSpace(item.Get("type").String()) == "image_generation_call" {
 			if result := item.Get("result"); result.Exists() {
@@ -950,84 +967,72 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 						remember(fmt.Sprintf("data:%s;base64,%s", mime, resultStr))
 					}
 					if next, err := sjson.Delete(item.Raw, "result"); err == nil {
-						itemRaws[itemIndex] = next
+						itemRaw = next
 						changed = true
 					}
 				}
 			}
-			if itemIndex > 0 {
-				outLen++
-			}
-			outLen += len(itemRaws[itemIndex])
-			continue
-		}
-		if !hasDataURL {
-			if itemIndex > 0 {
-				outLen++
-			}
-			outLen += len(itemRaws[itemIndex])
-			continue
-		}
-		// message / content text fields
-		if content := item.Get("content"); content.Type == gjson.String {
-			if next, ok := replaceCodexDataURLImagesInText(content.String(), nextPlaceholder, remember); ok {
-				if rewritten, err := sjson.Set(item.Raw, "content", next); err == nil {
-					itemRaws[itemIndex] = rewritten
-					changed = true
+		} else if hasDataURL {
+			// message / content text fields
+			if content := item.Get("content"); content.Type == gjson.String {
+				if next, ok := replaceCodexDataURLImagesInText(content.String(), nextPlaceholder, remember); ok {
+					if rewritten, err := sjson.Set(itemRaw, "content", next); err == nil {
+						itemRaw = rewritten
+						changed = true
+					}
 				}
-			}
-			if itemIndex > 0 {
-				outLen++
-			}
-			outLen += len(itemRaws[itemIndex])
-			continue
-		}
-		if content := item.Get("content"); content.IsArray() {
-			parts := content.Array()
-			partRaws := make([]string, len(parts))
-			partChanged := false
-			partOutLen := 2
-			for partIndex, part := range parts {
-				partRaws[partIndex] = part.Raw
-				partType := strings.TrimSpace(part.Get("type").String())
-				// Only rewrite text parts. Do not touch structured input_image (user uploads /
-				// vision) — those are intentional pixels, not Desktop session replay of our
-				// outbound markdown data URLs.
-				if partType == "input_text" || partType == "output_text" || partType == "text" {
-					text := part.Get("text").String()
-					if next, ok := replaceCodexDataURLImagesInText(text, nextPlaceholder, remember); ok {
-						if rewritten, err := sjson.Set(part.Raw, "text", next); err == nil {
-							partRaws[partIndex] = rewritten
-							partChanged = true
+			} else if content.IsArray() {
+				parts := content.Array()
+				partRaws := make([]string, len(parts))
+				partChanged := false
+				partOutLen := 2
+				for partIndex, part := range parts {
+					partRaws[partIndex] = part.Raw
+					partType := strings.TrimSpace(part.Get("type").String())
+					// Only rewrite text parts. Do not touch structured input_image (user uploads /
+					// vision) — those are intentional pixels, not Desktop session replay of our
+					// outbound markdown data URLs.
+					if partType == "input_text" || partType == "output_text" || partType == "text" {
+						text := part.Get("text").String()
+						if next, ok := replaceCodexDataURLImagesInText(text, nextPlaceholder, remember); ok {
+							if rewritten, err := sjson.Set(part.Raw, "text", next); err == nil {
+								partRaws[partIndex] = rewritten
+								partChanged = true
+							}
 						}
 					}
-				}
-				if partIndex > 0 {
-					partOutLen++
-				}
-				partOutLen += len(partRaws[partIndex])
-			}
-			if partChanged {
-				var contentBuf bytes.Buffer
-				contentBuf.Grow(partOutLen)
-				contentBuf.WriteByte('[')
-				for i, p := range partRaws {
-					if i > 0 {
-						contentBuf.WriteByte(',')
+					if partIndex > 0 {
+						partOutLen++
 					}
-					contentBuf.WriteString(p)
+					partOutLen += len(partRaws[partIndex])
 				}
-				contentBuf.WriteByte(']')
-				if rewritten, err := sjson.SetRaw(item.Raw, "content", contentBuf.String()); err == nil {
-					itemRaws[itemIndex] = rewritten
-					changed = true
+				if partChanged {
+					var contentBuf bytes.Buffer
+					contentBuf.Grow(partOutLen)
+					contentBuf.WriteByte('[')
+					for i, p := range partRaws {
+						if i > 0 {
+							contentBuf.WriteByte(',')
+						}
+						contentBuf.WriteString(p)
+					}
+					contentBuf.WriteByte(']')
+					if rewritten, err := sjson.SetRaw(itemRaw, "content", contentBuf.String()); err == nil {
+						itemRaw = rewritten
+						changed = true
+					}
 				}
 			}
 		}
-		if itemIndex > 0 {
-			outLen++
+		if stripStoredItemIDs {
+			var itemChanged, drop bool
+			itemRaw, itemChanged, drop = stripCodexStoredHistoryItemReference(itemRaw)
+			changed = changed || itemChanged
+			if drop {
+				continue
+			}
 		}
-		outLen += len(itemRaws[itemIndex])
+		appendItem(itemRaw)
 	}
 
 	// Re-identify / edit: move last history image into structured input_image (not text tokens).

--- a/internal/runtime/executor/codex_image_generation_bridge_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_test.go
@@ -377,13 +377,32 @@ func TestSanitizeCodexResponsesRequestStripsHistoryDataURL(t *testing.T) {
 
 func TestStripCodexHistoryDataURLImagesDropsImageGenerationCallResult(t *testing.T) {
 	b64 := strings.Repeat("C", 400)
-	body := []byte(`{"input":[{"type":"image_generation_call","id":"ig_1","result":"` + b64 + `","status":"completed"}]}`)
+	body := []byte(`{"store":false,"input":[{"type":"image_generation_call","id":"ig_1","result":"` + b64 + `","status":"completed"}]}`)
 	out := stripCodexHistoryDataURLImages(body)
-	if gjson.GetBytes(out, "input.0.result").Exists() {
-		t.Fatalf("image_generation_call.result should be deleted; payload=%s", out)
+	for _, item := range gjson.GetBytes(out, "input").Array() {
+		if item.Get("result").Exists() {
+			t.Fatalf("image_generation_call.result should be deleted; payload=%s", out)
+		}
 	}
-	if got := gjson.GetBytes(out, "input.0.id").String(); got != "ig_1" {
-		t.Fatalf("id should remain, got %q", got)
+	if bytes.Contains(out, []byte(`"ig_1"`)) {
+		t.Fatalf("stored image_generation_call id should not be forwarded when store=false; payload=%s", out)
+	}
+	if got := gjson.GetBytes(out, "input.#").Int(); got != 0 {
+		t.Fatalf("image_generation_call without result should be dropped, got %d items; payload=%s", got, out)
+	}
+}
+
+func TestStripCodexHistoryDataURLImagesDropsImageGenerationCallReferenceOnlyItem(t *testing.T) {
+	body := []byte(`{"store":false,"input":[{"type":"image_generation_call","id":"ig_reference_only","status":"completed"},{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}]}`)
+	out := stripCodexHistoryDataURLImages(body)
+	if bytes.Contains(out, []byte(`"ig_reference_only"`)) {
+		t.Fatalf("reference-only image_generation_call should not be forwarded when store=false; payload=%s", out)
+	}
+	if got := gjson.GetBytes(out, "input.#").Int(); got != 1 {
+		t.Fatalf("input item count = %d, want 1; payload=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "input.0.content.0.text").String(); got != "continue" {
+		t.Fatalf("remaining user message changed: %q; payload=%s", got, out)
 	}
 }
 
@@ -391,14 +410,24 @@ func TestStripCodexHistoryDataURLImagesReattachesLastAsInputImage(t *testing.T) 
 	// Follow-up "描述一下" must still see pixels via structured input_image, not text base64.
 	b64 := strings.Repeat("D", 400)
 	body := []byte(`{
+		"store":false,
 		"model":"gpt-5.4",
 		"input":[
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"画小鱼"}]},
+			{"type":"image_generation_call","id":"ig_previous","result":"` + b64 + `","status":"completed","output_format":"png"},
 			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"好了\n\n![generated image](data:image/png;base64,` + b64 + `)"}]},
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"你画的是啥，详细描述"}]}
 		]
 	}`)
 	out := stripCodexHistoryDataURLImages(body)
+	if bytes.Contains(out, []byte(`"ig_previous"`)) {
+		t.Fatalf("stored image generation history should be removed; payload=%s", out)
+	}
+	for _, item := range gjson.GetBytes(out, "input").Array() {
+		if item.Get("result").Exists() {
+			t.Fatalf("stored image generation result should be removed; payload=%s", out)
+		}
+	}
 	asst := gjson.GetBytes(out, "input.1.content.0.text").String()
 	if strings.Contains(asst, "base64,") {
 		t.Fatalf("assistant text still has base64")

--- a/internal/runtime/executor/codex_responses.go
+++ b/internal/runtime/executor/codex_responses.go
@@ -29,8 +29,49 @@ func sanitizeCodexResponsesRequest(body []byte) []byte {
 	})
 	body = stripCodexResponsesImageGenerationSize(body)
 	// History hygiene: never forward multi-MB data:image blobs from Desktop session replay.
-	body = stripCodexHistoryDataURLImages(body)
+	// With store=false, also remove server item IDs so upstream treats retained history as
+	// inline content instead of looking up items that were never persisted.
+	store := gjson.GetBytes(body, "store")
+	body = stripCodexHistoryDataURLImagesForStore(body, store.Exists() && !store.Bool())
 	return body
+}
+
+func stripCodexStoredHistoryItemReference(itemRaw string) (string, bool, bool) {
+	item := gjson.Parse(itemRaw)
+	hadStoredID := strings.TrimSpace(item.Get("id").String()) != ""
+	changed := false
+	if hadStoredID {
+		if next, err := sjson.Delete(itemRaw, "id"); err == nil {
+			itemRaw = next
+			item = gjson.Parse(itemRaw)
+			changed = true
+		}
+	}
+
+	// Once result pixels are removed, an image_generation_call has no inline meaning and
+	// cannot be resolved by ID when store=false. The image is reattached to the latest user
+	// turn when it fits the existing size cap.
+	if strings.TrimSpace(item.Get("type").String()) == "image_generation_call" && strings.TrimSpace(item.Get("result").String()) == "" {
+		return "", true, true
+	}
+	if hadStoredID && codexHistoryItemIsReferenceOnly(item) {
+		return "", true, true
+	}
+	return itemRaw, changed, false
+}
+
+func codexHistoryItemIsReferenceOnly(item gjson.Result) bool {
+	referenceOnly := true
+	item.ForEach(func(key, _ gjson.Result) bool {
+		switch key.String() {
+		case "type", "status", "role", "name", "call_id":
+			return true
+		default:
+			referenceOnly = false
+			return false
+		}
+	})
+	return referenceOnly
 }
 
 func stripCodexResponsesImageGenerationSize(body []byte) []byte {

--- a/internal/runtime/executor/codex_responses_test.go
+++ b/internal/runtime/executor/codex_responses_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"net/http"
 	"strings"
 	"testing"
@@ -22,6 +23,46 @@ func TestSanitizeCodexResponsesRequestStripsUnsupportedTokenLimitFields(t *testi
 	}
 	if !gjson.GetBytes(got, "stream").Bool() {
 		t.Fatalf("stream should be preserved; payload=%s", got)
+	}
+}
+
+func TestSanitizeCodexResponsesRequestStripsStoredHistoryItemIDsWhenStoreFalse(t *testing.T) {
+	input := []byte(`{
+		"model":"gpt-5.4",
+		"store":false,
+		"input":[
+			{"type":"message","id":"msg_previous","role":"assistant","content":[{"type":"output_text","text":"done"}]},
+			{"type":"function_call","id":"fc_previous","call_id":"call_previous","name":"lookup","arguments":"{\"q\":\"x\"}","status":"completed"},
+			{"type":"reasoning","id":"rs_previous","encrypted_content":"encrypted","summary":[]}
+		]
+	}`)
+
+	got := sanitizeCodexResponsesRequest(input)
+	for _, id := range []string{"msg_previous", "fc_previous", "rs_previous"} {
+		if bytes.Contains(got, []byte(`"`+id+`"`)) {
+			t.Fatalf("stored item id %q should be stripped; payload=%s", id, got)
+		}
+	}
+	if text := gjson.GetBytes(got, "input.0.content.0.text").String(); text != "done" {
+		t.Fatalf("message content = %q, want done; payload=%s", text, got)
+	}
+	if callID := gjson.GetBytes(got, "input.1.call_id").String(); callID != "call_previous" {
+		t.Fatalf("function call_id = %q, want call_previous; payload=%s", callID, got)
+	}
+	if arguments := gjson.GetBytes(got, "input.1.arguments").String(); arguments != `{"q":"x"}` {
+		t.Fatalf("function arguments = %q; payload=%s", arguments, got)
+	}
+	if encrypted := gjson.GetBytes(got, "input.2.encrypted_content").String(); encrypted != "encrypted" {
+		t.Fatalf("reasoning encrypted_content = %q; payload=%s", encrypted, got)
+	}
+}
+
+func TestSanitizeCodexResponsesRequestKeepsStoredHistoryItemIDsWhenStoreTrue(t *testing.T) {
+	input := []byte(`{"store":true,"input":[{"type":"message","id":"msg_persisted","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}`)
+
+	got := sanitizeCodexResponsesRequest(input)
+	if id := gjson.GetBytes(got, "input.0.id").String(); id != "msg_persisted" {
+		t.Fatalf("stored item id = %q, want msg_persisted; payload=%s", id, got)
 	}
 }
 


### PR DESCRIPTION
## Root cause

Codex requests are sent with `store:false`, but Desktop multi-turn history can replay server-issued Responses item IDs such as `ig_...`. The existing image-history sanitizer removed `image_generation_call.result` while retaining the ID, leaving an item that upstream attempted to resolve from non-persisted storage and returned 404.

## Fix

- Detect the actual outbound `store:false` setting in the Responses sanitizer.
- Strip top-level server-issued `id` fields from retained `input` history items so their inline content is replayed statelessly.
- Drop reference-only history shells and `image_generation_call` items whose large `result` was removed.
- Preserve function `call_id`, arguments, reasoning encrypted content, existing data URL stripping, and last-image `input_image` reattachment.
- Keep `store:true` behavior unchanged.

## Tests

- `go test ./internal/runtime/executor/ -count=1 -run 'Codex|Sanitize|StripCodex|ImageGeneration'` — 129 passed
- `go test ./internal/translator/codex/... -count=1` — 35 passed
- `go test ./internal/runtime/executor/ -count=1` — 383 passed
