### PR TITLE
fix(audit): record what a denial actually was

### DIFF
--- a/internal/api/handlers/management/audit_middleware_postgres_test.go
+++ b/internal/api/handlers/management/audit_middleware_postgres_test.go
@@ -125,9 +125,125 @@ func TestManagementAuditRecordsOnlySecurityRelevantRequests(t *testing.T) {
 	}
 }
 
+// TestManagementAuditRecordsDenialAccurately pins what a denial row says about
+// itself. Both defects it covers were found in a live trail rather than in review:
+//
+//   - Every one of 1,623 refusals carried http.status 200, because the row was
+//     written before the response and gin reports 200 until something sets a code.
+//     The rows an audit reader reaches for first all claimed to have succeeded.
+//   - A missing permission and a tenant-scope refusal are both 403 and produced
+//     byte-identical rows, so the trail could not say which had happened — and the
+//     two have opposite remedies.
+func TestManagementAuditRecordsDenialAccurately(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CLIRELAY_POSTGRES_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	ctx := context.Background()
+	db, service := newDisposableIdentityService(t, ctx, dsn, "audit_denial")
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	// Lacks system.status.read: refused by the permission check.
+	noPermissionToken := seedPlatformUser(t, ctx, db, service, platformUserFixture{
+		username:    "denial-no-permission",
+		password:    "Denial-Password-123!",
+		userID:      "dddddddd-dddd-dddd-dddd-ddddddddddf1",
+		roleID:      "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeef1",
+		permissions: []string{"system.logs.read"},
+	})
+	// Holds the permission but sits on a business tenant, so the same route is
+	// refused one check later, for an entirely different reason.
+	tenantScopedToken := seedTenantUser(t, ctx, db, service, tenantUserFixture{
+		tenantID: "cccccccc-cccc-cccc-cccc-ccccccccccf1",
+		platformUserFixture: platformUserFixture{
+			username:    "denial-tenant-scope",
+			password:    "Denial-Password-123!",
+			userID:      "dddddddd-dddd-dddd-dddd-ddddddddddf2",
+			roleID:      "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeef2",
+			permissions: []string{"system.status.read"},
+		},
+	})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(h.Middleware())
+	router.GET("/v0/management/update/progress", func(c *gin.Context) {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "update_progress_failed"})
+	})
+
+	serve := func(token string) int {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/v0/management/update/progress", nil)
+		req.RemoteAddr = "127.0.0.1:4321"
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// The denial row for one actor, as JSON fields rather than a blob: a status that
+	// disagrees with the response is exactly what this test exists to catch.
+	readDenial := func(actorUserID string) (status int, reason string) {
+		t.Helper()
+		if err := db.QueryRowContext(ctx, `
+			SELECT (changes->'http'->>'status')::int, COALESCE(changes->>'denial_reason', '')
+			  FROM audit_logs
+			 WHERE actor_user_id = ? AND result = ?
+			 ORDER BY id DESC LIMIT 1
+		`, actorUserID, auditResultDenied).Scan(&status, &reason); err != nil {
+			t.Fatalf("read denial row for %s: %v", actorUserID, err)
+		}
+		return status, reason
+	}
+
+	if code := serve(noPermissionToken); code != http.StatusForbidden {
+		t.Fatalf("missing-permission response = %d, want %d", code, http.StatusForbidden)
+	}
+	status, reason := readDenial("dddddddd-dddd-dddd-dddd-ddddddddddf1")
+	if status != http.StatusForbidden {
+		t.Fatalf("missing-permission row recorded status %d, want %d (the code the client actually received)", status, http.StatusForbidden)
+	}
+	if reason != string(denialPermission) {
+		t.Fatalf("missing-permission row reason = %q, want %q", reason, denialPermission)
+	}
+
+	if code := serve(tenantScopedToken); code != http.StatusForbidden {
+		t.Fatalf("tenant-scope response = %d, want %d", code, http.StatusForbidden)
+	}
+	status, reason = readDenial("dddddddd-dddd-dddd-dddd-ddddddddddf2")
+	if status != http.StatusForbidden {
+		t.Fatalf("tenant-scope row recorded status %d, want %d", status, http.StatusForbidden)
+	}
+	if reason != string(denialTenantScope) {
+		t.Fatalf("tenant-scope row reason = %q, want %q — the two refusals must stay distinguishable", reason, denialTenantScope)
+	}
+}
+
 type platformUserFixture struct {
 	username, password, userID, roleID string
 	permissions                        []string
+}
+
+type tenantUserFixture struct {
+	platformUserFixture
+	tenantID string
+}
+
+// seedTenantUser creates a business tenant and a user inside it. Such a user is
+// refused on process-global routes by the tenant-scope check rather than by RBAC,
+// which is the second of the two 403s this file distinguishes.
+func seedTenantUser(t *testing.T, ctx context.Context, db *sql.DB, service *identity.Service, fx tenantUserFixture) string {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO tenants (id, slug, name, type, status, expires_at, created_at, updated_at)
+		VALUES (?, ?, ?, 'standard', 'active', now() + interval '30 days', now(), now())
+	`, fx.tenantID, "tenant-"+fx.username, fx.username+" tenant"); err != nil {
+		t.Fatalf("seed tenant %s: %v", fx.username, err)
+	}
+	return seedUserInTenant(t, ctx, db, service, fx.tenantID, fx.platformUserFixture)
 }
 
 // seedPlatformUser creates a platform-scoped role with exactly the given
@@ -136,6 +252,11 @@ type platformUserFixture struct {
 // operator provisioning a custom platform role would.
 func seedPlatformUser(t *testing.T, ctx context.Context, db *sql.DB, service *identity.Service, fx platformUserFixture) string {
 	t.Helper()
+	return seedUserInTenant(t, ctx, db, service, identity.SystemTenantID, fx)
+}
+
+func seedUserInTenant(t *testing.T, ctx context.Context, db *sql.DB, service *identity.Service, tenantID string, fx platformUserFixture) string {
+	t.Helper()
 	hash, err := identity.HashPassword(fx.password)
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +264,7 @@ func seedPlatformUser(t *testing.T, ctx context.Context, db *sql.DB, service *id
 	if _, err = db.ExecContext(ctx, `
 		INSERT INTO roles (id, tenant_id, code, name, description, scope, system_protected)
 		VALUES (?, ?, ?, ?, '', 'platform', false)
-	`, fx.roleID, identity.SystemTenantID, "platform_"+fx.username, fx.username+" role"); err != nil {
+	`, fx.roleID, tenantID, "platform_"+fx.username, fx.username+" role"); err != nil {
 		t.Fatalf("seed role %s: %v", fx.username, err)
 	}
 	for _, perm := range fx.permissions {
@@ -156,7 +277,7 @@ func seedPlatformUser(t *testing.T, ctx context.Context, db *sql.DB, service *id
 		  id, tenant_id, username, username_normalized, display_name, password_hash,
 		  status, must_change_password, password_changed_at, created_at, updated_at
 		) VALUES (?, ?, ?, ?, ?, ?, 'active', false, now(), now(), now())
-	`, fx.userID, identity.SystemTenantID, fx.username, fx.username, fx.username, hash); err != nil {
+	`, fx.userID, tenantID, fx.username, fx.username, fx.username, hash); err != nil {
 		t.Fatalf("seed user %s: %v", fx.username, err)
 	}
 	if _, err = db.ExecContext(ctx, `INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)`, fx.userID, fx.roleID); err != nil {

--- a/internal/api/handlers/management/audit_policy.go
+++ b/internal/api/handlers/management/audit_policy.go
@@ -31,6 +31,21 @@ const (
 	auditResultFailed  = "failed"
 )
 
+// managementDenial names why a request was refused.
+//
+// All three refusals below answer 403 and produced identical audit rows, so the
+// trail could not tell "this operator lacks the permission" from "this tenant may
+// not use this route at all" — two findings with completely different follow-ups
+// (grant a permission vs. the operator is on the wrong tenant). The reason is
+// recorded alongside the permission that was required.
+type managementDenial string
+
+const (
+	denialPermission        managementDenial = "permission_denied"
+	denialTenantScope       managementDenial = "tenant_resource_scope"
+	denialServiceCredential managementDenial = "service_credential_forbidden"
+)
+
 const (
 	// auditRepeatWindow is how long one signature holds the floor. Five minutes
 	// turns a 2s polling client from ~1800 rows/hour into 12, while still showing

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -242,8 +242,8 @@ func (h *Handler) authenticateSessionToken(c *gin.Context, token string) bool {
 	}
 	permission := permissionForManagementRequest(c.Request.Method, c.Request.URL.Path)
 	if !principalHasManagementRequestPermission(principal, c.Request.Method, c.Request.URL.Path, permission) {
-		h.recordManagementAudit(c, principal, "denied")
 		identityError(c, identity.ErrPermissionDenied)
+		h.recordManagementDenial(c, principal, denialPermission)
 		return false
 	}
 	// Some runtime/config stores remain process-global. Business-tenant sessions
@@ -251,8 +251,8 @@ func (h *Handler) authenticateSessionToken(c *gin.Context, token string) bool {
 	// after tenant switch so ops pages like /logs still work under an effective
 	// business tenant.
 	if deniesTenantResourceScope(principal, c.Request.URL.Path) {
-		h.recordManagementAudit(c, principal, "denied")
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "tenant_resource_scope_unavailable", "message": "tenant business resources are not enabled for this tenant"}})
+		h.recordManagementDenial(c, principal, denialTenantScope)
 		return false
 	}
 	c.Set(managementPrincipalKey, principal)

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -47,8 +47,8 @@ func principalFromContext(c *gin.Context) (identity.Principal, bool) {
 func (h *Handler) nextWithManagementAudit(c *gin.Context) {
 	if c != nil && c.Request != nil && isTenantGovernancePath(c.Request.URL.Path) {
 		if principal, ok := principalFromContext(c); ok && principal.Kind == "service_credential" {
-			h.recordManagementAudit(c, principal, "denied")
 			identityError(c, identity.ErrPermissionDenied)
+			h.recordManagementDenial(c, principal, denialServiceCredential)
 			return
 		}
 		if h.identity() == nil {
@@ -59,11 +59,26 @@ func (h *Handler) nextWithManagementAudit(c *gin.Context) {
 	c.Next()
 	principal, ok := principalFromContext(c)
 	if ok {
-		h.recordManagementAudit(c, principal, "")
+		h.recordManagementAudit(c, principal)
 	}
 }
 
-func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Principal, forcedResult string) {
+// recordManagementDenial writes the audit row for a refused request.
+//
+// It must be called *after* the response has been written. gin reports 200 until
+// something sets a status, so recording first stamped every denial row with
+// http.status 200 while the client received 403 — a live trail held 1,623 refusals
+// that all claimed to have succeeded, which is precisely backwards for the rows an
+// audit reader reaches for first.
+func (h *Handler) recordManagementDenial(c *gin.Context, principal identity.Principal, denial managementDenial) {
+	h.recordManagementAuditWithDenial(c, principal, denial)
+}
+
+func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Principal) {
+	h.recordManagementAuditWithDenial(c, principal, "")
+}
+
+func (h *Handler) recordManagementAuditWithDenial(c *gin.Context, principal identity.Principal, denial managementDenial) {
 	service := h.identity()
 	if service == nil || c == nil || c.Request == nil {
 		return
@@ -81,16 +96,16 @@ func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Princ
 	write := c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead
 	sensitiveRead := strings.Contains(relative, "/content") || strings.Contains(relative, "/egress") ||
 		strings.Contains(relative, "/export") || strings.Contains(relative, "/download")
-	result := forcedResult
-	if result == "" {
-		switch status := c.Writer.Status(); {
-		case status < http.StatusBadRequest:
-			result = auditResultSuccess
-		case status == http.StatusUnauthorized || status == http.StatusForbidden:
-			result = auditResultDenied
-		default:
-			result = auditResultFailed
-		}
+	// Derived from the status in every case, including denials: those are recorded
+	// after the response, so the code is real rather than gin's unwritten default.
+	var result string
+	switch status := c.Writer.Status(); {
+	case status < http.StatusBadRequest:
+		result = auditResultSuccess
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		result = auditResultDenied
+	default:
+		result = auditResultFailed
 	}
 	if result == auditResultSuccess && isTenantGovernancePath(c.Request.URL.Path) {
 		return
@@ -150,6 +165,9 @@ func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Princ
 			"resource": resourceType,
 			"route":    routePath,
 		},
+	}
+	if denial != "" {
+		changes["denial_reason"] = string(denial)
 	}
 	if repeat != nil {
 		changes["repeat"] = repeat


### PR DESCRIPTION
Record denials accurately with real HTTP status and distinct denial reason.