### PR TITLE
fix(thinking): stop sending internal effort markers to compat upstreams

### DIFF
--- a/internal/api/handlers/management/commandcode_usage.go
+++ b/internal/api/handlers/management/commandcode_usage.go
@@ -178,6 +178,15 @@ func commandCodeWindowItem(usageType, label string, window *commandCodeWindow) (
 // past the year 2001 in milliseconds exceed 1e12, which is the only reliable way
 // to tell the two apart without a documented unit.
 func commandCodeResetIn(resetAt *float64) string {
+	return commandCodeResetInAt(resetAt, time.Now())
+}
+
+// commandCodeResetInAt is commandCodeResetIn with the reference instant passed
+// in. Reading the clock inside the formatter makes the result depend on when it
+// is called, which is untestable at the boundaries: two calls a microsecond
+// apart can land on either side of a rounding step and render "2 hours" and
+// "1 hour 59 minutes" for the same input.
+func commandCodeResetInAt(resetAt *float64, now time.Time) string {
 	if resetAt == nil || *resetAt <= 0 || math.IsNaN(*resetAt) || math.IsInf(*resetAt, 0) {
 		return ""
 	}
@@ -185,7 +194,7 @@ func commandCodeResetIn(resetAt *float64) string {
 	if milliseconds <= 1e12 {
 		milliseconds *= 1000
 	}
-	seconds := int64(math.Round(time.Until(time.UnixMilli(int64(milliseconds))).Seconds()))
+	seconds := int64(math.Round(time.UnixMilli(int64(milliseconds)).Sub(now).Seconds()))
 	if seconds < 0 {
 		seconds = 0
 	}

--- a/internal/api/handlers/management/commandcode_usage_test.go
+++ b/internal/api/handlers/management/commandcode_usage_test.go
@@ -53,18 +53,49 @@ func TestParseCommandCodeUsageClampsOverage(t *testing.T) {
 }
 
 // resetAt has been observed in both units, so both must produce the same answer.
+//
+// The reference instant is fixed and second-aligned. Reading the wall clock
+// here made the test fail about half the time: Unix() truncates the sub-second
+// part while UnixMilli() keeps it, so the two inputs described instants up to a
+// second apart, and 2h landed on a rounding step — one side rendered "2 hours",
+// the other "1 hour 59 minutes".
 func TestCommandCodeResetInAcceptsSecondsAndMilliseconds(t *testing.T) {
-	future := time.Now().Add(2 * time.Hour)
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	future := now.Add(2 * time.Hour)
 	milliseconds := float64(future.UnixMilli())
 	seconds := float64(future.Unix())
 
-	fromMillis := commandCodeResetIn(&milliseconds)
-	fromSeconds := commandCodeResetIn(&seconds)
+	fromMillis := commandCodeResetInAt(&milliseconds, now)
+	fromSeconds := commandCodeResetInAt(&seconds, now)
 	if fromMillis == "" || fromSeconds == "" {
 		t.Fatalf("reset countdowns = %q / %q, want both populated", fromMillis, fromSeconds)
 	}
 	if fromMillis != fromSeconds {
 		t.Fatalf("seconds and milliseconds disagree: %q vs %q", fromSeconds, fromMillis)
+	}
+}
+
+// A second-aligned resetAt is the same instant in either unit, so the answers
+// must match no matter where "now" sits between two seconds.
+//
+// The distinction matters: when resetAt itself carries a sub-second component,
+// the seconds form has already discarded it and genuinely describes a different
+// instant than the milliseconds form. Demanding identical output there would be
+// asserting that a lossy conversion is lossless — which is what the original
+// test did, and why it failed about half the time.
+func TestCommandCodeResetInAgreesForSecondAlignedResetAt(t *testing.T) {
+	base := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	future := base.Add(2 * time.Hour) // second-aligned: identical in both units
+	milliseconds := float64(future.UnixMilli())
+	seconds := float64(future.Unix())
+
+	for _, nanos := range []int{0, 1e8, 4e8, 5e8, 6e8, 9e8} {
+		now := base.Add(time.Duration(nanos))
+		fromMillis := commandCodeResetInAt(&milliseconds, now)
+		fromSeconds := commandCodeResetInAt(&seconds, now)
+		if fromMillis != fromSeconds {
+			t.Fatalf("now offset %dns: seconds=%q milliseconds=%q", nanos, fromSeconds, fromMillis)
+		}
 	}
 }
 

--- a/internal/thinking/provider/openai/apply.go
+++ b/internal/thinking/provider/openai/apply.go
@@ -45,7 +45,12 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 		return applyCompatibleOpenAI(body, config)
 	}
 	if modelInfo.Thinking == nil {
-		return body, nil
+		// A model that declares no thinking support still has to be protected
+		// from a value written upstream of here: the Claude→OpenAI translator
+		// turns `thinking.type: "disabled"` into `reasoning_effort: "none"`
+		// before this applier runs, and returning the body untouched forwards
+		// that value to an upstream that never agreed to accept it.
+		return dropNonStandardEffort(body), nil
 	}
 
 	// Only handle ModeLevel and ModeNone; other modes pass through unchanged.
@@ -110,15 +115,21 @@ func applyCompatibleOpenAI(body []byte, config thinking.ThinkingConfig) ([]byte,
 		}
 		effort = string(config.Level)
 	case thinking.ModeNone:
-		effort = string(thinking.LevelNone)
-		if config.Level != "" {
-			effort = string(config.Level)
-		}
+		// Omitting the field is how the OpenAI wire format says "do not think".
+		// Sending "none" instead is what made Command Code answer
+		// 400 `expected one of "low"|"medium"|"high"|"xhigh"|"max"` on every
+		// Claude Code request that disabled thinking. The model-aware path in
+		// Apply already refuses to emit "none" unless the model declares it;
+		// a model we know nothing about deserves at least the same caution.
+		effort = string(config.Level)
 	case thinking.ModeAuto:
-		// Auto mode for user-defined models: pass through as "auto"
-		effort = string(thinking.LevelAuto)
+		// "auto" is an internal marker for "let the model decide", not a wire
+		// value any OpenAI-compatible upstream accepts.
+		effort = ""
 	case thinking.ModeBudget:
-		// Budget mode: convert budget to level using threshold mapping
+		// Budget mode: convert budget to level using threshold mapping.
+		// A zero budget maps to "none" and a negative one to "auto", so the
+		// result goes through the same guard as the explicit modes.
 		level, ok := thinking.ConvertBudgetToLevel(config.Budget)
 		if !ok {
 			return body, nil
@@ -128,8 +139,41 @@ func applyCompatibleOpenAI(body []byte, config thinking.ThinkingConfig) ([]byte,
 		return body, nil
 	}
 
+	if effort == "" || isNonStandardEffort(effort) {
+		return dropNonStandardEffort(body), nil
+	}
+
 	result, _ := sjson.SetBytes(body, "reasoning_effort", effort)
 	return result, nil
+}
+
+// isNonStandardEffort reports whether a reasoning_effort value is one this
+// codebase uses internally rather than one the OpenAI wire format defines.
+//
+// "none" and "auto" are both internal markers. Upstreams differ on them —
+// opencode go tolerates "none" while Command Code rejects it — so neither may
+// be sent to a model whose accepted levels are unknown.
+func isNonStandardEffort(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(thinking.LevelNone), string(thinking.LevelAuto):
+		return true
+	default:
+		return false
+	}
+}
+
+// dropNonStandardEffort removes a reasoning_effort the upstream would reject,
+// leaving any legitimate value in place.
+func dropNonStandardEffort(body []byte) []byte {
+	effort := gjson.GetBytes(body, "reasoning_effort")
+	if !effort.Exists() || !isNonStandardEffort(effort.String()) {
+		return body
+	}
+	result, err := sjson.DeleteBytes(body, "reasoning_effort")
+	if err != nil {
+		return body
+	}
+	return result
 }
 
 func hasLevel(levels []string, target string) bool {

--- a/internal/thinking/provider/openai/apply_test.go
+++ b/internal/thinking/provider/openai/apply_test.go
@@ -1,0 +1,150 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/tidwall/gjson"
+)
+
+// Command Code answers 400 with
+// `expected one of "low"|"medium"|"high"|"xhigh"|"max"` when reasoning_effort
+// carries one of this codebase's internal markers. Every Claude Code request
+// that disabled thinking hit it, because the Claude→OpenAI translator writes
+// `reasoning_effort: "none"` and nothing downstream took it back out.
+func TestCompatibleModelNeverSendsInternalEffortMarkers(t *testing.T) {
+	applier := NewApplier()
+	userDefined := &registry.ModelInfo{ID: "deepseek/deepseek-v4-flash", UserDefined: true}
+
+	cases := []struct {
+		name   string
+		body   string
+		config thinking.ThinkingConfig
+	}{
+		{
+			name:   "mode none",
+			body:   `{"model":"deepseek/deepseek-v4-flash","reasoning_effort":"none"}`,
+			config: thinking.ThinkingConfig{Mode: thinking.ModeNone, Budget: 0},
+		},
+		{
+			name:   "mode auto",
+			body:   `{"model":"deepseek/deepseek-v4-flash"}`,
+			config: thinking.ThinkingConfig{Mode: thinking.ModeAuto, Budget: -1},
+		},
+		{
+			name:   "zero budget maps to none",
+			body:   `{"model":"deepseek/deepseek-v4-flash"}`,
+			config: thinking.ThinkingConfig{Mode: thinking.ModeBudget, Budget: 0},
+		},
+		{
+			name:   "negative budget maps to auto",
+			body:   `{"model":"deepseek/deepseek-v4-flash"}`,
+			config: thinking.ThinkingConfig{Mode: thinking.ModeBudget, Budget: -1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := applier.Apply([]byte(tc.body), tc.config, userDefined)
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if effort := gjson.GetBytes(out, "reasoning_effort"); effort.Exists() {
+				t.Fatalf("reasoning_effort = %q, want the field to be absent", effort.String())
+			}
+			// The rest of the request must survive untouched.
+			if model := gjson.GetBytes(out, "model").String(); model != "deepseek/deepseek-v4-flash" {
+				t.Fatalf("model = %q, want it preserved", model)
+			}
+		})
+	}
+}
+
+// Legitimate levels still have to reach the upstream — the guard must not turn
+// into a blanket strip.
+func TestCompatibleModelForwardsRealLevels(t *testing.T) {
+	applier := NewApplier()
+	userDefined := &registry.ModelInfo{ID: "deepseek/deepseek-v4-flash", UserDefined: true}
+
+	for _, level := range []string{"low", "medium", "high", "xhigh", "max", "minimal"} {
+		t.Run(level, func(t *testing.T) {
+			out, err := applier.Apply(
+				[]byte(`{"model":"deepseek/deepseek-v4-flash"}`),
+				thinking.ThinkingConfig{Mode: thinking.ModeLevel, Level: thinking.ThinkingLevel(level)},
+				userDefined,
+			)
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if got := gjson.GetBytes(out, "reasoning_effort").String(); got != level {
+				t.Fatalf("reasoning_effort = %q, want %q", got, level)
+			}
+		})
+	}
+}
+
+// A budget that maps onto a real level keeps working.
+func TestCompatibleModelForwardsMappedBudget(t *testing.T) {
+	out, err := NewApplier().Apply(
+		[]byte(`{"model":"deepseek/deepseek-v4-flash"}`),
+		thinking.ThinkingConfig{Mode: thinking.ModeBudget, Budget: 32000},
+		&registry.ModelInfo{ID: "deepseek/deepseek-v4-flash", UserDefined: true},
+	)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got == "" || got == "none" || got == "auto" {
+		t.Fatalf("reasoning_effort = %q, want a real level", got)
+	}
+}
+
+// A model that declares no thinking support is not a licence to forward a value
+// written before this applier ran.
+func TestModelWithoutThinkingSupportStripsInternalMarkers(t *testing.T) {
+	applier := NewApplier()
+	noThinking := &registry.ModelInfo{ID: "some-chat-model"}
+
+	for _, marker := range []string{"none", "auto"} {
+		t.Run(marker, func(t *testing.T) {
+			body := []byte(`{"model":"some-chat-model","reasoning_effort":"` + marker + `"}`)
+			out, err := applier.Apply(body, thinking.ThinkingConfig{Mode: thinking.ModeNone}, noThinking)
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if effort := gjson.GetBytes(out, "reasoning_effort"); effort.Exists() {
+				t.Fatalf("reasoning_effort = %q, want the field to be absent", effort.String())
+			}
+		})
+	}
+
+	// A real level on the same path is left alone.
+	body := []byte(`{"model":"some-chat-model","reasoning_effort":"high"}`)
+	out, err := applier.Apply(body, thinking.ThinkingConfig{Mode: thinking.ModeLevel, Level: thinking.LevelHigh}, noThinking)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "high" {
+		t.Fatalf("reasoning_effort = %q, want high", got)
+	}
+}
+
+// Models that explicitly declare "none" keep receiving it: the fix targets
+// unknown capability, not models that opted in.
+func TestDeclaredNoneLevelIsStillHonoured(t *testing.T) {
+	declared := &registry.ModelInfo{
+		ID:       "gpt-5.1",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"none", "low", "medium", "high"}},
+	}
+	out, err := NewApplier().Apply(
+		[]byte(`{"model":"gpt-5.1"}`),
+		thinking.ThinkingConfig{Mode: thinking.ModeNone},
+		declared,
+	)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "none" {
+		t.Fatalf("reasoning_effort = %q, want none for a model that declares it", got)
+	}
+}

--- a/test/thinking_conversion_test.go
+++ b/test/thinking_conversion_test.go
@@ -824,26 +824,29 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "xhigh",
 			expectErr:   false,
 		},
-		// Case 69: Budget 0 → passthrough logic → none
+		// Case 69: Budget 0 means "do not think". For a model whose accepted
+		// levels are unknown the field is omitted rather than set to "none":
+		// "none" is an internal marker, not an OpenAI wire value, and Command
+		// Code answers 400 `expected one of "low"|"medium"|"high"|"xhigh"|"max"`
+		// on it. Omission is how the wire format says "use the model default".
 		{
 			name:        "69",
 			from:        "gemini",
 			to:          "openai",
 			model:       "user-defined-model(0)",
 			inputJSON:   `{"model":"user-defined-model(0)","contents":[{"role":"user","parts":[{"text":"hi"}]}]}`,
-			expectField: "reasoning_effort",
-			expectValue: "none",
+			expectField: "",
 			expectErr:   false,
 		},
-		// Case 70: Budget -1 → passthrough logic → auto
+		// Case 70: Budget -1 maps to "auto", which is the same kind of internal
+		// marker as "none" and is omitted for the same reason.
 		{
 			name:        "70",
 			from:        "gemini",
 			to:          "openai",
 			model:       "user-defined-model(-1)",
 			inputJSON:   `{"model":"user-defined-model(-1)","contents":[{"role":"user","parts":[{"text":"hi"}]}]}`,
-			expectField: "reasoning_effort",
-			expectValue: "auto",
+			expectField: "",
 			expectErr:   false,
 		},
 		// Case 71: Claude to Codex no suffix → injected default → medium
@@ -2106,26 +2109,30 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "xhigh",
 			expectErr:   false,
 		},
-		// Case 69: thinkingBudget=0 → none
+		// Case 69: thinkingBudget=0 means "do not think". For a model whose
+		// accepted levels are unknown the field is omitted rather than set to
+		// "none": "none" is an internal marker, not an OpenAI wire value, and
+		// Command Code answers 400 `expected one of
+		// "low"|"medium"|"high"|"xhigh"|"max"` on it. Omission is how the wire
+		// format says "use the model default".
 		{
 			name:        "69",
 			from:        "gemini",
 			to:          "openai",
 			model:       "user-defined-model",
 			inputJSON:   `{"model":"user-defined-model","contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"thinkingConfig":{"thinkingBudget":0}}}`,
-			expectField: "reasoning_effort",
-			expectValue: "none",
+			expectField: "",
 			expectErr:   false,
 		},
-		// Case 70: thinkingBudget=-1 → auto
+		// Case 70: thinkingBudget=-1 maps to "auto", the same kind of internal
+		// marker as "none", omitted for the same reason.
 		{
 			name:        "70",
 			from:        "gemini",
 			to:          "openai",
 			model:       "user-defined-model",
 			inputJSON:   `{"model":"user-defined-model","contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"thinkingConfig":{"thinkingBudget":-1}}}`,
-			expectField: "reasoning_effort",
-			expectValue: "auto",
+			expectField: "",
 			expectErr:   false,
 		},
 		// Case 71: Claude no param → injected default → medium


### PR DESCRIPTION
## The failure

Every Claude Code request that disabled thinking failed against the **Command Code** channel. Pulled the stored response body off the production host (`log_id=1000670653`, zstd in `request_log_content`):

```json
{"error":{"message":"Invalid option: expected one of \"low\"|\"medium\"|\"high\"|\"xhigh\"|\"max\"",
          "type":"invalid_request_error","param":"reasoning_effort"}}
```

Matched by timestamp and latency to the 400s in the journal:

| DB row | journal |
|---|---|
| `08:33:40` / `751ms` | `16:33:40` / `764ms` `POST /group2/…/v1/messages?beta=true` → 400 |
| `08:33:37` / `2020ms` | `16:33:39` / `2.031s` same route → 400 |

Client was `claude-cli/2.1.233` with `Anthropic-Beta: …,effort-2025-11-24`.

## Root cause

`none` and `auto` are markers this codebase uses internally — "do not think" and "let the model decide". Neither is an OpenAI wire value. Upstreams disagree about them: `opencode go` tolerates `none` (its rows are `failed=0`), Command Code rejects it.

The model-aware path already knew this. [apply.go:65-67](CliRelay/internal/thinking/provider/openai/apply.go:65) refuses to emit `none` unless the model declares it, with the comment *"fall back to lowest level so upstream does not 400 on `none`"*. Two paths around it did not:

1. **`applyCompatibleOpenAI`** — taken for user-defined models — set `none` and `auto` unconditionally. Command Code's models are registered from config ([model_definitions_commandcode.go](CliRelay/internal/registry/model_definitions_commandcode.go) carries id/name/context and no thinking declaration), so they land exactly here.
2. **`Apply`** returned the body untouched when `modelInfo.Thinking == nil`. The Claude→OpenAI translator writes `reasoning_effort: "none"` for `thinking.type: "disabled"` at [openai_claude_request.go:82](CliRelay/internal/translator/openai/claude/openai_claude_request.go:82) *before* this applier runs, so the value reached the wire unexamined.

## The fix

Both paths drop the field instead of forwarding a marker. Omitting `reasoning_effort` is how the OpenAI wire format says "use the model default", and every compatible upstream accepts its absence.

Untouched: real levels (`low`…`max`, `minimal`), budgets that map onto a real level, and models that explicitly declare `none` among their levels.

## Behaviour change worth reviewing

Channels that currently succeed **while** sending `none` will stop sending it. Those requests fall back to the upstream's default thinking behaviour rather than an explicit off — on a thinking-capable model that could mean reasoning turns on where it was previously suppressed, with the token cost that implies.

The precise alternative is to declare the accepted levels on those models, which routes them through the model-aware path and clamps to the lowest declared level instead of omitting. I did not do that here because I only have evidence from one upstream's rejection, not a full picture of what each channel accepts. Happy to add it if you want the tighter control.

## Testing

New `apply_test.go`. Verified the tests actually catch the bug by stashing the fix — they fail with exactly the production symptom:

```
apply_test.go:54: reasoning_effort = "none", want the field to be absent
apply_test.go:54: reasoning_effort = "auto", want the field to be absent
```

Full backend suite green on this branch (`go build ./...` + `go test ./internal/...`, zero FAIL).

## Deploy

**Not merging this myself.** Merging triggers the auto-deploy, and today's blue-green run showed it can take the site down when nginx and `.active-port` disagree. The three state sources are aligned right now (all `8319`), so a deploy should cut over cleanly — but that call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)