### PR TITLE
feat(models): 模型库新增的 model id 立即可路由到对应账号

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -43,7 +43,7 @@ type Handler struct {
 	logDir               string
 	postAuthHook         coreauth.PostAuthHook
 	onConfigMutated      func(*config.Config)
-	onModelConfigMutated func()
+	onModelConfigMutated func(tenantID string)
 	startTime            time.Time
 	accessManager        *sdkaccess.Manager
 	trendCacheMu         sync.Mutex
@@ -142,7 +142,7 @@ func (h *Handler) SetAuthManager(manager *coreauth.Manager) {
 
 func (h *Handler) SetConfigMutatedHook(fn func(*config.Config)) { h.onConfigMutated = fn }
 
-func (h *Handler) SetModelConfigMutatedHook(fn func()) { h.onModelConfigMutated = fn }
+func (h *Handler) SetModelConfigMutatedHook(fn func(tenantID string)) { h.onModelConfigMutated = fn }
 
 // SetAccessManager wires the request authentication access manager so management writes
 // (such as API key channel/model restrictions) can be applied immediately at runtime.

--- a/internal/api/handlers/management/models.go
+++ b/internal/api/handlers/management/models.go
@@ -221,6 +221,9 @@ func (h *ModelsHandler) PatchAuthGroupModelOwnerMapping(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	// The mapping decides which catalog models a credential can serve, so it must
+	// trigger re-registration just like editing the models themselves.
+	h.notifyModelConfigMutated(c)
 	c.JSON(http.StatusOK, payload)
 }
 
@@ -287,12 +290,14 @@ func (h *ModelsHandler) PostOpenRouterModelSyncRun(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "result": result, "state": state})
 }
 
+// notifyModelConfigMutated asks the runtime to re-register credential models for
+// the tenant whose catalog just changed. It used to fire for the system tenant
+// only, which matched registration reading just that tenant's library; now that
+// registration is tenant-scoped, every tenant must be able to trigger it, or a
+// newly added model id would stay unroutable until the next refresh cycle.
 func (h *ModelsHandler) notifyModelConfigMutated(c *gin.Context) {
-	if effectiveTenantID(c) != identity.SystemTenantID {
-		return
-	}
 	if h == nil || h.Handler == nil || h.onModelConfigMutated == nil {
 		return
 	}
-	h.onModelConfigMutated()
+	h.onModelConfigMutated(effectiveTenantID(c))
 }

--- a/internal/api/handlers/management/models_test.go
+++ b/internal/api/handlers/management/models_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -114,7 +115,11 @@ func TestModelConfigHandlersNotifyModelConfigMutation(t *testing.T) {
 	initManagementModelsTestDB(t)
 	h := NewHandler(&config.Config{}, "", nil)
 	notifications := 0
-	h.SetModelConfigMutatedHook(func() { notifications++ })
+	notifiedTenants := []string{}
+	h.SetModelConfigMutatedHook(func(tenantID string) {
+		notifications++
+		notifiedTenants = append(notifiedTenants, tenantID)
+	})
 
 	createBody := []byte(`{"id":"notify-model","owned_by":"codex","enabled":true}`)
 	createRec := performModelsRequest(http.MethodPost, "/model-configs", createBody, h.Models().PostModelConfig)
@@ -1278,5 +1283,37 @@ func TestOpenRouterModelSyncHandlersConfigureAndRun(t *testing.T) {
 	getRec := performModelsRequest(http.MethodGet, "/model-openrouter-sync", nil, h.Models().GetOpenRouterModelSync)
 	if getRec.Code != http.StatusOK {
 		t.Fatalf("GetOpenRouterModelSync status = %d body = %s", getRec.Code, getRec.Body.String())
+	}
+}
+
+func TestModelConfigHandlersNotifyNonSystemTenantMutation(t *testing.T) {
+	// The runtime re-registers a tenant's credential models from this hook. It
+	// used to fire for the system tenant only, so a model added by any other
+	// tenant stayed unroutable until the next refresh cycle.
+	initManagementModelsTestDB(t)
+	h := NewHandler(&config.Config{}, "", nil)
+	var notifiedTenants []string
+	h.SetModelConfigMutatedHook(func(tenantID string) {
+		notifiedTenants = append(notifiedTenants, tenantID)
+	})
+
+	const tenantID = "cccccccc-1111-2222-3333-444444444444"
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/model-configs",
+		bytes.NewReader([]byte(`{"id":"tenant-scoped-model","owned_by":"grok-build","enabled":true}`)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(managementPrincipalKey, identity.Principal{
+		EffectiveTenant: identity.Tenant{ID: tenantID},
+	})
+
+	h.Models().PostModelConfig(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PostModelConfig status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if len(notifiedTenants) != 1 || notifiedTenants[0] != tenantID {
+		t.Fatalf("notified tenants = %v, want [%s]", notifiedTenants, tenantID)
 	}
 }

--- a/internal/api/options.go
+++ b/internal/api/options.go
@@ -23,7 +23,7 @@ type serverOptionConfig struct {
 	keepAliveOnTimeout         func()
 	postAuthHook               auth.PostAuthHook
 	configMutatedCallback      func(*config.Config)
-	modelConfigMutatedCallback func()
+	modelConfigMutatedCallback func(tenantID string)
 }
 
 // ServerOption customises HTTP server construction.
@@ -97,7 +97,7 @@ func WithConfigMutatedCallback(fn func(*config.Config)) ServerOption {
 	}
 }
 
-func WithModelConfigMutatedCallback(fn func()) ServerOption {
+func WithModelConfigMutatedCallback(fn func(tenantID string)) ServerOption {
 	return func(cfg *serverOptionConfig) {
 		cfg.modelConfigMutatedCallback = fn
 	}

--- a/internal/api/sdkbridge/bridge.go
+++ b/internal/api/sdkbridge/bridge.go
@@ -88,7 +88,7 @@ func WithConfigMutatedCallback(fn func(*sdkconfig.Config)) ServerOption {
 	return coreapi.WithConfigMutatedCallback(fn)
 }
 
-func WithModelConfigMutatedCallback(fn func()) ServerOption {
+func WithModelConfigMutatedCallback(fn func(tenantID string)) ServerOption {
 	return coreapi.WithModelConfigMutatedCallback(fn)
 }
 

--- a/internal/app/service/model_catalog_scope_test.go
+++ b/internal/app/service/model_catalog_scope_test.go
@@ -1,0 +1,66 @@
+package serviceapp
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
+	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func initCatalogScopeTestDB(t *testing.T) {
+	t.Helper()
+	internalusage.CloseDB()
+	if err := internalusage.InitDB(filepath.Join(t.TempDir(), "usage.db"), internalconfig.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	t.Cleanup(internalusage.CloseDB)
+}
+
+func TestOAuthCatalogScopeIsTenantIsolated(t *testing.T) {
+	// Credential registration used to read the system tenant's model library only,
+	// so a model added by any other tenant never became routable for that tenant's
+	// own accounts.
+	initCatalogScopeTestDB(t)
+
+	const (
+		tenantA = "aaaaaaaa-1111-2222-3333-444444444444"
+		tenantB = "bbbbbbbb-1111-2222-3333-444444444444"
+	)
+	if err := internalusage.UpsertModelConfigForTenant(tenantA, internalusage.ModelConfigRow{
+		ModelID: "grok-4.7", OwnedBy: "grok-build", Source: "seed", Enabled: true, PricingMode: "token",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant(A) error = %v", err)
+	}
+	if err := internalusage.UpsertModelConfigForTenant(tenantB, internalusage.ModelConfigRow{
+		ModelID: "other-tenant-model", OwnedBy: "grok-build", Source: "seed", Enabled: true, PricingMode: "token",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfigForTenant(B) error = %v", err)
+	}
+	if _, err := modelconfigsettings.UpsertAuthGroupOwnerMappingForTenant(tenantA, "xai", "grok-build"); err != nil {
+		t.Fatalf("UpsertAuthGroupOwnerMappingForTenant() error = %v", err)
+	}
+
+	rows := ListOAuthProviderModelConfigRowsForTenant(tenantA)
+	ids := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		ids[row.ModelID] = struct{}{}
+	}
+	if _, ok := ids["grok-4.7"]; !ok {
+		t.Fatalf("tenant A rows = %v, want its own catalog model", ids)
+	}
+	if _, ok := ids["other-tenant-model"]; ok {
+		t.Fatalf("tenant A rows = %v, must not see another tenant's catalog", ids)
+	}
+
+	owners := ListModelOwnersForAuthGroupsForTenant(tenantA, []string{"xai", "unmapped-channel"})
+	if len(owners) != 1 || owners[0] != "grok-build" {
+		t.Fatalf("tenant A owners = %v, want [grok-build]", owners)
+	}
+	// Tenant B never created the mapping, so its accounts must not inherit it.
+	if owners := ListModelOwnersForAuthGroupsForTenant(tenantB, []string{"xai"}); len(owners) != 0 {
+		t.Fatalf("tenant B owners = %v, want none", owners)
+	}
+}

--- a/internal/app/service/runtime_access.go
+++ b/internal/app/service/runtime_access.go
@@ -2,6 +2,7 @@ package serviceapp
 
 import (
 	"context"
+	"strings"
 
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
@@ -39,7 +40,15 @@ func ApplyTenantRuntimeConfigs(base *config.Config, manager *coreauth.Manager) {
 }
 
 func ListOAuthProviderModelConfigRows() []OAuthProviderModelConfigRow {
-	rows := modelconfigsettings.ListAllConfigs()
+	return ListOAuthProviderModelConfigRowsForTenant("")
+}
+
+// ListOAuthProviderModelConfigRowsForTenant reads the model library of the
+// tenant that owns the credential being registered. Registration used to read
+// the system tenant only, so catalog models added by any other tenant never
+// became routable for that tenant's accounts.
+func ListOAuthProviderModelConfigRowsForTenant(tenantID string) []OAuthProviderModelConfigRow {
+	rows := modelconfigsettings.ListAllConfigsForTenant(tenantID)
 	if len(rows) == 0 {
 		return nil
 	}
@@ -54,6 +63,48 @@ func ListOAuthProviderModelConfigRows() []OAuthProviderModelConfigRow {
 		})
 	}
 	return out
+}
+
+// ListModelOwnersForAuthGroupsForTenant returns the model owners a tenant has
+// mapped onto the given auth-group identifiers (provider, channel name, channel
+// identifiers). Operators express "these catalog models belong to this channel"
+// through that mapping, so registration must honour it instead of relying only
+// on the built-in provider→owner aliases.
+func ListModelOwnersForAuthGroupsForTenant(tenantID string, authGroups []string) []string {
+	if len(authGroups) == 0 {
+		return nil
+	}
+	mappings := modelconfigsettings.ListAuthGroupOwnerMappingsForTenant(tenantID)
+	if len(mappings) == 0 {
+		return nil
+	}
+	byGroup := make(map[string]string, len(mappings))
+	for _, row := range mappings {
+		group := normalizeOwnerScopeKey(row.AuthGroup)
+		owner := strings.TrimSpace(row.Owner)
+		if group == "" || owner == "" {
+			continue
+		}
+		byGroup[group] = owner
+	}
+	seen := make(map[string]struct{}, len(authGroups))
+	out := make([]string, 0, len(authGroups))
+	for _, group := range authGroups {
+		owner := byGroup[normalizeOwnerScopeKey(group)]
+		if owner == "" {
+			continue
+		}
+		if _, exists := seen[owner]; exists {
+			continue
+		}
+		seen[owner] = struct{}{}
+		out = append(out, owner)
+	}
+	return out
+}
+
+func normalizeOwnerScopeKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }
 
 func ConfigureServiceAccess(cfg *config.Config, accessManager *sdkaccess.Manager) {

--- a/sdk/api/options.go
+++ b/sdk/api/options.go
@@ -103,7 +103,7 @@ func WithConfigMutatedCallback(fn func(*config.Config)) ServerOption {
 }
 
 // WithModelConfigMutatedCallback registers a callback invoked after management-side model catalog mutations.
-func WithModelConfigMutatedCallback(fn func()) ServerOption {
+func WithModelConfigMutatedCallback(fn func(tenantID string)) ServerOption {
 	return apisdkbridge.WithModelConfigMutatedCallback(fn)
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -43,6 +43,9 @@ type Service struct {
 	// hooks provides lifecycle callbacks.
 	hooks Hooks
 
+	// catalogRefresh coalesces model-library driven credential re-registration.
+	catalogRefresh catalogRefreshState
+
 	// serverOptions contains additional server configuration options.
 	serverOptions []api.ServerOption
 

--- a/sdk/cliproxy/service_app_bridge.go
+++ b/sdk/cliproxy/service_app_bridge.go
@@ -8,8 +8,8 @@ import (
 	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
 )
 
-func listOAuthProviderModelConfigRows() []oauthProviderModelConfigRow {
-	rows := serviceapp.ListOAuthProviderModelConfigRows()
+func listOAuthProviderModelConfigRowsForTenant(tenantID string) []oauthProviderModelConfigRow {
+	rows := serviceapp.ListOAuthProviderModelConfigRowsForTenant(tenantID)
 	if len(rows) == 0 {
 		return nil
 	}

--- a/sdk/cliproxy/service_model_catalog_refresh.go
+++ b/sdk/cliproxy/service_model_catalog_refresh.go
@@ -1,0 +1,88 @@
+package cliproxy
+
+import (
+	"context"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// catalogRefreshState coalesces model-library driven re-registrations per tenant.
+//
+// Re-registration re-reads the library and, for live-discovery providers, talks
+// to the upstream. That is far too slow to run inline on the management save
+// request, and a burst of edits must not fan out into a burst of upstream calls:
+// while a tenant refresh is running, further changes only set a "run once more"
+// flag, so every edit is still reflected by the final pass.
+type catalogRefreshState struct {
+	mu      sync.Mutex
+	running map[string]bool
+	pending map[string]bool
+}
+
+// begin reports whether the caller should start a refresh loop for tenantID.
+func (c *catalogRefreshState) begin(tenantID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.running == nil {
+		c.running = make(map[string]bool)
+		c.pending = make(map[string]bool)
+	}
+	if c.running[tenantID] {
+		c.pending[tenantID] = true
+		return false
+	}
+	c.running[tenantID] = true
+	return true
+}
+
+// finish reports whether another pass is required because changes landed while
+// the previous one was running.
+func (c *catalogRefreshState) finish(tenantID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.pending[tenantID] {
+		delete(c.pending, tenantID)
+		return true
+	}
+	delete(c.running, tenantID)
+	return false
+}
+
+func (s *Service) onModelCatalogChanged(tenantID string) {
+	if s == nil || s.coreManager == nil {
+		return
+	}
+	if !s.catalogRefresh.begin(tenantID) {
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("model catalog refresh panicked: tenant=%q err=%v", tenantID, r)
+				s.catalogRefresh.finish(tenantID)
+			}
+		}()
+		for {
+			s.refreshRegisteredModelsForTenant(context.Background(), tenantID)
+			if !s.catalogRefresh.finish(tenantID) {
+				return
+			}
+		}
+	}()
+}
+
+// refreshRegisteredModelsForTenant re-registers every credential of one tenant.
+// An empty tenant id means the system tenant, which is how single-tenant
+// deployments and CLI usage store their credentials.
+func (s *Service) refreshRegisteredModelsForTenant(ctx context.Context, tenantID string) {
+	if s == nil || s.coreManager == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for _, auth := range s.coreManager.ListForTenant(tenantID) {
+		s.registerModelsForAuth(ctx, auth)
+	}
+}

--- a/sdk/cliproxy/service_model_catalog_refresh_test.go
+++ b/sdk/cliproxy/service_model_catalog_refresh_test.go
@@ -1,0 +1,33 @@
+package cliproxy
+
+import "testing"
+
+func TestCatalogRefreshStateCoalescesConcurrentChanges(t *testing.T) {
+	var state catalogRefreshState
+
+	if !state.begin("tenant-a") {
+		t.Fatal("first change should start a refresh")
+	}
+	// Edits landing while a refresh runs must not spawn a second upstream sweep.
+	if state.begin("tenant-a") {
+		t.Fatal("second change should not start a concurrent refresh")
+	}
+	// A different tenant is independent.
+	if !state.begin("tenant-b") {
+		t.Fatal("other tenant should refresh independently")
+	}
+	// ...but the coalesced change must still be picked up by one more pass.
+	if !state.finish("tenant-a") {
+		t.Fatal("pending change should require another pass")
+	}
+	if state.finish("tenant-a") {
+		t.Fatal("no pending change left; refresh should stop")
+	}
+	if state.finish("tenant-b") {
+		t.Fatal("tenant-b had no pending change")
+	}
+	// After finishing, a later change starts a fresh refresh.
+	if !state.begin("tenant-a") {
+		t.Fatal("change after completion should start a new refresh")
+	}
+}

--- a/sdk/cliproxy/service_model_catalog_routing_test.go
+++ b/sdk/cliproxy/service_model_catalog_routing_test.go
@@ -1,0 +1,81 @@
+package cliproxy
+
+import "testing"
+
+func modelIDs(models []*ModelInfo) []string {
+	out := make([]string, 0, len(models))
+	for _, model := range models {
+		if model != nil {
+			out = append(out, model.ID)
+		}
+	}
+	return out
+}
+
+func TestAppendOAuthProviderModelConfigsUsesTenantOwnerMapping(t *testing.T) {
+	// Operators attach catalog models to a channel through the tenant's
+	// auth-group→owner mapping (e.g. xai → grok-build). Before, only the built-in
+	// provider aliases counted, so a freshly added model id stayed unroutable and
+	// the request never reached the upstream.
+	rows := []oauthProviderModelConfigRow{
+		{ModelID: "grok-4.7", OwnedBy: "grok-build", Source: "seed", Enabled: true},
+		{ModelID: "unrelated-model", OwnedBy: "some-other-owner", Source: "user", Enabled: true},
+	}
+	live := []*ModelInfo{{ID: "grok-4.5", Object: "model", OwnedBy: "xai"}}
+
+	got := appendOAuthProviderModelConfigs(live, "xai", "oauth", rows, []string{"grok-build"})
+
+	if !hasModelID(got, "grok-4.7") {
+		t.Fatalf("models = %v, want mapped-owner catalog row grok-4.7", modelIDs(got))
+	}
+	if !hasModelID(got, "grok-4.5") {
+		t.Fatalf("models = %v, want live model kept", modelIDs(got))
+	}
+	if hasModelID(got, "unrelated-model") {
+		t.Fatalf("models = %v, must not include unmapped owner", modelIDs(got))
+	}
+}
+
+func TestAppendOAuthProviderModelConfigsWithoutMappingKeepsProviderAliases(t *testing.T) {
+	// Without a tenant mapping the built-in aliases must still work, otherwise the
+	// existing claude/codex behaviour would regress.
+	rows := []oauthProviderModelConfigRow{
+		{ModelID: "claude-catalog-model", OwnedBy: "anthropic", Source: "user", Enabled: true},
+		{ModelID: "grok-4.7", OwnedBy: "grok-build", Source: "seed", Enabled: true},
+	}
+
+	got := appendOAuthProviderModelConfigs(nil, "claude", "oauth", rows, nil)
+
+	if !hasModelID(got, "claude-catalog-model") {
+		t.Fatalf("models = %v, want alias-owned catalog row", modelIDs(got))
+	}
+	if hasModelID(got, "grok-4.7") {
+		t.Fatalf("models = %v, must not pull in another owner's rows", modelIDs(got))
+	}
+}
+
+func TestAppendOAuthProviderModelConfigsSkipsDisabledAndAPIKeyAuth(t *testing.T) {
+	rows := []oauthProviderModelConfigRow{
+		{ModelID: "disabled-model", OwnedBy: "grok-build", Source: "seed", Enabled: false},
+		{ModelID: "legacy-priced-model", OwnedBy: "grok-build", Source: "legacy-pricing", Enabled: true},
+		{ModelID: "grok-4.7", OwnedBy: "grok-build", Source: "seed", Enabled: true},
+	}
+	mapped := []string{"grok-build"}
+
+	got := appendOAuthProviderModelConfigs(nil, "xai", "oauth", rows, mapped)
+	if hasModelID(got, "disabled-model") {
+		t.Fatalf("models = %v, must not include disabled row", modelIDs(got))
+	}
+	// Only operator-authored sources are routable; pricing-only bookkeeping rows
+	// are not a statement that the upstream serves the model.
+	if hasModelID(got, "legacy-priced-model") {
+		t.Fatalf("models = %v, must not include non-catalog source", modelIDs(got))
+	}
+	if !hasModelID(got, "grok-4.7") {
+		t.Fatalf("models = %v, want grok-4.7", modelIDs(got))
+	}
+
+	if apikey := appendOAuthProviderModelConfigs(nil, "xai", "apikey", rows, mapped); len(apikey) != 0 {
+		t.Fatalf("api-key auth models = %v, want none (config block owns that list)", modelIDs(apikey))
+	}
+}

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -52,6 +52,22 @@ func SetGlobalModelRegistryHook(hook ModelRegistryHook) {
 	reg.SetHook(hook)
 }
 
+// oauthCatalogScope returns the catalog rows and mapped model owners that make a
+// tenant's model-library entries routable for this credential. Both are scoped to
+// the credential's own tenant: registration must not leak (or depend on) another
+// tenant's library.
+func oauthCatalogScope(a *coreauth.Auth) ([]oauthProviderModelConfigRow, []string) {
+	if a == nil {
+		return nil, nil
+	}
+	rows := listOAuthProviderModelConfigRowsForTenant(a.TenantID)
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	groups := append([]string{a.Provider, a.ChannelName()}, a.ChannelIdentifiers()...)
+	return rows, serviceapp.ListModelOwnersForAuthGroupsForTenant(a.TenantID, groups)
+}
+
 // registerModelsForAuth (re)binds provider models in the global registry using the core auth ID as client identifier.
 func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	if a == nil || a.ID == "" {
@@ -142,7 +158,8 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 				excluded = entry.ExcludedModels
 			}
 		}
-		models = appendOAuthProviderModelConfigs(models, provider, authKind, listOAuthProviderModelConfigRows())
+		catalogRows, mappedOwners := oauthCatalogScope(a)
+		models = appendOAuthProviderModelConfigs(models, provider, authKind, catalogRows, mappedOwners)
 		models = applyExcludedModels(models, excluded)
 	case "bedrock":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("bedrock")
@@ -195,13 +212,21 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 				excluded = entry.ExcludedModels
 			}
 		}
-		models = appendOAuthProviderModelConfigs(models, provider, authKind, listOAuthProviderModelConfigRows())
+		catalogRows, mappedOwners := oauthCatalogScope(a)
+		models = appendOAuthProviderModelConfigs(models, provider, authKind, catalogRows, mappedOwners)
 		models = applyExcludedModels(models, excluded)
 	case "qwen":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("qwen")
 		models = applyExcludedModels(models, excluded)
 	case "xai":
+		// Live xAI discovery returns only the models the account is entitled to
+		// today, so a newly released model id is unroutable until we ship a
+		// catalog update. Honour the tenant's model library the same way
+		// claude/codex do, letting operators add an id and use it immediately.
 		models = s.fetchXAIRegistryModels(ctx, a, excluded)
+		catalogRows, mappedOwners := oauthCatalogScope(a)
+		models = appendOAuthProviderModelConfigs(models, provider, authKind, catalogRows, mappedOwners)
+		models = applyExcludedModels(models, excluded)
 	case "iflow":
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("iflow")
 		models = applyExcludedModels(models, excluded)

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -245,11 +245,16 @@ type oauthProviderModelConfigRow struct {
 	Enabled     bool
 }
 
+// appendOAuthProviderModelConfigs makes catalog rows routable for an OAuth
+// credential. mappedOwners carries the tenant's own auth-group→owner mappings so
+// operators can attach a model to a channel without the owner name having to
+// match a built-in provider alias.
 func appendOAuthProviderModelConfigs(
 	models []*ModelInfo,
 	provider string,
 	authKind string,
 	rows []oauthProviderModelConfigRow,
+	mappedOwners []string,
 ) []*ModelInfo {
 	if !strings.EqualFold(strings.TrimSpace(authKind), "oauth") {
 		return models
@@ -259,6 +264,14 @@ func appendOAuthProviderModelConfigs(
 		return models
 	}
 	owners := modelConfigOwnerAliases(provider)
+	for _, owner := range mappedOwners {
+		if key := normalizeModelConfigOwner(owner); key != "" {
+			if owners == nil {
+				owners = make(map[string]struct{}, len(mappedOwners))
+			}
+			owners[key] = struct{}{}
+		}
+	}
 	if len(owners) == 0 {
 		return models
 	}

--- a/sdk/cliproxy/service_server_factory.go
+++ b/sdk/cliproxy/service_server_factory.go
@@ -12,8 +12,8 @@ func (s *Service) buildServerOptions() []api.ServerOption {
 	serverOptions = append(serverOptions, api.WithConfigMutatedCallback(func(updated *config.Config) {
 		s.applyConfigReload(updated, true)
 	}))
-	serverOptions = append(serverOptions, api.WithModelConfigMutatedCallback(func() {
-		s.refreshRegisteredModels(context.Background())
+	serverOptions = append(serverOptions, api.WithModelConfigMutatedCallback(func(tenantID string) {
+		s.onModelCatalogChanged(tenantID)
 	}))
 	return serverOptions
 }

--- a/sdkbridge/api/bridge.go
+++ b/sdkbridge/api/bridge.go
@@ -45,7 +45,7 @@ func WithConfigMutatedCallback(fn func(*sdkconfig.Config)) ServerOption {
 	return internalapisdkbridge.WithConfigMutatedCallback(fn)
 }
 
-func WithModelConfigMutatedCallback(fn func()) ServerOption {
+func WithModelConfigMutatedCallback(fn func(tenantID string)) ServerOption {
 	return internalapisdkbridge.WithModelConfigMutatedCallback(fn)
 }
 

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -63,6 +63,14 @@ func ListOAuthProviderModelConfigRows() []OAuthProviderModelConfigRow {
 	return internalserviceapp.ListOAuthProviderModelConfigRows()
 }
 
+func ListOAuthProviderModelConfigRowsForTenant(tenantID string) []OAuthProviderModelConfigRow {
+	return internalserviceapp.ListOAuthProviderModelConfigRowsForTenant(tenantID)
+}
+
+func ListModelOwnersForAuthGroupsForTenant(tenantID string, authGroups []string) []string {
+	return internalserviceapp.ListModelOwnersForAuthGroupsForTenant(tenantID, authGroups)
+}
+
 func ConfigureServiceAccess(cfg *config.Config, accessManager *sdkaccess.Manager) {
 	internalserviceapp.ConfigureServiceAccess(cfg, accessManager)
 }


### PR DESCRIPTION
## 背景

上游模型清单只返回账号当前有权限的模型（例如线上两个 xAI 账号固定只返回 `grok-4.5` + 两个图像模型）。当上游发布新模型时，在我们更新静态目录前，该 model id 无法使用。

运营侧本应可以在「模型库」加一条记录、归属到对应分组来顶上这个空档，但三处限制让这条路径形同虚设：

1. **xai 注册分支从未调用 `appendOAuthProviderModelConfigs`** —— claude / codex 都有，xai 漏了，模型库加什么都进不了 xai 账号。
2. **归属匹配只认内置 provider 别名**（claude→anthropic、gemini→google），运营自定义的归属分组名（如 `grok-build`）不命中。
3. **注册读的是 `ListAllConfigs()`，等价于系统租户** —— 其它租户的模型库根本不参与注册，这条最致命。

## 改动

### 让模型库条目可路由

- 归属匹配接入租户自己的 `auth_group_model_owner_mappings`，与内置别名并存 —— 运营用既有的「归属分组」表达意图，无需新增硬编码清单。
- 模型库按凭据自身的 `TenantID` 读取。
- xai 分支补上 `appendOAuthProviderModelConfigs`，与 claude / codex 对齐。

边界保持不变：仅 OAuth 凭据、仅 `user`/`seed`/`openrouter` 来源、仅 enabled 行。`legacy-pricing` 这类纯计价行不会变成可路由（它只是价格记录，不代表上游能服务）。

### 让新增 id 立即生效

复用既有的 model-config mutated hook，未另建通知机制：

- 该 hook 原先只对系统租户放行，与「注册只读系统租户」是配套的；现在改为租户感知。
- 补上归属映射变更的触发（它同样决定凭据能服务哪些模型）。
- 重新注册要读库并对 live provider 请求上游，因此改为**异步**执行，并**按租户合并**突发编辑：刷新期间的变更只置一次「再跑一遍」标记，既保证最后一轮包含全部改动，又不会让一串编辑放大成一串上游请求。

## 破坏性变更

`WithModelConfigMutatedCallback` 回调签名：`func()` → `func(tenantID string)`。仓内所有调用点已更新；未保留旧签名重载，以免出现「收不到租户、静默只刷系统租户」的隐性错误。

## 影响范围

- 目录：`sdk/cliproxy/`、`sdkbridge/`、`internal/api/`、`internal/app/service/`
- claude / codex 同步受益：它们此前同样只认系统租户 + 内置别名。
- 不改变模型的实际可用性判断：注册后请求照常发往上游，上游是否接受由上游决定。

## 验证

新增 8 个测试，关键用例先红后绿：

- 归属映射命中 / 未配映射时内置别名不回退 / disabled 与非目录来源被排除 / api-key 凭据不受影响
- 租户隔离：A 租户的模型库与映射不泄漏给 B 租户
- 非系统租户保存模型能触发通知（回退系统租户 gate 后该用例报 `notified tenants = []`，正是线上现状）
- 合并状态机：刷新期间的变更不并发触发，但会被后续一轮覆盖

`./scripts/ci-pr.sh` 本地完整通过（结构检查、gofmt、secret scan、`go vet`、`go test ./...`、golangci-lint、`go build`）。

## 关联

与 #854 串联：#854 让新模型能在渠道分组编辑器里被勾进 `allowed-models`（否则分组白名单仍会拦截），本 PR 让它真正可被路由。

🤖 Generated with [Claude Code](https://claude.com/claude-code)