### PR TITLE
fix(usage): expand management user filter to owned API keys

### DIFF
--- a/internal/management/usagelogs/expand_api_key_filters.go
+++ b/internal/management/usagelogs/expand_api_key_filters.go
@@ -1,0 +1,52 @@
+package usagelogs
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+// expandManagementAPIKeyFilters expands account-representative secrets to every
+// owned key secret so management user filters match the aggregated counts.
+func expandManagementAPIKeyFilters(tenantID string, apiKeys []string) []string {
+	if len(apiKeys) == 0 {
+		return nil
+	}
+
+	expanded := make([]string, 0, len(apiKeys))
+	seen := make(map[string]struct{}, len(apiKeys))
+	appendKey := func(key string) {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		expanded = append(expanded, key)
+	}
+
+	for _, key := range apiKeys {
+		key = strings.TrimSpace(key)
+		if key == "__system__" {
+			appendKey(key)
+			continue
+		}
+		row := usage.GetAPIKeyForTenant(tenantID, key)
+		if row == nil || strings.TrimSpace(row.EndUserID) == "" {
+			appendKey(key)
+			continue
+		}
+
+		secrets := usage.ListAPIKeySecretsForEndUserForTenant(tenantID, row.EndUserID)
+		if len(secrets) == 0 {
+			appendKey(key)
+			continue
+		}
+		for _, secret := range secrets {
+			appendKey(secret)
+		}
+	}
+	return expanded
+}

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -136,50 +136,6 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	}, nil
 }
 
-// Management API-key facets represent end-user accounts, not individual owned keys.
-func expandManagementAPIKeyFilters(tenantID string, apiKeys []string) []string {
-	if len(apiKeys) == 0 {
-		return nil
-	}
-
-	expanded := make([]string, 0, len(apiKeys))
-	seen := make(map[string]struct{}, len(apiKeys))
-	appendKey := func(key string) {
-		key = strings.TrimSpace(key)
-		if key == "" {
-			return
-		}
-		if _, ok := seen[key]; ok {
-			return
-		}
-		seen[key] = struct{}{}
-		expanded = append(expanded, key)
-	}
-
-	for _, key := range apiKeys {
-		key = strings.TrimSpace(key)
-		if key == "__system__" {
-			appendKey(key)
-			continue
-		}
-		row := usage.GetAPIKeyForTenant(tenantID, key)
-		if row == nil || strings.TrimSpace(row.EndUserID) == "" {
-			appendKey(key)
-			continue
-		}
-
-		secrets := usage.ListAPIKeySecretsForEndUserForTenant(tenantID, row.EndUserID)
-		if len(secrets) == 0 {
-			appendKey(key)
-			continue
-		}
-		for _, secret := range secrets {
-			appendKey(secret)
-		}
-	}
-	return expanded
-}
-
 func (s *Service) ClearAllRequestLogs() (any, error) {
 	return usage.ClearAllRequestLogsForTenant(s.tenantID)
 }

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -17,6 +17,7 @@ import (
 
 func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any, error) {
 	maps := s.buildNameMaps()
+	apiKeys := expandManagementAPIKeyFilters(s.tenantID, input.APIKeys)
 	authSubjectIDs, authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(
 		input.Channels,
 		maps.channelNameMap,
@@ -34,7 +35,7 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 		Page:                  input.Page,
 		Size:                  input.Size,
 		Days:                  input.Days,
-		APIKeys:               input.APIKeys,
+		APIKeys:               apiKeys,
 		Models:                input.Models,
 		Statuses:              input.Statuses,
 		MatchNoAPIKeys:        input.MatchNoAPIKeys,
@@ -133,6 +134,50 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 		"filters": filters,
 		"stats":   stats,
 	}, nil
+}
+
+// Management API-key facets represent end-user accounts, not individual owned keys.
+func expandManagementAPIKeyFilters(tenantID string, apiKeys []string) []string {
+	if len(apiKeys) == 0 {
+		return nil
+	}
+
+	expanded := make([]string, 0, len(apiKeys))
+	seen := make(map[string]struct{}, len(apiKeys))
+	appendKey := func(key string) {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		expanded = append(expanded, key)
+	}
+
+	for _, key := range apiKeys {
+		key = strings.TrimSpace(key)
+		if key == "__system__" {
+			appendKey(key)
+			continue
+		}
+		row := usage.GetAPIKeyForTenant(tenantID, key)
+		if row == nil || strings.TrimSpace(row.EndUserID) == "" {
+			appendKey(key)
+			continue
+		}
+
+		secrets := usage.ListAPIKeySecretsForEndUserForTenant(tenantID, row.EndUserID)
+		if len(secrets) == 0 {
+			appendKey(key)
+			continue
+		}
+		for _, secret := range secrets {
+			appendKey(secret)
+		}
+	}
+	return expanded
 }
 
 func (s *Service) ClearAllRequestLogs() (any, error) {

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -3,14 +3,107 @@ package usagelogs
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
+
+func TestManagementLogsExpandsOwnedAPIKeyFilterIncludingSoftDeletedKeys(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	tenantID := "00000000-0000-0000-0000-0000000000ac"
+	endUserID := "00000000-0000-0000-0000-0000000000bd"
+	now := time.Now().UTC().Format(time.RFC3339)
+	rows := []usage.APIKeyRow{
+		{TenantID: tenantID, ID: "00000000-0000-0000-0000-0000000000a2", Key: "sk-owned-log-a", Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{TenantID: tenantID, ID: "00000000-0000-0000-0000-0000000000b2", Key: "sk-owned-log-b", Name: "Automation", EndUserID: endUserID, IsDefault: true, CreatedAt: now, UpdatedAt: now},
+		{TenantID: tenantID, ID: "00000000-0000-0000-0000-0000000000c2", Key: "sk-standalone", Name: "Standalone", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, row := range rows {
+		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
+		}
+	}
+
+	logTime := time.Now().UTC()
+	usage.InsertLog("sk-owned-log-a", "Laptop", "gpt-test", "test", "channel", "auth-owned", false, logTime, 1, 0, usage.TokenStats{TotalTokens: 1}, "", "")
+	usage.InsertLog("sk-owned-log-a", "Laptop", "gpt-test", "test", "channel", "auth-owned", false, logTime.Add(time.Second), 1, 0, usage.TokenStats{TotalTokens: 1}, "", "")
+	usage.InsertLog("sk-standalone", "Standalone", "gpt-test", "test", "channel", "auth-standalone", false, logTime, 1, 0, usage.TokenStats{TotalTokens: 1}, "", "")
+	if err := usage.DeleteAPIKeyByIDForTenant(tenantID, rows[0].ID); err != nil {
+		t.Fatalf("DeleteAPIKeyByIDForTenant(%s): %v", rows[0].ID, err)
+	}
+
+	expanded := expandManagementAPIKeyFilters(tenantID, []string{
+		" sk-owned-log-b ", "sk-owned-log-b", " __system__ ", "__system__",
+	})
+	hasTombstone := false
+	for _, key := range expanded {
+		if strings.HasPrefix(key, "sk-deleted-") {
+			hasTombstone = true
+			break
+		}
+	}
+	if len(expanded) != 3 || !hasTombstone ||
+		!slices.Contains(expanded, "sk-owned-log-b") || !slices.Contains(expanded, "__system__") {
+		t.Fatalf("expanded filters = %#v, want active, soft-deleted, and system selectors", expanded)
+	}
+
+	service := NewForTenant(tenantID, &config.Config{}, nil)
+	unfiltered, err := service.ManagementLogs(ManagementLogQueryInput{Days: 1, Page: 1, Size: 50})
+	if err != nil {
+		t.Fatalf("ManagementLogs(unfiltered): %v", err)
+	}
+	filters := unfiltered["filters"].(usage.FilterOptions)
+	if !slices.Contains(filters.APIKeys, "sk-owned-log-b") {
+		t.Fatalf("filters.APIKeys = %#v, want representative sk-owned-log-b", filters.APIKeys)
+	}
+	if filters.APIKeyCounts["sk-owned-log-b"] != 2 {
+		t.Fatalf("filters.APIKeyCounts[sk-owned-log-b] = %d, want 2 account requests", filters.APIKeyCounts["sk-owned-log-b"])
+	}
+
+	owned, err := service.ManagementLogs(ManagementLogQueryInput{
+		Days: 1, Page: 1, Size: 50, APIKeys: []string{"sk-owned-log-b"},
+	})
+	if err != nil {
+		t.Fatalf("ManagementLogs(owned representative): %v", err)
+	}
+	if total := owned["total"].(int64); total != 2 {
+		t.Fatalf("owned total = %d, want 2 account requests", total)
+	}
+	ownedItems := owned["items"].([]usage.LogRow)
+	if len(ownedItems) != 2 || ownedItems[0].APIKey != "sk-owned-log-a" || ownedItems[1].APIKey != "sk-owned-log-a" {
+		t.Fatalf("owned items = %#v, want two sk-owned-log-a requests", ownedItems)
+	}
+	if stats := owned["stats"].(usage.LogStats); stats.Total != 2 {
+		t.Fatalf("owned stats total = %d, want 2", stats.Total)
+	}
+
+	standalone, err := service.ManagementLogs(ManagementLogQueryInput{
+		Days: 1, Page: 1, Size: 50, APIKeys: []string{"sk-standalone"},
+	})
+	if err != nil {
+		t.Fatalf("ManagementLogs(standalone): %v", err)
+	}
+	if total := standalone["total"].(int64); total != 1 {
+		t.Fatalf("standalone total = %d, want 1", total)
+	}
+	standaloneItems := standalone["items"].([]usage.LogRow)
+	if len(standaloneItems) != 1 || standaloneItems[0].APIKey != "sk-standalone" {
+		t.Fatalf("standalone items = %#v, want only sk-standalone", standaloneItems)
+	}
+}
 
 func TestLooksLikeAuthIndex(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## 症状
管理面板请求日志的用户筛选项显示账号聚合计数，但选择该用户后列表可能返回 0 条。

## 根因
筛选选项按 end-user 账号折叠到代表 API key 并汇总全部 owned keys 的请求数，而 management 列表查询仍按代表 secret 做 key-scoped 匹配。

## 修复
- 仅在 management 请求日志列表路径，将选中的 owned key 展开为同一 end-user 下全部 API key secrets（包含保留的 soft-deleted key 行）。
- 保留独立 key 与 `__system__` 筛选语义，并对输入 trim/去重。
- 不修改 public/key-scoped 查询契约，也不修改 codeProxy。

## 测试
- `go test ./internal/usage/ -count=1 -run 'Filter|APIKey|Account|EndUser|QueryLogs|QueryFilters'`
- `go test ./internal/management/usagelogs/ ./internal/api/handlers/management/ -count=1 -run 'UsageLogs|APIKey|Filter'`
- `go test ./internal/usage/ ./internal/management/usagelogs/ ./internal/api/handlers/management/ -count=1`
