### PR TITLE
fix(auth): route OAuth traffic through the credential's own proxy

### DIFF
--- a/internal/api/handlers/management/auth_oauth.go
+++ b/internal/api/handlers/management/auth_oauth.go
@@ -126,6 +126,14 @@ func oauthProxyIDFromRequest(c *gin.Context) string {
 	return strings.TrimSpace(c.Query("proxy-id"))
 }
 
+func (h *Handler) resolveOAuthProxyURL(c *gin.Context) string {
+	proxyID := oauthProxyIDFromRequest(c)
+	if proxyID == "" {
+		return ""
+	}
+	return h.cfg.ResolveProxyURL(proxyID, "")
+}
+
 func (h *Handler) tenantOAuthBindings(c *gin.Context) (
 	authDir string,
 	saveRecord func(context.Context, *coreauth.Auth) (string, error),
@@ -159,6 +167,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	result, err := claudeprovider.StartOAuthLogin(ctx, claudeprovider.OAuthLoginOptions{
 		AuthDir:               authDir,
 		Config:                h.cfg,
+		ProxyURL:              h.resolveOAuthProxyURL(c),
 		WebUI:                 isWebUIRequest(c),
 		PreferredCallbackPort: anthropicCallbackPort,
 		CallbackTarget:        h.managementCallbackURL,
@@ -243,6 +252,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 	result, err := codexprovider.StartOAuthLogin(ctx, codexprovider.OAuthLoginOptions{
 		AuthDir:             authDir,
 		Config:              h.cfg,
+		ProxyURL:            h.resolveOAuthProxyURL(c),
 		WebUI:               isWebUIRequest(c),
 		CallbackPort:        codexCallbackPort,
 		CallbackTarget:      h.managementCallbackURL,
@@ -284,6 +294,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	result, err := antigravityprovider.StartOAuthLogin(ctx, antigravityprovider.OAuthLoginOptions{
 		AuthDir:             authDir,
 		Config:              h.cfg,
+		ProxyURL:            h.resolveOAuthProxyURL(c),
 		WebUI:               isWebUIRequest(c),
 		CallbackTarget:      h.managementCallbackURL,
 		WaitCallback:        WaitOAuthCallbackFile,
@@ -371,6 +382,7 @@ func (h *Handler) RequestXAIToken(c *gin.Context) {
 	result, err := xaiprovider.StartOAuthLogin(ctx, xaiprovider.OAuthLoginOptions{
 		AuthDir:             authDir,
 		Config:              h.cfg,
+		ProxyURL:            h.resolveOAuthProxyURL(c),
 		WebUI:               isWebUIRequest(c),
 		UsingAPI:            queryBool(c, "using_api"),
 		CallbackTarget:      h.managementCallbackURL,

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -36,6 +36,24 @@ type AntigravityAuth struct {
 	secret     string
 }
 
+// NewAntigravityAuthWithProxy is NewAntigravityAuth pinned to one egress proxy.
+// An empty proxyURL keeps the configured default.
+func NewAntigravityAuthWithProxy(cfg *config.Config, proxyURL string) *AntigravityAuth {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	sdkCfg := cfg.SDKConfig
+	if trimmed := strings.TrimSpace(proxyURL); trimmed != "" {
+		sdkCfg.ProxyURL = trimmed
+	}
+	clientID, clientSecret := cfg.OAuthClientCredentials(config.OAuthClientAntigravity)
+	return &AntigravityAuth{
+		httpClient: util.SetProxy(&sdkCfg, util.NewHTTPClient(util.DefaultHTTPClientTimeout)),
+		clientID:   clientID,
+		secret:     clientSecret,
+	}
+}
+
 // NewAntigravityAuth creates a new Antigravity auth service.
 func NewAntigravityAuth(cfg *config.Config, httpClient *http.Client) *AntigravityAuth {
 	if cfg == nil {

--- a/internal/management/oauth/providers/antigravity/flow.go
+++ b/internal/management/oauth/providers/antigravity/flow.go
@@ -49,6 +49,7 @@ type OAuthLoginOptions struct {
 	Config              *config.Config
 	Auth                OAuthAuth
 	AuthDir             string
+	ProxyURL            string
 	WebUI               bool
 	CallbackPort        int
 	CallbackWaitTimeout time.Duration
@@ -72,7 +73,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 
 	auth := opts.Auth
 	if auth == nil {
-		auth = internalantigravity.NewAntigravityAuth(opts.Config, nil)
+		auth = internalantigravity.NewAntigravityAuthWithProxy(opts.Config, opts.ProxyURL)
 	}
 
 	generateState := opts.GenerateState

--- a/internal/management/oauth/providers/claude/flow.go
+++ b/internal/management/oauth/providers/claude/flow.go
@@ -51,6 +51,7 @@ type OAuthLoginOptions struct {
 	Config                *config.Config
 	Auth                  OAuthAuth
 	AuthDir               string
+	ProxyURL              string
 	WebUI                 bool
 	PreferredCallbackPort int
 	CallbackWaitTimeout   time.Duration
@@ -92,7 +93,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 
 	auth := opts.Auth
 	if auth == nil {
-		auth = internalclaude.NewClaudeAuth(opts.Config)
+		auth = internalclaude.NewClaudeAuthWithProxy(opts.Config, opts.ProxyURL)
 	}
 
 	redirectURI, forwarder, callbackPort := resolveRedirectURI(opts)

--- a/internal/management/oauth/providers/codex/flow.go
+++ b/internal/management/oauth/providers/codex/flow.go
@@ -50,6 +50,7 @@ type OAuthLoginOptions struct {
 	Config              *config.Config
 	Auth                OAuthAuth
 	AuthDir             string
+	ProxyURL            string
 	WebUI               bool
 	CallbackPort        int
 	CallbackWaitTimeout time.Duration
@@ -91,7 +92,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 
 	auth := opts.Auth
 	if auth == nil {
-		auth = internalcodex.NewCodexAuth(opts.Config)
+		auth = internalcodex.NewCodexAuthWithProxy(opts.Config, opts.ProxyURL)
 	}
 	authURL, errAuthURL := auth.GenerateAuthURL(state, pkceCodes)
 	if errAuthURL != nil {

--- a/internal/management/oauth/providers/xai/flow.go
+++ b/internal/management/oauth/providers/xai/flow.go
@@ -51,6 +51,7 @@ type OAuthLoginOptions struct {
 	Config              *config.Config
 	Auth                OAuthAuth
 	AuthDir             string
+	ProxyURL            string
 	WebUI               bool
 	UsingAPI            bool
 	CallbackPort        int
@@ -95,7 +96,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 
 	auth := opts.Auth
 	if auth == nil {
-		auth = internalxai.NewXAIAuth(opts.Config)
+		auth = internalxai.NewXAIAuthWithProxyURL(opts.Config, opts.ProxyURL)
 	}
 	discovery, errDiscovery := auth.Discover(ctx)
 	if errDiscovery != nil {


### PR DESCRIPTION
## Summary

- Token refresh and initial OAuth code exchange both built HTTP clients from the process-wide config, ignoring the proxy-pool entry the operator chose in the login dialog
- On a Hong Kong host with no global proxy, `auth.openai.com` rejected both refresh and exchange requests with `403 unsupported_country_region_territory`
- Now both paths resolve `proxy_id` through `cfg.ResolveProxyURL` and pin the HTTP client to the credential's own egress, so upstream sees one consistent origin

## Changes

**Commit 1 — token refresh** (existing):
- Added `NewCodexAuthWithProxy` / `NewClaudeAuthWithProxy` / `NewQwenAuthWithProxy` constructors
- Added `resolveAuthProxyURL` helper in the executor package
- Codex, Claude, and Qwen executors now refresh through the credential's proxy

**Commit 2 — initial token exchange** (new):
- Each OAuth provider's `OAuthLoginOptions` gains a `ProxyURL` field
- `StartOAuthLogin` forwards it to the provider's `WithProxy` constructor
- Handler layer resolves `proxy_id` via `resolveOAuthProxyURL` before calling the flow
- Added `NewAntigravityAuthWithProxy` for consistency across all providers

## Test plan

- [x] `go build ./...` — clean
- [x] Unit tests for affected packages — all pass
- [ ] Deploy to staging and re-attempt Codex OAuth login with "美西 洛杉矶 住宅 ip" proxy selected
- [ ] Verify token refresh also uses the correct proxy (check logs for `unsupported_country_region_territory` absence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)