### PR TITLE
fix(translator): normalise message roles Gemini cannot accept

### DIFF
--- a/internal/runtime/executor/antigravity_request.go
+++ b/internal/runtime/executor/antigravity_request.go
@@ -54,6 +54,16 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 
 	useAntigravitySchema := strings.Contains(modelName, "claude") || strings.Contains(modelName, "gemini-3-pro-high")
 	payloadStr := string(payload)
+
+	// The upstream accepts only "user" and "model" here and rejects anything
+	// else with a bare 400 INVALID_ARGUMENT naming no field. Claude Code sends
+	// "system" turns inside `messages` in addition to the top-level `system`
+	// field, and the Claude translator forwards any role it does not recognise
+	// unchanged, so those reached the upstream verbatim and failed the request.
+	//
+	// Normalising here rather than in the translator covers every entrypoint
+	// format at once: this is the last point all of them pass through.
+	payloadStr = util.NormalizeGeminiContentRoles(payloadStr, "request.contents")
 	paths := make([]string, 0)
 	util.Walk(gjson.Parse(payloadStr), "", "parametersJsonSchema", &paths)
 	for _, p := range paths {

--- a/internal/util/gemini_role.go
+++ b/internal/util/gemini_role.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// NormalizeGeminiContentRole maps a message role onto one of the two roles
+// Gemini accepts in `contents[].role`.
+//
+// Gemini rejects anything else with a bare 400 INVALID_ARGUMENT that names no
+// field, which makes the cause expensive to find. The Claude translators rewrite
+// "assistant" and pass every other role through untouched, so a "system" entry
+// inside `messages` — which Claude Code sends alongside the top-level `system`
+// field — reached the upstream verbatim and failed the whole request.
+//
+// An allowlist rather than a list of roles to rewrite: a role this code has
+// never heard of becomes "user" and its text still reaches the model, instead
+// of being forwarded as an invalid value.
+func NormalizeGeminiContentRole(role string) string {
+	switch role {
+	case "assistant", "model":
+		return "model"
+	default:
+		return "user"
+	}
+}
+
+// NormalizeGeminiContentRoles rewrites every contents[].role in an Antigravity
+// or Gemini request payload so the upstream cannot be sent a role it rejects.
+//
+// This runs at the executor rather than in the translators because it is the
+// last point every request passes through regardless of which entrypoint format
+// produced it: fixing one translator would leave the same defect reachable via
+// the others.
+func NormalizeGeminiContentRoles(payload string, contentsPath string) string {
+	contents := gjson.Get(payload, contentsPath)
+	if !contents.IsArray() {
+		return payload
+	}
+	updated := payload
+	index := 0
+	contents.ForEach(func(_, content gjson.Result) bool {
+		role := content.Get("role")
+		if role.Type == gjson.String {
+			if normalized := NormalizeGeminiContentRole(role.String()); normalized != role.String() {
+				updated, _ = sjson.Set(updated, fmt.Sprintf("%s.%d.role", contentsPath, index), normalized)
+			}
+		}
+		index++
+		return true
+	})
+	return updated
+}

--- a/internal/util/gemini_role_test.go
+++ b/internal/util/gemini_role_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// Gemini accepts only "user" and "model" in contents[].role and rejects
+// anything else with a bare 400 INVALID_ARGUMENT that names no field.
+func TestNormalizeGeminiContentRole(t *testing.T) {
+	cases := map[string]string{
+		"user":      "user",
+		"assistant": "model",
+		"model":     "model",
+		// Claude Code sends system entries inside `messages` alongside the
+		// top-level `system` field. Forwarded verbatim, they failed the whole
+		// request; as "user" the text still reaches the model.
+		"system": "user",
+		// Roles this code has never seen must not reach the upstream either.
+		"tool":      "user",
+		"developer": "user",
+		"":          "user",
+	}
+	for input, want := range cases {
+		if got := NormalizeGeminiContentRole(input); got != want {
+			t.Fatalf("role %q -> %q, want %q", input, got, want)
+		}
+	}
+}
+
+// The payload-level pass is what actually protects the upstream: it runs at the
+// executor, after any translator has produced the request, so a role no
+// translator normalised still cannot escape.
+func TestNormalizeGeminiContentRolesRewritesPayload(t *testing.T) {
+	payload := `{"request":{"contents":[
+		{"role":"user","parts":[{"text":"one"}]},
+		{"role":"system","parts":[{"text":"stray"}]},
+		{"role":"assistant","parts":[{"text":"two"}]},
+		{"role":"tool","parts":[{"text":"three"}]}
+	]}}`
+	out := NormalizeGeminiContentRoles(payload, "request.contents")
+
+	roles := gjson.Get(out, "request.contents.#.role").Array()
+	want := []string{"user", "user", "model", "user"}
+	if len(roles) != len(want) {
+		t.Fatalf("contents = %d, want %d", len(roles), len(want))
+	}
+	for i, role := range roles {
+		if role.String() != want[i] {
+			t.Fatalf("contents[%d].role = %q, want %q", i, role.String(), want[i])
+		}
+	}
+	// Only the role is rewritten; the turn's text must survive.
+	if !strings.Contains(out, "stray") {
+		t.Fatal("text of the rewritten turn was dropped")
+	}
+}
+
+// A payload without contents must pass through untouched rather than being
+// rewritten into something the upstream cannot parse.
+func TestNormalizeGeminiContentRolesLeavesOtherPayloadsAlone(t *testing.T) {
+	for _, payload := range []string{`{}`, `{"request":{}}`, `{"request":{"contents":"nope"}}`} {
+		if got := NormalizeGeminiContentRoles(payload, "request.contents"); got != payload {
+			t.Fatalf("payload %s was rewritten to %s", payload, got)
+		}
+	}
+}


### PR DESCRIPTION
## The error

```json
{"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT"}}
```

Names no field, so the message alone gives nothing to work with.

## Root cause

The upstream accepts only `user` and `model` in `contents[].role`. The Claude translator rewrites `assistant` and forwards **any other role unchanged**.

Claude Code sends `system` turns **inside `messages`**, in addition to the top-level `system` field. Those reached the upstream verbatim and failed the entire request — which is why a hand-written request never reproduced it.

## How it was pinned down

The failing request was pulled from its per-request log and replayed against production. Translated `contents` carried:

```
roles: {user: 2, system: 2, model: 1}
```

The replay reproduced the 400 exactly. Then one variable at a time:

| variant | result |
|---|---|
| baseline | 400 |
| no tools | 400 |
| no thinking | 400 |
| no output_config | 400 |
| **messages replaced with one user turn** | **200** |

So it was the roles, not the tool schemas or the thinking config.

## Where the fix lives

**At the executor, not the translator.**

Two reasons. It is the last point every request passes through regardless of entrypoint format, so the fix cannot be bypassed by arriving through a different translator — the same defect exists in the `gemini` and `gemini-cli` Claude translators. And `internal/translator` is closed to pull requests by `pr-path-guard`; my first attempt patched all three translators and was correctly rejected by that gate.

The mapping is an allowlist:

```go
case "assistant", "model": return "model"
default:                   return "user"
```

A role this code has never seen — `tool`, `developer`, anything future — still delivers its text as a user turn rather than being forwarded as an invalid value.

## Relationship to the earlier fixes

Third independent cause on the same symptom. #916 fixed non-streaming requests hitting an endpoint that does not cover every model; #917 stopped throttling 429s being read as exhausted quota. Neither touches this one, which only fires when the caller sends a role the upstream rejects.

## Verification

Full `go test ./...` green; `gofmt` and `go vet` clean. Tests cover the role mapping, the payload rewrite end to end, that the rewritten turn's text survives, and that payloads without `contents` pass through untouched.

Will replay the exact request that produced the original 400 against production once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)