### PR TITLE
fix(deploy): stop severing in-flight streams during blue-green cutover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 15
     env:
       SHOULD_DEPLOY: ${{ github.event_name == 'workflow_dispatch' || vars.CLIRELAY_DEV_AUTO_DEPLOY == 'true' }}
-      EXPECTED_SCRIPT_VERSION: '2026.08.19.2'
+      EXPECTED_SCRIPT_VERSION: '2026.08.19.3'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -120,13 +120,25 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`scripts/cleanup-drained-slot.sh`,
 		`grep -v '\.bak\.'`,
 		`SCRIPT_VERSION`,
-		`TimeoutStopSec=90`,
+		`TimeoutStopSec=${SHUTDOWN_GRACE_SECONDS}`,
+		`CLIRELAY_SHUTDOWN_GRACE`,
+		// The cutover must prove it happened rather than infer it from an exit
+		// status. A missing rewrite tool once left the config untouched while
+		// the deploy reported success, which is what manufactured the slot
+		// drift behind two outages.
+		`rewrite_slot_port`,
+		`nginx_slot_port`,
+		`required command not found on deploy host`,
+		`refusing to stop`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("deploy script missing guard %q", want)
 		}
 	}
 	for _, forbidden := range []string{
+		// perl is not installed on the deploy host. Using it for the config
+		// rewrite failed silently and the deploy still reported success.
+		`perl -0pi`,
 		`migrate-sqlite-to-postgres.sh`,
 		`Legacy SQLite`,
 		`stop_active_units_for_migration`,

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SCRIPT_VERSION must stay in sync with deploy gate expectations.
-SCRIPT_VERSION="${SCRIPT_VERSION:-2026.08.19.2}"
+SCRIPT_VERSION="${SCRIPT_VERSION:-2026.08.19.3}"
 set -euo pipefail
 
 SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
@@ -10,7 +10,16 @@ DOMAIN="${DOMAIN:-relay.07230805.xyz}"
 PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-https://${DOMAIN}}"
 PORT_A="${PORT_A:-8318}"
 PORT_B="${PORT_B:-8319}"
-DRAIN_SECONDS="${DRAIN_SECONDS:-35}"
+# How long the retired slot keeps serving after nginx has stopped sending it
+# new traffic. It only needs to outlast requests already in flight, and this
+# proxy fronts LLMs where a single streamed answer runs for minutes — 35s cut
+# those off. Draining is scheduled asynchronously, so a longer window costs
+# one idle process, not deploy time.
+DRAIN_SECONDS="${DRAIN_SECONDS:-180}"
+# Upper bound the retiring process may spend finishing in-flight requests
+# after SIGTERM. Passed to the unit as TimeoutStopSec and to the binary as
+# CLIRELAY_SHUTDOWN_GRACE so systemd cannot kill it mid-stream.
+SHUTDOWN_GRACE_SECONDS="${SHUTDOWN_GRACE_SECONDS:-300}"
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-90}"
 SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-30}"
 MIN_AVAILABLE_MB="${MIN_AVAILABLE_MB:-512}"
@@ -330,7 +339,8 @@ unit_file="/etc/systemd/system/${next_unit}.service"
 	echo "Restart=always"
 	echo "RestartSec=3"
 	echo "KillSignal=SIGTERM"
-	echo "TimeoutStopSec=90"
+	echo "TimeoutStopSec=${SHUTDOWN_GRACE_SECONDS}"
+	echo "Environment=CLIRELAY_SHUTDOWN_GRACE=${SHUTDOWN_GRACE_SECONDS}s"
 	[ -n "$SERVICE_CPU_QUOTA" ] && echo "CPUQuota=${SERVICE_CPU_QUOTA}"
 	[ -n "$SERVICE_MEMORY_HIGH" ] && echo "MemoryHigh=${SERVICE_MEMORY_HIGH}"
 	[ -n "$SERVICE_MEMORY_MAX" ] && echo "MemoryMax=${SERVICE_MEMORY_MAX}"

--- a/sdk/cliproxy/lifecycle.go
+++ b/sdk/cliproxy/lifecycle.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
@@ -23,7 +25,7 @@ func (s *Service) Run(ctx context.Context) error {
 
 	usage.StartDefault(ctx)
 
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownGracePeriod())
 	defer shutdownCancel()
 	defer func() {
 		if err := s.Shutdown(shutdownCtx); err != nil {
@@ -160,9 +162,18 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		}
 
 		if s.server != nil {
-			shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			defer cancel()
-			if err := s.server.Stop(shutdownCtx); err != nil {
+			// Honour the caller's deadline instead of clamping it. Wrapping the
+			// incoming context in a fresh 30s timeout here silently overrode
+			// whatever budget the caller had granted, so widening the window in
+			// Run alone would have changed nothing: this was the limit that
+			// actually cut off in-flight requests.
+			stopCtx := ctx
+			if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+				var cancel context.CancelFunc
+				stopCtx, cancel = context.WithTimeout(ctx, shutdownGracePeriod())
+				defer cancel()
+			}
+			if err := s.server.Stop(stopCtx); err != nil {
 				log.Errorf("error stopping API server: %v", err)
 				if shutdownErr == nil {
 					shutdownErr = err
@@ -181,3 +192,30 @@ func (s *Service) ensureAuthDir() error {
 	}
 	return ensureServiceAuthDir(s.cfg.AuthDir)
 }
+
+// shutdownGracePeriod bounds how long a terminating process waits for requests
+// already in flight to finish.
+//
+// This is a proxy in front of LLMs: a single streamed answer routinely runs for
+// minutes. The previous fixed 30s meant a blue-green deploy cut off any request
+// still streaming 30 seconds after the old slot was signalled, which is a
+// user-visible failure even though the deploy itself reported success. The
+// window now defaults to five minutes and is overridable, so an operator can
+// match it to the systemd TimeoutStopSec on the host.
+//
+// Note this is an upper bound, not a delay: Shutdown returns as soon as the
+// last in-flight request completes.
+func shutdownGracePeriod() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("CLIRELAY_SHUTDOWN_GRACE"))
+	if raw == "" {
+		return defaultShutdownGracePeriod
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil || parsed <= 0 {
+		log.Warnf("cliproxy: ignoring invalid CLIRELAY_SHUTDOWN_GRACE %q, using %s", raw, defaultShutdownGracePeriod)
+		return defaultShutdownGracePeriod
+	}
+	return parsed
+}
+
+const defaultShutdownGracePeriod = 5 * time.Minute

--- a/sdk/cliproxy/lifecycle_shutdown_test.go
+++ b/sdk/cliproxy/lifecycle_shutdown_test.go
@@ -1,0 +1,36 @@
+package cliproxy
+
+import (
+	"testing"
+	"time"
+)
+
+// The window bounds how long a terminating process may spend finishing requests
+// that are already streaming. Five minutes is the floor for an LLM proxy; the
+// previous fixed 30s cut long answers off mid-stream on every deploy.
+func TestShutdownGracePeriodDefaultsToFiveMinutes(t *testing.T) {
+	t.Setenv("CLIRELAY_SHUTDOWN_GRACE", "")
+	if got := shutdownGracePeriod(); got != 5*time.Minute {
+		t.Fatalf("grace period = %s, want 5m", got)
+	}
+}
+
+func TestShutdownGracePeriodHonoursOverride(t *testing.T) {
+	t.Setenv("CLIRELAY_SHUTDOWN_GRACE", "90s")
+	if got := shutdownGracePeriod(); got != 90*time.Second {
+		t.Fatalf("grace period = %s, want 90s", got)
+	}
+}
+
+// A malformed or non-positive override must not silently disable the wait —
+// falling back to zero would make every deploy sever in-flight requests.
+func TestShutdownGracePeriodRejectsUnusableValues(t *testing.T) {
+	for _, raw := range []string{"nonsense", "0", "-30s"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv("CLIRELAY_SHUTDOWN_GRACE", raw)
+			if got := shutdownGracePeriod(); got != 5*time.Minute {
+				t.Fatalf("grace period for %q = %s, want the 5m default", raw, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What is still wrong after #907 / #908

Cutover no longer 502s. But it still **cuts requests off**.

A retiring slot got 35s of drain plus 30s of graceful shutdown — 65 seconds total. This proxy fronts LLMs, where one streamed answer routinely runs longer than that. Every deploy severed whatever was mid-stream. The deploy reported success; the user saw a dropped connection.

That is not zero-downtime, it is downtime distributed onto the slowest requests.

## The 30s was written twice, and I initially found the wrong one

`Run` created a 30s shutdown context. `Shutdown` then wrapped the context **it was handed** in *another* fixed 30s before calling `server.Stop`:

```go
// Run
shutdownCtx, _ := context.WithTimeout(..., 30*time.Second)
// Shutdown — the binding constraint
shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
```

The inner one wins. Widening only `Run` would have changed nothing — worth knowing for anyone who tries to tune this later.

## Changes

- `Shutdown` honours the caller's deadline instead of clamping it, and only imposes its own bound when handed a context without one.
- Window is `CLIRELAY_SHUTDOWN_GRACE`, default **5 minutes**. An unparseable or non-positive value falls back to the default rather than to zero — zero would sever every request instead of none.
- `DRAIN_SECONDS` 35 → **180**, `TimeoutStopSec` 90 → **300**, and the unit now exports `CLIRELAY_SHUTDOWN_GRACE` so systemd cannot kill the process while it is still finishing work.

## Cost

Draining is scheduled asynchronously through `systemd-run`, so a longer window costs one idle process for a few minutes — not deploy time. The grace period is an upper bound, not a delay: shutdown returns as soon as the last in-flight request finishes. Host memory is ~3.9GB with one slot using well under `MemoryMax=1600M`, so two slots overlapping for three minutes is comfortable.

## Testing

New `lifecycle_shutdown_test.go` covers the default, an override, and the malformed/zero/negative cases that must not collapse the window to zero.

`SCRIPT_VERSION` → `2026.08.19.3`; the script needs syncing to the host before merge, as with #908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)