### PR TITLE
fix: allow controlled chrome-extension CORS wildcard

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -62,11 +62,16 @@ tls:
 
 # Explicit browser origins allowed to call API routes cross-origin.
 # Leave empty to disable cross-origin browser access by default.
-# Chrome extension origins (`chrome-extension://<extension-id>`) are allowed by default.
+# Same-host browser origins are always allowed. Everything else must be listed.
+# Chrome extensions are NOT allowed by default; add either a precise ID or the
+# controlled pattern chrome-extension://* (also accepts chrome-extension:*) to
+# allow any installed extension. Prefer precise IDs in production.
 # Examples:
 # cors-allow-origins:
 #   - "https://admin.example.com"
 #   - "http://localhost:5173"
+#   - "chrome-extension://abcdefghijklmnop"
+#   - "chrome-extension://*"
 cors-allow-origins: []
 
 # Reverse proxies whose X-Forwarded-For / X-Real-IP headers may be trusted.

--- a/internal/api/server_http_middleware.go
+++ b/internal/api/server_http_middleware.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -84,11 +85,44 @@ func resolveAllowedCORSOrigin(r *http.Request, cfg *config.Config) string {
 		return ""
 	}
 	for _, candidate := range cfg.CORSAllowOrigins {
-		if strings.EqualFold(strings.TrimSpace(candidate), origin) {
+		trimmed := strings.TrimSpace(candidate)
+		if trimmed == "" {
+			continue
+		}
+		if strings.EqualFold(trimmed, origin) {
+			return origin
+		}
+		// Explicit chrome-extension pattern only; not a general origin glob.
+		if isChromeExtensionWildcard(trimmed) && isChromeExtensionOrigin(origin) {
 			return origin
 		}
 	}
 	return ""
+}
+
+// isChromeExtensionWildcard reports whether a configured allowlist entry is the
+// controlled "any chrome extension" pattern. Only these exact forms match.
+func isChromeExtensionWildcard(candidate string) bool {
+	switch strings.ToLower(strings.TrimSpace(candidate)) {
+	case "chrome-extension://*", "chrome-extension:*":
+		return true
+	default:
+		return false
+	}
+}
+
+// isChromeExtensionOrigin reports a real browser extension Origin
+// (chrome-extension://<non-empty-id>), not a config pattern string.
+func isChromeExtensionOrigin(origin string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(origin))
+	if err != nil || parsed == nil {
+		return false
+	}
+	if !strings.EqualFold(parsed.Scheme, "chrome-extension") {
+		return false
+	}
+	host := strings.TrimSpace(parsed.Host)
+	return host != "" && host != "*"
 }
 
 func versionHeaderMiddleware(configFilePath string) gin.HandlerFunc {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -931,6 +931,73 @@ func TestCORSMiddlewareAllowsConfiguredChromeExtensionOrigin(t *testing.T) {
 	}
 }
 
+func TestCORSMiddlewareAllowsChromeExtensionWildcard(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowlist []string
+		origin    string
+		wantCode  int
+		wantACAO  string
+	}{
+		{
+			name:      "chrome-extension://* allows real extension origin",
+			allowlist: []string{"chrome-extension://*"},
+			origin:    "chrome-extension://dnjfbdinlpcfefpheddgehgobcefxxxx",
+			wantCode:  http.StatusNoContent,
+			wantACAO:  "chrome-extension://dnjfbdinlpcfefpheddgehgobcefxxxx",
+		},
+		{
+			name:      "chrome-extension:* allows real extension origin",
+			allowlist: []string{"chrome-extension:*"},
+			origin:    "chrome-extension://abcdefghijklmnop",
+			wantCode:  http.StatusNoContent,
+			wantACAO:  "chrome-extension://abcdefghijklmnop",
+		},
+		{
+			name:      "wildcard does not allow https origins",
+			allowlist: []string{"chrome-extension://*"},
+			origin:    "https://evil.example",
+			wantCode:  http.StatusForbidden,
+			wantACAO:  "",
+		},
+		{
+			name:      "exact extension id still rejects other extensions",
+			allowlist: []string{"chrome-extension://abcdefghijklmnop"},
+			origin:    "chrome-extension://otheridotheridother",
+			wantCode:  http.StatusForbidden,
+			wantACAO:  "",
+		},
+		{
+			name:      "generic https://* is not a wildcard",
+			allowlist: []string{"https://*"},
+			origin:    "https://evil.example",
+			wantCode:  http.StatusForbidden,
+			wantACAO:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
+				cfg.CORSAllowOrigins = append([]string(nil), tt.allowlist...)
+			})
+
+			req := httptest.NewRequest(http.MethodOptions, "/v1/models", nil)
+			req.Header.Set("Origin", tt.origin)
+
+			rr := httptest.NewRecorder()
+			server.engine.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+			if got := rr.Header().Get("Access-Control-Allow-Origin"); got != tt.wantACAO {
+				t.Fatalf("Access-Control-Allow-Origin = %q, want %q", got, tt.wantACAO)
+			}
+		})
+	}
+}
+
 func TestCORSMiddlewareUsesUpdatedCORSAllowOrigins(t *testing.T) {
 	server := newTestServer(t)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 
 	// CORSAllowOrigins defines the explicit browser origins allowed to call API routes cross-origin.
 	// Leave empty to disable cross-origin browser access by default.
+	// Entries are exact origin matches, except chrome-extension://* / chrome-extension:*
+	// which allow any real chrome-extension://<id> Origin.
 	CORSAllowOrigins []string `yaml:"cors-allow-origins" json:"cors-allow-origins"`
 
 	// TrustedProxies lists reverse proxy IPs or CIDRs whose forwarding headers may be trusted.


### PR DESCRIPTION
## Summary
- `cors-allow-origins` 支持受控 pattern：`chrome-extension://*` / `chrome-extension:*`，匹配真实 `chrome-extension://<id>` 并回显真实 Origin
- 未配置仍拒绝任意 extension；`https://*` 等通用 glob 不生效
- 修正 `config.example.yaml` / 字段注释：扩展不默认放行

## Test plan
- [x] `go test ./internal/api -run 'TestCORSMiddleware' -count=1`（11 passed）
- [ ] GHA required checks
- [ ] 合入后：配置 `chrome-extension://*`，真实扩展 Origin 不再 403

Refs: CliProxy `docs/plan/083-cors-chrome-extension-wildcard-20260803.md`