### PR TITLE
fix: preserve Claude tool result images

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -146,6 +146,28 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 				appendContentPart(part.String())
 			}
 
+			imageDataURL := func(imageResult gjson.Result) string {
+				sourceResult := imageResult.Get("source")
+				if !sourceResult.Exists() {
+					return ""
+				}
+				data := sourceResult.Get("data").String()
+				if data == "" {
+					data = sourceResult.Get("base64").String()
+				}
+				if data == "" {
+					return ""
+				}
+				mediaType := sourceResult.Get("media_type").String()
+				if mediaType == "" {
+					mediaType = sourceResult.Get("mime_type").String()
+				}
+				if mediaType == "" {
+					mediaType = "application/octet-stream"
+				}
+				return fmt.Sprintf("data:%s;base64,%s", mediaType, data)
+			}
+
 			messageContentsResult := messageResult.Get("content")
 			if messageContentsResult.IsArray() {
 				messageContentResults := messageContentsResult.Array()
@@ -157,23 +179,8 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 					case "text":
 						appendTextContentRaw(messageContentResult.Get("text").Raw)
 					case "image":
-						sourceResult := messageContentResult.Get("source")
-						if sourceResult.Exists() {
-							data := sourceResult.Get("data").String()
-							if data == "" {
-								data = sourceResult.Get("base64").String()
-							}
-							if data != "" {
-								mediaType := sourceResult.Get("media_type").String()
-								if mediaType == "" {
-									mediaType = sourceResult.Get("mime_type").String()
-								}
-								if mediaType == "" {
-									mediaType = "application/octet-stream"
-								}
-								dataURL := fmt.Sprintf("data:%s;base64,%s", mediaType, data)
-								appendImageContent(dataURL)
-							}
+						if dataURL := imageDataURL(messageContentResult); dataURL != "" {
+							appendImageContent(dataURL)
 						}
 					case "tool_use":
 						flushMessage()
@@ -192,9 +199,33 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 						appendInput(functionCallMessage)
 					case "tool_result":
 						flushMessage()
+						toolResultContent := messageContentResult.Get("content")
+						toolOutput := toolResultContent.String()
+						if toolResultContent.IsArray() {
+							var textParts []string
+							hasImage := false
+							for _, part := range toolResultContent.Array() {
+								switch part.Get("type").String() {
+								case "text":
+									if text := part.Get("text").String(); text != "" {
+										textParts = append(textParts, text)
+									}
+								case "image":
+									// 图片必须走视觉输入，不能作为函数输出文本传递。
+									if dataURL := imageDataURL(part); dataURL != "" {
+										appendImageContent(dataURL)
+										hasImage = true
+									}
+								}
+							}
+							toolOutput = strings.Join(textParts, "\n")
+							if toolOutput == "" && hasImage {
+								toolOutput = "[Image attached]"
+							}
+						}
 						functionCallOutputMessage := `{"type":"function_call_output"}`
 						functionCallOutputMessage, _ = sjson.Set(functionCallOutputMessage, "call_id", messageContentResult.Get("tool_use_id").String())
-						functionCallOutputMessage, _ = sjson.Set(functionCallOutputMessage, "output", messageContentResult.Get("content").String())
+						functionCallOutputMessage, _ = sjson.Set(functionCallOutputMessage, "output", toolOutput)
 						appendInput(functionCallOutputMessage)
 					}
 				}

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -45,5 +46,55 @@ func TestConvertClaudeRequestToCodex_EmptyToolsOmitsToolChoice(t *testing.T) {
 	}
 	if tools := gjson.GetBytes(out, "tools"); tools.Exists() && len(tools.Array()) != 0 {
 		t.Fatalf("unexpected translated tools: %s", out)
+	}
+}
+
+func TestConvertClaudeRequestToCodex_MapsToolResultImageToVisionInput(t *testing.T) {
+	input := []byte(`{
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [{"type": "tool_use", "id": "call_read", "name": "Read", "input": {"file_path": "screenshot.png"}}]
+			},
+			{
+				"role": "user",
+				"content": [{
+					"type": "tool_result",
+					"tool_use_id": "call_read",
+					"content": [
+						{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGVsbG8="}}
+					]
+				}]
+			}
+		]
+	}`)
+
+	out := ConvertClaudeRequestToCodex("gpt-5.6-luna", input, true)
+	items := gjson.GetBytes(out, "input")
+	if !items.IsArray() || len(items.Array()) != 3 {
+		t.Fatalf("expected function call, output, and image message: %s", out)
+	}
+
+	functionOutput := items.Array()[1]
+	if got := functionOutput.Get("type").String(); got != "function_call_output" {
+		t.Fatalf("second input type = %q, want function_call_output", got)
+	}
+	if got := functionOutput.Get("output").String(); got != "[Image attached]" {
+		t.Fatalf("function output = %q, want image completion marker", got)
+	}
+	if strings.Contains(functionOutput.Get("output").String(), "aGVsbG8=") {
+		t.Fatalf("function output must not contain image Base64: %s", functionOutput.Raw)
+	}
+
+	imageMessage := items.Array()[2]
+	if got := imageMessage.Get("role").String(); got != "user" {
+		t.Fatalf("image message role = %q, want user", got)
+	}
+	image := imageMessage.Get("content.0")
+	if got := image.Get("type").String(); got != "input_image" {
+		t.Fatalf("image content type = %q, want input_image", got)
+	}
+	if got := image.Get("image_url").String(); got != "data:image/png;base64,aGVsbG8=" {
+		t.Fatalf("image URL = %q", got)
 	}
 }


### PR DESCRIPTION
## 问题

Claude Code 的 `Read` 工具返回图片时，转译器会把图片数据当作普通文本传递，造成上下文大小异常，一直显示 400 Your input exceeds the context window of this model，最初以为是模型的问题，不是的，是转发出问题了。。。

## 修复

- 工具结果中的图片改为视觉输入传递。
- 函数输出只保留文本内容；纯图片结果保留图片完成标记。
- 混合文本和图片的结果会同时保留。

## 验证

已验证通过。
