### PR TITLE
fix(usage): read thinking level from request body

### DIFF
--- a/internal/runtime/executor/execution_context.go
+++ b/internal/runtime/executor/execution_context.go
@@ -189,11 +189,17 @@ func (ec *ExecutionContext) Reporter() *usageReporter {
 		model = ec.BaseModel
 	}
 	reporter := newUsageReporter(ec.Context, ec.Provider, model, ec.BaseModel, ec.Auth)
-	reporter.setThinkingLevel(parsedModel.RawSuffix)
+	level := thinking.ExtractThinkingLevel(ec.OriginalPayload, ec.SourceFormat.String())
+	if parsedModel.HasSuffix {
+		level = parsedModel.RawSuffix
+	}
+	reporter.setThinkingLevel(level)
 	if fallback := visionFallbackLogFromContext(ec.Context); fallback.FallbackModel != "" {
 		fallbackModel := thinking.ParseSuffix(fallback.RequestedModel)
 		reporter.setModel(fallbackModel.ModelName)
-		reporter.setThinkingLevel(fallbackModel.RawSuffix)
+		if fallbackModel.HasSuffix {
+			reporter.setThinkingLevel(fallbackModel.RawSuffix)
+		}
 		reporter.setUpstreamModel(fallback.UpstreamModel)
 		reporter.setVisionFallbackModel(fallback.FallbackModel)
 	}

--- a/internal/runtime/executor/execution_context_test.go
+++ b/internal/runtime/executor/execution_context_test.go
@@ -62,16 +62,22 @@ func TestExecutionContextUsesOriginalRequestAndRequestedModel(t *testing.T) {
 	}
 }
 
-func TestExecutionContextReporterCapturesThinkingSuffix(t *testing.T) {
+func TestExecutionContextReporterCapturesThinkingLevel(t *testing.T) {
 	tests := []struct {
 		name           string
 		requestedModel string
+		payload        []byte
+		sourceFormat   sdktranslator.Format
 		wantModel      string
 		wantLevel      string
 	}{
-		{name: "level", requestedModel: "gpt-5.6-sol(max)", wantModel: "gpt-5.6-sol", wantLevel: "max"},
+		{name: "body effort", requestedModel: "gpt-5.6-sol", payload: []byte(`{"reasoning":{"effort":"max"}}`), sourceFormat: sdktranslator.FormatOpenAIResponse, wantModel: "gpt-5.6-sol", wantLevel: "max"},
+		{name: "body effort trimmed", requestedModel: "gpt-5.6-sol", payload: []byte(`{"reasoning":{"effort":" high "}}`), sourceFormat: sdktranslator.FormatOpenAIResponse, wantModel: "gpt-5.6-sol", wantLevel: "high"},
+		{name: "chat completions effort", requestedModel: "gpt-5.5", payload: []byte(`{"reasoning_effort":"medium"}`), sourceFormat: sdktranslator.FormatOpenAI, wantModel: "gpt-5.5", wantLevel: "medium"},
+		{name: "claude budget", requestedModel: "claude-sonnet", payload: []byte(`{"thinking":{"type":"enabled","budget_tokens":4096}}`), sourceFormat: sdktranslator.FormatClaude, wantModel: "claude-sonnet", wantLevel: "4096"},
+		{name: "suffix takes priority", requestedModel: "gpt-5.6-sol(high)", payload: []byte(`{"reasoning":{"effort":"max"}}`), sourceFormat: sdktranslator.FormatOpenAIResponse, wantModel: "gpt-5.6-sol", wantLevel: "high"},
 		{name: "numeric budget", requestedModel: "gpt-5.6-sol(8192)", wantModel: "gpt-5.6-sol", wantLevel: "8192"},
-		{name: "no suffix", requestedModel: "gpt-5.6-sol", wantModel: "gpt-5.6-sol", wantLevel: ""},
+		{name: "no suffix or body effort", requestedModel: "gpt-5.6-sol", wantModel: "gpt-5.6-sol", wantLevel: ""},
 		{name: "context marker only", requestedModel: "gpt-5.6-sol[128K]", wantModel: "gpt-5.6-sol", wantLevel: ""},
 	}
 
@@ -82,8 +88,8 @@ func TestExecutionContextReporterCapturesThinkingSuffix(t *testing.T) {
 				"codex",
 				&config.Config{},
 				nil,
-				cliproxyexecutor.Request{Model: tt.requestedModel},
-				cliproxyexecutor.Options{},
+				cliproxyexecutor.Request{Model: tt.requestedModel, Payload: tt.payload},
+				cliproxyexecutor.Options{SourceFormat: tt.sourceFormat},
 				ExecutionOptions{},
 			)
 

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -119,7 +119,7 @@ func (r *usageReporter) setThinkingLevel(level string) {
 	if r == nil {
 		return
 	}
-	r.thinkingLevel = level
+	r.thinkingLevel = strings.TrimSpace(level)
 }
 
 func (r *usageReporter) setUpstreamModel(model string) {

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -319,7 +319,7 @@ func extractThinkingConfig(body []byte, provider string) ThinkingConfig {
 		return extractGeminiConfig(body, provider)
 	case "openai":
 		return extractOpenAIConfig(body)
-	case "codex", "xai":
+	case "codex", "xai", "openai-response":
 		return extractCodexConfig(body)
 	case "iflow":
 		config := extractIFlowConfig(body)

--- a/internal/thinking/level.go
+++ b/internal/thinking/level.go
@@ -1,0 +1,28 @@
+package thinking
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ExtractThinkingLevel returns the request body's thinking level or numeric budget
+// using the same protocol-specific parsing as ApplyThinking.
+func ExtractThinkingLevel(body []byte, format string) string {
+	config := extractThinkingConfig(body, strings.ToLower(strings.TrimSpace(format)))
+	if !hasThinkingConfig(config) {
+		return ""
+	}
+
+	switch config.Mode {
+	case ModeNone:
+		return string(LevelNone)
+	case ModeAuto:
+		return string(LevelAuto)
+	case ModeLevel:
+		return strings.TrimSpace(string(config.Level))
+	case ModeBudget:
+		return strconv.Itoa(config.Budget)
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary
- reuse the existing unified thinking parser to read request-body effort/budget values
- keep model suffixes authoritative and fall back to `OriginalPayload` only when no suffix exists
- normalize logged values with trimming and cover Responses, Chat Completions, Claude budget, suffix priority, and empty fallback

## Root cause
The original usage logging change only read `thinking.ParseSuffix(ec.RequestedModel)`. Real clients send thinking configuration in the request body (for example `reasoning.effort`), so suffix-free requests always persisted an empty `thinking_level`.

## Tests
- red/green: `go test ./internal/runtime/executor -run ^'TestExecutionContextReporterCapturesThinkingLevel$' -count=1`\n- `go test ./internal/thinking ./internal/runtime/executor -count=1`\n- `./scripts/ci-pr.sh`