### PR TITLE
fix(models): restore only the models discovery cannot report, not the whole catalog

### DIFF
--- a/internal/management/authfiles/static_catalog_merge.go
+++ b/internal/management/authfiles/static_catalog_merge.go
@@ -20,11 +20,15 @@ import (
 // from the panel the moment an operator pressed refresh, which reads as "this
 // account does not have that model".
 //
-// Displayed and routable have to agree, so discovery is merged over the static
-// catalog rather than replacing it.
+// The merge is deliberately narrow. Discovery is authoritative for anything it can
+// report: a chat model absent from the listing has been retired upstream, and
+// resurrecting it from the compiled-in catalog would show operators models they
+// cannot use. Only models the listing structurally cannot contain are restored —
+// image generation lives on a different endpoint and never appears in a chat model
+// listing, which is exactly why gpt-image-2 went missing while gpt-5.5 did not.
 
-// mergeDiscoveryWithStaticCatalog returns the union of a provider's static catalog
-// and its live discovery result.
+// mergeDiscoveryWithStaticCatalog restores the static models a provider's discovery
+// endpoint cannot report, leaving everything else to discovery.
 //
 // Upstream wins on conflicting ids: when a provider does report a model, its live
 // definition is more current than the compiled-in one. Providers whose discovery is
@@ -50,7 +54,7 @@ func mergeDiscoveryWithStaticCatalog(provider string, live []*registry.ModelInfo
 	merged := make([]*registry.ModelInfo, 0, len(live)+len(static))
 	merged = append(merged, live...)
 	for _, model := range static {
-		if model == nil {
+		if model == nil || !undiscoverableByChatListing(model.ID) {
 			continue
 		}
 		if _, exists := seen[strings.ToLower(strings.TrimSpace(model.ID))]; exists {
@@ -59,6 +63,16 @@ func mergeDiscoveryWithStaticCatalog(provider string, live []*registry.ModelInfo
 		merged = append(merged, model)
 	}
 	return merged
+}
+
+// undiscoverableByChatListing reports whether a model can never appear in a
+// provider's chat model listing, and therefore has to come from the static catalog.
+//
+// Image generation is served by a separate endpoint and is absent from every chat
+// listing regardless of entitlement. A chat model missing from the listing means
+// something different — it was retired — so it is deliberately not restored here.
+func undiscoverableByChatListing(modelID string) bool {
+	return registry.IsImageGenerationModel(modelID)
 }
 
 // discoveryIsPartial reports whether a provider's upstream listing is known to be a

--- a/internal/management/authfiles/static_catalog_merge_test.go
+++ b/internal/management/authfiles/static_catalog_merge_test.go
@@ -35,6 +35,26 @@ func TestRefreshKeepsModelsDiscoveryOmits(t *testing.T) {
 	}
 }
 
+// TestRetiredChatModelsStayHidden is the counterpart to the test above. An earlier
+// revision merged the whole static catalog, which resurrected models OpenAI has
+// retired (gpt-5.1, gpt-5.2, gpt-5-codex...) and showed operators models they
+// cannot use. A chat model absent from the listing has been withdrawn; only models
+// the listing structurally cannot contain are restored.
+func TestRetiredChatModelsStayHidden(t *testing.T) {
+	live := []*registry.ModelInfo{{ID: "gpt-5.5", Object: "model"}}
+
+	ids := mergedIDs("codex", live)
+	for _, retired := range []string{"gpt-5", "gpt-5.1", "gpt-5.2", "gpt-5-codex", "gpt-5.1-codex"} {
+		if _, ok := ids[retired]; ok {
+			t.Errorf("%s is not reported by discovery and must not be resurrected", retired)
+		}
+	}
+	// The one model the listing cannot contain is still restored.
+	if _, ok := ids["gpt-image-2"]; !ok {
+		t.Error("gpt-image-2 must still be restored")
+	}
+}
+
 // TestUpstreamDefinitionWins keeps discovery authoritative for anything it reports,
 // so a live definition is never shadowed by the compiled-in one.
 func TestUpstreamDefinitionWins(t *testing.T) {
@@ -72,10 +92,14 @@ func TestXAIRefreshKeepsImageModels(t *testing.T) {
 	// The Grok CLI gateway advertises a single chat model; the Imagine models are
 	// not discoverable and must still be listed.
 	ids := mergedIDs("xai", []*registry.ModelInfo{{ID: "grok-4.5", Object: "model"}})
-	for _, modelID := range []string{"grok-4.5", "grok-imagine-image"} {
+	for _, modelID := range []string{"grok-4.5", "grok-imagine-image", "grok-imagine-image-quality"} {
 		if _, ok := ids[modelID]; !ok {
 			t.Errorf("%s missing from the merged xai list", modelID)
 		}
+	}
+	// Retired Grok chat models must not come back either.
+	if _, ok := ids["grok-build-0.1"]; ok {
+		t.Error("a chat model absent from discovery must not be resurrected")
 	}
 }
 


### PR DESCRIPTION
## 问题

上一版我把**整个静态目录**并进了刷新结果,于是把 OpenAI 早已下架的模型也带了回来:`gpt-5`、`gpt-5.1`、`gpt-5.2`、`gpt-5-codex`……面板给运维展示了一堆根本用不了的模型。修过头了。

## 正确的规则

**发现接口能报告的,以发现结果为准。** 聊天模型没出现在列表里,说明上游已经下架——这时候编译进来的静态目录才是过期的那一方,不该把它翻出来。

**只补上「发现接口结构上不可能包含」的模型。** 生图走的是另一个端点,无论账号什么权限都不会出现在聊天模型列表里——这正是 `gpt-image-2` 会消失而 `gpt-5.5` 不会的原因。

## 验证

- 本地完整 `./scripts/ci-pr.sh`:通过(`exit=0`)
- 新增 `TestRetiredChatModelsStayHidden`:断言 `gpt-5`/`gpt-5.1`/`gpt-5.2`/`gpt-5-codex`/`gpt-5.1-codex` 不会被复活,同时 `gpt-image-2` 仍然补得回来
- xai 侧同样断言:Imagine 两个模型补得回来,但发现结果里没有的聊天模型(`grok-build-0.1`)不会被复活

🤖 Generated with [Claude Code](https://claude.com/claude-code)