### PR TITLE
fix(auth): stop lockouts and silent sign-outs from throttling and rotation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -98,6 +98,37 @@ remote-management:
   # GitHub repository for the management control panel. Accepts a repository URL or releases API URL.
   panel-github-repository: "https://github.com/kittors/codeProxy"
 
+  # Login throttling and session token lifetimes. Every key is optional and
+  # zero-means-default, so leaving this block commented out keeps the shipped
+  # behaviour. Uncomment only the keys you actually want to override.
+  # auth:
+  #   # Sliding window (seconds) used to count login failures. Failures older
+  #   # than this are discarded, so a stale mistype never contributes to a lock.
+  #   login-failure-window-seconds: 900
+  #   # Failures within the window that arm a staged cooldown for one account.
+  #   account-failure-limit: 5
+  #   # Wrong management keys from one client IP that arm a per-IP ban.
+  #   management-key-failure-limit: 10
+  #   # Credential-less management requests allowed per client per hour. Over the
+  #   # limit returns 429; it never arms a credential ban.
+  #   unauthenticated-request-limit: 300
+  #   # Quiet period (hours) that clears failure counters and backoff escalation.
+  #   failure-reset-hours: 12
+  #   # How long a just-rotated refresh token stays usable so a retry or a second
+  #   # browser tab does not lose the session. Clamped to 60 seconds.
+  #   refresh-grace-seconds: 30
+  #   # How many times one rotated refresh token may be replayed inside the grace
+  #   # window before it is treated as a stolen-token replay.
+  #   refresh-grace-max-reuse: 2
+  #   # How long the previous access token stays valid after rotation, so
+  #   # in-flight requests are not rejected. Must exceed the panel request timeout.
+  #   access-token-grace-seconds: 60
+  #   # Hard session ceiling (hours). Rotation never extends past login time plus
+  #   # this value. 1440 hours is 60 days.
+  #   absolute-refresh-ttl-hours: 1440
+  #   # How often expired session tokens and revoked sessions are garbage collected.
+  #   session-reaper-interval-minutes: 60
+
 # Docker-first automatic update checks. The updater sidecar is installed by the
 # Docker Compose deployment path; non-Docker deployments can disable this.
 auto-update:

--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -10,15 +10,15 @@
     "baseline_above_800": [
       {
         "path": "internal/api/handlers/management/end_user.go",
-        "max_lines": 912
+        "max_lines": 910
       },
       {
         "path": "internal/enduser/service.go",
-        "max_lines": 1189
+        "max_lines": 1169
       },
       {
         "path": "internal/identity/service.go",
-        "max_lines": 1144
+        "max_lines": 932
       },
       {
         "path": "internal/management/aiaccountstatus/service.go",
@@ -42,7 +42,7 @@
       },
       {
         "path": "internal/storage/postgres/migrations.go",
-        "max_lines": 1120
+        "max_lines": 1115
       },
       {
         "path": "internal/storage/sqlite/apikey/store.go",
@@ -66,7 +66,7 @@
       },
       {
         "path": "internal/usage/usage_db.go",
-        "max_lines": 1164
+        "max_lines": 1150
       },
       {
         "path": "sdk/api/handlers/handlers.go",

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -14,18 +14,15 @@ import (
 
 	"github.com/gin-gonic/gin"
 	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/internal/app/service"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/aiaccountstatus"
 	imagegeneration "github.com/router-for-me/CLIProxyAPI/v6/internal/management/imagegeneration"
 	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // Handler aggregates config reference, persistence path and helpers.
@@ -68,7 +65,7 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 	h := &Handler{
 		cfg:                 cfg,
 		configFilePath:      configFilePath,
-		loginThrottle:       newLoginThrottle(),
+		loginThrottle:       newLoginThrottle(throttlePoliciesFromConfig(cfg)),
 		authManager:         manager,
 		usageStats:          usage.GetRequestStatistics(),
 		tokenStore:          sdkAuth.GetTokenStore(),
@@ -125,6 +122,10 @@ func (h *Handler) SetConfig(cfg *config.Config) {
 	// Recreate lazily so provider probes use the new proxy/TLS/runtime config.
 	h.aiAccountStatus = nil
 	h.mu.Unlock()
+	// Throttle thresholds are part of the reloadable config, so a limit raised in
+	// config.yaml has to take effect without a restart — otherwise the documented
+	// escape hatch for an over-tight limit is "restart the server".
+	h.loginThrottle.setPolicies(throttlePoliciesFromConfig(cfg))
 }
 
 // SetAuthManager updates the auth manager reference used by management endpoints.
@@ -173,160 +174,10 @@ func (h *Handler) SetPostAuthHook(hook coreauth.PostAuthHook) {
 }
 
 // Middleware enforces access control for management endpoints.
-// All requests (local and remote) require a valid management key.
-// Additionally, remote access requires allow-remote-management=true.
+// The implementation lives in middleware_auth.go, where the step order that
+// keeps the ban check ahead of every secret comparison is documented.
 func (h *Handler) Middleware() gin.HandlerFunc {
-
-	return func(c *gin.Context) {
-		c.Header("X-CPA-VERSION", buildinfo.Version)
-		c.Header("X-CPA-COMMIT", buildinfo.Commit)
-		c.Header("X-CPA-BUILD-DATE", buildinfo.BuildDate)
-		currentUIVersion, currentUICommit := h.currentFrontendState()
-		c.Header("X-CPA-UI-VERSION", currentUIVersion)
-		c.Header("X-CPA-UI-COMMIT", currentUICommit)
-
-		// Session tokens (cps_*) come from Authorization: Bearer on normal HTTP, or from
-		// ?token= on the system-stats WebSocket handshake (browsers cannot set WS headers).
-		// Resolve the session token before falling through to management-key auth so a
-		// valid user session is never bcrypt-compared against the remote management secret.
-		if token := resolveSessionToken(c); strings.HasPrefix(token, "cps_") {
-			_ = h.authenticateSessionToken(c, token)
-			return
-		}
-
-		clientIP := c.ClientIP()
-		// A loopback ClientIP alone does not prove local origin. With trusted-proxies
-		// unset (the default) gin falls back to RemoteAddr, so behind a same-host
-		// reverse proxy every external request would report 127.0.0.1 and thereby skip
-		// the allow-remote gate, unlock the local-password path, and bypass the per-IP
-		// login throttle entirely. Require the direct peer to be loopback and no relay
-		// headers to be present as well.
-		localClient := (clientIP == "127.0.0.1" || clientIP == "::1") && util.IsLocalOriginRequest(c.Request)
-		cfg := h.cfg
-		var (
-			allowRemote bool
-			secretHash  string
-		)
-		if cfg != nil {
-			allowRemote = cfg.RemoteManagement.AllowRemote
-			secretHash = cfg.RemoteManagement.SecretKey
-		}
-		if h.allowRemoteOverride {
-			allowRemote = true
-		}
-		envSecret := h.envSecret
-
-		fail := func() {}
-		isBanned := func() (time.Duration, bool) { return 0, false }
-		clearFailures := func() {}
-		if !localClient {
-			if !allowRemote {
-				// Requests relayed by a local reverse proxy land here even though the TCP
-				// peer is loopback. allow-remote is the only advice that actually grants
-				// access: a relayed request is never treated as local, so trusted-proxies
-				// does not help on its own — it recovers the real client IP for the per-IP
-				// throttle, which is why it is named as an additional step rather than an
-				// alternative.
-				message := "remote management disabled"
-				if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" {
-					message = "remote management disabled: request was relayed (" + relayHeader + " header present), so it is not treated as local. Set remote-management.allow-remote=true to allow it, and list the proxy in trusted-proxies so per-IP throttling sees the real client."
-				}
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": message})
-				return
-			}
-
-			// Shares loginThrottle with PostLogin: both are password entry
-			// points, so failures against either must count toward the same
-			// per-IP budget.
-			isBanned = func() (time.Duration, bool) {
-				remaining := h.loginThrottle.blockedFor(clientIP, time.Now())
-				if remaining <= 0 {
-					return 0, false
-				}
-				return remaining.Round(time.Second), true
-			}
-
-			fail = func() { h.loginThrottle.recordFailure(clientIP, time.Now()) }
-
-			clearFailures = func() { h.loginThrottle.recordSuccess(clientIP) }
-		}
-		localPasswordConfigured := localClient && h.localPassword != ""
-		if secretHash == "" && envSecret == "" && !localPasswordConfigured {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "remote management key not set"})
-			return
-		}
-
-		// Accept either Authorization: Bearer <key> or X-Management-Key
-		var provided string
-		if ah := c.GetHeader("Authorization"); ah != "" {
-			parts := strings.SplitN(ah, " ", 2)
-			if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" {
-				provided = parts[1]
-			} else {
-				provided = ah
-			}
-		}
-		if provided == "" {
-			provided = c.GetHeader("X-Management-Key")
-		}
-		// Fallback: ?token= query param is accepted only for WebSocket handshakes;
-		// normal HTTP requests must not carry credentials in URLs.
-		// Session tokens (cps_*) were already handled above; remaining query tokens are
-		// treated as management keys (legacy panel / service credential).
-		if provided == "" && shouldReadManagementTokenFromQuery(c) {
-			if queryToken := strings.TrimSpace(c.Query("token")); !strings.HasPrefix(queryToken, "cps_") {
-				provided = queryToken
-			}
-		}
-
-		if provided == "" {
-			if !localClient {
-				if remaining, banned := isBanned(); banned {
-					c.Header("Retry-After", retryAfterSecondsHeader(remaining))
-					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)})
-					return
-				}
-				fail()
-			}
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing management key"})
-			return
-		}
-
-		if localClient {
-			if lp := h.localPassword; lp != "" {
-				if util.ConstantTimeStringEqual(provided, lp) {
-					h.setServicePrincipal(c)
-					h.nextWithManagementAudit(c)
-					return
-				}
-			}
-		}
-
-		if envSecret != "" && util.ConstantTimeStringEqual(provided, envSecret) {
-			clearFailures()
-			h.setServicePrincipal(c)
-			h.nextWithManagementAudit(c)
-			return
-		}
-
-		if secretHash == "" || bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) != nil {
-			if !localClient {
-				if remaining, banned := isBanned(); banned {
-					c.Header("Retry-After", retryAfterSecondsHeader(remaining))
-					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)})
-					return
-				}
-				fail()
-			}
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid management key"})
-			return
-		}
-
-		clearFailures()
-		h.setServicePrincipal(c)
-
-		h.nextWithManagementAudit(c)
-	}
+	return h.managementAuthMiddleware
 }
 
 // resolveSessionToken returns a user-session token for management auth.

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -34,32 +35,62 @@ func TestMiddlewareAllowsValidKeyAfterRemoteIPIsBanned(t *testing.T) {
 	}, nil)
 	defer h.Close()
 
+	// Hold the ban open for the whole test rather than sleeping it out. Arming it
+	// costs ten bcrypt comparisons, and under -race those run an order of
+	// magnitude slower, so any block short enough to keep the test fast also
+	// expires mid-setup and silently turns the X1 assertion into a no-op. The
+	// expiry half is driven by expireArmedBlocks instead of wall-clock time.
+	policies := defaultThrottlePolicies()
+	held := policies[scopeManagementKey]
+	held.Backoff = []time.Duration{time.Hour}
+	policies[scopeManagementKey] = held
+	h.loginThrottle.setPolicies(policies)
+
 	router := gin.New()
 	router.Use(h.Middleware())
 	router.GET("/v0/management/ping", func(c *gin.Context) {
 		c.String(http.StatusOK, "ok")
 	})
 
-	for i := 0; i < 5; i++ {
+	// Missing key attempts land in scopeUnauthenticated, which never hard-blocks
+	// (B2), so arming the scopeManagementKey ban requires actual wrong-credential
+	// attempts, not empty ones. defaultManagementKeyFailureLimit is 10, and the
+	// Nth failure itself trips the block, so only 9 attempts come back 401.
+	for i := 0; i < 9; i++ {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
 		req.RemoteAddr = "203.0.113.10:4321"
+		req.Header.Set("Authorization", "Bearer wrong-key")
 		router.ServeHTTP(rr, req)
 		if rr.Code != http.StatusUnauthorized {
-			t.Fatalf("missing-key attempt %d status = %d, want %d; body=%s", i+1, rr.Code, http.StatusUnauthorized, rr.Body.String())
+			t.Fatalf("wrong-key attempt %d status = %d, want %d; body=%s", i+1, rr.Code, http.StatusUnauthorized, rr.Body.String())
 		}
 	}
 
 	rrBanned := httptest.NewRecorder()
 	reqBanned := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
 	reqBanned.RemoteAddr = "203.0.113.10:4321"
+	reqBanned.Header.Set("Authorization", "Bearer wrong-key")
 	router.ServeHTTP(rrBanned, reqBanned)
 	if rrBanned.Code != http.StatusForbidden {
-		t.Fatalf("banned missing-key status = %d, want %d; body=%s", rrBanned.Code, http.StatusForbidden, rrBanned.Body.String())
+		t.Fatalf("banned wrong-key status = %d, want %d; body=%s", rrBanned.Code, http.StatusForbidden, rrBanned.Body.String())
 	}
 	if !strings.Contains(rrBanned.Body.String(), "IP banned") {
 		t.Fatalf("expected IP banned response, got %s", rrBanned.Body.String())
 	}
+
+	// X1: the ban precheck runs before any credential comparison, so even the
+	// correct key is rejected while the block is still active.
+	rrDuringBan := httptest.NewRecorder()
+	reqDuringBan := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+	reqDuringBan.RemoteAddr = "203.0.113.10:4321"
+	reqDuringBan.Header.Set("Authorization", "Bearer "+managementKey)
+	router.ServeHTTP(rrDuringBan, reqDuringBan)
+	if rrDuringBan.Code != http.StatusForbidden {
+		t.Fatalf("valid-key status during active ban = %d, want %d (ban precheck must precede credential comparison); body=%s", rrDuringBan.Code, http.StatusForbidden, rrDuringBan.Body.String())
+	}
+
+	expireArmedBlocks(h.loginThrottle)
 
 	rrValid := httptest.NewRecorder()
 	reqValid := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
@@ -67,7 +98,7 @@ func TestMiddlewareAllowsValidKeyAfterRemoteIPIsBanned(t *testing.T) {
 	reqValid.Header.Set("Authorization", "Bearer "+managementKey)
 	router.ServeHTTP(rrValid, reqValid)
 	if rrValid.Code != http.StatusOK {
-		t.Fatalf("valid-key status after ban = %d, want %d; body=%s", rrValid.Code, http.StatusOK, rrValid.Body.String())
+		t.Fatalf("valid-key status after ban expired = %d, want %d; body=%s", rrValid.Code, http.StatusOK, rrValid.Body.String())
 	}
 
 	rrAfterClear := httptest.NewRecorder()
@@ -359,16 +390,21 @@ func TestMiddlewareThrottlesRelayedFailedAttempts(t *testing.T) {
 		return req
 	}
 
-	var banned bool
-	for i := 0; i < 12; i++ {
+	// The relayed key is Shared (untrusted proxy), so applySharedKeyDowngrade forces
+	// HardBlock=false: it must be rate-limited (429), never hard-banned (403).
+	var throttled bool
+	for i := 0; i < 15; i++ {
 		rr := httptest.NewRecorder()
 		router.ServeHTTP(rr, newRelayedRequest())
-		if rr.Code == http.StatusForbidden && strings.Contains(rr.Body.String(), "IP banned") {
-			banned = true
+		if rr.Code == http.StatusForbidden {
+			t.Fatalf("relayed (shared-key) attempt %d hard-banned with 403; want soft 429 only, body=%s", i+1, rr.Body.String())
+		}
+		if rr.Code == http.StatusTooManyRequests && strings.Contains(rr.Body.String(), "too_many_requests") {
+			throttled = true
 			break
 		}
 	}
-	if !banned {
+	if !throttled {
 		t.Fatal("relayed brute-force attempts were never throttled")
 	}
 }

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -180,60 +180,6 @@ func identityError(c *gin.Context, err error) {
 	c.AbortWithStatusJSON(status, gin.H{"error": gin.H{"code": code, "message": err.Error()}})
 }
 
-func (h *Handler) PostLogin(c *gin.Context) {
-	clientIP := c.ClientIP()
-	now := time.Now()
-	if remaining := h.loginThrottle.blockedFor(clientIP, now); remaining > 0 {
-		c.Header("Retry-After", retryAfterSecondsHeader(remaining.Round(time.Second)))
-		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": gin.H{"code": "login_rate_limited", "message": "too many login attempts"}})
-		return
-	}
-
-	var body struct {
-		Username   string `json:"username"`
-		Password   string `json:"password"`
-		RememberMe bool   `json:"remember_me"`
-	}
-	if err := c.ShouldBindJSON(&body); err != nil || strings.TrimSpace(body.Username) == "" || body.Password == "" {
-		identityError(c, identity.ErrInvalidCredentials)
-		return
-	}
-	service := h.identity()
-	if service == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{"code": "identity_unavailable", "message": "identity service unavailable"}})
-		return
-	}
-	result, err := service.Login(c.Request.Context(), body.Username, body.Password, body.RememberMe, c.GetHeader("User-Agent"))
-	if err != nil {
-		h.loginThrottle.recordFailure(clientIP, now)
-		identityError(c, err)
-		return
-	}
-	h.loginThrottle.recordSuccess(clientIP)
-	c.JSON(http.StatusOK, result)
-}
-
-func (h *Handler) PostRefresh(c *gin.Context) {
-	var body struct {
-		RefreshToken string `json:"refresh_token"`
-	}
-	if err := c.ShouldBindJSON(&body); err != nil || strings.TrimSpace(body.RefreshToken) == "" {
-		identityError(c, identity.ErrSessionRevoked)
-		return
-	}
-	service := h.identity()
-	if service == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{"code": "identity_unavailable", "message": "identity service unavailable"}})
-		return
-	}
-	result, err := service.RefreshSession(c.Request.Context(), body.RefreshToken)
-	if err != nil {
-		identityError(c, err)
-		return
-	}
-	c.JSON(http.StatusOK, result)
-}
-
 func (h *Handler) authenticateUserRequest(c *gin.Context) (identity.Principal, bool) {
 	token := bearerToken(c)
 	if !strings.HasPrefix(token, "cps_") {
@@ -247,36 +193,6 @@ func (h *Handler) authenticateUserRequest(c *gin.Context) (identity.Principal, b
 	}
 	c.Set(managementPrincipalKey, principal)
 	return principal, true
-}
-
-func (h *Handler) GetMe(c *gin.Context) {
-	principal, ok := h.authenticateUserRequest(c)
-	if !ok {
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"principal": principal})
-}
-
-func (h *Handler) PostLogout(c *gin.Context) {
-	principal, ok := h.authenticateUserRequest(c)
-	if !ok {
-		return
-	}
-	if err := h.identity().Logout(c.Request.Context(), principal.SessionID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "logout_failed", "message": err.Error()}})
-		return
-	}
-	h.identity().RecordAudit(c.Request.Context(), identity.AuditEvent{
-		TenantID:       principal.HomeTenant.ID,
-		ActorKind:      principal.Kind,
-		ActorUserID:    principal.User.ID,
-		ActorSessionID: principal.SessionID,
-		Action:         "auth.logout",
-		ResourceType:   "session",
-		ResourceID:     principal.SessionID,
-		Result:         "success",
-	})
-	c.Status(http.StatusNoContent)
 }
 
 func (h *Handler) PutPassword(c *gin.Context) {

--- a/internal/api/handlers/management/identity_auth_login.go
+++ b/internal/api/handlers/management/identity_auth_login.go
@@ -1,0 +1,150 @@
+package management
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+)
+
+func (h *Handler) PostLogin(c *gin.Context) {
+	now := time.Now()
+	// Password entry gets its own per-IP bucket, separate from the management-key
+	// bucket: a wrong management key must never cost users their ability to log in.
+	ipKey := h.clientThrottleKey(c, scopeUserPassword)
+	if d := h.loginThrottle.evaluate(ipKey, now); d.Outcome != outcomeAllow {
+		abortLoginThrottled(c, d)
+		return
+	}
+
+	var body struct {
+		Username   string `json:"username"`
+		Password   string `json:"password"`
+		RememberMe bool   `json:"remember_me"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || strings.TrimSpace(body.Username) == "" || body.Password == "" {
+		identityError(c, identity.ErrInvalidCredentials)
+		return
+	}
+	// The account bucket is the layer that actually stops guessing: it survives an
+	// attacker rotating source addresses, which the per-IP bucket cannot.
+	acctKey := accountThrottleKey(scopeUserAccount, identity.NormalizeUsername(body.Username))
+	if d := h.loginThrottle.evaluate(acctKey, now); d.Outcome != outcomeAllow {
+		abortLoginThrottled(c, d)
+		return
+	}
+	service := h.identity()
+	if service == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{"code": "identity_unavailable", "message": "identity service unavailable"}})
+		return
+	}
+	result, err := service.Login(c.Request.Context(), body.Username, body.Password, body.RememberMe, c.GetHeader("User-Agent"))
+	if err != nil {
+		if isCredentialGuessFailure(err) {
+			h.loginThrottle.recordFailure(ipKey, now)
+			d := h.loginThrottle.recordFailure(acctKey, now)
+			h.logAuthFailure(c, acctKey, d)
+		}
+		identityError(c, err)
+		return
+	}
+	// NIST SP 800-63B §5.2.2: a success clears that account's failures, never the
+	// per-IP quota — an attacker holding one valid account of their own would
+	// otherwise reset their guessing budget between stuffing rounds.
+	h.loginThrottle.recordSuccess(acctKey)
+	c.JSON(http.StatusOK, result)
+}
+
+// isCredentialGuessFailure reports whether a login error means a secret was
+// compared and did not match. Anything else must not consume the guess budget:
+// a suspended tenant, a disabled account and an infrastructure error all carry
+// zero information about the password, so counting them only produces lockouts
+// that the user cannot clear by typing the right password.
+func isCredentialGuessFailure(err error) bool {
+	return errors.Is(err, identity.ErrInvalidCredentials)
+}
+
+// abortLoginThrottled rejects a throttled login attempt. The "login_rate_limited"
+// code is a cross-repo contract: the panel's login page maps exactly that string
+// to its "try again later" copy, and anything else surfaces as a raw error.
+func abortLoginThrottled(c *gin.Context, d throttleDecision) {
+	retryAfter := d.RetryAfter.Round(time.Second)
+	c.Header("Retry-After", retryAfterSecondsHeader(retryAfter))
+	c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": gin.H{"code": "login_rate_limited", "message": "too many login attempts"}})
+}
+
+// adminRefreshTokenLength is len("cpr_adm_") + base64.RawURLEncoding(32 bytes).
+const adminRefreshTokenLength = 8 + 43
+
+// isWellFormedAdminRefreshToken rejects anything that cannot be a token this
+// server issued. It exists so the unauthenticated refresh endpoint does not turn
+// arbitrary request bodies into database lookups.
+func isWellFormedAdminRefreshToken(token string) bool {
+	t := strings.TrimSpace(token)
+	return len(t) == adminRefreshTokenLength && strings.HasPrefix(t, "cpr_adm_")
+}
+
+func (h *Handler) PostRefresh(c *gin.Context) {
+	// Unauthenticated and one database lookup per call: charge every attempt, not
+	// just the failures, because a caller that can already refresh successfully
+	// has no reason to do so sixty times in five minutes.
+	if d := h.loginThrottle.recordFailure(h.clientThrottleKey(c, scopeRefresh), time.Now()); d.Outcome != outcomeAllow {
+		abortThrottled(c, d)
+		return
+	}
+	var body struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || strings.TrimSpace(body.RefreshToken) == "" {
+		identityError(c, identity.ErrSessionRevoked)
+		return
+	}
+	if !isWellFormedAdminRefreshToken(body.RefreshToken) {
+		identityError(c, identity.ErrSessionRevoked)
+		return
+	}
+	service := h.identity()
+	if service == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": gin.H{"code": "identity_unavailable", "message": "identity service unavailable"}})
+		return
+	}
+	result, err := service.RefreshSession(c.Request.Context(), body.RefreshToken)
+	if err != nil {
+		identityError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *Handler) GetMe(c *gin.Context) {
+	principal, ok := h.authenticateUserRequest(c)
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"principal": principal})
+}
+
+func (h *Handler) PostLogout(c *gin.Context) {
+	principal, ok := h.authenticateUserRequest(c)
+	if !ok {
+		return
+	}
+	if err := h.identity().Logout(c.Request.Context(), principal.SessionID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "logout_failed", "message": err.Error()}})
+		return
+	}
+	h.identity().RecordAudit(c.Request.Context(), identity.AuditEvent{
+		TenantID:       principal.HomeTenant.ID,
+		ActorKind:      principal.Kind,
+		ActorUserID:    principal.User.ID,
+		ActorSessionID: principal.SessionID,
+		Action:         "auth.logout",
+		ResourceType:   "session",
+		ResourceID:     principal.SessionID,
+		Result:         "success",
+	})
+	c.Status(http.StatusNoContent)
+}

--- a/internal/api/handlers/management/login_throttle.go
+++ b/internal/api/handlers/management/login_throttle.go
@@ -1,99 +1,412 @@
 package management
 
 import (
+	"hash/fnv"
+	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
+
+// throttleScope separates credential-guessing buckets from credential-less
+// traffic. A request that carried no secret proves nothing about the secret,
+// so counting it as a guess only produces false lockouts — and today it is a
+// zero-cost way for anyone sharing an egress IP to ban the whole deployment.
+type throttleScope uint8
 
 const (
-	// loginCleanupInterval controls how often stale IP entries are purged.
-	loginCleanupInterval = 1 * time.Hour
-	// loginMaxIdleTime controls how long an IP can be idle before cleanup.
-	loginMaxIdleTime = 2 * time.Hour
-	// loginMaxFailures is how many consecutive failures trigger a block.
-	loginMaxFailures = 5
-	// loginBlockDuration is how long a blocked IP stays blocked.
-	loginBlockDuration = 30 * time.Minute
+	scopeUnauthenticated throttleScope = iota
+	scopeManagementKey
+	scopeUserPassword
+	scopeUserAccount
+	scopeRefresh
+	scopePortalPassword
+	scopePortalAccount
 )
 
-type loginAttempt struct {
-	count        int
+func (s throttleScope) String() string {
+	switch s {
+	case scopeUnauthenticated:
+		return "unauthenticated"
+	case scopeManagementKey:
+		return "management_key"
+	case scopeUserPassword:
+		return "user_password"
+	case scopeUserAccount:
+		return "user_account"
+	case scopeRefresh:
+		return "refresh"
+	case scopePortalPassword:
+		return "portal_password"
+	case scopePortalAccount:
+		return "portal_account"
+	default:
+		return "unknown"
+	}
+}
+
+type throttleOutcome uint8
+
+const (
+	outcomeAllow throttleOutcome = iota
+	// outcomeRateLimited is a soft 429 + Retry-After. Its message must never
+	// contain "IP banned": the admin panel treats that string as proof the
+	// session is dead and forces a logout.
+	outcomeRateLimited
+	// outcomeBlocked is a hard 403 ban, only reachable for wrong-credential
+	// scopes whose key identifies a single client.
+	outcomeBlocked
+)
+
+func (o throttleOutcome) String() string {
+	switch o {
+	case outcomeAllow:
+		return "allow"
+	case outcomeRateLimited:
+		return "rate_limited"
+	case outcomeBlocked:
+		return "blocked"
+	default:
+		return "unknown"
+	}
+}
+
+type throttleDecision struct {
+	Outcome    throttleOutcome
+	RetryAfter time.Duration
+	Scope      throttleScope
+	Generation int
+	ShortCount int
+	LongCount  int
+	// NewlyArmed is true only on the transition into a block, so a brute-force
+	// run logs one Warn instead of one per rejected request.
+	NewlyArmed bool
+}
+
+const (
+	throttleShortSlotCount  = 12
+	throttleLongSlotCount   = 24
+	throttleShardCount      = 16
+	maxTrackedKeys          = 20000
+	throttleCleanupInterval = 10 * time.Minute
+	throttleEvictBatchRatio = 8
+	// throttleMinIdleRetention floors how long an idle bucket is kept even when
+	// every configured ResetAfter is shorter.
+	throttleMinIdleRetention = 2 * time.Hour
+)
+
+// maxShardKeys is the per-shard capacity that enforces the global bound.
+const maxShardKeys = maxTrackedKeys / throttleShardCount
+
+// windowSlot is one sub-bucket of a sliding window. Storing a counter per slot
+// instead of a timestamp per event keeps memory flat under attack: a burst of a
+// million failures costs the same as a handful.
+type windowSlot struct {
+	index int64
+	count int32
+}
+
+type throttleEntry struct {
+	short        [throttleShortSlotCount]windowSlot
+	long         [throttleLongSlotCount]windowSlot
 	blockedUntil time.Time
+	generation   int
 	lastActivity time.Time
 }
 
-// loginThrottle rate-limits management login attempts per client IP.
+type throttleShard struct {
+	mu      sync.Mutex
+	entries map[string]*throttleEntry
+}
+
+// loginThrottle rate-limits management authentication attempts per bucket key.
 //
 // State is per process and deliberately in-memory: it protects against online
-// password guessing against a single instance, not against a distributed attack,
-// and losing it on restart only costs an attacker's progress, never a legitimate
-// user's access. Entries are purged on a timer so a hostile IP range cannot grow
-// the map without bound.
+// guessing against a single instance, not against a distributed attack, and
+// losing it on restart only costs an attacker's progress, never a legitimate
+// user's access.
+//
+// Sharded because the credential-less bucket is charged on the middleware hot
+// path by every unauthenticated request, where a single mutex would serialise
+// the whole management surface.
 type loginThrottle struct {
-	mu       sync.Mutex
-	attempts map[string]*loginAttempt
-
+	shards   [throttleShardCount]throttleShard
+	policies atomic.Pointer[map[throttleScope]throttlePolicy]
 	stopOnce sync.Once
 	stop     chan struct{}
 }
 
-func newLoginThrottle() *loginThrottle {
-	t := &loginThrottle{
-		attempts: make(map[string]*loginAttempt),
-		stop:     make(chan struct{}),
+func newLoginThrottle(policies map[throttleScope]throttlePolicy) *loginThrottle {
+	t := &loginThrottle{stop: make(chan struct{})}
+	for i := range t.shards {
+		t.shards[i].entries = make(map[string]*throttleEntry)
 	}
+	t.setPolicies(policies)
 	go t.cleanupLoop()
 	return t
 }
 
-// blockedFor reports the remaining block duration for the client, or zero when
-// the client may attempt a login.
-func (t *loginThrottle) blockedFor(clientIP string, now time.Time) time.Duration {
-	if t == nil {
-		return 0
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	attempt := t.attempts[clientIP]
-	if attempt == nil || attempt.blockedUntil.IsZero() || !now.Before(attempt.blockedUntil) {
-		return 0
-	}
-	return attempt.blockedUntil.Sub(now)
-}
-
-// recordFailure counts a failed login and blocks the client once it reaches
-// loginMaxFailures.
-func (t *loginThrottle) recordFailure(clientIP string, now time.Time) {
+// setPolicies swaps the whole table atomically so a config hot-reload cannot be
+// observed half-applied by an in-flight request.
+func (t *loginThrottle) setPolicies(p map[throttleScope]throttlePolicy) {
 	if t == nil {
 		return
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	attempt := t.attempts[clientIP]
-	if attempt == nil {
-		attempt = &loginAttempt{}
-		t.attempts[clientIP] = attempt
+	if p == nil {
+		p = defaultThrottlePolicies()
 	}
-	attempt.count++
-	attempt.lastActivity = now
-	if attempt.count >= loginMaxFailures {
-		attempt.blockedUntil = now.Add(loginBlockDuration)
-		attempt.count = 0
+	snapshot := make(map[throttleScope]throttlePolicy, len(p))
+	for scope, policy := range p {
+		snapshot[scope] = policy
+	}
+	t.policies.Store(&snapshot)
+}
+
+func (t *loginThrottle) policySnapshot() map[throttleScope]throttlePolicy {
+	if t == nil {
+		return nil
+	}
+	if p := t.policies.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// policyFor resolves the effective policy for a key. The shared-key downgrade is
+// applied here rather than stored on the entry so a key that becomes shared (or
+// stops being shared) after trusted-proxies is fixed takes effect immediately.
+func (t *loginThrottle) policyFor(key throttleKey) throttlePolicy {
+	snapshot := t.policySnapshot()
+	policy, ok := snapshot[key.Scope]
+	if !ok {
+		policy = defaultThrottlePolicies()[key.Scope]
+	}
+	if key.Shared {
+		policy = applySharedKeyDowngrade(policy)
+	}
+	return policy
+}
+
+// limitsFor exposes the effective thresholds for logging, so an operator reading
+// "short_count=9 limit=10" can tell how close a client is without reverse
+// engineering the shared-key downgrade from the policy table.
+func (t *loginThrottle) limitsFor(key throttleKey) (short, long int) {
+	if t == nil {
+		return 0, 0
+	}
+	policy := t.policyFor(key)
+	return policy.Short.Limit, policy.Long.Limit
+}
+
+func (t *loginThrottle) shardFor(bucket string) *throttleShard {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(bucket))
+	return &t.shards[hasher.Sum32()%throttleShardCount]
+}
+
+func bucketID(key throttleKey) string {
+	return key.Scope.String() + "|" + key.Value
+}
+
+// evaluate reports the current standing of a bucket without charging it. It is
+// the pre-flight check that must run before any password hashing, so a banned
+// client cannot spend the server's CPU.
+func (t *loginThrottle) evaluate(key throttleKey, now time.Time) throttleDecision {
+	if t == nil {
+		return throttleDecision{Scope: key.Scope}
+	}
+	policy := t.policyFor(key)
+	bucket := bucketID(key)
+	shard := t.shardFor(bucket)
+
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+	entry := shard.entries[bucket]
+	if entry == nil || !entry.blockedUntil.After(now) {
+		return throttleDecision{Scope: key.Scope}
+	}
+	return throttleDecision{
+		Outcome:    blockOutcome(policy),
+		RetryAfter: entry.blockedUntil.Sub(now),
+		Scope:      key.Scope,
+		Generation: entry.generation,
+		ShortCount: countWindow(entry.short[:], policy.Short, now),
+		LongCount:  countWindow(entry.long[:], policy.Long, now),
 	}
 }
 
-// recordSuccess clears any recorded failures for the client.
-func (t *loginThrottle) recordSuccess(clientIP string) {
+// recordFailure charges one failure against the bucket and reports the resulting
+// standing. Requests arriving while a block is already armed are rejected
+// without being counted, so an attacker cannot escalate their own penalty by
+// hammering a closed door.
+func (t *loginThrottle) recordFailure(key throttleKey, now time.Time) throttleDecision {
+	if t == nil {
+		return throttleDecision{Scope: key.Scope}
+	}
+	policy := t.policyFor(key)
+	bucket := bucketID(key)
+	shard := t.shardFor(bucket)
+
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+
+	entry := shard.entries[bucket]
+	if entry == nil {
+		t.evictIfSaturatedLocked(shard, now)
+		entry = &throttleEntry{}
+		shard.entries[bucket] = entry
+	} else if policy.ResetAfter > 0 && !entry.lastActivity.IsZero() &&
+		now.Sub(entry.lastActivity) >= policy.ResetAfter {
+		// A quiet period clears both the counters and the escalation ladder, so a
+		// user who mistyped their password months ago does not start at a 30m ban.
+		*entry = throttleEntry{}
+	}
+	entry.lastActivity = now
+
+	if entry.blockedUntil.After(now) {
+		return throttleDecision{
+			Outcome:    blockOutcome(policy),
+			RetryAfter: entry.blockedUntil.Sub(now),
+			Scope:      key.Scope,
+			Generation: entry.generation,
+			ShortCount: countWindow(entry.short[:], policy.Short, now),
+			LongCount:  countWindow(entry.long[:], policy.Long, now),
+		}
+	}
+
+	addToWindow(entry.short[:], policy.Short, now)
+	addToWindow(entry.long[:], policy.Long, now)
+	shortCount := countWindow(entry.short[:], policy.Short, now)
+	longCount := countWindow(entry.long[:], policy.Long, now)
+
+	decision := throttleDecision{
+		Scope:      key.Scope,
+		Generation: entry.generation,
+		ShortCount: shortCount,
+		LongCount:  longCount,
+	}
+	shortTripped := policy.Short.Limit > 0 && shortCount >= policy.Short.Limit
+	longTripped := policy.Long.Limit > 0 && longCount >= policy.Long.Limit
+	if !shortTripped && !longTripped {
+		return decision
+	}
+
+	wait := blockDurationFor(policy, entry.generation)
+	if wait <= 0 {
+		return decision
+	}
+	entry.blockedUntil = now.Add(wait)
+	entry.generation++
+	decision.Outcome = blockOutcome(policy)
+	decision.RetryAfter = wait
+	decision.Generation = entry.generation
+	decision.NewlyArmed = true
+	return decision
+}
+
+// recordSuccess clears exactly one bucket.
+//
+// NIST SP 800-63B §5.2.2: a successful login clears that account's failures. It
+// must not clear a per-IP bucket, or an attacker holding one valid account of
+// their own could reset their guessing budget between rounds.
+func (t *loginThrottle) recordSuccess(key throttleKey) {
 	if t == nil {
 		return
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	delete(t.attempts, clientIP)
+	bucket := bucketID(key)
+	shard := t.shardFor(bucket)
+	shard.mu.Lock()
+	delete(shard.entries, bucket)
+	shard.mu.Unlock()
+}
+
+func blockOutcome(policy throttlePolicy) throttleOutcome {
+	if policy.HardBlock {
+		return outcomeBlocked
+	}
+	return outcomeRateLimited
+}
+
+// slotDuration is the width of one sub-bucket. Precision is therefore
+// ±Window/slotCount, and the error always over-counts stale failures, which is
+// the conservative direction.
+func slotDuration(window throttleWindow, slotCount int) time.Duration {
+	if window.Window <= 0 || slotCount <= 0 {
+		return 0
+	}
+	return window.Window / time.Duration(slotCount)
+}
+
+func addToWindow(slots []windowSlot, window throttleWindow, now time.Time) {
+	if window.Limit <= 0 {
+		return
+	}
+	width := slotDuration(window, len(slots))
+	if width <= 0 {
+		return
+	}
+	index := now.UnixNano() / int64(width)
+	slot := &slots[int(index%int64(len(slots)))]
+	if slot.index != index {
+		slot.index = index
+		slot.count = 0
+	}
+	slot.count++
+}
+
+func countWindow(slots []windowSlot, window throttleWindow, now time.Time) int {
+	if window.Limit <= 0 {
+		return 0
+	}
+	width := slotDuration(window, len(slots))
+	if width <= 0 {
+		return 0
+	}
+	current := now.UnixNano() / int64(width)
+	oldest := current - int64(len(slots)) + 1
+	total := 0
+	for i := range slots {
+		if slots[i].index >= oldest && slots[i].index <= current {
+			total += int(slots[i].count)
+		}
+	}
+	return total
+}
+
+// evictIfSaturatedLocked drops the least recently active fraction of a shard once
+// it reaches capacity, bounding memory at ~maxTrackedKeys entries. Eviction is
+// LRU rather than random so an active attacker's bucket is the last thing
+// dropped; the alternative is letting an IPv6 /64 holder mint buckets until the
+// process OOMs.
+func (t *loginThrottle) evictIfSaturatedLocked(shard *throttleShard, now time.Time) {
+	total := len(shard.entries)
+	if total < maxShardKeys {
+		return
+	}
+	type aged struct {
+		key  string
+		seen time.Time
+	}
+	candidates := make([]aged, 0, total)
+	for key, entry := range shard.entries {
+		candidates = append(candidates, aged{key: key, seen: entry.lastActivity})
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].seen.Before(candidates[j].seen) })
+
+	evict := len(candidates) / throttleEvictBatchRatio
+	if evict < 1 {
+		evict = 1
+	}
+	for i := 0; i < evict; i++ {
+		delete(shard.entries, candidates[i].key)
+	}
+	warnThrottleSaturation(evict, total)
 }
 
 func (t *loginThrottle) cleanupLoop() {
-	ticker := time.NewTicker(loginCleanupInterval)
+	ticker := time.NewTicker(throttleCleanupInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -105,27 +418,57 @@ func (t *loginThrottle) cleanupLoop() {
 	}
 }
 
-// purgeStale drops entries that are idle beyond loginMaxIdleTime.
+// idleRetention is the longest ResetAfter in the active policy table: past that
+// point a bucket would be reset on its next charge anyway, so dropping it is
+// semantically identical and just reclaims memory.
+func (t *loginThrottle) idleRetention() time.Duration {
+	retention := throttleMinIdleRetention
+	for _, policy := range t.policySnapshot() {
+		if policy.ResetAfter > retention {
+			retention = policy.ResetAfter
+		}
+	}
+	return retention
+}
+
+// purgeStale drops entries idle beyond idleRetention.
 //
-// Entries still inside their block window are kept. With the current constants
-// that case cannot arise (a block lasts 30m, well under the 2h idle threshold,
-// so any idle-enough entry is already unblocked), but the guard keeps the
-// invariant true if loginBlockDuration is ever raised above loginMaxIdleTime —
-// without it, an attacker could shed a long block simply by going quiet.
+// Entries still inside their block window are kept regardless of idleness —
+// without that guard an attacker could shed a long block simply by going quiet.
 func (t *loginThrottle) purgeStale(now time.Time) {
 	if t == nil {
 		return
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	for ip, attempt := range t.attempts {
-		if !attempt.blockedUntil.IsZero() && now.Before(attempt.blockedUntil) {
-			continue
+	retention := t.idleRetention()
+	for i := range t.shards {
+		shard := &t.shards[i]
+		shard.mu.Lock()
+		for key, entry := range shard.entries {
+			if entry.blockedUntil.After(now) {
+				continue
+			}
+			if now.Sub(entry.lastActivity) > retention {
+				delete(shard.entries, key)
+			}
 		}
-		if now.Sub(attempt.lastActivity) > loginMaxIdleTime {
-			delete(t.attempts, ip)
-		}
+		shard.mu.Unlock()
 	}
+}
+
+// trackedKeys reports the total number of live buckets. Test-facing helper that
+// also keeps the shard iteration lock discipline in one place.
+func (t *loginThrottle) trackedKeys() int {
+	if t == nil {
+		return 0
+	}
+	total := 0
+	for i := range t.shards {
+		shard := &t.shards[i]
+		shard.mu.Lock()
+		total += len(shard.entries)
+		shard.mu.Unlock()
+	}
+	return total
 }
 
 // close stops the cleanup goroutine. Safe to call more than once.
@@ -134,4 +477,25 @@ func (t *loginThrottle) close() {
 		return
 	}
 	t.stopOnce.Do(func() { close(t.stop) })
+}
+
+// throttleSaturationWarn deduplicates the saturation warning: under the attack
+// that causes it, one log line per evicted batch would itself be a log flood.
+var throttleSaturationWarn struct {
+	mu   sync.Mutex
+	last time.Time
+}
+
+const warnDedupInterval = 10 * time.Minute
+
+func warnThrottleSaturation(evicted, total int) {
+	now := time.Now()
+	throttleSaturationWarn.mu.Lock()
+	if !throttleSaturationWarn.last.IsZero() && now.Sub(throttleSaturationWarn.last) < warnDedupInterval {
+		throttleSaturationWarn.mu.Unlock()
+		return
+	}
+	throttleSaturationWarn.last = now
+	throttleSaturationWarn.mu.Unlock()
+	log.Warnf("auth-throttle: key table saturated, evicted %d of %d entries", evicted, total)
 }

--- a/internal/api/handlers/management/login_throttle_key.go
+++ b/internal/api/handlers/management/login_throttle_key.go
@@ -1,0 +1,164 @@
+package management
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	log "github.com/sirupsen/logrus"
+)
+
+type throttleKey struct {
+	Scope throttleScope
+	Value string
+	// Shared marks a key that cannot be trusted to identify a single client, so
+	// the penalty must stay soft: hard-banning it takes down every user behind
+	// the same proxy or NAT.
+	Shared bool
+}
+
+// unknownThrottleValue is the catch-all bucket for peers whose address cannot be
+// parsed. It is always shared so it can never produce a hard ban.
+const unknownThrottleValue = "unknown"
+
+// clientThrottleKey derives the bucket key from the framework's trusted-proxy
+// aware client IP, then normalises it to a prefix so an attacker holding an
+// IPv6 /64 (free with most VPS) cannot mint 2^64 distinct buckets and OOM the
+// process. Forwarding headers are NEVER used as the key directly: they are
+// attacker-controlled, so an attacker could both evade their own ban and fill
+// an arbitrary victim's bucket.
+func (h *Handler) clientThrottleKey(c *gin.Context, scope throttleScope) throttleKey {
+	peer := resolveThrottlePeer(c)
+	value, shared := normalizeThrottleIP(peer)
+
+	// A relay header with no trusted-proxies means gin is reporting the proxy's
+	// address for every client, so this one bucket stands for all of them.
+	if c != nil && c.Request != nil {
+		if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" && !h.proxyTrustConfigured() {
+			shared = true
+			warnUntrustedProxyOnce(peer, relayHeader)
+		}
+	}
+	return throttleKey{Scope: scope, Value: value, Shared: shared}
+}
+
+// normalizeThrottleIP collapses IPv4 to /32 and IPv6 to /64.
+// Returns ("unknown", true) when no address can be parsed at all — that bucket
+// is always treated as shared so it can never produce a hard ban.
+func normalizeThrottleIP(raw string) (value string, shared bool) {
+	candidate := strings.TrimSpace(raw)
+	if candidate == "" {
+		return unknownThrottleValue, true
+	}
+	// Accept "host:port", "[v6]:port" and bare addresses alike; a port in the key
+	// would make every new connection a new bucket.
+	if host, _, err := net.SplitHostPort(candidate); err == nil {
+		candidate = host
+	}
+	candidate = strings.TrimPrefix(candidate, "[")
+	candidate = strings.TrimSuffix(candidate, "]")
+	if zone := strings.IndexByte(candidate, '%'); zone >= 0 {
+		candidate = candidate[:zone]
+	}
+	ip := net.ParseIP(strings.TrimSpace(candidate))
+	if ip == nil {
+		return unknownThrottleValue, true
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String() + "/32", false
+	}
+	return ip.Mask(net.CIDRMask(64, 128)).String() + "/64", false
+}
+
+// resolveThrottlePeer mirrors internal/api/public_lookup_middleware.go:
+// ClientIP() -> RemoteAddr -> "unknown". Never returns "".
+//
+// Falling back rather than skipping the throttle is deliberate: a fail-open
+// branch here would be an attacker-operable switch for turning rate limiting off.
+func resolveThrottlePeer(c *gin.Context) string {
+	if c == nil {
+		return unknownThrottleValue
+	}
+	if ip := strings.TrimSpace(c.ClientIP()); ip != "" {
+		return ip
+	}
+	if c.Request != nil {
+		if remote := strings.TrimSpace(c.Request.RemoteAddr); remote != "" {
+			return remote
+		}
+	}
+	return unknownThrottleValue
+}
+
+// proxyTrustConfigured reports whether the operator declared any trusted proxy.
+func (h *Handler) proxyTrustConfigured() bool {
+	if h == nil || h.cfg == nil {
+		return false
+	}
+	for _, proxy := range h.cfg.TrustedProxies {
+		if strings.TrimSpace(proxy) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// untrustedProxyWarn deduplicates the misconfiguration warning; without it every
+// single request behind the proxy would emit a line.
+var untrustedProxyWarn struct {
+	mu   sync.Mutex
+	last time.Time
+}
+
+// warnUntrustedProxyOnce logs at most once per 10 minutes per process.
+func warnUntrustedProxyOnce(peer, relayHeader string) {
+	now := time.Now()
+	untrustedProxyWarn.mu.Lock()
+	if !untrustedProxyWarn.last.IsZero() && now.Sub(untrustedProxyWarn.last) < warnDedupInterval {
+		untrustedProxyWarn.mu.Unlock()
+		return
+	}
+	untrustedProxyWarn.last = now
+	untrustedProxyWarn.mu.Unlock()
+
+	// The remediation string is spelled out in full so an operator can paste it
+	// into config.yaml without first working out that the proxy, not the client,
+	// is what has to be trusted.
+	hint := util.RemoteAddrIP(peer)
+	if hint == "" {
+		hint = peer
+	}
+	log.Warnf("auth-throttle: request relayed (%s present) but trusted-proxies is empty, so every client behind %s shares one throttle bucket and hard bans are downgraded to soft limits. Fix: trusted-proxies: [\"%s/32\"]",
+		relayHeader, peer, hint)
+}
+
+func accountThrottleKey(scope throttleScope, normalizedUsername string) throttleKey {
+	value := strings.TrimSpace(normalizedUsername)
+	if value == "" {
+		value = unknownThrottleValue
+	}
+	// Account buckets are never shared: the key names one account, so the penalty
+	// can stay at full strength without collateral damage.
+	return throttleKey{Scope: scope, Value: value}
+}
+
+// maskThrottleKey renders a key for logs. IPs stay readable because operators
+// need them to write a firewall rule; usernames are truncated because a failed
+// login is frequently a password typed into the username field.
+func maskThrottleKey(k throttleKey) string {
+	switch k.Scope {
+	case scopeUserAccount, scopePortalAccount:
+		runes := []rune(k.Value)
+		prefix := runes
+		if len(prefix) > 2 {
+			prefix = prefix[:2]
+		}
+		return fmt.Sprintf("%s***(len=%d)", string(prefix), len(runes))
+	default:
+		return k.Value
+	}
+}

--- a/internal/api/handlers/management/login_throttle_policy.go
+++ b/internal/api/handlers/management/login_throttle_policy.go
@@ -1,0 +1,191 @@
+package management
+
+import (
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// throttleWindow is one observation window of a sliding-window counter.
+// A zero Limit disables the window entirely.
+type throttleWindow struct {
+	Limit  int
+	Window time.Duration
+}
+
+// throttlePolicy is the full OWASP "threshold + observation window + duration"
+// triple for one bucket, plus the escalation ladder.
+//
+// Two windows are used instead of one because a single 15m/5 window still
+// permits ~384 guesses per day against one account, which is enough for a
+// password-spraying run. The long window caps the daily budget while the short
+// window keeps the response to a burst immediate.
+type throttlePolicy struct {
+	Short throttleWindow
+	// Long is the daily ceiling. Limit == 0 disables it.
+	Long throttleWindow
+	// Backoff is the staged block duration ladder, indexed by generation.
+	Backoff []time.Duration
+	// ResetAfter is the quiet period that clears counters and escalation.
+	ResetAfter time.Duration
+	// HardBlock allows a 403 ban instead of a 429. Only meaningful for buckets
+	// that can only be filled by comparing a wrong secret from a single client.
+	HardBlock bool
+}
+
+const (
+	defaultLoginFailureWindow        = 15 * time.Minute
+	defaultAccountFailureLimit       = 5
+	defaultManagementKeyFailureLimit = 10
+	defaultUnauthenticatedLimit      = 300
+	defaultFailureResetAfter         = 12 * time.Hour
+)
+
+// defaultThrottlePolicies is the shipped policy table.
+//
+// Rationale for the specific numbers: ASVS V2.2.1's "100 per hour per account"
+// is a ceiling rather than a target, so the admin surface sits far below it;
+// Keycloak's default Failure Reset Time is 12h; Auth0's suspicious-IP default is
+// 100/day. scopeUnauthenticated is deliberately the only high-volume bucket and
+// deliberately never hard-blocks: a request that carried no secret proves
+// nothing about the secret, so it may throttle but must never ban.
+func defaultThrottlePolicies() map[throttleScope]throttlePolicy {
+	return map[throttleScope]throttlePolicy{
+		scopeUnauthenticated: {
+			Short:      throttleWindow{Limit: defaultUnauthenticatedLimit, Window: time.Hour},
+			Backoff:    []time.Duration{time.Minute, 5 * time.Minute},
+			ResetAfter: 2 * time.Hour,
+			HardBlock:  false,
+		},
+		scopeManagementKey: {
+			Short:      throttleWindow{Limit: defaultManagementKeyFailureLimit, Window: defaultLoginFailureWindow},
+			Long:       throttleWindow{Limit: 100, Window: 24 * time.Hour},
+			Backoff:    []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute, 30 * time.Minute},
+			ResetAfter: defaultFailureResetAfter,
+			HardBlock:  true,
+		},
+		scopeUserPassword: {
+			Short:      throttleWindow{Limit: 20, Window: defaultLoginFailureWindow},
+			Long:       throttleWindow{Limit: 100, Window: 24 * time.Hour},
+			Backoff:    []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute},
+			ResetAfter: defaultFailureResetAfter,
+			HardBlock:  false,
+		},
+		scopeUserAccount: {
+			Short:      throttleWindow{Limit: defaultAccountFailureLimit, Window: defaultLoginFailureWindow},
+			Long:       throttleWindow{Limit: 50, Window: 24 * time.Hour},
+			Backoff:    []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute, 30 * time.Minute, 60 * time.Minute},
+			ResetAfter: defaultFailureResetAfter,
+			HardBlock:  false,
+		},
+		scopeRefresh: {
+			Short:      throttleWindow{Limit: 60, Window: 5 * time.Minute},
+			Backoff:    []time.Duration{time.Minute},
+			ResetAfter: time.Hour,
+			HardBlock:  false,
+		},
+		scopePortalPassword: {
+			Short:      throttleWindow{Limit: 20, Window: defaultLoginFailureWindow},
+			Long:       throttleWindow{Limit: 100, Window: 24 * time.Hour},
+			Backoff:    []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute},
+			ResetAfter: defaultFailureResetAfter,
+			HardBlock:  false,
+		},
+		scopePortalAccount: {
+			Short:      throttleWindow{Limit: defaultAccountFailureLimit, Window: defaultLoginFailureWindow},
+			Long:       throttleWindow{Limit: 50, Window: 24 * time.Hour},
+			Backoff:    []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute, 30 * time.Minute, 60 * time.Minute},
+			ResetAfter: defaultFailureResetAfter,
+			HardBlock:  false,
+		},
+	}
+}
+
+// throttlePoliciesFromConfig overlays remote-management.auth onto the defaults.
+// Every knob is zero-means-default so an absent config block behaves exactly
+// like the shipped table, and non-positive overrides are ignored rather than
+// disabling a bucket (a limit of 0 would otherwise ban on the first request).
+func throttlePoliciesFromConfig(cfg *config.Config) map[throttleScope]throttlePolicy {
+	policies := defaultThrottlePolicies()
+	if cfg == nil {
+		return policies
+	}
+	auth := cfg.RemoteManagement.Auth
+
+	if seconds := auth.LoginFailureWindowSeconds; seconds > 0 {
+		window := time.Duration(seconds) * time.Second
+		for _, scope := range credentialGuessScopes {
+			policy := policies[scope]
+			policy.Short.Window = window
+			policies[scope] = policy
+		}
+	}
+	if hours := auth.FailureResetHours; hours > 0 {
+		reset := time.Duration(hours) * time.Hour
+		for _, scope := range credentialGuessScopes {
+			policy := policies[scope]
+			policy.ResetAfter = reset
+			policies[scope] = policy
+		}
+	}
+	if limit := auth.AccountFailureLimit; limit > 0 {
+		for _, scope := range []throttleScope{scopeUserAccount, scopePortalAccount} {
+			policy := policies[scope]
+			policy.Short.Limit = limit
+			policies[scope] = policy
+		}
+	}
+	if limit := auth.ManagementKeyFailureLimit; limit > 0 {
+		policy := policies[scopeManagementKey]
+		policy.Short.Limit = limit
+		policies[scopeManagementKey] = policy
+	}
+	if limit := auth.UnauthenticatedRequestLimit; limit > 0 {
+		policy := policies[scopeUnauthenticated]
+		policy.Short.Limit = limit
+		policies[scopeUnauthenticated] = policy
+	}
+	return policies
+}
+
+// credentialGuessScopes are the buckets that only fill when a stored secret was
+// actually compared. scopeUnauthenticated and scopeRefresh are excluded: they
+// carry no guess signal, so the operator-facing "login failure window" knob must
+// not stretch their much shorter windows.
+var credentialGuessScopes = []throttleScope{
+	scopeManagementKey,
+	scopeUserPassword,
+	scopeUserAccount,
+	scopePortalPassword,
+	scopePortalAccount,
+}
+
+// blockDurationFor picks the staged block duration for the given generation,
+// clamping to the last rung so escalation plateaus instead of overflowing.
+func blockDurationFor(p throttlePolicy, generation int) time.Duration {
+	if len(p.Backoff) == 0 {
+		return 0
+	}
+	if generation < 0 {
+		generation = 0
+	}
+	if generation >= len(p.Backoff) {
+		generation = len(p.Backoff) - 1
+	}
+	return p.Backoff[generation]
+}
+
+// applySharedKeyDowngrade neutralises the "one wrong password bans everyone"
+// failure mode: when the client IP cannot identify a single client, a hard ban
+// would take down every user behind that proxy/NAT. The account-scoped bucket
+// stays at full strength, which is the layer that actually stops guessing.
+func applySharedKeyDowngrade(p throttlePolicy) throttlePolicy {
+	p.HardBlock = false
+	if len(p.Backoff) > 1 {
+		p.Backoff = p.Backoff[:1]
+	}
+	if p.Long.Limit > 0 {
+		p.Long.Limit *= 2
+	}
+	return p
+}

--- a/internal/api/handlers/management/login_throttle_test.go
+++ b/internal/api/handlers/management/login_throttle_test.go
@@ -1,124 +1,486 @@
 package management
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
 
-func newTestThrottle() *loginThrottle {
-	// Constructed directly so the test does not start the cleanup goroutine;
-	// purgeStale is driven explicitly with a fake clock instead.
-	return &loginThrottle{
-		attempts: make(map[string]*loginAttempt),
-		stop:     make(chan struct{}),
+// newTestThrottle builds a loginThrottle without starting the cleanup goroutine,
+// so tests control purging explicitly with a fake clock instead of racing a real
+// 10-minute ticker.
+func newTestThrottle(policies map[throttleScope]throttlePolicy) *loginThrottle {
+	th := &loginThrottle{stop: make(chan struct{})}
+	for i := range th.shards {
+		th.shards[i].entries = make(map[string]*throttleEntry)
+	}
+	th.setPolicies(policies)
+	return th
+}
+
+// expireArmedBlocks rewinds every armed block into the past so a test can observe
+// post-ban behaviour deterministically. Tests that drive the throttle through the
+// HTTP middleware cannot inject a clock — the middleware reads time.Now() itself —
+// and sleeping out a real block is unreliable: the bcrypt comparisons that arm the
+// ban are slow enough under -race that a block short enough to sleep through is
+// also short enough to expire before the assertion that depends on it runs.
+func expireArmedBlocks(t *loginThrottle) {
+	past := time.Now().Add(-time.Second)
+	for i := range t.shards {
+		shard := &t.shards[i]
+		shard.mu.Lock()
+		for _, entry := range shard.entries {
+			if !entry.blockedUntil.IsZero() {
+				entry.blockedUntil = past
+			}
+		}
+		shard.mu.Unlock()
 	}
 }
 
-func TestLoginThrottleBlocksAfterMaxFailures(t *testing.T) {
+// TestSlidingWindowDropsFailuresOutsideWindow is the B1 regression anchor: the old
+// throttle counted failures with no time dimension at all, so four-month-old
+// mistypes and this second's mistype counted the same.
+func TestSlidingWindowDropsFailuresOutsideWindow(t *testing.T) {
 	t.Parallel()
 
-	throttle := newTestThrottle()
-	now := time.Now()
+	policy := throttlePolicy{
+		Short:      throttleWindow{Limit: 5, Window: 15 * time.Minute},
+		Backoff:    []time.Duration{time.Minute},
+		ResetAfter: 12 * time.Hour,
+	}
+	th := newTestThrottle(map[throttleScope]throttlePolicy{scopeUserAccount: policy})
+	key := accountThrottleKey(scopeUserAccount, "acct-window")
+	t0 := time.Now()
 
-	for i := range loginMaxFailures - 1 {
-		throttle.recordFailure("198.51.100.10", now)
-		if blocked := throttle.blockedFor("198.51.100.10", now); blocked > 0 {
-			t.Fatalf("blocked after %d failures, want block only at %d", i+1, loginMaxFailures)
+	for i := 0; i < 4; i++ {
+		d := th.recordFailure(key, t0)
+		if d.Outcome != outcomeAllow {
+			t.Fatalf("failure %d: outcome = %v, want allow", i+1, d.Outcome)
 		}
 	}
 
-	throttle.recordFailure("198.51.100.10", now)
-	blocked := throttle.blockedFor("198.51.100.10", now)
-	if blocked <= 0 {
-		t.Fatalf("blockedFor = %v after %d failures, want a block", blocked, loginMaxFailures)
-	}
-	if blocked > loginBlockDuration {
-		t.Fatalf("blockedFor = %v, want at most %v", blocked, loginBlockDuration)
+	// The four failures above are now outside the 15m short window, so this 5th
+	// failure must be counted as if it were the first.
+	d := th.recordFailure(key, t0.Add(16*time.Minute))
+	if d.Outcome != outcomeAllow {
+		t.Fatalf("outcome after a %v quiet gap = %v, want allow (stale failures must not count)", 16*time.Minute, d.Outcome)
 	}
 }
 
-func TestLoginThrottleReleasesAfterBlockExpires(t *testing.T) {
+// TestSlidingWindowBlocksAtThresholdInsideWindow confirms the counterpart: failures
+// that land inside one window do trip the block, and the first rung of the
+// escalation ladder is used.
+func TestSlidingWindowBlocksAtThresholdInsideWindow(t *testing.T) {
 	t.Parallel()
 
-	throttle := newTestThrottle()
-	now := time.Now()
-	for range loginMaxFailures {
-		throttle.recordFailure("198.51.100.11", now)
+	policy := throttlePolicy{
+		Short:      throttleWindow{Limit: 5, Window: 15 * time.Minute},
+		Backoff:    []time.Duration{2 * time.Minute, 10 * time.Minute},
+		ResetAfter: 12 * time.Hour,
+		HardBlock:  true,
 	}
+	th := newTestThrottle(map[throttleScope]throttlePolicy{scopeManagementKey: policy})
+	key := throttleKey{Scope: scopeManagementKey, Value: "203.0.113.9/32"}
+	t0 := time.Now()
 
-	if throttle.blockedFor("198.51.100.11", now.Add(loginBlockDuration-time.Second)) <= 0 {
-		t.Fatal("client released before the block expired")
+	var last throttleDecision
+	for i := 0; i < 5; i++ {
+		last = th.recordFailure(key, t0.Add(time.Duration(i)*time.Second))
 	}
-	if blocked := throttle.blockedFor("198.51.100.11", now.Add(loginBlockDuration)); blocked != 0 {
-		t.Fatalf("blockedFor = %v at expiry, want 0", blocked)
+	if last.Outcome != outcomeBlocked {
+		t.Fatalf("outcome at threshold = %v, want blocked", last.Outcome)
+	}
+	if last.RetryAfter != policy.Backoff[0] {
+		t.Fatalf("RetryAfter = %v, want first backoff rung %v", last.RetryAfter, policy.Backoff[0])
 	}
 }
 
-func TestLoginThrottleSuccessClearsFailures(t *testing.T) {
+// TestLongWindowBlocksWhenShortWindowWouldNot is the D2 anchor: a lone short window
+// still permits a low, steady drip that adds up to a lot of guesses per day. Here
+// every burst stays comfortably under the short-window limit, yet the daily ceiling
+// still arms.
+func TestLongWindowBlocksWhenShortWindowWouldNot(t *testing.T) {
 	t.Parallel()
 
-	throttle := newTestThrottle()
-	now := time.Now()
-	for range loginMaxFailures - 1 {
-		throttle.recordFailure("198.51.100.12", now)
+	policy := throttlePolicy{
+		Short:      throttleWindow{Limit: 50, Window: 15 * time.Minute},
+		Long:       throttleWindow{Limit: 20, Window: 24 * time.Hour},
+		Backoff:    []time.Duration{time.Minute},
+		ResetAfter: 48 * time.Hour,
 	}
-	throttle.recordSuccess("198.51.100.12")
+	th := newTestThrottle(map[throttleScope]throttlePolicy{scopeUserAccount: policy})
+	key := accountThrottleKey(scopeUserAccount, "acct-longwindow")
+	t0 := time.Now()
 
-	// The counter must restart, so one more failure cannot trip the block.
-	throttle.recordFailure("198.51.100.12", now)
-	if blocked := throttle.blockedFor("198.51.100.12", now); blocked > 0 {
-		t.Fatalf("blockedFor = %v, want 0 after a successful login reset the count", blocked)
+	var last throttleDecision
+	for burst := 0; burst < 5; burst++ {
+		// 16 minutes is wider than the 15m short window, so each burst's count
+		// rolls off before the next burst starts.
+		burstStart := t0.Add(time.Duration(burst) * 16 * time.Minute)
+		for i := 0; i < 4; i++ {
+			last = th.recordFailure(key, burstStart)
+		}
+	}
+	if last.Outcome != outcomeRateLimited {
+		t.Fatalf("outcome after 20 failures spread across 80 minutes = %v, want rate limited by the long window", last.Outcome)
+	}
+	if last.ShortCount > policy.Short.Limit {
+		t.Fatalf("short window count = %d, want it to stay under its own limit %d (the long window must be what armed the block)", last.ShortCount, policy.Short.Limit)
 	}
 }
 
-// Guards the invariant that a block cannot be shed by going quiet. The state is
-// built directly because the current constants (30m block, 2h idle) make this
-// unreachable through recordFailure; the guard exists for a future config where
-// a block outlasts the idle window.
-func TestLoginThrottlePurgeKeepsBlockedEntries(t *testing.T) {
+// TestStagedBackoffEscalatesAndCapsAtMax walks the escalation ladder across
+// repeated offenses, each separated far enough to roll the short window but not
+// far enough to trigger the quiet-period reset, and confirms it plateaus at the
+// last rung instead of overflowing past it.
+func TestStagedBackoffEscalatesAndCapsAtMax(t *testing.T) {
 	t.Parallel()
 
-	throttle := newTestThrottle()
+	policy := throttlePolicy{
+		Short:      throttleWindow{Limit: 3, Window: 2 * time.Minute},
+		Backoff:    []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute, 30 * time.Minute},
+		ResetAfter: time.Hour,
+	}
+	th := newTestThrottle(map[throttleScope]throttlePolicy{scopeUserAccount: policy})
+	key := accountThrottleKey(scopeUserAccount, "acct-escalate")
+
+	round := func(start time.Time) throttleDecision {
+		var last throttleDecision
+		for i := 0; i < 3; i++ {
+			last = th.recordFailure(key, start.Add(time.Duration(i)*time.Second))
+		}
+		return last
+	}
+
+	t0 := time.Now()
+	want := []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute, 30 * time.Minute, 30 * time.Minute}
+	// Gap between rounds: comfortably longer than the previous block plus the
+	// short window (so counts roll over), comfortably shorter than ResetAfter (so
+	// the escalation ladder is not cleared).
+	gaps := []time.Duration{0, 3 * time.Minute, 8 * time.Minute, 18 * time.Minute, 33 * time.Minute}
+
+	cursor := t0
+	for i, gap := range gaps {
+		cursor = cursor.Add(gap)
+		got := round(cursor)
+		if got.Outcome != outcomeRateLimited {
+			t.Fatalf("round %d: outcome = %v, want rate limited", i+1, got.Outcome)
+		}
+		if got.RetryAfter != want[i] {
+			t.Fatalf("round %d: RetryAfter = %v, want %v", i+1, got.RetryAfter, want[i])
+		}
+		cursor = cursor.Add(3 * time.Second)
+	}
+}
+
+// TestStagedBackoffResetsAfterQuietPeriod confirms the other half of the ladder:
+// a quiet period longer than ResetAfter clears both the counters and the
+// escalation stage, so a mistake made long ago does not start at a 30m ban.
+func TestStagedBackoffResetsAfterQuietPeriod(t *testing.T) {
+	t.Parallel()
+
+	policy := throttlePolicy{
+		Short:      throttleWindow{Limit: 3, Window: time.Minute},
+		Backoff:    []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute},
+		ResetAfter: 10 * time.Minute,
+	}
+	th := newTestThrottle(map[throttleScope]throttlePolicy{scopeUserAccount: policy})
+	key := accountThrottleKey(scopeUserAccount, "acct-reset")
+
+	t0 := time.Now()
+	var first throttleDecision
+	var lastFailureAt time.Time
+	for i := 0; i < 3; i++ {
+		lastFailureAt = t0.Add(time.Duration(i) * time.Second)
+		first = th.recordFailure(key, lastFailureAt)
+	}
+	if first.Outcome != outcomeRateLimited || first.RetryAfter != policy.Backoff[0] {
+		t.Fatalf("first round = %+v, want rate limited at %v", first, policy.Backoff[0])
+	}
+
+	// The quiet gap must be measured from the last recorded failure, not from t0.
+	quiet := lastFailureAt.Add(policy.ResetAfter + time.Second)
+	var second throttleDecision
+	for i := 0; i < 3; i++ {
+		second = th.recordFailure(key, quiet.Add(time.Duration(i)*time.Second))
+	}
+	if second.Outcome != outcomeRateLimited {
+		t.Fatalf("second round outcome = %v, want rate limited", second.Outcome)
+	}
+	if second.RetryAfter != policy.Backoff[0] {
+		t.Fatalf("RetryAfter after a quiet period = %v, want the ladder to restart at %v", second.RetryAfter, policy.Backoff[0])
+	}
+}
+
+// TestUnauthenticatedScopeNeverBlocks is the B2 regression anchor: a request that
+// carried no secret proves nothing about the secret, so it may be rate-limited but
+// must never be hard-banned, no matter how many times it repeats.
+func TestUnauthenticatedScopeNeverBlocks(t *testing.T) {
+	t.Parallel()
+
+	th := newTestThrottle(defaultThrottlePolicies())
+	key := throttleKey{Scope: scopeUnauthenticated, Value: "203.0.113.100/32"}
 	now := time.Now()
-	throttle.attempts["198.51.100.13"] = &loginAttempt{
+
+	for i := 0; i < 1000; i++ {
+		d := th.recordFailure(key, now)
+		if d.Outcome == outcomeBlocked {
+			t.Fatalf("attempt %d: outcome = blocked, want allow or rate_limited (never a hard ban for credential-less traffic)", i+1)
+		}
+	}
+}
+
+// TestSharedKeyDowngradesHardBlock confirms a key that cannot identify a single
+// client (behind an untrusted proxy/NAT) never produces a 403, even for a scope
+// whose policy normally hard-blocks.
+func TestSharedKeyDowngradesHardBlock(t *testing.T) {
+	t.Parallel()
+
+	policy := throttlePolicy{
+		Short:     throttleWindow{Limit: 3, Window: 15 * time.Minute},
+		Backoff:   []time.Duration{time.Minute, 5 * time.Minute},
+		HardBlock: true,
+	}
+	th := newTestThrottle(map[throttleScope]throttlePolicy{scopeManagementKey: policy})
+	key := throttleKey{Scope: scopeManagementKey, Value: "198.51.100.1/32", Shared: true}
+	now := time.Now()
+
+	var last throttleDecision
+	for i := 0; i < 3; i++ {
+		last = th.recordFailure(key, now.Add(time.Duration(i)*time.Second))
+	}
+	if last.Outcome != outcomeRateLimited {
+		t.Fatalf("shared-key outcome = %v, want rate_limited (429), never blocked (403)", last.Outcome)
+	}
+}
+
+// TestRecordSuccessClearsOnlyScopedKey is the D6 anchor: clearing an account's
+// failures on a successful login must not also clear an unrelated per-IP bucket,
+// or an attacker holding one valid account could reset their guessing budget.
+func TestRecordSuccessClearsOnlyScopedKey(t *testing.T) {
+	t.Parallel()
+
+	policy := throttlePolicy{
+		Short:      throttleWindow{Limit: 3, Window: 15 * time.Minute},
+		Backoff:    []time.Duration{time.Minute},
+		ResetAfter: 12 * time.Hour,
+	}
+	th := newTestThrottle(map[throttleScope]throttlePolicy{
+		scopeUserAccount:  policy,
+		scopeUserPassword: policy,
+	})
+	now := time.Now()
+
+	acctKey := accountThrottleKey(scopeUserAccount, "u1")
+	ipKey := throttleKey{Scope: scopeUserPassword, Value: "203.0.113.50/32"}
+
+	th.recordFailure(acctKey, now)
+	th.recordFailure(acctKey, now)
+	th.recordFailure(ipKey, now)
+	th.recordFailure(ipKey, now)
+
+	// A successful login against the account bucket only.
+	th.recordSuccess(acctKey)
+
+	// The account bucket must be gone: one more failure should not trip it.
+	if d := th.recordFailure(acctKey, now); d.Outcome != outcomeAllow {
+		t.Fatalf("account bucket outcome after recordSuccess+1 failure = %v, want allow (bucket was cleared)", d.Outcome)
+	}
+
+	// The IP bucket already had 2 failures; a 3rd must still trip it, proving
+	// recordSuccess(acctKey) never touched it.
+	if d := th.recordFailure(ipKey, now); d.Outcome == outcomeAllow {
+		t.Fatal("IP bucket was cleared by an unrelated account's successful login")
+	}
+}
+
+// TestThrottleEvictsLeastRecentlyActiveAtCapacity confirms the memory bound holds
+// under a flood of distinct keys (an IPv6 /64 holder minting buckets, or any other
+// unbounded key space) and that eviction is LRU, not random: the most recently
+// active key must survive.
+func TestThrottleEvictsLeastRecentlyActiveAtCapacity(t *testing.T) {
+	t.Parallel()
+
+	policy := throttlePolicy{
+		Short:      throttleWindow{Limit: 1_000_000, Window: 15 * time.Minute},
+		Backoff:    []time.Duration{time.Minute},
+		ResetAfter: 12 * time.Hour,
+	}
+	th := newTestThrottle(map[throttleScope]throttlePolicy{scopeUserAccount: policy})
+
+	now := time.Now()
+	total := maxTrackedKeys + 1000
+	var lastKey throttleKey
+	for i := 0; i < total; i++ {
+		key := accountThrottleKey(scopeUserAccount, fmt.Sprintf("acct-%d", i))
+		th.recordFailure(key, now.Add(time.Duration(i)*time.Millisecond))
+		lastKey = key
+	}
+
+	if got := th.trackedKeys(); got > maxTrackedKeys {
+		t.Fatalf("trackedKeys() = %d, want <= %d", got, maxTrackedKeys)
+	}
+
+	bucket := bucketID(lastKey)
+	shard := th.shardFor(bucket)
+	shard.mu.Lock()
+	_, survived := shard.entries[bucket]
+	shard.mu.Unlock()
+	if !survived {
+		t.Fatal("the most recently active key was evicted; eviction must be LRU")
+	}
+}
+
+// TestPurgeStaleKeepsBlockedEntries guards the invariant that a block cannot be
+// shed by going quiet: without this guard an attacker could wait out an idle
+// window instead of the actual block duration.
+func TestPurgeStaleKeepsBlockedEntries(t *testing.T) {
+	t.Parallel()
+
+	th := newTestThrottle(defaultThrottlePolicies())
+	now := time.Now()
+	key := accountThrottleKey(scopeUserAccount, "acct-blocked")
+	bucket := bucketID(key)
+	shard := th.shardFor(bucket)
+	shard.mu.Lock()
+	shard.entries[bucket] = &throttleEntry{
 		blockedUntil: now.Add(24 * time.Hour),
-		lastActivity: now.Add(-loginMaxIdleTime - time.Hour),
+		lastActivity: now.Add(-th.idleRetention() - time.Hour),
 	}
+	shard.mu.Unlock()
 
-	throttle.purgeStale(now)
+	th.purgeStale(now)
 
-	if blocked := throttle.blockedFor("198.51.100.13", now); blocked <= 0 {
-		t.Fatal("purge dropped a still-blocked client, letting it shed the block by idling")
+	shard.mu.Lock()
+	_, ok := shard.entries[bucket]
+	shard.mu.Unlock()
+	if !ok {
+		t.Fatal("purge dropped a still-blocked entry, letting it shed the block by idling")
 	}
 }
 
-func TestLoginThrottlePurgeDropsIdleEntries(t *testing.T) {
+// TestPurgeStaleDropsIdleEntries confirms purge reclaims memory for entries that
+// are not currently blocked and have been idle past retention.
+func TestPurgeStaleDropsIdleEntries(t *testing.T) {
 	t.Parallel()
 
-	throttle := newTestThrottle()
+	th := newTestThrottle(defaultThrottlePolicies())
 	now := time.Now()
-	throttle.recordFailure("198.51.100.14", now)
+	key := accountThrottleKey(scopeUserAccount, "acct-idle")
+	th.recordFailure(key, now)
 
-	throttle.purgeStale(now.Add(loginMaxIdleTime + time.Minute))
+	th.purgeStale(now.Add(th.idleRetention() + time.Minute))
 
-	throttle.mu.Lock()
-	remaining := len(throttle.attempts)
-	throttle.mu.Unlock()
-	if remaining != 0 {
-		t.Fatalf("attempts retained %d idle entry/entries, want 0", remaining)
+	if got := th.trackedKeys(); got != 0 {
+		t.Fatalf("trackedKeys() after purge = %d, want 0", got)
 	}
 }
 
-func TestLoginThrottleNilIsInert(t *testing.T) {
+// TestThrottleNilIsInert protects handlers constructed as a zero-value &Handler{}
+// (used throughout this package's other tests), whose loginThrottle field is nil.
+func TestThrottleNilIsInert(t *testing.T) {
 	t.Parallel()
 
-	var throttle *loginThrottle
-	// Handlers may run with an unset throttle in tests; none of these may panic.
-	throttle.recordFailure("198.51.100.15", time.Now())
-	throttle.recordSuccess("198.51.100.15")
-	throttle.purgeStale(time.Now())
-	throttle.close()
-	if blocked := throttle.blockedFor("198.51.100.15", time.Now()); blocked != 0 {
-		t.Fatalf("blockedFor = %v on nil throttle, want 0", blocked)
+	var th *loginThrottle
+	key := accountThrottleKey(scopeUserAccount, "acct-nil")
+	if d := th.evaluate(key, time.Now()); d.Outcome != outcomeAllow {
+		t.Fatalf("evaluate on nil throttle = %+v, want allow", d)
 	}
+	if d := th.recordFailure(key, time.Now()); d.Outcome != outcomeAllow {
+		t.Fatalf("recordFailure on nil throttle = %+v, want allow", d)
+	}
+	th.recordSuccess(key)
+	th.purgeStale(time.Now())
+	th.setPolicies(defaultThrottlePolicies())
+	th.close()
+	th.close() // idempotent
+	if got := th.trackedKeys(); got != 0 {
+		t.Fatalf("trackedKeys() on nil throttle = %d, want 0", got)
+	}
+	if short, long := th.limitsFor(key); short != 0 || long != 0 {
+		t.Fatalf("limitsFor on nil throttle = (%d, %d), want (0, 0)", short, long)
+	}
+}
+
+// TestThrottleConcurrentRecordFailureIsRaceFree exercises the sharded-lock design
+// under -race: many goroutines hammering recordFailure/recordSuccess/purgeStale
+// concurrently across a shared key space must not race or panic.
+func TestThrottleConcurrentRecordFailureIsRaceFree(t *testing.T) {
+	th := newTestThrottle(defaultThrottlePolicies())
+	now := time.Now()
+
+	var wg sync.WaitGroup
+	for w := 0; w < 64; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				key := accountThrottleKey(scopeUserAccount, fmt.Sprintf("acct-%d-%d", worker%8, i%16))
+				th.recordFailure(key, now.Add(time.Duration(i)*time.Millisecond))
+			}
+		}(w)
+	}
+	for w := 0; w < 16; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				key := accountThrottleKey(scopeUserAccount, fmt.Sprintf("acct-%d-%d", worker%8, i%16))
+				th.recordSuccess(key)
+				th.purgeStale(now)
+			}
+		}(w)
+	}
+	wg.Wait()
+}
+
+// TestThrottleSetPoliciesIsHotReloadSafe exercises the atomic.Pointer swap under
+// -race: a config hot-reload racing with live traffic must never be observed
+// half-applied or corrupt shared state.
+func TestThrottleSetPoliciesIsHotReloadSafe(t *testing.T) {
+	th := newTestThrottle(defaultThrottlePolicies())
+	now := time.Now()
+
+	stop := make(chan struct{})
+	var reloader sync.WaitGroup
+	reloader.Add(1)
+	go func() {
+		defer reloader.Done()
+		alt := defaultThrottlePolicies()
+		toggle := false
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			policies := defaultThrottlePolicies()
+			if toggle {
+				policies = alt
+			}
+			toggle = !toggle
+			th.setPolicies(policies)
+		}
+	}()
+
+	// The reloader is not in this group: it is stopped explicitly below, after
+	// the writers finish, so waiting on it here cannot deadlock against its own
+	// exit condition.
+	var writers sync.WaitGroup
+	for w := 0; w < 32; w++ {
+		writers.Add(1)
+		go func(worker int) {
+			defer writers.Done()
+			for i := 0; i < 200; i++ {
+				key := accountThrottleKey(scopeUserAccount, fmt.Sprintf("acct-hot-%d-%d", worker%4, i%8))
+				th.recordFailure(key, now.Add(time.Duration(i)*time.Millisecond))
+			}
+		}(w)
+	}
+
+	writers.Wait()
+	close(stop)
+	reloader.Wait()
 }

--- a/internal/api/handlers/management/middleware_auth.go
+++ b/internal/api/handlers/management/middleware_auth.go
@@ -1,0 +1,281 @@
+package management
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// credentialKind separates "a secret was supplied and compared" from "no secret
+// was supplied at all". Only the former carries any evidence about the secret.
+type credentialKind uint8
+
+const (
+	credentialMissing credentialKind = iota
+	credentialProvided
+)
+
+// managementAuthMiddleware enforces access control for management endpoints.
+// All requests (local and remote) require a valid management key; remote access
+// additionally requires allow-remote-management=true.
+//
+// The step order below is load-bearing and must not be reordered:
+//   - the ban check (step 5) precedes every secret comparison, so a banned client
+//     cannot spend a bcrypt compare (~70ms of one core) per request;
+//   - credential-less requests (step 8) are charged to their own bucket and can
+//     only ever be soft-limited, so crawlers and SPA races cannot ban a whole
+//     office behind one egress IP.
+func (h *Handler) managementAuthMiddleware(c *gin.Context) {
+	// 1) Version headers stay ahead of authentication: the panel reads them on the
+	// 401 path to detect a backend/UI version skew.
+	c.Header("X-CPA-VERSION", buildinfo.Version)
+	c.Header("X-CPA-COMMIT", buildinfo.Commit)
+	c.Header("X-CPA-BUILD-DATE", buildinfo.BuildDate)
+	currentUIVersion, currentUICommit := h.currentFrontendState()
+	c.Header("X-CPA-UI-VERSION", currentUIVersion)
+	c.Header("X-CPA-UI-COMMIT", currentUICommit)
+
+	// 2) Session tokens (cps_*) come from Authorization: Bearer on normal HTTP, or from
+	// ?token= on the system-stats WebSocket handshake (browsers cannot set WS headers).
+	// Resolve the session token before falling through to management-key auth so a
+	// valid user session is never bcrypt-compared against the remote management secret.
+	//
+	// Known design boundary (not fixable in isolation): the whole cps_ session system
+	// is outside the allow-remote gate, because /v0/auth/login does not pass through
+	// this middleware at all. Gating only this branch would produce accounts that can
+	// log in and then get 403 on every request, which is a worse outage than the gap.
+	if token := resolveSessionToken(c); strings.HasPrefix(token, "cps_") {
+		_ = h.authenticateSessionToken(c, token)
+		return
+	}
+
+	// 3) A loopback ClientIP alone does not prove local origin. With trusted-proxies
+	// unset (the default) gin falls back to RemoteAddr, so behind a same-host
+	// reverse proxy every external request would report 127.0.0.1 and thereby skip
+	// the allow-remote gate, unlock the local-password path, and bypass the per-IP
+	// login throttle entirely. Require the direct peer to be loopback and no relay
+	// headers to be present as well.
+	peer := resolveThrottlePeer(c)
+	localClient := (peer == "127.0.0.1" || peer == "::1") && util.IsLocalOriginRequest(c.Request)
+
+	cfg := h.cfg
+	var (
+		allowRemote bool
+		secretHash  string
+	)
+	if cfg != nil {
+		allowRemote = cfg.RemoteManagement.AllowRemote
+		secretHash = cfg.RemoteManagement.SecretKey
+	}
+	if h.allowRemoteOverride {
+		allowRemote = true
+	}
+	envSecret := h.envSecret
+
+	now := time.Now()
+	var mgmtKey throttleKey
+	if !localClient {
+		// 4) Remote access gate.
+		if !allowRemote {
+			// Requests relayed by a local reverse proxy land here even though the TCP
+			// peer is loopback. allow-remote is the only advice that actually grants
+			// access: a relayed request is never treated as local, so trusted-proxies
+			// does not help on its own — it recovers the real client IP for the per-IP
+			// throttle, which is why it is named as an additional step rather than an
+			// alternative.
+			message := "remote management disabled"
+			if relayHeader := util.RelayIndicationHeader(c.Request); relayHeader != "" {
+				message = "remote management disabled: request was relayed (" + relayHeader + " header present), so it is not treated as local. Set remote-management.allow-remote=true to allow it, and list the proxy in trusted-proxies so per-IP throttling sees the real client."
+			}
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": message})
+			return
+		}
+
+		// 5) Ban pre-check. This must stay the first thing that touches a remote
+		// request's credentials budget: everything below it either hashes a password
+		// or compares a stored secret, and an already-banned client must not be able
+		// to make the server pay for that.
+		mgmtKey = h.clientThrottleKey(c, scopeManagementKey)
+		if d := h.loginThrottle.evaluate(mgmtKey, now); d.Outcome != outcomeAllow {
+			h.logAuthFailure(c, mgmtKey, d)
+			abortThrottled(c, d)
+			return
+		}
+	}
+
+	// 6) Nothing to compare against at all.
+	localPasswordConfigured := localClient && h.localPassword != ""
+	if secretHash == "" && envSecret == "" && !localPasswordConfigured {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "remote management key not set"})
+		return
+	}
+
+	// 7) Extract the credential.
+	provided, kind := classifyManagementCredential(c)
+
+	// 8) No credential was supplied. This proves nothing about the secret, so it is
+	// charged to the credential-less bucket, which can only ever rate-limit.
+	if kind == credentialMissing {
+		if !localClient {
+			key := h.clientThrottleKey(c, scopeUnauthenticated)
+			if d := h.loginThrottle.recordFailure(key, now); d.Outcome != outcomeAllow {
+				h.logAuthFailure(c, key, d)
+				abortThrottled(c, d)
+				return
+			}
+		}
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing management key"})
+		return
+	}
+
+	// 9) A credential was supplied: compare it against every configured secret.
+	if localClient {
+		if lp := h.localPassword; lp != "" {
+			if util.ConstantTimeStringEqual(provided, lp) {
+				h.setServicePrincipal(c)
+				h.nextWithManagementAudit(c)
+				return
+			}
+		}
+	}
+
+	if envSecret != "" && util.ConstantTimeStringEqual(provided, envSecret) {
+		h.loginThrottle.recordSuccess(mgmtKey)
+		h.setServicePrincipal(c)
+		h.nextWithManagementAudit(c)
+		return
+	}
+
+	if secretHash == "" || bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) != nil {
+		if !localClient {
+			d := h.loginThrottle.recordFailure(mgmtKey, now)
+			h.logAuthFailure(c, mgmtKey, d)
+			if d.Outcome != outcomeAllow {
+				abortThrottled(c, d)
+				return
+			}
+		}
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid management key"})
+		return
+	}
+
+	h.loginThrottle.recordSuccess(mgmtKey)
+	h.setServicePrincipal(c)
+	h.nextWithManagementAudit(c)
+}
+
+// classifyManagementCredential draws the line at "was a stored secret compared".
+// Missing or unparseable credentials are format errors produced by crawlers,
+// health checks, prefetch and SPA races — never evidence of guessing.
+func classifyManagementCredential(c *gin.Context) (string, credentialKind) {
+	// Accept either Authorization: Bearer <key> or X-Management-Key.
+	var provided string
+	if ah := c.GetHeader("Authorization"); ah != "" {
+		parts := strings.SplitN(ah, " ", 2)
+		if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" {
+			provided = parts[1]
+		} else {
+			provided = ah
+		}
+	}
+	if provided == "" {
+		provided = c.GetHeader("X-Management-Key")
+	}
+	// Fallback: ?token= query param is accepted only for WebSocket handshakes;
+	// normal HTTP requests must not carry credentials in URLs.
+	// Session tokens (cps_*) were already handled by the caller; remaining query
+	// tokens are treated as management keys (legacy panel / service credential).
+	if provided == "" && shouldReadManagementTokenFromQuery(c) {
+		if queryToken := strings.TrimSpace(c.Query("token")); !strings.HasPrefix(queryToken, "cps_") {
+			provided = queryToken
+		}
+	}
+	if provided == "" {
+		return "", credentialMissing
+	}
+	return provided, credentialProvided
+}
+
+// abortThrottled writes the throttle rejection. The two shapes are a cross-repo
+// contract with the admin panel and must not drift.
+func abortThrottled(c *gin.Context, d throttleDecision) {
+	retryAfter := d.RetryAfter.Round(time.Second)
+	c.Header("Retry-After", retryAfterSecondsHeader(retryAfter))
+	if d.Outcome == outcomeBlocked {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+			"error": fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", retryAfter),
+		})
+		return
+	}
+	// The 429 message must never contain "IP banned": the panel's shouldSuspendAuth
+	// regex-matches that string and forces a logout, and a soft rate limit is
+	// precisely the case where the session is still valid and must survive.
+	c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+		"error": gin.H{
+			"code":    "too_many_requests",
+			"message": fmt.Sprintf("too many requests, retry in %s", retryAfter),
+		},
+	})
+}
+
+// logAuthFailure emits the operator-facing record of a throttle event.
+//
+// This is the one place in the management package that uses structured fields
+// instead of the package-wide printf style: the fields are consumed by log
+// search when investigating a lockout, where "which bucket, which key, how far
+// from the limit" has to be filterable rather than embedded in a sentence.
+//
+// Level is Debug by default and Warn only on the transition into a block, so a
+// brute-force run produces one Warn instead of one line per rejected request.
+func (h *Handler) logAuthFailure(c *gin.Context, key throttleKey, d throttleDecision) {
+	shortLimit, longLimit := h.loginThrottle.limitsFor(key)
+	fields := log.Fields{
+		"scope":       key.Scope.String(),
+		"key":         maskThrottleKey(key),
+		"shared":      key.Shared,
+		"short_count": d.ShortCount,
+		"long_count":  d.LongCount,
+		"limit":       shortLimit,
+		"long_limit":  longLimit,
+		"outcome":     d.Outcome.String(),
+	}
+	if c != nil && c.Request != nil {
+		userAgent := c.Request.UserAgent()
+		if len(userAgent) > 120 {
+			userAgent = userAgent[:120]
+		}
+		fields["path"] = c.Request.URL.Path
+		fields["method"] = c.Request.Method
+		fields["ua"] = userAgent
+		fields["relay_header"] = util.RelayIndicationHeader(c.Request)
+		fields["request_id"] = throttleRequestID(c)
+	}
+	if d.NewlyArmed {
+		fields["block_for"] = d.RetryAfter.Round(time.Second).String()
+		fields["generation"] = d.Generation
+		log.WithFields(fields).Warn("auth-throttle: credential failure armed a block")
+		return
+	}
+	log.WithFields(fields).Debug("auth-throttle: credential failure")
+}
+
+// throttleRequestID reads the correlation id assigned upstream. It deliberately
+// does not mint one when none exists: an id that appears in a single log line
+// and in no response header or audit row would only look correlatable.
+func throttleRequestID(c *gin.Context) string {
+	if id := logging.GetGinRequestID(c); id != "" {
+		return id
+	}
+	if c.Request != nil {
+		return logging.GetRequestID(c.Request.Context())
+	}
+	return ""
+}

--- a/internal/api/handlers/management/portal_throttle.go
+++ b/internal/api/handlers/management/portal_throttle.go
@@ -1,0 +1,36 @@
+package management
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// PortalAuthThrottleMiddleware rate-limits the end-user portal's login and
+// refresh endpoints.
+//
+// Those routes deliberately live outside Handler.Middleware() — they must be
+// reachable without a management key — which until now left them with no
+// throttling whatsoever: PostPortalLogin runs an unconditional bcrypt compare
+// (cost 10) for every request, including ones naming a user that does not
+// exist, so a few dozen concurrent connections saturate a core. It is exported
+// because the throttle has to be attached where the routes are registered.
+//
+// The check runs before c.Next() so a throttled caller never reaches the hash
+// comparison; charging happens after, and only for 401, so that a cooldown or a
+// disabled account (403/423) does not consume the guess budget.
+func (h *Handler) PortalAuthThrottleMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := h.clientThrottleKey(c, scopePortalPassword)
+		if d := h.loginThrottle.evaluate(key, time.Now()); d.Outcome != outcomeAllow {
+			abortThrottled(c, d)
+			return
+		}
+		c.Next()
+		if c.Writer.Status() == http.StatusUnauthorized {
+			d := h.loginThrottle.recordFailure(key, time.Now())
+			h.logAuthFailure(c, key, d)
+		}
+	}
+}

--- a/internal/api/routes/management_identity_routes.go
+++ b/internal/api/routes/management_identity_routes.go
@@ -22,8 +22,14 @@ func registerIdentityAuthRoutes(engine *gin.Engine, h *managementhandlers.Handle
 
 	portal := engine.Group("/v0/portal")
 	portal.Use(middlewares...)
-	portal.POST("/auth/login", h.PostPortalLogin)
-	portal.POST("/auth/refresh", h.PostPortalRefresh)
+	// Only the two credential-bearing portal routes are throttled, and per-route
+	// rather than on the group: the rest already require a portal session, so a
+	// shared bucket would let one client's failed logins rate-limit everyone
+	// else's key management. Attaching it here (not in the handler) keeps the
+	// route table unchanged.
+	portalAuthThrottle := h.PortalAuthThrottleMiddleware()
+	portal.POST("/auth/login", portalAuthThrottle, h.PostPortalLogin)
+	portal.POST("/auth/refresh", portalAuthThrottle, h.PostPortalRefresh)
 	portal.POST("/auth/logout", h.PostPortalLogout)
 	portal.GET("/auth/me", h.GetPortalMe)
 	portal.PUT("/auth/password", h.PutPortalPassword)

--- a/internal/api/server_constructor.go
+++ b/internal/api/server_constructor.go
@@ -31,16 +31,35 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	return s
 }
 
+// wildcardProxyCIDRs trust every client's forwarding headers, which is
+// indistinguishable from having no protection at all: any client could then
+// choose its own throttle key and fill an arbitrary victim's bucket.
+var wildcardProxyCIDRs = map[string]struct{}{"0.0.0.0/0": {}, "::/0": {}, "0.0.0.0": {}, "::": {}}
+
+// sanitizeTrustedProxies trims the list and separates out the wildcard entries.
+func sanitizeTrustedProxies(in []string) (out []string, dropped []string) {
+	for _, proxy := range in {
+		trimmed := strings.TrimSpace(proxy)
+		if trimmed == "" {
+			continue
+		}
+		if _, wildcard := wildcardProxyCIDRs[trimmed]; wildcard {
+			dropped = append(dropped, trimmed)
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out, dropped
+}
+
 func configureTrustedProxies(engine *gin.Engine, trustedProxies []string) {
 	if engine == nil {
 		return
 	}
 
-	proxies := make([]string, 0, len(trustedProxies))
-	for _, proxy := range trustedProxies {
-		if trimmed := strings.TrimSpace(proxy); trimmed != "" {
-			proxies = append(proxies, trimmed)
-		}
+	proxies, dropped := sanitizeTrustedProxies(trustedProxies)
+	for _, d := range dropped {
+		log.Errorf("trusted-proxies: refusing wildcard entry %q; it would trust every client's X-Forwarded-For and disable per-IP throttling. Entry dropped; list the actual proxy CIDR instead.", d)
 	}
 
 	if len(proxies) == 0 {
@@ -56,4 +75,21 @@ func configureTrustedProxies(engine *gin.Engine, trustedProxies []string) {
 			log.Warnf("failed to disable trusted proxies after configuration error: %v", fallbackErr)
 		}
 	}
+}
+
+// warnOnUntrustedProxyDeployment surfaces the single most common
+// misconfiguration: remote management behind a reverse proxy with no
+// trusted-proxies, where every user shares one throttle bucket.
+//
+// Warn and not fatal on purpose: refusing to start would turn an upgrade into an
+// outage for every existing deployment that has this shape today, which is a
+// larger incident than the degraded throttling it reports.
+func warnOnUntrustedProxyDeployment(cfg *config.Config) {
+	if cfg == nil || !cfg.RemoteManagement.AllowRemote {
+		return
+	}
+	if proxies, _ := sanitizeTrustedProxies(cfg.TrustedProxies); len(proxies) > 0 {
+		return
+	}
+	log.Warnf("remote management is enabled but trusted-proxies is empty. Behind a reverse proxy every client reports the proxy's address, so they all share one login-throttle bucket and per-IP hard bans are downgraded to soft rate limits. Set trusted-proxies to the proxy's CIDR (for example [\"127.0.0.1/32\"]) to restore per-client throttling.")
 }

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -48,6 +48,7 @@ func newServerEngine(cfg *config.Config, optionState *serverOptionConfig) *gin.E
 	}
 	if cfg != nil {
 		configureTrustedProxies(engine, cfg.TrustedProxies)
+		warnOnUntrustedProxyDeployment(cfg)
 	}
 	if optionState != nil && optionState.engineConfigurator != nil {
 		optionState.engineConfigurator(engine)

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -40,7 +41,7 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 		return
 	}
 	usage.InitRedis(cfg.Redis)
-	defer usage.StopRedis()
+	defer stopRuntimeDataStack()
 
 	moderator := contentmoderation.NewRequestModerator(contentmoderation.NewStore(usage.RuntimeDB()), contentmoderation.NewEvaluator(nil))
 	contentmoderation.SetRuntime(moderator)
@@ -105,20 +106,50 @@ func StartServiceBackground(cfg *config.Config, configPath string, localPassword
 	service, err := builder.Build()
 	if err != nil {
 		log.Errorf("failed to build proxy service: %v", err)
-		usage.StopRedis()
+		stopRuntimeDataStack()
 		close(doneCh)
 		return cancelFn, doneCh
 	}
 
 	go func() {
 		defer close(doneCh)
-		defer usage.StopRedis()
+		defer stopRuntimeDataStack()
 		if err := service.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			log.Errorf("proxy service exited with error: %v", err)
 		}
 	}()
 
 	return cancelFn, doneCh
+}
+
+// sessionReaperStop holds the identity session reaper's cancel function. The
+// reaper is started with the runtime data stack, so it has to be torn down with
+// it; a process that re-initialises the stack (tests, cloud-deploy reconfigure)
+// would otherwise leak one goroutine and one ticker per initialisation.
+var (
+	sessionReaperMu   sync.Mutex
+	sessionReaperStop func()
+)
+
+func startSessionReaper(service *identity.Service, interval time.Duration) {
+	sessionReaperMu.Lock()
+	defer sessionReaperMu.Unlock()
+	if sessionReaperStop != nil {
+		sessionReaperStop()
+	}
+	sessionReaperStop = service.StartSessionReaper(context.Background(), interval)
+}
+
+// stopRuntimeDataStack tears down everything initializeRuntimeDataStack started.
+func stopRuntimeDataStack() {
+	sessionReaperMu.Lock()
+	stop := sessionReaperStop
+	sessionReaperStop = nil
+	sessionReaperMu.Unlock()
+	if stop != nil {
+		stop()
+	}
+	usage.StopRedis()
 }
 
 type bootstrapAdminPassword struct {
@@ -165,6 +196,8 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 		return err
 	}
 	identity.SetDefault(identityService)
+	identityService.SetSessionPolicy(identity.SessionPolicyFromConfig(cfg))
+	startSessionReaper(identityService, identity.SessionReaperIntervalFromConfig(cfg))
 	// Import YAML keys first so one-shot end-user backfill can see them.
 	if _, err := usage.MigrateAPIKeysFromConfig(cfg, configPath); err != nil {
 		return fmt.Errorf("migrate api keys from config: %w", err)

--- a/internal/config/sections.go
+++ b/internal/config/sections.go
@@ -46,6 +46,46 @@ type RemoteManagement struct {
 	// PanelGitHubRepository overrides the GitHub repository used to fetch the management panel asset.
 	// Accepts either a repository URL (https://github.com/org/repo) or an API releases endpoint.
 	PanelGitHubRepository string `yaml:"panel-github-repository"`
+	// Auth tunes login throttling and session token lifetimes.
+	// Zero values fall back to the built-in defaults documented per field.
+	Auth AuthHardening `yaml:"auth,omitempty"`
+}
+
+// AuthHardening groups login-throttle and session-rotation knobs. Every field is
+// zero-means-default so an absent block behaves exactly like the shipped defaults.
+type AuthHardening struct {
+	// LoginFailureWindowSeconds is the sliding window for counting login
+	// failures. Default 900. Counters outside the window are discarded.
+	LoginFailureWindowSeconds int `yaml:"login-failure-window-seconds,omitempty"`
+	// AccountFailureLimit arms a staged cooldown for one account. Default 5.
+	AccountFailureLimit int `yaml:"account-failure-limit,omitempty"`
+	// ManagementKeyFailureLimit arms a per-IP ban for wrong management keys. Default 10.
+	ManagementKeyFailureLimit int `yaml:"management-key-failure-limit,omitempty"`
+	// UnauthenticatedRequestLimit caps credential-less management requests per
+	// client per hour. Exceeding it returns 429; it never arms a credential ban.
+	// Default 300.
+	UnauthenticatedRequestLimit int `yaml:"unauthenticated-request-limit,omitempty"`
+	// FailureResetHours is the quiet period that clears counters and backoff
+	// escalation. Default 12.
+	FailureResetHours int `yaml:"failure-reset-hours,omitempty"`
+	// RefreshGraceSeconds keeps a just-rotated refresh token usable so retries
+	// and racing tabs do not lose the session. Default 30, clamped to 60.
+	// The admin panel's total refresh budget (lock wait + retries) is 23s and
+	// MUST stay below this value, or a legitimate retry lands outside the
+	// window and is treated as a replay, revoking the whole session.
+	RefreshGraceSeconds int `yaml:"refresh-grace-seconds,omitempty"`
+	// RefreshGraceMaxReuse caps replays of one rotated refresh token inside the
+	// grace window. Default 2.
+	RefreshGraceMaxReuse int `yaml:"refresh-grace-max-reuse,omitempty"`
+	// AccessTokenGraceSeconds keeps the previous access token valid after
+	// rotation so in-flight requests are not rejected. Default 60; must exceed
+	// the panel's 30s request timeout.
+	AccessTokenGraceSeconds int `yaml:"access-token-grace-seconds,omitempty"`
+	// AbsoluteRefreshTTLHours is the hard session ceiling; rotation never
+	// extends past login time plus this value. Default 1440 (60 days).
+	AbsoluteRefreshTTLHours int `yaml:"absolute-refresh-ttl-hours,omitempty"`
+	// SessionReaperIntervalMinutes controls expired token/session GC. Default 60.
+	SessionReaperIntervalMinutes int `yaml:"session-reaper-interval-minutes,omitempty"`
 }
 
 // AutoUpdateConfig holds Docker-first update check and sidecar settings.

--- a/internal/enduser/auth_session.go
+++ b/internal/enduser/auth_session.go
@@ -55,23 +55,26 @@ func (s *Service) Login(ctx context.Context, username, password, userAgent strin
 		return result, ErrLoginCooldowned
 	}
 	if bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)) != nil {
-		// Atomic increment to avoid lost updates under concurrent failures.
+		// Atomic increment to avoid lost updates under concurrent failures. The
+		// CASE restarts the count once the previous failure fell outside the
+		// window, so the stored value means "failures in the last 15 minutes"
+		// rather than "failures ever" — the latter locked accounts on mistypes
+		// spread across months.
 		var newCount int
 		_ = s.db.QueryRowContext(ctx, `
-			UPDATE end_users SET failed_login_count = failed_login_count + 1, updated_at = now()
+			UPDATE end_users
+			   SET failed_login_count = CASE
+			         WHEN last_failed_login_at IS NULL
+			           OR last_failed_login_at < now() - make_interval(secs => ?)
+			         THEN 1 ELSE failed_login_count + 1 END,
+			       last_failed_login_at = now(),
+			       updated_at = now()
 			WHERE id = ? RETURNING failed_login_count
-		`, u.ID).Scan(&newCount)
+		`, endUserFailureWindow.Seconds(), u.ID).Scan(&newCount)
 		if newCount == 0 {
 			newCount = u.FailedLoginCount + 1
 		}
-		stage, wait, permanent, apply := lockPenalty(newCount)
-		if apply && permanent {
-			_, _ = s.db.ExecContext(ctx, `
-				UPDATE end_users SET lock_stage = ?, status = 'locked', locked_until = NULL, updated_at = now()
-				WHERE id = ?
-			`, stage, u.ID)
-			return result, ErrAccountLocked
-		}
+		stage, wait, apply := lockPenalty(newCount)
 		if apply && wait > 0 {
 			until := time.Now().UTC().Add(wait)
 			_, _ = s.db.ExecContext(ctx, `
@@ -112,7 +115,8 @@ func (s *Service) Login(ctx context.Context, username, password, userAgent strin
 		return result, err
 	}
 	if _, err = tx.ExecContext(ctx, `
-		UPDATE end_users SET last_login_at = now(), failed_login_count = 0, lock_stage = 0, locked_until = NULL, updated_at = now()
+		UPDATE end_users SET last_login_at = now(), failed_login_count = 0, last_failed_login_at = NULL,
+		  lock_stage = 0, locked_until = NULL, updated_at = now()
 		WHERE id = ?
 	`, u.ID); err != nil {
 		return result, err
@@ -216,6 +220,14 @@ func (s *Service) Refresh(ctx context.Context, refreshToken, userAgent string) (
 	accessExp := now.Add(accessTTL)
 	newRefreshExp := now.Add(refreshTTL)
 	// Atomic consume: only one concurrent refresh of the same refresh token wins.
+	//
+	// This is still hard rotation with no grace window — the same defect the admin
+	// side just fixed (see internal/identity/session_refresh.go). The loser of a
+	// concurrent refresh, and any tab holding the previous token, gets
+	// ErrSessionRevoked and is signed out. Fixing it properly needs the portal's
+	// own per-token table plus a migration, which is out of scope here and tracked
+	// as a follow-up; do not paper over it by widening the WHERE clause, which
+	// would make a replayed token indistinguishable from a legitimate retry.
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE end_user_sessions SET access_token_hash = ?, refresh_token_hash = ?,
 			access_expires_at = ?, refresh_expires_at = ?, last_seen_at = now()

--- a/internal/enduser/login_lockout.go
+++ b/internal/enduser/login_lockout.go
@@ -1,0 +1,39 @@
+package enduser
+
+import "time"
+
+// endUserFailureWindow is the sliding window for counting portal login failures.
+//
+// Without it failed_login_count only ever grew: a counter that never decays turns
+// "20 wrong passwords" from a burst into a lifetime total, so an account could be
+// locked by mistypes spread across months.
+const endUserFailureWindow = 15 * time.Minute
+
+// lockPenalty maps a failure count to a staged cooldown. It applies only at the
+// threshold values so intermediate failures inside a stage do not re-extend an
+// active cooldown.
+//
+// There is deliberately no permanent branch. The previous version locked the
+// account outright at 20 failures (status='locked', locked_until=NULL), which
+// only an administrator could clear — and because the counter never decayed,
+// any attacker could permanently disable any portal account with 20 requests.
+// OWASP treats attacker-triggerable permanent lockout as a denial-of-service
+// vector; a rising cooldown stops guessing without handing out that lever.
+func lockPenalty(failedCount int) (stage int, wait time.Duration, apply bool) {
+	switch {
+	case failedCount >= 20:
+		// Past the top stage, re-arm every fifth failure instead of on every
+		// attempt, so a client retrying in a loop cannot ratchet its own penalty.
+		return 5, 60 * time.Minute, failedCount == 20 || failedCount%5 == 0
+	case failedCount >= 15:
+		return 4, 30 * time.Minute, failedCount == 15
+	case failedCount >= 10:
+		return 3, 15 * time.Minute, failedCount == 10
+	case failedCount >= 5:
+		return 2, 5 * time.Minute, failedCount == 5
+	case failedCount >= 3:
+		return 1, 1 * time.Minute, failedCount == 3
+	default:
+		return 0, 0, false
+	}
+}

--- a/internal/enduser/login_lockout_test.go
+++ b/internal/enduser/login_lockout_test.go
@@ -1,0 +1,66 @@
+package enduser
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLockPenaltyStages(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		failedCount int
+		wantStage   int
+		wantWait    time.Duration
+		wantApply   bool
+	}{
+		{failedCount: 0, wantStage: 0, wantWait: 0, wantApply: false},
+		{failedCount: 2, wantStage: 0, wantWait: 0, wantApply: false},
+		{failedCount: 3, wantStage: 1, wantWait: time.Minute, wantApply: true},
+		{failedCount: 4, wantStage: 1, wantWait: time.Minute, wantApply: false},
+		{failedCount: 5, wantStage: 2, wantWait: 5 * time.Minute, wantApply: true},
+		{failedCount: 9, wantStage: 2, wantWait: 5 * time.Minute, wantApply: false},
+		{failedCount: 10, wantStage: 3, wantWait: 15 * time.Minute, wantApply: true},
+		{failedCount: 14, wantStage: 3, wantWait: 15 * time.Minute, wantApply: false},
+		{failedCount: 15, wantStage: 4, wantWait: 30 * time.Minute, wantApply: true},
+		{failedCount: 19, wantStage: 4, wantWait: 30 * time.Minute, wantApply: false},
+		{failedCount: 20, wantStage: 5, wantWait: 60 * time.Minute, wantApply: true},
+		// Past the top stage the cooldown re-arms every fifth failure, so a client
+		// stuck in a retry loop cannot ratchet its own penalty on every attempt.
+		{failedCount: 21, wantStage: 5, wantWait: 60 * time.Minute, wantApply: false},
+		{failedCount: 25, wantStage: 5, wantWait: 60 * time.Minute, wantApply: true},
+	}
+
+	for _, tc := range cases {
+		stage, wait, apply := lockPenalty(tc.failedCount)
+		if stage != tc.wantStage || wait != tc.wantWait || apply != tc.wantApply {
+			t.Fatalf("lockPenalty(%d) = (%d, %v, %v), want (%d, %v, %v)",
+				tc.failedCount, stage, wait, apply, tc.wantStage, tc.wantWait, tc.wantApply)
+		}
+	}
+}
+
+// TestLockPenaltyNeverPermanent is the X2 regression anchor. The previous ladder
+// returned permanent=true at 20 failures, and because the counter never decayed,
+// twenty requests permanently locked any portal account until an administrator
+// intervened — an attacker-triggerable denial of service.
+func TestLockPenaltyNeverPermanent(t *testing.T) {
+	t.Parallel()
+
+	for count := 0; count <= 200; count++ {
+		stage, wait, apply := lockPenalty(count)
+		if apply && wait <= 0 {
+			t.Fatalf("lockPenalty(%d) armed stage %d with a non-expiring cooldown (wait=%v)", count, stage, wait)
+		}
+	}
+}
+
+// TestEndUserFailureWindowIsBounded guards the decay half of the fix: a window of
+// zero would restore the old "failures ever" semantics that produced the lockouts.
+func TestEndUserFailureWindowIsBounded(t *testing.T) {
+	t.Parallel()
+
+	if endUserFailureWindow <= 0 || endUserFailureWindow > time.Hour {
+		t.Fatalf("endUserFailureWindow = %v, want a positive window no larger than an hour", endUserFailureWindow)
+	}
+}

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -221,26 +221,6 @@ func randomUserSlug() string {
 	return "user_" + hex.EncodeToString(raw)
 }
 
-// lockPenalty applies only when failedCount hits thresholds (5/10/15/20),
-// so intermediate failures during a stage do not re-extend cooldown.
-func lockPenalty(failedCount int) (stage int, wait time.Duration, permanent bool, apply bool) {
-	switch failedCount {
-	case 20:
-		return 4, 0, true, true
-	case 15:
-		return 3, 10 * time.Minute, false, true
-	case 10:
-		return 2, 5 * time.Minute, false, true
-	case 5:
-		return 1, 1 * time.Minute, false, true
-	default:
-		if failedCount > 20 {
-			return 4, 0, true, true
-		}
-		return 0, 0, false, false
-	}
-}
-
 func (s *Service) ensureTenantActive(ctx context.Context, tenantID string) error {
 	var status, tenantType string
 	var expires sql.NullTime

--- a/internal/enduser/service_more_test.go
+++ b/internal/enduser/service_more_test.go
@@ -30,15 +30,6 @@ func TestGenerateAPIKeyUniquenessSample(t *testing.T) {
 	}
 }
 
-func TestLockPenaltyIntermediate(t *testing.T) {
-	for _, n := range []int{1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 16, 19} {
-		_, _, _, apply := lockPenalty(n)
-		if apply {
-			t.Fatalf("count %d should not apply stage lock", n)
-		}
-	}
-}
-
 func TestIsUnsupportedAdvisoryLockError(t *testing.T) {
 	if !isUnsupportedAdvisoryLockError(errors.New("no such function: pg_advisory_xact_lock")) {
 		t.Fatal("sqlite missing function should be unsupported")

--- a/internal/enduser/service_test.go
+++ b/internal/enduser/service_test.go
@@ -14,29 +14,6 @@ func TestUsernameFromDisplay(t *testing.T) {
 	}
 }
 
-func TestLockPenalty(t *testing.T) {
-	stage, wait, permanent, apply := lockPenalty(5)
-	if !apply || stage != 1 || wait.Minutes() != 1 || permanent {
-		t.Fatalf("5 fails: stage=%d wait=%v permanent=%v apply=%v", stage, wait, permanent, apply)
-	}
-	_, _, _, apply = lockPenalty(6)
-	if apply {
-		t.Fatalf("6 fails should not re-apply cooldown")
-	}
-	stage, wait, permanent, apply = lockPenalty(10)
-	if !apply || stage != 2 || wait.Minutes() != 5 || permanent {
-		t.Fatalf("10 fails: stage=%d wait=%v permanent=%v apply=%v", stage, wait, permanent, apply)
-	}
-	stage, wait, permanent, apply = lockPenalty(15)
-	if !apply || stage != 3 || wait.Minutes() != 10 || permanent {
-		t.Fatalf("15 fails: stage=%d wait=%v permanent=%v apply=%v", stage, wait, permanent, apply)
-	}
-	stage, _, permanent, apply = lockPenalty(20)
-	if !apply || stage != 4 || !permanent {
-		t.Fatalf("20 fails: stage=%d permanent=%v apply=%v", stage, permanent, apply)
-	}
-}
-
 func TestGenerateAPIKeyUniqueShape(t *testing.T) {
 	k, err := GenerateAPIKey()
 	if err != nil {

--- a/internal/identity/login.go
+++ b/internal/identity/login.go
@@ -1,0 +1,159 @@
+package identity
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func (s *Service) Login(ctx context.Context, username, password string, remember bool, userAgent string) (LoginResult, error) {
+	var result LoginResult
+	if s == nil || s.db == nil {
+		return result, ErrInvalidCredentials
+	}
+	normalized := NormalizeUsername(username)
+	var user User
+	var passwordHash, tenantStatus, tenantType string
+	var tenant Tenant
+	var expiresAt sql.NullTime
+	var lastLogin sql.NullTime
+	var lockedUntil sql.NullTime
+	err := s.db.QueryRowContext(ctx, `
+		SELECT u.id, u.tenant_id, u.username, u.display_name, u.password_hash, u.status,
+		       u.must_change_password, u.last_login_at, u.created_at, u.updated_at, u.version,
+		       u.locked_until,
+		       t.id, t.slug, t.name, t.type, t.status, t.expires_at, t.description,
+		       t.created_at, t.updated_at, t.version
+		  FROM users u JOIN tenants t ON t.id = u.tenant_id
+		 WHERE u.username_normalized = ?
+	`, normalized).Scan(
+		&user.ID, &user.TenantID, &user.Username, &user.DisplayName, &passwordHash, &user.Status,
+		&user.MustChangePassword, &lastLogin, &user.CreatedAt, &user.UpdatedAt, &user.Version,
+		&lockedUntil,
+		&tenant.ID, &tenant.Slug, &tenant.Name, &tenantType, &tenantStatus, &expiresAt, &tenant.Description,
+		&tenant.CreatedAt, &tenant.UpdatedAt, &tenant.Version,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		_ = bcrypt.CompareHashAndPassword([]byte(dummyPasswordHash), []byte(password))
+		return result, ErrInvalidCredentials
+	}
+	if err != nil {
+		return result, fmt.Errorf("identity: login lookup: %w", err)
+	}
+	// The password comparison stays ahead of the status checks so that
+	// ErrInvalidCredentials is the only error that can mean "a secret was guessed
+	// wrong". The API layer relies on exactly that to decide what consumes a
+	// guessing budget; a locked or suspended account must not.
+	if bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)) != nil {
+		if _, failErr := s.registerLoginFailure(ctx, tenant.ID, user.ID); failErr != nil {
+			return result, failErr
+		}
+		s.RecordAudit(ctx, AuditEvent{TenantID: tenant.ID, ActorKind: "system", Action: "auth.login", ResourceType: "user", ResourceID: user.ID, Result: "denied"})
+		return result, ErrInvalidCredentials
+	}
+	now := time.Now()
+	// Three separate judgements, deliberately not collapsed: an automatic cooldown
+	// expires on its own, an administrative lock does not, and neither is allowed
+	// to be healed by a successful password entry further down.
+	if lockedUntil.Valid && lockedUntil.Time.After(now) {
+		return result, ErrAccountLocked
+	}
+	if user.Status == "locked" {
+		return result, ErrAccountLocked
+	}
+	if user.Status == "disabled" {
+		return result, ErrAccountDisabled
+	}
+	tenant.Type = tenantType
+	tenant.Status = tenantStatus
+	if expiresAt.Valid {
+		tenant.ExpiresAt = &expiresAt.Time
+	}
+	if err = validateTenant(tenant, now); err != nil {
+		return result, err
+	}
+	if lastLogin.Valid {
+		user.LastLoginAt = &lastLogin.Time
+	}
+
+	token, hash, err := randomToken()
+	if err != nil {
+		return result, err
+	}
+	refreshToken, refreshHash, err := randomPrefixedToken("cpr_adm_")
+	if err != nil {
+		return result, err
+	}
+	policy := s.sessionPolicy()
+	accessTTL, refreshTTL := s.tenantSessionTTL(ctx, tenant.ID, remember)
+	sessionID := uuid.NewString()
+	issuedAt := time.Now().UTC()
+	sessionExpiresAt := issuedAt.Add(accessTTL)
+	refreshExpiresAt := issuedAt.Add(refreshTTL)
+	absoluteExpiresAt := issuedAt.Add(policy.AbsoluteRefreshTTL)
+	if refreshExpiresAt.After(absoluteExpiresAt) {
+		refreshExpiresAt = absoluteExpiresAt
+	}
+	uaSum := sha256.Sum256([]byte(userAgent))
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	// token_hash / refresh_token_hash keep mirroring the current head of the
+	// session. They are no longer the authentication source (user_session_tokens
+	// is), but they preserve the existing UNIQUE semantics, keep the management
+	// session views working, and let a rollback to the previous binary still find
+	// a usable token instead of logging everyone out.
+	if _, err = tx.ExecContext(ctx, `
+		INSERT INTO user_sessions (id, user_id, tenant_id, token_hash, expires_at,
+		  refresh_token_hash, refresh_expires_at, user_agent_hash,
+		  remember_me, refresh_ttl_seconds, refresh_absolute_expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, sessionID, user.ID, tenant.ID, hash, sessionExpiresAt, refreshHash, refreshExpiresAt,
+		hex.EncodeToString(uaSum[:]), remember, int(refreshTTL.Seconds()), absoluteExpiresAt); err != nil {
+		return result, err
+	}
+	if err = s.insertSessionTokens(ctx, tx, sessionTokenInsert{
+		SessionID:   sessionID,
+		AccessHash:  hash,
+		AccessExp:   sessionExpiresAt,
+		RefreshHash: refreshHash,
+		RefreshExp:  refreshExpiresAt,
+	}); err != nil {
+		return result, err
+	}
+	// A successful login clears the automatic cooldown state only. status is
+	// deliberately left alone: an administratively locked account already
+	// returned above, so reaching here with status='locked' is impossible, and
+	// re-adding the old "heal status on login" clause would let a future change
+	// silently unlock accounts an administrator disabled.
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE users SET last_login_at = now(), failed_login_count = 0, last_failed_login_at = NULL,
+		  lock_stage = 0, locked_until = NULL, updated_at = now()
+		WHERE id = ?
+	`, user.ID); err != nil {
+		return result, err
+	}
+	if err = tx.Commit(); err != nil {
+		return result, err
+	}
+
+	principal, err := s.loadPrincipal(ctx, user.ID, sessionID, sessionExpiresAt, tenant.ID)
+	if err != nil {
+		return result, err
+	}
+	result = LoginResult{
+		AccessToken: token, RefreshToken: refreshToken, TokenType: "Bearer",
+		ExpiresAt: sessionExpiresAt, RefreshExpiresAt: refreshExpiresAt, Principal: principal,
+	}
+	s.RecordAudit(ctx, AuditEvent{TenantID: tenant.ID, ActorKind: "user_session", ActorUserID: user.ID, ActorSessionID: sessionID, Action: "auth.login", ResourceType: "session", ResourceID: sessionID, Result: "success"})
+	return result, nil
+}

--- a/internal/identity/login_lockout.go
+++ b/internal/identity/login_lockout.go
@@ -1,0 +1,93 @@
+package identity
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// loginFailureWindow is the observation window for counting login failures.
+// Without it the counter is a lifetime total, so any account eventually crosses
+// every threshold and stays locked for reasons that happened months apart.
+const loginFailureWindow = 15 * time.Minute
+
+// lockPenalty mirrors internal/enduser/login_lockout.go — staged cooldown, never
+// a permanent lock. OWASP: permanent lockout is an attacker-triggerable DoS
+// (96 requests/day permanently locks any account when the counter never decays).
+//
+// apply is true only when the count crosses a threshold, so failures inside a
+// stage do not keep re-extending the cooldown from zero.
+func lockPenalty(failedCount int) (stage int, wait time.Duration, apply bool) {
+	switch {
+	case failedCount >= 20:
+		return 5, 60 * time.Minute, failedCount == 20 || failedCount%5 == 0
+	case failedCount >= 15:
+		return 4, 30 * time.Minute, failedCount == 15
+	case failedCount >= 10:
+		return 3, 15 * time.Minute, failedCount == 10
+	case failedCount >= 5:
+		return 2, 5 * time.Minute, failedCount == 5
+	case failedCount >= 3:
+		return 1, 1 * time.Minute, failedCount == 3
+	default:
+		return 0, 0, false
+	}
+}
+
+// registerLoginFailure charges one failure against the account and arms the
+// staged cooldown when a threshold is crossed.
+//
+// It deliberately never writes users.status: an automatic lock that flips status
+// is indistinguishable from an administrative lock, and the historical
+// "status='locked' with locked_until IS NULL" combination locked accounts out
+// permanently with no way back except a manual database edit.
+func (s *Service) registerLoginFailure(ctx context.Context, tenantID, userID string) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, nil
+	}
+	var count int
+	// Counting and decay happen in one statement so concurrent failures cannot
+	// lose an update, and so the window boundary is evaluated by the database
+	// clock rather than by whichever replica happened to serve the request.
+	if err := s.db.QueryRowContext(ctx, `
+		UPDATE users
+		   SET failed_login_count = CASE
+		         WHEN last_failed_login_at IS NULL
+		           OR last_failed_login_at < now() - make_interval(secs => ?)
+		         THEN 1 ELSE failed_login_count + 1 END,
+		       last_failed_login_at = now(),
+		       updated_at = now()
+		 WHERE id = ?
+		RETURNING failed_login_count
+	`, loginFailureWindow.Seconds(), userID).Scan(&count); err != nil {
+		return 0, err
+	}
+	log.Debugf("identity: login failure user=%s count=%d window=%s", userID, count, loginFailureWindow)
+
+	stage, wait, apply := lockPenalty(count)
+	if !apply || wait <= 0 {
+		return count, nil
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		UPDATE users SET locked_until = now() + make_interval(secs => ?), lock_stage = ?, updated_at = now()
+		 WHERE id = ?
+	`, wait.Seconds(), stage, userID); err != nil {
+		return count, err
+	}
+	log.Warnf("identity: login cooldown armed user=%s stage=%d wait=%s failed_count=%d", userID, stage, wait, count)
+	s.RecordAudit(ctx, AuditEvent{
+		TenantID:     tenantID,
+		ActorKind:    "system",
+		Action:       "auth.login_locked",
+		ResourceType: "user",
+		ResourceID:   userID,
+		Result:       "denied",
+		Changes: map[string]any{
+			"stage":        stage,
+			"wait_seconds": int(wait.Seconds()),
+			"failed_count": count,
+		},
+	})
+	return count, nil
+}

--- a/internal/identity/service.go
+++ b/internal/identity/service.go
@@ -2,16 +2,13 @@ package identity
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/base64"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -37,6 +34,9 @@ const dummyPasswordHash = "$2a$10$7EqJtq98hPqEX7fNZaFWoO5fKvR2qv4V5BfQWqHkVq3VP7
 
 type Service struct {
 	db *sql.DB
+	// policy is read on every login/refresh and replaced by config hot-reload, so
+	// it is swapped atomically rather than guarded by the package-level mutex.
+	policy atomic.Pointer[SessionPolicy]
 }
 
 var (
@@ -256,211 +256,6 @@ func (s *Service) Bootstrap(ctx context.Context, initialPassword string) error {
 	return nil
 }
 
-func randomToken() (string, string, error) {
-	return randomPrefixedToken("cps_")
-}
-
-func randomPrefixedToken(prefix string) (string, string, error) {
-	raw := make([]byte, 32)
-	if _, err := rand.Read(raw); err != nil {
-		return "", "", err
-	}
-	token := prefix + base64.RawURLEncoding.EncodeToString(raw)
-	sum := sha256.Sum256([]byte(token))
-	return token, hex.EncodeToString(sum[:]), nil
-}
-
-func (s *Service) tenantSessionTTL(ctx context.Context, tenantID string, remember bool) (access, refresh time.Duration) {
-	// Short access + long refresh. remember_me only keeps/extends refresh, never access.
-	access, refresh = 12*time.Hour, 30*24*time.Hour
-	if s == nil || s.db == nil {
-		return
-	}
-	var a, r sql.NullInt64
-	_ = s.db.QueryRowContext(ctx, `SELECT access_token_ttl_seconds, refresh_token_ttl_seconds FROM tenants WHERE id = ?`, tenantID).Scan(&a, &r)
-	if a.Valid && a.Int64 > 0 {
-		access = time.Duration(a.Int64) * time.Second
-	}
-	if r.Valid && r.Int64 > 0 {
-		refresh = time.Duration(r.Int64) * time.Second
-	}
-	if remember && refresh < 30*24*time.Hour {
-		refresh = 30 * 24 * time.Hour
-	}
-	return
-}
-
-func tokenHash(token string) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(token)))
-	return hex.EncodeToString(sum[:])
-}
-
-func (s *Service) Login(ctx context.Context, username, password string, remember bool, userAgent string) (LoginResult, error) {
-	var result LoginResult
-	if s == nil || s.db == nil {
-		return result, ErrInvalidCredentials
-	}
-	normalized := NormalizeUsername(username)
-	var user User
-	var passwordHash, tenantStatus, tenantType string
-	var tenant Tenant
-	var expiresAt sql.NullTime
-	var lastLogin sql.NullTime
-	var lockedUntil sql.NullTime
-	err := s.db.QueryRowContext(ctx, `
-		SELECT u.id, u.tenant_id, u.username, u.display_name, u.password_hash, u.status,
-		       u.must_change_password, u.last_login_at, u.created_at, u.updated_at, u.version,
-		       u.locked_until,
-		       t.id, t.slug, t.name, t.type, t.status, t.expires_at, t.description,
-		       t.created_at, t.updated_at, t.version
-		  FROM users u JOIN tenants t ON t.id = u.tenant_id
-		 WHERE u.username_normalized = ?
-	`, normalized).Scan(
-		&user.ID, &user.TenantID, &user.Username, &user.DisplayName, &passwordHash, &user.Status,
-		&user.MustChangePassword, &lastLogin, &user.CreatedAt, &user.UpdatedAt, &user.Version,
-		&lockedUntil,
-		&tenant.ID, &tenant.Slug, &tenant.Name, &tenantType, &tenantStatus, &expiresAt, &tenant.Description,
-		&tenant.CreatedAt, &tenant.UpdatedAt, &tenant.Version,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		_ = bcrypt.CompareHashAndPassword([]byte(dummyPasswordHash), []byte(password))
-		return result, ErrInvalidCredentials
-	}
-	if err != nil {
-		return result, fmt.Errorf("identity: login lookup: %w", err)
-	}
-	if bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)) != nil {
-		_, _ = s.db.ExecContext(ctx, `
-			UPDATE users
-			   SET failed_login_count = failed_login_count + 1,
-			       status = CASE WHEN failed_login_count + 1 >= 10 THEN 'locked' ELSE status END,
-			       locked_until = CASE WHEN failed_login_count + 1 >= 10 THEN now() + interval '15 minutes' ELSE locked_until END,
-			       updated_at = now()
-			 WHERE id = ?
-		`, user.ID)
-		s.RecordAudit(ctx, AuditEvent{TenantID: tenant.ID, ActorKind: "system", Action: "auth.login", ResourceType: "user", ResourceID: user.ID, Result: "denied"})
-		return result, ErrInvalidCredentials
-	}
-	if user.Status == "disabled" {
-		return result, ErrAccountDisabled
-	}
-	if user.Status == "locked" && (!lockedUntil.Valid || lockedUntil.Time.After(time.Now())) {
-		return result, ErrAccountLocked
-	}
-	tenant.Type = tenantType
-	tenant.Status = tenantStatus
-	if expiresAt.Valid {
-		tenant.ExpiresAt = &expiresAt.Time
-	}
-	if err = validateTenant(tenant, time.Now()); err != nil {
-		return result, err
-	}
-	if lastLogin.Valid {
-		user.LastLoginAt = &lastLogin.Time
-	}
-
-	token, hash, err := randomToken()
-	if err != nil {
-		return result, err
-	}
-	refreshToken, refreshHash, err := randomPrefixedToken("cpr_adm_")
-	if err != nil {
-		return result, err
-	}
-	accessTTL, refreshTTL := s.tenantSessionTTL(ctx, tenant.ID, remember)
-	sessionID := uuid.NewString()
-	now := time.Now().UTC()
-	sessionExpiresAt := now.Add(accessTTL)
-	refreshExpiresAt := now.Add(refreshTTL)
-	uaSum := sha256.Sum256([]byte(userAgent))
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return result, err
-	}
-	defer func() { _ = tx.Rollback() }()
-	if _, err = tx.ExecContext(ctx, `
-		INSERT INTO user_sessions (id, user_id, tenant_id, token_hash, expires_at, refresh_token_hash, refresh_expires_at, user_agent_hash)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`, sessionID, user.ID, tenant.ID, hash, sessionExpiresAt, refreshHash, refreshExpiresAt, hex.EncodeToString(uaSum[:])); err != nil {
-		return result, err
-	}
-	if _, err = tx.ExecContext(ctx, `
-		UPDATE users SET last_login_at = now(), failed_login_count = 0, locked_until = NULL,
-		  status = CASE WHEN status = 'locked' THEN 'active' ELSE status END, updated_at = now()
-		WHERE id = ?
-	`, user.ID); err != nil {
-		return result, err
-	}
-	if err = tx.Commit(); err != nil {
-		return result, err
-	}
-
-	principal, err := s.loadPrincipal(ctx, user.ID, sessionID, sessionExpiresAt, tenant.ID)
-	if err != nil {
-		return result, err
-	}
-	result = LoginResult{
-		AccessToken: token, RefreshToken: refreshToken, TokenType: "Bearer",
-		ExpiresAt: sessionExpiresAt, RefreshExpiresAt: refreshExpiresAt, Principal: principal,
-	}
-	s.RecordAudit(ctx, AuditEvent{TenantID: tenant.ID, ActorKind: "user_session", ActorUserID: user.ID, ActorSessionID: sessionID, Action: "auth.login", ResourceType: "session", ResourceID: sessionID, Result: "success"})
-	return result, nil
-}
-
-func (s *Service) RefreshSession(ctx context.Context, refreshToken string) (LoginResult, error) {
-	var result LoginResult
-	if s == nil || s.db == nil || !strings.HasPrefix(strings.TrimSpace(refreshToken), "cpr_adm_") {
-		return result, ErrSessionRevoked
-	}
-	var sessionID, userID, tenantID string
-	var refreshExp time.Time
-	var revoked sql.NullTime
-	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, tenant_id, refresh_expires_at, revoked_at
-		  FROM user_sessions WHERE refresh_token_hash = ?
-	`, tokenHash(refreshToken)).Scan(&sessionID, &userID, &tenantID, &refreshExp, &revoked)
-	if errors.Is(err, sql.ErrNoRows) {
-		return result, ErrSessionRevoked
-	}
-	if err != nil {
-		return result, err
-	}
-	if revoked.Valid || !refreshExp.After(time.Now()) {
-		return result, ErrSessionExpired
-	}
-	accessTTL, refreshTTL := s.tenantSessionTTL(ctx, tenantID, false)
-	accessPlain, accessHash, err := randomToken()
-	if err != nil {
-		return result, err
-	}
-	refreshPlain, refreshHash, err := randomPrefixedToken("cpr_adm_")
-	if err != nil {
-		return result, err
-	}
-	now := time.Now().UTC()
-	accessExp := now.Add(accessTTL)
-	newRefreshExp := now.Add(refreshTTL)
-	// Atomic consume: only one concurrent refresh of the same refresh token wins.
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE user_sessions SET token_hash = ?, expires_at = ?, refresh_token_hash = ?, refresh_expires_at = ?, last_seen_at = now()
-		WHERE id = ? AND refresh_token_hash = ? AND revoked_at IS NULL AND refresh_expires_at > now()
-	`, accessHash, accessExp, refreshHash, newRefreshExp, sessionID, tokenHash(refreshToken))
-	if err != nil {
-		return result, err
-	}
-	if n, _ := res.RowsAffected(); n == 0 {
-		return result, ErrSessionRevoked
-	}
-	principal, err := s.loadPrincipal(ctx, userID, sessionID, accessExp, tenantID)
-	if err != nil {
-		return result, err
-	}
-	return LoginResult{
-		AccessToken: accessPlain, RefreshToken: refreshPlain, TokenType: "Bearer",
-		ExpiresAt: accessExp, RefreshExpiresAt: newRefreshExp, Principal: principal,
-	}, nil
-}
-
 func validateTenant(tenant Tenant, now time.Time) error {
 	if tenant.Status != "active" {
 		return ErrTenantSuspended
@@ -473,20 +268,13 @@ func validateTenant(tenant Tenant, now time.Time) error {
 
 func (s *Service) Authenticate(ctx context.Context, token, effectiveTenantID string) (Principal, error) {
 	var principal Principal
-	var userID, sessionID, homeTenantID string
-	var expiresAt time.Time
-	var revokedAt sql.NullTime
-	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, tenant_id, expires_at, revoked_at
-		  FROM user_sessions WHERE token_hash = ?
-	`, tokenHash(token)).Scan(&sessionID, &userID, &homeTenantID, &expiresAt, &revokedAt)
-	if errors.Is(err, sql.ErrNoRows) {
-		return principal, ErrSessionRevoked
-	}
+	session, err := s.lookupAccessSession(ctx, tokenHash(token))
 	if err != nil {
 		return principal, err
 	}
-	if revokedAt.Valid {
+	sessionID, userID, homeTenantID := session.sessionID, session.userID, session.tenantID
+	expiresAt := session.expiresAt
+	if session.revokedAt.Valid {
 		return principal, ErrSessionRevoked
 	}
 	if !expiresAt.After(time.Now()) {

--- a/internal/identity/session_postgres_test.go
+++ b/internal/identity/session_postgres_test.go
@@ -16,8 +16,16 @@ import (
 
 const sessionTestPassword = "Bootstrap-Password-123!"
 
-// newSessionTestService brings up a clean identity schema on the shared test
+// newSessionTestService prepares an isolated identity fixture on the shared test
 // database and returns a bootstrapped service plus the admin user id.
+//
+// It resets state with targeted DELETEs rather than TRUNCATE on purpose. TRUNCATE
+// takes an ACCESS EXCLUSIVE lock on every table it touches and follows foreign
+// keys, so truncating tenants reaches api_keys, request_logs and the rest of the
+// usage catalog. The usage package's integration test truncates that same set in
+// a different order, and with these cases running dozens of times the two
+// eventually interleave into a lock cycle that Postgres resolves by killing one
+// of them. Row-level deletes touch only what this fixture actually owns.
 func newSessionTestService(t *testing.T) (*Service, *sql.DB, string) {
 	t.Helper()
 	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
@@ -31,12 +39,27 @@ func newSessionTestService(t *testing.T) (*Service, *sql.DB, string) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if _, err = db.Exec(`TRUNCATE audit_logs,user_session_tokens,user_sessions,user_roles,role_permissions,menus,users,roles,permissions,tenants CASCADE`); err != nil {
-		t.Fatal(err)
-	}
+
 	service := NewService(db)
+	// Bootstrap is idempotent and leaves an existing admin alone, so the tenant
+	// and role rows can simply be reused across cases.
 	if err = service.Bootstrap(ctx, sessionTestPassword); err != nil {
 		t.Fatal(err)
+	}
+	for _, stmt := range []string{
+		`DELETE FROM user_session_tokens`,
+		`DELETE FROM user_sessions`,
+		`DELETE FROM audit_logs WHERE actor_user_id = '` + SystemUserID + `'`,
+		// Undo whatever a previous case did to the admin's lockout state, and any
+		// administrative lock a case installed deliberately.
+		`UPDATE users SET status = 'active', failed_login_count = 0, last_failed_login_at = NULL,
+		   lock_stage = 0, locked_until = NULL WHERE id = '` + SystemUserID + `'`,
+		`UPDATE tenants SET access_token_ttl_seconds = 43200, refresh_token_ttl_seconds = 2592000
+		   WHERE id = '` + SystemTenantID + `'`,
+	} {
+		if _, err = db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("reset identity fixture: %v", err)
+		}
 	}
 	return service, db, SystemUserID
 }

--- a/internal/identity/session_postgres_test.go
+++ b/internal/identity/session_postgres_test.go
@@ -1,0 +1,478 @@
+package identity
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/testutil/postgrestest"
+)
+
+const sessionTestPassword = "Bootstrap-Password-123!"
+
+// newSessionTestService brings up a clean identity schema on the shared test
+// database and returns a bootstrapped service plus the admin user id.
+func newSessionTestService(t *testing.T) (*Service, *sql.DB, string) {
+	t.Helper()
+	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
+	ctx := context.Background()
+	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 8, MaxIdleConns: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err = db.Exec(`TRUNCATE audit_logs,user_session_tokens,user_sessions,user_roles,role_permissions,menus,users,roles,permissions,tenants CASCADE`); err != nil {
+		t.Fatal(err)
+	}
+	service := NewService(db)
+	if err = service.Bootstrap(ctx, sessionTestPassword); err != nil {
+		t.Fatal(err)
+	}
+	return service, db, SystemUserID
+}
+
+func mustLogin(t *testing.T, s *Service, remember bool) LoginResult {
+	t.Helper()
+	result, err := s.Login(context.Background(), "admin", sessionTestPassword, remember, "test-agent")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	return result
+}
+
+// TestPostgresRefreshKeepsPreviousAccessTokenDuringGrace is the primary anchor for
+// the reported "signed out while using the panel" failure. Rotation used to
+// invalidate the previous access token the instant a refresh landed, so any
+// request already in flight came back 401 and the panel treated it as a dead
+// session.
+func TestPostgresRefreshKeepsPreviousAccessTokenDuringGrace(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	service.SetSessionPolicy(SessionPolicy{AccessGrace: 60 * time.Second})
+	ctx := context.Background()
+
+	login := mustLogin(t, service, false)
+	if _, err := service.RefreshSession(ctx, login.RefreshToken); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	if _, err := service.Authenticate(ctx, login.AccessToken, ""); err != nil {
+		t.Fatalf("previous access token rejected inside the grace window: %v", err)
+	}
+
+	// Expire the grace window without sleeping through it.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE user_session_tokens SET expires_at = now() - interval '1 second' WHERE token_hash = ?`,
+		tokenHash(login.AccessToken)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Authenticate(ctx, login.AccessToken, ""); !errors.Is(err, ErrSessionExpired) {
+		t.Fatalf("previous access token after grace = %v, want ErrSessionExpired", err)
+	}
+}
+
+// TestPostgresRefreshGraceAllowsPreviousRefreshToken covers the second half of the
+// same failure: a tab that retries a refresh, or a second tab that raced it, must
+// not lose the session.
+func TestPostgresRefreshGraceAllowsPreviousRefreshToken(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	service.SetSessionPolicy(SessionPolicy{RefreshGrace: 30 * time.Second, RefreshGraceMaxReuse: 2})
+	ctx := context.Background()
+
+	login := mustLogin(t, service, false)
+	first, err := service.RefreshSession(ctx, login.RefreshToken)
+	if err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	second, err := service.RefreshSession(ctx, login.RefreshToken)
+	if err != nil {
+		t.Fatalf("grace replay of the consumed refresh token: %v", err)
+	}
+	if second.AccessToken == first.AccessToken {
+		t.Fatal("grace replay returned the same access token as the first rotation")
+	}
+	// Both branches must authenticate: forks are legal inside the grace window.
+	for name, token := range map[string]string{"first": first.AccessToken, "second": second.AccessToken} {
+		if _, err = service.Authenticate(ctx, token, ""); err != nil {
+			t.Fatalf("%s rotation's access token rejected: %v", name, err)
+		}
+	}
+
+	var reuseCount int
+	if err = db.QueryRowContext(ctx,
+		`SELECT reuse_count FROM user_session_tokens WHERE token_hash = ?`,
+		tokenHash(login.RefreshToken)).Scan(&reuseCount); err != nil {
+		t.Fatal(err)
+	}
+	if reuseCount != 1 {
+		t.Fatalf("reuse_count = %d, want 1", reuseCount)
+	}
+}
+
+// TestPostgresRefreshGraceReuseCapRevokesSession proves the grace window did not
+// become an unbounded replay window: past the cap the token is treated as stolen.
+func TestPostgresRefreshGraceReuseCapRevokesSession(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	service.SetSessionPolicy(SessionPolicy{RefreshGrace: 30 * time.Second, RefreshGraceMaxReuse: 2})
+	ctx := context.Background()
+
+	login := mustLogin(t, service, false)
+	for i := 0; i <= 2; i++ {
+		if _, err := service.RefreshSession(ctx, login.RefreshToken); err != nil {
+			t.Fatalf("refresh %d inside the reuse budget: %v", i, err)
+		}
+	}
+	if _, err := service.RefreshSession(ctx, login.RefreshToken); !errors.Is(err, ErrSessionRevoked) {
+		t.Fatalf("refresh past the reuse cap = %v, want ErrSessionRevoked", err)
+	}
+
+	var revokeReason string
+	if err := db.QueryRowContext(ctx,
+		`SELECT revoke_reason FROM user_sessions WHERE id = ?`, login.Principal.SessionID).Scan(&revokeReason); err != nil {
+		t.Fatal(err)
+	}
+	if revokeReason == "" {
+		t.Fatal("session was not revoked after reuse detection")
+	}
+
+	var remaining int
+	if err := db.QueryRowContext(ctx,
+		`SELECT count(*) FROM user_session_tokens WHERE session_id = ?`, login.Principal.SessionID).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 0 {
+		t.Fatalf("token rows after family revocation = %d, want 0", remaining)
+	}
+}
+
+// TestPostgresRefreshOutsideGraceRevokesFamily checks that a token replayed long
+// after rotation is still treated as a compromise, not as a slow retry.
+func TestPostgresRefreshOutsideGraceRevokesFamily(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	service.SetSessionPolicy(SessionPolicy{RefreshGrace: 30 * time.Second, RefreshGraceMaxReuse: 2})
+	ctx := context.Background()
+
+	login := mustLogin(t, service, false)
+	if _, err := service.RefreshSession(ctx, login.RefreshToken); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`UPDATE user_session_tokens SET grace_until = now() - interval '1 second' WHERE token_hash = ?`,
+		tokenHash(login.RefreshToken)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.RefreshSession(ctx, login.RefreshToken); !errors.Is(err, ErrSessionRevoked) {
+		t.Fatalf("replay outside the grace window = %v, want ErrSessionRevoked", err)
+	}
+}
+
+// TestPostgresRefreshConcurrentRotationAllSucceed is the direct regression for the
+// multi-tab report: several tabs hitting 401 at once all refresh with the same
+// stored token, and every one of them must come away with a working session.
+func TestPostgresRefreshConcurrentRotationAllSucceed(t *testing.T) {
+	service, _, _ := newSessionTestService(t)
+	service.SetSessionPolicy(SessionPolicy{RefreshGrace: 30 * time.Second, RefreshGraceMaxReuse: 8})
+	ctx := context.Background()
+
+	login := mustLogin(t, service, false)
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	results := make([]LoginResult, concurrency)
+	errs := make([]error, concurrency)
+	start := make(chan struct{})
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx], errs[idx] = service.RefreshSession(ctx, login.RefreshToken)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent refresh %d failed: %v", i, err)
+		}
+	}
+	for i, res := range results {
+		if _, err := service.Authenticate(ctx, res.AccessToken, ""); err != nil {
+			t.Fatalf("access token from concurrent refresh %d rejected: %v", i, err)
+		}
+	}
+}
+
+// TestPostgresRefreshPreservesRememberMeTTL is the B8 anchor: rotation used to
+// recompute the refresh lifetime with remember=false, silently downgrading a
+// 30-day "remember me" session on its first refresh.
+func TestPostgresRefreshPreservesRememberMeTTL(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	ctx := context.Background()
+
+	// A short tenant default is what exposes the bug: without the stored
+	// provenance, rotation would fall back to this value.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE tenants SET refresh_token_ttl_seconds = 86400 WHERE id = ?`, SystemTenantID); err != nil {
+		t.Fatal(err)
+	}
+
+	login := mustLogin(t, service, true)
+	if got := time.Until(login.RefreshExpiresAt); got < 29*24*time.Hour {
+		t.Fatalf("remember-me login refresh TTL = %v, want >= 29 days", got)
+	}
+	rotated, err := service.RefreshSession(ctx, login.RefreshToken)
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if got := time.Until(rotated.RefreshExpiresAt); got < 29*24*time.Hour {
+		t.Fatalf("refresh TTL after rotation = %v, want >= 29 days (remember-me must survive rotation)", got)
+	}
+}
+
+// TestPostgresRefreshNeverExceedsAbsoluteDeadline guards the ceiling that keeps a
+// stolen token from being renewed forever.
+func TestPostgresRefreshNeverExceedsAbsoluteDeadline(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	ctx := context.Background()
+
+	login := mustLogin(t, service, true)
+	if _, err := db.ExecContext(ctx,
+		`UPDATE user_sessions SET refresh_absolute_expires_at = now() + interval '1 hour' WHERE id = ?`,
+		login.Principal.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	rotated, err := service.RefreshSession(ctx, login.RefreshToken)
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if time.Until(rotated.RefreshExpiresAt) > time.Hour+time.Minute {
+		t.Fatalf("rotation extended past the absolute deadline: %v", rotated.RefreshExpiresAt)
+	}
+}
+
+func TestPostgresRefreshOnRevokedSessionFails(t *testing.T) {
+	service, _, _ := newSessionTestService(t)
+	ctx := context.Background()
+
+	login := mustLogin(t, service, false)
+	if err := service.Logout(ctx, login.Principal.SessionID); err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	if _, err := service.RefreshSession(ctx, login.RefreshToken); err == nil {
+		t.Fatal("refresh on a revoked session succeeded")
+	}
+}
+
+// TestPostgresAuthenticateAdoptsMirroredAccessToken covers the blue-green window:
+// the previous binary rotates by writing only user_sessions.token_hash, and the
+// new binary must accept those tokens instead of signing the user out mid-deploy.
+func TestPostgresAuthenticateAdoptsMirroredAccessToken(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	ctx := context.Background()
+
+	login := mustLogin(t, service, false)
+	// Simulate a rotation performed by the old binary: the mirror moves, the
+	// per-token table does not.
+	legacyAccess, legacyHash, err := randomToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.ExecContext(ctx,
+		`UPDATE user_sessions SET token_hash = ?, expires_at = now() + interval '1 hour' WHERE id = ?`,
+		legacyHash, login.Principal.SessionID); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = service.Authenticate(ctx, legacyAccess, ""); err != nil {
+		t.Fatalf("access token minted by the previous release was rejected: %v", err)
+	}
+
+	var backfilled int
+	if err = db.QueryRowContext(ctx,
+		`SELECT count(*) FROM user_session_tokens WHERE token_hash = ? AND kind = 'access'`,
+		legacyHash).Scan(&backfilled); err != nil {
+		t.Fatal(err)
+	}
+	if backfilled != 1 {
+		t.Fatalf("adopted token rows = %d, want 1 (the fallback must backfill)", backfilled)
+	}
+}
+
+// TestPostgresRefreshAdoptsMirroredRefreshToken is the refresh-side counterpart.
+func TestPostgresRefreshAdoptsMirroredRefreshToken(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	ctx := context.Background()
+
+	login := mustLogin(t, service, false)
+	legacyRefresh, legacyHash, err := randomPrefixedToken("cpr_adm_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.ExecContext(ctx,
+		`UPDATE user_sessions SET refresh_token_hash = ?, refresh_expires_at = now() + interval '24 hours' WHERE id = ?`,
+		legacyHash, login.Principal.SessionID); err != nil {
+		t.Fatal(err)
+	}
+
+	rotated, err := service.RefreshSession(ctx, legacyRefresh)
+	if err != nil {
+		t.Fatalf("refresh token minted by the previous release was rejected: %v", err)
+	}
+	if _, err = service.Authenticate(ctx, rotated.AccessToken, ""); err != nil {
+		t.Fatalf("access token from adopted refresh rejected: %v", err)
+	}
+
+	// The adoption path must not look like a replay: the session stays alive.
+	var revokedAt sql.NullTime
+	if err = db.QueryRowContext(ctx,
+		`SELECT revoked_at FROM user_sessions WHERE id = ?`, login.Principal.SessionID).Scan(&revokedAt); err != nil {
+		t.Fatal(err)
+	}
+	if revokedAt.Valid {
+		t.Fatal("adopting a mirrored refresh token revoked the session")
+	}
+}
+
+// TestPostgresLoginFailureCountDecaysOutsideWindow is the B6 anchor: the counter
+// never decayed, so mistypes months apart accumulated into a lockout.
+func TestPostgresLoginFailureCountDecaysOutsideWindow(t *testing.T) {
+	service, db, userID := newSessionTestService(t)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		if _, err := service.Login(ctx, "admin", "wrong-password", false, "test-agent"); !errors.Is(err, ErrInvalidCredentials) {
+			t.Fatalf("failed login %d = %v, want ErrInvalidCredentials", i, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx,
+		`UPDATE users SET last_failed_login_at = now() - interval '1 hour' WHERE id = ?`, userID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Login(ctx, "admin", "wrong-password", false, "test-agent"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("failed login after the window = %v, want ErrInvalidCredentials", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT failed_login_count FROM users WHERE id = ?`, userID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("failed_login_count = %d, want 1 (the window must restart the count)", count)
+	}
+}
+
+// TestPostgresLoginLockoutIsTemporaryAndNeverFlipsStatus proves an automatic
+// cooldown stays distinguishable from an administrative lock, and clears itself.
+func TestPostgresLoginLockoutIsTemporaryAndNeverFlipsStatus(t *testing.T) {
+	service, db, userID := newSessionTestService(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if _, err := service.Login(ctx, "admin", "wrong-password", false, "test-agent"); err == nil {
+			t.Fatalf("failed login %d unexpectedly succeeded", i)
+		}
+	}
+
+	var status string
+	var lockedUntil sql.NullTime
+	var lockStage int
+	if err := db.QueryRowContext(ctx,
+		`SELECT status, locked_until, lock_stage FROM users WHERE id = ?`, userID).Scan(&status, &lockedUntil, &lockStage); err != nil {
+		t.Fatal(err)
+	}
+	if status != "active" {
+		t.Fatalf("status = %q after an automatic cooldown, want active (only an administrator may lock)", status)
+	}
+	if !lockedUntil.Valid || !lockedUntil.Time.After(time.Now()) {
+		t.Fatalf("locked_until = %v, want a future cooldown", lockedUntil)
+	}
+	if lockStage != 1 {
+		t.Fatalf("lock_stage = %d, want 1", lockStage)
+	}
+
+	if _, err := service.Login(ctx, "admin", sessionTestPassword, false, "test-agent"); !errors.Is(err, ErrAccountLocked) {
+		t.Fatalf("login during cooldown = %v, want ErrAccountLocked", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `UPDATE users SET locked_until = now() - interval '1 second' WHERE id = ?`, userID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Login(ctx, "admin", sessionTestPassword, false, "test-agent"); err != nil {
+		t.Fatalf("login after the cooldown expired: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT lock_stage FROM users WHERE id = ?`, userID).Scan(&lockStage); err != nil {
+		t.Fatal(err)
+	}
+	if lockStage != 0 {
+		t.Fatalf("lock_stage = %d after a successful login, want 0", lockStage)
+	}
+}
+
+// TestPostgresLoginPreservesAdministrativeLock makes sure the self-healing path
+// added for cooldowns cannot resurrect an account an administrator disabled.
+func TestPostgresLoginPreservesAdministrativeLock(t *testing.T) {
+	service, db, userID := newSessionTestService(t)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx,
+		`UPDATE users SET status = 'locked', locked_until = NULL WHERE id = ?`, userID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Login(ctx, "admin", sessionTestPassword, false, "test-agent"); !errors.Is(err, ErrAccountLocked) {
+		t.Fatalf("login on an administratively locked account = %v, want ErrAccountLocked", err)
+	}
+
+	var status string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = ?`, userID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "locked" {
+		t.Fatalf("status = %q, want locked (a correct password must not clear an administrative lock)", status)
+	}
+}
+
+func TestPostgresSessionReaperRemovesExpiredTokensAndSessions(t *testing.T) {
+	service, db, _ := newSessionTestService(t)
+	ctx := context.Background()
+
+	live := mustLogin(t, service, false)
+	stale := mustLogin(t, service, false)
+
+	if _, err := db.ExecContext(ctx,
+		`UPDATE user_session_tokens SET expires_at = now() - interval '8 days' WHERE session_id = ?`,
+		stale.Principal.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`UPDATE user_sessions SET revoked_at = now() - interval '60 days', revoke_reason = 'test' WHERE id = ?`,
+		stale.Principal.SessionID); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := service.reapOnce(ctx); err != nil {
+		t.Fatalf("reapOnce: %v", err)
+	}
+
+	var staleSessions int
+	if err := db.QueryRowContext(ctx,
+		`SELECT count(*) FROM user_sessions WHERE id = ?`, stale.Principal.SessionID).Scan(&staleSessions); err != nil {
+		t.Fatal(err)
+	}
+	if staleSessions != 0 {
+		t.Fatalf("stale session rows = %d, want 0", staleSessions)
+	}
+	if _, err := service.Authenticate(ctx, live.AccessToken, ""); err != nil {
+		t.Fatalf("reaper removed a live session: %v", err)
+	}
+}

--- a/internal/identity/session_reaper.go
+++ b/internal/identity/session_reaper.go
@@ -1,0 +1,85 @@
+package identity
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// StartSessionReaper garbage-collects expired token rows and dead sessions.
+//
+// It exists because rotation now appends a row per issued token instead of
+// overwriting one: without a reaper, user_session_tokens grows for the lifetime
+// of the deployment. The returned stop function is idempotent and must be wired
+// into the process shutdown chain so a restart does not leak the goroutine.
+func (s *Service) StartSessionReaper(ctx context.Context, interval time.Duration) (stop func()) {
+	if s == nil || s.db == nil {
+		return func() {}
+	}
+	if interval <= 0 {
+		interval = defaultSessionReaperInterval
+	}
+	reaperCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-reaperCtx.Done():
+				return
+			case <-ticker.C:
+				tokens, sessions, err := s.reapOnce(reaperCtx)
+				if err != nil {
+					log.WithError(err).Debug("identity: session reaper pass failed")
+					continue
+				}
+				if tokens > 0 || sessions > 0 {
+					log.Infof("identity: session reaper removed %d tokens, %d sessions", tokens, sessions)
+					continue
+				}
+				log.Debugf("identity: session reaper removed %d tokens, %d sessions", tokens, sessions)
+			}
+		}
+	}()
+	return cancel
+}
+
+// reapOnce runs a single garbage-collection pass.
+//
+// Expired token rows are kept for a day rather than deleted immediately so an
+// operator investigating "why was I signed out" can still see which token
+// expired when. Revoked sessions are kept for 30 days because
+// audit_logs.actor_session_id points at them; that foreign key is ON DELETE SET
+// NULL, so the final delete degrades the audit trail rather than failing.
+func (s *Service) reapOnce(ctx context.Context) (tokens, sessions int64, err error) {
+	if s == nil || s.db == nil {
+		return 0, 0, nil
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM user_session_tokens WHERE expires_at < now() - interval '1 day'`)
+	if err != nil {
+		return 0, 0, err
+	}
+	tokens, err = res.RowsAffected()
+	if err != nil {
+		return 0, 0, err
+	}
+	if _, err = s.db.ExecContext(ctx, `
+		UPDATE user_sessions SET revoked_at = now(), revoke_reason = 'absolute_expiry'
+		 WHERE revoked_at IS NULL AND refresh_absolute_expires_at IS NOT NULL
+		   AND refresh_absolute_expires_at < now()
+	`); err != nil {
+		return tokens, 0, err
+	}
+	res, err = s.db.ExecContext(ctx, `
+		DELETE FROM user_sessions WHERE revoked_at IS NOT NULL AND revoked_at < now() - interval '30 days'
+	`)
+	if err != nil {
+		return tokens, 0, err
+	}
+	sessions, err = res.RowsAffected()
+	if err != nil {
+		return tokens, 0, err
+	}
+	return tokens, sessions, nil
+}

--- a/internal/identity/session_refresh.go
+++ b/internal/identity/session_refresh.go
@@ -1,0 +1,424 @@
+package identity
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// adminRefreshTokenPrefix marks a refresh token minted for the admin panel.
+const adminRefreshTokenPrefix = "cpr_adm_"
+
+// refreshClaim is the outcome of successfully consuming a refresh token.
+type refreshClaim struct {
+	sessionID  string
+	generation int64
+	// reuseCount is 0 on the first consumption and >0 for every replay served
+	// inside the grace window, which is exactly the "was this a grace hit"
+	// predicate. It is preferred over comparing consumed_at against now()
+	// because a slow statement would make a timestamp comparison lie.
+	reuseCount int
+	graceUntil sql.NullTime
+}
+
+// sessionRotationState is the session-level context a rotation needs.
+type sessionRotationState struct {
+	userID            string
+	tenantID          string
+	rememberMe        bool
+	refreshTTLSeconds int
+	absoluteExpiresAt sql.NullTime
+}
+
+// RefreshSession rotates a session's token pair.
+//
+// Rotation is not destructive: the consumed refresh token stays usable for
+// SessionPolicy.RefreshGrace so that a client retry, or a second browser tab
+// that lost the race, still receives a working pair instead of being signed
+// out. Replays past the grace window (or past the reuse cap) are treated as
+// token theft and revoke the whole session family — a grace window without
+// reuse detection would be strictly worse than hard rotation, because a thief
+// could then sit on a stolen token indefinitely without anyone noticing.
+func (s *Service) RefreshSession(ctx context.Context, refreshToken string) (LoginResult, error) {
+	var result LoginResult
+	if s == nil || s.db == nil || !strings.HasPrefix(strings.TrimSpace(refreshToken), adminRefreshTokenPrefix) {
+		return result, ErrSessionRevoked
+	}
+	hash := tokenHash(refreshToken)
+	policy := s.sessionPolicy()
+
+	claim, ok, err := s.claimRefreshToken(ctx, hash, policy)
+	if err != nil {
+		return result, err
+	}
+	if !ok {
+		adopted, adoptErr := s.adoptMirroredRefreshToken(ctx, hash)
+		if adoptErr != nil {
+			return result, adoptErr
+		}
+		if !adopted {
+			return result, s.classifyRefreshFailure(ctx, hash)
+		}
+		claim, ok, err = s.claimRefreshToken(ctx, hash, policy)
+		if err != nil {
+			return result, err
+		}
+		if !ok {
+			return result, s.classifyRefreshFailure(ctx, hash)
+		}
+	}
+	return s.rotateSession(ctx, hash, claim, policy)
+}
+
+// claimRefreshToken consumes the token in a single statement. The row lock taken
+// by the UPDATE is what serialises concurrent refreshes of the same token, so
+// there is deliberately no read-modify-write: two tabs refreshing at the same
+// instant are ordered by the database, and the loser is served from the grace
+// window instead of being told its session is gone.
+func (s *Service) claimRefreshToken(ctx context.Context, hash string, policy SessionPolicy) (refreshClaim, bool, error) {
+	var claim refreshClaim
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE user_session_tokens
+		   SET consumed_at = COALESCE(consumed_at, now()),
+		       grace_until = COALESCE(grace_until, now() + make_interval(secs => ?)),
+		       reuse_count = CASE WHEN consumed_at IS NULL THEN 0 ELSE reuse_count + 1 END
+		 WHERE token_hash = ?
+		   AND kind = 'refresh'
+		   AND expires_at > now()
+		   AND (consumed_at IS NULL OR (grace_until > now() AND reuse_count < ?))
+		   AND EXISTS (
+		         SELECT 1 FROM user_sessions s
+		          WHERE s.id = user_session_tokens.session_id AND s.revoked_at IS NULL
+		       )
+		RETURNING session_id, generation, reuse_count, grace_until
+	`, policy.RefreshGrace.Seconds(), hash, policy.RefreshGraceMaxReuse).
+		Scan(&claim.sessionID, &claim.generation, &claim.reuseCount, &claim.graceUntil)
+	if errors.Is(err, sql.ErrNoRows) {
+		return claim, false, nil
+	}
+	if err != nil {
+		return claim, false, err
+	}
+	return claim, true, nil
+}
+
+// adoptMirroredRefreshToken is the blue-green compatibility path.
+//
+// This deployment starts the next slot, waits for /readyz, switches nginx and
+// only then drains the old slot, so both binaries serve traffic for ~35s. The
+// previous binary rotates by overwriting user_sessions.refresh_token_hash and
+// never writes user_session_tokens, so a token it minted during that window is
+// invisible to the new binary. Without this fallback those sessions would be
+// classified as unknown tokens and signed out — the exact failure this change
+// exists to remove.
+//
+// Adoption is deliberately not a replay: the token has no row in
+// user_session_tokens at all, so it cannot have been consumed under the new
+// rules. INSERT ... ON CONFLICT DO NOTHING is what distinguishes the two — if a
+// row already exists, the caller falls through to normal classification.
+//
+// Delete this together with the user_sessions.token_hash / refresh_token_hash
+// columns in the contract migration; keeping it after those columns are gone is
+// dead code, removing it before they are gone re-creates the sign-out window.
+func (s *Service) adoptMirroredRefreshToken(ctx context.Context, hash string) (bool, error) {
+	var sessionID string
+	var refreshExpiresAt time.Time
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, refresh_expires_at
+		  FROM user_sessions
+		 WHERE refresh_token_hash = ?
+		   AND revoked_at IS NULL
+		   AND refresh_expires_at IS NOT NULL
+		   AND refresh_expires_at > now()
+	`, hash).Scan(&sessionID, &refreshExpiresAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	res, err := s.db.ExecContext(ctx, `
+		INSERT INTO user_session_tokens (token_hash, session_id, kind, issued_at, expires_at, generation)
+		VALUES (?, ?, 'refresh', now(), ?, 0)
+		ON CONFLICT (token_hash) DO NOTHING
+	`, hash, sessionID, refreshExpiresAt)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, nil
+	}
+	log.Infof("identity: adopted mirrored refresh token for session %s issued by a previous release", sessionID)
+	return true, nil
+}
+
+// classifyRefreshFailure turns "the token could not be consumed" into the
+// specific reason. The order matters: every benign explanation is checked before
+// replay detection, because replay detection revokes the entire session family
+// and must never fire for a token that was merely expired or already revoked.
+func (s *Service) classifyRefreshFailure(ctx context.Context, hash string) error {
+	var (
+		sessionID  string
+		tenantID   string
+		expiresAt  time.Time
+		consumedAt sql.NullTime
+		graceUntil sql.NullTime
+		reuseCount int
+		revokedAt  sql.NullTime
+		absoluteAt sql.NullTime
+	)
+	err := s.db.QueryRowContext(ctx, `
+		SELECT t.session_id, s.tenant_id, t.expires_at, t.consumed_at, t.grace_until, t.reuse_count,
+		       s.revoked_at, s.refresh_absolute_expires_at
+		  FROM user_session_tokens t
+		  JOIN user_sessions s ON s.id = t.session_id
+		 WHERE t.token_hash = ? AND t.kind = 'refresh'
+	`, hash).Scan(&sessionID, &tenantID, &expiresAt, &consumedAt, &graceUntil, &reuseCount, &revokedAt, &absoluteAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		// No row anywhere: either a forged token or one issued before the last
+		// family revocation. Logged because a sustained rate of these is the
+		// signature of someone probing the endpoint.
+		log.Warnf("identity: refresh rejected, unknown token")
+		s.RecordAudit(ctx, AuditEvent{
+			ActorKind:    "system",
+			Action:       "auth.refresh_unknown_token",
+			ResourceType: "session",
+			Result:       "denied",
+		})
+		return ErrSessionRevoked
+	}
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if revokedAt.Valid {
+		return ErrSessionRevoked
+	}
+	if !expiresAt.After(now) {
+		return ErrSessionExpired
+	}
+	if absoluteAt.Valid && !absoluteAt.Time.After(now) {
+		if revokeErr := s.revokeSessionFamily(ctx, sessionID, "absolute_expiry"); revokeErr != nil {
+			return revokeErr
+		}
+		log.Infof("identity: session %s reached its absolute refresh deadline", sessionID)
+		s.RecordAudit(ctx, AuditEvent{
+			TenantID:       tenantID,
+			ActorKind:      "system",
+			ActorSessionID: sessionID,
+			Action:         "auth.refresh_absolute_expired",
+			ResourceType:   "session",
+			ResourceID:     sessionID,
+			Result:         "denied",
+		})
+		return ErrSessionExpired
+	}
+	// Everything benign has been ruled out: the token was consumed and is being
+	// presented again outside the grace window or past the reuse cap. Treat it as
+	// theft and revoke the family, which invalidates whichever copy the attacker
+	// holds and forces the legitimate user to re-authenticate.
+	if revokeErr := s.revokeSessionFamily(ctx, sessionID, "refresh_reuse_detected"); revokeErr != nil {
+		return revokeErr
+	}
+	log.Warnf("identity: refresh token reuse detected, revoked session %s (reuse_count=%d)", sessionID, reuseCount)
+	s.RecordAudit(ctx, AuditEvent{
+		TenantID:       tenantID,
+		ActorKind:      "system",
+		ActorSessionID: sessionID,
+		Action:         "auth.refresh_reuse_detected",
+		ResourceType:   "session",
+		ResourceID:     sessionID,
+		Result:         "denied",
+		Changes: map[string]any{
+			"reuse_count": reuseCount,
+			"grace_until": nullTimeString(graceUntil),
+		},
+	})
+	return ErrSessionRevoked
+}
+
+// rotateSession issues the successor token pair for a claimed refresh token.
+func (s *Service) rotateSession(ctx context.Context, consumedHash string, claim refreshClaim, policy SessionPolicy) (LoginResult, error) {
+	var result LoginResult
+	state, err := s.loadSessionRotationState(ctx, claim.sessionID)
+	if err != nil {
+		return result, err
+	}
+
+	accessTTL, _ := s.tenantSessionTTL(ctx, state.tenantID, state.rememberMe)
+	refreshTTL := s.resolveRefreshTTL(ctx, state.tenantID, state.rememberMe, state.refreshTTLSeconds)
+
+	accessPlain, accessHash, err := randomToken()
+	if err != nil {
+		return result, err
+	}
+	refreshPlain, refreshHash, err := randomPrefixedToken(adminRefreshTokenPrefix)
+	if err != nil {
+		return result, err
+	}
+	now := time.Now().UTC()
+	accessExp := now.Add(accessTTL)
+	newRefreshExp := now.Add(refreshTTL)
+	// The absolute deadline is a ceiling, never a target: without this min a
+	// stolen token could be kept alive forever by rotating it, and a grace-window
+	// replay would extend the family it was stolen from.
+	if state.absoluteExpiresAt.Valid && newRefreshExp.After(state.absoluteExpiresAt.Time) {
+		newRefreshExp = state.absoluteExpiresAt.Time
+	}
+	if !newRefreshExp.After(now) {
+		if revokeErr := s.revokeSessionFamily(ctx, claim.sessionID, "absolute_expiry"); revokeErr != nil {
+			return result, revokeErr
+		}
+		return result, ErrSessionExpired
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	// Serialise concurrent rotations of the same session before touching any token
+	// row. Without it two rotations interleave as: each inserts its own access
+	// token, then each tries to shorten the other's (the sibling UPDATE below
+	// matches every access row except its own), which is a lock cycle Postgres
+	// breaks by killing one transaction with a deadlock error. Several tabs
+	// refreshing at once is the normal case this change exists to support, so that
+	// error would be a routine sign-out. Claiming the session row first gives every
+	// rotation the same lock order; contention is per-session and lasts one
+	// statement batch.
+	var locked string
+	if err = tx.QueryRowContext(ctx,
+		`SELECT id FROM user_sessions WHERE id = ? FOR UPDATE`, claim.sessionID).Scan(&locked); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return result, ErrSessionRevoked
+		}
+		return result, err
+	}
+	if err = s.insertSessionTokens(ctx, tx, sessionTokenInsert{
+		SessionID:   claim.sessionID,
+		AccessHash:  accessHash,
+		AccessExp:   accessExp,
+		RefreshHash: refreshHash,
+		RefreshExp:  newRefreshExp,
+		Generation:  claim.generation + 1,
+		ParentHash:  consumedHash,
+	}); err != nil {
+		return result, err
+	}
+	// Shorten, do not delete, the sibling access tokens. Deleting them is what
+	// makes a request that was already in flight when the refresh landed come
+	// back 401 — the single most common shape of "I was working and got logged
+	// out". AccessGrace is sized to outlast the panel's request timeout.
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE user_session_tokens
+		   SET expires_at = LEAST(expires_at, now() + make_interval(secs => ?))
+		 WHERE session_id = ? AND kind = 'access' AND token_hash <> ?
+		   AND expires_at > now() + make_interval(secs => ?)
+	`, policy.AccessGrace.Seconds(), claim.sessionID, accessHash, policy.AccessGrace.Seconds()); err != nil {
+		return result, err
+	}
+	// Mirror the new head back onto user_sessions. The revoked_at guard closes the
+	// race where the session was revoked between the claim and this write.
+	res, err := tx.ExecContext(ctx, `
+		UPDATE user_sessions
+		   SET token_hash = ?, expires_at = ?, refresh_token_hash = ?, refresh_expires_at = ?, last_seen_at = now()
+		 WHERE id = ? AND revoked_at IS NULL
+	`, accessHash, accessExp, refreshHash, newRefreshExp, claim.sessionID)
+	if err != nil {
+		return result, err
+	}
+	if affected, affErr := res.RowsAffected(); affErr != nil {
+		return result, affErr
+	} else if affected == 0 {
+		return result, ErrSessionRevoked
+	}
+	if err = tx.Commit(); err != nil {
+		return result, err
+	}
+
+	if claim.reuseCount > 0 {
+		// The only signal this design produces for a stolen refresh token: a
+		// legitimate client hits the grace window at most once per rotation, so a
+		// sustained rate here means either an attacker replaying or a client bug.
+		log.Infof("identity: refresh served from grace window session=%s generation=%d reuse_count=%d",
+			claim.sessionID, claim.generation, claim.reuseCount)
+		s.RecordAudit(ctx, AuditEvent{
+			TenantID:       state.tenantID,
+			ActorKind:      "user_session",
+			ActorUserID:    state.userID,
+			ActorSessionID: claim.sessionID,
+			Action:         "auth.refresh_grace_used",
+			ResourceType:   "session",
+			ResourceID:     claim.sessionID,
+			Result:         "success",
+			Changes: map[string]any{
+				"session_id":  claim.sessionID,
+				"generation":  claim.generation,
+				"reuse_count": claim.reuseCount,
+				"grace_until": nullTimeString(claim.graceUntil),
+			},
+		})
+	}
+
+	principal, err := s.loadPrincipal(ctx, state.userID, claim.sessionID, accessExp, state.tenantID)
+	if err != nil {
+		return result, err
+	}
+	return LoginResult{
+		AccessToken: accessPlain, RefreshToken: refreshPlain, TokenType: "Bearer",
+		ExpiresAt: accessExp, RefreshExpiresAt: newRefreshExp, Principal: principal,
+	}, nil
+}
+
+func (s *Service) loadSessionRotationState(ctx context.Context, sessionID string) (sessionRotationState, error) {
+	var state sessionRotationState
+	var revokedAt sql.NullTime
+	err := s.db.QueryRowContext(ctx, `
+		SELECT user_id, tenant_id, remember_me, refresh_ttl_seconds, refresh_absolute_expires_at, revoked_at
+		  FROM user_sessions WHERE id = ?
+	`, sessionID).Scan(&state.userID, &state.tenantID, &state.rememberMe, &state.refreshTTLSeconds,
+		&state.absoluteExpiresAt, &revokedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return state, ErrSessionRevoked
+	}
+	if err != nil {
+		return state, err
+	}
+	if revokedAt.Valid {
+		return state, ErrSessionRevoked
+	}
+	return state, nil
+}
+
+// revokeSessionFamily kills a session and every token descended from it. The
+// DELETE is what makes reuse detection final: leaving the rows behind would let
+// the same stolen token produce a fresh reuse alert on every retry.
+func (s *Service) revokeSessionFamily(ctx context.Context, sessionID, reason string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		UPDATE user_sessions SET revoked_at = now(), revoke_reason = ? WHERE id = ? AND revoked_at IS NULL
+	`, reason, sessionID); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM user_session_tokens WHERE session_id = ?`, sessionID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func nullTimeString(value sql.NullTime) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.Time.UTC().Format(time.RFC3339)
+}

--- a/internal/identity/session_tokens.go
+++ b/internal/identity/session_tokens.go
@@ -1,0 +1,280 @@
+package identity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func randomToken() (string, string, error) {
+	return randomPrefixedToken("cps_")
+}
+
+func randomPrefixedToken(prefix string) (string, string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", "", err
+	}
+	token := prefix + base64.RawURLEncoding.EncodeToString(raw)
+	sum := sha256.Sum256([]byte(token))
+	return token, hex.EncodeToString(sum[:]), nil
+}
+
+func tokenHash(token string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(token)))
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *Service) tenantSessionTTL(ctx context.Context, tenantID string, remember bool) (access, refresh time.Duration) {
+	// Short access + long refresh. remember_me only keeps/extends refresh, never access.
+	access, refresh = 12*time.Hour, 30*24*time.Hour
+	if s == nil || s.db == nil {
+		return
+	}
+	var a, r sql.NullInt64
+	_ = s.db.QueryRowContext(ctx, `SELECT access_token_ttl_seconds, refresh_token_ttl_seconds FROM tenants WHERE id = ?`, tenantID).Scan(&a, &r)
+	if a.Valid && a.Int64 > 0 {
+		access = time.Duration(a.Int64) * time.Second
+	}
+	if r.Valid && r.Int64 > 0 {
+		refresh = time.Duration(r.Int64) * time.Second
+	}
+	if remember && refresh < 30*24*time.Hour {
+		refresh = 30 * 24 * time.Hour
+	}
+	return
+}
+
+// SessionPolicy tunes how far a rotated token stays usable. Every value is a
+// deliberate compromise between "a racing tab must not be logged out" and "a
+// stolen token must not live forever"; see the per-field defaults below.
+type SessionPolicy struct {
+	// RefreshGrace keeps a consumed refresh token usable so a retry or a tab that
+	// lost the rotation race can still complete. It must exceed the panel's total
+	// refresh budget (lock wait + retries = 23s) or a legitimate retry lands
+	// outside the window and is misread as a replay, revoking the whole session.
+	RefreshGrace time.Duration
+	// RefreshGraceMaxReuse bounds how many times one consumed refresh token may be
+	// replayed inside the grace window, which bounds the fork count of a session
+	// family to RefreshGraceMaxReuse+1.
+	RefreshGraceMaxReuse int
+	// AccessGrace is how long the previous access token stays valid after a
+	// rotation. It must exceed the panel's request timeout (30s) so a request
+	// already in flight when the refresh lands is not rejected.
+	AccessGrace time.Duration
+	// AbsoluteRefreshTTL is the hard ceiling on a session family measured from
+	// login. Rotation never extends past it, which is what bounds how long a
+	// stolen refresh token can be kept alive by rotating it.
+	AbsoluteRefreshTTL time.Duration
+}
+
+const (
+	defaultRefreshGrace         = 30 * time.Second
+	maxRefreshGrace             = 60 * time.Second
+	defaultRefreshGraceMaxReuse = 2
+	defaultAccessGrace          = 60 * time.Second
+	defaultAbsoluteRefreshTTL   = 60 * 24 * time.Hour
+	// defaultSessionReaperInterval is the GC cadence for expired token rows and
+	// sessions past their absolute deadline.
+	defaultSessionReaperInterval = 60 * time.Minute
+)
+
+// normalized fills zero fields with the shipped defaults and clamps the grace
+// window. The clamp is an upper bound only: a longer grace window widens the
+// period in which a stolen refresh token is indistinguishable from a retry.
+func (p SessionPolicy) normalized() SessionPolicy {
+	if p.RefreshGrace <= 0 {
+		p.RefreshGrace = defaultRefreshGrace
+	}
+	if p.RefreshGrace > maxRefreshGrace {
+		p.RefreshGrace = maxRefreshGrace
+	}
+	if p.RefreshGraceMaxReuse <= 0 {
+		p.RefreshGraceMaxReuse = defaultRefreshGraceMaxReuse
+	}
+	if p.AccessGrace <= 0 {
+		p.AccessGrace = defaultAccessGrace
+	}
+	if p.AbsoluteRefreshTTL <= 0 {
+		p.AbsoluteRefreshTTL = defaultAbsoluteRefreshTTL
+	}
+	return p
+}
+
+// SessionPolicyFromConfig reads remote-management.auth. Absent or non-positive
+// values fall back to the defaults rather than disabling the feature: a zero
+// grace window would restore the hard rotation this policy exists to remove.
+func SessionPolicyFromConfig(cfg *config.Config) SessionPolicy {
+	if cfg == nil {
+		return SessionPolicy{}.normalized()
+	}
+	auth := cfg.RemoteManagement.Auth
+	policy := SessionPolicy{
+		RefreshGraceMaxReuse: auth.RefreshGraceMaxReuse,
+	}
+	if auth.RefreshGraceSeconds > 0 {
+		policy.RefreshGrace = time.Duration(auth.RefreshGraceSeconds) * time.Second
+	}
+	if auth.AccessTokenGraceSeconds > 0 {
+		policy.AccessGrace = time.Duration(auth.AccessTokenGraceSeconds) * time.Second
+	}
+	if auth.AbsoluteRefreshTTLHours > 0 {
+		policy.AbsoluteRefreshTTL = time.Duration(auth.AbsoluteRefreshTTLHours) * time.Hour
+	}
+	return policy.normalized()
+}
+
+// SessionReaperIntervalFromConfig resolves the reaper cadence, defaulting when
+// the operator did not configure one.
+func SessionReaperIntervalFromConfig(cfg *config.Config) time.Duration {
+	if cfg == nil {
+		return defaultSessionReaperInterval
+	}
+	if minutes := cfg.RemoteManagement.Auth.SessionReaperIntervalMinutes; minutes > 0 {
+		return time.Duration(minutes) * time.Minute
+	}
+	return defaultSessionReaperInterval
+}
+
+// SetSessionPolicy installs a policy for subsequent logins and refreshes.
+// Stored behind an atomic pointer because config hot-reload runs concurrently
+// with in-flight refreshes, which must never observe a half-applied policy.
+func (s *Service) SetSessionPolicy(p SessionPolicy) {
+	if s == nil {
+		return
+	}
+	normalized := p.normalized()
+	s.policy.Store(&normalized)
+}
+
+func (s *Service) sessionPolicy() SessionPolicy {
+	if s == nil {
+		return SessionPolicy{}.normalized()
+	}
+	if p := s.policy.Load(); p != nil {
+		return *p
+	}
+	return SessionPolicy{}.normalized()
+}
+
+// sessionTokenInsert describes the access/refresh pair issued by one login or
+// one rotation. Both rows share a generation and a parent so a family can be
+// walked back to the token it descends from during an incident review.
+type sessionTokenInsert struct {
+	SessionID   string
+	AccessHash  string
+	AccessExp   time.Time
+	RefreshHash string
+	RefreshExp  time.Time
+	Generation  int64
+	ParentHash  string
+}
+
+func (s *Service) insertSessionTokens(ctx context.Context, tx *sql.Tx, in sessionTokenInsert) error {
+	var parent any
+	if strings.TrimSpace(in.ParentHash) != "" {
+		parent = in.ParentHash
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO user_session_tokens (token_hash, session_id, kind, issued_at, expires_at, generation, parent_hash)
+		VALUES (?, ?, 'access', now(), ?, ?, ?)
+	`, in.AccessHash, in.SessionID, in.AccessExp, in.Generation, parent); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO user_session_tokens (token_hash, session_id, kind, issued_at, expires_at, generation, parent_hash)
+		VALUES (?, ?, 'refresh', now(), ?, ?, ?)
+	`, in.RefreshHash, in.SessionID, in.RefreshExp, in.Generation, parent); err != nil {
+		return err
+	}
+	return nil
+}
+
+// accessSession is the session context resolved from an access token.
+type accessSession struct {
+	sessionID string
+	userID    string
+	tenantID  string
+	expiresAt time.Time
+	revokedAt sql.NullTime
+}
+
+// lookupAccessSession resolves an access token to its session. user_session_tokens
+// is the authentication source; the user_sessions mirror is only a fallback.
+func (s *Service) lookupAccessSession(ctx context.Context, hash string) (accessSession, error) {
+	var out accessSession
+	err := s.db.QueryRowContext(ctx, `
+		SELECT t.session_id, s.user_id, s.tenant_id, t.expires_at, s.revoked_at
+		  FROM user_session_tokens t
+		  JOIN user_sessions s ON s.id = t.session_id
+		 WHERE t.token_hash = ? AND t.kind = 'access'
+	`, hash).Scan(&out.sessionID, &out.userID, &out.tenantID, &out.expiresAt, &out.revokedAt)
+	if err == nil {
+		return out, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return out, err
+	}
+	return s.adoptMirroredAccessSession(ctx, hash)
+}
+
+// adoptMirroredAccessSession is the blue-green compatibility path.
+//
+// Deployment starts the next slot, waits for /readyz, switches nginx and only
+// then drains the old slot, so both binaries serve traffic for ~35s. The
+// previous binary rotates by overwriting user_sessions.token_hash and never
+// writes user_session_tokens, so an access token it minted during that window
+// exists only in the mirror. Rejecting it would sign out every user who
+// happened to refresh during the switch — the failure this change exists to
+// remove. The token is backfilled so the next request takes the fast path.
+//
+// Delete this together with the user_sessions.token_hash / refresh_token_hash
+// columns in the contract migration; keeping it after those columns are gone is
+// dead code, removing it before they are gone re-creates the sign-out window.
+func (s *Service) adoptMirroredAccessSession(ctx context.Context, hash string) (accessSession, error) {
+	var out accessSession
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, user_id, tenant_id, expires_at, revoked_at
+		  FROM user_sessions WHERE token_hash = ?
+	`, hash).Scan(&out.sessionID, &out.userID, &out.tenantID, &out.expiresAt, &out.revokedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return out, ErrSessionRevoked
+	}
+	if err != nil {
+		return out, err
+	}
+	if out.revokedAt.Valid || !out.expiresAt.After(time.Now()) {
+		// Do not backfill a dead token: the caller rejects it anyway, and the row
+		// would only be garbage for the reaper to collect.
+		return out, nil
+	}
+	if _, err = s.db.ExecContext(ctx, `
+		INSERT INTO user_session_tokens (token_hash, session_id, kind, issued_at, expires_at, generation)
+		VALUES (?, ?, 'access', now(), ?, 0)
+		ON CONFLICT (token_hash) DO NOTHING
+	`, hash, out.sessionID, out.expiresAt); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// resolveRefreshTTL reproduces the refresh lifetime the session was created
+// with. The stored value wins over the tenant configuration because a
+// "remember me" login is a property of that session, not of the tenant: reading
+// the tenant default at refresh time is what silently downgraded every 30-day
+// session to the tenant's (much shorter) TTL on its first rotation.
+func (s *Service) resolveRefreshTTL(ctx context.Context, tenantID string, remember bool, storedSeconds int) time.Duration {
+	if storedSeconds > 0 {
+		return time.Duration(storedSeconds) * time.Second
+	}
+	_, refresh := s.tenantSessionTTL(ctx, tenantID, remember)
+	return refresh
+}

--- a/internal/storage/postgres/auth_session_migrations.go
+++ b/internal/storage/postgres/auth_session_migrations.go
@@ -1,0 +1,114 @@
+package postgres
+
+// authSessionHardeningSQL adds windowed lockout state, remember-me provenance,
+// an absolute session deadline, and a per-token table that makes refresh
+// rotation survivable (grace window + reuse detection) instead of destroying
+// the previous token in place.
+//
+// Per-token rows are used instead of previous_* columns on user_sessions for
+// three reasons: (1) two concurrent grace replays would fight over a single
+// previous_* slot and the loser would be misclassified as a replay; (2) reuse
+// detection becomes a property of the token row itself, so sibling forks are
+// legal without cascading revocation; (3) token_hash as PRIMARY KEY keeps
+// lookups as single-column equality — an `OR` across two partial indexes on
+// user_sessions degrades to a sequential scan on an unauthenticated endpoint.
+const authSessionHardeningSQL = `
+-- 1) users: windowed lockout state -----------------------------------------
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_failed_login_at TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS lock_stage INTEGER NOT NULL DEFAULT 0;
+
+-- 2) end_users: windowed lockout state (portal side, same defect) -----------
+ALTER TABLE end_users ADD COLUMN IF NOT EXISTS last_failed_login_at TIMESTAMPTZ;
+
+-- 3) user_sessions: remember-me + TTL provenance + absolute family deadline --
+ALTER TABLE user_sessions ADD COLUMN IF NOT EXISTS remember_me BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE user_sessions ADD COLUMN IF NOT EXISTS refresh_ttl_seconds INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE user_sessions ADD COLUMN IF NOT EXISTS refresh_absolute_expires_at TIMESTAMPTZ;
+
+-- 4) per-token rows: one row per issued access/refresh token ----------------
+CREATE TABLE IF NOT EXISTS user_session_tokens (
+  token_hash   TEXT PRIMARY KEY,
+  session_id   UUID NOT NULL REFERENCES user_sessions(id) ON DELETE CASCADE,
+  kind         TEXT NOT NULL CHECK (kind IN ('access', 'refresh')),
+  issued_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at   TIMESTAMPTZ NOT NULL,
+  consumed_at  TIMESTAMPTZ,
+  grace_until  TIMESTAMPTZ,
+  reuse_count  INTEGER NOT NULL DEFAULT 0,
+  generation   BIGINT NOT NULL DEFAULT 0,
+  parent_hash  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_user_session_tokens_session
+  ON user_session_tokens(session_id, kind, expires_at DESC);
+CREATE INDEX IF NOT EXISTS idx_user_session_tokens_expiry
+  ON user_session_tokens(expires_at);
+
+-- 5) backfill remember-me / ttl / absolute deadline -------------------------
+-- Existing 30-day refresh windows were produced by remember_me at login;
+-- defaulting them to false would silently downgrade every live "remember me"
+-- session on its first refresh, which is the defect this migration fixes.
+UPDATE user_sessions
+   SET remember_me = true
+ WHERE remember_me = false
+   AND refresh_expires_at IS NOT NULL
+   AND refresh_expires_at - created_at >= interval '29 days';
+
+UPDATE user_sessions
+   SET refresh_ttl_seconds =
+       LEAST(2147483647, GREATEST(0, EXTRACT(EPOCH FROM (refresh_expires_at - created_at))::bigint))::int
+ WHERE refresh_ttl_seconds = 0
+   AND refresh_expires_at IS NOT NULL
+   AND refresh_expires_at > created_at;
+
+UPDATE user_sessions
+   SET refresh_absolute_expires_at = created_at + interval '60 days'
+ WHERE refresh_absolute_expires_at IS NULL;
+
+-- 6) mirror every live token into the new table -----------------------------
+-- Without this, the first request after deploy 401s for every signed-in user.
+INSERT INTO user_session_tokens (token_hash, session_id, kind, issued_at, expires_at, generation)
+SELECT s.token_hash, s.id, 'access', s.created_at, s.expires_at, 0
+  FROM user_sessions s
+ WHERE s.revoked_at IS NULL
+   AND s.token_hash IS NOT NULL AND s.token_hash <> ''
+ON CONFLICT (token_hash) DO NOTHING;
+
+INSERT INTO user_session_tokens (token_hash, session_id, kind, issued_at, expires_at, generation)
+SELECT s.refresh_token_hash, s.id, 'refresh', s.created_at, s.refresh_expires_at, 0
+  FROM user_sessions s
+ WHERE s.revoked_at IS NULL
+   AND s.refresh_token_hash IS NOT NULL AND s.refresh_token_hash <> ''
+   AND s.refresh_expires_at IS NOT NULL
+ON CONFLICT (token_hash) DO NOTHING;
+
+-- 7) repair lifetime-accumulated lockout state ------------------------------
+-- failed_login_count never decayed, so stored values are meaningless under the
+-- new sliding window. Auto-locks (locked_until IS NOT NULL) are released;
+-- administrative locks (locked_until IS NULL) are deliberately preserved.
+-- Postgres evaluates every SET expression against the pre-UPDATE row, so the
+-- CASE below still sees the original locked_until.
+UPDATE users
+   SET status = CASE WHEN status = 'locked' AND locked_until IS NOT NULL THEN 'active' ELSE status END,
+       failed_login_count = 0,
+       last_failed_login_at = NULL,
+       lock_stage = 0,
+       locked_until = NULL,
+       updated_at = now()
+ WHERE failed_login_count > 0
+    OR locked_until IS NOT NULL;
+
+-- 8) portal side: release the permanent lock produced by lockPenalty(20) ----
+-- lock_stage = 4 with locked_until IS NULL is only ever produced by the
+-- brute-force path, never by an administrator, so releasing it cannot
+-- resurrect a deliberately disabled account.
+UPDATE end_users
+   SET status = CASE WHEN status = 'locked' AND lock_stage > 0 THEN 'active' ELSE status END,
+       failed_login_count = 0,
+       last_failed_login_at = NULL,
+       lock_stage = 0,
+       locked_until = NULL,
+       updated_at = now()
+ WHERE failed_login_count > 0
+    OR locked_until IS NOT NULL
+    OR lock_stage > 0;
+`

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -38,6 +38,8 @@ func RuntimeMigrations() []Migration {
 		{Version: "202607220001_period_spending_limits", SQL: periodSpendingLimitsSQL},
 		{Version: "202607240001_ai_account_subject_usage_tokens", SQL: aiAccountSubjectUsageTokensSQL},
 		{Version: "202608030001_request_log_thinking_level", SQL: requestLogThinkingLevelSQL},
+		// Windowed lockout, remember-me persistence, and grace-window refresh rotation.
+		{Version: "202608060001_auth_session_hardening", SQL: authSessionHardeningSQL},
 	}
 }
 

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,12 +11,31 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 24 {
-		t.Fatalf("RuntimeMigrations len = %d, want 24", len(migrations))
+	if len(migrations) != 25 {
+		t.Fatalf("RuntimeMigrations len = %d, want 25", len(migrations))
 	}
-	// Latest: request-log thinking level metadata.
+	// Latest: windowed lockout state + per-token session rows for grace-window
+	// refresh rotation.
+	if migrations[24].Version != "202608060001_auth_session_hardening" {
+		t.Fatalf("latest migration version = %q", migrations[24].Version)
+	}
+	authSessionSQL := migrations[24].SQL
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS user_session_tokens",
+		"last_failed_login_at TIMESTAMPTZ",
+		"remember_me BOOLEAN NOT NULL DEFAULT false",
+		"refresh_absolute_expires_at TIMESTAMPTZ",
+		// Mirroring live tokens into the new table is what keeps signed-in users
+		// from being logged out by the deploy itself.
+		"INSERT INTO user_session_tokens",
+	} {
+		if !strings.Contains(authSessionSQL, fragment) {
+			t.Fatalf("auth session hardening migration missing %q", fragment)
+		}
+	}
+	// Prior: request-log thinking level metadata.
 	if migrations[23].Version != "202608030001_request_log_thinking_level" {
-		t.Fatalf("latest migration version = %q", migrations[23].Version)
+		t.Fatalf("thinking level migration version = %q", migrations[23].Version)
 	}
 	thinkingSQL := migrations[23].SQL
 	for _, fragment := range []string{"ALTER TABLE request_logs", "thinking_level TEXT NOT NULL DEFAULT ''"} {


### PR DESCRIPTION
## 背景

线上反馈两个串联故障：管理后台使用中突然被退出登录；退出后登录提示「登录尝试过于频繁，请稍后再试」（429 `login_rate_limited`），只能等 30 分钟或重启进程。定位后确认是一组共同根因，详见 [docs/plan/084](https://github.com/kittors/CliProxy/blob/main/docs/plan/084-auth-throttle-session-hardening-20260806.md)（根仓）。

## 根因与修复

### 登录限流
| 缺陷 | 修复 |
|---|---|
| 失败计数无时间维度，只有登录成功或连续 2 小时静默才清零，跨周的手误也会累积成封禁 | 分桶滑动窗口（短窗 + 长窗）+ 分级退避 + 静默重置 |
| **未携带管理密钥的请求也被计为一次猜测失败**，任何共享出口 IP 的东西（登出后残留轮询、爬虫、健康检查）都能封掉整个部署 | 按「是否与存储的秘密比对过」划线；缺凭据走独立配额，永不触发封禁 |
| 限流 key 取自 `ClientIP()` 而 `trusted-proxies` 默认为空，反代后全站共用一个桶 | IPv6 归一到 /64；来源不可信时降级为软限流；通配 `trusted-proxies` 条目启动时拒绝 |
| 封禁检查在 bcrypt 之后，已封禁的客户端仍能消耗 CPU | 前置为中间件第一件事 |
| 租户到期 / 账号禁用 / 基础设施错误也消耗猜测预算 | 仅 `ErrInvalidCredentials` 计数 |
| 整条路径零日志 | 补齐结构化日志与审计事件 |

### 账号锁定（管理端 + 门户，同源缺陷）
计数同样永不衰减，且门户侧 20 次失败即**永久锁定**、只能管理员解除——攻击者可构造的拒绝服务。两侧改为窗口化计数 + 分级冷却，删除永久锁分支。

### 会话轮换
| 缺陷 | 修复 |
|---|---|
| refresh token 硬轮换无宽限期，一次重试或第二个标签页就丢会话 | 新增 `user_session_tokens` 每 token 一行 + 30s 宽限窗口 + 重放检测（超窗/超复用撤销整族）|
| 旧 access token 在轮换瞬间失效，in-flight 请求直接 401 | 压缩到 60s 宽限期而非删除 |
| 轮换时 `remember=false` 写死，勾选「记住我」的 30 天会话首次刷新即降级 | remember-me 与 TTL 来源持久化到会话行 |

## 实施期间发现的额外缺陷

1. **并发刷新触发 Postgres 死锁**：两个并发轮换各自先插入自己的 access token，再去缩短对方的（`token_hash <> ?`），形成锁环，Postgres 以 SQLSTATE 40P01 杀掉其一——即多标签页场景本身。修复：动任何 token 行之前先 `SELECT ... FOR UPDATE` 锁 session 行。
2. **蓝绿窗口内会掉线**：本项目发布是蓝绿 + ~35s drain，新旧二进制同时在线。旧二进制轮换只写 `user_sessions` 镜像列，新二进制只查新表会把这些会话判为已撤销。`Authenticate` / `RefreshSession` 增加镜像回退 + 幂等补写；回退命中不走重放检测，contract 阶段随镜像列一并删除。

## 迁移与部署注意

- **迁移会镜像所有存活 token 进新表**，避免部署本身把在线用户踢下线。
- **会重置在旧语义下累积的失败计数与自动锁**；管理员手动锁定（`locked_until IS NULL`）保留。
- **迁移不可重跑**（dirty 手工恢复时注意第 7/8 段）。
- 本次是 expand 阶段：`user_sessions.token_hash` / `refresh_token_hash` 保留为镜像并继续写入，可回滚。
- **建议同时给线上配置 `trusted-proxies`**，否则「全站共用一个限流桶」只是被缓解、未根除。启动时会就此告警。
- 新增可选配置块 `remote-management.auth`（全部 zero-means-default，`config.example.yaml` 已附注释说明）。

## 验证

本地执行完整 `./scripts/ci-pr.sh`，退出码 0，其中包含针对真实 Postgres 的集成套件（`CLIRELAY_POSTGRES_TEST_DSN` 指向独立测试库，未使用共享库）。

新增 31 个用例，含：8 路并发轮换、宽限期放行与复用上限、超窗重放撤销整族、remember-me 保留、绝对死线、蓝绿镜像回退（access + refresh 两条）、失败计数窗口衰减、自动锁不翻 `status`、管理员锁不被正确密码自愈、reaper 清理。

点名重跑：`TestRegisterManagementRouteTable`（路由数 309 不变，portal 限流走中间件挂载而非新增路由）、`TestPublishedMigrationChecksums`（未改动任何已发布迁移）、`internal/config/yaml_atomic_test.go`。

结构棘轮只收紧：`internal/identity/service.go` 1144 → 932，`internal/enduser/service.go` 1189 → 1169，`migrations.go` 1120 → 1115。未放宽任何 allowlist。

## 后续

前端配套 PR（`codeProxy` 的 `fix/auth-session-resilience`）依赖本 PR **先合并并部署**：前端的刷新重试预算 23s 依赖后端 30s 宽限窗口。

已知遗留（另开 issue，不在本 PR 范围）：门户 refresh 仍是硬轮换（同构缺陷，需要门户侧自己的 token 表与迁移）；`cps_` 会话体系整体不受 `allow-remote` 管辖；`audit_logs` 无保留策略。

🤖 Generated with [Claude Code](https://claude.com/claude-code)