### PR TITLE
fix(selection): say which channel group blocked a model instead of "no auth available"

### DIFF
--- a/internal/registry/image_generation_models.go
+++ b/internal/registry/image_generation_models.go
@@ -28,17 +28,19 @@ var imageGenerationModels = map[string]imageGenerationModelDefaults{
 		PricePerCall: 0.04,
 		Description:  "Image generation model billed per invocation",
 	},
-	// Grok Imagine. Pricing is left at zero because xAI bills these against the
-	// subscription rather than at a published per-image rate; an invented number
-	// would show up as real spend in usage reporting.
+	// Grok Imagine. These two ids are what api.x.ai actually serves; earlier
+	// revisions also listed grok-imagine-image-pro and grok-2-image-1212, taken
+	// from a third-party model list and never present in the live catalog, so
+	// selecting them could only ever fail.
+	//
+	// Pricing is left at zero because xAI bills these against the subscription
+	// rather than at a published per-image rate; an invented number would show up
+	// as real spend in usage reporting.
 	"grok-imagine-image": {
 		Description: "Grok Imagine image generation, billed per invocation",
 	},
-	"grok-imagine-image-pro": {
-		Description: "Grok Imagine Pro image generation, billed per invocation",
-	},
-	"grok-2-image-1212": {
-		Description: "Grok 2 image generation, billed per invocation",
+	"grok-imagine-image-quality": {
+		Description: "Grok Imagine Quality image generation, billed per invocation",
 	},
 }
 
@@ -183,8 +185,6 @@ func SupportsImageEditing(modelID string) bool {
 	case strings.HasPrefix(normalized, "grok-imagine-image"):
 		return true
 	default:
-		// grok-2-image-1212 is text-to-image only; offering an edit form for it
-		// would produce upstream 404s rather than a useful error.
 		return false
 	}
 }

--- a/internal/registry/image_generation_models_test.go
+++ b/internal/registry/image_generation_models_test.go
@@ -8,8 +8,7 @@ func TestIsImageGenerationModel(t *testing.T) {
 		"GPT-Image-2",
 		"gpt-image-3",
 		"grok-imagine-image",
-		"grok-imagine-image-pro",
-		"grok-2-image-1212",
+		"grok-imagine-image-quality",
 	}
 	for _, modelID := range imageModels {
 		if !IsImageGenerationModel(modelID) {
@@ -17,7 +16,11 @@ func TestIsImageGenerationModel(t *testing.T) {
 		}
 	}
 
-	textModels := []string{"", "grok-4.5", "grok-build-0.1", "gpt-5.5", "grok-imagine-video"}
+	// grok-2-image-1212 and grok-imagine-image-pro came from a third-party model
+	// list and are not in the live xAI catalog, so they must not classify.
+	textModels := []string{
+		"", "grok-4.5", "grok-build-0.1", "gpt-5.5", "grok-imagine-video", "grok-2-image-1212",
+	}
 	for _, modelID := range textModels {
 		if IsImageGenerationModel(modelID) {
 			t.Errorf("IsImageGenerationModel(%q) = true, want false", modelID)
@@ -62,6 +65,11 @@ func TestImageGenerationModelDefaults(t *testing.T) {
 		t.Errorf("grok-imagine-image price = %v, want 0", price)
 	}
 
+	// Models absent from the live catalog must not classify at all.
+	if IsImageGenerationModel("grok-2-image-1212") {
+		t.Error("grok-2-image-1212 is not in the xAI catalog and must not classify")
+	}
+
 	if _, _, ok := ImageGenerationModelDefaults("grok-4.5"); ok {
 		t.Error("a text model should have no image defaults")
 	}
@@ -71,7 +79,7 @@ func TestImageGenerationModelDefaults(t *testing.T) {
 // not the same as an image input modality, and widening it would reclassify
 // existing models as image-to-image in the catalog.
 func TestImageInputModalityStaysTextOnly(t *testing.T) {
-	for _, modelID := range []string{"gpt-image-2", "grok-imagine-image", "grok-2-image-1212"} {
+	for _, modelID := range []string{"gpt-image-2", "grok-imagine-image", "grok-imagine-image-quality"} {
 		got := ImageGenerationInputModalities(modelID)
 		if len(got) != 1 || got[0] != "text" {
 			t.Errorf("ImageGenerationInputModalities(%q) = %v, want [text]", modelID, got)
@@ -80,15 +88,10 @@ func TestImageInputModalityStaysTextOnly(t *testing.T) {
 }
 
 func TestSupportsImageEditing(t *testing.T) {
-	for _, modelID := range []string{"gpt-image-2", "grok-imagine-image", "grok-imagine-image-pro"} {
+	for _, modelID := range []string{"gpt-image-2", "grok-imagine-image", "grok-imagine-image-quality"} {
 		if !SupportsImageEditing(modelID) {
 			t.Errorf("SupportsImageEditing(%q) = false, want true", modelID)
 		}
-	}
-	// grok-2-image-1212 has no edit endpoint; offering the control would only
-	// produce upstream 404s.
-	if SupportsImageEditing("grok-2-image-1212") {
-		t.Error("grok-2-image-1212 has no edit endpoint and must not advertise one")
 	}
 }
 
@@ -108,7 +111,7 @@ func TestGrokImageModelsAreRegistered(t *testing.T) {
 	for _, model := range GetXAIModels() {
 		registered[model.ID] = struct{}{}
 	}
-	for _, modelID := range []string{"grok-imagine-image", "grok-imagine-image-pro", "grok-2-image-1212"} {
+	for _, modelID := range []string{"grok-imagine-image", "grok-imagine-image-quality"} {
 		if _, ok := registered[modelID]; !ok {
 			t.Errorf("%s is classified as an image model but is not in the xAI catalog", modelID)
 		}

--- a/internal/registry/model_definitions_image_data.go
+++ b/internal/registry/model_definitions_image_data.go
@@ -40,33 +40,20 @@ func getXAIImageModelDefinitions() []*ModelInfo {
 			DisplayName: "Grok Imagine",
 			Name:        "grok-imagine-image",
 			Description: "Grok Imagine text-to-image generation with reference image editing.",
-			// Media requests go to the official API host even for subscription
+			// Media requests reach the official API host even for subscription
 			// credentials; see xaiMediaBaseURL in the runtime executor.
 			SupportedParameters: []string{"prompt", "n", "response_format", "image", "mask"},
 		},
 		{
-			ID:                  "grok-imagine-image-pro",
+			ID:                  "grok-imagine-image-quality",
 			Object:              "model",
 			OwnedBy:             "xai",
 			Type:                "xai",
-			Version:             "grok-imagine-image-pro",
-			DisplayName:         "Grok Imagine Pro",
-			Name:                "grok-imagine-image-pro",
+			Version:             "grok-imagine-image-quality",
+			DisplayName:         "Grok Imagine Quality",
+			Name:                "grok-imagine-image-quality",
 			Description:         "Higher fidelity Grok Imagine image generation.",
 			SupportedParameters: []string{"prompt", "n", "response_format", "image", "mask"},
-		},
-		{
-			ID:          "grok-2-image-1212",
-			Object:      "model",
-			OwnedBy:     "xai",
-			Type:        "xai",
-			Version:     "grok-2-image-1212",
-			DisplayName: "Grok 2 Image",
-			Name:        "grok-2-image-1212",
-			Description: "Grok 2 text-to-image generation.",
-			// No image input: this model has no edit endpoint, so advertising one
-			// would only produce upstream 404s.
-			SupportedParameters: []string{"prompt", "n", "response_format"},
 		},
 	}
 }

--- a/internal/runtime/executor/xai_image_models_test.go
+++ b/internal/runtime/executor/xai_image_models_test.go
@@ -44,7 +44,7 @@ func TestDiscoveredModelsCarryImageModels(t *testing.T) {
 	if _, ok := ids["grok-4.5"]; !ok {
 		t.Error("the live chat model list was lost")
 	}
-	for _, modelID := range []string{grokImagineModel, "grok-imagine-image-pro", "grok-2-image-1212"} {
+	for _, modelID := range []string{grokImagineModel, "grok-imagine-image-quality"} {
 		if _, ok := ids[modelID]; !ok {
 			t.Errorf("%s is not routable; the credential cannot serve it", modelID)
 		}
@@ -100,8 +100,11 @@ func TestUpstreamWinsWhenItAdvertisesAnImageModel(t *testing.T) {
 }
 
 func TestImageModelInfosCoverEveryRegisteredImageModel(t *testing.T) {
-	if len(xaiImageModelInfos()) != 3 {
-		t.Errorf("image model count = %d, want the three registered Grok image models", len(xaiImageModelInfos()))
+	// Two models: grok-imagine-image and grok-imagine-image-quality. Earlier
+	// revisions also carried grok-imagine-image-pro and grok-2-image-1212, which
+	// the live xAI catalog does not serve.
+	if len(xaiImageModelInfos()) != 2 {
+		t.Errorf("image model count = %d, want the two registered Grok image models", len(xaiImageModelInfos()))
 	}
 	for _, model := range xaiImageModelInfos() {
 		if model.Type != "xai" {

--- a/sdk/cliproxy/auth/conductor_selector_service.go
+++ b/sdk/cliproxy/auth/conductor_selector_service.go
@@ -232,9 +232,13 @@ func (s selectorService) pickLocked(
 	includeCandidate func(candidate *Auth) bool,
 ) (*Auth, string, error) {
 	registryRef := s.manager.modelRegistry
+	var diagnosis error
 	for _, selectorRouteGroup := range scope.routeGroupsToTry() {
 		candidates := s.buildCandidatesLocked(scope, selectorRouteGroup, tried, registryRef, includeCandidate)
 		if len(candidates) == 0 {
+			if diagnosis == nil {
+				diagnosis = s.diagnoseEmptyCandidates(scope, selectorRouteGroup, includeCandidate)
+			}
 			continue
 		}
 		selector := s.manager.selectorForRoutingScopeLocked(scope.cfg, selectorRouteGroup, scope.allowedGroups)
@@ -246,6 +250,11 @@ func (s selectorService) pickLocked(
 			return nil, "", &Error{Code: "auth_not_found", Message: "selector returned no auth"}
 		}
 		return selected, selectorRouteGroup, nil
+	}
+	// A specific cause beats the generic message: "no auth available" reads as
+	// "the account is missing" when the account is present and healthy.
+	if diagnosis != nil {
+		return nil, "", diagnosis
 	}
 	return nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 }

--- a/sdk/cliproxy/auth/selection_diagnostics.go
+++ b/sdk/cliproxy/auth/selection_diagnostics.go
@@ -1,0 +1,151 @@
+package auth
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Selection diagnostics.
+//
+// When no credential can serve a request the selector used to report
+// "auth_not_found: no auth available" regardless of the reason. That message is
+// actively misleading in the most common case: the credentials exist and are
+// healthy, but the requested model is absent from a channel group's allowed-models
+// list, so every candidate is filtered out before selection runs.
+//
+// Diagnosing that from the outside is close to impossible — the operator sees
+// "no auth available" while the panel happily lists the account. Reconstructing
+// the reason here costs one extra pass over the candidate set, and only on the
+// failure path, where the request is already lost.
+
+// selectionRejection explains why a candidate was excluded.
+type selectionRejection struct {
+	// modelBlockedByGroups holds the channel groups whose allowed-models list
+	// excluded the requested model.
+	modelBlockedByGroups map[string]struct{}
+	// sawTenantCandidate records that the tenant owns at least one enabled
+	// credential for the request's provider, which is what makes a model-scope
+	// rejection the likely explanation rather than "there are no accounts".
+	sawTenantCandidate bool
+}
+
+// diagnoseEmptyCandidates inspects the credentials the scope considered and
+// returns a specific error when the cause is identifiable, or nil to fall back to
+// the generic message.
+func (s selectorService) diagnoseEmptyCandidates(
+	scope selectionScope,
+	scopedRouteGroup string,
+	includeCandidate func(candidate *Auth) bool,
+) error {
+	if s.manager == nil || scope.modelKey == "" {
+		return nil
+	}
+
+	rejection := selectionRejection{modelBlockedByGroups: map[string]struct{}{}}
+	for _, candidate := range s.manager.auths {
+		if candidate == nil || candidate.Disabled || candidate.Status == StatusDisabled {
+			continue
+		}
+		if normalizedTenantID(candidate.TenantID) != scope.tenantID {
+			continue
+		}
+		if includeCandidate != nil && !includeCandidate(candidate) {
+			continue
+		}
+		rejection.sawTenantCandidate = true
+
+		// Re-run only the model-scope gate. A candidate that clears it was excluded
+		// for some other reason, which this diagnosis deliberately does not guess at.
+		groups := authGroups(scope.cfg, candidate)
+		if modelAllowedByRoutingGroupScopes(scope.cfg, scope.modelKey, groups, scopedRouteGroup, scope.allowedGroups) {
+			continue
+		}
+		for _, name := range blockingRouteGroups(scope.cfg, scope.modelKey, groups, scopedRouteGroup, scope.allowedGroups) {
+			rejection.modelBlockedByGroups[name] = struct{}{}
+		}
+	}
+
+	if !rejection.sawTenantCandidate || len(rejection.modelBlockedByGroups) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(rejection.modelBlockedByGroups))
+	for name := range rejection.modelBlockedByGroups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return &Error{
+		Code: "model_not_allowed_by_channel_group",
+		Message: fmt.Sprintf(
+			"model %q is not in the allowed models of channel group %s; add it there or route the request to a group that permits it",
+			scope.modelKey, strings.Join(quoteAll(names), ", "),
+		),
+	}
+}
+
+// blockingRouteGroups lists the groups whose allowed-models list rejected a model.
+func blockingRouteGroups(
+	cfg *runtimeConfigSnapshot,
+	modelID string,
+	candidateGroups map[string]struct{},
+	routeGroup string,
+	allowedGroups map[string]struct{},
+) []string {
+	if cfg == nil || len(candidateGroups) == 0 {
+		return nil
+	}
+
+	scoped := scopedRouteGroupNames(candidateGroups, routeGroup, allowedGroups)
+	if len(scoped) == 0 {
+		return nil
+	}
+
+	blocking := make([]string, 0, len(scoped))
+	for _, group := range cfg.Routing.ChannelGroups {
+		name := normalizeGroupName(group.Name)
+		if _, ok := scoped[name]; !ok {
+			continue
+		}
+		if len(group.AllowedModels) == 0 {
+			continue
+		}
+		if !routingGroupAllowsModel(name, group.AllowedModels, modelID) {
+			blocking = append(blocking, group.Name)
+		}
+	}
+	return blocking
+}
+
+// scopedRouteGroupNames mirrors the group narrowing modelAllowedByRoutingGroupScopes
+// performs, so the diagnosis reports the same groups the gate actually consulted.
+func scopedRouteGroupNames(
+	candidateGroups map[string]struct{},
+	routeGroup string,
+	allowedGroups map[string]struct{},
+) map[string]struct{} {
+	scoped := make(map[string]struct{})
+	if routeGroup != "" {
+		normalized := normalizeGroupName(routeGroup)
+		if _, ok := candidateGroups[normalized]; ok {
+			scoped[normalized] = struct{}{}
+		}
+	}
+	if len(allowedGroups) > 0 {
+		for group := range candidateGroups {
+			if _, ok := allowedGroups[group]; ok {
+				scoped[group] = struct{}{}
+			}
+		}
+	}
+	return scoped
+}
+
+func quoteAll(values []string) []string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", value))
+	}
+	return quoted
+}

--- a/sdk/cliproxy/auth/selection_diagnostics_test.go
+++ b/sdk/cliproxy/auth/selection_diagnostics_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+// restrictedGroupManager reproduces the production shape that made this bug so hard
+// to diagnose: a healthy credential in a channel group whose allowed-models list
+// covers the chat model but not the image model.
+func restrictedGroupManager(t *testing.T) *Manager {
+	t.Helper()
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{
+					Name:          "default",
+					AllowedModels: []string{"grok-4.5"},
+				},
+			},
+		},
+	})
+	manager.RegisterExecutor(&stubExecutor{id: "xai"})
+
+	if _, err := manager.Register(context.Background(), &Auth{
+		ID:       "xai-auth",
+		Label:    "Grok Account",
+		Provider: "xai",
+		Status:   StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	return manager
+}
+
+func pickWithModel(manager *Manager, model string) error {
+	_, _, _, err := manager.pickNextMixed(
+		context.Background(),
+		[]string{"xai"},
+		model,
+		cliproxyexecutor.Options{},
+		map[string]struct{}{},
+	)
+	return err
+}
+
+// TestBlockedModelReportsTheChannelGroup is the fix. Reporting "no auth available"
+// for this case sent an operator hunting for a missing or broken account while the
+// account was present and healthy, and cost several rounds of investigation before
+// the allowed-models list was found.
+func TestBlockedModelReportsTheChannelGroup(t *testing.T) {
+	manager := restrictedGroupManager(t)
+
+	err := pickWithModel(manager, "grok-imagine-image")
+	if err == nil {
+		t.Fatal("a model outside the group's allowed list must not be selectable")
+	}
+
+	var selectionErr *Error
+	if asErr, ok := err.(*Error); ok {
+		selectionErr = asErr
+	} else {
+		t.Fatalf("error type = %T, want *Error", err)
+	}
+
+	if selectionErr.Code != "model_not_allowed_by_channel_group" {
+		t.Errorf("code = %q, want model_not_allowed_by_channel_group", selectionErr.Code)
+	}
+	// The message has to name both halves of the problem, because the fix is to
+	// edit one specific list.
+	if !strings.Contains(selectionErr.Message, "grok-imagine-image") {
+		t.Errorf("message does not name the model: %q", selectionErr.Message)
+	}
+	if !strings.Contains(selectionErr.Message, "default") {
+		t.Errorf("message does not name the channel group: %q", selectionErr.Message)
+	}
+}
+
+// TestAllowedModelStillSelectable pins that the diagnosis did not change routing:
+// a model on the list is still served.
+func TestAllowedModelStillSelectable(t *testing.T) {
+	manager := restrictedGroupManager(t)
+
+	if err := pickWithModel(manager, "grok-4.5"); err != nil {
+		t.Fatalf("an allowed model must still be selectable: %v", err)
+	}
+}
+
+// TestGenericErrorRemainsWhenNoCredentialExists keeps the original message for the
+// case it actually describes, so the new one stays meaningful.
+func TestGenericErrorRemainsWhenNoCredentialExists(t *testing.T) {
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{})
+	manager.RegisterExecutor(&stubExecutor{id: "xai"})
+
+	err := pickWithModel(manager, "grok-imagine-image")
+	if err == nil {
+		t.Fatal("expected an error when the tenant owns no credentials")
+	}
+	if asErr, ok := err.(*Error); ok && asErr.Code == "model_not_allowed_by_channel_group" {
+		t.Error("a tenant with no credentials must not be told about channel groups")
+	}
+}
+
+// TestUnrestrictedGroupDoesNotClaimBlocking guards against blaming a group that
+// permits everything when the real cause is something else.
+func TestUnrestrictedGroupDoesNotClaimBlocking(t *testing.T) {
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{Name: "default"},
+			},
+		},
+	})
+	manager.RegisterExecutor(&stubExecutor{id: "xai"})
+	if _, err := manager.Register(context.Background(), &Auth{
+		ID: "xai-auth", Provider: "xai", Status: StatusActive,
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	if err := pickWithModel(manager, "grok-imagine-image"); err != nil {
+		if asErr, ok := err.(*Error); ok && asErr.Code == "model_not_allowed_by_channel_group" {
+			t.Errorf("a group without an allowed-models list must not be reported as blocking: %v", asErr.Message)
+		}
+	}
+}


### PR DESCRIPTION
## 根因(线上实测确认)

你的租户 `default` 渠道组配了 `allowed-models` 白名单:

```
codex-auto-review, gpt-5.3-codex-spark, gpt-5.4, gpt-5.4-mini,
gpt-5.5, gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra, grok-4.5
```

`grok-4.5` 在里面 → 聊天正常。`gpt-image-2` 和 `grok-imagine-image` 不在 → 候选凭据在选择前就被全部过滤掉 → 报 `auth_not_found: no auth available`。

**Codex 和 Grok 表现完全一样,正是同一个白名单卡的**,和图片功能本身、和之前那两个 PR 都无关。

## 改动

**1. 错误信息说人话**

`auth_not_found: no auth available` 读起来是「账号没了/坏了」,但账号明明健在、还在正常跑别的模型。这条误导性信息让我在排查上绕了好几轮:面板列得出账号、聊天跑得通,一直到翻路由配置才发现白名单。

现在会明确报出**模型名 + 渠道组名**——因为修复动作就是去改那一个列表:

```
model "grok-imagine-image" is not in the allowed models of channel group "default";
add it there or route the request to a group that permits it
```

诊断只在失败路径上跑,且只有当租户确实拥有该 provider 的可用凭据时才给这个结论;租户压根没账号时保留原来的信息(那才是它真正描述的情况)。

**2. 修正 Grok 图片模型 ID**

用你账号的 token 实测 `api.x.ai/v1/models`,真实目录里是 `grok-imagine-image` 和 `grok-imagine-image-quality`。**`grok-imagine-image-pro` 和 `grok-2-image-1212` 根本不存在** —— 这两个是我上一轮从 new-api 的常量文件抄的,没核实,选中只会必然失败。已删除并补上 `-quality`。

## 验证

- 本地完整 `./scripts/ci-pr.sh`:通过(`exit=0`)
- 新增 4 条测试复现线上场景:健康凭据 + 白名单只含聊天模型 → 断言错误码为 `model_not_allowed_by_channel_group` 且消息同时含模型名和组名;白名单内模型仍可选;无凭据时保留原信息;无白名单的组不会被误报为阻断者

## 你需要做的

合并后,到面板**渠道组**页给 `default` 组的 allowed-models 加上:

```
gpt-image-2
grok-imagine-image
grok-imagine-image-quality
```

加完即可用。这个 PR 不会自动放行——白名单是你有意配的访问控制,不该由代码绕过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)