### PR TITLE
fix(usage): 用锚定周期修复共享账号用量被切碎导致的卡片/详情对不上

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -266,7 +266,10 @@ func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 			if _, err := usage.RunAIAccountSharedSubjectBackfillAtInit(); err != nil {
 				return err
 			}
-			return usage.RunAIAccountSubjectUsageTokensBackfillAtInit()
+			if err := usage.RunAIAccountSubjectUsageTokensBackfillAtInit(); err != nil {
+				return err
+			}
+			return usage.RunAIAccountSubjectCycleBucketMergeAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/management/aiaccountstatus/status_view.go
+++ b/internal/management/aiaccountstatus/status_view.go
@@ -1,7 +1,6 @@
 package aiaccountstatus
 
 import (
-	"strings"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -80,15 +79,9 @@ func weeklyUsedFromQuotas(quotas []usage.QuotaWindowDTO, preferred ...string) *f
 	return nil
 }
 
+// primaryWeeklyKeys delegates to the usage package so the card list, the detail
+// trend and the projection that writes the buckets all anchor to one cycle. Three
+// private copies of this table is how they drifted apart in the first place.
 func primaryWeeklyKeys(provider string) []string {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case "anthropic", "claude":
-		return []string{"seven_day"}
-	case "codex", "kimi":
-		return []string{"code_week"}
-	case "xai", "grok":
-		return []string{"weekly_limit"}
-	default:
-		return nil
-	}
+	return usage.PrimaryWeeklyQuotaKeys(provider)
 }

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -397,18 +397,10 @@ func latestWeeklyQuotaCycleStart(series []usage.QuotaSnapshotSeries, preferredQu
 	return latestPoint.ResetAt.Add(-time.Duration(latestWindow) * time.Second).UTC(), true
 }
 
+// primaryWeeklyQuotaKeysForProvider delegates to the usage package so the detail
+// trend anchors to the same cycle the card list and the usage projection use.
 func primaryWeeklyQuotaKeysForProvider(provider string) []string {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case "anthropic", "claude":
-		return []string{"seven_day"}
-	case "codex", "kimi":
-		return []string{"code_week"}
-	case "xai", "grok":
-		// Matches frontend quota-xai weekly_limit snapshot key.
-		return []string{"weekly_limit"}
-	default:
-		return nil
-	}
+	return usage.PrimaryWeeklyQuotaKeys(provider)
 }
 
 func (s *Service) authIndexesForProviderGroup(group string) []string {

--- a/internal/usage/ai_account_subject_cycle_merge.go
+++ b/internal/usage/ai_account_subject_cycle_merge.go
@@ -1,0 +1,262 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const aiAccountSubjectCycleBucketMergeMarker = "ai_account_subject_cycle_bucket_merge_v1"
+
+type aiAccountSubjectCycleBucketRow struct {
+	subjectID  string
+	start      string
+	at         time.Time
+	requests   int64
+	successes  int64
+	failures   int64
+	cost       float64
+	tokens     int64
+	firstEvent time.Time
+	updatedAt  time.Time
+}
+
+// RunAIAccountSubjectCycleBucketMergeAtInit repairs periods that were split into
+// several usage buckets before cycle anchoring landed.
+//
+// The bucket key was the probed cycle start, and upstreams re-derive that start
+// from a remaining-seconds countdown, so a single weekly period accumulated one
+// bucket per probe jitter (production carried 404 / 114 / 1 request fragments of
+// the same period). Each reader then anchored to whichever fragment matched the
+// timestamp it read, which is why the card and the detail dialog disagreed about
+// the same account. Anchoring stops new fragments; this merges the existing ones
+// so the totals are correct without waiting for the next period to roll over.
+func RunAIAccountSubjectCycleBucketMergeAtInit() error {
+	return runAIAccountSubjectCycleBucketMergeDB(getDB())
+}
+
+func runAIAccountSubjectCycleBucketMergeDB(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+
+	usageProjectionMu.Lock()
+	defer usageProjectionMu.Unlock()
+
+	ensureUsageProjectionMarkerTable(db)
+	if projectionMarkerValue(db, aiAccountSubjectCycleBucketMergeMarker) == rollupMarkerDone {
+		return nil
+	}
+
+	rows, err := loadAIAccountSubjectCycleBuckets(db)
+	if err != nil {
+		return err
+	}
+	groups := groupAIAccountSubjectCycleBuckets(rows)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin shared subject cycle merge: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UTC()
+	for _, group := range groups {
+		if len(group) < 2 {
+			continue
+		}
+		if err := mergeAIAccountSubjectCycleGroupTx(tx, group); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO UPDATE SET
+			marker_value = excluded.marker_value,
+			updated_at = excluded.updated_at
+	`, aiAccountSubjectCycleBucketMergeMarker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: mark shared subject cycle merge: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit shared subject cycle merge: %w", err)
+	}
+	return nil
+}
+
+func loadAIAccountSubjectCycleBuckets(db *sql.DB) ([]aiAccountSubjectCycleBucketRow, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, bucket_start, request_count, success_count, failure_count,
+			cost_total, total_tokens, first_event_at, updated_at
+		FROM ai_account_subject_usage_buckets
+		WHERE bucket_kind = 'cycle'
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared subject cycle buckets: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]aiAccountSubjectCycleBucketRow, 0)
+	for rows.Next() {
+		var row aiAccountSubjectCycleBucketRow
+		var first, updated storedTime
+		if err := rows.Scan(&row.subjectID, &row.start, &row.requests, &row.successes, &row.failures,
+			&row.cost, &row.tokens, &first, &updated); err != nil {
+			return nil, fmt.Errorf("usage: scan shared subject cycle bucket: %w", err)
+		}
+		row.subjectID = strings.TrimSpace(row.subjectID)
+		parsed, ok := parseStoredTimeString(row.start)
+		if row.subjectID == "" || !ok {
+			continue
+		}
+		row.at = parsed.UTC()
+		if first.Valid {
+			row.firstEvent = first.Time.UTC()
+		}
+		if updated.Valid {
+			row.updatedAt = updated.Time.UTC()
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// groupAIAccountSubjectCycleBuckets clusters one subject's buckets into periods.
+//
+// Membership is tested against the group's anchor rather than the previous
+// bucket, so a long chain of small drifts can never merge two genuinely
+// different periods into one.
+func groupAIAccountSubjectCycleBuckets(rows []aiAccountSubjectCycleBucketRow) [][]aiAccountSubjectCycleBucketRow {
+	bySubject := make(map[string][]aiAccountSubjectCycleBucketRow)
+	for _, row := range rows {
+		bySubject[row.subjectID] = append(bySubject[row.subjectID], row)
+	}
+	subjectIDs := make([]string, 0, len(bySubject))
+	for subjectID := range bySubject {
+		subjectIDs = append(subjectIDs, subjectID)
+	}
+	sort.Strings(subjectIDs)
+
+	groups := make([][]aiAccountSubjectCycleBucketRow, 0)
+	for _, subjectID := range subjectIDs {
+		buckets := bySubject[subjectID]
+		sort.Slice(buckets, func(i, j int) bool { return buckets[i].at.Before(buckets[j].at) })
+		var current []aiAccountSubjectCycleBucketRow
+		for _, bucket := range buckets {
+			if len(current) > 0 &&
+				!sameAIAccountSubjectCycle(current[0].at, bucket.at, aiAccountSubjectWeeklyWindowSeconds) {
+				groups = append(groups, current)
+				current = nil
+			}
+			current = append(current, bucket)
+		}
+		if len(current) > 0 {
+			groups = append(groups, current)
+		}
+	}
+	return groups
+}
+
+// mergeAIAccountSubjectCycleGroupTx folds a fragmented period onto its earliest
+// bucket, which is the closest surviving record of when the period actually began.
+func mergeAIAccountSubjectCycleGroupTx(tx *sql.Tx, group []aiAccountSubjectCycleBucketRow) error {
+	anchor := group[0]
+	merged := anchor
+	for _, bucket := range group[1:] {
+		merged.requests += bucket.requests
+		merged.successes += bucket.successes
+		merged.failures += bucket.failures
+		merged.cost += bucket.cost
+		merged.tokens += bucket.tokens
+		if !bucket.firstEvent.IsZero() && (merged.firstEvent.IsZero() || bucket.firstEvent.Before(merged.firstEvent)) {
+			merged.firstEvent = bucket.firstEvent
+		}
+		if bucket.updatedAt.After(merged.updatedAt) {
+			merged.updatedAt = bucket.updatedAt
+		}
+	}
+	if merged.firstEvent.IsZero() {
+		merged.firstEvent = anchor.at
+	}
+	if merged.updatedAt.IsZero() {
+		merged.updatedAt = anchor.at
+	}
+
+	for _, bucket := range group[1:] {
+		if _, err := tx.Exec(`
+			DELETE FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+		`, bucket.subjectID, bucket.start); err != nil {
+			return fmt.Errorf("usage: drop fragmented cycle bucket: %w", err)
+		}
+	}
+	if _, err := tx.Exec(`
+		UPDATE ai_account_subject_usage_buckets
+		SET request_count = ?, success_count = ?, failure_count = ?, cost_total = ?,
+			total_tokens = ?, first_event_at = ?, updated_at = ?
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, merged.requests, merged.successes, merged.failures, merged.cost, merged.tokens,
+		merged.firstEvent.Format(time.RFC3339Nano), merged.updatedAt.Format(time.RFC3339Nano),
+		anchor.subjectID, anchor.start); err != nil {
+		return fmt.Errorf("usage: write merged cycle bucket: %w", err)
+	}
+
+	return realignAIAccountSubjectQuotaCycleTx(tx, anchor.subjectID, anchor.at)
+}
+
+// realignAIAccountSubjectQuotaCycleTx repoints live cycle rows at the merged
+// anchor. A row still carrying a dropped fragment's start would send the next
+// read looking for a bucket that no longer exists, which reads as zero usage.
+func realignAIAccountSubjectQuotaCycleTx(tx *sql.Tx, subjectID string, anchorAt time.Time) error {
+	rows, err := tx.Query(`
+		SELECT quota_key, cycle_start_at, window_seconds
+		FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND window_seconds >= ?
+	`, subjectID, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return fmt.Errorf("usage: load shared quota cycles for realign: %w", err)
+	}
+	type realignTarget struct {
+		quotaKey string
+		window   int64
+	}
+	targets := make([]realignTarget, 0)
+	for rows.Next() {
+		var quotaKey string
+		var start storedTime
+		var window int64
+		if err := rows.Scan(&quotaKey, &start, &window); err != nil {
+			rows.Close()
+			return fmt.Errorf("usage: scan shared quota cycle for realign: %w", err)
+		}
+		if !start.Valid || start.Time.UTC().Equal(anchorAt) {
+			continue
+		}
+		if !sameAIAccountSubjectCycle(start.Time, anchorAt, window) {
+			continue
+		}
+		targets = append(targets, realignTarget{quotaKey: quotaKey, window: window})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	for _, target := range targets {
+		resetAt := anchorAt.Add(time.Duration(target.window) * time.Second)
+		if _, err := tx.Exec(`
+			UPDATE ai_account_subject_quota_cycles
+			SET cycle_start_at = ?, reset_at = ?
+			WHERE auth_subject_id = ? AND quota_key = ?
+		`, anchorAt.Format(time.RFC3339Nano), resetAt.Format(time.RFC3339Nano),
+			subjectID, target.quotaKey); err != nil {
+			return fmt.Errorf("usage: realign shared quota cycle: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/usage/ai_account_subject_cycle_merge_test.go
+++ b/internal/usage/ai_account_subject_cycle_merge_test.go
@@ -1,0 +1,239 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+// Production reproduced: one weekly period held three cycle buckets whose starts
+// were 00:51:21 / :23 / :24, carrying 404 / 114 / 1 requests. Whichever fragment
+// a reader's timestamp matched became "the" cycle total, so the card said 19 and
+// the detail dialog said 436 for the same account in the same minute.
+func TestRecordQuotaPointsKeepsOneCycleAcrossProbeJitter(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "jitter", "acct-jitter", "jitter@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	baseReset := now.Add(120 * time.Hour)
+	pct := 50.0
+	// Three probes, each reporting the reset a couple of seconds off the last.
+	for i, drift := range []time.Duration{0, 2 * time.Second, 3 * time.Second} {
+		resetAt := baseReset.Add(drift)
+		if err := RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []QuotaSnapshotPoint{{
+			RecordedAt: now.Add(time.Duration(i) * time.Minute), Provider: "codex",
+			QuotaKey: "code_week", QuotaLabel: "Week", Percent: &pct,
+			ResetAt: &resetAt, WindowSeconds: 604800,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+		tx, err := getDB().Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 1, 10, now.Add(time.Duration(i)*time.Minute)); err != nil {
+			_ = tx.Rollback()
+			t.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var buckets int
+	if err := getDB().QueryRow(`
+		SELECT COUNT(*) FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, identity.ID).Scan(&buckets); err != nil {
+		t.Fatal(err)
+	}
+	if buckets != 1 {
+		t.Fatalf("cycle buckets = %d, want 1 (jitter must not open a new period)", buckets)
+	}
+
+	anchor := baseReset.Add(-7 * 24 * time.Hour)
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, map[string]time.Time{identity.ID: anchor})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := summaries[identity.ID]
+	if !got.CycleKnown || got.CycleRequestTotal != 3 || got.CycleTotalTokens != 30 {
+		t.Fatalf("cycle summary = %+v, want 3 requests / 30 tokens", got)
+	}
+}
+
+// A real rollover moves the start by a whole window, far outside the tolerance,
+// so the period must still roll instead of absorbing the next week's traffic.
+func TestRecordQuotaPointsRollsCycleOnGenuineReset(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "rollover", "acct-rollover", "roll@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	firstReset := now.Add(24 * time.Hour)
+	secondReset := firstReset.Add(7 * 24 * time.Hour)
+	pct := 50.0
+	for _, resetAt := range []time.Time{firstReset, secondReset} {
+		reset := resetAt
+		if err := RecordAIAccountSubjectQuotaPoints(identity.ID, "codex", []QuotaSnapshotPoint{{
+			RecordedAt: now, Provider: "codex", QuotaKey: "code_week", QuotaLabel: "Week",
+			Percent: &pct, ResetAt: &reset, WindowSeconds: 604800,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var start storedTime
+	if err := getDB().QueryRow(`
+		SELECT cycle_start_at FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = 'code_week'
+	`, identity.ID).Scan(&start); err != nil {
+		t.Fatal(err)
+	}
+	want := secondReset.Add(-7 * 24 * time.Hour)
+	if !start.Valid || !start.Time.UTC().Equal(want) {
+		t.Fatalf("cycle start = %v, want %v (a real reset must roll the period)", start.Time, want)
+	}
+}
+
+// Buckets written before anchoring landed are still fragmented on disk; the
+// migration folds them onto the earliest start and repoints the live cycle row.
+func TestCycleBucketMergeFoldsFragmentedPeriod(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "merge", "acct-merge", "merge@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	anchor := now.Add(-48 * time.Hour)
+	fragments := []struct {
+		at       time.Time
+		requests int64
+		tokens   int64
+		cost     float64
+	}{
+		{anchor, 404, 57702997, 52.5},
+		{anchor.Add(2 * time.Second), 114, 23291786, 16.8},
+		{anchor.Add(3 * time.Second), 1, 271753, 0.15},
+	}
+	for _, fragment := range fragments {
+		if _, err := getDB().Exec(`
+			INSERT INTO ai_account_subject_usage_buckets (
+				auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+				failure_count, cost_total, total_tokens, first_event_at, updated_at
+			) VALUES (?, 'cycle', ?, ?, ?, 0, ?, ?, ?, ?)
+		`, identity.ID, formatAIAccountSubjectCycleBucketStart(fragment.at), fragment.requests,
+			fragment.requests, fragment.cost, fragment.tokens,
+			fragment.at.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The live cycle row points at the newest fragment, which is exactly why a
+	// reader saw only one request instead of the period's 519.
+	newest := fragments[len(fragments)-1].at
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'codex', 'code_week', ?, ?, 604800, ?)
+	`, identity.ID, newest.Format(time.RFC3339Nano),
+		newest.Add(7*24*time.Hour).Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleBucketMergeDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	var buckets int
+	var requests, tokens int64
+	if err := getDB().QueryRow(`
+		SELECT COUNT(*), COALESCE(SUM(request_count), 0), COALESCE(SUM(total_tokens), 0)
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, identity.ID).Scan(&buckets, &requests, &tokens); err != nil {
+		t.Fatal(err)
+	}
+	if buckets != 1 || requests != 519 || tokens != 81266536 {
+		t.Fatalf("merged buckets=%d requests=%d tokens=%d, want 1/519/81266536", buckets, requests, tokens)
+	}
+
+	var start storedTime
+	if err := getDB().QueryRow(`
+		SELECT cycle_start_at FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = 'code_week'
+	`, identity.ID).Scan(&start); err != nil {
+		t.Fatal(err)
+	}
+	if !start.Valid || !start.Time.UTC().Equal(anchor) {
+		t.Fatalf("cycle row start = %v, want realigned to %v", start.Time, anchor)
+	}
+
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{identity.ID}, map[string]time.Time{identity.ID: anchor})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := summaries[identity.ID]; got.CycleRequestTotal != 519 || got.CycleTotalTokens != 81266536 {
+		t.Fatalf("summary after merge = %+v, want 519 requests / 81266536 tokens", got)
+	}
+}
+
+// Distinct periods must survive the merge: the grouping compares each bucket to
+// its group anchor, so a chain of small drifts cannot swallow a whole week.
+func TestCycleBucketMergeKeepsDistinctPeriodsApart(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "distinct", "acct-distinct", "distinct@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	lastWeek := now.Add(-7 * 24 * time.Hour)
+	for _, at := range []time.Time{lastWeek, lastWeek.Add(time.Second), now, now.Add(time.Second)} {
+		if _, err := getDB().Exec(`
+			INSERT INTO ai_account_subject_usage_buckets (
+				auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+				failure_count, cost_total, total_tokens, first_event_at, updated_at
+			) VALUES (?, 'cycle', ?, 10, 10, 0, 1, 100, ?, ?)
+		`, identity.ID, formatAIAccountSubjectCycleBucketStart(at),
+			at.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := runAIAccountSubjectCycleBucketMergeDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	var buckets int
+	if err := getDB().QueryRow(`
+		SELECT COUNT(*) FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, identity.ID).Scan(&buckets); err != nil {
+		t.Fatal(err)
+	}
+	if buckets != 2 {
+		t.Fatalf("cycle buckets = %d, want 2 (one per real period)", buckets)
+	}
+}
+
+func TestCycleBucketMergeRunsOncePerMarker(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	if err := runAIAccountSubjectCycleBucketMergeDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	if got := projectionMarkerValue(getDB(), aiAccountSubjectCycleBucketMergeMarker); got != rollupMarkerDone {
+		t.Fatalf("marker = %q, want %q", got, rollupMarkerDone)
+	}
+	if err := runAIAccountSubjectCycleBucketMergeDB(getDB()); err != nil {
+		t.Fatalf("rerun: %v", err)
+	}
+}

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -65,10 +65,14 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 				CycleStartAt: point.ResetAt.UTC().Add(-time.Duration(point.WindowSeconds) * time.Second),
 				ResetAt:      point.ResetAt.UTC(), WindowSeconds: point.WindowSeconds, LastVerifiedAt: recordedAt,
 			}
-			if err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle); err != nil {
+			// Cache the anchored cycle, not the freshly derived one: the in-memory
+			// cache feeds the usage projection's bucket key, so seeding it with the
+			// jittered value would re-split the period the anchor just protected.
+			anchored, err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle)
+			if err != nil {
 				return err
 			}
-			cycles = append(cycles, cycle)
+			cycles = append(cycles, anchored)
 		}
 		var latestAt sql.NullString
 		var latestPercent sql.NullFloat64
@@ -119,8 +123,49 @@ func nullableStoredTimeEqual(stored sql.NullString, value *time.Time) bool {
 	return ok && parsed.Equal(value.UTC())
 }
 
-func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) error {
-	_, err := tx.Exec(`
+// anchorAIAccountSubjectQuotaCycleTx keeps a cycle's identity stable across probes.
+//
+// The stored cycle_start doubles as the usage bucket key, so letting it follow
+// the upstream's per-probe jitter silently opened a new bucket every few seconds
+// and split one weekly period into fragments. Within the drift tolerance the
+// stored anchor wins and only last_verified_at moves; a real rollover shifts the
+// start by a whole window and falls outside the tolerance, so it still rolls.
+func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, error) {
+	var start, reset storedTime
+	var window int64
+	err := tx.QueryRow(`
+		SELECT cycle_start_at, reset_at, window_seconds
+		FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, cycle.AuthSubjectID, cycle.QuotaKey).Scan(&start, &reset, &window)
+	if err == sql.ErrNoRows {
+		return cycle, nil
+	}
+	if err != nil {
+		return cycle, fmt.Errorf("usage: load shared quota cycle anchor: %w", err)
+	}
+	if !start.Valid || window != cycle.WindowSeconds {
+		return cycle, nil
+	}
+	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) {
+		return cycle, nil
+	}
+	cycle.CycleStartAt = start.Time.UTC()
+	if reset.Valid && !reset.Time.IsZero() {
+		// Keep reset_at consistent with the anchor so the card countdown stops
+		// jittering by a second or two on every probe.
+		cycle.ResetAt = reset.Time.UTC()
+	}
+	return cycle, nil
+}
+
+func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, error) {
+	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle)
+	if err != nil {
+		return cycle, err
+	}
+	cycle = anchored
+	_, err = tx.Exec(`
 		INSERT INTO ai_account_subject_quota_cycles
 			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -134,9 +179,9 @@ func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 		cycle.CycleStartAt.UTC().Format(time.RFC3339Nano), cycle.ResetAt.UTC().Format(time.RFC3339Nano),
 		cycle.WindowSeconds, cycle.LastVerifiedAt.UTC().Format(time.RFC3339Nano))
 	if err != nil {
-		return fmt.Errorf("usage: upsert shared quota cycle: %w", err)
+		return cycle, fmt.Errorf("usage: upsert shared quota cycle: %w", err)
 	}
-	return nil
+	return cycle, nil
 }
 
 // QueryAIAccountSubjectQuotaSeries loads shared quota history for the detail trend chart.

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -53,6 +53,56 @@ func primaryAIAccountSubjectWeeklyQuotaKey(provider string) string {
 	}
 }
 
+// PrimaryWeeklyQuotaKeys is the single source of truth for "which quota window
+// is this provider's card cycle". The card list and the detail trend must agree
+// on it: when they disagree they anchor their totals to different cycles and
+// report different numbers for the same account.
+func PrimaryWeeklyQuotaKeys(provider string) []string {
+	key := primaryAIAccountSubjectWeeklyQuotaKey(provider)
+	if key == "" {
+		return nil
+	}
+	return []string{key}
+}
+
+// aiAccountSubjectCycleDriftTolerance bounds how far a re-probed cycle start may
+// move and still count as the same cycle.
+//
+// Upstreams report the window as a remaining-seconds countdown, so reset_at (and
+// with it cycle_start = reset_at - window) lands a few seconds apart on every
+// probe. Treating those as distinct cycles is what split one weekly period into
+// several usage buckets, leaving each reader to see whichever fragment matched
+// the timestamp it happened to read. The tolerance is three orders of magnitude
+// below the window, far above real jitter and far below a genuine rollover.
+func aiAccountSubjectCycleDriftTolerance(windowSeconds int64) time.Duration {
+	if windowSeconds <= 0 {
+		return time.Minute
+	}
+	tolerance := time.Duration(windowSeconds) * time.Second / 1000
+	if tolerance < time.Minute {
+		tolerance = time.Minute
+	}
+	if tolerance > 30*time.Minute {
+		tolerance = 30 * time.Minute
+	}
+	return tolerance
+}
+
+func absDuration(value time.Duration) time.Duration {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+// sameAIAccountSubjectCycle reports whether two cycle anchors describe one cycle.
+func sameAIAccountSubjectCycle(a, b time.Time, windowSeconds int64) bool {
+	if a.IsZero() || b.IsZero() {
+		return false
+	}
+	return absDuration(a.UTC().Sub(b.UTC())) <= aiAccountSubjectCycleDriftTolerance(windowSeconds)
+}
+
 func selectAIAccountSubjectWeeklyCycle(cycles []AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, bool) {
 	var selected AIAccountSubjectQuotaCycle
 	for _, cycle := range cycles {
@@ -364,40 +414,33 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 	}
 
 	cycleIDs := make([]string, 0, len(cycleStartBySubject))
-	cycleStarts := make([]string, 0, len(cycleStartBySubject))
-	startSeen := make(map[string]struct{}, len(cycleStartBySubject))
 	for id, start := range cycleStartBySubject {
 		if _, ok := out[id]; !ok || start.IsZero() {
 			continue
 		}
-		startKey := formatAIAccountSubjectCycleBucketStart(start)
 		s := out[id]
 		s.CycleKnown = true
 		s.CycleStart = start.UTC().Format(time.RFC3339)
 		out[id] = s
 		cycleIDs = append(cycleIDs, id)
-		if _, ok := startSeen[startKey]; !ok {
-			startSeen[startKey] = struct{}{}
-			cycleStarts = append(cycleStarts, startKey)
-		}
 	}
 	if len(cycleIDs) == 0 {
 		return out, nil
 	}
 
-	cycleArgs := make([]any, 0, len(cycleIDs)+len(cycleStarts))
+	cycleArgs := make([]any, 0, len(cycleIDs))
 	for _, id := range cycleIDs {
 		cycleArgs = append(cycleArgs, id)
 	}
-	for _, start := range cycleStarts {
-		cycleArgs = append(cycleArgs, start)
-	}
+	// Match buckets by tolerance rather than by exact key. Buckets written before
+	// cycle anchoring landed are still keyed to jittered starts, and an exact
+	// match would report only the fragment that happens to carry the current
+	// timestamp — the same period read as 19 requests here and 436 there.
 	cycleRows, err := db.Query(`
 		SELECT auth_subject_id, bucket_start, request_count, cost_total, total_tokens, updated_at
 		FROM ai_account_subject_usage_buckets
 		WHERE bucket_kind = 'cycle'
 		  AND auth_subject_id IN (`+strings.TrimSuffix(strings.Repeat("?,", len(cycleIDs)), ",")+`)
-		  AND bucket_start IN (`+strings.TrimSuffix(strings.Repeat("?,", len(cycleStarts)), ",")+`)
 	`, cycleArgs...)
 	if err != nil {
 		return nil, err
@@ -412,11 +455,17 @@ func QueryAIAccountSubjectUsageSummaries(subjectIDs []string, cycleStartBySubjec
 			return nil, err
 		}
 		expected, ok := cycleStartBySubject[id]
-		if !ok || bucketStart != formatAIAccountSubjectCycleBucketStart(expected) {
+		if !ok {
+			continue
+		}
+		bucketAt, parsed := parseStoredTimeString(bucketStart)
+		if !parsed || !sameAIAccountSubjectCycle(bucketAt, expected, aiAccountSubjectWeeklyWindowSeconds) {
 			continue
 		}
 		s := out[id]
-		s.CycleRequestTotal, s.CycleCostTotal, s.CycleTotalTokens = req, cost, totalTokens
+		s.CycleRequestTotal += req
+		s.CycleCostTotal += cost
+		s.CycleTotalTokens += totalTokens
 		if t, ok := parseStoredTimeString(updated.String); ok && t.After(s.UpdatedAt) {
 			s.UpdatedAt = t
 		}


### PR DESCRIPTION
## 现象

同一个 AI 账号（codex，`tyktgyk@gmail.com`）在同一分钟里：

| | 卡片 | 详情弹窗 |
|---|---|---|
| 本周期请求 | 19 | 436 |
| 本周期 Token | 4.8M | 65.8M |
| 计划徽标 | PRO | PRO 20X |

切换租户后看到的数字也各不相同，看起来像"数据没有跨租户共享"。

## 根因

不是租户隔离，是**同一个周期被切成了多个用量桶**。

`ai_account_subject_usage_buckets` 的 `cycle` 桶以 `cycle_start` 为桶键，而 `cycle_start = reset_at - window`；上游用「剩余秒数」报窗口，每次探测换算出的 `reset_at` 都差几秒，于是每次抖动都新开一个桶。

线上实测该账号当周的 cycle 桶：

```
2026-08-11T00:51:21Z  404 次  57,702,997 tokens  $52.57
2026-08-11T00:51:23Z  114 次  23,291,786 tokens  $16.79
2026-08-11T00:51:24Z    1 次     271,753 tokens  $0.16
```

读取时用「当前 cycle_start」精确匹配桶键，于是各读各的碎片：卡片走 `/ai-accounts/status`（无缓存）拿到最新碎片，详情走 `/usage/auth-file-trend`（60s 缓存）拿到稍早的碎片。切租户时因为请求时刻不同，同样表现为"不共享"。

计划徽标是同一根因的下游：20X 档位按 `cycle 费用 ÷ 周额度百分比` 推算周预算，碎片费用算出的预算掉回 PRO 档。截图里详情的 `$58.2555 ÷ 2% = $2912.77` 正好是它显示 PRO 20X 的原因。

## 改动

- **周期锚定（根治写入侧）**：容差内的 `cycle_start` 变化视为同一周期，保留已存锚点，只更新 `last_verified_at`。容差取窗口的千分之一（周窗口 ≈ 10 分钟），远大于真实抖动、远小于一次真实换周期。内存缓存改为缓存锚定后的值——投影的桶键取自该缓存，缓存了抖动值就会立刻把刚锚好的周期再切开。
- **读取容差**：按容差匹配并累加 cycle 桶，历史碎片不再只报其中一片。
- **迁移 `ai_account_subject_cycle_bucket_merge_v1`**：把已经碎掉的桶折叠到各周期最早的锚点，并把仍指向碎片的 `ai_account_subject_quota_cycles` 行重新对齐（否则下次读取会扑空报 0）。分组时每个桶与组锚点比较而不是与前一个桶比较，避免一串小漂移把两个真实周期连成一片。
- **统一 weekly quota key**：`aiaccountstatus` / `usagelogs` / `usage` 三份各自维护的 provider → weekly key 表，收敛到 `usage.PrimaryWeeklyQuotaKeys`。三份副本正是让读取方锚到不同周期的温床。

## 验证

本地 `./scripts/ci-pr.sh` 全绿（结构检查、gofmt、secret scan、go vet、`go test ./...`、golangci-lint、go build）。

新增用例：探测抖动只保留一个桶且总量完整、真实换周期仍正常滚动、碎片合并后总量为各片之和且 `quota_cycles` 被重新对齐、两个真实周期不会被合并、迁移可重入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)