### PR TITLE
fix(xai): keep SuperGrok plan when monthlyLimit is zero

### DIFF
--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -252,6 +252,26 @@ func TestParseXAIBillingFullSummaryAndPlan(t *testing.T) {
 	}
 }
 
+func TestResolveXAIPlanUsesEntitlementWhenMonthlyLimitIsZero(t *testing.T) {
+	weekly := []byte(`{"config":{"currentPeriod":{"type":"WEEKLY","end":"2026-08-20T00:00:00Z"},"creditUsagePercent":12,"productUsage":[{"product":"grok-code","usagePercent":8}]}}`)
+	zeroMonthly := []byte(`{"config":{"monthlyLimit":{"val":0},"used":{"val":0},"onDemandCap":{"val":0},"billingPeriodEnd":"2026-09-01T00:00:00Z"}}`)
+	if got := resolveXAIPlan(zeroMonthly, weekly); got != "supergrok" {
+		t.Fatalf("zero monthly + weekly entitlement plan=%q, want supergrok", got)
+	}
+	if got := resolveXAIPlan([]byte(`{"config":{"monthlyLimit":{"val":150000}}}`), weekly); got != "supergrok-heavy" {
+		t.Fatalf("legacy heavy monthly plan=%q", got)
+	}
+	if got := resolveXAIPlan([]byte(`{"config":{"planType":"SuperGrok Heavy"}}`), weekly); got != "supergrok-heavy" {
+		t.Fatalf("explicit heavy plan=%q", got)
+	}
+	if got := resolveXAIPlan(weekly); got != "" {
+		t.Fatalf("weekly-only free grok plan=%q, want empty", got)
+	}
+	if got := resolveXAIPlan(zeroMonthly); got != "" {
+		t.Fatalf("zero monthly without weekly plan=%q, want empty", got)
+	}
+}
+
 func TestParseAntigravityModelsSummarizesWorstRemainingAndEarliestReset(t *testing.T) {
 	body := []byte(`{"models":{
 		"gemini-3-pro-high":{"quotaInfo":{"remainingFraction":0.8,"resetTime":"2026-07-20T00:00:00Z"}},

--- a/internal/management/aiaccountstatus/probe_xai.go
+++ b/internal/management/aiaccountstatus/probe_xai.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
@@ -55,11 +56,7 @@ func probeXAI(ctx context.Context, svc *managementapitools.Service, auth *coreau
 	if len(quotas) == 0 {
 		return ProbeResult{}, fmt.Errorf("empty_data")
 	}
-	planBody := monthlyBody
-	if monthlyErr != nil {
-		planBody = weeklyBody
-	}
-	return ProbeResult{Quotas: quotas, PlanType: resolveXAIPlan(planBody)}, nil
+	return ProbeResult{Quotas: quotas, PlanType: resolveXAIPlan(monthlyBody, weeklyBody)}, nil
 }
 
 // fetchXAIBillingParallel runs weekly and monthly fetches concurrently and
@@ -213,8 +210,52 @@ func xaiCentValue(cfg gjson.Result, paths ...string) (float64, bool) {
 	return value.Float(), true
 }
 
-func resolveXAIPlan(body []byte) string {
-	cfg := gjson.GetBytes(body, "config")
+func resolveXAIPlan(bodies ...[]byte) string {
+	var best string
+	var hasMonthlyConfig, hasWeeklyEntitlement bool
+	for _, body := range bodies {
+		if len(body) == 0 {
+			continue
+		}
+		if plan := resolveXAIPlanFromBody(body); plan != "" {
+			if plan == "supergrok-heavy" {
+				return plan
+			}
+			best = plan
+		}
+		if xaiHasMonthlyConfig(body) {
+			hasMonthlyConfig = true
+		}
+		if _, ok := xaiauth.ParseWeeklyBilling(body); ok {
+			hasWeeklyEntitlement = true
+		}
+	}
+	if best != "" {
+		return best
+	}
+	// xAI no longer always sends the old SuperGrok monthlyLimit cents
+	// (15000 / 150000). A monthly billing config plus weekly/product
+	// entitlement still means a paid subscription; free Grok only has
+	// the weekly credits endpoint.
+	if hasMonthlyConfig && hasWeeklyEntitlement {
+		return "supergrok"
+	}
+	return ""
+}
+
+func resolveXAIPlanFromBody(body []byte) string {
+	root := gjson.ParseBytes(body)
+	cfg := firstJSONResult(root, "config")
+	for _, src := range []gjson.Result{cfg, root} {
+		if plan := normalizeXAIPlanName(firstJSONResult(src,
+			"plan", "planType", "plan_type",
+			"tier", "subscriptionTier", "subscription_tier",
+			"subscriptionType", "subscription_type",
+			"entitlement", "entitlementName", "entitlement_name",
+		).String()); plan != "" {
+			return plan
+		}
+	}
 	limit, ok := xaiCentValue(cfg, "monthlyLimit", "monthly_limit")
 	if !ok {
 		return ""
@@ -224,6 +265,31 @@ func resolveXAIPlan(body []byte) string {
 		return "supergrok"
 	case 150000:
 		return "supergrok-heavy"
+	default:
+		return ""
+	}
+}
+
+func xaiHasMonthlyConfig(body []byte) bool {
+	cfg := gjson.GetBytes(body, "config")
+	if !cfg.Exists() {
+		return false
+	}
+	_, hasMonthlyLimit := xaiCentValue(cfg, "monthlyLimit", "monthly_limit")
+	_, hasUsed := xaiCentValue(cfg, "used")
+	_, hasOnDemandCap := xaiCentValue(cfg, "onDemandCap", "on_demand_cap")
+	return hasMonthlyLimit || hasUsed || hasOnDemandCap
+}
+
+func normalizeXAIPlanName(raw string) string {
+	compact := strings.NewReplacer("_", "", "-", "", " ", "").Replace(strings.ToLower(strings.TrimSpace(raw)))
+	switch {
+	case compact == "":
+		return ""
+	case strings.Contains(compact, "heavy"):
+		return "supergrok-heavy"
+	case strings.Contains(compact, "supergrok"):
+		return "supergrok"
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary
- xAI status refresh succeeded but `resolveXAIPlan()` only mapped `monthlyLimit` of exactly 15000 / 150000 cents.
- Current billing still returns a monthly config plus weekly/product entitlement, just with `$0.00 / $0.00` monthly credits, so `plan_type` was persisted empty and the SuperGrok badge disappeared.
- Prefer an explicit plan/tier field when present, keep the legacy monthlyLimit mapping, and treat monthly billing + weekly entitlement as `supergrok`. Weekly-only free Grok stays unlabelled.

Fixes #881

## Test plan
- [x] `go test ./internal/management/aiaccountstatus/ -count=1`
- [x] Regression covers zero monthly + weekly entitlement → `supergrok`, legacy 150000 → `supergrok-heavy`, explicit `planType`, weekly-only free Grok stays empty
