### PR TITLE
fix(image-generation): strip arguments xAI rejects and stop hiding routable models

### DIFF
--- a/internal/management/authfiles/models.go
+++ b/internal/management/authfiles/models.go
@@ -300,7 +300,7 @@ func ListModelEntriesLiveForTenant(
 		}
 		// Live miss/fail: keep last good discovery list if any (do not snap back to static).
 		if cached := loadDiscoveryCache(tenantID, provider); len(cached) > 0 {
-			return modelEntriesFromRegistry(cached), "upstream"
+			return modelEntriesFromRegistry(mergeDiscoveryWithStaticCatalog(provider, cached)), "upstream"
 		}
 		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
 	}
@@ -313,6 +313,10 @@ func ListModelEntriesLiveForTenant(
 	if len(live) == 0 {
 		return ListModelEntriesForTenant(manager, source, tenantID, name), sourceLabel
 	}
+
+	// Discovery for these providers is a subset of what the runtime registers, so
+	// it supplements the static catalog instead of replacing the panel's view.
+	live = mergeDiscoveryWithStaticCatalog(liveProvider, live)
 
 	sourceLabel = "upstream"
 	if updateRegistry && registrar != nil {

--- a/internal/management/authfiles/static_catalog_merge.go
+++ b/internal/management/authfiles/static_catalog_merge.go
@@ -1,0 +1,78 @@
+package authfiles
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+// Static catalog merging for discovery results.
+//
+// For claude, codex and xai the runtime registers the *static* catalog and treats
+// upstream discovery as supplementary — the ChatGPT manifest is gated by client
+// version, and the Grok CLI gateway advertises a single chat model, so neither is a
+// full catalog. That is already documented at the fetch call sites.
+//
+// The management panel, however, replaced its view with the discovery result. The
+// effect was a model list narrower than what the deployment can actually route:
+// gpt-image-2 is registered and serviceable for every Codex account, but vanished
+// from the panel the moment an operator pressed refresh, which reads as "this
+// account does not have that model".
+//
+// Displayed and routable have to agree, so discovery is merged over the static
+// catalog rather than replacing it.
+
+// mergeDiscoveryWithStaticCatalog returns the union of a provider's static catalog
+// and its live discovery result.
+//
+// Upstream wins on conflicting ids: when a provider does report a model, its live
+// definition is more current than the compiled-in one. Providers whose discovery is
+// authoritative pass through untouched.
+func mergeDiscoveryWithStaticCatalog(provider string, live []*registry.ModelInfo) []*registry.ModelInfo {
+	if !discoveryIsPartial(provider) {
+		return live
+	}
+
+	static := staticCatalogForProvider(provider)
+	if len(static) == 0 {
+		return live
+	}
+
+	seen := make(map[string]struct{}, len(live))
+	for _, model := range live {
+		if model == nil {
+			continue
+		}
+		seen[strings.ToLower(strings.TrimSpace(model.ID))] = struct{}{}
+	}
+
+	merged := make([]*registry.ModelInfo, 0, len(live)+len(static))
+	merged = append(merged, live...)
+	for _, model := range static {
+		if model == nil {
+			continue
+		}
+		if _, exists := seen[strings.ToLower(strings.TrimSpace(model.ID))]; exists {
+			continue
+		}
+		merged = append(merged, model)
+	}
+	return merged
+}
+
+// discoveryIsPartial reports whether a provider's upstream listing is known to be a
+// subset of what the runtime registers, and therefore must not replace the catalog.
+func discoveryIsPartial(provider string) bool {
+	return supportsSharedDiscovery(provider)
+}
+
+// staticCatalogForProvider resolves the compiled-in catalog the runtime registers
+// for a provider, converted to the registry shape the panel renders.
+func staticCatalogForProvider(provider string) []*registry.ModelInfo {
+	channel := normalizeDiscoveryProvider(provider)
+	if channel == "" {
+		return nil
+	}
+	return cloneSDKModelsToRegistry(sdkmodelcatalog.StaticModelDefinitionsByChannel(channel))
+}

--- a/internal/management/authfiles/static_catalog_merge_test.go
+++ b/internal/management/authfiles/static_catalog_merge_test.go
@@ -1,0 +1,78 @@
+package authfiles
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+)
+
+func mergedIDs(provider string, live []*registry.ModelInfo) map[string]struct{} {
+	merged := mergeDiscoveryWithStaticCatalog(provider, live)
+	ids := make(map[string]struct{}, len(merged))
+	for _, model := range merged {
+		if model != nil {
+			ids[model.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
+// TestRefreshKeepsModelsDiscoveryOmits is the reported bug: pressing refresh on a
+// Codex account dropped gpt-image-2 from the panel, because the ChatGPT manifest is
+// a subset of what the runtime actually registers. The panel then showed a narrower
+// list than the deployment can route, which reads as "this account lacks the model".
+func TestRefreshKeepsModelsDiscoveryOmits(t *testing.T) {
+	live := []*registry.ModelInfo{{ID: "gpt-5.5", Object: "model"}}
+
+	ids := mergedIDs("codex", live)
+	if _, ok := ids["gpt-5.5"]; !ok {
+		t.Error("the discovered model was lost")
+	}
+	if _, ok := ids["gpt-image-2"]; !ok {
+		t.Error("gpt-image-2 is registered and routable but missing from the panel view")
+	}
+}
+
+// TestUpstreamDefinitionWins keeps discovery authoritative for anything it reports,
+// so a live definition is never shadowed by the compiled-in one.
+func TestUpstreamDefinitionWins(t *testing.T) {
+	live := []*registry.ModelInfo{{ID: "gpt-image-2", Object: "model", DisplayName: "Live Name"}}
+
+	merged := mergeDiscoveryWithStaticCatalog("codex", live)
+	count := 0
+	var found *registry.ModelInfo
+	for _, model := range merged {
+		if model != nil && model.ID == "gpt-image-2" {
+			count++
+			found = model
+		}
+	}
+	if count != 1 {
+		t.Fatalf("gpt-image-2 appears %d times, want 1", count)
+	}
+	if found.DisplayName != "Live Name" {
+		t.Error("the static definition shadowed what upstream reported")
+	}
+}
+
+// TestAuthoritativeProvidersAreUntouched: antigravity discovery replaces the
+// registry, so merging a static catalog into it would resurrect stale models.
+func TestAuthoritativeProvidersAreUntouched(t *testing.T) {
+	live := []*registry.ModelInfo{{ID: "only-model", Object: "model"}}
+
+	merged := mergeDiscoveryWithStaticCatalog("antigravity", live)
+	if len(merged) != 1 || merged[0].ID != "only-model" {
+		t.Errorf("merged = %v, want the discovery result unchanged", merged)
+	}
+}
+
+func TestXAIRefreshKeepsImageModels(t *testing.T) {
+	// The Grok CLI gateway advertises a single chat model; the Imagine models are
+	// not discoverable and must still be listed.
+	ids := mergedIDs("xai", []*registry.ModelInfo{{ID: "grok-4.5", Object: "model"}})
+	for _, modelID := range []string{"grok-4.5", "grok-imagine-image"} {
+		if _, ok := ids[modelID]; !ok {
+			t.Errorf("%s missing from the merged xai list", modelID)
+		}
+	}
+}

--- a/internal/runtime/executor/xai_media.go
+++ b/internal/runtime/executor/xai_media.go
@@ -58,10 +58,10 @@ func xaiMediaPath(alt string) string {
 
 // executeImageGeneration forwards an image request to the Grok Imagine API.
 //
-// The upstream is OpenAI-compatible on both the request and response side, so the
-// payload passes through untranslated. That is deliberate: inventing a translation
-// layer here would mean re-encoding fields we do not model, and any field xAI adds
-// later would be silently dropped instead of reaching the caller.
+// The response passes through untranslated because the upstream shape already
+// matches: re-encoding it would drop any field xAI adds that we do not model. The
+// request cannot be passed through, because xAI rejects OpenAI-only arguments
+// outright; see shapeXAIImageRequest.
 func (e *XAIExecutor) executeImageGeneration(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{})
 	reporter := execCtx.Reporter()
@@ -75,6 +75,15 @@ func (e *XAIExecutor) executeImageGeneration(ctx context.Context, auth *cliproxy
 	payload := req.Payload
 	if len(bytes.TrimSpace(payload)) == 0 {
 		return resp, statusErr{code: http.StatusBadRequest, msg: "image request body is empty"}
+	}
+
+	// xAI rejects the entire request when an OpenAI-only argument is present, so
+	// the body is filtered to what the Imagine endpoints accept.
+	payload, dropped := shapeXAIImageRequest(payload)
+	if len(dropped) > 0 {
+		logWithRequestID(execCtx.Context).Debugf(
+			"xai image request: dropped unsupported arguments %s", strings.Join(dropped, ", "),
+		)
 	}
 
 	endpoint := strings.TrimSuffix(xaiMediaBaseURL(auth), "/") + xaiMediaPath(opts.Alt)

--- a/internal/runtime/executor/xai_media_request.go
+++ b/internal/runtime/executor/xai_media_request.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Request shaping for the Grok Imagine endpoints.
+//
+// The endpoints are OpenAI-compatible in shape but not in accepted arguments: xAI
+// rejects the whole request with 400 "Argument not supported: size" when an
+// OpenAI-only field is present. Forwarding the body verbatim therefore fails for
+// any caller that sets size or quality — which the console does by default.
+//
+// An earlier revision passed media bodies through untranslated, reasoning that a
+// translation layer would silently drop fields xAI might add later. That reasoning
+// was wrong here: the risk is not hypothetical future fields, it is that today's
+// request is rejected outright. Filtering to an allowlist keeps unknown fields out
+// while leaving everything xAI documents intact.
+//
+// The allowlist mirrors the SupportedParameters declared for these models in
+// internal/registry, so the catalog and the wire format cannot drift apart.
+
+// xaiImageRequestFields are the top-level keys xAI accepts on /images/generations.
+var xaiImageRequestFields = map[string]struct{}{
+	"model":           {},
+	"prompt":          {},
+	"n":               {},
+	"response_format": {},
+	// Reference inputs for the edit endpoint; harmless on generations.
+	"image": {},
+	"mask":  {},
+	// Passed through for upstream abuse attribution.
+	"user": {},
+}
+
+// shapeXAIImageRequest removes fields the Grok Imagine API rejects.
+//
+// It returns the filtered body and the names it dropped, so the caller can tell the
+// operator which of their settings were ignored rather than silently changing the
+// meaning of the request.
+func shapeXAIImageRequest(payload []byte) ([]byte, []string) {
+	parsed := gjson.ParseBytes(payload)
+	if !parsed.IsObject() {
+		return payload, nil
+	}
+
+	dropped := make([]string, 0, 4)
+	shaped := payload
+	parsed.ForEach(func(key, _ gjson.Result) bool {
+		name := key.String()
+		if _, ok := xaiImageRequestFields[strings.ToLower(strings.TrimSpace(name))]; ok {
+			return true
+		}
+		if next, err := sjson.DeleteBytes(shaped, escapeJSONPathKey(name)); err == nil {
+			shaped = next
+			dropped = append(dropped, name)
+		}
+		return true
+	})
+
+	if len(dropped) == 0 {
+		return payload, nil
+	}
+	return shaped, dropped
+}
+
+// escapeJSONPathKey protects keys containing the separators sjson treats specially,
+// so a field named "a.b" is deleted rather than being read as a nested path.
+func escapeJSONPathKey(key string) string {
+	replacer := strings.NewReplacer(".", `\.`, "*", `\*`, "?", `\?`)
+	return replacer.Replace(key)
+}

--- a/internal/runtime/executor/xai_media_request_test.go
+++ b/internal/runtime/executor/xai_media_request_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+)
+
+// TestShapeDropsArgumentsXAIRejects is the fix for the failure an operator hits on
+// the very first attempt: the console sends size and quality by default, and xAI
+// rejects the whole request with 400 "Argument not supported: size".
+func TestShapeDropsArgumentsXAIRejects(t *testing.T) {
+	body := []byte(`{
+		"model":"grok-imagine-image-quality",
+		"prompt":"a cat",
+		"n":1,
+		"response_format":"b64_json",
+		"size":"1024x1024",
+		"quality":"medium",
+		"style":"vivid",
+		"background":"transparent",
+		"output_format":"png"
+	}`)
+
+	shaped, dropped := shapeXAIImageRequest(body)
+
+	var decoded map[string]any
+	if err := json.Unmarshal(shaped, &decoded); err != nil {
+		t.Fatalf("shaped body is not valid json: %v", err)
+	}
+	for _, field := range []string{"size", "quality", "style", "background", "output_format"} {
+		if _, present := decoded[field]; present {
+			t.Errorf("%q survived and will be rejected upstream", field)
+		}
+		if !slices.Contains(dropped, field) {
+			t.Errorf("%q was removed but not reported to the caller", field)
+		}
+	}
+
+	// Everything the endpoint documents has to survive untouched.
+	for field, want := range map[string]any{
+		"model": "grok-imagine-image-quality", "prompt": "a cat", "response_format": "b64_json",
+	} {
+		if decoded[field] != want {
+			t.Errorf("%q = %v, want %v", field, decoded[field], want)
+		}
+	}
+	if decoded["n"] != float64(1) {
+		t.Errorf("n = %v, want 1", decoded["n"])
+	}
+}
+
+func TestShapeLeavesASupportedRequestUntouched(t *testing.T) {
+	body := []byte(`{"model":"grok-imagine-image","prompt":"x","n":2,"response_format":"url"}`)
+
+	shaped, dropped := shapeXAIImageRequest(body)
+	if len(dropped) != 0 {
+		t.Errorf("dropped = %v, want nothing", dropped)
+	}
+	if string(shaped) != string(body) {
+		t.Errorf("body was rewritten unnecessarily: %s", shaped)
+	}
+}
+
+// TestShapeKeepsEditInputs guards the edits endpoint: stripping the reference image
+// would turn an edit into a plain generation without saying so.
+func TestShapeKeepsEditInputs(t *testing.T) {
+	body := []byte(`{"model":"grok-imagine-image","prompt":"x","image":"data:image/png;base64,AAA","mask":"data:image/png;base64,BBB"}`)
+
+	shaped, dropped := shapeXAIImageRequest(body)
+	if len(dropped) != 0 {
+		t.Fatalf("dropped = %v, want nothing", dropped)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(shaped, &decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded["image"] == nil || decoded["mask"] == nil {
+		t.Error("reference inputs were stripped from an edit request")
+	}
+}
+
+func TestShapeIgnoresNonObjectBodies(t *testing.T) {
+	for _, body := range []string{`[]`, `"text"`, ``} {
+		shaped, dropped := shapeXAIImageRequest([]byte(body))
+		if string(shaped) != body || len(dropped) != 0 {
+			t.Errorf("body %q was modified: %q %v", body, shaped, dropped)
+		}
+	}
+}


### PR DESCRIPTION
## 1. Grok 生图报 `400 Argument not supported: size`

好消息:白名单加上之后**请求真的打到 xAI 了**,这个 400 是真实上游返回的 —— 说明 api.x.ai + OAuth token 那条链路是通的。

问题在参数:Imagine 接口**形状**是 OpenAI 兼容的,但**接受的参数**不是。控制台默认会带 `size` 和 `quality`,xAI 直接整个请求打回。

我上一版特意写了"媒体请求原样透传,不做翻译",理由是加翻译层会把 xAI 以后新增的字段吃掉 —— 这个权衡在这里是错的:拿一个**假设中的未来损失**换了一个**确定的当下失败**。现在按接口实际接受的字段过滤,被丢弃的参数会记日志,不会悄悄改变用户的请求语义。

允许字段直接对齐这些模型在 `internal/registry` 里已声明的 `SupportedParameters`,避免目录和线格式两边漂移。

## 2. 刷新模型刷不出 `gpt-image-2`

对 claude / codex / xai 三家,运行时注册的是**静态目录**,上游发现只作为补充 —— ChatGPT manifest 受 client_version 限制、Grok CLI 网关只报一个聊天模型,代码注释自己都写了 "not a full catalog"。

但管理面板在刷新时**用发现结果整个替换**了视图。结果就是面板显示的比部署实际能路由的更窄:`gpt-image-2` 一直是注册好、能用的,一按刷新就消失,看起来像"这个账号没有这个模型"。

现在发现结果**合并**到静态目录之上;上游确实报告了的模型,以上游定义为准(不会被编译进来的旧定义盖住)。

## 验证

- 本地完整 `./scripts/ci-pr.sh`:通过(`exit=0`)
- 参数过滤:4 条测试覆盖 —— 丢弃 size/quality/style/background/output_format 且告知调用方、合法请求原样不动、edits 的 `image`/`mask` 参考图不被剥离(否则会把编辑悄悄变成纯生成)、非对象 body 不处理
- 目录合并:4 条测试覆盖 —— codex 刷新后 `gpt-image-2` 仍在、上游定义优先、antigravity 这类发现即权威的 provider 不受影响、xai 刷新后 Imagine 模型仍在

## 说明

`size` / `quality` 这两个控件对 Grok 模型目前是无效输入,后端会丢弃。前端按模型能力隐藏它们是更干净的做法,我可以接着做 —— 但先把这个后端修复发出去,让生图能真正跑通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)