### PR TITLE
fix(video): make Grok video models routable, selectable and honestly gated

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -50,7 +50,7 @@
       },
       {
         "path": "internal/storage/sqlite/modelconfig/store.go",
-        "max_lines": 946
+        "max_lines": 934
       },
       {
         "path": "internal/usage/ai_account_subject_store.go",

--- a/internal/api/handlers/management/video_generation.go
+++ b/internal/api/handlers/management/video_generation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -37,10 +38,21 @@ const (
 	videoPollBudget = 8 * time.Minute
 )
 
+// ListVideoGenerationModels reports the video models together with the channels
+// this tenant can actually reach.
+//
+// The catalog alone is not enough for the console: a tenant with no xAI credential
+// would still see a selectable model and a live "generate" button, and only learn
+// at request time that nothing can serve it ("auth_not_found: no auth available").
+// Availability is therefore computed per effective tenant and returned alongside,
+// so the page can disable the action and say why.
 func (h *Handler) ListVideoGenerationModels(c *gin.Context) {
 	models := registry.ListVideoGenerationModels()
+	channelsByProvider := h.videoGenerationChannelsByProvider(c)
+
 	items := make([]gin.H, 0, len(models))
 	for _, model := range models {
+		channels := channelsByProvider[strings.ToLower(strings.TrimSpace(model.Provider))]
 		items = append(items, gin.H{
 			"id":                      model.ID,
 			"provider":                model.Provider,
@@ -49,9 +61,68 @@ func (h *Handler) ListVideoGenerationModels(c *gin.Context) {
 			"supports_image_to_video": model.SupportsImage,
 			"max_duration_seconds":    model.MaxDurationSeconds,
 			"price_per_call":          model.PricePerCall,
+			"channels":                channels,
+			"available":               len(channels) > 0,
 		})
 	}
-	c.JSON(http.StatusOK, gin.H{"models": items})
+
+	flat := make([]string, 0)
+	flatSeen := make(map[string]struct{})
+	for _, channels := range channelsByProvider {
+		for _, name := range channels {
+			key := strings.ToLower(name)
+			if _, ok := flatSeen[key]; ok {
+				continue
+			}
+			flatSeen[key] = struct{}{}
+			flat = append(flat, name)
+		}
+	}
+	sort.Strings(flat)
+
+	c.JSON(http.StatusOK, gin.H{"models": items, "channels": flat})
+}
+
+// videoGenerationChannelsByProvider lists the enabled credentials of this tenant
+// that can serve a video model, keyed by provider.
+//
+// Unlike the image equivalent this does not require an OAuth account: xAI serves
+// the media host with an API key just as well, and filtering those out would hide
+// working credentials.
+func (h *Handler) videoGenerationChannelsByProvider(c *gin.Context) map[string][]string {
+	byProvider := make(map[string][]string)
+	if h == nil || h.authManager == nil {
+		return byProvider
+	}
+	providers := make(map[string]struct{})
+	for _, model := range registry.ListVideoGenerationModels() {
+		providers[strings.ToLower(strings.TrimSpace(model.Provider))] = struct{}{}
+	}
+
+	seen := make(map[string]struct{})
+	for _, auth := range h.authManager.ListForTenant(effectiveTenantID(c)) {
+		if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+			continue
+		}
+		provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+		if _, ok := providers[provider]; !ok {
+			continue
+		}
+		name := strings.TrimSpace(auth.ChannelName())
+		if name == "" {
+			continue
+		}
+		key := provider + "\x00" + strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		byProvider[provider] = append(byProvider[provider], name)
+	}
+	for provider := range byProvider {
+		sort.Strings(byProvider[provider])
+	}
+	return byProvider
 }
 
 func (h *Handler) PostVideoGenerationTest(c *gin.Context) {

--- a/internal/runtime/executor/xai_image_models.go
+++ b/internal/runtime/executor/xai_image_models.go
@@ -7,7 +7,7 @@ import (
 	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
 )
 
-// withXAIImageModels merges the Grok Imagine models into a discovered model list.
+// withXAIMediaModels merges the Grok Imagine models into a discovered model list.
 //
 // An xAI credential's routable models come entirely from the upstream /models
 // endpoint. For an OAuth subscription that endpoint is the CLI chat proxy, which
@@ -22,8 +22,8 @@ import (
 // Merging is safe because the media host is reachable with the same token the chat
 // surface uses; a credential that cannot reach it fails at request time with a real
 // upstream error rather than looking like a missing model.
-func withXAIImageModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
-	imageModels := xaiImageModelInfos()
+func withXAIMediaModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	imageModels := xaiMediaModelInfos()
 	if len(imageModels) == 0 {
 		return models
 	}
@@ -49,14 +49,22 @@ func withXAIImageModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.
 	return merged
 }
 
-// xaiImageModelInfos converts the static Grok image definitions into catalog
+// xaiMediaModelInfos converts the static Grok media definitions into catalog
 // entries. Sourcing them from the registry keeps one definition of the model set,
 // so adding a model there makes it routable without a second edit here.
-func xaiImageModelInfos() []*sdkmodelcatalog.ModelInfo {
+//
+// Both image and video belong here: neither is discoverable upstream, and a video
+// model that is only in the static catalog reproduces exactly the failure this
+// file exists to prevent — visible in the panel, "auth_not_found: no auth
+// available" on use.
+func xaiMediaModelInfos() []*sdkmodelcatalog.ModelInfo {
 	definitions := registry.GetXAIModels()
 	models := make([]*sdkmodelcatalog.ModelInfo, 0, len(definitions))
 	for _, definition := range definitions {
-		if definition == nil || !registry.IsImageGenerationModel(definition.ID) {
+		if definition == nil {
+			continue
+		}
+		if !registry.IsImageGenerationModel(definition.ID) && !registry.IsVideoGenerationModel(definition.ID) {
 			continue
 		}
 		models = append(models, &sdkmodelcatalog.ModelInfo{

--- a/internal/runtime/executor/xai_image_models_test.go
+++ b/internal/runtime/executor/xai_image_models_test.go
@@ -100,13 +100,20 @@ func TestUpstreamWinsWhenItAdvertisesAnImageModel(t *testing.T) {
 }
 
 func TestImageModelInfosCoverEveryRegisteredImageModel(t *testing.T) {
-	// Two models: grok-imagine-image and grok-imagine-image-quality. Earlier
-	// revisions also carried grok-imagine-image-pro and grok-2-image-1212, which
-	// the live xAI catalog does not serve.
-	if len(xaiImageModelInfos()) != 2 {
-		t.Errorf("image model count = %d, want the two registered Grok image models", len(xaiImageModelInfos()))
+	// Every registered Grok media model must be here, image and video alike:
+	// none of them is discoverable through the upstream /models listing, so a
+	// model missing from this merge is unroutable no matter what the catalog says.
+	models := xaiMediaModelInfos()
+	seen := make(map[string]bool, len(models))
+	for _, model := range models {
+		seen[model.ID] = true
 	}
-	for _, model := range xaiImageModelInfos() {
+	for _, id := range []string{"grok-imagine-image", "grok-imagine-image-quality", "grok-imagine-video-1.5"} {
+		if !seen[id] {
+			t.Errorf("%s missing from the merged media models; it would fail with auth_not_found", id)
+		}
+	}
+	for _, model := range xaiMediaModelInfos() {
 		if model.Type != "xai" {
 			t.Errorf("%s type = %q, want xai so provider routing resolves", model.ID, model.Type)
 		}

--- a/internal/runtime/executor/xai_models.go
+++ b/internal/runtime/executor/xai_models.go
@@ -90,11 +90,11 @@ func loadXAIModels() []*sdkmodelcatalog.ModelInfo {
 func fallbackXAIModels() []*sdkmodelcatalog.ModelInfo {
 	if models := loadXAIModels(); len(models) > 0 {
 		log.Debugf("xai executor: using cached model list (%d models)", len(models))
-		return withXAIImageModels(models)
+		return withXAIMediaModels(models)
 	}
 	// The Imagine models are not discoverable, so they are still routable even when
 	// nothing could be fetched and no cache exists.
-	return withXAIImageModels(nil)
+	return withXAIMediaModels(nil)
 }
 
 // FetchXAIModels retrieves the OAuth account's live model list from xAI.
@@ -149,7 +149,7 @@ func FetchXAIModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Co
 		return fallbackXAIModels()
 	}
 	storeXAIModels(models)
-	return withXAIImageModels(models)
+	return withXAIMediaModels(models)
 }
 
 func parseXAIModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {

--- a/internal/storage/sqlite/modelconfig/media_generation_seed.go
+++ b/internal/storage/sqlite/modelconfig/media_generation_seed.go
@@ -7,6 +7,32 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// seedModelChannels lists the provider channels whose static models are seeded
+// into the model library.
+//
+// xai was missing from this list, which is why no Grok model ever reached the
+// library: the catalog knew them, but the library — what the channel-group editor
+// and the pricing table read — did not, so a request for one was rejected with
+// "not in the allowed models of channel group" and the operator had no way to add
+// it from the console.
+func seedModelChannels() []string {
+	return []string{
+		"claude",
+		"gemini",
+		"vertex",
+		"gemini-cli",
+		"aistudio",
+		"codex",
+		"qwen",
+		"iflow",
+		"kimi",
+		"cline",
+		"opencode-go",
+		"antigravity",
+		"xai",
+	}
+}
+
 // applyMediaGenerationSeedDefaults stamps the billing and modality shape a media
 // model needs onto a seed row.
 //

--- a/internal/storage/sqlite/modelconfig/media_generation_seed.go
+++ b/internal/storage/sqlite/modelconfig/media_generation_seed.go
@@ -1,0 +1,88 @@
+package modelconfig
+
+import (
+	"database/sql"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	log "github.com/sirupsen/logrus"
+)
+
+// applyMediaGenerationSeedDefaults stamps the billing and modality shape a media
+// model needs onto a seed row.
+//
+// Image and video models are billed per invocation rather than per token, so a row
+// seeded with the default token pricing would under-report spend. The
+// classification lives in internal/registry alongside the model definitions, so
+// adding a provider does not mean hunting for every branch that special-cased a
+// model ID.
+func applyMediaGenerationSeedDefaults(row *ModelConfigRow, modelID string) {
+	applyImageGenerationSeedDefaults(row, modelID)
+	applyVideoGenerationSeedDefaults(row, modelID)
+}
+
+// applyVideoGenerationSeedDefaults is the video half. It is separate from the
+// image one because the two classifications must not bleed into each other: a
+// video model that classified as an image model would be offered on the
+// /images/* endpoints it cannot serve.
+func applyVideoGenerationSeedDefaults(row *ModelConfigRow, modelID string) {
+	if row == nil || !registry.IsVideoGenerationModel(modelID) {
+		return
+	}
+	row.InputModalities = registry.VideoGenerationInputModalities(modelID)
+	row.OutputModalities = registry.VideoGenerationOutputModalities()
+	row.PricingMode = "call"
+	if price, description, ok := registry.VideoGenerationModelDefaults(modelID); ok {
+		row.PricePerCall = price
+		row.Description = description
+	}
+}
+
+// isMediaGenerationModel reports whether a model is billed per call because it
+// produces images or video.
+func isMediaGenerationModel(modelID string) bool {
+	return registry.IsImageGenerationModel(modelID) || registry.IsVideoGenerationModel(modelID)
+}
+
+// repairMediaGenerationModelConfigRows promotes pre-existing media rows into the
+// model library.
+//
+// Rows for these models can predate their catalog entry — legacy pricing import
+// creates them with source 'legacy-pricing', which the library scope filters out.
+// The effect is that the channel-group editor cannot offer the model, so a request
+// for it is rejected with "not in the allowed models of channel group" and the
+// operator has no way to fix it from the console.
+//
+// Only 'legacy-pricing' rows are touched: 'user' rows carry deliberate operator
+// pricing, and 'openrouter' rows already surface in the library. Every tenant is
+// covered, because the seed itself only ever wrote the system tenant.
+func repairMediaGenerationModelConfigRows(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	now := nowRFC3339()
+	for _, row := range defaultModelConfigRows() {
+		if !isMediaGenerationModel(row.ModelID) {
+			continue
+		}
+		_, err := db.Exec(
+			`UPDATE model_configs
+			 SET source = 'seed',
+			     pricing_mode = 'call',
+			     input_modalities = ?,
+			     output_modalities = ?,
+			     owned_by = CASE WHEN owned_by = '' THEN ? ELSE owned_by END,
+			     display_name = CASE WHEN display_name = '' THEN ? ELSE display_name END,
+			     updated_at = ?
+			 WHERE model_id = ? AND source = 'legacy-pricing'`,
+			encodeModelModalities(row.InputModalities),
+			encodeModelModalities(row.OutputModalities),
+			row.OwnedBy,
+			row.DisplayName,
+			now,
+			row.ModelID,
+		)
+		if err != nil {
+			log.Warnf("sqlite/modelconfig: repair media model config %s: %v", row.ModelID, err)
+		}
+	}
+}

--- a/internal/storage/sqlite/modelconfig/media_generation_seed_test.go
+++ b/internal/storage/sqlite/modelconfig/media_generation_seed_test.go
@@ -1,0 +1,53 @@
+package modelconfig
+
+import "testing"
+
+// The library scope only surfaces 'seed' and 'openrouter' rows, and the
+// channel-group editor reads the library. A media model missing from the seed is
+// therefore unselectable there, which is what made a Grok request fail with
+// "not in the allowed models of channel group" and left the operator no fix.
+func TestSeedRowsCoverGrokMediaModels(t *testing.T) {
+	rows := defaultModelConfigRows()
+	byID := make(map[string]ModelConfigRow, len(rows))
+	for _, row := range rows {
+		byID[row.ModelID] = row
+	}
+
+	for _, id := range []string{"grok-imagine-image", "grok-imagine-image-quality", "grok-imagine-video-1.5"} {
+		row, ok := byID[id]
+		if !ok {
+			t.Errorf("%s missing from the seeded model library", id)
+			continue
+		}
+		if NormalizePricingMode(row.PricingMode) != "call" {
+			t.Errorf("%s pricing mode = %q, want call: media models are billed per invocation", id, row.PricingMode)
+		}
+		if len(row.OutputModalities) == 0 {
+			t.Errorf("%s has no output modality, so the catalog cannot classify it", id)
+		}
+	}
+
+	if got := byID["grok-imagine-video-1.5"].OutputModalities; len(got) != 1 || got[0] != "video" {
+		t.Errorf("video output modalities = %v, want [video]", got)
+	}
+}
+
+func TestMediaSeedDefaultsDoNotCrossClassify(t *testing.T) {
+	video := ModelConfigRow{ModelID: "grok-imagine-video-1.5", PricingMode: "token"}
+	applyMediaGenerationSeedDefaults(&video, video.ModelID)
+	if len(video.InputModalities) != 2 {
+		t.Fatalf("video input modalities = %v, want text and image", video.InputModalities)
+	}
+
+	image := ModelConfigRow{ModelID: "grok-imagine-image", PricingMode: "token"}
+	applyMediaGenerationSeedDefaults(&image, image.ModelID)
+	if len(image.OutputModalities) != 1 || image.OutputModalities[0] != "image" {
+		t.Fatalf("image output modalities = %v, want [image]", image.OutputModalities)
+	}
+
+	chat := ModelConfigRow{ModelID: "grok-4.5", PricingMode: "token"}
+	applyMediaGenerationSeedDefaults(&chat, chat.ModelID)
+	if NormalizePricingMode(chat.PricingMode) != "token" {
+		t.Fatalf("a chat model must keep token pricing, got %q", chat.PricingMode)
+	}
+}

--- a/internal/storage/sqlite/modelconfig/store.go
+++ b/internal/storage/sqlite/modelconfig/store.go
@@ -648,26 +648,7 @@ func NormalizeModelReasoningJSON(value string) string {
 }
 
 func defaultModelConfigRows() []ModelConfigRow {
-	channels := []string{
-		"claude",
-		"gemini",
-		"vertex",
-		"gemini-cli",
-		"aistudio",
-		"codex",
-		"qwen",
-		"iflow",
-		"kimi",
-		"cline",
-		"opencode-go",
-		"antigravity",
-		// xai was missing here, which is why no Grok model ever reached the model
-		// library: the catalog knew them, but the library — what the channel-group
-		// editor and the pricing table read — did not, so a request for one was
-		// rejected with "not in the allowed models of channel group" and the
-		// operator had no way to add it.
-		"xai",
-	}
+	channels := seedModelChannels()
 
 	seen := make(map[string]struct{})
 	rows := make([]ModelConfigRow, 0, 256)

--- a/internal/storage/sqlite/modelconfig/store.go
+++ b/internal/storage/sqlite/modelconfig/store.go
@@ -161,6 +161,7 @@ func InitTables(db *sql.DB) {
 	seedDefaultModelConfigRows(db)
 	mergeLegacyPricingIntoModelConfigs(db)
 	repairDefaultPerCallModelConfigRows(db)
+	repairMediaGenerationModelConfigRows(db)
 }
 
 func NormalizeModelOwnerValue(value string) string {
@@ -660,6 +661,12 @@ func defaultModelConfigRows() []ModelConfigRow {
 		"cline",
 		"opencode-go",
 		"antigravity",
+		// xai was missing here, which is why no Grok model ever reached the model
+		// library: the catalog knew them, but the library — what the channel-group
+		// editor and the pricing table read — did not, so a request for one was
+		// rejected with "not in the allowed models of channel group" and the
+		// operator had no way to add it.
+		"xai",
 	}
 
 	seen := make(map[string]struct{})
@@ -699,7 +706,7 @@ func defaultModelConfigRows() []ModelConfigRow {
 				PricingMode:         "token",
 				Source:              "seed",
 			}
-			applyImageGenerationSeedDefaults(&row, modelID)
+			applyMediaGenerationSeedDefaults(&row, modelID)
 			rows = append(rows, row)
 		}
 	}


### PR DESCRIPTION
## 三个截图，三个不同的根因

### 1. `auth_not_found: no auth available`

xAI 凭据可路由的模型**完全来自上游 `/models` 列表**，而它从不返回 Imagine 系列——那些模型在 media host 上，不可发现。仓库里 `xai_image_models.go` 的注释早就写明了这点，并为图像模型做了「合并进每个凭据的模型集」。上一版我把视频模型只加进静态目录，于是路由器认为没有任何凭据能服务它。视频现在走同一条合并路径。

这也回答「能不能动态获取」：**chat 模型本来就是动态拉的**（`FetchXAIModels` 打 `/models`，上游报什么就是什么）；媒体模型上游不提供发现端点，只能由我们声明。声明按前缀分类（`grok-imagine-video*`），新版本 id 不改代码即可识别；上游哪天开始在 `/models` 返回它们，合并逻辑是「上游优先」，会自动让位。

### 2. `model_not_allowed_by_channel_group`

模型库 seed 走一份**硬编码 channel 清单**，其中没有 `xai`——所以任何 Grok 模型都没进过模型库。而渠道分组编辑器和定价表读的正是模型库：错误提示让用户「把模型加进分组」，用户却在选择器里找不到它。清单补上 `xai`，媒体行按 per-call 计费与真实 modality 落库。

**存量数据**：早于目录条目的行以 `legacy-pricing` 导入，被 library scope 过滤掉，而 seed 是 `INSERT OR IGNORE` 不会更新它们。新增一次性修正把这些行提升为 `seed`，**覆盖所有租户**（seed 本身只写系统租户）；`user` 行保留运营方定的价格，`openrouter` 行本就可见。

### 3. 没有 Grok 账号时不该给可点的按钮

`/video-generation/models` 现在按 **effective tenant** 返回每个模型可用的渠道与 `available`，前端据此置灰并说明缺什么，而不是让请求走到路由层再抛 `auth_not_found`。

## 验证

- `./scripts/ci-pr.sh` 全绿（含 `golangci-lint`、结构检查）。
- 新增用例：三个 Grok 媒体模型都在凭据合并集里（缺一个即复现 `auth_not_found`）、seed 覆盖三个媒体模型且为 per-call、图像/视频 modality 不互相串、chat 模型不被误标 per-call。
- 线上存量已核对：`grok-imagine-video-1.5` 在多个租户下确为 `legacy-pricing`，正是修正要覆盖的行。

前端 PR：kittors/codeProxy#923

🤖 Generated with [Claude Code](https://claude.com/claude-code)