### PR TITLE
fix(antigravity): show one representative model per family, not an aggregate

### DIFF
--- a/internal/management/aiaccountstatus/probe_antigravity.go
+++ b/internal/management/aiaccountstatus/probe_antigravity.go
@@ -446,19 +446,16 @@ func parseAntigravityHourToken(value string) int64 {
 // parseAntigravityModels is the fallback view built from fetchAvailableModels,
 // used when the account cannot read the grouped summary.
 //
-// Models are grouped by the quota they actually draw on, which the payload
-// states directly: models sharing a bucket report the same resetTime and the
-// same remainingFraction. Nothing here classifies by model name.
+// One row per model family, each showing a single representative model's real
+// quota. Picking a representative rather than aggregating the family matters:
+// on a live account gemini-2.5-pro and gemini-3.1-pro-high are both "Gemini
+// Pro" yet draw on different buckets, so folding them together produced the
+// minimum of two unrelated quotas — a number belonging to neither, and a reset
+// countdown from whichever bucket happened to expire first.
 //
-// That distinction is the whole point. A previous version grouped by model
-// family — "Gemini Pro", "Gemini Flash", "Claude" — and the real buckets do not
-// follow family lines at all. On a live account the buckets split by generation:
-// nineteen models including claude-sonnet-4-6, gpt-oss-120b-medium and the whole
-// gemini-3.x line share one weekly bucket, while gemini-2.5-* sit in a separate
-// 5h one. Family grouping therefore drew one shared quota as five independent
-// bars, and worse, put gemini-2.5-pro and gemini-3.1-pro-high on the same row
-// while they belong to different buckets — the row then reported the minimum of
-// two unrelated quotas, a number matching neither.
+// Preference order is a ranking, not an allowlist: a family with none of its
+// preferred ids still shows whichever member the upstream did send, so a model
+// shipped after this code cannot make a row disappear.
 func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 	root := gjson.ParseBytes(body)
 	models := root.Get("models")
@@ -469,8 +466,13 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		return nil
 	}
 
-	buckets := make(map[string]*antigravityModelBucket, 4)
-	order := make([]string, 0, 4)
+	type candidate struct {
+		id          string
+		displayName string
+		percent     *float64
+		resetAt     *time.Time
+	}
+	families := make(map[string][]candidate, 8)
 
 	models.ForEach(func(modelID, model gjson.Result) bool {
 		id := normalizeAntigravityModelID(modelID.String())
@@ -479,12 +481,10 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		}
 		info := firstJSONResult(model, "quotaInfo", "quota_info")
 		fraction := firstJSONResult(info, "remainingFraction", "remaining_fraction", "remaining")
-		resetRaw := strings.TrimSpace(firstJSONResult(info, "resetTime", "reset_time").String())
 		resetAt := parseFlexibleTime(firstJSONResult(info, "resetTime", "reset_time"))
 		if !fraction.Exists() && resetAt == nil {
 			return true
 		}
-
 		var percent *float64
 		if fraction.Exists() {
 			if value := quotaFraction(fraction); value != nil {
@@ -492,66 +492,140 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 				percent = &remaining
 			}
 		}
-
-		// Reset instant plus remaining fraction identifies the bucket. Pairing
-		// the two is deliberately conservative: two buckets that happen to reset
-		// together stay separate as soon as their usage differs, whereas keying
-		// on the reset alone would merge them and invent a shared quota.
-		percentKey := "none"
-		if percent != nil {
-			percentKey = strconv.FormatFloat(*percent, 'f', -1, 64)
-		}
-		bucketKey := resetRaw + "|" + percentKey
-
-		current := buckets[bucketKey]
-		if current == nil {
-			current = &antigravityModelBucket{percent: percent, resetAt: resetAt}
-			buckets[bucketKey] = current
-			order = append(order, bucketKey)
-		}
-		current.models = append(current.models, id)
+		family := categorizeAntigravityModel(id)
+		families[family] = append(families[family], candidate{
+			id:          id,
+			displayName: strings.TrimSpace(firstJSONResult(model, "displayName", "display_name").String()),
+			percent:     percent,
+			resetAt:     resetAt,
+		})
 		return true
 	})
 
-	out := make([]usage.QuotaWindowDTO, 0, len(order))
-	for _, bucketKey := range order {
-		bucket := buckets[bucketKey]
-		if bucket == nil || len(bucket.models) == 0 {
+	out := make([]usage.QuotaWindowDTO, 0, len(families))
+	for _, family := range antigravityFamilyOrder {
+		members := families[family]
+		if len(members) == 0 {
 			continue
 		}
-		sort.Strings(bucket.models)
+		sort.SliceStable(members, func(i, j int) bool {
+			return antigravityPreferenceRank(family, members[i].id) < antigravityPreferenceRank(family, members[j].id)
+		})
+		chosen := members[0]
+		label := antigravityFamilyLabel(family)
+		if family == antigravityCategoryOther {
+			label = chosen.displayName
+			if label == "" {
+				label = chosen.id
+			}
+		}
 		out = append(out, usage.QuotaWindowDTO{
-			// Named after the first model in the bucket so the key survives the
-			// reset that changes resetTime every cycle.
-			QuotaKey: "antigravity:group_" + normalizeQuotaKeyPart(bucket.models[0]),
-			// The card counts the models and renders the phrase; sending a
-			// sentence from here could not be localised.
-			QuotaLabel: antigravitySharedGroupLabel,
-			Meta:       strings.Join(bucket.models, ","),
-			Percent:    bucket.percent,
-			ResetAt:    bucket.resetAt,
+			QuotaKey:      "antigravity:" + family,
+			QuotaLabel:    label,
+			Percent:       chosen.percent,
+			ResetAt:       chosen.resetAt,
+			WindowSeconds: antigravityWindowFiveHour,
+			// The row shows one model's quota; naming it lets the card explain
+			// which, instead of implying the whole family was measured.
+			Meta: chosen.id,
 		})
 	}
 
-	// Soonest reset first: the bucket about to run out is the one worth reading.
-	sort.SliceStable(out, func(i, j int) bool {
-		left, right := out[i].ResetAt, out[j].ResetAt
-		if left == nil || right == nil {
-			return right != nil
+	// "other" collapses every unclassified model onto one row, so emit each of
+	// them instead: they are unrelated models that merely failed classification.
+	if extras := families[antigravityCategoryOther]; len(extras) > 1 {
+		out = out[:len(out)-1]
+		sort.SliceStable(extras, func(i, j int) bool { return extras[i].id < extras[j].id })
+		for _, extra := range extras {
+			label := extra.displayName
+			if label == "" {
+				label = extra.id
+			}
+			out = append(out, usage.QuotaWindowDTO{
+				QuotaKey:      "antigravity:model_" + normalizeQuotaKeyPart(extra.id),
+				QuotaLabel:    label,
+				Percent:       extra.percent,
+				ResetAt:       extra.resetAt,
+				WindowSeconds: antigravityWindowFiveHour,
+				Meta:          extra.id,
+			})
 		}
-		return left.Before(*right)
-	})
+	}
 	return out
 }
 
-// antigravitySharedGroupLabel tells the card to name the row after how many
-// models draw on the bucket. The count lives in Meta, which carries the ids.
-const antigravitySharedGroupLabel = "antigravity_quota.shared_group"
+const (
+	antigravityCategoryGeminiPro   = "gemini_pro"
+	antigravityCategoryGeminiFlash = "gemini_flash"
+	antigravityCategoryGeminiImage = "gemini_image"
+	antigravityCategoryClaude      = "claude"
+	antigravityCategoryOther       = "other"
+)
 
-type antigravityModelBucket struct {
-	models  []string
-	percent *float64
-	resetAt *time.Time
+var antigravityFamilyOrder = []string{
+	antigravityCategoryGeminiPro,
+	antigravityCategoryGeminiFlash,
+	antigravityCategoryGeminiImage,
+	antigravityCategoryClaude,
+	antigravityCategoryOther,
+}
+
+// antigravityPreferences ranks which member best represents its family — the
+// agent-facing model an operator actually spends. Absent ids simply rank last,
+// so this never decides whether a row exists.
+var antigravityPreferences = map[string][]string{
+	antigravityCategoryGeminiPro:   {"gemini-pro-agent", "gemini-3.1-pro-high", "gemini-3.1-pro-low"},
+	antigravityCategoryGeminiFlash: {"gemini-3-flash-agent", "gemini-3-flash"},
+	antigravityCategoryGeminiImage: {"gemini-3.1-flash-image", "gemini-3-pro-image"},
+	antigravityCategoryClaude:      {"claude-sonnet-4-6", "claude-opus-4-6-thinking"},
+}
+
+func antigravityPreferenceRank(family, id string) int {
+	for index, preferred := range antigravityPreferences[family] {
+		if preferred == id {
+			return index
+		}
+	}
+	// Unpreferred members keep upstream order behind the preferred ones.
+	return len(antigravityPreferences[family]) + 1
+}
+
+// categorizeAntigravityModel groups a model by the shape of its id instead of by
+// membership in a list, so a model that does not exist yet still lands in the
+// right family.
+func categorizeAntigravityModel(id string) string {
+	switch {
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "image"),
+		strings.HasPrefix(id, "image"),
+		strings.HasPrefix(id, "imagen"):
+		return antigravityCategoryGeminiImage
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "flash"):
+		return antigravityCategoryGeminiFlash
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "pro"):
+		return antigravityCategoryGeminiPro
+	case strings.Contains(id, "claude"),
+		strings.Contains(id, "opus"),
+		strings.Contains(id, "sonnet"),
+		strings.Contains(id, "haiku"):
+		return antigravityCategoryClaude
+	default:
+		return antigravityCategoryOther
+	}
+}
+
+func antigravityFamilyLabel(family string) string {
+	switch family {
+	case antigravityCategoryGeminiPro:
+		return "Gemini Pro"
+	case antigravityCategoryGeminiFlash:
+		return "Gemini Flash"
+	case antigravityCategoryGeminiImage:
+		return "Gemini Image"
+	case antigravityCategoryClaude:
+		return "Claude"
+	default:
+		return ""
+	}
 }
 
 func normalizeAntigravityModelID(raw string) string {

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -273,83 +274,77 @@ func TestResolveXAIPlanUsesEntitlementWhenMonthlyLimitIsZero(t *testing.T) {
 	}
 }
 
-// Models sharing a bucket report the same reset and the same remaining
-// fraction. Grouping on those two values reproduces the account's real quota
-// structure; grouping by model family does not, and this payload is the shape
-// a live account actually returns — claude, gpt-oss and gemini-3.x on one
-// weekly bucket, gemini-2.5-* on a separate 5h one.
-func TestParseAntigravityModelsGroupsByTheQuotaModelsShare(t *testing.T) {
+// One row per family, each carrying a single representative model's real quota.
+//
+// gemini-2.5-pro and gemini-3.1-pro-high are both "Gemini Pro" yet draw on
+// different buckets — captured from a live account, where gemini-3.x resets
+// weekly and gemini-2.5-* on a 5h cycle. Aggregating them reported the minimum
+// of two unrelated quotas with a countdown from the wrong one; picking the
+// preferred member reports something that is actually true of a model.
+func TestParseAntigravityModelsPicksOneRepresentativePerFamily(t *testing.T) {
 	body := []byte(`{"models":{
-		"claude-sonnet-4-6":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
-		"gpt-oss-120b-medium":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
-		"gemini-3.1-pro-high":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
-		"gemini-2.5-pro":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-20T20:17:11Z"}},
-		"gemini-2.5-flash":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-20T20:17:11Z"}},
+		"gemini-3.1-pro-high":{"quotaInfo":{"remainingFraction":0.8,"resetTime":"2026-08-27T15:17:11Z"}},
+		"gemini-2.5-pro":{"quotaInfo":{"remainingFraction":0.1,"resetTime":"2026-08-20T20:17:11Z"}},
+		"gemini-3-flash-agent":{"quotaInfo":{"remainingFraction":0.6,"resetTime":"2026-08-27T15:17:11Z"}},
+		"claude-sonnet-4-6":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}},
 		"chat_20706":{"quotaInfo":{"remainingFraction":1}}
 	}}`)
 	items := parseAntigravityModels(body)
-	if len(items) != 2 {
-		t.Fatalf("buckets=%d, want 2: %+v", len(items), items)
+
+	pro := quotaByKey(items, "antigravity:gemini_pro")
+	if pro == nil || pro.Percent == nil || *pro.Percent != 80 {
+		t.Fatalf("pro=%+v, want the preferred gemini-3.1-pro-high at 80", pro)
+	}
+	if pro.Meta != "gemini-3.1-pro-high" {
+		t.Fatalf("pro represented by %q", pro.Meta)
+	}
+	// The 2.5 model's 10% must not leak into the row: different bucket.
+	if pro.ResetAt == nil || pro.ResetAt.Format(time.RFC3339) != "2026-08-27T15:17:11Z" {
+		t.Fatalf("pro reset=%v, want the represented model's own reset", pro.ResetAt)
 	}
 
-	// Soonest reset first: the bucket about to run out is the one worth reading.
-	if items[0].ResetAt == nil || items[0].ResetAt.Format(time.RFC3339) != "2026-08-20T20:17:11Z" {
-		t.Fatalf("first bucket reset=%v, want the 5h one", items[0].ResetAt)
+	flash := quotaByKey(items, "antigravity:gemini_flash")
+	if flash == nil || flash.Percent == nil || *flash.Percent != 60 {
+		t.Fatalf("flash=%+v", flash)
 	}
-
-	shortWindow := items[0]
-	if shortWindow.Meta != "gemini-2.5-flash,gemini-2.5-pro" {
-		t.Fatalf("5h bucket members=%q", shortWindow.Meta)
+	claude := quotaByKey(items, "antigravity:claude")
+	if claude == nil || claude.Percent == nil || *claude.Percent != 90 {
+		t.Fatalf("claude=%+v", claude)
 	}
-	if shortWindow.QuotaKey != "antigravity:group_gemini_2_5_flash" {
-		t.Fatalf("5h bucket key=%q, want it named after its first model", shortWindow.QuotaKey)
-	}
-
-	weekly := items[1]
-	if weekly.Meta != "claude-sonnet-4-6,gemini-3.1-pro-high,gpt-oss-120b-medium" {
-		t.Fatalf("weekly bucket members=%q, want claude, gemini and gpt-oss together", weekly.Meta)
-	}
-
-	// The card counts the members and renders the phrase, so the label is a key
-	// rather than a sentence that could not be localised.
 	for _, item := range items {
-		if item.QuotaLabel != antigravitySharedGroupLabel {
-			t.Fatalf("label=%q, want %q", item.QuotaLabel, antigravitySharedGroupLabel)
-		}
-		if item.Percent == nil || *item.Percent != 100 {
-			t.Fatalf("percent=%+v", item.Percent)
+		if strings.Contains(item.QuotaKey, "chat_") {
+			t.Fatalf("internal model leaked: %+v", item)
 		}
 	}
 }
 
-// Two buckets that reset at the same instant but differ in usage must stay
-// apart. Keying on the reset alone would merge them and report a shared quota
-// that does not exist.
-func TestParseAntigravityModelsKeepsBucketsWithDifferentUsageApart(t *testing.T) {
+// Preference is a ranking, not an allowlist: a family whose preferred ids are
+// all absent still shows the member the upstream did send.
+func TestParseAntigravityModelsFallsBackToAnyFamilyMember(t *testing.T) {
 	body := []byte(`{"models":{
-		"model-a":{"quotaInfo":{"remainingFraction":0.4,"resetTime":"2026-08-27T15:17:11Z"}},
-		"model-b":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}}
+		"gemini-9-pro-experimental":{"quotaInfo":{"remainingFraction":0.45,"resetTime":"2026-08-27T15:17:11Z"}}
 	}}`)
-	items := parseAntigravityModels(body)
-	if len(items) != 2 {
-		t.Fatalf("buckets=%d, want 2 (same reset, different usage): %+v", len(items), items)
+	pro := quotaByKey(parseAntigravityModels(body), "antigravity:gemini_pro")
+	if pro == nil || pro.Percent == nil || *pro.Percent != 45 {
+		t.Fatalf("pro=%+v, want the only member of the family", pro)
 	}
 }
 
-// A model the upstream ships after this code was written still reaches the
-// card: membership follows the quota it reports, so there is no list to miss.
-func TestParseAntigravityModelsKeepsUnknownModels(t *testing.T) {
+// Unclassified models are unrelated to each other, so each gets its own row
+// under its own name rather than being collapsed into one "other" bar.
+func TestParseAntigravityModelsGivesUnclassifiedModelsTheirOwnRows(t *testing.T) {
 	body := []byte(`{"models":{
-		"gemini-9-ultra":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
-		"brand-new-model":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
-		"tab_flash_lite_preview":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}}
+		"gpt-oss-120b-medium":{"displayName":"GPT-OSS 120B (Medium)","quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
+		"grok-5-fast":{"displayName":"Grok 5 Fast","quotaInfo":{"remainingFraction":0.25,"resetTime":"2026-08-27T15:17:11Z"}}
 	}}`)
 	items := parseAntigravityModels(body)
-	if len(items) != 1 {
-		t.Fatalf("buckets=%d, want 1: %+v", len(items), items)
+	gpt := quotaByKey(items, "antigravity:model_gpt_oss_120b_medium")
+	grok := quotaByKey(items, "antigravity:model_grok_5_fast")
+	if gpt == nil || gpt.QuotaLabel != "GPT-OSS 120B (Medium)" || gpt.Percent == nil || *gpt.Percent != 50 {
+		t.Fatalf("gpt=%+v", gpt)
 	}
-	if items[0].Meta != "brand-new-model,gemini-9-ultra" {
-		t.Fatalf("members=%q, want both unknown models and no internal ones", items[0].Meta)
+	if grok == nil || grok.Percent == nil || *grok.Percent != 25 {
+		t.Fatalf("grok=%+v", grok)
 	}
 }
 

--- a/internal/usage/ai_account_subject_status_store.go
+++ b/internal/usage/ai_account_subject_status_store.go
@@ -56,6 +56,25 @@ type AIAccountSubjectStatusRecord struct {
 // varies the order it reports windows in.
 func mergeQuotaWindows(previous, incoming []QuotaWindowDTO, observedAt time.Time) []QuotaWindowDTO {
 	observedAt = observedAt.UTC()
+	// A provider whose probe always returns the full picture gets replacement
+	// instead: carrying a window forward there can only preserve a key the
+	// provider has stopped using. Renaming antigravity's keys once left the card
+	// rendering both the old and the new set side by side for a whole retention
+	// window, which reads as duplicated quotas.
+	if len(incoming) > 0 && quotaPayloadIsCompleteSnapshot(incoming) {
+		replaced := make([]QuotaWindowDTO, 0, len(incoming))
+		for _, window := range incoming {
+			key := strings.TrimSpace(window.QuotaKey)
+			if key == "" {
+				continue
+			}
+			window.QuotaKey = key
+			stamp := observedAt
+			window.ObservedAt = &stamp
+			replaced = append(replaced, window)
+		}
+		return replaced
+	}
 	incomingByKey := make(map[string]QuotaWindowDTO, len(incoming))
 	incomingOrder := make([]string, 0, len(incoming))
 	for _, window := range incoming {
@@ -102,6 +121,23 @@ func mergeQuotaWindows(previous, incoming []QuotaWindowDTO, observedAt time.Time
 		merged = append(merged, incomingByKey[key])
 	}
 	return merged
+}
+
+// quotaPayloadIsCompleteSnapshot reports whether every window in the payload
+// comes from a provider that reports all of its windows on every probe.
+//
+// Codex is the counter-example this merge exists for: it answers with only
+// `rate_limit` or only `additional_rate_limits` on roughly a fifth of probes,
+// so a missing window there means "not mentioned", not "gone". Antigravity's
+// two endpoints each return the account's full quota set or nothing at all,
+// so a missing window genuinely means the provider dropped it.
+func quotaPayloadIsCompleteSnapshot(windows []QuotaWindowDTO) bool {
+	for _, window := range windows {
+		if !strings.HasPrefix(strings.TrimSpace(window.QuotaKey), "antigravity:") {
+			return false
+		}
+	}
+	return true
 }
 
 // applyQuotaObservedFallback fills per-window ObservedAt for rows written before

--- a/internal/usage/ai_account_subject_status_store_test.go
+++ b/internal/usage/ai_account_subject_status_store_test.go
@@ -174,3 +174,56 @@ func TestProbeFailureKeepsQuotaObservationTimeBehind(t *testing.T) {
 		t.Fatal("attempt time must be strictly newer than the quota it describes")
 	}
 }
+
+// Antigravity reports its whole quota set on every probe, so a key the payload
+// no longer contains is genuinely gone. Carrying it forward is what left the
+// card showing the old and the new key set side by side after a rename.
+func TestMergeQuotaWindowsReplacesCompleteSnapshots(t *testing.T) {
+	now := time.Now().UTC()
+	old := now.Add(-time.Hour)
+	pct := func(v float64) *float64 { return &v }
+	previous := []QuotaWindowDTO{
+		{QuotaKey: "antigravity:group_old_name", Percent: pct(10), ObservedAt: &old},
+	}
+	incoming := []QuotaWindowDTO{
+		{QuotaKey: "antigravity:gemini_pro", Percent: pct(80)},
+		{QuotaKey: "antigravity:claude", Percent: pct(90)},
+	}
+	merged := mergeQuotaWindows(previous, incoming, now)
+	if len(merged) != 2 {
+		t.Fatalf("merged=%d, want only the incoming snapshot: %+v", len(merged), merged)
+	}
+	for _, window := range merged {
+		if window.QuotaKey == "antigravity:group_old_name" {
+			t.Fatal("a key the provider stopped sending must not survive a full snapshot")
+		}
+		if window.ObservedAt == nil || !window.ObservedAt.Equal(now) {
+			t.Fatalf("window %q kept a stale timestamp", window.QuotaKey)
+		}
+	}
+}
+
+// Codex answers with a subset on roughly a fifth of probes, so a window missing
+// from one payload must keep its previous value and its original timestamp.
+func TestMergeQuotaWindowsStillCarriesPartialProvidersForward(t *testing.T) {
+	now := time.Now().UTC()
+	old := now.Add(-time.Hour)
+	pct := func(v float64) *float64 { return &v }
+	previous := []QuotaWindowDTO{
+		{QuotaKey: "code_week", Percent: pct(60), ObservedAt: &old},
+		{QuotaKey: "review_week", Percent: pct(70), ObservedAt: &old},
+	}
+	incoming := []QuotaWindowDTO{{QuotaKey: "code_week", Percent: pct(55)}}
+	merged := mergeQuotaWindows(previous, incoming, now)
+	if len(merged) != 2 {
+		t.Fatalf("merged=%d, want the unmentioned window carried forward: %+v", len(merged), merged)
+	}
+	for _, window := range merged {
+		if window.QuotaKey != "review_week" {
+			continue
+		}
+		if window.ObservedAt == nil || !window.ObservedAt.Equal(old) {
+			t.Fatal("a carried-forward window must keep its original timestamp")
+		}
+	}
+}


### PR DESCRIPTION
Backend half. Pairs with codeProxy — **merge this first**.

## The card was describing something no model experiences

Aggregating a family took the **minimum across its members**, but members do not share a bucket. Captured from the live account:

| model | family | resets |
|---|---|---|
| `gemini-3.1-pro-high` | Gemini Pro | weekly |
| `gemini-2.5-pro` | Gemini Pro | 5-hourly |

The row therefore reported the lower of two unrelated quotas, with a countdown from whichever expired first — **a pair of numbers true of neither model**. Invisible while everything sits at 100%, wrong the moment usage diverges.

## The change

Each family shows **one representative member's** real percentage and its own reset.

Preference order (`gemini-pro-agent` → `gemini-3.1-pro-high` → …) is a **ranking, not an allowlist**: a family with none of its preferred ids still shows whichever member the upstream sent, so a model shipped after this code cannot make a row disappear. Unclassified models each get their own row under their own name instead of collapsing into one "other" bar.

`Meta` names the model behind the number, so the card can state which model was measured rather than implying the whole family was.

## Quota merging: replace for full-snapshot providers

Renaming antigravity's keys previously left the **old and new key sets rendering side by side** for the full 24h retention window — the duplicated-rows report.

`mergeQuotaWindows` now replaces rather than carries forward when every incoming window belongs to a provider that reports its complete set on each probe. Codex is the counter-example the merge exists for — it answers with only `rate_limit` or only `additional_rate_limits` on roughly a fifth of probes, so a missing window there means "not mentioned". Antigravity's two endpoints return everything or nothing, so a missing window means gone.

Both behaviours are pinned by tests, including that a carried-forward codex window keeps its original timestamp.

## Verification

`go build ./...`, `gofmt`, `go vet` clean; full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)