### PR TITLE
fix: preserve image test usage tenant

### DIFF
--- a/internal/api/handlers/management/image_generation_test.go
+++ b/internal/api/handlers/management/image_generation_test.go
@@ -27,6 +27,7 @@ type managementImageExecutor struct {
 	payloads        []string
 	originalRequest string
 	metadata        map[string]any
+	authID          string
 	calls           int
 	err             error
 }
@@ -53,6 +54,9 @@ func (e *managementImageExecutor) Execute(ctx context.Context, auth *coreauth.Au
 	e.payloads = append(e.payloads, e.payload)
 	e.originalRequest = string(opts.OriginalRequest)
 	e.metadata = opts.Metadata
+	if auth != nil {
+		e.authID = auth.ID
+	}
 	if e.err != nil {
 		return coreexecutor.Response{}, e.err
 	}
@@ -81,8 +85,14 @@ func (e *managementImageExecutor) HttpRequest(context.Context, *coreauth.Auth, *
 
 func registerManagementImageAuth(t *testing.T, manager *coreauth.Manager, id string, models ...string) {
 	t.Helper()
+	registerManagementImageAuthForTenant(t, manager, identity.SystemTenantID, id, models...)
+}
+
+func registerManagementImageAuthForTenant(t *testing.T, manager *coreauth.Manager, tenantID, id string, models ...string) {
+	t.Helper()
 	if _, err := manager.Register(context.Background(), &coreauth.Auth{
 		ID:       id,
+		TenantID: tenantID,
 		Provider: "codex",
 		Status:   coreauth.StatusActive,
 		Metadata: map[string]any{"access_token": "token"},
@@ -346,6 +356,60 @@ func TestPostImageGenerationTestCreatesTaskAndPollsSucceededResult(t *testing.T)
 	}
 }
 
+func TestPostImageGenerationTestUsesEffectiveTenantAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const tenantID = "00000000-0000-0000-0000-00000000000a"
+	systemExecutor := &managementImageExecutor{}
+	tenantExecutor := &managementImageExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(systemExecutor)
+	manager.RegisterExecutorForTenant(tenantID, tenantExecutor)
+	registerManagementImageAuth(t, manager, "codex-auth-system", imageGenerationModel)
+	registerManagementImageAuthForTenant(t, manager, tenantID, "codex-auth-tenant-a", imageGenerationModel)
+
+	h := &Handler{authManager: manager}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set(managementPrincipalKey, identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}})
+	req := httptest.NewRequest(http.MethodPost, "/image-generation/test", strings.NewReader(`{
+		"model":"gpt-image-2",
+		"prompt":"safe tenant test prompt"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	h.PostImageGenerationTest(c)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	var created struct {
+		TaskID string `json:"task_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("Unmarshal create task response: %v", err)
+	}
+	waitForImageGenerationTaskForTenant(t, h, tenantID, created.TaskID, func(body []byte) bool {
+		var task struct {
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(body, &task); err != nil {
+			t.Fatalf("Unmarshal poll response: %v", err)
+		}
+		return task.Status == "succeeded"
+	})
+
+	if tenantExecutor.calls != 1 || tenantExecutor.authID != "codex-auth-tenant-a" {
+		t.Fatalf("tenant executor calls=%d auth=%q, want one call with tenant auth", tenantExecutor.calls, tenantExecutor.authID)
+	}
+	if systemExecutor.calls != 0 {
+		t.Fatalf("system executor calls = %d, want 0", systemExecutor.calls)
+	}
+	if got := tenantExecutor.metadata[coreexecutor.TenantMetadataKey]; got != tenantID {
+		t.Fatalf("tenant metadata = %v, want %q", got, tenantID)
+	}
+}
+
 func TestPostImageGenerationTestCreatesTaskAndPollsFailedError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -420,10 +484,16 @@ func TestPostImageGenerationTestCreatesTaskAndPollsFailedError(t *testing.T) {
 
 func waitForImageGenerationTask(t *testing.T, h *Handler, taskID string, done func([]byte) bool) {
 	t.Helper()
+	waitForImageGenerationTaskForTenant(t, h, identity.SystemTenantID, taskID, done)
+}
+
+func waitForImageGenerationTaskForTenant(t *testing.T, h *Handler, tenantID, taskID string, done func([]byte) bool) {
+	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		rec := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(rec)
+		c.Set(managementPrincipalKey, identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}})
 		c.Params = gin.Params{{Key: "task_id", Value: taskID}}
 		c.Request = httptest.NewRequest(http.MethodGet, "/image-generation/test/"+taskID, nil)
 

--- a/internal/management/imagegeneration/service.go
+++ b/internal/management/imagegeneration/service.go
@@ -108,6 +108,7 @@ func (s *Service) run(tenantID, taskID string, payload []byte, alt string) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
 	defer cancel()
+	ctx = context.WithValue(ctx, util.ContextKeyTrustedTenantID, tenantID)
 	ctx = context.WithValue(ctx, util.ContextKeyAPIKey, s.systemAPIKey)
 	ctx = context.WithValue(ctx, util.ContextKeyImageGenerationPhaseHook, func(phase string) {
 		s.update(taskID, func(item *task) {

--- a/internal/management/imagegeneration/service_test.go
+++ b/internal/management/imagegeneration/service_test.go
@@ -5,7 +5,37 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
+
+func TestServiceBackgroundContextRetainsTrustedTenantAttribution(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tenantID     = "00000000-0000-0000-0000-00000000000a"
+		systemAPIKey = "POST /image-generation/test"
+	)
+	contextSeen := make(chan context.Context, 1)
+	svc := NewService(func(ctx context.Context, gotTenantID string, _ []byte, _ string) ([]byte, error) {
+		if gotTenantID != tenantID {
+			t.Errorf("tenantID = %q, want %q", gotTenantID, tenantID)
+		}
+		contextSeen <- ctx
+		return []byte(`{"data":[]}`), nil
+	}, systemAPIKey)
+
+	task := svc.Start(tenantID, []byte(`{"prompt":"hello"}`), "images/generations")
+	_ = waitTaskStatus(t, svc, tenantID, task.ID, "succeeded")
+
+	ctx := <-contextSeen
+	if got, _ := ctx.Value(util.ContextKeyTrustedTenantID).(string); got != tenantID {
+		t.Fatalf("trusted tenant in background context = %q, want %q", got, tenantID)
+	}
+	if got, _ := ctx.Value(util.ContextKeyAPIKey).(string); got != systemAPIKey {
+		t.Fatalf("api key label = %q, want %q", got, systemAPIKey)
+	}
+}
 
 func TestServiceStartAndGetLifecycle(t *testing.T) {
 	t.Parallel()

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	log "github.com/sirupsen/logrus"
@@ -29,6 +30,7 @@ type usageReporter struct {
 	authIndex           string
 	authSubjectID       string
 	apiKey              string
+	trustedTenantID     string
 	apiKeyID            string
 	apiKeyName          string
 	source              string
@@ -57,6 +59,7 @@ func newUsageReporter(ctx context.Context, provider, model, upstreamModel string
 		upstreamModel:      upstreamModel,
 		requestedAt:        time.Now(),
 		apiKey:             apiKey,
+		trustedTenantID:    strings.TrimSpace(contextStringValue(ctx, util.ContextKeyTrustedTenantID)),
 		source:             resolveUsageSource(auth, apiKey),
 		captureFullContent: internalusage.RequestLogBodyStorageEnabled(),
 	}
@@ -342,6 +345,7 @@ func (r *usageReporter) publishWithOutcome(ctx context.Context, detail coreusage
 			Source:              r.source,
 			ChannelName:         r.channelName,
 			APIKey:              r.apiKey,
+			TrustedTenantID:     r.trustedTenantID,
 			APIKeyID:            r.apiKeyID,
 			APIKeyName:          r.apiKeyName,
 			AuthID:              r.authID,
@@ -391,6 +395,7 @@ func (r *usageReporter) ensurePublished(ctx context.Context) {
 			Source:              r.source,
 			ChannelName:         r.channelName,
 			APIKey:              r.apiKey,
+			TrustedTenantID:     r.trustedTenantID,
 			APIKeyID:            r.apiKeyID,
 			APIKeyName:          r.apiKeyName,
 			AuthID:              r.authID,

--- a/internal/runtime/executor/usage_reporter_tenant_test.go
+++ b/internal/runtime/executor/usage_reporter_tenant_test.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+)
+
+type tenantUsageCapturePlugin struct {
+	records chan coreusage.Record
+}
+
+func (p *tenantUsageCapturePlugin) HandleUsage(_ context.Context, record coreusage.Record) {
+	select {
+	case p.records <- record:
+	default:
+	}
+}
+
+func TestUsageReporterPublishesTrustedTenantSeparatelyFromAPIKeyLabel(t *testing.T) {
+	const (
+		tenantID     = "00000000-0000-0000-0000-00000000000a"
+		systemAPIKey = "POST /image-generation/test"
+		model        = "image-generation-trusted-tenant-test"
+	)
+	plugin := &tenantUsageCapturePlugin{records: make(chan coreusage.Record, 8)}
+	coreusage.RegisterPlugin(plugin)
+
+	ctx := context.WithValue(context.Background(), util.ContextKeyTrustedTenantID, tenantID)
+	ctx = context.WithValue(ctx, util.ContextKeyAPIKey, systemAPIKey)
+	reporter := newUsageReporter(ctx, "codex", model, "", nil)
+	reporter.ensurePublished(ctx)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case record := <-plugin.records:
+			if record.Model != model {
+				continue
+			}
+			if record.TrustedTenantID != tenantID {
+				t.Fatalf("TrustedTenantID = %q, want %q", record.TrustedTenantID, tenantID)
+			}
+			if record.APIKey != systemAPIKey {
+				t.Fatalf("APIKey = %q, want display label %q", record.APIKey, systemAPIKey)
+			}
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for usage record")
+		}
+	}
+}

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -377,7 +377,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	inputContent := resolveDeferredUsageContent(record.InputContent, record.InputContentPath)
 	outputContent := resolveDeferredUsageContent(record.OutputContent, record.OutputContentPath)
 	detailContent := resolveDeferredUsageContent(record.DetailContent, record.DetailContentPath)
-	InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(statsKey, apiKeyID, record.AuthSubjectID, apiKeyName, modelName, record.UpstreamModel, record.VisionFallbackModel, record.Source, record.ChannelName,
+	InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(record.TrustedTenantID, statsKey, apiKeyID, record.AuthSubjectID, apiKeyName, modelName, record.UpstreamModel, record.VisionFallbackModel, record.Source, record.ChannelName,
 		record.AuthIndex, failed, timestamp, record.LatencyMs, record.FirstTokenMs, detail,
 		inputContent, outputContent, detailContent, record.Streaming)
 }

--- a/internal/usage/logger_plugin_tenant_test.go
+++ b/internal/usage/logger_plugin_tenant_test.go
@@ -1,0 +1,81 @@
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+)
+
+func TestLoggerPluginUsesTrustedTenantBeforeAPIKeyLookup(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	const (
+		businessTenantID = "00000000-0000-0000-0000-00000000000a"
+		apiKeyLabel      = "POST /image-generation/test"
+		businessModel    = "image-generation-business-tenant-test"
+		systemModel      = "image-generation-system-tenant-test"
+		realAPIKey       = "sk-real-tenant-fallback"
+		realAPIKeyModel  = "ordinary-api-key-tenant-test"
+		realTenantID     = "00000000-0000-0000-0000-00000000000b"
+	)
+	plugin := NewLoggerPlugin()
+	now := time.Now().UTC()
+
+	plugin.HandleUsage(context.Background(), coreusage.Record{
+		TrustedTenantID: businessTenantID,
+		APIKey:          apiKeyLabel,
+		Model:           businessModel,
+		RequestedAt:     now,
+		Detail:          coreusage.Detail{TotalTokens: 1},
+	})
+	assertRequestLogTenantAndAPIKey(t, businessModel, businessTenantID, apiKeyLabel)
+
+	var polluted int
+	if err := getDB().QueryRow(`SELECT COUNT(*) FROM request_logs WHERE tenant_id = ? AND model = ?`, systemTenantID, businessModel).Scan(&polluted); err != nil {
+		t.Fatalf("count system tenant pollution: %v", err)
+	}
+	if polluted != 0 {
+		t.Fatalf("business image test wrote %d system tenant rows, want 0", polluted)
+	}
+
+	plugin.HandleUsage(context.Background(), coreusage.Record{
+		TrustedTenantID: systemTenantID,
+		APIKey:          apiKeyLabel,
+		Model:           systemModel,
+		RequestedAt:     now.Add(time.Second),
+		Detail:          coreusage.Detail{TotalTokens: 1},
+	})
+	assertRequestLogTenantAndAPIKey(t, systemModel, systemTenantID, apiKeyLabel)
+
+	if err := UpsertAPIKeyForTenant(realTenantID, APIKeyRow{
+		ID:   "real-tenant-fallback-key",
+		Key:  realAPIKey,
+		Name: "Real tenant fallback",
+	}); err != nil {
+		t.Fatalf("UpsertAPIKeyForTenant: %v", err)
+	}
+	plugin.HandleUsage(context.Background(), coreusage.Record{
+		APIKey:      realAPIKey,
+		Model:       realAPIKeyModel,
+		RequestedAt: now.Add(2 * time.Second),
+		Detail:      coreusage.Detail{TotalTokens: 1},
+	})
+	assertRequestLogTenantAndAPIKey(t, realAPIKeyModel, realTenantID, realAPIKey)
+}
+
+func assertRequestLogTenantAndAPIKey(t *testing.T, model, wantTenantID, wantAPIKey string) {
+	t.Helper()
+	var tenantID, apiKey string
+	if err := getDB().QueryRow(`SELECT tenant_id, api_key FROM request_logs WHERE model = ?`, model).Scan(&tenantID, &apiKey); err != nil {
+		t.Fatalf("query request log for %s: %v", model, err)
+	}
+	if tenantID != wantTenantID {
+		t.Fatalf("tenant_id for %s = %q, want %q", model, tenantID, wantTenantID)
+	}
+	if apiKey != wantAPIKey {
+		t.Fatalf("api_key for %s = %q, want %q", model, apiKey, wantAPIKey)
+	}
+}

--- a/internal/usage/tenant_scope.go
+++ b/internal/usage/tenant_scope.go
@@ -12,6 +12,13 @@ func normalizeTenantID(tenantID string) string {
 	return tenantID
 }
 
+func resolveRequestLogTenantID(trustedTenantID, apiKey string) string {
+	if tenantID := strings.TrimSpace(trustedTenantID); tenantID != "" {
+		return normalizeTenantID(tenantID)
+	}
+	return normalizeTenantID(ResolveAPIKeyTenant(apiKey))
+}
+
 // isSystemTenant reports whether tenantID resolves to the shared system catalog tenant.
 // OpenRouter pricing/model metadata is written there and inherited by business tenants on read.
 func isSystemTenant(tenantID string) bool {

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -863,48 +863,48 @@ func CloseDB() {
 func InsertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent string) {
-	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "", isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "", isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetails(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentity(apiKey, apiKeyID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, apiKeyID, "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubject(apiKey, apiKeyID, authSubjectID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubjectUpstream(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubjectUpstreamVision(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 // InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming persists an
 // explicit streaming classification even when request body storage is disabled.
-func InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
+func InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string, streaming bool) {
-	insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, streaming)
+	insertLogIdentity(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, streaming)
 }
 
-func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
+func insertLogIdentity(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string, streaming bool) {
 	db := getDB()
@@ -912,9 +912,9 @@ func insertLogIdentity(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstr
 		return
 	}
 
-	tenantID := normalizeTenantID(ResolveAPIKeyTenant(apiKey))
+	tenantID := resolveRequestLogTenantID(trustedTenantID, apiKey)
 
-	// Calculate cost from the authenticated API key's tenant-scoped pricing catalog.
+	// Calculate cost from the trusted execution tenant or API key tenant catalog.
 	cost := CalculateCostV2ForTenant(tenantID, model, tokens)
 
 	apiKeyID = strings.TrimSpace(apiKeyID)

--- a/internal/util/context_keys.go
+++ b/internal/util/context_keys.go
@@ -11,6 +11,7 @@ const (
 	ContextKeyGin                      = sdkrequestctx.ContextKeyGin
 	ContextKeyRoundTripper             = sdkrequestctx.ContextKeyRoundTripper
 	ContextKeyAPIKey                   = sdkrequestctx.ContextKeyAPIKey
+	ContextKeyTrustedTenantID          = sdkrequestctx.ContextKeyTrustedTenantID
 	ContextKeyImageGenerationPhaseHook = sdkrequestctx.ContextKeyImageGenerationPhaseHook
 )
 

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -33,6 +33,10 @@ type Record struct {
 	Streaming           bool
 	Detail              Detail
 
+	// TrustedTenantID is set only by authenticated internal execution paths.
+	// When empty, persistence resolves the tenant from the real API key.
+	TrustedTenantID string
+
 	// Optional: request/response content for log detail viewer.
 	// These are stored in SQLite when non-empty and can be retrieved via the
 	// /usage/logs/:id/content API. The persistence layer may compress and retain

--- a/sdk/requestctx/context_keys.go
+++ b/sdk/requestctx/context_keys.go
@@ -20,6 +20,10 @@ const (
 	// paths that still need request-log attribution.
 	ContextKeyAPIKey ContextKey = "cliproxy.api_key"
 
+	// ContextKeyTrustedTenantID carries a tenant scope established at an
+	// authenticated execution boundary. It must not be populated from raw client input.
+	ContextKeyTrustedTenantID ContextKey = "cliproxy.trusted_tenant_id"
+
 	// ContextKeyImageGenerationPhaseHook carries an optional callback that
 	// receives backend image-generation phase updates.
 	ContextKeyImageGenerationPhaseHook ContextKey = "cliproxy.image_generation.phase_hook"


### PR DESCRIPTION
## Summary
- Management image-generation test tasks run on a background context that only carried the synthetic API key `POST /image-generation/test`.
- Usage logging resolved tenant from that key, failed to find it, and normalized to the system tenant, so business-tenant tests polluted system request logs/usage.
- Carry the authenticated execution tenant through the background task context and usage record; keep real API-key lookup for normal requests.

## Test plan
- [x] `go test ./internal/management/imagegeneration/... ./internal/api/handlers/management/ -count=1`
- [x] `go test ./internal/usage/... ./internal/runtime/executor/... -count=1`
- [x] `./scripts/ci-pr.sh`
- [ ] GHA `build` required check green
- [ ] After deploy: business tenant image test appears in that tenant's request logs, not system admin