### PR TITLE
feat(security): IP access control and authentication attempt telemetry

### DIFF
--- a/internal/api/handlers/management/auth_observability.go
+++ b/internal/api/handlers/management/auth_observability.go
@@ -1,0 +1,162 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+)
+
+// autoBanWriteTimeout bounds the database write that arms an automatic ban. It
+// uses its own context rather than the request's: the client being rejected is
+// often the one that disconnects, and a ban that vanished because the attacker
+// hung up would be worse than no ban at all.
+const autoBanWriteTimeout = 5 * time.Second
+
+// surfaceForScope maps a throttle bucket to the door it guards, so callers never
+// pass a surface string that could drift from the scope it describes.
+func surfaceForScope(scope throttleScope) string {
+	switch scope {
+	case scopeManagementKey:
+		return authevents.SurfaceManagementKey
+	case scopeUserPassword, scopeUserAccount:
+		return authevents.SurfaceAdminLogin
+	case scopePortalPassword, scopePortalAccount:
+		return authevents.SurfacePortalLogin
+	case scopeRefresh:
+		return authevents.SurfaceRefresh
+	default:
+		return authevents.SurfaceRequest
+	}
+}
+
+// throttleEvaluate reports a bucket's standing, honouring allow-list exemption.
+//
+// An allow-listed source skips the throttle entirely rather than getting a
+// larger budget: the operator has asserted the address is theirs, and the point
+// of the exemption is that an office NAT behind one address cannot lock itself
+// out by collective typo.
+func (h *Handler) throttleEvaluate(c *gin.Context, key throttleKey, now time.Time) throttleDecision {
+	if ipaccess.ExemptFromThrottle(c) {
+		return throttleDecision{Scope: key.Scope}
+	}
+	return h.loginThrottle.evaluate(key, now)
+}
+
+// throttleCharge charges one failure against a bucket, honouring exemption.
+//
+// Charging and observability are separate calls because a single failed login
+// charges two buckets (per-IP and per-account) but is still one attempt: folding
+// the event write into the charge would double every row in the attempt log and
+// halve the effective auto-ban threshold.
+func (h *Handler) throttleCharge(c *gin.Context, key throttleKey, now time.Time) throttleDecision {
+	if ipaccess.ExemptFromThrottle(c) {
+		return throttleDecision{Scope: key.Scope}
+	}
+	return h.loginThrottle.recordFailure(key, now)
+}
+
+// noteCredentialFailure records one real credential failure: exactly one attempt
+// row and one auto-ban charge. Call it once per attempt, never once per bucket.
+func (h *Handler) noteCredentialFailure(c *gin.Context, key throttleKey, decision throttleDecision, username, reason string) {
+	if ipaccess.ExemptFromThrottle(c) {
+		return
+	}
+	outcome := authevents.OutcomeFailure
+	if decision.Outcome != outcomeAllow {
+		outcome = authevents.OutcomeThrottled
+	}
+	h.recordAuthAttempt(c, key, outcome, username, reason)
+	h.feedAutoBan(c, key, username, reason)
+}
+
+// noteNonCredentialFailure records a rejection that proves nothing about any
+// secret — a missing credential, a malformed refresh token — so it is logged for
+// visibility but never counted towards a ban.
+func (h *Handler) noteNonCredentialFailure(c *gin.Context, key throttleKey, decision throttleDecision, reason string) {
+	if ipaccess.ExemptFromThrottle(c) {
+		return
+	}
+	outcome := authevents.OutcomeFailure
+	if decision.Outcome != outcomeAllow {
+		outcome = authevents.OutcomeThrottled
+	}
+	h.recordAuthAttempt(c, key, outcome, "", reason)
+}
+
+// noteThrottledAttempt records an attempt turned away by an already-armed block.
+// The throttle deliberately does not count these, but they are the bulk of an
+// attack's traffic and the only evidence of how long it kept going.
+func (h *Handler) noteThrottledAttempt(c *gin.Context, key throttleKey, username string) {
+	if ipaccess.ExemptFromThrottle(c) {
+		return
+	}
+	h.recordAuthAttempt(c, key, authevents.OutcomeThrottled, username, "rejected by an armed throttle")
+}
+
+// noteAuthSuccess records a successful authentication.
+//
+// Only interactive logins are recorded, not every management-key request: the
+// key is verified on every management API call, so logging those successes would
+// bury the attempt log under ordinary panel traffic. "This source failed ninety
+// times and then succeeded" is the line worth keeping.
+func (h *Handler) noteAuthSuccess(c *gin.Context, key throttleKey, username string) {
+	h.recordAuthAttempt(c, key, authevents.OutcomeSuccess, username, "")
+}
+
+func (h *Handler) recordAuthAttempt(c *gin.Context, key throttleKey, outcome, username, reason string) {
+	recorder := authevents.Default()
+	if recorder == nil {
+		return
+	}
+	address := ipaccess.AddressFor(c)
+	if username == "" && (key.Scope == scopeUserAccount || key.Scope == scopePortalAccount) {
+		username = key.Value
+	}
+	event := authevents.Event{
+		IP:       address.Raw,
+		IPPrefix: ipaccess.BanCIDR(address.IP),
+		Trusted:  address.Trusted,
+		Scope:    key.Scope.String(),
+		Surface:  surfaceForScope(key.Scope),
+		Username: username,
+		Outcome:  outcome,
+		Reason:   reason,
+	}
+	if c != nil && c.Request != nil {
+		event.RequestPath = c.Request.URL.Path
+		event.UserAgent = c.Request.UserAgent()
+		event.RequestID = logging.GetGinRequestID(c)
+	}
+	recorder.Record(event)
+}
+
+func (h *Handler) feedAutoBan(c *gin.Context, key throttleKey, username, reason string) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		return
+	}
+	address := ipaccess.AddressFor(c)
+	if address.IP == nil {
+		return
+	}
+	if reason == "" {
+		reason = "repeated authentication failures (" + key.Scope.String() + ")"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), autoBanWriteTimeout)
+	defer cancel()
+	outcome := registry.AutoBan().RecordFailure(ctx, address, reason)
+	if !outcome.Triggered {
+		return
+	}
+	result := authevents.OutcomeWouldBan
+	if outcome.Enforced {
+		result = authevents.OutcomeAutoBanned
+	}
+	h.recordAuthAttempt(c, key, result, username,
+		fmt.Sprintf("auto-ban rule matched %s after %d failures", outcome.CIDR, outcome.Failures))
+}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -126,8 +126,10 @@ func (h *Handler) SetConfig(cfg *config.Config) {
 	h.mu.Unlock()
 	// Throttle thresholds are part of the reloadable config, so a limit raised in
 	// config.yaml has to take effect without a restart — otherwise the documented
-	// escape hatch for an over-tight limit is "restart the server".
-	h.loginThrottle.setPolicies(throttlePoliciesFromConfig(cfg))
+	// escape hatch for an over-tight limit is "restart the server". Panel-set
+	// overrides are re-applied on top, or a config reload would silently revert
+	// them while the panel kept displaying them as active.
+	h.loginThrottle.setPolicies(overlayThrottleOverride(throttlePoliciesFromConfig(cfg), storedThrottleOverride()))
 }
 
 // SetAuthManager updates the auth manager reference used by management endpoints.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -62,6 +62,10 @@ type trendCacheEntry struct {
 func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Manager) *Handler {
 	envSecret, _ := os.LookupEnv("MANAGEMENT_PASSWORD")
 	envSecret = strings.TrimSpace(envSecret)
+	// IP access control follows database availability, not one startup path: any
+	// caller that assembles the management API itself must get a working registry
+	// rather than 503 on every rule endpoint.
+	ensureIPAccessRuntime(cfg)
 
 	h := &Handler{
 		cfg:                 cfg,
@@ -124,6 +128,7 @@ func (h *Handler) SetConfig(cfg *config.Config) {
 	// Recreate lazily so provider probes use the new proxy/TLS/runtime config.
 	h.aiAccountStatus = nil
 	h.mu.Unlock()
+	ensureIPAccessRuntime(cfg)
 	// Throttle thresholds are part of the reloadable config, so a limit raised in
 	// config.yaml has to take effect without a restart — otherwise the documented
 	// escape hatch for an over-tight limit is "restart the server". Panel-set

--- a/internal/api/handlers/management/identity_auth_login.go
+++ b/internal/api/handlers/management/identity_auth_login.go
@@ -15,7 +15,8 @@ func (h *Handler) PostLogin(c *gin.Context) {
 	// Password entry gets its own per-IP bucket, separate from the management-key
 	// bucket: a wrong management key must never cost users their ability to log in.
 	ipKey := h.clientThrottleKey(c, scopeUserPassword)
-	if d := h.loginThrottle.evaluate(ipKey, now); d.Outcome != outcomeAllow {
+	if d := h.throttleEvaluate(c, ipKey, now); d.Outcome != outcomeAllow {
+		h.noteThrottledAttempt(c, ipKey, "")
 		abortLoginThrottled(c, d)
 		return
 	}
@@ -32,7 +33,8 @@ func (h *Handler) PostLogin(c *gin.Context) {
 	// The account bucket is the layer that actually stops guessing: it survives an
 	// attacker rotating source addresses, which the per-IP bucket cannot.
 	acctKey := accountThrottleKey(scopeUserAccount, identity.NormalizeUsername(body.Username))
-	if d := h.loginThrottle.evaluate(acctKey, now); d.Outcome != outcomeAllow {
+	if d := h.throttleEvaluate(c, acctKey, now); d.Outcome != outcomeAllow {
+		h.noteThrottledAttempt(c, acctKey, body.Username)
 		abortLoginThrottled(c, d)
 		return
 	}
@@ -44,9 +46,12 @@ func (h *Handler) PostLogin(c *gin.Context) {
 	result, err := service.Login(c.Request.Context(), body.Username, body.Password, body.RememberMe, c.GetHeader("User-Agent"))
 	if err != nil {
 		if isCredentialGuessFailure(err) {
-			h.loginThrottle.recordFailure(ipKey, now)
-			d := h.loginThrottle.recordFailure(acctKey, now)
+			h.throttleCharge(c, ipKey, now)
+			d := h.throttleCharge(c, acctKey, now)
 			h.logAuthFailure(c, acctKey, d)
+			// One attempt, one record: the two charges above are two views of the
+			// same failure.
+			h.noteCredentialFailure(c, acctKey, d, body.Username, "invalid password")
 		}
 		identityError(c, err)
 		return
@@ -55,6 +60,7 @@ func (h *Handler) PostLogin(c *gin.Context) {
 	// per-IP quota — an attacker holding one valid account of their own would
 	// otherwise reset their guessing budget between stuffing rounds.
 	h.loginThrottle.recordSuccess(acctKey)
+	h.noteAuthSuccess(c, acctKey, body.Username)
 	c.JSON(http.StatusOK, result)
 }
 
@@ -91,7 +97,9 @@ func (h *Handler) PostRefresh(c *gin.Context) {
 	// Unauthenticated and one database lookup per call: charge every attempt, not
 	// just the failures, because a caller that can already refresh successfully
 	// has no reason to do so sixty times in five minutes.
-	if d := h.loginThrottle.recordFailure(h.clientThrottleKey(c, scopeRefresh), time.Now()); d.Outcome != outcomeAllow {
+	refreshKey := h.clientThrottleKey(c, scopeRefresh)
+	if d := h.throttleCharge(c, refreshKey, time.Now()); d.Outcome != outcomeAllow {
+		h.noteNonCredentialFailure(c, refreshKey, d, "refresh endpoint rate limit")
 		abortThrottled(c, d)
 		return
 	}

--- a/internal/api/handlers/management/ip_access.go
+++ b/internal/api/handlers/management/ip_access.go
@@ -1,0 +1,252 @@
+package management
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
+)
+
+func ipAccessUnavailable(c *gin.Context) {
+	c.JSON(http.StatusServiceUnavailable, gin.H{
+		"error": gin.H{"code": "ip_access_unavailable", "message": "ip access control requires the database backend"},
+	})
+}
+
+func ipAccessBadRequest(c *gin.Context, err error) {
+	c.JSON(http.StatusBadRequest, gin.H{
+		"error": gin.H{"code": "invalid_rule", "message": err.Error()},
+	})
+}
+
+// GetIPAccessRules lists allow/deny rules.
+func (h *Handler) GetIPAccessRules(c *gin.Context) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		ipAccessUnavailable(c)
+		return
+	}
+	filter := ipaccess.ListFilter{
+		Effect: c.Query("effect"),
+		Source: c.Query("source"),
+		Search: c.Query("search"),
+	}
+	if raw := strings.TrimSpace(c.Query("enabled")); raw != "" {
+		if enabled, err := strconv.ParseBool(raw); err == nil {
+			filter.Enabled = &enabled
+		}
+	}
+	filter.Page, _ = strconv.Atoi(c.DefaultQuery("page", "1"))
+	filter.Size, _ = strconv.Atoi(c.DefaultQuery("size", "50"))
+
+	rules, total, err := registry.Store().List(c.Request.Context(), filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "list_failed", "message": err.Error()}})
+		return
+	}
+	if rules == nil {
+		rules = []ipaccess.Rule{}
+	}
+	c.JSON(http.StatusOK, gin.H{"items": rules, "total": total, "page": filter.Page, "size": filter.Size})
+}
+
+// PostIPAccessRule creates a rule.
+func (h *Handler) PostIPAccessRule(c *gin.Context) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		ipAccessUnavailable(c)
+		return
+	}
+	var body struct {
+		CIDR      string `json:"cidr"`
+		Effect    string `json:"effect"`
+		Note      string `json:"note"`
+		Reason    string `json:"reason"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		ipAccessBadRequest(c, err)
+		return
+	}
+	effect, err := ipaccess.ParseEffect(body.Effect)
+	if err != nil {
+		ipAccessBadRequest(c, err)
+		return
+	}
+	input := ipaccess.CreateInput{
+		CIDR:   body.CIDR,
+		Effect: effect,
+		Source: ipaccess.SourceManual,
+		Reason: body.Reason,
+		Note:   body.Note,
+	}
+	if trimmed := strings.TrimSpace(body.ExpiresAt); trimmed != "" {
+		expires, parseErr := time.Parse(time.RFC3339, trimmed)
+		if parseErr != nil {
+			ipAccessBadRequest(c, parseErr)
+			return
+		}
+		input.ExpiresAt = &expires
+	}
+	if principal, ok := principalFromContext(c); ok {
+		input.CreatedBy = principal.User.ID
+	}
+
+	// Refuse to deny the address making the request. The operator would lose the
+	// panel on the very next call, and recovering means editing the database by
+	// hand — a mistake the API can simply decline to make.
+	if effect == ipaccess.EffectDeny {
+		if blocked, checkErr := selfDenyCheck(c, input.CIDR); checkErr != nil {
+			ipAccessBadRequest(c, checkErr)
+			return
+		} else if blocked {
+			ipAccessBadRequest(c, errors.New("this rule would deny your own address; add it as an allow rule first or use a narrower range"))
+			return
+		}
+	}
+
+	rule, err := registry.Store().Create(c.Request.Context(), input)
+	if err != nil {
+		if errors.Is(err, ipaccess.ErrDuplicateRule) {
+			c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "duplicate_rule", "message": err.Error()}})
+			return
+		}
+		ipAccessBadRequest(c, err)
+		return
+	}
+	if refreshErr := registry.Refresh(c.Request.Context()); refreshErr != nil {
+		// The row is written; the snapshot will catch up on the next tick.
+		c.JSON(http.StatusCreated, gin.H{"rule": rule, "warning": "rule saved but the in-memory snapshot could not be refreshed immediately"})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"rule": rule})
+}
+
+// selfDenyCheck reports whether a proposed deny rule would cover the requester.
+func selfDenyCheck(c *gin.Context, cidr string) (bool, error) {
+	normalized, _, err := ipaccess.NormalizeCIDR(cidr)
+	if err != nil {
+		return false, err
+	}
+	address := ipaccess.AddressFor(c)
+	if address.IP == nil || !address.Trusted {
+		// An untrusted address cannot be compared meaningfully, and rules are not
+		// enforced in that state anyway.
+		return false, nil
+	}
+	candidate := ipaccess.Rule{CIDR: normalized, Effect: ipaccess.EffectDeny, Enabled: true}
+	probe := ipaccess.NewMatcher([]ipaccess.Rule{candidate}, false, time.Now())
+	decision, _ := probe.Match(address.IP)
+	return decision == ipaccess.DecisionDeny, nil
+}
+
+// PatchIPAccessRule updates the mutable fields of a rule.
+func (h *Handler) PatchIPAccessRule(c *gin.Context) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		ipAccessUnavailable(c)
+		return
+	}
+	var body struct {
+		Enabled   *bool   `json:"enabled"`
+		Note      *string `json:"note"`
+		ExpiresAt *string `json:"expires_at"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		ipAccessBadRequest(c, err)
+		return
+	}
+	input := ipaccess.UpdateInput{Enabled: body.Enabled, Note: body.Note}
+	if body.ExpiresAt != nil {
+		if strings.TrimSpace(*body.ExpiresAt) == "" {
+			input.ClearExpires = true
+		} else {
+			expires, err := time.Parse(time.RFC3339, *body.ExpiresAt)
+			if err != nil {
+				ipAccessBadRequest(c, err)
+				return
+			}
+			pointer := &expires
+			input.ExpiresAt = &pointer
+		}
+	}
+	rule, err := registry.Store().Update(c.Request.Context(), c.Param("id"), input)
+	if err != nil {
+		if errors.Is(err, ipaccess.ErrRuleNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "rule_not_found", "message": err.Error()}})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "update_failed", "message": err.Error()}})
+		return
+	}
+	_ = registry.Refresh(c.Request.Context())
+	c.JSON(http.StatusOK, gin.H{"rule": rule})
+}
+
+// DeleteIPAccessRule removes a rule.
+func (h *Handler) DeleteIPAccessRule(c *gin.Context) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		ipAccessUnavailable(c)
+		return
+	}
+	if err := registry.Store().Delete(c.Request.Context(), c.Param("id")); err != nil {
+		if errors.Is(err, ipaccess.ErrRuleNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "rule_not_found", "message": err.Error()}})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "delete_failed", "message": err.Error()}})
+		return
+	}
+	_ = registry.Refresh(c.Request.Context())
+	c.Status(http.StatusNoContent)
+}
+
+// GetIPAccessStatus reports whether the list is actually in force.
+//
+// This endpoint exists because the feature has a silent failure mode: behind an
+// unconfigured reverse proxy every rule is stored, listed and displayed, and
+// none of it is enforced. The panel renders this response as a banner so that
+// state is impossible to miss rather than something an operator discovers after
+// an incident.
+func (h *Handler) GetIPAccessStatus(c *gin.Context) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		ipAccessUnavailable(c)
+		return
+	}
+	address := ipaccess.AddressFor(c)
+	matcher := registry.Matcher()
+	policy := registry.Policy()
+
+	response := gin.H{
+		"client_ip":                  address.Raw,
+		"trusted":                    address.Trusted,
+		"relay_header":               address.RelayHeader,
+		"trusted_proxies_configured": registry.ProxyTrusted(),
+		"enforced":                   address.Trusted || address.Loopback(),
+		"lockdown":                   policy.Lockdown,
+		"active_rules":               matcher.Count(),
+		"storage_available":          registry.Store().Available(),
+		"auto_ban_mode":              policy.AutoBan.Mode,
+	}
+	if !address.Trusted && address.Raw != "" {
+		// Hand back the exact line to paste into config.yaml: the remedy is one
+		// setting, and every minute this stays unfixed is a minute the rules do
+		// nothing.
+		response["suggested_trusted_proxies"] = []string{address.Raw + "/32"}
+	}
+	if recorder := authevents.Default(); recorder != nil {
+		response["dropped_events"] = recorder.Dropped()
+	}
+	if address.IP != nil {
+		response["self_allowed"] = matcher.AllowsAddress(address.IP)
+		response["suggested_self_rule"] = ipaccess.BanCIDR(address.IP)
+	}
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/api/handlers/management/ip_access_bootstrap.go
+++ b/internal/api/handlers/management/ip_access_bootstrap.go
@@ -1,0 +1,37 @@
+package management
+
+import (
+	"context"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+// ensureIPAccessRuntime binds the allow/deny list and the attempt log to
+// whatever database the runtime currently holds.
+//
+// Both helpers are idempotent and re-bind when the pool is swapped, so calling
+// this from handler construction and from every config reload is cheap and
+// keeps the registry pointing at a live handle.
+//
+// Policy persistence is not wired here: it lives in the settings store, which
+// management handlers deliberately do not reach into. The CLI runner attaches
+// the persister on top. Without it the protection policy still applies, it just
+// resets to defaults on restart — a far better failure mode than the endpoints
+// answering 503.
+func ensureIPAccessRuntime(cfg *config.Config) {
+	db := usage.RuntimeDB()
+	if db == nil {
+		return
+	}
+	ctx := context.Background()
+	authevents.EnsureDefault(ctx, db)
+
+	var trustedProxies []string
+	if cfg != nil {
+		trustedProxies = cfg.TrustedProxies
+	}
+	ipaccess.EnsureDefault(ctx, db, ipaccess.ProxyTrustConfigured(trustedProxies))
+}

--- a/internal/api/handlers/management/ip_access_events.go
+++ b/internal/api/handlers/management/ip_access_events.go
@@ -1,0 +1,167 @@
+package management
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
+)
+
+// summaryWindows are the aggregation ranges the panel offers. Bounded to a
+// fixed set so a hand-crafted query cannot ask the database to group over the
+// entire retention period.
+var summaryWindows = map[string]time.Duration{
+	"1h":  time.Hour,
+	"6h":  6 * time.Hour,
+	"24h": 24 * time.Hour,
+	"7d":  7 * 24 * time.Hour,
+}
+
+const defaultSummaryWindow = "24h"
+
+func authEventsUnavailable(c *gin.Context) {
+	c.JSON(http.StatusServiceUnavailable, gin.H{
+		"error": gin.H{"code": "auth_events_unavailable", "message": "authentication attempt history requires the database backend"},
+	})
+}
+
+// GetAuthAttempts lists individual authentication attempts.
+func (h *Handler) GetAuthAttempts(c *gin.Context) {
+	recorder := authevents.Default()
+	if recorder == nil || !recorder.Available() {
+		authEventsUnavailable(c)
+		return
+	}
+	filter := authevents.ListFilter{
+		IPPrefix: strings.TrimSpace(c.Query("ip")),
+		Username: strings.TrimSpace(c.Query("username")),
+		Outcome:  strings.TrimSpace(c.Query("outcome")),
+		Surface:  strings.TrimSpace(c.Query("surface")),
+	}
+	filter.Page, _ = strconv.Atoi(c.DefaultQuery("page", "1"))
+	filter.Size, _ = strconv.Atoi(c.DefaultQuery("size", "50"))
+	if window, ok := summaryWindows[strings.TrimSpace(c.Query("window"))]; ok {
+		filter.Since = time.Now().Add(-window)
+	}
+
+	events, total, err := recorder.List(c.Request.Context(), filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "list_failed", "message": err.Error()}})
+		return
+	}
+	if events == nil {
+		events = []authevents.Event{}
+	}
+	c.JSON(http.StatusOK, gin.H{"items": events, "total": total, "page": filter.Page, "size": filter.Size})
+}
+
+// GetAuthAttemptSummary ranks sources by failure volume and annotates each with
+// its current standing in the rule list, so "who is attacking us" and "what have
+// I already done about it" are one answer instead of two screens.
+func (h *Handler) GetAuthAttemptSummary(c *gin.Context) {
+	recorder := authevents.Default()
+	if recorder == nil || !recorder.Available() {
+		authEventsUnavailable(c)
+		return
+	}
+	windowKey := strings.TrimSpace(c.DefaultQuery("window", defaultSummaryWindow))
+	window, ok := summaryWindows[windowKey]
+	if !ok {
+		windowKey = defaultSummaryWindow
+		window = summaryWindows[defaultSummaryWindow]
+	}
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+
+	summaries, err := recorder.Summarize(c.Request.Context(), time.Now().Add(-window), limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "summary_failed", "message": err.Error()}})
+		return
+	}
+	if summaries == nil {
+		summaries = []authevents.SourceSummary{}
+	}
+	annotateWithRules(summaries)
+	c.JSON(http.StatusOK, gin.H{"items": summaries, "window": windowKey})
+}
+
+// annotateWithRules fills in each source's current rule standing using the live
+// matcher rather than a SQL join, so a source covered by a /16 deny is reported
+// as blocked instead of appearing unhandled because no rule names it exactly.
+func annotateWithRules(summaries []authevents.SourceSummary) {
+	matcher := ipaccess.Default().Matcher()
+	if matcher == nil {
+		return
+	}
+	for i := range summaries {
+		probe := ipaccess.ParseIPForMatch(summaries[i].SampleIP)
+		if probe == nil {
+			continue
+		}
+		decision, rule := matcher.Match(probe)
+		if decision == ipaccess.DecisionNeutral {
+			continue
+		}
+		summaries[i].RuleEffect = decision.String()
+		if rule != nil {
+			summaries[i].RuleID = rule.ID
+			summaries[i].RuleExpires = rule.ExpiresAt
+		}
+	}
+}
+
+// GetIPAccessPolicy returns the current protection policy.
+func (h *Handler) GetIPAccessPolicy(c *gin.Context) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		ipAccessUnavailable(c)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"policy":   registry.Policy(),
+		"throttle": h.throttlePolicySnapshot(),
+	})
+}
+
+// PutIPAccessPolicy updates the protection policy.
+func (h *Handler) PutIPAccessPolicy(c *gin.Context) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		ipAccessUnavailable(c)
+		return
+	}
+	var body ipaccess.ProtectionPolicy
+	if err := c.ShouldBindJSON(&body); err != nil {
+		ipAccessBadRequest(c, err)
+		return
+	}
+	current := registry.Policy()
+
+	// Self-lockout guard. Turning on lockdown while the requester is not on the
+	// allow list locks the operator out on their next request, and the only
+	// recovery is editing the database by hand. Refuse, and say what to add.
+	if body.Lockdown && !current.Lockdown {
+		address := ipaccess.AddressFor(c)
+		if !address.Trusted && !address.Loopback() {
+			ipAccessBadRequest(c, errors.New("lockdown cannot be enabled while the client address is untrusted: configure trusted-proxies first, or the rules cannot identify anyone"))
+			return
+		}
+		if !address.Loopback() && !registry.Matcher().AllowsAddress(address.IP) {
+			ipAccessBadRequest(c, errors.New("lockdown would lock you out: add an allow rule covering "+ipaccess.BanCIDR(address.IP)+" first"))
+			return
+		}
+	}
+
+	if err := registry.UpdatePolicy(c.Request.Context(), body); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "policy_save_failed", "message": err.Error()}})
+		return
+	}
+	// Throttle overrides take effect on the running limiter immediately; they
+	// are otherwise indistinguishable from "saved but ignored".
+	h.applyThrottleOverride(registry.Policy().Throttle)
+	c.JSON(http.StatusOK, gin.H{"policy": registry.Policy(), "throttle": h.throttlePolicySnapshot()})
+}

--- a/internal/api/handlers/management/ip_access_throttle.go
+++ b/internal/api/handlers/management/ip_access_throttle.go
@@ -1,0 +1,124 @@
+package management
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
+)
+
+// applyThrottleOverride rebuilds the limiter's policy table from config and then
+// layers the operator's runtime overrides on top.
+//
+// It rebuilds from config rather than mutating the live table so that clearing
+// an override in the panel actually restores the configured value, instead of
+// leaving the last non-zero number in place forever.
+func (h *Handler) applyThrottleOverride(override ipaccess.ThrottleOverride) {
+	if h == nil {
+		return
+	}
+	policies := throttlePoliciesFromConfig(h.cfg)
+	policies = overlayThrottleOverride(policies, override)
+	h.loginThrottle.setPolicies(policies)
+}
+
+// storedThrottleOverride reads the persisted override, so a config reload does
+// not silently discard settings an operator made in the panel.
+func storedThrottleOverride() ipaccess.ThrottleOverride {
+	registry := ipaccess.Default()
+	if registry == nil {
+		return ipaccess.ThrottleOverride{}
+	}
+	return registry.Policy().Throttle
+}
+
+// throttlePolicySnapshot renders the effective limits for display. The panel
+// shows what is actually in force, not what was configured, because the two
+// differ whenever an override is set or a bucket is shared-key downgraded.
+func (h *Handler) throttlePolicySnapshot() []gin.H {
+	if h == nil || h.loginThrottle == nil {
+		return nil
+	}
+	snapshot := h.loginThrottle.policySnapshot()
+	scopes := []throttleScope{
+		scopeUnauthenticated, scopeManagementKey, scopeUserPassword,
+		scopeUserAccount, scopeRefresh, scopePortalPassword, scopePortalAccount,
+	}
+	rendered := make([]gin.H, 0, len(scopes))
+	for _, scope := range scopes {
+		policy, ok := snapshot[scope]
+		if !ok {
+			policy = defaultThrottlePolicies()[scope]
+		}
+		backoff := make([]string, 0, len(policy.Backoff))
+		for _, step := range policy.Backoff {
+			backoff = append(backoff, step.String())
+		}
+		rendered = append(rendered, gin.H{
+			"scope":         scope.String(),
+			"short_limit":   policy.Short.Limit,
+			"short_window":  policy.Short.Window.String(),
+			"long_limit":    policy.Long.Limit,
+			"long_window":   policy.Long.Window.String(),
+			"backoff":       backoff,
+			"reset_after":   policy.ResetAfter.String(),
+			"hard_block":    policy.HardBlock,
+			"key_dimension": throttleKeyDimension(scope),
+		})
+	}
+	return rendered
+}
+
+// throttleKeyDimension names what a bucket counts against. The panel shows it
+// because "too many login attempts" is ambiguous to the person reading it: the
+// per-IP and per-account buckets return the identical error code, and knowing
+// which one is armed is the difference between "wait" and "someone is guessing
+// my password".
+func throttleKeyDimension(scope throttleScope) string {
+	switch scope {
+	case scopeUserAccount, scopePortalAccount:
+		return "username"
+	default:
+		return "client_ip"
+	}
+}
+
+// overlayThrottleOverride applies operator overrides to a policy table. A zero
+// value means "keep whatever config or the shipped defaults said", so an
+// untouched field never rewrites configured behaviour.
+func overlayThrottleOverride(policies map[throttleScope]throttlePolicy, override ipaccess.ThrottleOverride) map[throttleScope]throttlePolicy {
+	if seconds := override.LoginFailureWindowSeconds; seconds > 0 {
+		window := time.Duration(seconds) * time.Second
+		for _, scope := range credentialGuessScopes {
+			policy := policies[scope]
+			policy.Short.Window = window
+			policies[scope] = policy
+		}
+	}
+	if hours := override.FailureResetHours; hours > 0 {
+		reset := time.Duration(hours) * time.Hour
+		for _, scope := range credentialGuessScopes {
+			policy := policies[scope]
+			policy.ResetAfter = reset
+			policies[scope] = policy
+		}
+	}
+	if limit := override.AccountFailureLimit; limit > 0 {
+		for _, scope := range []throttleScope{scopeUserAccount, scopePortalAccount} {
+			policy := policies[scope]
+			policy.Short.Limit = limit
+			policies[scope] = policy
+		}
+	}
+	if limit := override.ManagementKeyFailureLimit; limit > 0 {
+		policy := policies[scopeManagementKey]
+		policy.Short.Limit = limit
+		policies[scopeManagementKey] = policy
+	}
+	if limit := override.UnauthenticatedRequestLimit; limit > 0 {
+		policy := policies[scopeUnauthenticated]
+		policy.Short.Limit = limit
+		policies[scopeUnauthenticated] = policy
+	}
+	return policies
+}

--- a/internal/api/handlers/management/middleware_auth.go
+++ b/internal/api/handlers/management/middleware_auth.go
@@ -104,8 +104,9 @@ func (h *Handler) managementAuthMiddleware(c *gin.Context) {
 		// or compares a stored secret, and an already-banned client must not be able
 		// to make the server pay for that.
 		mgmtKey = h.clientThrottleKey(c, scopeManagementKey)
-		if d := h.loginThrottle.evaluate(mgmtKey, now); d.Outcome != outcomeAllow {
+		if d := h.throttleEvaluate(c, mgmtKey, now); d.Outcome != outcomeAllow {
 			h.logAuthFailure(c, mgmtKey, d)
+			h.noteThrottledAttempt(c, mgmtKey, "")
 			abortThrottled(c, d)
 			return
 		}
@@ -126,7 +127,9 @@ func (h *Handler) managementAuthMiddleware(c *gin.Context) {
 	if kind == credentialMissing {
 		if !localClient {
 			key := h.clientThrottleKey(c, scopeUnauthenticated)
-			if d := h.loginThrottle.recordFailure(key, now); d.Outcome != outcomeAllow {
+			d := h.throttleCharge(c, key, now)
+			h.noteNonCredentialFailure(c, key, d, "management request carried no credential")
+			if d.Outcome != outcomeAllow {
 				h.logAuthFailure(c, key, d)
 				abortThrottled(c, d)
 				return
@@ -156,8 +159,9 @@ func (h *Handler) managementAuthMiddleware(c *gin.Context) {
 
 	if secretHash == "" || bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) != nil {
 		if !localClient {
-			d := h.loginThrottle.recordFailure(mgmtKey, now)
+			d := h.throttleCharge(c, mgmtKey, now)
 			h.logAuthFailure(c, mgmtKey, d)
+			h.noteCredentialFailure(c, mgmtKey, d, "", "invalid management key")
 			if d.Outcome != outcomeAllow {
 				abortThrottled(c, d)
 				return

--- a/internal/api/handlers/management/portal_throttle.go
+++ b/internal/api/handlers/management/portal_throttle.go
@@ -23,14 +23,16 @@ import (
 func (h *Handler) PortalAuthThrottleMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		key := h.clientThrottleKey(c, scopePortalPassword)
-		if d := h.loginThrottle.evaluate(key, time.Now()); d.Outcome != outcomeAllow {
+		if d := h.throttleEvaluate(c, key, time.Now()); d.Outcome != outcomeAllow {
+			h.noteThrottledAttempt(c, key, "")
 			abortThrottled(c, d)
 			return
 		}
 		c.Next()
 		if c.Writer.Status() == http.StatusUnauthorized {
-			d := h.loginThrottle.recordFailure(key, time.Now())
+			d := h.throttleCharge(c, key, time.Now())
 			h.logAuthFailure(c, key, d)
+			h.noteCredentialFailure(c, key, d, "", "invalid portal credentials")
 		}
 	}
 }

--- a/internal/api/handlers/management/route_permissions.go
+++ b/internal/api/handlers/management/route_permissions.go
@@ -74,6 +74,14 @@ func permissionForManagementRequest(method, path string) string {
 		return "tenant.audit.read"
 	case strings.HasPrefix(relative, "/audit-logs/") && method == http.MethodDelete:
 		return "tenant.audit.delete"
+	// The IP allow/deny list and the attempt history share one permission pair:
+	// reading the attempt log tells you exactly who to ban, so splitting them
+	// would produce a role that can see the attack and not act on it.
+	case strings.HasPrefix(relative, "/ip-access"), strings.HasPrefix(relative, "/auth-attempts"):
+		if write {
+			return "platform.ip_access.write"
+		}
+		return "platform.ip_access.read"
 	case relative == "/menus" && method == http.MethodGet:
 		return "platform.menus.read"
 	case relative == "/menus" && write:

--- a/internal/api/ip_access_middleware.go
+++ b/internal/api/ip_access_middleware.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	log "github.com/sirupsen/logrus"
+)
+
+// healthProbePaths are never subject to the deny list.
+//
+// A blocked health probe does not just hide a problem, it creates one: the
+// blue/green deploy script gates cutover on /readyz, so a deny rule that
+// happened to cover the load balancer would turn every future deployment into a
+// rollback.
+var healthProbePaths = map[string]struct{}{
+	"/healthz": {},
+	"/readyz":  {},
+}
+
+// untrustedAdmissionWarn deduplicates the "list not enforced" warning, which
+// otherwise fires on literally every request of a misconfigured deployment.
+var untrustedAdmissionWarn struct {
+	mu   sync.Mutex
+	last time.Time
+}
+
+const untrustedWarnInterval = 10 * time.Minute
+
+// ipAccessMiddleware enforces the IP allow/deny list ahead of routing.
+//
+// It runs before authentication on purpose: a source an operator has banned
+// should not be able to spend the server's CPU on credential comparison, and a
+// ban that only covered the login endpoint would leave the business API open to
+// the same source.
+func ipAccessMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		registry := ipaccess.Default()
+		if registry == nil {
+			c.Next()
+			return
+		}
+		if c.Request != nil {
+			if _, exempt := healthProbePaths[c.Request.URL.Path]; exempt {
+				c.Next()
+				return
+			}
+		}
+
+		address := registry.ResolveAddress(c.Request, c.ClientIP())
+		verdict := registry.Evaluate(address)
+		ipaccess.StoreContext(c, ipaccess.RequestContext{Address: address, Verdict: verdict})
+		if c.Request != nil {
+			// Also on the request context so audit records downstream can read the
+			// source address without every call site passing it along.
+			c.Request = c.Request.WithContext(ipaccess.WithAddress(c.Request.Context(), address))
+		}
+
+		if !verdict.Enforced && verdict.Reason != "" && registry.Matcher().Count() > 0 {
+			warnListNotEnforced(verdict.Reason, address)
+		}
+		if verdict.Allowed() {
+			c.Next()
+			return
+		}
+
+		recordBlocked(c, address, verdict)
+		// The body deliberately does not say which rule matched or when it
+		// expires: that is operator information, and echoing it back would let a
+		// banned source measure the ban and plan around it.
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+			"error": gin.H{
+				"code":    "ip_forbidden",
+				"message": "access from this address is not permitted",
+			},
+		})
+	}
+}
+
+func recordBlocked(c *gin.Context, address ipaccess.ClientAddress, verdict ipaccess.Verdict) {
+	reason := "deny rule"
+	if verdict.Rule == nil {
+		reason = "lockdown: address not on the allow list"
+	} else if verdict.Rule.Reason != "" {
+		reason = verdict.Rule.Reason
+	}
+	event := authevents.Event{
+		IP:      address.Raw,
+		Trusted: address.Trusted,
+		Surface: authevents.SurfaceRequest,
+		Outcome: authevents.OutcomeBlocked,
+		Reason:  reason,
+	}
+	if verdict.Rule != nil {
+		event.IPPrefix = verdict.Rule.CIDR
+	} else {
+		event.IPPrefix = ipaccess.BanCIDR(address.IP)
+	}
+	if c.Request != nil {
+		event.RequestPath = c.Request.URL.Path
+		event.UserAgent = c.Request.UserAgent()
+		event.RequestID = logging.GetGinRequestID(c)
+	}
+	authevents.Record(event)
+}
+
+func warnListNotEnforced(reason string, address ipaccess.ClientAddress) {
+	now := time.Now()
+	untrustedAdmissionWarn.mu.Lock()
+	if !untrustedAdmissionWarn.last.IsZero() && now.Sub(untrustedAdmissionWarn.last) < untrustedWarnInterval {
+		untrustedAdmissionWarn.mu.Unlock()
+		return
+	}
+	untrustedAdmissionWarn.last = now
+	untrustedAdmissionWarn.mu.Unlock()
+
+	// The remediation is spelled out because the failure is silent by nature:
+	// rules exist, the panel lists them, and nothing enforces them.
+	hint := address.Raw
+	if hint == "" {
+		hint = "the proxy address"
+	}
+	log.Warnf("ip-access: rules are configured but NOT enforced because %s. Every client currently reports %s. Fix: set trusted-proxies to your reverse proxy's CIDR (for example [\"%s/32\"]) so the real client address is resolved.",
+		reason, hint, hint)
+}

--- a/internal/api/routes/management_identity_routes.go
+++ b/internal/api/routes/management_identity_routes.go
@@ -87,4 +87,13 @@ func registerManagementIdentityRoutes(group *gin.RouterGroup, h *managementhandl
 	group.DELETE("/audit-logs", h.ClearAuditLogs)
 	group.GET("/audit-logs/:id", h.GetAuditLog)
 	group.DELETE("/audit-logs/:id", h.DeleteAuditLog)
+	group.GET("/ip-access/rules", h.GetIPAccessRules)
+	group.POST("/ip-access/rules", h.PostIPAccessRule)
+	group.PATCH("/ip-access/rules/:id", h.PatchIPAccessRule)
+	group.DELETE("/ip-access/rules/:id", h.DeleteIPAccessRule)
+	group.GET("/ip-access/status", h.GetIPAccessStatus)
+	group.GET("/ip-access/policy", h.GetIPAccessPolicy)
+	group.PUT("/ip-access/policy", h.PutIPAccessPolicy)
+	group.GET("/auth-attempts", h.GetAuthAttempts)
+	group.GET("/auth-attempts/summary", h.GetAuthAttemptSummary)
 }

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 309; got != want {
+	if got, want := len(routes), 318; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -245,6 +245,15 @@ func expectedManagementRoutes() []string {
 		"DELETE /v0/management/audit-logs",
 		"GET /v0/management/audit-logs/:id",
 		"DELETE /v0/management/audit-logs/:id",
+		"GET /v0/management/ip-access/rules",
+		"POST /v0/management/ip-access/rules",
+		"PATCH /v0/management/ip-access/rules/:id",
+		"DELETE /v0/management/ip-access/rules/:id",
+		"GET /v0/management/ip-access/status",
+		"GET /v0/management/ip-access/policy",
+		"PUT /v0/management/ip-access/policy",
+		"GET /v0/management/auth-attempts",
+		"GET /v0/management/auth-attempts/summary",
 		"DELETE /v0/management/roles/:id",
 		"DELETE /v0/management/ampcode/model-mappings",
 		"DELETE /v0/management/ampcode/upstream-api-key",

--- a/internal/api/server_config_reload.go
+++ b/internal/api/server_config_reload.go
@@ -10,6 +10,7 @@ import (
 	internalserviceapp "github.com/router-for-me/CLIProxyAPI/v6/internal/app/service"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/managementasset"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -205,6 +206,11 @@ func (s *Server) commitUpdatedConfig(oldCfg, cfg *config.Config) {
 		return
 	}
 	s.cfg = cfg
+	// A reload replaces the config pointer, so the admission layer has to be told
+	// separately. "Is the client address trustworthy" is precisely the answer
+	// that changes when an operator finally configures trusted-proxies, and it
+	// gates whether the IP rules are enforced at all.
+	ipaccess.Default().SetProxyTrusted(ipaccess.ProxyTrustConfigured(cfg.TrustedProxies))
 	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
 	if oldCfg != nil && s.wsAuthChanged != nil && oldCfg.WebsocketAuth != cfg.WebsocketAuth {
 		s.wsAuthChanged(oldCfg.WebsocketAuth, cfg.WebsocketAuth)

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -56,6 +56,9 @@ func newServerEngine(cfg *config.Config, optionState *serverOptionConfig) *gin.E
 
 	engine.Use(logging.GinLogrusLogger())
 	engine.Use(logging.GinLogrusRecovery())
+	// Admission runs before any body handling: a denied source must not be able
+	// to make the process decompress or buffer what it sent.
+	engine.Use(ipAccessMiddleware())
 	engine.Use(middleware.DecompressRequestMiddleware())
 	engine.Use(middleware.RequestBodyCleanupMiddleware())
 	if optionState != nil {

--- a/internal/authevents/bootstrap.go
+++ b/internal/authevents/bootstrap.go
@@ -1,0 +1,40 @@
+package authevents
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+)
+
+// installed tracks which database the process-wide recorder was built for, so a
+// swapped pool produces a recorder writing to the live handle rather than a
+// closed one.
+var installed struct {
+	mu sync.Mutex
+	db *sql.DB
+}
+
+// EnsureDefault installs the process-wide recorder for db and returns it.
+//
+// Idempotent, and bound to database availability rather than to one startup
+// path — see the matching note in ipaccess.EnsureDefault for why that
+// distinction was worth a bug.
+func EnsureDefault(ctx context.Context, db *sql.DB) *Recorder {
+	if db == nil {
+		return Default()
+	}
+	installed.mu.Lock()
+	defer installed.mu.Unlock()
+
+	if existing := Default(); existing != nil && installed.db == db {
+		return existing
+	}
+	if previous := Default(); previous != nil {
+		previous.Close()
+	}
+	recorder := NewRecorder(db)
+	recorder.Start(ctx)
+	SetDefault(recorder)
+	installed.db = db
+	return recorder
+}

--- a/internal/authevents/event.go
+++ b/internal/authevents/event.go
@@ -1,0 +1,110 @@
+// Package authevents records authentication attempts so an operator can answer
+// "who is attacking us" from the panel instead of grepping process logs.
+//
+// The pre-existing answer was a logrus line at Debug level whose structured
+// fields never reached the output, on a deployment that runs with debug off —
+// which is to say there was no answer at all.
+package authevents
+
+import "time"
+
+// Outcome classifies what happened to an attempt.
+const (
+	// OutcomeSuccess is a completed authentication. It is recorded because
+	// "this source failed ninety times and then succeeded" is the single most
+	// important line in a breach timeline, and a failures-only log omits it.
+	OutcomeSuccess = "success"
+	// OutcomeFailure is a credential that was compared and did not match.
+	OutcomeFailure = "failure"
+	// OutcomeThrottled is a request rejected by the rate limiter.
+	OutcomeThrottled = "throttled"
+	// OutcomeBlocked is a request rejected by the IP deny list.
+	OutcomeBlocked = "blocked"
+	// OutcomeAutoBanned marks the attempt that tipped a source into a ban.
+	OutcomeAutoBanned = "auto_banned"
+	// OutcomeWouldBan is the observe-mode counterpart of OutcomeAutoBanned: the
+	// rule fired but no ban was written.
+	OutcomeWouldBan = "would_ban"
+)
+
+// Surface names the door the attempt arrived at.
+const (
+	SurfaceAdminLogin    = "admin_login"
+	SurfacePortalLogin   = "portal_login"
+	SurfaceManagementKey = "management_key"
+	SurfaceRefresh       = "refresh"
+	SurfaceRequest       = "request"
+)
+
+// Event is one recorded authentication attempt.
+type Event struct {
+	OccurredAt time.Time `json:"occurred_at"`
+	ID         int64     `json:"id,omitempty"`
+	IP         string    `json:"ip"`
+	// IPPrefix is the throttle bucket key (/32 or /64), so aggregation here
+	// matches what the rate limiter counted.
+	IPPrefix string `json:"ip_prefix"`
+	// Trusted reports whether IP identified a client. Untrusted rows are kept
+	// rather than dropped: they are the evidence that trusted-proxies is
+	// misconfigured, and hiding them would hide the misconfiguration.
+	Trusted     bool   `json:"trusted"`
+	Scope       string `json:"scope"`
+	Surface     string `json:"surface"`
+	Username    string `json:"username"`
+	Outcome     string `json:"outcome"`
+	Reason      string `json:"reason"`
+	UserAgent   string `json:"user_agent"`
+	RequestPath string `json:"request_path"`
+	RequestID   string `json:"request_id"`
+	TenantID    string `json:"tenant_id,omitempty"`
+}
+
+// Field length caps. Attacker-supplied strings must not be able to turn one
+// request into an unbounded database row.
+const (
+	maxUserAgentLen = 200
+	maxUsernameLen  = 120
+	maxReasonLen    = 200
+	maxPathLen      = 200
+)
+
+func truncate(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit]
+}
+
+// sanitized clamps user-controlled fields and fills in defaults.
+func (e Event) sanitized() Event {
+	if e.OccurredAt.IsZero() {
+		e.OccurredAt = time.Now()
+	}
+	e.UserAgent = truncate(e.UserAgent, maxUserAgentLen)
+	e.Username = truncate(e.Username, maxUsernameLen)
+	e.Reason = truncate(e.Reason, maxReasonLen)
+	e.RequestPath = truncate(e.RequestPath, maxPathLen)
+	if e.Outcome == "" {
+		e.Outcome = OutcomeFailure
+	}
+	return e
+}
+
+// SourceSummary aggregates attempts by source address.
+type SourceSummary struct {
+	IPPrefix     string     `json:"ip_prefix"`
+	SampleIP     string     `json:"sample_ip"`
+	Trusted      bool       `json:"trusted"`
+	Attempts     int64      `json:"attempts"`
+	Failures     int64      `json:"failures"`
+	Throttled    int64      `json:"throttled"`
+	Blocked      int64      `json:"blocked"`
+	Successes    int64      `json:"successes"`
+	DistinctUser int64      `json:"distinct_usernames"`
+	FirstSeen    time.Time  `json:"first_seen"`
+	LastSeen     time.Time  `json:"last_seen"`
+	Surfaces     string     `json:"surfaces"`
+	RuleEffect   string     `json:"rule_effect,omitempty"`
+	RuleID       string     `json:"rule_id,omitempty"`
+	RuleExpires  *time.Time `json:"rule_expires_at,omitempty"`
+}

--- a/internal/authevents/query.go
+++ b/internal/authevents/query.go
@@ -1,0 +1,186 @@
+package authevents
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+)
+
+// ListFilter narrows an attempt listing.
+type ListFilter struct {
+	IPPrefix string
+	Username string
+	Outcome  string
+	Surface  string
+	Since    time.Time
+	Until    time.Time
+	Page     int
+	Size     int
+}
+
+const (
+	defaultPageSize = 50
+	maxPageSize     = 200
+	// maxSummarySources caps the aggregation result. An unbounded GROUP BY over
+	// an attack window could return hundreds of thousands of rows straight into
+	// the panel.
+	maxSummarySources = 100
+)
+
+func (f ListFilter) normalized() ListFilter {
+	if f.Page < 1 {
+		f.Page = 1
+	}
+	if f.Size < 1 {
+		f.Size = defaultPageSize
+	}
+	if f.Size > maxPageSize {
+		f.Size = maxPageSize
+	}
+	return f
+}
+
+func (f ListFilter) conditions() ([]string, []any) {
+	where := make([]string, 0, 6)
+	args := make([]any, 0, 6)
+	if value := strings.TrimSpace(f.IPPrefix); value != "" {
+		where = append(where, "(ip_prefix = ? OR ip = ?)")
+		args = append(args, value, value)
+	}
+	if value := strings.TrimSpace(f.Username); value != "" {
+		where = append(where, "username ILIKE ?")
+		args = append(args, "%"+value+"%")
+	}
+	if value := strings.TrimSpace(f.Outcome); value != "" {
+		where = append(where, "outcome = ?")
+		args = append(args, value)
+	}
+	if value := strings.TrimSpace(f.Surface); value != "" {
+		where = append(where, "surface = ?")
+		args = append(args, value)
+	}
+	if !f.Since.IsZero() {
+		where = append(where, "occurred_at >= ?")
+		args = append(args, f.Since.UTC())
+	}
+	if !f.Until.IsZero() {
+		where = append(where, "occurred_at <= ?")
+		args = append(args, f.Until.UTC())
+	}
+	return where, args
+}
+
+// List returns a page of attempts with the total row count.
+func (r *Recorder) List(ctx context.Context, filter ListFilter) ([]Event, int, error) {
+	if !r.Available() {
+		return nil, 0, nil
+	}
+	filter = filter.normalized()
+	where, args := filter.conditions()
+	clause := ""
+	if len(where) > 0 {
+		clause = " WHERE " + strings.Join(where, " AND ")
+	}
+
+	var total int
+	if err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM auth_attempt_events`+clause, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	query := `SELECT id,occurred_at,ip,ip_prefix,trusted,scope,surface,username,outcome,reason,user_agent,request_path,request_id,tenant_id
+		FROM auth_attempt_events` + clause + ` ORDER BY occurred_at DESC, id DESC LIMIT ? OFFSET ?`
+	args = append(args, filter.Size, (filter.Page-1)*filter.Size)
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	events := make([]Event, 0, filter.Size)
+	for rows.Next() {
+		var (
+			event    Event
+			tenantID sql.NullString
+		)
+		if err = rows.Scan(&event.ID, &event.OccurredAt, &event.IP, &event.IPPrefix, &event.Trusted,
+			&event.Scope, &event.Surface, &event.Username, &event.Outcome, &event.Reason,
+			&event.UserAgent, &event.RequestPath, &event.RequestID, &tenantID); err != nil {
+			return nil, 0, err
+		}
+		if tenantID.Valid {
+			event.TenantID = tenantID.String
+		}
+		events = append(events, event)
+	}
+	return events, total, rows.Err()
+}
+
+// Summarize aggregates attempts by source over a window.
+//
+// Ordering puts the noisiest failing sources first, because the question this
+// answers is "who should I ban", not "who visited". Successes are counted but
+// never rank a source up.
+func (r *Recorder) Summarize(ctx context.Context, since time.Time, limit int) ([]SourceSummary, error) {
+	if !r.Available() {
+		return nil, nil
+	}
+	if limit < 1 || limit > maxSummarySources {
+		limit = maxSummarySources
+	}
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT ip_prefix,
+		       MAX(ip)                                                        AS sample_ip,
+		       BOOL_OR(trusted)                                               AS trusted,
+		       COUNT(*)                                                       AS attempts,
+		       COUNT(*) FILTER (WHERE outcome = 'failure')                    AS failures,
+		       COUNT(*) FILTER (WHERE outcome = 'throttled')                  AS throttled,
+		       COUNT(*) FILTER (WHERE outcome IN ('blocked','auto_banned'))   AS blocked,
+		       COUNT(*) FILTER (WHERE outcome = 'success')                    AS successes,
+		       COUNT(DISTINCT NULLIF(username, ''))                           AS distinct_usernames,
+		       MIN(occurred_at)                                               AS first_seen,
+		       MAX(occurred_at)                                               AS last_seen,
+		       STRING_AGG(DISTINCT surface, ',')                              AS surfaces
+		  FROM auth_attempt_events
+		 WHERE occurred_at >= ? AND ip_prefix <> ''
+		 GROUP BY ip_prefix
+		 ORDER BY failures DESC, attempts DESC
+		 LIMIT ?`, since.UTC(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	summaries := make([]SourceSummary, 0, limit)
+	for rows.Next() {
+		var (
+			summary  SourceSummary
+			sampleIP sql.NullString
+			surfaces sql.NullString
+		)
+		if err = rows.Scan(&summary.IPPrefix, &sampleIP, &summary.Trusted, &summary.Attempts,
+			&summary.Failures, &summary.Throttled, &summary.Blocked, &summary.Successes,
+			&summary.DistinctUser, &summary.FirstSeen, &summary.LastSeen, &surfaces); err != nil {
+			return nil, err
+		}
+		if sampleIP.Valid {
+			summary.SampleIP = sampleIP.String
+		}
+		if surfaces.Valid {
+			summary.Surfaces = surfaces.String
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, rows.Err()
+}
+
+// Purge deletes attempts older than cutoff and reports how many rows went.
+func (r *Recorder) Purge(ctx context.Context, cutoff time.Time) (int64, error) {
+	if !r.Available() {
+		return 0, nil
+	}
+	result, err := r.db.ExecContext(ctx, `DELETE FROM auth_attempt_events WHERE occurred_at < ?`, cutoff.UTC())
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/internal/authevents/recorder.go
+++ b/internal/authevents/recorder.go
@@ -1,0 +1,210 @@
+package authevents
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// queueCapacity bounds the in-flight buffer. Sized to absorb a burst of a
+	// few seconds at attack rates without becoming a memory sink of its own.
+	queueCapacity = 4096
+	// batchSize is the maximum rows per multi-row insert.
+	batchSize = 128
+	// flushInterval bounds how long a low-volume event waits before it is
+	// visible in the panel.
+	flushInterval = 2 * time.Second
+	// dropWarnInterval deduplicates the overflow warning, which by definition
+	// fires when the process is already under load.
+	dropWarnInterval = time.Minute
+)
+
+// Recorder persists events off the request path.
+//
+// Writes are asynchronous and lossy by design: this is security telemetry, and
+// a telemetry backlog must never be able to slow down or block a login. When the
+// queue overflows the events are dropped and counted, never buffered without
+// bound and never written synchronously as a fallback.
+type Recorder struct {
+	db      *sql.DB
+	queue   chan Event
+	stop    chan struct{}
+	done    chan struct{}
+	once    sync.Once
+	dropped atomic.Int64
+
+	warnMu   sync.Mutex
+	lastWarn time.Time
+}
+
+// NewRecorder builds a recorder. A nil db yields a recorder whose Record is a
+// no-op, so callers never need to check.
+func NewRecorder(db *sql.DB) *Recorder {
+	return &Recorder{
+		db:    db,
+		queue: make(chan Event, queueCapacity),
+		stop:  make(chan struct{}),
+		done:  make(chan struct{}),
+	}
+}
+
+// Available reports whether events can be persisted.
+func (r *Recorder) Available() bool { return r != nil && r.db != nil }
+
+// Record queues an event. It never blocks and never returns an error: no
+// authentication path should be able to fail because logging failed.
+func (r *Recorder) Record(event Event) {
+	if !r.Available() {
+		return
+	}
+	select {
+	case r.queue <- event.sanitized():
+	default:
+		r.dropped.Add(1)
+		r.warnDropped()
+	}
+}
+
+func (r *Recorder) warnDropped() {
+	now := time.Now()
+	r.warnMu.Lock()
+	if !r.lastWarn.IsZero() && now.Sub(r.lastWarn) < dropWarnInterval {
+		r.warnMu.Unlock()
+		return
+	}
+	r.lastWarn = now
+	r.warnMu.Unlock()
+	log.Warnf("auth-events: queue full, dropped %d events so far; attempt history is incomplete for this period", r.dropped.Load())
+}
+
+// Dropped reports how many events were discarded. Surfacing this matters: a
+// report built from a truncated event log would otherwise look authoritative.
+func (r *Recorder) Dropped() int64 {
+	if r == nil {
+		return 0
+	}
+	return r.dropped.Load()
+}
+
+// Start launches the writer goroutine.
+func (r *Recorder) Start(ctx context.Context) {
+	if !r.Available() {
+		return
+	}
+	go r.loop(ctx)
+}
+
+func (r *Recorder) loop(ctx context.Context) {
+	defer close(r.done)
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+	pending := make([]Event, 0, batchSize)
+
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		r.write(ctx, pending)
+		pending = pending[:0]
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			flush()
+			return
+		case <-r.stop:
+			// Drain what is already queued so a graceful shutdown does not lose
+			// the events describing whatever prompted the restart.
+			for {
+				select {
+				case event := <-r.queue:
+					pending = append(pending, event)
+					if len(pending) >= batchSize {
+						flush()
+					}
+					continue
+				default:
+				}
+				break
+			}
+			flush()
+			return
+		case event := <-r.queue:
+			pending = append(pending, event)
+			if len(pending) >= batchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		}
+	}
+}
+
+func (r *Recorder) write(ctx context.Context, events []Event) {
+	if len(events) == 0 {
+		return
+	}
+	// A dedicated timeout keeps a stalled database from pinning the writer
+	// goroutine and letting the queue back up into drops.
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	var builder strings.Builder
+	builder.WriteString(`INSERT INTO auth_attempt_events
+		(occurred_at,ip,ip_prefix,trusted,scope,surface,username,outcome,reason,user_agent,request_path,request_id,tenant_id) VALUES `)
+	args := make([]any, 0, len(events)*13)
+	for i := range events {
+		if i > 0 {
+			builder.WriteString(",")
+		}
+		builder.WriteString("(?,?,?,?,?,?,?,?,?,?,?,?,?)")
+		event := events[i]
+		var tenantID any
+		if strings.TrimSpace(event.TenantID) != "" {
+			tenantID = event.TenantID
+		}
+		args = append(args, event.OccurredAt.UTC(), event.IP, event.IPPrefix, event.Trusted,
+			event.Scope, event.Surface, event.Username, event.Outcome, event.Reason,
+			event.UserAgent, event.RequestPath, event.RequestID, tenantID)
+	}
+	if _, err := r.db.ExecContext(writeCtx, builder.String(), args...); err != nil {
+		log.WithError(err).Warnf("auth-events: failed to persist %d events", len(events))
+	}
+}
+
+// Close stops the writer and waits for the final flush.
+func (r *Recorder) Close() {
+	if !r.Available() {
+		return
+	}
+	r.once.Do(func() {
+		close(r.stop)
+		select {
+		case <-r.done:
+		case <-time.After(5 * time.Second):
+			log.Warn("auth-events: writer did not drain within 5s")
+		}
+	})
+}
+
+var defaultRecorder atomic.Pointer[Recorder]
+
+// SetDefault publishes the process-wide recorder.
+func SetDefault(r *Recorder) { defaultRecorder.Store(r) }
+
+// Default returns the process-wide recorder, or nil when none is configured.
+func Default() *Recorder { return defaultRecorder.Load() }
+
+// Record sends an event to the process-wide recorder when one exists.
+func Record(event Event) {
+	if recorder := Default(); recorder != nil {
+		recorder.Record(event)
+	}
+}

--- a/internal/cmd/ip_access_bootstrap.go
+++ b/internal/cmd/ip_access_bootstrap.go
@@ -46,21 +46,23 @@ func (ipAccessPolicyStore) Save(policy ipaccess.ProtectionPolicy) error {
 // attempt log into the process.
 func initializeIPAccessControl(ctx context.Context, cfg *config.Config) {
 	db := usage.RuntimeDB()
-
-	recorder := authevents.NewRecorder(db)
-	recorder.Start(ctx)
-	authevents.SetDefault(recorder)
-	startAuthEventRetention(ctx, recorder)
-
+	if db == nil {
+		return
+	}
 	var trustedProxies []string
 	if cfg != nil {
 		trustedProxies = cfg.TrustedProxies
 	}
-	registry := ipaccess.NewRegistry(ipaccess.NewStore(db))
-	registry.SetProxyTrusted(ipaccess.ProxyTrustConfigured(trustedProxies))
+	// The registry and recorder themselves are installed by the same helpers the
+	// management handler uses, so both startup paths converge on one instance.
+	// What only the CLI runner can add is persistence: the settings store is off
+	// limits to management handlers, and the retention sweep needs a long-lived
+	// process to run in.
+	recorder := authevents.EnsureDefault(ctx, db)
+	startAuthEventRetention(ctx, recorder)
+
+	registry := ipaccess.EnsureDefault(ctx, db, ipaccess.ProxyTrustConfigured(trustedProxies))
 	registry.SetPolicyPersister(ctx, ipAccessPolicyStore{})
-	registry.Start(ctx)
-	ipaccess.SetDefault(registry)
 }
 
 func startAuthEventRetention(ctx context.Context, recorder *authevents.Recorder) {

--- a/internal/cmd/ip_access_bootstrap.go
+++ b/internal/cmd/ip_access_bootstrap.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	log "github.com/sirupsen/logrus"
+)
+
+// authEventRetention is how long authentication attempts are kept. Long enough
+// to investigate an incident reported a few weeks late, short enough that a
+// sustained attack cannot fill the disk.
+const authEventRetention = 30 * 24 * time.Hour
+
+// authEventPurgeInterval is how often the retention sweep runs.
+const authEventPurgeInterval = 6 * time.Hour
+
+// ipAccessPolicyStore adapts the runtime settings store to the persister
+// interface the ipaccess package expects.
+type ipAccessPolicyStore struct{}
+
+func (ipAccessPolicyStore) Load() (ipaccess.ProtectionPolicy, bool) {
+	payload, ok := settingsstore.GetRuntimeSettingPayload(ipaccess.SettingKey)
+	if !ok || len(payload) == 0 {
+		return ipaccess.ProtectionPolicy{}, false
+	}
+	var policy ipaccess.ProtectionPolicy
+	if err := json.Unmarshal(payload, &policy); err != nil {
+		log.WithError(err).Warn("ip-access: stored protection policy is unreadable, falling back to defaults")
+		return ipaccess.ProtectionPolicy{}, false
+	}
+	return policy, true
+}
+
+func (ipAccessPolicyStore) Save(policy ipaccess.ProtectionPolicy) error {
+	return settingsstore.UpsertRuntimeSetting(ipaccess.SettingKey, policy)
+}
+
+// initializeIPAccessControl wires the allow/deny list and the authentication
+// attempt log into the process.
+func initializeIPAccessControl(ctx context.Context, cfg *config.Config) {
+	db := usage.RuntimeDB()
+
+	recorder := authevents.NewRecorder(db)
+	recorder.Start(ctx)
+	authevents.SetDefault(recorder)
+	startAuthEventRetention(ctx, recorder)
+
+	var trustedProxies []string
+	if cfg != nil {
+		trustedProxies = cfg.TrustedProxies
+	}
+	registry := ipaccess.NewRegistry(ipaccess.NewStore(db))
+	registry.SetProxyTrusted(ipaccess.ProxyTrustConfigured(trustedProxies))
+	registry.SetPolicyPersister(ctx, ipAccessPolicyStore{})
+	registry.Start(ctx)
+	ipaccess.SetDefault(registry)
+}
+
+func startAuthEventRetention(ctx context.Context, recorder *authevents.Recorder) {
+	if recorder == nil || !recorder.Available() {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(authEventPurgeInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				removed, err := recorder.Purge(ctx, time.Now().Add(-authEventRetention))
+				if err != nil {
+					log.WithError(err).Debug("auth-events: retention sweep failed")
+					continue
+				}
+				if removed > 0 {
+					log.Debugf("auth-events: purged %d attempts older than %s", removed, authEventRetention)
+				}
+			}
+		}
+	}()
+}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -240,6 +240,8 @@ func initializeRuntimeDataStack(cfg *config.Config, configPath string, loc *time
 	usage.ApplyStoredProxyPool(cfg)
 	settingsstore.MigrateRuntimeSettingsFromConfig(cfg, configPath)
 	settingsstore.ApplyStoredRuntimeSettings(cfg)
+	// After the settings store is live: the protection policy is read from it.
+	initializeIPAccessControl(context.Background(), cfg)
 	middleware.InitQuotaUsageFuncs(usage.CountTodayByKey, usage.CountTotalByKey, usage.QueryTotalCostByKey, usage.QueryTodayCostByKey)
 	middleware.InitQuotaEndUserUsageFuncs(usage.CountTodayByEndUser, usage.CountTotalByEndUser, usage.QueryTotalCostByEndUser, usage.QueryTodayCostByEndUser)
 	middleware.InitQuotaPeriodUsageFuncs(usage.QueryPeriodSpendingByAPIKeyIDForTenant, usage.QueryPeriodSpendingByEndUserForTenant)

--- a/internal/identity/menus.go
+++ b/internal/identity/menus.go
@@ -119,6 +119,7 @@ var MenuCatalog = []MenuSeed{
 	{Code: "governance.users", ParentCode: "group.governance", Type: "menu", Path: "/governance/users", Component: "users", LabelKey: "shell.nav_users", Icon: "user-round", PermissionCode: "tenant.users.read", SortOrder: 20},
 	{Code: "governance.roles", ParentCode: "group.governance", Type: "menu", Path: "/governance/roles", Component: "roles", LabelKey: "shell.nav_roles", Icon: "shield-check", PermissionCode: "tenant.roles.read", SortOrder: 30},
 	{Code: "governance.audit", ParentCode: "group.governance", Type: "menu", Path: "/governance/audit-logs", Component: "audit-logs", LabelKey: "shell.nav_audit_logs", Icon: "file-text", PermissionCode: "tenant.audit.read", SortOrder: 40},
+	{Code: "governance.ip-access", ParentCode: "group.governance", Type: "menu", Path: "/governance/ip-access", Component: "ip-access", LabelKey: "shell.nav_ip_access", Icon: "shield-ban", PermissionCode: "platform.ip_access.read", SortOrder: 50},
 	// System settings only
 	{Code: "system.config", ParentCode: "group.system", Type: "menu", Path: "/system/config", Component: "config", LabelKey: "shell.nav_config", Icon: "settings", PermissionCode: "system.config.read", SortOrder: 10},
 	{Code: MenuManagementCode, ParentCode: "group.system", Type: "menu", Path: "/system/menu-management", Component: "menu-management", LabelKey: "shell.nav_menu_management", Icon: "menu", PermissionCode: "platform.menus.read", SortOrder: 20},

--- a/internal/identity/permissions.go
+++ b/internal/identity/permissions.go
@@ -75,6 +75,10 @@ var PermissionCatalog = []PermissionSeed{
 	{Code: "proxies.test", Name: "Test proxies", Scope: "tenant", Resource: "proxies", Action: "test", Sensitive: true},
 	{Code: "tenant_settings.read", Name: "Read tenant settings", Scope: "tenant", Resource: "tenant_settings", Action: "read"},
 	{Code: "tenant_settings.write", Name: "Write tenant settings", Scope: "tenant", Resource: "tenant_settings", Action: "write", Sensitive: true},
+	// Platform scope: the allow/deny list gates the process itself, before any
+	// tenant is identified, so it cannot be delegated per tenant.
+	{Code: "platform.ip_access.read", Name: "Read IP access control", Scope: "platform", Resource: "ip_access", Action: "read", Sensitive: true},
+	{Code: "platform.ip_access.write", Name: "Write IP access control", Scope: "platform", Resource: "ip_access", Action: "write", Sensitive: true},
 }
 
 func menuCodeForPermission(permission PermissionSeed) string {
@@ -87,6 +91,8 @@ func menuCodeForPermission(permission PermissionSeed) string {
 		return "governance.roles"
 	case "audit":
 		return "governance.audit"
+	case "ip_access":
+		return "governance.ip-access"
 	case "menus":
 		return MenuManagementCode
 	case "system":

--- a/internal/identity/service_admin.go
+++ b/internal/identity/service_admin.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	log "github.com/sirupsen/logrus"
 )
@@ -27,6 +28,7 @@ type AuditLog struct {
 	ResourceID       string  `json:"resource_id"`
 	Result           string  `json:"result"`
 	RequestID        string  `json:"request_id"`
+	IPAddress        string  `json:"ip_address"`
 	// Changes is only populated for detail views.
 	Changes   map[string]any `json:"changes,omitempty"`
 	CreatedAt time.Time      `json:"created_at"`
@@ -87,10 +89,17 @@ func (s *Service) RecordAudit(ctx context.Context, event AuditEvent) {
 	if err != nil {
 		changesJSON = []byte("{}")
 	}
+	// Source address comes from the request context rather than a parameter, so
+	// every audit row gets provenance without each call site remembering to pass
+	// it. An explicit event.IPAddress still wins for callers outside a request.
+	ipAddress := event.IPAddress
+	if ipAddress == "" {
+		ipAddress = ipaccess.AuditAddress(ctx)
+	}
 	ctx = context.WithoutCancel(ctx)
 	auditCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	if _, err := s.db.ExecContext(auditCtx, `INSERT INTO audit_logs (tenant_id,actor_kind,actor_user_id,actor_session_id,action,resource_type,resource_id,result,request_id,changes) VALUES (?,?,?,?,?,?,?,?,?,?::jsonb)`, tenantID, event.ActorKind, actorUserID, actorSessionID, event.Action, event.ResourceType, event.ResourceID, event.Result, event.RequestID, string(changesJSON)); err != nil {
+	if _, err := s.db.ExecContext(auditCtx, `INSERT INTO audit_logs (tenant_id,actor_kind,actor_user_id,actor_session_id,action,resource_type,resource_id,result,request_id,changes,ip_address) VALUES (?,?,?,?,?,?,?,?,?,?::jsonb,?)`, tenantID, event.ActorKind, actorUserID, actorSessionID, event.Action, event.ResourceType, event.ResourceID, event.Result, event.RequestID, string(changesJSON), ipAddress); err != nil {
 		log.WithError(err).WithFields(log.Fields{"action": event.Action, "resource_type": event.ResourceType, "resource_id": event.ResourceID}).Error("identity: record audit event")
 	}
 }
@@ -113,11 +122,12 @@ func scanAuditLog(scanner interface {
 }, includeChanges bool) (AuditLog, error) {
 	var item AuditLog
 	var tenant, actor, tenantName, tenantSlug, actorUsername, actorDisplay sql.NullString
+	var ipAddress sql.NullString
 	var changesRaw []byte
 	dest := []any{
 		&item.ID, &tenant, &tenantName, &tenantSlug,
 		&item.ActorKind, &actor, &actorUsername, &actorDisplay,
-		&item.Action, &item.ResourceType, &item.ResourceID, &item.Result, &item.RequestID, &item.CreatedAt,
+		&item.Action, &item.ResourceType, &item.ResourceID, &item.Result, &item.RequestID, &ipAddress, &item.CreatedAt,
 	}
 	if includeChanges {
 		dest = append(dest, &changesRaw)
@@ -135,6 +145,7 @@ func scanAuditLog(scanner interface {
 	item.TenantSlug = tenantSlug.String
 	item.ActorUsername = actorUsername.String
 	item.ActorDisplayName = actorDisplay.String
+	item.IPAddress = ipAddress.String
 	if includeChanges {
 		item.Changes = map[string]any{}
 		if len(changesRaw) > 0 {
@@ -147,7 +158,7 @@ func scanAuditLog(scanner interface {
 const auditLogSelectBase = `
 SELECT a.id, a.tenant_id, t.name, t.slug,
        a.actor_kind, a.actor_user_id, u.username, u.display_name,
-       a.action, a.resource_type, a.resource_id, a.result, a.request_id, a.created_at`
+       a.action, a.resource_type, a.resource_id, a.result, a.request_id, a.ip_address, a.created_at`
 
 // ListAuditLogs returns a page of audit logs. Platform readers may see all tenants.
 func (s *Service) ListAuditLogs(ctx context.Context, tenantID string, platform bool, page, size int) (AuditLogListResult, error) {

--- a/internal/identity/types.go
+++ b/internal/identity/types.go
@@ -88,6 +88,10 @@ type AuditEvent struct {
 	ResourceID     string
 	Result         string
 	RequestID      string
+	// IPAddress is the source address. Usually left empty: RecordAudit fills it
+	// from the request context. Set it explicitly only for events raised outside
+	// a request, where no context carries the address.
+	IPAddress string
 	// Changes stores structured call-chain / mutation metadata (JSON object).
 	Changes map[string]any
 }

--- a/internal/ipaccess/autoban.go
+++ b/internal/ipaccess/autoban.go
@@ -1,0 +1,239 @@
+package ipaccess
+
+import (
+	"context"
+	"net"
+	"sort"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// autoBanSlotCount divides the observation window into sub-buckets. Counting
+	// per slot instead of storing a timestamp per failure keeps memory flat while
+	// under attack, which is exactly when this structure is being filled.
+	autoBanSlotCount = 12
+	// maxTrackedSources bounds memory. An IPv6 /64 is free with most hosting, so
+	// an attacker can mint sources at will; without a cap this map is the OOM.
+	maxTrackedSources = 20000
+	// autoBanEvictRatio is the fraction of the least recently seen sources
+	// dropped when the table saturates.
+	autoBanEvictRatio = 8
+)
+
+// AutoBanOutcome reports what the engine did with one failure.
+type AutoBanOutcome struct {
+	// Triggered is true when the failure count crossed the threshold.
+	Triggered bool
+	// Enforced is true when a deny rule was actually written. It is false in
+	// observe mode, which is the shipped default.
+	Enforced bool
+	// CIDR is the network that was (or would be) banned.
+	CIDR string
+	// Until is the ban expiry when enforced.
+	Until time.Time
+	// Failures is the count inside the observation window.
+	Failures int
+}
+
+type autoBanSlot struct {
+	index int64
+	count int32
+}
+
+type autoBanCounter struct {
+	slots [autoBanSlotCount]autoBanSlot
+	// banCount drives the escalation ladder and survives the window reset, so a
+	// source that returns every hour gets progressively longer bans.
+	banCount     int
+	bannedUntil  time.Time
+	lastActivity time.Time
+}
+
+// autoBanEngine promotes repeated authentication failures into temporary deny
+// rules. It is deliberately separate from the login throttle: the throttle asks
+// "has this credential been guessed too often", while this asks "is this source
+// worth talking to at all", and the second question spans every surface.
+type autoBanEngine struct {
+	registry *Registry
+	mu       sync.Mutex
+	counters map[string]*autoBanCounter
+}
+
+func newAutoBanEngine(registry *Registry) *autoBanEngine {
+	return &autoBanEngine{registry: registry, counters: make(map[string]*autoBanCounter)}
+}
+
+// BanCIDR renders the network an automatic ban covers: a single IPv4 host, or an
+// IPv6 /64 because a single /64 is one customer allocation and banning /128 just
+// invites the next address in the same block.
+func BanCIDR(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String() + "/32"
+	}
+	return ip.Mask(net.CIDRMask(64, 128)).String() + "/64"
+}
+
+// RecordFailure charges one authentication failure against a source and applies
+// the auto-ban policy.
+func (e *autoBanEngine) RecordFailure(ctx context.Context, addr ClientAddress, reason string) AutoBanOutcome {
+	if e == nil || e.registry == nil {
+		return AutoBanOutcome{}
+	}
+	policy := e.registry.Policy().AutoBan
+	if policy.Mode == AutoBanOff {
+		return AutoBanOutcome{}
+	}
+	// An untrusted address is the proxy's, so banning it would take down every
+	// client behind it. A loopback source is the operator's own channel.
+	if !addr.Trusted || addr.Loopback() || addr.IP == nil {
+		return AutoBanOutcome{}
+	}
+	// An allow-listed source is exempt by definition; the engine must never be
+	// able to override an operator's explicit decision.
+	if e.registry.Matcher().AllowsAddress(addr.IP) {
+		return AutoBanOutcome{}
+	}
+
+	cidr := BanCIDR(addr.IP)
+	now := time.Now()
+	failures, banCount, alreadyBanned := e.charge(cidr, policy, now)
+	if alreadyBanned || failures < policy.FailureThreshold {
+		return AutoBanOutcome{Failures: failures, CIDR: cidr}
+	}
+
+	outcome := AutoBanOutcome{Triggered: true, Failures: failures, CIDR: cidr}
+	duration := policy.BanDuration(banCount)
+	outcome.Until = now.Add(duration)
+
+	if policy.Mode != AutoBanEnforce {
+		// Observe mode still marks the source as banned internally so the log
+		// records one decision per offender instead of one per request.
+		e.markBanned(cidr, outcome.Until, now)
+		log.Warnf("ip-access: auto-ban would trigger for %s (%d failures in %s, %s) — observe mode, no rule written",
+			cidr, failures, policy.Window(), reason)
+		return outcome
+	}
+
+	rule, created, err := e.registry.store.UpsertAutoBan(ctx, cidr, reason, outcome.Until)
+	if err != nil {
+		log.WithError(err).Warnf("ip-access: auto-ban write failed for %s", cidr)
+		return outcome
+	}
+	// A pre-existing manual rule means an operator already decided; leave it be.
+	if rule.Source == SourceManual {
+		return outcome
+	}
+	e.markBanned(cidr, outcome.Until, now)
+	outcome.Enforced = true
+	if created {
+		log.Warnf("ip-access: auto-banned %s until %s (%d failures in %s, %s)",
+			cidr, outcome.Until.Format(time.RFC3339), failures, policy.Window(), reason)
+	}
+	if err = e.registry.Refresh(ctx); err != nil {
+		log.WithError(err).Debug("ip-access: refresh after auto-ban failed")
+	}
+	return outcome
+}
+
+// charge adds one failure and reports the window count, the number of previous
+// bans, and whether a ban is already in force.
+func (e *autoBanEngine) charge(cidr string, policy AutoBanPolicy, now time.Time) (int, int, bool) {
+	window := policy.Window()
+	if window <= 0 {
+		return 0, 0, false
+	}
+	width := window / autoBanSlotCount
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	counter := e.counters[cidr]
+	if counter == nil {
+		e.evictIfSaturatedLocked()
+		counter = &autoBanCounter{}
+		e.counters[cidr] = counter
+	}
+	counter.lastActivity = now
+	if counter.bannedUntil.After(now) {
+		return 0, counter.banCount, true
+	}
+
+	index := now.UnixNano() / int64(width)
+	slot := &counter.slots[int(index%autoBanSlotCount)]
+	if slot.index != index {
+		slot.index = index
+		slot.count = 0
+	}
+	slot.count++
+
+	oldest := index - autoBanSlotCount + 1
+	total := 0
+	for i := range counter.slots {
+		if counter.slots[i].index >= oldest && counter.slots[i].index <= index {
+			total += int(counter.slots[i].count)
+		}
+	}
+	return total, counter.banCount, false
+}
+
+func (e *autoBanEngine) markBanned(cidr string, until time.Time, now time.Time) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	counter := e.counters[cidr]
+	if counter == nil {
+		counter = &autoBanCounter{}
+		e.counters[cidr] = counter
+	}
+	counter.bannedUntil = until
+	counter.banCount++
+	counter.lastActivity = now
+	// Clear the window so the same failures cannot immediately re-trigger once
+	// the ban lapses.
+	for i := range counter.slots {
+		counter.slots[i] = autoBanSlot{}
+	}
+}
+
+func (e *autoBanEngine) evictIfSaturatedLocked() {
+	if len(e.counters) < maxTrackedSources {
+		return
+	}
+	type aged struct {
+		key  string
+		seen time.Time
+	}
+	candidates := make([]aged, 0, len(e.counters))
+	for key, counter := range e.counters {
+		// Never evict a source that is currently banned: dropping it would hand
+		// the attacker an early release.
+		if counter.bannedUntil.After(time.Now()) {
+			continue
+		}
+		candidates = append(candidates, aged{key: key, seen: counter.lastActivity})
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].seen.Before(candidates[j].seen) })
+	evict := len(candidates) / autoBanEvictRatio
+	if evict < 1 {
+		evict = 1
+	}
+	for i := 0; i < evict && i < len(candidates); i++ {
+		delete(e.counters, candidates[i].key)
+	}
+	log.Warnf("ip-access: auto-ban source table saturated, evicted %d entries", evict)
+}
+
+// TrackedSources reports how many sources are being counted. Test-facing.
+func (e *autoBanEngine) TrackedSources() int {
+	if e == nil {
+		return 0
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.counters)
+}

--- a/internal/ipaccess/autoban_test.go
+++ b/internal/ipaccess/autoban_test.go
@@ -1,0 +1,142 @@
+package ipaccess
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func testRegistry(t *testing.T, policy ProtectionPolicy) *Registry {
+	t.Helper()
+	registry := NewRegistry(NewStore(nil))
+	normalized := policy.Normalized()
+	registry.policy.Store(&normalized)
+	registry.matcher.Store(NewMatcher(nil, normalized.Lockdown, time.Now()))
+	return registry
+}
+
+func trustedAddress(ip string) ClientAddress {
+	return ClientAddress{IP: net.ParseIP(ip), Raw: ip, Trusted: true}
+}
+
+func TestAutoBanObserveModeDoesNotWriteRules(t *testing.T) {
+	// The shipped default must never ban on its own: an auto-ban firing on a
+	// threshold nobody has watched against real traffic is a self-inflicted
+	// outage.
+	policy := DefaultPolicy()
+	policy.AutoBan.FailureThreshold = 3
+	registry := testRegistry(t, policy)
+
+	var outcome AutoBanOutcome
+	for i := 0; i < 3; i++ {
+		outcome = registry.AutoBan().RecordFailure(context.Background(), trustedAddress("203.0.113.5"), "test")
+	}
+	if !outcome.Triggered {
+		t.Fatal("threshold was reached but the rule did not trigger")
+	}
+	if outcome.Enforced {
+		t.Error("observe mode wrote a ban rule")
+	}
+}
+
+func TestAutoBanBelowThresholdDoesNothing(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.AutoBan.FailureThreshold = 5
+	registry := testRegistry(t, policy)
+
+	for i := 0; i < 4; i++ {
+		if outcome := registry.AutoBan().RecordFailure(context.Background(), trustedAddress("203.0.113.6"), "test"); outcome.Triggered {
+			t.Fatalf("triggered after %d failures, threshold is 5", i+1)
+		}
+	}
+}
+
+func TestAutoBanSkipsAllowListedSource(t *testing.T) {
+	// An operator's explicit allow must outrank the engine's judgement, or the
+	// office IP gets banned by the engine the operator was trying to protect it
+	// from.
+	policy := DefaultPolicy()
+	policy.AutoBan.FailureThreshold = 2
+	registry := testRegistry(t, policy)
+	rule := Rule{ID: "allow", CIDR: "203.0.113.7/32", Effect: EffectAllow, Enabled: true}
+	registry.matcher.Store(NewMatcher([]Rule{rule}, false, time.Now()))
+
+	for i := 0; i < 5; i++ {
+		if outcome := registry.AutoBan().RecordFailure(context.Background(), trustedAddress("203.0.113.7"), "test"); outcome.Triggered {
+			t.Fatal("an allow-listed source was proposed for a ban")
+		}
+	}
+}
+
+func TestAutoBanSkipsUntrustedAndLoopback(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.AutoBan.FailureThreshold = 1
+	registry := testRegistry(t, policy)
+
+	untrusted := ClientAddress{IP: net.ParseIP("172.17.0.1"), Raw: "172.17.0.1", Trusted: false}
+	if outcome := registry.AutoBan().RecordFailure(context.Background(), untrusted, "test"); outcome.Triggered {
+		t.Error("banned an untrusted address: that is the proxy, and every client behind it")
+	}
+	if outcome := registry.AutoBan().RecordFailure(context.Background(), trustedAddress("127.0.0.1"), "test"); outcome.Triggered {
+		t.Error("banned loopback: the operator's own channel")
+	}
+}
+
+func TestAutoBanModeOffDisablesEngine(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.AutoBan.Mode = AutoBanOff
+	policy.AutoBan.FailureThreshold = 1
+	registry := testRegistry(t, policy)
+
+	if outcome := registry.AutoBan().RecordFailure(context.Background(), trustedAddress("203.0.113.8"), "test"); outcome.Triggered {
+		t.Error("engine acted while switched off")
+	}
+}
+
+func TestAutoBanDoesNotRetriggerWhileBanned(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.AutoBan.FailureThreshold = 2
+	registry := testRegistry(t, policy)
+	address := trustedAddress("203.0.113.9")
+
+	registry.AutoBan().RecordFailure(context.Background(), address, "test")
+	first := registry.AutoBan().RecordFailure(context.Background(), address, "test")
+	if !first.Triggered {
+		t.Fatal("expected the second failure to trigger")
+	}
+	for i := 0; i < 5; i++ {
+		if again := registry.AutoBan().RecordFailure(context.Background(), address, "test"); again.Triggered {
+			t.Error("re-triggered while a ban was already in force; one offender should produce one decision")
+		}
+	}
+}
+
+func TestBanDurationEscalatesAndClamps(t *testing.T) {
+	policy := AutoBanPolicy{BanMinutes: 60, MaxBanMinutes: 240}
+	cases := []struct {
+		repeats int
+		want    time.Duration
+	}{
+		{0, 60 * time.Minute},
+		{1, 120 * time.Minute},
+		{2, 240 * time.Minute},
+		{9, 240 * time.Minute},
+	}
+	for _, tc := range cases {
+		if got := policy.BanDuration(tc.repeats); got != tc.want {
+			t.Errorf("BanDuration(%d) = %v, want %v", tc.repeats, got, tc.want)
+		}
+	}
+}
+
+func TestPolicyNormalizedRejectsZeroThreshold(t *testing.T) {
+	// A zero threshold would ban the first client to mistype a password.
+	policy := ProtectionPolicy{AutoBan: AutoBanPolicy{Mode: AutoBanEnforce}}.Normalized()
+	if policy.AutoBan.FailureThreshold <= 0 {
+		t.Error("threshold was left at zero")
+	}
+	if policy.AutoBan.WindowSeconds <= 0 || policy.AutoBan.BanMinutes <= 0 {
+		t.Error("window or ban duration was left at zero")
+	}
+}

--- a/internal/ipaccess/bootstrap.go
+++ b/internal/ipaccess/bootstrap.go
@@ -1,0 +1,46 @@
+package ipaccess
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+)
+
+// installed tracks which database the process-wide registry was built for, so a
+// runtime that swaps its pool (tests do this between cases, and a reconnect can
+// do it in production) gets a registry pointing at the live handle instead of a
+// closed one.
+var installed struct {
+	mu sync.Mutex
+	db *sql.DB
+}
+
+// EnsureDefault installs the process-wide registry for db and returns it.
+//
+// It is idempotent and safe to call from every entry point. Binding the registry
+// to "a database is available" rather than to one particular startup path is
+// deliberate: the previous version initialised only from the CLI runner, so any
+// caller that assembled the management API itself — the route smoke tests, and
+// anyone embedding the server through the SDK — got a nil registry and every IP
+// access endpoint answered 503.
+func EnsureDefault(ctx context.Context, db *sql.DB, proxyTrusted bool) *Registry {
+	if db == nil {
+		return Default()
+	}
+	installed.mu.Lock()
+	defer installed.mu.Unlock()
+
+	if existing := Default(); existing != nil && installed.db == db {
+		existing.SetProxyTrusted(proxyTrusted)
+		return existing
+	}
+	if previous := Default(); previous != nil {
+		previous.Close()
+	}
+	registry := NewRegistry(NewStore(db))
+	registry.SetProxyTrusted(proxyTrusted)
+	registry.Start(ctx)
+	SetDefault(registry)
+	installed.db = db
+	return registry
+}

--- a/internal/ipaccess/context.go
+++ b/internal/ipaccess/context.go
@@ -1,0 +1,42 @@
+package ipaccess
+
+import "context"
+
+type addressContextKey struct{}
+
+// WithAddress attaches the resolved client address to a request context.
+//
+// Audit records need the source address, and threading a parameter through every
+// RecordAudit call site would be dozens of edits that a future call site would
+// simply forget. The context carries it instead, so provenance is automatic.
+func WithAddress(ctx context.Context, address ClientAddress) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	return context.WithValue(ctx, addressContextKey{}, address)
+}
+
+// AddressFromContext reads back the client address, if one was attached.
+func AddressFromContext(ctx context.Context) (ClientAddress, bool) {
+	if ctx == nil {
+		return ClientAddress{}, false
+	}
+	address, ok := ctx.Value(addressContextKey{}).(ClientAddress)
+	return address, ok
+}
+
+// AuditAddress renders the source address for an audit row.
+//
+// An untrusted address is recorded with a marker rather than silently: writing
+// the proxy's address as if it were the actor's would make every audit row agree
+// on a single wrong answer, which is worse than an honest blank.
+func AuditAddress(ctx context.Context) string {
+	address, ok := AddressFromContext(ctx)
+	if !ok || address.Raw == "" {
+		return ""
+	}
+	if !address.Trusted {
+		return address.Raw + " (untrusted)"
+	}
+	return address.Raw
+}

--- a/internal/ipaccess/gin.go
+++ b/internal/ipaccess/gin.go
@@ -1,0 +1,57 @@
+package ipaccess
+
+import "github.com/gin-gonic/gin"
+
+// GinContextKey is where the admission middleware stashes its findings so later
+// layers reuse them instead of re-resolving the address. Re-resolving would not
+// merely waste work: two layers deriving trust independently could disagree, and
+// a throttle that thinks an address is trustworthy while admission does not is
+// exactly the inconsistency that produces phantom lockouts.
+const GinContextKey = "cliproxy.ipaccess"
+
+// RequestContext is the per-request result of consulting the list.
+type RequestContext struct {
+	Address ClientAddress
+	Verdict Verdict
+}
+
+// StoreContext publishes the findings for later middleware.
+func StoreContext(c *gin.Context, rc RequestContext) {
+	if c == nil {
+		return
+	}
+	c.Set(GinContextKey, rc)
+}
+
+// FromGin reads back what the admission middleware recorded.
+func FromGin(c *gin.Context) (RequestContext, bool) {
+	if c == nil {
+		return RequestContext{}, false
+	}
+	value, ok := c.Get(GinContextKey)
+	if !ok {
+		return RequestContext{}, false
+	}
+	rc, ok := value.(RequestContext)
+	return rc, ok
+}
+
+// ExemptFromThrottle reports whether this request matched an allow rule and so
+// must not be rate limited.
+func ExemptFromThrottle(c *gin.Context) bool {
+	rc, ok := FromGin(c)
+	return ok && rc.Verdict.Exempt()
+}
+
+// AddressFor returns the resolved client address, falling back to resolving it
+// on the spot for requests that never passed through the admission middleware
+// (management routes mounted on a bare engine in tests, for instance).
+func AddressFor(c *gin.Context) ClientAddress {
+	if rc, ok := FromGin(c); ok {
+		return rc.Address
+	}
+	if c == nil {
+		return ClientAddress{}
+	}
+	return Default().ResolveAddress(c.Request, c.ClientIP())
+}

--- a/internal/ipaccess/matcher.go
+++ b/internal/ipaccess/matcher.go
@@ -1,0 +1,208 @@
+package ipaccess
+
+import (
+	"net"
+	"sort"
+	"time"
+)
+
+// Decision is the outcome of matching an address against the list.
+type Decision uint8
+
+const (
+	// DecisionNeutral means no rule matched. Under lockdown the caller turns
+	// this into a rejection; otherwise it is a pass.
+	DecisionNeutral Decision = iota
+	DecisionAllow
+	DecisionDeny
+)
+
+func (d Decision) String() string {
+	switch d {
+	case DecisionAllow:
+		return "allow"
+	case DecisionDeny:
+		return "deny"
+	default:
+		return "neutral"
+	}
+}
+
+// prefixIndex stores rules bucketed by prefix length, so a lookup costs one map
+// probe per distinct prefix length present rather than a scan over every rule.
+// Operators typically use a handful of prefix lengths, so this stays at a few
+// probes even with thousands of rules on the request hot path.
+type prefixIndex struct {
+	v4     map[int]map[[4]byte]*Rule
+	v6     map[int]map[[16]byte]*Rule
+	v4Lens []int
+	v6Lens []int
+}
+
+func newPrefixIndex() *prefixIndex {
+	return &prefixIndex{
+		v4: make(map[int]map[[4]byte]*Rule),
+		v6: make(map[int]map[[16]byte]*Rule),
+	}
+}
+
+func (p *prefixIndex) add(rule *Rule, network *net.IPNet) {
+	ones, bits := network.Mask.Size()
+	if bits == 32 {
+		var key [4]byte
+		copy(key[:], network.IP.To4())
+		bucket, ok := p.v4[ones]
+		if !ok {
+			bucket = make(map[[4]byte]*Rule)
+			p.v4[ones] = bucket
+			p.v4Lens = append(p.v4Lens, ones)
+		}
+		bucket[key] = rule
+		return
+	}
+	var key [16]byte
+	copy(key[:], network.IP.To16())
+	bucket, ok := p.v6[ones]
+	if !ok {
+		bucket = make(map[[16]byte]*Rule)
+		p.v6[ones] = bucket
+		p.v6Lens = append(p.v6Lens, ones)
+	}
+	bucket[key] = rule
+}
+
+// seal orders prefix lengths from most to least specific so lookup can return
+// the longest-prefix match on its first hit.
+func (p *prefixIndex) seal() {
+	sort.Sort(sort.Reverse(sort.IntSlice(p.v4Lens)))
+	sort.Sort(sort.Reverse(sort.IntSlice(p.v6Lens)))
+}
+
+func (p *prefixIndex) lookup(ip net.IP) *Rule {
+	if v4 := ip.To4(); v4 != nil {
+		for _, ones := range p.v4Lens {
+			bucket := p.v4[ones]
+			if len(bucket) == 0 {
+				continue
+			}
+			var key [4]byte
+			mask := net.CIDRMask(ones, 32)
+			for i := 0; i < 4; i++ {
+				key[i] = v4[i] & mask[i]
+			}
+			if rule, ok := bucket[key]; ok {
+				return rule
+			}
+		}
+		return nil
+	}
+	v6 := ip.To16()
+	if v6 == nil {
+		return nil
+	}
+	for _, ones := range p.v6Lens {
+		bucket := p.v6[ones]
+		if len(bucket) == 0 {
+			continue
+		}
+		var key [16]byte
+		mask := net.CIDRMask(ones, 128)
+		for i := 0; i < 16; i++ {
+			key[i] = v6[i] & mask[i]
+		}
+		if rule, ok := bucket[key]; ok {
+			return rule
+		}
+	}
+	return nil
+}
+
+// Matcher is an immutable snapshot of the active rule set. It is rebuilt on
+// refresh and swapped in atomically, so a request never observes a half-applied
+// rule change.
+type Matcher struct {
+	allow    *prefixIndex
+	deny     *prefixIndex
+	lockdown bool
+	count    int
+}
+
+// NewMatcher builds a snapshot from the rules that are active at now.
+//
+// lockdown turns the list into an admission list: anything that does not match
+// an allow rule is rejected. It is stored on the snapshot rather than read from
+// config at match time so that "which rules were live" and "was lockdown on"
+// can never disagree for a single request.
+func NewMatcher(rules []Rule, lockdown bool, now time.Time) *Matcher {
+	m := &Matcher{allow: newPrefixIndex(), deny: newPrefixIndex(), lockdown: lockdown}
+	for i := range rules {
+		rule := rules[i]
+		if !rule.Active(now) {
+			continue
+		}
+		_, network, err := net.ParseCIDR(rule.CIDR)
+		if err != nil || network == nil {
+			// Stored rows are normalised on write, so this only fires for data
+			// edited outside the API. Skipping beats failing the whole snapshot
+			// and dropping every other rule with it.
+			continue
+		}
+		stored := rule
+		switch rule.Effect {
+		case EffectAllow:
+			m.allow.add(&stored, network)
+		case EffectDeny:
+			m.deny.add(&stored, network)
+		default:
+			continue
+		}
+		m.count++
+	}
+	m.allow.seal()
+	m.deny.seal()
+	return m
+}
+
+// Match resolves an address against the snapshot.
+//
+// Allow wins over deny by design: a specific exception must be able to override
+// a broad ban, otherwise banning 1.2.0.0/16 permanently locks out the one office
+// machine inside it and the only fix is deleting the ban entirely.
+func (m *Matcher) Match(ip net.IP) (Decision, *Rule) {
+	if m == nil || ip == nil {
+		return DecisionNeutral, nil
+	}
+	if rule := m.allow.lookup(ip); rule != nil {
+		return DecisionAllow, rule
+	}
+	if rule := m.deny.lookup(ip); rule != nil {
+		return DecisionDeny, rule
+	}
+	if m.lockdown {
+		return DecisionDeny, nil
+	}
+	return DecisionNeutral, nil
+}
+
+// Lockdown reports whether this snapshot rejects unlisted addresses.
+func (m *Matcher) Lockdown() bool {
+	return m != nil && m.lockdown
+}
+
+// Count reports how many rules are live in this snapshot.
+func (m *Matcher) Count() int {
+	if m == nil {
+		return 0
+	}
+	return m.count
+}
+
+// AllowsAddress reports whether an address is explicitly allow-listed. It backs
+// the self-lockout guard: enabling lockdown is only safe if the operator making
+// the request would still be admitted afterwards.
+func (m *Matcher) AllowsAddress(ip net.IP) bool {
+	if m == nil || ip == nil {
+		return false
+	}
+	return m.allow.lookup(ip) != nil
+}

--- a/internal/ipaccess/matcher_test.go
+++ b/internal/ipaccess/matcher_test.go
@@ -1,0 +1,183 @@
+package ipaccess
+
+import (
+	"net"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func mustRule(t *testing.T, cidr string, effect Effect) Rule {
+	t.Helper()
+	normalized, family, err := NormalizeCIDR(cidr)
+	if err != nil {
+		t.Fatalf("NormalizeCIDR(%q): %v", cidr, err)
+	}
+	return Rule{ID: cidr, CIDR: normalized, Family: family, Effect: effect, Enabled: true}
+}
+
+func TestNormalizeCIDRClearsHostBits(t *testing.T) {
+	// Without this the same network can be stored twice under different spellings
+	// and the uniqueness constraint never fires.
+	got, family, err := NormalizeCIDR("1.2.3.5/24")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "1.2.3.0/24" || family != 4 {
+		t.Fatalf("got %q family %d, want 1.2.3.0/24 family 4", got, family)
+	}
+}
+
+func TestNormalizeCIDRBareAddressBecomesHostRoute(t *testing.T) {
+	got, _, err := NormalizeCIDR("203.0.113.7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "203.0.113.7/32" {
+		t.Fatalf("got %q, want 203.0.113.7/32", got)
+	}
+}
+
+func TestNormalizeCIDRRejectsSelfDestructiveInput(t *testing.T) {
+	for _, input := range []string{"0.0.0.0/0", "::/0", "10.0.0.0/4", "127.0.0.1", "::1", "", "not-an-ip"} {
+		if _, _, err := NormalizeCIDR(input); err == nil {
+			t.Errorf("NormalizeCIDR(%q) accepted input that should be rejected", input)
+		}
+	}
+}
+
+func TestMatcherAllowBeatsDeny(t *testing.T) {
+	// A specific exception must override a broad ban, or banning a /16 makes the
+	// one office machine inside it unreachable with no way back short of deleting
+	// the ban entirely.
+	matcher := NewMatcher([]Rule{
+		mustRule(t, "1.2.0.0/16", EffectDeny),
+		mustRule(t, "1.2.3.4/32", EffectAllow),
+	}, false, time.Now())
+
+	if decision, _ := matcher.Match(net.ParseIP("1.2.3.4")); decision != DecisionAllow {
+		t.Errorf("allowed host inside denied range: got %v, want allow", decision)
+	}
+	if decision, _ := matcher.Match(net.ParseIP("1.2.9.9")); decision != DecisionDeny {
+		t.Errorf("other host in denied range: got %v, want deny", decision)
+	}
+	if decision, _ := matcher.Match(net.ParseIP("9.9.9.9")); decision != DecisionNeutral {
+		t.Errorf("unrelated host: got %v, want neutral", decision)
+	}
+}
+
+func TestMatcherLongestPrefixWins(t *testing.T) {
+	matcher := NewMatcher([]Rule{
+		mustRule(t, "10.0.0.0/8", EffectDeny),
+		mustRule(t, "10.1.2.0/24", EffectAllow),
+	}, false, time.Now())
+	if decision, _ := matcher.Match(net.ParseIP("10.1.2.99")); decision != DecisionAllow {
+		t.Errorf("got %v, want allow from the more specific rule", decision)
+	}
+}
+
+func TestMatcherIPv6MatchesBySixtyFour(t *testing.T) {
+	matcher := NewMatcher([]Rule{mustRule(t, "2001:db8:1:2::/64", EffectDeny)}, false, time.Now())
+	if decision, _ := matcher.Match(net.ParseIP("2001:db8:1:2::dead")); decision != DecisionDeny {
+		t.Errorf("got %v, want deny for an address inside the /64", decision)
+	}
+	if decision, _ := matcher.Match(net.ParseIP("2001:db8:1:3::1")); decision != DecisionNeutral {
+		t.Errorf("got %v, want neutral for a neighbouring /64", decision)
+	}
+}
+
+func TestMatcherSkipsExpiredAndDisabled(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	expired := mustRule(t, "5.5.5.5/32", EffectDeny)
+	expired.ExpiresAt = &past
+	disabled := mustRule(t, "6.6.6.6/32", EffectDeny)
+	disabled.Enabled = false
+
+	matcher := NewMatcher([]Rule{expired, disabled}, false, time.Now())
+	if decision, _ := matcher.Match(net.ParseIP("5.5.5.5")); decision != DecisionNeutral {
+		t.Errorf("expired rule still applied: got %v", decision)
+	}
+	if decision, _ := matcher.Match(net.ParseIP("6.6.6.6")); decision != DecisionNeutral {
+		t.Errorf("disabled rule still applied: got %v", decision)
+	}
+}
+
+func TestMatcherLockdownDeniesUnlisted(t *testing.T) {
+	matcher := NewMatcher([]Rule{mustRule(t, "1.2.3.4/32", EffectAllow)}, true, time.Now())
+	if decision, _ := matcher.Match(net.ParseIP("1.2.3.4")); decision != DecisionAllow {
+		t.Errorf("listed address under lockdown: got %v, want allow", decision)
+	}
+	if decision, _ := matcher.Match(net.ParseIP("1.2.3.5")); decision != DecisionDeny {
+		t.Errorf("unlisted address under lockdown: got %v, want deny", decision)
+	}
+}
+
+func TestResolveMarksRelayedRequestUntrustedWithoutTrustedProxies(t *testing.T) {
+	// This is the production state that made the whole feature inert: nginx sets
+	// X-Forwarded-For, trusted-proxies is empty, so the resolved address is the
+	// proxy's and stands for every client behind it.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.9")
+
+	untrusted := Resolve(req, "172.17.0.1", false)
+	if untrusted.Trusted {
+		t.Error("relayed request with no trusted-proxies was treated as trustworthy")
+	}
+	if untrusted.RelayHeader == "" {
+		t.Error("relay header was not reported")
+	}
+
+	trusted := Resolve(req, "203.0.113.9", true)
+	if !trusted.Trusted {
+		t.Error("relayed request with trusted-proxies configured should be trusted")
+	}
+	if trusted.Raw != "203.0.113.9" {
+		t.Errorf("got %q, want the framework-resolved client address", trusted.Raw)
+	}
+}
+
+func TestResolveIgnoresForwardingHeaderAsAddress(t *testing.T) {
+	// The header is attacker-controlled; only the framework-resolved address may
+	// be used, otherwise a banned client renames itself out of its ban.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	address := Resolve(req, "198.51.100.7", true)
+	if address.Raw != "198.51.100.7" {
+		t.Errorf("got %q, want the resolved address rather than the header value", address.Raw)
+	}
+}
+
+func TestRegistryDoesNotEnforceUntrustedAddress(t *testing.T) {
+	registry := NewRegistry(NewStore(nil))
+	registry.matcher.Store(NewMatcher([]Rule{mustRule(t, "203.0.113.9/32", EffectDeny)}, false, time.Now()))
+
+	verdict := registry.Evaluate(ClientAddress{IP: net.ParseIP("203.0.113.9"), Raw: "203.0.113.9", Trusted: false})
+	if verdict.Enforced {
+		t.Error("verdict was enforced for an untrusted address")
+	}
+	if !verdict.Allowed() {
+		t.Error("an unenforceable verdict must fail open, never deny")
+	}
+}
+
+func TestRegistryAlwaysAdmitsLoopback(t *testing.T) {
+	registry := NewRegistry(NewStore(nil))
+	policy := DefaultPolicy()
+	policy.Lockdown = true
+	registry.policy.Store(&policy)
+	registry.matcher.Store(NewMatcher(nil, true, time.Now()))
+
+	verdict := registry.Evaluate(ClientAddress{IP: net.ParseIP("127.0.0.1"), Raw: "127.0.0.1", Trusted: true})
+	if !verdict.Allowed() {
+		t.Error("loopback was denied; the operator would lose access to their own host")
+	}
+}
+
+func TestBanCIDRCollapsesIPv6ToSixtyFour(t *testing.T) {
+	if got := BanCIDR(net.ParseIP("2001:db8:1:2::5")); got != "2001:db8:1:2::/64" {
+		t.Errorf("got %q, want the /64 so the next address in the block is covered", got)
+	}
+	if got := BanCIDR(net.ParseIP("192.0.2.5")); got != "192.0.2.5/32" {
+		t.Errorf("got %q, want a host route for IPv4", got)
+	}
+}

--- a/internal/ipaccess/policy.go
+++ b/internal/ipaccess/policy.go
@@ -1,0 +1,144 @@
+package ipaccess
+
+import "time"
+
+// AutoBanMode controls what the automatic ban engine does with a source that
+// crosses the failure threshold.
+type AutoBanMode string
+
+const (
+	// AutoBanOff disables evaluation entirely.
+	AutoBanOff AutoBanMode = "off"
+	// AutoBanObserve records a would_ban event but writes no rule. This is the
+	// shipped default: an automatic ban rule that fires on a bad threshold is a
+	// self-inflicted outage, so operators get to watch the rule fire against
+	// real traffic before it is allowed to act.
+	AutoBanObserve AutoBanMode = "observe"
+	// AutoBanEnforce writes a temporary deny rule.
+	AutoBanEnforce AutoBanMode = "enforce"
+)
+
+// AutoBanPolicy is the rule that promotes repeated authentication failures into
+// a temporary deny entry.
+type AutoBanPolicy struct {
+	Mode AutoBanMode `json:"mode"`
+	// WindowSeconds is the observation window for counting failures.
+	WindowSeconds int `json:"window_seconds"`
+	// FailureThreshold is the failure count within the window that triggers a ban.
+	// Failures are counted across every authentication surface, because an
+	// attacker spreading attempts over login, portal and management-key endpoints
+	// is more suspicious than one hammering a single door, not less.
+	FailureThreshold int `json:"failure_threshold"`
+	// BanMinutes is the first ban duration.
+	BanMinutes int `json:"ban_minutes"`
+	// MaxBanMinutes caps the doubling escalation applied to repeat offenders.
+	MaxBanMinutes int `json:"max_ban_minutes"`
+}
+
+// ThrottleOverride mirrors the config.AuthHardening knobs that operators may
+// retune at runtime. Zero means "keep the configured or shipped value", so an
+// untouched field never silently rewrites config.yaml semantics.
+type ThrottleOverride struct {
+	LoginFailureWindowSeconds   int `json:"login_failure_window_seconds"`
+	AccountFailureLimit         int `json:"account_failure_limit"`
+	ManagementKeyFailureLimit   int `json:"management_key_failure_limit"`
+	UnauthenticatedRequestLimit int `json:"unauthenticated_request_limit"`
+	FailureResetHours           int `json:"failure_reset_hours"`
+}
+
+// ProtectionPolicy is the persisted, operator-editable half of the protection
+// settings. It is stored as one runtime-settings document rather than a table
+// because it is a single object that is read on every refresh and never queried
+// by field.
+type ProtectionPolicy struct {
+	// Lockdown rejects any address that is not explicitly allow-listed.
+	Lockdown bool             `json:"lockdown"`
+	AutoBan  AutoBanPolicy    `json:"auto_ban"`
+	Throttle ThrottleOverride `json:"throttle"`
+}
+
+// SettingKey is the runtime-settings document key for ProtectionPolicy.
+const SettingKey = "ip-access-protection-policy"
+
+const (
+	defaultAutoBanWindowSeconds = 600
+	defaultAutoBanThreshold     = 20
+	defaultAutoBanMinutes       = 60
+	defaultAutoBanMaxMinutes    = 24 * 60
+)
+
+// DefaultPolicy is the shipped configuration: the list is enforced, but nothing
+// bans automatically until an operator has seen the rule fire.
+func DefaultPolicy() ProtectionPolicy {
+	return ProtectionPolicy{
+		Lockdown: false,
+		AutoBan: AutoBanPolicy{
+			Mode:             AutoBanObserve,
+			WindowSeconds:    defaultAutoBanWindowSeconds,
+			FailureThreshold: defaultAutoBanThreshold,
+			BanMinutes:       defaultAutoBanMinutes,
+			MaxBanMinutes:    defaultAutoBanMaxMinutes,
+		},
+	}
+}
+
+// Normalized clamps operator input into a workable policy. Out-of-range values
+// fall back to the default rather than disabling protection, because a zero
+// threshold would otherwise ban the first client to mistype a password.
+func (p ProtectionPolicy) Normalized() ProtectionPolicy {
+	defaults := DefaultPolicy()
+	switch p.AutoBan.Mode {
+	case AutoBanOff, AutoBanObserve, AutoBanEnforce:
+	default:
+		p.AutoBan.Mode = defaults.AutoBan.Mode
+	}
+	if p.AutoBan.WindowSeconds <= 0 {
+		p.AutoBan.WindowSeconds = defaults.AutoBan.WindowSeconds
+	}
+	if p.AutoBan.FailureThreshold <= 0 {
+		p.AutoBan.FailureThreshold = defaults.AutoBan.FailureThreshold
+	}
+	if p.AutoBan.BanMinutes <= 0 {
+		p.AutoBan.BanMinutes = defaults.AutoBan.BanMinutes
+	}
+	if p.AutoBan.MaxBanMinutes <= 0 {
+		p.AutoBan.MaxBanMinutes = defaults.AutoBan.MaxBanMinutes
+	}
+	if p.AutoBan.MaxBanMinutes < p.AutoBan.BanMinutes {
+		p.AutoBan.MaxBanMinutes = p.AutoBan.BanMinutes
+	}
+	if p.Throttle.LoginFailureWindowSeconds < 0 {
+		p.Throttle.LoginFailureWindowSeconds = 0
+	}
+	if p.Throttle.AccountFailureLimit < 0 {
+		p.Throttle.AccountFailureLimit = 0
+	}
+	if p.Throttle.ManagementKeyFailureLimit < 0 {
+		p.Throttle.ManagementKeyFailureLimit = 0
+	}
+	if p.Throttle.UnauthenticatedRequestLimit < 0 {
+		p.Throttle.UnauthenticatedRequestLimit = 0
+	}
+	if p.Throttle.FailureResetHours < 0 {
+		p.Throttle.FailureResetHours = 0
+	}
+	return p
+}
+
+// Window returns the auto-ban observation window.
+func (p AutoBanPolicy) Window() time.Duration {
+	return time.Duration(p.WindowSeconds) * time.Second
+}
+
+// BanDuration returns the ban length for a source that has already been banned
+// repeats times, doubling each round up to MaxBanMinutes.
+func (p AutoBanPolicy) BanDuration(repeats int) time.Duration {
+	minutes := p.BanMinutes
+	for i := 0; i < repeats && minutes < p.MaxBanMinutes; i++ {
+		minutes *= 2
+	}
+	if minutes > p.MaxBanMinutes {
+		minutes = p.MaxBanMinutes
+	}
+	return time.Duration(minutes) * time.Minute
+}

--- a/internal/ipaccess/registry.go
+++ b/internal/ipaccess/registry.go
@@ -1,0 +1,327 @@
+package ipaccess
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// refreshInterval bounds how long a rule change takes to reach another
+	// process. The deployment runs blue/green slots that share no memory, so the
+	// database is the only common ground and every slot must poll it.
+	refreshInterval = 15 * time.Second
+	// hitFlushInterval batches match counters back to the database.
+	hitFlushInterval = time.Minute
+	// autoPurgeInterval reclaims lapsed automatic bans.
+	autoPurgeInterval = time.Hour
+)
+
+// Verdict is the admission decision for one request.
+type Verdict struct {
+	Decision Decision
+	// Rule is the rule that matched, nil for lockdown rejections and passes.
+	Rule *Rule
+	// Enforced is false when the list was consulted but could not be applied,
+	// which happens when the client address is not trustworthy. Callers must
+	// treat a non-enforced verdict as "allow and warn", never as "deny".
+	Enforced bool
+	// Reason explains a non-enforced verdict for diagnostics.
+	Reason string
+}
+
+// Allowed reports whether the request may proceed.
+func (v Verdict) Allowed() bool {
+	return !v.Enforced || v.Decision != DecisionDeny
+}
+
+// Exempt reports whether the request matched an allow rule and should therefore
+// skip rate limiting.
+func (v Verdict) Exempt() bool {
+	return v.Enforced && v.Decision == DecisionAllow
+}
+
+const (
+	reasonUntrustedClientIP = "client address is not trustworthy (relayed request with no trusted-proxies)"
+	reasonNoStorage         = "rule storage unavailable"
+)
+
+// Registry owns the live rule snapshot and keeps it in step with the database.
+type Registry struct {
+	store     *Store
+	matcher   atomic.Pointer[Matcher]
+	policy    atomic.Pointer[ProtectionPolicy]
+	persister PolicyPersister
+
+	// proxyTrusted mirrors "trusted-proxies is non-empty". It lives here rather
+	// than being read from config at match time because a hot reload swaps the
+	// whole config pointer, so a middleware that captured the old one would keep
+	// answering from a stale deployment.
+	proxyTrusted atomic.Bool
+
+	hitsMu sync.Mutex
+	hits   map[string]int64
+
+	stop     chan struct{}
+	stopOnce sync.Once
+
+	autoBan *autoBanEngine
+}
+
+// NewRegistry builds a registry over the given store. The snapshot starts empty,
+// so requests pass until the first refresh completes — failing open on startup
+// is deliberate: a database hiccup must not make the service unreachable.
+func NewRegistry(store *Store) *Registry {
+	r := &Registry{store: store, hits: make(map[string]int64), stop: make(chan struct{})}
+	policy := DefaultPolicy()
+	r.policy.Store(&policy)
+	r.matcher.Store(NewMatcher(nil, false, time.Now()))
+	r.autoBan = newAutoBanEngine(r)
+	return r
+}
+
+// Policy returns the active protection policy.
+func (r *Registry) Policy() ProtectionPolicy {
+	if r == nil {
+		return DefaultPolicy()
+	}
+	if p := r.policy.Load(); p != nil {
+		return *p
+	}
+	return DefaultPolicy()
+}
+
+// SetPolicy swaps the policy in memory and rebuilds the snapshot, because the
+// lockdown flag lives on the snapshot.
+func (r *Registry) SetPolicy(ctx context.Context, policy ProtectionPolicy) {
+	if r == nil {
+		return
+	}
+	normalized := policy.Normalized()
+	r.policy.Store(&normalized)
+	if err := r.Refresh(ctx); err != nil {
+		log.WithError(err).Warn("ip-access: refresh after policy change failed")
+	}
+}
+
+// PolicyPersister stores the policy document.
+//
+// It is an interface so this package never learns about the settings store:
+// the admission layer sits on the request path and must not acquire a
+// dependency on the configuration subsystem to get there.
+type PolicyPersister interface {
+	Load() (ProtectionPolicy, bool)
+	Save(ProtectionPolicy) error
+}
+
+// SetPolicyPersister attaches persistence and adopts whatever is already stored.
+func (r *Registry) SetPolicyPersister(ctx context.Context, persister PolicyPersister) {
+	if r == nil || persister == nil {
+		return
+	}
+	r.persister = persister
+	if stored, ok := persister.Load(); ok {
+		r.SetPolicy(ctx, stored)
+	}
+}
+
+// UpdatePolicy persists a new policy and applies it. The write happens first:
+// a policy that took effect but did not survive a restart would silently revert,
+// and an operator who saw "lockdown enabled" would be wrong after the next
+// deploy.
+func (r *Registry) UpdatePolicy(ctx context.Context, policy ProtectionPolicy) error {
+	if r == nil {
+		return nil
+	}
+	normalized := policy.Normalized()
+	if r.persister != nil {
+		if err := r.persister.Save(normalized); err != nil {
+			return err
+		}
+	}
+	r.SetPolicy(ctx, normalized)
+	return nil
+}
+
+// ReloadPolicy re-adopts the stored policy. Used by the config watcher so a
+// change written by the other blue/green slot is picked up here too.
+func (r *Registry) ReloadPolicy(ctx context.Context) {
+	if r == nil || r.persister == nil {
+		return
+	}
+	if stored, ok := r.persister.Load(); ok {
+		r.SetPolicy(ctx, stored)
+	}
+}
+
+// SetProxyTrusted records whether the operator declared any trusted proxy.
+func (r *Registry) SetProxyTrusted(configured bool) {
+	if r == nil {
+		return
+	}
+	r.proxyTrusted.Store(configured)
+}
+
+// ProxyTrusted reports whether forwarding headers may be believed.
+func (r *Registry) ProxyTrusted() bool {
+	return r != nil && r.proxyTrusted.Load()
+}
+
+// ResolveAddress derives the client address for a request using the registry's
+// view of proxy trust, so admission and throttling can never disagree about
+// whether an address is meaningful.
+func (r *Registry) ResolveAddress(req *http.Request, resolvedIP string) ClientAddress {
+	return Resolve(req, resolvedIP, r.ProxyTrusted())
+}
+
+// Store exposes the rule store for the management API.
+func (r *Registry) Store() *Store {
+	if r == nil {
+		return nil
+	}
+	return r.store
+}
+
+// Matcher exposes the current snapshot.
+func (r *Registry) Matcher() *Matcher {
+	if r == nil {
+		return nil
+	}
+	return r.matcher.Load()
+}
+
+// Refresh rebuilds the snapshot from the database.
+func (r *Registry) Refresh(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	if !r.store.Available() {
+		return nil
+	}
+	now := time.Now()
+	rules, err := r.store.LoadActive(ctx, now)
+	if err != nil {
+		// The previous snapshot stays in force. Dropping every rule because one
+		// query failed would silently unban whoever is currently being blocked.
+		return err
+	}
+	r.matcher.Store(NewMatcher(rules, r.Policy().Lockdown, now))
+	return nil
+}
+
+// Evaluate resolves a client address against the list.
+func (r *Registry) Evaluate(addr ClientAddress) Verdict {
+	if r == nil {
+		return Verdict{Decision: DecisionNeutral}
+	}
+	// Loopback is unconditionally admitted so a bad list can never lock an
+	// operator out of the host the process runs on.
+	if addr.Loopback() {
+		return Verdict{Decision: DecisionAllow, Enforced: true, Reason: "loopback"}
+	}
+	if !addr.Trusted {
+		return Verdict{Decision: DecisionNeutral, Enforced: false, Reason: reasonUntrustedClientIP}
+	}
+	if !r.store.Available() {
+		return Verdict{Decision: DecisionNeutral, Enforced: false, Reason: reasonNoStorage}
+	}
+	matcher := r.matcher.Load()
+	decision, rule := matcher.Match(addr.IP)
+	if rule != nil {
+		r.noteHit(rule.ID)
+	}
+	return Verdict{Decision: decision, Rule: rule, Enforced: true}
+}
+
+func (r *Registry) noteHit(id string) {
+	if id == "" {
+		return
+	}
+	r.hitsMu.Lock()
+	r.hits[id]++
+	r.hitsMu.Unlock()
+}
+
+// AutoBan exposes the automatic ban engine.
+func (r *Registry) AutoBan() *autoBanEngine {
+	if r == nil {
+		return nil
+	}
+	return r.autoBan
+}
+
+// Start launches the background loops. It returns immediately.
+func (r *Registry) Start(ctx context.Context) {
+	if r == nil || !r.store.Available() {
+		return
+	}
+	if err := r.Refresh(ctx); err != nil {
+		log.WithError(err).Warn("ip-access: initial rule load failed")
+	}
+	go r.loop(ctx)
+}
+
+func (r *Registry) loop(ctx context.Context) {
+	refresh := time.NewTicker(refreshInterval)
+	flush := time.NewTicker(hitFlushInterval)
+	purge := time.NewTicker(autoPurgeInterval)
+	defer refresh.Stop()
+	defer flush.Stop()
+	defer purge.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.stop:
+			return
+		case <-refresh.C:
+			if err := r.Refresh(ctx); err != nil {
+				log.WithError(err).Debug("ip-access: periodic refresh failed")
+			}
+		case <-flush.C:
+			r.flushHits(ctx)
+		case <-purge.C:
+			// Keep lapsed bans for a day before reclaiming them so the panel can
+			// still show what was recently blocked and why.
+			if removed, err := r.store.PurgeExpiredAuto(ctx, time.Now().Add(-24*time.Hour)); err != nil {
+				log.WithError(err).Debug("ip-access: purge expired auto rules failed")
+			} else if removed > 0 {
+				log.Debugf("ip-access: purged %d expired automatic rules", removed)
+			}
+		}
+	}
+}
+
+func (r *Registry) flushHits(ctx context.Context) {
+	r.hitsMu.Lock()
+	if len(r.hits) == 0 {
+		r.hitsMu.Unlock()
+		return
+	}
+	pending := r.hits
+	r.hits = make(map[string]int64)
+	r.hitsMu.Unlock()
+	if err := r.store.RecordHits(ctx, pending, time.Now()); err != nil {
+		log.WithError(err).Debug("ip-access: flush rule hit counters failed")
+	}
+}
+
+// Close stops the background loops. Safe to call more than once.
+func (r *Registry) Close() {
+	if r == nil {
+		return
+	}
+	r.stopOnce.Do(func() { close(r.stop) })
+}
+
+var defaultRegistry atomic.Pointer[Registry]
+
+// SetDefault publishes the process-wide registry.
+func SetDefault(r *Registry) { defaultRegistry.Store(r) }
+
+// Default returns the process-wide registry, or nil when none is configured.
+func Default() *Registry { return defaultRegistry.Load() }

--- a/internal/ipaccess/rule.go
+++ b/internal/ipaccess/rule.go
@@ -1,0 +1,188 @@
+// Package ipaccess implements the operator-managed IP allow/deny list that
+// fronts every request, together with the trust check that decides whether the
+// observed client address is meaningful at all.
+//
+// The trust check is not an optional refinement: behind a reverse proxy with no
+// trusted-proxies configured, every client reports the proxy's address. Denying
+// that address bans everyone and allowing it exempts everyone, so a list that
+// ignored trust would be actively dangerous rather than merely useless.
+package ipaccess
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// Effect is the verdict a rule carries when it matches.
+type Effect string
+
+const (
+	EffectAllow Effect = "allow"
+	EffectDeny  Effect = "deny"
+)
+
+// Source records who created a rule. Automatic rules are reclaimable by the
+// expiry sweeper; manual rules are never removed without an operator asking.
+type Source string
+
+const (
+	SourceManual Source = "manual"
+	SourceAuto   Source = "auto"
+)
+
+// Minimum prefix lengths. A rule coarser than these covers so much of the
+// address space that it can only be a mistake: /8 is 16 million addresses, and
+// a deny that wide takes the deployment offline while an allow that wide
+// silently disables the deny list.
+const (
+	MinPrefixLenV4 = 8
+	MinPrefixLenV6 = 32
+)
+
+var (
+	ErrEmptyCIDR       = errors.New("ip access: empty address")
+	ErrInvalidCIDR     = errors.New("ip access: not a valid IP address or CIDR")
+	ErrLoopbackCIDR    = errors.New("ip access: loopback addresses are always permitted and cannot be listed")
+	ErrUnspecifiedCIDR = errors.New("ip access: unspecified address cannot be listed")
+	ErrInvalidEffect   = errors.New("ip access: effect must be allow or deny")
+)
+
+// Rule is one persisted allow/deny entry.
+type Rule struct {
+	ID        string     `json:"id"`
+	CIDR      string     `json:"cidr"`
+	Family    int        `json:"family"`
+	Effect    Effect     `json:"effect"`
+	Source    Source     `json:"source"`
+	Reason    string     `json:"reason"`
+	Note      string     `json:"note"`
+	Enabled   bool       `json:"enabled"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	CreatedBy string     `json:"created_by,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	HitCount  int64      `json:"hit_count"`
+	LastHitAt *time.Time `json:"last_hit_at,omitempty"`
+}
+
+// Active reports whether a rule should participate in matching at the given
+// instant. Expiry is evaluated here rather than only in SQL so a rule that
+// lapses between two refresh cycles stops applying immediately.
+func (r Rule) Active(now time.Time) bool {
+	if !r.Enabled {
+		return false
+	}
+	if r.ExpiresAt != nil && !r.ExpiresAt.After(now) {
+		return false
+	}
+	return true
+}
+
+// ParseEffect validates operator input.
+func ParseEffect(raw string) (Effect, error) {
+	switch Effect(strings.ToLower(strings.TrimSpace(raw))) {
+	case EffectAllow:
+		return EffectAllow, nil
+	case EffectDeny:
+		return EffectDeny, nil
+	default:
+		return "", ErrInvalidEffect
+	}
+}
+
+// NormalizeCIDR canonicalises operator input into a masked CIDR string and
+// reports the address family.
+//
+// Bare addresses become host routes (/32, /128) so the stored form is always a
+// network, and host bits are cleared so "1.2.3.5/24" and "1.2.3.0/24" cannot
+// become two rows describing the same network.
+func NormalizeCIDR(raw string) (string, int, error) {
+	candidate := strings.TrimSpace(raw)
+	if candidate == "" {
+		return "", 0, ErrEmptyCIDR
+	}
+	candidate = strings.TrimPrefix(candidate, "[")
+	candidate = strings.TrimSuffix(candidate, "]")
+	if zone := strings.IndexByte(candidate, '%'); zone >= 0 {
+		candidate = candidate[:zone]
+	}
+
+	var network *net.IPNet
+	if strings.Contains(candidate, "/") {
+		_, parsed, err := net.ParseCIDR(candidate)
+		if err != nil || parsed == nil {
+			return "", 0, ErrInvalidCIDR
+		}
+		network = parsed
+	} else {
+		ip := net.ParseIP(candidate)
+		if ip == nil {
+			return "", 0, ErrInvalidCIDR
+		}
+		bits := 128
+		if v4 := ip.To4(); v4 != nil {
+			ip = v4
+			bits = 32
+		}
+		network = &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}
+	}
+
+	if network.IP.IsLoopback() {
+		return "", 0, ErrLoopbackCIDR
+	}
+	if network.IP.IsUnspecified() {
+		return "", 0, ErrUnspecifiedCIDR
+	}
+
+	ones, bits := network.Mask.Size()
+	if bits == 0 {
+		return "", 0, ErrInvalidCIDR
+	}
+	family := 6
+	minPrefix := MinPrefixLenV6
+	if bits == 32 {
+		family = 4
+		minPrefix = MinPrefixLenV4
+	}
+	if ones < minPrefix {
+		return "", 0, fmt.Errorf("ip access: prefix /%d is too broad, minimum is /%d for IPv%d", ones, minPrefix, family)
+	}
+	return network.String(), family, nil
+}
+
+// ParseIPForMatch parses a textual address into a form Matcher.Match accepts,
+// tolerating the "host:port" and bracketed shapes that appear in logs and stored
+// events. Returns nil when the input names no address.
+func ParseIPForMatch(raw string) net.IP {
+	normalized, ok := NormalizeObservedIP(raw)
+	if !ok {
+		return nil
+	}
+	return net.ParseIP(normalized)
+}
+
+// NormalizeObservedIP canonicalises an address seen on a request so it can be
+// offered as a pre-filled rule candidate. Unlike NormalizeCIDR it accepts
+// "host:port" forms, because that is what RemoteAddr carries.
+func NormalizeObservedIP(raw string) (string, bool) {
+	candidate := strings.TrimSpace(raw)
+	if candidate == "" {
+		return "", false
+	}
+	if host, _, err := net.SplitHostPort(candidate); err == nil {
+		candidate = host
+	}
+	candidate = strings.TrimPrefix(candidate, "[")
+	candidate = strings.TrimSuffix(candidate, "]")
+	if zone := strings.IndexByte(candidate, '%'); zone >= 0 {
+		candidate = candidate[:zone]
+	}
+	ip := net.ParseIP(strings.TrimSpace(candidate))
+	if ip == nil {
+		return "", false
+	}
+	return ip.String(), true
+}

--- a/internal/ipaccess/store.go
+++ b/internal/ipaccess/store.go
@@ -1,0 +1,403 @@
+package ipaccess
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrRuleNotFound is returned when an id does not resolve to a rule.
+var ErrRuleNotFound = errors.New("ip access: rule not found")
+
+// ErrDuplicateRule is returned when the same effect already covers this CIDR.
+var ErrDuplicateRule = errors.New("ip access: a rule with this effect and CIDR already exists")
+
+// Store persists allow/deny rules.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore wires a store to the runtime database. A nil db yields a store whose
+// methods are no-ops returning errors, which keeps callers free of nil checks in
+// deployments that run without Postgres.
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+// Available reports whether persistence is usable.
+func (s *Store) Available() bool { return s != nil && s.db != nil }
+
+const ruleColumns = `id,cidr,family,effect,source,reason,note,enabled,expires_at,created_by,created_at,updated_at,hit_count,last_hit_at`
+
+func scanRule(scanner interface{ Scan(...any) error }) (Rule, error) {
+	var (
+		rule      Rule
+		expires   sql.NullTime
+		createdBy sql.NullString
+		lastHit   sql.NullTime
+		effect    string
+		source    string
+	)
+	if err := scanner.Scan(&rule.ID, &rule.CIDR, &rule.Family, &effect, &source, &rule.Reason,
+		&rule.Note, &rule.Enabled, &expires, &createdBy, &rule.CreatedAt, &rule.UpdatedAt,
+		&rule.HitCount, &lastHit); err != nil {
+		return Rule{}, err
+	}
+	rule.Effect = Effect(effect)
+	rule.Source = Source(source)
+	if expires.Valid {
+		t := expires.Time
+		rule.ExpiresAt = &t
+	}
+	if lastHit.Valid {
+		t := lastHit.Time
+		rule.LastHitAt = &t
+	}
+	if createdBy.Valid {
+		rule.CreatedBy = createdBy.String
+	}
+	return rule, nil
+}
+
+// LoadActive returns every rule that could match right now.
+//
+// Expired rules are filtered in SQL as well as in the matcher: without the SQL
+// filter a long-abandoned deployment would rebuild a snapshot from thousands of
+// dead auto-ban rows on every refresh.
+func (s *Store) LoadActive(ctx context.Context, now time.Time) ([]Rule, error) {
+	if !s.Available() {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT `+ruleColumns+` FROM ip_access_rules
+		WHERE enabled = true AND (expires_at IS NULL OR expires_at > ?)`, now.UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var rules []Rule
+	for rows.Next() {
+		rule, scanErr := scanRule(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		rules = append(rules, rule)
+	}
+	return rules, rows.Err()
+}
+
+// ListFilter narrows a rule listing.
+type ListFilter struct {
+	Effect  string
+	Source  string
+	Enabled *bool
+	Search  string
+	Page    int
+	Size    int
+}
+
+const (
+	defaultListSize = 50
+	maxListSize     = 200
+)
+
+func (f ListFilter) normalized() ListFilter {
+	if f.Page < 1 {
+		f.Page = 1
+	}
+	if f.Size < 1 {
+		f.Size = defaultListSize
+	}
+	if f.Size > maxListSize {
+		f.Size = maxListSize
+	}
+	return f
+}
+
+// List returns a page of rules together with the total row count.
+func (s *Store) List(ctx context.Context, filter ListFilter) ([]Rule, int, error) {
+	if !s.Available() {
+		return nil, 0, nil
+	}
+	filter = filter.normalized()
+	where := make([]string, 0, 4)
+	args := make([]any, 0, 4)
+	if effect := strings.TrimSpace(filter.Effect); effect != "" {
+		where = append(where, "effect = ?")
+		args = append(args, effect)
+	}
+	if source := strings.TrimSpace(filter.Source); source != "" {
+		where = append(where, "source = ?")
+		args = append(args, source)
+	}
+	if filter.Enabled != nil {
+		where = append(where, "enabled = ?")
+		args = append(args, *filter.Enabled)
+	}
+	if search := strings.TrimSpace(filter.Search); search != "" {
+		where = append(where, "(cidr ILIKE ? OR note ILIKE ? OR reason ILIKE ?)")
+		pattern := "%" + search + "%"
+		args = append(args, pattern, pattern, pattern)
+	}
+	clause := ""
+	if len(where) > 0 {
+		clause = " WHERE " + strings.Join(where, " AND ")
+	}
+
+	var total int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM ip_access_rules`+clause, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	// Deny rules first, then newest: an operator opening this page is far more
+	// often chasing an active block than reviewing the allow list.
+	query := `SELECT ` + ruleColumns + ` FROM ip_access_rules` + clause +
+		` ORDER BY effect DESC, created_at DESC LIMIT ? OFFSET ?`
+	args = append(args, filter.Size, (filter.Page-1)*filter.Size)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = rows.Close() }()
+	rules := make([]Rule, 0, filter.Size)
+	for rows.Next() {
+		rule, scanErr := scanRule(rows)
+		if scanErr != nil {
+			return nil, 0, scanErr
+		}
+		rules = append(rules, rule)
+	}
+	return rules, total, rows.Err()
+}
+
+// Get resolves one rule by id.
+func (s *Store) Get(ctx context.Context, id string) (Rule, error) {
+	if !s.Available() {
+		return Rule{}, ErrRuleNotFound
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT `+ruleColumns+` FROM ip_access_rules WHERE id = ?`, id)
+	rule, err := scanRule(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Rule{}, ErrRuleNotFound
+	}
+	return rule, err
+}
+
+// CreateInput is an operator-supplied rule.
+type CreateInput struct {
+	CIDR      string
+	Effect    Effect
+	Source    Source
+	Reason    string
+	Note      string
+	ExpiresAt *time.Time
+	CreatedBy string
+}
+
+// Create stores a new rule, normalising the CIDR first so the uniqueness
+// constraint sees canonical values.
+func (s *Store) Create(ctx context.Context, in CreateInput) (Rule, error) {
+	if !s.Available() {
+		return Rule{}, errors.New("ip access: storage unavailable")
+	}
+	cidr, family, err := NormalizeCIDR(in.CIDR)
+	if err != nil {
+		return Rule{}, err
+	}
+	if in.Effect != EffectAllow && in.Effect != EffectDeny {
+		return Rule{}, ErrInvalidEffect
+	}
+	source := in.Source
+	if source != SourceAuto {
+		source = SourceManual
+	}
+	var createdBy any
+	if strings.TrimSpace(in.CreatedBy) != "" {
+		createdBy = in.CreatedBy
+	}
+	var expires any
+	if in.ExpiresAt != nil {
+		expires = in.ExpiresAt.UTC()
+	}
+	id := uuid.NewString()
+	_, err = s.db.ExecContext(ctx, `INSERT INTO ip_access_rules
+		(id,cidr,family,effect,source,reason,note,enabled,expires_at,created_by)
+		VALUES (?,?,?,?,?,?,?,true,?,?)`,
+		id, cidr, family, string(in.Effect), string(source), in.Reason, in.Note, expires, createdBy)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return Rule{}, ErrDuplicateRule
+		}
+		return Rule{}, err
+	}
+	return s.Get(ctx, id)
+}
+
+// UpdateInput carries the mutable fields. Nil means "leave unchanged", so a
+// partial update from the panel cannot blank out fields it never rendered.
+type UpdateInput struct {
+	Enabled      *bool
+	Note         *string
+	ExpiresAt    **time.Time
+	ClearExpires bool
+}
+
+// Update mutates an existing rule.
+func (s *Store) Update(ctx context.Context, id string, in UpdateInput) (Rule, error) {
+	if !s.Available() {
+		return Rule{}, ErrRuleNotFound
+	}
+	sets := make([]string, 0, 4)
+	args := make([]any, 0, 4)
+	if in.Enabled != nil {
+		sets = append(sets, "enabled = ?")
+		args = append(args, *in.Enabled)
+	}
+	if in.Note != nil {
+		sets = append(sets, "note = ?")
+		args = append(args, *in.Note)
+	}
+	if in.ClearExpires {
+		sets = append(sets, "expires_at = NULL")
+	} else if in.ExpiresAt != nil && *in.ExpiresAt != nil {
+		sets = append(sets, "expires_at = ?")
+		args = append(args, (*in.ExpiresAt).UTC())
+	}
+	if len(sets) == 0 {
+		return s.Get(ctx, id)
+	}
+	sets = append(sets, "updated_at = now()")
+	args = append(args, id)
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE ip_access_rules SET `+strings.Join(sets, ", ")+` WHERE id = ?`, args...)
+	if err != nil {
+		return Rule{}, err
+	}
+	if affected, affErr := result.RowsAffected(); affErr == nil && affected == 0 {
+		return Rule{}, ErrRuleNotFound
+	}
+	return s.Get(ctx, id)
+}
+
+// Delete removes a rule.
+func (s *Store) Delete(ctx context.Context, id string) error {
+	if !s.Available() {
+		return ErrRuleNotFound
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM ip_access_rules WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	if affected, affErr := result.RowsAffected(); affErr == nil && affected == 0 {
+		return ErrRuleNotFound
+	}
+	return nil
+}
+
+// UpsertAutoBan records an automatic ban.
+//
+// An existing manual rule for the same CIDR is left untouched: an operator's
+// decision outranks the engine's, in both directions. An existing automatic ban
+// has its expiry extended rather than duplicated, which is also what makes the
+// escalation ladder observable — repeat_count grows on the same row.
+func (s *Store) UpsertAutoBan(ctx context.Context, cidr, reason string, expiresAt time.Time) (Rule, bool, error) {
+	if !s.Available() {
+		return Rule{}, false, errors.New("ip access: storage unavailable")
+	}
+	normalized, family, err := NormalizeCIDR(cidr)
+	if err != nil {
+		return Rule{}, false, err
+	}
+	existing, err := s.findByEffectCIDR(ctx, EffectDeny, normalized)
+	if err != nil && !errors.Is(err, ErrRuleNotFound) {
+		return Rule{}, false, err
+	}
+	if err == nil {
+		if existing.Source == SourceManual {
+			return existing, false, nil
+		}
+		if _, updateErr := s.db.ExecContext(ctx,
+			`UPDATE ip_access_rules SET expires_at = ?, enabled = true, reason = ?, updated_at = now() WHERE id = ?`,
+			expiresAt.UTC(), reason, existing.ID); updateErr != nil {
+			return Rule{}, false, updateErr
+		}
+		refreshed, getErr := s.Get(ctx, existing.ID)
+		return refreshed, true, getErr
+	}
+
+	id := uuid.NewString()
+	if _, err = s.db.ExecContext(ctx, `INSERT INTO ip_access_rules
+		(id,cidr,family,effect,source,reason,note,enabled,expires_at)
+		VALUES (?,?,?,'deny','auto',?,'',true,?)`,
+		id, normalized, family, reason, expiresAt.UTC()); err != nil {
+		if isUniqueViolation(err) {
+			// Another slot won the race; its row is equally valid.
+			rule, getErr := s.findByEffectCIDR(ctx, EffectDeny, normalized)
+			return rule, false, getErr
+		}
+		return Rule{}, false, err
+	}
+	rule, err := s.Get(ctx, id)
+	return rule, true, err
+}
+
+func (s *Store) findByEffectCIDR(ctx context.Context, effect Effect, cidr string) (Rule, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+ruleColumns+` FROM ip_access_rules WHERE effect = ? AND cidr = ?`, string(effect), cidr)
+	rule, err := scanRule(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Rule{}, ErrRuleNotFound
+	}
+	return rule, err
+}
+
+// RecordHits folds buffered match counts back into the rules.
+//
+// Counts are batched by the caller instead of incremented per request: a deny
+// rule exists precisely because something is hammering the server, so a write
+// per match would turn a block into a database load generator.
+func (s *Store) RecordHits(ctx context.Context, hits map[string]int64, at time.Time) error {
+	if !s.Available() || len(hits) == 0 {
+		return nil
+	}
+	for id, count := range hits {
+		if count <= 0 {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE ip_access_rules SET hit_count = hit_count + ?, last_hit_at = ? WHERE id = ?`,
+			count, at.UTC(), id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PurgeExpiredAuto deletes automatic rules that lapsed before cutoff. Manual
+// rules are never swept, expired or not: an operator may keep a lapsed entry as
+// a record of what was banned and why.
+func (s *Store) PurgeExpiredAuto(ctx context.Context, cutoff time.Time) (int64, error) {
+	if !s.Available() {
+		return 0, nil
+	}
+	result, err := s.db.ExecContext(ctx,
+		`DELETE FROM ip_access_rules WHERE source = 'auto' AND expires_at IS NOT NULL AND expires_at < ?`,
+		cutoff.UTC())
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// isUniqueViolation recognises the duplicate-key error without importing a
+// driver-specific package: the compat layer may surface either the pq or pgx
+// error type, and both spell the SQLSTATE into the message.
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "23505") ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "unique constraint")
+}

--- a/internal/ipaccess/trust.go
+++ b/internal/ipaccess/trust.go
@@ -1,0 +1,80 @@
+package ipaccess
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+)
+
+// ClientAddress is everything the admission and throttle layers need to know
+// about where a request came from.
+type ClientAddress struct {
+	// IP is the address the framework resolved, honouring trusted-proxies.
+	IP net.IP
+	// Raw is the textual form, kept for display and for the rare case where the
+	// address could not be parsed at all.
+	Raw string
+	// Trusted reports whether IP actually identifies the client. It is false
+	// when the request was relayed but no trusted proxy was configured, in which
+	// case IP is the proxy's address and stands for every client behind it.
+	Trusted bool
+	// RelayHeader names the forwarding header that was present, for diagnostics.
+	RelayHeader string
+}
+
+// ProxyTrustConfigured reports whether the operator declared any trusted proxy,
+// which is what decides whether forwarding headers may be believed.
+func ProxyTrustConfigured(trustedProxies []string) bool {
+	for _, proxy := range trustedProxies {
+		if strings.TrimSpace(proxy) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// Loopback reports whether the peer is the local host. Loopback keeps an
+// unconditional operator channel: a misconfigured allow list must never be able
+// to lock the machine's own administrator out of the process it is running.
+func (a ClientAddress) Loopback() bool {
+	return a.IP != nil && a.IP.IsLoopback()
+}
+
+// Resolve derives the client address from a request.
+//
+// resolvedIP is what the web framework reports after applying trusted-proxies
+// (gin's ClientIP), and proxyTrustConfigured is whether the operator declared
+// any trusted proxy at all.
+//
+// The forwarding headers are deliberately never read as the address itself:
+// they are attacker-controlled, so trusting them would let anyone both evade a
+// ban and forge membership of the allow list.
+func Resolve(req *http.Request, resolvedIP string, proxyTrustConfigured bool) ClientAddress {
+	addr := ClientAddress{Trusted: true}
+	if req != nil {
+		addr.RelayHeader = util.RelayIndicationHeader(req)
+	}
+
+	candidate := strings.TrimSpace(resolvedIP)
+	if candidate == "" && req != nil {
+		candidate = util.RemoteAddrIP(req.RemoteAddr)
+	}
+	addr.Raw = candidate
+
+	if normalized, ok := NormalizeObservedIP(candidate); ok {
+		addr.IP = net.ParseIP(normalized)
+		addr.Raw = normalized
+	}
+	if addr.IP == nil {
+		// An address that cannot be parsed identifies nobody, so no admission
+		// decision made from it can be correct.
+		addr.Trusted = false
+		return addr
+	}
+	if addr.RelayHeader != "" && !proxyTrustConfigured {
+		addr.Trusted = false
+	}
+	return addr
+}

--- a/internal/logging/global_logger.go
+++ b/internal/logging/global_logger.go
@@ -30,7 +30,15 @@ var (
 type LogFormatter struct{}
 
 // logFieldOrder defines the display order for common log fields.
-var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error_class", "profile_id", "profile_version", "resolution_source", "channel_type", "channel_id", "action", "latency_ms", "cache_hit", "category", "score", "error"}
+//
+// This is an allowlist: a field absent from it is silently dropped. That bit us
+// in production — the auth-throttle warnings carried scope/key/counts and none
+// of it was ever printed, so "credential failure armed a block" appeared with no
+// indication of which address or account triggered it, which is the only part an
+// operator needs. Any new structured field must be registered here to be visible.
+var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error_class", "profile_id", "profile_version", "resolution_source", "channel_type", "channel_id", "action", "latency_ms", "cache_hit", "category", "score", "error",
+	// auth-throttle / ip-access diagnostics
+	"scope", "key", "shared", "short_count", "long_count", "limit", "long_limit", "outcome", "block_for", "generation", "path", "method", "ua", "relay_header"}
 
 // Format renders a single log entry with custom formatting.
 func (m *LogFormatter) Format(entry *log.Entry) ([]byte, error) {

--- a/internal/storage/postgres/ip_access_migrations.go
+++ b/internal/storage/postgres/ip_access_migrations.go
@@ -1,0 +1,88 @@
+package postgres
+
+// laterRuntimeMigrations carries migrations added after migrations.go reached
+// its size ceiling. RuntimeMigrations appends this list, so new schema changes
+// land here instead of growing a file that the structure gate only lets shrink.
+// Order still matters: entries run after every migration in the main list.
+func laterRuntimeMigrations() []Migration {
+	return []Migration{
+		// Operator-managed IP allow/deny list, authentication attempt log, and
+		// source address on audit rows.
+		{Version: "202608100001_ip_access_control", SQL: ipAccessControlSQL},
+	}
+}
+
+// ipAccessControlSQL adds the operator-managed IP allow/deny list, the
+// authentication attempt log that makes an attack source identifiable, and the
+// source address on audit rows.
+//
+// Attempts live in their own table rather than in audit_logs because they are
+// high-volume, low-value-per-row telemetry with a short retention: mixing them
+// into audit_logs would bury the deliberate, compliance-relevant records under
+// failed-login noise, and audit_logs' actor_kind/result CHECK constraints have
+// no vocabulary for "an anonymous source failed a guess".
+const ipAccessControlSQL = `
+-- 1) allow / deny rules -----------------------------------------------------
+-- allow and deny share one table because every lookup consults both and must
+-- resolve their precedence in one place; splitting them only creates two
+-- queries and a window where the two halves disagree.
+CREATE TABLE IF NOT EXISTS ip_access_rules (
+  id           UUID PRIMARY KEY,
+  cidr         TEXT NOT NULL,
+  family       SMALLINT NOT NULL,
+  effect       TEXT NOT NULL CHECK (effect IN ('allow', 'deny')),
+  source       TEXT NOT NULL CHECK (source IN ('manual', 'auto')),
+  reason       TEXT NOT NULL DEFAULT '',
+  note         TEXT NOT NULL DEFAULT '',
+  enabled      BOOLEAN NOT NULL DEFAULT true,
+  expires_at   TIMESTAMPTZ,
+  created_by   UUID REFERENCES users(id),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  hit_count    BIGINT NOT NULL DEFAULT 0,
+  last_hit_at  TIMESTAMPTZ
+);
+
+-- CIDRs are normalised (host bits cleared) before insert, so this constraint
+-- makes "1.2.3.0/24" and "1.2.3.5/24" collide as the one network they describe.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ip_access_rules_effect_cidr
+  ON ip_access_rules(effect, cidr);
+CREATE INDEX IF NOT EXISTS idx_ip_access_rules_active
+  ON ip_access_rules(enabled, expires_at);
+
+-- 2) authentication attempts ------------------------------------------------
+CREATE TABLE IF NOT EXISTS auth_attempt_events (
+  id           BIGSERIAL PRIMARY KEY,
+  occurred_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ip           TEXT NOT NULL DEFAULT '',
+  -- ip_prefix is the throttle bucket key (/32 or /64) so aggregation here lines
+  -- up with what the rate limiter actually counted.
+  ip_prefix    TEXT NOT NULL DEFAULT '',
+  -- trusted records whether the address identified a client at all; without it
+  -- a report built from proxy addresses would read as a single mega-attacker.
+  trusted      BOOLEAN NOT NULL DEFAULT false,
+  scope        TEXT NOT NULL DEFAULT '',
+  surface      TEXT NOT NULL DEFAULT '',
+  username     TEXT NOT NULL DEFAULT '',
+  outcome      TEXT NOT NULL,
+  reason       TEXT NOT NULL DEFAULT '',
+  user_agent   TEXT NOT NULL DEFAULT '',
+  request_path TEXT NOT NULL DEFAULT '',
+  request_id   TEXT NOT NULL DEFAULT '',
+  tenant_id    UUID
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_attempts_time
+  ON auth_attempt_events(occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_auth_attempts_prefix_time
+  ON auth_attempt_events(ip_prefix, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_auth_attempts_username_time
+  ON auth_attempt_events(username, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_auth_attempts_outcome_time
+  ON auth_attempt_events(outcome, occurred_at DESC);
+
+-- 3) audit rows carry their source address ----------------------------------
+-- Every audit event gains provenance, not just logins: "who changed this" is
+-- only half an answer without "from where".
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS ip_address TEXT NOT NULL DEFAULT '';
+`

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -1,7 +1,7 @@
 package postgres
 
 func RuntimeMigrations() []Migration {
-	return []Migration{
+	return append([]Migration{
 		{Version: "202607050001_runtime_schema", SQL: runtimeSchemaSQL},
 		{Version: "202607100001_identity_fingerprint_profiles", SQL: identityFingerprintProfilesSQL},
 		{Version: "202607110001_multi_tenant_identity", SQL: multiTenantIdentitySQL},
@@ -46,7 +46,7 @@ func RuntimeMigrations() []Migration {
 		// Retire audit rows written by the pre-fix policy that logged read traffic,
 		// and index created_at for the new retention pass.
 		{Version: "202608080001_audit_log_read_noise_cleanup", SQL: auditLogReadNoiseCleanupSQL},
-	}
+	}, laterRuntimeMigrations()...)
 }
 
 const aiAccountSubjectUsageTokensSQL = `

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,12 +11,26 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 27 {
-		t.Fatalf("RuntimeMigrations len = %d, want 27", len(migrations))
+	if len(migrations) != 28 {
+		t.Fatalf("RuntimeMigrations len = %d, want 28", len(migrations))
 	}
-	// Latest: retire the audit rows the pre-fix policy wrote for read traffic.
+	// Latest: the IP allow/deny list, authentication attempt log, and source
+	// address on audit rows. Appended from laterRuntimeMigrations() because
+	// migrations.go sits at its structure-gate size ceiling.
+	if migrations[27].Version != "202608100001_ip_access_control" {
+		t.Fatalf("latest migration version = %q", migrations[27].Version)
+	}
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS ip_access_rules",
+		"CREATE TABLE IF NOT EXISTS auth_attempt_events",
+		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS ip_address",
+	} {
+		if !strings.Contains(migrations[27].SQL, fragment) {
+			t.Fatalf("ip access migration missing %q", fragment)
+		}
+	}
 	if migrations[26].Version != "202608080001_audit_log_read_noise_cleanup" {
-		t.Fatalf("latest migration version = %q", migrations[26].Version)
+		t.Fatalf("audit cleanup migration version = %q", migrations[26].Version)
 	}
 	for _, fragment := range []string{
 		"DELETE FROM audit_logs",


### PR DESCRIPTION
## 背景

线上取证（`relay.07230805.xyz`，slot 8318）暴露了三个串联问题：

| 证据 | 结论 |
|---|---|
| `config.yaml` 无 `trusted-proxies`，nginx 却设置了 `X-Forwarded-For` | `ClientIP()` 回落 RemoteAddr，**所有客户端共用一个 per-IP 限流桶** |
| journal 反复出现 `every client behind 104.194.69.137 shares one throttle bucket` | 代码自己在报警，一直没人看见 |
| 2026-08-10 20:33–20:44 每分钟一条 `credential failure armed a block` | 持续的认证失败流量 |
| 该 Warn 由 `log.WithFields` 产出，输出行却只有 message | **结构化字段被日志格式吞掉**，无法判断是哪个 IP / 账号 / scope |
| `audit_logs` 无 IP 列 | 登录失败虽写审计，事后仍无法归因 |

结果就是：用户被「登录尝试过于频繁」拦住，而运维查不出是谁在打。

## 改动

**IP 允许/拒绝名单**（`internal/ipaccess`）
- CIDR 匹配器，按前缀长度分组，查找成本与规则条数无关
- **allow 优先 deny、最长前缀命中**：封了 `/16` 还能放行其中一台办公机
- DB 为真源 + 15s 内存快照：线上是蓝绿双 slot，内存不共享，只能靠轮询收敛
- 全局准入中间件，命中即 403，覆盖 `/v1` 在内的所有路径

**可信度前提（本 PR 的地基）**
- 反代未配 `trusted-proxies` 时拿到的是 nginx 地址：封它=封所有人，放它=放所有人
- 因此 **IP 不可信时整个功能降级为 no-op**，并通过 `/ip-access/status` 暴露该状态给面板显式告警
- 绝不回退去读转发头——那等于把准入决策交给攻击者

**认证尝试日志**（`internal/authevents`）
- 独立表而非塞进 `audit_logs`：高频、短保留，且 `audit_logs` 的 CHECK 约束没有「匿名来源猜错密码」这种词汇
- 异步 + 有界队列，满则丢弃并计数：安全遥测绝不能拖慢登录
- 记录成功登录 —— 「某 IP 失败 90 次后成功」是最重要的那一行

**自动封禁**
- 默认 **observe 模式**：未经真实流量验证的阈值直接封禁 = 自己制造故障
- 永不作用于 allow 名单与回环；IP 不可信时不评估

**防自锁**
- 回环永远放行
- 操作者不在白名单内时拒绝开启锁定模式，并回传该加哪条规则
- 拒绝创建覆盖操作者自身地址的 deny 规则

**顺带修复**
- `logFieldOrder` 是 allowlist，auth-throttle 告警的 scope/key/counts 全被丢弃 —— 这就是线上那条告警看不出来源的原因

**结构债**
- 迁移经 `laterRuntimeMigrations()` 追加，因为 `migrations.go` 已在结构门禁上限、只允许变小

## 验证

本地完整 `./scripts/ci-pr.sh`，**退出码 0，零 FAIL**（secret scan、结构检查、gofmt、go vet、`go test ./...`、golangci-lint、go build）。

新增 20 个单测覆盖：allow 优先级、最长前缀、IPv6 /64、过期与禁用、锁定模式、不可信不执行、回环永远放行、observe 不写规则、allow 豁免自动封禁、阈值与退避阶梯。

路由表断言 309 → 318，迁移数断言 27 → 28。

## 上线后必须做

在 `/opt/clirelay2/config.yaml` 配置：

```yaml
trusted-proxies: ["104.194.69.137/32"]
```

**不配的话名单一条都不生效**，面板会一直挂红色横幅提示这一点。这也是当前所有人共用一个限流桶的根因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)