### PR TITLE
fix(codex): isolate Team member quota identities

### DIFF
--- a/internal/management/aiaccountstatus/service_test.go
+++ b/internal/management/aiaccountstatus/service_test.go
@@ -332,6 +332,35 @@ func TestPreferEnabledAliasOverDisabledSameSubject(t *testing.T) {
 	}
 }
 
+func TestStartRefreshSeparatesCodexTeamMembers(t *testing.T) {
+	authA := &coreauth.Auth{
+		ID: "team-user-a", Provider: "codex", FileName: "team-user-a.json",
+		Metadata: map[string]any{"account_id": "shared-team", "chatgpt_user_id": "user-a"},
+	}
+	authB := &coreauth.Auth{
+		ID: "team-user-b", Provider: "codex", FileName: "team-user-b.json",
+		Metadata: map[string]any{"account_id": "shared-team", "chatgpt_user_id": "user-b"},
+	}
+	manager := newTestManager(t, "tenant-team", authA, authB)
+	var probes atomic.Int32
+	svc := New(&config.Config{}, manager, func(string) *managementapitools.Service {
+		return managementapitools.NewForTenant("tenant-team", &config.Config{}, manager, managementapitools.Dependencies{})
+	}, nil)
+	svc.SetProbeFunc(func(context.Context, *managementapitools.Service, *config.Config, *coreauth.Auth) (ProbeResult, error) {
+		probes.Add(1)
+		return ProbeResult{}, nil
+	})
+
+	accepted := svc.StartRefresh("tenant-team", RefreshRequest{Force: true})
+	if accepted.Accepted != 2 {
+		t.Fatalf("accepted=%d want 2 independent Team members", accepted.Accepted)
+	}
+	waitJob(t, svc, "tenant-team", accepted.JobID)
+	if got := probes.Load(); got != 2 {
+		t.Fatalf("probes=%d want 2 independent Team members", got)
+	}
+}
+
 func TestPersistFailureDoesNotReportSuccess(t *testing.T) {
 	auth := &coreauth.Auth{
 		ID: "id-persist", Provider: "codex", FileName: "p.json",

--- a/internal/management/authfiles/identity.go
+++ b/internal/management/authfiles/identity.go
@@ -67,6 +67,9 @@ func CodexIDTokenClaims(auth *coreauth.Auth) map[string]any {
 	if v := strings.TrimSpace(claims.CodexAuthInfo.ChatgptAccountID); v != "" {
 		result["chatgpt_account_id"] = v
 	}
+	if v := strings.TrimSpace(claims.CodexAuthInfo.ChatgptUserID); v != "" {
+		result["chatgpt_user_id"] = v
+	}
 	if v := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType); v != "" {
 		result["plan_type"] = v
 	}

--- a/internal/management/authfiles/identity_test.go
+++ b/internal/management/authfiles/identity_test.go
@@ -37,6 +37,7 @@ func TestCodexIDTokenClaimsReturnsDisplayClaims(t *testing.T) {
 		"https://api.openai.com/auth": map[string]any{
 			"chatgpt_plan_type":  "plus",
 			"chatgpt_account_id": "acct_123",
+			"chatgpt_user_id":    "user_team_member",
 		},
 	})
 	auth := &coreauth.Auth{
@@ -53,6 +54,9 @@ func TestCodexIDTokenClaimsReturnsDisplayClaims(t *testing.T) {
 	}
 	if got, _ := claims["chatgpt_account_id"].(string); got != "acct_123" {
 		t.Fatalf("chatgpt_account_id = %q, want acct_123", got)
+	}
+	if got, _ := claims["chatgpt_user_id"].(string); got != "user_team_member" {
+		t.Fatalf("chatgpt_user_id = %q, want user_team_member", got)
 	}
 }
 

--- a/internal/management/oauth/providers/codex/record.go
+++ b/internal/management/oauth/providers/codex/record.go
@@ -35,6 +35,11 @@ func MetadataFromTokenStorage(tokenStorage *internalcodex.CodexTokenStorage, pla
 	}
 	metadata["email"] = tokenStorage.Email
 	metadata["account_id"] = tokenStorage.AccountID
+	if claims, _ := internalcodex.ParseJWTToken(tokenStorage.IDToken); claims != nil {
+		if userID := strings.TrimSpace(claims.CodexAuthInfo.ChatgptUserID); userID != "" {
+			metadata["chatgpt_user_id"] = userID
+		}
+	}
 	return metadata
 }
 

--- a/internal/management/oauth/providers/codex/record_test.go
+++ b/internal/management/oauth/providers/codex/record_test.go
@@ -17,6 +17,7 @@ func TestRecordFromTokenStorageUsesPlanAndAccountHashFromIDToken(t *testing.T) {
 		"https://api.openai.com/auth": map[string]any{
 			"chatgpt_account_id": "acct-team",
 			"chatgpt_plan_type":  " team ",
+			"chatgpt_user_id":    "user-team-member",
 		},
 	})
 	storage := &internalcodex.CodexTokenStorage{
@@ -45,6 +46,9 @@ func TestRecordFromTokenStorageUsesPlanAndAccountHashFromIDToken(t *testing.T) {
 	}
 	if got, _ := record.Metadata["plan_type"].(string); got != "team" {
 		t.Fatalf("metadata[plan_type] = %q, want team", got)
+	}
+	if got, _ := record.Metadata["chatgpt_user_id"].(string); got != "user-team-member" {
+		t.Fatalf("metadata[chatgpt_user_id] = %q, want user-team-member", got)
 	}
 }
 

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -101,6 +101,14 @@ func sharedSubjectTestAuth(tenantID, authID, accountID, email string) *coreauth.
 	}
 }
 
+func codexMemberTestAuth(tenantID, authID, accountID, userID, email string) *coreauth.Auth {
+	auth := sharedSubjectTestAuth(tenantID, authID, accountID, email)
+	if userID != "" {
+		auth.Metadata["chatgpt_user_id"] = userID
+	}
+	return auth
+}
+
 // A subject is the physical upstream account. Every seed that names that account
 // — the provider's id, the account email, the credential's own id — must resolve
 // to one subject however many tenants mounted it; only auth_index, which names
@@ -180,6 +188,28 @@ func TestResolveAuthSubjectIdentitySharesEverySeedThatNamesAnAccount(t *testing.
 	}
 	if indexA.ID == indexB.ID {
 		t.Fatalf("auth_index crossed the tenant boundary: %q", indexA.ID)
+	}
+}
+
+func TestResolveAuthSubjectIdentitySeparatesCodexTeamMembers(t *testing.T) {
+	authA := codexMemberTestAuth(sharedSubjectTenantA, "auth-a", "acct-team", "user-a", "a@example.com")
+	authB := codexMemberTestAuth(sharedSubjectTenantA, "auth-b", "acct-team", "user-b", "b@example.com")
+	authACopy := codexMemberTestAuth(sharedSubjectTenantB, "auth-a-copy", "acct-team", "user-a", "a@example.com")
+
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	identityACopy := ResolveAuthSubjectIdentity(authACopy)
+	if identityA == nil || identityB == nil || identityACopy == nil {
+		t.Fatal("expected Codex member identities")
+	}
+	if identityA.ID == identityB.ID {
+		t.Fatalf("different Team members share subject %q", identityA.ID)
+	}
+	if identityA.ID != identityACopy.ID {
+		t.Fatalf("same Team member differs across tenants: %q != %q", identityA.ID, identityACopy.ID)
+	}
+	if identityA.SeedKind != "account_user_id" || identityA.AccountID != "acct-team" || identityA.UserID != "user-a" {
+		t.Fatalf("Codex member identity contract = %+v", identityA)
 	}
 }
 

--- a/internal/usage/auth_subject_identity.go
+++ b/internal/usage/auth_subject_identity.go
@@ -23,6 +23,7 @@ type AuthSubjectIdentity struct {
 	ID            string
 	Provider      string
 	AccountID     string
+	UserID        string
 	Email         string
 	SeedKind      string
 	SeedHash      string
@@ -49,6 +50,7 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 	}
 	tenantID := coreauth.NormalizedTenantID(auth.TenantID)
 	accountID := authMetadataString(auth.Metadata, "account_id", "accountId", "chatgpt_account_id")
+	userID := authMetadataString(auth.Metadata, "chatgpt_user_id", "chatgptUserId")
 	email := strings.ToLower(authEmail(auth))
 
 	seedKind := ""
@@ -57,6 +59,12 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 	subjectScope := AIAccountSubjectScopeTenant
 	shareReason := "fallback_identity_is_tenant_scoped"
 	switch {
+	case provider == "codex" && accountID != "" && userID != "":
+		seedKind = "account_user_id"
+		seedValue = accountID + "\x1f" + userID
+		shareEligible = true
+		subjectScope = AIAccountSubjectScopeShared
+		shareReason = "stable_provider_account_and_user_id"
 	case accountID != "":
 		seedKind = "account_id"
 		seedValue = accountID
@@ -104,6 +112,7 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 		ID:            stableAuthSubjectID(subjectSeed...),
 		Provider:      provider,
 		AccountID:     accountID,
+		UserID:        userID,
 		Email:         email,
 		SeedKind:      seedKind,
 		SeedHash:      stableSeedHash(seedHashValue),

--- a/sdk/auth/codex_device.go
+++ b/sdk/auth/codex_device.go
@@ -260,10 +260,12 @@ func (a *CodexAuthenticator) buildAuthRecord(authSvc *codex.CodexAuth, authBundl
 	planType := ""
 	hashAccountID := ""
 	accountID := ""
+	userID := ""
 	if tokenStorage.IDToken != "" {
 		if claims, errParse := codex.ParseJWTToken(tokenStorage.IDToken); errParse == nil && claims != nil {
 			planType = strings.ToLower(strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType))
 			accountID = strings.TrimSpace(claims.CodexAuthInfo.ChatgptAccountID)
+			userID = strings.TrimSpace(claims.CodexAuthInfo.ChatgptUserID)
 			if accountID != "" {
 				digest := sha256.Sum256([]byte(accountID))
 				hashAccountID = hex.EncodeToString(digest[:])[:8]
@@ -277,6 +279,9 @@ func (a *CodexAuthenticator) buildAuthRecord(authSvc *codex.CodexAuth, authBundl
 	}
 	if accountID != "" {
 		metadata["account_id"] = accountID
+	}
+	if userID != "" {
+		metadata["chatgpt_user_id"] = userID
 	}
 	if planType != "" {
 		metadata["plan_type"] = planType

--- a/sdk/auth/codex_metadata.go
+++ b/sdk/auth/codex_metadata.go
@@ -1,0 +1,111 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func normalizeCodexAuthMetadata(metadata map[string]any) {
+	if metadata == nil {
+		return
+	}
+	metadata["type"] = "codex"
+	if accountID := metadataString(metadata, "account_id", "chatgpt_account_id", "chatgptAccountID"); accountID != "" {
+		metadata["account_id"] = accountID
+	}
+	if email := metadataString(metadata, "email", "account_claims_email", "accountClaimsEmail"); email != "" {
+		metadata["email"] = email
+	}
+	if planType := strings.ToLower(metadataString(metadata, "plan_type", "planType", "chatgpt_plan_type")); planType != "" {
+		metadata["plan_type"] = planType
+	}
+	if userID := metadataString(metadata, "chatgpt_user_id", "chatgptUserId"); userID != "" {
+		metadata["chatgpt_user_id"] = userID
+	}
+	normalizeCodexMetadataFromJWT(metadataString(metadata, "id_token"), metadata)
+	normalizeCodexMetadataFromJWT(metadataString(metadata, "access_token"), metadata)
+}
+
+func normalizeCodexMetadataFromJWT(token string, metadata map[string]any) {
+	claims, ok := parseJWTClaimsMap(token)
+	if !ok {
+		return
+	}
+	if metadataString(metadata, "email") == "" {
+		if email, ok := claims["email"].(string); ok && strings.TrimSpace(email) != "" {
+			metadata["email"] = strings.TrimSpace(email)
+		}
+	}
+	if metadataString(metadata, "expired") == "" {
+		if exp, ok := jwtNumericClaim(claims, "exp"); ok && exp > 0 {
+			metadata["expired"] = time.Unix(exp, 0).UTC().Format(time.RFC3339)
+		}
+	}
+	if metadataString(metadata, "last_refresh") == "" {
+		if iat, ok := jwtNumericClaim(claims, "iat"); ok && iat > 0 {
+			metadata["last_refresh"] = time.Unix(iat, 0).UTC().Format(time.RFC3339)
+		}
+	}
+	authClaims, _ := claims["https://api.openai.com/auth"].(map[string]any)
+	if len(authClaims) == 0 {
+		return
+	}
+	if metadataString(metadata, "account_id") == "" {
+		if accountID := metadataString(authClaims, "account_id", "chatgpt_account_id"); accountID != "" {
+			metadata["account_id"] = accountID
+		}
+	}
+	if metadataString(metadata, "chatgpt_user_id") == "" {
+		if userID := metadataString(authClaims, "chatgpt_user_id"); userID != "" {
+			metadata["chatgpt_user_id"] = userID
+		}
+	}
+	if metadataString(metadata, "plan_type") == "" {
+		if planType := strings.ToLower(metadataString(authClaims, "chatgpt_plan_type", "plan_type")); planType != "" {
+			metadata["plan_type"] = planType
+		}
+	}
+}
+
+func parseJWTClaimsMap(token string) (map[string]any, bool) {
+	token = strings.TrimSpace(token)
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+	}
+	if err != nil {
+		return nil, false
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, false
+	}
+	return claims, true
+}
+
+func jwtNumericClaim(claims map[string]any, key string) (int64, bool) {
+	switch value := claims[key].(type) {
+	case float64:
+		return int64(value), value > 0
+	case int64:
+		return value, value > 0
+	case int:
+		return int64(value), value > 0
+	case json.Number:
+		if i, err := value.Int64(); err == nil && i > 0 {
+			return i, true
+		}
+	case string:
+		if i, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil && i > 0 {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/sdk/auth/codex_metadata_test.go
+++ b/sdk/auth/codex_metadata_test.go
@@ -18,6 +18,7 @@ func TestCodexBuildAuthRecord_PersistsPlanTypeMetadata(t *testing.T) {
 		"https://api.openai.com/auth": map[string]any{
 			"chatgpt_plan_type":  "FREE",
 			"chatgpt_account_id": "acct_123",
+			"chatgpt_user_id":    "user_123",
 		},
 	}
 	jwt := makeJWTForTest(t, claims)
@@ -40,6 +41,9 @@ func TestCodexBuildAuthRecord_PersistsPlanTypeMetadata(t *testing.T) {
 	}
 	if got := record.Metadata["account_id"]; got != "acct_123" {
 		t.Fatalf("account_id = %v, want acct_123", got)
+	}
+	if got := record.Metadata["chatgpt_user_id"]; got != "user_123" {
+		t.Fatalf("chatgpt_user_id = %v, want user_123", got)
 	}
 }
 

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -503,6 +503,9 @@ func normalizeCodexAuthMetadata(metadata map[string]any) {
 	if planType := strings.ToLower(metadataString(metadata, "plan_type", "planType", "chatgpt_plan_type")); planType != "" {
 		metadata["plan_type"] = planType
 	}
+	if userID := metadataString(metadata, "chatgpt_user_id", "chatgptUserId"); userID != "" {
+		metadata["chatgpt_user_id"] = userID
+	}
 	normalizeCodexMetadataFromJWT(metadataString(metadata, "id_token"), metadata)
 	normalizeCodexMetadataFromJWT(metadataString(metadata, "access_token"), metadata)
 }
@@ -534,6 +537,11 @@ func normalizeCodexMetadataFromJWT(token string, metadata map[string]any) {
 	if metadataString(metadata, "account_id") == "" {
 		if accountID := metadataString(authClaims, "account_id", "chatgpt_account_id"); accountID != "" {
 			metadata["account_id"] = accountID
+		}
+	}
+	if metadataString(metadata, "chatgpt_user_id") == "" {
+		if userID := metadataString(authClaims, "chatgpt_user_id"); userID != "" {
+			metadata["chatgpt_user_id"] = userID
 		}
 	}
 	if metadataString(metadata, "plan_type") == "" {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -12,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -487,108 +485,6 @@ func hasNestedRefreshToken(metadata map[string]any) bool {
 		return false
 	}
 	return metadataString(tokenRaw, "refresh_token", "refreshToken") != ""
-}
-
-func normalizeCodexAuthMetadata(metadata map[string]any) {
-	if metadata == nil {
-		return
-	}
-	metadata["type"] = "codex"
-	if accountID := metadataString(metadata, "account_id", "chatgpt_account_id", "chatgptAccountID"); accountID != "" {
-		metadata["account_id"] = accountID
-	}
-	if email := metadataString(metadata, "email", "account_claims_email", "accountClaimsEmail"); email != "" {
-		metadata["email"] = email
-	}
-	if planType := strings.ToLower(metadataString(metadata, "plan_type", "planType", "chatgpt_plan_type")); planType != "" {
-		metadata["plan_type"] = planType
-	}
-	if userID := metadataString(metadata, "chatgpt_user_id", "chatgptUserId"); userID != "" {
-		metadata["chatgpt_user_id"] = userID
-	}
-	normalizeCodexMetadataFromJWT(metadataString(metadata, "id_token"), metadata)
-	normalizeCodexMetadataFromJWT(metadataString(metadata, "access_token"), metadata)
-}
-
-func normalizeCodexMetadataFromJWT(token string, metadata map[string]any) {
-	claims, ok := parseJWTClaimsMap(token)
-	if !ok {
-		return
-	}
-	if metadataString(metadata, "email") == "" {
-		if email, ok := claims["email"].(string); ok && strings.TrimSpace(email) != "" {
-			metadata["email"] = strings.TrimSpace(email)
-		}
-	}
-	if metadataString(metadata, "expired") == "" {
-		if exp, ok := jwtNumericClaim(claims, "exp"); ok && exp > 0 {
-			metadata["expired"] = time.Unix(exp, 0).UTC().Format(time.RFC3339)
-		}
-	}
-	if metadataString(metadata, "last_refresh") == "" {
-		if iat, ok := jwtNumericClaim(claims, "iat"); ok && iat > 0 {
-			metadata["last_refresh"] = time.Unix(iat, 0).UTC().Format(time.RFC3339)
-		}
-	}
-	authClaims, _ := claims["https://api.openai.com/auth"].(map[string]any)
-	if len(authClaims) == 0 {
-		return
-	}
-	if metadataString(metadata, "account_id") == "" {
-		if accountID := metadataString(authClaims, "account_id", "chatgpt_account_id"); accountID != "" {
-			metadata["account_id"] = accountID
-		}
-	}
-	if metadataString(metadata, "chatgpt_user_id") == "" {
-		if userID := metadataString(authClaims, "chatgpt_user_id"); userID != "" {
-			metadata["chatgpt_user_id"] = userID
-		}
-	}
-	if metadataString(metadata, "plan_type") == "" {
-		if planType := strings.ToLower(metadataString(authClaims, "chatgpt_plan_type", "plan_type")); planType != "" {
-			metadata["plan_type"] = planType
-		}
-	}
-}
-
-func parseJWTClaimsMap(token string) (map[string]any, bool) {
-	token = strings.TrimSpace(token)
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return nil, false
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		payload, err = base64.URLEncoding.DecodeString(parts[1])
-	}
-	if err != nil {
-		return nil, false
-	}
-	var claims map[string]any
-	if err := json.Unmarshal(payload, &claims); err != nil {
-		return nil, false
-	}
-	return claims, true
-}
-
-func jwtNumericClaim(claims map[string]any, key string) (int64, bool) {
-	switch value := claims[key].(type) {
-	case float64:
-		return int64(value), value > 0
-	case int64:
-		return value, value > 0
-	case int:
-		return int64(value), value > 0
-	case json.Number:
-		if i, err := value.Int64(); err == nil && i > 0 {
-			return i, true
-		}
-	case string:
-		if i, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil && i > 0 {
-			return i, true
-		}
-	}
-	return 0, false
 }
 
 func syncRoutingMetadata(auth *cliproxyauth.Auth) {

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -154,6 +154,7 @@ func TestFileTokenStoreListNormalizesOpenAIBundleJSONForCodex(t *testing.T) {
 		"https://api.openai.com/auth": map[string]any{
 			"chatgpt_account_id": accountID,
 			"chatgpt_plan_type":  "plus",
+			"chatgpt_user_id":    "user-bundle",
 		},
 	})
 	idToken := makeJWTForTest(t, map[string]any{
@@ -163,6 +164,7 @@ func TestFileTokenStoreListNormalizesOpenAIBundleJSONForCodex(t *testing.T) {
 		"https://api.openai.com/auth": map[string]any{
 			"chatgpt_account_id": accountID,
 			"chatgpt_plan_type":  "plus",
+			"chatgpt_user_id":    "user-bundle",
 		},
 	})
 	data, err := json.Marshal(map[string]any{
@@ -196,12 +198,13 @@ func TestFileTokenStoreListNormalizesOpenAIBundleJSONForCodex(t *testing.T) {
 	wantExpired := time.Unix(expiresAt, 0).UTC().Format(time.RFC3339)
 	wantLastRefresh := time.Unix(issuedAt, 0).UTC().Format(time.RFC3339)
 	for key, want := range map[string]any{
-		"type":         "codex",
-		"account_id":   accountID,
-		"email":        "bundle@example.com",
-		"expired":      wantExpired,
-		"last_refresh": wantLastRefresh,
-		"plan_type":    "plus",
+		"type":            "codex",
+		"account_id":      accountID,
+		"chatgpt_user_id": "user-bundle",
+		"email":           "bundle@example.com",
+		"expired":         wantExpired,
+		"last_refresh":    wantLastRefresh,
+		"plan_type":       "plus",
 	} {
 		if got := auths[0].Metadata[key]; got != want {
 			t.Fatalf("metadata[%s] = %#v, want %#v", key, got, want)


### PR DESCRIPTION
## Summary

Fixes #879.

Codex Team members can share the same `chatgpt_account_id` while having different `chatgpt_user_id` values. The previous subject identity used only `account_id`, causing quota/status rows to overwrite each other and refresh jobs to deduplicate distinct members.

## Fix

- Extract and persist `chatgpt_user_id` from Codex JWTs across OAuth, device auth, and imported auth files.
- Resolve Codex member subjects from `chatgpt_account_id + chatgpt_user_id`.
- Keep the original `account_id` unchanged for the upstream `Chatgpt-Account-Id` request header.
- Preserve the old `account_id` fallback when member-level claims are unavailable.
- Reconcile existing auth bindings on load so upgraded credentials move to member-specific local subjects.

## How it works

The local subject key now distinguishes members as:

```text
Codex local subject = chatgpt_account_id + chatgpt_user_id
```

This composite identity is used only for CliRelay's local quota, status, refresh-deduplication, and usage bookkeeping. Requests sent to the upstream service still use the real Team account ID:

```http
Chatgpt-Account-Id: <original chatgpt_account_id>
```

No upstream account ID is modified or fabricated.

## Existing data and upgrade behavior

After upgrade, loading existing auth files rebuilds member-specific bindings from JWT claims. New quota refreshes and usage records are stored under separated subjects.

Previously merged historical status cannot always be split safely without member-attributed request logs, so this change does not guess or duplicate shared historical totals. Credentials without a `chatgpt_user_id` continue to use the previous account-ID fallback.

## Verification

- Added identity tests for two Team members sharing one account ID.
- Added refresh regression coverage confirming both members are probed independently.
- Added JWT/import metadata coverage.
- Ran `go test ./...` successfully.
