### PR TITLE
feat(ip-access): manage trusted proxies from the database, not config.yaml

### DIFF
--- a/internal/api/handlers/management/ip_access.go
+++ b/internal/api/handlers/management/ip_access.go
@@ -250,22 +250,28 @@ func (h *Handler) GetIPAccessStatus(c *gin.Context) {
 	address := ipaccess.AddressFor(c)
 	matcher := registry.Matcher()
 	policy := registry.Policy()
+	trustedProxies, proxySource := registry.TrustedProxies()
 
 	response := gin.H{
 		"client_ip":                  address.Raw,
 		"trusted":                    address.Trusted,
 		"relay_header":               address.RelayHeader,
 		"trusted_proxies_configured": registry.ProxyTrusted(),
-		"enforced":                   address.Trusted || address.Loopback(),
-		"lockdown":                   policy.Lockdown,
-		"active_rules":               matcher.Count(),
-		"storage_available":          registry.Store().Available(),
-		"auto_ban_mode":              policy.AutoBan.Mode,
+		"trusted_proxies":            trustedProxies,
+		// Where the live list came from: "database" (panel-managed), "config"
+		// (config.yaml fallback) or "none". The panel needs it to explain why an
+		// edit here may not be what is in force.
+		"trusted_proxies_source": proxySource,
+		"enforced":               address.Trusted || address.Loopback(),
+		"lockdown":               policy.Lockdown,
+		"active_rules":           matcher.Count(),
+		"storage_available":      registry.Store().Available(),
+		"auto_ban_mode":          policy.AutoBan.Mode,
 	}
 	if !address.Trusted && address.Raw != "" {
-		// Hand back the exact line to paste into config.yaml: the remedy is one
-		// setting, and every minute this stays unfixed is a minute the rules do
-		// nothing.
+		// The address the panel should add as a trusted proxy to fix this. It is
+		// applied through the policy endpoint, so the remedy is a button rather
+		// than a file edit and a restart.
 		response["suggested_trusted_proxies"] = []string{address.Raw + "/32"}
 	}
 	if recorder := authevents.Default(); recorder != nil {

--- a/internal/api/handlers/management/ip_access_bootstrap.go
+++ b/internal/api/handlers/management/ip_access_bootstrap.go
@@ -34,10 +34,13 @@ func ensureIPAccessRuntime(cfg *config.Config) {
 	if cfg != nil {
 		trustedProxies = cfg.TrustedProxies
 	}
-	registry := ipaccess.EnsureDefault(ctx, db, ipaccess.ProxyTrustConfigured(trustedProxies))
+	registry := ipaccess.EnsureDefault(ctx, db, trustedProxies)
+	// Protection follows the list actually in force, which may come from the
+	// database rather than config.yaml.
+	effectiveProxies, _ := registry.TrustedProxies()
 	registry.SetProtectedAddresses(
 		ipaccess.LocalInterfaceAddresses(),
-		trustedProxies,
+		effectiveProxies,
 		ipaccess.ProxyHostAddresses(outboundProxyURLs(cfg)),
 	)
 }

--- a/internal/api/server_config_reload.go
+++ b/internal/api/server_config_reload.go
@@ -207,10 +207,9 @@ func (s *Server) commitUpdatedConfig(oldCfg, cfg *config.Config) {
 	}
 	s.cfg = cfg
 	// A reload replaces the config pointer, so the admission layer has to be told
-	// separately. "Is the client address trustworthy" is precisely the answer
-	// that changes when an operator finally configures trusted-proxies, and it
-	// gates whether the IP rules are enforced at all.
-	ipaccess.Default().SetProxyTrusted(ipaccess.ProxyTrustConfigured(cfg.TrustedProxies))
+	// separately. The config list is only the fallback now — the panel-managed
+	// list in the database wins — but it still has to track reloads.
+	ipaccess.Default().SetConfiguredProxies(cfg.TrustedProxies)
 	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
 	if oldCfg != nil && s.wsAuthChanged != nil && oldCfg.WebsocketAuth != cfg.WebsocketAuth {
 		s.wsAuthChanged(oldCfg.WebsocketAuth, cfg.WebsocketAuth)

--- a/internal/cmd/ip_access_bootstrap.go
+++ b/internal/cmd/ip_access_bootstrap.go
@@ -61,7 +61,7 @@ func initializeIPAccessControl(ctx context.Context, cfg *config.Config) {
 	recorder := authevents.EnsureDefault(ctx, db)
 	startAuthEventRetention(ctx, recorder)
 
-	registry := ipaccess.EnsureDefault(ctx, db, ipaccess.ProxyTrustConfigured(trustedProxies))
+	registry := ipaccess.EnsureDefault(ctx, db, trustedProxies)
 	registry.SetPolicyPersister(ctx, ipAccessPolicyStore{})
 }
 

--- a/internal/ipaccess/bootstrap.go
+++ b/internal/ipaccess/bootstrap.go
@@ -23,7 +23,7 @@ var installed struct {
 // caller that assembled the management API itself — the route smoke tests, and
 // anyone embedding the server through the SDK — got a nil registry and every IP
 // access endpoint answered 503.
-func EnsureDefault(ctx context.Context, db *sql.DB, proxyTrusted bool) *Registry {
+func EnsureDefault(ctx context.Context, db *sql.DB, configuredProxies []string) *Registry {
 	if db == nil {
 		return Default()
 	}
@@ -31,14 +31,14 @@ func EnsureDefault(ctx context.Context, db *sql.DB, proxyTrusted bool) *Registry
 	defer installed.mu.Unlock()
 
 	if existing := Default(); existing != nil && installed.db == db {
-		existing.SetProxyTrusted(proxyTrusted)
+		existing.SetConfiguredProxies(configuredProxies)
 		return existing
 	}
 	if previous := Default(); previous != nil {
 		previous.Close()
 	}
 	registry := NewRegistry(NewStore(db))
-	registry.SetProxyTrusted(proxyTrusted)
+	registry.SetConfiguredProxies(configuredProxies)
 	registry.Start(ctx)
 	SetDefault(registry)
 	installed.db = db

--- a/internal/ipaccess/forwarded.go
+++ b/internal/ipaccess/forwarded.go
@@ -1,0 +1,181 @@
+package ipaccess
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// forwardedHeaders are walked in priority order. X-Forwarded-For is the de-facto
+// standard; X-Real-IP carries a single address; Forwarded is RFC 7239.
+var forwardedHeaders = []string{"X-Forwarded-For", "X-Real-IP", "Forwarded"}
+
+// trustedProxyMatcher decides whether a hop may be believed.
+type trustedProxyMatcher struct {
+	nets []*net.IPNet
+}
+
+func newTrustedProxyMatcher(cidrs []string) *trustedProxyMatcher {
+	matcher := &trustedProxyMatcher{}
+	for _, raw := range cidrs {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		if !strings.Contains(trimmed, "/") {
+			if ip := net.ParseIP(trimmed); ip != nil {
+				bits := 128
+				if v4 := ip.To4(); v4 != nil {
+					ip, bits = v4, 32
+				}
+				matcher.nets = append(matcher.nets, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+			}
+			continue
+		}
+		if _, network, err := net.ParseCIDR(trimmed); err == nil && network != nil {
+			matcher.nets = append(matcher.nets, network)
+		}
+	}
+	return matcher
+}
+
+func (m *trustedProxyMatcher) configured() bool { return m != nil && len(m.nets) > 0 }
+
+func (m *trustedProxyMatcher) trusts(ip net.IP) bool {
+	if m == nil || ip == nil {
+		return false
+	}
+	for _, network := range m.nets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveForwarded walks the forwarding chain from the direct peer outwards and
+// returns the first address that no trusted proxy vouched for — that is the
+// client.
+//
+// The walk is right-to-left because only the rightmost entries were appended by
+// infrastructure we control; everything to the left of the first untrusted hop
+// is attacker-supplied and must be discarded, not merely deprioritised. A single
+// spoofed X-Forwarded-For would otherwise let a banned client rename itself, or
+// forge membership of the allow list.
+//
+// Returns trusted=false when the chain cannot be resolved to a real client:
+// either nothing is configured as a proxy while the request was clearly relayed,
+// or every hop is a trusted proxy and the real client is simply not in the
+// header. Both cases mean the address identifies infrastructure rather than a
+// client, and the caller must not enforce anything on it.
+func resolveForwarded(req *http.Request, matcher *trustedProxyMatcher) ClientAddress {
+	addr := ClientAddress{}
+	if req == nil {
+		return addr
+	}
+	addr.RelayHeader = firstForwardedHeader(req)
+
+	peerText := hostOnly(req.RemoteAddr)
+	peer := net.ParseIP(peerText)
+	addr.Raw, addr.IP = peerText, peer
+
+	if peer == nil {
+		return addr
+	}
+	// A direct connection from something that is not a declared proxy is already
+	// the client, headers or not: whatever it claims about upstream hops is
+	// unverifiable, so it is ignored.
+	if !matcher.trusts(peer) {
+		addr.Trusted = true
+		if addr.RelayHeader != "" && !matcher.configured() {
+			// Relayed but no proxy declared: this is the proxy's address standing
+			// in for every client behind it.
+			addr.Trusted = false
+		}
+		return addr
+	}
+
+	// The peer is a declared proxy, so its forwarding header may be believed as
+	// far as the first hop it did not add itself.
+	for index := len(forwardedHeaders) - 1; index >= 0; index-- {
+		hops := parseForwardedHeader(req, forwardedHeaders[index])
+		for i := len(hops) - 1; i >= 0; i-- {
+			ip := net.ParseIP(hops[i])
+			if ip == nil {
+				continue
+			}
+			if matcher.trusts(ip) {
+				continue
+			}
+			return ClientAddress{IP: ip, Raw: ip.String(), Trusted: true, RelayHeader: addr.RelayHeader}
+		}
+	}
+	// Every hop was a trusted proxy: the real client never made it into the
+	// header, so nothing here identifies one.
+	return addr
+}
+
+func firstForwardedHeader(req *http.Request) string {
+	for _, header := range forwardedHeaders {
+		for _, value := range req.Header.Values(header) {
+			if strings.TrimSpace(value) != "" {
+				return header
+			}
+		}
+	}
+	return ""
+}
+
+func parseForwardedHeader(req *http.Request, header string) []string {
+	values := req.Header.Values(header)
+	if len(values) == 0 {
+		return nil
+	}
+	hops := make([]string, 0, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			candidate := strings.TrimSpace(part)
+			if candidate == "" {
+				continue
+			}
+			// RFC 7239 shape: for=192.0.2.1;proto=https
+			if header == "Forwarded" {
+				candidate = extractForwardedFor(candidate)
+				if candidate == "" {
+					continue
+				}
+			}
+			hops = append(hops, hostOnly(candidate))
+		}
+	}
+	return hops
+}
+
+func extractForwardedFor(directive string) string {
+	for _, token := range strings.Split(directive, ";") {
+		token = strings.TrimSpace(token)
+		if !strings.HasPrefix(strings.ToLower(token), "for=") {
+			continue
+		}
+		value := strings.TrimPrefix(token[4:], "\"")
+		return strings.TrimSuffix(value, "\"")
+	}
+	return ""
+}
+
+// hostOnly strips a port and IPv6 brackets, leaving a bare address.
+func hostOnly(raw string) string {
+	candidate := strings.TrimSpace(raw)
+	if candidate == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(candidate); err == nil {
+		candidate = host
+	}
+	candidate = strings.TrimPrefix(candidate, "[")
+	candidate = strings.TrimSuffix(candidate, "]")
+	if zone := strings.IndexByte(candidate, '%'); zone >= 0 {
+		candidate = candidate[:zone]
+	}
+	return strings.TrimSpace(candidate)
+}

--- a/internal/ipaccess/matcher_test.go
+++ b/internal/ipaccess/matcher_test.go
@@ -234,3 +234,93 @@ func TestProxyHostAddressesKeepsOnlyLiterals(t *testing.T) {
 		t.Errorf("got %v, want [203.0.113.9]", got)
 	}
 }
+
+func TestResolveForwardedWalksChainAgainstDeclaredProxies(t *testing.T) {
+	// The rightmost hops were appended by infrastructure we control; everything
+	// left of the first untrusted hop is attacker-supplied and must be discarded.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:5000"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4, 203.0.113.7, 10.0.0.2")
+
+	matcher := newTrustedProxyMatcher([]string{"10.0.0.0/24"})
+	addr := resolveForwarded(req, matcher)
+	if !addr.Trusted {
+		t.Fatal("chain resolved through declared proxies should be trusted")
+	}
+	if addr.Raw != "203.0.113.7" {
+		t.Errorf("got %q, want the first hop no trusted proxy vouched for", addr.Raw)
+	}
+}
+
+func TestResolveForwardedIgnoresHeaderFromUndeclaredPeer(t *testing.T) {
+	// A direct client claiming upstream hops is unverifiable, so the claim is
+	// dropped rather than believed — otherwise a banned client renames itself.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.9:44000"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+
+	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"10.0.0.0/24"}))
+	if addr.Raw != "203.0.113.9" || !addr.Trusted {
+		t.Errorf("got %q trusted=%t, want the peer address treated as the client", addr.Raw, addr.Trusted)
+	}
+}
+
+func TestResolveForwardedUntrustedWhenRelayedWithNoDeclaredProxy(t *testing.T) {
+	// This is the production state: nginx relays, nothing is declared, so the
+	// address is the proxy's and stands for everyone behind it.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "104.194.69.137:5000"
+	req.Header.Set("X-Forwarded-For", "203.0.113.9")
+
+	addr := resolveForwarded(req, newTrustedProxyMatcher(nil))
+	if addr.Trusted {
+		t.Error("relayed request with no declared proxy must not be trusted")
+	}
+	if addr.Raw != "104.194.69.137" {
+		t.Errorf("got %q, want the proxy address", addr.Raw)
+	}
+}
+
+func TestResolveForwardedAllHopsTrustedIsNotAClient(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:5000"
+	req.Header.Set("X-Forwarded-For", "10.0.0.2, 10.0.0.3")
+
+	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"10.0.0.0/24"}))
+	if addr.Trusted {
+		t.Error("a chain of only proxies identifies no client and must not be trusted")
+	}
+}
+
+func TestPolicyNormalizesAndDeduplicatesTrustedProxies(t *testing.T) {
+	policy := ProtectionPolicy{TrustedProxies: []string{
+		" 104.194.69.137 ", "104.194.69.137", "10.0.0.0/24", "not-an-ip", "",
+	}}.Normalized()
+	want := []string{"104.194.69.137/32", "10.0.0.0/24"}
+	if len(policy.TrustedProxies) != len(want) {
+		t.Fatalf("got %v, want %v", policy.TrustedProxies, want)
+	}
+	for i := range want {
+		if policy.TrustedProxies[i] != want[i] {
+			t.Errorf("index %d: got %q, want %q", i, policy.TrustedProxies[i], want[i])
+		}
+	}
+}
+
+func TestRegistryPrefersStoredProxiesOverConfig(t *testing.T) {
+	registry := NewRegistry(NewStore(nil))
+	registry.SetConfiguredProxies([]string{"10.0.0.0/24"})
+	if proxies, source := registry.TrustedProxies(); source != "config" || len(proxies) != 1 {
+		t.Fatalf("got %v from %q, want the config fallback", proxies, source)
+	}
+	registry.SetPolicy(context.Background(), ProtectionPolicy{TrustedProxies: []string{"104.194.69.137"}})
+	proxies, source := registry.TrustedProxies()
+	if source != "database" || len(proxies) != 1 || proxies[0] != "104.194.69.137/32" {
+		t.Fatalf("got %v from %q, want the stored list to win", proxies, source)
+	}
+	// Clearing the stored list must fall back rather than strand the deployment.
+	registry.SetPolicy(context.Background(), ProtectionPolicy{})
+	if _, source = registry.TrustedProxies(); source != "config" {
+		t.Errorf("got %q, want the config fallback after clearing the stored list", source)
+	}
+}

--- a/internal/ipaccess/policy.go
+++ b/internal/ipaccess/policy.go
@@ -1,6 +1,10 @@
 package ipaccess
 
-import "time"
+import (
+	"net"
+	"strings"
+	"time"
+)
 
 // AutoBanMode controls what the automatic ban engine does with a source that
 // crosses the failure threshold.
@@ -55,6 +59,15 @@ type ProtectionPolicy struct {
 	Lockdown bool             `json:"lockdown"`
 	AutoBan  AutoBanPolicy    `json:"auto_ban"`
 	Throttle ThrottleOverride `json:"throttle"`
+	// TrustedProxies are the reverse proxies whose forwarding headers may be
+	// believed. It lives here, in the database, rather than in config.yaml
+	// because it is the single setting that decides whether this whole feature
+	// does anything — and an operator watching an attack should be able to fix it
+	// from the panel instead of editing a file and restarting the process.
+	//
+	// config.yaml's trusted-proxies still applies when this is empty, so existing
+	// deployments keep working and nothing silently changes under them.
+	TrustedProxies []string `json:"trusted_proxies,omitempty"`
 }
 
 // SettingKey is the runtime-settings document key for ProtectionPolicy.
@@ -122,7 +135,46 @@ func (p ProtectionPolicy) Normalized() ProtectionPolicy {
 	if p.Throttle.FailureResetHours < 0 {
 		p.Throttle.FailureResetHours = 0
 	}
+	cleaned := make([]string, 0, len(p.TrustedProxies))
+	seen := make(map[string]struct{}, len(p.TrustedProxies))
+	for _, proxy := range p.TrustedProxies {
+		normalized, ok := NormalizeTrustedProxy(proxy)
+		if !ok {
+			continue
+		}
+		if _, duplicate := seen[normalized]; duplicate {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		cleaned = append(cleaned, normalized)
+	}
+	p.TrustedProxies = cleaned
 	return p
+}
+
+// NormalizeTrustedProxy canonicalises one entry of the trusted proxy list. A
+// bare address becomes a host route so the stored form is always a network.
+func NormalizeTrustedProxy(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	if strings.Contains(trimmed, "/") {
+		_, network, err := net.ParseCIDR(trimmed)
+		if err != nil || network == nil {
+			return "", false
+		}
+		return network.String(), true
+	}
+	ip := net.ParseIP(trimmed)
+	if ip == nil {
+		return "", false
+	}
+	bits := 128
+	if v4 := ip.To4(); v4 != nil {
+		ip, bits = v4, 32
+	}
+	return (&net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}).String(), true
 }
 
 // Window returns the auto-ban observation window.

--- a/internal/ipaccess/registry.go
+++ b/internal/ipaccess/registry.go
@@ -61,11 +61,14 @@ type Registry struct {
 	// protected is the set of addresses no rule may reject.
 	protected atomic.Pointer[protectedSet]
 
-	// proxyTrusted mirrors "trusted-proxies is non-empty". It lives here rather
-	// than being read from config at match time because a hot reload swaps the
-	// whole config pointer, so a middleware that captured the old one would keep
-	// answering from a stale deployment.
-	proxyTrusted atomic.Bool
+	// configProxies is the config.yaml fallback, used only when the stored policy
+	// lists none. Kept separately so saving an empty list in the panel restores
+	// the configured value instead of stranding the deployment with nothing.
+	configProxies atomic.Pointer[[]string]
+	// proxyMatcher resolves the forwarding chain. It is rebuilt whenever the
+	// policy or the config changes, so an operator can fix trust from the panel
+	// and have it apply to the very next request.
+	proxyMatcher atomic.Pointer[trustedProxyMatcher]
 
 	hitsMu sync.Mutex
 	hits   map[string]int64
@@ -107,6 +110,7 @@ func (r *Registry) SetPolicy(ctx context.Context, policy ProtectionPolicy) {
 	}
 	normalized := policy.Normalized()
 	r.policy.Store(&normalized)
+	r.rebuildProxyMatcher()
 	if err := r.Refresh(ctx); err != nil {
 		log.WithError(err).Warn("ip-access: refresh after policy change failed")
 	}
@@ -192,24 +196,60 @@ func (r *Registry) Protected(ip net.IP) (ProtectedEntry, bool) {
 	return r.protected.Load().match(ip)
 }
 
-// SetProxyTrusted records whether the operator declared any trusted proxy.
-func (r *Registry) SetProxyTrusted(configured bool) {
+// SetConfiguredProxies records the config.yaml fallback list.
+func (r *Registry) SetConfiguredProxies(proxies []string) {
 	if r == nil {
 		return
 	}
-	r.proxyTrusted.Store(configured)
+	copied := append([]string(nil), proxies...)
+	r.configProxies.Store(&copied)
+	r.rebuildProxyMatcher()
 }
 
-// ProxyTrusted reports whether forwarding headers may be believed.
+// TrustedProxies returns the list actually in force, and whether it came from
+// the database or from config.yaml.
+func (r *Registry) TrustedProxies() ([]string, string) {
+	if r == nil {
+		return nil, "none"
+	}
+	if stored := r.Policy().TrustedProxies; len(stored) > 0 {
+		return append([]string(nil), stored...), "database"
+	}
+	if configured := r.configProxies.Load(); configured != nil && len(*configured) > 0 {
+		return append([]string(nil), *configured...), "config"
+	}
+	return nil, "none"
+}
+
+func (r *Registry) rebuildProxyMatcher() {
+	proxies, _ := r.TrustedProxies()
+	r.proxyMatcher.Store(newTrustedProxyMatcher(proxies))
+}
+
+// ProxyTrusted reports whether any reverse proxy is declared, from either source.
 func (r *Registry) ProxyTrusted() bool {
-	return r != nil && r.proxyTrusted.Load()
+	if r == nil {
+		return false
+	}
+	return r.proxyMatcher.Load().configured()
 }
 
-// ResolveAddress derives the client address for a request using the registry's
-// view of proxy trust, so admission and throttling can never disagree about
-// whether an address is meaningful.
+// ResolveAddress derives the client address for a request by walking the
+// forwarding chain against the declared proxies, so admission and throttling can
+// never disagree about whether an address is meaningful.
+//
+// resolvedIP (the framework's ClientIP) is accepted for compatibility but is no
+// longer authoritative: it is fixed at engine construction from config.yaml,
+// which is exactly the restart-to-change behaviour this replaces.
 func (r *Registry) ResolveAddress(req *http.Request, resolvedIP string) ClientAddress {
-	return Resolve(req, resolvedIP, r.ProxyTrusted())
+	if r == nil {
+		return Resolve(req, resolvedIP, false)
+	}
+	matcher := r.proxyMatcher.Load()
+	if req == nil {
+		return Resolve(req, resolvedIP, matcher.configured())
+	}
+	return resolveForwarded(req, matcher)
 }
 
 // Store exposes the rule store for the management API.


### PR DESCRIPTION
## 起因

「相关的数据不是应该放在数据库中吗？你别什么都写到 config.yaml 中呀。」

说得对，而且这条尤其不该在文件里：`trusted-proxies` 是决定整个 IP 访问控制功能**是否起作用**的唯一开关，却只能改文件 + 重启。运维正盯着攻击的时候，应该能在面板上几秒钟改完。

## 改动

配置移入数据库中的防护策略文档，并且**不再依赖 gin 的 `ClientIP()`** —— 它的可信代理列表在 engine 构造时就固定了，那正是要消除的"改完要重启"行为。

新的解析器从直连对端开始，**从右往左**走转发链，返回第一个没有可信代理为其背书的地址。方向很关键：只有最右侧的条目是我们自己的基础设施追加的，第一个不可信跳之前的内容全部是攻击者可控的，必须**丢弃**而不是降权。否则一个伪造的 `X-Forwarded-For` 就能让被封的客户端改名脱身，或者伪造成白名单成员。

三种情况刻意判定为"不可信"而不是猜：

- 请求被转发但没声明任何代理（当前线上就是这个状态）
- 链上每一跳都是可信代理（真实客户端根本没进 header）
- 对端地址无法解析

这三种都意味着这个地址标识的是基础设施而非客户端，调用方不得据此拦截任何人。

`config.yaml` 在数据库列表为空时仍然生效，所以现有部署不受影响；面板上清空列表会回落到配置值，而不是让部署处于"一个代理都没有"的状态。

## 验证

完整 `./scripts/ci-pr.sh` 退出码 0，零失败。新增 6 个单测覆盖：转发链行走、未声明对端伪造 header、全代理链、归一化去重、数据库优先于配置、清空后回落。

🤖 Generated with [Claude Code](https://claude.com/claude-code)