### PR TITLE
fix(ai-accounts): stop presenting unrefreshed quota as current

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -22,7 +22,7 @@
       },
       {
         "path": "internal/management/aiaccountstatus/service.go",
-        "max_lines": 1066
+        "max_lines": 1001
       },
       {
         "path": "internal/management/modelcatalog/availability.go",
@@ -42,7 +42,7 @@
       },
       {
         "path": "internal/storage/postgres/migrations.go",
-        "max_lines": 1115
+        "max_lines": 881
       },
       {
         "path": "internal/storage/sqlite/apikey/store.go",
@@ -54,7 +54,7 @@
       },
       {
         "path": "internal/usage/ai_account_subject_store.go",
-        "max_lines": 1075
+        "max_lines": 905
       },
       {
         "path": "internal/usage/openrouter_model_sync.go",

--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -12,6 +12,7 @@ import (
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -477,6 +478,13 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 		probe.SubscriptionSource = asserted.SubscriptionSource
 	}
 	if probeErr != nil {
+		// Probe outcomes were previously invisible in logs, so "the panel shows a
+		// week-old number" could not be traced to the upstream failure behind it.
+		log.WithFields(log.Fields{
+			"auth_subject_id": subjectID,
+			"provider":        auth.Provider,
+			"auth_index":      auth.Index,
+		}).WithError(probeErr).Warn("ai account status probe failed; stored quota is kept but not refreshed")
 		_ = usage.UpdateAIAccountSubjectProbeFailure(subjectID, auth.Provider, "probe_failed", probeErr.Error(), checked)
 		_ = usage.UpdateAIAccountRefreshFailure(
 			tenantID, subjectID, auth.Index, auth.Provider, string(auth.Status),
@@ -504,6 +512,16 @@ func (s *Service) refreshOne(jobID, tenantID string, auth *coreauth.Auth, subjec
 			r.UpdatedAt = checked
 		})
 		return
+	}
+	// A 200 that parses to zero windows means the upstream payload shape changed or
+	// the account genuinely has no quota. Either way the stored windows are carried
+	// forward unrefreshed, so surface it instead of silently serving aging values.
+	if len(probe.Quotas) == 0 {
+		log.WithFields(log.Fields{
+			"auth_subject_id": subjectID,
+			"provider":        auth.Provider,
+			"auth_index":      auth.Index,
+		}).Warn("ai account status probe returned no quota windows; stored quota is kept but not refreshed")
 	}
 	s.applyRuntimeQuotaProbe(ctx, auth, probe)
 
@@ -864,90 +882,6 @@ func (s *Service) ListStatus(tenantID string, authIndexes, authSubjectIDs []stri
 		items = append(items, statusViewFromSharedRecord(row, auth, summaries[sid], subject, bindingCounts[sid]))
 	}
 	return StatusListResponse{Items: items}, nil
-}
-
-func statusViewFromSharedRecord(row usage.AIAccountSubjectStatusRecord, auth *coreauth.Auth, summary usage.AuthSubjectUsageSummary, subject usage.AIAccountSubjectRecord, bindingCount int) AccountStatusView {
-	view := AccountStatusView{
-		AuthSubjectID: row.AuthSubjectID, Provider: row.Provider, StatusScope: usage.AIAccountStatusScopeShared,
-		SubjectScope: subject.SubjectScope, ShareEligible: subject.ShareEligible, SubjectSeedKind: subject.SeedKind,
-		CurrentTenantBindingCount: bindingCount, RefreshState: row.LastProbeState, HealthStatus: row.HealthStatus,
-		PlanType: row.PlanType, RestrictionSummary: row.RestrictionSummary, ErrorSummary: row.ErrorSummary,
-		ErrorCode: row.ErrorCode, Quotas: row.Quotas, ResetCreditCount: row.ResetCreditCount,
-		ResetCreditExpirations: row.ResetCreditExpirations, Usage: summary,
-		SubscriptionStartedAt: row.SubscriptionStartedAt, SubscriptionExpiresAt: row.SubscriptionExpiresAt,
-		SubscriptionSource: row.SubscriptionSource, UpstreamCheckedAt: row.UpstreamCheckedAt,
-		ExpiresAt: row.SubscriptionExpiresAt, Version: row.Version, UpdatedAt: timePointer(row.UpdatedAt),
-	}
-	if auth != nil {
-		view.AuthIndex = auth.Index
-		if view.Provider == "" {
-			view.Provider = auth.Provider
-		}
-		if view.HealthStatus == "" {
-			view.HealthStatus = string(auth.Status)
-		}
-	}
-	if view.Quotas == nil {
-		view.Quotas = []usage.QuotaWindowDTO{}
-	}
-	if view.Usage.AuthSubjectID == "" {
-		view.Usage.AuthSubjectID = row.AuthSubjectID
-	}
-	if !summary.UpdatedAt.IsZero() {
-		view.UsageUpdatedAt = timePointer(summary.UpdatedAt)
-	}
-	if view.Usage.WeeklyQuotaUsed == nil && auth != nil {
-		view.Usage.WeeklyQuotaUsed = weeklyUsedFromQuotas(row.Quotas, primaryWeeklyKeys(auth.Provider)...)
-	}
-	return view
-}
-
-func timePointer(value time.Time) *time.Time {
-	if value.IsZero() {
-		return nil
-	}
-	value = value.UTC()
-	return &value
-}
-
-func weeklyUsedFromQuotas(quotas []usage.QuotaWindowDTO, preferred ...string) *float64 {
-	pref := make(map[string]struct{}, len(preferred))
-	for _, k := range preferred {
-		pref[k] = struct{}{}
-	}
-	for i := range quotas {
-		q := &quotas[i]
-		if q.Percent == nil {
-			continue
-		}
-		if len(pref) > 0 {
-			if _, ok := pref[q.QuotaKey]; !ok {
-				continue
-			}
-		}
-		used := 100 - *q.Percent
-		if used < 0 {
-			used = 0
-		}
-		if used > 100 {
-			used = 100
-		}
-		return &used
-	}
-	return nil
-}
-
-func primaryWeeklyKeys(provider string) []string {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case "anthropic", "claude":
-		return []string{"seven_day"}
-	case "codex", "kimi":
-		return []string{"code_week"}
-	case "xai", "grok":
-		return []string{"weekly_limit"}
-	default:
-		return nil
-	}
 }
 
 func (s *Service) listAuths(tenantID string) []*coreauth.Auth {

--- a/internal/management/aiaccountstatus/status_view.go
+++ b/internal/management/aiaccountstatus/status_view.go
@@ -1,0 +1,94 @@
+package aiaccountstatus
+
+import (
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func statusViewFromSharedRecord(row usage.AIAccountSubjectStatusRecord, auth *coreauth.Auth, summary usage.AuthSubjectUsageSummary, subject usage.AIAccountSubjectRecord, bindingCount int) AccountStatusView {
+	view := AccountStatusView{
+		AuthSubjectID: row.AuthSubjectID, Provider: row.Provider, StatusScope: usage.AIAccountStatusScopeShared,
+		SubjectScope: subject.SubjectScope, ShareEligible: subject.ShareEligible, SubjectSeedKind: subject.SeedKind,
+		CurrentTenantBindingCount: bindingCount, RefreshState: row.LastProbeState, HealthStatus: row.HealthStatus,
+		PlanType: row.PlanType, RestrictionSummary: row.RestrictionSummary, ErrorSummary: row.ErrorSummary,
+		ErrorCode: row.ErrorCode, Quotas: row.Quotas, ResetCreditCount: row.ResetCreditCount,
+		ResetCreditExpirations: row.ResetCreditExpirations, Usage: summary,
+		SubscriptionStartedAt: row.SubscriptionStartedAt, SubscriptionExpiresAt: row.SubscriptionExpiresAt,
+		SubscriptionSource: row.SubscriptionSource, UpstreamCheckedAt: row.UpstreamCheckedAt,
+		QuotaObservedAt: row.QuotaObservedAt,
+		ExpiresAt:       row.SubscriptionExpiresAt, Version: row.Version, UpdatedAt: timePointer(row.UpdatedAt),
+	}
+	if auth != nil {
+		view.AuthIndex = auth.Index
+		if view.Provider == "" {
+			view.Provider = auth.Provider
+		}
+		if view.HealthStatus == "" {
+			view.HealthStatus = string(auth.Status)
+		}
+	}
+	if view.Quotas == nil {
+		view.Quotas = []usage.QuotaWindowDTO{}
+	}
+	if view.Usage.AuthSubjectID == "" {
+		view.Usage.AuthSubjectID = row.AuthSubjectID
+	}
+	if !summary.UpdatedAt.IsZero() {
+		view.UsageUpdatedAt = timePointer(summary.UpdatedAt)
+	}
+	if view.Usage.WeeklyQuotaUsed == nil && auth != nil {
+		view.Usage.WeeklyQuotaUsed = weeklyUsedFromQuotas(row.Quotas, primaryWeeklyKeys(auth.Provider)...)
+	}
+	return view
+}
+
+func timePointer(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
+}
+
+func weeklyUsedFromQuotas(quotas []usage.QuotaWindowDTO, preferred ...string) *float64 {
+	pref := make(map[string]struct{}, len(preferred))
+	for _, k := range preferred {
+		pref[k] = struct{}{}
+	}
+	for i := range quotas {
+		q := &quotas[i]
+		if q.Percent == nil {
+			continue
+		}
+		if len(pref) > 0 {
+			if _, ok := pref[q.QuotaKey]; !ok {
+				continue
+			}
+		}
+		used := 100 - *q.Percent
+		if used < 0 {
+			used = 0
+		}
+		if used > 100 {
+			used = 100
+		}
+		return &used
+	}
+	return nil
+}
+
+func primaryWeeklyKeys(provider string) []string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return []string{"seven_day"}
+	case "codex", "kimi":
+		return []string{"code_week"}
+	case "xai", "grok":
+		return []string{"weekly_limit"}
+	default:
+		return nil
+	}
+}

--- a/internal/management/aiaccountstatus/types.go
+++ b/internal/management/aiaccountstatus/types.go
@@ -77,10 +77,14 @@ type AccountStatusView struct {
 	SubscriptionExpiresAt     *time.Time                    `json:"subscription_expires_at,omitempty"`
 	SubscriptionSource        string                        `json:"subscription_source,omitempty"`
 	UpstreamCheckedAt         *time.Time                    `json:"upstream_checked_at,omitempty"`
-	UsageUpdatedAt            *time.Time                    `json:"usage_updated_at,omitempty"`
-	ExpiresAt                 *time.Time                    `json:"expires_at,omitempty"`
-	Version                   int64                         `json:"version"`
-	UpdatedAt                 *time.Time                    `json:"updated_at,omitempty"`
+	// QuotaObservedAt dates the quota payload itself. It lags UpstreamCheckedAt
+	// whenever probes are failing or returning partial window sets, which is what
+	// lets the panel mark quota values as stale instead of implying they are live.
+	QuotaObservedAt *time.Time `json:"quota_observed_at,omitempty"`
+	UsageUpdatedAt  *time.Time `json:"usage_updated_at,omitempty"`
+	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
+	Version         int64      `json:"version"`
+	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
 }
 
 type StatusListResponse struct {

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -40,8 +40,27 @@ func RuntimeMigrations() []Migration {
 		{Version: "202608030001_request_log_thinking_level", SQL: requestLogThinkingLevelSQL},
 		// Windowed lockout, remember-me persistence, and grace-window refresh rotation.
 		{Version: "202608060001_auth_session_hardening", SQL: authSessionHardeningSQL},
+		// Separate "when did we last try" from "when was this quota actually observed",
+		// so a failing probe can no longer make stale quota look freshly checked.
+		{Version: "202608070001_ai_account_quota_observed_at", SQL: aiAccountQuotaObservedAtSQL},
 	}
 }
+
+const aiAccountQuotaObservedAtSQL = `
+ALTER TABLE ai_account_subject_status
+ADD COLUMN IF NOT EXISTS quota_observed_at TIMESTAMPTZ;
+
+-- ai_account_subject_quota_points is only written after a successful probe, so its
+-- newest row dates the stored payload correctly even for accounts that have been
+-- failing for days (whose upstream_checked_at has moved far past the data it describes).
+UPDATE ai_account_subject_status s
+SET quota_observed_at = COALESCE(
+  (SELECT MAX(p.recorded_at) FROM ai_account_subject_quota_points p
+   WHERE p.auth_subject_id = s.auth_subject_id),
+  CASE WHEN s.last_probe_state = 'success' THEN s.upstream_checked_at END
+)
+WHERE s.quota_observed_at IS NULL AND s.quota_json <> '[]';
+`
 
 const aiAccountSubjectUsageTokensSQL = `
 ALTER TABLE ai_account_subject_usage_buckets
@@ -389,259 +408,6 @@ CREATE TABLE IF NOT EXISTS usage_projection_markers (
   marker_value TEXT NOT NULL DEFAULT '',
   updated_at   TIMESTAMPTZ NOT NULL
 );
-`
-
-const runtimeSchemaSQL = `
-CREATE TABLE IF NOT EXISTS request_logs (
-  id               BIGSERIAL PRIMARY KEY,
-  timestamp        TIMESTAMPTZ NOT NULL,
-  api_key          TEXT NOT NULL DEFAULT '',
-  api_key_id       TEXT NOT NULL DEFAULT '',
-  auth_subject_id  TEXT NOT NULL DEFAULT '',
-  api_key_name     TEXT NOT NULL DEFAULT '',
-  model            TEXT NOT NULL DEFAULT '',
-  upstream_model   TEXT NOT NULL DEFAULT '',
-  vision_fallback_model TEXT NOT NULL DEFAULT '',
-  source           TEXT NOT NULL DEFAULT '',
-  channel_name     TEXT NOT NULL DEFAULT '',
-  auth_index       TEXT NOT NULL DEFAULT '',
-  failed           INTEGER NOT NULL DEFAULT 0,
-  streaming        INTEGER NOT NULL DEFAULT 0,
-  latency_ms       BIGINT NOT NULL DEFAULT 0,
-  first_token_ms   BIGINT NOT NULL DEFAULT 0,
-  input_tokens     BIGINT NOT NULL DEFAULT 0,
-  output_tokens    BIGINT NOT NULL DEFAULT 0,
-  reasoning_tokens BIGINT NOT NULL DEFAULT 0,
-  cached_tokens    BIGINT NOT NULL DEFAULT 0,
-  total_tokens     BIGINT NOT NULL DEFAULT 0,
-  cost             DOUBLE PRECISION NOT NULL DEFAULT 0,
-  input_content    TEXT NOT NULL DEFAULT '',
-  output_content   TEXT NOT NULL DEFAULT ''
-);
-
-CREATE TABLE IF NOT EXISTS request_log_content (
-  log_id           BIGINT PRIMARY KEY REFERENCES request_logs(id) ON DELETE CASCADE,
-  timestamp        TIMESTAMPTZ NOT NULL,
-  compression      TEXT NOT NULL DEFAULT 'zstd',
-  input_content    BYTEA NOT NULL DEFAULT decode('', 'hex'),
-  output_content   BYTEA NOT NULL DEFAULT decode('', 'hex'),
-  detail_content   BYTEA NOT NULL DEFAULT decode('', 'hex'),
-  session_id       TEXT NOT NULL DEFAULT ''
-);
-
-CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON request_logs(timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_logs_api_key ON request_logs(api_key);
-CREATE INDEX IF NOT EXISTS idx_logs_api_key_timestamp ON request_logs(api_key, timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_logs_api_key_id ON request_logs(api_key_id);
-CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_timestamp ON request_logs(api_key_id, timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_logs_api_key_chart_cover ON request_logs(api_key, api_key_id, timestamp DESC, model, failed, input_tokens, output_tokens, total_tokens, cost, cached_tokens);
-CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_chart_cover ON request_logs(api_key_id, timestamp DESC, model, failed, input_tokens, output_tokens, total_tokens, cost, cached_tokens);
-CREATE INDEX IF NOT EXISTS idx_logs_model ON request_logs(model);
-CREATE INDEX IF NOT EXISTS idx_logs_failed ON request_logs(failed);
-CREATE INDEX IF NOT EXISTS idx_logs_auth_index ON request_logs(auth_index);
-CREATE INDEX IF NOT EXISTS idx_logs_auth_subject_id ON request_logs(auth_subject_id);
-CREATE INDEX IF NOT EXISTS idx_log_content_timestamp ON request_log_content(timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_log_content_detail_timestamp ON request_log_content(timestamp DESC) WHERE length(detail_content) > 0;
-CREATE INDEX IF NOT EXISTS idx_log_content_session_timestamp ON request_log_content(session_id, timestamp DESC) WHERE session_id <> '';
-
-CREATE TABLE IF NOT EXISTS auth_file_quota_snapshots (
-  date_key      TEXT NOT NULL,
-  auth_index    TEXT NOT NULL,
-  auth_subject_id TEXT NOT NULL DEFAULT '',
-  provider      TEXT NOT NULL DEFAULT '',
-  quota_key     TEXT NOT NULL,
-  percent       DOUBLE PRECISION,
-  recorded_at   TIMESTAMPTZ NOT NULL,
-  PRIMARY KEY (date_key, auth_index, quota_key)
-);
-CREATE INDEX IF NOT EXISTS idx_quota_snapshots_date ON auth_file_quota_snapshots(date_key);
-CREATE INDEX IF NOT EXISTS idx_quota_snapshots_auth ON auth_file_quota_snapshots(auth_index);
-CREATE INDEX IF NOT EXISTS idx_quota_snapshots_subject ON auth_file_quota_snapshots(auth_subject_id);
-
-CREATE TABLE IF NOT EXISTS auth_file_quota_snapshot_points (
-  id             BIGSERIAL PRIMARY KEY,
-  recorded_at    TIMESTAMPTZ NOT NULL,
-  auth_index     TEXT NOT NULL,
-  auth_subject_id TEXT NOT NULL DEFAULT '',
-  provider       TEXT NOT NULL DEFAULT '',
-  quota_key      TEXT NOT NULL,
-  quota_label    TEXT NOT NULL DEFAULT '',
-  percent        DOUBLE PRECISION,
-  reset_at       TIMESTAMPTZ,
-  window_seconds BIGINT NOT NULL DEFAULT 0
-);
-CREATE INDEX IF NOT EXISTS idx_quota_snapshot_points_auth_time ON auth_file_quota_snapshot_points(auth_index, recorded_at);
-CREATE INDEX IF NOT EXISTS idx_quota_snapshot_points_auth_key_time ON auth_file_quota_snapshot_points(auth_index, quota_key, recorded_at);
-CREATE INDEX IF NOT EXISTS idx_quota_snapshot_points_subject_time ON auth_file_quota_snapshot_points(auth_subject_id, recorded_at);
-
-CREATE TABLE IF NOT EXISTS auth_subject_quota_cycles (
-  subject_id       TEXT NOT NULL,
-  auth_index       TEXT NOT NULL DEFAULT '',
-  provider         TEXT NOT NULL DEFAULT '',
-  quota_key        TEXT NOT NULL,
-  cycle_start_at   TIMESTAMPTZ NOT NULL,
-  reset_at         TIMESTAMPTZ NOT NULL,
-  window_seconds   BIGINT NOT NULL DEFAULT 0,
-  last_verified_at TIMESTAMPTZ NOT NULL,
-  PRIMARY KEY (subject_id, quota_key)
-);
-CREATE INDEX IF NOT EXISTS idx_auth_subject_quota_cycles_subject_window
-  ON auth_subject_quota_cycles(subject_id, window_seconds, last_verified_at);
-
-CREATE TABLE IF NOT EXISTS model_pricing (
-  model_id                      TEXT PRIMARY KEY,
-  input_price_per_million        DOUBLE PRECISION NOT NULL DEFAULT 0,
-  output_price_per_million       DOUBLE PRECISION NOT NULL DEFAULT 0,
-  cached_price_per_million       DOUBLE PRECISION NOT NULL DEFAULT 0,
-  cache_read_price_per_million   DOUBLE PRECISION NOT NULL DEFAULT 0,
-  cache_write_price_per_million  DOUBLE PRECISION NOT NULL DEFAULT 0,
-  updated_at                    TIMESTAMPTZ NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
-  id                     TEXT PRIMARY KEY NOT NULL,
-  name                   TEXT NOT NULL DEFAULT '',
-  daily_limit            INTEGER NOT NULL DEFAULT 0,
-  total_quota            INTEGER NOT NULL DEFAULT 0,
-  concurrency_limit      INTEGER NOT NULL DEFAULT 0,
-  rpm_limit              INTEGER NOT NULL DEFAULT 0,
-  tpm_limit              INTEGER NOT NULL DEFAULT 0,
-  allowed_models         TEXT NOT NULL DEFAULT '[]',
-  allowed_channels       TEXT NOT NULL DEFAULT '[]',
-  allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
-  system_prompt          TEXT NOT NULL DEFAULT '',
-  created_at             TEXT NOT NULL DEFAULT '',
-  updated_at             TEXT NOT NULL DEFAULT ''
-);
-
-CREATE TABLE IF NOT EXISTS api_keys (
-  key               TEXT PRIMARY KEY NOT NULL,
-  id                TEXT NOT NULL DEFAULT '',
-  name              TEXT NOT NULL DEFAULT '',
-  disabled          INTEGER NOT NULL DEFAULT 0,
-  permission_profile_id TEXT NOT NULL DEFAULT '',
-  daily_limit       INTEGER NOT NULL DEFAULT 0,
-  total_quota       INTEGER NOT NULL DEFAULT 0,
-  spending_limit    DOUBLE PRECISION NOT NULL DEFAULT 0,
-  daily_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0,
-  concurrency_limit INTEGER NOT NULL DEFAULT 0,
-  rpm_limit         INTEGER NOT NULL DEFAULT 0,
-  tpm_limit         INTEGER NOT NULL DEFAULT 0,
-  allowed_models    TEXT NOT NULL DEFAULT '[]',
-  allowed_channels  TEXT NOT NULL DEFAULT '[]',
-  allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
-  system_prompt     TEXT NOT NULL DEFAULT '',
-  created_at        TEXT NOT NULL DEFAULT '',
-  updated_at        TEXT NOT NULL DEFAULT ''
-);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);
-
-CREATE TABLE IF NOT EXISTS model_configs (
-  model_id                      TEXT PRIMARY KEY,
-  owned_by                      TEXT NOT NULL DEFAULT '',
-  description                   TEXT NOT NULL DEFAULT '',
-  enabled                       INTEGER NOT NULL DEFAULT 1,
-  input_modalities              TEXT NOT NULL DEFAULT '',
-  output_modalities             TEXT NOT NULL DEFAULT '',
-  pricing_mode                  TEXT NOT NULL DEFAULT 'token',
-  input_price_per_million        DOUBLE PRECISION NOT NULL DEFAULT 0,
-  output_price_per_million       DOUBLE PRECISION NOT NULL DEFAULT 0,
-  cached_price_per_million       DOUBLE PRECISION NOT NULL DEFAULT 0,
-  cache_read_price_per_million   DOUBLE PRECISION NOT NULL DEFAULT 0,
-  cache_write_price_per_million  DOUBLE PRECISION NOT NULL DEFAULT 0,
-  price_per_call                 DOUBLE PRECISION NOT NULL DEFAULT 0,
-  source                        TEXT NOT NULL DEFAULT 'user',
-  updated_at                    TIMESTAMPTZ NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_model_configs_owned_by ON model_configs(owned_by);
-
-CREATE TABLE IF NOT EXISTS model_owner_presets (
-  value       TEXT PRIMARY KEY,
-  label       TEXT NOT NULL DEFAULT '',
-  description TEXT NOT NULL DEFAULT '',
-  enabled     INTEGER NOT NULL DEFAULT 1,
-  updated_at  TIMESTAMPTZ NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS auth_group_model_owner_mappings (
-  auth_group TEXT PRIMARY KEY,
-  owner      TEXT NOT NULL DEFAULT '',
-  updated_at TIMESTAMPTZ NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_auth_group_model_owner_mappings_owner
-  ON auth_group_model_owner_mappings(owner);
-
-CREATE TABLE IF NOT EXISTS model_openrouter_sync_state (
-  id               INTEGER PRIMARY KEY CHECK(id = 1),
-  enabled          INTEGER NOT NULL DEFAULT 0,
-  interval_minutes INTEGER NOT NULL DEFAULT 1440,
-  last_sync_at     TEXT NOT NULL DEFAULT '',
-  last_success_at  TEXT NOT NULL DEFAULT '',
-  last_error       TEXT NOT NULL DEFAULT '',
-  last_seen        INTEGER NOT NULL DEFAULT 0,
-  last_added       INTEGER NOT NULL DEFAULT 0,
-  last_updated     INTEGER NOT NULL DEFAULT 0,
-  last_skipped     INTEGER NOT NULL DEFAULT 0,
-  updated_at       TIMESTAMPTZ NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS proxy_pool (
-  id          TEXT PRIMARY KEY NOT NULL,
-  name        TEXT NOT NULL DEFAULT '',
-  url         TEXT NOT NULL,
-  enabled     INTEGER NOT NULL DEFAULT 1,
-  description TEXT NOT NULL DEFAULT '',
-  created_at  TEXT NOT NULL DEFAULT '',
-  updated_at  TEXT NOT NULL DEFAULT ''
-);
-
-CREATE TABLE IF NOT EXISTS routing_config (
-  id         INTEGER PRIMARY KEY NOT NULL CHECK (id = 1),
-  payload    TEXT NOT NULL DEFAULT '{}',
-  updated_at TEXT NOT NULL DEFAULT ''
-);
-
-CREATE TABLE IF NOT EXISTS runtime_settings (
-  setting_key TEXT PRIMARY KEY NOT NULL,
-  payload     TEXT NOT NULL DEFAULT '{}',
-  updated_at  TEXT NOT NULL DEFAULT ''
-);
-
-CREATE TABLE IF NOT EXISTS identity_fingerprints (
-  provider          TEXT NOT NULL,
-  account_key       TEXT NOT NULL,
-  auth_subject_id   TEXT NOT NULL DEFAULT '',
-  client_product    TEXT NOT NULL DEFAULT '',
-  client_variant    TEXT NOT NULL DEFAULT '',
-  version           TEXT NOT NULL DEFAULT '',
-  fields_json       TEXT NOT NULL DEFAULT '{}',
-  observed_headers_json TEXT NOT NULL DEFAULT '{}',
-  created_at        TEXT NOT NULL DEFAULT '',
-  updated_at        TEXT NOT NULL DEFAULT '',
-  last_seen_at      TEXT NOT NULL DEFAULT '',
-  PRIMARY KEY (provider, account_key)
-);
-CREATE INDEX IF NOT EXISTS idx_identity_fingerprints_provider_seen
-  ON identity_fingerprints(provider, last_seen_at DESC);
-
-CREATE TABLE IF NOT EXISTS ccswitch_import_configs (
-  id                     TEXT PRIMARY KEY NOT NULL,
-  client_type            TEXT NOT NULL,
-  provider_name          TEXT NOT NULL DEFAULT '',
-  note                   TEXT NOT NULL DEFAULT '',
-  default_model          TEXT NOT NULL DEFAULT '',
-  model_mappings         TEXT NOT NULL DEFAULT '[]',
-  allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
-  route_path             TEXT NOT NULL DEFAULT '',
-  endpoint_path          TEXT NOT NULL DEFAULT '',
-  usage_auto_interval    INTEGER NOT NULL DEFAULT 30,
-  api_key_field          TEXT NOT NULL DEFAULT '',
-  created_at             TEXT NOT NULL DEFAULT '',
-  updated_at             TEXT NOT NULL DEFAULT ''
-);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_ccswitch_import_configs_route_path
-  ON ccswitch_import_configs(route_path) WHERE route_path <> '';
 `
 
 const identityFingerprintProfilesSQL = `

--- a/internal/storage/postgres/migrations_runtime_schema.go
+++ b/internal/storage/postgres/migrations_runtime_schema.go
@@ -1,0 +1,254 @@
+package postgres
+
+const runtimeSchemaSQL = `
+CREATE TABLE IF NOT EXISTS request_logs (
+  id               BIGSERIAL PRIMARY KEY,
+  timestamp        TIMESTAMPTZ NOT NULL,
+  api_key          TEXT NOT NULL DEFAULT '',
+  api_key_id       TEXT NOT NULL DEFAULT '',
+  auth_subject_id  TEXT NOT NULL DEFAULT '',
+  api_key_name     TEXT NOT NULL DEFAULT '',
+  model            TEXT NOT NULL DEFAULT '',
+  upstream_model   TEXT NOT NULL DEFAULT '',
+  vision_fallback_model TEXT NOT NULL DEFAULT '',
+  source           TEXT NOT NULL DEFAULT '',
+  channel_name     TEXT NOT NULL DEFAULT '',
+  auth_index       TEXT NOT NULL DEFAULT '',
+  failed           INTEGER NOT NULL DEFAULT 0,
+  streaming        INTEGER NOT NULL DEFAULT 0,
+  latency_ms       BIGINT NOT NULL DEFAULT 0,
+  first_token_ms   BIGINT NOT NULL DEFAULT 0,
+  input_tokens     BIGINT NOT NULL DEFAULT 0,
+  output_tokens    BIGINT NOT NULL DEFAULT 0,
+  reasoning_tokens BIGINT NOT NULL DEFAULT 0,
+  cached_tokens    BIGINT NOT NULL DEFAULT 0,
+  total_tokens     BIGINT NOT NULL DEFAULT 0,
+  cost             DOUBLE PRECISION NOT NULL DEFAULT 0,
+  input_content    TEXT NOT NULL DEFAULT '',
+  output_content   TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS request_log_content (
+  log_id           BIGINT PRIMARY KEY REFERENCES request_logs(id) ON DELETE CASCADE,
+  timestamp        TIMESTAMPTZ NOT NULL,
+  compression      TEXT NOT NULL DEFAULT 'zstd',
+  input_content    BYTEA NOT NULL DEFAULT decode('', 'hex'),
+  output_content   BYTEA NOT NULL DEFAULT decode('', 'hex'),
+  detail_content   BYTEA NOT NULL DEFAULT decode('', 'hex'),
+  session_id       TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON request_logs(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key ON request_logs(api_key);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key_timestamp ON request_logs(api_key, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key_id ON request_logs(api_key_id);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_timestamp ON request_logs(api_key_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key_chart_cover ON request_logs(api_key, api_key_id, timestamp DESC, model, failed, input_tokens, output_tokens, total_tokens, cost, cached_tokens);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key_id_chart_cover ON request_logs(api_key_id, timestamp DESC, model, failed, input_tokens, output_tokens, total_tokens, cost, cached_tokens);
+CREATE INDEX IF NOT EXISTS idx_logs_model ON request_logs(model);
+CREATE INDEX IF NOT EXISTS idx_logs_failed ON request_logs(failed);
+CREATE INDEX IF NOT EXISTS idx_logs_auth_index ON request_logs(auth_index);
+CREATE INDEX IF NOT EXISTS idx_logs_auth_subject_id ON request_logs(auth_subject_id);
+CREATE INDEX IF NOT EXISTS idx_log_content_timestamp ON request_log_content(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_log_content_detail_timestamp ON request_log_content(timestamp DESC) WHERE length(detail_content) > 0;
+CREATE INDEX IF NOT EXISTS idx_log_content_session_timestamp ON request_log_content(session_id, timestamp DESC) WHERE session_id <> '';
+
+CREATE TABLE IF NOT EXISTS auth_file_quota_snapshots (
+  date_key      TEXT NOT NULL,
+  auth_index    TEXT NOT NULL,
+  auth_subject_id TEXT NOT NULL DEFAULT '',
+  provider      TEXT NOT NULL DEFAULT '',
+  quota_key     TEXT NOT NULL,
+  percent       DOUBLE PRECISION,
+  recorded_at   TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (date_key, auth_index, quota_key)
+);
+CREATE INDEX IF NOT EXISTS idx_quota_snapshots_date ON auth_file_quota_snapshots(date_key);
+CREATE INDEX IF NOT EXISTS idx_quota_snapshots_auth ON auth_file_quota_snapshots(auth_index);
+CREATE INDEX IF NOT EXISTS idx_quota_snapshots_subject ON auth_file_quota_snapshots(auth_subject_id);
+
+CREATE TABLE IF NOT EXISTS auth_file_quota_snapshot_points (
+  id             BIGSERIAL PRIMARY KEY,
+  recorded_at    TIMESTAMPTZ NOT NULL,
+  auth_index     TEXT NOT NULL,
+  auth_subject_id TEXT NOT NULL DEFAULT '',
+  provider       TEXT NOT NULL DEFAULT '',
+  quota_key      TEXT NOT NULL,
+  quota_label    TEXT NOT NULL DEFAULT '',
+  percent        DOUBLE PRECISION,
+  reset_at       TIMESTAMPTZ,
+  window_seconds BIGINT NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_quota_snapshot_points_auth_time ON auth_file_quota_snapshot_points(auth_index, recorded_at);
+CREATE INDEX IF NOT EXISTS idx_quota_snapshot_points_auth_key_time ON auth_file_quota_snapshot_points(auth_index, quota_key, recorded_at);
+CREATE INDEX IF NOT EXISTS idx_quota_snapshot_points_subject_time ON auth_file_quota_snapshot_points(auth_subject_id, recorded_at);
+
+CREATE TABLE IF NOT EXISTS auth_subject_quota_cycles (
+  subject_id       TEXT NOT NULL,
+  auth_index       TEXT NOT NULL DEFAULT '',
+  provider         TEXT NOT NULL DEFAULT '',
+  quota_key        TEXT NOT NULL,
+  cycle_start_at   TIMESTAMPTZ NOT NULL,
+  reset_at         TIMESTAMPTZ NOT NULL,
+  window_seconds   BIGINT NOT NULL DEFAULT 0,
+  last_verified_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (subject_id, quota_key)
+);
+CREATE INDEX IF NOT EXISTS idx_auth_subject_quota_cycles_subject_window
+  ON auth_subject_quota_cycles(subject_id, window_seconds, last_verified_at);
+
+CREATE TABLE IF NOT EXISTS model_pricing (
+  model_id                      TEXT PRIMARY KEY,
+  input_price_per_million        DOUBLE PRECISION NOT NULL DEFAULT 0,
+  output_price_per_million       DOUBLE PRECISION NOT NULL DEFAULT 0,
+  cached_price_per_million       DOUBLE PRECISION NOT NULL DEFAULT 0,
+  cache_read_price_per_million   DOUBLE PRECISION NOT NULL DEFAULT 0,
+  cache_write_price_per_million  DOUBLE PRECISION NOT NULL DEFAULT 0,
+  updated_at                    TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS api_key_permission_profiles (
+  id                     TEXT PRIMARY KEY NOT NULL,
+  name                   TEXT NOT NULL DEFAULT '',
+  daily_limit            INTEGER NOT NULL DEFAULT 0,
+  total_quota            INTEGER NOT NULL DEFAULT 0,
+  concurrency_limit      INTEGER NOT NULL DEFAULT 0,
+  rpm_limit              INTEGER NOT NULL DEFAULT 0,
+  tpm_limit              INTEGER NOT NULL DEFAULT 0,
+  allowed_models         TEXT NOT NULL DEFAULT '[]',
+  allowed_channels       TEXT NOT NULL DEFAULT '[]',
+  allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+  system_prompt          TEXT NOT NULL DEFAULT '',
+  created_at             TEXT NOT NULL DEFAULT '',
+  updated_at             TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  key               TEXT PRIMARY KEY NOT NULL,
+  id                TEXT NOT NULL DEFAULT '',
+  name              TEXT NOT NULL DEFAULT '',
+  disabled          INTEGER NOT NULL DEFAULT 0,
+  permission_profile_id TEXT NOT NULL DEFAULT '',
+  daily_limit       INTEGER NOT NULL DEFAULT 0,
+  total_quota       INTEGER NOT NULL DEFAULT 0,
+  spending_limit    DOUBLE PRECISION NOT NULL DEFAULT 0,
+  daily_spending_limit DOUBLE PRECISION NOT NULL DEFAULT 0,
+  concurrency_limit INTEGER NOT NULL DEFAULT 0,
+  rpm_limit         INTEGER NOT NULL DEFAULT 0,
+  tpm_limit         INTEGER NOT NULL DEFAULT 0,
+  allowed_models    TEXT NOT NULL DEFAULT '[]',
+  allowed_channels  TEXT NOT NULL DEFAULT '[]',
+  allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+  system_prompt     TEXT NOT NULL DEFAULT '',
+  created_at        TEXT NOT NULL DEFAULT '',
+  updated_at        TEXT NOT NULL DEFAULT ''
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);
+
+CREATE TABLE IF NOT EXISTS model_configs (
+  model_id                      TEXT PRIMARY KEY,
+  owned_by                      TEXT NOT NULL DEFAULT '',
+  description                   TEXT NOT NULL DEFAULT '',
+  enabled                       INTEGER NOT NULL DEFAULT 1,
+  input_modalities              TEXT NOT NULL DEFAULT '',
+  output_modalities             TEXT NOT NULL DEFAULT '',
+  pricing_mode                  TEXT NOT NULL DEFAULT 'token',
+  input_price_per_million        DOUBLE PRECISION NOT NULL DEFAULT 0,
+  output_price_per_million       DOUBLE PRECISION NOT NULL DEFAULT 0,
+  cached_price_per_million       DOUBLE PRECISION NOT NULL DEFAULT 0,
+  cache_read_price_per_million   DOUBLE PRECISION NOT NULL DEFAULT 0,
+  cache_write_price_per_million  DOUBLE PRECISION NOT NULL DEFAULT 0,
+  price_per_call                 DOUBLE PRECISION NOT NULL DEFAULT 0,
+  source                        TEXT NOT NULL DEFAULT 'user',
+  updated_at                    TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_model_configs_owned_by ON model_configs(owned_by);
+
+CREATE TABLE IF NOT EXISTS model_owner_presets (
+  value       TEXT PRIMARY KEY,
+  label       TEXT NOT NULL DEFAULT '',
+  description TEXT NOT NULL DEFAULT '',
+  enabled     INTEGER NOT NULL DEFAULT 1,
+  updated_at  TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS auth_group_model_owner_mappings (
+  auth_group TEXT PRIMARY KEY,
+  owner      TEXT NOT NULL DEFAULT '',
+  updated_at TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_group_model_owner_mappings_owner
+  ON auth_group_model_owner_mappings(owner);
+
+CREATE TABLE IF NOT EXISTS model_openrouter_sync_state (
+  id               INTEGER PRIMARY KEY CHECK(id = 1),
+  enabled          INTEGER NOT NULL DEFAULT 0,
+  interval_minutes INTEGER NOT NULL DEFAULT 1440,
+  last_sync_at     TEXT NOT NULL DEFAULT '',
+  last_success_at  TEXT NOT NULL DEFAULT '',
+  last_error       TEXT NOT NULL DEFAULT '',
+  last_seen        INTEGER NOT NULL DEFAULT 0,
+  last_added       INTEGER NOT NULL DEFAULT 0,
+  last_updated     INTEGER NOT NULL DEFAULT 0,
+  last_skipped     INTEGER NOT NULL DEFAULT 0,
+  updated_at       TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS proxy_pool (
+  id          TEXT PRIMARY KEY NOT NULL,
+  name        TEXT NOT NULL DEFAULT '',
+  url         TEXT NOT NULL,
+  enabled     INTEGER NOT NULL DEFAULT 1,
+  description TEXT NOT NULL DEFAULT '',
+  created_at  TEXT NOT NULL DEFAULT '',
+  updated_at  TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS routing_config (
+  id         INTEGER PRIMARY KEY NOT NULL CHECK (id = 1),
+  payload    TEXT NOT NULL DEFAULT '{}',
+  updated_at TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS runtime_settings (
+  setting_key TEXT PRIMARY KEY NOT NULL,
+  payload     TEXT NOT NULL DEFAULT '{}',
+  updated_at  TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS identity_fingerprints (
+  provider          TEXT NOT NULL,
+  account_key       TEXT NOT NULL,
+  auth_subject_id   TEXT NOT NULL DEFAULT '',
+  client_product    TEXT NOT NULL DEFAULT '',
+  client_variant    TEXT NOT NULL DEFAULT '',
+  version           TEXT NOT NULL DEFAULT '',
+  fields_json       TEXT NOT NULL DEFAULT '{}',
+  observed_headers_json TEXT NOT NULL DEFAULT '{}',
+  created_at        TEXT NOT NULL DEFAULT '',
+  updated_at        TEXT NOT NULL DEFAULT '',
+  last_seen_at      TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (provider, account_key)
+);
+CREATE INDEX IF NOT EXISTS idx_identity_fingerprints_provider_seen
+  ON identity_fingerprints(provider, last_seen_at DESC);
+
+CREATE TABLE IF NOT EXISTS ccswitch_import_configs (
+  id                     TEXT PRIMARY KEY NOT NULL,
+  client_type            TEXT NOT NULL,
+  provider_name          TEXT NOT NULL DEFAULT '',
+  note                   TEXT NOT NULL DEFAULT '',
+  default_model          TEXT NOT NULL DEFAULT '',
+  model_mappings         TEXT NOT NULL DEFAULT '[]',
+  allowed_channel_groups TEXT NOT NULL DEFAULT '[]',
+  route_path             TEXT NOT NULL DEFAULT '',
+  endpoint_path          TEXT NOT NULL DEFAULT '',
+  usage_auto_interval    INTEGER NOT NULL DEFAULT 30,
+  api_key_field          TEXT NOT NULL DEFAULT '',
+  created_at             TEXT NOT NULL DEFAULT '',
+  updated_at             TEXT NOT NULL DEFAULT ''
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ccswitch_import_configs_route_path
+  ON ccswitch_import_configs(route_path) WHERE route_path <> '';
+`

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,13 +11,24 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 25 {
-		t.Fatalf("RuntimeMigrations len = %d, want 25", len(migrations))
+	if len(migrations) != 26 {
+		t.Fatalf("RuntimeMigrations len = %d, want 26", len(migrations))
 	}
-	// Latest: windowed lockout state + per-token session rows for grace-window
-	// refresh rotation.
+	// Latest: quota observation time, so a failing probe stops making stale quota
+	// look freshly checked.
+	if migrations[25].Version != "202608070001_ai_account_quota_observed_at" {
+		t.Fatalf("latest migration version = %q", migrations[25].Version)
+	}
+	for _, fragment := range []string{
+		"ADD COLUMN IF NOT EXISTS quota_observed_at TIMESTAMPTZ",
+		"FROM ai_account_subject_quota_points p",
+	} {
+		if !strings.Contains(migrations[25].SQL, fragment) {
+			t.Fatalf("quota observed_at migration missing %q", fragment)
+		}
+	}
 	if migrations[24].Version != "202608060001_auth_session_hardening" {
-		t.Fatalf("latest migration version = %q", migrations[24].Version)
+		t.Fatalf("auth session migration version = %q", migrations[24].Version)
 	}
 	authSessionSQL := migrations[24].SQL
 	for _, fragment := range []string{

--- a/internal/usage/ai_account_status_store.go
+++ b/internal/usage/ai_account_status_store.go
@@ -19,6 +19,13 @@ type QuotaWindowDTO struct {
 	WindowSeconds int64      `json:"window_seconds,omitempty"`
 	Value         string     `json:"value,omitempty"`
 	Meta          string     `json:"meta,omitempty"`
+	// ObservedAt is when this specific window was last confirmed by the upstream.
+	// Upstreams routinely return only a subset of windows per probe (codex answers
+	// with just `rate_limit` or just `additional_rate_limits` in ~20% of probes), so
+	// windows carried forward by a merge keep their original timestamp instead of
+	// inheriting the probe time. Nil means "unknown" (pre-migration rows) and the
+	// row-level QuotaObservedAt is used as the fallback.
+	ObservedAt *time.Time `json:"observed_at,omitempty"`
 }
 
 // AIAccountStatusRecord is the persisted latest status for one tenant+auth_subject_id.

--- a/internal/usage/ai_account_subject_status_store.go
+++ b/internal/usage/ai_account_subject_status_store.go
@@ -1,0 +1,366 @@
+package usage
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// quotaWindowRetention bounds how long a window that the upstream stopped
+// reporting is carried forward. Upstreams answer with a partial window set on a
+// large minority of probes, so a window missing from one payload must not be
+// dropped; a window missing for a full day is genuinely gone (plan change,
+// product retired) and is removed on the next merge.
+const quotaWindowRetention = 24 * time.Hour
+
+// AIAccountSubjectStatusRecord is the shared, cross-tenant latest status for one
+// physical AI account.
+type AIAccountSubjectStatusRecord struct {
+	AuthSubjectID          string
+	Provider               string
+	LastProbeState         string
+	HealthStatus           string
+	PlanType               string
+	SubscriptionStartedAt  *time.Time
+	SubscriptionExpiresAt  *time.Time
+	SubscriptionSource     string
+	RestrictionSummary     string
+	ErrorCode              string
+	ErrorSummary           string
+	Quotas                 []QuotaWindowDTO
+	ResetCreditCount       *int64
+	ResetCreditExpirations []string
+	// UpstreamCheckedAt is the last probe *attempt* and moves even when the probe
+	// failed. QuotaObservedAt is the last time the quota payload itself was
+	// confirmed by the upstream. Keeping them apart is what lets the UI tell
+	// "checked a second ago, data from six days ago" from genuinely fresh data.
+	UpstreamCheckedAt *time.Time
+	QuotaObservedAt   *time.Time
+	Version           int64
+	UpdatedAt         time.Time
+}
+
+// mergeQuotaWindows folds a probe payload into the stored window set.
+//
+// The upstream is not required to report every window on every probe — codex
+// answers with only `rate_limit` or only `additional_rate_limits` in roughly a
+// fifth of probes. Replacing the whole set with the payload therefore made
+// windows disappear and reappear between refreshes. Each window instead keeps
+// its own ObservedAt: windows present in the payload are refreshed and stamped,
+// windows absent from it are carried forward untouched so their staleness stays
+// visible, and windows unconfirmed past quotaWindowRetention are dropped.
+//
+// Previous ordering is preserved so cards do not reshuffle when the upstream
+// varies the order it reports windows in.
+func mergeQuotaWindows(previous, incoming []QuotaWindowDTO, observedAt time.Time) []QuotaWindowDTO {
+	observedAt = observedAt.UTC()
+	incomingByKey := make(map[string]QuotaWindowDTO, len(incoming))
+	incomingOrder := make([]string, 0, len(incoming))
+	for _, window := range incoming {
+		key := strings.TrimSpace(window.QuotaKey)
+		if key == "" {
+			continue
+		}
+		window.QuotaKey = key
+		stamp := observedAt
+		window.ObservedAt = &stamp
+		if _, seen := incomingByKey[key]; !seen {
+			incomingOrder = append(incomingOrder, key)
+		}
+		incomingByKey[key] = window
+	}
+
+	merged := make([]QuotaWindowDTO, 0, len(previous)+len(incomingOrder))
+	consumed := make(map[string]struct{}, len(incomingByKey))
+	for _, window := range previous {
+		key := strings.TrimSpace(window.QuotaKey)
+		if key == "" {
+			continue
+		}
+		if fresh, ok := incomingByKey[key]; ok {
+			merged = append(merged, fresh)
+			consumed[key] = struct{}{}
+			continue
+		}
+		if _, duplicate := consumed[key]; duplicate {
+			continue
+		}
+		consumed[key] = struct{}{}
+		// Carried-forward window: keep the value and its original timestamp so the
+		// UI can show how old it is, unless it has gone unconfirmed for too long.
+		if window.ObservedAt == nil || observedAt.Sub(window.ObservedAt.UTC()) <= quotaWindowRetention {
+			merged = append(merged, window)
+		}
+	}
+	for _, key := range incomingOrder {
+		if _, ok := consumed[key]; ok {
+			continue
+		}
+		consumed[key] = struct{}{}
+		merged = append(merged, incomingByKey[key])
+	}
+	return merged
+}
+
+// applyQuotaObservedFallback fills per-window ObservedAt for rows written before
+// quota freshness tracking existed, so migrated data reports one coherent age
+// instead of "unknown".
+func applyQuotaObservedFallback(quotas []QuotaWindowDTO, rowObserved *time.Time) []QuotaWindowDTO {
+	if rowObserved == nil {
+		return quotas
+	}
+	for i := range quotas {
+		if quotas[i].ObservedAt == nil {
+			stamp := rowObserved.UTC()
+			quotas[i].ObservedAt = &stamp
+		}
+	}
+	return quotas
+}
+
+// latestQuotaObservedAt reports the newest per-window observation, used as the
+// row-level summary the API exposes.
+func latestQuotaObservedAt(quotas []QuotaWindowDTO, fallback *time.Time) *time.Time {
+	var newest *time.Time
+	for i := range quotas {
+		at := quotas[i].ObservedAt
+		if at == nil {
+			continue
+		}
+		if newest == nil || at.After(*newest) {
+			value := at.UTC()
+			newest = &value
+		}
+	}
+	if newest == nil {
+		return fallback
+	}
+	return newest
+}
+
+func loadSubjectQuotaState(db *sql.DB, subjectID string) ([]QuotaWindowDTO, *time.Time) {
+	if db == nil {
+		return nil, nil
+	}
+	var quotaJSON string
+	var observed sql.NullString
+	err := db.QueryRow(`
+		SELECT quota_json, quota_observed_at FROM ai_account_subject_status WHERE auth_subject_id = ?
+	`, subjectID).Scan(&quotaJSON, &observed)
+	if err != nil {
+		return nil, nil
+	}
+	rowObserved := parseNullableTime(observed)
+	return applyQuotaObservedFallback(decodeQuotaWindows(quotaJSON), rowObserved), rowObserved
+}
+
+// UpsertAIAccountSubjectStatus persists a successful probe result.
+//
+// Quota windows are merged rather than replaced (see mergeQuotaWindows). The
+// read-modify-write is safe because status refresh is serialized per subject by
+// the singleflight group in the aiaccountstatus service — one physical account
+// is never probed concurrently, even across tenants.
+func UpsertAIAccountSubjectStatus(record AIAccountSubjectStatusRecord) error {
+	db := getDB()
+	if db == nil || strings.TrimSpace(record.AuthSubjectID) == "" {
+		return nil
+	}
+	if record.LastProbeState == "" {
+		record.LastProbeState = "idle"
+	}
+	if record.UpdatedAt.IsZero() {
+		record.UpdatedAt = time.Now().UTC()
+	}
+	if record.Version < 1 {
+		record.Version = 1
+	}
+
+	observedAt := record.UpdatedAt.UTC()
+	if record.UpstreamCheckedAt != nil && !record.UpstreamCheckedAt.IsZero() {
+		observedAt = record.UpstreamCheckedAt.UTC()
+	}
+	previous, previousObserved := loadSubjectQuotaState(db, record.AuthSubjectID)
+	merged := mergeQuotaWindows(previous, record.Quotas, observedAt)
+	// An empty payload confirms nothing: carried-forward windows keep their old
+	// timestamps and the row-level marker stays put, so the UI reports the data as
+	// aging instead of silently presenting it as just-refreshed.
+	quotaObserved := previousObserved
+	if len(record.Quotas) > 0 {
+		quotaObserved = &observedAt
+	}
+	record.Quotas = merged
+	record.QuotaObservedAt = quotaObserved
+
+	quotaJSON, err := json.Marshal(merged)
+	if err != nil {
+		return err
+	}
+	expJSON, err := json.Marshal(record.ResetCreditExpirations)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(`
+		INSERT INTO ai_account_subject_status (
+			auth_subject_id, provider, last_probe_state, health_status, plan_type,
+			subscription_started_at, subscription_expires_at, subscription_source,
+			restriction_summary, error_code, error_summary, quota_json,
+			reset_credit_count, reset_credit_expirations, upstream_checked_at,
+			quota_observed_at, version, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(auth_subject_id) DO UPDATE SET
+			provider = excluded.provider,
+			last_probe_state = excluded.last_probe_state,
+			health_status = excluded.health_status,
+			plan_type = excluded.plan_type,
+			subscription_started_at = CASE WHEN excluded.subscription_source <> ''
+				THEN excluded.subscription_started_at ELSE ai_account_subject_status.subscription_started_at END,
+			subscription_expires_at = CASE WHEN excluded.subscription_source <> ''
+				THEN excluded.subscription_expires_at ELSE ai_account_subject_status.subscription_expires_at END,
+			subscription_source = CASE WHEN excluded.subscription_source <> ''
+				THEN excluded.subscription_source ELSE ai_account_subject_status.subscription_source END,
+			restriction_summary = excluded.restriction_summary,
+			error_code = excluded.error_code,
+			error_summary = excluded.error_summary,
+			quota_json = excluded.quota_json,
+			reset_credit_count = excluded.reset_credit_count,
+			reset_credit_expirations = excluded.reset_credit_expirations,
+			upstream_checked_at = excluded.upstream_checked_at,
+			quota_observed_at = excluded.quota_observed_at,
+			version = CASE WHEN excluded.version > ai_account_subject_status.version
+				THEN excluded.version ELSE ai_account_subject_status.version + 1 END,
+			updated_at = excluded.updated_at
+	`, record.AuthSubjectID, record.Provider, record.LastProbeState, record.HealthStatus, record.PlanType,
+		nullableTimeValue(record.SubscriptionStartedAt), nullableTimeValue(record.SubscriptionExpiresAt), record.SubscriptionSource,
+		record.RestrictionSummary, record.ErrorCode, record.ErrorSummary, string(quotaJSON), record.ResetCreditCount,
+		string(expJSON), nullableTimeValue(record.UpstreamCheckedAt), nullableTimeValue(record.QuotaObservedAt),
+		record.Version, record.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("usage: upsert shared ai account status: %w", err)
+	}
+	return nil
+}
+
+// UpdateAIAccountSubjectProbeFailure records a failed probe.
+//
+// quota_json and quota_observed_at are deliberately left untouched: the last
+// known quota is still the best answer available, but it must not be presented
+// as fresh. upstream_checked_at moves (the attempt did happen) while
+// quota_observed_at stays behind, which is exactly the gap the UI surfaces.
+func UpdateAIAccountSubjectProbeFailure(subjectID, provider, errorCode, errorSummary string, checked time.Time) error {
+	db := getDB()
+	if db == nil || strings.TrimSpace(subjectID) == "" {
+		return nil
+	}
+	if checked.IsZero() {
+		checked = time.Now().UTC()
+	}
+	_, err := db.Exec(`
+		INSERT INTO ai_account_subject_status (
+			auth_subject_id, provider, last_probe_state, error_code, error_summary,
+			upstream_checked_at, version, updated_at
+		) VALUES (?, ?, 'error', ?, ?, ?, 1, ?)
+		ON CONFLICT(auth_subject_id) DO UPDATE SET
+			provider = excluded.provider,
+			last_probe_state = 'error',
+			error_code = excluded.error_code,
+			error_summary = excluded.error_summary,
+			upstream_checked_at = excluded.upstream_checked_at,
+			version = ai_account_subject_status.version + 1,
+			updated_at = excluded.updated_at
+	`, subjectID, provider, strings.TrimSpace(errorCode), sanitizeSharedStatusError(errorSummary),
+		checked.UTC().Format(time.RFC3339Nano), checked.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("usage: update shared ai account failure: %w", err)
+	}
+	return nil
+}
+
+func sanitizeSharedStatusError(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case strings.Contains(value, "timeout"), strings.Contains(value, "deadline"):
+		return "upstream status probe timed out"
+	case strings.Contains(value, "unauthorized"), strings.Contains(value, "http 401"):
+		return "upstream authorization failed"
+	case strings.Contains(value, "forbidden"), strings.Contains(value, "http 403"):
+		return "upstream access was denied"
+	default:
+		return "upstream status probe failed"
+	}
+}
+
+func ListAIAccountSubjectStatus(subjectIDs []string) ([]AIAccountSubjectStatusRecord, error) {
+	db := getReadDB()
+	ids := dedupeExactStrings(subjectIDs)
+	if db == nil || len(ids) == 0 {
+		return []AIAccountSubjectStatusRecord{}, nil
+	}
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(`
+		SELECT auth_subject_id, provider, last_probe_state, health_status, plan_type,
+			subscription_started_at, subscription_expires_at, subscription_source,
+			restriction_summary, error_code, error_summary, quota_json,
+			reset_credit_count, reset_credit_expirations, upstream_checked_at,
+			quota_observed_at, version, updated_at
+		FROM ai_account_subject_status
+		WHERE auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")+`)
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: list shared ai account status: %w", err)
+	}
+	defer rows.Close()
+	out := make([]AIAccountSubjectStatusRecord, 0, len(ids))
+	for rows.Next() {
+		var row AIAccountSubjectStatusRecord
+		var started, expires, checked, observed, updated sql.NullString
+		var reset sql.NullInt64
+		var quotaJSON, expJSON string
+		if err := rows.Scan(&row.AuthSubjectID, &row.Provider, &row.LastProbeState, &row.HealthStatus, &row.PlanType,
+			&started, &expires, &row.SubscriptionSource, &row.RestrictionSummary, &row.ErrorCode, &row.ErrorSummary,
+			&quotaJSON, &reset, &expJSON, &checked, &observed, &row.Version, &updated); err != nil {
+			return nil, err
+		}
+		row.SubscriptionStartedAt = parseNullableTime(started)
+		row.SubscriptionExpiresAt = parseNullableTime(expires)
+		row.UpstreamCheckedAt = parseNullableTime(checked)
+		rowObserved := parseNullableTime(observed)
+		row.Quotas = applyQuotaObservedFallback(decodeQuotaWindows(quotaJSON), rowObserved)
+		row.QuotaObservedAt = latestQuotaObservedAt(row.Quotas, rowObserved)
+		row.ResetCreditExpirations = decodeStringSlice(expJSON)
+		if reset.Valid {
+			v := reset.Int64
+			row.ResetCreditCount = &v
+		}
+		if t, ok := parseStoredTimeString(updated.String); ok {
+			row.UpdatedAt = t
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// backfillSQLiteQuotaObservedAt dates existing quota payloads on SQLite.
+//
+// ai_account_subject_quota_points is only written after a successful probe, so
+// its newest row is the true last-observation time — including for accounts that
+// have been failing for days and whose upstream_checked_at has long since moved
+// past the data it describes.
+func backfillSQLiteQuotaObservedAt(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	_, _ = db.Exec(`
+		UPDATE ai_account_subject_status
+		SET quota_observed_at = COALESCE(
+			(SELECT MAX(p.recorded_at) FROM ai_account_subject_quota_points p
+			 WHERE p.auth_subject_id = ai_account_subject_status.auth_subject_id),
+			CASE WHEN last_probe_state = 'success' THEN upstream_checked_at END
+		)
+		WHERE quota_observed_at IS NULL AND quota_json <> '[]'
+	`)
+}

--- a/internal/usage/ai_account_subject_status_store_test.go
+++ b/internal/usage/ai_account_subject_status_store_test.go
@@ -1,0 +1,176 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func quotaWindow(key string, percent float64, observed *time.Time) QuotaWindowDTO {
+	p := percent
+	return QuotaWindowDTO{QuotaKey: key, Percent: &p, ObservedAt: observed}
+}
+
+func findWindow(windows []QuotaWindowDTO, key string) *QuotaWindowDTO {
+	for i := range windows {
+		if windows[i].QuotaKey == key {
+			return &windows[i]
+		}
+	}
+	return nil
+}
+
+// Codex answers with only `rate_limit` or only `additional_rate_limits` on a
+// large minority of probes. Replacing the set wholesale made the other window
+// vanish from the card until the next probe happened to include it again.
+func TestMergeQuotaWindowsKeepsWindowsMissingFromPartialPayload(t *testing.T) {
+	first := time.Date(2026, 8, 7, 8, 0, 0, 0, time.UTC)
+	second := first.Add(30 * time.Minute)
+
+	stored := mergeQuotaWindows(nil, []QuotaWindowDTO{
+		quotaWindow("code_week", 15, nil),
+		quotaWindow("additional:codex_bengalfox:week", 96, nil),
+	}, first)
+	if len(stored) != 2 {
+		t.Fatalf("expected both windows stored, got %d", len(stored))
+	}
+
+	// Second probe reports only the primary window.
+	merged := mergeQuotaWindows(stored, []QuotaWindowDTO{quotaWindow("code_week", 14, nil)}, second)
+	if len(merged) != 2 {
+		t.Fatalf("partial payload dropped a window: got %d windows", len(merged))
+	}
+
+	refreshed := findWindow(merged, "code_week")
+	if refreshed == nil || *refreshed.Percent != 14 {
+		t.Fatalf("confirmed window not refreshed: %+v", refreshed)
+	}
+	if refreshed.ObservedAt == nil || !refreshed.ObservedAt.Equal(second) {
+		t.Fatalf("confirmed window should be stamped with the new probe time, got %v", refreshed.ObservedAt)
+	}
+
+	carried := findWindow(merged, "additional:codex_bengalfox:week")
+	if carried == nil || *carried.Percent != 96 {
+		t.Fatalf("carried window lost its value: %+v", carried)
+	}
+	// The whole point: a carried window must not inherit the new probe time, or the
+	// UI cannot tell it apart from a value the upstream actually just confirmed.
+	if carried.ObservedAt == nil || !carried.ObservedAt.Equal(first) {
+		t.Fatalf("carried window must keep its original observation time, got %v", carried.ObservedAt)
+	}
+}
+
+func TestMergeQuotaWindowsDropsWindowsUnconfirmedPastRetention(t *testing.T) {
+	old := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	now := old.Add(quotaWindowRetention + time.Hour)
+
+	stored := []QuotaWindowDTO{quotaWindow("retired_window", 50, &old)}
+	merged := mergeQuotaWindows(stored, []QuotaWindowDTO{quotaWindow("code_week", 20, nil)}, now)
+
+	if findWindow(merged, "retired_window") != nil {
+		t.Fatal("window unconfirmed past retention should be dropped")
+	}
+	if findWindow(merged, "code_week") == nil {
+		t.Fatal("confirmed window missing")
+	}
+}
+
+// An empty payload confirms nothing. Windows stay (they are still the best known
+// answer) but must keep aging so the UI can mark them stale.
+func TestMergeQuotaWindowsEmptyPayloadDoesNotRefreshTimestamps(t *testing.T) {
+	first := time.Date(2026, 8, 7, 8, 0, 0, 0, time.UTC)
+	stored := mergeQuotaWindows(nil, []QuotaWindowDTO{quotaWindow("code_week", 15, nil)}, first)
+
+	merged := mergeQuotaWindows(stored, nil, first.Add(time.Hour))
+	window := findWindow(merged, "code_week")
+	if window == nil {
+		t.Fatal("empty payload should not clear the last known window")
+	}
+	if window.ObservedAt == nil || !window.ObservedAt.Equal(first) {
+		t.Fatalf("empty payload must not restamp the window, got %v", window.ObservedAt)
+	}
+}
+
+func TestMergeQuotaWindowsPreservesPreviousOrdering(t *testing.T) {
+	at := time.Date(2026, 8, 7, 8, 0, 0, 0, time.UTC)
+	stored := mergeQuotaWindows(nil, []QuotaWindowDTO{
+		quotaWindow("code_5h", 40, nil),
+		quotaWindow("code_week", 15, nil),
+	}, at)
+
+	// Upstream reports the same windows in the opposite order, plus a new one.
+	merged := mergeQuotaWindows(stored, []QuotaWindowDTO{
+		quotaWindow("code_week", 14, nil),
+		quotaWindow("code_5h", 39, nil),
+		quotaWindow("review_week", 88, nil),
+	}, at.Add(time.Minute))
+
+	got := []string{merged[0].QuotaKey, merged[1].QuotaKey, merged[2].QuotaKey}
+	want := []string{"code_5h", "code_week", "review_week"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("card ordering churned: got %v want %v", got, want)
+		}
+	}
+}
+
+// A failing probe must move upstream_checked_at (the attempt happened) while
+// leaving quota_observed_at behind, so "checked seconds ago, data from days ago"
+// is representable instead of collapsing into one misleading timestamp.
+func TestProbeFailureKeepsQuotaObservationTimeBehind(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		CloseDB()
+		_ = os.Remove(dbPath)
+	})
+	if err := UpsertAIAccountSubject(&AuthSubjectIdentity{
+		ID: "sub-fresh", Provider: "codex", SubjectScope: AIAccountSubjectScopeShared,
+		SeedKind: "test", SeedHash: "hash-fresh",
+	}); err != nil {
+		t.Fatalf("upsert subject: %v", err)
+	}
+
+	observed := time.Now().UTC().Add(-6 * time.Hour)
+	if err := UpsertAIAccountSubjectStatus(AIAccountSubjectStatusRecord{
+		AuthSubjectID: "sub-fresh", Provider: "codex", LastProbeState: "success", HealthStatus: "ok",
+		Quotas:            []QuotaWindowDTO{quotaWindow("code_week", 15, nil)},
+		UpstreamCheckedAt: &observed, UpdatedAt: observed,
+	}); err != nil {
+		t.Fatalf("seed status: %v", err)
+	}
+
+	failedAt := time.Now().UTC()
+	if err := UpdateAIAccountSubjectProbeFailure("sub-fresh", "codex", "probe_failed", "http 401 unauthorized", failedAt); err != nil {
+		t.Fatalf("probe failure: %v", err)
+	}
+
+	rows, err := ListAIAccountSubjectStatus([]string{"sub-fresh"})
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("list status: %v rows=%d", err, len(rows))
+	}
+	row := rows[0]
+	if row.LastProbeState != "error" {
+		t.Fatalf("expected error state, got %q", row.LastProbeState)
+	}
+	if len(row.Quotas) != 1 {
+		t.Fatalf("failed probe must keep the last known quota, got %d windows", len(row.Quotas))
+	}
+	if row.UpstreamCheckedAt == nil || row.UpstreamCheckedAt.Before(failedAt.Add(-time.Second)) {
+		t.Fatalf("attempt time should advance to the failure, got %v", row.UpstreamCheckedAt)
+	}
+	if row.QuotaObservedAt == nil {
+		t.Fatal("quota observation time missing")
+	}
+	if row.QuotaObservedAt.After(observed.Add(time.Second)) {
+		t.Fatalf("failed probe must not restamp quota observation: observed=%v got=%v", observed, row.QuotaObservedAt)
+	}
+	if !row.UpstreamCheckedAt.After(*row.QuotaObservedAt) {
+		t.Fatal("attempt time must be strictly newer than the quota it describes")
+	}
+}

--- a/internal/usage/ai_account_subject_store.go
+++ b/internal/usage/ai_account_subject_store.go
@@ -2,7 +2,6 @@ package usage
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -79,6 +78,7 @@ CREATE TABLE IF NOT EXISTS ai_account_subject_status (
   reset_credit_count INTEGER,
   reset_credit_expirations TEXT NOT NULL DEFAULT '[]',
   upstream_checked_at DATETIME,
+  quota_observed_at DATETIME,
   version INTEGER NOT NULL DEFAULT 1,
   updated_at DATETIME NOT NULL,
   FOREIGN KEY (auth_subject_id) REFERENCES ai_account_subjects(auth_subject_id)
@@ -156,26 +156,6 @@ type AIAccountTenantBinding struct {
 	DeletedAt       *time.Time
 }
 
-type AIAccountSubjectStatusRecord struct {
-	AuthSubjectID          string
-	Provider               string
-	LastProbeState         string
-	HealthStatus           string
-	PlanType               string
-	SubscriptionStartedAt  *time.Time
-	SubscriptionExpiresAt  *time.Time
-	SubscriptionSource     string
-	RestrictionSummary     string
-	ErrorCode              string
-	ErrorSummary           string
-	Quotas                 []QuotaWindowDTO
-	ResetCreditCount       *int64
-	ResetCreditExpirations []string
-	UpstreamCheckedAt      *time.Time
-	Version                int64
-	UpdatedAt              time.Time
-}
-
 type AIAccountSharedBackfillReport struct {
 	Subjects               int64
 	Bindings               int64
@@ -198,6 +178,9 @@ func ensureAIAccountSharedSubjectTables(db *sql.DB) error {
 		}
 		// Additive migration for SQLite databases created before cycle token projection.
 		_, _ = db.Exec(`ALTER TABLE ai_account_subject_usage_buckets ADD COLUMN total_tokens INTEGER NOT NULL DEFAULT 0`)
+		// Additive migration for databases created before quota freshness tracking.
+		_, _ = db.Exec(`ALTER TABLE ai_account_subject_status ADD COLUMN quota_observed_at DATETIME`)
+		backfillSQLiteQuotaObservedAt(db)
 	}
 	ensureUsageProjectionMarkerTable(db)
 	if err := setProjectionMarker(db, aiAccountSharedSchemaMarker, "done"); err != nil {
@@ -438,159 +421,6 @@ func ListAIAccountSubjects(subjectIDs []string) (map[string]AIAccountSubjectReco
 			row.UpdatedAt = t
 		}
 		out[row.AuthSubjectID] = row
-	}
-	return out, rows.Err()
-}
-
-func UpsertAIAccountSubjectStatus(record AIAccountSubjectStatusRecord) error {
-	db := getDB()
-	if db == nil || strings.TrimSpace(record.AuthSubjectID) == "" {
-		return nil
-	}
-	if record.LastProbeState == "" {
-		record.LastProbeState = "idle"
-	}
-	if record.UpdatedAt.IsZero() {
-		record.UpdatedAt = time.Now().UTC()
-	}
-	if record.Version < 1 {
-		record.Version = 1
-	}
-	quotaJSON, err := json.Marshal(record.Quotas)
-	if err != nil {
-		return err
-	}
-	expJSON, err := json.Marshal(record.ResetCreditExpirations)
-	if err != nil {
-		return err
-	}
-	_, err = db.Exec(`
-		INSERT INTO ai_account_subject_status (
-			auth_subject_id, provider, last_probe_state, health_status, plan_type,
-			subscription_started_at, subscription_expires_at, subscription_source,
-			restriction_summary, error_code, error_summary, quota_json,
-			reset_credit_count, reset_credit_expirations, upstream_checked_at, version, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(auth_subject_id) DO UPDATE SET
-			provider = excluded.provider,
-			last_probe_state = excluded.last_probe_state,
-			health_status = excluded.health_status,
-			plan_type = excluded.plan_type,
-			subscription_started_at = CASE WHEN excluded.subscription_source <> ''
-				THEN excluded.subscription_started_at ELSE ai_account_subject_status.subscription_started_at END,
-			subscription_expires_at = CASE WHEN excluded.subscription_source <> ''
-				THEN excluded.subscription_expires_at ELSE ai_account_subject_status.subscription_expires_at END,
-			subscription_source = CASE WHEN excluded.subscription_source <> ''
-				THEN excluded.subscription_source ELSE ai_account_subject_status.subscription_source END,
-			restriction_summary = excluded.restriction_summary,
-			error_code = excluded.error_code,
-			error_summary = excluded.error_summary,
-			quota_json = excluded.quota_json,
-			reset_credit_count = excluded.reset_credit_count,
-			reset_credit_expirations = excluded.reset_credit_expirations,
-			upstream_checked_at = excluded.upstream_checked_at,
-			version = CASE WHEN excluded.version > ai_account_subject_status.version
-				THEN excluded.version ELSE ai_account_subject_status.version + 1 END,
-			updated_at = excluded.updated_at
-	`, record.AuthSubjectID, record.Provider, record.LastProbeState, record.HealthStatus, record.PlanType,
-		nullableTimeValue(record.SubscriptionStartedAt), nullableTimeValue(record.SubscriptionExpiresAt), record.SubscriptionSource,
-		record.RestrictionSummary, record.ErrorCode, record.ErrorSummary, string(quotaJSON), record.ResetCreditCount,
-		string(expJSON), nullableTimeValue(record.UpstreamCheckedAt), record.Version, record.UpdatedAt.UTC().Format(time.RFC3339Nano))
-	if err != nil {
-		return fmt.Errorf("usage: upsert shared ai account status: %w", err)
-	}
-	return nil
-}
-
-func UpdateAIAccountSubjectProbeFailure(subjectID, provider, errorCode, errorSummary string, checked time.Time) error {
-	db := getDB()
-	if db == nil || strings.TrimSpace(subjectID) == "" {
-		return nil
-	}
-	if checked.IsZero() {
-		checked = time.Now().UTC()
-	}
-	_, err := db.Exec(`
-		INSERT INTO ai_account_subject_status (
-			auth_subject_id, provider, last_probe_state, error_code, error_summary,
-			upstream_checked_at, version, updated_at
-		) VALUES (?, ?, 'error', ?, ?, ?, 1, ?)
-		ON CONFLICT(auth_subject_id) DO UPDATE SET
-			provider = excluded.provider,
-			last_probe_state = 'error',
-			error_code = excluded.error_code,
-			error_summary = excluded.error_summary,
-			upstream_checked_at = excluded.upstream_checked_at,
-			version = ai_account_subject_status.version + 1,
-			updated_at = excluded.updated_at
-	`, subjectID, provider, strings.TrimSpace(errorCode), sanitizeSharedStatusError(errorSummary),
-		checked.UTC().Format(time.RFC3339Nano), checked.UTC().Format(time.RFC3339Nano))
-	if err != nil {
-		return fmt.Errorf("usage: update shared ai account failure: %w", err)
-	}
-	return nil
-}
-
-func sanitizeSharedStatusError(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	switch {
-	case strings.Contains(value, "timeout"), strings.Contains(value, "deadline"):
-		return "upstream status probe timed out"
-	case strings.Contains(value, "unauthorized"), strings.Contains(value, "http 401"):
-		return "upstream authorization failed"
-	case strings.Contains(value, "forbidden"), strings.Contains(value, "http 403"):
-		return "upstream access was denied"
-	default:
-		return "upstream status probe failed"
-	}
-}
-
-func ListAIAccountSubjectStatus(subjectIDs []string) ([]AIAccountSubjectStatusRecord, error) {
-	db := getReadDB()
-	ids := dedupeExactStrings(subjectIDs)
-	if db == nil || len(ids) == 0 {
-		return []AIAccountSubjectStatusRecord{}, nil
-	}
-	args := make([]any, 0, len(ids))
-	for _, id := range ids {
-		args = append(args, id)
-	}
-	rows, err := db.Query(`
-		SELECT auth_subject_id, provider, last_probe_state, health_status, plan_type,
-			subscription_started_at, subscription_expires_at, subscription_source,
-			restriction_summary, error_code, error_summary, quota_json,
-			reset_credit_count, reset_credit_expirations, upstream_checked_at, version, updated_at
-		FROM ai_account_subject_status
-		WHERE auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")+`)
-	`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("usage: list shared ai account status: %w", err)
-	}
-	defer rows.Close()
-	out := make([]AIAccountSubjectStatusRecord, 0, len(ids))
-	for rows.Next() {
-		var row AIAccountSubjectStatusRecord
-		var started, expires, checked, updated sql.NullString
-		var reset sql.NullInt64
-		var quotaJSON, expJSON string
-		if err := rows.Scan(&row.AuthSubjectID, &row.Provider, &row.LastProbeState, &row.HealthStatus, &row.PlanType,
-			&started, &expires, &row.SubscriptionSource, &row.RestrictionSummary, &row.ErrorCode, &row.ErrorSummary,
-			&quotaJSON, &reset, &expJSON, &checked, &row.Version, &updated); err != nil {
-			return nil, err
-		}
-		row.SubscriptionStartedAt = parseNullableTime(started)
-		row.SubscriptionExpiresAt = parseNullableTime(expires)
-		row.UpstreamCheckedAt = parseNullableTime(checked)
-		row.Quotas = decodeQuotaWindows(quotaJSON)
-		row.ResetCreditExpirations = decodeStringSlice(expJSON)
-		if reset.Valid {
-			v := reset.Int64
-			row.ResetCreditCount = &v
-		}
-		if t, ok := parseStoredTimeString(updated.String); ok {
-			row.UpdatedAt = t
-		}
-		out = append(out, row)
 	}
 	return out, rows.Err()
 }


### PR DESCRIPTION
## 问题

AI 账号卡片会把几天前的配额数值当作当前值展示，而且看不出任何异常。线上 `ai_account_subject_status` 里此刻就有 4 个账号处于这个状态，最久的一个 **16 天**前就停止被确认，数值仍在原样下发。

三个缺陷叠在一起：

1. **探测失败保留旧配额，却推进时间戳。** `UpdateAIAccountSubjectProbeFailure` 的 `ON CONFLICT` 不含 `quota_json`（这是有意的，旧值仍是最好的已知答案），但 `upstream_checked_at` 和 `version` 照常前移 —— 数据和描述它的时间戳就此脱节，前端连"这份数据有多旧"都无从判断。

2. **窗口集合不稳定时整体覆盖。** 上游在大量探测里只返回一部分窗口 —— 对线上某 codex 账号统计，两天内 67 次探测有 14 次（21%）只返回了一半：10 次只有 `code_week`，4 次只有 `additional:codex_bengalfox:week`。整体覆盖 `quota_json` 会让另一行直接消失，下一轮又冒出来。

3. **200 但解析为空会静默清空**，且整个探测路径没有任何日志，失败与空返回都查不到。

## 方案

把「配额新鲜度」显式建模，而不是靠行级时间戳猜。

- `QuotaWindowDTO` 增加 `observed_at`，**按 `quota_key` 增量合并**：本次确认的窗口刷新并重新打戳，未出现的窗口原样保留且**保持旧时间戳**，超过 24h 未被确认的窗口丢弃。顺序沿用旧集合，卡片不会因上游换序而抖动。
- 行级 `quota_observed_at` 描述整份配额的观测时间，与 `upstream_checked_at`（最后一次*尝试*）分离 —— 「一秒前检查过，数据是六天前的」现在可表达。
- 迁移回填取 `ai_account_subject_quota_points` 的 `MAX(recorded_at)`：该表只在探测成功后写入，因此对长期失败的账号也能给出真实的最后观测时间。
- 探测失败与空 payload 补日志（subject / provider / auth_index）。

## 结构债

改动会让三个已在基线上的文件变大，因此按规范先拆后改，三个基线都降了：

| 文件 | 基线 | 现在 |
|---|---|---|
| `internal/usage/ai_account_subject_store.go` | 1075 | 905 |
| `internal/management/aiaccountstatus/service.go` | 1066 | 1001 |
| `internal/storage/postgres/migrations.go` | 1115 | 881 |

拆出：`ai_account_subject_status_store.go`（共享状态存取 + 合并）、`status_view.go`（视图组装）、`migrations_runtime_schema.go`（运行时 schema 常量）。

## 兼容性

纯增量：新增列与新增 JSON 字段，旧前端忽略即可。按 expand/contract 顺序先合本 PR，前端消费 PR 随后。

## 验证

- `./scripts/ci-pr.sh` 全绿（gofmt / secret scan / 结构检查 / `go vet` / `go test ./...` / golangci-lint / `go build`）
- 新增 5 个测试：部分 payload 不丢窗口、carried-forward 保留原时间戳、超期窗口清理、空 payload 不重新打戳、失败探测后 `upstream_checked_at` 严格新于 `quota_observed_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)