### PR TITLE
release: v0.4.29

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -139,6 +139,22 @@ auto-update:
   docker-image: ghcr.io/kittors/clirelay
   updater-url: http://clirelay-updater:8320
 
+# Background re-probe of AI account quota status.
+#
+# Without it a quota snapshot only advances while someone has the accounts panel
+# open. That is enough while this proxy is the only thing spending the
+# allowance, but a Grok subscription is billed across surfaces the proxy never
+# sees: an account drained by Grok Chat on the web reads as untouched until a
+# human happens to look. The per-account min-gap and in-flight dedupe still
+# apply, so a scheduled round overlapping a manual refresh costs no extra
+# upstream calls.
+account-status-refresh:
+  enabled: true
+  # How often each account is re-probed. Floors at 5.
+  interval-minutes: 15
+  # Delay before the first round, so boot does not fire one probe per credential at once.
+  startup-delay-seconds: 60
+
 # Authentication directory (supports ~ for home directory).
 # In Docker/cloud deployments, AUTH_PATH overrides this value at runtime.
 auth-dir: "~/.cli-proxy-api"

--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -22,7 +22,7 @@
       },
       {
         "path": "internal/management/aiaccountstatus/service.go",
-        "max_lines": 990
+        "max_lines": 910
       },
       {
         "path": "internal/management/modelcatalog/availability.go",

--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -22,7 +22,7 @@
       },
       {
         "path": "internal/management/aiaccountstatus/service.go",
-        "max_lines": 1000
+        "max_lines": 990
       },
       {
         "path": "internal/management/modelcatalog/availability.go",

--- a/internal/api/handlers/management/ai_account_status.go
+++ b/internal/api/handlers/management/ai_account_status.go
@@ -3,11 +3,13 @@ package management
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/aiaccountstatus"
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 // invalidateAIAccountCaches drops auth-file-trend keys for every credential
@@ -69,6 +71,61 @@ func (h *Handler) aiAccountStatusService() *aiaccountstatus.Service {
 		}, h.invalidateAIAccountCaches)
 	}
 	return h.aiAccountStatus
+}
+
+// StartAccountStatusScheduler starts (or restarts) the background quota probe.
+//
+// Called from server startup rather than from the first panel request: the
+// whole point is to keep snapshots current for accounts nobody is looking at,
+// which the lazily-built service can never do on its own.
+func (h *Handler) StartAccountStatusScheduler() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	cfg := h.cfg
+	h.mu.Unlock()
+	if cfg == nil || !cfg.AccountStatusRefresh.Enabled {
+		h.stopAccountStatusScheduler()
+		return
+	}
+	interval := time.Duration(cfg.AccountStatusRefresh.IntervalMinutes) * time.Minute
+	if interval <= 0 {
+		h.stopAccountStatusScheduler()
+		return
+	}
+	scheduler := aiaccountstatus.NewScheduler(
+		h.aiAccountStatusService,
+		func() *coreauth.Manager {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			return h.authManager
+		},
+		interval,
+		time.Duration(cfg.AccountStatusRefresh.StartupDelaySeconds)*time.Second,
+	)
+
+	h.mu.Lock()
+	previous := h.statusScheduler
+	h.statusScheduler = scheduler
+	h.mu.Unlock()
+	if previous != nil {
+		previous.Stop()
+	}
+	scheduler.Start()
+}
+
+func (h *Handler) stopAccountStatusScheduler() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	scheduler := h.statusScheduler
+	h.statusScheduler = nil
+	h.mu.Unlock()
+	if scheduler != nil {
+		scheduler.Stop()
+	}
 }
 
 type aiAccountStatusRefreshBody struct {

--- a/internal/api/handlers/management/audit_middleware_postgres_test.go
+++ b/internal/api/handlers/management/audit_middleware_postgres_test.go
@@ -125,9 +125,125 @@ func TestManagementAuditRecordsOnlySecurityRelevantRequests(t *testing.T) {
 	}
 }
 
+// TestManagementAuditRecordsDenialAccurately pins what a denial row says about
+// itself. Both defects it covers were found in a live trail rather than in review:
+//
+//   - Every one of 1,623 refusals carried http.status 200, because the row was
+//     written before the response and gin reports 200 until something sets a code.
+//     The rows an audit reader reaches for first all claimed to have succeeded.
+//   - A missing permission and a tenant-scope refusal are both 403 and produced
+//     byte-identical rows, so the trail could not say which had happened — and the
+//     two have opposite remedies.
+func TestManagementAuditRecordsDenialAccurately(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CLIRELAY_POSTGRES_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	ctx := context.Background()
+	db, service := newDisposableIdentityService(t, ctx, dsn, "audit_denial")
+
+	h := NewHandler(nil, "", nil)
+	h.identityService = service
+	t.Cleanup(h.Close)
+
+	// Lacks system.status.read: refused by the permission check.
+	noPermissionToken := seedPlatformUser(t, ctx, db, service, platformUserFixture{
+		username:    "denial-no-permission",
+		password:    "Denial-Password-123!",
+		userID:      "dddddddd-dddd-dddd-dddd-ddddddddddf1",
+		roleID:      "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeef1",
+		permissions: []string{"system.logs.read"},
+	})
+	// Holds the permission but sits on a business tenant, so the same route is
+	// refused one check later, for an entirely different reason.
+	tenantScopedToken := seedTenantUser(t, ctx, db, service, tenantUserFixture{
+		tenantID: "cccccccc-cccc-cccc-cccc-ccccccccccf1",
+		platformUserFixture: platformUserFixture{
+			username:    "denial-tenant-scope",
+			password:    "Denial-Password-123!",
+			userID:      "dddddddd-dddd-dddd-dddd-ddddddddddf2",
+			roleID:      "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeef2",
+			permissions: []string{"system.status.read"},
+		},
+	})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(h.Middleware())
+	router.GET("/v0/management/update/progress", func(c *gin.Context) {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "update_progress_failed"})
+	})
+
+	serve := func(token string) int {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/v0/management/update/progress", nil)
+		req.RemoteAddr = "127.0.0.1:4321"
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// The denial row for one actor, as JSON fields rather than a blob: a status that
+	// disagrees with the response is exactly what this test exists to catch.
+	readDenial := func(actorUserID string) (status int, reason string) {
+		t.Helper()
+		if err := db.QueryRowContext(ctx, `
+			SELECT (changes->'http'->>'status')::int, COALESCE(changes->>'denial_reason', '')
+			  FROM audit_logs
+			 WHERE actor_user_id = ? AND result = ?
+			 ORDER BY id DESC LIMIT 1
+		`, actorUserID, auditResultDenied).Scan(&status, &reason); err != nil {
+			t.Fatalf("read denial row for %s: %v", actorUserID, err)
+		}
+		return status, reason
+	}
+
+	if code := serve(noPermissionToken); code != http.StatusForbidden {
+		t.Fatalf("missing-permission response = %d, want %d", code, http.StatusForbidden)
+	}
+	status, reason := readDenial("dddddddd-dddd-dddd-dddd-ddddddddddf1")
+	if status != http.StatusForbidden {
+		t.Fatalf("missing-permission row recorded status %d, want %d (the code the client actually received)", status, http.StatusForbidden)
+	}
+	if reason != string(denialPermission) {
+		t.Fatalf("missing-permission row reason = %q, want %q", reason, denialPermission)
+	}
+
+	if code := serve(tenantScopedToken); code != http.StatusForbidden {
+		t.Fatalf("tenant-scope response = %d, want %d", code, http.StatusForbidden)
+	}
+	status, reason = readDenial("dddddddd-dddd-dddd-dddd-ddddddddddf2")
+	if status != http.StatusForbidden {
+		t.Fatalf("tenant-scope row recorded status %d, want %d", status, http.StatusForbidden)
+	}
+	if reason != string(denialTenantScope) {
+		t.Fatalf("tenant-scope row reason = %q, want %q — the two refusals must stay distinguishable", reason, denialTenantScope)
+	}
+}
+
 type platformUserFixture struct {
 	username, password, userID, roleID string
 	permissions                        []string
+}
+
+type tenantUserFixture struct {
+	platformUserFixture
+	tenantID string
+}
+
+// seedTenantUser creates a business tenant and a user inside it. Such a user is
+// refused on process-global routes by the tenant-scope check rather than by RBAC,
+// which is the second of the two 403s this file distinguishes.
+func seedTenantUser(t *testing.T, ctx context.Context, db *sql.DB, service *identity.Service, fx tenantUserFixture) string {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO tenants (id, slug, name, type, status, expires_at, created_at, updated_at)
+		VALUES (?, ?, ?, 'standard', 'active', now() + interval '30 days', now(), now())
+	`, fx.tenantID, "tenant-"+fx.username, fx.username+" tenant"); err != nil {
+		t.Fatalf("seed tenant %s: %v", fx.username, err)
+	}
+	return seedUserInTenant(t, ctx, db, service, fx.tenantID, fx.platformUserFixture)
 }
 
 // seedPlatformUser creates a platform-scoped role with exactly the given
@@ -136,6 +252,11 @@ type platformUserFixture struct {
 // operator provisioning a custom platform role would.
 func seedPlatformUser(t *testing.T, ctx context.Context, db *sql.DB, service *identity.Service, fx platformUserFixture) string {
 	t.Helper()
+	return seedUserInTenant(t, ctx, db, service, identity.SystemTenantID, fx)
+}
+
+func seedUserInTenant(t *testing.T, ctx context.Context, db *sql.DB, service *identity.Service, tenantID string, fx platformUserFixture) string {
+	t.Helper()
 	hash, err := identity.HashPassword(fx.password)
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +264,7 @@ func seedPlatformUser(t *testing.T, ctx context.Context, db *sql.DB, service *id
 	if _, err = db.ExecContext(ctx, `
 		INSERT INTO roles (id, tenant_id, code, name, description, scope, system_protected)
 		VALUES (?, ?, ?, ?, '', 'platform', false)
-	`, fx.roleID, identity.SystemTenantID, "platform_"+fx.username, fx.username+" role"); err != nil {
+	`, fx.roleID, tenantID, "platform_"+fx.username, fx.username+" role"); err != nil {
 		t.Fatalf("seed role %s: %v", fx.username, err)
 	}
 	for _, perm := range fx.permissions {
@@ -156,7 +277,7 @@ func seedPlatformUser(t *testing.T, ctx context.Context, db *sql.DB, service *id
 		  id, tenant_id, username, username_normalized, display_name, password_hash,
 		  status, must_change_password, password_changed_at, created_at, updated_at
 		) VALUES (?, ?, ?, ?, ?, ?, 'active', false, now(), now(), now())
-	`, fx.userID, identity.SystemTenantID, fx.username, fx.username, fx.username, hash); err != nil {
+	`, fx.userID, tenantID, fx.username, fx.username, fx.username, hash); err != nil {
 		t.Fatalf("seed user %s: %v", fx.username, err)
 	}
 	if _, err = db.ExecContext(ctx, `INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)`, fx.userID, fx.roleID); err != nil {

--- a/internal/api/handlers/management/audit_policy.go
+++ b/internal/api/handlers/management/audit_policy.go
@@ -31,6 +31,21 @@ const (
 	auditResultFailed  = "failed"
 )
 
+// managementDenial names why a request was refused.
+//
+// All three refusals below answer 403 and produced identical audit rows, so the
+// trail could not tell "this operator lacks the permission" from "this tenant may
+// not use this route at all" — two findings with completely different follow-ups
+// (grant a permission vs. the operator is on the wrong tenant). The reason is
+// recorded alongside the permission that was required.
+type managementDenial string
+
+const (
+	denialPermission        managementDenial = "permission_denied"
+	denialTenantScope       managementDenial = "tenant_resource_scope"
+	denialServiceCredential managementDenial = "service_credential_forbidden"
+)
+
 const (
 	// auditRepeatWindow is how long one signature holds the floor. Five minutes
 	// turns a 2s polling client from ~1800 rows/hour into 12, while still showing

--- a/internal/api/handlers/management/auth_oauth.go
+++ b/internal/api/handlers/management/auth_oauth.go
@@ -126,6 +126,14 @@ func oauthProxyIDFromRequest(c *gin.Context) string {
 	return strings.TrimSpace(c.Query("proxy-id"))
 }
 
+func (h *Handler) resolveOAuthProxyURL(c *gin.Context) string {
+	proxyID := oauthProxyIDFromRequest(c)
+	if proxyID == "" {
+		return ""
+	}
+	return h.cfg.ResolveProxyURL(proxyID, "")
+}
+
 func (h *Handler) tenantOAuthBindings(c *gin.Context) (
 	authDir string,
 	saveRecord func(context.Context, *coreauth.Auth) (string, error),
@@ -159,6 +167,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	result, err := claudeprovider.StartOAuthLogin(ctx, claudeprovider.OAuthLoginOptions{
 		AuthDir:               authDir,
 		Config:                h.cfg,
+		ProxyURL:              h.resolveOAuthProxyURL(c),
 		WebUI:                 isWebUIRequest(c),
 		PreferredCallbackPort: anthropicCallbackPort,
 		CallbackTarget:        h.managementCallbackURL,
@@ -243,6 +252,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 	result, err := codexprovider.StartOAuthLogin(ctx, codexprovider.OAuthLoginOptions{
 		AuthDir:             authDir,
 		Config:              h.cfg,
+		ProxyURL:            h.resolveOAuthProxyURL(c),
 		WebUI:               isWebUIRequest(c),
 		CallbackPort:        codexCallbackPort,
 		CallbackTarget:      h.managementCallbackURL,
@@ -284,6 +294,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	result, err := antigravityprovider.StartOAuthLogin(ctx, antigravityprovider.OAuthLoginOptions{
 		AuthDir:             authDir,
 		Config:              h.cfg,
+		ProxyURL:            h.resolveOAuthProxyURL(c),
 		WebUI:               isWebUIRequest(c),
 		CallbackTarget:      h.managementCallbackURL,
 		WaitCallback:        WaitOAuthCallbackFile,
@@ -371,6 +382,7 @@ func (h *Handler) RequestXAIToken(c *gin.Context) {
 	result, err := xaiprovider.StartOAuthLogin(ctx, xaiprovider.OAuthLoginOptions{
 		AuthDir:             authDir,
 		Config:              h.cfg,
+		ProxyURL:            h.resolveOAuthProxyURL(c),
 		WebUI:               isWebUIRequest(c),
 		UsingAPI:            queryBool(c, "using_api"),
 		CallbackTarget:      h.managementCallbackURL,

--- a/internal/api/handlers/management/auth_oauth.go
+++ b/internal/api/handlers/management/auth_oauth.go
@@ -109,6 +109,23 @@ func (h *Handler) saveTenantTokenRecord(ctx context.Context, tenantID string, re
 	return savedPath, nil
 }
 
+// oauthProxyIDFromRequest reads the proxy-pool entry chosen in the login dialog.
+//
+// The start request is the authoritative carrier: the record is built and saved
+// by the goroutine that request spawns, so a proxy id arriving later on
+// /oauth-callback would reach a closure that has already been handed its value.
+// The callback panel sends the field too, which is harmless duplication rather
+// than a second source of truth.
+func oauthProxyIDFromRequest(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	if proxyID := strings.TrimSpace(c.Query("proxy_id")); proxyID != "" {
+		return proxyID
+	}
+	return strings.TrimSpace(c.Query("proxy-id"))
+}
+
 func (h *Handler) tenantOAuthBindings(c *gin.Context) (
 	authDir string,
 	saveRecord func(context.Context, *coreauth.Auth) (string, error),
@@ -117,7 +134,13 @@ func (h *Handler) tenantOAuthBindings(c *gin.Context) (
 ) {
 	tenantID := effectiveTenantID(c)
 	authDir = managementauthfiles.TenantAuthDir(h.cfg.AuthDir, tenantID)
+	// The proxy the operator picked in the login dialog is bound here rather than
+	// inside each provider flow. Every OAuth provider funnels its finished record
+	// through this one closure, so binding at this point covers all of them and
+	// leaves no provider to be forgotten when the next one is added.
+	proxyID := oauthProxyIDFromRequest(c)
 	saveRecord = func(ctx context.Context, record *coreauth.Auth) (string, error) {
+		managementauthfiles.BindProxyID(record, proxyID)
 		return h.saveTenantTokenRecord(ctx, tenantID, record)
 	}
 	registerSession = func(state, provider string) {
@@ -429,18 +452,25 @@ func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 	ctx := requestAuthContext(c)
 	authDir, saveRecord, _, _ := h.tenantOAuthBindings(c)
 
+	// Cookie login posts its fields as JSON, so the proxy id arrives in the body
+	// rather than the query string tenantOAuthBindings reads.
 	var payload struct {
-		Cookie string `json:"cookie"`
+		Cookie  string `json:"cookie"`
+		ProxyID string `json:"proxy_id"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "cookie is required"})
 		return
 	}
+	saveWithProxy := func(ctx context.Context, record *coreauth.Auth) (string, error) {
+		managementauthfiles.BindProxyID(record, payload.ProxyID)
+		return saveRecord(ctx, record)
+	}
 
 	result, err := iflowprovider.AuthenticateCookie(ctx, payload.Cookie, iflowprovider.CookieLoginOptions{
 		Config:     h.cfg,
 		AuthDir:    authDir,
-		SaveRecord: saveRecord,
+		SaveRecord: saveWithProxy,
 	})
 	if err != nil {
 		var duplicate iflowprovider.DuplicateBXAuthError

--- a/internal/api/handlers/management/auth_oauth_proxy_binding_test.go
+++ b/internal/api/handlers/management/auth_oauth_proxy_binding_test.go
@@ -1,0 +1,74 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// The login dialog offers an "authorization proxy" and the panel sends it as
+// proxy_id, but nothing on this side used to read it: the record was written
+// with an empty ProxyID, so every probe and API call for that account went out
+// through the deployment host's own address. On an Antigravity account that
+// showed up as a paid plan being reported back as restricted, because the tier
+// lookup is answered per egress IP.
+func TestOAuthSaveRecordBindsSelectedProxy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{cfg: &config.Config{AuthDir: t.TempDir()}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/antigravity-auth-url?is_webui=true&proxy_id=us-residential", nil)
+
+	_, saveRecord, _, _ := h.tenantOAuthBindings(c)
+
+	record := &coreauth.Auth{
+		Provider: "antigravity",
+		FileName: "antigravity-someone@example.com.json",
+		Metadata: map[string]any{"email": "someone@example.com"},
+	}
+	if _, err := saveRecord(context.Background(), record); err != nil {
+		t.Fatalf("saveRecord() error = %v", err)
+	}
+
+	if record.ProxyID != "us-residential" {
+		t.Fatalf("ProxyID = %q, want the proxy chosen in the login dialog", record.ProxyID)
+	}
+	// Runtime egress reads the field; a reload rebuilds it from metadata. A
+	// binding that is missing from either one silently stops applying.
+	if got := record.Metadata["proxy_id"]; got != "us-residential" {
+		t.Fatalf("metadata proxy_id = %v, want the binding to survive a reload", got)
+	}
+}
+
+func TestOAuthSaveRecordLeavesProxyUnsetWhenDialogPickedNone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{cfg: &config.Config{AuthDir: t.TempDir()}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/antigravity-auth-url?is_webui=true", nil)
+
+	_, saveRecord, _, _ := h.tenantOAuthBindings(c)
+
+	record := &coreauth.Auth{
+		Provider: "antigravity",
+		FileName: "antigravity-someone@example.com.json",
+		Metadata: map[string]any{"email": "someone@example.com"},
+	}
+	if _, err := saveRecord(context.Background(), record); err != nil {
+		t.Fatalf("saveRecord() error = %v", err)
+	}
+
+	if record.ProxyID != "" {
+		t.Fatalf("ProxyID = %q, want empty when the dialog left the proxy blank", record.ProxyID)
+	}
+	if _, exists := record.Metadata["proxy_id"]; exists {
+		t.Fatal("an unset proxy must not be written to metadata")
+	}
+}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -242,8 +242,8 @@ func (h *Handler) authenticateSessionToken(c *gin.Context, token string) bool {
 	}
 	permission := permissionForManagementRequest(c.Request.Method, c.Request.URL.Path)
 	if !principalHasManagementRequestPermission(principal, c.Request.Method, c.Request.URL.Path, permission) {
-		h.recordManagementAudit(c, principal, "denied")
 		identityError(c, identity.ErrPermissionDenied)
+		h.recordManagementDenial(c, principal, denialPermission)
 		return false
 	}
 	// Some runtime/config stores remain process-global. Business-tenant sessions
@@ -251,8 +251,8 @@ func (h *Handler) authenticateSessionToken(c *gin.Context, token string) bool {
 	// after tenant switch so ops pages like /logs still work under an effective
 	// business tenant.
 	if deniesTenantResourceScope(principal, c.Request.URL.Path) {
-		h.recordManagementAudit(c, principal, "denied")
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "tenant_resource_scope_unavailable", "message": "tenant business resources are not enabled for this tenant"}})
+		h.recordManagementDenial(c, principal, denialTenantScope)
 		return false
 	}
 	c.Set(managementPrincipalKey, principal)

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -52,6 +52,7 @@ type Handler struct {
 	videoGeneration      *imagegeneration.Service
 	identityService      *identity.Service
 	aiAccountStatus      *aiaccountstatus.Service
+	statusScheduler      *aiaccountstatus.Scheduler
 }
 
 type trendCacheEntry struct {
@@ -125,6 +126,7 @@ func (h *Handler) Close() {
 		return
 	}
 	h.loginThrottle.close()
+	h.stopAccountStatusScheduler()
 }
 
 // NewHandler creates a new management handler instance.
@@ -149,6 +151,9 @@ func (h *Handler) SetConfig(cfg *config.Config) {
 	// overrides are re-applied on top, or a config reload would silently revert
 	// them while the panel kept displaying them as active.
 	h.loginThrottle.setPolicies(overlayThrottleOverride(throttlePoliciesFromConfig(cfg), storedThrottleOverride()))
+	// Interval and on/off are reloadable for the same reason: turning the probe
+	// down must not require a restart.
+	h.StartAccountStatusScheduler()
 }
 
 // SetAuthManager updates the auth manager reference used by management endpoints.

--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -47,8 +47,8 @@ func principalFromContext(c *gin.Context) (identity.Principal, bool) {
 func (h *Handler) nextWithManagementAudit(c *gin.Context) {
 	if c != nil && c.Request != nil && isTenantGovernancePath(c.Request.URL.Path) {
 		if principal, ok := principalFromContext(c); ok && principal.Kind == "service_credential" {
-			h.recordManagementAudit(c, principal, "denied")
 			identityError(c, identity.ErrPermissionDenied)
+			h.recordManagementDenial(c, principal, denialServiceCredential)
 			return
 		}
 		if h.identity() == nil {
@@ -59,11 +59,26 @@ func (h *Handler) nextWithManagementAudit(c *gin.Context) {
 	c.Next()
 	principal, ok := principalFromContext(c)
 	if ok {
-		h.recordManagementAudit(c, principal, "")
+		h.recordManagementAudit(c, principal)
 	}
 }
 
-func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Principal, forcedResult string) {
+// recordManagementDenial writes the audit row for a refused request.
+//
+// It must be called *after* the response has been written. gin reports 200 until
+// something sets a status, so recording first stamped every denial row with
+// http.status 200 while the client received 403 — a live trail held 1,623 refusals
+// that all claimed to have succeeded, which is precisely backwards for the rows an
+// audit reader reaches for first.
+func (h *Handler) recordManagementDenial(c *gin.Context, principal identity.Principal, denial managementDenial) {
+	h.recordManagementAuditWithDenial(c, principal, denial)
+}
+
+func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Principal) {
+	h.recordManagementAuditWithDenial(c, principal, "")
+}
+
+func (h *Handler) recordManagementAuditWithDenial(c *gin.Context, principal identity.Principal, denial managementDenial) {
 	service := h.identity()
 	if service == nil || c == nil || c.Request == nil {
 		return
@@ -81,16 +96,16 @@ func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Princ
 	write := c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead
 	sensitiveRead := strings.Contains(relative, "/content") || strings.Contains(relative, "/egress") ||
 		strings.Contains(relative, "/export") || strings.Contains(relative, "/download")
-	result := forcedResult
-	if result == "" {
-		switch status := c.Writer.Status(); {
-		case status < http.StatusBadRequest:
-			result = auditResultSuccess
-		case status == http.StatusUnauthorized || status == http.StatusForbidden:
-			result = auditResultDenied
-		default:
-			result = auditResultFailed
-		}
+	// Derived from the status in every case, including denials: those are recorded
+	// after the response, so the code is real rather than gin's unwritten default.
+	var result string
+	switch status := c.Writer.Status(); {
+	case status < http.StatusBadRequest:
+		result = auditResultSuccess
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		result = auditResultDenied
+	default:
+		result = auditResultFailed
 	}
 	if result == auditResultSuccess && isTenantGovernancePath(c.Request.URL.Path) {
 		return
@@ -150,6 +165,9 @@ func (h *Handler) recordManagementAudit(c *gin.Context, principal identity.Princ
 			"resource": resourceType,
 			"route":    routePath,
 		},
+	}
+	if denial != "" {
+		changes["denial_reason"] = string(denial)
 	}
 	if repeat != nil {
 		changes["repeat"] = repeat

--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -231,17 +231,20 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 		Provider:      identityfingerprint.ProviderCodex,
 		AccountKey:    accountKey,
 		AuthSubjectID: accountKey,
-		ClientProduct: "codex-tui",
+		// The learned sample is the current CLI on purpose: a legacy codex-tui
+		// profile is refused for outbound use, so it would never surface as the
+		// effective identity this test is about.
+		ClientProduct: "codex_cli_rs",
 		Version:       "0.125.0",
 		Fields: map[string]string{
-			identityfingerprint.FieldUserAgent:       "codex-tui/0.125.0 (Mac OS 26.5; arm64)",
+			identityfingerprint.FieldUserAgent:       "codex_cli_rs/0.125.0 (Mac OS 26.5; arm64)",
 			identityfingerprint.FieldCodexVersion:    "0.125.0",
-			identityfingerprint.FieldCodexOriginator: "codex-tui",
+			identityfingerprint.FieldCodexOriginator: "codex_cli_rs",
 		},
 		ObservedHeaders: map[string]string{
-			"User-Agent": "codex-tui/0.125.0 (Mac OS 26.5; arm64)",
+			"User-Agent": "codex_cli_rs/0.125.0 (Mac OS 26.5; arm64)",
 			"Version":    "0.125.0",
-			"Originator": "codex-tui",
+			"Originator": "codex_cli_rs",
 		},
 		CreatedAt:  time.Date(2026, 6, 23, 2, 0, 0, 0, time.UTC),
 		UpdatedAt:  time.Date(2026, 6, 23, 2, 1, 0, 0, time.UTC),
@@ -291,7 +294,7 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
-	if got := payload.Effective.Fields[identityfingerprint.FieldUserAgent]; got.Value != "codex-tui/0.125.0 (Mac OS 26.5; arm64)" || got.Source != "learned" {
+	if got := payload.Effective.Fields[identityfingerprint.FieldUserAgent]; got.Value != "codex_cli_rs/0.125.0 (Mac OS 26.5; arm64)" || got.Source != "learned" {
 		t.Fatalf("user-agent field = %+v, want learned Codex client", got)
 	}
 	if got, ok := payload.Effective.Fields[identityfingerprint.FieldCodexWebsocketBeta]; ok && got.Value != "" {

--- a/internal/api/handlers/management/identity_fingerprint_test.go
+++ b/internal/api/handlers/management/identity_fingerprint_test.go
@@ -303,7 +303,7 @@ func TestGetIdentityFingerprintAccountReturnsLearnedPresetAndBuiltinDefault(t *t
 	if payload.Preset.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64)" {
 		t.Fatalf("preset user-agent = %q", payload.Preset.UserAgent)
 	}
-	if payload.BuiltinDefault.Originator != "codex-tui" {
+	if payload.BuiltinDefault.Originator != config.DefaultCodexFingerprintOriginator {
 		t.Fatalf("builtin default originator = %q", payload.BuiltinDefault.Originator)
 	}
 	if payload.Learned.ObservedHeaders["Version"] != "0.125.0" {

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -218,6 +218,9 @@ func (s *Server) configureManagementHandler(
 	if optionState != nil && optionState.modelConfigMutatedCallback != nil {
 		s.mgmt.SetModelConfigMutatedHook(optionState.modelConfigMutatedCallback)
 	}
+	// Quota snapshots have to keep advancing for accounts nobody is watching;
+	// see config.AccountStatusRefreshConfig.
+	s.mgmt.StartAccountStatusScheduler()
 }
 
 func (s *Server) registerBuiltinModules(cfg *config.Config, accessManager *sdkaccess.Manager) {

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -36,6 +36,24 @@ type AntigravityAuth struct {
 	secret     string
 }
 
+// NewAntigravityAuthWithProxy is NewAntigravityAuth pinned to one egress proxy.
+// An empty proxyURL keeps the configured default.
+func NewAntigravityAuthWithProxy(cfg *config.Config, proxyURL string) *AntigravityAuth {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	sdkCfg := cfg.SDKConfig
+	if trimmed := strings.TrimSpace(proxyURL); trimmed != "" {
+		sdkCfg.ProxyURL = trimmed
+	}
+	clientID, clientSecret := cfg.OAuthClientCredentials(config.OAuthClientAntigravity)
+	return &AntigravityAuth{
+		httpClient: util.SetProxy(&sdkCfg, util.NewHTTPClient(util.DefaultHTTPClientTimeout)),
+		clientID:   clientID,
+		secret:     clientSecret,
+	}
+}
+
 // NewAntigravityAuth creates a new Antigravity auth service.
 func NewAntigravityAuth(cfg *config.Config, httpClient *http.Client) *AntigravityAuth {
 	if cfg == nil {

--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -61,10 +61,28 @@ type ClaudeAuth struct {
 // Returns:
 //   - *ClaudeAuth: A new Claude authentication service instance
 func NewClaudeAuth(cfg *config.Config) *ClaudeAuth {
+	return NewClaudeAuthWithProxy(cfg, "")
+}
+
+// NewClaudeAuthWithProxy is NewClaudeAuth pinned to one egress proxy.
+//
+// Token refresh has to leave from the same address as the credential's own
+// requests; see resolveAuthProxyURL in the executor package for what goes wrong
+// when the two diverge. An empty proxyURL keeps the configured default. The
+// Firefox TLS fingerprint is preserved either way, since the proxy is applied by
+// substituting the dialer's config rather than replacing the transport.
+func NewClaudeAuthWithProxy(cfg *config.Config, proxyURL string) *ClaudeAuth {
+	var sdkCfg config.SDKConfig
+	if cfg != nil {
+		sdkCfg = cfg.SDKConfig
+	}
+	if trimmed := strings.TrimSpace(proxyURL); trimmed != "" {
+		sdkCfg.ProxyURL = trimmed
+	}
 	// Use custom HTTP client with Firefox TLS fingerprint to bypass
 	// Cloudflare's bot detection on Anthropic domains
 	return &ClaudeAuth{
-		httpClient: NewAnthropicHttpClient(&cfg.SDKConfig),
+		httpClient: NewAnthropicHttpClient(&sdkCfg),
 	}
 }
 

--- a/internal/auth/claude/refresh_proxy_test.go
+++ b/internal/auth/claude/refresh_proxy_test.go
@@ -1,0 +1,34 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// Pinning a credential's proxy must not leak into the shared config, and the
+// Firefox TLS fingerprint transport must survive it: this provider relies on
+// that fingerprint to get past Cloudflare, so losing it would trade one outage
+// for another.
+func TestNewClaudeAuthWithProxyKeepsFingerprintAndConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SDKConfig.ProxyURL = "http://global.example:7890"
+
+	svc := NewClaudeAuthWithProxy(cfg, "socks5://pinned.example:1080")
+
+	if got := cfg.SDKConfig.ProxyURL; got != "http://global.example:7890" {
+		t.Fatalf("shared config proxy = %q, want it unchanged", got)
+	}
+	if svc == nil || svc.httpClient == nil {
+		t.Fatal("no client was built")
+	}
+	if _, ok := svc.httpClient.Transport.(*utlsRoundTripper); !ok {
+		t.Fatalf("transport = %T, want the utls fingerprint transport", svc.httpClient.Transport)
+	}
+}
+
+func TestNewClaudeAuthWithProxyHandlesNilConfig(t *testing.T) {
+	if svc := NewClaudeAuthWithProxy(nil, "socks5://pinned.example:1080"); svc == nil || svc.httpClient == nil {
+		t.Fatal("nil config must still yield a usable client")
+	}
+}

--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -37,9 +37,32 @@ type CodexAuth struct {
 // NewCodexAuth creates a new CodexAuth service instance.
 // It initializes an HTTP client with proxy settings from the provided configuration.
 func NewCodexAuth(cfg *config.Config) *CodexAuth {
+	return NewCodexAuthWithProxy(cfg, "")
+}
+
+// NewCodexAuthWithProxy is NewCodexAuth pinned to one egress proxy.
+//
+// Token refresh has to leave from the same address as the credential's own
+// requests; see resolveAuthProxyURL in the executor package for what goes wrong
+// when the two diverge. An empty proxyURL keeps the configured default.
+func NewCodexAuthWithProxy(cfg *config.Config, proxyURL string) *CodexAuth {
+	sdkCfg := sdkConfigWithProxy(cfg, proxyURL)
 	return &CodexAuth{
-		httpClient: util.SetProxy(&cfg.SDKConfig, util.NewHTTPClient(util.DefaultHTTPClientTimeout)),
+		httpClient: util.SetProxy(sdkCfg, util.NewHTTPClient(util.DefaultHTTPClientTimeout)),
 	}
+}
+
+// sdkConfigWithProxy copies the SDK config with proxyURL substituted, so pinning
+// an egress proxy cannot mutate shared configuration.
+func sdkConfigWithProxy(cfg *config.Config, proxyURL string) *config.SDKConfig {
+	var sdkCfg config.SDKConfig
+	if cfg != nil {
+		sdkCfg = cfg.SDKConfig
+	}
+	if proxyURL = strings.TrimSpace(proxyURL); proxyURL != "" {
+		sdkCfg.ProxyURL = proxyURL
+	}
+	return &sdkCfg
 }
 
 // GenerateAuthURL creates the OAuth authorization URL with PKCE (Proof Key for Code Exchange).

--- a/internal/auth/codex/refresh_proxy_test.go
+++ b/internal/auth/codex/refresh_proxy_test.go
@@ -1,0 +1,77 @@
+package codex
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func newTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.SDKConfig.ProxyURL = "http://global.example:7890"
+	return cfg
+}
+
+// TestNewCodexAuthWithProxyPinsEgress checks that the pinned proxy is what the
+// refresh client actually dials, rather than the process-wide default. An HTTP
+// proxy is used because that scheme lands on Transport.Proxy and is therefore
+// directly observable; socks5 goes through the same substitution but is applied
+// as a dialer.
+func TestNewCodexAuthWithProxyPinsEgress(t *testing.T) {
+	cfg := newTestConfig()
+
+	svc := NewCodexAuthWithProxy(cfg, "http://pinned.example:1080")
+	transport, ok := svc.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", svc.httpClient.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("transport has no proxy resolver, so refresh would go out direct")
+	}
+	proxyURL, err := transport.Proxy(httptest.NewRequest(http.MethodPost, "https://auth.openai.com/oauth/token", nil))
+	if err != nil {
+		t.Fatalf("proxy resolver error: %v", err)
+	}
+	if proxyURL == nil || proxyURL.Host != "pinned.example:1080" {
+		t.Fatalf("refresh proxy = %v, want pinned.example:1080", proxyURL)
+	}
+}
+
+// The substitution must not leak into the shared config: every other caller
+// reads the same struct, and one credential's proxy is not theirs.
+func TestNewCodexAuthWithProxyLeavesSharedConfigUntouched(t *testing.T) {
+	cfg := newTestConfig()
+
+	_ = NewCodexAuthWithProxy(cfg, "http://pinned.example:1080")
+
+	if got := cfg.SDKConfig.ProxyURL; got != "http://global.example:7890" {
+		t.Fatalf("shared config proxy = %q, want it unchanged", got)
+	}
+}
+
+// An empty proxy keeps the configured default, so callers that have no
+// credential-scoped proxy behave exactly as before.
+func TestNewCodexAuthWithoutProxyKeepsDefault(t *testing.T) {
+	cfg := newTestConfig()
+
+	svc := NewCodexAuthWithProxy(cfg, "   ")
+	transport, ok := svc.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", svc.httpClient.Transport)
+	}
+	proxyURL, err := transport.Proxy(httptest.NewRequest(http.MethodPost, "https://auth.openai.com/oauth/token", nil))
+	if err != nil {
+		t.Fatalf("proxy resolver error: %v", err)
+	}
+	if proxyURL == nil || proxyURL.Host != "global.example:7890" {
+		t.Fatalf("refresh proxy = %v, want the global default", proxyURL)
+	}
+}
+
+func TestNewCodexAuthHandlesNilConfig(t *testing.T) {
+	if svc := NewCodexAuthWithProxy(nil, "http://pinned.example:1080"); svc == nil || svc.httpClient == nil {
+		t.Fatal("nil config must still yield a usable client")
+	}
+}

--- a/internal/auth/qwen/qwen_auth.go
+++ b/internal/auth/qwen/qwen_auth.go
@@ -86,13 +86,31 @@ const defaultOAuthUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWe
 
 // NewQwenAuth creates a new QwenAuth instance with a proxy-configured HTTP client.
 func NewQwenAuth(cfg *config.Config) *QwenAuth {
+	return NewQwenAuthWithProxy(cfg, "")
+}
+
+// NewQwenAuthWithProxy is NewQwenAuth pinned to one egress proxy.
+//
+// Token refresh has to leave from the same address as the credential's own
+// requests; see resolveAuthProxyURL in the executor package for what goes wrong
+// when the two diverge. An empty proxyURL keeps the configured default.
+func NewQwenAuthWithProxy(cfg *config.Config, proxyURL string) *QwenAuth {
 	var sdkCfg *config.SDKConfig
 	userAgent := defaultOAuthUserAgent
 	if cfg != nil {
-		sdkCfg = &cfg.SDKConfig
+		// Copied rather than referenced: pinning a proxy must not mutate the
+		// shared configuration every other caller reads.
+		copied := cfg.SDKConfig
+		sdkCfg = &copied
 		if strings.TrimSpace(cfg.OAuthUserAgent) != "" {
 			userAgent = strings.TrimSpace(cfg.OAuthUserAgent)
 		}
+	}
+	if trimmed := strings.TrimSpace(proxyURL); trimmed != "" {
+		if sdkCfg == nil {
+			sdkCfg = &config.SDKConfig{}
+		}
+		sdkCfg.ProxyURL = trimmed
 	}
 	return &QwenAuth{
 		httpClient: util.SetProxy(sdkCfg, util.NewHTTPClient(util.DefaultHTTPClientTimeout)),

--- a/internal/auth/qwen/refresh_proxy_test.go
+++ b/internal/auth/qwen/refresh_proxy_test.go
@@ -1,0 +1,55 @@
+package qwen
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// Token refresh must dial the credential's own proxy, and pinning it must not
+// leak into the shared config that every other caller reads.
+func TestNewQwenAuthWithProxyPinsEgressWithoutMutatingConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SDKConfig.ProxyURL = "http://global.example:7890"
+
+	svc := NewQwenAuthWithProxy(cfg, "http://pinned.example:1080")
+
+	if got := cfg.SDKConfig.ProxyURL; got != "http://global.example:7890" {
+		t.Fatalf("shared config proxy = %q, want it unchanged", got)
+	}
+	transport, ok := svc.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", svc.httpClient.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("transport has no proxy resolver, so refresh would go out direct")
+	}
+	proxyURL, err := transport.Proxy(httptest.NewRequest(http.MethodPost, "https://example.com/token", nil))
+	if err != nil {
+		t.Fatalf("proxy resolver error: %v", err)
+	}
+	if proxyURL == nil || proxyURL.Host != "pinned.example:1080" {
+		t.Fatalf("refresh proxy = %v, want pinned.example:1080", proxyURL)
+	}
+}
+
+// The OAuth user agent is part of this provider's identity and must survive the
+// proxy substitution.
+func TestNewQwenAuthWithProxyKeepsUserAgent(t *testing.T) {
+	cfg := &config.Config{OAuthUserAgent: "custom-agent/1.0"}
+
+	if got := NewQwenAuthWithProxy(cfg, "http://pinned.example:1080").userAgent; got != "custom-agent/1.0" {
+		t.Fatalf("userAgent = %q, want the configured value", got)
+	}
+	if got := NewQwenAuthWithProxy(&config.Config{}, "").userAgent; got != defaultOAuthUserAgent {
+		t.Fatalf("userAgent = %q, want the default", got)
+	}
+}
+
+func TestNewQwenAuthWithProxyHandlesNilConfig(t *testing.T) {
+	if svc := NewQwenAuthWithProxy(nil, "http://pinned.example:1080"); svc == nil || svc.httpClient == nil {
+		t.Fatal("nil config must still yield a usable client")
+	}
+}

--- a/internal/auth/xai/quota.go
+++ b/internal/auth/xai/quota.go
@@ -1,7 +1,6 @@
 package xai
 
 import (
-	"math"
 	"strings"
 	"time"
 
@@ -13,23 +12,70 @@ const (
 	BillingWeeklyPath = "/billing?format=credits"
 	// CLIWeeklyBillingURL is the production Grok Build weekly included-usage URL.
 	CLIWeeklyBillingURL = CLIChatProxyBaseURL + BillingWeeklyPath
+	// WeeklyExhaustedRemainingPercent is the remaining share below which the
+	// weekly allowance counts as spent.
+	//
+	// Percentages are kept at upstream precision (see ParseWeeklyBilling), so a
+	// credential can sit at 0.2% remaining — enough to pass a "> 0" check, not
+	// enough to serve a request. Treating that as recovered makes the conductor
+	// hand the credential out, take the 402, cool down, re-probe, and repeat
+	// until the real weekly reset.
+	WeeklyExhaustedRemainingPercent = 0.5
 )
 
 // WeeklyBilling describes the quota fields shared by runtime recovery probes and
 // the management account-status view.
+//
+// Grok bills SuperGrok as one weekly credit pool shared by every product
+// (isUnifiedBillingUser). RemainingPercent therefore covers Grok Chat, Imagine
+// and App Builder usage as well — traffic this proxy never sees. Anything that
+// has to line up an upstream percentage with locally recorded cost must use
+// AttributableUsedPercent instead; see that method for why.
 type WeeklyBilling struct {
 	RemainingPercent float64
+	PeriodStart      time.Time
 	ResetAt          time.Time
 	Products         []WeeklyProductBilling
 }
 
 // WeeklyProductBilling describes one product-specific weekly usage entry.
+//
+// Products the account has not touched come back without a usagePercent field
+// at all, which is why HasUsage exists: "absent" and "reported as 0" are the
+// same number but not the same fact, and only a reported value may be summed
+// into an attributable total.
 type WeeklyProductBilling struct {
 	Name             string
 	RemainingPercent float64
+	HasUsage         bool
+	// Attributable marks products whose weekly consumption is produced by
+	// traffic this proxy forwards.
+	Attributable bool
+}
+
+// attributableWeeklyProducts lists the Grok products whose weekly consumption
+// this proxy actually produces, keyed by normalized product name.
+//
+// OAuth (SuperGrok) chat traffic all leaves through cli-chat-proxy.grok.com,
+// which upstream accounts for as Grok Build. Image and video generation is sent
+// to api.x.ai instead (see xaiMediaBaseURL) and is billed against API credits,
+// not this weekly pool — GrokImagine stays untouched on accounts that generate
+// media through the proxy, which is why it is not listed here. GrokChat and
+// GrokAppBuilder are first-party surfaces the proxy has no part in.
+//
+// "grokcode" is the pre-rename key and is kept so accounts still reported under
+// it do not silently fall back to the unattributable total.
+var attributableWeeklyProducts = map[string]struct{}{
+	"grokbuild": {},
+	"grokcode":  {},
 }
 
 // ParseWeeklyBilling parses the Grok Build billing response's weekly usage data.
+//
+// Percentages are stored exactly as upstream reports them. Rounding them to
+// whole percents used to look harmless because the panel prints integers, but
+// the value is also the divisor of the weekly-budget projection: at 2% consumed
+// a half-point of rounding moves the projected budget by a quarter.
 func ParseWeeklyBilling(body []byte) (WeeklyBilling, bool) {
 	cfg := gjson.GetBytes(body, "config")
 	if !cfg.Exists() {
@@ -45,29 +91,109 @@ func ParseWeeklyBilling(body []byte) (WeeklyBilling, bool) {
 
 	weekly := WeeklyBilling{RemainingPercent: 100}
 	if used.Exists() {
-		weekly.RemainingPercent = math.Round(100 - clampBillingPercent(used.Float()))
+		weekly.RemainingPercent = 100 - clampBillingPercent(used.Float())
 	}
 	reset := firstBillingResult(current, "end")
 	if !reset.Exists() {
 		reset = firstBillingResult(cfg, "billingPeriodEnd", "billing_period_end")
 	}
 	weekly.ResetAt = parseBillingTime(reset)
+	start := firstBillingResult(current, "start")
+	if !start.Exists() {
+		start = firstBillingResult(cfg, "billingPeriodStart", "billing_period_start")
+	}
+	weekly.PeriodStart = parseBillingTime(start)
 
 	if products.IsArray() {
 		weekly.Products = make([]WeeklyProductBilling, 0)
 		products.ForEach(func(_, product gjson.Result) bool {
+			name := strings.TrimSpace(product.Get("product").String())
 			item := WeeklyProductBilling{
-				Name:             strings.TrimSpace(product.Get("product").String()),
+				Name:             name,
 				RemainingPercent: 100,
+				Attributable:     IsAttributableWeeklyProduct(name),
 			}
 			if productUsed := firstBillingResult(product, "usagePercent", "usage_percent"); productUsed.Exists() {
-				item.RemainingPercent = math.Round(100 - clampBillingPercent(productUsed.Float()))
+				item.RemainingPercent = 100 - clampBillingPercent(productUsed.Float())
+				item.HasUsage = true
 			}
 			weekly.Products = append(weekly.Products, item)
 			return true
 		})
 	}
 	return weekly, true
+}
+
+// IsAttributableWeeklyProduct reports whether a product's weekly consumption is
+// produced by traffic this proxy forwards.
+func IsAttributableWeeklyProduct(name string) bool {
+	_, ok := attributableWeeklyProducts[normalizeWeeklyProductName(name)]
+	return ok
+}
+
+// AttributableUsedPercent returns the share of the weekly pool consumed by
+// products this proxy forwards to, and whether upstream reported enough to say.
+//
+// This is the divisor the weekly-budget projection needs. Dividing locally
+// recorded cost by the pool-wide consumption instead answers a question nobody
+// asked: the numerator only covers Grok Build requests, so every percent Grok
+// Chat burns on the web shrinks the projected budget of an account whose budget
+// did not change. Product shares sum to the pool total (16% Build + 3% Chat =
+// 19% overall on a live account), so restricting the divisor to attributable
+// products restores the pool-sized answer.
+//
+// Reports false when upstream sent no product breakdown at all; callers fall
+// back to the pool-wide percentage rather than invent one.
+func (w WeeklyBilling) AttributableUsedPercent() (float64, bool) {
+	var used float64
+	var reported bool
+	for _, product := range w.Products {
+		if !product.Attributable || !product.HasUsage {
+			continue
+		}
+		used += clampBillingPercent(100 - product.RemainingPercent)
+		reported = true
+	}
+	if !reported {
+		return 0, false
+	}
+	return clampBillingPercent(used), true
+}
+
+// WindowSeconds returns the length of the reported billing period.
+//
+// Upstream sends both ends of the period, so the width does not have to be
+// assumed. Readers derive the cycle start as reset_at - window, and a hard-coded
+// seven days silently misplaces that start whenever a plan change shortens or
+// stretches the period — which in turn misplaces the cost window the projection
+// divides. Falls back to the nominal week when either end is missing, and never
+// reports less than a week so the window still registers as the weekly one for
+// readers that select windows by width.
+func (w WeeklyBilling) WindowSeconds() int64 {
+	const nominalWeek = int64(7 * 24 * 60 * 60)
+	if w.PeriodStart.IsZero() || w.ResetAt.IsZero() {
+		return nominalWeek
+	}
+	seconds := int64(w.ResetAt.Sub(w.PeriodStart).Round(time.Second) / time.Second)
+	if seconds < nominalWeek {
+		return nominalWeek
+	}
+	return seconds
+}
+
+// Exhausted reports whether the weekly allowance is spent.
+func (w WeeklyBilling) Exhausted() bool {
+	return w.RemainingPercent < WeeklyExhaustedRemainingPercent
+}
+
+func normalizeWeeklyProductName(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func firstBillingResult(root gjson.Result, paths ...string) gjson.Result {

--- a/internal/auth/xai/quota_test.go
+++ b/internal/auth/xai/quota_test.go
@@ -1,0 +1,200 @@
+package xai
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// liveWeeklyBillingBody is a verbatim capture of a SuperGrok account's
+// /billing?format=credits response. It is the shape every claim below rests on:
+// product shares sum to the pool-wide percentage (16 + 3 = 19), untouched
+// products omit usagePercent entirely, and both period ends are present.
+const liveWeeklyBillingBody = `{
+  "config": {
+    "currentPeriod": {
+      "type": "USAGE_PERIOD_TYPE_WEEKLY",
+      "start": "2026-08-20T06:45:51.606435+00:00",
+      "end": "2026-08-27T06:45:51.606435+00:00"
+    },
+    "creditUsagePercent": 19.0,
+    "onDemandCap": {"val": 0},
+    "onDemandUsed": {"val": 0},
+    "productUsage": [
+      {"product": "GrokBuild", "usagePercent": 16.0},
+      {"product": "GrokChat", "usagePercent": 3.0},
+      {"product": "GrokAppBuilder"},
+      {"product": "GrokImagine"}
+    ],
+    "isUnifiedBillingUser": true,
+    "prepaidBalance": {"val": 0},
+    "billingPeriodStart": "2026-08-20T06:45:51.606435+00:00",
+    "billingPeriodEnd": "2026-08-27T06:45:51.606435+00:00"
+  }
+}`
+
+func TestParseWeeklyBillingSeparatesAttributableFromPoolWide(t *testing.T) {
+	weekly, ok := ParseWeeklyBilling([]byte(liveWeeklyBillingBody))
+	if !ok {
+		t.Fatal("ParseWeeklyBilling rejected a live response body")
+	}
+	if weekly.RemainingPercent != 81 {
+		t.Fatalf("pool-wide remaining=%v, want 81", weekly.RemainingPercent)
+	}
+
+	// The whole point of the fix: the divisor for the budget projection is the
+	// 16% Grok Build burned, not the 19% the account burned everywhere.
+	used, reported := weekly.AttributableUsedPercent()
+	if !reported {
+		t.Fatal("attributable share not reported for a body carrying GrokBuild usage")
+	}
+	if used != 16 {
+		t.Fatalf("attributable used=%v, want 16 (Grok Chat's 3%% must not count)", used)
+	}
+
+	if want := time.Date(2026, 8, 20, 6, 45, 51, 606435000, time.UTC); !weekly.PeriodStart.Equal(want) {
+		t.Fatalf("period start=%v, want %v", weekly.PeriodStart, want)
+	}
+	if got := weekly.WindowSeconds(); got != 604800 {
+		t.Fatalf("window=%d, want 604800", got)
+	}
+	if weekly.Exhausted() {
+		t.Fatal("81% remaining must not read as exhausted")
+	}
+}
+
+func TestParseWeeklyBillingFlagsProductsAndUsageReporting(t *testing.T) {
+	weekly, ok := ParseWeeklyBilling([]byte(liveWeeklyBillingBody))
+	if !ok {
+		t.Fatal("ParseWeeklyBilling rejected a live response body")
+	}
+	byName := make(map[string]WeeklyProductBilling, len(weekly.Products))
+	for _, product := range weekly.Products {
+		byName[product.Name] = product
+	}
+	for _, tc := range []struct {
+		name         string
+		attributable bool
+		hasUsage     bool
+		remaining    float64
+	}{
+		{"GrokBuild", true, true, 84},
+		{"GrokChat", false, true, 97},
+		{"GrokAppBuilder", false, false, 100},
+		{"GrokImagine", false, false, 100},
+	} {
+		product, ok := byName[tc.name]
+		if !ok {
+			t.Fatalf("%s missing from parsed products", tc.name)
+		}
+		if product.Attributable != tc.attributable {
+			t.Fatalf("%s attributable=%v, want %v", tc.name, product.Attributable, tc.attributable)
+		}
+		if product.HasUsage != tc.hasUsage {
+			t.Fatalf("%s hasUsage=%v, want %v", tc.name, product.HasUsage, tc.hasUsage)
+		}
+		if product.RemainingPercent != tc.remaining {
+			t.Fatalf("%s remaining=%v, want %v", tc.name, product.RemainingPercent, tc.remaining)
+		}
+	}
+}
+
+// Rounding to whole percents is invisible in the panel and ruinous in the
+// projection: at 2.4% consumed, rounding to 2% inflates the projected budget by
+// 20%.
+func TestParseWeeklyBillingKeepsFractionalPrecision(t *testing.T) {
+	body := []byte(`{"config":{"currentPeriod":{"type":"WEEKLY","end":"2026-08-27T00:00:00Z"},"creditUsagePercent":2.4,` +
+		`"productUsage":[{"product":"GrokBuild","usagePercent":2.4}]}}`)
+	weekly, ok := ParseWeeklyBilling(body)
+	if !ok {
+		t.Fatal("ParseWeeklyBilling rejected a fractional body")
+	}
+	if math.Abs(weekly.RemainingPercent-97.6) > 1e-9 {
+		t.Fatalf("pool remaining=%v, want 97.6", weekly.RemainingPercent)
+	}
+	used, reported := weekly.AttributableUsedPercent()
+	if !reported || math.Abs(used-2.4) > 1e-9 {
+		t.Fatalf("attributable used=%v reported=%v, want 2.4", used, reported)
+	}
+}
+
+// A body with no product breakdown must say so rather than answer 0, which the
+// caller would divide by.
+func TestAttributableUsedPercentUnreportedWithoutProducts(t *testing.T) {
+	weekly, ok := ParseWeeklyBilling([]byte(`{"config":{"currentPeriod":{"type":"WEEKLY","end":"2026-08-27T00:00:00Z"},"creditUsagePercent":19}}`))
+	if !ok {
+		t.Fatal("ParseWeeklyBilling rejected a product-less body")
+	}
+	if used, reported := weekly.AttributableUsedPercent(); reported {
+		t.Fatalf("reported=%v used=%v, want unreported", reported, used)
+	}
+}
+
+// Every product the account owns being non-attributable is still an answer:
+// nothing this proxy forwards has consumed the pool.
+func TestAttributableUsedPercentZeroWhenOnlyOtherProductsSpent(t *testing.T) {
+	weekly, ok := ParseWeeklyBilling([]byte(`{"config":{"currentPeriod":{"type":"WEEKLY","end":"2026-08-27T00:00:00Z"},` +
+		`"creditUsagePercent":9,"productUsage":[{"product":"GrokBuild"},{"product":"GrokChat","usagePercent":9}]}}`))
+	if !ok {
+		t.Fatal("ParseWeeklyBilling rejected the body")
+	}
+	if used, reported := weekly.AttributableUsedPercent(); reported || used != 0 {
+		t.Fatalf("used=%v reported=%v, want 0/false (GrokBuild reported no usage)", used, reported)
+	}
+}
+
+func TestIsAttributableWeeklyProductNormalizesNames(t *testing.T) {
+	for _, name := range []string{"GrokBuild", "grok-build", "grok_build", " GROK BUILD ", "grok-code"} {
+		if !IsAttributableWeeklyProduct(name) {
+			t.Fatalf("%q should be attributable", name)
+		}
+	}
+	for _, name := range []string{"GrokChat", "GrokImagine", "GrokAppBuilder", "", "grokbuilder"} {
+		if IsAttributableWeeklyProduct(name) {
+			t.Fatalf("%q must not be attributable", name)
+		}
+	}
+}
+
+// Exhaustion is a threshold, not "> 0". A sliver of remaining allowance cannot
+// serve a request, and calling it recovered makes the conductor hand out the
+// credential, take a 402, cool down and re-probe in a loop.
+func TestExhaustedUsesThresholdNotStrictZero(t *testing.T) {
+	for _, tc := range []struct {
+		remaining float64
+		exhausted bool
+	}{
+		{0, true},
+		{0.2, true},
+		{0.5, false},
+		{1, false},
+		{81, false},
+	} {
+		if got := (WeeklyBilling{RemainingPercent: tc.remaining}).Exhausted(); got != tc.exhausted {
+			t.Fatalf("remaining=%v exhausted=%v, want %v", tc.remaining, got, tc.exhausted)
+		}
+	}
+}
+
+// The cycle start readers derive is reset_at minus this width, so a period that
+// is not exactly seven days long has to report its real width.
+func TestWindowSecondsFollowsReportedPeriod(t *testing.T) {
+	start := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name   string
+		weekly WeeklyBilling
+		want   int64
+	}{
+		{"nominal week", WeeklyBilling{PeriodStart: start, ResetAt: start.AddDate(0, 0, 7)}, 604800},
+		{"longer period", WeeklyBilling{PeriodStart: start, ResetAt: start.AddDate(0, 0, 10)}, 864000},
+		// A short period still has to register as the weekly window for readers
+		// that select windows by width, so it floors at a week.
+		{"short period floors at a week", WeeklyBilling{PeriodStart: start, ResetAt: start.AddDate(0, 0, 3)}, 604800},
+		{"missing start", WeeklyBilling{ResetAt: start.AddDate(0, 0, 7)}, 604800},
+	}
+	for _, tc := range cases {
+		if got := tc.weekly.WindowSeconds(); got != tc.want {
+			t.Fatalf("%s: window=%d, want %d", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -278,7 +278,12 @@ func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 			// After realign: that pass folds fragments onto the stored anchor, and
 			// this one may then move that anchor to the period it should have
 			// rolled into.
-			return usage.RunAIAccountSubjectCycleRolloverRepairAtInit()
+			if err := usage.RunAIAccountSubjectCycleRolloverRepairAtInit(); err != nil {
+				return err
+			}
+			// Last: it repairs the anchors the metered-probe pass above cannot see,
+			// those held on a period the upstream refilled rather than spent out.
+			return usage.RunAIAccountSubjectCycleRefillRepairAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -272,7 +272,13 @@ func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 			if err := usage.RunAIAccountSubjectCycleBucketMergeAtInit(); err != nil {
 				return err
 			}
-			return usage.RunAIAccountSubjectCycleRealignAtInit()
+			if err := usage.RunAIAccountSubjectCycleRealignAtInit(); err != nil {
+				return err
+			}
+			// After realign: that pass folds fragments onto the stored anchor, and
+			// this one may then move that anchor to the period it should have
+			// rolled into.
+			return usage.RunAIAccountSubjectCycleRolloverRepairAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -269,7 +269,10 @@ func defaultRuntimeDataStackMaintenanceOps() runtimeDataStackMaintenanceOps {
 			if err := usage.RunAIAccountSubjectUsageTokensBackfillAtInit(); err != nil {
 				return err
 			}
-			return usage.RunAIAccountSubjectCycleBucketMergeAtInit()
+			if err := usage.RunAIAccountSubjectCycleBucketMergeAtInit(); err != nil {
+				return err
+			}
+			return usage.RunAIAccountSubjectCycleRealignAtInit()
 		},
 		scheduleUsageRollupCatchup: usage.ScheduleUsageRollupBlueGreenCatchup,
 	}

--- a/internal/config/account_status_refresh_test.go
+++ b/internal/config/account_status_refresh_test.go
@@ -1,0 +1,57 @@
+package config
+
+import "testing"
+
+func TestSanitizeAccountStatusRefreshDefaultsAndFloor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		in           AccountStatusRefreshConfig
+		wantInterval int
+		wantDelay    int
+	}{
+		{"unset takes defaults", AccountStatusRefreshConfig{Enabled: true}, 15, 60},
+		{"explicit values kept", AccountStatusRefreshConfig{Enabled: true, IntervalMinutes: 30, StartupDelaySeconds: 5}, 30, 5},
+		// A one-minute interval would probe every billing endpoint 60x an hour
+		// per account for readings the snapshot heartbeat would discard anyway.
+		{"too-short interval floors", AccountStatusRefreshConfig{Enabled: true, IntervalMinutes: 1}, 5, 60},
+		// Unset and negative alike take the default: firing one probe per
+		// credential in the same instant as boot is a burst nobody asked for.
+		{"unset delay takes the default", AccountStatusRefreshConfig{Enabled: true, IntervalMinutes: 15, StartupDelaySeconds: 0}, 15, 60},
+		{"negative delay takes the default", AccountStatusRefreshConfig{Enabled: true, IntervalMinutes: 15, StartupDelaySeconds: -1}, 15, 60},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{AccountStatusRefresh: tc.in}
+			cfg.SanitizeAccountStatusRefresh()
+			if cfg.AccountStatusRefresh.IntervalMinutes != tc.wantInterval {
+				t.Fatalf("interval=%d, want %d", cfg.AccountStatusRefresh.IntervalMinutes, tc.wantInterval)
+			}
+			if cfg.AccountStatusRefresh.StartupDelaySeconds != tc.wantDelay {
+				t.Fatalf("startup delay=%d, want %d", cfg.AccountStatusRefresh.StartupDelaySeconds, tc.wantDelay)
+			}
+		})
+	}
+}
+
+// Sanitizing must not switch the probe on for an operator who turned it off.
+func TestSanitizeAccountStatusRefreshKeepsDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{AccountStatusRefresh: AccountStatusRefreshConfig{Enabled: false}}
+	cfg.SanitizeAccountStatusRefresh()
+	if cfg.AccountStatusRefresh.Enabled {
+		t.Fatal("sanitize re-enabled a disabled probe")
+	}
+}
+
+func TestDefaultAccountStatusRefreshIsOn(t *testing.T) {
+	t.Parallel()
+
+	if !defaultAccountStatusRefreshConfig().Enabled {
+		t.Fatal("background quota refresh must default to on; otherwise xAI accounts spent outside the proxy stay stale")
+	}
+}

--- a/internal/config/codex_convergence_config_test.go
+++ b/internal/config/codex_convergence_config_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestNormalizeCodexIdentityFingerprintConvergenceDefaults(t *testing.T) {
 	got := NormalizeCodexIdentityFingerprint(CodexIdentityFingerprintConfig{})
-	if got.ConvergenceMode != CodexFingerprintConvergenceSession {
-		t.Fatalf("convergence mode = %q, want the session default", got.ConvergenceMode)
+	if got.ConvergenceMode != CodexFingerprintConvergenceDevice {
+		t.Fatalf("convergence mode = %q, want the device default", got.ConvergenceMode)
 	}
 
 	got = NormalizeCodexIdentityFingerprint(CodexIdentityFingerprintConfig{ConvergenceMode: "nonsense"})
-	if got.ConvergenceMode != CodexFingerprintConvergenceSession {
+	if got.ConvergenceMode != CodexFingerprintConvergenceDevice {
 		t.Fatalf("convergence mode = %q, want an invalid value to fall back", got.ConvergenceMode)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,6 +172,9 @@ type Config struct {
 	// to common upstream AI API hosts through the fixed residential proxy.
 	ProxyWarmup ProxyWarmConfig `yaml:"proxy-warmup,omitempty" json:"proxy-warmup,omitempty"`
 
+	// AccountStatusRefresh configures the server-side periodic quota probe.
+	AccountStatusRefresh AccountStatusRefreshConfig `yaml:"account-status-refresh,omitempty" json:"account-status-refresh,omitempty"`
+
 	// OpenAICompatibility defines OpenAI API compatibility configurations for external providers.
 	OpenAICompatibility []OpenAICompatibility `yaml:"openai-compatibility" json:"openai-compatibility"`
 
@@ -308,6 +311,58 @@ type ProxyWarmTarget struct {
 	Host   string `yaml:"host" json:"host"`
 	URL    string `yaml:"url" json:"url"`
 	Method string `yaml:"method" json:"method"`
+}
+
+// AccountStatusRefreshConfig controls the server-side periodic quota probe.
+//
+// Quota snapshots used to advance only while someone had the accounts panel
+// open, because the panel was the only thing that ever asked for a refresh.
+// That is fine for consumption the proxy itself produces — the request that
+// spends the quota is the request that updates it — but not for accounts whose
+// allowance is also spent elsewhere: a Grok subscription burned down by Grok
+// Chat on the web looked untouched here until a human happened to look.
+type AccountStatusRefreshConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// IntervalMinutes is how often each account is re-probed. The per-account
+	// min-gap and in-flight dedupe in the status service still apply, so a panel
+	// refresh landing near a scheduled one costs no extra upstream calls.
+	IntervalMinutes int `yaml:"interval-minutes,omitempty" json:"interval-minutes,omitempty"`
+	// StartupDelaySeconds waits this long after start before the first round, so
+	// boot does not fire one upstream probe per credential at once.
+	StartupDelaySeconds int `yaml:"startup-delay-seconds,omitempty" json:"startup-delay-seconds,omitempty"`
+}
+
+func defaultAccountStatusRefreshConfig() AccountStatusRefreshConfig {
+	return AccountStatusRefreshConfig{
+		Enabled: true,
+		// Matches the quota snapshot heartbeat: probing faster than that writes
+		// no new history point unless the percentage actually moved.
+		IntervalMinutes:     15,
+		StartupDelaySeconds: 60,
+	}
+}
+
+// SanitizeAccountStatusRefresh fills unset fields with defaults and rejects
+// intervals short enough to hammer upstream billing endpoints.
+func (cfg *Config) SanitizeAccountStatusRefresh() {
+	if cfg == nil {
+		return
+	}
+	defaults := defaultAccountStatusRefreshConfig()
+	refresh := cfg.AccountStatusRefresh
+	if refresh.IntervalMinutes <= 0 {
+		refresh.IntervalMinutes = defaults.IntervalMinutes
+	}
+	if refresh.IntervalMinutes < 5 {
+		refresh.IntervalMinutes = 5
+	}
+	// Unset and negative both take the default: starting every credential's probe
+	// in the same instant as boot is a burst nobody asked for, and a YAML int has
+	// no way to say "zero on purpose".
+	if refresh.StartupDelaySeconds <= 0 {
+		refresh.StartupDelaySeconds = defaults.StartupDelaySeconds
+	}
+	cfg.AccountStatusRefresh = refresh
 }
 
 func defaultProxyWarmConfig() ProxyWarmConfig {

--- a/internal/config/example_config_load_test.go
+++ b/internal/config/example_config_load_test.go
@@ -1,0 +1,20 @@
+package config
+
+import "testing"
+
+// The shipped example must parse and land on the documented defaults; an example
+// that silently fails to load is how an operator ends up with a config they
+// think is active.
+func TestExampleConfigLoadsAccountStatusRefresh(t *testing.T) {
+	cfg, err := LoadConfig("../../config.example.yaml")
+	if err != nil {
+		t.Fatalf("load config.example.yaml: %v", err)
+	}
+	refresh := cfg.AccountStatusRefresh
+	if !refresh.Enabled {
+		t.Fatal("example config must ship the background quota probe enabled")
+	}
+	if refresh.IntervalMinutes != 15 || refresh.StartupDelaySeconds != 60 {
+		t.Fatalf("example refresh = %+v, want interval 15 / delay 60", refresh)
+	}
+}

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -9,11 +9,15 @@ import (
 )
 
 const (
-	// Defaults are intentionally aligned with upstream CLIProxyAPI's codex-tui behavior.
-	// Update these when upstream codex-tui identity changes.
-	DefaultCodexFingerprintUserAgent     = "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
+	// Defaults follow the identity the current official Codex CLI sends.
+	// `codex-tui` is a legacy originator: upstream A/B probes (CLIProxyAPI #4679)
+	// showed gpt-5.6-sol requests carrying it get load-shed with
+	// `server_is_overloaded`, while `codex_cli_rs` succeeds from the same account.
+	// Spoofing only the User-Agent does not help, so both values move together.
+	// Update the version when the official CLI releases a new stable tag.
+	DefaultCodexFingerprintUserAgent     = "codex_cli_rs/0.149.1 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9"
 	DefaultCodexFingerprintVersion       = ""
-	DefaultCodexFingerprintOriginator    = "codex-tui"
+	DefaultCodexFingerprintOriginator    = "codex_cli_rs"
 	DefaultCodexFingerprintWebsocketBeta = "responses_websockets=2026-02-06"
 	DefaultCodexFingerprintBetaFeatures  = ""
 	DefaultCodexFingerprintSessionMode   = "per-request"
@@ -28,10 +32,18 @@ const (
 	CodexFingerprintConvergenceSession = "session"
 	CodexFingerprintConvergenceFull    = "full"
 
-	// DefaultCodexFingerprintConvergenceMode converges installation and session
-	// while keeping one thread per real client session, which is the shape a
-	// single user spawning sub-agents produces upstream.
-	DefaultCodexFingerprintConvergenceMode = CodexFingerprintConvergenceSession
+	// DefaultCodexFingerprintConvergenceMode converges only the installation and
+	// leaves the client's own session, thread and window state alone.
+	//
+	// Device is the strongest mode that still matches the official client: a real
+	// Codex install legitimately hosts many sessions, so one installation with N
+	// client sessions is a shape upstream already sees. Session and full instead
+	// fold unrelated users into one session id while prompt_cache_key keeps the
+	// per-conversation value, and derive thread/window ids that disagree with the
+	// official state machine (root threads use session_id == thread_id, both
+	// UUIDv7; window ids are their own UUIDv7, not thread_id+":0"). That triple
+	// is a combination no official client emits.
+	DefaultCodexFingerprintConvergenceMode = CodexFingerprintConvergenceDevice
 
 	DefaultClaudeFingerprintCLIVersion              = "2.1.161"
 	DefaultClaudeFingerprintEntrypoint              = "cli"

--- a/internal/config/identity_fingerprint_test.go
+++ b/internal/config/identity_fingerprint_test.go
@@ -2,8 +2,28 @@ package config
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
+
+// assertOfficialCodexCLIIdentity pins the outbound identity to the official
+// Codex CLI. The legacy `codex-tui` originator gets requests load-shed upstream
+// (CLIProxyAPI #4679), and spoofing only the User-Agent does not avoid it, so
+// both fields are checked together. The version is deliberately not pinned so
+// routine CLI bumps do not break the test.
+func assertOfficialCodexCLIIdentity(t *testing.T, got CodexIdentityFingerprintConfig) {
+	t.Helper()
+
+	if got.Originator != "codex_cli_rs" {
+		t.Fatalf("Originator = %q, want codex_cli_rs", got.Originator)
+	}
+	if !strings.HasPrefix(got.UserAgent, "codex_cli_rs/") {
+		t.Fatalf("UserAgent = %q, want a codex_cli_rs/<version> user agent", got.UserAgent)
+	}
+	if strings.Contains(got.UserAgent, "codex-tui") {
+		t.Fatalf("UserAgent = %q, must not carry the legacy codex-tui marker", got.UserAgent)
+	}
+}
 
 func TestDefaultCodexIdentityFingerprintUsesCurrentVersionAndDynamicSessions(t *testing.T) {
 	t.Parallel()
@@ -14,11 +34,9 @@ func TestDefaultCodexIdentityFingerprintUsesCurrentVersionAndDynamicSessions(t *
 		t.Fatalf("Enabled = false, want true by default")
 	}
 	if got.Version != "" {
-		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
+		t.Fatalf("Version = %q, want empty (the CLI does not require Version)", got.Version)
 	}
-	if got.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)" {
-		t.Fatalf("UserAgent = %q, want codex-tui user agent", got.UserAgent)
-	}
+	assertOfficialCodexCLIIdentity(t, got)
 	if got.SessionMode != "per-request" {
 		t.Fatalf("SessionMode = %q, want per-request", got.SessionMode)
 	}
@@ -33,11 +51,9 @@ func TestNormalizeCodexIdentityFingerprintAppliesCurrentDefaults(t *testing.T) {
 		t.Fatalf("Enabled = false, want true by default")
 	}
 	if got.Version != "" {
-		t.Fatalf("Version = %q, want empty (codex-tui does not require Version)", got.Version)
+		t.Fatalf("Version = %q, want empty (the CLI does not require Version)", got.Version)
 	}
-	if got.UserAgent != "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)" {
-		t.Fatalf("UserAgent = %q, want codex-tui user agent", got.UserAgent)
-	}
+	assertOfficialCodexCLIIdentity(t, got)
 	if got.SessionMode != "per-request" {
 		t.Fatalf("SessionMode = %q, want per-request", got.SessionMode)
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -99,6 +99,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.AutoUpdate.DockerImage = DefaultAutoUpdateDockerImage
 	cfg.AutoUpdate.UpdaterURL = DefaultAutoUpdateUpdaterURL
 	cfg.ProxyWarmup = defaultProxyWarmConfig()
+	cfg.AccountStatusRefresh = defaultAccountStatusRefreshConfig()
 	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		if optional {
 			// In cloud deploy mode, if YAML parsing fails, return empty config instead of error.
@@ -146,6 +147,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.SanitizeCommandCodeKeys()
 	cfg.SanitizeGeminiKeys()
 	cfg.SanitizeProxyWarmup()
+	cfg.SanitizeAccountStatusRefresh()
 
 	// Normalize secret-key: if provided and not bcrypt-hashed, hash it on load for runtime use.
 	if cfg.RemoteManagement.SecretKey != "" && !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {

--- a/internal/identityfingerprint/profiles.go
+++ b/internal/identityfingerprint/profiles.go
@@ -135,11 +135,32 @@ func CodexProfileOutboundEligibility(record *LearnedRecord) (bool, string) {
 	if classifiedKey != profileKey {
 		return false, "profile_key_mismatch"
 	}
+	if IsLegacyCodexProfileKey(classifiedKey) {
+		return false, "legacy_client_product"
+	}
 	switch family {
 	case ProfileFamilyCLI, ProfileFamilyIDE, ProfileFamilyDesktop:
 		return true, ""
 	default:
 		return false, "unsupported_profile_family"
+	}
+}
+
+// IsLegacyCodexProfileKey reports products that must not be replayed upstream
+// even when a client still presents them.
+//
+// `codex-tui` is the pre-rename Codex CLI. Upstream A/B probes (CLIProxyAPI
+// #4679) had requests carrying it load-shed with `server_is_overloaded` while
+// the same account succeeded as `codex_cli_rs`, and spoofing only the
+// User-Agent did not help. Learning such a profile from a downstream client
+// would otherwise pin the account to that identity, so it is refused here and
+// resolution falls back to the coherent builtin CLI profile.
+func IsLegacyCodexProfileKey(profileKey string) bool {
+	switch strings.ToLower(strings.TrimSpace(profileKey)) {
+	case "codex-tui", "codex_tui":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/identityfingerprint/profiles_test.go
+++ b/internal/identityfingerprint/profiles_test.go
@@ -156,7 +156,9 @@ func TestResolveCodexSafeFallbackRejectsMixedAccountPreset(t *testing.T) {
 	if got := effective.Fields[FieldUserAgent].Source; got != FieldSourceBuiltinDefault {
 		t.Fatalf("safe fallback user-agent source = %q", got)
 	}
-	if effective.ProfileKey != "codex-tui" || effective.ProfileFamily != ProfileFamilyCLI {
+	// The fallback profile key is derived from the builtin originator, so it
+	// tracks that constant rather than a pinned product name.
+	if effective.ProfileKey != config.DefaultCodexFingerprintOriginator || effective.ProfileFamily != ProfileFamilyCLI {
 		t.Fatalf("safe fallback metadata = %#v", effective)
 	}
 }

--- a/internal/identityfingerprint/profiles_test.go
+++ b/internal/identityfingerprint/profiles_test.go
@@ -138,6 +138,43 @@ func TestSelectCodexProfileReportsNoSelectableProfile(t *testing.T) {
 	}
 }
 
+// A downstream client on the pre-rename CLI must not pin the account to that
+// identity: upstream load-sheds `codex-tui` traffic, so a self-consistent
+// codex-tui profile is still refused for outbound use and selection falls
+// through to the builtin CLI profile.
+func TestCodexTUIProfileIsNeverSelectedForOutbound(t *testing.T) {
+	legacy := LearnedRecord{
+		Provider: ProviderCodex, AccountKey: "acct",
+		ProfileKey: "codex-tui", ProfileFamily: ProfileFamilyCLI,
+		Fields: map[string]string{
+			FieldUserAgent:       "codex-tui/0.118.0 (Mac OS 26.3.1; arm64)",
+			FieldCodexOriginator: "codex-tui",
+		},
+	}
+	if eligible, reason := CodexProfileOutboundEligibility(&legacy); eligible || reason != "legacy_client_product" {
+		t.Fatalf("codex-tui eligibility = %v/%q, want refusal as a legacy product", eligible, reason)
+	}
+
+	selection := SelectCodexProfile([]LearnedRecord{legacy}, AccountPolicy{Provider: ProviderCodex, AccountKey: "acct"})
+	if selection.Profile != nil {
+		t.Fatalf("codex-tui was selected for outbound use: %+v", selection.Profile)
+	}
+	if selection.Reason != "no_selectable_profile" {
+		t.Fatalf("selection reason = %q, want no_selectable_profile", selection.Reason)
+	}
+
+	// The current CLI on the same account stays selectable.
+	current := legacy
+	current.ProfileKey = "codex_cli_rs"
+	current.Fields = map[string]string{
+		FieldUserAgent:       "codex_cli_rs/0.149.1 (Mac OS 26.3.1; arm64)",
+		FieldCodexOriginator: "codex_cli_rs",
+	}
+	if eligible, reason := CodexProfileOutboundEligibility(&current); !eligible {
+		t.Fatalf("codex_cli_rs eligibility = %v/%q, want eligible", eligible, reason)
+	}
+}
+
 func TestResolveCodexSafeFallbackRejectsMixedAccountPreset(t *testing.T) {
 	resolved, effective := ResolveCodexSafeFallback(config.CodexIdentityFingerprintConfig{
 		Enabled:       true,

--- a/internal/management/aiaccountstatus/probe_codex.go
+++ b/internal/management/aiaccountstatus/probe_codex.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	codexauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -24,7 +25,7 @@ const (
 func probeCodex(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) (ProbeResult, error) {
 	body, err := doAuthGET(ctx, svc, auth, codexUsageURL, map[string]string{
 		"Content-Type": "application/json",
-		"User-Agent":   "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+		"User-Agent":   config.DefaultCodexFingerprintUserAgent,
 	}, func(req *http.Request) {
 		if accountID := codexAccountID(auth); accountID != "" {
 			req.Header.Set("Chatgpt-Account-Id", accountID)
@@ -47,7 +48,7 @@ func probeCodex(ctx context.Context, svc *managementapitools.Service, auth *core
 		if v > 0 {
 			if expBody, expErr := doAuthGET(ctx, svc, auth, codexResetCreditsURL, map[string]string{
 				"Content-Type": "application/json",
-				"User-Agent":   "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+				"User-Agent":   config.DefaultCodexFingerprintUserAgent,
 			}, func(req *http.Request) {
 				if accountID := codexAccountID(auth); accountID != "" {
 					req.Header.Set("Chatgpt-Account-Id", accountID)

--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -672,3 +672,52 @@ func TestParseAntigravityQuotaSummaryLabelsRowsByGroupOnly(t *testing.T) {
 		t.Fatalf("5h meta=%+v, want group and bucket descriptions joined", fiveHour)
 	}
 }
+
+// Only the products this proxy feeds carry the weekly window. That window is
+// what the budget projection selects on, so tagging Grok Chat with it would let
+// the projection anchor on consumption produced somewhere else entirely.
+func TestParseXAIWeeklyBillingWindowsOnlyAttributableProducts(t *testing.T) {
+	body := []byte(`{"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-08-20T06:45:51Z","end":"2026-08-27T06:45:51Z"},` +
+		`"creditUsagePercent":19,"productUsage":[{"product":"GrokBuild","usagePercent":16},{"product":"GrokChat","usagePercent":3},{"product":"GrokImagine"}]}}`)
+	items := parseXAIWeeklyBilling(body)
+
+	build := quotaByKey(items, "product:GrokBuild")
+	if build == nil || build.Percent == nil || *build.Percent != 84 {
+		t.Fatalf("build=%+v", build)
+	}
+	if build.WindowSeconds != 604800 || build.ResetAt == nil {
+		t.Fatalf("attributable product must carry the weekly window: %+v", build)
+	}
+
+	for _, key := range []string{"product:GrokChat", "product:GrokImagine"} {
+		item := quotaByKey(items, key)
+		if item == nil {
+			t.Fatalf("%s missing", key)
+		}
+		if item.WindowSeconds != 0 || item.ResetAt != nil {
+			t.Fatalf("%s must stay display-only, got window=%d reset=%v", key, item.WindowSeconds, item.ResetAt)
+		}
+	}
+
+	// The pool-wide window keeps reporting total consumption; it is what the
+	// "weekly quota used" figure shows.
+	weekly := quotaByKey(items, "weekly_limit")
+	if weekly == nil || weekly.Percent == nil || *weekly.Percent != 81 || weekly.WindowSeconds != 604800 {
+		t.Fatalf("weekly=%+v", weekly)
+	}
+}
+
+// Percentages reach the panel unrounded now; the displayed value is formatted
+// at the edge instead.
+func TestParseXAIWeeklyBillingKeepsFractionalPercent(t *testing.T) {
+	body := []byte(`{"config":{"currentPeriod":{"type":"WEEKLY","end":"2026-08-27T00:00:00Z"},"creditUsagePercent":2.4,` +
+		`"productUsage":[{"product":"GrokBuild","usagePercent":2.4}]}}`)
+	items := parseXAIWeeklyBilling(body)
+	weekly := quotaByKey(items, "weekly_limit")
+	if weekly == nil || weekly.Percent == nil || *weekly.Percent != 97.6 {
+		t.Fatalf("weekly percent=%+v, want 97.6", weekly)
+	}
+	if weekly.Value != "98%" {
+		t.Fatalf("weekly display value=%q, want 98%%", weekly.Value)
+	}
+}

--- a/internal/management/aiaccountstatus/probe_xai.go
+++ b/internal/management/aiaccountstatus/probe_xai.go
@@ -114,11 +114,12 @@ func parseXAIWeeklyBilling(body []byte) []usage.QuotaWindowDTO {
 		reset := weekly.ResetAt
 		resetAt = &reset
 	}
+	windowSeconds := weekly.WindowSeconds()
 	// Weekly cards already show relative reset from ResetAt; keep Meta empty so the
 	// UI is not flooded with raw ISO period strings like "2026-07-16T06:45:51+00:00 - …".
 	out := []usage.QuotaWindowDTO{{
 		QuotaKey: "weekly_limit", QuotaLabel: "xai_quota.weekly_limit", Percent: &weekly.RemainingPercent,
-		Value: formatPercent(weekly.RemainingPercent), ResetAt: resetAt, WindowSeconds: 604800,
+		Value: formatPercent(weekly.RemainingPercent), ResetAt: resetAt, WindowSeconds: windowSeconds,
 	}}
 	for index, product := range weekly.Products {
 		name := product.Name
@@ -126,10 +127,20 @@ func parseXAIWeeklyBilling(body []byte) []usage.QuotaWindowDTO {
 			name = fmt.Sprintf("Product %d", index+1)
 		}
 		remaining := product.RemainingPercent
-		out = append(out, usage.QuotaWindowDTO{
+		window := usage.QuotaWindowDTO{
 			QuotaKey: "product:" + name, QuotaLabel: "xai_quota.product_usage_named::" + name,
 			Percent: &remaining, Value: formatPercent(remaining),
-		})
+		}
+		// Attributable products carry the weekly window so the projection can pick
+		// them out of the snapshot series by width, the same way it selects every
+		// other provider's weekly quota. Products the proxy does not feed stay
+		// window-less: they are display-only, and giving them a weekly window would
+		// let the projection anchor on a share of the pool nobody here produced.
+		if product.Attributable {
+			window.ResetAt = resetAt
+			window.WindowSeconds = windowSeconds
+		}
+		out = append(out, window)
 	}
 	return out
 }

--- a/internal/management/aiaccountstatus/scheduler.go
+++ b/internal/management/aiaccountstatus/scheduler.go
@@ -1,0 +1,139 @@
+package aiaccountstatus
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// Scheduler re-probes every tenant's accounts on a fixed interval.
+//
+// Without it a quota snapshot only advances when a panel session asks for one.
+// That is enough while the proxy is the only thing spending the allowance, but
+// Grok bills its weekly pool across surfaces the proxy never sees: an account
+// drained by Grok Chat on the web reads as untouched here until somebody opens
+// the page. Everything the panel's refresh button does is reused, including the
+// per-account min-gap and the in-flight dedupe, so a scheduled round overlapping
+// a manual one costs no additional upstream calls.
+type Scheduler struct {
+	serviceFor func() *Service
+	authFor    func() *coreauth.Manager
+	interval   time.Duration
+	startDelay time.Duration
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+}
+
+// NewScheduler builds a scheduler. Both accessors are called per round rather
+// than captured once, because a config reload replaces the status service.
+func NewScheduler(serviceFor func() *Service, authFor func() *coreauth.Manager, interval, startDelay time.Duration) *Scheduler {
+	return &Scheduler{serviceFor: serviceFor, authFor: authFor, interval: interval, startDelay: startDelay}
+}
+
+// Start runs rounds until Stop. Restarting an already-running scheduler stops
+// the previous loop first, which is what a config reload needs.
+func (s *Scheduler) Start() {
+	if s == nil || s.serviceFor == nil || s.authFor == nil || s.interval <= 0 {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s.mu.Lock()
+	previous := s.cancel
+	s.cancel = cancel
+	s.mu.Unlock()
+	if previous != nil {
+		previous()
+	}
+
+	go s.loop(ctx)
+	log.Infof("ai account status: background refresh every %s", s.interval)
+}
+
+// Stop halts the loop. Safe to call when never started.
+func (s *Scheduler) Stop() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	cancel := s.cancel
+	s.cancel = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *Scheduler) loop(ctx context.Context) {
+	if s.startDelay > 0 {
+		timer := time.NewTimer(s.startDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		s.runRound()
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Scheduler) runRound() {
+	service := s.serviceFor()
+	if service == nil {
+		return
+	}
+	tenants := tenantIDsWithAccounts(s.authFor())
+	if len(tenants) == 0 {
+		return
+	}
+	var accepted, skipped int
+	for _, tenantID := range tenants {
+		// force=false on purpose: an account probed moments ago by the panel is
+		// reported as skipped rather than probed twice.
+		result := service.StartRefresh(tenantID, RefreshRequest{})
+		accepted += result.Accepted
+		skipped += len(result.Skipped)
+	}
+	if accepted > 0 {
+		log.Debugf("ai account status: scheduled refresh queued %d account(s) across %d tenant(s), %d already fresh",
+			accepted, len(tenants), skipped)
+	}
+}
+
+// tenantIDsWithAccounts lists the tenants that own at least one credential.
+// Tenants without credentials are skipped so an empty tenant does not cost a
+// job per round.
+func tenantIDsWithAccounts(manager *coreauth.Manager) []string {
+	if manager == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	tenants := make([]string, 0, 1)
+	for _, auth := range manager.List() {
+		if auth == nil {
+			continue
+		}
+		tenantID := strings.TrimSpace(auth.TenantID)
+		if _, ok := seen[tenantID]; ok {
+			continue
+		}
+		seen[tenantID] = struct{}{}
+		tenants = append(tenants, tenantID)
+	}
+	return tenants
+}

--- a/internal/management/aiaccountstatus/scheduler_test.go
+++ b/internal/management/aiaccountstatus/scheduler_test.go
@@ -1,0 +1,98 @@
+package aiaccountstatus
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// The reason the scheduler exists: an account nobody is looking at still gets
+// probed, so a Grok subscription drained by Grok Chat on the web stops reading
+// as untouched until a human opens the panel.
+func TestSchedulerProbesWithoutAPanelSession(t *testing.T) {
+	auth := &coreauth.Auth{ID: "id-a", Provider: "xai", FileName: "a.json", Metadata: map[string]any{"account_id": "acct-a"}}
+	manager := newTestManager(t, "tenant-1", auth)
+	svc := New(&config.Config{}, manager, func(string) *managementapitools.Service {
+		return managementapitools.NewForTenant("tenant-1", &config.Config{}, manager, managementapitools.Dependencies{})
+	}, nil)
+	var probes atomic.Int32
+	svc.SetProbeFunc(func(context.Context, *managementapitools.Service, *config.Config, *coreauth.Auth) (ProbeResult, error) {
+		probes.Add(1)
+		return ProbeResult{}, nil
+	})
+
+	scheduler := NewScheduler(func() *Service { return svc }, func() *coreauth.Manager { return manager }, 20*time.Millisecond, 0)
+	scheduler.Start()
+	defer scheduler.Stop()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if probes.Load() > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("scheduler never probed the account")
+}
+
+// Stop has to actually end the loop; a scheduler that keeps ticking after
+// shutdown keeps calling upstream during drain.
+func TestSchedulerStopEndsRounds(t *testing.T) {
+	auth := &coreauth.Auth{ID: "id-a", Provider: "xai", FileName: "a.json", Metadata: map[string]any{"account_id": "acct-a"}}
+	manager := newTestManager(t, "tenant-1", auth)
+	svc := New(&config.Config{}, manager, func(string) *managementapitools.Service {
+		return managementapitools.NewForTenant("tenant-1", &config.Config{}, manager, managementapitools.Dependencies{})
+	}, nil)
+	var rounds atomic.Int32
+	svc.SetProbeFunc(func(context.Context, *managementapitools.Service, *config.Config, *coreauth.Auth) (ProbeResult, error) {
+		rounds.Add(1)
+		return ProbeResult{}, nil
+	})
+
+	scheduler := NewScheduler(func() *Service { return svc }, func() *coreauth.Manager { return manager }, 10*time.Millisecond, 0)
+	scheduler.Start()
+	time.Sleep(60 * time.Millisecond)
+	scheduler.Stop()
+
+	settled := rounds.Load()
+	time.Sleep(80 * time.Millisecond)
+	// The per-account min-gap suppresses repeat probes, so the count may simply
+	// stop climbing; what must not happen is it climbing after Stop.
+	if grew := rounds.Load() - settled; grew > 1 {
+		t.Fatalf("rounds grew by %d after Stop", grew)
+	}
+}
+
+// Stopping something that never started, and starting twice, are both things a
+// config reload does.
+func TestSchedulerRestartAndStopWithoutStartAreSafe(t *testing.T) {
+	manager := newTestManager(t, "tenant-1")
+	svc := New(&config.Config{}, manager, nil, nil)
+
+	scheduler := NewScheduler(func() *Service { return svc }, func() *coreauth.Manager { return manager }, time.Hour, time.Hour)
+	scheduler.Stop()
+	scheduler.Start()
+	scheduler.Start()
+	scheduler.Stop()
+	scheduler.Stop()
+}
+
+// A tenant with no credentials must not cost a refresh job per round.
+func TestTenantIDsWithAccountsDedupesAndSkipsEmpty(t *testing.T) {
+	if got := tenantIDsWithAccounts(nil); got != nil {
+		t.Fatalf("nil manager tenants=%v, want nil", got)
+	}
+	manager := newTestManager(t, "tenant-1",
+		&coreauth.Auth{ID: "id-a", Provider: "xai", FileName: "a.json", Metadata: map[string]any{"account_id": "a"}},
+		&coreauth.Auth{ID: "id-b", Provider: "codex", FileName: "b.json", Metadata: map[string]any{"account_id": "b"}},
+	)
+	tenants := tenantIDsWithAccounts(manager)
+	if len(tenants) != 1 || tenants[0] != "tenant-1" {
+		t.Fatalf("tenants=%v, want [tenant-1]", tenants)
+	}
+}

--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -719,7 +719,7 @@ func (s *Service) loadPersistedStatus(subjectID string) (*usage.AIAccountSubject
 }
 
 func (s *Service) viewFromPersistedRecord(tenantID string, auth *coreauth.Auth, record usage.AIAccountSubjectStatusRecord) *AccountStatusView {
-	cycleStarts, _ := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{record.AuthSubjectID}, primaryWeeklyKeys(auth.Provider))
+	cycleStarts, _ := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{record.AuthSubjectID})
 	summaries, _ := usage.QueryAIAccountSubjectUsageSummaries([]string{record.AuthSubjectID}, cycleStarts)
 	subjects, _ := usage.ListAIAccountSubjects([]string{record.AuthSubjectID})
 	counts, _ := usage.CountAIAccountTenantBindings(tenantID, []string{record.AuthSubjectID})
@@ -841,17 +841,7 @@ func (s *Service) ListStatus(tenantID string, authIndexes, authSubjectIDs []stri
 	if err != nil {
 		return StatusListResponse{}, err
 	}
-	prefKeys := make([]string, 0)
-	prefSeen := map[string]struct{}{}
-	for _, auth := range wanted {
-		for _, key := range primaryWeeklyKeys(auth.Provider) {
-			if _, ok := prefSeen[key]; !ok {
-				prefSeen[key] = struct{}{}
-				prefKeys = append(prefKeys, key)
-			}
-		}
-	}
-	cycleStart, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs, prefKeys)
+	cycleStart, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs)
 	if err != nil {
 		return StatusListResponse{}, err
 	}

--- a/internal/management/aiaccountstatus/service.go
+++ b/internal/management/aiaccountstatus/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	xaiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/xai"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	managementapitools "github.com/router-for-me/CLIProxyAPI/v6/internal/management/apitools"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -680,9 +681,14 @@ func (s *Service) applyRuntimeQuotaProbe(ctx context.Context, auth *coreauth.Aut
 		if quota.QuotaKey != "weekly_limit" || quota.Percent == nil {
 			continue
 		}
+		// Same threshold the runtime recovery probe uses: percentages now carry
+		// upstream precision, and a fraction of a percent left cannot serve a
+		// request. Calling that recovered puts the credential back in rotation to
+		// take another 402 and cool down again, over and over until the reset.
+		exhausted := xaiauth.WeeklyBilling{RemainingPercent: *quota.Percent}.Exhausted()
 		result := &coreauth.QuotaProbeResult{
-			Recovered:       *quota.Percent > 0,
-			WindowExhausted: *quota.Percent <= 0,
+			Recovered:       !exhausted,
+			WindowExhausted: exhausted,
 			Window:          "week",
 			WindowMinutes:   10080,
 		}
@@ -901,90 +907,4 @@ func (s *Service) purgeExpiredJobs() {
 			delete(s.inFlight, key)
 		}
 	}
-}
-
-func flightKey(_ string, subjectID string) string {
-	return strings.TrimSpace(subjectID)
-}
-
-func reconcileTenantBindings(auths []*coreauth.Auth) error {
-	if len(auths) == 0 {
-		return nil
-	}
-	tenantID := ""
-	authIDs := make([]string, 0, len(auths))
-	for _, auth := range auths {
-		if auth != nil {
-			tenantID = auth.TenantID
-			if id := strings.TrimSpace(auth.ID); id != "" {
-				authIDs = append(authIDs, id)
-			}
-		}
-	}
-	rows, err := usage.ListAIAccountBindingsForTenantAuths(tenantID, authIDs)
-	if err != nil {
-		return err
-	}
-	byID := make(map[string]usage.AIAccountTenantBinding, len(rows))
-	for _, row := range rows {
-		byID[row.AuthID] = row
-	}
-	// Best-effort per auth: one bad binding row must not 500 the whole status list.
-	var firstErr error
-	for _, auth := range auths {
-		if auth == nil {
-			continue
-		}
-		identity := usage.ResolveAuthSubjectIdentity(auth)
-		if identity == nil {
-			continue
-		}
-		row, ok := byID[auth.ID]
-		if ok && row.BindingState == "active" && row.AuthSubjectID == identity.ID && row.AuthIndex == auth.EnsureIndex() && row.BindingSeedHash == identity.SeedHash {
-			continue
-		}
-		if err := usage.UpsertAIAccountTenantBinding(auth, identity); err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-		}
-	}
-	return firstErr
-}
-
-func sanitizeMsg(msg string) string {
-	msg = strings.TrimSpace(msg)
-	lower := strings.ToLower(msg)
-	if strings.Contains(lower, "bearer ") || strings.Contains(lower, "authorization:") {
-		return "upstream request failed"
-	}
-	if len(msg) > 200 {
-		return msg[:200]
-	}
-	return msg
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if s := strings.TrimSpace(v); s != "" {
-			return s
-		}
-	}
-	return ""
-}
-
-func metadataString(auth *coreauth.Auth, keys ...string) string {
-	if auth == nil || auth.Metadata == nil {
-		return ""
-	}
-	for _, key := range keys {
-		if v, ok := auth.Metadata[key]; ok {
-			if s, ok := v.(string); ok {
-				if t := strings.TrimSpace(s); t != "" {
-					return t
-				}
-			}
-		}
-	}
-	return ""
 }

--- a/internal/management/aiaccountstatus/service_cross_tenant_usage_test.go
+++ b/internal/management/aiaccountstatus/service_cross_tenant_usage_test.go
@@ -1,0 +1,99 @@
+package aiaccountstatus
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	_ "modernc.org/sqlite"
+)
+
+// One upstream account mounted by two tenants must read the same in both. It did
+// not: every seed but account_id folded tenant_id in, so a Google account became
+// one subject per tenant. The tenant that had not called it yet showed 0 calls
+// beside the whole account's quota, and the operator read that as "this tenant's
+// data has not synced".
+func TestListStatusReportsOneAccountIdenticallyInEveryTenant(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { usage.CloseDB(); _ = os.Remove(dbPath) })
+
+	const tenantBusy, tenantIdle = "tenant-busy", "tenant-idle"
+	busyAuth := &coreauth.Auth{
+		ID: tenantBusy + "/antigravity-shared@example.com.json", Provider: "antigravity",
+		FileName: "antigravity-busy.json", Metadata: map[string]any{"email": "shared@example.com"},
+	}
+	idleAuth := &coreauth.Auth{
+		ID: tenantIdle + "/antigravity-shared@example.com.json", Provider: "antigravity",
+		FileName: "antigravity-idle.json", Metadata: map[string]any{"email": "shared@example.com"},
+	}
+	busyManager := newTestManager(t, tenantBusy, busyAuth)
+	idleManager := newTestManager(t, tenantIdle, idleAuth)
+
+	identity := usage.ResolveAuthSubjectIdentity(busyAuth)
+	if identity == nil || identity.ID != usage.ResolveAuthSubjectIdentity(idleAuth).ID {
+		t.Fatalf("one account still resolves to two subjects: %+v", identity)
+	}
+	hook := usage.AIAccountBindingHook{}
+	hook.OnAuthLoaded(context.Background(), busyAuth)
+	hook.OnAuthLoaded(context.Background(), idleAuth)
+
+	checked := time.Now().UTC().Truncate(time.Second)
+	percent := 87.0
+	if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+		AuthSubjectID: identity.ID, Provider: "antigravity",
+		LastProbeState: string(RefreshSuccess), HealthStatus: "ok", PlanType: "google-ai-pro",
+		Quotas: []usage.QuotaWindowDTO{{
+			QuotaKey: "antigravity:gemini_weekly", Percent: &percent, WindowSeconds: 604800,
+		}},
+		UpstreamCheckedAt: &checked, UpdatedAt: checked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Only the busy tenant ever called the account; the subject projection is
+	// shared, so the idle tenant must still read the account's totals.
+	admin, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+	if _, err := admin.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets
+			(auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+			 failure_count, cost_total, total_tokens, first_event_at, updated_at)
+		VALUES (?, 'lifetime', '1970-01-01', 9, 9, 0, 3, 1234, ?, ?)
+	`, identity.ID, checked.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, view := range []struct {
+		tenant  string
+		manager *coreauth.Manager
+	}{{tenantBusy, busyManager}, {tenantIdle, idleManager}} {
+		response, err := New(&config.Config{}, view.manager, nil, nil).ListStatus(view.tenant, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(response.Items) != 1 {
+			t.Fatalf("%s items=%+v", view.tenant, response.Items)
+		}
+		item := response.Items[0]
+		if item.AuthSubjectID != identity.ID {
+			t.Fatalf("%s resolved subject %q, want %q", view.tenant, item.AuthSubjectID, identity.ID)
+		}
+		if item.Usage.RequestTotal != 9 || item.Usage.SuccessTotal != 9 {
+			t.Fatalf("%s usage = %+v, want the account total", view.tenant, item.Usage)
+		}
+		if item.PlanType != "google-ai-pro" {
+			t.Fatalf("%s plan = %q", view.tenant, item.PlanType)
+		}
+	}
+}

--- a/internal/management/aiaccountstatus/service_cycle_usage_test.go
+++ b/internal/management/aiaccountstatus/service_cycle_usage_test.go
@@ -1,0 +1,118 @@
+package aiaccountstatus
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	_ "modernc.org/sqlite"
+)
+
+// A tenant's accounts are resolved in one batch, and the batch used to carry a
+// single list of preferred quota keys assembled from every provider in it. Any
+// provider whose windows were not on that list — antigravity names its buckets
+// after whatever the upstream calls them — had all of its cycles filtered out,
+// so its cards reported no usage for the period while the other providers' cards
+// were fine.
+func TestListStatusKeepsCycleUsageForMixedProviders(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { usage.CloseDB(); _ = os.Remove(dbPath) })
+
+	const tenant = "tenant-mixed"
+	codexAuth := &coreauth.Auth{
+		ID: "codex-1", Provider: "codex", FileName: "codex-1.json",
+		Metadata: map[string]any{"account_id": "codex-account"},
+	}
+	antigravityAuth := &coreauth.Auth{
+		ID: "antigravity-1", Provider: "antigravity", FileName: "antigravity-1.json",
+		Metadata: map[string]any{"account_id": "antigravity-account"},
+	}
+	manager := newTestManager(t, tenant, codexAuth, antigravityAuth)
+
+	admin, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+
+	checked := time.Now().UTC().Truncate(time.Second)
+	resetAt := checked.Add(72 * time.Hour)
+	cycleStart := resetAt.Add(-7 * 24 * time.Hour)
+	percent := 61.0
+
+	accounts := []struct {
+		auth     *coreauth.Auth
+		provider string
+		quotaKey string
+		requests int64
+		tokens   int64
+	}{
+		{codexAuth, "codex", "code_week", 4, 4000},
+		{antigravityAuth, "antigravity", "antigravity:gemini_weekly", 7, 7000},
+	}
+	subjects := make(map[string]string, len(accounts))
+	for _, account := range accounts {
+		identity := usage.ResolveAuthSubjectIdentity(account.auth)
+		if identity == nil {
+			t.Fatalf("no identity for %s", account.auth.ID)
+		}
+		subjects[account.auth.ID] = identity.ID
+		if err := usage.UpsertAIAccountTenantBinding(account.auth, identity); err != nil {
+			t.Fatal(err)
+		}
+		if err := usage.UpsertAIAccountSubjectStatus(usage.AIAccountSubjectStatusRecord{
+			AuthSubjectID: identity.ID, Provider: account.provider,
+			LastProbeState: string(RefreshSuccess), HealthStatus: "ok",
+			Quotas:            []usage.QuotaWindowDTO{{QuotaKey: account.quotaKey, Percent: &percent}},
+			UpstreamCheckedAt: &checked, UpdatedAt: checked,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		reset := resetAt
+		if err := usage.RecordAIAccountSubjectQuotaPoints(identity.ID, account.provider, []usage.QuotaSnapshotPoint{{
+			RecordedAt: checked, Provider: account.provider, QuotaKey: account.quotaKey,
+			QuotaLabel: account.quotaKey, Percent: &percent, ResetAt: &reset, WindowSeconds: 604800,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := admin.Exec(`
+			INSERT INTO ai_account_subject_usage_buckets
+				(auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+				 failure_count, cost_total, total_tokens, first_event_at, updated_at)
+			VALUES (?, 'cycle', ?, ?, ?, 0, 0, ?, ?, ?)
+		`, identity.ID, cycleStart.Format(time.RFC3339Nano), account.requests, account.requests,
+			account.tokens, cycleStart.Format(time.RFC3339Nano), checked.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	response, listErr := New(&config.Config{}, manager, nil, nil).ListStatus(tenant, nil, nil)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(response.Items) != len(accounts) {
+		t.Fatalf("items=%d, want %d", len(response.Items), len(accounts))
+	}
+	bySubject := make(map[string]AccountStatusView, len(response.Items))
+	for _, item := range response.Items {
+		bySubject[item.AuthSubjectID] = item
+	}
+	for _, account := range accounts {
+		item, ok := bySubject[subjects[account.auth.ID]]
+		if !ok {
+			t.Fatalf("%s missing from status list", account.provider)
+		}
+		if !item.Usage.CycleKnown || item.Usage.CycleRequestTotal != account.requests {
+			t.Fatalf("%s cycle usage = %+v, want %d requests",
+				account.provider, item.Usage, account.requests)
+		}
+	}
+}

--- a/internal/management/aiaccountstatus/service_helpers.go
+++ b/internal/management/aiaccountstatus/service_helpers.go
@@ -1,0 +1,94 @@
+package aiaccountstatus
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func flightKey(_ string, subjectID string) string {
+	return strings.TrimSpace(subjectID)
+}
+
+func reconcileTenantBindings(auths []*coreauth.Auth) error {
+	if len(auths) == 0 {
+		return nil
+	}
+	tenantID := ""
+	authIDs := make([]string, 0, len(auths))
+	for _, auth := range auths {
+		if auth != nil {
+			tenantID = auth.TenantID
+			if id := strings.TrimSpace(auth.ID); id != "" {
+				authIDs = append(authIDs, id)
+			}
+		}
+	}
+	rows, err := usage.ListAIAccountBindingsForTenantAuths(tenantID, authIDs)
+	if err != nil {
+		return err
+	}
+	byID := make(map[string]usage.AIAccountTenantBinding, len(rows))
+	for _, row := range rows {
+		byID[row.AuthID] = row
+	}
+	// Best-effort per auth: one bad binding row must not 500 the whole status list.
+	var firstErr error
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		identity := usage.ResolveAuthSubjectIdentity(auth)
+		if identity == nil {
+			continue
+		}
+		row, ok := byID[auth.ID]
+		if ok && row.BindingState == "active" && row.AuthSubjectID == identity.ID && row.AuthIndex == auth.EnsureIndex() && row.BindingSeedHash == identity.SeedHash {
+			continue
+		}
+		if err := usage.UpsertAIAccountTenantBinding(auth, identity); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func sanitizeMsg(msg string) string {
+	msg = strings.TrimSpace(msg)
+	lower := strings.ToLower(msg)
+	if strings.Contains(lower, "bearer ") || strings.Contains(lower, "authorization:") {
+		return "upstream request failed"
+	}
+	if len(msg) > 200 {
+		return msg[:200]
+	}
+	return msg
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func metadataString(auth *coreauth.Auth, keys ...string) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	for _, key := range keys {
+		if v, ok := auth.Metadata[key]; ok {
+			if s, ok := v.(string); ok {
+				if t := strings.TrimSpace(s); t != "" {
+					return t
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -57,6 +57,10 @@ func ApplyStatusPatch(auth *coreauth.Auth, disabled bool, now time.Time) error {
 		auth.Status = coreauth.StatusActive
 		auth.StatusMessage = ""
 	}
+	// Keep the in-memory metadata projection aligned with the runtime flag.
+	// Stores mirror it again on save, but the manager hands this same metadata
+	// to field patches and list responses in between.
+	coreauth.SyncPersistedDisabled(auth)
 	auth.UpdatedAt = now
 	return nil
 }

--- a/internal/management/authfiles/patch_status_persistence_test.go
+++ b/internal/management/authfiles/patch_status_persistence_test.go
@@ -1,0 +1,145 @@
+package authfiles
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	codexauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	sdkauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// The management toggle is only useful if it survives a reload: the auth file on
+// disk must carry the new state, and loading that file back must reproduce it.
+func TestPatchStatusPersistsDisabledAcrossReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex-toggle.json")
+	metadata := map[string]any{
+		"type":          "codex",
+		"email":         "toggle@example.com",
+		"access_token":  "at",
+		"refresh_token": "rt",
+		"disabled":      false,
+	}
+	seed, errMarshal := json.Marshal(metadata)
+	if errMarshal != nil {
+		t.Fatalf("Marshal: %v", errMarshal)
+	}
+	if errWrite := os.WriteFile(path, seed, 0o600); errWrite != nil {
+		t.Fatalf("WriteFile: %v", errWrite)
+	}
+
+	store := sdkauth.NewFileTokenStore()
+	store.SetBaseDir(dir)
+	manager := coreauth.NewManager(store, nil, nil)
+	if _, errRegister := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "codex-toggle.json",
+		FileName:   "codex-toggle.json",
+		Provider:   "codex",
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"path": path},
+		Metadata:   metadata,
+		// OAuth credentials keep a TokenStorage; the disabled flag has to be
+		// mirrored through it too.
+		Storage: &codexauth.CodexTokenStorage{
+			AccessToken:  "at",
+			RefreshToken: "rt",
+			Email:        "toggle@example.com",
+			Type:         "codex",
+		},
+	}); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	service := PatchService{Manager: manager, Repository: Repository{Store: store, BaseDir: dir}}
+
+	for _, step := range []struct {
+		name     string
+		disabled bool
+	}{
+		{name: "disable", disabled: true},
+		{name: "re-enable", disabled: false},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			disabled := step.disabled
+			result, errPatch := service.PatchStatus(context.Background(), StatusPatch{
+				Name:     "codex-toggle.json",
+				Disabled: &disabled,
+			})
+			if errPatch != nil {
+				t.Fatalf("PatchStatus: %v", errPatch)
+			}
+			if result.Disabled != step.disabled {
+				t.Fatalf("result disabled = %v, want %v", result.Disabled, step.disabled)
+			}
+
+			raw, errRead := os.ReadFile(path)
+			if errRead != nil {
+				t.Fatalf("ReadFile: %v", errRead)
+			}
+			onDisk := map[string]any{}
+			if errUnmarshal := json.Unmarshal(raw, &onDisk); errUnmarshal != nil {
+				t.Fatalf("Unmarshal: %v", errUnmarshal)
+			}
+			if onDisk["disabled"] != step.disabled {
+				t.Fatalf("on-disk disabled = %#v, want %v", onDisk["disabled"], step.disabled)
+			}
+
+			reloaded, errList := store.List(context.Background())
+			if errList != nil {
+				t.Fatalf("List: %v", errList)
+			}
+			if len(reloaded) != 1 {
+				t.Fatalf("reloaded auth count = %d, want 1", len(reloaded))
+			}
+			if reloaded[0].Disabled != step.disabled {
+				t.Fatalf("reloaded Disabled = %v, want %v", reloaded[0].Disabled, step.disabled)
+			}
+			wantStatus := coreauth.StatusActive
+			if step.disabled {
+				wantStatus = coreauth.StatusDisabled
+			}
+			if reloaded[0].Status != wantStatus {
+				t.Fatalf("reloaded Status = %q, want %q", reloaded[0].Status, wantStatus)
+			}
+		})
+	}
+}
+
+// ApplyStatusPatch owns the in-memory projection; stores mirror it again on save.
+func TestApplyStatusPatchSyncsMetadata(t *testing.T) {
+	auth := &coreauth.Auth{Status: coreauth.StatusActive, Metadata: map[string]any{"type": "codex"}}
+	if err := ApplyStatusPatch(auth, true, time.Time{}); err != nil {
+		t.Fatalf("ApplyStatusPatch: %v", err)
+	}
+	if auth.Metadata[coreauth.DisabledMetadataKey] != true {
+		t.Fatalf("metadata disabled = %#v, want true", auth.Metadata[coreauth.DisabledMetadataKey])
+	}
+	if err := ApplyStatusPatch(auth, false, time.Time{}); err != nil {
+		t.Fatalf("ApplyStatusPatch: %v", err)
+	}
+	if auth.Metadata[coreauth.DisabledMetadataKey] != false {
+		t.Fatalf("metadata disabled = %#v, want false", auth.Metadata[coreauth.DisabledMetadataKey])
+	}
+}
+
+// Config-derived API keys live in config.yaml and own no auth file. Toggling one
+// must stay in memory instead of materializing a JSON file in the auth dir.
+func TestApplyStatusPatchLeavesConfigDerivedAuthUnpersisted(t *testing.T) {
+	auth := &coreauth.Auth{
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"source": "config:gemini[abc]", "api_key": "key"},
+	}
+	if err := ApplyStatusPatch(auth, true, time.Time{}); err != nil {
+		t.Fatalf("ApplyStatusPatch: %v", err)
+	}
+	if auth.Metadata != nil {
+		t.Fatalf("Metadata = %#v, want nil", auth.Metadata)
+	}
+	if !auth.Disabled || auth.Status != coreauth.StatusDisabled {
+		t.Fatalf("Disabled=%v Status=%q, want disabled", auth.Disabled, auth.Status)
+	}
+}

--- a/internal/management/authfiles/proxy_binding.go
+++ b/internal/management/authfiles/proxy_binding.go
@@ -1,0 +1,31 @@
+package authfiles
+
+import (
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// BindProxyID attaches a proxy-pool entry to an auth record.
+//
+// Both places have to be written. Auth.ProxyID is what the runtime reads when it
+// picks an egress route — APICallTransport and the executors resolve it through
+// Config.ResolveProxyURL — while metadata["proxy_id"] is what survives to disk
+// and is read back by RecordFromMetadata on reload. Setting only the field gives
+// a binding that disappears on restart; setting only the metadata gives one that
+// does not take effect until then.
+//
+// An empty proxyID is a no-op rather than an unbind: callers that mean to clear a
+// binding go through the patch path, which distinguishes "not supplied" from
+// "set to empty".
+func BindProxyID(auth *coreauth.Auth, proxyID string) {
+	if auth == nil {
+		return
+	}
+	proxyID = strings.TrimSpace(proxyID)
+	if proxyID == "" {
+		return
+	}
+	auth.ProxyID = proxyID
+	ensureMetadata(auth)["proxy_id"] = proxyID
+}

--- a/internal/management/oauth/providers/antigravity/flow.go
+++ b/internal/management/oauth/providers/antigravity/flow.go
@@ -49,6 +49,7 @@ type OAuthLoginOptions struct {
 	Config              *config.Config
 	Auth                OAuthAuth
 	AuthDir             string
+	ProxyURL            string
 	WebUI               bool
 	CallbackPort        int
 	CallbackWaitTimeout time.Duration
@@ -72,7 +73,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 
 	auth := opts.Auth
 	if auth == nil {
-		auth = internalantigravity.NewAntigravityAuth(opts.Config, nil)
+		auth = internalantigravity.NewAntigravityAuthWithProxy(opts.Config, opts.ProxyURL)
 	}
 
 	generateState := opts.GenerateState

--- a/internal/management/oauth/providers/claude/flow.go
+++ b/internal/management/oauth/providers/claude/flow.go
@@ -51,6 +51,7 @@ type OAuthLoginOptions struct {
 	Config                *config.Config
 	Auth                  OAuthAuth
 	AuthDir               string
+	ProxyURL              string
 	WebUI                 bool
 	PreferredCallbackPort int
 	CallbackWaitTimeout   time.Duration
@@ -92,7 +93,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 
 	auth := opts.Auth
 	if auth == nil {
-		auth = internalclaude.NewClaudeAuth(opts.Config)
+		auth = internalclaude.NewClaudeAuthWithProxy(opts.Config, opts.ProxyURL)
 	}
 
 	redirectURI, forwarder, callbackPort := resolveRedirectURI(opts)

--- a/internal/management/oauth/providers/codex/flow.go
+++ b/internal/management/oauth/providers/codex/flow.go
@@ -50,6 +50,7 @@ type OAuthLoginOptions struct {
 	Config              *config.Config
 	Auth                OAuthAuth
 	AuthDir             string
+	ProxyURL            string
 	WebUI               bool
 	CallbackPort        int
 	CallbackWaitTimeout time.Duration
@@ -91,7 +92,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 
 	auth := opts.Auth
 	if auth == nil {
-		auth = internalcodex.NewCodexAuth(opts.Config)
+		auth = internalcodex.NewCodexAuthWithProxy(opts.Config, opts.ProxyURL)
 	}
 	authURL, errAuthURL := auth.GenerateAuthURL(state, pkceCodes)
 	if errAuthURL != nil {

--- a/internal/management/oauth/providers/xai/flow.go
+++ b/internal/management/oauth/providers/xai/flow.go
@@ -51,6 +51,7 @@ type OAuthLoginOptions struct {
 	Config              *config.Config
 	Auth                OAuthAuth
 	AuthDir             string
+	ProxyURL            string
 	WebUI               bool
 	UsingAPI            bool
 	CallbackPort        int
@@ -95,7 +96,7 @@ func StartOAuthLogin(ctx context.Context, opts OAuthLoginOptions) (OAuthLoginRes
 
 	auth := opts.Auth
 	if auth == nil {
-		auth = internalxai.NewXAIAuth(opts.Config)
+		auth = internalxai.NewXAIAuthWithProxyURL(opts.Config, opts.ProxyURL)
 	}
 	discovery, errDiscovery := auth.Discover(ctx)
 	if errDiscovery != nil {

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -144,6 +144,7 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 		series = []usage.QuotaSnapshotSeries{}
 	}
 	weeklyQuotaUsed := latestWeeklyQuotaUsedPercent(series, preferredWeeklyQuotaKeys...)
+	projectionQuotaUsed := latestProjectionQuotaUsedPercent(series, auth.Provider)
 
 	cycleStarts, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID})
 	if err != nil {
@@ -177,19 +178,21 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 	}
 
 	return http.StatusOK, AuthFileTrendResponse{
-		AuthIndex:         authIndex,
-		Days:              days,
-		Hours:             hours,
-		RequestTotal:      requestTotal,
-		CycleRequestTotal: cycleRequestTotal,
-		CycleCostTotal:    cycleCostTotal,
-		CycleTotalTokens:  cycleTotalTokens,
-		WeeklyQuotaUsed:   weeklyQuotaUsed,
-		CycleKnown:        cycleKnown,
-		CycleStart:        cycleStartStr,
-		DailyUsage:        daily,
-		HourlyUsage:       hourly,
-		QuotaSeries:       series,
+		AuthIndex:                   authIndex,
+		Days:                        days,
+		Hours:                       hours,
+		RequestTotal:                requestTotal,
+		CycleRequestTotal:           cycleRequestTotal,
+		CycleCostTotal:              cycleCostTotal,
+		CycleTotalTokens:            cycleTotalTokens,
+		WeeklyQuotaUsed:             weeklyQuotaUsed,
+		ProjectionQuotaUsed:         projectionQuotaUsed,
+		ProjectionQuotaAttributable: usage.ProjectionQuotaIsAttributable(auth.Provider),
+		CycleKnown:                  cycleKnown,
+		CycleStart:                  cycleStartStr,
+		DailyUsage:                  daily,
+		HourlyUsage:                 hourly,
+		QuotaSeries:                 series,
 	}
 }
 
@@ -227,6 +230,7 @@ func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.A
 		series = []usage.QuotaSnapshotSeries{}
 	}
 	weeklyQuotaUsed := latestWeeklyQuotaUsedPercent(series, preferredWeeklyQuotaKeys...)
+	projectionQuotaUsed := latestProjectionQuotaUsedPercent(series, auth.Provider)
 
 	var cycleStart time.Time
 	if identity := usage.ResolveAuthSubjectIdentity(auth); identity != nil && identity.ID != "" {
@@ -267,19 +271,21 @@ func (s *Service) authFileTrendFromTenantLogs(authIndex string, auth *coreauth.A
 		cycleStartStr = cycleStart.UTC().Format(time.RFC3339)
 	}
 	return http.StatusOK, AuthFileTrendResponse{
-		AuthIndex:         authIndex,
-		Days:              days,
-		Hours:             hours,
-		RequestTotal:      requestTotal,
-		CycleRequestTotal: cycleRequestTotal,
-		CycleCostTotal:    cycleCostTotal,
-		CycleTotalTokens:  cycleTotalTokens,
-		WeeklyQuotaUsed:   weeklyQuotaUsed,
-		CycleKnown:        cycleKnown,
-		CycleStart:        cycleStartStr,
-		DailyUsage:        daily,
-		HourlyUsage:       hourly,
-		QuotaSeries:       series,
+		AuthIndex:                   authIndex,
+		Days:                        days,
+		Hours:                       hours,
+		RequestTotal:                requestTotal,
+		CycleRequestTotal:           cycleRequestTotal,
+		CycleCostTotal:              cycleCostTotal,
+		CycleTotalTokens:            cycleTotalTokens,
+		WeeklyQuotaUsed:             weeklyQuotaUsed,
+		ProjectionQuotaUsed:         projectionQuotaUsed,
+		ProjectionQuotaAttributable: usage.ProjectionQuotaIsAttributable(auth.Provider),
+		CycleKnown:                  cycleKnown,
+		CycleStart:                  cycleStartStr,
+		DailyUsage:                  daily,
+		HourlyUsage:                 hourly,
+		QuotaSeries:                 series,
 	}
 }
 
@@ -308,10 +314,61 @@ func fillDailyUsagePoints(points []usage.DailyUsagePoint, days int) []usage.Dail
 
 func latestWeeklyQuotaUsedPercent(series []usage.QuotaSnapshotSeries, preferredQuotaKeys ...string) *float64 {
 	latest := latestWeeklyQuotaPercentPoint(series, preferredQuotaKeys...)
-	if latest == nil || latest.Percent == nil {
+	return quotaUsedPercentFromPoint(latest)
+}
+
+// latestProjectionQuotaUsedPercent picks the divisor for the weekly-budget
+// projection: the consumption share produced by traffic this proxy forwards.
+//
+// Unlike latestWeeklyQuotaUsedPercent this does not fall back to "any weekly
+// window". A wrong divisor here does not degrade the projection, it inverts its
+// meaning — dividing Grok Build cost by pool-wide consumption reports a smaller
+// budget the more the account uses Grok Chat. Returning nil lets the caller fall
+// back explicitly, at the pool-wide number it already has.
+func latestProjectionQuotaUsedPercent(series []usage.QuotaSnapshotSeries, provider string) *float64 {
+	// Summed, not "latest wins": several attributable windows are several slices
+	// of one pool, and the projection needs the whole attributable slice. Each
+	// window contributes its own most recent reading.
+	var total float64
+	var found bool
+	for i := range series {
+		if series[i].WindowSeconds < usage.WeeklyQuotaWindowSeconds {
+			continue
+		}
+		if !usage.MatchesProjectionQuotaKey(provider, series[i].QuotaKey) {
+			continue
+		}
+		var latestPoint *usage.QuotaSnapshotSeriesPoint
+		for j := range series[i].Points {
+			point := &series[i].Points[j]
+			if point.Percent == nil {
+				continue
+			}
+			if latestPoint == nil || point.Timestamp.After(latestPoint.Timestamp) {
+				latestPoint = point
+			}
+		}
+		used := quotaUsedPercentFromPoint(latestPoint)
+		if used == nil {
+			continue
+		}
+		total += *used
+		found = true
+	}
+	if !found {
 		return nil
 	}
-	value := 100 - *latest.Percent
+	if total > 100 {
+		total = 100
+	}
+	return &total
+}
+
+func quotaUsedPercentFromPoint(point *usage.QuotaSnapshotSeriesPoint) *float64 {
+	if point == nil || point.Percent == nil {
+		return nil
+	}
+	value := 100 - *point.Percent
 	if value < 0 {
 		value = 0
 	}

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -145,7 +145,7 @@ func (s *Service) authFileTrendFromSharedSubject(authIndex string, auth *coreaut
 	}
 	weeklyQuotaUsed := latestWeeklyQuotaUsedPercent(series, preferredWeeklyQuotaKeys...)
 
-	cycleStarts, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID}, preferredWeeklyQuotaKeys)
+	cycleStarts, err := usage.QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID})
 	if err != nil {
 		return http.StatusInternalServerError, map[string]any{"error": err.Error()}
 	}

--- a/internal/management/usagelogs/trends_projection_quota_test.go
+++ b/internal/management/usagelogs/trends_projection_quota_test.go
@@ -1,0 +1,113 @@
+package usagelogs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func percentPtr(v float64) *float64 { return &v }
+
+func quotaSeries(quotaKey string, windowSeconds int64, points ...usage.QuotaSnapshotSeriesPoint) usage.QuotaSnapshotSeries {
+	return usage.QuotaSnapshotSeries{QuotaKey: quotaKey, WindowSeconds: windowSeconds, Points: points}
+}
+
+// A live SuperGrok account: 19% of the shared weekly pool spent, of which 16%
+// is Grok Build (this proxy) and 3% is Grok Chat (the web app). The panel shows
+// 19% consumed, but the budget projection divides Grok Build cost, so it must
+// divide by 16.
+func TestProjectionQuotaUsedIgnoresNonAttributableConsumption(t *testing.T) {
+	t.Parallel()
+
+	older := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	series := []usage.QuotaSnapshotSeries{
+		quotaSeries("weekly_limit", 604800,
+			usage.QuotaSnapshotSeriesPoint{Timestamp: older, Percent: percentPtr(88)},
+			usage.QuotaSnapshotSeriesPoint{Timestamp: newer, Percent: percentPtr(81)},
+		),
+		quotaSeries("product:GrokBuild", 604800,
+			usage.QuotaSnapshotSeriesPoint{Timestamp: older, Percent: percentPtr(90)},
+			usage.QuotaSnapshotSeriesPoint{Timestamp: newer, Percent: percentPtr(84)},
+		),
+		// Not window-tagged by the probe, so it can never be selected even
+		// though it is a product window.
+		quotaSeries("product:GrokChat", 0,
+			usage.QuotaSnapshotSeriesPoint{Timestamp: newer, Percent: percentPtr(97)},
+		),
+	}
+
+	weekly := latestWeeklyQuotaUsedPercent(series, "weekly_limit")
+	if weekly == nil || *weekly != 19 {
+		t.Fatalf("pool-wide used=%v, want 19", weekly)
+	}
+	projection := latestProjectionQuotaUsedPercent(series, "xai")
+	if projection == nil || *projection != 16 {
+		t.Fatalf("projection used=%v, want 16", projection)
+	}
+
+	// The concrete regression: $128.4874 of recorded Grok Build cost.
+	const cost = 128.4874
+	if got := cost / (*weekly / 100); got > 700 {
+		t.Fatalf("sanity: pool-wide divisor should understate the budget, got %v", got)
+	}
+	if got := cost / (*projection / 100); got < 800 {
+		t.Fatalf("attributable divisor budget=%v, want the pool-sized ~803", got)
+	}
+}
+
+// Without a product breakdown there is nothing attributable to divide by; the
+// caller has to be told so it can fall back rather than divide by a zero this
+// function invented.
+func TestProjectionQuotaUsedNilWithoutAttributableWindow(t *testing.T) {
+	t.Parallel()
+
+	series := []usage.QuotaSnapshotSeries{
+		quotaSeries("weekly_limit", 604800,
+			usage.QuotaSnapshotSeriesPoint{
+				Timestamp: time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC),
+				Percent:   percentPtr(81),
+			},
+		),
+	}
+	if got := latestProjectionQuotaUsedPercent(series, "xai"); got != nil {
+		t.Fatalf("projection used=%v, want nil", *got)
+	}
+}
+
+// Providers that bill one pool per surface keep using their primary window, so
+// the projection is unchanged for them.
+func TestProjectionQuotaUsedMatchesPrimaryWindowForOtherProviders(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	series := []usage.QuotaSnapshotSeries{
+		quotaSeries("code_week", 604800, usage.QuotaSnapshotSeriesPoint{Timestamp: at, Percent: percentPtr(40)}),
+		quotaSeries("code_5h", 18000, usage.QuotaSnapshotSeriesPoint{Timestamp: at, Percent: percentPtr(10)}),
+	}
+	projection := latestProjectionQuotaUsedPercent(series, "codex")
+	weekly := latestWeeklyQuotaUsedPercent(series, "code_week")
+	if projection == nil || weekly == nil || *projection != *weekly {
+		t.Fatalf("codex projection=%v weekly=%v, want equal", projection, weekly)
+	}
+	if *projection != 60 {
+		t.Fatalf("codex projection used=%v, want 60", *projection)
+	}
+}
+
+// Several attributable windows are several slices of one pool, so the divisor
+// is their sum — taking whichever was written last would drop the rest.
+func TestProjectionQuotaUsedSumsAttributableWindows(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	series := []usage.QuotaSnapshotSeries{
+		quotaSeries("product:GrokBuild", 604800, usage.QuotaSnapshotSeriesPoint{Timestamp: at, Percent: percentPtr(90)}),
+		quotaSeries("product:grok-code", 604800, usage.QuotaSnapshotSeriesPoint{Timestamp: at, Percent: percentPtr(95)}),
+	}
+	got := latestProjectionQuotaUsedPercent(series, "xai")
+	if got == nil || *got != 15 {
+		t.Fatalf("summed projection used=%v, want 15", got)
+	}
+}

--- a/internal/management/usagelogs/types.go
+++ b/internal/management/usagelogs/types.go
@@ -48,17 +48,30 @@ type AuthFileGroupTrendResponse struct {
 }
 
 type AuthFileTrendResponse struct {
-	AuthIndex         string                      `json:"auth_index"`
-	Days              int                         `json:"days"`
-	Hours             int                         `json:"hours"`
-	RequestTotal      int64                       `json:"request_total"`
-	CycleRequestTotal int64                       `json:"cycle_request_total"`
-	CycleCostTotal    float64                     `json:"cycle_cost_total"`
-	CycleTotalTokens  int64                       `json:"cycle_total_tokens"`
-	WeeklyQuotaUsed   *float64                    `json:"weekly_quota_used_percent"`
-	CycleKnown        bool                        `json:"cycle_known"`
-	CycleStart        string                      `json:"cycle_start"`
-	DailyUsage        []usage.DailyUsagePoint     `json:"daily_usage"`
-	HourlyUsage       []usage.HourlyUsagePoint    `json:"hourly_usage"`
-	QuotaSeries       []usage.QuotaSnapshotSeries `json:"quota_series"`
+	AuthIndex         string  `json:"auth_index"`
+	Days              int     `json:"days"`
+	Hours             int     `json:"hours"`
+	RequestTotal      int64   `json:"request_total"`
+	CycleRequestTotal int64   `json:"cycle_request_total"`
+	CycleCostTotal    float64 `json:"cycle_cost_total"`
+	CycleTotalTokens  int64   `json:"cycle_total_tokens"`
+	// WeeklyQuotaUsed is the pool-wide share consumed this cycle — what the
+	// account has spent in total, including surfaces the proxy does not serve.
+	WeeklyQuotaUsed *float64 `json:"weekly_quota_used_percent"`
+	// ProjectionQuotaUsed is the share consumed by traffic this proxy forwards,
+	// and the only correct divisor for the weekly-budget projection: the cost
+	// it is divided into covers those requests and no others. Equal to
+	// WeeklyQuotaUsed for providers that bill one pool per surface; smaller for
+	// xAI, whose weekly pool is shared with Grok Chat and friends. Nil when
+	// upstream reported no attributable window, and callers fall back to
+	// WeeklyQuotaUsed rather than dropping the projection.
+	ProjectionQuotaUsed *float64 `json:"projection_quota_used_percent"`
+	// ProjectionQuotaAttributable tells the panel the two percentages above can
+	// legitimately differ, so it can say so instead of looking self-inconsistent.
+	ProjectionQuotaAttributable bool                        `json:"projection_quota_attributable"`
+	CycleKnown                  bool                        `json:"cycle_known"`
+	CycleStart                  string                      `json:"cycle_start"`
+	DailyUsage                  []usage.DailyUsagePoint     `json:"daily_usage"`
+	HourlyUsage                 []usage.HourlyUsagePoint    `json:"hourly_usage"`
+	QuotaSeries                 []usage.QuotaSnapshotSeries `json:"quota_series"`
 }

--- a/internal/runtime/executor/antigravity_count_tokens.go
+++ b/internal/runtime/executor/antigravity_count_tokens.go
@@ -87,12 +87,11 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 			return cliproxyexecutor.Response{Payload: []byte(translated), Headers: httpResp.Header.Clone()}, nil
 		}
 
-		lastStatus = httpResp.StatusCode
-		lastBody = append([]byte(nil), bodyBytes...)
-		lastErr = nil
-		// 429 is an account-level RESOURCE_EXHAUSTED signal, not a
+		// This branch now always returns below, so it no longer needs to
+		// leave a lastStatus/lastBody/lastErr trail for the post-loop
+		// switch — 429 is an account-level RESOURCE_EXHAUSTED signal, not a
 		// host-specific hiccup: see antigravity_executor.go for the
-		// production trace that motivated dropping this fallback.
+		// production trace that motivated dropping the host fallback.
 		sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
 		if httpResp.StatusCode == http.StatusTooManyRequests {
 			if retryAfter, parseErr := parseRetryDelay(bodyBytes); parseErr == nil && retryAfter != nil {

--- a/internal/runtime/executor/antigravity_count_tokens.go
+++ b/internal/runtime/executor/antigravity_count_tokens.go
@@ -90,10 +90,9 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 		lastStatus = httpResp.StatusCode
 		lastBody = append([]byte(nil), bodyBytes...)
 		lastErr = nil
-		if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-			log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-			continue
-		}
+		// 429 is an account-level RESOURCE_EXHAUSTED signal, not a
+		// host-specific hiccup: see antigravity_executor.go for the
+		// production trace that motivated dropping this fallback.
 		sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
 		if httpResp.StatusCode == http.StatusTooManyRequests {
 			if retryAfter, parseErr := parseRetryDelay(bodyBytes); parseErr == nil && retryAfter != nil {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -203,10 +203,13 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
+				// 429 is an account-level RESOURCE_EXHAUSTED signal, not a
+				// host-specific hiccup: production traces show the same auth
+				// getting 429 on both sandbox and daily back to back, so
+				// falling back to the other host here only burns a second
+				// attempt on an account that's already known to be limited,
+				// leaving the outer selector fewer retries to reach a
+				// different, healthy account.
 				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
 					if idx+1 < len(baseURLs) {
 						log.Debugf("antigravity executor: no capacity on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])

--- a/internal/runtime/executor/antigravity_nonstream.go
+++ b/internal/runtime/executor/antigravity_nonstream.go
@@ -112,10 +112,9 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
+				// 429 is an account-level RESOURCE_EXHAUSTED signal, not a
+				// host-specific hiccup: see antigravity_executor.go for the
+				// production trace that motivated dropping this fallback.
 				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
 					if idx+1 < len(baseURLs) {
 						log.Debugf("antigravity executor: no capacity on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -478,7 +478,9 @@ func (e *ClaudeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (
 	if refreshToken == "" {
 		return auth, nil
 	}
-	svc := claudeauth.NewClaudeAuth(e.cfg)
+	// Refresh goes out through this credential's own proxy, not the process
+	// default, so the token is renewed from the address that uses it.
+	svc := claudeauth.NewClaudeAuthWithProxy(e.cfg, resolveAuthProxyURL(e.cfg, auth))
 	td, err := svc.RefreshTokens(ctx, refreshToken)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/codex_auth.go
+++ b/internal/runtime/executor/codex_auth.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	// Keep defaults aligned with upstream CLIProxyAPI (codex-tui).
-	codexUserAgent  = "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
-	codexOriginator = "codex-tui"
+	// Fallback identity for requests that bypass the fingerprint resolver. Kept in
+	// sync with config.DefaultCodexFingerprint* so both paths present the same
+	// official Codex CLI identity; see that block for why `codex-tui` was dropped.
+	codexUserAgent  = config.DefaultCodexFingerprintUserAgent
+	codexOriginator = config.DefaultCodexFingerprintOriginator
 )
 
 func applyCodexHeaders(r *http.Request, cfg *config.Config, auth *cliproxyauth.Auth, token string, stream bool) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -540,7 +540,9 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	if refreshToken == "" {
 		return auth, nil
 	}
-	svc := codexauth.NewCodexAuth(e.cfg)
+	// Refresh goes out through this credential's own proxy, not the process
+	// default, so the token is renewed from the address that uses it.
+	svc := codexauth.NewCodexAuthWithProxy(e.cfg, resolveAuthProxyURL(e.cfg, auth))
 	td, err := svc.RefreshTokensWithRetry(ctx, refreshToken, 3)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/codex_fingerprint_convergence.go
+++ b/internal/runtime/executor/codex_fingerprint_convergence.go
@@ -46,11 +46,20 @@ type codexConvergedIDs struct {
 	threadID       string
 	turnID         string
 	windowID       string
+	// clientRequestID mirrors x-client-request-id. Official Codex sets it to the
+	// thread id, but device mode scopes whatever the client actually sent rather
+	// than assuming that equality holds for every client.
+	clientRequestID string
 	// turnStartedAtUnixMs is stamped from the same clock that produced turnID
 	// (a time-ordered UUIDv7). Keeping the client's original timestamp next to a
 	// server-generated turn id would leave the two disagreeing about when the
 	// turn started, which is a discrepancy a real client never produces.
 	turnStartedAtUnixMs int64
+	// scopedFromClient marks the device-mode snapshot, whose session, thread and
+	// window ids are scoped rewrites of the client's own values instead of
+	// proxy-invented ones. Projection then only touches fields the client sent,
+	// and keeps its turn id and turn timestamp untouched.
+	scopedFromClient bool
 }
 
 type codexConvergedIDsContextKeyType struct{}
@@ -158,6 +167,51 @@ func resolveConvergedThreadID(scope, clientSessionID string) string {
 	return deriveStableUUIDv4("clirelay:codex-thread-id:v1:" + scope + ":" + clientSessionID)
 }
 
+// adoptScopedClientIdentity fills the snapshot with account-scoped rewrites of
+// the identifiers the client itself sent, instead of proxy-invented ones.
+//
+// This is what device mode projects. Every field goes through the same scope,
+// so the relationships the client established survive the rewrite: a root turn
+// that arrived with session_id == thread_id still leaves with the two equal,
+// and a window id keeps pointing at its own session. Fields the client did not
+// send stay empty, and projection then leaves them alone.
+func (ids *codexConvergedIDs) adoptScopedClientIdentity(scope string, clientHeaders http.Header) {
+	if ids == nil || scope == "" {
+		return
+	}
+	ids.scopedFromClient = true
+
+	// Clients split these between real headers and the turn metadata blob; both
+	// reach upstream, so both have to resolve to the same scoped value.
+	metadata := ""
+	if clientHeaders != nil {
+		metadata = strings.TrimSpace(clientHeaders.Get("X-Codex-Turn-Metadata"))
+	}
+	if metadata != "" && !gjson.Valid(metadata) {
+		metadata = ""
+	}
+	clientValue := func(metadataKey string, headerNames ...string) string {
+		if clientHeaders != nil {
+			for _, name := range headerNames {
+				if v := strings.TrimSpace(clientHeaders.Get(name)); v != "" {
+					return v
+				}
+			}
+		}
+		if metadata != "" && metadataKey != "" {
+			if v := strings.TrimSpace(gjson.Get(metadata, metadataKey).String()); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
+
+	ids.sessionID = codexScopedIdentifier(scope, clientValue("session_id", "Session-Id", "Session_id"))
+	ids.threadID = codexScopedIdentifier(scope, clientValue("thread_id", "Thread-Id"))
+	ids.windowID = codexScopedIdentifier(scope, clientValue("window_id", "X-Codex-Window-Id"))
+	ids.clientRequestID = codexScopedIdentifier(scope, clientValue("", "X-Client-Request-Id"))
+}
+
 // extractClientSessionID reads the client's own session identifier before any
 // rewrite. Codex CLI sends the hyphenated form; the underscore form is accepted
 // as a fallback because some clients and earlier proxy layers emit it.
@@ -192,6 +246,12 @@ func resolveCodexConvergedIDs(cfg *config.Config, auth *cliproxyauth.Auth, clien
 
 	ids := &codexConvergedIDs{mode: mode, installationID: installationID}
 	if mode == config.CodexFingerprintConvergenceDevice {
+		// Deliberately the session isolation scope, not the convergence scope
+		// above: the cache helper already maps prompt_cache_key through that one,
+		// and the two must agree or the body cache key and the wire session end up
+		// naming different sessions. Installation keeps the convergence scope so
+		// existing device identities do not shift.
+		ids.adoptScopedClientIdentity(sessionIsolationScope(auth), clientHeaders)
 		return ids
 	}
 
@@ -257,6 +317,20 @@ func applyCodexConvergenceHeaders(h http.Header, ids *codexConvergedIDs, clientH
 	setIfClientSent(h, clientHeaders, "X-Codex-Installation-Id", ids.installationID)
 
 	if ids.mode == config.CodexFingerprintConvergenceDevice {
+		if ids.scopedFromClient {
+			// The scoped ids replace the client's own values wherever they travel.
+			// Session_id and Conversation_id are already on the request: the cache
+			// helper derived them from prompt_cache_key, which for a default Codex
+			// client equals the session id and therefore scopes to the same value.
+			// Pinning them here makes that hold even when a client overrides the
+			// cache key, so header and body never describe two different sessions.
+			setIfClientSent(h, clientHeaders, "Session-Id", ids.sessionID)
+			setIfClientSent(h, clientHeaders, "Session_id", ids.sessionID)
+			setIfClientSent(h, clientHeaders, "Conversation_id", ids.sessionID)
+			setIfClientSent(h, clientHeaders, "Thread-Id", ids.threadID)
+			setIfClientSent(h, clientHeaders, "X-Codex-Window-Id", ids.windowID)
+			setIfClientSent(h, clientHeaders, "X-Client-Request-Id", ids.clientRequestID)
+		}
 		rewriteCodexTurnMetadataHeader(h, ids.turnMetadataFields())
 		return
 	}
@@ -311,6 +385,22 @@ func (ids *codexConvergedIDs) deviceOnly() *codexConvergedIDs {
 // thread or turn fields the client sent.
 func (ids *codexConvergedIDs) turnMetadataFields() map[string]any {
 	fields := map[string]any{"installation_id": ids.installationID}
+	if ids.scopedFromClient {
+		// Device mode rewrites exactly the ids it scoped. turn_id and
+		// turn_started_at_unix_ms stay as the client sent them: they identify a
+		// single turn and carry no cross-request identity, so rewriting them
+		// would add divergence without hiding anything.
+		for key, value := range map[string]string{
+			"session_id": ids.sessionID,
+			"thread_id":  ids.threadID,
+			"window_id":  ids.windowID,
+		} {
+			if value != "" {
+				fields[key] = value
+			}
+		}
+		return fields
+	}
 	if ids.mode == config.CodexFingerprintConvergenceDevice {
 		return fields
 	}
@@ -376,7 +466,20 @@ func applyCodexConvergenceClientMetadata(body []byte, ids *codexConvergedIDs) []
 	fields := map[string]any{
 		"client_metadata.x-codex-installation-id": ids.installationID,
 	}
-	if ids.mode != config.CodexFingerprintConvergenceDevice {
+	switch {
+	case ids.scopedFromClient:
+		// Same snapshot as the headers, so the body cannot describe a different
+		// session than the wire does.
+		for key, value := range map[string]string{
+			"client_metadata.session_id":        ids.sessionID,
+			"client_metadata.thread_id":         ids.threadID,
+			"client_metadata.x-codex-window-id": ids.windowID,
+		} {
+			if value != "" {
+				fields[key] = value
+			}
+		}
+	case ids.mode != config.CodexFingerprintConvergenceDevice:
 		fields["client_metadata.session_id"] = ids.sessionID
 		fields["client_metadata.thread_id"] = ids.threadID
 		fields["client_metadata.turn_id"] = ids.turnID

--- a/internal/runtime/executor/codex_fingerprint_convergence_test.go
+++ b/internal/runtime/executor/codex_fingerprint_convergence_test.go
@@ -354,14 +354,14 @@ func TestDeviceOnlyLeavesSessionUntouched(t *testing.T) {
 	}
 }
 
-func TestCodexConvergenceDefaultsToSessionMode(t *testing.T) {
+func TestCodexConvergenceDefaultsToDeviceMode(t *testing.T) {
 	cfg := codexConvergenceTestConfig("")
-	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-default")); got != config.CodexFingerprintConvergenceSession {
-		t.Fatalf("convergence mode = %q, want the session default", got)
+	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-default")); got != config.CodexFingerprintConvergenceDevice {
+		t.Fatalf("convergence mode = %q, want the device default", got)
 	}
 
 	cfg = codexConvergenceTestConfig("nonsense")
-	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-bogus")); got != config.CodexFingerprintConvergenceSession {
+	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-bogus")); got != config.CodexFingerprintConvergenceDevice {
 		t.Fatalf("convergence mode = %q, want an unrecognised value to fall back to the default", got)
 	}
 }

--- a/internal/runtime/executor/codex_identity_projection_test.go
+++ b/internal/runtime/executor/codex_identity_projection_test.go
@@ -1,0 +1,220 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// The identifiers below mirror a real Codex Desktop turn captured from the
+// production request log: a root turn, so session, thread and x-client-request-id
+// all carry one value, the window id appends a compaction counter, and the turn
+// metadata repeats the same graph inside a JSON blob.
+const (
+	clientRootID    = "01a02380-e7de-79a1-a6ae-bcb146d1c0c9"
+	clientWindowID  = clientRootID + ":2"
+	clientTurnID    = "01a031cb-1b7f-72b1-b7de-6ffa906b0505"
+	clientInstallID = "7e296383-a82a-4b29-bb1a-b561986714ef"
+)
+
+func codexDeviceModeRequest(t *testing.T) *http.Request {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	for key, value := range map[string]string{
+		"Session-Id":          clientRootID,
+		"Thread-Id":           clientRootID,
+		"X-Client-Request-Id": clientRootID,
+		"X-Codex-Window-Id":   clientWindowID,
+		"X-Codex-Turn-Metadata": `{"installation_id":"` + clientInstallID + `","session_id":"` + clientRootID +
+			`","thread_id":"` + clientRootID + `","turn_id":"` + clientTurnID + `","window_id":"` + clientWindowID +
+			`","request_kind":"turn","sandbox":"none"}`,
+	} {
+		ginCtx.Request.Header.Set(key, value)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+	return req.WithContext(context.WithValue(req.Context(), util.ContextKeyGin, ginCtx))
+}
+
+// TestDeviceModeProjectsOneCoherentIdentityGraph pins the invariants that
+// production was violating: every outbound identifier is a well-formed UUID,
+// the header copy and the turn-metadata copy agree, and the equalities the
+// client established survive the account scoping.
+func TestDeviceModeProjectsOneCoherentIdentityGraph(t *testing.T) {
+	req := codexDeviceModeRequest(t)
+	cfg := codexConvergenceTestConfig(config.CodexFingerprintConvergenceDevice)
+	applyCodexHeaders(req, cfg, codexConvergenceTestAuth("codex-projection"), "token", true)
+
+	session := req.Header.Get("Session_id")
+	thread := req.Header.Get("Thread-Id")
+	window := req.Header.Get("X-Codex-Window-Id")
+	requestID := req.Header.Get("X-Client-Request-Id")
+
+	if session == "" || thread == "" || window == "" || requestID == "" {
+		t.Fatalf("client identifiers were dropped: session=%q thread=%q window=%q request=%q",
+			session, thread, window, requestID)
+	}
+	// A suffixed id like "<uuid>-79e1abc32c2ef4d0" is not a shape any Codex
+	// client emits; that malformed value was the strongest tell in production.
+	for name, value := range map[string]string{"Session_id": session, "Thread-Id": thread, "X-Client-Request-Id": requestID} {
+		if _, err := uuid.Parse(value); err != nil {
+			t.Fatalf("%s = %q is not a well-formed UUID", name, value)
+		}
+	}
+	if _, err := uuid.Parse(strings.TrimSuffix(window, ":2")); err != nil {
+		t.Fatalf("window id = %q, want <uuid>:<counter>", window)
+	}
+	if !strings.HasSuffix(window, ":2") {
+		t.Fatalf("window id = %q, want the client's compaction counter preserved", window)
+	}
+
+	// The client sent one root turn, so upstream must still see one.
+	if session != thread || session != requestID {
+		t.Fatalf("root-turn equality broken: session=%q thread=%q request=%q", session, thread, requestID)
+	}
+	if strings.HasPrefix(window, session+":") == false {
+		t.Fatalf("window id = %q no longer points at session %q", window, session)
+	}
+	if session == clientRootID {
+		t.Fatal("session id reached upstream unscoped, so accounts are not isolated")
+	}
+
+	metadata := req.Header.Get("X-Codex-Turn-Metadata")
+	for field, want := range map[string]string{"session_id": session, "thread_id": thread, "window_id": window} {
+		if got := gjson.Get(metadata, field).String(); got != want {
+			t.Fatalf("turn metadata %s = %q, want the header value %q", field, got, want)
+		}
+	}
+	// A single turn carries no cross-request identity, so it is left alone.
+	if got := gjson.Get(metadata, "turn_id").String(); got != clientTurnID {
+		t.Fatalf("turn metadata turn_id = %q, want the client value untouched", got)
+	}
+	if got := gjson.Get(metadata, "installation_id").String(); got == clientInstallID || got == "" {
+		t.Fatalf("turn metadata installation_id = %q, want a converged value", got)
+	}
+	if got := gjson.Get(metadata, "sandbox").String(); got != "none" {
+		t.Fatalf("unrelated metadata field was dropped: sandbox = %q", got)
+	}
+}
+
+// TestDeviceModeBodyMatchesHeaders guards the other half of the split that
+// production showed: client_metadata described a different session than the
+// headers did.
+func TestDeviceModeBodyMatchesHeaders(t *testing.T) {
+	req := codexDeviceModeRequest(t)
+	cfg := codexConvergenceTestConfig(config.CodexFingerprintConvergenceDevice)
+	auth := codexConvergenceTestAuth("codex-projection")
+
+	ids := resolveCodexConvergedIDs(cfg, auth, req.Context().Value(util.ContextKeyGin).(*gin.Context).Request.Header)
+	if ids == nil {
+		t.Fatal("device mode returned no snapshot")
+	}
+	body := []byte(`{"client_metadata":{"x-codex-installation-id":"` + clientInstallID + `","session_id":"` + clientRootID +
+		`","thread_id":"` + clientRootID + `","x-codex-window-id":"` + clientWindowID + `"}}`)
+	body = applyCodexConvergenceClientMetadata(body, ids)
+
+	for field, want := range map[string]string{
+		"client_metadata.session_id":        ids.sessionID,
+		"client_metadata.thread_id":         ids.threadID,
+		"client_metadata.x-codex-window-id": ids.windowID,
+	} {
+		if got := gjson.GetBytes(body, field).String(); got != want {
+			t.Fatalf("%s = %q, want %q", field, got, want)
+		}
+	}
+}
+
+// TestCacheKeyAndSessionHeaderAgreeEndToEnd walks the real order of operations:
+// cacheHelper derives prompt_cache_key and stamps the session headers, then
+// applyCodexHeaders projects the convergence snapshot over them. Production
+// showed those two steps disagreeing, so the body cache key and the wire
+// session have to be asserted together rather than in isolation.
+func TestCacheKeyAndSessionHeaderAgreeEndToEnd(t *testing.T) {
+	auth := codexConvergenceTestAuth("codex-endtoend")
+	// A default Codex client sets prompt_cache_key to its session id.
+	payload := []byte(`{"model":"gpt-5-codex","prompt_cache_key":"` + clientRootID + `"}`)
+	httpReq := codexCacheHelperRequest(t, auth, sdktranslator.FromString("openai-response"),
+		cliproxyexecutor.Request{Model: "gpt-5-codex", Payload: payload})
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = codexDeviceModeRequest(t).Context().Value(util.ContextKeyGin).(*gin.Context).Request
+	httpReq = httpReq.WithContext(context.WithValue(httpReq.Context(), util.ContextKeyGin, ginCtx))
+
+	cacheKey := gjson.GetBytes(readRequestBody(t, httpReq), "prompt_cache_key").String()
+	applyCodexHeaders(httpReq, codexConvergenceTestConfig(config.CodexFingerprintConvergenceDevice), auth, "token", true)
+
+	session := httpReq.Header.Get("Session_id")
+	if cacheKey == "" || session == "" {
+		t.Fatalf("cache key = %q, session = %q", cacheKey, session)
+	}
+	if cacheKey != session {
+		t.Fatalf("body cache key %q and header session %q describe different sessions", cacheKey, session)
+	}
+	if got := httpReq.Header.Get("Conversation_id"); got != session {
+		t.Fatalf("Conversation_id = %q, want the session %q", got, session)
+	}
+	if _, err := uuid.Parse(session); err != nil {
+		t.Fatalf("session %q is not a well-formed UUID", session)
+	}
+}
+
+// TestScopedIdentifierIsInjectiveAndShapePreserving covers the mapping itself:
+// it must keep UUID version and variant, keep a v7 timestamp so ids stay
+// time-ordered, separate accounts, and never collapse two distinct inputs.
+func TestScopedIdentifierIsInjectiveAndShapePreserving(t *testing.T) {
+	const scopeA = "account:a"
+	const scopeB = "account:b"
+
+	v7 := uuid.Must(uuid.NewV7()).String()
+	mapped := codexScopedIdentifier(scopeA, v7)
+	parsed, err := uuid.Parse(mapped)
+	if err != nil {
+		t.Fatalf("mapped v7 id = %q, not a UUID", mapped)
+	}
+	if parsed.Version() != 7 {
+		t.Fatalf("mapped id version = %d, want 7", parsed.Version())
+	}
+	if mapped[:8] != v7[:8] {
+		t.Fatalf("v7 timestamp prefix changed: %q vs %q", mapped[:8], v7[:8])
+	}
+	if mapped == v7 {
+		t.Fatal("identifier was not scoped at all")
+	}
+
+	v4 := uuid.NewString()
+	if got := uuid.MustParse(codexScopedIdentifier(scopeA, v4)).Version(); got != 4 {
+		t.Fatalf("mapped v4 id version = %d, want the original 4", got)
+	}
+
+	if again := codexScopedIdentifier(scopeA, v7); again != mapped {
+		t.Fatalf("mapping is not deterministic: %q then %q", mapped, again)
+	}
+	if codexScopedIdentifier(scopeB, v7) == mapped {
+		t.Fatal("two accounts mapped one client id onto the same value")
+	}
+	other := uuid.Must(uuid.NewV7()).String()
+	if codexScopedIdentifier(scopeA, other) == mapped {
+		t.Fatal("two distinct client ids collided within one account")
+	}
+
+	// Non-UUID ids cannot keep a shape they never had, but must stay isolated.
+	plain := codexScopedIdentifier(scopeA, "shared-session")
+	if plain == "shared-session" || !strings.HasPrefix(plain, "shared-session-") {
+		t.Fatalf("non-uuid identifier = %q, want a scope-derived suffix", plain)
+	}
+	if plain == codexScopedIdentifier(scopeB, "shared-session") {
+		t.Fatal("non-uuid identifier is not account-isolated")
+	}
+}

--- a/internal/runtime/executor/codex_session_isolation.go
+++ b/internal/runtime/executor/codex_session_isolation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/google/uuid"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -17,8 +18,82 @@ func codexAccountScopedExplicitSessionID(auth *cliproxyauth.Auth, raw string) st
 	if scope == "" {
 		return raw
 	}
+	return codexScopedIdentifier(scope, raw)
+}
+
+// codexScopedIdentifier maps one client identifier into an account-scoped one
+// while preserving the exact shape a real Codex client emits.
+//
+// The mapping is injective per scope: the same input always lands on the same
+// output, and two different inputs never collide. That property is what keeps
+// the client's own identity graph intact — a root turn where session_id equals
+// thread_id still comes out with the two equal, and a sub-agent thread stays
+// distinct from its root. Callers must therefore run every identifier of one
+// request through this with the same scope, or the graph breaks apart.
+//
+// Shapes handled:
+//   - UUID: version and variant nibbles are preserved, and for v7 so is the
+//     48-bit timestamp, so the result is a well-formed, still time-ordered UUID
+//     of the same version. Only the entropy is replaced.
+//   - "<uuid>:<n>" (Codex window ids): the UUID part is mapped, the counter is
+//     kept, because the counter tracks compaction rounds rather than identity.
+//
+// Anything else falls back to appending a scope-derived suffix. An identifier
+// that is not a UUID did not come from an official Codex client, so there is no
+// official shape left to preserve and account isolation is what matters.
+func codexScopedIdentifier(scope, raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || scope == "" {
+		return raw
+	}
+	if uuidPart, suffix, ok := splitCodexWindowIdentifier(raw); ok {
+		if mapped := scopeUUIDPreservingShape(scope, uuidPart); mapped != "" {
+			return mapped + suffix
+		}
+	} else if mapped := scopeUUIDPreservingShape(scope, raw); mapped != "" {
+		return mapped
+	}
 	sum := sha256.Sum256([]byte(scope + "\x00" + raw))
 	return raw + "-" + hex.EncodeToString(sum[:8])
+}
+
+// splitCodexWindowIdentifier recognises the "<uuid>:<counter>" window id form.
+func splitCodexWindowIdentifier(raw string) (string, string, bool) {
+	idx := strings.LastIndex(raw, ":")
+	if idx <= 0 || idx == len(raw)-1 {
+		return "", "", false
+	}
+	for _, r := range raw[idx+1:] {
+		if r < '0' || r > '9' {
+			return "", "", false
+		}
+	}
+	return raw[:idx], raw[idx:], true
+}
+
+// scopeUUIDPreservingShape rewrites a UUID's entropy from (scope, raw) and
+// returns "" when raw is not a UUID, so callers can fall back.
+func scopeUUIDPreservingShape(scope, raw string) string {
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	original := [16]byte(parsed)
+	sum := sha256.Sum256([]byte(scope + "\x00" + raw))
+
+	var out [16]byte
+	copy(out[:], sum[:16])
+	// UUIDv7 carries a 48-bit big-endian millisecond timestamp in bytes 0..5.
+	// Keeping it means the rewritten id sorts in the same order and sits in the
+	// same time range as the client's, which a freshly hashed prefix would not.
+	if parsed.Version() == 7 {
+		copy(out[0:6], original[0:6])
+	}
+	// Restore the version nibble and the RFC 4122 variant bits so the result is
+	// still a valid UUID of the very same version the client sent.
+	out[6] = (out[6] & 0x0f) | (original[6] & 0xf0)
+	out[8] = (out[8] & 0x3f) | (original[8] & 0xc0)
+	return uuid.UUID(out).String()
 }
 
 func codexSessionIsolationScope(auth *cliproxyauth.Auth) string {

--- a/internal/runtime/executor/codex_websockets_helpers.go
+++ b/internal/runtime/executor/codex_websockets_helpers.go
@@ -207,10 +207,11 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, cfg *c
 		misc.EnsureHeader(headers, ginHeaders, "User-Agent", codexUserAgent)
 	}
 
-	// Device fingerprint convergence, narrowed to the installation identifier:
-	// the websocket handshake pins Session_id to Conversation_id and
-	// prompt_cache_key above, so converging the session here would break prompt
-	// cache matching.
+	// Device fingerprint convergence, narrowed to the installation identifier so
+	// the stronger modes cannot invent a session here. In device mode the
+	// snapshot instead carries scope-mapped copies of the client's own ids, which
+	// is the same mapping the handshake applied to prompt_cache_key above, so
+	// Session_id, Conversation_id and the cache key stay in one cache domain.
 	applyCodexConvergenceHeaders(headers, resolveCodexConvergedIDs(cfg, auth, ginHeaders).deviceOnly(), ginHeaders)
 
 	// Match upstream: only attach Session_id when UA indicates a desktop client, and do not forward UA over websocket.

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -34,6 +34,34 @@ type requestLogEgressRoute struct {
 	ProxyURLHost string `json:"proxy_url_host,omitempty"`
 }
 
+// resolveAuthProxyURL returns the proxy a credential's own traffic goes out
+// through, using the same precedence as newProxyAwareHTTPClient.
+//
+// OAuth token refresh must leave from this address rather than the process
+// default. The two had drifted apart in production: requests went out through
+// the credential's proxy-pool entry while refresh went direct, so upstream saw
+// one account acting from two regions and rejected the refresh with
+// `unsupported_country_region_territory` once the host region was unsupported.
+// The access token then aged out and the account went unauthorized even though
+// its request path was healthy.
+//
+// It returns "" when nothing is configured, which leaves the caller on its
+// existing default.
+func resolveAuthProxyURL(cfg *config.Config, auth *cliproxyauth.Auth) string {
+	if cfg == nil {
+		if auth == nil {
+			return ""
+		}
+		return strings.TrimSpace(auth.ProxyURL)
+	}
+	proxyID, fallbackURL := "", ""
+	if auth != nil {
+		proxyID = auth.ProxyID
+		fallbackURL = auth.ProxyURL
+	}
+	return strings.TrimSpace(cfg.ResolveProxyURL(proxyID, fallbackURL))
+}
+
 // newProxyAwareHTTPClient creates an HTTP client with proper proxy configuration priority:
 // 1. Use auth.ProxyID when it resolves to an enabled proxy-pool entry
 // 2. Use auth.ProxyURL if configured

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -493,7 +493,9 @@ func (e *QwenExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*c
 		return auth, nil
 	}
 
-	svc := qwenauth.NewQwenAuth(e.cfg)
+	// Refresh goes out through this credential's own proxy, not the process
+	// default, so the token is renewed from the address that uses it.
+	svc := qwenauth.NewQwenAuthWithProxy(e.cfg, resolveAuthProxyURL(e.cfg, auth))
 	td, err := svc.RefreshTokens(ctx, refreshToken)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/executor/refresh_proxy_test.go
+++ b/internal/runtime/executor/refresh_proxy_test.go
@@ -1,0 +1,95 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// TestResolveAuthProxyURLMatchesRequestEgress pins the property the outage came
+// down to: whatever proxy a credential's requests leave through, its token
+// refresh has to leave through the same one. Production had refresh on the
+// process default while requests used a proxy-pool entry, so upstream saw the
+// account acting from two regions and refused to refresh.
+func TestResolveAuthProxyURLMatchesRequestEgress(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{ProxyURL: "http://global.example:7890"},
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "pool-hk", Name: "HK", URL: "socks5://10.0.0.1:1080", Enabled: true},
+			{ID: "pool-off", Name: "Off", URL: "socks5://10.0.0.2:1080", Enabled: false},
+		},
+	}
+
+	tests := []struct {
+		name string
+		auth *cliproxyauth.Auth
+		want string
+	}{
+		{
+			name: "pool entry wins over global",
+			auth: &cliproxyauth.Auth{ProxyID: "pool-hk"},
+			want: "socks5://10.0.0.1:1080",
+		},
+		{
+			name: "auth url wins over global",
+			auth: &cliproxyauth.Auth{ProxyURL: "socks5://10.0.0.9:1080"},
+			want: "socks5://10.0.0.9:1080",
+		},
+		{
+			name: "disabled pool entry falls back to the auth url",
+			auth: &cliproxyauth.Auth{ProxyID: "pool-off", ProxyURL: "socks5://10.0.0.9:1080"},
+			want: "socks5://10.0.0.9:1080",
+		},
+		{
+			name: "no credential proxy keeps the global default",
+			auth: &cliproxyauth.Auth{},
+			want: "http://global.example:7890",
+		},
+		{
+			name: "nil auth keeps the global default",
+			auth: nil,
+			want: "http://global.example:7890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAuthProxyURL(cfg, tt.auth); got != tt.want {
+				t.Fatalf("resolveAuthProxyURL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The refresh path must agree with the request path by construction, so the two
+// resolvers are compared directly rather than restated as literals.
+func TestResolveAuthProxyURLAgreesWithRequestClientResolution(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{ProxyURL: "http://global.example:7890"},
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "pool-hk", Name: "HK", URL: "socks5://10.0.0.1:1080", Enabled: true},
+		},
+	}
+	auth := &cliproxyauth.Auth{ProxyID: "pool-hk", ProxyURL: "socks5://ignored.example:1080"}
+
+	want := cfg.ResolveProxyURL(auth.ProxyID, auth.ProxyURL)
+	if got := resolveAuthProxyURL(cfg, auth); got != want {
+		t.Fatalf("refresh proxy %q diverged from request proxy %q", got, want)
+	}
+}
+
+func TestResolveAuthProxyURLWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveAuthProxyURL(nil, &cliproxyauth.Auth{ProxyURL: "socks5://10.0.0.9:1080"}); got != "socks5://10.0.0.9:1080" {
+		t.Fatalf("resolveAuthProxyURL = %q, want the auth proxy", got)
+	}
+	if got := resolveAuthProxyURL(nil, nil); got != "" {
+		t.Fatalf("resolveAuthProxyURL = %q, want empty", got)
+	}
+}

--- a/internal/runtime/executor/xai_quota_recovery.go
+++ b/internal/runtime/executor/xai_quota_recovery.go
@@ -66,7 +66,9 @@ func parseXAIQuotaProbe(body []byte, now time.Time) *cliproxyauth.QuotaProbeResu
 	if !ok {
 		return nil
 	}
-	if weekly.RemainingPercent > 0 {
+	// Exhaustion is a threshold, not "> 0": weekly percentages carry upstream
+	// precision now, and a sliver of remaining allowance cannot serve a request.
+	if !weekly.Exhausted() {
 		return &cliproxyauth.QuotaProbeResult{Recovered: true}
 	}
 	result := &cliproxyauth.QuotaProbeResult{

--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -244,6 +244,9 @@ func (s *GitTokenStore) Save(_ context.Context, auth *cliproxyauth.Auth) (string
 	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("auth filestore: create dir failed: %w", err)
 	}
+	// The committed auth JSON is the record of truth for this store, so the
+	// disabled flag has to be part of it.
+	cliproxyauth.SyncPersistedDisabled(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -450,6 +453,7 @@ func (s *GitTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, 
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
+	cliproxyauth.RestorePersistedDisabled(auth)
 	return auth, nil
 }
 

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -182,6 +182,9 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("object store: create auth directory: %w", err)
 	}
+	// Mirrors what the local auth JSON (and the uploaded object) must carry so a
+	// disable survives the next reload.
+	cliproxyauth.SyncPersistedDisabled(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -598,6 +601,7 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 		LastRefreshedAt:  time.Time{},
 		NextRefreshAfter: time.Time{},
 	}
+	cliproxyauth.RestorePersistedDisabled(auth)
 	return auth, nil
 }
 

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -235,6 +235,9 @@ func (s *PostgresStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (stri
 	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("postgres store: create auth directory: %w", err)
 	}
+	// The mirrored auth JSON is what List (and the file watcher) reads back, so
+	// the disabled flag must be part of the payload, not just runtime state.
+	cliproxyauth.SyncPersistedDisabled(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -337,6 +340,7 @@ func (s *PostgresStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error) 
 			LastRefreshedAt:  time.Time{},
 			NextRefreshAfter: time.Time{},
 		}
+		cliproxyauth.RestorePersistedDisabled(auth)
 		auths = append(auths, auth)
 	}
 	if err = rows.Err(); err != nil {

--- a/internal/store/postgresstore_disabled_test.go
+++ b/internal/store/postgresstore_disabled_test.go
@@ -1,0 +1,112 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// The Postgres store mirrors auth records to disk and back into the database.
+// Both copies have to carry the disabled flag, otherwise a management toggle is
+// lost on the next process start (or blue/green cutover).
+func TestPostgresStoreRoundTripsDisabledFlag(t *testing.T) {
+	dsn := os.Getenv("CLIRELAY_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLIRELAY_POSTGRES_TEST_DSN is not set")
+	}
+	ctx := context.Background()
+	schema := "auth_disabled_test_" + time.Now().UTC().Format("20060102150405")
+	store, err := NewPostgresStore(ctx, PostgresStoreConfig{DSN: dsn, Schema: schema, SpoolDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	defer store.Close()
+	defer func() { _, _ = store.db.ExecContext(ctx, `DROP SCHEMA IF EXISTS "`+schema+`" CASCADE`) }()
+	if err = store.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	const tenant = "00000000-0000-0000-0000-000000000001"
+	authID := tenant + "/codex-toggle.json"
+	path := filepath.Join(store.AuthDir(), tenant, "codex-toggle.json")
+	if errMkdir := os.MkdirAll(filepath.Dir(path), 0o700); errMkdir != nil {
+		t.Fatalf("MkdirAll: %v", errMkdir)
+	}
+	metadata := map[string]any{
+		"type":          "codex",
+		"email":         "toggle@example.com",
+		"access_token":  "at",
+		"refresh_token": "rt",
+		"disabled":      false,
+	}
+	seed, _ := json.Marshal(metadata)
+	if errWrite := os.WriteFile(path, seed, 0o600); errWrite != nil {
+		t.Fatalf("WriteFile: %v", errWrite)
+	}
+
+	auth := &cliproxyauth.Auth{
+		ID:         authID,
+		TenantID:   tenant,
+		Provider:   "codex",
+		FileName:   authID,
+		Status:     cliproxyauth.StatusActive,
+		Attributes: map[string]string{"path": path},
+		Metadata:   metadata,
+	}
+	if _, errSave := store.Save(ctx, auth); errSave != nil {
+		t.Fatalf("initial Save: %v", errSave)
+	}
+
+	for _, step := range []struct {
+		name     string
+		disabled bool
+		status   cliproxyauth.Status
+	}{
+		{name: "disable", disabled: true, status: cliproxyauth.StatusDisabled},
+		{name: "re-enable", disabled: false, status: cliproxyauth.StatusActive},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			auth.Disabled = step.disabled
+			auth.Status = step.status
+			if _, errSave := store.Save(ctx, auth); errSave != nil {
+				t.Fatalf("Save: %v", errSave)
+			}
+
+			raw, errRead := os.ReadFile(path)
+			if errRead != nil {
+				t.Fatalf("ReadFile: %v", errRead)
+			}
+			onDisk := map[string]any{}
+			if errUnmarshal := json.Unmarshal(raw, &onDisk); errUnmarshal != nil {
+				t.Fatalf("Unmarshal: %v", errUnmarshal)
+			}
+			if onDisk["disabled"] != step.disabled {
+				t.Fatalf("on-disk disabled = %#v, want %v", onDisk["disabled"], step.disabled)
+			}
+
+			var reloaded *cliproxyauth.Auth
+			auths, errList := store.List(ctx)
+			if errList != nil {
+				t.Fatalf("List: %v", errList)
+			}
+			for _, candidate := range auths {
+				if candidate != nil && candidate.ID == authID {
+					reloaded = candidate
+					break
+				}
+			}
+			if reloaded == nil {
+				t.Fatalf("auth %s missing after reload", authID)
+			}
+			if reloaded.Disabled != step.disabled || reloaded.Status != step.status {
+				t.Fatalf("reloaded Disabled=%v Status=%q, want %v/%q",
+					reloaded.Disabled, reloaded.Status, step.disabled, step.status)
+			}
+		})
+	}
+}

--- a/internal/usage/ai_account_binding_hook.go
+++ b/internal/usage/ai_account_binding_hook.go
@@ -40,6 +40,14 @@ func reconcileAIAccountBinding(auth *coreauth.Auth) {
 	if identity == nil {
 		return
 	}
+	// Runs before the binding upsert so the account's history is already under the
+	// shared id by the time anything points at it.
+	if err := MergeLegacySplitAuthSubject(auth, identity); err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"tenant_id": normalizeTenantID(auth.TenantID), "provider": identity.Provider,
+			"auth_subject_id": identity.ID,
+		}).Warn("usage: merge legacy split ai account subject")
+	}
 	if err := UpsertAIAccountTenantBinding(auth, identity); err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"tenant_id": normalizeTenantID(auth.TenantID), "provider": identity.Provider,

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -101,7 +101,11 @@ func sharedSubjectTestAuth(tenantID, authID, accountID, email string) *coreauth.
 	}
 }
 
-func TestResolveAuthSubjectIdentitySharesOnlyStableAccountID(t *testing.T) {
+// A subject is the physical upstream account. Every seed that names that account
+// — the provider's id, the account email, the credential's own id — must resolve
+// to one subject however many tenants mounted it; only auth_index, which names
+// no account, stays tenant local.
+func TestResolveAuthSubjectIdentitySharesEverySeedThatNamesAnAccount(t *testing.T) {
 	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "auth-a", "acct-shared", "a@example.com")
 	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "auth-b", "acct-shared", "b@example.com")
 	identityA := ResolveAuthSubjectIdentity(authA)
@@ -120,18 +124,62 @@ func TestResolveAuthSubjectIdentitySharesOnlyStableAccountID(t *testing.T) {
 		t.Fatal("account_key/auth_subject_id must be non-empty")
 	}
 
-	fallbackA := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantA, "fallback-a", "", "same@example.com"))
-	fallbackB := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantB, "fallback-b", "", "same@example.com"))
-	if fallbackA == nil || fallbackB == nil {
-		t.Fatal("expected fallback identities")
+	// One Google account mounted by two tenants: production split it in three and
+	// each tenant saw only the calls it had made, beside the whole account's quota.
+	emailA := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantA, "email-a", "", "same@example.com"))
+	emailB := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantB, "email-b", "", "same@example.com"))
+	if emailA == nil || emailB == nil {
+		t.Fatal("expected email identities")
 	}
-	if fallbackA.ID == fallbackB.ID {
-		t.Fatalf("email fallback crossed tenant boundary: %q", fallbackA.ID)
+	if emailA.ID != emailB.ID {
+		t.Fatalf("one account email split across tenants: %q != %q", emailA.ID, emailB.ID)
 	}
-	for _, identity := range []*AuthSubjectIdentity{fallbackA, fallbackB} {
-		if identity.SubjectScope != AIAccountSubjectScopeTenant || identity.ShareEligible || identity.SeedKind != "email" {
-			t.Fatalf("tenant fallback contract = %+v", identity)
+	for _, identity := range []*AuthSubjectIdentity{emailA, emailB} {
+		if identity.SubjectScope != AIAccountSubjectScopeShared || !identity.ShareEligible || identity.SeedKind != "email" {
+			t.Fatalf("email identity contract = %+v", identity)
 		}
+	}
+
+	// The same API key mounted by two tenants. Its id is stored tenant-prefixed,
+	// and the prefix is the only part that is not derived from the key material.
+	keyA := ResolveAuthSubjectIdentity(&coreauth.Auth{
+		ID: sharedSubjectTenantA + "/codex:apikey:deadbeef", TenantID: sharedSubjectTenantA,
+		Provider: "codex", FileName: "codex-a.json",
+	})
+	keyB := ResolveAuthSubjectIdentity(&coreauth.Auth{
+		ID: sharedSubjectTenantB + "/codex:apikey:deadbeef", TenantID: sharedSubjectTenantB,
+		Provider: "codex", FileName: "codex-b.json",
+	})
+	if keyA == nil || keyB == nil {
+		t.Fatal("expected auth_id identities")
+	}
+	if keyA.ID != keyB.ID {
+		t.Fatalf("one API key split across tenants: %q != %q", keyA.ID, keyB.ID)
+	}
+	if keyA.SeedKind != "auth_id" || !keyA.ShareEligible {
+		t.Fatalf("auth_id identity contract = %+v", keyA)
+	}
+	// A different key must stay a different account.
+	other := ResolveAuthSubjectIdentity(&coreauth.Auth{
+		ID: sharedSubjectTenantA + "/codex:apikey:feedface", TenantID: sharedSubjectTenantA,
+		Provider: "codex", FileName: "codex-other.json",
+	})
+	if other == nil || other.ID == keyA.ID {
+		t.Fatalf("distinct API keys collapsed onto one subject: %+v", other)
+	}
+
+	// auth_index identifies nothing about the account, so it cannot claim two
+	// tenants hold the same one.
+	indexA := ResolveAuthSubjectIdentity(&coreauth.Auth{TenantID: sharedSubjectTenantA, Provider: "codex", FileName: "shared-name.json"})
+	indexB := ResolveAuthSubjectIdentity(&coreauth.Auth{TenantID: sharedSubjectTenantB, Provider: "codex", FileName: "shared-name.json"})
+	if indexA == nil || indexB == nil {
+		t.Fatal("expected auth_index identities")
+	}
+	if indexA.SeedKind != "auth_index" || indexA.ShareEligible || indexA.SubjectScope != AIAccountSubjectScopeTenant {
+		t.Fatalf("auth_index identity contract = %+v", indexA)
+	}
+	if indexA.ID == indexB.ID {
+		t.Fatalf("auth_index crossed the tenant boundary: %q", indexA.ID)
 	}
 }
 
@@ -668,8 +716,13 @@ func TestFingerprintPolicyUsesSharedSubjectKeyAndTenantFallbackIsolation(t *test
 		t.Fatalf("invalidation count=%d key=%q", invalidations, invalidatedKey)
 	}
 
-	fallbackA := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantA, "fp-email-a", "", "same@example.com"))
-	fallbackB := ResolveAuthSubjectIdentity(sharedSubjectTestAuth(sharedSubjectTenantB, "fp-email-b", "", "same@example.com"))
+	// auth_index is the only seed left that stays tenant local, so it is what has
+	// to keep two tenants' fingerprint policies apart.
+	fallbackA := ResolveAuthSubjectIdentity(&coreauth.Auth{TenantID: sharedSubjectTenantA, Provider: "codex", FileName: "fp-fallback.json"})
+	fallbackB := ResolveAuthSubjectIdentity(&coreauth.Auth{TenantID: sharedSubjectTenantB, Provider: "codex", FileName: "fp-fallback.json"})
+	if fallbackA == nil || fallbackB == nil || fallbackA.SeedKind != "auth_index" {
+		t.Fatalf("expected auth_index fallbacks: A=%+v B=%+v", fallbackA, fallbackB)
+	}
 	if fallbackA.ID == fallbackB.ID {
 		t.Fatal("tenant-scoped fingerprint fallback merged across tenants")
 	}

--- a/internal/usage/ai_account_shared_subject_test.go
+++ b/internal/usage/ai_account_shared_subject_test.go
@@ -266,7 +266,7 @@ func TestRequestProjectionSharesUsageWithoutTouchingBindingAndSurvivesLogCleanup
 		t.Fatalf("direct day summary id=%s 7d=%d 30d=%d start7=%s start30=%s", directID, direct7, direct30, start7, start30)
 	}
 
-	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID}, []string{"code_week"})
+	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +373,10 @@ func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
 		}
 	}
 	resetOld := now.Add(24 * time.Hour)
-	resetNew := now.Add(48 * time.Hour)
+	// The later probe must describe the period that follows the stored one, not a
+	// stored period whose reset simply drifted later: only a rollover replaces an
+	// anchor, so an arbitrary later reset would (correctly) be kept out.
+	resetNew := resetOld.Add(7 * 24 * time.Hour)
 	if err := RecordQuotaSnapshotPointsIdentityForTenant(sharedSubjectTenantA, authA.EnsureIndex(), identity.ID, "codex", []QuotaSnapshotPoint{{
 		RecordedAt: older, QuotaKey: "code_week", QuotaLabel: "Week", Percent: &pctOld, ResetAt: &resetOld, WindowSeconds: 604800,
 	}}); err != nil {
@@ -419,7 +422,7 @@ func TestSharedSubjectBackfillUsesOnlySmallTablesAndIsIdempotent(t *testing.T) {
 	if !ok || !parsedReset.Equal(resetNew) {
 		t.Fatalf("cycle reset=%q want %s", cycleReset, resetNew)
 	}
-	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID}, []string{"code_week"})
+	cycleStarts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{identity.ID})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usage/ai_account_subject_cycle_anchor_test.go
+++ b/internal/usage/ai_account_subject_cycle_anchor_test.go
@@ -1,0 +1,318 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	antigravityGeminiWeeklyKey = "antigravity:gemini_weekly"
+	antigravity3pWeeklyKey     = "antigravity:3p_weekly"
+	weeklyWindowSeconds        = int64(604800)
+)
+
+func projectSubjectRequest(t *testing.T, subjectID string, at time.Time, tokens int64) {
+	t.Helper()
+	tx, err := getDB().Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := projectAIAccountSubjectUsageTx(tx, subjectID, false, 1, tokens, at); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func countCycleBuckets(t *testing.T, subjectID string) int {
+	t.Helper()
+	var count int
+	if err := getDB().QueryRow(`
+		SELECT COUNT(*) FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle'
+	`, subjectID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}
+
+func readCycleSummary(t *testing.T, subjectID string) AuthSubjectUsageSummary {
+	t.Helper()
+	starts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{subjectID}, starts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return summaries[subjectID]
+}
+
+// Production: an antigravity account with 1084 lifetime calls showed 0 for the
+// period. Its untouched third-party weekly bucket is answered as "a full window
+// remaining", so the start derived from that countdown walked forward by hours on
+// every probe, opening a usage bucket per step, while the readers resolved a
+// single anchor that matched none of them.
+func TestAntigravitySlidingWeeklyResetKeepsOnePeriod(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_antigravity_slide"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	// The bucket the account actually spends reports a fixed reset.
+	geminiReset := now.Add(120 * time.Hour)
+	geminiPercent, thirdPartyPercent := 87.0, 100.0
+
+	for i := 0; i < 6; i++ {
+		at := now.Add(time.Duration(i) * 12 * time.Hour)
+		slidingReset := at.Add(7 * 24 * time.Hour)
+		if err := RecordAIAccountSubjectQuotaPoints(subjectID, "antigravity", []QuotaSnapshotPoint{
+			{
+				RecordedAt: at, Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey,
+				QuotaLabel: "Gemini", Percent: &geminiPercent, ResetAt: &geminiReset,
+				WindowSeconds: weeklyWindowSeconds,
+			},
+			{
+				RecordedAt: at, Provider: "antigravity", QuotaKey: antigravity3pWeeklyKey,
+				QuotaLabel: "Claude and GPT", Percent: &thirdPartyPercent, ResetAt: &slidingReset,
+				WindowSeconds: weeklyWindowSeconds,
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		projectSubjectRequest(t, subjectID, at, 10)
+	}
+
+	if buckets := countCycleBuckets(t, subjectID); buckets != 1 {
+		t.Fatalf("cycle buckets = %d, want 1 (a sliding countdown must not open a period)", buckets)
+	}
+
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 6 || got.CycleTotalTokens != 60 {
+		t.Fatalf("cycle summary = %+v, want 6 requests / 60 tokens", got)
+	}
+
+	// The anchor must be the bucket that is actually metering, not the untouched
+	// one whose window merely happens to be re-stamped on every probe.
+	var start storedTime
+	if err := getDB().QueryRow(`
+		SELECT cycle_start_at FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, subjectID, antigravity3pWeeklyKey).Scan(&start); err != nil {
+		t.Fatal(err)
+	}
+	if !start.Valid || !start.Time.UTC().Equal(now) {
+		t.Fatalf("third-party anchor = %v, want it pinned to its first probe %v", start.Time, now)
+	}
+}
+
+// The projection reads the anchor from an in-memory map and the readers read it
+// from a SQL result set. With several weekly windows re-stamped by one probe, any
+// ordering by timestamp let the two sides disagree, and requests landed in a
+// bucket nobody read back.
+func TestWeeklyCycleSelectionIsIndependentOfCandidateOrder(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	gemini := AIAccountSubjectQuotaCycle{
+		AuthSubjectID: "authsub_order", Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey,
+		CycleStartAt: now.Add(-48 * time.Hour), ResetAt: now.Add(120 * time.Hour),
+		WindowSeconds: weeklyWindowSeconds, LastVerifiedAt: now,
+	}
+	thirdParty := AIAccountSubjectQuotaCycle{
+		AuthSubjectID: "authsub_order", Provider: "antigravity", QuotaKey: antigravity3pWeeklyKey,
+		CycleStartAt: now, ResetAt: now.Add(7 * 24 * time.Hour),
+		WindowSeconds: weeklyWindowSeconds, LastVerifiedAt: now,
+	}
+
+	forward, okForward := selectAIAccountSubjectWeeklyCycle([]AIAccountSubjectQuotaCycle{gemini, thirdParty})
+	reverse, okReverse := selectAIAccountSubjectWeeklyCycle([]AIAccountSubjectQuotaCycle{thirdParty, gemini})
+	if !okForward || !okReverse {
+		t.Fatal("expected a weekly cycle from both orderings")
+	}
+	if forward.QuotaKey != reverse.QuotaKey {
+		t.Fatalf("selection depends on input order: %q vs %q", forward.QuotaKey, reverse.QuotaKey)
+	}
+	if forward.QuotaKey != antigravityGeminiWeeklyKey {
+		t.Fatalf("selected %q, want the provider's named weekly window", forward.QuotaKey)
+	}
+
+	// An upstream rename must degrade to a stable choice rather than to no cycle.
+	renamed := []AIAccountSubjectQuotaCycle{
+		{
+			AuthSubjectID: "authsub_order", Provider: "antigravity", QuotaKey: "antigravity:zz_weekly",
+			CycleStartAt: now, ResetAt: now.Add(7 * 24 * time.Hour),
+			WindowSeconds: weeklyWindowSeconds, LastVerifiedAt: now,
+		},
+		{
+			AuthSubjectID: "authsub_order", Provider: "antigravity", QuotaKey: "antigravity:aa_weekly",
+			CycleStartAt: now.Add(-time.Hour), ResetAt: now.Add(167 * time.Hour),
+			WindowSeconds: weeklyWindowSeconds, LastVerifiedAt: now,
+		},
+	}
+	fallback, ok := selectAIAccountSubjectWeeklyCycle(renamed)
+	if !ok || fallback.QuotaKey != "antigravity:aa_weekly" {
+		t.Fatalf("fallback selection = %+v, want the deterministic aa_weekly", fallback)
+	}
+}
+
+// One batch mixes providers. Filtering candidates by a single list of quota keys
+// built from that batch dropped every window belonging to a provider that names
+// its buckets differently: with "seven_day" in the list, antigravity reported no
+// cycle at all.
+func TestWeeklyCycleBatchKeepsProvidersWithUnlistedQuotaKeys(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	claudeSubject := "authsub_batch_claude"
+	antigravitySubject := "authsub_batch_antigravity"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	reset := now.Add(120 * time.Hour)
+	percent := 50.0
+	if err := RecordAIAccountSubjectQuotaPoints(claudeSubject, "claude", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "claude", QuotaKey: "seven_day", QuotaLabel: "7d",
+		Percent: &percent, ResetAt: &reset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordAIAccountSubjectQuotaPoints(antigravitySubject, "antigravity", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey, QuotaLabel: "Gemini",
+		Percent: &percent, ResetAt: &reset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	starts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{claudeSubject, antigravitySubject})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, subjectID := range []string{claudeSubject, antigravitySubject} {
+		if starts[subjectID].IsZero() {
+			t.Fatalf("subject %s lost its cycle in a mixed-provider batch: %+v", subjectID, starts)
+		}
+	}
+}
+
+// A period still has to roll when the upstream says the old one is over —
+// otherwise the next week's traffic would be added to the previous week's total.
+func TestWeeklyCycleRollsAfterStoredPeriodEnds(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_rollover_after_end"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	firstReset := now.Add(2 * time.Hour)
+	percent := 10.0
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "antigravity", []QuotaSnapshotPoint{{
+		RecordedAt: now, Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey, QuotaLabel: "Gemini",
+		Percent: &percent, ResetAt: &firstReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Probed after the stored period ended, reporting a window that is not
+	// contiguous with it (the account was idle across the boundary).
+	after := firstReset.Add(3 * time.Hour)
+	secondReset := after.Add(7 * 24 * time.Hour)
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "antigravity", []QuotaSnapshotPoint{{
+		RecordedAt: after, Provider: "antigravity", QuotaKey: antigravityGeminiWeeklyKey, QuotaLabel: "Gemini",
+		Percent: &percent, ResetAt: &secondReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	var start storedTime
+	if err := getDB().QueryRow(`
+		SELECT cycle_start_at FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, subjectID, antigravityGeminiWeeklyKey).Scan(&start); err != nil {
+		t.Fatal(err)
+	}
+	want := secondReset.Add(-7 * 24 * time.Hour)
+	if !start.Valid || !start.Time.UTC().Equal(want) {
+		t.Fatalf("cycle start = %v, want %v (an ended period must roll)", start.Time, want)
+	}
+}
+
+// The buckets already scattered on disk are repaired in place: waiting out a full
+// window before totals become correct is not a fix an operator can use.
+func TestCycleRealignFoldsFragmentsOntoLiveAnchor(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_realign"
+
+	anchorAt := time.Now().UTC().Truncate(time.Second).Add(-60 * time.Hour)
+	resetAt := anchorAt.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'antigravity', ?, ?, ?, ?, ?)
+	`, subjectID, antigravityGeminiWeeklyKey,
+		anchorAt.Format(time.RFC3339Nano), resetAt.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, anchorAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	// The third-party window, whose sliding reset produced the fragments, is the
+	// one a timestamp ordering would have picked.
+	slidTo := anchorAt.Add(58 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'antigravity', ?, ?, ?, ?, ?)
+	`, subjectID, antigravity3pWeeklyKey,
+		slidTo.Format(time.RFC3339Nano), slidTo.Add(7*24*time.Hour).Format(time.RFC3339Nano),
+		weeklyWindowSeconds, slidTo.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Production's shape: six fragments of one week, plus a bucket from the
+	// previous period that must survive untouched.
+	previous := anchorAt.Add(-8 * 24 * time.Hour)
+	fragments := []struct {
+		at       time.Time
+		requests int64
+		tokens   int64
+	}{
+		{previous, 90, 900},
+		{anchorAt, 545, 13258533},
+		{anchorAt.Add(3 * time.Hour), 13, 186046},
+		{anchorAt.Add(5 * time.Hour), 7, 246262},
+		{anchorAt.Add(7 * time.Hour), 17, 408122},
+		{anchorAt.Add(23 * time.Hour), 487, 27117844},
+		{anchorAt.Add(48 * time.Hour), 15, 304158},
+	}
+	var wantRequests, wantTokens int64
+	for _, fragment := range fragments {
+		if _, err := getDB().Exec(`
+			INSERT INTO ai_account_subject_usage_buckets (
+				auth_subject_id, bucket_kind, bucket_start, request_count,
+				success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+			) VALUES (?, 'cycle', ?, ?, ?, 0, 0, ?, ?, ?)
+		`, subjectID, formatAIAccountSubjectCycleBucketStart(fragment.at),
+			fragment.requests, fragment.requests, fragment.tokens,
+			fragment.at.Format(time.RFC3339Nano), fragment.at.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+		if !fragment.at.Before(anchorAt) {
+			wantRequests += fragment.requests
+			wantTokens += fragment.tokens
+		}
+	}
+
+	if err := runAIAccountSubjectCycleRealignDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	if buckets := countCycleBuckets(t, subjectID); buckets != 2 {
+		t.Fatalf("cycle buckets = %d, want 2 (this period folded, the previous kept)", buckets)
+	}
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != wantRequests || got.CycleTotalTokens != wantTokens {
+		t.Fatalf("cycle summary = %+v, want %d requests / %d tokens", got, wantRequests, wantTokens)
+	}
+
+	// Idempotent: the marker stops a second pass from touching anything.
+	if err := runAIAccountSubjectCycleRealignDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	if buckets := countCycleBuckets(t, subjectID); buckets != 2 {
+		t.Fatalf("cycle buckets after rerun = %d, want 2", buckets)
+	}
+}

--- a/internal/usage/ai_account_subject_cycle_anchor_test.go
+++ b/internal/usage/ai_account_subject_cycle_anchor_test.go
@@ -316,3 +316,41 @@ func TestCycleRealignFoldsFragmentsOntoLiveAnchor(t *testing.T) {
 		t.Fatalf("cycle buckets after rerun = %d, want 2", buckets)
 	}
 }
+
+// One bucket keyed to a start no reader resolves reads as zero just as surely as
+// six do, so the repair cannot be limited to subjects with several fragments.
+func TestCycleRealignRekeysLoneMisplacedBucket(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_realign_single"
+
+	anchorAt := time.Now().UTC().Truncate(time.Second).Add(-40 * time.Hour)
+	resetAt := anchorAt.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'antigravity', ?, ?, ?, ?, ?)
+	`, subjectID, antigravityGeminiWeeklyKey,
+		anchorAt.Format(time.RFC3339Nano), resetAt.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, anchorAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	strayAt := anchorAt.Add(30 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, 42, 42, 0, 0, 4200, ?, ?)
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(strayAt),
+		strayAt.Format(time.RFC3339Nano), strayAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleRealignDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 42 || got.CycleTotalTokens != 4200 {
+		t.Fatalf("cycle summary = %+v, want 42 requests / 4200 tokens", got)
+	}
+}

--- a/internal/usage/ai_account_subject_cycle_merge.go
+++ b/internal/usage/ai_account_subject_cycle_merge.go
@@ -105,7 +105,10 @@ func loadAIAccountSubjectCycleBuckets(db *sql.DB) ([]aiAccountSubjectCycleBucket
 		return nil, fmt.Errorf("usage: query shared subject cycle buckets: %w", err)
 	}
 	defer rows.Close()
+	return scanAIAccountSubjectCycleBuckets(rows)
+}
 
+func scanAIAccountSubjectCycleBuckets(rows *sql.Rows) ([]aiAccountSubjectCycleBucketRow, error) {
 	out := make([]aiAccountSubjectCycleBucketRow, 0)
 	for rows.Next() {
 		var row aiAccountSubjectCycleBucketRow

--- a/internal/usage/ai_account_subject_cycle_realign.go
+++ b/internal/usage/ai_account_subject_cycle_realign.go
@@ -70,11 +70,19 @@ func runAIAccountSubjectCycleRealignDB(db *sql.DB) error {
 	defer func() { _ = tx.Rollback() }()
 
 	for _, subjectID := range subjectIDs {
-		group := aiAccountSubjectCycleBucketsInPeriod(bySubject[subjectID], anchors[subjectID])
-		if len(group) < 2 {
+		anchor := anchors[subjectID]
+		group := aiAccountSubjectCycleBucketsInPeriod(bySubject[subjectID], anchor)
+		if len(group) == 0 {
 			continue
 		}
-		if err := foldAIAccountSubjectCycleBucketsTx(tx, anchors[subjectID].CycleStartAt, group); err != nil {
+		// A lone bucket still needs the pass when it is keyed to a start the
+		// readers no longer resolve — one misplaced bucket reads as zero just as
+		// surely as six do.
+		anchorKey := formatAIAccountSubjectCycleBucketStart(anchor.CycleStartAt)
+		if len(group) == 1 && group[0].start == anchorKey {
+			continue
+		}
+		if err := foldAIAccountSubjectCycleBucketsTx(tx, anchor.CycleStartAt, group); err != nil {
 			return err
 		}
 	}

--- a/internal/usage/ai_account_subject_cycle_realign.go
+++ b/internal/usage/ai_account_subject_cycle_realign.go
@@ -1,0 +1,224 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+)
+
+const aiAccountSubjectCycleRealignMarker = "ai_account_subject_cycle_realign_v1"
+
+// RunAIAccountSubjectCycleRealignAtInit folds every usage bucket that belongs to
+// the live period onto that period's anchor.
+//
+// The earlier merge (see ai_account_subject_cycle_merge.go) clustered buckets by
+// drift tolerance, which only reunites fragments minutes apart. It could not
+// repair the fragmentation a sliding reset causes: a quota bucket the account has
+// not touched is answered as "a full window remaining", so its derived start
+// walked forward by hours on every probe and each step opened a bucket of its own.
+// Production carried one weekly period split across six buckets — 545 / 13 / 7 /
+// 17 / 487 / 15 requests — none of which matched the anchor the readers resolved,
+// so a card for an account with 1084 lifetime calls reported 0 for the period.
+//
+// Anchoring now refuses to roll a period that has not ended, so no new fragments
+// appear. This repairs the ones already on disk instead of making operators wait
+// out a full window for correct totals.
+func RunAIAccountSubjectCycleRealignAtInit() error {
+	return runAIAccountSubjectCycleRealignDB(getDB())
+}
+
+func runAIAccountSubjectCycleRealignDB(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+
+	usageProjectionMu.Lock()
+	defer usageProjectionMu.Unlock()
+
+	ensureUsageProjectionMarkerTable(db)
+	if projectionMarkerValue(db, aiAccountSubjectCycleRealignMarker) == rollupMarkerDone {
+		return nil
+	}
+
+	anchors, err := loadAIAccountSubjectCycleAnchors(db)
+	if err != nil {
+		return err
+	}
+	buckets, err := loadAIAccountSubjectCycleBuckets(db)
+	if err != nil {
+		return err
+	}
+	bySubject := make(map[string][]aiAccountSubjectCycleBucketRow, len(anchors))
+	for _, bucket := range buckets {
+		if _, ok := anchors[bucket.subjectID]; !ok {
+			continue
+		}
+		bySubject[bucket.subjectID] = append(bySubject[bucket.subjectID], bucket)
+	}
+
+	subjectIDs := make([]string, 0, len(bySubject))
+	for subjectID := range bySubject {
+		subjectIDs = append(subjectIDs, subjectID)
+	}
+	sort.Strings(subjectIDs)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin shared subject cycle realign: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, subjectID := range subjectIDs {
+		group := aiAccountSubjectCycleBucketsInPeriod(bySubject[subjectID], anchors[subjectID])
+		if len(group) < 2 {
+			continue
+		}
+		if err := foldAIAccountSubjectCycleBucketsTx(tx, anchors[subjectID].CycleStartAt, group); err != nil {
+			return err
+		}
+	}
+
+	now := time.Now().UTC()
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO UPDATE SET
+			marker_value = excluded.marker_value,
+			updated_at = excluded.updated_at
+	`, aiAccountSubjectCycleRealignMarker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: mark shared subject cycle realign: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit shared subject cycle realign: %w", err)
+	}
+	// The projection keys its buckets off this cache; drop it so the next write
+	// re-reads the anchors this pass just folded onto.
+	resetAIAccountSubjectCycleCache()
+	return nil
+}
+
+// loadAIAccountSubjectCycleAnchors resolves each subject's live period through the
+// same selection the projection and the readers use, so the repair lands on the
+// bucket key they will look for.
+func loadAIAccountSubjectCycleAnchors(db *sql.DB) (map[string]AIAccountSubjectQuotaCycle, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE window_seconds >= ?
+	`, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query shared quota cycles for realign: %w", err)
+	}
+	defer rows.Close()
+
+	bySubject := make(map[string][]AIAccountSubjectQuotaCycle)
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			return nil, fmt.Errorf("usage: scan shared quota cycle for realign: %w", err)
+		}
+		if start.Valid {
+			cycle.CycleStartAt = start.Time.UTC()
+		}
+		if reset.Valid {
+			cycle.ResetAt = reset.Time.UTC()
+		}
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time.UTC()
+		}
+		bySubject[cycle.AuthSubjectID] = append(bySubject[cycle.AuthSubjectID], cycle)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]AIAccountSubjectQuotaCycle, len(bySubject))
+	for subjectID, cycles := range bySubject {
+		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
+			out[subjectID] = cycle
+		}
+	}
+	return out, nil
+}
+
+// aiAccountSubjectCycleBucketsInPeriod returns the buckets whose key falls inside
+// the live period, oldest first. A fragment's key is the start the writer believed
+// in, and every fragment of one period sits between that period's start and its
+// reset; buckets outside it belong to earlier periods and are left alone.
+func aiAccountSubjectCycleBucketsInPeriod(
+	buckets []aiAccountSubjectCycleBucketRow,
+	anchor AIAccountSubjectQuotaCycle,
+) []aiAccountSubjectCycleBucketRow {
+	if anchor.CycleStartAt.IsZero() || anchor.ResetAt.IsZero() {
+		return nil
+	}
+	// The anchor itself may sit a tolerance away from the fragment that recorded
+	// the period's true beginning, so admit that much slack on the lower edge.
+	from := anchor.CycleStartAt.Add(-aiAccountSubjectCycleDriftTolerance(anchor.WindowSeconds))
+	out := make([]aiAccountSubjectCycleBucketRow, 0, len(buckets))
+	for _, bucket := range buckets {
+		if bucket.at.Before(from) || !bucket.at.Before(anchor.ResetAt) {
+			continue
+		}
+		out = append(out, bucket)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].at.Before(out[j].at) })
+	return out
+}
+
+// foldAIAccountSubjectCycleBucketsTx rewrites a period's fragments as one bucket
+// keyed to the anchor the readers resolve.
+func foldAIAccountSubjectCycleBucketsTx(
+	tx *sql.Tx,
+	anchorAt time.Time,
+	group []aiAccountSubjectCycleBucketRow,
+) error {
+	subjectID := group[0].subjectID
+	anchorKey := formatAIAccountSubjectCycleBucketStart(anchorAt)
+
+	merged := aiAccountSubjectCycleBucketRow{subjectID: subjectID, start: anchorKey, at: anchorAt}
+	for _, bucket := range group {
+		merged.requests += bucket.requests
+		merged.successes += bucket.successes
+		merged.failures += bucket.failures
+		merged.cost += bucket.cost
+		merged.tokens += bucket.tokens
+		if !bucket.firstEvent.IsZero() && (merged.firstEvent.IsZero() || bucket.firstEvent.Before(merged.firstEvent)) {
+			merged.firstEvent = bucket.firstEvent
+		}
+		if bucket.updatedAt.After(merged.updatedAt) {
+			merged.updatedAt = bucket.updatedAt
+		}
+	}
+	if merged.firstEvent.IsZero() {
+		merged.firstEvent = group[0].at
+	}
+	if merged.updatedAt.IsZero() {
+		merged.updatedAt = group[len(group)-1].at
+	}
+
+	for _, bucket := range group {
+		if _, err := tx.Exec(`
+			DELETE FROM ai_account_subject_usage_buckets
+			WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+		`, bucket.subjectID, bucket.start); err != nil {
+			return fmt.Errorf("usage: drop realigned cycle bucket: %w", err)
+		}
+	}
+	// Deleting first and inserting once keeps this correct whether or not the
+	// anchor's own key was among the fragments.
+	if _, err := tx.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, ?, ?, ?, ?, ?, ?, ?)
+	`, subjectID, anchorKey, merged.requests, merged.successes, merged.failures,
+		merged.cost, merged.tokens,
+		merged.firstEvent.UTC().Format(time.RFC3339Nano),
+		merged.updatedAt.UTC().Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: write realigned cycle bucket: %w", err)
+	}
+	return nil
+}

--- a/internal/usage/ai_account_subject_cycle_realign.go
+++ b/internal/usage/ai_account_subject_cycle_realign.go
@@ -187,13 +187,32 @@ func loadAuthSubjectCycleBucketsTx(tx *sql.Tx, subjectID string) ([]aiAccountSub
 // same selection the projection and the readers use, so the repair lands on the
 // bucket key they will look for.
 func loadAIAccountSubjectCycleAnchors(db *sql.DB) (map[string]AIAccountSubjectQuotaCycle, error) {
+	bySubject, err := loadAIAccountSubjectWeeklyCyclesBySubject(db)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]AIAccountSubjectQuotaCycle, len(bySubject))
+	for subjectID, cycles := range bySubject {
+		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
+			out[subjectID] = cycle
+		}
+	}
+	return out, nil
+}
+
+// loadAIAccountSubjectWeeklyCyclesBySubject returns every stored weekly window,
+// grouped by subject. Repairs that re-derive an anchor need all of a subject's
+// windows, not just the one currently selected: correcting a single window can
+// change which one the selection resolves to.
+func loadAIAccountSubjectWeeklyCyclesBySubject(db *sql.DB) (map[string][]AIAccountSubjectQuotaCycle, error) {
 	rows, err := db.Query(`
 		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
 		FROM ai_account_subject_quota_cycles
 		WHERE window_seconds >= ?
 	`, aiAccountSubjectWeeklyWindowSeconds)
 	if err != nil {
-		return nil, fmt.Errorf("usage: query shared quota cycles for realign: %w", err)
+		return nil, fmt.Errorf("usage: query shared quota cycles: %w", err)
 	}
 	defer rows.Close()
 
@@ -202,7 +221,11 @@ func loadAIAccountSubjectCycleAnchors(db *sql.DB) (map[string]AIAccountSubjectQu
 		var cycle AIAccountSubjectQuotaCycle
 		var start, reset, verified storedTime
 		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
-			return nil, fmt.Errorf("usage: scan shared quota cycle for realign: %w", err)
+			return nil, fmt.Errorf("usage: scan shared quota cycle: %w", err)
+		}
+		cycle.AuthSubjectID = strings.TrimSpace(cycle.AuthSubjectID)
+		if cycle.AuthSubjectID == "" {
+			continue
 		}
 		if start.Valid {
 			cycle.CycleStartAt = start.Time.UTC()
@@ -215,17 +238,7 @@ func loadAIAccountSubjectCycleAnchors(db *sql.DB) (map[string]AIAccountSubjectQu
 		}
 		bySubject[cycle.AuthSubjectID] = append(bySubject[cycle.AuthSubjectID], cycle)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	out := make(map[string]AIAccountSubjectQuotaCycle, len(bySubject))
-	for subjectID, cycles := range bySubject {
-		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
-			out[subjectID] = cycle
-		}
-	}
-	return out, nil
+	return bySubject, rows.Err()
 }
 
 // aiAccountSubjectCycleBucketsInPeriod returns the buckets whose key falls inside

--- a/internal/usage/ai_account_subject_cycle_realign.go
+++ b/internal/usage/ai_account_subject_cycle_realign.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -104,6 +105,82 @@ func runAIAccountSubjectCycleRealignDB(db *sql.DB) error {
 	// re-reads the anchors this pass just folded onto.
 	resetAIAccountSubjectCycleCache()
 	return nil
+}
+
+// realignAuthSubjectCycleBucketsTx runs the same repair for one subject inside a
+// caller's transaction. Merging two tenants' halves of an account brings together
+// buckets anchored independently, which is the fragmented shape all over again.
+func realignAuthSubjectCycleBucketsTx(tx *sql.Tx, subjectID string) error {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		return nil
+	}
+	anchor, ok, err := loadAuthSubjectCycleAnchorTx(tx, subjectID)
+	if err != nil || !ok {
+		return err
+	}
+	buckets, err := loadAuthSubjectCycleBucketsTx(tx, subjectID)
+	if err != nil {
+		return err
+	}
+	group := aiAccountSubjectCycleBucketsInPeriod(buckets, anchor)
+	if len(group) == 0 {
+		return nil
+	}
+	anchorKey := formatAIAccountSubjectCycleBucketStart(anchor.CycleStartAt)
+	if len(group) == 1 && group[0].start == anchorKey {
+		return nil
+	}
+	return foldAIAccountSubjectCycleBucketsTx(tx, anchor.CycleStartAt, group)
+}
+
+func loadAuthSubjectCycleAnchorTx(tx *sql.Tx, subjectID string) (AIAccountSubjectQuotaCycle, bool, error) {
+	rows, err := tx.Query(`
+		SELECT auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at
+		FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND window_seconds >= ?
+	`, subjectID, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return AIAccountSubjectQuotaCycle{}, false, fmt.Errorf("usage: query subject quota cycles for realign: %w", err)
+	}
+	defer rows.Close()
+	cycles := make([]AIAccountSubjectQuotaCycle, 0, 4)
+	for rows.Next() {
+		var cycle AIAccountSubjectQuotaCycle
+		var start, reset, verified storedTime
+		if err := rows.Scan(&cycle.AuthSubjectID, &cycle.Provider, &cycle.QuotaKey, &start, &reset, &cycle.WindowSeconds, &verified); err != nil {
+			return AIAccountSubjectQuotaCycle{}, false, fmt.Errorf("usage: scan subject quota cycle for realign: %w", err)
+		}
+		if start.Valid {
+			cycle.CycleStartAt = start.Time.UTC()
+		}
+		if reset.Valid {
+			cycle.ResetAt = reset.Time.UTC()
+		}
+		if verified.Valid {
+			cycle.LastVerifiedAt = verified.Time.UTC()
+		}
+		cycles = append(cycles, cycle)
+	}
+	if err := rows.Err(); err != nil {
+		return AIAccountSubjectQuotaCycle{}, false, err
+	}
+	cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles)
+	return cycle, ok, nil
+}
+
+func loadAuthSubjectCycleBucketsTx(tx *sql.Tx, subjectID string) ([]aiAccountSubjectCycleBucketRow, error) {
+	rows, err := tx.Query(`
+		SELECT auth_subject_id, bucket_start, request_count, success_count, failure_count,
+			cost_total, total_tokens, first_event_at, updated_at
+		FROM ai_account_subject_usage_buckets
+		WHERE bucket_kind = 'cycle' AND auth_subject_id = ?
+	`, subjectID)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query subject cycle buckets for realign: %w", err)
+	}
+	defer rows.Close()
+	return scanAIAccountSubjectCycleBuckets(rows)
 }
 
 // loadAIAccountSubjectCycleAnchors resolves each subject's live period through the

--- a/internal/usage/ai_account_subject_cycle_rollover_repair.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_repair.go
@@ -10,7 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const aiAccountSubjectCycleRolloverRepairMarker = "ai_account_subject_cycle_rollover_repair_v1"
+const (
+	aiAccountSubjectCycleRolloverRepairMarker = "ai_account_subject_cycle_rollover_repair_v1"
+	aiAccountSubjectCycleRefillRepairMarker   = "ai_account_subject_cycle_refill_repair_v1"
+)
 
 type meteredWeeklyQuotaProbe struct {
 	resetAt       time.Time
@@ -49,7 +52,38 @@ func RunAIAccountSubjectCycleRolloverRepairAtInit() error {
 	return runAIAccountSubjectCycleRolloverRepairDB(getDB())
 }
 
+// RunAIAccountSubjectCycleRefillRepairAtInit repairs the anchors the metering rule
+// could not: those held on a period the upstream refilled rather than spent out.
+//
+// A refilled period sits at a full allowance until the account draws on it, so the
+// pass above — which only trusts metered probes — has no probe to roll them with,
+// and the anchor stays frozen with the new period's usage landing in the old
+// period's bucket for as long as the account leaves the fresh allowance alone.
+func RunAIAccountSubjectCycleRefillRepairAtInit() error {
+	return runAIAccountSubjectCycleRefillRepairDB(getDB())
+}
+
 func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
+	return runAIAccountSubjectCycleAnchorRepairDB(db, aiAccountSubjectCycleRolloverRepairMarker,
+		loadLatestMeteredWeeklyQuotaProbes, aiAccountSubjectQuotaObservation{metering: true})
+}
+
+func runAIAccountSubjectCycleRefillRepairDB(db *sql.DB) error {
+	return runAIAccountSubjectCycleAnchorRepairDB(db, aiAccountSubjectCycleRefillRepairMarker,
+		loadLatestWeeklyQuotaRefillProbes, aiAccountSubjectQuotaObservation{refilled: true})
+}
+
+// runAIAccountSubjectCycleAnchorRepairDB rolls stored anchors forward onto the
+// period a probe shows is live, and rebuilds the usage buckets on both sides of
+// the move. The probe loader and the observation it stands for are the only
+// difference between the passes, so both judge with the same rule the running
+// server uses and cannot disagree with it about which period an account is in.
+func runAIAccountSubjectCycleAnchorRepairDB(
+	db *sql.DB,
+	marker string,
+	loadProbes func(*sql.DB) (map[string]meteredWeeklyQuotaProbe, error),
+	observed aiAccountSubjectQuotaObservation,
+) error {
 	if db == nil {
 		return nil
 	}
@@ -58,7 +92,7 @@ func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
 	defer usageProjectionMu.Unlock()
 
 	ensureUsageProjectionMarkerTable(db)
-	if projectionMarkerValue(db, aiAccountSubjectCycleRolloverRepairMarker) == rollupMarkerDone {
+	if projectionMarkerValue(db, marker) == rollupMarkerDone {
 		return nil
 	}
 
@@ -66,7 +100,7 @@ func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	probes, err := loadLatestMeteredWeeklyQuotaProbes(db)
+	probes, err := loadProbes(db)
 	if err != nil {
 		return err
 	}
@@ -85,41 +119,70 @@ func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
 
 	now := time.Now().UTC()
 	repaired := 0
+	anchorsRolled := 0
 	for _, subjectID := range subjectIDs {
 		cycles := cyclesBySubject[subjectID]
 		before, hadBefore := selectAIAccountSubjectWeeklyCycle(cycles)
 
-		changed := false
+		if !hadBefore {
+			continue
+		}
+		rolled := false
 		for i, cycle := range cycles {
 			probe, ok := probes[aiAccountSubjectQuotaProbeKey(subjectID, cycle.QuotaKey)]
 			if !ok {
 				continue
 			}
-			rolled, ok := aiAccountSubjectCycleRolloverFromProbe(cycle, probe)
+			next, ok := aiAccountSubjectCycleRolloverFromProbe(cycle, probe, observed)
 			if !ok {
 				continue
 			}
-			if err := writeAIAccountSubjectQuotaCycleAnchorTx(tx, rolled); err != nil {
+			if err := writeAIAccountSubjectQuotaCycleAnchorTx(tx, next); err != nil {
 				return err
 			}
-			cycles[i] = rolled
-			changed = true
+			cycles[i] = next
+			rolled = true
 		}
-		if !changed || !hadBefore {
-			continue
+		if rolled {
+			anchorsRolled++
 		}
 		after, hadAfter := selectAIAccountSubjectWeeklyCycle(cycles)
-		if !hadAfter || !after.CycleStartAt.After(before.CycleStartAt) {
+		if !hadAfter {
 			continue
 		}
-		moved, err := repairAIAccountSubjectCycleBucketsTx(tx, subjectID, before.CycleStartAt, after.CycleStartAt, now)
+		previousStart := before.CycleStartAt
+		if !after.CycleStartAt.After(before.CycleStartAt) {
+			// The anchor already names the period the probe describes, so there is
+			// nothing to roll — but a frozen anchor rolls on its own the moment the
+			// account spends into the fresh allowance, and everything it served while
+			// frozen stays filed under the period before it. The bucket boundary is
+			// then the only thing left wrong, and the period that kept those requests
+			// is the one whose bucket precedes this period's.
+			probe, ok := probes[aiAccountSubjectQuotaProbeKey(subjectID, after.QuotaKey)]
+			if !ok || !aiAccountSubjectCycleMatchesProbe(after, probe) {
+				continue
+			}
+			earlier, found, err := previousAIAccountSubjectCycleBucketStartTx(tx, subjectID, after.CycleStartAt)
+			if err != nil {
+				return err
+			}
+			if !found {
+				continue
+			}
+			previousStart = earlier
+		}
+		moved, err := repairAIAccountSubjectCycleBucketsTx(tx, subjectID, previousStart, after.CycleStartAt, now)
 		if err != nil {
 			return err
+		}
+		if moved == 0 && !rolled {
+			continue
 		}
 		repaired++
 		log.WithFields(log.Fields{
 			"auth_subject_id": subjectID,
-			"from":            before.CycleStartAt.Format(time.RFC3339),
+			"marker":          marker,
+			"from":            previousStart.Format(time.RFC3339),
 			"to":              after.CycleStartAt.Format(time.RFC3339),
 			"moved_requests":  moved,
 		}).Info("usage: repaired a cycle anchor held on an ended period")
@@ -131,18 +194,57 @@ func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
 		ON CONFLICT(marker_key) DO UPDATE SET
 			marker_value = excluded.marker_value,
 			updated_at = excluded.updated_at
-	`, aiAccountSubjectCycleRolloverRepairMarker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
+	`, marker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
 		return fmt.Errorf("usage: mark shared subject cycle rollover repair: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("usage: commit shared subject cycle rollover repair: %w", err)
 	}
-	if repaired > 0 {
+	if repaired > 0 || anchorsRolled > 0 {
 		// The projection keys its buckets off this cache; drop it so the next write
 		// re-reads the anchors this pass rolled.
 		resetAIAccountSubjectCycleCache()
 	}
 	return nil
+}
+
+// aiAccountSubjectCycleMatchesProbe reports whether a probe describes the period
+// the stored anchor already names, which is what separates "the anchor rolled on
+// its own and left usage behind" from "this probe has nothing to do with the
+// stored period".
+func aiAccountSubjectCycleMatchesProbe(cycle AIAccountSubjectQuotaCycle, probe meteredWeeklyQuotaProbe) bool {
+	if probe.windowSeconds != cycle.WindowSeconds || probe.resetAt.IsZero() {
+		return false
+	}
+	start := probe.resetAt.Add(-time.Duration(probe.windowSeconds) * time.Second)
+	return sameAIAccountSubjectCycle(start, cycle.CycleStartAt, cycle.WindowSeconds)
+}
+
+// previousAIAccountSubjectCycleBucketStartTx finds the bucket a period's requests
+// were being added to before the anchor named that period. Bucket starts are
+// stored as UTC RFC3339, so ordering them as text orders them in time.
+func previousAIAccountSubjectCycleBucketStartTx(
+	tx *sql.Tx,
+	subjectID string,
+	before time.Time,
+) (time.Time, bool, error) {
+	var start storedTime
+	err := tx.QueryRow(`
+		SELECT bucket_start
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start < ?
+		ORDER BY bucket_start DESC LIMIT 1
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(before)).Scan(&start)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("usage: load preceding cycle bucket: %w", err)
+	}
+	if !start.Valid {
+		return time.Time{}, false, nil
+	}
+	return start.Time.UTC(), true, nil
 }
 
 func aiAccountSubjectQuotaProbeKey(subjectID, quotaKey string) string {
@@ -187,12 +289,69 @@ func loadLatestMeteredWeeklyQuotaProbes(db *sql.DB) (map[string]meteredWeeklyQuo
 	return out, rows.Err()
 }
 
+// loadLatestWeeklyQuotaRefillProbes keeps, per window, the newest probe that found
+// a full allowance directly after a metered one.
+//
+// The metered-probe pass cannot reach a period that was refilled rather than spent
+// out: its newest metered probe still describes the period that was consumed, which
+// is the one already stored. The step up into a full allowance is the only record
+// that the upstream ended that period, and it stays in the history for as long as
+// the fresh allowance goes untouched.
+//
+// The step is tracked in Go rather than with a window function because this store
+// runs on both SQLite and Postgres, and it reuses the running server's observation
+// rule so a repaired anchor is one the server would also have rolled.
+func loadLatestWeeklyQuotaRefillProbes(db *sql.DB) (map[string]meteredWeeklyQuotaProbe, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, quota_key, percent, reset_at, window_seconds, recorded_at
+		FROM ai_account_subject_quota_points
+		WHERE window_seconds >= ?
+		ORDER BY recorded_at ASC
+	`, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query weekly quota refill probes: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]meteredWeeklyQuotaProbe)
+	previousPercent := make(map[string]*float64)
+	for rows.Next() {
+		var subjectID, quotaKey string
+		var percent sql.NullFloat64
+		var reset, recorded storedTime
+		var windowSeconds int64
+		if err := rows.Scan(&subjectID, &quotaKey, &percent, &reset, &windowSeconds, &recorded); err != nil {
+			return nil, fmt.Errorf("usage: scan weekly quota refill probe: %w", err)
+		}
+		subjectID = strings.TrimSpace(subjectID)
+		quotaKey = strings.TrimSpace(quotaKey)
+		if subjectID == "" || quotaKey == "" || windowSeconds <= 0 {
+			continue
+		}
+		key := aiAccountSubjectQuotaProbeKey(subjectID, quotaKey)
+		current := nullableProbePercent(percent)
+		observed := newAIAccountSubjectQuotaObservation(previousPercent[key], current)
+		previousPercent[key] = current
+		if !observed.refilled || !reset.Valid || !recorded.Valid {
+			continue
+		}
+		// Ascending order means a later refill replaces an earlier one.
+		out[key] = meteredWeeklyQuotaProbe{
+			resetAt:       reset.Time.UTC(),
+			windowSeconds: windowSeconds,
+			recordedAt:    recorded.Time.UTC(),
+		}
+	}
+	return out, rows.Err()
+}
+
 // aiAccountSubjectCycleRolloverFromProbe applies the live anchoring rule to a
 // stored row, so the repair and the running server cannot disagree about which
 // period an account is in.
 func aiAccountSubjectCycleRolloverFromProbe(
 	stored AIAccountSubjectQuotaCycle,
 	probe meteredWeeklyQuotaProbe,
+	observed aiAccountSubjectQuotaObservation,
 ) (AIAccountSubjectQuotaCycle, bool) {
 	if stored.CycleStartAt.IsZero() || probe.windowSeconds != stored.WindowSeconds {
 		return stored, false
@@ -211,7 +370,7 @@ func aiAccountSubjectCycleRolloverFromProbe(
 	if sameAIAccountSubjectCycle(incoming.CycleStartAt, stored.CycleStartAt, stored.WindowSeconds) {
 		return stored, false
 	}
-	if !aiAccountSubjectCycleRollover(incoming, stored.ResetAt, true) {
+	if !aiAccountSubjectCycleRollover(incoming, stored.ResetAt, observed) {
 		return stored, false
 	}
 	// The metering probe a period is derived from can be older than the last probe
@@ -240,9 +399,21 @@ func writeAIAccountSubjectQuotaCycleAnchorTx(tx *sql.Tx, cycle AIAccountSubjectQ
 // bucket the frozen anchor kept it in.
 //
 // The request log is the only record with the per-request timestamps needed to
-// split them, so the new period is recomputed from it and the same totals are
-// taken back off the previous bucket. Whatever the log no longer covers stays
-// where it is: totals move between buckets but are never invented or lost.
+// split them, so the new period is recomputed from it and only what its bucket
+// was still missing is taken back off the previous one. Whatever the log no longer
+// covers stays where it is: totals move between buckets but are never invented or
+// lost.
+//
+// Charging the previous period the whole recomputed total would double-count a
+// period that has already been partly moved, and that is the common case rather
+// than a corner one: an anchor frozen on a refilled period rolls on its own as
+// soon as the account spends into the fresh allowance, so its bucket already holds
+// everything after the rollover and only the requests from before it are still
+// misfiled. Production, 2026-08-25: a Codex account's new period held 6 requests
+// against 162 in the log, the other 156 left behind in the previous week.
+//
+// Recomputing to a smaller total means the log has aged out from under the bucket,
+// so the bucket is left alone: a repair may complete a period, never truncate one.
 func repairAIAccountSubjectCycleBucketsTx(
 	tx *sql.Tx,
 	subjectID string,
@@ -255,13 +426,52 @@ func repairAIAccountSubjectCycleBucketsTx(
 	if totals.requests == 0 {
 		return 0, nil
 	}
+	stored, err := readAIAccountSubjectCycleBucketTotalsTx(tx, subjectID, newStart)
+	if err != nil {
+		return 0, err
+	}
+	if totals.requests <= stored.requests {
+		return 0, nil
+	}
+	missing := aiAccountSubjectCycleTotalsDifference(totals, stored)
 	if err := writeAIAccountSubjectCycleBucketTx(tx, subjectID, newStart, totals); err != nil {
 		return 0, err
 	}
-	if err := subtractAIAccountSubjectCycleBucketTx(tx, subjectID, previousStart, totals); err != nil {
+	if err := subtractAIAccountSubjectCycleBucketTx(tx, subjectID, previousStart, missing); err != nil {
 		return 0, err
 	}
-	return totals.requests, nil
+	return missing.requests, nil
+}
+
+func readAIAccountSubjectCycleBucketTotalsTx(
+	tx *sql.Tx,
+	subjectID string,
+	start time.Time,
+) (aiAccountSubjectCycleTotals, error) {
+	var totals aiAccountSubjectCycleTotals
+	err := tx.QueryRow(`
+		SELECT request_count, success_count, failure_count, cost_total, total_tokens
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(start)).
+		Scan(&totals.requests, &totals.successes, &totals.failures, &totals.cost, &totals.tokens)
+	if err == sql.ErrNoRows {
+		return aiAccountSubjectCycleTotals{}, nil
+	}
+	if err != nil {
+		return totals, fmt.Errorf("usage: load repaired cycle bucket totals: %w", err)
+	}
+	return totals, nil
+}
+
+func aiAccountSubjectCycleTotalsDifference(from, subtract aiAccountSubjectCycleTotals) aiAccountSubjectCycleTotals {
+	return aiAccountSubjectCycleTotals{
+		requests:  clampNonNegativeInt64(from.requests - subtract.requests),
+		successes: clampNonNegativeInt64(from.successes - subtract.successes),
+		failures:  clampNonNegativeInt64(from.failures - subtract.failures),
+		cost:      clampNonNegativeFloat64(from.cost - subtract.cost),
+		tokens:    clampNonNegativeInt64(from.tokens - subtract.tokens),
+	}
 }
 
 func sumAIAccountSubjectRequestLogsTx(

--- a/internal/usage/ai_account_subject_cycle_rollover_repair.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_repair.go
@@ -1,0 +1,382 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const aiAccountSubjectCycleRolloverRepairMarker = "ai_account_subject_cycle_rollover_repair_v1"
+
+type meteredWeeklyQuotaProbe struct {
+	resetAt       time.Time
+	windowSeconds int64
+	recordedAt    time.Time
+}
+
+type aiAccountSubjectCycleTotals struct {
+	requests   int64
+	successes  int64
+	failures   int64
+	cost       float64
+	tokens     int64
+	firstEvent time.Time
+	lastEvent  time.Time
+}
+
+// RunAIAccountSubjectCycleRolloverRepairAtInit re-derives anchors that were held
+// on a period the upstream had already ended, and rebuilds the usage bucket of
+// the period they should have rolled into.
+//
+// Anchoring refused to leave a stored period before its own reset, to stop an
+// idle quota bucket's "a full window remaining" countdown from re-keying the
+// usage bucket on every probe. That also blocked the legitimate case: an upstream
+// may end a period early. Production had a Codex account whose code_week window
+// reported 41% spent against a reset on the 27th, then a full allowance against a
+// reset on the 31st — a real new period, four days before the stored one was due.
+// The anchor stayed on the old period, so the card kept showing the previous
+// week's start while the new week's requests were added to the previous week's
+// bucket: 12735 requests and $702 against a window the upstream said was 1% used.
+//
+// Anchoring now rolls on a metering probe, so no new anchor freezes. This repairs
+// the ones already on disk rather than leaving operators to wait out a window
+// whose totals stay wrong until it ends.
+func RunAIAccountSubjectCycleRolloverRepairAtInit() error {
+	return runAIAccountSubjectCycleRolloverRepairDB(getDB())
+}
+
+func runAIAccountSubjectCycleRolloverRepairDB(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+
+	usageProjectionMu.Lock()
+	defer usageProjectionMu.Unlock()
+
+	ensureUsageProjectionMarkerTable(db)
+	if projectionMarkerValue(db, aiAccountSubjectCycleRolloverRepairMarker) == rollupMarkerDone {
+		return nil
+	}
+
+	cyclesBySubject, err := loadAIAccountSubjectWeeklyCyclesBySubject(db)
+	if err != nil {
+		return err
+	}
+	probes, err := loadLatestMeteredWeeklyQuotaProbes(db)
+	if err != nil {
+		return err
+	}
+
+	subjectIDs := make([]string, 0, len(cyclesBySubject))
+	for subjectID := range cyclesBySubject {
+		subjectIDs = append(subjectIDs, subjectID)
+	}
+	sort.Strings(subjectIDs)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin shared subject cycle rollover repair: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UTC()
+	repaired := 0
+	for _, subjectID := range subjectIDs {
+		cycles := cyclesBySubject[subjectID]
+		before, hadBefore := selectAIAccountSubjectWeeklyCycle(cycles)
+
+		changed := false
+		for i, cycle := range cycles {
+			probe, ok := probes[aiAccountSubjectQuotaProbeKey(subjectID, cycle.QuotaKey)]
+			if !ok {
+				continue
+			}
+			rolled, ok := aiAccountSubjectCycleRolloverFromProbe(cycle, probe)
+			if !ok {
+				continue
+			}
+			if err := writeAIAccountSubjectQuotaCycleAnchorTx(tx, rolled); err != nil {
+				return err
+			}
+			cycles[i] = rolled
+			changed = true
+		}
+		if !changed || !hadBefore {
+			continue
+		}
+		after, hadAfter := selectAIAccountSubjectWeeklyCycle(cycles)
+		if !hadAfter || !after.CycleStartAt.After(before.CycleStartAt) {
+			continue
+		}
+		moved, err := repairAIAccountSubjectCycleBucketsTx(tx, subjectID, before.CycleStartAt, after.CycleStartAt, now)
+		if err != nil {
+			return err
+		}
+		repaired++
+		log.WithFields(log.Fields{
+			"auth_subject_id": subjectID,
+			"from":            before.CycleStartAt.Format(time.RFC3339),
+			"to":              after.CycleStartAt.Format(time.RFC3339),
+			"moved_requests":  moved,
+		}).Info("usage: repaired a cycle anchor held on an ended period")
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(marker_key) DO UPDATE SET
+			marker_value = excluded.marker_value,
+			updated_at = excluded.updated_at
+	`, aiAccountSubjectCycleRolloverRepairMarker, rollupMarkerDone, now.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: mark shared subject cycle rollover repair: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit shared subject cycle rollover repair: %w", err)
+	}
+	if repaired > 0 {
+		// The projection keys its buckets off this cache; drop it so the next write
+		// re-reads the anchors this pass rolled.
+		resetAIAccountSubjectCycleCache()
+	}
+	return nil
+}
+
+func aiAccountSubjectQuotaProbeKey(subjectID, quotaKey string) string {
+	return subjectID + "\x00" + quotaKey
+}
+
+// loadLatestMeteredWeeklyQuotaProbes keeps only probes that reported consumption.
+// A window at a full allowance carries no evidence about where its period began,
+// which is exactly the countdown the anchor must not follow.
+func loadLatestMeteredWeeklyQuotaProbes(db *sql.DB) (map[string]meteredWeeklyQuotaProbe, error) {
+	rows, err := db.Query(`
+		SELECT auth_subject_id, quota_key, reset_at, window_seconds, recorded_at
+		FROM ai_account_subject_quota_points
+		WHERE window_seconds >= ? AND percent IS NOT NULL AND percent < 100
+		ORDER BY recorded_at ASC
+	`, aiAccountSubjectWeeklyWindowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("usage: query metered weekly quota probes: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]meteredWeeklyQuotaProbe)
+	for rows.Next() {
+		var subjectID, quotaKey string
+		var reset, recorded storedTime
+		var windowSeconds int64
+		if err := rows.Scan(&subjectID, &quotaKey, &reset, &windowSeconds, &recorded); err != nil {
+			return nil, fmt.Errorf("usage: scan metered weekly quota probe: %w", err)
+		}
+		subjectID = strings.TrimSpace(subjectID)
+		quotaKey = strings.TrimSpace(quotaKey)
+		if subjectID == "" || quotaKey == "" || !reset.Valid || !recorded.Valid || windowSeconds <= 0 {
+			continue
+		}
+		// Ascending order means the last row written per key is the newest one.
+		out[aiAccountSubjectQuotaProbeKey(subjectID, quotaKey)] = meteredWeeklyQuotaProbe{
+			resetAt:       reset.Time.UTC(),
+			windowSeconds: windowSeconds,
+			recordedAt:    recorded.Time.UTC(),
+		}
+	}
+	return out, rows.Err()
+}
+
+// aiAccountSubjectCycleRolloverFromProbe applies the live anchoring rule to a
+// stored row, so the repair and the running server cannot disagree about which
+// period an account is in.
+func aiAccountSubjectCycleRolloverFromProbe(
+	stored AIAccountSubjectQuotaCycle,
+	probe meteredWeeklyQuotaProbe,
+) (AIAccountSubjectQuotaCycle, bool) {
+	if stored.CycleStartAt.IsZero() || probe.windowSeconds != stored.WindowSeconds {
+		return stored, false
+	}
+	incoming := stored
+	incoming.CycleStartAt = probe.resetAt.Add(-time.Duration(probe.windowSeconds) * time.Second)
+	incoming.ResetAt = probe.resetAt
+	incoming.LastVerifiedAt = probe.recordedAt
+	// Only ever forward: a probe older than the stored anchor must not rewind a
+	// period the server has already rolled into.
+	if !incoming.CycleStartAt.After(stored.CycleStartAt) {
+		return stored, false
+	}
+	if sameAIAccountSubjectCycle(incoming.CycleStartAt, stored.CycleStartAt, stored.WindowSeconds) {
+		return stored, false
+	}
+	if !aiAccountSubjectCycleRollover(incoming, stored.ResetAt, true) {
+		return stored, false
+	}
+	return incoming, true
+}
+
+func writeAIAccountSubjectQuotaCycleAnchorTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) error {
+	if _, err := tx.Exec(`
+		UPDATE ai_account_subject_quota_cycles
+		SET cycle_start_at = ?, reset_at = ?, last_verified_at = ?
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, cycle.CycleStartAt.UTC().Format(time.RFC3339Nano),
+		cycle.ResetAt.UTC().Format(time.RFC3339Nano),
+		cycle.LastVerifiedAt.UTC().Format(time.RFC3339Nano),
+		cycle.AuthSubjectID, cycle.QuotaKey); err != nil {
+		return fmt.Errorf("usage: roll stored shared quota cycle: %w", err)
+	}
+	return nil
+}
+
+// repairAIAccountSubjectCycleBucketsTx moves the new period's usage out of the
+// bucket the frozen anchor kept it in.
+//
+// The request log is the only record with the per-request timestamps needed to
+// split them, so the new period is recomputed from it and the same totals are
+// taken back off the previous bucket. Whatever the log no longer covers stays
+// where it is: totals move between buckets but are never invented or lost.
+func repairAIAccountSubjectCycleBucketsTx(
+	tx *sql.Tx,
+	subjectID string,
+	previousStart, newStart, now time.Time,
+) (int64, error) {
+	totals, err := sumAIAccountSubjectRequestLogsTx(tx, subjectID, newStart, now)
+	if err != nil {
+		return 0, err
+	}
+	if totals.requests == 0 {
+		return 0, nil
+	}
+	if err := writeAIAccountSubjectCycleBucketTx(tx, subjectID, newStart, totals); err != nil {
+		return 0, err
+	}
+	if err := subtractAIAccountSubjectCycleBucketTx(tx, subjectID, previousStart, totals); err != nil {
+		return 0, err
+	}
+	return totals.requests, nil
+}
+
+func sumAIAccountSubjectRequestLogsTx(
+	tx *sql.Tx,
+	subjectID string,
+	from, to time.Time,
+) (aiAccountSubjectCycleTotals, error) {
+	var totals aiAccountSubjectCycleTotals
+	var cost sql.NullFloat64
+	var tokens sql.NullInt64
+	var successes, failures sql.NullInt64
+	var first, last storedTime
+	err := tx.QueryRow(`
+		SELECT COUNT(*),
+			SUM(CASE WHEN failed = 0 THEN 1 ELSE 0 END),
+			SUM(CASE WHEN failed = 0 THEN 0 ELSE 1 END),
+			SUM(cost), SUM(total_tokens), MIN(timestamp), MAX(timestamp)
+		FROM request_logs
+		WHERE auth_subject_id = ? AND timestamp >= ? AND timestamp <= ?
+	`, subjectID, from.UTC().Format(time.RFC3339Nano), to.UTC().Format(time.RFC3339Nano)).
+		Scan(&totals.requests, &successes, &failures, &cost, &tokens, &first, &last)
+	if err != nil {
+		return totals, fmt.Errorf("usage: sum shared subject cycle request logs: %w", err)
+	}
+	totals.successes = successes.Int64
+	totals.failures = failures.Int64
+	totals.cost = cost.Float64
+	totals.tokens = tokens.Int64
+	if first.Valid {
+		totals.firstEvent = first.Time.UTC()
+	}
+	if last.Valid {
+		totals.lastEvent = last.Time.UTC()
+	}
+	return totals, nil
+}
+
+func writeAIAccountSubjectCycleBucketTx(
+	tx *sql.Tx,
+	subjectID string,
+	start time.Time,
+	totals aiAccountSubjectCycleTotals,
+) error {
+	firstEvent := totals.firstEvent
+	if firstEvent.IsZero() {
+		firstEvent = start
+	}
+	updatedAt := totals.lastEvent
+	if updatedAt.IsZero() {
+		updatedAt = start
+	}
+	// Overwrite rather than accumulate: the request log is authoritative for this
+	// period, so a rerun that lands on an existing bucket must not double it.
+	if _, err := tx.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			request_count = excluded.request_count,
+			success_count = excluded.success_count,
+			failure_count = excluded.failure_count,
+			cost_total = excluded.cost_total,
+			total_tokens = excluded.total_tokens,
+			first_event_at = excluded.first_event_at,
+			updated_at = excluded.updated_at
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(start),
+		totals.requests, totals.successes, totals.failures, totals.cost, totals.tokens,
+		firstEvent.Format(time.RFC3339Nano), updatedAt.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("usage: write repaired cycle bucket: %w", err)
+	}
+	return nil
+}
+
+// subtractAIAccountSubjectCycleBucketTx clamps in Go rather than in SQL: the
+// greatest-of-two spelling differs between the SQLite and Postgres backends this
+// store runs on.
+func subtractAIAccountSubjectCycleBucketTx(
+	tx *sql.Tx,
+	subjectID string,
+	start time.Time,
+	totals aiAccountSubjectCycleTotals,
+) error {
+	key := formatAIAccountSubjectCycleBucketStart(start)
+	var requests, successes, failures, tokens int64
+	var cost float64
+	err := tx.QueryRow(`
+		SELECT request_count, success_count, failure_count, cost_total, total_tokens
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, subjectID, key).Scan(&requests, &successes, &failures, &cost, &tokens)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("usage: load previous cycle bucket for repair: %w", err)
+	}
+	if _, err := tx.Exec(`
+		UPDATE ai_account_subject_usage_buckets
+		SET request_count = ?, success_count = ?, failure_count = ?, cost_total = ?, total_tokens = ?
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, clampNonNegativeInt64(requests-totals.requests),
+		clampNonNegativeInt64(successes-totals.successes),
+		clampNonNegativeInt64(failures-totals.failures),
+		clampNonNegativeFloat64(cost-totals.cost),
+		clampNonNegativeInt64(tokens-totals.tokens),
+		subjectID, key); err != nil {
+		return fmt.Errorf("usage: subtract repaired usage from previous cycle bucket: %w", err)
+	}
+	return nil
+}
+
+func clampNonNegativeInt64(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func clampNonNegativeFloat64(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}

--- a/internal/usage/ai_account_subject_cycle_rollover_repair.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_repair.go
@@ -200,6 +200,8 @@ func aiAccountSubjectCycleRolloverFromProbe(
 	incoming := stored
 	incoming.CycleStartAt = probe.resetAt.Add(-time.Duration(probe.windowSeconds) * time.Second)
 	incoming.ResetAt = probe.resetAt
+	// The rule reads LastVerifiedAt as "when this observation was made", so judge
+	// with the probe's own timestamp.
 	incoming.LastVerifiedAt = probe.recordedAt
 	// Only ever forward: a probe older than the stored anchor must not rewind a
 	// period the server has already rolled into.
@@ -211,6 +213,11 @@ func aiAccountSubjectCycleRolloverFromProbe(
 	}
 	if !aiAccountSubjectCycleRollover(incoming, stored.ResetAt, true) {
 		return stored, false
+	}
+	// The metering probe a period is derived from can be older than the last probe
+	// of any kind, and the stored verification time must not travel backwards.
+	if stored.LastVerifiedAt.After(incoming.LastVerifiedAt) {
+		incoming.LastVerifiedAt = stored.LastVerifiedAt
 	}
 	return incoming, true
 }

--- a/internal/usage/ai_account_subject_cycle_rollover_test.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_test.go
@@ -86,6 +86,68 @@ func TestWeeklyCycleRollsWhenUpstreamEndsPeriodEarly(t *testing.T) {
 	}
 }
 
+// Production, 2026-08-25: two Codex accounts had code_week step from 55% and 70%
+// straight back to a full allowance, against resets a week past the stored ones.
+// The upstream had ended those periods early, but a refilled period is at a full
+// allowance by definition, so the metering rule could never admit the very probe
+// that announces one: both anchors stayed on the period that began on the 24th
+// while the new period's requests kept being added to it, and one card reported
+// 12311 requests and 1.4B tokens for two periods added together.
+func TestWeeklyCycleRollsWhenUpstreamRefillsTheAllowance(t *testing.T) {
+	// The two accounts described the same refill differently, so the anchor has to
+	// take both shapes: one reported a fixed period edge, the other "this instant
+	// plus a whole window" — which is what an untouched bucket reports too, and is
+	// why the refill itself has to be the evidence.
+	for _, shape := range []struct {
+		name           string
+		resetFromProbe time.Duration
+	}{
+		{name: "fixed period edge", resetFromProbe: 7*24*time.Hour - 14*time.Minute},
+		{name: "full window from the probe", resetFromProbe: 7 * 24 * time.Hour},
+	} {
+		t.Run(shape.name, func(t *testing.T) {
+			initSharedSubjectTestDB(t)
+			subjectID := "authsub_codex_refill"
+
+			spentProbe := time.Now().UTC().Truncate(time.Second).Add(-3 * time.Hour)
+			spentReset := spentProbe.Add(5 * 24 * time.Hour)
+			spent := 55.0
+			if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+				RecordedAt: spentProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+				Percent: &spent, ResetAt: &spentReset, WindowSeconds: weeklyWindowSeconds,
+			}}); err != nil {
+				t.Fatal(err)
+			}
+
+			refillProbe := spentProbe.Add(time.Hour)
+			refillReset := refillProbe.Add(shape.resetFromProbe)
+			full := 100.0
+			if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+				RecordedAt: refillProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+				Percent: &full, ResetAt: &refillReset, WindowSeconds: weeklyWindowSeconds,
+			}}); err != nil {
+				t.Fatal(err)
+			}
+
+			start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+			wantStart := refillReset.Add(-7 * 24 * time.Hour)
+			if !start.Equal(wantStart) || !reset.Equal(refillReset) {
+				t.Fatalf("anchor = %v..%v, want the refilled period %v..%v",
+					start, reset, wantStart, refillReset)
+			}
+
+			// The period the card reports and the one the projection writes into have
+			// to be the same, or the fresh allowance's usage is added to the period
+			// the upstream just ended.
+			projectSubjectRequest(t, subjectID, refillProbe.Add(time.Minute), 40)
+			got := readCycleSummary(t, subjectID)
+			if !got.CycleKnown || got.CycleRequestTotal != 1 || got.CycleTotalTokens != 40 {
+				t.Fatalf("cycle summary = %+v, want the refilled period's single request", got)
+			}
+		})
+	}
+}
+
 // The guard that made the freeze possible has to keep working: a window the
 // account never touched answers every probe with a full window remaining, and
 // following that countdown re-keys the usage bucket on each pass.
@@ -283,5 +345,192 @@ func TestCycleRolloverRepairMovesUsageToTheLivePeriod(t *testing.T) {
 	}
 	if requests, _, _ := readCycleBucket(t, subjectID, frozenStart); requests != 2 {
 		t.Fatalf("previous bucket after rerun = %d requests, want 2", requests)
+	}
+}
+
+func insertQuotaPoint(t *testing.T, subjectID string, percent float64, resetAt, recordedAt time.Time) {
+	t.Helper()
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_points
+			(auth_subject_id, provider, quota_key, quota_label, percent, reset_at, window_seconds, recorded_at)
+		VALUES (?, 'codex', ?, 'Weekly', ?, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey, percent, resetAt.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, recordedAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func insertFrozenWeeklyAnchor(t *testing.T, subjectID string, start, reset, verifiedAt time.Time) {
+	t.Helper()
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'codex', ?, ?, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey, start.Format(time.RFC3339Nano), reset.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, verifiedAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The metered-probe repair cannot reach an anchor frozen on a period the upstream
+// refilled rather than spent out: every probe taken since the refill reports a full
+// allowance, so the newest metered probe is the one describing the frozen period
+// itself. Without a pass that reads the refill, these anchors stay wrong until the
+// account spends into the fresh allowance.
+func TestCycleRefillRepairMovesUsageToTheRefilledPeriod(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_repair_refilled"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	frozenStart := now.Add(-4 * 24 * time.Hour)
+	frozenReset := frozenStart.Add(7 * 24 * time.Hour)
+	insertFrozenWeeklyAnchor(t, subjectID, frozenStart, frozenReset, now)
+
+	// The history holds the step the anchor missed: metered on the frozen period,
+	// then a full allowance against a reset a week past it, and only full-allowance
+	// probes after that.
+	refillAt := now.Add(-90 * time.Minute)
+	refillReset := refillAt.Add(7 * 24 * time.Hour)
+	insertQuotaPoint(t, subjectID, 55, frozenReset, now.Add(-3*time.Hour))
+	insertQuotaPoint(t, subjectID, 100, refillReset, refillAt)
+	insertQuotaPoint(t, subjectID, 100, now.Add(-30*time.Minute).Add(7*24*time.Hour), now.Add(-30*time.Minute))
+
+	// Two requests in the period that ended, three in the refilled one — all five
+	// were counted into the frozen period's bucket.
+	events := []time.Time{
+		frozenStart.Add(time.Hour), frozenStart.Add(30 * time.Hour),
+		refillAt.Add(time.Minute), refillAt.Add(20 * time.Minute), refillAt.Add(80 * time.Minute),
+	}
+	for _, at := range events {
+		if _, err := getDB().Exec(`
+			INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, failed, cost, total_tokens)
+			VALUES ('default', ?, ?, 0, 2, 100)
+		`, at.Format(time.RFC3339Nano), subjectID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, 5, 5, 0, 10, 500, ?, ?)
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(frozenStart),
+		events[0].Format(time.RFC3339Nano), events[4].Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleRefillRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	if !start.Equal(refillAt) || !reset.Equal(refillReset) {
+		t.Fatalf("anchor = %v..%v, want the refilled period %v..%v", start, reset, refillAt, refillReset)
+	}
+	if requests, cost, tokens := readCycleBucket(t, subjectID, refillAt); requests != 3 || cost != 6 || tokens != 300 {
+		t.Fatalf("refilled bucket = %d requests / %v cost / %d tokens, want 3 / 6 / 300", requests, cost, tokens)
+	}
+	if requests, cost, tokens := readCycleBucket(t, subjectID, frozenStart); requests != 2 || cost != 4 || tokens != 200 {
+		t.Fatalf("previous bucket = %d requests / %v cost / %d tokens, want 2 / 4 / 200", requests, cost, tokens)
+	}
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 3 || got.CycleTotalTokens != 300 {
+		t.Fatalf("cycle summary = %+v, want the refilled period's 3 requests / 300 tokens", got)
+	}
+
+	if err := runAIAccountSubjectCycleRefillRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	if requests, _, _ := readCycleBucket(t, subjectID, frozenStart); requests != 2 {
+		t.Fatalf("previous bucket after rerun = %d requests, want 2", requests)
+	}
+}
+
+// A frozen anchor rolls on its own the moment the account spends into the fresh
+// allowance, which leaves the anchor right and the buckets wrong: everything
+// served while it was frozen is still filed under the period before it, and the
+// anchor no longer needs moving so nothing goes looking for it. Production,
+// 2026-08-25: a Codex account's refilled period held 6 requests against 162 in
+// the request log, the other 156 left in the previous week's bucket.
+func TestCycleRefillRepairCompletesAPeriodTheAnchorRolledIntoLate(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_repair_late_roll"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	previousStart := now.Add(-2 * 24 * time.Hour)
+	refillAt := now.Add(-2 * time.Hour)
+	refillReset := refillAt.Add(7 * 24 * time.Hour)
+
+	insertFrozenWeeklyAnchor(t, subjectID, refillAt, refillReset, now)
+	insertQuotaPoint(t, subjectID, 55, previousStart.Add(7*24*time.Hour), now.Add(-3*time.Hour))
+	insertQuotaPoint(t, subjectID, 100, refillReset, refillAt)
+
+	// One request in the period that ended and five in the refilled one, of which
+	// the bucket only caught the two served after the anchor rolled.
+	events := []time.Time{
+		previousStart.Add(time.Hour),
+		refillAt.Add(time.Minute), refillAt.Add(2 * time.Minute), refillAt.Add(3 * time.Minute),
+		refillAt.Add(90 * time.Minute), refillAt.Add(100 * time.Minute),
+	}
+	for _, at := range events {
+		if _, err := getDB().Exec(`
+			INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, failed, cost, total_tokens)
+			VALUES ('default', ?, ?, 0, 2, 100)
+		`, at.Format(time.RFC3339Nano), subjectID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, 4, 4, 0, 8, 400, ?, ?), (?, 'cycle', ?, 2, 2, 0, 4, 200, ?, ?)
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(previousStart),
+		events[0].Format(time.RFC3339Nano), events[3].Format(time.RFC3339Nano),
+		subjectID, formatAIAccountSubjectCycleBucketStart(refillAt),
+		events[4].Format(time.RFC3339Nano), events[5].Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleRefillRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	if start, _ := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey); !start.Equal(refillAt) {
+		t.Fatalf("anchor = %v, want it left on the refilled period %v", start, refillAt)
+	}
+	if requests, cost, tokens := readCycleBucket(t, subjectID, refillAt); requests != 5 || cost != 10 || tokens != 500 {
+		t.Fatalf("refilled bucket = %d requests / %v cost / %d tokens, want 5 / 10 / 500", requests, cost, tokens)
+	}
+	// Only the three that were misfiled came off the previous period, not all five.
+	if requests, cost, tokens := readCycleBucket(t, subjectID, previousStart); requests != 1 || cost != 2 || tokens != 100 {
+		t.Fatalf("previous bucket = %d requests / %v cost / %d tokens, want 1 / 2 / 100", requests, cost, tokens)
+	}
+}
+
+// A window that has only ever answered "a full window remaining" never refilled,
+// because it never metered. Repairing it would move the anchor onto whatever the
+// last probe's countdown happened to say and re-key the usage bucket with it.
+func TestCycleRefillRepairLeavesNeverMeteredWindowsAlone(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_repair_untouched"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	storedStart := now.Add(-3 * 24 * time.Hour)
+	storedReset := storedStart.Add(7 * 24 * time.Hour)
+	insertFrozenWeeklyAnchor(t, subjectID, storedStart, storedReset, now)
+
+	for i := 3; i >= 1; i-- {
+		at := now.Add(-time.Duration(i) * time.Hour)
+		insertQuotaPoint(t, subjectID, 100, at.Add(7*24*time.Hour), at)
+	}
+
+	if err := runAIAccountSubjectCycleRefillRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	if !start.Equal(storedStart) || !reset.Equal(storedReset) {
+		t.Fatalf("anchor = %v..%v, want the stored period %v..%v left alone",
+			start, reset, storedStart, storedReset)
 	}
 }

--- a/internal/usage/ai_account_subject_cycle_rollover_test.go
+++ b/internal/usage/ai_account_subject_cycle_rollover_test.go
@@ -1,0 +1,287 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+const codexWeeklyQuotaKey = "code_week"
+
+func readCycleAnchor(t *testing.T, subjectID, quotaKey string) (time.Time, time.Time) {
+	t.Helper()
+	var start, reset storedTime
+	if err := getDB().QueryRow(`
+		SELECT cycle_start_at, reset_at FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND quota_key = ?
+	`, subjectID, quotaKey).Scan(&start, &reset); err != nil {
+		t.Fatal(err)
+	}
+	if !start.Valid || !reset.Valid {
+		t.Fatalf("anchor for %s/%s is not stored", subjectID, quotaKey)
+	}
+	return start.Time.UTC(), reset.Time.UTC()
+}
+
+func readCycleBucket(t *testing.T, subjectID string, start time.Time) (int64, float64, int64) {
+	t.Helper()
+	var requests, tokens int64
+	var cost float64
+	err := getDB().QueryRow(`
+		SELECT request_count, cost_total, total_tokens
+		FROM ai_account_subject_usage_buckets
+		WHERE auth_subject_id = ? AND bucket_kind = 'cycle' AND bucket_start = ?
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(start)).Scan(&requests, &cost, &tokens)
+	if err != nil {
+		t.Fatalf("read cycle bucket at %v: %v", start, err)
+	}
+	return requests, cost, tokens
+}
+
+// Production, 2026-08-24: a Codex account reported 41% of code_week spent against
+// a reset on the 27th, then hours later a full allowance against a reset on the
+// 31st — the upstream ended the period four days before it was due. Refusing to
+// leave a period until its own reset froze the anchor on the previous week: the
+// card kept showing the old start while the new week's requests kept landing in
+// the old week's bucket, so 12735 requests and $702 were reported for a window
+// the same probe said was 1% used.
+func TestWeeklyCycleRollsWhenUpstreamEndsPeriodEarly(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_codex_early_reset"
+
+	firstProbe := time.Now().UTC().Truncate(time.Second).Add(-8 * time.Hour)
+	firstReset := firstProbe.Add(76 * time.Hour)
+	spent := 59.0
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: firstProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &spent, ResetAt: &firstReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The allowance came back before the stored reset, against a reset a week past
+	// it, and the account has already drawn on the new period.
+	secondProbe := firstProbe.Add(7 * time.Hour)
+	secondReset := firstReset.Add(4*24*time.Hour - 45*time.Minute)
+	fresh := 99.0
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: secondProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &fresh, ResetAt: &secondReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	wantStart := secondReset.Add(-7 * 24 * time.Hour)
+	if !start.Equal(wantStart) || !reset.Equal(secondReset) {
+		t.Fatalf("anchor = %v..%v, want %v..%v (an early upstream reset is a real new period)",
+			start, reset, wantStart, secondReset)
+	}
+
+	// The period the card reports and the period the projection writes into must
+	// be the same one, or the new week's usage is added to the old week's total.
+	projectSubjectRequest(t, subjectID, secondProbe.Add(time.Minute), 10)
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 1 || got.CycleTotalTokens != 10 {
+		t.Fatalf("cycle summary = %+v, want the new period's single request", got)
+	}
+}
+
+// The guard that made the freeze possible has to keep working: a window the
+// account never touched answers every probe with a full window remaining, and
+// following that countdown re-keys the usage bucket on each pass.
+func TestUntouchedWeeklyWindowStillDoesNotRollOnCountdown(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_codex_untouched"
+
+	firstProbe := time.Now().UTC().Truncate(time.Second).Add(-9 * time.Hour)
+	untouched := 100.0
+	first := firstProbe.Add(7 * 24 * time.Hour)
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: firstProbe, Provider: "codex", QuotaKey: "additional:extra:week", QuotaLabel: "Extra",
+		Percent: &untouched, ResetAt: &first, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 3; i++ {
+		at := firstProbe.Add(time.Duration(i) * 2 * time.Hour)
+		sliding := at.Add(7 * 24 * time.Hour)
+		if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+			RecordedAt: at, Provider: "codex", QuotaKey: "additional:extra:week", QuotaLabel: "Extra",
+			Percent: &untouched, ResetAt: &sliding, WindowSeconds: weeklyWindowSeconds,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	start, _ := readCycleAnchor(t, subjectID, "additional:extra:week")
+	if !start.Equal(firstProbe) {
+		t.Fatalf("anchor = %v, want it pinned to the first probe %v", start, firstProbe)
+	}
+}
+
+// A metering probe whose reset is still a whole window away from the probe itself
+// is that same countdown wearing a percentage, so it must not move the anchor
+// either. Once the clock moves on and the reset does not, it is recognised.
+func TestMeteringProbeWithFullWindowCountdownDefersRollover(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_countdown_metering"
+
+	firstProbe := time.Now().UTC().Truncate(time.Second).Add(-30 * time.Hour)
+	firstReset := firstProbe.Add(100 * time.Hour)
+	percent := 80.0
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: firstProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &percent, ResetAt: &firstReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	countdownProbe := firstProbe.Add(10 * time.Hour)
+	countdownReset := countdownProbe.Add(7 * 24 * time.Hour)
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: countdownProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &percent, ResetAt: &countdownReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if start, _ := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey); !start.Equal(firstProbe.Add(100*time.Hour - 7*24*time.Hour)) {
+		t.Fatalf("anchor = %v, want the stored period kept while the reset only counts down", start)
+	}
+
+	// Same reset, later probe: the period is now visibly older than the probe.
+	settledProbe := countdownProbe.Add(3 * time.Hour)
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "codex", []QuotaSnapshotPoint{{
+		RecordedAt: settledProbe, Provider: "codex", QuotaKey: codexWeeklyQuotaKey, QuotaLabel: "Weekly",
+		Percent: &percent, ResetAt: &countdownReset, WindowSeconds: weeklyWindowSeconds,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	start, _ := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	if !start.Equal(countdownReset.Add(-7 * 24 * time.Hour)) {
+		t.Fatalf("anchor = %v, want it rolled once the reset held still across probes", start)
+	}
+}
+
+// Probes stop for disabled, rate limited or unreachable accounts. The projection
+// keys a request's bucket to the period the request happened in, so a reader that
+// reports the stored period verbatim answers with the previous period's start and
+// totals for as long as the outage lasts.
+func TestExpiredAnchorRollsForReadersWithoutAProbe(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_probe_outage"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	staleStart := now.Add(-9 * 24 * time.Hour)
+	staleReset := staleStart.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'codex', ?, ?, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey,
+		staleStart.Format(time.RFC3339Nano), staleReset.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, staleReset.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	starts, err := QueryLatestAIAccountSubjectWeeklyCyclesBatch([]string{subjectID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !starts[subjectID].UTC().Equal(staleReset) {
+		t.Fatalf("reader cycle start = %v, want the period after the expired one (%v)",
+			starts[subjectID].UTC(), staleReset)
+	}
+
+	// The writer must agree, so the request lands in the bucket the reader totals.
+	projectSubjectRequest(t, subjectID, now, 25)
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 1 || got.CycleTotalTokens != 25 {
+		t.Fatalf("cycle summary = %+v, want the rolled period's single request", got)
+	}
+}
+
+// Anchors already frozen on disk cannot wait for the stored period to expire:
+// their totals stay wrong for the rest of a week that upstream has already ended.
+func TestCycleRolloverRepairMovesUsageToTheLivePeriod(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	subjectID := "authsub_repair_frozen"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	frozenStart := now.Add(-4 * 24 * time.Hour)
+	frozenReset := frozenStart.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_cycles
+			(auth_subject_id, provider, quota_key, cycle_start_at, reset_at, window_seconds, last_verified_at)
+		VALUES (?, 'codex', ?, ?, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey,
+		frozenStart.Format(time.RFC3339Nano), frozenReset.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, now.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The probe history already shows the live period: metered, reset a week past
+	// the frozen one.
+	liveStart := now.Add(-90 * time.Minute)
+	liveReset := liveStart.Add(7 * 24 * time.Hour)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_quota_points
+			(auth_subject_id, provider, quota_key, quota_label, percent, reset_at, window_seconds, recorded_at)
+		VALUES (?, 'codex', ?, 'Weekly', 99, ?, ?, ?)
+	`, subjectID, codexWeeklyQuotaKey, liveReset.Format(time.RFC3339Nano),
+		weeklyWindowSeconds, now.Add(-30*time.Minute).Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two requests in the previous period, three in the live one — all five were
+	// counted into the frozen period's bucket.
+	events := []time.Time{
+		frozenStart.Add(time.Hour), frozenStart.Add(30 * time.Hour),
+		liveStart.Add(time.Minute), liveStart.Add(20 * time.Minute), liveStart.Add(80 * time.Minute),
+	}
+	for _, at := range events {
+		if _, err := getDB().Exec(`
+			INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, failed, cost, total_tokens)
+			VALUES ('default', ?, ?, 0, 2, 100)
+		`, at.Format(time.RFC3339Nano), subjectID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count,
+			success_count, failure_count, cost_total, total_tokens, first_event_at, updated_at
+		) VALUES (?, 'cycle', ?, 5, 5, 0, 10, 500, ?, ?)
+	`, subjectID, formatAIAccountSubjectCycleBucketStart(frozenStart),
+		events[0].Format(time.RFC3339Nano), events[4].Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAIAccountSubjectCycleRolloverRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+
+	start, reset := readCycleAnchor(t, subjectID, codexWeeklyQuotaKey)
+	if !start.Equal(liveStart) || !reset.Equal(liveReset) {
+		t.Fatalf("anchor = %v..%v, want the live period %v..%v", start, reset, liveStart, liveReset)
+	}
+	if requests, cost, tokens := readCycleBucket(t, subjectID, liveStart); requests != 3 || cost != 6 || tokens != 300 {
+		t.Fatalf("live bucket = %d requests / %v cost / %d tokens, want 3 / 6 / 300", requests, cost, tokens)
+	}
+	// The usage moved rather than being duplicated: the previous period keeps only
+	// what actually happened in it.
+	if requests, cost, tokens := readCycleBucket(t, subjectID, frozenStart); requests != 2 || cost != 4 || tokens != 200 {
+		t.Fatalf("previous bucket = %d requests / %v cost / %d tokens, want 2 / 4 / 200", requests, cost, tokens)
+	}
+	got := readCycleSummary(t, subjectID)
+	if !got.CycleKnown || got.CycleRequestTotal != 3 || got.CycleTotalTokens != 300 {
+		t.Fatalf("cycle summary = %+v, want the live period's 3 requests / 300 tokens", got)
+	}
+
+	// Idempotent: the marker stops a second pass from moving the totals again.
+	if err := runAIAccountSubjectCycleRolloverRepairDB(getDB()); err != nil {
+		t.Fatal(err)
+	}
+	if requests, _, _ := readCycleBucket(t, subjectID, frozenStart); requests != 2 {
+		t.Fatalf("previous bucket after rerun = %d requests, want 2", requests)
+	}
+}

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -59,21 +59,10 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 			}
 			point.Percent = &v
 		}
-		if point.ResetAt != nil && !point.ResetAt.IsZero() && point.WindowSeconds > 0 {
-			cycle := AIAccountSubjectQuotaCycle{
-				AuthSubjectID: authSubjectID, Provider: pointProvider, QuotaKey: key,
-				CycleStartAt: point.ResetAt.UTC().Add(-time.Duration(point.WindowSeconds) * time.Second),
-				ResetAt:      point.ResetAt.UTC(), WindowSeconds: point.WindowSeconds, LastVerifiedAt: recordedAt,
-			}
-			// Cache the anchored cycle, not the freshly derived one: the in-memory
-			// cache feeds the usage projection's bucket key, so seeding it with the
-			// jittered value would re-split the period the anchor just protected.
-			anchored, err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle, aiAccountSubjectQuotaWindowMetering(point.Percent))
-			if err != nil {
-				return err
-			}
-			cycles = append(cycles, anchored)
-		}
+		// The previous probe is loaded before anchoring, not only for the heartbeat
+		// de-duplication below: a period's end is a transition between two probes —
+		// a window that was metering and now reports a full allowance has been reset
+		// upstream — and a single probe cannot show it.
 		var latestAt sql.NullString
 		var latestPercent sql.NullFloat64
 		var latestReset sql.NullString
@@ -86,6 +75,26 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 		`, authSubjectID, key).Scan(&latestAt, &latestPercent, &latestReset, &latestWindow)
 		if err != nil && err != sql.ErrNoRows {
 			return err
+		}
+		var previousPercent *float64
+		if err == nil {
+			previousPercent = nullableProbePercent(latestPercent)
+		}
+		if point.ResetAt != nil && !point.ResetAt.IsZero() && point.WindowSeconds > 0 {
+			cycle := AIAccountSubjectQuotaCycle{
+				AuthSubjectID: authSubjectID, Provider: pointProvider, QuotaKey: key,
+				CycleStartAt: point.ResetAt.UTC().Add(-time.Duration(point.WindowSeconds) * time.Second),
+				ResetAt:      point.ResetAt.UTC(), WindowSeconds: point.WindowSeconds, LastVerifiedAt: recordedAt,
+			}
+			// Cache the anchored cycle, not the freshly derived one: the in-memory
+			// cache feeds the usage projection's bucket key, so seeding it with the
+			// jittered value would re-split the period the anchor just protected.
+			anchored, upsertErr := upsertAIAccountSubjectQuotaCycleTx(tx, cycle,
+				newAIAccountSubjectQuotaObservation(previousPercent, point.Percent))
+			if upsertErr != nil {
+				return upsertErr
+			}
+			cycles = append(cycles, anchored)
 		}
 		if err == nil {
 			latest, _ := parseStoredTimeString(latestAt.String)
@@ -130,7 +139,7 @@ func nullableStoredTimeEqual(stored sql.NullString, value *time.Time) bool {
 // and split one weekly period into fragments. Within the drift tolerance the
 // stored anchor wins and only last_verified_at moves; a real rollover shifts the
 // start by a whole window and falls outside the tolerance, so it still rolls.
-func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, metering bool) (AIAccountSubjectQuotaCycle, error) {
+func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, observed aiAccountSubjectQuotaObservation) (AIAccountSubjectQuotaCycle, error) {
 	var start, reset storedTime
 	var window int64
 	err := tx.QueryRow(`
@@ -152,7 +161,7 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 		storedReset = reset.Time.UTC()
 	}
 	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) &&
-		aiAccountSubjectCycleRollover(cycle, storedReset, metering) {
+		aiAccountSubjectCycleRollover(cycle, storedReset, observed) {
 		return cycle, nil
 	}
 	cycle.CycleStartAt = start.Time.UTC()
@@ -187,7 +196,22 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 // week while its usage kept accruing into the previous week's bucket. A window
 // that reports consumption is one the upstream is actually counting, so its
 // reset is a real period edge rather than an idle bucket's countdown.
-func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time, metering bool) bool {
+//
+// Metering alone still froze the moment it was meant to catch. A period that has
+// just been refilled is at a full allowance by definition, so the probe that first
+// sees the new period never meters, and rollover waited for the account to spend
+// into it. Production, 2026-08-25: two Codex accounts had code_week drop from 55%
+// and 70% to a full allowance against resets a week past the stored ones, and both
+// anchors stayed on the period that started on the 24th — one card counted 12311
+// requests and 1.4B tokens of two periods added together.
+//
+// The refill itself is therefore the evidence, and it is checked before the
+// countdown guard because the two are indistinguishable by shape: of those two
+// accounts one reported the new period against a fixed edge and the other against
+// "this instant plus a window", which is exactly what an untouched bucket reports.
+// Only the transition out of metering separates a period that just began from one
+// that never started.
+func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time, observed aiAccountSubjectQuotaObservation) bool {
 	if storedReset.IsZero() {
 		return true
 	}
@@ -200,7 +224,40 @@ func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedRe
 	if incoming.ResetAt.UTC().Before(storedReset) {
 		return true
 	}
-	return metering && !aiAccountSubjectCycleFullWindowCountdown(incoming)
+	if observed.refilled {
+		return true
+	}
+	return observed.metering && !aiAccountSubjectCycleFullWindowCountdown(incoming)
+}
+
+// aiAccountSubjectQuotaObservation is what two consecutive probes say about one
+// window. Anchoring is judged on the pair because the end of a period is a
+// transition — no single probe carries it.
+type aiAccountSubjectQuotaObservation struct {
+	// metering reports that this probe shows consumption drawn from the period it
+	// describes, which makes its reset a real period edge.
+	metering bool
+	// refilled reports that the previous probe was metering and this one is back to
+	// a full allowance: the upstream ended the period it had been counting.
+	refilled bool
+}
+
+func newAIAccountSubjectQuotaObservation(previous, current *float64) aiAccountSubjectQuotaObservation {
+	return aiAccountSubjectQuotaObservation{
+		metering: aiAccountSubjectQuotaWindowMetering(current),
+		refilled: aiAccountSubjectQuotaWindowMetering(previous) && current != nil && *current >= 100,
+	}
+}
+
+// nullableProbePercent adapts a stored percentage for comparison. It is absent
+// both when no probe has been recorded yet and when the upstream reports no
+// percentage, and neither case says anything about a period ending.
+func nullableProbePercent(stored sql.NullFloat64) *float64 {
+	if !stored.Valid {
+		return nil
+	}
+	value := stored.Float64
+	return &value
 }
 
 // aiAccountSubjectQuotaWindowMetering reports whether a probe shows the window
@@ -232,8 +289,8 @@ func aiAccountSubjectCycleFullWindowCountdown(incoming AIAccountSubjectQuotaCycl
 
 const aiAccountSubjectFullWindowCountdownSlack = 2 * time.Minute
 
-func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, metering bool) (AIAccountSubjectQuotaCycle, error) {
-	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle, metering)
+func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, observed aiAccountSubjectQuotaObservation) (AIAccountSubjectQuotaCycle, error) {
+	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle, observed)
 	if err != nil {
 		return cycle, err
 	}

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -147,16 +147,48 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 	if !start.Valid || window != cycle.WindowSeconds {
 		return cycle, nil
 	}
-	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) {
+	storedReset := time.Time{}
+	if reset.Valid {
+		storedReset = reset.Time.UTC()
+	}
+	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) &&
+		aiAccountSubjectCycleRollover(cycle, storedReset) {
 		return cycle, nil
 	}
 	cycle.CycleStartAt = start.Time.UTC()
-	if reset.Valid && !reset.Time.IsZero() {
+	if !storedReset.IsZero() {
 		// Keep reset_at consistent with the anchor so the card countdown stops
 		// jittering by a second or two on every probe.
-		cycle.ResetAt = reset.Time.UTC()
+		cycle.ResetAt = storedReset
 	}
 	return cycle, nil
+}
+
+// aiAccountSubjectCycleRollover reports whether a probe describes a genuinely new
+// period rather than the stored one seen through a moving countdown.
+//
+// Drift tolerance alone was not enough. A quota bucket the account has not touched
+// is answered as "a full window remaining", so its reset — and the start derived
+// from it — advances by however long has passed since the last probe. Hours of
+// that is far outside any tolerance, yet nothing has rolled: it is the same
+// untouched period. Treating each probe as a new period is what re-keyed the
+// usage bucket every few hours and scattered one week's requests across six of
+// them.
+//
+// A period may therefore only be replaced when the upstream shows the old one is
+// finished: the probe ran after it ended, the new period starts where it ended,
+// or the reset moved closer (credits reset, plan change).
+func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time) bool {
+	if storedReset.IsZero() {
+		return true
+	}
+	if !incoming.LastVerifiedAt.IsZero() && !incoming.LastVerifiedAt.UTC().Before(storedReset) {
+		return true
+	}
+	if sameAIAccountSubjectCycle(incoming.CycleStartAt, storedReset, incoming.WindowSeconds) {
+		return true
+	}
+	return incoming.ResetAt.UTC().Before(storedReset)
 }
 
 func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, error) {
@@ -248,14 +280,21 @@ func QueryAIAccountSubjectQuotaSeries(authSubjectID string, start, end time.Time
 	return series, rows.Err()
 }
 
-func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferredKeys []string) (map[string]time.Time, error) {
+// QueryLatestAIAccountSubjectWeeklyCyclesBatch resolves each subject's cycle
+// anchor. Candidate filtering deliberately happens in
+// selectAIAccountSubjectWeeklyCycle rather than in SQL: the preference is
+// per-provider, and a single IN list built from a mixed batch dropped every
+// window belonging to a provider that names its buckets differently — with the
+// list holding "seven_day" for Claude, antigravity's own weekly rows never came
+// back and its accounts reported no cycle at all.
+func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string) (map[string]time.Time, error) {
 	db := getReadDB()
 	ids := dedupeExactStrings(subjectIDs)
 	out := make(map[string]time.Time)
 	if db == nil || len(ids) == 0 {
 		return out, nil
 	}
-	args := make([]any, 0, len(ids)+len(preferredKeys)+1)
+	args := make([]any, 0, len(ids)+1)
 	for _, id := range ids {
 		args = append(args, id)
 	}
@@ -265,14 +304,6 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string, preferred
 		FROM ai_account_subject_quota_cycles
 		WHERE auth_subject_id IN (` + strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + `)
 		  AND window_seconds >= ?`
-	keys := dedupeExactStrings(preferredKeys)
-	if len(keys) > 0 {
-		query += ` AND quota_key IN (` + strings.TrimSuffix(strings.Repeat("?,", len(keys)), ",") + `)`
-		for _, key := range keys {
-			args = append(args, key)
-		}
-	}
-	query += ` ORDER BY last_verified_at DESC, reset_at DESC`
 	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("usage: query shared quota cycles: %w", err)

--- a/internal/usage/ai_account_subject_quota_store.go
+++ b/internal/usage/ai_account_subject_quota_store.go
@@ -68,7 +68,7 @@ func RecordAIAccountSubjectQuotaPoints(authSubjectID, provider string, points []
 			// Cache the anchored cycle, not the freshly derived one: the in-memory
 			// cache feeds the usage projection's bucket key, so seeding it with the
 			// jittered value would re-split the period the anchor just protected.
-			anchored, err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle)
+			anchored, err := upsertAIAccountSubjectQuotaCycleTx(tx, cycle, aiAccountSubjectQuotaWindowMetering(point.Percent))
 			if err != nil {
 				return err
 			}
@@ -130,7 +130,7 @@ func nullableStoredTimeEqual(stored sql.NullString, value *time.Time) bool {
 // and split one weekly period into fragments. Within the drift tolerance the
 // stored anchor wins and only last_verified_at moves; a real rollover shifts the
 // start by a whole window and falls outside the tolerance, so it still rolls.
-func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, error) {
+func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, metering bool) (AIAccountSubjectQuotaCycle, error) {
 	var start, reset storedTime
 	var window int64
 	err := tx.QueryRow(`
@@ -152,7 +152,7 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 		storedReset = reset.Time.UTC()
 	}
 	if !sameAIAccountSubjectCycle(cycle.CycleStartAt, start.Time, cycle.WindowSeconds) &&
-		aiAccountSubjectCycleRollover(cycle, storedReset) {
+		aiAccountSubjectCycleRollover(cycle, storedReset, metering) {
 		return cycle, nil
 	}
 	cycle.CycleStartAt = start.Time.UTC()
@@ -175,10 +175,19 @@ func anchorAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaC
 // usage bucket every few hours and scattered one week's requests across six of
 // them.
 //
-// A period may therefore only be replaced when the upstream shows the old one is
+// A period may therefore be replaced when the upstream shows the old one is
 // finished: the probe ran after it ended, the new period starts where it ended,
 // or the reset moved closer (credits reset, plan change).
-func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time) bool {
+//
+// It may also be replaced when the probe is metering. An upstream can end a
+// period early — production had a Codex account report 41% of code_week spent
+// against a reset four days out, then, hours later, a full allowance against a
+// reset a week past the old one. That is a real new period arriving before the
+// stored one was due, and holding the old anchor froze the card on the previous
+// week while its usage kept accruing into the previous week's bucket. A window
+// that reports consumption is one the upstream is actually counting, so its
+// reset is a real period edge rather than an idle bucket's countdown.
+func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedReset time.Time, metering bool) bool {
 	if storedReset.IsZero() {
 		return true
 	}
@@ -188,11 +197,43 @@ func aiAccountSubjectCycleRollover(incoming AIAccountSubjectQuotaCycle, storedRe
 	if sameAIAccountSubjectCycle(incoming.CycleStartAt, storedReset, incoming.WindowSeconds) {
 		return true
 	}
-	return incoming.ResetAt.UTC().Before(storedReset)
+	if incoming.ResetAt.UTC().Before(storedReset) {
+		return true
+	}
+	return metering && !aiAccountSubjectCycleFullWindowCountdown(incoming)
 }
 
-func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, error) {
-	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle)
+// aiAccountSubjectQuotaWindowMetering reports whether a probe shows the window
+// counting usage. Percent is the share remaining, so 100 (or an upstream that
+// reports no percentage at all) means nothing has been drawn from the period the
+// probe describes, and its reset carries no evidence about where that period began.
+func aiAccountSubjectQuotaWindowMetering(percent *float64) bool {
+	return percent != nil && *percent < 100
+}
+
+// aiAccountSubjectCycleFullWindowCountdown reports whether the probe's reset is
+// simply "one full window from this probe".
+//
+// A metering percentage alone would still admit an upstream that answers every
+// probe with a whole window remaining; the derived start would then track the
+// probe clock and re-key the usage bucket on each pass. A genuine period began
+// before the probe that observed it, so its derived start sits behind the probe
+// by however long the period has been running. The slack is small on purpose:
+// an idle bucket's countdown lands on the probe instant to the second, and a real
+// period caught within the slack of its own start is recognised on the next probe,
+// once the clock has moved on and the reset has not.
+func aiAccountSubjectCycleFullWindowCountdown(incoming AIAccountSubjectQuotaCycle) bool {
+	if incoming.LastVerifiedAt.IsZero() {
+		return false
+	}
+	drift := absDuration(incoming.CycleStartAt.UTC().Sub(incoming.LastVerifiedAt.UTC()))
+	return drift <= aiAccountSubjectFullWindowCountdownSlack
+}
+
+const aiAccountSubjectFullWindowCountdownSlack = 2 * time.Minute
+
+func upsertAIAccountSubjectQuotaCycleTx(tx *sql.Tx, cycle AIAccountSubjectQuotaCycle, metering bool) (AIAccountSubjectQuotaCycle, error) {
+	anchored, err := anchorAIAccountSubjectQuotaCycleTx(tx, cycle, metering)
 	if err != nil {
 		return cycle, err
 	}
@@ -331,9 +372,10 @@ func QueryLatestAIAccountSubjectWeeklyCyclesBatch(subjectIDs []string) (map[stri
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	now := time.Now().UTC()
 	for subjectID, cycles := range cyclesBySubject {
 		if cycle, ok := selectAIAccountSubjectWeeklyCycle(cycles); ok {
-			out[subjectID] = cycle.CycleStartAt
+			out[subjectID] = advanceAIAccountSubjectCycleTo(cycle, now).CycleStartAt
 		}
 	}
 	return out, nil

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -78,6 +78,54 @@ func PrimaryWeeklyQuotaKeys(provider string) []string {
 	return []string{key}
 }
 
+// xaiProductQuotaKeyPrefix marks a per-product xAI weekly window.
+const xaiProductQuotaKeyPrefix = "product:"
+
+// MatchesProjectionQuotaKey reports whether a weekly quota window may serve as
+// the divisor of the weekly-budget projection.
+//
+// The projection divides locally recorded cost by an upstream consumption
+// share, so the two sides have to describe the same requests. For most
+// providers the card cycle window is also the only window the proxy's traffic
+// feeds, and the primary key is the right divisor.
+//
+// xAI is the exception: SuperGrok bills every product — Grok Chat on the web
+// included — against one shared weekly pool, so weekly_limit counts consumption
+// this proxy never produced and using it understates the projected budget by
+// however much the account spent elsewhere. The xAI probe attaches the weekly
+// window only to products the proxy actually feeds (see parseXAIWeeklyBilling),
+// so a product window of weekly width is exactly the attributable share.
+//
+// Callers keep applying their own window-width filter; this only narrows which
+// keys within that width are eligible.
+func MatchesProjectionQuotaKey(provider, quotaKey string) bool {
+	quotaKey = strings.TrimSpace(quotaKey)
+	if quotaKey == "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "xai", "grok":
+		return strings.HasPrefix(quotaKey, xaiProductQuotaKeyPrefix)
+	default:
+		return quotaKey == primaryAIAccountSubjectWeeklyQuotaKey(provider)
+	}
+}
+
+// ProjectionQuotaIsAttributable reports whether a provider's projection divisor
+// is narrower than its pool-wide weekly percentage.
+//
+// The panel shows both numbers — "weekly quota used" from the pool and the
+// projected budget from the attributable share — and without this flag the two
+// read as contradictory (19% consumed against a budget derived from 16%).
+func ProjectionQuotaIsAttributable(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "xai", "grok":
+		return true
+	default:
+		return false
+	}
+}
+
 // aiAccountSubjectCycleDriftTolerance bounds how far a re-probed cycle start may
 // move and still count as the same cycle.
 //

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -54,6 +54,13 @@ func primaryAIAccountSubjectWeeklyQuotaKey(provider string) string {
 		return "code_week"
 	case "xai", "grok":
 		return "weekly_limit"
+	case "antigravity":
+		// Antigravity reports two weekly buckets — Gemini models and the
+		// third-party (Claude/GPT) ones. Gemini is the bucket an account actually
+		// spends; the 3p bucket usually sits unused, and while it does the
+		// upstream answers its reset as "now + 7d", so its derived start walks
+		// forward on every probe and can never anchor a period.
+		return "antigravity:gemini_weekly"
 	default:
 		return ""
 	}
@@ -113,21 +120,57 @@ func sameAIAccountSubjectCycle(a, b time.Time, windowSeconds int64) bool {
 	return absDuration(a.UTC().Sub(b.UTC())) <= aiAccountSubjectCycleDriftTolerance(windowSeconds)
 }
 
+// selectAIAccountSubjectWeeklyCycle answers "which window is this subject's card
+// cycle" and must answer it identically everywhere.
+//
+// The request-hot projection asks via an in-memory map and the readers ask via a
+// SQL result set, so the answer cannot depend on the order candidates arrive in.
+// It also cannot depend on last_verified_at or reset_at: a provider that reports
+// several weekly windows re-stamps them all on the same probe, and ordering by a
+// moving timestamp let the two sides pick different windows. Requests then landed
+// in a bucket no reader looked at — production had an account with 1084 lifetime
+// calls whose card reported 0 for the period.
 func selectAIAccountSubjectWeeklyCycle(cycles []AIAccountSubjectQuotaCycle) (AIAccountSubjectQuotaCycle, bool) {
-	var selected AIAccountSubjectQuotaCycle
+	candidates := make([]AIAccountSubjectQuotaCycle, 0, len(cycles))
+	preferred := make([]AIAccountSubjectQuotaCycle, 0, len(cycles))
 	for _, cycle := range cycles {
 		if cycle.WindowSeconds < aiAccountSubjectWeeklyWindowSeconds || cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() {
 			continue
 		}
+		candidates = append(candidates, cycle)
 		primaryKey := primaryAIAccountSubjectWeeklyQuotaKey(cycle.Provider)
-		if primaryKey != "" && strings.TrimSpace(cycle.QuotaKey) != primaryKey {
-			continue
+		if primaryKey != "" && strings.TrimSpace(cycle.QuotaKey) == primaryKey {
+			preferred = append(preferred, cycle)
 		}
-		if selected.AuthSubjectID == "" || cycle.LastVerifiedAt.After(selected.LastVerifiedAt) {
+	}
+	// The provider's named window wins when the probe returned it. When it did
+	// not — an upstream rename, or a fallback probe that only sees other windows
+	// — keep the remaining candidates instead of reporting no cycle at all.
+	if len(preferred) > 0 {
+		candidates = preferred
+	}
+	if len(candidates) == 0 {
+		return AIAccountSubjectQuotaCycle{}, false
+	}
+	selected := candidates[0]
+	for _, cycle := range candidates[1:] {
+		if aiAccountSubjectCycleRanksAhead(cycle, selected) {
 			selected = cycle
 		}
 	}
-	return selected, selected.AuthSubjectID != ""
+	return selected, true
+}
+
+// aiAccountSubjectCycleRanksAhead is a total order over cycle candidates, so the
+// winner is a pure function of the set. The narrowest window at or above a week
+// is the weekly one — a monthly window sorts behind it rather than displacing it
+// — and the quota key breaks the tie because, unlike any timestamp, it does not
+// move when the next probe lands.
+func aiAccountSubjectCycleRanksAhead(candidate, current AIAccountSubjectQuotaCycle) bool {
+	if candidate.WindowSeconds != current.WindowSeconds {
+		return candidate.WindowSeconds < current.WindowSeconds
+	}
+	return strings.TrimSpace(candidate.QuotaKey) < strings.TrimSpace(current.QuotaKey)
 }
 
 func cachedAIAccountSubjectWeeklyCycle(subjectID string) (AIAccountSubjectQuotaCycle, bool) {

--- a/internal/usage/ai_account_subject_usage.go
+++ b/internal/usage/ai_account_subject_usage.go
@@ -233,13 +233,42 @@ func aiAccountSubjectCycleAt(tx *sql.Tx, subjectID string, at time.Time) (AIAcco
 	if !ok {
 		return AIAccountSubjectQuotaCycle{}, false, nil
 	}
-	at = at.UTC()
-	window := time.Duration(cycle.WindowSeconds) * time.Second
-	for !at.Before(cycle.ResetAt) {
-		cycle.CycleStartAt = cycle.ResetAt
-		cycle.ResetAt = cycle.ResetAt.Add(window)
+	cycle = advanceAIAccountSubjectCycleTo(cycle, at)
+	return cycle, !at.UTC().Before(cycle.CycleStartAt), nil
+}
+
+// advanceAIAccountSubjectCycleTo rolls a stored anchor forward to the period that
+// contains at.
+//
+// The stored anchor only moves when a probe lands, and probes stop whenever the
+// account is disabled, rate limited or simply unreachable. Every reader must
+// therefore apply the same elapsed-time roll the projection applies, or the two
+// sides disagree the moment a reset passes unprobed: the writer keys the bucket
+// to the period the request happened in while the card still reports the previous
+// period's start — and, matching buckets against that stale start, the previous
+// period's totals.
+func advanceAIAccountSubjectCycleTo(cycle AIAccountSubjectQuotaCycle, at time.Time) AIAccountSubjectQuotaCycle {
+	cycle.CycleStartAt, cycle.ResetAt = advanceQuotaCyclePeriod(cycle.CycleStartAt, cycle.ResetAt, cycle.WindowSeconds, at)
+	return cycle
+}
+
+// advanceQuotaCyclePeriod is the shared roll used by both cycle tables, so the
+// tenant-scoped reader cannot answer with a different period than the shared one.
+func advanceQuotaCyclePeriod(start, reset time.Time, windowSeconds int64, at time.Time) (time.Time, time.Time) {
+	if windowSeconds <= 0 || reset.IsZero() {
+		return start, reset
 	}
-	return cycle, !at.Before(cycle.CycleStartAt), nil
+	at = at.UTC()
+	reset = reset.UTC()
+	if at.Before(reset) {
+		return start, reset
+	}
+	// Jump to the containing period rather than stepping one window at a time: an
+	// anchor left behind by a long probe outage can be many windows old.
+	window := time.Duration(windowSeconds) * time.Second
+	skipped := at.Sub(reset) / window
+	start = reset.Add(skipped * window)
+	return start, start.Add(window)
 }
 
 func formatAIAccountSubjectCycleBucketStart(value time.Time) string {

--- a/internal/usage/auth_subject_identity.go
+++ b/internal/usage/auth_subject_identity.go
@@ -5,13 +5,20 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/google/uuid"
+
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 // AuthSubjectIdentity is the single account identity contract used by status,
 // usage, quota and identity fingerprints. AccountKey must always equal ID.
-// Only provider-stable account_id seeds are eligible for cross-tenant sharing;
-// all fallbacks include tenant_id in the seed and remain tenant scoped.
+//
+// A subject is meant to be the physical upstream account: one account, one
+// subject, bound by however many tenants happen to hold a credential for it.
+// Sharing therefore follows whether the seed identifies that account —
+// the provider's account id, the account's email, or the credential's own
+// provider-scoped id all do. Only auth_index, which is local bookkeeping and
+// names no account at all, stays tenant scoped.
 type AuthSubjectIdentity struct {
 	ID            string
 	Provider      string
@@ -47,28 +54,43 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 	seedKind := ""
 	seedValue := ""
 	shareEligible := false
-	subjectScope := "tenant"
+	subjectScope := AIAccountSubjectScopeTenant
 	shareReason := "fallback_identity_is_tenant_scoped"
 	switch {
 	case accountID != "":
 		seedKind = "account_id"
 		seedValue = accountID
 		shareEligible = true
-		subjectScope = "shared"
 		shareReason = "stable_provider_account_id"
 	case email != "":
+		// The email is the account, not a property of the tenant that mounted it.
+		// Folding tenant_id into this seed split one Google account across every
+		// tenant holding a credential for it, so each tenant saw a fraction of the
+		// account's usage next to the whole account's quota.
 		seedKind = "email"
 		seedValue = email
-	case strings.TrimSpace(auth.ID) != "":
+		shareEligible = true
+		shareReason = "provider_account_email"
+	case providerScopedAuthID(auth) != "":
+		// API-key credentials land here: their id is "<provider>:apikey:<digest>",
+		// which is the same string wherever the key is mounted once the tenant
+		// prefix — the only tenant-local part — is removed.
 		seedKind = "auth_id"
-		seedValue = strings.TrimSpace(auth.ID)
+		seedValue = providerScopedAuthID(auth)
+		shareEligible = true
+		shareReason = "provider_scoped_auth_id"
 	default:
 		authIndex := strings.TrimSpace(auth.EnsureIndex())
 		if authIndex == "" {
 			return nil
 		}
+		// auth_index is local bookkeeping and identifies no account, so it cannot
+		// be trusted to mean "the same account" across tenants.
 		seedKind = "auth_index"
 		seedValue = authIndex
+	}
+	if shareEligible {
+		subjectScope = AIAccountSubjectScopeShared
 	}
 
 	subjectSeed := []string{provider, seedKind, seedValue}
@@ -89,6 +111,63 @@ func ResolveAuthSubjectIdentity(auth *coreauth.Auth) *AuthSubjectIdentity {
 		ShareEligible: shareEligible,
 		ShareReason:   shareReason,
 	}
+}
+
+// providerScopedAuthID strips the tenant prefix an auth id is stored with.
+//
+// Ids are persisted as "<tenant-uuid>/<provider>:apikey:<digest>" (the system
+// tenant keeps the bare form). Everything after the prefix is derived from the
+// credential itself, so removing it yields the same string for one credential no
+// matter which tenant mounted it — while two different keys still differ, their
+// digests being taken from the key material.
+func providerScopedAuthID(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	id := strings.TrimSpace(auth.ID)
+	if id == "" {
+		return ""
+	}
+	slash := strings.Index(id, "/")
+	if slash <= 0 {
+		return id
+	}
+	if _, err := uuid.Parse(id[:slash]); err != nil {
+		return id
+	}
+	return strings.TrimSpace(id[slash+1:])
+}
+
+// LegacyTenantScopedAuthSubjectID recomputes the subject id this auth had while
+// every non-account_id seed was tenant scoped. The migration needs it to find
+// the rows an account accumulated under its old, split identity; nothing on the
+// live path may use it.
+func LegacyTenantScopedAuthSubjectID(auth *coreauth.Auth) string {
+	identity := ResolveAuthSubjectIdentity(auth)
+	if identity == nil {
+		return ""
+	}
+	// account_id and auth_index seeds never changed shape, so they have no legacy
+	// counterpart to migrate from.
+	seedValue := ""
+	switch identity.SeedKind {
+	case "email":
+		seedValue = identity.Email
+	case "auth_id":
+		// The legacy seed carried the id exactly as stored, prefix included.
+		seedValue = strings.TrimSpace(auth.ID)
+	default:
+		return ""
+	}
+	if seedValue == "" {
+		return ""
+	}
+	return stableAuthSubjectID(
+		identity.Provider,
+		identity.SeedKind,
+		coreauth.NormalizedTenantID(auth.TenantID),
+		seedValue,
+	)
 }
 
 func BuildAuthSubjectMatcher(current *coreauth.Auth, auths []*coreauth.Auth) AuthSubjectMatcher {

--- a/internal/usage/auth_subject_identity_migration.go
+++ b/internal/usage/auth_subject_identity_migration.go
@@ -1,0 +1,339 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// mergedLegacySubjects remembers the legacy ids this process has already dealt
+// with. Auth reload fires the binding hook for every credential on every config
+// change, and the check below is otherwise a handful of queries per credential
+// that can only ever find nothing after the first pass.
+var mergedLegacySubjects sync.Map
+
+// legacySubjectMergeMu serialises merges. Two credentials for one account load
+// concurrently and would otherwise race to move the same legacy rows.
+var legacySubjectMergeMu sync.Mutex
+
+// subjectRewriteTables carry a subject reference whose primary key already
+// includes tenant_id (or is a surrogate id), so one account's rows from two
+// tenants cannot collide and a plain rewrite is enough.
+var subjectRewriteTables = []struct{ table, column string }{
+	{"ai_account_tenant_bindings", "auth_subject_id"},
+	{"ai_account_status", "auth_subject_id"},
+	{"ai_account_subject_quota_points", "auth_subject_id"},
+	{"auth_subject_usage_daily", "auth_subject_id"},
+	{"auth_subject_quota_cycles", "subject_id"},
+	{"auth_file_quota_snapshots", "auth_subject_id"},
+	{"auth_file_quota_snapshot_points", "auth_subject_id"},
+	{"identity_fingerprints", "auth_subject_id"},
+	{"request_logs", "auth_subject_id"},
+	{"usage_rollup_buckets", "auth_subject_id"},
+}
+
+// subjectAccountKeyTables key fingerprint rows by account_key, which is defined
+// to equal the subject id. Their uniqueness includes tenant_id, so the collision
+// to resolve is only the one a tenant that held both halves would hit — and the
+// key set differs per table, which is what decides whether a row is a duplicate.
+var subjectAccountKeyTables = []struct {
+	table       string
+	uniqueRest  []string
+	preferNewer string
+}{
+	{"identity_fingerprints", []string{"tenant_id", "provider", "profile_key"}, "last_seen_at"},
+	{"identity_fingerprint_account_policies", []string{"tenant_id", "provider"}, "updated_at"},
+}
+
+// MergeLegacySplitAuthSubject folds the rows an account accumulated while its
+// identity was tenant scoped onto the shared identity it has now.
+//
+// Every seed except auth_index used to carry tenant_id, so one upstream account
+// became a separate subject in each tenant holding a credential for it. Usage,
+// status and cycle rows were then split across those subjects while the quota
+// they sat next to described the whole account — a tenant that had not called
+// the account yet showed zeros beside a quota bar reading 87%.
+//
+// Called from the binding hook, so it runs with the authoritative auth in hand
+// rather than trying to reconstruct seeds from hashes on disk.
+func MergeLegacySplitAuthSubject(auth *coreauth.Auth, identity *AuthSubjectIdentity) error {
+	if auth == nil || identity == nil || strings.TrimSpace(identity.ID) == "" {
+		return nil
+	}
+	legacyID := LegacyTenantScopedAuthSubjectID(auth)
+	if legacyID == "" || legacyID == identity.ID {
+		return nil
+	}
+	if _, seen := mergedLegacySubjects.Load(legacyID); seen {
+		return nil
+	}
+	db := getDB()
+	if db == nil {
+		return nil
+	}
+
+	legacySubjectMergeMu.Lock()
+	defer legacySubjectMergeMu.Unlock()
+	if _, seen := mergedLegacySubjects.Load(legacyID); seen {
+		return nil
+	}
+
+	present, err := legacyAuthSubjectHasRows(db, legacyID)
+	if err != nil {
+		return err
+	}
+	if !present {
+		mergedLegacySubjects.Store(legacyID, struct{}{})
+		return nil
+	}
+
+	if err := mergeLegacyAuthSubjectDB(db, legacyID, identity); err != nil {
+		return err
+	}
+	mergedLegacySubjects.Store(legacyID, struct{}{})
+	return nil
+}
+
+// legacyAuthSubjectHasRows is the cheap guard on the reload path: an account
+// that was never split, or was migrated on an earlier boot, answers false here
+// and never opens a transaction.
+func legacyAuthSubjectHasRows(db *sql.DB, legacyID string) (bool, error) {
+	for _, probe := range []string{
+		`SELECT 1 FROM ai_account_subjects WHERE auth_subject_id = ? LIMIT 1`,
+		`SELECT 1 FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ? LIMIT 1`,
+		`SELECT 1 FROM ai_account_subject_status WHERE auth_subject_id = ? LIMIT 1`,
+	} {
+		var found int
+		err := db.QueryRow(probe, legacyID).Scan(&found)
+		if err == nil {
+			return true, nil
+		}
+		if err != sql.ErrNoRows {
+			return false, fmt.Errorf("usage: probe legacy auth subject: %w", err)
+		}
+	}
+	return false, nil
+}
+
+func mergeLegacyAuthSubjectDB(db *sql.DB, legacyID string, identity *AuthSubjectIdentity) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("usage: begin legacy auth subject merge: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// The shared subject row must exist first: four tables carry a foreign key to
+	// it, so nothing may point at an id that is not there yet.
+	if err := ensureAuthSubjectRowTx(tx, legacyID, identity); err != nil {
+		return err
+	}
+	if err := mergeLegacySubjectUsageBucketsTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	if err := mergeLegacySubjectStatusTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	if err := mergeLegacySubjectQuotaCyclesTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	for _, target := range subjectRewriteTables {
+		if _, err := tx.Exec(
+			`UPDATE `+target.table+` SET `+target.column+` = ? WHERE `+target.column+` = ?`,
+			identity.ID, legacyID,
+		); err != nil {
+			return fmt.Errorf("usage: rewrite %s.%s: %w", target.table, target.column, err)
+		}
+	}
+	for _, target := range subjectAccountKeyTables {
+		if err := mergeSubjectAccountKeyRowsTx(tx, target.table, target.uniqueRest, target.preferNewer, legacyID, identity.ID); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`DELETE FROM ai_account_subjects WHERE auth_subject_id = ?`, legacyID); err != nil {
+		return fmt.Errorf("usage: drop legacy auth subject: %w", err)
+	}
+
+	// Two tenants anchored their halves of this account independently, so the
+	// merged cycle buckets can be keyed to different starts. Fold them now rather
+	// than leaving the account reading zero until the period rolls.
+	if err := realignAuthSubjectCycleBucketsTx(tx, identity.ID); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("usage: commit legacy auth subject merge: %w", err)
+	}
+	// The projection keys buckets off the cycle cache, which may still hold the
+	// pre-merge anchor for either half.
+	resetAIAccountSubjectCycleCache()
+	return nil
+}
+
+// ensureAuthSubjectRowTx creates the shared subject row, seeding its history
+// markers from the legacy row so a merged account does not look newly observed.
+func ensureAuthSubjectRowTx(tx *sql.Tx, legacyID string, identity *AuthSubjectIdentity) error {
+	shareEligible := 0
+	if identity.ShareEligible {
+		shareEligible = 1
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO ai_account_subjects (
+			auth_subject_id, provider, subject_scope, seed_kind, seed_hash, share_eligible,
+			usage_projected_since, usage_history_complete, created_at, updated_at
+		)
+		SELECT ?, ?, ?, ?, ?, ?, usage_projected_since, usage_history_complete, created_at, updated_at
+		FROM ai_account_subjects WHERE auth_subject_id = ?
+		ON CONFLICT(auth_subject_id) DO UPDATE SET
+			usage_projected_since = CASE
+				WHEN excluded.usage_projected_since IS NOT NULL
+				 AND (ai_account_subjects.usage_projected_since IS NULL
+				      OR excluded.usage_projected_since < ai_account_subjects.usage_projected_since)
+				THEN excluded.usage_projected_since
+				ELSE ai_account_subjects.usage_projected_since END,
+			created_at = CASE WHEN excluded.created_at < ai_account_subjects.created_at
+				THEN excluded.created_at ELSE ai_account_subjects.created_at END,
+			updated_at = CASE WHEN excluded.updated_at > ai_account_subjects.updated_at
+				THEN excluded.updated_at ELSE ai_account_subjects.updated_at END
+	`, identity.ID, identity.Provider, identity.SubjectScope, identity.SeedKind, identity.SeedHash,
+		shareEligible, legacyID); err != nil {
+		return fmt.Errorf("usage: ensure shared auth subject: %w", err)
+	}
+	return nil
+}
+
+// mergeLegacySubjectUsageBucketsTx adds the legacy totals into the shared rows.
+// Counters sum, the first event keeps the earliest sighting and updated_at the
+// latest, so the merged account reads as one continuous history.
+func mergeLegacySubjectUsageBucketsTx(tx *sql.Tx, legacyID, subjectID string) error {
+	if _, err := tx.Exec(`
+		INSERT INTO ai_account_subject_usage_buckets (
+			auth_subject_id, bucket_kind, bucket_start, request_count, success_count,
+			failure_count, cost_total, total_tokens, first_event_at, updated_at
+		)
+		SELECT ?, bucket_kind, bucket_start, request_count, success_count,
+			failure_count, cost_total, total_tokens, first_event_at, updated_at
+		FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ?
+		ON CONFLICT(auth_subject_id, bucket_kind, bucket_start) DO UPDATE SET
+			request_count = ai_account_subject_usage_buckets.request_count + excluded.request_count,
+			success_count = ai_account_subject_usage_buckets.success_count + excluded.success_count,
+			failure_count = ai_account_subject_usage_buckets.failure_count + excluded.failure_count,
+			cost_total = ai_account_subject_usage_buckets.cost_total + excluded.cost_total,
+			total_tokens = ai_account_subject_usage_buckets.total_tokens + excluded.total_tokens,
+			first_event_at = CASE WHEN excluded.first_event_at < ai_account_subject_usage_buckets.first_event_at
+				THEN excluded.first_event_at ELSE ai_account_subject_usage_buckets.first_event_at END,
+			updated_at = CASE WHEN excluded.updated_at > ai_account_subject_usage_buckets.updated_at
+				THEN excluded.updated_at ELSE ai_account_subject_usage_buckets.updated_at END
+	`, subjectID, legacyID); err != nil {
+		return fmt.Errorf("usage: merge legacy subject usage buckets: %w", err)
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ?`, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: drop legacy subject usage buckets: %w", err)
+	}
+	return nil
+}
+
+// mergeSubjectAccountKeyRowsTx re-keys fingerprint rows onto the shared subject.
+//
+// A tenant only collides with itself here — it held both halves of the account
+// and so has a row under each key. The newer row wins, since these describe the
+// client identity last presented for the account, and the loser is dropped
+// rather than being rewritten into a duplicate key.
+func mergeSubjectAccountKeyRowsTx(tx *sql.Tx, table string, uniqueRest []string, preferNewer, legacyID, subjectID string) error {
+	match := make([]string, 0, len(uniqueRest))
+	for _, column := range uniqueRest {
+		match = append(match, "other."+column+" = "+table+"."+column)
+	}
+	matched := strings.Join(match, " AND ")
+
+	// Drop whichever side is older wherever both exist for the same tenant row.
+	for _, drop := range []struct{ victim, rival string }{
+		{subjectID, legacyID},
+		{legacyID, subjectID},
+	} {
+		comparison := ">"
+		if drop.victim == legacyID {
+			// The shared row survives ties: re-keying the legacy row on top of an
+			// equally fresh shared row would only trade one for an identical other.
+			comparison = ">="
+		}
+		if _, err := tx.Exec(
+			`DELETE FROM `+table+` WHERE account_key = ? AND EXISTS (
+				SELECT 1 FROM `+table+` other
+				WHERE other.account_key = ? AND `+matched+`
+				  AND other.`+preferNewer+` `+comparison+` `+table+`.`+preferNewer+`
+			)`, drop.victim, drop.rival,
+		); err != nil {
+			return fmt.Errorf("usage: drop duplicate %s row: %w", table, err)
+		}
+	}
+	if _, err := tx.Exec(
+		`UPDATE `+table+` SET account_key = ? WHERE account_key = ?`, subjectID, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: rewrite %s.account_key: %w", table, err)
+	}
+	return nil
+}
+
+// mergeLegacySubjectStatusTx keeps whichever half was probed last. Status is a
+// snapshot of the upstream account, not something to add up.
+func mergeLegacySubjectStatusTx(tx *sql.Tx, legacyID, subjectID string) error {
+	if _, err := tx.Exec(`
+		DELETE FROM ai_account_subject_status
+		WHERE auth_subject_id = ? AND EXISTS (
+			SELECT 1 FROM ai_account_subject_status legacy
+			WHERE legacy.auth_subject_id = ?
+			  AND legacy.updated_at > ai_account_subject_status.updated_at
+		)`, subjectID, legacyID); err != nil {
+		return fmt.Errorf("usage: drop stale shared subject status: %w", err)
+	}
+	if _, err := tx.Exec(`
+		DELETE FROM ai_account_subject_status
+		WHERE auth_subject_id = ? AND EXISTS (
+			SELECT 1 FROM ai_account_subject_status shared WHERE shared.auth_subject_id = ?
+		)`, legacyID, subjectID); err != nil {
+		return fmt.Errorf("usage: drop stale legacy subject status: %w", err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE ai_account_subject_status SET auth_subject_id = ? WHERE auth_subject_id = ?`,
+		subjectID, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: rewrite legacy subject status: %w", err)
+	}
+	return nil
+}
+
+// mergeLegacySubjectQuotaCyclesTx keeps the most recently verified anchor per
+// quota key — both halves describe the same upstream window.
+func mergeLegacySubjectQuotaCyclesTx(tx *sql.Tx, legacyID, subjectID string) error {
+	if _, err := tx.Exec(`
+		DELETE FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND EXISTS (
+			SELECT 1 FROM ai_account_subject_quota_cycles legacy
+			WHERE legacy.auth_subject_id = ?
+			  AND legacy.quota_key = ai_account_subject_quota_cycles.quota_key
+			  AND legacy.last_verified_at > ai_account_subject_quota_cycles.last_verified_at
+		)`, subjectID, legacyID); err != nil {
+		return fmt.Errorf("usage: drop stale shared quota cycles: %w", err)
+	}
+	if _, err := tx.Exec(`
+		DELETE FROM ai_account_subject_quota_cycles
+		WHERE auth_subject_id = ? AND EXISTS (
+			SELECT 1 FROM ai_account_subject_quota_cycles shared
+			WHERE shared.auth_subject_id = ?
+			  AND shared.quota_key = ai_account_subject_quota_cycles.quota_key
+		)`, legacyID, subjectID); err != nil {
+		return fmt.Errorf("usage: drop stale legacy quota cycles: %w", err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE ai_account_subject_quota_cycles SET auth_subject_id = ? WHERE auth_subject_id = ?`,
+		subjectID, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: rewrite legacy quota cycles: %w", err)
+	}
+	return nil
+}

--- a/internal/usage/auth_subject_identity_migration_test.go
+++ b/internal/usage/auth_subject_identity_migration_test.go
@@ -1,0 +1,372 @@
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func resetMergedLegacySubjects() {
+	mergedLegacySubjects.Range(func(key, _ any) bool {
+		mergedLegacySubjects.Delete(key)
+		return true
+	})
+}
+
+func seedLegacyAuthSubjectRow(t *testing.T, legacyID, provider, seedKind string, at time.Time) {
+	t.Helper()
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subjects (
+			auth_subject_id, provider, subject_scope, seed_kind, seed_hash, share_eligible,
+			usage_projected_since, usage_history_complete, created_at, updated_at
+		) VALUES (?, ?, 'tenant', ?, ?, 0, ?, 0, ?, ?)
+	`, legacyID, provider, seedKind, "hash-"+legacyID, stamp, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedLegacySubjectStatus(t *testing.T, legacyID, provider, planType string, at time.Time) {
+	t.Helper()
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_subject_status (
+			auth_subject_id, provider, last_probe_state, health_status, plan_type, updated_at
+		) VALUES (?, ?, 'success', 'ok', ?, ?)
+	`, legacyID, provider, planType, stamp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readSubjectSummary(t *testing.T, subjectID string) AuthSubjectUsageSummary {
+	t.Helper()
+	summaries, err := QueryAIAccountSubjectUsageSummaries([]string{subjectID}, map[string]time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return summaries[subjectID]
+}
+
+// Production: one Google account mounted by three tenants became three subjects.
+// The tenant that had not called it yet showed 0 calls / 0 tokens next to a quota
+// bar reading 87%, because the account's usage was filed under another tenant's
+// copy of the same account.
+func TestMergeLegacySplitSubjectFoldsTenantHalvesOntoOneAccount(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "a.json", "", "shared@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "b.json", "", "shared@example.com")
+	authA.Provider, authB.Provider = "antigravity", "antigravity"
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA.ID != identityB.ID {
+		t.Fatalf("one account still split: %q != %q", identityA.ID, identityB.ID)
+	}
+	legacyA := LegacyTenantScopedAuthSubjectID(authA)
+	legacyB := LegacyTenantScopedAuthSubjectID(authB)
+	if legacyA == "" || legacyA == legacyB || legacyA == identityA.ID {
+		t.Fatalf("legacy ids look wrong: A=%q B=%q shared=%q", legacyA, legacyB, identityA.ID)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyA, "antigravity", "email", now.Add(-72*time.Hour))
+	seedLegacyAuthSubjectRow(t, legacyB, "antigravity", "email", now.Add(-24*time.Hour))
+	// The half probed most recently is the one whose plan must survive.
+	seedLegacySubjectStatus(t, legacyA, "antigravity", "stale-plan", now.Add(-10*time.Hour))
+	seedLegacySubjectStatus(t, legacyB, "antigravity", "google-ai-pro", now.Add(-time.Hour))
+
+	for i := 0; i < 49; i++ {
+		projectSubjectRequest(t, legacyA, now.Add(-48*time.Hour), 100)
+	}
+	for i := 0; i < 3; i++ {
+		projectSubjectRequest(t, legacyB, now.Add(-2*time.Hour), 10)
+	}
+	if _, err := getDB().Exec(`
+		INSERT INTO request_logs (tenant_id, timestamp, auth_subject_id, model, failed, streaming)
+		VALUES (?, ?, ?, 'gemini-pro', 0, 0)
+	`, sharedSubjectTenantA, now.Add(-48*time.Hour).Format(time.RFC3339Nano), legacyA); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MergeLegacySplitAuthSubject(authA, identityA); err != nil {
+		t.Fatal(err)
+	}
+	if err := MergeLegacySplitAuthSubject(authB, identityB); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readSubjectSummary(t, identityA.ID)
+	if got.RequestTotal != 52 || got.SuccessTotal != 52 || got.CostTotal == 0 {
+		t.Fatalf("merged lifetime = %+v, want 52 requests", got)
+	}
+
+	var planType string
+	if err := getDB().QueryRow(
+		`SELECT plan_type FROM ai_account_subject_status WHERE auth_subject_id = ?`, identityA.ID,
+	).Scan(&planType); err != nil {
+		t.Fatal(err)
+	}
+	if planType != "google-ai-pro" {
+		t.Fatalf("status plan = %q, want the most recently probed half", planType)
+	}
+
+	for _, legacyID := range []string{legacyA, legacyB} {
+		var leftovers int
+		if err := getDB().QueryRow(`
+			SELECT (SELECT COUNT(*) FROM ai_account_subjects WHERE auth_subject_id = ?)
+			     + (SELECT COUNT(*) FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ?)
+			     + (SELECT COUNT(*) FROM ai_account_subject_status WHERE auth_subject_id = ?)
+			     + (SELECT COUNT(*) FROM request_logs WHERE auth_subject_id = ?)
+		`, legacyID, legacyID, legacyID, legacyID).Scan(&leftovers); err != nil {
+			t.Fatal(err)
+		}
+		if leftovers != 0 {
+			t.Fatalf("legacy subject %s left %d rows behind", legacyID, leftovers)
+		}
+	}
+
+	// Idempotent: a reload must not double the totals.
+	resetMergedLegacySubjects()
+	if err := MergeLegacySplitAuthSubject(authA, identityA); err != nil {
+		t.Fatal(err)
+	}
+	if again := readSubjectSummary(t, identityA.ID); again.RequestTotal != 52 {
+		t.Fatalf("re-running the merge changed totals: %+v", again)
+	}
+}
+
+// The same API key mounted by two tenants is one upstream account. Its id is
+// stored tenant-prefixed, which is what used to split it.
+func TestMergeLegacySplitSubjectFoldsSharedAPIKey(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := &coreauth.Auth{
+		ID: sharedSubjectTenantA + "/codex:apikey:abc123", TenantID: sharedSubjectTenantA,
+		Provider: "codex", FileName: "key-a.json",
+	}
+	authB := &coreauth.Auth{
+		ID: sharedSubjectTenantB + "/codex:apikey:abc123", TenantID: sharedSubjectTenantB,
+		Provider: "codex", FileName: "key-b.json",
+	}
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA.ID != identityB.ID || identityA.SeedKind != "auth_id" {
+		t.Fatalf("API key identities = %+v / %+v", identityA, identityB)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, seed := range []struct {
+		auth     *coreauth.Auth
+		identity *AuthSubjectIdentity
+		requests int
+	}{{authA, identityA, 5}, {authB, identityB, 7}} {
+		legacyID := LegacyTenantScopedAuthSubjectID(seed.auth)
+		seedLegacyAuthSubjectRow(t, legacyID, "codex", "auth_id", now.Add(-time.Hour))
+		for i := 0; i < seed.requests; i++ {
+			projectSubjectRequest(t, legacyID, now.Add(-time.Hour), 20)
+		}
+		if err := MergeLegacySplitAuthSubject(seed.auth, seed.identity); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := readSubjectSummary(t, identityA.ID); got.RequestTotal != 12 {
+		t.Fatalf("merged API key lifetime = %+v, want 12 requests", got)
+	}
+}
+
+// Merging brings together halves that were anchored independently, which is the
+// fragmented-period shape again — the totals must not read zero afterwards.
+func TestMergeLegacySplitSubjectRealignsCycleBuckets(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "cyc-a.json", "", "cycle@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantB, "cyc-b.json", "", "cycle@example.com")
+	authA.Provider, authB.Provider = "antigravity", "antigravity"
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	reset := now.Add(96 * time.Hour)
+	percent := 70.0
+	for _, seed := range []struct {
+		auth     *coreauth.Auth
+		identity *AuthSubjectIdentity
+		at       time.Time
+		requests int
+	}{
+		{authA, identityA, now.Add(-50 * time.Hour), 9},
+		{authB, identityB, now.Add(-20 * time.Hour), 4},
+	} {
+		legacyID := LegacyTenantScopedAuthSubjectID(seed.auth)
+		seedLegacyAuthSubjectRow(t, legacyID, "antigravity", "email", now.Add(-72*time.Hour))
+		resetAt := reset
+		if err := RecordAIAccountSubjectQuotaPoints(legacyID, "antigravity", []QuotaSnapshotPoint{{
+			RecordedAt: seed.at, Provider: "antigravity", QuotaKey: "antigravity:gemini_weekly",
+			QuotaLabel: "Gemini", Percent: &percent, ResetAt: &resetAt, WindowSeconds: 604800,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < seed.requests; i++ {
+			projectSubjectRequest(t, legacyID, seed.at, 50)
+		}
+		if err := MergeLegacySplitAuthSubject(seed.auth, seed.identity); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if buckets := countCycleBuckets(t, identityA.ID); buckets != 1 {
+		t.Fatalf("cycle buckets after merge = %d, want 1", buckets)
+	}
+	got := readCycleSummary(t, identityA.ID)
+	if !got.CycleKnown || got.CycleRequestTotal != 13 {
+		t.Fatalf("merged cycle summary = %+v, want 13 requests", got)
+	}
+}
+
+// The merge has to happen on the auth-load path: it is the only place holding an
+// authoritative auth, and it is what an operator's restart actually runs.
+func TestBindingHookMergesLegacySubjectOnAuthLoad(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "hook.json", "", "hook@example.com")
+	auth.Provider = "antigravity"
+	identity := ResolveAuthSubjectIdentity(auth)
+	legacyID := LegacyTenantScopedAuthSubjectID(auth)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyID, "antigravity", "email", now.Add(-time.Hour))
+	for i := 0; i < 8; i++ {
+		projectSubjectRequest(t, legacyID, now.Add(-time.Hour), 25)
+	}
+
+	AIAccountBindingHook{}.OnAuthLoaded(context.Background(), auth)
+
+	if got := readSubjectSummary(t, identity.ID); got.RequestTotal != 8 || got.SuccessTotal != 8 {
+		t.Fatalf("hook did not migrate the account: %+v", got)
+	}
+	bindings, err := ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{auth.ID})
+	if err != nil || len(bindings) != 1 || bindings[0].AuthSubjectID != identity.ID {
+		t.Fatalf("binding=%+v err=%v, want it pointing at the shared subject", bindings, err)
+	}
+}
+
+// Fingerprint rows are unique per (tenant, provider, account_key, profile_key).
+// A tenant holding both halves collides only within one profile, so the merge
+// must compare profiles too — matching on tenant and provider alone discards
+// profiles the account still needs.
+func TestMergeLegacySplitSubjectKeepsFingerprintProfiles(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	auth := sharedSubjectTestAuth(sharedSubjectTenantA, "fp.json", "", "fp@example.com")
+	auth.Provider = "codex"
+	identity := ResolveAuthSubjectIdentity(auth)
+	legacyID := LegacyTenantScopedAuthSubjectID(auth)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyID, "codex", "email", now.Add(-time.Hour))
+
+	seedFingerprint := func(accountKey, profileKey string, seenAt time.Time) {
+		t.Helper()
+		if _, err := getDB().Exec(`
+			INSERT INTO identity_fingerprints (
+				tenant_id, provider, account_key, profile_key, auth_subject_id,
+				client_product, client_variant, version, fields_json, observed_headers_json,
+				created_at, updated_at, last_seen_at
+			) VALUES (?, 'codex', ?, ?, ?, 'cli', '', '1', '{}', '{}', ?, ?, ?)
+		`, sharedSubjectTenantA, accountKey, profileKey, accountKey,
+			seenAt.Format(time.RFC3339Nano), seenAt.Format(time.RFC3339Nano), seenAt.Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// One profile exists on both sides (the shared row is newer and must win); a
+	// second exists only on the legacy side and must survive the merge.
+	seedFingerprint(legacyID, "default", now.Add(-2*time.Hour))
+	seedFingerprint(identity.ID, "default", now.Add(-time.Minute))
+	seedFingerprint(legacyID, "secondary", now.Add(-3*time.Hour))
+
+	if err := MergeLegacySplitAuthSubject(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := getDB().Query(
+		`SELECT profile_key, last_seen_at FROM identity_fingerprints WHERE account_key = ? ORDER BY profile_key`,
+		identity.ID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	profiles := map[string]time.Time{}
+	for rows.Next() {
+		var profile string
+		var seen storedTime
+		if err := rows.Scan(&profile, &seen); err != nil {
+			t.Fatal(err)
+		}
+		profiles[profile] = seen.Time.UTC()
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("profiles after merge = %v, want default + secondary", profiles)
+	}
+	if !profiles["default"].Equal(now.Add(-time.Minute)) {
+		t.Fatalf("default profile = %v, want the newer shared row", profiles["default"])
+	}
+
+	var leftovers int
+	if err := getDB().QueryRow(
+		`SELECT COUNT(*) FROM identity_fingerprints WHERE account_key = ?`, legacyID,
+	).Scan(&leftovers); err != nil {
+		t.Fatal(err)
+	}
+	if leftovers != 0 {
+		t.Fatalf("legacy fingerprints left behind: %d", leftovers)
+	}
+}
+
+// Two genuinely different accounts must never be folded together.
+func TestMergeLegacySplitSubjectKeepsDistinctAccountsApart(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := sharedSubjectTestAuth(sharedSubjectTenantA, "one.json", "", "one@example.com")
+	authB := sharedSubjectTestAuth(sharedSubjectTenantA, "two.json", "", "two@example.com")
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	if identityA.ID == identityB.ID {
+		t.Fatal("different emails collapsed onto one subject")
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, seed := range []struct {
+		auth     *coreauth.Auth
+		identity *AuthSubjectIdentity
+		requests int
+	}{{authA, identityA, 2}, {authB, identityB, 6}} {
+		legacyID := LegacyTenantScopedAuthSubjectID(seed.auth)
+		seedLegacyAuthSubjectRow(t, legacyID, "codex", "email", now.Add(-time.Hour))
+		for i := 0; i < seed.requests; i++ {
+			projectSubjectRequest(t, legacyID, now.Add(-time.Hour), 10)
+		}
+		if err := MergeLegacySplitAuthSubject(seed.auth, seed.identity); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := readSubjectSummary(t, identityA.ID); got.RequestTotal != 2 {
+		t.Fatalf("account one = %+v, want 2 requests", got)
+	}
+	if got := readSubjectSummary(t, identityB.ID); got.RequestTotal != 6 {
+		t.Fatalf("account two = %+v, want 6 requests", got)
+	}
+}

--- a/internal/usage/auth_subject_quota_store.go
+++ b/internal/usage/auth_subject_quota_store.go
@@ -464,6 +464,11 @@ func QueryLatestWeeklyQuotaCycleByAuthSubjectForTenant(tenantID, subjectID strin
 	if cycle.CycleStartAt.IsZero() || cycle.ResetAt.IsZero() || cycle.WindowSeconds <= 0 {
 		return nil, nil
 	}
+	// Roll an anchor whose period already ended, exactly as the shared reader and
+	// the projection do. Probes stop for disabled or unreachable accounts, and a
+	// frozen anchor would report the previous period's window as the live one.
+	cycle.CycleStartAt, cycle.ResetAt = advanceQuotaCyclePeriod(
+		cycle.CycleStartAt, cycle.ResetAt, cycle.WindowSeconds, time.Now())
 	return &cycle, nil
 }
 

--- a/internal/usage/projection_quota_backfill_test.go
+++ b/internal/usage/projection_quota_backfill_test.go
@@ -1,0 +1,62 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+// Existing xAI accounts already have product snapshots stored without a window,
+// because the probe did not tag them until now. Those rows are what makes the
+// projection fall back to the pool-wide figure, so the first probe after the
+// upgrade has to write a windowed point even when the percentage has not moved
+// — otherwise the dedupe swallows it and the account never heals.
+func TestQuotaSnapshotWritesWindowChangeAtUnchangedPercent(t *testing.T) {
+	initSharedSubjectTestDB(t)
+
+	const subjectID = "authsub_xai_backfill"
+	percent := 84.0
+	reset := time.Date(2026, 8, 27, 6, 45, 51, 0, time.UTC)
+	recorded := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+
+	// Pre-upgrade shape: a product percentage with no window and no reset.
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "xai", []QuotaSnapshotPoint{{
+		RecordedAt: recorded,
+		AuthIndex:  "auth-1",
+		Provider:   "xai",
+		QuotaKey:   "product:GrokBuild",
+		QuotaLabel: "xai_quota.product_usage_named::GrokBuild",
+		Percent:    &percent,
+	}}); err != nil {
+		t.Fatalf("record legacy point: %v", err)
+	}
+
+	// Post-upgrade probe, minutes later and at the very same percentage.
+	samePercent := percent
+	if err := RecordAIAccountSubjectQuotaPoints(subjectID, "xai", []QuotaSnapshotPoint{{
+		RecordedAt:    recorded.Add(2 * time.Minute),
+		AuthIndex:     "auth-1",
+		Provider:      "xai",
+		QuotaKey:      "product:GrokBuild",
+		QuotaLabel:    "xai_quota.product_usage_named::GrokBuild",
+		Percent:       &samePercent,
+		ResetAt:       &reset,
+		WindowSeconds: WeeklyQuotaWindowSeconds,
+	}}); err != nil {
+		t.Fatalf("record windowed point: %v", err)
+	}
+
+	db := getDB()
+	if db == nil {
+		t.Fatal("db unavailable")
+	}
+	var windowed int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM ai_account_subject_quota_points
+		WHERE auth_subject_id = ? AND quota_key = ? AND window_seconds = ?
+	`, subjectID, "product:GrokBuild", WeeklyQuotaWindowSeconds).Scan(&windowed); err != nil {
+		t.Fatalf("count windowed points: %v", err)
+	}
+	if windowed != 1 {
+		t.Fatalf("windowed points = %d, want 1 (dedupe must not swallow a window change)", windowed)
+	}
+}

--- a/internal/usage/projection_quota_key_test.go
+++ b/internal/usage/projection_quota_key_test.go
@@ -1,0 +1,53 @@
+package usage
+
+import "testing"
+
+// xAI bills every product against one weekly pool, so the projection divisor
+// has to be the per-product window the probe tagged as attributable, not the
+// pool-wide weekly_limit the card cycle anchors on.
+func TestMatchesProjectionQuotaKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		provider string
+		quotaKey string
+		want     bool
+	}{
+		{"xai", "product:GrokBuild", true},
+		{"Grok", "product:grok-code", true},
+		{"xai", "weekly_limit", false},
+		{"xai", "monthly_credits", false},
+		{"xai", "", false},
+		{"codex", "code_week", true},
+		{"codex", "code_5h", false},
+		{"claude", "seven_day", true},
+		{"claude", "five_hour", false},
+		{"kimi", "code_week", true},
+		{"antigravity", "antigravity:gemini_weekly", true},
+		{"unknown", "anything", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.provider+"/"+tc.quotaKey, func(t *testing.T) {
+			t.Parallel()
+			if got := MatchesProjectionQuotaKey(tc.provider, tc.quotaKey); got != tc.want {
+				t.Fatalf("MatchesProjectionQuotaKey(%q, %q) = %v, want %v", tc.provider, tc.quotaKey, got, tc.want)
+			}
+		})
+	}
+}
+
+// Only xAI's projection divisor is narrower than its pool-wide percentage, and
+// the panel needs to know so the two figures do not read as contradictory.
+func TestProjectionQuotaIsAttributable(t *testing.T) {
+	t.Parallel()
+
+	for provider, want := range map[string]bool{
+		"xai": true, "grok": true, "XAI": true,
+		"codex": false, "claude": false, "kimi": false, "antigravity": false, "": false,
+	} {
+		if got := ProjectionQuotaIsAttributable(provider); got != want {
+			t.Fatalf("ProjectionQuotaIsAttributable(%q) = %v, want %v", provider, got, want)
+		}
+	}
+}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -107,12 +107,6 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 			}
 		}
 
-		disabled, _ := metadata["disabled"].(bool)
-		status := coreauth.StatusActive
-		if disabled {
-			status = coreauth.StatusDisabled
-		}
-
 		// Read per-account excluded models from the OAuth JSON file
 		perAccountExcluded := extractExcludedModelsFromMetadata(metadata)
 
@@ -123,8 +117,7 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 			FileName: name,
 			Label:    label,
 			Prefix:   prefix,
-			Status:   status,
-			Disabled: disabled,
+			Status:   coreauth.StatusActive,
 			Attributes: map[string]string{
 				"source": full,
 				"path":   full,
@@ -135,6 +128,7 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
+		coreauth.RestorePersistedDisabled(a)
 		// Read priority from auth file
 		if rawPriority, ok := metadata["priority"]; ok {
 			switch v := rawPriority.(type) {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -69,6 +69,10 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		return "", fmt.Errorf("auth filestore: create dir failed: %w", err)
 	}
 	syncRoutingMetadata(auth)
+	// Both branches serialize auth.Metadata, so the disabled flag has to be
+	// mirrored before either of them runs; the Storage branch used to skip it,
+	// which lost every enable/disable made on an OAuth credential.
+	cliproxyauth.SyncPersistedDisabled(auth)
 
 	switch {
 	case auth.Storage != nil:
@@ -77,7 +81,6 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 			return "", err
 		}
 	case auth.Metadata != nil:
-		auth.Metadata["disabled"] = auth.Disabled
 		raw, errMarshal := json.Marshal(auth.Metadata)
 		if errMarshal != nil {
 			return "", fmt.Errorf("auth filestore: marshal metadata failed: %w", errMarshal)
@@ -239,11 +242,6 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		return nil, fmt.Errorf("stat file: %w", err)
 	}
 	id := s.idFor(path, baseDir)
-	disabled, _ := metadata["disabled"].(bool)
-	status := cliproxyauth.StatusActive
-	if disabled {
-		status = cliproxyauth.StatusDisabled
-	}
 	auth := &cliproxyauth.Auth{
 		ID:               id,
 		TenantID:         cliproxyauth.TenantIDFromAuthID(id),
@@ -253,8 +251,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		ProxyID:          metadataString(metadata, "proxy_id", "proxy-id", "proxyId"),
 		FileName:         id,
 		Label:            s.labelFor(metadata),
-		Status:           status,
-		Disabled:         disabled,
+		Status:           cliproxyauth.StatusActive,
 		Attributes:       buildFileAuthAttributes(path, metadata),
 		Metadata:         metadata,
 		CreatedAt:        info.ModTime(),
@@ -262,6 +259,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		LastRefreshedAt:  time.Time{},
 		NextRefreshAfter: time.Time{},
 	}
+	cliproxyauth.RestorePersistedDisabled(auth)
 	return auth, nil
 }
 

--- a/sdk/auth/filestore_disabled_test.go
+++ b/sdk/auth/filestore_disabled_test.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	codexauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// OAuth credentials carry a TokenStorage, which used to bypass the disabled
+// mirror entirely: the management API reported success, the file kept the old
+// value, and the next reload flipped the credential back.
+func TestFileTokenStoreSavesDisabledThroughTokenStorage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex-account.json")
+	metadata := map[string]any{
+		"type":          "codex",
+		"email":         "account@example.com",
+		"access_token":  "at",
+		"refresh_token": "rt",
+		"disabled":      false,
+	}
+	writeJSON(t, path, metadata)
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auth := &cliproxyauth.Auth{
+		ID:         "codex-account.json",
+		FileName:   "codex-account.json",
+		Provider:   "codex",
+		Status:     cliproxyauth.StatusDisabled,
+		Disabled:   true,
+		Attributes: map[string]string{"path": path},
+		Metadata:   metadata,
+		Storage: &codexauth.CodexTokenStorage{
+			AccessToken:  "at",
+			RefreshToken: "rt",
+			Email:        "account@example.com",
+			Type:         "codex",
+		},
+	}
+	if _, err := store.Save(context.Background(), auth); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := readJSON(t, path)["disabled"]; got != true {
+		t.Fatalf("on-disk disabled = %#v, want true", got)
+	}
+
+	// Re-enabling has to clear the flag again, otherwise the account can be
+	// switched off but never back on.
+	auth.Disabled = false
+	auth.Status = cliproxyauth.StatusActive
+	if _, err := store.Save(context.Background(), auth); err != nil {
+		t.Fatalf("Save enabled: %v", err)
+	}
+	if got := readJSON(t, path)["disabled"]; got != false {
+		t.Fatalf("on-disk disabled = %#v, want false", got)
+	}
+}
+
+func TestFileTokenStoreListRestoresDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "codex-off.json"), map[string]any{
+		"type":     "codex",
+		"email":    "off@example.com",
+		"disabled": true,
+	})
+	writeJSON(t, filepath.Join(dir, "codex-on.json"), map[string]any{
+		"type":     "codex",
+		"email":    "on@example.com",
+		"disabled": false,
+	})
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	byID := make(map[string]*cliproxyauth.Auth, len(auths))
+	for _, auth := range auths {
+		byID[auth.ID] = auth
+	}
+	off := byID["codex-off.json"]
+	if off == nil || !off.Disabled || off.Status != cliproxyauth.StatusDisabled {
+		t.Fatalf("codex-off.json = %+v, want disabled", off)
+	}
+	on := byID["codex-on.json"]
+	if on == nil || on.Disabled || on.Status != cliproxyauth.StatusActive {
+		t.Fatalf("codex-on.json = %+v, want active", on)
+	}
+}
+
+func writeJSON(t *testing.T, path string, payload map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err = os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	out := map[string]any{}
+	if err = json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	return out
+}

--- a/sdk/cliproxy/auth/disabled_persistence.go
+++ b/sdk/cliproxy/auth/disabled_persistence.go
@@ -1,0 +1,70 @@
+package auth
+
+// The auth JSON on disk (and its mirror in the database) is the source of truth
+// for the enabled/disabled state of a credential. Auth.Disabled is the runtime
+// projection of that key, so every persistence backend has to write it back on
+// save and read it back on load. Keeping both directions here stops the four
+// store implementations from drifting apart again: a store that only wrote the
+// runtime field made "disable" survive until the next reload and then silently
+// flip back to enabled.
+const DisabledMetadataKey = "disabled"
+
+// SyncPersistedDisabled mirrors the runtime Disabled flag into the metadata map
+// that stores serialize. Call it in every Store.Save implementation before the
+// auth file is written.
+//
+// A record with neither metadata nor token storage owns no auth file at all —
+// config-derived API keys live in config.yaml — so it is left untouched.
+// Creating a metadata map for one would make the manager treat it as
+// persistable and write a stray JSON file into the auth directory.
+func SyncPersistedDisabled(auth *Auth) {
+	if auth == nil || (auth.Metadata == nil && auth.Storage == nil) {
+		return
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any, 1)
+	}
+	auth.Metadata[DisabledMetadataKey] = auth.Disabled
+}
+
+// RestorePersistedDisabled projects the persisted metadata key back onto the
+// runtime fields. Call it in every Store.List implementation after an auth
+// record has been rebuilt from storage.
+//
+// Only an explicit true disables the credential: a missing key means the record
+// predates the flag and must stay usable.
+func RestorePersistedDisabled(auth *Auth) {
+	if auth == nil || auth.Metadata == nil {
+		return
+	}
+	disabled, ok := metadataBoolValue(auth.Metadata[DisabledMetadataKey])
+	if !ok || !disabled {
+		return
+	}
+	auth.Disabled = true
+	auth.Status = StatusDisabled
+}
+
+// metadataBoolValue accepts the shapes JSON round-trips produce for a boolean:
+// real bools, "true"/"false" strings written by hand-edited auth files, and the
+// numeric form some older exports used.
+func metadataBoolValue(raw any) (bool, bool) {
+	switch value := raw.(type) {
+	case bool:
+		return value, true
+	case string:
+		switch value {
+		case "true", "True", "TRUE", "1", "yes":
+			return true, true
+		case "false", "False", "FALSE", "0", "no":
+			return false, true
+		}
+	case float64:
+		return value != 0, true
+	case int:
+		return value != 0, true
+	case int64:
+		return value != 0, true
+	}
+	return false, false
+}

--- a/sdk/cliproxy/auth/disabled_persistence_test.go
+++ b/sdk/cliproxy/auth/disabled_persistence_test.go
@@ -1,0 +1,115 @@
+package auth
+
+import "testing"
+
+func TestSyncPersistedDisabledMirrorsRuntimeFlag(t *testing.T) {
+	auth := &Auth{Disabled: true, Metadata: map[string]any{"type": "codex"}}
+	SyncPersistedDisabled(auth)
+	if auth.Metadata[DisabledMetadataKey] != true {
+		t.Fatalf("metadata[%s] = %#v, want true", DisabledMetadataKey, auth.Metadata[DisabledMetadataKey])
+	}
+
+	auth.Disabled = false
+	SyncPersistedDisabled(auth)
+	if auth.Metadata[DisabledMetadataKey] != false {
+		t.Fatalf("metadata[%s] = %#v, want false", DisabledMetadataKey, auth.Metadata[DisabledMetadataKey])
+	}
+}
+
+func TestSyncPersistedDisabledIgnoresNilAuth(t *testing.T) {
+	SyncPersistedDisabled(nil)
+}
+
+// Config-derived API keys carry neither metadata nor token storage: nothing of
+// them is serialized, and creating a metadata map would make the manager start
+// writing stray auth files for them.
+func TestSyncPersistedDisabledSkipsRecordsWithNothingToSerialize(t *testing.T) {
+	auth := &Auth{Disabled: true, Attributes: map[string]string{"api_key": "k"}}
+	SyncPersistedDisabled(auth)
+	if auth.Metadata != nil {
+		t.Fatalf("Metadata = %#v, want nil", auth.Metadata)
+	}
+}
+
+// An OAuth credential keeps its payload in TokenStorage; the flag still has to
+// reach the file the storage writes.
+func TestSyncPersistedDisabledSeedsMetadataForTokenStorage(t *testing.T) {
+	auth := &Auth{Disabled: true, Storage: stubTokenStorage{}}
+	SyncPersistedDisabled(auth)
+	if auth.Metadata[DisabledMetadataKey] != true {
+		t.Fatalf("metadata[%s] = %#v, want true", DisabledMetadataKey, auth.Metadata[DisabledMetadataKey])
+	}
+}
+
+type stubTokenStorage struct{}
+
+func (stubTokenStorage) SaveTokenToFile(string) error { return nil }
+
+func TestRestorePersistedDisabled(t *testing.T) {
+	cases := []struct {
+		name         string
+		metadata     map[string]any
+		wantDisabled bool
+		wantStatus   Status
+	}{
+		{name: "missing key stays active", metadata: map[string]any{}, wantStatus: StatusActive},
+		{name: "explicit false stays active", metadata: map[string]any{"disabled": false}, wantStatus: StatusActive},
+		{
+			name:         "bool true disables",
+			metadata:     map[string]any{"disabled": true},
+			wantDisabled: true,
+			wantStatus:   StatusDisabled,
+		},
+		{
+			// Hand-edited auth files sometimes carry the flag as a string.
+			name:         "string true disables",
+			metadata:     map[string]any{"disabled": "true"},
+			wantDisabled: true,
+			wantStatus:   StatusDisabled,
+		},
+		{name: "string false stays active", metadata: map[string]any{"disabled": "false"}, wantStatus: StatusActive},
+		{name: "unparseable value stays active", metadata: map[string]any{"disabled": "maybe"}, wantStatus: StatusActive},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &Auth{Status: StatusActive, Metadata: tc.metadata}
+			RestorePersistedDisabled(auth)
+			if auth.Disabled != tc.wantDisabled {
+				t.Fatalf("Disabled = %v, want %v", auth.Disabled, tc.wantDisabled)
+			}
+			if auth.Status != tc.wantStatus {
+				t.Fatalf("Status = %q, want %q", auth.Status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// A metadata-less record must not panic and must not be forced into a state.
+func TestRestorePersistedDisabledIgnoresEmptyRecords(t *testing.T) {
+	RestorePersistedDisabled(nil)
+	auth := &Auth{Status: StatusActive}
+	RestorePersistedDisabled(auth)
+	if auth.Disabled || auth.Status != StatusActive {
+		t.Fatalf("Disabled=%v Status=%q, want active", auth.Disabled, auth.Status)
+	}
+}
+
+// Round-tripping must not resurrect a stale disable after the credential has
+// been re-enabled: the enable path has to overwrite the persisted key.
+func TestDisabledPersistenceRoundTrip(t *testing.T) {
+	auth := &Auth{Status: StatusActive, Metadata: map[string]any{"disabled": true}}
+	RestorePersistedDisabled(auth)
+	if !auth.Disabled {
+		t.Fatal("expected the persisted flag to disable the auth")
+	}
+
+	auth.Disabled = false
+	auth.Status = StatusActive
+	SyncPersistedDisabled(auth)
+
+	reloaded := &Auth{Status: StatusActive, Metadata: auth.Metadata}
+	RestorePersistedDisabled(reloaded)
+	if reloaded.Disabled || reloaded.Status != StatusActive {
+		t.Fatalf("after re-enable: Disabled=%v Status=%q, want active", reloaded.Disabled, reloaded.Status)
+	}
+}


### PR DESCRIPTION
Release v0.4.29: OAuth proxy egress, audit denial accuracy, cycle rollover on allowance refill, and quota projection.