### PR TITLE
Release: merge dev into main for v0.4.16

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/bodyutil"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
@@ -198,6 +199,9 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		Repository: h.authFileRepository(),
 		RemoveChannels: func(channels []string) error {
 			return h.removeChannelReferencesForTenant(effectiveTenantID(c), channels)
+		},
+		RemoveAuthBindings: func(authIDs []string) error {
+			return h.deleteContentModerationBindings(ctx, effectiveTenantID(c), contentmoderation.ChannelTypeAuthFile, authIDs)
 		},
 	}
 	if managementauthfiles.IsDeleteAllValue(c.Query("all")) {

--- a/internal/api/handlers/management/auth_files_delete_test.go
+++ b/internal/api/handlers/management/auth_files_delete_test.go
@@ -2,14 +2,18 @@ package management
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -111,6 +115,22 @@ func TestDeleteAuthFileRemovesDeletedChannelReferences(t *testing.T) {
 		authManager: manager,
 		tokenStore:  store,
 	}
+	moderationStore := contentmoderation.NewStore(usage.RuntimeDB())
+	moderationProfile, err := contentmoderation.NewProfile(identity.SystemTenantID, "profile-auth-cleanup", contentmoderation.CreateProfileInput{Name: "auth cleanup"}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if err = moderationStore.CreateProfile(context.Background(), moderationProfile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	profileID := moderationProfile.ID
+	if err = moderationStore.PatchBindings(context.Background(), identity.SystemTenantID, false, []contentmoderation.BindingOperation{{
+		ChannelType: contentmoderation.ChannelTypeAuthFile,
+		ChannelID:   "kimi-a.json",
+		ProfileID:   &profileID,
+	}}); err != nil {
+		t.Fatalf("PatchBindings: %v", err)
+	}
 
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -126,6 +146,9 @@ func TestDeleteAuthFileRemovesDeletedChannelReferences(t *testing.T) {
 	}
 	if _, ok := manager.GetByID("kimi-b.json"); !ok {
 		t.Fatal("expected remaining auth to stay in manager")
+	}
+	if _, _, err = moderationStore.ResolveProfile(context.Background(), identity.SystemTenantID, "kimi-a.json", "", ""); !errors.Is(err, contentmoderation.ErrNotFound) {
+		t.Fatalf("ResolveProfile error=%v, want ErrNotFound", err)
 	}
 
 	profiles := usage.ListAPIKeyPermissionProfiles()

--- a/internal/api/handlers/management/content_moderation.go
+++ b/internal/api/handlers/management/content_moderation.go
@@ -42,6 +42,15 @@ func (h *Handler) deleteContentModerationBindings(ctx context.Context, tenantID,
 	return h.contentModerationStore().PatchBindings(ctx, tenantID, false, operations)
 }
 
+func (h *Handler) GetContentModerationMetrics(c *gin.Context) {
+	runtime := contentmoderation.Runtime()
+	if runtime == nil {
+		c.JSON(http.StatusOK, contentmoderation.ModerationMetrics{})
+		return
+	}
+	c.JSON(http.StatusOK, runtime.Metrics())
+}
+
 func (h *Handler) GetContentModerationProfiles(c *gin.Context) {
 	tenantID := effectiveTenantID(c)
 	profiles, err := h.contentModerationStore().ListProfiles(c.Request.Context(), tenantID)

--- a/internal/api/handlers/management/content_moderation.go
+++ b/internal/api/handlers/management/content_moderation.go
@@ -1,0 +1,267 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type contentModerationProfileResponse struct {
+	contentmoderation.Profile
+	APIKeyConfigured bool           `json:"api_key_configured"`
+	APIKeyMasked     string         `json:"api_key_masked,omitempty"`
+	BindingCounts    map[string]int `json:"binding_counts"`
+}
+
+func (h *Handler) contentModerationStore() *contentmoderation.Store {
+	return contentmoderation.NewStore(usage.RuntimeDB())
+}
+
+func (h *Handler) deleteContentModerationBindings(ctx context.Context, tenantID, channelType string, channelIDs []string) error {
+	if usage.RuntimeDB() == nil || len(channelIDs) == 0 {
+		return nil
+	}
+	operations := make([]contentmoderation.BindingOperation, 0, len(channelIDs))
+	for _, channelID := range channelIDs {
+		if channelID = strings.TrimSpace(channelID); channelID != "" {
+			operations = append(operations, contentmoderation.BindingOperation{ChannelType: channelType, ChannelID: channelID})
+		}
+	}
+	if len(operations) == 0 {
+		return nil
+	}
+	return h.contentModerationStore().PatchBindings(ctx, tenantID, false, operations)
+}
+
+func (h *Handler) GetContentModerationProfiles(c *gin.Context) {
+	tenantID := effectiveTenantID(c)
+	profiles, err := h.contentModerationStore().ListProfiles(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	counts, err := h.contentModerationStore().BindingCounts(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	items := make([]contentModerationProfileResponse, 0, len(profiles))
+	for _, profile := range profiles {
+		items = append(items, contentModerationProfileView(profile, counts[profile.ID]))
+	}
+	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+func (h *Handler) PostContentModerationProfile(c *gin.Context) {
+	var input contentmoderation.CreateProfileInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		contentModerationBadRequest(c, err.Error())
+		return
+	}
+	profile, err := contentmoderation.NewProfile(effectiveTenantID(c), uuid.NewString(), input, time.Now())
+	if err != nil {
+		contentModerationBadRequest(c, err.Error())
+		return
+	}
+	if err = h.contentModerationStore().CreateProfile(c.Request.Context(), profile); err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, contentModerationProfileView(profile, map[string]int{}))
+}
+
+func (h *Handler) GetContentModerationProfile(c *gin.Context) {
+	tenantID := effectiveTenantID(c)
+	profile, err := h.contentModerationStore().GetProfile(c.Request.Context(), tenantID, c.Param("id"))
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	counts, err := h.contentModerationStore().BindingCounts(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, contentModerationProfileView(profile, counts[profile.ID]))
+}
+
+func (h *Handler) PatchContentModerationProfile(c *gin.Context) {
+	var input contentmoderation.PatchProfileInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		contentModerationBadRequest(c, err.Error())
+		return
+	}
+	store := h.contentModerationStore()
+	profile, err := store.GetProfile(c.Request.Context(), effectiveTenantID(c), c.Param("id"))
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	updated, err := contentmoderation.ApplyProfilePatch(profile, input, time.Now())
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	if err = store.UpdateProfile(c.Request.Context(), updated, profile.Version); err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	counts, err := store.BindingCounts(c.Request.Context(), updated.TenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, contentModerationProfileView(updated, counts[updated.ID]))
+}
+
+func (h *Handler) DeleteContentModerationProfile(c *gin.Context) {
+	if err := h.contentModerationStore().DeleteProfile(c.Request.Context(), effectiveTenantID(c), c.Param("id")); err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) GetContentModerationChannels(c *gin.Context) {
+	tenantID := effectiveTenantID(c)
+	bindings, err := h.contentModerationStore().ListBindings(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	cfg := h.providerConfigForTenant(c)
+	var auths []*coreauth.Auth
+	if h.authManager != nil {
+		auths = h.authManager.ListForTenant(tenantID)
+	}
+	page, pageSize := queryPositiveInt(c, "page", 1), queryPositiveInt(c, "page_size", 20)
+	tags := splitQueryValues(c.Query("tags"))
+	result := contentmoderation.ListChannels(cfg, auths, bindings, contentmoderation.ChannelQuery{
+		ChannelType: c.Query("channel_type"),
+		Query:       c.Query("query"),
+		Tags:        tags,
+		TagMode:     c.Query("tag_mode"),
+		Provider:    c.Query("provider"),
+		ProfileID:   c.Query("profile_id"),
+		Page:        page,
+		PageSize:    pageSize,
+	})
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *Handler) PatchContentModerationChannelBindings(c *gin.Context) {
+	var body struct {
+		AllowRebind bool                                 `json:"allow_rebind"`
+		Operations  []contentmoderation.BindingOperation `json:"operations"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || len(body.Operations) == 0 {
+		contentModerationBadRequest(c, "operations are required")
+		return
+	}
+	tenantID := effectiveTenantID(c)
+	cfg := h.providerConfigForTenant(c)
+	var auths []*coreauth.Auth
+	if h.authManager != nil {
+		auths = h.authManager.ListForTenant(tenantID)
+	}
+	for _, operation := range body.Operations {
+		if operation.ProfileID == nil || strings.TrimSpace(*operation.ProfileID) == "" {
+			continue
+		}
+		if !contentmoderation.ChannelExists(cfg, auths, operation.ChannelType, operation.ChannelID) {
+			contentModerationBadRequest(c, "channel does not exist in the effective tenant")
+			return
+		}
+	}
+	store := h.contentModerationStore()
+	if err := store.PatchBindings(c.Request.Context(), tenantID, body.AllowRebind, body.Operations); err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	bindings, err := store.ListBindings(c.Request.Context(), tenantID)
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"bindings": bindings})
+}
+
+func contentModerationProfileView(profile contentmoderation.Profile, counts map[string]int) contentModerationProfileResponse {
+	if counts == nil {
+		counts = map[string]int{}
+	}
+	return contentModerationProfileResponse{
+		Profile:          profile,
+		APIKeyConfigured: strings.TrimSpace(profile.APIKeySecret) != "",
+		APIKeyMasked:     contentmoderation.MaskSecret(profile.APIKeySecret),
+		BindingCounts:    counts,
+	}
+}
+
+func contentModerationError(c *gin.Context, err error) {
+	status, code := http.StatusInternalServerError, "content_moderation_error"
+	extra := gin.H{}
+	switch {
+	case errors.Is(err, contentmoderation.ErrNotFound):
+		status, code = http.StatusNotFound, "content_moderation_not_found"
+	case errors.Is(err, contentmoderation.ErrNameConflict):
+		status, code = http.StatusConflict, "content_moderation_name_conflict"
+	case errors.Is(err, contentmoderation.ErrVersionConflict):
+		status, code = http.StatusConflict, "content_moderation_version_conflict"
+	case errors.Is(err, contentmoderation.ErrProfileBound):
+		status, code = http.StatusConflict, "content_moderation_profile_bound"
+		var bound *contentmoderation.ProfileBoundError
+		if errors.As(err, &bound) {
+			extra["binding_count"] = bound.Count
+		}
+	case errors.Is(err, contentmoderation.ErrBindingConflict):
+		status, code = http.StatusConflict, "content_moderation_binding_conflict"
+		var conflict *contentmoderation.BindingConflictError
+		if errors.As(err, &conflict) {
+			extra["channel_type"] = conflict.ChannelType
+			extra["channel_id"] = conflict.ChannelID
+			extra["existing_profile_id"] = conflict.ExistingProfileID
+		}
+	case errors.Is(err, contentmoderation.ErrInvalidChannel):
+		status, code = http.StatusBadRequest, "content_moderation_invalid_channel"
+	case errors.Is(err, contentmoderation.ErrUnavailable):
+		status, code = http.StatusServiceUnavailable, "content_moderation_unavailable"
+	}
+	payload := gin.H{"code": code, "message": err.Error()}
+	for key, value := range extra {
+		payload[key] = value
+	}
+	c.JSON(status, gin.H{"error": payload})
+}
+
+func contentModerationBadRequest(c *gin.Context, message string) {
+	c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "content_moderation_invalid_request", "message": message}})
+}
+
+func queryPositiveInt(c *gin.Context, key string, fallback int) int {
+	value, err := strconv.Atoi(strings.TrimSpace(c.Query(key)))
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+func splitQueryValues(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/internal/api/handlers/management/content_moderation.go
+++ b/internal/api/handlers/management/content_moderation.go
@@ -48,7 +48,8 @@ func (h *Handler) GetContentModerationMetrics(c *gin.Context) {
 		c.JSON(http.StatusOK, contentmoderation.ModerationMetrics{})
 		return
 	}
-	c.JSON(http.StatusOK, runtime.Metrics())
+	// Tenant-scoped only: never expose process-wide counters across tenants.
+	c.JSON(http.StatusOK, runtime.MetricsForTenant(effectiveTenantID(c)))
 }
 
 func (h *Handler) GetContentModerationProfiles(c *gin.Context) {

--- a/internal/api/handlers/management/content_moderation_test.go
+++ b/internal/api/handlers/management/content_moderation_test.go
@@ -77,6 +77,36 @@ func TestContentModerationProfileUsesPrincipalTenantAndHidesSecret(t *testing.T)
 	}
 }
 
+func TestContentModerationProfileTestEvaluatesDisabledProfile(t *testing.T) {
+	h, tenantID := setupContentModerationHandlerTest(t)
+	profile, err := contentmoderation.NewProfile(tenantID, "profile-disabled-test", contentmoderation.CreateProfileInput{
+		Name:            "disabled test",
+		Mode:            contentmoderation.ModeOff,
+		KeywordMode:     contentmoderation.KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"blocked"},
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if err = h.contentModerationStore().CreateProfile(context.Background(), profile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+
+	c, rec := moderationContext(tenantID, http.MethodPost, "/v0/management/content-moderation/profiles/"+profile.ID+"/test", `{"input":"contains BLOCKED text"}`)
+	c.Params = gin.Params{{Key: "id", Value: profile.ID}}
+	h.PostContentModerationProfileTest(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST test status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var decision contentmoderation.Decision
+	if err = json.Unmarshal(rec.Body.Bytes(), &decision); err != nil {
+		t.Fatalf("decode decision: %v", err)
+	}
+	if !decision.WouldBlock || decision.Action != contentmoderation.ActionKeywordBlock || decision.MatchedKeyword != "blocked" {
+		t.Fatalf("decision = %#v", decision)
+	}
+}
+
 func TestContentModerationChannelsArePagedAndSecretFree(t *testing.T) {
 	h, tenantID := setupContentModerationHandlerTest(t)
 	c, rec := moderationContext(tenantID, http.MethodGet, "/v0/management/content-moderation/channels?page=1&page_size=1", "")

--- a/internal/api/handlers/management/content_moderation_test.go
+++ b/internal/api/handlers/management/content_moderation_test.go
@@ -114,6 +114,84 @@ func TestContentModerationMetricsUseLiveRuntime(t *testing.T) {
 	}
 }
 
+func TestContentModerationMetricsAreTenantScoped(t *testing.T) {
+	const tenantA = "tenant-metrics-a"
+	const tenantB = "tenant-metrics-b"
+	profileA, err := contentmoderation.NewProfile(tenantA, "profile-a", contentmoderation.CreateProfileInput{
+		Name:        "a",
+		Mode:        contentmoderation.ModePreBlock,
+		KeywordMode: contentmoderation.KeywordModeKeywordOnly,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile A: %v", err)
+	}
+	profileB, err := contentmoderation.NewProfile(tenantB, "profile-b", contentmoderation.CreateProfileInput{
+		Name:        "b",
+		Mode:        contentmoderation.ModePreBlock,
+		KeywordMode: contentmoderation.KeywordModeKeywordOnly,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile B: %v", err)
+	}
+	runtime := contentmoderation.NewRequestModerator(tenantAwareMetricsResolver{
+		profiles: map[string]contentmoderation.Profile{
+			tenantA: profileA,
+			tenantB: profileB,
+		},
+	}, managementMetricsEvaluator{})
+	previous := contentmoderation.Runtime()
+	contentmoderation.SetRuntime(runtime)
+	t.Cleanup(func() { contentmoderation.SetRuntime(previous) })
+
+	body, _ := json.Marshal(map[string]any{"messages": []map[string]any{{"role": "user", "content": "safe"}}})
+	for i := 0; i < 3; i++ {
+		runtime.Moderate(context.Background(), &coreauth.Auth{
+			ID: "auth-a", TenantID: tenantA, Attributes: map[string]string{"provider_key_id": "key-a"},
+		}, cliproxyexecutor.Options{
+			OriginalRequest: body, SourceFormat: sdktranslator.FormatOpenAI,
+			Metadata: map[string]any{cliproxyexecutor.TenantMetadataKey: tenantA},
+		})
+	}
+	runtime.Moderate(context.Background(), &coreauth.Auth{
+		ID: "auth-b", TenantID: tenantB, Attributes: map[string]string{"provider_key_id": "key-b"},
+	}, cliproxyexecutor.Options{
+		OriginalRequest: body, SourceFormat: sdktranslator.FormatOpenAI,
+		Metadata: map[string]any{cliproxyexecutor.TenantMetadataKey: tenantB},
+	})
+
+	h := &Handler{}
+	cA, recA := moderationContext(tenantA, http.MethodGet, "/v0/management/content-moderation/metrics", "")
+	h.GetContentModerationMetrics(cA)
+	cB, recB := moderationContext(tenantB, http.MethodGet, "/v0/management/content-moderation/metrics", "")
+	h.GetContentModerationMetrics(cB)
+
+	var metricsA, metricsB contentmoderation.ModerationMetrics
+	if err := json.Unmarshal(recA.Body.Bytes(), &metricsA); err != nil {
+		t.Fatalf("decode A: %v", err)
+	}
+	if err := json.Unmarshal(recB.Body.Bytes(), &metricsB); err != nil {
+		t.Fatalf("decode B: %v", err)
+	}
+	if metricsA.Requests != 3 || metricsA.Allows != 3 {
+		t.Fatalf("tenant A metrics = %#v, want requests/allows=3", metricsA)
+	}
+	if metricsB.Requests != 1 || metricsB.Allows != 1 {
+		t.Fatalf("tenant B metrics = %#v, want requests/allows=1", metricsB)
+	}
+}
+
+type tenantAwareMetricsResolver struct {
+	profiles map[string]contentmoderation.Profile
+}
+
+func (r tenantAwareMetricsResolver) ResolveProfile(_ context.Context, tenantID, _, _, _ string) (contentmoderation.Profile, string, error) {
+	profile, ok := r.profiles[tenantID]
+	if !ok {
+		return contentmoderation.Profile{}, "", contentmoderation.ErrNotFound
+	}
+	return profile, contentmoderation.ChannelTypeProviderKey, nil
+}
+
 func TestContentModerationProfileUsesPrincipalTenantAndHidesSecret(t *testing.T) {
 	h, tenantID := setupContentModerationHandlerTest(t)
 	body := `{"tenant_id":"attacker-tenant","name":"primary","mode":"pre_block","keyword_mode":"api_only","api_key":"moderation-secret"}`

--- a/internal/api/handlers/management/content_moderation_test.go
+++ b/internal/api/handlers/management/content_moderation_test.go
@@ -1,0 +1,126 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func setupContentModerationHandlerTest(t *testing.T) (*Handler, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	usage.CloseDB()
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+	const tenantID = "00000000-0000-0000-0000-0000000000ab"
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "auth-file-1",
+		TenantID: tenantID,
+		FileName: "auth-file-1.json",
+		Provider: "codex",
+		Label:    "Codex Account",
+		Status:   coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	cfg := &config.Config{GeminiKey: []config.GeminiKey{{ID: "11111111-1111-4111-8111-111111111111", Name: "Gemini Provider", APIKey: "provider-secret"}}}
+	if err := usage.UpsertRuntimeSettingForTenant(tenantID, usage.RuntimeSettingGeminiKeys, cfg.GeminiKey); err != nil {
+		t.Fatalf("persist tenant provider: %v", err)
+	}
+	return &Handler{cfg: cfg, authManager: manager}, tenantID
+}
+
+func moderationContext(tenantID, method, path, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set(managementPrincipalKey, identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}})
+	c.Request = httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	return c, rec
+}
+
+func TestContentModerationProfileUsesPrincipalTenantAndHidesSecret(t *testing.T) {
+	h, tenantID := setupContentModerationHandlerTest(t)
+	body := `{"tenant_id":"attacker-tenant","name":"primary","mode":"pre_block","keyword_mode":"api_only","api_key":"moderation-secret"}`
+	c, rec := moderationContext(tenantID, http.MethodPost, "/v0/management/content-moderation/profiles", body)
+	h.PostContentModerationProfile(c)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "moderation-secret") || strings.Contains(rec.Body.String(), "attacker-tenant") {
+		t.Fatalf("response leaked secret/body tenant: %s", rec.Body.String())
+	}
+	profiles, err := h.contentModerationStore().ListProfiles(context.Background(), tenantID)
+	if err != nil || len(profiles) != 1 || profiles[0].TenantID != tenantID {
+		t.Fatalf("stored profiles = %#v err=%v", profiles, err)
+	}
+	other, err := h.contentModerationStore().ListProfiles(context.Background(), "attacker-tenant")
+	if err != nil || len(other) != 0 {
+		t.Fatalf("attacker tenant profiles = %#v err=%v", other, err)
+	}
+}
+
+func TestContentModerationChannelsArePagedAndSecretFree(t *testing.T) {
+	h, tenantID := setupContentModerationHandlerTest(t)
+	c, rec := moderationContext(tenantID, http.MethodGet, "/v0/management/content-moderation/channels?page=1&page_size=1", "")
+	h.GetContentModerationChannels(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET channels status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "provider-secret") {
+		t.Fatalf("channel response leaked provider secret: %s", rec.Body.String())
+	}
+	var page contentmoderation.ChannelPage
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if page.PageSize != 1 || len(page.Items) != 1 || page.Total != 2 {
+		t.Fatalf("page = %#v", page)
+	}
+}
+
+func TestProviderDeleteRemovesContentModerationBindings(t *testing.T) {
+	h, tenantID := setupContentModerationHandlerTest(t)
+	store := h.contentModerationStore()
+	profile, err := contentmoderation.NewProfile(tenantID, "profile-provider-cleanup", contentmoderation.CreateProfileInput{Name: "provider cleanup"}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if err = store.CreateProfile(context.Background(), profile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	profileID := profile.ID
+	if err = store.PatchBindings(context.Background(), tenantID, false, []contentmoderation.BindingOperation{{
+		ChannelType: contentmoderation.ChannelTypeProviderKey,
+		ChannelID:   "11111111-1111-4111-8111-111111111111",
+		ProfileID:   &profileID,
+	}}); err != nil {
+		t.Fatalf("PatchBindings: %v", err)
+	}
+
+	c, rec := moderationContext(tenantID, http.MethodDelete, "/v0/management/gemini-api-key?index=0", "")
+	h.ProviderKeys().DeleteGeminiKey(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE provider status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, _, err = store.ResolveProfile(context.Background(), tenantID, "", "11111111-1111-4111-8111-111111111111", ""); !errors.Is(err, contentmoderation.ErrNotFound) {
+		t.Fatalf("ResolveProfile error=%v, want ErrNotFound", err)
+	}
+}

--- a/internal/api/handlers/management/content_moderation_test.go
+++ b/internal/api/handlers/management/content_moderation_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 )
 
 func setupContentModerationHandlerTest(t *testing.T) (*Handler, string) {
@@ -54,6 +56,62 @@ func moderationContext(tenantID, method, path, body string) (*gin.Context, *http
 	c.Request = httptest.NewRequest(method, path, bytes.NewBufferString(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 	return c, rec
+}
+
+type managementMetricsResolver struct {
+	profile contentmoderation.Profile
+}
+
+func (r managementMetricsResolver) ResolveProfile(context.Context, string, string, string, string) (contentmoderation.Profile, string, error) {
+	return r.profile, contentmoderation.ChannelTypeProviderKey, nil
+}
+
+type managementMetricsEvaluator struct{}
+
+func (managementMetricsEvaluator) Evaluate(context.Context, contentmoderation.Profile, string) contentmoderation.Decision {
+	return contentmoderation.Decision{Action: contentmoderation.ActionAllow}
+}
+
+func TestContentModerationMetricsUseLiveRuntime(t *testing.T) {
+	const tenantID = "tenant-metrics"
+	profile, err := contentmoderation.NewProfile(tenantID, "profile-metrics", contentmoderation.CreateProfileInput{
+		Name:        "metrics",
+		Mode:        contentmoderation.ModePreBlock,
+		KeywordMode: contentmoderation.KeywordModeKeywordOnly,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	runtime := contentmoderation.NewRequestModerator(managementMetricsResolver{profile: profile}, managementMetricsEvaluator{})
+	previous := contentmoderation.Runtime()
+	contentmoderation.SetRuntime(runtime)
+	t.Cleanup(func() { contentmoderation.SetRuntime(previous) })
+	body, _ := json.Marshal(map[string]any{"messages": []map[string]any{{"role": "user", "content": "safe"}}})
+	runtime.Moderate(context.Background(), &coreauth.Auth{
+		ID:       "auth-metrics",
+		TenantID: tenantID,
+		Attributes: map[string]string{
+			"provider_key_id": "provider-key-metrics",
+		},
+	}, cliproxyexecutor.Options{
+		OriginalRequest: body,
+		SourceFormat:    sdktranslator.FormatOpenAI,
+		Metadata:        map[string]any{cliproxyexecutor.TenantMetadataKey: tenantID},
+	})
+
+	h := &Handler{}
+	c, rec := moderationContext(tenantID, http.MethodGet, "/v0/management/content-moderation/metrics", "")
+	h.GetContentModerationMetrics(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET metrics status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var metrics contentmoderation.ModerationMetrics
+	if err = json.Unmarshal(rec.Body.Bytes(), &metrics); err != nil {
+		t.Fatalf("decode metrics: %v", err)
+	}
+	if metrics.Requests != 1 || metrics.Allows != 1 {
+		t.Fatalf("metrics = %#v", metrics)
+	}
 }
 
 func TestContentModerationProfileUsesPrincipalTenantAndHidesSecret(t *testing.T) {

--- a/internal/api/handlers/management/content_moderation_test_endpoint.go
+++ b/internal/api/handlers/management/content_moderation_test_endpoint.go
@@ -21,6 +21,8 @@ func (h *Handler) PostContentModerationProfileTest(c *gin.Context) {
 		contentModerationError(c, err)
 		return
 	}
+	// Dry-run evaluates the saved configuration without enabling it for live traffic.
+	profile.Mode = contentmoderation.ModePreBlock
 	decision := contentmoderation.NewEvaluator(nil).Evaluate(c.Request.Context(), profile, body.Input)
 	c.JSON(http.StatusOK, decision)
 }

--- a/internal/api/handlers/management/content_moderation_test_endpoint.go
+++ b/internal/api/handlers/management/content_moderation_test_endpoint.go
@@ -1,0 +1,26 @@
+package management
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+)
+
+func (h *Handler) PostContentModerationProfileTest(c *gin.Context) {
+	var body struct {
+		Input string `json:"input"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || strings.TrimSpace(body.Input) == "" {
+		contentModerationBadRequest(c, "input is required")
+		return
+	}
+	profile, err := h.contentModerationStore().GetProfile(c.Request.Context(), effectiveTenantID(c), c.Param("id"))
+	if err != nil {
+		contentModerationError(c, err)
+		return
+	}
+	decision := contentmoderation.NewEvaluator(nil).Evaluate(c.Request.Context(), profile, body.Input)
+	c.JSON(http.StatusOK, decision)
+}

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -589,6 +589,7 @@ func isTenantScopedManagementPath(path string) bool {
 	case relative == "/dashboard-summary", relative == "/config":
 		return true
 	case strings.HasPrefix(relative, "/auth-files"),
+		strings.HasPrefix(relative, "/content-moderation"),
 		strings.HasPrefix(relative, "/identity-fingerprint"),
 		strings.HasPrefix(relative, "/model-definitions/"),
 		strings.HasPrefix(relative, "/image-generation"),

--- a/internal/api/handlers/management/image_generation.go
+++ b/internal/api/handlers/management/image_generation.go
@@ -266,8 +266,9 @@ func (h *Handler) executeImageGenerationTestForTenant(ctx context.Context, tenan
 			Payload: execPayload,
 			Format:  sdktranslator.FromString("openai"),
 		}, coreexecutor.Options{
-			Alt:          alt,
-			SourceFormat: sdktranslator.FromString("openai"),
+			Alt:             alt,
+			OriginalRequest: payload,
+			SourceFormat:    sdktranslator.FromString("openai"),
 			Metadata: map[string]any{
 				coreexecutor.SinglePickMetadataKey: true,
 				coreexecutor.TenantMetadataKey:     coreauth.NormalizedTenantID(tenantID),

--- a/internal/api/handlers/management/image_generation_test.go
+++ b/internal/api/handlers/management/image_generation_test.go
@@ -21,13 +21,14 @@ import (
 )
 
 type managementImageExecutor struct {
-	alt      string
-	model    string
-	payload  string
-	payloads []string
-	metadata map[string]any
-	calls    int
-	err      error
+	alt             string
+	model           string
+	payload         string
+	payloads        []string
+	originalRequest string
+	metadata        map[string]any
+	calls           int
+	err             error
 }
 
 type managementUpstreamStatusError struct {
@@ -50,6 +51,7 @@ func (e *managementImageExecutor) Execute(ctx context.Context, auth *coreauth.Au
 	e.model = req.Model
 	e.payload = string(req.Payload)
 	e.payloads = append(e.payloads, e.payload)
+	e.originalRequest = string(opts.OriginalRequest)
 	e.metadata = opts.Metadata
 	if e.err != nil {
 		return coreexecutor.Response{}, e.err
@@ -224,6 +226,9 @@ func TestPostImageGenerationTestExecutesCodexImageAlt(t *testing.T) {
 	}
 	if executor.metadata[coreexecutor.SinglePickMetadataKey] != true {
 		t.Fatalf("single-pick metadata = %#v, want true", executor.metadata[coreexecutor.SinglePickMetadataKey])
+	}
+	if executor.originalRequest != `{"model":"gpt-image-2","prompt":"test prompt"}` {
+		t.Fatalf("original request = %q, want image request payload", executor.originalRequest)
 	}
 }
 

--- a/internal/api/handlers/management/provider_content_moderation_bindings.go
+++ b/internal/api/handlers/management/provider_content_moderation_bindings.go
@@ -1,0 +1,52 @@
+package management
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
+)
+
+const providerModerationBindingSnapshotKey = "management.provider_moderation_binding_snapshot"
+
+func captureProviderModerationBindingSnapshot(c *gin.Context, cfg *config.Config) {
+	if c == nil {
+		return
+	}
+	if _, exists := c.Get(providerModerationBindingSnapshotKey); exists {
+		return
+	}
+	refs := contentmoderation.ProviderChannelRefs(cfg)
+	c.Set(providerModerationBindingSnapshotKey, refs)
+}
+
+func (h *Handler) cleanupRemovedProviderModerationBindings(ctx context.Context, c *gin.Context, tenantID string, cfg *config.Config) error {
+	if c == nil {
+		return nil
+	}
+	value, exists := c.Get(providerModerationBindingSnapshotKey)
+	if !exists {
+		return nil
+	}
+	before, ok := value.([]contentmoderation.ChannelRef)
+	if !ok || len(before) == 0 {
+		return nil
+	}
+	after := make(map[string]struct{})
+	for _, ref := range contentmoderation.ProviderChannelRefs(cfg) {
+		after[ref.ChannelType+"\x00"+ref.ChannelID] = struct{}{}
+	}
+	byType := make(map[string][]string)
+	for _, ref := range before {
+		if _, exists := after[ref.ChannelType+"\x00"+ref.ChannelID]; !exists {
+			byType[ref.ChannelType] = append(byType[ref.ChannelType], ref.ChannelID)
+		}
+	}
+	for channelType, ids := range byType {
+		if err := h.deleteContentModerationBindings(ctx, tenantID, channelType, ids); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/api/handlers/management/provider_settings.go
+++ b/internal/api/handlers/management/provider_settings.go
@@ -35,6 +35,7 @@ func providerSettingsService(h *ProviderKeysHandler, c *gin.Context) *providerse
 		return providersettings.NewService(nil, nil)
 	}
 	cfg := h.providerConfigForTenant(c)
+	captureProviderModerationBindingSnapshot(c, cfg)
 	tenantID := effectiveTenantID(c)
 	return providersettings.NewService(cfg, func() error {
 		var auths []*coreauth.Auth
@@ -67,10 +68,26 @@ func (h *Handler) providerConfigForTenant(c *gin.Context) *config.Config {
 
 func (h *ProviderKeysHandler) persistProviderSettings(c *gin.Context) bool {
 	tenantID := effectiveTenantID(c)
-	if tenantID == identity.SystemTenantID {
-		return h.persist(c)
-	}
 	cfg := h.providerConfigForTenant(c)
+	if tenantID == identity.SystemTenantID {
+		h.mu.Lock()
+		err := settingsstore.SaveConfig(h.cfg, h.configFilePath)
+		mutated := h.onConfigMutated
+		h.mu.Unlock()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save config: %v", err)})
+			return false
+		}
+		payload := gin.H{"status": "ok"}
+		if errCleanup := h.cleanupRemovedProviderModerationBindings(c.Request.Context(), c, tenantID, cfg); errCleanup != nil {
+			payload["warning"] = fmt.Sprintf("provider saved but content moderation binding cleanup failed: %v", errCleanup)
+		}
+		c.JSON(http.StatusOK, payload)
+		if mutated != nil {
+			mutated(h.cfg)
+		}
+		return true
+	}
 	key, value := providerRuntimeSetting(c.Request.URL.Path, cfg)
 	if key == "" {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "unsupported provider setting"})
@@ -83,7 +100,11 @@ func (h *ProviderKeysHandler) persistProviderSettings(c *gin.Context) bool {
 	if h.authManager != nil {
 		serviceapp.SyncConfigDerivedAuthsForTenant(h.cfg, h.authManager, tenantID)
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	payload := gin.H{"status": "ok"}
+	if errCleanup := h.cleanupRemovedProviderModerationBindings(c.Request.Context(), c, tenantID, cfg); errCleanup != nil {
+		payload["warning"] = fmt.Sprintf("provider saved but content moderation binding cleanup failed: %v", errCleanup)
+	}
+	c.JSON(http.StatusOK, payload)
 	return true
 }
 

--- a/internal/api/handlers/management/route_permissions.go
+++ b/internal/api/handlers/management/route_permissions.go
@@ -157,6 +157,14 @@ func permissionForManagementRequest(method, path string) string {
 			return "models.write"
 		}
 		return "models.read"
+	case strings.HasPrefix(relative, "/content-moderation"):
+		if strings.HasSuffix(relative, "/test") {
+			return "content_moderation.test"
+		}
+		if write {
+			return "content_moderation.write"
+		}
+		return "content_moderation.read"
 	case strings.HasPrefix(relative, "/image-generation"):
 		if strings.Contains(relative, "/test") {
 			return "image_generation.test"

--- a/internal/api/handlers/management/usage_logs_handler_test.go
+++ b/internal/api/handlers/management/usage_logs_handler_test.go
@@ -874,6 +874,7 @@ func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 		RequestTotal      int64    `json:"request_total"`
 		CycleRequestTotal int64    `json:"cycle_request_total"`
 		CycleCostTotal    float64  `json:"cycle_cost_total"`
+		CycleTotalTokens  int64    `json:"cycle_total_tokens"`
 		WeeklyQuotaUsed   *float64 `json:"weekly_quota_used_percent"`
 		CycleStart        string   `json:"cycle_start"`
 		DailyUsage        []struct {
@@ -911,6 +912,9 @@ func TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal(t *testing.T) {
 	}
 	if math.Abs(payload.CycleCostTotal-0.008) > 1e-12 {
 		t.Fatalf("cycle_cost_total = %v, want 0.008", payload.CycleCostTotal)
+	}
+	if payload.CycleTotalTokens != 5000 {
+		t.Fatalf("cycle_total_tokens = %d, want 5000", payload.CycleTotalTokens)
 	}
 	if payload.WeeklyQuotaUsed == nil || math.Abs(*payload.WeeklyQuotaUsed-7) > 1e-12 {
 		t.Fatalf("weekly_quota_used_percent = %v, want 7", payload.WeeklyQuotaUsed)
@@ -1039,6 +1043,7 @@ func TestGetAuthFileTrendSharesCycleAcrossTenantsForStableAccountID(t *testing.T
 	var payload struct {
 		CycleRequestTotal int64    `json:"cycle_request_total"`
 		CycleCostTotal    float64  `json:"cycle_cost_total"`
+		CycleTotalTokens  int64    `json:"cycle_total_tokens"`
 		RequestTotal      int64    `json:"request_total"`
 		WeeklyQuotaUsed   *float64 `json:"weekly_quota_used_percent"`
 		CycleKnown        bool     `json:"cycle_known"`
@@ -1063,6 +1068,9 @@ func TestGetAuthFileTrendSharesCycleAcrossTenantsForStableAccountID(t *testing.T
 	}
 	if math.Abs(payload.CycleCostTotal-0.008) > 1e-12 {
 		t.Fatalf("tenant B cycle_cost_total=%v, want 0.008", payload.CycleCostTotal)
+	}
+	if payload.CycleTotalTokens != 5000 {
+		t.Fatalf("cycle_total_tokens = %d, want 5000", payload.CycleTotalTokens)
 	}
 	if payload.RequestTotal != 2 {
 		t.Fatalf("tenant B request_total=%d, want 2", payload.RequestTotal)
@@ -1175,6 +1183,7 @@ func TestGetAuthFileTrendKeepsWeeklyCycleAcrossCodexPlanRename(t *testing.T) {
 		RequestTotal      int64   `json:"request_total"`
 		CycleRequestTotal int64   `json:"cycle_request_total"`
 		CycleCostTotal    float64 `json:"cycle_cost_total"`
+		CycleTotalTokens  int64   `json:"cycle_total_tokens"`
 		CycleKnown        bool    `json:"cycle_known"`
 		CycleStart        string  `json:"cycle_start"`
 	}
@@ -1189,6 +1198,9 @@ func TestGetAuthFileTrendKeepsWeeklyCycleAcrossCodexPlanRename(t *testing.T) {
 	}
 	if math.Abs(payload.CycleCostTotal-0.008) > 1e-12 {
 		t.Fatalf("cycle_cost_total = %v, want 0.008", payload.CycleCostTotal)
+	}
+	if payload.CycleTotalTokens != 5000 {
+		t.Fatalf("cycle_total_tokens = %d, want 5000", payload.CycleTotalTokens)
 	}
 	if !payload.CycleKnown {
 		t.Fatalf("cycle_known = false, want true")

--- a/internal/api/routes/management.go
+++ b/internal/api/routes/management.go
@@ -44,6 +44,7 @@ func RegisterManagement(engine *gin.Engine, h *managementhandlers.Handler, opts 
 	registerManagementModelRoutes(mgmt, h)
 	registerManagementUsageRoutes(mgmt, h)
 	registerManagementSettingsRoutes(mgmt, h)
+	registerManagementContentModerationRoutes(mgmt, h)
 	registerManagementAPIKeyRoutes(mgmt, h)
 	registerManagementLogRoutes(mgmt, h)
 	registerManagementAmpRoutes(mgmt, h)

--- a/internal/api/routes/management_content_moderation_routes.go
+++ b/internal/api/routes/management_content_moderation_routes.go
@@ -1,0 +1,17 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+	managementhandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
+)
+
+func registerManagementContentModerationRoutes(group *gin.RouterGroup, h *managementhandlers.Handler) {
+	group.GET("/content-moderation/profiles", h.GetContentModerationProfiles)
+	group.POST("/content-moderation/profiles", h.PostContentModerationProfile)
+	group.GET("/content-moderation/profiles/:id", h.GetContentModerationProfile)
+	group.PATCH("/content-moderation/profiles/:id", h.PatchContentModerationProfile)
+	group.DELETE("/content-moderation/profiles/:id", h.DeleteContentModerationProfile)
+	group.POST("/content-moderation/profiles/:id/test", h.PostContentModerationProfileTest)
+	group.GET("/content-moderation/channels", h.GetContentModerationChannels)
+	group.PATCH("/content-moderation/channel-bindings", h.PatchContentModerationChannelBindings)
+}

--- a/internal/api/routes/management_content_moderation_routes.go
+++ b/internal/api/routes/management_content_moderation_routes.go
@@ -6,6 +6,7 @@ import (
 )
 
 func registerManagementContentModerationRoutes(group *gin.RouterGroup, h *managementhandlers.Handler) {
+	group.GET("/content-moderation/metrics", h.GetContentModerationMetrics)
 	group.GET("/content-moderation/profiles", h.GetContentModerationProfiles)
 	group.POST("/content-moderation/profiles", h.PostContentModerationProfile)
 	group.GET("/content-moderation/profiles/:id", h.GetContentModerationProfile)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 304; got != want {
+	if got, want := len(routes), 305; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -34,6 +34,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 	}
 
 	required := []string{
+		"GET /v0/management/content-moderation/metrics",
 		"GET /v0/management/content-moderation/profiles",
 		"POST /v0/management/content-moderation/profiles",
 		"GET /v0/management/content-moderation/profiles/:id",
@@ -299,6 +300,7 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/config",
 		"GET /v0/management/config.yaml",
 		"GET /v0/management/content-moderation/channels",
+		"GET /v0/management/content-moderation/metrics",
 		"GET /v0/management/content-moderation/profiles",
 		"GET /v0/management/content-moderation/profiles/:id",
 		"GET /v0/management/dashboard-summary",

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 296; got != want {
+	if got, want := len(routes), 304; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -34,6 +34,14 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 	}
 
 	required := []string{
+		"GET /v0/management/content-moderation/profiles",
+		"POST /v0/management/content-moderation/profiles",
+		"GET /v0/management/content-moderation/profiles/:id",
+		"PATCH /v0/management/content-moderation/profiles/:id",
+		"DELETE /v0/management/content-moderation/profiles/:id",
+		"POST /v0/management/content-moderation/profiles/:id/test",
+		"GET /v0/management/content-moderation/channels",
+		"PATCH /v0/management/content-moderation/channel-bindings",
 		"GET /v0/management/dashboard-summary",
 		"GET /v0/management/system-stats/ws",
 		"GET /v0/management/model-configs",
@@ -244,6 +252,7 @@ func expectedManagementRoutes() []string {
 		"DELETE /v0/management/claude-api-key",
 		"DELETE /v0/management/cline-api-key",
 		"DELETE /v0/management/codex-api-key",
+		"DELETE /v0/management/content-moderation/profiles/:id",
 		"DELETE /v0/management/gemini-api-key",
 		"DELETE /v0/management/identity-fingerprint/account/profile",
 		"DELETE /v0/management/identity-fingerprint/learned",
@@ -289,6 +298,9 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/codex-oauth-admission",
 		"GET /v0/management/config",
 		"GET /v0/management/config.yaml",
+		"GET /v0/management/content-moderation/channels",
+		"GET /v0/management/content-moderation/profiles",
+		"GET /v0/management/content-moderation/profiles/:id",
 		"GET /v0/management/dashboard-summary",
 		"GET /v0/management/debug",
 		"GET /v0/management/error-logs-max-files",
@@ -378,6 +390,8 @@ func expectedManagementRoutes() []string {
 		"PATCH /v0/management/claude-api-key",
 		"PATCH /v0/management/cline-api-key",
 		"PATCH /v0/management/codex-api-key",
+		"PATCH /v0/management/content-moderation/channel-bindings",
+		"PATCH /v0/management/content-moderation/profiles/:id",
 		"PATCH /v0/management/debug",
 		"PATCH /v0/management/error-logs-max-files",
 		"PATCH /v0/management/force-model-prefix",
@@ -402,6 +416,8 @@ func expectedManagementRoutes() []string {
 		"PATCH /v0/management/vertex-api-key",
 		"PATCH /v0/management/ws-auth",
 		"POST /v0/management/api-call",
+		"POST /v0/management/content-moderation/profiles",
+		"POST /v0/management/content-moderation/profiles/:id/test",
 		"POST /v0/management/api-key-entries/daily-spending/reset",
 		"POST /v0/management/auth-files",
 		"POST /v0/management/iflow-auth-url",

--- a/internal/api/server_models_endpoint.go
+++ b/internal/api/server_models_endpoint.go
@@ -154,6 +154,16 @@ func enrichOpenAIModelsWithCatalog(tenantID string, models []map[string]interfac
 	if len(models) == 0 {
 		return
 	}
+	configRows := modelconfigsettings.ListAllConfigsForTenant(tenantID)
+	configByID := make(map[string]usage.ModelConfigRow, len(configRows))
+	for _, row := range configRows {
+		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
+	}
+	pricingRows := usage.GetAllModelPricingForTenant(tenantID)
+	pricingByID := make(map[string]usage.ModelPricingRow, len(pricingRows))
+	for modelID, row := range pricingRows {
+		pricingByID[strings.ToLower(strings.TrimSpace(modelID))] = row
+	}
 	for _, model := range models {
 		if model == nil {
 			continue
@@ -163,7 +173,7 @@ func enrichOpenAIModelsWithCatalog(tenantID string, models []map[string]interfac
 		if id == "" {
 			continue
 		}
-		if row, ok := modelconfigsettings.GetConfigForTenant(tenantID, id); ok {
+		if row, ok := configByID[strings.ToLower(id)]; ok {
 			if ownedBy := strings.TrimSpace(row.OwnedBy); ownedBy != "" {
 				if existing, _ := model["owned_by"].(string); strings.TrimSpace(existing) == "" {
 					model["owned_by"] = ownedBy
@@ -191,27 +201,16 @@ func enrichOpenAIModelsWithCatalog(tenantID string, models []map[string]interfac
 				}
 			}
 			model["supports_vision"] = supportsVision
-			model["pricing"] = map[string]any{
-				"mode":                          row.PricingMode,
-				"input_price_per_million":       row.InputPricePerMillion,
-				"output_price_per_million":      row.OutputPricePerMillion,
-				"cached_price_per_million":      row.CachedPricePerMillion,
-				"cache_read_price_per_million":  row.CacheReadPricePerMillion,
-				"cache_write_price_per_million": row.CacheWritePricePerMillion,
-				"price_per_call":                row.PricePerCall,
-			}
-			continue
 		}
-		// Fallback: legacy model_pricing table when no model_config row exists.
-		if pricing, ok := usage.GetModelPricingForTenant(tenantID, id); ok {
+		if pricing, ok := usage.ResolveModelPricingRow(id, configByID, pricingByID); ok {
 			model["pricing"] = map[string]any{
-				"mode":                          "token",
+				"mode":                          pricing.PricingMode,
 				"input_price_per_million":       pricing.InputPricePerMillion,
 				"output_price_per_million":      pricing.OutputPricePerMillion,
 				"cached_price_per_million":      pricing.CachedPricePerMillion,
 				"cache_read_price_per_million":  pricing.CacheReadPricePerMillion,
 				"cache_write_price_per_million": pricing.CacheWritePricePerMillion,
-				"price_per_call":                0,
+				"price_per_call":                pricing.PricePerCall,
 			}
 		}
 	}

--- a/internal/api/server_models_endpoint_test.go
+++ b/internal/api/server_models_endpoint_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -13,6 +15,7 @@ import (
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/openai"
@@ -224,6 +227,38 @@ func TestEnrichOpenAIModelsWithCatalogLeavesUnknownModels(t *testing.T) {
 	}
 	if _, hasDesc := models[0]["description"]; hasDesc {
 		t.Fatal("unexpected description for unknown model")
+	}
+}
+
+func TestEnrichOpenAIModelsWithCatalogInheritsPrefixedPricing(t *testing.T) {
+	usage.CloseDB()
+	if err := usage.InitDB(filepath.Join(t.TempDir(), "usage.db"), config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("usage.InitDB() error = %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	models := []map[string]interface{}{{
+		"id":     "ollama/deepseek-v4-flash",
+		"object": "model",
+	}}
+	enrichOpenAIModelsWithCatalog("", models)
+	pricing, ok := models[0]["pricing"].(map[string]any)
+	if !ok {
+		t.Fatalf("pricing = %#v, want inherited pricing map", models[0]["pricing"])
+	}
+	if pricing["input_price_per_million"] != 0.3 || pricing["output_price_per_million"] != 1.2 {
+		t.Fatalf("pricing = %#v, want input=0.3 output=1.2", pricing)
 	}
 }
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -203,8 +203,10 @@ type runtimeDataStackMaintenanceOps struct {
 func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 	return runtimeDataStackMaintenanceOps{
 		runAIAccountSharedSubjectBackfill: func() error {
-			_, err := usage.RunAIAccountSharedSubjectBackfillAtInit()
-			return err
+			if _, err := usage.RunAIAccountSharedSubjectBackfillAtInit(); err != nil {
+				return err
+			}
+			return usage.RunAIAccountSubjectUsageTokensBackfillAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
@@ -45,6 +46,7 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
+		WithRequestModerator(contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))).
 		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 
@@ -89,6 +91,7 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
+		WithRequestModerator(contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))).
 		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -42,11 +42,13 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 	usage.InitRedis(cfg.Redis)
 	defer usage.StopRedis()
 
+	moderator := contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))
+	contentmoderation.SetRuntime(moderator)
 	builder := cliproxy.NewBuilder().
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
-		WithRequestModerator(contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))).
+		WithRequestModerator(moderator).
 		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 
@@ -87,11 +89,13 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 	}
 	usage.InitRedis(cfg.Redis)
 
+	moderator := contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))
+	contentmoderation.SetRuntime(moderator)
 	builder := cliproxy.NewBuilder().
 		WithConfig(cfg).
 		WithConfigPath(configPath).
 		WithCoreAuthHook(usage.NewAIAccountBindingHook()).
-		WithRequestModerator(contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))).
+		WithRequestModerator(moderator).
 		WithHooks(runtimeDataStackPostStartHooks(defaultRuntimeDataStackMaintenanceOps())).
 		WithLocalManagementPassword(localPassword)
 

--- a/internal/config/bedrock.go
+++ b/internal/config/bedrock.go
@@ -11,6 +11,9 @@ const (
 // BedrockKey represents an AWS Bedrock Runtime credential.
 // It supports both AWS SigV4 credentials and Bedrock API key bearer auth.
 type BedrockKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// Name is a human-readable label for this channel.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -109,6 +109,14 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
+	// Provider IDs are a versioned one-time migration because moderation bindings
+	// reference them across credential rotation and process restarts.
+	if migrateProviderStableIDsV1(&cfg) && !optional && strings.TrimSpace(configFile) != "" {
+		if err = SaveConfigPreserveComments(configFile, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to persist provider stable ID migration: %w", err)
+		}
+	}
+
 	// Detect legacy keys but intentionally do not migrate/persist on startup.
 	// var legacy legacyConfigData
 	// if err = yaml.Unmarshal(data, &legacy); err == nil {

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -3,6 +3,9 @@ package config
 // ClaudeKey represents the configuration for a Claude API key,
 // including the API key itself and an optional base URL for the API endpoint.
 type ClaudeKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing Claude API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -63,6 +66,9 @@ func (m ClaudeModel) GetAlias() string { return m.Alias }
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
 type CodexKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing Codex API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -117,6 +123,9 @@ func (m CodexModel) GetAlias() string { return m.Alias }
 // GeminiKey represents the configuration for a Gemini API key,
 // including optional overrides for upstream base URL, proxy routing, and headers.
 type GeminiKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing Gemini API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -167,6 +176,9 @@ func (m GeminiModel) GetAlias() string { return m.Alias }
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
 type OpenAICompatibility struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// Name is the identifier for this OpenAI compatibility configuration.
 	Name string `yaml:"name" json:"name"`
 
@@ -195,6 +207,9 @@ type OpenAICompatibility struct {
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.
 type OpenAICompatibilityAPIKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing the external API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -224,6 +239,9 @@ func (m OpenAICompatibilityModel) GetAlias() string { return m.Alias }
 // OpenCodeGoKey represents an OpenCode Go plan API key.
 // The upstream endpoint is fixed to https://opencode.ai/zen/go/v1.
 type OpenCodeGoKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for OpenCode Go.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
@@ -278,6 +296,9 @@ const DefaultClineBaseURL = "https://api.cline.bot/api/v1"
 
 // ClineKey represents a ClinePass OpenAI-compatible API key.
 type ClineKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	APIKey string `yaml:"api-key" json:"api-key"`
 
 	// Name is a human-readable label for this channel.
@@ -329,6 +350,9 @@ const DefaultOllamaCloudBaseURL = "https://ollama.com"
 
 // OllamaCloudKey represents an Ollama Cloud API key.
 type OllamaCloudKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	APIKey string `yaml:"api-key" json:"api-key"`
 
 	// Name is a human-readable label for this channel.

--- a/internal/config/provider_stable_ids.go
+++ b/internal/config/provider_stable_ids.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const providerStableIDMigrationVersion = 1
+
+// migrateProviderStableIDsV1 is kept versioned so future identifier migrations can
+// be introduced without changing the persisted IDs created by this rollout.
+func migrateProviderStableIDsV1(cfg *Config) bool {
+	_ = providerStableIDMigrationVersion
+	return cfg.EnsureProviderStableIDs()
+}
+
+// EnsureProviderStableIDs assigns persistent UUIDs to every config-backed provider channel.
+// Existing valid IDs are never recomputed, so credential rotation does not move bindings.
+func (cfg *Config) EnsureProviderStableIDs() bool {
+	if cfg == nil {
+		return false
+	}
+	changed := false
+	seen := make(map[string]struct{})
+	ensure := func(id *string) {
+		trimmed := strings.TrimSpace(*id)
+		if parsed, err := uuid.Parse(trimmed); err == nil {
+			normalized := parsed.String()
+			if _, exists := seen[normalized]; !exists {
+				seen[normalized] = struct{}{}
+				if *id != normalized {
+					*id = normalized
+					changed = true
+				}
+				return
+			}
+		}
+		*id = uuid.NewString()
+		seen[*id] = struct{}{}
+		changed = true
+	}
+
+	for i := range cfg.GeminiKey {
+		ensure(&cfg.GeminiKey[i].ID)
+	}
+	for i := range cfg.CodexKey {
+		ensure(&cfg.CodexKey[i].ID)
+	}
+	for i := range cfg.ClaudeKey {
+		ensure(&cfg.ClaudeKey[i].ID)
+	}
+	for i := range cfg.BedrockKey {
+		ensure(&cfg.BedrockKey[i].ID)
+	}
+	for i := range cfg.OpenCodeGoKey {
+		ensure(&cfg.OpenCodeGoKey[i].ID)
+	}
+	for i := range cfg.ClineKey {
+		ensure(&cfg.ClineKey[i].ID)
+	}
+	for i := range cfg.OllamaCloudKey {
+		ensure(&cfg.OllamaCloudKey[i].ID)
+	}
+	for i := range cfg.OpenAICompatibility {
+		ensure(&cfg.OpenAICompatibility[i].ID)
+		for j := range cfg.OpenAICompatibility[i].APIKeyEntries {
+			ensure(&cfg.OpenAICompatibility[i].APIKeyEntries[j].ID)
+		}
+	}
+	for i := range cfg.VertexCompatAPIKey {
+		ensure(&cfg.VertexCompatAPIKey[i].ID)
+	}
+	return changed
+}
+
+// PreserveMissingProviderStableIDs keeps IDs across full-array management PUTs whose
+// clients predate the ID field. Explicit IDs from import/export remain authoritative.
+func PreserveMissingProviderStableIDs(previous, next *Config) {
+	if previous == nil || next == nil {
+		return
+	}
+	preserveIDs(previous.GeminiKey, next.GeminiKey, func(v *GeminiKey) *string { return &v.ID })
+	preserveIDs(previous.CodexKey, next.CodexKey, func(v *CodexKey) *string { return &v.ID })
+	preserveIDs(previous.ClaudeKey, next.ClaudeKey, func(v *ClaudeKey) *string { return &v.ID })
+	preserveIDs(previous.BedrockKey, next.BedrockKey, func(v *BedrockKey) *string { return &v.ID })
+	preserveIDs(previous.OpenCodeGoKey, next.OpenCodeGoKey, func(v *OpenCodeGoKey) *string { return &v.ID })
+	preserveIDs(previous.ClineKey, next.ClineKey, func(v *ClineKey) *string { return &v.ID })
+	preserveIDs(previous.OllamaCloudKey, next.OllamaCloudKey, func(v *OllamaCloudKey) *string { return &v.ID })
+	preserveIDs(previous.VertexCompatAPIKey, next.VertexCompatAPIKey, func(v *VertexCompatKey) *string { return &v.ID })
+	preserveIDs(previous.OpenAICompatibility, next.OpenAICompatibility, func(v *OpenAICompatibility) *string { return &v.ID })
+	for i := range next.OpenAICompatibility {
+		if i >= len(previous.OpenAICompatibility) {
+			break
+		}
+		preserveIDs(
+			previous.OpenAICompatibility[i].APIKeyEntries,
+			next.OpenAICompatibility[i].APIKeyEntries,
+			func(v *OpenAICompatibilityAPIKey) *string { return &v.ID },
+		)
+	}
+}
+
+func preserveIDs[T any](previous, next []T, id func(*T) *string) {
+	for i := range next {
+		if strings.TrimSpace(*id(&next[i])) != "" || i >= len(previous) {
+			continue
+		}
+		*id(&next[i]) = strings.TrimSpace(*id(&previous[i]))
+	}
+}

--- a/internal/config/provider_stable_ids_test.go
+++ b/internal/config/provider_stable_ids_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoadConfigBackfillsProviderStableIDsOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `gemini-api-key:
+  - api-key: gemini-secret
+openai-compatibility:
+  - name: compat
+    base-url: https://compat.example
+    api-key-entries:
+      - api-key: compat-secret
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	first, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig(first): %v", err)
+	}
+	ids := []string{
+		first.GeminiKey[0].ID,
+		first.OpenAICompatibility[0].ID,
+		first.OpenAICompatibility[0].APIKeyEntries[0].ID,
+	}
+	for _, id := range ids {
+		if _, err := uuid.Parse(id); err != nil {
+			t.Fatalf("backfilled ID %q is not UUID: %v", id, err)
+		}
+	}
+
+	persisted, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(persisted, &raw); err != nil {
+		t.Fatalf("parse migrated config: %v", err)
+	}
+	if len(persisted) == 0 {
+		t.Fatal("migrated config is empty")
+	}
+
+	second, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig(second): %v", err)
+	}
+	got := []string{
+		second.GeminiKey[0].ID,
+		second.OpenAICompatibility[0].ID,
+		second.OpenAICompatibility[0].APIKeyEntries[0].ID,
+	}
+	for i := range ids {
+		if got[i] != ids[i] {
+			t.Fatalf("ID changed on second load: first=%q second=%q", ids[i], got[i])
+		}
+	}
+}
+
+func TestEnsureProviderStableIDsRepairsDuplicates(t *testing.T) {
+	duplicate := uuid.NewString()
+	cfg := &Config{
+		GeminiKey: []GeminiKey{{ID: duplicate, APIKey: "one"}},
+		ClaudeKey: []ClaudeKey{{ID: duplicate, APIKey: "two"}},
+	}
+	if !cfg.EnsureProviderStableIDs() {
+		t.Fatal("EnsureProviderStableIDs returned false for duplicate IDs")
+	}
+	if cfg.GeminiKey[0].ID == cfg.ClaudeKey[0].ID {
+		t.Fatalf("duplicate IDs were not repaired: %q", duplicate)
+	}
+}

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -9,6 +9,9 @@ import "strings"
 //
 // Example services: zenmux.ai and similar Vertex-compatible providers.
 type VertexCompatKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
 	// APIKey is the authentication key for accessing the Vertex-compatible API.
 	// Maps to the x-goog-api-key header.
 	APIKey string `yaml:"api-key" json:"api-key"`

--- a/internal/contentmoderation/catalog.go
+++ b/internal/contentmoderation/catalog.go
@@ -1,0 +1,344 @@
+package contentmoderation
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type Channel struct {
+	ChannelType string   `json:"channel_type"`
+	ChannelID   string   `json:"channel_id"`
+	Name        string   `json:"name"`
+	Provider    string   `json:"provider"`
+	Tags        []string `json:"tags"`
+	Disabled    bool     `json:"disabled"`
+	ProfileID   string   `json:"profile_id,omitempty"`
+}
+
+type ChannelRef struct {
+	ChannelType string
+	ChannelID   string
+}
+
+type ChannelQuery struct {
+	ChannelType string
+	Query       string
+	Tags        []string
+	TagMode     string
+	Provider    string
+	ProfileID   string
+	Page        int
+	PageSize    int
+}
+
+type ChannelPage struct {
+	Items    []Channel `json:"items"`
+	Page     int       `json:"page"`
+	PageSize int       `json:"page_size"`
+	Total    int       `json:"total"`
+}
+
+func ListChannels(cfg *config.Config, auths []*coreauth.Auth, bindings []Binding, query ChannelQuery) ChannelPage {
+	bindingByChannel := make(map[string]string, len(bindings))
+	for _, binding := range bindings {
+		bindingByChannel[binding.ChannelType+"\x00"+binding.ChannelID] = binding.ProfileID
+	}
+	channels := buildChannels(cfg, auths, bindingByChannel)
+	filtered := channels[:0]
+	for _, channel := range channels {
+		if channelMatches(channel, query) {
+			filtered = append(filtered, channel)
+		}
+	}
+	page := query.Page
+	if page < 1 {
+		page = 1
+	}
+	pageSize := query.PageSize
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	if pageSize > 50 {
+		pageSize = 50
+	}
+	start := (page - 1) * pageSize
+	if start > len(filtered) {
+		start = len(filtered)
+	}
+	end := start + pageSize
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	items := append([]Channel(nil), filtered[start:end]...)
+	return ChannelPage{Items: items, Page: page, PageSize: pageSize, Total: len(filtered)}
+}
+
+func ChannelExists(cfg *config.Config, auths []*coreauth.Auth, channelType, channelID string) bool {
+	channelType = strings.TrimSpace(channelType)
+	channelID = strings.TrimSpace(channelID)
+	if channelID == "" || !IsChannelType(channelType) {
+		return false
+	}
+	for _, channel := range buildChannels(cfg, auths, nil) {
+		if channel.ChannelType == channelType && channel.ChannelID == channelID {
+			return true
+		}
+	}
+	return false
+}
+
+func ProviderChannelRefs(cfg *config.Config) []ChannelRef {
+	if cfg == nil {
+		return nil
+	}
+	refs := make([]ChannelRef, 0, len(cfg.GeminiKey)+len(cfg.ClaudeKey)+len(cfg.BedrockKey)+len(cfg.CodexKey)+len(cfg.OpenCodeGoKey)+len(cfg.ClineKey)+len(cfg.OllamaCloudKey)+len(cfg.VertexCompatAPIKey)+len(cfg.OpenAICompatibility))
+	addKey := func(id string) {
+		if id = strings.TrimSpace(id); id != "" {
+			refs = append(refs, ChannelRef{ChannelType: ChannelTypeProviderKey, ChannelID: id})
+		}
+	}
+	for _, entry := range cfg.GeminiKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.ClaudeKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.BedrockKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.CodexKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.OpenCodeGoKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.ClineKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.OllamaCloudKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.VertexCompatAPIKey {
+		addKey(entry.ID)
+	}
+	for _, provider := range cfg.OpenAICompatibility {
+		if id := strings.TrimSpace(provider.ID); id != "" {
+			refs = append(refs, ChannelRef{ChannelType: ChannelTypeProvider, ChannelID: id})
+		}
+		for _, entry := range provider.APIKeyEntries {
+			addKey(entry.ID)
+		}
+	}
+	return refs
+}
+
+func NormalizeAuthFileChannelID(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if parent := strings.TrimSpace(auth.Attributes["gemini_virtual_parent"]); parent != "" {
+		return parent
+	}
+	return strings.TrimSpace(auth.ID)
+}
+
+func buildChannels(cfg *config.Config, auths []*coreauth.Auth, bindings map[string]string) []Channel {
+	channels := make([]Channel, 0, len(auths)+16)
+	seen := make(map[string]struct{})
+	add := func(channel Channel) {
+		channel.ChannelType = strings.TrimSpace(channel.ChannelType)
+		channel.ChannelID = strings.TrimSpace(channel.ChannelID)
+		if channel.ChannelID == "" || !IsChannelType(channel.ChannelType) {
+			return
+		}
+		key := channel.ChannelType + "\x00" + channel.ChannelID
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		channel.Name = strings.TrimSpace(channel.Name)
+		if channel.Name == "" {
+			channel.Name = channel.Provider
+		}
+		channel.Provider = strings.ToLower(strings.TrimSpace(channel.Provider))
+		if channel.Tags == nil {
+			channel.Tags = []string{}
+		}
+		channel.ProfileID = bindings[key]
+		channels = append(channels, channel)
+	}
+
+	for _, auth := range auths {
+		if auth == nil || (strings.TrimSpace(auth.FileName) == "" && strings.TrimSpace(auth.Attributes["path"]) == "") {
+			continue
+		}
+		channelID := NormalizeAuthFileChannelID(auth)
+		name := strings.TrimSpace(auth.Label)
+		if name == "" {
+			name = strings.TrimSpace(auth.FileName)
+		}
+		if name == "" {
+			name = channelID
+		}
+		add(Channel{
+			ChannelType: ChannelTypeAuthFile,
+			ChannelID:   channelID,
+			Name:        name,
+			Provider:    auth.Provider,
+			Tags:        authDisplayTags(auth),
+			Disabled:    auth.Disabled,
+		})
+	}
+	if cfg != nil {
+		for _, entry := range cfg.GeminiKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "gemini", false))
+		}
+		for _, entry := range cfg.ClaudeKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "claude", false))
+		}
+		for _, entry := range cfg.BedrockKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "bedrock", false))
+		}
+		for _, entry := range cfg.CodexKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "codex", false))
+		}
+		for _, entry := range cfg.OpenCodeGoKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "opencode-go", entry.Disabled))
+		}
+		for _, entry := range cfg.ClineKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "cline", entry.Disabled))
+		}
+		for _, entry := range cfg.OllamaCloudKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "ollama-cloud", entry.Disabled))
+		}
+		for _, entry := range cfg.VertexCompatAPIKey {
+			add(simpleProviderChannel(entry.ID, "vertex", "vertex", false))
+		}
+		for _, provider := range cfg.OpenAICompatibility {
+			providerName := strings.ToLower(strings.TrimSpace(provider.Name))
+			add(Channel{ChannelType: ChannelTypeProvider, ChannelID: provider.ID, Name: provider.Name, Provider: providerName, Tags: []string{}, Disabled: provider.Disabled})
+			for index, entry := range provider.APIKeyEntries {
+				name := fmt.Sprintf("%s key %d", strings.TrimSpace(provider.Name), index+1)
+				add(Channel{ChannelType: ChannelTypeProviderKey, ChannelID: entry.ID, Name: name, Provider: providerName, Tags: []string{}, Disabled: provider.Disabled || entry.Disabled})
+			}
+		}
+	}
+	sort.Slice(channels, func(i, j int) bool {
+		if channels[i].ChannelType != channels[j].ChannelType {
+			return channels[i].ChannelType < channels[j].ChannelType
+		}
+		left, right := strings.ToLower(channels[i].Name), strings.ToLower(channels[j].Name)
+		if left != right {
+			return left < right
+		}
+		return channels[i].ChannelID < channels[j].ChannelID
+	})
+	return channels
+}
+
+func simpleProviderChannel(id, name, provider string, disabled bool) Channel {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = provider
+	}
+	return Channel{ChannelType: ChannelTypeProviderKey, ChannelID: id, Name: name, Provider: provider, Tags: []string{}, Disabled: disabled}
+}
+
+func channelMatches(channel Channel, query ChannelQuery) bool {
+	if channelType := strings.TrimSpace(query.ChannelType); channelType != "" && channel.ChannelType != channelType {
+		return false
+	}
+	if provider := strings.ToLower(strings.TrimSpace(query.Provider)); provider != "" && channel.Provider != provider {
+		return false
+	}
+	if profileID := strings.TrimSpace(query.ProfileID); profileID != "" && channel.ProfileID != profileID {
+		return false
+	}
+	if needle := strings.ToLower(strings.TrimSpace(query.Query)); needle != "" {
+		haystack := strings.ToLower(channel.Name + "\n" + channel.Provider + "\n" + channel.ChannelID)
+		if !strings.Contains(haystack, needle) {
+			return false
+		}
+	}
+	if len(query.Tags) == 0 {
+		return true
+	}
+	tagSet := make(map[string]struct{}, len(channel.Tags))
+	for _, tag := range channel.Tags {
+		tagSet[strings.ToLower(strings.TrimSpace(tag))] = struct{}{}
+	}
+	matched := 0
+	for _, tag := range query.Tags {
+		if _, ok := tagSet[strings.ToLower(strings.TrimSpace(tag))]; ok {
+			matched++
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(query.TagMode), "all") {
+		return matched == len(query.Tags)
+	}
+	return matched > 0
+}
+
+func authDisplayTags(auth *coreauth.Auth) []string {
+	if auth == nil {
+		return []string{}
+	}
+	if tags, present := metadataStringSlice(auth.Metadata, "display_tags"); present {
+		return tags
+	}
+	values := []string{auth.Provider}
+	if plan, _ := auth.Metadata["plan_type"].(string); strings.TrimSpace(plan) != "" {
+		values = append(values, plan)
+	}
+	if custom, _ := metadataStringSlice(auth.Metadata, "custom_tags"); len(custom) > 0 {
+		values = append(values, custom...)
+	}
+	return normalizeTags(values)
+}
+
+func metadataStringSlice(metadata map[string]any, key string) ([]string, bool) {
+	if metadata == nil {
+		return nil, false
+	}
+	raw, exists := metadata[key]
+	if !exists {
+		return nil, false
+	}
+	switch value := raw.(type) {
+	case []string:
+		return normalizeTags(value), true
+	case []any:
+		items := make([]string, 0, len(value))
+		for _, item := range value {
+			if text, ok := item.(string); ok {
+				items = append(items, text)
+			}
+		}
+		return normalizeTags(items), true
+	case string:
+		return normalizeTags(strings.Split(value, ",")), true
+	default:
+		return []string{}, true
+	}
+}
+
+func normalizeTags(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/contentmoderation/catalog_test.go
+++ b/internal/contentmoderation/catalog_test.go
@@ -1,0 +1,48 @@
+package contentmoderation
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestListChannelsPaginatesAndNormalizesGeminiVirtualParent(t *testing.T) {
+	cfg := &config.Config{GeminiKey: []config.GeminiKey{{ID: "provider-key-1", Name: "Gemini Provider", APIKey: "secret"}}}
+	auths := []*coreauth.Auth{
+		{ID: "parent-auth", FileName: "gemini.json", Provider: "gemini-cli", Label: "Gemini Account", Metadata: map[string]any{"display_tags": []string{"team-a"}}},
+		{ID: "virtual-auth", Provider: "gemini-cli", Label: "Virtual", Attributes: map[string]string{"path": "gemini.json", "gemini_virtual_parent": "parent-auth"}},
+	}
+	page := ListChannels(cfg, auths, nil, ChannelQuery{Page: 1, PageSize: 1})
+	if page.Total != 2 || len(page.Items) != 1 {
+		t.Fatalf("page = %#v", page)
+	}
+	full := ListChannels(cfg, auths, nil, ChannelQuery{Page: 1, PageSize: 50})
+	authCount := 0
+	for _, channel := range full.Items {
+		if channel.ChannelType == ChannelTypeAuthFile {
+			authCount++
+			if channel.ChannelID != "parent-auth" {
+				t.Fatalf("auth channel id = %q, want parent-auth", channel.ChannelID)
+			}
+		}
+	}
+	if authCount != 1 {
+		t.Fatalf("auth channel count = %d, want 1", authCount)
+	}
+}
+
+func TestListChannelsFiltersTagsAndBindings(t *testing.T) {
+	auths := []*coreauth.Auth{{
+		ID:       "auth-1",
+		FileName: "auth.json",
+		Provider: "codex",
+		Label:    "Codex Team",
+		Metadata: map[string]any{"display_tags": []string{"team-a", "pro"}},
+	}}
+	bindings := []Binding{{ChannelType: ChannelTypeAuthFile, ChannelID: "auth-1", ProfileID: "profile-1"}}
+	page := ListChannels(&config.Config{}, auths, bindings, ChannelQuery{Tags: []string{"team-a", "pro"}, TagMode: "all", ProfileID: "profile-1"})
+	if page.Total != 1 || page.Items[0].ProfileID != "profile-1" {
+		t.Fatalf("filtered page = %#v", page)
+	}
+}

--- a/internal/contentmoderation/evaluator.go
+++ b/internal/contentmoderation/evaluator.go
@@ -1,0 +1,137 @@
+package contentmoderation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	ActionAllow        = "allow"
+	ActionKeywordBlock = "keyword_block"
+	ActionAPIBlock     = "api_block"
+	ActionAPIError     = "api_error"
+)
+
+type Decision struct {
+	WouldBlock      bool               `json:"would_block"`
+	Action          string             `json:"action"`
+	MatchedKeyword  string             `json:"matched_keyword,omitempty"`
+	HighestCategory string             `json:"highest_category,omitempty"`
+	HighestScore    float64            `json:"highest_score,omitempty"`
+	CategoryScores  map[string]float64 `json:"category_scores"`
+	Thresholds      map[string]float64 `json:"thresholds"`
+	LatencyMS       int64              `json:"latency_ms"`
+	ModerationError string             `json:"moderation_error,omitempty"`
+}
+
+type Evaluator struct {
+	httpClient *http.Client
+}
+
+func NewEvaluator(client *http.Client) *Evaluator {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Evaluator{httpClient: client}
+}
+
+func (e *Evaluator) Evaluate(ctx context.Context, profile Profile, input string) Decision {
+	decision := Decision{Action: ActionAllow, CategoryScores: map[string]float64{}, Thresholds: mergeThresholds(profile.Thresholds)}
+	input = strings.TrimSpace(input)
+	if profile.Mode != ModePreBlock || input == "" {
+		return decision
+	}
+	if profile.KeywordMode != KeywordModeAPIOnly {
+		if keyword, hit := matchKeyword(input, profile.BlockedKeywords); hit {
+			decision.WouldBlock = true
+			decision.Action = ActionKeywordBlock
+			decision.MatchedKeyword = keyword
+			return decision
+		}
+	}
+	if profile.KeywordMode == KeywordModeKeywordOnly {
+		return decision
+	}
+	start := time.Now()
+	scores, err := e.callModeration(ctx, profile, input)
+	decision.LatencyMS = time.Since(start).Milliseconds()
+	if err != nil {
+		decision.Action = ActionAPIError
+		decision.ModerationError = err.Error()
+		return decision
+	}
+	decision.CategoryScores = scores
+	for category, score := range scores {
+		if decision.HighestCategory == "" || score > decision.HighestScore {
+			decision.HighestCategory = category
+			decision.HighestScore = score
+		}
+		if threshold, ok := decision.Thresholds[category]; ok && score >= threshold {
+			decision.WouldBlock = true
+		}
+	}
+	if decision.WouldBlock {
+		decision.Action = ActionAPIBlock
+	}
+	return decision
+}
+
+func matchKeyword(input string, keywords []string) (string, bool) {
+	input = strings.ToLower(input)
+	for _, keyword := range keywords {
+		keyword = strings.TrimSpace(keyword)
+		if keyword != "" && strings.Contains(input, strings.ToLower(keyword)) {
+			return keyword, true
+		}
+	}
+	return "", false
+}
+
+func (e *Evaluator) callModeration(ctx context.Context, profile Profile, input string) (map[string]float64, error) {
+	endpoint, err := url.JoinPath(strings.TrimRight(profile.BaseURL, "/"), "v1/moderations")
+	if err != nil {
+		return nil, fmt.Errorf("invalid moderation base URL: %w", err)
+	}
+	payload, err := json.Marshal(struct {
+		Model string `json:"model"`
+		Input string `json:"input"`
+	}{Model: profile.Model, Input: input})
+	if err != nil {
+		return nil, fmt.Errorf("encode moderation request: %w", err)
+	}
+	timeout := time.Duration(profile.TimeoutMS) * time.Millisecond
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create moderation request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+profile.APIKeySecret)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("moderation request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("moderation API returned status %d", resp.StatusCode)
+	}
+	var result struct {
+		Results []struct {
+			CategoryScores map[string]float64 `json:"category_scores"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode moderation response: %w", err)
+	}
+	if len(result.Results) == 0 || result.Results[0].CategoryScores == nil {
+		return nil, fmt.Errorf("moderation response missing category scores")
+	}
+	return result.Results[0].CategoryScores, nil
+}

--- a/internal/contentmoderation/evaluator_test.go
+++ b/internal/contentmoderation/evaluator_test.go
@@ -1,0 +1,44 @@
+package contentmoderation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestEvaluatorKeywordAndAPIModes(t *testing.T) {
+	profile := testProfile(t, "tenant-a", "keywords", ModePreBlock, KeywordModeKeywordOnly)
+	profile.BlockedKeywords = []string{"forbidden"}
+	decision := NewEvaluator(nil).Evaluate(context.Background(), profile, "contains FORBIDDEN text")
+	if !decision.WouldBlock || decision.Action != ActionKeywordBlock || decision.MatchedKeyword != "forbidden" {
+		t.Fatalf("keyword decision = %#v", decision)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"category_scores":{"hate":0.9,"violence":0.1}}]}`))
+	}))
+	defer server.Close()
+	profile.BaseURL = server.URL
+	profile.KeywordMode = KeywordModeAPIOnly
+	decision = NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "test input")
+	if !decision.WouldBlock || decision.Action != ActionAPIBlock || decision.HighestCategory != "hate" {
+		t.Fatalf("api decision = %#v", decision)
+	}
+}
+
+func TestEvaluatorFailsOpenOnModerationError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	profile := testProfile(t, "tenant-a", "api", ModePreBlock, KeywordModeAPIOnly)
+	profile.BaseURL = server.URL
+	profile.TimeoutMS = int((100 * time.Millisecond) / time.Millisecond)
+	decision := NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "test input")
+	if decision.WouldBlock || decision.Action != ActionAPIError || decision.ModerationError == "" {
+		t.Fatalf("fail-open decision = %#v", decision)
+	}
+}

--- a/internal/contentmoderation/extractor.go
+++ b/internal/contentmoderation/extractor.go
@@ -30,14 +30,14 @@ func collectLastRoleContent(messages gjson.Result, role string, parts *[]string,
 		return
 	}
 	items := messages.Array()
-	if len(items) == 0 {
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		if !strings.EqualFold(strings.TrimSpace(item.Get("role").String()), role) {
+			continue
+		}
+		collectTextValue(item.Get("content"), parts, skipSystemReminder)
 		return
 	}
-	last := items[len(items)-1]
-	if !strings.EqualFold(strings.TrimSpace(last.Get("role").String()), role) {
-		return
-	}
-	collectTextValue(last.Get("content"), parts, skipSystemReminder)
 }
 
 func collectResponsesInput(input gjson.Result, parts *[]string) {
@@ -48,18 +48,18 @@ func collectResponsesInput(input gjson.Result, parts *[]string) {
 		addText(parts, input.String(), false)
 	case input.IsArray():
 		items := input.Array()
-		if len(items) == 0 {
+		for i := len(items) - 1; i >= 0; i-- {
+			item := items[i]
+			role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+			typeName := strings.ToLower(strings.TrimSpace(item.Get("type").String()))
+			if role != "user" && typeName != "input_text" {
+				continue
+			}
+			collectTextValue(item.Get("content"), parts, false)
+			if typeName == "input_text" || item.Get("text").Exists() {
+				collectTextValue(item, parts, false)
+			}
 			return
-		}
-		last := items[len(items)-1]
-		role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
-		typeName := strings.ToLower(strings.TrimSpace(last.Get("type").String()))
-		if role != "user" && typeName != "input_text" {
-			return
-		}
-		collectTextValue(last.Get("content"), parts, false)
-		if typeName == "input_text" || last.Get("text").Exists() {
-			collectTextValue(last, parts, false)
 		}
 	case input.IsObject():
 		role := strings.ToLower(strings.TrimSpace(input.Get("role").String()))
@@ -76,18 +76,18 @@ func collectLastGeminiContent(contents gjson.Result, parts *[]string) {
 		return
 	}
 	items := contents.Array()
-	if len(items) == 0 {
-		return
-	}
-	last := items[len(items)-1]
-	role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
-	if role != "" && role != "user" {
-		return
-	}
-	if values := last.Get("parts"); values.IsArray() {
-		for _, part := range values.Array() {
-			addText(parts, part.Get("text").String(), false)
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+		if role != "" && role != "user" {
+			continue
 		}
+		if values := item.Get("parts"); values.IsArray() {
+			for _, part := range values.Array() {
+				addText(parts, part.Get("text").String(), false)
+			}
+		}
+		return
 	}
 }
 

--- a/internal/contentmoderation/extractor.go
+++ b/internal/contentmoderation/extractor.go
@@ -21,6 +21,12 @@ func ExtractLastUserText(format sdktranslator.Format, payload []byte) string {
 		collectLastGeminiContent(gjson.GetBytes(payload, "contents"), &parts)
 	default:
 		collectLastRoleContent(gjson.GetBytes(payload, "messages"), "user", &parts, false)
+		if len(parts) == 0 {
+			prompt := gjson.GetBytes(payload, "prompt")
+			if prompt.Type == gjson.String {
+				addText(&parts, prompt.String(), false)
+			}
+		}
 	}
 	return strings.Join(strings.Fields(strings.Join(parts, "\n")), " ")
 }

--- a/internal/contentmoderation/extractor.go
+++ b/internal/contentmoderation/extractor.go
@@ -1,0 +1,119 @@
+package contentmoderation
+
+import (
+	"strings"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func ExtractLastUserText(format sdktranslator.Format, payload []byte) string {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return ""
+	}
+	var parts []string
+	switch format {
+	case sdktranslator.FormatOpenAIResponse:
+		collectResponsesInput(gjson.GetBytes(payload, "input"), &parts)
+	case sdktranslator.FormatClaude:
+		collectLastRoleContent(gjson.GetBytes(payload, "messages"), "user", &parts, true)
+	case sdktranslator.FormatGemini, sdktranslator.FormatGeminiCLI:
+		collectLastGeminiContent(gjson.GetBytes(payload, "contents"), &parts)
+	default:
+		collectLastRoleContent(gjson.GetBytes(payload, "messages"), "user", &parts, false)
+	}
+	return strings.Join(strings.Fields(strings.Join(parts, "\n")), " ")
+}
+
+func collectLastRoleContent(messages gjson.Result, role string, parts *[]string, skipSystemReminder bool) {
+	if !messages.IsArray() {
+		return
+	}
+	items := messages.Array()
+	if len(items) == 0 {
+		return
+	}
+	last := items[len(items)-1]
+	if !strings.EqualFold(strings.TrimSpace(last.Get("role").String()), role) {
+		return
+	}
+	collectTextValue(last.Get("content"), parts, skipSystemReminder)
+}
+
+func collectResponsesInput(input gjson.Result, parts *[]string) {
+	switch {
+	case !input.Exists():
+		return
+	case input.Type == gjson.String:
+		addText(parts, input.String(), false)
+	case input.IsArray():
+		items := input.Array()
+		if len(items) == 0 {
+			return
+		}
+		last := items[len(items)-1]
+		role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
+		typeName := strings.ToLower(strings.TrimSpace(last.Get("type").String()))
+		if role != "user" && typeName != "input_text" {
+			return
+		}
+		collectTextValue(last.Get("content"), parts, false)
+		if typeName == "input_text" || last.Get("text").Exists() {
+			collectTextValue(last, parts, false)
+		}
+	case input.IsObject():
+		role := strings.ToLower(strings.TrimSpace(input.Get("role").String()))
+		typeName := strings.ToLower(strings.TrimSpace(input.Get("type").String()))
+		if role == "user" || typeName == "input_text" {
+			collectTextValue(input.Get("content"), parts, false)
+			collectTextValue(input, parts, false)
+		}
+	}
+}
+
+func collectLastGeminiContent(contents gjson.Result, parts *[]string) {
+	if !contents.IsArray() {
+		return
+	}
+	items := contents.Array()
+	if len(items) == 0 {
+		return
+	}
+	last := items[len(items)-1]
+	role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
+	if role != "" && role != "user" {
+		return
+	}
+	if values := last.Get("parts"); values.IsArray() {
+		for _, part := range values.Array() {
+			addText(parts, part.Get("text").String(), false)
+		}
+	}
+}
+
+func collectTextValue(value gjson.Result, parts *[]string, skipSystemReminder bool) {
+	switch {
+	case !value.Exists():
+		return
+	case value.Type == gjson.String:
+		addText(parts, value.String(), skipSystemReminder)
+	case value.IsArray():
+		for _, item := range value.Array() {
+			collectTextValue(item, parts, skipSystemReminder)
+		}
+	case value.IsObject():
+		typeName := strings.ToLower(strings.TrimSpace(value.Get("type").String()))
+		if typeName == "" || typeName == "text" || typeName == "input_text" || typeName == "message" {
+			addText(parts, value.Get("text").String(), skipSystemReminder)
+			collectTextValue(value.Get("content"), parts, skipSystemReminder)
+		}
+	}
+}
+
+func addText(parts *[]string, value string, skipSystemReminder bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || (skipSystemReminder && strings.HasPrefix(value, "<system-reminder>")) {
+		return
+	}
+	*parts = append(*parts, value)
+}

--- a/internal/contentmoderation/extractor_test.go
+++ b/internal/contentmoderation/extractor_test.go
@@ -17,6 +17,9 @@ func TestExtractLastUserText(t *testing.T) {
 		{"responses", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"assistant","content":[{"type":"output_text","text":"old"}]},{"role":"user","content":[{"type":"input_text","text":"response text"}]}]}`, "response text"},
 		{"claude", sdktranslator.FormatClaude, `{"messages":[{"role":"user","content":[{"type":"text","text":"claude text"}]}]}`, "claude text"},
 		{"gemini", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini text"}]}]}`, "gemini text"},
+		{"last user before assistant", sdktranslator.FormatOpenAI, `{"messages":[{"role":"user","content":"last user"},{"role":"assistant","content":"generated"}]}`, "last user"},
+		{"responses last user before output", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"user","content":[{"type":"input_text","text":"response user"}]},{"role":"assistant","content":[{"type":"output_text","text":"generated"}]}]}`, "response user"},
+		{"gemini last user before model", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini user"}]},{"role":"model","parts":[{"text":"generated"}]}]}`, "gemini user"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/contentmoderation/extractor_test.go
+++ b/internal/contentmoderation/extractor_test.go
@@ -1,0 +1,28 @@
+package contentmoderation
+
+import (
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+func TestExtractLastUserText(t *testing.T) {
+	tests := []struct {
+		name   string
+		format sdktranslator.Format
+		body   string
+		want   string
+	}{
+		{"openai chat", sdktranslator.FormatOpenAI, `{"messages":[{"role":"assistant","content":"old"},{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":"world"}]}]}`, "hello world"},
+		{"responses", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"assistant","content":[{"type":"output_text","text":"old"}]},{"role":"user","content":[{"type":"input_text","text":"response text"}]}]}`, "response text"},
+		{"claude", sdktranslator.FormatClaude, `{"messages":[{"role":"user","content":[{"type":"text","text":"claude text"}]}]}`, "claude text"},
+		{"gemini", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini text"}]}]}`, "gemini text"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractLastUserText(tt.format, []byte(tt.body)); got != tt.want {
+				t.Fatalf("ExtractLastUserText = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/contentmoderation/extractor_test.go
+++ b/internal/contentmoderation/extractor_test.go
@@ -14,12 +14,15 @@ func TestExtractLastUserText(t *testing.T) {
 		want   string
 	}{
 		{"openai chat", sdktranslator.FormatOpenAI, `{"messages":[{"role":"assistant","content":"old"},{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":"world"}]}]}`, "hello world"},
+		{"openai image prompt", sdktranslator.FormatOpenAI, `{"model":"gpt-image-2","prompt":"bad word"}`, "bad word"},
 		{"responses", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"assistant","content":[{"type":"output_text","text":"old"}]},{"role":"user","content":[{"type":"input_text","text":"response text"}]}]}`, "response text"},
 		{"claude", sdktranslator.FormatClaude, `{"messages":[{"role":"user","content":[{"type":"text","text":"claude text"}]}]}`, "claude text"},
 		{"gemini", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini text"}]}]}`, "gemini text"},
 		{"last user before assistant", sdktranslator.FormatOpenAI, `{"messages":[{"role":"user","content":"last user"},{"role":"assistant","content":"generated"}]}`, "last user"},
 		{"responses last user before output", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"user","content":[{"type":"input_text","text":"response user"}]},{"role":"assistant","content":[{"type":"output_text","text":"generated"}]}]}`, "response user"},
 		{"gemini last user before model", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini user"}]},{"role":"model","parts":[{"text":"generated"}]}]}`, "gemini user"},
+		{"openai empty body", sdktranslator.FormatOpenAI, `{}`, ""},
+		{"openai no prompt", sdktranslator.FormatOpenAI, `{"model":"gpt-image-2"}`, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/contentmoderation/runtime.go
+++ b/internal/contentmoderation/runtime.go
@@ -1,0 +1,312 @@
+package contentmoderation
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+const requestDecisionCacheMetadataKey = "content_moderation_decision_cache"
+
+type ProfileResolver interface {
+	ResolveProfile(ctx context.Context, tenantID, authFileID, providerKeyID, providerID string) (Profile, string, error)
+}
+
+type DecisionEvaluator interface {
+	Evaluate(ctx context.Context, profile Profile, input string) Decision
+}
+
+type RuntimeModerator struct {
+	resolver  ProfileResolver
+	evaluator DecisionEvaluator
+
+	lastGoodMu sync.RWMutex
+	lastGood   map[resolutionKey]resolvedProfile
+
+	requests  atomic.Uint64
+	allows    atomic.Uint64
+	blocks    atomic.Uint64
+	errors    atomic.Uint64
+	cacheHits atomic.Uint64
+}
+
+type resolutionKey struct {
+	tenantID      string
+	authFileID    string
+	providerKeyID string
+	providerID    string
+}
+
+type resolvedProfile struct {
+	profile Profile
+	source  string
+}
+
+type requestDecisionCache struct {
+	mu        sync.Mutex
+	decisions map[string]Decision
+}
+
+type ModerationMetrics struct {
+	Requests  uint64 `json:"requests"`
+	Allows    uint64 `json:"allows"`
+	Blocks    uint64 `json:"blocks"`
+	Errors    uint64 `json:"errors"`
+	CacheHits uint64 `json:"cache_hits"`
+}
+
+func NewRequestModerator(resolver ProfileResolver, evaluator DecisionEvaluator) *RuntimeModerator {
+	if evaluator == nil {
+		evaluator = NewEvaluator(nil)
+	}
+	return &RuntimeModerator{
+		resolver:  resolver,
+		evaluator: evaluator,
+		lastGood:  make(map[resolutionKey]resolvedProfile),
+	}
+}
+
+func (m *RuntimeModerator) Metrics() ModerationMetrics {
+	if m == nil {
+		return ModerationMetrics{}
+	}
+	return ModerationMetrics{
+		Requests:  m.requests.Load(),
+		Allows:    m.allows.Load(),
+		Blocks:    m.blocks.Load(),
+		Errors:    m.errors.Load(),
+		CacheHits: m.cacheHits.Load(),
+	}
+}
+
+func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, opts cliproxyexecutor.Options) coreauth.RequestModerationResult {
+	if m == nil || auth == nil || m.resolver == nil || m.evaluator == nil {
+		return coreauth.RequestModerationResult{}
+	}
+	m.requests.Add(1)
+	tenantID := coreauth.NormalizedTenantID(metadataString(opts.Metadata, cliproxyexecutor.TenantMetadataKey))
+	if coreauth.NormalizedTenantID(auth.TenantID) != tenantID {
+		m.recordError(tenantID, auth, "", Profile{}, "tenant_mismatch", 0)
+		return coreauth.RequestModerationResult{}
+	}
+
+	authFileID, providerKeyID, providerID := runtimeChannelIDs(auth)
+	key := resolutionKey{tenantID: tenantID, authFileID: authFileID, providerKeyID: providerKeyID, providerID: providerID}
+	resolved, usedLastGood, err := m.resolve(ctx, key)
+	if errors.Is(err, ErrNotFound) {
+		m.allows.Add(1)
+		return coreauth.RequestModerationResult{}
+	}
+	if err != nil {
+		m.recordError(tenantID, auth, "", Profile{}, "store_error", 0)
+		return coreauth.RequestModerationResult{}
+	}
+	if usedLastGood {
+		m.recordError(tenantID, auth, resolved.source, resolved.profile, "store_error_last_good", 0)
+	}
+	profile := resolved.profile
+	if profile.Mode == ModeOff {
+		m.allows.Add(1)
+		m.logDecision(tenantID, auth, resolved.source, profile, Decision{Action: ActionAllow}, false)
+		return coreauth.RequestModerationResult{}
+	}
+
+	input := ExtractLastUserText(opts.SourceFormat, opts.OriginalRequest)
+	if input == "" {
+		m.allows.Add(1)
+		m.logDecision(tenantID, auth, resolved.source, profile, Decision{Action: ActionAllow}, false)
+		return coreauth.RequestModerationResult{}
+	}
+
+	cacheKey := decisionCacheKey(profile, input)
+	cache := decisionCacheFromMetadata(opts.Metadata)
+	if cache != nil {
+		if decision, ok := cache.get(cacheKey); ok {
+			m.cacheHits.Add(1)
+			return m.resultForDecision(tenantID, auth, resolved.source, profile, decision, true)
+		}
+	}
+	decision := m.evaluator.Evaluate(ctx, profile, input)
+	if cache != nil {
+		cache.put(cacheKey, decision)
+	}
+	return m.resultForDecision(tenantID, auth, resolved.source, profile, decision, false)
+}
+
+func (m *RuntimeModerator) resolve(ctx context.Context, key resolutionKey) (resolvedProfile, bool, error) {
+	profile, source, err := m.resolver.ResolveProfile(ctx, key.tenantID, key.authFileID, key.providerKeyID, key.providerID)
+	if err == nil {
+		resolved := resolvedProfile{profile: profile, source: source}
+		m.lastGoodMu.Lock()
+		m.lastGood[key] = resolved
+		m.lastGoodMu.Unlock()
+		return resolved, false, nil
+	}
+	if errors.Is(err, ErrNotFound) {
+		m.lastGoodMu.Lock()
+		delete(m.lastGood, key)
+		m.lastGoodMu.Unlock()
+		return resolvedProfile{}, false, ErrNotFound
+	}
+	m.lastGoodMu.RLock()
+	resolved, ok := m.lastGood[key]
+	m.lastGoodMu.RUnlock()
+	if ok {
+		return resolved, true, nil
+	}
+	return resolvedProfile{}, false, err
+}
+
+func (m *RuntimeModerator) resultForDecision(tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) coreauth.RequestModerationResult {
+	if decision.Action == ActionAPIError {
+		m.allows.Add(1)
+		m.recordError(tenantID, auth, source, profile, moderationErrorClass(decision.ModerationError), decision.LatencyMS)
+		return coreauth.RequestModerationResult{}
+	}
+	if decision.WouldBlock {
+		m.blocks.Add(1)
+		m.logDecision(tenantID, auth, source, profile, decision, cached)
+		return coreauth.RequestModerationResult{Blocked: true, Message: profile.BlockMessage, HTTPStatus: profile.BlockHTTPStatus}
+	}
+	m.allows.Add(1)
+	m.logDecision(tenantID, auth, source, profile, decision, cached)
+	return coreauth.RequestModerationResult{}
+}
+
+func (m *RuntimeModerator) recordError(tenantID string, auth *coreauth.Auth, source string, profile Profile, errorClass string, latencyMS int64) {
+	m.errors.Add(1)
+	fields := moderationLogFields(tenantID, auth, source, profile)
+	fields["action"] = ActionAPIError
+	fields["error_class"] = errorClass
+	fields["latency_ms"] = latencyMS
+	log.WithFields(fields).Warn("content moderation failed open")
+}
+
+func (m *RuntimeModerator) logDecision(tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) {
+	fields := moderationLogFields(tenantID, auth, source, profile)
+	fields["action"] = decision.Action
+	fields["latency_ms"] = decision.LatencyMS
+	fields["cache_hit"] = cached
+	if decision.Action == ActionKeywordBlock {
+		fields["category"] = "keyword"
+		fields["score"] = 1.0
+	} else if decision.HighestCategory != "" {
+		fields["category"] = decision.HighestCategory
+		fields["score"] = decision.HighestScore
+	}
+	entry := log.WithFields(fields)
+	if decision.WouldBlock {
+		entry.Warn("content moderation blocked request")
+	} else {
+		entry.Debug("content moderation allowed request")
+	}
+}
+
+func moderationLogFields(tenantID string, auth *coreauth.Auth, source string, profile Profile) log.Fields {
+	channelType, channelID := resolvedChannel(auth, source)
+	return log.Fields{
+		"tenant_id":         tenantID,
+		"profile_id":        profile.ID,
+		"profile_version":   profile.Version,
+		"resolution_source": source,
+		"channel_type":      channelType,
+		"channel_id":        channelID,
+	}
+}
+
+func resolvedChannel(auth *coreauth.Auth, source string) (string, string) {
+	authFileID, providerKeyID, providerID := runtimeChannelIDs(auth)
+	switch source {
+	case ChannelTypeAuthFile:
+		return source, authFileID
+	case ChannelTypeProviderKey:
+		return source, providerKeyID
+	case ChannelTypeProvider:
+		return source, providerID
+	default:
+		return "", ""
+	}
+}
+
+func runtimeChannelIDs(auth *coreauth.Auth) (authFileID, providerKeyID, providerID string) {
+	if auth == nil {
+		return "", "", ""
+	}
+	if strings.TrimSpace(auth.FileName) != "" || strings.TrimSpace(auth.Attributes["path"]) != "" {
+		authFileID = strings.TrimSpace(auth.Attributes["gemini_virtual_parent"])
+		if authFileID == "" {
+			authFileID = strings.TrimSpace(auth.ID)
+		}
+	}
+	providerKeyID = strings.TrimSpace(auth.Attributes["provider_key_id"])
+	providerID = strings.TrimSpace(auth.Attributes["provider_config_id"])
+	return authFileID, providerKeyID, providerID
+}
+
+func decisionCacheKey(profile Profile, input string) string {
+	hash := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("%s:%d:%x", profile.ID, profile.Version, hash)
+}
+
+func decisionCacheFromMetadata(metadata map[string]any) *requestDecisionCache {
+	if metadata == nil {
+		return nil
+	}
+	if cache, ok := metadata[requestDecisionCacheMetadataKey].(*requestDecisionCache); ok && cache != nil {
+		return cache
+	}
+	cache := &requestDecisionCache{decisions: make(map[string]Decision)}
+	metadata[requestDecisionCacheMetadataKey] = cache
+	return cache
+}
+
+func (c *requestDecisionCache) get(key string) (Decision, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	decision, ok := c.decisions[key]
+	return decision, ok
+}
+
+func (c *requestDecisionCache) put(key string, decision Decision) {
+	c.mu.Lock()
+	c.decisions[key] = decision
+	c.mu.Unlock()
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	switch value := metadata[key].(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []byte:
+		return strings.TrimSpace(string(value))
+	default:
+		return ""
+	}
+}
+
+func moderationErrorClass(message string) string {
+	message = strings.ToLower(strings.TrimSpace(message))
+	switch {
+	case strings.Contains(message, "deadline exceeded") || strings.Contains(message, "timeout"):
+		return "timeout"
+	case strings.Contains(message, "returned status"):
+		return "upstream_status"
+	case strings.Contains(message, "decode") || strings.Contains(message, "missing category scores"):
+		return "invalid_response"
+	case strings.Contains(message, "request failed"):
+		return "transport"
+	default:
+		return "moderation_error"
+	}
+}

--- a/internal/contentmoderation/runtime.go
+++ b/internal/contentmoderation/runtime.go
@@ -31,11 +31,14 @@ type RuntimeModerator struct {
 	lastGoodMu sync.RWMutex
 	lastGood   map[resolutionKey]resolvedProfile
 
-	requests  atomic.Uint64
-	allows    atomic.Uint64
-	blocks    atomic.Uint64
-	errors    atomic.Uint64
-	cacheHits atomic.Uint64
+	requests       atomic.Uint64
+	allows         atomic.Uint64
+	blocks         atomic.Uint64
+	errors         atomic.Uint64
+	cacheHits      atomic.Uint64
+	inFlight       atomic.Int64
+	latencyTotalMS atomic.Uint64
+	latencySamples atomic.Uint64
 }
 
 type resolutionKey struct {
@@ -56,11 +59,27 @@ type requestDecisionCache struct {
 }
 
 type ModerationMetrics struct {
-	Requests  uint64 `json:"requests"`
-	Allows    uint64 `json:"allows"`
-	Blocks    uint64 `json:"blocks"`
-	Errors    uint64 `json:"errors"`
-	CacheHits uint64 `json:"cache_hits"`
+	Requests       uint64  `json:"requests"`
+	Allows         uint64  `json:"allows"`
+	Blocks         uint64  `json:"blocks"`
+	Errors         uint64  `json:"errors"`
+	CacheHits      uint64  `json:"cache_hits"`
+	InFlight       int64   `json:"in_flight"`
+	LatencyTotalMS uint64  `json:"latency_total_ms"`
+	LatencySamples uint64  `json:"latency_samples"`
+	AvgLatencyMS   float64 `json:"avg_latency_ms"`
+}
+
+var runtimeModerator atomic.Pointer[RuntimeModerator]
+
+// SetRuntime exposes the live proxy moderator to process-local management metrics.
+func SetRuntime(moderator *RuntimeModerator) {
+	runtimeModerator.Store(moderator)
+}
+
+// Runtime returns the moderator used by the live proxy process.
+func Runtime() *RuntimeModerator {
+	return runtimeModerator.Load()
 }
 
 func NewRequestModerator(resolver ProfileResolver, evaluator DecisionEvaluator) *RuntimeModerator {
@@ -78,13 +97,22 @@ func (m *RuntimeModerator) Metrics() ModerationMetrics {
 	if m == nil {
 		return ModerationMetrics{}
 	}
-	return ModerationMetrics{
-		Requests:  m.requests.Load(),
-		Allows:    m.allows.Load(),
-		Blocks:    m.blocks.Load(),
-		Errors:    m.errors.Load(),
-		CacheHits: m.cacheHits.Load(),
+	latencyTotalMS := m.latencyTotalMS.Load()
+	latencySamples := m.latencySamples.Load()
+	metrics := ModerationMetrics{
+		Requests:       m.requests.Load(),
+		Allows:         m.allows.Load(),
+		Blocks:         m.blocks.Load(),
+		Errors:         m.errors.Load(),
+		CacheHits:      m.cacheHits.Load(),
+		InFlight:       m.inFlight.Load(),
+		LatencyTotalMS: latencyTotalMS,
+		LatencySamples: latencySamples,
 	}
+	if latencySamples > 0 {
+		metrics.AvgLatencyMS = float64(latencyTotalMS) / float64(latencySamples)
+	}
+	return metrics
 }
 
 func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, opts cliproxyexecutor.Options) coreauth.RequestModerationResult {
@@ -94,7 +122,7 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 	m.requests.Add(1)
 	tenantID := coreauth.NormalizedTenantID(metadataString(opts.Metadata, cliproxyexecutor.TenantMetadataKey))
 	if coreauth.NormalizedTenantID(auth.TenantID) != tenantID {
-		m.recordError(tenantID, auth, "", Profile{}, "tenant_mismatch", 0)
+		m.recordError(tenantID, auth, "", Profile{}, "tenant_mismatch", 0, false)
 		return coreauth.RequestModerationResult{}
 	}
 
@@ -106,23 +134,27 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 		return coreauth.RequestModerationResult{}
 	}
 	if err != nil {
-		m.recordError(tenantID, auth, "", Profile{}, "store_error", 0)
+		m.recordError(tenantID, auth, "", Profile{}, "store_error", 0, false)
 		return coreauth.RequestModerationResult{}
 	}
 	if usedLastGood {
-		m.recordError(tenantID, auth, resolved.source, resolved.profile, "store_error_last_good", 0)
+		m.recordError(tenantID, auth, resolved.source, resolved.profile, "store_error_last_good", 0, false)
 	}
 	profile := resolved.profile
 	if profile.Mode == ModeOff {
 		m.allows.Add(1)
-		m.logDecision(tenantID, auth, resolved.source, profile, Decision{Action: ActionAllow}, false)
+		decision := Decision{Action: ActionAllow}
+		m.setSnapshot(ctx, auth, resolved.source, profile, decision, false, false)
+		m.logDecision(tenantID, auth, resolved.source, profile, decision, false)
 		return coreauth.RequestModerationResult{}
 	}
 
 	input := ExtractLastUserText(opts.SourceFormat, opts.OriginalRequest)
 	if input == "" {
 		m.allows.Add(1)
-		m.logDecision(tenantID, auth, resolved.source, profile, Decision{Action: ActionAllow}, false)
+		decision := Decision{Action: ActionAllow}
+		m.setSnapshot(ctx, auth, resolved.source, profile, decision, false, false)
+		m.logDecision(tenantID, auth, resolved.source, profile, decision, false)
 		return coreauth.RequestModerationResult{}
 	}
 
@@ -131,14 +163,25 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 	if cache != nil {
 		if decision, ok := cache.get(cacheKey); ok {
 			m.cacheHits.Add(1)
-			return m.resultForDecision(tenantID, auth, resolved.source, profile, decision, true)
+			return m.resultForDecision(ctx, tenantID, auth, resolved.source, profile, decision, true)
 		}
 	}
+	apiPath := moderationAPIPath(profile, input)
+	if apiPath {
+		m.inFlight.Add(1)
+	}
 	decision := m.evaluator.Evaluate(ctx, profile, input)
+	if apiPath {
+		m.inFlight.Add(-1)
+		if decision.LatencyMS >= 0 {
+			m.latencyTotalMS.Add(uint64(decision.LatencyMS))
+			m.latencySamples.Add(1)
+		}
+	}
 	if cache != nil {
 		cache.put(cacheKey, decision)
 	}
-	return m.resultForDecision(tenantID, auth, resolved.source, profile, decision, false)
+	return m.resultForDecision(ctx, tenantID, auth, resolved.source, profile, decision, false)
 }
 
 func (m *RuntimeModerator) resolve(ctx context.Context, key resolutionKey) (resolvedProfile, bool, error) {
@@ -165,12 +208,15 @@ func (m *RuntimeModerator) resolve(ctx context.Context, key resolutionKey) (reso
 	return resolvedProfile{}, false, err
 }
 
-func (m *RuntimeModerator) resultForDecision(tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) coreauth.RequestModerationResult {
+func (m *RuntimeModerator) resultForDecision(ctx context.Context, tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) coreauth.RequestModerationResult {
 	if decision.Action == ActionAPIError {
 		m.allows.Add(1)
-		m.recordError(tenantID, auth, source, profile, moderationErrorClass(decision.ModerationError), decision.LatencyMS)
+		errorClass := moderationErrorClass(decision.ModerationError)
+		m.setSnapshot(ctx, auth, source, profile, decision, true, cached)
+		m.recordError(tenantID, auth, source, profile, errorClass, decision.LatencyMS, cached)
 		return coreauth.RequestModerationResult{}
 	}
+	m.setSnapshot(ctx, auth, source, profile, decision, true, cached)
 	if decision.WouldBlock {
 		m.blocks.Add(1)
 		m.logDecision(tenantID, auth, source, profile, decision, cached)
@@ -181,12 +227,13 @@ func (m *RuntimeModerator) resultForDecision(tenantID string, auth *coreauth.Aut
 	return coreauth.RequestModerationResult{}
 }
 
-func (m *RuntimeModerator) recordError(tenantID string, auth *coreauth.Auth, source string, profile Profile, errorClass string, latencyMS int64) {
+func (m *RuntimeModerator) recordError(tenantID string, auth *coreauth.Auth, source string, profile Profile, errorClass string, latencyMS int64, cached bool) {
 	m.errors.Add(1)
 	fields := moderationLogFields(tenantID, auth, source, profile)
 	fields["action"] = ActionAPIError
 	fields["error_class"] = errorClass
 	fields["latency_ms"] = latencyMS
+	fields["cache_hit"] = cached
 	log.WithFields(fields).Warn("content moderation failed open")
 }
 
@@ -249,6 +296,17 @@ func runtimeChannelIDs(auth *coreauth.Auth) (authFileID, providerKeyID, provider
 	providerKeyID = strings.TrimSpace(auth.Attributes["provider_key_id"])
 	providerID = strings.TrimSpace(auth.Attributes["provider_config_id"])
 	return authFileID, providerKeyID, providerID
+}
+
+func moderationAPIPath(profile Profile, input string) bool {
+	if profile.Mode != ModePreBlock || profile.KeywordMode == KeywordModeKeywordOnly || strings.TrimSpace(input) == "" {
+		return false
+	}
+	if profile.KeywordMode == KeywordModeKeywordAndAPI {
+		_, keywordHit := matchKeyword(input, profile.BlockedKeywords)
+		return !keywordHit
+	}
+	return true
 }
 
 func decisionCacheKey(profile Profile, input string) string {

--- a/internal/contentmoderation/runtime.go
+++ b/internal/contentmoderation/runtime.go
@@ -31,6 +31,11 @@ type RuntimeModerator struct {
 	lastGoodMu sync.RWMutex
 	lastGood   map[resolutionKey]resolvedProfile
 
+	// Per-tenant process-local counters. Management metrics must never cross tenants.
+	tenantMetrics sync.Map // map[string]*tenantMetricCounters
+}
+
+type tenantMetricCounters struct {
 	requests       atomic.Uint64
 	allows         atomic.Uint64
 	blocks         atomic.Uint64
@@ -93,19 +98,35 @@ func NewRequestModerator(resolver ProfileResolver, evaluator DecisionEvaluator) 
 	}
 }
 
-func (m *RuntimeModerator) Metrics() ModerationMetrics {
+func (m *RuntimeModerator) counters(tenantID string) *tenantMetricCounters {
 	if m == nil {
+		return &tenantMetricCounters{}
+	}
+	key := coreauth.NormalizedTenantID(tenantID)
+	if key == "" {
+		key = "unknown"
+	}
+	if existing, ok := m.tenantMetrics.Load(key); ok {
+		return existing.(*tenantMetricCounters)
+	}
+	created := &tenantMetricCounters{}
+	actual, _ := m.tenantMetrics.LoadOrStore(key, created)
+	return actual.(*tenantMetricCounters)
+}
+
+func snapshotMetrics(c *tenantMetricCounters) ModerationMetrics {
+	if c == nil {
 		return ModerationMetrics{}
 	}
-	latencyTotalMS := m.latencyTotalMS.Load()
-	latencySamples := m.latencySamples.Load()
+	latencyTotalMS := c.latencyTotalMS.Load()
+	latencySamples := c.latencySamples.Load()
 	metrics := ModerationMetrics{
-		Requests:       m.requests.Load(),
-		Allows:         m.allows.Load(),
-		Blocks:         m.blocks.Load(),
-		Errors:         m.errors.Load(),
-		CacheHits:      m.cacheHits.Load(),
-		InFlight:       m.inFlight.Load(),
+		Requests:       c.requests.Load(),
+		Allows:         c.allows.Load(),
+		Blocks:         c.blocks.Load(),
+		Errors:         c.errors.Load(),
+		CacheHits:      c.cacheHits.Load(),
+		InFlight:       c.inFlight.Load(),
 		LatencyTotalMS: latencyTotalMS,
 		LatencySamples: latencySamples,
 	}
@@ -115,12 +136,53 @@ func (m *RuntimeModerator) Metrics() ModerationMetrics {
 	return metrics
 }
 
+// MetricsForTenant returns process-local counters for one tenant only.
+func (m *RuntimeModerator) MetricsForTenant(tenantID string) ModerationMetrics {
+	if m == nil {
+		return ModerationMetrics{}
+	}
+	key := coreauth.NormalizedTenantID(tenantID)
+	if key == "" {
+		return ModerationMetrics{}
+	}
+	existing, ok := m.tenantMetrics.Load(key)
+	if !ok {
+		return ModerationMetrics{}
+	}
+	return snapshotMetrics(existing.(*tenantMetricCounters))
+}
+
+// Metrics is retained for tests that inspect a single-tenant moderator instance.
+func (m *RuntimeModerator) Metrics() ModerationMetrics {
+	if m == nil {
+		return ModerationMetrics{}
+	}
+	var out ModerationMetrics
+	m.tenantMetrics.Range(func(_, value any) bool {
+		part := snapshotMetrics(value.(*tenantMetricCounters))
+		out.Requests += part.Requests
+		out.Allows += part.Allows
+		out.Blocks += part.Blocks
+		out.Errors += part.Errors
+		out.CacheHits += part.CacheHits
+		out.InFlight += part.InFlight
+		out.LatencyTotalMS += part.LatencyTotalMS
+		out.LatencySamples += part.LatencySamples
+		return true
+	})
+	if out.LatencySamples > 0 {
+		out.AvgLatencyMS = float64(out.LatencyTotalMS) / float64(out.LatencySamples)
+	}
+	return out
+}
+
 func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, opts cliproxyexecutor.Options) coreauth.RequestModerationResult {
 	if m == nil || auth == nil || m.resolver == nil || m.evaluator == nil {
 		return coreauth.RequestModerationResult{}
 	}
-	m.requests.Add(1)
 	tenantID := coreauth.NormalizedTenantID(metadataString(opts.Metadata, cliproxyexecutor.TenantMetadataKey))
+	counters := m.counters(tenantID)
+	counters.requests.Add(1)
 	if coreauth.NormalizedTenantID(auth.TenantID) != tenantID {
 		m.recordError(tenantID, auth, "", Profile{}, "tenant_mismatch", 0, false)
 		return coreauth.RequestModerationResult{}
@@ -130,7 +192,7 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 	key := resolutionKey{tenantID: tenantID, authFileID: authFileID, providerKeyID: providerKeyID, providerID: providerID}
 	resolved, usedLastGood, err := m.resolve(ctx, key)
 	if errors.Is(err, ErrNotFound) {
-		m.allows.Add(1)
+		counters.allows.Add(1)
 		return coreauth.RequestModerationResult{}
 	}
 	if err != nil {
@@ -142,7 +204,7 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 	}
 	profile := resolved.profile
 	if profile.Mode == ModeOff {
-		m.allows.Add(1)
+		counters.allows.Add(1)
 		decision := Decision{Action: ActionAllow}
 		m.setSnapshot(ctx, auth, resolved.source, profile, decision, false, false)
 		m.logDecision(tenantID, auth, resolved.source, profile, decision, false)
@@ -151,7 +213,7 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 
 	input := ExtractLastUserText(opts.SourceFormat, opts.OriginalRequest)
 	if input == "" {
-		m.allows.Add(1)
+		counters.allows.Add(1)
 		decision := Decision{Action: ActionAllow}
 		m.setSnapshot(ctx, auth, resolved.source, profile, decision, false, false)
 		m.logDecision(tenantID, auth, resolved.source, profile, decision, false)
@@ -162,20 +224,20 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 	cache := decisionCacheFromMetadata(opts.Metadata)
 	if cache != nil {
 		if decision, ok := cache.get(cacheKey); ok {
-			m.cacheHits.Add(1)
+			counters.cacheHits.Add(1)
 			return m.resultForDecision(ctx, tenantID, auth, resolved.source, profile, decision, true)
 		}
 	}
 	apiPath := moderationAPIPath(profile, input)
 	if apiPath {
-		m.inFlight.Add(1)
+		counters.inFlight.Add(1)
 	}
 	decision := m.evaluator.Evaluate(ctx, profile, input)
 	if apiPath {
-		m.inFlight.Add(-1)
+		counters.inFlight.Add(-1)
 		if decision.LatencyMS >= 0 {
-			m.latencyTotalMS.Add(uint64(decision.LatencyMS))
-			m.latencySamples.Add(1)
+			counters.latencyTotalMS.Add(uint64(decision.LatencyMS))
+			counters.latencySamples.Add(1)
 		}
 	}
 	if cache != nil {
@@ -209,8 +271,9 @@ func (m *RuntimeModerator) resolve(ctx context.Context, key resolutionKey) (reso
 }
 
 func (m *RuntimeModerator) resultForDecision(ctx context.Context, tenantID string, auth *coreauth.Auth, source string, profile Profile, decision Decision, cached bool) coreauth.RequestModerationResult {
+	counters := m.counters(tenantID)
 	if decision.Action == ActionAPIError {
-		m.allows.Add(1)
+		counters.allows.Add(1)
 		errorClass := moderationErrorClass(decision.ModerationError)
 		m.setSnapshot(ctx, auth, source, profile, decision, true, cached)
 		m.recordError(tenantID, auth, source, profile, errorClass, decision.LatencyMS, cached)
@@ -218,17 +281,17 @@ func (m *RuntimeModerator) resultForDecision(ctx context.Context, tenantID strin
 	}
 	m.setSnapshot(ctx, auth, source, profile, decision, true, cached)
 	if decision.WouldBlock {
-		m.blocks.Add(1)
+		counters.blocks.Add(1)
 		m.logDecision(tenantID, auth, source, profile, decision, cached)
 		return coreauth.RequestModerationResult{Blocked: true, Message: profile.BlockMessage, HTTPStatus: profile.BlockHTTPStatus}
 	}
-	m.allows.Add(1)
+	counters.allows.Add(1)
 	m.logDecision(tenantID, auth, source, profile, decision, cached)
 	return coreauth.RequestModerationResult{}
 }
 
 func (m *RuntimeModerator) recordError(tenantID string, auth *coreauth.Auth, source string, profile Profile, errorClass string, latencyMS int64, cached bool) {
-	m.errors.Add(1)
+	m.counters(tenantID).errors.Add(1)
 	fields := moderationLogFields(tenantID, auth, source, profile)
 	fields["action"] = ActionAPIError
 	fields["error_class"] = errorClass

--- a/internal/contentmoderation/runtime_snapshot.go
+++ b/internal/contentmoderation/runtime_snapshot.go
@@ -1,0 +1,98 @@
+package contentmoderation
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const ginRuntimeSnapshotKey = "content_moderation_runtime_snapshot"
+
+// RuntimeSnapshot is the secret-free moderation outcome persisted with request details.
+type RuntimeSnapshot struct {
+	Evaluated        bool     `json:"evaluated"`
+	ProfileID        string   `json:"profile_id"`
+	ProfileName      string   `json:"profile_name"`
+	ProfileVersion   int64    `json:"profile_version"`
+	ResolutionSource string   `json:"resolution_source"`
+	ChannelType      string   `json:"channel_type"`
+	ChannelID        string   `json:"channel_id"`
+	Action           string   `json:"action"`
+	WouldBlock       bool     `json:"would_block"`
+	MatchedKeyword   string   `json:"matched_keyword,omitempty"`
+	HighestCategory  string   `json:"highest_category,omitempty"`
+	HighestScore     *float64 `json:"highest_score,omitempty"`
+	LatencyMS        int64    `json:"latency_ms"`
+	CacheHit         bool     `json:"cache_hit"`
+	ErrorClass       string   `json:"error_class,omitempty"`
+	ModerationError  string   `json:"moderation_error,omitempty"`
+}
+
+// SetRuntimeSnapshot attaches a moderation outcome to the request's Gin context.
+func SetRuntimeSnapshot(ctx context.Context, snapshot RuntimeSnapshot) {
+	if ctx == nil {
+		return
+	}
+	ginCtx, _ := ctx.Value(util.ContextKeyGin).(*gin.Context)
+	if ginCtx != nil {
+		ginCtx.Set(ginRuntimeSnapshotKey, snapshot)
+	}
+}
+
+// RuntimeSnapshotFromGin returns the request-scoped moderation outcome, if any.
+func RuntimeSnapshotFromGin(ginCtx *gin.Context) (RuntimeSnapshot, bool) {
+	if ginCtx == nil {
+		return RuntimeSnapshot{}, false
+	}
+	value, exists := ginCtx.Get(ginRuntimeSnapshotKey)
+	if !exists {
+		return RuntimeSnapshot{}, false
+	}
+	snapshot, ok := value.(RuntimeSnapshot)
+	return snapshot, ok
+}
+
+func (m *RuntimeModerator) setSnapshot(ctx context.Context, auth *coreauth.Auth, source string, profile Profile, decision Decision, evaluated, cached bool) {
+	channelType, channelID := resolvedChannel(auth, source)
+	snapshot := RuntimeSnapshot{
+		Evaluated:        evaluated,
+		ProfileID:        profile.ID,
+		ProfileName:      profile.Name,
+		ProfileVersion:   profile.Version,
+		ResolutionSource: source,
+		ChannelType:      channelType,
+		ChannelID:        channelID,
+		Action:           decision.Action,
+		WouldBlock:       decision.WouldBlock,
+		MatchedKeyword:   decision.MatchedKeyword,
+		HighestCategory:  decision.HighestCategory,
+		LatencyMS:        decision.LatencyMS,
+		CacheHit:         cached,
+	}
+	if decision.HighestCategory != "" {
+		score := decision.HighestScore
+		snapshot.HighestScore = &score
+	}
+	if decision.Action == ActionAPIError {
+		snapshot.ErrorClass = moderationErrorClass(decision.ModerationError)
+		snapshot.ModerationError = moderationErrorSummary(snapshot.ErrorClass)
+	}
+	SetRuntimeSnapshot(ctx, snapshot)
+}
+
+func moderationErrorSummary(errorClass string) string {
+	switch errorClass {
+	case "timeout":
+		return "moderation API request timed out"
+	case "upstream_status":
+		return "moderation API returned a non-success status"
+	case "invalid_response":
+		return "moderation API returned an invalid response"
+	case "transport":
+		return "moderation API transport failed"
+	default:
+		return "moderation API evaluation failed"
+	}
+}

--- a/internal/contentmoderation/runtime_test.go
+++ b/internal/contentmoderation/runtime_test.go
@@ -27,6 +27,18 @@ func (e *runtimeEvaluatorStub) Evaluate(context.Context, Profile, string) Decisi
 	return e.decision
 }
 
+type blockingRuntimeEvaluator struct {
+	started  chan struct{}
+	release  chan struct{}
+	decision Decision
+}
+
+func (e *blockingRuntimeEvaluator) Evaluate(context.Context, Profile, string) Decision {
+	close(e.started)
+	<-e.release
+	return e.decision
+}
+
 type runtimeResolverStub struct {
 	calls atomic.Int32
 	fn    func() (Profile, string, error)
@@ -180,6 +192,59 @@ func TestRuntimeModeratorTenantMismatchNeverQueriesResolver(t *testing.T) {
 	}
 	if moderator.Metrics().Errors != 1 {
 		t.Fatalf("metrics = %#v, want one error", moderator.Metrics())
+	}
+}
+
+func TestRuntimeModeratorMetricsTrackAPILatencyAndInFlight(t *testing.T) {
+	const tenantID = "tenant-metrics"
+	profile, err := NewProfile(tenantID, "profile-metrics", CreateProfileInput{
+		Name:        "metrics",
+		Mode:        ModePreBlock,
+		KeywordMode: KeywordModeAPIOnly,
+		APIKey:      "moderation-secret",
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	resolver := &runtimeResolverStub{fn: func() (Profile, string, error) {
+		return profile, ChannelTypeProviderKey, nil
+	}}
+	evaluator := &blockingRuntimeEvaluator{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		decision: Decision{Action: ActionAllow, LatencyMS: 24},
+	}
+	moderator := NewRequestModerator(resolver, evaluator)
+	auth := &coreauth.Auth{
+		ID:       "auth-metrics",
+		TenantID: tenantID,
+		Attributes: map[string]string{
+			"provider_key_id": "key-metrics",
+		},
+	}
+	resultCh := make(chan coreauth.RequestModerationResult, 1)
+	go func() {
+		resultCh <- moderator.Moderate(context.Background(), auth, runtimeOptions(tenantID, "safe"))
+	}()
+
+	select {
+	case <-evaluator.started:
+	case <-time.After(time.Second):
+		t.Fatal("moderation evaluator did not start")
+	}
+	if metrics := moderator.Metrics(); metrics.Requests != 1 || metrics.InFlight != 1 {
+		t.Fatalf("metrics during evaluation = %#v", metrics)
+	}
+	close(evaluator.release)
+	if result := <-resultCh; result.Blocked {
+		t.Fatal("allow decision unexpectedly blocked")
+	}
+	metrics := moderator.Metrics()
+	if metrics.Requests != 1 || metrics.Allows != 1 || metrics.Blocks != 0 || metrics.Errors != 0 || metrics.InFlight != 0 {
+		t.Fatalf("metrics after evaluation = %#v", metrics)
+	}
+	if metrics.LatencyTotalMS != 24 || metrics.LatencySamples != 1 || metrics.AvgLatencyMS != 24 {
+		t.Fatalf("latency metrics = %#v", metrics)
 	}
 }
 

--- a/internal/contentmoderation/runtime_test.go
+++ b/internal/contentmoderation/runtime_test.go
@@ -195,6 +195,36 @@ func TestRuntimeModeratorTenantMismatchNeverQueriesResolver(t *testing.T) {
 	}
 }
 
+func TestRuntimeModeratorBlocksOpenAIImagePrompt(t *testing.T) {
+	const tenantID = "tenant-image-prompt"
+	store := newTestStore(t)
+	profile := createRuntimeProfile(t, store, tenantID, "profile-image-prompt", CreateProfileInput{
+		Name:            "image prompt block",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"bad word"},
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "image-key", profile.ID)
+	moderator := NewRequestModerator(store, NewEvaluator(nil))
+	auth := &coreauth.Auth{
+		ID:       "image-auth",
+		TenantID: tenantID,
+		Provider: "moderation-runtime",
+		Attributes: map[string]string{
+			"provider_key_id": "image-key",
+		},
+	}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"model":"gpt-image-2","prompt":"bad word"}`),
+		SourceFormat:    sdktranslator.FormatOpenAI,
+		Metadata:        map[string]any{cliproxyexecutor.TenantMetadataKey: tenantID},
+	}
+
+	if result := moderator.Moderate(context.Background(), auth, opts); !result.Blocked {
+		t.Fatal("images-style prompt was not blocked")
+	}
+}
+
 func TestRuntimeModeratorMetricsAreTenantScoped(t *testing.T) {
 	profileA, err := NewProfile("tenant-a", "profile-a", CreateProfileInput{
 		Name: "a", Mode: ModePreBlock, KeywordMode: KeywordModeKeywordOnly,

--- a/internal/contentmoderation/runtime_test.go
+++ b/internal/contentmoderation/runtime_test.go
@@ -1,0 +1,334 @@
+package contentmoderation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+type runtimeEvaluatorStub struct {
+	calls    atomic.Int32
+	decision Decision
+}
+
+func (e *runtimeEvaluatorStub) Evaluate(context.Context, Profile, string) Decision {
+	e.calls.Add(1)
+	return e.decision
+}
+
+type runtimeResolverStub struct {
+	calls atomic.Int32
+	fn    func() (Profile, string, error)
+}
+
+func (r *runtimeResolverStub) ResolveProfile(context.Context, string, string, string, string) (Profile, string, error) {
+	r.calls.Add(1)
+	return r.fn()
+}
+
+type runtimeOrderedSelector struct{}
+
+func (runtimeOrderedSelector) Pick(_ context.Context, _ string, _ string, _ cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
+	if len(auths) == 0 {
+		return nil, errors.New("no auth")
+	}
+	sort.Slice(auths, func(i, j int) bool { return auths[i].ID < auths[j].ID })
+	return auths[0], nil
+}
+
+type runtimeExecutor struct {
+	mu         sync.Mutex
+	calls      map[string]int
+	failAuthID string
+}
+
+func (e *runtimeExecutor) Identifier() string { return "moderation-runtime" }
+
+func (e *runtimeExecutor) Execute(_ context.Context, auth *coreauth.Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.calls[auth.ID]++
+	e.mu.Unlock()
+	if auth.ID == e.failAuthID {
+		return cliproxyexecutor.Response{}, errors.New("upstream unavailable")
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *runtimeExecutor) ExecuteStream(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *runtimeExecutor) CountTokens(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *runtimeExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *runtimeExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func createRuntimeProfile(t *testing.T, store *Store, tenantID, id string, input CreateProfileInput) Profile {
+	t.Helper()
+	profile, err := NewProfile(tenantID, id, input, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if err = store.CreateProfile(context.Background(), profile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	return profile
+}
+
+func bindRuntimeChannel(t *testing.T, store *Store, tenantID, channelType, channelID, profileID string) {
+	t.Helper()
+	if err := store.PatchBindings(context.Background(), tenantID, false, []BindingOperation{{
+		ChannelType: channelType,
+		ChannelID:   channelID,
+		ProfileID:   &profileID,
+	}}); err != nil {
+		t.Fatalf("PatchBindings: %v", err)
+	}
+}
+
+func runtimeOptions(tenantID, text string) cliproxyexecutor.Options {
+	body, _ := json.Marshal(map[string]any{"messages": []map[string]any{{"role": "user", "content": text}}})
+	return cliproxyexecutor.Options{
+		OriginalRequest: body,
+		SourceFormat:    sdktranslator.FormatOpenAI,
+		Metadata:        map[string]any{cliproxyexecutor.TenantMetadataKey: tenantID},
+	}
+}
+
+func newRuntimeManager(t *testing.T, moderator coreauth.RequestModerator, executor *runtimeExecutor, auths ...*coreauth.Auth) *coreauth.Manager {
+	t.Helper()
+	manager := coreauth.NewManager(nil, runtimeOrderedSelector{}, nil)
+	manager.SetRequestModerator(moderator)
+	registeredTenants := make(map[string]struct{})
+	for _, auth := range auths {
+		tenantID := coreauth.NormalizedTenantID(auth.TenantID)
+		if _, exists := registeredTenants[tenantID]; !exists {
+			manager.RegisterExecutorForTenant(tenantID, executor)
+			registeredTenants[tenantID] = struct{}{}
+		}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s): %v", auth.ID, err)
+		}
+	}
+	return manager
+}
+
+func TestRuntimeModeratorAuthOffOverridesProviderBinding(t *testing.T) {
+	const tenantID = "tenant-auth-off"
+	store := newTestStore(t)
+	authProfile := createRuntimeProfile(t, store, tenantID, "profile-auth-off", CreateProfileInput{Name: "auth off", Mode: ModeOff})
+	providerProfile := createRuntimeProfile(t, store, tenantID, "profile-provider-block", CreateProfileInput{
+		Name:            "provider block",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"blocked"},
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeAuthFile, "auth-file", authProfile.ID)
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProvider, "provider-id", providerProfile.ID)
+	evaluator := &runtimeEvaluatorStub{decision: Decision{WouldBlock: true, Action: ActionKeywordBlock}}
+	moderator := NewRequestModerator(store, evaluator)
+	auth := &coreauth.Auth{
+		ID:       "auth-file",
+		TenantID: tenantID,
+		FileName: "auth-file.json",
+		Provider: "moderation-runtime",
+		Attributes: map[string]string{
+			"provider_config_id": "provider-id",
+		},
+	}
+
+	result := moderator.Moderate(context.Background(), auth, runtimeOptions(tenantID, "blocked"))
+	if result.Blocked {
+		t.Fatal("auth-specific off profile must allow without provider fallback")
+	}
+	if evaluator.calls.Load() != 0 {
+		t.Fatalf("evaluator calls = %d, want zero", evaluator.calls.Load())
+	}
+}
+
+func TestRuntimeModeratorTenantMismatchNeverQueriesResolver(t *testing.T) {
+	resolver := &runtimeResolverStub{fn: func() (Profile, string, error) {
+		return Profile{}, "", ErrNotFound
+	}}
+	moderator := NewRequestModerator(resolver, &runtimeEvaluatorStub{})
+	result := moderator.Moderate(context.Background(), &coreauth.Auth{ID: "auth", TenantID: "tenant-a"}, runtimeOptions("tenant-b", "hello"))
+	if result.Blocked {
+		t.Fatal("tenant mismatch must fail open")
+	}
+	if resolver.calls.Load() != 0 {
+		t.Fatalf("resolver calls = %d, want zero", resolver.calls.Load())
+	}
+	if moderator.Metrics().Errors != 1 {
+		t.Fatalf("metrics = %#v, want one error", moderator.Metrics())
+	}
+}
+
+func TestRuntimeModeratorModerationAPIFailureCallsExecutor(t *testing.T) {
+	const tenantID = "tenant-api-error"
+	var moderationCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		moderationCalls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	profile := createRuntimeProfile(t, store, tenantID, "profile-api", CreateProfileInput{
+		Name:        "api",
+		Mode:        ModePreBlock,
+		KeywordMode: KeywordModeAPIOnly,
+		APIKey:      "moderation-secret",
+		BaseURL:     server.URL,
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-a", profile.ID)
+	moderator := NewRequestModerator(store, NewEvaluator(server.Client()))
+	executor := &runtimeExecutor{calls: make(map[string]int)}
+	manager := newRuntimeManager(t, moderator, executor, &coreauth.Auth{
+		ID:       "auth-a",
+		TenantID: tenantID,
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"provider_key_id": "key-a",
+		},
+	})
+
+	if _, err := manager.Execute(context.Background(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: "model"}, runtimeOptions(tenantID, "hello")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if moderationCalls.Load() != 1 {
+		t.Fatalf("moderation calls = %d, want 1", moderationCalls.Load())
+	}
+	executor.mu.Lock()
+	calls := executor.calls["auth-a"]
+	executor.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("executor calls = %d, want 1", calls)
+	}
+	if metrics := moderator.Metrics(); metrics.Errors != 1 || metrics.Allows != 1 {
+		t.Fatalf("metrics = %#v, want fail-open allow", metrics)
+	}
+}
+
+func TestRuntimeModeratorFallbackReResolvesAndBlocksSecondCandidate(t *testing.T) {
+	const tenantID = "tenant-fallback"
+	store := newTestStore(t)
+	allowProfile := createRuntimeProfile(t, store, tenantID, "profile-allow", CreateProfileInput{
+		Name:            "allow",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"never-match"},
+	})
+	blockProfile := createRuntimeProfile(t, store, tenantID, "profile-block", CreateProfileInput{
+		Name:            "block",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"blocked"},
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-a", allowProfile.ID)
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-b", blockProfile.ID)
+	moderator := NewRequestModerator(store, NewEvaluator(nil))
+	executor := &runtimeExecutor{calls: make(map[string]int), failAuthID: "auth-a"}
+	manager := newRuntimeManager(t, moderator, executor,
+		&coreauth.Auth{ID: "auth-a", TenantID: tenantID, Provider: executor.Identifier(), Status: coreauth.StatusActive, Attributes: map[string]string{"provider_key_id": "key-a"}},
+		&coreauth.Auth{ID: "auth-b", TenantID: tenantID, Provider: executor.Identifier(), Status: coreauth.StatusActive, Attributes: map[string]string{"provider_key_id": "key-b"}},
+	)
+
+	_, err := manager.Execute(context.Background(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: "model"}, runtimeOptions(tenantID, "blocked"))
+	var authErr *coreauth.Error
+	if !errors.As(err, &authErr) || authErr.Code != "content_policy_violation" {
+		t.Fatalf("Execute error = %#v, want content policy violation", err)
+	}
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if executor.calls["auth-a"] != 1 || executor.calls["auth-b"] != 0 {
+		t.Fatalf("executor calls = %#v, want first called and blocked second skipped", executor.calls)
+	}
+}
+
+func TestRuntimeModeratorRequestCacheAvoidsDuplicateModerationCallOnFallback(t *testing.T) {
+	const tenantID = "tenant-cache"
+	var moderationCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		moderationCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"category_scores":{"violence":0.01}}]}`))
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	profile := createRuntimeProfile(t, store, tenantID, "profile-shared", CreateProfileInput{
+		Name:        "shared",
+		Mode:        ModePreBlock,
+		KeywordMode: KeywordModeAPIOnly,
+		APIKey:      "moderation-secret",
+		BaseURL:     server.URL,
+	})
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-a", profile.ID)
+	bindRuntimeChannel(t, store, tenantID, ChannelTypeProviderKey, "key-b", profile.ID)
+	moderator := NewRequestModerator(store, NewEvaluator(server.Client()))
+	executor := &runtimeExecutor{calls: make(map[string]int), failAuthID: "auth-a"}
+	manager := newRuntimeManager(t, moderator, executor,
+		&coreauth.Auth{ID: "auth-a", TenantID: tenantID, Provider: executor.Identifier(), Status: coreauth.StatusActive, Attributes: map[string]string{"provider_key_id": "key-a"}},
+		&coreauth.Auth{ID: "auth-b", TenantID: tenantID, Provider: executor.Identifier(), Status: coreauth.StatusActive, Attributes: map[string]string{"provider_key_id": "key-b"}},
+	)
+
+	if _, err := manager.Execute(context.Background(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: "model"}, runtimeOptions(tenantID, "safe")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if moderationCalls.Load() != 1 {
+		t.Fatalf("moderation calls = %d, want 1", moderationCalls.Load())
+	}
+	if moderator.Metrics().CacheHits != 1 {
+		t.Fatalf("metrics = %#v, want one cache hit", moderator.Metrics())
+	}
+}
+
+func TestRuntimeModeratorUsesLastGoodResolutionOnStoreError(t *testing.T) {
+	profile, err := NewProfile("tenant-last-good", "profile-last-good", CreateProfileInput{
+		Name:            "last good",
+		Mode:            ModePreBlock,
+		KeywordMode:     KeywordModeKeywordOnly,
+		BlockedKeywords: []string{"blocked"},
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	var call atomic.Int32
+	resolver := &runtimeResolverStub{fn: func() (Profile, string, error) {
+		if call.Add(1) == 1 {
+			return profile, ChannelTypeProviderKey, nil
+		}
+		return Profile{}, "", errors.New("database unavailable")
+	}}
+	moderator := NewRequestModerator(resolver, NewEvaluator(nil))
+	auth := &coreauth.Auth{ID: "auth", TenantID: profile.TenantID, Attributes: map[string]string{"provider_key_id": "key"}}
+	for i := 0; i < 2; i++ {
+		if result := moderator.Moderate(context.Background(), auth, runtimeOptions(profile.TenantID, "blocked")); !result.Blocked {
+			t.Fatalf("call %d was not blocked", i+1)
+		}
+	}
+	if moderator.Metrics().Errors != 1 {
+		t.Fatalf("metrics = %#v, want last-good store error", moderator.Metrics())
+	}
+}

--- a/internal/contentmoderation/runtime_test.go
+++ b/internal/contentmoderation/runtime_test.go
@@ -195,6 +195,56 @@ func TestRuntimeModeratorTenantMismatchNeverQueriesResolver(t *testing.T) {
 	}
 }
 
+func TestRuntimeModeratorMetricsAreTenantScoped(t *testing.T) {
+	profileA, err := NewProfile("tenant-a", "profile-a", CreateProfileInput{
+		Name: "a", Mode: ModePreBlock, KeywordMode: KeywordModeKeywordOnly,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile A: %v", err)
+	}
+	profileB, err := NewProfile("tenant-b", "profile-b", CreateProfileInput{
+		Name: "b", Mode: ModePreBlock, KeywordMode: KeywordModeKeywordOnly,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile B: %v", err)
+	}
+	moderator := NewRequestModerator(tenantMetricsResolver{profiles: map[string]Profile{
+		"tenant-a": profileA,
+		"tenant-b": profileB,
+	}}, &runtimeEvaluatorStub{decision: Decision{Action: ActionAllow}})
+
+	for i := 0; i < 2; i++ {
+		moderator.Moderate(context.Background(), &coreauth.Auth{
+			ID: "a", TenantID: "tenant-a", Attributes: map[string]string{"provider_key_id": "k-a"},
+		}, runtimeOptions("tenant-a", "safe"))
+	}
+	moderator.Moderate(context.Background(), &coreauth.Auth{
+		ID: "b", TenantID: "tenant-b", Attributes: map[string]string{"provider_key_id": "k-b"},
+	}, runtimeOptions("tenant-b", "safe"))
+
+	if got := moderator.MetricsForTenant("tenant-a"); got.Requests != 2 || got.Allows != 2 {
+		t.Fatalf("tenant-a metrics = %#v", got)
+	}
+	if got := moderator.MetricsForTenant("tenant-b"); got.Requests != 1 || got.Allows != 1 {
+		t.Fatalf("tenant-b metrics = %#v", got)
+	}
+	if got := moderator.MetricsForTenant("tenant-missing"); got.Requests != 0 {
+		t.Fatalf("missing tenant metrics = %#v", got)
+	}
+}
+
+type tenantMetricsResolver struct {
+	profiles map[string]Profile
+}
+
+func (r tenantMetricsResolver) ResolveProfile(_ context.Context, tenantID, _, _, _ string) (Profile, string, error) {
+	profile, ok := r.profiles[tenantID]
+	if !ok {
+		return Profile{}, "", ErrNotFound
+	}
+	return profile, ChannelTypeProviderKey, nil
+}
+
 func TestRuntimeModeratorMetricsTrackAPILatencyAndInFlight(t *testing.T) {
 	const tenantID = "tenant-metrics"
 	profile, err := NewProfile(tenantID, "profile-metrics", CreateProfileInput{

--- a/internal/contentmoderation/store.go
+++ b/internal/contentmoderation/store.go
@@ -1,0 +1,364 @@
+package contentmoderation
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const createTablesSQL = `
+CREATE TABLE IF NOT EXISTS content_moderation_profiles (
+  tenant_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  mode TEXT NOT NULL DEFAULT 'off',
+  base_url TEXT NOT NULL DEFAULT 'https://api.openai.com',
+  model TEXT NOT NULL DEFAULT 'omni-moderation-latest',
+  api_key_secret TEXT NOT NULL DEFAULT '',
+  timeout_ms INTEGER NOT NULL DEFAULT 3000,
+  keyword_mode TEXT NOT NULL DEFAULT 'api_only',
+  blocked_keywords_json TEXT NOT NULL DEFAULT '[]',
+  thresholds_json TEXT NOT NULL DEFAULT '{}',
+  block_http_status INTEGER NOT NULL DEFAULT 403,
+  block_message TEXT NOT NULL DEFAULT '',
+  version INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (tenant_id, id),
+  UNIQUE (tenant_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS content_moderation_channel_bindings (
+  tenant_id TEXT NOT NULL,
+  channel_type TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  profile_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (tenant_id, channel_type, channel_id),
+  FOREIGN KEY (tenant_id, profile_id)
+    REFERENCES content_moderation_profiles(tenant_id, id)
+    ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_moderation_bindings_profile
+  ON content_moderation_channel_bindings(tenant_id, profile_id);
+`
+
+func InitTables(db *sql.DB) error {
+	if db == nil {
+		return ErrUnavailable
+	}
+	if _, err := db.Exec(createTablesSQL); err != nil {
+		return fmt.Errorf("create content moderation tables: %w", err)
+	}
+	return nil
+}
+
+type Store struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+func (s *Store) ListProfiles(ctx context.Context, tenantID string) ([]Profile, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrUnavailable
+	}
+	rows, err := s.db.QueryContext(ctx, profileSelectSQL+` WHERE tenant_id = $1 ORDER BY lower(name), id`, strings.TrimSpace(tenantID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	profiles := make([]Profile, 0)
+	for rows.Next() {
+		profile, err := scanProfile(rows)
+		if err != nil {
+			return nil, err
+		}
+		profiles = append(profiles, profile)
+	}
+	return profiles, rows.Err()
+}
+
+func (s *Store) GetProfile(ctx context.Context, tenantID, id string) (Profile, error) {
+	if s == nil || s.db == nil {
+		return Profile{}, ErrUnavailable
+	}
+	profile, err := scanProfile(s.db.QueryRowContext(ctx, profileSelectSQL+` WHERE tenant_id = $1 AND id = $2`, strings.TrimSpace(tenantID), strings.TrimSpace(id)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Profile{}, ErrNotFound
+	}
+	return profile, err
+}
+
+func (s *Store) CreateProfile(ctx context.Context, profile Profile) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	keywords, thresholds, err := profileJSON(profile)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO content_moderation_profiles
+		(tenant_id,id,name,mode,base_url,model,api_key_secret,timeout_ms,keyword_mode,blocked_keywords_json,thresholds_json,block_http_status,block_message,version,created_at,updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+		profile.TenantID, profile.ID, profile.Name, profile.Mode, profile.BaseURL, profile.Model, profile.APIKeySecret,
+		profile.TimeoutMS, profile.KeywordMode, keywords, thresholds, profile.BlockHTTPStatus, profile.BlockMessage,
+		profile.Version, formatTime(profile.CreatedAt), formatTime(profile.UpdatedAt))
+	if isUniqueViolation(err) {
+		return ErrNameConflict
+	}
+	return err
+}
+
+func (s *Store) UpdateProfile(ctx context.Context, profile Profile, expectedVersion int64) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	keywords, thresholds, err := profileJSON(profile)
+	if err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE content_moderation_profiles SET
+		name=$1,mode=$2,base_url=$3,model=$4,api_key_secret=$5,timeout_ms=$6,keyword_mode=$7,
+		blocked_keywords_json=$8,thresholds_json=$9,block_http_status=$10,block_message=$11,version=$12,updated_at=$13
+		WHERE tenant_id=$14 AND id=$15 AND version=$16`,
+		profile.Name, profile.Mode, profile.BaseURL, profile.Model, profile.APIKeySecret, profile.TimeoutMS, profile.KeywordMode,
+		keywords, thresholds, profile.BlockHTTPStatus, profile.BlockMessage, profile.Version, formatTime(profile.UpdatedAt),
+		profile.TenantID, profile.ID, expectedVersion)
+	if isUniqueViolation(err) {
+		return ErrNameConflict
+	}
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		if _, getErr := s.GetProfile(ctx, profile.TenantID, profile.ID); errors.Is(getErr, ErrNotFound) {
+			return ErrNotFound
+		}
+		return ErrVersionConflict
+	}
+	return nil
+}
+
+func (s *Store) DeleteProfile(ctx context.Context, tenantID, id string) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var count int
+	if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_moderation_channel_bindings WHERE tenant_id=$1 AND profile_id=$2`, tenantID, id).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return &ProfileBoundError{Count: count}
+	}
+	result, err := tx.ExecContext(ctx, `DELETE FROM content_moderation_profiles WHERE tenant_id=$1 AND id=$2`, tenantID, id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return tx.Commit()
+}
+
+func (s *Store) BindingCounts(ctx context.Context, tenantID string) (map[string]map[string]int, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrUnavailable
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT profile_id, channel_type, COUNT(*) FROM content_moderation_channel_bindings WHERE tenant_id=$1 GROUP BY profile_id, channel_type`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]map[string]int)
+	for rows.Next() {
+		var profileID, channelType string
+		var count int
+		if err := rows.Scan(&profileID, &channelType, &count); err != nil {
+			return nil, err
+		}
+		if out[profileID] == nil {
+			out[profileID] = make(map[string]int)
+		}
+		out[profileID][channelType] = count
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) ListBindings(ctx context.Context, tenantID string) ([]Binding, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrUnavailable
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT tenant_id,channel_type,channel_id,profile_id,created_at,updated_at FROM content_moderation_channel_bindings WHERE tenant_id=$1`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	bindings := make([]Binding, 0)
+	for rows.Next() {
+		var binding Binding
+		var createdAt, updatedAt string
+		if err := rows.Scan(&binding.TenantID, &binding.ChannelType, &binding.ChannelID, &binding.ProfileID, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		binding.CreatedAt = parseTime(createdAt)
+		binding.UpdatedAt = parseTime(updatedAt)
+		bindings = append(bindings, binding)
+	}
+	return bindings, rows.Err()
+}
+
+func (s *Store) PatchBindings(ctx context.Context, tenantID string, allowRebind bool, operations []BindingOperation) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	now := formatTime(time.Now().UTC())
+	for _, operation := range operations {
+		channelType := strings.TrimSpace(operation.ChannelType)
+		channelID := strings.TrimSpace(operation.ChannelID)
+		if !IsChannelType(channelType) || channelID == "" {
+			return ErrInvalidChannel
+		}
+		if operation.ProfileID == nil || strings.TrimSpace(*operation.ProfileID) == "" {
+			if _, err = tx.ExecContext(ctx, `DELETE FROM content_moderation_channel_bindings WHERE tenant_id=$1 AND channel_type=$2 AND channel_id=$3`, tenantID, channelType, channelID); err != nil {
+				return err
+			}
+			continue
+		}
+		profileID := strings.TrimSpace(*operation.ProfileID)
+		var exists int
+		if err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_moderation_profiles WHERE tenant_id=$1 AND id=$2`, tenantID, profileID).Scan(&exists); err != nil {
+			return err
+		}
+		if exists == 0 {
+			return ErrNotFound
+		}
+		var existing string
+		err = tx.QueryRowContext(ctx, `SELECT profile_id FROM content_moderation_channel_bindings WHERE tenant_id=$1 AND channel_type=$2 AND channel_id=$3`, tenantID, channelType, channelID).Scan(&existing)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if err == nil && existing != profileID && !allowRebind {
+			return &BindingConflictError{ChannelType: channelType, ChannelID: channelID, ExistingProfileID: existing}
+		}
+		if err == nil && existing == profileID {
+			continue
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO content_moderation_channel_bindings
+			(tenant_id,channel_type,channel_id,profile_id,created_at,updated_at) VALUES ($1,$2,$3,$4,$5,$5)
+			ON CONFLICT(tenant_id,channel_type,channel_id) DO UPDATE SET profile_id=excluded.profile_id,updated_at=excluded.updated_at`,
+			tenantID, channelType, channelID, profileID, now)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Store) DeleteChannelBinding(ctx context.Context, tenantID, channelType, channelID string) error {
+	if s == nil || s.db == nil {
+		return ErrUnavailable
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM content_moderation_channel_bindings WHERE tenant_id=$1 AND channel_type=$2 AND channel_id=$3`, tenantID, channelType, channelID)
+	return err
+}
+
+func (s *Store) ResolveProfile(ctx context.Context, tenantID, authFileID, providerKeyID, providerID string) (Profile, string, error) {
+	lookups := []struct {
+		channelType string
+		channelID   string
+	}{
+		{ChannelTypeAuthFile, strings.TrimSpace(authFileID)},
+		{ChannelTypeProviderKey, strings.TrimSpace(providerKeyID)},
+		{ChannelTypeProvider, strings.TrimSpace(providerID)},
+	}
+	for _, lookup := range lookups {
+		if lookup.channelID == "" {
+			continue
+		}
+		profile, err := scanProfile(s.db.QueryRowContext(ctx, profileSelectSQL+`
+			JOIN content_moderation_channel_bindings b ON b.tenant_id=content_moderation_profiles.tenant_id AND b.profile_id=content_moderation_profiles.id
+			WHERE b.tenant_id=$1 AND b.channel_type=$2 AND b.channel_id=$3`, tenantID, lookup.channelType, lookup.channelID))
+		if err == nil {
+			return profile, lookup.channelType, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return Profile{}, "", err
+		}
+	}
+	return Profile{}, "", ErrNotFound
+}
+
+const profileSelectSQL = `SELECT content_moderation_profiles.tenant_id,content_moderation_profiles.id,content_moderation_profiles.name,content_moderation_profiles.mode,content_moderation_profiles.base_url,content_moderation_profiles.model,content_moderation_profiles.api_key_secret,content_moderation_profiles.timeout_ms,content_moderation_profiles.keyword_mode,content_moderation_profiles.blocked_keywords_json,content_moderation_profiles.thresholds_json,content_moderation_profiles.block_http_status,content_moderation_profiles.block_message,content_moderation_profiles.version,content_moderation_profiles.created_at,content_moderation_profiles.updated_at FROM content_moderation_profiles`
+
+func scanProfile(scanner interface{ Scan(...any) error }) (Profile, error) {
+	var profile Profile
+	var keywordsJSON, thresholdsJSON, createdAt, updatedAt string
+	if err := scanner.Scan(
+		&profile.TenantID, &profile.ID, &profile.Name, &profile.Mode, &profile.BaseURL, &profile.Model, &profile.APIKeySecret,
+		&profile.TimeoutMS, &profile.KeywordMode, &keywordsJSON, &thresholdsJSON, &profile.BlockHTTPStatus, &profile.BlockMessage,
+		&profile.Version, &createdAt, &updatedAt,
+	); err != nil {
+		return Profile{}, err
+	}
+	if err := json.Unmarshal([]byte(keywordsJSON), &profile.BlockedKeywords); err != nil {
+		return Profile{}, fmt.Errorf("decode blocked keywords: %w", err)
+	}
+	if err := json.Unmarshal([]byte(thresholdsJSON), &profile.Thresholds); err != nil {
+		return Profile{}, fmt.Errorf("decode thresholds: %w", err)
+	}
+	profile.CreatedAt = parseTime(createdAt)
+	profile.UpdatedAt = parseTime(updatedAt)
+	return profile, nil
+}
+
+func profileJSON(profile Profile) (string, string, error) {
+	keywords, err := json.Marshal(profile.BlockedKeywords)
+	if err != nil {
+		return "", "", err
+	}
+	thresholds, err := json.Marshal(profile.Thresholds)
+	if err != nil {
+		return "", "", err
+	}
+	return string(keywords), string(thresholds), nil
+}
+
+func formatTime(value time.Time) string { return value.UTC().Format(time.RFC3339Nano) }
+
+func parseTime(value string) time.Time {
+	parsed, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	return parsed.UTC()
+}
+
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "unique constraint") || strings.Contains(message, "duplicate key")
+}

--- a/internal/contentmoderation/store.go
+++ b/internal/contentmoderation/store.go
@@ -288,6 +288,9 @@ func (s *Store) DeleteChannelBinding(ctx context.Context, tenantID, channelType,
 }
 
 func (s *Store) ResolveProfile(ctx context.Context, tenantID, authFileID, providerKeyID, providerID string) (Profile, string, error) {
+	if s == nil || s.db == nil {
+		return Profile{}, "", ErrUnavailable
+	}
 	lookups := []struct {
 		channelType string
 		channelID   string

--- a/internal/contentmoderation/store_test.go
+++ b/internal/contentmoderation/store_test.go
@@ -1,0 +1,114 @@
+package contentmoderation
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "modernc.org/sqlite"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "moderation.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := InitTables(db); err != nil {
+		t.Fatalf("InitTables: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewStore(db)
+}
+
+func testProfile(t *testing.T, tenantID, name, mode, keywordMode string) Profile {
+	t.Helper()
+	profile, err := NewProfile(tenantID, uuid.NewString(), CreateProfileInput{
+		Name:        name,
+		Mode:        mode,
+		KeywordMode: keywordMode,
+		APIKey:      "moderation-secret",
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	return profile
+}
+
+func TestStoreTenantIsolation(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	profileA := testProfile(t, "tenant-a", "shared-name", ModeOff, KeywordModeAPIOnly)
+	profileB := testProfile(t, "tenant-b", "shared-name", ModeOff, KeywordModeAPIOnly)
+	profileB.ID = profileA.ID
+	if err := store.CreateProfile(ctx, profileA); err != nil {
+		t.Fatalf("create tenant A: %v", err)
+	}
+	if err := store.CreateProfile(ctx, profileB); err != nil {
+		t.Fatalf("create tenant B: %v", err)
+	}
+	got, err := store.GetProfile(ctx, "tenant-a", profileA.ID)
+	if err != nil || got.TenantID != "tenant-a" {
+		t.Fatalf("tenant A get = %#v, %v", got, err)
+	}
+	items, err := store.ListProfiles(ctx, "tenant-b")
+	if err != nil || len(items) != 1 || items[0].TenantID != "tenant-b" {
+		t.Fatalf("tenant B list = %#v, %v", items, err)
+	}
+}
+
+func TestStoreDeleteProfileRestrictsBindings(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	profile := testProfile(t, "tenant-a", "bound", ModeOff, KeywordModeAPIOnly)
+	if err := store.CreateProfile(ctx, profile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	profileID := profile.ID
+	if err := store.PatchBindings(ctx, profile.TenantID, false, []BindingOperation{{
+		ChannelType: ChannelTypeAuthFile,
+		ChannelID:   "auth-1",
+		ProfileID:   &profileID,
+	}}); err != nil {
+		t.Fatalf("PatchBindings: %v", err)
+	}
+	if err := store.DeleteProfile(ctx, profile.TenantID, profile.ID); !errors.Is(err, ErrProfileBound) {
+		t.Fatalf("DeleteProfile error = %v, want ErrProfileBound", err)
+	}
+	if err := store.PatchBindings(ctx, profile.TenantID, false, []BindingOperation{{ChannelType: ChannelTypeAuthFile, ChannelID: "auth-1"}}); err != nil {
+		t.Fatalf("unbind: %v", err)
+	}
+	if err := store.DeleteProfile(ctx, profile.TenantID, profile.ID); err != nil {
+		t.Fatalf("DeleteProfile after unbind: %v", err)
+	}
+}
+
+func TestStorePatchBindingsRequiresExplicitRebind(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	first := testProfile(t, "tenant-a", "first", ModeOff, KeywordModeAPIOnly)
+	second := testProfile(t, "tenant-a", "second", ModeOff, KeywordModeAPIOnly)
+	for _, profile := range []Profile{first, second} {
+		if err := store.CreateProfile(ctx, profile); err != nil {
+			t.Fatalf("CreateProfile: %v", err)
+		}
+	}
+	if err := store.PatchBindings(ctx, "tenant-a", false, []BindingOperation{{ChannelType: ChannelTypeProviderKey, ChannelID: "key-1", ProfileID: &first.ID}}); err != nil {
+		t.Fatalf("initial bind: %v", err)
+	}
+	if err := store.PatchBindings(ctx, "tenant-a", false, []BindingOperation{{ChannelType: ChannelTypeProviderKey, ChannelID: "key-1", ProfileID: &second.ID}}); !errors.Is(err, ErrBindingConflict) {
+		t.Fatalf("rebind error = %v, want conflict", err)
+	}
+	if err := store.PatchBindings(ctx, "tenant-a", true, []BindingOperation{{ChannelType: ChannelTypeProviderKey, ChannelID: "key-1", ProfileID: &second.ID}}); err != nil {
+		t.Fatalf("allowed rebind: %v", err)
+	}
+	resolved, source, err := store.ResolveProfile(ctx, "tenant-a", "", "key-1", "")
+	if err != nil || resolved.ID != second.ID || source != ChannelTypeProviderKey {
+		t.Fatalf("ResolveProfile = %#v source=%q err=%v", resolved, source, err)
+	}
+}

--- a/internal/contentmoderation/types.go
+++ b/internal/contentmoderation/types.go
@@ -1,0 +1,328 @@
+package contentmoderation
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	ModeOff      = "off"
+	ModePreBlock = "pre_block"
+
+	KeywordModeAPIOnly       = "api_only"
+	KeywordModeKeywordOnly   = "keyword_only"
+	KeywordModeKeywordAndAPI = "keyword_and_api"
+
+	ChannelTypeAuthFile    = "auth_file"
+	ChannelTypeProviderKey = "provider_key"
+	ChannelTypeProvider    = "provider"
+
+	DefaultBaseURL      = "https://api.openai.com"
+	DefaultModel        = "omni-moderation-latest"
+	DefaultTimeoutMS    = 3000
+	DefaultBlockStatus  = 403
+	DefaultBlockMessage = "Your request was blocked by the content moderation policy."
+)
+
+var (
+	ErrUnavailable     = errors.New("content moderation store unavailable")
+	ErrNotFound        = errors.New("content moderation profile not found")
+	ErrNameConflict    = errors.New("content moderation profile name already exists")
+	ErrVersionConflict = errors.New("content moderation profile version conflict")
+	ErrProfileBound    = errors.New("content moderation profile has channel bindings")
+	ErrBindingConflict = errors.New("content moderation channel is already bound")
+	ErrInvalidChannel  = errors.New("invalid content moderation channel")
+)
+
+type Profile struct {
+	TenantID        string             `json:"-"`
+	ID              string             `json:"id"`
+	Name            string             `json:"name"`
+	Mode            string             `json:"mode"`
+	BaseURL         string             `json:"base_url"`
+	Model           string             `json:"model"`
+	APIKeySecret    string             `json:"-"`
+	TimeoutMS       int                `json:"timeout_ms"`
+	KeywordMode     string             `json:"keyword_mode"`
+	BlockedKeywords []string           `json:"blocked_keywords"`
+	Thresholds      map[string]float64 `json:"thresholds"`
+	BlockHTTPStatus int                `json:"block_http_status"`
+	BlockMessage    string             `json:"block_message"`
+	Version         int64              `json:"version"`
+	CreatedAt       time.Time          `json:"created_at"`
+	UpdatedAt       time.Time          `json:"updated_at"`
+}
+
+type CreateProfileInput struct {
+	Name            string             `json:"name"`
+	Mode            string             `json:"mode"`
+	BaseURL         string             `json:"base_url"`
+	Model           string             `json:"model"`
+	APIKey          string             `json:"api_key"`
+	TimeoutMS       int                `json:"timeout_ms"`
+	KeywordMode     string             `json:"keyword_mode"`
+	BlockedKeywords []string           `json:"blocked_keywords"`
+	Thresholds      map[string]float64 `json:"thresholds"`
+	BlockHTTPStatus int                `json:"block_http_status"`
+	BlockMessage    string             `json:"block_message"`
+}
+
+type PatchProfileInput struct {
+	Name            *string             `json:"name"`
+	Mode            *string             `json:"mode"`
+	BaseURL         *string             `json:"base_url"`
+	Model           *string             `json:"model"`
+	APIKey          *string             `json:"api_key"`
+	ClearAPIKey     bool                `json:"clear_api_key"`
+	TimeoutMS       *int                `json:"timeout_ms"`
+	KeywordMode     *string             `json:"keyword_mode"`
+	BlockedKeywords *[]string           `json:"blocked_keywords"`
+	Thresholds      *map[string]float64 `json:"thresholds"`
+	BlockHTTPStatus *int                `json:"block_http_status"`
+	BlockMessage    *string             `json:"block_message"`
+	Version         int64               `json:"version"`
+}
+
+type Binding struct {
+	TenantID    string    `json:"-"`
+	ChannelType string    `json:"channel_type"`
+	ChannelID   string    `json:"channel_id"`
+	ProfileID   string    `json:"profile_id"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type BindingOperation struct {
+	ChannelType string  `json:"channel_type"`
+	ChannelID   string  `json:"channel_id"`
+	ProfileID   *string `json:"profile_id"`
+}
+
+type BindingConflictError struct {
+	ChannelType       string
+	ChannelID         string
+	ExistingProfileID string
+}
+
+func (e *BindingConflictError) Error() string {
+	return fmt.Sprintf("%s %s is already bound to profile %s", e.ChannelType, e.ChannelID, e.ExistingProfileID)
+}
+
+func (e *BindingConflictError) Unwrap() error { return ErrBindingConflict }
+
+type ProfileBoundError struct {
+	Count int
+}
+
+func (e *ProfileBoundError) Error() string {
+	return fmt.Sprintf("profile has %d channel binding(s)", e.Count)
+}
+
+func (e *ProfileBoundError) Unwrap() error { return ErrProfileBound }
+
+func DefaultThresholds() map[string]float64 {
+	return map[string]float64{
+		"harassment":             0.98,
+		"harassment/threatening": 0.90,
+		"hate":                   0.65,
+		"hate/threatening":       0.65,
+		"illicit":                0.95,
+		"illicit/violent":        0.95,
+		"self-harm":              0.65,
+		"self-harm/intent":       0.85,
+		"self-harm/instructions": 0.65,
+		"sexual":                 0.65,
+		"sexual/minors":          0.65,
+		"violence":               0.95,
+		"violence/graphic":       0.95,
+	}
+}
+
+func NewProfile(tenantID, id string, input CreateProfileInput, now time.Time) (Profile, error) {
+	profile := Profile{
+		TenantID:        strings.TrimSpace(tenantID),
+		ID:              strings.TrimSpace(id),
+		Name:            input.Name,
+		Mode:            input.Mode,
+		BaseURL:         input.BaseURL,
+		Model:           input.Model,
+		APIKeySecret:    input.APIKey,
+		TimeoutMS:       input.TimeoutMS,
+		KeywordMode:     input.KeywordMode,
+		BlockedKeywords: input.BlockedKeywords,
+		Thresholds:      input.Thresholds,
+		BlockHTTPStatus: input.BlockHTTPStatus,
+		BlockMessage:    input.BlockMessage,
+		Version:         1,
+		CreatedAt:       now.UTC(),
+		UpdatedAt:       now.UTC(),
+	}
+	applyProfileDefaults(&profile)
+	return profile, ValidateProfile(profile)
+}
+
+func ApplyProfilePatch(profile Profile, patch PatchProfileInput, now time.Time) (Profile, error) {
+	if patch.Version <= 0 || patch.Version != profile.Version {
+		return Profile{}, ErrVersionConflict
+	}
+	if patch.Name != nil {
+		profile.Name = *patch.Name
+	}
+	if patch.Mode != nil {
+		profile.Mode = *patch.Mode
+	}
+	if patch.BaseURL != nil {
+		profile.BaseURL = *patch.BaseURL
+	}
+	if patch.Model != nil {
+		profile.Model = *patch.Model
+	}
+	if patch.APIKey != nil {
+		if key := strings.TrimSpace(*patch.APIKey); key != "" {
+			profile.APIKeySecret = key
+		}
+	}
+	if patch.ClearAPIKey {
+		profile.APIKeySecret = ""
+	}
+	if patch.TimeoutMS != nil {
+		profile.TimeoutMS = *patch.TimeoutMS
+	}
+	if patch.KeywordMode != nil {
+		profile.KeywordMode = *patch.KeywordMode
+	}
+	if patch.BlockedKeywords != nil {
+		profile.BlockedKeywords = *patch.BlockedKeywords
+	}
+	if patch.Thresholds != nil {
+		profile.Thresholds = *patch.Thresholds
+	}
+	if patch.BlockHTTPStatus != nil {
+		profile.BlockHTTPStatus = *patch.BlockHTTPStatus
+	}
+	if patch.BlockMessage != nil {
+		profile.BlockMessage = *patch.BlockMessage
+	}
+	applyProfileDefaults(&profile)
+	profile.Version++
+	profile.UpdatedAt = now.UTC()
+	return profile, ValidateProfile(profile)
+}
+
+func applyProfileDefaults(profile *Profile) {
+	profile.Name = strings.TrimSpace(profile.Name)
+	profile.Mode = strings.ToLower(strings.TrimSpace(profile.Mode))
+	if profile.Mode == "" {
+		profile.Mode = ModeOff
+	}
+	profile.BaseURL = strings.TrimRight(strings.TrimSpace(profile.BaseURL), "/")
+	if profile.BaseURL == "" {
+		profile.BaseURL = DefaultBaseURL
+	}
+	profile.Model = strings.TrimSpace(profile.Model)
+	if profile.Model == "" {
+		profile.Model = DefaultModel
+	}
+	profile.APIKeySecret = strings.TrimSpace(profile.APIKeySecret)
+	if profile.TimeoutMS == 0 {
+		profile.TimeoutMS = DefaultTimeoutMS
+	}
+	profile.KeywordMode = strings.ToLower(strings.TrimSpace(profile.KeywordMode))
+	if profile.KeywordMode == "" {
+		profile.KeywordMode = KeywordModeAPIOnly
+	}
+	profile.BlockedKeywords = normalizeKeywords(profile.BlockedKeywords)
+	profile.Thresholds = mergeThresholds(profile.Thresholds)
+	if profile.BlockHTTPStatus == 0 {
+		profile.BlockHTTPStatus = DefaultBlockStatus
+	}
+	profile.BlockMessage = strings.TrimSpace(profile.BlockMessage)
+	if profile.BlockMessage == "" {
+		profile.BlockMessage = DefaultBlockMessage
+	}
+}
+
+func ValidateProfile(profile Profile) error {
+	if profile.TenantID == "" || profile.ID == "" {
+		return errors.New("tenant and profile id are required")
+	}
+	if profile.Name == "" {
+		return errors.New("name is required")
+	}
+	if profile.Mode != ModeOff && profile.Mode != ModePreBlock {
+		return errors.New("mode must be off or pre_block")
+	}
+	switch profile.KeywordMode {
+	case KeywordModeAPIOnly, KeywordModeKeywordOnly, KeywordModeKeywordAndAPI:
+	default:
+		return errors.New("keyword_mode must be api_only, keyword_only, or keyword_and_api")
+	}
+	if profile.TimeoutMS <= 0 || profile.TimeoutMS > 30000 {
+		return errors.New("timeout_ms must be between 1 and 30000")
+	}
+	if profile.BlockHTTPStatus < 400 || profile.BlockHTTPStatus > 599 {
+		return errors.New("block_http_status must be between 400 and 599")
+	}
+	if profile.Mode == ModePreBlock && profile.KeywordMode != KeywordModeKeywordOnly && profile.APIKeySecret == "" {
+		return errors.New("api_key is required for API moderation in pre_block mode")
+	}
+	for category, threshold := range profile.Thresholds {
+		if strings.TrimSpace(category) == "" || threshold < 0 || threshold > 1 {
+			return fmt.Errorf("invalid threshold for category %q", category)
+		}
+	}
+	return nil
+}
+
+func normalizeKeywords(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return strings.ToLower(out[i]) < strings.ToLower(out[j]) })
+	return out
+}
+
+func mergeThresholds(overrides map[string]float64) map[string]float64 {
+	out := DefaultThresholds()
+	for category, threshold := range overrides {
+		category = strings.TrimSpace(category)
+		if category != "" {
+			out[category] = threshold
+		}
+	}
+	return out
+}
+
+func IsChannelType(value string) bool {
+	switch strings.TrimSpace(value) {
+	case ChannelTypeAuthFile, ChannelTypeProviderKey, ChannelTypeProvider:
+		return true
+	default:
+		return false
+	}
+}
+
+func MaskSecret(secret string) string {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return ""
+	}
+	if len(secret) <= 8 {
+		return "****"
+	}
+	return secret[:4] + "****" + secret[len(secret)-4:]
+}

--- a/internal/identity/menus.go
+++ b/internal/identity/menus.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 )
 
-const MenuManagementCode = "system.menus"
+const (
+	MenuManagementCode        = "system.menus"
+	ContentModerationMenuCode = "runtime.content-moderation"
+)
 
 type Menu struct {
 	Code            string `json:"code"`
@@ -89,7 +92,6 @@ var MenuCatalog = []MenuSeed{
 	{Code: "runtime.monitor", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/monitor", Component: "monitor", LabelKey: "shell.nav_monitor", Icon: "activity", PermissionCode: "monitor.read", SortOrder: 10},
 	{Code: "runtime.request-logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/request-logs", Component: "request-logs", LabelKey: "shell.nav_request_logs", Icon: "scroll-text", PermissionCode: "request_logs.read", SortOrder: 20},
 	{Code: "runtime.logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/logs", Component: "logs", LabelKey: "shell.nav_logs", Icon: "file-text", PermissionCode: "system.logs.read", SortOrder: 30},
-	{Code: "runtime.content-moderation", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/content-moderation", Component: "content-moderation", LabelKey: "shell.nav_content_moderation", Icon: "shield-alert", PermissionCode: "content_moderation.read", SortOrder: 40},
 	// Access & credentials (upstream AI + client keys)
 	{Code: "access.providers", ParentCode: "group.access", Type: "menu", Path: "/access/ai-providers", Component: "providers", LabelKey: "shell.nav_ai_providers", Icon: "bot", PermissionCode: "providers.read", SortOrder: 10},
 	// Stable code kept for role/menu bindings; path lives under /access as AI OAuth accounts.
@@ -100,6 +102,8 @@ var MenuCatalog = []MenuSeed{
 	{Code: "access.end-users", ParentCode: "group.access", Type: "menu", Path: "/access/end-users", Component: "end-users", LabelKey: "shell.nav_end_users", Icon: "user-round", PermissionCode: "end_users.read", SortOrder: 25},
 	// Stable code kept; API Key permission profiles belong with client credentials.
 	{Code: "system.api-key-permissions", ParentCode: "group.access", Type: "menu", Path: "/access/api-key-permissions", Component: "api-key-permissions", LabelKey: "shell.nav_api_key_permissions", Icon: "shield-check", PermissionCode: "api_key_profiles.read", SortOrder: 40},
+	// Stable code kept for existing menu references; content moderation belongs with access credentials.
+	{Code: ContentModerationMenuCode, ParentCode: "group.access", Type: "menu", Path: "/access/content-moderation", Component: "content-moderation", LabelKey: "shell.nav_content_moderation", Icon: "shield-alert", PermissionCode: "content_moderation.read", SortOrder: 45},
 	// Tenant-scoped: matches /ccswitch-import-configs API auth (routing.read/write).
 	// Must not use platform system.config.read, or ordinary tenants never see this menu.
 	{Code: "access.ccswitch", ParentCode: "group.access", Type: "menu", Path: "/access/ccswitch-import-settings", Component: "ccswitch-import-settings", LabelKey: "shell.nav_ccswitch_import_settings", Icon: "arrow-down-to-line", PermissionCode: "routing.read", SortOrder: 50},

--- a/internal/identity/menus.go
+++ b/internal/identity/menus.go
@@ -89,6 +89,7 @@ var MenuCatalog = []MenuSeed{
 	{Code: "runtime.monitor", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/monitor", Component: "monitor", LabelKey: "shell.nav_monitor", Icon: "activity", PermissionCode: "monitor.read", SortOrder: 10},
 	{Code: "runtime.request-logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/request-logs", Component: "request-logs", LabelKey: "shell.nav_request_logs", Icon: "scroll-text", PermissionCode: "request_logs.read", SortOrder: 20},
 	{Code: "runtime.logs", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/logs", Component: "logs", LabelKey: "shell.nav_logs", Icon: "file-text", PermissionCode: "system.logs.read", SortOrder: 30},
+	{Code: "runtime.content-moderation", ParentCode: "group.runtime", Type: "menu", Path: "/runtime/content-moderation", Component: "content-moderation", LabelKey: "shell.nav_content_moderation", Icon: "shield-alert", PermissionCode: "content_moderation.read", SortOrder: 40},
 	// Access & credentials (upstream AI + client keys)
 	{Code: "access.providers", ParentCode: "group.access", Type: "menu", Path: "/access/ai-providers", Component: "providers", LabelKey: "shell.nav_ai_providers", Icon: "bot", PermissionCode: "providers.read", SortOrder: 10},
 	// Stable code kept for role/menu bindings; path lives under /access as AI OAuth accounts.

--- a/internal/identity/permissions.go
+++ b/internal/identity/permissions.go
@@ -102,7 +102,7 @@ func menuCodeForPermission(permission PermissionSeed) string {
 	case "request_logs":
 		return "runtime.request-logs"
 	case "content_moderation":
-		return "runtime.content-moderation"
+		return ContentModerationMenuCode
 	case "providers":
 		return "access.providers"
 	case "auth_files":

--- a/internal/identity/permissions.go
+++ b/internal/identity/permissions.go
@@ -48,6 +48,9 @@ var PermissionCatalog = []PermissionSeed{
 	{Code: "request_logs.read", Name: "Read request logs", Scope: "tenant", Resource: "request_logs", Action: "read"},
 	{Code: "request_logs.content.read", Name: "Read request content", Scope: "tenant", Resource: "request_logs", Action: "read_content", Sensitive: true},
 	{Code: "request_logs.delete", Name: "Delete request logs", Scope: "tenant", Resource: "request_logs", Action: "delete", Sensitive: true},
+	{Code: "content_moderation.read", Name: "Read content moderation", Scope: "tenant", Resource: "content_moderation", Action: "read"},
+	{Code: "content_moderation.write", Name: "Write content moderation", Scope: "tenant", Resource: "content_moderation", Action: "write", Sensitive: true},
+	{Code: "content_moderation.test", Name: "Test content moderation", Scope: "tenant", Resource: "content_moderation", Action: "test", Sensitive: true},
 	{Code: "providers.read", Name: "Read providers", Scope: "tenant", Resource: "providers", Action: "read"},
 	{Code: "providers.write", Name: "Write providers", Scope: "tenant", Resource: "providers", Action: "write", Sensitive: true},
 	{Code: "providers.test", Name: "Test providers", Scope: "tenant", Resource: "providers", Action: "test", Sensitive: true},
@@ -98,6 +101,8 @@ func menuCodeForPermission(permission PermissionSeed) string {
 		return "runtime.monitor"
 	case "request_logs":
 		return "runtime.request-logs"
+	case "content_moderation":
+		return "runtime.content-moderation"
 	case "providers":
 		return "access.providers"
 	case "auth_files":

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -187,6 +187,20 @@ func TestMenuCatalogReferencesExistingParents(t *testing.T) {
 	if plaza.PermissionCode != "system.status.read" {
 		t.Fatalf("models.plaza permission = %q, want system.status.read", plaza.PermissionCode)
 	}
+	// Content moderation is an access/credential concern, while its stable code preserves existing references.
+	moderation, ok := seen[ContentModerationMenuCode]
+	if !ok {
+		t.Fatalf("%s menu is missing", ContentModerationMenuCode)
+	}
+	if moderation.ParentCode != "group.access" {
+		t.Fatalf("%s parent = %q, want group.access", ContentModerationMenuCode, moderation.ParentCode)
+	}
+	if moderation.Path != "/access/content-moderation" {
+		t.Fatalf("%s path = %q, want /access/content-moderation", ContentModerationMenuCode, moderation.Path)
+	}
+	if moderation.PermissionCode != "content_moderation.read" {
+		t.Fatalf("%s permission = %q, want content_moderation.read", ContentModerationMenuCode, moderation.PermissionCode)
+	}
 }
 
 func TestGeneratedIdentifier(t *testing.T) {
@@ -219,11 +233,12 @@ func TestMenuCodeForPermission(t *testing.T) {
 		menuCodes[menu.Code] = true
 	}
 	tests := map[string]string{
-		"tenant.users.update":   "governance.users",
-		"request_logs.delete":   "runtime.request-logs",
-		"system.logs.delete":    "runtime.logs",
-		"platform.menus.update": MenuManagementCode,
-		"proxies.test":          "models.proxies",
+		"tenant.users.update":     "governance.users",
+		"request_logs.delete":     "runtime.request-logs",
+		"system.logs.delete":      "runtime.logs",
+		"platform.menus.update":   MenuManagementCode,
+		"content_moderation.read": ContentModerationMenuCode,
+		"proxies.test":            "models.proxies",
 	}
 	for _, permission := range PermissionCatalog {
 		got := menuCodeForPermission(permission)

--- a/internal/logging/global_logger.go
+++ b/internal/logging/global_logger.go
@@ -30,7 +30,7 @@ var (
 type LogFormatter struct{}
 
 // logFieldOrder defines the display order for common log fields.
-var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error"}
+var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error_class", "profile_id", "profile_version", "resolution_source", "channel_type", "channel_id", "action", "latency_ms", "cache_hit", "category", "score", "error"}
 
 // Format renders a single log entry with custom formatting.
 func (m *LogFormatter) Format(entry *log.Entry) ([]byte, error) {

--- a/internal/logging/global_logger_test.go
+++ b/internal/logging/global_logger_test.go
@@ -1,0 +1,53 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestLogFormatterIncludesModerationFields(t *testing.T) {
+	entry := &log.Entry{
+		Logger:  log.New(),
+		Time:    time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC),
+		Level:   log.WarnLevel,
+		Message: "content moderation failed open",
+		Data: log.Fields{
+			"error_class":       "timeout",
+			"profile_id":        "profile-1",
+			"profile_version":   3,
+			"resolution_source": "provider_key",
+			"channel_type":      "provider_key",
+			"channel_id":        "key-1",
+			"action":            "api_error",
+			"latency_ms":        3000,
+			"cache_hit":         false,
+			"category":          "violence",
+			"score":             0.91,
+		},
+	}
+	formatted, err := (&LogFormatter{}).Format(entry)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	output := string(formatted)
+	for _, field := range []string{
+		"error_class=timeout",
+		"profile_id=profile-1",
+		"profile_version=3",
+		"resolution_source=provider_key",
+		"channel_type=provider_key",
+		"channel_id=key-1",
+		"action=api_error",
+		"latency_ms=3000",
+		"cache_hit=false",
+		"category=violence",
+		"score=0.91",
+	} {
+		if !strings.Contains(output, field) {
+			t.Fatalf("formatted log missing %q: %s", field, output)
+		}
+	}
+}

--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -323,12 +323,18 @@ func needsRuntimeQuotaReconcile(auth *coreauth.Auth) bool {
 		return false
 	}
 	now := time.Now()
+	if auth.Quota.Exceeded && auth.Quota.RecoveryRequired {
+		return true
+	}
 	if auth.Unavailable && auth.Quota.Exceeded && auth.NextRetryAfter.After(now) {
 		return true
 	}
 	for _, state := range auth.ModelStates {
 		if state == nil {
 			continue
+		}
+		if state.Quota.Exceeded && state.Quota.RecoveryRequired {
+			return true
 		}
 		if state.Unavailable && state.Quota.Exceeded && state.NextRetryAfter.After(now) {
 			return true
@@ -499,6 +505,7 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		})
 		return
 	}
+	s.applyRuntimeQuotaProbe(ctx, auth, probe)
 
 	healthStatus := strings.TrimSpace(probe.Health)
 	if healthStatus == "" {
@@ -641,6 +648,32 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		r.UpdatedAt = checked
 		r.Result = view
 	})
+}
+
+func (s *Service) applyRuntimeQuotaProbe(ctx context.Context, auth *coreauth.Auth, probe ProbeResult) {
+	if s == nil || s.authManager == nil || auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if provider != "xai" && provider != "x-ai" && provider != "grok" {
+		return
+	}
+	for _, quota := range probe.Quotas {
+		if quota.QuotaKey != "weekly_limit" || quota.Percent == nil {
+			continue
+		}
+		result := &coreauth.QuotaProbeResult{
+			Recovered:       *quota.Percent > 0,
+			WindowExhausted: *quota.Percent <= 0,
+			Window:          "week",
+			WindowMinutes:   10080,
+		}
+		if quota.ResetAt != nil && quota.ResetAt.After(time.Now()) {
+			result.NextRecoverAt = *quota.ResetAt
+		}
+		_, _ = s.authManager.UpdateQuotaFromProbe(ctx, auth.ID, result)
+		return
+	}
 }
 
 func (s *Service) loadLegacyPersistedStatus(tenantID, subjectID string) (*usage.AIAccountStatusRecord, error) {

--- a/internal/management/aiaccountstatus/service_test.go
+++ b/internal/management/aiaccountstatus/service_test.go
@@ -876,8 +876,8 @@ func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
 	defer admin.Close()
 	if _, err := admin.Exec(`
 		INSERT INTO ai_account_subject_usage_buckets
-			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, first_event_at, updated_at)
-		VALUES (?, 'cycle', ?, 1, 1, 0, 1, ?, ?)
+			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at)
+		VALUES (?, 'cycle', ?, 1, 1, 0, 1, 456, ?, ?)
 	`, identity.ID, cycleStart.Format(time.RFC3339Nano), cycleStart.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
 		t.Fatal(err)
 	}
@@ -913,7 +913,7 @@ func TestListStatusNewTenantBindingReadsExistingSharedStatus(t *testing.T) {
 	if item.CurrentTenantBindingCount != 1 || item.AuthIndex != authB.EnsureIndex() {
 		t.Fatalf("tenant B binding projection=%+v", item)
 	}
-	if !item.Usage.CycleKnown || item.Usage.CycleRequestTotal != 1 {
+	if !item.Usage.CycleKnown || item.Usage.CycleRequestTotal != 1 || item.Usage.CycleTotalTokens != 456 {
 		t.Fatalf("binding repair changed shared cycle usage: %+v", item.Usage)
 	}
 }

--- a/internal/management/aiaccountstatus/service_test.go
+++ b/internal/management/aiaccountstatus/service_test.go
@@ -13,6 +13,7 @@ import (
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	_ "modernc.org/sqlite"
 )
 
@@ -573,6 +574,52 @@ func TestNeedsRuntimeQuotaReconcile(t *testing.T) {
 	}
 	if !needsRuntimeQuotaReconcile(cool) {
 		t.Fatal("cooldown should reconcile")
+	}
+}
+
+func TestApplyRuntimeQuotaProbe_XAIWeeklyZeroBlocksUntilRecovered(t *testing.T) {
+	t.Parallel()
+
+	auth := &coreauth.Auth{
+		ID:       "xai-weekly-zero",
+		Provider: "xai",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"type": "xai", "sub": "xai-user"},
+	}
+	manager := newTestManager(t, "tenant-xai", auth)
+	svc := New(&config.Config{}, manager, nil, nil)
+	zero := 0.0
+	svc.applyRuntimeQuotaProbe(context.Background(), auth, ProbeResult{Quotas: []usage.QuotaWindowDTO{{
+		QuotaKey: "weekly_limit",
+		Percent:  &zero,
+	}}})
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatal("updated auth missing")
+	}
+	if !got.Quota.Exceeded || !got.Quota.RecoveryRequired || got.Quota.Window != "week" {
+		t.Fatalf("quota = %#v, want weekly confirmed-recovery gate", got.Quota)
+	}
+	selector := &coreauth.RoundRobinSelector{}
+	if picked, err := selector.Pick(context.Background(), "xai", "grok-4.5", cliproxyexecutor.Options{}, []*coreauth.Auth{got}); err == nil || picked != nil {
+		t.Fatalf("Pick() = %#v, %v; want blocked auth", picked, err)
+	}
+
+	remaining := 25.0
+	svc.applyRuntimeQuotaProbe(context.Background(), auth, ProbeResult{Quotas: []usage.QuotaWindowDTO{{
+		QuotaKey: "weekly_limit",
+		Percent:  &remaining,
+	}}})
+	got, _ = manager.GetByID(auth.ID)
+	if got.Quota.Exceeded || got.Quota.RecoveryRequired {
+		t.Fatalf("quota = %#v, want recovered", got.Quota)
+	}
+	if _, exists := got.Metadata["_cli_proxy_runtime_quota"]; exists {
+		t.Fatal("recovered auth retained persisted quota runtime metadata")
+	}
+	if picked, err := selector.Pick(context.Background(), "xai", "grok-4.5", cliproxyexecutor.Options{}, []*coreauth.Auth{got}); err != nil || picked == nil {
+		t.Fatalf("Pick() = %#v, %v; want recovered auth", picked, err)
 	}
 }
 

--- a/internal/management/authfiles/delete.go
+++ b/internal/management/authfiles/delete.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -13,11 +14,12 @@ import (
 var ErrAuthFileNotFound = errors.New("auth file not found")
 
 type DeleteService struct {
-	AuthDir        string
-	TenantID       string
-	Manager        *coreauth.Manager
-	Repository     Repository
-	RemoveChannels func([]string) error
+	AuthDir            string
+	TenantID           string
+	Manager            *coreauth.Manager
+	Repository         Repository
+	RemoveChannels     func([]string) error
+	RemoveAuthBindings func([]string) error
 }
 
 type DeleteResult struct {
@@ -101,11 +103,15 @@ func (s DeleteService) DeleteOne(ctx context.Context, name string) (DeleteResult
 	}
 
 	deletedChannels := DeletedChannelIdentifiers(target)
+	deletedAuthIDs := deletedAuthBindingIdentifiers(target)
 	if target != nil && s.Manager != nil {
 		_, _ = s.Manager.Delete(coreauth.WithSkipPersist(ctx), target.ID)
 	}
 	result := DeleteResult{Deleted: 1}
-	if errCleanup := s.removeChannelReferences(deletedChannels); errCleanup != nil {
+	if errCleanup := errors.Join(
+		s.removeChannelReferences(deletedChannels),
+		s.removeAuthBindingReferences(deletedAuthIDs),
+	); errCleanup != nil {
 		// The credential is already durably deleted. Preserve that outcome so the
 		// caller can remove stale UI state while surfacing the cleanup warning.
 		return result, fmt.Errorf("auth file deleted but channel reference cleanup failed: %w", errCleanup)
@@ -113,9 +119,29 @@ func (s DeleteService) DeleteOne(ctx context.Context, name string) (DeleteResult
 	return result, nil
 }
 
+func deletedAuthBindingIdentifiers(auth *coreauth.Auth) []string {
+	if auth == nil {
+		return nil
+	}
+	if parent := strings.TrimSpace(Attribute(auth, "gemini_virtual_parent")); parent != "" {
+		return []string{parent}
+	}
+	if id := strings.TrimSpace(auth.ID); id != "" {
+		return []string{id}
+	}
+	return nil
+}
+
 func (s DeleteService) removeChannelReferences(channels []string) error {
 	if len(channels) == 0 || s.RemoveChannels == nil {
 		return nil
 	}
 	return s.RemoveChannels(channels)
+}
+
+func (s DeleteService) removeAuthBindingReferences(authIDs []string) error {
+	if len(authIDs) == 0 || s.RemoveAuthBindings == nil {
+		return nil
+	}
+	return s.RemoveAuthBindings(authIDs)
 }

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -77,11 +77,7 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		allModels = s.filterModelsByRoutingAllowedModels(allModels, allowedGroupsRaw)
 	}
 
-	allConfigRows := modelconfigsettings.ListAllConfigsForTenant(s.tenantID)
-	configByID := make(map[string]usage.ModelConfigRow, len(allConfigRows))
-	for _, row := range allConfigRows {
-		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
-	}
+	configByID, pricingByID := pricingLookupMapsForTenant(s.tenantID)
 	data := make([]map[string]any, 0, len(allModels))
 	activeMetadata := make([]map[string]any, 0, len(allModels))
 	for _, model := range allModels {
@@ -111,15 +107,6 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 		}
 		if row, ok := configByID[strings.ToLower(id)]; ok {
 			attachModelConfigCapabilities(entry, row)
-			entry["pricing"] = map[string]any{
-				"mode":                          row.PricingMode,
-				"input_price_per_million":       row.InputPricePerMillion,
-				"output_price_per_million":      row.OutputPricePerMillion,
-				"cached_price_per_million":      row.CachedPricePerMillion,
-				"cache_read_price_per_million":  row.CacheReadPricePerMillion,
-				"cache_write_price_per_million": row.CacheWritePricePerMillion,
-				"price_per_call":                row.PricePerCall,
-			}
 			if row.Description != "" {
 				entry["description"] = row.Description
 			}
@@ -134,6 +121,9 @@ func (s *Service) ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw st
 					"enabled":  row.Enabled,
 				})
 			}
+		}
+		if pricing, ok := usage.ResolveModelPricingRow(id, configByID, pricingByID); ok {
+			entry["pricing"] = modelPricingPayload(pricing)
 		}
 		data = append(data, entry)
 	}
@@ -169,7 +159,7 @@ func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string, opts ...Av
 		allModels = s.filterModelsByRoutingAllowedModels(allModels, allowedGroupsRaw)
 	}
 
-	pricingMap := usage.GetAllModelPricingForTenant(s.tenantID)
+	configByID, pricingByID := pricingLookupMapsForTenant(s.tenantID)
 	filteredModels := make([]map[string]any, len(allModels))
 	for i, model := range allModels {
 		filteredModel := map[string]any{
@@ -183,10 +173,10 @@ func (s *Service) Models(allowedChannelsRaw, allowedGroupsRaw string, opts ...Av
 			filteredModel["owned_by"] = ownedBy
 		}
 		if modelID, ok := model["id"].(string); ok {
-			if row, exists := modelconfigsettings.GetConfigForTenant(s.tenantID, modelID); exists {
+			if row, exists := configByID[strings.ToLower(strings.TrimSpace(modelID))]; exists {
 				attachModelConfigCapabilities(filteredModel, row)
 			}
-			if pricing, exists := pricingMap[modelID]; exists {
+			if pricing, exists := usage.ResolveModelPricingRow(modelID, configByID, pricingByID); exists {
 				filteredModel["pricing"] = map[string]any{
 					"input_price_per_million":  pricing.InputPricePerMillion,
 					"output_price_per_million": pricing.OutputPricePerMillion,

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -22,6 +22,73 @@ func initModelCatalogTestDB(t *testing.T) {
 	t.Cleanup(usage.CloseDB)
 }
 
+func TestRuntimePrefixedModelInheritsBasePricing(t *testing.T) {
+	initModelCatalogTestDB(t)
+
+	const (
+		baseModelID    = "deepseek-v4-flash"
+		runtimeModelID = "ollama/deepseek-v4-flash"
+		clientID       = "pricing-fallback-ollama"
+	)
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:               baseModelID,
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(clientID)
+	modelRegistry.RegisterClient(clientID, "ollama-cloud", []*registry.ModelInfo{{
+		ID:      runtimeModelID,
+		Object:  "model",
+		OwnedBy: "ollama",
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	service := New(&config.Config{}, nil)
+	assertInheritedPricing := func(stage string) {
+		t.Helper()
+		for name, result := range map[string]map[string]any{
+			"configured availability": service.ConfiguredAvailability("", ""),
+			"models":                  service.Models("", ""),
+		} {
+			data, ok := result["data"].([]map[string]any)
+			if !ok {
+				t.Fatalf("%s %s data = %#v, want []map[string]any", stage, name, result["data"])
+			}
+			var pricing map[string]any
+			for _, item := range data {
+				if item["id"] == runtimeModelID {
+					pricing, _ = item["pricing"].(map[string]any)
+					break
+				}
+			}
+			if pricing == nil {
+				t.Fatalf("%s %s missing inherited pricing for %q", stage, name, runtimeModelID)
+			}
+			if pricing["input_price_per_million"] != 0.3 || pricing["output_price_per_million"] != 1.2 {
+				t.Fatalf("%s %s pricing = %#v, want input=0.3 output=1.2", stage, name, pricing)
+			}
+		}
+	}
+
+	assertInheritedPricing("missing exact row")
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     runtimeModelID,
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(exact zero price) error = %v", err)
+	}
+	assertInheritedPricing("unpriced exact row")
+}
+
 func TestConfiguredAvailabilityIncludesModelSources(t *testing.T) {
 	const modelID = "source-test-model"
 	const codexClientID = "source-test-codex"

--- a/internal/management/modelcatalog/configs.go
+++ b/internal/management/modelcatalog/configs.go
@@ -18,9 +18,14 @@ var ErrAuthGroupRequired = errors.New("auth group is required")
 // - Responsibility: CRUD and response shaping for stored model catalog settings.
 func (s *Service) ListModelConfigs(scope string) map[string]any {
 	rows := modelconfigsettings.ListConfigsForTenant(s.tenantID, scope)
+	configByID, pricingByID := pricingLookupMapsForTenant(s.tenantID)
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
-		items = append(items, modelConfigResponse(row))
+		pricing := row
+		if resolved, ok := usage.ResolveModelPricingRow(row.ModelID, configByID, pricingByID); ok {
+			pricing = resolved
+		}
+		items = append(items, modelConfigResponse(row, pricing))
 	}
 	return map[string]any{"object": "list", "data": items}
 }
@@ -55,7 +60,12 @@ func (s *Service) UpsertModelConfig(payload ModelConfigPayload, originalID, scop
 		}
 		return nil, err
 	}
-	return modelConfigResponse(saved), nil
+	pricing := saved
+	configByID, pricingByID := pricingLookupMapsForTenant(s.tenantID)
+	if resolved, ok := usage.ResolveModelPricingRow(saved.ModelID, configByID, pricingByID); ok {
+		pricing = resolved
+	}
+	return modelConfigResponse(saved, pricing), nil
 }
 
 func (s *Service) DeleteModelConfig(modelID string) error {

--- a/internal/management/modelcatalog/configs_test.go
+++ b/internal/management/modelcatalog/configs_test.go
@@ -1,0 +1,68 @@
+package modelcatalog
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func TestListModelConfigsUsesEffectivePricing(t *testing.T) {
+	initModelCatalogTestDB(t)
+
+	const (
+		baseModelID    = "deepseek-v4-flash"
+		runtimeModelID = "ollama/deepseek-v4-flash"
+		variantModelID = "deepseek-v4-flash:free"
+	)
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:               baseModelID,
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.098,
+		OutputPricePerMillion: 0.196,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     runtimeModelID,
+		Description: "exact runtime row",
+		Enabled:     false,
+		PricingMode: "token",
+		Source:      "seed",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(runtime) error = %v", err)
+	}
+	if err := usage.UpsertModelConfig(usage.ModelConfigRow{
+		ModelID:     variantModelID,
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(variant) error = %v", err)
+	}
+
+	result := New(nil, nil).ListModelConfigs("library")
+	data, ok := result["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v, want []map[string]any", result["data"])
+	}
+	found := make(map[string]bool, 2)
+	for _, item := range data {
+		modelID, _ := item["id"].(string)
+		if modelID != runtimeModelID && modelID != variantModelID {
+			continue
+		}
+		if modelID == runtimeModelID && (item["description"] != "exact runtime row" || item["enabled"] != false || item["source"] != "seed") {
+			t.Fatalf("exact identity fields changed: %#v", item)
+		}
+		pricing, _ := item["pricing"].(map[string]any)
+		if pricing["input_price_per_million"] != 0.098 || pricing["output_price_per_million"] != 0.196 {
+			t.Fatalf("pricing for %q = %#v, want inherited base pricing", modelID, pricing)
+		}
+		found[modelID] = true
+	}
+	if !found[runtimeModelID] || !found[variantModelID] {
+		t.Fatalf("library response missing effective pricing rows: found=%v", found)
+	}
+}

--- a/internal/management/modelcatalog/pricing.go
+++ b/internal/management/modelcatalog/pricing.go
@@ -1,0 +1,34 @@
+package modelcatalog
+
+import (
+	"strings"
+
+	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func pricingLookupMapsForTenant(tenantID string) (map[string]usage.ModelConfigRow, map[string]usage.ModelPricingRow) {
+	configRows := modelconfigsettings.ListAllConfigsForTenant(tenantID)
+	configByID := make(map[string]usage.ModelConfigRow, len(configRows))
+	for _, row := range configRows {
+		configByID[strings.ToLower(strings.TrimSpace(row.ModelID))] = row
+	}
+	pricingRows := usage.GetAllModelPricingForTenant(tenantID)
+	pricingByID := make(map[string]usage.ModelPricingRow, len(pricingRows))
+	for modelID, row := range pricingRows {
+		pricingByID[strings.ToLower(strings.TrimSpace(modelID))] = row
+	}
+	return configByID, pricingByID
+}
+
+func modelPricingPayload(row usage.ModelConfigRow) map[string]any {
+	return map[string]any{
+		"mode":                          row.PricingMode,
+		"input_price_per_million":       row.InputPricePerMillion,
+		"output_price_per_million":      row.OutputPricePerMillion,
+		"cached_price_per_million":      row.CachedPricePerMillion,
+		"cache_read_price_per_million":  row.CacheReadPricePerMillion,
+		"cache_write_price_per_million": row.CacheWritePricePerMillion,
+		"price_per_call":                row.PricePerCall,
+	}
+}

--- a/internal/management/modelcatalog/types.go
+++ b/internal/management/modelcatalog/types.go
@@ -82,23 +82,15 @@ type configuredModelPathRoute struct {
 	Group string
 }
 
-func modelConfigResponse(row usage.ModelConfigRow) map[string]any {
+func modelConfigResponse(row, pricing usage.ModelConfigRow) map[string]any {
 	response := map[string]any{
 		"id":          row.ModelID,
 		"owned_by":    row.OwnedBy,
 		"description": row.Description,
 		"enabled":     row.Enabled,
-		"pricing": map[string]any{
-			"mode":                          row.PricingMode,
-			"input_price_per_million":       row.InputPricePerMillion,
-			"output_price_per_million":      row.OutputPricePerMillion,
-			"cached_price_per_million":      row.CachedPricePerMillion,
-			"cache_read_price_per_million":  row.CacheReadPricePerMillion,
-			"cache_write_price_per_million": row.CacheWritePricePerMillion,
-			"price_per_call":                row.PricePerCall,
-		},
-		"source":     row.Source,
-		"updated_at": row.UpdatedAt,
+		"pricing":     modelPricingPayload(pricing),
+		"source":      row.Source,
+		"updated_at":  row.UpdatedAt,
 	}
 	if row.DisplayName != "" {
 		response["display_name"] = row.DisplayName

--- a/internal/management/settings/providers/compatibility.go
+++ b/internal/management/settings/providers/compatibility.go
@@ -35,7 +35,9 @@ func (s *Service) ReplaceOpenAICompatibility(entries []config.OpenAICompatibilit
 		}
 	}
 	prev := append([]config.OpenAICompatibility(nil), s.cfg.OpenAICompatibility...)
-	s.cfg.OpenAICompatibility = filtered
+	next := &config.Config{OpenAICompatibility: filtered}
+	prepareProviderStableIDs(&config.Config{OpenAICompatibility: prev}, next)
+	s.cfg.OpenAICompatibility = next.OpenAICompatibility
 	s.cfg.SanitizeOpenAICompatibility()
 	if err := s.runValidator(); err != nil {
 		s.cfg.OpenAICompatibility = prev
@@ -85,7 +87,10 @@ func (s *Service) PatchOpenAICompatibility(index *int, name *string, patch OpenA
 		entry.BaseURL = trimmed
 	}
 	if patch.APIKeyEntries != nil {
-		entry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), (*patch.APIKeyEntries)...)
+		next := &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{APIKeyEntries: append([]config.OpenAICompatibilityAPIKey(nil), (*patch.APIKeyEntries)...)}}}
+		previous := &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{APIKeyEntries: entry.APIKeyEntries}}}
+		prepareProviderStableIDs(previous, next)
+		entry.APIKeyEntries = next.OpenAICompatibility[0].APIKeyEntries
 	}
 	if patch.Models != nil {
 		entry.Models = append([]config.OpenAICompatibilityModel(nil), (*patch.Models)...)
@@ -151,7 +156,10 @@ func (s *Service) ReplaceVertexCompatKeys(entries []config.VertexCompatKey) {
 	for i := range entries {
 		NormalizeVertexCompatKey(&entries[i])
 	}
-	s.cfg.VertexCompatAPIKey = entries
+	prev := append([]config.VertexCompatKey(nil), s.cfg.VertexCompatAPIKey...)
+	next := &config.Config{VertexCompatAPIKey: entries}
+	prepareProviderStableIDs(&config.Config{VertexCompatAPIKey: prev}, next)
+	s.cfg.VertexCompatAPIKey = next.VertexCompatAPIKey
 	s.cfg.SanitizeVertexCompatKeys()
 }
 

--- a/internal/management/settings/providers/provider_keys_extended.go
+++ b/internal/management/settings/providers/provider_keys_extended.go
@@ -48,7 +48,9 @@ func (s *Service) ReplaceBedrockKeys(entries []config.BedrockKey) error {
 		NormalizeBedrockKey(&normalized[i])
 	}
 	prev := append([]config.BedrockKey(nil), s.cfg.BedrockKey...)
-	s.cfg.BedrockKey = normalized
+	next := &config.Config{BedrockKey: normalized}
+	prepareProviderStableIDs(&config.Config{BedrockKey: prev}, next)
+	s.cfg.BedrockKey = next.BedrockKey
 	s.cfg.SanitizeBedrockKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.BedrockKey = prev
@@ -219,7 +221,9 @@ func (s *Service) ReplaceOpenCodeGoKeys(entries []config.OpenCodeGoKey) error {
 		return ErrProviderAPIKeyRequired
 	}
 	prev := append([]config.OpenCodeGoKey(nil), s.cfg.OpenCodeGoKey...)
-	s.cfg.OpenCodeGoKey = filtered
+	next := &config.Config{OpenCodeGoKey: filtered}
+	prepareProviderStableIDs(&config.Config{OpenCodeGoKey: prev}, next)
+	s.cfg.OpenCodeGoKey = next.OpenCodeGoKey
 	s.cfg.SanitizeOpenCodeGoKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.OpenCodeGoKey = prev
@@ -395,7 +399,9 @@ func (s *Service) ReplaceClineKeys(entries []config.ClineKey) error {
 		return ErrProviderAPIKeyRequired
 	}
 	prev := append([]config.ClineKey(nil), s.cfg.ClineKey...)
-	s.cfg.ClineKey = filtered
+	next := &config.Config{ClineKey: filtered}
+	prepareProviderStableIDs(&config.Config{ClineKey: prev}, next)
+	s.cfg.ClineKey = next.ClineKey
 	s.cfg.SanitizeClineKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.ClineKey = prev
@@ -571,7 +577,9 @@ func (s *Service) ReplaceOllamaCloudKeys(entries []config.OllamaCloudKey) error 
 		return ErrProviderAPIKeyRequired
 	}
 	prev := append([]config.OllamaCloudKey(nil), s.cfg.OllamaCloudKey...)
-	s.cfg.OllamaCloudKey = filtered
+	next := &config.Config{OllamaCloudKey: filtered}
+	prepareProviderStableIDs(&config.Config{OllamaCloudKey: prev}, next)
+	s.cfg.OllamaCloudKey = next.OllamaCloudKey
 	s.cfg.SanitizeOllamaCloudKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.OllamaCloudKey = prev

--- a/internal/management/settings/providers/provider_keys_primary.go
+++ b/internal/management/settings/providers/provider_keys_primary.go
@@ -28,7 +28,9 @@ func (s *Service) ReplaceGeminiKeys(entries []config.GeminiKey) error {
 		return nil
 	}
 	prev := append([]config.GeminiKey(nil), s.cfg.GeminiKey...)
-	s.cfg.GeminiKey = append([]config.GeminiKey(nil), entries...)
+	next := &config.Config{GeminiKey: append([]config.GeminiKey(nil), entries...)}
+	prepareProviderStableIDs(&config.Config{GeminiKey: prev}, next)
+	s.cfg.GeminiKey = next.GeminiKey
 	s.cfg.SanitizeGeminiKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.GeminiKey = prev
@@ -156,7 +158,9 @@ func (s *Service) ReplaceClaudeKeys(entries []config.ClaudeKey) error {
 		NormalizeClaudeKey(&normalized[i])
 	}
 	prev := append([]config.ClaudeKey(nil), s.cfg.ClaudeKey...)
-	s.cfg.ClaudeKey = normalized
+	next := &config.Config{ClaudeKey: normalized}
+	prepareProviderStableIDs(&config.Config{ClaudeKey: prev}, next)
+	s.cfg.ClaudeKey = next.ClaudeKey
 	s.cfg.SanitizeClaudeKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.ClaudeKey = prev
@@ -280,7 +284,9 @@ func (s *Service) ReplaceCodexKeys(entries []config.CodexKey) error {
 		filtered = append(filtered, entry)
 	}
 	prev := append([]config.CodexKey(nil), s.cfg.CodexKey...)
-	s.cfg.CodexKey = filtered
+	next := &config.Config{CodexKey: filtered}
+	prepareProviderStableIDs(&config.Config{CodexKey: prev}, next)
+	s.cfg.CodexKey = next.CodexKey
 	s.cfg.SanitizeCodexKeys()
 	if err := s.runValidator(); err != nil {
 		s.cfg.CodexKey = prev

--- a/internal/management/settings/providers/service.go
+++ b/internal/management/settings/providers/service.go
@@ -25,3 +25,8 @@ func (s *Service) runValidator() error {
 	}
 	return s.validate()
 }
+
+func prepareProviderStableIDs(previous, next *config.Config) {
+	config.PreserveMissingProviderStableIDs(previous, next)
+	next.EnsureProviderStableIDs()
+}

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -685,3 +685,45 @@ func TestModelAccessProviderGetHidesStaleModelsWhenAllAccessDisabled(t *testing.
 func stringPtr(value string) *string {
 	return &value
 }
+
+func TestPatchProviderAPIKeyKeepsStableID(t *testing.T) {
+	cfg := &config.Config{}
+	svc := NewService(cfg, nil)
+	if err := svc.ReplaceGeminiKeys([]config.GeminiKey{{APIKey: "old-secret"}}); err != nil {
+		t.Fatalf("ReplaceGeminiKeys: %v", err)
+	}
+	id := cfg.GeminiKey[0].ID
+	rotated := "new-secret"
+	index := 0
+	if err := svc.PatchGeminiKey(&index, nil, GeminiKeyPatch{APIKey: &rotated}); err != nil {
+		t.Fatalf("PatchGeminiKey: %v", err)
+	}
+	if cfg.GeminiKey[0].ID != id {
+		t.Fatalf("stable ID changed after API key rotation: before=%q after=%q", id, cfg.GeminiKey[0].ID)
+	}
+}
+
+func TestReplaceOpenAICompatibilityPreservesMissingIDs(t *testing.T) {
+	cfg := &config.Config{}
+	svc := NewService(cfg, nil)
+	initial := []config.OpenAICompatibility{{
+		Name:    "compat",
+		BaseURL: "https://compat.example",
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+			APIKey: "old-secret",
+		}},
+	}}
+	if err := svc.ReplaceOpenAICompatibility(initial); err != nil {
+		t.Fatalf("ReplaceOpenAICompatibility(initial): %v", err)
+	}
+	providerID := cfg.OpenAICompatibility[0].ID
+	keyID := cfg.OpenAICompatibility[0].APIKeyEntries[0].ID
+
+	initial[0].APIKeyEntries[0].APIKey = "new-secret"
+	if err := svc.ReplaceOpenAICompatibility(initial); err != nil {
+		t.Fatalf("ReplaceOpenAICompatibility(rotated): %v", err)
+	}
+	if cfg.OpenAICompatibility[0].ID != providerID || cfg.OpenAICompatibility[0].APIKeyEntries[0].ID != keyID {
+		t.Fatalf("IDs changed after legacy PUT rotation: provider=%q/%q key=%q/%q", providerID, cfg.OpenAICompatibility[0].ID, keyID, cfg.OpenAICompatibility[0].APIKeyEntries[0].ID)
+	}
+}

--- a/internal/management/usagelogs/channel_filter_options.go
+++ b/internal/management/usagelogs/channel_filter_options.go
@@ -1,0 +1,53 @@
+package usagelogs
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func canonicalChannelAuthIndex(authIndex string, authIndexGroup map[string][]string) string {
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return ""
+	}
+	if group := authIndexGroup[authIndex]; len(group) > 0 {
+		// buildNameMaps stores the live EnsureIndex() first.
+		return strings.TrimSpace(group[0])
+	}
+	return authIndex
+}
+
+// queryDistinctChannelRows groups by historical subject first. Record how many
+// distinct facet identities land on each canonical auth_index so a subject
+// rekey can collapse even when the live alias map no longer has it.
+func channelFacetIdentitiesByAuthIndex(
+	options []usage.ChannelFilterOption,
+	authIndexGroup map[string][]string,
+) map[string]map[string]struct{} {
+	identitiesByIndex := make(map[string]map[string]struct{})
+	for _, option := range options {
+		authIndex := strings.TrimSpace(option.AuthIndex)
+		if authIndex == "" && !looksLikeAuthSubjectID(option.Value) {
+			authIndex = strings.TrimSpace(option.Value)
+		}
+		authIndex = canonicalChannelAuthIndex(authIndex, authIndexGroup)
+		if authIndex == "" {
+			continue
+		}
+
+		identity := strings.TrimSpace(option.AuthSubjectID)
+		if identity == "" {
+			if value := strings.TrimSpace(option.Value); looksLikeAuthSubjectID(value) {
+				identity = value
+			} else {
+				identity = "<index-only>"
+			}
+		}
+		if identitiesByIndex[authIndex] == nil {
+			identitiesByIndex[authIndex] = make(map[string]struct{})
+		}
+		identitiesByIndex[authIndex][strings.ToLower(identity)] = struct{}{}
+	}
+	return identitiesByIndex
+}

--- a/internal/management/usagelogs/expand_api_key_filters.go
+++ b/internal/management/usagelogs/expand_api_key_filters.go
@@ -1,0 +1,52 @@
+package usagelogs
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+// expandManagementAPIKeyFilters expands account-representative secrets to every
+// owned key secret so management user filters match the aggregated counts.
+func expandManagementAPIKeyFilters(tenantID string, apiKeys []string) []string {
+	if len(apiKeys) == 0 {
+		return nil
+	}
+
+	expanded := make([]string, 0, len(apiKeys))
+	seen := make(map[string]struct{}, len(apiKeys))
+	appendKey := func(key string) {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		expanded = append(expanded, key)
+	}
+
+	for _, key := range apiKeys {
+		key = strings.TrimSpace(key)
+		if key == "__system__" {
+			appendKey(key)
+			continue
+		}
+		row := usage.GetAPIKeyForTenant(tenantID, key)
+		if row == nil || strings.TrimSpace(row.EndUserID) == "" {
+			appendKey(key)
+			continue
+		}
+
+		secrets := usage.ListAPIKeySecretsForEndUserForTenant(tenantID, row.EndUserID)
+		if len(secrets) == 0 {
+			appendKey(key)
+			continue
+		}
+		for _, secret := range secrets {
+			appendKey(secret)
+		}
+	}
+	return expanded
+}

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -595,23 +595,14 @@ func enrichChannelFilterOptions(
 		return make([]usage.ChannelFilterOption, 0)
 	}
 
-	// Prefer one option per auth_subject_id. Fall back to auth_index for orphans.
+	// Prefer one option per live auth_subject_id. When multiple facet rows share
+	// one canonical auth_index but no live subject mapping, use the auth_index as
+	// the option identity so selecting it matches every historical subject row.
 	// Collapse pure name-only rows when the same label already has auth-backed options.
 	out := make([]usage.ChannelFilterOption, 0, len(options))
 	seenValue := make(map[string]struct{}, len(options))
 	authBackedLabels := make(map[string]struct{})
 
-	canonicalAuthIndex := func(authIndex string) string {
-		authIndex = strings.TrimSpace(authIndex)
-		if authIndex == "" {
-			return ""
-		}
-		if group := authIndexGroup[authIndex]; len(group) > 0 {
-			// buildNameMaps stores the live EnsureIndex() first.
-			return strings.TrimSpace(group[0])
-		}
-		return authIndex
-	}
 	resolveSubject := func(option usage.ChannelFilterOption, authIndex string) string {
 		// Live auth metadata is the canonical subject. Persisted request-log rows
 		// may still carry an older subject ID after the identity seed changes.
@@ -627,12 +618,14 @@ func enrichChannelFilterOptions(
 		return ""
 	}
 
+	facetIdentitiesByAuthIndex := channelFacetIdentitiesByAuthIndex(options, authIndexGroup)
+
 	for _, option := range options {
 		authIndex := strings.TrimSpace(option.AuthIndex)
 		if authIndex == "" && !looksLikeAuthSubjectID(option.Value) {
 			authIndex = strings.TrimSpace(option.Value)
 		}
-		authIndex = canonicalAuthIndex(authIndex)
+		authIndex = canonicalChannelAuthIndex(authIndex, authIndexGroup)
 		subjectID := resolveSubject(option, authIndex)
 		if subjectID != "" {
 			if meta, ok := authMetaBySubject[subjectID]; ok && meta.label != "" {
@@ -655,7 +648,7 @@ func enrichChannelFilterOptions(
 		if authIndex == "" && !looksLikeAuthSubjectID(option.Value) {
 			authIndex = strings.TrimSpace(option.Value)
 		}
-		authIndex = canonicalAuthIndex(authIndex)
+		authIndex = canonicalChannelAuthIndex(authIndex, authIndexGroup)
 		subjectID := resolveSubject(option, authIndex)
 
 		if label == "" && authIndex != "" {
@@ -684,6 +677,12 @@ func enrichChannelFilterOptions(
 		authType := strings.TrimSpace(option.AuthType)
 		value := strings.TrimSpace(option.Value)
 		hasLiveMeta := false
+
+		// Without a live canonical subject, a repeated canonical auth_index is the
+		// only selector that covers every historical subject produced by the facet.
+		if authIndex != "" && strings.TrimSpace(authSubjectByIndex[authIndex]) == "" && len(facetIdentitiesByAuthIndex[authIndex]) > 1 {
+			subjectID = ""
+		}
 
 		if subjectID != "" {
 			value = subjectID

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -136,50 +136,6 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 	}, nil
 }
 
-// Management API-key facets represent end-user accounts, not individual owned keys.
-func expandManagementAPIKeyFilters(tenantID string, apiKeys []string) []string {
-	if len(apiKeys) == 0 {
-		return nil
-	}
-
-	expanded := make([]string, 0, len(apiKeys))
-	seen := make(map[string]struct{}, len(apiKeys))
-	appendKey := func(key string) {
-		key = strings.TrimSpace(key)
-		if key == "" {
-			return
-		}
-		if _, ok := seen[key]; ok {
-			return
-		}
-		seen[key] = struct{}{}
-		expanded = append(expanded, key)
-	}
-
-	for _, key := range apiKeys {
-		key = strings.TrimSpace(key)
-		if key == "__system__" {
-			appendKey(key)
-			continue
-		}
-		row := usage.GetAPIKeyForTenant(tenantID, key)
-		if row == nil || strings.TrimSpace(row.EndUserID) == "" {
-			appendKey(key)
-			continue
-		}
-
-		secrets := usage.ListAPIKeySecretsForEndUserForTenant(tenantID, row.EndUserID)
-		if len(secrets) == 0 {
-			appendKey(key)
-			continue
-		}
-		for _, secret := range secrets {
-			appendKey(secret)
-		}
-	}
-	return expanded
-}
-
 func (s *Service) ClearAllRequestLogs() (any, error) {
 	return usage.ClearAllRequestLogsForTenant(s.tenantID)
 }

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -17,6 +17,7 @@ import (
 
 func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any, error) {
 	maps := s.buildNameMaps()
+	apiKeys := expandManagementAPIKeyFilters(s.tenantID, input.APIKeys)
 	authSubjectIDs, authIndexes, channelNames, authIndexChannelNames := channelFilterSelectors(
 		input.Channels,
 		maps.channelNameMap,
@@ -34,7 +35,7 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 		Page:                  input.Page,
 		Size:                  input.Size,
 		Days:                  input.Days,
-		APIKeys:               input.APIKeys,
+		APIKeys:               apiKeys,
 		Models:                input.Models,
 		Statuses:              input.Statuses,
 		MatchNoAPIKeys:        input.MatchNoAPIKeys,
@@ -133,6 +134,50 @@ func (s *Service) ManagementLogs(input ManagementLogQueryInput) (map[string]any,
 		"filters": filters,
 		"stats":   stats,
 	}, nil
+}
+
+// Management API-key facets represent end-user accounts, not individual owned keys.
+func expandManagementAPIKeyFilters(tenantID string, apiKeys []string) []string {
+	if len(apiKeys) == 0 {
+		return nil
+	}
+
+	expanded := make([]string, 0, len(apiKeys))
+	seen := make(map[string]struct{}, len(apiKeys))
+	appendKey := func(key string) {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		expanded = append(expanded, key)
+	}
+
+	for _, key := range apiKeys {
+		key = strings.TrimSpace(key)
+		if key == "__system__" {
+			appendKey(key)
+			continue
+		}
+		row := usage.GetAPIKeyForTenant(tenantID, key)
+		if row == nil || strings.TrimSpace(row.EndUserID) == "" {
+			appendKey(key)
+			continue
+		}
+
+		secrets := usage.ListAPIKeySecretsForEndUserForTenant(tenantID, row.EndUserID)
+		if len(secrets) == 0 {
+			appendKey(key)
+			continue
+		}
+		for _, secret := range secrets {
+			appendKey(secret)
+		}
+	}
+	return expanded
 }
 
 func (s *Service) ClearAllRequestLogs() (any, error) {

--- a/internal/management/usagelogs/list.go
+++ b/internal/management/usagelogs/list.go
@@ -613,10 +613,12 @@ func enrichChannelFilterOptions(
 		return authIndex
 	}
 	resolveSubject := func(option usage.ChannelFilterOption, authIndex string) string {
-		if subjectID := strings.TrimSpace(option.AuthSubjectID); subjectID != "" {
+		// Live auth metadata is the canonical subject. Persisted request-log rows
+		// may still carry an older subject ID after the identity seed changes.
+		if subjectID := strings.TrimSpace(authSubjectByIndex[authIndex]); subjectID != "" {
 			return subjectID
 		}
-		if subjectID := strings.TrimSpace(authSubjectByIndex[authIndex]); subjectID != "" {
+		if subjectID := strings.TrimSpace(option.AuthSubjectID); subjectID != "" {
 			return subjectID
 		}
 		if value := strings.TrimSpace(option.Value); looksLikeAuthSubjectID(value) {

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -515,6 +515,54 @@ func TestEnrichChannelFilterOptionsCollapsesHistoricalSubjectRekeyByAuthIndex(t 
 	}
 }
 
+func TestEnrichChannelFilterOptionsCollapsesHistoricalSubjectsByAuthIndexWithoutLiveMap(t *testing.T) {
+	t.Parallel()
+
+	authIndex := "14c5636b41002b25"
+	oldSubject := "authsub_4ca6f5185e367ab2"
+	newSubject := "authsub_9ebad60f7efd0b3c"
+	label := "GinofkFerraiuolo@hotmail.com"
+
+	options := []usage.ChannelFilterOption{
+		{Value: oldSubject, Label: label, AuthIndex: authIndex, AuthSubjectID: oldSubject},
+		{Value: newSubject, Label: label, AuthIndex: authIndex, AuthSubjectID: newSubject},
+	}
+
+	// The production hole has no live auth_index -> subject alias to choose a
+	// canonical subject. The shared auth_index must therefore become the stable
+	// option value so the next request matches both historical subject rows.
+	got := enrichChannelFilterOptions(options, nil, nil, nil, nil, nil, nil)
+	if len(got) != 1 {
+		t.Fatalf("options = %#v, want one auth-index option", got)
+	}
+	if got[0].Value != authIndex || got[0].AuthIndex != authIndex || got[0].AuthSubjectID != "" {
+		t.Fatalf("option = %#v, want auth index %q without a non-canonical subject", got[0], authIndex)
+	}
+
+	subjects, authIndexes, channelNames, _ := channelFilterSelectors(
+		[]string{got[0].Value},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if len(subjects) != 0 || len(channelNames) != 0 {
+		t.Fatalf("subjects = %#v, channelNames = %#v, want auth-index-only filter", subjects, channelNames)
+	}
+	if !reflect.DeepEqual(authIndexes, []string{authIndex}) {
+		t.Fatalf("authIndexes = %#v, want [%s]", authIndexes, authIndex)
+	}
+	for _, row := range options {
+		if row.AuthIndex != authIndexes[0] {
+			t.Fatalf("historical subject %s was not covered by auth index %s", row.AuthSubjectID, authIndexes[0])
+		}
+	}
+}
+
 func TestEnrichChannelFilterOptionsInfersProviderAuthTypeWithoutLiveMeta(t *testing.T) {
 	t.Parallel()
 

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -484,6 +484,37 @@ func TestEnrichChannelFilterOptionsCollapsesByAuthSubject(t *testing.T) {
 	}
 }
 
+func TestEnrichChannelFilterOptionsCollapsesHistoricalSubjectRekeyByAuthIndex(t *testing.T) {
+	t.Parallel()
+
+	authIndex := "14c5636b41002b25"
+	oldSubject := "authsub_1111111111111111"
+	currentSubject := "authsub_2222222222222222"
+	label := "account@example.com"
+
+	options := []usage.ChannelFilterOption{
+		{Value: oldSubject, Label: label, AuthIndex: authIndex, AuthSubjectID: oldSubject},
+		{Value: currentSubject, Label: label, AuthIndex: authIndex, AuthSubjectID: currentSubject},
+	}
+	authMeta := authChannelMeta{label: label, provider: "codex", authType: "oauth"}
+
+	got := enrichChannelFilterOptions(
+		options,
+		nil,
+		map[string]string{authIndex: label},
+		map[string]authChannelMeta{authIndex: authMeta},
+		nil,
+		map[string]string{authIndex: currentSubject},
+		map[string]authChannelMeta{currentSubject: authMeta},
+	)
+	if len(got) != 1 {
+		t.Fatalf("options = %#v, want one current-subject option", got)
+	}
+	if got[0].Value != currentSubject || got[0].AuthSubjectID != currentSubject || got[0].AuthIndex != authIndex {
+		t.Fatalf("option = %#v, want current subject %q with auth index %q", got[0], currentSubject, authIndex)
+	}
+}
+
 func TestEnrichChannelFilterOptionsInfersProviderAuthTypeWithoutLiveMeta(t *testing.T) {
 	t.Parallel()
 

--- a/internal/management/usagelogs/list_test.go
+++ b/internal/management/usagelogs/list_test.go
@@ -3,14 +3,107 @@ package usagelogs
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
+
+func TestManagementLogsExpandsOwnedAPIKeyFilterIncludingSoftDeletedKeys(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(usage.CloseDB)
+
+	tenantID := "00000000-0000-0000-0000-0000000000ac"
+	endUserID := "00000000-0000-0000-0000-0000000000bd"
+	now := time.Now().UTC().Format(time.RFC3339)
+	rows := []usage.APIKeyRow{
+		{TenantID: tenantID, ID: "00000000-0000-0000-0000-0000000000a2", Key: "sk-owned-log-a", Name: "Laptop", EndUserID: endUserID, CreatedAt: now, UpdatedAt: now},
+		{TenantID: tenantID, ID: "00000000-0000-0000-0000-0000000000b2", Key: "sk-owned-log-b", Name: "Automation", EndUserID: endUserID, IsDefault: true, CreatedAt: now, UpdatedAt: now},
+		{TenantID: tenantID, ID: "00000000-0000-0000-0000-0000000000c2", Key: "sk-standalone", Name: "Standalone", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, row := range rows {
+		if err := usage.UpsertAPIKeyForTenant(tenantID, row); err != nil {
+			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
+		}
+	}
+
+	logTime := time.Now().UTC()
+	usage.InsertLog("sk-owned-log-a", "Laptop", "gpt-test", "test", "channel", "auth-owned", false, logTime, 1, 0, usage.TokenStats{TotalTokens: 1}, "", "")
+	usage.InsertLog("sk-owned-log-a", "Laptop", "gpt-test", "test", "channel", "auth-owned", false, logTime.Add(time.Second), 1, 0, usage.TokenStats{TotalTokens: 1}, "", "")
+	usage.InsertLog("sk-standalone", "Standalone", "gpt-test", "test", "channel", "auth-standalone", false, logTime, 1, 0, usage.TokenStats{TotalTokens: 1}, "", "")
+	if err := usage.DeleteAPIKeyByIDForTenant(tenantID, rows[0].ID); err != nil {
+		t.Fatalf("DeleteAPIKeyByIDForTenant(%s): %v", rows[0].ID, err)
+	}
+
+	expanded := expandManagementAPIKeyFilters(tenantID, []string{
+		" sk-owned-log-b ", "sk-owned-log-b", " __system__ ", "__system__",
+	})
+	hasTombstone := false
+	for _, key := range expanded {
+		if strings.HasPrefix(key, "sk-deleted-") {
+			hasTombstone = true
+			break
+		}
+	}
+	if len(expanded) != 3 || !hasTombstone ||
+		!slices.Contains(expanded, "sk-owned-log-b") || !slices.Contains(expanded, "__system__") {
+		t.Fatalf("expanded filters = %#v, want active, soft-deleted, and system selectors", expanded)
+	}
+
+	service := NewForTenant(tenantID, &config.Config{}, nil)
+	unfiltered, err := service.ManagementLogs(ManagementLogQueryInput{Days: 1, Page: 1, Size: 50})
+	if err != nil {
+		t.Fatalf("ManagementLogs(unfiltered): %v", err)
+	}
+	filters := unfiltered["filters"].(usage.FilterOptions)
+	if !slices.Contains(filters.APIKeys, "sk-owned-log-b") {
+		t.Fatalf("filters.APIKeys = %#v, want representative sk-owned-log-b", filters.APIKeys)
+	}
+	if filters.APIKeyCounts["sk-owned-log-b"] != 2 {
+		t.Fatalf("filters.APIKeyCounts[sk-owned-log-b] = %d, want 2 account requests", filters.APIKeyCounts["sk-owned-log-b"])
+	}
+
+	owned, err := service.ManagementLogs(ManagementLogQueryInput{
+		Days: 1, Page: 1, Size: 50, APIKeys: []string{"sk-owned-log-b"},
+	})
+	if err != nil {
+		t.Fatalf("ManagementLogs(owned representative): %v", err)
+	}
+	if total := owned["total"].(int64); total != 2 {
+		t.Fatalf("owned total = %d, want 2 account requests", total)
+	}
+	ownedItems := owned["items"].([]usage.LogRow)
+	if len(ownedItems) != 2 || ownedItems[0].APIKey != "sk-owned-log-a" || ownedItems[1].APIKey != "sk-owned-log-a" {
+		t.Fatalf("owned items = %#v, want two sk-owned-log-a requests", ownedItems)
+	}
+	if stats := owned["stats"].(usage.LogStats); stats.Total != 2 {
+		t.Fatalf("owned stats total = %d, want 2", stats.Total)
+	}
+
+	standalone, err := service.ManagementLogs(ManagementLogQueryInput{
+		Days: 1, Page: 1, Size: 50, APIKeys: []string{"sk-standalone"},
+	})
+	if err != nil {
+		t.Fatalf("ManagementLogs(standalone): %v", err)
+	}
+	if total := standalone["total"].(int64); total != 1 {
+		t.Fatalf("standalone total = %d, want 1", total)
+	}
+	standaloneItems := standalone["items"].([]usage.LogRow)
+	if len(standaloneItems) != 1 || standaloneItems[0].APIKey != "sk-standalone" {
+		t.Fatalf("standalone items = %#v, want only sk-standalone", standaloneItems)
+	}
+}
 
 func TestLooksLikeAuthIndex(t *testing.T) {
 	t.Parallel()

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -72,9 +72,11 @@ func mergeAuthFileTrendShared(tenant, shared AuthFileTrendResponse) AuthFileTren
 	out := tenant
 	if shared.CycleRequestTotal > tenant.CycleRequestTotal ||
 		(shared.CycleRequestTotal == tenant.CycleRequestTotal && shared.CycleCostTotal > tenant.CycleCostTotal) ||
+		(shared.CycleRequestTotal == tenant.CycleRequestTotal && shared.CycleCostTotal == tenant.CycleCostTotal && shared.CycleTotalTokens > tenant.CycleTotalTokens) ||
 		(tenant.CycleRequestTotal == 0 && shared.RequestTotal > tenant.RequestTotal) {
 		out.CycleRequestTotal = shared.CycleRequestTotal
 		out.CycleCostTotal = shared.CycleCostTotal
+		out.CycleTotalTokens = shared.CycleTotalTokens
 		if shared.RequestTotal > tenant.RequestTotal {
 			out.RequestTotal = shared.RequestTotal
 		}
@@ -166,6 +168,7 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 	cycleKnown := !cycleStart.IsZero() || summary.CycleKnown
 	cycleRequestTotal := summary.CycleRequestTotal
 	cycleCostTotal := summary.CycleCostTotal
+	cycleTotalTokens := summary.CycleTotalTokens
 	cycleStartStr := ""
 	if !cycleStart.IsZero() {
 		cycleStartStr = cycleStart.UTC().Format(time.RFC3339)
@@ -180,6 +183,7 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 		RequestTotal:      requestTotal,
 		CycleRequestTotal: cycleRequestTotal,
 		CycleCostTotal:    cycleCostTotal,
+		CycleTotalTokens:  cycleTotalTokens,
 		WeeklyQuotaUsed:   weeklyQuotaUsed,
 		CycleKnown:        cycleKnown,
 		CycleStart:        cycleStartStr,
@@ -240,7 +244,7 @@ func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.A
 		}
 	}
 
-	var cycleRequestTotal int64
+	var cycleRequestTotal, cycleTotalTokens int64
 	var cycleCostTotal float64
 	cycleKnown := !cycleStart.IsZero()
 	if cycleKnown {
@@ -249,6 +253,10 @@ func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.A
 			return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 		}
 		cycleCostTotal, err = usage.QueryCostByAuthSubjectSinceForTenant(s.tenantID, matcher, cycleStart)
+		if err != nil {
+			return http.StatusInternalServerError, map[string]any{"error": err.Error()}
+		}
+		cycleTotalTokens, err = usage.QueryTotalTokensByAuthSubjectSinceForTenant(s.tenantID, matcher, cycleStart)
 		if err != nil {
 			return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 		}
@@ -265,6 +273,7 @@ func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.A
 		RequestTotal:      requestTotal,
 		CycleRequestTotal: cycleRequestTotal,
 		CycleCostTotal:    cycleCostTotal,
+		CycleTotalTokens:  cycleTotalTokens,
 		WeeklyQuotaUsed:   weeklyQuotaUsed,
 		CycleKnown:        cycleKnown,
 		CycleStart:        cycleStartStr,

--- a/internal/management/usagelogs/types.go
+++ b/internal/management/usagelogs/types.go
@@ -54,6 +54,7 @@ type AuthFileTrendResponse struct {
 	RequestTotal      int64                       `json:"request_total"`
 	CycleRequestTotal int64                       `json:"cycle_request_total"`
 	CycleCostTotal    float64                     `json:"cycle_cost_total"`
+	CycleTotalTokens  int64                       `json:"cycle_total_tokens"`
 	WeeklyQuotaUsed   *float64                    `json:"weekly_quota_used_percent"`
 	CycleKnown        bool                        `json:"cycle_known"`
 	CycleStart        string                      `json:"cycle_start"`

--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -879,24 +879,34 @@ func maybeWrapSSEData(hadSSEPrefix bool, body []byte) []byte {
 // stripCodexHistoryDataURLImages removes multi-MB data:image payloads from request history
 // before upstream. Desktop keeps outbound data-url markdown for display, then re-sends it
 // on the next turn as text — that blows the model context (context_length_exceeded).
+func stripCodexHistoryDataURLImages(body []byte) []byte {
+	store := gjson.GetBytes(body, "store")
+	return stripCodexHistoryDataURLImagesForStore(body, store.Exists() && !store.Bool())
+}
+
+// stripCodexHistoryDataURLImagesForStore also strips server-issued history item IDs when
+// store is disabled. Those IDs otherwise make upstream attempt to resolve items that were
+// never persisted, while the remaining inline payload is sufficient for stateless replay.
 //
 // Strategy (no server storage / no global cache):
 //  1. Replace huge data URLs in history text with short cliproxy-image:N placeholders
 //  2. Re-attach at most the last extracted image as a structured input_image on the latest
 //     user turn so the model can re-identify / edit without keeping base64-as-text history
-//  3. All image bytes come from the current request body and die with the request
+//  3. With store=false, strip top-level item IDs and drop reference-only history shells
+//  4. All image bytes come from the current request body and die with the request
 //
 // Implementation rebuilds the input array once. Never call sjson.Set/Delete on the full
 // multi-MB body for each history item — that was the production RSS spike path.
-func stripCodexHistoryDataURLImages(body []byte) []byte {
+func stripCodexHistoryDataURLImagesForStore(body []byte, stripStoredItemIDs bool) []byte {
 	if len(body) == 0 {
 		return body
 	}
 	// Fast path: nothing to do when payload has neither markdown data URLs nor a large
-	// image_generation_call.result (Desktop usually only re-sends markdown data URLs).
+	// image_generation_call.result nor stored history item IDs.
 	hasDataURL := bytes.Contains(body, []byte("data:image/"))
 	hasIGResult := bytes.Contains(body, []byte(`"image_generation_call"`)) && bytes.Contains(body, []byte(`"result"`))
-	if !hasDataURL && !hasIGResult {
+	hasStoredItemID := stripStoredItemIDs && bytes.Contains(body, []byte(`"id"`))
+	if !hasDataURL && !hasIGResult && !hasStoredItemID {
 		return body
 	}
 	seq := 0
@@ -934,11 +944,18 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 	}
 	items := input.Array()
 	// Keep original raw strings for unchanged fragments; only allocate rewritten ones.
-	itemRaws := make([]string, len(items))
+	itemRaws := make([]string, 0, len(items))
 	changed := false
 	outLen := 2 // []
-	for itemIndex, item := range items {
-		itemRaws[itemIndex] = item.Raw
+	appendItem := func(raw string) {
+		if len(itemRaws) > 0 {
+			outLen++
+		}
+		itemRaws = append(itemRaws, raw)
+		outLen += len(raw)
+	}
+	for _, item := range items {
+		itemRaw := item.Raw
 		// Drop base64 from any re-sent image_generation_call history items; remember last.
 		if strings.TrimSpace(item.Get("type").String()) == "image_generation_call" {
 			if result := item.Get("result"); result.Exists() {
@@ -950,84 +967,72 @@ func stripCodexHistoryDataURLImages(body []byte) []byte {
 						remember(fmt.Sprintf("data:%s;base64,%s", mime, resultStr))
 					}
 					if next, err := sjson.Delete(item.Raw, "result"); err == nil {
-						itemRaws[itemIndex] = next
+						itemRaw = next
 						changed = true
 					}
 				}
 			}
-			if itemIndex > 0 {
-				outLen++
-			}
-			outLen += len(itemRaws[itemIndex])
-			continue
-		}
-		if !hasDataURL {
-			if itemIndex > 0 {
-				outLen++
-			}
-			outLen += len(itemRaws[itemIndex])
-			continue
-		}
-		// message / content text fields
-		if content := item.Get("content"); content.Type == gjson.String {
-			if next, ok := replaceCodexDataURLImagesInText(content.String(), nextPlaceholder, remember); ok {
-				if rewritten, err := sjson.Set(item.Raw, "content", next); err == nil {
-					itemRaws[itemIndex] = rewritten
-					changed = true
+		} else if hasDataURL {
+			// message / content text fields
+			if content := item.Get("content"); content.Type == gjson.String {
+				if next, ok := replaceCodexDataURLImagesInText(content.String(), nextPlaceholder, remember); ok {
+					if rewritten, err := sjson.Set(itemRaw, "content", next); err == nil {
+						itemRaw = rewritten
+						changed = true
+					}
 				}
-			}
-			if itemIndex > 0 {
-				outLen++
-			}
-			outLen += len(itemRaws[itemIndex])
-			continue
-		}
-		if content := item.Get("content"); content.IsArray() {
-			parts := content.Array()
-			partRaws := make([]string, len(parts))
-			partChanged := false
-			partOutLen := 2
-			for partIndex, part := range parts {
-				partRaws[partIndex] = part.Raw
-				partType := strings.TrimSpace(part.Get("type").String())
-				// Only rewrite text parts. Do not touch structured input_image (user uploads /
-				// vision) — those are intentional pixels, not Desktop session replay of our
-				// outbound markdown data URLs.
-				if partType == "input_text" || partType == "output_text" || partType == "text" {
-					text := part.Get("text").String()
-					if next, ok := replaceCodexDataURLImagesInText(text, nextPlaceholder, remember); ok {
-						if rewritten, err := sjson.Set(part.Raw, "text", next); err == nil {
-							partRaws[partIndex] = rewritten
-							partChanged = true
+			} else if content.IsArray() {
+				parts := content.Array()
+				partRaws := make([]string, len(parts))
+				partChanged := false
+				partOutLen := 2
+				for partIndex, part := range parts {
+					partRaws[partIndex] = part.Raw
+					partType := strings.TrimSpace(part.Get("type").String())
+					// Only rewrite text parts. Do not touch structured input_image (user uploads /
+					// vision) — those are intentional pixels, not Desktop session replay of our
+					// outbound markdown data URLs.
+					if partType == "input_text" || partType == "output_text" || partType == "text" {
+						text := part.Get("text").String()
+						if next, ok := replaceCodexDataURLImagesInText(text, nextPlaceholder, remember); ok {
+							if rewritten, err := sjson.Set(part.Raw, "text", next); err == nil {
+								partRaws[partIndex] = rewritten
+								partChanged = true
+							}
 						}
 					}
-				}
-				if partIndex > 0 {
-					partOutLen++
-				}
-				partOutLen += len(partRaws[partIndex])
-			}
-			if partChanged {
-				var contentBuf bytes.Buffer
-				contentBuf.Grow(partOutLen)
-				contentBuf.WriteByte('[')
-				for i, p := range partRaws {
-					if i > 0 {
-						contentBuf.WriteByte(',')
+					if partIndex > 0 {
+						partOutLen++
 					}
-					contentBuf.WriteString(p)
+					partOutLen += len(partRaws[partIndex])
 				}
-				contentBuf.WriteByte(']')
-				if rewritten, err := sjson.SetRaw(item.Raw, "content", contentBuf.String()); err == nil {
-					itemRaws[itemIndex] = rewritten
-					changed = true
+				if partChanged {
+					var contentBuf bytes.Buffer
+					contentBuf.Grow(partOutLen)
+					contentBuf.WriteByte('[')
+					for i, p := range partRaws {
+						if i > 0 {
+							contentBuf.WriteByte(',')
+						}
+						contentBuf.WriteString(p)
+					}
+					contentBuf.WriteByte(']')
+					if rewritten, err := sjson.SetRaw(itemRaw, "content", contentBuf.String()); err == nil {
+						itemRaw = rewritten
+						changed = true
+					}
 				}
 			}
 		}
-		if itemIndex > 0 {
-			outLen++
+		if stripStoredItemIDs {
+			var itemChanged, drop bool
+			itemRaw, itemChanged, drop = stripCodexStoredHistoryItemReference(itemRaw)
+			changed = changed || itemChanged
+			if drop {
+				continue
+			}
 		}
-		outLen += len(itemRaws[itemIndex])
+		appendItem(itemRaw)
 	}
 
 	// Re-identify / edit: move last history image into structured input_image (not text tokens).

--- a/internal/runtime/executor/codex_image_generation_bridge_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_test.go
@@ -377,13 +377,32 @@ func TestSanitizeCodexResponsesRequestStripsHistoryDataURL(t *testing.T) {
 
 func TestStripCodexHistoryDataURLImagesDropsImageGenerationCallResult(t *testing.T) {
 	b64 := strings.Repeat("C", 400)
-	body := []byte(`{"input":[{"type":"image_generation_call","id":"ig_1","result":"` + b64 + `","status":"completed"}]}`)
+	body := []byte(`{"store":false,"input":[{"type":"image_generation_call","id":"ig_1","result":"` + b64 + `","status":"completed"}]}`)
 	out := stripCodexHistoryDataURLImages(body)
-	if gjson.GetBytes(out, "input.0.result").Exists() {
-		t.Fatalf("image_generation_call.result should be deleted; payload=%s", out)
+	for _, item := range gjson.GetBytes(out, "input").Array() {
+		if item.Get("result").Exists() {
+			t.Fatalf("image_generation_call.result should be deleted; payload=%s", out)
+		}
 	}
-	if got := gjson.GetBytes(out, "input.0.id").String(); got != "ig_1" {
-		t.Fatalf("id should remain, got %q", got)
+	if bytes.Contains(out, []byte(`"ig_1"`)) {
+		t.Fatalf("stored image_generation_call id should not be forwarded when store=false; payload=%s", out)
+	}
+	if got := gjson.GetBytes(out, "input.#").Int(); got != 0 {
+		t.Fatalf("image_generation_call without result should be dropped, got %d items; payload=%s", got, out)
+	}
+}
+
+func TestStripCodexHistoryDataURLImagesDropsImageGenerationCallReferenceOnlyItem(t *testing.T) {
+	body := []byte(`{"store":false,"input":[{"type":"image_generation_call","id":"ig_reference_only","status":"completed"},{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}]}`)
+	out := stripCodexHistoryDataURLImages(body)
+	if bytes.Contains(out, []byte(`"ig_reference_only"`)) {
+		t.Fatalf("reference-only image_generation_call should not be forwarded when store=false; payload=%s", out)
+	}
+	if got := gjson.GetBytes(out, "input.#").Int(); got != 1 {
+		t.Fatalf("input item count = %d, want 1; payload=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "input.0.content.0.text").String(); got != "continue" {
+		t.Fatalf("remaining user message changed: %q; payload=%s", got, out)
 	}
 }
 
@@ -391,14 +410,24 @@ func TestStripCodexHistoryDataURLImagesReattachesLastAsInputImage(t *testing.T) 
 	// Follow-up "描述一下" must still see pixels via structured input_image, not text base64.
 	b64 := strings.Repeat("D", 400)
 	body := []byte(`{
+		"store":false,
 		"model":"gpt-5.4",
 		"input":[
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"画小鱼"}]},
+			{"type":"image_generation_call","id":"ig_previous","result":"` + b64 + `","status":"completed","output_format":"png"},
 			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"好了\n\n![generated image](data:image/png;base64,` + b64 + `)"}]},
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"你画的是啥，详细描述"}]}
 		]
 	}`)
 	out := stripCodexHistoryDataURLImages(body)
+	if bytes.Contains(out, []byte(`"ig_previous"`)) {
+		t.Fatalf("stored image generation history should be removed; payload=%s", out)
+	}
+	for _, item := range gjson.GetBytes(out, "input").Array() {
+		if item.Get("result").Exists() {
+			t.Fatalf("stored image generation result should be removed; payload=%s", out)
+		}
+	}
 	asst := gjson.GetBytes(out, "input.1.content.0.text").String()
 	if strings.Contains(asst, "base64,") {
 		t.Fatalf("assistant text still has base64")

--- a/internal/runtime/executor/codex_responses.go
+++ b/internal/runtime/executor/codex_responses.go
@@ -29,8 +29,49 @@ func sanitizeCodexResponsesRequest(body []byte) []byte {
 	})
 	body = stripCodexResponsesImageGenerationSize(body)
 	// History hygiene: never forward multi-MB data:image blobs from Desktop session replay.
-	body = stripCodexHistoryDataURLImages(body)
+	// With store=false, also remove server item IDs so upstream treats retained history as
+	// inline content instead of looking up items that were never persisted.
+	store := gjson.GetBytes(body, "store")
+	body = stripCodexHistoryDataURLImagesForStore(body, store.Exists() && !store.Bool())
 	return body
+}
+
+func stripCodexStoredHistoryItemReference(itemRaw string) (string, bool, bool) {
+	item := gjson.Parse(itemRaw)
+	hadStoredID := strings.TrimSpace(item.Get("id").String()) != ""
+	changed := false
+	if hadStoredID {
+		if next, err := sjson.Delete(itemRaw, "id"); err == nil {
+			itemRaw = next
+			item = gjson.Parse(itemRaw)
+			changed = true
+		}
+	}
+
+	// Once result pixels are removed, an image_generation_call has no inline meaning and
+	// cannot be resolved by ID when store=false. The image is reattached to the latest user
+	// turn when it fits the existing size cap.
+	if strings.TrimSpace(item.Get("type").String()) == "image_generation_call" && strings.TrimSpace(item.Get("result").String()) == "" {
+		return "", true, true
+	}
+	if hadStoredID && codexHistoryItemIsReferenceOnly(item) {
+		return "", true, true
+	}
+	return itemRaw, changed, false
+}
+
+func codexHistoryItemIsReferenceOnly(item gjson.Result) bool {
+	referenceOnly := true
+	item.ForEach(func(key, _ gjson.Result) bool {
+		switch key.String() {
+		case "type", "status", "role", "name", "call_id":
+			return true
+		default:
+			referenceOnly = false
+			return false
+		}
+	})
+	return referenceOnly
 }
 
 func stripCodexResponsesImageGenerationSize(body []byte) []byte {

--- a/internal/runtime/executor/codex_responses_test.go
+++ b/internal/runtime/executor/codex_responses_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"net/http"
 	"strings"
 	"testing"
@@ -22,6 +23,46 @@ func TestSanitizeCodexResponsesRequestStripsUnsupportedTokenLimitFields(t *testi
 	}
 	if !gjson.GetBytes(got, "stream").Bool() {
 		t.Fatalf("stream should be preserved; payload=%s", got)
+	}
+}
+
+func TestSanitizeCodexResponsesRequestStripsStoredHistoryItemIDsWhenStoreFalse(t *testing.T) {
+	input := []byte(`{
+		"model":"gpt-5.4",
+		"store":false,
+		"input":[
+			{"type":"message","id":"msg_previous","role":"assistant","content":[{"type":"output_text","text":"done"}]},
+			{"type":"function_call","id":"fc_previous","call_id":"call_previous","name":"lookup","arguments":"{\"q\":\"x\"}","status":"completed"},
+			{"type":"reasoning","id":"rs_previous","encrypted_content":"encrypted","summary":[]}
+		]
+	}`)
+
+	got := sanitizeCodexResponsesRequest(input)
+	for _, id := range []string{"msg_previous", "fc_previous", "rs_previous"} {
+		if bytes.Contains(got, []byte(`"`+id+`"`)) {
+			t.Fatalf("stored item id %q should be stripped; payload=%s", id, got)
+		}
+	}
+	if text := gjson.GetBytes(got, "input.0.content.0.text").String(); text != "done" {
+		t.Fatalf("message content = %q, want done; payload=%s", text, got)
+	}
+	if callID := gjson.GetBytes(got, "input.1.call_id").String(); callID != "call_previous" {
+		t.Fatalf("function call_id = %q, want call_previous; payload=%s", callID, got)
+	}
+	if arguments := gjson.GetBytes(got, "input.1.arguments").String(); arguments != `{"q":"x"}` {
+		t.Fatalf("function arguments = %q; payload=%s", arguments, got)
+	}
+	if encrypted := gjson.GetBytes(got, "input.2.encrypted_content").String(); encrypted != "encrypted" {
+		t.Fatalf("reasoning encrypted_content = %q; payload=%s", encrypted, got)
+	}
+}
+
+func TestSanitizeCodexResponsesRequestKeepsStoredHistoryItemIDsWhenStoreTrue(t *testing.T) {
+	input := []byte(`{"store":true,"input":[{"type":"message","id":"msg_persisted","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}`)
+
+	got := sanitizeCodexResponsesRequest(input)
+	if id := gjson.GetBytes(got, "input.0.id").String(); id != "msg_persisted" {
+		t.Fatalf("stored item id = %q, want msg_persisted; payload=%s", id, got)
 	}
 }
 

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
@@ -192,6 +193,43 @@ func TestRequestDetailsCaptureUpstreamLogsWhenOnlyContentStorageEnabled(t *testi
 	}
 	if !strings.Contains(detail.Response.UpstreamLog, `{"id":"resp-test"}`) {
 		t.Fatalf("upstream response log missing body: %q", detail.Response.UpstreamLog)
+	}
+}
+
+func TestRequestDetailsIncludeModerationSnapshot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"input":"not persisted"}`))
+	ginCtx.Request = req
+	ctx := context.WithValue(req.Context(), util.ContextKeyGin, ginCtx)
+	highestScore := 0.91
+	contentmoderation.SetRuntimeSnapshot(ctx, contentmoderation.RuntimeSnapshot{
+		Evaluated:        true,
+		ProfileID:        "profile-1",
+		ProfileName:      "Strict prompts",
+		ProfileVersion:   3,
+		ResolutionSource: contentmoderation.ChannelTypeProviderKey,
+		ChannelType:      contentmoderation.ChannelTypeProviderKey,
+		ChannelID:        "provider-key-1",
+		Action:           contentmoderation.ActionAPIBlock,
+		WouldBlock:       true,
+		HighestCategory:  "violence",
+		HighestScore:     &highestScore,
+		LatencyMS:        18,
+		CacheHit:         false,
+	})
+
+	var detail struct {
+		Moderation contentmoderation.RuntimeSnapshot `json:"moderation"`
+	}
+	if err := json.Unmarshal([]byte(buildRequestDetailContent(ctx, false)), &detail); err != nil {
+		t.Fatalf("unmarshal request details: %v", err)
+	}
+	if detail.Moderation.ProfileID != "profile-1" || detail.Moderation.ChannelID != "provider-key-1" || detail.Moderation.Action != contentmoderation.ActionAPIBlock {
+		t.Fatalf("moderation detail = %#v", detail.Moderation)
+	}
+	if detail.Moderation.HighestScore == nil || *detail.Moderation.HighestScore != highestScore {
+		t.Fatalf("moderation highest score = %#v", detail.Moderation.HighestScore)
 	}
 }
 

--- a/internal/runtime/executor/usage_request_details.go
+++ b/internal/runtime/executor/usage_request_details.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -129,6 +130,9 @@ func buildRequestDetailContent(ctx context.Context, includeBodies ...bool) strin
 		if snapshot := diagnostic.Snapshot(); !snapshot.IsZero() {
 			detail["diagnostic"] = snapshot
 		}
+	}
+	if moderation, ok := contentmoderation.RuntimeSnapshotFromGin(ginCtx); ok {
+		detail["moderation"] = moderation
 	}
 
 	data, err := json.Marshal(detail)

--- a/internal/runtime/executor/xai_quota_recovery.go
+++ b/internal/runtime/executor/xai_quota_recovery.go
@@ -69,7 +69,12 @@ func parseXAIQuotaProbe(body []byte, now time.Time) *cliproxyauth.QuotaProbeResu
 	if weekly.RemainingPercent > 0 {
 		return &cliproxyauth.QuotaProbeResult{Recovered: true}
 	}
-	result := &cliproxyauth.QuotaProbeResult{Recovered: false}
+	result := &cliproxyauth.QuotaProbeResult{
+		Recovered:       false,
+		WindowExhausted: true,
+		Window:          xaiWeeklyWindowLabel,
+		WindowMinutes:   xaiWeeklyWindowMinutes,
+	}
 	if weekly.ResetAt.After(now) {
 		result.NextRecoverAt = weekly.ResetAt
 	}

--- a/internal/runtime/executor/xai_quota_recovery_test.go
+++ b/internal/runtime/executor/xai_quota_recovery_test.go
@@ -78,6 +78,9 @@ func TestXAIExecutorProbeQuotaRecovery(t *testing.T) {
 			if result.Recovered != test.wantRecovered {
 				t.Fatalf("Recovered = %v, want %v", result.Recovered, test.wantRecovered)
 			}
+			if !test.wantRecovered && (!result.WindowExhausted || result.Window != "week" || result.WindowMinutes != 10080) {
+				t.Fatalf("quota window = exhausted:%v %q/%d, want weekly exhausted", result.WindowExhausted, result.Window, result.WindowMinutes)
+			}
 			if test.wantNextRecover {
 				if !result.NextRecoverAt.Equal(resetAt) {
 					t.Fatalf("NextRecoverAt = %v, want %v", result.NextRecoverAt, resetAt)

--- a/internal/storage/postgres/migration_upgrade_test.go
+++ b/internal/storage/postgres/migration_upgrade_test.go
@@ -139,6 +139,19 @@ func assertAIAccountSharedSubjectTables(t *testing.T, ctx context.Context, db *s
 			t.Fatalf("shared AI account table %s missing after upgrade", table)
 		}
 	}
+	var dataType string
+	if err := db.QueryRowContext(ctx, `
+		SELECT data_type
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name = 'ai_account_subject_usage_buckets'
+		  AND column_name = 'total_tokens'
+	`).Scan(&dataType); err != nil {
+		t.Fatalf("shared AI account total_tokens column missing after upgrade: %v", err)
+	}
+	if dataType != "bigint" {
+		t.Fatalf("shared AI account total_tokens data_type = %q, want bigint", dataType)
+	}
 }
 
 // publishedBaselineMigrations returns migrations up to and including

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -36,8 +36,14 @@ func RuntimeMigrations() []Migration {
 		// Append-only history of manual account-level daily spending resets.
 		{Version: "202607210001_end_user_daily_spending_reset_events", SQL: endUserDailySpendingResetEventsSQL},
 		{Version: "202607220001_period_spending_limits", SQL: periodSpendingLimitsSQL},
+		{Version: "202607240001_ai_account_subject_usage_tokens", SQL: aiAccountSubjectUsageTokensSQL},
 	}
 }
+
+const aiAccountSubjectUsageTokensSQL = `
+ALTER TABLE ai_account_subject_usage_buckets
+ADD COLUMN IF NOT EXISTS total_tokens BIGINT NOT NULL DEFAULT 0;
+`
 
 const periodSpendingLimitsSQL = `
 ALTER TABLE api_key_permission_profiles ADD COLUMN IF NOT EXISTS five_hour_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0;

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,10 +11,20 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 22 {
-		t.Fatalf("RuntimeMigrations len = %d, want 22", len(migrations))
+	if len(migrations) != 23 {
+		t.Fatalf("RuntimeMigrations len = %d, want 23", len(migrations))
 	}
-	// Latest: fixed period spending columns.
+	// Latest: shared AI-account cycle token projection.
+	if migrations[22].Version != "202607240001_ai_account_subject_usage_tokens" {
+		t.Fatalf("latest migration version = %q", migrations[22].Version)
+	}
+	tokenSQL := migrations[22].SQL
+	for _, fragment := range []string{"ALTER TABLE ai_account_subject_usage_buckets", "total_tokens BIGINT NOT NULL DEFAULT 0"} {
+		if !strings.Contains(tokenSQL, fragment) {
+			t.Fatalf("AI account subject token migration missing %q", fragment)
+		}
+	}
+	// Prior: fixed period spending columns.
 	periodSQL := migrations[21].SQL
 	for _, fragment := range []string{"five_hour_spending_limit", "weekly_spending_limit", "monthly_spending_limit"} {
 		if !strings.Contains(periodSQL, fragment) {

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"database/sql"
 	"math"
 	"path/filepath"
 	"testing"
@@ -24,6 +25,63 @@ func initSharedSubjectTestDB(t *testing.T) {
 		t.Fatalf("InitDB: %v", err)
 	}
 	t.Cleanup(CloseDB)
+}
+
+func TestInitDBAddsTotalTokensToExistingSharedUsageBuckets(t *testing.T) {
+	CloseDB()
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE ai_account_subject_usage_buckets (
+			auth_subject_id TEXT NOT NULL,
+			bucket_kind TEXT NOT NULL,
+			bucket_start TEXT NOT NULL,
+			request_count INTEGER NOT NULL DEFAULT 0,
+			success_count INTEGER NOT NULL DEFAULT 0,
+			failure_count INTEGER NOT NULL DEFAULT 0,
+			cost_total REAL NOT NULL DEFAULT 0,
+			first_event_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (auth_subject_id, bucket_kind, bucket_start)
+		)
+	`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(CloseDB)
+
+	rows, err := getDB().Query(`PRAGMA table_info(ai_account_subject_usage_buckets)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatal(err)
+		}
+		if name == "total_tokens" {
+			found = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("total_tokens column missing after SQLite additive migration")
+	}
 }
 
 func sharedSubjectTestAuth(tenantID, authID, accountID, email string) *coreauth.Auth {
@@ -179,15 +237,15 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 			t.Fatalf("UpsertAPIKeyForTenant(%s): %v", row.Key, err)
 		}
 	}
-	InsertLogWithDetailsIdentitySubject(keyA, "", identity.ID, "A", "gpt-5.4", "codex", "A", authA.EnsureIndex(), false, now, 10, 1, TokenStats{TotalTokens: 1}, "", "", "")
-	InsertLogWithDetailsIdentitySubject(keyB, "", identity.ID, "B", "gpt-5.4", "codex", "B", authB.EnsureIndex(), true, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 1}, "", "", "")
+	InsertLogWithDetailsIdentitySubject(keyA, "", identity.ID, "A", "gpt-5.4", "codex", "A", authA.EnsureIndex(), false, now, 10, 1, TokenStats{TotalTokens: 111}, "", "", "")
+	InsertLogWithDetailsIdentitySubject(keyB, "", identity.ID, "B", "gpt-5.4", "codex", "B", authB.EnsureIndex(), true, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 222}, "", "", "")
 
-	var dayRows, dayRequests int64
-	if err := getDB().QueryRow(`SELECT COUNT(*), COALESCE(SUM(request_count), 0) FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? AND bucket_kind = 'day'`, identity.ID).Scan(&dayRows, &dayRequests); err != nil {
+	var dayRows, dayRequests, dayTokens int64
+	if err := getDB().QueryRow(`SELECT COUNT(*), COALESCE(SUM(request_count), 0), COALESCE(SUM(total_tokens), 0) FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? AND bucket_kind = 'day'`, identity.ID).Scan(&dayRows, &dayRequests, &dayTokens); err != nil {
 		t.Fatal(err)
 	}
-	if dayRows != 1 || dayRequests != 2 {
-		t.Fatalf("day projection rows=%d requests=%d", dayRows, dayRequests)
+	if dayRows != 1 || dayRequests != 2 || dayTokens != 333 {
+		t.Fatalf("day projection rows=%d requests=%d tokens=%d", dayRows, dayRequests, dayTokens)
 	}
 	var legacyRows int64
 	if err := getDB().QueryRow(`SELECT COUNT(*) FROM auth_subject_usage_daily WHERE auth_subject_id = ?`, identity.ID).Scan(&legacyRows); err != nil {
@@ -217,7 +275,7 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 		t.Fatal(err)
 	}
 	got := summaries[identity.ID]
-	if got.RequestTotal != 2 || got.SuccessTotal != 1 || got.FailureTotal != 1 || got.RequestTotal30d != 2 || got.CycleRequestTotal != 2 || !got.CycleKnown {
+	if got.RequestTotal != 2 || got.SuccessTotal != 1 || got.FailureTotal != 1 || got.RequestTotal30d != 2 || got.CycleRequestTotal != 2 || got.CycleTotalTokens != 333 || !got.CycleKnown {
 		t.Fatalf("shared usage=%+v", got)
 	}
 	if got.SuccessRate == nil || math.Abs(*got.SuccessRate-0.5) > 1e-9 {
@@ -246,7 +304,7 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 		t.Fatal(err)
 	}
 	clean := afterCleanup[identity.ID]
-	if clean.RequestTotal != got.RequestTotal || clean.SuccessTotal != got.SuccessTotal || clean.FailureTotal != got.FailureTotal || clean.CycleRequestTotal != got.CycleRequestTotal {
+	if clean.RequestTotal != got.RequestTotal || clean.SuccessTotal != got.SuccessTotal || clean.FailureTotal != got.FailureTotal || clean.CycleRequestTotal != got.CycleRequestTotal || clean.CycleTotalTokens != got.CycleTotalTokens {
 		t.Fatalf("shared usage reset after request_logs cleanup: before=%+v after=%+v", got, clean)
 	}
 }
@@ -406,12 +464,17 @@ func TestProjectAIAccountSubjectUsageLoadsPrimaryCycleOnCacheMiss(t *testing.T) 
 		t.Fatal(err)
 	}
 	resetAIAccountSubjectCycleCache()
+	primaryStart := primaryReset.Add(-7 * 24 * time.Hour)
 
 	tx, err := getDB().Begin()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 1.5, now); err != nil {
+	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 0.5, 111, primaryStart.Add(-time.Second)); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 1.5, 321, now); err != nil {
 		_ = tx.Rollback()
 		t.Fatal(err)
 	}
@@ -419,26 +482,121 @@ func TestProjectAIAccountSubjectUsageLoadsPrimaryCycleOnCacheMiss(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	primaryStart := primaryReset.Add(-7 * 24 * time.Hour)
 	var bucketStart string
-	var requests int64
+	var requests, totalTokens int64
 	if err := getDB().QueryRow(`
-		SELECT bucket_start, request_count
+		SELECT bucket_start, request_count, total_tokens
 		FROM ai_account_subject_usage_buckets
 		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
-	`, identity.ID).Scan(&bucketStart, &requests); err != nil {
+	`, identity.ID).Scan(&bucketStart, &requests, &totalTokens); err != nil {
 		t.Fatal(err)
 	}
-	if bucketStart != formatAIAccountSubjectCycleBucketStart(primaryStart) || requests != 1 {
-		t.Fatalf("cycle bucket start=%q requests=%d want %q/1", bucketStart, requests, formatAIAccountSubjectCycleBucketStart(primaryStart))
+	if bucketStart != formatAIAccountSubjectCycleBucketStart(primaryStart) || requests != 1 || totalTokens != 321 {
+		t.Fatalf("cycle bucket start=%q requests=%d tokens=%d want %q/1/321", bucketStart, requests, totalTokens, formatAIAccountSubjectCycleBucketStart(primaryStart))
 	}
 	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, map[string]time.Time{identity.ID: primaryStart})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := summaries[identity.ID]; !got.CycleKnown || got.CycleRequestTotal != 1 {
+	if got := summaries[identity.ID]; !got.CycleKnown || got.CycleRequestTotal != 1 || got.CycleTotalTokens != 321 {
 		t.Fatalf("cycle summary=%+v", got)
 	}
+}
+
+func TestAIAccountSubjectUsageTokensBackfillUsesRollupsAndExactCycle(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "token-backfill", "acct-token-backfill", "tokens@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	cycleStart := now.Add(-48 * time.Hour)
+	resetAt := cycleStart.Add(7 * 24 * time.Hour)
+	pct := 50.0
+	if err := RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "codex", QuotaKey: "code_week", QuotaLabel: "Week",
+		Percent: &pct, ResetAt: &resetAt, WindowSeconds: 604800,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	beforeCycle := cycleStart.Add(-time.Hour)
+	insideCycle := cycleStart.Add(time.Hour)
+	for _, event := range []struct {
+		at     time.Time
+		tokens int64
+	}{{beforeCycle, 100}, {insideCycle, 200}} {
+		tx, err := getDB().Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := projectUsageRollupTx(tx, rollupEvent{
+			TenantID: sharedSubjectTenantA, AuthSubjectID: identity.ID, At: event.at,
+			Tokens: TokenStats{TotalTokens: event.tokens},
+		}); err != nil {
+			_ = tx.Rollback()
+			t.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := getDB().Exec(`
+			INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, total_tokens)
+			VALUES (?, ?, ?, ?)
+		`, sharedSubjectTenantA, event.at.Format(time.RFC3339Nano), identity.ID, event.tokens); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	assertTotals := func(wantDay, wantLifetime, wantCycle int64) {
+		t.Helper()
+		var day, lifetime, cycle int64
+		if err := getDB().QueryRow(`
+			SELECT COALESCE(SUM(total_tokens), 0)
+			FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'day'
+		`, identity.ID).Scan(&day); err != nil {
+			t.Fatal(err)
+		}
+		if err := getDB().QueryRow(`
+			SELECT total_tokens
+			FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'lifetime' AND bucket_start = '1970-01-01'
+		`, identity.ID).Scan(&lifetime); err != nil {
+			t.Fatal(err)
+		}
+		if err := getDB().QueryRow(`
+			SELECT total_tokens
+			FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+		`, identity.ID, formatAIAccountSubjectCycleBucketStart(cycleStart)).Scan(&cycle); err != nil {
+			t.Fatal(err)
+		}
+		if day != wantDay || lifetime != wantLifetime || cycle != wantCycle {
+			t.Fatalf("backfilled tokens day=%d lifetime=%d cycle=%d want %d/%d/%d", day, lifetime, cycle, wantDay, wantLifetime, wantCycle)
+		}
+	}
+
+	if err := RunAIAccountSubjectUsageTokensBackfillAtInit(); err != nil {
+		t.Fatal(err)
+	}
+	assertTotals(300, 300, 200)
+	if got := projectionMarkerValue(getDB(), aiAccountSubjectUsageTokensBackfillMarker); got != rollupMarkerDone {
+		t.Fatalf("token backfill marker=%q want %q", got, rollupMarkerDone)
+	}
+
+	if _, err := getDB().Exec(`UPDATE ai_account_subject_usage_buckets SET total_tokens = 999 WHERE auth_subject_id = ?`, identity.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getDB().Exec(`DELETE FROM usage_projection_markers WHERE marker_key = ?`, aiAccountSubjectUsageTokensBackfillMarker); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunAIAccountSubjectUsageTokensBackfillAtInit(); err != nil {
+		t.Fatal(err)
+	}
+	assertTotals(300, 300, 200)
 }
 
 func TestAIAccountBindingHookTracksAuthLifecycle(t *testing.T) {

--- a/internal/usage/ai_account_status_store_test.go
+++ b/internal/usage/ai_account_status_store_test.go
@@ -320,7 +320,7 @@ func TestAIAccountSubjectDayProjectionUsesConfiguredTimezone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := projectAIAccountSubjectUsageTx(tx, "sub-timezone", false, 1.25, at); err != nil {
+	if err := projectAIAccountSubjectUsageTx(tx, "sub-timezone", false, 1.25, 123, at); err != nil {
 		_ = tx.Rollback()
 		t.Fatal(err)
 	}

--- a/internal/usage/ai_account_subject_store.go
+++ b/internal/usage/ai_account_subject_store.go
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS ai_account_subject_usage_buckets (
   success_count INTEGER NOT NULL DEFAULT 0,
   failure_count INTEGER NOT NULL DEFAULT 0,
   cost_total REAL NOT NULL DEFAULT 0,
+  total_tokens INTEGER NOT NULL DEFAULT 0,
   first_event_at DATETIME NOT NULL,
   updated_at DATETIME NOT NULL,
   PRIMARY KEY (auth_subject_id, bucket_kind, bucket_start)
@@ -195,6 +196,8 @@ func ensureAIAccountSharedSubjectTables(db *sql.DB) error {
 		if _, err := db.Exec(aiAccountSharedSubjectTablesSQL); err != nil {
 			return fmt.Errorf("usage: ensure ai account shared subject tables: %w", err)
 		}
+		// Additive migration for SQLite databases created before cycle token projection.
+		_, _ = db.Exec(`ALTER TABLE ai_account_subject_usage_buckets ADD COLUMN total_tokens INTEGER NOT NULL DEFAULT 0`)
 	}
 	ensureUsageProjectionMarkerTable(db)
 	if err := setProjectionMarker(db, aiAccountSharedSchemaMarker, "done"); err != nil {

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -146,7 +146,7 @@ func formatAIAccountSubjectCycleBucketStart(value time.Time) string {
 // projectAIAccountSubjectUsageTx is the request-hot B-layer projection. It only
 // uses the server-computed subject already captured by usageReporter; it never
 // reads or upserts the low-frequency tenant binding table.
-func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed bool, cost float64, at time.Time) error {
+func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed bool, cost float64, totalTokens int64, at time.Time) error {
 	if tx == nil {
 		return nil
 	}
@@ -181,18 +181,19 @@ func projectAIAccountSubjectUsageTx(tx *sql.Tx, authSubjectID string, failed boo
 	const upsert = `
 		INSERT INTO ai_account_subject_usage_buckets (
 			auth_subject_id, bucket_kind, bucket_start, request_count,
-			success_count, failure_count, cost_total, first_event_at, updated_at
-		) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
 			request_count = ai_account_subject_usage_buckets.request_count + 1,
 			success_count = ai_account_subject_usage_buckets.success_count + excluded.success_count,
 			failure_count = ai_account_subject_usage_buckets.failure_count + excluded.failure_count,
 			cost_total = ai_account_subject_usage_buckets.cost_total + excluded.cost_total,
+			total_tokens = ai_account_subject_usage_buckets.total_tokens + excluded.total_tokens,
 			updated_at = excluded.updated_at
 	`
 	// The fixed day -> lifetime -> cycle order is shared by every writer.
 	for _, bucket := range buckets {
-		if _, err := tx.Exec(upsert, authSubjectID, bucket.kind, bucket.start, successInc, failureInc, cost, first, now); err != nil {
+		if _, err := tx.Exec(upsert, authSubjectID, bucket.kind, bucket.start, successInc, failureInc, cost, totalTokens, first, now); err != nil {
 			return fmt.Errorf("usage: project shared subject %s: %w", bucket.kind, err)
 		}
 	}
@@ -392,7 +393,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 		cycleArgs = append(cycleArgs, start)
 	}
 	cycleRows, err := db.Query(`
-		SELECT auth_subject_id, bucket_start, request_count, cost_total, updated_at
+		SELECT auth_subject_id, bucket_start, request_count, cost_total, total_tokens, updated_at
 		FROM ai_account_subject_usage_buckets
 		WHERE bucket_kind = 'cycle'
 		  AND auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(cycleIDs)), ",")+`)
@@ -403,10 +404,10 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 	}
 	for cycleRows.Next() {
 		var id, bucketStart string
-		var req int64
+		var req, totalTokens int64
 		var cost float64
 		var updated sql.NullString
-		if err := cycleRows.Scan(&id, &bucketStart, &req, &cost, &updated); err != nil {
+		if err := cycleRows.Scan(&id, &bucketStart, &req, &cost, &totalTokens, &updated); err != nil {
 			cycleRows.Close()
 			return nil, err
 		}
@@ -415,7 +416,7 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 			continue
 		}
 		s := out[id]
-		s.CycleRequestTotal, s.CycleCostTotal = req, cost
+		s.CycleRequestTotal, s.CycleCostTotal, s.CycleTotalTokens = req, cost, totalTokens
 		if t, ok := parseStoredTimeString(updated.String); ok && t.After(s.UpdatedAt) {
 			s.UpdatedAt = t
 		}

--- a/internal/usage/ai_account_subject_usage_tokens_backfill.go
+++ b/internal/usage/ai_account_subject_usage_tokens_backfill.go
@@ -1,0 +1,226 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const aiAccountSubjectUsageTokensBackfillMarker = "ai_account_subject_usage_tokens_backfill_v1"
+
+type aiAccountSubjectTokenBucket struct {
+	subjectID  string
+	kind       string
+	start      string
+	total      int64
+	firstEvent time.Time
+}
+
+// RunAIAccountSubjectUsageTokensBackfillAtInit fills the new token projection
+// from durable rollups and exact surviving cycle logs once per marker version.
+func RunAIAccountSubjectUsageTokensBackfillAtInit() error {
+	return runAIAccountSubjectUsageTokensBackfillAtInitDB(getDB())
+}
+
+func runAIAccountSubjectUsageTokensBackfillAtInitDB(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+
+	usageProjectionMu.Lock()
+	defer usageProjectionMu.Unlock()
+
+	ensureUsageProjectionMarkerTable(db)
+	if projectionMarkerValue(db, aiAccountSubjectUsageTokensBackfillMarker) == rollupMarkerDone {
+		return nil
+	}
+	if err := setProjectionMarker(db, aiAccountSubjectUsageTokensBackfillMarker, rollupMarkerPending); err != nil {
+		return fmt.Errorf("usage: mark shared subject token backfill pending: %w", err)
+	}
+
+	buckets, err := loadAIAccountSubjectDayAndLifetimeTokenBuckets(db)
+	if err != nil {
+		return err
+	}
+	cycleBuckets, err := loadAIAccountSubjectCycleTokenBuckets(db)
+	if err != nil {
+		return err
+	}
+	buckets = append(buckets, cycleBuckets...)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin shared subject token backfill: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UTC()
+	updatedAt := now.Format(time.RFC3339Nano)
+	const upsert = `
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?)
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			total_tokens = excluded.total_tokens,
+			updated_at = excluded.updated_at
+	`
+	for _, bucket := range buckets {
+		firstEvent := bucket.firstEvent
+		if firstEvent.IsZero() {
+			firstEvent = now
+		}
+		if _, err := tx.Exec(upsert, bucket.subjectID, bucket.kind, bucket.start, bucket.total, firstEvent.UTC().Format(time.RFC3339Nano), updatedAt); err != nil {
+			return fmt.Errorf("usage: backfill shared subject %s tokens: %w", bucket.kind, err)
+		}
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO UPDATE SET
+			marker_value = excluded.marker_value,
+			updated_at = excluded.updated_at
+	`, aiAccountSubjectUsageTokensBackfillMarker, rollupMarkerDone, updatedAt); err != nil {
+		return fmt.Errorf("usage: mark shared subject token backfill: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit shared subject token backfill: %w", err)
+	}
+	return nil
+}
+
+func loadAIAccountSubjectDayAndLifetimeTokenBuckets(db *sql.DB) ([]aiAccountSubjectTokenBucket, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, bucket_kind, bucket_start,
+			COALESCE(SUM(total_tokens), 0), MIN(updated_at)
+		FROM usage_rollup_buckets
+		WHERE bucket_kind IN ('day', 'lifetime')
+		  AND trim(coalesce(auth_subject_id, '')) <> ''
+		GROUP BY auth_subject_id, bucket_kind, bucket_start
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared subject token rollups: %w", err)
+	}
+	defer rows.Close()
+
+	buckets := make([]aiAccountSubjectTokenBucket, 0)
+	for rows.Next() {
+		var bucket aiAccountSubjectTokenBucket
+		var first storedTime
+		if err := rows.Scan(&bucket.subjectID, &bucket.kind, &bucket.start, &bucket.total, &first); err != nil {
+			return nil, fmt.Errorf("usage: scan shared subject token rollup: %w", err)
+		}
+		bucket.subjectID = strings.TrimSpace(bucket.subjectID)
+		if bucket.subjectID == "" {
+			continue
+		}
+		if first.Valid {
+			bucket.firstEvent = first.Time
+		}
+		buckets = append(buckets, bucket)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return buckets, nil
+}
+
+func loadAIAccountSubjectCycleTokenBuckets(db *sql.DB) ([]aiAccountSubjectTokenBucket, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE window_seconds >= ?
+		ORDER BY auth_subject_id, last_verified_at DESC, reset_at DESC
+	`, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared subject token cycles: %w", err)
+	}
+
+	bySubject := make(map[string][]AIAccountSubjectQuotaCycle)
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("usage: scan shared subject token cycle: %w", err)
+		}
+		cycle.AuthSubjectID = strings.TrimSpace(cycle.AuthSubjectID)
+		if cycle.AuthSubjectID == "" || !start.Valid || !reset.Valid {
+			continue
+		}
+		cycle.CycleStartAt = start.Time
+		cycle.ResetAt = reset.Time
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time
+		}
+		bySubject[cycle.AuthSubjectID] = append(bySubject[cycle.AuthSubjectID], cycle)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	selected := make(map[string]AIAccountSubjectQuotaCycle, len(bySubject))
+	var earliest time.Time
+	for subjectID, cycles := range bySubject {
+		cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles)
+		if !ok {
+			continue
+		}
+		selected[subjectID] = cycle
+		if earliest.IsZero() || cycle.CycleStartAt.Before(earliest) {
+			earliest = cycle.CycleStartAt
+		}
+	}
+	if len(selected) == 0 {
+		return []aiAccountSubjectTokenBucket{}, nil
+	}
+
+	totals := make(map[string]int64, len(selected))
+	firstEvents := make(map[string]time.Time, len(selected))
+	logRows, err := db.Query(`
+		SELECT auth_subject_id, timestamp, total_tokens
+		FROM request_logs
+		WHERE timestamp >= ?
+		  AND trim(coalesce(auth_subject_id, '')) <> ''
+	`, earliest.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared subject cycle tokens: %w", err)
+	}
+	defer logRows.Close()
+	for logRows.Next() {
+		var subjectID string
+		var at storedTime
+		var totalTokens int64
+		if err := logRows.Scan(&subjectID, &at, &totalTokens); err != nil {
+			return nil, fmt.Errorf("usage: scan shared subject cycle tokens: %w", err)
+		}
+		cycle, ok := selected[strings.TrimSpace(subjectID)]
+		if !ok || !at.Valid || at.Time.Before(cycle.CycleStartAt) {
+			continue
+		}
+		totals[cycle.AuthSubjectID] += totalTokens
+		if first := firstEvents[cycle.AuthSubjectID]; first.IsZero() || at.Time.Before(first) {
+			firstEvents[cycle.AuthSubjectID] = at.Time
+		}
+	}
+	if err := logRows.Close(); err != nil {
+		return nil, err
+	}
+
+	buckets := make([]aiAccountSubjectTokenBucket, 0, len(selected))
+	for subjectID, cycle := range selected {
+		firstEvent := firstEvents[subjectID]
+		if firstEvent.IsZero() {
+			firstEvent = cycle.CycleStartAt
+		}
+		buckets = append(buckets, aiAccountSubjectTokenBucket{
+			subjectID:  subjectID,
+			kind:       "cycle",
+			start:      formatAIAccountSubjectCycleBucketStart(cycle.CycleStartAt),
+			total:      totals[subjectID],
+			firstEvent: firstEvent,
+		})
+	}
+	return buckets, nil
+}

--- a/internal/usage/auth_subject_usage_daily.go
+++ b/internal/usage/auth_subject_usage_daily.go
@@ -25,6 +25,7 @@ type AuthSubjectUsageSummary struct {
 	FailureTotal30d   int64      `json:"failure_total_30d"`
 	CycleRequestTotal int64      `json:"cycle_request_total"`
 	CycleCostTotal    float64    `json:"cycle_cost_total"`
+	CycleTotalTokens  int64      `json:"cycle_total_tokens"`
 	CycleKnown        bool       `json:"cycle_known"`
 	CycleStart        string     `json:"cycle_start,omitempty"`
 	ProjectedSince    *time.Time `json:"projected_since,omitempty"`

--- a/internal/usage/auth_subject_usage_query.go
+++ b/internal/usage/auth_subject_usage_query.go
@@ -187,7 +187,15 @@ func QueryRequestCountByAuthSubjectSince(matcher AuthSubjectMatcher, since time.
 }
 
 func QueryRequestCountByAuthSubjectSinceForTenant(tenantID string, matcher AuthSubjectMatcher, since time.Time) (int64, error) {
-	return queryCountByAuthSubjectSince(tenantID, matcher, since, "COUNT(*)")
+	return queryInt64ByAuthSubjectSince(tenantID, matcher, since, "COUNT(*)", "count")
+}
+
+func QueryTotalTokensByAuthSubjectSince(matcher AuthSubjectMatcher, since time.Time) (int64, error) {
+	return QueryTotalTokensByAuthSubjectSinceForTenant(systemTenantID, matcher, since)
+}
+
+func QueryTotalTokensByAuthSubjectSinceForTenant(tenantID string, matcher AuthSubjectMatcher, since time.Time) (int64, error) {
+	return queryInt64ByAuthSubjectSince(tenantID, matcher, since, "COALESCE(SUM(total_tokens), 0)", "total tokens")
 }
 
 func QueryCostByAuthSubjectSince(matcher AuthSubjectMatcher, since time.Time) (float64, error) {
@@ -222,7 +230,7 @@ func QueryCostByAuthSubjectSinceForTenant(tenantID string, matcher AuthSubjectMa
 	return total, nil
 }
 
-func queryCountByAuthSubjectSince(tenantID string, matcher AuthSubjectMatcher, since time.Time, aggregate string) (int64, error) {
+func queryInt64ByAuthSubjectSince(tenantID string, matcher AuthSubjectMatcher, since time.Time, aggregate, label string) (int64, error) {
 	db := getReadDB()
 	if db == nil {
 		return 0, nil
@@ -244,7 +252,7 @@ func queryCountByAuthSubjectSince(tenantID string, matcher AuthSubjectMatcher, s
 		WHERE tenant_id = ? AND timestamp >= ? AND (%s)
 	`, aggregate, matchSQL), args...).Scan(&total)
 	if err != nil {
-		return 0, fmt.Errorf("usage: request count by auth subject query: %w", err)
+		return 0, fmt.Errorf("usage: request %s by auth subject query: %w", label, err)
 	}
 	return total, nil
 }

--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -749,7 +749,12 @@ func openRouterSyncExistingWrapperRows(tenantID, baseModelID string, model OpenR
 		if !exists {
 			continue
 		}
-		existing.OwnedBy = "cline"
+		switch {
+		case strings.HasPrefix(wrapperID, "cline-pass/"):
+			existing.OwnedBy = "cline"
+		case strings.HasPrefix(wrapperID, "ollama/"):
+			existing.OwnedBy = "ollama"
+		}
 		if description := openRouterModelDescription(model); description != "" && openRouterShouldSyncDescription(existing) {
 			existing.Description = description
 		}
@@ -766,7 +771,10 @@ func openRouterWrapperModelIDs(baseModelID string) []string {
 	if baseModelID == "" || strings.Contains(baseModelID, "/") {
 		return nil
 	}
-	return []string{"cline-pass/" + baseModelID}
+	return []string{
+		"cline-pass/" + baseModelID,
+		"ollama/" + baseModelID,
+	}
 }
 
 func openRouterStaticBaseModelRow(modelID string) (ModelConfigRow, bool) {

--- a/internal/usage/openrouter_model_sync_test.go
+++ b/internal/usage/openrouter_model_sync_test.go
@@ -304,6 +304,67 @@ func TestSyncOpenRouterModelsUpdatesExistingClinePassWrapperFromCanonicalModel(t
 	}
 }
 
+func TestSyncOpenRouterModelsUpdatesExistingOllamaWrapperFromCanonicalModel(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "ollama/deepseek-v4-flash",
+		OwnedBy:     "ollama",
+		Description: "",
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "user",
+		InputModalities: []string{
+			"text",
+		},
+		OutputModalities: []string{
+			"text",
+		},
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	result, err := SyncOpenRouterModelList(context.Background(), []OpenRouterRemoteModel{
+		{
+			ID:          "deepseek/deepseek-v4-flash",
+			Description: "DeepSeek V4 Flash from OpenRouter",
+			Architecture: OpenRouterRemoteArchitecture{
+				Modality:         "text+image->text",
+				InputModalities:  []string{"text", "image"},
+				OutputModalities: []string{"text"},
+			},
+			Pricing: OpenRouterRemotePricing{
+				Prompt:         "0.0000003",
+				Completion:     "0.0000012",
+				InputCacheRead: "0.00000003",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SyncOpenRouterModelList() error = %v", err)
+	}
+	if result.Seen != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+
+	model, ok := GetModelConfig("ollama/deepseek-v4-flash")
+	if !ok {
+		t.Fatal("expected existing ollama wrapper to remain configured")
+	}
+	if model.OwnedBy != "ollama" || model.Source != "user" {
+		t.Fatalf("ollama wrapper identity should be preserved: %+v", model)
+	}
+	if model.Description != "DeepSeek V4 Flash from OpenRouter" {
+		t.Fatalf("ollama wrapper should inherit remote description, got %q", model.Description)
+	}
+	if model.InputPricePerMillion != 0.3 || model.OutputPricePerMillion != 1.2 || model.CachedPricePerMillion != 0.03 {
+		t.Fatalf("ollama wrapper should inherit canonical pricing: %+v", model)
+	}
+	if strings.Join(model.InputModalities, ",") != "text,image" || strings.Join(model.OutputModalities, ",") != "text" {
+		t.Fatalf("ollama wrapper should inherit canonical modalities: %+v -> %+v", model.InputModalities, model.OutputModalities)
+	}
+}
+
 func TestSyncOpenRouterModelsUpdatesExistingOpenRouterDescription(t *testing.T) {
 	initModelConfigTestDB(t)
 

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -357,36 +357,113 @@ func modelPricingLookupModelIDs(modelID string) []string {
 	if modelID == "" {
 		return nil
 	}
-	prefix, _, found := strings.Cut(modelID, "/")
-	providerlessID := openRouterProviderlessModelID(modelID)
-	if !found || strings.TrimSpace(prefix) == "" || providerlessID == "" || providerlessID == modelID {
-		return []string{modelID}
+	lookupIDs := []string{modelID}
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || candidate == modelID {
+			return
+		}
+		for _, existing := range lookupIDs {
+			if existing == candidate {
+				return
+			}
+		}
+		lookupIDs = append(lookupIDs, candidate)
 	}
-	return []string{modelID, providerlessID}
+
+	if prefix, _, found := strings.Cut(modelID, "/"); found {
+		if strings.TrimSpace(prefix) != "" {
+			add(openRouterProviderlessModelID(modelID))
+		}
+		return lookupIDs
+	}
+	if prefix, suffix, found := strings.Cut(modelID, "-"); found && strings.TrimSpace(prefix) != "" {
+		add(suffix)
+	}
+	return lookupIDs
 }
 
-// resolveModelPricingRowForTenant resolves exact pricing first, then retries once
-// without the first provider segment. Each candidate preserves tenant-over-system
-// inheritance and ModelConfigRow-over-legacy-pricing precedence.
+func hasEffectiveModelPricing(row ModelConfigRow) bool {
+	if normalizePricingMode(row.PricingMode) == "call" {
+		return row.PricePerCall > 0
+	}
+	return row.InputPricePerMillion > 0 ||
+		row.OutputPricePerMillion > 0 ||
+		row.CachedPricePerMillion > 0 ||
+		row.CacheReadPricePerMillion > 0 ||
+		row.CacheWritePricePerMillion > 0
+}
+
+func modelConfigRowFromLegacyPricing(pricing ModelPricingRow) ModelConfigRow {
+	return ModelConfigRow{
+		ModelID:                   pricing.ModelID,
+		Enabled:                   true,
+		PricingMode:               "token",
+		InputPricePerMillion:      pricing.InputPricePerMillion,
+		OutputPricePerMillion:     pricing.OutputPricePerMillion,
+		CachedPricePerMillion:     pricing.CachedPricePerMillion,
+		CacheReadPricePerMillion:  pricing.CacheReadPricePerMillion,
+		CacheWritePricePerMillion: pricing.CacheWritePricePerMillion,
+	}
+}
+
+func resolveModelPricingRow(modelID string, lookup func(string) (ModelConfigRow, bool)) (ModelConfigRow, bool) {
+	var firstFound ModelConfigRow
+	foundAny := false
+	exactEnabled := true
+	exactExists := false
+	for i, lookupID := range modelPricingLookupModelIDs(modelID) {
+		row, ok := lookup(lookupID)
+		if !ok {
+			continue
+		}
+		if !foundAny {
+			firstFound = row
+			foundAny = true
+		}
+		if i == 0 {
+			exactEnabled = row.Enabled
+			exactExists = true
+		}
+		if hasEffectiveModelPricing(row) {
+			if exactExists && i > 0 {
+				row.Enabled = row.Enabled && exactEnabled
+			}
+			return row, true
+		}
+	}
+	return firstFound, foundAny
+}
+
+// ResolveModelPricingRow resolves exact pricing first, then a single inherited
+// base candidate for slash- or dash-prefixed runtime model IDs. Config rows take
+// precedence over legacy pricing for each candidate; unpriced rows do not block
+// a later priced base candidate. Map keys must be normalized to lowercase IDs.
+func ResolveModelPricingRow(modelID string, configByID map[string]ModelConfigRow, pricingByID map[string]ModelPricingRow) (ModelConfigRow, bool) {
+	return resolveModelPricingRow(modelID, func(lookupID string) (ModelConfigRow, bool) {
+		key := strings.ToLower(strings.TrimSpace(lookupID))
+		if row, ok := configByID[key]; ok {
+			return row, true
+		}
+		if pricing, ok := pricingByID[key]; ok {
+			return modelConfigRowFromLegacyPricing(pricing), true
+		}
+		return ModelConfigRow{}, false
+	})
+}
+
+// resolveModelPricingRowForTenant preserves tenant-over-system inheritance and
+// ModelConfigRow-over-legacy-pricing precedence for every lookup candidate.
 func resolveModelPricingRowForTenant(tenantID, modelID string) (ModelConfigRow, bool) {
-	for _, lookupID := range modelPricingLookupModelIDs(modelID) {
+	return resolveModelPricingRow(modelID, func(lookupID string) (ModelConfigRow, bool) {
 		if row, ok := GetModelConfigForTenant(tenantID, lookupID); ok {
 			return row, true
 		}
 		if pricing, ok := GetModelPricingForTenant(tenantID, lookupID); ok {
-			return ModelConfigRow{
-				ModelID:                   pricing.ModelID,
-				Enabled:                   true,
-				PricingMode:               "token",
-				InputPricePerMillion:      pricing.InputPricePerMillion,
-				OutputPricePerMillion:     pricing.OutputPricePerMillion,
-				CachedPricePerMillion:     pricing.CachedPricePerMillion,
-				CacheReadPricePerMillion:  pricing.CacheReadPricePerMillion,
-				CacheWritePricePerMillion: pricing.CacheWritePricePerMillion,
-			}, true
+			return modelConfigRowFromLegacyPricing(pricing), true
 		}
-	}
-	return ModelConfigRow{}, false
+		return ModelConfigRow{}, false
+	})
 }
 
 // resolveModelPricing returns the effective pricing for a model from either

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -375,10 +375,15 @@ func modelPricingLookupModelIDs(modelID string) []string {
 		if strings.TrimSpace(prefix) != "" {
 			add(openRouterProviderlessModelID(modelID))
 		}
-		return lookupIDs
 	}
-	if prefix, suffix, found := strings.Cut(modelID, "-"); found && strings.TrimSpace(prefix) != "" {
-		add(suffix)
+	if variantSeparator := strings.LastIndex(modelID, ":"); variantSeparator > 0 {
+		add(modelID[:variantSeparator])
+	}
+	if !strings.Contains(modelID, "/") {
+		prefix, suffix, found := strings.Cut(modelID, "-")
+		if found && strings.TrimSpace(prefix) != "" {
+			add(suffix)
+		}
 	}
 	return lookupIDs
 }
@@ -435,10 +440,11 @@ func resolveModelPricingRow(modelID string, lookup func(string) (ModelConfigRow,
 	return firstFound, foundAny
 }
 
-// ResolveModelPricingRow resolves exact pricing first, then a single inherited
-// base candidate for slash- or dash-prefixed runtime model IDs. Config rows take
-// precedence over legacy pricing for each candidate; unpriced rows do not block
-// a later priced base candidate. Map keys must be normalized to lowercase IDs.
+// ResolveModelPricingRow resolves exact pricing first, then inherited base
+// candidates for provider-prefixed, tagged, or dash-prefixed runtime model IDs.
+// Config rows take precedence over legacy pricing for each candidate; unpriced
+// rows do not block a later priced base candidate. Map keys must be normalized
+// to lowercase IDs.
 func ResolveModelPricingRow(modelID string, configByID map[string]ModelConfigRow, pricingByID map[string]ModelPricingRow) (ModelConfigRow, bool) {
 	return resolveModelPricingRow(modelID, func(lookupID string) (ModelConfigRow, bool) {
 		key := strings.ToLower(strings.TrimSpace(lookupID))

--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -352,21 +352,53 @@ func calculateTokenCostV2(inputTokens, outputTokens, cacheReadTokens, cacheWrite
 	return total
 }
 
+func modelPricingLookupModelIDs(modelID string) []string {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return nil
+	}
+	prefix, _, found := strings.Cut(modelID, "/")
+	providerlessID := openRouterProviderlessModelID(modelID)
+	if !found || strings.TrimSpace(prefix) == "" || providerlessID == "" || providerlessID == modelID {
+		return []string{modelID}
+	}
+	return []string{modelID, providerlessID}
+}
+
+// resolveModelPricingRowForTenant resolves exact pricing first, then retries once
+// without the first provider segment. Each candidate preserves tenant-over-system
+// inheritance and ModelConfigRow-over-legacy-pricing precedence.
+func resolveModelPricingRowForTenant(tenantID, modelID string) (ModelConfigRow, bool) {
+	for _, lookupID := range modelPricingLookupModelIDs(modelID) {
+		if row, ok := GetModelConfigForTenant(tenantID, lookupID); ok {
+			return row, true
+		}
+		if pricing, ok := GetModelPricingForTenant(tenantID, lookupID); ok {
+			return ModelConfigRow{
+				ModelID:                   pricing.ModelID,
+				Enabled:                   true,
+				PricingMode:               "token",
+				InputPricePerMillion:      pricing.InputPricePerMillion,
+				OutputPricePerMillion:     pricing.OutputPricePerMillion,
+				CachedPricePerMillion:     pricing.CachedPricePerMillion,
+				CacheReadPricePerMillion:  pricing.CacheReadPricePerMillion,
+				CacheWritePricePerMillion: pricing.CacheWritePricePerMillion,
+			}, true
+		}
+	}
+	return ModelConfigRow{}, false
+}
+
 // resolveModelPricing returns the effective pricing for a model from either
 // ModelConfigRow cache or ModelPricingRow cache, along with a boolean indicating
 // whether the model is enabled (or found at all).
 // Both lookups inherit system-tenant catalog prices when the business tenant has no override.
 func resolveModelPricingForTenant(tenantID, modelID string) (inputPrice, outputPrice, cachedPrice, cacheReadPrice, cacheWritePrice float64, enabled bool) {
-	if row, ok := GetModelConfigForTenant(tenantID, modelID); ok {
-		enabled = row.Enabled
-		return row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion, row.CacheReadPricePerMillion, row.CacheWritePricePerMillion, enabled
-	}
-
-	row, ok := GetModelPricingForTenant(tenantID, modelID)
+	row, ok := resolveModelPricingRowForTenant(tenantID, modelID)
 	if !ok {
 		return 0, 0, 0, 0, 0, false
 	}
-	return row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion, row.CacheReadPricePerMillion, row.CacheWritePricePerMillion, true
+	return row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion, row.CacheReadPricePerMillion, row.CacheWritePricePerMillion, row.Enabled
 }
 
 // CalculateCost computes the cost for a request based on the model's pricing.
@@ -376,19 +408,12 @@ func CalculateCost(modelID string, inputTokens, outputTokens, cachedTokens int64
 	return CalculateCostForTenant(systemTenantID, modelID, inputTokens, outputTokens, cachedTokens)
 }
 func CalculateCostForTenant(tenantID, modelID string, inputTokens, outputTokens, cachedTokens int64) float64 {
-	if row, ok := GetModelConfigForTenant(tenantID, modelID); ok {
-		if !row.Enabled {
-			return 0
-		}
-		if normalizePricingMode(row.PricingMode) == "call" {
-			return row.PricePerCall
-		}
-		return calculateTokenCost(inputTokens, outputTokens, cachedTokens, row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion)
-	}
-
-	row, ok := GetModelPricingForTenant(tenantID, modelID)
-	if !ok {
+	row, ok := resolveModelPricingRowForTenant(tenantID, modelID)
+	if !ok || !row.Enabled {
 		return 0
+	}
+	if normalizePricingMode(row.PricingMode) == "call" {
+		return row.PricePerCall
 	}
 	return calculateTokenCost(inputTokens, outputTokens, cachedTokens, row.InputPricePerMillion, row.OutputPricePerMillion, row.CachedPricePerMillion)
 }
@@ -397,7 +422,7 @@ func CalculateCostForTenant(tenantID, modelID string, inputTokens, outputTokens,
 // the per-call price if so, along with a boolean. This avoids re-checking the
 // model config cache directly in CalculateCostV2.
 func resolveCallPricingForTenant(tenantID, modelID string) (pricePerCall float64, isCall bool) {
-	if row, ok := GetModelConfigForTenant(tenantID, modelID); ok && row.Enabled && normalizePricingMode(row.PricingMode) == "call" {
+	if row, ok := resolveModelPricingRowForTenant(tenantID, modelID); ok && row.Enabled && normalizePricingMode(row.PricingMode) == "call" {
 		return row.PricePerCall, true
 	}
 	return 0, false

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -260,6 +260,101 @@ func TestCalculateCostV2FallbackLegacyWithModelPricingTable(t *testing.T) {
 	}
 }
 
+func TestCalculateCostFallsBackToProviderlessModelPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:                  "deepseek-v4-flash",
+		Enabled:                  true,
+		PricingMode:              "token",
+		InputPricePerMillion:     0.3,
+		OutputPricePerMillion:    1.2,
+		CacheReadPricePerMillion: 0.03,
+		Source:                   "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	const modelID = "ollama/deepseek-v4-flash"
+	legacyCost := CalculateCost(modelID, 1_000_000, 1_000_000, 0)
+	if legacyCost != 1.5 {
+		t.Fatalf("CalculateCost(%q) = %v, want 1.5", modelID, legacyCost)
+	}
+
+	v2Cost := CalculateCostV2(modelID, TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+	if v2Cost != 1.5 {
+		t.Fatalf("CalculateCostV2(%q) = %v, want 1.5", modelID, v2Cost)
+	}
+
+	if err := UpsertModelConfigForTenant(businessTenantID, ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  3,
+		OutputPricePerMillion: 12,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant() error = %v", err)
+	}
+	tenantCost := CalculateCostV2ForTenant(businessTenantID, "ollama/deepseek-v4-flash", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+	if tenantCost != 15 {
+		t.Fatalf("tenant providerless override cost = %v, want 15", tenantCost)
+	}
+}
+
+func TestCalculateCostProviderlessFallbackPreservesExactCustomPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfigForTenant(systemTenantID, ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant(base) error = %v", err)
+	}
+	if err := UpsertModelConfigForTenant(businessTenantID, ModelConfigRow{
+		ModelID:               "ollama/deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  3,
+		OutputPricePerMillion: 12,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant(exact) error = %v", err)
+	}
+
+	cost := CalculateCostV2ForTenant(businessTenantID, "ollama/deepseek-v4-flash", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+	if cost != 15 {
+		t.Fatalf("exact custom pricing cost = %v, want 15", cost)
+	}
+}
+
+func TestCalculateCostProviderlessFallbackSupportsCallPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:      "image-call-base",
+		Enabled:      true,
+		PricingMode:  "call",
+		PricePerCall: 0.04,
+		Source:       "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig() error = %v", err)
+	}
+
+	for name, cost := range map[string]float64{
+		"legacy": CalculateCost("ollama/image-call-base", 0, 0, 0),
+		"v2":     CalculateCostV2("ollama/image-call-base", TokenStats{}),
+	} {
+		if cost != 0.04 {
+			t.Fatalf("%s call cost = %v, want 0.04", name, cost)
+		}
+	}
+}
+
 func TestQueryTodayCostByKeyResetsDaily(t *testing.T) {
 	initModelConfigTestDB(t)
 	db := getDB()

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -275,15 +275,19 @@ func TestCalculateCostFallsBackToProviderlessModelPricing(t *testing.T) {
 		t.Fatalf("UpsertModelConfig() error = %v", err)
 	}
 
-	const modelID = "ollama/deepseek-v4-flash"
-	legacyCost := CalculateCost(modelID, 1_000_000, 1_000_000, 0)
-	if legacyCost != 1.5 {
-		t.Fatalf("CalculateCost(%q) = %v, want 1.5", modelID, legacyCost)
-	}
+	for _, modelID := range []string{
+		"ollama/deepseek-v4-flash",
+		"foo-deepseek-v4-flash",
+	} {
+		legacyCost := CalculateCost(modelID, 1_000_000, 1_000_000, 0)
+		if legacyCost != 1.5 {
+			t.Fatalf("CalculateCost(%q) = %v, want 1.5", modelID, legacyCost)
+		}
 
-	v2Cost := CalculateCostV2(modelID, TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
-	if v2Cost != 1.5 {
-		t.Fatalf("CalculateCostV2(%q) = %v, want 1.5", modelID, v2Cost)
+		v2Cost := CalculateCostV2(modelID, TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+		if v2Cost != 1.5 {
+			t.Fatalf("CalculateCostV2(%q) = %v, want 1.5", modelID, v2Cost)
+		}
 	}
 
 	if err := UpsertModelConfigForTenant(businessTenantID, ModelConfigRow{
@@ -299,6 +303,72 @@ func TestCalculateCostFallsBackToProviderlessModelPricing(t *testing.T) {
 	tenantCost := CalculateCostV2ForTenant(businessTenantID, "ollama/deepseek-v4-flash", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
 	if tenantCost != 15 {
 		t.Fatalf("tenant providerless override cost = %v, want 15", tenantCost)
+	}
+}
+
+func TestCalculateCostFallsBackPastExactUnpricedConfig(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "ollama/deepseek-v4-flash",
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(exact) error = %v", err)
+	}
+
+	for name, cost := range map[string]float64{
+		"legacy": CalculateCost("ollama/deepseek-v4-flash", 1_000_000, 1_000_000, 0),
+		"v2":     CalculateCostV2("ollama/deepseek-v4-flash", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000}),
+	} {
+		if cost != 1.5 {
+			t.Fatalf("%s exact-unpriced fallback cost = %v, want 1.5", name, cost)
+		}
+	}
+}
+
+func TestCalculateCostInheritedPricingRespectsExactDisabled(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 1.2,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "ollama/deepseek-v4-flash",
+		Enabled:     false,
+		PricingMode: "token",
+		Source:      "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(exact) error = %v", err)
+	}
+
+	row, ok := resolveModelPricingRowForTenant(systemTenantID, "ollama/deepseek-v4-flash")
+	if !ok || !hasEffectiveModelPricing(row) {
+		t.Fatalf("resolved pricing = %+v ok=%v, want inherited base pricing", row, ok)
+	}
+	if row.Enabled {
+		t.Fatalf("resolved pricing = %+v, want exact disabled state preserved", row)
+	}
+	if cost := CalculateCost("ollama/deepseek-v4-flash", 1_000_000, 1_000_000, 0); cost != 0 {
+		t.Fatalf("disabled exact model cost = %v, want 0", cost)
 	}
 }
 

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -338,6 +338,72 @@ func TestCalculateCostFallsBackPastExactUnpricedConfig(t *testing.T) {
 	}
 }
 
+func TestCalculateCostFallsBackPastUnpricedVariant(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.098,
+		OutputPricePerMillion: 0.196,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:     "deepseek-v4-flash:free",
+		Enabled:     true,
+		PricingMode: "token",
+		Source:      "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(variant) error = %v", err)
+	}
+
+	row, ok := resolveModelPricingRowForTenant(systemTenantID, "deepseek-v4-flash:free")
+	if !ok || row.InputPricePerMillion != 0.098 || row.OutputPricePerMillion != 0.196 {
+		t.Fatalf("resolved variant pricing = %+v ok=%v, want base pricing", row, ok)
+	}
+	wantCost := 0.098 + 0.196
+	for name, cost := range map[string]float64{
+		"legacy": CalculateCost("deepseek-v4-flash:free", 1_000_000, 1_000_000, 0),
+		"v2":     CalculateCostV2("deepseek-v4-flash:free", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000}),
+	} {
+		if math.Abs(cost-wantCost) > 1e-12 {
+			t.Fatalf("%s variant fallback cost = %v, want %v", name, cost, wantCost)
+		}
+	}
+}
+
+func TestCalculateCostVariantPreservesExactCustomPricing(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.098,
+		OutputPricePerMillion: 0.196,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "deepseek-v4-flash:free",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  3,
+		OutputPricePerMillion: 12,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(variant) error = %v", err)
+	}
+
+	if cost := CalculateCostV2("deepseek-v4-flash:free", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000}); cost != 15 {
+		t.Fatalf("exact variant custom pricing cost = %v, want 15", cost)
+	}
+}
+
 func TestCalculateCostInheritedPricingRespectsExactDisabled(t *testing.T) {
 	initModelConfigTestDB(t)
 

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -319,22 +319,95 @@ func (params LogQueryParams) withoutFacet(facet string) LogQueryParams {
 	return params
 }
 
-// QueryStats returns aggregated statistics from usage rollup projection.
-// Does not scan request_logs so detail retention cleanup cannot zero stats.
+// QueryStats returns aggregated statistics for the same filters as QueryLogs.
+// It prefers usage rollups, falling back to request_logs only when the rollup
+// dimensions cannot express the requested filter without changing its meaning.
 func QueryStats(params LogQueryParams) (LogStats, error) {
 	if getReadDB() == nil {
 		return LogStats{CacheRate: 0}, nil
 	}
-	// Explicit empty multi-selects match no rows; rollup does not model "empty model".
+	params = normalizeLogQueryParams(params)
+	// Explicit empty multi-selects match no rows.
 	if params.MatchNoAPIKeys || params.MatchNoAPIKeyIDs || params.MatchNoModels || params.MatchNoStatuses || params.MatchNoChannels {
 		return LogStats{CacheRate: 0}, nil
 	}
-	stats, err := queryStatsFromRollup(params)
+
+	filter, ok := rollupIdentityFilter(params)
+	if !ok {
+		// Preserve fail-closed identity behavior before considering a detail fallback.
+		return LogStats{CacheRate: 0}, nil
+	}
+
+	var (
+		stats LogStats
+		err   error
+	)
+	if queryStatsRequiresDetailAggregation(params) {
+		stats, err = queryStatsFromDetails(params)
+	} else {
+		stats, err = queryStatsFromRollupFilter(params, filter)
+	}
 	if err != nil {
 		log.Warnf("usage: stats query failed: %v", err)
 		return LogStats{}, err
 	}
 	return stats, nil
+}
+
+func queryStatsRequiresDetailAggregation(params LogQueryParams) bool {
+	// auth_index is not a rollup dimension, and precise legacy channel pairs
+	// cannot be represented by the rollup dimensions.
+	if len(params.AuthIndexes) > 0 || len(params.AuthIndexChannelNames) > 0 {
+		return true
+	}
+
+	// QueryLogs combines channel selector kinds with OR, while rollup dimensions
+	// are conjunctive. A mixed selector therefore needs the shared detail WHERE.
+	channelSelectorKinds := 0
+	if len(dedupeExactStrings(params.AuthSubjectIDs)) > 0 {
+		channelSelectorKinds++
+	}
+	if len(dedupeLowerTrimmedStrings(params.ChannelNames)) > 0 {
+		channelSelectorKinds++
+	}
+	if channelSelectorKinds > 1 {
+		return true
+	}
+
+	// Rollup buckets keep status counts, but token/cost/cache totals are not split
+	// by status. Use details for an exact single-status aggregate.
+	hasSuccess, hasFailed := requestedStatusFilter(params.Statuses)
+	return hasSuccess != hasFailed
+}
+
+func queryStatsFromDetails(params LogQueryParams) (LogStats, error) {
+	db := getReadDB()
+	if db == nil {
+		return LogStats{CacheRate: 0}, nil
+	}
+	where, args := buildWhereClause(params)
+
+	var agg rollupAgg
+	query := `
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(CASE WHEN failed = 0 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(total_tokens), 0),
+			COALESCE(SUM(cost), 0),
+			COALESCE(SUM(cached_tokens), 0),
+			COALESCE(SUM(` + cacheRateEffectiveInputSQL + `), 0)
+		FROM request_logs` + where
+	if err := db.QueryRow(query, args...).Scan(
+		&agg.RequestCount,
+		&agg.SuccessCount,
+		&agg.TotalTokens,
+		&agg.CostTotal,
+		&agg.CachedTokens,
+		&agg.EffectiveInputTokens,
+	); err != nil {
+		return LogStats{}, fmt.Errorf("usage: detail stats aggregate: %w", err)
+	}
+	return agg.toLogStats(), nil
 }
 
 // DeleteLogsByAPIKey removes all request_logs and request_log_content entries
@@ -606,6 +679,18 @@ func normalizeStringList(values []string) []string {
 	return result
 }
 
+func requestedStatusFilter(statuses []string) (hasSuccess, hasFailed bool) {
+	for _, status := range statuses {
+		switch strings.ToLower(strings.TrimSpace(status)) {
+		case "success":
+			hasSuccess = true
+		case "failed":
+			hasFailed = true
+		}
+	}
+	return hasSuccess, hasFailed
+}
+
 func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 	params = normalizeLogQueryParams(params)
 	if params.MatchNoAPIKeys || params.MatchNoAPIKeyIDs || params.MatchNoModels || params.MatchNoStatuses || params.MatchNoChannels {
@@ -708,16 +793,7 @@ func buildWhereClause(params LogQueryParams) (string, []interface{}) {
 
 	// Status multi-value filter
 	if len(params.Statuses) > 0 {
-		hasSuccess := false
-		hasFailed := false
-		for _, s := range params.Statuses {
-			switch strings.ToLower(s) {
-			case "success":
-				hasSuccess = true
-			case "failed":
-				hasFailed = true
-			}
-		}
+		hasSuccess, hasFailed := requestedStatusFilter(params.Statuses)
 		if hasSuccess && !hasFailed {
 			conditions = append(conditions, "failed = 0")
 		} else if hasFailed && !hasSuccess {

--- a/internal/usage/request_log_stats_filter_test.go
+++ b/internal/usage/request_log_stats_filter_test.go
@@ -1,0 +1,223 @@
+package usage
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestQueryStatsMatchesQueryLogsForMultiChannelSelectors(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	if err := UpsertModelPricing("model-target", 1, 2, 0.5); err != nil {
+		t.Fatalf("UpsertModelPricing(model-target): %v", err)
+	}
+	if err := UpsertModelPricing("model-other", 1, 2, 0.5); err != nil {
+		t.Fatalf("UpsertModelPricing(model-other): %v", err)
+	}
+
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model-target", "source", "Alpha", "auth-a", false, now, 10, 1, TokenStats{
+		InputTokens: 80, OutputTokens: 20, CachedTokens: 20, TotalTokens: 100,
+	}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model-other", "source", "Alpha", "auth-a", false, now.Add(time.Second), 10, 1, TokenStats{
+		InputTokens: 40, TotalTokens: 40,
+	}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-b", "subject-b", "", "model-target", "source", "Beta", "auth-b", true, now.Add(2*time.Second), 10, 1, TokenStats{
+		InputTokens: 10, OutputTokens: 250, CachedTokens: 40, TotalTokens: 300,
+	}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-c", "subject-c", "", "model-target", "source", "Gamma", "auth-c", false, now.Add(3*time.Second), 10, 1, TokenStats{
+		InputTokens: 10, TotalTokens: 10,
+	}, "", "", "")
+
+	tests := []struct {
+		name       string
+		params     LogQueryParams
+		wantDetail bool
+	}{
+		{
+			name:   "two auth subjects",
+			params: LogQueryParams{AuthSubjectIDs: []string{"subject-a", "subject-b"}},
+		},
+		{
+			name:   "two channel names",
+			params: LogQueryParams{ChannelNames: []string{" alpha ", "BETA"}},
+		},
+		{
+			name: "management subjects with legacy auth indexes",
+			params: LogQueryParams{
+				AuthSubjectIDs: []string{"subject-a", "subject-b"},
+				AuthIndexes:    []string{"auth-a", "auth-b"},
+			},
+			wantDetail: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := tt.params
+			params.Page = 1
+			params.Size = 10
+			params.Days = 1
+			gotDetail := queryStatsRequiresDetailAggregation(normalizeLogQueryParams(params))
+			if gotDetail != tt.wantDetail {
+				t.Fatalf("queryStatsRequiresDetailAggregation()=%v, want %v for %+v", gotDetail, tt.wantDetail, params)
+			}
+
+			logs, err := QueryLogs(params)
+			if err != nil {
+				t.Fatalf("QueryLogs(): %v", err)
+			}
+			stats, err := QueryStats(params)
+			if err != nil {
+				t.Fatalf("QueryStats(): %v", err)
+			}
+			if logs.Total != 3 || stats.Total != logs.Total {
+				t.Fatalf("logs.Total=%d stats.Total=%d, want both 3", logs.Total, stats.Total)
+			}
+			if stats.TotalTokens != 440 {
+				t.Fatalf("stats.TotalTokens=%d, want 440", stats.TotalTokens)
+			}
+			if math.Abs(stats.SuccessRate-(2.0/3.0*100)) > 1e-9 {
+				t.Fatalf("stats.SuccessRate=%v, want %v", stats.SuccessRate, 2.0/3.0*100)
+			}
+			if stats.TotalCost <= 0 {
+				t.Fatalf("stats.TotalCost=%v, want > 0", stats.TotalCost)
+			}
+			if stats.CacheRate <= 0 {
+				t.Fatalf("stats.CacheRate=%v, want > 0", stats.CacheRate)
+			}
+		})
+	}
+}
+
+func TestQueryStatsMatchesQueryLogsForChannelAndModel(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model-target", "source", "Alpha", "auth-a", false, now, 10, 1, TokenStats{TotalTokens: 11}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model-other", "source", "Alpha", "auth-a", false, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 22}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-b", "subject-b", "", "model-target", "source", "Beta", "auth-b", false, now.Add(2*time.Second), 10, 1, TokenStats{TotalTokens: 33}, "", "", "")
+
+	params := LogQueryParams{
+		Page:         1,
+		Size:         10,
+		Days:         1,
+		Models:       []string{"model-target"},
+		ChannelNames: []string{"alpha"},
+	}
+	logs, err := QueryLogs(params)
+	if err != nil {
+		t.Fatalf("QueryLogs(): %v", err)
+	}
+	stats, err := QueryStats(params)
+	if err != nil {
+		t.Fatalf("QueryStats(): %v", err)
+	}
+	if logs.Total != 1 || stats.Total != logs.Total || stats.TotalTokens != 11 {
+		t.Fatalf("logs.Total=%d stats=%+v, want one 11-token row", logs.Total, stats)
+	}
+}
+
+func TestQueryStatsMatchesQueryLogsForStatuses(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentitySubject("", "key-success", "subject-success", "", "model", "source", "Success", "auth-success", false, now, 10, 1, TokenStats{
+		InputTokens: 80, OutputTokens: 20, CachedTokens: 20, TotalTokens: 100,
+	}, "", "", "")
+	InsertLogWithDetailsIdentitySubject("", "key-failed", "subject-failed", "", "model", "source", "Failed", "auth-failed", true, now.Add(time.Second), 10, 1, TokenStats{
+		InputTokens: 10, OutputTokens: 250, CachedTokens: 40, TotalTokens: 300,
+	}, "", "", "")
+	if _, err := getDB().Exec(`UPDATE request_logs SET cost = CASE WHEN failed = 0 THEN 1.25 ELSE 2.5 END`); err != nil {
+		t.Fatalf("set detail costs: %v", err)
+	}
+
+	tests := []struct {
+		status      string
+		tokens      int64
+		cost        float64
+		successRate float64
+		cacheRate   float64
+	}{
+		{status: "success", tokens: 100, cost: 1.25, successRate: 100, cacheRate: 25},
+		{status: "failed", tokens: 300, cost: 2.5, successRate: 0, cacheRate: 80},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			params := LogQueryParams{Page: 1, Size: 10, Days: 1, Statuses: []string{tt.status}}
+			logs, err := QueryLogs(params)
+			if err != nil {
+				t.Fatalf("QueryLogs(): %v", err)
+			}
+			stats, err := QueryStats(params)
+			if err != nil {
+				t.Fatalf("QueryStats(): %v", err)
+			}
+			if logs.Total != 1 || stats.Total != logs.Total {
+				t.Fatalf("logs.Total=%d stats.Total=%d, want both 1", logs.Total, stats.Total)
+			}
+			if stats.TotalTokens != tt.tokens || math.Abs(stats.TotalCost-tt.cost) > 1e-12 ||
+				math.Abs(stats.SuccessRate-tt.successRate) > 1e-12 || math.Abs(stats.CacheRate-tt.cacheRate) > 1e-12 {
+				t.Fatalf("stats=%+v, want tokens=%d cost=%v success=%v cache=%v", stats, tt.tokens, tt.cost, tt.successRate, tt.cacheRate)
+			}
+		})
+	}
+}
+
+func TestQueryStatsWithoutFiltersRemainsRollupBacked(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	InsertLogWithDetailsIdentitySubject("", "key-a", "subject-a", "", "model", "source", "Alpha", "auth-a", false, time.Now().UTC(), 10, 1, TokenStats{TotalTokens: 17}, "", "", "")
+
+	params := LogQueryParams{Page: 1, Size: 10, Days: 1}
+	logs, err := QueryLogs(params)
+	if err != nil {
+		t.Fatalf("QueryLogs(): %v", err)
+	}
+	stats, err := QueryStats(params)
+	if err != nil {
+		t.Fatalf("QueryStats(): %v", err)
+	}
+	if logs.Total != 1 || stats.Total != logs.Total || stats.TotalTokens != 17 {
+		t.Fatalf("before detail delete logs.Total=%d stats=%+v", logs.Total, stats)
+	}
+	if _, err := getDB().Exec(`DELETE FROM request_logs`); err != nil {
+		t.Fatalf("delete request_logs: %v", err)
+	}
+	stats, err = QueryStats(params)
+	if err != nil {
+		t.Fatalf("QueryStats() after detail delete: %v", err)
+	}
+	if stats.Total != 1 || stats.TotalTokens != 17 {
+		t.Fatalf("stats after detail delete=%+v, want rollup total=1 tokens=17", stats)
+	}
+}
+
+func TestQueryStatsUnknownAPIKeyRemainsFailClosed(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	if err := UpsertAPIKey(APIKeyRow{ID: "known-key-id", Key: "sk-known", Name: "Known"}); err != nil {
+		t.Fatalf("UpsertAPIKey(): %v", err)
+	}
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentity("sk-known", "known-key-id", "Known", "model", "source", "Alpha", "auth-a", false, now, 10, 1, TokenStats{TotalTokens: 19}, "", "", "")
+	// This row deliberately has no api_keys registry entry. Even though the raw
+	// secret and auth_index match details, stats must keep the identity fail-closed.
+	InsertLogWithDetailsIdentity("sk-orphan", "orphan-key-id", "Orphan", "model", "source", "Beta", "auth-orphan", false, now.Add(time.Second), 10, 1, TokenStats{TotalTokens: 23}, "", "", "")
+
+	unfiltered, err := QueryStats(LogQueryParams{Days: 1})
+	if err != nil {
+		t.Fatalf("QueryStats(unfiltered): %v", err)
+	}
+	if unfiltered.Total != 2 {
+		t.Fatalf("unfiltered stats=%+v, want two tenant rows", unfiltered)
+	}
+	stats, err := QueryStats(LogQueryParams{
+		Days:        1,
+		APIKeys:     []string{"sk-orphan"},
+		AuthIndexes: []string{"auth-orphan"},
+	})
+	if err != nil {
+		t.Fatalf("QueryStats(unknown key): %v", err)
+	}
+	if stats != (LogStats{}) {
+		t.Fatalf("unknown-key stats=%+v, want all zero without tenant-wide fallback", stats)
+	}
+}

--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -77,7 +77,13 @@ func ApplyStoredRuntimeSettings(cfg *config.Config) bool {
 	if cfg == nil || !ConfigStoreAvailable() {
 		return false
 	}
-	return runtimeSettingsStore().ApplyToConfig(cfg)
+	store := runtimeSettingsStore()
+	applied := store.ApplyToConfig(cfg)
+	if cfg.EnsureProviderStableIDs() {
+		persistProviderStableIDBackfill(store, cfg)
+		return true
+	}
+	return applied
 }
 
 func MigrateRuntimeSettingsFromConfig(cfg *config.Config, configFilePath string) int {
@@ -113,7 +119,38 @@ func ApplyStoredRuntimeSettingsForTenant(tenantID string, cfg *config.Config) bo
 	if cfg == nil || !ConfigStoreAvailable() {
 		return false
 	}
-	return runtimeSettingsStoreForTenant(tenantID).ApplyToConfig(cfg)
+	store := runtimeSettingsStoreForTenant(tenantID)
+	applied := store.ApplyToConfig(cfg)
+	if cfg.EnsureProviderStableIDs() {
+		persistProviderStableIDBackfill(store, cfg)
+		return true
+	}
+	return applied
+}
+
+func persistProviderStableIDBackfill(store sqlsettings.RuntimeSettingsStore, cfg *config.Config) {
+	settings := []struct {
+		key   string
+		value any
+	}{
+		{RuntimeSettingGeminiKeys, cfg.GeminiKey},
+		{RuntimeSettingCodexKeys, cfg.CodexKey},
+		{RuntimeSettingClaudeKeys, cfg.ClaudeKey},
+		{RuntimeSettingBedrockKeys, cfg.BedrockKey},
+		{RuntimeSettingOpenCodeGoKeys, cfg.OpenCodeGoKey},
+		{RuntimeSettingClineKeys, cfg.ClineKey},
+		{RuntimeSettingOllamaCloudKeys, cfg.OllamaCloudKey},
+		{RuntimeSettingOpenAICompatibility, cfg.OpenAICompatibility},
+		{RuntimeSettingVertexCompatKeys, cfg.VertexCompatAPIKey},
+	}
+	for _, setting := range settings {
+		if !store.Exists(setting.key) {
+			continue
+		}
+		if err := store.Upsert(setting.key, setting.value); err != nil {
+			continue
+		}
+	}
 }
 
 // BuildTenantRuntimeConfig returns an isolated runtime snapshot for one tenant.

--- a/internal/usage/runtime_settings_db_test.go
+++ b/internal/usage/runtime_settings_db_test.go
@@ -305,3 +305,21 @@ func TestBuildTenantRuntimeConfigPreservesExplicitDisabledIdentityFingerprint(t 
 		t.Fatalf("Codex.Enabled = false, want true from tenant runtime row")
 	}
 }
+
+func TestTenantRuntimeProviderStableIDBackfillPersistsOnce(t *testing.T) {
+	cleanup := setupConfigMigrationTestDB(t)
+	defer cleanup()
+
+	const tenantID = "00000000-0000-0000-0000-0000000000aa"
+	if err := UpsertRuntimeSettingForTenant(tenantID, RuntimeSettingGeminiKeys, []config.GeminiKey{{APIKey: "tenant-secret"}}); err != nil {
+		t.Fatalf("UpsertRuntimeSettingForTenant: %v", err)
+	}
+	first := BuildTenantRuntimeConfig(&config.Config{}, tenantID)
+	if len(first.GeminiKey) != 1 || first.GeminiKey[0].ID == "" {
+		t.Fatalf("first backfill = %#v", first.GeminiKey)
+	}
+	second := BuildTenantRuntimeConfig(&config.Config{}, tenantID)
+	if second.GeminiKey[0].ID != first.GeminiKey[0].ID {
+		t.Fatalf("tenant stable ID changed: first=%q second=%q", first.GeminiKey[0].ID, second.GeminiKey[0].ID)
+	}
+}

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
 	log "github.com/sirupsen/logrus"
 	_ "modernc.org/sqlite"
@@ -813,6 +814,12 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 	initRuntimeSettingsTable(db)
 	log.Debugf("usage: initializing identity_fingerprints table")
 	initIdentityFingerprintsTable(db)
+	log.Debugf("usage: initializing content moderation tables")
+	if err := contentmoderation.InitTables(db); err != nil {
+		_ = db.Close()
+		usageDB, usageReadDB = nil, nil
+		return err
+	}
 	startRequestLogMaintenance(db, driver)
 	startRequestLogContentSessionIDBackfill(db)
 	log.Infof("usage: %s database initialised at %s", driver, dbPath)

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -506,7 +506,7 @@ func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 		return err
 	}
 	if ev.AuthSubjectID != "" {
-		if err := projectAIAccountSubjectUsageTx(tx, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.At); err != nil {
+		if err := projectAIAccountSubjectUsageTx(tx, ev.AuthSubjectID, ev.Failed, ev.Cost, ev.Tokens.TotalTokens, ev.At); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("project shared auth subject usage: %w", err)
 		}

--- a/internal/usage/usage_rollup_query.go
+++ b/internal/usage/usage_rollup_query.go
@@ -55,16 +55,17 @@ func (a rollupAgg) toDashboardKPI() DashboardKPI {
 }
 
 type rollupFilter struct {
-	TenantID      string
-	BucketKind    string
-	BucketFrom    string // inclusive day/hour/minute key; empty = no lower bound
-	BucketTo      string // exclusive optional
-	APIKeyIDs     []string
-	EndUserID     string
-	AuthSubjectID string
-	Models        []string
-	Sources       []string
-	ChannelNames  []string
+	TenantID       string
+	BucketKind     string
+	BucketFrom     string // inclusive day/hour/minute key; empty = no lower bound
+	BucketTo       string // exclusive optional
+	APIKeyIDs      []string
+	EndUserID      string
+	AuthSubjectID  string
+	AuthSubjectIDs []string
+	Models         []string
+	Sources        []string
+	ChannelNames   []string
 }
 
 func queryRollupAgg(filter rollupFilter) (rollupAgg, error) {
@@ -115,9 +116,18 @@ func queryRollupAgg(filter rollupFilter) (rollupAgg, error) {
 		b.WriteString(` AND end_user_id = ?`)
 		args = append(args, eu)
 	}
+	subjects := append([]string{}, filter.AuthSubjectIDs...)
 	if sub := strings.TrimSpace(filter.AuthSubjectID); sub != "" {
+		subjects = append(subjects, sub)
+	}
+	if subjects = dedupeExactStrings(subjects); len(subjects) == 1 {
 		b.WriteString(` AND auth_subject_id = ?`)
-		args = append(args, sub)
+		args = append(args, subjects[0])
+	} else if len(subjects) > 1 {
+		b.WriteString(` AND auth_subject_id IN (` + placeholders(len(subjects)) + `)`)
+		for _, subject := range subjects {
+			args = append(args, subject)
+		}
 	}
 	if models := dedupeExactStrings(filter.Models); len(models) > 0 {
 		b.WriteString(` AND model IN (` + placeholders(len(models)) + `)`)
@@ -131,10 +141,10 @@ func queryRollupAgg(filter rollupFilter) (rollupAgg, error) {
 			args = append(args, s)
 		}
 	}
-	if channels := dedupeExactStrings(filter.ChannelNames); len(channels) > 0 {
-		b.WriteString(` AND channel_name IN (` + placeholders(len(channels)) + `)`)
-		for _, c := range channels {
-			args = append(args, c)
+	if channels := dedupeLowerTrimmedStrings(filter.ChannelNames); len(channels) > 0 {
+		b.WriteString(` AND lower(trim(channel_name)) IN (` + placeholders(len(channels)) + `)`)
+		for _, channel := range channels {
+			args = append(args, channel)
 		}
 	}
 
@@ -211,10 +221,8 @@ func rollupIdentityFilter(params LogQueryParams) (rollupFilter, bool) {
 	if tenantID == "" {
 		tenantID = systemTenantID
 	}
-	authSubjectID := ""
-	if len(params.AuthSubjectIDs) == 1 {
-		authSubjectID = strings.TrimSpace(params.AuthSubjectIDs[0])
-	}
+	authSubjectIDs := dedupeExactStrings(params.AuthSubjectIDs)
+	channelNames := dedupeLowerTrimmedStrings(params.ChannelNames)
 	keyIDs := resolveAPIKeyIDsForStats(params)
 	keysRequested := len(requestedAPIKeys(params)) > 0 || len(params.APIKeyIDs) > 0
 	endUserID := strings.TrimSpace(params.EndUserID)
@@ -222,27 +230,40 @@ func rollupIdentityFilter(params LogQueryParams) (rollupFilter, bool) {
 	if keysRequested && len(keyIDs) == 0 && endUserID == "" {
 		return rollupFilter{}, false
 	}
-	// Multi auth subjects are not modeled as OR on rollup yet; fail closed.
-	if len(params.AuthSubjectIDs) > 1 {
+	// A requested rollup-supported channel selector with no usable values must
+	// not widen to tenant-wide aggregates. Unsupported selectors use details.
+	if (len(params.AuthSubjectIDs) > 0 || len(params.ChannelNames) > 0) &&
+		len(authSubjectIDs) == 0 && len(channelNames) == 0 &&
+		len(params.AuthIndexes) == 0 && len(params.AuthIndexChannelNames) == 0 {
 		return rollupFilter{}, false
 	}
-	return rollupFilter{
-		TenantID:      tenantID,
-		BucketKind:    rollupBucketDay,
-		APIKeyIDs:     keyIDs,
-		EndUserID:     endUserID,
-		AuthSubjectID: authSubjectID,
-		Models:        params.Models,
-	}, true
+	filter := rollupFilter{
+		TenantID:       tenantID,
+		BucketKind:     rollupBucketDay,
+		APIKeyIDs:      keyIDs,
+		EndUserID:      endUserID,
+		AuthSubjectIDs: authSubjectIDs,
+		Models:         params.Models,
+		ChannelNames:   channelNames,
+	}
+	if len(authSubjectIDs) == 1 {
+		filter.AuthSubjectID = authSubjectIDs[0]
+		filter.AuthSubjectIDs = nil
+	}
+	return filter, true
 }
 
 func queryStatsFromRollup(params LogQueryParams) (LogStats, error) {
-	if params.Days < 1 {
-		params.Days = 7
-	}
 	filter, ok := rollupIdentityFilter(params)
 	if !ok {
 		return LogStats{CacheRate: 0}, nil
+	}
+	return queryStatsFromRollupFilter(params, filter)
+}
+
+func queryStatsFromRollupFilter(params LogQueryParams, filter rollupFilter) (LogStats, error) {
+	if params.Days < 1 {
+		params.Days = 7
 	}
 	filter.BucketFrom = dayBucketFromDays(params.Days)
 	agg, err := queryRollupAgg(filter)

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -84,6 +84,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeys(ctx *SynthesisContext) []*corea
 		if label == "" {
 			label = "gemini-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "gemini",
@@ -142,6 +143,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		if label == "" {
 			label = "claude-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", ck.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "claude",
@@ -227,6 +229,7 @@ func (s *ConfigSynthesizer) synthesizeBedrockKeys(ctx *SynthesisContext) []*core
 			attrs["models_hash"] = hash
 		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		id, token := idGen.Next("bedrock:apikey", idParts...)
 		attrs["source"] = fmt.Sprintf("config:bedrock[%s]", token)
 		label := strings.TrimSpace(entry.Name)
@@ -290,6 +293,7 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 		if label == "" {
 			label = "codex-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", ck.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "codex",
@@ -344,6 +348,7 @@ func (s *ConfigSynthesizer) synthesizeOpenCodeGoKeys(ctx *SynthesisContext) []*c
 		if label == "" {
 			label = "opencode-go-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "opencode-go",
@@ -406,6 +411,7 @@ func (s *ConfigSynthesizer) synthesizeClineKeys(ctx *SynthesisContext) []*coreau
 		if label == "" {
 			label = "cline-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "cline",
@@ -468,6 +474,7 @@ func (s *ConfigSynthesizer) synthesizeOllamaCloudKeys(ctx *SynthesisContext) []*
 		if label == "" {
 			label = "ollama-cloud-apikey"
 		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "ollama-cloud",
@@ -534,6 +541,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				attrs["models_hash"] = hash
 			}
 			addConfigHeadersToAttrs(compat.Headers, attrs)
+			addProviderBindingAttrs(attrs, compat.ID, entry.ID)
 			a := &coreauth.Auth{
 				ID:         id,
 				Provider:   providerName,
@@ -565,6 +573,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				attrs["models_hash"] = hash
 			}
 			addConfigHeadersToAttrs(compat.Headers, attrs)
+			addProviderBindingAttrs(attrs, compat.ID, "")
 			a := &coreauth.Auth{
 				ID:         id,
 				Provider:   providerName,
@@ -614,6 +623,7 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 			attrs["models_hash"] = hash
 		}
 		addConfigHeadersToAttrs(compat.Headers, attrs)
+		addProviderBindingAttrs(attrs, "", compat.ID)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   providerName,

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -963,3 +963,38 @@ func TestConfigSynthesizer_AllProviders(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigSynthesizerAddsProviderBindingIDs(t *testing.T) {
+	cfg := &config.Config{
+		GeminiKey: []config.GeminiKey{{ID: "11111111-1111-4111-8111-111111111111", APIKey: "gemini-secret"}},
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			ID:      "22222222-2222-4222-8222-222222222222",
+			Name:    "compat",
+			BaseURL: "https://compat.example",
+			APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+				ID:     "33333333-3333-4333-8333-333333333333",
+				APIKey: "compat-secret",
+			}},
+		}},
+	}
+	auths, err := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+		Config:      cfg,
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("auth count = %d, want 2", len(auths))
+	}
+	if got := auths[0].Attributes["provider_key_id"]; got != cfg.GeminiKey[0].ID {
+		t.Fatalf("gemini provider_key_id = %q", got)
+	}
+	if got := auths[1].Attributes["provider_config_id"]; got != cfg.OpenAICompatibility[0].ID {
+		t.Fatalf("compat provider_config_id = %q", got)
+	}
+	if got := auths[1].Attributes["provider_key_id"]; got != cfg.OpenAICompatibility[0].APIKeyEntries[0].ID {
+		t.Fatalf("compat provider_key_id = %q", got)
+	}
+}

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -142,3 +142,15 @@ func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string)
 		attrs["header:"+key] = val
 	}
 }
+
+func addProviderBindingAttrs(attrs map[string]string, providerConfigID, providerKeyID string) {
+	if attrs == nil {
+		return
+	}
+	if id := strings.TrimSpace(providerConfigID); id != "" {
+		attrs["provider_config_id"] = id
+	}
+	if id := strings.TrimSpace(providerKeyID); id != "" {
+		attrs["provider_key_id"] = id
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -186,6 +186,8 @@ type Manager struct {
 
 	modelRegistry ModelRegistry
 
+	requestModerator RequestModerator
+
 	// Auto refresh state
 	refreshCancel    context.CancelFunc
 	refreshSemaphore chan struct{}

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -127,6 +127,9 @@ func (s cooldownService) shouldRetryAfterError(err error, attempt int, providers
 	if isRequestInvalidError(err) {
 		return 0, false
 	}
+	if isContentPolicyViolation(err) {
+		return 0, false
+	}
 	wait, found := s.closestWait(providers, model, attempt)
 	if !found || wait > maxWait {
 		return 0, false

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -153,6 +153,13 @@ func (s cooldownService) markResult(ctx context.Context, result Result) {
 
 	s.applyRegistryEffects(result, effects)
 	s.manager.hook.OnResult(ctx, result)
+	if !result.Success && result.RetryAfter == nil && isXAIWeekBalanceExhaustedError(result.Error) {
+		probeCtx := context.Background()
+		if ctx != nil {
+			probeCtx = context.WithoutCancel(ctx)
+		}
+		go s.manager.probeQuotaRecoveryWithLimit(probeCtx, result.AuthID, false)
+	}
 }
 
 func (s cooldownService) applyResultLocked(auth *Auth, result Result, now time.Time) resultStateEffects {
@@ -172,7 +179,7 @@ func (s cooldownService) applySuccessLocked(auth *Auth, result Result, now time.
 	markClaudeOAuthHealthSuccessLocked(auth, result, now)
 	if result.Model != "" {
 		state := ensureModelState(auth, result.Model)
-		if activeModelQuotaCooldown(state, now) {
+		if activeModelQuotaCooldown(state, now) && !quotaNeedsConfirmedRecovery(state.Quota) {
 			updateAggregatedAvailability(auth, now)
 			auth.UpdatedAt = now
 			return
@@ -189,7 +196,7 @@ func (s cooldownService) applySuccessLocked(auth *Auth, result Result, now time.
 		effects.clearModelQuota = true
 		return
 	}
-	if activeAuthQuotaCooldown(auth, now) {
+	if activeAuthQuotaCooldown(auth, now) && !quotaNeedsConfirmedRecovery(auth.Quota) {
 		updateAggregatedAvailability(auth, now)
 		auth.UpdatedAt = now
 		return
@@ -303,12 +310,13 @@ func applyModelQuotaFailureLocked(auth *Auth, state *ModelState, result Result, 
 	}
 	state.NextRetryAfter = next
 	state.Quota = QuotaState{
-		Exceeded:      true,
-		Reason:        "quota",
-		Window:        window,
-		WindowMinutes: windowMinutes,
-		NextRecoverAt: next,
-		BackoffLevel:  backoffLevel,
+		Exceeded:         true,
+		RecoveryRequired: isXAIWeekBalanceExhaustedError(result.Error),
+		Reason:           "quota",
+		Window:           window,
+		WindowMinutes:    windowMinutes,
+		NextRecoverAt:    next,
+		BackoffLevel:     backoffLevel,
 	}
 	if result.Error != nil && result.Error.Message != "" {
 		state.StatusMessage = result.Error.Message

--- a/sdk/cliproxy/auth/conductor_execution_service.go
+++ b/sdk/cliproxy/auth/conductor_execution_service.go
@@ -53,6 +53,9 @@ func runExecutionWithRetry[T any](
 	executeOnce func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (T, error),
 ) (T, error) {
 	var zero T
+	if opts.Metadata == nil {
+		opts.Metadata = make(map[string]any)
+	}
 
 	normalized := manager.normalizeProviders(providers)
 	if len(normalized) == 0 {
@@ -93,6 +96,9 @@ func (s executionService) executeMixedOnce(ctx context.Context, providers []stri
 		candidate, errPick := s.nextMixedCandidate(ctx, &scope, req)
 		if errPick != nil {
 			return cliproxyexecutor.Response{}, resolveMixedPickError(lastErr, errPick)
+		}
+		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
+			return cliproxyexecutor.Response{}, errModeration
 		}
 
 		resp, errExec := candidate.executor.Execute(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
@@ -137,6 +143,9 @@ func (s executionService) executeCountMixedOnce(ctx context.Context, providers [
 		if errPick != nil {
 			return cliproxyexecutor.Response{}, resolveMixedPickError(lastErr, errPick)
 		}
+		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
+			return cliproxyexecutor.Response{}, errModeration
+		}
 
 		resp, errExec := candidate.executor.CountTokens(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
 		if errExec != nil {
@@ -165,6 +174,9 @@ func (s executionService) executeStreamMixedOnce(ctx context.Context, providers 
 		candidate, errPick := s.nextMixedCandidate(ctx, &scope, req)
 		if errPick != nil {
 			return nil, resolveMixedPickError(lastErr, errPick)
+		}
+		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
+			return nil, errModeration
 		}
 
 		streamResult, errStream := candidate.executor.ExecuteStream(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)

--- a/sdk/cliproxy/auth/conductor_failure_state.go
+++ b/sdk/cliproxy/auth/conductor_failure_state.go
@@ -5,8 +5,6 @@ import (
 	"time"
 )
 
-const xaiWeekExhaustedDefaultCooldown = 6 * time.Hour
-
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
 	if auth == nil {
 		return
@@ -63,6 +61,7 @@ func applyAuthQuotaFailureState(auth *Auth, resultErr *Error, retryAfter *time.D
 		auth.StatusMessage = "quota exhausted"
 	}
 	auth.Quota.Exceeded = true
+	auth.Quota.RecoveryRequired = isXAIWeekBalanceExhaustedError(resultErr)
 	auth.Quota.Reason = "quota"
 	if resultErr != nil {
 		auth.Quota.Window = resultErr.QuotaWindow
@@ -86,7 +85,7 @@ func quotaFailureCooldown(resultErr *Error, retryAfter *time.Duration, prevLevel
 		return 0, prevLevel
 	}
 	if isXAIWeekBalanceExhaustedError(resultErr) {
-		return xaiWeekExhaustedDefaultCooldown, prevLevel
+		return 0, prevLevel
 	}
 	return nextQuotaCooldown(prevLevel, false)
 }

--- a/sdk/cliproxy/auth/conductor_persistence.go
+++ b/sdk/cliproxy/auth/conductor_persistence.go
@@ -29,6 +29,7 @@ func (s persistenceService) save(ctx context.Context, auth *Auth) error {
 	if !s.shouldPersist(ctx, auth) {
 		return nil
 	}
+	syncPersistedQuotaRuntime(auth)
 	_, err := s.manager.store.Save(ctx, auth)
 	return err
 }
@@ -47,7 +48,14 @@ func (s persistenceService) list(ctx context.Context) ([]*Auth, error) {
 	if s.manager == nil || s.manager.store == nil {
 		return nil, nil
 	}
-	return s.manager.store.List(ctx)
+	auths, err := s.manager.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, auth := range auths {
+		restorePersistedQuotaRuntime(auth)
+	}
+	return auths, nil
 }
 
 func (s persistenceService) shouldPersist(ctx context.Context, auth *Auth) bool {

--- a/sdk/cliproxy/auth/conductor_result_state.go
+++ b/sdk/cliproxy/auth/conductor_result_state.go
@@ -42,6 +42,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	quotaRecover := time.Time{}
 	quotaWindow := ""
 	quotaWindowMinutes := 0
+	quotaRecoveryRequired := false
 	maxBackoffLevel := 0
 	for _, state := range auth.ModelStates {
 		if state == nil {
@@ -50,6 +51,12 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		stateUnavailable := false
 		if state.Status == StatusDisabled {
 			stateUnavailable = true
+		} else if quotaNeedsConfirmedRecovery(state.Quota) {
+			stateUnavailable = true
+			state.Unavailable = true
+			if state.NextRetryAfter.After(now) && (earliestRetry.IsZero() || state.NextRetryAfter.Before(earliestRetry)) {
+				earliestRetry = state.NextRetryAfter
+			}
 		} else if state.Unavailable {
 			if state.NextRetryAfter.IsZero() {
 				stateUnavailable = false
@@ -68,6 +75,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		}
 		if state.Quota.Exceeded {
 			quotaExceeded = true
+			quotaRecoveryRequired = quotaRecoveryRequired || state.Quota.RecoveryRequired
 			if quotaRecover.IsZero() || (!state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.Before(quotaRecover)) {
 				quotaRecover = state.Quota.NextRecoverAt
 				quotaWindow = state.Quota.Window
@@ -89,6 +97,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	}
 	if quotaExceeded {
 		auth.Quota.Exceeded = true
+		auth.Quota.RecoveryRequired = quotaRecoveryRequired
 		auth.Quota.Reason = "quota"
 		auth.Quota.Window = quotaWindow
 		auth.Quota.WindowMinutes = quotaWindowMinutes
@@ -96,6 +105,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		auth.Quota.BackoffLevel = maxBackoffLevel
 	} else {
 		auth.Quota.Exceeded = false
+		auth.Quota.RecoveryRequired = false
 		auth.Quota.Reason = ""
 		auth.Quota.Window = ""
 		auth.Quota.WindowMinutes = 0
@@ -122,10 +132,17 @@ func activeQuotaCooldown(quota QuotaState, retryAfter time.Time, now time.Time) 
 	if !quota.Exceeded {
 		return false
 	}
+	if quotaNeedsConfirmedRecovery(quota) {
+		return true
+	}
 	if !quota.NextRecoverAt.IsZero() {
 		return quota.NextRecoverAt.After(now)
 	}
 	return !retryAfter.IsZero() && retryAfter.After(now)
+}
+
+func quotaNeedsConfirmedRecovery(quota QuotaState) bool {
+	return quota.Exceeded && quota.RecoveryRequired
 }
 
 func activeModelRuntimeState(state *ModelState, now time.Time) bool {
@@ -172,7 +189,7 @@ func hasModelError(auth *Auth, now time.Time) bool {
 			return true
 		}
 		if state.Status == StatusError {
-			if state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now)) {
+			if quotaNeedsConfirmedRecovery(state.Quota) || (state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now))) {
 				return true
 			}
 		}
@@ -188,6 +205,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Status = StatusActive
 	auth.StatusMessage = ""
 	auth.Quota.Exceeded = false
+	auth.Quota.RecoveryRequired = false
 	auth.Quota.Reason = ""
 	auth.Quota.Window = ""
 	auth.Quota.WindowMinutes = 0

--- a/sdk/cliproxy/auth/conductor_runtime_quota_test.go
+++ b/sdk/cliproxy/auth/conductor_runtime_quota_test.go
@@ -47,6 +47,9 @@ func TestManagerUpdatePreservesRuntimeQuotaState(t *testing.T) {
 	if beforeState == nil || !beforeState.Quota.Exceeded {
 		t.Fatalf("test setup failed: expected model quota to be exceeded")
 	}
+	if beforeState.Quota.RecoveryRequired {
+		t.Fatal("ordinary 429 unexpectedly requires confirmed recovery")
+	}
 
 	updated, err := m.Update(ctx, &Auth{
 		ID:       "auth-1",

--- a/sdk/cliproxy/auth/quota_persistence.go
+++ b/sdk/cliproxy/auth/quota_persistence.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const persistedQuotaRuntimeMetadataKey = "_cli_proxy_runtime_quota"
+
+type persistedQuotaRuntime struct {
+	Status         Status                                `json:"status,omitempty"`
+	StatusMessage  string                                `json:"status_message,omitempty"`
+	NextRetryAfter time.Time                             `json:"next_retry_after,omitempty"`
+	Quota          QuotaState                            `json:"quota"`
+	ModelStates    map[string]persistedQuotaModelRuntime `json:"model_states,omitempty"`
+}
+
+type persistedQuotaModelRuntime struct {
+	Status         Status     `json:"status,omitempty"`
+	StatusMessage  string     `json:"status_message,omitempty"`
+	NextRetryAfter time.Time  `json:"next_retry_after,omitempty"`
+	Quota          QuotaState `json:"quota"`
+}
+
+func syncPersistedQuotaRuntime(auth *Auth) {
+	if auth == nil || auth.Metadata == nil {
+		return
+	}
+
+	runtime := persistedQuotaRuntime{
+		Status:         auth.Status,
+		StatusMessage:  auth.StatusMessage,
+		NextRetryAfter: auth.NextRetryAfter,
+		Quota:          auth.Quota,
+	}
+	for model, state := range auth.ModelStates {
+		if state == nil || !quotaNeedsConfirmedRecovery(state.Quota) {
+			continue
+		}
+		if runtime.ModelStates == nil {
+			runtime.ModelStates = make(map[string]persistedQuotaModelRuntime)
+		}
+		runtime.ModelStates[model] = persistedQuotaModelRuntime{
+			Status:         state.Status,
+			StatusMessage:  state.StatusMessage,
+			NextRetryAfter: state.NextRetryAfter,
+			Quota:          state.Quota,
+		}
+	}
+
+	if !quotaNeedsConfirmedRecovery(runtime.Quota) && len(runtime.ModelStates) == 0 {
+		delete(auth.Metadata, persistedQuotaRuntimeMetadataKey)
+		return
+	}
+	auth.Metadata[persistedQuotaRuntimeMetadataKey] = runtime
+}
+
+func restorePersistedQuotaRuntime(auth *Auth) {
+	if auth == nil || auth.Metadata == nil || auth.Disabled || auth.Status == StatusDisabled {
+		return
+	}
+	raw, ok := auth.Metadata[persistedQuotaRuntimeMetadataKey]
+	if !ok || raw == nil {
+		return
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return
+	}
+	var runtime persistedQuotaRuntime
+	if err = json.Unmarshal(data, &runtime); err != nil {
+		return
+	}
+	if !quotaNeedsConfirmedRecovery(runtime.Quota) && len(runtime.ModelStates) == 0 {
+		return
+	}
+
+	if quotaNeedsConfirmedRecovery(runtime.Quota) {
+		auth.Quota = runtime.Quota
+		auth.NextRetryAfter = runtime.NextRetryAfter
+		auth.Unavailable = true
+		auth.Status = runtime.Status
+		if auth.Status == "" || auth.Status == StatusActive || auth.Status == StatusUnknown {
+			auth.Status = StatusError
+		}
+		auth.StatusMessage = runtime.StatusMessage
+		if auth.StatusMessage == "" {
+			auth.StatusMessage = "quota exhausted"
+		}
+	}
+	if len(runtime.ModelStates) == 0 {
+		return
+	}
+	if auth.ModelStates == nil {
+		auth.ModelStates = make(map[string]*ModelState, len(runtime.ModelStates))
+	}
+	for model, persisted := range runtime.ModelStates {
+		if !quotaNeedsConfirmedRecovery(persisted.Quota) {
+			continue
+		}
+		state := &ModelState{
+			Status:         persisted.Status,
+			StatusMessage:  persisted.StatusMessage,
+			Unavailable:    true,
+			NextRetryAfter: persisted.NextRetryAfter,
+			Quota:          persisted.Quota,
+		}
+		if state.Status == "" || state.Status == StatusActive || state.Status == StatusUnknown {
+			state.Status = StatusError
+		}
+		if state.StatusMessage == "" {
+			state.StatusMessage = "quota exhausted"
+		}
+		auth.ModelStates[model] = state
+	}
+	updateAggregatedAvailability(auth, time.Now())
+}

--- a/sdk/cliproxy/auth/quota_persistence_test.go
+++ b/sdk/cliproxy/auth/quota_persistence_test.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+type quotaRuntimeStore struct {
+	mu   sync.Mutex
+	auth *Auth
+}
+
+func (s *quotaRuntimeStore) List(context.Context) ([]*Auth, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.auth == nil {
+		return nil, nil
+	}
+	return []*Auth{s.auth.Clone()}, nil
+}
+
+func (s *quotaRuntimeStore) Save(_ context.Context, auth *Auth) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := json.Marshal(auth.Metadata)
+	if err != nil {
+		return "", err
+	}
+	metadata := make(map[string]any)
+	if err = json.Unmarshal(data, &metadata); err != nil {
+		return "", err
+	}
+	s.auth = &Auth{
+		ID:       auth.ID,
+		TenantID: auth.TenantID,
+		Provider: auth.Provider,
+		Status:   StatusActive,
+		Metadata: metadata,
+	}
+	return auth.ID, nil
+}
+
+func (s *quotaRuntimeStore) Delete(context.Context, string) error { return nil }
+
+func TestManagerLoadRestoresWindowExhaustedGate(t *testing.T) {
+	store := &quotaRuntimeStore{}
+	manager := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "xai-auth",
+		Provider: "xai",
+		Status:   StatusActive,
+		Metadata: map[string]any{"type": "xai"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "grok-4.5",
+		Error: &Error{
+			Message:            `{"error":"Grok Build usage balance exhausted"}`,
+			HTTPStatus:         http.StatusPaymentRequired,
+			QuotaWindow:        "week",
+			QuotaWindowMinutes: 10080,
+		},
+	})
+
+	reloaded := NewManager(store, nil, nil)
+	if err := reloaded.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	got, ok := reloaded.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatal("loaded auth missing")
+	}
+	if !got.Quota.Exceeded || !got.Quota.RecoveryRequired {
+		t.Fatalf("loaded quota = %#v, want confirmed-recovery gate", got.Quota)
+	}
+	blocked, _, _ := isAuthBlockedForModel(got, "grok-4.5", got.UpdatedAt)
+	if !blocked {
+		t.Fatal("loaded week-exhausted auth is selectable")
+	}
+}

--- a/sdk/cliproxy/auth/quota_reconcile.go
+++ b/sdk/cliproxy/auth/quota_reconcile.go
@@ -15,11 +15,14 @@ const (
 )
 
 // QuotaProbeResult describes the latest quota status for a credential.
-// When Models is empty, the result applies to every quota-blocked model state on the auth.
+// When Models is empty, the result applies auth-wide or to every quota-blocked model state.
 type QuotaProbeResult struct {
-	Recovered     bool
-	NextRecoverAt time.Time
-	Models        map[string]QuotaProbeModelResult
+	Recovered       bool
+	WindowExhausted bool
+	Window          string
+	WindowMinutes   int
+	NextRecoverAt   time.Time
+	Models          map[string]QuotaProbeModelResult
 }
 
 // QuotaProbeModelResult describes the latest quota status for a specific model.
@@ -37,6 +40,55 @@ type QuotaRecoveryProber interface {
 // ReconcileQuota forces an immediate quota reconciliation for the given auth entry.
 func (m *Manager) ReconcileQuota(ctx context.Context, id string) (bool, error) {
 	return m.probeQuotaRecovery(ctx, id, true)
+}
+
+// UpdateQuotaFromProbe applies an already-fetched upstream quota result without
+// issuing another provider request.
+func (m *Manager) UpdateQuotaFromProbe(ctx context.Context, id string, result *QuotaProbeResult) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	id = strings.TrimSpace(id)
+	if id == "" || result == nil {
+		return false, nil
+	}
+
+	now := time.Now()
+	var (
+		updated         *Auth
+		recoveredModels []string
+	)
+
+	m.mu.Lock()
+	current, ok := m.auths[id]
+	if !ok || current == nil {
+		delete(m.quotaProbeAfter, id)
+		m.mu.Unlock()
+		return false, nil
+	}
+	changed, models := applyQuotaProbeResult(current, result, now)
+	recoveredModels = models
+	if authHasActiveQuotaCooldown(current, now) {
+		m.quotaProbeAfter[id] = nextQuotaProbeTime(current, now)
+	} else {
+		delete(m.quotaProbeAfter, id)
+	}
+	if changed {
+		current.UpdatedAt = now
+		syncPersistedQuotaRuntime(current)
+		updated = current.Clone()
+		m.auths[id] = current
+	}
+	m.mu.Unlock()
+
+	if updated != nil {
+		if errPersist := m.persist(ctx, updated); errPersist != nil {
+			return true, errPersist
+		}
+		m.hook.OnAuthUpdated(ctx, updated.Clone())
+	}
+	m.resumeRecoveredQuotaModels(id, recoveredModels)
+	return updated != nil, nil
 }
 
 // ClearQuotaStatus manually clears local quota/cooldown runtime state for an auth entry.
@@ -68,6 +120,7 @@ func (m *Manager) ClearQuotaStatus(ctx context.Context, id string) (bool, error)
 	delete(m.quotaProbeAfter, id)
 	if changed {
 		current.UpdatedAt = now
+		syncPersistedQuotaRuntime(current)
 		updated = current.Clone()
 		m.auths[id] = current
 	}
@@ -180,42 +233,7 @@ func (m *Manager) probeQuotaRecovery(ctx context.Context, id string, force bool)
 		return false, nil
 	}
 
-	now = time.Now()
-	var (
-		updated         *Auth
-		recoveredModels []string
-	)
-
-	m.mu.Lock()
-	current, ok := m.auths[id]
-	if !ok || current == nil {
-		delete(m.quotaProbeAfter, id)
-		m.mu.Unlock()
-		return false, nil
-	}
-
-	changed, models := applyQuotaProbeResult(current, result, now)
-	recoveredModels = models
-	if authHasActiveQuotaCooldown(current, now) {
-		m.quotaProbeAfter[id] = nextQuotaProbeTime(current, now)
-	} else {
-		delete(m.quotaProbeAfter, id)
-	}
-	if changed {
-		current.UpdatedAt = now
-		updated = current.Clone()
-		m.auths[id] = current
-	}
-	m.mu.Unlock()
-
-	if updated != nil {
-		if errPersist := m.persist(ctx, updated); errPersist != nil {
-			return true, errPersist
-		}
-		m.hook.OnAuthUpdated(ctx, updated.Clone())
-	}
-	m.resumeRecoveredQuotaModels(id, recoveredModels)
-	return updated != nil, nil
+	return m.UpdateQuotaFromProbe(ctx, id, result)
 }
 
 func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) (bool, []string) {
@@ -227,8 +245,28 @@ func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) 
 	recoveredModels := make([]string, 0)
 	modelResults := normalizeQuotaProbeModels(result.Models)
 	authWide := QuotaProbeModelResult{Recovered: result.Recovered, NextRecoverAt: result.NextRecoverAt}
+	if result.WindowExhausted && !hasQuotaExceededModel(auth) {
+		changed := !auth.Unavailable || auth.Status != StatusError || auth.StatusMessage != "quota exhausted" ||
+			!auth.NextRetryAfter.Equal(result.NextRecoverAt) || !auth.Quota.Exceeded || !auth.Quota.RecoveryRequired ||
+			auth.Quota.Reason != "quota" || auth.Quota.Window != result.Window ||
+			auth.Quota.WindowMinutes != result.WindowMinutes || !auth.Quota.NextRecoverAt.Equal(result.NextRecoverAt)
+		auth.Unavailable = true
+		auth.Status = StatusError
+		auth.StatusMessage = "quota exhausted"
+		auth.NextRetryAfter = result.NextRecoverAt
+		auth.Quota = QuotaState{
+			Exceeded:         true,
+			RecoveryRequired: true,
+			Reason:           "quota",
+			Window:           result.Window,
+			WindowMinutes:    result.WindowMinutes,
+			NextRecoverAt:    result.NextRecoverAt,
+		}
+		auth.UpdatedAt = now
+		return changed, nil
+	}
 
-	if len(auth.ModelStates) > 0 {
+	if hasQuotaExceededModel(auth) {
 		beforeUnavailable := auth.Unavailable
 		beforeNextRetry := auth.NextRetryAfter
 		beforeQuota := auth.Quota
@@ -255,6 +293,15 @@ func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) 
 				}
 				recoveredModels = append(recoveredModels, modelID)
 				continue
+			}
+			if result.WindowExhausted {
+				if !state.Quota.RecoveryRequired || state.Quota.Window != result.Window || state.Quota.WindowMinutes != result.WindowMinutes {
+					state.Quota.RecoveryRequired = true
+					state.Quota.Window = result.Window
+					state.Quota.WindowMinutes = result.WindowMinutes
+					state.UpdatedAt = now
+					changed = true
+				}
 			}
 			if updateQuotaModelRecoverAt(state, outcome.NextRecoverAt, now) {
 				changed = true
@@ -289,6 +336,18 @@ func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) 
 		changed = true
 	}
 	return changed, nil
+}
+
+func hasQuotaExceededModel(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	for _, state := range auth.ModelStates {
+		if state != nil && state.Quota.Exceeded {
+			return true
+		}
+	}
+	return false
 }
 
 func clearQuotaStatusForAuth(auth *Auth, now time.Time) (bool, []string) {
@@ -340,14 +399,14 @@ func authHasActiveQuotaCooldown(auth *Auth, now time.Time) bool {
 	if auth == nil || auth.Disabled {
 		return false
 	}
-	if auth.Unavailable && auth.Quota.Exceeded && auth.NextRetryAfter.After(now) {
+	if activeAuthQuotaCooldown(auth, now) {
 		return true
 	}
 	for _, state := range auth.ModelStates {
 		if state == nil {
 			continue
 		}
-		if state.Unavailable && state.Quota.Exceeded && state.NextRetryAfter.After(now) {
+		if activeModelQuotaCooldown(state, now) {
 			return true
 		}
 	}
@@ -359,21 +418,26 @@ func nextQuotaProbeTime(auth *Auth, now time.Time) time.Time {
 	if auth == nil {
 		return now.Add(quotaProbeMinInterval)
 	}
-	if auth.Unavailable && auth.Quota.Exceeded && auth.NextRetryAfter.After(now) {
-		nextRecover = auth.NextRetryAfter
-		if !auth.Quota.NextRecoverAt.IsZero() && auth.Quota.NextRecoverAt.After(now) && auth.Quota.NextRecoverAt.Before(nextRecover) {
+	if activeAuthQuotaCooldown(auth, now) {
+		if auth.NextRetryAfter.After(now) {
+			nextRecover = auth.NextRetryAfter
+		}
+		if auth.Quota.NextRecoverAt.After(now) && (nextRecover.IsZero() || auth.Quota.NextRecoverAt.Before(nextRecover)) {
 			nextRecover = auth.Quota.NextRecoverAt
 		}
 	}
 	for _, state := range auth.ModelStates {
-		if state == nil || !state.Unavailable || !state.Quota.Exceeded || !state.NextRetryAfter.After(now) {
+		if state == nil || !activeModelQuotaCooldown(state, now) {
 			continue
 		}
-		candidate := state.NextRetryAfter
-		if !state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.After(now) && state.Quota.NextRecoverAt.Before(candidate) {
+		candidate := time.Time{}
+		if state.NextRetryAfter.After(now) {
+			candidate = state.NextRetryAfter
+		}
+		if state.Quota.NextRecoverAt.After(now) && (candidate.IsZero() || state.Quota.NextRecoverAt.Before(candidate)) {
 			candidate = state.Quota.NextRecoverAt
 		}
-		if nextRecover.IsZero() || candidate.Before(nextRecover) {
+		if !candidate.IsZero() && (nextRecover.IsZero() || candidate.Before(nextRecover)) {
 			nextRecover = candidate
 		}
 	}
@@ -432,8 +496,17 @@ func clearQuotaModelRuntimeState(state *ModelState, now time.Time) bool {
 }
 
 func updateQuotaModelRecoverAt(state *ModelState, next time.Time, now time.Time) bool {
-	if state == nil || next.IsZero() {
+	if state == nil {
 		return false
+	}
+	if next.IsZero() {
+		if !quotaNeedsConfirmedRecovery(state.Quota) {
+			return false
+		}
+		changed := !state.Unavailable
+		state.Unavailable = true
+		state.UpdatedAt = now
+		return changed
 	}
 	changed := !state.NextRetryAfter.Equal(next) || !state.Quota.NextRecoverAt.Equal(next) || !state.Unavailable || !state.Quota.Exceeded || state.Quota.Reason != "quota"
 	state.Unavailable = true
@@ -501,8 +574,17 @@ func hasQuotaRuntimeState(statusMessage string, lastError *Error, unavailable bo
 }
 
 func updateQuotaAuthRecoverAt(auth *Auth, next time.Time, now time.Time) bool {
-	if auth == nil || next.IsZero() {
+	if auth == nil {
 		return false
+	}
+	if next.IsZero() {
+		if !quotaNeedsConfirmedRecovery(auth.Quota) {
+			return false
+		}
+		changed := !auth.Unavailable
+		auth.Unavailable = true
+		auth.UpdatedAt = now
+		return changed
 	}
 	changed := !auth.NextRetryAfter.Equal(next) || !auth.Quota.NextRecoverAt.Equal(next) || !auth.Unavailable || !auth.Quota.Exceeded || auth.Quota.Reason != "quota"
 	auth.Unavailable = true

--- a/sdk/cliproxy/auth/quota_reconcile_test.go
+++ b/sdk/cliproxy/auth/quota_reconcile_test.go
@@ -61,9 +61,10 @@ func TestManagerReconcileQuota_ClearsRecoveredModelCooldown(t *testing.T) {
 		Status:      StatusError,
 		Unavailable: true,
 		Quota: QuotaState{
-			Exceeded:      true,
-			Reason:        "quota",
-			NextRecoverAt: next,
+			Exceeded:         true,
+			RecoveryRequired: true,
+			Reason:           "quota",
+			NextRecoverAt:    next,
 		},
 		ModelStates: map[string]*ModelState{
 			"gpt-5-codex": {
@@ -73,9 +74,10 @@ func TestManagerReconcileQuota_ClearsRecoveredModelCooldown(t *testing.T) {
 				NextRetryAfter: next,
 				LastError:      &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
 				Quota: QuotaState{
-					Exceeded:      true,
-					Reason:        "quota",
-					NextRecoverAt: next,
+					Exceeded:         true,
+					RecoveryRequired: true,
+					Reason:           "quota",
+					NextRecoverAt:    next,
 				},
 			},
 		},
@@ -117,6 +119,54 @@ func TestManagerReconcileQuota_ClearsRecoveredModelCooldown(t *testing.T) {
 	}
 	if updated.Status != StatusActive {
 		t.Fatalf("auth.Status = %q, want %q", updated.Status, StatusActive)
+	}
+}
+
+func TestApplyQuotaProbeResult_NotRecoveredWithoutResetKeepsWindowGate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := &Auth{
+		ID:          "xai-auth",
+		Provider:    "xai",
+		Status:      StatusError,
+		Unavailable: true,
+		Quota: QuotaState{
+			Exceeded:         true,
+			RecoveryRequired: true,
+			Reason:           "quota",
+			Window:           "week",
+			WindowMinutes:    10080,
+			NextRecoverAt:    now.Add(-time.Hour),
+		},
+		NextRetryAfter: now.Add(-time.Hour),
+		ModelStates: map[string]*ModelState{
+			"grok-4.5": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: now.Add(-time.Hour),
+				Quota: QuotaState{
+					Exceeded:         true,
+					RecoveryRequired: true,
+					Reason:           "quota",
+					Window:           "week",
+					WindowMinutes:    10080,
+					NextRecoverAt:    now.Add(-time.Hour),
+				},
+			},
+		},
+	}
+
+	applyQuotaProbeResult(auth, &QuotaProbeResult{Recovered: false}, now)
+	blocked, _, _ := isAuthBlockedForModel(auth, "grok-4.5", now)
+	if !blocked {
+		t.Fatal("not-recovered zero-reset probe released the credential")
+	}
+	if !authHasActiveQuotaCooldown(auth, now) {
+		t.Fatal("window gate no longer schedules recovery probes")
+	}
+	if next := nextQuotaProbeTime(auth, now); !next.After(now) || next.After(now.Add(2*quotaProbeMinInterval)) {
+		t.Fatalf("nextQuotaProbeTime() = %v, want prompt follow-up probe", next)
 	}
 }
 

--- a/sdk/cliproxy/auth/request_moderator.go
+++ b/sdk/cliproxy/auth/request_moderator.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+const contentPolicyViolationCode = "content_policy_violation"
+
+// RequestModerationResult is the narrow SDK contract returned by a host-provided
+// request moderator. Dependency failures must be handled fail-open by the host.
+type RequestModerationResult struct {
+	Blocked    bool
+	Message    string
+	HTTPStatus int
+}
+
+// RequestModerator evaluates the original inbound request after an auth
+// candidate is selected and before any provider executor is called.
+type RequestModerator interface {
+	Moderate(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options) RequestModerationResult
+}
+
+func (m *Manager) SetRequestModerator(moderator RequestModerator) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.requestModerator = moderator
+	m.mu.Unlock()
+}
+
+func (m *Manager) moderateRequest(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	moderator := m.requestModerator
+	m.mu.RUnlock()
+	if moderator == nil {
+		return nil
+	}
+	result := moderator.Moderate(ctx, auth, opts)
+	if !result.Blocked {
+		return nil
+	}
+	status := result.HTTPStatus
+	if status < 400 || status > 599 {
+		status = http.StatusForbidden
+	}
+	message := strings.TrimSpace(result.Message)
+	if message == "" {
+		message = "Your request was blocked by the content moderation policy."
+	}
+	return &Error{Code: contentPolicyViolationCode, Message: message, HTTPStatus: status}
+}
+
+func isContentPolicyViolation(err error) bool {
+	var authErr *Error
+	return errors.As(err, &authErr) && authErr != nil && authErr.Code == contentPolicyViolationCode
+}

--- a/sdk/cliproxy/auth/request_moderator_test.go
+++ b/sdk/cliproxy/auth/request_moderator_test.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"sync"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+type requestModeratorFunc func(context.Context, *Auth, cliproxyexecutor.Options) RequestModerationResult
+
+func (f requestModeratorFunc) Moderate(ctx context.Context, auth *Auth, opts cliproxyexecutor.Options) RequestModerationResult {
+	return f(ctx, auth, opts)
+}
+
+type moderationCountingExecutor struct {
+	mu          sync.Mutex
+	execute     int
+	stream      int
+	countTokens int
+	failAuthID  string
+}
+
+func (e *moderationCountingExecutor) Identifier() string { return "moderation-test" }
+
+func (e *moderationCountingExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.execute++
+	if auth != nil && auth.ID == e.failAuthID {
+		return cliproxyexecutor.Response{}, errors.New("upstream unavailable")
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *moderationCountingExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.stream++
+	e.mu.Unlock()
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *moderationCountingExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.countTokens++
+	e.mu.Unlock()
+	return cliproxyexecutor.Response{Payload: []byte("count")}, nil
+}
+
+func (e *moderationCountingExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *moderationCountingExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+type orderedAuthSelector struct{}
+
+func (orderedAuthSelector) Pick(_ context.Context, _ string, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if len(auths) == 0 {
+		return nil, errors.New("no auth")
+	}
+	sort.Slice(auths, func(i, j int) bool { return auths[i].ID < auths[j].ID })
+	return auths[0], nil
+}
+
+func newModerationTestManager(t *testing.T, executor *moderationCountingExecutor, auths ...*Auth) *Manager {
+	t.Helper()
+	manager := NewManager(nil, orderedAuthSelector{}, nil)
+	manager.RegisterExecutor(executor)
+	for _, auth := range auths {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register(%s): %v", auth.ID, err)
+		}
+	}
+	return manager
+}
+
+func TestRequestModeratorBlocksBeforeEveryExecutorPath(t *testing.T) {
+	paths := []struct {
+		name string
+		run  func(*Manager) error
+	}{
+		{name: "execute", run: func(manager *Manager) error {
+			_, err := manager.Execute(context.Background(), []string{"moderation-test"}, cliproxyexecutor.Request{Model: "model"}, cliproxyexecutor.Options{})
+			return err
+		}},
+		{name: "stream", run: func(manager *Manager) error {
+			_, err := manager.ExecuteStream(context.Background(), []string{"moderation-test"}, cliproxyexecutor.Request{Model: "model"}, cliproxyexecutor.Options{})
+			return err
+		}},
+		{name: "count", run: func(manager *Manager) error {
+			_, err := manager.ExecuteCount(context.Background(), []string{"moderation-test"}, cliproxyexecutor.Request{Model: "model"}, cliproxyexecutor.Options{})
+			return err
+		}},
+	}
+	for _, tt := range paths {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &moderationCountingExecutor{}
+			manager := newModerationTestManager(t, executor, &Auth{ID: "auth-a", Provider: executor.Identifier(), Status: StatusActive})
+			manager.SetRequestModerator(requestModeratorFunc(func(context.Context, *Auth, cliproxyexecutor.Options) RequestModerationResult {
+				return RequestModerationResult{Blocked: true, Message: "blocked", HTTPStatus: http.StatusUnavailableForLegalReasons}
+			}))
+
+			err := tt.run(manager)
+			var authErr *Error
+			if !errors.As(err, &authErr) || authErr.Code != contentPolicyViolationCode || authErr.HTTPStatus != http.StatusUnavailableForLegalReasons {
+				t.Fatalf("error = %#v, want content policy violation", err)
+			}
+			executor.mu.Lock()
+			defer executor.mu.Unlock()
+			if executor.execute != 0 || executor.stream != 0 || executor.countTokens != 0 {
+				t.Fatalf("executor calls execute=%d stream=%d count=%d, want zero", executor.execute, executor.stream, executor.countTokens)
+			}
+		})
+	}
+}
+
+func TestRequestModeratorRunsAgainForFallbackCandidate(t *testing.T) {
+	executor := &moderationCountingExecutor{failAuthID: "auth-a"}
+	manager := newModerationTestManager(t, executor,
+		&Auth{ID: "auth-a", Provider: executor.Identifier(), Status: StatusActive},
+		&Auth{ID: "auth-b", Provider: executor.Identifier(), Status: StatusActive},
+	)
+	var mu sync.Mutex
+	var moderated []string
+	manager.SetRequestModerator(requestModeratorFunc(func(_ context.Context, auth *Auth, _ cliproxyexecutor.Options) RequestModerationResult {
+		mu.Lock()
+		moderated = append(moderated, auth.ID)
+		mu.Unlock()
+		return RequestModerationResult{}
+	}))
+
+	if _, err := manager.Execute(context.Background(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: "model"}, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(moderated) != 2 || moderated[0] != "auth-a" || moderated[1] != "auth-b" {
+		t.Fatalf("moderated candidates = %#v, want auth-a then auth-b", moderated)
+	}
+}

--- a/sdk/cliproxy/auth/selector_availability.go
+++ b/sdk/cliproxy/auth/selector_availability.go
@@ -306,12 +306,12 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	// requests by switching models during the same quota window.
 	if auth.Quota.Exceeded {
 		next := auth.Quota.NextRecoverAt
-		if !next.IsZero() && next.After(now) {
+		if quotaNeedsConfirmedRecovery(auth.Quota) || (!next.IsZero() && next.After(now)) {
 			if auth.NextRetryAfter.After(now) && (next.IsZero() || auth.NextRetryAfter.Before(next)) {
 				next = auth.NextRetryAfter
 			}
-			if next.Before(now) {
-				next = now
+			if !next.After(now) {
+				next = time.Time{}
 			}
 			return true, blockReasonCooldown, next
 		}
@@ -329,6 +329,16 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 			if ok && state != nil {
 				if state.Status == StatusDisabled {
 					return true, blockReasonDisabled, time.Time{}
+				}
+				if quotaNeedsConfirmedRecovery(state.Quota) {
+					next := state.Quota.NextRecoverAt
+					if state.NextRetryAfter.After(now) && (next.IsZero() || state.NextRetryAfter.Before(next)) {
+						next = state.NextRetryAfter
+					}
+					if !next.After(now) {
+						next = time.Time{}
+					}
+					return true, blockReasonCooldown, next
 				}
 				if state.Unavailable {
 					if state.NextRetryAfter.IsZero() {

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -705,6 +705,35 @@ func TestIsAuthBlockedForModel_AuthQuotaCooldownBlocksAllModels(t *testing.T) {
 	}
 }
 
+func TestIsAuthBlockedForModel_WindowExhaustedRemainsBlockedAfterRecoverAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := &Auth{
+		ID: "xai-week-exhausted",
+		Quota: QuotaState{
+			Exceeded:         true,
+			RecoveryRequired: true,
+			Reason:           "quota",
+			Window:           "week",
+			WindowMinutes:    10080,
+			NextRecoverAt:    now.Add(-time.Hour),
+		},
+		NextRetryAfter: now.Add(-time.Hour),
+	}
+
+	blocked, reason, next := isAuthBlockedForModel(auth, "grok-4.5", now)
+	if !blocked {
+		t.Fatal("blocked = false, want true until recovery is confirmed")
+	}
+	if reason != blockReasonCooldown {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonCooldown)
+	}
+	if !next.IsZero() {
+		t.Fatalf("next = %v, want zero for an expired unconfirmed reset", next)
+	}
+}
+
 func TestFillFirstSelectorPick_ThinkingSuffixFallsBackToBaseModelState(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -101,6 +101,9 @@ type Auth struct {
 type QuotaState struct {
 	// Exceeded indicates the credential recently hit a quota error.
 	Exceeded bool `json:"exceeded"`
+	// RecoveryRequired keeps a confirmed quota window exhausted until an
+	// upstream probe or successful request confirms recovery.
+	RecoveryRequired bool `json:"recovery_required,omitempty"`
 	// Reason provides an optional provider specific human readable description.
 	Reason string `json:"reason,omitempty"`
 	// Window identifies the provider quota window that was exhausted, such as

--- a/sdk/cliproxy/auth/xai_402_quota_test.go
+++ b/sdk/cliproxy/auth/xai_402_quota_test.go
@@ -35,6 +35,7 @@ func (e *retryAfterQuotaErrorStub) RetryAfter() *time.Duration {
 type xaiQuotaExecutor struct {
 	err     error
 	execute func(*Auth) (cliproxyexecutor.Response, error)
+	probe   func(context.Context, *Auth) (*QuotaProbeResult, error)
 }
 
 func (e *xaiQuotaExecutor) Identifier() string { return "xai" }
@@ -54,7 +55,10 @@ func (e *xaiQuotaExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.
 func (e *xaiQuotaExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
 	return nil, e.err
 }
-func (e *xaiQuotaExecutor) ProbeQuotaRecovery(context.Context, *Auth) (*QuotaProbeResult, error) {
+func (e *xaiQuotaExecutor) ProbeQuotaRecovery(ctx context.Context, auth *Auth) (*QuotaProbeResult, error) {
+	if e.probe != nil {
+		return e.probe(ctx, auth)
+	}
 	return &QuotaProbeResult{Recovered: false}, nil
 }
 
@@ -103,7 +107,7 @@ func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testi
 	if state == nil {
 		t.Fatal("model state missing")
 	}
-	if !state.Quota.Exceeded || state.Quota.Reason != "quota" {
+	if !state.Quota.Exceeded || !state.Quota.RecoveryRequired || state.Quota.Reason != "quota" {
 		t.Fatalf("quota = %#v, want exceeded quota", state.Quota)
 	}
 	if state.Quota.Window != "week" || state.Quota.WindowMinutes != 10080 {
@@ -119,7 +123,7 @@ func TestManagerMarkResult_XAI402BalanceExhaustedUsesExplicitRetryAfter(t *testi
 	}
 }
 
-func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesDefaultCooldown(t *testing.T) {
+func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesRecoveryGate(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -165,16 +169,18 @@ func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesDefaultCooldown
 	if !state.Quota.Exceeded || state.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", state.Quota)
 	}
-	minExpected := before.Add(xaiWeekExhaustedDefaultCooldown - time.Minute)
-	maxExpected := before.Add(xaiWeekExhaustedDefaultCooldown + time.Minute)
-	if state.NextRetryAfter.Before(minExpected) || state.NextRetryAfter.After(maxExpected) {
-		t.Fatalf("NextRetryAfter = %v, want ~%v", state.NextRetryAfter, before.Add(xaiWeekExhaustedDefaultCooldown))
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %v, want zero without upstream reset", state.NextRetryAfter)
 	}
-	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
-		t.Fatalf("NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
+	if !state.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("NextRecoverAt = %v, want zero without upstream reset", state.Quota.NextRecoverAt)
 	}
-	if !got.Quota.Exceeded || got.Quota.NextRecoverAt.IsZero() {
-		t.Fatalf("aggregated auth quota = %#v, want exceeded with recovery time", got.Quota)
+	if !got.Quota.Exceeded || !got.Quota.RecoveryRequired {
+		t.Fatalf("aggregated auth quota = %#v, want confirmed-recovery gate", got.Quota)
+	}
+	blocked, _, _ := isAuthBlockedForModel(got, model, before.Add(7*time.Hour))
+	if !blocked {
+		t.Fatal("week-exhausted auth became selectable after the old 6h cooldown")
 	}
 }
 
@@ -229,15 +235,15 @@ func TestManagerExecute_XAIWeekExhaustedSkipsAuthForHealthyPeer(t *testing.T) {
 		t.Fatal("exhausted auth missing")
 	}
 	now := time.Now()
-	if !exhausted.Quota.Exceeded || !exhausted.Quota.NextRecoverAt.After(now.Add(time.Hour)) {
-		t.Fatalf("exhausted quota = %#v, want active long cooldown", exhausted.Quota)
+	if !exhausted.Quota.Exceeded || !exhausted.Quota.RecoveryRequired {
+		t.Fatalf("exhausted quota = %#v, want confirmed-recovery gate", exhausted.Quota)
 	}
-	if !manager.shouldProbeQuota(exhausted, now) {
-		t.Fatal("shouldProbeQuota() = false, want xAI cooldown eligible for recovery probe")
+	if !authHasActiveQuotaCooldown(exhausted, now) {
+		t.Fatal("authHasActiveQuotaCooldown() = false, want xAI gate eligible for recovery probes")
 	}
 	nextProbe := nextQuotaProbeTime(exhausted, now)
-	if !nextProbe.After(now) || !nextProbe.Before(exhausted.Quota.NextRecoverAt) {
-		t.Fatalf("nextQuotaProbeTime() = %v, want before cooldown recovery %v", nextProbe, exhausted.Quota.NextRecoverAt)
+	if !nextProbe.After(now) || nextProbe.After(now.Add(2*quotaProbeMinInterval)) {
+		t.Fatalf("nextQuotaProbeTime() = %v, want prompt follow-up probe", nextProbe)
 	}
 }
 
@@ -314,7 +320,7 @@ func TestApplyAuthFailureState_XAI402BalanceExhausted(t *testing.T) {
 	}
 }
 
-func TestApplyAuthFailureState_XAI402WithoutRetryUsesDefaultCooldown(t *testing.T) {
+func TestApplyAuthFailureState_XAI402WithoutRetryUsesRecoveryGate(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(1_700_000_000, 0)
@@ -326,13 +332,125 @@ func TestApplyAuthFailureState_XAI402WithoutRetryUsesDefaultCooldown(t *testing.
 		QuotaWindowMinutes: 10080,
 	}, nil, now)
 
-	if !auth.Quota.Exceeded || auth.Quota.Window != "week" {
+	if !auth.Quota.Exceeded || !auth.Quota.RecoveryRequired || auth.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", auth.Quota)
 	}
-	if !auth.NextRetryAfter.Equal(now.Add(xaiWeekExhaustedDefaultCooldown)) {
-		t.Fatalf("NextRetryAfter = %v, want %v", auth.NextRetryAfter, now.Add(xaiWeekExhaustedDefaultCooldown))
+	if !auth.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %v, want zero without upstream reset", auth.NextRetryAfter)
 	}
-	if !auth.Quota.NextRecoverAt.Equal(auth.NextRetryAfter) {
-		t.Fatalf("NextRecoverAt = %v, want %v", auth.Quota.NextRecoverAt, auth.NextRetryAfter)
+	if !auth.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("NextRecoverAt = %v, want zero without upstream reset", auth.Quota.NextRecoverAt)
+	}
+}
+
+func TestManagerMarkResult_XAIWeekExhaustedProbesImmediately(t *testing.T) {
+	t.Parallel()
+
+	probed := make(chan struct{}, 1)
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		err: &retryAfterQuotaErrorStub{
+			message:      `{"error":"Grok Build usage balance exhausted"}`,
+			status:       http.StatusPaymentRequired,
+			quotaWindow:  "week",
+			quotaMinutes: 10080,
+		},
+		probe: func(context.Context, *Auth) (*QuotaProbeResult, error) {
+			probed <- struct{}{}
+			return &QuotaProbeResult{Recovered: false}, nil
+		},
+	})
+	if _, err := manager.Register(context.Background(), &Auth{ID: "xai-probe", Provider: "xai", Status: StatusActive}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, _ = manager.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: "grok-4.5"}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.SinglePickMetadataKey: true},
+	})
+
+	select {
+	case <-probed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("billing recovery probe was not started after week-exhausted 402")
+	}
+}
+
+func TestManagerMarkResult_XAIWeekExhaustedProbePinsBillingReset(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Now().Add(3 * time.Hour).Round(time.Second)
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.RegisterExecutor(&xaiQuotaExecutor{
+		err: &retryAfterQuotaErrorStub{
+			message:      `{"error":"Grok Build usage balance exhausted"}`,
+			status:       http.StatusPaymentRequired,
+			quotaWindow:  "week",
+			quotaMinutes: 10080,
+		},
+		probe: func(context.Context, *Auth) (*QuotaProbeResult, error) {
+			return &QuotaProbeResult{
+				Recovered:       false,
+				WindowExhausted: true,
+				Window:          "week",
+				WindowMinutes:   10080,
+				NextRecoverAt:   resetAt,
+			}, nil
+		},
+	})
+	auth := &Auth{ID: "xai-reset", Provider: "xai", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, _ = manager.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: "grok-4.5"}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.SinglePickMetadataKey: true},
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, _ := manager.GetByID(auth.ID)
+		if got != nil {
+			if state := got.ModelStates["grok-4.5"]; state != nil && state.Quota.NextRecoverAt.Equal(resetAt) {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	got, _ := manager.GetByID(auth.ID)
+	t.Fatalf("billing reset was not applied: %#v", got)
+}
+
+func TestManagerMarkResult_SuccessClearsWindowExhaustedGate(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "xai-success", Provider: "xai", Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "grok-4.5",
+		Error: &Error{
+			Message:            `{"error":"Grok Build usage balance exhausted"}`,
+			HTTPStatus:         http.StatusPaymentRequired,
+			QuotaWindow:        "week",
+			QuotaWindowMinutes: 10080,
+		},
+	})
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "grok-4.5",
+		Success:  true,
+	})
+
+	got, _ := manager.GetByID(auth.ID)
+	if got.Quota.Exceeded || got.Quota.RecoveryRequired {
+		t.Fatalf("quota = %#v, want success-confirmed recovery", got.Quota)
+	}
+	if state := got.ModelStates["grok-4.5"]; state == nil || state.Quota.Exceeded || state.Unavailable {
+		t.Fatalf("model state = %#v, want recovered", state)
 	}
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -121,6 +121,8 @@ type Builder struct {
 	// coreAuthHook observes credential lifecycle without entering request hot paths.
 	coreAuthHook coreauth.Hook
 
+	requestModerator coreauth.RequestModerator
+
 	// serverOptions contains additional server configuration options.
 	serverOptions []api.ServerOption
 }
@@ -201,6 +203,13 @@ func (b *Builder) WithCoreAuthManager(mgr *coreauth.Manager) *Builder {
 // WithCoreAuthHook configures lifecycle callbacks for bindings and related read models.
 func (b *Builder) WithCoreAuthHook(hook coreauth.Hook) *Builder {
 	b.coreAuthHook = hook
+	return b
+}
+
+// WithRequestModerator injects request-time content moderation without coupling
+// the SDK to the host's persistence implementation.
+func (b *Builder) WithRequestModerator(moderator coreauth.RequestModerator) *Builder {
+	b.requestModerator = moderator
 	return b
 }
 
@@ -293,6 +302,7 @@ func (b *Builder) Build() (*Service, error) {
 	if b.coreAuthHook != nil {
 		coreManager.SetHook(b.coreAuthHook)
 	}
+	coreManager.SetRequestModerator(b.requestModerator)
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
 	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
 	coreManager.SetConfig(b.cfg)


### PR DESCRIPTION
## Summary

Promote verified `dev` to `main` for product release **v0.4.16**.

### Highlights
- Content moderation multi-profile + channel bindings + observability
- Pricing inherit for prefixed / library / OpenRouter models
- Request-log channel dedupe + stats filter alignment
- Week-exhausted credential gate; Codex store=false item-id strip
- AI account cycle token tracking; management user filter expands to owned API keys

## Test plan
- [x] Fast-forward `origin/main` ← `origin/dev` (no conflicts)
- [ ] Required PR checks green (`build`, `ensure-no-translator-changes`)
- [ ] Merge → tag `v0.4.16` → GHCR + goreleaser
- [ ] Sync `main` back to `dev`