### PR TITLE
fix(security): 修正并扩展本地来源判定（#811 复查后续）

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -222,11 +222,14 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		if !localClient {
 			if !allowRemote {
 				// Requests relayed by a local reverse proxy land here even though the TCP
-				// peer is loopback, so the hint names both ways out: open remote access, or
-				// declare the proxy so the real client IP is recovered.
+				// peer is loopback. allow-remote is the only advice that actually grants
+				// access: a relayed request is never treated as local, so trusted-proxies
+				// does not help on its own — it recovers the real client IP for the per-IP
+				// throttle, which is why it is named as an additional step rather than an
+				// alternative.
 				message := "remote management disabled"
 				if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" {
-					message = "remote management disabled: request was relayed (" + relayHeader + " header present). Set remote-management.allow-remote=true, or add the proxy to trusted-proxies so the original client IP is used."
+					message = "remote management disabled: request was relayed (" + relayHeader + " header present), so it is not treated as local. Set remote-management.allow-remote=true to allow it, and list the proxy in trusted-proxies so per-IP throttling sees the real client."
 				}
 				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": message})
 				return

--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -3,13 +3,13 @@ package amp
 import (
 	"context"
 	"errors"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/gemini"
@@ -58,30 +58,16 @@ func (m *AmpModule) localhostOnlyMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		// Use actual TCP connection address (RemoteAddr) to prevent header spoofing
-		// This cannot be forged by X-Forwarded-For or other client-controlled headers
-		remoteAddr := c.Request.RemoteAddr
-
-		// RemoteAddr format is "IP:port" or "[IPv6]:port", extract just the IP
-		host, _, err := net.SplitHostPort(remoteAddr)
-		if err != nil {
-			// Try parsing as raw IP (shouldn't happen with standard HTTP, but be defensive)
-			host = remoteAddr
-		}
-
-		// Parse the IP to handle both IPv4 and IPv6
-		ip := net.ParseIP(host)
-		if ip == nil {
-			log.Warnf("amp management: invalid RemoteAddr %s, denying access", remoteAddr)
-			c.AbortWithStatusJSON(403, gin.H{
-				"error": "Access denied: management routes restricted to localhost",
-			})
-			return
-		}
-
-		// Check if IP is loopback (127.0.0.1 or ::1)
-		if !ip.IsLoopback() {
-			log.Warnf("amp management: non-localhost connection from %s attempted access, denying", remoteAddr)
+		// A loopback TCP peer is not by itself proof of local origin: behind a same-host
+		// reverse proxy every external request arrives from 127.0.0.1. util.IsLocalOriginRequest
+		// additionally requires that no relay header is present, and fails closed on
+		// addresses it cannot parse. See its doc comment for what still slips through.
+		if !util.IsLocalOriginRequest(c.Request) {
+			if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" {
+				log.Warnf("amp management: relayed request from %s (%s header present) is not local, denying", c.Request.RemoteAddr, relayHeader)
+			} else {
+				log.Warnf("amp management: non-localhost connection from %s attempted access, denying", c.Request.RemoteAddr)
+			}
 			c.AbortWithStatusJSON(403, gin.H{
 				"error": "Access denied: management routes restricted to localhost",
 			})

--- a/internal/util/client_ip.go
+++ b/internal/util/client_ip.go
@@ -3,6 +3,7 @@ package util
 import (
 	"net"
 	"net/http"
+	"net/textproto"
 	"strings"
 )
 
@@ -66,7 +67,10 @@ func forwardedHeaderIP(headers http.Header) string {
 // only need to know that *some* relay handled the request, so headers that carry no
 // client IP (Via, X-Forwarded-Proto, CF-Ray) are just as conclusive as the ones that
 // do, and a header we fail to recognise is a bypass rather than a display glitch.
-var relayIndicationHeaders = []string{
+// Stored canonicalised so a future switch from Header.Values() to direct map indexing
+// cannot silently disable half the list: written literally, entries like "X-Real-IP" and
+// "CF-Ray" are not in textproto canonical form ("X-Real-Ip", "Cf-Ray").
+var relayIndicationHeaders = canonicalHeaderNames([]string{
 	"Forwarded",
 	"Via",
 	"X-Forwarded-For",
@@ -87,6 +91,14 @@ var relayIndicationHeaders = []string{
 	"X-Envoy-Internal",
 	"X-Azure-ClientIP",
 	"X-Azure-SocketIP",
+})
+
+func canonicalHeaderNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, textproto.CanonicalMIMEHeaderKey(name))
+	}
+	return out
 }
 
 // IsLocalOriginRequest reports whether req provably originates from this host, and is
@@ -98,10 +110,16 @@ var relayIndicationHeaders = []string{
 // loopback peer and the absence of any relay header, and fails closed on addresses it
 // cannot parse.
 //
-// Known limitation: a relay that rewrites nothing — nginx `stream`, HAProxy in TCP
-// mode, socat, an iptables DNAT rule, `cloudflared --url http://127.0.0.1:...` — is
-// indistinguishable from a local client at the HTTP layer. Endpoints that must hold
-// against those need their own credential, not just this check.
+// Known limitation: any relay that forwards a request without adding a header of its own
+// is indistinguishable from a local client at the HTTP layer. That covers more than L4
+// tunnels (nginx `stream`, HAProxy in TCP mode, socat, iptables DNAT, `cloudflared --url
+// http://127.0.0.1:...`) — notably, a bare nginx `proxy_pass` sets no forwarded headers
+// unless the operator adds proxy_set_header, so an ordinary L7 reverse proxy can also
+// slip through. A front-end vulnerable to request smuggling likewise lets an attacker
+// author the backend-bound bytes directly, with no operator misconfiguration needed.
+//
+// So this narrows the exposure, it does not close it. Endpoints that must hold against a
+// hostile network need their own credential rather than only this check.
 func IsLocalOriginRequest(req *http.Request) bool {
 	if req == nil {
 		return false

--- a/internal/util/client_ip_test.go
+++ b/internal/util/client_ip_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"testing"
 )
 
@@ -69,8 +70,10 @@ func TestIsLocalOriginRequestRejectsRelayedLoopbackPeers(t *testing.T) {
 		if IsLocalOriginRequest(req) {
 			t.Errorf("%s: %q: IsLocalOriginRequest() = true, want false", tc.header, tc.value)
 		}
-		if got := RelayIndicationHeader(req); got != tc.header {
-			t.Errorf("%s: RelayIndicationHeader() = %q, want %q", tc.header, got, tc.header)
+		// The reported name is the canonical form, which is what http.Header stores.
+		want := textproto.CanonicalMIMEHeaderKey(tc.header)
+		if got := RelayIndicationHeader(req); got != want {
+			t.Errorf("%s: RelayIndicationHeader() = %q, want %q", tc.header, got, want)
 		}
 	}
 }
@@ -95,5 +98,28 @@ func TestIsLocalOriginRequestRejectsNilRequest(t *testing.T) {
 	}
 	if got := RelayIndicationHeader(nil); got != "" {
 		t.Errorf("RelayIndicationHeader(nil) = %q, want empty", got)
+	}
+}
+
+// The list is stored canonicalised so a future switch from Header.Values() to direct map
+// indexing cannot silently disable the entries that are not written in canonical form.
+func TestRelayIndicationHeadersAreCanonical(t *testing.T) {
+	for _, header := range relayIndicationHeaders {
+		if canonical := textproto.CanonicalMIMEHeaderKey(header); canonical != header {
+			t.Errorf("relay header %q is not canonical, want %q", header, canonical)
+		}
+	}
+}
+
+// Direct map indexing must find every listed header, which is the property that makes the
+// list safe against that refactor.
+func TestRelayIndicationHeadersMatchDirectMapLookup(t *testing.T) {
+	for _, header := range relayIndicationHeaders {
+		req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", nil)
+		req.RemoteAddr = "127.0.0.1:54321"
+		req.Header[header] = []string{"203.0.113.42"}
+		if IsLocalOriginRequest(req) {
+			t.Errorf("header %q set via direct map index did not mark the request as relayed", header)
+		}
 	}
 }

--- a/sdk/api/handlers/gemini/gemini-cli_handlers.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -49,6 +50,52 @@ func (h *GeminiCLIAPIHandler) Models() []map[string]any {
 	return make([]map[string]any, 0)
 }
 
+// geminiCLIRejectLogInterval throttles rejection logging. This endpoint is actively
+// scanned, and the attacker is rejected before the body is read, so an unthrottled
+// warning per request is a cheap way to fill the operator's disk.
+const geminiCLIRejectLogInterval = time.Minute
+
+var geminiCLIRejectLog struct {
+	mu         sync.Mutex
+	lastAt     time.Time
+	suppressed int64
+}
+
+// logRejectedGeminiCLIRequest reports rejected non-local access at most once per
+// interval, folding the suppressed count into the next line so a burst is still visible.
+//
+// It logs the forwarded client IP rather than only RemoteAddr: in the reverse-proxy case
+// this warning exists to diagnose, RemoteAddr is always the local proxy and identifies
+// nothing. The forwarded value is attacker-controlled, so it is labelled as claimed.
+func logRejectedGeminiCLIRequest(c *gin.Context) {
+	geminiCLIRejectLog.mu.Lock()
+	now := time.Now()
+	if !geminiCLIRejectLog.lastAt.IsZero() && now.Sub(geminiCLIRejectLog.lastAt) < geminiCLIRejectLogInterval {
+		geminiCLIRejectLog.suppressed++
+		geminiCLIRejectLog.mu.Unlock()
+		return
+	}
+	suppressed := geminiCLIRejectLog.suppressed
+	geminiCLIRejectLog.suppressed = 0
+	geminiCLIRejectLog.lastAt = now
+	geminiCLIRejectLog.mu.Unlock()
+
+	claimedIP, ipHeader := util.ForwardedClientIP(c.Request)
+	origin := "peer " + c.Request.RemoteAddr
+	if claimedIP != "" {
+		origin += ", claimed client " + claimedIP + " via " + ipHeader
+	}
+	detail := ""
+	if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" {
+		detail = " (relayed, " + relayHeader + " header present); keep /v1internal off public reverse proxies"
+	}
+	if suppressed > 0 {
+		log.Warnf("gemini cli: rejected non-local request from %s%s; %d similar rejection(s) suppressed in the last %s", origin, detail, suppressed, geminiCLIRejectLogInterval)
+		return
+	}
+	log.Warnf("gemini cli: rejected non-local request from %s%s", origin, detail)
+}
+
 // CLIHandler handles CLI-specific requests for Gemini API operations.
 // It restricts access to localhost only and routes requests to appropriate internal handlers.
 //
@@ -57,13 +104,7 @@ func (h *GeminiCLIAPIHandler) Models() []map[string]any {
 // caller and the server's Gemini credential pool. It must stay fail-closed.
 func (h *GeminiCLIAPIHandler) CLIHandler(c *gin.Context) {
 	if !util.IsLocalOriginRequest(c.Request) {
-		// Logged because this endpoint is scanned for in the wild and a silent 403
-		// leaves operators with no signal that someone is probing it.
-		if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" {
-			log.Warnf("gemini cli: rejected non-local request from %s (relayed via %s header); configure trusted-proxies and keep /v1internal off public reverse proxies", c.Request.RemoteAddr, relayHeader)
-		} else {
-			log.Warnf("gemini cli: rejected non-local request from %s", c.Request.RemoteAddr)
-		}
+		logRejectedGeminiCLIRequest(c)
 		c.JSON(http.StatusForbidden, handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{
 				Message: "CLI reply only allow local access",

--- a/sdk/api/handlers/gemini/gemini-cli_handlers_test.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers_test.go
@@ -5,8 +5,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 // newCLITestRouter wires CLIHandler exactly as routes_public.go does: a single
@@ -92,3 +94,46 @@ func TestCLIHandlerAcceptsDirectLoopbackPeers(t *testing.T) {
 		})
 	}
 }
+
+// This endpoint is actively scanned and rejects before reading the body, so an
+// unthrottled warning per rejected request is a cheap way to fill an operator's disk.
+func TestRejectionLoggingIsThrottled(t *testing.T) {
+	var lines int
+	original := log.StandardLogger().Out
+	log.SetOutput(writerFunc(func(p []byte) (int, error) {
+		lines++
+		return len(p), nil
+	}))
+	t.Cleanup(func() { log.SetOutput(original) })
+
+	geminiCLIRejectLog.mu.Lock()
+	geminiCLIRejectLog.lastAt = time.Time{}
+	geminiCLIRejectLog.suppressed = 0
+	geminiCLIRejectLog.mu.Unlock()
+
+	router := newCLITestRouter()
+	for i := 0; i < 50; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", strings.NewReader(`{}`))
+		req.RemoteAddr = "127.0.0.1:54321"
+		req.Header.Set("X-Forwarded-For", "203.0.113.42")
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("request %d: status = %d, want 403", i, rr.Code)
+		}
+	}
+
+	if lines != 1 {
+		t.Fatalf("50 rejected requests produced %d log line(s), want 1", lines)
+	}
+	geminiCLIRejectLog.mu.Lock()
+	suppressed := geminiCLIRejectLog.suppressed
+	geminiCLIRejectLog.mu.Unlock()
+	if suppressed != 49 {
+		t.Fatalf("suppressed count = %d, want 49", suppressed)
+	}
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }


### PR DESCRIPTION
## 背景

对 #811（`56415f64`）做对抗式复查后发现的问题。原修复方向正确、确实关闭了报告的漏洞，但有几处需要纠正。

## 1. 局限说明严重低估了绕过面（最重要）

原注释只列了 L4 中继（nginx `stream`、HAProxy TCP、socat、iptables DNAT、cloudflared）。但**裸的 nginx `proxy_pass` 默认不设置任何转发头**——nginx 只隐式设 `Host` 和 `Connection`，`X-Forwarded-For` 等必须运维显式写 `proxy_set_header`。因此：

```nginx
location / { proxy_pass http://127.0.0.1:8317; }   # 无 proxy_set_header
```

这个**最常见的同机反代配置**在 HTTP 层与本地客户端完全无法区分，两个受保护端点都照旧敞开。已实测确认：仅带 `Host`/`Connection` 的外部请求，`IsLocalOriginRequest` 返回 true。

前置代理若存在请求走私（CL.TE/TE.CL）漏洞，攻击者可直接构造发往后端的字节流，同样绕过，且**不需要任何运维配置错误**。

注释改为明确写清：这个检查**只是缩小暴露面，并没有关闭它**；需要在敌意网络中站得住的端点必须有自己的凭据。仓库自带的 `docs/reverse-proxy_CN.md` 确实设置了转发头，但没有任何东西强制这一点。

## 2. management 的拒绝提示是错的

原提示说「或把代理加入 trusted-proxies 以恢复真实客户端 IP」，暗示这是一条获得访问权的出路。**但它不是**：`IsLocalOriginRequest` 按设计不看 trusted-proxies，经中继的请求永远不被判为本地。已用 gin 实测：即使把 `trusted-proxies` 配成 `127.0.0.1`，经中继的 loopback 请求仍然 `localClient=false`。

提示改为：`allow-remote=true` 才是授予访问的开关，`trusted-proxies` 是**附加**步骤（让按 IP 的节流看到真实客户端），而不是替代方案。

## 3. 中继头清单存在潜在陷阱

清单里 20 项有 10 项不是 textproto 规范形式（`X-Real-IP` → `X-Real-Ip`、`CF-Ray` → `Cf-Ray`、`X-Azure-ClientIP` → `X-Azure-Clientip` 等）。当前能工作**纯粹因为 `Header.Values()` 会规范化查找键**；一旦有人改成直接 map 索引（仓库里 `gemini-cli_handlers.go` 和 `internal/wsrelay/http.go` 已有这种写法），**半个清单会静默失效**。

改为在初始化时统一规范化，并加两个测试锁定：一个断言清单本身规范，一个断言通过原始 map 直接塞入的头仍能被识别。

## 4. amp 模块存在同根因缺陷，一并迁移

`internal/api/modules/amp/routes.go` 的 `localhostOnlyMiddleware` 用裸 `RemoteAddr` + `IsLoopback()`，没有任何中继头检查，同机反代下每个外部请求都满足。

该处是纵深防御（默认关闭，且后面串了 API key 认证），但属于同一根因，已迁移到共享 helper。

## 5. 拒绝日志无限量，且记录的信息没有用

每个被拒请求都 `log.Warnf` 一行，无采样无限流。而「这个端点正在被扫描」恰恰是产生海量日志的条件，攻击者在读 body 之前就被拒绝、代价极低——这是一条廉价的磁盘填满路径。

更讽刺的是它记录 `RemoteAddr`：在这条警告本来要诊断的反代场景里，`RemoteAddr` **恒为本地代理地址，什么也标识不了**。

改为每分钟最多一行，并把被抑制的条数折进下一行（突发仍然可见）；同时记录 `util.ForwardedClientIP` 得到的真实客户端 IP，并明确标注为 claimed——该值由攻击者控制，不能当作可信证据。

## 验证

本地执行完整 `./scripts/ci-pr.sh`，**退出码 0**。

新增测试：
- 头名规范性 + 通过原始 map 索引设置的头仍被识别；
- 50 次连续被拒请求只产生 1 行日志、抑制计数为 49。

既有测试 `TestIsLocalOriginRequestRejectsRelayedLoopbackPeers` 的断言相应放宽为比较规范形式（`RelayIndicationHeader` 现在返回 `X-Real-Ip` 而非 `X-Real-IP`，这正是 `http.Header` 内部存储的形式，检测行为不变）。

## 未纳入本 PR

- **文档**：`docs/reverse-proxy_CN.md` 与 `config.example.yaml` 仍按旧行为描述，应补充「反代后 management 需要 allow-remote」以及 `proxy_set_header` 的必要性。建议单独出一个文档 PR。
- `internal/api/public_lookup_middleware.go` 与 `identity_auth.go:184` 的限流键仍是裸 `c.ClientIP()`，声明了 trusted-proxies 时可用轮换 `X-Forwarded-For` 规避配额。属独立问题。

影响目录：仅 `CliRelay/`。

Refs #517, #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)