### PR TITLE
feat(kimi): discover models from the coding gateway instead of a compiled-in list

### DIFF
--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -481,6 +481,10 @@ func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Conf
 	return executor.FetchCodexModels(ctx, auth, cfg)
 }
 
+func FetchKimiModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return executor.FetchKimiModels(ctx, auth, cfg)
+}
+
 func RebindTenantExecutors(base *config.Config, coreManager *coreauth.Manager, tenantID string, gateway WebsocketGateway) {
 	if base == nil || coreManager == nil {
 		return

--- a/internal/management/authfiles/models.go
+++ b/internal/management/authfiles/models.go
@@ -21,7 +21,7 @@ type ModelRegistrar interface {
 	RegisterClient(clientID, clientProvider string, models []*registry.ModelInfo)
 }
 
-// Provider-level discovery cache for claude/codex/xai (Grok).
+// Provider-level discovery cache for claude/codex/xai (Grok)/kimi.
 // Live manifests are shared across accounts of the same provider+tenant so we
 // only hit upstream once (or on force refresh), then every auth-file models
 // panel reuses the same list without RegisterClient-replacing the static catalog.
@@ -75,7 +75,7 @@ func discoveryCacheKey(tenantID, provider string) string {
 
 func supportsSharedDiscovery(provider string) bool {
 	switch normalizeDiscoveryProvider(provider) {
-	case "claude", "codex", "xai":
+	case "claude", "codex", "xai", "kimi":
 		return true
 	default:
 		return false
@@ -119,7 +119,7 @@ func storeDiscoveryCache(tenantID, provider string, models []*registry.ModelInfo
 }
 
 // EnsureProviderDiscovery returns the shared live model list for
-// claude/codex/xai. Cache hit is preferred; on miss it warms once from the
+// claude/codex/xai/kimi. Cache hit is preferred; on miss it warms once from the
 // first active auth of that provider in the tenant (same single-flight path as
 // the auth-file models panel). force re-fetches upstream even when the cache
 // is warm.
@@ -257,7 +257,7 @@ func ListModelEntriesForTenant(manager *coreauth.Manager, source ModelSource, te
 // ListModelEntriesLiveForTenant returns models for an auth file panel.
 //
 // Behaviour:
-//   - claude / codex / xai (shared discovery):
+//   - claude / codex / xai / kimi (shared discovery):
 //     open (refresh=false): serve provider discovery cache if present; otherwise
 //     auto-warm once from upstream using this auth, store under provider+tenant,
 //     return source=upstream. Never RegisterClient-replace the static catalog.
@@ -286,8 +286,9 @@ func ListModelEntriesLiveForTenant(
 	}
 	provider := normalizeDiscoveryProvider(auth.Provider)
 
-	// Shared discovery path for Claude / Codex / xAI (Grok): prefer provider
-	// cache on open, auto-warm on first miss, force re-fetch only when refresh=1.
+	// Shared discovery path for Claude / Codex / xAI (Grok) / Kimi: prefer
+	// provider cache on open, auto-warm on first miss, force re-fetch only when
+	// refresh=1.
 	if supportsSharedDiscovery(provider) {
 		if !refresh {
 			if cached := loadDiscoveryCache(tenantID, provider); len(cached) > 0 {
@@ -329,7 +330,7 @@ func ListModelEntriesLiveForTenant(
 	return modelEntriesFromRegistry(live), sourceLabel
 }
 
-// warmSharedDiscovery fetches live models for claude/codex/xai and stores them
+// warmSharedDiscovery fetches live models for claude/codex/xai/kimi and stores them
 // in the provider-level cache. Concurrent warmers for the same key single-flight.
 // When force is false and another warmer already populated the cache, waiters
 // receive that result without a second upstream call.
@@ -432,6 +433,10 @@ func fetchLiveModelsForAuth(ctx context.Context, auth *coreauth.Auth, cfg *confi
 		// registers live xAI models via service_model_registration; management
 		// panels must not RegisterClient-replace per auth-file refresh.
 		sdkModels = executor.FetchXAIModels(fetchCtx, auth, cfg)
+	case provider == "kimi":
+		// Discovery only, same as xAI: startup registration owns the runtime
+		// registry, the panel just mirrors what the coding gateway advertises.
+		sdkModels = executor.FetchKimiModels(fetchCtx, auth, cfg)
 	case rawProvider == "antigravity":
 		sdkModels = executor.FetchAntigravityModels(fetchCtx, auth, cfg)
 		updateRegistry = true

--- a/internal/management/authfiles/models_test.go
+++ b/internal/management/authfiles/models_test.go
@@ -278,13 +278,47 @@ func TestXAISharedDiscoveryCacheAcrossAccounts(t *testing.T) {
 }
 
 func TestSupportsSharedDiscoveryIncludesXAI(t *testing.T) {
-	for _, provider := range []string{"xai", "x-ai", "grok", "XAI", "Claude", "codex"} {
+	for _, provider := range []string{"xai", "x-ai", "grok", "XAI", "Claude", "codex", "kimi", "Kimi"} {
 		if !SupportsSharedDiscovery(provider) {
 			t.Fatalf("SupportsSharedDiscovery(%q)=false, want true", provider)
 		}
 	}
 	if SupportsSharedDiscovery("antigravity") {
 		t.Fatalf("antigravity must not use shared discovery")
+	}
+}
+
+// Kimi used to serve the compiled-in catalog here, so the panel showed the same
+// four ids no matter what Moonshot had shipped. The discovery cache is what makes
+// the panel reflect the gateway instead.
+func TestKimiSharedDiscoveryServesCacheWithoutRegistrar(t *testing.T) {
+	ResetDiscoveryCacheForTest()
+	storeDiscoveryCache("", "kimi", []*registry.ModelInfo{
+		{ID: "kimi-k2.7", DisplayName: "Kimi K2.7", Type: "kimi", OwnedBy: "moonshot"},
+	})
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: "kimi-a", FileName: "kimi-a.json", Provider: "kimi",
+	}); err != nil {
+		t.Fatalf("Register kimi: %v", err)
+	}
+	source := &modelSourceStub{models: []*registry.ModelInfo{{ID: "kimi-k2"}}}
+	reg := &modelRegistrarStub{}
+
+	models, label := ListModelEntriesLiveForTenant(
+		context.Background(), manager, source, reg, nil, "", "kimi-a.json", false,
+	)
+	if label != "upstream" {
+		t.Fatalf("label=%q want upstream", label)
+	}
+	if !containsModelID(models, "kimi-k2.7") {
+		t.Fatalf("kimi discovery result not served: %#v", models)
+	}
+	if containsModelID(models, "kimi-k2") {
+		t.Fatalf("static catalog leaked into the kimi discovery result: %#v", models)
+	}
+	if reg.calls != 0 {
+		t.Fatalf("RegisterClient calls=%d want 0 for kimi discovery path", reg.calls)
 	}
 }
 

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -226,8 +226,8 @@ func managementVisibleModels(modelRegistry *registry.ModelRegistry) []map[string
 	return out
 }
 
-// sharedDiscoveryByProvider auto-warms (or reads) the claude/codex provider
-// discovery cache for the current tenant. force is reserved for future refresh
+// sharedDiscoveryByProvider auto-warms (or reads) the shared-discovery provider
+// cache (claude/codex/xai/kimi) for the current tenant. force is reserved for future refresh
 // query support; management list endpoints currently always use force=false.
 func (s *Service) sharedDiscoveryByProvider(force bool) map[string][]*registry.ModelInfo {
 	if s == nil || s.authManager == nil {

--- a/internal/runtime/executor/kimi_models.go
+++ b/internal/runtime/executor/kimi_models.go
@@ -1,0 +1,273 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	kimiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	kimiModelsPath = "/v1/models"
+	// Upstream advertises bare ids (k2.5); routing uses the kimi- namespace and
+	// stripKimiPrefix removes it again before the chat request goes out. Keeping
+	// discovery in the prefixed namespace is what makes a newly released id
+	// routable without a catalog change.
+	kimiModelIDPrefix = "kimi-"
+)
+
+var kimiModelsCache struct {
+	mu     sync.RWMutex
+	models []*sdkmodelcatalog.ModelInfo
+}
+
+type kimiModelsResponse struct {
+	Data []kimiModelPayload `json:"data"`
+}
+
+type kimiModelPayload struct {
+	ID                  string `json:"id"`
+	Object              string `json:"object"`
+	Created             int64  `json:"created"`
+	OwnedBy             string `json:"owned_by"`
+	DisplayName         string `json:"display_name"`
+	Description         string `json:"description"`
+	ContextLength       int    `json:"context_length"`
+	MaxCompletionTokens int    `json:"max_completion_tokens"`
+}
+
+func cloneKimiModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		if len(model.SupportedGenerationMethods) > 0 {
+			clone.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedParameters) > 0 {
+			clone.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+		}
+		clone.Thinking = cloneKimiThinking(model.Thinking)
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func storeKimiModels(models []*sdkmodelcatalog.ModelInfo) bool {
+	cloned := cloneKimiModels(models)
+	if len(cloned) == 0 {
+		return false
+	}
+	kimiModelsCache.mu.Lock()
+	kimiModelsCache.models = cloned
+	kimiModelsCache.mu.Unlock()
+	return true
+}
+
+func loadKimiModels() []*sdkmodelcatalog.ModelInfo {
+	kimiModelsCache.mu.RLock()
+	cloned := cloneKimiModels(kimiModelsCache.models)
+	kimiModelsCache.mu.RUnlock()
+	return cloned
+}
+
+// fallbackKimiModels keeps the last successful discovery result. It deliberately
+// does not fall back to the compiled-in catalog: callers that need a guaranteed
+// list (startup registration) apply that fallback themselves, so an empty return
+// here still means "upstream told us nothing".
+func fallbackKimiModels() []*sdkmodelcatalog.ModelInfo {
+	if models := loadKimiModels(); len(models) > 0 {
+		log.Debugf("kimi executor: using cached model list (%d models)", len(models))
+		return models
+	}
+	return nil
+}
+
+// FetchKimiModels retrieves the account's live model list from the Kimi coding
+// gateway, which exposes the OpenAI-compatible /v1/models listing on the same
+// base URL and credentials as chat completions.
+func FetchKimiModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token := strings.TrimSpace(kimiCreds(auth))
+	if token == "" {
+		return fallbackKimiModels()
+	}
+
+	modelsURL := strings.TrimRight(kimiauth.KimiAPIBaseURL, "/") + kimiModelsPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return fallbackKimiModels()
+	}
+	// Same identity headers as chat traffic: the gateway rejects requests that do
+	// not look like kimi-cli, and the device id must match the account's.
+	applyKimiHeadersWithAuth(req, token, false, auth, cfg)
+
+	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Debugf("kimi executor: models request failed: %v", err)
+		}
+		return fallbackKimiModels()
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("kimi executor: close models response body error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		log.Debugf("kimi executor: models request failed with status %d", resp.StatusCode)
+		return fallbackKimiModels()
+	}
+
+	body, err := readUpstreamResponseBody("kimi", resp.Body)
+	if err != nil {
+		log.Debugf("kimi executor: models response read failed: %v", err)
+		return fallbackKimiModels()
+	}
+
+	models, ok := parseKimiModels(body, time.Now().Unix())
+	if !ok {
+		log.Debug("kimi executor: fetched empty or invalid model list; retaining cached model list")
+		return fallbackKimiModels()
+	}
+	storeKimiModels(models)
+	return models
+}
+
+func parseKimiModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var decoded kimiModelsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, false
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(decoded.Data))
+	seen := make(map[string]struct{}, len(decoded.Data))
+	for _, item := range decoded.Data {
+		upstreamID := strings.TrimSpace(item.ID)
+		if upstreamID == "" {
+			continue
+		}
+		model := kimiModelInfoFromPayload(item, upstreamID, now)
+		key := strings.ToLower(model.ID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, model)
+	}
+	return out, len(out) > 0
+}
+
+func kimiModelInfoFromPayload(item kimiModelPayload, upstreamID string, now int64) *sdkmodelcatalog.ModelInfo {
+	modelID := namespaceKimiModelID(upstreamID)
+	object := strings.TrimSpace(item.Object)
+	if object == "" {
+		object = "model"
+	}
+	ownedBy := strings.TrimSpace(item.OwnedBy)
+	if ownedBy == "" {
+		ownedBy = "moonshot"
+	}
+	created := item.Created
+	if created == 0 {
+		created = now
+	}
+	model := &sdkmodelcatalog.ModelInfo{
+		ID:                  modelID,
+		Object:              object,
+		Created:             created,
+		OwnedBy:             ownedBy,
+		Type:                "kimi",
+		DisplayName:         firstNonEmptyString(item.DisplayName, kimiDisplayNameFromID(modelID)),
+		Name:                modelID,
+		Version:             modelID,
+		Description:         strings.TrimSpace(item.Description),
+		ContextLength:       item.ContextLength,
+		InputTokenLimit:     item.ContextLength,
+		MaxCompletionTokens: item.MaxCompletionTokens,
+		OutputTokenLimit:    item.MaxCompletionTokens,
+	}
+	if !strings.EqualFold(modelID, upstreamID) {
+		model.UpstreamModelID = upstreamID
+	}
+	// The listing carries ids, not capabilities. Reasoning support and token
+	// limits come from the compiled-in catalog when it knows the model; a model
+	// the catalog has never seen keeps Thinking nil rather than inheriting a
+	// guessed budget, because an unsupported reasoning_effort is a 400 upstream.
+	if static := sdkmodelcatalog.LookupStaticModelInfo(modelID); static != nil {
+		model.Thinking = cloneKimiThinking(static.Thinking)
+		if model.Description == "" {
+			model.Description = static.Description
+		}
+		model.DisplayName = firstNonEmptyString(item.DisplayName, static.DisplayName, model.DisplayName)
+		if model.ContextLength == 0 {
+			model.ContextLength = static.ContextLength
+			model.InputTokenLimit = static.ContextLength
+		}
+		if model.MaxCompletionTokens == 0 {
+			model.MaxCompletionTokens = static.MaxCompletionTokens
+			model.OutputTokenLimit = static.MaxCompletionTokens
+		}
+	}
+	return model
+}
+
+// namespaceKimiModelID puts an upstream id into the kimi- routing namespace.
+// Ids that already carry the prefix are left alone so the gateway switching to
+// prefixed ids would not produce kimi-kimi-k2.
+func namespaceKimiModelID(upstreamID string) string {
+	trimmed := strings.TrimSpace(upstreamID)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(trimmed), kimiModelIDPrefix) {
+		return trimmed
+	}
+	return kimiModelIDPrefix + trimmed
+}
+
+// kimiDisplayNameFromID renders kimi-k2.5 as "Kimi K2.5" so a model the catalog
+// does not know still reads like the curated entries in the panel.
+func kimiDisplayNameFromID(modelID string) string {
+	trimmed := strings.TrimSpace(modelID)
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(trimmed, "-")
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func cloneKimiThinking(thinking *sdkmodelcatalog.ThinkingSupport) *sdkmodelcatalog.ThinkingSupport {
+	if thinking == nil {
+		return nil
+	}
+	clone := *thinking
+	if len(thinking.Levels) > 0 {
+		clone.Levels = append([]string(nil), thinking.Levels...)
+	}
+	return &clone
+}

--- a/internal/runtime/executor/kimi_models_test.go
+++ b/internal/runtime/executor/kimi_models_test.go
@@ -1,0 +1,209 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	kimiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+type kimiModelsRoundTripper struct {
+	req    *http.Request
+	body   string
+	status int
+}
+
+func (k *kimiModelsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	k.req = req
+	status := k.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(k.body)),
+		Request:    req,
+	}, nil
+}
+
+func resetKimiModelsCacheForTest() {
+	kimiModelsCache.mu.Lock()
+	kimiModelsCache.models = nil
+	kimiModelsCache.mu.Unlock()
+}
+
+func kimiOAuthAuth() *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		Provider: "kimi",
+		Metadata: map[string]any{
+			"access_token": "kimi-token",
+			"device_id":    "device-abc",
+		},
+	}
+}
+
+func fetchKimiModelsWithBody(t *testing.T, body string) ([]*sdkmodelcatalog.ModelInfo, *kimiModelsRoundTripper) {
+	t.Helper()
+	rt := &kimiModelsRoundTripper{body: body}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+	return FetchKimiModels(ctx, kimiOAuthAuth(), nil), rt
+}
+
+func kimiModelsByID(models []*sdkmodelcatalog.ModelInfo) map[string]*sdkmodelcatalog.ModelInfo {
+	byID := make(map[string]*sdkmodelcatalog.ModelInfo, len(models))
+	for _, model := range models {
+		if model != nil {
+			byID[model.ID] = model
+		}
+	}
+	return byID
+}
+
+func TestFetchKimiModelsNamespacesUpstreamIDs(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	models, rt := fetchKimiModelsWithBody(t, `{
+		"object": "list",
+		"data": [
+			{"id": "k2.5", "object": "model", "created": 1769472000, "owned_by": "moonshot"},
+			{"id": "kimi-k2", "object": "model", "owned_by": "moonshot"}
+		]
+	}`)
+
+	if rt.req == nil {
+		t.Fatal("expected models request to be issued")
+	}
+	wantURL := strings.TrimRight(kimiauth.KimiAPIBaseURL, "/") + kimiModelsPath
+	if got := rt.req.URL.String(); got != wantURL {
+		t.Fatalf("models URL = %q, want %q", got, wantURL)
+	}
+	if got := rt.req.Header.Get("Authorization"); got != "Bearer kimi-token" {
+		t.Fatalf("Authorization = %q, want Bearer kimi-token", got)
+	}
+	// The gateway rejects requests that do not look like kimi-cli, so discovery
+	// must carry the same identity headers as chat traffic.
+	if got := rt.req.Header.Get("X-Msh-Platform"); got != "kimi_cli" {
+		t.Fatalf("X-Msh-Platform = %q, want kimi_cli", got)
+	}
+	if got := rt.req.Header.Get("X-Msh-Device-Id"); got != "device-abc" {
+		t.Fatalf("X-Msh-Device-Id = %q, want the account device id", got)
+	}
+
+	byID := kimiModelsByID(models)
+	bare := byID["kimi-k2.5"]
+	if bare == nil {
+		t.Fatalf("models = %+v, want bare id namespaced to kimi-k2.5", models)
+	}
+	if bare.UpstreamModelID != "k2.5" {
+		t.Fatalf("kimi-k2.5 upstream = %q, want k2.5", bare.UpstreamModelID)
+	}
+	if bare.Type != "kimi" {
+		t.Fatalf("kimi-k2.5 type = %q, want kimi", bare.Type)
+	}
+	prefixed := byID["kimi-k2"]
+	if prefixed == nil {
+		t.Fatalf("models = %+v, want already-prefixed id kept as kimi-k2", models)
+	}
+	if prefixed.UpstreamModelID != "" {
+		t.Fatalf("kimi-k2 upstream = %q, want empty when the id needs no rewrite", prefixed.UpstreamModelID)
+	}
+}
+
+func TestFetchKimiModelsEnrichesKnownModelsFromStaticCatalog(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	models, _ := fetchKimiModelsWithBody(t, `{"data":[{"id":"k2.6","object":"model"}]}`)
+
+	byID := kimiModelsByID(models)
+	model := byID["kimi-k2.6"]
+	if model == nil {
+		t.Fatalf("models = %+v, want kimi-k2.6", models)
+	}
+	// The listing carries ids only; reasoning support has to come from the catalog
+	// or ApplyThinking silently drops the client's reasoning_effort.
+	if model.Thinking == nil {
+		t.Fatal("kimi-k2.6 thinking support = nil, want the catalog definition")
+	}
+	if model.DisplayName != "Kimi K2.6" {
+		t.Fatalf("kimi-k2.6 display name = %q, want Kimi K2.6", model.DisplayName)
+	}
+	if model.ContextLength != 131072 {
+		t.Fatalf("kimi-k2.6 context length = %d, want the catalog value", model.ContextLength)
+	}
+	if model.OwnedBy != "moonshot" {
+		t.Fatalf("kimi-k2.6 owned_by = %q, want moonshot", model.OwnedBy)
+	}
+}
+
+func TestFetchKimiModelsKeepsUnknownModelWithoutGuessedCapabilities(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	models, _ := fetchKimiModelsWithBody(t, `{"data":[{"id":"k9-preview","object":"model"}]}`)
+
+	byID := kimiModelsByID(models)
+	model := byID["kimi-k9-preview"]
+	if model == nil {
+		t.Fatalf("models = %+v, want an id the catalog has never seen to still be routable", models)
+	}
+	if model.Thinking != nil {
+		t.Fatalf("kimi-k9-preview thinking = %+v, want nil rather than a guessed budget", model.Thinking)
+	}
+	if model.DisplayName != "Kimi K9 Preview" {
+		t.Fatalf("kimi-k9-preview display name = %q, want a readable fallback", model.DisplayName)
+	}
+}
+
+func TestFetchKimiModelsFallsBackToCachedCatalog(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	if ok := storeKimiModels([]*sdkmodelcatalog.ModelInfo{{ID: "kimi-cached", OwnedBy: "moonshot", Type: "kimi"}}); !ok {
+		t.Fatal("expected cache seed to store")
+	}
+
+	rt := &kimiModelsRoundTripper{status: http.StatusInternalServerError, body: `{"error":"boom"}`}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+	models := FetchKimiModels(ctx, kimiOAuthAuth(), nil)
+
+	if len(models) != 1 || models[0].ID != "kimi-cached" {
+		t.Fatalf("fallback models = %+v, want the cached list retained", models)
+	}
+}
+
+func TestFetchKimiModelsWithoutCredentialsDoesNotCallUpstream(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	rt := &kimiModelsRoundTripper{body: `{"data":[{"id":"k2.5"}]}`}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+	models := FetchKimiModels(ctx, &cliproxyauth.Auth{Provider: "kimi"}, nil)
+
+	if rt.req != nil {
+		t.Fatal("expected no upstream request without a token")
+	}
+	if len(models) != 0 {
+		t.Fatalf("models = %+v, want empty so callers apply their own floor", models)
+	}
+}
+
+func TestParseKimiModelsRejectsEmptyAndInvalidPayloads(t *testing.T) {
+	if _, ok := parseKimiModels([]byte(`not json`), 1); ok {
+		t.Fatal("invalid JSON reported as a usable model list")
+	}
+	if _, ok := parseKimiModels([]byte(`{"data":[]}`), 1); ok {
+		t.Fatal("empty listing reported as a usable model list")
+	}
+	if _, ok := parseKimiModels([]byte(`{"data":[{"id":"   "}]}`), 1); ok {
+		t.Fatal("blank id reported as a usable model list")
+	}
+}

--- a/sdk/cliproxy/service_model_kimi.go
+++ b/sdk/cliproxy/service_model_kimi.go
@@ -1,0 +1,30 @@
+package cliproxy
+
+import (
+	"context"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
+)
+
+// fetchKimiRegistryModels resolves the models a Kimi account can route.
+//
+// Discovery comes first so a newly released id is routable the moment the coding
+// gateway advertises it, instead of waiting for a catalog release. The compiled-in
+// catalog stays as the floor: a gateway outage or a credential that cannot list
+// models must not deregister every model on an otherwise working account.
+func (s *Service) fetchKimiRegistryModels(ctx context.Context, auth *coreauth.Auth, excluded []string) []*ModelInfo {
+	fetchCtx := ctx
+	if fetchCtx == nil {
+		fetchCtx = context.Background()
+	}
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(fetchCtx), 15*time.Second)
+	defer cancel()
+	models := serviceapp.FetchKimiModels(fetchCtx, auth, s.cfg)
+	if len(models) == 0 {
+		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("kimi")
+	}
+	return applyExcludedModels(models, excluded)
+}

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -240,7 +240,12 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("iflow")
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
-		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("kimi")
+		// Live discovery so a model Moonshot ships today is routable today; the
+		// tenant model library still supplements it, because the coding gateway
+		// lists what this account is entitled to rather than the full catalog.
+		models = s.fetchKimiRegistryModels(ctx, a, excluded)
+		catalogRows, mappedOwners := oauthCatalogScope(a)
+		models = appendOAuthProviderModelConfigs(models, provider, authKind, catalogRows, mappedOwners)
 		models = applyExcludedModels(models, excluded)
 	default:
 		if s.registerOpenAICompatModels(a, provider, compatProviderKey, compatDisplayName, compatDetected) {

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -336,6 +336,10 @@ func modelConfigOwnerAliases(provider string) map[string]struct{} {
 		values = append(values, "anthropic", "claude-code")
 	case "gemini", "gemini-cli", "vertex":
 		values = append(values, "google")
+	case "kimi":
+		// Kimi models are owned by Moonshot in the catalog, so a library row added
+		// under the vendor name has to resolve back to the kimi channel.
+		values = append(values, "moonshot", "moonshotai")
 	}
 	out := make(map[string]struct{}, len(values))
 	for _, value := range values {

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -119,6 +119,10 @@ func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Conf
 	return internalserviceapp.FetchCodexModels(ctx, auth, cfg)
 }
 
+func FetchKimiModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.FetchKimiModels(ctx, auth, cfg)
+}
+
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	internalserviceapp.RegisterExecutorForAuth(coreManager, cfg, auth, forceReplace, gateway)
 }


### PR DESCRIPTION
## 问题

kimi 渠道的模型来自编译进二进制的静态目录（`GetKimiModels`，4 个 id）。凭据详情的「模型」面板、模型广场、以及运行时可路由的模型集合全都来自这份清单，所以：

- Moonshot 上线新模型后，代理侧必须发版才能路由，面板也一直显示旧的四条；
- 已下线的模型仍然显示为「该凭据支持」。

其它 OAuth 供应商（claude / codex / xai）早已走上游发现，kimi 是唯一的例外。

## 改动

- 新增 `FetchKimiModels`：走 `https://api.kimi.com/coding/v1/models`（与 chat completions 同 base URL、同凭据、同 kimi-cli 身份头）。
- 上游返回裸 id（`k2.5`），路由用 `kimi-` 命名空间且发请求前会 `stripKimiPrefix` 剥掉，因此发现结果统一归一化到 `kimi-` 前缀，并记录 `UpstreamModelID`。
- 目录已知的 id 从静态目录补齐 thinking / 上下文长度 / 描述——listing 只给 id，不补的话 `ApplyThinking` 会静默丢掉客户端的 `reasoning_effort`。目录没见过的新 id 保持可路由，但 `Thinking` 留空而不是猜一个预算（不支持的 `reasoning_effort` 上游会 400）。
- kimi 接入共享 provider 发现缓存（`supportsSharedDiscovery`），同租户同类账号只暖一次，不再每个账号一次往返。
- 启动注册改为发现优先，**静态目录保留为下限**：网关故障或凭据列不出模型时，账号不会被注销掉全部模型。
- 租户模型库的 owner 别名补上 `moonshot` / `moonshotai`，让运营者能像 xai 那样手动补网关未播报的 id。

## 影响面

- 目录：`CliRelay/`（后端）。配套前端改动见 codeProxy 侧 PR（凭据面板复用同一份共享发现缓存）。
- 无新增配置项，无数据迁移。

## 已执行的验证

在 `CliRelay-wt-kimi-models` worktree 内执行 `./scripts/ci-pr.sh`，完整通过（exit 0）：结构扫描、`gofmt`、secret scan、`go vet ./...`、`go test ./...`、updater 子模块 vet/test/build、`golangci-lint run`、`go build ./cmd/server`。

新增测试：
- `internal/runtime/executor/kimi_models_test.go`：id 归一化、静态目录补全、未知模型不猜能力、失败回退缓存、无凭据不发请求、非法/空 payload 判定。
- `internal/management/authfiles/models_test.go`：kimi 走共享发现缓存且不 `RegisterClient` 替换注册表。

## 未验证项

上游 `/coding/v1/models` 的真实响应体未取到——手头没有可用的 kimi 凭据，只在香港源站确认了该端点存在（带无效 token 返回 401 而非 404，错误体为 OpenAI 兼容结构）。因此解析按标准 OpenAI listing 实现，并对空/非法响应、非 2xx、网络失败全部回退到缓存或静态目录，最坏情况等价于改动前的行为。