### PR TITLE
feat(xai): serve Grok Imagine image models through the media endpoints

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -50,7 +50,7 @@
       },
       {
         "path": "internal/storage/sqlite/modelconfig/store.go",
-        "max_lines": 952
+        "max_lines": 946
       },
       {
         "path": "internal/usage/ai_account_subject_store.go",
@@ -58,7 +58,7 @@
       },
       {
         "path": "internal/usage/openrouter_model_sync.go",
-        "max_lines": 1062
+        "max_lines": 1060
       },
       {
         "path": "internal/usage/request_log_query.go",

--- a/internal/api/handlers/management/image_generation.go
+++ b/internal/api/handlers/management/image_generation.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 	imagegeneration "github.com/router-for-me/CLIProxyAPI/v6/internal/management/imagegeneration"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
@@ -247,6 +248,13 @@ func (h *Handler) executeImageGenerationTestForTenant(ctx context.Context, tenan
 	if modelName == "" {
 		modelName = imageGenerationModel
 	}
+	// The credential pool is derived from the model rather than pinned. Pinning it
+	// to codex is what made every Grok image model unreachable from the console
+	// even once the runtime could serve them.
+	provider := registry.ImageGenerationProvider(modelName)
+	if provider == "" {
+		return nil, fmt.Errorf("model %q is not a supported image generation model", modelName)
+	}
 	imageCount, err := imageGenerationRequestCount(payload)
 	if err != nil {
 		return nil, err
@@ -261,7 +269,7 @@ func (h *Handler) executeImageGenerationTestForTenant(ctx context.Context, tenan
 				return nil, fmt.Errorf("invalid image generation request")
 			}
 		}
-		resp, execErr := h.authManager.Execute(ctx, []string{"codex"}, coreexecutor.Request{
+		resp, execErr := h.authManager.Execute(ctx, []string{provider}, coreexecutor.Request{
 			Model:   modelName,
 			Payload: execPayload,
 			Format:  sdktranslator.FromString("openai"),
@@ -576,39 +584,96 @@ func firstImageGenerationFormValue(values map[string][]string, key, fallback str
 	return fallback
 }
 
+// imageGenerationProviderChannels groups usable channels under the credential
+// provider that owns them.
+type imageGenerationProviderChannels struct {
+	Provider string   `json:"provider"`
+	Channels []string `json:"channels"`
+	Models   []string `json:"models"`
+}
+
 func (h *Handler) ListImageGenerationChannels(c *gin.Context) {
-	channels := make([]string, 0)
+	byProvider := make(map[string][]string)
 	seen := make(map[string]struct{})
+
 	if h != nil && h.authManager != nil {
 		for _, auth := range h.authManager.ListForTenant(effectiveTenantID(c)) {
-			if auth == nil || auth.Disabled {
+			if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
 				continue
 			}
-			if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+			provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+			// Only providers that actually serve an image model are offered; every
+			// other credential in the tenant is irrelevant to this page.
+			if !imageGenerationProviderHasModels(provider) {
 				continue
 			}
 			accountType, _ := auth.AccountInfo()
 			if !strings.EqualFold(strings.TrimSpace(accountType), "oauth") {
 				continue
 			}
-			if auth.Status == coreauth.StatusDisabled {
-				continue
-			}
 			name := strings.TrimSpace(auth.ChannelName())
 			if name == "" {
 				continue
 			}
-			key := strings.ToLower(name)
+			key := provider + "\x00" + strings.ToLower(name)
 			if _, ok := seen[key]; ok {
 				continue
 			}
 			seen[key] = struct{}{}
-			channels = append(channels, name)
+			byProvider[provider] = append(byProvider[provider], name)
 		}
 	}
-	sort.Strings(channels)
+
+	models := registry.ListImageGenerationModels()
+	providers := make([]imageGenerationProviderChannels, 0, len(byProvider))
+	flat := make([]string, 0)
+	flatSeen := make(map[string]struct{})
+
+	for provider, channels := range byProvider {
+		sort.Strings(channels)
+		providerModels := make([]string, 0, len(models))
+		for _, model := range models {
+			if model.Provider == provider {
+				providerModels = append(providerModels, model.ID)
+			}
+		}
+		providers = append(providers, imageGenerationProviderChannels{
+			Provider: provider,
+			Channels: channels,
+			Models:   providerModels,
+		})
+		for _, name := range channels {
+			key := strings.ToLower(name)
+			if _, ok := flatSeen[key]; ok {
+				continue
+			}
+			flatSeen[key] = struct{}{}
+			flat = append(flat, name)
+		}
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i].Provider < providers[j].Provider })
+	sort.Strings(flat)
+
+	// `model` and `channels` are retained verbatim: a panel built against the
+	// single-provider shape still works, and only reads the new fields once updated.
 	c.JSON(http.StatusOK, gin.H{
-		"model":    imageGenerationModel,
-		"channels": channels,
+		"model":     imageGenerationModel,
+		"channels":  flat,
+		"providers": providers,
+		"models":    models,
 	})
+}
+
+// imageGenerationProviderHasModels reports whether a credential provider serves at
+// least one image model this build knows about.
+func imageGenerationProviderHasModels(provider string) bool {
+	if strings.TrimSpace(provider) == "" {
+		return false
+	}
+	for _, model := range registry.ListImageGenerationModels() {
+		if strings.EqualFold(model.Provider, provider) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/handlers/management/image_generation_test.go
+++ b/internal/api/handlers/management/image_generation_test.go
@@ -727,3 +727,104 @@ func TestImageGenerationSizePresetsAreTenantScoped(t *testing.T) {
 		t.Fatalf("tenant B inherited tenant A presets: %s", rec.Body.String())
 	}
 }
+
+// managementImageProviderExecutor records which credential provider a request was
+// routed to.
+type managementImageProviderExecutor struct {
+	managementImageExecutor
+	identifier string
+}
+
+func (e *managementImageProviderExecutor) Identifier() string { return e.identifier }
+
+func registerManagementImageProviderAuth(t *testing.T, manager *coreauth.Manager, id string, provider string, models ...string) {
+	t.Helper()
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       id,
+		Provider: provider,
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"access_token": "token"},
+	}); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	modelInfos := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if strings.TrimSpace(model) != "" {
+			modelInfos = append(modelInfos, &registry.ModelInfo{ID: model})
+		}
+	}
+	registry.GetGlobalRegistry().RegisterClient(id, provider, modelInfos)
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(id) })
+}
+
+// TestImageGenerationRoutesGrokModelsToXAI is the point of the change: the handler
+// used to pin every image request to the codex credential pool, so Grok image
+// models were unreachable from the console even once the runtime could serve them.
+func TestImageGenerationRoutesGrokModelsToXAI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &managementImageProviderExecutor{identifier: "xai"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	registerManagementImageProviderAuth(t, manager, "xai-auth-image", "xai", "grok-imagine-image")
+
+	h := &Handler{authManager: manager}
+	_, err := h.executeImageGenerationTest(
+		context.Background(),
+		[]byte(`{"model":"grok-imagine-image","prompt":"a cat"}`),
+		imageGenerationAlt,
+	)
+	if err != nil {
+		t.Fatalf("executeImageGenerationTest() error = %v", err)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("xai executor calls = %d, want 1", executor.calls)
+	}
+	if executor.model != "grok-imagine-image" {
+		t.Errorf("model = %q, want grok-imagine-image", executor.model)
+	}
+	if executor.alt != imageGenerationAlt {
+		t.Errorf("alt = %q, want %q", executor.alt, imageGenerationAlt)
+	}
+}
+
+// TestImageGenerationStillRoutesCodexModelsToCodex guards the existing path from
+// regressing while the provider is derived rather than pinned.
+func TestImageGenerationStillRoutesCodexModelsToCodex(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &managementImageProviderExecutor{identifier: "codex"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	registerManagementImageProviderAuth(t, manager, "codex-auth-image", "codex", imageGenerationModel)
+
+	h := &Handler{authManager: manager}
+	if _, err := h.executeImageGenerationTest(
+		context.Background(),
+		[]byte(`{"model":"gpt-image-2","prompt":"a cat"}`),
+		imageGenerationAlt,
+	); err != nil {
+		t.Fatalf("executeImageGenerationTest() error = %v", err)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("codex executor calls = %d, want 1", executor.calls)
+	}
+}
+
+func TestImageGenerationRejectsNonImageModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	h := &Handler{authManager: manager}
+	_, err := h.executeImageGenerationTest(
+		context.Background(),
+		[]byte(`{"model":"grok-4.5","prompt":"a cat"}`),
+		imageGenerationAlt,
+	)
+	if err == nil {
+		t.Fatal("a chat model must not be accepted by the image generation path")
+	}
+	if !strings.Contains(err.Error(), "grok-4.5") {
+		t.Errorf("error should name the rejected model, got %q", err)
+	}
+}

--- a/internal/registry/image_generation_models.go
+++ b/internal/registry/image_generation_models.go
@@ -1,0 +1,190 @@
+package registry
+
+import "strings"
+
+// Image-generation model classification.
+//
+// This used to be spelled out at each call site — a `modelID == "gpt-image-2"`
+// branch when seeding model configs, a `HasPrefix(modelID, "gpt-image-")` branch
+// when syncing pricing. Adding a provider meant finding every one of those
+// branches, and missing one produced a model that generates images but is billed
+// per token, or that never surfaces an image capability in the panel.
+//
+// The classification lives here instead, next to the static model definitions it
+// describes, so a new image model is one entry rather than a hunt.
+
+// imageGenerationModelDefaults describes an image-generation model's billing and
+// modality shape.
+type imageGenerationModelDefaults struct {
+	// PricePerCall is the per-invocation price. Image models are billed per call
+	// rather than per token, which is why they need an explicit pricing mode.
+	PricePerCall float64
+	Description  string
+}
+
+// imageGenerationModels maps a model ID to its defaults. IDs are lower-cased.
+var imageGenerationModels = map[string]imageGenerationModelDefaults{
+	"gpt-image-2": {
+		PricePerCall: 0.04,
+		Description:  "Image generation model billed per invocation",
+	},
+	// Grok Imagine. Pricing is left at zero because xAI bills these against the
+	// subscription rather than at a published per-image rate; an invented number
+	// would show up as real spend in usage reporting.
+	"grok-imagine-image": {
+		Description: "Grok Imagine image generation, billed per invocation",
+	},
+	"grok-imagine-image-pro": {
+		Description: "Grok Imagine Pro image generation, billed per invocation",
+	},
+	"grok-2-image-1212": {
+		Description: "Grok 2 image generation, billed per invocation",
+	},
+}
+
+// imageGenerationModelPrefixes covers families that version faster than this list
+// can be updated. A new gpt-image-* release is still billed per call on day one.
+var imageGenerationModelPrefixes = []string{
+	"gpt-image-",
+	"grok-imagine-image",
+}
+
+// IsImageGenerationModel reports whether a model produces images rather than text.
+func IsImageGenerationModel(modelID string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	if normalized == "" {
+		return false
+	}
+	if _, ok := imageGenerationModels[normalized]; ok {
+		return true
+	}
+	for _, prefix := range imageGenerationModelPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ImageGenerationModelDefaults returns the per-call price and description for an
+// image model. The second result is false for models that are not image models, and
+// for image models matched only by prefix, which have no published price here.
+func ImageGenerationModelDefaults(modelID string) (float64, string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	defaults, ok := imageGenerationModels[normalized]
+	if !ok {
+		return 0, "", false
+	}
+	return defaults.PricePerCall, defaults.Description, true
+}
+
+// ImageGenerationOutputModalities is the output modality set every image model
+// carries. Returned as a fresh slice so callers can mutate it safely.
+func ImageGenerationOutputModalities() []string {
+	return []string{"image"}
+}
+
+// ImageGenerationInputModalities lists what an image model accepts.
+//
+// This stays text-only even for models whose edit endpoint takes reference images.
+// The modality set describes the primary generation call and drives catalog
+// filtering; widening it to "image" would reclassify existing models as
+// image-to-image in the panel. Edit capability is a separate question, answered by
+// SupportsImageEditing, which is what the UI uses to decide whether to offer a
+// reference-image control.
+func ImageGenerationInputModalities(string) []string {
+	return []string{"text"}
+}
+
+// Provider identifiers for image-generation models. The management console needs
+// to know which credential pool can serve a given image model; without this it
+// pinned every request to codex, which is what kept Grok models unreachable.
+const (
+	ImageProviderCodex = "codex"
+	ImageProviderXAI   = "xai"
+)
+
+// ImageGenerationProvider returns the credential provider that serves a model, or
+// "" when the model is not an image-generation model.
+func ImageGenerationProvider(modelID string) string {
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	switch {
+	case strings.HasPrefix(normalized, "gpt-image-"):
+		return ImageProviderCodex
+	case strings.HasPrefix(normalized, "grok-"):
+		if IsImageGenerationModel(normalized) {
+			return ImageProviderXAI
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+// ImageGenerationModel describes a selectable image model for the console.
+type ImageGenerationModel struct {
+	ID           string  `json:"id"`
+	Provider     string  `json:"provider"`
+	DisplayName  string  `json:"display_name,omitempty"`
+	Description  string  `json:"description,omitempty"`
+	SupportsEdit bool    `json:"supports_edit"`
+	PricePerCall float64 `json:"price_per_call,omitempty"`
+}
+
+// ListImageGenerationModels enumerates the image models this build knows about,
+// derived from the static catalog so a newly registered model needs no second edit
+// here to become selectable.
+func ListImageGenerationModels() []ImageGenerationModel {
+	seen := make(map[string]struct{})
+	models := make([]ImageGenerationModel, 0, 4)
+
+	appendModel := func(info *ModelInfo) {
+		if info == nil || !IsImageGenerationModel(info.ID) {
+			return
+		}
+		if _, ok := seen[info.ID]; ok {
+			return
+		}
+		provider := ImageGenerationProvider(info.ID)
+		if provider == "" {
+			return
+		}
+		seen[info.ID] = struct{}{}
+		price, description, _ := ImageGenerationModelDefaults(info.ID)
+		if strings.TrimSpace(info.Description) != "" {
+			description = info.Description
+		}
+		models = append(models, ImageGenerationModel{
+			ID:           info.ID,
+			Provider:     provider,
+			DisplayName:  info.DisplayName,
+			Description:  description,
+			SupportsEdit: SupportsImageEditing(info.ID),
+			PricePerCall: price,
+		})
+	}
+
+	for _, info := range GetOpenAIModels() {
+		appendModel(info)
+	}
+	for _, info := range GetXAIModels() {
+		appendModel(info)
+	}
+	return models
+}
+
+// SupportsImageEditing reports whether a model accepts reference images through the
+// /images/edits endpoint, as opposed to text-to-image only.
+func SupportsImageEditing(modelID string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	switch {
+	case strings.HasPrefix(normalized, "gpt-image-"):
+		return true
+	case strings.HasPrefix(normalized, "grok-imagine-image"):
+		return true
+	default:
+		// grok-2-image-1212 is text-to-image only; offering an edit form for it
+		// would produce upstream 404s rather than a useful error.
+		return false
+	}
+}

--- a/internal/registry/image_generation_models_test.go
+++ b/internal/registry/image_generation_models_test.go
@@ -1,0 +1,116 @@
+package registry
+
+import "testing"
+
+func TestIsImageGenerationModel(t *testing.T) {
+	imageModels := []string{
+		"gpt-image-2",
+		"GPT-Image-2",
+		"gpt-image-3",
+		"grok-imagine-image",
+		"grok-imagine-image-pro",
+		"grok-2-image-1212",
+	}
+	for _, modelID := range imageModels {
+		if !IsImageGenerationModel(modelID) {
+			t.Errorf("IsImageGenerationModel(%q) = false, want true", modelID)
+		}
+	}
+
+	textModels := []string{"", "grok-4.5", "grok-build-0.1", "gpt-5.5", "grok-imagine-video"}
+	for _, modelID := range textModels {
+		if IsImageGenerationModel(modelID) {
+			t.Errorf("IsImageGenerationModel(%q) = true, want false", modelID)
+		}
+	}
+}
+
+// TestUnknownImageModelVersionsStillClassify is why the prefix list exists: a new
+// release in a known family must be billed per call on day one, not per token.
+func TestUnknownImageModelVersionsStillClassify(t *testing.T) {
+	if !IsImageGenerationModel("gpt-image-9-preview") {
+		t.Error("an unreleased gpt-image version should still classify as image generation")
+	}
+	if price, _, ok := ImageGenerationModelDefaults("gpt-image-9-preview"); ok || price != 0 {
+		t.Error("a prefix-only match must not invent a price")
+	}
+}
+
+// TestVideoModelsAreNotImageModels guards the boundary while video support is being
+// built out: grok-imagine-video shares the family prefix but is not an image model.
+func TestVideoModelsAreNotImageModels(t *testing.T) {
+	if IsImageGenerationModel("grok-imagine-video") {
+		t.Error("grok-imagine-video must not classify as an image generation model")
+	}
+}
+
+func TestImageGenerationModelDefaults(t *testing.T) {
+	price, description, ok := ImageGenerationModelDefaults("gpt-image-2")
+	if !ok {
+		t.Fatal("gpt-image-2 should have defaults")
+	}
+	if price != 0.04 {
+		t.Errorf("price = %v, want 0.04 to preserve existing billing", price)
+	}
+	if description == "" {
+		t.Error("description should be set")
+	}
+
+	// Grok Imagine is billed against the subscription, so no per-call price is
+	// published. Inventing one would show up as real spend in usage reporting.
+	if price, _, ok := ImageGenerationModelDefaults("grok-imagine-image"); !ok || price != 0 {
+		t.Errorf("grok-imagine-image price = %v, want 0", price)
+	}
+
+	if _, _, ok := ImageGenerationModelDefaults("grok-4.5"); ok {
+		t.Error("a text model should have no image defaults")
+	}
+}
+
+// TestImageInputModalityStaysTextOnly pins a deliberate decision: edit support is
+// not the same as an image input modality, and widening it would reclassify
+// existing models as image-to-image in the catalog.
+func TestImageInputModalityStaysTextOnly(t *testing.T) {
+	for _, modelID := range []string{"gpt-image-2", "grok-imagine-image", "grok-2-image-1212"} {
+		got := ImageGenerationInputModalities(modelID)
+		if len(got) != 1 || got[0] != "text" {
+			t.Errorf("ImageGenerationInputModalities(%q) = %v, want [text]", modelID, got)
+		}
+	}
+}
+
+func TestSupportsImageEditing(t *testing.T) {
+	for _, modelID := range []string{"gpt-image-2", "grok-imagine-image", "grok-imagine-image-pro"} {
+		if !SupportsImageEditing(modelID) {
+			t.Errorf("SupportsImageEditing(%q) = false, want true", modelID)
+		}
+	}
+	// grok-2-image-1212 has no edit endpoint; offering the control would only
+	// produce upstream 404s.
+	if SupportsImageEditing("grok-2-image-1212") {
+		t.Error("grok-2-image-1212 has no edit endpoint and must not advertise one")
+	}
+}
+
+func TestImageGenerationOutputModalitiesIsNotShared(t *testing.T) {
+	first := ImageGenerationOutputModalities()
+	first[0] = "mutated"
+	if second := ImageGenerationOutputModalities(); second[0] != "image" {
+		t.Error("callers must not be able to mutate the shared modality set")
+	}
+}
+
+// TestGrokImageModelsAreRegistered ties the classifier to the static catalog: a
+// model that classifies as image generation but is absent from the catalog would
+// never be selectable.
+func TestGrokImageModelsAreRegistered(t *testing.T) {
+	registered := make(map[string]struct{})
+	for _, model := range GetXAIModels() {
+		registered[model.ID] = struct{}{}
+	}
+	for _, modelID := range []string{"grok-imagine-image", "grok-imagine-image-pro", "grok-2-image-1212"} {
+		if _, ok := registered[modelID]; !ok {
+			t.Errorf("%s is classified as an image model but is not in the xAI catalog", modelID)
+		}
+	}
+}

--- a/internal/registry/model_definitions_image_data.go
+++ b/internal/registry/model_definitions_image_data.go
@@ -1,0 +1,72 @@
+package registry
+
+// Image-generation model definitions.
+//
+// These live apart from the general static catalog for two reasons: that file is
+// already over the structure gate's line budget and may only shrink, and image
+// models carry billing and capability rules that the classifier in
+// image_generation_models.go reads. Keeping the definitions next to the rules that
+// interpret them means adding a model is one file, not two.
+
+// getOpenAIImageModelDefinitions returns OpenAI image-generation models.
+func getOpenAIImageModelDefinitions() []*ModelInfo {
+	return []*ModelInfo{
+		{
+			ID:                  "gpt-image-2",
+			Object:              "model",
+			OwnedBy:             "openai",
+			Type:                "openai",
+			Version:             "gpt-image-2",
+			DisplayName:         "GPT Image 2",
+			Description:         "Text-to-image generation model.",
+			SupportedParameters: []string{"prompt", "size", "n", "response_format"},
+		},
+	}
+}
+
+// getXAIImageModelDefinitions returns Grok Imagine image-generation models.
+//
+// Media requests reach the official API host even for subscription credentials,
+// because the CLI gateway rejects the payload sizes these carry; see
+// xaiMediaBaseURL in the runtime executor.
+func getXAIImageModelDefinitions() []*ModelInfo {
+	return []*ModelInfo{
+		{
+			ID:          "grok-imagine-image",
+			Object:      "model",
+			OwnedBy:     "xai",
+			Type:        "xai",
+			Version:     "grok-imagine-image",
+			DisplayName: "Grok Imagine",
+			Name:        "grok-imagine-image",
+			Description: "Grok Imagine text-to-image generation with reference image editing.",
+			// Media requests go to the official API host even for subscription
+			// credentials; see xaiMediaBaseURL in the runtime executor.
+			SupportedParameters: []string{"prompt", "n", "response_format", "image", "mask"},
+		},
+		{
+			ID:                  "grok-imagine-image-pro",
+			Object:              "model",
+			OwnedBy:             "xai",
+			Type:                "xai",
+			Version:             "grok-imagine-image-pro",
+			DisplayName:         "Grok Imagine Pro",
+			Name:                "grok-imagine-image-pro",
+			Description:         "Higher fidelity Grok Imagine image generation.",
+			SupportedParameters: []string{"prompt", "n", "response_format", "image", "mask"},
+		},
+		{
+			ID:          "grok-2-image-1212",
+			Object:      "model",
+			OwnedBy:     "xai",
+			Type:        "xai",
+			Version:     "grok-2-image-1212",
+			DisplayName: "Grok 2 Image",
+			Name:        "grok-2-image-1212",
+			Description: "Grok 2 text-to-image generation.",
+			// No image input: this model has no edit endpoint, so advertising one
+			// would only produce upstream 404s.
+			SupportedParameters: []string{"prompt", "n", "response_format"},
+		},
+	}
+}

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -696,7 +696,7 @@ func GetAIStudioModels() []*ModelInfo {
 
 // GetOpenAIModels returns the standard OpenAI model definitions
 func GetOpenAIModels() []*ModelInfo {
-	return append([]*ModelInfo{
+	return append(getOpenAIImageModelDefinitions(), append([]*ModelInfo{
 		{
 			ID:                  "gpt-5",
 			Object:              "model",
@@ -907,21 +907,11 @@ func GetOpenAIModels() []*ModelInfo {
 			SupportedParameters: []string{"tools"},
 			Thinking:            &ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh"}},
 		},
-		{
-			ID:                  "gpt-image-2",
-			Object:              "model",
-			OwnedBy:             "openai",
-			Type:                "openai",
-			Version:             "gpt-image-2",
-			DisplayName:         "GPT Image 2",
-			Description:         "Text-to-image generation model.",
-			SupportedParameters: []string{"prompt", "size", "n", "response_format"},
-		},
-	}, getGPT56ModelDefinitions()...)
+	}, getGPT56ModelDefinitions()...)...)
 }
 
 func GetXAIModels() []*ModelInfo {
-	return []*ModelInfo{
+	return append(getXAIImageModelDefinitions(), []*ModelInfo{
 		{
 			ID:                  "grok-build-0.1",
 			Object:              "model",
@@ -1035,7 +1025,7 @@ func GetXAIModels() []*ModelInfo {
 			ContextLength:       200000,
 			MaxCompletionTokens: 32768,
 		},
-	}
+	}...)
 }
 
 // GetQwenModels returns the standard Qwen model definitions

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -61,6 +61,9 @@ func (e *XAIExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, 
 }
 
 func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if xaiIsMediaAlt(opts.Alt) {
+		return e.executeImageGeneration(ctx, auth, req, opts)
+	}
 	if opts.Alt == "responses/compact" {
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
@@ -152,6 +155,9 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 }
 
 func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	if xaiIsMediaAlt(opts.Alt) {
+		return e.executeImageGenerationStream(ctx, auth, req, opts)
+	}
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
 	}

--- a/internal/runtime/executor/xai_media.go
+++ b/internal/runtime/executor/xai_media.go
@@ -1,0 +1,150 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	xaiImageGenerationAlt = "images/generations"
+	xaiImageEditsAlt      = "images/edits"
+
+	xaiImagesGenerationsPath = "/images/generations"
+	xaiImagesEditsPath       = "/images/edits"
+)
+
+// xaiIsMediaAlt reports whether a request targets one of the Grok Imagine media
+// endpoints rather than the chat surface.
+func xaiIsMediaAlt(alt string) bool {
+	switch strings.TrimSpace(alt) {
+	case xaiImageGenerationAlt, xaiImageEditsAlt:
+		return true
+	default:
+		return false
+	}
+}
+
+// xaiMediaBaseURL selects the upstream for Grok Imagine requests.
+//
+// Chat over an OAuth subscription resolves to the CLI gateway, but that gateway
+// enforces a small request-body limit and rejects the base64 payloads media
+// requests carry. Media therefore leaves for the official API host whenever chat
+// would have used the CLI gateway. An operator who pinned some other endpoint —
+// a regional host or a relay — keeps it, because that choice is deliberate and
+// usually exists precisely because the default is unreachable for them.
+func xaiMediaBaseURL(auth *cliproxyauth.Auth) string {
+	baseURL := xaiChatBaseURL(auth)
+	if xaiIsBaseURL(baseURL, xaiauth.CLIChatProxyBaseURL) {
+		return xaiauth.DefaultAPIBaseURL
+	}
+	return baseURL
+}
+
+// xaiMediaPath maps an alt to its upstream path.
+func xaiMediaPath(alt string) string {
+	if strings.TrimSpace(alt) == xaiImageEditsAlt {
+		return xaiImagesEditsPath
+	}
+	return xaiImagesGenerationsPath
+}
+
+// executeImageGeneration forwards an image request to the Grok Imagine API.
+//
+// The upstream is OpenAI-compatible on both the request and response side, so the
+// payload passes through untranslated. That is deliberate: inventing a translation
+// layer here would mean re-encoding fields we do not model, and any field xAI adds
+// later would be silently dropped instead of reaching the caller.
+func (e *XAIExecutor) executeImageGeneration(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{})
+	reporter := execCtx.Reporter()
+	defer reporter.trackFailure(execCtx.Context, &err)
+
+	token, _ := xaiCreds(auth)
+	if strings.TrimSpace(token) == "" {
+		return resp, statusErr{code: http.StatusUnauthorized, msg: "xai credential has no access token"}
+	}
+
+	payload := req.Payload
+	if len(bytes.TrimSpace(payload)) == 0 {
+		return resp, statusErr{code: http.StatusBadRequest, msg: "image request body is empty"}
+	}
+
+	endpoint := strings.TrimSuffix(xaiMediaBaseURL(auth), "/") + xaiMediaPath(opts.Alt)
+	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return resp, err
+	}
+	// Media never goes to the CLI gateway, so the Grok CLI client headers that
+	// gateway requires are deliberately not applied here.
+	applyXAIHeaders(httpReq, e.cfg, auth, token, false)
+
+	recorder := execCtx.Recorder()
+	recorder.RecordRequest(endpoint, http.MethodPost, httpReq.Header.Clone(), payload)
+
+	httpResp, err := execCtx.HTTPClient(0).Do(httpReq) //nolint:bodyclose // closed by the defer below.
+	if err != nil {
+		recorder.RecordResponseError(err)
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, err.Error())
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("xai executor: close image response body error: %v", errClose)
+		}
+	}()
+
+	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		body := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+		recorder.AppendResponseChunk(body)
+		logWithRequestID(execCtx.Context).Debugf(
+			"xai image request error, status: %d, message: %s",
+			httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), body),
+		)
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, string(body))
+		// Reuse the chat status mapping so a 402 still lands in the weekly quota
+		// cooldown path; a media call exhausts the same subscription balance.
+		return resp, newXAIStatusErr(httpResp.StatusCode, body, httpResp.Header)
+	}
+
+	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
+	if err != nil {
+		recorder.RecordResponseError(err)
+		return resp, err
+	}
+	recorder.AppendResponseChunk(data)
+
+	return cliproxyexecutor.Response{Payload: data, Headers: httpResp.Header.Clone()}, nil
+}
+
+// executeImageGenerationStream serves the streaming entry point.
+//
+// The Imagine image endpoints have no streaming form, so a single terminal chunk is
+// emitted rather than refusing the request: callers reaching this through the shared
+// OpenAI images handler should not have to know which providers stream.
+func (e *XAIExecutor) executeImageGenerationStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	resp, err := e.executeImageGeneration(ctx, auth, req, opts)
+	if err != nil {
+		return nil, err
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: resp.Payload}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+// xaiMediaEndpointFor exposes endpoint resolution for tests and diagnostics.
+func xaiMediaEndpointFor(auth *cliproxyauth.Auth, alt string) (string, error) {
+	if !xaiIsMediaAlt(alt) {
+		return "", fmt.Errorf("alt %q is not an xai media endpoint", alt)
+	}
+	return strings.TrimSuffix(xaiMediaBaseURL(auth), "/") + xaiMediaPath(alt), nil
+}

--- a/internal/runtime/executor/xai_media_test.go
+++ b/internal/runtime/executor/xai_media_test.go
@@ -1,0 +1,256 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func oauthAuth(baseURL string) *cliproxyauth.Auth {
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Metadata: map[string]any{
+			"access_token": "token-123",
+			"auth_kind":    "oauth",
+		},
+	}
+	if baseURL != "" {
+		auth.Metadata["base_url"] = baseURL
+	}
+	return auth
+}
+
+func apiKeyAuth(baseURL string) *cliproxyauth.Auth {
+	auth := &cliproxyauth.Auth{
+		Provider:   "xai",
+		Attributes: map[string]string{"api_key": "sk-test"},
+	}
+	if baseURL != "" {
+		auth.Attributes["base_url"] = baseURL
+	}
+	return auth
+}
+
+// TestMediaLeavesTheCLIGatewayForOAuth is the load-bearing rule. Chat over an OAuth
+// subscription resolves to the CLI gateway, but that gateway rejects the base64
+// payloads media requests carry, so media has to go to the official API host.
+func TestMediaLeavesTheCLIGatewayForOAuth(t *testing.T) {
+	auth := oauthAuth("")
+
+	if chat := xaiChatBaseURL(auth); !xaiIsBaseURL(chat, xaiauth.CLIChatProxyBaseURL) {
+		t.Fatalf("precondition failed: OAuth chat should use the CLI gateway, got %q", chat)
+	}
+
+	endpoint, err := xaiMediaEndpointFor(auth, xaiImageGenerationAlt)
+	if err != nil {
+		t.Fatalf("resolve media endpoint: %v", err)
+	}
+	want := xaiauth.DefaultAPIBaseURL + "/images/generations"
+	if endpoint != want {
+		t.Errorf("media endpoint = %q, want %q", endpoint, want)
+	}
+}
+
+// TestMediaKeepsAnOperatorSelectedEndpoint covers the deliberate override: a pinned
+// regional host or relay is usually pinned because the default is unreachable for
+// that deployment, so media must not silently route around it.
+func TestMediaKeepsAnOperatorSelectedEndpoint(t *testing.T) {
+	const relay = "https://relay.example.com/v1"
+
+	for name, auth := range map[string]*cliproxyauth.Auth{
+		"oauth":   oauthAuth(relay),
+		"api key": apiKeyAuth(relay),
+	} {
+		endpoint, err := xaiMediaEndpointFor(auth, xaiImageGenerationAlt)
+		if err != nil {
+			t.Fatalf("%s: resolve media endpoint: %v", name, err)
+		}
+		if endpoint != relay+"/images/generations" {
+			t.Errorf("%s: media endpoint = %q, want the pinned relay", name, endpoint)
+		}
+	}
+}
+
+func TestMediaEndpointPerAlt(t *testing.T) {
+	auth := apiKeyAuth(xaiauth.DefaultAPIBaseURL)
+
+	cases := map[string]string{
+		xaiImageGenerationAlt: xaiauth.DefaultAPIBaseURL + "/images/generations",
+		xaiImageEditsAlt:      xaiauth.DefaultAPIBaseURL + "/images/edits",
+	}
+	for alt, want := range cases {
+		got, err := xaiMediaEndpointFor(auth, alt)
+		if err != nil {
+			t.Fatalf("alt %q: %v", alt, err)
+		}
+		if got != want {
+			t.Errorf("alt %q endpoint = %q, want %q", alt, got, want)
+		}
+	}
+
+	if _, err := xaiMediaEndpointFor(auth, "responses"); err == nil {
+		t.Error("a non-media alt should be rejected")
+	}
+}
+
+func TestExecuteImageGenerationPassesThroughUpstreamPayload(t *testing.T) {
+	var gotPath, gotAuth, gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"b64_json":"AAAA","revised_prompt":"a cat"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	executor := NewXAIExecutor(&config.Config{})
+	auth := oauthAuth(upstream.URL + "/v1")
+	request := cliproxyexecutor.Request{
+		Model:   "grok-imagine-image",
+		Payload: []byte(`{"model":"grok-imagine-image","prompt":"a cat","n":1}`),
+	}
+
+	resp, err := executor.Execute(context.Background(), auth, request, cliproxyexecutor.Options{Alt: xaiImageGenerationAlt})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if gotPath != "/v1/images/generations" {
+		t.Errorf("upstream path = %q, want /v1/images/generations", gotPath)
+	}
+	if gotAuth != "Bearer token-123" {
+		t.Errorf("Authorization = %q, want the OAuth access token", gotAuth)
+	}
+	if !strings.Contains(gotBody, `"prompt":"a cat"`) {
+		t.Errorf("request body was not forwarded verbatim: %q", gotBody)
+	}
+
+	// The upstream is OpenAI-compatible, so the response must reach the caller
+	// unmodified rather than through a lossy re-encode.
+	var decoded struct {
+		Data []struct {
+			B64JSON       string `json:"b64_json"`
+			RevisedPrompt string `json:"revised_prompt"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Payload, &decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(decoded.Data) != 1 || decoded.Data[0].B64JSON != "AAAA" {
+		t.Fatalf("response payload lost data: %s", resp.Payload)
+	}
+	if decoded.Data[0].RevisedPrompt != "a cat" {
+		t.Error("a field the proxy does not model was dropped; media must pass through")
+	}
+}
+
+// TestExecuteImageGenerationDoesNotSendCLIGatewayHeaders guards against leaking the
+// Grok CLI client headers to the public API host, which only the CLI gateway wants.
+func TestExecuteImageGenerationDoesNotSendCLIGatewayHeaders(t *testing.T) {
+	var headers http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers = r.Header.Clone()
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	executor := NewXAIExecutor(&config.Config{})
+	_, err := executor.Execute(
+		context.Background(),
+		oauthAuth(upstream.URL+"/v1"),
+		cliproxyexecutor.Request{Model: "grok-imagine-image", Payload: []byte(`{"prompt":"x"}`)},
+		cliproxyexecutor.Options{Alt: xaiImageGenerationAlt},
+	)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := headers.Get(xaiTokenAuthHeader); got != "" {
+		t.Errorf("%s was sent to the media host: %q", xaiTokenAuthHeader, got)
+	}
+	if got := headers.Get("X-Grok-Client-Version"); got != "" {
+		t.Errorf("X-Grok-Client-Version was sent to the media host: %q", got)
+	}
+}
+
+func TestExecuteImageGenerationSurfacesUpstreamErrors(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte(`{"error":{"message":"balance exhausted"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	executor := NewXAIExecutor(&config.Config{})
+	_, err := executor.Execute(
+		context.Background(),
+		oauthAuth(upstream.URL+"/v1"),
+		cliproxyexecutor.Request{Model: "grok-imagine-image", Payload: []byte(`{"prompt":"x"}`)},
+		cliproxyexecutor.Options{Alt: xaiImageGenerationAlt},
+	)
+	if err == nil {
+		t.Fatal("an upstream 402 must surface as an error")
+	}
+	// A media call spends the same subscription balance as chat, so it has to land
+	// in the same quota-cooldown handling rather than looking like a generic failure.
+	coder, ok := err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("error does not carry a status code: %T", err)
+	}
+	if coder.StatusCode() != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want 402", coder.StatusCode())
+	}
+}
+
+func TestExecuteImageGenerationRejectsMissingCredential(t *testing.T) {
+	executor := NewXAIExecutor(&config.Config{})
+	_, err := executor.Execute(
+		context.Background(),
+		&cliproxyauth.Auth{Provider: "xai"},
+		cliproxyexecutor.Request{Model: "grok-imagine-image", Payload: []byte(`{"prompt":"x"}`)},
+		cliproxyexecutor.Options{Alt: xaiImageGenerationAlt},
+	)
+	if err == nil {
+		t.Fatal("a credential without an access token must be rejected")
+	}
+}
+
+func TestExecuteImageGenerationStreamEmitsASingleChunk(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"b64_json":"AAAA"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	executor := NewXAIExecutor(&config.Config{})
+	result, err := executor.ExecuteStream(
+		context.Background(),
+		oauthAuth(upstream.URL+"/v1"),
+		cliproxyexecutor.Request{Model: "grok-imagine-image", Payload: []byte(`{"prompt":"x"}`)},
+		cliproxyexecutor.Options{Alt: xaiImageGenerationAlt},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteStream: %v", err)
+	}
+
+	// The endpoint has no streaming form; callers going through the shared images
+	// handler should still get a well-formed terminal chunk instead of an error.
+	count := 0
+	for chunk := range result.Chunks {
+		count++
+		if !strings.Contains(string(chunk.Payload), "b64_json") {
+			t.Errorf("chunk payload = %q", chunk.Payload)
+		}
+	}
+	if count != 1 {
+		t.Errorf("chunk count = %d, want 1", count)
+	}
+}

--- a/internal/storage/sqlite/modelconfig/image_generation_seed.go
+++ b/internal/storage/sqlite/modelconfig/image_generation_seed.go
@@ -1,0 +1,24 @@
+package modelconfig
+
+import "github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+
+// applyImageGenerationSeedDefaults stamps the billing and modality shape an
+// image-generation model needs onto a seed row.
+//
+// Image models are billed per invocation rather than per token, so a row seeded
+// with the default token pricing would under-report spend. The classification is
+// deliberately not spelled out here: it lives in internal/registry alongside the
+// model definitions, so adding a provider does not mean hunting for every branch
+// that special-cased a model ID.
+func applyImageGenerationSeedDefaults(row *ModelConfigRow, modelID string) {
+	if row == nil || !registry.IsImageGenerationModel(modelID) {
+		return
+	}
+	row.InputModalities = registry.ImageGenerationInputModalities(modelID)
+	row.OutputModalities = registry.ImageGenerationOutputModalities()
+	row.PricingMode = "call"
+	if price, description, ok := registry.ImageGenerationModelDefaults(modelID); ok {
+		row.PricePerCall = price
+		row.Description = description
+	}
+}

--- a/internal/storage/sqlite/modelconfig/store.go
+++ b/internal/storage/sqlite/modelconfig/store.go
@@ -699,13 +699,7 @@ func defaultModelConfigRows() []ModelConfigRow {
 				PricingMode:         "token",
 				Source:              "seed",
 			}
-			if modelID == "gpt-image-2" {
-				row.Description = "Image generation model billed per invocation"
-				row.InputModalities = []string{"text"}
-				row.OutputModalities = []string{"image"}
-				row.PricingMode = "call"
-				row.PricePerCall = 0.04
-			}
+			applyImageGenerationSeedDefaults(&row, modelID)
 			rows = append(rows, row)
 		}
 	}

--- a/internal/usage/openrouter_model_sync.go
+++ b/internal/usage/openrouter_model_sync.go
@@ -644,7 +644,7 @@ func openRouterApplyImageGenerationSemantics(row *ModelConfigRow, model OpenRout
 
 func openRouterIsImageGenerationRow(row ModelConfigRow) bool {
 	modelID := strings.ToLower(strings.TrimSpace(row.ModelID))
-	if strings.HasPrefix(modelID, "gpt-image-") {
+	if registry.IsImageGenerationModel(modelID) {
 		return true
 	}
 	if strings.EqualFold(strings.TrimSpace(row.PricingMode), "call") {
@@ -659,12 +659,10 @@ func openRouterIsImageGenerationRow(row ModelConfigRow) bool {
 }
 
 func openRouterDefaultImageGenerationPricePerCall(modelID string) float64 {
-	switch strings.ToLower(strings.TrimSpace(modelID)) {
-	case "gpt-image-2":
-		return 0.04
-	default:
-		return 0
+	if price, _, ok := registry.ImageGenerationModelDefaults(modelID); ok {
+		return price
 	}
+	return 0
 }
 
 func imageOutputModalities(modalities []string) []string {


### PR DESCRIPTION
## 调查结论

参考了 `QuantumNous/new-api` 和 `Wei-Shaw/sub2api`。关键发现：

| 项 | 结论 |
|---|---|
| Grok 图片模型 | `grok-imagine-image`、`grok-imagine-image-pro`、`grok-2-image-1212` |
| OAuth 能否用 | **能**。sub2api 的注释写得很明确：订阅 CLI 网关有请求体积限制，会拒绝 base64 媒体负载，所以 OAuth 的媒体流量走 `api.x.ai` |
| 端点 | `/images/generations`、`/images/edits`（OpenAI 兼容） |

## 改动

**媒体走向**：Grok OAuth 的聊天解析到 `cli-chat-proxy.grok.com`，但它拒绝图片请求携带的大 payload。因此只要聊天会落到 CLI 网关，媒体就改走 `api.x.ai`——和 sub2api 对同类订阅凭据的处理一致。运维**手动指定过**的端点（区域主机或中转）保持原样，因为这种指定通常正是由于默认端点对该部署不可达。

**不做翻译**：上游请求和响应都已经是 OpenAI 兼容格式，直接透传。加一层翻译意味着 xAI 以后新增的任何字段都会被静默丢弃。

**去 codex 硬编码**：管理端把每个图片请求都钉死在 codex 凭据池、模型默认 `gpt-image-2`、渠道按 `provider == "codex"` 过滤。现在 provider 由模型推导。

**消除分散的判定**：图片模型的识别原本散落在各处——seed 配置里一个 `modelID == "gpt-image-2"`，同步价格时一个 `HasPrefix("gpt-image-")`。加一个 provider 就要找齐所有分支，漏一个就会出现「能出图但按 token 计费」的模型。现在统一在 `internal/registry`，和模型定义放在一起。

**定价**：Grok Imagine 不写死每次调用价格——xAI 是按订阅计费，编一个数字会在用量报表里变成真实开销。

## 结构债

结构门禁拦下了三个文件超基线。没有放宽 allowlist，而是把图片模型定义移出超长的静态目录、把 seed 装饰逻辑抽成 helper，三个文件全部**变小**并已锁定新基线。

## 验证

- 本地完整 `./scripts/ci-pr.sh`：通过（`exit=0`）
- 新增测试覆盖：媒体端点选择规则、OAuth 与 API key 两种凭据、透传保真（含未建模字段）、不向公共 API 主机泄漏 CLI 网关头、402 落入配额冷却、provider 路由（Grok → xai，Codex 仍走 codex）、非图片模型被拒

## ⚠️ 未验证

**没有跑过真实的 `api.x.ai` 媒体调用。** 这需要一个带有效订阅的 Grok OAuth 账号，我这边没有。测试全部基于 mock 上游，覆盖的是契约而不是真实上游行为。合并后请用真实账号发一次生图请求确认。

前端配套：kittors/codeProxy#(见下)

🤖 Generated with [Claude Code](https://claude.com/claude-code)