### PR TITLE
fix(cors): 放行服务端真正接受的认证头

### DIFF
--- a/internal/api/server_http_middleware.go
+++ b/internal/api/server_http_middleware.go
@@ -12,6 +12,23 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
 
+// corsAllowHeaders must cover every request header a browser client legitimately sends,
+// otherwise the preflight is rejected by the browser and the caller sees a bare CORS error
+// with no server-side trace.
+//
+// The three auth headers mirror what config_access.provider.Authenticate actually reads
+// (Authorization / X-Goog-Api-Key / X-Api-Key). Omitting the latter two meant the server
+// advertised auth schemes that no browser could ever use.
+//
+// anthropic-version is mandatory on the Anthropic wire format and anthropic-beta carries
+// feature opt-ins; x-stainless-* is emitted automatically by the official OpenAI and
+// Anthropic SDKs, so browser callers cannot drop it.
+const corsAllowHeaders = "Authorization, Content-Type, Accept, Origin, " +
+	"X-Api-Key, X-Goog-Api-Key, " +
+	"anthropic-version, anthropic-beta, " +
+	"x-stainless-arch, x-stainless-lang, x-stainless-os, x-stainless-package-version, " +
+	"x-stainless-retry-count, x-stainless-runtime, x-stainless-runtime-version, x-stainless-timeout"
+
 func corsMiddleware(cfgProvider func() *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c != nil && c.Request != nil && c.Request.URL != nil {
@@ -52,7 +69,7 @@ func corsMiddleware(cfgProvider func() *config.Config) gin.HandlerFunc {
 		c.Header("Vary", "Origin")
 		c.Header("Access-Control-Allow-Origin", allowedOrigin)
 		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, Origin")
+		c.Header("Access-Control-Allow-Headers", corsAllowHeaders)
 		c.Header("Access-Control-Expose-Headers", "X-CPA-VERSION, X-CPA-COMMIT, X-CPA-BUILD-DATE")
 
 		if c.Request.Method == http.MethodOptions {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1073,3 +1073,41 @@ func TestServerTrustedProxiesAllowConfiguredReverseProxyClientIP(t *testing.T) {
 		t.Fatalf("ClientIP() = %q, want forwarded client IP", got)
 	}
 }
+
+// The preflight must advertise every auth header the server is willing to authenticate with.
+// When these drift apart the server accepts a scheme that no browser client can ever send:
+// the browser rejects the request at preflight and the user only sees a bare CORS error.
+func TestCORSPreflightAdvertisesEveryAcceptedAuthHeader(t *testing.T) {
+	server := newTestServerWithConfig(t, func(cfg *proxyconfig.Config) {
+		cfg.CORSAllowOrigins = []string{"chrome-extension://*"}
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/v1/messages", nil)
+	req.Header.Set("Origin", "chrome-extension://dnjfbdinlpcfefpheddgehgobcefebli")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+
+	allowed := make(map[string]bool)
+	for _, header := range strings.Split(rr.Header().Get("Access-Control-Allow-Headers"), ",") {
+		allowed[strings.ToLower(strings.TrimSpace(header))] = true
+	}
+
+	// Mirrors config_access.provider.Authenticate.
+	for _, header := range []string{"authorization", "x-api-key", "x-goog-api-key"} {
+		if !allowed[header] {
+			t.Errorf("auth header %q is accepted by the server but not advertised to browsers", header)
+		}
+	}
+	// Mandatory / near-universal on the Anthropic wire format and the official SDKs.
+	for _, header := range []string{"anthropic-version", "anthropic-beta", "content-type"} {
+		if !allowed[header] {
+			t.Errorf("header %q is required by browser clients but not advertised", header)
+		}
+	}
+}


### PR DESCRIPTION
## 用户反馈

> 老哥，更新了之后还是不行，还是会遇到跨域问题。`chrome-extension://*` 设置了。
> ```json
> {"error": "origin not allowed", "origin": "chrome-extension://dnjfbdinlpcfefpheddgehgobcefebli"}
> ```

## 线上实测：origin 这关已经过了

在 `relay.07230805.xyz`（`dev-6afb147`）上对用户报的那个 origin 逐路径测：

| 路径 | 状态 | `Access-Control-Allow-Origin` |
|---|---|---|
| `/v1/models` | 401（缺 key，非 CORS） | ✅ 正确回显 |
| `/v1/messages` | 404 | ✅ 正确回显 |
| `/v1/chat/completions` | 404 | ✅ 正确回显 |
| `/v1beta/models` | 401 | ✅ 正确回显 |

对照组确认中间件确实在拦：`https://evil.example.com` → 403 `origin not allowed`；`chrome-extension://`（空 id）→ 403。

所以 #843 是生效的，那条 403 复现不出来了——用户当时应该还跑在不含 #843 的版本上。

## 但下一道门确实关着

`Access-Control-Allow-Headers` 是一行硬编码：

```
Authorization, Content-Type, Accept, Origin
```

而 [`config_access.provider.Authenticate`](https://github.com/kittors/CliRelay/blob/dev/internal/access/config_access/provider.go#L207-L209) 实际接受**三种**认证头：

```go
authHeader        := r.Header.Get("Authorization")
authHeaderGoogle  := r.Header.Get("X-Goog-Api-Key")
authHeaderAnthropic := r.Header.Get("X-Api-Key")
```

后两种从来没进过白名单。等于服务端对外宣称支持 Anthropic / Gemini 的标准认证方式，但浏览器客户端根本发不出来——预检响应不含该头，浏览器直接拦下实际请求，调用方只看到一个**没有任何服务端日志**的裸 CORS 错误。

线上复现（请求 `x-api-key,anthropic-version,anthropic-beta`，服务端只回固定四项）：

```
$ curl -sSI -X OPTIONS -H "Origin: chrome-extension://dnjfb..." \
    -H "Access-Control-Request-Headers: x-api-key,anthropic-version,anthropic-beta" \
    https://relay.07230805.xyz/v1/messages | grep -i allow-headers
access-control-allow-headers: Authorization, Content-Type, Accept, Origin
```

用 `Authorization: Bearer` 的客户端不受影响，这也是为什么之前没被发现。

## 改动

白名单补齐到服务端真正需要的集合：

- **认证**：`X-Api-Key`、`X-Goog-Api-Key`（对齐 `provider.Authenticate`）
- **协议**：`anthropic-version`（Anthropic 线格式必需）、`anthropic-beta`
- **SDK**：`x-stainless-*` 系列——官方 OpenAI / Anthropic SDK 在浏览器环境会自动附加，调用方无法去掉

新增测试直接对着 `provider.Authenticate` 的头列表断言，把两者绑在一起。把白名单改回旧值后测试会明确报错：

```
auth header "x-api-key" is accepted by the server but not advertised to browsers
auth header "x-goog-api-key" is accepted by the server but not advertised to browsers
header "anthropic-version" is required by browser clients but not advertised
```

## 未改动

`/v0/management/*` 与 `/manage` 仍然整体跳过 CORS（不回 ACAO）。从扩展跨域调管理接口本来就不该放行，这是有意的安全边界，不在本次范围内。

## 验证

`gofmt -l`（无输出）、`go vet ./...`、`go build ./...`、`go test ./internal/api/... ./internal/access/...`、`python3 scripts/check-backend-structure.py` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)