### PR TITLE
feat(usage): persist thinking level on request logs

### DIFF
--- a/internal/runtime/executor/execution_context.go
+++ b/internal/runtime/executor/execution_context.go
@@ -183,13 +183,17 @@ func (ec *ExecutionContext) Reporter() *usageReporter {
 	if ec == nil {
 		return nil
 	}
-	model := thinking.ParseSuffix(ec.RequestedModel).ModelName
+	parsedModel := thinking.ParseSuffix(ec.RequestedModel)
+	model := parsedModel.ModelName
 	if strings.TrimSpace(model) == "" {
 		model = ec.BaseModel
 	}
 	reporter := newUsageReporter(ec.Context, ec.Provider, model, ec.BaseModel, ec.Auth)
+	reporter.setThinkingLevel(parsedModel.RawSuffix)
 	if fallback := visionFallbackLogFromContext(ec.Context); fallback.FallbackModel != "" {
-		reporter.setModel(fallback.RequestedModel)
+		fallbackModel := thinking.ParseSuffix(fallback.RequestedModel)
+		reporter.setModel(fallbackModel.ModelName)
+		reporter.setThinkingLevel(fallbackModel.RawSuffix)
 		reporter.setUpstreamModel(fallback.UpstreamModel)
 		reporter.setVisionFallbackModel(fallback.FallbackModel)
 	}

--- a/internal/runtime/executor/execution_context_test.go
+++ b/internal/runtime/executor/execution_context_test.go
@@ -62,6 +62,42 @@ func TestExecutionContextUsesOriginalRequestAndRequestedModel(t *testing.T) {
 	}
 }
 
+func TestExecutionContextReporterCapturesThinkingSuffix(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestedModel string
+		wantModel      string
+		wantLevel      string
+	}{
+		{name: "level", requestedModel: "gpt-5.6-sol(max)", wantModel: "gpt-5.6-sol", wantLevel: "max"},
+		{name: "numeric budget", requestedModel: "gpt-5.6-sol(8192)", wantModel: "gpt-5.6-sol", wantLevel: "8192"},
+		{name: "no suffix", requestedModel: "gpt-5.6-sol", wantModel: "gpt-5.6-sol", wantLevel: ""},
+		{name: "context marker only", requestedModel: "gpt-5.6-sol[128K]", wantModel: "gpt-5.6-sol", wantLevel: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			execCtx := newExecutionContext(
+				context.Background(),
+				"codex",
+				&config.Config{},
+				nil,
+				cliproxyexecutor.Request{Model: tt.requestedModel},
+				cliproxyexecutor.Options{},
+				ExecutionOptions{},
+			)
+
+			reporter := execCtx.Reporter()
+			if reporter.model != tt.wantModel {
+				t.Fatalf("reporter.model = %q, want %q", reporter.model, tt.wantModel)
+			}
+			if reporter.thinkingLevel != tt.wantLevel {
+				t.Fatalf("reporter.thinkingLevel = %q, want %q", reporter.thinkingLevel, tt.wantLevel)
+			}
+		})
+	}
+}
+
 func TestExecutionContextTranslatesSharedRequestPayloadOnce(t *testing.T) {
 	var calls atomic.Int32
 	from := sdktranslator.FromString("execution-context-shared-source")
@@ -214,7 +250,7 @@ func byteSizeLabel(size int) string {
 }
 
 func TestExecutionContextReporterKeepsVisionFallbackSeparateFromModelMapping(t *testing.T) {
-	ctx := contextWithVisionFallbackLog(context.Background(), "alias-model", "real-model", "vision-model")
+	ctx := contextWithVisionFallbackLog(context.Background(), "alias-model(max)", "real-model", "vision-model")
 	req := cliproxyexecutor.Request{
 		Model:   "vision-model",
 		Payload: []byte(`{"messages":[]}`),
@@ -232,6 +268,9 @@ func TestExecutionContextReporterKeepsVisionFallbackSeparateFromModelMapping(t *
 	reporter := execCtx.Reporter()
 	if reporter.model != "alias-model" {
 		t.Fatalf("reporter.model = %q, want alias-model", reporter.model)
+	}
+	if reporter.thinkingLevel != "max" {
+		t.Fatalf("reporter.thinkingLevel = %q, want max", reporter.thinkingLevel)
 	}
 	if reporter.upstreamModel != "real-model" {
 		t.Fatalf("reporter.upstreamModel = %q, want real-model", reporter.upstreamModel)

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -24,6 +24,7 @@ const usageReporterOutputMemoryLimit = 256 * 1024
 type usageReporter struct {
 	provider            string
 	model               string
+	thinkingLevel       string
 	upstreamModel       string
 	visionFallbackModel string
 	authID              string
@@ -112,6 +113,13 @@ func (r *usageReporter) setModel(model string) {
 	if model = strings.TrimSpace(model); model != "" {
 		r.model = model
 	}
+}
+
+func (r *usageReporter) setThinkingLevel(level string) {
+	if r == nil {
+		return
+	}
+	r.thinkingLevel = level
 }
 
 func (r *usageReporter) setUpstreamModel(model string) {
@@ -340,6 +348,7 @@ func (r *usageReporter) publishWithOutcome(ctx context.Context, detail coreusage
 		coreusage.PublishRecord(ctx, coreusage.Record{
 			Provider:            r.provider,
 			Model:               r.model,
+			ThinkingLevel:       r.thinkingLevel,
 			UpstreamModel:       r.upstreamModel,
 			VisionFallbackModel: r.visionFallbackModel,
 			Source:              r.source,
@@ -390,6 +399,7 @@ func (r *usageReporter) ensurePublished(ctx context.Context) {
 		coreusage.PublishRecord(ctx, coreusage.Record{
 			Provider:            r.provider,
 			Model:               r.model,
+			ThinkingLevel:       r.thinkingLevel,
 			UpstreamModel:       r.upstreamModel,
 			VisionFallbackModel: r.visionFallbackModel,
 			Source:              r.source,

--- a/internal/runtime/executor/usage_reporter_tenant_test.go
+++ b/internal/runtime/executor/usage_reporter_tenant_test.go
@@ -32,6 +32,7 @@ func TestUsageReporterPublishesTrustedTenantSeparatelyFromAPIKeyLabel(t *testing
 	ctx := context.WithValue(context.Background(), util.ContextKeyTrustedTenantID, tenantID)
 	ctx = context.WithValue(ctx, util.ContextKeyAPIKey, systemAPIKey)
 	reporter := newUsageReporter(ctx, "codex", model, "", nil)
+	reporter.setThinkingLevel("high")
 	reporter.ensurePublished(ctx)
 
 	deadline := time.After(2 * time.Second)
@@ -46,6 +47,9 @@ func TestUsageReporterPublishesTrustedTenantSeparatelyFromAPIKeyLabel(t *testing
 			}
 			if record.APIKey != systemAPIKey {
 				t.Fatalf("APIKey = %q, want display label %q", record.APIKey, systemAPIKey)
+			}
+			if record.ThinkingLevel != "high" {
+				t.Fatalf("ThinkingLevel = %q, want high", record.ThinkingLevel)
 			}
 			return
 		case <-deadline:

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -37,6 +37,7 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607210001_end_user_daily_spending_reset_events", SQL: endUserDailySpendingResetEventsSQL},
 		{Version: "202607220001_period_spending_limits", SQL: periodSpendingLimitsSQL},
 		{Version: "202607240001_ai_account_subject_usage_tokens", SQL: aiAccountSubjectUsageTokensSQL},
+		{Version: "202608030001_request_log_thinking_level", SQL: requestLogThinkingLevelSQL},
 	}
 }
 
@@ -336,14 +337,6 @@ CREATE TABLE IF NOT EXISTS api_key_daily_spending_reset_events (
 );
 CREATE INDEX IF NOT EXISTS idx_api_key_daily_spending_reset_events_key
   ON api_key_daily_spending_reset_events(tenant_id, api_key_id, reset_at DESC);
-`
-
-const requestLogsAuthLookupIndexesSQL = `
-CREATE INDEX IF NOT EXISTS idx_request_logs_tenant_auth_index_time
-  ON request_logs(tenant_id, auth_index, timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_request_logs_tenant_auth_subject_time_cost
-  ON request_logs(tenant_id, auth_subject_id, timestamp DESC)
-  INCLUDE (cost);
 `
 
 // Schema only: historical backfill uses usageLoc at process init (not UTC-hardcoded SQL).

--- a/internal/storage/postgres/request_log_migrations.go
+++ b/internal/storage/postgres/request_log_migrations.go
@@ -1,0 +1,14 @@
+package postgres
+
+const requestLogsAuthLookupIndexesSQL = `
+CREATE INDEX IF NOT EXISTS idx_request_logs_tenant_auth_index_time
+  ON request_logs(tenant_id, auth_index, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_request_logs_tenant_auth_subject_time_cost
+  ON request_logs(tenant_id, auth_subject_id, timestamp DESC)
+  INCLUDE (cost);
+`
+
+const requestLogThinkingLevelSQL = `
+ALTER TABLE request_logs
+ADD COLUMN IF NOT EXISTS thinking_level TEXT NOT NULL DEFAULT '';
+`

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,13 +11,20 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 23 {
-		t.Fatalf("RuntimeMigrations len = %d, want 23", len(migrations))
+	if len(migrations) != 24 {
+		t.Fatalf("RuntimeMigrations len = %d, want 24", len(migrations))
 	}
-	// Latest: shared AI-account cycle token projection.
-	if migrations[22].Version != "202607240001_ai_account_subject_usage_tokens" {
-		t.Fatalf("latest migration version = %q", migrations[22].Version)
+	// Latest: request-log thinking level metadata.
+	if migrations[23].Version != "202608030001_request_log_thinking_level" {
+		t.Fatalf("latest migration version = %q", migrations[23].Version)
 	}
+	thinkingSQL := migrations[23].SQL
+	for _, fragment := range []string{"ALTER TABLE request_logs", "thinking_level TEXT NOT NULL DEFAULT ''"} {
+		if !strings.Contains(thinkingSQL, fragment) {
+			t.Fatalf("request log thinking level migration missing %q", fragment)
+		}
+	}
+	// Prior: shared AI-account cycle token projection.
 	tokenSQL := migrations[22].SQL
 	for _, fragment := range []string{"ALTER TABLE ai_account_subject_usage_buckets", "total_tokens BIGINT NOT NULL DEFAULT 0"} {
 		if !strings.Contains(tokenSQL, fragment) {

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -377,7 +377,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	inputContent := resolveDeferredUsageContent(record.InputContent, record.InputContentPath)
 	outputContent := resolveDeferredUsageContent(record.OutputContent, record.OutputContentPath)
 	detailContent := resolveDeferredUsageContent(record.DetailContent, record.DetailContentPath)
-	InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(record.TrustedTenantID, statsKey, apiKeyID, record.AuthSubjectID, apiKeyName, modelName, record.UpstreamModel, record.VisionFallbackModel, record.Source, record.ChannelName,
+	InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(record.TrustedTenantID, statsKey, apiKeyID, record.AuthSubjectID, apiKeyName, modelName, record.UpstreamModel, record.VisionFallbackModel, record.ThinkingLevel, record.Source, record.ChannelName,
 		record.AuthIndex, failed, timestamp, record.LatencyMs, record.FirstTokenMs, detail,
 		inputContent, outputContent, detailContent, record.Streaming)
 }

--- a/internal/usage/request_log_model_columns.go
+++ b/internal/usage/request_log_model_columns.go
@@ -1,0 +1,29 @@
+package usage
+
+import (
+	"database/sql"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func migrateUpstreamModelColumn(db *sql.DB) {
+	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN upstream_model TEXT NOT NULL DEFAULT ''")
+	if err != nil && !strings.Contains(err.Error(), "duplicate") {
+		log.Warnf("usage: migrate column upstream_model: %v", err)
+	}
+}
+
+func migrateVisionFallbackModelColumn(db *sql.DB) {
+	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN vision_fallback_model TEXT NOT NULL DEFAULT ''")
+	if err != nil && !strings.Contains(err.Error(), "duplicate") {
+		log.Warnf("usage: migrate column vision_fallback_model: %v", err)
+	}
+}
+
+func migrateThinkingLevelColumn(db *sql.DB) {
+	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN thinking_level TEXT NOT NULL DEFAULT ''")
+	if err != nil && !strings.Contains(err.Error(), "duplicate") {
+		log.Warnf("usage: migrate column thinking_level: %v", err)
+	}
+}

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -50,7 +50,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 
 	// Fetch page
 	offset := (params.Page - 1) * params.Size
-	querySQL := "SELECT id, timestamp, api_key, api_key_id, api_key_name, model, upstream_model, vision_fallback_model, source, channel_name, auth_index, auth_subject_id, " +
+	querySQL := "SELECT id, timestamp, api_key, api_key_id, api_key_name, model, thinking_level, upstream_model, vision_fallback_model, source, channel_name, auth_index, auth_subject_id, " +
 		"failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, " +
 		"cost, " +
 		"(CASE WHEN EXISTS (SELECT 1 FROM request_log_content content WHERE content.tenant_id = request_logs.tenant_id AND content.log_id = request_logs.id) " +
@@ -72,7 +72,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 		var ts storedTime
 		var failedInt, streamingInt, hasContentInt int
 		if err := rows.Scan(
-			&row.ID, &ts, &row.APIKey, &row.APIKeyID, &row.APIKeyName, &row.Model, &row.UpstreamModel, &row.VisionFallbackModel, &row.Source, &row.ChannelName,
+			&row.ID, &ts, &row.APIKey, &row.APIKeyID, &row.APIKeyName, &row.Model, &row.ThinkingLevel, &row.UpstreamModel, &row.VisionFallbackModel, &row.Source, &row.ChannelName,
 			&row.AuthIndex, &row.AuthSubjectID, &failedInt, &streamingInt, &row.LatencyMs, &row.FirstTokenMs,
 			&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
 			&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,

--- a/internal/usage/request_log_types.go
+++ b/internal/usage/request_log_types.go
@@ -13,6 +13,7 @@ type LogRow struct {
 	APIKeyOwnName       string    `json:"api_key_own_name,omitempty"`
 	EndUserDisplayName  string    `json:"end_user_display_name,omitempty"`
 	Model               string    `json:"model"`
+	ThinkingLevel       string    `json:"thinking_level"`
 	UpstreamModel       string    `json:"upstream_model,omitempty"`
 	VisionFallbackModel string    `json:"vision_fallback_model,omitempty"`
 	Source              string    `json:"source"`

--- a/internal/usage/request_log_write.go
+++ b/internal/usage/request_log_write.go
@@ -23,7 +23,7 @@ func isRetryableUsageWriteErr(err error) bool {
 
 func insertLogIdentityOnce(
 	db *sql.DB,
-	tenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel,
+	tenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, thinkingLevel,
 	source, channelName, authIndex, endUserID string,
 	failed, streaming bool,
 	timestamp time.Time, latencyMs, firstTokenMs int64,
@@ -52,12 +52,12 @@ func insertLogIdentityOnce(
 	}
 
 	insertSQL := `INSERT INTO request_logs
-		(tenant_id, timestamp, api_key, api_key_id, auth_subject_id, api_key_name, model, upstream_model, vision_fallback_model, source, channel_name, auth_index,
+		(tenant_id, timestamp, api_key, api_key_id, auth_subject_id, api_key_name, model, thinking_level, upstream_model, vision_fallback_model, source, channel_name, auth_index,
 		 failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
-	 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	insertArgs := []any{
 		tenantID, timestamp.UTC().Format(time.RFC3339Nano),
-		apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex,
+		apiKey, apiKeyID, authSubjectID, apiKeyName, model, thinkingLevel, upstreamModel, visionFallbackModel, source, channelName, authIndex,
 		failedInt, streamingInt, latencyMs, firstTokenMs,
 		tokens.InputTokens, tokens.OutputTokens, tokens.ReasoningTokens,
 		tokens.CachedTokens, tokens.TotalTokens, cost,

--- a/internal/usage/usage_db.go
+++ b/internal/usage/usage_db.go
@@ -62,6 +62,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
   api_key_id       TEXT NOT NULL DEFAULT '',
   auth_subject_id  TEXT NOT NULL DEFAULT '',
   model            TEXT NOT NULL DEFAULT '',
+  thinking_level   TEXT NOT NULL DEFAULT '',
   upstream_model   TEXT NOT NULL DEFAULT '',
   vision_fallback_model TEXT NOT NULL DEFAULT '',
   source           TEXT NOT NULL DEFAULT '',
@@ -181,24 +182,6 @@ func migrateApiKeyNameColumn(db *sql.DB) {
 	if err != nil {
 		if !strings.Contains(err.Error(), "duplicate") {
 			log.Warnf("usage: migrate column api_key_name: %v", err)
-		}
-	}
-}
-
-func migrateUpstreamModelColumn(db *sql.DB) {
-	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN upstream_model TEXT NOT NULL DEFAULT ''")
-	if err != nil {
-		if !strings.Contains(err.Error(), "duplicate") {
-			log.Warnf("usage: migrate column upstream_model: %v", err)
-		}
-	}
-}
-
-func migrateVisionFallbackModelColumn(db *sql.DB) {
-	_, err := db.Exec("ALTER TABLE request_logs ADD COLUMN vision_fallback_model TEXT NOT NULL DEFAULT ''")
-	if err != nil {
-		if !strings.Contains(err.Error(), "duplicate") {
-			log.Warnf("usage: migrate column vision_fallback_model: %v", err)
 		}
 	}
 }
@@ -737,6 +720,8 @@ func initOpenedDBLocked(db, readDB *sql.DB, dbPath, driver string, storageCfg co
 		migrateUpstreamModelColumn(db)
 		log.Debugf("usage: running vision_fallback_model column migration")
 		migrateVisionFallbackModelColumn(db)
+		log.Debugf("usage: running thinking_level column migration")
+		migrateThinkingLevelColumn(db)
 		log.Debugf("usage: running api_key_id column migration")
 		migrateAPIKeyIDColumn(db)
 		log.Debugf("usage: ensuring request log lookup indexes")
@@ -863,48 +848,48 @@ func CloseDB() {
 func InsertLog(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent string) {
-	insertLogIdentity("", apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "", isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, "", "", apiKeyName, model, "", "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, "", isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetails(apiKey, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity("", apiKey, "", "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, "", "", apiKeyName, model, "", "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentity(apiKey, apiKeyID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity("", apiKey, apiKeyID, "", apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, apiKeyID, "", apiKeyName, model, "", "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubject(apiKey, apiKeyID, authSubjectID, apiKeyName, model, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, "", "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubjectUpstream(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, "", "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 func InsertLogWithDetailsIdentitySubjectUpstreamVision(apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string) {
-	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
+	insertLogIdentity("", apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, "", source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, isStreamingRequestContent(inputContent))
 }
 
 // InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming persists an
 // explicit streaming classification even when request body storage is disabled.
-func InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
+func InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, thinkingLevel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string, streaming bool) {
-	insertLogIdentity(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, streaming)
+	insertLogIdentity(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, thinkingLevel, source, channelName, authIndex, failed, timestamp, latencyMs, firstTokenMs, tokens, inputContent, outputContent, detailContent, streaming)
 }
 
-func insertLogIdentity(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, source, channelName, authIndex string,
+func insertLogIdentity(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, thinkingLevel, source, channelName, authIndex string,
 	failed bool, timestamp time.Time, latencyMs, firstTokenMs int64, tokens TokenStats,
 	inputContent, outputContent, detailContent string, streaming bool) {
 	db := getDB()
@@ -922,6 +907,7 @@ func insertLogIdentity(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyN
 	apiKeyName = strings.TrimSpace(apiKeyName)
 	upstreamModel = strings.TrimSpace(upstreamModel)
 	visionFallbackModel = strings.TrimSpace(visionFallbackModel)
+	thinkingLevel = strings.TrimSpace(thinkingLevel)
 	// Resolve identity before opening the write tx: SQLite single-writer + maintenance
 	// would deadlock if we query api_keys while this connection already holds a tx.
 	endUserID := ""
@@ -952,7 +938,7 @@ func insertLogIdentity(trustedTenantID, apiKey, apiKeyID, authSubjectID, apiKeyN
 			time.Sleep(time.Duration(attempt*attempt) * time.Millisecond)
 		}
 		lastErr = insertLogIdentityOnce(
-			db, tenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel,
+			db, tenantID, apiKey, apiKeyID, authSubjectID, apiKeyName, model, upstreamModel, visionFallbackModel, thinkingLevel,
 			source, channelName, authIndex, endUserID, failed, streaming, timestamp, latencyMs, firstTokenMs,
 			tokens, cost, inputContent, outputContent, detailContent, shouldStoreContent,
 		)

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
@@ -553,6 +554,77 @@ func TestQueryLogsReturnsVisionFallbackModelSeparately(t *testing.T) {
 	}
 }
 
+func TestQueryLogsReturnsThinkingLevel(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	now := time.Now().UTC()
+	InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(
+		"",
+		"sk-thinking",
+		"key-thinking",
+		"subject-thinking",
+		"Primary",
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+		"",
+		"max",
+		"codex",
+		"Codex",
+		"auth-thinking",
+		false,
+		now,
+		140,
+		14,
+		TokenStats{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
+		"",
+		"",
+		"",
+		false,
+	)
+	InsertLog("sk-no-thinking", "", "gpt-5.6-sol", "codex", "Codex", "auth-no-thinking", false, now.Add(-time.Second), 100, 10, TokenStats{
+		InputTokens: 1, OutputTokens: 1, TotalTokens: 2,
+	}, "", "")
+
+	result, err := QueryLogs(LogQueryParams{Page: 1, Size: 10, Days: 1})
+	if err != nil {
+		t.Fatalf("QueryLogs() error = %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(result.Items))
+	}
+
+	rowsByKey := make(map[string]LogRow, len(result.Items))
+	for _, row := range result.Items {
+		rowsByKey[row.APIKey] = row
+	}
+	thinkingRow := rowsByKey["sk-thinking"]
+	if thinkingRow.Model != "gpt-5.6-sol" {
+		t.Fatalf("Model = %q, want gpt-5.6-sol", thinkingRow.Model)
+	}
+	if thinkingRow.ThinkingLevel != "max" {
+		t.Fatalf("ThinkingLevel = %q, want max", thinkingRow.ThinkingLevel)
+	}
+	noThinkingRow := rowsByKey["sk-no-thinking"]
+	if noThinkingRow.ThinkingLevel != "" {
+		t.Fatalf("ThinkingLevel without suffix = %q, want empty", noThinkingRow.ThinkingLevel)
+	}
+	encoded, err := json.Marshal(noThinkingRow)
+	if err != nil {
+		t.Fatalf("json.Marshal(LogRow) error = %v", err)
+	}
+	if !strings.Contains(string(encoded), `"thinking_level":""`) {
+		t.Fatalf("LogRow JSON = %s, want empty thinking_level field", encoded)
+	}
+
+	rowByID, err := QueryLogRowByID(thinkingRow.ID)
+	if err != nil {
+		t.Fatalf("QueryLogRowByID() error = %v", err)
+	}
+	if rowByID.ThinkingLevel != "max" {
+		t.Fatalf("QueryLogRowByID().ThinkingLevel = %q, want max", rowByID.ThinkingLevel)
+	}
+}
+
 func TestQueryLogContentKeepsMissingFailedOutputEmpty(t *testing.T) {
 	initTestUsageDB(t, config.RequestLogStorageConfig{
 		StoreContent:           true,
@@ -782,7 +854,7 @@ func TestInitDBMigratesFirstTokenAndStreamingColumns(t *testing.T) {
 		if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &pk); err != nil {
 			t.Fatalf("scan table info: %v", err)
 		}
-		if name == "first_token_ms" || name == "streaming" || name == "vision_fallback_model" {
+		if name == "first_token_ms" || name == "streaming" || name == "vision_fallback_model" || name == "thinking_level" {
 			found[name] = true
 		}
 	}
@@ -794,6 +866,9 @@ func TestInitDBMigratesFirstTokenAndStreamingColumns(t *testing.T) {
 	}
 	if !found["vision_fallback_model"] {
 		t.Fatalf("expected vision_fallback_model column to exist after InitDB migration")
+	}
+	if !found["thinking_level"] {
+		t.Fatalf("expected thinking_level column to exist after InitDB migration")
 	}
 }
 

--- a/internal/usage/usage_log_queries.go
+++ b/internal/usage/usage_log_queries.go
@@ -18,7 +18,7 @@ func QueryLogRowByIDForTenant(tenantID string, id int64) (LogRow, error) {
 	var ts storedTime
 	var failedInt, streamingInt, hasContentInt int
 	err := db.QueryRow(
-		"SELECT id, timestamp, api_key, api_key_name, model, source, channel_name, auth_index, "+
+		"SELECT id, timestamp, api_key, api_key_name, model, thinking_level, source, channel_name, auth_index, "+
 			"failed, streaming, latency_ms, first_token_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, "+
 			"cost, "+
 			"(CASE WHEN EXISTS (SELECT 1 FROM request_log_content content WHERE content.tenant_id = request_logs.tenant_id AND content.log_id = request_logs.id) "+
@@ -26,7 +26,7 @@ func QueryLogRowByIDForTenant(tenantID string, id int64) (LogRow, error) {
 			"FROM request_logs WHERE tenant_id = ? AND id = ?",
 		tenantID, id,
 	).Scan(
-		&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.Source, &row.ChannelName,
+		&row.ID, &ts, &row.APIKey, &row.APIKeyName, &row.Model, &row.ThinkingLevel, &row.Source, &row.ChannelName,
 		&row.AuthIndex, &failedInt, &streamingInt, &row.LatencyMs, &row.FirstTokenMs,
 		&row.InputTokens, &row.OutputTokens, &row.ReasoningTokens,
 		&row.CachedTokens, &row.TotalTokens, &row.Cost, &hasContentInt,

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -13,6 +13,7 @@ import (
 type Record struct {
 	Provider            string
 	Model               string
+	ThinkingLevel       string
 	UpstreamModel       string
 	VisionFallbackModel string
 	APIKey              string


### PR DESCRIPTION
## Summary
- capture the requested model thinking suffix before stripping it from `model`
- persist `thinking_level` in SQLite/PostgreSQL request logs and return it from all `LogRow` queries
- keep historical/no-suffix rows as an empty string and cover suffix, migration, persistence, and JSON behavior

## Validation
- `go test ./internal/runtime/executor ./sdk/cliproxy/usage -count=1`
- `go test ./internal/usage -count=1`
- `go test ./internal/storage/postgres/... -count=1`
- `go test ./internal/management/usagelogs ./internal/api/handlers/management -count=1`
- `./scripts/ci-pr.sh`

`CLIRELAY_POSTGRES_TEST_DSN` was not set locally, so external PostgreSQL integration cases were skipped by the test suite.