### PR TITLE
fix(models): 渠道分组编辑器可选中仅存在于模型库的模型

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -26,7 +26,7 @@
       },
       {
         "path": "internal/management/modelcatalog/availability.go",
-        "max_lines": 1188
+        "max_lines": 993
       },
       {
         "path": "internal/management/settings/providers/provider_keys_extended.go",

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
 	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
@@ -13,6 +12,11 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
+
+// defaultChannelGroupName is the implicit routing pool that every active,
+// non-prefixed account belongs to unless a group excludes it. It has no match
+// block in the routing config, so membership cannot be derived from match rules.
+const defaultChannelGroupName = "default"
 
 // AvailabilityFilterOptions tunes management model listing for specific UI paths.
 type AvailabilityFilterOptions struct {
@@ -530,7 +534,7 @@ func registryModelInfoAsOpenAIModel(info *registry.ModelInfo) map[string]any {
 
 func (s *Service) effectiveModels(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string, opts AvailabilityFilterOptions) []map[string]any {
 	filtered := s.filterModelsByScopes(models, allowedChannelsRaw, allowedGroupsRaw, opts)
-	return s.withScopedModelConfigRows(filtered, allowedChannelsRaw, allowedGroupsRaw)
+	return s.withScopedModelConfigRows(filtered, allowedChannelsRaw, allowedGroupsRaw, opts)
 }
 
 func (s *Service) filterModelsByScopes(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string, opts AvailabilityFilterOptions) []map[string]any {
@@ -574,8 +578,8 @@ func (s *Service) filterModelsByScopes(models []map[string]any, allowedChannelsR
 	return filtered
 }
 
-func (s *Service) withScopedModelConfigRows(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string) []map[string]any {
-	rows := s.scopedModelConfigRows(allowedChannelsRaw, allowedGroupsRaw)
+func (s *Service) withScopedModelConfigRows(models []map[string]any, allowedChannelsRaw, allowedGroupsRaw string, opts AvailabilityFilterOptions) []map[string]any {
+	rows := s.scopedModelConfigRows(allowedChannelsRaw, allowedGroupsRaw, opts)
 	if len(rows) == 0 {
 		return models
 	}
@@ -607,13 +611,20 @@ func (s *Service) withScopedModelConfigRows(models []map[string]any, allowedChan
 	return out
 }
 
-func (s *Service) scopedModelConfigRows(allowedChannelsRaw, allowedGroupsRaw string) []usage.ModelConfigRow {
+func (s *Service) scopedModelConfigRows(allowedChannelsRaw, allowedGroupsRaw string, opts AvailabilityFilterOptions) []usage.ModelConfigRow {
 	allowedGroups := internalrouting.ParseNormalizedSet(strings.TrimSpace(allowedGroupsRaw), internalrouting.NormalizeGroupName)
 	allowedChannels := parseScopedChannelList(allowedChannelsRaw)
 	if len(allowedGroups) == 0 && len(allowedChannels) == 0 {
 		return nil
 	}
 	ownerKeys, explicitModels := s.modelOwnerScope(allowedChannels, allowedGroups)
+	// The channel-group editor is where AllowedModels is edited, so that list must
+	// not narrow the very set it is picked from — otherwise a model can only be
+	// added to a group once it is already in the group (self-locking). Owner scope
+	// still applies, and plaza/catalog keep enforcing AllowedModels.
+	if opts.IgnoreGroupAllowedModels {
+		explicitModels = nil
+	}
 	if len(ownerKeys) == 0 && len(explicitModels) == 0 {
 		return nil
 	}
@@ -958,212 +969,6 @@ func parseScopedChannelList(value string) []string {
 		out = append(out, channel)
 	}
 	return out
-}
-
-func (s *Service) modelOwnerScope(channels []string, groups map[string]struct{}) (map[string]bool, map[string]struct{}) {
-	ownerMappings := s.authGroupOwnerMappingMap()
-	providerOwners := s.modelConfigOwnersBySource()
-	ownerKeys := make(map[string]bool)
-	explicitModels := make(map[string]struct{})
-	if s == nil {
-		return ownerKeys, explicitModels
-	}
-	auths := []*coreauth.Auth(nil)
-	if s.authManager != nil {
-		auths = s.authManager.ListForTenant(s.tenantID)
-	}
-	addOwnersForChannel := func(channel string) {
-		for _, owner := range ownersForChannel(channel, auths, ownerMappings, providerOwners) {
-			ownerKeys[owner] = true
-		}
-	}
-	addOwnersForAuth := func(auth *coreauth.Auth) {
-		for _, channel := range auth.ChannelIdentifiers() {
-			addOwnersForChannel(channel)
-		}
-	}
-	if routing := tenantRoutingConfig(s.tenantID, s.cfg); routing != nil {
-		for _, group := range routing.ChannelGroups {
-			groupName := internalrouting.NormalizeGroupName(group.Name)
-			if _, ok := groups[groupName]; !ok {
-				continue
-			}
-			for _, model := range group.AllowedModels {
-				model = strings.ToLower(strings.TrimSpace(model))
-				if model != "" {
-					explicitModels[model] = struct{}{}
-				}
-			}
-			for _, channel := range group.Match.Channels {
-				addOwnersForChannel(channel)
-			}
-			for _, auth := range auths {
-				if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
-					continue
-				}
-				if routingGroupMatchesAuthForModelScope(group, auth) {
-					addOwnersForAuth(auth)
-				}
-			}
-		}
-	}
-	if len(groups) == 0 {
-		for _, channel := range channels {
-			addOwnersForChannel(channel)
-		}
-	}
-	return ownerKeys, explicitModels
-}
-
-func routingGroupMatchesAuthForModelScope(group config.RoutingChannelGroup, auth *coreauth.Auth) bool {
-	if auth == nil {
-		return false
-	}
-	prefix := internalrouting.NormalizeGroupName(auth.Prefix)
-	for _, candidate := range group.Match.Prefixes {
-		if prefix != "" && prefix == internalrouting.NormalizeGroupName(candidate) {
-			return true
-		}
-	}
-	for _, channel := range group.Match.Channels {
-		if authChannelMatches(auth, channel) {
-			return true
-		}
-	}
-	return authMatchesRoutingTags(auth, group.Match.Tags)
-}
-
-func authMatchesRoutingTags(auth *coreauth.Auth, tags []string) bool {
-	if auth == nil || len(tags) == 0 {
-		return false
-	}
-	displayTags := make(map[string]struct{})
-	for _, tag := range managementauthfiles.BuildTagPayload(auth).DisplayTags {
-		normalized := config.NormalizeRoutingTag(tag)
-		if normalized != "" {
-			displayTags[normalized] = struct{}{}
-		}
-	}
-	if len(displayTags) == 0 {
-		return false
-	}
-	for _, tag := range tags {
-		if _, ok := displayTags[config.NormalizeRoutingTag(tag)]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-func (s *Service) authGroupOwnerMappingMap() map[string]string {
-	rows := modelconfigsettings.ListAuthGroupOwnerMappingsForTenant(s.tenantID)
-	out := make(map[string]string, len(rows))
-	for _, row := range rows {
-		authGroup := normalizeAuthGroupKey(row.AuthGroup)
-		owner := normalizeModelOwnerKey(row.Owner)
-		if authGroup == "" || owner == "" {
-			continue
-		}
-		out[authGroup] = owner
-	}
-	return out
-}
-
-func (s *Service) modelConfigOwnersBySource() map[string][]string {
-	rows := modelconfigsettings.ListAllConfigsForTenant(s.tenantID)
-	ownersBySource := make(map[string]map[string]struct{})
-	for _, row := range rows {
-		if !row.Enabled {
-			continue
-		}
-		source := normalizeAuthGroupKey(row.Source)
-		owner := normalizeModelOwnerKey(row.OwnedBy)
-		if source == "" || owner == "" {
-			continue
-		}
-		if ownersBySource[source] == nil {
-			ownersBySource[source] = make(map[string]struct{})
-		}
-		ownersBySource[source][owner] = struct{}{}
-	}
-	out := make(map[string][]string, len(ownersBySource))
-	for source, owners := range ownersBySource {
-		for owner := range owners {
-			out[source] = append(out[source], owner)
-		}
-	}
-	return out
-}
-
-func ownersForChannel(channel string, auths []*coreauth.Auth, ownerMappings map[string]string, providerOwners map[string][]string) []string {
-	channel = strings.TrimSpace(channel)
-	if channel == "" {
-		return nil
-	}
-	owners := make(map[string]bool)
-	addMappedOwner := func(value string) {
-		key := normalizeAuthGroupKey(value)
-		if key == "" {
-			return
-		}
-		if owner := ownerMappings[key]; owner != "" {
-			owners[owner] = true
-		}
-	}
-	addProviderOwners := func(value string) {
-		key := normalizeAuthGroupKey(value)
-		if key == "" {
-			return
-		}
-		for _, owner := range providerOwners[key] {
-			if owner != "" {
-				owners[owner] = true
-			}
-		}
-	}
-	addMappedOwner(channel)
-	addProviderOwners(channel)
-	for _, auth := range auths {
-		if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
-			continue
-		}
-		if !authChannelMatches(auth, channel) {
-			continue
-		}
-		addMappedOwner(auth.Provider)
-		addMappedOwner(auth.ChannelName())
-		addProviderOwners(auth.Provider)
-		addProviderOwners(auth.ChannelName())
-		for _, identifier := range auth.ChannelIdentifiers() {
-			addMappedOwner(identifier)
-			addProviderOwners(identifier)
-		}
-	}
-	out := make([]string, 0, len(owners))
-	for owner := range owners {
-		out = append(out, owner)
-	}
-	return out
-}
-
-func authChannelMatches(auth *coreauth.Auth, channel string) bool {
-	if auth == nil {
-		return false
-	}
-	for _, identifier := range auth.ChannelIdentifiers() {
-		if strings.EqualFold(strings.TrimSpace(identifier), channel) {
-			return true
-		}
-	}
-	return false
-}
-
-func normalizeAuthGroupKey(value string) string {
-	return strings.ToLower(strings.TrimSpace(value))
-}
-
-func normalizeModelOwnerKey(value string) string {
-	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), "-"))
 }
 
 func modelConfigRowAsOpenAIModel(row usage.ModelConfigRow) map[string]any {

--- a/internal/management/modelcatalog/availability_owner_scope.go
+++ b/internal/management/modelcatalog/availability_owner_scope.go
@@ -1,0 +1,234 @@
+package modelcatalog
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
+	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
+	internalrouting "github.com/router-for-me/CLIProxyAPI/v6/internal/routing"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// Model owner scope: resolves which model owners a channel/group selection maps
+// to, so DB-backed catalog rows can be scoped the same way registry models are.
+
+func (s *Service) modelOwnerScope(channels []string, groups map[string]struct{}) (map[string]bool, map[string]struct{}) {
+	ownerMappings := s.authGroupOwnerMappingMap()
+	providerOwners := s.modelConfigOwnersBySource()
+	ownerKeys := make(map[string]bool)
+	explicitModels := make(map[string]struct{})
+	if s == nil {
+		return ownerKeys, explicitModels
+	}
+	auths := []*coreauth.Auth(nil)
+	if s.authManager != nil {
+		auths = s.authManager.ListForTenant(s.tenantID)
+	}
+	addOwnersForChannel := func(channel string) {
+		for _, owner := range ownersForChannel(channel, auths, ownerMappings, providerOwners) {
+			ownerKeys[owner] = true
+		}
+	}
+	addOwnersForAuth := func(auth *coreauth.Auth) {
+		for _, channel := range auth.ChannelIdentifiers() {
+			addOwnersForChannel(channel)
+		}
+	}
+	if routing := tenantRoutingConfig(s.tenantID, s.cfg); routing != nil {
+		for _, group := range routing.ChannelGroups {
+			groupName := internalrouting.NormalizeGroupName(group.Name)
+			if _, ok := groups[groupName]; !ok {
+				continue
+			}
+			for _, model := range group.AllowedModels {
+				model = strings.ToLower(strings.TrimSpace(model))
+				if model != "" {
+					explicitModels[model] = struct{}{}
+				}
+			}
+			for _, channel := range group.Match.Channels {
+				addOwnersForChannel(channel)
+			}
+			for _, auth := range auths {
+				if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+					continue
+				}
+				if routingGroupMatchesAuthForModelScope(group, auth) {
+					addOwnersForAuth(auth)
+				}
+			}
+		}
+	}
+	if len(groups) == 0 {
+		for _, channel := range channels {
+			addOwnersForChannel(channel)
+		}
+	}
+	// The default pool is not a configured group with match rules, so the loop
+	// above resolves no accounts for it and its DB-backed catalog rows would never
+	// find an owner. Ask the auth manager instead, which owns the membership rule
+	// (include-default-group, prefixed accounts, exclude-from-default).
+	if _, wantsDefault := groups[defaultChannelGroupName]; wantsDefault && s.authManager != nil {
+		for _, auth := range auths {
+			if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+				continue
+			}
+			if _, inPool := s.authManager.ChannelGroupsForAuthForTenant(s.tenantID, auth)[defaultChannelGroupName]; inPool {
+				addOwnersForAuth(auth)
+			}
+		}
+	}
+	return ownerKeys, explicitModels
+}
+
+func routingGroupMatchesAuthForModelScope(group config.RoutingChannelGroup, auth *coreauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	prefix := internalrouting.NormalizeGroupName(auth.Prefix)
+	for _, candidate := range group.Match.Prefixes {
+		if prefix != "" && prefix == internalrouting.NormalizeGroupName(candidate) {
+			return true
+		}
+	}
+	for _, channel := range group.Match.Channels {
+		if authChannelMatches(auth, channel) {
+			return true
+		}
+	}
+	return authMatchesRoutingTags(auth, group.Match.Tags)
+}
+
+func authMatchesRoutingTags(auth *coreauth.Auth, tags []string) bool {
+	if auth == nil || len(tags) == 0 {
+		return false
+	}
+	displayTags := make(map[string]struct{})
+	for _, tag := range managementauthfiles.BuildTagPayload(auth).DisplayTags {
+		normalized := config.NormalizeRoutingTag(tag)
+		if normalized != "" {
+			displayTags[normalized] = struct{}{}
+		}
+	}
+	if len(displayTags) == 0 {
+		return false
+	}
+	for _, tag := range tags {
+		if _, ok := displayTags[config.NormalizeRoutingTag(tag)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) authGroupOwnerMappingMap() map[string]string {
+	rows := modelconfigsettings.ListAuthGroupOwnerMappingsForTenant(s.tenantID)
+	out := make(map[string]string, len(rows))
+	for _, row := range rows {
+		authGroup := normalizeAuthGroupKey(row.AuthGroup)
+		owner := normalizeModelOwnerKey(row.Owner)
+		if authGroup == "" || owner == "" {
+			continue
+		}
+		out[authGroup] = owner
+	}
+	return out
+}
+
+func (s *Service) modelConfigOwnersBySource() map[string][]string {
+	rows := modelconfigsettings.ListAllConfigsForTenant(s.tenantID)
+	ownersBySource := make(map[string]map[string]struct{})
+	for _, row := range rows {
+		if !row.Enabled {
+			continue
+		}
+		source := normalizeAuthGroupKey(row.Source)
+		owner := normalizeModelOwnerKey(row.OwnedBy)
+		if source == "" || owner == "" {
+			continue
+		}
+		if ownersBySource[source] == nil {
+			ownersBySource[source] = make(map[string]struct{})
+		}
+		ownersBySource[source][owner] = struct{}{}
+	}
+	out := make(map[string][]string, len(ownersBySource))
+	for source, owners := range ownersBySource {
+		for owner := range owners {
+			out[source] = append(out[source], owner)
+		}
+	}
+	return out
+}
+
+func ownersForChannel(channel string, auths []*coreauth.Auth, ownerMappings map[string]string, providerOwners map[string][]string) []string {
+	channel = strings.TrimSpace(channel)
+	if channel == "" {
+		return nil
+	}
+	owners := make(map[string]bool)
+	addMappedOwner := func(value string) {
+		key := normalizeAuthGroupKey(value)
+		if key == "" {
+			return
+		}
+		if owner := ownerMappings[key]; owner != "" {
+			owners[owner] = true
+		}
+	}
+	addProviderOwners := func(value string) {
+		key := normalizeAuthGroupKey(value)
+		if key == "" {
+			return
+		}
+		for _, owner := range providerOwners[key] {
+			if owner != "" {
+				owners[owner] = true
+			}
+		}
+	}
+	addMappedOwner(channel)
+	addProviderOwners(channel)
+	for _, auth := range auths {
+		if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+			continue
+		}
+		if !authChannelMatches(auth, channel) {
+			continue
+		}
+		addMappedOwner(auth.Provider)
+		addMappedOwner(auth.ChannelName())
+		addProviderOwners(auth.Provider)
+		addProviderOwners(auth.ChannelName())
+		for _, identifier := range auth.ChannelIdentifiers() {
+			addMappedOwner(identifier)
+			addProviderOwners(identifier)
+		}
+	}
+	out := make([]string, 0, len(owners))
+	for owner := range owners {
+		out = append(out, owner)
+	}
+	return out
+}
+
+func authChannelMatches(auth *coreauth.Auth, channel string) bool {
+	if auth == nil {
+		return false
+	}
+	for _, identifier := range auth.ChannelIdentifiers() {
+		if strings.EqualFold(strings.TrimSpace(identifier), channel) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeAuthGroupKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeModelOwnerKey(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), "-"))
+}

--- a/internal/management/modelcatalog/availability_test.go
+++ b/internal/management/modelcatalog/availability_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
+	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -847,4 +848,144 @@ func containsModelID(ids []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func modelsResultIDSet(t *testing.T, result map[string]any) map[string]struct{} {
+	t.Helper()
+	data, ok := result["data"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models data = %#v, want []map[string]any", result["data"])
+	}
+	out := make(map[string]struct{}, len(data))
+	for _, entry := range data {
+		if id, _ := entry["id"].(string); id != "" {
+			out[id] = struct{}{}
+		}
+	}
+	return out
+}
+
+// seedOwnerMappedCatalogRows registers two enabled catalog rows for the same
+// owner: one already on a group's allow-list and one that is not.
+func seedOwnerMappedCatalogRows(t *testing.T, tenantID, listed, unlisted string) {
+	t.Helper()
+	for _, modelID := range []string{listed, unlisted} {
+		if err := usage.UpsertModelConfigForTenant(tenantID, usage.ModelConfigRow{
+			ModelID:     modelID,
+			OwnedBy:     "grok-build",
+			Enabled:     true,
+			PricingMode: "token",
+			Source:      "seed",
+		}); err != nil {
+			t.Fatalf("UpsertModelConfigForTenant(%s) error = %v", modelID, err)
+		}
+	}
+	if _, err := modelconfigsettings.UpsertAuthGroupOwnerMappingForTenant(tenantID, "xai", "grok-build"); err != nil {
+		t.Fatalf("UpsertAuthGroupOwnerMappingForTenant() error = %v", err)
+	}
+}
+
+func TestModelsDefaultGroupEditorListsOwnerMappedConfigRows(t *testing.T) {
+	// Regression: a DB-only catalog model could never be added to the system
+	// default group. `default` carries no match block, so owner scope resolved no
+	// accounts for it, and the group's own AllowedModels additionally filtered the
+	// catalog rows the editor picks from — the model had to already be in the
+	// group to become selectable.
+	initModelCatalogTestDB(t)
+
+	const (
+		tenantID = "11111111-2222-3333-4444-555555555555"
+		authID   = "default-pool-xai-auth"
+		listed   = "editor-scope-listed-model"
+		unlisted = "editor-scope-unlisted-model"
+	)
+	seedOwnerMappedCatalogRows(t, tenantID, listed, unlisted)
+
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{Name: "default", AllowedModels: []string{listed}},
+			},
+		},
+	}
+	// Non-system tenants keep routing in the DB, which is what the service reads.
+	if err := usage.UpsertRoutingConfigForTenant(tenantID, cfg.Routing); err != nil {
+		t.Fatalf("UpsertRoutingConfigForTenant() error = %v", err)
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfigForTenant(tenantID, cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: authID, TenantID: tenantID, Provider: "xai", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	svc := NewForTenant(tenantID, cfg, manager)
+
+	editor := modelsResultIDSet(t, svc.Models("", "default", AvailabilityFilterOptions{IgnoreGroupAllowedModels: true}))
+	if _, ok := editor[unlisted]; !ok {
+		t.Fatalf("editor models = %v, want %q selectable", editor, unlisted)
+	}
+	if _, ok := editor[listed]; !ok {
+		t.Fatalf("editor models = %v, want %q", editor, listed)
+	}
+
+	// Plaza/catalog must still enforce the saved allow-list.
+	enforced := modelsResultIDSet(t, svc.Models("", "default"))
+	if _, ok := enforced[unlisted]; ok {
+		t.Fatalf("enforced models = %v, must not include %q", enforced, unlisted)
+	}
+	if _, ok := enforced[listed]; !ok {
+		t.Fatalf("enforced models = %v, want %q", enforced, listed)
+	}
+}
+
+func TestModelsNamedGroupEditorIgnoresAllowedModelsForConfigRows(t *testing.T) {
+	// IgnoreGroupAllowedModels must reach the catalog-row branch for named groups
+	// too: the editor picks from this list to edit AllowedModels, so AllowedModels
+	// cannot be what defines it.
+	initModelCatalogTestDB(t)
+
+	const (
+		tenantID  = "22222222-3333-4444-5555-666666666666"
+		authID    = "named-group-xai-auth"
+		groupName = "grok build"
+		listed    = "named-scope-listed-model"
+		unlisted  = "named-scope-unlisted-model"
+	)
+	seedOwnerMappedCatalogRows(t, tenantID, listed, unlisted)
+
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []config.RoutingChannelGroup{
+				{
+					Name:          groupName,
+					Match:         config.ChannelGroupMatch{Channels: []string{"xai"}},
+					AllowedModels: []string{listed},
+				},
+			},
+		},
+	}
+	if err := usage.UpsertRoutingConfigForTenant(tenantID, cfg.Routing); err != nil {
+		t.Fatalf("UpsertRoutingConfigForTenant() error = %v", err)
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfigForTenant(tenantID, cfg)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: authID, TenantID: tenantID, Provider: "xai", Status: coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	svc := NewForTenant(tenantID, cfg, manager)
+
+	editor := modelsResultIDSet(t, svc.Models("", groupName, AvailabilityFilterOptions{IgnoreGroupAllowedModels: true}))
+	if _, ok := editor[unlisted]; !ok {
+		t.Fatalf("editor models = %v, want %q selectable", editor, unlisted)
+	}
+
+	enforced := modelsResultIDSet(t, svc.Models("", groupName))
+	if _, ok := enforced[unlisted]; ok {
+		t.Fatalf("enforced models = %v, must not include %q", enforced, unlisted)
+	}
 }

--- a/sdk/cliproxy/auth/routing_groups.go
+++ b/sdk/cliproxy/auth/routing_groups.go
@@ -64,6 +64,18 @@ func (m *Manager) KnownChannelGroupsForTenant(tenantID string) map[string]struct
 	return out
 }
 
+// ChannelGroupsForAuthForTenant returns the channel groups auth belongs to under
+// the tenant's routing config, including the implicit "default" pool.
+// Management model scoping must use the same membership rule routing uses; the
+// default pool carries no match rules, so callers cannot re-derive it from the
+// routing config without duplicating (and drifting from) this logic.
+func (m *Manager) ChannelGroupsForAuthForTenant(tenantID string, auth *Auth) map[string]struct{} {
+	if m == nil || auth == nil {
+		return nil
+	}
+	return authGroups(m.currentRuntimeConfigForTenant(normalizedTenantID(tenantID)), auth)
+}
+
 // ServeModelScopeOptions tunes CanServeModelWithScopes* for management UI paths.
 type ServeModelScopeOptions struct {
 	// IgnoreGroupAllowedModels skips channel-group AllowedModels checks so the


### PR DESCRIPTION
## 问题

管理端「渠道分组 → 系统默认」的模型选择器列不出只存在于 `model_configs`、没有运行时注册来源的模型，因此这类模型无法被加入分组白名单。线上复现租户里，`grok-4.5` / `grok-imagine-*`（有 registry 来源）能选，同为归属分组 `grok-build` 的纯目录行则完全不出现。

两个原因叠加：

1. `effectiveModels` 没有把 `AvailabilityFilterOptions` 传给 `withScopedModelConfigRows`，于是 `ignore_group_allowed_models` 管不到模型库行这条支路。分组自身的 `allowed-models` 反过来过滤了它自己被编辑的候选集 —— 模型必须已经在分组里，才可能被加进分组（自锁）。
2. `modelOwnerScope` 只按 `match` 规则匹配账号，而 `default` 池没有 match 块，解析不出任何 owner，模型库行永远进不了系统默认分组。

## 改动

- 编辑器路径（`ignore_group_allowed_models=1`）忽略分组 `allowed-models` 对模型库行的过滤；plaza / catalog 仍照常执行白名单。
- `default` 池成员改为向 auth 包查询：新增 `Manager.ChannelGroupsForAuthForTenant`，复用路由自身的归属规则（include-default-group、prefix 账号、exclude-from-default），避免在管理端复制一份会与路由漂移的判定。
- 结构债门禁：改动后 `availability.go` 达 1214 行，超过 1200 上限。按规范拆分而不是放宽门禁 —— owner 解析整块移入新文件 `availability_owner_scope.go`（234 行），主文件 1188 → 993 行，并把基线从 1188 锁到 993。未改动其它文件的基线。

## 影响范围

- 目录：`internal/management/modelcatalog/`、`sdk/cliproxy/auth/`
- 不涉及 `codeProxy`：后端返回修正后，前端现有取交集逻辑即可正确展示。
- 运行时路由与模型可调用性不变：本 PR 只影响管理端可见 / 可配置范围。模型库里没有运行时来源的模型即使被勾选，调用行为与本次改动前一致。

## 验证

- 新增两个回归测试，均为先红后绿：
  - `TestModelsDefaultGroupEditorListsOwnerMappedConfigRows` —— 系统默认分组编辑器可列出不在 allowed-models 里的归属模型，同时断言非编辑器路径仍执行白名单。
  - `TestModelsNamedGroupEditorIgnoresAllowedModelsForConfigRows` —— 具名分组同理。
- `./scripts/ci-pr.sh` 本地完整通过（结构检查、gofmt、secret scan、`go vet`、`go test ./...`、golangci-lint、`go build`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)