### PR TITLE
fix(usage): 迁移后清空周期缓存并放宽漂移容差

### DIFF
--- a/internal/usage/ai_account_subject_cycle_merge.go
+++ b/internal/usage/ai_account_subject_cycle_merge.go
@@ -8,7 +8,9 @@ import (
 	"time"
 )
 
-const aiAccountSubjectCycleBucketMergeMarker = "ai_account_subject_cycle_bucket_merge_v1"
+// v2 re-runs the merge with the widened drift tolerance and, unlike v1, drops the
+// in-memory cycle cache afterwards.
+const aiAccountSubjectCycleBucketMergeMarker = "ai_account_subject_cycle_bucket_merge_v2"
 
 type aiAccountSubjectCycleBucketRow struct {
 	subjectID  string
@@ -83,6 +85,12 @@ func runAIAccountSubjectCycleBucketMergeDB(db *sql.DB) error {
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("usage: commit shared subject cycle merge: %w", err)
 	}
+	// The projection keys its buckets off this cache, and a probe that ran before
+	// the merge left it holding a start that no longer has a bucket. Production
+	// showed exactly that: minutes after the merge a fresh fragment appeared at the
+	// pre-merge start. Dropping the cache forces the next write to re-read the
+	// realigned anchor.
+	resetAIAccountSubjectCycleCache()
 	return nil
 }
 

--- a/internal/usage/ai_account_subject_cycle_merge_test.go
+++ b/internal/usage/ai_account_subject_cycle_merge_test.go
@@ -225,6 +225,115 @@ func TestCycleBucketMergeKeepsDistinctPeriodsApart(t *testing.T) {
 	}
 }
 
+// A probe that ran before the merge leaves the in-memory cache pointing at a
+// start the merge just dropped; the projection would then re-open that fragment.
+func TestCycleBucketMergeDropsStaleCycleCache(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "cache", "acct-cache", "cache-merge@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	anchor := now.Add(-24 * time.Hour)
+	stray := anchor.Add(3 * time.Second)
+	for _, at := range []time.Time{anchor, stray} {
+		if _, err := getDB().Exec(`
+			INSERT INTO ai_account_subject_usage_buckets (
+				auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+				failure_count, cost_total, total_tokens, first_event_at, updated_at
+			) VALUES (?, 'cycle', ?, 5, 5, 0, 1, 50, ?, ?)
+		`, identity.ID, formatAIAccountSubjectCycleBucketStart(at),
+			at.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'codex', 'code_week', ?, ?, 604800, ?)
+	`, identity.ID, stray.Format(time.RFC3339Nano),
+		stray.Add(7*24*time.Hour).Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	// Seed the cache the way a pre-merge probe would have.
+	setAIAccountSubjectActiveCycle(AIAccountSubjectQuotaCycle{
+		AuthSubjectID: identity.ID, Provider: "codex", QuotaKey: "code_week",
+		CycleStartAt: stray, ResetAt: stray.Add(7 * 24 * time.Hour),
+		WindowSeconds: 604800, LastVerifiedAt: now,
+	})
+
+	if err := runAIAccountSubjectCycleBucketMergeDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := getDB().Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := projectAIAccountSubjectUsageTx(tx, identity.ID, false, 1, 10, now); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buckets int
+	if err := getDB().QueryRow(`
+		SELECT COUNT(*) FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, identity.ID).Scan(&buckets); err != nil {
+		t.Fatal(err)
+	}
+	if buckets != 1 {
+		t.Fatalf("cycle buckets after post-merge write = %d, want 1", buckets)
+	}
+}
+
+// Production carried a weekly start that a single odd probe moved by 20 minutes,
+// stranding its own fragment. That is drift, not a new week.
+func TestCycleBucketMergeFoldsMinuteScaleDrift(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "drift20", "acct-drift20", "drift20@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	anchor := now.Add(-24 * time.Hour)
+	for _, at := range []time.Time{anchor, anchor.Add(20 * time.Minute)} {
+		if _, err := getDB().Exec(`
+			INSERT INTO ai_account_subject_usage_buckets (
+				auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+				failure_count, cost_total, total_tokens, first_event_at, updated_at
+			) VALUES (?, 'cycle', ?, 7, 7, 0, 1, 70, ?, ?)
+		`, identity.ID, formatAIAccountSubjectCycleBucketStart(at),
+			at.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := runAIAccountSubjectCycleBucketMergeDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	var buckets int
+	var requests int64
+	if err := getDB().QueryRow(`
+		SELECT COUNT(*), COALESCE(SUM(request_count), 0)
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, identity.ID).Scan(&buckets, &requests); err != nil {
+		t.Fatal(err)
+	}
+	if buckets != 1 || requests != 14 {
+		t.Fatalf("buckets=%d requests=%d, want 1/14", buckets, requests)
+	}
+}
+
 func TestCycleBucketMergeRunsOncePerMarker(t *testing.T) {
 	initSharedSubjectTestDB(t)
 	if err := runAIAccountSubjectCycleBucketMergeDB(getDB()); err != nil {

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -69,21 +69,25 @@ func PrimaryWeeklyQuotaKeys(provider string) []string {
 // move and still count as the same cycle.
 //
 // Upstreams report the window as a remaining-seconds countdown, so reset_at (and
-// with it cycle_start = reset_at - window) lands a few seconds apart on every
-// probe. Treating those as distinct cycles is what split one weekly period into
-// several usage buckets, leaving each reader to see whichever fragment matched
-// the timestamp it happened to read. The tolerance is three orders of magnitude
-// below the window, far above real jitter and far below a genuine rollover.
+// with it cycle_start = reset_at - window) lands apart on every probe. Treating
+// those as distinct cycles is what split one weekly period into several usage
+// buckets, leaving each reader to see whichever fragment matched the timestamp it
+// happened to read.
+//
+// One percent of the window: production showed drift is not always seconds — a
+// single odd probe moved a weekly start by 20 minutes and stranded its own
+// fragment — while a genuine rollover moves the start by a full window, a hundred
+// times the tolerance. Anything in between does not occur.
 func aiAccountSubjectCycleDriftTolerance(windowSeconds int64) time.Duration {
 	if windowSeconds <= 0 {
 		return time.Minute
 	}
-	tolerance := time.Duration(windowSeconds) * time.Second / 1000
+	tolerance := time.Duration(windowSeconds) * time.Second / 100
 	if tolerance < time.Minute {
 		tolerance = time.Minute
 	}
-	if tolerance > 30*time.Minute {
-		tolerance = 30 * time.Minute
+	if tolerance > 2*time.Hour {
+		tolerance = 2 * time.Hour
 	}
 	return tolerance
 }


### PR DESCRIPTION
## 背景

#875 部署后到线上复查数据，锚定和合并都生效了（08-08 那周的 5135/782/344/44 四个碎片正确合并成 6305），但有两处没堵死。

## 缺口一：迁移没清内存缓存

用量投影的桶键取自 `sharedCycleCache`。进程启动瞬间的探测会把**合并前**的 `cycle_start` 写进缓存，而迁移只改了库，于是合并完几分钟，那个已被删掉的碎片又长了回来：

```
2026-08-11T00:51:23Z   9 次   ← 迁移后新长出来的
2026-08-11T00:51:21Z 569 次   ← 合并锚点
```

迁移提交后清空缓存，下一次写入会重新从库里读对齐后的锚点。

## 缺口二：容差太窄

原本取窗口的千分之一（周窗口 ≈ 10 分钟）。线上有一次异常探测把周期起点挪了 **19 分 54 秒**，超出容差，它的碎片（14 次请求）没能并进来：

```
2026-08-11T00:31:27Z  14 次   ← 落单
2026-08-11T00:51:21Z 569 次
```

改成窗口的 1%（周窗口 ≈ 1.7 小时）。真实换周期偏移的是整整一个窗口——容差的一百倍，中间不存在灰区，所以放宽不会误合相邻周期。

marker 升到 `_v2`，让已经跑过 v1 的实例用新容差重跑一次，把残留碎片收干净。

## 验证

本地 `./scripts/ci-pr.sh` 全绿。新增两条用例：迁移后立即写入不再新开桶；20 分钟级漂移会被折叠成一个周期。原有「两个真实周期不会被合并」的用例在新容差下依然通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)