### PR TITLE
fix(auth): persist the disabled flag through every store

### DIFF
--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -57,6 +57,10 @@ func ApplyStatusPatch(auth *coreauth.Auth, disabled bool, now time.Time) error {
 		auth.Status = coreauth.StatusActive
 		auth.StatusMessage = ""
 	}
+	// Keep the in-memory metadata projection aligned with the runtime flag.
+	// Stores mirror it again on save, but the manager hands this same metadata
+	// to field patches and list responses in between.
+	coreauth.SyncPersistedDisabled(auth)
 	auth.UpdatedAt = now
 	return nil
 }

--- a/internal/management/authfiles/patch_status_persistence_test.go
+++ b/internal/management/authfiles/patch_status_persistence_test.go
@@ -111,7 +111,7 @@ func TestPatchStatusPersistsDisabledAcrossReload(t *testing.T) {
 
 // ApplyStatusPatch owns the in-memory projection; stores mirror it again on save.
 func TestApplyStatusPatchSyncsMetadata(t *testing.T) {
-	auth := &coreauth.Auth{Status: coreauth.StatusActive}
+	auth := &coreauth.Auth{Status: coreauth.StatusActive, Metadata: map[string]any{"type": "codex"}}
 	if err := ApplyStatusPatch(auth, true, time.Time{}); err != nil {
 		t.Fatalf("ApplyStatusPatch: %v", err)
 	}
@@ -123,5 +123,23 @@ func TestApplyStatusPatchSyncsMetadata(t *testing.T) {
 	}
 	if auth.Metadata[coreauth.DisabledMetadataKey] != false {
 		t.Fatalf("metadata disabled = %#v, want false", auth.Metadata[coreauth.DisabledMetadataKey])
+	}
+}
+
+// Config-derived API keys live in config.yaml and own no auth file. Toggling one
+// must stay in memory instead of materializing a JSON file in the auth dir.
+func TestApplyStatusPatchLeavesConfigDerivedAuthUnpersisted(t *testing.T) {
+	auth := &coreauth.Auth{
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"source": "config:gemini[abc]", "api_key": "key"},
+	}
+	if err := ApplyStatusPatch(auth, true, time.Time{}); err != nil {
+		t.Fatalf("ApplyStatusPatch: %v", err)
+	}
+	if auth.Metadata != nil {
+		t.Fatalf("Metadata = %#v, want nil", auth.Metadata)
+	}
+	if !auth.Disabled || auth.Status != coreauth.StatusDisabled {
+		t.Fatalf("Disabled=%v Status=%q, want disabled", auth.Disabled, auth.Status)
 	}
 }

--- a/internal/management/authfiles/patch_status_persistence_test.go
+++ b/internal/management/authfiles/patch_status_persistence_test.go
@@ -1,0 +1,127 @@
+package authfiles
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	codexauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	sdkauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// The management toggle is only useful if it survives a reload: the auth file on
+// disk must carry the new state, and loading that file back must reproduce it.
+func TestPatchStatusPersistsDisabledAcrossReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex-toggle.json")
+	metadata := map[string]any{
+		"type":          "codex",
+		"email":         "toggle@example.com",
+		"access_token":  "at",
+		"refresh_token": "rt",
+		"disabled":      false,
+	}
+	seed, errMarshal := json.Marshal(metadata)
+	if errMarshal != nil {
+		t.Fatalf("Marshal: %v", errMarshal)
+	}
+	if errWrite := os.WriteFile(path, seed, 0o600); errWrite != nil {
+		t.Fatalf("WriteFile: %v", errWrite)
+	}
+
+	store := sdkauth.NewFileTokenStore()
+	store.SetBaseDir(dir)
+	manager := coreauth.NewManager(store, nil, nil)
+	if _, errRegister := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "codex-toggle.json",
+		FileName:   "codex-toggle.json",
+		Provider:   "codex",
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"path": path},
+		Metadata:   metadata,
+		// OAuth credentials keep a TokenStorage; the disabled flag has to be
+		// mirrored through it too.
+		Storage: &codexauth.CodexTokenStorage{
+			AccessToken:  "at",
+			RefreshToken: "rt",
+			Email:        "toggle@example.com",
+			Type:         "codex",
+		},
+	}); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	service := PatchService{Manager: manager, Repository: Repository{Store: store, BaseDir: dir}}
+
+	for _, step := range []struct {
+		name     string
+		disabled bool
+	}{
+		{name: "disable", disabled: true},
+		{name: "re-enable", disabled: false},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			disabled := step.disabled
+			result, errPatch := service.PatchStatus(context.Background(), StatusPatch{
+				Name:     "codex-toggle.json",
+				Disabled: &disabled,
+			})
+			if errPatch != nil {
+				t.Fatalf("PatchStatus: %v", errPatch)
+			}
+			if result.Disabled != step.disabled {
+				t.Fatalf("result disabled = %v, want %v", result.Disabled, step.disabled)
+			}
+
+			raw, errRead := os.ReadFile(path)
+			if errRead != nil {
+				t.Fatalf("ReadFile: %v", errRead)
+			}
+			onDisk := map[string]any{}
+			if errUnmarshal := json.Unmarshal(raw, &onDisk); errUnmarshal != nil {
+				t.Fatalf("Unmarshal: %v", errUnmarshal)
+			}
+			if onDisk["disabled"] != step.disabled {
+				t.Fatalf("on-disk disabled = %#v, want %v", onDisk["disabled"], step.disabled)
+			}
+
+			reloaded, errList := store.List(context.Background())
+			if errList != nil {
+				t.Fatalf("List: %v", errList)
+			}
+			if len(reloaded) != 1 {
+				t.Fatalf("reloaded auth count = %d, want 1", len(reloaded))
+			}
+			if reloaded[0].Disabled != step.disabled {
+				t.Fatalf("reloaded Disabled = %v, want %v", reloaded[0].Disabled, step.disabled)
+			}
+			wantStatus := coreauth.StatusActive
+			if step.disabled {
+				wantStatus = coreauth.StatusDisabled
+			}
+			if reloaded[0].Status != wantStatus {
+				t.Fatalf("reloaded Status = %q, want %q", reloaded[0].Status, wantStatus)
+			}
+		})
+	}
+}
+
+// ApplyStatusPatch owns the in-memory projection; stores mirror it again on save.
+func TestApplyStatusPatchSyncsMetadata(t *testing.T) {
+	auth := &coreauth.Auth{Status: coreauth.StatusActive}
+	if err := ApplyStatusPatch(auth, true, time.Time{}); err != nil {
+		t.Fatalf("ApplyStatusPatch: %v", err)
+	}
+	if auth.Metadata[coreauth.DisabledMetadataKey] != true {
+		t.Fatalf("metadata disabled = %#v, want true", auth.Metadata[coreauth.DisabledMetadataKey])
+	}
+	if err := ApplyStatusPatch(auth, false, time.Time{}); err != nil {
+		t.Fatalf("ApplyStatusPatch: %v", err)
+	}
+	if auth.Metadata[coreauth.DisabledMetadataKey] != false {
+		t.Fatalf("metadata disabled = %#v, want false", auth.Metadata[coreauth.DisabledMetadataKey])
+	}
+}

--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -244,6 +244,9 @@ func (s *GitTokenStore) Save(_ context.Context, auth *cliproxyauth.Auth) (string
 	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("auth filestore: create dir failed: %w", err)
 	}
+	// The committed auth JSON is the record of truth for this store, so the
+	// disabled flag has to be part of it.
+	cliproxyauth.SyncPersistedDisabled(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -450,6 +453,7 @@ func (s *GitTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, 
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
+	cliproxyauth.RestorePersistedDisabled(auth)
 	return auth, nil
 }
 

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -182,6 +182,9 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("object store: create auth directory: %w", err)
 	}
+	// Mirrors what the local auth JSON (and the uploaded object) must carry so a
+	// disable survives the next reload.
+	cliproxyauth.SyncPersistedDisabled(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -598,6 +601,7 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 		LastRefreshedAt:  time.Time{},
 		NextRefreshAfter: time.Time{},
 	}
+	cliproxyauth.RestorePersistedDisabled(auth)
 	return auth, nil
 }
 

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -235,6 +235,9 @@ func (s *PostgresStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (stri
 	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("postgres store: create auth directory: %w", err)
 	}
+	// The mirrored auth JSON is what List (and the file watcher) reads back, so
+	// the disabled flag must be part of the payload, not just runtime state.
+	cliproxyauth.SyncPersistedDisabled(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -337,6 +340,7 @@ func (s *PostgresStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error) 
 			LastRefreshedAt:  time.Time{},
 			NextRefreshAfter: time.Time{},
 		}
+		cliproxyauth.RestorePersistedDisabled(auth)
 		auths = append(auths, auth)
 	}
 	if err = rows.Err(); err != nil {

--- a/internal/store/postgresstore_disabled_test.go
+++ b/internal/store/postgresstore_disabled_test.go
@@ -1,0 +1,112 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// The Postgres store mirrors auth records to disk and back into the database.
+// Both copies have to carry the disabled flag, otherwise a management toggle is
+// lost on the next process start (or blue/green cutover).
+func TestPostgresStoreRoundTripsDisabledFlag(t *testing.T) {
+	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	ctx := context.Background()
+	schema := "auth_disabled_test_" + time.Now().UTC().Format("20060102150405")
+	store, err := NewPostgresStore(ctx, PostgresStoreConfig{DSN: dsn, Schema: schema, SpoolDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	defer store.Close()
+	defer func() { _, _ = store.db.ExecContext(ctx, `DROP SCHEMA IF EXISTS "`+schema+`" CASCADE`) }()
+	if err = store.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	const tenant = "00000000-0000-0000-0000-000000000001"
+	authID := tenant + "/codex-toggle.json"
+	path := filepath.Join(store.AuthDir(), tenant, "codex-toggle.json")
+	if errMkdir := os.MkdirAll(filepath.Dir(path), 0o700); errMkdir != nil {
+		t.Fatalf("MkdirAll: %v", errMkdir)
+	}
+	metadata := map[string]any{
+		"type":          "codex",
+		"email":         "toggle@example.com",
+		"access_token":  "at",
+		"refresh_token": "rt",
+		"disabled":      false,
+	}
+	seed, _ := json.Marshal(metadata)
+	if errWrite := os.WriteFile(path, seed, 0o600); errWrite != nil {
+		t.Fatalf("WriteFile: %v", errWrite)
+	}
+
+	auth := &cliproxyauth.Auth{
+		ID:         authID,
+		TenantID:   tenant,
+		Provider:   "codex",
+		FileName:   authID,
+		Status:     cliproxyauth.StatusActive,
+		Attributes: map[string]string{"path": path},
+		Metadata:   metadata,
+	}
+	if _, errSave := store.Save(ctx, auth); errSave != nil {
+		t.Fatalf("initial Save: %v", errSave)
+	}
+
+	for _, step := range []struct {
+		name     string
+		disabled bool
+		status   cliproxyauth.Status
+	}{
+		{name: "disable", disabled: true, status: cliproxyauth.StatusDisabled},
+		{name: "re-enable", disabled: false, status: cliproxyauth.StatusActive},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			auth.Disabled = step.disabled
+			auth.Status = step.status
+			if _, errSave := store.Save(ctx, auth); errSave != nil {
+				t.Fatalf("Save: %v", errSave)
+			}
+
+			raw, errRead := os.ReadFile(path)
+			if errRead != nil {
+				t.Fatalf("ReadFile: %v", errRead)
+			}
+			onDisk := map[string]any{}
+			if errUnmarshal := json.Unmarshal(raw, &onDisk); errUnmarshal != nil {
+				t.Fatalf("Unmarshal: %v", errUnmarshal)
+			}
+			if onDisk["disabled"] != step.disabled {
+				t.Fatalf("on-disk disabled = %#v, want %v", onDisk["disabled"], step.disabled)
+			}
+
+			var reloaded *cliproxyauth.Auth
+			auths, errList := store.List(ctx)
+			if errList != nil {
+				t.Fatalf("List: %v", errList)
+			}
+			for _, candidate := range auths {
+				if candidate != nil && candidate.ID == authID {
+					reloaded = candidate
+					break
+				}
+			}
+			if reloaded == nil {
+				t.Fatalf("auth %s missing after reload", authID)
+			}
+			if reloaded.Disabled != step.disabled || reloaded.Status != step.status {
+				t.Fatalf("reloaded Disabled=%v Status=%q, want %v/%q",
+					reloaded.Disabled, reloaded.Status, step.disabled, step.status)
+			}
+		})
+	}
+}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -107,12 +107,6 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 			}
 		}
 
-		disabled, _ := metadata["disabled"].(bool)
-		status := coreauth.StatusActive
-		if disabled {
-			status = coreauth.StatusDisabled
-		}
-
 		// Read per-account excluded models from the OAuth JSON file
 		perAccountExcluded := extractExcludedModelsFromMetadata(metadata)
 
@@ -123,8 +117,7 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 			FileName: name,
 			Label:    label,
 			Prefix:   prefix,
-			Status:   status,
-			Disabled: disabled,
+			Status:   coreauth.StatusActive,
 			Attributes: map[string]string{
 				"source": full,
 				"path":   full,
@@ -135,6 +128,7 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
+		coreauth.RestorePersistedDisabled(a)
 		// Read priority from auth file
 		if rawPriority, ok := metadata["priority"]; ok {
 			switch v := rawPriority.(type) {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -69,6 +69,10 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		return "", fmt.Errorf("auth filestore: create dir failed: %w", err)
 	}
 	syncRoutingMetadata(auth)
+	// Both branches serialize auth.Metadata, so the disabled flag has to be
+	// mirrored before either of them runs; the Storage branch used to skip it,
+	// which lost every enable/disable made on an OAuth credential.
+	cliproxyauth.SyncPersistedDisabled(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -77,7 +81,6 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 			return "", err
 		}
 	case auth.Metadata != nil:
-		auth.Metadata["disabled"] = auth.Disabled
 		raw, errMarshal := json.Marshal(auth.Metadata)
 		if errMarshal != nil {
 			return "", fmt.Errorf("auth filestore: marshal metadata failed: %w", errMarshal)
@@ -239,11 +242,6 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		return nil, fmt.Errorf("stat file: %w", err)
 	}
 	id := s.idFor(path, baseDir)
-	disabled, _ := metadata["disabled"].(bool)
-	status := cliproxyauth.StatusActive
-	if disabled {
-		status = cliproxyauth.StatusDisabled
-	}
 	auth := &cliproxyauth.Auth{
 		ID:               id,
 		TenantID:         cliproxyauth.TenantIDFromAuthID(id),
@@ -253,8 +251,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		ProxyID:          metadataString(metadata, "proxy_id", "proxy-id", "proxyId"),
 		FileName:         id,
 		Label:            s.labelFor(metadata),
-		Status:           status,
-		Disabled:         disabled,
+		Status:           cliproxyauth.StatusActive,
 		Attributes:       buildFileAuthAttributes(path, metadata),
 		Metadata:         metadata,
 		CreatedAt:        info.ModTime(),
@@ -262,6 +259,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		LastRefreshedAt:  time.Time{},
 		NextRefreshAfter: time.Time{},
 	}
+	cliproxyauth.RestorePersistedDisabled(auth)
 	return auth, nil
 }
 

--- a/sdk/auth/filestore_disabled_test.go
+++ b/sdk/auth/filestore_disabled_test.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	codexauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// OAuth credentials carry a TokenStorage, which used to bypass the disabled
+// mirror entirely: the management API reported success, the file kept the old
+// value, and the next reload flipped the credential back.
+func TestFileTokenStoreSavesDisabledThroughTokenStorage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex-account.json")
+	metadata := map[string]any{
+		"type":          "codex",
+		"email":         "account@example.com",
+		"access_token":  "at",
+		"refresh_token": "rt",
+		"disabled":      false,
+	}
+	writeJSON(t, path, metadata)
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auth := &cliproxyauth.Auth{
+		ID:         "codex-account.json",
+		FileName:   "codex-account.json",
+		Provider:   "codex",
+		Status:     cliproxyauth.StatusDisabled,
+		Disabled:   true,
+		Attributes: map[string]string{"path": path},
+		Metadata:   metadata,
+		Storage: &codexauth.CodexTokenStorage{
+			AccessToken:  "at",
+			RefreshToken: "rt",
+			Email:        "account@example.com",
+			Type:         "codex",
+		},
+	}
+	if _, err := store.Save(context.Background(), auth); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := readJSON(t, path)["disabled"]; got != true {
+		t.Fatalf("on-disk disabled = %#v, want true", got)
+	}
+
+	// Re-enabling has to clear the flag again, otherwise the account can be
+	// switched off but never back on.
+	auth.Disabled = false
+	auth.Status = cliproxyauth.StatusActive
+	if _, err := store.Save(context.Background(), auth); err != nil {
+		t.Fatalf("Save enabled: %v", err)
+	}
+	if got := readJSON(t, path)["disabled"]; got != false {
+		t.Fatalf("on-disk disabled = %#v, want false", got)
+	}
+}
+
+func TestFileTokenStoreListRestoresDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "codex-off.json"), map[string]any{
+		"type":     "codex",
+		"email":    "off@example.com",
+		"disabled": true,
+	})
+	writeJSON(t, filepath.Join(dir, "codex-on.json"), map[string]any{
+		"type":     "codex",
+		"email":    "on@example.com",
+		"disabled": false,
+	})
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	byID := make(map[string]*cliproxyauth.Auth, len(auths))
+	for _, auth := range auths {
+		byID[auth.ID] = auth
+	}
+	off := byID["codex-off.json"]
+	if off == nil || !off.Disabled || off.Status != cliproxyauth.StatusDisabled {
+		t.Fatalf("codex-off.json = %+v, want disabled", off)
+	}
+	on := byID["codex-on.json"]
+	if on == nil || on.Disabled || on.Status != cliproxyauth.StatusActive {
+		t.Fatalf("codex-on.json = %+v, want active", on)
+	}
+}
+
+func writeJSON(t *testing.T, path string, payload map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err = os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	out := map[string]any{}
+	if err = json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	return out
+}

--- a/sdk/cliproxy/auth/disabled_persistence.go
+++ b/sdk/cliproxy/auth/disabled_persistence.go
@@ -12,8 +12,13 @@ const DisabledMetadataKey = "disabled"
 // SyncPersistedDisabled mirrors the runtime Disabled flag into the metadata map
 // that stores serialize. Call it in every Store.Save implementation before the
 // auth file is written.
+//
+// A record with neither metadata nor token storage owns no auth file at all —
+// config-derived API keys live in config.yaml — so it is left untouched.
+// Creating a metadata map for one would make the manager treat it as
+// persistable and write a stray JSON file into the auth directory.
 func SyncPersistedDisabled(auth *Auth) {
-	if auth == nil {
+	if auth == nil || (auth.Metadata == nil && auth.Storage == nil) {
 		return
 	}
 	if auth.Metadata == nil {

--- a/sdk/cliproxy/auth/disabled_persistence.go
+++ b/sdk/cliproxy/auth/disabled_persistence.go
@@ -1,0 +1,65 @@
+package auth
+
+// The auth JSON on disk (and its mirror in the database) is the source of truth
+// for the enabled/disabled state of a credential. Auth.Disabled is the runtime
+// projection of that key, so every persistence backend has to write it back on
+// save and read it back on load. Keeping both directions here stops the four
+// store implementations from drifting apart again: a store that only wrote the
+// runtime field made "disable" survive until the next reload and then silently
+// flip back to enabled.
+const DisabledMetadataKey = "disabled"
+
+// SyncPersistedDisabled mirrors the runtime Disabled flag into the metadata map
+// that stores serialize. Call it in every Store.Save implementation before the
+// auth file is written.
+func SyncPersistedDisabled(auth *Auth) {
+	if auth == nil {
+		return
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any, 1)
+	}
+	auth.Metadata[DisabledMetadataKey] = auth.Disabled
+}
+
+// RestorePersistedDisabled projects the persisted metadata key back onto the
+// runtime fields. Call it in every Store.List implementation after an auth
+// record has been rebuilt from storage.
+//
+// Only an explicit true disables the credential: a missing key means the record
+// predates the flag and must stay usable.
+func RestorePersistedDisabled(auth *Auth) {
+	if auth == nil || auth.Metadata == nil {
+		return
+	}
+	disabled, ok := metadataBoolValue(auth.Metadata[DisabledMetadataKey])
+	if !ok || !disabled {
+		return
+	}
+	auth.Disabled = true
+	auth.Status = StatusDisabled
+}
+
+// metadataBoolValue accepts the shapes JSON round-trips produce for a boolean:
+// real bools, "true"/"false" strings written by hand-edited auth files, and the
+// numeric form some older exports used.
+func metadataBoolValue(raw any) (bool, bool) {
+	switch value := raw.(type) {
+	case bool:
+		return value, true
+	case string:
+		switch value {
+		case "true", "True", "TRUE", "1", "yes":
+			return true, true
+		case "false", "False", "FALSE", "0", "no":
+			return false, true
+		}
+	case float64:
+		return value != 0, true
+	case int:
+		return value != 0, true
+	case int64:
+		return value != 0, true
+	}
+	return false, false
+}

--- a/sdk/cliproxy/auth/disabled_persistence_test.go
+++ b/sdk/cliproxy/auth/disabled_persistence_test.go
@@ -3,7 +3,7 @@ package auth
 import "testing"
 
 func TestSyncPersistedDisabledMirrorsRuntimeFlag(t *testing.T) {
-	auth := &Auth{Disabled: true}
+	auth := &Auth{Disabled: true, Metadata: map[string]any{"type": "codex"}}
 	SyncPersistedDisabled(auth)
 	if auth.Metadata[DisabledMetadataKey] != true {
 		t.Fatalf("metadata[%s] = %#v, want true", DisabledMetadataKey, auth.Metadata[DisabledMetadataKey])
@@ -19,6 +19,31 @@ func TestSyncPersistedDisabledMirrorsRuntimeFlag(t *testing.T) {
 func TestSyncPersistedDisabledIgnoresNilAuth(t *testing.T) {
 	SyncPersistedDisabled(nil)
 }
+
+// Config-derived API keys carry neither metadata nor token storage: nothing of
+// them is serialized, and creating a metadata map would make the manager start
+// writing stray auth files for them.
+func TestSyncPersistedDisabledSkipsRecordsWithNothingToSerialize(t *testing.T) {
+	auth := &Auth{Disabled: true, Attributes: map[string]string{"api_key": "k"}}
+	SyncPersistedDisabled(auth)
+	if auth.Metadata != nil {
+		t.Fatalf("Metadata = %#v, want nil", auth.Metadata)
+	}
+}
+
+// An OAuth credential keeps its payload in TokenStorage; the flag still has to
+// reach the file the storage writes.
+func TestSyncPersistedDisabledSeedsMetadataForTokenStorage(t *testing.T) {
+	auth := &Auth{Disabled: true, Storage: stubTokenStorage{}}
+	SyncPersistedDisabled(auth)
+	if auth.Metadata[DisabledMetadataKey] != true {
+		t.Fatalf("metadata[%s] = %#v, want true", DisabledMetadataKey, auth.Metadata[DisabledMetadataKey])
+	}
+}
+
+type stubTokenStorage struct{}
+
+func (stubTokenStorage) SaveTokenToFile(string) error { return nil }
 
 func TestRestorePersistedDisabled(t *testing.T) {
 	cases := []struct {

--- a/sdk/cliproxy/auth/disabled_persistence_test.go
+++ b/sdk/cliproxy/auth/disabled_persistence_test.go
@@ -1,0 +1,90 @@
+package auth
+
+import "testing"
+
+func TestSyncPersistedDisabledMirrorsRuntimeFlag(t *testing.T) {
+	auth := &Auth{Disabled: true}
+	SyncPersistedDisabled(auth)
+	if auth.Metadata[DisabledMetadataKey] != true {
+		t.Fatalf("metadata[%s] = %#v, want true", DisabledMetadataKey, auth.Metadata[DisabledMetadataKey])
+	}
+
+	auth.Disabled = false
+	SyncPersistedDisabled(auth)
+	if auth.Metadata[DisabledMetadataKey] != false {
+		t.Fatalf("metadata[%s] = %#v, want false", DisabledMetadataKey, auth.Metadata[DisabledMetadataKey])
+	}
+}
+
+func TestSyncPersistedDisabledIgnoresNilAuth(t *testing.T) {
+	SyncPersistedDisabled(nil)
+}
+
+func TestRestorePersistedDisabled(t *testing.T) {
+	cases := []struct {
+		name         string
+		metadata     map[string]any
+		wantDisabled bool
+		wantStatus   Status
+	}{
+		{name: "missing key stays active", metadata: map[string]any{}, wantStatus: StatusActive},
+		{name: "explicit false stays active", metadata: map[string]any{"disabled": false}, wantStatus: StatusActive},
+		{
+			name:         "bool true disables",
+			metadata:     map[string]any{"disabled": true},
+			wantDisabled: true,
+			wantStatus:   StatusDisabled,
+		},
+		{
+			// Hand-edited auth files sometimes carry the flag as a string.
+			name:         "string true disables",
+			metadata:     map[string]any{"disabled": "true"},
+			wantDisabled: true,
+			wantStatus:   StatusDisabled,
+		},
+		{name: "string false stays active", metadata: map[string]any{"disabled": "false"}, wantStatus: StatusActive},
+		{name: "unparseable value stays active", metadata: map[string]any{"disabled": "maybe"}, wantStatus: StatusActive},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &Auth{Status: StatusActive, Metadata: tc.metadata}
+			RestorePersistedDisabled(auth)
+			if auth.Disabled != tc.wantDisabled {
+				t.Fatalf("Disabled = %v, want %v", auth.Disabled, tc.wantDisabled)
+			}
+			if auth.Status != tc.wantStatus {
+				t.Fatalf("Status = %q, want %q", auth.Status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// A metadata-less record must not panic and must not be forced into a state.
+func TestRestorePersistedDisabledIgnoresEmptyRecords(t *testing.T) {
+	RestorePersistedDisabled(nil)
+	auth := &Auth{Status: StatusActive}
+	RestorePersistedDisabled(auth)
+	if auth.Disabled || auth.Status != StatusActive {
+		t.Fatalf("Disabled=%v Status=%q, want active", auth.Disabled, auth.Status)
+	}
+}
+
+// Round-tripping must not resurrect a stale disable after the credential has
+// been re-enabled: the enable path has to overwrite the persisted key.
+func TestDisabledPersistenceRoundTrip(t *testing.T) {
+	auth := &Auth{Status: StatusActive, Metadata: map[string]any{"disabled": true}}
+	RestorePersistedDisabled(auth)
+	if !auth.Disabled {
+		t.Fatal("expected the persisted flag to disable the auth")
+	}
+
+	auth.Disabled = false
+	auth.Status = StatusActive
+	SyncPersistedDisabled(auth)
+
+	reloaded := &Auth{Status: StatusActive, Metadata: auth.Metadata}
+	RestorePersistedDisabled(reloaded)
+	if reloaded.Disabled || reloaded.Status != StatusActive {
+		t.Fatalf("after re-enable: Disabled=%v Status=%q, want active", reloaded.Disabled, reloaded.Status)
+	}
+}


### PR DESCRIPTION
## 问题

管理面板里禁用/启用 AI 账号只改了内存中的 `Auth.Disabled`，磁盘上的 auth JSON（以及它在数据库里的镜像）没有跟着变。而 `Store.List` 和文件 watcher 都是从这份 JSON 重建凭证的，于是：

- 账号被禁用后，任何一次重载（配置 reload、进程重启、蓝绿切换）都会把它悄悄改回启用；
- 一个已经被写成 `disabled: true` 的账号，点"启用"在内存里生效、落盘却没变，重载后又变回禁用——用户看到的就是"启用点了没用"。

线上取证：`/opt/clirelay2/logs/main.log` 里连续 10 次 `PATCH /v0/management/auth-files/status` 全返回 200，但磁盘文件只在最初两次发生变化。

## 根因

`disabled` 这个状态没有单一真源：运行时字段 `Auth.Disabled` 与持久化键 `metadata["disabled"]` 各写各的。

- 只有 `FileTokenStore` 的 metadata 分支会补写 `metadata["disabled"]`；
- 它的 Storage 分支（所有 OAuth 凭证走这条）不写；
- `postgresstore` / `objectstore` / `gitstore` 两条分支都不写；
- 上面三个 store 的 `List` 还把 `Status` 硬编码成 `StatusActive`，完全忽略已持久化的禁用状态。

## 改动

在 `sdk/cliproxy/auth` 增加一对共享 helper，把两个方向都收敛到一处，避免四个 store 再次漂移：

- `SyncPersistedDisabled(auth)`：序列化前把运行时标志镜像进 metadata；
- `RestorePersistedDisabled(auth)`：从存储重建记录后投影回运行时字段。

四个 store 的 `Save`/`List`、watcher 的 synthesizer 统一改用它。`ApplyStatusPatch` 也同步内存中的 metadata 投影——manager 会把同一份 map 交给字段补丁和列表响应。

`RestorePersistedDisabled` 只认显式的 true（含手工编辑常见的 `"true"` 字符串），缺失该键的历史记录保持可用。

## 验证

- `./scripts/ci-pr.sh` 全绿（结构检查、gofmt、go vet、`go test ./...`、golangci-lint、build）
- `CLIRELAY_POSTGRES_TEST_DSN=... go test ./internal/store/ -run Disabled`：Postgres 往返（含 List 重载）通过
- 本地起真实服务端到端验证（文件存储）：
  - 禁用 → 接口 `disabled=true`、文件 `disabled=true`
  - 重启 → 仍为禁用
  - 启用 → 接口/文件均回到 `false`
  - 再重启 → 仍为启用
- 新增回归测试：helper 单测、filestore 的 Storage 分支往返、管理 API PatchStatus → 落盘 → 重载、Postgres store 往返（无 DSN 时 skip）

## 影响面

`CliRelay`：auth 持久化（四个 store）、管理 API 状态补丁、watcher synthesizer。前端配套改动见 codeProxy 的 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)