### PR TITLE
release: v0.4.28 — Codex default endpoint, honest streaming labels, keep failure diagnostics

### DIFF
--- a/internal/config/codex_keys_test.go
+++ b/internal/config/codex_keys_test.go
@@ -1,0 +1,31 @@
+package config
+
+import "testing"
+
+// A Codex row is usable when it carries a credential. An empty base-url means
+// "use the default Codex endpoint" (see CodexKey.BaseURL), which is also what
+// the runtime synthesizer assumes, so sanitising must not drop those rows.
+func TestSanitizeCodexKeysKeepsRowsWithoutBaseURL(t *testing.T) {
+	cfg := &Config{
+		CodexKey: []CodexKey{
+			{APIKey: " default-endpoint ", Prefix: " team "},
+			{APIKey: "third-party", BaseURL: " https://codex.example ", ProxyURL: " http://proxy.example "},
+			{APIKey: " ", BaseURL: "https://no-credential.example"},
+		},
+	}
+
+	cfg.SanitizeCodexKeys()
+
+	if len(cfg.CodexKey) != 2 {
+		t.Fatalf("CodexKey length = %d, want 2 (%#v)", len(cfg.CodexKey), cfg.CodexKey)
+	}
+	if got := cfg.CodexKey[0]; got.APIKey != "default-endpoint" || got.BaseURL != "" {
+		t.Fatalf("default-endpoint row = %#v, want kept with empty base url", got)
+	}
+	if cfg.CodexKey[0].Prefix != "team" {
+		t.Fatalf("prefix = %q, want team", cfg.CodexKey[0].Prefix)
+	}
+	if got := cfg.CodexKey[1]; got.BaseURL != "https://codex.example" || got.ProxyURL != "http://proxy.example" {
+		t.Fatalf("third-party row = %#v, want trimmed url fields", got)
+	}
+}

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -156,8 +156,14 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 	cfg.OpenAICompatibility = out
 }
 
-// SanitizeCodexKeys removes Codex API key entries missing a BaseURL.
+// SanitizeCodexKeys removes Codex API key entries missing an APIKey.
 // It trims whitespace and preserves order for remaining entries.
+//
+// The credential, not the endpoint, is what makes a Codex row usable: an empty
+// BaseURL means "use the default Codex endpoint" (see CodexKey.BaseURL), and the
+// runtime synthesizer only skips rows without an api-key. Dropping rows on an
+// empty BaseURL here silently deleted channels the operator had just saved
+// through the management API, which returned 200 all the same.
 func (cfg *Config) SanitizeCodexKeys() {
 	if cfg == nil || len(cfg.CodexKey) == 0 {
 		return
@@ -165,13 +171,14 @@ func (cfg *Config) SanitizeCodexKeys() {
 	out := make([]CodexKey, 0, len(cfg.CodexKey))
 	for i := range cfg.CodexKey {
 		e := cfg.CodexKey[i]
+		e.APIKey = strings.TrimSpace(e.APIKey)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
 		e.ProxyURL = strings.TrimSpace(e.ProxyURL)
 		e.ProxyID = strings.TrimSpace(e.ProxyID)
 		e.Headers = NormalizeHeaders(e.Headers)
 		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
-		if e.BaseURL == "" {
+		if e.APIKey == "" {
 			continue
 		}
 		out = append(out, e)

--- a/internal/management/settings/providers/provider_keys_primary.go
+++ b/internal/management/settings/providers/provider_keys_primary.go
@@ -274,13 +274,14 @@ func (s *Service) ReplaceCodexKeys(entries []config.CodexKey) error {
 	if s == nil || s.cfg == nil {
 		return nil
 	}
+	// Normalization only. Rows are dropped by SanitizeCodexKeys below, which
+	// keys on api-key like every other channel: an empty base-url means "use
+	// the default Codex endpoint", so filtering on it here silently discarded
+	// channels this call was asked to persist and still answered 200.
 	filtered := make([]config.CodexKey, 0, len(entries))
 	for i := range entries {
 		entry := entries[i]
 		NormalizeCodexKey(&entry)
-		if entry.BaseURL == "" {
-			continue
-		}
 		filtered = append(filtered, entry)
 	}
 	prev := append([]config.CodexKey(nil), s.cfg.CodexKey...)
@@ -324,12 +325,10 @@ func (s *Service) PatchCodexKey(index *int, match *string, patch CodexKeyPatch) 
 		entry.Prefix = strings.TrimSpace(*patch.Prefix)
 	}
 	if patch.BaseURL != nil {
-		trimmed := strings.TrimSpace(*patch.BaseURL)
-		if trimmed == "" {
-			s.deleteCodexKeyByIndex(targetIndex)
-			return nil
-		}
-		entry.BaseURL = trimmed
+		// Clearing base-url means "fall back to the default Codex endpoint",
+		// the same as every other channel. It used to delete the row, which is
+		// not something a PATCH of one field should ever do; DELETE exists.
+		entry.BaseURL = strings.TrimSpace(*patch.BaseURL)
 	}
 	if patch.ProxyURL != nil {
 		entry.ProxyURL = strings.TrimSpace(*patch.ProxyURL)

--- a/internal/management/settings/providers/service_test.go
+++ b/internal/management/settings/providers/service_test.go
@@ -230,28 +230,47 @@ func TestCodexKeysReplacePatchDeleteAndRollback(t *testing.T) {
 	}
 
 	svc = NewService(cfg, nil)
+	// base-url is optional (empty means the default Codex endpoint), so only the
+	// row without an api-key is dropped. Dropping on empty base-url used to make
+	// the management API answer 200 while discarding a channel it just accepted.
 	err = svc.ReplaceCodexKeys([]config.CodexKey{
 		{APIKey: "next", BaseURL: " https://codex.example ", ProxyURL: " http://proxy.example "},
-		{APIKey: "drop", BaseURL: " "},
+		{APIKey: "default-endpoint", BaseURL: " "},
+		{APIKey: " ", BaseURL: "https://no-credential.example"},
 	})
 	if err != nil {
 		t.Fatalf("ReplaceCodexKeys() error = %v, want nil", err)
 	}
-	if len(cfg.CodexKey) != 1 {
-		t.Fatalf("CodexKey len = %d, want 1", len(cfg.CodexKey))
+	if len(cfg.CodexKey) != 2 {
+		t.Fatalf("CodexKey len = %d, want 2 (%#v)", len(cfg.CodexKey), cfg.CodexKey)
 	}
 	if got := cfg.CodexKey[0]; got.BaseURL != "https://codex.example" || got.ProxyURL != "http://proxy.example" {
 		t.Fatalf("normalized codex key = %#v", got)
+	}
+	if got := cfg.CodexKey[1]; got.APIKey != "default-endpoint" || got.BaseURL != "" {
+		t.Fatalf("codex key without base url = %#v, want kept with empty base url", got)
 	}
 
 	match := "next"
 	emptyBaseURL := " "
 	err = svc.PatchCodexKey(nil, &match, CodexKeyPatch{BaseURL: &emptyBaseURL})
 	if err != nil {
-		t.Fatalf("PatchCodexKey(delete) error = %v, want nil", err)
+		t.Fatalf("PatchCodexKey(clear base url) error = %v, want nil", err)
 	}
-	if len(cfg.CodexKey) != 0 {
-		t.Fatalf("CodexKey after delete = %#v, want empty", cfg.CodexKey)
+	if len(cfg.CodexKey) != 2 {
+		t.Fatalf("CodexKey after clearing base url = %#v, want both entries kept", cfg.CodexKey)
+	}
+	if got := cfg.CodexKey[0]; got.APIKey != "next" || got.BaseURL != "" {
+		t.Fatalf("patched codex key = %#v, want base url cleared and row kept", got)
+	}
+
+	blankAPIKey := " "
+	err = svc.PatchCodexKey(nil, &match, CodexKeyPatch{APIKey: &blankAPIKey})
+	if err != nil {
+		t.Fatalf("PatchCodexKey(blank api key) error = %v, want nil", err)
+	}
+	if len(cfg.CodexKey) != 1 || cfg.CodexKey[0].APIKey != "default-endpoint" {
+		t.Fatalf("CodexKey after blank api key patch = %#v, want only the other row", cfg.CodexKey)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_usage_streaming_flag_test.go
+++ b/internal/runtime/executor/antigravity_usage_streaming_flag_test.go
@@ -1,0 +1,86 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	cliproxyusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+// A request that dies on the upstream's first answer never reaches the code
+// that reads the response body, which is where the streaming flag used to be
+// derived. Production filed every such failure as non-streaming: the resulting
+// bucket held non-streaming successes plus all failures, so it showed a ~90%
+// failure rate for a model whose streaming traffic looked flawless.
+func TestAntigravityStreamFailureKeepsStreamingClassification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	_, err := NewAntigravityExecutor(&config.Config{}).ExecuteStream(context.Background(), antigravityTestAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash-high",
+		Payload: []byte(`{"stream":true,"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("antigravity")})
+	if err == nil {
+		t.Fatal("ExecuteStream() error = nil, want the upstream 429")
+	}
+
+	record := waitForAntigravityFailureRecord(t, usagePlugin.records)
+	if !record.Streaming {
+		t.Fatal("a client-streamed request that fails upstream must stay classified as streaming")
+	}
+}
+
+// The mirror case: Antigravity serves non-streaming requests from the streaming
+// endpoint too, so the executor reads SSE either way. Only the client's own
+// request mode may decide the classification.
+func TestAntigravityNonStreamFailureStaysNonStreaming(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
+	}))
+	defer server.Close()
+
+	usagePlugin := &usageCapturePlugin{records: make(chan cliproxyusage.Record, 8)}
+	cliproxyusage.RegisterPlugin(usagePlugin)
+
+	_, err := NewAntigravityExecutor(&config.Config{}).Execute(context.Background(), antigravityTestAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash-high",
+		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("antigravity")})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want the upstream 429")
+	}
+
+	record := waitForAntigravityFailureRecord(t, usagePlugin.records)
+	if record.Streaming {
+		t.Fatal("a non-streaming client request must not be reclassified by the upstream call shape")
+	}
+}
+
+func waitForAntigravityFailureRecord(t *testing.T, records <-chan cliproxyusage.Record) cliproxyusage.Record {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case record := <-records:
+			if record.Provider == antigravityAuthType && record.Failed {
+				return record
+			}
+		case <-timer.C:
+			t.Fatal("timed out waiting for antigravity failure usage record")
+		}
+	}
+}

--- a/internal/runtime/executor/codex_executor_image_test.go
+++ b/internal/runtime/executor/codex_executor_image_test.go
@@ -702,7 +702,7 @@ func TestUsageReporterTrackFailureStoresErrorContent(t *testing.T) {
 		Provider: "codex",
 		Status:   cliproxyauth.StatusActive,
 	}
-	reporter := newUsageReporter(context.Background(), "codex", model, "", auth)
+	reporter := newUsageReporter(context.Background(), "codex", model, "", auth, false)
 	reporter.setInputContent(`{"model":"` + model + `","prompt":"draw a fox"}`)
 	errValue := fmt.Errorf("openai image conversation returned no downloadable images")
 
@@ -752,7 +752,7 @@ func TestUsageReporterTrackFailureStoresOfficialUpstreamBody(t *testing.T) {
 		Provider: "codex",
 		Status:   cliproxyauth.StatusActive,
 	}
-	reporter := newUsageReporter(context.Background(), "codex", "gpt-image-2", "", auth)
+	reporter := newUsageReporter(context.Background(), "codex", "gpt-image-2", "", auth, false)
 	reporter.setInputContent(`{"model":"gpt-image-2","prompt":"draw a fox"}`)
 	errValue := error(statusErr{
 		code:         http.StatusTooManyRequests,

--- a/internal/runtime/executor/execution_context.go
+++ b/internal/runtime/executor/execution_context.go
@@ -179,6 +179,22 @@ func newExecutionContext(
 	}
 }
 
+// ClientRequestedStream reports whether the caller asked for a streamed
+// response, which is what usage records classify by.
+//
+// The upstream call shape is not a usable proxy for it: Antigravity serves
+// every non-streaming request from :streamGenerateContent, so the executor is
+// reading SSE either way. Both payload views are consulted because
+// OriginalPayload only differs from Request.Payload when the handler supplied a
+// pre-translation body, and whichever view is the client's own is the one still
+// carrying the top-level "stream" flag.
+func (ec *ExecutionContext) ClientRequestedStream() bool {
+	if ec == nil {
+		return false
+	}
+	return isStreamingUsageRequestBytes(ec.OriginalPayload) || isStreamingUsageRequestBytes(ec.Request.Payload)
+}
+
 func (ec *ExecutionContext) Reporter() *usageReporter {
 	if ec == nil {
 		return nil
@@ -188,7 +204,7 @@ func (ec *ExecutionContext) Reporter() *usageReporter {
 	if strings.TrimSpace(model) == "" {
 		model = ec.BaseModel
 	}
-	reporter := newUsageReporter(ec.Context, ec.Provider, model, ec.BaseModel, ec.Auth)
+	reporter := newUsageReporter(ec.Context, ec.Provider, model, ec.BaseModel, ec.Auth, ec.ClientRequestedStream())
 	level := thinking.ExtractThinkingLevel(ec.OriginalPayload, ec.SourceFormat.String())
 	if parsedModel.HasSuffix {
 		level = parsedModel.RawSuffix

--- a/internal/runtime/executor/model_identity_test.go
+++ b/internal/runtime/executor/model_identity_test.go
@@ -35,21 +35,21 @@ func TestSameModelIdentityTreatsRoutingPrefixAsSameModel(t *testing.T) {
 }
 
 func TestUsageReporterDropsAliasOnlyUpstreamModel(t *testing.T) {
-	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/deepseek-v4-flash:0731", "deepseek-v4-flash:0731", &cliproxyauth.Auth{})
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/deepseek-v4-flash:0731", "deepseek-v4-flash:0731", &cliproxyauth.Auth{}, false)
 	if reporter.upstreamModel != "" {
 		t.Fatalf("upstream model = %q, want empty for a prefix-only alias", reporter.upstreamModel)
 	}
 }
 
 func TestUsageReporterKeepsRenamingUpstreamModel(t *testing.T) {
-	reporter := newUsageReporter(context.Background(), "claude", "fast", "claude-sonnet-4", &cliproxyauth.Auth{})
+	reporter := newUsageReporter(context.Background(), "claude", "fast", "claude-sonnet-4", &cliproxyauth.Auth{}, false)
 	if reporter.upstreamModel != "claude-sonnet-4" {
 		t.Fatalf("upstream model = %q, want claude-sonnet-4", reporter.upstreamModel)
 	}
 }
 
 func TestUsageReporterSettersRejectAliasOnlyNames(t *testing.T) {
-	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/gpt-oss:20b", "", &cliproxyauth.Auth{})
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "ollama/gpt-oss:20b", "", &cliproxyauth.Auth{}, false)
 	reporter.setUpstreamModel("gpt-oss:20b")
 	reporter.setVisionFallbackModel("gpt-oss:20b")
 	if reporter.upstreamModel != "" || reporter.visionFallbackModel != "" {
@@ -66,7 +66,7 @@ func TestUsageReporterSettersRejectAliasOnlyNames(t *testing.T) {
 // logged model after construction, and the record must not keep a name that has
 // meanwhile become an alias of it.
 func TestUsageReporterSetModelClearsNowRedundantUpstream(t *testing.T) {
-	reporter := newUsageReporter(context.Background(), "ollama-cloud", "some-other-model", "deepseek-v4-flash:0731", &cliproxyauth.Auth{})
+	reporter := newUsageReporter(context.Background(), "ollama-cloud", "some-other-model", "deepseek-v4-flash:0731", &cliproxyauth.Auth{}, false)
 	if reporter.upstreamModel == "" {
 		t.Fatal("precondition: upstream model should be recorded for unrelated models")
 	}

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -94,7 +94,7 @@ func TestParseOpenAIResponseModel(t *testing.T) {
 
 func TestUsageReporterSpillsLargeStreamingOutputToTempFile(t *testing.T) {
 	setUsageBodyCaptureForTest(t, true)
-	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil, false)
 	chunk := bytes.Repeat([]byte("x"), usageReporterOutputMemoryLimit/2)
 
 	reporter.appendOutputChunk(chunk)
@@ -344,7 +344,7 @@ func TestFirstTokenLatencyMsFromContext(t *testing.T) {
 
 func TestUsageReporterPreservesDirectContentBeforeSpilledChunks(t *testing.T) {
 	setUsageBodyCaptureForTest(t, true)
-	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil, false)
 	chunk := bytes.Repeat([]byte("x"), usageReporterOutputMemoryLimit+1)
 	reporter.appendOutputChunk(chunk)
 	reporter.outputContent = "prefix\n"
@@ -368,7 +368,7 @@ func TestUsageReporterPreservesDirectContentBeforeSpilledChunks(t *testing.T) {
 
 func TestUsageReporterDefersLargeInputContent(t *testing.T) {
 	setUsageBodyCaptureForTest(t, true)
-	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil, false)
 	input := strings.Repeat("i", usageReporterOutputMemoryLimit+1)
 	reporter.setInputContent(input)
 
@@ -388,8 +388,10 @@ func TestUsageReporterDefersLargeInputContent(t *testing.T) {
 
 func TestUsageReporterPreservesStreamingClassificationWithoutBodyCapture(t *testing.T) {
 	setUsageBodyCaptureForTest(t, false)
-	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil)
-	reporter.setInputContent(`{"model":"gpt-5.4","stream":true}`)
+	reporter := newUsageReporter(context.Background(), "provider", "model", "", nil, true)
+	// A body the flag can no longer be re-derived from: with storage disabled
+	// nothing is retained, and the classification must not depend on it either.
+	reporter.setInputContent(`{"model":"gpt-5.4"}`)
 
 	if !reporter.streamingRequest {
 		t.Fatal("streaming request classification should survive disabled body storage")

--- a/internal/runtime/executor/usage_reporter.go
+++ b/internal/runtime/executor/usage_reporter.go
@@ -40,8 +40,20 @@ type usageReporter struct {
 	once                sync.Once
 	contentMu           sync.Mutex
 	captureFullContent  bool
-	streamingRequest    bool
-	compactOutputFull   atomic.Bool
+	// streamingRequest records what the client asked for, so it is fixed at
+	// construction from the client payload and never revised afterwards.
+	//
+	// It used to be derived inside setInputContent, which every provider calls
+	// only after the upstream has answered 2xx and the response body is about to
+	// be read. Requests that failed before that point — an upstream 429, 5xx, a
+	// dial error — published their usage record with the zero value, so every
+	// early failure was filed as non-streaming regardless of what the client
+	// sent. In production that turned the "non-streaming" bucket into
+	// "non-streaming successes plus all failures" and left the streaming bucket
+	// looking flawless, which read as a non-streaming outage that no endpoint
+	// change could fix.
+	streamingRequest  bool
+	compactOutputFull atomic.Bool
 
 	// Content captured for log detail viewer
 	inputContent  string
@@ -52,7 +64,11 @@ type usageReporter struct {
 	outputPath    string
 }
 
-func newUsageReporter(ctx context.Context, provider, model, upstreamModel string, auth *cliproxyauth.Auth) *usageReporter {
+// newUsageReporter builds the reporter for one request. clientStreaming must
+// describe the client's own request mode: it is taken here rather than inferred
+// later so that a request failing before any upstream byte arrives is still
+// filed under the mode the caller actually used.
+func newUsageReporter(ctx context.Context, provider, model, upstreamModel string, auth *cliproxyauth.Auth, clientStreaming bool) *usageReporter {
 	apiKey := apiKeyFromContext(ctx)
 	if sameModelIdentity(model, upstreamModel) {
 		upstreamModel = ""
@@ -66,6 +82,7 @@ func newUsageReporter(ctx context.Context, provider, model, upstreamModel string
 		trustedTenantID:    strings.TrimSpace(contextStringValue(ctx, util.ContextKeyTrustedTenantID)),
 		source:             resolveUsageSource(auth, apiKey),
 		captureFullContent: internalusage.RequestLogBodyStorageEnabled(),
+		streamingRequest:   clientStreaming,
 	}
 	if identity := internalusage.ResolveAPIKeyIdentity(apiKey); identity != nil {
 		reporter.apiKeyID = identity.ID
@@ -94,7 +111,6 @@ func (r *usageReporter) publishWithContentBytes(ctx context.Context, detail core
 	if r == nil {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequestBytes(inputContent)
 	if r.captureFullContent {
 		r.contentMu.Lock()
 		r.setInputContentLocked(string(inputContent))
@@ -160,13 +176,14 @@ func (r *usageReporter) setInputContent(content string) {
 	r.setInputContentBytes([]byte(content))
 }
 
-// setInputContentBytes is the hot-path form: never force a string(payload) copy when
-// store-content is off and we only need the stream flag.
+// setInputContentBytes is the hot-path form: never force a string(payload) copy
+// when store-content is off and there is nothing to retain. It deliberately does
+// not touch streamingRequest — see that field for why the mode is settled at
+// construction instead.
 func (r *usageReporter) setInputContentBytes(content []byte) {
 	if r == nil {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequestBytes(content)
 	if !r.captureFullContent {
 		return
 	}
@@ -257,7 +274,6 @@ func (r *usageReporter) publishFailureWithContentBytes(ctx context.Context, inpu
 	if shouldSuppressUsageFailure(nil, outputContent) {
 		return
 	}
-	r.streamingRequest = isStreamingUsageRequestBytes(inputContent)
 	r.contentMu.Lock()
 	if r.captureFullContent {
 		r.setInputContentLocked(string(inputContent))

--- a/internal/runtime/executor/usage_reporter_tenant_test.go
+++ b/internal/runtime/executor/usage_reporter_tenant_test.go
@@ -31,7 +31,7 @@ func TestUsageReporterPublishesTrustedTenantSeparatelyFromAPIKeyLabel(t *testing
 
 	ctx := context.WithValue(context.Background(), util.ContextKeyTrustedTenantID, tenantID)
 	ctx = context.WithValue(ctx, util.ContextKeyAPIKey, systemAPIKey)
-	reporter := newUsageReporter(ctx, "codex", model, "", nil)
+	reporter := newUsageReporter(ctx, "codex", model, "", nil, false)
 	reporter.setThinkingLevel("high")
 	reporter.ensurePublished(ctx)
 

--- a/internal/usage/log_content_cleanup.go
+++ b/internal/usage/log_content_cleanup.go
@@ -58,9 +58,17 @@ func cleanupOversizedLogContentQuerierWithTotalInternal(q logContentQuerier, tot
 	var deletedBytes int64
 	for totalBytes > maxBytes {
 		required := totalBytes - maxBytes
-		ids, reclaimed, err := oldestContentRowsForTrim(q, required, 200)
+		ids, reclaimed, err := oldestContentRowsForTrim(q, required, 200, true)
 		if err != nil {
 			return deletedBytes, deletedRows, err
+		}
+		if len(ids) == 0 || reclaimed <= 0 {
+			// Only failure diagnostics are left. The cap still has to hold, so
+			// fall back to plain FIFO rather than let the table grow unbounded.
+			ids, reclaimed, err = oldestContentRowsForTrim(q, required, 200, false)
+			if err != nil {
+				return deletedBytes, deletedRows, err
+			}
 		}
 		if len(ids) == 0 || reclaimed <= 0 {
 			break
@@ -96,7 +104,25 @@ func queryStoredContentBytes(q logContentQuerier) (int64, error) {
 	return totalBytes.Int64, nil
 }
 
-func oldestContentRowsForTrim(q logContentQuerier, requiredBytes int64, limit int) ([]int64, int64, error) {
+// oldestContentRowsForTrim picks the rows to drop when stored content exceeds
+// the size cap.
+//
+// preserveFailed keeps failure diagnostics out of that first pass. A failed
+// request stores a few hundred bytes of upstream error; a successful one stores
+// a request and response body that routinely run into hundreds of kilobytes.
+// Under plain FIFO the successes consume the entire budget and carry the
+// diagnostics out with them, so a 3-day retention setting held under an hour of
+// rows in production and the upstream error explaining an incident was gone
+// before anyone opened the log. Evicting successes first costs little — they
+// are what fills the cap — and buys the error detail the retention it was
+// configured for.
+//
+// The lookup stays on the timestamp index and probes request_logs by primary
+// key per candidate; failures are a small minority, so the scan reaches its
+// limit in about as many rows as before. It matches on log_id alone, as the
+// delete below does: log ids come from one sequence, and leaving tenant_id out
+// can only ever keep a diagnostic row longer, never drop one early.
+func oldestContentRowsForTrim(q logContentQuerier, requiredBytes int64, limit int, preserveFailed bool) ([]int64, int64, error) {
 	if q == nil || requiredBytes <= 0 {
 		return nil, 0, nil
 	}
@@ -104,13 +130,19 @@ func oldestContentRowsForTrim(q logContentQuerier, requiredBytes int64, limit in
 		limit = 200
 	}
 
-	rows, err := q.Query(
-		`SELECT log_id, CAST(length(input_content) AS INTEGER) + CAST(length(output_content) AS INTEGER) + CAST(length(detail_content) AS INTEGER) AS size
+	query := `SELECT log_id, CAST(length(input_content) AS INTEGER) + CAST(length(output_content) AS INTEGER) + CAST(length(detail_content) AS INTEGER) AS size
 		 FROM request_log_content
 		 ORDER BY timestamp ASC, log_id ASC
-		 LIMIT ?`,
-		limit,
-	)
+		 LIMIT ?`
+	if preserveFailed {
+		query = `SELECT c.log_id, CAST(length(c.input_content) AS INTEGER) + CAST(length(c.output_content) AS INTEGER) + CAST(length(c.detail_content) AS INTEGER) AS size
+		 FROM request_log_content c
+		 WHERE NOT EXISTS (SELECT 1 FROM request_logs l WHERE l.id = c.log_id AND l.failed = 1)
+		 ORDER BY c.timestamp ASC, c.log_id ASC
+		 LIMIT ?`
+	}
+
+	rows, err := q.Query(query, limit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("usage: query oldest content rows: %w", err)
 	}

--- a/internal/usage/log_content_cleanup_failure_retention_test.go
+++ b/internal/usage/log_content_cleanup_failure_retention_test.go
@@ -1,0 +1,143 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// insertContentRowForTrim seeds one request_logs row and its stored content so
+// the size-cap trimmer has something to evict.
+func insertContentRowForTrim(t *testing.T, ts time.Time, apiKey string, failed int, compressed []byte) int64 {
+	t.Helper()
+	db := getDB()
+	result, err := db.Exec(
+		`INSERT INTO request_logs
+			(timestamp, api_key, model, source, channel_name, auth_index,
+			 failed, latency_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, cost)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		ts.Format(time.RFC3339Nano),
+		apiKey, "model", "source", "channel", apiKey,
+		failed, 5, 1, 1, 0, 0, 2, 0,
+	)
+	if err != nil {
+		t.Fatalf("insert request_logs row: %v", err)
+	}
+	logID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId() error = %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO request_log_content (log_id, timestamp, compression, input_content, output_content)
+		 VALUES (?, ?, ?, ?, ?)`,
+		logID,
+		ts.Format(time.RFC3339Nano),
+		requestLogContentCompression,
+		compressed,
+		[]byte{},
+	); err != nil {
+		t.Fatalf("insert request_log_content row: %v", err)
+	}
+	return logID
+}
+
+func contentRowExists(t *testing.T, logID int64) bool {
+	t.Helper()
+	var rows int
+	if err := getDB().QueryRow("SELECT COUNT(*) FROM request_log_content WHERE log_id = ?", logID).Scan(&rows); err != nil {
+		t.Fatalf("count content row %d: %v", logID, err)
+	}
+	return rows > 0
+}
+
+// A failed request stores a few hundred bytes of upstream error; a successful
+// one stores bodies that run into hundreds of kilobytes. Plain FIFO eviction
+// spent the whole budget on successes and took the diagnostics with them — in
+// production a 3-day retention setting held under an hour of rows, so the error
+// that explained an incident was gone before anyone opened the log.
+//
+// All three rows here are the same size, so only the eviction order can decide
+// which survives.
+func TestCleanupOversizedLogContentKeepsFailureDiagnostics(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+		MaxTotalSizeMB:         1,
+	})
+
+	maxBytes := int64(1024 * 1024)
+	compressed, err := compressLogContent(makePseudoRandomText(420 * 1024))
+	if err != nil {
+		t.Fatalf("compressLogContent() error = %v", err)
+	}
+	if rowBytes := int64(len(compressed)); rowBytes >= maxBytes || rowBytes*3 <= maxBytes {
+		t.Fatalf("payload sized wrong for a three-row cap test: %d", rowBytes)
+	}
+
+	now := time.Now().UTC()
+	failedID := insertContentRowForTrim(t, now.Add(-3*time.Hour), "sk-failed", 1, compressed)
+	oldestOKID := insertContentRowForTrim(t, now.Add(-2*time.Hour), "sk-ok-old", 0, compressed)
+	newestOKID := insertContentRowForTrim(t, now.Add(-1*time.Hour), "sk-ok-new", 0, compressed)
+
+	if _, err := cleanupOversizedLogContent(getDB(), maxBytes); err != nil {
+		t.Fatalf("cleanupOversizedLogContent() error = %v", err)
+	}
+
+	totalBytes, err := queryStoredContentBytes(getDB())
+	if err != nil {
+		t.Fatalf("queryStoredContentBytes() error = %v", err)
+	}
+	if totalBytes > maxBytes {
+		t.Fatalf("total stored bytes = %d, want <= %d", totalBytes, maxBytes)
+	}
+
+	if !contentRowExists(t, failedID) {
+		t.Fatal("the oldest row is a failure diagnostic and must outlive successful bodies")
+	}
+	if contentRowExists(t, oldestOKID) {
+		t.Fatal("the oldest successful body should have been evicted first")
+	}
+	if !contentRowExists(t, newestOKID) {
+		t.Fatal("evicting more than the cap required")
+	}
+}
+
+// Preserving diagnostics must not turn the cap into a suggestion: once nothing
+// but failures is left, they are evicted like anything else.
+func TestCleanupOversizedLogContentStillEnforcesCapWhenOnlyFailuresRemain(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{
+		StoreContent:           true,
+		ContentRetentionDays:   30,
+		CleanupIntervalMinutes: 1440,
+		MaxTotalSizeMB:         1,
+	})
+
+	maxBytes := int64(1024 * 1024)
+	compressed, err := compressLogContent(makePseudoRandomText(420 * 1024))
+	if err != nil {
+		t.Fatalf("compressLogContent() error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		insertContentRowForTrim(t, now.Add(-time.Duration(3-i)*time.Hour), "sk-failed", 1, compressed)
+	}
+
+	deleted, err := cleanupOversizedLogContent(getDB(), maxBytes)
+	if err != nil {
+		t.Fatalf("cleanupOversizedLogContent() error = %v", err)
+	}
+	if deleted == 0 {
+		t.Fatal("cap must still be enforced when every row is a failure")
+	}
+
+	totalBytes, err := queryStoredContentBytes(getDB())
+	if err != nil {
+		t.Fatalf("queryStoredContentBytes() error = %v", err)
+	}
+	if totalBytes > maxBytes {
+		t.Fatalf("total stored bytes = %d, want <= %d", totalBytes, maxBytes)
+	}
+}


### PR DESCRIPTION
Promotes the verified `dev` branch to `main` for **v0.4.28**.

## What matters most in this release

Three production defects that made the panel lie about channels and about failures.

Saving a Codex channel without a Base URL returned 200 and the panel said it was saved; the channel was then discarded because an empty URL was treated as invalid. Empty is the documented default Codex endpoint, so those channels now persist.

Request logs also mixed two different questions into one `streaming` flag. The flag was only set after the upstream answered 2xx, so every early failure (429, 5xx, connection error) was counted as non-streaming. `gemini-3.7-flash-high` then looked like a non-streaming outage even after the stream-endpoint routing from v0.4.27. The flag now records what the client asked for.

Failure diagnostics were then evicted by successful bodies. With `content-retention-days: 3` and `max-total-size-mb: 128`, the live table only covered about 50 minutes because hundred-kilobyte success bodies share the same FIFO quota as the few-hundred-byte upstream error that is the only record of why a request failed. Cleanup now keeps failure content while it still has room, and only then evicts success bodies.

## Key fixes and improvements

- **Codex channels with an empty Base URL are kept** (#921): empty means the default Codex endpoint. `ReplaceCodexKeys` and `SanitizeCodexKeys` used to `continue` those rows with no error, so the panel reported a save that never persisted.
- **A request is classified by what the client asked for, not by how far it got** (#922): `streaming` used to be derived only when the upstream returned 2xx. Early failures stayed at the zero value `false`, so the non-streaming bucket was "non-streaming successes plus every failure".
- **Successful bodies no longer evict failure diagnostics** (#923): failure rows are a few hundred bytes of structured upstream error; success rows are hundreds of kilobytes of request/response body. They shared one FIFO quota. Cleanup now prefers to keep the failures.

## Compatibility and upgrade notes

- No deploy-script or host change in this release.
- Pair with codeProxy **v0.4.28** so a Codex channel saved without a Base URL stays visible in the panel. The backend fix is sufficient on its own for persistence.
- No data migration. Existing request-log content is cleaned with the new policy on the next pass.

## Verification

- All 3 merged `dev` PRs passed `build` / `vulncheck` / `ensure-no-translator-changes`.
- Local on the release branch: `rtk go test ./internal/config/ ./internal/runtime/executor/ ./internal/usage/ ./internal/management/settings/providers/` → 867 passed.