### PR TITLE
fix(xai): make Grok image models routable, not just visible

### DIFF
--- a/internal/runtime/executor/xai_image_models.go
+++ b/internal/runtime/executor/xai_image_models.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+// withXAIImageModels merges the Grok Imagine models into a discovered model list.
+//
+// An xAI credential's routable models come entirely from the upstream /models
+// endpoint. For an OAuth subscription that endpoint is the CLI chat proxy, which
+// lists chat models only and never reports the Imagine models — they live on the
+// media host and are not discoverable at all.
+//
+// Registering them in the static catalog is therefore not enough: it makes them
+// visible in the panel while the request router still has no credential that
+// serves them, which surfaces as "auth_not_found: no auth available" before any
+// upstream call is made. They have to be merged into every credential's model set.
+//
+// Merging is safe because the media host is reachable with the same token the chat
+// surface uses; a credential that cannot reach it fails at request time with a real
+// upstream error rather than looking like a missing model.
+func withXAIImageModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	imageModels := xaiImageModelInfos()
+	if len(imageModels) == 0 {
+		return models
+	}
+
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		seen[strings.ToLower(strings.TrimSpace(model.ID))] = struct{}{}
+	}
+
+	merged := make([]*sdkmodelcatalog.ModelInfo, 0, len(models)+len(imageModels))
+	merged = append(merged, models...)
+	for _, model := range imageModels {
+		// A live listing that already advertises the model wins, so upstream stays
+		// authoritative about anything it does report.
+		if _, exists := seen[strings.ToLower(strings.TrimSpace(model.ID))]; exists {
+			continue
+		}
+		merged = append(merged, model)
+	}
+	return merged
+}
+
+// xaiImageModelInfos converts the static Grok image definitions into catalog
+// entries. Sourcing them from the registry keeps one definition of the model set,
+// so adding a model there makes it routable without a second edit here.
+func xaiImageModelInfos() []*sdkmodelcatalog.ModelInfo {
+	definitions := registry.GetXAIModels()
+	models := make([]*sdkmodelcatalog.ModelInfo, 0, len(definitions))
+	for _, definition := range definitions {
+		if definition == nil || !registry.IsImageGenerationModel(definition.ID) {
+			continue
+		}
+		models = append(models, &sdkmodelcatalog.ModelInfo{
+			ID:                  definition.ID,
+			Object:              "model",
+			Type:                "xai",
+			OwnedBy:             definition.OwnedBy,
+			DisplayName:         definition.DisplayName,
+			Name:                definition.Name,
+			Version:             definition.Version,
+			Description:         definition.Description,
+			SupportedParameters: append([]string(nil), definition.SupportedParameters...),
+		})
+	}
+	return models
+}

--- a/internal/runtime/executor/xai_image_models_test.go
+++ b/internal/runtime/executor/xai_image_models_test.go
@@ -1,0 +1,111 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+func modelIDs(models []*sdkmodelcatalog.ModelInfo) map[string]struct{} {
+	ids := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		if model != nil {
+			ids[model.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
+const grokImagineModel = "grok-imagine-image"
+
+// TestDiscoveredModelsCarryImageModels is the regression this fixes. The Imagine
+// models are not discoverable — the OAuth subscription's /models endpoint is the
+// CLI chat proxy, which lists chat models only. Registering them in the static
+// catalog made them visible in the panel while no credential actually served them,
+// so a request failed with "auth_not_found: no auth available" before reaching xAI.
+func TestDiscoveredModelsCarryImageModels(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"grok-4.5","object":"model"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	models := FetchXAIModels(
+		context.Background(),
+		oauthAuth(upstream.URL+"/v1"),
+		&config.Config{},
+	)
+
+	ids := modelIDs(models)
+	if _, ok := ids["grok-4.5"]; !ok {
+		t.Error("the live chat model list was lost")
+	}
+	for _, modelID := range []string{grokImagineModel, "grok-imagine-image-pro", "grok-2-image-1212"} {
+		if _, ok := ids[modelID]; !ok {
+			t.Errorf("%s is not routable; the credential cannot serve it", modelID)
+		}
+	}
+}
+
+// TestImageModelsRemainRoutableWhenDiscoveryFails covers a credential whose /models
+// call fails. The Imagine models are not discovered in the first place, so a failed
+// discovery must not make them disappear.
+func TestImageModelsRemainRoutableWhenDiscoveryFails(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(upstream.Close)
+
+	models := FetchXAIModels(context.Background(), oauthAuth(upstream.URL+"/v1"), &config.Config{})
+	if _, ok := modelIDs(models)[grokImagineModel]; !ok {
+		t.Error("image models must stay routable when model discovery fails")
+	}
+}
+
+func TestImageModelsRemainRoutableWithoutACredential(t *testing.T) {
+	models := FetchXAIModels(context.Background(), nil, &config.Config{})
+	if _, ok := modelIDs(models)[grokImagineModel]; !ok {
+		t.Error("image models should still be listed without a credential")
+	}
+}
+
+// TestUpstreamWinsWhenItAdvertisesAnImageModel keeps upstream authoritative about
+// anything it does report, so a live definition is never shadowed by the static one.
+func TestUpstreamWinsWhenItAdvertisesAnImageModel(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"grok-imagine-image","object":"model","context_length":4242}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	models := FetchXAIModels(context.Background(), oauthAuth(upstream.URL+"/v1"), &config.Config{})
+
+	count := 0
+	var found *sdkmodelcatalog.ModelInfo
+	for _, model := range models {
+		if model != nil && model.ID == grokImagineModel {
+			count++
+			found = model
+		}
+	}
+	if count != 1 {
+		t.Fatalf("grok-imagine-image appears %d times, want exactly 1", count)
+	}
+	if found.ContextLength != 4242 {
+		t.Error("the static definition shadowed what upstream reported")
+	}
+}
+
+func TestImageModelInfosCoverEveryRegisteredImageModel(t *testing.T) {
+	if len(xaiImageModelInfos()) != 3 {
+		t.Errorf("image model count = %d, want the three registered Grok image models", len(xaiImageModelInfos()))
+	}
+	for _, model := range xaiImageModelInfos() {
+		if model.Type != "xai" {
+			t.Errorf("%s type = %q, want xai so provider routing resolves", model.ID, model.Type)
+		}
+	}
+}

--- a/internal/runtime/executor/xai_models.go
+++ b/internal/runtime/executor/xai_models.go
@@ -90,9 +90,11 @@ func loadXAIModels() []*sdkmodelcatalog.ModelInfo {
 func fallbackXAIModels() []*sdkmodelcatalog.ModelInfo {
 	if models := loadXAIModels(); len(models) > 0 {
 		log.Debugf("xai executor: using cached model list (%d models)", len(models))
-		return models
+		return withXAIImageModels(models)
 	}
-	return nil
+	// The Imagine models are not discoverable, so they are still routable even when
+	// nothing could be fetched and no cache exists.
+	return withXAIImageModels(nil)
 }
 
 // FetchXAIModels retrieves the OAuth account's live model list from xAI.
@@ -147,7 +149,7 @@ func FetchXAIModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Co
 		return fallbackXAIModels()
 	}
 	storeXAIModels(models)
-	return models
+	return withXAIImageModels(models)
 }
 
 func parseXAIModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {

--- a/internal/runtime/executor/xai_models_test.go
+++ b/internal/runtime/executor/xai_models_test.go
@@ -103,8 +103,17 @@ func TestFetchXAIModelsFallsBackToCachedCatalog(t *testing.T) {
 			"base_url": "http://127.0.0.1:1",
 		},
 	}, nil)
-	if len(models) != 1 || models[0].ID != "cached-xai-model" {
-		t.Fatalf("fallback models = %+v, want cached-xai-model", models)
+	// The cached chat model must survive. It is no longer the only entry: the Grok
+	// Imagine models are not discoverable through /models at all, so they are merged
+	// into every credential's set and remain routable when discovery fails.
+	found := false
+	for _, model := range models {
+		if model != nil && model.ID == "cached-xai-model" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("fallback models = %+v, want the cached model retained", models)
 	}
 }
 


### PR DESCRIPTION
## 你踩到的报错

`auth_not_found: no auth available` —— 这**不是**我之前预测的 api.x.ai 拒绝 token。请求根本没发出去，在路由阶段就失败了。

## 根因（我上一个 PR 的漏洞）

xAI 凭据能路由哪些模型，**完全**由上游 `/models` 决定。OAuth 订阅的那个端点是 CLI 聊天代理，只列聊天模型——Imagine 系列在媒体主机上，`/models` 从来不会报告它们。

我上个 PR 只把模型加进了静态目录，于是：面板里**看得到**，但请求路由器手上**没有任何凭据声称能服务它**，所以在调用上游之前就 `auth_not_found`。

这就是「目录知道这个模型」和「有凭据能服务这个模型」两件事的区别，上一版我搞错了。

## 修复

把 Imagine 模型合并进每个 xAI 凭据的模型集，**所有返回路径都合并，包括 fallback**——这些模型本来就不是发现来的，所以发现失败时它们同样必须保持可路由。如果上游哪天真的报告了某个 Imagine 模型，以上游为准，静态定义不会覆盖它。

## 验证

- 本地完整 `./scripts/ci-pr.sh`：通过（`exit=0`）
- 新增回归测试：发现成功时聊天模型与图片模型共存、发现失败仍可路由、无凭据仍可列出、上游优先
- 既有的 cached-fallback 测试原本断言「缓存模型是唯一条目」，这个契约已经变了，已更新

## ⚠️ 仍未验证

**真实的 api.x.ai 媒体调用依然没跑过。** 这个修复解决的是路由层，请求现在能发到 xAI 了；但 token 是否被 `api.x.ai` 接受仍然要你实测。如果还报错，这次应该是真实的上游状态码（401/403/404），而不是 `auth_not_found`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)