### PR TITLE
feat(moderation): add qwen3guard backend alongside openai moderations

### DIFF
--- a/internal/contentmoderation/backend_config_test.go
+++ b/internal/contentmoderation/backend_config_test.go
@@ -1,0 +1,210 @@
+package contentmoderation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateProfileBackendRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   CreateProfileInput
+		wantErr string
+	}{
+		{
+			name:  "openai defaults fill endpoint",
+			input: CreateProfileInput{Name: "openai", Mode: ModePreBlock, APIKey: "sk-test"},
+		},
+		{
+			name:    "openai still requires an api key",
+			input:   CreateProfileInput{Name: "openai", Mode: ModePreBlock},
+			wantErr: "api_key is required",
+		},
+		{
+			name:    "unknown backend rejected",
+			input:   CreateProfileInput{Name: "x", Backend: "azure_content_safety"},
+			wantErr: "backend must be",
+		},
+		{
+			name:    "qwen3guard needs a base url in pre_block",
+			input:   CreateProfileInput{Name: "guard", Mode: ModePreBlock, Backend: BackendQwen3Guard, Model: "qwen3guard"},
+			wantErr: "base_url is required",
+		},
+		{
+			name:    "qwen3guard needs a model in pre_block",
+			input:   CreateProfileInput{Name: "guard", Mode: ModePreBlock, Backend: BackendQwen3Guard, BaseURL: "http://guard:8000"},
+			wantErr: "model is required",
+		},
+		{
+			name:  "qwen3guard does not require an api key",
+			input: CreateProfileInput{Name: "guard", Mode: ModePreBlock, Backend: BackendQwen3Guard, BaseURL: "http://guard:8000", Model: "qwen3guard"},
+		},
+		{
+			name:  "qwen3guard off may stay unconfigured",
+			input: CreateProfileInput{Name: "guard", Mode: ModeOff, Backend: BackendQwen3Guard},
+		},
+		{
+			name:  "qwen3guard keyword_only needs no endpoint",
+			input: CreateProfileInput{Name: "guard", Mode: ModePreBlock, Backend: BackendQwen3Guard, KeywordMode: KeywordModeKeywordOnly},
+		},
+		{
+			name:    "unknown scanner rejected",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, Scanners: []string{"telepathy"}},
+			wantErr: "unknown scanner category",
+		},
+		{
+			name:    "unknown elevated category rejected",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, ElevatedCategories: []string{"telepathy"}},
+			wantErr: "unknown elevated category",
+		},
+		{
+			name:    "unknown controversial action rejected",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, ControversialAction: "warn"},
+			wantErr: "controversial_action must be",
+		},
+		{
+			name:    "input limit floor enforced",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, InputLimit: 8},
+			wantErr: "input_limit must be",
+		},
+		{
+			name:    "max chunks ceiling enforced",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, MaxChunks: MaxChunksLimit + 1},
+			wantErr: "max_chunks must be",
+		},
+		{
+			name:    "base url with credentials rejected",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, BaseURL: "http://user:pass@guard:8000"},
+			wantErr: "must not contain credentials",
+		},
+		{
+			name:    "base url with query rejected",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, BaseURL: "http://guard:8000?token=abc"},
+			wantErr: "must not contain credentials",
+		},
+		{
+			name:    "non-http scheme rejected",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, BaseURL: "ftp://guard.internal:21"},
+			wantErr: "must use http or https",
+		},
+		{
+			name:    "hostless url rejected",
+			input:   CreateProfileInput{Name: "guard", Backend: BackendQwen3Guard, BaseURL: "file:///etc/passwd"},
+			wantErr: "invalid moderation base URL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewProfile("tenant-a", "id-1", tt.input, time.Now())
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNormalizeModerationBaseURL(t *testing.T) {
+	tests := []struct {
+		raw, want string
+		wantErr   bool
+	}{
+		{raw: "https://api.openai.com", want: "https://api.openai.com"},
+		{raw: "https://api.openai.com/", want: "https://api.openai.com"},
+		// A pasted OpenAI-style base must not produce /v1/v1/....
+		{raw: "https://api.openai.com/v1", want: "https://api.openai.com"},
+		{raw: "https://api.openai.com/V1/", want: "https://api.openai.com"},
+		{raw: "http://guard.internal:8000/openai", want: "http://guard.internal:8000/openai"},
+		// Private and loopback stay reachable: guard models are usually internal.
+		{raw: "http://127.0.0.1:11434", want: "http://127.0.0.1:11434"},
+		{raw: "http://10.0.0.5:8000", want: "http://10.0.0.5:8000"},
+		{raw: "", wantErr: true},
+		{raw: "guard.internal:8000", wantErr: true},
+		{raw: "ftp://guard.internal", wantErr: true},
+		{raw: "https://user@guard.internal", wantErr: true},
+		{raw: "https://guard.internal#frag", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := normalizeModerationBaseURL(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tt.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModerationEndpointURLJoinsPaths(t *testing.T) {
+	got, err := moderationEndpointURL("https://api.openai.com/v1", "/v1/moderations")
+	if err != nil || got != "https://api.openai.com/v1/moderations" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+	got, err = moderationEndpointURL("http://guard:8000", "/v1/chat/completions")
+	if err != nil || got != "http://guard:8000/v1/chat/completions" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+// The size cap protects the hot path from an endpoint that never stops writing.
+func TestOpenAIBackendRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"padding":"` + strings.Repeat("a", int(maxModerationResponseBytes)+16) + `","results":[{"category_scores":{"hate":1}}]}`))
+	}))
+	defer server.Close()
+	profile := testProfile(t, "tenant-a", "api", ModePreBlock, KeywordModeAPIOnly)
+	profile.BaseURL = server.URL
+	decision := NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "input")
+	if decision.WouldBlock || decision.Action != ActionAPIError {
+		t.Fatalf("decision = %#v, want fail-open", decision)
+	}
+	if got := moderationErrorClass(decision.ModerationError); got != "invalid_response" {
+		t.Fatalf("error class = %q (%s)", got, decision.ModerationError)
+	}
+}
+
+func TestNormalizeCategoryAliases(t *testing.T) {
+	aliases := map[string]string{
+		"Violent":                           ScannerViolent,
+		"violence":                          ScannerViolent,
+		"Non-violent Illegal Acts":          ScannerNonViolentIllegalActs,
+		"non_violent_illegal_acts":          ScannerNonViolentIllegalActs,
+		"Sexual Content or Sexual Acts":     ScannerSexualContentOrSexualActs,
+		"sexual":                            ScannerSexualContentOrSexualActs,
+		"PII":                               ScannerPII,
+		"personal identifiable information": ScannerPII,
+		"Suicide & Self-Harm":               ScannerSuicideAndSelfHarm,
+		"suicide/self harm":                 ScannerSuicideAndSelfHarm,
+		"Unethical Acts":                    ScannerUnethicalActs,
+		"Politically Sensitive Topics":      ScannerPoliticallySensitive,
+		"Copyright Violation":               ScannerCopyrightViolation,
+		"Jailbreak":                         ScannerJailbreak,
+		"prompt injection":                  ScannerJailbreak,
+	}
+	for alias, want := range aliases {
+		if got := NormalizeCategory(alias); got != want {
+			t.Fatalf("NormalizeCategory(%q) = %q, want %q", alias, got, want)
+		}
+	}
+	if got := NormalizeCategory("Future Risk"); got != "future_risk" || IsScannerID(got) {
+		t.Fatalf("unknown category handling = %q", got)
+	}
+}

--- a/internal/contentmoderation/backend_migration_test.go
+++ b/internal/contentmoderation/backend_migration_test.go
@@ -1,0 +1,199 @@
+package contentmoderation
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// legacyProfilesTableSQL is the schema as it shipped before qwen3guard support.
+const legacyProfilesTableSQL = `
+CREATE TABLE content_moderation_profiles (
+  tenant_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  mode TEXT NOT NULL DEFAULT 'off',
+  base_url TEXT NOT NULL DEFAULT 'https://api.openai.com',
+  model TEXT NOT NULL DEFAULT 'omni-moderation-latest',
+  api_key_secret TEXT NOT NULL DEFAULT '',
+  timeout_ms INTEGER NOT NULL DEFAULT 3000,
+  keyword_mode TEXT NOT NULL DEFAULT 'api_only',
+  blocked_keywords_json TEXT NOT NULL DEFAULT '[]',
+  thresholds_json TEXT NOT NULL DEFAULT '{}',
+  block_http_status INTEGER NOT NULL DEFAULT 403,
+  block_message TEXT NOT NULL DEFAULT '',
+  version INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (tenant_id, id),
+  UNIQUE (tenant_id, name)
+);`
+
+// A profile written by the previous release must keep behaving exactly as it
+// did: OpenAI moderations, same endpoint, same thresholds.
+func TestInitTablesMigratesLegacyProfilesToOpenAIBackend(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "legacy.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err = db.Exec(legacyProfilesTableSQL); err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	if _, err = db.Exec(`INSERT INTO content_moderation_profiles
+		(tenant_id,id,name,mode,base_url,model,api_key_secret,timeout_ms,keyword_mode,blocked_keywords_json,thresholds_json,block_http_status,block_message,version,created_at,updated_at)
+		VALUES ('tenant-a','legacy-1','legacy','pre_block','https://api.openai.com','omni-moderation-latest','sk-legacy',3000,'api_only','["bad"]','{"hate":0.5}',403,'blocked',7,'2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	if err = InitTables(db); err != nil {
+		t.Fatalf("InitTables: %v", err)
+	}
+	// Re-running must stay a no-op; duplicate-column errors are expected and ignored.
+	if err = InitTables(db); err != nil {
+		t.Fatalf("InitTables is not idempotent: %v", err)
+	}
+
+	profile, err := NewStore(db).GetProfile(context.Background(), "tenant-a", "legacy-1")
+	if err != nil {
+		t.Fatalf("GetProfile: %v", err)
+	}
+	if profile.Backend != BackendOpenAIModerations {
+		t.Fatalf("backend = %q, want the pre-migration behaviour", profile.Backend)
+	}
+	if profile.ControversialAction != ControversialActionElevatedOnly {
+		t.Fatalf("controversial_action = %q", profile.ControversialAction)
+	}
+	if profile.InputLimit != DefaultInputLimit || profile.MaxChunks != DefaultMaxChunks {
+		t.Fatalf("chunking defaults = %d/%d", profile.InputLimit, profile.MaxChunks)
+	}
+	if len(profile.Scanners) != 0 {
+		t.Fatalf("scanners = %v, want empty", profile.Scanners)
+	}
+	if len(profile.ElevatedCategories) != len(DefaultElevatedCategories()) {
+		t.Fatalf("elevated categories = %v", profile.ElevatedCategories)
+	}
+	// Untouched fields must survive the migration verbatim.
+	if profile.Version != 7 || profile.APIKeySecret != "sk-legacy" || profile.Thresholds["hate"] != 0.5 {
+		t.Fatalf("legacy values changed: %#v", profile)
+	}
+
+	// And the runtime path must still speak the moderations protocol.
+	var path string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"category_scores":{"hate":0.9}}]}`))
+	}))
+	defer server.Close()
+	profile.BaseURL = server.URL
+	decision := NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "input")
+	if path != "/v1/moderations" {
+		t.Fatalf("legacy profile called %q", path)
+	}
+	if !decision.WouldBlock || decision.Action != ActionAPIBlock {
+		t.Fatalf("decision = %#v", decision)
+	}
+	if decision.Safety != "" || len(decision.Categories) != 0 {
+		t.Fatalf("guard-only fields leaked into an OpenAI decision: %#v", decision)
+	}
+}
+
+func TestStoreRoundTripsBackendFields(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	profile, err := NewProfile("tenant-a", "guard-1", CreateProfileInput{
+		Name:                "guard",
+		Mode:                ModePreBlock,
+		Backend:             BackendQwen3Guard,
+		BaseURL:             "http://guard.internal:8000",
+		Model:               "qwen3guard",
+		KeywordMode:         KeywordModeAPIOnly,
+		Scanners:            []string{ScannerJailbreak, ScannerPII},
+		ControversialAction: ControversialActionBlock,
+		ElevatedCategories:  []string{ScannerJailbreak},
+		InputLimit:          2000,
+		MaxChunks:           2,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if err = store.CreateProfile(ctx, profile); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	stored, err := store.GetProfile(ctx, "tenant-a", "guard-1")
+	if err != nil {
+		t.Fatalf("GetProfile: %v", err)
+	}
+	if stored.Backend != BackendQwen3Guard || stored.ControversialAction != ControversialActionBlock {
+		t.Fatalf("stored = %#v", stored)
+	}
+	if stored.InputLimit != 2000 || stored.MaxChunks != 2 {
+		t.Fatalf("chunking = %d/%d", stored.InputLimit, stored.MaxChunks)
+	}
+	if len(stored.Scanners) != 2 || stored.Scanners[0] != ScannerPII || stored.Scanners[1] != ScannerJailbreak {
+		t.Fatalf("scanners = %v, want catalog order", stored.Scanners)
+	}
+	if len(stored.ElevatedCategories) != 1 || stored.ElevatedCategories[0] != ScannerJailbreak {
+		t.Fatalf("elevated = %v", stored.ElevatedCategories)
+	}
+
+	updated, err := ApplyProfilePatch(stored, PatchProfileInput{
+		Scanners:            &[]string{ScannerViolent},
+		ControversialAction: strPtr(ControversialActionAllow),
+		Version:             stored.Version,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("ApplyProfilePatch: %v", err)
+	}
+	if err = store.UpdateProfile(ctx, updated, stored.Version); err != nil {
+		t.Fatalf("UpdateProfile: %v", err)
+	}
+	reloaded, err := store.GetProfile(ctx, "tenant-a", "guard-1")
+	if err != nil {
+		t.Fatalf("GetProfile after patch: %v", err)
+	}
+	if len(reloaded.Scanners) != 1 || reloaded.Scanners[0] != ScannerViolent {
+		t.Fatalf("scanners = %v", reloaded.Scanners)
+	}
+	if reloaded.ControversialAction != ControversialActionAllow {
+		t.Fatalf("controversial_action = %q", reloaded.ControversialAction)
+	}
+}
+
+// An explicitly empty elevated list means "never escalate" and must not be
+// silently refilled with the recommended defaults.
+func TestExplicitlyEmptyElevatedCategoriesSurvive(t *testing.T) {
+	profile, err := NewProfile("tenant-a", "guard-2", CreateProfileInput{
+		Name:               "guard",
+		Mode:               ModeOff,
+		Backend:            BackendQwen3Guard,
+		ElevatedCategories: []string{},
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if len(profile.ElevatedCategories) != 0 {
+		t.Fatalf("elevated = %v, want empty", profile.ElevatedCategories)
+	}
+	omitted, err := NewProfile("tenant-a", "guard-3", CreateProfileInput{
+		Name:    "guard-default",
+		Mode:    ModeOff,
+		Backend: BackendQwen3Guard,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if len(omitted.ElevatedCategories) != len(DefaultElevatedCategories()) {
+		t.Fatalf("elevated = %v, want recommended defaults", omitted.ElevatedCategories)
+	}
+}
+
+func strPtr(value string) *string { return &value }

--- a/internal/contentmoderation/backend_openai.go
+++ b/internal/contentmoderation/backend_openai.go
@@ -1,0 +1,70 @@
+package contentmoderation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// openaiModerationsBackend targets the OpenAI /v1/moderations API, which
+// returns a per-category score map compared against the profile thresholds.
+type openaiModerationsBackend struct {
+	httpClient *http.Client
+}
+
+func (b *openaiModerationsBackend) Check(ctx context.Context, profile Profile, input string) (backendResult, error) {
+	endpoint, err := moderationEndpointURL(profile.BaseURL, "/v1/moderations")
+	if err != nil {
+		return backendResult{}, err
+	}
+	payload, err := json.Marshal(struct {
+		Model string `json:"model"`
+		Input string `json:"input"`
+	}{Model: profile.Model, Input: input})
+	if err != nil {
+		return backendResult{}, fmt.Errorf("encode moderation request: %w", err)
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, time.Duration(profile.TimeoutMS)*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return backendResult{}, fmt.Errorf("create moderation request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+profile.APIKeySecret)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return backendResult{}, fmt.Errorf("moderation request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return backendResult{}, fmt.Errorf("moderation API returned status %d", resp.StatusCode)
+	}
+	body, err := readModerationResponse(resp)
+	if err != nil {
+		return backendResult{}, err
+	}
+	var result struct {
+		Results []struct {
+			CategoryScores map[string]float64 `json:"category_scores"`
+		} `json:"results"`
+	}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return backendResult{}, fmt.Errorf("decode moderation response: %w", err)
+	}
+	if len(result.Results) == 0 || result.Results[0].CategoryScores == nil {
+		return backendResult{}, fmt.Errorf("moderation response missing category scores")
+	}
+	scores := result.Results[0].CategoryScores
+	thresholds := mergeThresholds(profile.Thresholds)
+	block := false
+	for category, score := range scores {
+		if threshold, ok := thresholds[category]; ok && score >= threshold {
+			block = true
+		}
+	}
+	return backendResult{Scores: scores, Block: block}, nil
+}

--- a/internal/contentmoderation/backend_qwen3guard.go
+++ b/internal/contentmoderation/backend_qwen3guard.go
@@ -1,0 +1,359 @@
+package contentmoderation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	safetySafe          = "Safe"
+	safetyControversial = "Controversial"
+	safetyUnsafe        = "Unsafe"
+
+	// guardMaxTokens follows the Qwen3Guard model card's max_new_tokens=128.
+	// A tighter cap risks truncating the "Categories:" line mid-list: the
+	// prefix has already been emitted at that point, so parsing succeeds and
+	// silently loses the tail categories — exactly when the most categories
+	// matched, i.e. the worst moment to under-report.
+	guardMaxTokens = 128
+)
+
+var errGuardInvalidResponse = errors.New("qwen3guard response is not a valid verdict")
+
+// guardVerdict is one parsed Qwen3Guard reply, before profile policy applies.
+type guardVerdict struct {
+	Safety            string
+	Categories        []string
+	UnknownCategories []string
+}
+
+// qwen3GuardBackend drives a Qwen3Guard-Gen model over an OpenAI-compatible
+// chat completions endpoint (vLLM, SGLang, Ollama or a hosted equivalent). The
+// model replies with a fixed two-line text verdict rather than scores:
+//
+//	Safety: Safe | Controversial | Unsafe
+//	Categories: Violent, Jailbreak, ...
+type qwen3GuardBackend struct {
+	httpClient *http.Client
+}
+
+func (b *qwen3GuardBackend) Check(ctx context.Context, profile Profile, input string) (backendResult, error) {
+	// TimeoutMS budgets the entire evaluation. Chunks run under one deadline so
+	// a long prompt cannot multiply the latency the caller was promised.
+	budgetCtx, cancel := context.WithTimeout(ctx, time.Duration(profile.TimeoutMS)*time.Millisecond)
+	defer cancel()
+
+	chunks, truncatedRunes := splitForGuard(input, profile.InputLimit, profile.MaxChunks)
+	if len(chunks) == 0 {
+		return backendResult{}, nil
+	}
+	if truncatedRunes > 0 {
+		// Never drop input silently: an unscanned tail is a coverage gap the
+		// operator has to be able to see and fix by raising the limits.
+		log.WithFields(log.Fields{
+			"profile_id":      profile.ID,
+			"input_limit":     profile.InputLimit,
+			"max_chunks":      profile.MaxChunks,
+			"truncated_chars": truncatedRunes,
+		}).Warn("content moderation truncated input before qwen3guard scan")
+	}
+
+	aggregate := backendResult{Scores: map[string]float64{}}
+	categories := make(map[string]struct{})
+	matched := make(map[string]struct{})
+	unknown := make(map[string]struct{})
+	// Chunks run serially: guard deployments are typically a single small
+	// instance, and firing every chunk at once would only stall them all.
+	for _, chunk := range chunks {
+		verdict, err := b.scanChunk(budgetCtx, profile, chunk)
+		if err != nil {
+			return backendResult{}, err
+		}
+		chunkMatched, block := decideGuardVerdict(profile, verdict)
+		if guardSeverity(verdict.Safety) > guardSeverity(aggregate.Safety) {
+			aggregate.Safety = verdict.Safety
+		}
+		for _, category := range verdict.Categories {
+			categories[category] = struct{}{}
+		}
+		for _, category := range verdict.UnknownCategories {
+			unknown[category] = struct{}{}
+		}
+		score := guardScore(verdict.Safety)
+		for _, category := range chunkMatched {
+			matched[category] = struct{}{}
+			if score > aggregate.Scores[category] {
+				aggregate.Scores[category] = score
+			}
+		}
+		if block {
+			aggregate.Block = true
+			break
+		}
+	}
+	aggregate.Categories = orderedScannerKeys(categories)
+	aggregate.MatchedScanners = orderedScannerKeys(matched)
+	aggregate.UnknownCategories = sortedKeys(unknown)
+	return aggregate, nil
+}
+
+func (b *qwen3GuardBackend) scanChunk(ctx context.Context, profile Profile, chunk string) (guardVerdict, error) {
+	endpoint, err := moderationEndpointURL(profile.BaseURL, "/v1/chat/completions")
+	if err != nil {
+		return guardVerdict{}, err
+	}
+	// No "seed": the model card does not ask for it and temperature 0 is
+	// already deterministic enough for classification, so we avoid sending a
+	// non-standard field that some OpenAI-compatible servers reject outright.
+	payload, err := json.Marshal(map[string]any{
+		"model":       profile.Model,
+		"messages":    []map[string]string{{"role": "user", "content": chunk}},
+		"temperature": 0,
+		"max_tokens":  guardMaxTokens,
+	})
+	if err != nil {
+		return guardVerdict{}, fmt.Errorf("encode qwen3guard request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return guardVerdict{}, fmt.Errorf("create qwen3guard request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Self-hosted guard endpoints frequently run unauthenticated.
+	if profile.APIKeySecret != "" {
+		req.Header.Set("Authorization", "Bearer "+profile.APIKeySecret)
+	}
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return guardVerdict{}, fmt.Errorf("qwen3guard request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return guardVerdict{}, fmt.Errorf("qwen3guard API returned status %d", resp.StatusCode)
+	}
+	body, err := readModerationResponse(resp)
+	if err != nil {
+		return guardVerdict{}, err
+	}
+	content, err := extractChatContent(body)
+	if err != nil {
+		return guardVerdict{}, err
+	}
+	return parseQwen3Guard(content)
+}
+
+// parseQwen3Guard reads the model's verdict lines.
+//
+// Line-prefix matching is deliberately stricter than the regex in the model
+// card: a duplicated Safety/Categories line means the model went off-script,
+// and picking the first match (as a regex would) would hide that. An invalid
+// verdict surfaces as an error so the caller fails open on an explicit
+// dependency failure rather than on a guessed verdict.
+func parseQwen3Guard(content string) (guardVerdict, error) {
+	var safety, categoryLine string
+	var sawCategories bool
+	for _, line := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		switch {
+		case strings.HasPrefix(lower, "safety:"):
+			if safety != "" {
+				return guardVerdict{}, errGuardInvalidResponse
+			}
+			safety = strings.TrimSpace(line[len("safety:"):])
+		case strings.HasPrefix(lower, "categories:"):
+			if sawCategories {
+				return guardVerdict{}, errGuardInvalidResponse
+			}
+			sawCategories = true
+			categoryLine = strings.TrimSpace(line[len("categories:"):])
+		default:
+			// Response-moderation emits an extra "Refusal:" line and models may
+			// append prose. Neither affects a prompt-moderation verdict.
+		}
+	}
+	switch strings.ToLower(safety) {
+	case "safe":
+		safety = safetySafe
+	case "controversial":
+		safety = safetyControversial
+	case "unsafe":
+		safety = safetyUnsafe
+	default:
+		return guardVerdict{}, errGuardInvalidResponse
+	}
+	if !sawCategories {
+		return guardVerdict{}, errGuardInvalidResponse
+	}
+	known := make(map[string]struct{})
+	unknown := make(map[string]struct{})
+	for _, raw := range strings.Split(categoryLine, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" || strings.EqualFold(raw, "none") || strings.EqualFold(raw, "n/a") {
+			continue
+		}
+		category := NormalizeCategory(raw)
+		if IsScannerID(category) {
+			known[category] = struct{}{}
+		} else {
+			unknown[unknownCategoryID(category)] = struct{}{}
+		}
+	}
+	return guardVerdict{
+		Safety:            safety,
+		Categories:        orderedScannerKeys(known),
+		UnknownCategories: sortedKeys(unknown),
+	}, nil
+}
+
+// decideGuardVerdict applies profile policy to one parsed verdict and reports
+// the enabled categories it matched.
+func decideGuardVerdict(profile Profile, verdict guardVerdict) ([]string, bool) {
+	enabled := profile.Scanners
+	// An empty scanner list means the operator watches every category.
+	if len(enabled) == 0 {
+		enabled = AllScannerIDs
+	}
+	enabledSet := make(map[string]struct{}, len(enabled))
+	for _, category := range enabled {
+		enabledSet[category] = struct{}{}
+	}
+	matched := make([]string, 0, len(verdict.Categories))
+	for _, category := range verdict.Categories {
+		if _, ok := enabledSet[category]; ok {
+			matched = append(matched, category)
+		}
+	}
+	switch verdict.Safety {
+	case safetyUnsafe:
+		// The model flagged content, but if every category it named is one the
+		// operator switched off, respect that and allow. Unnamed or
+		// out-of-catalog risks still block: we cannot prove they were opted out.
+		if len(matched) == 0 && len(verdict.Categories) > 0 && len(verdict.UnknownCategories) == 0 {
+			return matched, false
+		}
+		return matched, true
+	case safetyControversial:
+		switch profile.ControversialAction {
+		case ControversialActionBlock:
+			return matched, true
+		case ControversialActionAllow:
+			return matched, false
+		default:
+			// elevated_only: block only on categories whose false-negative cost
+			// outweighs a false positive (see DefaultElevatedCategories).
+			elevated := make(map[string]struct{}, len(profile.ElevatedCategories))
+			for _, category := range profile.ElevatedCategories {
+				elevated[category] = struct{}{}
+			}
+			for _, category := range matched {
+				if _, ok := elevated[category]; ok {
+					return matched, true
+				}
+			}
+			return matched, false
+		}
+	default:
+		return matched, false
+	}
+}
+
+// splitForGuard slices input into rune-safe chunks, returning how many runes
+// were dropped past the max_chunks ceiling.
+func splitForGuard(value string, limit, maxChunks int) ([]string, int) {
+	if limit <= 0 {
+		limit = DefaultInputLimit
+	}
+	if maxChunks <= 0 {
+		maxChunks = DefaultMaxChunks
+	}
+	runes := []rune(value)
+	chunks := make([]string, 0, maxChunks)
+	for start := 0; start < len(runes); start += limit {
+		if len(chunks) == maxChunks {
+			return chunks, len(runes) - start
+		}
+		end := start + limit
+		if end > len(runes) {
+			end = len(runes)
+		}
+		chunks = append(chunks, string(runes[start:end]))
+	}
+	return chunks, 0
+}
+
+// extractChatContent pulls the assistant text out of a chat completion, also
+// accepting the content-block array form some servers return.
+func extractChatContent(body []byte) (string, error) {
+	var response struct {
+		Choices []struct {
+			Message struct {
+				Content any `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil || len(response.Choices) == 0 {
+		return "", fmt.Errorf("decode qwen3guard response: %w", errGuardInvalidResponse)
+	}
+	switch typed := response.Choices[0].Message.Content.(type) {
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return "", errGuardInvalidResponse
+		}
+		return typed, nil
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			object, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := object["text"].(string); ok && strings.TrimSpace(text) != "" {
+				parts = append(parts, text)
+			}
+		}
+		if len(parts) == 0 {
+			return "", errGuardInvalidResponse
+		}
+		return strings.Join(parts, "\n"), nil
+	default:
+		return "", errGuardInvalidResponse
+	}
+}
+
+func guardSeverity(safety string) int {
+	switch safety {
+	case safetyUnsafe:
+		return 3
+	case safetyControversial:
+		return 2
+	case safetySafe:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// guardScore projects the three-state verdict onto the numeric scale the
+// existing Decision fields, logs and admin UI already understand.
+func guardScore(safety string) float64 {
+	switch safety {
+	case safetyUnsafe:
+		return 1
+	case safetyControversial:
+		return 0.5
+	default:
+		return 0
+	}
+}

--- a/internal/contentmoderation/backend_qwen3guard_test.go
+++ b/internal/contentmoderation/backend_qwen3guard_test.go
@@ -1,0 +1,473 @@
+package contentmoderation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func decodeJSON(r *http.Request, target any) error {
+	return json.NewDecoder(r.Body).Decode(target)
+}
+
+// recordedPaths collects request paths across the test server's goroutines.
+type recordedPaths struct {
+	mu     sync.Mutex
+	values []string
+}
+
+func (p *recordedPaths) add(value string) {
+	p.mu.Lock()
+	p.values = append(p.values, value)
+	p.mu.Unlock()
+}
+
+func (p *recordedPaths) snapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.values...)
+}
+
+func guardProfile(t *testing.T, baseURL string) Profile {
+	t.Helper()
+	profile, err := NewProfile("tenant-a", "profile-guard", CreateProfileInput{
+		Name:        "guard",
+		Mode:        ModePreBlock,
+		Backend:     BackendQwen3Guard,
+		BaseURL:     baseURL,
+		Model:       "qwen3guard",
+		KeywordMode: KeywordModeAPIOnly,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	return profile
+}
+
+// guardServer replies with the given verdicts in order, recording the requests.
+func guardServer(t *testing.T, verdicts ...string) (*httptest.Server, *recordedPaths, *atomic.Int32) {
+	t.Helper()
+	paths := &recordedPaths{}
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		index := int(calls.Add(1)) - 1
+		paths.add(r.URL.Path)
+		verdict := verdicts[len(verdicts)-1]
+		if index < len(verdicts) {
+			verdict = verdicts[index]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":` + jsonString(verdict) + `}}]}`))
+	}))
+	t.Cleanup(server.Close)
+	return server, paths, &calls
+}
+
+func jsonString(value string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(value, `"`, `\"`), "\n", `\n`) + `"`
+}
+
+func TestParseQwen3GuardVerdicts(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantSafety string
+		wantKnown  []string
+		wantErr    bool
+	}{
+		{"safe", "Safety: Safe\nCategories: None", safetySafe, nil, false},
+		{"unsafe", "Safety: Unsafe\nCategories: Violent", safetyUnsafe, []string{ScannerViolent}, false},
+		{"controversial", "Safety: Controversial\nCategories: PII", safetyControversial, []string{ScannerPII}, false},
+		{"crlf and blank lines", "Safety: Unsafe\r\n\r\nCategories: Jailbreak\r\n", safetyUnsafe, []string{ScannerJailbreak}, false},
+		{"lowercase labels", "safety: unsafe\ncategories: jailbreak", safetyUnsafe, []string{ScannerJailbreak}, false},
+		{"refusal line ignored", "Safety: Unsafe\nCategories: Violent\nRefusal: Yes", safetyUnsafe, []string{ScannerViolent}, false},
+		{"trailing prose ignored", "Safety: Safe\nCategories: None\nThis prompt is fine.", safetySafe, nil, false},
+		{"n/a categories", "Safety: Safe\nCategories: N/A", safetySafe, nil, false},
+		{"duplicate safety", "Safety: Safe\nSafety: Unsafe\nCategories: None", "", nil, true},
+		{"duplicate categories", "Safety: Safe\nCategories: None\nCategories: PII", "", nil, true},
+		{"missing categories", "Safety: Safe", "", nil, true},
+		{"missing safety", "Categories: None", "", nil, true},
+		{"unknown safety", "Safety: Maybe\nCategories: None", "", nil, true},
+		{"empty", "", "", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verdict, err := parseQwen3Guard(tt.content)
+			if tt.wantErr {
+				if !errors.Is(err, errGuardInvalidResponse) {
+					t.Fatalf("expected invalid verdict error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseQwen3Guard: %v", err)
+			}
+			if verdict.Safety != tt.wantSafety {
+				t.Fatalf("safety = %q, want %q", verdict.Safety, tt.wantSafety)
+			}
+			if len(verdict.Categories) != len(tt.wantKnown) {
+				t.Fatalf("categories = %v, want %v", verdict.Categories, tt.wantKnown)
+			}
+			for i, category := range tt.wantKnown {
+				if verdict.Categories[i] != category {
+					t.Fatalf("categories = %v, want %v", verdict.Categories, tt.wantKnown)
+				}
+			}
+		})
+	}
+}
+
+// The nine labels come straight from the Qwen3Guard model card; if the catalog
+// or the aliases drift, real verdicts would silently degrade into unknowns.
+func TestParseQwen3GuardOfficialCategorySet(t *testing.T) {
+	const official = "Violent, Non-violent Illegal Acts, Sexual Content or Sexual Acts, PII, " +
+		"Suicide & Self-Harm, Unethical Acts, Politically Sensitive Topics, Copyright Violation, Jailbreak"
+	verdict, err := parseQwen3Guard("Safety: Unsafe\nCategories: " + official)
+	if err != nil {
+		t.Fatalf("parseQwen3Guard: %v", err)
+	}
+	if len(verdict.UnknownCategories) != 0 {
+		t.Fatalf("unknown categories = %v, want none", verdict.UnknownCategories)
+	}
+	if len(verdict.Categories) != len(AllScannerIDs) {
+		t.Fatalf("categories = %v, want all %d", verdict.Categories, len(AllScannerIDs))
+	}
+	for i, category := range AllScannerIDs {
+		if verdict.Categories[i] != category {
+			t.Fatalf("categories = %v, want %v", verdict.Categories, AllScannerIDs)
+		}
+	}
+}
+
+// A truncated Categories line still parses (the prefix was emitted), so the
+// leftover fragment must not be silently ignored: it becomes an unknown
+// category, which keeps an Unsafe verdict blocking.
+func TestParseQwen3GuardTruncatedCategoryLineBlocks(t *testing.T) {
+	verdict, err := parseQwen3Guard("Safety: Unsafe\nCategories: Violent, Non-vio")
+	if err != nil {
+		t.Fatalf("parseQwen3Guard: %v", err)
+	}
+	if len(verdict.UnknownCategories) != 1 {
+		t.Fatalf("unknown categories = %v, want one fragment", verdict.UnknownCategories)
+	}
+	if !strings.HasPrefix(verdict.UnknownCategories[0], "unknown:") {
+		t.Fatalf("unknown category %q should be hashed", verdict.UnknownCategories[0])
+	}
+	profile := Profile{Scanners: []string{ScannerPII}}
+	if _, block := decideGuardVerdict(profile, verdict); !block {
+		t.Fatal("unsafe verdict with an unknown category must block")
+	}
+}
+
+func TestDecideGuardVerdict(t *testing.T) {
+	elevated := DefaultElevatedCategories()
+	tests := []struct {
+		name       string
+		profile    Profile
+		verdict    guardVerdict
+		wantBlock  bool
+		wantMatch  int
+		wantReason string
+	}{
+		{
+			name:      "safe allows",
+			profile:   Profile{ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetySafe},
+			wantBlock: false,
+		},
+		{
+			name:      "unsafe blocks",
+			profile:   Profile{ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyUnsafe, Categories: []string{ScannerViolent}},
+			wantBlock: true, wantMatch: 1,
+		},
+		{
+			name:      "unsafe with only disabled categories allows",
+			profile:   Profile{Scanners: []string{ScannerPII}, ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyUnsafe, Categories: []string{ScannerViolent}},
+			wantBlock: false,
+		},
+		{
+			name:      "unsafe without any category blocks",
+			profile:   Profile{Scanners: []string{ScannerPII}, ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyUnsafe},
+			wantBlock: true,
+		},
+		{
+			name:      "unsafe with unknown category blocks",
+			profile:   Profile{Scanners: []string{ScannerPII}, ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyUnsafe, Categories: []string{ScannerViolent}, UnknownCategories: []string{"unknown:abcd"}},
+			wantBlock: true,
+		},
+		{
+			name:      "controversial jailbreak escalates",
+			profile:   Profile{ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyControversial, Categories: []string{ScannerJailbreak}},
+			wantBlock: true, wantMatch: 1,
+		},
+		{
+			name:      "controversial pii escalates",
+			profile:   Profile{ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyControversial, Categories: []string{ScannerPII}},
+			wantBlock: true, wantMatch: 1,
+		},
+		{
+			name:      "controversial self harm escalates",
+			profile:   Profile{ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyControversial, Categories: []string{ScannerSuicideAndSelfHarm}},
+			wantBlock: true, wantMatch: 1,
+		},
+		{
+			name:      "controversial non-elevated allows",
+			profile:   Profile{ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyControversial, Categories: []string{ScannerViolent}},
+			wantBlock: false, wantMatch: 1,
+		},
+		{
+			name:      "controversial elevated but scanner disabled allows",
+			profile:   Profile{Scanners: []string{ScannerViolent}, ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyControversial, Categories: []string{ScannerJailbreak}},
+			wantBlock: false,
+		},
+		{
+			name:      "controversial action block blocks anything",
+			profile:   Profile{ControversialAction: ControversialActionBlock, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyControversial, Categories: []string{ScannerViolent}},
+			wantBlock: true, wantMatch: 1,
+		},
+		{
+			name:      "controversial action allow never blocks",
+			profile:   Profile{ControversialAction: ControversialActionAllow, ElevatedCategories: elevated},
+			verdict:   guardVerdict{Safety: safetyControversial, Categories: []string{ScannerJailbreak}},
+			wantBlock: false, wantMatch: 1,
+		},
+		{
+			name:      "empty elevated list never escalates",
+			profile:   Profile{ControversialAction: ControversialActionElevatedOnly, ElevatedCategories: []string{}},
+			verdict:   guardVerdict{Safety: safetyControversial, Categories: []string{ScannerJailbreak}},
+			wantBlock: false, wantMatch: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, block := decideGuardVerdict(tt.profile, tt.verdict)
+			if block != tt.wantBlock {
+				t.Fatalf("block = %v, want %v", block, tt.wantBlock)
+			}
+			if len(matched) != tt.wantMatch {
+				t.Fatalf("matched = %v, want %d entries", matched, tt.wantMatch)
+			}
+		})
+	}
+}
+
+func TestSplitForGuardChunksAndTruncates(t *testing.T) {
+	// Multi-byte runes must not be split mid-character.
+	input := strings.Repeat("中", 10)
+	chunks, truncated := splitForGuard(input, 4, 2)
+	if len(chunks) != 2 || truncated != 2 {
+		t.Fatalf("chunks = %v truncated = %d", chunks, truncated)
+	}
+	if chunks[0] != strings.Repeat("中", 4) || chunks[1] != strings.Repeat("中", 4) {
+		t.Fatalf("chunks = %v", chunks)
+	}
+	chunks, truncated = splitForGuard("short", 4000, 4)
+	if len(chunks) != 1 || truncated != 0 {
+		t.Fatalf("chunks = %v truncated = %d", chunks, truncated)
+	}
+	if chunks, truncated = splitForGuard("", 4000, 4); len(chunks) != 0 || truncated != 0 {
+		t.Fatalf("empty input produced chunks = %v truncated = %d", chunks, truncated)
+	}
+}
+
+func TestGuardBackendUsesChatCompletionsAndStopsAtFirstBlock(t *testing.T) {
+	server, paths, calls := guardServer(t,
+		"Safety: Safe\nCategories: None",
+		"Safety: Unsafe\nCategories: Violent",
+		"Safety: Safe\nCategories: None",
+	)
+	profile := guardProfile(t, server.URL)
+	profile.InputLimit = MinInputLimit
+	profile.MaxChunks = 4
+	decision := NewEvaluator(server.Client()).Evaluate(context.Background(), profile, strings.Repeat("a", MinInputLimit*3))
+	if !decision.WouldBlock || decision.Action != ActionGuardBlock {
+		t.Fatalf("decision = %#v", decision)
+	}
+	if decision.Safety != safetyUnsafe {
+		t.Fatalf("safety = %q", decision.Safety)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("guard called %d times, want 2 (stop after the blocking chunk)", got)
+	}
+	for _, path := range paths.snapshot() {
+		if path != "/v1/chat/completions" {
+			t.Fatalf("guard requested %q, want /v1/chat/completions", path)
+		}
+	}
+}
+
+func TestGuardBackendNeverCallsModerationsEndpoint(t *testing.T) {
+	server, paths, _ := guardServer(t, "Safety: Safe\nCategories: None")
+	profile := guardProfile(t, server.URL)
+	NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "hello")
+	for _, path := range paths.snapshot() {
+		if strings.Contains(path, "moderations") {
+			t.Fatalf("qwen3guard backend must not call %q", path)
+		}
+	}
+}
+
+func TestGuardBackendRequestShape(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = decodeJSON(r, &body)
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("unauthenticated profile sent Authorization %q", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"Safety: Safe\nCategories: None"}}]}`))
+	}))
+	defer server.Close()
+	profile := guardProfile(t, server.URL)
+	NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "hello")
+	if _, exists := body["seed"]; exists {
+		t.Fatal("seed must not be sent: it is non-standard and some servers reject it")
+	}
+	if got, ok := body["max_tokens"].(float64); !ok || int(got) != guardMaxTokens {
+		t.Fatalf("max_tokens = %v, want %d (model card max_new_tokens)", body["max_tokens"], guardMaxTokens)
+	}
+	if got, ok := body["temperature"].(float64); !ok || got != 0 {
+		t.Fatalf("temperature = %v, want 0", body["temperature"])
+	}
+}
+
+func TestGuardBackendSendsBearerWhenConfigured(t *testing.T) {
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"Safety: Safe\nCategories: None"}}]}`))
+	}))
+	defer server.Close()
+	profile := guardProfile(t, server.URL)
+	profile.APIKeySecret = "guard-token"
+	NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "hello")
+	if authHeader != "Bearer guard-token" {
+		t.Fatalf("Authorization = %q", authHeader)
+	}
+}
+
+func TestGuardBackendFailsOpen(t *testing.T) {
+	cases := []struct {
+		name       string
+		handler    http.HandlerFunc
+		errorClass string
+	}{
+		{
+			name: "upstream status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+			errorClass: "upstream_status",
+		},
+		{
+			name: "invalid verdict",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"I cannot help with that."}}]}`))
+			},
+			errorClass: "invalid_response",
+		},
+		{
+			name: "oversized body",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"` + strings.Repeat("a", int(maxModerationResponseBytes)+16) + `"}}]}`))
+			},
+			errorClass: "invalid_response",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+			profile := guardProfile(t, server.URL)
+			decision := NewEvaluator(server.Client()).Evaluate(context.Background(), profile, "hello")
+			if decision.WouldBlock || decision.Action != ActionAPIError {
+				t.Fatalf("decision = %#v, want fail-open", decision)
+			}
+			if got := moderationErrorClass(decision.ModerationError); got != tt.errorClass {
+				t.Fatalf("error class = %q, want %q (%s)", got, tt.errorClass, decision.ModerationError)
+			}
+		})
+	}
+}
+
+// TimeoutMS budgets the whole evaluation, so a slow endpoint cannot multiply
+// the promised latency by the chunk count.
+func TestGuardBackendBudgetsAllChunks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"Safety: Safe\nCategories: None"}}]}`))
+	}))
+	defer server.Close()
+	profile := guardProfile(t, server.URL)
+	profile.InputLimit = MinInputLimit
+	profile.MaxChunks = 8
+	profile.TimeoutMS = 200
+	start := time.Now()
+	decision := NewEvaluator(server.Client()).Evaluate(context.Background(), profile, strings.Repeat("a", MinInputLimit*8))
+	elapsed := time.Since(start)
+	if decision.WouldBlock || decision.Action != ActionAPIError {
+		t.Fatalf("decision = %#v, want fail-open on budget exhaustion", decision)
+	}
+	if elapsed > 900*time.Millisecond {
+		t.Fatalf("evaluation took %s; the budget must cover all chunks", elapsed)
+	}
+}
+
+func TestGuardBackendAggregatesAcrossChunks(t *testing.T) {
+	server, _, _ := guardServer(t,
+		"Safety: Safe\nCategories: None",
+		"Safety: Controversial\nCategories: Violent",
+		"Safety: Safe\nCategories: None",
+	)
+	profile := guardProfile(t, server.URL)
+	profile.InputLimit = MinInputLimit
+	profile.MaxChunks = 3
+	decision := NewEvaluator(server.Client()).Evaluate(context.Background(), profile, strings.Repeat("a", MinInputLimit*3))
+	if decision.WouldBlock {
+		t.Fatalf("decision = %#v, want allow (violent is not elevated)", decision)
+	}
+	if decision.Safety != safetyControversial {
+		t.Fatalf("safety = %q, want the most severe chunk verdict", decision.Safety)
+	}
+	if decision.CategoryScores[ScannerViolent] != 0.5 {
+		t.Fatalf("scores = %v, want controversial mapped to 0.5", decision.CategoryScores)
+	}
+	if decision.HighestCategory != ScannerViolent {
+		t.Fatalf("highest category = %q", decision.HighestCategory)
+	}
+}
+
+func TestExtractChatContentAcceptsStringAndBlocks(t *testing.T) {
+	content, err := extractChatContent([]byte(`{"choices":[{"message":{"content":"Safety: Safe"}}]}`))
+	if err != nil || content != "Safety: Safe" {
+		t.Fatalf("content = %q err = %v", content, err)
+	}
+	content, err = extractChatContent([]byte(`{"choices":[{"message":{"content":[{"type":"text","text":"Safety: Safe"},{"type":"text","text":"Categories: None"}]}}]}`))
+	if err != nil || content != "Safety: Safe\nCategories: None" {
+		t.Fatalf("content = %q err = %v", content, err)
+	}
+	for _, body := range []string{`{}`, `{"choices":[]}`, `{"choices":[{"message":{"content":null}}]}`, `{"choices":[{"message":{"content":"  "}}]}`, `not json`} {
+		if _, err = extractChatContent([]byte(body)); err == nil {
+			t.Fatalf("expected error for %s", body)
+		}
+	}
+}

--- a/internal/contentmoderation/evaluator.go
+++ b/internal/contentmoderation/evaluator.go
@@ -1,12 +1,8 @@
 package contentmoderation
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 )
@@ -15,6 +11,7 @@ const (
 	ActionAllow        = "allow"
 	ActionKeywordBlock = "keyword_block"
 	ActionAPIBlock     = "api_block"
+	ActionGuardBlock   = "guard_block"
 	ActionAPIError     = "api_error"
 )
 
@@ -26,8 +23,31 @@ type Decision struct {
 	HighestScore    float64            `json:"highest_score,omitempty"`
 	CategoryScores  map[string]float64 `json:"category_scores"`
 	Thresholds      map[string]float64 `json:"thresholds"`
-	LatencyMS       int64              `json:"latency_ms"`
-	ModerationError string             `json:"moderation_error,omitempty"`
+	// Safety, Categories and MatchedScanners come from guard backends that
+	// classify into labels instead of per-category scores.
+	Safety          string   `json:"safety,omitempty"`
+	Categories      []string `json:"categories,omitempty"`
+	MatchedScanners []string `json:"matched_scanners,omitempty"`
+	LatencyMS       int64    `json:"latency_ms"`
+	ModerationError string   `json:"moderation_error,omitempty"`
+}
+
+// backendResult is one moderation upstream's verdict, normalized across the
+// score-based and label-based backends.
+type backendResult struct {
+	Scores            map[string]float64
+	Safety            string
+	Categories        []string
+	MatchedScanners   []string
+	UnknownCategories []string
+	Block             bool
+}
+
+// moderationBackend is the pluggable upstream behind a profile. Implementations
+// own their wire protocol and their own block decision; the evaluator owns the
+// surrounding policy (mode, keywords, fail-open) that is identical for all.
+type moderationBackend interface {
+	Check(ctx context.Context, profile Profile, input string) (backendResult, error)
 }
 
 type Evaluator struct {
@@ -39,6 +59,13 @@ func NewEvaluator(client *http.Client) *Evaluator {
 		client = http.DefaultClient
 	}
 	return &Evaluator{httpClient: client}
+}
+
+func (e *Evaluator) backendFor(profile Profile) moderationBackend {
+	if profile.Backend == BackendQwen3Guard {
+		return &qwen3GuardBackend{httpClient: e.httpClient}
+	}
+	return &openaiModerationsBackend{httpClient: e.httpClient}
 }
 
 func (e *Evaluator) Evaluate(ctx context.Context, profile Profile, input string) Decision {
@@ -59,25 +86,32 @@ func (e *Evaluator) Evaluate(ctx context.Context, profile Profile, input string)
 		return decision
 	}
 	start := time.Now()
-	scores, err := e.callModeration(ctx, profile, input)
+	result, err := e.backendFor(profile).Check(ctx, profile, input)
 	decision.LatencyMS = time.Since(start).Milliseconds()
 	if err != nil {
+		// Fail open: a broken moderation dependency must not take traffic down.
 		decision.Action = ActionAPIError
 		decision.ModerationError = err.Error()
 		return decision
 	}
-	decision.CategoryScores = scores
-	for category, score := range scores {
+	if result.Scores != nil {
+		decision.CategoryScores = result.Scores
+	}
+	decision.Safety = result.Safety
+	decision.Categories = result.Categories
+	decision.MatchedScanners = result.MatchedScanners
+	for category, score := range decision.CategoryScores {
 		if decision.HighestCategory == "" || score > decision.HighestScore {
 			decision.HighestCategory = category
 			decision.HighestScore = score
 		}
-		if threshold, ok := decision.Thresholds[category]; ok && score >= threshold {
-			decision.WouldBlock = true
-		}
 	}
-	if decision.WouldBlock {
+	if result.Block {
+		decision.WouldBlock = true
 		decision.Action = ActionAPIBlock
+		if profile.Backend == BackendQwen3Guard {
+			decision.Action = ActionGuardBlock
+		}
 	}
 	return decision
 }
@@ -91,47 +125,4 @@ func matchKeyword(input string, keywords []string) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func (e *Evaluator) callModeration(ctx context.Context, profile Profile, input string) (map[string]float64, error) {
-	endpoint, err := url.JoinPath(strings.TrimRight(profile.BaseURL, "/"), "v1/moderations")
-	if err != nil {
-		return nil, fmt.Errorf("invalid moderation base URL: %w", err)
-	}
-	payload, err := json.Marshal(struct {
-		Model string `json:"model"`
-		Input string `json:"input"`
-	}{Model: profile.Model, Input: input})
-	if err != nil {
-		return nil, fmt.Errorf("encode moderation request: %w", err)
-	}
-	timeout := time.Duration(profile.TimeoutMS) * time.Millisecond
-	requestCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
-	if err != nil {
-		return nil, fmt.Errorf("create moderation request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+profile.APIKeySecret)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := e.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("moderation request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("moderation API returned status %d", resp.StatusCode)
-	}
-	var result struct {
-		Results []struct {
-			CategoryScores map[string]float64 `json:"category_scores"`
-		} `json:"results"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode moderation response: %w", err)
-	}
-	if len(result.Results) == 0 || result.Results[0].CategoryScores == nil {
-		return nil, fmt.Errorf("moderation response missing category scores")
-	}
-	return result.Results[0].CategoryScores, nil
 }

--- a/internal/contentmoderation/httpclient.go
+++ b/internal/contentmoderation/httpclient.go
@@ -1,0 +1,77 @@
+package contentmoderation
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// maxModerationResponseBytes caps how much of a moderation response we read.
+// Without it a faulty or hostile endpoint could stream indefinitely into the
+// JSON decoder while a live request waits on the hot path.
+const maxModerationResponseBytes int64 = 256 * 1024
+
+var errResponseTooLarge = errors.New("moderation response exceeds size limit")
+
+// normalizeModerationBaseURL validates an operator-supplied endpoint address.
+//
+// Credentials, query strings and fragments are rejected rather than silently
+// dropped: they cannot be carried onto the resulting API path, so accepting
+// them would let a profile look configured while sending something different.
+// A trailing "/v1" is folded away so operators can paste either the bare host
+// or the OpenAI-style base URL without producing "/v1/v1/...".
+//
+// Private and loopback destinations stay reachable on purpose. Guard models are
+// normally self-hosted on an internal network, so blocking those addresses
+// would reject the primary deployment shape; endpoint trust is an
+// administrator concern enforced by who may write profiles.
+func normalizeModerationBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", errors.New("invalid moderation base URL")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", errors.New("moderation base URL must use http or https")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New("moderation base URL must not contain credentials, query or fragment")
+	}
+	if strings.TrimSpace(parsed.Hostname()) == "" {
+		return "", errors.New("invalid moderation base URL")
+	}
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if strings.EqualFold(path, "/v1") {
+		path = ""
+	}
+	parsed.Path = path
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+// moderationEndpointURL joins a validated base URL with an API path.
+func moderationEndpointURL(baseURL, apiPath string) (string, error) {
+	normalized, err := normalizeModerationBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+	return normalized + apiPath, nil
+}
+
+// readModerationResponse enforces the response size cap. It reads one byte past
+// the limit so an exactly-at-limit body is still accepted while an oversized
+// one is rejected instead of being truncated into malformed JSON.
+func readModerationResponse(resp *http.Response) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxModerationResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read moderation response: %w", err)
+	}
+	if int64(len(body)) > maxModerationResponseBytes {
+		return nil, errResponseTooLarge
+	}
+	return body, nil
+}

--- a/internal/contentmoderation/qwen3guard_catalog.go
+++ b/internal/contentmoderation/qwen3guard_catalog.go
@@ -1,0 +1,151 @@
+package contentmoderation
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Qwen3Guard risk categories. The IDs are our canonical snake_case form; the
+// guard model emits the human-readable labels documented in the Qwen3Guard
+// model card ("Violent", "Non-violent Illegal Acts", ...), which
+// NormalizeCategory maps back onto these IDs.
+const (
+	ScannerViolent                   = "violent"
+	ScannerNonViolentIllegalActs     = "non_violent_illegal_acts"
+	ScannerSexualContentOrSexualActs = "sexual_content_or_sexual_acts"
+	ScannerPII                       = "pii"
+	ScannerSuicideAndSelfHarm        = "suicide_and_self_harm"
+	ScannerUnethicalActs             = "unethical_acts"
+	ScannerPoliticallySensitive      = "politically_sensitive_topics"
+	ScannerCopyrightViolation        = "copyright_violation"
+	ScannerJailbreak                 = "jailbreak"
+)
+
+// AllScannerIDs is the display and serialization order for categories.
+var AllScannerIDs = []string{
+	ScannerViolent,
+	ScannerNonViolentIllegalActs,
+	ScannerSexualContentOrSexualActs,
+	ScannerPII,
+	ScannerSuicideAndSelfHarm,
+	ScannerUnethicalActs,
+	ScannerPoliticallySensitive,
+	ScannerCopyrightViolation,
+	ScannerJailbreak,
+}
+
+var scannerCatalog = map[string]struct{}{
+	ScannerViolent:                   {},
+	ScannerNonViolentIllegalActs:     {},
+	ScannerSexualContentOrSexualActs: {},
+	ScannerPII:                       {},
+	ScannerSuicideAndSelfHarm:        {},
+	ScannerUnethicalActs:             {},
+	ScannerPoliticallySensitive:      {},
+	ScannerCopyrightViolation:        {},
+	ScannerJailbreak:                 {},
+}
+
+// categoryAliases maps normalized spellings the guard model (or an operator
+// typing into the admin UI) may produce onto canonical IDs. Keys are already
+// lowercase with separators collapsed to single spaces by NormalizeCategory.
+var categoryAliases = map[string]string{
+	"violent":                           ScannerViolent,
+	"violence":                          ScannerViolent,
+	"non violent illegal acts":          ScannerNonViolentIllegalActs,
+	"nonviolent illegal acts":           ScannerNonViolentIllegalActs,
+	"sexual content or sexual acts":     ScannerSexualContentOrSexualActs,
+	"sexual content":                    ScannerSexualContentOrSexualActs,
+	"sexual":                            ScannerSexualContentOrSexualActs,
+	"pii":                               ScannerPII,
+	"personal identifying information":  ScannerPII,
+	"personal identifiable information": ScannerPII,
+	"suicide and self harm":             ScannerSuicideAndSelfHarm,
+	"suicide self harm":                 ScannerSuicideAndSelfHarm,
+	"self harm":                         ScannerSuicideAndSelfHarm,
+	"unethical acts":                    ScannerUnethicalActs,
+	"unethical":                         ScannerUnethicalActs,
+	"politically sensitive topics":      ScannerPoliticallySensitive,
+	"political":                         ScannerPoliticallySensitive,
+	"copyright violation":               ScannerCopyrightViolation,
+	"copyright":                         ScannerCopyrightViolation,
+	"jailbreak":                         ScannerJailbreak,
+	"prompt injection":                  ScannerJailbreak,
+}
+
+// DefaultElevatedCategories are the categories that turn a "Controversial"
+// verdict into a block under ControversialActionElevatedOnly. Mis-allowing them
+// costs more than mis-blocking: jailbreak attacks this proxy itself, PII
+// carries compliance exposure, and self-harm carries personal risk.
+func DefaultElevatedCategories() []string {
+	return []string{ScannerJailbreak, ScannerPII, ScannerSuicideAndSelfHarm}
+}
+
+// IsScannerID reports whether value is one of the nine known categories.
+func IsScannerID(value string) bool {
+	_, ok := scannerCatalog[strings.TrimSpace(value)]
+	return ok
+}
+
+// NormalizeCategory folds separator and casing variants onto a canonical ID.
+// Unknown values are returned in snake_case rather than dropped so callers can
+// still surface them (see unknownCategoryID).
+func NormalizeCategory(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.NewReplacer("_", " ", "&", " and ", "/", " ", "-", " ", "–", " ", "—", " ").Replace(normalized)
+	normalized = strings.Join(strings.Fields(normalized), " ")
+	if canonical, ok := categoryAliases[normalized]; ok {
+		return canonical
+	}
+	return strings.ReplaceAll(normalized, " ", "_")
+}
+
+// unknownCategoryID hashes an out-of-catalog label instead of echoing it: the
+// label is model output derived from user prompt text and must not reach logs
+// or the admin API verbatim.
+func unknownCategoryID(value string) string {
+	digest := sha256.Sum256([]byte(strings.TrimSpace(strings.ToLower(value))))
+	return fmt.Sprintf("unknown:%x", digest[:8])
+}
+
+// normalizeScannerList canonicalizes, de-duplicates and orders a configured
+// category list. Out-of-catalog values are kept rather than dropped so
+// ValidateProfile can reject a typo instead of silently narrowing the policy
+// the operator believes they saved.
+func normalizeScannerList(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if category := NormalizeCategory(value); category != "" {
+			seen[category] = struct{}{}
+		}
+	}
+	return orderedScannerKeys(seen)
+}
+
+// orderedScannerKeys returns catalog members in AllScannerIDs order, followed
+// by any remaining keys sorted alphabetically, so output is deterministic.
+func orderedScannerKeys(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	remaining := make(map[string]struct{}, len(values))
+	for key := range values {
+		remaining[key] = struct{}{}
+	}
+	for _, scannerID := range AllScannerIDs {
+		if _, ok := remaining[scannerID]; ok {
+			result = append(result, scannerID)
+			delete(remaining, scannerID)
+		}
+	}
+	return append(result, sortedKeys(remaining)...)
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for key := range values {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/contentmoderation/runtime.go
+++ b/internal/contentmoderation/runtime.go
@@ -312,6 +312,14 @@ func (m *RuntimeModerator) logDecision(tenantID string, auth *coreauth.Auth, sou
 		fields["category"] = decision.HighestCategory
 		fields["score"] = decision.HighestScore
 	}
+	// A guard verdict can block without naming an enabled category (unknown or
+	// unnamed risk), so the label is logged independently of category/score.
+	if decision.Safety != "" {
+		fields["safety"] = decision.Safety
+	}
+	if len(decision.MatchedScanners) > 0 {
+		fields["matched_scanners"] = strings.Join(decision.MatchedScanners, ",")
+	}
 	entry := log.WithFields(fields)
 	if decision.WouldBlock {
 		entry.Warn("content moderation blocked request")
@@ -423,10 +431,15 @@ func moderationErrorClass(message string) string {
 		return "timeout"
 	case strings.Contains(message, "returned status"):
 		return "upstream_status"
-	case strings.Contains(message, "decode") || strings.Contains(message, "missing category scores"):
+	case strings.Contains(message, "decode") ||
+		strings.Contains(message, "missing category scores") ||
+		strings.Contains(message, "not a valid verdict") ||
+		strings.Contains(message, "exceeds size limit"):
 		return "invalid_response"
 	case strings.Contains(message, "request failed"):
 		return "transport"
+	case strings.Contains(message, "base url"):
+		return "invalid_config"
 	default:
 		return "moderation_error"
 	}

--- a/internal/contentmoderation/runtime_snapshot.go
+++ b/internal/contentmoderation/runtime_snapshot.go
@@ -16,6 +16,7 @@ type RuntimeSnapshot struct {
 	ProfileID        string   `json:"profile_id"`
 	ProfileName      string   `json:"profile_name"`
 	ProfileVersion   int64    `json:"profile_version"`
+	Backend          string   `json:"backend,omitempty"`
 	ResolutionSource string   `json:"resolution_source"`
 	ChannelType      string   `json:"channel_type"`
 	ChannelID        string   `json:"channel_id"`
@@ -24,10 +25,14 @@ type RuntimeSnapshot struct {
 	MatchedKeyword   string   `json:"matched_keyword,omitempty"`
 	HighestCategory  string   `json:"highest_category,omitempty"`
 	HighestScore     *float64 `json:"highest_score,omitempty"`
-	LatencyMS        int64    `json:"latency_ms"`
-	CacheHit         bool     `json:"cache_hit"`
-	ErrorClass       string   `json:"error_class,omitempty"`
-	ModerationError  string   `json:"moderation_error,omitempty"`
+	// Safety and MatchedScanners describe a guard verdict; a guard can block
+	// without an enabled category, so they are recorded independently.
+	Safety          string   `json:"safety,omitempty"`
+	MatchedScanners []string `json:"matched_scanners,omitempty"`
+	LatencyMS       int64    `json:"latency_ms"`
+	CacheHit        bool     `json:"cache_hit"`
+	ErrorClass      string   `json:"error_class,omitempty"`
+	ModerationError string   `json:"moderation_error,omitempty"`
 }
 
 // SetRuntimeSnapshot attaches a moderation outcome to the request's Gin context.
@@ -61,6 +66,7 @@ func (m *RuntimeModerator) setSnapshot(ctx context.Context, auth *coreauth.Auth,
 		ProfileID:        profile.ID,
 		ProfileName:      profile.Name,
 		ProfileVersion:   profile.Version,
+		Backend:          profile.Backend,
 		ResolutionSource: source,
 		ChannelType:      channelType,
 		ChannelID:        channelID,
@@ -68,6 +74,8 @@ func (m *RuntimeModerator) setSnapshot(ctx context.Context, auth *coreauth.Auth,
 		WouldBlock:       decision.WouldBlock,
 		MatchedKeyword:   decision.MatchedKeyword,
 		HighestCategory:  decision.HighestCategory,
+		Safety:           decision.Safety,
+		MatchedScanners:  decision.MatchedScanners,
 		LatencyMS:        decision.LatencyMS,
 		CacheHit:         cached,
 	}
@@ -92,6 +100,8 @@ func moderationErrorSummary(errorClass string) string {
 		return "moderation API returned an invalid response"
 	case "transport":
 		return "moderation API transport failed"
+	case "invalid_config":
+		return "moderation endpoint is misconfigured"
 	default:
 		return "moderation API evaluation failed"
 	}

--- a/internal/contentmoderation/store.go
+++ b/internal/contentmoderation/store.go
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS content_moderation_profiles (
   id TEXT NOT NULL,
   name TEXT NOT NULL,
   mode TEXT NOT NULL DEFAULT 'off',
+  backend TEXT NOT NULL DEFAULT 'openai_moderations',
   base_url TEXT NOT NULL DEFAULT 'https://api.openai.com',
   model TEXT NOT NULL DEFAULT 'omni-moderation-latest',
   api_key_secret TEXT NOT NULL DEFAULT '',
@@ -23,6 +24,11 @@ CREATE TABLE IF NOT EXISTS content_moderation_profiles (
   keyword_mode TEXT NOT NULL DEFAULT 'api_only',
   blocked_keywords_json TEXT NOT NULL DEFAULT '[]',
   thresholds_json TEXT NOT NULL DEFAULT '{}',
+  scanners_json TEXT NOT NULL DEFAULT '[]',
+  controversial_action TEXT NOT NULL DEFAULT 'elevated_only',
+  elevated_categories_json TEXT NOT NULL DEFAULT '["jailbreak","pii","suicide_and_self_harm"]',
+  input_limit INTEGER NOT NULL DEFAULT 4000,
+  max_chunks INTEGER NOT NULL DEFAULT 4,
   block_http_status INTEGER NOT NULL DEFAULT 403,
   block_message TEXT NOT NULL DEFAULT '',
   version INTEGER NOT NULL DEFAULT 1,
@@ -49,12 +55,28 @@ CREATE INDEX IF NOT EXISTS idx_content_moderation_bindings_profile
   ON content_moderation_channel_bindings(tenant_id, profile_id);
 `
 
+// profileColumnMigrations backfill the moderation-backend columns onto tables
+// created before qwen3guard support existed. The defaults reproduce the
+// previous behaviour exactly, so existing profiles keep running against the
+// OpenAI moderations API with no configuration change.
+var profileColumnMigrations = []string{
+	`ALTER TABLE content_moderation_profiles ADD COLUMN backend TEXT NOT NULL DEFAULT 'openai_moderations'`,
+	`ALTER TABLE content_moderation_profiles ADD COLUMN scanners_json TEXT NOT NULL DEFAULT '[]'`,
+	`ALTER TABLE content_moderation_profiles ADD COLUMN controversial_action TEXT NOT NULL DEFAULT 'elevated_only'`,
+	`ALTER TABLE content_moderation_profiles ADD COLUMN elevated_categories_json TEXT NOT NULL DEFAULT '["jailbreak","pii","suicide_and_self_harm"]'`,
+	`ALTER TABLE content_moderation_profiles ADD COLUMN input_limit INTEGER NOT NULL DEFAULT 4000`,
+	`ALTER TABLE content_moderation_profiles ADD COLUMN max_chunks INTEGER NOT NULL DEFAULT 4`,
+}
+
 func InitTables(db *sql.DB) error {
 	if db == nil {
 		return ErrUnavailable
 	}
 	if _, err := db.Exec(createTablesSQL); err != nil {
 		return fmt.Errorf("create content moderation tables: %w", err)
+	}
+	for _, stmt := range profileColumnMigrations {
+		_, _ = db.Exec(stmt) // ignore duplicate-column errors on already-migrated installs
 	}
 	return nil
 }
@@ -100,15 +122,18 @@ func (s *Store) CreateProfile(ctx context.Context, profile Profile) error {
 	if s == nil || s.db == nil {
 		return ErrUnavailable
 	}
-	keywords, thresholds, err := profileJSON(profile)
+	columns, err := profileJSON(profile)
 	if err != nil {
 		return err
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO content_moderation_profiles
-		(tenant_id,id,name,mode,base_url,model,api_key_secret,timeout_ms,keyword_mode,blocked_keywords_json,thresholds_json,block_http_status,block_message,version,created_at,updated_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
-		profile.TenantID, profile.ID, profile.Name, profile.Mode, profile.BaseURL, profile.Model, profile.APIKeySecret,
-		profile.TimeoutMS, profile.KeywordMode, keywords, thresholds, profile.BlockHTTPStatus, profile.BlockMessage,
+		(tenant_id,id,name,mode,backend,base_url,model,api_key_secret,timeout_ms,keyword_mode,blocked_keywords_json,thresholds_json,
+		 scanners_json,controversial_action,elevated_categories_json,input_limit,max_chunks,block_http_status,block_message,version,created_at,updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)`,
+		profile.TenantID, profile.ID, profile.Name, profile.Mode, profile.Backend, profile.BaseURL, profile.Model, profile.APIKeySecret,
+		profile.TimeoutMS, profile.KeywordMode, columns.Keywords, columns.Thresholds,
+		columns.Scanners, profile.ControversialAction, columns.Elevated, profile.InputLimit, profile.MaxChunks,
+		profile.BlockHTTPStatus, profile.BlockMessage,
 		profile.Version, formatTime(profile.CreatedAt), formatTime(profile.UpdatedAt))
 	if isUniqueViolation(err) {
 		return ErrNameConflict
@@ -120,16 +145,18 @@ func (s *Store) UpdateProfile(ctx context.Context, profile Profile, expectedVers
 	if s == nil || s.db == nil {
 		return ErrUnavailable
 	}
-	keywords, thresholds, err := profileJSON(profile)
+	columns, err := profileJSON(profile)
 	if err != nil {
 		return err
 	}
 	result, err := s.db.ExecContext(ctx, `UPDATE content_moderation_profiles SET
-		name=$1,mode=$2,base_url=$3,model=$4,api_key_secret=$5,timeout_ms=$6,keyword_mode=$7,
-		blocked_keywords_json=$8,thresholds_json=$9,block_http_status=$10,block_message=$11,version=$12,updated_at=$13
-		WHERE tenant_id=$14 AND id=$15 AND version=$16`,
-		profile.Name, profile.Mode, profile.BaseURL, profile.Model, profile.APIKeySecret, profile.TimeoutMS, profile.KeywordMode,
-		keywords, thresholds, profile.BlockHTTPStatus, profile.BlockMessage, profile.Version, formatTime(profile.UpdatedAt),
+		name=$1,mode=$2,backend=$3,base_url=$4,model=$5,api_key_secret=$6,timeout_ms=$7,keyword_mode=$8,
+		blocked_keywords_json=$9,thresholds_json=$10,scanners_json=$11,controversial_action=$12,elevated_categories_json=$13,
+		input_limit=$14,max_chunks=$15,block_http_status=$16,block_message=$17,version=$18,updated_at=$19
+		WHERE tenant_id=$20 AND id=$21 AND version=$22`,
+		profile.Name, profile.Mode, profile.Backend, profile.BaseURL, profile.Model, profile.APIKeySecret, profile.TimeoutMS, profile.KeywordMode,
+		columns.Keywords, columns.Thresholds, columns.Scanners, profile.ControversialAction, columns.Elevated,
+		profile.InputLimit, profile.MaxChunks, profile.BlockHTTPStatus, profile.BlockMessage, profile.Version, formatTime(profile.UpdatedAt),
 		profile.TenantID, profile.ID, expectedVersion)
 	if isUniqueViolation(err) {
 		return ErrNameConflict
@@ -316,14 +343,15 @@ func (s *Store) ResolveProfile(ctx context.Context, tenantID, authFileID, provid
 	return Profile{}, "", ErrNotFound
 }
 
-const profileSelectSQL = `SELECT content_moderation_profiles.tenant_id,content_moderation_profiles.id,content_moderation_profiles.name,content_moderation_profiles.mode,content_moderation_profiles.base_url,content_moderation_profiles.model,content_moderation_profiles.api_key_secret,content_moderation_profiles.timeout_ms,content_moderation_profiles.keyword_mode,content_moderation_profiles.blocked_keywords_json,content_moderation_profiles.thresholds_json,content_moderation_profiles.block_http_status,content_moderation_profiles.block_message,content_moderation_profiles.version,content_moderation_profiles.created_at,content_moderation_profiles.updated_at FROM content_moderation_profiles`
+const profileSelectSQL = `SELECT content_moderation_profiles.tenant_id,content_moderation_profiles.id,content_moderation_profiles.name,content_moderation_profiles.mode,content_moderation_profiles.backend,content_moderation_profiles.base_url,content_moderation_profiles.model,content_moderation_profiles.api_key_secret,content_moderation_profiles.timeout_ms,content_moderation_profiles.keyword_mode,content_moderation_profiles.blocked_keywords_json,content_moderation_profiles.thresholds_json,content_moderation_profiles.scanners_json,content_moderation_profiles.controversial_action,content_moderation_profiles.elevated_categories_json,content_moderation_profiles.input_limit,content_moderation_profiles.max_chunks,content_moderation_profiles.block_http_status,content_moderation_profiles.block_message,content_moderation_profiles.version,content_moderation_profiles.created_at,content_moderation_profiles.updated_at FROM content_moderation_profiles`
 
 func scanProfile(scanner interface{ Scan(...any) error }) (Profile, error) {
 	var profile Profile
-	var keywordsJSON, thresholdsJSON, createdAt, updatedAt string
+	var keywordsJSON, thresholdsJSON, scannersJSON, elevatedJSON, createdAt, updatedAt string
 	if err := scanner.Scan(
-		&profile.TenantID, &profile.ID, &profile.Name, &profile.Mode, &profile.BaseURL, &profile.Model, &profile.APIKeySecret,
-		&profile.TimeoutMS, &profile.KeywordMode, &keywordsJSON, &thresholdsJSON, &profile.BlockHTTPStatus, &profile.BlockMessage,
+		&profile.TenantID, &profile.ID, &profile.Name, &profile.Mode, &profile.Backend, &profile.BaseURL, &profile.Model, &profile.APIKeySecret,
+		&profile.TimeoutMS, &profile.KeywordMode, &keywordsJSON, &thresholdsJSON, &scannersJSON, &profile.ControversialAction, &elevatedJSON,
+		&profile.InputLimit, &profile.MaxChunks, &profile.BlockHTTPStatus, &profile.BlockMessage,
 		&profile.Version, &createdAt, &updatedAt,
 	); err != nil {
 		return Profile{}, err
@@ -334,21 +362,48 @@ func scanProfile(scanner interface{ Scan(...any) error }) (Profile, error) {
 	if err := json.Unmarshal([]byte(thresholdsJSON), &profile.Thresholds); err != nil {
 		return Profile{}, fmt.Errorf("decode thresholds: %w", err)
 	}
+	if err := json.Unmarshal([]byte(scannersJSON), &profile.Scanners); err != nil {
+		return Profile{}, fmt.Errorf("decode scanners: %w", err)
+	}
+	if err := json.Unmarshal([]byte(elevatedJSON), &profile.ElevatedCategories); err != nil {
+		return Profile{}, fmt.Errorf("decode elevated categories: %w", err)
+	}
 	profile.CreatedAt = parseTime(createdAt)
 	profile.UpdatedAt = parseTime(updatedAt)
 	return profile, nil
 }
 
-func profileJSON(profile Profile) (string, string, error) {
+// profileJSONColumns holds the profile's JSON-encoded columns.
+type profileJSONColumns struct {
+	Keywords   string
+	Thresholds string
+	Scanners   string
+	Elevated   string
+}
+
+func profileJSON(profile Profile) (profileJSONColumns, error) {
 	keywords, err := json.Marshal(profile.BlockedKeywords)
 	if err != nil {
-		return "", "", err
+		return profileJSONColumns{}, err
 	}
 	thresholds, err := json.Marshal(profile.Thresholds)
 	if err != nil {
-		return "", "", err
+		return profileJSONColumns{}, err
 	}
-	return string(keywords), string(thresholds), nil
+	scanners, err := json.Marshal(profile.Scanners)
+	if err != nil {
+		return profileJSONColumns{}, err
+	}
+	elevated, err := json.Marshal(profile.ElevatedCategories)
+	if err != nil {
+		return profileJSONColumns{}, err
+	}
+	return profileJSONColumns{
+		Keywords:   string(keywords),
+		Thresholds: string(thresholds),
+		Scanners:   string(scanners),
+		Elevated:   string(elevated),
+	}, nil
 }
 
 func formatTime(value time.Time) string { return value.UTC().Format(time.RFC3339Nano) }

--- a/internal/contentmoderation/types.go
+++ b/internal/contentmoderation/types.go
@@ -16,6 +16,18 @@ const (
 	KeywordModeKeywordOnly   = "keyword_only"
 	KeywordModeKeywordAndAPI = "keyword_and_api"
 
+	// Moderation upstreams. "backend" rather than "provider": provider already
+	// names an AI upstream channel in this codebase (ChannelTypeProvider,
+	// provider_config_id), and reusing it here would collide in logs and DTOs.
+	BackendOpenAIModerations = "openai_moderations"
+	BackendQwen3Guard        = "qwen3guard"
+
+	// How a Qwen3Guard "Controversial" verdict maps onto our two-state
+	// allow/block model.
+	ControversialActionAllow        = "allow"
+	ControversialActionBlock        = "block"
+	ControversialActionElevatedOnly = "elevated_only"
+
 	ChannelTypeAuthFile    = "auth_file"
 	ChannelTypeProviderKey = "provider_key"
 	ChannelTypeProvider    = "provider"
@@ -25,6 +37,12 @@ const (
 	DefaultTimeoutMS    = 3000
 	DefaultBlockStatus  = 403
 	DefaultBlockMessage = "Your request was blocked by the content moderation policy."
+
+	DefaultInputLimit = 4000
+	DefaultMaxChunks  = 4
+	MinInputLimit     = 128
+	MaxInputLimit     = 100000
+	MaxChunksLimit    = 32
 )
 
 var (
@@ -38,52 +56,74 @@ var (
 )
 
 type Profile struct {
-	TenantID        string             `json:"-"`
-	ID              string             `json:"id"`
-	Name            string             `json:"name"`
-	Mode            string             `json:"mode"`
-	BaseURL         string             `json:"base_url"`
-	Model           string             `json:"model"`
-	APIKeySecret    string             `json:"-"`
+	TenantID     string `json:"-"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Mode         string `json:"mode"`
+	Backend      string `json:"backend"`
+	BaseURL      string `json:"base_url"`
+	Model        string `json:"model"`
+	APIKeySecret string `json:"-"`
+	// TimeoutMS is the budget for the whole evaluation, not for one HTTP call:
+	// the Qwen3Guard backend may issue several chunk requests under it.
 	TimeoutMS       int                `json:"timeout_ms"`
 	KeywordMode     string             `json:"keyword_mode"`
 	BlockedKeywords []string           `json:"blocked_keywords"`
 	Thresholds      map[string]float64 `json:"thresholds"`
-	BlockHTTPStatus int                `json:"block_http_status"`
-	BlockMessage    string             `json:"block_message"`
-	Version         int64              `json:"version"`
-	CreatedAt       time.Time          `json:"created_at"`
-	UpdatedAt       time.Time          `json:"updated_at"`
+	// Scanners lists the Qwen3Guard categories this profile acts on. Empty
+	// means every category in the catalog.
+	Scanners            []string  `json:"scanners"`
+	ControversialAction string    `json:"controversial_action"`
+	ElevatedCategories  []string  `json:"elevated_categories"`
+	InputLimit          int       `json:"input_limit"`
+	MaxChunks           int       `json:"max_chunks"`
+	BlockHTTPStatus     int       `json:"block_http_status"`
+	BlockMessage        string    `json:"block_message"`
+	Version             int64     `json:"version"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
 }
 
 type CreateProfileInput struct {
-	Name            string             `json:"name"`
-	Mode            string             `json:"mode"`
-	BaseURL         string             `json:"base_url"`
-	Model           string             `json:"model"`
-	APIKey          string             `json:"api_key"`
-	TimeoutMS       int                `json:"timeout_ms"`
-	KeywordMode     string             `json:"keyword_mode"`
-	BlockedKeywords []string           `json:"blocked_keywords"`
-	Thresholds      map[string]float64 `json:"thresholds"`
-	BlockHTTPStatus int                `json:"block_http_status"`
-	BlockMessage    string             `json:"block_message"`
+	Name                string             `json:"name"`
+	Mode                string             `json:"mode"`
+	Backend             string             `json:"backend"`
+	BaseURL             string             `json:"base_url"`
+	Model               string             `json:"model"`
+	APIKey              string             `json:"api_key"`
+	TimeoutMS           int                `json:"timeout_ms"`
+	KeywordMode         string             `json:"keyword_mode"`
+	BlockedKeywords     []string           `json:"blocked_keywords"`
+	Thresholds          map[string]float64 `json:"thresholds"`
+	Scanners            []string           `json:"scanners"`
+	ControversialAction string             `json:"controversial_action"`
+	ElevatedCategories  []string           `json:"elevated_categories"`
+	InputLimit          int                `json:"input_limit"`
+	MaxChunks           int                `json:"max_chunks"`
+	BlockHTTPStatus     int                `json:"block_http_status"`
+	BlockMessage        string             `json:"block_message"`
 }
 
 type PatchProfileInput struct {
-	Name            *string             `json:"name"`
-	Mode            *string             `json:"mode"`
-	BaseURL         *string             `json:"base_url"`
-	Model           *string             `json:"model"`
-	APIKey          *string             `json:"api_key"`
-	ClearAPIKey     bool                `json:"clear_api_key"`
-	TimeoutMS       *int                `json:"timeout_ms"`
-	KeywordMode     *string             `json:"keyword_mode"`
-	BlockedKeywords *[]string           `json:"blocked_keywords"`
-	Thresholds      *map[string]float64 `json:"thresholds"`
-	BlockHTTPStatus *int                `json:"block_http_status"`
-	BlockMessage    *string             `json:"block_message"`
-	Version         int64               `json:"version"`
+	Name                *string             `json:"name"`
+	Mode                *string             `json:"mode"`
+	Backend             *string             `json:"backend"`
+	BaseURL             *string             `json:"base_url"`
+	Model               *string             `json:"model"`
+	APIKey              *string             `json:"api_key"`
+	ClearAPIKey         bool                `json:"clear_api_key"`
+	TimeoutMS           *int                `json:"timeout_ms"`
+	KeywordMode         *string             `json:"keyword_mode"`
+	BlockedKeywords     *[]string           `json:"blocked_keywords"`
+	Thresholds          *map[string]float64 `json:"thresholds"`
+	Scanners            *[]string           `json:"scanners"`
+	ControversialAction *string             `json:"controversial_action"`
+	ElevatedCategories  *[]string           `json:"elevated_categories"`
+	InputLimit          *int                `json:"input_limit"`
+	MaxChunks           *int                `json:"max_chunks"`
+	BlockHTTPStatus     *int                `json:"block_http_status"`
+	BlockMessage        *string             `json:"block_message"`
+	Version             int64               `json:"version"`
 }
 
 type Binding struct {
@@ -142,23 +182,35 @@ func DefaultThresholds() map[string]float64 {
 }
 
 func NewProfile(tenantID, id string, input CreateProfileInput, now time.Time) (Profile, error) {
+	elevated := input.ElevatedCategories
+	// A missing field means "use the recommended set"; an explicitly empty list
+	// means "never escalate on Controversial" and must survive.
+	if elevated == nil {
+		elevated = DefaultElevatedCategories()
+	}
 	profile := Profile{
-		TenantID:        strings.TrimSpace(tenantID),
-		ID:              strings.TrimSpace(id),
-		Name:            input.Name,
-		Mode:            input.Mode,
-		BaseURL:         input.BaseURL,
-		Model:           input.Model,
-		APIKeySecret:    input.APIKey,
-		TimeoutMS:       input.TimeoutMS,
-		KeywordMode:     input.KeywordMode,
-		BlockedKeywords: input.BlockedKeywords,
-		Thresholds:      input.Thresholds,
-		BlockHTTPStatus: input.BlockHTTPStatus,
-		BlockMessage:    input.BlockMessage,
-		Version:         1,
-		CreatedAt:       now.UTC(),
-		UpdatedAt:       now.UTC(),
+		TenantID:            strings.TrimSpace(tenantID),
+		ID:                  strings.TrimSpace(id),
+		Name:                input.Name,
+		Mode:                input.Mode,
+		Backend:             input.Backend,
+		BaseURL:             input.BaseURL,
+		Model:               input.Model,
+		APIKeySecret:        input.APIKey,
+		TimeoutMS:           input.TimeoutMS,
+		KeywordMode:         input.KeywordMode,
+		BlockedKeywords:     input.BlockedKeywords,
+		Thresholds:          input.Thresholds,
+		Scanners:            input.Scanners,
+		ControversialAction: input.ControversialAction,
+		ElevatedCategories:  elevated,
+		InputLimit:          input.InputLimit,
+		MaxChunks:           input.MaxChunks,
+		BlockHTTPStatus:     input.BlockHTTPStatus,
+		BlockMessage:        input.BlockMessage,
+		Version:             1,
+		CreatedAt:           now.UTC(),
+		UpdatedAt:           now.UTC(),
 	}
 	applyProfileDefaults(&profile)
 	return profile, ValidateProfile(profile)
@@ -173,6 +225,9 @@ func ApplyProfilePatch(profile Profile, patch PatchProfileInput, now time.Time) 
 	}
 	if patch.Mode != nil {
 		profile.Mode = *patch.Mode
+	}
+	if patch.Backend != nil {
+		profile.Backend = *patch.Backend
 	}
 	if patch.BaseURL != nil {
 		profile.BaseURL = *patch.BaseURL
@@ -200,6 +255,21 @@ func ApplyProfilePatch(profile Profile, patch PatchProfileInput, now time.Time) 
 	if patch.Thresholds != nil {
 		profile.Thresholds = *patch.Thresholds
 	}
+	if patch.Scanners != nil {
+		profile.Scanners = *patch.Scanners
+	}
+	if patch.ControversialAction != nil {
+		profile.ControversialAction = *patch.ControversialAction
+	}
+	if patch.ElevatedCategories != nil {
+		profile.ElevatedCategories = *patch.ElevatedCategories
+	}
+	if patch.InputLimit != nil {
+		profile.InputLimit = *patch.InputLimit
+	}
+	if patch.MaxChunks != nil {
+		profile.MaxChunks = *patch.MaxChunks
+	}
 	if patch.BlockHTTPStatus != nil {
 		profile.BlockHTTPStatus = *patch.BlockHTTPStatus
 	}
@@ -218,13 +288,22 @@ func applyProfileDefaults(profile *Profile) {
 	if profile.Mode == "" {
 		profile.Mode = ModeOff
 	}
-	profile.BaseURL = strings.TrimRight(strings.TrimSpace(profile.BaseURL), "/")
-	if profile.BaseURL == "" {
-		profile.BaseURL = DefaultBaseURL
+	profile.Backend = strings.ToLower(strings.TrimSpace(profile.Backend))
+	if profile.Backend == "" {
+		profile.Backend = BackendOpenAIModerations
 	}
+	profile.BaseURL = strings.TrimRight(strings.TrimSpace(profile.BaseURL), "/")
 	profile.Model = strings.TrimSpace(profile.Model)
-	if profile.Model == "" {
-		profile.Model = DefaultModel
+	// The OpenAI defaults are meaningless for a guard model, so they are only
+	// applied to the OpenAI backend. A qwen3guard profile with no endpoint is
+	// rejected by ValidateProfile once it is switched to pre_block.
+	if profile.Backend == BackendOpenAIModerations {
+		if profile.BaseURL == "" {
+			profile.BaseURL = DefaultBaseURL
+		}
+		if profile.Model == "" {
+			profile.Model = DefaultModel
+		}
 	}
 	profile.APIKeySecret = strings.TrimSpace(profile.APIKeySecret)
 	if profile.TimeoutMS == 0 {
@@ -236,6 +315,18 @@ func applyProfileDefaults(profile *Profile) {
 	}
 	profile.BlockedKeywords = normalizeKeywords(profile.BlockedKeywords)
 	profile.Thresholds = mergeThresholds(profile.Thresholds)
+	profile.Scanners = normalizeScannerList(profile.Scanners)
+	profile.ControversialAction = strings.ToLower(strings.TrimSpace(profile.ControversialAction))
+	if profile.ControversialAction == "" {
+		profile.ControversialAction = ControversialActionElevatedOnly
+	}
+	profile.ElevatedCategories = normalizeScannerList(profile.ElevatedCategories)
+	if profile.InputLimit == 0 {
+		profile.InputLimit = DefaultInputLimit
+	}
+	if profile.MaxChunks == 0 {
+		profile.MaxChunks = DefaultMaxChunks
+	}
 	if profile.BlockHTTPStatus == 0 {
 		profile.BlockHTTPStatus = DefaultBlockStatus
 	}
@@ -255,23 +346,70 @@ func ValidateProfile(profile Profile) error {
 	if profile.Mode != ModeOff && profile.Mode != ModePreBlock {
 		return errors.New("mode must be off or pre_block")
 	}
+	switch profile.Backend {
+	case BackendOpenAIModerations, BackendQwen3Guard:
+	default:
+		return errors.New("backend must be openai_moderations or qwen3guard")
+	}
 	switch profile.KeywordMode {
 	case KeywordModeAPIOnly, KeywordModeKeywordOnly, KeywordModeKeywordAndAPI:
 	default:
 		return errors.New("keyword_mode must be api_only, keyword_only, or keyword_and_api")
 	}
+	switch profile.ControversialAction {
+	case ControversialActionAllow, ControversialActionBlock, ControversialActionElevatedOnly:
+	default:
+		return errors.New("controversial_action must be allow, block, or elevated_only")
+	}
 	if profile.TimeoutMS <= 0 || profile.TimeoutMS > 30000 {
 		return errors.New("timeout_ms must be between 1 and 30000")
+	}
+	if profile.InputLimit < MinInputLimit || profile.InputLimit > MaxInputLimit {
+		return fmt.Errorf("input_limit must be between %d and %d", MinInputLimit, MaxInputLimit)
+	}
+	if profile.MaxChunks < 1 || profile.MaxChunks > MaxChunksLimit {
+		return fmt.Errorf("max_chunks must be between 1 and %d", MaxChunksLimit)
 	}
 	if profile.BlockHTTPStatus < 400 || profile.BlockHTTPStatus > 599 {
 		return errors.New("block_http_status must be between 400 and 599")
 	}
-	if profile.Mode == ModePreBlock && profile.KeywordMode != KeywordModeKeywordOnly && profile.APIKeySecret == "" {
-		return errors.New("api_key is required for API moderation in pre_block mode")
+	// Only the API path needs an upstream; keyword_only never leaves the process.
+	if profile.Mode == ModePreBlock && profile.KeywordMode != KeywordModeKeywordOnly {
+		switch profile.Backend {
+		case BackendOpenAIModerations:
+			if profile.APIKeySecret == "" {
+				return errors.New("api_key is required for API moderation in pre_block mode")
+			}
+		case BackendQwen3Guard:
+			// Self-hosted guard endpoints (vLLM, SGLang, Ollama) commonly run
+			// without auth, so api_key stays optional here; the endpoint
+			// address and model do not have usable defaults and are required.
+			if profile.BaseURL == "" {
+				return errors.New("base_url is required for qwen3guard in pre_block mode")
+			}
+			if profile.Model == "" {
+				return errors.New("model is required for qwen3guard in pre_block mode")
+			}
+		}
+	}
+	if profile.BaseURL != "" {
+		if _, err := normalizeModerationBaseURL(profile.BaseURL); err != nil {
+			return err
+		}
 	}
 	for category, threshold := range profile.Thresholds {
 		if strings.TrimSpace(category) == "" || threshold < 0 || threshold > 1 {
 			return fmt.Errorf("invalid threshold for category %q", category)
+		}
+	}
+	for _, category := range profile.Scanners {
+		if !IsScannerID(category) {
+			return fmt.Errorf("unknown scanner category %q", category)
+		}
+	}
+	for _, category := range profile.ElevatedCategories {
+		if !IsScannerID(category) {
+			return fmt.Errorf("unknown elevated category %q", category)
 		}
 	}
 	return nil


### PR DESCRIPTION
## 背景

内容审核只能对接 OpenAI `/v1/moderations`：路径、请求体、响应结构、阈值决策四层全部写死在单个 `callModeration` 里，换任何一种审核模型都无从下手。

本 PR 引入 backend 抽象，让同一套 profile / 渠道绑定 / 热路径挂载点额外支持 **Qwen3Guard-Gen**（走 OpenAI 兼容的 chat completions，可自建 vLLM / SGLang / Ollama）。

方案文档：`docs/plan/086-qwen3guard-moderation-backend-20260809.md`（治理仓）。

## 改动

- 抽出 `moderationBackend` 接口，拆为 `backend_openai.go` / `backend_qwen3guard.go` / `qwen3guard_catalog.go` / `httpclient.go`。`Evaluate` 骨架（mode → 关键词 → 后端 → 决策 → fail-open）不变。
- Qwen3Guard 返回两行文本而非分数，后端解析后把三态标签投影到既有的 score / category 字段，日志与管理端 UI 无需改造即可消费。
- `Profile` 增 6 个字段（`backend` / `scanners` / `controversial_action` / `elevated_categories` / `input_limit` / `max_chunks`），additive `ALTER TABLE` 迁移。

### 策略决策

- **Controversial → 默认对 jailbreak / PII / self-harm 阻断**（可配置）。这三类误放的代价高于误拦：越狱针对本服务，PII 有合规责任，自残有人身风险。
- **Unsafe 但命中类别全部未启用 → 放行**；未知或未具名风险仍阻断。
- **`timeout_ms` 改为整体预算**而非单次 HTTP 超时，分块扫描不会把承诺的延迟翻倍。超 `max_chunks` 的尾部截断并记 `truncated_chars` 告警，不静默丢弃。
- **`max_tokens` 用 128 而非 64**（对齐模型卡的 `max_new_tokens`）。64 会在 Categories 行列全 9 类时截断——前缀已输出，解析不报错，只会静默丢掉后半截类别，恰好在命中最多时漏判。
- **不发 `seed`**：模型卡未要求，`temperature: 0` 已足够确定，少一个非标准字段就少一份端点兼容风险。

### 顺带加固（新旧后端共用）

- 响应体限到 256 KiB，替代原先无上限地流进 JSON decoder。
- base URL 拒绝 userinfo / query / fragment，结尾 `/v1` 归一避免拼出 `/v1/v1/...`。
- **不封内网**：guard 端点绝大多数是内网自建，封掉等于封掉主要用法。

## 兼容性

存量 profile 迁移到 `backend=openai_moderations`，行为逐字节不变。`TestInitTablesMigratesLegacyProfilesToOpenAIBackend` 建旧 schema、灌旧数据、验证迁移后仍打 `/v1/moderations`，且 version / api_key / thresholds 原样保留。管理端 handler 通过嵌入 `Profile` 透传，路由与权限未变。

## 验证

本地执行 `TZ=UTC ./scripts/ci-pr.sh`，**全流程通过**（结构检查、gofmt、secret scan、`go vet`、`go test ./...`、updater 模块、golangci-lint v1.64.5、`go build`）。

⚠️ 需要 `TZ=UTC` 的原因：`TestGetAuthFileTrendUsesWeeklyResetCycleForRequestTotal` 在非 UTC 时区的开发机上失败，**与本 PR 无关**——已在干净 `origin/dev` 上用 `git stash` 复现确认。该测试从 `time.Now()` 构造 fixture 并断言 7 日分桶合计，本地时区平移日界后有一个数据点掉出窗口。GitHub Actions 运行在 UTC，required check 不受影响。属独立议题，未在本 PR 处理。

新增测试覆盖：解析器（14 个变体，含 CRLF / 大小写 / Refusal 行 / 重复行 / 官方 9 类全集 / 截断片段）、决策映射（13 个组合）、分块（多字节安全、截断计数）、协议隔离（断言 qwen3guard 绝不请求 `/v1/moderations`）、请求形状（无 seed、max_tokens=128、无鉴权时不发 Authorization）、fail-open（上游 5xx / 非法响应 / 超大响应 / 预算耗尽）、迁移、校验分支、base URL 规范化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)