### PR TITLE
fix(models): forward the editor's ignore flag to portal visibility too

### DIFF
--- a/internal/api/server_models_endpoint.go
+++ b/internal/api/server_models_endpoint.go
@@ -68,17 +68,18 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 
 		tenantID := requestTenantID(c)
 		tenantScoped := tenantID != identity.SystemTenantID
-		var portalVisibleModelIDs map[string]struct{}
-		if tenantScoped && s.handlers != nil {
-			portalVisibleModelIDs = modelcatalog.NewForTenant(tenantID, s.cfg, s.handlers.AuthManager).
-				PortalVisibleModelIDs(allowedChannelsRaw, allowedChannelGroupsRaw)
-		}
 		// The channel-group editor lists models so an operator can tick them into
 		// AllowedModels. Filtering that list by AllowedModels makes a model that is
 		// not yet allowed impossible to add — the list to edit it is gated on the
 		// very setting being edited. Only the editor sets this flag; plaza and
 		// catalog keep enforcement.
 		ignoreGroupAllowedModels := queryFlagEnabled(c, "ignore_group_allowed_models", "ignore-group-allowed-models")
+		var portalVisibleModelIDs map[string]struct{}
+		if tenantScoped && s.handlers != nil {
+			portalVisibleModelIDs = modelcatalog.NewForTenant(tenantID, s.cfg, s.handlers.AuthManager).
+				PortalVisibleModelIDs(allowedChannelsRaw, allowedChannelGroupsRaw,
+					modelcatalog.AvailabilityFilterOptions{IgnoreGroupAllowedModels: ignoreGroupAllowedModels})
+		}
 		scopedRoutingRestricted := !ignoreGroupAllowedModels &&
 			s.hasScopedRoutingModelRestrictionForTenant(tenantID, routeGroup, allowedChannelGroups)
 		needsScopeFilter := tenantScoped || allowedModels != nil || allowedChannels != nil || allowedChannelGroups != nil || routeGroup != "" || scopedRoutingRestricted

--- a/internal/management/modelcatalog/portal_visibility.go
+++ b/internal/management/modelcatalog/portal_visibility.go
@@ -10,8 +10,12 @@ const portalRootModelsPath = "/v1/models"
 // PortalVisibleModelIDs returns the model IDs shared by configured availability
 // and the root OpenAI-compatible GET /v1/models path. The management model
 // plaza derives its tenant-visible catalog from these same two sources.
-func (s *Service) PortalVisibleModelIDs(allowedChannelsRaw, allowedGroupsRaw string) map[string]struct{} {
-	configuredIDs := configuredAvailabilityModelIDs(s.ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw))
+//
+// opts is forwarded to the configured-availability pass so the channel-group
+// editor can see models that are not yet on a group's allow-list — otherwise the
+// list used to add a model is itself filtered by the setting being edited.
+func (s *Service) PortalVisibleModelIDs(allowedChannelsRaw, allowedGroupsRaw string, opts ...AvailabilityFilterOptions) map[string]struct{} {
+	configuredIDs := configuredAvailabilityModelIDs(s.ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw, opts...))
 	rootPathIDs := rootModelsPathIDs(s.PathAvailability())
 	visible := make(map[string]struct{})
 	for id := range configuredIDs {


### PR DESCRIPTION
## 承接 #831

#831 把 `ignore_group_allowed_models` 传给了凭据作用域检查,但**漏了先执行的 portal-visibility 那一步** —— 模型在到达那个检查之前就已经被剔除了。所以编辑器的列表依然被它要编辑的白名单过滤。

## 观测结果(#832 的日志)

服务端日志证实**注册层从来不是病因**:

```
auth=11f9ab9c.../codex-tyktgyk@gmail.com-pro.json provider="codex" kind="oauth"
branch=catalog models=21 [gpt-image-2 gpt-5 gpt-5-codex ...]
```

该租户的 codex 凭据注册了 21 个模型,**含 `gpt-image-2`**。之前几轮我在注册层的猜测和改动方向都是错的,全部失败都发生在下游过滤。

## 验证

本地完整 `./scripts/ci-pr.sh` 通过(`exit=0`)。合并部署后我会直接在线上验证 `gpt-image-2` 是否出现,不再靠推断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)