### PR TITLE
feat(commandcode): add Command Code as a first-class channel with plan usage

### DIFF
--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -89,6 +89,9 @@ func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []cha
 		for _, entry := range cfg.OllamaCloudKey {
 			push(entry.Name, entry.Prefix, "ollama-cloud", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, managementauthfiles.BuildTagPayloadFromValues("ollama-cloud", nil))
 		}
+		for _, entry := range cfg.CommandCodeKey {
+			push(entry.Name, entry.Prefix, "commandcode", providerExcludesAllModels(entry.ExcludedModels), channelDisabledAuthorityConfig, managementauthfiles.BuildTagPayloadFromValues("commandcode", nil))
+		}
 		for _, entry := range cfg.VertexCompatAPIKey {
 			push("", entry.Prefix, "vertex", false, channelDisabledAuthorityConfig, managementauthfiles.BuildTagPayloadFromValues("vertex", nil))
 		}

--- a/internal/api/handlers/management/commandcode_usage.go
+++ b/internal/api/handlers/management/commandcode_usage.go
@@ -1,0 +1,193 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// Command Code plan usage.
+//
+// Unlike the OpenCode Go, Cline and Ollama Cloud checks in opencode_go_usage.go,
+// this one needs no dashboard cookie: the credits endpoint authenticates with the
+// same API key that serves inference, so usage keeps working without the operator
+// pasting a browser cookie that later expires.
+//
+// The endpoint is not part of Command Code's published API reference — it was
+// observed on the live gateway. Treat every failure as "usage unavailable" rather
+// than "channel broken": a key that cannot read credits still serves requests
+// perfectly well, so nothing here may be turned into a credential error.
+
+var commandCodeCreditsURL = "https://api.commandcode.ai/alpha/billing/credits"
+
+// commandCodeCreditsResponse mirrors only the fields this handler reads.
+// cap/used are plan-window counters; resetAt has been observed in both seconds
+// and milliseconds, so it is normalized on read rather than trusted.
+type commandCodeCreditsResponse struct {
+	WindowLimits struct {
+		FiveHour *commandCodeWindow `json:"fiveHour"`
+		Weekly   *commandCodeWindow `json:"weekly"`
+	} `json:"windowLimits"`
+	Credits *struct {
+		MonthlyCredits   *float64 `json:"monthlyCredits"`
+		PurchasedCredits *float64 `json:"purchasedCredits"`
+		FreeCredits      *float64 `json:"freeCredits"`
+	} `json:"credits"`
+}
+
+type commandCodeWindow struct {
+	Cap     *float64 `json:"cap"`
+	Used    *float64 `json:"used"`
+	ResetAt *float64 `json:"resetAt"`
+}
+
+// QueryCommandCodeUsage reports Command Code plan windows for one credential.
+func (h *Handler) QueryCommandCodeUsage(c *gin.Context) {
+	var body openCodeGoUsageRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+
+	runtimeHandler := h.providerUsageHandler(c)
+	entry := runtimeHandler.findCommandCodeEntry(body)
+	apiKey := strings.TrimSpace(body.APIKey)
+	proxyID := strings.TrimSpace(body.ProxyID)
+	proxyURL := strings.TrimSpace(body.ProxyURL)
+	if entry != nil {
+		if apiKey == "" {
+			apiKey = strings.TrimSpace(entry.APIKey)
+		}
+		if proxyID == "" {
+			proxyID = strings.TrimSpace(entry.ProxyID)
+		}
+		if proxyURL == "" {
+			proxyURL = strings.TrimSpace(entry.ProxyURL)
+		}
+	}
+	if apiKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "api-key is required"})
+		return
+	}
+
+	items, err := runtimeHandler.fetchCommandCodeUsage(c.Request.Context(), apiKey, proxyID, proxyURL, resolveUsageTimeout(body.TimeoutSec))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"usage": items})
+}
+
+func (h *Handler) findCommandCodeEntry(body openCodeGoUsageRequest) *config.CommandCodeKey {
+	if h == nil || h.cfg == nil {
+		return nil
+	}
+	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.CommandCodeKey) {
+		return &h.cfg.CommandCodeKey[*body.Index]
+	}
+	apiKey := strings.TrimSpace(body.APIKey)
+	if apiKey != "" {
+		for i := range h.cfg.CommandCodeKey {
+			if strings.TrimSpace(h.cfg.CommandCodeKey[i].APIKey) == apiKey {
+				return &h.cfg.CommandCodeKey[i]
+			}
+		}
+	}
+	name := strings.TrimSpace(body.Name)
+	if name != "" {
+		for i := range h.cfg.CommandCodeKey {
+			if strings.TrimSpace(h.cfg.CommandCodeKey[i].Name) == name {
+				return &h.cfg.CommandCodeKey[i]
+			}
+		}
+	}
+	return nil
+}
+
+func (h *Handler) fetchCommandCodeUsage(ctx context.Context, apiKey, proxyID, proxyURL string, timeout time.Duration) ([]openCodeGoUsageItem, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, commandCodeCreditsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; CliRelay Command Code usage checker)")
+
+	resp, err := h.usageHTTPClient(timeout, proxyID, proxyURL).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, openCodeGoUsageError("Command Code API key is invalid or lacks billing access")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, openCodeGoUsageError("Command Code credits API returned HTTP " + resp.Status)
+	}
+
+	var payload commandCodeCreditsResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	items := parseCommandCodeUsage(payload)
+	if len(items) == 0 {
+		return nil, openCodeGoUsageError("Command Code reported no plan windows for this account")
+	}
+	return items, nil
+}
+
+func parseCommandCodeUsage(payload commandCodeCreditsResponse) []openCodeGoUsageItem {
+	items := make([]openCodeGoUsageItem, 0, 2)
+	if item, ok := commandCodeWindowItem("five_hour", "5-Hour", payload.WindowLimits.FiveHour); ok {
+		items = append(items, item)
+	}
+	if item, ok := commandCodeWindowItem("weekly", "Weekly", payload.WindowLimits.Weekly); ok {
+		items = append(items, item)
+	}
+	return items
+}
+
+func commandCodeWindowItem(usageType, label string, window *commandCodeWindow) (openCodeGoUsageItem, bool) {
+	// A window without a positive cap carries no ratio worth showing; reporting
+	// it as 0% would read as "plenty left" on a plan that may have none.
+	if window == nil || window.Cap == nil || window.Used == nil || *window.Cap <= 0 {
+		return openCodeGoUsageItem{}, false
+	}
+	percentage := clampUsagePercentage(*window.Used / *window.Cap * 100)
+	return openCodeGoUsageItem{
+		Type:       usageType,
+		Label:      label,
+		Percentage: percentage,
+		ResetsIn:   commandCodeResetIn(window.ResetAt),
+	}, true
+}
+
+// commandCodeResetIn accepts either a seconds or a milliseconds epoch. Values
+// past the year 2001 in milliseconds exceed 1e12, which is the only reliable way
+// to tell the two apart without a documented unit.
+func commandCodeResetIn(resetAt *float64) string {
+	if resetAt == nil || *resetAt <= 0 || math.IsNaN(*resetAt) || math.IsInf(*resetAt, 0) {
+		return ""
+	}
+	milliseconds := *resetAt
+	if milliseconds <= 1e12 {
+		milliseconds *= 1000
+	}
+	seconds := int64(math.Round(time.Until(time.UnixMilli(int64(milliseconds))).Seconds()))
+	if seconds < 0 {
+		seconds = 0
+	}
+	return formatOpenCodeGoResetIn(seconds)
+}

--- a/internal/api/handlers/management/commandcode_usage_test.go
+++ b/internal/api/handlers/management/commandcode_usage_test.go
@@ -1,0 +1,91 @@
+package management
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func decodeCommandCodeCredits(t *testing.T, raw string) commandCodeCreditsResponse {
+	t.Helper()
+	var payload commandCodeCreditsResponse
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("decode credits payload: %v", err)
+	}
+	return payload
+}
+
+func TestParseCommandCodeUsageReportsBothWindows(t *testing.T) {
+	resetAt := time.Now().Add(90 * time.Minute).UnixMilli()
+	raw := `{"windowLimits":{"fiveHour":{"cap":200,"used":50,"resetAt":` +
+		itoa(resetAt) + `},"weekly":{"cap":1000,"used":900,"resetAt":` + itoa(resetAt) + `}}}`
+
+	items := parseCommandCodeUsage(decodeCommandCodeCredits(t, raw))
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	if items[0].Type != "five_hour" || items[0].Percentage != 25 {
+		t.Fatalf("five hour window = %#v, want 25%%", items[0])
+	}
+	if items[1].Type != "weekly" || items[1].Percentage != 90 {
+		t.Fatalf("weekly window = %#v, want 90%%", items[1])
+	}
+	if items[0].ResetsIn == "" {
+		t.Fatal("expected a reset countdown for a future resetAt")
+	}
+}
+
+// A zero or missing cap carries no ratio. Reporting it as 0% would read as
+// "plenty of quota left" on an account that may have none.
+func TestParseCommandCodeUsageSkipsWindowsWithoutCap(t *testing.T) {
+	raw := `{"windowLimits":{"fiveHour":{"cap":0,"used":10},"weekly":{"used":5}}}`
+	if items := parseCommandCodeUsage(decodeCommandCodeCredits(t, raw)); len(items) != 0 {
+		t.Fatalf("items = %#v, want none", items)
+	}
+}
+
+func TestParseCommandCodeUsageClampsOverage(t *testing.T) {
+	raw := `{"windowLimits":{"weekly":{"cap":100,"used":150}}}`
+	items := parseCommandCodeUsage(decodeCommandCodeCredits(t, raw))
+	if len(items) != 1 || items[0].Percentage != 100 {
+		t.Fatalf("items = %#v, want a single 100%% entry", items)
+	}
+}
+
+// resetAt has been observed in both units, so both must produce the same answer.
+func TestCommandCodeResetInAcceptsSecondsAndMilliseconds(t *testing.T) {
+	future := time.Now().Add(2 * time.Hour)
+	milliseconds := float64(future.UnixMilli())
+	seconds := float64(future.Unix())
+
+	fromMillis := commandCodeResetIn(&milliseconds)
+	fromSeconds := commandCodeResetIn(&seconds)
+	if fromMillis == "" || fromSeconds == "" {
+		t.Fatalf("reset countdowns = %q / %q, want both populated", fromMillis, fromSeconds)
+	}
+	if fromMillis != fromSeconds {
+		t.Fatalf("seconds and milliseconds disagree: %q vs %q", fromSeconds, fromMillis)
+	}
+}
+
+func TestCommandCodeResetInHandlesPastAndMissing(t *testing.T) {
+	if got := commandCodeResetIn(nil); got != "" {
+		t.Fatalf("missing resetAt = %q, want empty", got)
+	}
+	past := float64(time.Now().Add(-time.Hour).UnixMilli())
+	if got := commandCodeResetIn(&past); got != "0 seconds" {
+		t.Fatalf("expired window = %q, want a floored countdown", got)
+	}
+}
+
+func itoa(value int64) string {
+	return string(mustJSON(value))
+}
+
+func mustJSON(value any) []byte {
+	out, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -50,6 +50,7 @@ func (h *Handler) GetConfig(c *gin.Context) {
 		OpenCodeGoKey:        runtimeCfg.OpenCodeGoKey,
 		ClineKey:             runtimeCfg.ClineKey,
 		OllamaCloudKey:       runtimeCfg.OllamaCloudKey,
+		CommandCodeKey:       runtimeCfg.CommandCodeKey,
 		OpenAICompatibility:  runtimeCfg.OpenAICompatibility,
 		VertexCompatAPIKey:   runtimeCfg.VertexCompatAPIKey,
 		ClaudeHeaderDefaults: runtimeCfg.ClaudeHeaderDefaults,
@@ -221,6 +222,15 @@ func sanitizeConfigForAPI(cfg *config.Config) *config.Config {
 		copy.OllamaCloudKey[i].ProxyURL = maskBaseURL(copy.OllamaCloudKey[i].ProxyURL)
 		copy.OllamaCloudKey[i].AuthCookie = maskKey(copy.OllamaCloudKey[i].AuthCookie)
 		copy.OllamaCloudKey[i].ExcludedModels = nil
+	}
+
+	// Mask Command Code API keys, names, URLs, and exclusions
+	for i := range copy.CommandCodeKey {
+		copy.CommandCodeKey[i].APIKey = maskKey(copy.CommandCodeKey[i].APIKey)
+		copy.CommandCodeKey[i].Name = maskName(copy.CommandCodeKey[i].Name)
+		copy.CommandCodeKey[i].BaseURL = maskBaseURL(copy.CommandCodeKey[i].BaseURL)
+		copy.CommandCodeKey[i].ProxyURL = maskBaseURL(copy.CommandCodeKey[i].ProxyURL)
+		copy.CommandCodeKey[i].ExcludedModels = nil
 	}
 
 	// Mask OpenAI compatibility API keys, names, URLs, and models

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -527,6 +527,7 @@ func isTenantScopedManagementPath(path string) bool {
 		strings.HasPrefix(relative, "/opencode-go-api-key"),
 		strings.HasPrefix(relative, "/cline-api-key"),
 		strings.HasPrefix(relative, "/ollama-cloud-api-key"),
+		strings.HasPrefix(relative, "/commandcode-api-key"),
 		strings.HasPrefix(relative, "/codex-api-key"),
 		strings.HasPrefix(relative, "/vertex-api-key"),
 		strings.HasPrefix(relative, "/openai-compatibility"),

--- a/internal/api/handlers/management/model_definitions.go
+++ b/internal/api/handlers/management/model_definitions.go
@@ -17,6 +17,10 @@ var (
 	clineRecommendedModelsClient = &http.Client{Timeout: 5 * time.Second}
 	ollamaCloudModelsURL         = "https://ollama.com/v1/models"
 	ollamaCloudModelsClient      = &http.Client{Timeout: 5 * time.Second}
+	// Command Code serves its catalog without a credential, so the live list is
+	// always available and the static snapshot only has to cover the offline case.
+	commandCodeModelsURL    = "https://api.commandcode.ai/provider/v1/models"
+	commandCodeModelsClient = &http.Client{Timeout: 5 * time.Second}
 )
 
 // GetStaticModelDefinitions returns static model metadata for a given channel.
@@ -44,6 +48,11 @@ func (h *Handler) GetStaticModelDefinitions(c *gin.Context) {
 	}
 	if normalizedChannel == "ollama-cloud" {
 		if remoteModels, err := fetchOllamaCloudModelDefinitions(c.Request.Context()); err == nil && len(remoteModels) > 0 {
+			models = remoteModels
+		}
+	}
+	if normalizedChannel == "commandcode" {
+		if remoteModels, err := fetchCommandCodeModelDefinitions(c.Request.Context()); err == nil && len(remoteModels) > 0 {
 			models = remoteModels
 		}
 	}
@@ -103,6 +112,57 @@ func fetchOllamaCloudModelDefinitions(ctx context.Context) ([]*registry.ModelInf
 			OwnedBy:     ownedBy,
 			Type:        "ollama-cloud",
 			DisplayName: id,
+		})
+	}
+	return models, nil
+}
+
+func fetchCommandCodeModelDefinitions(ctx context.Context) ([]*registry.ModelInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, commandCodeModelsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := commandCodeModelsClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("command code models status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Data []struct {
+			ID            string `json:"id"`
+			Name          string `json:"name"`
+			Created       int64  `json:"created"`
+			ContextLength int    `json:"context_length"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	models := make([]*registry.ModelInfo, 0, len(payload.Data))
+	for _, item := range payload.Data {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			continue
+		}
+		displayName := strings.TrimSpace(item.Name)
+		if displayName == "" {
+			displayName = id
+		}
+		models = append(models, &registry.ModelInfo{
+			ID:            id,
+			Object:        "model",
+			Created:       item.Created,
+			OwnedBy:       "command-code",
+			Type:          "commandcode",
+			DisplayName:   displayName,
+			ContextLength: item.ContextLength,
 		})
 	}
 	return models, nil

--- a/internal/api/handlers/management/provider_settings.go
+++ b/internal/api/handlers/management/provider_settings.go
@@ -126,6 +126,8 @@ func providerRuntimeSetting(path string, cfg *config.Config) (string, any) {
 		return settingsstore.RuntimeSettingClineKeys, cfg.ClineKey
 	case strings.HasPrefix(relative, "/ollama-cloud-api-key"):
 		return settingsstore.RuntimeSettingOllamaCloudKeys, cfg.OllamaCloudKey
+	case strings.HasPrefix(relative, "/commandcode-api-key"):
+		return settingsstore.RuntimeSettingCommandCodeKeys, cfg.CommandCodeKey
 	case strings.HasPrefix(relative, "/codex-api-key"):
 		return settingsstore.RuntimeSettingCodexKeys, cfg.CodexKey
 	case strings.HasPrefix(relative, "/openai-compatibility"):

--- a/internal/api/handlers/management/provider_settings_commandcode.go
+++ b/internal/api/handlers/management/provider_settings_commandcode.go
@@ -1,0 +1,96 @@
+package management
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	providersettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/providers"
+)
+
+// Command Code provider key endpoints.
+//
+// Kept beside provider_settings.go rather than inside it so that file stays
+// under the 800-line structure gate.
+
+// commandcode-api-key: []CommandCodeKey
+func (h *ProviderKeysHandler) GetCommandCodeKeys(c *gin.Context) {
+	c.JSON(200, gin.H{"commandcode-api-key": providerSettingsService(h, c).CommandCodeKeys()})
+}
+
+func (h *ProviderKeysHandler) PutCommandCodeKeys(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var arr []config.CommandCodeKey
+	if err = json.Unmarshal(data, &arr); err != nil {
+		var obj struct {
+			Items []config.CommandCodeKey `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		arr = obj.Items
+	}
+	if err := providerSettingsService(h, c).ReplaceCommandCodeKeys(arr); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	h.persistProviderSettings(c)
+}
+
+func (h *ProviderKeysHandler) PatchCommandCodeKey(c *gin.Context) {
+	var body struct {
+		APIKey *string                            `json:"api-key"`
+		Name   *string                            `json:"name"`
+		Index  *int                               `json:"index"`
+		Value  *providersettings.CommandCodePatch `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	if err := providerSettingsService(h, c).PatchCommandCodeKey(body.Index, body.APIKey, body.Name, *body.Value); err != nil {
+		if errors.Is(err, providersettings.ErrItemNotFound) {
+			c.JSON(404, gin.H{"error": "item not found"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	h.persistProviderSettings(c)
+}
+
+func (h *ProviderKeysHandler) DeleteCommandCodeKey(c *gin.Context) {
+	if apiKey := strings.TrimSpace(c.Query("api-key")); apiKey != "" {
+		if providerSettingsService(h, c).DeleteCommandCodeKeyByAPIKey(apiKey) {
+			h.persistProviderSettings(c)
+			return
+		}
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+	if name := strings.TrimSpace(c.Query("name")); name != "" {
+		if providerSettingsService(h, c).DeleteCommandCodeKeyByName(name) {
+			h.persistProviderSettings(c)
+			return
+		}
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+	if idxStr := c.Query("index"); idxStr != "" {
+		var idx int
+		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && providerSettingsService(h, c).DeleteCommandCodeKeyByIndex(idx) {
+			h.persistProviderSettings(c)
+			return
+		}
+	}
+	c.JSON(400, gin.H{"error": "missing api-key, name, or index"})
+}

--- a/internal/api/routes/management_keys_routes.go
+++ b/internal/api/routes/management_keys_routes.go
@@ -59,6 +59,12 @@ func registerManagementProviderRoutes(group *gin.RouterGroup, h *managementhandl
 	group.DELETE("/ollama-cloud-api-key", keys.DeleteOllamaCloudKey)
 	group.POST("/ollama-cloud-api-key/usage", h.QueryOllamaCloudUsage)
 
+	group.GET("/commandcode-api-key", keys.GetCommandCodeKeys)
+	group.PUT("/commandcode-api-key", keys.PutCommandCodeKeys)
+	group.PATCH("/commandcode-api-key", keys.PatchCommandCodeKey)
+	group.DELETE("/commandcode-api-key", keys.DeleteCommandCodeKey)
+	group.POST("/commandcode-api-key/usage", h.QueryCommandCodeUsage)
+
 	group.GET("/codex-api-key", keys.GetCodexKeys)
 	group.PUT("/codex-api-key", keys.PutCodexKeys)
 	group.PATCH("/codex-api-key", keys.PatchCodexKey)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 324; got != want {
+	if got, want := len(routes), 329; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -69,6 +69,11 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		"PATCH /v0/management/ollama-cloud-api-key",
 		"DELETE /v0/management/ollama-cloud-api-key",
 		"POST /v0/management/ollama-cloud-api-key/usage",
+		"GET /v0/management/commandcode-api-key",
+		"PUT /v0/management/commandcode-api-key",
+		"PATCH /v0/management/commandcode-api-key",
+		"DELETE /v0/management/commandcode-api-key",
+		"POST /v0/management/commandcode-api-key/usage",
 		"GET /v0/management/auth-files/models",
 		"GET /v0/management/image-generation/size-presets",
 		"PUT /v0/management/image-generation/size-presets",
@@ -281,6 +286,11 @@ func expectedManagementRoutes() []string {
 		"DELETE /v0/management/oauth-excluded-models",
 		"DELETE /v0/management/oauth-model-alias",
 		"DELETE /v0/management/ollama-cloud-api-key",
+		"DELETE /v0/management/commandcode-api-key",
+		"GET /v0/management/commandcode-api-key",
+		"PATCH /v0/management/commandcode-api-key",
+		"POST /v0/management/commandcode-api-key/usage",
+		"PUT /v0/management/commandcode-api-key",
 		"DELETE /v0/management/opencode-go-api-key",
 		"DELETE /v0/management/openai-compatibility",
 		"DELETE /v0/management/proxy-url",

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -126,7 +126,7 @@ func syncConfigDerivedAuthModels(cfg *config.Config, auth *coreauth.Auth) {
 		return
 	}
 	switch strings.ToLower(strings.TrimSpace(auth.Provider)) {
-	case "opencode-go", "cline", "ollama-cloud":
+	case "opencode-go", "cline", "ollama-cloud", "commandcode":
 		syncDynamicConfigAuthModels(reg, cfg, auth)
 	}
 }
@@ -162,6 +162,17 @@ func syncDynamicConfigAuthModels(reg sdkmodelcatalog.Registry, cfg *config.Confi
 	case "ollama-cloud":
 		ownedBy = "ollama"
 		entry := resolveConfigOllamaCloudKey(cfg, auth)
+		if entry == nil {
+			reg.UnregisterClient(auth.ID)
+			return
+		}
+		if len(entry.Models) > 0 {
+			models = buildNamedConfigModels(filterNamedConfigModels(entry.Models, isNotClinePassConfigModelID), staticModels, ownedBy, provider)
+		}
+		excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
+	case "commandcode":
+		ownedBy = "command-code"
+		entry := resolveConfigCommandCodeKey(cfg, auth)
 		if entry == nil {
 			reg.UnregisterClient(auth.ID)
 			return
@@ -239,6 +250,27 @@ func resolveConfigOllamaCloudKey(cfg *config.Config, auth *coreauth.Auth) *confi
 		cfgBase := strings.TrimSpace(entry.BaseURL)
 		if cfgBase == "" {
 			cfgBase = config.DefaultOllamaCloudBaseURL
+		}
+		if attrKey != "" && strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) {
+			if attrBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+		}
+	}
+	return nil
+}
+
+func resolveConfigCommandCodeKey(cfg *config.Config, auth *coreauth.Auth) *config.CommandCodeKey {
+	if cfg == nil || auth == nil || auth.Attributes == nil {
+		return nil
+	}
+	attrKey := strings.TrimSpace(auth.Attributes["api_key"])
+	attrBase := strings.TrimSpace(auth.Attributes["base_url"])
+	for i := range cfg.CommandCodeKey {
+		entry := &cfg.CommandCodeKey[i]
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if cfgBase == "" {
+			cfgBase = config.DefaultCommandCodeBaseURL
 		}
 		if attrKey != "" && strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) {
 			if attrBase == "" || strings.EqualFold(cfgBase, attrBase) {

--- a/internal/app/service/runtime_executor_registry_commandcode_test.go
+++ b/internal/app/service/runtime_executor_registry_commandcode_test.go
@@ -1,0 +1,100 @@
+package serviceapp
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+func commandCodeAuth() *coreauth.Auth {
+	return &coreauth.Auth{
+		ID:       "commandcode-auth",
+		Provider: "commandcode",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":      "cc-key",
+			"base_url":     config.DefaultCommandCodeBaseURL,
+			"compat_name":  "Command Code",
+			"provider_key": "commandcode",
+		},
+	}
+}
+
+// Command Code speaks plain OpenAI, so it must land on the shared compat
+// executor rather than falling through to a provider-specific one.
+func TestRegisterExecutorForAuthCommandCodeUsesOpenAICompatExecutor(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+
+	RegisterExecutorForAuth(manager, &config.Config{}, commandCodeAuth(), false, nil)
+
+	got, ok := manager.Executor("commandcode")
+	if !ok || got == nil {
+		t.Fatal("expected commandcode executor after bind")
+	}
+	compat, ok := got.(*executor.OpenAICompatExecutor)
+	if !ok {
+		t.Fatalf("executor = %T, want *executor.OpenAICompatExecutor", got)
+	}
+	if compat.Identifier() != "commandcode" {
+		t.Fatalf("identifier = %q, want commandcode", compat.Identifier())
+	}
+}
+
+// Without configured models the channel serves the static catalog snapshot.
+func TestSyncDynamicConfigAuthModelsCommandCodeFallsBackToCatalog(t *testing.T) {
+	reg := &testModelRegistry{}
+	cfg := &config.Config{CommandCodeKey: []config.CommandCodeKey{{
+		APIKey:  "cc-key",
+		BaseURL: config.DefaultCommandCodeBaseURL,
+	}}}
+
+	syncDynamicConfigAuthModels(reg, cfg, commandCodeAuth())
+
+	if len(reg.models) == 0 {
+		t.Fatal("expected the static Command Code catalog to be registered")
+	}
+	for _, model := range reg.models {
+		if model.OwnedBy != "command-code" {
+			t.Fatalf("model %q owned_by = %q, want command-code", model.ID, model.OwnedBy)
+		}
+	}
+}
+
+// An explicit model list wins over the snapshot, which is how an operator routes
+// a model that shipped upstream after this build.
+func TestSyncDynamicConfigAuthModelsCommandCodeHonoursConfiguredModels(t *testing.T) {
+	reg := &testModelRegistry{}
+	cfg := &config.Config{CommandCodeKey: []config.CommandCodeKey{{
+		APIKey:  "cc-key",
+		BaseURL: config.DefaultCommandCodeBaseURL,
+		Models: []config.CommandCodeModel{
+			{Name: "model-that-shipped-yesterday"},
+			{Name: "cline-pass/glm-5.2"},
+		},
+	}}}
+
+	syncDynamicConfigAuthModels(reg, cfg, commandCodeAuth())
+
+	ids := make(map[string]struct{}, len(reg.models))
+	for _, model := range reg.models {
+		ids[model.ID] = struct{}{}
+	}
+	if _, ok := ids["model-that-shipped-yesterday"]; !ok {
+		t.Fatalf("configured model missing from %v", modelIDs(reg.models))
+	}
+	// cline-pass ids belong to the Cline channel and must not route here.
+	if _, ok := ids["cline-pass/glm-5.2"]; ok {
+		t.Fatalf("cline-pass row leaked into Command Code: %v", modelIDs(reg.models))
+	}
+}
+
+func modelIDs(models []*sdkmodelcatalog.ModelInfo) []string {
+	out := make([]string, 0, len(models))
+	for _, model := range models {
+		out = append(out, model.ID)
+	}
+	return out
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,6 +147,9 @@ type Config struct {
 	// OllamaCloudKey defines Ollama Cloud API key configurations.
 	OllamaCloudKey []OllamaCloudKey `yaml:"ollama-cloud-api-key" json:"ollama-cloud-api-key"`
 
+	// CommandCodeKey defines Command Code Provider API key configurations.
+	CommandCodeKey []CommandCodeKey `yaml:"commandcode-api-key" json:"commandcode-api-key"`
+
 	// ClaudeHeaderDefaults configures default header values for Claude API requests.
 	// These are used as fallbacks when the client does not send its own headers.
 	ClaudeHeaderDefaults ClaudeHeaderDefaults `yaml:"claude-header-defaults" json:"claude-header-defaults"`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -143,6 +143,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.SanitizeOpenCodeGoKeys()
 	cfg.SanitizeClineKeys()
 	cfg.SanitizeOllamaCloudKeys()
+	cfg.SanitizeCommandCodeKeys()
 	cfg.SanitizeGeminiKeys()
 	cfg.SanitizeProxyWarmup()
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -435,6 +435,71 @@ func normalizeOllamaCloudBaseURL(baseURL string) string {
 	return strings.TrimSuffix(base, "/")
 }
 
+// SanitizeCommandCodeKeys deduplicates and normalizes Command Code credentials.
+func (cfg *Config) SanitizeCommandCodeKeys() {
+	if cfg == nil || len(cfg.CommandCodeKey) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(cfg.CommandCodeKey))
+	out := make([]CommandCodeKey, 0, len(cfg.CommandCodeKey))
+	for i := range cfg.CommandCodeKey {
+		entry := cfg.CommandCodeKey[i]
+		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		if entry.APIKey == "" {
+			continue
+		}
+		entry.BaseURL = normalizeCommandCodeBaseURL(entry.BaseURL)
+		seenKey := entry.APIKey + "\x00" + entry.BaseURL
+		if _, exists := seen[seenKey]; exists {
+			continue
+		}
+		seen[seenKey] = struct{}{}
+		entry.Name = strings.TrimSpace(entry.Name)
+		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+		entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+		entry.Headers = NormalizeHeaders(entry.Headers)
+		entry.Models = NormalizeCommandCodeModels(entry.Models)
+		entry.ExcludedModels = NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
+		if IsProviderModelAccessDisabledAll(entry.ExcludedModels) {
+			entry.Models = nil
+		}
+		entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+		out = append(out, entry)
+	}
+	cfg.CommandCodeKey = out
+}
+
+func NormalizeCommandCodeModels(models []CommandCodeModel) []CommandCodeModel {
+	if len(models) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(models))
+	out := make([]CommandCodeModel, 0, len(models))
+	for i := range models {
+		name := strings.TrimSpace(models[i].Name)
+		if name == "" {
+			continue
+		}
+		alias := strings.TrimSpace(models[i].Alias)
+		key := strings.ToLower(name)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, CommandCodeModel{Name: name, Alias: alias})
+	}
+	return out
+}
+
+func normalizeCommandCodeBaseURL(baseURL string) string {
+	base := strings.TrimSpace(baseURL)
+	if base == "" {
+		return DefaultCommandCodeBaseURL
+	}
+	return strings.TrimSuffix(base, "/")
+}
+
 // SanitizeGeminiKeys deduplicates and normalizes Gemini credentials.
 func (cfg *Config) SanitizeGeminiKeys() {
 	if cfg == nil {

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -403,3 +403,62 @@ type OllamaCloudModel struct {
 
 func (m OllamaCloudModel) GetName() string  { return m.Name }
 func (m OllamaCloudModel) GetAlias() string { return m.Alias }
+
+// DefaultCommandCodeBaseURL is Command Code's documented Provider API. Note that
+// the plan tier is an entitlement rather than a credential concern: accounts on
+// the $1 "Go" plan mint a valid key but still receive 403 upgrade_required here,
+// because that plan excludes API access. Every other plan (GOAT and above) works.
+const DefaultCommandCodeBaseURL = "https://api.commandcode.ai/provider/v1"
+
+// CommandCodeKey represents a Command Code OpenAI-compatible API key.
+type CommandCodeKey struct {
+	// ID is the immutable persistent UUID used by channel bindings.
+	ID string `yaml:"id,omitempty" json:"id,omitempty"`
+
+	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// Name is a human-readable label for this channel.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
+	// Disabled prevents this credential from serving requests without changing its model allowlist.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
+	// Priority controls selection preference when multiple credentials match.
+	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Prefix optionally namespaces models for this credential.
+	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// BaseURL is the OpenAI-compatible base URL. Defaults to DefaultCommandCodeBaseURL.
+	BaseURL string `yaml:"base-url,omitempty" json:"base-url,omitempty"`
+
+	// ProxyURL overrides the global proxy setting for this API key if provided.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+
+	// ProxyID references a reusable proxy-pool entry. When valid, it takes precedence over ProxyURL.
+	ProxyID string `yaml:"proxy-id,omitempty" json:"proxy-id,omitempty"`
+
+	// Models defines upstream Command Code model IDs and optional client-facing aliases.
+	Models []CommandCodeModel `yaml:"models,omitempty" json:"models,omitempty"`
+
+	// Headers optionally adds extra HTTP headers for requests sent with this key.
+	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+
+	// ExcludedModels lists model IDs that should be excluded for this provider.
+	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+
+	// VisionFallbackModel is used for image requests whose requested model lacks vision support.
+	VisionFallbackModel string `yaml:"vision-fallback-model,omitempty" json:"vision-fallback-model,omitempty"`
+}
+
+func (k CommandCodeKey) GetAPIKey() string  { return k.APIKey }
+func (k CommandCodeKey) GetBaseURL() string { return k.BaseURL }
+
+// CommandCodeModel describes a model explicitly enabled for Command Code routing.
+type CommandCodeModel struct {
+	Name  string `yaml:"name" json:"name"`
+	Alias string `yaml:"alias,omitempty" json:"alias,omitempty"`
+}
+
+func (m CommandCodeModel) GetName() string  { return m.Name }
+func (m CommandCodeModel) GetAlias() string { return m.Alias }

--- a/internal/config/provider_stable_ids.go
+++ b/internal/config/provider_stable_ids.go
@@ -62,6 +62,9 @@ func (cfg *Config) EnsureProviderStableIDs() bool {
 	for i := range cfg.OllamaCloudKey {
 		ensure(&cfg.OllamaCloudKey[i].ID)
 	}
+	for i := range cfg.CommandCodeKey {
+		ensure(&cfg.CommandCodeKey[i].ID)
+	}
 	for i := range cfg.OpenAICompatibility {
 		ensure(&cfg.OpenAICompatibility[i].ID)
 		for j := range cfg.OpenAICompatibility[i].APIKeyEntries {
@@ -87,6 +90,7 @@ func PreserveMissingProviderStableIDs(previous, next *Config) {
 	preserveIDs(previous.OpenCodeGoKey, next.OpenCodeGoKey, func(v *OpenCodeGoKey) *string { return &v.ID })
 	preserveIDs(previous.ClineKey, next.ClineKey, func(v *ClineKey) *string { return &v.ID })
 	preserveIDs(previous.OllamaCloudKey, next.OllamaCloudKey, func(v *OllamaCloudKey) *string { return &v.ID })
+	preserveIDs(previous.CommandCodeKey, next.CommandCodeKey, func(v *CommandCodeKey) *string { return &v.ID })
 	preserveIDs(previous.VertexCompatAPIKey, next.VertexCompatAPIKey, func(v *VertexCompatKey) *string { return &v.ID })
 	preserveIDs(previous.OpenAICompatibility, next.OpenAICompatibility, func(v *OpenAICompatibility) *string { return &v.ID })
 	for i := range next.OpenAICompatibility {

--- a/internal/config/sdkbridge/bridge.go
+++ b/internal/config/sdkbridge/bridge.go
@@ -36,6 +36,8 @@ type ClineKey = coreconfig.ClineKey
 type ClineModel = coreconfig.ClineModel
 type OllamaCloudKey = coreconfig.OllamaCloudKey
 type OllamaCloudModel = coreconfig.OllamaCloudModel
+type CommandCodeKey = coreconfig.CommandCodeKey
+type CommandCodeModel = coreconfig.CommandCodeModel
 type VertexCompatKey = coreconfig.VertexCompatKey
 type VertexCompatModel = coreconfig.VertexCompatModel
 type OpenAICompatibility = coreconfig.OpenAICompatibility
@@ -49,6 +51,7 @@ const (
 	DefaultBedrockRegion         = coreconfig.DefaultBedrockRegion
 	DefaultClineBaseURL          = coreconfig.DefaultClineBaseURL
 	DefaultOllamaCloudBaseURL    = coreconfig.DefaultOllamaCloudBaseURL
+	DefaultCommandCodeBaseURL    = coreconfig.DefaultCommandCodeBaseURL
 )
 
 func LoadConfig(configFile string) (*Config, error) { return coreconfig.LoadConfig(configFile) }

--- a/internal/contentmoderation/catalog.go
+++ b/internal/contentmoderation/catalog.go
@@ -95,7 +95,7 @@ func ProviderChannelRefs(cfg *config.Config) []ChannelRef {
 	if cfg == nil {
 		return nil
 	}
-	refs := make([]ChannelRef, 0, len(cfg.GeminiKey)+len(cfg.ClaudeKey)+len(cfg.BedrockKey)+len(cfg.CodexKey)+len(cfg.OpenCodeGoKey)+len(cfg.ClineKey)+len(cfg.OllamaCloudKey)+len(cfg.VertexCompatAPIKey)+len(cfg.OpenAICompatibility))
+	refs := make([]ChannelRef, 0, len(cfg.GeminiKey)+len(cfg.ClaudeKey)+len(cfg.BedrockKey)+len(cfg.CodexKey)+len(cfg.OpenCodeGoKey)+len(cfg.ClineKey)+len(cfg.OllamaCloudKey)+len(cfg.CommandCodeKey)+len(cfg.VertexCompatAPIKey)+len(cfg.OpenAICompatibility))
 	addKey := func(id string) {
 		if id = strings.TrimSpace(id); id != "" {
 			refs = append(refs, ChannelRef{ChannelType: ChannelTypeProviderKey, ChannelID: id})
@@ -120,6 +120,9 @@ func ProviderChannelRefs(cfg *config.Config) []ChannelRef {
 		addKey(entry.ID)
 	}
 	for _, entry := range cfg.OllamaCloudKey {
+		addKey(entry.ID)
+	}
+	for _, entry := range cfg.CommandCodeKey {
 		addKey(entry.ID)
 	}
 	for _, entry := range cfg.VertexCompatAPIKey {
@@ -214,6 +217,9 @@ func buildChannels(cfg *config.Config, auths []*coreauth.Auth, bindings map[stri
 		}
 		for _, entry := range cfg.OllamaCloudKey {
 			add(simpleProviderChannel(entry.ID, entry.Name, "ollama-cloud", entry.Disabled))
+		}
+		for _, entry := range cfg.CommandCodeKey {
+			add(simpleProviderChannel(entry.ID, entry.Name, "commandcode", entry.Disabled))
 		}
 		for _, entry := range cfg.VertexCompatAPIKey {
 			add(simpleProviderChannel(entry.ID, "vertex", "vertex", false))

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -218,7 +218,7 @@ func managementVisibleModels(modelRegistry *registry.ModelRegistry) []map[string
 	for _, model := range modelRegistry.GetAvailableModels("openai") {
 		add(model)
 	}
-	for _, provider := range []string{"opencode-go", "cline", "ollama-cloud"} {
+	for _, provider := range []string{"opencode-go", "cline", "ollama-cloud", "commandcode"} {
 		for _, info := range modelRegistry.GetAvailableModelsByProvider(provider) {
 			add(registryModelInfoAsOpenAIModel(info))
 		}
@@ -779,7 +779,7 @@ func registryModelOnlyHasDynamicProviderSources(modelRegistry *registry.ModelReg
 		// These config-backed providers publish their serviceable models from runtime model lists,
 		// so a missing system model-config row must not hide the registry model.
 		switch provider {
-		case "opencode-go", "cline", "ollama-cloud":
+		case "opencode-go", "cline", "ollama-cloud", "commandcode":
 		default:
 			return false
 		}

--- a/internal/management/settings/providers/provider_keys_commandcode.go
+++ b/internal/management/settings/providers/provider_keys_commandcode.go
@@ -1,0 +1,244 @@
+package providers
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// Command Code provider settings.
+//
+// Kept in its own file because provider_keys_extended.go is frozen at its
+// current size by the structure ratchet and may only shrink.
+//
+// Unlike Cline, Ollama Cloud and OpenCode Go, this channel carries no dashboard
+// cookie: Command Code reports plan windows and credits from an endpoint that
+// authenticates with the same API key used for inference, so there is nothing
+// for the operator to paste from a browser and nothing here that expires.
+
+type CommandCodePatch struct {
+	APIKey         *string                    `json:"api-key"`
+	Name           *string                    `json:"name"`
+	Disabled       *bool                      `json:"disabled"`
+	Priority       *int                       `json:"priority"`
+	Prefix         *string                    `json:"prefix"`
+	BaseURL        *string                    `json:"base-url"`
+	ProxyURL       *string                    `json:"proxy-url"`
+	ProxyID        *string                    `json:"proxy-id"`
+	Headers        *map[string]string         `json:"headers"`
+	Models         *[]config.CommandCodeModel `json:"models"`
+	ExcludedModels *[]string                  `json:"excluded-models"`
+	VisionFallback *string                    `json:"vision-fallback-model"`
+}
+
+func (s *Service) CommandCodeKeys() []config.CommandCodeKey {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return NormalizedCommandCodeKeyEntries(s.cfg.CommandCodeKey)
+}
+
+func (s *Service) ReplaceCommandCodeKeys(entries []config.CommandCodeKey) error {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	filtered := make([]config.CommandCodeKey, 0, len(entries))
+	for i := range entries {
+		NormalizeCommandCodeKey(&entries[i])
+		if strings.TrimSpace(entries[i].APIKey) != "" {
+			if err := validateCommandCodeKeyModels(entries[i]); err != nil {
+				return err
+			}
+			filtered = append(filtered, entries[i])
+		}
+	}
+	if len(entries) > 0 && len(filtered) == 0 {
+		return ErrProviderAPIKeyRequired
+	}
+	prev := append([]config.CommandCodeKey(nil), s.cfg.CommandCodeKey...)
+	next := &config.Config{CommandCodeKey: filtered}
+	prepareProviderStableIDs(&config.Config{CommandCodeKey: prev}, next)
+	s.cfg.CommandCodeKey = next.CommandCodeKey
+	s.cfg.SanitizeCommandCodeKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.CommandCodeKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) PatchCommandCodeKey(index *int, apiKey *string, name *string, patch CommandCodePatch) error {
+	if s == nil || s.cfg == nil {
+		return ErrItemNotFound
+	}
+	targetIndex := -1
+	if index != nil && *index >= 0 && *index < len(s.cfg.CommandCodeKey) {
+		targetIndex = *index
+	}
+	if targetIndex == -1 && apiKey != nil {
+		match := strings.TrimSpace(*apiKey)
+		for i := range s.cfg.CommandCodeKey {
+			if s.cfg.CommandCodeKey[i].APIKey == match {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 && name != nil {
+		match := strings.TrimSpace(*name)
+		for i := range s.cfg.CommandCodeKey {
+			if s.cfg.CommandCodeKey[i].Name == match {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 {
+		return ErrItemNotFound
+	}
+
+	entry := s.cfg.CommandCodeKey[targetIndex]
+	if patch.APIKey != nil {
+		entry.APIKey = strings.TrimSpace(*patch.APIKey)
+	}
+	if patch.Name != nil {
+		entry.Name = strings.TrimSpace(*patch.Name)
+	}
+	if patch.Disabled != nil {
+		entry.Disabled = *patch.Disabled
+	}
+	if patch.Priority != nil {
+		entry.Priority = *patch.Priority
+	}
+	if patch.Prefix != nil {
+		entry.Prefix = strings.TrimSpace(*patch.Prefix)
+	}
+	if patch.BaseURL != nil {
+		entry.BaseURL = strings.TrimSpace(*patch.BaseURL)
+	}
+	if patch.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*patch.ProxyURL)
+	}
+	if patch.ProxyID != nil {
+		entry.ProxyID = strings.TrimSpace(*patch.ProxyID)
+	}
+	if patch.Headers != nil {
+		entry.Headers = config.NormalizeHeaders(*patch.Headers)
+	}
+	if patch.Models != nil {
+		entry.Models = append([]config.CommandCodeModel(nil), (*patch.Models)...)
+	}
+	if patch.ExcludedModels != nil {
+		entry.ExcludedModels = config.NormalizeExcludedModels(*patch.ExcludedModels)
+	}
+	if patch.VisionFallback != nil {
+		entry.VisionFallbackModel = strings.TrimSpace(*patch.VisionFallback)
+	}
+	NormalizeCommandCodeKey(&entry)
+	if entry.APIKey == "" {
+		return ErrProviderAPIKeyRequired
+	}
+	if err := validateCommandCodeKeyModels(entry); err != nil {
+		return err
+	}
+	prev := append([]config.CommandCodeKey(nil), s.cfg.CommandCodeKey...)
+	s.cfg.CommandCodeKey[targetIndex] = entry
+	s.cfg.SanitizeCommandCodeKeys()
+	if err := s.runValidator(); err != nil {
+		s.cfg.CommandCodeKey = prev
+		return err
+	}
+	return nil
+}
+
+func (s *Service) DeleteCommandCodeKeyByAPIKey(apiKey string) bool {
+	return s.deleteCommandCodeKeys(func(entry config.CommandCodeKey) bool { return entry.APIKey == apiKey })
+}
+
+func (s *Service) DeleteCommandCodeKeyByName(name string) bool {
+	return s.deleteCommandCodeKeys(func(entry config.CommandCodeKey) bool { return entry.Name == name })
+}
+
+func (s *Service) DeleteCommandCodeKeyByIndex(index int) bool {
+	if s == nil || s.cfg == nil || index < 0 || index >= len(s.cfg.CommandCodeKey) {
+		return false
+	}
+	s.deleteCommandCodeKeyByIndex(index)
+	return true
+}
+
+func (s *Service) deleteCommandCodeKeys(match func(config.CommandCodeKey) bool) bool {
+	if s == nil || s.cfg == nil {
+		return false
+	}
+	out := make([]config.CommandCodeKey, 0, len(s.cfg.CommandCodeKey))
+	for _, entry := range s.cfg.CommandCodeKey {
+		if !match(entry) {
+			out = append(out, entry)
+		}
+	}
+	if len(out) == len(s.cfg.CommandCodeKey) {
+		return false
+	}
+	s.cfg.CommandCodeKey = out
+	s.cfg.SanitizeCommandCodeKeys()
+	return true
+}
+
+func (s *Service) deleteCommandCodeKeyByIndex(index int) {
+	s.cfg.CommandCodeKey = append(s.cfg.CommandCodeKey[:index], s.cfg.CommandCodeKey[index+1:]...)
+	s.cfg.SanitizeCommandCodeKeys()
+}
+
+func NormalizeCommandCodeKey(entry *config.CommandCodeKey) {
+	if entry == nil {
+		return
+	}
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.BaseURL = strings.TrimSuffix(strings.TrimSpace(entry.BaseURL), "/")
+	if entry.BaseURL == "" {
+		entry.BaseURL = config.DefaultCommandCodeBaseURL
+	}
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.ProxyID = strings.TrimSpace(entry.ProxyID)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.Models = config.NormalizeCommandCodeModels(entry.Models)
+	entry.ExcludedModels = config.NormalizeProviderModelAccessExcludedModels(entry.ExcludedModels)
+	entry.VisionFallbackModel = strings.TrimSpace(entry.VisionFallbackModel)
+}
+
+func NormalizedCommandCodeKeyEntries(entries []config.CommandCodeKey) []config.CommandCodeKey {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.CommandCodeKey, len(entries))
+	for i := range entries {
+		out[i] = entries[i]
+		NormalizeCommandCodeKey(&out[i])
+		if config.IsProviderModelAccessDisabledAll(out[i].ExcludedModels) {
+			out[i].Models = nil
+		}
+	}
+	return out
+}
+
+// validateCommandCodeKeyModels keeps cline-pass IDs out of this channel; those
+// belong to Cline and would otherwise be routed to the wrong upstream.
+func validateCommandCodeKeyModels(entry config.CommandCodeKey) error {
+	for _, model := range entry.Models {
+		if isClinePassModelID(model.Name) {
+			return providerModelOwnershipError("commandcode", "models", model.Name, "must not use cline-pass model IDs")
+		}
+	}
+	for _, model := range entry.ExcludedModels {
+		if model == "*" {
+			continue
+		}
+		if isClinePassModelID(model) {
+			return providerModelOwnershipError("commandcode", "excluded-models", model, "must not use cline-pass model IDs")
+		}
+	}
+	return nil
+}

--- a/internal/management/settings/runtimeconfig/spec.go
+++ b/internal/management/settings/runtimeconfig/spec.go
@@ -16,6 +16,7 @@ const (
 	RuntimeSettingOpenCodeGoKeys       = "opencode-go-api-key"
 	RuntimeSettingClineKeys            = "cline-api-key"
 	RuntimeSettingOllamaCloudKeys      = "ollama-cloud-api-key"
+	RuntimeSettingCommandCodeKeys      = "commandcode-api-key"
 	RuntimeSettingOpenAICompatibility  = "openai-compatibility"
 	RuntimeSettingVertexCompatKeys     = "vertex-api-key"
 	RuntimeSettingClaudeHeaderDefaults = "claude-header-defaults"
@@ -187,6 +188,28 @@ func Specs() []Spec {
 				holder := &config.Config{OllamaCloudKey: value}
 				holder.SanitizeOllamaCloudKeys()
 				cfg.OllamaCloudKey = holder.OllamaCloudKey
+				return true
+			},
+		},
+		{
+			Key: RuntimeSettingCommandCodeKeys,
+			Meaningful: func(cfg *config.Config) bool {
+				return len(cfg.CommandCodeKey) > 0
+			},
+			Value: func(cfg *config.Config) any {
+				holder := &config.Config{CommandCodeKey: append([]config.CommandCodeKey(nil), cfg.CommandCodeKey...)}
+				holder.SanitizeCommandCodeKeys()
+				return holder.CommandCodeKey
+			},
+			Apply: func(cfg *config.Config, raw json.RawMessage) bool {
+				var value []config.CommandCodeKey
+				if err := json.Unmarshal(raw, &value); err != nil {
+					log.Warnf("runtimeconfig: decode %s: %v", RuntimeSettingCommandCodeKeys, err)
+					return false
+				}
+				holder := &config.Config{CommandCodeKey: value}
+				holder.SanitizeCommandCodeKeys()
+				cfg.CommandCodeKey = holder.CommandCodeKey
 				return true
 			},
 		},

--- a/internal/management/settings/store/runtime_settings.go
+++ b/internal/management/settings/store/runtime_settings.go
@@ -17,6 +17,7 @@ const (
 	RuntimeSettingOpenCodeGoKeys       = runtimeconfig.RuntimeSettingOpenCodeGoKeys
 	RuntimeSettingClineKeys            = runtimeconfig.RuntimeSettingClineKeys
 	RuntimeSettingOllamaCloudKeys      = runtimeconfig.RuntimeSettingOllamaCloudKeys
+	RuntimeSettingCommandCodeKeys      = runtimeconfig.RuntimeSettingCommandCodeKeys
 	RuntimeSettingOpenAICompatibility  = runtimeconfig.RuntimeSettingOpenAICompatibility
 	RuntimeSettingVertexCompatKeys     = runtimeconfig.RuntimeSettingVertexCompatKeys
 	RuntimeSettingClaudeHeaderDefaults = runtimeconfig.RuntimeSettingClaudeHeaderDefaults

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -25,6 +25,7 @@ import (
 //   - opencode-go
 //   - cline
 //   - ollama-cloud
+//   - commandcode
 //   - antigravity (returns static overrides only)
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	key := strings.ToLower(strings.TrimSpace(channel))
@@ -57,6 +58,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetClineModels()
 	case "ollama-cloud":
 		return GetOllamaCloudModels()
+	case "commandcode":
+		return GetCommandCodeModels()
 	case "antigravity":
 		cfg := GetAntigravityModelConfig()
 		if len(cfg) == 0 {

--- a/internal/registry/model_definitions_commandcode.go
+++ b/internal/registry/model_definitions_commandcode.go
@@ -1,0 +1,92 @@
+package registry
+
+// Command Code model definitions.
+//
+// Kept out of model_definitions_static_data.go because that file is frozen at its
+// current size by the structure ratchet in scripts/check-backend-structure.py and
+// may only shrink.
+//
+// This list is a fallback, not a gate. Command Code publishes the authoritative
+// catalog at GET /provider/v1/models, which needs no credential, so an operator
+// running ahead of this snapshot can name any newer model explicitly under
+// commandcode-api-key[].models and it will route without touching this file.
+// Regenerate the snapshot from that endpoint rather than hand-editing entries.
+
+// GetCommandCodeModels returns the Command Code Provider API catalog snapshot.
+func GetCommandCodeModels() []*ModelInfo {
+	definitions := []struct {
+		id            string
+		displayName   string
+		contextLength int
+	}{
+		{"claude-sonnet-5", "Claude Sonnet 5", 1000000},
+		{"claude-sonnet-4-6", "Claude Sonnet 4.6", 1000000},
+		{"claude-fable-5", "Claude Fable 5", 1000000},
+		{"claude-opus-5", "Claude Opus 5", 1000000},
+		{"claude-opus-4-8", "Claude Opus 4.8", 1000000},
+		{"claude-opus-4-7", "Claude Opus 4.7", 1000000},
+		{"claude-haiku-4-5-20251001", "Claude Haiku 4.5", 200000},
+		{"gpt-5.6-sol", "GPT-5.6 Sol", 1050000},
+		{"gpt-5.6-terra", "GPT-5.6 Terra", 1050000},
+		{"gpt-5.6-luna", "GPT-5.6 Luna", 1050000},
+		{"gpt-5.5", "GPT-5.5", 200000},
+		{"gpt-5.4", "GPT-5.4", 400000},
+		{"gpt-5.3-codex", "GPT-5.3 Codex", 400000},
+		{"gpt-5.4-mini", "GPT-5.4 Mini", 400000},
+		{"deepseek/deepseek-v4-pro", "DeepSeek V4 Pro (latest)", 1000000},
+		{"deepseek/deepseek-v4-flash", "DeepSeek V4 Flash (latest)", 1000000},
+		{"moonshotai/Kimi-K3", "Kimi K3", 1000000},
+		{"moonshotai/Kimi-K2.7-Code", "Kimi K2.7 Code", 256000},
+		{"moonshotai/Kimi-K2.7-Code-Highspeed", "Kimi K2.7 Code HighSpeed", 262000},
+		{"moonshotai/Kimi-K2.6", "Kimi K2.6", 256000},
+		{"moonshotai/Kimi-K2.5", "Kimi K2.5", 256000},
+		{"zai-org/GLM-5.3", "GLM-5.3", 1000000},
+		{"zai-org/GLM-5.2", "GLM-5.2", 1000000},
+		{"zai-org/GLM-5.2-Fast", "GLM-5.2 Fast", 1000000},
+		{"zai-org/GLM-5.1", "GLM-5.1", 200000},
+		{"zai-org/GLM-5", "GLM-5", 200000},
+		{"MiniMaxAI/MiniMax-M3", "MiniMax M3", 1000000},
+		{"MiniMaxAI/MiniMax-M2.7", "MiniMax M2.7", 200000},
+		{"MiniMaxAI/MiniMax-M2.5", "MiniMax M2.5", 200000},
+		{"xiaomi/mimo-v2.5-pro", "MiMo V2.5 Pro", 1000000},
+		{"xiaomi/mimo-v2.5", "MiMo V2.5", 1000000},
+		{"Qwen/Qwen3.8-Max", "Qwen 3.8 Max", 1000000},
+		{"Qwen/Qwen3.7-Max", "Qwen 3.7 Max", 1000000},
+		{"Qwen/Qwen3.7-Plus", "Qwen 3.7 Plus", 1000000},
+		{"Qwen/Qwen3.7-Flash", "Qwen 3.7 Flash", 1000000},
+		{"Qwen/Qwen3.6-Max-Preview", "Qwen 3.6 Max Preview", 200000},
+		{"Qwen/Qwen3.6-Plus", "Qwen 3.6 Plus", 200000},
+		{"stepfun/Step-3.7-Flash", "Step 3.7 Flash", 256000},
+		{"stepfun/Step-3.5-Flash", "Step 3.5 Flash", 1000000},
+		{"tencent/hy3-paid", "Tencent Hy3", 262144},
+		{"google/gemini-3.7-flash", "Gemini 3.7 Flash", 1048576},
+		{"google/gemini-3.6-flash", "Gemini 3.6 Flash", 1000000},
+		{"google/gemini-3.5-flash", "Gemini 3.5 Flash", 1000000},
+		{"google/gemini-3.5-flash-lite", "Gemini 3.5 Flash Lite", 1000000},
+		{"google/gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", 1000000},
+		{"sakana/fugu-ultra", "Fugu Ultra", 1000000},
+		{"nvidia/nemotron-3-ultra-550b-a55b", "Nemotron 3 Ultra", 1000000},
+		{"thinkingmachines/inkling", "Inkling", 256000},
+		{"thinkingmachines/inkling-small", "Inkling Small", 1000000},
+		{"poolside/laguna-s-2.1-free", "Laguna S 2.1", 256000},
+		{"meta/muse-spark-1.1", "Muse Spark 1.1", 1048576},
+		{"meta/muse-spark-1.2", "Muse Spark 1.2", 1048576},
+		{"meta/muse-spark-1.2-contributor", "Muse Spark 1.2 Contributor", 1048576},
+		{"xai/grok-4.5", "Grok 4.5", 500000},
+		{"xai/grok-4.6", "Grok 4.6", 500000},
+	}
+
+	models := make([]*ModelInfo, 0, len(definitions))
+	for _, definition := range definitions {
+		models = append(models, &ModelInfo{
+			ID:            definition.id,
+			Object:        "model",
+			Created:       1787060518,
+			OwnedBy:       "command-code",
+			Type:          "commandcode",
+			DisplayName:   definition.displayName,
+			ContextLength: definition.contextLength,
+		})
+	}
+	return models
+}

--- a/internal/runtime/executor/commandcode.go
+++ b/internal/runtime/executor/commandcode.go
@@ -1,0 +1,14 @@
+package executor
+
+// Command Code speaks plain OpenAI on https://api.commandcode.ai/provider/v1, so
+// it is served by OpenAICompatExecutor rather than a dedicated executor. What
+// lives here is only the provider identity and the per-credential lookups that
+// the shared compat paths need.
+//
+// Note the plan boundary: Command Code's $1 "Go" plan mints a working key but
+// answers 403 upgrade_required on this base URL, because that plan excludes API
+// access. Every plan above it (GOAT and up) is served normally. The refusal is
+// an entitlement signal, not a credential fault, so it is surfaced to the
+// operator as-is instead of being retried or masked.
+
+const commandCodeProvider = "commandcode"

--- a/internal/runtime/executor/opencode_go_executor.go
+++ b/internal/runtime/executor/opencode_go_executor.go
@@ -289,7 +289,7 @@ func applyVisionFallback(req cliproxyexecutor.Request, opts cliproxyexecutor.Opt
 
 func openAICompatSupportsVisionFallback(provider string) bool {
 	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case "cline", "ollama-cloud":
+	case "cline", "ollama-cloud", commandCodeProvider:
 		return true
 	default:
 		return false
@@ -302,6 +302,8 @@ func openAICompatVisionFallbackModel(cfg *config.Config, auth *cliproxyauth.Auth
 		return configOpenAICompatVisionFallbackModel(cfg, auth, "cline")
 	case "ollama-cloud":
 		return configOpenAICompatVisionFallbackModel(cfg, auth, "ollama-cloud")
+	case commandCodeProvider:
+		return configOpenAICompatVisionFallbackModel(cfg, auth, commandCodeProvider)
 	default:
 		return ""
 	}
@@ -345,6 +347,18 @@ func configOpenAICompatVisionFallbackModel(cfg *config.Config, auth *cliproxyaut
 	case "ollama-cloud":
 		for i := range cfg.OllamaCloudKey {
 			entry := &cfg.OllamaCloudKey[i]
+			if !strings.EqualFold(strings.TrimSpace(entry.APIKey), apiKey) {
+				continue
+			}
+			fallback := strings.TrimSpace(entry.VisionFallbackModel)
+			if opencodeGoModelExcluded(fallback, strings.Join(entry.ExcludedModels, ",")) {
+				return ""
+			}
+			return fallback
+		}
+	case commandCodeProvider:
+		for i := range cfg.CommandCodeKey {
+			entry := &cfg.CommandCodeKey[i]
 			if !strings.EqualFold(strings.TrimSpace(entry.APIKey), apiKey) {
 				continue
 			}

--- a/internal/runtime/executor/prompt_cache_key.go
+++ b/internal/runtime/executor/prompt_cache_key.go
@@ -107,7 +107,9 @@ func providerSupportsClaudeCacheControl(provider string) bool {
 
 func providerSupportsSessionPromptCacheKey(provider string) bool {
 	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case openCodeGoProvider, "cline", "ollama-cloud":
+	// Command Code prices cache reads separately from fresh input, so a stable
+	// per-session key is what lets a long conversation stay on the cheap side.
+	case openCodeGoProvider, "cline", "ollama-cloud", commandCodeProvider:
 		return true
 	default:
 		return false

--- a/internal/usage/config_yaml_cleanup.go
+++ b/internal/usage/config_yaml_cleanup.go
@@ -100,6 +100,7 @@ func cleanRuntimeSettingsFromYAML(configFilePath string) {
 		"opencode-go-api-key":    true,
 		"cline-api-key":          true,
 		"ollama-cloud-api-key":   true,
+		"commandcode-api-key":    true,
 		"openai-compatibility":   true,
 		"vertex-api-key":         true,
 		"claude-header-defaults": true,

--- a/internal/usage/runtime_settings_db.go
+++ b/internal/usage/runtime_settings_db.go
@@ -23,6 +23,7 @@ const (
 	RuntimeSettingOpenCodeGoKeys       = runtimeconfig.RuntimeSettingOpenCodeGoKeys
 	RuntimeSettingClineKeys            = runtimeconfig.RuntimeSettingClineKeys
 	RuntimeSettingOllamaCloudKeys      = runtimeconfig.RuntimeSettingOllamaCloudKeys
+	RuntimeSettingCommandCodeKeys      = runtimeconfig.RuntimeSettingCommandCodeKeys
 	RuntimeSettingOpenAICompatibility  = runtimeconfig.RuntimeSettingOpenAICompatibility
 	RuntimeSettingVertexCompatKeys     = runtimeconfig.RuntimeSettingVertexCompatKeys
 	RuntimeSettingClaudeHeaderDefaults = runtimeconfig.RuntimeSettingClaudeHeaderDefaults
@@ -140,6 +141,7 @@ func persistProviderStableIDBackfill(store sqlsettings.RuntimeSettingsStore, cfg
 		{RuntimeSettingOpenCodeGoKeys, cfg.OpenCodeGoKey},
 		{RuntimeSettingClineKeys, cfg.ClineKey},
 		{RuntimeSettingOllamaCloudKeys, cfg.OllamaCloudKey},
+		{RuntimeSettingCommandCodeKeys, cfg.CommandCodeKey},
 		{RuntimeSettingOpenAICompatibility, cfg.OpenAICompatibility},
 		{RuntimeSettingVertexCompatKeys, cfg.VertexCompatAPIKey},
 	}
@@ -172,6 +174,7 @@ func BuildTenantRuntimeConfig(base *config.Config, tenantID string) config.Confi
 	tenantCfg.OpenCodeGoKey = nil
 	tenantCfg.ClineKey = nil
 	tenantCfg.OllamaCloudKey = nil
+	tenantCfg.CommandCodeKey = nil
 	tenantCfg.OpenAICompatibility = nil
 	tenantCfg.VertexCompatAPIKey = nil
 	tenantCfg.ClaudeHeaderDefaults = config.ClaudeHeaderDefaults{}

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -116,6 +116,21 @@ func ComputeOpenCodeGoModelsHash(models []config.OpenCodeGoModel) string {
 	return hashJoined(keys)
 }
 
+// ComputeCommandCodeModelsHash returns a stable hash for Command Code model aliases.
+func ComputeCommandCodeModelsHash(models []config.CommandCodeModel) string {
+	keys := normalizeModelPairs(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+		}
+	})
+	return hashJoined(keys)
+}
+
 // ComputeClineModelsHash returns a stable hash for Cline model aliases.
 func ComputeClineModelsHash(models []config.ClineModel) string {
 	keys := normalizeModelPairs(func(out func(key string)) {

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -40,6 +40,8 @@ func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth,
 	out = append(out, s.synthesizeClineKeys(ctx)...)
 	// Ollama Cloud API Keys
 	out = append(out, s.synthesizeOllamaCloudKeys(ctx)...)
+	// Command Code API Keys
+	out = append(out, s.synthesizeCommandCodeKeys(ctx)...)
 	// OpenAI-compat
 	out = append(out, s.synthesizeOpenAICompat(ctx)...)
 	// Vertex-compat
@@ -415,6 +417,73 @@ func (s *ConfigSynthesizer) synthesizeClineKeys(ctx *SynthesisContext) []*coreau
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "cline",
+			Label:      label,
+			Prefix:     prefix,
+			Status:     coreauth.StatusActive,
+			ProxyURL:   proxyURL,
+			ProxyID:    proxyID,
+			Attributes: attrs,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
+		ApplyConfigDisabledState(a, entry.Disabled)
+		out = append(out, a)
+	}
+	return out
+}
+
+// synthesizeCommandCodeKeys creates Auth entries for Command Code API keys.
+//
+// Command Code speaks plain OpenAI on its Provider API, so the auth carries
+// compat metadata and is served by the shared OpenAI-compatible executor rather
+// than a dedicated one.
+func (s *ConfigSynthesizer) synthesizeCommandCodeKeys(ctx *SynthesisContext) []*coreauth.Auth {
+	cfg := ctx.Config
+	now := ctx.Now
+	idGen := ctx.IDGenerator
+
+	out := make([]*coreauth.Auth, 0, len(cfg.CommandCodeKey))
+	for i := range cfg.CommandCodeKey {
+		entry := cfg.CommandCodeKey[i]
+		key := strings.TrimSpace(entry.APIKey)
+		if key == "" {
+			continue
+		}
+		prefix := strings.TrimSpace(entry.Prefix)
+		base := strings.TrimSpace(entry.BaseURL)
+		if base == "" {
+			base = config.DefaultCommandCodeBaseURL
+		}
+		base = strings.TrimSuffix(base, "/")
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		proxyID := strings.TrimSpace(entry.ProxyID)
+		id, token := idGen.Next("commandcode:apikey", key, base, proxyURL)
+		attrs := map[string]string{
+			"source":       fmt.Sprintf("config:commandcode[%s]", token),
+			"api_key":      key,
+			"base_url":     base,
+			"compat_name":  "Command Code",
+			"provider_key": "commandcode",
+		}
+		if entry.Priority != 0 {
+			attrs["priority"] = strconv.Itoa(entry.Priority)
+		}
+		if hash := diff.ComputeCommandCodeModelsHash(entry.Models); hash != "" {
+			attrs["models_hash"] = hash
+		}
+		if visionFallbackModel := strings.TrimSpace(entry.VisionFallbackModel); visionFallbackModel != "" {
+			attrs["vision_fallback_model"] = visionFallbackModel
+		}
+		addConfigHeadersToAttrs(entry.Headers, attrs)
+		label := strings.TrimSpace(entry.Name)
+		if label == "" {
+			label = "commandcode-apikey"
+		}
+		addProviderBindingAttrs(attrs, "", entry.ID)
+		a := &coreauth.Auth{
+			ID:         id,
+			Provider:   "commandcode",
 			Label:      label,
 			Prefix:     prefix,
 			Status:     coreauth.StatusActive,

--- a/internal/watcher/synthesizer/config_commandcode_test.go
+++ b/internal/watcher/synthesizer/config_commandcode_test.go
@@ -1,0 +1,110 @@
+package synthesizer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func synthesizeCommandCode(t *testing.T, cfg *config.Config) []*commandCodeAuthView {
+	t.Helper()
+	auths, err := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+		Config:      cfg,
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+	out := make([]*commandCodeAuthView, 0, len(auths))
+	for _, auth := range auths {
+		if auth != nil && auth.Provider == "commandcode" {
+			out = append(out, &commandCodeAuthView{
+				Label:      auth.Label,
+				Prefix:     auth.Prefix,
+				ProxyURL:   auth.ProxyURL,
+				Attributes: auth.Attributes,
+				Disabled:   auth.Disabled,
+			})
+		}
+	}
+	return out
+}
+
+type commandCodeAuthView struct {
+	Label      string
+	Prefix     string
+	ProxyURL   string
+	Attributes map[string]string
+	Disabled   bool
+}
+
+// The auth must carry compat metadata, or the router has no way to pick the
+// shared OpenAI-compatible executor for it.
+func TestConfigSynthesizerCommandCodeKeysCarryCompatMetadata(t *testing.T) {
+	auths := synthesizeCommandCode(t, &config.Config{
+		CommandCodeKey: []config.CommandCodeKey{{
+			APIKey:   "cc-key",
+			Name:     "GOAT plan",
+			Prefix:   "cc",
+			ProxyURL: "socks5://127.0.0.1:1080",
+		}},
+	})
+
+	if len(auths) != 1 {
+		t.Fatalf("auths = %d, want 1", len(auths))
+	}
+	auth := auths[0]
+	if auth.Label != "GOAT plan" || auth.Prefix != "cc" {
+		t.Fatalf("label/prefix = %q/%q", auth.Label, auth.Prefix)
+	}
+	if auth.ProxyURL != "socks5://127.0.0.1:1080" {
+		t.Fatalf("proxy = %q, want the configured one", auth.ProxyURL)
+	}
+	want := map[string]string{
+		"api_key":      "cc-key",
+		"base_url":     config.DefaultCommandCodeBaseURL,
+		"compat_name":  "Command Code",
+		"provider_key": "commandcode",
+	}
+	for key, value := range want {
+		if auth.Attributes[key] != value {
+			t.Fatalf("attribute %q = %q, want %q", key, auth.Attributes[key], value)
+		}
+	}
+}
+
+func TestConfigSynthesizerCommandCodeKeysSkipEmptyAndPropagateDisabled(t *testing.T) {
+	auths := synthesizeCommandCode(t, &config.Config{
+		CommandCodeKey: []config.CommandCodeKey{
+			{APIKey: "   "},
+			{APIKey: "cc-key", Disabled: true},
+		},
+	})
+
+	if len(auths) != 1 {
+		t.Fatalf("auths = %d, want the blank credential skipped", len(auths))
+	}
+	if !auths[0].Disabled {
+		t.Fatal("a disabled credential must not synthesize an active auth")
+	}
+}
+
+// An operator who points the channel at a mirror must have that honoured, since
+// the executor reads the endpoint from this attribute.
+func TestConfigSynthesizerCommandCodeKeysHonourCustomBaseURL(t *testing.T) {
+	auths := synthesizeCommandCode(t, &config.Config{
+		CommandCodeKey: []config.CommandCodeKey{{
+			APIKey:  "cc-key",
+			BaseURL: "https://mirror.example.com/provider/v1/",
+		}},
+	})
+
+	if len(auths) != 1 {
+		t.Fatalf("auths = %d, want 1", len(auths))
+	}
+	if got := auths[0].Attributes["base_url"]; got != "https://mirror.example.com/provider/v1" {
+		t.Fatalf("base_url = %q, want the trimmed mirror URL", got)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_api_key_alias.go
+++ b/sdk/cliproxy/auth/conductor_api_key_alias.go
@@ -41,6 +41,8 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 		upstreamModel = resolveUpstreamModelForClineAPIKey(cfg, auth, requestedModel)
 	case "ollama-cloud":
 		upstreamModel = resolveUpstreamModelForOllamaCloudAPIKey(cfg, auth, requestedModel)
+	case "commandcode":
+		upstreamModel = resolveUpstreamModelForCommandCodeAPIKey(cfg, auth, requestedModel)
 	case "bedrock":
 		upstreamModel = resolveUpstreamModelForBedrockAPIKey(cfg, auth, requestedModel)
 	case "vertex":
@@ -139,6 +141,13 @@ func resolveOllamaCloudAPIKeyConfig(cfg *runtimeConfigSnapshot, auth *Auth) *run
 	return resolveAPIKeyConfig(cfg.OllamaCloudKey, auth)
 }
 
+func resolveCommandCodeAPIKeyConfig(cfg *runtimeConfigSnapshot, auth *Auth) *runtimeAPIKeyModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	return resolveAPIKeyConfig(cfg.CommandCodeKey, auth)
+}
+
 func resolveBedrockAPIKeyConfig(cfg *runtimeConfigSnapshot, auth *Auth) *runtimeBedrockKeyConfig {
 	if cfg == nil || auth == nil {
 		return nil
@@ -235,6 +244,14 @@ func resolveUpstreamModelForClineAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, 
 
 func resolveUpstreamModelForOllamaCloudAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, requestedModel string) string {
 	entry := resolveOllamaCloudAPIKeyConfig(cfg, auth)
+	if entry == nil {
+		return ""
+	}
+	return resolveModelAliasFromConfigModels(requestedModel, asModelAliasEntries(entry.Models))
+}
+
+func resolveUpstreamModelForCommandCodeAPIKey(cfg *runtimeConfigSnapshot, auth *Auth, requestedModel string) string {
+	entry := resolveCommandCodeAPIKeyConfig(cfg, auth)
 	if entry == nil {
 		return ""
 	}

--- a/sdk/cliproxy/auth/conductor_runtime_config.go
+++ b/sdk/cliproxy/auth/conductor_runtime_config.go
@@ -122,6 +122,10 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked() {
 			if entry := resolveOllamaCloudAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
 			}
+		case "commandcode":
+			if entry := resolveCommandCodeAPIKeyConfig(cfg, auth); entry != nil {
+				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+			}
 		case "bedrock":
 			if entry := resolveBedrockAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)

--- a/sdk/cliproxy/auth/conductor_runtime_snapshot.go
+++ b/sdk/cliproxy/auth/conductor_runtime_snapshot.go
@@ -13,6 +13,7 @@ type runtimeConfigSnapshot struct {
 	CodexKey            []runtimeAPIKeyModelConfig
 	ClineKey            []runtimeAPIKeyModelConfig
 	OllamaCloudKey      []runtimeAPIKeyModelConfig
+	CommandCodeKey      []runtimeAPIKeyModelConfig
 	BedrockKey          []runtimeBedrockKeyConfig
 	VertexCompatAPIKey  []runtimeAPIKeyModelConfig
 	OpenAICompatibility []runtimeOpenAICompatibilityConfig
@@ -100,6 +101,7 @@ func newRuntimeConfigSnapshot(cfg *sdkconfig.Config) *runtimeConfigSnapshot {
 		CodexKey:            cloneRuntimeAPIKeyModelConfigs(cfg.CodexKey),
 		ClineKey:            cloneRuntimeClineModelConfigs(cfg.ClineKey),
 		OllamaCloudKey:      cloneRuntimeAPIKeyModelConfigs(cfg.OllamaCloudKey),
+		CommandCodeKey:      cloneRuntimeAPIKeyModelConfigs(cfg.CommandCodeKey),
 		BedrockKey:          cloneRuntimeBedrockKeyConfigs(cfg.BedrockKey),
 		VertexCompatAPIKey:  cloneRuntimeAPIKeyModelConfigs(cfg.VertexCompatAPIKey),
 		OpenAICompatibility: cloneRuntimeOpenAICompatibilityConfigs(cfg.OpenAICompatibility),
@@ -196,6 +198,8 @@ func modelsForRuntimeConfigEntry[T any](entry T) []runtimeModelAliasEntry {
 	case sdkconfig.ClineKey:
 		return cloneRuntimeModelAliasEntries(typed.Models)
 	case sdkconfig.OllamaCloudKey:
+		return cloneRuntimeModelAliasEntries(typed.Models)
+	case sdkconfig.CommandCodeKey:
 		return cloneRuntimeModelAliasEntries(typed.Models)
 	case sdkconfig.VertexCompatKey:
 		return cloneRuntimeModelAliasEntries(typed.Models)

--- a/sdk/cliproxy/service_model_config_resolvers.go
+++ b/sdk/cliproxy/service_model_config_resolvers.go
@@ -202,6 +202,35 @@ func (s *Service) resolveConfigOllamaCloudKey(auth *coreauth.Auth) *config.Ollam
 	return nil
 }
 
+func (s *Service) resolveConfigCommandCodeKey(auth *coreauth.Auth) *config.CommandCodeKey {
+	if auth == nil || s.cfg == nil {
+		return nil
+	}
+	var attrKey, attrBase string
+	if auth.Attributes != nil {
+		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
+		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	for i := range s.cfg.CommandCodeKey {
+		entry := &s.cfg.CommandCodeKey[i]
+		cfgKey := strings.TrimSpace(entry.APIKey)
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if cfgBase == "" {
+			cfgBase = config.DefaultCommandCodeBaseURL
+		}
+		if attrKey != "" && strings.EqualFold(cfgKey, attrKey) {
+			if attrBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
+		if attrKey == "" && attrBase != "" && strings.EqualFold(cfgBase, attrBase) {
+			return entry
+		}
+	}
+	return nil
+}
+
 func (s *Service) resolveConfigVertexCompatKey(auth *coreauth.Auth) *config.VertexCompatKey {
 	if auth == nil || s.cfg == nil {
 		return nil

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -101,9 +101,9 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	}
 	provider := strings.ToLower(strings.TrimSpace(a.Provider))
 	compatProviderKey, compatDisplayName, compatDetected := openAICompatInfoFromAuth(a)
-	// Cline and Ollama Cloud use OpenAI-compatible transport metadata to pick
-	// executors, but their model lists are owned by their native config blocks.
-	if compatDetected && provider != "cline" && provider != "ollama-cloud" {
+	// Cline, Ollama Cloud and Command Code use OpenAI-compatible transport metadata
+	// to pick executors, but their model lists are owned by their native config blocks.
+	if compatDetected && provider != "cline" && provider != "ollama-cloud" && provider != "commandcode" {
 		provider = "openai-compatibility"
 	}
 	excluded := s.oauthExcludedModels(provider, authKind)
@@ -186,6 +186,15 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		if entry := s.resolveConfigClineKey(a); entry != nil && authKind == "apikey" {
 			if len(entry.Models) > 0 {
 				models = buildClineConfigModels(entry)
+			}
+			excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
+		}
+		models = applyExcludedModels(models, excluded)
+	case "commandcode":
+		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("commandcode")
+		if entry := s.resolveConfigCommandCodeKey(a); entry != nil && authKind == "apikey" {
+			if len(entry.Models) > 0 {
+				models = buildCommandCodeConfigModels(entry)
 			}
 			excluded = providerModelAccessExcludedModels(entry.ExcludedModels)
 		}

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -382,6 +382,16 @@ func buildClineConfigModels(entry *config.ClineKey) []*ModelInfo {
 	return buildConfigModels(models, "cline", "cline", nil)
 }
 
+func buildCommandCodeConfigModels(entry *config.CommandCodeKey) []*ModelInfo {
+	if entry == nil || len(entry.Models) == 0 {
+		return nil
+	}
+	models := filterConfigModels(entry.Models, func(name string) bool {
+		return !isClinePassConfigModelID(name)
+	})
+	return buildConfigModels(models, "command-code", "commandcode", nil)
+}
+
 func buildOllamaCloudConfigModels(entry *config.OllamaCloudKey) []*ModelInfo {
 	if entry == nil || len(entry.Models) == 0 {
 		return nil

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -37,6 +37,8 @@ type ClineKey = bridgeconfig.ClineKey
 type ClineModel = bridgeconfig.ClineModel
 type OllamaCloudKey = bridgeconfig.OllamaCloudKey
 type OllamaCloudModel = bridgeconfig.OllamaCloudModel
+type CommandCodeKey = bridgeconfig.CommandCodeKey
+type CommandCodeModel = bridgeconfig.CommandCodeModel
 type VertexCompatKey = bridgeconfig.VertexCompatKey
 type VertexCompatModel = bridgeconfig.VertexCompatModel
 type OpenAICompatibility = bridgeconfig.OpenAICompatibility
@@ -50,6 +52,7 @@ const (
 	DefaultBedrockRegion         = bridgeconfig.DefaultBedrockRegion
 	DefaultClineBaseURL          = bridgeconfig.DefaultClineBaseURL
 	DefaultOllamaCloudBaseURL    = bridgeconfig.DefaultOllamaCloudBaseURL
+	DefaultCommandCodeBaseURL    = bridgeconfig.DefaultCommandCodeBaseURL
 	DefaultPprofAddr             = bridgeconfig.DefaultPprofAddr
 )
 

--- a/sdkbridge/config/config.go
+++ b/sdkbridge/config/config.go
@@ -34,6 +34,8 @@ type ClineKey = internalconfig.ClineKey
 type ClineModel = internalconfig.ClineModel
 type OllamaCloudKey = internalconfig.OllamaCloudKey
 type OllamaCloudModel = internalconfig.OllamaCloudModel
+type CommandCodeKey = internalconfig.CommandCodeKey
+type CommandCodeModel = internalconfig.CommandCodeModel
 type VertexCompatKey = internalconfig.VertexCompatKey
 type VertexCompatModel = internalconfig.VertexCompatModel
 type OpenAICompatibility = internalconfig.OpenAICompatibility
@@ -47,6 +49,7 @@ const (
 	DefaultBedrockRegion         = internalconfig.DefaultBedrockRegion
 	DefaultClineBaseURL          = internalconfig.DefaultClineBaseURL
 	DefaultOllamaCloudBaseURL    = internalconfig.DefaultOllamaCloudBaseURL
+	DefaultCommandCodeBaseURL    = internalconfig.DefaultCommandCodeBaseURL
 	DefaultPprofAddr             = internalconfig.DefaultPprofAddr
 )
 


### PR DESCRIPTION
## 这是什么

把 [Command Code](https://commandcode.ai) 接成一等渠道。它在 `https://api.commandcode.ai/provider/v1` 上说标准 OpenAI 协议，所以复用现有的 `OpenAICompatExecutor`，没有新增传输层 —— 和 Cline 的接法一致。

## 三件值得知道的事

**套餐是权限而非凭据问题。** $1 的 Go 套餐能签出可用的 key，但在 `/provider/v1` 上仍然吃 `403 upgrade_required`，因为那一档不含 API 权限；GOAT 及以上正常。这个拒绝原样透传，不重试也不掩盖，让运维看到网关真正说了什么。

**额度查询不需要面板 Cookie。** OpenCode Go / Cline / Ollama Cloud 的额度都靠抓控制台页面或带浏览器 Cookie 调接口，Cookie 会过期；Command Code 的 5 小时与每周窗口能用同一把推理 key 读出来。该接口不在公开文档里，所以任何失败都降级为「额度不可用」，绝不降级为凭据错误 —— 读不到额度的 key 照样能正常转发。`resetAt` 实测有秒和毫秒两种单位，读取时归一化。

**模型发现沿用 Cline 的先例。** 目录端点完全不需要凭据，所以控制台拉实时清单，静态快照只兜底离线场景；运维要用比快照更新的模型，直接写进 `commandcode-api-key[].models` 就能路由，不必改代码。

## 结构说明

三个被结构棘轮冻结的文件不能变大，所以 provider 设置、管理 handler 和模型快照各自独立成新文件，而不是撑大它们本该挨着的那个文件。

## 验证

- `./scripts/ci-pr.sh` 通过（结构门禁、gofmt、vet、`go test ./...`、golangci-lint、build）
- 路由表测试 `TestRegisterManagementRouteTable` 已更新（新增 5 条管理路由）
- 新增 11 条测试：额度解析 5、config→auth 合成 3、auth→executor 路由 3
- 端点真实性用无凭据探测确认：`/provider/v1/models` 200、`chat/completions` 与 `alpha/billing/credits` 401（未知路径返 404，故 401 证明路由存在）

真实请求与真实额度尚未端到端验证 —— 需要 GOAT 及以上的账号。

🤖 Generated with [Claude Code](https://claude.com/claude-code)