### PR TITLE
fix(providers): stop dropping Codex channels that use the default endpoint

### DIFF
--- a/internal/config/codex_keys_test.go
+++ b/internal/config/codex_keys_test.go
@@ -1,0 +1,31 @@
+package config
+
+import "testing"
+
+// A Codex row is usable when it carries a credential. An empty base-url means
+// "use the default Codex endpoint" (see CodexKey.BaseURL), which is also what
+// the runtime synthesizer assumes, so sanitising must not drop those rows.
+func TestSanitizeCodexKeysKeepsRowsWithoutBaseURL(t *testing.T) {
+	cfg := &Config{
+		CodexKey: []CodexKey{
+			{APIKey: " default-endpoint ", Prefix: " team "},
+			{APIKey: "third-party", BaseURL: " https://codex.example ", ProxyURL: " http://proxy.example "},
+			{APIKey: " ", BaseURL: "https://no-credential.example"},
+		},
+	}
+
+	cfg.SanitizeCodexKeys()
+
+	if len(cfg.CodexKey) != 2 {
+		t.Fatalf("CodexKey length = %d, want 2 (%#v)", len(cfg.CodexKey), cfg.CodexKey)
+	}
+	if got := cfg.CodexKey[0]; got.APIKey != "default-endpoint" || got.BaseURL != "" {
+		t.Fatalf("default-endpoint row = %#v, want kept with empty base url", got)
+	}
+	if cfg.CodexKey[0].Prefix != "team" {
+		t.Fatalf("prefix = %q, want team", cfg.CodexKey[0].Prefix)
+	}
+	if got := cfg.CodexKey[1]; got.BaseURL != "https://codex.example" || got.ProxyURL != "http://proxy.example" {
+		t.Fatalf("third-party row = %#v, want trimmed url fields", got)
+	}
+}

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -156,8 +156,14 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 	cfg.OpenAICompatibility = out
 }
 
-// SanitizeCodexKeys removes Codex API key entries missing a BaseURL.
+// SanitizeCodexKeys removes Codex API key entries missing an APIKey.
 // It trims whitespace and preserves order for remaining entries.
+//
+// The credential, not the endpoint, is what makes a Codex row usable: an empty
+// BaseURL means "use the default Codex endpoint" (see CodexKey.BaseURL), and the
+// runtime synthesizer only skips rows without an api-key. Dropping rows on an
+// empty BaseURL here silently deleted channels the operator had just saved
+// through the management API, which returned 200 all the same.
 func (cfg *Config) SanitizeCodexKeys() {
 	if cfg == nil || len(cfg.CodexKey) == 0 {
 		return
@@ -165,13 +171,14 @@ func (cfg *Config) SanitizeCodexKeys() {
 	out := make([]CodexKey, 0, len(cfg.CodexKey))
 	for i := range cfg.CodexKey {
 		e := cfg.CodexKey[i]
+		e.APIKey = strings.TrimSpace(e.APIKey)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
 		e.ProxyURL = strings.TrimSpace(e.ProxyURL)
 		e.ProxyID = strings.TrimSpace(e.ProxyID)
 		e.Headers = NormalizeHeaders(e.Headers)
 		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
-		if e.BaseURL == "" {
+		if e.APIKey == "" {
 			continue
 		}
 		out = append(out, e)

--- a/internal/management/settings/providers/provider_keys_primary.go
+++ b/internal/management/settings/providers/provider_keys_primary.go
@@ -274,13 +274,14 @@ func (s *Service) ReplaceCodexKeys(entries []config.CodexKey) error {
 	if s == nil || s.cfg == nil {
 		return nil
 	}
+	// Normalization only. Rows are dropped by SanitizeCodexKeys below, which
+	// keys on api-key like every other channel: an empty base-url means "use
+	// the default Codex endpoint", so filtering on it here silently discarded
+	// channels this call was asked to persist and still answered 200.
 	filtered := make([]config.CodexKey, 0, len(entries))
 	for i := range entries {
 		entry := entries[i]
 		NormalizeCodexKey(&entry)
-		if entry.BaseURL == "" {
-			continue
-		}
 		filtered = append(filtered, entry)
 	}
 	prev := append([]config.CodexKey(nil), s.cfg.CodexKey...)
@@ -324,12 +325,10 @@ func (s *Service) PatchCodexKey(index *int, match *string, patch CodexKeyPatch) 
 		entry.Prefix = strings.TrimSpace(*patch.Prefix)
 	}
 	if patch.BaseURL != nil {
-		trimmed := strings.TrimSpace(*patch.BaseURL)
-		if trimmed == "" {
-			s.deleteCodexKeyByIndex(targetIndex)
-			return nil
-		}
-		entry.BaseURL = trimmed
+		// Clearing base-url means "fall back to the default Codex endpoint",
+		// the same as every other channel. It used to delete the row, which is
+		// not something a PATCH of one field should ever do; DELETE exists.
+		entry.BaseURL = strings.TrimSpace(*patch.BaseURL)
 	}
 	if patch.ProxyURL != nil {
 		entry.ProxyURL = strings.TrimSpace(*patch.ProxyURL)

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -230,28 +230,47 @@ func TestCodexKeysReplacePatchDeleteAndRollback(t *testing.T) {
 	}
 
 	svc = NewService(cfg, nil)
+	// base-url is optional (empty means the default Codex endpoint), so only the
+	// row without an api-key is dropped. Dropping on empty base-url used to make
+	// the management API answer 200 while discarding a channel it just accepted.
 	err = svc.ReplaceCodexKeys([]config.CodexKey{
 		{APIKey: "next", BaseURL: " https://codex.example ", ProxyURL: " http://proxy.example "},
-		{APIKey: "drop", BaseURL: " "},
+		{APIKey: "default-endpoint", BaseURL: " "},
+		{APIKey: " ", BaseURL: "https://no-credential.example"},
 	})
 	if err != nil {
 		t.Fatalf("ReplaceCodexKeys() error = %v, want nil", err)
 	}
-	if len(cfg.CodexKey) != 1 {
-		t.Fatalf("CodexKey len = %d, want 1", len(cfg.CodexKey))
+	if len(cfg.CodexKey) != 2 {
+		t.Fatalf("CodexKey len = %d, want 2 (%#v)", len(cfg.CodexKey), cfg.CodexKey)
 	}
 	if got := cfg.CodexKey[0]; got.BaseURL != "https://codex.example" || got.ProxyURL != "http://proxy.example" {
 		t.Fatalf("normalized codex key = %#v", got)
+	}
+	if got := cfg.CodexKey[1]; got.APIKey != "default-endpoint" || got.BaseURL != "" {
+		t.Fatalf("codex key without base url = %#v, want kept with empty base url", got)
 	}
 
 	match := "next"
 	emptyBaseURL := " "
 	err = svc.PatchCodexKey(nil, &match, CodexKeyPatch{BaseURL: &emptyBaseURL})
 	if err != nil {
-		t.Fatalf("PatchCodexKey(delete) error = %v, want nil", err)
+		t.Fatalf("PatchCodexKey(clear base url) error = %v, want nil", err)
 	}
-	if len(cfg.CodexKey) != 0 {
-		t.Fatalf("CodexKey after delete = %#v, want empty", cfg.CodexKey)
+	if len(cfg.CodexKey) != 2 {
+		t.Fatalf("CodexKey after clearing base url = %#v, want both entries kept", cfg.CodexKey)
+	}
+	if got := cfg.CodexKey[0]; got.APIKey != "next" || got.BaseURL != "" {
+		t.Fatalf("patched codex key = %#v, want base url cleared and row kept", got)
+	}
+
+	blankAPIKey := " "
+	err = svc.PatchCodexKey(nil, &match, CodexKeyPatch{APIKey: &blankAPIKey})
+	if err != nil {
+		t.Fatalf("PatchCodexKey(blank api key) error = %v, want nil", err)
+	}
+	if len(cfg.CodexKey) != 1 || cfg.CodexKey[0].APIKey != "default-endpoint" {
+		t.Fatalf("CodexKey after blank api key patch = %#v, want only the other row", cfg.CodexKey)
 	}
 }
 


### PR DESCRIPTION
## 问题

在管理面板 **AI 供应商 → Codex** 里新增渠道，如果不填 Base URL，接口返回 200、面板提示"保存成功"，但刷新后卡片不出现——渠道实际上没有被持久化。用户的实际观感是"codex 完全加不进去"。

## 根因

`ReplaceCodexKeys` 与 `SanitizeCodexKeys` 都把 `BaseURL == ""` 的条目直接 `continue` 丢弃，且不报错。

但空 base-url 对 Codex 是**合法配置**：

- `CodexKey.BaseURL` 的字段注释写的是 *"If empty, the default Codex API URL will be used."*
- 运行时 `synthesizeCodexKeys` 只在 **api-key 为空**时跳过该行，base-url 为空时不写 `base_url` attribute，走默认端点。
- 其他所有渠道（claude/gemini/opencode-go/cline/…）都按 api-key 判断，只有 codex 例外，看起来是从 `SanitizeOpenAICompatibility`（那里 base-url 确实必填）复制过来的。

`PatchCodexKey` 里还有同一个错误模型的变体：把 base-url patch 成空会**删除整条记录**。单字段 PATCH 不应该有删除语义，其他渠道都是直接赋值。

## 改动

- `SanitizeCodexKeys`：丢弃条件由 `BaseURL == ""` 改为 `APIKey == ""`，与运行时和其他渠道一致。
- `ReplaceCodexKeys`：去掉自己的 base-url 过滤，只做规范化，丢弃交给 sanitize。
- `PatchCodexKey`：清空 base-url 只清空字段（回落默认端点），不再删除记录；删除仍走 DELETE。

前端侧的配套改动（卡片布局回归 + Vertex base-url 必填校验 + 重复凭据提示）在 codeProxy 的独立 PR 里。

## 验证

- `./scripts/ci-pr.sh` 全量通过（gofmt / go vet / `go test ./...` 200 个包 / golangci-lint / go build / 结构与 secret 检查）。
- 新增 `internal/config/codex_keys_test.go`：无 base-url 的行保留、无 api-key 的行丢弃、URL 字段 trim。
- 更新 `TestCodexKeysReplacePatchDeleteAndRollback`：原用例锁的是旧的错误行为（丢弃无 base-url、patch 空 base-url 即删除），现改为锁定正确行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)