### PR TITLE
fix(usage): stop a sliding quota countdown from shredding the period

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -269,7 +269,10 @@ func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 			if err := usage.RunAIAccountSubjectUsageTokensBackfillAtInit(); err != nil {
 				return err
 			}
-			return usage.RunAIAccountSubjectCycleBucketMergeAtInit()
+			if err := usage.RunAIAccountSubjectCycleBucketMergeAtInit(); err != nil {
+				return err
+			}
+			return usage.RunAIAccountSubjectCycleRealignAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -719,7 +719,7 @@ func (s *Service) loadPersistedStatus(subjectID string) (*usage.AIAccountSubject
 }
 
 func (s *Service) viewFromPersistedRecord(tenantID string, auth *coreauth.Auth, record usage.AIAccountSubjectStatusRecord) *AccountStatusView {
-	cycleStarts, _ := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{record.AuthSubjectID}, primaryWeeklyKeys(auth.Provider))
+	cycleStarts, _ := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{record.AuthSubjectID})
 	summaries, _ := usage.QueryAIAccountSubjectUsageSummaries([]string{record.AuthSubjectID}, cycleStarts)
 	subjects, _ := usage.ListAIAccountSubjects([]string{record.AuthSubjectID})
 	counts, _ := usage.CountAIAccountTenantBindings(tenantID, []string{record.AuthSubjectID})
@@ -841,17 +841,7 @@ func (s *Service) ListStatus(tenantID string, authIndexes, authSubjectIDs []stri
 	if err != nil {
 		return StatusListResponse{}, err
 	}
-	prefKeys := make([]string, 0)
-	prefSeen := map[string]struct{}{}
-	for _, auth := range wanted {
-		for _, key := range primaryWeeklyKeys(auth.Provider) {
-			if _, ok := prefSeen[key]; !ok {
-				prefSeen[key] = struct{}{}
-				prefKeys = append(prefKeys, key)
-			}
-		}
-	}
-	cycleStart, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs, prefKeys)
+	cycleStart, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs)
 	if err != nil {
 		return StatusListResponse{}, err
 	}

--- a/internal/management/aiaccountstatus/service_cycle_usage_test.go
+++ b/internal/management/aiaccountstatus/service_cycle_usage_test.go
@@ -1,0 +1,118 @@
+package aiaccountstatus
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	_ "modernc.org/sqlite"
+)
+
+// A tenant's accounts are resolved in one batch, and the batch used to carry a
+// single list of preferred quota keys assembled from every provider in it. Any
+// provider whose windows were not on that list — antigravity names its buckets
+// after whatever the upstream calls them — had all of its cycles filtered out,
+// so its cards reported no usage for the period while the other providers' cards
+// were fine.
+func TestListStatusKeepsCycleUsageForMixedProviders(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { usage.CloseDB(); _ = os.Remove(dbPath) })
+
+	const tenant = "tenant-mixed"
+	codexAuth := &coreauth.Auth{
+		ID: "codex-1", Provider: "codex", FileName: "codex-1.json",
+		Metadata: map[string]any{"account_id": "codex-account"},
+	}
+	antigravityAuth := &coreauth.Auth{
+		ID: "antigravity-1", Provider: "antigravity", FileName: "antigravity-1.json",
+		Metadata: map[string]any{"account_id": "antigravity-account"},
+	}
+	manager := newTestManager(t, tenant, codexAuth, antigravityAuth)
+
+	admin, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+
+	checked := time.Now().UTC().Truncate(time.Second)
+	resetAt := checked.Add(72 * time.Hour)
+	cycleStart := resetAt.Add(-7 * 24 * time.Hour)
+	percent := 61.0
+
+	accounts := []struct {
+		auth     *coreauth.Auth
+		provider string
+		quotaKey string
+		requests int64
+		tokens   int64
+	}{
+		{codexAuth, "codex", "code_week", 4, 4000},
+		{antigravityAuth, "antigravity", "antigravity:gemini_weekly", 7, 7000},
+	}
+	subjects := make(map[string]string, len(accounts))
+	for _, account := range accounts {
+		identity := usage.ResolveAuthSubjectIdentity(account.auth)
+		if identity == nil {
+			t.Fatalf("no identity for %s", account.auth.ID)
+		}
+		subjects[account.auth.ID] = identity.ID
+		if err := usage.UpsertAIAccountTenantBinding(account.auth, identity); err != nil {
+			t.Fatal(err)
+		}
+		if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+			AuthSubjectID: identity.ID, Provider: account.provider,
+			LastProbeState: string(RefreshSuccess), HealthStatus: "ok",
+			Quotas:            []usage.QuotaWindowDTO{{QuotaKey: account.quotaKey, Percent: &percent}},
+			UpstreamCheckedAt: &checked, UpdatedAt: checked,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		reset := resetAt
+		if err := usage.RecordAIAccountSubjectQuotaPoints(identity.ID, account.provider, []usage.QuotaSnapshotPoint{{
+			RecordedAt: checked, Provider: account.provider, QuotaKey: account.quotaKey,
+			QuotaLabel: account.quotaKey, Percent: &percent, ResetAt: &reset, WindowSeconds: 604800,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := admin.Exec(`
+			INSERT INTO ai_account_subject_usage_buckets
+				(auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+				 failure_count, cost_total, total_tokens, first_event_at, updated_at)
+			VALUES (?, 'cycle', ?, ?, ?, 0, 0, ?, ?, ?)
+		`, identity.ID, cycleStart.Format(time.RFC3339Nano), account.requests, account.requests,
+			account.tokens, cycleStart.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	response, listErr := New(&config.Config{}, manager, nil, nil).ListStatus(tenant, nil, nil)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(response.Items) != len(accounts) {
+		t.Fatalf("items=%d, want %d", len(response.Items), len(accounts))
+	}
+	bySubject := make(map[string]AccountStatusView, len(response.Items))
+	for _, item := range response.Items {
+		bySubject[item.AuthSubjectID] = item
+	}
+	for _, account := range accounts {
+		item, ok := bySubject[subjects[account.auth.ID]]
+		if !ok {
+			t.Fatalf("%s missing from status list", account.provider)
+		}
+		if !item.Usage.CycleKnown || item.Usage.CycleRequestTotal != account.requests {
+			t.Fatalf("%s cycle usage = %+v, want %d requests",
+				account.provider, item.Usage, account.requests)
+		}
+	}
+}

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -145,7 +145,7 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 	}
 	weeklyQuotaUsed := latestWeeklyQuotaUsedPercent(series, preferredWeeklyQuotaKeys...)
 
-	cycleStarts, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID}, preferredWeeklyQuotaKeys)
+	cycleStarts, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID})
 	if err != nil {
 		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 	}

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -266,7 +266,7 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 		t.Fatalf("direct day summary id=%s 7d=%d 30d=%d start7=%s start30=%s", directID, direct7, direct30, start7, start30)
 	}
 
-	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID}, []string{"code_week"})
+	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +373,10 @@ func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
 		}
 	}
 	resetOld := now.Add(24 * time.Hour)
-	resetNew := now.Add(48 * time.Hour)
+	// The later probe must describe the period that follows the stored one, not a
+	// stored period whose reset simply drifted later: only a rollover replaces an
+	// anchor, so an arbitrary later reset would (correctly) be kept out.
+	resetNew := resetOld.Add(7 * 24 * time.Hour)
 	if err := RecordQuotaSnapshotPointsIdentityForTenant(sharedSubjectTenantA, authA.EnsureIndex(), identity.ID, "codex", []QuotaSnapshotPoint{{
 		RecordedAt: older, QuotaKey: "code_week", QuotaLabel: "Week", Percent: &pctOld, ResetAt: &resetOld, WindowSeconds: 604800,
 	}}); err != nil {
@@ -419,7 +422,7 @@ func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
 	if !ok || !parsedReset.Equal(resetNew) {
 		t.Fatalf("cycle reset=%q want %s", cycleReset, resetNew)
 	}
-	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID}, []string{"code_week"})
+	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usage/ai_account_subject_cycle_anchor_test.go
+++ b/internal/usage/ai_account_subject_cycle_anchor_test.go
@@ -1,0 +1,318 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	antigravityGeminiWeeklyKey = "antigravity:gemini_weekly"
+	antigravity3pWeeklyKey     = "antigravity:3p_weekly"
+	weeklyWindowSeconds        = int64(604800)
+)
+
+func projectSubjectRequest(t *testing.T, subjectID string, at time.Time, tokens int64) {
+	t.Helper()
+	tx, err := getDB().Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := projectAIAccountSubjectUsageTx(tx, subjectID, false, 1, tokens, at); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func countCycleBuckets(t *testing.T, subjectID string) int {
+	t.Helper()
+	var count int
+	if err := getDB().QueryRow(`
+		SELECT COUNT(*) FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, subjectID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}
+
+func readCycleSummary(t *testing.T, subjectID string) AuthSubjectUsageSummary {
+	t.Helper()
+	starts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{subjectID}, starts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return summaries[subjectID]
+}
+
+// Production: an antigravity account with 1084 lifetime calls showed 0 for the
+// period. Its untouched third-party weekly bucket is answered as "a full window
+// remaining", so the start derived from that countdown walked forward by hours on
+// every probe, opening a usage bucket per step, while the readers resolved a
+// single anchor that matched none of them.
+func TestAntigravitySlidingWeeklyResetKeepsOnePeriod(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_antigravity_slide"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	// The bucket the account actually spends reports a fixed reset.
+	geminiReset := now.Add(120 * time.Hour)
+	geminiPercent, thirdPartyPercent := 87.0, 100.0
+
+	for i := 0; i < 6; i++ {
+		at := now.Add(time.Duration(i) * 12 * time.Hour)
+		slidingReset := at.Add(7 * 24 * time.Hour)
+		if err := RecordAIAccountSubjectQuotaPoints(subjectID, "antigravity", []QuotaSnapshotPoint{
+			{
+				RecordedAt: at, Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey,
+				QuotaLabel: "Gemini", Percent: &geminiPercent, ResetAt: &geminiReset,
+				WindowSeconds: weeklyWindowSeconds,
+			},
+			{
+				RecordedAt: at, Provider: "antigravity", QuotaKey: antigravity3pWeeklyKey,
+				QuotaLabel: "Claude and GPT", Percent: &thirdPartyPercent, ResetAt: &slidingReset,
+				WindowSeconds: weeklyWindowSeconds,
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		projectSubjectRequest(t, subjectID, at, 10)
+	}
+
+	if buckets := countCycleBuckets(t, subjectID); buckets != 1 {
+		t.Fatalf("cycle buckets = %d, want 1 (a sliding countdown must not open a period)", buckets)
+	}
+
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 6 || got.CycleTotalTokens != 60 {
+		t.Fatalf("cycle summary = %+v, want 6 requests / 60 tokens", got)
+	}
+
+	// The anchor must be the bucket that is actually metering, not the untouched
+	// one whose window merely happens to be re-stamped on every probe.
+	var start storedTime
+	if err := getDB().QueryRow(`
+		SELECT cycle_start_at FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, subjectID, antigravity3pWeeklyKey).Scan(&start); err != nil {
+		t.Fatal(err)
+	}
+	if !start.Valid || !start.Time.UTC().Equal(now) {
+		t.Fatalf("third-party anchor = %v, want it pinned to its first probe %v", start.Time, now)
+	}
+}
+
+// The projection reads the anchor from an in-memory map and the readers read it
+// from a SQL result set. With several weekly windows re-stamped by one probe, any
+// ordering by timestamp let the two sides disagree, and requests landed in a
+// bucket nobody read back.
+func TestWeeklyCycleSelectionIsIndependentOfCandidateOrder(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	gemini := AIAccountSubjectQuotaCycle{
+		AuthSubjectID: "authsub_order", Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey,
+		CycleStartAt: now.Add(-48 * time.Hour), ResetAt: now.Add(120 * time.Hour),
+		WindowSeconds: weeklyWindowSeconds, LastVerifiedAt: now,
+	}
+	thirdParty := AIAccountSubjectQuotaCycle{
+		AuthSubjectID: "authsub_order", Provider: "antigravity", QuotaKey: antigravity3pWeeklyKey,
+		CycleStartAt: now, ResetAt: now.Add(7 * 24 * time.Hour),
+		WindowSeconds: weeklyWindowSeconds, LastVerifiedAt: now,
+	}
+
+	forward, okForward := selectAIAccountSubjectWeeklyCycle([]AIAccountSubjectQuotaCycle{gemini, thirdParty})
+	reverse, okReverse := selectAIAccountSubjectWeeklyCycle([]AIAccountSubjectQuotaCycle{thirdParty, gemini})
+	if !okForward || !okReverse {
+		t.Fatal("expected a weekly cycle from both orderings")
+	}
+	if forward.QuotaKey != reverse.QuotaKey {
+		t.Fatalf("selection depends on input order: %q vs %q", forward.QuotaKey, reverse.QuotaKey)
+	}
+	if forward.QuotaKey != antigravityGeminiWeeklyKey {
+		t.Fatalf("selected %q, want the provider's named weekly window", forward.QuotaKey)
+	}
+
+	// An upstream rename must degrade to a stable choice rather than to no cycle.
+	renamed := []AIAccountSubjectQuotaCycle{
+		{
+			AuthSubjectID: "authsub_order", Provider: "antigravity", QuotaKey: "antigravity:zz_weekly",
+			CycleStartAt: now, ResetAt: now.Add(7 * 24 * time.Hour),
+			WindowSeconds: weeklyWindowSeconds, LastVerifiedAt: now,
+		},
+		{
+			AuthSubjectID: "authsub_order", Provider: "antigravity", QuotaKey: "antigravity:aa_weekly",
+			CycleStartAt: now.Add(-time.Hour), ResetAt: now.Add(167 * time.Hour),
+			WindowSeconds: weeklyWindowSeconds, LastVerifiedAt: now,
+		},
+	}
+	fallback, ok := selectAIAccountSubjectWeeklyCycle(renamed)
+	if !ok || fallback.QuotaKey != "antigravity:aa_weekly" {
+		t.Fatalf("fallback selection = %+v, want the deterministic aa_weekly", fallback)
+	}
+}
+
+// One batch mixes providers. Filtering candidates by a single list of quota keys
+// built from that batch dropped every window belonging to a provider that names
+// its buckets differently: with "seven_day" in the list, antigravity reported no
+// cycle at all.
+func TestWeeklyCycleBatchKeepsProvidersWithUnlistedQuotaKeys(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	claudeSubject := "authsub_batch_claude"
+	antigravitySubject := "authsub_batch_antigravity"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	reset := now.Add(120 * time.Hour)
+	percent := 50.0
+	if err := RecordAIAccountSubjectQuotaPoints(claudeSubject, "claude", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "claude", QuotaKey: "seven_day", QuotaLabel: "7d",
+		Percent: &percent, ResetAt: &reset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordAIAccountSubjectQuotaPoints(antigravitySubject, "antigravity", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey, QuotaLabel: "Gemini",
+		Percent: &percent, ResetAt: &reset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	starts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{claudeSubject, antigravitySubject})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, subjectID := range []string{claudeSubject, antigravitySubject} {
+		if starts[subjectID].IsZero() {
+			t.Fatalf("subject %s lost its cycle in a mixed-provider batch: %+v", subjectID, starts)
+		}
+	}
+}
+
+// A period still has to roll when the upstream says the old one is over —
+// otherwise the next week's traffic would be added to the previous week's total.
+func TestWeeklyCycleRollsAfterStoredPeriodEnds(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_rollover_after_end"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	firstReset := now.Add(2 * time.Hour)
+	percent := 10.0
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "antigravity", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey, QuotaLabel: "Gemini",
+		Percent: &percent, ResetAt: &firstReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Probed after the stored period ended, reporting a window that is not
+	// contiguous with it (the account was idle across the boundary).
+	after := firstReset.Add(3 * time.Hour)
+	secondReset := after.Add(7 * 24 * time.Hour)
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "antigravity", []QuotaSnapshotPoint{{
+		RecordedAt: after, Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey, QuotaLabel: "Gemini",
+		Percent: &percent, ResetAt: &secondReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	var start storedTime
+	if err := getDB().QueryRow(`
+		SELECT cycle_start_at FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, subjectID, antigravityGeminiWeeklyKey).Scan(&start); err != nil {
+		t.Fatal(err)
+	}
+	want := secondReset.Add(-7 * 24 * time.Hour)
+	if !start.Valid || !start.Time.UTC().Equal(want) {
+		t.Fatalf("cycle start = %v, want %v (an ended period must roll)", start.Time, want)
+	}
+}
+
+// The buckets already scattered on disk are repaired in place: waiting out a full
+// window before totals become correct is not a fix an operator can use.
+func TestCycleRealignFoldsFragmentsOntoLiveAnchor(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_realign"
+
+	anchorAt := time.Now().UTC().Truncate(time.Second).Add(-60 * time.Hour)
+	resetAt := anchorAt.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'antigravity', ?, ?, ?, ?, ?)
+	`, subjectID, antigravityGeminiWeeklyKey,
+		anchorAt.Format(time.RFC3339Nano), resetAt.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, anchorAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	// The third-party window, whose sliding reset produced the fragments, is the
+	// one a timestamp ordering would have picked.
+	slidTo := anchorAt.Add(58 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'antigravity', ?, ?, ?, ?, ?)
+	`, subjectID, antigravity3pWeeklyKey,
+		slidTo.Format(time.RFC3339Nano), slidTo.Add(7*24*time.Hour).Format(time.RFC3339Nano),
+		weeklyWindowSeconds, slidTo.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Production's shape: six fragments of one week, plus a bucket from the
+	// previous period that must survive untouched.
+	previous := anchorAt.Add(-8 * 24 * time.Hour)
+	fragments := []struct {
+		at       time.Time
+		requests int64
+		tokens   int64
+	}{
+		{previous, 90, 900},
+		{anchorAt, 545, 13258533},
+		{anchorAt.Add(3 * time.Hour), 13, 186046},
+		{anchorAt.Add(5 * time.Hour), 7, 246262},
+		{anchorAt.Add(7 * time.Hour), 17, 408122},
+		{anchorAt.Add(23 * time.Hour), 487, 27117844},
+		{anchorAt.Add(48 * time.Hour), 15, 304158},
+	}
+	var wantRequests, wantTokens int64
+	for _, fragment := range fragments {
+		if _, err := getDB().Exec(`
+			INSERT INTO ai_account_subject_usage_buckets (
+				auth_subject_id, bucket_kind, bucket_start, request_count,
+				success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+			) VALUES (?, 'cycle', ?, ?, ?, 0, 0, ?, ?, ?)
+		`, subjectID, formatAIAccountSubjectCycleBucketStart(fragment.at),
+			fragment.requests, fragment.requests, fragment.tokens,
+			fragment.at.Format(time.RFC3339Nano), fragment.at.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+		if !fragment.at.Before(anchorAt) {
+			wantRequests += fragment.requests
+			wantTokens += fragment.tokens
+		}
+	}
+
+	if err := runAIAccountSubjectCycleRealignDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	if buckets := countCycleBuckets(t, subjectID); buckets != 2 {
+		t.Fatalf("cycle buckets = %d, want 2 (this period folded, the previous kept)", buckets)
+	}
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != wantRequests || got.CycleTotalTokens != wantTokens {
+		t.Fatalf("cycle summary = %+v, want %d requests / %d tokens", got, wantRequests, wantTokens)
+	}
+
+	// Idempotent: the marker stops a second pass from touching anything.
+	if err := runAIAccountSubjectCycleRealignDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	if buckets := countCycleBuckets(t, subjectID); buckets != 2 {
+		t.Fatalf("cycle buckets after rerun = %d, want 2", buckets)
+	}
+}

--- a/internal/usage/ai_account_subject_cycle_anchor_test.go
+++ b/internal/usage/ai_account_subject_cycle_anchor_test.go
@@ -316,3 +316,41 @@ func TestCycleRealignFoldsFragmentsOntoLiveAnchor(t *testing.T) {
 		t.Fatalf("cycle buckets after rerun = %d, want 2", buckets)
 	}
 }
+
+// One bucket keyed to a start no reader resolves reads as zero just as surely as
+// six do, so the repair cannot be limited to subjects with several fragments.
+func TestCycleRealignRekeysLoneMisplacedBucket(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_realign_single"
+
+	anchorAt := time.Now().UTC().Truncate(time.Second).Add(-40 * time.Hour)
+	resetAt := anchorAt.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'antigravity', ?, ?, ?, ?, ?)
+	`, subjectID, antigravityGeminiWeeklyKey,
+		anchorAt.Format(time.RFC3339Nano), resetAt.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, anchorAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	strayAt := anchorAt.Add(30 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, 42, 42, 0, 0, 4200, ?, ?)
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(strayAt),
+		strayAt.Format(time.RFC3339Nano), strayAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleRealignDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 42 || got.CycleTotalTokens != 4200 {
+		t.Fatalf("cycle summary = %+v, want 42 requests / 4200 tokens", got)
+	}
+}

--- a/internal/usage/ai_account_subject_cycle_realign.go
+++ b/internal/usage/ai_account_subject_cycle_realign.go
@@ -70,11 +70,19 @@ func runAIAccountSubjectCycleRealignDB(db *sql.DB) error {
 	defer func() { _ = tx.Rollback() }()
 
 	for _, subjectID := range subjectIDs {
-		group := aiAccountSubjectCycleBucketsInPeriod(bySubject[subjectID], anchors[subjectID])
-		if len(group) < 2 {
+		anchor := anchors[subjectID]
+		group := aiAccountSubjectCycleBucketsInPeriod(bySubject[subjectID], anchor)
+		if len(group) == 0 {
 			continue
 		}
-		if err := foldAIAccountSubjectCycleBucketsTx(tx, anchors[subjectID].CycleStartAt, group); err != nil {
+		// A lone bucket still needs the pass when it is keyed to a start the
+		// readers no longer resolve — one misplaced bucket reads as zero just as
+		// surely as six do.
+		anchorKey := formatAIAccountSubjectCycleBucketStart(anchor.CycleStartAt)
+		if len(group) == 1 && group[0].start == anchorKey {
+			continue
+		}
+		if err := foldAIAccountSubjectCycleBucketsTx(tx, anchor.CycleStartAt, group); err != nil {
 			return err
 		}
 	}

--- a/internal/usage/ai_account_subject_cycle_realign.go
+++ b/internal/usage/ai_account_subject_cycle_realign.go
@@ -1,0 +1,224 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+)
+
+const aiAccountSubjectCycleRealignMarker = "ai_account_subject_cycle_realign_v1"
+
+// RunAIAccountSubjectCycleRealignAtInit folds every usage bucket that belongs to
+// the live period onto that period's anchor.
+//
+// The earlier merge (see ai_account_subject_cycle_merge.go) clustered buckets by
+// drift tolerance, which only reunites fragments minutes apart. It could not
+// repair the fragmentation a sliding reset causes: a quota bucket the account has
+// not touched is answered as "a full window remaining", so its derived start
+// walked forward by hours on every probe and each step opened a bucket of its own.
+// Production carried one weekly period split across six buckets — 545 / 13 / 7 /
+// 17 / 487 / 15 requests — none of which matched the anchor the readers resolved,
+// so a card for an account with 1084 lifetime calls reported 0 for the period.
+//
+// Anchoring now refuses to roll a period that has not ended, so no new fragments
+// appear. This repairs the ones already on disk instead of making operators wait
+// out a full window for correct totals.
+func RunAIAccountSubjectCycleRealignAtInit() error {
+	return runAIAccountSubjectCycleRealignDB(getDB())
+}
+
+func runAIAccountSubjectCycleRealignDB(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+
+	usageProjectionMu.Lock()
+	defer usageProjectionMu.Unlock()
+
+	ensureUsageProjectionMarkerTable(db)
+	if projectionMarkerValue(db, aiAccountSubjectCycleRealignMarker) == rollupMarkerDone {
+		return nil
+	}
+
+	anchors, err := loadAIAccountSubjectCycleAnchors(db)
+	if err != nil {
+		return err
+	}
+	buckets, err := loadAIAccountSubjectCycleBuckets(db)
+	if err != nil {
+		return err
+	}
+	bySubject := make(map[string][]aiAccountSubjectCycleBucketRow, len(anchors))
+	for _, bucket := range buckets {
+		if _, ok := anchors[bucket.subjectID]; !ok {
+			continue
+		}
+		bySubject[bucket.subjectID] = append(bySubject[bucket.subjectID], bucket)
+	}
+
+	subjectIDs := make([]string, 0, len(bySubject))
+	for subjectID := range bySubject {
+		subjectIDs = append(subjectIDs, subjectID)
+	}
+	sort.Strings(subjectIDs)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin shared subject cycle realign: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, subjectID := range subjectIDs {
+		group := aiAccountSubjectCycleBucketsInPeriod(bySubject[subjectID], anchors[subjectID])
+		if len(group) < 2 {
+			continue
+		}
+		if err := foldAIAccountSubjectCycleBucketsTx(tx, anchors[subjectID].CycleStartAt, group); err != nil {
+			return err
+		}
+	}
+
+	now := time.Now().UTC()
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO UPDATE SET
+			marker_value = excluded.marker_value,
+			updated_at = excluded.updated_at
+	`, aiAccountSubjectCycleRealignMarker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: mark shared subject cycle realign: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit shared subject cycle realign: %w", err)
+	}
+	// The projection keys its buckets off this cache; drop it so the next write
+	// re-reads the anchors this pass just folded onto.
+	resetAIAccountSubjectCycleCache()
+	return nil
+}
+
+// loadAIAccountSubjectCycleAnchors resolves each subject's live period through the
+// same selection the projection and the readers use, so the repair lands on the
+// bucket key they will look for.
+func loadAIAccountSubjectCycleAnchors(db *sql.DB) (map[string]AIAccountSubjectQuotaCycle, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE window_seconds >= ?
+	`, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared quota cycles for realign: %w", err)
+	}
+	defer rows.Close()
+
+	bySubject := make(map[string][]AIAccountSubjectQuotaCycle)
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			return nil, fmt.Errorf("usage: scan shared quota cycle for realign: %w", err)
+		}
+		if start.Valid {
+			cycle.CycleStartAt = start.Time.UTC()
+		}
+		if reset.Valid {
+			cycle.ResetAt = reset.Time.UTC()
+		}
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time.UTC()
+		}
+		bySubject[cycle.AuthSubjectID] = append(bySubject[cycle.AuthSubjectID], cycle)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]AIAccountSubjectQuotaCycle, len(bySubject))
+	for subjectID, cycles := range bySubject {
+		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
+			out[subjectID] = cycle
+		}
+	}
+	return out, nil
+}
+
+// aiAccountSubjectCycleBucketsInPeriod returns the buckets whose key falls inside
+// the live period, oldest first. A fragment's key is the start the writer believed
+// in, and every fragment of one period sits between that period's start and its
+// reset; buckets outside it belong to earlier periods and are left alone.
+func aiAccountSubjectCycleBucketsInPeriod(
+	buckets []aiAccountSubjectCycleBucketRow,
+	anchor AIAccountSubjectQuotaCycle,
+) []aiAccountSubjectCycleBucketRow {
+	if anchor.CycleStartAt.IsZero() || anchor.ResetAt.IsZero() {
+		return nil
+	}
+	// The anchor itself may sit a tolerance away from the fragment that recorded
+	// the period's true beginning, so admit that much slack on the lower edge.
+	from := anchor.CycleStartAt.Add(-aiAccountSubjectCycleDriftTolerance(anchor.WindowSeconds))
+	out := make([]aiAccountSubjectCycleBucketRow, 0, len(buckets))
+	for _, bucket := range buckets {
+		if bucket.at.Before(from) || !bucket.at.Before(anchor.ResetAt) {
+			continue
+		}
+		out = append(out, bucket)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].at.Before(out[j].at) })
+	return out
+}
+
+// foldAIAccountSubjectCycleBucketsTx rewrites a period's fragments as one bucket
+// keyed to the anchor the readers resolve.
+func foldAIAccountSubjectCycleBucketsTx(
+	tx *sql.Tx,
+	anchorAt time.Time,
+	group []aiAccountSubjectCycleBucketRow,
+) error {
+	subjectID := group[0].subjectID
+	anchorKey := formatAIAccountSubjectCycleBucketStart(anchorAt)
+
+	merged := aiAccountSubjectCycleBucketRow{subjectID: subjectID, start: anchorKey, at: anchorAt}
+	for _, bucket := range group {
+		merged.requests += bucket.requests
+		merged.successes += bucket.successes
+		merged.failures += bucket.failures
+		merged.cost += bucket.cost
+		merged.tokens += bucket.tokens
+		if !bucket.firstEvent.IsZero() && (merged.firstEvent.IsZero() || bucket.firstEvent.Before(merged.firstEvent)) {
+			merged.firstEvent = bucket.firstEvent
+		}
+		if bucket.updatedAt.After(merged.updatedAt) {
+			merged.updatedAt = bucket.updatedAt
+		}
+	}
+	if merged.firstEvent.IsZero() {
+		merged.firstEvent = group[0].at
+	}
+	if merged.updatedAt.IsZero() {
+		merged.updatedAt = group[len(group)-1].at
+	}
+
+	for _, bucket := range group {
+		if _, err := tx.Exec(`
+			DELETE FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+		`, bucket.subjectID, bucket.start); err != nil {
+			return fmt.Errorf("usage: drop realigned cycle bucket: %w", err)
+		}
+	}
+	// Deleting first and inserting once keeps this correct whether or not the
+	// anchor's own key was among the fragments.
+	if _, err := tx.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, ?, ?, ?, ?, ?, ?, ?)
+	`, subjectID, anchorKey, merged.requests, merged.successes, merged.failures,
+		merged.cost, merged.tokens,
+		merged.firstEvent.UTC().Format(time.RFC3339Nano),
+		merged.updatedAt.UTC().Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: write realigned cycle bucket: %w", err)
+	}
+	return nil
+}

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -147,16 +147,48 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 	if !start.Valid || window != cycle.WindowSeconds {
 		return cycle, nil
 	}
-	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) {
+	storedReset := time.Time{}
+	if reset.Valid {
+		storedReset = reset.Time.UTC()
+	}
+	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) &&
+		aiAccountSubjectCycleRollover(cycle, storedReset) {
 		return cycle, nil
 	}
 	cycle.CycleStartAt = start.Time.UTC()
-	if reset.Valid && !reset.Time.IsZero() {
+	if !storedReset.IsZero() {
 		// Keep reset_at consistent with the anchor so the card countdown stops
 		// jittering by a second or two on every probe.
-		cycle.ResetAt = reset.Time.UTC()
+		cycle.ResetAt = storedReset
 	}
 	return cycle, nil
+}
+
+// aiAccountSubjectCycleRollover reports whether a probe describes a genuinely new
+// period rather than the stored one seen through a moving countdown.
+//
+// Drift tolerance alone was not enough. A quota bucket the account has not touched
+// is answered as "a full window remaining", so its reset — and the start derived
+// from it — advances by however long has passed since the last probe. Hours of
+// that is far outside any tolerance, yet nothing has rolled: it is the same
+// untouched period. Treating each probe as a new period is what re-keyed the
+// usage bucket every few hours and scattered one week's requests across six of
+// them.
+//
+// A period may therefore only be replaced when the upstream shows the old one is
+// finished: the probe ran after it ended, the new period starts where it ended,
+// or the reset moved closer (credits reset, plan change).
+func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time) bool {
+	if storedReset.IsZero() {
+		return true
+	}
+	if !incoming.LastVerifiedAt.IsZero() && !incoming.LastVerifiedAt.UTC().Before(storedReset) {
+		return true
+	}
+	if sameAIAccountSubjectCycle(incoming.CycleStartAt, storedReset, incoming.WindowSeconds) {
+		return true
+	}
+	return incoming.ResetAt.UTC().Before(storedReset)
 }
 
 func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, error) {
@@ -248,14 +280,21 @@ func QueryAIAccountSubjectQuotaSeries(authSubjectID string, start, end time.Time
 	return series, rows.Err()
 }
 
-func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferredKeys []string) (map[string]time.Time, error) {
+// QueryLatestAIAccountSubjectWeeklyCyclesBatch resolves each subject's cycle
+// anchor. Candidate filtering deliberately happens in
+// selectAIAccountSubjectWeeklyCycle rather than in SQL: the preference is
+// per-provider, and a single IN list built from a mixed batch dropped every
+// window belonging to a provider that names its buckets differently — with the
+// list holding "seven_day" for Claude, antigravity's own weekly rows never came
+// back and its accounts reported no cycle at all.
+func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string) (map[string]time.Time, error) {
 	db := getReadDB()
 	ids := dedupeExactStrings(subjectIDs)
 	out := make(map[string]time.Time)
 	if db == nil || len(ids) == 0 {
 		return out, nil
 	}
-	args := make([]any, 0, len(ids)+len(preferredKeys)+1)
+	args := make([]any, 0, len(ids)+1)
 	for _, id := range ids {
 		args = append(args, id)
 	}
@@ -265,14 +304,6 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferred
 		FROM ai_account_subject_quota_cycles
 		WHERE auth_subject_id IN (` + strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + `)
 		  AND window_seconds >= ?`
-	keys := dedupeExactStrings(preferredKeys)
-	if len(keys) > 0 {
-		query += ` AND quota_key IN (` + strings.TrimSuffix(strings.Repeat("?,", len(keys)), ",") + `)`
-		for _, key := range keys {
-			args = append(args, key)
-		}
-	}
-	query += ` ORDER BY last_verified_at DESC, reset_at DESC`
 	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("usage: query shared quota cycles: %w", err)

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -54,6 +54,13 @@ func primaryAIAccountSubjectWeeklyQuotaKey(provider string) string {
 		return "code_week"
 	case "xai", "grok":
 		return "weekly_limit"
+	case "antigravity":
+		// Antigravity reports two weekly buckets — Gemini models and the
+		// third-party (Claude/GPT) ones. Gemini is the bucket an account actually
+		// spends; the 3p bucket usually sits unused, and while it does the
+		// upstream answers its reset as "now + 7d", so its derived start walks
+		// forward on every probe and can never anchor a period.
+		return "antigravity:gemini_weekly"
 	default:
 		return ""
 	}
@@ -113,21 +120,57 @@ func sameAIAccountSubjectCycle(a, b time.Time, windowSeconds int64) bool {
 	return absDuration(a.UTC().Sub(b.UTC())) <= aiAccountSubjectCycleDriftTolerance(windowSeconds)
 }
 
+// selectAIAccountSubjectWeeklyCycle answers "which window is this subject's card
+// cycle" and must answer it identically everywhere.
+//
+// The request-hot projection asks via an in-memory map and the readers ask via a
+// SQL result set, so the answer cannot depend on the order candidates arrive in.
+// It also cannot depend on last_verified_at or reset_at: a provider that reports
+// several weekly windows re-stamps them all on the same probe, and ordering by a
+// moving timestamp let the two sides pick different windows. Requests then landed
+// in a bucket no reader looked at — production had an account with 1084 lifetime
+// calls whose card reported 0 for the period.
 func selectAIAccountSubjectWeeklyCycle(cycles []AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, bool) {
-	var selected AIAccountSubjectQuotaCycle
+	candidates := make([]AIAccountSubjectQuotaCycle, 0, len(cycles))
+	preferred := make([]AIAccountSubjectQuotaCycle, 0, len(cycles))
 	for _, cycle := range cycles {
 		if cycle.WindowSeconds < aiAccountSubjectWeeklyWindowSeconds || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() {
 			continue
 		}
+		candidates = append(candidates, cycle)
 		primaryKey := primaryAIAccountSubjectWeeklyQuotaKey(cycle.Provider)
-		if primaryKey != "" && strings.TrimSpace(cycle.QuotaKey) != primaryKey {
-			continue
+		if primaryKey != "" && strings.TrimSpace(cycle.QuotaKey) == primaryKey {
+			preferred = append(preferred, cycle)
 		}
-		if selected.AuthSubjectID == "" || cycle.LastVerifiedAt.After(selected.LastVerifiedAt) {
+	}
+	// The provider's named window wins when the probe returned it. When it did
+	// not — an upstream rename, or a fallback probe that only sees other windows
+	// — keep the remaining candidates instead of reporting no cycle at all.
+	if len(preferred) > 0 {
+		candidates = preferred
+	}
+	if len(candidates) == 0 {
+		return AIAccountSubjectQuotaCycle{}, false
+	}
+	selected := candidates[0]
+	for _, cycle := range candidates[1:] {
+		if aiAccountSubjectCycleRanksAhead(cycle, selected) {
 			selected = cycle
 		}
 	}
-	return selected, selected.AuthSubjectID != ""
+	return selected, true
+}
+
+// aiAccountSubjectCycleRanksAhead is a total order over cycle candidates, so the
+// winner is a pure function of the set. The narrowest window at or above a week
+// is the weekly one — a monthly window sorts behind it rather than displacing it
+// — and the quota key breaks the tie because, unlike any timestamp, it does not
+// move when the next probe lands.
+func aiAccountSubjectCycleRanksAhead(candidate, current AIAccountSubjectQuotaCycle) bool {
+	if candidate.WindowSeconds != current.WindowSeconds {
+		return candidate.WindowSeconds < current.WindowSeconds
+	}
+	return strings.TrimSpace(candidate.QuotaKey) < strings.TrimSpace(current.QuotaKey)
 }
 
 func cachedAIAccountSubjectWeeklyCycle(subjectID string) (AIAccountSubjectQuotaCycle, bool) {


### PR DESCRIPTION
## 问题

antigravity 卡片上的「本周期调用数 / 本周期 token」恒为 0，成功率却正常。生产库取证（`14b1ee9a` 租户）：

| subject | lifetime | cycle 桶 |
|---|---|---|
| `authsub_7434ed61d4162512` | 1084 次 / 41.5M tokens | 被拆成 6 个：545 / 13 / 7 / 17 / 487 / 15 |
| `authsub_17a39432c7958b7f` | 25 次 | 被拆成 3 个：11 / 12 / 2 |

读端解析出的锚点与任何一个碎片都对不上，于是统计为 0。

## 三个成因

**1. 未使用的配额窗口，reset 每次探测都在滑**

`ai_account_subject_quota_points` 实证：

```
antigravity:gemini_weekly  87%  reset 2026-08-28 00:29:49   ← 固定
antigravity:3p_weekly     100%  reset = 每次探测时刻 + 7 天  ← 滑动
```

上游对没动过的桶回答的是「还剩一整个窗口」，于是 `cycle_start = reset - window` 每次探测往前挪几个小时。锚定容差只有窗口的 1%（约 100 分钟），挡不住，于是每次探测都开一个新桶。

现在只有三种情况才允许换周期：探测发生在存量 reset 之后、新周期起点与存量 reset 首尾相接、或 reset 提前了（额度重置/改套餐）。

**2. 写端和读端各选各的周期**

投影走内存 map，读端走 SQL 结果集，两边都按 `last_verified_at` 排序 —— 而一次探测会给所有窗口盖同一个时间戳。平局下 map 遍历是随机的，SQL 则固定取 `reset_at` 最大的那个，两边选不同窗口，请求就写进了没人读的桶。

选择改成候选集上的全序（窗口宽度 + quota key，都不随时间移动），并给 antigravity 指定主窗口 `antigravity:gemini_weekly`（真正在计量的那个），匹配不到时退回确定性选择而不是「没有周期」。

**3. 混批查询把整类 provider 的周期过滤掉了**

`ListStatus` 把批次里所有 provider 的 primary key 拼成一个 `quota_key IN (...)`。生产实测该租户返回 **0 行** —— antigravity 的窗口不在列表里，全被滤掉。过滤本来就是 per-provider 的，已经在选择函数里按 `cycle.Provider` 做了，SQL 那层是多余且有害的，删掉。

## 历史数据

已经散在磁盘上的碎片由一次性迁移（`ai_account_subject_cycle_realign_v1`）折叠到当前锚点，不用等下个周期滚完才有正确数字。既有的 merge 迁移只能重聚相差几分钟的碎片，修不了这种形态。按生产数据推演：1084 和 25 都能完整合回。

## 验证

- `./scripts/ci-pr.sh` 全绿
- 新增回归测试在退回旧实现时确实失败（逐项验证过）：滑动窗口开新桶、选择结果依赖输入顺序、迁移不折叠碎片
- 混批场景补 `TestListStatusKeepsCycleUsageForMixedProviders`

🤖 Generated with [Claude Code](https://claude.com/claude-code)