### PR TITLE
fix(auth): refresh tokens through the credential's own proxy

### DIFF
--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -61,10 +61,28 @@ type ClaudeAuth struct {
 // Returns:
 //   - *ClaudeAuth: A new Claude authentication service instance
 func NewClaudeAuth(cfg *config.Config) *ClaudeAuth {
+	return NewClaudeAuthWithProxy(cfg, "")
+}
+
+// NewClaudeAuthWithProxy is NewClaudeAuth pinned to one egress proxy.
+//
+// Token refresh has to leave from the same address as the credential's own
+// requests; see resolveAuthProxyURL in the executor package for what goes wrong
+// when the two diverge. An empty proxyURL keeps the configured default. The
+// Firefox TLS fingerprint is preserved either way, since the proxy is applied by
+// substituting the dialer's config rather than replacing the transport.
+func NewClaudeAuthWithProxy(cfg *config.Config, proxyURL string) *ClaudeAuth {
+	var sdkCfg config.SDKConfig
+	if cfg != nil {
+		sdkCfg = cfg.SDKConfig
+	}
+	if trimmed := strings.TrimSpace(proxyURL); trimmed != "" {
+		sdkCfg.ProxyURL = trimmed
+	}
 	// Use custom HTTP client with Firefox TLS fingerprint to bypass
 	// Cloudflare's bot detection on Anthropic domains
 	return &ClaudeAuth{
-		httpClient: NewAnthropicHttpClient(&cfg.SDKConfig),
+		httpClient: NewAnthropicHttpClient(&sdkCfg),
 	}
 }
 

--- a/internal/auth/claude/refresh_proxy_test.go
+++ b/internal/auth/claude/refresh_proxy_test.go
@@ -1,0 +1,34 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// Pinning a credential's proxy must not leak into the shared config, and the
+// Firefox TLS fingerprint transport must survive it: this provider relies on
+// that fingerprint to get past Cloudflare, so losing it would trade one outage
+// for another.
+func TestNewClaudeAuthWithProxyKeepsFingerprintAndConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SDKConfig.ProxyURL = "http://global.example:7890"
+
+	svc := NewClaudeAuthWithProxy(cfg, "socks5://pinned.example:1080")
+
+	if got := cfg.SDKConfig.ProxyURL; got != "http://global.example:7890" {
+		t.Fatalf("shared config proxy = %q, want it unchanged", got)
+	}
+	if svc == nil || svc.httpClient == nil {
+		t.Fatal("no client was built")
+	}
+	if _, ok := svc.httpClient.Transport.(*utlsRoundTripper); !ok {
+		t.Fatalf("transport = %T, want the utls fingerprint transport", svc.httpClient.Transport)
+	}
+}
+
+func TestNewClaudeAuthWithProxyHandlesNilConfig(t *testing.T) {
+	if svc := NewClaudeAuthWithProxy(nil, "socks5://pinned.example:1080"); svc == nil || svc.httpClient == nil {
+		t.Fatal("nil config must still yield a usable client")
+	}
+}

--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -37,9 +37,32 @@ type CodexAuth struct {
 // NewCodexAuth creates a new CodexAuth service instance.
 // It initializes an HTTP client with proxy settings from the provided configuration.
 func NewCodexAuth(cfg *config.Config) *CodexAuth {
+	return NewCodexAuthWithProxy(cfg, "")
+}
+
+// NewCodexAuthWithProxy is NewCodexAuth pinned to one egress proxy.
+//
+// Token refresh has to leave from the same address as the credential's own
+// requests; see resolveAuthProxyURL in the executor package for what goes wrong
+// when the two diverge. An empty proxyURL keeps the configured default.
+func NewCodexAuthWithProxy(cfg *config.Config, proxyURL string) *CodexAuth {
+	sdkCfg := sdkConfigWithProxy(cfg, proxyURL)
 	return &CodexAuth{
-		httpClient: util.SetProxy(&cfg.SDKConfig, util.NewHTTPClient(util.DefaultHTTPClientTimeout)),
+		httpClient: util.SetProxy(sdkCfg, util.NewHTTPClient(util.DefaultHTTPClientTimeout)),
 	}
+}
+
+// sdkConfigWithProxy copies the SDK config with proxyURL substituted, so pinning
+// an egress proxy cannot mutate shared configuration.
+func sdkConfigWithProxy(cfg *config.Config, proxyURL string) *config.SDKConfig {
+	var sdkCfg config.SDKConfig
+	if cfg != nil {
+		sdkCfg = cfg.SDKConfig
+	}
+	if proxyURL = strings.TrimSpace(proxyURL); proxyURL != "" {
+		sdkCfg.ProxyURL = proxyURL
+	}
+	return &sdkCfg
 }
 
 // GenerateAuthURL creates the OAuth authorization URL with PKCE (Proof Key for Code Exchange).

--- a/internal/auth/codex/refresh_proxy_test.go
+++ b/internal/auth/codex/refresh_proxy_test.go
@@ -1,0 +1,77 @@
+package codex
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func newTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.SDKConfig.ProxyURL = "http://global.example:7890"
+	return cfg
+}
+
+// TestNewCodexAuthWithProxyPinsEgress checks that the pinned proxy is what the
+// refresh client actually dials, rather than the process-wide default. An HTTP
+// proxy is used because that scheme lands on Transport.Proxy and is therefore
+// directly observable; socks5 goes through the same substitution but is applied
+// as a dialer.
+func TestNewCodexAuthWithProxyPinsEgress(t *testing.T) {
+	cfg := newTestConfig()
+
+	svc := NewCodexAuthWithProxy(cfg, "http://pinned.example:1080")
+	transport, ok := svc.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", svc.httpClient.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("transport has no proxy resolver, so refresh would go out direct")
+	}
+	proxyURL, err := transport.Proxy(httptest.NewRequest(http.MethodPost, "https://auth.openai.com/oauth/token", nil))
+	if err != nil {
+		t.Fatalf("proxy resolver error: %v", err)
+	}
+	if proxyURL == nil || proxyURL.Host != "pinned.example:1080" {
+		t.Fatalf("refresh proxy = %v, want pinned.example:1080", proxyURL)
+	}
+}
+
+// The substitution must not leak into the shared config: every other caller
+// reads the same struct, and one credential's proxy is not theirs.
+func TestNewCodexAuthWithProxyLeavesSharedConfigUntouched(t *testing.T) {
+	cfg := newTestConfig()
+
+	_ = NewCodexAuthWithProxy(cfg, "http://pinned.example:1080")
+
+	if got := cfg.SDKConfig.ProxyURL; got != "http://global.example:7890" {
+		t.Fatalf("shared config proxy = %q, want it unchanged", got)
+	}
+}
+
+// An empty proxy keeps the configured default, so callers that have no
+// credential-scoped proxy behave exactly as before.
+func TestNewCodexAuthWithoutProxyKeepsDefault(t *testing.T) {
+	cfg := newTestConfig()
+
+	svc := NewCodexAuthWithProxy(cfg, "   ")
+	transport, ok := svc.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", svc.httpClient.Transport)
+	}
+	proxyURL, err := transport.Proxy(httptest.NewRequest(http.MethodPost, "https://auth.openai.com/oauth/token", nil))
+	if err != nil {
+		t.Fatalf("proxy resolver error: %v", err)
+	}
+	if proxyURL == nil || proxyURL.Host != "global.example:7890" {
+		t.Fatalf("refresh proxy = %v, want the global default", proxyURL)
+	}
+}
+
+func TestNewCodexAuthHandlesNilConfig(t *testing.T) {
+	if svc := NewCodexAuthWithProxy(nil, "http://pinned.example:1080"); svc == nil || svc.httpClient == nil {
+		t.Fatal("nil config must still yield a usable client")
+	}
+}

--- a/internal/auth/qwen/qwen_auth.go
+++ b/internal/auth/qwen/qwen_auth.go
@@ -86,13 +86,31 @@ const defaultOAuthUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWe
 
 // NewQwenAuth creates a new QwenAuth instance with a proxy-configured HTTP client.
 func NewQwenAuth(cfg *config.Config) *QwenAuth {
+	return NewQwenAuthWithProxy(cfg, "")
+}
+
+// NewQwenAuthWithProxy is NewQwenAuth pinned to one egress proxy.
+//
+// Token refresh has to leave from the same address as the credential's own
+// requests; see resolveAuthProxyURL in the executor package for what goes wrong
+// when the two diverge. An empty proxyURL keeps the configured default.
+func NewQwenAuthWithProxy(cfg *config.Config, proxyURL string) *QwenAuth {
 	var sdkCfg *config.SDKConfig
 	userAgent := defaultOAuthUserAgent
 	if cfg != nil {
-		sdkCfg = &cfg.SDKConfig
+		// Copied rather than referenced: pinning a proxy must not mutate the
+		// shared configuration every other caller reads.
+		copied := cfg.SDKConfig
+		sdkCfg = &copied
 		if strings.TrimSpace(cfg.OAuthUserAgent) != "" {
 			userAgent = strings.TrimSpace(cfg.OAuthUserAgent)
 		}
+	}
+	if trimmed := strings.TrimSpace(proxyURL); trimmed != "" {
+		if sdkCfg == nil {
+			sdkCfg = &config.SDKConfig{}
+		}
+		sdkCfg.ProxyURL = trimmed
 	}
 	return &QwenAuth{
 		httpClient: util.SetProxy(sdkCfg, util.NewHTTPClient(util.DefaultHTTPClientTimeout)),

--- a/internal/auth/qwen/refresh_proxy_test.go
+++ b/internal/auth/qwen/refresh_proxy_test.go
@@ -1,0 +1,55 @@
+package qwen
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// Token refresh must dial the credential's own proxy, and pinning it must not
+// leak into the shared config that every other caller reads.
+func TestNewQwenAuthWithProxyPinsEgressWithoutMutatingConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SDKConfig.ProxyURL = "http://global.example:7890"
+
+	svc := NewQwenAuthWithProxy(cfg, "http://pinned.example:1080")
+
+	if got := cfg.SDKConfig.ProxyURL; got != "http://global.example:7890" {
+		t.Fatalf("shared config proxy = %q, want it unchanged", got)
+	}
+	transport, ok := svc.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", svc.httpClient.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("transport has no proxy resolver, so refresh would go out direct")
+	}
+	proxyURL, err := transport.Proxy(httptest.NewRequest(http.MethodPost, "https://example.com/token", nil))
+	if err != nil {
+		t.Fatalf("proxy resolver error: %v", err)
+	}
+	if proxyURL == nil || proxyURL.Host != "pinned.example:1080" {
+		t.Fatalf("refresh proxy = %v, want pinned.example:1080", proxyURL)
+	}
+}
+
+// The OAuth user agent is part of this provider's identity and must survive the
+// proxy substitution.
+func TestNewQwenAuthWithProxyKeepsUserAgent(t *testing.T) {
+	cfg := &config.Config{OAuthUserAgent: "custom-agent/1.0"}
+
+	if got := NewQwenAuthWithProxy(cfg, "http://pinned.example:1080").userAgent; got != "custom-agent/1.0" {
+		t.Fatalf("userAgent = %q, want the configured value", got)
+	}
+	if got := NewQwenAuthWithProxy(&config.Config{}, "").userAgent; got != defaultOAuthUserAgent {
+		t.Fatalf("userAgent = %q, want the default", got)
+	}
+}
+
+func TestNewQwenAuthWithProxyHandlesNilConfig(t *testing.T) {
+	if svc := NewQwenAuthWithProxy(nil, "http://pinned.example:1080"); svc == nil || svc.httpClient == nil {
+		t.Fatal("nil config must still yield a usable client")
+	}
+}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -478,7 +478,9 @@ func (e *ClaudeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (
 	if refreshToken == "" {
 		return auth, nil
 	}
-	svc := claudeauth.NewClaudeAuth(e.cfg)
+	// Refresh goes out through this credential's own proxy, not the process
+	// default, so the token is renewed from the address that uses it.
+	svc := claudeauth.NewClaudeAuthWithProxy(e.cfg, resolveAuthProxyURL(e.cfg, auth))
 	td, err := svc.RefreshTokens(ctx, refreshToken)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -540,7 +540,9 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	if refreshToken == "" {
 		return auth, nil
 	}
-	svc := codexauth.NewCodexAuth(e.cfg)
+	// Refresh goes out through this credential's own proxy, not the process
+	// default, so the token is renewed from the address that uses it.
+	svc := codexauth.NewCodexAuthWithProxy(e.cfg, resolveAuthProxyURL(e.cfg, auth))
 	td, err := svc.RefreshTokensWithRetry(ctx, refreshToken, 3)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -34,6 +34,34 @@ type requestLogEgressRoute struct {
 	ProxyURLHost string `json:"proxy_url_host,omitempty"`
 }
 
+// resolveAuthProxyURL returns the proxy a credential's own traffic goes out
+// through, using the same precedence as newProxyAwareHTTPClient.
+//
+// OAuth token refresh must leave from this address rather than the process
+// default. The two had drifted apart in production: requests went out through
+// the credential's proxy-pool entry while refresh went direct, so upstream saw
+// one account acting from two regions and rejected the refresh with
+// `unsupported_country_region_territory` once the host region was unsupported.
+// The access token then aged out and the account went unauthorized even though
+// its request path was healthy.
+//
+// It returns "" when nothing is configured, which leaves the caller on its
+// existing default.
+func resolveAuthProxyURL(cfg *config.Config, auth *cliproxyauth.Auth) string {
+	if cfg == nil {
+		if auth == nil {
+			return ""
+		}
+		return strings.TrimSpace(auth.ProxyURL)
+	}
+	proxyID, fallbackURL := "", ""
+	if auth != nil {
+		proxyID = auth.ProxyID
+		fallbackURL = auth.ProxyURL
+	}
+	return strings.TrimSpace(cfg.ResolveProxyURL(proxyID, fallbackURL))
+}
+
 // newProxyAwareHTTPClient creates an HTTP client with proper proxy configuration priority:
 // 1. Use auth.ProxyID when it resolves to an enabled proxy-pool entry
 // 2. Use auth.ProxyURL if configured

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -493,7 +493,9 @@ func (e *QwenExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*c
 		return auth, nil
 	}
 
-	svc := qwenauth.NewQwenAuth(e.cfg)
+	// Refresh goes out through this credential's own proxy, not the process
+	// default, so the token is renewed from the address that uses it.
+	svc := qwenauth.NewQwenAuthWithProxy(e.cfg, resolveAuthProxyURL(e.cfg, auth))
 	td, err := svc.RefreshTokens(ctx, refreshToken)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/refresh_proxy_test.go
+++ b/internal/runtime/executor/refresh_proxy_test.go
@@ -1,0 +1,95 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// TestResolveAuthProxyURLMatchesRequestEgress pins the property the outage came
+// down to: whatever proxy a credential's requests leave through, its token
+// refresh has to leave through the same one. Production had refresh on the
+// process default while requests used a proxy-pool entry, so upstream saw the
+// account acting from two regions and refused to refresh.
+func TestResolveAuthProxyURLMatchesRequestEgress(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{ProxyURL: "http://global.example:7890"},
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "pool-hk", Name: "HK", URL: "socks5://10.0.0.1:1080", Enabled: true},
+			{ID: "pool-off", Name: "Off", URL: "socks5://10.0.0.2:1080", Enabled: false},
+		},
+	}
+
+	tests := []struct {
+		name string
+		auth *cliproxyauth.Auth
+		want string
+	}{
+		{
+			name: "pool entry wins over global",
+			auth: &cliproxyauth.Auth{ProxyID: "pool-hk"},
+			want: "socks5://10.0.0.1:1080",
+		},
+		{
+			name: "auth url wins over global",
+			auth: &cliproxyauth.Auth{ProxyURL: "socks5://10.0.0.9:1080"},
+			want: "socks5://10.0.0.9:1080",
+		},
+		{
+			name: "disabled pool entry falls back to the auth url",
+			auth: &cliproxyauth.Auth{ProxyID: "pool-off", ProxyURL: "socks5://10.0.0.9:1080"},
+			want: "socks5://10.0.0.9:1080",
+		},
+		{
+			name: "no credential proxy keeps the global default",
+			auth: &cliproxyauth.Auth{},
+			want: "http://global.example:7890",
+		},
+		{
+			name: "nil auth keeps the global default",
+			auth: nil,
+			want: "http://global.example:7890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAuthProxyURL(cfg, tt.auth); got != tt.want {
+				t.Fatalf("resolveAuthProxyURL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The refresh path must agree with the request path by construction, so the two
+// resolvers are compared directly rather than restated as literals.
+func TestResolveAuthProxyURLAgreesWithRequestClientResolution(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{ProxyURL: "http://global.example:7890"},
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "pool-hk", Name: "HK", URL: "socks5://10.0.0.1:1080", Enabled: true},
+		},
+	}
+	auth := &cliproxyauth.Auth{ProxyID: "pool-hk", ProxyURL: "socks5://ignored.example:1080"}
+
+	want := cfg.ResolveProxyURL(auth.ProxyID, auth.ProxyURL)
+	if got := resolveAuthProxyURL(cfg, auth); got != want {
+		t.Fatalf("refresh proxy %q diverged from request proxy %q", got, want)
+	}
+}
+
+func TestResolveAuthProxyURLWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveAuthProxyURL(nil, &cliproxyauth.Auth{ProxyURL: "socks5://10.0.0.9:1080"}); got != "socks5://10.0.0.9:1080" {
+		t.Fatalf("resolveAuthProxyURL = %q, want the auth proxy", got)
+	}
+	if got := resolveAuthProxyURL(nil, nil); got != "" {
+		t.Fatalf("resolveAuthProxyURL = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## 现象

`lanlanjiaxin@proton.me` 报 `upstream authorization failed` 掉线，但用模型测试却"正常"。

## 根因

请求路径和 refresh 路径用了两套代理来源：

| 路径 | 代理来源 | 结果 |
| --- | --- | --- |
| 业务请求 | `newProxyAwareHTTPClient(ctx, cfg, auth, …)` → `auth.ProxyID` → proxy pool | 走 socks5 代理，正常 |
| token refresh | `NewCodexAuth(e.cfg)` → `util.SetProxy(&cfg.SDKConfig, …)` | 线上未配 `proxy-url`，**直连宿主机出口** |

宿主机出口在受限地区，于是 refresh 被拒：

```
403 {"error":{"code":"unsupported_country_region_territory",
              "message":"Country, region, or territory not supported"}}
```

线上取证：

```
last_refresh   2026-08-14 12:52      ← 最后一次成功刷新，10 天前
08:55          refresh 开始被拒（当天 164 次）
12:48          access_token 到期
12:52          首次 Suspended ... unauthorized
```

所以 refresh 已经坏了很多天，**账号是等到 access token 自然过期才崩的**，看起来像突发认证故障。同一代理下的第二个账号 `jd7njnb5nh` 当时仍在服务，只因为它的 token 还没到期——是同样的定时炸弹。

## 修改

新增 `resolveAuthProxyURL`，与 `newProxyAwareHTTPClient` **共用** `cfg.ResolveProxyURL`，所以两条路径不可能再漂移。Refresh 从此走该凭据自己的代理。

除了修掉这次故障，这也消除了"同一账号从两个地区活动"这个信号本身。

同一缺陷存在于所有从 config 单独构造 OAuth client 的 provider，按 AGENTS.md 一次修完：

- **codex**、**claude**、**qwen** 三个 `Refresh` 都改为传入凭据级代理
- **claude** 通过替换 dialer 配置而非 transport 来注入代理，**保留 Firefox TLS 指纹**（它靠这个过 Cloudflare，丢了等于用一个故障换另一个）
- **qwen** 保留 OAuth user agent
- claude 与 qwen 原先都直接持有 `&cfg.SDKConfig` 指针，现改为**复制**，避免钉住某个凭据的代理时污染其他调用方读到的共享配置

## 测试

- `TestResolveAuthProxyURLMatchesRequestEgress`：代理优先级（pool entry > auth url > 全局），含 disabled 条目回退与 nil auth
- `TestResolveAuthProxyURLAgreesWithRequestClientResolution`：直接与 `cfg.ResolveProxyURL` 对比，而不是把预期值重写一遍字面量——保证两条路径由构造保持一致
- `TestNewCodexAuthWithProxyPinsEgress`：断言 pinned 代理确实到达 `Transport.Proxy`（用 http scheme 以便可观测；socks5 走同一替换逻辑，落在 dialer 上）
- 三个 provider 各有"不污染共享配置"测试；claude 额外断言 transport 仍是 utls 指纹类型；qwen 额外断言 user agent 保留

## 已执行的校验

- `./scripts/ci-pr.sh`（完整门禁，绿）

## 上线后

`lanlanjiaxin` 的 access token 已过期，需要 refresh 成功一次才能恢复。部署后应能看到该账号 refresh 转为成功并解除 Suspended；`jd7njnb5nh` 则是在其 token 到期时不再重演。

## 不在本 PR 范围

排查中另外发现两个独立问题，各自需要单独处理：

1. **模型测试给假阳性**：前端请求体只有 `{model, messages, stream}`，无账号 pin，"渠道"仅决定用哪个 API key；请求进正常负载均衡。日志显示选 `lanlanjiaxin` 实际走了 `jd7njnb5nh`，所以账号已挂却测出"正常"。
2. **请求日志入库自 2026-08-19 04:34 起停摆**：`request_logs` 无新行，`request_log_storage_state` 最后更新 08-19 04:17，而容量（84MB/128MB、80882/100000 行）与投影 marker 均正常。文件层日志仍在生成。UI 看不到模型测试，是因为已 5 天没有任何新数据。