### PR TITLE
fix(identity-fingerprint): 未知 Codex 客户端变体导致指纹完全不记录

### DIFF
--- a/internal/identityfingerprint/profiles.go
+++ b/internal/identityfingerprint/profiles.go
@@ -46,21 +46,62 @@ func CodexProfileKey(userAgent, originator string) (profileKey, family string, o
 	uaKey, uaFamily := classifyCodexUserAgent(userAgent)
 	originatorKey, originatorFamily := classifyCodexOriginator(originator)
 
-	// A present but unknown identity signal is not safe to merge into a known
-	// profile. Reject it instead of persisting a bundle with mismatched parts.
-	if (userAgent != "" && uaKey == "") || (originator != "" && originatorKey == "") {
-		return "", ProfileFamilyUnknown, false
-	}
-	if uaKey != "" && originatorKey != "" && uaKey != originatorKey {
+	// A present but unrecognisable User-Agent means the caller is not the client
+	// it claims to be, so nothing here can be trusted.
+	if userAgent != "" && uaKey == "" {
 		return "", ProfileFamilyUnknown, false
 	}
 	if originatorKey != "" {
+		if uaKey != "" && uaKey != originatorKey {
+			return "", ProfileFamilyUnknown, false
+		}
 		return originatorKey, originatorFamily, true
+	}
+	if originator != "" {
+		// OpenAI ships new Codex originators (codex_work_desktop, plain "Codex")
+		// faster than this allowlist can track. Dropping the whole observation
+		// left such accounts with no learned fingerprint at all — no last-seen,
+		// no fields, nothing for an operator to inspect. Record the variant under
+		// its own profile key instead: an unknown family is never selected for
+		// outbound spoofing (see CodexProfileOutboundEligibility), so observing
+		// it is safe while still surfacing the client in the UI.
+		if key := normalizeUnknownCodexToken(originator); key != "" {
+			return key, ProfileFamilyUnknown, true
+		}
+		return "", ProfileFamilyUnknown, false
 	}
 	if uaKey != "" {
 		return uaKey, uaFamily, true
 	}
 	return "", ProfileFamilyUnknown, false
+}
+
+// unknownCodexTokenMaxLen bounds the profile key derived from a client-supplied
+// Originator header.
+const unknownCodexTokenMaxLen = 40
+
+// normalizeUnknownCodexToken accepts an unrecognised Originator only when it
+// still looks like a Codex client id, and returns its canonical profile key.
+//
+// The header is caller-controlled and the result becomes part of a primary key,
+// so the shape is deliberately narrow: a "codex" prefix, a small character set
+// and a length cap. Without that, a client holding a valid API key could mint an
+// unbounded number of profile rows per account.
+func normalizeUnknownCodexToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if !strings.HasPrefix(value, "codex") || len(value) > unknownCodexTokenMaxLen {
+		return ""
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return ""
+		}
+	}
+	return value
 }
 
 func CodexProfileFamily(profileKey string) string {

--- a/internal/identityfingerprint/profiles_test.go
+++ b/internal/identityfingerprint/profiles_test.go
@@ -1,6 +1,7 @@
 package identityfingerprint
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -190,5 +191,101 @@ func TestResolveCodexProfileNeverFillsFromAnotherProductPreset(t *testing.T) {
 	}
 	if effective.ProfileKey != "codex_cli_rs" || effective.ProfileFamily != ProfileFamilyCLI {
 		t.Fatalf("effective profile = %#v", effective)
+	}
+}
+
+// OpenAI ships new Codex originators faster than the allowlist tracks them.
+// Before this was handled, an unrecognised value made the whole observation be
+// dropped, so accounts running such a client learned nothing at all — no
+// fields, no last-seen. Both values below were taken from production logs.
+func TestCodexProfileKeyRecordsUnknownOriginatorAsOwnProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		userAgent  string
+		originator string
+		wantKey    string
+	}{
+		{
+			name:       "work desktop variant",
+			userAgent:  "Codex Desktop/0.146.0-alpha.3.1 (Mac OS 26.5.1; arm64) unknown (Codex Desktop; 26.721.41059)",
+			originator: "codex_work_desktop",
+			wantKey:    "codex_work_desktop",
+		},
+		{
+			name:       "bare product name",
+			userAgent:  "Codex Desktop/0.146.0-alpha.3.1 (Mac OS 26.5.1; arm64)",
+			originator: "Codex",
+			wantKey:    "codex",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, family, ok := CodexProfileKey(tt.userAgent, tt.originator)
+			if !ok {
+				t.Fatal("ok = false, want the observation to be recorded")
+			}
+			if key != tt.wantKey {
+				t.Fatalf("profileKey = %q, want %q", key, tt.wantKey)
+			}
+			// Unknown family keeps the variant out of outbound selection: we
+			// observe the client without impersonating it.
+			if family != ProfileFamilyUnknown {
+				t.Fatalf("family = %q, want %q", family, ProfileFamilyUnknown)
+			}
+		})
+	}
+}
+
+func TestCodexProfileKeyRejectsUntrustworthyIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		userAgent  string
+		originator string
+	}{
+		// A non-Codex UA means the caller is not the client it claims to be.
+		{name: "spoofed user agent", userAgent: "curl/8.0", originator: "codex_cli_rs"},
+		{name: "unknown originator with foreign ua", userAgent: "curl/8.0", originator: "codex_work_desktop"},
+		// The header is caller-controlled and becomes part of a primary key.
+		{name: "non codex prefix", userAgent: "Codex Desktop/0.146.0 (Mac OS)", originator: "attacker_tool"},
+		{name: "unsafe characters", userAgent: "Codex Desktop/0.146.0 (Mac OS)", originator: "codex<script>"},
+		{name: "over length", userAgent: "Codex Desktop/0.146.0 (Mac OS)", originator: "codex_" + strings.Repeat("a", unknownCodexTokenMaxLen)},
+		// A known originator that contradicts the UA is still a conflict.
+		{name: "conflicting known pair", userAgent: "codex_vscode/0.146.0 (Mac OS)", originator: "codex_cli_rs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, ok := CodexProfileKey(tt.userAgent, tt.originator); ok {
+				t.Fatal("ok = true, want the observation to be rejected")
+			}
+		})
+	}
+}
+
+// An unknown variant must never be picked for outbound spoofing, even when it
+// is the only profile the account has.
+func TestSelectCodexProfileSkipsUnknownFamilyVariant(t *testing.T) {
+	t.Parallel()
+
+	records := []LearnedRecord{{
+		Provider:      ProviderCodex,
+		AccountKey:    "acct",
+		ProfileKey:    "codex_work_desktop",
+		ProfileFamily: ProfileFamilyUnknown,
+		Fields: map[string]string{
+			FieldUserAgent:       "Codex Desktop/0.146.0-alpha.3.1 (Mac OS 26.5.1; arm64) unknown (Codex Desktop; 26.721.41059)",
+			FieldCodexOriginator: "codex_work_desktop",
+		},
+	}}
+
+	selection := SelectCodexProfile(records, AccountPolicy{})
+	if selection.Profile != nil {
+		t.Fatalf("selected %q for outbound use, want none", selection.Profile.ProfileKey)
+	}
+	if selection.Reason != "no_selectable_profile" {
+		t.Fatalf("reason = %q, want no_selectable_profile", selection.Reason)
 	}
 }


### PR DESCRIPTION
## 现象

用户反馈某账号（`jd7njnb5nh@privaterelay.appleid.com` / `authsub_a0436c51c20583ca`）在管理端「身份」页看不到任何自学习指纹：**更新时间和最后出现都是 `--`，自学习字段 0**，只有账号组预设的 4 个字段。

## 根因（线上日志实证）

**不是「失败请求不记录」，是「未知客户端变体被整条丢弃」。**

线上数据：

```sql
-- 该账号：2 次请求，全部失败，指纹记录 0 条
SELECT count(*) FROM identity_fingerprints WHERE account_key='authsub_a0436c51c20583ca';  -- 0
SELECT count(*), sum(failed) FROM request_logs WHERE auth_subject_id='authsub_a0436c51c20583ca';  -- 2, 2
```

线上错误日志 `error-v1-responses-2026-07-26T213413-b04df7b1.log` 里的客户端请求头：

```
User-Agent: Codex Desktop/0.146.0-alpha.3.1 (Mac OS 26.5.1; arm64) unknown (Codex Desktop; 26.721.41059)
Originator: codex_work_desktop
```

`codex_work_desktop` 不在 `classifyCodexToken` 的白名单里 → `classifyCodexOriginator` 返回空 → `CodexProfileKey` 命中「有信号但无法识别」分支返回 `ok=false` → `extractCodexObservation` 返回 `false` → `observeRuntimeIdentityFingerprint` 直接 `return nil`。**整条观测被丢弃，什么都不写。**

统计线上所有错误日志的 originator，发现有**两个**未被识别的值：

| Originator | 出现次数 | 是否识别 |
|-----------|---------|---------|
| `codex_work_desktop` | 9 | ❌ |
| `codex_cli_rs` | 7 | ✅ |
| `Codex` | 6 | ❌ |

说明这不是单个值的遗漏——**白名单方式跟不上 OpenAI 发布新客户端变体的速度**。

（顺带说明：该账号那 2 次失败是上游 400，请求体近 5MB，与本 bug 无关。学习本来就发生在请求发出**之前**，成功与否不影响。）

## 修复

原来那句拒绝的注释写的是「未知信号不能被合并进已知 profile」——**这个意图是对的，但"不合并"不等于"不记录"**。

改为：未知但格式合法的 originator **获得自己独立的 profile key**，family 标记为 `unknown`。

这样把两件事分开了：

- **观测**：变体被记录，运营能在 UI 看到它、有 last-seen
- **使用**：`unknown` family 永远不会被选去出站伪装——`SelectCodexProfile` 只在 `cli`/`ide`/`desktop` 三个 family 里挑，且每个候选还要过 `CodexProfileOutboundEligibility`（该函数对 unknown family 返回 `unsupported_profile_family`）

**安全边界**：Originator 是调用方可控的 header，且这个值会成为数据库主键的一部分。所以接受条件收得很窄：

- 必须以 `codex` 开头
- 只允许 `[a-z0-9_-]`
- 最长 40 字符
- **User-Agent 仍必须能被识别为 Codex 客户端**——UA 对不上就整体拒绝

否则持有合法 API key 的客户端可以用任意 originator 无限制地生成 profile 行。

## 测试

新增三组回归测试，两个真实 originator 取自线上日志：

- `TestCodexProfileKeyRecordsUnknownOriginatorAsOwnProfile`：`codex_work_desktop` 与 `Codex` 被记录且 family 为 unknown
- `TestCodexProfileKeyRejectsUntrustworthyIdentity`：伪造 UA、非 codex 前缀、非法字符、超长、已知值互相冲突——全部拒绝
- `TestSelectCodexProfileSkipsUnknownFamilyVariant`：即使 unknown 变体是账号唯一的 profile，也不会被选去出站

`./scripts/ci-pr.sh` 全量通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)