### PR TITLE
release: v0.4.27 — Antigravity quota windows, non-stream routing, throttling 429s

### DIFF
--- a/internal/management/aiaccountstatus/probe_antigravity.go
+++ b/internal/management/aiaccountstatus/probe_antigravity.go
@@ -301,12 +301,13 @@ func parseAntigravityQuotaSummary(body []byte) []usage.QuotaWindowDTO {
 	seen := make(map[string]struct{}, 8)
 	groups.ForEach(func(groupIndex, group gjson.Result) bool {
 		groupName := strings.TrimSpace(firstJSONResult(group, "displayName", "display_name").String())
+		groupDescription := strings.TrimSpace(firstJSONResult(group, "description").String())
 		buckets := firstJSONResult(group, "buckets", "quotaBuckets", "quota_buckets")
 		if !buckets.IsArray() {
 			return true
 		}
 		buckets.ForEach(func(bucketIndex, bucket gjson.Result) bool {
-			dto, ok := antigravityBucketDTO(bucket, groupName, groupIndex.Int(), bucketIndex.Int())
+			dto, ok := antigravityBucketDTO(bucket, groupName, groupDescription, groupIndex.Int(), bucketIndex.Int())
 			if !ok {
 				return true
 			}
@@ -322,7 +323,7 @@ func parseAntigravityQuotaSummary(body []byte) []usage.QuotaWindowDTO {
 	return out
 }
 
-func antigravityBucketDTO(bucket gjson.Result, groupName string, groupIndex, bucketIndex int64) (usage.QuotaWindowDTO, bool) {
+func antigravityBucketDTO(bucket gjson.Result, groupName, groupDescription string, groupIndex, bucketIndex int64) (usage.QuotaWindowDTO, bool) {
 	fraction := firstJSONResult(bucket, "remainingFraction", "remaining_fraction", "remaining")
 	resetAt := parseFlexibleTime(firstJSONResult(bucket, "resetTime", "reset_time"))
 	if !fraction.Exists() && resetAt == nil {
@@ -343,7 +344,8 @@ func antigravityBucketDTO(bucket gjson.Result, groupName string, groupIndex, buc
 
 	dto := usage.QuotaWindowDTO{
 		QuotaKey:      "antigravity:" + key,
-		QuotaLabel:    antigravityBucketLabel(bucket, groupName, bucketID, window),
+		QuotaLabel:    antigravityGroupLabel(groupName, bucketID, window),
+		Meta:          antigravityBucketMeta(bucket, groupDescription),
 		ResetAt:       resetAt,
 		WindowSeconds: windowSeconds,
 	}
@@ -356,26 +358,35 @@ func antigravityBucketDTO(bucket gjson.Result, groupName string, groupIndex, buc
 	return dto, true
 }
 
-// antigravityBucketLabel keeps the upstream's own wording. Translating it here
-// would mean maintaining a table of names the upstream is free to change.
-func antigravityBucketLabel(bucket gjson.Result, groupName, bucketID, window string) string {
-	if name := strings.TrimSpace(firstJSONResult(bucket, "displayName", "display_name").String()); name != "" {
-		if groupName != "" && !strings.EqualFold(name, groupName) {
-			return groupName + " · " + name
+// antigravityGroupLabel names the row after the model group only.
+//
+// The upstream also names the bucket ("Weekly Limit Remaining"), and pairing
+// that with the group produced labels like
+// "Gemini Models · Weekly Limit Remaining" — too long for a card row, and
+// redundant once the window is rendered from WindowSeconds. The card composes
+// "<group> · <localised window>" itself, so the group name is all this has to
+// carry, and it still comes from the upstream rather than a table here.
+func antigravityGroupLabel(groupName, bucketID, window string) string {
+	if groupName != "" {
+		return groupName
+	}
+	if bucketID != "" {
+		return bucketID
+	}
+	return window
+}
+
+// antigravityBucketMeta carries the upstream's own explanation of the group —
+// typically which models draw on it. The card keeps it out of the row and shows
+// it on hover, so a long sentence cannot crowd out the numbers.
+func antigravityBucketMeta(bucket gjson.Result, groupDescription string) string {
+	if description := strings.TrimSpace(firstJSONResult(bucket, "description").String()); description != "" {
+		if groupDescription != "" && !strings.EqualFold(description, groupDescription) {
+			return groupDescription + " · " + description
 		}
-		return name
+		return description
 	}
-	label := groupName
-	if label == "" {
-		label = bucketID
-	}
-	if label == "" {
-		return window
-	}
-	if window != "" {
-		return label + " · " + window
-	}
-	return label
+	return groupDescription
 }
 
 // antigravityWindowSeconds maps the upstream's window token onto a duration.

--- a/internal/management/aiaccountstatus/probe_antigravity.go
+++ b/internal/management/aiaccountstatus/probe_antigravity.go
@@ -446,19 +446,16 @@ func parseAntigravityHourToken(value string) int64 {
 // parseAntigravityModels is the fallback view built from fetchAvailableModels,
 // used when the account cannot read the grouped summary.
 //
-// Models are grouped by the quota they actually draw on, which the payload
-// states directly: models sharing a bucket report the same resetTime and the
-// same remainingFraction. Nothing here classifies by model name.
+// One row per model family, each showing a single representative model's real
+// quota. Picking a representative rather than aggregating the family matters:
+// on a live account gemini-2.5-pro and gemini-3.1-pro-high are both "Gemini
+// Pro" yet draw on different buckets, so folding them together produced the
+// minimum of two unrelated quotas — a number belonging to neither, and a reset
+// countdown from whichever bucket happened to expire first.
 //
-// That distinction is the whole point. A previous version grouped by model
-// family — "Gemini Pro", "Gemini Flash", "Claude" — and the real buckets do not
-// follow family lines at all. On a live account the buckets split by generation:
-// nineteen models including claude-sonnet-4-6, gpt-oss-120b-medium and the whole
-// gemini-3.x line share one weekly bucket, while gemini-2.5-* sit in a separate
-// 5h one. Family grouping therefore drew one shared quota as five independent
-// bars, and worse, put gemini-2.5-pro and gemini-3.1-pro-high on the same row
-// while they belong to different buckets — the row then reported the minimum of
-// two unrelated quotas, a number matching neither.
+// Preference order is a ranking, not an allowlist: a family with none of its
+// preferred ids still shows whichever member the upstream did send, so a model
+// shipped after this code cannot make a row disappear.
 func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 	root := gjson.ParseBytes(body)
 	models := root.Get("models")
@@ -469,8 +466,13 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		return nil
 	}
 
-	buckets := make(map[string]*antigravityModelBucket, 4)
-	order := make([]string, 0, 4)
+	type candidate struct {
+		id          string
+		displayName string
+		percent     *float64
+		resetAt     *time.Time
+	}
+	families := make(map[string][]candidate, 8)
 
 	models.ForEach(func(modelID, model gjson.Result) bool {
 		id := normalizeAntigravityModelID(modelID.String())
@@ -479,12 +481,10 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		}
 		info := firstJSONResult(model, "quotaInfo", "quota_info")
 		fraction := firstJSONResult(info, "remainingFraction", "remaining_fraction", "remaining")
-		resetRaw := strings.TrimSpace(firstJSONResult(info, "resetTime", "reset_time").String())
 		resetAt := parseFlexibleTime(firstJSONResult(info, "resetTime", "reset_time"))
 		if !fraction.Exists() && resetAt == nil {
 			return true
 		}
-
 		var percent *float64
 		if fraction.Exists() {
 			if value := quotaFraction(fraction); value != nil {
@@ -492,66 +492,140 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 				percent = &remaining
 			}
 		}
-
-		// Reset instant plus remaining fraction identifies the bucket. Pairing
-		// the two is deliberately conservative: two buckets that happen to reset
-		// together stay separate as soon as their usage differs, whereas keying
-		// on the reset alone would merge them and invent a shared quota.
-		percentKey := "none"
-		if percent != nil {
-			percentKey = strconv.FormatFloat(*percent, 'f', -1, 64)
-		}
-		bucketKey := resetRaw + "|" + percentKey
-
-		current := buckets[bucketKey]
-		if current == nil {
-			current = &antigravityModelBucket{percent: percent, resetAt: resetAt}
-			buckets[bucketKey] = current
-			order = append(order, bucketKey)
-		}
-		current.models = append(current.models, id)
+		family := categorizeAntigravityModel(id)
+		families[family] = append(families[family], candidate{
+			id:          id,
+			displayName: strings.TrimSpace(firstJSONResult(model, "displayName", "display_name").String()),
+			percent:     percent,
+			resetAt:     resetAt,
+		})
 		return true
 	})
 
-	out := make([]usage.QuotaWindowDTO, 0, len(order))
-	for _, bucketKey := range order {
-		bucket := buckets[bucketKey]
-		if bucket == nil || len(bucket.models) == 0 {
+	out := make([]usage.QuotaWindowDTO, 0, len(families))
+	for _, family := range antigravityFamilyOrder {
+		members := families[family]
+		if len(members) == 0 {
 			continue
 		}
-		sort.Strings(bucket.models)
+		sort.SliceStable(members, func(i, j int) bool {
+			return antigravityPreferenceRank(family, members[i].id) < antigravityPreferenceRank(family, members[j].id)
+		})
+		chosen := members[0]
+		label := antigravityFamilyLabel(family)
+		if family == antigravityCategoryOther {
+			label = chosen.displayName
+			if label == "" {
+				label = chosen.id
+			}
+		}
 		out = append(out, usage.QuotaWindowDTO{
-			// Named after the first model in the bucket so the key survives the
-			// reset that changes resetTime every cycle.
-			QuotaKey: "antigravity:group_" + normalizeQuotaKeyPart(bucket.models[0]),
-			// The card counts the models and renders the phrase; sending a
-			// sentence from here could not be localised.
-			QuotaLabel: antigravitySharedGroupLabel,
-			Meta:       strings.Join(bucket.models, ","),
-			Percent:    bucket.percent,
-			ResetAt:    bucket.resetAt,
+			QuotaKey:      "antigravity:" + family,
+			QuotaLabel:    label,
+			Percent:       chosen.percent,
+			ResetAt:       chosen.resetAt,
+			WindowSeconds: antigravityWindowFiveHour,
+			// The row shows one model's quota; naming it lets the card explain
+			// which, instead of implying the whole family was measured.
+			Meta: chosen.id,
 		})
 	}
 
-	// Soonest reset first: the bucket about to run out is the one worth reading.
-	sort.SliceStable(out, func(i, j int) bool {
-		left, right := out[i].ResetAt, out[j].ResetAt
-		if left == nil || right == nil {
-			return right != nil
+	// "other" collapses every unclassified model onto one row, so emit each of
+	// them instead: they are unrelated models that merely failed classification.
+	if extras := families[antigravityCategoryOther]; len(extras) > 1 {
+		out = out[:len(out)-1]
+		sort.SliceStable(extras, func(i, j int) bool { return extras[i].id < extras[j].id })
+		for _, extra := range extras {
+			label := extra.displayName
+			if label == "" {
+				label = extra.id
+			}
+			out = append(out, usage.QuotaWindowDTO{
+				QuotaKey:      "antigravity:model_" + normalizeQuotaKeyPart(extra.id),
+				QuotaLabel:    label,
+				Percent:       extra.percent,
+				ResetAt:       extra.resetAt,
+				WindowSeconds: antigravityWindowFiveHour,
+				Meta:          extra.id,
+			})
 		}
-		return left.Before(*right)
-	})
+	}
 	return out
 }
 
-// antigravitySharedGroupLabel tells the card to name the row after how many
-// models draw on the bucket. The count lives in Meta, which carries the ids.
-const antigravitySharedGroupLabel = "antigravity_quota.shared_group"
+const (
+	antigravityCategoryGeminiPro   = "gemini_pro"
+	antigravityCategoryGeminiFlash = "gemini_flash"
+	antigravityCategoryGeminiImage = "gemini_image"
+	antigravityCategoryClaude      = "claude"
+	antigravityCategoryOther       = "other"
+)
 
-type antigravityModelBucket struct {
-	models  []string
-	percent *float64
-	resetAt *time.Time
+var antigravityFamilyOrder = []string{
+	antigravityCategoryGeminiPro,
+	antigravityCategoryGeminiFlash,
+	antigravityCategoryGeminiImage,
+	antigravityCategoryClaude,
+	antigravityCategoryOther,
+}
+
+// antigravityPreferences ranks which member best represents its family — the
+// agent-facing model an operator actually spends. Absent ids simply rank last,
+// so this never decides whether a row exists.
+var antigravityPreferences = map[string][]string{
+	antigravityCategoryGeminiPro:   {"gemini-pro-agent", "gemini-3.1-pro-high", "gemini-3.1-pro-low"},
+	antigravityCategoryGeminiFlash: {"gemini-3-flash-agent", "gemini-3-flash"},
+	antigravityCategoryGeminiImage: {"gemini-3.1-flash-image", "gemini-3-pro-image"},
+	antigravityCategoryClaude:      {"claude-sonnet-4-6", "claude-opus-4-6-thinking"},
+}
+
+func antigravityPreferenceRank(family, id string) int {
+	for index, preferred := range antigravityPreferences[family] {
+		if preferred == id {
+			return index
+		}
+	}
+	// Unpreferred members keep upstream order behind the preferred ones.
+	return len(antigravityPreferences[family]) + 1
+}
+
+// categorizeAntigravityModel groups a model by the shape of its id instead of by
+// membership in a list, so a model that does not exist yet still lands in the
+// right family.
+func categorizeAntigravityModel(id string) string {
+	switch {
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "image"),
+		strings.HasPrefix(id, "image"),
+		strings.HasPrefix(id, "imagen"):
+		return antigravityCategoryGeminiImage
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "flash"):
+		return antigravityCategoryGeminiFlash
+	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "pro"):
+		return antigravityCategoryGeminiPro
+	case strings.Contains(id, "claude"),
+		strings.Contains(id, "opus"),
+		strings.Contains(id, "sonnet"),
+		strings.Contains(id, "haiku"):
+		return antigravityCategoryClaude
+	default:
+		return antigravityCategoryOther
+	}
+}
+
+func antigravityFamilyLabel(family string) string {
+	switch family {
+	case antigravityCategoryGeminiPro:
+		return "Gemini Pro"
+	case antigravityCategoryGeminiFlash:
+		return "Gemini Flash"
+	case antigravityCategoryGeminiImage:
+		return "Gemini Image"
+	case antigravityCategoryClaude:
+		return "Claude"
+	default:
+		return ""
+	}
 }
 
 func normalizeAntigravityModelID(raw string) string {

--- a/internal/management/aiaccountstatus/probe_antigravity.go
+++ b/internal/management/aiaccountstatus/probe_antigravity.go
@@ -443,11 +443,22 @@ func parseAntigravityHourToken(value string) int64 {
 	return 0
 }
 
-// parseAntigravityModels is the fallback view built from fetchAvailableModels.
-// It carries only the 5h window, and the upstream does not group the models, so
-// we classify them by shape. Anything we cannot classify is still reported under
-// its own id: a model list is a moving target, and a model missing from a
-// hand-written table used to vanish from the card entirely.
+// parseAntigravityModels is the fallback view built from fetchAvailableModels,
+// used when the account cannot read the grouped summary.
+//
+// Models are grouped by the quota they actually draw on, which the payload
+// states directly: models sharing a bucket report the same resetTime and the
+// same remainingFraction. Nothing here classifies by model name.
+//
+// That distinction is the whole point. A previous version grouped by model
+// family — "Gemini Pro", "Gemini Flash", "Claude" — and the real buckets do not
+// follow family lines at all. On a live account the buckets split by generation:
+// nineteen models including claude-sonnet-4-6, gpt-oss-120b-medium and the whole
+// gemini-3.x line share one weekly bucket, while gemini-2.5-* sit in a separate
+// 5h one. Family grouping therefore drew one shared quota as five independent
+// bars, and worse, put gemini-2.5-pro and gemini-3.1-pro-high on the same row
+// while they belong to different buckets — the row then reported the minimum of
+// two unrelated quotas, a number matching neither.
 func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 	root := gjson.ParseBytes(body)
 	models := root.Get("models")
@@ -458,8 +469,8 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		return nil
 	}
 
-	grouped := make(map[string]*antigravityModelGroup, 8)
-	keys := make([]string, 0, 8)
+	buckets := make(map[string]*antigravityModelBucket, 4)
+	order := make([]string, 0, 4)
 
 	models.ForEach(func(modelID, model gjson.Result) bool {
 		id := normalizeAntigravityModelID(modelID.String())
@@ -468,86 +479,79 @@ func parseAntigravityModels(body []byte) []usage.QuotaWindowDTO {
 		}
 		info := firstJSONResult(model, "quotaInfo", "quota_info")
 		fraction := firstJSONResult(info, "remainingFraction", "remaining_fraction", "remaining")
+		resetRaw := strings.TrimSpace(firstJSONResult(info, "resetTime", "reset_time").String())
 		resetAt := parseFlexibleTime(firstJSONResult(info, "resetTime", "reset_time"))
 		if !fraction.Exists() && resetAt == nil {
 			return true
 		}
 
-		category := categorizeAntigravityModel(id)
-		key := category
-		label := antigravityCategoryLabel(category)
-		if category == antigravityCategoryOther {
-			key = "model_" + normalizeQuotaKeyPart(id)
-			label = strings.TrimSpace(firstJSONResult(model, "displayName", "display_name").String())
-			if label == "" {
-				label = id
-			}
-		}
-
-		current := grouped[key]
-		if current == nil {
-			current = &antigravityModelGroup{label: label}
-			grouped[key] = current
-			keys = append(keys, key)
-		}
-		current.count++
+		var percent *float64
 		if fraction.Exists() {
 			if value := quotaFraction(fraction); value != nil {
 				remaining := math.Round(clampPct(*value * 100))
-				if current.percent == nil || remaining < *current.percent {
-					current.percent = &remaining
-				}
+				percent = &remaining
 			}
 		}
-		if resetAt != nil && (current.resetAt == nil || resetAt.Before(*current.resetAt)) {
-			current.resetAt = resetAt
+
+		// Reset instant plus remaining fraction identifies the bucket. Pairing
+		// the two is deliberately conservative: two buckets that happen to reset
+		// together stay separate as soon as their usage differs, whereas keying
+		// on the reset alone would merge them and invent a shared quota.
+		percentKey := "none"
+		if percent != nil {
+			percentKey = strconv.FormatFloat(*percent, 'f', -1, 64)
 		}
+		bucketKey := resetRaw + "|" + percentKey
+
+		current := buckets[bucketKey]
+		if current == nil {
+			current = &antigravityModelBucket{percent: percent, resetAt: resetAt}
+			buckets[bucketKey] = current
+			order = append(order, bucketKey)
+		}
+		current.models = append(current.models, id)
 		return true
 	})
 
-	// Ranked so the well-known families lead and the unclassified models trail
-	// them, rather than surfacing in Go's randomized map order.
-	sort.SliceStable(keys, func(i, j int) bool {
-		return antigravityCategoryRank(keys[i]) < antigravityCategoryRank(keys[j])
-	})
-
-	out := make([]usage.QuotaWindowDTO, 0, len(keys))
-	for _, key := range keys {
-		value := grouped[key]
-		if value == nil || value.count == 0 {
+	out := make([]usage.QuotaWindowDTO, 0, len(order))
+	for _, bucketKey := range order {
+		bucket := buckets[bucketKey]
+		if bucket == nil || len(bucket.models) == 0 {
 			continue
 		}
+		sort.Strings(bucket.models)
 		out = append(out, usage.QuotaWindowDTO{
-			QuotaKey:      "antigravity:" + key,
-			QuotaLabel:    value.label,
-			Percent:       value.percent,
-			ResetAt:       value.resetAt,
-			WindowSeconds: antigravityWindowFiveHour,
+			// Named after the first model in the bucket so the key survives the
+			// reset that changes resetTime every cycle.
+			QuotaKey: "antigravity:group_" + normalizeQuotaKeyPart(bucket.models[0]),
+			// The card counts the models and renders the phrase; sending a
+			// sentence from here could not be localised.
+			QuotaLabel: antigravitySharedGroupLabel,
+			Meta:       strings.Join(bucket.models, ","),
+			Percent:    bucket.percent,
+			ResetAt:    bucket.resetAt,
 		})
 	}
+
+	// Soonest reset first: the bucket about to run out is the one worth reading.
+	sort.SliceStable(out, func(i, j int) bool {
+		left, right := out[i].ResetAt, out[j].ResetAt
+		if left == nil || right == nil {
+			return right != nil
+		}
+		return left.Before(*right)
+	})
 	return out
 }
 
-type antigravityModelGroup struct {
-	label   string
+// antigravitySharedGroupLabel tells the card to name the row after how many
+// models draw on the bucket. The count lives in Meta, which carries the ids.
+const antigravitySharedGroupLabel = "antigravity_quota.shared_group"
+
+type antigravityModelBucket struct {
+	models  []string
 	percent *float64
 	resetAt *time.Time
-	count   int
-}
-
-func antigravityCategoryRank(key string) int {
-	switch key {
-	case antigravityCategoryGeminiPro:
-		return 0
-	case antigravityCategoryGeminiFlash:
-		return 1
-	case antigravityCategoryGeminiImage:
-		return 2
-	case antigravityCategoryClaude:
-		return 3
-	default:
-		return 4
-	}
 }
 
 func normalizeAntigravityModelID(raw string) string {
@@ -560,52 +564,6 @@ func normalizeAntigravityModelID(raw string) string {
 // does not surface as a user-visible quota row.
 func isAntigravityInternalModel(id string) bool {
 	return strings.HasPrefix(id, "chat_") || strings.HasPrefix(id, "tab_")
-}
-
-const (
-	antigravityCategoryGeminiPro   = "gemini_pro"
-	antigravityCategoryGeminiFlash = "gemini_flash"
-	antigravityCategoryGeminiImage = "gemini_image"
-	antigravityCategoryClaude      = "claude"
-	antigravityCategoryOther       = "other"
-)
-
-// categorizeAntigravityModel groups a model by the shape of its id instead of by
-// membership in a list. A list has to be edited every time the upstream ships a
-// model; the shapes below already cover the ones that do not exist yet.
-func categorizeAntigravityModel(id string) string {
-	switch {
-	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "image"),
-		strings.HasPrefix(id, "image"),
-		strings.HasPrefix(id, "imagen"):
-		return antigravityCategoryGeminiImage
-	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "flash"):
-		return antigravityCategoryGeminiFlash
-	case strings.HasPrefix(id, "gemini") && strings.Contains(id, "pro"):
-		return antigravityCategoryGeminiPro
-	case strings.Contains(id, "claude"),
-		strings.Contains(id, "opus"),
-		strings.Contains(id, "sonnet"),
-		strings.Contains(id, "haiku"):
-		return antigravityCategoryClaude
-	default:
-		return antigravityCategoryOther
-	}
-}
-
-func antigravityCategoryLabel(category string) string {
-	switch category {
-	case antigravityCategoryGeminiPro:
-		return "Gemini Pro"
-	case antigravityCategoryGeminiFlash:
-		return "Gemini Flash"
-	case antigravityCategoryGeminiImage:
-		return "Gemini Image"
-	case antigravityCategoryClaude:
-		return "Claude"
-	default:
-		return ""
-	}
 }
 
 func stringSet(values ...string) map[string]struct{} {

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -273,83 +274,77 @@ func TestResolveXAIPlanUsesEntitlementWhenMonthlyLimitIsZero(t *testing.T) {
 	}
 }
 
-// Models sharing a bucket report the same reset and the same remaining
-// fraction. Grouping on those two values reproduces the account's real quota
-// structure; grouping by model family does not, and this payload is the shape
-// a live account actually returns — claude, gpt-oss and gemini-3.x on one
-// weekly bucket, gemini-2.5-* on a separate 5h one.
-func TestParseAntigravityModelsGroupsByTheQuotaModelsShare(t *testing.T) {
+// One row per family, each carrying a single representative model's real quota.
+//
+// gemini-2.5-pro and gemini-3.1-pro-high are both "Gemini Pro" yet draw on
+// different buckets — captured from a live account, where gemini-3.x resets
+// weekly and gemini-2.5-* on a 5h cycle. Aggregating them reported the minimum
+// of two unrelated quotas with a countdown from the wrong one; picking the
+// preferred member reports something that is actually true of a model.
+func TestParseAntigravityModelsPicksOneRepresentativePerFamily(t *testing.T) {
 	body := []byte(`{"models":{
-		"claude-sonnet-4-6":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
-		"gpt-oss-120b-medium":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
-		"gemini-3.1-pro-high":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
-		"gemini-2.5-pro":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-20T20:17:11Z"}},
-		"gemini-2.5-flash":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-20T20:17:11Z"}},
+		"gemini-3.1-pro-high":{"quotaInfo":{"remainingFraction":0.8,"resetTime":"2026-08-27T15:17:11Z"}},
+		"gemini-2.5-pro":{"quotaInfo":{"remainingFraction":0.1,"resetTime":"2026-08-20T20:17:11Z"}},
+		"gemini-3-flash-agent":{"quotaInfo":{"remainingFraction":0.6,"resetTime":"2026-08-27T15:17:11Z"}},
+		"claude-sonnet-4-6":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}},
 		"chat_20706":{"quotaInfo":{"remainingFraction":1}}
 	}}`)
 	items := parseAntigravityModels(body)
-	if len(items) != 2 {
-		t.Fatalf("buckets=%d, want 2: %+v", len(items), items)
+
+	pro := quotaByKey(items, "antigravity:gemini_pro")
+	if pro == nil || pro.Percent == nil || *pro.Percent != 80 {
+		t.Fatalf("pro=%+v, want the preferred gemini-3.1-pro-high at 80", pro)
+	}
+	if pro.Meta != "gemini-3.1-pro-high" {
+		t.Fatalf("pro represented by %q", pro.Meta)
+	}
+	// The 2.5 model's 10% must not leak into the row: different bucket.
+	if pro.ResetAt == nil || pro.ResetAt.Format(time.RFC3339) != "2026-08-27T15:17:11Z" {
+		t.Fatalf("pro reset=%v, want the represented model's own reset", pro.ResetAt)
 	}
 
-	// Soonest reset first: the bucket about to run out is the one worth reading.
-	if items[0].ResetAt == nil || items[0].ResetAt.Format(time.RFC3339) != "2026-08-20T20:17:11Z" {
-		t.Fatalf("first bucket reset=%v, want the 5h one", items[0].ResetAt)
+	flash := quotaByKey(items, "antigravity:gemini_flash")
+	if flash == nil || flash.Percent == nil || *flash.Percent != 60 {
+		t.Fatalf("flash=%+v", flash)
 	}
-
-	shortWindow := items[0]
-	if shortWindow.Meta != "gemini-2.5-flash,gemini-2.5-pro" {
-		t.Fatalf("5h bucket members=%q", shortWindow.Meta)
+	claude := quotaByKey(items, "antigravity:claude")
+	if claude == nil || claude.Percent == nil || *claude.Percent != 90 {
+		t.Fatalf("claude=%+v", claude)
 	}
-	if shortWindow.QuotaKey != "antigravity:group_gemini_2_5_flash" {
-		t.Fatalf("5h bucket key=%q, want it named after its first model", shortWindow.QuotaKey)
-	}
-
-	weekly := items[1]
-	if weekly.Meta != "claude-sonnet-4-6,gemini-3.1-pro-high,gpt-oss-120b-medium" {
-		t.Fatalf("weekly bucket members=%q, want claude, gemini and gpt-oss together", weekly.Meta)
-	}
-
-	// The card counts the members and renders the phrase, so the label is a key
-	// rather than a sentence that could not be localised.
 	for _, item := range items {
-		if item.QuotaLabel != antigravitySharedGroupLabel {
-			t.Fatalf("label=%q, want %q", item.QuotaLabel, antigravitySharedGroupLabel)
-		}
-		if item.Percent == nil || *item.Percent != 100 {
-			t.Fatalf("percent=%+v", item.Percent)
+		if strings.Contains(item.QuotaKey, "chat_") {
+			t.Fatalf("internal model leaked: %+v", item)
 		}
 	}
 }
 
-// Two buckets that reset at the same instant but differ in usage must stay
-// apart. Keying on the reset alone would merge them and report a shared quota
-// that does not exist.
-func TestParseAntigravityModelsKeepsBucketsWithDifferentUsageApart(t *testing.T) {
+// Preference is a ranking, not an allowlist: a family whose preferred ids are
+// all absent still shows the member the upstream did send.
+func TestParseAntigravityModelsFallsBackToAnyFamilyMember(t *testing.T) {
 	body := []byte(`{"models":{
-		"model-a":{"quotaInfo":{"remainingFraction":0.4,"resetTime":"2026-08-27T15:17:11Z"}},
-		"model-b":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}}
+		"gemini-9-pro-experimental":{"quotaInfo":{"remainingFraction":0.45,"resetTime":"2026-08-27T15:17:11Z"}}
 	}}`)
-	items := parseAntigravityModels(body)
-	if len(items) != 2 {
-		t.Fatalf("buckets=%d, want 2 (same reset, different usage): %+v", len(items), items)
+	pro := quotaByKey(parseAntigravityModels(body), "antigravity:gemini_pro")
+	if pro == nil || pro.Percent == nil || *pro.Percent != 45 {
+		t.Fatalf("pro=%+v, want the only member of the family", pro)
 	}
 }
 
-// A model the upstream ships after this code was written still reaches the
-// card: membership follows the quota it reports, so there is no list to miss.
-func TestParseAntigravityModelsKeepsUnknownModels(t *testing.T) {
+// Unclassified models are unrelated to each other, so each gets its own row
+// under its own name rather than being collapsed into one "other" bar.
+func TestParseAntigravityModelsGivesUnclassifiedModelsTheirOwnRows(t *testing.T) {
 	body := []byte(`{"models":{
-		"gemini-9-ultra":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
-		"brand-new-model":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
-		"tab_flash_lite_preview":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}}
+		"gpt-oss-120b-medium":{"displayName":"GPT-OSS 120B (Medium)","quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
+		"grok-5-fast":{"displayName":"Grok 5 Fast","quotaInfo":{"remainingFraction":0.25,"resetTime":"2026-08-27T15:17:11Z"}}
 	}}`)
 	items := parseAntigravityModels(body)
-	if len(items) != 1 {
-		t.Fatalf("buckets=%d, want 1: %+v", len(items), items)
+	gpt := quotaByKey(items, "antigravity:model_gpt_oss_120b_medium")
+	grok := quotaByKey(items, "antigravity:model_grok_5_fast")
+	if gpt == nil || gpt.QuotaLabel != "GPT-OSS 120B (Medium)" || gpt.Percent == nil || *gpt.Percent != 50 {
+		t.Fatalf("gpt=%+v", gpt)
 	}
-	if items[0].Meta != "brand-new-model,gemini-9-ultra" {
-		t.Fatalf("members=%q, want both unknown models and no internal ones", items[0].Meta)
+	if grok == nil || grok.Percent == nil || *grok.Percent != 25 {
+		t.Fatalf("grok=%+v", grok)
 	}
 }
 

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -344,8 +344,14 @@ func TestParseAntigravityQuotaSummaryUsesUpstreamGrouping(t *testing.T) {
 	if fiveHour.WindowSeconds != antigravityWindowFiveHour {
 		t.Fatalf("gemini 5h window=%d", fiveHour.WindowSeconds)
 	}
-	if fiveHour.QuotaLabel != "Gemini Models · 5h" {
-		t.Fatalf("gemini 5h label=%q", fiveHour.QuotaLabel)
+	// The row is named after the group only; the window is rendered from
+	// WindowSeconds, and the upstream's bucket wording would make the label too
+	// long for a card row.
+	if fiveHour.QuotaLabel != "Gemini Models" {
+		t.Fatalf("gemini 5h label=%q, want the group name alone", fiveHour.QuotaLabel)
+	}
+	if fiveHour.Meta != "Gemini family" {
+		t.Fatalf("gemini 5h meta=%q, want the group description", fiveHour.Meta)
 	}
 
 	weekly := quotaByKey(items, "antigravity:gemini_weekly")
@@ -601,5 +607,38 @@ func TestWeeklyUsedFromQuotasKeepsExactMatchForKeyedProviders(t *testing.T) {
 	}
 	if missing := weeklyUsedFromQuotas(quotas, "seven_day"); missing != nil {
 		t.Fatalf("used=%v, want nil when the declared key is absent", missing)
+	}
+}
+
+// The card composes "<group> · <window>" itself, so the label must carry the
+// group name alone. Pairing it with the upstream's bucket wording produced
+// "Gemini Models · Weekly Limit Remaining", which is too long for a card row
+// and cannot be localised.
+func TestParseAntigravityQuotaSummaryLabelsRowsByGroupOnly(t *testing.T) {
+	body := []byte(`{"groups":[
+		{"displayName":"Gemini Models","description":"Models within this group: Gemini Flash, Gemini Pro","buckets":[
+			{"bucketId":"gemini-weekly","window":"weekly","remainingFraction":0.51,"displayName":"Weekly Limit Remaining"},
+			{"bucketId":"gemini-5h","window":"5h","remainingFraction":0.72,"displayName":"Five Hour Limit Remaining","description":"Quota available"}
+		]}
+	]}`)
+	items := parseAntigravityQuotaSummary(body)
+	if len(items) != 2 {
+		t.Fatalf("items=%d, want 2: %+v", len(items), items)
+	}
+	for _, item := range items {
+		if item.QuotaLabel != "Gemini Models" {
+			t.Fatalf("label=%q, want the group name alone", item.QuotaLabel)
+		}
+	}
+
+	weekly := quotaByKey(items, "antigravity:gemini_weekly")
+	if weekly == nil || weekly.Meta != "Models within this group: Gemini Flash, Gemini Pro" {
+		t.Fatalf("weekly meta=%+v, want the group description", weekly)
+	}
+	// A bucket that describes itself gets both, so the hint says which models
+	// the group covers and what state this particular window is in.
+	fiveHour := quotaByKey(items, "antigravity:gemini_5h")
+	if fiveHour == nil || fiveHour.Meta != "Models within this group: Gemini Flash, Gemini Pro · Quota available" {
+		t.Fatalf("5h meta=%+v, want group and bucket descriptions joined", fiveHour)
 	}
 }

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -274,47 +273,83 @@ func TestResolveXAIPlanUsesEntitlementWhenMonthlyLimitIsZero(t *testing.T) {
 	}
 }
 
-func TestParseAntigravityModelsSummarizesWorstRemainingAndEarliestReset(t *testing.T) {
+// Models sharing a bucket report the same reset and the same remaining
+// fraction. Grouping on those two values reproduces the account's real quota
+// structure; grouping by model family does not, and this payload is the shape
+// a live account actually returns — claude, gpt-oss and gemini-3.x on one
+// weekly bucket, gemini-2.5-* on a separate 5h one.
+func TestParseAntigravityModelsGroupsByTheQuotaModelsShare(t *testing.T) {
 	body := []byte(`{"models":{
-		"gemini-3-pro-high":{"quotaInfo":{"remainingFraction":0.8,"resetTime":"2026-07-20T00:00:00Z"}},
-		"gemini-3.1-pro-low":{"quota_info":{"remaining_fraction":0.4,"reset_time":"2026-07-19T00:00:00Z"}}
+		"claude-sonnet-4-6":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
+		"gpt-oss-120b-medium":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
+		"gemini-3.1-pro-high":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-27T15:17:11Z"}},
+		"gemini-2.5-pro":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-20T20:17:11Z"}},
+		"gemini-2.5-flash":{"quotaInfo":{"remainingFraction":1,"resetTime":"2026-08-20T20:17:11Z"}},
+		"chat_20706":{"quotaInfo":{"remainingFraction":1}}
 	}}`)
 	items := parseAntigravityModels(body)
-	pro := quotaByKey(items, "antigravity:gemini_pro")
-	if pro == nil || pro.Percent == nil || *pro.Percent != 40 || pro.ResetAt == nil || pro.ResetAt.Format(time.RFC3339) != "2026-07-19T00:00:00Z" {
-		t.Fatalf("pro=%+v", pro)
+	if len(items) != 2 {
+		t.Fatalf("buckets=%d, want 2: %+v", len(items), items)
 	}
-	if pro.WindowSeconds != antigravityWindowFiveHour {
-		t.Fatalf("window=%d, want %d", pro.WindowSeconds, antigravityWindowFiveHour)
+
+	// Soonest reset first: the bucket about to run out is the one worth reading.
+	if items[0].ResetAt == nil || items[0].ResetAt.Format(time.RFC3339) != "2026-08-20T20:17:11Z" {
+		t.Fatalf("first bucket reset=%v, want the 5h one", items[0].ResetAt)
+	}
+
+	shortWindow := items[0]
+	if shortWindow.Meta != "gemini-2.5-flash,gemini-2.5-pro" {
+		t.Fatalf("5h bucket members=%q", shortWindow.Meta)
+	}
+	if shortWindow.QuotaKey != "antigravity:group_gemini_2_5_flash" {
+		t.Fatalf("5h bucket key=%q, want it named after its first model", shortWindow.QuotaKey)
+	}
+
+	weekly := items[1]
+	if weekly.Meta != "claude-sonnet-4-6,gemini-3.1-pro-high,gpt-oss-120b-medium" {
+		t.Fatalf("weekly bucket members=%q, want claude, gemini and gpt-oss together", weekly.Meta)
+	}
+
+	// The card counts the members and renders the phrase, so the label is a key
+	// rather than a sentence that could not be localised.
+	for _, item := range items {
+		if item.QuotaLabel != antigravitySharedGroupLabel {
+			t.Fatalf("label=%q, want %q", item.QuotaLabel, antigravitySharedGroupLabel)
+		}
+		if item.Percent == nil || *item.Percent != 100 {
+			t.Fatalf("percent=%+v", item.Percent)
+		}
 	}
 }
 
-// A model the upstream ships after this code was written must still reach the
-// card. The previous grouping dropped anything missing from a hand-written id
-// list, so a new model family silently rendered as nothing at all.
-func TestParseAntigravityModelsKeepsUnknownModels(t *testing.T) {
+// Two buckets that reset at the same instant but differ in usage must stay
+// apart. Keying on the reset alone would merge them and report a shared quota
+// that does not exist.
+func TestParseAntigravityModelsKeepsBucketsWithDifferentUsageApart(t *testing.T) {
 	body := []byte(`{"models":{
-		"gemini-9-ultra":{"quotaInfo":{"remainingFraction":0.5},"displayName":"Gemini 9 Ultra"},
-		"grok-5-fast":{"quotaInfo":{"remainingFraction":0.25},"displayName":"Grok 5 Fast"},
-		"chat_20706":{"quotaInfo":{"remainingFraction":0.9}},
-		"tab_flash_lite_preview":{"quotaInfo":{"remainingFraction":0.9}}
+		"model-a":{"quotaInfo":{"remainingFraction":0.4,"resetTime":"2026-08-27T15:17:11Z"}},
+		"model-b":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}}
 	}}`)
 	items := parseAntigravityModels(body)
+	if len(items) != 2 {
+		t.Fatalf("buckets=%d, want 2 (same reset, different usage): %+v", len(items), items)
+	}
+}
 
-	// gemini-9-ultra has neither "flash" nor "pro" nor "image" in its id, so it
-	// lands in the unclassified bucket under its own name rather than vanishing.
-	ultra := quotaByKey(items, "antigravity:model_gemini_9_ultra")
-	if ultra == nil || ultra.Percent == nil || *ultra.Percent != 50 || ultra.QuotaLabel != "Gemini 9 Ultra" {
-		t.Fatalf("ultra=%+v", ultra)
+// A model the upstream ships after this code was written still reaches the
+// card: membership follows the quota it reports, so there is no list to miss.
+func TestParseAntigravityModelsKeepsUnknownModels(t *testing.T) {
+	body := []byte(`{"models":{
+		"gemini-9-ultra":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
+		"brand-new-model":{"quotaInfo":{"remainingFraction":0.5,"resetTime":"2026-08-27T15:17:11Z"}},
+		"tab_flash_lite_preview":{"quotaInfo":{"remainingFraction":0.9,"resetTime":"2026-08-27T15:17:11Z"}}
+	}}`)
+	items := parseAntigravityModels(body)
+	if len(items) != 1 {
+		t.Fatalf("buckets=%d, want 1: %+v", len(items), items)
 	}
-	grok := quotaByKey(items, "antigravity:model_grok_5_fast")
-	if grok == nil || grok.Percent == nil || *grok.Percent != 25 {
-		t.Fatalf("grok=%+v", grok)
-	}
-	for _, item := range items {
-		if strings.Contains(item.QuotaKey, "chat_") || strings.Contains(item.QuotaKey, "tab_") {
-			t.Fatalf("internal model leaked into quotas: %+v", item)
-		}
+	if items[0].Meta != "brand-new-model,gemini-9-ultra" {
+		t.Fatalf("members=%q, want both unknown models and no internal ones", items[0].Meta)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -92,143 +91,23 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	baseModel := strings.TrimSpace(req.Model)
-	isClaude := strings.Contains(strings.ToLower(baseModel), "claude")
-
-	if isClaude || strings.Contains(baseModel, "gemini-3-pro") {
-		return e.executeClaudeNonStream(ctx, auth, req, opts)
-	}
-
-	token, updatedAuth, errToken := e.ensureAccessToken(ctx, auth)
-	if errToken != nil {
-		return resp, errToken
-	}
-	if updatedAuth != nil {
-		auth = updatedAuth
-	}
-
-	execCtx := e.newAntigravityExecutionContext(ctx, auth, req, opts, false)
-	reporter := execCtx.Reporter()
-	defer reporter.trackFailure(execCtx.Context, &err)
-	translated, err := e.buildAntigravityPayload(execCtx)
-	if err != nil {
-		return resp, err
-	}
-
-	baseURLs := antigravityBaseURLFallbackOrder(auth)
-	httpClient := execCtx.HTTPClient(0)
-	recorder := execCtx.Recorder()
-
-	attempts := antigravityRetryAttempts(auth, e.cfg)
-
-attemptLoop:
-	for attempt := 0; attempt < attempts; attempt++ {
-		var lastStatus int
-		var lastBody []byte
-		var lastErr error
-
-		for idx, baseURL := range baseURLs {
-			httpReq, requestBody, errReq := e.buildRequest(execCtx.Context, auth, token, execCtx.BaseModel, translated, false, opts.Alt, baseURL)
-			if errReq != nil {
-				err = errReq
-				return resp, err
-			}
-			recorder.RecordRequest(httpReq.URL.String(), httpReq.Method, httpReq.Header.Clone(), requestBody)
-
-			httpResp, errDo := httpClient.Do(httpReq)
-			if errDo != nil {
-				recorder.RecordResponseError(errDo)
-				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-					return resp, errDo
-				}
-				lastStatus = 0
-				lastBody = nil
-				lastErr = errDo
-				if idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
-				err = errDo
-				return resp, err
-			}
-
-			recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
-			readBody := readUpstreamResponseBody
-			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
-				readBody = func(provider string, r io.Reader) ([]byte, error) {
-					return readUpstreamErrorBody(provider, r), nil
-				}
-			}
-			bodyBytes, errRead := readBody("antigravity", httpResp.Body)
-			if errClose := httpResp.Body.Close(); errClose != nil {
-				log.Errorf("antigravity executor: close response body error: %v", errClose)
-			}
-			if errRead != nil {
-				recorder.RecordResponseError(errRead)
-				err = errRead
-				return resp, err
-			}
-			recorder.AppendResponseChunk(bodyBytes)
-
-			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
-				log.Debugf("antigravity executor: upstream error status: %d, body: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), bodyBytes))
-				lastStatus = httpResp.StatusCode
-				lastBody = append([]byte(nil), bodyBytes...)
-				lastErr = nil
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
-				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
-					if idx+1 < len(baseURLs) {
-						log.Debugf("antigravity executor: no capacity on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-						continue
-					}
-					if attempt+1 < attempts {
-						delay := antigravityNoCapacityRetryDelay(attempt)
-						log.Debugf("antigravity executor: no capacity for model %s, retrying in %s (attempt %d/%d)", execCtx.BaseModel, delay, attempt+1, attempts)
-						if errWait := antigravityWait(ctx, delay); errWait != nil {
-							return resp, errWait
-						}
-						continue attemptLoop
-					}
-				}
-				sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
-				if httpResp.StatusCode == http.StatusTooManyRequests {
-					if retryAfter, parseErr := parseRetryDelay(bodyBytes); parseErr == nil && retryAfter != nil {
-						sErr.retryAfter = retryAfter
-					}
-				}
-				err = sErr
-				return resp, err
-			}
-
-			reporter.publishWithContent(execCtx.Context, parseAntigravityUsage(bodyBytes), string(req.Payload), string(bodyBytes))
-			var param any
-			converted := sdktranslator.TranslateNonStream(execCtx.Context, execCtx.Execution.TargetFormat, execCtx.SourceFormat, req.Model, execCtx.OriginalPayload, translated, bodyBytes, &param)
-			resp = cliproxyexecutor.Response{Payload: []byte(converted), Headers: httpResp.Header.Clone()}
-			reporter.ensurePublished(execCtx.Context)
-			return resp, nil
-		}
-
-		switch {
-		case lastStatus != 0:
-			sErr := statusErr{code: lastStatus, msg: string(lastBody)}
-			if lastStatus == http.StatusTooManyRequests {
-				if retryAfter, parseErr := parseRetryDelay(lastBody); parseErr == nil && retryAfter != nil {
-					sErr.retryAfter = retryAfter
-				}
-			}
-			err = sErr
-		case lastErr != nil:
-			err = lastErr
-		default:
-			err = statusErr{code: http.StatusServiceUnavailable, msg: "antigravity executor: no base url available"}
-		}
-		return resp, err
-	}
-
-	return resp, err
+	// Every non-streaming request is served by asking the streaming endpoint and
+	// assembling the result.
+	//
+	// The upstream's :generateContent does not work for the whole model range.
+	// Production data over a week: 41 non-streaming calls to gemini-3.7-flash-*
+	// failed without exception while 38 streaming calls to the same model on the
+	// same account all succeeded; gemini-2.5-flash, meanwhile, worked either way.
+	// So the endpoint's coverage varies per model and cannot be predicted from
+	// the name.
+	//
+	// This detour already existed but was gated on `claude` or `gemini-3-pro`
+	// appearing in the model id — a list that silently excluded every model
+	// added since, including the gemini-3.x line. Rather than extending the list
+	// on each incident, every model now takes the path that is known to work for
+	// all of them: :streamGenerateContent is what ordinary streaming requests
+	// use, so it is exercised continuously by real traffic.
+	return e.executeViaStreamEndpoint(ctx, auth, req, opts)
 }
 
 // ExecuteStream performs a streaming request to the Antigravity API.

--- a/internal/runtime/executor/antigravity_nonstream.go
+++ b/internal/runtime/executor/antigravity_nonstream.go
@@ -17,8 +17,13 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// executeClaudeNonStream performs a claude non-streaming request to the Antigravity API.
-func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+// executeViaStreamEndpoint serves a non-streaming request by calling the
+// upstream's streaming endpoint and assembling the chunks into one response.
+//
+// Named for what it does rather than for claude, which is all it used to serve:
+// the endpoint choice is about which upstream path actually works, not about
+// which model family asked.
+func (e *AntigravityExecutor) executeViaStreamEndpoint(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/internal/runtime/executor/antigravity_nonstream_routing_test.go
+++ b/internal/runtime/executor/antigravity_nonstream_routing_test.go
@@ -1,0 +1,65 @@
+package executor
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Non-streaming requests must not be routed by model name.
+//
+// The upstream's :generateContent works for some models and not others —
+// gemini-3.7-flash-* failed 41 out of 41 non-streaming calls in production
+// while succeeding on every streaming one. The previous dispatch sent only
+// `claude` and `gemini-3-pro` down the working path, so each newly shipped
+// model silently inherited the broken one until someone noticed.
+//
+// This asserts on the source because the failure mode is a routing decision
+// that no unit-level call can observe: both paths return a valid response
+// against a stub, and only the chosen URL differs.
+func TestExecuteRoutesEveryModelThroughTheStreamEndpoint(t *testing.T) {
+	source, err := os.ReadFile("antigravity_executor.go")
+	if err != nil {
+		t.Fatalf("read executor source: %v", err)
+	}
+	body := string(source)
+	start := strings.Index(body, "func (e *AntigravityExecutor) Execute(")
+	if start < 0 {
+		t.Fatal("Execute not found")
+	}
+	end := strings.Index(body[start:], "\nfunc ")
+	if end < 0 {
+		end = len(body) - start
+	}
+	execute := body[start : start+end]
+
+	if !strings.Contains(execute, "executeViaStreamEndpoint") {
+		t.Fatal("Execute must delegate to executeViaStreamEndpoint")
+	}
+	// A model-name condition here is the bug this test exists to prevent.
+	for _, marker := range []string{`"gemini-3-pro"`, "isClaude", `"claude"`} {
+		if strings.Contains(execute, marker) {
+			t.Fatalf("Execute routes on model name (%s); every model must take the same path", marker)
+		}
+	}
+}
+
+// The detour is only meaningful if it actually asks for the streaming endpoint.
+func TestNonStreamPathRequestsTheStreamingEndpoint(t *testing.T) {
+	source, err := os.ReadFile("antigravity_nonstream.go")
+	if err != nil {
+		t.Fatalf("read nonstream source: %v", err)
+	}
+	body := string(source)
+	if !strings.Contains(body, "executeViaStreamEndpoint") {
+		t.Fatal("executeViaStreamEndpoint not found")
+	}
+	if !strings.Contains(body, "convertStreamToNonStream") {
+		t.Fatal("the streamed reply must be assembled back into one response")
+	}
+	// buildRequest's stream flag selects :streamGenerateContent over
+	// :generateContent; passing false here would silently restore the bug.
+	if !strings.Contains(body, "execCtx.BaseModel, translated, true,") {
+		t.Fatal("buildRequest must be called with stream=true so the streaming endpoint is used")
+	}
+}

--- a/internal/runtime/executor/antigravity_request.go
+++ b/internal/runtime/executor/antigravity_request.go
@@ -54,6 +54,16 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 
 	useAntigravitySchema := strings.Contains(modelName, "claude") || strings.Contains(modelName, "gemini-3-pro-high")
 	payloadStr := string(payload)
+
+	// The upstream accepts only "user" and "model" here and rejects anything
+	// else with a bare 400 INVALID_ARGUMENT naming no field. Claude Code sends
+	// "system" turns inside `messages` in addition to the top-level `system`
+	// field, and the Claude translator forwards any role it does not recognise
+	// unchanged, so those reached the upstream verbatim and failed the request.
+	//
+	// Normalising here rather than in the translator covers every entrypoint
+	// format at once: this is the last point all of them pass through.
+	payloadStr = util.NormalizeGeminiContentRoles(payloadStr, "request.contents")
 	paths := make([]string, 0)
 	util.Walk(gjson.Parse(payloadStr), "", "parametersJsonSchema", &paths)
 	for _, p := range paths {

--- a/internal/runtime/executor/antigravity_request.go
+++ b/internal/runtime/executor/antigravity_request.go
@@ -229,9 +229,13 @@ func antigravityBaseURLFallbackOrder(auth *cliproxyauth.Auth) []string {
 	if base := resolveCustomAntigravityBaseURL(auth); base != "" {
 		return []string{base}
 	}
+	// Sandbox first: the non-sandbox daily host throttles far more readily, and
+	// every 429 it returns costs a retry and risks being read as an exhausted
+	// quota. Production logs showed the daily host rate-limiting requests that
+	// the sandbox host then served without complaint.
 	return []string{
-		antigravityBaseURLDaily,
 		antigravitySandboxBaseURLDaily,
+		antigravityBaseURLDaily,
 		// antigravityBaseURLProd,
 	}
 }

--- a/internal/runtime/executor/antigravity_usage_content_test.go
+++ b/internal/runtime/executor/antigravity_usage_content_test.go
@@ -19,11 +19,15 @@ import (
 func TestAntigravityExecutePublishesUsageContent(t *testing.T) {
 	setUsageBodyCaptureForTest(t, true)
 	const input = `{"request":{"contents":[{"role":"user","parts":[{"text":"ag input marker"}]}]}}`
-	const output = `{"response":{"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":3,"totalTokenCount":5}}}`
+	// A non-streaming Execute now asks the streaming endpoint and assembles the
+	// reply, because :generateContent is not available for every model. The
+	// stub therefore speaks SSE even though the caller wants one response.
+	const output = `data: {"response":{"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":3,"totalTokenCount":5}}}` + "\n\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != antigravityGeneratePath {
+		if r.URL.Path != antigravityStreamPath {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte(output))
 	}))
 	defer server.Close()

--- a/internal/usage/ai_account_subject_status_store.go
+++ b/internal/usage/ai_account_subject_status_store.go
@@ -56,6 +56,25 @@ type AIAccountSubjectStatusRecord struct {
 // varies the order it reports windows in.
 func mergeQuotaWindows(previous, incoming []QuotaWindowDTO, observedAt time.Time) []QuotaWindowDTO {
 	observedAt = observedAt.UTC()
+	// A provider whose probe always returns the full picture gets replacement
+	// instead: carrying a window forward there can only preserve a key the
+	// provider has stopped using. Renaming antigravity's keys once left the card
+	// rendering both the old and the new set side by side for a whole retention
+	// window, which reads as duplicated quotas.
+	if len(incoming) > 0 && quotaPayloadIsCompleteSnapshot(incoming) {
+		replaced := make([]QuotaWindowDTO, 0, len(incoming))
+		for _, window := range incoming {
+			key := strings.TrimSpace(window.QuotaKey)
+			if key == "" {
+				continue
+			}
+			window.QuotaKey = key
+			stamp := observedAt
+			window.ObservedAt = &stamp
+			replaced = append(replaced, window)
+		}
+		return replaced
+	}
 	incomingByKey := make(map[string]QuotaWindowDTO, len(incoming))
 	incomingOrder := make([]string, 0, len(incoming))
 	for _, window := range incoming {
@@ -102,6 +121,23 @@ func mergeQuotaWindows(previous, incoming []QuotaWindowDTO, observedAt time.Time
 		merged = append(merged, incomingByKey[key])
 	}
 	return merged
+}
+
+// quotaPayloadIsCompleteSnapshot reports whether every window in the payload
+// comes from a provider that reports all of its windows on every probe.
+//
+// Codex is the counter-example this merge exists for: it answers with only
+// `rate_limit` or only `additional_rate_limits` on roughly a fifth of probes,
+// so a missing window there means "not mentioned", not "gone". Antigravity's
+// two endpoints each return the account's full quota set or nothing at all,
+// so a missing window genuinely means the provider dropped it.
+func quotaPayloadIsCompleteSnapshot(windows []QuotaWindowDTO) bool {
+	for _, window := range windows {
+		if !strings.HasPrefix(strings.TrimSpace(window.QuotaKey), "antigravity:") {
+			return false
+		}
+	}
+	return true
 }
 
 // applyQuotaObservedFallback fills per-window ObservedAt for rows written before

--- a/internal/usage/ai_account_subject_status_store_test.go
+++ b/internal/usage/ai_account_subject_status_store_test.go
@@ -174,3 +174,56 @@ func TestProbeFailureKeepsQuotaObservationTimeBehind(t *testing.T) {
 		t.Fatal("attempt time must be strictly newer than the quota it describes")
 	}
 }
+
+// Antigravity reports its whole quota set on every probe, so a key the payload
+// no longer contains is genuinely gone. Carrying it forward is what left the
+// card showing the old and the new key set side by side after a rename.
+func TestMergeQuotaWindowsReplacesCompleteSnapshots(t *testing.T) {
+	now := time.Now().UTC()
+	old := now.Add(-time.Hour)
+	pct := func(v float64) *float64 { return &v }
+	previous := []QuotaWindowDTO{
+		{QuotaKey: "antigravity:group_old_name", Percent: pct(10), ObservedAt: &old},
+	}
+	incoming := []QuotaWindowDTO{
+		{QuotaKey: "antigravity:gemini_pro", Percent: pct(80)},
+		{QuotaKey: "antigravity:claude", Percent: pct(90)},
+	}
+	merged := mergeQuotaWindows(previous, incoming, now)
+	if len(merged) != 2 {
+		t.Fatalf("merged=%d, want only the incoming snapshot: %+v", len(merged), merged)
+	}
+	for _, window := range merged {
+		if window.QuotaKey == "antigravity:group_old_name" {
+			t.Fatal("a key the provider stopped sending must not survive a full snapshot")
+		}
+		if window.ObservedAt == nil || !window.ObservedAt.Equal(now) {
+			t.Fatalf("window %q kept a stale timestamp", window.QuotaKey)
+		}
+	}
+}
+
+// Codex answers with a subset on roughly a fifth of probes, so a window missing
+// from one payload must keep its previous value and its original timestamp.
+func TestMergeQuotaWindowsStillCarriesPartialProvidersForward(t *testing.T) {
+	now := time.Now().UTC()
+	old := now.Add(-time.Hour)
+	pct := func(v float64) *float64 { return &v }
+	previous := []QuotaWindowDTO{
+		{QuotaKey: "code_week", Percent: pct(60), ObservedAt: &old},
+		{QuotaKey: "review_week", Percent: pct(70), ObservedAt: &old},
+	}
+	incoming := []QuotaWindowDTO{{QuotaKey: "code_week", Percent: pct(55)}}
+	merged := mergeQuotaWindows(previous, incoming, now)
+	if len(merged) != 2 {
+		t.Fatalf("merged=%d, want the unmentioned window carried forward: %+v", len(merged), merged)
+	}
+	for _, window := range merged {
+		if window.QuotaKey != "review_week" {
+			continue
+		}
+		if window.ObservedAt == nil || !window.ObservedAt.Equal(old) {
+			t.Fatal("a carried-forward window must keep its original timestamp")
+		}
+	}
+}

--- a/internal/util/gemini_role.go
+++ b/internal/util/gemini_role.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// NormalizeGeminiContentRole maps a message role onto one of the two roles
+// Gemini accepts in `contents[].role`.
+//
+// Gemini rejects anything else with a bare 400 INVALID_ARGUMENT that names no
+// field, which makes the cause expensive to find. The Claude translators rewrite
+// "assistant" and pass every other role through untouched, so a "system" entry
+// inside `messages` — which Claude Code sends alongside the top-level `system`
+// field — reached the upstream verbatim and failed the whole request.
+//
+// An allowlist rather than a list of roles to rewrite: a role this code has
+// never heard of becomes "user" and its text still reaches the model, instead
+// of being forwarded as an invalid value.
+func NormalizeGeminiContentRole(role string) string {
+	switch role {
+	case "assistant", "model":
+		return "model"
+	default:
+		return "user"
+	}
+}
+
+// NormalizeGeminiContentRoles rewrites every contents[].role in an Antigravity
+// or Gemini request payload so the upstream cannot be sent a role it rejects.
+//
+// This runs at the executor rather than in the translators because it is the
+// last point every request passes through regardless of which entrypoint format
+// produced it: fixing one translator would leave the same defect reachable via
+// the others.
+func NormalizeGeminiContentRoles(payload string, contentsPath string) string {
+	contents := gjson.Get(payload, contentsPath)
+	if !contents.IsArray() {
+		return payload
+	}
+	updated := payload
+	index := 0
+	contents.ForEach(func(_, content gjson.Result) bool {
+		role := content.Get("role")
+		if role.Type == gjson.String {
+			if normalized := NormalizeGeminiContentRole(role.String()); normalized != role.String() {
+				updated, _ = sjson.Set(updated, fmt.Sprintf("%s.%d.role", contentsPath, index), normalized)
+			}
+		}
+		index++
+		return true
+	})
+	return updated
+}

--- a/internal/util/gemini_role_test.go
+++ b/internal/util/gemini_role_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// Gemini accepts only "user" and "model" in contents[].role and rejects
+// anything else with a bare 400 INVALID_ARGUMENT that names no field.
+func TestNormalizeGeminiContentRole(t *testing.T) {
+	cases := map[string]string{
+		"user":      "user",
+		"assistant": "model",
+		"model":     "model",
+		// Claude Code sends system entries inside `messages` alongside the
+		// top-level `system` field. Forwarded verbatim, they failed the whole
+		// request; as "user" the text still reaches the model.
+		"system": "user",
+		// Roles this code has never seen must not reach the upstream either.
+		"tool":      "user",
+		"developer": "user",
+		"":          "user",
+	}
+	for input, want := range cases {
+		if got := NormalizeGeminiContentRole(input); got != want {
+			t.Fatalf("role %q -> %q, want %q", input, got, want)
+		}
+	}
+}
+
+// The payload-level pass is what actually protects the upstream: it runs at the
+// executor, after any translator has produced the request, so a role no
+// translator normalised still cannot escape.
+func TestNormalizeGeminiContentRolesRewritesPayload(t *testing.T) {
+	payload := `{"request":{"contents":[
+		{"role":"user","parts":[{"text":"one"}]},
+		{"role":"system","parts":[{"text":"stray"}]},
+		{"role":"assistant","parts":[{"text":"two"}]},
+		{"role":"tool","parts":[{"text":"three"}]}
+	]}}`
+	out := NormalizeGeminiContentRoles(payload, "request.contents")
+
+	roles := gjson.Get(out, "request.contents.#.role").Array()
+	want := []string{"user", "user", "model", "user"}
+	if len(roles) != len(want) {
+		t.Fatalf("contents = %d, want %d", len(roles), len(want))
+	}
+	for i, role := range roles {
+		if role.String() != want[i] {
+			t.Fatalf("contents[%d].role = %q, want %q", i, role.String(), want[i])
+		}
+	}
+	// Only the role is rewritten; the turn's text must survive.
+	if !strings.Contains(out, "stray") {
+		t.Fatal("text of the rewritten turn was dropped")
+	}
+}
+
+// A payload without contents must pass through untouched rather than being
+// rewritten into something the upstream cannot parse.
+func TestNormalizeGeminiContentRolesLeavesOtherPayloadsAlone(t *testing.T) {
+	for _, payload := range []string{`{}`, `{"request":{}}`, `{"request":{"contents":"nope"}}`} {
+		if got := NormalizeGeminiContentRoles(payload, "request.contents"); got != payload {
+			t.Fatalf("payload %s was rewritten to %s", payload, got)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/conductor_cooldown_service.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_service.go
@@ -268,6 +268,19 @@ func (s cooldownService) applyModelFailureLocked(auth *Auth, result Result, now 
 			effects.suspendReason = "not_found"
 			effects.shouldSuspendModel = true
 		case 429:
+			// A 429 is not automatically an exhausted quota. Google's CloudCode
+			// answers "Resource has been exhausted" for ordinary per-minute
+			// throttling, and treating that as quota exhaustion suspends the
+			// model on an account that still has its full allowance.
+			//
+			// Observed in production: an antigravity account reporting 100%
+			// remaining cycled suspend → resume → suspend within five seconds,
+			// repeatedly, because the first request after each recovery drew
+			// another throttling 429 and was again read as exhaustion.
+			if isTransientRateLimitError(result.Error) {
+				applyTransientRateLimitLocked(auth, state, result, now, effects)
+				break
+			}
 			applyModelQuotaFailureLocked(auth, state, result, now, effects)
 		case 408, 500, 502, 503, 504:
 			if quotaCooldownDisabledForAuth(auth) {
@@ -342,6 +355,69 @@ func isQuotaExhaustionError(err *Error, retryAfter *time.Duration) bool {
 	}
 	return isUsageBalanceExhaustedMessage(err.Message)
 }
+
+// isTransientRateLimitError reports whether a 429 describes short-term
+// throttling rather than an exhausted allowance.
+//
+// The distinction is in the body: providers name an exhausted quota explicitly
+// ("quota_exhausted", a quotaResetDelay, a daily quota), whereas a bare
+// "resource has been exhausted" is the generic throttle Google returns for
+// per-minute limits. Anything not recognised as throttling keeps the previous
+// behaviour and is treated as exhaustion, so this can only narrow the cases
+// that suspend a model, never widen them.
+func isTransientRateLimitError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	body := strings.ToLower(err.Message)
+	if body == "" {
+		return false
+	}
+	for _, explicit := range []string{
+		"quota_exhausted", "quotaresetdelay", "quota reset",
+		"quota limit", "daily quota", "usage balance exhausted", "balance exhausted",
+	} {
+		if strings.Contains(body, explicit) {
+			return false
+		}
+	}
+	return strings.Contains(body, "resource has been exhausted") ||
+		strings.Contains(body, "resource_exhausted") ||
+		strings.Contains(body, "rate limit") ||
+		strings.Contains(body, "too many requests")
+}
+
+// applyTransientRateLimitLocked backs off briefly without declaring the model
+// out of quota: no quota state, no suspension, so the next scheduling pass can
+// use the account again instead of parking it behind a quota cooldown.
+func applyTransientRateLimitLocked(auth *Auth, state *ModelState, result Result, now time.Time, effects *resultStateEffects) {
+	if state == nil {
+		return
+	}
+	cooldown := transientRateLimitCooldown
+	if result.RetryAfter != nil && *result.RetryAfter > 0 {
+		cooldown = *result.RetryAfter
+	}
+	if quotaCooldownDisabledForAuth(auth) {
+		cooldown = 0
+	}
+	if cooldown > 0 {
+		state.NextRetryAfter = now.Add(cooldown)
+	} else {
+		state.NextRetryAfter = time.Time{}
+	}
+	// Explicitly clear any quota flag a previous misclassification may have set,
+	// so one throttled request cannot leave the model parked indefinitely.
+	state.Quota = QuotaState{}
+	effects.clearModelQuota = true
+	auth.Status = StatusError
+	auth.UpdatedAt = now
+	updateAggregatedAvailability(auth, now)
+}
+
+// transientRateLimitCooldown matches the shortest window a provider realistically
+// throttles on; a per-minute limit clears within it.
+const transientRateLimitCooldown = time.Minute
 
 func isUsageBalanceExhaustedMessage(message string) bool {
 	lower := strings.ToLower(strings.TrimSpace(message))

--- a/sdk/cliproxy/auth/conductor_rate_limit_test.go
+++ b/sdk/cliproxy/auth/conductor_rate_limit_test.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// Google's CloudCode returns "Resource has been exhausted" for ordinary
+// per-minute throttling. Reading that as an exhausted quota suspended models on
+// accounts that still had their full allowance, producing a suspend → resume →
+// suspend loop within seconds.
+func TestTransientRateLimitIsNotQuotaExhaustion(t *testing.T) {
+	throttles := []string{
+		"Resource has been exhausted (e.g. check quota).",
+		`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED"}}`,
+		"rate limit exceeded",
+		"Too Many Requests",
+	}
+	for _, message := range throttles {
+		if !isTransientRateLimitError(&Error{Message: message}) {
+			t.Fatalf("%q should be treated as throttling, not exhaustion", message)
+		}
+	}
+}
+
+// An explicitly named quota keeps the old behaviour: it really is exhausted and
+// the model should be parked until the window resets.
+func TestNamedQuotaExhaustionStillCountsAsExhaustion(t *testing.T) {
+	exhausted := []string{
+		`{"error":{"details":[{"reason":"QUOTA_EXHAUSTED"}]}}`,
+		`{"error":{"details":[{"metadata":{"quotaResetDelay":"2h1m1s"}}]}}`,
+		"Quota limit 'Tokens per minute' exceeded",
+		"daily quota reached",
+		"usage balance exhausted",
+	}
+	for _, message := range exhausted {
+		if isTransientRateLimitError(&Error{Message: message}) {
+			t.Fatalf("%q names a quota and must stay an exhaustion", message)
+		}
+	}
+}
+
+// The real-world message that caused the loop: it contains the word "quota"
+// only inside the generic hint, which must not tip the classification.
+func TestGenericExhaustedHintMentioningQuotaIsStillThrottling(t *testing.T) {
+	err := &Error{Message: `{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`}
+	if !isTransientRateLimitError(err) {
+		t.Fatal("the parenthetical 'check quota' hint must not make this an exhaustion")
+	}
+}
+
+// Nothing recognisable keeps the previous behaviour, so this change can only
+// narrow which failures suspend a model.
+func TestUnrecognisedMessageFallsBackToExhaustion(t *testing.T) {
+	for _, message := range []string{"", "upstream exploded"} {
+		if isTransientRateLimitError(&Error{Message: message}) {
+			t.Fatalf("%q must not be classified as throttling", message)
+		}
+	}
+	if isTransientRateLimitError(nil) {
+		t.Fatal("nil error must not be classified as throttling")
+	}
+}
+
+// Throttling must leave no quota state behind, otherwise the model stays parked
+// even though its allowance was never the problem.
+func TestTransientRateLimitClearsQuotaStateAndDoesNotSuspend(t *testing.T) {
+	auth := &Auth{}
+	state := &ModelState{Quota: QuotaState{Exceeded: true, Reason: "quota"}}
+	effects := &resultStateEffects{}
+	now := time.Now().UTC()
+
+	applyTransientRateLimitLocked(auth, state, Result{}, now, effects)
+
+	if state.Quota.Exceeded {
+		t.Fatal("quota flag must be cleared for a throttled request")
+	}
+	if effects.shouldSuspendModel {
+		t.Fatal("throttling must not suspend the model")
+	}
+	if !effects.clearModelQuota {
+		t.Fatal("a previously misclassified quota flag must be cleared")
+	}
+	if !state.NextRetryAfter.After(now) {
+		t.Fatal("a short backoff should still be applied")
+	}
+}
+
+// A provider-supplied Retry-After wins over the default backoff.
+func TestTransientRateLimitHonoursRetryAfter(t *testing.T) {
+	auth := &Auth{}
+	state := &ModelState{}
+	effects := &resultStateEffects{}
+	now := time.Now().UTC()
+	retry := 10 * time.Second
+
+	applyTransientRateLimitLocked(auth, state, Result{RetryAfter: &retry}, now, effects)
+
+	if got := state.NextRetryAfter.Sub(now); got < 9*time.Second || got > 11*time.Second {
+		t.Fatalf("backoff = %s, want the provider's 10s", got)
+	}
+}


### PR DESCRIPTION
Promotes the verified `dev` branch to `main` for **v0.4.27**.

## What matters most in this release

Antigravity quota on the card is now the quota the account actually draws on, and two production failure modes that looked like "the model is broken" are fixed at the source.

The card used to invent a grouping the upstream never reported, then aggregate unrelated buckets into one family row. A live account has Claude, GPT-OSS and Gemini 3.x sharing one weekly quota while Gemini 2.5 sits in its own 5-hour bucket — so a "Gemini Pro" row was reporting a pair of numbers true of neither model. The card now labels by the group the upstream uses, keeps both windows, and never averages across buckets.

Separately, `gemini-3.7-flash-high` failed for every non-streaming caller while streaming callers on the same account succeeded. Non-streaming is now routed through the stream endpoint. After that deploy, the same account was still being suspended for "quota" on ordinary per-minute 429s even though every quota probe reported 100% remaining — throttling 429s are no longer treated as exhausted quota.

## Key fixes and improvements

- **Quota rows are labelled by group, not by a concatenated English sentence** (#913): the window lives in `WindowSeconds` so the panel can localise it; the upstream's description moves into `Meta`.
- **Fallback quotas group by the bucket models actually share** (#914): Claude, GPT-OSS and Gemini 3.x share one weekly quota on the live account; Gemini 2.5 has its own 5-hour bucket. The split is by generation, not by family.
- **One representative model per family, not an aggregate** (#915): aggregating a family took the minimum across members that do not share a bucket, so the row reported numbers true of neither model.
- **Every non-streaming Antigravity request goes through the stream endpoint** (#916): one week of production traffic had 41 non-streaming failures and 38 streaming successes on the same account and model. Clients that stream by default never saw it.
- **Throttling 429s are not exhausted quota** (#917): CloudCode answers ordinary per-minute throttling with a 429 whose message is `Resource has been exhausted`, which the conductor treated as quota and suspended the account. The account's own probe stayed at 100%.
- **Contents roles Gemini cannot accept are normalised** (#918): the upstream accepts only `user` and `model`. Claude Code sends `system` turns inside `messages`; those reached CloudCode unchanged and failed the entire request with `INVALID_ARGUMENT`.

## Compatibility and upgrade notes

- No deploy-script or host change in this release.
- Quota payload shape stays `antigravity:*`. Pair with codeProxy **v0.4.27** so the card can render both windows and the shared-bucket grouping; an older panel still reads the payload, it just cannot show the extra window or the "N models share" copy.
- No data migration.

## Verification

- All 6 merged `dev` PRs passed `build` / `vulncheck` / `ensure-no-translator-changes`.
- Local on the release branch: `rtk go test ./internal/management/aiaccountstatus/ ./internal/runtime/executor/ ./internal/usage/ ./internal/util/ ./sdk/cliproxy/auth/` → 1147 passed.