### PR TITLE
feat(models): log which branch registered each credential's models

### DIFF
--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -210,6 +210,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = applyExcludedModels(models, excluded)
 	default:
 		if s.registerOpenAICompatModels(a, provider, compatProviderKey, compatDisplayName, compatDetected) {
+			logModelRegistration(a, provider, authKind, "openai-compat", nil)
 			return
 		}
 	}
@@ -222,6 +223,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		if key == "" {
 			key = strings.ToLower(strings.TrimSpace(a.Provider))
 		}
+		logModelRegistration(a, provider, authKind, "catalog", models)
 		GlobalModelRegistry().RegisterClient(a.ID, key, applyModelPrefixes(models, a.Prefix, s.cfg != nil && s.cfg.ForceModelPrefix))
 		if provider == "antigravity" {
 			s.backfillAntigravityModels(a, models)
@@ -229,6 +231,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		return
 	}
 
+	logModelRegistration(a, provider, authKind, "none", nil)
 	GlobalModelRegistry().UnregisterClient(a.ID)
 }
 

--- a/sdk/cliproxy/service_model_registration_log.go
+++ b/sdk/cliproxy/service_model_registration_log.go
@@ -1,0 +1,34 @@
+package cliproxy
+
+import (
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// logModelRegistration records what each credential ended up serving.
+//
+// Which branch a credential takes, and how many models survive the exclusion and
+// alias filters, is otherwise invisible: the panel shows a merged view and the
+// registry has no read-only surface. Diagnosing "this account cannot serve model
+// X" then means guessing at the branch, which has repeatedly been the slow part of
+// real incidents.
+//
+// One line per credential at startup and on credential change is cheap, and names
+// the branch so the next investigation starts from fact rather than inference.
+func logModelRegistration(auth *coreauth.Auth, provider, authKind, branch string, models []*ModelInfo) {
+	if auth == nil {
+		return
+	}
+	ids := make([]string, 0, len(models))
+	for _, model := range models {
+		if model != nil && strings.TrimSpace(model.ID) != "" {
+			ids = append(ids, model.ID)
+		}
+	}
+	log.Infof(
+		"model registration: auth=%s provider=%q kind=%q branch=%s models=%d [%s]",
+		auth.ID, provider, authKind, branch, len(ids), strings.Join(ids, " "),
+	)
+}


### PR DESCRIPTION
## 目的

排查「某账号为什么服务不了某模型」时,注册走了哪个分支、过滤后剩多少模型,目前**完全不可观测**——面板显示的是合并后的视图,注册表没有只读接口。最近几轮排查最耗时间的部分都卡在这里:同一个账号文件在两个租户下产出不同的模型集,而原因看不见。

现在每个凭据在启动和变更时输出一行:分支名 + 模型数 + 模型 ID 列表。

## 验证

本地完整 `./scripts/ci-pr.sh` 通过(`exit=0`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)