### PR TITLE
fix(config): 修复面板保存把 config.yaml 拼接损坏（#748）

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -341,21 +341,14 @@ func (h *Handler) GetLatestVersion(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"latest-version": version})
 }
 
+// WriteConfig replaces config.yaml with data. It shares the atomic write and the
+// process-wide write lock with every other config.yaml writer; an in-place truncating
+// write here could splice the file against a concurrent save.
 func WriteConfig(path string, data []byte) error {
-	data = config.NormalizeCommentIndentation(data)
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	if _, errWrite := f.Write(data); errWrite != nil {
-		_ = f.Close()
-		return errWrite
-	}
-	if errSync := f.Sync(); errSync != nil {
-		_ = f.Close()
-		return errSync
-	}
-	return f.Close()
+	normalized := config.NormalizeCommentIndentation(data)
+	return config.WithConfigFileWriteLock(func() error {
+		return config.WriteYAMLFileAtomic(path, normalized)
+	})
 }
 
 func (h *Handler) PutConfigYAML(c *gin.Context) {

--- a/internal/config/yaml_atomic.go
+++ b/internal/config/yaml_atomic.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"gopkg.in/yaml.v3"
+)
+
+// configFileWriteMu serializes read-modify-write cycles against config.yaml.
+//
+// A process-wide mutex rather than a per-path one: a process owns exactly one
+// config.yaml, and several independent subsystems rewrite it — management handlers,
+// the DB-backed section cleanup in internal/usage, and the config watcher's reload
+// chain. Those paths do not share a handler lock (the watcher chain holds none, and
+// the management onConfigMutated hook runs after the handler releases h.mu), so the
+// lock has to live below all of them.
+//
+// It must wrap the whole read-modify-write cycle, not just the write: two writers that
+// each read the file first would otherwise still lose one side's changes.
+var configFileWriteMu sync.Mutex
+
+// WithConfigFileWriteLock runs fn while holding the config.yaml write lock. Every
+// code path that rewrites config.yaml must go through this, otherwise it can
+// interleave with the others and corrupt or clobber the file.
+func WithConfigFileWriteLock(fn func() error) error {
+	if fn == nil {
+		return nil
+	}
+	configFileWriteMu.Lock()
+	defer configFileWriteMu.Unlock()
+	return fn()
+}
+
+// WriteYAMLFileAtomic replaces path with data via a temporary file and rename.
+//
+// This exists because in-place truncating writes (os.Create / O_TRUNC) corrupt the
+// file when two of them overlap: both write from offset 0 into the same inode, the
+// shorter write leaves the longer one's tail behind, and the result is a spliced file
+// whose seam usually lands mid-line. A rename publishes the new contents in one step,
+// so a reader or a competing writer never observes a partial file.
+//
+// data is re-parsed before anything is published: writing YAML that cannot be read
+// back bricks the config for every later save, so it is worth rejecting up front.
+func WriteYAMLFileAtomic(path string, data []byte) error {
+	return writeYAMLFileAtomicWithRename(path, data, os.Rename)
+}
+
+// writeYAMLFileAtomicWithRename takes the rename function so tests can exercise the
+// EBUSY/EXDEV fallback that bind mounts hit.
+func writeYAMLFileAtomicWithRename(path string, data []byte, renameFile func(string, string) error) error {
+	var probe yaml.Node
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("refusing to write unparseable YAML to %s: %w", path, err)
+	}
+
+	// Preserve the existing permissions; fall back to owner-only for a new file.
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if renameFile == nil {
+		renameFile = os.Rename
+	}
+	if err := renameFile(tmpPath, path); err != nil {
+		// Bind mounts and cross-device layouts (Docker, some NAS setups) can reject
+		// rename. Falling back to an in-place write keeps those deployments working;
+		// the write lock is what protects it from interleaving.
+		if isAtomicReplaceUnsupported(err) {
+			if fallbackErr := writeFileInPlace(path, data, mode); fallbackErr != nil {
+				return fmt.Errorf("atomic replace failed: %w; in-place write failed: %w", err, fallbackErr)
+			}
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func isAtomicReplaceUnsupported(err error) bool {
+	return errors.Is(err, syscall.EBUSY) || errors.Is(err, syscall.EXDEV)
+}
+
+func writeFileInPlace(path string, data []byte, mode os.FileMode) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}

--- a/internal/config/yaml_atomic_test.go
+++ b/internal/config/yaml_atomic_test.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Issue #748: two overlapping saves used to splice config.yaml. Both wrote from offset 0
+// into the same inode via os.Create (O_TRUNC), so the shorter write left the longer
+// write's tail behind. In config.example.yaml that tail lands inside the big commented
+// payload example, which is why the reported artifact was the back half of a long
+// comment line with its leading '#' gone, followed by a duplicated "# filter:" block.
+//
+// The size delta between the two rendered configs is what sets the splice point, so the
+// test manufactures one deliberately.
+func TestConcurrentSavesNeverCorruptConfig(t *testing.T) {
+	example, err := os.ReadFile(filepath.Join("..", "..", "config.example.yaml"))
+	if err != nil {
+		t.Fatalf("read config.example.yaml: %v", err)
+	}
+
+	const iterations = 40
+	for i := 0; i < iterations; i++ {
+		configPath := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(configPath, example, 0o600); err != nil {
+			t.Fatalf("seed config: %v", err)
+		}
+
+		short, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		long, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		// Make the two renderings differ in length by a few hundred bytes.
+		short.OpenAICompatibility = nil
+		short.APIKeys = nil
+		long.APIKeys = append(long.APIKeys, strings.Repeat("x", 470))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = SaveConfigPreserveComments(configPath, short)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = SaveConfigPreserveComments(configPath, long)
+		}()
+		wg.Wait()
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("read config after concurrent saves: %v", err)
+		}
+		var parsed yaml.Node
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("iteration %d: config.yaml is unparseable after concurrent saves: %v", i, err)
+		}
+		// A splice duplicates whatever followed the seam, so a repeated unique example
+		// comment is corruption even when the result still happens to parse.
+		if got := strings.Count(string(data), "#   filter: # Filter rules remove specified parameters from the payload."); got > 1 {
+			t.Fatalf("iteration %d: filter example comment appears %d times, want at most 1", i, got)
+		}
+	}
+}
+
+// The nested-scalar writer shares the same lock, so it must not splice against a full
+// save either.
+func TestConcurrentNestedScalarSaveNeverCorruptsConfig(t *testing.T) {
+	example, err := os.ReadFile(filepath.Join("..", "..", "config.example.yaml"))
+	if err != nil {
+		t.Fatalf("read config.example.yaml: %v", err)
+	}
+
+	for i := 0; i < 40; i++ {
+		configPath := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(configPath, example, 0o600); err != nil {
+			t.Fatalf("seed config: %v", err)
+		}
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		cfg.APIKeys = append(cfg.APIKeys, strings.Repeat("y", 512))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = SaveConfigPreserveComments(configPath, cfg)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = SaveConfigPreserveCommentsUpdateNestedScalar(configPath, []string{"remote-management", "secret-key"}, "rotated-secret")
+		}()
+		wg.Wait()
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("read config: %v", err)
+		}
+		var parsed yaml.Node
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("iteration %d: config.yaml is unparseable: %v", i, err)
+		}
+	}
+}
+
+func TestWriteYAMLFileAtomicRejectsUnparseableYAML(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	const original = "port: 8317\n"
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// The exact shape issue #748 produced: a stray unquoted JSON fragment.
+	broken := []byte("port: 8317\n\":{\\\"name\\\":\\\"answer\\\"}}}\"\n")
+	if err := WriteYAMLFileAtomic(configPath, broken); err == nil {
+		t.Fatal("WriteYAMLFileAtomic accepted unparseable YAML, want error")
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("config was modified by a rejected write:\n%s", string(data))
+	}
+}
+
+func TestWriteYAMLFileAtomicPreservesPermissions(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8317\n"), 0o640); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	if err := WriteYAMLFileAtomic(configPath, []byte("port: 8318\n")); err != nil {
+		t.Fatalf("WriteYAMLFileAtomic: %v", err)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("mode = %o, want 640", got)
+	}
+}
+
+// Bind mounts and cross-device layouts (Docker, some NAS setups) reject rename; those
+// deployments must keep working via the in-place fallback.
+func TestWriteYAMLFileAtomicFallsBackWhenRenameUnsupported(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("routing:\n  strategy: round-robin\n"), 0o640); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	renameCalled := false
+	err := writeYAMLFileAtomicWithRename(configPath, []byte("port: 8318\nlogging-to-file: true\n"), func(oldPath, newPath string) error {
+		renameCalled = true
+		if filepath.Dir(oldPath) != filepath.Dir(configPath) {
+			t.Fatalf("temp file dir = %s, want %s", filepath.Dir(oldPath), filepath.Dir(configPath))
+		}
+		if newPath != configPath {
+			t.Fatalf("rename target = %s, want %s", newPath, configPath)
+		}
+		return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: syscall.EBUSY}
+	})
+	if err != nil {
+		t.Fatalf("writeYAMLFileAtomicWithRename returned error: %v", err)
+	}
+	if !renameCalled {
+		t.Fatal("rename was not attempted")
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if got := string(data); strings.Contains(got, "routing:") || !strings.Contains(got, "logging-to-file: true") {
+		t.Fatalf("config was not rewritten in place:\n%s", got)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("mode = %o, want 640", got)
+	}
+}

--- a/internal/config/yaml_save.go
+++ b/internal/config/yaml_save.go
@@ -10,7 +10,18 @@ import (
 
 // SaveConfigPreserveComments writes the config back to YAML while preserving existing comments
 // and key ordering by loading the original file into a yaml.Node tree and updating values in-place.
+//
+// The whole read-modify-write cycle runs under the config.yaml write lock: this function
+// re-reads the file to recover its comments, so an overlapping writer would otherwise
+// have its changes dropped, and before the switch to an atomic write two overlapping
+// calls could splice the file into unparseable YAML.
 func SaveConfigPreserveComments(configFile string, cfg *Config) error {
+	return WithConfigFileWriteLock(func() error {
+		return saveConfigPreserveCommentsLocked(configFile, cfg)
+	})
+}
+
+func saveConfigPreserveCommentsLocked(configFile string, cfg *Config) error {
 	persistCfg := cfg
 	data, err := os.ReadFile(configFile)
 	if err != nil {
@@ -54,11 +65,6 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 	mergeMappingPreserve(original.Content[0], generated.Content[0])
 	normalizeCollectionNodeStyles(original.Content[0])
 
-	f, err := os.Create(configFile)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
@@ -69,14 +75,18 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 	if err = enc.Close(); err != nil {
 		return err
 	}
-	data = NormalizeCommentIndentation(buf.Bytes())
-	_, err = f.Write(data)
-	return err
+	return WriteYAMLFileAtomic(configFile, NormalizeCommentIndentation(buf.Bytes()))
 }
 
 // SaveConfigPreserveCommentsUpdateNestedScalar updates a nested scalar key path like ["a","b"]
 // while preserving comments and positions.
 func SaveConfigPreserveCommentsUpdateNestedScalar(configFile string, path []string, value string) error {
+	return WithConfigFileWriteLock(func() error {
+		return saveConfigPreserveCommentsUpdateNestedScalarLocked(configFile, path, value)
+	})
+}
+
+func saveConfigPreserveCommentsUpdateNestedScalarLocked(configFile string, path []string, value string) error {
 	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return err
@@ -104,11 +114,6 @@ func SaveConfigPreserveCommentsUpdateNestedScalar(configFile string, path []stri
 			node = next
 		}
 	}
-	f, err := os.Create(configFile)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
@@ -119,9 +124,7 @@ func SaveConfigPreserveCommentsUpdateNestedScalar(configFile string, path []stri
 	if err = enc.Close(); err != nil {
 		return err
 	}
-	data = NormalizeCommentIndentation(buf.Bytes())
-	_, err = f.Write(data)
-	return err
+	return WriteYAMLFileAtomic(configFile, NormalizeCommentIndentation(buf.Bytes()))
 }
 
 // NormalizeCommentIndentation removes indentation from standalone YAML comment lines to keep them left aligned.

--- a/internal/usage/config_yaml_cleanup.go
+++ b/internal/usage/config_yaml_cleanup.go
@@ -2,13 +2,10 @@ package usage
 
 import (
 	"bytes"
-	"errors"
-	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
-	"syscall"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -115,10 +112,28 @@ func cleanRuntimeSettingsFromYAML(configFilePath string) {
 	}, "runtime_settings")
 }
 
+// cleanConfigKeysFromYAML strips the given root keys from config.yaml. It runs under
+// the shared config.yaml write lock: the cleanup is itself a read-modify-write cycle,
+// and it is triggered both directly after management saves and from the watcher reload
+// chain, so without the lock it can interleave with a management save and drop one
+// side's changes.
 func cleanConfigKeysFromYAML(configFilePath string, keysToRemove map[string]bool, label string) int {
 	if strings.TrimSpace(configFilePath) == "" || len(keysToRemove) == 0 {
 		return 0
 	}
+	removed := 0
+	err := config.WithConfigFileWriteLock(func() error {
+		removed = cleanConfigKeysFromYAMLLocked(configFilePath, keysToRemove, label)
+		return nil
+	})
+	if err != nil {
+		log.Warnf("usage: failed to acquire config write lock for %s cleanup: %v", label, err)
+		return 0
+	}
+	return removed
+}
+
+func cleanConfigKeysFromYAMLLocked(configFilePath string, keysToRemove map[string]bool, label string) int {
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		log.Warnf("usage: failed to read config for %s cleanup: %v", label, err)
@@ -161,11 +176,9 @@ func cleanConfigKeysFromYAML(configFilePath string, keysToRemove map[string]bool
 	return removed
 }
 
+// writeYAMLNodeAtomic encodes root and hands it to the shared atomic writer in
+// internal/config, so every config.yaml write goes through one implementation.
 func writeYAMLNodeAtomic(configFilePath string, root *yaml.Node) error {
-	return writeYAMLNodeAtomicWithRename(configFilePath, root, os.Rename)
-}
-
-func writeYAMLNodeAtomicWithRename(configFilePath string, root *yaml.Node, renameFile func(string, string) error) error {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
@@ -176,67 +189,5 @@ func writeYAMLNodeAtomicWithRename(configFilePath string, root *yaml.Node, renam
 	if err := enc.Close(); err != nil {
 		return err
 	}
-
-	mode := os.FileMode(0o600)
-	if info, err := os.Stat(configFilePath); err == nil {
-		mode = info.Mode().Perm()
-	}
-
-	dir := filepath.Dir(configFilePath)
-	base := filepath.Base(configFilePath)
-	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer func() { _ = os.Remove(tmpPath) }()
-
-	if err := tmp.Chmod(mode); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(buf.Bytes()); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if renameFile == nil {
-		renameFile = os.Rename
-	}
-	if err := renameFile(tmpPath, configFilePath); err != nil {
-		if isAtomicYAMLReplaceUnsupported(err) {
-			if errFallback := writeYAMLFileInPlace(configFilePath, buf.Bytes(), mode); errFallback != nil {
-				return fmt.Errorf("atomic replace failed: %w; in-place write failed: %w", err, errFallback)
-			}
-			return nil
-		}
-		return err
-	}
-	return nil
-}
-
-func isAtomicYAMLReplaceUnsupported(err error) bool {
-	return errors.Is(err, syscall.EBUSY) || errors.Is(err, syscall.EXDEV)
-}
-
-func writeYAMLFileInPlace(path string, data []byte, mode os.FileMode) error {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
-	if err != nil {
-		return err
-	}
-	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		return err
-	}
-	if err := file.Sync(); err != nil {
-		_ = file.Close()
-		return err
-	}
-	return file.Close()
+	return config.WriteYAMLFileAtomic(configFilePath, buf.Bytes())
 }

--- a/internal/usage/config_yaml_cleanup_test.go
+++ b/internal/usage/config_yaml_cleanup_test.go
@@ -5,11 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
-	"gopkg.in/yaml.v3"
 	_ "modernc.org/sqlite"
 )
 
@@ -138,51 +136,6 @@ func TestCleanDBBackedConfigFromYAMLCleansPersistedSections(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o640 {
 		t.Fatalf("cleaned config mode = %o, want 640", got)
-	}
-}
-
-func TestWriteYAMLNodeAtomicFallsBackWhenRenameTargetBusy(t *testing.T) {
-	configPath := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(configPath, []byte("routing:\n  strategy: round-robin\n"), 0o640); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-
-	var root yaml.Node
-	if err := yaml.Unmarshal([]byte("port: 8318\nlogging-to-file: true\n"), &root); err != nil {
-		t.Fatalf("parse yaml: %v", err)
-	}
-
-	renameCalled := false
-	err := writeYAMLNodeAtomicWithRename(configPath, &root, func(oldPath, newPath string) error {
-		renameCalled = true
-		if filepath.Dir(oldPath) != filepath.Dir(configPath) {
-			t.Fatalf("temp file dir = %s, want %s", filepath.Dir(oldPath), filepath.Dir(configPath))
-		}
-		if newPath != configPath {
-			t.Fatalf("rename target = %s, want %s", newPath, configPath)
-		}
-		return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: syscall.EBUSY}
-	})
-	if err != nil {
-		t.Fatalf("writeYAMLNodeAtomicWithRename returned error: %v", err)
-	}
-	if !renameCalled {
-		t.Fatal("rename was not attempted")
-	}
-
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read config: %v", err)
-	}
-	if got := string(data); strings.Contains(got, "routing:") || !strings.Contains(got, "logging-to-file: true") {
-		t.Fatalf("config was not rewritten in place:\n%s", got)
-	}
-	info, err := os.Stat(configPath)
-	if err != nil {
-		t.Fatalf("stat config: %v", err)
-	}
-	if got := info.Mode().Perm(); got != 0o640 {
-		t.Fatalf("config mode = %o, want 640", got)
 	}
 }
 


### PR DESCRIPTION
## 问题

从管理面板保存配置会把 `config.yaml` 拼接成无法解析的 YAML，之后**每一次**保存都失败于 `yaml: line N: could not find expected ':'`——除非手工修文件，否则面板再也无法持久化任何改动（issue #748）。

报告者提供的损坏现场（第 415 行是一段丢了 `#` 前缀的未注释 JSON 碎片，且 `# filter:` 示例块出现两次）已完整对上根因。

## 根因

`SaveConfigPreserveComments`（`internal/config/yaml_save.go:57`）与 `management.WriteConfig`（`config_basic.go:346`）都用 **O_TRUNC 原地写**（`os.Create` / `os.OpenFile`）。两个重叠的 writer 各自从 offset 0 写入**同一个 inode**：后完成的写决定 `[0, N_last)`，但文件长度是 `max(N_a, N_b)`，于是 `[N_last, N_max)` 是**另一个 writer 残留的尾部**。

在由 `config.example.yaml` 生成的配置里，这段尾部正好落在大段被注释的 `payload:` 示例中间——所以碎片的起点在一条长注释行内部（`#` 属于已被覆盖的字节，因此消失），紧随其后的注释行被重复，`# filter:` 块出现两次。**报告的两个症状是同一次拼接的产物**，碎片长度等于两次渲染的体积差。

重叠的 writer 不是偶发，而是设计必然产生的：

1. 每次保存写**两次**且体积差很大——`SaveConfigPreserveComments` 经 `mergeMappingPreserve` 把 DB-backed 的键重新补回 YAML，`CleanDBBackedConfigFromYAML` 随即再剥掉（日志里每轮都出现的 `removed N DB-backed config section(s)` 就是它）；
2. 每次写都触发 fsnotify → 150ms debounce 的 reload，而 reload 自身又会写最多 4 次（`load.go` 的 stable-ID 迁移 + `runtime_access.go` 的 3 次 cleanup）；
3. `reloadConfigIfChanged` 在 goroutine 间**可重入**（timer 在回调执行前就被清空），加上管理端 `onConfigMutated` 钩子在 `h.mu` 释放**之后**才跑，因此 3～4 个 writer 可以同时在写。

这也解释了报告者日志里「同一秒内多轮 cleanup 重写」，以及「损坏后 PUT 仍 200 而 PATCH 500」——DB-only 的 `PersistRuntimeSetting` 路径把同一个解析错误吞在 cleanup 的 `Warnf` 里仍返回 200。

## 修复

新增 `internal/config/yaml_atomic.go`：

- **`WriteYAMLFileAtomic`**：temp file + rename，内容一步发布，读者与竞争 writer 永远看不到半个文件——这从根本上消除了"拼接"这一失败模式。保留 EBUSY/EXDEV 的原地写回退（Docker bind mount、部分 NAS 布局会拒绝 rename），并保留原文件权限。
- **写前 re-parse 校验**：落盘前先 `yaml.Unmarshal` 验证。写出读不回来的 YAML 会让后续每次保存都失败，值得在源头拒绝。
- **`WithConfigFileWriteLock`**：一把进程级锁，包住**整个 read-modify-write 周期**而不只是写那一刻——两个各自先读文件的 writer 否则仍会丢掉一侧的改动。锁放在 `internal/config` 是因为它必须位于所有 writer 之下：watcher 链完全不持有任何 handler 锁。

所有写 `config.yaml` 的路径都接入：`yaml_save.go` 的两个函数、management `WriteConfig`、以及 `internal/usage` 的 cleanup。`internal/usage` 里那份重复的原子写实现改为委托给共享实现，全仓库只剩一份；它的 EBUSY 回退测试随之迁到 `internal/config`。

## 验证

已确认回归测试在修复前的代码上**确实失败，且第一次迭代就复现报告的症状**：

```
--- FAIL: TestConcurrentSavesNeverCorruptConfig
    iteration 0: config.yaml is unparseable after concurrent saves:
    yaml: line 473: could not find expected ':'
```

与 issue 报告的 `yaml: line 415: could not find expected ':'` 是同一错误形态。

新增测试（`internal/config/yaml_atomic_test.go`）：
- 并发保存 40 轮后 YAML 仍可解析，且唯一的 `# filter:` 示例注释不出现两次（拼接会复制接缝之后的内容，即使侥幸能解析也算损坏）；
- 全量保存与嵌套 scalar 保存并发同样不损坏；
- 不可解析的 YAML 被拒绝且**原文件不被修改**（用的正是 #748 那种未注释 JSON 碎片）；
- 权限保留；EBUSY 时回退原地写。

本地执行完整 `./scripts/ci-pr.sh`，**退出码 0**（含 `check-backend-structure.py` → `Result: passed`、`gofmt`、`go vet ./...`、`go test ./...`、`golangci-lint run`、`go build ./cmd/server`）。另外对 `internal/config`、`internal/usage` 跑了 `go test -race`，无数据竞争。

## 未纳入本 PR

save → watch → save 的自激反馈循环仍会让每次保存重写文件多次。那是 churn 与无谓 I/O 问题，不再导致损坏（原子写已保证每次发布都是完整文件），根治它需要改 `mergeMappingPreserve` 的 DB-backed 键回填语义或 reload 的 hash 记账，属于独立根因，不在本 PR 范围。

影响目录：仅 `CliRelay/`，不涉及 `codeProxy/`。

Fixes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)