### PR TITLE
feat(aiaccountstatus): parse Claude scoped weekly limits and probe plan type

### DIFF
--- a/internal/management/aiaccountstatus/probe_claude.go
+++ b/internal/management/aiaccountstatus/probe_claude.go
@@ -10,38 +10,58 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const claudeUsageURL = "https://api.anthropic.com/api/oauth/usage"
+const (
+	claudeUsageURL   = "https://api.anthropic.com/api/oauth/usage"
+	claudeProfileURL = "https://api.anthropic.com/api/oauth/profile"
+)
 
-func probeClaude(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) (ProbeResult, error) {
-	body, err := doAuthGET(ctx, svc, auth, claudeUsageURL, map[string]string{
+func claudeProbeHeaders() map[string]string {
+	return map[string]string{
 		"Accept":         "application/json, text/plain, */*",
 		"Content-Type":   "application/json",
 		"User-Agent":     "claude-code/2.1.7",
 		"anthropic-beta": "oauth-2025-04-20",
-	}, nil)
+	}
+}
+
+func probeClaude(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) (ProbeResult, error) {
+	body, err := doAuthGET(ctx, svc, auth, claudeUsageURL, claudeProbeHeaders(), nil)
 	if err != nil {
 		return ProbeResult{}, err
 	}
-	return ProbeResult{Quotas: parseClaudeUsage(body)}, nil
+	result := ProbeResult{Quotas: parseClaudeUsage(body)}
+	// Best effort: usage data stays valid even when the profile call fails.
+	if profileBody, profileErr := doAuthGET(ctx, svc, auth, claudeProfileURL, claudeProbeHeaders(), nil); profileErr == nil {
+		result.PlanType = parseClaudePlanType(profileBody)
+	}
+	return result, nil
 }
 
 func parseClaudeUsage(body []byte) []usage.QuotaWindowDTO {
 	keys := []struct {
-		path, key, label string
-		window           int64
+		paths  []string
+		key    string
+		label  string
+		window int64
 	}{
-		{"five_hour", "five_hour", "claude_quota.five_hour", 18000},
-		{"seven_day", "seven_day", "claude_quota.seven_day", 604800},
-		{"seven_day_oauth_apps", "seven_day_oauth_apps", "claude_quota.seven_day_oauth_apps", 604800},
-		{"seven_day_opus", "seven_day_opus", "claude_quota.seven_day_opus", 604800},
-		{"seven_day_sonnet", "seven_day_sonnet", "claude_quota.seven_day_sonnet", 604800},
-		{"seven_day_cowork", "seven_day_cowork", "claude_quota.seven_day_cowork", 604800},
-		{"iguana_necktie", "iguana_necktie", "claude_quota.iguana_necktie", 0},
+		{[]string{"five_hour"}, "five_hour", "claude_quota.five_hour", 18000},
+		{[]string{"seven_day"}, "seven_day", "claude_quota.seven_day", 604800},
+		{[]string{"seven_day_oauth_apps"}, "seven_day_oauth_apps", "claude_quota.seven_day_oauth_apps", 604800},
+		{[]string{"seven_day_opus"}, "seven_day_opus", "claude_quota.seven_day_opus", 604800},
+		{[]string{"seven_day_sonnet"}, "seven_day_sonnet", "claude_quota.seven_day_sonnet", 604800},
+		{[]string{"seven_day_cowork", "seven_day_routines", "seven_day_claude_routines", "claude_routines", "routines"}, "seven_day_cowork", "claude_quota.seven_day_cowork", 604800},
+		{[]string{"iguana_necktie"}, "iguana_necktie", "claude_quota.iguana_necktie", 0},
 	}
 	out := make([]usage.QuotaWindowDTO, 0, len(keys)+1)
 	root := gjson.ParseBytes(body)
 	for _, k := range keys {
-		win := root.Get(k.path)
+		var win gjson.Result
+		for _, path := range k.paths {
+			if candidate := root.Get(path); candidate.Exists() && candidate.IsObject() {
+				win = candidate
+				break
+			}
+		}
 		if !win.Exists() {
 			continue
 		}
@@ -57,6 +77,7 @@ func parseClaudeUsage(body []byte) []usage.QuotaWindowDTO {
 			out = append(out, dto)
 		}
 	}
+	out = appendClaudeScopedLimits(out, root)
 	extra := root.Get("extra_usage")
 	if extra.Exists() && extra.Get("is_enabled").Bool() {
 		if utilization := extra.Get("utilization"); utilization.Exists() {
@@ -73,4 +94,121 @@ func parseClaudeUsage(body []byte) []usage.QuotaWindowDTO {
 		}
 	}
 	return out
+}
+
+// appendClaudeScopedLimits maps the newer `limits[]` shape (kind "weekly_scoped")
+// that superseded the flat `seven_day_<model>` fields for model-scoped weekly windows.
+func appendClaudeScopedLimits(out []usage.QuotaWindowDTO, root gjson.Result) []usage.QuotaWindowDTO {
+	limits := root.Get("limits")
+	if !limits.IsArray() {
+		return out
+	}
+	seen := make(map[string]bool, len(out))
+	for _, dto := range out {
+		seen[dto.QuotaKey] = true
+	}
+	for _, entry := range limits.Array() {
+		if entry.Get("kind").String() != "weekly_scoped" || entry.Get("group").String() != "weekly" {
+			continue
+		}
+		percent := entry.Get("percent")
+		if !percent.Exists() {
+			continue
+		}
+		model := entry.Get("scope.model")
+		name := strings.TrimSpace(firstJSONResult(model, "display_name", "displayName").String())
+		id := strings.TrimSpace(model.Get("id").String())
+		if name == "" {
+			name = id
+		}
+		slug := claudeModelSlug(id)
+		if slug == "" {
+			slug = claudeModelSlug(name)
+		}
+		// "All models" scopes duplicate the main seven_day window.
+		if slug == "" || slug == "all-models" || strings.HasSuffix(slug, "-all-models") || claudeModelSlug(name) == "all-models" {
+			continue
+		}
+		// Flat seven_day_opus / seven_day_sonnet already cover these models when present.
+		if (seen["seven_day_opus"] && strings.Contains(slug, "opus")) ||
+			(seen["seven_day_sonnet"] && strings.Contains(slug, "sonnet")) {
+			continue
+		}
+		key := "weekly_scoped_" + slug
+		if seen[key] {
+			continue
+		}
+		remaining := 100 - clampPct(percent.Float())
+		dto := usage.QuotaWindowDTO{
+			QuotaKey:      key,
+			QuotaLabel:    "claude_quota.model_weekly::" + name,
+			WindowSeconds: 604800,
+			Percent:       &remaining,
+		}
+		if reset := firstJSONResult(entry, "resets_at", "resetsAt"); reset.Exists() {
+			dto.ResetAt = parseFlexibleTime(reset)
+		}
+		seen[key] = true
+		out = append(out, dto)
+	}
+	return out
+}
+
+func claudeModelSlug(value string) string {
+	var b strings.Builder
+	lastDash := true
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		switch {
+		case r >= 'a' && r <= 'z' || r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// parseClaudePlanType maps /api/oauth/profile onto membership plan keys the
+// dashboard renders (max_20x / max_5x / max / pro / team / enterprise / free).
+func parseClaudePlanType(body []byte) string {
+	root := gjson.ParseBytes(body)
+	orgType := strings.ToLower(strings.TrimSpace(firstJSONResult(root,
+		"organization.organization_type", "organization.organizationType").String()))
+	if strings.Contains(orgType, "enterprise") {
+		return "enterprise"
+	}
+	if strings.Contains(orgType, "team") {
+		return "team"
+	}
+	tier := strings.ToLower(strings.TrimSpace(firstJSONResult(root,
+		"organization.rate_limit_tier", "organization.rateLimitTier").String()))
+	switch {
+	case strings.Contains(tier, "max_20x"):
+		return "max_20x"
+	case strings.Contains(tier, "max_5x"):
+		return "max_5x"
+	case strings.Contains(tier, "max"):
+		return "max"
+	case strings.Contains(tier, "pro"):
+		return "pro"
+	}
+	switch {
+	case strings.Contains(orgType, "max"):
+		return "max"
+	case strings.Contains(orgType, "pro"):
+		return "pro"
+	case strings.Contains(orgType, "free"):
+		return "free"
+	}
+	if root.Get("account.has_claude_max").Bool() {
+		return "max"
+	}
+	if root.Get("account.has_claude_pro").Bool() {
+		return "pro"
+	}
+	return ""
 }

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -330,3 +330,66 @@ func TestFetchXAIBillingParallelPartialFailure(t *testing.T) {
 		t.Fatalf("weeklyBody=%q monthlyBody=%q", weeklyBody, monthlyBody)
 	}
 }
+
+func TestParseClaudeUsageScopedLimitsAndRoutines(t *testing.T) {
+	body := []byte(`{
+		"five_hour":{"utilization":10,"resets_at":"2026-07-16T12:00:00Z"},
+		"seven_day":{"utilization":40,"resets_at":"2026-07-20T12:00:00Z"},
+		"seven_day_routines":{"utilization":5,"resets_at":"2026-07-20T12:00:00Z"},
+		"limits":[
+			{"kind":"weekly_scoped","group":"weekly","percent":30,"resets_at":"2026-07-20T12:00:00Z","scope":{"model":{"id":"claude-opus-5","display_name":"Opus"}}},
+			{"kind":"weekly_scoped","group":"weekly","percent":80,"scope":{"model":{"id":"all-models","display_name":"All models"}}},
+			{"kind":"five_hour","group":"session","percent":10,"scope":{"model":{"id":"claude-opus-5","display_name":"Opus"}}}
+		]
+	}`)
+	items := parseClaudeUsage(body)
+	routines := quotaByKey(items, "seven_day_cowork")
+	if routines == nil || routines.Percent == nil || *routines.Percent != 95 {
+		t.Fatalf("routines=%+v", routines)
+	}
+	opus := quotaByKey(items, "weekly_scoped_claude-opus-5")
+	if opus == nil || opus.Percent == nil || *opus.Percent != 70 || opus.QuotaLabel != "claude_quota.model_weekly::Opus" || opus.ResetAt == nil {
+		t.Fatalf("opus=%+v", opus)
+	}
+	if quotaByKey(items, "weekly_scoped_all-models") != nil {
+		t.Fatal("all-models scope should be skipped")
+	}
+	if len(items) != 4 {
+		t.Fatalf("items=%+v", items)
+	}
+}
+
+func TestParseClaudeUsageScopedLimitSkippedWhenFlatWindowPresent(t *testing.T) {
+	body := []byte(`{
+		"seven_day_opus":{"utilization":20,"resets_at":"2026-07-20T12:00:00Z"},
+		"limits":[
+			{"kind":"weekly_scoped","group":"weekly","percent":30,"scope":{"model":{"id":"claude-opus-5","display_name":"Opus"}}}
+		]
+	}`)
+	items := parseClaudeUsage(body)
+	if len(items) != 1 || items[0].QuotaKey != "seven_day_opus" {
+		t.Fatalf("items=%+v", items)
+	}
+}
+
+func TestParseClaudePlanType(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`{"organization":{"organization_type":"claude_max","rate_limit_tier":"default_claude_max_20x"}}`, "max_20x"},
+		{`{"organization":{"organization_type":"claude_max","rate_limit_tier":"default_claude_max_5x"}}`, "max_5x"},
+		{`{"organization":{"organization_type":"claude_max","rate_limit_tier":"default_claude_max_1x"}}`, "max"},
+		{`{"organization":{"organization_type":"claude_pro","rate_limit_tier":"default_claude"}}`, "pro"},
+		{`{"organization":{"organization_type":"claude_enterprise","rate_limit_tier":"default_claude_max_20x"}}`, "enterprise"},
+		{`{"organization":{"organization_type":"claude_team"}}`, "team"},
+		{`{"account":{"has_claude_max":true}}`, "max"},
+		{`{"account":{"has_claude_pro":true}}`, "pro"},
+		{`{}`, ""},
+	}
+	for _, tc := range cases {
+		if got := parseClaudePlanType([]byte(tc.body)); got != tc.want {
+			t.Fatalf("body=%s got=%q want=%q", tc.body, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## 背景

前端 claude 账号卡片存在两个数据缺口：

1. **进度条缺失**：Anthropic 新版 `oauth/usage` 把按模型划分的 7 天限额挪进了 `limits[]` 数组（`kind: "weekly_scoped"`），并把 Cowork 窗口更名为 `seven_day_routines`；后端只解析旧扁平字段，这些窗口全部丢失。
2. **会员标签缺失**：后端从不探测 claude 订阅等级，`plan_type` 恒为空，前端已就绪的 MAX 20X / MAX 5X / PRO 徽章无数据可显示。

## 改动

- `parseClaudeUsage` 新增 `limits[]` 解析：仅取 `weekly_scoped` + `weekly` 条目，跳过与主窗口重复的 "All models"，与旧 `seven_day_opus` / `seven_day_sonnet` 扁平字段去重；label 采用 `claude_quota.model_weekly::<模型名>` 参数化格式（配套前端 PR 支持翻译）。
- cowork 窗口兼容 `seven_day_routines` / `seven_day_claude_routines` / `claude_routines` / `routines` 别名。
- `probeClaude` 追加 best-effort 的 `oauth/profile` 请求，由 `organization.rate_limit_tier`（`default_claude_max_20x` / `_5x` / `_1x`）、`organization_type`、`account.has_claude_*` 推导 `max_20x` / `max_5x` / `max` / `pro` / `team` / `enterprise` / `free` 写入 `ProbeResult.PlanType`；profile 失败不影响额度数据。

## 测试

- 新增 `TestParseClaudeUsageScopedLimitsAndRoutines`、`TestParseClaudeUsageScopedLimitSkippedWhenFlatWindowPresent`、`TestParseClaudePlanType`（9 组取值矩阵）。
- 本地完整 `./scripts/ci-pr.sh` 通过（gofmt / secret scan / go vet / go test ./... / golangci-lint / go build）。

配套前端 PR：kittors/codeProxy（claude 新窗口翻译 + 无数据隐藏 "--" chips）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)