### PR TITLE
fix: throttle antigravity project id discovery

### DIFF
--- a/internal/runtime/executor/antigravity_auth.go
+++ b/internal/runtime/executor/antigravity_auth.go
@@ -125,7 +125,11 @@ func (e *AntigravityExecutor) refreshToken(ctx context.Context, auth *cliproxyau
 	auth.Metadata["expired"] = now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339)
 	auth.Metadata["type"] = antigravityAuthType
 	if errProject := e.ensureAntigravityProjectID(ctx, auth, tokenResp.AccessToken); errProject != nil {
-		log.Warnf("antigravity executor: ensure project id failed: %v", errProject)
+		if isAntigravityProjectIDMissing(errProject) {
+			log.Debugf("antigravity executor: project id unavailable: %v", errProject)
+		} else {
+			log.Warnf("antigravity executor: ensure project id failed: %v", errProject)
+		}
 	}
 	return auth, nil
 }
@@ -161,6 +165,10 @@ func (e *AntigravityExecutor) ensureAntigravityProjectID(ctx context.Context, au
 	auth.Metadata["project_id"] = strings.TrimSpace(projectID)
 
 	return nil
+}
+
+func isAntigravityProjectIDMissing(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no project_id in response")
 }
 
 func tokenExpiry(metadata map[string]any) time.Time {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -29,6 +29,13 @@ type FileTokenStore struct {
 	baseDir string
 }
 
+const (
+	projectIDFetchFailedAtKey = "project_id_fetch_failed_at"
+	projectIDFetchCooldown    = time.Hour
+)
+
+var fetchAntigravityProjectID = FetchAntigravityProjectID
+
 // NewFileTokenStore creates a token store that saves credentials to disk through the
 // TokenStorage implementation embedded in the token record.
 func NewFileTokenStore() *FileTokenStore {
@@ -209,7 +216,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		if pid, ok := metadata["project_id"].(string); ok {
 			projectID = strings.TrimSpace(pid)
 		}
-		if projectID == "" {
+		if projectID == "" && shouldAttemptProjectIDFetch(metadata, time.Now()) {
 			accessToken := extractAccessToken(metadata)
 			// For gemini type, the stored access_token is likely expired (~1h lifetime).
 			// Refresh it using the long-lived refresh_token before querying.
@@ -221,15 +228,14 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 				}
 			}
 			if accessToken != "" {
-				fetchedProjectID, errFetch := FetchAntigravityProjectID(context.Background(), accessToken, http.DefaultClient)
+				fetchedProjectID, errFetch := fetchAntigravityProjectID(context.Background(), accessToken, http.DefaultClient)
 				if errFetch == nil && strings.TrimSpace(fetchedProjectID) != "" {
 					metadata["project_id"] = strings.TrimSpace(fetchedProjectID)
-					if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
-						if file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); errOpen == nil {
-							_, _ = file.Write(raw)
-							_ = file.Close()
-						}
-					}
+					delete(metadata, projectIDFetchFailedAtKey)
+					_ = persistAuthMetadata(path, metadata)
+				} else if errFetch != nil {
+					metadata[projectIDFetchFailedAtKey] = time.Now().UTC().Format(time.RFC3339)
+					_ = persistAuthMetadata(path, metadata)
 				}
 			}
 		}
@@ -263,6 +269,37 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		NextRefreshAfter: time.Time{},
 	}
 	return auth, nil
+}
+
+func shouldAttemptProjectIDFetch(metadata map[string]any, now time.Time) bool {
+	if metadata == nil {
+		return true
+	}
+	raw, ok := metadata[projectIDFetchFailedAtKey].(string)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return true
+	}
+	failedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(raw))
+	if err != nil {
+		return true
+	}
+	return now.Sub(failedAt) >= projectIDFetchCooldown
+}
+
+func persistAuthMetadata(path string, metadata map[string]any) error {
+	raw, errMarshal := json.Marshal(metadata)
+	if errMarshal != nil {
+		return errMarshal
+	}
+	file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)
+	if errOpen != nil {
+		return errOpen
+	}
+	if _, errWrite := file.Write(raw); errWrite != nil {
+		_ = file.Close()
+		return errWrite
+	}
+	return file.Close()
 }
 
 // buildFileAuthAttributes keeps disk-loaded credentials aligned with OAuth login

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -274,6 +276,84 @@ func TestFileTokenStoreListNormalizesXAIImportMetadata(t *testing.T) {
 	}
 	if persisted["auth_kind"] != "oauth" || persisted["type"] != "xai" {
 		t.Fatalf("persisted = %#v", persisted)
+	}
+}
+
+func TestFileTokenStoreListRecordsProjectIDFetchFailureCooldown(t *testing.T) {
+	dir := t.TempDir()
+	fileName := "antigravity-missing-project.json"
+	path := filepath.Join(dir, fileName)
+	data := []byte(`{"type":"antigravity","email":"anti@example.com","access_token":"access","refresh_token":"refresh"}`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	origFetch := fetchAntigravityProjectID
+	defer func() { fetchAntigravityProjectID = origFetch }()
+	calls := 0
+	fetchAntigravityProjectID = func(context.Context, string, *http.Client) (string, error) {
+		calls++
+		return "", errors.New("no project_id in response")
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	if _, err := store.List(context.Background()); err != nil {
+		t.Fatalf("first List: %v", err)
+	}
+	if _, err := store.List(context.Background()); err != nil {
+		t.Fatalf("second List: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("project fetch calls = %d, want 1", calls)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var persisted map[string]any
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := persisted[projectIDFetchFailedAtKey].(string); !ok {
+		t.Fatalf("missing %s in persisted metadata: %#v", projectIDFetchFailedAtKey, persisted)
+	}
+}
+
+func TestFileTokenStoreListSkipsProjectIDFetchDuringCooldown(t *testing.T) {
+	dir := t.TempDir()
+	fileName := "antigravity-cooldown.json"
+	path := filepath.Join(dir, fileName)
+	data, err := json.Marshal(map[string]any{
+		"type":                    "antigravity",
+		"email":                   "anti@example.com",
+		"access_token":            "access",
+		"refresh_token":           "refresh",
+		projectIDFetchFailedAtKey: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	origFetch := fetchAntigravityProjectID
+	defer func() { fetchAntigravityProjectID = origFetch }()
+	calls := 0
+	fetchAntigravityProjectID = func(context.Context, string, *http.Client) (string, error) {
+		calls++
+		return "project-id", nil
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	if _, err := store.List(context.Background()); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("project fetch calls = %d, want 0", calls)
 	}
 }
 


### PR DESCRIPTION
Draft PR for Antigravity project_id discovery. It records a cooldown after failed project-id discovery and demotes the known no-project-id response from warn to debug while preserving warnings for other failures. Validated with targeted Go tests for sdk/auth and runtime executor.