### PR TITLE
fix(codex): route Claude system prompts to Responses API instructions

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -55,25 +55,28 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 		inputBuf.WriteString(raw)
 	}
 
-	// Process system messages and convert them to input content format.
+	// Convert Claude's top-level system prompt to Responses API instructions.
+	// Do not emit system/developer messages inside input because the Codex
+	// ChatGPT OAuth upstream rejects them ("System messages are not allowed").
+	var instructionParts []string
 	systemsResult := rootResult.Get("system")
-	if systemsResult.IsArray() {
-		systemResults := systemsResult.Array()
-		message := `{"type":"message","role":"developer","content":[]}`
-		for i := 0; i < len(systemResults); i++ {
-			systemResult := systemResults[i]
-			systemTypeResult := systemResult.Get("type")
-			if systemTypeResult.String() == "text" {
-				message, _ = sjson.Set(message, fmt.Sprintf("content.%d.type", i), "input_text")
-				if textRaw := systemResult.Get("text").Raw; strings.HasPrefix(textRaw, `"`) {
-					message, _ = sjson.SetRaw(message, fmt.Sprintf("content.%d.text", i), textRaw)
-				} else {
-					message, _ = sjson.Set(message, fmt.Sprintf("content.%d.text", i), systemResult.Get("text").String())
-				}
+	switch {
+	case systemsResult.IsArray():
+		for _, systemResult := range systemsResult.Array() {
+			if systemResult.Get("type").String() != "text" {
+				continue
+			}
+			if text := systemResult.Get("text").String(); text != "" {
+				instructionParts = append(instructionParts, text)
 			}
 		}
-		appendInput(message)
+	case systemsResult.Type == gjson.String:
+		if text := systemsResult.String(); text != "" {
+			instructionParts = append(instructionParts, text)
+		}
 	}
+	// Note: instructions is assembled after the message loop below, because
+	// in-conversation system/developer messages are also folded into it.
 
 	// Build tool short-name map once for tool_use renames (avoid rescanning tools per call).
 	toolNameMap := buildReverseMapFromClaudeOriginalToShort(rawJSON)
@@ -86,6 +89,30 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 		for i := 0; i < len(messageResults); i++ {
 			messageResult := messageResults[i]
 			messageRole := messageResult.Get("role").String()
+
+			// Some clients (e.g. Claude Code Agent Teams) inject system/developer
+			// messages inside the messages array. The Codex ChatGPT OAuth upstream
+			// rejects those roles in input ("System messages are not allowed"), so
+			// fold their text into the top-level instructions instead of emitting
+			// them as input messages.
+			if messageRole == "system" || messageRole == "developer" {
+				roleContent := messageResult.Get("content")
+				if roleContent.IsArray() {
+					for _, part := range roleContent.Array() {
+						if part.Get("type").String() != "text" {
+							continue
+						}
+						if text := part.Get("text").String(); text != "" {
+							instructionParts = append(instructionParts, text)
+						}
+					}
+				} else if roleContent.Type == gjson.String {
+					if text := roleContent.String(); text != "" {
+						instructionParts = append(instructionParts, text)
+					}
+				}
+				continue
+			}
 
 			var contentBuf bytes.Buffer
 			contentFirst := true
@@ -207,6 +234,10 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	}
 	inputBuf.WriteByte(']')
 
+	// Assemble instructions from top-level system plus any in-conversation
+	// system/developer messages collected during the loop above.
+	instructions := strings.Join(instructionParts, "\n\n")
+
 	// Convert tools declarations once.
 	// Codex rejects defer_loading without tools.tool_search; strip it on each tool
 	// fragment only — never N× sjson.DeleteBytes on the full multi-MB request.
@@ -295,7 +326,9 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	out.Grow(inputBuf.Len() + toolsBuf.Len() + 512)
 	out.WriteString(`{"model":`)
 	out.Write(mustJSONString(modelName))
-	out.WriteString(`,"instructions":"","input":`)
+	out.WriteString(`,"instructions":`)
+	out.Write(mustJSONString(instructions))
+	out.WriteString(`,"input":`)
 	out.Write(inputBuf.Bytes())
 	if hasTools {
 		out.WriteString(`,"tools":`)

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -31,6 +31,66 @@ func TestConvertClaudeRequestToCodex_StripsDeferLoading(t *testing.T) {
 	})
 }
 
+func TestConvertClaudeRequestToCodex_SystemBecomesInstructions(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-opus-5",
+		"system": [
+			{"type": "text", "text": "You are Claude Code."},
+			{"type": "text", "text": "Follow repository instructions."}
+		],
+		"messages": [
+			{"role": "user", "content": "hello"}
+		]
+	}`)
+
+	out := ConvertClaudeRequestToCodex("gpt-5.6-sol", input, true)
+
+	gotInstructions := gjson.GetBytes(out, "instructions").String()
+	wantInstructions := "You are Claude Code.\n\nFollow repository instructions."
+
+	if gotInstructions != wantInstructions {
+		t.Fatalf("unexpected instructions:\nwant: %q\ngot:  %q\noutput: %s",
+			wantInstructions, gotInstructions, out)
+	}
+
+	inputMessages := gjson.GetBytes(out, "input").Array()
+	for _, message := range inputMessages {
+		role := message.Get("role").String()
+		if role == "system" || role == "developer" {
+			t.Fatalf("system/developer message must not appear in input: %s", out)
+		}
+	}
+}
+
+func TestConvertClaudeRequestToCodex_InConversationSystemMessageFolded(t *testing.T) {
+	// Claude Code Agent Teams injects a role:"system" message inside messages.
+	// It must be folded into instructions, never emitted into input.
+	input := []byte(`{
+		"model": "gpt-5.6-sol",
+		"system": [{"type": "text", "text": "You are Claude Code."}],
+		"messages": [
+			{"role": "user", "content": "hi"},
+			{"role": "system", "content": [{"type": "text", "text": "Available agent types for the Agent tool: BigBrother."}]},
+			{"role": "user", "content": "go"}
+		]
+	}`)
+
+	out := ConvertClaudeRequestToCodex("gpt-5.6-sol", input, true)
+
+	gotInstructions := gjson.GetBytes(out, "instructions").String()
+	wantInstructions := "You are Claude Code.\n\nAvailable agent types for the Agent tool: BigBrother."
+	if gotInstructions != wantInstructions {
+		t.Fatalf("unexpected instructions:\nwant: %q\ngot:  %q\noutput: %s",
+			wantInstructions, gotInstructions, out)
+	}
+
+	for _, message := range gjson.GetBytes(out, "input").Array() {
+		if role := message.Get("role").String(); role == "system" || role == "developer" {
+			t.Fatalf("system/developer message must not appear in input: %s", out)
+		}
+	}
+}
+
 func TestConvertClaudeRequestToCodex_EmptyToolsOmitsToolChoice(t *testing.T) {
 	input := []byte(`{
 		"model":"claude-haiku-4-5",


### PR DESCRIPTION
## Problem

When translating Claude requests to the Codex Responses API, the ChatGPT OAuth upstream rejects `system`/`developer` role messages inside the `input` array with:

```
System messages are not allowed
```

Two sources produced such messages:

1. The **top-level Claude `system` prompt** was emitted as a `role:"developer"` message inside `input`, while the top-level `instructions` field was hard-coded to `""`.
2. Any **`role:"system"` message injected into the conversation** (e.g. by Claude Code **Agent Teams**, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, which adds an "Available agent types…" system message) was passed through verbatim into `input`.

Both caused upstream `400 System messages are not allowed`.

## Fix

`internal/translator/codex/claude/codex_claude_request.go`:

- Fold the top-level `system` field (array or string) into the top-level `instructions` string.
- During message conversion, fold any `system`/`developer` role message's text into `instructions` as well, instead of emitting it into `input`.
- Never emit `system`/`developer` roles into `input`.

Result envelope now looks like:

```json
{ "model": "...", "instructions": "<system prompt>", "input": [ { "role": "user", ... } ] }
```

## Tests

Added to `codex_claude_request_test.go`:

- `TestConvertClaudeRequestToCodex_SystemBecomesInstructions` — top-level system → instructions, no system/developer in input.
- `TestConvertClaudeRequestToCodex_InConversationSystemMessageFolded` — in-conversation `role:"system"` message folded into instructions, absent from input.

`go test ./internal/translator/codex/claude` passes.

Verified end-to-end against a live Codex (`gpt-5.6-sol`) route with Agent Teams enabled: previously `400 System messages are not allowed`, now `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)