### PR TITLE
fix(test): 让路由 smoke 容忍 device-login 上游不可达

### DIFF
--- a/internal/api/routes/management_postgres_regression_test.go
+++ b/internal/api/routes/management_postgres_regression_test.go
@@ -312,6 +312,16 @@ func postgresSmokeAllowsStatus(routePath string, status int, body string) bool {
 		return routePath == "/v0/management/update/progress" && strings.Contains(body, "update_progress_failed") ||
 			routePath == "/v0/management/update/events" && strings.Contains(body, "update_events_failed")
 	}
+	if status == http.StatusInternalServerError {
+		// Qwen and Kimi use OAuth *device* login: the handler must reach the upstream
+		// provider to exchange a device code before it can return an auth URL. The other
+		// six *-auth-url routes build a PKCE URL locally and stay green offline.
+		// This smoke asserts the route is registered and reachable — upstream availability
+		// is not what it covers — so a sandboxed runner with no egress must not fail it.
+		deviceLogin := routePath == "/v0/management/qwen-auth-url" ||
+			routePath == "/v0/management/kimi-auth-url"
+		return deviceLogin && strings.Contains(body, "failed to generate authorization url")
+	}
 	if status != http.StatusServiceUnavailable {
 		return false
 	}
@@ -362,4 +372,28 @@ func (client postgresManagementClient) request(method, path, body string) *httpt
 	rec := httptest.NewRecorder()
 	client.router.ServeHTTP(rec, req)
 	return rec
+}
+
+func TestPostgresSmokeAllowsDeviceLoginUpstreamFailure(t *testing.T) {
+	const authURLFailure = `{"error":"failed to generate authorization url"}`
+
+	// Device-login routes must survive a runner with no egress to the provider.
+	for _, routePath := range []string{
+		"/v0/management/qwen-auth-url",
+		"/v0/management/kimi-auth-url",
+	} {
+		if !postgresSmokeAllowsStatus(routePath, http.StatusInternalServerError, authURLFailure) {
+			t.Errorf("%s: upstream device-code failure should be tolerated by the route smoke", routePath)
+		}
+	}
+
+	// The remaining *-auth-url routes build their URL locally, so a 500 there is a real bug.
+	if postgresSmokeAllowsStatus("/v0/management/codex-auth-url", http.StatusInternalServerError, authURLFailure) {
+		t.Error("codex-auth-url builds its URL locally; a 500 must still fail the smoke")
+	}
+
+	// The allowance is scoped to this one failure, not to 500s in general.
+	if postgresSmokeAllowsStatus("/v0/management/qwen-auth-url", http.StatusInternalServerError, `{"error":"boom"}`) {
+		t.Error("unrelated 500s on qwen-auth-url must still fail the smoke")
+	}
 }


### PR DESCRIPTION
## 问题

`TestManagementAPIPostgresAllRoutesSmoke` 在 GitHub runner 上稳定失败（连续两次运行，非偶发）：

```
GET /v0/management/qwen-auth-url status=500
body={"error":"failed to generate authorization url"}
```

发现于 release PR #846。该分支的代码树与 `origin/dev` 完全一致（同一个 tree hash），dev 上同样的代码 12 小时前 CI 是绿的——所以这不是本轮改动引入的，是这条 smoke 对外部网络的既有依赖被 runner 环境暴露了。

## 根因

八个 `*-auth-url` 路由里，只有 **qwen 和 kimi 走 OAuth device login**：handler 必须先连到上游换 device code 才能返回 auth URL（`qwenprovider.StartDeviceLogin` / `kimiprovider.StartDeviceLogin`）。其余六个在本地用 PKCE 拼 URL，离线也返回 200，所以一直是绿的。

这条 smoke 断言的是「路由已注册且可达」，不是「上游服务可用」——文件里既有的注释就是这么写的：

> The generic smoke sends placeholder ids / empty JSON. These routes therefore have no real target; dedicated handler tests cover success.

没有出网的 runner 不该让它变红。

## 改动

按 `/update/progress` 502 已有的同一套豁免机制，把这两个 device-login 路由在该特定错误下的 500 纳入允许集。

豁免范围刻意收窄，并补了针对豁免函数的单测锁住边界：

- qwen / kimi + `failed to generate authorization url` + 500 → 放过
- `codex-auth-url` 的同样 500 → 仍然失败（它本地构造 URL，500 是真 bug）
- qwen 上无关的 500（如 `{"error":"boom"}`）→ 仍然失败

不改任何产品代码。

## 验证

`gofmt -l`（无输出）、`go vet ./internal/api/routes/`、`go build ./...`、`go test ./internal/api/routes/`（含 `TestRegisterManagementRouteTable`）、`python3 scripts/check-backend-structure.py` 均通过。

合并后重跑 #846 的 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)