### PR TITLE
feat(ip-access): alerting, retention, bulk edits, export and portal history

### DIFF
--- a/internal/api/handlers/management/ip_access_bulk.go
+++ b/internal/api/handlers/management/ip_access_bulk.go
@@ -1,0 +1,89 @@
+package management
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/ipaccess"
+)
+
+// maxBulkRuleIDs caps one bulk request. Operators select from a page, so this is
+// far above any real selection while keeping a single request bounded.
+const maxBulkRuleIDs = 200
+
+// PatchIPAccessRulesBulk applies one change to many rules.
+//
+// It exists because the realistic cleanup after an attack is "disable these
+// fourteen automatic bans", and doing that one request at a time is both slow
+// and partially-applied when something fails halfway.
+func (h *Handler) PatchIPAccessRulesBulk(c *gin.Context) {
+	registry := ipaccess.Default()
+	if registry == nil {
+		ipAccessUnavailable(c)
+		return
+	}
+	var body struct {
+		IDs       []string `json:"ids"`
+		Enabled   *bool    `json:"enabled"`
+		Delete    bool     `json:"delete"`
+		ExpiresAt *string  `json:"expires_at"`
+		Note      *string  `json:"note"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		ipAccessBadRequest(c, err)
+		return
+	}
+	if len(body.IDs) == 0 {
+		ipAccessBadRequest(c, errors.New("no rule ids supplied"))
+		return
+	}
+	if len(body.IDs) > maxBulkRuleIDs {
+		ipAccessBadRequest(c, errors.New("too many rule ids in one request"))
+		return
+	}
+
+	input := ipaccess.UpdateInput{Enabled: body.Enabled, Note: body.Note}
+	if body.ExpiresAt != nil {
+		if strings.TrimSpace(*body.ExpiresAt) == "" {
+			input.ClearExpires = true
+		} else {
+			expires, err := time.Parse(time.RFC3339, *body.ExpiresAt)
+			if err != nil {
+				ipAccessBadRequest(c, err)
+				return
+			}
+			pointer := &expires
+			input.ExpiresAt = &pointer
+		}
+	}
+
+	// Per-id outcomes rather than one all-or-nothing status: a rule another
+	// operator just deleted should not fail the other thirteen, and the caller
+	// still needs to know which ones did not apply.
+	applied := make([]string, 0, len(body.IDs))
+	failed := make(map[string]string)
+	for _, id := range body.IDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		var err error
+		if body.Delete {
+			err = registry.Store().Delete(c.Request.Context(), id)
+		} else {
+			_, err = registry.Store().Update(c.Request.Context(), id, input)
+		}
+		if err != nil {
+			failed[id] = err.Error()
+			continue
+		}
+		applied = append(applied, id)
+	}
+	if len(applied) > 0 {
+		_ = registry.Refresh(c.Request.Context())
+	}
+	c.JSON(http.StatusOK, gin.H{"applied": applied, "failed": failed})
+}

--- a/internal/api/handlers/management/ip_access_export.go
+++ b/internal/api/handlers/management/ip_access_export.go
@@ -1,0 +1,107 @@
+package management
+
+import (
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
+)
+
+// exportPageSize is the database page size used while streaming. Large enough to
+// keep the query count sane, small enough that one page never sits in memory as
+// a meaningful cost.
+const exportPageSize = 500
+
+// maxExportRows bounds one export. An unbounded export over an attack window is
+// a way to make the server build a hundred-megabyte response for a single click.
+const maxExportRows = 50000
+
+// GetAuthAttemptsExport streams matching attempts as CSV.
+//
+// Streaming rather than building the file in memory: the rows worth exporting
+// are exactly the ones produced during an attack, which is when the process can
+// least afford to buffer all of them.
+func (h *Handler) GetAuthAttemptsExport(c *gin.Context) {
+	recorder := authevents.Default()
+	if recorder == nil || !recorder.Available() {
+		authEventsUnavailable(c)
+		return
+	}
+	filter := authevents.ListFilter{
+		IPPrefix: strings.TrimSpace(c.Query("ip")),
+		Username: strings.TrimSpace(c.Query("username")),
+		Outcome:  strings.TrimSpace(c.Query("outcome")),
+		Surface:  strings.TrimSpace(c.Query("surface")),
+		Size:     exportPageSize,
+	}
+	if window, ok := summaryWindows[strings.TrimSpace(c.Query("window"))]; ok {
+		filter.Since = time.Now().Add(-window)
+	}
+
+	filename := fmt.Sprintf("auth-attempts-%s.csv", time.Now().Format("20060102-150405"))
+	c.Header("Content-Type", "text/csv; charset=utf-8")
+	c.Header("Content-Disposition", `attachment; filename="`+filename+`"`)
+
+	writer := csv.NewWriter(c.Writer)
+	// A BOM so Excel opens UTF-8 correctly; without it Chinese reasons and
+	// usernames arrive as mojibake, which is the main way this file gets read.
+	_, _ = c.Writer.Write([]byte{0xEF, 0xBB, 0xBF})
+	if err := writer.Write([]string{
+		"occurred_at", "ip", "ip_prefix", "trusted", "scope", "surface",
+		"username", "outcome", "reason", "user_agent", "request_path", "request_id",
+	}); err != nil {
+		return
+	}
+
+	written := 0
+	for page := 1; written < maxExportRows; page++ {
+		filter.Page = page
+		events, total, err := recorder.List(c.Request.Context(), filter)
+		if err != nil {
+			// Headers are already sent, so the only honest signal left is to stop
+			// writing; the partial file ends at the last complete row.
+			writer.Flush()
+			return
+		}
+		if len(events) == 0 {
+			break
+		}
+		for i := range events {
+			event := events[i]
+			if err = writer.Write([]string{
+				event.OccurredAt.Format(time.RFC3339),
+				event.IP,
+				event.IPPrefix,
+				strconv.FormatBool(event.Trusted),
+				event.Scope,
+				event.Surface,
+				event.Username,
+				event.Outcome,
+				event.Reason,
+				event.UserAgent,
+				event.RequestPath,
+				event.RequestID,
+			}); err != nil {
+				writer.Flush()
+				return
+			}
+			written++
+			if written >= maxExportRows {
+				break
+			}
+		}
+		writer.Flush()
+		if c.Writer.Status() >= http.StatusBadRequest {
+			return
+		}
+		if page*filter.Size >= total {
+			break
+		}
+	}
+	writer.Flush()
+}

--- a/internal/api/handlers/management/portal_auth_attempts.go
+++ b/internal/api/handlers/management/portal_auth_attempts.go
@@ -1,0 +1,99 @@
+package management
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/authevents"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
+)
+
+// portalAttemptWindow bounds what an end user can look back over. They are
+// answering "was this me?", which is a recent-history question; a longer window
+// only widens what one compromised portal session can enumerate.
+const portalAttemptWindow = 30 * 24 * time.Hour
+
+// maxPortalAttemptSize caps one page for the portal.
+const maxPortalAttemptSize = 50
+
+// GetPortalAuthAttempts returns the caller's own sign-in history.
+//
+// The customer-facing half of the attempt log: when an end user asks "why is my
+// quota gone" or "was that login me", the answer should not require them to
+// open a support ticket and an operator to run a query.
+//
+// The username filter is taken from the authenticated session and never from the
+// request, so a portal session cannot read anyone else's history.
+func (h *Handler) GetPortalAuthAttempts(c *gin.Context) {
+	user, _, ok := h.authenticatePortal(c)
+	if !ok {
+		return
+	}
+	recorder := authevents.Default()
+	if recorder == nil || !recorder.Available() {
+		authEventsUnavailable(c)
+		return
+	}
+
+	size, _ := strconv.Atoi(c.DefaultQuery("size", "20"))
+	if size < 1 || size > maxPortalAttemptSize {
+		size = 20
+	}
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	if page < 1 {
+		page = 1
+	}
+
+	events, total, err := recorder.List(c.Request.Context(), authevents.ListFilter{
+		Username: enduser.NormalizeUsername(user.Username),
+		Surface:  authevents.SurfacePortalLogin,
+		Since:    time.Now().Add(-portalAttemptWindow),
+		Page:     page,
+		Size:     size,
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "list_failed", "message": err.Error()}})
+		return
+	}
+
+	// Deliberately reduced compared with the operator view: an end user needs to
+	// recognise their own sessions, not to receive a reconnaissance feed. Scope,
+	// request id and the trust flag are operator diagnostics and stay out.
+	items := make([]gin.H, 0, len(events))
+	for i := range events {
+		items = append(items, gin.H{
+			"occurred_at": events[i].OccurredAt,
+			"ip":          maskPortalIP(events[i].IP),
+			"outcome":     events[i].Outcome,
+			"user_agent":  events[i].UserAgent,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"items": items, "total": total, "page": page, "size": size})
+}
+
+// maskPortalIP hides the final octet of an address shown to an end user.
+//
+// Enough to recognise "that was my office" or "that was not me", without handing
+// a full address to whoever is holding a stolen portal session.
+func maskPortalIP(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.Contains(trimmed, ":") {
+		// IPv6: keep the routing prefix, drop the interface half.
+		parts := strings.Split(trimmed, ":")
+		if len(parts) > 4 {
+			return strings.Join(parts[:4], ":") + ":···"
+		}
+		return trimmed
+	}
+	parts := strings.Split(trimmed, ".")
+	if len(parts) != 4 {
+		return trimmed
+	}
+	return strings.Join(parts[:3], ".") + ".×"
+}

--- a/internal/api/handlers/management/portal_auth_attempts_test.go
+++ b/internal/api/handlers/management/portal_auth_attempts_test.go
@@ -1,0 +1,31 @@
+package management
+
+import "testing"
+
+func TestMaskPortalIPHidesTheHostPart(t *testing.T) {
+	// Enough for an end user to recognise "that was my office", not enough to
+	// hand a stolen portal session a usable address.
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"203.0.113.66", "203.0.113.×"},
+		{"10.0.0.1", "10.0.0.×"},
+		{"2001:db8:1:2:3:4:5:6", "2001:db8:1:2:···"},
+		{"", ""},
+		{"not-an-ip", "not-an-ip"},
+	}
+	for _, tc := range cases {
+		if got := maskPortalIP(tc.in); got != tc.want {
+			t.Errorf("maskPortalIP(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMaskPortalIPKeepsShortIPv6Intact(t *testing.T) {
+	// Too few groups to split meaningfully; returning it unchanged is better
+	// than emitting something that looks masked but is not.
+	if got := maskPortalIP("::1"); got != "::1" {
+		t.Errorf("got %q, want the input unchanged", got)
+	}
+}

--- a/internal/api/routes/management_identity_routes.go
+++ b/internal/api/routes/management_identity_routes.go
@@ -33,6 +33,7 @@ func registerIdentityAuthRoutes(engine *gin.Engine, h *managementhandlers.Handle
 	portal.POST("/auth/logout", h.PostPortalLogout)
 	portal.GET("/auth/me", h.GetPortalMe)
 	portal.PUT("/auth/password", h.PutPortalPassword)
+	portal.GET("/auth/attempts", h.GetPortalAuthAttempts)
 	portal.GET("/api-keys", h.GetPortalAPIKeys)
 	portal.POST("/api-keys", h.PostPortalAPIKey)
 	portal.GET("/api-keys/:id/secret", h.GetPortalAPIKeySecret)
@@ -94,6 +95,8 @@ func registerManagementIdentityRoutes(group *gin.RouterGroup, h *managementhandl
 	group.GET("/ip-access/status", h.GetIPAccessStatus)
 	group.GET("/ip-access/policy", h.GetIPAccessPolicy)
 	group.PUT("/ip-access/policy", h.PutIPAccessPolicy)
+	group.PATCH("/ip-access/rules", h.PatchIPAccessRulesBulk)
 	group.GET("/auth-attempts", h.GetAuthAttempts)
 	group.GET("/auth-attempts/summary", h.GetAuthAttemptSummary)
+	group.GET("/auth-attempts/export", h.GetAuthAttemptsExport)
 }

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 318; got != want {
+	if got, want := len(routes), 321; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -203,6 +203,7 @@ func expectedManagementRoutes() []string {
 		"POST /v0/portal/auth/login",
 		"POST /v0/portal/auth/logout",
 		"GET /v0/portal/auth/me",
+		"GET /v0/portal/auth/attempts",
 		"PUT /v0/portal/auth/password",
 		"POST /v0/portal/auth/refresh",
 		"GET /v0/management/menus",
@@ -252,8 +253,10 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/ip-access/status",
 		"GET /v0/management/ip-access/policy",
 		"PUT /v0/management/ip-access/policy",
+		"PATCH /v0/management/ip-access/rules",
 		"GET /v0/management/auth-attempts",
 		"GET /v0/management/auth-attempts/summary",
+		"GET /v0/management/auth-attempts/export",
 		"DELETE /v0/management/roles/:id",
 		"DELETE /v0/management/ampcode/model-mappings",
 		"DELETE /v0/management/ampcode/upstream-api-key",

--- a/internal/cmd/ip_access_bootstrap.go
+++ b/internal/cmd/ip_access_bootstrap.go
@@ -13,11 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// authEventRetention is how long authentication attempts are kept. Long enough
-// to investigate an incident reported a few weeks late, short enough that a
-// sustained attack cannot fill the disk.
-const authEventRetention = 30 * 24 * time.Hour
-
 // authEventPurgeInterval is how often the retention sweep runs.
 const authEventPurgeInterval = 6 * time.Hour
 
@@ -59,13 +54,15 @@ func initializeIPAccessControl(ctx context.Context, cfg *config.Config) {
 	// limits to management handlers, and the retention sweep needs a long-lived
 	// process to run in.
 	recorder := authevents.EnsureDefault(ctx, db)
-	startAuthEventRetention(ctx, recorder)
 
 	registry := ipaccess.EnsureDefault(ctx, db, trustedProxies)
 	registry.SetPolicyPersister(ctx, ipAccessPolicyStore{})
+	// Retention is read from the policy on each sweep rather than captured here,
+	// so changing it in the panel takes effect without a restart.
+	startAuthEventRetention(ctx, recorder, registry)
 }
 
-func startAuthEventRetention(ctx context.Context, recorder *authevents.Recorder) {
+func startAuthEventRetention(ctx context.Context, recorder *authevents.Recorder, registry *ipaccess.Registry) {
 	if recorder == nil || !recorder.Available() {
 		return
 	}
@@ -77,13 +74,17 @@ func startAuthEventRetention(ctx context.Context, recorder *authevents.Recorder)
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				removed, err := recorder.Purge(ctx, time.Now().Add(-authEventRetention))
+				retention := time.Duration(registry.Policy().AttemptRetentionDays) * 24 * time.Hour
+				if retention <= 0 {
+					retention = ipaccess.DefaultAttemptRetentionDays * 24 * time.Hour
+				}
+				removed, err := recorder.Purge(ctx, time.Now().Add(-retention))
 				if err != nil {
 					log.WithError(err).Debug("auth-events: retention sweep failed")
 					continue
 				}
 				if removed > 0 {
-					log.Debugf("auth-events: purged %d attempts older than %s", removed, authEventRetention)
+					log.Debugf("auth-events: purged %d attempts older than %s", removed, retention)
 				}
 			}
 		}

--- a/internal/ipaccess/alert.go
+++ b/internal/ipaccess/alert.go
@@ -1,0 +1,169 @@
+package ipaccess
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// AlertPolicy configures outbound notification for ban decisions.
+//
+// Without a channel the feature only writes rows an operator has to go and look
+// at, which is no help at 03:00 — the case the automatic ban exists for.
+type AlertPolicy struct {
+	// WebhookURL receives a JSON POST per alert. Empty disables alerting.
+	WebhookURL string `json:"webhook_url,omitempty"`
+	// NotifyObserve also sends alerts while auto-ban is in observe mode, so a
+	// threshold can be validated against real traffic before it is allowed to act.
+	NotifyObserve bool `json:"notify_observe"`
+	// CooldownMinutes suppresses repeats for the same source. Under attack the
+	// engine can decide about one source many times, and an alert channel that
+	// relays each one is a channel operators mute — which is worse than none.
+	CooldownMinutes int `json:"cooldown_minutes"`
+}
+
+const (
+	defaultAlertCooldownMinutes = 30
+	// alertTimeout bounds one delivery. Alerting must never become the slowest
+	// part of rejecting a request.
+	alertTimeout = 5 * time.Second
+	// maxTrackedAlertKeys bounds the dedup table; an attacker minting sources
+	// must not be able to grow it without limit.
+	maxTrackedAlertKeys = 4096
+)
+
+func (p AlertPolicy) normalized() AlertPolicy {
+	p.WebhookURL = strings.TrimSpace(p.WebhookURL)
+	if p.CooldownMinutes <= 0 {
+		p.CooldownMinutes = defaultAlertCooldownMinutes
+	}
+	return p
+}
+
+// Enabled reports whether alerts should be delivered at all.
+func (p AlertPolicy) Enabled() bool { return strings.TrimSpace(p.WebhookURL) != "" }
+
+// AlertEvent is the payload delivered to the webhook.
+type AlertEvent struct {
+	Event      string    `json:"event"`
+	CIDR       string    `json:"cidr"`
+	Failures   int       `json:"failures"`
+	Window     string    `json:"window"`
+	Reason     string    `json:"reason"`
+	Enforced   bool      `json:"enforced"`
+	ExpiresAt  string    `json:"expires_at,omitempty"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+// alerter delivers ban notifications with per-source cooldown.
+type alerter struct {
+	client *http.Client
+
+	mu   sync.Mutex
+	last map[string]time.Time
+}
+
+func newAlerter() *alerter {
+	return &alerter{
+		client: &http.Client{Timeout: alertTimeout},
+		last:   make(map[string]time.Time),
+	}
+}
+
+// shouldSend reports whether this source is outside its cooldown, and records
+// the send. Returns false when suppressed.
+func (a *alerter) shouldSend(key string, cooldown time.Duration, now time.Time) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if previous, ok := a.last[key]; ok && now.Sub(previous) < cooldown {
+		return false
+	}
+	if len(a.last) >= maxTrackedAlertKeys {
+		// Drop everything already outside its cooldown; entries still inside it
+		// are the ones actively suppressing noise and must be kept.
+		for existing, at := range a.last {
+			if now.Sub(at) >= cooldown {
+				delete(a.last, existing)
+			}
+		}
+		if len(a.last) >= maxTrackedAlertKeys {
+			return false
+		}
+	}
+	a.last[key] = now
+	return true
+}
+
+// deliver posts the event. Failures are logged and swallowed: an unreachable
+// webhook must never turn into a failed ban or a slow request.
+func (a *alerter) deliver(ctx context.Context, url string, event AlertEvent) {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		log.WithError(err).Warn("ip-access: alert webhook URL is not usable")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		log.WithError(err).Warn("ip-access: alert delivery failed")
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		log.Warnf("ip-access: alert webhook returned %d", resp.StatusCode)
+	}
+}
+
+// notifyBan sends an alert for a ban decision, honouring mode and cooldown.
+func (r *Registry) notifyBan(outcome AutoBanOutcome, reason string) {
+	if r == nil || !outcome.Triggered {
+		return
+	}
+	policy := r.Policy()
+	alert := policy.Alert.normalized()
+	if !alert.Enabled() {
+		return
+	}
+	// In observe mode nothing was blocked, so alerting is opt-in: an operator
+	// validating a threshold wants to see it, one who already trusts it does not.
+	if !outcome.Enforced && !alert.NotifyObserve {
+		return
+	}
+	now := time.Now()
+	if !r.alerter.shouldSend(outcome.CIDR, time.Duration(alert.CooldownMinutes)*time.Minute, now) {
+		return
+	}
+
+	event := AlertEvent{
+		Event:      "ip_access.auto_ban",
+		CIDR:       outcome.CIDR,
+		Failures:   outcome.Failures,
+		Window:     policy.AutoBan.Window().String(),
+		Reason:     reason,
+		Enforced:   outcome.Enforced,
+		OccurredAt: now,
+	}
+	if !outcome.Until.IsZero() {
+		event.ExpiresAt = outcome.Until.Format(time.RFC3339)
+	}
+	if !outcome.Enforced {
+		event.Event = "ip_access.auto_ban_observed"
+	}
+	// Delivery is detached from the request that triggered it: the client being
+	// rejected is often the one that disconnects, and an alert must not die with it.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), alertTimeout)
+		defer cancel()
+		r.alerter.deliver(ctx, alert.WebhookURL, event)
+	}()
+}

--- a/internal/ipaccess/alert_test.go
+++ b/internal/ipaccess/alert_test.go
@@ -1,0 +1,177 @@
+package ipaccess
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAlertCooldownSuppressesRepeatsPerSource(t *testing.T) {
+	// Under attack the engine decides about one source many times. A channel that
+	// relays every decision is a channel operators mute, which is worse than none.
+	a := newAlerter()
+	now := time.Now()
+	cooldown := 30 * time.Minute
+
+	if !a.shouldSend("1.2.3.4/32", cooldown, now) {
+		t.Fatal("first alert for a source must be delivered")
+	}
+	if a.shouldSend("1.2.3.4/32", cooldown, now.Add(29*time.Minute)) {
+		t.Error("repeat inside the cooldown was not suppressed")
+	}
+	// A different source is unrelated and must not be suppressed by the first.
+	if !a.shouldSend("5.6.7.8/32", cooldown, now.Add(time.Minute)) {
+		t.Error("a different source was suppressed by another source's cooldown")
+	}
+	if !a.shouldSend("1.2.3.4/32", cooldown, now.Add(31*time.Minute)) {
+		t.Error("alert after the cooldown expired was suppressed")
+	}
+}
+
+func TestAlertDedupTableStaysBounded(t *testing.T) {
+	// An attacker minting sources must not be able to grow this table without
+	// limit just by failing logins from new addresses.
+	a := newAlerter()
+	now := time.Now()
+	cooldown := time.Hour
+	for i := 0; i < maxTrackedAlertKeys+500; i++ {
+		a.shouldSend(string(rune(i%128))+"-"+time.Duration(i).String(), cooldown, now)
+	}
+	a.mu.Lock()
+	size := len(a.last)
+	a.mu.Unlock()
+	if size > maxTrackedAlertKeys {
+		t.Errorf("dedup table grew to %d, cap is %d", size, maxTrackedAlertKeys)
+	}
+}
+
+func TestNotifyBanSkipsObserveUnlessOptedIn(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		received []AlertEvent
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event AlertEvent
+		_ = json.NewDecoder(r.Body).Decode(&event)
+		mu.Lock()
+		received = append(received, event)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	registry := NewRegistry(NewStore(nil))
+	policy := DefaultPolicy()
+	policy.Alert = AlertPolicy{WebhookURL: server.URL, CooldownMinutes: 30}
+	registry.SetPolicy(context.Background(), policy)
+
+	// Observe-mode decision: nothing was blocked, so it is opt-in.
+	registry.notifyBan(AutoBanOutcome{Triggered: true, Enforced: false, CIDR: "1.2.3.4/32"}, "test")
+	time.Sleep(150 * time.Millisecond)
+	mu.Lock()
+	countAfterObserve := len(received)
+	mu.Unlock()
+	if countAfterObserve != 0 {
+		t.Fatalf("observe-mode decision delivered %d alerts without opting in", countAfterObserve)
+	}
+
+	// An enforced ban always alerts.
+	registry.notifyBan(AutoBanOutcome{Triggered: true, Enforced: true, CIDR: "5.6.7.8/32"}, "test")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := len(received)
+		mu.Unlock()
+		if got == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("enforced ban delivered %d alerts, want 1", len(received))
+	}
+	if received[0].Event != "ip_access.auto_ban" || received[0].CIDR != "5.6.7.8/32" {
+		t.Errorf("unexpected payload: %+v", received[0])
+	}
+}
+
+func TestNotifyBanOptsIntoObserveAlerts(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		received []AlertEvent
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event AlertEvent
+		_ = json.NewDecoder(r.Body).Decode(&event)
+		mu.Lock()
+		received = append(received, event)
+		mu.Unlock()
+	}))
+	defer server.Close()
+
+	registry := NewRegistry(NewStore(nil))
+	policy := DefaultPolicy()
+	policy.Alert = AlertPolicy{WebhookURL: server.URL, NotifyObserve: true, CooldownMinutes: 30}
+	registry.SetPolicy(context.Background(), policy)
+
+	registry.notifyBan(AutoBanOutcome{Triggered: true, Enforced: false, CIDR: "1.2.3.4/32"}, "test")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := len(received)
+		mu.Unlock()
+		if got == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("got %d alerts, want 1 once observe alerts are opted into", len(received))
+	}
+	// Observe alerts are labelled differently so a rule can route them elsewhere.
+	if received[0].Event != "ip_access.auto_ban_observed" {
+		t.Errorf("event = %q, want the observed variant", received[0].Event)
+	}
+}
+
+func TestNotifyBanIsANoOpWithoutWebhook(t *testing.T) {
+	registry := NewRegistry(NewStore(nil))
+	// Must not panic or block when no channel is configured.
+	registry.notifyBan(AutoBanOutcome{Triggered: true, Enforced: true, CIDR: "1.2.3.4/32"}, "test")
+}
+
+func TestUnreachableWebhookDoesNotBlockTheDecision(t *testing.T) {
+	// Alerting must never become the slowest part of rejecting a request.
+	registry := NewRegistry(NewStore(nil))
+	policy := DefaultPolicy()
+	policy.Alert = AlertPolicy{WebhookURL: "http://127.0.0.1:1/unreachable", CooldownMinutes: 1}
+	registry.SetPolicy(context.Background(), policy)
+
+	start := time.Now()
+	registry.notifyBan(AutoBanOutcome{Triggered: true, Enforced: true, CIDR: "1.2.3.4/32"}, "test")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("notifyBan blocked for %s; delivery must be detached", elapsed)
+	}
+}
+
+func TestAttemptRetentionIsClampedNotTrusted(t *testing.T) {
+	// The attempt table grows with attack volume, so unbounded retention is a
+	// disk-exhaustion path an attacker controls.
+	if got := (ProtectionPolicy{AttemptRetentionDays: 0}).Normalized().AttemptRetentionDays; got != DefaultAttemptRetentionDays {
+		t.Errorf("zero retention = %d, want the default %d", got, DefaultAttemptRetentionDays)
+	}
+	if got := (ProtectionPolicy{AttemptRetentionDays: 99999}).Normalized().AttemptRetentionDays; got != maxAttemptRetentionDays {
+		t.Errorf("oversized retention = %d, want the cap %d", got, maxAttemptRetentionDays)
+	}
+	if got := (ProtectionPolicy{AttemptRetentionDays: 7}).Normalized().AttemptRetentionDays; got != 7 {
+		t.Errorf("valid retention = %d, want it preserved", got)
+	}
+}

--- a/internal/ipaccess/autoban.go
+++ b/internal/ipaccess/autoban.go
@@ -121,6 +121,7 @@ func (e *autoBanEngine) RecordFailure(ctx context.Context, addr ClientAddress, r
 		e.markBanned(cidr, outcome.Until, now)
 		log.Warnf("ip-access: auto-ban would trigger for %s (%d failures in %s, %s) — observe mode, no rule written",
 			cidr, failures, policy.Window(), reason)
+		e.registry.notifyBan(outcome, reason)
 		return outcome
 	}
 
@@ -142,6 +143,7 @@ func (e *autoBanEngine) RecordFailure(ctx context.Context, addr ClientAddress, r
 	if err = e.registry.Refresh(ctx); err != nil {
 		log.WithError(err).Debug("ip-access: refresh after auto-ban failed")
 	}
+	e.registry.notifyBan(outcome, reason)
 	return outcome
 }
 

--- a/internal/ipaccess/policy.go
+++ b/internal/ipaccess/policy.go
@@ -68,10 +68,24 @@ type ProtectionPolicy struct {
 	// config.yaml's trusted-proxies still applies when this is empty, so existing
 	// deployments keep working and nothing silently changes under them.
 	TrustedProxies []string `json:"trusted_proxies,omitempty"`
+	// Alert configures outbound notification for ban decisions.
+	Alert AlertPolicy `json:"alert"`
+	// AttemptRetentionDays bounds how long authentication attempts are kept.
+	// Zero uses the shipped default.
+	AttemptRetentionDays int `json:"attempt_retention_days"`
 }
 
 // SettingKey is the runtime-settings document key for ProtectionPolicy.
 const SettingKey = "ip-access-protection-policy"
+
+// DefaultAttemptRetentionDays is long enough to investigate an incident reported
+// a few weeks late, short enough that a sustained attack cannot fill the disk.
+const DefaultAttemptRetentionDays = 30
+
+// maxAttemptRetentionDays caps operator input. The attempt table grows with
+// attack volume, not with legitimate traffic, so unbounded retention is a
+// disk-exhaustion path an attacker controls.
+const maxAttemptRetentionDays = 365
 
 const (
 	defaultAutoBanWindowSeconds = 600
@@ -92,6 +106,8 @@ func DefaultPolicy() ProtectionPolicy {
 			BanMinutes:       defaultAutoBanMinutes,
 			MaxBanMinutes:    defaultAutoBanMaxMinutes,
 		},
+		Alert:                AlertPolicy{CooldownMinutes: defaultAlertCooldownMinutes},
+		AttemptRetentionDays: DefaultAttemptRetentionDays,
 	}
 }
 
@@ -149,6 +165,13 @@ func (p ProtectionPolicy) Normalized() ProtectionPolicy {
 		cleaned = append(cleaned, normalized)
 	}
 	p.TrustedProxies = cleaned
+	p.Alert = p.Alert.normalized()
+	if p.AttemptRetentionDays <= 0 {
+		p.AttemptRetentionDays = DefaultAttemptRetentionDays
+	}
+	if p.AttemptRetentionDays > maxAttemptRetentionDays {
+		p.AttemptRetentionDays = maxAttemptRetentionDays
+	}
 	return p
 }
 

--- a/internal/ipaccess/registry.go
+++ b/internal/ipaccess/registry.go
@@ -77,6 +77,7 @@ type Registry struct {
 	stopOnce sync.Once
 
 	autoBan *autoBanEngine
+	alerter *alerter
 }
 
 // NewRegistry builds a registry over the given store. The snapshot starts empty,
@@ -88,6 +89,7 @@ func NewRegistry(store *Store) *Registry {
 	r.policy.Store(&policy)
 	r.matcher.Store(NewMatcher(nil, false, time.Now()))
 	r.autoBan = newAutoBanEngine(r)
+	r.alerter = newAlerter()
 	return r
 }
 


### PR DESCRIPTION
## 起因

盘点后发现 11 项缺口：4 项后端有能力前端够不着、2 项方案里写了没做、5 项业务上该有。本 PR 是后端部分。

## 改动

**告警。** 自动封禁只写一行日志，半夜发生就等于没发生——而那正是它存在的场景。现在封禁决策会 POST 到 webhook，有两个刻意的约束：

- **按来源静默期**：被攻击时引擎会对同一个来源反复决策，逐条转发的告警渠道会被运维静音，那比没有告警更糟
- **投递与请求解耦**：被拒绝的客户端往往就是断开连接的那个，告警不能跟着它一起死

观察模式的决策默认不通知（可开启），并且用不同的 event 名，方便在验证阈值期间路由到别处。

**保留期**进入策略文档，每次清理时读取而非启动时固化，上限 365 天——尝试记录随攻击量增长而非正常流量，无上限保留是攻击者可控的磁盘耗尽路径。

**批量操作**返回逐条结果而不是一个整体状态：被别人刚删掉的一条规则不该让另外十三条失败，同时调用方仍需知道哪些没生效。

**导出**逐页流式输出而非内存拼装——值得导出的行恰恰是攻击期间产生的，那时进程最没有余力缓冲它们——并且有行数上限，避免一次点击让服务端构造无界响应。

**门户历史**让终端用户能自己回答"那次登录是不是我"，不必开工单。账号从会话推导、绝不取自请求，所以一个门户会话读不到别人的记录；地址做了脱敏：够认出"那是我公司"，不够给一个被盗会话提供侦察信息。

## 验证

- 完整 `./scripts/ci-pr.sh` 退出码 0，零失败
- **真实 Postgres 路由冒烟通过**，含新增的批量/导出/门户三条路由
- 新增单测：告警静默期、去重表有界、观察模式默认不发、opt-in 后发送且事件名不同、webhook 不可达不阻塞决策、保留期上下限钳制、门户地址脱敏

🤖 Generated with [Claude Code](https://claude.com/claude-code)