### PR TITLE
fix(oauth): bind the proxy chosen at login to the account it creates

### DIFF
--- a/internal/api/handlers/management/auth_oauth.go
+++ b/internal/api/handlers/management/auth_oauth.go
@@ -109,6 +109,23 @@ func (h *Handler) saveTenantTokenRecord(ctx context.Context, tenantID string, re
 	return savedPath, nil
 }
 
+// oauthProxyIDFromRequest reads the proxy-pool entry chosen in the login dialog.
+//
+// The start request is the authoritative carrier: the record is built and saved
+// by the goroutine that request spawns, so a proxy id arriving later on
+// /oauth-callback would reach a closure that has already been handed its value.
+// The callback panel sends the field too, which is harmless duplication rather
+// than a second source of truth.
+func oauthProxyIDFromRequest(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	if proxyID := strings.TrimSpace(c.Query("proxy_id")); proxyID != "" {
+		return proxyID
+	}
+	return strings.TrimSpace(c.Query("proxy-id"))
+}
+
 func (h *Handler) tenantOAuthBindings(c *gin.Context) (
 	authDir string,
 	saveRecord func(context.Context, *coreauth.Auth) (string, error),
@@ -117,7 +134,13 @@ func (h *Handler) tenantOAuthBindings(c *gin.Context) (
 ) {
 	tenantID := effectiveTenantID(c)
 	authDir = managementauthfiles.TenantAuthDir(h.cfg.AuthDir, tenantID)
+	// The proxy the operator picked in the login dialog is bound here rather than
+	// inside each provider flow. Every OAuth provider funnels its finished record
+	// through this one closure, so binding at this point covers all of them and
+	// leaves no provider to be forgotten when the next one is added.
+	proxyID := oauthProxyIDFromRequest(c)
 	saveRecord = func(ctx context.Context, record *coreauth.Auth) (string, error) {
+		managementauthfiles.BindProxyID(record, proxyID)
 		return h.saveTenantTokenRecord(ctx, tenantID, record)
 	}
 	registerSession = func(state, provider string) {
@@ -429,18 +452,25 @@ func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 	ctx := requestAuthContext(c)
 	authDir, saveRecord, _, _ := h.tenantOAuthBindings(c)
 
+	// Cookie login posts its fields as JSON, so the proxy id arrives in the body
+	// rather than the query string tenantOAuthBindings reads.
 	var payload struct {
-		Cookie string `json:"cookie"`
+		Cookie  string `json:"cookie"`
+		ProxyID string `json:"proxy_id"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "cookie is required"})
 		return
 	}
+	saveWithProxy := func(ctx context.Context, record *coreauth.Auth) (string, error) {
+		managementauthfiles.BindProxyID(record, payload.ProxyID)
+		return saveRecord(ctx, record)
+	}
 
 	result, err := iflowprovider.AuthenticateCookie(ctx, payload.Cookie, iflowprovider.CookieLoginOptions{
 		Config:     h.cfg,
 		AuthDir:    authDir,
-		SaveRecord: saveRecord,
+		SaveRecord: saveWithProxy,
 	})
 	if err != nil {
 		var duplicate iflowprovider.DuplicateBXAuthError

--- a/internal/api/handlers/management/auth_oauth_proxy_binding_test.go
+++ b/internal/api/handlers/management/auth_oauth_proxy_binding_test.go
@@ -1,0 +1,74 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// The login dialog offers an "authorization proxy" and the panel sends it as
+// proxy_id, but nothing on this side used to read it: the record was written
+// with an empty ProxyID, so every probe and API call for that account went out
+// through the deployment host's own address. On an Antigravity account that
+// showed up as a paid plan being reported back as restricted, because the tier
+// lookup is answered per egress IP.
+func TestOAuthSaveRecordBindsSelectedProxy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{cfg: &config.Config{AuthDir: t.TempDir()}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/antigravity-auth-url?is_webui=true&proxy_id=us-residential", nil)
+
+	_, saveRecord, _, _ := h.tenantOAuthBindings(c)
+
+	record := &coreauth.Auth{
+		Provider: "antigravity",
+		FileName: "antigravity-someone@example.com.json",
+		Metadata: map[string]any{"email": "someone@example.com"},
+	}
+	if _, err := saveRecord(context.Background(), record); err != nil {
+		t.Fatalf("saveRecord() error = %v", err)
+	}
+
+	if record.ProxyID != "us-residential" {
+		t.Fatalf("ProxyID = %q, want the proxy chosen in the login dialog", record.ProxyID)
+	}
+	// Runtime egress reads the field; a reload rebuilds it from metadata. A
+	// binding that is missing from either one silently stops applying.
+	if got := record.Metadata["proxy_id"]; got != "us-residential" {
+		t.Fatalf("metadata proxy_id = %v, want the binding to survive a reload", got)
+	}
+}
+
+func TestOAuthSaveRecordLeavesProxyUnsetWhenDialogPickedNone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{cfg: &config.Config{AuthDir: t.TempDir()}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/antigravity-auth-url?is_webui=true", nil)
+
+	_, saveRecord, _, _ := h.tenantOAuthBindings(c)
+
+	record := &coreauth.Auth{
+		Provider: "antigravity",
+		FileName: "antigravity-someone@example.com.json",
+		Metadata: map[string]any{"email": "someone@example.com"},
+	}
+	if _, err := saveRecord(context.Background(), record); err != nil {
+		t.Fatalf("saveRecord() error = %v", err)
+	}
+
+	if record.ProxyID != "" {
+		t.Fatalf("ProxyID = %q, want empty when the dialog left the proxy blank", record.ProxyID)
+	}
+	if _, exists := record.Metadata["proxy_id"]; exists {
+		t.Fatal("an unset proxy must not be written to metadata")
+	}
+}

--- a/internal/management/authfiles/proxy_binding.go
+++ b/internal/management/authfiles/proxy_binding.go
@@ -1,0 +1,31 @@
+package authfiles
+
+import (
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// BindProxyID attaches a proxy-pool entry to an auth record.
+//
+// Both places have to be written. Auth.ProxyID is what the runtime reads when it
+// picks an egress route — APICallTransport and the executors resolve it through
+// Config.ResolveProxyURL — while metadata["proxy_id"] is what survives to disk
+// and is read back by RecordFromMetadata on reload. Setting only the field gives
+// a binding that disappears on restart; setting only the metadata gives one that
+// does not take effect until then.
+//
+// An empty proxyID is a no-op rather than an unbind: callers that mean to clear a
+// binding go through the patch path, which distinguishes "not supplied" from
+// "set to empty".
+func BindProxyID(auth *coreauth.Auth, proxyID string) {
+	if auth == nil {
+		return
+	}
+	proxyID = strings.TrimSpace(proxyID)
+	if proxyID == "" {
+		return
+	}
+	auth.ProxyID = proxyID
+	ensureMetadata(auth)["proxy_id"] = proxyID
+}


### PR DESCRIPTION
## 现象

在「增加 OAuth 登录」里选了「授权代理」（例如 `美国住宅 ip`），账号添加成功后打开卡片详情，**代理是空的**。

## 根因

前端确实把选择传过来了（[oauth.ts](https://github.com/kittors/codeProxy/blob/dev/packages/api-client/src/endpoints/oauth.ts)）：`startAuth` 放进 query、`submitCallback` 放进 body、`iflowCookieAuth` 放进 body。

后端一个都没读：

- `RequestAntigravityToken` 及同族的启动端点从不读这个查询参数
- `oauthCallbackRequest` 只声明了 `provider/redirect_url/code/state/error`，`proxy_id` 在 JSON 绑定阶段被丢弃
- `RequestIFlowCookieToken` 的 payload 只绑了 `cookie`

于是无论选什么，创建出来的账号 `ProxyID` 都是空的。

## 影响不止是"卡片没显示"

出站路由是按 `auth.ProxyID` 选的：`APICallTransport` 通过 `Config.ResolveProxyURL` 解析它用于所有管理探测，executor 走同一套用于业务流量。**没绑定的账号一律从部署机自己的 IP 出去。**

线上表现就是另一个 issue：一个已升级的 Antigravity 账号一直报 `Antigravity (Restricted)`。tier 查询是按出口 IP 回答的，`loadCodeAssist` 对香港机器返回了 `ineligibleTiers`。

同一台机器上的两个账号可以互相印证：绑了代理的报 `Google AI Pro`，没绑的报 Restricted，而**两者的授权过程都是同样不走代理的**——所以决定 tier 的是探测的出口，不是登录的出口。

## 改动

绑定放在 `tenantOAuthBindings`，不放进各 provider 的 flow：所有 OAuth provider 都把最终 record 交给这一个闭包，一处覆盖全部，也不会在新增 provider 时被漏掉。Cookie 登录走 JSON body，从自己的 payload 里读。

`BindProxyID` 同时写 `auth.ProxyID` 和 `metadata["proxy_id"]`：前者是运行时读的，后者是落盘并由 `RecordFromMetadata` 重建的。只写一个会得到「重启即失效」或「重启才生效」的绑定。传空 id 是 no-op 而不是解绑——解绑仍走 patch 路径，那里能区分「未提供」和「置空」。

## 测试

`auth_oauth_proxy_binding_test.go` 对真实保存路径做正反两个方向，并断言持久化的 metadata 而不只是内存字段。去掉修复后第一个测试会红。

`go test ./internal/api/handlers/management/ ./internal/management/authfiles/` 全绿，`scripts/check-backend-structure.py` 通过。

## 已知缺口（本 PR 未覆盖）

OAuth 换 token 的过程本身仍走部署机网络，而不是选中的代理。各 provider 构造 HTTP 客户端的方式不统一，改动面和风险都独立，适合单独处理。线上证据表明它不影响 tier 判定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)