### PR TITLE
fix(images): route public image models by provider and reject image models on chat

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -888,6 +888,13 @@ func (h *BaseAPIHandler) getRequestDetails(ctx context.Context, modelName string
 	baseModel := strings.TrimSpace(parsed.ModelName)
 	routeCtx := routeContextFromExecutionContext(ctx)
 	requestedPrefix, unprefixedModel := splitRequestedModelPrefix(baseModel)
+	// Image models must use image endpoints instead of reaching text executors.
+	if registry.IsImageGenerationModel(unprefixedModel) {
+		return nil, "", &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("model %q generates images; use /v1/images/generations or /v1/images/edits instead", modelName),
+		}
+	}
 	if routeCtx != nil && routeCtx.Group != "" && requestedPrefix != "" && requestedPrefix != routeCtx.Group && !internalrouting.IsCcSwitchMappedTargetModel(routeCtx, baseModel) {
 		return nil, "", &interfaces.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
@@ -905,11 +912,8 @@ func (h *BaseAPIHandler) getRequestDetails(ctx context.Context, modelName string
 	}
 
 	providers = scopedProvidersForModel(lookupModel, scopedGroups)
-	// Fallback: if baseModel has no provider but differs from resolvedModelName,
-	// try using the full model name. This handles edge cases where custom models
-	// may be registered with their full suffixed name (e.g., "my-model(8192)").
-	// Evaluated in Story 11.8: This fallback is intentionally preserved to support
-	// custom model registrations that include thinking suffixes.
+	// Preserve support for custom model registrations that include thinking
+	// suffixes, evaluated in Story 11.8.
 	if len(providers) == 0 && baseModel != resolvedModelName {
 		providers = scopedProvidersForModel(resolvedModelName, scopedGroups)
 	}
@@ -918,18 +922,14 @@ func (h *BaseAPIHandler) getRequestDetails(ctx context.Context, modelName string
 		return nil, "", &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("unknown provider for model %s", modelName)}
 	}
 
-	// Reconstruct the returned model name from parsed result to ensure trailing
-	// [...] context window markers (e.g., "[1M]", "[128K]") are stripped, even
-	// when they appear before a thinking suffix (e.g., "model[1M](8192)").
-	// Round bracket thinking suffixes are preserved for existing thinking config.
+	// Strip context-window markers while preserving round-bracket thinking
+	// suffixes for existing thinking config.
 	if parsed.HasSuffix {
 		resolvedModelName = parsed.ModelName + "(" + parsed.RawSuffix + ")"
 	} else {
 		resolvedModelName = parsed.ModelName
 	}
 
-	// The thinking suffix is preserved in the model name itself, so no
-	// metadata-based configuration passing is needed.
 	return providers, resolvedModelName, nil
 }
 

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -50,6 +50,10 @@ func (h *OpenAIAPIHandler) HandlerType() string {
 	return OpenAI
 }
 
+func openAIImageGenerationProvider(modelID string) string {
+	return registry.ImageGenerationProvider(modelID)
+}
+
 // Models returns the OpenAI-compatible model metadata supported by this handler.
 func (h *OpenAIAPIHandler) Models() []map[string]any {
 	// Get dynamic models from the global registry

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -61,6 +61,11 @@ func (h *OpenAIImagesAPIHandler) executeImages(c *gin.Context, rawJSON []byte, a
 			rawJSON = updated
 		}
 	}
+	provider := openAIImageGenerationProvider(modelName)
+	if provider == "" {
+		writeOpenAIImagesError(c, http.StatusBadRequest, "invalid_request_error", fmt.Sprintf("model %q is not a supported image generation model", modelName))
+		return
+	}
 	imageCount, countErr := openAIImageRequestCount(rawJSON)
 	if countErr != nil {
 		writeOpenAIImagesError(c, http.StatusBadRequest, "invalid_request_error", countErr.Error())
@@ -89,7 +94,7 @@ func (h *OpenAIImagesAPIHandler) executeImages(c *gin.Context, rawJSON []byte, a
 				return
 			}
 		}
-		resp, err := h.AuthManager.Execute(cliCtx, []string{"codex"}, coreexecutor.Request{
+		resp, err := h.AuthManager.Execute(cliCtx, []string{provider}, coreexecutor.Request{
 			Model:   modelName,
 			Payload: execPayload,
 			Format:  sdktranslator.FromString("openai"),

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -31,6 +31,13 @@ type imageCaptureExecutor struct {
 
 func (e *imageCaptureExecutor) Identifier() string { return "codex" }
 
+type imageProviderCaptureExecutor struct {
+	imageCaptureExecutor
+	identifier string
+}
+
+func (e *imageProviderCaptureExecutor) Identifier() string { return e.identifier }
+
 func (e *imageCaptureExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
 	e.calls++
 	e.alt = opts.Alt
@@ -63,10 +70,15 @@ func (e *imageCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *htt
 
 func registerImageTestCodexAuth(t *testing.T, manager *coreauth.Manager, id string, models ...string) {
 	t.Helper()
+	registerImageTestProviderAuth(t, manager, id, "codex", "Team Codex", models...)
+}
+
+func registerImageTestProviderAuth(t *testing.T, manager *coreauth.Manager, id, provider, label string, models ...string) {
+	t.Helper()
 	if _, err := manager.Register(context.Background(), &coreauth.Auth{
 		ID:       id,
-		Provider: "codex",
-		Label:    "Team Codex",
+		Provider: provider,
+		Label:    label,
 		Status:   coreauth.StatusActive,
 		Metadata: map[string]any{"access_token": "token", "email": "team@example.com"},
 	}); err != nil {
@@ -79,10 +91,61 @@ func registerImageTestCodexAuth(t *testing.T, manager *coreauth.Manager, id stri
 			modelInfos = append(modelInfos, &registry.ModelInfo{ID: model})
 		}
 	}
-	registry.GetGlobalRegistry().RegisterClient(id, "codex", modelInfos)
+	registry.GetGlobalRegistry().RegisterClient(id, provider, modelInfos)
 	t.Cleanup(func() {
 		registry.GetGlobalRegistry().UnregisterClient(id)
 	})
+}
+
+func TestOpenAIImagesGenerationsRoutesByImageProvider(t *testing.T) {
+	tests := []struct {
+		model        string
+		wantProvider string
+	}{
+		{model: "grok-imagine-image", wantProvider: "xai"},
+		{model: "grok-imagine-image-quality", wantProvider: "xai"},
+		{model: "gpt-image-2", wantProvider: "codex"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+
+			codexExecutor := &imageProviderCaptureExecutor{identifier: "codex"}
+			xaiExecutor := &imageProviderCaptureExecutor{identifier: "xai"}
+			manager := coreauth.NewManager(nil, nil, nil)
+			manager.RegisterExecutor(codexExecutor)
+			manager.RegisterExecutor(xaiExecutor)
+			registerImageTestProviderAuth(t, manager, "codex-auth-"+tt.model, "codex", "Team Codex", tt.model)
+			registerImageTestProviderAuth(t, manager, "xai-auth-"+tt.model, "xai", "Team XAI", tt.model)
+
+			base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+			h := NewOpenAIImagesAPIHandler(base)
+			router := gin.New()
+			router.POST("/v1/images/generations", h.Generations)
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"`+tt.model+`","prompt":"draw a fox"}`))
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+			}
+			calls := map[string]int{
+				"codex": codexExecutor.calls,
+				"xai":   xaiExecutor.calls,
+			}
+			if calls[tt.wantProvider] != 1 {
+				t.Fatalf("%s executor calls = %d, want 1; all calls=%v", tt.wantProvider, calls[tt.wantProvider], calls)
+			}
+			for provider, count := range calls {
+				if provider != tt.wantProvider && count != 0 {
+					t.Fatalf("%s executor calls = %d, want 0; all calls=%v", provider, count, calls)
+				}
+			}
+		})
+	}
 }
 
 func TestOpenAIImagesGenerationsExecutesCodexImageAlt(t *testing.T) {
@@ -187,6 +250,80 @@ func TestOpenAIImagesGenerationsRequiresImageModelSupport(t *testing.T) {
 	}
 	if !strings.Contains(resp.Body.String(), "auth_not_found") {
 		t.Fatalf("body = %s, want auth_not_found", resp.Body.String())
+	}
+}
+
+func TestOpenAIImagesGenerationsRejectsNonImageModelBeforeAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &imageProviderCaptureExecutor{identifier: "xai"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	registerImageTestProviderAuth(t, manager, "xai-auth-chat-model", "xai", "Team XAI", "grok-4.5")
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIImagesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/images/generations", h.Generations)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"grok-4.5","prompt":"draw a fox"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusBadRequest, resp.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("executor calls = %d, want 0", executor.calls)
+	}
+	if !strings.Contains(resp.Body.String(), `"type":"invalid_request_error"`) || !strings.Contains(resp.Body.String(), "grok-4.5") {
+		t.Fatalf("body = %s, want local invalid_request_error naming the model", resp.Body.String())
+	}
+}
+
+func TestOpenAIChatCompletionsRejectsImageModelsBeforeAuth(t *testing.T) {
+	tests := []struct {
+		model      string
+		wantStatus int
+		wantCalls  int
+	}{
+		{model: "grok-imagine-image", wantStatus: http.StatusBadRequest, wantCalls: 0},
+		{model: "grok-4.5", wantStatus: http.StatusOK, wantCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+
+			executor := &imageProviderCaptureExecutor{identifier: "xai"}
+			manager := coreauth.NewManager(nil, nil, nil)
+			manager.RegisterExecutor(executor)
+			registerImageTestProviderAuth(t, manager, "xai-auth-chat-"+tt.model, "xai", "Team XAI", tt.model)
+
+			base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+			h := NewOpenAIAPIHandler(base)
+			router := gin.New()
+			router.POST("/v1/chat/completions", h.ChatCompletions)
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"`+tt.model+`","messages":[{"role":"user","content":"draw a fox"}]}`))
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d, body=%s", resp.Code, tt.wantStatus, resp.Body.String())
+			}
+			if executor.calls != tt.wantCalls {
+				t.Fatalf("executor calls = %d, want %d", executor.calls, tt.wantCalls)
+			}
+			if tt.wantCalls == 0 {
+				body := resp.Body.String()
+				if !strings.Contains(body, `"type":"invalid_request_error"`) || !strings.Contains(body, "/v1/images/generations") {
+					t.Fatalf("body = %s, want local image-endpoint guidance", body)
+				}
+			}
+		})
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_gpt_image_standard_test.go
+++ b/sdk/api/handlers/openai/openai_responses_gpt_image_standard_test.go
@@ -55,7 +55,7 @@ func (e *responsesCaptureExecutor) HttpRequest(_ context.Context, _ *coreauth.Au
 	return nil, errors.New("not implemented")
 }
 
-func TestOpenAIResponsesGPTImage2UsesStandardNonStreamingResponsesFlow(t *testing.T) {
+func TestOpenAIResponsesRejectsGPTImage2BeforeNonStreamingExecution(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	executor := &responsesCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -80,21 +80,18 @@ func TestOpenAIResponsesGPTImage2UsesStandardNonStreamingResponsesFlow(t *testin
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusBadRequest, resp.Body.String())
 	}
-	if executor.calls != 1 {
-		t.Fatalf("executor calls = %d, want 1", executor.calls)
+	if executor.calls != 0 {
+		t.Fatalf("executor calls = %d, want 0", executor.calls)
 	}
-	if executor.alt == openAIImageGenerationAlt {
-		t.Fatalf("alt = %q, want standard responses flow instead of image alt", executor.alt)
-	}
-	if strings.TrimSpace(resp.Body.String()) != `{"ok":true}` {
-		t.Fatalf("body = %s, want passthrough responses payload", resp.Body.String())
+	if body := resp.Body.String(); !strings.Contains(body, `"type":"invalid_request_error"`) || !strings.Contains(body, "/v1/images/generations") {
+		t.Fatalf("body = %s, want local image-endpoint guidance", body)
 	}
 }
 
-func TestOpenAIResponsesGPTImage2UsesStandardStreamingResponsesFlow(t *testing.T) {
+func TestOpenAIResponsesRejectsGPTImage2BeforeStreamingExecution(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	executor := &responsesCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -119,16 +116,13 @@ func TestOpenAIResponsesGPTImage2UsesStandardStreamingResponsesFlow(t *testing.T
 
 	h.Responses(c)
 
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body=%s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
 	}
-	if executor.streamCalls != 1 {
-		t.Fatalf("stream calls = %d, want 1", executor.streamCalls)
+	if executor.streamCalls != 0 {
+		t.Fatalf("stream calls = %d, want 0", executor.streamCalls)
 	}
-	if executor.streamAlt == openAIImageGenerationAlt {
-		t.Fatalf("stream alt = %q, want standard responses streaming flow", executor.streamAlt)
-	}
-	if !strings.Contains(recorder.Body.String(), `"type":"response.completed"`) {
-		t.Fatalf("body = %s, want passthrough responses SSE payload", recorder.Body.String())
+	if body := recorder.Body.String(); !strings.Contains(body, `"type":"invalid_request_error"`) || !strings.Contains(body, "/v1/images/generations") {
+		t.Fatalf("body = %s, want local image-endpoint guidance", body)
 	}
 }


### PR DESCRIPTION
## Summary
- Public `/v1/images/generations` and `/v1/images/edits` no longer pin the auth pool to `codex`; provider is derived from the request model via `registry.ImageGenerationProvider` (Grok Imagine → `xai`, `gpt-image-2` → `codex`).
- Text endpoints (`chat/completions`, completions, responses) reject image-generation models locally with a clear `invalid_request_error` instead of forwarding them upstream.
- Fixes live `auth_not_found` for `grok-imagine-image` / `grok-imagine-image-quality` on the public images API while leaving Codex image routing intact.

## Root cause
`OpenAIImagesAPIHandler.executeImages` always called `Execute(..., []string{"codex"}, ...)`. Management already used `ImageGenerationProvider(model)`; the public path did not, so Grok models never entered the xAI credential pool.

## Test plan
- [x] `go test ./sdk/api/handlers/openai/... ./internal/api/handlers/management/... -count=1` (376 pass)
- [x] `go test ./sdk/api/handlers/... -count=1` (95 pass)
- [x] `python3 scripts/check-backend-structure.py`
- [ ] GHA `build` required check
- [ ] After deploy: `POST /v1/images/generations` with `grok-imagine-image` succeeds; chat with image model returns local 400