### PR TITLE
fix(deploy): 修复全新 Compose 部署因 admin 密码不合规而启动失败

### DIFF
--- a/compose_init_env_test.go
+++ b/compose_init_env_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 )
 
 func TestComposeInitEnvGeneratesMissingEnv(t *testing.T) {
@@ -45,8 +47,11 @@ func TestComposeInitEnvGeneratesMissingEnv(t *testing.T) {
 	if len(values["CLIRELAY_UPDATER_TOKEN"]) != 32 {
 		t.Fatalf("updater token length = %d, want 32", len(values["CLIRELAY_UPDATER_TOKEN"]))
 	}
-	if len(values["CLIRELAY_ADMIN_PASSWORD"]) != 32 {
-		t.Fatalf("admin password length = %d, want 32", len(values["CLIRELAY_ADMIN_PASSWORD"]))
+	// The admin password carries 32 hex characters of entropy plus the character
+	// classes the identity bootstrap requires, so only the lower bound is asserted
+	// here; TestComposeInitEnvAdminPasswordPassesIdentityValidation checks usability.
+	if len(values["CLIRELAY_ADMIN_PASSWORD"]) < 32 {
+		t.Fatalf("admin password length = %d, want at least 32", len(values["CLIRELAY_ADMIN_PASSWORD"]))
 	}
 	if len(values["CLIRELAY_POSTGRES_PASSWORD"]) != 32 {
 		t.Fatalf("postgres password length = %d, want 32", len(values["CLIRELAY_POSTGRES_PASSWORD"]))
@@ -156,4 +161,31 @@ func readEnvFile(t *testing.T, path string) map[string]string {
 		}
 	}
 	return values
+}
+
+// Proves the generated admin password is actually usable: the compose bootstrap feeds
+// CLIRELAY_ADMIN_PASSWORD straight into identity.HashPassword on a fresh database, so a
+// value that fails its character-class checks makes first startup crash.
+func TestComposeInitEnvAdminPasswordPassesIdentityValidation(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+
+	cmd := exec.Command("sh", "scripts/init-compose-env.sh")
+	cmd.Env = append(os.Environ(),
+		"CLIRELAY_ENV_FILE="+envFile,
+		"CLIRELAY_PROJECT_DIR="+dir,
+		"CLI_PROXY_IMAGE=ghcr.io/kittors/clirelay:test",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("init script failed: %v\n%s", err, out)
+	}
+
+	values := readEnvFile(t, envFile)
+	password := values["CLIRELAY_ADMIN_PASSWORD"]
+	if password == "" {
+		t.Fatal("CLIRELAY_ADMIN_PASSWORD was not generated")
+	}
+	if _, err := identity.HashPassword(password); err != nil {
+		t.Fatalf("generated admin password %q is rejected by identity.HashPassword: %v", password, err)
+	}
 }

--- a/install.sh
+++ b/install.sh
@@ -175,6 +175,14 @@ rand_hex() {
     openssl rand -hex "$1" 2>/dev/null || head -c $(( $1 * 2 )) /dev/urandom | xxd -p | head -c $(( $1 * 2 ))
 }
 
+# rand_password generates a value the identity bootstrap will accept. Plain hex is not
+# enough: HashPassword requires an upper-case letter and a non-alphanumeric character.
+# The classes are prepended deterministically so generation can never emit a value that
+# fails validation; all of the entropy still comes from the hex part.
+rand_password() {
+    printf 'Aa1!%s' "$(rand_hex "${1:-16}")"
+}
+
 compose_cmd() {
     docker compose --env-file "${INSTALL_DIR}/.env" -f "${INSTALL_DIR}/docker-compose.yml" "$@"
 }
@@ -490,8 +498,12 @@ YAML
 }
 
 write_env() {
-    local updater_token postgres_db postgres_user postgres_password postgres_dsn postgres_data_path redis_addr redis_password redis_db redis_data_path
+    local updater_token admin_password postgres_db postgres_user postgres_password postgres_dsn postgres_data_path redis_addr redis_password redis_db redis_data_path
     updater_token="${CLIRELAY_UPDATER_TOKEN:-$(rand_hex 16)}"
+    # Without this the identity bootstrap falls back to remote-management.secret-key,
+    # which is empty in the generated config, so a fresh install cannot create its
+    # first admin and the container crash-loops on startup.
+    admin_password="${CLIRELAY_ADMIN_PASSWORD:-$(rand_password 16)}"
     postgres_db="${CLIRELAY_POSTGRES_DB:-cliproxy}"
     postgres_user="${CLIRELAY_POSTGRES_USER:-cliproxy}"
     postgres_password="${CLIRELAY_POSTGRES_PASSWORD:-$(rand_hex 16)}"
@@ -513,6 +525,7 @@ CLIRELAY_PORT=${CFG_PORT}
 CLIRELAY_UPDATE_CHANNEL=main
 CLIRELAY_UPDATER_URL=http://clirelay-updater:8320
 CLIRELAY_UPDATER_TOKEN=${updater_token}
+CLIRELAY_ADMIN_PASSWORD=${admin_password}
 CLIRELAY_TARGET_SERVICE=clirelay
 CLIRELAY_COMPOSE_PROJECT_NAME=$(basename "${INSTALL_DIR}")
 CLIRELAY_POSTGRES_DB=${postgres_db}
@@ -555,6 +568,7 @@ services:
       CLIRELAY_UPDATE_CHANNEL: ${CLIRELAY_UPDATE_CHANNEL}
       CLIRELAY_UPDATER_URL: ${CLIRELAY_UPDATER_URL}
       CLIRELAY_UPDATER_TOKEN: ${CLIRELAY_UPDATER_TOKEN}
+      CLIRELAY_ADMIN_PASSWORD: ${CLIRELAY_ADMIN_PASSWORD}
       CLIRELAY_TARGET_SERVICE: ${CLIRELAY_TARGET_SERVICE}
       CLIRELAY_POSTGRES_DSN: ${CLIRELAY_POSTGRES_DSN}
       CLIRELAY_REDIS_ENABLE: ${CLIRELAY_REDIS_ENABLE}

--- a/install_compose_test.go
+++ b/install_compose_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 )
 
 // These are configuration drift guard tests: they assert generated install
@@ -131,4 +134,81 @@ func TestInstallComposeIncludesRuntimeDataStack(t *testing.T) {
 			t.Fatalf("install.sh missing runtime data stack text %q", want)
 		}
 	}
+}
+
+func TestInstallEnvGeneratesBootstrapAdminPassword(t *testing.T) {
+	data, err := os.ReadFile("install.sh")
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+	content := string(data)
+
+	// Without a generated admin password the identity bootstrap falls back to the
+	// empty remote-management.secret-key and a fresh install crash-loops.
+	for _, want := range []string{
+		`admin_password="${CLIRELAY_ADMIN_PASSWORD:-$(rand_password 16)}"`,
+		"CLIRELAY_ADMIN_PASSWORD=${admin_password}",
+		"CLIRELAY_ADMIN_PASSWORD: ${CLIRELAY_ADMIN_PASSWORD}",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("install.sh missing %q", want)
+		}
+	}
+}
+
+// Executes the password generator defined in install.sh and checks the result against
+// the same validation the bootstrap applies, so a hex-only generator cannot regress.
+func TestInstallRandPasswordPassesIdentityValidation(t *testing.T) {
+	script := `set -euo pipefail
+` + extractShellFunctions(t, "install.sh", "rand_hex", "rand_password") + `
+rand_password 16`
+
+	out, err := exec.Command("bash", "-c", script).Output()
+	if err != nil {
+		t.Fatalf("run install.sh rand_password: %v", err)
+	}
+	password := strings.TrimSpace(string(out))
+	if password == "" {
+		t.Fatal("rand_password produced an empty value")
+	}
+	if _, err := identity.HashPassword(password); err != nil {
+		t.Fatalf("install.sh rand_password produced %q, rejected by identity.HashPassword: %v", password, err)
+	}
+}
+
+// extractShellFunctions pulls top-level `name() { ... }` blocks out of a shell script so
+// a test can run them without executing the whole installer.
+func extractShellFunctions(t *testing.T, path string, names ...string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	var out []string
+	for _, name := range names {
+		header := name + "() {"
+		start := -1
+		for i, line := range lines {
+			if strings.TrimSpace(line) == header {
+				start = i
+				break
+			}
+		}
+		if start < 0 {
+			t.Fatalf("%s does not define %s()", path, name)
+		}
+		end := -1
+		for i := start + 1; i < len(lines); i++ {
+			if lines[i] == "}" {
+				end = i
+				break
+			}
+		}
+		if end < 0 {
+			t.Fatalf("%s: unterminated %s()", path, name)
+		}
+		out = append(out, strings.Join(lines[start:end+1], "\n"))
+	}
+	return strings.Join(out, "\n")
 }

--- a/scripts/init-compose-env.sh
+++ b/scripts/init-compose-env.sh
@@ -35,6 +35,16 @@ rand_hex() {
 	od -An -N "${1:-16}" -tx1 /dev/urandom | tr -d ' \n'
 }
 
+# rand_password generates a value the identity bootstrap will accept. Plain hex is not
+# enough: HashPassword requires an upper-case letter and a non-alphanumeric character,
+# so a hex-only secret makes first startup fail with "password must contain at least one
+# uppercase letter". The classes are prepended deterministically rather than drawn at
+# random so generation can never emit a value that fails validation; all of the entropy
+# still comes from the hex part.
+rand_password() {
+	printf 'Aa1!%s' "$(rand_hex "${1:-16}")"
+}
+
 append_env() {
 	key="$1"
 	value="$2"
@@ -60,7 +70,7 @@ admin_password="$(env_value CLIRELAY_ADMIN_PASSWORD)"
 postgres_password="$(env_value CLIRELAY_POSTGRES_PASSWORD)"
 
 [ -n "$updater_token" ] || updater_token="$(rand_hex 16)"
-[ -n "$admin_password" ] || admin_password="$(rand_hex 16)"
+[ -n "$admin_password" ] || admin_password="$(rand_password 16)"
 [ -n "$postgres_password" ] || postgres_password="$(rand_hex 16)"
 
 postgres_db="$(env_value CLIRELAY_POSTGRES_DB)"


### PR DESCRIPTION
## 问题

**全新 Docker Compose 部署无法创建首个 admin 账号，容器在启动时 crash-loop。**

`scripts/init-compose-env.sh` 用 `rand_hex 16` 生成 `CLIRELAY_ADMIN_PASSWORD`，输出是 **32 个小写十六进制字符**（例如 `cb8d2113f1d3557c5796da936fe49033`）。而 `identity.HashPassword`（`internal/identity/password.go:39-47`）要求密码包含大写字母和非字母数字字符，因此生成的值**必然**被拒：

```
identity bootstrap using admin password from CLIRELAY_ADMIN_PASSWORD:
identity: bootstrap admin password: validation failed:
password must contain at least one uppercase letter
```

触发条件：空 Postgres 库首次引导（`internal/identity/service.go:229` 的 `adminCount == 0` 分支），即官方 `docker-compose.yml` 的标准 fresh install 路径。

`install.sh` 是同一问题的另一种形态：它**完全不生成** admin password，也不把 `CLIRELAY_ADMIN_PASSWORD` 传给容器（服务的 `environment` 白名单里没有这一项），于是 bootstrap 回退到 `remote-management.secret-key`——而生成的配置里该字段为空，同样引导失败。这正是 issue #750 报告者遇到的现象。

## 验证（先证明 bug 存在）

新增的测试在修复前**确实失败**，直接跑真实的 init 脚本并把它生成的密码喂给真实的 `HashPassword`：

```
--- FAIL: TestComposeInitEnvAdminPasswordPassesIdentityValidation
    generated admin password "cb8d2113f1d3557c5796da936fe49033" is rejected
    by identity.HashPassword: validation failed:
    password must contain at least one uppercase letter
```

## 修复

两个入口都改用 `rand_password` helper：在随机 hex 前拼上所需的字符类。字符类是**固定**的而非随机抽取——随机抽取虽然大概率满足要求，但不是确定的，会变成间歇性启动失败，比确定性更糟。全部熵仍来自那 32 个 hex 字符（128 bit），前缀公开不降低强度。

`install.sh` 另外补上 `.env` 写入与容器 `environment` 传递。

## 为什么 CI 之前没抓到

原有断言只检查长度恰好为 32：

```go
if len(values["CLIRELAY_ADMIN_PASSWORD"]) != 32 {
```

它把「32 个 hex 字符」固化成了预期，却从不检验这个值**能不能用**。现在改为断言熵下限，并新增两个测试把两个生成器的真实输出交给 `identity.HashPassword` 校验，覆盖 compose 与 install.sh 两条路径。

## 未纳入本 PR

`cmd/updater/main.go` 的 `ensureRuntimeEnvFile`（升级时重建 `.env` 的兜底路径）同样不生成 `CLIRELAY_ADMIN_PASSWORD`。该文件 1144 行且已在结构债基线中（**只能变小**），加代码会触发门禁失败；且它只影响「`.env` 被重建」的升级场景，而非 fresh install 的启动阻断。留待需要时配合抽函数一并处理，避免在本 PR 里为绕门禁做无关重构。

## 验证命令

本地执行完整 `./scripts/ci-pr.sh`，**退出码 0**（含 `check-backend-structure.py` → `Result: passed`、`gofmt`、`go vet ./...`、`go test ./...`、`golangci-lint run`、`go build ./cmd/server`）。另外 `bash -n install.sh`、`sh -n scripts/init-compose-env.sh` 语法检查通过。

影响目录：仅 `CliRelay/`（`scripts/init-compose-env.sh`、`install.sh` 及对应测试），不涉及 `codeProxy/`。

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)