### PR TITLE
fix(usage): stop logging alias-only upstream models and estimate Ollama cache reads

### DIFF
--- a/internal/runtime/executor/model_identity.go
+++ b/internal/runtime/executor/model_identity.go
@@ -1,0 +1,26 @@
+package executor
+
+import "strings"
+
+// sameModelIdentity reports whether a requested model name and the model that
+// was actually sent upstream denote the same model.
+//
+// Provider aliases usually only add a routing segment: an Ollama Cloud account
+// exposing "deepseek-v4-flash:0731" as "ollama/deepseek-v4-flash:0731" makes the
+// executor send the unprefixed name upstream while the request log keeps the
+// prefixed one. Recording that pair as "requested X, upstream Y" turns every
+// aliased request into a bogus "real model ID" hint in the console, so treat a
+// pure routing-prefix difference as the same model. Aliases that rename the
+// model (for example "fast" -> "claude-sonnet-4") stay different and are still
+// reported, because there the upstream ID carries real information.
+func sameModelIdentity(requested, upstream string) bool {
+	a := strings.ToLower(strings.TrimSpace(requested))
+	b := strings.ToLower(strings.TrimSpace(upstream))
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return strings.HasSuffix(a, "/"+b) || strings.HasSuffix(b, "/"+a)
+}

--- a/internal/runtime/executor/model_identity_test.go
+++ b/internal/runtime/executor/model_identity_test.go
@@ -1,0 +1,100 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestSameModelIdentityTreatsRoutingPrefixAsSameModel(t *testing.T) {
+	cases := []struct {
+		name      string
+		requested string
+		upstream  string
+		want      bool
+	}{
+		{"identical", "deepseek-v4-flash:0731", "deepseek-v4-flash:0731", true},
+		{"provider prefix alias", "ollama/deepseek-v4-flash:0731", "deepseek-v4-flash:0731", true},
+		{"group prefix alias", "cline-pass/deepseek-v4-flash", "deepseek-v4-flash", true},
+		{"nested prefix alias", "group/ollama/gpt-oss:20b", "gpt-oss:20b", true},
+		{"case insensitive", "Ollama/GPT-OSS:20B", "gpt-oss:20b", true},
+		{"renaming alias", "fast", "claude-sonnet-4", false},
+		{"different models", "gpt-oss:20b", "gpt-oss:120b", false},
+		{"substring without separator", "xdeepseek-v4-flash", "deepseek-v4-flash", false},
+		{"empty upstream", "deepseek-v4-flash", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameModelIdentity(tc.requested, tc.upstream); got != tc.want {
+				t.Fatalf("sameModelIdentity(%q, %q) = %v, want %v", tc.requested, tc.upstream, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUsageReporterDropsAliasOnlyUpstreamModel(t *testing.T) {
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/deepseek-v4-flash:0731", "deepseek-v4-flash:0731", &cliproxyauth.Auth{})
+	if reporter.upstreamModel != "" {
+		t.Fatalf("upstream model = %q, want empty for a prefix-only alias", reporter.upstreamModel)
+	}
+}
+
+func TestUsageReporterKeepsRenamingUpstreamModel(t *testing.T) {
+	reporter := newUsageReporter(context.Background(), "claude", "fast", "claude-sonnet-4", &cliproxyauth.Auth{})
+	if reporter.upstreamModel != "claude-sonnet-4" {
+		t.Fatalf("upstream model = %q, want claude-sonnet-4", reporter.upstreamModel)
+	}
+}
+
+func TestUsageReporterSettersRejectAliasOnlyNames(t *testing.T) {
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/gpt-oss:20b", "", &cliproxyauth.Auth{})
+	reporter.setUpstreamModel("gpt-oss:20b")
+	reporter.setVisionFallbackModel("gpt-oss:20b")
+	if reporter.upstreamModel != "" || reporter.visionFallbackModel != "" {
+		t.Fatalf("upstream/fallback = %q/%q, want both empty", reporter.upstreamModel, reporter.visionFallbackModel)
+	}
+
+	reporter.setVisionFallbackModel("qwen3.5-plus")
+	if reporter.visionFallbackModel != "qwen3.5-plus" {
+		t.Fatalf("vision fallback = %q, want qwen3.5-plus", reporter.visionFallbackModel)
+	}
+}
+
+// setModel re-evaluates the recorded upstream name: a vision fallback rewrites the
+// logged model after construction, and the record must not keep a name that has
+// meanwhile become an alias of it.
+func TestUsageReporterSetModelClearsNowRedundantUpstream(t *testing.T) {
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "some-other-model", "deepseek-v4-flash:0731", &cliproxyauth.Auth{})
+	if reporter.upstreamModel == "" {
+		t.Fatal("precondition: upstream model should be recorded for unrelated models")
+	}
+	reporter.setModel("ollama/deepseek-v4-flash:0731")
+	if reporter.upstreamModel != "" {
+		t.Fatalf("upstream model = %q, want empty after the logged model became its alias", reporter.upstreamModel)
+	}
+}
+
+// A retry of the same request must not be scored against its own stored prompt:
+// that would report a full cache hit for work the upstream is doing again.
+func TestOllamaPromptCacheEstimatorReplaysEstimateOnRetry(t *testing.T) {
+	key := "ollama-retry-test"
+	first := strings.Repeat("stable session prefix ", 400)
+	second := first + "next turn"
+
+	if got := newOllamaPromptCacheEstimator(key, first).estimate(1000); got != 0 {
+		t.Fatalf("first turn estimate = %d, want 0", got)
+	}
+	turnTwo := newOllamaPromptCacheEstimator(key, second).estimate(1000)
+	if turnTwo <= 0 {
+		t.Fatalf("second turn estimate = %d, want a positive cache hit", turnTwo)
+	}
+	retry := newOllamaPromptCacheEstimator(key, second).estimate(1000)
+	if retry != turnTwo {
+		t.Fatalf("retry estimate = %d, want the original %d", retry, turnTwo)
+	}
+	if retry >= 1000 {
+		t.Fatalf("retry estimate = %d, must not claim the whole prompt was cached", retry)
+	}
+}

--- a/internal/runtime/executor/ollama_cloud_executor.go
+++ b/internal/runtime/executor/ollama_cloud_executor.go
@@ -79,7 +79,7 @@ func (e *OllamaCloudExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
-	ctx = preparedCtx
+	ctx = withOllamaPromptCacheEstimator(preparedCtx, auth, prepared.Request, opts)
 	req = prepared.Request
 
 	var resp cliproxyexecutor.Response
@@ -102,7 +102,7 @@ func (e *OllamaCloudExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	if err != nil {
 		return nil, err
 	}
-	ctx = preparedCtx
+	ctx = withOllamaPromptCacheEstimator(preparedCtx, auth, prepared.Request, opts)
 	req = prepared.Request
 
 	var result *cliproxyexecutor.StreamResult

--- a/internal/runtime/executor/ollama_cloud_executor_test.go
+++ b/internal/runtime/executor/ollama_cloud_executor_test.go
@@ -5,13 +5,16 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	"github.com/tidwall/gjson"
 )
@@ -286,8 +289,8 @@ func TestOllamaCloudNativeCacheKeyScopesExplicitPromptKey(t *testing.T) {
 	authA := &cliproxyauth.Auth{ID: "ollama-cloud:one"}
 	authB := &cliproxyauth.Auth{ID: "ollama-cloud:two"}
 
-	keyA := ollamaNativeCacheKey(authA, "glm-5.2", source, nil, cliproxyexecutor.Options{})
-	keyB := ollamaNativeCacheKey(authB, "glm-5.2", source, nil, cliproxyexecutor.Options{})
+	keyA := ollamaPromptCacheKey(authA, "glm-5.2", source, cliproxyexecutor.Options{}, "hi")
+	keyB := ollamaPromptCacheKey(authB, "glm-5.2", source, cliproxyexecutor.Options{}, "hi")
 
 	if keyA == "" || keyB == "" {
 		t.Fatalf("cache keys must be present: %q / %q", keyA, keyB)
@@ -335,7 +338,7 @@ func TestOllamaCloudExecutorRoutesResponsesToNativeChat(t *testing.T) {
 }
 
 func TestOllamaCloudNativeChatConvertsToolCallArguments(t *testing.T) {
-	body, _ := ollamaNativeChatRequest([]byte(`{
+	body := ollamaNativeChatRequest([]byte(`{
 		"model":"deepseek-v4-flash",
 		"messages":[
 			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"exec_command","arguments":"{\"cmd\":\"cat /Users/kittors/.codex/RTK.md\"}"}}]},
@@ -445,6 +448,56 @@ func TestOllamaCloudExecutorClaudeMessagesAddsCacheControl(t *testing.T) {
 	}
 	if got := gjson.GetBytes(gotBody, "messages.0.content.0.cache_control.type").String(); got != "ephemeral" {
 		t.Fatalf("cache_control = %q, want ephemeral; body=%s", got, gotBody)
+	}
+}
+
+// Ollama's Anthropic-compatible endpoint never returns cache_read_input_tokens,
+// so Claude-format clients (Claude Code and friends) used to log a flat 0 cached
+// tokens for every turn of a conversation. The estimate must cover this path too,
+// not just native /api/chat.
+func TestOllamaCloudExecutorClaudeMessagesReportsEstimatedCacheHit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"glm-5.2","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1000,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	exec := NewOllamaCloudExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{ID: "ollama-cloud:apikey:claude", Attributes: map[string]string{"api_key": "test-key", "base_url": server.URL}}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
+	history := strings.Repeat("shared conversation history ", 400)
+
+	for _, turn := range []string{history, history + " plus one more turn"} {
+		payload := []byte(`{"model":"glm-5.2","max_tokens":1024,"messages":[{"role":"user","content":` + strconv.Quote(turn) + `}]}`)
+		if _, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{Model: "glm-5.2", Payload: payload}, opts); err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+	}
+
+	timer := time.After(2 * time.Second)
+	var lastCached int64
+	for {
+		select {
+		case record := <-usagePlugin.records:
+			if record.Provider != "ollama-cloud" {
+				continue
+			}
+			lastCached = record.Detail.CachedTokens
+			if lastCached > 0 {
+				if record.Detail.CacheReadTokens != lastCached {
+					t.Fatalf("cache read = %d, want %d", record.Detail.CacheReadTokens, lastCached)
+				}
+				if lastCached > record.Detail.InputTokens {
+					t.Fatalf("cached tokens %d exceed input tokens %d", lastCached, record.Detail.InputTokens)
+				}
+				return
+			}
+		case <-timer:
+			t.Fatalf("timed out waiting for a cache estimate on the Claude path (last cached=%d)", lastCached)
+		}
 	}
 }
 

--- a/internal/runtime/executor/ollama_cloud_native_chat.go
+++ b/internal/runtime/executor/ollama_cloud_native_chat.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -26,7 +25,7 @@ import (
 const ollamaCloudNativeKeepAlive = "30m"
 
 func (e *OllamaCloudExecutor) executeNativeChat(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	execCtx, translated, body, cacheKey, promptText, err := e.prepareNativeChat(ctx, auth, req, opts, false)
+	execCtx, translated, body, err := e.prepareNativeChat(ctx, auth, req, opts, false)
 	if err != nil {
 		return resp, err
 	}
@@ -58,7 +57,7 @@ func (e *OllamaCloudExecutor) executeNativeChat(ctx context.Context, auth *clipr
 		return resp, err
 	}
 	recorder.AppendResponseChunk(data)
-	openAIResponse := ollamaNativeChatToOpenAI(data, execCtx.BaseModel, cacheKey, promptText)
+	openAIResponse := ollamaNativeChatToOpenAI(data, execCtx.BaseModel, ollamaPromptCacheEstimatorFromContext(execCtx.Context))
 	reporter.publishWithContent(execCtx.Context, parseOpenAIUsage(openAIResponse), string(req.Payload), string(openAIResponse))
 	reporter.ensurePublished(execCtx.Context)
 
@@ -68,10 +67,11 @@ func (e *OllamaCloudExecutor) executeNativeChat(ctx context.Context, auth *clipr
 }
 
 func (e *OllamaCloudExecutor) executeNativeChatStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	execCtx, translated, body, cacheKey, promptText, err := e.prepareNativeChat(ctx, auth, req, opts, true)
+	execCtx, translated, body, err := e.prepareNativeChat(ctx, auth, req, opts, true)
 	if err != nil {
 		return nil, err
 	}
+	estimator := ollamaPromptCacheEstimatorFromContext(execCtx.Context)
 	reporter := execCtx.Reporter()
 	defer reporter.trackFailure(execCtx.Context, &err)
 
@@ -117,7 +117,7 @@ func (e *OllamaCloudExecutor) executeNativeChatStream(ctx context.Context, auth 
 				continue
 			}
 			recorder.AppendResponseChunk(line)
-			openAILines, usage, usageSeen := ollamaNativeStreamChunkToOpenAI(line, execCtx.BaseModel, responseID, cacheKey, promptText, &roleSent)
+			openAILines, usage, usageSeen := ollamaNativeStreamChunkToOpenAI(line, execCtx.BaseModel, responseID, estimator, &roleSent)
 			if usageSeen {
 				lastUsage = usage
 				hasUsage = true
@@ -161,7 +161,7 @@ func (e *OllamaCloudExecutor) executeNativeChatStream(ctx context.Context, auth 
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }
 
-func (e *OllamaCloudExecutor) prepareNativeChat(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*ExecutionContext, []byte, []byte, string, string, error) {
+func (e *OllamaCloudExecutor) prepareNativeChat(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*ExecutionContext, []byte, []byte, error) {
 	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
 		TargetFormat:      sdktranslator.FormatOpenAI,
 		TranslateAsStream: stream,
@@ -171,14 +171,13 @@ func (e *OllamaCloudExecutor) prepareNativeChat(ctx context.Context, auth *clipr
 	translated = execCtx.ApplyPayloadConfig(translated, originalTranslated)
 	updated, err := thinking.ApplyThinking(translated, req.Model, execCtx.SourceFormat.String(), sdktranslator.FormatOpenAI.String(), e.Identifier())
 	if err != nil {
-		return nil, nil, nil, "", "", err
+		return nil, nil, nil, err
 	}
 	updated = applyOllamaCloudImagePolicy(req, updated)
 	updated = normalizeOpenAIChatToolCallMessages(updated)
 	updated = applyProviderPromptCaching(updated, req.Payload, auth, e.Identifier(), execCtx.BaseModel, sdktranslator.FormatOpenAI, opts)
-	body, promptText := ollamaNativeChatRequest(updated, stream)
-	cacheKey := ollamaNativeCacheKey(auth, execCtx.BaseModel, req.Payload, updated, opts)
-	return execCtx, updated, body, cacheKey, promptText, nil
+	body := ollamaNativeChatRequest(updated, stream)
+	return execCtx, updated, body, nil
 }
 
 func (e *OllamaCloudExecutor) doNativeChatJSON(execCtx *ExecutionContext, auth *cliproxyauth.Auth, body []byte, stream bool) (*http.Response, error) {
@@ -226,12 +225,12 @@ func ollamaCloudNativeBaseURL(baseURL string) string {
 	return base
 }
 
-func ollamaNativeChatRequest(openAIChat []byte, stream bool) ([]byte, string) {
+func ollamaNativeChatRequest(openAIChat []byte, stream bool) []byte {
 	var root map[string]any
 	if err := json.Unmarshal(openAIChat, &root); err != nil {
-		return openAIChat, ""
+		return openAIChat
 	}
-	messages, promptText := ollamaNativeMessages(root["messages"])
+	messages := ollamaNativeMessages(root["messages"])
 	out := map[string]any{
 		"model":      strings.TrimSpace(fmt.Sprint(root["model"])),
 		"messages":   messages,
@@ -249,29 +248,14 @@ func ollamaNativeChatRequest(openAIChat []byte, stream bool) ([]byte, string) {
 	}
 	body, err := json.Marshal(out)
 	if err != nil {
-		return openAIChat, promptText
+		return openAIChat
 	}
-	return body, promptText
+	return body
 }
 
-func ollamaNativeCacheKey(auth *cliproxyauth.Auth, model string, source, translated []byte, opts cliproxyexecutor.Options) string {
-	seed := sessionPromptCacheSeed(opts, source)
-	if seed == "" {
-		seed = sessionPromptCacheSeed(opts, translated)
-	}
-	if seed == "" {
-		seed = strings.TrimSpace(gjson.GetBytes(source, "prompt_cache_key").String())
-	}
-	if seed == "" {
-		seed = strings.TrimSpace(gjson.GetBytes(translated, "prompt_cache_key").String())
-	}
-	return scopedPromptCacheKey(auth, model, seed)
-}
-
-func ollamaNativeMessages(raw any) ([]any, string) {
+func ollamaNativeMessages(raw any) []any {
 	items, _ := raw.([]any)
 	messages := make([]any, 0, len(items))
-	var prompt strings.Builder
 	toolNames := map[string]string{}
 	for _, item := range items {
 		msg, ok := item.(map[string]any)
@@ -299,12 +283,8 @@ func ollamaNativeMessages(raw any) ([]any, string) {
 			}
 		}
 		messages = append(messages, next)
-		prompt.WriteString(role)
-		prompt.WriteByte('\n')
-		prompt.WriteString(content)
-		prompt.WriteByte('\n')
 	}
-	return messages, prompt.String()
+	return messages
 }
 
 func normalizeOllamaNativeToolCalls(calls []any, toolNames map[string]string) {
@@ -433,11 +413,11 @@ func ollamaNativeOptions(root map[string]any) map[string]any {
 	return options
 }
 
-func ollamaNativeChatToOpenAI(native []byte, model, cacheKey, promptText string) []byte {
+func ollamaNativeChatToOpenAI(native []byte, model string, estimator *ollamaPromptCacheEstimator) []byte {
 	root := gjson.ParseBytes(native)
 	promptTokens := root.Get("prompt_eval_count").Int()
 	outputTokens := root.Get("eval_count").Int()
-	cachedTokens := ollamaPromptCacheEstimateAndStore(cacheKey, promptText, promptTokens)
+	cachedTokens := estimator.estimate(promptTokens)
 	out := `{"id":"","object":"chat.completion","created":0,"model":"","choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"prompt_tokens_details":{"cached_tokens":0}}}`
 	out, _ = sjson.Set(out, "id", fmt.Sprintf("chatcmpl_%x", time.Now().UnixNano()))
 	out, _ = sjson.Set(out, "created", time.Now().Unix())
@@ -456,7 +436,7 @@ func ollamaNativeChatToOpenAI(native []byte, model, cacheKey, promptText string)
 	return []byte(out)
 }
 
-func ollamaNativeStreamChunkToOpenAI(line []byte, model, responseID, cacheKey, promptText string, roleSent *bool) ([][]byte, coreusage.Detail, bool) {
+func ollamaNativeStreamChunkToOpenAI(line []byte, model, responseID string, estimator *ollamaPromptCacheEstimator, roleSent *bool) ([][]byte, coreusage.Detail, bool) {
 	root := gjson.ParseBytes(line)
 	created := time.Now().Unix()
 	var out [][]byte
@@ -481,7 +461,7 @@ func ollamaNativeStreamChunkToOpenAI(line []byte, model, responseID, cacheKey, p
 	out = append(out, ollamaOpenAIStreamDoneLine(responseID, model, created, root.Get("done_reason").String()))
 	promptTokens := root.Get("prompt_eval_count").Int()
 	outputTokens := root.Get("eval_count").Int()
-	cachedTokens := ollamaPromptCacheEstimateAndStore(cacheKey, promptText, promptTokens)
+	cachedTokens := estimator.estimate(promptTokens)
 	usage := coreusage.Detail{
 		InputTokens:              promptTokens,
 		OutputTokens:             outputTokens,
@@ -543,52 +523,5 @@ func ollamaOpenAIStreamDoneLine(id, model string, created int64, reason string) 
 	return append(append([]byte("data: "), payload...), '\n', '\n')
 }
 
-type ollamaPromptCacheEntry struct {
-	prompt    string
-	expiresAt time.Time
-}
-
-var ollamaPromptCache sync.Map
-
-func ollamaPromptCacheEstimateAndStore(cacheKey, prompt string, inputTokens int64) int64 {
-	cacheKey = strings.TrimSpace(cacheKey)
-	if cacheKey == "" || strings.TrimSpace(prompt) == "" || inputTokens <= 0 {
-		return 0
-	}
-	now := time.Now()
-	var cached int64
-	if raw, ok := ollamaPromptCache.Load(cacheKey); ok {
-		entry, _ := raw.(ollamaPromptCacheEntry)
-		if now.Before(entry.expiresAt) {
-			common := commonPrefixLen(entry.prompt, prompt)
-			if common >= 4096 && len(prompt) > 0 {
-				cached = inputTokens * int64(common) / int64(len(prompt))
-				if cached > inputTokens {
-					cached = inputTokens
-				}
-			}
-		}
-	}
-	// Native Ollama exercises the real runner prefix cache via /api/chat +
-	// keep_alive, but its API reports prompt_eval_count, not cached token count.
-	// Expose an OpenAI-compatible cache read estimate from the stable session
-	// prefix so dashboards can show the hit without claiming provider reporting.
-	ollamaPromptCache.Store(cacheKey, ollamaPromptCacheEntry{
-		prompt:    prompt,
-		expiresAt: now.Add(30 * time.Minute),
-	})
-	return cached
-}
-
-func commonPrefixLen(a, b string) int {
-	limit := len(a)
-	if len(b) < limit {
-		limit = len(b)
-	}
-	for i := 0; i < limit; i++ {
-		if a[i] != b[i] {
-			return i
-		}
-	}
-	return limit
-}
+// Prompt-cache estimation lives in ollama_cloud_prompt_cache.go so the native,
+// Anthropic-compatible and OpenAI-compatible paths share one estimate per request.

--- a/internal/runtime/executor/ollama_cloud_prompt_cache.go
+++ b/internal/runtime/executor/ollama_cloud_prompt_cache.go
@@ -1,0 +1,235 @@
+package executor
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	"github.com/tidwall/gjson"
+)
+
+// Ollama never reports prompt-cache counters. The native /api/chat response only
+// carries prompt_eval_count, and both the OpenAI- and Anthropic-compatible
+// endpoints mirror that shape, so every Ollama Cloud request used to log zero
+// cached tokens even though the runner keeps a prefix cache alive between turns
+// (see ollamaCloudNativeKeepAlive). We derive a cache-read estimate from the
+// stable session prefix instead, and only when the upstream reported nothing of
+// its own — if Ollama ever starts publishing real counters they win.
+
+const (
+	// A prefix shorter than this is noise (shared system preamble at most), not a
+	// reused conversation, so it must not be reported as a cache hit.
+	ollamaPromptCacheMinPrefixChars = 4096
+	// Prefix window used to derive a session key when the client sends no session
+	// identifier: the opening of a conversation (system prompt plus first turn) is
+	// stable across turns while differing between conversations.
+	ollamaPromptCacheFingerprintChars = 2048
+	ollamaPromptCacheTTL              = 30 * time.Minute
+)
+
+type ollamaPromptCacheEntry struct {
+	prompt string
+	// commonLen of the request that stored this prompt, replayed when the exact
+	// same prompt comes back (see newOllamaPromptCacheEstimator).
+	commonLen int
+	expiresAt time.Time
+}
+
+var ollamaPromptCache sync.Map
+
+// ollamaPromptCacheEstimator holds one request's cache-read estimate. It is
+// created once per request, before the upstream call: construction compares the
+// prompt against the previous turn of the same session and immediately stores
+// the new prompt, so later usage events (streaming emits several) can be scored
+// without re-reading a cache the current request has already overwritten.
+type ollamaPromptCacheEstimator struct {
+	promptLen int
+	commonLen int
+}
+
+type ollamaPromptCacheContextKey struct{}
+
+func contextWithOllamaPromptCacheEstimator(ctx context.Context, estimator *ollamaPromptCacheEstimator) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if estimator == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ollamaPromptCacheContextKey{}, estimator)
+}
+
+func ollamaPromptCacheEstimatorFromContext(ctx context.Context) *ollamaPromptCacheEstimator {
+	if ctx == nil {
+		return nil
+	}
+	estimator, _ := ctx.Value(ollamaPromptCacheContextKey{}).(*ollamaPromptCacheEstimator)
+	return estimator
+}
+
+func newOllamaPromptCacheEstimator(cacheKey, prompt string) *ollamaPromptCacheEstimator {
+	cacheKey = strings.TrimSpace(cacheKey)
+	if cacheKey == "" || strings.TrimSpace(prompt) == "" {
+		return nil
+	}
+	now := time.Now()
+	commonLen := 0
+	if raw, ok := ollamaPromptCache.Load(cacheKey); ok {
+		if entry, _ := raw.(ollamaPromptCacheEntry); now.Before(entry.expiresAt) {
+			if entry.prompt == prompt {
+				// Identical prompt on the same key means this request is being retried
+				// (same account, new attempt), not a new turn. Scoring it against itself
+				// would claim a 100% cache hit, so replay the original estimate.
+				commonLen = entry.commonLen
+			} else {
+				commonLen = commonPrefixLen(entry.prompt, prompt)
+			}
+		}
+	}
+	ollamaPromptCache.Store(cacheKey, ollamaPromptCacheEntry{
+		prompt:    prompt,
+		commonLen: commonLen,
+		expiresAt: now.Add(ollamaPromptCacheTTL),
+	})
+	return &ollamaPromptCacheEstimator{promptLen: len(prompt), commonLen: commonLen}
+}
+
+// estimate converts the shared prefix into a token count, proportionally to the
+// prompt tokens the upstream did report for this request.
+func (e *ollamaPromptCacheEstimator) estimate(inputTokens int64) int64 {
+	if e == nil || inputTokens <= 0 || e.promptLen <= 0 {
+		return 0
+	}
+	if e.commonLen < ollamaPromptCacheMinPrefixChars {
+		return 0
+	}
+	cached := inputTokens * int64(e.commonLen) / int64(e.promptLen)
+	if cached > inputTokens {
+		cached = inputTokens
+	}
+	return cached
+}
+
+// applyOllamaPromptCacheEstimate fills the cache-read counters of a usage detail
+// that the provider left empty. Called from the usage reporter so it covers every
+// Ollama Cloud path: native /api/chat, the Anthropic-compatible /messages
+// executor, and the OpenAI-compatible executor it delegates to.
+func applyOllamaPromptCacheEstimate(ctx context.Context, detail coreusage.Detail) coreusage.Detail {
+	if detail.CachedTokens > 0 || detail.CacheReadTokens > 0 || detail.CacheWriteTokens > 0 {
+		return detail
+	}
+	cached := ollamaPromptCacheEstimatorFromContext(ctx).estimate(detail.InputTokens)
+	if cached <= 0 {
+		return detail
+	}
+	detail.CacheReadTokens = cached
+	detail.CachedTokens = cached
+	// Ollama counts the whole prompt in prompt_eval_count / input_tokens, so the
+	// cached part is included rather than additive.
+	detail.CacheReadIncludedInInput = true
+	return detail
+}
+
+// withOllamaPromptCacheEstimator attaches one estimate to the request context.
+// It is installed at the executor entry points so the native, Anthropic- and
+// OpenAI-compatible branches all score the same prompt exactly once.
+func withOllamaPromptCacheEstimator(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) context.Context {
+	prompt := ollamaPromptCacheText(req.Payload)
+	if prompt == "" {
+		return ctx
+	}
+	model := thinking.ParseSuffix(req.Model).ModelName
+	key := ollamaPromptCacheKey(auth, model, req.Payload, opts, prompt)
+	return contextWithOllamaPromptCacheEstimator(ctx, newOllamaPromptCacheEstimator(key, prompt))
+}
+
+// ollamaPromptCacheKey scopes the estimate to one conversation on one account.
+// Clients that send a session identifier get the shared session key; the rest
+// fall back to a fingerprint of the prompt opening, which is stable across the
+// turns of a conversation and distinct between conversations.
+func ollamaPromptCacheKey(auth *cliproxyauth.Auth, model string, payload []byte, opts cliproxyexecutor.Options, prompt string) string {
+	seed := sessionPromptCacheSeed(opts, payload)
+	if seed == "" {
+		seed = strings.TrimSpace(gjson.GetBytes(payload, "prompt_cache_key").String())
+	}
+	if seed == "" {
+		if prompt = strings.TrimSpace(prompt); prompt == "" {
+			return ""
+		}
+		head := prompt
+		if len(head) > ollamaPromptCacheFingerprintChars {
+			head = head[:ollamaPromptCacheFingerprintChars]
+		}
+		sum := sha256.Sum256([]byte(head))
+		seed = "prompt-prefix:" + hex.EncodeToString(sum[:16])
+	}
+	return scopedPromptCacheKey(auth, model, seed)
+}
+
+// ollamaPromptCacheText flattens the conversation of a request payload into the
+// text used for prefix comparison. It accepts every source format Ollama Cloud
+// serves (Claude messages, OpenAI chat, OpenAI responses, Gemini contents) since
+// the executor sees the client's original payload, not a normalized one.
+func ollamaPromptCacheText(payload []byte) string {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return ""
+	}
+	root := gjson.ParseBytes(payload)
+	var builder strings.Builder
+	appendNode(&builder, root.Get("system"))
+	appendNode(&builder, root.Get("system_instruction"))
+	appendNode(&builder, root.Get("systemInstruction"))
+	for _, key := range []string{"messages", "input", "contents"} {
+		node := root.Get(key)
+		if !node.Exists() {
+			continue
+		}
+		appendNode(&builder, node)
+		break
+	}
+	return builder.String()
+}
+
+// appendNode walks the message tree and keeps only textual leaves, so that
+// per-request noise such as ids or booleans cannot break the shared prefix.
+func appendNode(builder *strings.Builder, node gjson.Result) {
+	if !node.Exists() {
+		return
+	}
+	switch {
+	case node.IsArray():
+		node.ForEach(func(_, value gjson.Result) bool {
+			appendNode(builder, value)
+			return true
+		})
+	case node.IsObject():
+		for _, key := range []string{"role", "type", "name", "text", "content", "parts", "arguments", "input"} {
+			appendNode(builder, node.Get(key))
+		}
+	default:
+		if text := node.String(); text != "" {
+			builder.WriteString(text)
+			builder.WriteByte('\n')
+		}
+	}
+}
+
+func commonPrefixLen(a, b string) int {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	for i := 0; i < limit; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return limit
+}

--- a/internal/runtime/executor/openai_compat_cline_test.go
+++ b/internal/runtime/executor/openai_compat_cline_test.go
@@ -128,8 +128,11 @@ func TestOpenAICompatExecutorClineUsesOpenCodeGoForCrossProviderVisionFallback(t
 				if record.ChannelName != "opencode go" {
 					t.Fatalf("channel name = %q, want opencode go", record.ChannelName)
 				}
-				if record.UpstreamModel != "qwen3.5-plus" {
-					t.Fatalf("upstream model = %q, want qwen3.5-plus", record.UpstreamModel)
+				// The fallback executor runs with the fallback model as the requested
+				// model, so there is no second model to disclose: recording one would
+				// light up the console's "real model ID" hint for nothing.
+				if record.UpstreamModel != "" {
+					t.Fatalf("upstream model = %q, want empty for a self-identical upstream", record.UpstreamModel)
 				}
 				return
 			}

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -54,6 +54,9 @@ type usageReporter struct {
 
 func newUsageReporter(ctx context.Context, provider, model, upstreamModel string, auth *cliproxyauth.Auth) *usageReporter {
 	apiKey := apiKeyFromContext(ctx)
+	if sameModelIdentity(model, upstreamModel) {
+		upstreamModel = ""
+	}
 	reporter := &usageReporter{
 		provider:           provider,
 		model:              model,
@@ -112,6 +115,14 @@ func (r *usageReporter) setModel(model string) {
 	}
 	if model = strings.TrimSpace(model); model != "" {
 		r.model = model
+		// Keep the invariant that upstream/fallback names recorded on the usage
+		// record are genuinely different models than the logged one.
+		if sameModelIdentity(r.model, r.upstreamModel) {
+			r.upstreamModel = ""
+		}
+		if sameModelIdentity(r.model, r.visionFallbackModel) {
+			r.visionFallbackModel = ""
+		}
 	}
 }
 
@@ -122,11 +133,14 @@ func (r *usageReporter) setThinkingLevel(level string) {
 	r.thinkingLevel = strings.TrimSpace(level)
 }
 
+// setUpstreamModel records the model actually sent upstream. Names that only
+// differ from the requested model by a routing prefix are dropped: see
+// sameModelIdentity for why an alias is not a different model.
 func (r *usageReporter) setUpstreamModel(model string) {
 	if r == nil {
 		return
 	}
-	if model = strings.TrimSpace(model); model != "" {
+	if model = strings.TrimSpace(model); model != "" && !sameModelIdentity(r.model, model) {
 		r.upstreamModel = model
 	}
 }
@@ -135,7 +149,7 @@ func (r *usageReporter) setVisionFallbackModel(model string) {
 	if r == nil {
 		return
 	}
-	if model = strings.TrimSpace(model); model != "" {
+	if model = strings.TrimSpace(model); model != "" && !sameModelIdentity(r.model, model) {
 		r.visionFallbackModel = model
 	}
 }
@@ -327,6 +341,7 @@ func (r *usageReporter) publishWithOutcome(ctx context.Context, detail coreusage
 	if r == nil {
 		return
 	}
+	detail = applyOllamaPromptCacheEstimate(ctx, detail)
 	if detail.TotalTokens == 0 {
 		total := detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
 		if total > 0 {


### PR DESCRIPTION
## 问题

面板请求日志里两个来自同一处建模的问题：

1. **模型别名被当成「另一个模型」**：`ollama/deepseek-v4-flash:0731` 的每一行都亮「真实模型 ID → deepseek-v4-flash:0731」。别名只是加了路由前缀，原名和别名指的是同一个模型。
2. **Ollama Cloud 缓存永远为 0**：线上近 7 天 985 条 Ollama Cloud 记录 **0 条** 有缓存，而同期 opencode go 10786 条里 10475 条有缓存。

## 线上实证

```
model                          | upstream_model         | cached_tokens
ollama/deepseek-v4-flash:0731  | deepseek-v4-flash:0731 | 0
```

供应商页显示映射 `deepseek-v4-flash:0731 → ollama/deepseek-v4-flash:0731`，确认差异只来自账号别名。

## 根因

**别名噪音**：`usageReporter` 无条件把执行期模型记为 `upstream_model`，而 API key 账号的别名解析（`conductor_api_key_alias.go`）在执行前就把别名换成上游名。于是走别名的每条请求都被记成「请求 A、实际 B」。

**缓存为 0**：Ollama 上游从不报告缓存计数——原生 `/api/chat` 只有 `prompt_eval_count`，OpenAI / Anthropic 兼容端点同样没有。仓库此前只在 native 路径做了会话前缀估算，而 executor 有三条路径：

| 源格式 | 上游端点 | 改动前 |
|---|---|---|
| OpenAI / Responses | `/api/chat` | 有估算 |
| **Claude（Claude Code）** | **`/v1/messages`** | **恒为 0** |
| 其它 | `/v1/chat/completions` | 恒为 0 |

估算的 key 还依赖客户端会话标识，没有 `session_id` 时直接返回 0。

## 改动

- 新增 `sameModelIdentity`：只差路由前缀 / 大小写视为同一模型；重命名式别名（`fast` → `claude-sonnet-4`）仍视为不同并继续记录。`usageReporter` 在构造与三个 setter 上维持「记录的 upstream / vision 一定是不同模型」的不变量。
- 新增 `ollama_cloud_prompt_cache.go`：每请求一个估算器，在 executor 入口注入 context，native / Claude / OpenAI 兼容三条路径共用；只在上游未报告缓存时填充，上游一旦返回真实计数则真实值优先。
- 无会话标识时用 prompt 开头 2048 字符指纹派生 key：同一会话跨轮稳定，不同会话隔离。
- 重试同一 prompt 时复用首次估算，避免把重试算成 100% 命中。

## 权衡

- 估算值是「基于稳定会话前缀的推断」，不是上游报告值；沿用 native 路径既有的 4096 字符门槛与 30 分钟 TTL（与 `keep_alive` 对齐）。缓存 token 参与成本计算，Ollama 模型未配缓存价时无影响。
- `request_logs.upstream_model` 的存量别名值不做批量 UPDATE：该字段只用于展示、不参与计费，前端做同样归一化即可覆盖历史行；对上万行日志表全表改写风险大于收益。

## 验证

- `./scripts/ci-pr.sh`（结构检查、gofmt、secret scan、`go vet`、`go test ./...`、updater 模块、`golangci-lint run`、build）通过。
- 反向验证：移除 usage reporter 里的估算注入 → 新增的 Claude 路径缓存测试失败；关掉重试分支 → 重试测试失败。
- 前端联动见 codeProxy 侧 PR（历史日志行的归一化在那边）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)