### PR TITLE
fix(audit): stop logging read traffic and bound the audit trail

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -22,7 +22,7 @@
       },
       {
         "path": "internal/management/aiaccountstatus/service.go",
-        "max_lines": 1001
+        "max_lines": 1000
       },
       {
         "path": "internal/management/modelcatalog/availability.go",
@@ -42,7 +42,7 @@
       },
       {
         "path": "internal/storage/postgres/migrations.go",
-        "max_lines": 881
+        "max_lines": 868
       },
       {
         "path": "internal/storage/sqlite/apikey/store.go",

--- a/internal/api/handlers/management/audit_middleware_postgres_test.go
+++ b/internal/api/handlers/management/audit_middleware_postgres_test.go
@@ -1,0 +1,224 @@
+package management
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
+)
+
+// TestManagementAuditRecordsOnlySecurityRelevantRequests pins the write policy
+// against a real database, because the defect it replaces was invisible in unit
+// tests: every non-2xx management response, reads included, became an audit row.
+// A single panel tab polling GET /update/progress produced 33k rows in 18 hours
+// on a live deployment.
+func TestManagementAuditRecordsOnlySecurityRelevantRequests(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CLIRELAY_POSTGRES_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	ctx := context.Background()
+	db, service := newDisposableIdentityService(t, ctx, dsn, "audit_policy")
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	// One operator may read system status, the other may not: the panel subscribes
+	// every authenticated user to update progress, so both shapes occur in the wild.
+	statusToken := seedPlatformUser(t, ctx, db, service, platformUserFixture{
+		username:    "status-reader",
+		password:    "Status-Password-123!",
+		userID:      "dddddddd-dddd-dddd-dddd-ddddddddddd1",
+		roleID:      "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1",
+		permissions: []string{"system.status.read", "system.update.manage"},
+	})
+	noStatusToken := seedPlatformUser(t, ctx, db, service, platformUserFixture{
+		username:    "status-blind",
+		password:    "Blind-Password-123!",
+		userID:      "dddddddd-dddd-dddd-dddd-ddddddddddd2",
+		roleID:      "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee2",
+		permissions: []string{"system.logs.read"},
+	})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(h.Middleware())
+	// Mirrors the deployed failure: the updater sidecar is not installed, so the
+	// read proxies upstream and answers 502 forever.
+	router.GET("/v0/management/update/progress", func(c *gin.Context) {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "update_progress_failed"})
+	})
+	router.POST("/v0/management/update/apply", func(c *gin.Context) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "apply_failed"})
+	})
+
+	serve := func(method, path, token string) int {
+		t.Helper()
+		req := httptest.NewRequest(method, path, nil)
+		req.RemoteAddr = "127.0.0.1:4321"
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	countAudit := func(action, resourceType, resourceID, result string) int64 {
+		t.Helper()
+		var count int64
+		if err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM audit_logs
+			 WHERE action = ? AND resource_type = ? AND resource_id = ? AND result = ?
+		`, action, resourceType, resourceID, result).Scan(&count); err != nil {
+			t.Fatalf("count audit rows: %v", err)
+		}
+		return count
+	}
+
+	// A read that fails upstream is an operational fault, not an audit event.
+	for i := 0; i < 5; i++ {
+		if code := serve(http.MethodGet, "/v0/management/update/progress", statusToken); code != http.StatusBadGateway {
+			t.Fatalf("permitted read status = %d, want %d", code, http.StatusBadGateway)
+		}
+	}
+	if got := countAudit("management.get", "update", "progress", auditResultFailed); got != 0 {
+		t.Fatalf("failed reads wrote %d audit rows, want 0", got)
+	}
+
+	// A refused read is worth recording once; repeats collapse into that row.
+	for i := 0; i < 20; i++ {
+		if code := serve(http.MethodGet, "/v0/management/update/progress", noStatusToken); code != http.StatusForbidden {
+			t.Fatalf("refused read status = %d, want %d", code, http.StatusForbidden)
+		}
+	}
+	if got := countAudit("management.get", "update", "progress", auditResultDenied); got != 1 {
+		t.Fatalf("refused reads wrote %d audit rows, want exactly 1", got)
+	}
+
+	// Writes are never collapsed: each attempt to change something is its own row.
+	for i := 0; i < 3; i++ {
+		if code := serve(http.MethodPost, "/v0/management/update/apply", statusToken); code != http.StatusInternalServerError {
+			t.Fatalf("failed write status = %d, want %d", code, http.StatusInternalServerError)
+		}
+	}
+	if got := countAudit("management.post", "update", "apply", auditResultFailed); got != 3 {
+		t.Fatalf("failed writes wrote %d audit rows, want 3", got)
+	}
+	// A refused write is also recorded per attempt.
+	for i := 0; i < 2; i++ {
+		if code := serve(http.MethodPost, "/v0/management/update/apply", noStatusToken); code != http.StatusForbidden {
+			t.Fatalf("refused write status = %d, want %d", code, http.StatusForbidden)
+		}
+	}
+	if got := countAudit("management.post", "update", "apply", auditResultDenied); got != 2 {
+		t.Fatalf("refused writes wrote %d audit rows, want 2", got)
+	}
+}
+
+type platformUserFixture struct {
+	username, password, userID, roleID string
+	permissions                        []string
+}
+
+// seedPlatformUser creates a platform-scoped role with exactly the given
+// permissions, a user holding it, and returns a fresh access token. CreateRole
+// rejects platform-scoped permissions, so the fixture seeds them the way an
+// operator provisioning a custom platform role would.
+func seedPlatformUser(t *testing.T, ctx context.Context, db *sql.DB, service *identity.Service, fx platformUserFixture) string {
+	t.Helper()
+	hash, err := identity.HashPassword(fx.password)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.ExecContext(ctx, `
+		INSERT INTO roles (id, tenant_id, code, name, description, scope, system_protected)
+		VALUES (?, ?, ?, ?, '', 'platform', false)
+	`, fx.roleID, identity.SystemTenantID, "platform_"+fx.username, fx.username+" role"); err != nil {
+		t.Fatalf("seed role %s: %v", fx.username, err)
+	}
+	for _, perm := range fx.permissions {
+		if _, err = db.ExecContext(ctx, `INSERT INTO role_permissions (role_id, permission_code) VALUES (?, ?)`, fx.roleID, perm); err != nil {
+			t.Fatalf("seed role permission %s: %v", perm, err)
+		}
+	}
+	if _, err = db.ExecContext(ctx, `
+		INSERT INTO users (
+		  id, tenant_id, username, username_normalized, display_name, password_hash,
+		  status, must_change_password, password_changed_at, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, 'active', false, now(), now(), now())
+	`, fx.userID, identity.SystemTenantID, fx.username, fx.username, fx.username, hash); err != nil {
+		t.Fatalf("seed user %s: %v", fx.username, err)
+	}
+	if _, err = db.ExecContext(ctx, `INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)`, fx.userID, fx.roleID); err != nil {
+		t.Fatalf("seed user role %s: %v", fx.username, err)
+	}
+	login, err := service.Login(ctx, fx.username, fx.password, false, "audit-policy-test")
+	if err != nil {
+		t.Fatalf("login %s: %v", fx.username, err)
+	}
+	return login.AccessToken
+}
+
+// newDisposableIdentityService gives the test its own database so package tests
+// that TRUNCATE the shared catalog cannot race this fixture.
+func newDisposableIdentityService(t *testing.T, ctx context.Context, dsn, prefix string) (*sql.DB, *identity.Service) {
+	t.Helper()
+	adminDB, err := sql.Open("pgxq", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = adminDB.PingContext(ctx); err != nil {
+		_ = adminDB.Close()
+		t.Fatal(err)
+	}
+	dbName := fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+	if _, err = adminDB.ExecContext(ctx, "CREATE DATABASE "+dbName); err != nil {
+		_ = adminDB.Close()
+		t.Fatalf("create disposable db: %v", err)
+	}
+	// Registered first so LIFO cleanup runs: runtime close → drop → admin close.
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		if _, err := adminDB.ExecContext(cleanupCtx, `
+			SELECT pg_terminate_backend(pid)
+			  FROM pg_stat_activity
+			 WHERE datname = $1 AND pid <> pg_backend_pid()
+		`, dbName); err != nil {
+			t.Errorf("terminate connections on disposable db %s: %v", dbName, err)
+		}
+		if _, err := adminDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+dbName); err != nil {
+			t.Errorf("drop disposable db %s: %v", dbName, err)
+		}
+		if err := adminDB.Close(); err != nil {
+			t.Errorf("close admin db: %v", err)
+		}
+	})
+	testDSN, err := replacePostgresDatabaseForTest(dsn, dbName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: testDSN, MaxOpenConns: 4, MaxIdleConns: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close runtime db: %v", err)
+		}
+	})
+	service := identity.NewService(db)
+	if err = service.Bootstrap(ctx, "Bootstrap-Password-123!"); err != nil {
+		t.Fatal(err)
+	}
+	return db, service
+}

--- a/internal/api/handlers/management/audit_policy.go
+++ b/internal/api/handlers/management/audit_policy.go
@@ -1,0 +1,153 @@
+package management
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Audit policy for the management middleware.
+//
+// The audit trail answers "who changed what, and who was refused". It is not a
+// traffic log, and the two were conflated: every management response that was not
+// 2xx produced a row, reads included. On a live deployment that meant one row
+// every two seconds forever from a single panel tab polling GET /update/progress
+// — denied for operators without system.status.read, and 502 wherever the updater
+// sidecar is not installed. 33k rows accumulated in 18 hours, of which roughly 50
+// were real events; the page that is supposed to show security-sensitive changes
+// showed 656 pages of update polling.
+//
+// Two rules keep the trail readable:
+//
+//  1. An ordinary read is audited only when it was *refused*. A read that merely
+//     errored is an operational fault and belongs in the request log.
+//  2. Identical refusals collapse into one row per window, carrying the number of
+//     occurrences folded into it, so no client can bury real events by polling.
+
+const (
+	auditResultSuccess = "success"
+	auditResultDenied  = "denied"
+	auditResultFailed  = "failed"
+)
+
+const (
+	// auditRepeatWindow is how long one signature holds the floor. Five minutes
+	// turns a 2s polling client from ~1800 rows/hour into 12, while still showing
+	// an operator that the refusals are ongoing rather than a one-off.
+	auditRepeatWindow = 5 * time.Minute
+
+	// auditRepeatIdleTTL is how long a silent signature is kept so its pending
+	// count can still be attached to a later row. Beyond this the client has
+	// stopped and the entry is dropped to bound memory.
+	auditRepeatIdleTTL = 2 * auditRepeatWindow
+
+	auditRepeatSweepInterval = auditRepeatWindow
+)
+
+// shouldRecordManagementAudit reports whether a management request belongs in the
+// audit trail.
+//
+// Writes are always recorded, including failures: a rejected attempt to change
+// something is exactly what an audit reader is looking for. Sensitive reads
+// (request bodies, egress, exports, downloads) are recorded because reading them
+// is itself a disclosure. Everything else only earns a row when it was refused.
+func shouldRecordManagementAudit(write, sensitiveRead bool, result string) bool {
+	if write || sensitiveRead {
+		return true
+	}
+	return result == auditResultDenied
+}
+
+// auditRepeatKey identifies "the same thing happening again": same actor, same
+// route, same outcome. Deliberately excludes the request id and timestamp.
+func auditRepeatKey(tenantID, actorKind, actorUserID, action, resourceType, resourceID, result string) string {
+	return strings.Join([]string{tenantID, actorKind, actorUserID, action, resourceType, resourceID, result}, "\x00")
+}
+
+type auditRepeatEntry struct {
+	// windowEnds is when this signature may write again.
+	windowEnds time.Time
+	// lastSeen tracks liveness for sweeping, not for the window.
+	lastSeen time.Time
+	// suppressed counts events folded in since the last written row.
+	suppressed int64
+}
+
+// auditRepeatLimiter admits one row per signature per window and counts the rest.
+//
+// State is per process and in-memory on purpose: it shapes this instance's own
+// write rate. Losing it on restart costs at most one extra row per signature.
+type auditRepeatLimiter struct {
+	mu        sync.Mutex
+	window    time.Duration
+	idleTTL   time.Duration
+	entries   map[string]*auditRepeatEntry
+	nextSweep time.Time
+}
+
+func newAuditRepeatLimiter(window, idleTTL time.Duration) *auditRepeatLimiter {
+	if window <= 0 {
+		window = auditRepeatWindow
+	}
+	if idleTTL < window {
+		idleTTL = 2 * window
+	}
+	return &auditRepeatLimiter{
+		window:  window,
+		idleTTL: idleTTL,
+		entries: make(map[string]*auditRepeatEntry),
+	}
+}
+
+// admit reports whether this event may be written and, when it may, how many
+// identical events were folded into it since the previous write. A nil limiter
+// admits everything so a handler built without one keeps the old behaviour.
+func (l *auditRepeatLimiter) admit(key string, now time.Time) (bool, int64) {
+	if l == nil {
+		return true, 0
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.sweepLocked(now)
+
+	entry, ok := l.entries[key]
+	if !ok {
+		l.entries[key] = &auditRepeatEntry{windowEnds: now.Add(l.window), lastSeen: now}
+		return true, 0
+	}
+	entry.lastSeen = now
+	if now.Before(entry.windowEnds) {
+		entry.suppressed++
+		return false, 0
+	}
+	folded := entry.suppressed
+	entry.suppressed = 0
+	entry.windowEnds = now.Add(l.window)
+	return true, folded
+}
+
+// sweepLocked drops signatures that have gone quiet. An entry still holding a
+// suppressed count is dropped with it: the client stopped, its first refusal is
+// already in the log, and keeping the map bounded matters more than a tail count
+// nobody will read.
+func (l *auditRepeatLimiter) sweepLocked(now time.Time) {
+	if now.Before(l.nextSweep) {
+		return
+	}
+	l.nextSweep = now.Add(auditRepeatSweepInterval)
+	for key, entry := range l.entries {
+		if now.Sub(entry.lastSeen) >= l.idleTTL {
+			delete(l.entries, key)
+		}
+	}
+}
+
+// auditRepeatNote renders the folded count for the audit detail payload.
+func auditRepeatNote(folded int64, window time.Duration) map[string]any {
+	return map[string]any{
+		"suppressed":     folded,
+		"window_seconds": int64(window / time.Second),
+		"note":           "identical events collapsed into this row: " + strconv.FormatInt(folded, 10) + " suppressed since the previous one",
+	}
+}

--- a/internal/api/handlers/management/audit_policy_test.go
+++ b/internal/api/handlers/management/audit_policy_test.go
@@ -1,0 +1,109 @@
+package management
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShouldRecordManagementAudit(t *testing.T) {
+	cases := []struct {
+		name          string
+		write         bool
+		sensitiveRead bool
+		result        string
+		want          bool
+	}{
+		{name: "successful write", write: true, result: auditResultSuccess, want: true},
+		{name: "failed write", write: true, result: auditResultFailed, want: true},
+		{name: "denied write", write: true, result: auditResultDenied, want: true},
+		{name: "sensitive read", sensitiveRead: true, result: auditResultSuccess, want: true},
+		{name: "failed sensitive read", sensitiveRead: true, result: auditResultFailed, want: true},
+		{name: "successful read", result: auditResultSuccess, want: false},
+		// The flood this policy exists for: a read endpoint answering 502 because an
+		// optional sidecar is absent is an operational fault, not an audit event.
+		{name: "failed read", result: auditResultFailed, want: false},
+		{name: "denied read", result: auditResultDenied, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldRecordManagementAudit(tc.write, tc.sensitiveRead, tc.result); got != tc.want {
+				t.Fatalf("shouldRecordManagementAudit(%v, %v, %q) = %v, want %v", tc.write, tc.sensitiveRead, tc.result, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuditRepeatLimiterCollapsesWithinWindow(t *testing.T) {
+	limiter := newAuditRepeatLimiter(5*time.Minute, 10*time.Minute)
+	start := time.Unix(1700000000, 0).UTC()
+	key := auditRepeatKey("tenant", "user_session", "user", "management.get", "update", "progress", auditResultDenied)
+
+	if allowed, folded := limiter.admit(key, start); !allowed || folded != 0 {
+		t.Fatalf("first admit = (%v, %d), want (true, 0)", allowed, folded)
+	}
+	// A client polling every two seconds for the rest of the window.
+	suppressed := 0
+	for offset := 2 * time.Second; offset < 5*time.Minute; offset += 2 * time.Second {
+		if allowed, _ := limiter.admit(key, start.Add(offset)); allowed {
+			t.Fatalf("admit at +%s = true, want the window to hold", offset)
+		}
+		suppressed++
+	}
+	if suppressed == 0 {
+		t.Fatal("test did not exercise any suppression")
+	}
+	allowed, folded := limiter.admit(key, start.Add(5*time.Minute))
+	if !allowed {
+		t.Fatal("admit after the window = false, want true")
+	}
+	if folded != int64(suppressed) {
+		t.Fatalf("folded = %d, want %d", folded, suppressed)
+	}
+	// The count belongs to the row that carried it and must not be replayed.
+	if allowed, folded = limiter.admit(key, start.Add(10*time.Minute)); !allowed || folded != 0 {
+		t.Fatalf("next window admit = (%v, %d), want (true, 0)", allowed, folded)
+	}
+}
+
+func TestAuditRepeatLimiterKeepsDistinctSignaturesApart(t *testing.T) {
+	limiter := newAuditRepeatLimiter(5*time.Minute, 10*time.Minute)
+	now := time.Unix(1700000000, 0).UTC()
+
+	denied := auditRepeatKey("tenant", "user_session", "user", "management.get", "update", "progress", auditResultDenied)
+	otherActor := auditRepeatKey("tenant", "user_session", "other", "management.get", "update", "progress", auditResultDenied)
+	otherRoute := auditRepeatKey("tenant", "user_session", "user", "management.get", "tenants", "", auditResultDenied)
+
+	for _, key := range []string{denied, otherActor, otherRoute} {
+		if allowed, _ := limiter.admit(key, now); !allowed {
+			t.Fatalf("first admit for %q = false, want true", key)
+		}
+	}
+	if allowed, _ := limiter.admit(denied, now.Add(time.Second)); allowed {
+		t.Fatal("repeat of the same signature was admitted")
+	}
+}
+
+func TestAuditRepeatLimiterSweepsIdleSignatures(t *testing.T) {
+	limiter := newAuditRepeatLimiter(time.Minute, 2*time.Minute)
+	now := time.Unix(1700000000, 0).UTC()
+	key := auditRepeatKey("tenant", "user_session", "user", "management.get", "update", "progress", auditResultDenied)
+
+	limiter.admit(key, now)
+	limiter.admit(key, now.Add(time.Second))
+	// A different signature drives the sweep once the idle TTL has elapsed.
+	limiter.admit(auditRepeatKey("tenant", "user_session", "user", "management.get", "roles", "", auditResultDenied), now.Add(5*time.Minute))
+
+	limiter.mu.Lock()
+	_, stillTracked := limiter.entries[key]
+	limiter.mu.Unlock()
+	if stillTracked {
+		t.Fatal("idle signature survived the sweep")
+	}
+}
+
+func TestAuditRepeatLimiterNilAdmitsEverything(t *testing.T) {
+	var limiter *auditRepeatLimiter
+	if allowed, folded := limiter.admit("key", time.Now()); !allowed || folded != 0 {
+		t.Fatalf("nil limiter admit = (%v, %d), want (true, 0)", allowed, folded)
+	}
+}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -31,6 +31,7 @@ type Handler struct {
 	configFilePath       string
 	mu                   sync.Mutex
 	loginThrottle        *loginThrottle
+	auditRepeat          *auditRepeatLimiter
 	authManager          *coreauth.Manager
 	usageStats           *usage.RequestStatistics
 	tokenStore           coreauth.Store
@@ -66,6 +67,7 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 		cfg:                 cfg,
 		configFilePath:      configFilePath,
 		loginThrottle:       newLoginThrottle(throttlePoliciesFromConfig(cfg)),
+		auditRepeat:         newAuditRepeatLimiter(auditRepeatWindow, auditRepeatIdleTTL),
 		authManager:         manager,
 		usageStats:          usage.GetRequestStatistics(),
 		tokenStore:          sdkAuth.GetTokenStore(),

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -85,18 +85,34 @@ func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Princ
 	if result == "" {
 		switch status := c.Writer.Status(); {
 		case status < http.StatusBadRequest:
-			result = "success"
+			result = auditResultSuccess
 		case status == http.StatusUnauthorized || status == http.StatusForbidden:
-			result = "denied"
+			result = auditResultDenied
 		default:
-			result = "failed"
+			result = auditResultFailed
 		}
 	}
-	if result == "success" && isTenantGovernancePath(c.Request.URL.Path) {
+	if result == auditResultSuccess && isTenantGovernancePath(c.Request.URL.Path) {
 		return
 	}
-	if result == "success" && !write && !sensitiveRead {
+	if !shouldRecordManagementAudit(write, sensitiveRead, result) {
 		return
+	}
+	action := "management." + strings.ToLower(c.Request.Method)
+	// Reads that reach this point were refused, and a client polling a route it
+	// lacks permission for repeats that refusal indefinitely. Collapse the repeats
+	// into one row per window; writes are never collapsed because each one is a
+	// distinct attempt to change something.
+	var repeat map[string]any
+	if !write {
+		key := auditRepeatKey(principal.EffectiveTenant.ID, principal.Kind, principal.User.ID, action, resourceType, resourceID, result)
+		allowed, folded := h.auditRepeat.admit(key, time.Now())
+		if !allowed {
+			return
+		}
+		if folded > 0 {
+			repeat = auditRepeatNote(folded, auditRepeatWindow)
+		}
 	}
 	// Prefer middleware-assigned ID; fall back to generating one so audit rows stay correlatable
 	// even if request-id middleware skipped this path (e.g. older deployments / test routers).
@@ -114,37 +130,41 @@ func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Princ
 	routePath := strings.TrimPrefix(c.Request.URL.Path, "/v0/management")
 	handlerName := c.Request.Method + " " + routePath
 	permission := permissionForManagementRequest(c.Request.Method, c.Request.URL.Path)
+	changes := map[string]any{
+		"http": map[string]any{
+			"method": c.Request.Method,
+			"path":   c.Request.URL.Path,
+			"status": c.Writer.Status(),
+		},
+		"permission": permission,
+		// call_chain reconstructs the management request path for audit detail UI.
+		"call_chain": []map[string]any{
+			{"step": 1, "layer": "http", "name": c.Request.Method + " " + c.Request.URL.Path, "detail": "client request"},
+			{"step": 2, "layer": "middleware", "name": "management.auth", "detail": "session + RBAC"},
+			{"step": 3, "layer": "handler", "name": handlerName, "package": "internal/api/handlers/management"},
+			{"step": 4, "layer": "service", "name": "identity/management service", "resource": resourceType, "resource_id": resourceID},
+		},
+		"project_method": map[string]any{
+			"package":  "internal/api/handlers/management",
+			"handler":  handlerName,
+			"resource": resourceType,
+			"route":    routePath,
+		},
+	}
+	if repeat != nil {
+		changes["repeat"] = repeat
+	}
 	service.RecordAudit(c.Request.Context(), identity.AuditEvent{
 		TenantID:       principal.EffectiveTenant.ID,
 		ActorKind:      principal.Kind,
 		ActorUserID:    principal.User.ID,
 		ActorSessionID: principal.SessionID,
-		Action:         "management." + strings.ToLower(c.Request.Method),
+		Action:         action,
 		ResourceType:   resourceType,
 		ResourceID:     resourceID,
 		Result:         result,
 		RequestID:      requestID,
-		Changes: map[string]any{
-			"http": map[string]any{
-				"method": c.Request.Method,
-				"path":   c.Request.URL.Path,
-				"status": c.Writer.Status(),
-			},
-			"permission": permission,
-			// call_chain reconstructs the management request path for audit detail UI.
-			"call_chain": []map[string]any{
-				{"step": 1, "layer": "http", "name": c.Request.Method + " " + c.Request.URL.Path, "detail": "client request"},
-				{"step": 2, "layer": "middleware", "name": "management.auth", "detail": "session + RBAC"},
-				{"step": 3, "layer": "handler", "name": handlerName, "package": "internal/api/handlers/management"},
-				{"step": 4, "layer": "service", "name": "identity/management service", "resource": resourceType, "resource_id": resourceID},
-			},
-			"project_method": map[string]any{
-				"package":  "internal/api/handlers/management",
-				"handler":  handlerName,
-				"resource": resourceType,
-				"route":    routePath,
-			},
-		},
+		Changes:        changes,
 	})
 }
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -140,6 +140,23 @@ func startSessionReaper(service *identity.Service, interval time.Duration) {
 	sessionReaperStop = service.StartSessionReaper(context.Background(), interval)
 }
 
+// auditRetentionStop mirrors the session reaper's lifecycle: started with the
+// runtime data stack, so it has to be stopped with it or a re-initialisation
+// leaks a goroutine and a ticker.
+var (
+	auditRetentionMu   sync.Mutex
+	auditRetentionStop func()
+)
+
+func startAuditRetention(service *identity.Service, policy identity.AuditRetentionPolicy) {
+	auditRetentionMu.Lock()
+	defer auditRetentionMu.Unlock()
+	if auditRetentionStop != nil {
+		auditRetentionStop()
+	}
+	auditRetentionStop = service.StartAuditRetention(context.Background(), policy)
+}
+
 // stopRuntimeDataStack tears down everything initializeRuntimeDataStack started.
 func stopRuntimeDataStack() {
 	sessionReaperMu.Lock()
@@ -148,6 +165,13 @@ func stopRuntimeDataStack() {
 	sessionReaperMu.Unlock()
 	if stop != nil {
 		stop()
+	}
+	auditRetentionMu.Lock()
+	stopAudit := auditRetentionStop
+	auditRetentionStop = nil
+	auditRetentionMu.Unlock()
+	if stopAudit != nil {
+		stopAudit()
 	}
 	usage.StopRedis()
 }
@@ -198,6 +222,7 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 	identity.SetDefault(identityService)
 	identityService.SetSessionPolicy(identity.SessionPolicyFromConfig(cfg))
 	startSessionReaper(identityService, identity.SessionReaperIntervalFromConfig(cfg))
+	startAuditRetention(identityService, identity.AuditRetentionPolicyFromConfig(cfg))
 	// Import YAML keys first so one-shot end-user backfill can see them.
 	if _, err := usage.MigrateAPIKeysFromConfig(cfg, configPath); err != nil {
 		return fmt.Errorf("migrate api keys from config: %w", err)

--- a/internal/config/sections.go
+++ b/internal/config/sections.go
@@ -86,6 +86,13 @@ type AuthHardening struct {
 	AbsoluteRefreshTTLHours int `yaml:"absolute-refresh-ttl-hours,omitempty"`
 	// SessionReaperIntervalMinutes controls expired token/session GC. Default 60.
 	SessionReaperIntervalMinutes int `yaml:"session-reaper-interval-minutes,omitempty"`
+	// AuditRetentionDays drops audit_logs rows older than this. Default 180.
+	// Negative disables the age limit and keeps rows until the row cap applies.
+	AuditRetentionDays int `yaml:"audit-retention-days,omitempty"`
+	// AuditMaxRows caps audit_logs; the oldest rows are pruned first. Default
+	// 200000. Negative disables the cap. It is a runaway guard, not a trim: with
+	// the audit write policy in place, normal use stays orders of magnitude below.
+	AuditMaxRows int `yaml:"audit-max-rows,omitempty"`
 }
 
 // AutoUpdateConfig holds Docker-first update check and sidecar settings.

--- a/internal/identity/audit_retention.go
+++ b/internal/identity/audit_retention.go
@@ -1,0 +1,217 @@
+package identity
+
+import (
+	"context"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	log "github.com/sirupsen/logrus"
+)
+
+// Audit retention.
+//
+// audit_logs had no lifecycle at all: rows accumulated for the life of the
+// deployment, and the only way to shrink the table was the panel's "clear all"
+// button, which throws away the entire trail. A write policy that only records
+// security-relevant events (see the management middleware) keeps the growth rate
+// sane, but an audit table still needs a ceiling — the point of a bound is that
+// it holds even when a future caller starts recording something noisy.
+//
+// Both limits are deliberately generous. Retention is what an operator answers
+// compliance questions with; the row cap exists to stop a runaway, not to trim
+// normal usage, and it is only reached if something is writing far more than the
+// current policy allows.
+const (
+	defaultAuditRetention        = 180 * 24 * time.Hour
+	defaultAuditMaxRows          = int64(200000)
+	defaultAuditRetentionBatch   = 500
+	defaultAuditRetentionCadence = time.Hour
+)
+
+// AuditRetentionPolicy bounds the audit trail by age and by row count.
+type AuditRetentionPolicy struct {
+	// MaxAge drops rows older than this. Zero disables the age limit.
+	MaxAge time.Duration
+	// MaxRows keeps only the newest rows once the table exceeds it. Zero
+	// disables the cap.
+	MaxRows int64
+	// BatchSize caps rows deleted per statement so a pass never holds a long
+	// write lock on the table the middleware writes to.
+	BatchSize int
+	// Interval is the cadence of the background pass.
+	Interval time.Duration
+}
+
+func (p AuditRetentionPolicy) normalized() AuditRetentionPolicy {
+	if p.MaxAge < 0 {
+		p.MaxAge = 0
+	}
+	if p.MaxRows < 0 {
+		p.MaxRows = 0
+	}
+	if p.BatchSize <= 0 {
+		p.BatchSize = defaultAuditRetentionBatch
+	}
+	if p.Interval <= 0 {
+		p.Interval = defaultAuditRetentionCadence
+	}
+	return p
+}
+
+// DefaultAuditRetentionPolicy is used when the operator configured nothing.
+func DefaultAuditRetentionPolicy() AuditRetentionPolicy {
+	return AuditRetentionPolicy{
+		MaxAge:    defaultAuditRetention,
+		MaxRows:   defaultAuditMaxRows,
+		BatchSize: defaultAuditRetentionBatch,
+		Interval:  defaultAuditRetentionCadence,
+	}
+}
+
+// AuditRetentionPolicyFromConfig resolves the policy, defaulting per field so an
+// operator who sets only one of them still gets the shipped value for the other.
+// A negative value disables that limit explicitly.
+func AuditRetentionPolicyFromConfig(cfg *config.Config) AuditRetentionPolicy {
+	policy := DefaultAuditRetentionPolicy()
+	if cfg == nil {
+		return policy
+	}
+	auth := cfg.RemoteManagement.Auth
+	if days := auth.AuditRetentionDays; days != 0 {
+		if days < 0 {
+			policy.MaxAge = 0
+		} else {
+			policy.MaxAge = time.Duration(days) * 24 * time.Hour
+		}
+	}
+	if rows := auth.AuditMaxRows; rows != 0 {
+		if rows < 0 {
+			policy.MaxRows = 0
+		} else {
+			policy.MaxRows = int64(rows)
+		}
+	}
+	return policy
+}
+
+// StartAuditRetention runs the retention pass on a ticker until the returned stop
+// function is called. Like the session reaper, the stop function must be wired
+// into process shutdown so a re-initialised runtime stack does not leak the
+// goroutine.
+func (s *Service) StartAuditRetention(ctx context.Context, policy AuditRetentionPolicy) (stop func()) {
+	if s == nil || s.db == nil {
+		return func() {}
+	}
+	policy = policy.normalized()
+	if policy.MaxAge == 0 && policy.MaxRows == 0 {
+		log.Debug("identity: audit retention disabled by configuration")
+		return func() {}
+	}
+	retentionCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		ticker := time.NewTicker(policy.Interval)
+		defer ticker.Stop()
+		// Run once at startup so an existing oversized table is brought inside the
+		// policy without waiting a full interval.
+		s.runAuditRetentionPass(retentionCtx, policy)
+		for {
+			select {
+			case <-retentionCtx.Done():
+				return
+			case <-ticker.C:
+				s.runAuditRetentionPass(retentionCtx, policy)
+			}
+		}
+	}()
+	return cancel
+}
+
+func (s *Service) runAuditRetentionPass(ctx context.Context, policy AuditRetentionPolicy) {
+	deleted, err := s.PruneAuditLogs(ctx, policy)
+	switch {
+	case err != nil && ctx.Err() != nil:
+		return
+	case err != nil:
+		log.WithError(err).Warn("identity: audit retention pass failed")
+	case deleted > 0:
+		log.Infof("identity: audit retention removed %d audit_logs rows", deleted)
+	default:
+		log.Debug("identity: audit retention removed 0 audit_logs rows")
+	}
+}
+
+// PruneAuditLogs enforces the policy once and returns how many rows it removed.
+// Age is enforced first so the row cap only ever has to deal with rows an
+// operator still wants to keep.
+func (s *Service) PruneAuditLogs(ctx context.Context, policy AuditRetentionPolicy) (int64, error) {
+	if s == nil || s.db == nil {
+		return 0, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	policy = policy.normalized()
+	var total int64
+
+	if policy.MaxAge > 0 {
+		cutoff := time.Now().UTC().Add(-policy.MaxAge)
+		for {
+			if err := ctx.Err(); err != nil {
+				return total, err
+			}
+			res, err := s.db.ExecContext(ctx, `
+				DELETE FROM audit_logs
+				 WHERE id IN (SELECT id FROM audit_logs WHERE created_at < ? ORDER BY id LIMIT ?)
+			`, cutoff, policy.BatchSize)
+			if err != nil {
+				return total, err
+			}
+			n, err := res.RowsAffected()
+			if err != nil {
+				return total, err
+			}
+			total += n
+			if n < int64(policy.BatchSize) {
+				break
+			}
+		}
+	}
+
+	if policy.MaxRows > 0 {
+		for {
+			if err := ctx.Err(); err != nil {
+				return total, err
+			}
+			var count int64
+			if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audit_logs`).Scan(&count); err != nil {
+				return total, err
+			}
+			if count <= policy.MaxRows {
+				break
+			}
+			// The id of the oldest row still inside the cap; everything below it goes.
+			var cutoffID int64
+			if err := s.db.QueryRowContext(ctx,
+				`SELECT id FROM audit_logs ORDER BY id DESC LIMIT 1 OFFSET ?`, policy.MaxRows-1).Scan(&cutoffID); err != nil {
+				return total, err
+			}
+			res, err := s.db.ExecContext(ctx, `
+				DELETE FROM audit_logs
+				 WHERE id IN (SELECT id FROM audit_logs WHERE id < ? ORDER BY id LIMIT ?)
+			`, cutoffID, policy.BatchSize)
+			if err != nil {
+				return total, err
+			}
+			n, err := res.RowsAffected()
+			if err != nil {
+				return total, err
+			}
+			total += n
+			if n == 0 {
+				break
+			}
+		}
+	}
+
+	return total, nil
+}

--- a/internal/identity/audit_retention_test.go
+++ b/internal/identity/audit_retention_test.go
@@ -1,0 +1,125 @@
+package identity
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	postgresstore "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/testutil/postgrestest"
+)
+
+func TestAuditRetentionPolicyFromConfig(t *testing.T) {
+	if got := AuditRetentionPolicyFromConfig(nil); got != DefaultAuditRetentionPolicy() {
+		t.Fatalf("nil config = %+v, want defaults %+v", got, DefaultAuditRetentionPolicy())
+	}
+
+	cfg := &config.Config{}
+	cfg.RemoteManagement.Auth.AuditRetentionDays = 30
+	policy := AuditRetentionPolicyFromConfig(cfg)
+	if policy.MaxAge != 30*24*time.Hour {
+		t.Fatalf("MaxAge = %v, want 720h", policy.MaxAge)
+	}
+	// Configuring one limit must not silently drop the other.
+	if policy.MaxRows != defaultAuditMaxRows {
+		t.Fatalf("MaxRows = %d, want default %d", policy.MaxRows, defaultAuditMaxRows)
+	}
+
+	cfg.RemoteManagement.Auth.AuditRetentionDays = -1
+	cfg.RemoteManagement.Auth.AuditMaxRows = -1
+	disabled := AuditRetentionPolicyFromConfig(cfg)
+	if disabled.MaxAge != 0 || disabled.MaxRows != 0 {
+		t.Fatalf("negative config = %+v, want both limits disabled", disabled)
+	}
+}
+
+func TestPruneAuditLogsNilService(t *testing.T) {
+	var service *Service
+	deleted, err := service.PruneAuditLogs(context.Background(), DefaultAuditRetentionPolicy())
+	if err != nil || deleted != 0 {
+		t.Fatalf("nil service prune = (%d, %v), want (0, nil)", deleted, err)
+	}
+}
+
+// TestPostgresPruneAuditLogs covers the two limits that keep audit_logs bounded.
+// Before retention existed the table only ever grew; the panel's "clear all" was
+// the sole way to shrink it, and it discards the entire trail.
+func TestPostgresPruneAuditLogs(t *testing.T) {
+	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	postgrestest.LockSharedRuntimeDB(t, dsn)
+	ctx := context.Background()
+	db, err := postgresstore.OpenRuntimeDB(ctx, config.PostgresConfig{DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Leave the shared catalog clean for the next test, then close: cleanups run
+	// after the test body, so a deferred close would beat the truncate to it.
+	t.Cleanup(func() {
+		if _, cleanupErr := db.ExecContext(context.Background(), `TRUNCATE audit_logs`); cleanupErr != nil {
+			t.Errorf("truncate audit_logs: %v", cleanupErr)
+		}
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("close runtime db: %v", closeErr)
+		}
+	})
+	if _, err = db.ExecContext(ctx, `TRUNCATE audit_logs`); err != nil {
+		t.Fatal(err)
+	}
+
+	service := NewService(db)
+	insert := func(age time.Duration, action string) {
+		t.Helper()
+		if _, err = db.ExecContext(ctx, `
+			INSERT INTO audit_logs (tenant_id, actor_kind, action, resource_type, resource_id, result, request_id, changes, created_at)
+			VALUES (NULL, 'system', ?, 'test', '', 'success', '', '{}'::jsonb, ?)
+		`, action, time.Now().UTC().Add(-age)); err != nil {
+			t.Fatalf("insert audit row: %v", err)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		insert(90*24*time.Hour, "test.old")
+	}
+	for i := 0; i < 7; i++ {
+		insert(time.Hour, "test.recent")
+	}
+
+	deleted, err := service.PruneAuditLogs(ctx, AuditRetentionPolicy{MaxAge: 30 * 24 * time.Hour, BatchSize: 2})
+	if err != nil {
+		t.Fatalf("prune by age: %v", err)
+	}
+	if deleted != 5 {
+		t.Fatalf("age prune deleted %d rows, want 5", deleted)
+	}
+	var remaining int64
+	if err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audit_logs`).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 7 {
+		t.Fatalf("rows after age prune = %d, want 7", remaining)
+	}
+
+	deleted, err = service.PruneAuditLogs(ctx, AuditRetentionPolicy{MaxRows: 3, BatchSize: 2})
+	if err != nil {
+		t.Fatalf("prune by row cap: %v", err)
+	}
+	if deleted != 4 {
+		t.Fatalf("row cap prune deleted %d rows, want 4", deleted)
+	}
+	if err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audit_logs`).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 3 {
+		t.Fatalf("rows after cap prune = %d, want 3", remaining)
+	}
+
+	// Both limits satisfied: a further pass must be a no-op rather than looping.
+	if deleted, err = service.PruneAuditLogs(ctx, AuditRetentionPolicy{MaxAge: 30 * 24 * time.Hour, MaxRows: 3}); err != nil || deleted != 0 {
+		t.Fatalf("idempotent pass = (%d, %v), want (0, nil)", deleted, err)
+	}
+}

--- a/internal/storage/postgres/ai_account_migrations.go
+++ b/internal/storage/postgres/ai_account_migrations.go
@@ -1,0 +1,21 @@
+package postgres
+
+// Migrations for the shared AI-account read model. Kept out of migrations.go so
+// that file stops growing with every release; auth_session_migrations.go set the
+// same precedent for identity.
+
+const aiAccountQuotaObservedAtSQL = `
+ALTER TABLE ai_account_subject_status
+ADD COLUMN IF NOT EXISTS quota_observed_at TIMESTAMPTZ;
+
+-- ai_account_subject_quota_points is only written after a successful probe, so its
+-- newest row dates the stored payload correctly even for accounts that have been
+-- failing for days (whose upstream_checked_at has moved far past the data it describes).
+UPDATE ai_account_subject_status s
+SET quota_observed_at = COALESCE(
+  (SELECT MAX(p.recorded_at) FROM ai_account_subject_quota_points p
+   WHERE p.auth_subject_id = s.auth_subject_id),
+  CASE WHEN s.last_probe_state = 'success' THEN s.upstream_checked_at END
+)
+WHERE s.quota_observed_at IS NULL AND s.quota_json <> '[]';
+`

--- a/internal/storage/postgres/audit_log_cleanup_test.go
+++ b/internal/storage/postgres/audit_log_cleanup_test.go
@@ -1,0 +1,154 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/storage/postgres/compatdriver"
+)
+
+// TestAuditLogReadNoiseCleanupMigration covers the one-time cleanup of rows the
+// pre-fix audit policy wrote for read traffic. It replays the migration SQL under
+// a throwaway version, because the shipped version has already been applied by
+// the time the fixture has rows to clean.
+func TestAuditLogReadNoiseCleanupMigration(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CLIRELAY_POSTGRES_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	ctx := context.Background()
+	db := newDisposableMigratedDB(t, ctx, dsn, "audit_noise")
+
+	// Bucket boundaries are absolute (epoch/300), and midnight UTC is aligned, so
+	// these offsets land in exactly three five-minute buckets.
+	base := "2026-08-07 00:00:00+00"
+	seed := func(offsetSeconds int, actorKind, action, resourceType, resourceID, result string) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO audit_logs (tenant_id, actor_kind, action, resource_type, resource_id, result, request_id, changes, created_at)
+			VALUES (NULL, $1, $2, $3, $4, $5, '', '{}'::jsonb, TIMESTAMPTZ '`+base+`' + make_interval(secs => $6))
+		`, actorKind, action, resourceType, resourceID, result, offsetSeconds); err != nil {
+			t.Fatalf("seed audit row: %v", err)
+		}
+	}
+
+	// The observed flood: a panel polling one read endpoint it may not call.
+	for _, offset := range []int{0, 60, 299, 300, 599, 600} {
+		seed(offset, "user_session", "management.get", "update", "progress", "denied")
+	}
+	// Reads that merely errored are no longer audit events at all.
+	for _, offset := range []int{0, 120, 240} {
+		seed(offset, "user_session", "management.get", "update", "progress", "failed")
+	}
+	// A different route is a different signature and keeps its own row per bucket.
+	seed(60, "user_session", "management.get", "update", "check", "denied")
+	// Sensitive reads stay audited under the new policy, successful or not.
+	seed(60, "user_session", "management.get", "usage", "logs/1/content", "success")
+	seed(61, "user_session", "management.get", "usage", "logs/2/content", "failed")
+	// Writes are untouched.
+	seed(60, "user_session", "management.post", "users", "u1", "success")
+	seed(61, "user_session", "management.delete", "users", "u1", "failed")
+
+	if err := ApplyMigrations(ctx, db, []Migration{
+		{Version: "test_replay_audit_log_read_noise_cleanup", SQL: auditLogReadNoiseCleanupSQL},
+	}); err != nil {
+		t.Fatalf("replay cleanup migration: %v", err)
+	}
+
+	count := func(query string, args ...any) int64 {
+		t.Helper()
+		var n int64
+		if err := db.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
+		return n
+	}
+
+	if got := count(`SELECT COUNT(*) FROM audit_logs WHERE resource_type = 'update' AND resource_id = 'progress' AND result = 'denied'`); got != 3 {
+		t.Fatalf("collapsed refusals = %d rows, want 3 (one per five-minute bucket)", got)
+	}
+	if got := count(`SELECT COUNT(*) FROM audit_logs WHERE resource_type = 'update' AND result = 'failed'`); got != 0 {
+		t.Fatalf("errored reads = %d rows, want 0", got)
+	}
+	if got := count(`SELECT COUNT(*) FROM audit_logs WHERE resource_type = 'update' AND resource_id = 'check'`); got != 1 {
+		t.Fatalf("other refused route = %d rows, want 1", got)
+	}
+	if got := count(`SELECT COUNT(*) FROM audit_logs WHERE resource_type = 'usage'`); got != 2 {
+		t.Fatalf("sensitive reads = %d rows, want 2", got)
+	}
+	if got := count(`SELECT COUNT(*) FROM audit_logs WHERE action IN ('management.post', 'management.delete')`); got != 2 {
+		t.Fatalf("writes = %d rows, want 2", got)
+	}
+	// The surviving row of each bucket is its first, so the trail still starts
+	// where the refusals started.
+	var earliest time.Time
+	if err := db.QueryRowContext(ctx, `
+		SELECT MIN(created_at) FROM audit_logs WHERE resource_type = 'update' AND resource_id = 'progress'
+	`).Scan(&earliest); err != nil {
+		t.Fatalf("read earliest surviving row: %v", err)
+	}
+	if offset := earliest.UTC().Sub(time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC)); offset != 0 {
+		t.Fatalf("earliest surviving row is %v past the base, want the first refusal", offset)
+	}
+}
+
+// newDisposableMigratedDB creates a throwaway database with the full schema so
+// migration tests cannot disturb the shared catalog.
+func newDisposableMigratedDB(t *testing.T, ctx context.Context, dsn, prefix string) *sql.DB {
+	t.Helper()
+	adminDB, err := sql.Open(driverName, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = adminDB.PingContext(ctx); err != nil {
+		_ = adminDB.Close()
+		t.Fatal(err)
+	}
+	dbName := fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+	if _, err = adminDB.ExecContext(ctx, "CREATE DATABASE "+dbName); err != nil {
+		_ = adminDB.Close()
+		t.Fatalf("create disposable db: %v", err)
+	}
+	// Registered first so LIFO cleanup runs: runtime close → drop → admin close.
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		if _, err := adminDB.ExecContext(cleanupCtx, `
+			SELECT pg_terminate_backend(pid)
+			  FROM pg_stat_activity
+			 WHERE datname = $1 AND pid <> pg_backend_pid()
+		`, dbName); err != nil {
+			t.Errorf("terminate connections on disposable db %s: %v", dbName, err)
+		}
+		if _, err := adminDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+dbName); err != nil {
+			t.Errorf("drop disposable db %s: %v", dbName, err)
+		}
+		if err := adminDB.Close(); err != nil {
+			t.Errorf("close admin db: %v", err)
+		}
+	})
+	testDSN, err := replacePostgresDatabase(dsn, dbName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open(driverName, testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close runtime db: %v", err)
+		}
+	})
+	if err = db.PingContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err = ApplyMigrations(ctx, db, RuntimeMigrations()); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+	return db
+}

--- a/internal/storage/postgres/audit_log_migrations.go
+++ b/internal/storage/postgres/audit_log_migrations.go
@@ -1,0 +1,43 @@
+package postgres
+
+// auditLogReadNoiseCleanupSQL retires the rows written by the pre-fix audit
+// policy, which recorded every non-2xx management response including plain reads.
+// A panel tab polling GET /update/progress — refused for operators without
+// system.status.read, 502 wherever the updater sidecar is absent — wrote one row
+// every two seconds; one deployment held 33,065 rows of which ~50 were real
+// events, and the governance page was 656 pages of update polling.
+//
+// The cleanup applies the new policy to the history it produced rather than
+// clearing the table: errored reads are no longer audit events and go entirely,
+// while refused reads survive collapsed to the same one-row-per-five-minutes the
+// middleware now enforces, so "this actor was refused on this route, repeatedly,
+// during these hours" is still readable. Sensitive reads (bodies, egress,
+// exports, downloads) are audited under the new policy too and are excluded.
+const auditLogReadNoiseCleanupSQL = `
+DELETE FROM audit_logs
+ WHERE action IN ('management.get', 'management.head')
+   AND result <> 'denied'
+   AND (resource_type || '/' || resource_id) NOT LIKE '%content%'
+   AND (resource_type || '/' || resource_id) NOT LIKE '%egress%'
+   AND (resource_type || '/' || resource_id) NOT LIKE '%export%'
+   AND (resource_type || '/' || resource_id) NOT LIKE '%download%';
+
+DELETE FROM audit_logs a
+ USING (
+   SELECT id,
+          row_number() OVER (
+            PARTITION BY tenant_id, actor_kind, actor_user_id, action, resource_type, resource_id, result,
+                         floor(extract(epoch FROM created_at) / 300)
+            ORDER BY created_at, id
+          ) AS repeat_rank
+     FROM audit_logs
+    WHERE action IN ('management.get', 'management.head')
+      AND result = 'denied'
+ ) collapsed
+ WHERE a.id = collapsed.id
+   AND collapsed.repeat_rank > 1;
+
+-- Retention prunes by age; the existing indexes are all tenant/actor/action
+-- prefixed and cannot serve a bare created_at range scan.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs(created_at);
+`

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -43,24 +43,11 @@ func RuntimeMigrations() []Migration {
 		// Separate "when did we last try" from "when was this quota actually observed",
 		// so a failing probe can no longer make stale quota look freshly checked.
 		{Version: "202608070001_ai_account_quota_observed_at", SQL: aiAccountQuotaObservedAtSQL},
+		// Retire audit rows written by the pre-fix policy that logged read traffic,
+		// and index created_at for the new retention pass.
+		{Version: "202608080001_audit_log_read_noise_cleanup", SQL: auditLogReadNoiseCleanupSQL},
 	}
 }
-
-const aiAccountQuotaObservedAtSQL = `
-ALTER TABLE ai_account_subject_status
-ADD COLUMN IF NOT EXISTS quota_observed_at TIMESTAMPTZ;
-
--- ai_account_subject_quota_points is only written after a successful probe, so its
--- newest row dates the stored payload correctly even for accounts that have been
--- failing for days (whose upstream_checked_at has moved far past the data it describes).
-UPDATE ai_account_subject_status s
-SET quota_observed_at = COALESCE(
-  (SELECT MAX(p.recorded_at) FROM ai_account_subject_quota_points p
-   WHERE p.auth_subject_id = s.auth_subject_id),
-  CASE WHEN s.last_probe_state = 'success' THEN s.upstream_checked_at END
-)
-WHERE s.quota_observed_at IS NULL AND s.quota_json <> '[]';
-`
 
 const aiAccountSubjectUsageTokensSQL = `
 ALTER TABLE ai_account_subject_usage_buckets

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,13 +11,26 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 26 {
-		t.Fatalf("RuntimeMigrations len = %d, want 26", len(migrations))
+	if len(migrations) != 27 {
+		t.Fatalf("RuntimeMigrations len = %d, want 27", len(migrations))
 	}
-	// Latest: quota observation time, so a failing probe stops making stale quota
-	// look freshly checked.
+	// Latest: retire the audit rows the pre-fix policy wrote for read traffic.
+	if migrations[26].Version != "202608080001_audit_log_read_noise_cleanup" {
+		t.Fatalf("latest migration version = %q", migrations[26].Version)
+	}
+	for _, fragment := range []string{
+		"DELETE FROM audit_logs",
+		"result <> 'denied'",
+		"idx_audit_logs_created_at",
+	} {
+		if !strings.Contains(migrations[26].SQL, fragment) {
+			t.Fatalf("audit log cleanup migration missing %q", fragment)
+		}
+	}
+	// Quota observation time, so a failing probe stops making stale quota look
+	// freshly checked.
 	if migrations[25].Version != "202608070001_ai_account_quota_observed_at" {
-		t.Fatalf("latest migration version = %q", migrations[25].Version)
+		t.Fatalf("quota observed_at migration version = %q", migrations[25].Version)
 	}
 	for _, fragment := range []string{
 		"ADD COLUMN IF NOT EXISTS quota_observed_at TIMESTAMPTZ",


### PR DESCRIPTION
## 问题

线上 `/manage/governance/audit-logs` 累计 33065 条日志，"安全敏感变更记录"页面变成 656 页轮询流水。Postgres 统计（时间跨度 2026-08-07 08:14 → 2026-08-08 02:01，不到 18 小时）：

```
management.get | update | progress | denied | 28435   ← 86%
management.get | update | progress | failed |  4584   ← 14%
management.post| ai-accounts | status-refresh | success | 26
其余全部个位数，真实事件约 50 条
```

`journalctl` 显示两类客户端在打同一个只读接口：一个公网客户端每 ~3s 拿 403（用户没有 `system.status.read`），浏览器面板每 ~7s 拿 502（本部署没有 updater sidecar，`/v1/status` 不可达，5s 后前端超时中断）。

根因在写入策略：`recordManagementAudit` 对所有非 2xx 的管理请求写审计行，**包含只读 GET**。只读接口失败是运行故障，属于 request log，不属于"谁改了什么"的审计轨迹。

## 改动

- **写入策略**：写操作与敏感读（content / egress / export / download）一律记录；普通读只在**被拒绝**时记录；普通读的成功与失败都不再入库。
- **拒绝去重**：同签名（租户 + 主体 + action + 资源 + 结果）5 分钟内只落一行，被折叠的次数写进 `changes.repeat.suppressed`，证据不丢。只对只读生效——写操作每次尝试都是独立事件。
- **保留策略**：`audit_logs` 此前只增不减，唯一收缩手段是面板"清空全部"（等于丢掉整条轨迹）。现按时间（默认 180 天）+ 行数上限（默认 200000）分批修剪，挂在 session reaper 的生命周期上；配置项 `remote-management.auth.audit-retention-days` / `audit-max-rows`，负值关闭对应限制。
- **历史清理迁移** `202608080001_audit_log_read_noise_cleanup`：把新策略回灌到它自己产生的历史——错误读全删；被拒读按同样的 5 分钟窗口折叠并保留每窗口最早一行，所以"谁在哪段时间被持续拒绝"仍可读；敏感读与写操作不动。同时补 `idx_audit_logs_created_at` 供保留策略做时间范围扫描。

`migrations.go` 已在结构债基线（881 行）上限，因此把新 SQL 与最近一条 AI account 迁移拆到独立文件（沿用 `auth_session_migrations.go` 的既有约定），文件收缩到 868 行并更新基线。基线更新同时锁定了一条来自 dev 的无关改善（`aiaccountstatus/service.go` 1001 → 1000）。

前端配套 PR（权限门控 + 空闲轮询降频）在 codeProxy，建议本 PR 先合并部署。

## 验证

本地完整 `./scripts/ci-pr.sh` 通过（结构检查、gofmt、密钥扫描、`go vet`、`go test ./...`、updater 子模块、golangci-lint 1.64.5、build），Postgres 集成用例由本地 `postgres:15-alpine` 提供 `CLIRELAY_POSTGRES_TEST_DSN`。

新增用例：

- `TestManagementAuditRecordsOnlySecurityRelevantRequests`：5 次失败读 → 0 行；20 次被拒读 → 恰好 1 行；3 次失败写 → 3 行；2 次被拒写 → 2 行。
- `TestPostgresPruneAuditLogs`：按时间删 5 行、按行数上限删 4 行、再跑一次为 0。
- `TestAuditLogReadNoiseCleanupMigration`：6 条被拒读折叠成 3 条（每 5 分钟窗口保留最早一条），3 条错误读清零，敏感读与写操作原样保留。
- `audit_policy_test.go`：策略判定表 + 去重窗口、签名隔离、空闲清扫、nil 限流器。

已知环境噪声：`GET /v0/management/latest-version` 会打真实 GitHub API，本机出口 IP 触发匿名限流时返回 502。已在**未带本改动的干净 dev** 上复现同样失败，与本 PR 无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)