### PR TITLE
fix(codex): floor upstream client version to unblock gated models (gpt-5.6-sol)

### DIFF
--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -10,8 +10,9 @@ import (
 const (
 	// Defaults are intentionally aligned with upstream CLIProxyAPI's codex-tui behavior.
 	// Update these when upstream codex-tui identity changes.
-	DefaultCodexFingerprintUserAgent     = "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
-	DefaultCodexFingerprintVersion       = ""
+	// 0.147.0: ChatGPT rejects gpt-5.6-sol for Codex clients older than this.
+	DefaultCodexFingerprintUserAgent     = "codex-tui/0.147.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.147.0)"
+	DefaultCodexFingerprintVersion       = "0.147.0"
 	DefaultCodexFingerprintOriginator    = "codex-tui"
 	DefaultCodexFingerprintWebsocketBeta = "responses_websockets=2026-02-06"
 	DefaultCodexFingerprintBetaFeatures  = ""

--- a/internal/config/identity_fingerprint_test.go
+++ b/internal/config/identity_fingerprint_test.go
@@ -13,10 +13,10 @@ func TestDefaultCodexIdentityFingerprintUsesCurrentVersionAndDynamicSessions(t *
 	if !got.Enabled {
 		t.Fatalf("Enabled = false, want true by default")
 	}
-	if got.Version != "" {
-		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
+	if got.Version != "0.147.0" {
+		t.Fatalf("Version = %q, want current Codex client version (ChatGPT gates newer models on it)", got.Version)
 	}
-	if got.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)" {
+	if got.UserAgent != "codex-tui/0.147.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.147.0)" {
 		t.Fatalf("UserAgent = %q, want codex-tui user agent", got.UserAgent)
 	}
 	if got.SessionMode != "per-request" {
@@ -32,10 +32,10 @@ func TestNormalizeCodexIdentityFingerprintAppliesCurrentDefaults(t *testing.T) {
 	if !got.Enabled {
 		t.Fatalf("Enabled = false, want true by default")
 	}
-	if got.Version != "" {
-		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
+	if got.Version != "0.147.0" {
+		t.Fatalf("Version = %q, want current Codex client version (ChatGPT gates newer models on it)", got.Version)
 	}
-	if got.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)" {
+	if got.UserAgent != "codex-tui/0.147.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.147.0)" {
 		t.Fatalf("UserAgent = %q, want codex-tui user agent", got.UserAgent)
 	}
 	if got.SessionMode != "per-request" {

--- a/internal/identityfingerprint/extract_resolve_test.go
+++ b/internal/identityfingerprint/extract_resolve_test.go
@@ -255,19 +255,19 @@ func TestResolveCodexEffectiveVersionUsesFieldLevelPriority(t *testing.T) {
 		Provider:   ProviderCodex,
 		AccountKey: "acct",
 		Fields: map[string]string{
-			FieldCodexVersion: "0.142.0",
+			FieldCodexVersion: "0.151.0",
 		},
 	}
 
 	fp, effective := ResolveCodex(config.CodexIdentityFingerprintConfig{
 		Enabled: true,
-		Version: "0.140.0",
+		Version: "0.150.0",
 	}, learned)
 
-	if fp.Version != "0.142.0" {
+	if fp.Version != "0.151.0" {
 		t.Fatalf("resolved version = %q, want learned field", fp.Version)
 	}
-	if effective.Version != "0.142.0" {
+	if effective.Version != "0.151.0" {
 		t.Fatalf("effective version = %q, want learned field", effective.Version)
 	}
 	if got := effective.Fields[FieldCodexVersion].Source; got != FieldSourceLearned {

--- a/internal/identityfingerprint/profiles_test.go
+++ b/internal/identityfingerprint/profiles_test.go
@@ -143,7 +143,7 @@ func TestResolveCodexSafeFallbackRejectsMixedAccountPreset(t *testing.T) {
 		Enabled:       true,
 		UserAgent:     "codex_cli_rs/0.144.1",
 		Originator:    "Codex Desktop",
-		Version:       "0.144.0",
+		Version:       "0.150.0",
 		BetaFeatures:  "desktop_only",
 		WebsocketBeta: "responses_websockets=desktop",
 	})
@@ -167,23 +167,23 @@ func TestResolveCodexProfileNeverFillsFromAnotherProductPreset(t *testing.T) {
 		AccountKey:    "acct",
 		ProfileKey:    "codex_cli_rs",
 		ProfileFamily: ProfileFamilyCLI,
-		Version:       "0.144.1",
+		Version:       "0.150.1",
 		Fields: map[string]string{
-			FieldUserAgent:       "codex_cli_rs/0.144.1 (Mac OS 26.5.2; arm64) unknown",
+			FieldUserAgent:       "codex_cli_rs/0.150.1 (Mac OS 26.5.2; arm64) unknown",
 			FieldCodexOriginator: "codex_cli_rs",
-			FieldCodexVersion:    "0.144.1",
+			FieldCodexVersion:    "0.150.1",
 		},
 	}
 	resolved, effective := ResolveCodexProfile(config.CodexIdentityFingerprintConfig{
 		Enabled:       true,
-		UserAgent:     "Codex Desktop/0.144.0-alpha.4",
+		UserAgent:     "Codex Desktop/0.150.0-alpha.4",
 		Originator:    "Codex Desktop",
-		Version:       "0.144.0",
+		Version:       "0.150.0",
 		WebsocketBeta: "responses_websockets=desktop",
 		BetaFeatures:  "desktop_only",
 	}, profile)
 
-	if resolved.UserAgent != profile.Fields[FieldUserAgent] || resolved.Originator != "codex_cli_rs" || resolved.Version != "0.144.1" {
+	if resolved.UserAgent != profile.Fields[FieldUserAgent] || resolved.Originator != "codex_cli_rs" || resolved.Version != "0.150.1" {
 		t.Fatalf("resolved = %#v, want complete CLI bundle", resolved)
 	}
 	if resolved.WebsocketBeta != "" || resolved.BetaFeatures != "" {

--- a/internal/identityfingerprint/resolve.go
+++ b/internal/identityfingerprint/resolve.go
@@ -1,10 +1,132 @@
 package identityfingerprint
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 )
+
+// minCodexClientVersion is the floor for the outbound Codex "Version" header
+// and the version embedded in the spoofed User-Agent. ChatGPT gates newer
+// models (e.g. gpt-5.6-sol) on the client version and answers "requires a
+// newer version of Codex" for anything older, so a learned or configured
+// identity must never advertise a version below this floor.
+const minCodexClientVersion = "0.147.0"
+
+// codexVersionBelow reports whether version is a dotted-numeric version lower
+// than the floor. Unparseable values are treated as below the floor so callers
+// fall back to a known-good version instead of leaking a stale one upstream.
+func codexVersionBelow(version, floor string) bool {
+	parse := func(s string) []int {
+		parts := strings.Split(strings.TrimSpace(s), ".")
+		out := make([]int, 0, len(parts))
+		for _, p := range parts {
+			end := 0
+			for end < len(p) && p[end] >= '0' && p[end] <= '9' {
+				end++
+			}
+			if end == 0 {
+				return nil
+			}
+			n, err := strconv.Atoi(p[:end])
+			if err != nil {
+				return nil
+			}
+			out = append(out, n)
+		}
+		return out
+	}
+	v, f := parse(version), parse(floor)
+	if v == nil {
+		return true
+	}
+	if f == nil {
+		return false
+	}
+	n := len(v)
+	if len(f) > n {
+		n = len(f)
+	}
+	for i := 0; i < n; i++ {
+		vi, fi := 0, 0
+		if i < len(v) {
+			vi = v[i]
+		}
+		if i < len(f) {
+			fi = f[i]
+		}
+		if vi < fi {
+			return true
+		}
+		if vi > fi {
+			return false
+		}
+	}
+	return false
+}
+
+// floorCodexVersion clamps a below-floor version up to the minimum.
+func floorCodexVersion(version string) string {
+	if codexVersionBelow(version, minCodexClientVersion) {
+		return minCodexClientVersion
+	}
+	return strings.TrimSpace(version)
+}
+
+// clampCodexIdentityVersion aligns the Version header and the version embedded
+// in the User-Agent with the minimum supported Codex client version. When the
+// version is raised, the UA product token is rewritten to match so the pair
+// stays consistent upstream.
+func clampCodexIdentityVersion(resolved *config.CodexIdentityFingerprintConfig) {
+	if resolved == nil {
+		return
+	}
+	floored := floorCodexVersion(resolved.Version)
+	if floored == resolved.Version {
+		return
+	}
+	resolved.Version = floored
+	resolved.UserAgent = rewriteCodexUserAgentVersion(resolved.UserAgent, floored)
+}
+
+// rewriteCodexUserAgentVersion replaces the client version inside a Codex
+// User-Agent with the given version. Only the product token immediately
+// following "name/" and the parenthesized "(product; ver)" detail are
+// rewritten; OS, terminal, and other dotted numbers are preserved.
+func rewriteCodexUserAgentVersion(userAgent, version string) string {
+	ua := strings.TrimSpace(userAgent)
+	version = strings.TrimSpace(version)
+	if ua == "" || version == "" {
+		return ua
+	}
+	// Product token: the dotted version right after the first "/".
+	if idx := strings.Index(ua, "/"); idx >= 0 {
+		start := idx + 1
+		end := start
+		for end < len(ua) && ((ua[end] >= '0' && ua[end] <= '9') || ua[end] == '.') {
+			end++
+		}
+		if end > start && strings.Contains(ua[start:end], ".") {
+			ua = ua[:start] + version + ua[end:]
+		}
+	}
+	// Parenthesized product detail: "(codex_exec; 0.130.0)" style.
+	if idx := strings.LastIndex(ua, ";"); idx >= 0 {
+		start := idx + 1
+		for start < len(ua) && ua[start] == ' ' {
+			start++
+		}
+		end := start
+		for end < len(ua) && ((ua[end] >= '0' && ua[end] <= '9') || ua[end] == '.') {
+			end++
+		}
+		if end > start && strings.Contains(ua[start:end], ".") {
+			ua = ua[:start] + version + ua[end:]
+		}
+	}
+	return ua
+}
 
 func ResolveClaude(cfg config.ClaudeIdentityFingerprintConfig, learned *LearnedRecord) (config.ClaudeIdentityFingerprintConfig, EffectiveFingerprint) {
 	clean := config.CleanClaudeIdentityFingerprint(cfg)
@@ -79,8 +201,9 @@ func ResolveCodex(cfg config.CodexIdentityFingerprintConfig, learned *LearnedRec
 		SessionID:     clean.SessionID,
 		CustomHeaders: clean.CustomHeaders,
 	}
+	clampCodexIdentityVersion(&resolved)
 	effective := effective(ProviderCodex, clean.Enabled, learned, fields)
-	effective.Version = version
+	effective.Version = resolved.Version
 	return resolved, effective
 }
 
@@ -144,8 +267,9 @@ func ResolveCodexProfile(cfg config.CodexIdentityFingerprintConfig, profile *Lea
 		SessionID:     clean.SessionID,
 		CustomHeaders: clean.CustomHeaders,
 	}
+	clampCodexIdentityVersion(&resolved)
 	effective := effective(ProviderCodex, clean.Enabled, profile, fields)
-	effective.Version = version
+	effective.Version = resolved.Version
 	return resolved, effective
 }
 

--- a/internal/identityfingerprint/resolve_floor_test.go
+++ b/internal/identityfingerprint/resolve_floor_test.go
@@ -1,0 +1,114 @@
+package identityfingerprint
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestCodexVersionBelow(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"0.130.0", true},
+		{"0.118.0", true},
+		{"0.146.9", true},
+		{"0.147.0", false},
+		{"0.147.1", false},
+		{"0.180.0", false},
+		{"0.147.0-alpha.6.6", false}, // pre-release of the floor parses as 0.147.0
+		{"", true},
+		{"abc", true},
+	}
+	for _, tc := range cases {
+		if got := codexVersionBelow(tc.version, minCodexClientVersion); got != tc.want {
+			t.Fatalf("codexVersionBelow(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestRewriteCodexUserAgentVersion(t *testing.T) {
+	t.Parallel()
+	in := "codex_exec/0.130.0 (Debian 13.0.0; aarch64) xterm-256color (codex_exec; 0.130.0)"
+	want := "codex_exec/0.147.0 (Debian 13.0.0; aarch64) xterm-256color (codex_exec; 0.147.0)"
+	if got := rewriteCodexUserAgentVersion(in, "0.147.0"); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	// Single-component numbers (e.g. the "3" in a terminal name) must survive.
+	in2 := "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
+	got2 := rewriteCodexUserAgentVersion(in2, "0.147.0")
+	want2 := "codex-tui/0.147.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.147.0)"
+	if got2 != want2 {
+		t.Fatalf("got %q, want %q", got2, want2)
+	}
+}
+
+func TestResolveCodexFloorsLearnedStaleVersion(t *testing.T) {
+	t.Parallel()
+	learned := &LearnedRecord{
+		Provider:   ProviderCodex,
+		ProfileKey: "codex_exec",
+		Version:    "0.130.0",
+		Fields: map[string]string{
+			FieldUserAgent:       "codex_exec/0.130.0 (Debian 13.0.0; aarch64) xterm-256color (codex_exec; 0.130.0)",
+			FieldCodexVersion:    "0.130.0",
+			FieldCodexOriginator: "codex_exec",
+		},
+	}
+	resolved, _ := ResolveCodex(config.CodexIdentityFingerprintConfig{Enabled: true}, learned)
+	if resolved.Version != minCodexClientVersion {
+		t.Fatalf("Version = %q, want floored to %q", resolved.Version, minCodexClientVersion)
+	}
+	wantUA := "codex_exec/0.147.0 (Debian 13.0.0; aarch64) xterm-256color (codex_exec; 0.147.0)"
+	if resolved.UserAgent != wantUA {
+		t.Fatalf("UserAgent = %q, want %q", resolved.UserAgent, wantUA)
+	}
+	if resolved.Originator != "codex_exec" {
+		t.Fatalf("Originator = %q, want learned codex_exec preserved", resolved.Originator)
+	}
+}
+
+func TestResolveCodexKeepsNewerLearnedVersion(t *testing.T) {
+	t.Parallel()
+	learned := &LearnedRecord{
+		Provider:   ProviderCodex,
+		ProfileKey: ProfileKeyCodexDesktop,
+		Version:    "0.180.0",
+		Fields: map[string]string{
+			FieldUserAgent:       "Codex Desktop/0.180.0 (Windows 10.0.26220; x86_64) unknown (Codex Desktop; 26.803.81509)",
+			FieldCodexVersion:    "0.180.0",
+			FieldCodexOriginator: "Codex Desktop",
+		},
+	}
+	resolved, _ := ResolveCodex(config.CodexIdentityFingerprintConfig{Enabled: true}, learned)
+	if resolved.Version != "0.180.0" {
+		t.Fatalf("Version = %q, want learned 0.180.0 preserved", resolved.Version)
+	}
+	if resolved.UserAgent != learned.Fields[FieldUserAgent] {
+		t.Fatalf("UserAgent = %q, want learned UA untouched", resolved.UserAgent)
+	}
+}
+
+func TestResolveCodexProfileFloorsStaleVersion(t *testing.T) {
+	t.Parallel()
+	profile := &LearnedRecord{
+		Provider:   ProviderCodex,
+		ProfileKey: "codex_exec",
+		Version:    "0.130.0",
+		Fields: map[string]string{
+			FieldUserAgent:       "codex_exec/0.130.0 (Debian 13.0.0; aarch64) xterm-256color (codex_exec; 0.130.0)",
+			FieldCodexVersion:    "0.130.0",
+			FieldCodexOriginator: "codex_exec",
+		},
+	}
+	resolved, _ := ResolveCodexProfile(config.CodexIdentityFingerprintConfig{Enabled: true}, profile)
+	if resolved.Version != minCodexClientVersion {
+		t.Fatalf("Version = %q, want floored to %q", resolved.Version, minCodexClientVersion)
+	}
+	wantUA := "codex_exec/0.147.0 (Debian 13.0.0; aarch64) xterm-256color (codex_exec; 0.147.0)"
+	if resolved.UserAgent != wantUA {
+		t.Fatalf("UserAgent = %q, want %q", resolved.UserAgent, wantUA)
+	}
+}

--- a/internal/management/aiaccountstatus/probe_codex.go
+++ b/internal/management/aiaccountstatus/probe_codex.go
@@ -24,7 +24,7 @@ const (
 func probeCodex(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) (ProbeResult, error) {
 	body, err := doAuthGET(ctx, svc, auth, codexUsageURL, map[string]string{
 		"Content-Type": "application/json",
-		"User-Agent":   "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+		"User-Agent":   "codex_cli_rs/0.147.0 (Debian 13.0.0; x86_64) WindowsTerminal",
 	}, func(req *http.Request) {
 		if accountID := codexAccountID(auth); accountID != "" {
 			req.Header.Set("Chatgpt-Account-Id", accountID)
@@ -47,7 +47,7 @@ func probeCodex(ctx context.Context, svc *managementapitools.Service, auth *core
 		if v > 0 {
 			if expBody, expErr := doAuthGET(ctx, svc, auth, codexResetCreditsURL, map[string]string{
 				"Content-Type": "application/json",
-				"User-Agent":   "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+				"User-Agent":   "codex_cli_rs/0.147.0 (Debian 13.0.0; x86_64) WindowsTerminal",
 			}, func(req *http.Request) {
 				if accountID := codexAccountID(auth); accountID != "" {
 					req.Header.Set("Chatgpt-Account-Id", accountID)

--- a/internal/runtime/executor/codex_auth.go
+++ b/internal/runtime/executor/codex_auth.go
@@ -14,8 +14,14 @@ import (
 
 const (
 	// Keep defaults aligned with upstream CLIProxyAPI (codex-tui).
-	codexUserAgent  = "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
+	// Bumped to 0.147.0: ChatGPT's backend rejects gpt-5.6-sol for older Codex
+	// client versions ("requires a newer version of Codex").
+	codexUserAgent  = "codex-tui/0.147.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.147.0)"
 	codexOriginator = "codex-tui"
+	// codexDefaultClientVersion is sent as the Codex "Version" header when the
+	// inbound client did not provide one. ChatGPT gates newer models on it, so
+	// a missing header must not mean "too old" upstream.
+	codexDefaultClientVersion = "0.147.0"
 )
 
 func applyCodexHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.Auth, token string, stream bool) {
@@ -35,7 +41,10 @@ func applyCodexHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.A
 		}
 	}
 	// Align with upstream: only propagate these from the client when present.
-	misc.EnsureHeader(r.Header, ginHeaders, "Version", "")
+	// Version defaults to a current Codex release: ChatGPT gates newer models
+	// (e.g. gpt-5.6-sol) on the client version, and an absent Version header is
+	// treated as too old upstream.
+	misc.EnsureHeader(r.Header, ginHeaders, "Version", codexDefaultClientVersion)
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Turn-Metadata", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Client-Request-Id", "")
 

--- a/internal/runtime/executor/codex_websockets_helpers.go
+++ b/internal/runtime/executor/codex_websockets_helpers.go
@@ -194,8 +194,10 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, cfg *c
 		misc.EnsureHeader(headers, ginHeaders, "x-client-request-id", "")
 		misc.EnsureHeader(headers, ginHeaders, "x-responsesapi-include-timing-metrics", "")
 
-		// Align with upstream: Version is only propagated from client when present.
-		misc.EnsureHeader(headers, ginHeaders, "Version", "")
+		// Align with upstream: Version is propagated from the client when present,
+		// but defaults to a current Codex release so model gating upstream does not
+		// treat a missing header as an outdated client.
+		misc.EnsureHeader(headers, ginHeaders, "Version", codexDefaultClientVersion)
 		betaHeader := strings.TrimSpace(headers.Get("OpenAI-Beta"))
 		if betaHeader == "" && ginHeaders != nil {
 			betaHeader = strings.TrimSpace(ginHeaders.Get("OpenAI-Beta"))

--- a/internal/runtime/executor/identity_fingerprint_runtime_test.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime_test.go
@@ -279,8 +279,8 @@ func TestCodexHeadersReplayLearnedFingerprintWithoutInboundHeaders(t *testing.T)
 		},
 	}
 	inbound := http.Header{}
-	inbound.Set("User-Agent", "codex_cli_rs/0.130.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9")
-	inbound.Set("Version", "0.130.0")
+	inbound.Set("User-Agent", "codex_cli_rs/0.150.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9")
+	inbound.Set("Version", "0.150.0")
 	inbound.Set("Originator", "codex_cli_rs")
 	inbound.Set("X-Codex-Beta-Features", "compact_mode")
 	ctx := contextWithInboundHeaders(http.MethodPost, "/v1/responses", inbound)
@@ -289,7 +289,7 @@ func TestCodexHeadersReplayLearnedFingerprintWithoutInboundHeaders(t *testing.T)
 
 	applyCodexHeaders(req, cfg, auth, "codex-token", false)
 
-	if got := req.Header.Get("User-Agent"); got != "codex_cli_rs/0.130.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9" {
+	if got := req.Header.Get("User-Agent"); got != "codex_cli_rs/0.150.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9" {
 		t.Fatalf("first User-Agent = %q, want learned Codex UA", got)
 	}
 	if got := req.Header.Get("Originator"); got != "codex_cli_rs" {
@@ -302,10 +302,10 @@ func TestCodexHeadersReplayLearnedFingerprintWithoutInboundHeaders(t *testing.T)
 	replayReq := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
 	applyCodexHeaders(replayReq, cfg, auth, "codex-token", false)
 
-	if got := replayReq.Header.Get("User-Agent"); got != "codex_cli_rs/0.130.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9" {
+	if got := replayReq.Header.Get("User-Agent"); got != "codex_cli_rs/0.150.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9" {
 		t.Fatalf("replayed User-Agent = %q, want stored learned Codex UA", got)
 	}
-	if got := replayReq.Header.Get("Version"); got != "0.130.0" {
+	if got := replayReq.Header.Get("Version"); got != "0.150.0" {
 		t.Fatalf("replayed Version = %q, want stored learned Codex version", got)
 	}
 	if got := replayReq.Header.Get("Originator"); got != "codex_cli_rs" {
@@ -333,8 +333,8 @@ func TestCodexFingerprintRepeatedRequestUsesHotPathCache(t *testing.T) {
 		},
 	}
 	inbound := http.Header{}
-	inbound.Set("User-Agent", "codex_cli_rs/0.144.1 (Mac OS 26.5.2; arm64) iTerm.app/3.6.9")
-	inbound.Set("Version", "0.144.1")
+	inbound.Set("User-Agent", "codex_cli_rs/0.150.1 (Mac OS 26.5.2; arm64) iTerm.app/3.6.9")
+	inbound.Set("Version", "0.150.1")
 	inbound.Set("Originator", "codex_cli_rs")
 	ctx := contextWithInboundHeaders(http.MethodPost, "/v1/responses", inbound)
 
@@ -558,11 +558,11 @@ func TestCodexHeadersUseOneSelectedProfileWithoutFieldMixing(t *testing.T) {
 			ProfileFamily: identityfingerprint.ProfileFamilyCLI,
 			ClientProduct: "codex_cli_rs",
 			ClientVariant: "codex_cli_rs",
-			Version:       "0.144.1",
+			Version:       "0.150.1",
 			Fields: map[string]string{
-				identityfingerprint.FieldUserAgent:       "codex_cli_rs/0.144.1 (Mac OS 26.5.2; arm64) unknown",
+				identityfingerprint.FieldUserAgent:       "codex_cli_rs/0.150.1 (Mac OS 26.5.2; arm64) unknown",
 				identityfingerprint.FieldCodexOriginator: "codex_cli_rs",
-				identityfingerprint.FieldCodexVersion:    "0.144.1",
+				identityfingerprint.FieldCodexVersion:    "0.150.1",
 			},
 			CreatedAt: now.Add(-time.Hour), UpdatedAt: now.Add(-time.Hour), LastSeenAt: now.Add(-time.Hour),
 		},
@@ -573,11 +573,11 @@ func TestCodexHeadersUseOneSelectedProfileWithoutFieldMixing(t *testing.T) {
 			ProfileFamily: identityfingerprint.ProfileFamilyDesktop,
 			ClientProduct: "codex",
 			ClientVariant: "Codex Desktop",
-			Version:       "0.144.0",
+			Version:       "0.150.0",
 			Fields: map[string]string{
-				identityfingerprint.FieldUserAgent:         "Codex Desktop/0.144.0-alpha.4 (Mac OS 26.5.2; arm64)",
+				identityfingerprint.FieldUserAgent:         "Codex Desktop/0.150.0-alpha.4 (Mac OS 26.5.2; arm64)",
 				identityfingerprint.FieldCodexOriginator:   "Codex Desktop",
-				identityfingerprint.FieldCodexVersion:      "0.144.0",
+				identityfingerprint.FieldCodexVersion:      "0.150.0",
 				identityfingerprint.FieldCodexBetaFeatures: "remote_compaction_v2",
 			},
 			CreatedAt: now, UpdatedAt: now, LastSeenAt: now,
@@ -591,9 +591,9 @@ func TestCodexHeadersUseOneSelectedProfileWithoutFieldMixing(t *testing.T) {
 	eventually(t, time.Second, func() bool {
 		cliReq := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
 		applyCodexHeaders(cliReq, cfg, auth, "codex-token", false)
-		return cliReq.Header.Get("User-Agent") == "codex_cli_rs/0.144.1 (Mac OS 26.5.2; arm64) unknown" &&
+		return cliReq.Header.Get("User-Agent") == "codex_cli_rs/0.150.1 (Mac OS 26.5.2; arm64) unknown" &&
 			cliReq.Header.Get("Originator") == "codex_cli_rs" &&
-			cliReq.Header.Get("Version") == "0.144.1" &&
+			cliReq.Header.Get("Version") == "0.150.1" &&
 			cliReq.Header.Get("X-Codex-Beta-Features") == ""
 	})
 
@@ -608,9 +608,9 @@ func TestCodexHeadersUseOneSelectedProfileWithoutFieldMixing(t *testing.T) {
 	eventually(t, time.Second, func() bool {
 		desktopReq := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
 		applyCodexHeaders(desktopReq, cfg, auth, "codex-token", false)
-		return desktopReq.Header.Get("User-Agent") == "Codex Desktop/0.144.0-alpha.4 (Mac OS 26.5.2; arm64)" &&
+		return desktopReq.Header.Get("User-Agent") == "Codex Desktop/0.150.0-alpha.4 (Mac OS 26.5.2; arm64)" &&
 			desktopReq.Header.Get("Originator") == "Codex Desktop" &&
-			desktopReq.Header.Get("Version") == "0.144.0" &&
+			desktopReq.Header.Get("Version") == "0.150.0" &&
 			desktopReq.Header.Get("X-Codex-Beta-Features") == "remote_compaction_v2"
 	})
 }


### PR DESCRIPTION
## 问题

ChatGPT 的 Codex 后端对较新模型（如 `gpt-5.6-sol`）做了**客户端版本门槛**。当 relay 以旧版本 Codex 客户端身份请求时，上游返回 400：

```
{"detail":"The 'gpt-5.6-sol' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}
```

## 根因（两层）

1. **内置身份默认值过旧**：`codex-tui/0.118.0`、`codex_cli_rs/0.76.0`，且默认不发送 `Version` 头。
2. **更隐蔽的一层**：身份指纹学习（identity-fingerprint learning）会把之前观察到的客户端版本（例如 `codex_exec/0.130.0`）记录为出站身份。**一旦学进旧版本，它会在后续的 fingerprint 选择中覆盖默认值**，即使升级了常量也依然复现该报错。

## 修复内容

- 将内置 `codex-tui` / `codex_cli_rs` 身份升级到 **0.147.0**。
- 当入站客户端未提供 `Version` 头时，默认发送当前 Codex 版本（0.147.0），不再留空。
- 在 codex 指纹解析层新增**最低版本下限（0.147.0）**：任何学习到 / 配置的旧于下限的版本都会被提升，同时 UA 中的 product token 和括号内 `(product; ver)` 版本会被一致改写（保留 OS / 终端等其余数字）。**不低于下限的版本原样透传**。

## 改动文件

- `internal/config/identity_fingerprint.go` — 默认 UA / Version 升级
- `internal/runtime/executor/codex_auth.go` — 默认 UA 升级 + Version 头默认值
- `internal/runtime/executor/codex_websockets_helpers.go` — websocket 路径 Version 默认值
- `internal/management/aiaccountstatus/probe_codex.go` — 探测 UA 升级
- `internal/identityfingerprint/resolve.go` — 新增版本下限钳制 + UA 版本改写
- `internal/identityfingerprint/resolve_floor_test.go` — 新增钳制单元测试
- 相关存量测试同步更新

## 验证

在真实部署环境验证通过：

| 场景 | 结果 |
|------|------|
| 公网域名 + claude-cli UA + `gpt-5.6-sol` | ✅ 成功 |
| 直连 + 旧 `codex_exec/0.130.0` 身份 + `gpt-5.6-sol` | ✅ 成功（版本被钳制到 0.147.0） |
| `gpt-5.5` 回归 | ✅ 正常 |

`go test ./...` 通过（仅容器缺 `bash` 导致的部署脚本测试失败，与本改动无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)