### PR TITLE
feat(quota): 累计消费额度可重新发放

### DIFF
--- a/internal/api/handlers/management/period_spending_reset.go
+++ b/internal/api/handlers/management/period_spending_reset.go
@@ -97,7 +97,13 @@ func (h *Handler) PostEndUserPeriodSpendingReset(c *gin.Context) {
 	effective := usage.EffectiveEndUserQuota(*accountQuota)
 	effective.PeriodSpendingLimits.Day = effective.DailySpendingLimit
 	for _, period := range periods {
-		if effective.PeriodSpendingLimits.Value(period) <= 0 {
+		// The lifetime allowance is stored in its own column, not in the rolling
+		// period limits, so it needs its own configured check.
+		limit := effective.PeriodSpendingLimits.Value(period)
+		if period == quota.PeriodLifetime {
+			limit = effective.SpendingLimit
+		}
+		if limit <= 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{
 				"code": "period_limit_missing", "message": fmt.Sprintf("Account %s spending limit is not configured", period), "period": period,
 			}})

--- a/internal/quota/period.go
+++ b/internal/quota/period.go
@@ -13,6 +13,11 @@ const (
 	PeriodDay      Period = "day"
 	PeriodWeek     Period = "week"
 	PeriodMonth    Period = "month"
+	// PeriodLifetime is the account's cumulative spend. It is not a rolling
+	// window: it only resets when an operator explicitly grants a new allowance,
+	// which is why it is deliberately absent from OrderedPeriods (that list drives
+	// the four rolling per-period limits) while still being a resettable period.
+	PeriodLifetime Period = "lifetime"
 )
 
 var OrderedPeriods = [...]Period{PeriodFiveHour, PeriodDay, PeriodWeek, PeriodMonth}
@@ -46,7 +51,7 @@ func NormalizePeriods(periods []Period) ([]Period, error) {
 	seen := make(map[Period]struct{}, len(periods))
 	for _, period := range periods {
 		switch period {
-		case PeriodFiveHour, PeriodDay, PeriodWeek, PeriodMonth:
+		case PeriodFiveHour, PeriodDay, PeriodWeek, PeriodMonth, PeriodLifetime:
 		default:
 			return nil, &InvalidPeriodError{Period: period}
 		}
@@ -232,6 +237,8 @@ func (u PeriodSpendingUsage) Value(period Period) float64 {
 		return u.Week
 	case PeriodMonth:
 		return u.Month
+	case PeriodLifetime:
+		return u.Lifetime
 	default:
 		return 0
 	}

--- a/internal/usage/enduser_quota.go
+++ b/internal/usage/enduser_quota.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -265,7 +266,11 @@ func CountTotalByEndUser(endUserID string) (int64, error) {
 	return queryLifetimeCountByEndUserFromRollup(tenantID, endUserID)
 }
 
-// QueryTotalCostByEndUser sums lifetime cost across all keys of the end user.
+// QueryTotalCostByEndUser returns spend counted against the account's current
+// lifetime allowance: cumulative cost minus the baseline recorded by the last
+// allowance grant. Without the baseline the limit would be a permanent ceiling
+// on the account's entire history, so granting a fresh allowance would require
+// the operator to add past spend into the new limit by hand.
 func QueryTotalCostByEndUser(endUserID string) (float64, error) {
 	quota := GetEndUserQuota(endUserID)
 	tenantID := systemTenantID
@@ -280,7 +285,39 @@ func QueryTotalCostByEndUser(endUserID string) (float64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("usage: total cost by end user: %w", err)
 	}
-	return agg.CostTotal, nil
+	baseline, err := lifetimeSpendingBaseline(tenantID, periodSubjectEndUser, endUserID)
+	if err != nil {
+		return 0, fmt.Errorf("usage: total cost by end user: %w", err)
+	}
+	if remaining := agg.CostTotal - baseline; remaining > 0 {
+		return remaining, nil
+	}
+	return 0, nil
+}
+
+// lifetimeSpendingBaseline returns the cumulative-spend baseline stored by the
+// last allowance grant, or 0 when the subject was never granted one.
+func lifetimeSpendingBaseline(tenantID string, subject periodSubject, subjectID string) (float64, error) {
+	subjectType, err := periodResetSubjectType(subject)
+	if err != nil {
+		return 0, err
+	}
+	db := getReadDB()
+	if db == nil {
+		return 0, ErrQuotaUsageUnavailable
+	}
+	var baseline float64
+	err = db.QueryRow(`SELECT cost_baseline FROM period_spending_resets
+		WHERE tenant_id = ? AND subject_type = ? AND subject_id = ? AND period = ?`,
+		normalizeTenantID(tenantID), subjectType, strings.TrimSpace(subjectID), string(quota.PeriodLifetime),
+	).Scan(&baseline)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return baseline, nil
 }
 
 // QueryTodayCostByEndUser returns account-level project-day spend after the latest same-day reset baseline.

--- a/internal/usage/period_spending_reset.go
+++ b/internal/usage/period_spending_reset.go
@@ -106,6 +106,9 @@ func periodResetSubjectType(subject periodSubject) (string, error) {
 	}
 }
 
+// lifetimeWindowKey is the constant window key stored for cumulative-spend resets.
+const lifetimeWindowKey = "lifetime"
+
 func periodWindowKey(period quota.Period, windows PeriodWindowKeys) string {
 	switch period {
 	case quota.PeriodFiveHour:
@@ -116,6 +119,11 @@ func periodWindowKey(period quota.Period, windows PeriodWindowKeys) string {
 		return windows.WeekFrom
 	case quota.PeriodMonth:
 		return windows.MonthFrom
+	case quota.PeriodLifetime:
+		// Cumulative spend has no window to roll over, so its baseline stays in
+		// force until the next grant. A constant key makes the generic
+		// "same window?" validity check always hold for this period.
+		return lifetimeWindowKey
 	default:
 		return ""
 	}
@@ -134,6 +142,8 @@ func setPeriodUsageValue(used *quota.PeriodSpendingUsage, period quota.Period, v
 		used.Week = value
 	case quota.PeriodMonth:
 		used.Month = value
+	case quota.PeriodLifetime:
+		used.Lifetime = value
 	}
 }
 

--- a/internal/usage/period_spending_test.go
+++ b/internal/usage/period_spending_test.go
@@ -211,3 +211,85 @@ func TestPeriodSpendingResetExpiresWhenWindowChanges(t *testing.T) {
 		t.Fatalf("next-week used = %+v, want week=4 (old baseline expired)", got[keyID])
 	}
 }
+
+// TestLifetimeAllowanceResetsToFullOnGrant covers the operator-facing promise:
+// granting a new allowance makes the account spendable again for the full
+// amount, no matter how much it spent historically. Before cumulative spend
+// became resettable, a $1000 limit on an account that had already spent $594
+// only bought it $406 of runway, forcing operators to hand-compute
+// "past spend + intended allowance" on every top-up.
+func TestLifetimeAllowanceResetsToFullOnGrant(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	const endUserID = "lifetime-grant-user"
+
+	if _, err := db.Exec(`INSERT INTO usage_rollup_buckets
+		(tenant_id,bucket_kind,bucket_start,end_user_id,cost_total,updated_at)
+		VALUES (?,?,?,?,?,?)`, systemTenantID, rollupBucketLifetime, rollupLifetimeStart, endUserID, 594.92, now); err != nil {
+		t.Fatalf("seed lifetime spend: %v", err)
+	}
+
+	spent, err := QueryTotalCostByEndUser(endUserID)
+	if err != nil {
+		t.Fatalf("QueryTotalCostByEndUser: %v", err)
+	}
+	if spent != 594.92 {
+		t.Fatalf("spend before grant = %v, want 594.92", spent)
+	}
+
+	if _, err := resetPeriodSpendingForSubject(systemTenantID, periodSubjectEndUser, endUserID,
+		[]quota.Period{quota.PeriodLifetime}, PeriodSpendingResetActor{Username: "admin"}, now); err != nil {
+		t.Fatalf("grant allowance: %v", err)
+	}
+
+	spent, err = QueryTotalCostByEndUser(endUserID)
+	if err != nil {
+		t.Fatalf("QueryTotalCostByEndUser after grant: %v", err)
+	}
+	if spent != 0 {
+		t.Fatalf("spend after grant = %v, want 0 so the full allowance is available", spent)
+	}
+
+	// Spend that lands after the grant counts against the new allowance.
+	if _, err := db.Exec(`UPDATE usage_rollup_buckets SET cost_total = ? WHERE end_user_id = ? AND bucket_kind = ?`,
+		630.92, endUserID, rollupBucketLifetime); err != nil {
+		t.Fatalf("add post-grant spend: %v", err)
+	}
+	spent, err = QueryTotalCostByEndUser(endUserID)
+	if err != nil {
+		t.Fatalf("QueryTotalCostByEndUser after new spend: %v", err)
+	}
+	if spent != 36 {
+		t.Fatalf("post-grant spend = %v, want 36", spent)
+	}
+}
+
+func TestLifetimeAllowanceBaselineSurvivesWindowRollover(t *testing.T) {
+	// Rolling periods lose their baseline when the window changes. A lifetime
+	// allowance has no window, so a grant must still hold days later — otherwise
+	// the account would silently revert to counting its whole history.
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	db := getDB()
+	granted := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	const endUserID = "lifetime-rollover-user"
+
+	if _, err := db.Exec(`INSERT INTO usage_rollup_buckets
+		(tenant_id,bucket_kind,bucket_start,end_user_id,cost_total,updated_at)
+		VALUES (?,?,?,?,?,?)`, systemTenantID, rollupBucketLifetime, rollupLifetimeStart, endUserID, 500, granted); err != nil {
+		t.Fatalf("seed spend: %v", err)
+	}
+	if _, err := resetPeriodSpendingForSubject(systemTenantID, periodSubjectEndUser, endUserID,
+		[]quota.Period{quota.PeriodLifetime}, PeriodSpendingResetActor{Username: "admin"}, granted); err != nil {
+		t.Fatalf("grant allowance: %v", err)
+	}
+
+	muchLater := granted.AddDate(0, 2, 3)
+	usage, err := QueryPeriodSpendingByEndUsersForTenantAt(systemTenantID, []string{endUserID}, muchLater)
+	if err != nil {
+		t.Fatalf("QueryPeriodSpending: %v", err)
+	}
+	if got := usage[endUserID].Lifetime; got != 0 {
+		t.Fatalf("lifetime used two months after the grant = %v, want 0", got)
+	}
+}


### PR DESCRIPTION
## 问题

「累计消费限额」的实际含义是**这个账号有史以来最多花多少**，因为累计消费只能单调累加、永远归不了零：

```go
totalCost = 该账号 lifetime 桶的累计花费   // 无基准，从开天辟地累加
if totalCost >= spendingLimit → 拒绝
```

对比「当日消费」有重置基准（`QueryTodayCostByEndUser` 取最近一次重置基准之后的花费），累计消费没有这套机制。

后果：运营想给账号发 1000 刀额度，必须先查出历史已花多少，再填 `已花 + 1000`。填 1000 的结果是账号只剩 `1000 − 已花` 可用——线上真实案例是设 $1000、历史已花 $594.92，界面显示只剩 $405.08。每次续期都要手工做加法。

## 改动

把「累计」接入既有的周期重置机制，让额度可以**重新发放**：

- `quota` 包新增 `PeriodLifetime`。它**不进** `OrderedPeriods`——那是四个滚动周期限额的遍历依据，累计额度存在自己的 `spending_limit` 列，不参与周期限额模型。
- 滚动周期靠 `window_key` 换窗口让基准自然失效；累计没有窗口，用固定 `window_key` 使基准一直有效到下次发放。`period_spending_resets` 的 `period` 是字符串列，**新增一种周期无需迁移**。
- `QueryTotalCostByEndUser` 改为返回「本轮已花」= 累计花费 − 上次发放基准。这是 quota 中间件判定 `spending_limit` 的依据。
- 展示路径复用同一基准（`applyPeriodBaseline` 支持累计后自动生效），保证界面与实际放行一致——否则会出现界面显示还有额度、请求却被拒的情况。
- 重置接口接受 `lifetime`，其「是否已配置额度」改查 `spending_limit` 列而非周期限额。

## 兼容性

存量账号没有基准记录时基准为 0，行为与改动前**完全一致**（不会突然放开或收紧任何账号），无需数据迁移。语义从「历史总账上限」变为「本轮额度」，运营侧需知悉。

## 验证

新增 2 个测试：

- `TestLifetimeAllowanceResetsToFullOnGrant`：历史已花 $594.92 的账号在发放后可用额度回到满额；发放后新产生的花费正确计入新额度。移除基准扣减后该用例报 `spend after grant = 594.92, want 0`。
- `TestLifetimeAllowanceBaselineSurvivesWindowRollover`：发放两个月后基准仍有效，不会因窗口滚动而回退到统计全部历史。

`./scripts/ci-pr.sh` 本地完整通过。

## 后续

前端需要提供「重新发放额度」的入口（复用现有周期重置弹窗，把累计作为可选项），单独 PR 跟进。本 PR 合入后能力已可用，但管理端尚无按钮触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)