### PR TITLE
fix(models): keep image models registered when chat models are curated

### DIFF
--- a/internal/app/service/image_model_registration.go
+++ b/internal/app/service/image_model_registration.go
@@ -1,0 +1,87 @@
+package serviceapp
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+// Image-generation model registration.
+//
+// Chat model lists are curated: retired models are pruned so operators are not
+// offered something upstream no longer serves. Image models must not be swept up
+// in that pruning, and repeatedly were:
+//
+//   - They never appear in a provider's chat model listing, because generation is
+//     served by a different endpoint. Absence there carries no signal about
+//     availability, unlike a retired chat model.
+//   - Every entitled account has them. gpt-image-2 is available to any Codex Plus
+//     or Pro account, and the Grok Imagine models to any subscription that can
+//     reach the media host.
+//
+// The result of getting this wrong is that a model the runtime can serve is not
+// registered, so it cannot be selected, cannot be added to a channel group's
+// allowed list, and reports itself as unavailable — while the credential detail
+// panel happily shows it.
+//
+// This was previously fixed for xAI alone, inside its model fetch. Doing it per
+// provider is what let Codex regress the same way, so it now applies to every
+// provider that serves image models.
+//
+// It lives on the internal side because sdk packages may not import internal ones,
+// and no sdk/cliproxy file does today. Widening that boundary for one helper would
+// be the wrong trade.
+
+// withRegisteredImageModels guarantees a provider's image-generation models are in
+// the set registered for a credential.
+//
+// Models already present are left alone: a live definition is more current than the
+// compiled-in one.
+func WithRegisteredImageModels(provider string, models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	imageModels := imageModelsForProvider(provider)
+	if len(imageModels) == 0 {
+		return models
+	}
+
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		seen[strings.ToLower(strings.TrimSpace(model.ID))] = struct{}{}
+	}
+
+	out := append([]*sdkmodelcatalog.ModelInfo(nil), models...)
+	for _, model := range imageModels {
+		if _, exists := seen[strings.ToLower(strings.TrimSpace(model.ID))]; exists {
+			continue
+		}
+		out = append(out, model)
+	}
+	return out
+}
+
+// imageModelsForProvider resolves a provider's image models from the static
+// catalog, so adding one there makes it routable without a second edit here.
+func imageModelsForProvider(provider string) []*sdkmodelcatalog.ModelInfo {
+	channel := strings.ToLower(strings.TrimSpace(provider))
+	if channel == "" {
+		return nil
+	}
+
+	definitions := sdkmodelcatalog.StaticModelDefinitionsByChannel(channel)
+	images := make([]*sdkmodelcatalog.ModelInfo, 0, 2)
+	for _, definition := range definitions {
+		if definition == nil || !registry.IsImageGenerationModel(definition.ID) {
+			continue
+		}
+		// The provider that serves the model has to match the credential's, or a
+		// Codex account would advertise Grok's models and fail at request time.
+		if !strings.EqualFold(registry.ImageGenerationProvider(definition.ID), channel) {
+			continue
+		}
+		images = append(images, definition)
+	}
+	return images
+}

--- a/sdk/cliproxy/service_model_image_registration_test.go
+++ b/sdk/cliproxy/service_model_image_registration_test.go
@@ -1,0 +1,91 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
+)
+
+func registeredIDs(t *testing.T, auth *coreauth.Auth) map[string]struct{} {
+	t.Helper()
+	ids := make(map[string]struct{})
+	for _, model := range GlobalModelRegistry().GetModelsForClient(auth.ID) {
+		if model != nil {
+			ids[model.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
+// TestCodexKeepsImageModelWhenChatModelsAreCurated is the reported failure. A
+// deployment prunes retired chat models from the registered set; gpt-image-2 was
+// swept up in that pruning, so the console could not select it, could not add it to
+// a channel group, and reported it unavailable — while the credential panel showed
+// it.
+func TestCodexKeepsImageModelWhenChatModelsAreCurated(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID: "codex-image", Provider: "codex", Status: coreauth.StatusActive,
+		Metadata:   map[string]any{"access_token": "t"},
+		Attributes: map[string]string{"auth_kind": "oauth"},
+	}
+	// Reproduce curation by excluding everything the deployment retired, which is
+	// what an operator's exclusion list ends up doing.
+	auth.Attributes["excluded_models"] = "gpt-5,gpt-5.1,gpt-5.2,gpt-5-codex,gpt-5-codex-mini,gpt-image-2"
+
+	service := &Service{cfg: &config.Config{}}
+	service.registerModelsForAuth(context.Background(), auth)
+	t.Cleanup(func() { GlobalModelRegistry().UnregisterClient(auth.ID) })
+
+	ids := registeredIDs(t, auth)
+	if _, ok := ids["gpt-image-2"]; !ok {
+		t.Error("gpt-image-2 must stay registered: it is available to every entitled account and is never reported by chat discovery")
+	}
+	// Curation of chat models still applies.
+	if _, ok := ids["gpt-5.1"]; ok {
+		t.Error("a retired chat model must remain excluded")
+	}
+}
+
+func TestImageModelsAreNotCrossRegisteredBetweenProviders(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID: "codex-only", Provider: "codex", Status: coreauth.StatusActive,
+		Metadata:   map[string]any{"access_token": "t"},
+		Attributes: map[string]string{"auth_kind": "oauth"},
+	}
+	service := &Service{cfg: &config.Config{}}
+	service.registerModelsForAuth(context.Background(), auth)
+	t.Cleanup(func() { GlobalModelRegistry().UnregisterClient(auth.ID) })
+
+	// A Codex credential advertising Grok's models would fail at request time.
+	if _, ok := registeredIDs(t, auth)["grok-imagine-image"]; ok {
+		t.Error("a codex credential must not advertise xai image models")
+	}
+}
+
+func TestWithRegisteredImageModelsDoesNotDuplicate(t *testing.T) {
+	existing := []*ModelInfo{{ID: "gpt-image-2", DisplayName: "Live Definition"}}
+
+	merged := serviceapp.WithRegisteredImageModels("codex", existing)
+	count := 0
+	for _, model := range merged {
+		if model != nil && model.ID == "gpt-image-2" {
+			count++
+			if model.DisplayName != "Live Definition" {
+				t.Error("the live definition was replaced by the static one")
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("gpt-image-2 appears %d times, want 1", count)
+	}
+}
+
+func TestProvidersWithoutImageModelsAreUnchanged(t *testing.T) {
+	existing := []*ModelInfo{{ID: "claude-opus-4-6"}}
+	if merged := serviceapp.WithRegisteredImageModels("claude", existing); len(merged) != 1 {
+		t.Errorf("merged = %d models, want the input unchanged", len(merged))
+	}
+}

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -2,6 +2,7 @@ package cliproxy
 
 import (
 	"context"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
 	"strings"
 
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -213,6 +214,9 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		}
 	}
 	models = applyOAuthModelAlias(s.cfg, provider, authKind, models)
+	// Applied after every filter: image models are entitlement-universal and never
+	// reported by chat discovery, so chat-model curation must not remove them.
+	models = serviceapp.WithRegisteredImageModels(provider, models)
 	if len(models) > 0 {
 		key := provider
 		if key == "" {

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -114,3 +114,9 @@ func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Conf
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	internalserviceapp.RegisterExecutorForAuth(coreManager, cfg, auth, forceReplace, gateway)
 }
+
+// WithRegisteredImageModels guarantees a provider's image-generation models are in
+// the set registered for a credential. See internal/app/service for why.
+func WithRegisteredImageModels(provider string, models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.WithRegisteredImageModels(provider, models)
+}


### PR DESCRIPTION
## 问题

线上实测该租户 `/v1/models` 只有 11 个模型:有 `grok-imagine-image` / `-quality`,**没有 `gpt-image-2`**。

连锁反应正是你截图里那三个现象:
- 凭据详情**显示** `gpt-image-2`(那是上一版我加的**展示层**合并)
- 渠道组「允许模型」勾选列表**没有它** → 你根本勾不上
- 生图报 `model_not_allowed_by_channel_group` → 因为它不在白名单,而你又加不进去

根子是我自己的不一致:**xai 我修在注册层,codex 我只修了展示层。**

## 判据

线上把静态目录收敛成了"当前在售"的 8 个,`gpt-5`/`gpt-5.1`/`gpt-5.2`/`gpt-5-codex` 这些下架的都被剔除了 —— 这是对的。但 `gpt-image-2` 被一起剔掉了,这是错的:

- 生图走的是**另一个端点**,不出现在聊天模型列表里,所以"没被列出"对它**不构成下架信号**(对聊天模型才构成)
- 它是**权限普适**的:任何 Plus / Pro 账号都有,Grok Imagine 对任何能访问媒体主机的订阅也一样

所以:聊天模型的裁剪照旧,生图模型在所有过滤之后保证在场。并且校验 provider 归属,避免 Codex 凭据去广告 Grok 的模型然后在请求时失败。

## 边界

助手放在 internal 侧,通过既有的 `sdkbridge` 调用。结构门禁拦了我第一版(sdk 包不得 import internal),我查了 allowlist:`sdk/cliproxy/` 下**一个条目都没有**,加第一个就是真的破坏边界,不是"和邻居保持一致"。所以换位置而不是加白名单。

## 验证

- 本地完整 `./scripts/ci-pr.sh`:通过(`exit=0`)
- 4 条测试:模拟线上裁剪(把下架模型和 gpt-image-2 一起排除)后 `gpt-image-2` 仍注册、下架聊天模型仍被排除、Codex 不会拿到 Grok 的图片模型、已存在的实时定义不被静态定义覆盖、无图片模型的 provider 不受影响

## 合并后

`gpt-image-2` 会出现在渠道组的勾选列表里,你可以正常勾选。或者更省事:**清空 `default` 组的允许模型列表**(留空 = 放行全部),这个现在就能做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)