### PR TITLE
fix(usage): stop successful bodies from evicting failure diagnostics

### DIFF
--- a/internal/usage/log_content_cleanup.go
+++ b/internal/usage/log_content_cleanup.go
@@ -58,9 +58,17 @@ func cleanupOversizedLogContentQuerierWithTotalInternal(q logContentQuerier, tot
 	var deletedBytes int64
 	for totalBytes > maxBytes {
 		required := totalBytes - maxBytes
-		ids, reclaimed, err := oldestContentRowsForTrim(q, required, 200)
+		ids, reclaimed, err := oldestContentRowsForTrim(q, required, 200, true)
 		if err != nil {
 			return deletedBytes, deletedRows, err
+		}
+		if len(ids) == 0 || reclaimed <= 0 {
+			// Only failure diagnostics are left. The cap still has to hold, so
+			// fall back to plain FIFO rather than let the table grow unbounded.
+			ids, reclaimed, err = oldestContentRowsForTrim(q, required, 200, false)
+			if err != nil {
+				return deletedBytes, deletedRows, err
+			}
 		}
 		if len(ids) == 0 || reclaimed <= 0 {
 			break
@@ -96,7 +104,25 @@ func queryStoredContentBytes(q logContentQuerier) (int64, error) {
 	return totalBytes.Int64, nil
 }
 
-func oldestContentRowsForTrim(q logContentQuerier, requiredBytes int64, limit int) ([]int64, int64, error) {
+// oldestContentRowsForTrim picks the rows to drop when stored content exceeds
+// the size cap.
+//
+// preserveFailed keeps failure diagnostics out of that first pass. A failed
+// request stores a few hundred bytes of upstream error; a successful one stores
+// a request and response body that routinely run into hundreds of kilobytes.
+// Under plain FIFO the successes consume the entire budget and carry the
+// diagnostics out with them, so a 3-day retention setting held under an hour of
+// rows in production and the upstream error explaining an incident was gone
+// before anyone opened the log. Evicting successes first costs little — they
+// are what fills the cap — and buys the error detail the retention it was
+// configured for.
+//
+// The lookup stays on the timestamp index and probes request_logs by primary
+// key per candidate; failures are a small minority, so the scan reaches its
+// limit in about as many rows as before. It matches on log_id alone, as the
+// delete below does: log ids come from one sequence, and leaving tenant_id out
+// can only ever keep a diagnostic row longer, never drop one early.
+func oldestContentRowsForTrim(q logContentQuerier, requiredBytes int64, limit int, preserveFailed bool) ([]int64, int64, error) {
 	if q == nil || requiredBytes <= 0 {
 		return nil, 0, nil
 	}
@@ -104,13 +130,19 @@ func oldestContentRowsForTrim(q logContentQuerier, requiredBytes int64, limit in
 		limit = 200
 	}
 
-	rows, err := q.Query(
-		`SELECT log_id, CAST(length(input_content) AS INTEGER) + CAST(length(output_content) AS INTEGER) + CAST(length(detail_content) AS INTEGER) AS size
+	query := `SELECT log_id, CAST(length(input_content) AS INTEGER) + CAST(length(output_content) AS INTEGER) + CAST(length(detail_content) AS INTEGER) AS size
 		 FROM request_log_content
 		 ORDER BY timestamp ASC, log_id ASC
-		 LIMIT ?`,
-		limit,
-	)
+		 LIMIT ?`
+	if preserveFailed {
+		query = `SELECT c.log_id, CAST(length(c.input_content) AS INTEGER) + CAST(length(c.output_content) AS INTEGER) + CAST(length(c.detail_content) AS INTEGER) AS size
+		 FROM request_log_content c
+		 WHERE NOT EXISTS (SELECT 1 FROM request_logs l WHERE l.id = c.log_id AND l.failed = 1)
+		 ORDER BY c.timestamp ASC, c.log_id ASC
+		 LIMIT ?`
+	}
+
+	rows, err := q.Query(query, limit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("usage: query oldest content rows: %w", err)
 	}

--- a/internal/usage/log_content_cleanup_failure_retention_test.go
+++ b/internal/usage/log_content_cleanup_failure_retention_test.go
@@ -1,0 +1,143 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// insertContentRowForTrim seeds one request_logs row and its stored content so
+// the size-cap trimmer has something to evict.
+func insertContentRowForTrim(t *testing.T, ts time.Time, apiKey string, failed int, compressed []byte) int64 {
+	t.Helper()
+	db := getDB()
+	result, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, model, source, channel_name, auth_index,
+			 failed, latency_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		ts.Format(time.RFC3339Nano),
+		apiKey, "model", "source", "channel", apiKey,
+		failed, 5, 1, 1, 0, 0, 2, 0,
+	)
+	if err != nil {
+		t.Fatalf("insert request_logs row: %v", err)
+	}
+	logID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId() error = %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO request_log_content (log_id, timestamp, compression, input_content, output_content)
+		 VALUES (?, ?, ?, ?, ?)`,
+		logID,
+		ts.Format(time.RFC3339Nano),
+		requestLogContentCompression,
+		compressed,
+		[]byte{},
+	); err != nil {
+		t.Fatalf("insert request_log_content row: %v", err)
+	}
+	return logID
+}
+
+func contentRowExists(t *testing.T, logID int64) bool {
+	t.Helper()
+	var rows int
+	if err := getDB().QueryRow("SELECT COUNT(*) FROM request_log_content WHERE log_id = ?", logID).Scan(&rows); err != nil {
+		t.Fatalf("count content row %d: %v", logID, err)
+	}
+	return rows > 0
+}
+
+// A failed request stores a few hundred bytes of upstream error; a successful
+// one stores bodies that run into hundreds of kilobytes. Plain FIFO eviction
+// spent the whole budget on successes and took the diagnostics with them — in
+// production a 3-day retention setting held under an hour of rows, so the error
+// that explained an incident was gone before anyone opened the log.
+//
+// All three rows here are the same size, so only the eviction order can decide
+// which survives.
+func TestCleanupOversizedLogContentKeepsFailureDiagnostics(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+		MaxTotalSizeMB:         1,
+	})
+
+	maxBytes := int64(1024 * 1024)
+	compressed, err := compressLogContent(makePseudoRandomText(420 * 1024))
+	if err != nil {
+		t.Fatalf("compressLogContent() error = %v", err)
+	}
+	if rowBytes := int64(len(compressed)); rowBytes >= maxBytes || rowBytes*3 <= maxBytes {
+		t.Fatalf("payload sized wrong for a three-row cap test: %d", rowBytes)
+	}
+
+	now := time.Now().UTC()
+	failedID := insertContentRowForTrim(t, now.Add(-3*time.Hour), "sk-failed", 1, compressed)
+	oldestOKID := insertContentRowForTrim(t, now.Add(-2*time.Hour), "sk-ok-old", 0, compressed)
+	newestOKID := insertContentRowForTrim(t, now.Add(-1*time.Hour), "sk-ok-new", 0, compressed)
+
+	if _, err := cleanupOversizedLogContent(getDB(), maxBytes); err != nil {
+		t.Fatalf("cleanupOversizedLogContent() error = %v", err)
+	}
+
+	totalBytes, err := queryStoredContentBytes(getDB())
+	if err != nil {
+		t.Fatalf("queryStoredContentBytes() error = %v", err)
+	}
+	if totalBytes > maxBytes {
+		t.Fatalf("total stored bytes = %d, want <= %d", totalBytes, maxBytes)
+	}
+
+	if !contentRowExists(t, failedID) {
+		t.Fatal("the oldest row is a failure diagnostic and must outlive successful bodies")
+	}
+	if contentRowExists(t, oldestOKID) {
+		t.Fatal("the oldest successful body should have been evicted first")
+	}
+	if !contentRowExists(t, newestOKID) {
+		t.Fatal("evicting more than the cap required")
+	}
+}
+
+// Preserving diagnostics must not turn the cap into a suggestion: once nothing
+// but failures is left, they are evicted like anything else.
+func TestCleanupOversizedLogContentStillEnforcesCapWhenOnlyFailuresRemain(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+		MaxTotalSizeMB:         1,
+	})
+
+	maxBytes := int64(1024 * 1024)
+	compressed, err := compressLogContent(makePseudoRandomText(420 * 1024))
+	if err != nil {
+		t.Fatalf("compressLogContent() error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		insertContentRowForTrim(t, now.Add(-time.Duration(3-i)*time.Hour), "sk-failed", 1, compressed)
+	}
+
+	deleted, err := cleanupOversizedLogContent(getDB(), maxBytes)
+	if err != nil {
+		t.Fatalf("cleanupOversizedLogContent() error = %v", err)
+	}
+	if deleted == 0 {
+		t.Fatal("cap must still be enforced when every row is a failure")
+	}
+
+	totalBytes, err := queryStoredContentBytes(getDB())
+	if err != nil {
+		t.Fatalf("queryStoredContentBytes() error = %v", err)
+	}
+	if totalBytes > maxBytes {
+		t.Fatalf("total stored bytes = %d, want <= %d", totalBytes, maxBytes)
+	}
+}


### PR DESCRIPTION
## 现象

线上 `request_log_storage` 配的是 `content-retention-days: 3` + `max-total-size-mb: 128`，但 `request_log_content` 表实际只覆盖**最近约 50 分钟**。排查 18:35 的一次上游 429 时，错误详情早已被清掉，只能回到磁盘上的 request log 文件里翻 —— 管理界面的错误详情弹窗打开是空的。

## 根因

失败请求存的是几百字节的结构化上游错误，也是它为什么失败的唯一记录；成功请求存的是动辄几百 KB 的 request/response body。两者共用同一个 `max-total-size-mb` 配额，而淘汰逻辑严格按 `timestamp ASC` FIFO 删除 —— 成功 body 把配额吃光，顺带把诊断数据一起冲掉。

retention 配置本身没错，只是**永远够不着**。

## 改动

淘汰时先跳过 failed 的行、优先删成功的行：

- 成功 body 本来就是撑满配额的那部分，先删它们几乎没有代价
- 只剩失败行时仍然照删，配额不会因此失效、表不会无界增长
- 候选查询仍走 timestamp 索引，每行多一次 request_logs 主键探测；失败是少数，扫描量与原来基本相同
- **无 schema 变更**，因此无需迁移或回填：历史行按它所属请求的 failed 状态判定，那个状态本来就已记录

## 测试

`internal/usage/log_content_cleanup_failure_retention_test.go`：

1. 三行等大内容，最老的一行是失败记录 —— 只有淘汰顺序能决定谁存活；断言失败行活下来、更新的成功行被先删。去掉修复后该测试失败。
2. 全部是失败行时，配额仍然被强制执行。

`go test ./internal/usage/` 全绿（含原有的 `TestCleanupOversizedLogContentPrunesOldestRows`），`scripts/check-backend-structure.py` 通过。

## 关联

与 #922 同源：#922 修的是失败请求被误标成「非流式」导致看不出真实故障面，这个 PR 修的是即使看到了失败、也查不到上游报错原文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)