### PR TITLE
fix(antigravity): group fallback quotas by the bucket models share

### DIFF
--- a/internal/management/aiaccountstatus/probe_antigravity.go
+++ b/internal/management/aiaccountstatus/probe_antigravity.go
@@ -443,11 +443,22 @@ func parseAntigravityHourToken(value string) int64 {
 	return 0
 }
 
-// parseAntigravityModels is the fallback view built from fetchAvailableModels.
-// It carries only the 5h window, and the upstream does not group the models, so
-// we classify them by shape. Anything we cannot classify is still reported under
-// its own id: a model list is a moving target, and a model missing from a
-// hand-written table used to vanish from the card entirely.
+// parseAntigravityModels is the fallback view built from fetchAvailableModels,
+// used when the account cannot read the grouped summary.
+//
+// Models are grouped by the quota they actually draw on, which the payload
+// states directly: models sharing a bucket report the same resetTime and the
+// same remainingFraction. Nothing here classifies by model name.
+//
+// That distinction is the whole point. A previous version grouped by model
+// family — "Gemini Pro", "Gemini Flash", "Claude" — and the real buckets do not
+// follow family lines at all. On a live account the buckets split by generation:
+// nineteen models including claude-sonnet-4-6, gpt-oss-120b-medium and the whole
+// gemini-3.x line share one weekly bucket, while gemini-2.5-* sit in a separate
+// 5h one. Family grouping therefore drew one shared quota as five independent
+// bars, and worse, put gemini-2.5-pro and gemini-3.1-pro-high on the same row
+// while they belong to different buckets — the row then reported the minimum of
+// two unrelated quotas, a number matching neither.
 func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 	root := gjson.ParseBytes(body)
 	models := root.Get("models")
@@ -458,8 +469,8 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		return nil
 	}
 
-	grouped := make(map[string]*antigravityModelGroup, 8)
-	keys := make([]string, 0, 8)
+	buckets := make(map[string]*antigravityModelBucket, 4)
+	order := make([]string, 0, 4)
 
 	models.ForEach(func(modelID, model gjson.Result) bool {
 		id := normalizeAntigravityModelID(modelID.String())
@@ -468,86 +479,79 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		}
 		info := firstJSONResult(model, "quotaInfo", "quota_info")
 		fraction := firstJSONResult(info, "remainingFraction", "remaining_fraction", "remaining")
+		resetRaw := strings.TrimSpace(firstJSONResult(info, "resetTime", "reset_time").String())
 		resetAt := parseFlexibleTime(firstJSONResult(info, "resetTime", "reset_time"))
 		if !fraction.Exists() && resetAt == nil {
 			return true
 		}
 
-		category := categorizeAntigravityModel(id)
-		key := category
-		label := antigravityCategoryLabel(category)
-		if category == antigravityCategoryOther {
-			key = "model_" + normalizeQuotaKeyPart(id)
-			label = strings.TrimSpace(firstJSONResult(model, "displayName", "display_name").String())
-			if label == "" {
-				label = id
-			}
-		}
-
-		current := grouped[key]
-		if current == nil {
-			current = &antigravityModelGroup{label: label}
-			grouped[key] = current
-			keys = append(keys, key)
-		}
-		current.count++
+		var percent *float64
 		if fraction.Exists() {
 			if value := quotaFraction(fraction); value != nil {
 				remaining := math.Round(clampPct(*value * 100))
-				if current.percent == nil || remaining < *current.percent {
-					current.percent = &remaining
-				}
+				percent = &remaining
 			}
 		}
-		if resetAt != nil && (current.resetAt == nil || resetAt.Before(*current.resetAt)) {
-			current.resetAt = resetAt
+
+		// Reset instant plus remaining fraction identifies the bucket. Pairing
+		// the two is deliberately conservative: two buckets that happen to reset
+		// together stay separate as soon as their usage differs, whereas keying
+		// on the reset alone would merge them and invent a shared quota.
+		percentKey := "none"
+		if percent != nil {
+			percentKey = strconv.FormatFloat(*percent, 'f', -1, 64)
 		}
+		bucketKey := resetRaw + "|" + percentKey
+
+		current := buckets[bucketKey]
+		if current == nil {
+			current = &antigravityModelBucket{percent: percent, resetAt: resetAt}
+			buckets[bucketKey] = current
+			order = append(order, bucketKey)
+		}
+		current.models = append(current.models, id)
 		return true
 	})
 
-	// Ranked so the well-known families lead and the unclassified models trail
-	// them, rather than surfacing in Go's randomized map order.
-	sort.SliceStable(keys, func(i, j int) bool {
-		return antigravityCategoryRank(keys[i]) < antigravityCategoryRank(keys[j])
-	})
-
-	out := make([]usage.QuotaWindowDTO, 0, len(keys))
-	for _, key := range keys {
-		value := grouped[key]
-		if value == nil || value.count == 0 {
+	out := make([]usage.QuotaWindowDTO, 0, len(order))
+	for _, bucketKey := range order {
+		bucket := buckets[bucketKey]
+		if bucket == nil || len(bucket.models) == 0 {
 			continue
 		}
+		sort.Strings(bucket.models)
 		out = append(out, usage.QuotaWindowDTO{
-			QuotaKey:      "antigravity:" + key,
-			QuotaLabel:    value.label,
-			Percent:       value.percent,
-			ResetAt:       value.resetAt,
-			WindowSeconds: antigravityWindowFiveHour,
+			// Named after the first model in the bucket so the key survives the
+			// reset that changes resetTime every cycle.
+			QuotaKey: "antigravity:group_" + normalizeQuotaKeyPart(bucket.models[0]),
+			// The card counts the models and renders the phrase; sending a
+			// sentence from here could not be localised.
+			QuotaLabel: antigravitySharedGroupLabel,
+			Meta:       strings.Join(bucket.models, ","),
+			Percent:    bucket.percent,
+			ResetAt:    bucket.resetAt,
 		})
 	}
+
+	// Soonest reset first: the bucket about to run out is the one worth reading.
+	sort.SliceStable(out, func(i, j int) bool {
+		left, right := out[i].ResetAt, out[j].ResetAt
+		if left == nil || right == nil {
+			return right != nil
+		}
+		return left.Before(*right)
+	})
 	return out
 }
 
-type antigravityModelGroup struct {
-	label   string
+// antigravitySharedGroupLabel tells the card to name the row after how many
+// models draw on the bucket. The count lives in Meta, which carries the ids.
+const antigravitySharedGroupLabel = "antigravity_quota.shared_group"
+
+type antigravityModelBucket struct {
+	models  []string
 	percent *float64
 	resetAt *time.Time
-	count   int
-}
-
-func antigravityCategoryRank(key string) int {
-	switch key {
-	case antigravityCategoryGeminiPro:
-		return 0
-	case antigravityCategoryGeminiFlash:
-		return 1
-	case antigravityCategoryGeminiImage:
-		return 2
-	case antigravityCategoryClaude:
-		return 3
-	default:
-		return 4
-	}
 }
 
 func normalizeAntigravityModelID(raw string) string {
@@ -560,52 +564,6 @@ func normalizeAntigravityModelID(raw string) string {
 // does not surface as a user-visible quota row.
 func isAntigravityInternalModel(id string) bool {
 	return strings.HasPrefix(id, "chat_") || strings.HasPrefix(id, "tab_")
-}
-
-const (
-	antigravityCategoryGeminiPro   = "gemini_pro"
-	antigravityCategoryGeminiFlash = "gemini_flash"
-	antigravityCategoryGeminiImage = "gemini_image"
-	antigravityCategoryClaude      = "claude"
-	antigravityCategoryOther       = "other"
-)
-
-// categorizeAntigravityModel groups a model by the shape of its id instead of by
-// membership in a list. A list has to be edited every time the upstream ships a
-// model; the shapes below already cover the ones that do not exist yet.
-func categorizeAntigravityModel(id string) string {
-	switch {
-	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "image"),
-		strings.HasPrefix(id, "image"),
-		strings.HasPrefix(id, "imagen"):
-		return antigravityCategoryGeminiImage
-	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "flash"):
-		return antigravityCategoryGeminiFlash
-	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "pro"):
-		return antigravityCategoryGeminiPro
-	case strings.Contains(id, "claude"),
-		strings.Contains(id, "opus"),
-		strings.Contains(id, "sonnet"),
-		strings.Contains(id, "haiku"):
-		return antigravityCategoryClaude
-	default:
-		return antigravityCategoryOther
-	}
-}
-
-func antigravityCategoryLabel(category string) string {
-	switch category {
-	case antigravityCategoryGeminiPro:
-		return "Gemini Pro"
-	case antigravityCategoryGeminiFlash:
-		return "Gemini Flash"
-	case antigravityCategoryGeminiImage:
-		return "Gemini Image"
-	case antigravityCategoryClaude:
-		return "Claude"
-	default:
-		return ""
-	}
 }
 
 func stringSet(values ...string) map[string]struct{} {

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -274,47 +273,83 @@ func TestResolveXAIPlanUsesEntitlementWhenMonthlyLimitIsZero(t *testing.T) {
 	}
 }
 
-func TestParseAntigravityModelsSummarizesWorstRemainingAndEarliestReset(t *testing.T) {
+// Models sharing a bucket report the same reset and the same remaining
+// fraction. Grouping on those two values reproduces the account's real quota
+// structure; grouping by model family does not, and this payload is the shape
+// a live account actually returns — claude, gpt-oss and gemini-3.x on one
+// weekly bucket, gemini-2.5-* on a separate 5h one.
+func TestParseAntigravityModelsGroupsByTheQuotaModelsShare(t *testing.T) {
 	body := []byte(`{"models":{
-		"gemini-3-pro-high":{"quotaInfo":{"remainingFraction":0.8,"resetTime":"2026-07-20T00:00:00Z"}},
-		"gemini-3.1-pro-low":{"quota_info":{"remaining_fraction":0.4,"reset_time":"2026-07-19T00:00:00Z"}}
+		"claude-sonnet-4-6":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
+		"gpt-oss-120b-medium":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
+		"gemini-3.1-pro-high":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
+		"gemini-2.5-pro":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-20T20:17:11Z"}},
+		"gemini-2.5-flash":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-20T20:17:11Z"}},
+		"chat_20706":{"quotaInfo":{"remainingFraction":1}}
 	}}`)
 	items := parseAntigravityModels(body)
-	pro := quotaByKey(items, "antigravity:gemini_pro")
-	if pro == nil || pro.Percent == nil || *pro.Percent != 40 || pro.ResetAt == nil || pro.ResetAt.Format(time.RFC3339) != "2026-07-19T00:00:00Z" {
-		t.Fatalf("pro=%+v", pro)
+	if len(items) != 2 {
+		t.Fatalf("buckets=%d, want 2: %+v", len(items), items)
 	}
-	if pro.WindowSeconds != antigravityWindowFiveHour {
-		t.Fatalf("window=%d, want %d", pro.WindowSeconds, antigravityWindowFiveHour)
+
+	// Soonest reset first: the bucket about to run out is the one worth reading.
+	if items[0].ResetAt == nil || items[0].ResetAt.Format(time.RFC3339) != "2026-08-20T20:17:11Z" {
+		t.Fatalf("first bucket reset=%v, want the 5h one", items[0].ResetAt)
+	}
+
+	shortWindow := items[0]
+	if shortWindow.Meta != "gemini-2.5-flash,gemini-2.5-pro" {
+		t.Fatalf("5h bucket members=%q", shortWindow.Meta)
+	}
+	if shortWindow.QuotaKey != "antigravity:group_gemini_2_5_flash" {
+		t.Fatalf("5h bucket key=%q, want it named after its first model", shortWindow.QuotaKey)
+	}
+
+	weekly := items[1]
+	if weekly.Meta != "claude-sonnet-4-6,gemini-3.1-pro-high,gpt-oss-120b-medium" {
+		t.Fatalf("weekly bucket members=%q, want claude, gemini and gpt-oss together", weekly.Meta)
+	}
+
+	// The card counts the members and renders the phrase, so the label is a key
+	// rather than a sentence that could not be localised.
+	for _, item := range items {
+		if item.QuotaLabel != antigravitySharedGroupLabel {
+			t.Fatalf("label=%q, want %q", item.QuotaLabel, antigravitySharedGroupLabel)
+		}
+		if item.Percent == nil || *item.Percent != 100 {
+			t.Fatalf("percent=%+v", item.Percent)
+		}
 	}
 }
 
-// A model the upstream ships after this code was written must still reach the
-// card. The previous grouping dropped anything missing from a hand-written id
-// list, so a new model family silently rendered as nothing at all.
-func TestParseAntigravityModelsKeepsUnknownModels(t *testing.T) {
+// Two buckets that reset at the same instant but differ in usage must stay
+// apart. Keying on the reset alone would merge them and report a shared quota
+// that does not exist.
+func TestParseAntigravityModelsKeepsBucketsWithDifferentUsageApart(t *testing.T) {
 	body := []byte(`{"models":{
-		"gemini-9-ultra":{"quotaInfo":{"remainingFraction":0.5},"displayName":"Gemini 9 Ultra"},
-		"grok-5-fast":{"quotaInfo":{"remainingFraction":0.25},"displayName":"Grok 5 Fast"},
-		"chat_20706":{"quotaInfo":{"remainingFraction":0.9}},
-		"tab_flash_lite_preview":{"quotaInfo":{"remainingFraction":0.9}}
+		"model-a":{"quotaInfo":{"remainingFraction":0.4,"resetTime":"2026-08-27T15:17:11Z"}},
+		"model-b":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}}
 	}}`)
 	items := parseAntigravityModels(body)
+	if len(items) != 2 {
+		t.Fatalf("buckets=%d, want 2 (same reset, different usage): %+v", len(items), items)
+	}
+}
 
-	// gemini-9-ultra has neither "flash" nor "pro" nor "image" in its id, so it
-	// lands in the unclassified bucket under its own name rather than vanishing.
-	ultra := quotaByKey(items, "antigravity:model_gemini_9_ultra")
-	if ultra == nil || ultra.Percent == nil || *ultra.Percent != 50 || ultra.QuotaLabel != "Gemini 9 Ultra" {
-		t.Fatalf("ultra=%+v", ultra)
+// A model the upstream ships after this code was written still reaches the
+// card: membership follows the quota it reports, so there is no list to miss.
+func TestParseAntigravityModelsKeepsUnknownModels(t *testing.T) {
+	body := []byte(`{"models":{
+		"gemini-9-ultra":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
+		"brand-new-model":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
+		"tab_flash_lite_preview":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}}
+	}}`)
+	items := parseAntigravityModels(body)
+	if len(items) != 1 {
+		t.Fatalf("buckets=%d, want 1: %+v", len(items), items)
 	}
-	grok := quotaByKey(items, "antigravity:model_grok_5_fast")
-	if grok == nil || grok.Percent == nil || *grok.Percent != 25 {
-		t.Fatalf("grok=%+v", grok)
-	}
-	for _, item := range items {
-		if strings.Contains(item.QuotaKey, "chat_") || strings.Contains(item.QuotaKey, "tab_") {
-			t.Fatalf("internal model leaked into quotas: %+v", item)
-		}
+	if items[0].Meta != "brand-new-model,gemini-9-ultra" {
+		t.Fatalf("members=%q, want both unknown models and no internal ones", items[0].Meta)
 	}
 }
 


### PR DESCRIPTION
Backend half. Pairs with codeProxy — **merge this first**.

## What the live account actually reports

Captured from `fetchAvailableModels` on a real account, grouped by `resetTime`:

| bucket | reset | models |
|---|---|---|
| A | **exactly 168.0 hours out** (weekly) | 19 — `claude-opus-4-6-thinking`, `claude-sonnet-4-6`, `gpt-oss-120b-medium`, `gemini-3-flash`, `gemini-3.1-pro-high/low`, `gemini-3.1-flash-image`, `gemini-3.5/3.6/3.7-flash-*`, `gemini-pro-agent` |
| B | ~5 hours out | 5 — `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.5-flash-thinking`, `gemini-2.5-pro`, `gemini-3.1-flash-lite` |

**The split is by generation, not by family.** Claude, GPT-OSS and Gemini 3.x share one weekly quota; Gemini 2.5 sits in its own 5h one.

## What the family grouping produced

The previous code grouped by "Gemini Pro" / "Gemini Flash" / "Gemini Image" / "Claude" / other. Against the data above that is wrong twice:

1. **One shared quota drawn as five independent bars.** Nothing on the card indicated that spending Gemini Pro also spends Claude.
2. **`gemini-2.5-pro` and `gemini-3.1-pro-high` landed on the same row** while belonging to *different buckets*. The row reported the minimum of two unrelated quotas — a number matching neither. Invisible while everything sits at 100%, wrong the moment usage diverges.

This is the same lesson as removing the hard-coded model list, one level up: I dropped the hard-coded *ids* but kept a hard-coded *grouping dimension*, and the real boundary never followed it.

## The change

Group by what the payload states: **same `resetTime` and same `remainingFraction` means the same bucket.**

Pairing the two is deliberately conservative. Buckets that happen to reset together stay separate as soon as their usage differs, whereas keying on the reset alone would merge them and invent a shared quota.

- **Key** is named after the bucket's first model, so it survives the reset that changes `resetTime` every cycle.
- **Members** travel in `Meta` for the card to count and list.
- **Order** is soonest-reset-first: the bucket about to run out is the one worth reading.
- The family classifier is **deleted**, not left unused — it encodes a grouping the data contradicts.

The grouped-summary path (`retrieveUserQuotaSummary`) is untouched; when an account can read it, the upstream's own groups and windows are used as before.

## Verification

`go build ./...`, `gofmt`, `go vet` clean; full `go test ./...` green. New tests pin the real bucket shape, that same-reset-different-usage stays split, and that a model shipped after this code still reaches the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)