### PR TITLE
fix(ollama): handle images for non-vision models

### DIFF
--- a/internal/runtime/executor/image_input_sanitize.go
+++ b/internal/runtime/executor/image_input_sanitize.go
@@ -1,0 +1,169 @@
+package executor
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func opencodeGoSanitizeHistoricalImages(payload []byte) ([]byte, bool) {
+	return sanitizeImageInputs(payload, "[Image omitted from previous turn.]", false)
+}
+
+func sanitizeImageInputs(payload []byte, placeholder string, alwaysPlaceholder bool) ([]byte, bool) {
+	if len(payload) == 0 || !json.Valid(payload) {
+		return payload, false
+	}
+	var root map[string]any
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return payload, false
+	}
+	changed := false
+	if messages, ok := root["messages"].([]any); ok {
+		if sanitizeImageMessageArray(messages, placeholder, alwaysPlaceholder) {
+			root["messages"] = messages
+			changed = true
+		}
+	}
+	if input, ok := root["input"]; ok {
+		if sanitized, ok := sanitizeImageResponsesInput(input, placeholder, alwaysPlaceholder); ok {
+			root["input"] = sanitized
+			changed = true
+		}
+	}
+	if !changed {
+		return payload, false
+	}
+	out, err := json.Marshal(root)
+	if err != nil {
+		return payload, false
+	}
+	return out, true
+}
+
+func sanitizeImageMessageArray(messages []any, placeholder string, alwaysPlaceholder bool) bool {
+	changed := false
+	for _, raw := range messages {
+		message, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		content, ok := message["content"]
+		if !ok {
+			continue
+		}
+		if sanitized, ok := sanitizeImageContentParts(content, "text", placeholder, alwaysPlaceholder); ok {
+			message["content"] = sanitized
+			changed = true
+		}
+	}
+	return changed
+}
+
+func sanitizeImageResponsesInput(input any, placeholder string, alwaysPlaceholder bool) (any, bool) {
+	switch typed := input.(type) {
+	case []any:
+		changed := false
+		for i, raw := range typed {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if opencodeGoContentPartIsImage(item) {
+				typed[i] = imagePlaceholderPart("input_text", placeholder)
+				changed = true
+				continue
+			}
+			content, ok := item["content"]
+			if !ok {
+				continue
+			}
+			if sanitized, ok := sanitizeImageContentParts(content, "input_text", placeholder, alwaysPlaceholder); ok {
+				item["content"] = sanitized
+				changed = true
+			}
+		}
+		return typed, changed
+	case map[string]any:
+		if opencodeGoContentPartIsImage(typed) {
+			return imagePlaceholderPart("input_text", placeholder), true
+		}
+		content, ok := typed["content"]
+		if !ok {
+			return input, false
+		}
+		if sanitized, ok := sanitizeImageContentParts(content, "input_text", placeholder, alwaysPlaceholder); ok {
+			typed["content"] = sanitized
+			return typed, true
+		}
+	}
+	return input, false
+}
+
+func sanitizeImageContentParts(content any, placeholderType, placeholder string, alwaysPlaceholder bool) (any, bool) {
+	parts, ok := content.([]any)
+	if !ok {
+		return content, false
+	}
+	changed := false
+	out := make([]any, 0, len(parts))
+	for _, part := range parts {
+		partMap, ok := part.(map[string]any)
+		if !ok || !opencodeGoContentPartIsImage(partMap) {
+			out = append(out, part)
+			continue
+		}
+		if alwaysPlaceholder || !opencodeGoContentPartsHaveText(out) {
+			out = append(out, imagePlaceholderPart(placeholderType, placeholder))
+		}
+		changed = true
+	}
+	if !changed {
+		return content, false
+	}
+	if len(out) == 0 {
+		out = append(out, imagePlaceholderPart(placeholderType, placeholder))
+	}
+	return out, true
+}
+
+func opencodeGoContentPartIsImage(part map[string]any) bool {
+	rawType, _ := part["type"].(string)
+	switch strings.ToLower(strings.TrimSpace(rawType)) {
+	case "image", "image_url", "input_image":
+		return true
+	}
+	_, ok := part["image_url"]
+	return ok
+}
+
+func opencodeGoContentPartsHaveText(parts []any) bool {
+	for _, part := range parts {
+		partMap, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		rawType, _ := partMap["type"].(string)
+		switch strings.ToLower(strings.TrimSpace(rawType)) {
+		case "text", "input_text", "output_text":
+			if text, _ := partMap["text"].(string); strings.TrimSpace(text) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func imagePlaceholderPart(partType, placeholder string) map[string]any {
+	partType = strings.TrimSpace(partType)
+	if partType == "" {
+		partType = "text"
+	}
+	placeholder = strings.TrimSpace(placeholder)
+	if placeholder == "" {
+		placeholder = "[Image omitted.]"
+	}
+	return map[string]any{
+		"type": partType,
+		"text": placeholder,
+	}
+}

--- a/internal/runtime/executor/ollama_cloud_executor.go
+++ b/internal/runtime/executor/ollama_cloud_executor.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
@@ -23,6 +25,18 @@ import (
 type OllamaCloudExecutor struct {
 	cfg *config.Config
 }
+
+const (
+	ollamaCloudCapabilityCacheTTL  = 10 * time.Minute
+	ollamaCloudImagePlaceholderKey = "ollama_cloud_image_placeholder"
+)
+
+type ollamaCloudCapabilityCacheEntry struct {
+	supportsVision bool
+	expiresAt      time.Time
+}
+
+var ollamaCloudCapabilityCache sync.Map
 
 func NewOllamaCloudExecutor(cfg *config.Config) *OllamaCloudExecutor {
 	return &OllamaCloudExecutor{cfg: cfg}
@@ -61,33 +75,48 @@ func (e *OllamaCloudExecutor) HttpRequest(ctx context.Context, auth *cliproxyaut
 }
 
 func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	preparedCtx, prepared, err := e.prepareImageInput(ctx, auth, req, opts)
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	ctx = preparedCtx
+	req = prepared.Request
+
+	var resp cliproxyexecutor.Response
 	if opts.Alt != "responses/compact" && (opts.SourceFormat == sdktranslator.FormatOpenAIResponse || opts.SourceFormat == sdktranslator.FormatOpenAI) {
-		return e.executeNativeChat(ctx, auth, req, opts)
+		resp, err = e.executeNativeChat(ctx, auth, req, opts)
+	} else if opts.Alt != "responses/compact" && opts.SourceFormat == sdktranslator.FormatClaude {
+		resp, err = e.executeDirect(ctx, auth, req, opts, sdktranslator.FormatClaude, "/messages", parseClaudeUsage)
+	} else {
+		resp, err = e.openAIExecutor().Execute(ctx, e.openAIAuth(auth), req, opts)
 	}
-	if opts.Alt != "responses/compact" {
-		switch opts.SourceFormat {
-		case sdktranslator.FormatOpenAIResponse:
-			return e.executeDirect(ctx, auth, req, opts, sdktranslator.FormatOpenAIResponse, "/responses", parseOpenAIUsage)
-		case sdktranslator.FormatClaude:
-			return e.executeDirect(ctx, auth, req, opts, sdktranslator.FormatClaude, "/messages", parseClaudeUsage)
-		}
+	if err != nil || !prepared.Applied {
+		return resp, err
 	}
-	return e.openAIExecutor().Execute(ctx, e.openAIAuth(auth), req, opts)
+	resp.Payload = opencodeGoRewriteFallbackResponseModel(resp.Payload, prepared.OriginalModel)
+	return resp, nil
 }
 
 func (e *OllamaCloudExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	preparedCtx, prepared, err := e.prepareImageInput(ctx, auth, req, opts)
+	if err != nil {
+		return nil, err
+	}
+	ctx = preparedCtx
+	req = prepared.Request
+
+	var result *cliproxyexecutor.StreamResult
 	if opts.Alt != "responses/compact" && (opts.SourceFormat == sdktranslator.FormatOpenAIResponse || opts.SourceFormat == sdktranslator.FormatOpenAI) {
-		return e.executeNativeChatStream(ctx, auth, req, opts)
+		result, err = e.executeNativeChatStream(ctx, auth, req, opts)
+	} else if opts.Alt != "responses/compact" && opts.SourceFormat == sdktranslator.FormatClaude {
+		result, err = e.executeDirectStream(ctx, auth, req, opts, sdktranslator.FormatClaude, "/messages", parseClaudeStreamUsage)
+	} else {
+		result, err = e.openAIExecutor().ExecuteStream(ctx, e.openAIAuth(auth), req, opts)
 	}
-	if opts.Alt != "responses/compact" {
-		switch opts.SourceFormat {
-		case sdktranslator.FormatOpenAIResponse:
-			return e.executeDirectStream(ctx, auth, req, opts, sdktranslator.FormatOpenAIResponse, "/responses", parseOpenAIResponsesStreamUsage)
-		case sdktranslator.FormatClaude:
-			return e.executeDirectStream(ctx, auth, req, opts, sdktranslator.FormatClaude, "/messages", parseClaudeStreamUsage)
-		}
+	if err != nil || !prepared.Applied {
+		return result, err
 	}
-	return e.openAIExecutor().ExecuteStream(ctx, e.openAIAuth(auth), req, opts)
+	return opencodeGoRewriteFallbackStreamResult(result, prepared.OriginalModel), nil
 }
 
 func (e *OllamaCloudExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
@@ -221,8 +250,130 @@ func (e *OllamaCloudExecutor) prepareDirect(ctx context.Context, auth *cliproxya
 	if err != nil {
 		return nil, nil, err
 	}
+	updated = applyOllamaCloudImagePolicy(req, updated)
 	updated = applyProviderPromptCaching(updated, req.Payload, auth, e.Identifier(), execCtx.BaseModel, target, opts)
 	return execCtx, updated, nil
+}
+
+func (e *OllamaCloudExecutor) prepareImageInput(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (context.Context, opencodeGoVisionFallbackResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result := opencodeGoVisionFallbackResult{
+		Request:       req,
+		OriginalModel: payloadRequestedModel(opts, req.Model),
+	}
+	if !opencodeGoPayloadHasImage(req.Payload) {
+		return ctx, result, nil
+	}
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+
+	supportsVision, capabilityErr := e.modelSupportsVision(ctx, auth, baseModel)
+	if capabilityErr == nil && supportsVision {
+		return ctx, result, nil
+	}
+
+	fallbackModel := openAICompatVisionFallbackModel(e.cfg, auth, e.Identifier())
+	if fallbackModel != "" && !strings.EqualFold(baseModel, fallbackModel) {
+		fallbackSupportsVision, fallbackErr := e.modelSupportsVision(ctx, auth, fallbackModel)
+		if fallbackErr == nil && fallbackSupportsVision {
+			req.Model = fallbackModel
+			req.Payload, _ = sjson.SetBytes(req.Payload, "model", fallbackModel)
+			result.Request = req
+			result.FallbackModel = fallbackModel
+			result.Applied = true
+			ctx = contextWithVisionFallbackLog(ctx, result.OriginalModel, baseModel, fallbackModel)
+			return ctx, result, nil
+		}
+	}
+
+	placeholder := "[Image omitted: the selected Ollama model does not support image input. Switch to a vision-capable model to analyze it.]"
+	if capabilityErr != nil {
+		log.Warnf("ollama cloud executor: could not verify vision capability for %s: %v", baseModel, capabilityErr)
+		placeholder = "[Image omitted: CliRelay could not verify that the selected Ollama model supports image input. Switch to a verified vision-capable model to analyze it.]"
+	}
+	result.Request = withOllamaCloudImagePlaceholder(req, placeholder)
+	return ctx, result, nil
+}
+
+func (e *OllamaCloudExecutor) modelSupportsVision(ctx context.Context, auth *cliproxyauth.Auth, model string) (bool, error) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false, fmt.Errorf("model is empty")
+	}
+	baseURL, _ := e.resolveCredentials(auth)
+	cacheKey := strings.ToLower(ollamaCloudNativeBaseURL(baseURL) + "\x00" + model)
+	if cached, ok := ollamaCloudCapabilityCache.Load(cacheKey); ok {
+		entry, _ := cached.(ollamaCloudCapabilityCacheEntry)
+		if time.Now().Before(entry.expiresAt) {
+			return entry.supportsVision, nil
+		}
+		ollamaCloudCapabilityCache.Delete(cacheKey)
+	}
+
+	body := []byte(`{"model":"","verbose":false}`)
+	body, _ = sjson.SetBytes(body, "model", model)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, ollamaCloudNativeBaseURL(baseURL)+"/api/show", bytes.NewReader(body))
+	if err != nil {
+		return false, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", "cli-proxy-ollama-cloud")
+	if err = e.PrepareRequest(httpReq, auth); err != nil {
+		return false, err
+	}
+
+	httpResp, err := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0).Do(httpReq)
+	if err != nil {
+		return false, err
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return false, fmt.Errorf("capability request returned status %d: %s", httpResp.StatusCode, strings.TrimSpace(string(readUpstreamErrorBody(e.Identifier(), httpResp.Body))))
+	}
+	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
+	if err != nil {
+		return false, err
+	}
+	capabilities := gjson.GetBytes(data, "capabilities")
+	if !capabilities.IsArray() {
+		return false, fmt.Errorf("capability response has no capabilities array")
+	}
+	supportsVision := false
+	for _, capability := range capabilities.Array() {
+		if strings.EqualFold(strings.TrimSpace(capability.String()), "vision") {
+			supportsVision = true
+			break
+		}
+	}
+	ollamaCloudCapabilityCache.Store(cacheKey, ollamaCloudCapabilityCacheEntry{
+		supportsVision: supportsVision,
+		expiresAt:      time.Now().Add(ollamaCloudCapabilityCacheTTL),
+	})
+	return supportsVision, nil
+}
+
+func withOllamaCloudImagePlaceholder(req cliproxyexecutor.Request, placeholder string) cliproxyexecutor.Request {
+	metadata := make(map[string]any, len(req.Metadata)+1)
+	for key, value := range req.Metadata {
+		metadata[key] = value
+	}
+	metadata[ollamaCloudImagePlaceholderKey] = placeholder
+	req.Metadata = metadata
+	return req
+}
+
+func applyOllamaCloudImagePolicy(req cliproxyexecutor.Request, payload []byte) []byte {
+	placeholder, _ := req.Metadata[ollamaCloudImagePlaceholderKey].(string)
+	placeholder = strings.TrimSpace(placeholder)
+	if placeholder == "" {
+		return payload
+	}
+	if updated, changed := sanitizeImageInputs(payload, placeholder, true); changed {
+		return updated
+	}
+	return payload
 }
 
 func (e *OllamaCloudExecutor) doJSON(execCtx *ExecutionContext, auth *cliproxyauth.Auth, endpoint string, body []byte, stream bool) (*http.Response, error) {

--- a/internal/runtime/executor/ollama_cloud_executor_test.go
+++ b/internal/runtime/executor/ollama_cloud_executor_test.go
@@ -47,6 +47,240 @@ func TestOllamaCloudExecutorRoutesChatToOpenAICompatibleV1(t *testing.T) {
 	}
 }
 
+func TestOllamaCloudExecutorStripsImagesForNonVisionModelsAcrossIngressFormats(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   sdktranslator.Format
+		payload  string
+		wantPath string
+	}{
+		{
+			name:     "openai",
+			source:   sdktranslator.FormatOpenAI,
+			payload:  `{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`,
+			wantPath: "/api/chat",
+		},
+		{
+			name:     "claude",
+			source:   sdktranslator.FormatClaude,
+			payload:  `{"model":"deepseek-v4-flash","max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGVsbG8="}}]}]}`,
+			wantPath: "/v1/messages",
+		},
+		{
+			name:     "gemini",
+			source:   sdktranslator.FormatGemini,
+			payload:  `{"model":"deepseek-v4-flash","contents":[{"role":"user","parts":[{"text":"describe"},{"inlineData":{"mimeType":"image/png","data":"aGVsbG8="}}]}]}`,
+			wantPath: "/v1/chat/completions",
+		},
+		{
+			name:     "openai tool history",
+			source:   sdktranslator.FormatOpenAI,
+			payload:  `{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"capture the screen"},{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"capture","arguments":"{}"}}]},{"role":"tool","tool_call_id":"call_1","content":[{"type":"text","text":"screenshot"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]},{"role":"user","content":"continue with text"}]}`,
+			wantPath: "/api/chat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			var gotBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/show":
+					_, _ = w.Write([]byte(`{"capabilities":["completion","tools"]}`))
+					return
+				case "/api/chat":
+					_, _ = w.Write([]byte(`{"model":"deepseek-v4-flash","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`))
+				case "/v1/messages":
+					_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"deepseek-v4-flash","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+				case "/v1/chat/completions":
+					_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+				default:
+					http.NotFound(w, r)
+					return
+				}
+				gotPath = r.URL.Path
+				gotBody, _ = io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "application/json")
+			}))
+			defer server.Close()
+
+			exec := NewOllamaCloudExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+			_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "deepseek-v4-flash",
+				Payload: []byte(tt.payload),
+			}, cliproxyexecutor.Options{SourceFormat: tt.source})
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if gotPath != tt.wantPath {
+				t.Fatalf("path = %q, want %q", gotPath, tt.wantPath)
+			}
+			if strings.Contains(string(gotBody), "aGVsbG8=") || strings.Contains(string(gotBody), `"images"`) || strings.Contains(string(gotBody), `"image_url"`) || strings.Contains(string(gotBody), `"type":"image"`) {
+				t.Fatalf("non-vision upstream received raw image content: %s", gotBody)
+			}
+			if !strings.Contains(string(gotBody), "Image omitted") {
+				t.Fatalf("upstream body lacks actionable image placeholder: %s", gotBody)
+			}
+		})
+	}
+}
+
+func TestOllamaCloudExecutorTextFollowUpAfterImageUsesCachedNonVisionCapability(t *testing.T) {
+	var showCalls int
+	var chatBodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			showCalls++
+			_, _ = w.Write([]byte(`{"capabilities":["completion","tools"]}`))
+		case "/api/chat":
+			body, _ := io.ReadAll(r.Body)
+			chatBodies = append(chatBodies, body)
+			_, _ = w.Write([]byte(`{"model":"deepseek-v4-flash","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	requests := []string{
+		`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`,
+		`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]},{"role":"assistant","content":"ok"},{"role":"user","content":"now answer a text-only follow-up"}]}`,
+	}
+	for _, payload := range requests {
+		if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "deepseek-v4-flash",
+			Payload: []byte(payload),
+		}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}); err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+	}
+
+	if showCalls != 1 {
+		t.Fatalf("/api/show calls = %d, want 1 cached capability lookup", showCalls)
+	}
+	if len(chatBodies) != 2 {
+		t.Fatalf("/api/chat calls = %d, want 2", len(chatBodies))
+	}
+	for i, body := range chatBodies {
+		if strings.Contains(string(body), `"images"`) || strings.Contains(string(body), "aGVsbG8=") {
+			t.Fatalf("chat body %d retained image input: %s", i, body)
+		}
+	}
+}
+
+func TestOllamaCloudExecutorPreservesImagesForVisionModel(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			_, _ = w.Write([]byte(`{"capabilities":["completion","tools","vision"]}`))
+		case "/api/chat":
+			gotBody, _ = io.ReadAll(r.Body)
+			_, _ = w.Write([]byte(`{"model":"qwen3.5:397b","message":{"role":"assistant","content":"vision ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "qwen3.5:397b",
+		Payload: []byte(`{"model":"qwen3.5:397b","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if got := gjson.GetBytes(gotBody, "messages.0.images.0").String(); got != "aGVsbG8=" {
+		t.Fatalf("vision model image = %q, want base64 payload; body=%s", got, gotBody)
+	}
+}
+
+func TestOllamaCloudExecutorUsesVerifiedVisionFallback(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			body, _ := io.ReadAll(r.Body)
+			if gjson.GetBytes(body, "model").String() == "qwen3.5:397b" {
+				_, _ = w.Write([]byte(`{"capabilities":["completion","vision"]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"capabilities":["completion","tools"]}`))
+			}
+		case "/api/chat":
+			gotBody, _ = io.ReadAll(r.Body)
+			_, _ = w.Write([]byte(`{"model":"qwen3.5:397b","message":{"role":"assistant","content":"vision ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":               "test-key",
+		"base_url":              server.URL,
+		"vision_fallback_model": "qwen3.5:397b",
+	}}
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if got := gjson.GetBytes(gotBody, "model").String(); got != "qwen3.5:397b" {
+		t.Fatalf("upstream model = %q, want verified vision fallback; body=%s", got, gotBody)
+	}
+	if got := gjson.GetBytes(gotBody, "messages.0.images.0").String(); got != "aGVsbG8=" {
+		t.Fatalf("fallback image = %q, want preserved image; body=%s", got, gotBody)
+	}
+	if got := gjson.GetBytes(resp.Payload, "model").String(); got != "deepseek-v4-flash" {
+		t.Fatalf("response model = %q, want original model; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestOllamaCloudExecutorStreamStripsImagesForNonVisionModel(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			_, _ = w.Write([]byte(`{"capabilities":["completion"]}`))
+		case "/api/chat":
+			gotBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(`{"model":"deepseek-v4-flash","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}` + "\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: []byte(`{"model":"deepseek-v4-flash","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}]}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream returned error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+	if strings.Contains(string(gotBody), "aGVsbG8=") || gjson.GetBytes(gotBody, "messages.0.images").Exists() {
+		t.Fatalf("stream upstream received image input: %s", gotBody)
+	}
+}
+
 func TestOllamaCloudNativeCacheKeyScopesExplicitPromptKey(t *testing.T) {
 	source := []byte(`{"model":"glm-5.2","prompt_cache_key":"shared-session","input":"hi"}`)
 	authA := &cliproxyauth.Auth{ID: "ollama-cloud:one"}

--- a/internal/runtime/executor/ollama_cloud_native_chat.go
+++ b/internal/runtime/executor/ollama_cloud_native_chat.go
@@ -173,6 +173,7 @@ func (e *OllamaCloudExecutor) prepareNativeChat(ctx context.Context, auth *clipr
 	if err != nil {
 		return nil, nil, nil, "", "", err
 	}
+	updated = applyOllamaCloudImagePolicy(req, updated)
 	updated = normalizeOpenAIChatToolCallMessages(updated)
 	updated = applyProviderPromptCaching(updated, req.Payload, auth, e.Identifier(), execCtx.BaseModel, sdktranslator.FormatOpenAI, opts)
 	body, promptText := ollamaNativeChatRequest(updated, stream)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -117,6 +117,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return resp, err
 	}
+	if strings.EqualFold(e.provider, "ollama-cloud") {
+		translated = applyOllamaCloudImagePolicy(req, translated)
+	}
 	if shouldNormalizeKimiCompatPayload(execCtx.BaseModel) {
 		translated, err = normalizeKimiToolMessageLinks(translated)
 		if err != nil {
@@ -249,6 +252,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	translated, err = thinking.ApplyThinking(translated, req.Model, execCtx.SourceFormat.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
+	}
+	if strings.EqualFold(e.provider, "ollama-cloud") {
+		translated = applyOllamaCloudImagePolicy(req, translated)
 	}
 	if shouldNormalizeKimiCompatPayload(execCtx.BaseModel) {
 		translated, err = normalizeKimiToolMessageLinks(translated)

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -425,161 +425,6 @@ func opencodeGoCurrentRequestHasImage(payload []byte) bool {
 	return vision.CurrentTurnHasImages(payload)
 }
 
-func opencodeGoSanitizeHistoricalImages(payload []byte) ([]byte, bool) {
-	if len(payload) == 0 || !json.Valid(payload) {
-		return payload, false
-	}
-	var root map[string]any
-	if err := json.Unmarshal(payload, &root); err != nil {
-		return payload, false
-	}
-	changed := false
-	if messages, ok := root["messages"].([]any); ok {
-		if opencodeGoSanitizeMessageArray(messages) {
-			root["messages"] = messages
-			changed = true
-		}
-	}
-	if input, ok := root["input"]; ok {
-		if sanitized, ok := opencodeGoSanitizeResponsesInput(input); ok {
-			root["input"] = sanitized
-			changed = true
-		}
-	}
-	if !changed {
-		return payload, false
-	}
-	out, err := json.Marshal(root)
-	if err != nil {
-		return payload, false
-	}
-	return out, true
-}
-
-func opencodeGoSanitizeMessageArray(messages []any) bool {
-	changed := false
-	for _, raw := range messages {
-		message, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		content, ok := message["content"]
-		if !ok {
-			continue
-		}
-		if sanitized, ok := opencodeGoSanitizeContentParts(content, "text"); ok {
-			message["content"] = sanitized
-			changed = true
-		}
-	}
-	return changed
-}
-
-func opencodeGoSanitizeResponsesInput(input any) (any, bool) {
-	switch typed := input.(type) {
-	case []any:
-		changed := false
-		for i, raw := range typed {
-			item, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			if opencodeGoContentPartIsImage(item) {
-				typed[i] = opencodeGoImagePlaceholderPart("input_text")
-				changed = true
-				continue
-			}
-			content, ok := item["content"]
-			if !ok {
-				continue
-			}
-			if sanitized, ok := opencodeGoSanitizeContentParts(content, "input_text"); ok {
-				item["content"] = sanitized
-				changed = true
-			}
-		}
-		return typed, changed
-	case map[string]any:
-		if opencodeGoContentPartIsImage(typed) {
-			return opencodeGoImagePlaceholderPart("input_text"), true
-		}
-		content, ok := typed["content"]
-		if !ok {
-			return input, false
-		}
-		if sanitized, ok := opencodeGoSanitizeContentParts(content, "input_text"); ok {
-			typed["content"] = sanitized
-			return typed, true
-		}
-	}
-	return input, false
-}
-
-func opencodeGoSanitizeContentParts(content any, placeholderType string) (any, bool) {
-	parts, ok := content.([]any)
-	if !ok {
-		return content, false
-	}
-	changed := false
-	out := make([]any, 0, len(parts))
-	for _, part := range parts {
-		partMap, ok := part.(map[string]any)
-		if !ok || !opencodeGoContentPartIsImage(partMap) {
-			out = append(out, part)
-			continue
-		}
-		if !opencodeGoContentPartsHaveText(out) {
-			out = append(out, opencodeGoImagePlaceholderPart(placeholderType))
-		}
-		changed = true
-	}
-	if !changed {
-		return content, false
-	}
-	if len(out) == 0 {
-		out = append(out, opencodeGoImagePlaceholderPart(placeholderType))
-	}
-	return out, true
-}
-
-func opencodeGoContentPartIsImage(part map[string]any) bool {
-	rawType, _ := part["type"].(string)
-	switch strings.ToLower(strings.TrimSpace(rawType)) {
-	case "image", "image_url", "input_image":
-		return true
-	}
-	_, ok := part["image_url"]
-	return ok
-}
-
-func opencodeGoContentPartsHaveText(parts []any) bool {
-	for _, part := range parts {
-		partMap, ok := part.(map[string]any)
-		if !ok {
-			continue
-		}
-		rawType, _ := partMap["type"].(string)
-		switch strings.ToLower(strings.TrimSpace(rawType)) {
-		case "text", "input_text", "output_text":
-			if text, _ := partMap["text"].(string); strings.TrimSpace(text) != "" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func opencodeGoImagePlaceholderPart(partType string) map[string]any {
-	partType = strings.TrimSpace(partType)
-	if partType == "" {
-		partType = "text"
-	}
-	return map[string]any{
-		"type": partType,
-		"text": "[Image omitted from previous turn.]",
-	}
-}
-
 func opencodeGoCurrentValueHasImage(value any) (bool, bool) {
 	root, ok := value.(map[string]any)
 	if !ok {
@@ -667,6 +512,12 @@ func opencodeGoValueHasImage(value any) bool {
 			}
 		}
 		if _, ok := typed["image_url"]; ok {
+			return true
+		}
+		if _, ok := typed["inlineData"]; ok {
+			return true
+		}
+		if _, ok := typed["inline_data"]; ok {
 			return true
 		}
 		for _, child := range typed {


### PR DESCRIPTION
## Summary
- Non-vision Ollama Cloud models (e.g. `ollama/deepseek-v4-flash`) no longer permanently break chats that already contain images.
- Before upstream call, query Ollama `/api/show` capabilities (cached); vision models keep images; non-vision / unknown capability replace images with recoverable text placeholders.
- Covers native, Claude direct, Gemini/OpenAI-compatible, and streaming paths.

## Root cause
History image parts were forwarded unconditionally to non-vision Ollama models → `400 this model does not support image input` on every subsequent turn.

## Test plan
- [x] Focused ollama image regression tests
- [x] Ollama executor race tests
- [x] Related package tests
- [x] `./scripts/ci-pr.sh`