### PR TITLE
fix(usage): 上游提前结束周期时让周期锚点跟着滚动

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -272,7 +272,13 @@ func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 			if err := usage.RunAIAccountSubjectCycleBucketMergeAtInit(); err != nil {
 				return err
 			}
-			return usage.RunAIAccountSubjectCycleRealignAtInit()
+			if err := usage.RunAIAccountSubjectCycleRealignAtInit(); err != nil {
+				return err
+			}
+			// After realign: that pass folds fragments onto the stored anchor, and
+			// this one may then move that anchor to the period it should have
+			// rolled into.
+			return usage.RunAIAccountSubjectCycleRolloverRepairAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/usage/ai_account_subject_cycle_realign.go
+++ b/internal/usage/ai_account_subject_cycle_realign.go
@@ -187,13 +187,32 @@ func loadAuthSubjectCycleBucketsTx(tx *sql.Tx, subjectID string) ([]aiAccountSub
 // same selection the projection and the readers use, so the repair lands on the
 // bucket key they will look for.
 func loadAIAccountSubjectCycleAnchors(db *sql.DB) (map[string]AIAccountSubjectQuotaCycle, error) {
+	bySubject, err := loadAIAccountSubjectWeeklyCyclesBySubject(db)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]AIAccountSubjectQuotaCycle, len(bySubject))
+	for subjectID, cycles := range bySubject {
+		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
+			out[subjectID] = cycle
+		}
+	}
+	return out, nil
+}
+
+// loadAIAccountSubjectWeeklyCyclesBySubject returns every stored weekly window,
+// grouped by subject. Repairs that re-derive an anchor need all of a subject's
+// windows, not just the one currently selected: correcting a single window can
+// change which one the selection resolves to.
+func loadAIAccountSubjectWeeklyCyclesBySubject(db *sql.DB) (map[string][]AIAccountSubjectQuotaCycle, error) {
 	rows, err := db.Query(`
 		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
 		FROM ai_account_subject_quota_cycles
 		WHERE window_seconds >= ?
 	`, aiAccountSubjectWeeklyWindowSeconds)
 	if err != nil {
-		return nil, fmt.Errorf("usage: query shared quota cycles for realign: %w", err)
+		return nil, fmt.Errorf("usage: query shared quota cycles: %w", err)
 	}
 	defer rows.Close()
 
@@ -202,7 +221,11 @@ func loadAIAccountSubjectCycleAnchors(db *sql.DB) (map[string]AIAccountSubjectQu
 		var cycle AIAccountSubjectQuotaCycle
 		var start, reset, verified storedTime
 		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
-			return nil, fmt.Errorf("usage: scan shared quota cycle for realign: %w", err)
+			return nil, fmt.Errorf("usage: scan shared quota cycle: %w", err)
+		}
+		cycle.AuthSubjectID = strings.TrimSpace(cycle.AuthSubjectID)
+		if cycle.AuthSubjectID == "" {
+			continue
 		}
 		if start.Valid {
 			cycle.CycleStartAt = start.Time.UTC()
@@ -215,17 +238,7 @@ func loadAIAccountSubjectCycleAnchors(db *sql.DB) (map[string]AIAccountSubjectQu
 		}
 		bySubject[cycle.AuthSubjectID] = append(bySubject[cycle.AuthSubjectID], cycle)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	out := make(map[string]AIAccountSubjectQuotaCycle, len(bySubject))
-	for subjectID, cycles := range bySubject {
-		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
-			out[subjectID] = cycle
-		}
-	}
-	return out, nil
+	return bySubject, rows.Err()
 }
 
 // aiAccountSubjectCycleBucketsInPeriod returns the buckets whose key falls inside

--- a/internal/usage/ai_account_subject_cycle_rollover_repair.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_repair.go
@@ -1,0 +1,382 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const aiAccountSubjectCycleRolloverRepairMarker = "ai_account_subject_cycle_rollover_repair_v1"
+
+type meteredWeeklyQuotaProbe struct {
+	resetAt       time.Time
+	windowSeconds int64
+	recordedAt    time.Time
+}
+
+type aiAccountSubjectCycleTotals struct {
+	requests   int64
+	successes  int64
+	failures   int64
+	cost       float64
+	tokens     int64
+	firstEvent time.Time
+	lastEvent  time.Time
+}
+
+// RunAIAccountSubjectCycleRolloverRepairAtInit re-derives anchors that were held
+// on a period the upstream had already ended, and rebuilds the usage bucket of
+// the period they should have rolled into.
+//
+// Anchoring refused to leave a stored period before its own reset, to stop an
+// idle quota bucket's "a full window remaining" countdown from re-keying the
+// usage bucket on every probe. That also blocked the legitimate case: an upstream
+// may end a period early. Production had a Codex account whose code_week window
+// reported 41% spent against a reset on the 27th, then a full allowance against a
+// reset on the 31st — a real new period, four days before the stored one was due.
+// The anchor stayed on the old period, so the card kept showing the previous
+// week's start while the new week's requests were added to the previous week's
+// bucket: 12735 requests and $702 against a window the upstream said was 1% used.
+//
+// Anchoring now rolls on a metering probe, so no new anchor freezes. This repairs
+// the ones already on disk rather than leaving operators to wait out a window
+// whose totals stay wrong until it ends.
+func RunAIAccountSubjectCycleRolloverRepairAtInit() error {
+	return runAIAccountSubjectCycleRolloverRepairDB(getDB())
+}
+
+func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+
+	usageProjectionMu.Lock()
+	defer usageProjectionMu.Unlock()
+
+	ensureUsageProjectionMarkerTable(db)
+	if projectionMarkerValue(db, aiAccountSubjectCycleRolloverRepairMarker) == rollupMarkerDone {
+		return nil
+	}
+
+	cyclesBySubject, err := loadAIAccountSubjectWeeklyCyclesBySubject(db)
+	if err != nil {
+		return err
+	}
+	probes, err := loadLatestMeteredWeeklyQuotaProbes(db)
+	if err != nil {
+		return err
+	}
+
+	subjectIDs := make([]string, 0, len(cyclesBySubject))
+	for subjectID := range cyclesBySubject {
+		subjectIDs = append(subjectIDs, subjectID)
+	}
+	sort.Strings(subjectIDs)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin shared subject cycle rollover repair: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UTC()
+	repaired := 0
+	for _, subjectID := range subjectIDs {
+		cycles := cyclesBySubject[subjectID]
+		before, hadBefore := selectAIAccountSubjectWeeklyCycle(cycles)
+
+		changed := false
+		for i, cycle := range cycles {
+			probe, ok := probes[aiAccountSubjectQuotaProbeKey(subjectID, cycle.QuotaKey)]
+			if !ok {
+				continue
+			}
+			rolled, ok := aiAccountSubjectCycleRolloverFromProbe(cycle, probe)
+			if !ok {
+				continue
+			}
+			if err := writeAIAccountSubjectQuotaCycleAnchorTx(tx, rolled); err != nil {
+				return err
+			}
+			cycles[i] = rolled
+			changed = true
+		}
+		if !changed || !hadBefore {
+			continue
+		}
+		after, hadAfter := selectAIAccountSubjectWeeklyCycle(cycles)
+		if !hadAfter || !after.CycleStartAt.After(before.CycleStartAt) {
+			continue
+		}
+		moved, err := repairAIAccountSubjectCycleBucketsTx(tx, subjectID, before.CycleStartAt, after.CycleStartAt, now)
+		if err != nil {
+			return err
+		}
+		repaired++
+		log.WithFields(log.Fields{
+			"auth_subject_id": subjectID,
+			"from":            before.CycleStartAt.Format(time.RFC3339),
+			"to":              after.CycleStartAt.Format(time.RFC3339),
+			"moved_requests":  moved,
+		}).Info("usage: repaired a cycle anchor held on an ended period")
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO UPDATE SET
+			marker_value = excluded.marker_value,
+			updated_at = excluded.updated_at
+	`, aiAccountSubjectCycleRolloverRepairMarker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: mark shared subject cycle rollover repair: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit shared subject cycle rollover repair: %w", err)
+	}
+	if repaired > 0 {
+		// The projection keys its buckets off this cache; drop it so the next write
+		// re-reads the anchors this pass rolled.
+		resetAIAccountSubjectCycleCache()
+	}
+	return nil
+}
+
+func aiAccountSubjectQuotaProbeKey(subjectID, quotaKey string) string {
+	return subjectID + "\x00" + quotaKey
+}
+
+// loadLatestMeteredWeeklyQuotaProbes keeps only probes that reported consumption.
+// A window at a full allowance carries no evidence about where its period began,
+// which is exactly the countdown the anchor must not follow.
+func loadLatestMeteredWeeklyQuotaProbes(db *sql.DB) (map[string]meteredWeeklyQuotaProbe, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, quota_key, reset_at, window_seconds, recorded_at
+		FROM ai_account_subject_quota_points
+		WHERE window_seconds >= ? AND percent IS NOT NULL AND percent < 100
+		ORDER BY recorded_at ASC
+	`, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query metered weekly quota probes: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]meteredWeeklyQuotaProbe)
+	for rows.Next() {
+		var subjectID, quotaKey string
+		var reset, recorded storedTime
+		var windowSeconds int64
+		if err := rows.Scan(&subjectID, &quotaKey, &reset, &windowSeconds, &recorded); err != nil {
+			return nil, fmt.Errorf("usage: scan metered weekly quota probe: %w", err)
+		}
+		subjectID = strings.TrimSpace(subjectID)
+		quotaKey = strings.TrimSpace(quotaKey)
+		if subjectID == "" || quotaKey == "" || !reset.Valid || !recorded.Valid || windowSeconds <= 0 {
+			continue
+		}
+		// Ascending order means the last row written per key is the newest one.
+		out[aiAccountSubjectQuotaProbeKey(subjectID, quotaKey)] = meteredWeeklyQuotaProbe{
+			resetAt:       reset.Time.UTC(),
+			windowSeconds: windowSeconds,
+			recordedAt:    recorded.Time.UTC(),
+		}
+	}
+	return out, rows.Err()
+}
+
+// aiAccountSubjectCycleRolloverFromProbe applies the live anchoring rule to a
+// stored row, so the repair and the running server cannot disagree about which
+// period an account is in.
+func aiAccountSubjectCycleRolloverFromProbe(
+	stored AIAccountSubjectQuotaCycle,
+	probe meteredWeeklyQuotaProbe,
+) (AIAccountSubjectQuotaCycle, bool) {
+	if stored.CycleStartAt.IsZero() || probe.windowSeconds != stored.WindowSeconds {
+		return stored, false
+	}
+	incoming := stored
+	incoming.CycleStartAt = probe.resetAt.Add(-time.Duration(probe.windowSeconds) * time.Second)
+	incoming.ResetAt = probe.resetAt
+	incoming.LastVerifiedAt = probe.recordedAt
+	// Only ever forward: a probe older than the stored anchor must not rewind a
+	// period the server has already rolled into.
+	if !incoming.CycleStartAt.After(stored.CycleStartAt) {
+		return stored, false
+	}
+	if sameAIAccountSubjectCycle(incoming.CycleStartAt, stored.CycleStartAt, stored.WindowSeconds) {
+		return stored, false
+	}
+	if !aiAccountSubjectCycleRollover(incoming, stored.ResetAt, true) {
+		return stored, false
+	}
+	return incoming, true
+}
+
+func writeAIAccountSubjectQuotaCycleAnchorTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) error {
+	if _, err := tx.Exec(`
+		UPDATE ai_account_subject_quota_cycles
+		SET cycle_start_at = ?, reset_at = ?, last_verified_at = ?
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, cycle.CycleStartAt.UTC().Format(time.RFC3339Nano),
+		cycle.ResetAt.UTC().Format(time.RFC3339Nano),
+		cycle.LastVerifiedAt.UTC().Format(time.RFC3339Nano),
+		cycle.AuthSubjectID, cycle.QuotaKey); err != nil {
+		return fmt.Errorf("usage: roll stored shared quota cycle: %w", err)
+	}
+	return nil
+}
+
+// repairAIAccountSubjectCycleBucketsTx moves the new period's usage out of the
+// bucket the frozen anchor kept it in.
+//
+// The request log is the only record with the per-request timestamps needed to
+// split them, so the new period is recomputed from it and the same totals are
+// taken back off the previous bucket. Whatever the log no longer covers stays
+// where it is: totals move between buckets but are never invented or lost.
+func repairAIAccountSubjectCycleBucketsTx(
+	tx *sql.Tx,
+	subjectID string,
+	previousStart, newStart, now time.Time,
+) (int64, error) {
+	totals, err := sumAIAccountSubjectRequestLogsTx(tx, subjectID, newStart, now)
+	if err != nil {
+		return 0, err
+	}
+	if totals.requests == 0 {
+		return 0, nil
+	}
+	if err := writeAIAccountSubjectCycleBucketTx(tx, subjectID, newStart, totals); err != nil {
+		return 0, err
+	}
+	if err := subtractAIAccountSubjectCycleBucketTx(tx, subjectID, previousStart, totals); err != nil {
+		return 0, err
+	}
+	return totals.requests, nil
+}
+
+func sumAIAccountSubjectRequestLogsTx(
+	tx *sql.Tx,
+	subjectID string,
+	from, to time.Time,
+) (aiAccountSubjectCycleTotals, error) {
+	var totals aiAccountSubjectCycleTotals
+	var cost sql.NullFloat64
+	var tokens sql.NullInt64
+	var successes, failures sql.NullInt64
+	var first, last storedTime
+	err := tx.QueryRow(`
+		SELECT COUNT(*),
+			SUM(CASE WHEN failed = 0 THEN 1 ELSE 0 END),
+			SUM(CASE WHEN failed = 0 THEN 0 ELSE 1 END),
+			SUM(cost), SUM(total_tokens), MIN(timestamp), MAX(timestamp)
+		FROM request_logs
+		WHERE auth_subject_id = ? AND timestamp >= ? AND timestamp <= ?
+	`, subjectID, from.UTC().Format(time.RFC3339Nano), to.UTC().Format(time.RFC3339Nano)).
+		Scan(&totals.requests, &successes, &failures, &cost, &tokens, &first, &last)
+	if err != nil {
+		return totals, fmt.Errorf("usage: sum shared subject cycle request logs: %w", err)
+	}
+	totals.successes = successes.Int64
+	totals.failures = failures.Int64
+	totals.cost = cost.Float64
+	totals.tokens = tokens.Int64
+	if first.Valid {
+		totals.firstEvent = first.Time.UTC()
+	}
+	if last.Valid {
+		totals.lastEvent = last.Time.UTC()
+	}
+	return totals, nil
+}
+
+func writeAIAccountSubjectCycleBucketTx(
+	tx *sql.Tx,
+	subjectID string,
+	start time.Time,
+	totals aiAccountSubjectCycleTotals,
+) error {
+	firstEvent := totals.firstEvent
+	if firstEvent.IsZero() {
+		firstEvent = start
+	}
+	updatedAt := totals.lastEvent
+	if updatedAt.IsZero() {
+		updatedAt = start
+	}
+	// Overwrite rather than accumulate: the request log is authoritative for this
+	// period, so a rerun that lands on an existing bucket must not double it.
+	if _, err := tx.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			request_count = excluded.request_count,
+			success_count = excluded.success_count,
+			failure_count = excluded.failure_count,
+			cost_total = excluded.cost_total,
+			total_tokens = excluded.total_tokens,
+			first_event_at = excluded.first_event_at,
+			updated_at = excluded.updated_at
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(start),
+		totals.requests, totals.successes, totals.failures, totals.cost, totals.tokens,
+		firstEvent.Format(time.RFC3339Nano), updatedAt.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: write repaired cycle bucket: %w", err)
+	}
+	return nil
+}
+
+// subtractAIAccountSubjectCycleBucketTx clamps in Go rather than in SQL: the
+// greatest-of-two spelling differs between the SQLite and Postgres backends this
+// store runs on.
+func subtractAIAccountSubjectCycleBucketTx(
+	tx *sql.Tx,
+	subjectID string,
+	start time.Time,
+	totals aiAccountSubjectCycleTotals,
+) error {
+	key := formatAIAccountSubjectCycleBucketStart(start)
+	var requests, successes, failures, tokens int64
+	var cost float64
+	err := tx.QueryRow(`
+		SELECT request_count, success_count, failure_count, cost_total, total_tokens
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, subjectID, key).Scan(&requests, &successes, &failures, &cost, &tokens)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("usage: load previous cycle bucket for repair: %w", err)
+	}
+	if _, err := tx.Exec(`
+		UPDATE ai_account_subject_usage_buckets
+		SET request_count = ?, success_count = ?, failure_count = ?, cost_total = ?, total_tokens = ?
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, clampNonNegativeInt64(requests-totals.requests),
+		clampNonNegativeInt64(successes-totals.successes),
+		clampNonNegativeInt64(failures-totals.failures),
+		clampNonNegativeFloat64(cost-totals.cost),
+		clampNonNegativeInt64(tokens-totals.tokens),
+		subjectID, key); err != nil {
+		return fmt.Errorf("usage: subtract repaired usage from previous cycle bucket: %w", err)
+	}
+	return nil
+}
+
+func clampNonNegativeInt64(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func clampNonNegativeFloat64(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}

--- a/internal/usage/ai_account_subject_cycle_rollover_repair.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_repair.go
@@ -200,6 +200,8 @@ func aiAccountSubjectCycleRolloverFromProbe(
 	incoming := stored
 	incoming.CycleStartAt = probe.resetAt.Add(-time.Duration(probe.windowSeconds) * time.Second)
 	incoming.ResetAt = probe.resetAt
+	// The rule reads LastVerifiedAt as "when this observation was made", so judge
+	// with the probe's own timestamp.
 	incoming.LastVerifiedAt = probe.recordedAt
 	// Only ever forward: a probe older than the stored anchor must not rewind a
 	// period the server has already rolled into.
@@ -211,6 +213,11 @@ func aiAccountSubjectCycleRolloverFromProbe(
 	}
 	if !aiAccountSubjectCycleRollover(incoming, stored.ResetAt, true) {
 		return stored, false
+	}
+	// The metering probe a period is derived from can be older than the last probe
+	// of any kind, and the stored verification time must not travel backwards.
+	if stored.LastVerifiedAt.After(incoming.LastVerifiedAt) {
+		incoming.LastVerifiedAt = stored.LastVerifiedAt
 	}
 	return incoming, true
 }

--- a/internal/usage/ai_account_subject_cycle_rollover_test.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_test.go
@@ -1,0 +1,287 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+const codexWeeklyQuotaKey = "code_week"
+
+func readCycleAnchor(t *testing.T, subjectID, quotaKey string) (time.Time, time.Time) {
+	t.Helper()
+	var start, reset storedTime
+	if err := getDB().QueryRow(`
+		SELECT cycle_start_at, reset_at FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, subjectID, quotaKey).Scan(&start, &reset); err != nil {
+		t.Fatal(err)
+	}
+	if !start.Valid || !reset.Valid {
+		t.Fatalf("anchor for %s/%s is not stored", subjectID, quotaKey)
+	}
+	return start.Time.UTC(), reset.Time.UTC()
+}
+
+func readCycleBucket(t *testing.T, subjectID string, start time.Time) (int64, float64, int64) {
+	t.Helper()
+	var requests, tokens int64
+	var cost float64
+	err := getDB().QueryRow(`
+		SELECT request_count, cost_total, total_tokens
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(start)).Scan(&requests, &cost, &tokens)
+	if err != nil {
+		t.Fatalf("read cycle bucket at %v: %v", start, err)
+	}
+	return requests, cost, tokens
+}
+
+// Production, 2026-08-24: a Codex account reported 41% of code_week spent against
+// a reset on the 27th, then hours later a full allowance against a reset on the
+// 31st — the upstream ended the period four days before it was due. Refusing to
+// leave a period until its own reset froze the anchor on the previous week: the
+// card kept showing the old start while the new week's requests kept landing in
+// the old week's bucket, so 12735 requests and $702 were reported for a window
+// the same probe said was 1% used.
+func TestWeeklyCycleRollsWhenUpstreamEndsPeriodEarly(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_codex_early_reset"
+
+	firstProbe := time.Now().UTC().Truncate(time.Second).Add(-8 * time.Hour)
+	firstReset := firstProbe.Add(76 * time.Hour)
+	spent := 59.0
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: firstProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &spent, ResetAt: &firstReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The allowance came back before the stored reset, against a reset a week past
+	// it, and the account has already drawn on the new period.
+	secondProbe := firstProbe.Add(7 * time.Hour)
+	secondReset := firstReset.Add(4*24*time.Hour - 45*time.Minute)
+	fresh := 99.0
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: secondProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &fresh, ResetAt: &secondReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	wantStart := secondReset.Add(-7 * 24 * time.Hour)
+	if !start.Equal(wantStart) || !reset.Equal(secondReset) {
+		t.Fatalf("anchor = %v..%v, want %v..%v (an early upstream reset is a real new period)",
+			start, reset, wantStart, secondReset)
+	}
+
+	// The period the card reports and the period the projection writes into must
+	// be the same one, or the new week's usage is added to the old week's total.
+	projectSubjectRequest(t, subjectID, secondProbe.Add(time.Minute), 10)
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 1 || got.CycleTotalTokens != 10 {
+		t.Fatalf("cycle summary = %+v, want the new period's single request", got)
+	}
+}
+
+// The guard that made the freeze possible has to keep working: a window the
+// account never touched answers every probe with a full window remaining, and
+// following that countdown re-keys the usage bucket on each pass.
+func TestUntouchedWeeklyWindowStillDoesNotRollOnCountdown(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_codex_untouched"
+
+	firstProbe := time.Now().UTC().Truncate(time.Second).Add(-9 * time.Hour)
+	untouched := 100.0
+	first := firstProbe.Add(7 * 24 * time.Hour)
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: firstProbe, Provider: "codex", QuotaKey: "additional:extra:week", QuotaLabel: "Extra",
+		Percent: &untouched, ResetAt: &first, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 3; i++ {
+		at := firstProbe.Add(time.Duration(i) * 2 * time.Hour)
+		sliding := at.Add(7 * 24 * time.Hour)
+		if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+			RecordedAt: at, Provider: "codex", QuotaKey: "additional:extra:week", QuotaLabel: "Extra",
+			Percent: &untouched, ResetAt: &sliding, WindowSeconds: weeklyWindowSeconds,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	start, _ := readCycleAnchor(t, subjectID, "additional:extra:week")
+	if !start.Equal(firstProbe) {
+		t.Fatalf("anchor = %v, want it pinned to the first probe %v", start, firstProbe)
+	}
+}
+
+// A metering probe whose reset is still a whole window away from the probe itself
+// is that same countdown wearing a percentage, so it must not move the anchor
+// either. Once the clock moves on and the reset does not, it is recognised.
+func TestMeteringProbeWithFullWindowCountdownDefersRollover(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_countdown_metering"
+
+	firstProbe := time.Now().UTC().Truncate(time.Second).Add(-30 * time.Hour)
+	firstReset := firstProbe.Add(100 * time.Hour)
+	percent := 80.0
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: firstProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &percent, ResetAt: &firstReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	countdownProbe := firstProbe.Add(10 * time.Hour)
+	countdownReset := countdownProbe.Add(7 * 24 * time.Hour)
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: countdownProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &percent, ResetAt: &countdownReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if start, _ := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey); !start.Equal(firstProbe.Add(100*time.Hour - 7*24*time.Hour)) {
+		t.Fatalf("anchor = %v, want the stored period kept while the reset only counts down", start)
+	}
+
+	// Same reset, later probe: the period is now visibly older than the probe.
+	settledProbe := countdownProbe.Add(3 * time.Hour)
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: settledProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &percent, ResetAt: &countdownReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	start, _ := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	if !start.Equal(countdownReset.Add(-7 * 24 * time.Hour)) {
+		t.Fatalf("anchor = %v, want it rolled once the reset held still across probes", start)
+	}
+}
+
+// Probes stop for disabled, rate limited or unreachable accounts. The projection
+// keys a request's bucket to the period the request happened in, so a reader that
+// reports the stored period verbatim answers with the previous period's start and
+// totals for as long as the outage lasts.
+func TestExpiredAnchorRollsForReadersWithoutAProbe(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_probe_outage"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	staleStart := now.Add(-9 * 24 * time.Hour)
+	staleReset := staleStart.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'codex', ?, ?, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey,
+		staleStart.Format(time.RFC3339Nano), staleReset.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, staleReset.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	starts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !starts[subjectID].UTC().Equal(staleReset) {
+		t.Fatalf("reader cycle start = %v, want the period after the expired one (%v)",
+			starts[subjectID].UTC(), staleReset)
+	}
+
+	// The writer must agree, so the request lands in the bucket the reader totals.
+	projectSubjectRequest(t, subjectID, now, 25)
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 1 || got.CycleTotalTokens != 25 {
+		t.Fatalf("cycle summary = %+v, want the rolled period's single request", got)
+	}
+}
+
+// Anchors already frozen on disk cannot wait for the stored period to expire:
+// their totals stay wrong for the rest of a week that upstream has already ended.
+func TestCycleRolloverRepairMovesUsageToTheLivePeriod(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_repair_frozen"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	frozenStart := now.Add(-4 * 24 * time.Hour)
+	frozenReset := frozenStart.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'codex', ?, ?, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey,
+		frozenStart.Format(time.RFC3339Nano), frozenReset.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, now.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The probe history already shows the live period: metered, reset a week past
+	// the frozen one.
+	liveStart := now.Add(-90 * time.Minute)
+	liveReset := liveStart.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_points
+			(auth_subject_id, provider, quota_key, quota_label, percent, reset_at, window_seconds, recorded_at)
+		VALUES (?, 'codex', ?, 'Weekly', 99, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey, liveReset.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, now.Add(-30*time.Minute).Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two requests in the previous period, three in the live one — all five were
+	// counted into the frozen period's bucket.
+	events := []time.Time{
+		frozenStart.Add(time.Hour), frozenStart.Add(30 * time.Hour),
+		liveStart.Add(time.Minute), liveStart.Add(20 * time.Minute), liveStart.Add(80 * time.Minute),
+	}
+	for _, at := range events {
+		if _, err := getDB().Exec(`
+			INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, failed, cost, total_tokens)
+			VALUES ('default', ?, ?, 0, 2, 100)
+		`, at.Format(time.RFC3339Nano), subjectID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, 5, 5, 0, 10, 500, ?, ?)
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(frozenStart),
+		events[0].Format(time.RFC3339Nano), events[4].Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleRolloverRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	if !start.Equal(liveStart) || !reset.Equal(liveReset) {
+		t.Fatalf("anchor = %v..%v, want the live period %v..%v", start, reset, liveStart, liveReset)
+	}
+	if requests, cost, tokens := readCycleBucket(t, subjectID, liveStart); requests != 3 || cost != 6 || tokens != 300 {
+		t.Fatalf("live bucket = %d requests / %v cost / %d tokens, want 3 / 6 / 300", requests, cost, tokens)
+	}
+	// The usage moved rather than being duplicated: the previous period keeps only
+	// what actually happened in it.
+	if requests, cost, tokens := readCycleBucket(t, subjectID, frozenStart); requests != 2 || cost != 4 || tokens != 200 {
+		t.Fatalf("previous bucket = %d requests / %v cost / %d tokens, want 2 / 4 / 200", requests, cost, tokens)
+	}
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 3 || got.CycleTotalTokens != 300 {
+		t.Fatalf("cycle summary = %+v, want the live period's 3 requests / 300 tokens", got)
+	}
+
+	// Idempotent: the marker stops a second pass from moving the totals again.
+	if err := runAIAccountSubjectCycleRolloverRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	if requests, _, _ := readCycleBucket(t, subjectID, frozenStart); requests != 2 {
+		t.Fatalf("previous bucket after rerun = %d requests, want 2", requests)
+	}
+}

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -68,7 +68,7 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 			// Cache the anchored cycle, not the freshly derived one: the in-memory
 			// cache feeds the usage projection's bucket key, so seeding it with the
 			// jittered value would re-split the period the anchor just protected.
-			anchored, err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle)
+			anchored, err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle, aiAccountSubjectQuotaWindowMetering(point.Percent))
 			if err != nil {
 				return err
 			}
@@ -130,7 +130,7 @@ func nullableStoredTimeEqual(stored sql.NullString, value *time.Time) bool {
 // and split one weekly period into fragments. Within the drift tolerance the
 // stored anchor wins and only last_verified_at moves; a real rollover shifts the
 // start by a whole window and falls outside the tolerance, so it still rolls.
-func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, error) {
+func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, metering bool) (AIAccountSubjectQuotaCycle, error) {
 	var start, reset storedTime
 	var window int64
 	err := tx.QueryRow(`
@@ -152,7 +152,7 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 		storedReset = reset.Time.UTC()
 	}
 	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) &&
-		aiAccountSubjectCycleRollover(cycle, storedReset) {
+		aiAccountSubjectCycleRollover(cycle, storedReset, metering) {
 		return cycle, nil
 	}
 	cycle.CycleStartAt = start.Time.UTC()
@@ -175,10 +175,19 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 // usage bucket every few hours and scattered one week's requests across six of
 // them.
 //
-// A period may therefore only be replaced when the upstream shows the old one is
+// A period may therefore be replaced when the upstream shows the old one is
 // finished: the probe ran after it ended, the new period starts where it ended,
 // or the reset moved closer (credits reset, plan change).
-func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time) bool {
+//
+// It may also be replaced when the probe is metering. An upstream can end a
+// period early — production had a Codex account report 41% of code_week spent
+// against a reset four days out, then, hours later, a full allowance against a
+// reset a week past the old one. That is a real new period arriving before the
+// stored one was due, and holding the old anchor froze the card on the previous
+// week while its usage kept accruing into the previous week's bucket. A window
+// that reports consumption is one the upstream is actually counting, so its
+// reset is a real period edge rather than an idle bucket's countdown.
+func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time, metering bool) bool {
 	if storedReset.IsZero() {
 		return true
 	}
@@ -188,11 +197,43 @@ func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedRe
 	if sameAIAccountSubjectCycle(incoming.CycleStartAt, storedReset, incoming.WindowSeconds) {
 		return true
 	}
-	return incoming.ResetAt.UTC().Before(storedReset)
+	if incoming.ResetAt.UTC().Before(storedReset) {
+		return true
+	}
+	return metering && !aiAccountSubjectCycleFullWindowCountdown(incoming)
 }
 
-func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, error) {
-	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle)
+// aiAccountSubjectQuotaWindowMetering reports whether a probe shows the window
+// counting usage. Percent is the share remaining, so 100 (or an upstream that
+// reports no percentage at all) means nothing has been drawn from the period the
+// probe describes, and its reset carries no evidence about where that period began.
+func aiAccountSubjectQuotaWindowMetering(percent *float64) bool {
+	return percent != nil && *percent < 100
+}
+
+// aiAccountSubjectCycleFullWindowCountdown reports whether the probe's reset is
+// simply "one full window from this probe".
+//
+// A metering percentage alone would still admit an upstream that answers every
+// probe with a whole window remaining; the derived start would then track the
+// probe clock and re-key the usage bucket on each pass. A genuine period began
+// before the probe that observed it, so its derived start sits behind the probe
+// by however long the period has been running. The slack is small on purpose:
+// an idle bucket's countdown lands on the probe instant to the second, and a real
+// period caught within the slack of its own start is recognised on the next probe,
+// once the clock has moved on and the reset has not.
+func aiAccountSubjectCycleFullWindowCountdown(incoming AIAccountSubjectQuotaCycle) bool {
+	if incoming.LastVerifiedAt.IsZero() {
+		return false
+	}
+	drift := absDuration(incoming.CycleStartAt.UTC().Sub(incoming.LastVerifiedAt.UTC()))
+	return drift <= aiAccountSubjectFullWindowCountdownSlack
+}
+
+const aiAccountSubjectFullWindowCountdownSlack = 2 * time.Minute
+
+func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, metering bool) (AIAccountSubjectQuotaCycle, error) {
+	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle, metering)
 	if err != nil {
 		return cycle, err
 	}
@@ -331,9 +372,10 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string) (map[stri
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	now := time.Now().UTC()
 	for subjectID, cycles := range cyclesBySubject {
 		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
-			out[subjectID] = cycle.CycleStartAt
+			out[subjectID] = advanceAIAccountSubjectCycleTo(cycle, now).CycleStartAt
 		}
 	}
 	return out, nil

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -233,13 +233,42 @@ func aiAccountSubjectCycleAt(tx *sql.Tx, subjectID string, at time.Time) (AIAcco
 	if !ok {
 		return AIAccountSubjectQuotaCycle{}, false, nil
 	}
-	at = at.UTC()
-	window := time.Duration(cycle.WindowSeconds) * time.Second
-	for !at.Before(cycle.ResetAt) {
-		cycle.CycleStartAt = cycle.ResetAt
-		cycle.ResetAt = cycle.ResetAt.Add(window)
+	cycle = advanceAIAccountSubjectCycleTo(cycle, at)
+	return cycle, !at.UTC().Before(cycle.CycleStartAt), nil
+}
+
+// advanceAIAccountSubjectCycleTo rolls a stored anchor forward to the period that
+// contains at.
+//
+// The stored anchor only moves when a probe lands, and probes stop whenever the
+// account is disabled, rate limited or simply unreachable. Every reader must
+// therefore apply the same elapsed-time roll the projection applies, or the two
+// sides disagree the moment a reset passes unprobed: the writer keys the bucket
+// to the period the request happened in while the card still reports the previous
+// period's start — and, matching buckets against that stale start, the previous
+// period's totals.
+func advanceAIAccountSubjectCycleTo(cycle AIAccountSubjectQuotaCycle, at time.Time) AIAccountSubjectQuotaCycle {
+	cycle.CycleStartAt, cycle.ResetAt = advanceQuotaCyclePeriod(cycle.CycleStartAt, cycle.ResetAt, cycle.WindowSeconds, at)
+	return cycle
+}
+
+// advanceQuotaCyclePeriod is the shared roll used by both cycle tables, so the
+// tenant-scoped reader cannot answer with a different period than the shared one.
+func advanceQuotaCyclePeriod(start, reset time.Time, windowSeconds int64, at time.Time) (time.Time, time.Time) {
+	if windowSeconds <= 0 || reset.IsZero() {
+		return start, reset
 	}
-	return cycle, !at.Before(cycle.CycleStartAt), nil
+	at = at.UTC()
+	reset = reset.UTC()
+	if at.Before(reset) {
+		return start, reset
+	}
+	// Jump to the containing period rather than stepping one window at a time: an
+	// anchor left behind by a long probe outage can be many windows old.
+	window := time.Duration(windowSeconds) * time.Second
+	skipped := at.Sub(reset) / window
+	start = reset.Add(skipped * window)
+	return start, start.Add(window)
 }
 
 func formatAIAccountSubjectCycleBucketStart(value time.Time) string {

--- a/internal/usage/auth_subject_quota_store.go
+++ b/internal/usage/auth_subject_quota_store.go
@@ -464,6 +464,11 @@ func QueryLatestWeeklyQuotaCycleByAuthSubjectForTenant(tenantID, subjectID strin
 	if cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() || cycle.WindowSeconds <= 0 {
 		return nil, nil
 	}
+	// Roll an anchor whose period already ended, exactly as the shared reader and
+	// the projection do. Probes stop for disabled or unreachable accounts, and a
+	// frozen anchor would report the previous period's window as the live one.
+	cycle.CycleStartAt, cycle.ResetAt = advanceQuotaCyclePeriod(
+		cycle.CycleStartAt, cycle.ResetAt, cycle.WindowSeconds, time.Now())
 	return &cycle, nil
 }
 


### PR DESCRIPTION
## 问题

面板上账号的「周期开始」停在上一个周期，额度明明已经刷新却不更新。生产实证（`authsub_a0436c51c205`，Codex）：

| 来源 | 数据 |
|------|------|
| 探测点 8/23 16:26 | `code_week` 剩余 59%，`reset_at` = 8/27 03:29:46 |
| 探测点 8/24 00:56 起 | `code_week` 剩余 100→99%，`reset_at` = **8/31 00:45:39** |
| 周期锚点表 | `cycle_start_at` 仍是 **8/20 03:29:46**、`reset_at` 仍是 8/27，只有 `last_verified_at` 刷到了 8/24 01:44 |

上游在原定 reset 之前四天就结束了周期并开了新的，而锚点没跟着滚。后果是：

- 卡片/详情的「周期开始」一直显示上个周期（截图里的 `2026/8/20 11:29:46`）
- 新周期的请求继续累加进上周期的桶：8/20 那个桶涨到 12735 次 / $702 / 15.3 亿 token
- 「周额度已消耗」取自最新探测（1%），与桶不同源，于是「预测周窗口额度」算出 `$68601` 这种离谱值

## 根因

#928 引入 `aiAccountSubjectCycleRollover`，用来挡住「未计量的配额桶把 `reset_at` 报成 `探测时刻 + 整窗`」导致的周期碎片化。它只在这几种情况下允许换周期：探测发生在旧 reset 之后、新起点接上旧终点、reset 提前。

「上游提前结束周期」三条都不满足（探测 8/24 早于旧 reset 8/27，新起点 8/24 与旧终点 8/27 差三天，新 reset 8/31 更晚），因此被判为「同一周期的抖动」，`anchorAIAccountSubjectQuotaCycleTx` 保留旧的 `cycle_start_at` / `reset_at`，只更新 `last_verified_at` —— 与线上观察到的那一行完全一致。

## 修复

把判据从「reset 往哪个方向动」换成「这个窗口有没有在计量」（`Percent` 各 provider 统一为剩余百分比，已逐个核对 claude/codex/xai/antigravity/gemini/kimi）：

- **剩余 100%（或不报百分比）的窗口**：reset 只是倒计时占位，仍然不得改写锚点 —— #928 防的碎片化场景原样保留，`TestAntigravitySlidingWeeklyResetKeepsOnePeriod` 继续通过
- **有消耗的窗口**：reset 是上游给出的真实周期边界，只要与存量不是同一周期就滚动
- **额外排除** `reset ≈ 本次探测 + 整窗` 的情况（2 分钟 slack），避免带百分比的倒计时拖着锚点走；这种情况下一次探测（时钟前进而 reset 不变）就能识别，不会长期卡住

顺带修掉同一族的两处缺陷：

1. **读端不滚动**：`QueryLatestAIAccountSubjectWeeklyCyclesBatch` 和 tenant 版此前直接返回存量 `cycle_start`，而投影写端 `aiAccountSubjectCycleAt` 会按请求时间自行滚动。探测中断（账号停用 / 限流 / 不可达）时两端错位，卡片报上个周期的起点和总量。现在两端共用 `advanceQuotaCyclePeriod`。
2. **存量脏数据**：新增一次性迁移 `RunAIAccountSubjectCycleRolloverRepairAtInit`，按同一判据纠正已冻结在磁盘上的锚点，并用 `request_logs` 把新周期的用量从上个周期的桶里**搬**回来（写新桶 + 从旧桶等量扣减，总量守恒，不凭空增删）。带 marker，幂等。

对本次那个账号，迁移后预期：新周期桶 592 次 / $26.39 / 5790 万 token（已用生产日志预演核对），旧桶相应减去同样的量。

## 验证

- 新增 5 个测试；把判据临时退回旧实现后，其中 4 个如实失败，失败值与生产现象一致（锚点停在旧周期）
- `TestAntigravitySlidingWeeklyResetKeepsOnePeriod` / `TestWeeklyCycleRollsAfterStoredPeriodEnds` / `TestCycleRealign*` 全部保持通过
- 本地 `./scripts/ci-pr.sh` 全绿（结构检查、gofmt、密钥扫描、`go vet`、`go test ./...`、golangci-lint v1.64.5、build）

## 未纳入本次范围

`upsertAuthSubjectQuotaCycleTx`（tenant 维度的 `auth_subject_quota_cycles`）没有 anchor，每次探测直接覆盖，因此会跟随倒计时漂移。它与本次「anchor 过强」是相反方向的问题，且该路径的用量从明细实时计算、不用桶，不会碎片化；单独跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
