### PR TITLE
fix(codex): project one coherent identity graph on Codex requests

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -231,17 +231,20 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 		Provider:      identityfingerprint.ProviderCodex,
 		AccountKey:    accountKey,
 		AuthSubjectID: accountKey,
-		ClientProduct: "codex-tui",
+		// The learned sample is the current CLI on purpose: a legacy codex-tui
+		// profile is refused for outbound use, so it would never surface as the
+		// effective identity this test is about.
+		ClientProduct: "codex_cli_rs",
 		Version:       "0.125.0",
 		Fields: map[string]string{
-			identityfingerprint.FieldUserAgent:       "codex-tui/0.125.0 (Mac OS 26.5; arm64)",
+			identityfingerprint.FieldUserAgent:       "codex_cli_rs/0.125.0 (Mac OS 26.5; arm64)",
 			identityfingerprint.FieldCodexVersion:    "0.125.0",
-			identityfingerprint.FieldCodexOriginator: "codex-tui",
+			identityfingerprint.FieldCodexOriginator: "codex_cli_rs",
 		},
 		ObservedHeaders: map[string]string{
-			"User-Agent": "codex-tui/0.125.0 (Mac OS 26.5; arm64)",
+			"User-Agent": "codex_cli_rs/0.125.0 (Mac OS 26.5; arm64)",
 			"Version":    "0.125.0",
-			"Originator": "codex-tui",
+			"Originator": "codex_cli_rs",
 		},
 		CreatedAt:  time.Date(2026, 6, 23, 2, 0, 0, 0, time.UTC),
 		UpdatedAt:  time.Date(2026, 6, 23, 2, 1, 0, 0, time.UTC),
@@ -291,7 +294,7 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
-	if got := payload.Effective.Fields[identityfingerprint.FieldUserAgent]; got.Value != "codex-tui/0.125.0 (Mac OS 26.5; arm64)" || got.Source != "learned" {
+	if got := payload.Effective.Fields[identityfingerprint.FieldUserAgent]; got.Value != "codex_cli_rs/0.125.0 (Mac OS 26.5; arm64)" || got.Source != "learned" {
 		t.Fatalf("user-agent field = %+v, want learned Codex client", got)
 	}
 	if got, ok := payload.Effective.Fields[identityfingerprint.FieldCodexWebsocketBeta]; ok && got.Value != "" {

--- a/internal/identityfingerprint/profiles.go
+++ b/internal/identityfingerprint/profiles.go
@@ -135,11 +135,32 @@ func CodexProfileOutboundEligibility(record *LearnedRecord) (bool, string) {
 	if classifiedKey != profileKey {
 		return false, "profile_key_mismatch"
 	}
+	if IsLegacyCodexProfileKey(classifiedKey) {
+		return false, "legacy_client_product"
+	}
 	switch family {
 	case ProfileFamilyCLI, ProfileFamilyIDE, ProfileFamilyDesktop:
 		return true, ""
 	default:
 		return false, "unsupported_profile_family"
+	}
+}
+
+// IsLegacyCodexProfileKey reports products that must not be replayed upstream
+// even when a client still presents them.
+//
+// `codex-tui` is the pre-rename Codex CLI. Upstream A/B probes (CLIProxyAPI
+// #4679) had requests carrying it load-shed with `server_is_overloaded` while
+// the same account succeeded as `codex_cli_rs`, and spoofing only the
+// User-Agent did not help. Learning such a profile from a downstream client
+// would otherwise pin the account to that identity, so it is refused here and
+// resolution falls back to the coherent builtin CLI profile.
+func IsLegacyCodexProfileKey(profileKey string) bool {
+	switch strings.ToLower(strings.TrimSpace(profileKey)) {
+	case "codex-tui", "codex_tui":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/identityfingerprint/profiles_test.go
+++ b/internal/identityfingerprint/profiles_test.go
@@ -138,6 +138,43 @@ func TestSelectCodexProfileReportsNoSelectableProfile(t *testing.T) {
 	}
 }
 
+// A downstream client on the pre-rename CLI must not pin the account to that
+// identity: upstream load-sheds `codex-tui` traffic, so a self-consistent
+// codex-tui profile is still refused for outbound use and selection falls
+// through to the builtin CLI profile.
+func TestCodexTUIProfileIsNeverSelectedForOutbound(t *testing.T) {
+	legacy := LearnedRecord{
+		Provider: ProviderCodex, AccountKey: "acct",
+		ProfileKey: "codex-tui", ProfileFamily: ProfileFamilyCLI,
+		Fields: map[string]string{
+			FieldUserAgent:       "codex-tui/0.118.0 (Mac OS 26.3.1; arm64)",
+			FieldCodexOriginator: "codex-tui",
+		},
+	}
+	if eligible, reason := CodexProfileOutboundEligibility(&legacy); eligible || reason != "legacy_client_product" {
+		t.Fatalf("codex-tui eligibility = %v/%q, want refusal as a legacy product", eligible, reason)
+	}
+
+	selection := SelectCodexProfile([]LearnedRecord{legacy}, AccountPolicy{Provider: ProviderCodex, AccountKey: "acct"})
+	if selection.Profile != nil {
+		t.Fatalf("codex-tui was selected for outbound use: %+v", selection.Profile)
+	}
+	if selection.Reason != "no_selectable_profile" {
+		t.Fatalf("selection reason = %q, want no_selectable_profile", selection.Reason)
+	}
+
+	// The current CLI on the same account stays selectable.
+	current := legacy
+	current.ProfileKey = "codex_cli_rs"
+	current.Fields = map[string]string{
+		FieldUserAgent:       "codex_cli_rs/0.149.1 (Mac OS 26.3.1; arm64)",
+		FieldCodexOriginator: "codex_cli_rs",
+	}
+	if eligible, reason := CodexProfileOutboundEligibility(&current); !eligible {
+		t.Fatalf("codex_cli_rs eligibility = %v/%q, want eligible", eligible, reason)
+	}
+}
+
 func TestResolveCodexSafeFallbackRejectsMixedAccountPreset(t *testing.T) {
 	resolved, effective := ResolveCodexSafeFallback(config.CodexIdentityFingerprintConfig{
 		Enabled:       true,

--- a/internal/runtime/executor/codex_fingerprint_convergence.go
+++ b/internal/runtime/executor/codex_fingerprint_convergence.go
@@ -46,11 +46,20 @@ type codexConvergedIDs struct {
 	threadID       string
 	turnID         string
 	windowID       string
+	// clientRequestID mirrors x-client-request-id. Official Codex sets it to the
+	// thread id, but device mode scopes whatever the client actually sent rather
+	// than assuming that equality holds for every client.
+	clientRequestID string
 	// turnStartedAtUnixMs is stamped from the same clock that produced turnID
 	// (a time-ordered UUIDv7). Keeping the client's original timestamp next to a
 	// server-generated turn id would leave the two disagreeing about when the
 	// turn started, which is a discrepancy a real client never produces.
 	turnStartedAtUnixMs int64
+	// scopedFromClient marks the device-mode snapshot, whose session, thread and
+	// window ids are scoped rewrites of the client's own values instead of
+	// proxy-invented ones. Projection then only touches fields the client sent,
+	// and keeps its turn id and turn timestamp untouched.
+	scopedFromClient bool
 }
 
 type codexConvergedIDsContextKeyType struct{}
@@ -158,6 +167,51 @@ func resolveConvergedThreadID(scope, clientSessionID string) string {
 	return deriveStableUUIDv4("clirelay:codex-thread-id:v1:" + scope + ":" + clientSessionID)
 }
 
+// adoptScopedClientIdentity fills the snapshot with account-scoped rewrites of
+// the identifiers the client itself sent, instead of proxy-invented ones.
+//
+// This is what device mode projects. Every field goes through the same scope,
+// so the relationships the client established survive the rewrite: a root turn
+// that arrived with session_id == thread_id still leaves with the two equal,
+// and a window id keeps pointing at its own session. Fields the client did not
+// send stay empty, and projection then leaves them alone.
+func (ids *codexConvergedIDs) adoptScopedClientIdentity(scope string, clientHeaders http.Header) {
+	if ids == nil || scope == "" {
+		return
+	}
+	ids.scopedFromClient = true
+
+	// Clients split these between real headers and the turn metadata blob; both
+	// reach upstream, so both have to resolve to the same scoped value.
+	metadata := ""
+	if clientHeaders != nil {
+		metadata = strings.TrimSpace(clientHeaders.Get("X-Codex-Turn-Metadata"))
+	}
+	if metadata != "" && !gjson.Valid(metadata) {
+		metadata = ""
+	}
+	clientValue := func(metadataKey string, headerNames ...string) string {
+		if clientHeaders != nil {
+			for _, name := range headerNames {
+				if v := strings.TrimSpace(clientHeaders.Get(name)); v != "" {
+					return v
+				}
+			}
+		}
+		if metadata != "" && metadataKey != "" {
+			if v := strings.TrimSpace(gjson.Get(metadata, metadataKey).String()); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
+
+	ids.sessionID = codexScopedIdentifier(scope, clientValue("session_id", "Session-Id", "Session_id"))
+	ids.threadID = codexScopedIdentifier(scope, clientValue("thread_id", "Thread-Id"))
+	ids.windowID = codexScopedIdentifier(scope, clientValue("window_id", "X-Codex-Window-Id"))
+	ids.clientRequestID = codexScopedIdentifier(scope, clientValue("", "X-Client-Request-Id"))
+}
+
 // extractClientSessionID reads the client's own session identifier before any
 // rewrite. Codex CLI sends the hyphenated form; the underscore form is accepted
 // as a fallback because some clients and earlier proxy layers emit it.
@@ -192,6 +246,12 @@ func resolveCodexConvergedIDs(cfg *config.Config, auth *cliproxyauth.Auth, clien
 
 	ids := &codexConvergedIDs{mode: mode, installationID: installationID}
 	if mode == config.CodexFingerprintConvergenceDevice {
+		// Deliberately the session isolation scope, not the convergence scope
+		// above: the cache helper already maps prompt_cache_key through that one,
+		// and the two must agree or the body cache key and the wire session end up
+		// naming different sessions. Installation keeps the convergence scope so
+		// existing device identities do not shift.
+		ids.adoptScopedClientIdentity(sessionIsolationScope(auth), clientHeaders)
 		return ids
 	}
 
@@ -257,6 +317,20 @@ func applyCodexConvergenceHeaders(h http.Header, ids *codexConvergedIDs, clientH
 	setIfClientSent(h, clientHeaders, "X-Codex-Installation-Id", ids.installationID)
 
 	if ids.mode == config.CodexFingerprintConvergenceDevice {
+		if ids.scopedFromClient {
+			// The scoped ids replace the client's own values wherever they travel.
+			// Session_id and Conversation_id are already on the request: the cache
+			// helper derived them from prompt_cache_key, which for a default Codex
+			// client equals the session id and therefore scopes to the same value.
+			// Pinning them here makes that hold even when a client overrides the
+			// cache key, so header and body never describe two different sessions.
+			setIfClientSent(h, clientHeaders, "Session-Id", ids.sessionID)
+			setIfClientSent(h, clientHeaders, "Session_id", ids.sessionID)
+			setIfClientSent(h, clientHeaders, "Conversation_id", ids.sessionID)
+			setIfClientSent(h, clientHeaders, "Thread-Id", ids.threadID)
+			setIfClientSent(h, clientHeaders, "X-Codex-Window-Id", ids.windowID)
+			setIfClientSent(h, clientHeaders, "X-Client-Request-Id", ids.clientRequestID)
+		}
 		rewriteCodexTurnMetadataHeader(h, ids.turnMetadataFields())
 		return
 	}
@@ -311,6 +385,22 @@ func (ids *codexConvergedIDs) deviceOnly() *codexConvergedIDs {
 // thread or turn fields the client sent.
 func (ids *codexConvergedIDs) turnMetadataFields() map[string]any {
 	fields := map[string]any{"installation_id": ids.installationID}
+	if ids.scopedFromClient {
+		// Device mode rewrites exactly the ids it scoped. turn_id and
+		// turn_started_at_unix_ms stay as the client sent them: they identify a
+		// single turn and carry no cross-request identity, so rewriting them
+		// would add divergence without hiding anything.
+		for key, value := range map[string]string{
+			"session_id": ids.sessionID,
+			"thread_id":  ids.threadID,
+			"window_id":  ids.windowID,
+		} {
+			if value != "" {
+				fields[key] = value
+			}
+		}
+		return fields
+	}
 	if ids.mode == config.CodexFingerprintConvergenceDevice {
 		return fields
 	}
@@ -376,7 +466,20 @@ func applyCodexConvergenceClientMetadata(body []byte, ids *codexConvergedIDs) []
 	fields := map[string]any{
 		"client_metadata.x-codex-installation-id": ids.installationID,
 	}
-	if ids.mode != config.CodexFingerprintConvergenceDevice {
+	switch {
+	case ids.scopedFromClient:
+		// Same snapshot as the headers, so the body cannot describe a different
+		// session than the wire does.
+		for key, value := range map[string]string{
+			"client_metadata.session_id":        ids.sessionID,
+			"client_metadata.thread_id":         ids.threadID,
+			"client_metadata.x-codex-window-id": ids.windowID,
+		} {
+			if value != "" {
+				fields[key] = value
+			}
+		}
+	case ids.mode != config.CodexFingerprintConvergenceDevice:
 		fields["client_metadata.session_id"] = ids.sessionID
 		fields["client_metadata.thread_id"] = ids.threadID
 		fields["client_metadata.turn_id"] = ids.turnID

--- a/internal/runtime/executor/codex_identity_projection_test.go
+++ b/internal/runtime/executor/codex_identity_projection_test.go
@@ -1,0 +1,220 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// The identifiers below mirror a real Codex Desktop turn captured from the
+// production request log: a root turn, so session, thread and x-client-request-id
+// all carry one value, the window id appends a compaction counter, and the turn
+// metadata repeats the same graph inside a JSON blob.
+const (
+	clientRootID    = "01a02380-e7de-79a1-a6ae-bcb146d1c0c9"
+	clientWindowID  = clientRootID + ":2"
+	clientTurnID    = "01a031cb-1b7f-72b1-b7de-6ffa906b0505"
+	clientInstallID = "7e296383-a82a-4b29-bb1a-b561986714ef"
+)
+
+func codexDeviceModeRequest(t *testing.T) *http.Request {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	for key, value := range map[string]string{
+		"Session-Id":          clientRootID,
+		"Thread-Id":           clientRootID,
+		"X-Client-Request-Id": clientRootID,
+		"X-Codex-Window-Id":   clientWindowID,
+		"X-Codex-Turn-Metadata": `{"installation_id":"` + clientInstallID + `","session_id":"` + clientRootID +
+			`","thread_id":"` + clientRootID + `","turn_id":"` + clientTurnID + `","window_id":"` + clientWindowID +
+			`","request_kind":"turn","sandbox":"none"}`,
+	} {
+		ginCtx.Request.Header.Set(key, value)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+	return req.WithContext(context.WithValue(req.Context(), util.ContextKeyGin, ginCtx))
+}
+
+// TestDeviceModeProjectsOneCoherentIdentityGraph pins the invariants that
+// production was violating: every outbound identifier is a well-formed UUID,
+// the header copy and the turn-metadata copy agree, and the equalities the
+// client established survive the account scoping.
+func TestDeviceModeProjectsOneCoherentIdentityGraph(t *testing.T) {
+	req := codexDeviceModeRequest(t)
+	cfg := codexConvergenceTestConfig(config.CodexFingerprintConvergenceDevice)
+	applyCodexHeaders(req, cfg, codexConvergenceTestAuth("codex-projection"), "token", true)
+
+	session := req.Header.Get("Session_id")
+	thread := req.Header.Get("Thread-Id")
+	window := req.Header.Get("X-Codex-Window-Id")
+	requestID := req.Header.Get("X-Client-Request-Id")
+
+	if session == "" || thread == "" || window == "" || requestID == "" {
+		t.Fatalf("client identifiers were dropped: session=%q thread=%q window=%q request=%q",
+			session, thread, window, requestID)
+	}
+	// A suffixed id like "<uuid>-79e1abc32c2ef4d0" is not a shape any Codex
+	// client emits; that malformed value was the strongest tell in production.
+	for name, value := range map[string]string{"Session_id": session, "Thread-Id": thread, "X-Client-Request-Id": requestID} {
+		if _, err := uuid.Parse(value); err != nil {
+			t.Fatalf("%s = %q is not a well-formed UUID", name, value)
+		}
+	}
+	if _, err := uuid.Parse(strings.TrimSuffix(window, ":2")); err != nil {
+		t.Fatalf("window id = %q, want <uuid>:<counter>", window)
+	}
+	if !strings.HasSuffix(window, ":2") {
+		t.Fatalf("window id = %q, want the client's compaction counter preserved", window)
+	}
+
+	// The client sent one root turn, so upstream must still see one.
+	if session != thread || session != requestID {
+		t.Fatalf("root-turn equality broken: session=%q thread=%q request=%q", session, thread, requestID)
+	}
+	if strings.HasPrefix(window, session+":") == false {
+		t.Fatalf("window id = %q no longer points at session %q", window, session)
+	}
+	if session == clientRootID {
+		t.Fatal("session id reached upstream unscoped, so accounts are not isolated")
+	}
+
+	metadata := req.Header.Get("X-Codex-Turn-Metadata")
+	for field, want := range map[string]string{"session_id": session, "thread_id": thread, "window_id": window} {
+		if got := gjson.Get(metadata, field).String(); got != want {
+			t.Fatalf("turn metadata %s = %q, want the header value %q", field, got, want)
+		}
+	}
+	// A single turn carries no cross-request identity, so it is left alone.
+	if got := gjson.Get(metadata, "turn_id").String(); got != clientTurnID {
+		t.Fatalf("turn metadata turn_id = %q, want the client value untouched", got)
+	}
+	if got := gjson.Get(metadata, "installation_id").String(); got == clientInstallID || got == "" {
+		t.Fatalf("turn metadata installation_id = %q, want a converged value", got)
+	}
+	if got := gjson.Get(metadata, "sandbox").String(); got != "none" {
+		t.Fatalf("unrelated metadata field was dropped: sandbox = %q", got)
+	}
+}
+
+// TestDeviceModeBodyMatchesHeaders guards the other half of the split that
+// production showed: client_metadata described a different session than the
+// headers did.
+func TestDeviceModeBodyMatchesHeaders(t *testing.T) {
+	req := codexDeviceModeRequest(t)
+	cfg := codexConvergenceTestConfig(config.CodexFingerprintConvergenceDevice)
+	auth := codexConvergenceTestAuth("codex-projection")
+
+	ids := resolveCodexConvergedIDs(cfg, auth, req.Context().Value(util.ContextKeyGin).(*gin.Context).Request.Header)
+	if ids == nil {
+		t.Fatal("device mode returned no snapshot")
+	}
+	body := []byte(`{"client_metadata":{"x-codex-installation-id":"` + clientInstallID + `","session_id":"` + clientRootID +
+		`","thread_id":"` + clientRootID + `","x-codex-window-id":"` + clientWindowID + `"}}`)
+	body = applyCodexConvergenceClientMetadata(body, ids)
+
+	for field, want := range map[string]string{
+		"client_metadata.session_id":        ids.sessionID,
+		"client_metadata.thread_id":         ids.threadID,
+		"client_metadata.x-codex-window-id": ids.windowID,
+	} {
+		if got := gjson.GetBytes(body, field).String(); got != want {
+			t.Fatalf("%s = %q, want %q", field, got, want)
+		}
+	}
+}
+
+// TestCacheKeyAndSessionHeaderAgreeEndToEnd walks the real order of operations:
+// cacheHelper derives prompt_cache_key and stamps the session headers, then
+// applyCodexHeaders projects the convergence snapshot over them. Production
+// showed those two steps disagreeing, so the body cache key and the wire
+// session have to be asserted together rather than in isolation.
+func TestCacheKeyAndSessionHeaderAgreeEndToEnd(t *testing.T) {
+	auth := codexConvergenceTestAuth("codex-endtoend")
+	// A default Codex client sets prompt_cache_key to its session id.
+	payload := []byte(`{"model":"gpt-5-codex","prompt_cache_key":"` + clientRootID + `"}`)
+	httpReq := codexCacheHelperRequest(t, auth, sdktranslator.FromString("openai-response"),
+		cliproxyexecutor.Request{Model: "gpt-5-codex", Payload: payload})
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = codexDeviceModeRequest(t).Context().Value(util.ContextKeyGin).(*gin.Context).Request
+	httpReq = httpReq.WithContext(context.WithValue(httpReq.Context(), util.ContextKeyGin, ginCtx))
+
+	cacheKey := gjson.GetBytes(readRequestBody(t, httpReq), "prompt_cache_key").String()
+	applyCodexHeaders(httpReq, codexConvergenceTestConfig(config.CodexFingerprintConvergenceDevice), auth, "token", true)
+
+	session := httpReq.Header.Get("Session_id")
+	if cacheKey == "" || session == "" {
+		t.Fatalf("cache key = %q, session = %q", cacheKey, session)
+	}
+	if cacheKey != session {
+		t.Fatalf("body cache key %q and header session %q describe different sessions", cacheKey, session)
+	}
+	if got := httpReq.Header.Get("Conversation_id"); got != session {
+		t.Fatalf("Conversation_id = %q, want the session %q", got, session)
+	}
+	if _, err := uuid.Parse(session); err != nil {
+		t.Fatalf("session %q is not a well-formed UUID", session)
+	}
+}
+
+// TestScopedIdentifierIsInjectiveAndShapePreserving covers the mapping itself:
+// it must keep UUID version and variant, keep a v7 timestamp so ids stay
+// time-ordered, separate accounts, and never collapse two distinct inputs.
+func TestScopedIdentifierIsInjectiveAndShapePreserving(t *testing.T) {
+	const scopeA = "account:a"
+	const scopeB = "account:b"
+
+	v7 := uuid.Must(uuid.NewV7()).String()
+	mapped := codexScopedIdentifier(scopeA, v7)
+	parsed, err := uuid.Parse(mapped)
+	if err != nil {
+		t.Fatalf("mapped v7 id = %q, not a UUID", mapped)
+	}
+	if parsed.Version() != 7 {
+		t.Fatalf("mapped id version = %d, want 7", parsed.Version())
+	}
+	if mapped[:8] != v7[:8] {
+		t.Fatalf("v7 timestamp prefix changed: %q vs %q", mapped[:8], v7[:8])
+	}
+	if mapped == v7 {
+		t.Fatal("identifier was not scoped at all")
+	}
+
+	v4 := uuid.NewString()
+	if got := uuid.MustParse(codexScopedIdentifier(scopeA, v4)).Version(); got != 4 {
+		t.Fatalf("mapped v4 id version = %d, want the original 4", got)
+	}
+
+	if again := codexScopedIdentifier(scopeA, v7); again != mapped {
+		t.Fatalf("mapping is not deterministic: %q then %q", mapped, again)
+	}
+	if codexScopedIdentifier(scopeB, v7) == mapped {
+		t.Fatal("two accounts mapped one client id onto the same value")
+	}
+	other := uuid.Must(uuid.NewV7()).String()
+	if codexScopedIdentifier(scopeA, other) == mapped {
+		t.Fatal("two distinct client ids collided within one account")
+	}
+
+	// Non-UUID ids cannot keep a shape they never had, but must stay isolated.
+	plain := codexScopedIdentifier(scopeA, "shared-session")
+	if plain == "shared-session" || !strings.HasPrefix(plain, "shared-session-") {
+		t.Fatalf("non-uuid identifier = %q, want a scope-derived suffix", plain)
+	}
+	if plain == codexScopedIdentifier(scopeB, "shared-session") {
+		t.Fatal("non-uuid identifier is not account-isolated")
+	}
+}

--- a/internal/runtime/executor/codex_session_isolation.go
+++ b/internal/runtime/executor/codex_session_isolation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/google/uuid"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -17,8 +18,82 @@ func codexAccountScopedExplicitSessionID(auth *cliproxyauth.Auth, raw string) st
 	if scope == "" {
 		return raw
 	}
+	return codexScopedIdentifier(scope, raw)
+}
+
+// codexScopedIdentifier maps one client identifier into an account-scoped one
+// while preserving the exact shape a real Codex client emits.
+//
+// The mapping is injective per scope: the same input always lands on the same
+// output, and two different inputs never collide. That property is what keeps
+// the client's own identity graph intact — a root turn where session_id equals
+// thread_id still comes out with the two equal, and a sub-agent thread stays
+// distinct from its root. Callers must therefore run every identifier of one
+// request through this with the same scope, or the graph breaks apart.
+//
+// Shapes handled:
+//   - UUID: version and variant nibbles are preserved, and for v7 so is the
+//     48-bit timestamp, so the result is a well-formed, still time-ordered UUID
+//     of the same version. Only the entropy is replaced.
+//   - "<uuid>:<n>" (Codex window ids): the UUID part is mapped, the counter is
+//     kept, because the counter tracks compaction rounds rather than identity.
+//
+// Anything else falls back to appending a scope-derived suffix. An identifier
+// that is not a UUID did not come from an official Codex client, so there is no
+// official shape left to preserve and account isolation is what matters.
+func codexScopedIdentifier(scope, raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || scope == "" {
+		return raw
+	}
+	if uuidPart, suffix, ok := splitCodexWindowIdentifier(raw); ok {
+		if mapped := scopeUUIDPreservingShape(scope, uuidPart); mapped != "" {
+			return mapped + suffix
+		}
+	} else if mapped := scopeUUIDPreservingShape(scope, raw); mapped != "" {
+		return mapped
+	}
 	sum := sha256.Sum256([]byte(scope + "\x00" + raw))
 	return raw + "-" + hex.EncodeToString(sum[:8])
+}
+
+// splitCodexWindowIdentifier recognises the "<uuid>:<counter>" window id form.
+func splitCodexWindowIdentifier(raw string) (string, string, bool) {
+	idx := strings.LastIndex(raw, ":")
+	if idx <= 0 || idx == len(raw)-1 {
+		return "", "", false
+	}
+	for _, r := range raw[idx+1:] {
+		if r < '0' || r > '9' {
+			return "", "", false
+		}
+	}
+	return raw[:idx], raw[idx:], true
+}
+
+// scopeUUIDPreservingShape rewrites a UUID's entropy from (scope, raw) and
+// returns "" when raw is not a UUID, so callers can fall back.
+func scopeUUIDPreservingShape(scope, raw string) string {
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	original := [16]byte(parsed)
+	sum := sha256.Sum256([]byte(scope + "\x00" + raw))
+
+	var out [16]byte
+	copy(out[:], sum[:16])
+	// UUIDv7 carries a 48-bit big-endian millisecond timestamp in bytes 0..5.
+	// Keeping it means the rewritten id sorts in the same order and sits in the
+	// same time range as the client's, which a freshly hashed prefix would not.
+	if parsed.Version() == 7 {
+		copy(out[0:6], original[0:6])
+	}
+	// Restore the version nibble and the RFC 4122 variant bits so the result is
+	// still a valid UUID of the very same version the client sent.
+	out[6] = (out[6] & 0x0f) | (original[6] & 0xf0)
+	out[8] = (out[8] & 0x3f) | (original[8] & 0xc0)
+	return uuid.UUID(out).String()
 }
 
 func codexSessionIsolationScope(auth *cliproxyauth.Auth) string {

--- a/internal/runtime/executor/codex_websockets_helpers.go
+++ b/internal/runtime/executor/codex_websockets_helpers.go
@@ -207,10 +207,11 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, cfg *c
 		misc.EnsureHeader(headers, ginHeaders, "User-Agent", codexUserAgent)
 	}
 
-	// Device fingerprint convergence, narrowed to the installation identifier:
-	// the websocket handshake pins Session_id to Conversation_id and
-	// prompt_cache_key above, so converging the session here would break prompt
-	// cache matching.
+	// Device fingerprint convergence, narrowed to the installation identifier so
+	// the stronger modes cannot invent a session here. In device mode the
+	// snapshot instead carries scope-mapped copies of the client's own ids, which
+	// is the same mapping the handshake applied to prompt_cache_key above, so
+	// Session_id, Conversation_id and the cache key stay in one cache domain.
 	applyCodexConvergenceHeaders(headers, resolveCodexConvergedIDs(cfg, auth, ginHeaders).deviceOnly(), ginHeaders)
 
 	// Match upstream: only attach Session_id when UA indicates a desktop client, and do not forward UA over websocket.


### PR DESCRIPTION
## 背景

延续 #931。那个 PR 上线后我抓了线上请求日志做实证，发现**同一个出站请求同时描述了三个不同的 session**：

| 出站字段 | 线上实际值 | 问题 |
| --- | --- | --- |
| `Session_id` / `Conversation_id` | `01a02380-…-79e1abc32c2ef4d0` | 不是合法 UUID |
| `X-Codex-Turn-Metadata.session_id` | `01a02380-…`（客户端原值） | 与上面**不是同一个值** |
| `X-Client-Request-Id` | `01a02380-…`（未 scope 化） | 与 session 不同源 |
| `Thread-Id`、`X-Codex-Window-Id` | **出站丢失** | 客户端发了，代理吃掉了 |

根因是两套独立的改写器：`cacheHelper` 用「追加 hash 后缀」的方式 scope 化 `prompt_cache_key` 和 session 头，`applyCodexConvergenceHeaders` 用自己的 snapshot 改写 turn metadata，两者互不知情。而追加后缀这个形态本身也是错的——官方 Codex 的 session / thread / window id 都是 UUID。

## 修改

**一、device 模式改为单一 snapshot 投影到所有载体**

每请求解析一次身份，然后统一投影到：session / thread / window / client-request 四个头、`X-Codex-Turn-Metadata` blob、body 的 `client_metadata`。

映射改为**保形保结构**而非追加：

- UUID 保留 version 与 variant 位；v7 额外保留 48 位时间戳，所以 id 仍然是同版本合法 UUID 且保持时间序
- window id 的 `:<counter>` 后缀保留（counter 跟踪 compaction 轮次，不是身份）
- 映射在同一 scope 下是**单射**的，所以客户端自己的关系得以保留：根线程进来时 `session_id == thread_id`，出去仍然相等；子 agent 的 thread 仍与根不同
- 非 UUID 标识符保持旧的后缀行为——它不来自官方客户端，没有形态可保，隔离性优先

关键一点：投影用的是 `sessionIsolationScope`，与 `cacheHelper` 完全同一个 scope。写测试时先用了 `codexConvergenceScope`，端到端测试立刻抓出两者派生值不同——这正是原先「两套各改各的」的根源。installation 仍用 convergence scope，避免已有设备身份漂移。

**二、拒绝 `codex-tui` profile 用于出站**

#931 只改了内建默认值，但出站身份优先取**学习到的 profile**。若某账号学到的 profile 本身就是 codex-tui（客户端确实是 codex-tui 时就会这样），改默认值不生效。现在 `CodexProfileOutboundEligibility` 把 legacy 产品判为 `legacy_client_product`，选择逻辑跳过它，回退到连贯的内建 CLI profile。

**刻意不改的**：`turn_id` 和 `turn_started_at_unix_ms` 保持客户端原值。它们标识单次 turn、不承载跨请求身份，改写只会增加偏差而无收益。

## 测试

新增 `codex_identity_projection_test.go`，固件直接取自线上那条 Codex Desktop 请求：

- `TestDeviceModeProjectsOneCoherentIdentityGraph`：所有出站 id 是合法 UUID、header 与 turn metadata 一致、根线程相等关系保留、window 仍指向自己的 session、session 确实被 scope 化
- `TestDeviceModeBodyMatchesHeaders`：body 的 `client_metadata` 与 header 同源
- `TestCacheKeyAndSessionHeaderAgreeEndToEnd`：走真实调用顺序（cacheHelper 先设、applyCodexHeaders 后投影），断言 body cache key 与 wire session 落在同一个值
- `TestScopedIdentifierIsInjectiveAndShapePreserving`：映射的确定性、账号隔离、无碰撞、保 version / 保 v7 时间戳
- `TestCodexTUIProfileIsNeverSelectedForOutbound`：legacy 被拒且当前 CLI 仍可选

改了两处既有测试固件：`identity_fingerprint_test.go` 的 learned 样本从 codex-tui 换成 codex_cli_rs（该测试验证的是 API 的三层返回，legacy 产品已不可能成为 effective 身份）。把 codex-tui 作为**入站**客户端的固件全部保留——那仍是代理必须正确处理的合法客户端标识。

## 已执行的校验

- `./scripts/ci-pr.sh`（完整门禁，绿）

## 上线注意

- 这次改动会让**所有现有会话的 session id 与 prompt cache key 变化**（从后缀形态变为重映射 UUID），是一次性的缓存失效。之后趋于稳定。
- 出站仍带一个 `Conversation_id` 头，官方 Codex 客户端并不发它（入站日志里 Codex Desktop 就没发），是 `cacheHelper` 加的。本 PR 让它与 session 保持一致，但**没有移除**——移除可能影响上游会话关联，缺乏证据支撑，留作单独议题。
- 建议的验证仍是缓存命中率（`cached_input_tokens / input_tokens`）与 `server_is_overloaded` 频率，而非只看周额度数字。