### PR TITLE
fix(ip-access): a relayed chain ending on loopback is unresolved, not local

### DIFF
--- a/internal/api/handlers/management/ip_access.go
+++ b/internal/api/handlers/management/ip_access.go
@@ -262,17 +262,28 @@ func (h *Handler) GetIPAccessStatus(c *gin.Context) {
 		// (config.yaml fallback) or "none". The panel needs it to explain why an
 		// edit here may not be what is in force.
 		"trusted_proxies_source": proxySource,
-		"enforced":               address.Trusted || address.Loopback(),
-		"lockdown":               policy.Lockdown,
-		"active_rules":           matcher.Count(),
-		"storage_available":      registry.Store().Available(),
-		"auto_ban_mode":          policy.AutoBan.Mode,
+		// Diagnostics: an operator cannot declare the right proxies without
+		// seeing what the chain actually contains. Guessing produced a
+		// half-configured chain that resolved to loopback and quietly exempted
+		// every external client.
+		"peer":              address.Peer,
+		"forwarded_chain":   address.Chain,
+		"direct_peer":       address.DirectPeer,
+		"enforced":          address.Trusted || address.Loopback(),
+		"lockdown":          policy.Lockdown,
+		"active_rules":      matcher.Count(),
+		"storage_available": registry.Store().Available(),
+		"auto_ban_mode":     policy.AutoBan.Mode,
 	}
-	if !address.Trusted && address.Raw != "" {
-		// The address the panel should add as a trusted proxy to fix this. It is
-		// applied through the policy endpoint, so the remedy is a button rather
-		// than a file edit and a restart.
-		response["suggested_trusted_proxies"] = []string{address.Raw + "/32"}
+	if !address.Trusted {
+		// Suggest the hop the chain actually stopped at: that is the one still to
+		// be declared. With a multi-hop chain this converges one hop per click,
+		// and the diagnostics above show how many remain.
+		if candidate := address.Raw; candidate != "" {
+			response["suggested_trusted_proxies"] = []string{candidate + "/32"}
+		} else if address.Peer != "" {
+			response["suggested_trusted_proxies"] = []string{address.Peer + "/32"}
+		}
 	}
 	if recorder := authevents.Default(); recorder != nil {
 		response["dropped_events"] = recorder.Dropped()

--- a/internal/ipaccess/autoban.go
+++ b/internal/ipaccess/autoban.go
@@ -90,7 +90,14 @@ func (e *autoBanEngine) RecordFailure(ctx context.Context, addr ClientAddress, r
 		return AutoBanOutcome{}
 	}
 	// An untrusted address is the proxy's, so banning it would take down every
-	// client behind it. A loopback source is the operator's own channel.
+	// client behind it.
+	//
+	// Loopback is skipped here in its broad sense — any loopback result, not just
+	// a genuine local operator — because the two directions fail asymmetrically.
+	// Admission uses the strict LocalOperator test: wrongly exempting a chain that
+	// merely dead-ends on loopback lets everyone past. Banning uses the broad test:
+	// a deny rule on a loopback address that a half-configured chain resolves to
+	// would block every external request at once. Each side takes the safer error.
 	if !addr.Trusted || addr.Loopback() || addr.IP == nil {
 		return AutoBanOutcome{}
 	}

--- a/internal/ipaccess/forwarded.go
+++ b/internal/ipaccess/forwarded.go
@@ -74,10 +74,12 @@ func resolveForwarded(req *http.Request, matcher *trustedProxyMatcher) ClientAdd
 		return addr
 	}
 	addr.RelayHeader = firstForwardedHeader(req)
+	addr.Chain = collectForwardedChain(req)
+	addr.DirectPeer = addr.RelayHeader == ""
 
 	peerText := hostOnly(req.RemoteAddr)
 	peer := net.ParseIP(peerText)
-	addr.Raw, addr.IP = peerText, peer
+	addr.Peer, addr.Raw, addr.IP = peerText, peerText, peer
 
 	if peer == nil {
 		return addr
@@ -107,12 +109,39 @@ func resolveForwarded(req *http.Request, matcher *trustedProxyMatcher) ClientAdd
 			if matcher.trusts(ip) {
 				continue
 			}
-			return ClientAddress{IP: ip, Raw: ip.String(), Trusted: true, RelayHeader: addr.RelayHeader}
+			resolved := ClientAddress{
+				Peer:        addr.Peer,
+				Chain:       addr.Chain,
+				IP:          ip,
+				Raw:         ip.String(),
+				Trusted:     true,
+				RelayHeader: addr.RelayHeader,
+			}
+			// A relayed chain that dead-ends on a loopback address has not been
+			// resolved: some hop in front of us is talking to the next over
+			// loopback and was never declared. Trusting it would hand every
+			// external client the local-operator exemption, which is exactly the
+			// "everyone is localhost" failure this guard exists to prevent.
+			if ip.IsLoopback() {
+				resolved.Trusted = false
+			}
+			return resolved
 		}
 	}
 	// Every hop was a trusted proxy: the real client never made it into the
 	// header, so nothing here identifies one.
 	return addr
+}
+
+// collectForwardedChain returns every hop seen across the forwarding headers,
+// left to right, purely for diagnostics. Operators cannot declare the right
+// proxies without being able to see what the chain actually contains.
+func collectForwardedChain(req *http.Request) []string {
+	var chain []string
+	for _, header := range forwardedHeaders {
+		chain = append(chain, parseForwardedHeader(req, header)...)
+	}
+	return chain
 }
 
 func firstForwardedHeader(req *http.Request) string {

--- a/internal/ipaccess/matcher_test.go
+++ b/internal/ipaccess/matcher_test.go
@@ -324,3 +324,91 @@ func TestRegistryPrefersStoredProxiesOverConfig(t *testing.T) {
 		t.Errorf("got %q, want the config fallback after clearing the stored list", source)
 	}
 }
+
+func TestRelayedChainEndingOnLoopbackIsNotTrusted(t *testing.T) {
+	// Reproduces a real production incident. Declaring only the outer proxy left
+	// the chain one hop short, so it resolved to the loopback address the inner
+	// hop used — and loopback was being treated as the local operator channel.
+	// Every external request was therefore exempt from rate limiting and from the
+	// rule list at once.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "104.194.69.137:5000"
+	req.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
+
+	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"104.194.69.137/32"}))
+	if addr.Raw != "127.0.0.1" {
+		t.Fatalf("got %q, want the hop the chain stopped at", addr.Raw)
+	}
+	if addr.Trusted {
+		t.Error("a chain that dead-ends on loopback must not be trusted")
+	}
+	if addr.LocalOperator() {
+		t.Error("a relayed request is never the local operator, whatever it resolves to")
+	}
+}
+
+func TestLocalOperatorRequiresADirectConnection(t *testing.T) {
+	direct := httptest.NewRequest("GET", "/", nil)
+	direct.RemoteAddr = "127.0.0.1:5000"
+	if addr := resolveForwarded(direct, newTrustedProxyMatcher(nil)); !addr.LocalOperator() {
+		t.Error("a direct loopback connection with no forwarding header is the local operator")
+	}
+
+	relayed := httptest.NewRequest("GET", "/", nil)
+	relayed.RemoteAddr = "127.0.0.1:5000"
+	relayed.Header.Set("X-Forwarded-For", "203.0.113.9")
+	if addr := resolveForwarded(relayed, newTrustedProxyMatcher(nil)); addr.LocalOperator() {
+		t.Error("a relayed request must not qualify as the local operator")
+	}
+}
+
+func TestRegistryDoesNotExemptARelayedLoopbackChain(t *testing.T) {
+	// The end-to-end shape of the same incident: the verdict must not come back
+	// as an enforced allow just because the chain resolved to loopback.
+	registry := NewRegistry(NewStore(nil))
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "104.194.69.137:5000"
+	req.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
+	registry.SetPolicy(context.Background(), ProtectionPolicy{TrustedProxies: []string{"104.194.69.137/32"}})
+
+	addr := registry.ResolveAddress(req, "")
+	verdict := registry.Evaluate(addr)
+	if verdict.Enforced {
+		t.Error("an unresolved chain must not produce an enforced verdict")
+	}
+	if verdict.Exempt() {
+		t.Error("an unresolved chain must not exempt the request from throttling")
+	}
+}
+
+func TestFullyDeclaredChainResolvesTheRealClient(t *testing.T) {
+	// Declaring every hop is what makes the feature work; this is the state the
+	// diagnostics are meant to guide an operator towards.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "104.194.69.137:5000"
+	req.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
+
+	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"104.194.69.137/32", "127.0.0.1/32"}))
+	if addr.Raw != "203.0.113.9" || !addr.Trusted {
+		t.Fatalf("got %q trusted=%t, want the real client trusted", addr.Raw, addr.Trusted)
+	}
+	if addr.LocalOperator() {
+		t.Error("a resolved external client is not the local operator")
+	}
+}
+
+func TestForwardedChainIsReportedForDiagnostics(t *testing.T) {
+	// Operators cannot declare the right hops without seeing the chain; guessing
+	// is what produced the half-configured state in the first place.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "104.194.69.137:5000"
+	req.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
+
+	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"104.194.69.137/32"}))
+	if addr.Peer != "104.194.69.137" {
+		t.Errorf("peer = %q, want the direct TCP peer", addr.Peer)
+	}
+	if len(addr.Chain) != 2 || addr.Chain[0] != "203.0.113.9" || addr.Chain[1] != "127.0.0.1" {
+		t.Errorf("chain = %v, want both hops in order", addr.Chain)
+	}
+}

--- a/internal/ipaccess/registry.go
+++ b/internal/ipaccess/registry.go
@@ -294,10 +294,13 @@ func (r *Registry) Evaluate(addr ClientAddress) Verdict {
 	if r == nil {
 		return Verdict{Decision: DecisionNeutral}
 	}
-	// Loopback is unconditionally admitted so a bad list can never lock an
-	// operator out of the host the process runs on.
-	if addr.Loopback() {
-		return Verdict{Decision: DecisionAllow, Enforced: true, Reason: "loopback"}
+	// A genuine local connection is unconditionally admitted so a bad list can
+	// never lock an operator out of the host the process runs on. Note this is
+	// LocalOperator, not Loopback: a relayed chain that merely dead-ends on a
+	// loopback address is an unresolved chain, and admitting it would exempt
+	// every external client from the rules.
+	if addr.LocalOperator() {
+		return Verdict{Decision: DecisionAllow, Enforced: true, Reason: "local_operator"}
 	}
 	if !addr.Trusted {
 		return Verdict{Decision: DecisionNeutral, Enforced: false, Reason: reasonUntrustedClientIP}

--- a/internal/ipaccess/trust.go
+++ b/internal/ipaccess/trust.go
@@ -11,6 +11,15 @@ import (
 // ClientAddress is everything the admission and throttle layers need to know
 // about where a request came from.
 type ClientAddress struct {
+	// Peer is the direct TCP peer, before any forwarding header is considered.
+	// Kept for diagnostics: it is the hop an operator has to declare next when
+	// the chain cannot be resolved.
+	Peer string
+	// DirectPeer reports that the request carried no forwarding header at all, so
+	// Peer is the client itself rather than infrastructure in front of it.
+	DirectPeer bool
+	// Chain is the forwarding chain as received, left to right, for diagnostics.
+	Chain []string
 	// IP is the address the framework resolved, honouring trusted-proxies.
 	IP net.IP
 	// Raw is the textual form, kept for display and for the rare case where the
@@ -35,11 +44,21 @@ func ProxyTrustConfigured(trustedProxies []string) bool {
 	return false
 }
 
-// Loopback reports whether the peer is the local host. Loopback keeps an
-// unconditional operator channel: a misconfigured allow list must never be able
-// to lock the machine's own administrator out of the process it is running.
+// Loopback reports whether the resolved address is a loopback address.
 func (a ClientAddress) Loopback() bool {
 	return a.IP != nil && a.IP.IsLoopback()
+}
+
+// LocalOperator reports a request that genuinely originated on this host: a
+// loopback peer that arrived with no forwarding header at all.
+//
+// This is the distinction that matters, and conflating it with Loopback() was a
+// real defect. A relayed request whose chain resolves to a loopback address is
+// not a local operator — it is a chain that could not be resolved, and treating
+// it as the operator channel exempts the entire internet from rate limiting and
+// from the rule list. Only a direct connection earns that exemption.
+func (a ClientAddress) LocalOperator() bool {
+	return a.DirectPeer && a.Loopback()
 }
 
 // Resolve derives the client address from a request.


### PR DESCRIPTION
## 线上集成测试发现的真实事故

在生产环境点了「添加检测到的 104.194.69.137/32」之后，**每一个外部请求都被解析成了 `127.0.0.1`**——那是内层跳用来连本服务的地址。而回环当时被当作"本机运维通道"无条件放行并豁免限流。

结果：限流、IP 名单、认证事件记录**对全世界同时失效**。服务一切正常，这恰恰是它不会被发现的原因。

两条各自正确的规则组合成了故障：

1. 「回环无条件放行」——保留运维通道，防止把自己锁在外面
2. 「按已声明的可信代理走转发链」——只信任自己的基础设施

链路声明少一跳时，二者叠加 = 所有人都拿到了运维豁免。

## 修复

把我混为一谈的两件事分开：

- **`LocalOperator()`** = 回环对端 **且完全没有转发头**，即真正的本机直连。准入豁免只认这个严格判定。
- **转发链停在回环** 现在标记为不可信——那是链路没解析完，不是本机请求。不可信会让整个功能降级为 no-op，而不是豁免任何人。
- **自动封禁仍然跳过广义回环**。两个方向的失败代价不对称：错误豁免是放过所有人，错误封禁是一次性挡住所有外部请求。**每一侧都取更安全的那个错误**，而不是用同一个判定。

同时修掉它之所以能发生的根因——运维看不见链路：

`/ip-access/status` 现在返回直连对端、完整转发链、是否直连；建议值改为**链路实际停下的那一跳**而不是解析结果，这样多跳链路每点一次收敛一跳，而不是靠猜。

## 验证

完整 `./scripts/ci-pr.sh` 退出码 0。新增 5 个测试钉死这次事故，包括生产的确切形状（外层已声明、内层未声明）以及完整声明后正确解析出真实客户端。

🤖 Generated with [Claude Code](https://claude.com/claude-code)