### PR TITLE
fix(usage): classify a request by what the client asked for, not by how far it got

### DIFF
--- a/internal/runtime/executor/antigravity_usage_streaming_flag_test.go
+++ b/internal/runtime/executor/antigravity_usage_streaming_flag_test.go
@@ -1,0 +1,86 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+// A request that dies on the upstream's first answer never reaches the code
+// that reads the response body, which is where the streaming flag used to be
+// derived. Production filed every such failure as non-streaming: the resulting
+// bucket held non-streaming successes plus all failures, so it showed a ~90%
+// failure rate for a model whose streaming traffic looked flawless.
+func TestAntigravityStreamFailureKeepsStreamingClassification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	_, err := NewAntigravityExecutor(&config.Config{}).ExecuteStream(context.Background(), antigravityTestAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash-high",
+		Payload: []byte(`{"stream":true,"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("antigravity")})
+	if err == nil {
+		t.Fatal("ExecuteStream() error = nil, want the upstream 429")
+	}
+
+	record := waitForAntigravityFailureRecord(t, usagePlugin.records)
+	if !record.Streaming {
+		t.Fatal("a client-streamed request that fails upstream must stay classified as streaming")
+	}
+}
+
+// The mirror case: Antigravity serves non-streaming requests from the streaming
+// endpoint too, so the executor reads SSE either way. Only the client's own
+// request mode may decide the classification.
+func TestAntigravityNonStreamFailureStaysNonStreaming(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	_, err := NewAntigravityExecutor(&config.Config{}).Execute(context.Background(), antigravityTestAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash-high",
+		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("antigravity")})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want the upstream 429")
+	}
+
+	record := waitForAntigravityFailureRecord(t, usagePlugin.records)
+	if record.Streaming {
+		t.Fatal("a non-streaming client request must not be reclassified by the upstream call shape")
+	}
+}
+
+func waitForAntigravityFailureRecord(t *testing.T, records <-chan cliproxyusage.Record) cliproxyusage.Record {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case record := <-records:
+			if record.Provider == antigravityAuthType && record.Failed {
+				return record
+			}
+		case <-timer.C:
+			t.Fatal("timed out waiting for antigravity failure usage record")
+		}
+	}
+}

--- a/internal/runtime/executor/codex_executor_image_test.go
+++ b/internal/runtime/executor/codex_executor_image_test.go
@@ -702,7 +702,7 @@ func TestUsageReporterTrackFailureStoresErrorContent(t *testing.T) {
 		Provider: "codex",
 		Status:   cliproxyauth.StatusActive,
 	}
-	reporter := newUsageReporter(context.Background(), "codex", model, "", auth)
+	reporter := newUsageReporter(context.Background(), "codex", model, "", auth, false)
 	reporter.setInputContent(`{"model":"` + model + `","prompt":"draw a fox"}`)
 	errValue := fmt.Errorf("openai image conversation returned no downloadable images")
 
@@ -752,7 +752,7 @@ func TestUsageReporterTrackFailureStoresOfficialUpstreamBody(t *testing.T) {
 		Provider: "codex",
 		Status:   cliproxyauth.StatusActive,
 	}
-	reporter := newUsageReporter(context.Background(), "codex", "gpt-image-2", "", auth)
+	reporter := newUsageReporter(context.Background(), "codex", "gpt-image-2", "", auth, false)
 	reporter.setInputContent(`{"model":"gpt-image-2","prompt":"draw a fox"}`)
 	errValue := error(statusErr{
 		code:         http.StatusTooManyRequests,

--- a/internal/runtime/executor/execution_context.go
+++ b/internal/runtime/executor/execution_context.go
@@ -179,6 +179,22 @@ func newExecutionContext(
 	}
 }
 
+// ClientRequestedStream reports whether the caller asked for a streamed
+// response, which is what usage records classify by.
+//
+// The upstream call shape is not a usable proxy for it: Antigravity serves
+// every non-streaming request from :streamGenerateContent, so the executor is
+// reading SSE either way. Both payload views are consulted because
+// OriginalPayload only differs from Request.Payload when the handler supplied a
+// pre-translation body, and whichever view is the client's own is the one still
+// carrying the top-level "stream" flag.
+func (ec *ExecutionContext) ClientRequestedStream() bool {
+	if ec == nil {
+		return false
+	}
+	return isStreamingUsageRequestBytes(ec.OriginalPayload) || isStreamingUsageRequestBytes(ec.Request.Payload)
+}
+
 func (ec *ExecutionContext) Reporter() *usageReporter {
 	if ec == nil {
 		return nil
@@ -188,7 +204,7 @@ func (ec *ExecutionContext) Reporter() *usageReporter {
 	if strings.TrimSpace(model) == "" {
 		model = ec.BaseModel
 	}
-	reporter := newUsageReporter(ec.Context, ec.Provider, model, ec.BaseModel, ec.Auth)
+	reporter := newUsageReporter(ec.Context, ec.Provider, model, ec.BaseModel, ec.Auth, ec.ClientRequestedStream())
 	level := thinking.ExtractThinkingLevel(ec.OriginalPayload, ec.SourceFormat.String())
 	if parsedModel.HasSuffix {
 		level = parsedModel.RawSuffix

--- a/internal/runtime/executor/model_identity_test.go
+++ b/internal/runtime/executor/model_identity_test.go
@@ -35,21 +35,21 @@ func TestSameModelIdentityTreatsRoutingPrefixAsSameModel(t *testing.T) {
 }
 
 func TestUsageReporterDropsAliasOnlyUpstreamModel(t *testing.T) {
-	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/deepseek-v4-flash:0731", "deepseek-v4-flash:0731", &cliproxyauth.Auth{})
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/deepseek-v4-flash:0731", "deepseek-v4-flash:0731", &cliproxyauth.Auth{}, false)
 	if reporter.upstreamModel != "" {
 		t.Fatalf("upstream model = %q, want empty for a prefix-only alias", reporter.upstreamModel)
 	}
 }
 
 func TestUsageReporterKeepsRenamingUpstreamModel(t *testing.T) {
-	reporter := newUsageReporter(context.Background(), "claude", "fast", "claude-sonnet-4", &cliproxyauth.Auth{})
+	reporter := newUsageReporter(context.Background(), "claude", "fast", "claude-sonnet-4", &cliproxyauth.Auth{}, false)
 	if reporter.upstreamModel != "claude-sonnet-4" {
 		t.Fatalf("upstream model = %q, want claude-sonnet-4", reporter.upstreamModel)
 	}
 }
 
 func TestUsageReporterSettersRejectAliasOnlyNames(t *testing.T) {
-	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/gpt-oss:20b", "", &cliproxyauth.Auth{})
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/gpt-oss:20b", "", &cliproxyauth.Auth{}, false)
 	reporter.setUpstreamModel("gpt-oss:20b")
 	reporter.setVisionFallbackModel("gpt-oss:20b")
 	if reporter.upstreamModel != "" || reporter.visionFallbackModel != "" {
@@ -66,7 +66,7 @@ func TestUsageReporterSettersRejectAliasOnlyNames(t *testing.T) {
 // logged model after construction, and the record must not keep a name that has
 // meanwhile become an alias of it.
 func TestUsageReporterSetModelClearsNowRedundantUpstream(t *testing.T) {
-	reporter := newUsageReporter(context.Background(), "ollama-cloud", "some-other-model", "deepseek-v4-flash:0731", &cliproxyauth.Auth{})
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "some-other-model", "deepseek-v4-flash:0731", &cliproxyauth.Auth{}, false)
 	if reporter.upstreamModel == "" {
 		t.Fatal("precondition: upstream model should be recorded for unrelated models")
 	}

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -94,7 +94,7 @@ func TestParseOpenAIResponseModel(t *testing.T) {
 
 func TestUsageReporterSpillsLargeStreamingOutputToTempFile(t *testing.T) {
 	setUsageBodyCaptureForTest(t, true)
-	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil, false)
 	chunk := bytes.Repeat([]byte("x"), usageReporterOutputMemoryLimit/2)
 
 	reporter.appendOutputChunk(chunk)
@@ -344,7 +344,7 @@ func TestFirstTokenLatencyMsFromContext(t *testing.T) {
 
 func TestUsageReporterPreservesDirectContentBeforeSpilledChunks(t *testing.T) {
 	setUsageBodyCaptureForTest(t, true)
-	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil, false)
 	chunk := bytes.Repeat([]byte("x"), usageReporterOutputMemoryLimit+1)
 	reporter.appendOutputChunk(chunk)
 	reporter.outputContent = "prefix\n"
@@ -368,7 +368,7 @@ func TestUsageReporterPreservesDirectContentBeforeSpilledChunks(t *testing.T) {
 
 func TestUsageReporterDefersLargeInputContent(t *testing.T) {
 	setUsageBodyCaptureForTest(t, true)
-	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil, false)
 	input := strings.Repeat("i", usageReporterOutputMemoryLimit+1)
 	reporter.setInputContent(input)
 
@@ -388,8 +388,10 @@ func TestUsageReporterDefersLargeInputContent(t *testing.T) {
 
 func TestUsageReporterPreservesStreamingClassificationWithoutBodyCapture(t *testing.T) {
 	setUsageBodyCaptureForTest(t, false)
-	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
-	reporter.setInputContent(`{"model":"gpt-5.4","stream":true}`)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil, true)
+	// A body the flag can no longer be re-derived from: with storage disabled
+	// nothing is retained, and the classification must not depend on it either.
+	reporter.setInputContent(`{"model":"gpt-5.4"}`)
 
 	if !reporter.streamingRequest {
 		t.Fatal("streaming request classification should survive disabled body storage")

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -40,8 +40,20 @@ type usageReporter struct {
 	once                sync.Once
 	contentMu           sync.Mutex
 	captureFullContent  bool
-	streamingRequest    bool
-	compactOutputFull   atomic.Bool
+	// streamingRequest records what the client asked for, so it is fixed at
+	// construction from the client payload and never revised afterwards.
+	//
+	// It used to be derived inside setInputContent, which every provider calls
+	// only after the upstream has answered 2xx and the response body is about to
+	// be read. Requests that failed before that point — an upstream 429, 5xx, a
+	// dial error — published their usage record with the zero value, so every
+	// early failure was filed as non-streaming regardless of what the client
+	// sent. In production that turned the "non-streaming" bucket into
+	// "non-streaming successes plus all failures" and left the streaming bucket
+	// looking flawless, which read as a non-streaming outage that no endpoint
+	// change could fix.
+	streamingRequest  bool
+	compactOutputFull atomic.Bool
 
 	// Content captured for log detail viewer
 	inputContent  string
@@ -52,7 +64,11 @@ type usageReporter struct {
 	outputPath    string
 }
 
-func newUsageReporter(ctx context.Context, provider, model, upstreamModel string, auth *cliproxyauth.Auth) *usageReporter {
+// newUsageReporter builds the reporter for one request. clientStreaming must
+// describe the client's own request mode: it is taken here rather than inferred
+// later so that a request failing before any upstream byte arrives is still
+// filed under the mode the caller actually used.
+func newUsageReporter(ctx context.Context, provider, model, upstreamModel string, auth *cliproxyauth.Auth, clientStreaming bool) *usageReporter {
 	apiKey := apiKeyFromContext(ctx)
 	if sameModelIdentity(model, upstreamModel) {
 		upstreamModel = ""
@@ -66,6 +82,7 @@ func newUsageReporter(ctx context.Context, provider, model, upstreamModel string
 		trustedTenantID:    strings.TrimSpace(contextStringValue(ctx, util.ContextKeyTrustedTenantID)),
 		source:             resolveUsageSource(auth, apiKey),
 		captureFullContent: internalusage.RequestLogBodyStorageEnabled(),
+		streamingRequest:   clientStreaming,
 	}
 	if identity := internalusage.ResolveAPIKeyIdentity(apiKey); identity != nil {
 		reporter.apiKeyID = identity.ID
@@ -94,7 +111,6 @@ func (r *usageReporter) publishWithContentBytes(ctx context.Context, detail core
 	if r == nil {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequestBytes(inputContent)
 	if r.captureFullContent {
 		r.contentMu.Lock()
 		r.setInputContentLocked(string(inputContent))
@@ -160,13 +176,14 @@ func (r *usageReporter) setInputContent(content string) {
 	r.setInputContentBytes([]byte(content))
 }
 
-// setInputContentBytes is the hot-path form: never force a string(payload) copy when
-// store-content is off and we only need the stream flag.
+// setInputContentBytes is the hot-path form: never force a string(payload) copy
+// when store-content is off and there is nothing to retain. It deliberately does
+// not touch streamingRequest — see that field for why the mode is settled at
+// construction instead.
 func (r *usageReporter) setInputContentBytes(content []byte) {
 	if r == nil {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequestBytes(content)
 	if !r.captureFullContent {
 		return
 	}
@@ -257,7 +274,6 @@ func (r *usageReporter) publishFailureWithContentBytes(ctx context.Context, inpu
 	if shouldSuppressUsageFailure(nil, outputContent) {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequestBytes(inputContent)
 	r.contentMu.Lock()
 	if r.captureFullContent {
 		r.setInputContentLocked(string(inputContent))

--- a/internal/runtime/executor/usage_reporter_tenant_test.go
+++ b/internal/runtime/executor/usage_reporter_tenant_test.go
@@ -31,7 +31,7 @@ func TestUsageReporterPublishesTrustedTenantSeparatelyFromAPIKeyLabel(t *testing
 
 	ctx := context.WithValue(context.Background(), util.ContextKeyTrustedTenantID, tenantID)
 	ctx = context.WithValue(ctx, util.ContextKeyAPIKey, systemAPIKey)
-	reporter := newUsageReporter(ctx, "codex", model, "", nil)
+	reporter := newUsageReporter(ctx, "codex", model, "", nil, false)
 	reporter.setThinkingLevel("high")
 	reporter.ensurePublished(ctx)
 


### PR DESCRIPTION
## 现象

`gemini-3.7-flash-high` 看起来是「非流式全线故障」：非流式 294 失败 / 29 成功，而同一模型的 625 次流式调用**零失败**。上一轮已经把非流式全部改走 `:streamGenerateContent`，现象没有任何变化 —— 因为端点从来不是原因。

## 根因

`streaming` 标记在 `setInputContent` 里推导，而所有 provider 都只在**上游返回 2xx、即将读响应体时**才调用它。死在这之前的请求（上游 429、5xx、连接错误）发布记录时该字段仍是零值 `false`。

结果是「非流式」这一桶的真实含义变成了「非流式的成功 + 全部失败」，「流式」桶只剩成功和中途断流。这样构造出来的桶必然显示 ~90% 失败率。

## 线上证据

- DB `request_logs` 中 `18:35:17.889`（`streaming=0`, `failed=1`）与上游日志 `API REQUEST 1 Timestamp: 18:35:17.891` 是同一请求，其客户端 body 为 `"stream":true`
- 当天该通道全部失败请求，客户端 payload 清一色 `"stream":true`（429 × 53、503 × 74，仅 7 条是 `stream:false`）
- 真实失败是上游 `429 RESOURCE_EXHAUSTED`，集中在 7 分钟窗口内，与流式与否无关

## 改动

流式标记改为在 reporter 构造时由客户端 payload 定死，之后不再修订：

- `ExecutionContext.Reporter` 是唯一构造点，客户端模式成为 `newUsageReporter` 的必填入参，provider 无法漏设
- 移除 `setInputContent` / `publishWithContent` / `publishFailureWithContent` 里的三处后续推导，避免翻译后的 payload 把正确值改写掉
- 不能用上游调用形态推导：Antigravity 的非流式请求同样走流式端点，executor 两种情况都在读 SSE

## 测试

`internal/runtime/executor/antigravity_usage_streaming_flag_test.go` 覆盖两个方向：客户端流式请求撞上游 429 后仍归类为流式；非流式请求不会被 SSE 绕行改判。去掉修复后两个测试都会失败。

`go test ./internal/runtime/executor/ ./internal/usage/` 全绿，`scripts/check-backend-structure.py` 通过。

## 影响

修复后失败会回到它们真正所属的模式桶里，`gemini-3.7-flash-high` 的流式失败率将不再显示为 0 —— 这是上游限流的真实暴露，不是新增故障。

🤖 Generated with [Claude Code](https://claude.com/claude-code)