### PR TITLE
fix: clear non-quota auth restriction state

### DIFF
--- a/internal/api/handlers/management/quota_test.go
+++ b/internal/api/handlers/management/quota_test.go
@@ -7,31 +7,21 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
-func TestPostQuotaClearStatusClearsAuthByIndex(t *testing.T) {
+func TestPostQuotaClearStatusClearsUnauthorizedAuthByIndex(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	manager := coreauth.NewManager(nil, nil, nil)
-	next := time.Now().Add(30 * time.Minute)
 	registered, err := manager.Register(context.Background(), &coreauth.Auth{
-		ID:             "codex-auth",
-		Provider:       "codex",
-		FileName:       "codex.json",
-		Status:         coreauth.StatusError,
-		StatusMessage:  "quota exhausted",
-		Unavailable:    true,
-		NextRetryAfter: next,
-		LastError:      &coreauth.Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
-		Quota: coreauth.QuotaState{
-			Exceeded:      true,
-			Reason:        "quota",
-			NextRecoverAt: next,
-		},
+		ID:        "xai-auth",
+		Provider:  "xai",
+		FileName:  "xai.json",
+		Status:    coreauth.StatusError,
+		LastError: &coreauth.Error{HTTPStatus: http.StatusUnauthorized},
 	})
 	if err != nil {
 		t.Fatalf("Register() error = %v", err)
@@ -56,6 +46,15 @@ func TestPostQuotaClearStatusClearsAuthByIndex(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
 	}
+	var response struct {
+		Changed bool `json:"changed"`
+	}
+	if err = json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Unmarshal(response) error = %v", err)
+	}
+	if !response.Changed {
+		t.Fatalf("response.changed = false, want true; body=%s", rr.Body.String())
+	}
 
 	updated, ok := manager.GetByID(registered.ID)
 	if !ok || updated == nil {
@@ -65,6 +64,6 @@ func TestPostQuotaClearStatusClearsAuthByIndex(t *testing.T) {
 		t.Fatalf("auth.Status = %q, want %q", updated.Status, coreauth.StatusActive)
 	}
 	if updated.StatusMessage != "" || updated.Unavailable || !updated.NextRetryAfter.IsZero() || updated.LastError != nil || updated.Quota != (coreauth.QuotaState{}) {
-		t.Fatalf("quota runtime state was not cleared: %#v", updated)
+		t.Fatalf("401 runtime state was not cleared: %#v", updated)
 	}
 }

--- a/internal/management/authfiles/restrictions_test.go
+++ b/internal/management/authfiles/restrictions_test.go
@@ -1,12 +1,59 @@
 package authfiles
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
 
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
+
+func TestClearQuotaStatusRemovesHTTPOnlyUnauthorizedRestriction(t *testing.T) {
+	now := time.Date(2026, 7, 27, 5, 19, 8, 0, time.UTC)
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := &coreauth.Auth{
+		ID:        "xai-http-only-401",
+		Provider:  "xai",
+		Status:    coreauth.StatusError,
+		LastError: &coreauth.Error{HTTPStatus: http.StatusUnauthorized},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before, ok := manager.GetByID(auth.ID)
+	if !ok || before == nil {
+		t.Fatal("GetByID() missing auth before clear")
+	}
+	restrictionsBefore := BuildRestrictionPayload(before, now)
+	t.Logf("restrictions before clear: %#v", restrictionsBefore)
+	if len(restrictionsBefore) != 1 {
+		t.Fatalf("restrictions before clear = %#v, want one 401 restriction", restrictionsBefore)
+	}
+	if got := restrictionsBefore[0]; got["http_status"] != http.StatusUnauthorized || got["scope"] != "auth" {
+		t.Fatalf("restriction before clear = %#v, want auth HTTP 401", got)
+	} else if _, ok := got["status_message"]; ok {
+		t.Fatalf("restriction before clear unexpectedly has status_message: %#v", got)
+	}
+
+	changed, err := manager.ClearQuotaStatus(context.Background(), auth.ID)
+	if err != nil {
+		t.Fatalf("ClearQuotaStatus() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("ClearQuotaStatus() changed = false, want true")
+	}
+	after, ok := manager.GetByID(auth.ID)
+	if !ok || after == nil {
+		t.Fatal("GetByID() missing auth after clear")
+	}
+	restrictionsAfter := BuildRestrictionPayload(after, now)
+	t.Logf("restrictions after clear: %#v", restrictionsAfter)
+	if len(restrictionsAfter) != 0 {
+		t.Fatalf("restrictions after clear = %#v, want empty", restrictionsAfter)
+	}
+}
 
 func TestBuildRestrictionPayloadIncludesModelRestriction(t *testing.T) {
 	now := time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC)

--- a/sdk/cliproxy/auth/claude_oauth_health.go
+++ b/sdk/cliproxy/auth/claude_oauth_health.go
@@ -114,6 +114,40 @@ func markClaudeOAuthHealthRefreshSuccessLocked(auth *Auth, now time.Time) {
 	auth.Metadata[ClaudeOAuthHealthMetadataKey] = health
 }
 
+// clearClaudeOAuthRuntimeRestrictionLocked removes only scheduling state from
+// the Claude OAuth health projection. Historical diagnostics and quota-window
+// observations remain available, while refresh_pending/oauth_401 can no longer
+// keep an operator-cleared credential out of rotation.
+func clearClaudeOAuthRuntimeRestrictionLocked(auth *Auth, now time.Time) bool {
+	if auth == nil || auth.Metadata == nil {
+		return false
+	}
+	if _, ok := auth.Metadata[ClaudeOAuthHealthMetadataKey]; !ok {
+		return false
+	}
+
+	health := cloneClaudeOAuthHealth(auth)
+	changed := false
+	if status, _ := health["status"].(string); !strings.EqualFold(strings.TrimSpace(status), claudeOAuthHealthStatusActive) {
+		health["status"] = claudeOAuthHealthStatusActive
+		changed = true
+	}
+	if _, ok := health["temporary_unschedulable_until"]; ok {
+		delete(health, "temporary_unschedulable_until")
+		changed = true
+	}
+	if _, ok := health["temporary_unschedulable_reason"]; ok {
+		delete(health, "temporary_unschedulable_reason")
+		changed = true
+	}
+	if !changed {
+		return false
+	}
+	health["updated_at"] = formatClaudeOAuthHealthTime(now)
+	auth.Metadata[ClaudeOAuthHealthMetadataKey] = health
+	return true
+}
+
 func applyClaudeOAuthFailureLocked(auth *Auth, result Result, now time.Time, effects *resultStateEffects) bool {
 	if !isClaudeOAuthAuth(auth) {
 		return false

--- a/sdk/cliproxy/auth/quota_reconcile.go
+++ b/sdk/cliproxy/auth/quota_reconcile.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"net/http"
 	"strings"
 	"time"
 )
@@ -91,7 +90,13 @@ func (m *Manager) UpdateQuotaFromProbe(ctx context.Context, id string, result *Q
 	return updated != nil, nil
 }
 
-// ClearQuotaStatus manually clears local quota/cooldown runtime state for an auth entry.
+// ClearQuotaStatus manually clears local runtime restrictions for an auth entry.
+//
+// The method name and management route are retained for API compatibility, but
+// this is an operator reset rather than quota reconciliation: auth/model errors,
+// cooldowns, refresh backoff, quota gates, and provider-specific scheduling
+// metadata must all be cleared together so the credential can be tried once
+// immediately. A real upstream failure may then establish a new restriction.
 func (m *Manager) ClearQuotaStatus(ctx context.Context, id string) (bool, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -115,7 +120,7 @@ func (m *Manager) ClearQuotaStatus(ctx context.Context, id string) (bool, error)
 		return false, nil
 	}
 
-	changed, models := clearQuotaStatusForAuth(current, now)
+	changed, models := clearManualRuntimeStatusForAuth(current, now)
 	recoveredModels = models
 	delete(m.quotaProbeAfter, id)
 	if changed {
@@ -366,31 +371,25 @@ func hasQuotaExceededModel(auth *Auth) bool {
 	return false
 }
 
-func clearQuotaStatusForAuth(auth *Auth, now time.Time) (bool, []string) {
+func clearManualRuntimeStatusForAuth(auth *Auth, now time.Time) (bool, []string) {
 	if auth == nil {
 		return false, nil
 	}
 
-	authHadQuotaRuntime := hasQuotaRuntimeState(auth.StatusMessage, auth.LastError, auth.Unavailable, auth.NextRetryAfter, auth.Quota)
 	var changed bool
 	recoveredModels := make([]string, 0, len(auth.ModelStates))
 	for modelID, state := range auth.ModelStates {
-		if clearQuotaModelRuntimeState(state, now) {
+		if clearManualModelRuntimeState(state, now) {
 			changed = true
-			recoveredModels = append(recoveredModels, modelID)
+			if state.Status != StatusDisabled {
+				recoveredModels = append(recoveredModels, modelID)
+			}
 		}
 	}
-
-	if len(auth.ModelStates) > 0 {
-		beforeUnavailable := auth.Unavailable
-		beforeNextRetry := auth.NextRetryAfter
-		beforeQuota := auth.Quota
-		updateAggregatedAvailability(auth, now)
-		if auth.Unavailable != beforeUnavailable || !auth.NextRetryAfter.Equal(beforeNextRetry) || auth.Quota != beforeQuota {
-			changed = true
-		}
+	if clearManualAuthRuntimeState(auth, now) {
+		changed = true
 	}
-	if clearQuotaAuthRuntimeState(auth, now, authHadQuotaRuntime) {
+	if clearClaudeOAuthRuntimeRestrictionLocked(auth, now) {
 		changed = true
 	}
 	return changed, recoveredModels
@@ -496,20 +495,23 @@ func clearQuotaModelState(state *ModelState, now time.Time) bool {
 	return changed
 }
 
-func clearQuotaModelRuntimeState(state *ModelState, now time.Time) bool {
-	if state == nil || !hasQuotaRuntimeState(state.StatusMessage, state.LastError, state.Unavailable, state.NextRetryAfter, state.Quota) {
+func clearManualModelRuntimeState(state *ModelState, now time.Time) bool {
+	if state == nil {
 		return false
 	}
 	preserveDisabled := state.Status == StatusDisabled
 	changed := state.Unavailable || !state.NextRetryAfter.IsZero() || state.LastError != nil || state.Quota != (QuotaState{})
+	if !preserveDisabled && (state.Status != StatusActive || state.StatusMessage != "") {
+		changed = true
+	}
+	if !changed {
+		return false
+	}
 	state.Unavailable = false
 	state.NextRetryAfter = time.Time{}
 	state.LastError = nil
 	state.Quota = QuotaState{}
 	if !preserveDisabled {
-		if state.Status != StatusActive || state.StatusMessage != "" {
-			changed = true
-		}
 		state.Status = StatusActive
 		state.StatusMessage = ""
 	}
@@ -561,44 +563,29 @@ func clearQuotaAuthState(auth *Auth, now time.Time) bool {
 	return changed
 }
 
-func clearQuotaAuthRuntimeState(auth *Auth, now time.Time, force bool) bool {
-	if auth == nil || (!force && !hasQuotaRuntimeState(auth.StatusMessage, auth.LastError, auth.Unavailable, auth.NextRetryAfter, auth.Quota)) {
+func clearManualAuthRuntimeState(auth *Auth, now time.Time) bool {
+	if auth == nil {
 		return false
 	}
 	preserveDisabled := auth.Status == StatusDisabled
-	changed := auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.LastError != nil || auth.Quota != (QuotaState{})
+	changed := auth.Unavailable || !auth.NextRetryAfter.IsZero() || !auth.NextRefreshAfter.IsZero() || auth.LastError != nil || auth.Quota != (QuotaState{})
+	if !preserveDisabled && (auth.Status != StatusActive || auth.StatusMessage != "") {
+		changed = true
+	}
+	if !changed {
+		return false
+	}
 	auth.Unavailable = false
 	auth.NextRetryAfter = time.Time{}
+	auth.NextRefreshAfter = time.Time{}
 	auth.LastError = nil
 	auth.Quota = QuotaState{}
 	if !preserveDisabled {
-		if auth.Status != StatusActive || auth.StatusMessage != "" {
-			changed = true
-		}
 		auth.Status = StatusActive
 		auth.StatusMessage = ""
 	}
 	auth.UpdatedAt = now
 	return changed
-}
-
-func hasQuotaRuntimeState(statusMessage string, lastError *Error, unavailable bool, nextRetryAfter time.Time, quota QuotaState) bool {
-	if quota != (QuotaState{}) || unavailable || !nextRetryAfter.IsZero() {
-		return true
-	}
-	if lastError != nil {
-		// 429 and quota-like 402 (xAI weekly balance exhausted) are both local quota runtime.
-		if lastError.HTTPStatus == http.StatusTooManyRequests ||
-			(lastError.HTTPStatus == http.StatusPaymentRequired && (lastError.QuotaWindow != "" || isUsageBalanceExhaustedMessage(lastError.Message))) {
-			return true
-		}
-		text := strings.ToLower(strings.TrimSpace(lastError.Code + " " + lastError.Message))
-		if strings.Contains(text, "quota") || strings.Contains(text, "rate limit") || strings.Contains(text, "429") || strings.Contains(text, "cooldown") || strings.Contains(text, "balance exhausted") {
-			return true
-		}
-	}
-	text := strings.ToLower(strings.TrimSpace(statusMessage))
-	return strings.Contains(text, "quota") || strings.Contains(text, "rate limit") || strings.Contains(text, "429") || strings.Contains(text, "cooldown") || strings.Contains(text, "balance exhausted")
 }
 
 func updateQuotaAuthRecoverAt(auth *Auth, next time.Time, now time.Time) bool {

--- a/sdk/cliproxy/auth/quota_reconcile_test.go
+++ b/sdk/cliproxy/auth/quota_reconcile_test.go
@@ -308,20 +308,168 @@ func TestManagerClearQuotaStatus_ClearsAuthAndModelRuntimeQuota(t *testing.T) {
 	}
 }
 
+func TestManagerClearQuotaStatus_ClearsUnauthorizedWithoutQuotaState(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	now := time.Now()
+	auth := &Auth{
+		ID:               "xai-auth",
+		Provider:         "xai",
+		Status:           StatusError,
+		LastError:        &Error{HTTPStatus: http.StatusUnauthorized},
+		NextRefreshAfter: now.Add(10 * time.Minute),
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	changed, err := manager.ClearQuotaStatus(context.Background(), auth.ID)
+	if err != nil {
+		t.Fatalf("ClearQuotaStatus() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("ClearQuotaStatus() changed = false, want true for auth-level 401")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("GetByID() missing auth")
+	}
+	if updated.Status != StatusActive || updated.StatusMessage != "" || updated.LastError != nil {
+		t.Fatalf("auth error state was not cleared: %#v", updated)
+	}
+	if updated.Unavailable || !updated.NextRetryAfter.IsZero() || !updated.NextRefreshAfter.IsZero() || updated.Quota != (QuotaState{}) {
+		t.Fatalf("auth retry state was not cleared: %#v", updated)
+	}
+	if blocked, reason, next := isAuthBlockedForModel(updated, "grok-4.5", time.Now()); blocked {
+		t.Fatalf("auth remains blocked after manual clear: reason=%v next=%v", reason, next)
+	}
+}
+
+func TestManagerClearQuotaStatus_ClearsModelUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	next := time.Now().Add(30 * time.Minute)
+	auth := &Auth{
+		ID:             "xai-model-auth",
+		Provider:       "xai",
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: next,
+		LastError:      &Error{HTTPStatus: http.StatusUnauthorized},
+		ModelStates: map[string]*ModelState{
+			"grok-4.5": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: next,
+				LastError:      &Error{HTTPStatus: http.StatusUnauthorized},
+			},
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	changed, err := manager.ClearQuotaStatus(context.Background(), auth.ID)
+	if err != nil {
+		t.Fatalf("ClearQuotaStatus() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("ClearQuotaStatus() changed = false, want true for model-level 401")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("GetByID() missing auth")
+	}
+	state := updated.ModelStates["grok-4.5"]
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.Status != StatusActive || state.StatusMessage != "" || state.Unavailable || !state.NextRetryAfter.IsZero() || state.LastError != nil || state.Quota != (QuotaState{}) {
+		t.Fatalf("model 401 state was not cleared: %#v", state)
+	}
+	if blocked, reason, retryAt := isAuthBlockedForModel(updated, "grok-4.5", time.Now()); blocked {
+		t.Fatalf("model remains blocked after manual clear: reason=%v next=%v", reason, retryAt)
+	}
+}
+
+func TestManagerClearQuotaStatus_ClearsClaudeOAuthSchedulingMetadata(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil)
+	now := time.Now()
+	auth := &Auth{
+		ID:             "claude-oauth",
+		Provider:       "claude",
+		Status:         StatusActive,
+		StatusMessage:  claudeOAuthRefreshPendingMessage,
+		Unavailable:    true,
+		NextRetryAfter: now.Add(claudeOAuth401Cooldown),
+		LastError:      &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid oauth token"},
+		Metadata: map[string]any{
+			"type":          "claude",
+			"access_token":  "access-token",
+			"refresh_token": "refresh-token",
+			ClaudeOAuthHealthMetadataKey: map[string]any{
+				"status":                         claudeOAuthHealthStatusRefreshPending,
+				"temporary_unschedulable_until":  formatClaudeOAuthHealthTime(now.Add(claudeOAuth401Cooldown)),
+				"temporary_unschedulable_reason": claudeOAuthReasonOAuth401,
+				"last_401_at":                    formatClaudeOAuthHealthTime(now),
+			},
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	changed, err := manager.ClearQuotaStatus(context.Background(), auth.ID)
+	if err != nil {
+		t.Fatalf("ClearQuotaStatus() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("ClearQuotaStatus() changed = false, want true for Claude OAuth metadata")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("GetByID() missing auth")
+	}
+	health := cloneClaudeOAuthHealth(updated)
+	if health["status"] != claudeOAuthHealthStatusActive {
+		t.Fatalf("claude_oauth_health status = %#v, want active", health["status"])
+	}
+	if _, ok := health["temporary_unschedulable_until"]; ok {
+		t.Fatalf("temporary_unschedulable_until survived clear: %#v", health)
+	}
+	if _, ok := health["temporary_unschedulable_reason"]; ok {
+		t.Fatalf("temporary_unschedulable_reason survived clear: %#v", health)
+	}
+	if health["last_401_at"] == nil {
+		t.Fatalf("historical diagnostics were removed: %#v", health)
+	}
+	if claudeOAuthRefreshPending(updated) {
+		t.Fatalf("Claude OAuth refresh-pending side state still blocks scheduling: %#v", health)
+	}
+}
+
 func TestManagerClearQuotaStatus_PreservesStatusDisabled(t *testing.T) {
 	t.Parallel()
 
 	manager := NewManager(nil, nil, nil)
 	next := time.Now().Add(30 * time.Minute)
 	auth := &Auth{
-		ID:             "disabled-auth",
-		Provider:       "codex",
-		Status:         StatusDisabled,
-		StatusMessage:  "manually disabled",
-		Disabled:       true,
-		Unavailable:    true,
-		NextRetryAfter: next,
-		LastError:      &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+		ID:               "disabled-auth",
+		Provider:         "codex",
+		Status:           StatusDisabled,
+		StatusMessage:    "manually disabled",
+		Disabled:         true,
+		Unavailable:      true,
+		NextRetryAfter:   next,
+		NextRefreshAfter: next,
+		LastError:        &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
 		Quota: QuotaState{
 			Exceeded:      true,
 			Reason:        "quota",
@@ -361,7 +509,7 @@ func TestManagerClearQuotaStatus_PreservesStatusDisabled(t *testing.T) {
 	if !updated.Disabled || updated.Status != StatusDisabled || updated.StatusMessage != "manually disabled" {
 		t.Fatalf("disabled auth status changed: disabled=%v status=%q message=%q", updated.Disabled, updated.Status, updated.StatusMessage)
 	}
-	if updated.Unavailable || !updated.NextRetryAfter.IsZero() || updated.LastError != nil || updated.Quota != (QuotaState{}) {
+	if updated.Unavailable || !updated.NextRetryAfter.IsZero() || !updated.NextRefreshAfter.IsZero() || updated.LastError != nil || updated.Quota != (QuotaState{}) {
 		t.Fatalf("disabled auth quota runtime state was not cleared: %#v", updated)
 	}
 	state := updated.ModelStates["gpt-5-codex"]


### PR DESCRIPTION
## 根因

- `ClearQuotaStatus` 先经过 `hasQuotaRuntimeState` 门槛；该判断只识别 quota / rate-limit / cooldown 等配额信号。纯 `StatusError + LastError{HTTPStatus: 401}`、且没有 quota 状态的账号会被判定为无可清内容，导致显式“清除状态”请求直接 `changed=false`。
- 清除成功后，`BuildEntry` 会省略空的 `restrictions` 字段；配套前端此前使用 `fresh.restrictions ?? previous.restrictions` 合并轮询结果，会把旧 restriction 回填回来，使 401 徽章及原恢复时间原样“复活”。
- Claude OAuth 还有 `claude_oauth_health` 旁路调度状态；旧实现未清除 `temporary_unschedulable_until`、`temporary_unschedulable_reason=oauth_401`、`status=refresh_pending`，因此主运行时状态清掉后仍可能不可调度。

## 改动范围

- 将 `ClearQuotaStatus` 明确定义为用户显式运维清除：清理 auth/model 级可恢复运行时错误、冷却、`LastError`、quota 状态及 auth refresh retry 状态。
- 保留 `StatusDisabled` 及禁用原因，不把被禁用账号错误恢复为可用；只恢复非 disabled 模型的 registry suspension。
- 清除 Claude OAuth 临时不可调度/refresh-pending metadata，同时保留 `last_401_at` 等历史诊断字段。
- 保持自动 quota 恢复、`quotaNeedsConfirmedRecovery`、`disable_cooling` 和 xAI 402 周额度语义不变。
- 补充 manager、management handler 与 restriction payload 回归测试，覆盖纯 401、模型级 401、disabled 保留和 Claude OAuth 旁路状态清除。

## 验证

- `go test ./sdk/cliproxy/auth/... ./internal/management/authfiles/... ./internal/api/handlers/management/...`：通过（3 packages，640 tests）。
- `go build ./...`：通过。
- `python3 scripts/check-backend-structure.py`：通过。
- `./scripts/ci-pr.sh`：通过（secret scan、结构检查、gofmt、go vet、全量 `go test ./...`、golangci-lint、server build）。
- restriction 回归证据：清除前为 `[{"scope":"auth","status":"error","unavailable":false,"http_status":401}]`，清除后为 `[]`。

## 跨仓依赖

配套前端 PR：kittors/codeProxy#862

后端会以字段缺失表达“restriction 已清除”，前端必须同时停止用旧值回填该权威字段；**两侧必须一起上线才算完整修复**。
