### PR TITLE
fix: keep request logs independent from usage rollups

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -234,6 +234,10 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 
 		if detail, ok := parseCodexUsage(line); ok {
 			reporter.publishWithContentBytes(execCtx.Context, detail, req.Payload, string(data))
+		} else {
+			reporter.setInputContentBytes(req.Payload)
+			reporter.appendOutputChunk(data)
+			reporter.ensurePublished(execCtx.Context)
 		}
 
 		var param any
@@ -428,7 +432,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				if bytes.HasPrefix(eventLine, dataTag) {
 					data := bytes.TrimSpace(eventLine[len(dataTag):])
 					switch gjson.GetBytes(data, "type").String() {
-					case "response.completed":
+					case "response.completed", "response.done":
 						completed = true
 						if detail, ok := parseCodexUsage(data); ok {
 							reporter.publish(execCtx.Context, detail)
@@ -451,10 +455,6 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			}
 		}
 		if errScan := scanner.Err(); errScan != nil {
-			if shouldSuppressUsageFailure(errScan, "") {
-				out <- cliproxyexecutor.StreamChunk{Err: errScan}
-				return
-			}
 			recorder.RecordResponseError(errScan)
 			reporter.publishFailure(execCtx.Context)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}

--- a/internal/runtime/executor/codex_executor_responses_bridge_test.go
+++ b/internal/runtime/executor/codex_executor_responses_bridge_test.go
@@ -7,11 +7,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	"github.com/tidwall/gjson"
 )
@@ -132,6 +134,137 @@ func TestCodexExecutorExecuteStreamPreservesResponsesImageBridgeModel(t *testing
 	}
 	if got := gjson.Get(lastBody, "tools.0.model").String(); got != "gpt-image-2" {
 		t.Fatalf("tools.0.model = %q, want %q; body=%s", got, "gpt-image-2", lastBody)
+	}
+}
+
+func TestCodexExecutorExecuteStreamPublishesUsageForResponseDone(t *testing.T) {
+	const model = "gpt-response-done-log-test"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/backend-api/codex/responses" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(
+			"data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n" +
+				"data: {\"type\":\"response.done\",\"response\":{\"id\":\"resp_1\",\"model\":\"" + model + "\",\"usage\":{\"input_tokens\":3,\"output_tokens\":2,\"total_tokens\":5}}}\n\n" +
+				"data: [DONE]\n\n",
+		))
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "codex-auth-stream-response-done",
+		Provider: "codex",
+		Status:   cliproxyauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url": server.URL + "/backend-api/codex",
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"account_id":   "account-1",
+		},
+	}
+
+	stream, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   model,
+		Payload: []byte(`{"model":"` + model + `","input":"hi","stream":true}`),
+		Format:  sdktranslator.FromString("openai-response"),
+	}, cliproxyexecutor.Options{
+		Stream:       true,
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range stream.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Provider != "codex" || record.Model != model {
+				continue
+			}
+			if record.Failed {
+				t.Fatal("response.done stream with usage should not be marked failed")
+			}
+			if !record.Streaming {
+				t.Fatal("response.done usage record should be marked streaming")
+			}
+			if record.Detail.InputTokens != 3 || record.Detail.OutputTokens != 2 || record.Detail.TotalTokens != 5 {
+				t.Fatalf("usage = %d/%d/%d, want 3/2/5", record.Detail.InputTokens, record.Detail.OutputTokens, record.Detail.TotalTokens)
+			}
+			return
+		case <-timer.C:
+			t.Fatal("timed out waiting for Codex response.done usage record")
+		}
+	}
+}
+
+func TestCodexExecutorExecutePublishesUsageRecordWithoutUsage(t *testing.T) {
+	const model = "gpt-codex-no-usage-log-test"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/backend-api/codex/responses" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"" + model + "\",\"output\":[]}}\n\n"))
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "codex-auth-no-usage",
+		Provider: "codex",
+		Status:   cliproxyauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url": server.URL + "/backend-api/codex",
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"account_id":   "account-1",
+		},
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   model,
+		Payload: []byte(`{"model":"` + model + `","input":"hi"}`),
+		Format:  sdktranslator.FromString("openai-response"),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Provider != "codex" || record.Model != model {
+				continue
+			}
+			if record.Failed {
+				t.Fatal("completed response without usage should not be marked failed")
+			}
+			if record.Streaming {
+				t.Fatal("non-stream response should not be marked streaming")
+			}
+			return
+		case <-timer.C:
+			t.Fatal("timed out waiting for Codex no-usage success record")
+		}
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -425,8 +425,14 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	go func() {
 		terminateReason := "completed"
 		var terminateErr error
+		completed := false
 
 		defer close(out)
+		defer func() {
+			if completed {
+				reporter.ensurePublished(execCtx.Context)
+			}
+		}()
 		defer func() {
 			if sess != nil {
 				sess.clearActive(readCh)
@@ -518,6 +524,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			for _, eventPayload := range normalizedEvents {
 				eventType := gjson.GetBytes(eventPayload, "type").String()
 				if eventType == "response.completed" || eventType == "response.done" {
+					completed = true
 					if detail, ok := parseCodexUsage(eventPayload); ok {
 						reporter.publish(execCtx.Context, detail)
 					}

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -260,6 +261,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
+	reporter.setInputContent(string(req.Payload))
 	go func() {
 		defer close(out)
 		defer func() {
@@ -270,17 +272,21 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, streamScannerBuffer)
 		var param any
+		var lastUsage cliproxyusage.Detail
+		hasUsage := false
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			recorder.AppendResponseChunk(line)
+			if detail, ok := parseGeminiStreamUsage(line); ok {
+				lastUsage = detail
+				hasUsage = true
+			}
 			filtered := FilterSSEUsageMetadata(line)
 			payload := jsonPayload(filtered)
 			if len(payload) == 0 {
 				continue
 			}
-			if detail, ok := parseGeminiStreamUsage(payload); ok {
-				reporter.publish(execCtx.Context, detail)
-			}
+			reporter.appendOutputChunk(payload)
 			lines := sdktranslator.TranslateStream(execCtx.Context, to, execCtx.SourceFormat, req.Model, opts.OriginalRequest, body, bytes.Clone(payload), &param)
 			for i := range lines {
 				out <- cliproxyexecutor.StreamChunk{Payload: []byte(lines[i])}
@@ -294,7 +300,13 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			recorder.RecordResponseError(errScan)
 			reporter.publishFailure(execCtx.Context)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			return
 		}
+		if hasUsage {
+			reporter.publish(execCtx.Context, lastUsage)
+			return
+		}
+		reporter.ensurePublished(execCtx.Context)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }

--- a/internal/runtime/executor/gemini_executor_usage_test.go
+++ b/internal/runtime/executor/gemini_executor_usage_test.go
@@ -1,0 +1,137 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+func TestGeminiExecuteStreamPublishesUsageRecordWithoutUsageMetadata(t *testing.T) {
+	const model = "gemini-log-fallback-test"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1beta/models/"+model+":streamGenerateContent" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hello\"}]}}]}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	auth := &cliproxyauth.Auth{
+		ID:       "gemini-log-fallback-auth",
+		Provider: "gemini",
+		Status:   cliproxyauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":  "test-key",
+			"base_url": server.URL,
+		},
+	}
+
+	stream, err := NewGeminiExecutor(&config.Config{}).ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   model,
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}],"stream":true}`),
+		Format:  sdktranslator.FromString("gemini"),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("gemini")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range stream.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Provider != "gemini" || record.Model != model {
+				continue
+			}
+			if record.Failed {
+				t.Fatal("completed stream without usage metadata should not be marked failed")
+			}
+			if !record.Streaming {
+				t.Fatal("completed stream usage record should be marked streaming")
+			}
+			return
+		case <-timer.C:
+			t.Fatal("timed out waiting for Gemini stream fallback usage record")
+		}
+	}
+}
+
+func TestGeminiExecuteStreamPublishesUsageFromFilteredMetadataChunk(t *testing.T) {
+	const model = "gemini-filtered-usage-log-test"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1beta/models/"+model+":streamGenerateContent" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hello\"}]}}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":3,\"totalTokenCount\":5}}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	auth := &cliproxyauth.Auth{
+		ID:       "gemini-filtered-usage-auth",
+		Provider: "gemini",
+		Status:   cliproxyauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":  "test-key",
+			"base_url": server.URL,
+		},
+	}
+
+	stream, err := NewGeminiExecutor(&config.Config{}).ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   model,
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}],"stream":true}`),
+		Format:  sdktranslator.FromString("gemini"),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("gemini")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range stream.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Provider != "gemini" || record.Model != model {
+				continue
+			}
+			if record.Failed {
+				t.Fatal("filtered usage metadata stream should not be marked failed")
+			}
+			if record.Detail.InputTokens != 2 || record.Detail.OutputTokens != 3 || record.Detail.TotalTokens != 5 {
+				t.Fatalf("usage = %d/%d/%d, want 2/3/5", record.Detail.InputTokens, record.Detail.OutputTokens, record.Detail.TotalTokens)
+			}
+			return
+		case <-timer.C:
+			t.Fatal("timed out waiting for Gemini filtered usage metadata record")
+		}
+	}
+}

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/contentmoderation"
 	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 )
 
 func setUsageBodyCaptureForTest(t *testing.T, enabled bool) {
@@ -80,6 +80,29 @@ func TestParseOpenAIUsageUnwrapsProviderDataEnvelope(t *testing.T) {
 	}
 }
 
+func TestParseCodexUsageAcceptsTopLevelUsage(t *testing.T) {
+	data := []byte(`{"type":"response.done","usage":{"input_tokens":4,"output_tokens":6,"total_tokens":10,"input_tokens_details":{"cached_tokens":2},"output_tokens_details":{"reasoning_tokens":3}}}`)
+	detail, ok := parseCodexUsage(data)
+	if !ok {
+		t.Fatal("parseCodexUsage() ok = false, want true")
+	}
+	if detail.InputTokens != 4 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 4)
+	}
+	if detail.OutputTokens != 6 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 6)
+	}
+	if detail.TotalTokens != 10 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 10)
+	}
+	if detail.CachedTokens != 2 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 2)
+	}
+	if detail.ReasoningTokens != 3 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 3)
+	}
+}
+
 func TestParseOpenAIResponseModel(t *testing.T) {
 	if got := parseOpenAIResponseModel([]byte(`{"model":"gpt-5.4","usage":{"total_tokens":1}}`)); got != "gpt-5.4" {
 		t.Fatalf("model = %q, want gpt-5.4", got)
@@ -125,19 +148,29 @@ func TestUsageReporterSpillsLargeStreamingOutputToTempFile(t *testing.T) {
 	}
 }
 
-func TestShouldSuppressUsageFailureForContextCanceled(t *testing.T) {
-	if !shouldSuppressUsageFailure(context.Canceled, "") {
-		t.Fatal("context.Canceled should not be published as a failed usage record")
-	}
-	wrapped := &urlErrorForTest{err: context.Canceled}
-	if !shouldSuppressUsageFailure(wrapped, "") {
-		t.Fatal("wrapped context.Canceled should not be published as a failed usage record")
-	}
-	if !shouldSuppressUsageFailure(nil, `Post "https://chatgpt.com/backend-api/codex/responses": context canceled`) {
-		t.Fatal("context canceled output text should not be published as a failed usage record")
-	}
-	if shouldSuppressUsageFailure(errors.New("upstream 500"), "") {
-		t.Fatal("ordinary upstream errors should still be published as failed usage records")
+func TestUsageReporterPublishesContextCanceledFailure(t *testing.T) {
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	reporter := newUsageReporter(context.Background(), "gemini", "gemini-cancel-log-test", "gemini-cancel-log-test", nil)
+	err := context.Canceled
+	reporter.trackFailure(context.Background(), &err)
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Provider != "gemini" || record.Model != "gemini-cancel-log-test" {
+				continue
+			}
+			if !record.Failed {
+				t.Fatal("context canceled usage record should be marked failed")
+			}
+			return
+		case <-timer.C:
+			t.Fatal("timed out waiting for context canceled usage record")
+		}
 	}
 }
 

--- a/internal/runtime/executor/usage_parsers.go
+++ b/internal/runtime/executor/usage_parsers.go
@@ -11,19 +11,36 @@ import (
 func parseCodexUsage(data []byte) (usage.Detail, bool) {
 	usageNode := gjson.ParseBytes(data).Get("response.usage")
 	if !usageNode.Exists() {
+		usageNode = gjson.ParseBytes(data).Get("usage")
+	}
+	if !usageNode.Exists() {
 		return usage.Detail{}, false
 	}
+	inputNode := usageNode.Get("input_tokens")
+	if !inputNode.Exists() {
+		inputNode = usageNode.Get("prompt_tokens")
+	}
+	outputNode := usageNode.Get("output_tokens")
+	if !outputNode.Exists() {
+		outputNode = usageNode.Get("completion_tokens")
+	}
 	detail := usage.Detail{
-		InputTokens:  usageNode.Get("input_tokens").Int(),
-		OutputTokens: usageNode.Get("output_tokens").Int(),
+		InputTokens:  inputNode.Int(),
+		OutputTokens: outputNode.Int(),
 		TotalTokens:  usageNode.Get("total_tokens").Int(),
 	}
 	if cached := usageNode.Get("input_tokens_details.cached_tokens"); cached.Exists() {
 		detail.CacheReadTokens = cached.Int()
 		detail.CachedTokens = detail.CacheReadTokens
 		detail.CacheReadIncludedInInput = true
+	} else if cached := usageNode.Get("prompt_tokens_details.cached_tokens"); cached.Exists() {
+		detail.CacheReadTokens = cached.Int()
+		detail.CachedTokens = detail.CacheReadTokens
+		detail.CacheReadIncludedInInput = true
 	}
 	if reasoning := usageNode.Get("output_tokens_details.reasoning_tokens"); reasoning.Exists() {
+		detail.ReasoningTokens = reasoning.Int()
+	} else if reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens"); reasoning.Exists() {
 		detail.ReasoningTokens = reasoning.Int()
 	}
 	return detail, true

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 	"strings"
@@ -240,9 +239,6 @@ func (r *usageReporter) publishFailureWithContentBytes(ctx context.Context, inpu
 	if r == nil {
 		return
 	}
-	if shouldSuppressUsageFailure(nil, outputContent) {
-		return
-	}
 	r.streamingRequest = isStreamingUsageRequestBytes(inputContent)
 	r.contentMu.Lock()
 	if r.captureFullContent {
@@ -260,9 +256,6 @@ func (r *usageReporter) trackFailure(ctx context.Context, errPtr *error) {
 		return
 	}
 	if *errPtr != nil {
-		if shouldSuppressUsageFailure(*errPtr, "") {
-			return
-		}
 		r.contentMu.Lock()
 		if r.outputContent == "" && r.outputBuilder.Len() == 0 && r.outputFile == nil {
 			output := structuredUpstreamErrorJSON(*errPtr)
@@ -274,13 +267,6 @@ func (r *usageReporter) trackFailure(ctx context.Context, errPtr *error) {
 		r.contentMu.Unlock()
 		r.publishFailure(ctx)
 	}
-}
-
-func shouldSuppressUsageFailure(err error, outputContent string) bool {
-	if errors.Is(err, context.Canceled) {
-		return true
-	}
-	return strings.Contains(strings.ToLower(outputContent), "context canceled")
 }
 
 type upstreamBodyError interface {

--- a/internal/usage/request_log_write.go
+++ b/internal/usage/request_log_write.go
@@ -3,10 +3,15 @@ package usage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
+
+var errUsageProjectionBusy = errors.New("usage projection busy")
 
 func isRetryableUsageWriteErr(err error) bool {
 	if err == nil {
@@ -31,11 +36,6 @@ func insertLogIdentityOnce(
 	inputContent, outputContent, detailContent string,
 	shouldStoreContent bool,
 ) error {
-	// Shared projection lock before opening a DB tx so exclusive rebuilds never
-	// leave writers holding connections while waiting on the mutex (pool deadlock).
-	usageProjectionMu.RLock()
-	defer usageProjectionMu.RUnlock()
-
 	// 插入 request log 的事务由 usage 存储层统一拥有，不从外部 HTTP 请求透传 context，
 	// 以避免请求取消把已经选定要持久化的审计记录中断在半途。
 	tx, err := db.BeginTx(context.Background(), nil)
@@ -91,7 +91,11 @@ func insertLogIdentityOnce(
 		return fmt.Errorf("insert log: %w", err)
 	}
 
-	if errCommit := commitLogWithProjections(tx, rollupEvent{
+	if errCommit := tx.Commit(); errCommit != nil {
+		return fmt.Errorf("commit log insert: %w", errCommit)
+	}
+
+	projectRollupAfterLogInsert(db, rollupEvent{
 		TenantID:      tenantID,
 		APIKeyID:      apiKeyID,
 		EndUserID:     endUserID,
@@ -106,8 +110,49 @@ func insertLogIdentityOnce(
 		Tokens:        tokens,
 		Cost:          cost,
 		At:            timestamp,
-	}); errCommit != nil {
-		return fmt.Errorf("commit log insert: %w", errCommit)
-	}
+	})
 	return nil
+}
+
+func projectRollupAfterLogInsert(db *sql.DB, ev rollupEvent) {
+	for attempt := 0; attempt < 8; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt*attempt) * time.Millisecond)
+		}
+		if err := projectRollupOnce(db, ev); err != nil {
+			if errors.Is(err, errUsageProjectionBusy) || isRetryableUsageWriteErr(err) {
+				continue
+			}
+			log.Errorf("usage: project rollup after log insert: %v", err)
+			return
+		}
+		return
+	}
+	log.Errorf("usage: project rollup after log insert: retries exhausted")
+}
+
+func projectRollupOnce(db *sql.DB, ev rollupEvent) error {
+	if db == nil {
+		return nil
+	}
+	if !usageProjectionMu.TryRLock() {
+		return errUsageProjectionBusy
+	}
+	defer usageProjectionMu.RUnlock()
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("begin rollup tx: %w", err)
+	}
+	if usageDriver == "postgres" {
+		if _, err := tx.Exec(`SET LOCAL lock_timeout = '1500ms'`); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("set rollup lock timeout: %w", err)
+		}
+		if _, err := tx.Exec(`SET LOCAL statement_timeout = '3000ms'`); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("set rollup statement timeout: %w", err)
+		}
+	}
+	return commitLogWithProjections(tx, ev)
 }

--- a/internal/usage/usage_rollup_test.go
+++ b/internal/usage/usage_rollup_test.go
@@ -121,3 +121,43 @@ func TestQueryStatsDoesNotRequireRequestLogs(t *testing.T) {
 		t.Fatalf("expected rollup-backed stats, got %#v", stats)
 	}
 }
+
+func TestInsertLogPersistsDetailWhenRollupProjectionFails(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{StoreContent: false})
+
+	if _, err := getDB().Exec(`DROP TABLE usage_rollup_buckets`); err != nil {
+		t.Fatalf("drop rollup table: %v", err)
+	}
+
+	InsertLogWithDetailsIdentitySubjectUpstreamVisionStreaming(
+		systemTenantID,
+		"sk-rollup-fail",
+		"key-rollup-fail",
+		"subject-rollup-fail",
+		"Rollup Fail Test",
+		"gpt-rollup-fail",
+		"",
+		"",
+		"",
+		"openai-compatibility",
+		"test-channel",
+		"0",
+		false,
+		time.Now().UTC(),
+		100,
+		20,
+		TokenStats{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+		`{"model":"gpt-rollup-fail","stream":true}`,
+		"",
+		"",
+		true,
+	)
+
+	var count int
+	if err := getDB().QueryRow(`SELECT COUNT(*) FROM request_logs WHERE api_key_id = ?`, "key-rollup-fail").Scan(&count); err != nil {
+		t.Fatalf("count request log: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("request log count = %d, want 1", count)
+	}
+}

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -78,15 +78,14 @@ type queueItem struct {
 
 // Manager maintains a queue of usage records and delivers them to registered plugins.
 type Manager struct {
-	once     sync.Once
-	stopOnce sync.Once
-	cancel   context.CancelFunc
+	cancel context.CancelFunc
 
 	mu       sync.Mutex
 	cond     *sync.Cond
 	queue    []queueItem
 	capacity int
 	closed   bool
+	running  bool
 
 	pluginsMu sync.RWMutex
 	plugins   []Plugin
@@ -107,14 +106,22 @@ func (m *Manager) Start(ctx context.Context) {
 	if m == nil {
 		return
 	}
-	m.once.Do(func() {
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		var workerCtx context.Context
-		workerCtx, m.cancel = context.WithCancel(ctx)
-		go m.run(workerCtx)
-	})
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.mu.Lock()
+	if m.running {
+		m.mu.Unlock()
+		return
+	}
+	var workerCtx context.Context
+	workerCtx, m.cancel = context.WithCancel(ctx)
+	m.closed = false
+	m.running = true
+	m.mu.Unlock()
+
+	go m.run(workerCtx)
 }
 
 // Stop stops the dispatcher and drains the queue.
@@ -122,15 +129,23 @@ func (m *Manager) Stop() {
 	if m == nil {
 		return
 	}
-	m.stopOnce.Do(func() {
-		if m.cancel != nil {
-			m.cancel()
-		}
-		m.mu.Lock()
+	m.mu.Lock()
+	if !m.running {
 		m.closed = true
 		m.mu.Unlock()
 		m.cond.Broadcast()
-	})
+		return
+	}
+	if m.cancel != nil {
+		m.cancel()
+		m.cancel = nil
+	}
+	m.closed = true
+	m.cond.Broadcast()
+	for m.running {
+		m.cond.Wait()
+	}
+	m.mu.Unlock()
 }
 
 // Register appends a plugin to the delivery list.
@@ -173,6 +188,9 @@ func (m *Manager) run(ctx context.Context) {
 			m.cond.Wait()
 		}
 		if len(m.queue) == 0 && m.closed {
+			m.running = false
+			m.cancel = nil
+			m.cond.Broadcast()
 			m.mu.Unlock()
 			return
 		}

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -128,3 +128,33 @@ func TestManagerDoesNotRetainRequestContext(t *testing.T) {
 	}
 	manager.Stop()
 }
+
+func TestManagerRestartsAfterStop(t *testing.T) {
+	manager := NewManager(2)
+	plugin := &observingPlugin{seen: make(chan Record, 2)}
+	manager.Register(plugin)
+
+	manager.Publish(context.Background(), Record{Model: "before-stop"})
+	select {
+	case record := <-plugin.seen:
+		if record.Model != "before-stop" {
+			t.Fatalf("first record model = %q, want before-stop", record.Model)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("plugin did not receive first record")
+	}
+
+	manager.Stop()
+	manager.Start(context.Background())
+	manager.Publish(context.Background(), Record{Model: "after-restart"})
+
+	select {
+	case record := <-plugin.seen:
+		if record.Model != "after-restart" {
+			t.Fatalf("restarted record model = %q, want after-restart", record.Model)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("plugin did not receive record after manager restart")
+	}
+	manager.Stop()
+}


### PR DESCRIPTION
Draft PR for request-log reliability. It makes usage publication restartable and commits request_logs before best-effort rollup projection. Validated with targeted Go tests for executor, usage manager, and internal usage packages.