### PR TITLE
fix(antigravity): read the account's real quota buckets

### DIFF
--- a/internal/management/aiaccountstatus/probe.go
+++ b/internal/management/aiaccountstatus/probe.go
@@ -86,16 +86,30 @@ func doAuthGET(ctx context.Context, svc *managementapitools.Service, auth *corea
 }
 
 func doAuthPOST(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth, url string, headers map[string]string, body string) ([]byte, error) {
-	return doAuthRequest(ctx, svc, auth, http.MethodPost, url, headers, body, nil)
+	raw, _, err := doAuthPOSTStatus(ctx, svc, auth, url, headers, body)
+	return raw, err
+}
+
+// doAuthPOSTStatus is doAuthPOST plus the upstream status code. Probes that must
+// branch on the status — antigravity retries a 403 without the project field
+// before believing the account is actually forbidden — cannot recover it from the
+// error string.
+func doAuthPOSTStatus(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth, url string, headers map[string]string, body string) ([]byte, int, error) {
+	return doAuthRequestStatus(ctx, svc, auth, http.MethodPost, url, headers, body, nil)
 }
 
 func doAuthRequest(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth, method, urlStr string, headers map[string]string, body string, mutate func(*http.Request)) ([]byte, error) {
+	raw, _, err := doAuthRequestStatus(ctx, svc, auth, method, urlStr, headers, body, mutate)
+	return raw, err
+}
+
+func doAuthRequestStatus(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth, method, urlStr string, headers map[string]string, body string, mutate func(*http.Request)) ([]byte, int, error) {
 	if svc == nil {
-		return nil, fmt.Errorf("api tools unavailable")
+		return nil, 0, fmt.Errorf("api tools unavailable")
 	}
 	token, err := svc.ResolveTokenForAuth(ctx, auth)
 	if err != nil || strings.TrimSpace(token) == "" {
-		return nil, fmt.Errorf("token unavailable")
+		return nil, 0, fmt.Errorf("token unavailable")
 	}
 	var reader io.Reader
 	if body != "" {
@@ -103,7 +117,7 @@ func doAuthRequest(ctx context.Context, svc *managementapitools.Service, auth *c
 	}
 	req, err := http.NewRequestWithContext(ctx, method, urlStr, reader)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	for k, v := range headers {
@@ -122,17 +136,17 @@ func doAuthRequest(ctx context.Context, svc *managementapitools.Service, auth *c
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, err
+		return nil, resp.StatusCode, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("upstream http %d", resp.StatusCode)
+		return nil, resp.StatusCode, fmt.Errorf("upstream http %d", resp.StatusCode)
 	}
-	return raw, nil
+	return raw, resp.StatusCode, nil
 }
 
 func authString(auth *coreauth.Auth, keys ...string) string {

--- a/internal/management/aiaccountstatus/probe_antigravity.go
+++ b/internal/management/aiaccountstatus/probe_antigravity.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
@@ -14,32 +17,236 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const defaultAntigravityProject = "bamboo-precept-lgxtn"
+// antigravityClientVersion is the floor for the client version we advertise to
+// the CloudCode upstream.
+//
+// The upstream gates its answer on this version: an outdated client is served a
+// reduced model set and a coarser quota view, which is how a probe can report
+// three separate model families sharing one identical percentage and reset time.
+// The probe previously sent 1.11.5 while the request executor sent 1.104.0, so
+// the two halves of this provider disagreed about what client they were.
+const antigravityClientVersion = "4.3.0"
 
-var antigravityQuotaURLs = []string{
-	"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
-	"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
-	"https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+// antigravityProbeUserAgent matches the header the Antigravity client sends on
+// its own quota calls. The literal `1.X.X` is not a placeholder we failed to
+// fill in — that is the string the client itself sends.
+const antigravityProbeUserAgent = "vscode/1.X.X (Antigravity/" + antigravityClientVersion + ")"
+
+// antigravityHosts is ordered sandbox-first. The sandbox host is the one that
+// stays reachable when the production host is shedding load with 429s.
+var antigravityHosts = []string{
+	"https://daily-cloudcode-pa.sandbox.googleapis.com",
+	"https://daily-cloudcode-pa.googleapis.com",
+	"https://cloudcode-pa.googleapis.com",
 }
 
+const (
+	antigravityQuotaSummaryPath = "/v1internal:retrieveUserQuotaSummary"
+	antigravityModelsPath       = "/v1internal:fetchAvailableModels"
+	antigravityLoadPath         = "/v1internal:loadCodeAssist"
+)
+
+// antigravityFallbackProject is the shared project the upstream accepts when an
+// account has no project of its own. It is a last resort, not a default: asking
+// for quota under a project that is not yours reports that project's remaining
+// fraction, which is how exhausted accounts come back as 100% available.
+const antigravityFallbackProject = "bamboo-precept-lgxtn"
+
+const (
+	antigravityWindowFiveHour = int64(5 * 60 * 60)
+	antigravityWindowWeek     = int64(7 * 24 * 60 * 60)
+)
+
 func probeAntigravity(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) (ProbeResult, error) {
-	projectID := firstNonEmpty(
+	account := resolveAntigravityAccount(ctx, svc, auth)
+
+	quotas, err := fetchAntigravityQuotas(ctx, svc, auth, account.projectID)
+	if err != nil {
+		return ProbeResult{}, err
+	}
+	return ProbeResult{Quotas: quotas, PlanType: account.planType}, nil
+}
+
+// antigravityAccount is the per-account context the quota endpoints need.
+type antigravityAccount struct {
+	projectID string
+	planType  string
+}
+
+// antigravityAccountCache keeps loadCodeAssist results for a short while. The
+// endpoint is the same one the request path hits on every cold token, and it
+// rate-limits well before the quota endpoints do.
+var antigravityAccountCache sync.Map // auth key -> antigravityAccountCacheEntry
+
+type antigravityAccountCacheEntry struct {
+	account   antigravityAccount
+	expiresAt time.Time
+}
+
+const antigravityAccountCacheTTL = 10 * time.Minute
+
+func antigravityAuthKey(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if id := strings.TrimSpace(auth.ID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(auth.Index)
+}
+
+// resolveAntigravityAccount answers "which project and which plan is this
+// account on". The stored metadata is trusted first, then loadCodeAssist, and
+// only then the shared fallback project.
+func resolveAntigravityAccount(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) antigravityAccount {
+	stored := firstNonEmpty(
 		metadataString(auth, "project_id", "projectId"),
 		metadataNestedString(auth, "installed", "project_id", "projectId"),
 		metadataNestedString(auth, "web", "project_id", "projectId"),
-		defaultAntigravityProject,
 	)
-	payloadJSON, err := json.Marshal(map[string]string{"project": projectID})
-	if err != nil {
-		return ProbeResult{}, fmt.Errorf("encode antigravity project: %w", err)
+
+	cacheKey := antigravityAuthKey(auth)
+	if cacheKey != "" {
+		if raw, ok := antigravityAccountCache.Load(cacheKey); ok {
+			if entry, okEntry := raw.(antigravityAccountCacheEntry); okEntry && time.Now().Before(entry.expiresAt) {
+				if entry.account.projectID == "" {
+					entry.account.projectID = stored
+				}
+				return entry.account
+			}
+		}
 	}
-	payload := string(payloadJSON)
+
+	account := loadAntigravityCodeAssist(ctx, svc, auth)
+	if account.projectID == "" {
+		account.projectID = stored
+	}
+	if cacheKey != "" && (account.projectID != "" || account.planType != "") {
+		antigravityAccountCache.Store(cacheKey, antigravityAccountCacheEntry{
+			account:   account,
+			expiresAt: time.Now().Add(antigravityAccountCacheTTL),
+		})
+	}
+	return account
+}
+
+func loadAntigravityCodeAssist(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) antigravityAccount {
+	payload, err := json.Marshal(map[string]any{
+		"metadata": map[string]string{
+			"ideType":    "ANTIGRAVITY",
+			"platform":   "PLATFORM_UNSPECIFIED",
+			"pluginType": "GEMINI",
+		},
+	})
+	if err != nil {
+		return antigravityAccount{}
+	}
+	for _, host := range antigravityHosts {
+		body, err := doAuthPOST(ctx, svc, auth, host+antigravityLoadPath, antigravityHeaders(), string(payload))
+		if err != nil {
+			continue
+		}
+		return parseAntigravityCodeAssist(body)
+	}
+	return antigravityAccount{}
+}
+
+func parseAntigravityCodeAssist(body []byte) antigravityAccount {
+	root := gjson.ParseBytes(body)
+	account := antigravityAccount{}
+
+	project := root.Get("cloudaicompanionProject")
+	if project.IsObject() {
+		account.projectID = strings.TrimSpace(project.Get("id").String())
+	} else {
+		account.projectID = strings.TrimSpace(project.String())
+	}
+
+	account.planType = parseAntigravityPlanType(root)
+	return account
+}
+
+// parseAntigravityPlanType walks the same ladder the upstream's own client does.
+// A paid tier wins outright; otherwise the current tier counts only when the
+// account is not marked ineligible, and an ineligible account falls back to the
+// default allowed tier flagged as restricted.
+func parseAntigravityPlanType(root gjson.Result) string {
+	tierName := func(tier gjson.Result) string {
+		if !tier.Exists() {
+			return ""
+		}
+		if name := strings.TrimSpace(tier.Get("name").String()); name != "" {
+			return name
+		}
+		return strings.TrimSpace(tier.Get("id").String())
+	}
+
+	if paid := tierName(root.Get("paidTier")); paid != "" {
+		return paid
+	}
+
+	ineligible := root.Get("ineligibleTiers")
+	isIneligible := ineligible.IsArray() && len(ineligible.Array()) > 0
+	if !isIneligible {
+		if current := tierName(root.Get("currentTier")); current != "" {
+			return current
+		}
+		return ""
+	}
+
+	var restricted string
+	root.Get("allowedTiers").ForEach(func(_, tier gjson.Result) bool {
+		if !tier.Get("isDefault").Bool() {
+			return true
+		}
+		if name := tierName(tier); name != "" {
+			restricted = name + " (Restricted)"
+			return false
+		}
+		return true
+	})
+	return restricted
+}
+
+func antigravityHeaders() map[string]string {
+	return map[string]string{
+		"Content-Type": "application/json",
+		"User-Agent":   antigravityProbeUserAgent,
+	}
+}
+
+// fetchAntigravityQuotas prefers the grouped summary, which reports the account's
+// real quota buckets — weekly and 5h, per model family — as the upstream itself
+// groups them. fetchAvailableModels is the fallback: it only carries the 5h
+// window and leaves the grouping to us.
+func fetchAntigravityQuotas(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth, projectID string) ([]usage.QuotaWindowDTO, error) {
+	if quotas := fetchAntigravityQuotaSummary(ctx, svc, auth, projectID); len(quotas) > 0 {
+		return quotas, nil
+	}
+	return fetchAntigravityModelQuotas(ctx, svc, auth, projectID)
+}
+
+func fetchAntigravityQuotaSummary(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth, projectID string) []usage.QuotaWindowDTO {
+	for _, host := range antigravityHosts {
+		body, status, err := antigravityPost(ctx, svc, auth, host+antigravityQuotaSummaryPath, projectID)
+		if err != nil {
+			// A 4xx other than 429 means every host will answer the same way.
+			if status >= 400 && status < 500 && status != 429 {
+				return nil
+			}
+			continue
+		}
+		if quotas := parseAntigravityQuotaSummary(body); len(quotas) > 0 {
+			return quotas
+		}
+	}
+	return nil
+}
+
+func fetchAntigravityModelQuotas(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth, projectID string) ([]usage.QuotaWindowDTO, error) {
 	var lastErr error
-	for _, url := range antigravityQuotaURLs {
-		body, err := doAuthPOST(ctx, svc, auth, url, map[string]string{
-			"Content-Type": "application/json",
-			"User-Agent":   "antigravity/1.11.5 windows/amd64",
-		}, payload)
+	for _, host := range antigravityHosts {
+		body, _, err := antigravityPost(ctx, svc, auth, host+antigravityModelsPath, projectID)
 		if err != nil {
 			lastErr = err
 			continue
@@ -49,31 +256,194 @@ func probeAntigravity(ctx context.Context, svc *managementapitools.Service, auth
 			lastErr = fmt.Errorf("no_model_quota")
 			continue
 		}
-		return ProbeResult{Quotas: quotas}, nil
+		return quotas, nil
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("request_failed")
 	}
-	return ProbeResult{}, lastErr
+	return nil, lastErr
 }
 
-type antigravityQuotaGroup struct {
-	key, label string
-	models     map[string]struct{}
+// antigravityPost sends the project-scoped request and, on 403, retries once
+// without the project field. A project the account cannot read is rejected
+// outright, and the accountless form is what the upstream falls back to.
+func antigravityPost(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth, url, projectID string) ([]byte, int, error) {
+	payloads := make([]string, 0, 2)
+	if strings.TrimSpace(projectID) != "" {
+		if encoded, err := json.Marshal(map[string]string{"project": projectID}); err == nil {
+			payloads = append(payloads, string(encoded))
+		}
+	}
+	payloads = append(payloads, "{}")
+
+	var lastBody []byte
+	var lastStatus int
+	var lastErr error
+	for _, payload := range payloads {
+		body, status, err := doAuthPOSTStatus(ctx, svc, auth, url, antigravityHeaders(), payload)
+		if err == nil {
+			return body, status, nil
+		}
+		lastBody, lastStatus, lastErr = body, status, err
+		if status != 403 {
+			break
+		}
+	}
+	return lastBody, lastStatus, lastErr
 }
 
-var antigravityQuotaGroups = []antigravityQuotaGroup{
-	{key: "provider:gemini3-pro", label: "antigravity_quota.gemini3_pro", models: stringSet("gemini-3-pro-low", "gemini-3-pro-high", "gemini-3-pro-preview", "gemini-3.1-pro-low", "gemini-3.1-pro-high", "gemini-3.1-pro-preview")},
-	{key: "provider:gemini3-flash", label: "antigravity_quota.gemini3_flash", models: stringSet("gemini-3-flash", "gemini-3-flash-agent")},
-	{key: "provider:gemini-image", label: "antigravity_quota.gemini_image", models: stringSet("gemini-2.5-flash-image", "gemini-3.1-flash-image", "gemini-3-pro-image", "gemini-3-pro-image-preview")},
-	{key: "provider:claude", label: "antigravity_quota.claude", models: stringSet("claude-fable-5", "claude-sonnet-4-5", "claude-sonnet-4-5-thinking", "claude-opus-4-5-thinking", "claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-6-thinking", "claude-opus-4-7", "claude-opus-4-8")},
+// parseAntigravityQuotaSummary reads retrieveUserQuotaSummary. Every label and
+// every grouping here comes from the upstream payload: the account's real
+// buckets are `gemini-weekly`, `gemini-5h`, `3p-weekly`, `3p-5h`, and inventing
+// our own model-family split on top of them is what made one bucket render as
+// several rows showing the same number.
+func parseAntigravityQuotaSummary(body []byte) []usage.QuotaWindowDTO {
+	root := gjson.ParseBytes(body)
+	groups := firstJSONResult(root, "groups", "quotaGroups", "quota_groups")
+	if !groups.IsArray() {
+		return nil
+	}
+
+	out := make([]usage.QuotaWindowDTO, 0, 8)
+	seen := make(map[string]struct{}, 8)
+	groups.ForEach(func(groupIndex, group gjson.Result) bool {
+		groupName := strings.TrimSpace(firstJSONResult(group, "displayName", "display_name").String())
+		buckets := firstJSONResult(group, "buckets", "quotaBuckets", "quota_buckets")
+		if !buckets.IsArray() {
+			return true
+		}
+		buckets.ForEach(func(bucketIndex, bucket gjson.Result) bool {
+			dto, ok := antigravityBucketDTO(bucket, groupName, groupIndex.Int(), bucketIndex.Int())
+			if !ok {
+				return true
+			}
+			if _, duplicate := seen[dto.QuotaKey]; duplicate {
+				return true
+			}
+			seen[dto.QuotaKey] = struct{}{}
+			out = append(out, dto)
+			return true
+		})
+		return true
+	})
+	return out
 }
 
-var antigravitySkippedModels = stringSet(
-	"chat_20706", "chat_23310", "tab_flash_lite_preview", "tab_jump_flash_lite_preview",
-	"gemini-2.5-flash-thinking", "gemini-2.5-pro",
-)
+func antigravityBucketDTO(bucket gjson.Result, groupName string, groupIndex, bucketIndex int64) (usage.QuotaWindowDTO, bool) {
+	fraction := firstJSONResult(bucket, "remainingFraction", "remaining_fraction", "remaining")
+	resetAt := parseFlexibleTime(firstJSONResult(bucket, "resetTime", "reset_time"))
+	if !fraction.Exists() && resetAt == nil {
+		return usage.QuotaWindowDTO{}, false
+	}
 
+	bucketID := strings.TrimSpace(firstJSONResult(bucket, "bucketId", "bucket_id", "id").String())
+	window := strings.TrimSpace(bucket.Get("window").String())
+	windowSeconds := antigravityWindowSeconds(window, bucketID)
+
+	key := normalizeQuotaKeyPart(bucketID)
+	if key == "" {
+		key = fmt.Sprintf("g%d_b%d", groupIndex, bucketIndex)
+		if suffix := normalizeQuotaKeyPart(window); suffix != "" {
+			key = fmt.Sprintf("g%d_%s", groupIndex, suffix)
+		}
+	}
+
+	dto := usage.QuotaWindowDTO{
+		QuotaKey:      "antigravity:" + key,
+		QuotaLabel:    antigravityBucketLabel(bucket, groupName, bucketID, window),
+		ResetAt:       resetAt,
+		WindowSeconds: windowSeconds,
+	}
+	if fraction.Exists() {
+		if value := quotaFraction(fraction); value != nil {
+			percent := math.Round(clampPct(*value * 100))
+			dto.Percent = &percent
+		}
+	}
+	return dto, true
+}
+
+// antigravityBucketLabel keeps the upstream's own wording. Translating it here
+// would mean maintaining a table of names the upstream is free to change.
+func antigravityBucketLabel(bucket gjson.Result, groupName, bucketID, window string) string {
+	if name := strings.TrimSpace(firstJSONResult(bucket, "displayName", "display_name").String()); name != "" {
+		if groupName != "" && !strings.EqualFold(name, groupName) {
+			return groupName + " · " + name
+		}
+		return name
+	}
+	label := groupName
+	if label == "" {
+		label = bucketID
+	}
+	if label == "" {
+		return window
+	}
+	if window != "" {
+		return label + " · " + window
+	}
+	return label
+}
+
+// antigravityWindowSeconds maps the upstream's window token onto a duration.
+// Unknown tokens return 0 rather than guessing, so a window we cannot classify
+// is still reported — it just does not claim to be the weekly cycle.
+func antigravityWindowSeconds(window, bucketID string) int64 {
+	normalize := func(value string) string {
+		v := strings.ToLower(strings.TrimSpace(value))
+		v = strings.ReplaceAll(v, "_", "")
+		v = strings.ReplaceAll(v, "-", "")
+		return strings.ReplaceAll(v, " ", "")
+	}
+	for _, candidate := range []string{normalize(window), normalize(bucketID)} {
+		if candidate == "" {
+			continue
+		}
+		switch {
+		case strings.Contains(candidate, "week"):
+			return antigravityWindowWeek
+		case strings.Contains(candidate, "month"):
+			return 30 * 24 * 60 * 60
+		case strings.Contains(candidate, "day") || strings.Contains(candidate, "daily"):
+			return 24 * 60 * 60
+		}
+		if seconds := parseAntigravityHourToken(candidate); seconds > 0 {
+			return seconds
+		}
+	}
+	return 0
+}
+
+// parseAntigravityHourToken reads the digits immediately preceding an `h`.
+// Every `h` is considered, not just the first: a bucket id like `gemini-flash-5h`
+// carries an `h` inside "flash" that no digits precede, and stopping there would
+// classify a 5h bucket as having no window at all.
+func parseAntigravityHourToken(value string) int64 {
+	for i := 0; i < len(value); i++ {
+		if value[i] != 'h' {
+			continue
+		}
+		start := i
+		for start > 0 && value[start-1] >= '0' && value[start-1] <= '9' {
+			start--
+		}
+		if start == i {
+			continue
+		}
+		hours, err := strconv.ParseInt(value[start:i], 10, 64)
+		if err != nil || hours <= 0 || hours > 24*31 {
+			continue
+		}
+		return hours * 60 * 60
+	}
+	return 0
+}
+
+// parseAntigravityModels is the fallback view built from fetchAvailableModels.
+// It carries only the 5h window, and the upstream does not group the models, so
+// we classify them by shape. Anything we cannot classify is still reported under
+// its own id: a model list is a moving target, and a model missing from a
+// hand-written table used to vanish from the card entirely.
 func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 	root := gjson.ParseBytes(body)
 	models := root.Get("models")
@@ -83,29 +453,13 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 	if !models.IsObject() {
 		return nil
 	}
-	type groupValue struct {
-		percent *float64
-		resetAt *time.Time
-		count   int
-	}
-	grouped := make(map[string]*groupValue, len(antigravityQuotaGroups))
+
+	grouped := make(map[string]*antigravityModelGroup, 8)
+	keys := make([]string, 0, 8)
+
 	models.ForEach(func(modelID, model gjson.Result) bool {
-		id := strings.ToLower(strings.TrimSpace(modelID.String()))
-		id = strings.TrimPrefix(id, "models/")
-		if id == "" {
-			return true
-		}
-		if _, skip := antigravitySkippedModels[id]; skip {
-			return true
-		}
-		var group *antigravityQuotaGroup
-		for i := range antigravityQuotaGroups {
-			if _, ok := antigravityQuotaGroups[i].models[id]; ok {
-				group = &antigravityQuotaGroups[i]
-				break
-			}
-		}
-		if group == nil {
+		id := normalizeAntigravityModelID(modelID.String())
+		if id == "" || isAntigravityInternalModel(id) {
 			return true
 		}
 		info := firstJSONResult(model, "quotaInfo", "quota_info")
@@ -114,20 +468,31 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		if !fraction.Exists() && resetAt == nil {
 			return true
 		}
-		current := grouped[group.key]
+
+		category := categorizeAntigravityModel(id)
+		key := category
+		label := antigravityCategoryLabel(category)
+		if category == antigravityCategoryOther {
+			key = "model_" + normalizeQuotaKeyPart(id)
+			label = strings.TrimSpace(firstJSONResult(model, "displayName", "display_name").String())
+			if label == "" {
+				label = id
+			}
+		}
+
+		current := grouped[key]
 		if current == nil {
-			current = &groupValue{}
-			grouped[group.key] = current
+			current = &antigravityModelGroup{label: label}
+			grouped[key] = current
+			keys = append(keys, key)
 		}
 		current.count++
 		if fraction.Exists() {
-			fractionValue := quotaFraction(fraction)
-			if fractionValue == nil {
-				return true
-			}
-			remaining := math.Round(clampPct(*fractionValue * 100))
-			if current.percent == nil || remaining < *current.percent {
-				current.percent = &remaining
+			if value := quotaFraction(fraction); value != nil {
+				remaining := math.Round(clampPct(*value * 100))
+				if current.percent == nil || remaining < *current.percent {
+					current.percent = &remaining
+				}
 			}
 		}
 		if resetAt != nil && (current.resetAt == nil || resetAt.Before(*current.resetAt)) {
@@ -136,17 +501,107 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		return true
 	})
 
-	out := make([]usage.QuotaWindowDTO, 0, len(grouped))
-	for _, group := range antigravityQuotaGroups {
-		value := grouped[group.key]
+	// Ranked so the well-known families lead and the unclassified models trail
+	// them, rather than surfacing in Go's randomized map order.
+	sort.SliceStable(keys, func(i, j int) bool {
+		return antigravityCategoryRank(keys[i]) < antigravityCategoryRank(keys[j])
+	})
+
+	out := make([]usage.QuotaWindowDTO, 0, len(keys))
+	for _, key := range keys {
+		value := grouped[key]
 		if value == nil || value.count == 0 {
 			continue
 		}
 		out = append(out, usage.QuotaWindowDTO{
-			QuotaKey: group.key, QuotaLabel: group.label, Percent: value.percent, ResetAt: value.resetAt,
+			QuotaKey:      "antigravity:" + key,
+			QuotaLabel:    value.label,
+			Percent:       value.percent,
+			ResetAt:       value.resetAt,
+			WindowSeconds: antigravityWindowFiveHour,
 		})
 	}
 	return out
+}
+
+type antigravityModelGroup struct {
+	label   string
+	percent *float64
+	resetAt *time.Time
+	count   int
+}
+
+func antigravityCategoryRank(key string) int {
+	switch key {
+	case antigravityCategoryGeminiPro:
+		return 0
+	case antigravityCategoryGeminiFlash:
+		return 1
+	case antigravityCategoryGeminiImage:
+		return 2
+	case antigravityCategoryClaude:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func normalizeAntigravityModelID(raw string) string {
+	id := strings.ToLower(strings.TrimSpace(raw))
+	return strings.TrimPrefix(id, "models/")
+}
+
+// isAntigravityInternalModel filters the upstream's non-conversational entries.
+// These are matched by shape rather than by id so a newly added internal model
+// does not surface as a user-visible quota row.
+func isAntigravityInternalModel(id string) bool {
+	return strings.HasPrefix(id, "chat_") || strings.HasPrefix(id, "tab_")
+}
+
+const (
+	antigravityCategoryGeminiPro   = "gemini_pro"
+	antigravityCategoryGeminiFlash = "gemini_flash"
+	antigravityCategoryGeminiImage = "gemini_image"
+	antigravityCategoryClaude      = "claude"
+	antigravityCategoryOther       = "other"
+)
+
+// categorizeAntigravityModel groups a model by the shape of its id instead of by
+// membership in a list. A list has to be edited every time the upstream ships a
+// model; the shapes below already cover the ones that do not exist yet.
+func categorizeAntigravityModel(id string) string {
+	switch {
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "image"),
+		strings.HasPrefix(id, "image"),
+		strings.HasPrefix(id, "imagen"):
+		return antigravityCategoryGeminiImage
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "flash"):
+		return antigravityCategoryGeminiFlash
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "pro"):
+		return antigravityCategoryGeminiPro
+	case strings.Contains(id, "claude"),
+		strings.Contains(id, "opus"),
+		strings.Contains(id, "sonnet"),
+		strings.Contains(id, "haiku"):
+		return antigravityCategoryClaude
+	default:
+		return antigravityCategoryOther
+	}
+}
+
+func antigravityCategoryLabel(category string) string {
+	switch category {
+	case antigravityCategoryGeminiPro:
+		return "Gemini Pro"
+	case antigravityCategoryGeminiFlash:
+		return "Gemini Flash"
+	case antigravityCategoryGeminiImage:
+		return "Gemini Image"
+	case antigravityCategoryClaude:
+		return "Claude"
+	default:
+		return ""
+	}
 }
 
 func stringSet(values ...string) map[string]struct{} {

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
 )
 
 func TestParseCodexWhamQuotas(t *testing.T) {
@@ -275,13 +277,144 @@ func TestResolveXAIPlanUsesEntitlementWhenMonthlyLimitIsZero(t *testing.T) {
 func TestParseAntigravityModelsSummarizesWorstRemainingAndEarliestReset(t *testing.T) {
 	body := []byte(`{"models":{
 		"gemini-3-pro-high":{"quotaInfo":{"remainingFraction":0.8,"resetTime":"2026-07-20T00:00:00Z"}},
-		"gemini-3.1-pro-low":{"quota_info":{"remaining_fraction":0.4,"reset_time":"2026-07-19T00:00:00Z"}},
-		"gemini-2.5-pro":{"quotaInfo":{"remainingFraction":0.1}}
+		"gemini-3.1-pro-low":{"quota_info":{"remaining_fraction":0.4,"reset_time":"2026-07-19T00:00:00Z"}}
 	}}`)
 	items := parseAntigravityModels(body)
-	pro := quotaByKey(items, "provider:gemini3-pro")
+	pro := quotaByKey(items, "antigravity:gemini_pro")
 	if pro == nil || pro.Percent == nil || *pro.Percent != 40 || pro.ResetAt == nil || pro.ResetAt.Format(time.RFC3339) != "2026-07-19T00:00:00Z" {
 		t.Fatalf("pro=%+v", pro)
+	}
+	if pro.WindowSeconds != antigravityWindowFiveHour {
+		t.Fatalf("window=%d, want %d", pro.WindowSeconds, antigravityWindowFiveHour)
+	}
+}
+
+// A model the upstream ships after this code was written must still reach the
+// card. The previous grouping dropped anything missing from a hand-written id
+// list, so a new model family silently rendered as nothing at all.
+func TestParseAntigravityModelsKeepsUnknownModels(t *testing.T) {
+	body := []byte(`{"models":{
+		"gemini-9-ultra":{"quotaInfo":{"remainingFraction":0.5},"displayName":"Gemini 9 Ultra"},
+		"grok-5-fast":{"quotaInfo":{"remainingFraction":0.25},"displayName":"Grok 5 Fast"},
+		"chat_20706":{"quotaInfo":{"remainingFraction":0.9}},
+		"tab_flash_lite_preview":{"quotaInfo":{"remainingFraction":0.9}}
+	}}`)
+	items := parseAntigravityModels(body)
+
+	// gemini-9-ultra has neither "flash" nor "pro" nor "image" in its id, so it
+	// lands in the unclassified bucket under its own name rather than vanishing.
+	ultra := quotaByKey(items, "antigravity:model_gemini_9_ultra")
+	if ultra == nil || ultra.Percent == nil || *ultra.Percent != 50 || ultra.QuotaLabel != "Gemini 9 Ultra" {
+		t.Fatalf("ultra=%+v", ultra)
+	}
+	grok := quotaByKey(items, "antigravity:model_grok_5_fast")
+	if grok == nil || grok.Percent == nil || *grok.Percent != 25 {
+		t.Fatalf("grok=%+v", grok)
+	}
+	for _, item := range items {
+		if strings.Contains(item.QuotaKey, "chat_") || strings.Contains(item.QuotaKey, "tab_") {
+			t.Fatalf("internal model leaked into quotas: %+v", item)
+		}
+	}
+}
+
+// retrieveUserQuotaSummary is the authoritative view: the upstream reports one
+// bucket per family per window, and both the grouping and the wording are its
+// own. Splitting a single bucket into several rows by model id is what made one
+// quota render three times with identical numbers.
+func TestParseAntigravityQuotaSummaryUsesUpstreamGrouping(t *testing.T) {
+	body := []byte(`{"groups":[
+		{"displayName":"Gemini Models","description":"Gemini family","buckets":[
+			{"bucketId":"gemini-5h","window":"5h","remainingFraction":0.72,"resetTime":"2026-08-19T07:00:00Z"},
+			{"bucketId":"gemini-weekly","window":"weekly","remainingFraction":0.51,"resetTime":"2026-08-24T07:00:00Z"}
+		]},
+		{"displayName":"Claude and GPT models","buckets":[
+			{"bucketId":"3p-5h","window":"5h","remainingFraction":1,"resetTime":"2026-08-19T11:00:00Z"}
+		]}
+	]}`)
+	items := parseAntigravityQuotaSummary(body)
+	if len(items) != 3 {
+		t.Fatalf("items=%d, want 3: %+v", len(items), items)
+	}
+
+	fiveHour := quotaByKey(items, "antigravity:gemini_5h")
+	if fiveHour == nil || fiveHour.Percent == nil || *fiveHour.Percent != 72 {
+		t.Fatalf("gemini 5h=%+v", fiveHour)
+	}
+	if fiveHour.WindowSeconds != antigravityWindowFiveHour {
+		t.Fatalf("gemini 5h window=%d", fiveHour.WindowSeconds)
+	}
+	if fiveHour.QuotaLabel != "Gemini Models · 5h" {
+		t.Fatalf("gemini 5h label=%q", fiveHour.QuotaLabel)
+	}
+
+	weekly := quotaByKey(items, "antigravity:gemini_weekly")
+	if weekly == nil || weekly.Percent == nil || *weekly.Percent != 51 {
+		t.Fatalf("gemini weekly=%+v", weekly)
+	}
+	if weekly.WindowSeconds != antigravityWindowWeek {
+		t.Fatalf("gemini weekly window=%d, want %d", weekly.WindowSeconds, antigravityWindowWeek)
+	}
+
+	thirdParty := quotaByKey(items, "antigravity:3p_5h")
+	if thirdParty == nil || thirdParty.Percent == nil || *thirdParty.Percent != 100 {
+		t.Fatalf("3p 5h=%+v", thirdParty)
+	}
+}
+
+func TestAntigravityWindowSecondsFallsBackToBucketID(t *testing.T) {
+	cases := []struct {
+		window, bucketID string
+		want             int64
+	}{
+		{"weekly", "gemini-weekly", antigravityWindowWeek},
+		{"5h", "gemini-5h", antigravityWindowFiveHour},
+		{"", "3p-weekly", antigravityWindowWeek},
+		{"", "3p-5h", antigravityWindowFiveHour},
+		{"24h", "", 24 * 60 * 60},
+		{"", "", 0},
+		{"per-request", "odd-bucket", 0},
+		// The `h` inside "flash" has no digits before it; the one that matters
+		// is further along.
+		{"", "gemini-flash-5h", antigravityWindowFiveHour},
+		{"", "high-throughput", 0},
+	}
+	for _, tc := range cases {
+		if got := antigravityWindowSeconds(tc.window, tc.bucketID); got != tc.want {
+			t.Fatalf("window(%q,%q)=%d, want %d", tc.window, tc.bucketID, got, tc.want)
+		}
+	}
+}
+
+// The plan ladder mirrors the upstream client: paid wins, current counts only
+// while the account is eligible, and an ineligible account reports its default
+// allowed tier as restricted.
+func TestParseAntigravityPlanType(t *testing.T) {
+	cases := []struct {
+		name, body, want string
+	}{
+		{"paid tier wins", `{"paidTier":{"name":"Ultra"},"currentTier":{"name":"Pro"}}`, "Ultra"},
+		{"paid tier id fallback", `{"paidTier":{"id":"ultra-tier"}}`, "ultra-tier"},
+		{"current tier when eligible", `{"currentTier":{"name":"Pro"}}`, "Pro"},
+		{"ineligible falls to default allowed tier", `{"currentTier":{"name":"Pro"},"ineligibleTiers":[{"reasonCode":"RESTRICTED"}],"allowedTiers":[{"isDefault":true,"name":"Free"}]}`, "Free (Restricted)"},
+		{"ineligible without allowed tiers", `{"currentTier":{"name":"Pro"},"ineligibleTiers":[{"reasonCode":"RESTRICTED"}]}`, ""},
+		{"empty", `{}`, ""},
+	}
+	for _, tc := range cases {
+		if got := parseAntigravityPlanType(gjson.Parse(tc.body)); got != tc.want {
+			t.Fatalf("%s: plan=%q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestParseAntigravityCodeAssistReadsProjectAndPlan(t *testing.T) {
+	account := parseAntigravityCodeAssist([]byte(`{"cloudaicompanionProject":"real-project-123","paidTier":{"name":"Ultra"}}`))
+	if account.projectID != "real-project-123" || account.planType != "Ultra" {
+		t.Fatalf("account=%+v", account)
+	}
+	nested := parseAntigravityCodeAssist([]byte(`{"cloudaicompanionProject":{"id":"nested-project"}}`))
+	if nested.projectID != "nested-project" {
+		t.Fatalf("nested=%+v", nested)
 	}
 }
 
@@ -411,5 +544,62 @@ func TestParseClaudePlanType(t *testing.T) {
 		if got := parseClaudePlanType([]byte(tc.body)); got != tc.want {
 			t.Fatalf("body=%s got=%q want=%q", tc.body, got, tc.want)
 		}
+	}
+}
+
+// weeklyUsedFromQuotas picks the cycle a card's "used this week" figure refers
+// to. Providers that declare a primary key keep their exact-match behaviour;
+// antigravity has none, and used to be handed whichever window happened to come
+// first — a 5h window reported as the weekly number.
+func TestWeeklyUsedFromQuotasPrefersWeeklyWindowWithoutPrimaryKey(t *testing.T) {
+	pct := func(v float64) *float64 { return &v }
+	quotas := []usage.QuotaWindowDTO{
+		{QuotaKey: "antigravity:gemini_5h", Percent: pct(72), WindowSeconds: antigravityWindowFiveHour},
+		{QuotaKey: "antigravity:gemini_weekly", Percent: pct(51), WindowSeconds: antigravityWindowWeek},
+		{QuotaKey: "antigravity:3p_5h", Percent: pct(100), WindowSeconds: antigravityWindowFiveHour},
+	}
+	got := weeklyUsedFromQuotas(quotas)
+	if got == nil || *got != 49 {
+		t.Fatalf("used=%v, want 49 (from the weekly window)", got)
+	}
+}
+
+func TestWeeklyUsedFromQuotasPrefersNarrowestWeeklyWindow(t *testing.T) {
+	pct := func(v float64) *float64 { return &v }
+	quotas := []usage.QuotaWindowDTO{
+		{QuotaKey: "monthly", Percent: pct(90), WindowSeconds: 30 * 24 * 60 * 60},
+		{QuotaKey: "weekly", Percent: pct(40), WindowSeconds: antigravityWindowWeek},
+	}
+	got := weeklyUsedFromQuotas(quotas)
+	if got == nil || *got != 60 {
+		t.Fatalf("used=%v, want 60 (weekly beats monthly)", got)
+	}
+}
+
+// Only windows narrower than a week exist: the figure still has to come from
+// somewhere, so the original first-window behaviour remains as the last resort.
+func TestWeeklyUsedFromQuotasFallsBackWhenNoWeeklyWindow(t *testing.T) {
+	pct := func(v float64) *float64 { return &v }
+	quotas := []usage.QuotaWindowDTO{{QuotaKey: "only_5h", Percent: pct(30), WindowSeconds: antigravityWindowFiveHour}}
+	got := weeklyUsedFromQuotas(quotas)
+	if got == nil || *got != 70 {
+		t.Fatalf("used=%v, want 70", got)
+	}
+}
+
+// Providers that declare a primary weekly key must not start matching by window
+// width: an unrelated window of the same width would silently take over.
+func TestWeeklyUsedFromQuotasKeepsExactMatchForKeyedProviders(t *testing.T) {
+	pct := func(v float64) *float64 { return &v }
+	quotas := []usage.QuotaWindowDTO{
+		{QuotaKey: "review_week", Percent: pct(10), WindowSeconds: antigravityWindowWeek},
+		{QuotaKey: "code_week", Percent: pct(80), WindowSeconds: antigravityWindowWeek},
+	}
+	got := weeklyUsedFromQuotas(quotas, "code_week")
+	if got == nil || *got != 20 {
+		t.Fatalf("used=%v, want 20 (code_week, not review_week)", got)
+	}
+	if missing := weeklyUsedFromQuotas(quotas, "seven_day"); missing != nil {
+		t.Fatalf("used=%v, want nil when the declared key is absent", missing)
 	}
 }

--- a/internal/management/aiaccountstatus/status_view.go
+++ b/internal/management/aiaccountstatus/status_view.go
@@ -53,20 +53,7 @@ func timePointer(value time.Time) *time.Time {
 }
 
 func weeklyUsedFromQuotas(quotas []usage.QuotaWindowDTO, preferred ...string) *float64 {
-	pref := make(map[string]struct{}, len(preferred))
-	for _, k := range preferred {
-		pref[k] = struct{}{}
-	}
-	for i := range quotas {
-		q := &quotas[i]
-		if q.Percent == nil {
-			continue
-		}
-		if len(pref) > 0 {
-			if _, ok := pref[q.QuotaKey]; !ok {
-				continue
-			}
-		}
+	usedFrom := func(q *usage.QuotaWindowDTO) *float64 {
 		used := 100 - *q.Percent
 		if used < 0 {
 			used = 0
@@ -75,6 +62,55 @@ func weeklyUsedFromQuotas(quotas []usage.QuotaWindowDTO, preferred ...string) *f
 			used = 100
 		}
 		return &used
+	}
+
+	if len(preferred) > 0 {
+		pref := make(map[string]struct{}, len(preferred))
+		for _, k := range preferred {
+			pref[k] = struct{}{}
+		}
+		for i := range quotas {
+			q := &quotas[i]
+			if q.Percent == nil {
+				continue
+			}
+			if _, ok := pref[q.QuotaKey]; !ok {
+				continue
+			}
+			return usedFrom(q)
+		}
+		return nil
+	}
+
+	// Providers with no fixed weekly key — antigravity names its buckets after
+	// whatever the upstream calls them — are matched by window width instead.
+	// Falling through to "whichever window came first" reported a 5h window as
+	// the weekly figure, so the card showed a number for a cycle it never
+	// measured. The narrowest window at or above a week is the weekly one; a
+	// monthly window sorts after it rather than displacing it.
+	var weekly *usage.QuotaWindowDTO
+	for i := range quotas {
+		q := &quotas[i]
+		if q.Percent == nil || q.WindowSeconds < usage.WeeklyQuotaWindowSeconds {
+			continue
+		}
+		if weekly == nil || q.WindowSeconds < weekly.WindowSeconds {
+			weekly = q
+		}
+	}
+	if weekly != nil {
+		return usedFrom(weekly)
+	}
+
+	// No window is wide enough to be a weekly cycle. Providers that report a
+	// single unlabelled window still need a figure, so keep the original
+	// first-window behaviour as the last resort.
+	for i := range quotas {
+		q := &quotas[i]
+		if q.Percent == nil {
+			continue
+		}
+		return usedFrom(q)
 	}
 	return nil
 }

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -11,6 +11,12 @@ import (
 const aiAccountSubjectDayRetention = 400 * 24 * time.Hour
 const aiAccountSubjectWeeklyWindowSeconds = int64(7 * 24 * time.Hour / time.Second)
 
+// WeeklyQuotaWindowSeconds is the width at which a quota window counts as the
+// weekly cycle. Readers outside this package need the same threshold to pick a
+// weekly window out of a quota list; exporting it keeps them from hard-coding a
+// second copy that can drift from the one the cycle projection uses.
+const WeeklyQuotaWindowSeconds = aiAccountSubjectWeeklyWindowSeconds
+
 // Keep every (subject, quota key) cycle so additional weekly windows cannot
 // replace the provider's primary card cycle.
 var sharedCycleCache = struct {


### PR DESCRIPTION
## What was wrong

The Antigravity quota probe announced client version `1.11.5` while the request executor announced `1.104.0`. The upstream gates its answer on that header, so the probe was served a coarser quota view than the account actually has — three model families came back sharing one percentage and one reset time, because upstream they are a single bucket.

Three further sources of wrong numbers sat on top of that:

- **Hard-coded project id.** The probe queried under a shared fallback project. Quota is reported per project, so an account with no project of its own read back *that* project's remaining fraction — an exhausted account could report 100% available.
- **Hand-written model list.** Models were grouped by an id whitelist. A model missing from it was not shown as unknown, it was dropped, so a newly shipped family rendered as nothing at all.
- **No weekly anchor.** `weeklyUsedFromQuotas` fell through to "whichever window came first", which for this provider is a 5h window. The card reported a weekly number for a cycle it never measured.

## What changed

- Announce the client version the upstream still serves in full, and try the sandbox host first.
- Read `retrieveUserQuotaSummary` for the upstream's own weekly and 5h buckets, keeping its grouping and its wording; fall back to `fetchAvailableModels` when unavailable.
- Resolve the account's own project through `loadCodeAssist`, and take the subscription tier from the same response — this provider never reported `plan_type` before. Cached for 10 minutes so repeated probes do not hammer the endpoint.
- Retry once without the `project` field on a 403; a project the account cannot read is rejected outright.
- Classify models by the shape of their id, keeping unclassified ones under their own name.
- `weeklyUsedFromQuotas` matches by window width when a provider declares no primary key.

## Blast radius

`weeklyUsedFromQuotas` is shared. Providers that declare a primary weekly key — claude, codex, kimi, xai — keep exact-match behaviour unchanged; a regression test pins this, including that a declared-but-absent key still returns nil rather than falling back to something else.

## Testing

- `go build ./...` clean, `go vet ./internal/...` clean, `gofmt` clean
- `internal/management/aiaccountstatus` green, with new cases for summary parsing, unknown-model retention, the plan-type ladder, window-width parsing, and the weekly anchor fallback

Two failures exist on `dev` and are unrelated to this change (both reproduced on a clean tree via `git stash`): `TestUsageRollupSurvivesDetailDelete` fails deterministically, and `TestCommandCodeResetInAcceptsSecondsAndMilliseconds` is a wall-clock race that fails roughly two runs in three.

## Not included

The request executor still announces `antigravity/1.104.0 darwin/arm64` and the auth path `google-api-nodejs-client/9.15.1`. Unifying those touches the hot forwarding path and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)