### PR TITLE
fix(models): honour the editor's ignore flag in path availability

### DIFF
--- a/internal/management/modelcatalog/availability_routing_filter.go
+++ b/internal/management/modelcatalog/availability_routing_filter.go
@@ -9,6 +9,15 @@ import (
 // filterModelsByRoutingAllowedModels drops models outside the effective channel
 // group's allowed-models list. Used after live-discovery merge: discovery models
 // are not registry-backed, so CanServe cannot enforce AllowedModels for them.
+// filterModelsByRoutingAllowedModelsOpts skips the filter entirely when the caller
+// is the channel-group editor, which must list models it is meant to add.
+func (s *Service) filterModelsByRoutingAllowedModelsOpts(opts AvailabilityFilterOptions, models []map[string]any, allowedGroupsRaw string) []map[string]any {
+	if opts.IgnoreGroupAllowedModels {
+		return models
+	}
+	return s.filterModelsByRoutingAllowedModels(models, allowedGroupsRaw)
+}
+
 func (s *Service) filterModelsByRoutingAllowedModels(models []map[string]any, allowedGroupsRaw string) []map[string]any {
 	allowed := s.routingAllowedModels(allowedGroupsRaw)
 	if allowed == nil {

--- a/internal/management/modelcatalog/path_availability.go
+++ b/internal/management/modelcatalog/path_availability.go
@@ -17,7 +17,16 @@ import (
 //
 // Claude/Codex live discovery is merged into the root OpenAI path so the model
 // catalog "path-only" enrichment matches the auth-file models panel.
-func (s *Service) PathAvailability() map[string]any {
+// PathAvailability lists per-model route capabilities.
+//
+// opts is honoured so the channel-group editor can see models that are not yet on
+// a group's allow-list. Without it the editor's list is filtered by the very
+// setting it exists to edit, and a model can never be added.
+func (s *Service) PathAvailability(opts ...AvailabilityFilterOptions) map[string]any {
+	var filterOpts AvailabilityFilterOptions
+	if len(opts) > 0 {
+		filterOpts = opts[0]
+	}
 	modelRegistry := registry.GetGlobalRegistry()
 	items := make(map[string]*modelPathAvailabilityResponse)
 
@@ -39,12 +48,12 @@ func (s *Service) PathAvailability() map[string]any {
 	// Live discovery is not registry-backed, so CanServe cannot enforce
 	// channel-group AllowedModels for those rows. Filter after merge so plaza
 	// and catalog path enrichment match configured-availability.
-	openaiModels = s.filterModelsByRoutingAllowedModels(
+	openaiModels = s.filterModelsByRoutingAllowedModelsOpts(filterOpts,
 		appendSharedDiscoveryModels(openaiModels, discoveryByProvider),
 		"",
 	)
 	appendModelPaths(items, openaiModels, "/", rootOpenAICapabilities)
-	appendModelPaths(items, s.filterModelsByRoutingAllowedModels(
+	appendModelPaths(items, s.filterModelsByRoutingAllowedModelsOpts(filterOpts,
 		s.modelRootRouteScopedModels(modelRegistry.GetAvailableModels("gemini"), routingConfig),
 		"",
 	), "/", rootGeminiCapabilities)
@@ -69,11 +78,11 @@ func (s *Service) PathAvailability() map[string]any {
 			ReadOnly:     false,
 			Capabilities: capabilities,
 		})
-		appendModelPaths(items, s.filterModelsByRoutingAllowedModels(
+		appendModelPaths(items, s.filterModelsByRoutingAllowedModelsOpts(filterOpts,
 			s.modelPathRouteScopedModels(modelRegistry.GetAvailableModels("openai"), route.Group),
 			route.Group,
 		), route.Path, openAIV1Capabilities(route.Path))
-		appendModelPaths(items, s.filterModelsByRoutingAllowedModels(
+		appendModelPaths(items, s.filterModelsByRoutingAllowedModelsOpts(filterOpts,
 			s.modelPathRouteScopedModels(modelRegistry.GetAvailableModels("gemini"), route.Group),
 			route.Group,
 		), route.Path, geminiV1BetaCapabilities(route.Path))

--- a/internal/management/modelcatalog/portal_visibility.go
+++ b/internal/management/modelcatalog/portal_visibility.go
@@ -16,7 +16,7 @@ const portalRootModelsPath = "/v1/models"
 // list used to add a model is itself filtered by the setting being edited.
 func (s *Service) PortalVisibleModelIDs(allowedChannelsRaw, allowedGroupsRaw string, opts ...AvailabilityFilterOptions) map[string]struct{} {
 	configuredIDs := configuredAvailabilityModelIDs(s.ConfiguredAvailability(allowedChannelsRaw, allowedGroupsRaw, opts...))
-	rootPathIDs := rootModelsPathIDs(s.PathAvailability())
+	rootPathIDs := rootModelsPathIDs(s.PathAvailability(opts...))
 	visible := make(map[string]struct{})
 	for id := range configuredIDs {
 		if _, ok := rootPathIDs[id]; ok {


### PR DESCRIPTION
承接 #833。`PortalVisibleModelIDs` 是两个集合的交集,#833 只把 flag 传给了第一个,第二个 `PathAvailability()` 又按白名单筛了一遍,交集把模型再次干掉。现在两边都传。

其他调用方不变,强制过滤保持。

本地完整 `./scripts/ci-pr.sh` 除一条**既有失败**外全绿:`TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal` 在干净 `dev` 上同样失败(日期相关,与本改动无关)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)