### PR TITLE
fix(security): 审核绕过 + 凭证永久拉黑 + 面板防嵌套 + Actions SHA 固定

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout backend
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Reject vendored panel assets
         run: ./scripts/ensure-no-vendored-panel-assets.sh
@@ -62,13 +62,13 @@ jobs:
           echo "frontend_commit=${FRONTEND_COMMIT}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -76,7 +76,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -93,7 +93,7 @@ jobs:
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pr-path-guard.yml
+++ b/.github/workflows/pr-path-guard.yml
@@ -11,12 +11,12 @@ jobs:
   ensure-no-translator-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Detect internal/translator changes
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45.0.2
         with:
           files: |
             internal/translator/**

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -35,9 +35,9 @@ jobs:
       CLIRELAY_POSTGRES_TEST_DSN: postgres://cliproxy:cliproxy@localhost:5432/cliproxy?sslmode=disable
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -45,7 +45,7 @@ jobs:
       # Cache the fixed-version binary compiled by the configured toolchain instead.
       - name: Cache golangci-lint
         id: cache-golangci-lint
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/clirelay/golangci-lint/${{ env.GO_VERSION }}-${{ env.GOLANGCI_LINT_VERSION }}/golangci-lint
           key: golangci-lint-${{ runner.os }}-${{ runner.arch }}-${{ env.GO_VERSION }}-${{ env.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,13 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Reject vendored panel assets
         run: ./scripts/ensure-no-vendored-panel-assets.sh
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: '>=1.26.1'
           cache: true
@@ -28,7 +28,7 @@ jobs:
           echo VERSION=`git describe --tags --always --dirty` >> $GITHUB_ENV
           echo COMMIT=`git rev-parse --short HEAD` >> $GITHUB_ENV
           echo BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` >> $GITHUB_ENV
-      - uses: goreleaser/goreleaser-action@v4
+      - uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           distribution: goreleaser
           version: latest

--- a/internal/api/server_management_ui.go
+++ b/internal/api/server_management_ui.go
@@ -44,6 +44,16 @@ func (s *Server) managementAvailabilityMiddleware() gin.HandlerFunc {
 	}
 }
 
+// setPanelSecurityHeaders hardens management panel HTML responses.
+// frame-ancestors 'self' blocks cross-site clickjacking while still allowing
+// same-origin embed menus configured inside the panel itself.
+func setPanelSecurityHeaders(c *gin.Context) {
+	c.Header("X-Frame-Options", "SAMEORIGIN")
+	c.Header("Content-Security-Policy", "frame-ancestors 'self'")
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Header("Referrer-Policy", "no-referrer")
+}
+
 func (s *Server) serveManagementControlPanel(c *gin.Context) {
 	cfg := s.cfg
 	if cfg == nil || cfg.RemoteManagement.DisableControlPanel {
@@ -76,6 +86,7 @@ func (s *Server) serveManagementControlPanel(c *gin.Context) {
 				return
 			}
 		}
+		setPanelSecurityHeaders(c)
 		c.File(filePath)
 		return
 	}
@@ -100,6 +111,7 @@ func (s *Server) serveManagementControlPanel(c *gin.Context) {
 			return
 		}
 	}
+	setPanelSecurityHeaders(c)
 	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
 	c.File(htmlFile)
 }

--- a/internal/api/server_management_ui_test.go
+++ b/internal/api/server_management_ui_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSetPanelSecurityHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.GET("/manage", func(c *gin.Context) {
+		setPanelSecurityHeaders(c)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/manage", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Frame-Options"); got != "SAMEORIGIN" {
+		t.Fatalf("X-Frame-Options = %q, want SAMEORIGIN", got)
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got != "frame-ancestors 'self'" {
+		t.Fatalf("Content-Security-Policy = %q, want frame-ancestors 'self'", got)
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := rec.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("Referrer-Policy = %q, want no-referrer", got)
+	}
+}

--- a/internal/contentmoderation/extractor.go
+++ b/internal/contentmoderation/extractor.go
@@ -7,7 +7,24 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func ExtractLastUserText(format sdktranslator.Format, payload []byte) string {
+// moderatableRoles are the request roles whose text the caller fully controls.
+// Assistant/model turns are excluded: they are upstream output being replayed,
+// and blocking them would break legitimate multi-turn conversations.
+var moderatableRoles = map[string]bool{
+	"user":      true,
+	"system":    true,
+	"developer": true,
+	"human":     true,
+}
+
+// ExtractModeratableText returns every caller-controlled text fragment in the
+// request, joined into a single string for moderation.
+//
+// It must cover the whole request, not just the newest turn: a client controls
+// the entire payload, so moderating only the last message lets an attacker put
+// banned text in an earlier turn (or in a system prompt) and append an empty or
+// image-only final message to slip past pre_block.
+func ExtractModeratableText(format sdktranslator.Format, payload []byte) string {
 	if len(payload) == 0 || !gjson.ValidBytes(payload) {
 		return ""
 	}
@@ -15,34 +32,34 @@ func ExtractLastUserText(format sdktranslator.Format, payload []byte) string {
 	switch format {
 	case sdktranslator.FormatOpenAIResponse:
 		collectResponsesInput(gjson.GetBytes(payload, "input"), &parts)
+		collectTextValue(gjson.GetBytes(payload, "instructions"), &parts, false)
 	case sdktranslator.FormatClaude:
-		collectLastRoleContent(gjson.GetBytes(payload, "messages"), "user", &parts, true)
+		// Claude carries the system prompt outside messages; it is caller-controlled too.
+		collectTextValue(gjson.GetBytes(payload, "system"), &parts, true)
+		collectRoleContent(gjson.GetBytes(payload, "messages"), &parts, true)
 	case sdktranslator.FormatGemini, sdktranslator.FormatGeminiCLI:
-		collectLastGeminiContent(gjson.GetBytes(payload, "contents"), &parts)
+		collectGeminiContent(gjson.GetBytes(payload, "systemInstruction"), &parts)
+		collectGeminiContents(gjson.GetBytes(payload, "contents"), &parts)
 	default:
-		collectLastRoleContent(gjson.GetBytes(payload, "messages"), "user", &parts, false)
-		if len(parts) == 0 {
-			prompt := gjson.GetBytes(payload, "prompt")
-			if prompt.Type == gjson.String {
-				addText(&parts, prompt.String(), false)
-			}
+		collectRoleContent(gjson.GetBytes(payload, "messages"), &parts, false)
+		// Image generation endpoints carry the prompt at the top level.
+		if prompt := gjson.GetBytes(payload, "prompt"); prompt.Type == gjson.String {
+			addText(&parts, prompt.String(), false)
 		}
 	}
 	return strings.Join(strings.Fields(strings.Join(parts, "\n")), " ")
 }
 
-func collectLastRoleContent(messages gjson.Result, role string, parts *[]string, skipSystemReminder bool) {
+func collectRoleContent(messages gjson.Result, parts *[]string, skipSystemReminder bool) {
 	if !messages.IsArray() {
 		return
 	}
-	items := messages.Array()
-	for i := len(items) - 1; i >= 0; i-- {
-		item := items[i]
-		if !strings.EqualFold(strings.TrimSpace(item.Get("role").String()), role) {
+	for _, item := range messages.Array() {
+		role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+		if !moderatableRoles[role] {
 			continue
 		}
 		collectTextValue(item.Get("content"), parts, skipSystemReminder)
-		return
 	}
 }
 
@@ -53,47 +70,49 @@ func collectResponsesInput(input gjson.Result, parts *[]string) {
 	case input.Type == gjson.String:
 		addText(parts, input.String(), false)
 	case input.IsArray():
-		items := input.Array()
-		for i := len(items) - 1; i >= 0; i-- {
-			item := items[i]
-			role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
-			typeName := strings.ToLower(strings.TrimSpace(item.Get("type").String()))
-			if role != "user" && typeName != "input_text" {
-				continue
-			}
-			collectTextValue(item.Get("content"), parts, false)
-			if typeName == "input_text" || item.Get("text").Exists() {
-				collectTextValue(item, parts, false)
-			}
-			return
+		for _, item := range input.Array() {
+			collectResponsesInputItem(item, parts)
 		}
 	case input.IsObject():
-		role := strings.ToLower(strings.TrimSpace(input.Get("role").String()))
-		typeName := strings.ToLower(strings.TrimSpace(input.Get("type").String()))
-		if role == "user" || typeName == "input_text" {
-			collectTextValue(input.Get("content"), parts, false)
-			collectTextValue(input, parts, false)
-		}
+		collectResponsesInputItem(input, parts)
 	}
 }
 
-func collectLastGeminiContent(contents gjson.Result, parts *[]string) {
+func collectResponsesInputItem(item gjson.Result, parts *[]string) {
+	role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+	typeName := strings.ToLower(strings.TrimSpace(item.Get("type").String()))
+	// Items without a role but typed input_text are caller input as well.
+	if !moderatableRoles[role] && typeName != "input_text" {
+		return
+	}
+	collectTextValue(item.Get("content"), parts, false)
+	if typeName == "input_text" || item.Get("text").Exists() {
+		collectTextValue(item, parts, false)
+	}
+}
+
+func collectGeminiContents(contents gjson.Result, parts *[]string) {
 	if !contents.IsArray() {
 		return
 	}
-	items := contents.Array()
-	for i := len(items) - 1; i >= 0; i-- {
-		item := items[i]
-		role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
-		if role != "" && role != "user" {
-			continue
-		}
-		if values := item.Get("parts"); values.IsArray() {
-			for _, part := range values.Array() {
-				addText(parts, part.Get("text").String(), false)
-			}
-		}
+	for _, item := range contents.Array() {
+		collectGeminiContent(item, parts)
+	}
+}
+
+func collectGeminiContent(content gjson.Result, parts *[]string) {
+	if !content.Exists() {
 		return
+	}
+	role := strings.ToLower(strings.TrimSpace(content.Get("role").String()))
+	// Gemini omits the role on single-turn and systemInstruction payloads.
+	if role != "" && !moderatableRoles[role] {
+		return
+	}
+	if values := content.Get("parts"); values.IsArray() {
+		for _, part := range values.Array() {
+			addText(parts, part.Get("text").String(), false)
+		}
 	}
 }
 
@@ -118,6 +137,7 @@ func collectTextValue(value gjson.Result, parts *[]string, skipSystemReminder bo
 
 func addText(parts *[]string, value string, skipSystemReminder bool) {
 	value = strings.TrimSpace(value)
+	// <system-reminder> blocks are client-injected boilerplate, not caller prose.
 	if value == "" || (skipSystemReminder && strings.HasPrefix(value, "<system-reminder>")) {
 		return
 	}

--- a/internal/contentmoderation/extractor_test.go
+++ b/internal/contentmoderation/extractor_test.go
@@ -6,7 +6,7 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 )
 
-func TestExtractLastUserText(t *testing.T) {
+func TestExtractModeratableText(t *testing.T) {
 	tests := []struct {
 		name   string
 		format sdktranslator.Format
@@ -18,16 +18,81 @@ func TestExtractLastUserText(t *testing.T) {
 		{"responses", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"assistant","content":[{"type":"output_text","text":"old"}]},{"role":"user","content":[{"type":"input_text","text":"response text"}]}]}`, "response text"},
 		{"claude", sdktranslator.FormatClaude, `{"messages":[{"role":"user","content":[{"type":"text","text":"claude text"}]}]}`, "claude text"},
 		{"gemini", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini text"}]}]}`, "gemini text"},
-		{"last user before assistant", sdktranslator.FormatOpenAI, `{"messages":[{"role":"user","content":"last user"},{"role":"assistant","content":"generated"}]}`, "last user"},
-		{"responses last user before output", sdktranslator.FormatOpenAIResponse, `{"input":[{"role":"user","content":[{"type":"input_text","text":"response user"}]},{"role":"assistant","content":[{"type":"output_text","text":"generated"}]}]}`, "response user"},
-		{"gemini last user before model", sdktranslator.FormatGemini, `{"contents":[{"role":"user","parts":[{"text":"gemini user"}]},{"role":"model","parts":[{"text":"generated"}]}]}`, "gemini user"},
 		{"openai empty body", sdktranslator.FormatOpenAI, `{}`, ""},
 		{"openai no prompt", sdktranslator.FormatOpenAI, `{"model":"gpt-image-2"}`, ""},
+
+		// Every caller-controlled turn must be moderated, not only the newest one.
+		{
+			"openai all user turns",
+			sdktranslator.FormatOpenAI,
+			`{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"generated"},{"role":"user","content":"second"}]}`,
+			"first second",
+		},
+		{
+			"openai trailing empty user does not hide earlier turn",
+			sdktranslator.FormatOpenAI,
+			`{"messages":[{"role":"user","content":"banned"},{"role":"user","content":""}]}`,
+			"banned",
+		},
+		{
+			"openai trailing image-only user does not hide earlier turn",
+			sdktranslator.FormatOpenAI,
+			`{"messages":[{"role":"user","content":"banned"},{"role":"user","content":[{"type":"image_url","image_url":{"url":"http://example.invalid/a.png"}}]}]}`,
+			"banned",
+		},
+		{
+			"openai system role is moderated",
+			sdktranslator.FormatOpenAI,
+			`{"messages":[{"role":"system","content":"banned"},{"role":"user","content":"hi"}]}`,
+			"banned hi",
+		},
+		{
+			"claude system field is moderated",
+			sdktranslator.FormatClaude,
+			`{"system":"banned","messages":[{"role":"user","content":"hi"}]}`,
+			"banned hi",
+		},
+		{
+			"claude system reminder is skipped",
+			sdktranslator.FormatClaude,
+			`{"messages":[{"role":"user","content":"real"},{"role":"user","content":"<system-reminder>noise</system-reminder>"}]}`,
+			"real",
+		},
+		{
+			"responses all user turns",
+			sdktranslator.FormatOpenAIResponse,
+			`{"input":[{"role":"user","content":[{"type":"input_text","text":"banned"}]},{"role":"assistant","content":[{"type":"output_text","text":"generated"}]},{"role":"user","content":[{"type":"input_text","text":""}]}]}`,
+			"banned",
+		},
+		{
+			"responses instructions are moderated",
+			sdktranslator.FormatOpenAIResponse,
+			`{"instructions":"banned","input":"hi"}`,
+			"hi banned",
+		},
+		{
+			"gemini all user turns",
+			sdktranslator.FormatGemini,
+			`{"contents":[{"role":"user","parts":[{"text":"banned"}]},{"role":"model","parts":[{"text":"generated"}]},{"role":"user","parts":[{"text":""}]}]}`,
+			"banned",
+		},
+		{
+			"gemini system instruction is moderated",
+			sdktranslator.FormatGemini,
+			`{"systemInstruction":{"parts":[{"text":"banned"}]},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`,
+			"banned hi",
+		},
+		{
+			"assistant-only payload yields nothing",
+			sdktranslator.FormatOpenAI,
+			`{"messages":[{"role":"assistant","content":"generated"}]}`,
+			"",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ExtractLastUserText(tt.format, []byte(tt.body)); got != tt.want {
-				t.Fatalf("ExtractLastUserText = %q, want %q", got, tt.want)
+			if got := ExtractModeratableText(tt.format, []byte(tt.body)); got != tt.want {
+				t.Fatalf("ExtractModeratableText = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/contentmoderation/runtime.go
+++ b/internal/contentmoderation/runtime.go
@@ -211,7 +211,7 @@ func (m *RuntimeModerator) Moderate(ctx context.Context, auth *coreauth.Auth, op
 		return coreauth.RequestModerationResult{}
 	}
 
-	input := ExtractLastUserText(opts.SourceFormat, opts.OriginalRequest)
+	input := ExtractModeratableText(opts.SourceFormat, opts.OriginalRequest)
 	if input == "" {
 		counters.allows.Add(1)
 		decision := Decision{Action: ActionAllow}

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -179,7 +179,7 @@ func (s cooldownService) applySuccessLocked(auth *Auth, result Result, now time.
 	markClaudeOAuthHealthSuccessLocked(auth, result, now)
 	if result.Model != "" {
 		state := ensureModelState(auth, result.Model)
-		if activeModelQuotaCooldown(state, now) && !quotaNeedsConfirmedRecovery(state.Quota) {
+		if activeModelQuotaCooldown(state, now) && !quotaNeedsConfirmedRecovery(state.Quota, now) {
 			updateAggregatedAvailability(auth, now)
 			auth.UpdatedAt = now
 			return
@@ -196,7 +196,7 @@ func (s cooldownService) applySuccessLocked(auth *Auth, result Result, now time.
 		effects.clearModelQuota = true
 		return
 	}
-	if activeAuthQuotaCooldown(auth, now) && !quotaNeedsConfirmedRecovery(auth.Quota) {
+	if activeAuthQuotaCooldown(auth, now) && !quotaNeedsConfirmedRecovery(auth.Quota, now) {
 		updateAggregatedAvailability(auth, now)
 		auth.UpdatedAt = now
 		return

--- a/sdk/cliproxy/auth/conductor_failure_state.go
+++ b/sdk/cliproxy/auth/conductor_failure_state.go
@@ -60,14 +60,18 @@ func applyAuthQuotaFailureState(auth *Auth, resultErr *Error, retryAfter *time.D
 	} else {
 		auth.StatusMessage = "quota exhausted"
 	}
+	disableCooling := quotaCooldownDisabledForAuth(auth)
 	auth.Quota.Exceeded = true
-	auth.Quota.RecoveryRequired = isXAIWeekBalanceExhaustedError(resultErr)
+	// disable_cooling is an explicit operator override of quota scheduling; the
+	// probe-confirmed gate must honour it too, otherwise the flag silently stops
+	// working for exactly the credentials that hit weekly exhaustion.
+	auth.Quota.RecoveryRequired = !disableCooling && isXAIWeekBalanceExhaustedError(resultErr)
 	auth.Quota.Reason = "quota"
 	if resultErr != nil {
 		auth.Quota.Window = resultErr.QuotaWindow
 		auth.Quota.WindowMinutes = resultErr.QuotaWindowMinutes
 	}
-	cooldown, nextLevel := quotaFailureCooldown(resultErr, retryAfter, auth.Quota.BackoffLevel, quotaCooldownDisabledForAuth(auth))
+	cooldown, nextLevel := quotaFailureCooldown(resultErr, retryAfter, auth.Quota.BackoffLevel, disableCooling)
 	var next time.Time
 	if cooldown > 0 {
 		next = now.Add(cooldown)
@@ -85,9 +89,26 @@ func quotaFailureCooldown(resultErr *Error, retryAfter *time.Duration, prevLevel
 		return 0, prevLevel
 	}
 	if isXAIWeekBalanceExhaustedError(resultErr) {
-		return 0, prevLevel
+		// Upstream reported weekly exhaustion without a reset time. Recovery is
+		// normally confirmed by the billing probe, but that probe can be
+		// permanently unavailable, so fall back to the declared quota window
+		// instead of leaving the credential without any retry deadline.
+		return quotaWindowFallbackCooldown(resultErr), prevLevel
 	}
 	return nextQuotaCooldown(prevLevel, false)
+}
+
+// quotaWindowMaxCooldown caps the fallback deadline for an exhausted quota
+// window; xAI's weekly window is the longest one we observe.
+const quotaWindowMaxCooldown = 7 * 24 * time.Hour
+
+func quotaWindowFallbackCooldown(resultErr *Error) time.Duration {
+	if resultErr != nil && resultErr.QuotaWindowMinutes > 0 {
+		if window := time.Duration(resultErr.QuotaWindowMinutes) * time.Minute; window < quotaWindowMaxCooldown {
+			return window
+		}
+	}
+	return quotaWindowMaxCooldown
 }
 
 func isXAIWeekBalanceExhaustedError(resultErr *Error) bool {

--- a/sdk/cliproxy/auth/conductor_result_state.go
+++ b/sdk/cliproxy/auth/conductor_result_state.go
@@ -51,7 +51,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		stateUnavailable := false
 		if state.Status == StatusDisabled {
 			stateUnavailable = true
-		} else if quotaNeedsConfirmedRecovery(state.Quota) {
+		} else if quotaNeedsConfirmedRecovery(state.Quota, now) {
 			stateUnavailable = true
 			state.Unavailable = true
 			if state.NextRetryAfter.After(now) && (earliestRetry.IsZero() || state.NextRetryAfter.Before(earliestRetry)) {
@@ -132,7 +132,7 @@ func activeQuotaCooldown(quota QuotaState, retryAfter time.Time, now time.Time) 
 	if !quota.Exceeded {
 		return false
 	}
-	if quotaNeedsConfirmedRecovery(quota) {
+	if quotaNeedsConfirmedRecovery(quota, now) {
 		return true
 	}
 	if !quota.NextRecoverAt.IsZero() {
@@ -141,8 +141,18 @@ func activeQuotaCooldown(quota QuotaState, retryAfter time.Time, now time.Time) 
 	return !retryAfter.IsZero() && retryAfter.After(now)
 }
 
-func quotaNeedsConfirmedRecovery(quota QuotaState) bool {
-	return quota.Exceeded && quota.RecoveryRequired
+// quotaNeedsConfirmedRecovery reports whether the credential must stay blocked
+// until a recovery probe confirms quota is back.
+//
+// The gate is always bounded by NextRecoverAt. Without that ceiling a credential
+// whose probe can never succeed — API-key mode xAI auths reject the Grok Build
+// billing probe outright, and the billing endpoint can simply be down — would be
+// blacklisted forever, because the selector never picks it again and only a
+// successful request could clear the flag. A zero or elapsed NextRecoverAt
+// therefore lets one request through; if quota really is still exhausted the
+// upstream 402 re-arms the gate with a fresh window.
+func quotaNeedsConfirmedRecovery(quota QuotaState, now time.Time) bool {
+	return quota.Exceeded && quota.RecoveryRequired && quota.NextRecoverAt.After(now)
 }
 
 func activeModelRuntimeState(state *ModelState, now time.Time) bool {
@@ -189,7 +199,7 @@ func hasModelError(auth *Auth, now time.Time) bool {
 			return true
 		}
 		if state.Status == StatusError {
-			if quotaNeedsConfirmedRecovery(state.Quota) || (state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now))) {
+			if quotaNeedsConfirmedRecovery(state.Quota, now) || (state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now))) {
 				return true
 			}
 		}

--- a/sdk/cliproxy/auth/quota_persistence.go
+++ b/sdk/cliproxy/auth/quota_persistence.go
@@ -34,7 +34,7 @@ func syncPersistedQuotaRuntime(auth *Auth) {
 		Quota:          auth.Quota,
 	}
 	for model, state := range auth.ModelStates {
-		if state == nil || !quotaNeedsConfirmedRecovery(state.Quota) {
+		if state == nil || !quotaRecoveryGateArmed(state.Quota) {
 			continue
 		}
 		if runtime.ModelStates == nil {
@@ -48,7 +48,7 @@ func syncPersistedQuotaRuntime(auth *Auth) {
 		}
 	}
 
-	if !quotaNeedsConfirmedRecovery(runtime.Quota) && len(runtime.ModelStates) == 0 {
+	if !quotaRecoveryGateArmed(runtime.Quota) && len(runtime.ModelStates) == 0 {
 		delete(auth.Metadata, persistedQuotaRuntimeMetadataKey)
 		return
 	}
@@ -71,11 +71,11 @@ func restorePersistedQuotaRuntime(auth *Auth) {
 	if err = json.Unmarshal(data, &runtime); err != nil {
 		return
 	}
-	if !quotaNeedsConfirmedRecovery(runtime.Quota) && len(runtime.ModelStates) == 0 {
+	if !quotaRecoveryGateArmed(runtime.Quota) && len(runtime.ModelStates) == 0 {
 		return
 	}
 
-	if quotaNeedsConfirmedRecovery(runtime.Quota) {
+	if quotaRecoveryGateArmed(runtime.Quota) {
 		auth.Quota = runtime.Quota
 		auth.NextRetryAfter = runtime.NextRetryAfter
 		auth.Unavailable = true
@@ -95,7 +95,7 @@ func restorePersistedQuotaRuntime(auth *Auth) {
 		auth.ModelStates = make(map[string]*ModelState, len(runtime.ModelStates))
 	}
 	for model, persisted := range runtime.ModelStates {
-		if !quotaNeedsConfirmedRecovery(persisted.Quota) {
+		if !quotaRecoveryGateArmed(persisted.Quota) {
 			continue
 		}
 		state := &ModelState{
@@ -114,4 +114,11 @@ func restorePersistedQuotaRuntime(auth *Auth) {
 		auth.ModelStates[model] = state
 	}
 	updateAggregatedAvailability(auth, time.Now())
+}
+
+// quotaRecoveryGateArmed reports whether a probe-confirmed quota gate exists at
+// all, ignoring its deadline. Persistence must not drop a gate just because its
+// deadline is close: expiry is re-evaluated against the clock on every check.
+func quotaRecoveryGateArmed(quota QuotaState) bool {
+	return quota.Exceeded && quota.RecoveryRequired
 }

--- a/sdk/cliproxy/auth/quota_reconcile.go
+++ b/sdk/cliproxy/auth/quota_reconcile.go
@@ -236,6 +236,15 @@ func (m *Manager) probeQuotaRecovery(ctx context.Context, id string, force bool)
 	return m.UpdateQuotaFromProbe(ctx, id, result)
 }
 
+func probeWindowFallbackCooldown(windowMinutes int) time.Duration {
+	if windowMinutes > 0 {
+		if window := time.Duration(windowMinutes) * time.Minute; window < quotaWindowMaxCooldown {
+			return window
+		}
+	}
+	return quotaWindowMaxCooldown
+}
+
 func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) (bool, []string) {
 	if auth == nil || result == nil {
 		return false, nil
@@ -246,21 +255,28 @@ func applyQuotaProbeResult(auth *Auth, result *QuotaProbeResult, now time.Time) 
 	modelResults := normalizeQuotaProbeModels(result.Models)
 	authWide := QuotaProbeModelResult{Recovered: result.Recovered, NextRecoverAt: result.NextRecoverAt}
 	if result.WindowExhausted && !hasQuotaExceededModel(auth) {
+		// Upstream can report an exhausted window without a reset timestamp.
+		// Derive a deadline from the window length so the gate always expires;
+		// an open-ended gate can never be lifted once probing stops working.
+		recoverAt := result.NextRecoverAt
+		if recoverAt.IsZero() {
+			recoverAt = now.Add(probeWindowFallbackCooldown(result.WindowMinutes))
+		}
 		changed := !auth.Unavailable || auth.Status != StatusError || auth.StatusMessage != "quota exhausted" ||
-			!auth.NextRetryAfter.Equal(result.NextRecoverAt) || !auth.Quota.Exceeded || !auth.Quota.RecoveryRequired ||
+			!auth.NextRetryAfter.Equal(recoverAt) || !auth.Quota.Exceeded || !auth.Quota.RecoveryRequired ||
 			auth.Quota.Reason != "quota" || auth.Quota.Window != result.Window ||
-			auth.Quota.WindowMinutes != result.WindowMinutes || !auth.Quota.NextRecoverAt.Equal(result.NextRecoverAt)
+			auth.Quota.WindowMinutes != result.WindowMinutes || !auth.Quota.NextRecoverAt.Equal(recoverAt)
 		auth.Unavailable = true
 		auth.Status = StatusError
 		auth.StatusMessage = "quota exhausted"
-		auth.NextRetryAfter = result.NextRecoverAt
+		auth.NextRetryAfter = recoverAt
 		auth.Quota = QuotaState{
 			Exceeded:         true,
 			RecoveryRequired: true,
 			Reason:           "quota",
 			Window:           result.Window,
 			WindowMinutes:    result.WindowMinutes,
-			NextRecoverAt:    result.NextRecoverAt,
+			NextRecoverAt:    recoverAt,
 		}
 		auth.UpdatedAt = now
 		return changed, nil
@@ -445,6 +461,12 @@ func nextQuotaProbeTime(auth *Auth, now time.Time) time.Time {
 	if nextRecover.IsZero() {
 		return now.Add(quotaProbeMinInterval)
 	}
+	// A probe-confirmed gate keeps the credential out of rotation until the probe
+	// says otherwise, so keep polling promptly instead of scaling the interval to
+	// the (week-long) window deadline that only acts as a ceiling.
+	if quotaRecoveryGateArmed(auth.Quota) {
+		return now.Add(quotaProbeMinInterval)
+	}
 	remaining := nextRecover.Sub(now)
 	if remaining <= 0 {
 		return now.Add(quotaProbeMinInterval)
@@ -500,11 +522,17 @@ func updateQuotaModelRecoverAt(state *ModelState, next time.Time, now time.Time)
 		return false
 	}
 	if next.IsZero() {
-		if !quotaNeedsConfirmedRecovery(state.Quota) {
+		if !quotaRecoveryGateArmed(state.Quota) {
 			return false
 		}
-		changed := !state.Unavailable
+		// The probe answered "still exhausted" but gave no reset time. That is
+		// fresh evidence, so push the window deadline out instead of letting an
+		// already-elapsed one release the credential on the next pick.
+		deadline := now.Add(probeWindowFallbackCooldown(state.Quota.WindowMinutes))
+		changed := !state.Unavailable || !state.Quota.NextRecoverAt.Equal(deadline)
 		state.Unavailable = true
+		state.NextRetryAfter = deadline
+		state.Quota.NextRecoverAt = deadline
 		state.UpdatedAt = now
 		return changed
 	}
@@ -578,11 +606,16 @@ func updateQuotaAuthRecoverAt(auth *Auth, next time.Time, now time.Time) bool {
 		return false
 	}
 	if next.IsZero() {
-		if !quotaNeedsConfirmedRecovery(auth.Quota) {
+		if !quotaRecoveryGateArmed(auth.Quota) {
 			return false
 		}
-		changed := !auth.Unavailable
+		// See updateQuotaModelRecoverAt: a confirmed-still-exhausted probe
+		// without a reset time refreshes the window deadline.
+		deadline := now.Add(probeWindowFallbackCooldown(auth.Quota.WindowMinutes))
+		changed := !auth.Unavailable || !auth.Quota.NextRecoverAt.Equal(deadline)
 		auth.Unavailable = true
+		auth.NextRetryAfter = deadline
+		auth.Quota.NextRecoverAt = deadline
 		auth.UpdatedAt = now
 		return changed
 	}

--- a/sdk/cliproxy/auth/quota_reconcile_test.go
+++ b/sdk/cliproxy/auth/quota_reconcile_test.go
@@ -375,3 +375,53 @@ func TestManagerClearQuotaStatus_PreservesStatusDisabled(t *testing.T) {
 		t.Fatalf("disabled model quota runtime state was not cleared: %#v", state)
 	}
 }
+
+// A week-exhausted credential whose recovery probe can never succeed (xAI
+// API-key mode rejects the Grok Build billing probe) must still leave the gate
+// once the real quota window elapses, instead of being blacklisted forever.
+func TestWeekExhaustedGateExpiresWhenProbeNeverConfirms(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := &Auth{ID: "xai-api-key", Provider: "xai", Status: StatusActive}
+	applyAuthFailureState(auth, &Error{
+		Message:            `{"error":"Grok Build usage balance exhausted"}`,
+		HTTPStatus:         http.StatusPaymentRequired,
+		QuotaWindow:        "week",
+		QuotaWindowMinutes: 10080,
+	}, nil, now)
+
+	if blocked, _, _ := isAuthBlockedForModel(auth, "grok-4.5", now.Add(6*time.Hour)); !blocked {
+		t.Fatal("blocked = false at +6h, want the gate to outlast the old short cooldown")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(auth, "grok-4.5", now.Add(8*24*time.Hour)); blocked {
+		t.Fatal("blocked = true past the quota window, want the credential back in rotation")
+	}
+}
+
+// disable_cooling is an explicit operator override and must also disable the
+// probe-confirmed gate, otherwise it silently stops working for weekly quota.
+func TestWeekExhaustedGateHonoursDisableCooling(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := &Auth{
+		ID:       "xai-no-cooling",
+		Provider: "xai",
+		Status:   StatusActive,
+		Metadata: map[string]any{"disable_cooling": true},
+	}
+	applyAuthFailureState(auth, &Error{
+		Message:            `{"error":"Grok Build usage balance exhausted"}`,
+		HTTPStatus:         http.StatusPaymentRequired,
+		QuotaWindow:        "week",
+		QuotaWindowMinutes: 10080,
+	}, nil, now)
+
+	if auth.Quota.RecoveryRequired {
+		t.Fatal("RecoveryRequired = true, want disable_cooling to suppress the gate")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(auth, "grok-4.5", now.Add(time.Minute)); blocked {
+		t.Fatal("blocked = true, want disable_cooling to keep the credential selectable")
+	}
+}

--- a/sdk/cliproxy/auth/selector_availability.go
+++ b/sdk/cliproxy/auth/selector_availability.go
@@ -306,7 +306,7 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	// requests by switching models during the same quota window.
 	if auth.Quota.Exceeded {
 		next := auth.Quota.NextRecoverAt
-		if quotaNeedsConfirmedRecovery(auth.Quota) || (!next.IsZero() && next.After(now)) {
+		if quotaNeedsConfirmedRecovery(auth.Quota, now) || (!next.IsZero() && next.After(now)) {
 			if auth.NextRetryAfter.After(now) && (next.IsZero() || auth.NextRetryAfter.Before(next)) {
 				next = auth.NextRetryAfter
 			}
@@ -330,7 +330,7 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 				if state.Status == StatusDisabled {
 					return true, blockReasonDisabled, time.Time{}
 				}
-				if quotaNeedsConfirmedRecovery(state.Quota) {
+				if quotaNeedsConfirmedRecovery(state.Quota, now) {
 					next := state.Quota.NextRecoverAt
 					if state.NextRetryAfter.After(now) && (next.IsZero() || state.NextRetryAfter.Before(next)) {
 						next = state.NextRetryAfter

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -705,11 +705,8 @@ func TestIsAuthBlockedForModel_AuthQuotaCooldownBlocksAllModels(t *testing.T) {
 	}
 }
 
-func TestIsAuthBlockedForModel_WindowExhaustedRemainsBlockedAfterRecoverAt(t *testing.T) {
-	t.Parallel()
-
-	now := time.Now()
-	auth := &Auth{
+func weekExhaustedAuth(now time.Time, recoverAt time.Time) *Auth {
+	return &Auth{
 		ID: "xai-week-exhausted",
 		Quota: QuotaState{
 			Exceeded:         true,
@@ -717,10 +714,17 @@ func TestIsAuthBlockedForModel_WindowExhaustedRemainsBlockedAfterRecoverAt(t *te
 			Reason:           "quota",
 			Window:           "week",
 			WindowMinutes:    10080,
-			NextRecoverAt:    now.Add(-time.Hour),
+			NextRecoverAt:    recoverAt,
 		},
-		NextRetryAfter: now.Add(-time.Hour),
+		NextRetryAfter: recoverAt,
 	}
+}
+
+func TestIsAuthBlockedForModel_WindowExhaustedStaysBlockedUntilWindowDeadline(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := weekExhaustedAuth(now, now.Add(6*24*time.Hour))
 
 	blocked, reason, next := isAuthBlockedForModel(auth, "grok-4.5", now)
 	if !blocked {
@@ -729,8 +733,36 @@ func TestIsAuthBlockedForModel_WindowExhaustedRemainsBlockedAfterRecoverAt(t *te
 	if reason != blockReasonCooldown {
 		t.Fatalf("reason = %v, want %v", reason, blockReasonCooldown)
 	}
-	if !next.IsZero() {
-		t.Fatalf("next = %v, want zero for an expired unconfirmed reset", next)
+	if next.IsZero() {
+		t.Fatal("next = zero, want the window deadline")
+	}
+}
+
+// The gate must expire: an xAI auth in API-key mode rejects the billing probe
+// outright, so a gate that only a probe can lift would blacklist it forever.
+func TestIsAuthBlockedForModel_WindowExhaustedReleasesAfterWindowDeadline(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := weekExhaustedAuth(now, now.Add(-time.Hour))
+
+	blocked, _, _ := isAuthBlockedForModel(auth, "grok-4.5", now)
+	if blocked {
+		t.Fatal("blocked = true, want release for one retry once the quota window elapsed")
+	}
+}
+
+// Runtime state persisted before the window deadline existed must not stay
+// blocked forever after an upgrade.
+func TestIsAuthBlockedForModel_WindowExhaustedWithoutDeadlineIsNotPermanent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := weekExhaustedAuth(now, time.Time{})
+
+	blocked, _, _ := isAuthBlockedForModel(auth, "grok-4.5", now)
+	if blocked {
+		t.Fatal("blocked = true, want release for a legacy gate carrying no deadline")
 	}
 }
 

--- a/sdk/cliproxy/auth/xai_402_quota_test.go
+++ b/sdk/cliproxy/auth/xai_402_quota_test.go
@@ -169,11 +169,14 @@ func TestManagerMarkResult_XAI402BalanceExhaustedWithoutRetryUsesRecoveryGate(t 
 	if !state.Quota.Exceeded || state.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", state.Quota)
 	}
-	if !state.NextRetryAfter.IsZero() {
-		t.Fatalf("NextRetryAfter = %v, want zero without upstream reset", state.NextRetryAfter)
+	// Without an upstream reset the gate falls back to the declared window so a
+	// credential whose recovery probe never succeeds still returns to the pool.
+	wantDeadline := before.Add(10080 * time.Minute)
+	if state.NextRetryAfter.Before(wantDeadline.Add(-time.Minute)) || state.NextRetryAfter.After(wantDeadline.Add(time.Minute)) {
+		t.Fatalf("NextRetryAfter = %v, want ~%v (quota window fallback)", state.NextRetryAfter, wantDeadline)
 	}
-	if !state.Quota.NextRecoverAt.IsZero() {
-		t.Fatalf("NextRecoverAt = %v, want zero without upstream reset", state.Quota.NextRecoverAt)
+	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
+		t.Fatalf("NextRecoverAt = %v, want same as NextRetryAfter", state.Quota.NextRecoverAt)
 	}
 	if !got.Quota.Exceeded || !got.Quota.RecoveryRequired {
 		t.Fatalf("aggregated auth quota = %#v, want confirmed-recovery gate", got.Quota)
@@ -335,11 +338,12 @@ func TestApplyAuthFailureState_XAI402WithoutRetryUsesRecoveryGate(t *testing.T) 
 	if !auth.Quota.Exceeded || !auth.Quota.RecoveryRequired || auth.Quota.Window != "week" {
 		t.Fatalf("quota = %#v, want week exceeded", auth.Quota)
 	}
-	if !auth.NextRetryAfter.IsZero() {
-		t.Fatalf("NextRetryAfter = %v, want zero without upstream reset", auth.NextRetryAfter)
+	wantDeadline := now.Add(10080 * time.Minute)
+	if !auth.NextRetryAfter.Equal(wantDeadline) {
+		t.Fatalf("NextRetryAfter = %v, want %v (quota window fallback)", auth.NextRetryAfter, wantDeadline)
 	}
-	if !auth.Quota.NextRecoverAt.IsZero() {
-		t.Fatalf("NextRecoverAt = %v, want zero without upstream reset", auth.Quota.NextRecoverAt)
+	if !auth.Quota.NextRecoverAt.Equal(wantDeadline) {
+		t.Fatalf("NextRecoverAt = %v, want %v (quota window fallback)", auth.Quota.NextRecoverAt, wantDeadline)
 	}
 }
 


### PR DESCRIPTION
## 背景

本轮全仓 review 发现的 P1/P2 问题，逐条核实源码后修复。

## 修复内容

### 1. P1 内容审核 pre_block 可被平凡绕过

`ExtractLastUserText` 只取**最后一条** user 消息的文本，取不到就判空放行。实测三种绕过：末尾追加空 user 消息、末尾只放 image_url、把违禁内容放在 Claude 的 `system` 字段。

改为 `ExtractModeratableText`，覆盖请求中**全部调用方可控文本**：所有 user/system/developer 轮次 + Claude `system` + Gemini `systemInstruction` + Responses `instructions` + 图像生成的顶层 `prompt`。assistant/model 轮次仍排除（那是上游产出的回放，拦截会破坏正常多轮对话）；Claude 的 `<system-reminder>` 仍跳过。

### 2. P1 week-exhausted 凭证可被永久拉黑

PR #802 用 `RecoveryRequired` 取代固定冷却，但没有任何超时兜底：只要探针无法确认恢复，凭证就永远出不来。API key 模式的 xAI auth（`ProbeQuotaRecovery` 直接返回 error）必然命中——选号器再也不选它，就永远拿不到能解禁的成功请求，且该状态会持久化到 auth 文件，重启也无效，只能人工调 `ClearQuotaStatus`。同时 `disable_cooling` 对该门禁完全失效。

修复：
- 门禁始终以 `NextRecoverAt` 为上限，取自上游声明的额度窗口（week=7 天），而不是无期限；
- 探针回报「仍耗尽但无 reset 时间」时**续期**该 deadline，因此只要探针还能工作，行为与 #802 一致（不会 6h 抖动）；
- 探针结果 `WindowExhausted` 但无 reset 时间时同样派生 deadline，不再写出无期限门禁；
- `disable_cooling` 现在会抑制该门禁，与文档语义一致；
- 升级前已持久化的无 deadline 门禁会自愈（放行一次，若真耗尽则被新的 402 重新武装）。

### 3. P2 管理面板缺少防跨站嵌套响应头

面板 HTML 现在返回 `X-Frame-Options: SAMEORIGIN`、CSP `frame-ancestors 'self'`、`nosniff`、`no-referrer`。用 `'self'` 而非 `'none'` 是为了不影响面板内部自己的 embed 菜单。

### 4. P2 GitHub Actions 使用可变 tag

所有 workflow 的 action 改为 commit SHA 固定（保留版本注释）。此前 deploy/release job 把可变 tag 的第三方 action 与部署密钥、发布令牌放在同一 job 中，上游 tag 一旦被劫持即可直接接管服务器或发布产物（`tj-actions/changed-files` 就真实发生过）。

## 测试

- 新增 `TestExtractModeratableText` 覆盖全部绕过场景与各 format 的多轮聚合
- 新增 `TestWeekExhaustedGateExpiresWhenProbeNeverConfirms`、`TestWeekExhaustedGateHonoursDisableCooling`
- 重写 `TestIsAuthBlockedForModel_WindowExhausted*` 为三条明确契约（窗口内阻断 / 窗口后放行 / legacy 无 deadline 不永久阻断）
- 新增 `TestSetPanelSecurityHeaders`
- `./scripts/ci-pr.sh` 全量通过

## 遗留

本轮确认但未修的问题（多为 schema 级，需单独立项）见根仓 `docs/issue/002-project-audit-remaining-findings-20260726.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)