### PR TITLE
fix(security): 修复 loopback 信任边界导致的本地接口绕过

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -195,7 +195,13 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		}
 
 		clientIP := c.ClientIP()
-		localClient := clientIP == "127.0.0.1" || clientIP == "::1"
+		// A loopback ClientIP alone does not prove local origin. With trusted-proxies
+		// unset (the default) gin falls back to RemoteAddr, so behind a same-host
+		// reverse proxy every external request would report 127.0.0.1 and thereby skip
+		// the allow-remote gate, unlock the local-password path, and bypass the per-IP
+		// login throttle entirely. Require the direct peer to be loopback and no relay
+		// headers to be present as well.
+		localClient := (clientIP == "127.0.0.1" || clientIP == "::1") && util.IsLocalOriginRequest(c.Request)
 		cfg := h.cfg
 		var (
 			allowRemote bool
@@ -215,7 +221,14 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		clearFailures := func() {}
 		if !localClient {
 			if !allowRemote {
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "remote management disabled"})
+				// Requests relayed by a local reverse proxy land here even though the TCP
+				// peer is loopback, so the hint names both ways out: open remote access, or
+				// declare the proxy so the real client IP is recovered.
+				message := "remote management disabled"
+				if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" {
+					message = "remote management disabled: request was relayed (" + relayHeader + " header present). Set remote-management.allow-remote=true, or add the proxy to trusted-proxies so the original client IP is used."
+				}
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": message})
 				return
 			}
 

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -249,6 +249,153 @@ func TestMiddlewareIgnoresQuerySessionTokenOnNormalHTTP(t *testing.T) {
 	}
 }
 
+// newDefaultTrustProxyRouter mirrors the production engine for a deployment that left
+// trusted-proxies empty (the shipped default): configureTrustedProxies calls
+// SetTrustedProxies(nil), which makes gin's ClientIP fall back to RemoteAddr. That
+// fallback is what turned a same-host reverse proxy into a local-origin bypass.
+func newDefaultTrustProxyRouter(t *testing.T, h *Handler) *gin.Engine {
+	t.Helper()
+	router := gin.New()
+	if err := router.SetTrustedProxies(nil); err != nil {
+		t.Fatalf("SetTrustedProxies(nil): %v", err)
+	}
+	router.Use(h.Middleware())
+	router.GET("/v0/management/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+	return router
+}
+
+// Same root cause as issue #517, on the management surface: with trusted-proxies unset
+// gin's ClientIP falls back to RemoteAddr, so a same-host reverse proxy made every
+// external request look local — which skipped the allow-remote gate entirely.
+func TestMiddlewareRejectsRelayedRequestWhenRemoteDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const managementKey = "correct-management-key"
+	hashed, err := bcrypt.GenerateFromPassword([]byte(managementKey), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash test management key: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		RemoteManagement: config.RemoteManagement{
+			AllowRemote: false,
+			SecretKey:   string(hashed),
+		},
+	}, nil)
+	defer h.Close()
+
+	router := newDefaultTrustProxyRouter(t, h)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+	// The proxy is the TCP peer; the real client is external.
+	req.RemoteAddr = "127.0.0.1:4321"
+	req.Header.Set("X-Forwarded-For", "203.0.113.42")
+	req.Header.Set("Authorization", "Bearer "+managementKey)
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("relayed request status = %d, want %d; body=%s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "remote management disabled") {
+		t.Fatalf("expected remote-management rejection, got body=%s", rr.Body.String())
+	}
+	// The hint must name a way out, otherwise operators just see a broken panel.
+	if !strings.Contains(rr.Body.String(), "trusted-proxies") {
+		t.Fatalf("expected remediation hint naming trusted-proxies, got body=%s", rr.Body.String())
+	}
+}
+
+// The local-password path is reachable without any remote secret, so it must not be
+// exposed to relayed requests.
+func TestMiddlewareRejectsRelayedRequestUsingLocalPassword(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, nil)
+	h.SetLocalPassword("local-management-password")
+	defer h.Close()
+
+	router := newDefaultTrustProxyRouter(t, h)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+	req.RemoteAddr = "127.0.0.1:4321"
+	req.Header.Set("X-Forwarded-For", "203.0.113.42")
+	req.Header.Set("Authorization", "Bearer local-management-password")
+	router.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusOK {
+		t.Fatalf("relayed request authenticated with the local password; body=%s", rr.Body.String())
+	}
+}
+
+// Relayed requests must also be subject to the per-IP login throttle that the
+// localClient shortcut used to skip.
+func TestMiddlewareThrottlesRelayedFailedAttempts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	hashed, err := bcrypt.GenerateFromPassword([]byte("correct-management-key"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash test management key: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		RemoteManagement: config.RemoteManagement{
+			AllowRemote: true,
+			SecretKey:   string(hashed),
+		},
+	}, nil)
+	defer h.Close()
+
+	router := newDefaultTrustProxyRouter(t, h)
+
+	newRelayedRequest := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+		req.RemoteAddr = "127.0.0.1:4321"
+		req.Header.Set("X-Forwarded-For", "203.0.113.42")
+		req.Header.Set("Authorization", "Bearer wrong-key")
+		return req
+	}
+
+	var banned bool
+	for i := 0; i < 12; i++ {
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, newRelayedRequest())
+		if rr.Code == http.StatusForbidden && strings.Contains(rr.Body.String(), "IP banned") {
+			banned = true
+			break
+		}
+	}
+	if !banned {
+		t.Fatal("relayed brute-force attempts were never throttled")
+	}
+}
+
+// A genuine local client (no relay headers) must keep working unchanged.
+func TestMiddlewareAllowsDirectLoopbackLocalPassword(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, nil)
+	h.SetLocalPassword("local-management-password")
+	defer h.Close()
+
+	router := newDefaultTrustProxyRouter(t, h)
+
+	for _, remoteAddr := range []string{"127.0.0.1:4321", "[::1]:4321"} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+		req.RemoteAddr = remoteAddr
+		req.Header.Set("Authorization", "Bearer local-management-password")
+		router.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("direct loopback %s status = %d, want %d; body=%s", remoteAddr, rr.Code, http.StatusOK, rr.Body.String())
+		}
+	}
+}
+
 func TestResolveSessionToken(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/util/client_ip.go
+++ b/internal/util/client_ip.go
@@ -58,6 +58,88 @@ func forwardedHeaderIP(headers http.Header) string {
 	return ""
 }
 
+// relayIndicationHeaders are headers that reverse proxies, CDNs, load balancers and
+// tunnels add when they relay a request. Any of them being present means the direct
+// TCP peer is a relay rather than the original client.
+//
+// The list is deliberately broader than ForwardedClientIP's priority list: here we
+// only need to know that *some* relay handled the request, so headers that carry no
+// client IP (Via, X-Forwarded-Proto, CF-Ray) are just as conclusive as the ones that
+// do, and a header we fail to recognise is a bypass rather than a display glitch.
+var relayIndicationHeaders = []string{
+	"Forwarded",
+	"Via",
+	"X-Forwarded-For",
+	"X-Forwarded-Host",
+	"X-Forwarded-Port",
+	"X-Forwarded-Proto",
+	"X-Forwarded-Server",
+	"X-Original-Forwarded-For",
+	"X-Real-IP",
+	"X-Client-IP",
+	"X-Cluster-Client-IP",
+	"CF-Connecting-IP",
+	"CF-Connecting-IPv6",
+	"CF-Ray",
+	"True-Client-IP",
+	"Fastly-Client-IP",
+	"X-Envoy-External-Address",
+	"X-Envoy-Internal",
+	"X-Azure-ClientIP",
+	"X-Azure-SocketIP",
+}
+
+// IsLocalOriginRequest reports whether req provably originates from this host, and is
+// the check to use when an endpoint is gated on "local access only".
+//
+// A loopback RemoteAddr on its own does not prove local origin: when CliRelay sits
+// behind a same-host reverse proxy, the direct TCP peer is that proxy, so every
+// external request arrives from 127.0.0.1. This function therefore requires both a
+// loopback peer and the absence of any relay header, and fails closed on addresses it
+// cannot parse.
+//
+// Known limitation: a relay that rewrites nothing — nginx `stream`, HAProxy in TCP
+// mode, socat, an iptables DNAT rule, `cloudflared --url http://127.0.0.1:...` — is
+// indistinguishable from a local client at the HTTP layer. Endpoints that must hold
+// against those need their own credential, not just this check.
+func IsLocalOriginRequest(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	peer := net.ParseIP(RemoteAddrIP(req.RemoteAddr))
+	if peer == nil || !peer.IsLoopback() {
+		return false
+	}
+	return !hasRelayIndication(req.Header)
+}
+
+// RelayIndicationHeader returns the first relay header present on the request, for
+// logging why a request was not treated as local. It returns "" when none is set.
+func RelayIndicationHeader(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+	return firstRelayIndicationHeader(req.Header)
+}
+
+func hasRelayIndication(headers http.Header) bool {
+	return firstRelayIndicationHeader(headers) != ""
+}
+
+func firstRelayIndicationHeader(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+	for _, header := range relayIndicationHeaders {
+		for _, value := range headers.Values(header) {
+			if strings.TrimSpace(value) != "" {
+				return header
+			}
+		}
+	}
+	return ""
+}
+
 // RemoteAddrIP extracts and normalizes the IP part of net/http Request.RemoteAddr.
 func RemoteAddrIP(remoteAddr string) string {
 	remoteAddr = strings.TrimSpace(remoteAddr)

--- a/internal/util/client_ip_test.go
+++ b/internal/util/client_ip_test.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsLocalOriginRequestAcceptsDirectLoopbackPeers(t *testing.T) {
+	for _, remoteAddr := range []string{
+		"127.0.0.1:54321",
+		"127.0.0.2:54321",
+		"[::1]:54321",
+		"[::ffff:127.0.0.1]:54321",
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", nil)
+		req.RemoteAddr = remoteAddr
+		if !IsLocalOriginRequest(req) {
+			t.Errorf("RemoteAddr %q: IsLocalOriginRequest() = false, want true", remoteAddr)
+		}
+	}
+}
+
+func TestIsLocalOriginRequestRejectsNonLoopbackPeers(t *testing.T) {
+	for _, remoteAddr := range []string{
+		"203.0.113.10:54321",
+		"172.17.0.1:54321",
+		"[2001:db8::1]:54321",
+		"",
+		"not-an-address",
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", nil)
+		req.RemoteAddr = remoteAddr
+		if IsLocalOriginRequest(req) {
+			t.Errorf("RemoteAddr %q: IsLocalOriginRequest() = true, want false", remoteAddr)
+		}
+	}
+}
+
+// The reverse-proxy bypass from issue #517: the peer is the local proxy, so RemoteAddr
+// looks local even though the original client is external.
+func TestIsLocalOriginRequestRejectsRelayedLoopbackPeers(t *testing.T) {
+	cases := []struct {
+		header string
+		value  string
+	}{
+		{"X-Forwarded-For", "203.0.113.42"},
+		{"X-Forwarded-For", "127.0.0.1, 203.0.113.42"},
+		{"X-Forwarded-For", "127.0.0.1"},
+		{"X-Real-IP", "203.0.113.42"},
+		{"X-Forwarded-Proto", "https"},
+		{"X-Forwarded-Host", "relay.example.com"},
+		{"Forwarded", "for=203.0.113.42;proto=https"},
+		{"Via", "1.1 nginx"},
+		{"CF-Connecting-IP", "203.0.113.42"},
+		{"CF-Ray", "8a1b2c3d4e5f6789-LAX"},
+		{"True-Client-IP", "203.0.113.42"},
+		{"X-Client-IP", "203.0.113.42"},
+		{"X-Cluster-Client-IP", "203.0.113.42"},
+		{"X-Original-Forwarded-For", "203.0.113.42"},
+		{"Fastly-Client-IP", "203.0.113.42"},
+		{"X-Envoy-External-Address", "203.0.113.42"},
+		{"X-Azure-ClientIP", "203.0.113.42"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", nil)
+		req.RemoteAddr = "127.0.0.1:54321"
+		req.Header.Set(tc.header, tc.value)
+		if IsLocalOriginRequest(req) {
+			t.Errorf("%s: %q: IsLocalOriginRequest() = true, want false", tc.header, tc.value)
+		}
+		if got := RelayIndicationHeader(req); got != tc.header {
+			t.Errorf("%s: RelayIndicationHeader() = %q, want %q", tc.header, got, tc.header)
+		}
+	}
+}
+
+// A header present but empty carries no relay signal; rejecting on it would break local
+// clients that send blank headers.
+func TestIsLocalOriginRequestIgnoresBlankRelayHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "   ")
+	if !IsLocalOriginRequest(req) {
+		t.Error("blank X-Forwarded-For: IsLocalOriginRequest() = false, want true")
+	}
+	if got := RelayIndicationHeader(req); got != "" {
+		t.Errorf("blank X-Forwarded-For: RelayIndicationHeader() = %q, want empty", got)
+	}
+}
+
+func TestIsLocalOriginRequestRejectsNilRequest(t *testing.T) {
+	if IsLocalOriginRequest(nil) {
+		t.Error("IsLocalOriginRequest(nil) = true, want false")
+	}
+	if got := RelayIndicationHeader(nil); got != "" {
+		t.Errorf("RelayIndicationHeader(nil) = %q, want empty", got)
+	}
+}

--- a/sdk/api/handlers/gemini/gemini-cli_handlers.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -52,8 +51,19 @@ func (h *GeminiCLIAPIHandler) Models() []map[string]any {
 
 // CLIHandler handles CLI-specific requests for Gemini API operations.
 // It restricts access to localhost only and routes requests to appropriate internal handlers.
+//
+// This route carries no API key of its own (it is not registered under an authenticated
+// route group), so the local-origin check below is the only thing standing between a
+// caller and the server's Gemini credential pool. It must stay fail-closed.
 func (h *GeminiCLIAPIHandler) CLIHandler(c *gin.Context) {
-	if !strings.HasPrefix(c.Request.RemoteAddr, "127.0.0.1:") {
+	if !util.IsLocalOriginRequest(c.Request) {
+		// Logged because this endpoint is scanned for in the wild and a silent 403
+		// leaves operators with no signal that someone is probing it.
+		if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" {
+			log.Warnf("gemini cli: rejected non-local request from %s (relayed via %s header); configure trusted-proxies and keep /v1internal off public reverse proxies", c.Request.RemoteAddr, relayHeader)
+		} else {
+			log.Warnf("gemini cli: rejected non-local request from %s", c.Request.RemoteAddr)
+		}
 		c.JSON(http.StatusForbidden, handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{
 				Message: "CLI reply only allow local access",

--- a/sdk/api/handlers/gemini/gemini-cli_handlers_test.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers_test.go
@@ -1,0 +1,94 @@
+package gemini
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newCLITestRouter wires CLIHandler exactly as routes_public.go does: a single
+// wildcard route on the engine root, outside every authenticated route group. A nil
+// BaseAPIHandler is safe here because every case in this file is rejected by the
+// local-origin gate before the handler touches its dependencies.
+func newCLITestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/v1internal:method", NewGeminiCLIAPIHandler(nil).CLIHandler)
+	return router
+}
+
+// Issue #517: behind a same-host reverse proxy the TCP peer is the proxy, so the old
+// RemoteAddr prefix check let external callers reach the credential pool.
+func TestCLIHandlerRejectsReverseProxiedRequests(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		value  string
+	}{
+		{"external forwarded client", "X-Forwarded-For", "203.0.113.42"},
+		{"spoofed loopback first hop", "X-Forwarded-For", "127.0.0.1, 203.0.113.42"},
+		{"forwarded rfc7239", "Forwarded", "for=203.0.113.42;proto=https"},
+		{"cloudflare", "CF-Connecting-IP", "203.0.113.42"},
+		{"proxy hop marker only", "Via", "1.1 nginx"},
+		{"tls terminated upstream", "X-Forwarded-Proto", "https"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := newCLITestRouter()
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", strings.NewReader(`{}`))
+			req.RemoteAddr = "127.0.0.1:54321"
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(tc.header, tc.value)
+			router.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusForbidden, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), "only allow local access") {
+				t.Fatalf("body = %s, want local-access rejection", rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestCLIHandlerRejectsNonLoopbackPeers(t *testing.T) {
+	router := newCLITestRouter()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", strings.NewReader(`{}`))
+	req.RemoteAddr = "203.0.113.10:54321"
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+}
+
+// A genuine local CLI must still get past the gate. It fails later (nil dependencies),
+// so the assertion is only that it was not rejected as non-local.
+func TestCLIHandlerAcceptsDirectLoopbackPeers(t *testing.T) {
+	for _, remoteAddr := range []string{"127.0.0.1:54321", "[::1]:54321"} {
+		t.Run(remoteAddr, func(t *testing.T) {
+			router := newCLITestRouter()
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", strings.NewReader(`{}`))
+			req.RemoteAddr = remoteAddr
+			req.Header.Set("Content-Type", "application/json")
+
+			defer func() {
+				// Reaching a nil-dependency panic proves the request passed the gate,
+				// which is what this test is about.
+				_ = recover()
+			}()
+			router.ServeHTTP(rr, req)
+
+			if rr.Code == http.StatusForbidden && strings.Contains(rr.Body.String(), "only allow local access") {
+				t.Fatalf("loopback peer %s was rejected as non-local: %s", remoteAddr, rr.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 问题

两处代码把「TCP peer 是 loopback」当作「请求来自本机」，在同机反向代理部署下，直连 peer 是代理本身，外部请求因此被判定为本地。

**1. Gemini CLI 内部路由（issue #517）**

`sdk/api/handlers/gemini/gemini-cli_handlers.go` 原判定为 `strings.HasPrefix(c.Request.RemoteAddr, "127.0.0.1:")`。该路由注册在 engine 根上（`internal/api/routes_public.go:133`），**不在任何带 `AuthMiddleware` 的 route group 内**，因此这个字符串前缀比较是保护服务端 Gemini 账号池的唯一访问控制。报告者已被扫描并盗刷一周。顺带修掉了 IPv6 loopback（`::1`、`::ffff:127.0.0.1`）被误拒的老问题。

**2. Management 中间件（同根因，与 issue #404 现象吻合）**

`internal/api/handlers/management/handler.go` 的 `localClient := clientIP == "127.0.0.1" || clientIP == "::1"`。`trusted-proxies` 默认为空 → `configureTrustedProxies` 调用 `SetTrustedProxies(nil)` → gin 的 `ClientIP()` 退化为 `RemoteAddr` → 同机反代后**所有**外部请求都被判为 `localClient`，后果有三项：

- 绕过 `remote-management.allow-remote=false` 的「remote management disabled」拒绝；
- 打开 local-password 认证路径（该路径无需任何 remote secret）；
- **完全跳过按 IP 的登录失败节流与封禁**（`fail`/`isBanned`/`clearFailures` 只在 `!localClient` 时安装），即反代后可无限爆破 management key。

这解释了 #404 报告的「外部 IP 访问 `/v0/management/config.yaml`、`/auth-files/download` 返回 200 而非 401/403」。

## 修复

在 `internal/util/client_ip.go` 新增 `IsLocalOriginRequest`：要求直连 peer 是 loopback **且**不存在任何中继头，地址解析失败即 fail closed。中继头清单比 `ForwardedClientIP` 的优先级列表更宽——这里只需知道「有中继经手」，所以不携带客户端 IP 的头（`Via`、`X-Forwarded-Proto`、`CF-Ray`）与携带的同样有结论性，而漏掉一个头就是一条绕过路径。

两个调用点都改用该 helper，并复用已有的 `RemoteAddrIP` / `normalizeIPCandidate`，未复制解析逻辑。

- Gemini CLI 拒绝时补 `log.Warnf`（含触发的中继头名）。该端点正在被扫描，静默 403 让运维毫无信号——报告者「被盗刷一周才发现」正说明缺可观测性。
- Management 的 allow-remote 拒绝信息改为可操作：**本修复会正确地开始拒绝此前能用的部署**（反代 + `allow-remote=false` + 未配 `trusted-proxies`），因此提示同时给出两条出路——设 `allow-remote=true`，或把代理加入 `trusted-proxies` 以恢复真实客户端 IP。

### 已知局限（已写入 helper 文档注释）

不改写任何头的中继——nginx `stream`、HAProxy TCP 模式、socat、iptables DNAT、`cloudflared --url http://127.0.0.1:...`——在 HTTP 层与本地客户端不可区分，仍会通过。需要抵御这类场景的端点应当有自己的凭据，而不是只依赖本检查。`/v1internal:*` 目前无 API key 认证属于更根本的设计问题，建议单独开 issue 跟踪，本 PR 不扩大范围。

## 验证

已确认新测试在修复前的代码上**确实失败**（关键：测试用 `SetTrustedProxies(nil)` 复现生产默认配置，`gin.New()` 默认信任所有代理，不设置就测不出漏洞）：

```
--- FAIL: TestMiddlewareRejectsRelayedRequestWhenRemoteDisabled
    relayed request status = 200, want 403; body=ok
--- FAIL: TestMiddlewareRejectsRelayedRequestUsingLocalPassword
    relayed request authenticated with the local password; body=ok
--- FAIL: TestMiddlewareThrottlesRelayedFailedAttempts
    relayed brute-force attempts were never throttled
```

新增测试：
- `internal/util/client_ip_test.go`（新文件）：直连 loopback 接受、非 loopback 拒绝、17 种中继头拒绝、空白头不误判、nil 请求 fail closed。
- `sdk/api/handlers/gemini/gemini-cli_handlers_test.go`（新文件，该包首个测试）：6 种反代场景 403、非 loopback peer 403、真实本地 CLI 仍放行。
- `internal/api/handlers/management/handler_test.go`：上述三项回归 + 直连 loopback 本地密码仍可用。

本地执行完整 `./scripts/ci-pr.sh`，**退出码 0**（含 secret scan、`check-backend-structure.py` → `Result: passed`、`gofmt`、`go vet ./...`、`go test ./...`、`golangci-lint run`、`go build ./cmd/server`）。属 auth/security 高风险变更，按 AGENTS.md 要求跑了完整门禁。

影响目录：仅 `CliRelay/`，不涉及 `codeProxy/`。

Refs #517, #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)