### PR TITLE
fix(usage): roll the quota cycle when the upstream refills the allowance

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -278,7 +278,12 @@ func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 			// After realign: that pass folds fragments onto the stored anchor, and
 			// this one may then move that anchor to the period it should have
 			// rolled into.
-			return usage.RunAIAccountSubjectCycleRolloverRepairAtInit()
+			if err := usage.RunAIAccountSubjectCycleRolloverRepairAtInit(); err != nil {
+				return err
+			}
+			// Last: it repairs the anchors the metered-probe pass above cannot see,
+			// those held on a period the upstream refilled rather than spent out.
+			return usage.RunAIAccountSubjectCycleRefillRepairAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/usage/ai_account_subject_cycle_rollover_repair.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_repair.go
@@ -10,7 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const aiAccountSubjectCycleRolloverRepairMarker = "ai_account_subject_cycle_rollover_repair_v1"
+const (
+	aiAccountSubjectCycleRolloverRepairMarker = "ai_account_subject_cycle_rollover_repair_v1"
+	aiAccountSubjectCycleRefillRepairMarker   = "ai_account_subject_cycle_refill_repair_v1"
+)
 
 type meteredWeeklyQuotaProbe struct {
 	resetAt       time.Time
@@ -49,7 +52,38 @@ func RunAIAccountSubjectCycleRolloverRepairAtInit() error {
 	return runAIAccountSubjectCycleRolloverRepairDB(getDB())
 }
 
+// RunAIAccountSubjectCycleRefillRepairAtInit repairs the anchors the metering rule
+// could not: those held on a period the upstream refilled rather than spent out.
+//
+// A refilled period sits at a full allowance until the account draws on it, so the
+// pass above — which only trusts metered probes — has no probe to roll them with,
+// and the anchor stays frozen with the new period's usage landing in the old
+// period's bucket for as long as the account leaves the fresh allowance alone.
+func RunAIAccountSubjectCycleRefillRepairAtInit() error {
+	return runAIAccountSubjectCycleRefillRepairDB(getDB())
+}
+
 func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
+	return runAIAccountSubjectCycleAnchorRepairDB(db, aiAccountSubjectCycleRolloverRepairMarker,
+		loadLatestMeteredWeeklyQuotaProbes, aiAccountSubjectQuotaObservation{metering: true})
+}
+
+func runAIAccountSubjectCycleRefillRepairDB(db *sql.DB) error {
+	return runAIAccountSubjectCycleAnchorRepairDB(db, aiAccountSubjectCycleRefillRepairMarker,
+		loadLatestWeeklyQuotaRefillProbes, aiAccountSubjectQuotaObservation{refilled: true})
+}
+
+// runAIAccountSubjectCycleAnchorRepairDB rolls stored anchors forward onto the
+// period a probe shows is live, and rebuilds the usage buckets on both sides of
+// the move. The probe loader and the observation it stands for are the only
+// difference between the passes, so both judge with the same rule the running
+// server uses and cannot disagree with it about which period an account is in.
+func runAIAccountSubjectCycleAnchorRepairDB(
+	db *sql.DB,
+	marker string,
+	loadProbes func(*sql.DB) (map[string]meteredWeeklyQuotaProbe, error),
+	observed aiAccountSubjectQuotaObservation,
+) error {
 	if db == nil {
 		return nil
 	}
@@ -58,7 +92,7 @@ func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
 	defer usageProjectionMu.Unlock()
 
 	ensureUsageProjectionMarkerTable(db)
-	if projectionMarkerValue(db, aiAccountSubjectCycleRolloverRepairMarker) == rollupMarkerDone {
+	if projectionMarkerValue(db, marker) == rollupMarkerDone {
 		return nil
 	}
 
@@ -66,7 +100,7 @@ func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	probes, err := loadLatestMeteredWeeklyQuotaProbes(db)
+	probes, err := loadProbes(db)
 	if err != nil {
 		return err
 	}
@@ -85,41 +119,70 @@ func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
 
 	now := time.Now().UTC()
 	repaired := 0
+	anchorsRolled := 0
 	for _, subjectID := range subjectIDs {
 		cycles := cyclesBySubject[subjectID]
 		before, hadBefore := selectAIAccountSubjectWeeklyCycle(cycles)
 
-		changed := false
+		if !hadBefore {
+			continue
+		}
+		rolled := false
 		for i, cycle := range cycles {
 			probe, ok := probes[aiAccountSubjectQuotaProbeKey(subjectID, cycle.QuotaKey)]
 			if !ok {
 				continue
 			}
-			rolled, ok := aiAccountSubjectCycleRolloverFromProbe(cycle, probe)
+			next, ok := aiAccountSubjectCycleRolloverFromProbe(cycle, probe, observed)
 			if !ok {
 				continue
 			}
-			if err := writeAIAccountSubjectQuotaCycleAnchorTx(tx, rolled); err != nil {
+			if err := writeAIAccountSubjectQuotaCycleAnchorTx(tx, next); err != nil {
 				return err
 			}
-			cycles[i] = rolled
-			changed = true
+			cycles[i] = next
+			rolled = true
 		}
-		if !changed || !hadBefore {
-			continue
+		if rolled {
+			anchorsRolled++
 		}
 		after, hadAfter := selectAIAccountSubjectWeeklyCycle(cycles)
-		if !hadAfter || !after.CycleStartAt.After(before.CycleStartAt) {
+		if !hadAfter {
 			continue
 		}
-		moved, err := repairAIAccountSubjectCycleBucketsTx(tx, subjectID, before.CycleStartAt, after.CycleStartAt, now)
+		previousStart := before.CycleStartAt
+		if !after.CycleStartAt.After(before.CycleStartAt) {
+			// The anchor already names the period the probe describes, so there is
+			// nothing to roll — but a frozen anchor rolls on its own the moment the
+			// account spends into the fresh allowance, and everything it served while
+			// frozen stays filed under the period before it. The bucket boundary is
+			// then the only thing left wrong, and the period that kept those requests
+			// is the one whose bucket precedes this period's.
+			probe, ok := probes[aiAccountSubjectQuotaProbeKey(subjectID, after.QuotaKey)]
+			if !ok || !aiAccountSubjectCycleMatchesProbe(after, probe) {
+				continue
+			}
+			earlier, found, err := previousAIAccountSubjectCycleBucketStartTx(tx, subjectID, after.CycleStartAt)
+			if err != nil {
+				return err
+			}
+			if !found {
+				continue
+			}
+			previousStart = earlier
+		}
+		moved, err := repairAIAccountSubjectCycleBucketsTx(tx, subjectID, previousStart, after.CycleStartAt, now)
 		if err != nil {
 			return err
+		}
+		if moved == 0 && !rolled {
+			continue
 		}
 		repaired++
 		log.WithFields(log.Fields{
 			"auth_subject_id": subjectID,
-			"from":            before.CycleStartAt.Format(time.RFC3339),
+			"marker":          marker,
+			"from":            previousStart.Format(time.RFC3339),
 			"to":              after.CycleStartAt.Format(time.RFC3339),
 			"moved_requests":  moved,
 		}).Info("usage: repaired a cycle anchor held on an ended period")
@@ -131,18 +194,57 @@ func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
 		ON CONFLICT(marker_key) DO UPDATE SET
 			marker_value = excluded.marker_value,
 			updated_at = excluded.updated_at
-	`, aiAccountSubjectCycleRolloverRepairMarker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
+	`, marker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
 		return fmt.Errorf("usage: mark shared subject cycle rollover repair: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("usage: commit shared subject cycle rollover repair: %w", err)
 	}
-	if repaired > 0 {
+	if repaired > 0 || anchorsRolled > 0 {
 		// The projection keys its buckets off this cache; drop it so the next write
 		// re-reads the anchors this pass rolled.
 		resetAIAccountSubjectCycleCache()
 	}
 	return nil
+}
+
+// aiAccountSubjectCycleMatchesProbe reports whether a probe describes the period
+// the stored anchor already names, which is what separates "the anchor rolled on
+// its own and left usage behind" from "this probe has nothing to do with the
+// stored period".
+func aiAccountSubjectCycleMatchesProbe(cycle AIAccountSubjectQuotaCycle, probe meteredWeeklyQuotaProbe) bool {
+	if probe.windowSeconds != cycle.WindowSeconds || probe.resetAt.IsZero() {
+		return false
+	}
+	start := probe.resetAt.Add(-time.Duration(probe.windowSeconds) * time.Second)
+	return sameAIAccountSubjectCycle(start, cycle.CycleStartAt, cycle.WindowSeconds)
+}
+
+// previousAIAccountSubjectCycleBucketStartTx finds the bucket a period's requests
+// were being added to before the anchor named that period. Bucket starts are
+// stored as UTC RFC3339, so ordering them as text orders them in time.
+func previousAIAccountSubjectCycleBucketStartTx(
+	tx *sql.Tx,
+	subjectID string,
+	before time.Time,
+) (time.Time, bool, error) {
+	var start storedTime
+	err := tx.QueryRow(`
+		SELECT bucket_start
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start < ?
+		ORDER BY bucket_start DESC LIMIT 1
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(before)).Scan(&start)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("usage: load preceding cycle bucket: %w", err)
+	}
+	if !start.Valid {
+		return time.Time{}, false, nil
+	}
+	return start.Time.UTC(), true, nil
 }
 
 func aiAccountSubjectQuotaProbeKey(subjectID, quotaKey string) string {
@@ -187,12 +289,69 @@ func loadLatestMeteredWeeklyQuotaProbes(db *sql.DB) (map[string]meteredWeeklyQuo
 	return out, rows.Err()
 }
 
+// loadLatestWeeklyQuotaRefillProbes keeps, per window, the newest probe that found
+// a full allowance directly after a metered one.
+//
+// The metered-probe pass cannot reach a period that was refilled rather than spent
+// out: its newest metered probe still describes the period that was consumed, which
+// is the one already stored. The step up into a full allowance is the only record
+// that the upstream ended that period, and it stays in the history for as long as
+// the fresh allowance goes untouched.
+//
+// The step is tracked in Go rather than with a window function because this store
+// runs on both SQLite and Postgres, and it reuses the running server's observation
+// rule so a repaired anchor is one the server would also have rolled.
+func loadLatestWeeklyQuotaRefillProbes(db *sql.DB) (map[string]meteredWeeklyQuotaProbe, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, quota_key, percent, reset_at, window_seconds, recorded_at
+		FROM ai_account_subject_quota_points
+		WHERE window_seconds >= ?
+		ORDER BY recorded_at ASC
+	`, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query weekly quota refill probes: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]meteredWeeklyQuotaProbe)
+	previousPercent := make(map[string]*float64)
+	for rows.Next() {
+		var subjectID, quotaKey string
+		var percent sql.NullFloat64
+		var reset, recorded storedTime
+		var windowSeconds int64
+		if err := rows.Scan(&subjectID, &quotaKey, &percent, &reset, &windowSeconds, &recorded); err != nil {
+			return nil, fmt.Errorf("usage: scan weekly quota refill probe: %w", err)
+		}
+		subjectID = strings.TrimSpace(subjectID)
+		quotaKey = strings.TrimSpace(quotaKey)
+		if subjectID == "" || quotaKey == "" || windowSeconds <= 0 {
+			continue
+		}
+		key := aiAccountSubjectQuotaProbeKey(subjectID, quotaKey)
+		current := nullableProbePercent(percent)
+		observed := newAIAccountSubjectQuotaObservation(previousPercent[key], current)
+		previousPercent[key] = current
+		if !observed.refilled || !reset.Valid || !recorded.Valid {
+			continue
+		}
+		// Ascending order means a later refill replaces an earlier one.
+		out[key] = meteredWeeklyQuotaProbe{
+			resetAt:       reset.Time.UTC(),
+			windowSeconds: windowSeconds,
+			recordedAt:    recorded.Time.UTC(),
+		}
+	}
+	return out, rows.Err()
+}
+
 // aiAccountSubjectCycleRolloverFromProbe applies the live anchoring rule to a
 // stored row, so the repair and the running server cannot disagree about which
 // period an account is in.
 func aiAccountSubjectCycleRolloverFromProbe(
 	stored AIAccountSubjectQuotaCycle,
 	probe meteredWeeklyQuotaProbe,
+	observed aiAccountSubjectQuotaObservation,
 ) (AIAccountSubjectQuotaCycle, bool) {
 	if stored.CycleStartAt.IsZero() || probe.windowSeconds != stored.WindowSeconds {
 		return stored, false
@@ -211,7 +370,7 @@ func aiAccountSubjectCycleRolloverFromProbe(
 	if sameAIAccountSubjectCycle(incoming.CycleStartAt, stored.CycleStartAt, stored.WindowSeconds) {
 		return stored, false
 	}
-	if !aiAccountSubjectCycleRollover(incoming, stored.ResetAt, true) {
+	if !aiAccountSubjectCycleRollover(incoming, stored.ResetAt, observed) {
 		return stored, false
 	}
 	// The metering probe a period is derived from can be older than the last probe
@@ -240,9 +399,21 @@ func writeAIAccountSubjectQuotaCycleAnchorTx(tx *sql.Tx, cycle AIAccountSubjectQ
 // bucket the frozen anchor kept it in.
 //
 // The request log is the only record with the per-request timestamps needed to
-// split them, so the new period is recomputed from it and the same totals are
-// taken back off the previous bucket. Whatever the log no longer covers stays
-// where it is: totals move between buckets but are never invented or lost.
+// split them, so the new period is recomputed from it and only what its bucket
+// was still missing is taken back off the previous one. Whatever the log no longer
+// covers stays where it is: totals move between buckets but are never invented or
+// lost.
+//
+// Charging the previous period the whole recomputed total would double-count a
+// period that has already been partly moved, and that is the common case rather
+// than a corner one: an anchor frozen on a refilled period rolls on its own as
+// soon as the account spends into the fresh allowance, so its bucket already holds
+// everything after the rollover and only the requests from before it are still
+// misfiled. Production, 2026-08-25: a Codex account's new period held 6 requests
+// against 162 in the log, the other 156 left behind in the previous week.
+//
+// Recomputing to a smaller total means the log has aged out from under the bucket,
+// so the bucket is left alone: a repair may complete a period, never truncate one.
 func repairAIAccountSubjectCycleBucketsTx(
 	tx *sql.Tx,
 	subjectID string,
@@ -255,13 +426,52 @@ func repairAIAccountSubjectCycleBucketsTx(
 	if totals.requests == 0 {
 		return 0, nil
 	}
+	stored, err := readAIAccountSubjectCycleBucketTotalsTx(tx, subjectID, newStart)
+	if err != nil {
+		return 0, err
+	}
+	if totals.requests <= stored.requests {
+		return 0, nil
+	}
+	missing := aiAccountSubjectCycleTotalsDifference(totals, stored)
 	if err := writeAIAccountSubjectCycleBucketTx(tx, subjectID, newStart, totals); err != nil {
 		return 0, err
 	}
-	if err := subtractAIAccountSubjectCycleBucketTx(tx, subjectID, previousStart, totals); err != nil {
+	if err := subtractAIAccountSubjectCycleBucketTx(tx, subjectID, previousStart, missing); err != nil {
 		return 0, err
 	}
-	return totals.requests, nil
+	return missing.requests, nil
+}
+
+func readAIAccountSubjectCycleBucketTotalsTx(
+	tx *sql.Tx,
+	subjectID string,
+	start time.Time,
+) (aiAccountSubjectCycleTotals, error) {
+	var totals aiAccountSubjectCycleTotals
+	err := tx.QueryRow(`
+		SELECT request_count, success_count, failure_count, cost_total, total_tokens
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(start)).
+		Scan(&totals.requests, &totals.successes, &totals.failures, &totals.cost, &totals.tokens)
+	if err == sql.ErrNoRows {
+		return aiAccountSubjectCycleTotals{}, nil
+	}
+	if err != nil {
+		return totals, fmt.Errorf("usage: load repaired cycle bucket totals: %w", err)
+	}
+	return totals, nil
+}
+
+func aiAccountSubjectCycleTotalsDifference(from, subtract aiAccountSubjectCycleTotals) aiAccountSubjectCycleTotals {
+	return aiAccountSubjectCycleTotals{
+		requests:  clampNonNegativeInt64(from.requests - subtract.requests),
+		successes: clampNonNegativeInt64(from.successes - subtract.successes),
+		failures:  clampNonNegativeInt64(from.failures - subtract.failures),
+		cost:      clampNonNegativeFloat64(from.cost - subtract.cost),
+		tokens:    clampNonNegativeInt64(from.tokens - subtract.tokens),
+	}
 }
 
 func sumAIAccountSubjectRequestLogsTx(

--- a/internal/usage/ai_account_subject_cycle_rollover_test.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_test.go
@@ -86,6 +86,68 @@ func TestWeeklyCycleRollsWhenUpstreamEndsPeriodEarly(t *testing.T) {
 	}
 }
 
+// Production, 2026-08-25: two Codex accounts had code_week step from 55% and 70%
+// straight back to a full allowance, against resets a week past the stored ones.
+// The upstream had ended those periods early, but a refilled period is at a full
+// allowance by definition, so the metering rule could never admit the very probe
+// that announces one: both anchors stayed on the period that began on the 24th
+// while the new period's requests kept being added to it, and one card reported
+// 12311 requests and 1.4B tokens for two periods added together.
+func TestWeeklyCycleRollsWhenUpstreamRefillsTheAllowance(t *testing.T) {
+	// The two accounts described the same refill differently, so the anchor has to
+	// take both shapes: one reported a fixed period edge, the other "this instant
+	// plus a whole window" — which is what an untouched bucket reports too, and is
+	// why the refill itself has to be the evidence.
+	for _, shape := range []struct {
+		name           string
+		resetFromProbe time.Duration
+	}{
+		{name: "fixed period edge", resetFromProbe: 7*24*time.Hour - 14*time.Minute},
+		{name: "full window from the probe", resetFromProbe: 7 * 24 * time.Hour},
+	} {
+		t.Run(shape.name, func(t *testing.T) {
+			initSharedSubjectTestDB(t)
+			subjectID := "authsub_codex_refill"
+
+			spentProbe := time.Now().UTC().Truncate(time.Second).Add(-3 * time.Hour)
+			spentReset := spentProbe.Add(5 * 24 * time.Hour)
+			spent := 55.0
+			if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+				RecordedAt: spentProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+				Percent: &spent, ResetAt: &spentReset, WindowSeconds: weeklyWindowSeconds,
+			}}); err != nil {
+				t.Fatal(err)
+			}
+
+			refillProbe := spentProbe.Add(time.Hour)
+			refillReset := refillProbe.Add(shape.resetFromProbe)
+			full := 100.0
+			if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+				RecordedAt: refillProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+				Percent: &full, ResetAt: &refillReset, WindowSeconds: weeklyWindowSeconds,
+			}}); err != nil {
+				t.Fatal(err)
+			}
+
+			start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+			wantStart := refillReset.Add(-7 * 24 * time.Hour)
+			if !start.Equal(wantStart) || !reset.Equal(refillReset) {
+				t.Fatalf("anchor = %v..%v, want the refilled period %v..%v",
+					start, reset, wantStart, refillReset)
+			}
+
+			// The period the card reports and the one the projection writes into have
+			// to be the same, or the fresh allowance's usage is added to the period
+			// the upstream just ended.
+			projectSubjectRequest(t, subjectID, refillProbe.Add(time.Minute), 40)
+			got := readCycleSummary(t, subjectID)
+			if !got.CycleKnown || got.CycleRequestTotal != 1 || got.CycleTotalTokens != 40 {
+				t.Fatalf("cycle summary = %+v, want the refilled period's single request", got)
+			}
+		})
+	}
+}
+
 // The guard that made the freeze possible has to keep working: a window the
 // account never touched answers every probe with a full window remaining, and
 // following that countdown re-keys the usage bucket on each pass.
@@ -283,5 +345,192 @@ func TestCycleRolloverRepairMovesUsageToTheLivePeriod(t *testing.T) {
 	}
 	if requests, _, _ := readCycleBucket(t, subjectID, frozenStart); requests != 2 {
 		t.Fatalf("previous bucket after rerun = %d requests, want 2", requests)
+	}
+}
+
+func insertQuotaPoint(t *testing.T, subjectID string, percent float64, resetAt, recordedAt time.Time) {
+	t.Helper()
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_points
+			(auth_subject_id, provider, quota_key, quota_label, percent, reset_at, window_seconds, recorded_at)
+		VALUES (?, 'codex', ?, 'Weekly', ?, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey, percent, resetAt.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, recordedAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func insertFrozenWeeklyAnchor(t *testing.T, subjectID string, start, reset, verifiedAt time.Time) {
+	t.Helper()
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'codex', ?, ?, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey, start.Format(time.RFC3339Nano), reset.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, verifiedAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The metered-probe repair cannot reach an anchor frozen on a period the upstream
+// refilled rather than spent out: every probe taken since the refill reports a full
+// allowance, so the newest metered probe is the one describing the frozen period
+// itself. Without a pass that reads the refill, these anchors stay wrong until the
+// account spends into the fresh allowance.
+func TestCycleRefillRepairMovesUsageToTheRefilledPeriod(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_repair_refilled"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	frozenStart := now.Add(-4 * 24 * time.Hour)
+	frozenReset := frozenStart.Add(7 * 24 * time.Hour)
+	insertFrozenWeeklyAnchor(t, subjectID, frozenStart, frozenReset, now)
+
+	// The history holds the step the anchor missed: metered on the frozen period,
+	// then a full allowance against a reset a week past it, and only full-allowance
+	// probes after that.
+	refillAt := now.Add(-90 * time.Minute)
+	refillReset := refillAt.Add(7 * 24 * time.Hour)
+	insertQuotaPoint(t, subjectID, 55, frozenReset, now.Add(-3*time.Hour))
+	insertQuotaPoint(t, subjectID, 100, refillReset, refillAt)
+	insertQuotaPoint(t, subjectID, 100, now.Add(-30*time.Minute).Add(7*24*time.Hour), now.Add(-30*time.Minute))
+
+	// Two requests in the period that ended, three in the refilled one — all five
+	// were counted into the frozen period's bucket.
+	events := []time.Time{
+		frozenStart.Add(time.Hour), frozenStart.Add(30 * time.Hour),
+		refillAt.Add(time.Minute), refillAt.Add(20 * time.Minute), refillAt.Add(80 * time.Minute),
+	}
+	for _, at := range events {
+		if _, err := getDB().Exec(`
+			INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, failed, cost, total_tokens)
+			VALUES ('default', ?, ?, 0, 2, 100)
+		`, at.Format(time.RFC3339Nano), subjectID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, 5, 5, 0, 10, 500, ?, ?)
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(frozenStart),
+		events[0].Format(time.RFC3339Nano), events[4].Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleRefillRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	if !start.Equal(refillAt) || !reset.Equal(refillReset) {
+		t.Fatalf("anchor = %v..%v, want the refilled period %v..%v", start, reset, refillAt, refillReset)
+	}
+	if requests, cost, tokens := readCycleBucket(t, subjectID, refillAt); requests != 3 || cost != 6 || tokens != 300 {
+		t.Fatalf("refilled bucket = %d requests / %v cost / %d tokens, want 3 / 6 / 300", requests, cost, tokens)
+	}
+	if requests, cost, tokens := readCycleBucket(t, subjectID, frozenStart); requests != 2 || cost != 4 || tokens != 200 {
+		t.Fatalf("previous bucket = %d requests / %v cost / %d tokens, want 2 / 4 / 200", requests, cost, tokens)
+	}
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 3 || got.CycleTotalTokens != 300 {
+		t.Fatalf("cycle summary = %+v, want the refilled period's 3 requests / 300 tokens", got)
+	}
+
+	if err := runAIAccountSubjectCycleRefillRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	if requests, _, _ := readCycleBucket(t, subjectID, frozenStart); requests != 2 {
+		t.Fatalf("previous bucket after rerun = %d requests, want 2", requests)
+	}
+}
+
+// A frozen anchor rolls on its own the moment the account spends into the fresh
+// allowance, which leaves the anchor right and the buckets wrong: everything
+// served while it was frozen is still filed under the period before it, and the
+// anchor no longer needs moving so nothing goes looking for it. Production,
+// 2026-08-25: a Codex account's refilled period held 6 requests against 162 in
+// the request log, the other 156 left in the previous week's bucket.
+func TestCycleRefillRepairCompletesAPeriodTheAnchorRolledIntoLate(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_repair_late_roll"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	previousStart := now.Add(-2 * 24 * time.Hour)
+	refillAt := now.Add(-2 * time.Hour)
+	refillReset := refillAt.Add(7 * 24 * time.Hour)
+
+	insertFrozenWeeklyAnchor(t, subjectID, refillAt, refillReset, now)
+	insertQuotaPoint(t, subjectID, 55, previousStart.Add(7*24*time.Hour), now.Add(-3*time.Hour))
+	insertQuotaPoint(t, subjectID, 100, refillReset, refillAt)
+
+	// One request in the period that ended and five in the refilled one, of which
+	// the bucket only caught the two served after the anchor rolled.
+	events := []time.Time{
+		previousStart.Add(time.Hour),
+		refillAt.Add(time.Minute), refillAt.Add(2 * time.Minute), refillAt.Add(3 * time.Minute),
+		refillAt.Add(90 * time.Minute), refillAt.Add(100 * time.Minute),
+	}
+	for _, at := range events {
+		if _, err := getDB().Exec(`
+			INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, failed, cost, total_tokens)
+			VALUES ('default', ?, ?, 0, 2, 100)
+		`, at.Format(time.RFC3339Nano), subjectID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, 4, 4, 0, 8, 400, ?, ?), (?, 'cycle', ?, 2, 2, 0, 4, 200, ?, ?)
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(previousStart),
+		events[0].Format(time.RFC3339Nano), events[3].Format(time.RFC3339Nano),
+		subjectID, formatAIAccountSubjectCycleBucketStart(refillAt),
+		events[4].Format(time.RFC3339Nano), events[5].Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleRefillRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	if start, _ := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey); !start.Equal(refillAt) {
+		t.Fatalf("anchor = %v, want it left on the refilled period %v", start, refillAt)
+	}
+	if requests, cost, tokens := readCycleBucket(t, subjectID, refillAt); requests != 5 || cost != 10 || tokens != 500 {
+		t.Fatalf("refilled bucket = %d requests / %v cost / %d tokens, want 5 / 10 / 500", requests, cost, tokens)
+	}
+	// Only the three that were misfiled came off the previous period, not all five.
+	if requests, cost, tokens := readCycleBucket(t, subjectID, previousStart); requests != 1 || cost != 2 || tokens != 100 {
+		t.Fatalf("previous bucket = %d requests / %v cost / %d tokens, want 1 / 2 / 100", requests, cost, tokens)
+	}
+}
+
+// A window that has only ever answered "a full window remaining" never refilled,
+// because it never metered. Repairing it would move the anchor onto whatever the
+// last probe's countdown happened to say and re-key the usage bucket with it.
+func TestCycleRefillRepairLeavesNeverMeteredWindowsAlone(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_repair_untouched"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	storedStart := now.Add(-3 * 24 * time.Hour)
+	storedReset := storedStart.Add(7 * 24 * time.Hour)
+	insertFrozenWeeklyAnchor(t, subjectID, storedStart, storedReset, now)
+
+	for i := 3; i >= 1; i-- {
+		at := now.Add(-time.Duration(i) * time.Hour)
+		insertQuotaPoint(t, subjectID, 100, at.Add(7*24*time.Hour), at)
+	}
+
+	if err := runAIAccountSubjectCycleRefillRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	if !start.Equal(storedStart) || !reset.Equal(storedReset) {
+		t.Fatalf("anchor = %v..%v, want the stored period %v..%v left alone",
+			start, reset, storedStart, storedReset)
 	}
 }

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -59,21 +59,10 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 			}
 			point.Percent = &v
 		}
-		if point.ResetAt != nil && !point.ResetAt.IsZero() && point.WindowSeconds > 0 {
-			cycle := AIAccountSubjectQuotaCycle{
-				AuthSubjectID: authSubjectID, Provider: pointProvider, QuotaKey: key,
-				CycleStartAt: point.ResetAt.UTC().Add(-time.Duration(point.WindowSeconds) * time.Second),
-				ResetAt:      point.ResetAt.UTC(), WindowSeconds: point.WindowSeconds, LastVerifiedAt: recordedAt,
-			}
-			// Cache the anchored cycle, not the freshly derived one: the in-memory
-			// cache feeds the usage projection's bucket key, so seeding it with the
-			// jittered value would re-split the period the anchor just protected.
-			anchored, err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle, aiAccountSubjectQuotaWindowMetering(point.Percent))
-			if err != nil {
-				return err
-			}
-			cycles = append(cycles, anchored)
-		}
+		// The previous probe is loaded before anchoring, not only for the heartbeat
+		// de-duplication below: a period's end is a transition between two probes —
+		// a window that was metering and now reports a full allowance has been reset
+		// upstream — and a single probe cannot show it.
 		var latestAt sql.NullString
 		var latestPercent sql.NullFloat64
 		var latestReset sql.NullString
@@ -86,6 +75,26 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 		`, authSubjectID, key).Scan(&latestAt, &latestPercent, &latestReset, &latestWindow)
 		if err != nil && err != sql.ErrNoRows {
 			return err
+		}
+		var previousPercent *float64
+		if err == nil {
+			previousPercent = nullableProbePercent(latestPercent)
+		}
+		if point.ResetAt != nil && !point.ResetAt.IsZero() && point.WindowSeconds > 0 {
+			cycle := AIAccountSubjectQuotaCycle{
+				AuthSubjectID: authSubjectID, Provider: pointProvider, QuotaKey: key,
+				CycleStartAt: point.ResetAt.UTC().Add(-time.Duration(point.WindowSeconds) * time.Second),
+				ResetAt:      point.ResetAt.UTC(), WindowSeconds: point.WindowSeconds, LastVerifiedAt: recordedAt,
+			}
+			// Cache the anchored cycle, not the freshly derived one: the in-memory
+			// cache feeds the usage projection's bucket key, so seeding it with the
+			// jittered value would re-split the period the anchor just protected.
+			anchored, upsertErr := upsertAIAccountSubjectQuotaCycleTx(tx, cycle,
+				newAIAccountSubjectQuotaObservation(previousPercent, point.Percent))
+			if upsertErr != nil {
+				return upsertErr
+			}
+			cycles = append(cycles, anchored)
 		}
 		if err == nil {
 			latest, _ := parseStoredTimeString(latestAt.String)
@@ -130,7 +139,7 @@ func nullableStoredTimeEqual(stored sql.NullString, value *time.Time) bool {
 // and split one weekly period into fragments. Within the drift tolerance the
 // stored anchor wins and only last_verified_at moves; a real rollover shifts the
 // start by a whole window and falls outside the tolerance, so it still rolls.
-func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, metering bool) (AIAccountSubjectQuotaCycle, error) {
+func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, observed aiAccountSubjectQuotaObservation) (AIAccountSubjectQuotaCycle, error) {
 	var start, reset storedTime
 	var window int64
 	err := tx.QueryRow(`
@@ -152,7 +161,7 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 		storedReset = reset.Time.UTC()
 	}
 	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) &&
-		aiAccountSubjectCycleRollover(cycle, storedReset, metering) {
+		aiAccountSubjectCycleRollover(cycle, storedReset, observed) {
 		return cycle, nil
 	}
 	cycle.CycleStartAt = start.Time.UTC()
@@ -187,7 +196,22 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 // week while its usage kept accruing into the previous week's bucket. A window
 // that reports consumption is one the upstream is actually counting, so its
 // reset is a real period edge rather than an idle bucket's countdown.
-func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time, metering bool) bool {
+//
+// Metering alone still froze the moment it was meant to catch. A period that has
+// just been refilled is at a full allowance by definition, so the probe that first
+// sees the new period never meters, and rollover waited for the account to spend
+// into it. Production, 2026-08-25: two Codex accounts had code_week drop from 55%
+// and 70% to a full allowance against resets a week past the stored ones, and both
+// anchors stayed on the period that started on the 24th — one card counted 12311
+// requests and 1.4B tokens of two periods added together.
+//
+// The refill itself is therefore the evidence, and it is checked before the
+// countdown guard because the two are indistinguishable by shape: of those two
+// accounts one reported the new period against a fixed edge and the other against
+// "this instant plus a window", which is exactly what an untouched bucket reports.
+// Only the transition out of metering separates a period that just began from one
+// that never started.
+func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time, observed aiAccountSubjectQuotaObservation) bool {
 	if storedReset.IsZero() {
 		return true
 	}
@@ -200,7 +224,40 @@ func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedRe
 	if incoming.ResetAt.UTC().Before(storedReset) {
 		return true
 	}
-	return metering && !aiAccountSubjectCycleFullWindowCountdown(incoming)
+	if observed.refilled {
+		return true
+	}
+	return observed.metering && !aiAccountSubjectCycleFullWindowCountdown(incoming)
+}
+
+// aiAccountSubjectQuotaObservation is what two consecutive probes say about one
+// window. Anchoring is judged on the pair because the end of a period is a
+// transition — no single probe carries it.
+type aiAccountSubjectQuotaObservation struct {
+	// metering reports that this probe shows consumption drawn from the period it
+	// describes, which makes its reset a real period edge.
+	metering bool
+	// refilled reports that the previous probe was metering and this one is back to
+	// a full allowance: the upstream ended the period it had been counting.
+	refilled bool
+}
+
+func newAIAccountSubjectQuotaObservation(previous, current *float64) aiAccountSubjectQuotaObservation {
+	return aiAccountSubjectQuotaObservation{
+		metering: aiAccountSubjectQuotaWindowMetering(current),
+		refilled: aiAccountSubjectQuotaWindowMetering(previous) && current != nil && *current >= 100,
+	}
+}
+
+// nullableProbePercent adapts a stored percentage for comparison. It is absent
+// both when no probe has been recorded yet and when the upstream reports no
+// percentage, and neither case says anything about a period ending.
+func nullableProbePercent(stored sql.NullFloat64) *float64 {
+	if !stored.Valid {
+		return nil
+	}
+	value := stored.Float64
+	return &value
 }
 
 // aiAccountSubjectQuotaWindowMetering reports whether a probe shows the window
@@ -232,8 +289,8 @@ func aiAccountSubjectCycleFullWindowCountdown(incoming AIAccountSubjectQuotaCycl
 
 const aiAccountSubjectFullWindowCountdownSlack = 2 * time.Minute
 
-func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, metering bool) (AIAccountSubjectQuotaCycle, error) {
-	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle, metering)
+func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, observed aiAccountSubjectQuotaObservation) (AIAccountSubjectQuotaCycle, error) {
+	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle, observed)
 	if err != nil {
 		return cycle, err
 	}


### PR DESCRIPTION
## 问题

额度刷新后，账号卡片仍然统计上一个周期。截图里的两个 Codex 账号三条限额都回到 100%，调用数却还是 12286 / 8388 —— 那是上一周期加新周期混算的结果。

锚点只肯为「报告了消耗」的探测离开已存周期，这道限制本来是拦住闲置桶那种「永远剩一整窗」的倒计时，防止它每次探测都给用量桶换 key。但**刚刷新的周期按定义就是满额**，宣告新周期的那一次探测永远不计量，于是锚点卡在上游已经结束的周期上。

生产实证（2026-08-25，`ai_account_subject_quota_points`）：

| 账号 | 探测 | 剩余 | 上游 reset |
|---|---|---|---|
| a0 | 14:14:45 | 55% | 08-31 00:45:39 |
| a0 | 14:29:42 | **100%** | **09-01 14:15:18** |
| fc | 13:59:46 | 70% | 08-31 00:43:19 |
| fc | 14:14:45 | **100%** | **09-01 14:14:45** |

两个账号的旧周期都被上游提前 6 天结束，锚点却都停在 08-24 那个周期，新周期的请求继续往旧桶里加。

## 修复

把 refill 本身当作周期结束的证据（上一次探测在计量、这一次满额），并且**放在整窗倒计时判据之前**——因为这两件事从形状上无法区分：上面两个账号一个把新周期报成固定边界，另一个报成「此刻 + 一整窗」，后者正是闲置桶的形状。只有「跨出计量状态」这一步能区分刚开始的周期和从未开始的周期。

判据只放宽了这一种情况，原有的闲置桶保护、整窗倒计时保护全部保持不变。

## 历史数据

冻结的锚点会在账号消耗新额度的那一刻自己滚过去，于是留下一个锚点正确、桶却跨周期的状态：a0 新周期日志有 162 次请求，桶里只有 6 次，其余 156 次留在上一周的桶里。

- 新增一遍 repair（marker `ai_account_subject_cycle_refill_repair_v1`），从探测历史里找 refill 跃迁来修锚点
- 桶修复改为只搬「该周期桶尚缺的那部分」，因此幂等，也能修锚点不需要移动、只有桶边界错的情况
- 重算结果小于现存值说明请求日志已过保留期，此时保持原样不动，只补不截断

上线后预期：a0 新桶 17 → 173（前桶扣 156），fc 锚点滚到 08-25 14:14:45 并搬 74 次请求。

## 验证

- `./scripts/ci-pr.sh` 完整通过（secret scan、结构检查、gofmt、go vet、`go test ./...`、golangci-lint、go build）
- 新增测试覆盖两种 reset 形状的 refill 滚动、refill repair 搬桶、锚点已自行滚动后的补桶、以及从未计量窗口保持不动
- 测试有效性已反向验证：撤掉 `observed.refilled` 分支后三个新测试全部失败，失败信息正是生产现象
- 生产库只读 dry-run 核对过锚点推导与搬桶数字

🤖 Generated with [Claude Code](https://claude.com/claude-code)