### PR TITLE
fix(antigravity): stop retrying the same account after a 429

### DIFF
--- a/internal/runtime/executor/antigravity_count_tokens.go
+++ b/internal/runtime/executor/antigravity_count_tokens.go
@@ -87,12 +87,11 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 			return cliproxyexecutor.Response{Payload: []byte(translated), Headers: httpResp.Header.Clone()}, nil
 		}
 
-		lastStatus = httpResp.StatusCode
-		lastBody = append([]byte(nil), bodyBytes...)
-		lastErr = nil
-		// 429 is an account-level RESOURCE_EXHAUSTED signal, not a
+		// This branch now always returns below, so it no longer needs to
+		// leave a lastStatus/lastBody/lastErr trail for the post-loop
+		// switch — 429 is an account-level RESOURCE_EXHAUSTED signal, not a
 		// host-specific hiccup: see antigravity_executor.go for the
-		// production trace that motivated dropping this fallback.
+		// production trace that motivated dropping the host fallback.
 		sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
 		if httpResp.StatusCode == http.StatusTooManyRequests {
 			if retryAfter, parseErr := parseRetryDelay(bodyBytes); parseErr == nil && retryAfter != nil {

--- a/internal/runtime/executor/antigravity_count_tokens.go
+++ b/internal/runtime/executor/antigravity_count_tokens.go
@@ -90,10 +90,9 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 		lastStatus = httpResp.StatusCode
 		lastBody = append([]byte(nil), bodyBytes...)
 		lastErr = nil
-		if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-			log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-			continue
-		}
+		// 429 is an account-level RESOURCE_EXHAUSTED signal, not a
+		// host-specific hiccup: see antigravity_executor.go for the
+		// production trace that motivated dropping this fallback.
 		sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
 		if httpResp.StatusCode == http.StatusTooManyRequests {
 			if retryAfter, parseErr := parseRetryDelay(bodyBytes); parseErr == nil && retryAfter != nil {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -203,10 +203,13 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
+				// 429 is an account-level RESOURCE_EXHAUSTED signal, not a
+				// host-specific hiccup: production traces show the same auth
+				// getting 429 on both sandbox and daily back to back, so
+				// falling back to the other host here only burns a second
+				// attempt on an account that's already known to be limited,
+				// leaving the outer selector fewer retries to reach a
+				// different, healthy account.
 				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
 					if idx+1 < len(baseURLs) {
 						log.Debugf("antigravity executor: no capacity on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])

--- a/internal/runtime/executor/antigravity_nonstream.go
+++ b/internal/runtime/executor/antigravity_nonstream.go
@@ -112,10 +112,9 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
+				// 429 is an account-level RESOURCE_EXHAUSTED signal, not a
+				// host-specific hiccup: see antigravity_executor.go for the
+				// production trace that motivated dropping this fallback.
 				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
 					if idx+1 < len(baseURLs) {
 						log.Debugf("antigravity executor: no capacity on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])


### PR DESCRIPTION
## Summary
- The sandbox/daily base URL fallback retried a 429 on the *same* auth account against the other host before giving up — wasting a retry attempt instead of moving to a different account.
- Production trace for `阮阳阳`'s Claude Code session today (`gemini-3.7-flash-high`, 15:24 CST) shows exactly this: 4 upstream calls, 2 accounts, each 429'd on **both** hosts back to back. RESOURCE_EXHAUSTED is account-level, not host-level, so the second host call never had a real chance.
- Removed the 429-triggers-host-fallback branch in the 3 executor paths that share it: `ExecuteStream`, `executeViaStreamEndpoint` (non-streaming), and `CountTokens`. Left `antigravity_models.go` alone — it has a broader any-status fallback, wasn't implicated by the trace, and is out of scope here.
- Complements `eede1113` (already on `dev`), which stops a transient 429 from parking an account behind a long quota cooldown. That fix governs whether an account is available for the *next* request; this one governs whether a single request's own retry loop wastes attempts on an account it just watched fail.

## Not fixed by this PR
The same trace shows this tenant's antigravity pool for `gemini-3.7-flash-high` currently has only 2 accounts (one of which is the admin's own personal account). A sustained agentic workload (Claude Code / Codex-style clients) can exhaust 2 personal accounts' per-minute rate limit regardless of retry efficiency — that's a pool-capacity/provisioning question, not something this change (or any retry-logic change) can solve. Flagging for a separate decision.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/runtime/executor/...`
- [x] `go test ./internal/runtime/executor/... -run Antigravity -v` — all existing antigravity tests pass unchanged, including the two that assert a 429 surfaces as an error (`TestAntigravityStreamFailureKeepsStreamingClassification`, `TestAntigravityNonStreamFailureStaysNonStreaming`)
- [ ] No new regression test added for the two-host fallback path specifically — doing so would need the base URL constants to be test-injectable (they're hardcoded `const`s), which felt like a separate, larger change. Happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)