### PR TITLE
fix(routing): say which scope hid the credential instead of "no auth available"

### DIFF
--- a/sdk/cliproxy/auth/conductor_selector_service.go
+++ b/sdk/cliproxy/auth/conductor_selector_service.go
@@ -237,7 +237,7 @@ func (s selectorService) pickLocked(
 		candidates := s.buildCandidatesLocked(scope, selectorRouteGroup, tried, registryRef, includeCandidate)
 		if len(candidates) == 0 {
 			if diagnosis == nil {
-				diagnosis = s.diagnoseEmptyCandidates(scope, selectorRouteGroup, includeCandidate)
+				diagnosis = s.diagnoseEmptyCandidates(scope, selectorRouteGroup, registryRef, includeCandidate)
 			}
 			continue
 		}

--- a/sdk/cliproxy/auth/selection_diagnostics.go
+++ b/sdk/cliproxy/auth/selection_diagnostics.go
@@ -28,6 +28,16 @@ type selectionRejection struct {
 	// credential for the request's provider, which is what makes a model-scope
 	// rejection the likely explanation rather than "there are no accounts".
 	sawTenantCandidate bool
+	// sawServingCandidate records that some healthy tenant credential actually
+	// serves the requested model. Without it a scope rejection means nothing:
+	// the model may simply not be registered anywhere.
+	sawServingCandidate bool
+	// servingBlockedByChannels records that a serving credential was excluded by
+	// the caller's allowed-channels restriction.
+	servingBlockedByChannels bool
+	// servingBlockedByGroups records that a serving credential was excluded by
+	// the caller's allowed-channel-groups restriction.
+	servingBlockedByGroups bool
 }
 
 // diagnoseEmptyCandidates inspects the credentials the scope considered and
@@ -36,6 +46,7 @@ type selectionRejection struct {
 func (s selectorService) diagnoseEmptyCandidates(
 	scope selectionScope,
 	scopedRouteGroup string,
+	registryRef ModelRegistry,
 	includeCandidate func(candidate *Auth) bool,
 ) error {
 	if s.manager == nil || scope.modelKey == "" {
@@ -55,6 +66,26 @@ func (s selectorService) diagnoseEmptyCandidates(
 		}
 		rejection.sawTenantCandidate = true
 
+		// Everything below only makes sense for a credential that serves the model.
+		// A credential outside the caller's channel scope that could not serve it
+		// anyway is not the reason the request failed.
+		if !candidateServesModel(registryRef, candidate, scope.modelKey) {
+			continue
+		}
+		rejection.sawServingCandidate = true
+
+		// The caller's own restrictions come first: they exclude the credential
+		// before any group's model list is consulted, and they are what the
+		// operator has to change.
+		if !authAllowedByChannels(candidate, scope.allowedChannels) {
+			rejection.servingBlockedByChannels = true
+			continue
+		}
+		if !authAllowedByGroups(scope.cfg, candidate, scope.allowedGroups) {
+			rejection.servingBlockedByGroups = true
+			continue
+		}
+
 		// Re-run only the model-scope gate. A candidate that clears it was excluded
 		// for some other reason, which this diagnosis deliberately does not guess at.
 		groups := authGroups(scope.cfg, candidate)
@@ -66,7 +97,35 @@ func (s selectorService) diagnoseEmptyCandidates(
 		}
 	}
 
-	if !rejection.sawTenantCandidate || len(rejection.modelBlockedByGroups) == 0 {
+	if !rejection.sawTenantCandidate {
+		return nil
+	}
+
+	// A credential that serves the model exists but the caller may not reach it.
+	// This is the case the generic message hid worst: the panel lists the account,
+	// the model panel lists the model, and the request still says "no auth".
+	if rejection.sawServingCandidate {
+		if rejection.servingBlockedByGroups {
+			return &Error{
+				Code: "model_outside_allowed_channel_groups",
+				Message: fmt.Sprintf(
+					"model %q is served only by credentials outside the channel groups this credential may use (%s); add a serving account to one of those groups, or widen the allowed channel groups",
+					scope.modelKey, describeScopeNames(scope.allowedGroups),
+				),
+			}
+		}
+		if rejection.servingBlockedByChannels {
+			return &Error{
+				Code: "model_outside_allowed_channels",
+				Message: fmt.Sprintf(
+					"model %q is served only by credentials outside the channels this credential may use (%s); widen the allowed channels or use an account in one of them",
+					scope.modelKey, describeScopeNames(scope.allowedChannels),
+				),
+			}
+		}
+	}
+
+	if len(rejection.modelBlockedByGroups) == 0 {
 		return nil
 	}
 
@@ -83,6 +142,35 @@ func (s selectorService) diagnoseEmptyCandidates(
 			scope.modelKey, strings.Join(quoteAll(names), ", "),
 		),
 	}
+}
+
+// candidateServesModel reports whether a credential can serve a model, ignoring
+// every scope gate. It mirrors the registry half of candidateSupportsModelOpts so
+// the diagnosis agrees with the selector on what "serves" means.
+func candidateServesModel(registryRef ModelRegistry, auth *Auth, modelID string) bool {
+	if auth == nil {
+		return false
+	}
+	if registryRef == nil {
+		return true
+	}
+	if len(registryRef.GetModelsForClient(auth.ID)) == 0 {
+		return !authHasDisableAllModelsRule(auth)
+	}
+	return registryRef.ClientSupportsModel(auth.ID, modelID)
+}
+
+// describeScopeNames renders a restriction set for an operator-facing message.
+func describeScopeNames(scope map[string]struct{}) string {
+	if len(scope) == 0 {
+		return "none"
+	}
+	names := make([]string, 0, len(scope))
+	for name := range scope {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(quoteAll(names), ", ")
 }
 
 // blockingRouteGroups lists the groups whose allowed-models list rejected a model.

--- a/sdk/cliproxy/auth/selection_diagnostics_test.go
+++ b/sdk/cliproxy/auth/selection_diagnostics_test.go
@@ -7,6 +7,7 @@ import (
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
 )
 
 // restrictedGroupManager reproduces the production shape that made this bug so hard
@@ -132,5 +133,143 @@ func TestUnrestrictedGroupDoesNotClaimBlocking(t *testing.T) {
 		if asErr, ok := err.(*Error); ok && asErr.Code == "model_not_allowed_by_channel_group" {
 			t.Errorf("a group without an allowed-models list must not be reported as blocking: %v", asErr.Message)
 		}
+	}
+}
+
+// pickWithScope drives selection with the caller-side restrictions an API key or
+// end user carries, which is where the misleading message came from in production.
+func pickWithScope(manager *Manager, model string, meta map[string]any) error {
+	_, _, _, err := manager.pickNextMixed(
+		context.Background(),
+		[]string{"xai", "kimi"},
+		model,
+		cliproxyexecutor.Options{Metadata: meta},
+		map[string]struct{}{},
+	)
+	return err
+}
+
+// scopedModelRegistry serves each model from exactly one credential, which is what
+// makes "the account that serves this model is out of scope" distinguishable from
+// "nothing serves this model".
+type scopedModelRegistry struct {
+	byClient map[string][]string
+}
+
+func (r *scopedModelRegistry) ClearModelQuotaExceeded(string, string)    {}
+func (r *scopedModelRegistry) SetModelQuotaExceeded(string, string)      {}
+func (r *scopedModelRegistry) SuspendClientModel(string, string, string) {}
+func (r *scopedModelRegistry) ResumeClientModel(string, string)          {}
+
+func (r *scopedModelRegistry) ClientSupportsModel(clientID, modelID string) bool {
+	for _, model := range r.byClient[clientID] {
+		if strings.EqualFold(model, modelID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *scopedModelRegistry) GetModelsForClient(clientID string) []*sdkmodelcatalog.ModelInfo {
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(r.byClient[clientID]))
+	for _, model := range r.byClient[clientID] {
+		out = append(out, &sdkmodelcatalog.ModelInfo{ID: model})
+	}
+	return out
+}
+
+// twoChannelManager mirrors the reported deployment: two healthy accounts, only one
+// of them inside the channel group the caller is restricted to.
+func twoChannelManager(t *testing.T) *Manager {
+	t.Helper()
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{Name: "group", Match: internalconfig.ChannelGroupMatch{Channels: []string{"Grok Account"}}},
+			},
+		},
+	})
+	manager.RegisterExecutor(&stubExecutor{id: "xai"})
+	manager.RegisterExecutor(&stubExecutor{id: "kimi"})
+
+	for _, auth := range []*Auth{
+		{ID: "xai-auth", Label: "Grok Account", Provider: "xai", Status: StatusActive},
+		{ID: "kimi-auth", Label: "kimi", Provider: "kimi", Status: StatusActive},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", auth.ID, err)
+		}
+	}
+	manager.SetModelRegistry(&scopedModelRegistry{byClient: map[string][]string{
+		"xai-auth":  {"grok-4.5"},
+		"kimi-auth": {"kimi-k3"},
+	}})
+	return manager
+}
+
+// TestModelOutsideAllowedChannelGroupsIsNamed is the fix for the reported case: the
+// kimi account was healthy, the model was registered on it, and the request still
+// said "no auth available" because the caller could only use one channel group.
+func TestModelOutsideAllowedChannelGroupsIsNamed(t *testing.T) {
+	manager := twoChannelManager(t)
+
+	err := pickWithScope(manager, "kimi-k3", map[string]any{
+		"allowed-channel-groups": []string{"group"},
+	})
+	if err == nil {
+		t.Fatal("a credential outside the allowed channel groups must not be selectable")
+	}
+	selectionErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("error type = %T, want *Error", err)
+	}
+	if selectionErr.Code != "model_outside_allowed_channel_groups" {
+		t.Fatalf("code = %q, want model_outside_allowed_channel_groups (message: %s)", selectionErr.Code, selectionErr.Message)
+	}
+	// Both halves have to be named: the model the caller asked for and the scope
+	// that excluded it, because the fix is to edit one of them.
+	if !strings.Contains(selectionErr.Message, "kimi-k3") {
+		t.Errorf("message does not name the model: %q", selectionErr.Message)
+	}
+	if !strings.Contains(selectionErr.Message, "group") {
+		t.Errorf("message does not name the allowed channel group: %q", selectionErr.Message)
+	}
+}
+
+// TestReachableModelStillSelectableUnderChannelGroupScope pins that the diagnosis
+// changed no routing: the account inside the allowed group still serves.
+func TestReachableModelStillSelectableUnderChannelGroupScope(t *testing.T) {
+	manager := twoChannelManager(t)
+
+	if err := pickWithScope(manager, "grok-4.5", map[string]any{
+		"allowed-channel-groups": []string{"group"},
+	}); err != nil {
+		t.Fatalf("an account inside the allowed group must still be selectable: %v", err)
+	}
+}
+
+// TestModelOutsideAllowedChannelsIsNamed covers the per-channel restriction, which
+// produced the same unhelpful message.
+func TestModelOutsideAllowedChannelsIsNamed(t *testing.T) {
+	manager := twoChannelManager(t)
+
+	err := pickWithScope(manager, "kimi-k3", map[string]any{
+		"allowed-channels": []string{"Grok Account"},
+	})
+	if err == nil {
+		t.Fatal("a credential outside the allowed channels must not be selectable")
+	}
+	selectionErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("error type = %T, want *Error", err)
+	}
+	if selectionErr.Code != "model_outside_allowed_channels" {
+		t.Fatalf("code = %q, want model_outside_allowed_channels (message: %s)", selectionErr.Code, selectionErr.Message)
+	}
+	if !strings.Contains(selectionErr.Message, "kimi-k3") {
+		t.Errorf("message does not name the model: %q", selectionErr.Message)
 	}
 }


### PR DESCRIPTION
## 问题（线上实证）

管理面板「测试模型」对 kimi 模型一律返回 `auth_not_found: no auth available`，但面板里 kimi 账号健康、模型也确实注册在它上面。

香港源站取证（`dev-d05f6a5`）：

- kimi 账号 `kimi-1787796223378.json`：`status=active`、`disabled=false`、`unavailable=false`，注册了 8 个模型（含 `kimi-k3`、`kimi-k2.6`）。
- 同一个 API key 打 `grok-4.6` → 200；打 `kimi-k3` / `kimi-k2.6` / `kimi-for-coding` → 全部 500 `auth_not_found`。
- 该 key 绑定的终端用户 `kittors` 配了 `allowed-channel-groups: ["group"]`，而 kimi 账号不在 `group` 组里。

也就是说：**账号在、模型在、只是调用方够不着**，而错误信息把它说成「没有可用账号」。这条信息误导性极强——面板明明列着账号，运营者只能去查账号是不是坏了。

## 根因

`diagnoseEmptyCandidates` 只重跑了一道门：渠道组的 `allowed-models`。而调用方自身的 `allowed-channels` / `allowed-channel-groups` 在更早的 `allowsCandidate` 里就把候选剔除了，诊断完全没覆盖，于是回落到通用消息。

更糟的是这两条路径的收窄逻辑不同：`scopedRouteGroupNames` 在没有 route group、也没有 allowed groups 时返回空集，所以连原有的那道诊断也一起失效。

## 改动

`diagnoseEmptyCandidates` 现在：

1. 只统计**确实能服务该模型**的候选（`candidateServesModel`，镜像 selector 的 registry 判定）。够不着但本来也服务不了的账号不是失败原因，不参与归因。
2. 依次重跑调用方自己的两道门，命中就报出可操作的原因：
   - `model_outside_allowed_channel_groups` — 能服务该模型的账号都在这个凭据可用的渠道组之外，并列出这些组名
   - `model_outside_allowed_channels` — 同理，渠道级限制
3. 都没命中时才走原有的 `model_not_allowed_by_channel_group`，再不行才是通用消息。

路由行为完全不变：这段代码只在候选为空的失败路径上执行，请求此时已经失败。

## 影响面

- 目录：`CliRelay/`（`sdk/cliproxy/auth`）。无前端改动，错误消息由前端原样展示。
- 无配置项、无数据迁移、无接口契约变化（只新增两个 error code）。

## 已执行的验证

在 `CliRelay-wt-selection-diag` worktree 内执行 `./scripts/ci-pr.sh`，完整通过（exit 0）：结构扫描、`gofmt`、secret scan、`go vet ./...`、`go test ./...`、updater 子模块 vet/test/build、`golangci-lint run`、`go build ./cmd/server`。

`sdk/cliproxy/auth/selection_diagnostics_test.go` 新增三例，复刻线上形状（两个健康账号，只有一个在允许的渠道组内，各自服务不同模型）：
- 渠道组之外的模型报 `model_outside_allowed_channel_groups` 并点名模型与组
- 渠道之外的模型报 `model_outside_allowed_channels`
- 组内账号仍可正常选中（确认没改路由）

原有四例（`model_not_allowed_by_channel_group`、允许模型仍可选、无凭据时保留通用消息、无限制组不背锅）全部保持通过。

## 备注

本 PR 只修错误归因。用户遇到的那次失败本身是配置问题——把 kimi 账号加入渠道组 `group`，或放宽终端用户的渠道组限制即可。修完之后同样的配置会直接告诉运营者这一点，而不是让他去查账号死没死。