### PR TITLE
chore: remove production defaults from bots and test fixtures

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL || vars.OPENAI_BASE_URL || 'https://relay.07230805.xyz/v1' }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL || vars.OPENAI_BASE_URL }}
       OPENAI_MODEL: ${{ secrets.OPENAI_MODEL || vars.OPENAI_MODEL || 'grok-4.5' }}
       TRIAGE_ISSUE_NUMBER: ${{ github.event.inputs.issue_number || '' }}
       # Auto-comment on newly opened issues (not on every edit) unless bot:quiet.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL || vars.OPENAI_BASE_URL || 'https://relay.07230805.xyz/v1' }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL || vars.OPENAI_BASE_URL }}
       OPENAI_MODEL: ${{ secrets.OPENAI_MODEL || vars.OPENAI_MODEL || 'grok-4.5' }}
       REVIEW_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
     steps:

--- a/internal/ipaccess/matcher_test.go
+++ b/internal/ipaccess/matcher_test.go
@@ -188,13 +188,13 @@ func TestProtectedAddressesSurviveEveryRule(t *testing.T) {
 	// own address or its reverse proxy takes the deployment offline instead of
 	// blocking an attacker, so the list must not be able to express it.
 	registry := NewRegistry(NewStore(nil))
-	registry.SetProtectedAddresses([]string{"10.0.0.5"}, []string{"104.194.69.137"}, nil)
+	registry.SetProtectedAddresses([]string{"10.0.0.5"}, []string{"203.0.113.10"}, nil)
 	registry.matcher.Store(NewMatcher([]Rule{
 		mustRule(t, "10.0.0.0/8", EffectDeny),
-		mustRule(t, "104.194.69.137/32", EffectDeny),
+		mustRule(t, "203.0.113.10/32", EffectDeny),
 	}, true, time.Now()))
 
-	for _, ip := range []string{"10.0.0.5", "104.194.69.137"} {
+	for _, ip := range []string{"10.0.0.5", "203.0.113.10"} {
 		verdict := registry.Evaluate(ClientAddress{IP: net.ParseIP(ip), Raw: ip, Trusted: true})
 		if !verdict.Allowed() || !verdict.Enforced || verdict.Decision != DecisionAllow {
 			t.Errorf("%s: got %v (enforced=%t), want an enforced allow despite the deny rules", ip, verdict.Decision, verdict.Enforced)
@@ -211,10 +211,10 @@ func TestProtectedAddressesAreNotAutoBanned(t *testing.T) {
 	policy := DefaultPolicy()
 	policy.AutoBan.FailureThreshold = 2
 	registry := testRegistry(t, policy)
-	registry.SetProtectedAddresses(nil, []string{"104.194.69.137"}, nil)
+	registry.SetProtectedAddresses(nil, []string{"203.0.113.10"}, nil)
 
 	for i := 0; i < 5; i++ {
-		outcome := registry.AutoBan().RecordFailure(context.Background(), trustedAddress("104.194.69.137"), "test")
+		outcome := registry.AutoBan().RecordFailure(context.Background(), trustedAddress("203.0.113.10"), "test")
 		if outcome.Triggered {
 			t.Fatal("the reverse proxy was proposed for an automatic ban")
 		}
@@ -269,14 +269,14 @@ func TestResolveForwardedUntrustedWhenRelayedWithNoDeclaredProxy(t *testing.T) {
 	// This is the production state: nginx relays, nothing is declared, so the
 	// address is the proxy's and stands for everyone behind it.
 	req := httptest.NewRequest("GET", "/", nil)
-	req.RemoteAddr = "104.194.69.137:5000"
+	req.RemoteAddr = "203.0.113.10:5000"
 	req.Header.Set("X-Forwarded-For", "203.0.113.9")
 
 	addr := resolveForwarded(req, newTrustedProxyMatcher(nil))
 	if addr.Trusted {
 		t.Error("relayed request with no declared proxy must not be trusted")
 	}
-	if addr.Raw != "104.194.69.137" {
+	if addr.Raw != "203.0.113.10" {
 		t.Errorf("got %q, want the proxy address", addr.Raw)
 	}
 }
@@ -294,9 +294,9 @@ func TestResolveForwardedAllHopsTrustedIsNotAClient(t *testing.T) {
 
 func TestPolicyNormalizesAndDeduplicatesTrustedProxies(t *testing.T) {
 	policy := ProtectionPolicy{TrustedProxies: []string{
-		" 104.194.69.137 ", "104.194.69.137", "10.0.0.0/24", "not-an-ip", "",
+		" 203.0.113.10 ", "203.0.113.10", "10.0.0.0/24", "not-an-ip", "",
 	}}.Normalized()
-	want := []string{"104.194.69.137/32", "10.0.0.0/24"}
+	want := []string{"203.0.113.10/32", "10.0.0.0/24"}
 	if len(policy.TrustedProxies) != len(want) {
 		t.Fatalf("got %v, want %v", policy.TrustedProxies, want)
 	}
@@ -313,9 +313,9 @@ func TestRegistryPrefersStoredProxiesOverConfig(t *testing.T) {
 	if proxies, source := registry.TrustedProxies(); source != "config" || len(proxies) != 1 {
 		t.Fatalf("got %v from %q, want the config fallback", proxies, source)
 	}
-	registry.SetPolicy(context.Background(), ProtectionPolicy{TrustedProxies: []string{"104.194.69.137"}})
+	registry.SetPolicy(context.Background(), ProtectionPolicy{TrustedProxies: []string{"203.0.113.10"}})
 	proxies, source := registry.TrustedProxies()
-	if source != "database" || len(proxies) != 1 || proxies[0] != "104.194.69.137/32" {
+	if source != "database" || len(proxies) != 1 || proxies[0] != "203.0.113.10/32" {
 		t.Fatalf("got %v from %q, want the stored list to win", proxies, source)
 	}
 	// Clearing the stored list must fall back rather than strand the deployment.
@@ -332,10 +332,10 @@ func TestRelayedChainEndingOnLoopbackIsNotTrusted(t *testing.T) {
 	// Every external request was therefore exempt from rate limiting and from the
 	// rule list at once.
 	req := httptest.NewRequest("GET", "/", nil)
-	req.RemoteAddr = "104.194.69.137:5000"
+	req.RemoteAddr = "203.0.113.10:5000"
 	req.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
 
-	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"104.194.69.137/32"}))
+	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"203.0.113.10/32"}))
 	if addr.Raw != "127.0.0.1" {
 		t.Fatalf("got %q, want the hop the chain stopped at", addr.Raw)
 	}
@@ -367,9 +367,9 @@ func TestRegistryDoesNotExemptARelayedLoopbackChain(t *testing.T) {
 	// as an enforced allow just because the chain resolved to loopback.
 	registry := NewRegistry(NewStore(nil))
 	req := httptest.NewRequest("GET", "/", nil)
-	req.RemoteAddr = "104.194.69.137:5000"
+	req.RemoteAddr = "203.0.113.10:5000"
 	req.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
-	registry.SetPolicy(context.Background(), ProtectionPolicy{TrustedProxies: []string{"104.194.69.137/32"}})
+	registry.SetPolicy(context.Background(), ProtectionPolicy{TrustedProxies: []string{"203.0.113.10/32"}})
 
 	addr := registry.ResolveAddress(req, "")
 	verdict := registry.Evaluate(addr)
@@ -385,10 +385,10 @@ func TestFullyDeclaredChainResolvesTheRealClient(t *testing.T) {
 	// Declaring every hop is what makes the feature work; this is the state the
 	// diagnostics are meant to guide an operator towards.
 	req := httptest.NewRequest("GET", "/", nil)
-	req.RemoteAddr = "104.194.69.137:5000"
+	req.RemoteAddr = "203.0.113.10:5000"
 	req.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
 
-	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"104.194.69.137/32", "127.0.0.1/32"}))
+	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"203.0.113.10/32", "127.0.0.1/32"}))
 	if addr.Raw != "203.0.113.9" || !addr.Trusted {
 		t.Fatalf("got %q trusted=%t, want the real client trusted", addr.Raw, addr.Trusted)
 	}
@@ -401,11 +401,11 @@ func TestForwardedChainIsReportedForDiagnostics(t *testing.T) {
 	// Operators cannot declare the right hops without seeing the chain; guessing
 	// is what produced the half-configured state in the first place.
 	req := httptest.NewRequest("GET", "/", nil)
-	req.RemoteAddr = "104.194.69.137:5000"
+	req.RemoteAddr = "203.0.113.10:5000"
 	req.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
 
-	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"104.194.69.137/32"}))
-	if addr.Peer != "104.194.69.137" {
+	addr := resolveForwarded(req, newTrustedProxyMatcher([]string{"203.0.113.10/32"}))
+	if addr.Peer != "203.0.113.10" {
 		t.Errorf("peer = %q, want the direct TCP peer", addr.Peer)
 	}
 	if len(addr.Chain) != 2 || addr.Chain[0] != "203.0.113.9" || addr.Chain[1] != "127.0.0.1" {

--- a/internal/routing/scope_test.go
+++ b/internal/routing/scope_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestNormalizeNamespacePathAcceptsFullURL(t *testing.T) {
 	t.Parallel()
 
-	if got := NormalizeNamespacePath("https://relay.07230805.xyz/pro"); got != "/pro" {
+	if got := NormalizeNamespacePath("https://relay.example.com/pro"); got != "/pro" {
 		t.Fatalf("NormalizeNamespacePath(full URL) = %q, want %q", got, "/pro")
 	}
 }
@@ -21,7 +21,7 @@ func TestNormalizeNamespacePathAcceptsMultiSegmentPath(t *testing.T) {
 func TestNormalizeNamespacePathAcceptsMultiSegmentFullURL(t *testing.T) {
 	t.Parallel()
 
-	if got := NormalizeNamespacePath("https://relay.07230805.xyz/openai/pro"); got != "/openai/pro" {
+	if got := NormalizeNamespacePath("https://relay.example.com/openai/pro"); got != "/openai/pro" {
 		t.Fatalf("NormalizeNamespacePath(multi segment URL) = %q, want %q", got, "/openai/pro")
 	}
 }
@@ -29,7 +29,7 @@ func TestNormalizeNamespacePathAcceptsMultiSegmentFullURL(t *testing.T) {
 func TestNormalizeNamespacePathAcceptsFullURLWithUnicodePath(t *testing.T) {
 	t.Parallel()
 
-	if got := NormalizeNamespacePath("https://relay.07230805.xyz/%E8%B7%AF%E5%BE%84"); got != "/路径" {
+	if got := NormalizeNamespacePath("https://relay.example.com/%E8%B7%AF%E5%BE%84"); got != "/路径" {
 		t.Fatalf("NormalizeNamespacePath(encoded URL) = %q, want %q", got, "/路径")
 	}
 }

--- a/scripts/ci-pr.sh
+++ b/scripts/ci-pr.sh
@@ -5,6 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 ./scripts/ensure-no-vendored-panel-assets.sh
 python3 scripts/check-backend-structure.py
+python3 -m unittest discover -s scripts -p test_agent_model_config.py
 
 files="$(gofmt -l . || true)"
 if [ -n "${files}" ]; then

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
 BASE_DIR="${BASE_DIR:-/opt/clirelay2}"
 TEMP_BIN="${TEMP_BIN:-${BASE_DIR}/cli-proxy-api-new}"
-DOMAIN="${DOMAIN:-relay.07230805.xyz}"
+DOMAIN="${DOMAIN:-relay.example.com}"
 PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-https://${DOMAIN}}"
 PORT_A="${PORT_A:-8318}"
 PORT_B="${PORT_B:-8319}"

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
 BASE_DIR="${BASE_DIR:-/opt/clirelay2}"
 TEMP_BIN="${TEMP_BIN:-${BASE_DIR}/cli-proxy-api-new}"
-DOMAIN="${DOMAIN:-relay.example.com}"
+DOMAIN="${DOMAIN:-relay.07230805.xyz}"
 PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-https://${DOMAIN}}"
 PORT_A="${PORT_A:-8318}"
 PORT_B="${PORT_B:-8319}"

--- a/scripts/issue_triage_agent.py
+++ b/scripts/issue_triage_agent.py
@@ -463,7 +463,7 @@ def call_model(system, user_payload):
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY is not set")
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.07230805.xyz/v1").rstrip("/")
+    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.example.com/v1").rstrip("/")
     model = os.environ.get("OPENAI_MODEL", "grok-4.5")
     data = {
         "model": model,

--- a/scripts/issue_triage_agent.py
+++ b/scripts/issue_triage_agent.py
@@ -463,7 +463,15 @@ def call_model(system, user_payload):
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY is not set")
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.example.com/v1").rstrip("/")
+    # Actions exports an empty value when neither a secret nor a variable is set.
+    base_url = os.environ.get("OPENAI_BASE_URL", "").strip().rstrip("/")
+    try:
+        parsed_base_url = urllib.parse.urlsplit(base_url)
+        valid_base_url = parsed_base_url.scheme in {"http", "https"} and parsed_base_url.hostname
+    except ValueError:
+        valid_base_url = False
+    if not valid_base_url:
+        raise RuntimeError("OPENAI_BASE_URL must be set to an absolute HTTP(S) URL")
     model = os.environ.get("OPENAI_MODEL", "grok-4.5")
     data = {
         "model": model,

--- a/scripts/pr_review_agent.py
+++ b/scripts/pr_review_agent.py
@@ -180,7 +180,7 @@ def call_model(system: str, user_payload: str, max_tokens: int = 3500) -> str:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY is not set")
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.07230805.xyz/v1").rstrip("/")
+    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.example.com/v1").rstrip("/")
     model = os.environ.get("OPENAI_MODEL", "grok-4.5")
     data = {
         "model": model,

--- a/scripts/pr_review_agent.py
+++ b/scripts/pr_review_agent.py
@@ -180,7 +180,15 @@ def call_model(system: str, user_payload: str, max_tokens: int = 3500) -> str:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY is not set")
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.example.com/v1").rstrip("/")
+    # Actions exports an empty value when neither a secret nor a variable is set.
+    base_url = os.environ.get("OPENAI_BASE_URL", "").strip().rstrip("/")
+    try:
+        parsed_base_url = urllib.parse.urlsplit(base_url)
+        valid_base_url = parsed_base_url.scheme in {"http", "https"} and parsed_base_url.hostname
+    except ValueError:
+        valid_base_url = False
+    if not valid_base_url:
+        raise RuntimeError("OPENAI_BASE_URL must be set to an absolute HTTP(S) URL")
     model = os.environ.get("OPENAI_MODEL", "grok-4.5")
     data = {
         "model": model,

--- a/scripts/test_agent_model_config.py
+++ b/scripts/test_agent_model_config.py
@@ -1,0 +1,53 @@
+"""Exercise the real bot request paths without contacting an upstream service."""
+
+import io
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+import issue_triage_agent
+import pr_review_agent
+
+
+class ModelConfigTests(unittest.TestCase):
+    agents = (issue_triage_agent, pr_review_agent)
+
+    def test_invalid_base_url_fails_before_network(self):
+        for agent in self.agents:
+            for base_url in (None, "", "  ", "ftp://example.com/v1", "/v1", "https:///v1"):
+                with self.subTest(agent=agent.__name__, base_url=base_url):
+                    env = {"OPENAI_API_KEY": "test-key"}
+                    if base_url is not None:
+                        env["OPENAI_BASE_URL"] = base_url
+                    with patch.dict(os.environ, env, clear=True), patch(
+                        "urllib.request.urlopen", side_effect=AssertionError("network must not run")
+                    ) as urlopen:
+                        with self.assertRaisesRegex(RuntimeError, "OPENAI_BASE_URL"):
+                            agent.call_model("system", "payload")
+                        urlopen.assert_not_called()
+
+    def test_configured_http_endpoints_preserve_request_contract(self):
+        body = json.dumps({"choices": [{"message": {"content": "ok"}}]}).encode()
+        for agent in self.agents:
+            for base_url in ("https://relay.example.com/v1/", "http://localhost:8317/v1"):
+                with self.subTest(agent=agent.__name__, base_url=base_url):
+                    env = {
+                        "OPENAI_API_KEY": "test-key",
+                        "OPENAI_BASE_URL": base_url,
+                        "OPENAI_MODEL": "configured-model",
+                    }
+                    with patch.dict(os.environ, env, clear=True), patch(
+                        "urllib.request.urlopen", return_value=io.BytesIO(body)
+                    ) as urlopen:
+                        self.assertEqual(agent.call_model("system", "payload"), "ok")
+                    urlopen.assert_called_once()
+                    request = urlopen.call_args.args[0]
+                    self.assertEqual(request.full_url, base_url.rstrip("/") + "/chat/completions")
+                    self.assertEqual(request.get_method(), "POST")
+                    self.assertEqual(request.get_header("Authorization"), "Bearer test-key")
+                    self.assertEqual(json.loads(request.data)["model"], "configured-model")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Remove production endpoints from issue/PR bot defaults and replace production addresses in tests with documentation examples. Both bots now require an explicit absolute HTTP(S) `OPENAI_BASE_URL` and reject missing, empty or unsupported URLs before network access.

The original deployment DOMAIN change is excluded: the deployed root script still requires a separate trusted configuration/version/host rollout to remove its default safely. This PR leaves the current deployment scripts and deployment workflow unchanged. It does not claim to scrub every production hostname in the repository.

Validation: real `call_model` regression tests reproduced invalid configuration behavior before the fix; 12 invalid/no-network and 4 valid request-contract scenarios pass, as do the two existing bot self-tests and Python compilation. The regression is included in `scripts/ci-pr.sh`, whose complete local run passed. Required GitHub checks must pass on the updated branch before merge.
