### PR TITLE
fix(routing): stop reading throttling 429s as exhausted quota

### DIFF
--- a/internal/runtime/executor/antigravity_request.go
+++ b/internal/runtime/executor/antigravity_request.go
@@ -229,9 +229,13 @@ func antigravityBaseURLFallbackOrder(auth *cliproxyauth.Auth) []string {
 	if base := resolveCustomAntigravityBaseURL(auth); base != "" {
 		return []string{base}
 	}
+	// Sandbox first: the non-sandbox daily host throttles far more readily, and
+	// every 429 it returns costs a retry and risks being read as an exhausted
+	// quota. Production logs showed the daily host rate-limiting requests that
+	// the sandbox host then served without complaint.
 	return []string{
-		antigravityBaseURLDaily,
 		antigravitySandboxBaseURLDaily,
+		antigravityBaseURLDaily,
 		// antigravityBaseURLProd,
 	}
 }

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -268,6 +268,19 @@ func (s cooldownService) applyModelFailureLocked(auth *Auth, result Result, now 
 			effects.suspendReason = "not_found"
 			effects.shouldSuspendModel = true
 		case 429:
+			// A 429 is not automatically an exhausted quota. Google's CloudCode
+			// answers "Resource has been exhausted" for ordinary per-minute
+			// throttling, and treating that as quota exhaustion suspends the
+			// model on an account that still has its full allowance.
+			//
+			// Observed in production: an antigravity account reporting 100%
+			// remaining cycled suspend → resume → suspend within five seconds,
+			// repeatedly, because the first request after each recovery drew
+			// another throttling 429 and was again read as exhaustion.
+			if isTransientRateLimitError(result.Error) {
+				applyTransientRateLimitLocked(auth, state, result, now, effects)
+				break
+			}
 			applyModelQuotaFailureLocked(auth, state, result, now, effects)
 		case 408, 500, 502, 503, 504:
 			if quotaCooldownDisabledForAuth(auth) {
@@ -342,6 +355,69 @@ func isQuotaExhaustionError(err *Error, retryAfter *time.Duration) bool {
 	}
 	return isUsageBalanceExhaustedMessage(err.Message)
 }
+
+// isTransientRateLimitError reports whether a 429 describes short-term
+// throttling rather than an exhausted allowance.
+//
+// The distinction is in the body: providers name an exhausted quota explicitly
+// ("quota_exhausted", a quotaResetDelay, a daily quota), whereas a bare
+// "resource has been exhausted" is the generic throttle Google returns for
+// per-minute limits. Anything not recognised as throttling keeps the previous
+// behaviour and is treated as exhaustion, so this can only narrow the cases
+// that suspend a model, never widen them.
+func isTransientRateLimitError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	body := strings.ToLower(err.Message)
+	if body == "" {
+		return false
+	}
+	for _, explicit := range []string{
+		"quota_exhausted", "quotaresetdelay", "quota reset",
+		"quota limit", "daily quota", "usage balance exhausted", "balance exhausted",
+	} {
+		if strings.Contains(body, explicit) {
+			return false
+		}
+	}
+	return strings.Contains(body, "resource has been exhausted") ||
+		strings.Contains(body, "resource_exhausted") ||
+		strings.Contains(body, "rate limit") ||
+		strings.Contains(body, "too many requests")
+}
+
+// applyTransientRateLimitLocked backs off briefly without declaring the model
+// out of quota: no quota state, no suspension, so the next scheduling pass can
+// use the account again instead of parking it behind a quota cooldown.
+func applyTransientRateLimitLocked(auth *Auth, state *ModelState, result Result, now time.Time, effects *resultStateEffects) {
+	if state == nil {
+		return
+	}
+	cooldown := transientRateLimitCooldown
+	if result.RetryAfter != nil && *result.RetryAfter > 0 {
+		cooldown = *result.RetryAfter
+	}
+	if quotaCooldownDisabledForAuth(auth) {
+		cooldown = 0
+	}
+	if cooldown > 0 {
+		state.NextRetryAfter = now.Add(cooldown)
+	} else {
+		state.NextRetryAfter = time.Time{}
+	}
+	// Explicitly clear any quota flag a previous misclassification may have set,
+	// so one throttled request cannot leave the model parked indefinitely.
+	state.Quota = QuotaState{}
+	effects.clearModelQuota = true
+	auth.Status = StatusError
+	auth.UpdatedAt = now
+	updateAggregatedAvailability(auth, now)
+}
+
+// transientRateLimitCooldown matches the shortest window a provider realistically
+// throttles on; a per-minute limit clears within it.
+const transientRateLimitCooldown = time.Minute
 
 func isUsageBalanceExhaustedMessage(message string) bool {
 	lower := strings.ToLower(strings.TrimSpace(message))

--- a/sdk/cliproxy/auth/conductor_rate_limit_test.go
+++ b/sdk/cliproxy/auth/conductor_rate_limit_test.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// Google's CloudCode returns "Resource has been exhausted" for ordinary
+// per-minute throttling. Reading that as an exhausted quota suspended models on
+// accounts that still had their full allowance, producing a suspend → resume →
+// suspend loop within seconds.
+func TestTransientRateLimitIsNotQuotaExhaustion(t *testing.T) {
+	throttles := []string{
+		"Resource has been exhausted (e.g. check quota).",
+		`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED"}}`,
+		"rate limit exceeded",
+		"Too Many Requests",
+	}
+	for _, message := range throttles {
+		if !isTransientRateLimitError(&Error{Message: message}) {
+			t.Fatalf("%q should be treated as throttling, not exhaustion", message)
+		}
+	}
+}
+
+// An explicitly named quota keeps the old behaviour: it really is exhausted and
+// the model should be parked until the window resets.
+func TestNamedQuotaExhaustionStillCountsAsExhaustion(t *testing.T) {
+	exhausted := []string{
+		`{"error":{"details":[{"reason":"QUOTA_EXHAUSTED"}]}}`,
+		`{"error":{"details":[{"metadata":{"quotaResetDelay":"2h1m1s"}}]}}`,
+		"Quota limit 'Tokens per minute' exceeded",
+		"daily quota reached",
+		"usage balance exhausted",
+	}
+	for _, message := range exhausted {
+		if isTransientRateLimitError(&Error{Message: message}) {
+			t.Fatalf("%q names a quota and must stay an exhaustion", message)
+		}
+	}
+}
+
+// The real-world message that caused the loop: it contains the word "quota"
+// only inside the generic hint, which must not tip the classification.
+func TestGenericExhaustedHintMentioningQuotaIsStillThrottling(t *testing.T) {
+	err := &Error{Message: `{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`}
+	if !isTransientRateLimitError(err) {
+		t.Fatal("the parenthetical 'check quota' hint must not make this an exhaustion")
+	}
+}
+
+// Nothing recognisable keeps the previous behaviour, so this change can only
+// narrow which failures suspend a model.
+func TestUnrecognisedMessageFallsBackToExhaustion(t *testing.T) {
+	for _, message := range []string{"", "upstream exploded"} {
+		if isTransientRateLimitError(&Error{Message: message}) {
+			t.Fatalf("%q must not be classified as throttling", message)
+		}
+	}
+	if isTransientRateLimitError(nil) {
+		t.Fatal("nil error must not be classified as throttling")
+	}
+}
+
+// Throttling must leave no quota state behind, otherwise the model stays parked
+// even though its allowance was never the problem.
+func TestTransientRateLimitClearsQuotaStateAndDoesNotSuspend(t *testing.T) {
+	auth := &Auth{}
+	state := &ModelState{Quota: QuotaState{Exceeded: true, Reason: "quota"}}
+	effects := &resultStateEffects{}
+	now := time.Now().UTC()
+
+	applyTransientRateLimitLocked(auth, state, Result{}, now, effects)
+
+	if state.Quota.Exceeded {
+		t.Fatal("quota flag must be cleared for a throttled request")
+	}
+	if effects.shouldSuspendModel {
+		t.Fatal("throttling must not suspend the model")
+	}
+	if !effects.clearModelQuota {
+		t.Fatal("a previously misclassified quota flag must be cleared")
+	}
+	if !state.NextRetryAfter.After(now) {
+		t.Fatal("a short backoff should still be applied")
+	}
+}
+
+// A provider-supplied Retry-After wins over the default backoff.
+func TestTransientRateLimitHonoursRetryAfter(t *testing.T) {
+	auth := &Auth{}
+	state := &ModelState{}
+	effects := &resultStateEffects{}
+	now := time.Now().UTC()
+	retry := 10 * time.Second
+
+	applyTransientRateLimitLocked(auth, state, Result{RetryAfter: &retry}, now, effects)
+
+	if got := state.NextRetryAfter.Sub(now); got < 9*time.Second || got > 11*time.Second {
+		t.Fatalf("backoff = %s, want the provider's 10s", got)
+	}
+}


### PR DESCRIPTION
## What was happening

`gemini-3.7-flash-high` kept failing in production. Earlier I traced it to the non-streaming endpoint and fixed that (#916), but requests **still failed after that deploy** — so the endpoint was only part of it.

The real loop, from `main.log`:

```
10:01:31 Suspended ... for model gemini-3.7-flash-high: quota
10:02:50 Resumed
10:02:55 Suspended ... quota          ← 5 seconds after recovering
10:04:14 Resumed
10:05:06 Suspended ... quota
10:41:26 Suspended ... quota
```

**The account was never out of quota** — its own quota probe reports 100% remaining on every window.

## Root cause

Google's CloudCode answers ordinary per-minute throttling with:

```json
{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}
```

Every 429 was routed to `applyModelQuotaFailureLocked`, whose own comment says *"Used for classic 429s"*. That sets `QuotaState.Exceeded`, suspends the model, and parks it behind a quota cooldown.

So each recovery was immediately undone: the first request after a resume drew another throttling 429, which was again read as exhaustion, which suspended the model again. Nothing about the account's actual allowance was involved.

## The fix

429 now splits on what the body actually says:

| body | treatment |
|---|---|
| `quota_exhausted`, `quotaResetDelay`, `quota limit`, `daily quota`, `balance exhausted` | unchanged — real exhaustion, park it |
| `resource has been exhausted`, `resource_exhausted`, `rate limit`, `too many requests` | back off 1 minute, **no quota state, no suspension** |
| anything unrecognised | unchanged |

Throttling also **clears** a quota flag left by a previous misclassification, so one throttled request cannot leave a model parked indefinitely.

Because unrecognised messages keep the old path, this can only narrow which failures suspend a model, never widen them.

The parenthetical `(e.g. check quota)` in Google's generic message is the trap here — it mentions quota without naming one. A test pins that it stays classified as throttling.

This is the distinction Antigravity-Manager makes too: generic `resource_exhausted` gets a short lock, an explicit quota gets long backoff. I noted it while reading that project and did not apply it — this is that gap.

## Also: sandbox host first

`antigravityBaseURLFallbackOrder` tried `daily-cloudcode-pa.googleapis.com` before the sandbox host. The logs show the daily host rate-limiting requests the sandbox host then served fine:

```
rate limited on base url https://daily-cloudcode-pa.googleapis.com,
retrying with fallback base url: https://daily-cloudcode-pa.sandbox.googleapis.com
```

Each of those 429s cost a retry and risked the misclassification above. Sandbox now goes first — matching what the quota probe already does.

## Verification

Full `go test ./...` green; `gofmt` and `go vet` clean. Six new tests cover the real throttling messages, the explicitly-named quotas that must stay exhaustions, the `(e.g. check quota)` trap, the unrecognised fallback, and that throttling clears quota state without suspending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)