### PR TITLE
fix(usage): make one upstream account one subject across tenants

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -22,7 +22,7 @@
       },
       {
         "path": "internal/management/aiaccountstatus/service.go",
-        "max_lines": 1000
+        "max_lines": 990
       },
       {
         "path": "internal/management/modelcatalog/availability.go",

--- a/internal/management/aiaccountstatus/service_cross_tenant_usage_test.go
+++ b/internal/management/aiaccountstatus/service_cross_tenant_usage_test.go
@@ -1,0 +1,99 @@
+package aiaccountstatus
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	_ "modernc.org/sqlite"
+)
+
+// One upstream account mounted by two tenants must read the same in both. It did
+// not: every seed but account_id folded tenant_id in, so a Google account became
+// one subject per tenant. The tenant that had not called it yet showed 0 calls
+// beside the whole account's quota, and the operator read that as "this tenant's
+// data has not synced".
+func TestListStatusReportsOneAccountIdenticallyInEveryTenant(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { usage.CloseDB(); _ = os.Remove(dbPath) })
+
+	const tenantBusy, tenantIdle = "tenant-busy", "tenant-idle"
+	busyAuth := &coreauth.Auth{
+		ID: tenantBusy + "/antigravity-shared@example.com.json", Provider: "antigravity",
+		FileName: "antigravity-busy.json", Metadata: map[string]any{"email": "shared@example.com"},
+	}
+	idleAuth := &coreauth.Auth{
+		ID: tenantIdle + "/antigravity-shared@example.com.json", Provider: "antigravity",
+		FileName: "antigravity-idle.json", Metadata: map[string]any{"email": "shared@example.com"},
+	}
+	busyManager := newTestManager(t, tenantBusy, busyAuth)
+	idleManager := newTestManager(t, tenantIdle, idleAuth)
+
+	identity := usage.ResolveAuthSubjectIdentity(busyAuth)
+	if identity == nil || identity.ID != usage.ResolveAuthSubjectIdentity(idleAuth).ID {
+		t.Fatalf("one account still resolves to two subjects: %+v", identity)
+	}
+	hook := usage.AIAccountBindingHook{}
+	hook.OnAuthLoaded(context.Background(), busyAuth)
+	hook.OnAuthLoaded(context.Background(), idleAuth)
+
+	checked := time.Now().UTC().Truncate(time.Second)
+	percent := 87.0
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID: identity.ID, Provider: "antigravity",
+		LastProbeState: string(RefreshSuccess), HealthStatus: "ok", PlanType: "google-ai-pro",
+		Quotas: []usage.QuotaWindowDTO{{
+			QuotaKey: "antigravity:gemini_weekly", Percent: &percent, WindowSeconds: 604800,
+		}},
+		UpstreamCheckedAt: &checked, UpdatedAt: checked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Only the busy tenant ever called the account; the subject projection is
+	// shared, so the idle tenant must still read the account's totals.
+	admin, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+	if _, err := admin.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets
+			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+			 failure_count, cost_total, total_tokens, first_event_at, updated_at)
+		VALUES (?, 'lifetime', '1970-01-01', 9, 9, 0, 3, 1234, ?, ?)
+	`, identity.ID, checked.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, view := range []struct {
+		tenant  string
+		manager *coreauth.Manager
+	}{{tenantBusy, busyManager}, {tenantIdle, idleManager}} {
+		response, err := New(&config.Config{}, view.manager, nil, nil).ListStatus(view.tenant, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(response.Items) != 1 {
+			t.Fatalf("%s items=%+v", view.tenant, response.Items)
+		}
+		item := response.Items[0]
+		if item.AuthSubjectID != identity.ID {
+			t.Fatalf("%s resolved subject %q, want %q", view.tenant, item.AuthSubjectID, identity.ID)
+		}
+		if item.Usage.RequestTotal != 9 || item.Usage.SuccessTotal != 9 {
+			t.Fatalf("%s usage = %+v, want the account total", view.tenant, item.Usage)
+		}
+		if item.PlanType != "google-ai-pro" {
+			t.Fatalf("%s plan = %q", view.tenant, item.PlanType)
+		}
+	}
+}

--- a/internal/usage/ai_account_binding_hook.go
+++ b/internal/usage/ai_account_binding_hook.go
@@ -40,6 +40,14 @@ func reconcileAIAccountBinding(auth *coreauth.Auth) {
 	if identity == nil {
 		return
 	}
+	// Runs before the binding upsert so the account's history is already under the
+	// shared id by the time anything points at it.
+	if err := MergeLegacySplitAuthSubject(auth, identity); err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"tenant_id": normalizeTenantID(auth.TenantID), "provider": identity.Provider,
+			"auth_subject_id": identity.ID,
+		}).Warn("usage: merge legacy split ai account subject")
+	}
 	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"tenant_id": normalizeTenantID(auth.TenantID), "provider": identity.Provider,

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -101,7 +101,11 @@ func sharedSubjectTestAuth(tenantID, authID, accountID, email string) *coreauth.
 	}
 }
 
-func TestResolveAuthSubjectIdentitySharesOnlyStableAccountID(t *testing.T) {
+// A subject is the physical upstream account. Every seed that names that account
+// — the provider's id, the account email, the credential's own id — must resolve
+// to one subject however many tenants mounted it; only auth_index, which names
+// no account, stays tenant local.
+func TestResolveAuthSubjectIdentitySharesEverySeedThatNamesAnAccount(t *testing.T) {
 	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "auth-a", "acct-shared", "a@example.com")
 	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "auth-b", "acct-shared", "b@example.com")
 	identityA := ResolveAuthSubjectIdentity(authA)
@@ -120,18 +124,62 @@ func TestResolveAuthSubjectIdentitySharesOnlyStableAccountID(t *testing.T) {
 		t.Fatal("account_key/auth_subject_id must be non-empty")
 	}
 
-	fallbackA := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantA, "fallback-a", "", "same@example.com"))
-	fallbackB := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantB, "fallback-b", "", "same@example.com"))
-	if fallbackA == nil || fallbackB == nil {
-		t.Fatal("expected fallback identities")
+	// One Google account mounted by two tenants: production split it in three and
+	// each tenant saw only the calls it had made, beside the whole account's quota.
+	emailA := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantA, "email-a", "", "same@example.com"))
+	emailB := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantB, "email-b", "", "same@example.com"))
+	if emailA == nil || emailB == nil {
+		t.Fatal("expected email identities")
 	}
-	if fallbackA.ID == fallbackB.ID {
-		t.Fatalf("email fallback crossed tenant boundary: %q", fallbackA.ID)
+	if emailA.ID != emailB.ID {
+		t.Fatalf("one account email split across tenants: %q != %q", emailA.ID, emailB.ID)
 	}
-	for _, identity := range []*AuthSubjectIdentity{fallbackA, fallbackB} {
-		if identity.SubjectScope != AIAccountSubjectScopeTenant || identity.ShareEligible || identity.SeedKind != "email" {
-			t.Fatalf("tenant fallback contract = %+v", identity)
+	for _, identity := range []*AuthSubjectIdentity{emailA, emailB} {
+		if identity.SubjectScope != AIAccountSubjectScopeShared || !identity.ShareEligible || identity.SeedKind != "email" {
+			t.Fatalf("email identity contract = %+v", identity)
 		}
+	}
+
+	// The same API key mounted by two tenants. Its id is stored tenant-prefixed,
+	// and the prefix is the only part that is not derived from the key material.
+	keyA := ResolveAuthSubjectIdentity(&coreauth.Auth{
+		ID: sharedSubjectTenantA + "/codex:apikey:deadbeef", TenantID: sharedSubjectTenantA,
+		Provider: "codex", FileName: "codex-a.json",
+	})
+	keyB := ResolveAuthSubjectIdentity(&coreauth.Auth{
+		ID: sharedSubjectTenantB + "/codex:apikey:deadbeef", TenantID: sharedSubjectTenantB,
+		Provider: "codex", FileName: "codex-b.json",
+	})
+	if keyA == nil || keyB == nil {
+		t.Fatal("expected auth_id identities")
+	}
+	if keyA.ID != keyB.ID {
+		t.Fatalf("one API key split across tenants: %q != %q", keyA.ID, keyB.ID)
+	}
+	if keyA.SeedKind != "auth_id" || !keyA.ShareEligible {
+		t.Fatalf("auth_id identity contract = %+v", keyA)
+	}
+	// A different key must stay a different account.
+	other := ResolveAuthSubjectIdentity(&coreauth.Auth{
+		ID: sharedSubjectTenantA + "/codex:apikey:feedface", TenantID: sharedSubjectTenantA,
+		Provider: "codex", FileName: "codex-other.json",
+	})
+	if other == nil || other.ID == keyA.ID {
+		t.Fatalf("distinct API keys collapsed onto one subject: %+v", other)
+	}
+
+	// auth_index identifies nothing about the account, so it cannot claim two
+	// tenants hold the same one.
+	indexA := ResolveAuthSubjectIdentity(&coreauth.Auth{TenantID: sharedSubjectTenantA, Provider: "codex", FileName: "shared-name.json"})
+	indexB := ResolveAuthSubjectIdentity(&coreauth.Auth{TenantID: sharedSubjectTenantB, Provider: "codex", FileName: "shared-name.json"})
+	if indexA == nil || indexB == nil {
+		t.Fatal("expected auth_index identities")
+	}
+	if indexA.SeedKind != "auth_index" || indexA.ShareEligible || indexA.SubjectScope != AIAccountSubjectScopeTenant {
+		t.Fatalf("auth_index identity contract = %+v", indexA)
+	}
+	if indexA.ID == indexB.ID {
+		t.Fatalf("auth_index crossed the tenant boundary: %q", indexA.ID)
 	}
 }
 
@@ -668,8 +716,13 @@ func TestFingerprintPolicyUsesSharedSubjectKeyAndTenantFallbackIsolation(t *test
 		t.Fatalf("invalidation count=%d key=%q", invalidations, invalidatedKey)
 	}
 
-	fallbackA := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantA, "fp-email-a", "", "same@example.com"))
-	fallbackB := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantB, "fp-email-b", "", "same@example.com"))
+	// auth_index is the only seed left that stays tenant local, so it is what has
+	// to keep two tenants' fingerprint policies apart.
+	fallbackA := ResolveAuthSubjectIdentity(&coreauth.Auth{TenantID: sharedSubjectTenantA, Provider: "codex", FileName: "fp-fallback.json"})
+	fallbackB := ResolveAuthSubjectIdentity(&coreauth.Auth{TenantID: sharedSubjectTenantB, Provider: "codex", FileName: "fp-fallback.json"})
+	if fallbackA == nil || fallbackB == nil || fallbackA.SeedKind != "auth_index" {
+		t.Fatalf("expected auth_index fallbacks: A=%+v B=%+v", fallbackA, fallbackB)
+	}
 	if fallbackA.ID == fallbackB.ID {
 		t.Fatal("tenant-scoped fingerprint fallback merged across tenants")
 	}

--- a/internal/usage/ai_account_subject_cycle_merge.go
+++ b/internal/usage/ai_account_subject_cycle_merge.go
@@ -105,7 +105,10 @@ func loadAIAccountSubjectCycleBuckets(db *sql.DB) ([]aiAccountSubjectCycleBucket
 		return nil, fmt.Errorf("usage: query shared subject cycle buckets: %w", err)
 	}
 	defer rows.Close()
+	return scanAIAccountSubjectCycleBuckets(rows)
+}
 
+func scanAIAccountSubjectCycleBuckets(rows *sql.Rows) ([]aiAccountSubjectCycleBucketRow, error) {
 	out := make([]aiAccountSubjectCycleBucketRow, 0)
 	for rows.Next() {
 		var row aiAccountSubjectCycleBucketRow

--- a/internal/usage/ai_account_subject_cycle_realign.go
+++ b/internal/usage/ai_account_subject_cycle_realign.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -104,6 +105,82 @@ func runAIAccountSubjectCycleRealignDB(db *sql.DB) error {
 	// re-reads the anchors this pass just folded onto.
 	resetAIAccountSubjectCycleCache()
 	return nil
+}
+
+// realignAuthSubjectCycleBucketsTx runs the same repair for one subject inside a
+// caller's transaction. Merging two tenants' halves of an account brings together
+// buckets anchored independently, which is the fragmented shape all over again.
+func realignAuthSubjectCycleBucketsTx(tx *sql.Tx, subjectID string) error {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		return nil
+	}
+	anchor, ok, err := loadAuthSubjectCycleAnchorTx(tx, subjectID)
+	if err != nil || !ok {
+		return err
+	}
+	buckets, err := loadAuthSubjectCycleBucketsTx(tx, subjectID)
+	if err != nil {
+		return err
+	}
+	group := aiAccountSubjectCycleBucketsInPeriod(buckets, anchor)
+	if len(group) == 0 {
+		return nil
+	}
+	anchorKey := formatAIAccountSubjectCycleBucketStart(anchor.CycleStartAt)
+	if len(group) == 1 && group[0].start == anchorKey {
+		return nil
+	}
+	return foldAIAccountSubjectCycleBucketsTx(tx, anchor.CycleStartAt, group)
+}
+
+func loadAuthSubjectCycleAnchorTx(tx *sql.Tx, subjectID string) (AIAccountSubjectQuotaCycle, bool, error) {
+	rows, err := tx.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND window_seconds >= ?
+	`, subjectID, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return AIAccountSubjectQuotaCycle{}, false, fmt.Errorf("usage: query subject quota cycles for realign: %w", err)
+	}
+	defer rows.Close()
+	cycles := make([]AIAccountSubjectQuotaCycle, 0, 4)
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			return AIAccountSubjectQuotaCycle{}, false, fmt.Errorf("usage: scan subject quota cycle for realign: %w", err)
+		}
+		if start.Valid {
+			cycle.CycleStartAt = start.Time.UTC()
+		}
+		if reset.Valid {
+			cycle.ResetAt = reset.Time.UTC()
+		}
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time.UTC()
+		}
+		cycles = append(cycles, cycle)
+	}
+	if err := rows.Err(); err != nil {
+		return AIAccountSubjectQuotaCycle{}, false, err
+	}
+	cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles)
+	return cycle, ok, nil
+}
+
+func loadAuthSubjectCycleBucketsTx(tx *sql.Tx, subjectID string) ([]aiAccountSubjectCycleBucketRow, error) {
+	rows, err := tx.Query(`
+		SELECT auth_subject_id, bucket_start, request_count, success_count, failure_count,
+			cost_total, total_tokens, first_event_at, updated_at
+		FROM ai_account_subject_usage_buckets
+		WHERE bucket_kind = 'cycle' AND auth_subject_id = ?
+	`, subjectID)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query subject cycle buckets for realign: %w", err)
+	}
+	defer rows.Close()
+	return scanAIAccountSubjectCycleBuckets(rows)
 }
 
 // loadAIAccountSubjectCycleAnchors resolves each subject's live period through the

--- a/internal/usage/auth_subject_identity.go
+++ b/internal/usage/auth_subject_identity.go
@@ -5,13 +5,20 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/google/uuid"
+
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 // AuthSubjectIdentity is the single account identity contract used by status,
 // usage, quota and identity fingerprints. AccountKey must always equal ID.
-// Only provider-stable account_id seeds are eligible for cross-tenant sharing;
-// all fallbacks include tenant_id in the seed and remain tenant scoped.
+//
+// A subject is meant to be the physical upstream account: one account, one
+// subject, bound by however many tenants happen to hold a credential for it.
+// Sharing therefore follows whether the seed identifies that account —
+// the provider's account id, the account's email, or the credential's own
+// provider-scoped id all do. Only auth_index, which is local bookkeeping and
+// names no account at all, stays tenant scoped.
 type AuthSubjectIdentity struct {
 	ID            string
 	Provider      string
@@ -47,28 +54,43 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 	seedKind := ""
 	seedValue := ""
 	shareEligible := false
-	subjectScope := "tenant"
+	subjectScope := AIAccountSubjectScopeTenant
 	shareReason := "fallback_identity_is_tenant_scoped"
 	switch {
 	case accountID != "":
 		seedKind = "account_id"
 		seedValue = accountID
 		shareEligible = true
-		subjectScope = "shared"
 		shareReason = "stable_provider_account_id"
 	case email != "":
+		// The email is the account, not a property of the tenant that mounted it.
+		// Folding tenant_id into this seed split one Google account across every
+		// tenant holding a credential for it, so each tenant saw a fraction of the
+		// account's usage next to the whole account's quota.
 		seedKind = "email"
 		seedValue = email
-	case strings.TrimSpace(auth.ID) != "":
+		shareEligible = true
+		shareReason = "provider_account_email"
+	case providerScopedAuthID(auth) != "":
+		// API-key credentials land here: their id is "<provider>:apikey:<digest>",
+		// which is the same string wherever the key is mounted once the tenant
+		// prefix — the only tenant-local part — is removed.
 		seedKind = "auth_id"
-		seedValue = strings.TrimSpace(auth.ID)
+		seedValue = providerScopedAuthID(auth)
+		shareEligible = true
+		shareReason = "provider_scoped_auth_id"
 	default:
 		authIndex := strings.TrimSpace(auth.EnsureIndex())
 		if authIndex == "" {
 			return nil
 		}
+		// auth_index is local bookkeeping and identifies no account, so it cannot
+		// be trusted to mean "the same account" across tenants.
 		seedKind = "auth_index"
 		seedValue = authIndex
+	}
+	if shareEligible {
+		subjectScope = AIAccountSubjectScopeShared
 	}
 
 	subjectSeed := []string{provider, seedKind, seedValue}
@@ -89,6 +111,63 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 		ShareEligible: shareEligible,
 		ShareReason:   shareReason,
 	}
+}
+
+// providerScopedAuthID strips the tenant prefix an auth id is stored with.
+//
+// Ids are persisted as "<tenant-uuid>/<provider>:apikey:<digest>" (the system
+// tenant keeps the bare form). Everything after the prefix is derived from the
+// credential itself, so removing it yields the same string for one credential no
+// matter which tenant mounted it — while two different keys still differ, their
+// digests being taken from the key material.
+func providerScopedAuthID(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	id := strings.TrimSpace(auth.ID)
+	if id == "" {
+		return ""
+	}
+	slash := strings.Index(id, "/")
+	if slash <= 0 {
+		return id
+	}
+	if _, err := uuid.Parse(id[:slash]); err != nil {
+		return id
+	}
+	return strings.TrimSpace(id[slash+1:])
+}
+
+// LegacyTenantScopedAuthSubjectID recomputes the subject id this auth had while
+// every non-account_id seed was tenant scoped. The migration needs it to find
+// the rows an account accumulated under its old, split identity; nothing on the
+// live path may use it.
+func LegacyTenantScopedAuthSubjectID(auth *coreauth.Auth) string {
+	identity := ResolveAuthSubjectIdentity(auth)
+	if identity == nil {
+		return ""
+	}
+	// account_id and auth_index seeds never changed shape, so they have no legacy
+	// counterpart to migrate from.
+	seedValue := ""
+	switch identity.SeedKind {
+	case "email":
+		seedValue = identity.Email
+	case "auth_id":
+		// The legacy seed carried the id exactly as stored, prefix included.
+		seedValue = strings.TrimSpace(auth.ID)
+	default:
+		return ""
+	}
+	if seedValue == "" {
+		return ""
+	}
+	return stableAuthSubjectID(
+		identity.Provider,
+		identity.SeedKind,
+		coreauth.NormalizedTenantID(auth.TenantID),
+		seedValue,
+	)
 }
 
 func BuildAuthSubjectMatcher(current *coreauth.Auth, auths []*coreauth.Auth) AuthSubjectMatcher {

--- a/internal/usage/auth_subject_identity_migration.go
+++ b/internal/usage/auth_subject_identity_migration.go
@@ -1,0 +1,339 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// mergedLegacySubjects remembers the legacy ids this process has already dealt
+// with. Auth reload fires the binding hook for every credential on every config
+// change, and the check below is otherwise a handful of queries per credential
+// that can only ever find nothing after the first pass.
+var mergedLegacySubjects sync.Map
+
+// legacySubjectMergeMu serialises merges. Two credentials for one account load
+// concurrently and would otherwise race to move the same legacy rows.
+var legacySubjectMergeMu sync.Mutex
+
+// subjectRewriteTables carry a subject reference whose primary key already
+// includes tenant_id (or is a surrogate id), so one account's rows from two
+// tenants cannot collide and a plain rewrite is enough.
+var subjectRewriteTables = []struct{ table, column string }{
+	{"ai_account_tenant_bindings", "auth_subject_id"},
+	{"ai_account_status", "auth_subject_id"},
+	{"ai_account_subject_quota_points", "auth_subject_id"},
+	{"auth_subject_usage_daily", "auth_subject_id"},
+	{"auth_subject_quota_cycles", "subject_id"},
+	{"auth_file_quota_snapshots", "auth_subject_id"},
+	{"auth_file_quota_snapshot_points", "auth_subject_id"},
+	{"identity_fingerprints", "auth_subject_id"},
+	{"request_logs", "auth_subject_id"},
+	{"usage_rollup_buckets", "auth_subject_id"},
+}
+
+// subjectAccountKeyTables key fingerprint rows by account_key, which is defined
+// to equal the subject id. Their uniqueness includes tenant_id, so the collision
+// to resolve is only the one a tenant that held both halves would hit — and the
+// key set differs per table, which is what decides whether a row is a duplicate.
+var subjectAccountKeyTables = []struct {
+	table       string
+	uniqueRest  []string
+	preferNewer string
+}{
+	{"identity_fingerprints", []string{"tenant_id", "provider", "profile_key"}, "last_seen_at"},
+	{"identity_fingerprint_account_policies", []string{"tenant_id", "provider"}, "updated_at"},
+}
+
+// MergeLegacySplitAuthSubject folds the rows an account accumulated while its
+// identity was tenant scoped onto the shared identity it has now.
+//
+// Every seed except auth_index used to carry tenant_id, so one upstream account
+// became a separate subject in each tenant holding a credential for it. Usage,
+// status and cycle rows were then split across those subjects while the quota
+// they sat next to described the whole account — a tenant that had not called
+// the account yet showed zeros beside a quota bar reading 87%.
+//
+// Called from the binding hook, so it runs with the authoritative auth in hand
+// rather than trying to reconstruct seeds from hashes on disk.
+func MergeLegacySplitAuthSubject(auth *coreauth.Auth, identity *AuthSubjectIdentity) error {
+	if auth == nil || identity == nil || strings.TrimSpace(identity.ID) == "" {
+		return nil
+	}
+	legacyID := LegacyTenantScopedAuthSubjectID(auth)
+	if legacyID == "" || legacyID == identity.ID {
+		return nil
+	}
+	if _, seen := mergedLegacySubjects.Load(legacyID); seen {
+		return nil
+	}
+	db := getDB()
+	if db == nil {
+		return nil
+	}
+
+	legacySubjectMergeMu.Lock()
+	defer legacySubjectMergeMu.Unlock()
+	if _, seen := mergedLegacySubjects.Load(legacyID); seen {
+		return nil
+	}
+
+	present, err := legacyAuthSubjectHasRows(db, legacyID)
+	if err != nil {
+		return err
+	}
+	if !present {
+		mergedLegacySubjects.Store(legacyID, struct{}{})
+		return nil
+	}
+
+	if err := mergeLegacyAuthSubjectDB(db, legacyID, identity); err != nil {
+		return err
+	}
+	mergedLegacySubjects.Store(legacyID, struct{}{})
+	return nil
+}
+
+// legacyAuthSubjectHasRows is the cheap guard on the reload path: an account
+// that was never split, or was migrated on an earlier boot, answers false here
+// and never opens a transaction.
+func legacyAuthSubjectHasRows(db *sql.DB, legacyID string) (bool, error) {
+	for _, probe := range []string{
+		`SELECT 1 FROM ai_account_subjects WHERE auth_subject_id = ? LIMIT 1`,
+		`SELECT 1 FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? LIMIT 1`,
+		`SELECT 1 FROM ai_account_subject_status WHERE auth_subject_id = ? LIMIT 1`,
+	} {
+		var found int
+		err := db.QueryRow(probe, legacyID).Scan(&found)
+		if err == nil {
+			return true, nil
+		}
+		if err != sql.ErrNoRows {
+			return false, fmt.Errorf("usage: probe legacy auth subject: %w", err)
+		}
+	}
+	return false, nil
+}
+
+func mergeLegacyAuthSubjectDB(db *sql.DB, legacyID string, identity *AuthSubjectIdentity) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin legacy auth subject merge: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// The shared subject row must exist first: four tables carry a foreign key to
+	// it, so nothing may point at an id that is not there yet.
+	if err := ensureAuthSubjectRowTx(tx, legacyID, identity); err != nil {
+		return err
+	}
+	if err := mergeLegacySubjectUsageBucketsTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	if err := mergeLegacySubjectStatusTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	if err := mergeLegacySubjectQuotaCyclesTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	for _, target := range subjectRewriteTables {
+		if _, err := tx.Exec(
+			`UPDATE `+target.table+` SET `+target.column+` = ? WHERE `+target.column+` = ?`,
+			identity.ID, legacyID,
+		); err != nil {
+			return fmt.Errorf("usage: rewrite %s.%s: %w", target.table, target.column, err)
+		}
+	}
+	for _, target := range subjectAccountKeyTables {
+		if err := mergeSubjectAccountKeyRowsTx(tx, target.table, target.uniqueRest, target.preferNewer, legacyID, identity.ID); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`DELETE FROM ai_account_subjects WHERE auth_subject_id = ?`, legacyID); err != nil {
+		return fmt.Errorf("usage: drop legacy auth subject: %w", err)
+	}
+
+	// Two tenants anchored their halves of this account independently, so the
+	// merged cycle buckets can be keyed to different starts. Fold them now rather
+	// than leaving the account reading zero until the period rolls.
+	if err := realignAuthSubjectCycleBucketsTx(tx, identity.ID); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit legacy auth subject merge: %w", err)
+	}
+	// The projection keys buckets off the cycle cache, which may still hold the
+	// pre-merge anchor for either half.
+	resetAIAccountSubjectCycleCache()
+	return nil
+}
+
+// ensureAuthSubjectRowTx creates the shared subject row, seeding its history
+// markers from the legacy row so a merged account does not look newly observed.
+func ensureAuthSubjectRowTx(tx *sql.Tx, legacyID string, identity *AuthSubjectIdentity) error {
+	shareEligible := 0
+	if identity.ShareEligible {
+		shareEligible = 1
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO ai_account_subjects (
+			auth_subject_id, provider, subject_scope, seed_kind, seed_hash, share_eligible,
+			usage_projected_since, usage_history_complete, created_at, updated_at
+		)
+		SELECT ?, ?, ?, ?, ?, ?, usage_projected_since, usage_history_complete, created_at, updated_at
+		FROM ai_account_subjects WHERE auth_subject_id = ?
+		ON CONFLICT(auth_subject_id) DO UPDATE SET
+			usage_projected_since = CASE
+				WHEN excluded.usage_projected_since IS NOT NULL
+				 AND (ai_account_subjects.usage_projected_since IS NULL
+				      OR excluded.usage_projected_since < ai_account_subjects.usage_projected_since)
+				THEN excluded.usage_projected_since
+				ELSE ai_account_subjects.usage_projected_since END,
+			created_at = CASE WHEN excluded.created_at < ai_account_subjects.created_at
+				THEN excluded.created_at ELSE ai_account_subjects.created_at END,
+			updated_at = CASE WHEN excluded.updated_at > ai_account_subjects.updated_at
+				THEN excluded.updated_at ELSE ai_account_subjects.updated_at END
+	`, identity.ID, identity.Provider, identity.SubjectScope, identity.SeedKind, identity.SeedHash,
+		shareEligible, legacyID); err != nil {
+		return fmt.Errorf("usage: ensure shared auth subject: %w", err)
+	}
+	return nil
+}
+
+// mergeLegacySubjectUsageBucketsTx adds the legacy totals into the shared rows.
+// Counters sum, the first event keeps the earliest sighting and updated_at the
+// latest, so the merged account reads as one continuous history.
+func mergeLegacySubjectUsageBucketsTx(tx *sql.Tx, legacyID, subjectID string) error {
+	if _, err := tx.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+			failure_count, cost_total, total_tokens, first_event_at, updated_at
+		)
+		SELECT ?, bucket_kind, bucket_start, request_count, success_count,
+			failure_count, cost_total, total_tokens, first_event_at, updated_at
+		FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ?
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			request_count = ai_account_subject_usage_buckets.request_count + excluded.request_count,
+			success_count = ai_account_subject_usage_buckets.success_count + excluded.success_count,
+			failure_count = ai_account_subject_usage_buckets.failure_count + excluded.failure_count,
+			cost_total = ai_account_subject_usage_buckets.cost_total + excluded.cost_total,
+			total_tokens = ai_account_subject_usage_buckets.total_tokens + excluded.total_tokens,
+			first_event_at = CASE WHEN excluded.first_event_at < ai_account_subject_usage_buckets.first_event_at
+				THEN excluded.first_event_at ELSE ai_account_subject_usage_buckets.first_event_at END,
+			updated_at = CASE WHEN excluded.updated_at > ai_account_subject_usage_buckets.updated_at
+				THEN excluded.updated_at ELSE ai_account_subject_usage_buckets.updated_at END
+	`, subjectID, legacyID); err != nil {
+		return fmt.Errorf("usage: merge legacy subject usage buckets: %w", err)
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ?`, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: drop legacy subject usage buckets: %w", err)
+	}
+	return nil
+}
+
+// mergeSubjectAccountKeyRowsTx re-keys fingerprint rows onto the shared subject.
+//
+// A tenant only collides with itself here — it held both halves of the account
+// and so has a row under each key. The newer row wins, since these describe the
+// client identity last presented for the account, and the loser is dropped
+// rather than being rewritten into a duplicate key.
+func mergeSubjectAccountKeyRowsTx(tx *sql.Tx, table string, uniqueRest []string, preferNewer, legacyID, subjectID string) error {
+	match := make([]string, 0, len(uniqueRest))
+	for _, column := range uniqueRest {
+		match = append(match, "other."+column+" = "+table+"."+column)
+	}
+	matched := strings.Join(match, " AND ")
+
+	// Drop whichever side is older wherever both exist for the same tenant row.
+	for _, drop := range []struct{ victim, rival string }{
+		{subjectID, legacyID},
+		{legacyID, subjectID},
+	} {
+		comparison := ">"
+		if drop.victim == legacyID {
+			// The shared row survives ties: re-keying the legacy row on top of an
+			// equally fresh shared row would only trade one for an identical other.
+			comparison = ">="
+		}
+		if _, err := tx.Exec(
+			`DELETE FROM `+table+` WHERE account_key = ? AND EXISTS (
+				SELECT 1 FROM `+table+` other
+				WHERE other.account_key = ? AND `+matched+`
+				  AND other.`+preferNewer+` `+comparison+` `+table+`.`+preferNewer+`
+			)`, drop.victim, drop.rival,
+		); err != nil {
+			return fmt.Errorf("usage: drop duplicate %s row: %w", table, err)
+		}
+	}
+	if _, err := tx.Exec(
+		`UPDATE `+table+` SET account_key = ? WHERE account_key = ?`, subjectID, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: rewrite %s.account_key: %w", table, err)
+	}
+	return nil
+}
+
+// mergeLegacySubjectStatusTx keeps whichever half was probed last. Status is a
+// snapshot of the upstream account, not something to add up.
+func mergeLegacySubjectStatusTx(tx *sql.Tx, legacyID, subjectID string) error {
+	if _, err := tx.Exec(`
+		DELETE FROM ai_account_subject_status
+		WHERE auth_subject_id = ? AND EXISTS (
+			SELECT 1 FROM ai_account_subject_status legacy
+			WHERE legacy.auth_subject_id = ?
+			  AND legacy.updated_at > ai_account_subject_status.updated_at
+		)`, subjectID, legacyID); err != nil {
+		return fmt.Errorf("usage: drop stale shared subject status: %w", err)
+	}
+	if _, err := tx.Exec(`
+		DELETE FROM ai_account_subject_status
+		WHERE auth_subject_id = ? AND EXISTS (
+			SELECT 1 FROM ai_account_subject_status shared WHERE shared.auth_subject_id = ?
+		)`, legacyID, subjectID); err != nil {
+		return fmt.Errorf("usage: drop stale legacy subject status: %w", err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE ai_account_subject_status SET auth_subject_id = ? WHERE auth_subject_id = ?`,
+		subjectID, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: rewrite legacy subject status: %w", err)
+	}
+	return nil
+}
+
+// mergeLegacySubjectQuotaCyclesTx keeps the most recently verified anchor per
+// quota key — both halves describe the same upstream window.
+func mergeLegacySubjectQuotaCyclesTx(tx *sql.Tx, legacyID, subjectID string) error {
+	if _, err := tx.Exec(`
+		DELETE FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND EXISTS (
+			SELECT 1 FROM ai_account_subject_quota_cycles legacy
+			WHERE legacy.auth_subject_id = ?
+			  AND legacy.quota_key = ai_account_subject_quota_cycles.quota_key
+			  AND legacy.last_verified_at > ai_account_subject_quota_cycles.last_verified_at
+		)`, subjectID, legacyID); err != nil {
+		return fmt.Errorf("usage: drop stale shared quota cycles: %w", err)
+	}
+	if _, err := tx.Exec(`
+		DELETE FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND EXISTS (
+			SELECT 1 FROM ai_account_subject_quota_cycles shared
+			WHERE shared.auth_subject_id = ?
+			  AND shared.quota_key = ai_account_subject_quota_cycles.quota_key
+		)`, legacyID, subjectID); err != nil {
+		return fmt.Errorf("usage: drop stale legacy quota cycles: %w", err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE ai_account_subject_quota_cycles SET auth_subject_id = ? WHERE auth_subject_id = ?`,
+		subjectID, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: rewrite legacy quota cycles: %w", err)
+	}
+	return nil
+}

--- a/internal/usage/auth_subject_identity_migration_test.go
+++ b/internal/usage/auth_subject_identity_migration_test.go
@@ -1,0 +1,372 @@
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func resetMergedLegacySubjects() {
+	mergedLegacySubjects.Range(func(key, _ any) bool {
+		mergedLegacySubjects.Delete(key)
+		return true
+	})
+}
+
+func seedLegacyAuthSubjectRow(t *testing.T, legacyID, provider, seedKind string, at time.Time) {
+	t.Helper()
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subjects (
+			auth_subject_id, provider, subject_scope, seed_kind, seed_hash, share_eligible,
+			usage_projected_since, usage_history_complete, created_at, updated_at
+		) VALUES (?, ?, 'tenant', ?, ?, 0, ?, 0, ?, ?)
+	`, legacyID, provider, seedKind, "hash-"+legacyID, stamp, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedLegacySubjectStatus(t *testing.T, legacyID, provider, planType string, at time.Time) {
+	t.Helper()
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_status (
+			auth_subject_id, provider, last_probe_state, health_status, plan_type, updated_at
+		) VALUES (?, ?, 'success', 'ok', ?, ?)
+	`, legacyID, provider, planType, stamp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readSubjectSummary(t *testing.T, subjectID string) AuthSubjectUsageSummary {
+	t.Helper()
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{subjectID}, map[string]time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return summaries[subjectID]
+}
+
+// Production: one Google account mounted by three tenants became three subjects.
+// The tenant that had not called it yet showed 0 calls / 0 tokens next to a quota
+// bar reading 87%, because the account's usage was filed under another tenant's
+// copy of the same account.
+func TestMergeLegacySplitSubjectFoldsTenantHalvesOntoOneAccount(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "a.json", "", "shared@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "b.json", "", "shared@example.com")
+	authA.Provider, authB.Provider = "antigravity", "antigravity"
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA.ID != identityB.ID {
+		t.Fatalf("one account still split: %q != %q", identityA.ID, identityB.ID)
+	}
+	legacyA := LegacyTenantScopedAuthSubjectID(authA)
+	legacyB := LegacyTenantScopedAuthSubjectID(authB)
+	if legacyA == "" || legacyA == legacyB || legacyA == identityA.ID {
+		t.Fatalf("legacy ids look wrong: A=%q B=%q shared=%q", legacyA, legacyB, identityA.ID)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyA, "antigravity", "email", now.Add(-72*time.Hour))
+	seedLegacyAuthSubjectRow(t, legacyB, "antigravity", "email", now.Add(-24*time.Hour))
+	// The half probed most recently is the one whose plan must survive.
+	seedLegacySubjectStatus(t, legacyA, "antigravity", "stale-plan", now.Add(-10*time.Hour))
+	seedLegacySubjectStatus(t, legacyB, "antigravity", "google-ai-pro", now.Add(-time.Hour))
+
+	for i := 0; i < 49; i++ {
+		projectSubjectRequest(t, legacyA, now.Add(-48*time.Hour), 100)
+	}
+	for i := 0; i < 3; i++ {
+		projectSubjectRequest(t, legacyB, now.Add(-2*time.Hour), 10)
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, model, failed, streaming)
+		VALUES (?, ?, ?, 'gemini-pro', 0, 0)
+	`, sharedSubjectTenantA, now.Add(-48*time.Hour).Format(time.RFC3339Nano), legacyA); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MergeLegacySplitAuthSubject(authA, identityA); err != nil {
+		t.Fatal(err)
+	}
+	if err := MergeLegacySplitAuthSubject(authB, identityB); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readSubjectSummary(t, identityA.ID)
+	if got.RequestTotal != 52 || got.SuccessTotal != 52 || got.CostTotal == 0 {
+		t.Fatalf("merged lifetime = %+v, want 52 requests", got)
+	}
+
+	var planType string
+	if err := getDB().QueryRow(
+		`SELECT plan_type FROM ai_account_subject_status WHERE auth_subject_id = ?`, identityA.ID,
+	).Scan(&planType); err != nil {
+		t.Fatal(err)
+	}
+	if planType != "google-ai-pro" {
+		t.Fatalf("status plan = %q, want the most recently probed half", planType)
+	}
+
+	for _, legacyID := range []string{legacyA, legacyB} {
+		var leftovers int
+		if err := getDB().QueryRow(`
+			SELECT (SELECT COUNT(*) FROM ai_account_subjects WHERE auth_subject_id = ?)
+			     + (SELECT COUNT(*) FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ?)
+			     + (SELECT COUNT(*) FROM ai_account_subject_status WHERE auth_subject_id = ?)
+			     + (SELECT COUNT(*) FROM request_logs WHERE auth_subject_id = ?)
+		`, legacyID, legacyID, legacyID, legacyID).Scan(&leftovers); err != nil {
+			t.Fatal(err)
+		}
+		if leftovers != 0 {
+			t.Fatalf("legacy subject %s left %d rows behind", legacyID, leftovers)
+		}
+	}
+
+	// Idempotent: a reload must not double the totals.
+	resetMergedLegacySubjects()
+	if err := MergeLegacySplitAuthSubject(authA, identityA); err != nil {
+		t.Fatal(err)
+	}
+	if again := readSubjectSummary(t, identityA.ID); again.RequestTotal != 52 {
+		t.Fatalf("re-running the merge changed totals: %+v", again)
+	}
+}
+
+// The same API key mounted by two tenants is one upstream account. Its id is
+// stored tenant-prefixed, which is what used to split it.
+func TestMergeLegacySplitSubjectFoldsSharedAPIKey(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := &coreauth.Auth{
+		ID: sharedSubjectTenantA + "/codex:apikey:abc123", TenantID: sharedSubjectTenantA,
+		Provider: "codex", FileName: "key-a.json",
+	}
+	authB := &coreauth.Auth{
+		ID: sharedSubjectTenantB + "/codex:apikey:abc123", TenantID: sharedSubjectTenantB,
+		Provider: "codex", FileName: "key-b.json",
+	}
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA.ID != identityB.ID || identityA.SeedKind != "auth_id" {
+		t.Fatalf("API key identities = %+v / %+v", identityA, identityB)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, seed := range []struct {
+		auth     *coreauth.Auth
+		identity *AuthSubjectIdentity
+		requests int
+	}{{authA, identityA, 5}, {authB, identityB, 7}} {
+		legacyID := LegacyTenantScopedAuthSubjectID(seed.auth)
+		seedLegacyAuthSubjectRow(t, legacyID, "codex", "auth_id", now.Add(-time.Hour))
+		for i := 0; i < seed.requests; i++ {
+			projectSubjectRequest(t, legacyID, now.Add(-time.Hour), 20)
+		}
+		if err := MergeLegacySplitAuthSubject(seed.auth, seed.identity); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := readSubjectSummary(t, identityA.ID); got.RequestTotal != 12 {
+		t.Fatalf("merged API key lifetime = %+v, want 12 requests", got)
+	}
+}
+
+// Merging brings together halves that were anchored independently, which is the
+// fragmented-period shape again — the totals must not read zero afterwards.
+func TestMergeLegacySplitSubjectRealignsCycleBuckets(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "cyc-a.json", "", "cycle@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "cyc-b.json", "", "cycle@example.com")
+	authA.Provider, authB.Provider = "antigravity", "antigravity"
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	reset := now.Add(96 * time.Hour)
+	percent := 70.0
+	for _, seed := range []struct {
+		auth     *coreauth.Auth
+		identity *AuthSubjectIdentity
+		at       time.Time
+		requests int
+	}{
+		{authA, identityA, now.Add(-50 * time.Hour), 9},
+		{authB, identityB, now.Add(-20 * time.Hour), 4},
+	} {
+		legacyID := LegacyTenantScopedAuthSubjectID(seed.auth)
+		seedLegacyAuthSubjectRow(t, legacyID, "antigravity", "email", now.Add(-72*time.Hour))
+		resetAt := reset
+		if err := RecordAIAccountSubjectQuotaPoints(legacyID, "antigravity", []QuotaSnapshotPoint{{
+			RecordedAt: seed.at, Provider: "antigravity", QuotaKey: "antigravity:gemini_weekly",
+			QuotaLabel: "Gemini", Percent: &percent, ResetAt: &resetAt, WindowSeconds: 604800,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < seed.requests; i++ {
+			projectSubjectRequest(t, legacyID, seed.at, 50)
+		}
+		if err := MergeLegacySplitAuthSubject(seed.auth, seed.identity); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if buckets := countCycleBuckets(t, identityA.ID); buckets != 1 {
+		t.Fatalf("cycle buckets after merge = %d, want 1", buckets)
+	}
+	got := readCycleSummary(t, identityA.ID)
+	if !got.CycleKnown || got.CycleRequestTotal != 13 {
+		t.Fatalf("merged cycle summary = %+v, want 13 requests", got)
+	}
+}
+
+// The merge has to happen on the auth-load path: it is the only place holding an
+// authoritative auth, and it is what an operator's restart actually runs.
+func TestBindingHookMergesLegacySubjectOnAuthLoad(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "hook.json", "", "hook@example.com")
+	auth.Provider = "antigravity"
+	identity := ResolveAuthSubjectIdentity(auth)
+	legacyID := LegacyTenantScopedAuthSubjectID(auth)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyID, "antigravity", "email", now.Add(-time.Hour))
+	for i := 0; i < 8; i++ {
+		projectSubjectRequest(t, legacyID, now.Add(-time.Hour), 25)
+	}
+
+	AIAccountBindingHook{}.OnAuthLoaded(context.Background(), auth)
+
+	if got := readSubjectSummary(t, identity.ID); got.RequestTotal != 8 || got.SuccessTotal != 8 {
+		t.Fatalf("hook did not migrate the account: %+v", got)
+	}
+	bindings, err := ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{auth.ID})
+	if err != nil || len(bindings) != 1 || bindings[0].AuthSubjectID != identity.ID {
+		t.Fatalf("binding=%+v err=%v, want it pointing at the shared subject", bindings, err)
+	}
+}
+
+// Fingerprint rows are unique per (tenant, provider, account_key, profile_key).
+// A tenant holding both halves collides only within one profile, so the merge
+// must compare profiles too — matching on tenant and provider alone discards
+// profiles the account still needs.
+func TestMergeLegacySplitSubjectKeepsFingerprintProfiles(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "fp.json", "", "fp@example.com")
+	auth.Provider = "codex"
+	identity := ResolveAuthSubjectIdentity(auth)
+	legacyID := LegacyTenantScopedAuthSubjectID(auth)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyID, "codex", "email", now.Add(-time.Hour))
+
+	seedFingerprint := func(accountKey, profileKey string, seenAt time.Time) {
+		t.Helper()
+		if _, err := getDB().Exec(`
+			INSERT INTO identity_fingerprints (
+				tenant_id, provider, account_key, profile_key, auth_subject_id,
+				client_product, client_variant, version, fields_json, observed_headers_json,
+				created_at, updated_at, last_seen_at
+			) VALUES (?, 'codex', ?, ?, ?, 'cli', '', '1', '{}', '{}', ?, ?, ?)
+		`, sharedSubjectTenantA, accountKey, profileKey, accountKey,
+			seenAt.Format(time.RFC3339Nano), seenAt.Format(time.RFC3339Nano), seenAt.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// One profile exists on both sides (the shared row is newer and must win); a
+	// second exists only on the legacy side and must survive the merge.
+	seedFingerprint(legacyID, "default", now.Add(-2*time.Hour))
+	seedFingerprint(identity.ID, "default", now.Add(-time.Minute))
+	seedFingerprint(legacyID, "secondary", now.Add(-3*time.Hour))
+
+	if err := MergeLegacySplitAuthSubject(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := getDB().Query(
+		`SELECT profile_key, last_seen_at FROM identity_fingerprints WHERE account_key = ? ORDER BY profile_key`,
+		identity.ID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	profiles := map[string]time.Time{}
+	for rows.Next() {
+		var profile string
+		var seen storedTime
+		if err := rows.Scan(&profile, &seen); err != nil {
+			t.Fatal(err)
+		}
+		profiles[profile] = seen.Time.UTC()
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("profiles after merge = %v, want default + secondary", profiles)
+	}
+	if !profiles["default"].Equal(now.Add(-time.Minute)) {
+		t.Fatalf("default profile = %v, want the newer shared row", profiles["default"])
+	}
+
+	var leftovers int
+	if err := getDB().QueryRow(
+		`SELECT COUNT(*) FROM identity_fingerprints WHERE account_key = ?`, legacyID,
+	).Scan(&leftovers); err != nil {
+		t.Fatal(err)
+	}
+	if leftovers != 0 {
+		t.Fatalf("legacy fingerprints left behind: %d", leftovers)
+	}
+}
+
+// Two genuinely different accounts must never be folded together.
+func TestMergeLegacySplitSubjectKeepsDistinctAccountsApart(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "one.json", "", "one@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantA, "two.json", "", "two@example.com")
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA.ID == identityB.ID {
+		t.Fatal("different emails collapsed onto one subject")
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, seed := range []struct {
+		auth     *coreauth.Auth
+		identity *AuthSubjectIdentity
+		requests int
+	}{{authA, identityA, 2}, {authB, identityB, 6}} {
+		legacyID := LegacyTenantScopedAuthSubjectID(seed.auth)
+		seedLegacyAuthSubjectRow(t, legacyID, "codex", "email", now.Add(-time.Hour))
+		for i := 0; i < seed.requests; i++ {
+			projectSubjectRequest(t, legacyID, now.Add(-time.Hour), 10)
+		}
+		if err := MergeLegacySplitAuthSubject(seed.auth, seed.identity); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := readSubjectSummary(t, identityA.ID); got.RequestTotal != 2 {
+		t.Fatalf("account one = %+v, want 2 requests", got)
+	}
+	if got := readSubjectSummary(t, identityB.ID); got.RequestTotal != 6 {
+		t.Fatalf("account two = %+v, want 6 requests", got)
+	}
+}


### PR DESCRIPTION
## 问题

同一个 AI 账号在不同租户下被算成了**不同的账号主体**，用量因此分家。`yuan364299311@gmail.com` 在「蹬的飞快」显示 0 次调用，而它在另一个租户下有 49 次。

生产实证（三个租户各持有同一个 Google 账号的凭证）：

```
11f9ab9c(蹬的飞快) → authsub_db64119e   0 次
14b1ee9a           → authsub_17a39432  49 次
9e003dfb(已删)      → authsub_0945926c   0 次
```

不只是 antigravity。全库 `seed_kind` 分布显示，**只有 codex 的 4 个账号是共享的**，其余全部按租户分裂：

| provider | seed_kind | 作用域 | 个数 |
|---|---|---|---|
| codex | account_id | shared | 4 |
| antigravity / xai / gemini / gemini-cli / claude | email | tenant | 16 |
| codex / claude / cline / opencode-go / ollama-cloud / commandcode | auth_id | tenant | 31 |

API key 账号同样分裂：`claude:apikey:58017fafdcc6` 在 2 个租户下是 2 个主体，`cline:apikey:7ea52891b41f` 在 3 个租户下是 3 个主体 —— 因为 auth id 是带租户前缀存的，前缀进了种子。

## 根因

`ai_account_subjects` + `ai_account_tenant_bindings` 这套模型本身就是为「一个物理账号被多个租户绑定」设计的，但只有 `account_id` 种子真的这么工作。其余种子都把 `tenant_id` 掺进去了，于是配额是整个账号的、用量却是本租户的，摆在同一张卡片上必然对不上。

## 改法

共享与否取决于**种子是否指向那个账号**：

- `account_id` — 指向，共享（不变）
- `email` — 指向，改为共享
- `auth_id` — 剥掉租户前缀后指向（`<uuid>/codex:apikey:abc` → `codex:apikey:abc`），改为共享；不同的 key 摘要不同，仍然是不同账号
- `auth_index` — 不指向任何账号，保持租户隔离

## 历史数据

改种子就改了 id，所以要把账号在分裂身份下积累的数据折回来：

- **用量桶**累加（请求/成功/失败/成本/token，首次事件取最早、更新时间取最晚）
- **状态**和**周期锚点**取最后一次探测的那半边
- 其余引用重新指向新 id

主键已含 `tenant_id` 的表（`usage_rollup_buckets`、`auth_subject_usage_daily`、`ai_account_status`、指纹表等）两个租户的行不可能撞键，直接改写；只按 subject 做主键的 4 张表才需要合并语义。指纹表比较完整的唯一键（含 `profile_key`）——只比 tenant+provider 会误删账号还在用的 profile，这一点单独写了测试钉住。

迁移挂在 auth 加载 hook 上：那是唯一拿得到权威 auth 对象的地方（`ai_account_subjects` 只存种子哈希，反推不出邮箱），而且重启本来就会走这条路径。合并完会重新折叠一次周期桶，因为两半各自锚过一次，合起来又是上个 PR 修的碎片形态。

**已知边界**：绑定已被删除的账号不会加载，其残留数据留在旧 id 上（生产上是 3 次调用的一个已删账号）。这些账号本来就不在界面显示。

## 验证

- `./scripts/ci-pr.sh` 全绿
- 新增测试逐条钉住：跨租户 email 账号合并（49+3=52）、同一 API key 跨租户合并、状态取最新半边、周期桶重折、幂等（重跑不翻倍）、不同账号不误合、指纹 profile 保留、auth_index 仍隔离
- 端到端：`TestListStatusReportsOneAccountIdenticallyInEveryTenant` 验证两个租户读到同一份数字
- 指纹键 bug 已用退回旧实现的方式验证测试能抓到

顺带：`aiaccountstatus/service.go` 因上个 PR 变小，按门禁提示更新了结构基线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)