### PR TITLE
fix(proxy-pool): rebind tenant executors and reject duplicate proxy ids

### DIFF
--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/internal/app/service"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	proxypoolsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/proxypool"
@@ -69,6 +70,10 @@ func (h *Handler) PutProxyPool(c *gin.Context) {
 		body.Items = entries
 	}
 
+	if dups := config.ProxyPoolDuplicateIDs(body.Items); len(dups) > 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("duplicate proxy ids: %s", strings.Join(dups, ", "))})
+		return
+	}
 	normalized := config.NormalizeProxyPool(body.Items)
 	if len(body.Items) > 0 && len(normalized) == 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no valid proxy entries"})
@@ -192,8 +197,11 @@ func (h *Handler) applyTenantProxyPoolConfig(tenantID string) {
 	if h == nil || h.authManager == nil || h.cfg == nil {
 		return
 	}
+	// Executors capture a tenant cfg snapshot (including ProxyPool) at bind time.
+	// SetConfig alone is not enough: rebind so auth ProxyID resolves to the new URL.
 	tenantCfg := usage.BuildTenantRuntimeConfig(h.cfg, tenantID)
 	h.authManager.SetConfigForTenant(tenantID, &tenantCfg)
+	serviceapp.RebindTenantExecutors(h.cfg, h.authManager, tenantID, nil)
 }
 
 // GetPublicPing returns a lightweight public 204 endpoint for proxy latency probes.

--- a/internal/api/handlers/management/proxy_pool_test.go
+++ b/internal/api/handlers/management/proxy_pool_test.go
@@ -252,6 +252,36 @@ func TestProxyPoolHandlersUseSQLiteWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestPutProxyPoolRejectsDuplicateIDs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := usageTestProxyPoolDB(t)
+	defer cleanup()
+
+	h := NewHandler(&config.Config{}, "", nil)
+	defer h.Close()
+
+	payload := []byte(`{"items":[
+		{"id":"ip","name":"old","url":"socks5://1.1.1.1:1080","enabled":true},
+		{"id":"IP","name":"new","url":"socks5://2.2.2.2:1080","enabled":true}
+	]}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPut, "/proxy-pool", bytes.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PutProxyPool(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "duplicate proxy ids") {
+		t.Fatalf("body = %s, want duplicate proxy ids", w.Body.String())
+	}
+	if rows := usage.ListProxyPool(); len(rows) != 0 {
+		t.Fatalf("store should stay empty on rejected put, got %#v", rows)
+	}
+}
+
 func TestPatchProxyPoolEntryUsesSQLiteWhenAvailable(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cleanup := usageTestProxyPoolDB(t)

--- a/internal/config/proxy_pool.go
+++ b/internal/config/proxy_pool.go
@@ -47,18 +47,9 @@ func NormalizeProxyPool(entries []ProxyPoolEntry) []ProxyPoolEntry {
 	seen := make(map[string]struct{}, len(entries))
 	out := make([]ProxyPoolEntry, 0, len(entries))
 	for _, entry := range entries {
-		entry.ID = normalizeProxyID(entry.ID)
-		entry.Name = strings.TrimSpace(entry.Name)
-		entry.URL = strings.TrimSpace(entry.URL)
-		entry.Description = strings.TrimSpace(entry.Description)
-		if entry.URL == "" || ValidateProxyURL(entry.URL) != nil {
+		entry = normalizeProxyPoolEntry(entry)
+		if entry.URL == "" {
 			continue
-		}
-		if entry.ID == "" {
-			entry.ID = proxyIDFromURL(entry.URL)
-		}
-		if entry.Name == "" {
-			entry.Name = entry.ID
 		}
 		if _, ok := seen[entry.ID]; ok {
 			continue
@@ -70,6 +61,52 @@ func NormalizeProxyPool(entries []ProxyPoolEntry) []ProxyPoolEntry {
 		return nil
 	}
 	return out
+}
+
+// ProxyPoolDuplicateIDs returns normalized ids that appear more than once among valid entries.
+// Used by the management API so silent first-wins drops cannot hide a failed create.
+func ProxyPoolDuplicateIDs(entries []ProxyPoolEntry) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(entries))
+	var dups []string
+	dupSeen := make(map[string]struct{})
+	for _, entry := range entries {
+		entry = normalizeProxyPoolEntry(entry)
+		if entry.URL == "" {
+			continue
+		}
+		if _, ok := seen[entry.ID]; ok {
+			if _, reported := dupSeen[entry.ID]; !reported {
+				dups = append(dups, entry.ID)
+				dupSeen[entry.ID] = struct{}{}
+			}
+			continue
+		}
+		seen[entry.ID] = struct{}{}
+	}
+	return dups
+}
+
+func normalizeProxyPoolEntry(entry ProxyPoolEntry) ProxyPoolEntry {
+	entry.ID = normalizeProxyID(entry.ID)
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.URL = strings.TrimSpace(entry.URL)
+	entry.Description = strings.TrimSpace(entry.Description)
+	if entry.URL == "" || ValidateProxyURL(entry.URL) != nil {
+		entry.URL = ""
+		return entry
+	}
+	if entry.ID == "" {
+		// Prefer a stable id from the full proxy URL (host+auth+port) so
+		// Chinese-only names do not all collapse to the same slug.
+		entry.ID = proxyIDFromURL(entry.URL)
+	}
+	if entry.Name == "" {
+		entry.Name = entry.ID
+	}
+	return entry
 }
 
 // SanitizeProxyPool normalizes the configured reusable proxy list in-place.

--- a/internal/config/proxy_pool_test.go
+++ b/internal/config/proxy_pool_test.go
@@ -25,6 +25,39 @@ func TestNormalizeProxyPoolTrimsDeduplicatesAndValidatesEntries(t *testing.T) {
 	}
 }
 
+func TestNormalizeProxyPoolEmptyChineseNameUsesURLHash(t *testing.T) {
+	t.Parallel()
+
+	a := NormalizeProxyPool([]ProxyPoolEntry{
+		{Name: "洛杉矶 ip", URL: "socks5://user:pass@1.2.3.4:1080", Enabled: true},
+	})
+	b := NormalizeProxyPool([]ProxyPoolEntry{
+		{Name: "住宅 ip", URL: "socks5://user:pass@5.6.7.8:1080", Enabled: true},
+	})
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("normalize lengths a=%d b=%d", len(a), len(b))
+	}
+	if a[0].ID == "ip" || b[0].ID == "ip" {
+		t.Fatalf("CJK names must not collapse to id=ip: a=%q b=%q", a[0].ID, b[0].ID)
+	}
+	if a[0].ID == b[0].ID {
+		t.Fatalf("different proxy URLs must get different auto ids: %q", a[0].ID)
+	}
+}
+
+func TestProxyPoolDuplicateIDsReportsCollisions(t *testing.T) {
+	t.Parallel()
+
+	dups := ProxyPoolDuplicateIDs([]ProxyPoolEntry{
+		{ID: "ip", Name: "old", URL: "socks5://1.1.1.1:1080", Enabled: true},
+		{ID: "IP", Name: "new", URL: "socks5://2.2.2.2:1080", Enabled: true},
+		{ID: "ok", Name: "ok", URL: "socks5://3.3.3.3:1080", Enabled: true},
+	})
+	if len(dups) != 1 || dups[0] != "ip" {
+		t.Fatalf("ProxyPoolDuplicateIDs = %#v, want [ip]", dups)
+	}
+}
+
 func TestValidateProxyURLAllowsSupportedSchemesOnly(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- After tenant proxy-pool PUT/PATCH, rebind tenant executors so auth `ProxyID` resolves to the updated SOCKS URL (fixes stale egress after edit).
- Reject PUT bodies with duplicate normalized proxy ids instead of silently keeping the first entry.

## Root cause
1. `applyTenantProxyPoolConfig` only called `SetConfigForTenant`; executors capture `ProxyPool` at bind time and kept serving the old URL.
2. CJK names + first-wins id normalize dropped new proxies / mixed latency checks (frontend companion PR).

## Test plan
- [x] `go test ./internal/config -run 'ProxyPool|NormalizeProxy'`
- [x] `go test ./internal/api/handlers/management -run 'ProxyPool|PutProxy'`
- [ ] GHA PR checks green