### PR TITLE
feat(ip-access): make the host and its proxies structurally un-bannable

### DIFF
--- a/internal/api/handlers/management/ip_access.go
+++ b/internal/api/handlers/management/ip_access.go
@@ -2,6 +2,8 @@ package management
 
 import (
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -97,10 +99,14 @@ func (h *Handler) PostIPAccessRule(c *gin.Context) {
 		input.CreatedBy = principal.User.ID
 	}
 
-	// Refuse to deny the address making the request. The operator would lose the
-	// panel on the very next call, and recovering means editing the database by
-	// hand — a mistake the API can simply decline to make.
+	// Refuse to deny an address the deployment depends on. These are exactly the
+	// rules an operator writes by accident while under attack, and each of them
+	// takes the service down rather than stopping anyone.
 	if effect == ipaccess.EffectDeny {
+		if entry, covered := coversProtectedAddress(input.CIDR); covered {
+			ipAccessBadRequest(c, fmt.Errorf("this rule would cover %s, which is protected (%s) and cannot be denied", entry.CIDR, entry.Reason))
+			return
+		}
 		if blocked, checkErr := selfDenyCheck(c, input.CIDR); checkErr != nil {
 			ipAccessBadRequest(c, checkErr)
 			return
@@ -125,6 +131,27 @@ func (h *Handler) PostIPAccessRule(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"rule": rule})
+}
+
+// coversProtectedAddress reports whether a proposed CIDR would swallow any
+// address the process must never reject.
+func coversProtectedAddress(cidr string) (ipaccess.ProtectedEntry, bool) {
+	normalized, _, err := ipaccess.NormalizeCIDR(cidr)
+	if err != nil {
+		return ipaccess.ProtectedEntry{}, false
+	}
+	_, network, parseErr := net.ParseCIDR(normalized)
+	if parseErr != nil || network == nil {
+		return ipaccess.ProtectedEntry{}, false
+	}
+	registry := ipaccess.Default()
+	for _, entry := range registry.ProtectedEntries() {
+		probe := ipaccess.ParseIPForMatch(entry.CIDR[:strings.Index(entry.CIDR, "/")])
+		if probe != nil && network.Contains(probe) {
+			return entry, true
+		}
+	}
+	return ipaccess.ProtectedEntry{}, false
 }
 
 // selfDenyCheck reports whether a proposed deny rule would cover the requester.
@@ -244,6 +271,7 @@ func (h *Handler) GetIPAccessStatus(c *gin.Context) {
 	if recorder := authevents.Default(); recorder != nil {
 		response["dropped_events"] = recorder.Dropped()
 	}
+	response["protected"] = registry.ProtectedEntries()
 	if address.IP != nil {
 		response["self_allowed"] = matcher.AllowsAddress(address.IP)
 		response["suggested_self_rule"] = ipaccess.BanCIDR(address.IP)

--- a/internal/api/handlers/management/ip_access_bootstrap.go
+++ b/internal/api/handlers/management/ip_access_bootstrap.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -33,5 +34,27 @@ func ensureIPAccessRuntime(cfg *config.Config) {
 	if cfg != nil {
 		trustedProxies = cfg.TrustedProxies
 	}
-	ipaccess.EnsureDefault(ctx, db, ipaccess.ProxyTrustConfigured(trustedProxies))
+	registry := ipaccess.EnsureDefault(ctx, db, ipaccess.ProxyTrustConfigured(trustedProxies))
+	registry.SetProtectedAddresses(
+		ipaccess.LocalInterfaceAddresses(),
+		trustedProxies,
+		ipaccess.ProxyHostAddresses(outboundProxyURLs(cfg)),
+	)
+}
+
+// outboundProxyURLs collects the egress proxy pool so those hosts are protected
+// too. Operators reasonably read "our proxies" as something that must never be
+// blocked; an egress proxy never arrives as an inbound client, so protecting it
+// costs nothing and stops a confusing manual rule from being written instead.
+func outboundProxyURLs(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	urls := make([]string, 0, len(cfg.ProxyPool))
+	for _, entry := range cfg.ProxyPool {
+		if strings.TrimSpace(entry.URL) != "" {
+			urls = append(urls, entry.URL)
+		}
+	}
+	return urls
 }

--- a/internal/ipaccess/autoban.go
+++ b/internal/ipaccess/autoban.go
@@ -99,6 +99,10 @@ func (e *autoBanEngine) RecordFailure(ctx context.Context, addr ClientAddress, r
 	if e.registry.Matcher().AllowsAddress(addr.IP) {
 		return AutoBanOutcome{}
 	}
+	// Nor may it ban the host itself, its reverse proxy, or an egress proxy.
+	if _, ok := e.registry.Protected(addr.IP); ok {
+		return AutoBanOutcome{}
+	}
 
 	cidr := BanCIDR(addr.IP)
 	now := time.Now()

--- a/internal/ipaccess/matcher_test.go
+++ b/internal/ipaccess/matcher_test.go
@@ -1,6 +1,7 @@
 package ipaccess
 
 import (
+	"context"
 	"net"
 	"net/http/httptest"
 	"testing"
@@ -179,5 +180,57 @@ func TestBanCIDRCollapsesIPv6ToSixtyFour(t *testing.T) {
 	}
 	if got := BanCIDR(net.ParseIP("192.0.2.5")); got != "192.0.2.5/32" {
 		t.Errorf("got %q, want a host route for IPv4", got)
+	}
+}
+
+func TestProtectedAddressesSurviveEveryRule(t *testing.T) {
+	// The interesting failure here is self-inflicted: a rule covering the host's
+	// own address or its reverse proxy takes the deployment offline instead of
+	// blocking an attacker, so the list must not be able to express it.
+	registry := NewRegistry(NewStore(nil))
+	registry.SetProtectedAddresses([]string{"10.0.0.5"}, []string{"104.194.69.137"}, nil)
+	registry.matcher.Store(NewMatcher([]Rule{
+		mustRule(t, "10.0.0.0/8", EffectDeny),
+		mustRule(t, "104.194.69.137/32", EffectDeny),
+	}, true, time.Now()))
+
+	for _, ip := range []string{"10.0.0.5", "104.194.69.137"} {
+		verdict := registry.Evaluate(ClientAddress{IP: net.ParseIP(ip), Raw: ip, Trusted: true})
+		if !verdict.Allowed() || !verdict.Enforced || verdict.Decision != DecisionAllow {
+			t.Errorf("%s: got %v (enforced=%t), want an enforced allow despite the deny rules", ip, verdict.Decision, verdict.Enforced)
+		}
+	}
+	// Protection is per-address, not per-range: a neighbour inside the same denied
+	// /8 must not inherit it.
+	if _, ok := registry.Protected(net.ParseIP("10.0.0.6")); ok {
+		t.Error("protection leaked to an unprotected address in the same range")
+	}
+}
+
+func TestProtectedAddressesAreNotAutoBanned(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.AutoBan.FailureThreshold = 2
+	registry := testRegistry(t, policy)
+	registry.SetProtectedAddresses(nil, []string{"104.194.69.137"}, nil)
+
+	for i := 0; i < 5; i++ {
+		outcome := registry.AutoBan().RecordFailure(context.Background(), trustedAddress("104.194.69.137"), "test")
+		if outcome.Triggered {
+			t.Fatal("the reverse proxy was proposed for an automatic ban")
+		}
+	}
+}
+
+func TestProxyHostAddressesKeepsOnlyLiterals(t *testing.T) {
+	// A hostname is skipped rather than resolved: resolving at startup bakes in
+	// one answer and silently protects the wrong address after a DNS change.
+	got := ProxyHostAddresses([]string{
+		"http://203.0.113.9:8080",
+		"socks5://proxy.internal:1080",
+		"not a url",
+		"",
+	})
+	if len(got) != 1 || got[0] != "203.0.113.9" {
+		t.Errorf("got %v, want [203.0.113.9]", got)
 	}
 }

--- a/internal/ipaccess/protected.go
+++ b/internal/ipaccess/protected.go
@@ -1,0 +1,138 @@
+package ipaccess
+
+import (
+	"net"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// ProtectedReason explains why an address can never be denied.
+type ProtectedReason string
+
+const (
+	ProtectedLoopback     ProtectedReason = "loopback"
+	ProtectedLocalAddress ProtectedReason = "local_address"
+	ProtectedTrustedProxy ProtectedReason = "trusted_proxy"
+	ProtectedOutboundPeer ProtectedReason = "outbound_proxy"
+)
+
+// ProtectedEntry is one un-bannable address or range.
+type ProtectedEntry struct {
+	CIDR   string          `json:"cidr"`
+	Reason ProtectedReason `json:"reason"`
+	net    *net.IPNet
+}
+
+// protectedSet is the set of addresses that must survive any rule, automatic or
+// manual.
+//
+// It exists because the interesting failure here is self-inflicted: the machine's
+// own address is what a reverse proxy, a health probe and any loopback tooling
+// present themselves as, so a rule covering it takes the deployment offline
+// rather than blocking an attacker. Making these structurally un-bannable is
+// strictly better than documenting "please don't ban these" — an operator acting
+// under pressure during an attack is exactly who would ban them by accident.
+type protectedSet struct {
+	entries []ProtectedEntry
+}
+
+func (p *protectedSet) match(ip net.IP) (ProtectedEntry, bool) {
+	if p == nil || ip == nil {
+		return ProtectedEntry{}, false
+	}
+	for i := range p.entries {
+		if p.entries[i].net != nil && p.entries[i].net.Contains(ip) {
+			return p.entries[i], true
+		}
+	}
+	return ProtectedEntry{}, false
+}
+
+// buildProtectedSet collects every address the process must never reject.
+//
+// localAddresses are the host's own interface addresses, trustedProxies the
+// declared reverse proxies, and outboundProxies the egress proxy pool. The proxy
+// pool is included because operators reasonably expect "our proxies" to be
+// exempt; in practice an egress proxy never appears as an inbound client, so the
+// entry is harmless and prevents a confusing manual rule from being written
+// instead.
+func buildProtectedSet(localAddresses, trustedProxies, outboundProxies []string) *protectedSet {
+	set := &protectedSet{}
+	seen := make(map[string]struct{})
+
+	add := func(raw string, reason ProtectedReason) {
+		normalized, _, err := NormalizeCIDR(raw)
+		if err != nil {
+			// Loopback is rejected by NormalizeCIDR (it is already unconditionally
+			// admitted), and unparseable input is simply not a protectable address.
+			return
+		}
+		if _, exists := seen[normalized]; exists {
+			return
+		}
+		_, network, parseErr := net.ParseCIDR(normalized)
+		if parseErr != nil || network == nil {
+			return
+		}
+		seen[normalized] = struct{}{}
+		set.entries = append(set.entries, ProtectedEntry{CIDR: normalized, Reason: reason, net: network})
+	}
+
+	for _, address := range localAddresses {
+		add(address, ProtectedLocalAddress)
+	}
+	for _, address := range trustedProxies {
+		add(address, ProtectedTrustedProxy)
+	}
+	for _, address := range outboundProxies {
+		add(address, ProtectedOutboundPeer)
+	}
+
+	sort.Slice(set.entries, func(i, j int) bool { return set.entries[i].CIDR < set.entries[j].CIDR })
+	return set
+}
+
+// LocalInterfaceAddresses returns the host's own non-loopback addresses.
+//
+// Failures are swallowed: an enumeration error must not stop the process from
+// starting, and the loopback guard still covers the most important case.
+func LocalInterfaceAddresses() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || ipNet.IP == nil || ipNet.IP.IsLoopback() {
+			continue
+		}
+		out = append(out, ipNet.IP.String())
+	}
+	return out
+}
+
+// ProxyHostAddresses extracts the host portion of outbound proxy URLs, keeping
+// only entries that are already literal addresses. A hostname is skipped rather
+// than resolved: resolution at startup would bake in one answer and silently
+// protect the wrong address after a DNS change.
+func ProxyHostAddresses(proxyURLs []string) []string {
+	out := make([]string, 0, len(proxyURLs))
+	for _, raw := range proxyURLs {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		parsed, err := url.Parse(trimmed)
+		if err != nil || parsed.Host == "" {
+			continue
+		}
+		host := parsed.Hostname()
+		if net.ParseIP(host) == nil {
+			continue
+		}
+		out = append(out, host)
+	}
+	return out
+}

--- a/internal/ipaccess/registry.go
+++ b/internal/ipaccess/registry.go
@@ -2,6 +2,7 @@ package ipaccess
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -56,6 +57,9 @@ type Registry struct {
 	matcher   atomic.Pointer[Matcher]
 	policy    atomic.Pointer[ProtectionPolicy]
 	persister PolicyPersister
+
+	// protected is the set of addresses no rule may reject.
+	protected atomic.Pointer[protectedSet]
 
 	// proxyTrusted mirrors "trusted-proxies is non-empty". It lives here rather
 	// than being read from config at match time because a hot reload swaps the
@@ -158,6 +162,36 @@ func (r *Registry) ReloadPolicy(ctx context.Context) {
 	}
 }
 
+// SetProtectedAddresses rebuilds the un-bannable set.
+func (r *Registry) SetProtectedAddresses(localAddresses, trustedProxies, outboundProxies []string) {
+	if r == nil {
+		return
+	}
+	r.protected.Store(buildProtectedSet(localAddresses, trustedProxies, outboundProxies))
+}
+
+// ProtectedEntries lists the un-bannable addresses for display.
+func (r *Registry) ProtectedEntries() []ProtectedEntry {
+	if r == nil {
+		return nil
+	}
+	set := r.protected.Load()
+	if set == nil {
+		return nil
+	}
+	out := make([]ProtectedEntry, len(set.entries))
+	copy(out, set.entries)
+	return out
+}
+
+// Protected reports whether an address is structurally un-bannable.
+func (r *Registry) Protected(ip net.IP) (ProtectedEntry, bool) {
+	if r == nil {
+		return ProtectedEntry{}, false
+	}
+	return r.protected.Load().match(ip)
+}
+
 // SetProxyTrusted records whether the operator declared any trusted proxy.
 func (r *Registry) SetProxyTrusted(configured bool) {
 	if r == nil {
@@ -225,6 +259,12 @@ func (r *Registry) Evaluate(addr ClientAddress) Verdict {
 	}
 	if !addr.Trusted {
 		return Verdict{Decision: DecisionNeutral, Enforced: false, Reason: reasonUntrustedClientIP}
+	}
+	// Protected addresses win over every rule, including lockdown, and are checked
+	// before storage availability because the guarantee is absolute: the host's own
+	// address and its reverse proxy stay reachable whatever the rule store is doing.
+	if entry, ok := r.protected.Load().match(addr.IP); ok {
+		return Verdict{Decision: DecisionAllow, Enforced: true, Reason: string(entry.Reason)}
 	}
 	if !r.store.Available() {
 		return Verdict{Decision: DecisionNeutral, Enforced: false, Reason: reasonNoStorage}


### PR DESCRIPTION
## 起因

「我们的服务器 IP 和代理池 IP 一定要进白名单。」

这个诉求是对的，但用白名单表达是错的，而且在当前部署下是有害的：`104.194.69.137` 是 nginx 自己的地址，在 `trusted-proxies` 未配置时**所有客户端**在后端看来都是它。把它加进 allow 名单，等于豁免全世界，整个名单立刻失去意义。

所以这个保证从规则表挪进了进程本身。

## 改动

- 主机自身网卡地址、声明的 `trusted-proxies`、出站代理池，统一收进一个**保护集合**，优先级高于所有规则（含锁定模式），并且在存储可用性判断**之前**检查——这个保证是绝对的，不该取决于规则库当时能不能读。
- 自动封禁引擎跳过它们，避免一波失败把部署自己打下线。
- 创建会覆盖它们的 deny 规则时直接拒绝并说明原因。这正是运维在被攻击时手忙脚乱写出来的那条规则。
- `/ip-access/status` 返回该集合，面板据此展示「哪些地址受保护、为什么」，而不是让人对着一个被拒绝的封禁操作发懵。

出站代理也纳入保护：它作为入站客户端永远不会出现，所以这条记录没有任何成本，但能挡住一条本来会被写出来的、令人困惑的手工规则。代理主机名不做解析而是跳过——启动时解析会把一个瞬时答案固化下来，DNS 一变就在保护错误的地址。

## 验证

完整 `./scripts/ci-pr.sh` 退出码 0，零失败。新增 3 个单测覆盖：保护地址在 deny + lockdown 下仍放行、保护不泄漏到同网段邻居、反向代理不会被自动封禁、代理主机名不被误纳入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)