### PR TITLE
fix: keep DeepSeek Harness sessions on their own cache identity

### DIFF
--- a/internal/runtime/executor/opencode_go_reasoning.go
+++ b/internal/runtime/executor/opencode_go_reasoning.go
@@ -67,7 +67,20 @@ func opencodeGoSessionID(opts cliproxyexecutor.Options, auth *cliproxyauth.Auth)
 		}
 	}
 	if raw, ok := opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey]; ok {
-		if s, ok := raw.(string); ok {
+		if s, ok := raw.(string); ok && strings.TrimSpace(s) != "" {
+			return strings.TrimSpace(s)
+		}
+	}
+	// ExecutionSessionMetadataKey is only set on the websocket path, so ordinary
+	// HTTP turns from clients that send a client-specific session header (DeepSeek
+	// Harness: X-Deepseek-Harness-Session-Id, Grok: X-Grok-Session-Id) would reach
+	// the auth-ID fallback below. That collapses every concurrent session of one
+	// API key onto a single cache slot (reasoningCacheMaxEntriesPerKey == 1), so
+	// turns overwrite each other and get injected with another session's
+	// reasoning_content — which changes the request prefix and destroys the
+	// upstream prefix cache. The sticky key already carries exactly this identity.
+	if raw, ok := opts.Metadata[cliproxyexecutor.SessionStickyMetadataKey]; ok {
+		if s, ok := raw.(string); ok && strings.TrimSpace(s) != "" {
 			return strings.TrimSpace(s)
 		}
 	}

--- a/internal/runtime/executor/opencode_go_reasoning_test.go
+++ b/internal/runtime/executor/opencode_go_reasoning_test.go
@@ -98,6 +98,70 @@ func TestOpenCodeGoSessionID_Empty(t *testing.T) {
 	}
 }
 
+func TestOpenCodeGoSessionID_FromSessionStickyKey(t *testing.T) {
+	// Ordinary HTTP turns never set ExecutionSessionMetadataKey (websocket only),
+	// so the sticky key is what carries session identity for header-based clients.
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:x-deepseek-harness-session-id:ses_abc",
+		},
+	}
+	if got, want := opencodeGoSessionID(opts, nil), "header:x-deepseek-harness-session-id:ses_abc"; got != want {
+		t.Errorf("opencodeGoSessionID = %q, want %q", got, want)
+	}
+}
+
+func TestOpenCodeGoSessionID_StickyKeyBeatsAuthFallback(t *testing.T) {
+	// The regression this guards: two concurrent sessions on ONE api key must not
+	// collapse onto the same reasoning slot (reasoningCacheMaxEntriesPerKey == 1),
+	// or each turn is injected with the other session's reasoning_content and the
+	// upstream prefix cache is lost.
+	auth := &cliproxyauth.Auth{ID: "auth-shared"}
+	first := opencodeGoSessionID(cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:x-deepseek-harness-session-id:ses_first",
+		},
+	}, auth)
+	second := opencodeGoSessionID(cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:x-deepseek-harness-session-id:ses_second",
+		},
+	}, auth)
+	if first == second {
+		t.Fatalf("expected distinct session ids for distinct sticky keys, both were %q", first)
+	}
+	if first == auth.ID || second == auth.ID {
+		t.Fatalf("expected sticky key to win over auth fallback, got %q and %q", first, second)
+	}
+}
+
+func TestOpenCodeGoSessionID_ExecutionSessionBeatsStickyKey(t *testing.T) {
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "exec_session",
+			cliproxyexecutor.SessionStickyMetadataKey:    "header:x-deepseek-harness-session-id:ses_abc",
+		},
+	}
+	if got := opencodeGoSessionID(opts, nil); got != "exec_session" {
+		t.Errorf("opencodeGoSessionID = %q, want exec_session", got)
+	}
+}
+
+func TestOpenCodeGoSessionID_BlankMetadataFallsThrough(t *testing.T) {
+	// A present-but-blank metadata value must not short-circuit the remaining
+	// candidates: blanks previously returned "" and skipped the auth fallback.
+	auth := &cliproxyauth.Auth{ID: "auth-1"}
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "   ",
+			cliproxyexecutor.SessionStickyMetadataKey:    "  ",
+		},
+	}
+	if got := opencodeGoSessionID(opts, auth); got != "auth-1" {
+		t.Errorf("opencodeGoSessionID = %q, want auth-1", got)
+	}
+}
+
 func TestOpenCodeGoSessionID_FallbackToAuthID(t *testing.T) {
 	auth := &cliproxyauth.Auth{ID: "opencode-go:apikey:abc123"}
 	opts := cliproxyexecutor.Options{}

--- a/internal/vision/session.go
+++ b/internal/vision/session.go
@@ -14,7 +14,8 @@ import (
 // Priority:
 //  1. opts.Metadata[ExecutionSessionMetadataKey]
 //  2. Session-Id header
-//  3. Return (empty, false) — never fallback to auth.ID
+//  3. opts.Metadata[SessionStickyMetadataKey]
+//  4. Return (empty, false) — never fallback to auth.ID
 func ResolveSessionKey(opts cliproxyexecutor.Options, auth *cliproxyauth.Auth) (SessionKey, bool) {
 	// 1. Metadata first — most reliable when available
 	if raw, ok := opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey]; ok {
@@ -30,6 +31,18 @@ func ResolveSessionKey(opts cliproxyexecutor.Options, auth *cliproxyauth.Auth) (
 		}
 	}
 
-	// 3. Never fallback to auth.ID for image memory — would leak across sessions
+	// 3. Sticky key — set only when the request carried a client-specific session
+	// header (DeepSeek Harness, Grok, Codex, …). ExecutionSessionMetadataKey is
+	// websocket-only, so without this those clients get no cross-turn image
+	// memory at all. Safe by construction: the sticky key is per conversation,
+	// not per API key, so it cannot leak images between sessions the way an
+	// auth.ID fallback would.
+	if raw, ok := opts.Metadata[cliproxyexecutor.SessionStickyMetadataKey]; ok {
+		if s, ok := raw.(string); ok && strings.TrimSpace(s) != "" {
+			return SessionKey(strings.TrimSpace(s)), true
+		}
+	}
+
+	// 4. Never fallback to auth.ID for image memory — would leak across sessions
 	return "", false
 }

--- a/internal/vision/session_test.go
+++ b/internal/vision/session_test.go
@@ -1,0 +1,85 @@
+package vision
+
+import (
+	"net/http"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func TestResolveSessionKey_FromStickyKey(t *testing.T) {
+	// ExecutionSessionMetadataKey is websocket-only, so header-based clients
+	// (DeepSeek Harness, Grok, …) reach image memory only through the sticky key.
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:x-deepseek-harness-session-id:ses_abc",
+		},
+	}
+	key, ok := ResolveSessionKey(opts, nil)
+	if !ok {
+		t.Fatal("expected a resolved session key")
+	}
+	if want := SessionKey("header:x-deepseek-harness-session-id:ses_abc"); key != want {
+		t.Fatalf("key = %q, want %q", key, want)
+	}
+}
+
+func TestResolveSessionKey_StickyKeysStayDistinct(t *testing.T) {
+	// Distinct conversations on one API key must not share an image registry.
+	auth := &cliproxyauth.Auth{ID: "auth-shared"}
+	first, okFirst := ResolveSessionKey(cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:x-deepseek-harness-session-id:ses_first",
+		},
+	}, auth)
+	second, okSecond := ResolveSessionKey(cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:x-deepseek-harness-session-id:ses_second",
+		},
+	}, auth)
+	if !okFirst || !okSecond {
+		t.Fatalf("expected both keys to resolve, got %v and %v", okFirst, okSecond)
+	}
+	if first == second {
+		t.Fatalf("expected distinct session keys, both were %q", first)
+	}
+}
+
+func TestResolveSessionKey_ExistingSourcesKeepPrecedence(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Session-Id", "sess_header")
+	opts := cliproxyexecutor.Options{
+		Headers: headers,
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "header:x-deepseek-harness-session-id:ses_abc",
+		},
+	}
+	key, ok := ResolveSessionKey(opts, nil)
+	if !ok || key != SessionKey("sess_header") {
+		t.Fatalf("key = %q (ok=%v), want sess_header", key, ok)
+	}
+
+	opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey] = "exec_session"
+	key, ok = ResolveSessionKey(opts, nil)
+	if !ok || key != SessionKey("exec_session") {
+		t.Fatalf("key = %q (ok=%v), want exec_session", key, ok)
+	}
+}
+
+func TestResolveSessionKey_NeverFallsBackToAuthID(t *testing.T) {
+	// The existing safety property: without a real session identity there is no
+	// cross-turn image memory, because auth.ID would leak images between sessions.
+	auth := &cliproxyauth.Auth{ID: "auth-1"}
+	if key, ok := ResolveSessionKey(cliproxyexecutor.Options{}, auth); ok || key != "" {
+		t.Fatalf("key = %q (ok=%v), want empty and false", key, ok)
+	}
+	blank := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SessionStickyMetadataKey: "   ",
+		},
+	}
+	if key, ok := ResolveSessionKey(blank, auth); ok || key != "" {
+		t.Fatalf("blank sticky key = %q (ok=%v), want empty and false", key, ok)
+	}
+}

--- a/sdk/api/handlers/session_sticky.go
+++ b/sdk/api/handlers/session_sticky.go
@@ -13,6 +13,11 @@ func requestSessionStickyHeaderKey(c *gin.Context) string {
 	// Prefer stable client session / conversation headers. Grok/xAI clients send
 	// X-Grok-Session-Id / X-Grok-Conv-Id rather than generic Session-Id; without
 	// them session-sticky collapses many concurrent chats onto one auth binding.
+	// DeepSeek Harness likewise sends only X-Deepseek-Harness-Session-Id (per
+	// turn, stable for the session) and no generic header or body session field:
+	// missing it leaves the seed empty, so applySessionPromptCacheKey emits no
+	// prompt_cache_key and the turn drifts across auth bindings, losing the
+	// provider-side prefix cache that is scoped per upstream account.
 	for _, header := range []string{
 		"Session-Id",
 		"session_id",
@@ -20,6 +25,7 @@ func requestSessionStickyHeaderKey(c *gin.Context) string {
 		"X-Codex-Session-Id",
 		"X-Claude-Code-Session-Id",
 		"X-Grok-Session-Id",
+		"X-Deepseek-Harness-Session-Id",
 		"Conversation-Id",
 		"conversation_id",
 		"X-Conversation-Id",

--- a/sdk/api/handlers/session_sticky_test.go
+++ b/sdk/api/handlers/session_sticky_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newStickyContext(t *testing.T, headers map[string]string) *gin.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	for name, value := range headers {
+		c.Request.Header.Set(name, value)
+	}
+	return c
+}
+
+func TestRequestSessionStickyHeaderKey_DeepSeekHarness(t *testing.T) {
+	// DeepSeek Harness sends the header lowercased on every turn; Go canonicalizes
+	// it, so the wire casing must not change the derived sticky key.
+	for _, header := range []string{
+		"x-deepseek-harness-session-id",
+		"X-Deepseek-Harness-Session-Id",
+		"X-DEEPSEEK-HARNESS-SESSION-ID",
+	} {
+		c := newStickyContext(t, map[string]string{header: "ses_abc123"})
+		got := requestSessionStickyHeaderKey(c)
+		want := "header:x-deepseek-harness-session-id:ses_abc123"
+		if got != want {
+			t.Fatalf("header %q: got %q, want %q", header, got, want)
+		}
+	}
+}
+
+func TestRequestSessionStickyHeaderKey_DeepSeekHarnessDistinctSessions(t *testing.T) {
+	// Two concurrent harness sessions must not collapse onto one auth binding:
+	// each keeps its own upstream account, and therefore its own prefix cache.
+	first := requestSessionStickyHeaderKey(newStickyContext(t, map[string]string{
+		"x-deepseek-harness-session-id": "ses_first",
+	}))
+	second := requestSessionStickyHeaderKey(newStickyContext(t, map[string]string{
+		"x-deepseek-harness-session-id": "ses_second",
+	}))
+	if first == "" || second == "" {
+		t.Fatalf("expected non-empty sticky keys, got %q and %q", first, second)
+	}
+	if first == second {
+		t.Fatalf("expected distinct sticky keys, both were %q", first)
+	}
+}
+
+func TestRequestSessionStickyHeaderKey_GenericHeaderStillWins(t *testing.T) {
+	// The generic header keeps its existing precedence; adding the harness entry
+	// must not reorder callers that already send Session-Id.
+	c := newStickyContext(t, map[string]string{
+		"Session-Id":                    "generic",
+		"x-deepseek-harness-session-id": "ses_abc123",
+	})
+	if got, want := requestSessionStickyHeaderKey(c), "header:session-id:generic"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestRequestSessionStickyHeaderKey_NoHeaders(t *testing.T) {
+	// No recognized header means no seed at all: applySessionPromptCacheKey then
+	// emits no prompt_cache_key rather than inventing an unstable one.
+	if got := requestSessionStickyHeaderKey(newStickyContext(t, nil)); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+	if got := requestSessionStickyHeaderKey(nil); got != "" {
+		t.Fatalf("nil context: got %q, want empty", got)
+	}
+}
+
+func TestRequestSessionStickyHeaderKey_BlankValueIgnored(t *testing.T) {
+	// A present-but-blank header must fall through to the next candidate instead
+	// of binding every such request to one shared key.
+	c := newStickyContext(t, map[string]string{
+		"x-deepseek-harness-session-id": "   ",
+		"X-Conversation-Id":             "conv-1",
+	})
+	if got, want := requestSessionStickyHeaderKey(c), "header:x-conversation-id:conv-1"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## 问题

DeepSeek Harness（dsh）经 opencode-go 渠道调用 deepseek-v4-flash 时，上游 prompt 缓存命中率极低且忽高忽低。

根因是 dsh 每轮都发 `X-Deepseek-Harness-Session-Id`，但**不发**通用的 `Session-Id`，body 里也没有 `session_id`/`conversation_id`。网关因此完全推导不出它的会话身份，导致两条独立的破坏路径：

1. `requestSessionStickyHeaderKey` 不认识该 header → sticky key 为空 → `applySessionPromptCacheKey` 不注入 `prompt_cache_key`，同一会话的请求在多个 auth 绑定间漂移。上游前缀缓存是按账号隔离的，漂移即必然 miss。
2. `opencodeGoSessionID` 三个来源全部落空（`ExecutionSessionMetadataKey` 仅 websocket 路径设置），回退到 `auth.ID`。而 `reasoningCacheMaxEntriesPerKey == 1`，于是**同一 API key 下所有并发会话共用一个 reasoning 槽位**，互相覆盖，每轮被注入其它会话的 `reasoning_content`，请求前缀持续变化。

第 2 条影响更大，且在并发使用 subagent 时被显著放大。

## 改动

- `session_sticky.go`：header 白名单补 `X-Deepseek-Harness-Session-Id`。
- `opencode_go_reasoning.go`：`opencodeGoSessionID` 在回退到 `auth.ID` 前先读 sticky key —— 该 key 本就携带所需的会话身份，无需新增机制。顺带修正空白 metadata 值会短路后续候选的问题。
- `vision/session.go`：`ResolveSessionKey` 同源问题（header 类客户端拿不到 key，跨轮图片记忆静默失效）。sticky key 在此安全的理由与 `auth.ID` 不同：它按会话而非按 API key 划分，不会在并发会话间泄漏图片。

三处均保持既有来源的优先级不变，只在原本必然失败的分支上补一条来源。

## 验证

- 新增 13 个用例：sticky header 解析 5、`opencodeGoSessionID` 4、`ResolveSessionKey` 4。含关键回归：同一 auth 下不同会话必须得到不同 id。
- 既有用例（含 `TestOpenCodeGoSessionID_FallbackToAuthID`）无回归。
- 完整 `./scripts/ci-pr.sh` 通过（退出码 0）：结构检查、gofmt、secret scan、`go vet`、`go test ./...`、golangci-lint v1.64.5、`go build`。

真实命中率需部署后用 dsh 实测 `prompt_cache_hit_tokens` 确认；本 PR 仅在代码层面证明会话身份已正确传递。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
