### PR TITLE
fix(models): let the channel-group editor list models it is meant to add

### DIFF
--- a/internal/api/models_endpoint_ignore_allowed_test.go
+++ b/internal/api/models_endpoint_ignore_allowed_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestQueryFlagEnabled pins the flag parsing the channel-group editor relies on.
+//
+// Without it the editor's model list is filtered by the AllowedModels list it
+// exists to edit, so a model that is not yet allowed can never be added — the
+// control for fixing the restriction is gated on the restriction.
+func TestQueryFlagEnabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	enabled := map[string]bool{
+		"?ignore_group_allowed_models=1":    true,
+		"?ignore_group_allowed_models=true": true,
+		"?ignore_group_allowed_models=yes":  true,
+		"?ignore_group_allowed_models=on":   true,
+		"?ignore-group-allowed-models=1":    true,
+		"?ignore_group_allowed_models=0":    false,
+		"?ignore_group_allowed_models=":     false,
+		"":                                  false,
+	}
+
+	for query, want := range enabled {
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = httptest.NewRequest("GET", "/models"+query, nil)
+		got := queryFlagEnabled(ctx, "ignore_group_allowed_models", "ignore-group-allowed-models")
+		if got != want {
+			t.Errorf("query %q = %v, want %v", query, got, want)
+		}
+	}
+}
+
+// TestUnrelatedFlagsDoNotEnableIt guards the default: plaza and catalog omit the
+// flag and must keep AllowedModels enforcement.
+func TestUnrelatedFlagsDoNotEnableIt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("GET", "/models?allowed_channel_groups=default", nil)
+
+	if queryFlagEnabled(ctx, "ignore_group_allowed_models", "ignore-group-allowed-models") {
+		t.Error("enforcement must stay on unless the editor explicitly asks for it")
+	}
+}

--- a/internal/api/server_models_endpoint.go
+++ b/internal/api/server_models_endpoint.go
@@ -15,6 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers/openai"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 // unifiedModelsHandler creates a unified handler for the /v1/models endpoint
@@ -72,7 +73,14 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 			portalVisibleModelIDs = modelcatalog.NewForTenant(tenantID, s.cfg, s.handlers.AuthManager).
 				PortalVisibleModelIDs(allowedChannelsRaw, allowedChannelGroupsRaw)
 		}
-		scopedRoutingRestricted := s.hasScopedRoutingModelRestrictionForTenant(tenantID, routeGroup, allowedChannelGroups)
+		// The channel-group editor lists models so an operator can tick them into
+		// AllowedModels. Filtering that list by AllowedModels makes a model that is
+		// not yet allowed impossible to add — the list to edit it is gated on the
+		// very setting being edited. Only the editor sets this flag; plaza and
+		// catalog keep enforcement.
+		ignoreGroupAllowedModels := queryFlagEnabled(c, "ignore_group_allowed_models", "ignore-group-allowed-models")
+		scopedRoutingRestricted := !ignoreGroupAllowedModels &&
+			s.hasScopedRoutingModelRestrictionForTenant(tenantID, routeGroup, allowedChannelGroups)
 		needsScopeFilter := tenantScoped || allowedModels != nil || allowedChannels != nil || allowedChannelGroups != nil || routeGroup != "" || scopedRoutingRestricted
 
 		recorder := &responseRecorder{
@@ -114,7 +122,10 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 						}
 					}
 					if tenantScoped || allowedChannels != nil || allowedChannelGroups != nil || routeGroup != "" {
-						if s.handlers == nil || s.handlers.AuthManager == nil || !s.handlers.AuthManager.CanServeModelWithScopesForTenant(tenantID, id, allowedChannels, allowedChannelGroups, routeGroup) {
+						if s.handlers == nil || s.handlers.AuthManager == nil || !s.handlers.AuthManager.CanServeModelWithScopesForTenantOpts(
+							tenantID, id, allowedChannels, allowedChannelGroups, routeGroup,
+							coreauth.ServeModelScopeOptions{IgnoreGroupAllowedModels: ignoreGroupAllowedModels},
+						) {
 							continue
 						}
 					}
@@ -345,4 +356,18 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 
 func (r *responseRecorder) WriteHeader(code int) {
 	r.statusCode = code
+}
+
+// queryFlagEnabled reads a boolean query flag under either naming convention.
+func queryFlagEnabled(c *gin.Context, primary, fallback string) bool {
+	raw := strings.TrimSpace(c.Query(primary))
+	if raw == "" && fallback != "" {
+		raw = strings.TrimSpace(c.Query(fallback))
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## 死锁

编辑「允许模型」的那个勾选列表,**自己也被「允许模型」过滤了**。所以还没在白名单里的模型,你永远勾不进去——唯一能解除限制的控件,被它要解除的限制挡住了。

在配了限制性 `default` 组的部署上,表现就是:生图报「模型不在允许列表」,而你去加白名单时列表里没有这个模型。

## 根因

前端**早就**传了 `ignore_group_allowed_models=1`,auth 层也**早就**有 `ServeModelScopeOptions.IgnoreGroupAllowedModels` 就是为这个场景准备的——但 `/models` 列表接口**从来没读过这个参数**,只有 availability 接口读了。

现在读了并透传下去。其他地方的强制过滤不变:模型广场和模型目录不传这个参数,照常过滤。

## 定位过程(记录一下,因为我前面绕了很久)

关键证据是跨租户对比:两个租户用**同一个 codex 账号文件**,

| 租户 | `default` 组白名单 | `gpt-image-2` |
|---|---|---|
| `9e003dfb` | 空(放行全部) | ✅ 可见,44 个模型 |
| `11f9ab9c` | 9 项 | ❌ 不可见,11 个模型 |

同一份注册表、同一个账号,唯一差异是白名单——**注册层从来不是病因**。我之前两个 PR(#829/#830)打在了错误的层上,#830 是道无害的防御但没解决问题。

## 验证

- 本地完整 `./scripts/ci-pr.sh`:通过(`exit=0`)
- 新增测试覆盖参数解析的各种写法,以及"不传参数时强制过滤保持开启"

🤖 Generated with [Claude Code](https://claude.com/claude-code)