### PR TITLE
fix(antigravity): label quota rows by group and move the prose to meta

### DIFF
--- a/internal/management/aiaccountstatus/probe_antigravity.go
+++ b/internal/management/aiaccountstatus/probe_antigravity.go
@@ -301,12 +301,13 @@ func parseAntigravityQuotaSummary(body []byte) []usage.QuotaWindowDTO {
 	seen := make(map[string]struct{}, 8)
 	groups.ForEach(func(groupIndex, group gjson.Result) bool {
 		groupName := strings.TrimSpace(firstJSONResult(group, "displayName", "display_name").String())
+		groupDescription := strings.TrimSpace(firstJSONResult(group, "description").String())
 		buckets := firstJSONResult(group, "buckets", "quotaBuckets", "quota_buckets")
 		if !buckets.IsArray() {
 			return true
 		}
 		buckets.ForEach(func(bucketIndex, bucket gjson.Result) bool {
-			dto, ok := antigravityBucketDTO(bucket, groupName, groupIndex.Int(), bucketIndex.Int())
+			dto, ok := antigravityBucketDTO(bucket, groupName, groupDescription, groupIndex.Int(), bucketIndex.Int())
 			if !ok {
 				return true
 			}
@@ -322,7 +323,7 @@ func parseAntigravityQuotaSummary(body []byte) []usage.QuotaWindowDTO {
 	return out
 }
 
-func antigravityBucketDTO(bucket gjson.Result, groupName string, groupIndex, bucketIndex int64) (usage.QuotaWindowDTO, bool) {
+func antigravityBucketDTO(bucket gjson.Result, groupName, groupDescription string, groupIndex, bucketIndex int64) (usage.QuotaWindowDTO, bool) {
 	fraction := firstJSONResult(bucket, "remainingFraction", "remaining_fraction", "remaining")
 	resetAt := parseFlexibleTime(firstJSONResult(bucket, "resetTime", "reset_time"))
 	if !fraction.Exists() && resetAt == nil {
@@ -343,7 +344,8 @@ func antigravityBucketDTO(bucket gjson.Result, groupName string, groupIndex, buc
 
 	dto := usage.QuotaWindowDTO{
 		QuotaKey:      "antigravity:" + key,
-		QuotaLabel:    antigravityBucketLabel(bucket, groupName, bucketID, window),
+		QuotaLabel:    antigravityGroupLabel(groupName, bucketID, window),
+		Meta:          antigravityBucketMeta(bucket, groupDescription),
 		ResetAt:       resetAt,
 		WindowSeconds: windowSeconds,
 	}
@@ -356,26 +358,35 @@ func antigravityBucketDTO(bucket gjson.Result, groupName string, groupIndex, buc
 	return dto, true
 }
 
-// antigravityBucketLabel keeps the upstream's own wording. Translating it here
-// would mean maintaining a table of names the upstream is free to change.
-func antigravityBucketLabel(bucket gjson.Result, groupName, bucketID, window string) string {
-	if name := strings.TrimSpace(firstJSONResult(bucket, "displayName", "display_name").String()); name != "" {
-		if groupName != "" && !strings.EqualFold(name, groupName) {
-			return groupName + " · " + name
+// antigravityGroupLabel names the row after the model group only.
+//
+// The upstream also names the bucket ("Weekly Limit Remaining"), and pairing
+// that with the group produced labels like
+// "Gemini Models · Weekly Limit Remaining" — too long for a card row, and
+// redundant once the window is rendered from WindowSeconds. The card composes
+// "<group> · <localised window>" itself, so the group name is all this has to
+// carry, and it still comes from the upstream rather than a table here.
+func antigravityGroupLabel(groupName, bucketID, window string) string {
+	if groupName != "" {
+		return groupName
+	}
+	if bucketID != "" {
+		return bucketID
+	}
+	return window
+}
+
+// antigravityBucketMeta carries the upstream's own explanation of the group —
+// typically which models draw on it. The card keeps it out of the row and shows
+// it on hover, so a long sentence cannot crowd out the numbers.
+func antigravityBucketMeta(bucket gjson.Result, groupDescription string) string {
+	if description := strings.TrimSpace(firstJSONResult(bucket, "description").String()); description != "" {
+		if groupDescription != "" && !strings.EqualFold(description, groupDescription) {
+			return groupDescription + " · " + description
 		}
-		return name
+		return description
 	}
-	label := groupName
-	if label == "" {
-		label = bucketID
-	}
-	if label == "" {
-		return window
-	}
-	if window != "" {
-		return label + " · " + window
-	}
-	return label
+	return groupDescription
 }
 
 // antigravityWindowSeconds maps the upstream's window token onto a duration.

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -344,8 +344,14 @@ func TestParseAntigravityQuotaSummaryUsesUpstreamGrouping(t *testing.T) {
 	if fiveHour.WindowSeconds != antigravityWindowFiveHour {
 		t.Fatalf("gemini 5h window=%d", fiveHour.WindowSeconds)
 	}
-	if fiveHour.QuotaLabel != "Gemini Models · 5h" {
-		t.Fatalf("gemini 5h label=%q", fiveHour.QuotaLabel)
+	// The row is named after the group only; the window is rendered from
+	// WindowSeconds, and the upstream's bucket wording would make the label too
+	// long for a card row.
+	if fiveHour.QuotaLabel != "Gemini Models" {
+		t.Fatalf("gemini 5h label=%q, want the group name alone", fiveHour.QuotaLabel)
+	}
+	if fiveHour.Meta != "Gemini family" {
+		t.Fatalf("gemini 5h meta=%q, want the group description", fiveHour.Meta)
 	}
 
 	weekly := quotaByKey(items, "antigravity:gemini_weekly")
@@ -601,5 +607,38 @@ func TestWeeklyUsedFromQuotasKeepsExactMatchForKeyedProviders(t *testing.T) {
 	}
 	if missing := weeklyUsedFromQuotas(quotas, "seven_day"); missing != nil {
 		t.Fatalf("used=%v, want nil when the declared key is absent", missing)
+	}
+}
+
+// The card composes "<group> · <window>" itself, so the label must carry the
+// group name alone. Pairing it with the upstream's bucket wording produced
+// "Gemini Models · Weekly Limit Remaining", which is too long for a card row
+// and cannot be localised.
+func TestParseAntigravityQuotaSummaryLabelsRowsByGroupOnly(t *testing.T) {
+	body := []byte(`{"groups":[
+		{"displayName":"Gemini Models","description":"Models within this group: Gemini Flash, Gemini Pro","buckets":[
+			{"bucketId":"gemini-weekly","window":"weekly","remainingFraction":0.51,"displayName":"Weekly Limit Remaining"},
+			{"bucketId":"gemini-5h","window":"5h","remainingFraction":0.72,"displayName":"Five Hour Limit Remaining","description":"Quota available"}
+		]}
+	]}`)
+	items := parseAntigravityQuotaSummary(body)
+	if len(items) != 2 {
+		t.Fatalf("items=%d, want 2: %+v", len(items), items)
+	}
+	for _, item := range items {
+		if item.QuotaLabel != "Gemini Models" {
+			t.Fatalf("label=%q, want the group name alone", item.QuotaLabel)
+		}
+	}
+
+	weekly := quotaByKey(items, "antigravity:gemini_weekly")
+	if weekly == nil || weekly.Meta != "Models within this group: Gemini Flash, Gemini Pro" {
+		t.Fatalf("weekly meta=%+v, want the group description", weekly)
+	}
+	// A bucket that describes itself gets both, so the hint says which models
+	// the group covers and what state this particular window is in.
+	fiveHour := quotaByKey(items, "antigravity:gemini_5h")
+	if fiveHour == nil || fiveHour.Meta != "Models within this group: Gemini Flash, Gemini Pro · Quota available" {
+		t.Fatalf("5h meta=%+v, want group and bucket descriptions joined", fiveHour)
 	}
 }


### PR DESCRIPTION
Backend half of showing both Antigravity quota windows the way the upstream client does. Pairs with codeProxy — **merge this first**, see below.

## The problem

The row label joined the group name to the upstream's bucket wording:

```
Gemini Models · Weekly Limit Remaining
```

Too long for a card row, and being upstream prose it could not be localised — the card showed an English sentence where every other provider shows a short localised label.

## The change

- **Label carries the group name alone.** The window is already in `WindowSeconds`, so the card can render it in the operator's language and compose `<group> · <window>` itself.
- **The upstream's description moves into `Meta`**, joined with the bucket's own description when the two differ. The card puts it behind a hint icon instead of printing it, so a full sentence cannot crowd out the numbers.

Nothing here decides presentation: the group name and both descriptions are the upstream's own strings, and the window is a duration rather than a phrase.

## Merge order

New backend + old panel would render two rows both labelled "Gemini Models" with nothing to tell them apart. Old backend + new panel degrades safely — the rows keep their existing labels and simply do not group.

So: merge this, then the codeProxy PR. Both deploy in minutes, and the intermediate state is only reachable in the gap between them.

## Verification

`go build ./...` and `gofmt` clean; full `go test ./...` green. New test pins that every row in a group is labelled with the group name alone, and that a bucket describing itself contributes to the hint alongside the group description.

Still not verifiable against production: the host has no antigravity accounts (`ai_account_status` holds only xai, codex and claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)