### PR TITLE
fix(codex): send the official CLI identity and default convergence to device

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -303,7 +303,7 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 	if payload.Preset.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64)" {
 		t.Fatalf("preset user-agent = %q", payload.Preset.UserAgent)
 	}
-	if payload.BuiltinDefault.Originator != "codex-tui" {
+	if payload.BuiltinDefault.Originator != config.DefaultCodexFingerprintOriginator {
 		t.Fatalf("builtin default originator = %q", payload.BuiltinDefault.Originator)
 	}
 	if payload.Learned.ObservedHeaders["Version"] != "0.125.0" {

--- a/internal/config/codex_convergence_config_test.go
+++ b/internal/config/codex_convergence_config_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestNormalizeCodexIdentityFingerprintConvergenceDefaults(t *testing.T) {
 	got := NormalizeCodexIdentityFingerprint(CodexIdentityFingerprintConfig{})
-	if got.ConvergenceMode != CodexFingerprintConvergenceSession {
-		t.Fatalf("convergence mode = %q, want the session default", got.ConvergenceMode)
+	if got.ConvergenceMode != CodexFingerprintConvergenceDevice {
+		t.Fatalf("convergence mode = %q, want the device default", got.ConvergenceMode)
 	}
 
 	got = NormalizeCodexIdentityFingerprint(CodexIdentityFingerprintConfig{ConvergenceMode: "nonsense"})
-	if got.ConvergenceMode != CodexFingerprintConvergenceSession {
+	if got.ConvergenceMode != CodexFingerprintConvergenceDevice {
 		t.Fatalf("convergence mode = %q, want an invalid value to fall back", got.ConvergenceMode)
 	}
 

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -9,11 +9,15 @@ import (
 )
 
 const (
-	// Defaults are intentionally aligned with upstream CLIProxyAPI's codex-tui behavior.
-	// Update these when upstream codex-tui identity changes.
-	DefaultCodexFingerprintUserAgent     = "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
+	// Defaults follow the identity the current official Codex CLI sends.
+	// `codex-tui` is a legacy originator: upstream A/B probes (CLIProxyAPI #4679)
+	// showed gpt-5.6-sol requests carrying it get load-shed with
+	// `server_is_overloaded`, while `codex_cli_rs` succeeds from the same account.
+	// Spoofing only the User-Agent does not help, so both values move together.
+	// Update the version when the official CLI releases a new stable tag.
+	DefaultCodexFingerprintUserAgent     = "codex_cli_rs/0.149.1 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9"
 	DefaultCodexFingerprintVersion       = ""
-	DefaultCodexFingerprintOriginator    = "codex-tui"
+	DefaultCodexFingerprintOriginator    = "codex_cli_rs"
 	DefaultCodexFingerprintWebsocketBeta = "responses_websockets=2026-02-06"
 	DefaultCodexFingerprintBetaFeatures  = ""
 	DefaultCodexFingerprintSessionMode   = "per-request"
@@ -28,10 +32,18 @@ const (
 	CodexFingerprintConvergenceSession = "session"
 	CodexFingerprintConvergenceFull    = "full"
 
-	// DefaultCodexFingerprintConvergenceMode converges installation and session
-	// while keeping one thread per real client session, which is the shape a
-	// single user spawning sub-agents produces upstream.
-	DefaultCodexFingerprintConvergenceMode = CodexFingerprintConvergenceSession
+	// DefaultCodexFingerprintConvergenceMode converges only the installation and
+	// leaves the client's own session, thread and window state alone.
+	//
+	// Device is the strongest mode that still matches the official client: a real
+	// Codex install legitimately hosts many sessions, so one installation with N
+	// client sessions is a shape upstream already sees. Session and full instead
+	// fold unrelated users into one session id while prompt_cache_key keeps the
+	// per-conversation value, and derive thread/window ids that disagree with the
+	// official state machine (root threads use session_id == thread_id, both
+	// UUIDv7; window ids are their own UUIDv7, not thread_id+":0"). That triple
+	// is a combination no official client emits.
+	DefaultCodexFingerprintConvergenceMode = CodexFingerprintConvergenceDevice
 
 	DefaultClaudeFingerprintCLIVersion              = "2.1.161"
 	DefaultClaudeFingerprintEntrypoint              = "cli"

--- a/internal/config/identity_fingerprint_test.go
+++ b/internal/config/identity_fingerprint_test.go
@@ -2,8 +2,28 @@ package config
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
+
+// assertOfficialCodexCLIIdentity pins the outbound identity to the official
+// Codex CLI. The legacy `codex-tui` originator gets requests load-shed upstream
+// (CLIProxyAPI #4679), and spoofing only the User-Agent does not avoid it, so
+// both fields are checked together. The version is deliberately not pinned so
+// routine CLI bumps do not break the test.
+func assertOfficialCodexCLIIdentity(t *testing.T, got CodexIdentityFingerprintConfig) {
+	t.Helper()
+
+	if got.Originator != "codex_cli_rs" {
+		t.Fatalf("Originator = %q, want codex_cli_rs", got.Originator)
+	}
+	if !strings.HasPrefix(got.UserAgent, "codex_cli_rs/") {
+		t.Fatalf("UserAgent = %q, want a codex_cli_rs/<version> user agent", got.UserAgent)
+	}
+	if strings.Contains(got.UserAgent, "codex-tui") {
+		t.Fatalf("UserAgent = %q, must not carry the legacy codex-tui marker", got.UserAgent)
+	}
+}
 
 func TestDefaultCodexIdentityFingerprintUsesCurrentVersionAndDynamicSessions(t *testing.T) {
 	t.Parallel()
@@ -14,11 +34,9 @@ func TestDefaultCodexIdentityFingerprintUsesCurrentVersionAndDynamicSessions(t *
 		t.Fatalf("Enabled = false, want true by default")
 	}
 	if got.Version != "" {
-		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
+		t.Fatalf("Version = %q, want empty (the CLI does not require Version)", got.Version)
 	}
-	if got.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)" {
-		t.Fatalf("UserAgent = %q, want codex-tui user agent", got.UserAgent)
-	}
+	assertOfficialCodexCLIIdentity(t, got)
 	if got.SessionMode != "per-request" {
 		t.Fatalf("SessionMode = %q, want per-request", got.SessionMode)
 	}
@@ -33,11 +51,9 @@ func TestNormalizeCodexIdentityFingerprintAppliesCurrentDefaults(t *testing.T) {
 		t.Fatalf("Enabled = false, want true by default")
 	}
 	if got.Version != "" {
-		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
+		t.Fatalf("Version = %q, want empty (the CLI does not require Version)", got.Version)
 	}
-	if got.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)" {
-		t.Fatalf("UserAgent = %q, want codex-tui user agent", got.UserAgent)
-	}
+	assertOfficialCodexCLIIdentity(t, got)
 	if got.SessionMode != "per-request" {
 		t.Fatalf("SessionMode = %q, want per-request", got.SessionMode)
 	}

--- a/internal/identityfingerprint/profiles_test.go
+++ b/internal/identityfingerprint/profiles_test.go
@@ -156,7 +156,9 @@ func TestResolveCodexSafeFallbackRejectsMixedAccountPreset(t *testing.T) {
 	if got := effective.Fields[FieldUserAgent].Source; got != FieldSourceBuiltinDefault {
 		t.Fatalf("safe fallback user-agent source = %q", got)
 	}
-	if effective.ProfileKey != "codex-tui" || effective.ProfileFamily != ProfileFamilyCLI {
+	// The fallback profile key is derived from the builtin originator, so it
+	// tracks that constant rather than a pinned product name.
+	if effective.ProfileKey != config.DefaultCodexFingerprintOriginator || effective.ProfileFamily != ProfileFamilyCLI {
 		t.Fatalf("safe fallback metadata = %#v", effective)
 	}
 }

--- a/internal/management/aiaccountstatus/probe_codex.go
+++ b/internal/management/aiaccountstatus/probe_codex.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	codexauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -24,7 +25,7 @@ const (
 func probeCodex(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) (ProbeResult, error) {
 	body, err := doAuthGET(ctx, svc, auth, codexUsageURL, map[string]string{
 		"Content-Type": "application/json",
-		"User-Agent":   "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+		"User-Agent":   config.DefaultCodexFingerprintUserAgent,
 	}, func(req *http.Request) {
 		if accountID := codexAccountID(auth); accountID != "" {
 			req.Header.Set("Chatgpt-Account-Id", accountID)
@@ -47,7 +48,7 @@ func probeCodex(ctx context.Context, svc *managementapitools.Service, auth *core
 		if v > 0 {
 			if expBody, expErr := doAuthGET(ctx, svc, auth, codexResetCreditsURL, map[string]string{
 				"Content-Type": "application/json",
-				"User-Agent":   "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+				"User-Agent":   config.DefaultCodexFingerprintUserAgent,
 			}, func(req *http.Request) {
 				if accountID := codexAccountID(auth); accountID != "" {
 					req.Header.Set("Chatgpt-Account-Id", accountID)

--- a/internal/runtime/executor/codex_auth.go
+++ b/internal/runtime/executor/codex_auth.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	// Keep defaults aligned with upstream CLIProxyAPI (codex-tui).
-	codexUserAgent  = "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
-	codexOriginator = "codex-tui"
+	// Fallback identity for requests that bypass the fingerprint resolver. Kept in
+	// sync with config.DefaultCodexFingerprint* so both paths present the same
+	// official Codex CLI identity; see that block for why `codex-tui` was dropped.
+	codexUserAgent  = config.DefaultCodexFingerprintUserAgent
+	codexOriginator = config.DefaultCodexFingerprintOriginator
 )
 
 func applyCodexHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.Auth, token string, stream bool) {

--- a/internal/runtime/executor/codex_fingerprint_convergence_test.go
+++ b/internal/runtime/executor/codex_fingerprint_convergence_test.go
@@ -354,14 +354,14 @@ func TestDeviceOnlyLeavesSessionUntouched(t *testing.T) {
 	}
 }
 
-func TestCodexConvergenceDefaultsToSessionMode(t *testing.T) {
+func TestCodexConvergenceDefaultsToDeviceMode(t *testing.T) {
 	cfg := codexConvergenceTestConfig("")
-	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-default")); got != config.CodexFingerprintConvergenceSession {
-		t.Fatalf("convergence mode = %q, want the session default", got)
+	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-default")); got != config.CodexFingerprintConvergenceDevice {
+		t.Fatalf("convergence mode = %q, want the device default", got)
 	}
 
 	cfg = codexConvergenceTestConfig("nonsense")
-	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-bogus")); got != config.CodexFingerprintConvergenceSession {
+	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-bogus")); got != config.CodexFingerprintConvergenceDevice {
 		t.Fatalf("convergence mode = %q, want an unrecognised value to fall back to the default", got)
 	}
 }


### PR DESCRIPTION
## 背景

Codex 账号周额度从 2600+ 掉到 1000 出头。调研发现这是跨中转项目的共性现象（sub2api [#6134](https://github.com/Wei-Shaw/sub2api/issues/6134) 今天报告了逐字一致的数字），并非本仓库独有。这个 PR 不声称能解决额度问题，只修掉两处**代码级可确认**的出站身份缺陷。

## 修改范围

影响目录：`CliRelay/`（不波及 `codeProxy/`）。

**1. 出站身份从 `codex-tui` 换成官方 `codex_cli_rs`**

上游 CLIProxyAPI [#4679](https://github.com/router-for-me/CLIProxyAPI/issues/4679) 的 A/B 实测：同一账号下 `Originator: codex_cli_rs` 4/4 成功，`codex-tui` 立即 `server_is_overloaded`，且只伪装 UA 保留 codex-tui 仍然失败。维护者确认 OpenAI 在高负载下开始优先处理自家客户端流量，上游已于 v7.2.110 改默认，本 fork 停留在改之前。

`codex_auth.go` 的 fallback 常量改为直接引用 `config.DefaultCodexFingerprint*`，消除两套值各自漂移的可能。WebSocket 路径与 models manifest 探测共用这两个常量，顺带修好了 manifest 探测原先「UA 写 `codex_cli_rs`、Originator 写 `codex-tui`」的自相矛盾组合。

**2. 默认收敛档位 `session` → `device`**

session 模式下发出的是官方客户端不可能产生的组合：

| 字段 | 改前（session） | 官方 Codex |
| --- | --- | --- |
| `session_id` / `thread_id` | 两个不同的 UUIDv4 派生值 | 根线程二者相等，且是 UUIDv7 |
| `prompt_cache_key` | 第三个值（`cacheHelper` 的 `cache.ID`） | 默认等于 `session_id` |
| `x-codex-window-id` | `thread_id + ":0"` | 独立 UUIDv7，随 compaction 轮换 |

`Session_id` 在 `codex_executor.go` 被设成 `cache.ID`，随后被 `applyCodexConvergenceHeaders` 覆盖成 `ids.sessionID`，而 body 的 `prompt_cache_key` 仍是 `cache.ID`——三个值互不相同。device 模式提前返回、不覆盖 `Session_id`，三者恢复一致。

依据 sub2api [#5727](https://github.com/Wei-Shaw/sub2api/issues/5727) 对 openai/codex 源码的逐行审计，其结论是 session/full 无法靠无状态字符串改写做对，建议统一到 device。

## 测试改动说明

只更新了断言**内建默认值**的两处（`BuiltinDefault.Originator`、安全回退的 `ProfileKey`），改为跟踪常量而非硬编码。把 `codex-tui` 作为**入站客户端**喂进去的固件全部保留——那仍是代理必须正确处理的合法客户端标识。

`identity_fingerprint_test.go` 的默认值断言改为守不变量（Originator 必须是 `codex_cli_rs`、UA 必须以 `codex_cli_rs/` 开头且不含 `codex-tui`），版本号不锁，例行升级不会碎测试。

## 已执行的校验

- `./scripts/ci-pr.sh`（完整门禁，绿）

## 上线注意

- 改的是**默认值**。线上 `config.yaml` 若显式写了 `identity-fingerprint.codex.convergence-mode`，第 2 项不生效，需单独核对。
- 合并后上游会看到一次身份形态突变：客户端产品名切换，且该账号的 session 数从 1 个变成 N 个（各下游用户的真实 session）。`X-Codex-Installation-Id` 的派生 scope 未动，设备身份连续。
- 效果需实测。建议盯缓存命中率（`cached_input_tokens / input_tokens`，device 下客户端各自的 cache key 得以保留，应上升）与 `server_is_overloaded` 频率，而非只看周额度数字。