### PR TITLE
feat(kimi): learn and replay the account's real kimi-cli identity

### DIFF
--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -40,6 +40,7 @@ func (h *Handler) GetIdentityFingerprint(c *gin.Context) {
 			"codex":  {Enabled: current.Codex.Enabled, LearnedCount: len(learned["codex"])},
 			"gemini": {Enabled: current.Gemini.Enabled, LearnedCount: len(learned["gemini"])},
 			"xai":    {Enabled: current.XAI.Enabled, LearnedCount: len(learned["xai"])},
+			"kimi":   {Enabled: current.Kimi.Enabled, LearnedCount: len(learned["kimi"])},
 		},
 	})
 }
@@ -65,6 +66,10 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 		return
 	}
 	if err := validateXAIIdentityFingerprint(body.XAI); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := validateKimiIdentityFingerprint(body.Kimi); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -126,14 +131,16 @@ func (h *Handler) identityFingerprintState(current config.IdentityFingerprintCon
 		"codex":  {},
 		"gemini": {},
 		"xai":    {},
+		"kimi":   {},
 	}
 	effective := map[string][]identityfingerprint.EffectiveFingerprint{
 		"claude": {},
 		"codex":  {},
 		"gemini": {},
 		"xai":    {},
+		"kimi":   {},
 	}
-	for _, provider := range []identityfingerprint.Provider{identityfingerprint.ProviderClaude, identityfingerprint.ProviderCodex, identityfingerprint.ProviderGemini, identityfingerprint.ProviderXAI} {
+	for _, provider := range []identityfingerprint.Provider{identityfingerprint.ProviderClaude, identityfingerprint.ProviderCodex, identityfingerprint.ProviderGemini, identityfingerprint.ProviderXAI, identityfingerprint.ProviderKimi} {
 		records, err := usage.ListIdentityFingerprints(provider, 200)
 		if err != nil {
 			continue
@@ -154,6 +161,9 @@ func (h *Handler) identityFingerprintState(current config.IdentityFingerprintCon
 				effective[key] = append(effective[key], eff)
 			case identityfingerprint.ProviderXAI:
 				_, eff := identityfingerprint.ResolveXAI(current.XAI, &record)
+				effective[key] = append(effective[key], eff)
+			case identityfingerprint.ProviderKimi:
+				_, eff := identityfingerprint.ResolveKimi(current.Kimi, &record)
 				effective[key] = append(effective[key], eff)
 			}
 		}
@@ -268,6 +278,33 @@ func validateXAIIdentityFingerprint(fp config.XAIIdentityFingerprintConfig) erro
 	return nil
 }
 
+func validateKimiIdentityFingerprint(fp config.KimiIdentityFingerprintConfig) error {
+	if containsHeaderLineBreak(fp.UserAgent) ||
+		containsHeaderLineBreak(fp.Platform) ||
+		containsHeaderLineBreak(fp.Version) ||
+		containsHeaderLineBreak(fp.DeviceName) ||
+		containsHeaderLineBreak(fp.DeviceModel) {
+		return fmt.Errorf("identity fingerprint fields must not contain line breaks")
+	}
+	for key, value := range fp.CustomHeaders {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return fmt.Errorf("custom header name cannot be empty")
+		}
+		if !isHTTPHeaderToken(key) {
+			return fmt.Errorf("invalid custom header name: %s", key)
+		}
+		if isIdentityFingerprintBlockedHeader(key) || isKimiIdentityFingerprintBlockedHeader(key) {
+			return fmt.Errorf("custom header %s is managed by the system", key)
+		}
+		if containsHeaderLineBreak(value) {
+			return fmt.Errorf("custom header %s must not contain line breaks", key)
+		}
+	}
+	return nil
+}
+
 func containsHeaderLineBreak(value string) bool {
 	return strings.ContainsAny(value, "\r\n")
 }
@@ -308,6 +345,18 @@ func isGeminiIdentityFingerprintBlockedHeader(key string) bool {
 func isXAIIdentityFingerprintBlockedHeader(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
 	case "x-grok-client-identifier", "x-grok-client-version", "x-grok-conv-id":
+		return true
+	default:
+		return false
+	}
+}
+
+// isKimiIdentityFingerprintBlockedHeader covers the headers the kimi fingerprint
+// owns. The device id is included even though it has no preset: it is resolved
+// per account, and a custom header would override every account with one value.
+func isKimiIdentityFingerprintBlockedHeader(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "x-msh-platform", "x-msh-version", "x-msh-device-name", "x-msh-device-model", "x-msh-device-id":
 		return true
 	default:
 		return false

--- a/internal/api/handlers/management/identity_fingerprint_account.go
+++ b/internal/api/handlers/management/identity_fingerprint_account.go
@@ -448,6 +448,9 @@ func resolveIdentityFingerprint(current config.IdentityFingerprintConfig, provid
 	case identityfingerprint.ProviderXAI:
 		_, effective := identityfingerprint.ResolveXAI(current.XAI, learned)
 		return effective, current.XAI, config.DefaultXAIIdentityFingerprint()
+	case identityfingerprint.ProviderKimi:
+		_, effective := identityfingerprint.ResolveKimi(current.Kimi, learned)
+		return effective, current.Kimi, config.DefaultKimiIdentityFingerprint()
 	default:
 		return identityfingerprint.EffectiveFingerprint{}, nil, nil
 	}
@@ -504,6 +507,10 @@ func identityFingerprintSummaryVersion(provider identityfingerprint.Provider, ef
 		}
 	case identityfingerprint.ProviderXAI:
 		return strings.TrimSpace(effective.Version)
+	case identityfingerprint.ProviderKimi:
+		if value := identityFingerprintEffectiveField(effective, identityfingerprint.FieldKimiVersion); value != "" {
+			return value
+		}
 	}
 	return strings.TrimSpace(effective.Version)
 }
@@ -583,6 +590,8 @@ func normalizeIdentityFingerprintProvider(value string) (identityfingerprint.Pro
 		return identityfingerprint.ProviderGemini, true
 	case string(identityfingerprint.ProviderXAI), "grok":
 		return identityfingerprint.ProviderXAI, true
+	case string(identityfingerprint.ProviderKimi), "moonshot":
+		return identityfingerprint.ProviderKimi, true
 	default:
 		return "", false
 	}

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -68,6 +68,7 @@ type IdentityFingerprintConfig struct {
 	Claude ClaudeIdentityFingerprintConfig `yaml:"claude,omitempty" json:"claude,omitempty"`
 	Gemini GeminiIdentityFingerprintConfig `yaml:"gemini,omitempty" json:"gemini,omitempty"`
 	XAI    XAIIdentityFingerprintConfig    `yaml:"xai,omitempty" json:"xai,omitempty"`
+	Kimi   KimiIdentityFingerprintConfig   `yaml:"kimi,omitempty" json:"kimi,omitempty"`
 }
 
 // CodexIdentityFingerprintConfig configures Codex upstream identity headers.
@@ -231,14 +232,21 @@ func DefaultIdentityFingerprintConfig() IdentityFingerprintConfig {
 		Claude: DefaultClaudeIdentityFingerprint(),
 		Gemini: DefaultGeminiIdentityFingerprint(),
 		XAI:    DefaultXAIIdentityFingerprint(),
+		Kimi:   DefaultKimiIdentityFingerprint(),
 	}
 }
 
 // SanitizeIdentityFingerprint normalizes provider identity fingerprint config.
+//
+// The legacy kimi-header-defaults block is folded into the kimi fingerprint here
+// so the runtime, the management API and the panel all read one source. Doing it
+// anywhere later would leave the panel showing the builtin template while a
+// deployment's configured headers were what actually went upstream.
 func (cfg *Config) SanitizeIdentityFingerprint() {
 	if cfg == nil {
 		return
 	}
+	cfg.IdentityFingerprint.Kimi = WithKimiHeaderDefaults(cfg.IdentityFingerprint.Kimi, cfg.KimiHeaderDefaults)
 	cfg.IdentityFingerprint = NormalizeIdentityFingerprintConfig(cfg.IdentityFingerprint)
 }
 
@@ -250,6 +258,7 @@ func CleanIdentityFingerprintConfig(in IdentityFingerprintConfig) IdentityFinger
 		Claude: CleanClaudeIdentityFingerprint(in.Claude),
 		Gemini: CleanGeminiIdentityFingerprint(in.Gemini),
 		XAI:    CleanXAIIdentityFingerprint(in.XAI),
+		Kimi:   CleanKimiIdentityFingerprint(in.Kimi),
 	}
 }
 
@@ -261,6 +270,7 @@ func NormalizeIdentityFingerprintConfig(in IdentityFingerprintConfig) IdentityFi
 	out.Claude = defaultClaudeIdentityFingerprintEnabled(out.Claude)
 	out.Gemini = defaultGeminiIdentityFingerprintEnabled(out.Gemini)
 	out.XAI = defaultXAIIdentityFingerprintEnabled(out.XAI)
+	out.Kimi = defaultKimiIdentityFingerprintEnabled(out.Kimi)
 	return out
 }
 
@@ -279,6 +289,9 @@ func NormalizeLegacyIdentityFingerprintRuntimeConfig(in IdentityFingerprintConfi
 	}
 	if xaiLegacyDefaultDisabled(out.XAI) {
 		out.XAI.enabledSet = false
+	}
+	if kimiLegacyDefaultDisabled(out.Kimi) {
+		out.Kimi.enabledSet = false
 	}
 	return NormalizeIdentityFingerprintConfig(out)
 }

--- a/internal/config/identity_fingerprint_kimi.go
+++ b/internal/config/identity_fingerprint_kimi.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// Defaults follow the identity the official kimi-cli sends. They match the
+	// values the Kimi executor has always hardcoded, so an account with no learned
+	// fingerprint and no operator preset keeps its previous outbound identity.
+	DefaultKimiFingerprintUserAgent = "KimiCLI/1.10.6"
+	DefaultKimiFingerprintPlatform  = "kimi_cli"
+	DefaultKimiFingerprintVersion   = "1.10.6"
+)
+
+// KimiIdentityFingerprintConfig configures the kimi-cli identity headers sent to
+// the Kimi coding gateway.
+//
+// Device name and model have no compiled-in default on purpose. They describe the
+// machine the client runs on, and the only value the proxy could invent is its own
+// hostname — which is both wrong and identical across every account on the host.
+// Leaving them empty lets the runtime keep its existing host-derived fallback while
+// a learned observation, when present, replaces it with the real client's value.
+type KimiIdentityFingerprintConfig struct {
+	Enabled       bool              `yaml:"enabled" json:"enabled"`
+	UserAgent     string            `yaml:"user-agent,omitempty" json:"user-agent,omitempty"`
+	Platform      string            `yaml:"x-msh-platform,omitempty" json:"x-msh-platform,omitempty"`
+	Version       string            `yaml:"x-msh-version,omitempty" json:"x-msh-version,omitempty"`
+	DeviceName    string            `yaml:"x-msh-device-name,omitempty" json:"x-msh-device-name,omitempty"`
+	DeviceModel   string            `yaml:"x-msh-device-model,omitempty" json:"x-msh-device-model,omitempty"`
+	CustomHeaders map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet    bool
+}
+
+// DefaultKimiIdentityFingerprint returns the recommended kimi-cli identity template.
+func DefaultKimiIdentityFingerprint() KimiIdentityFingerprintConfig {
+	return KimiIdentityFingerprintConfig{
+		Enabled:       true,
+		UserAgent:     DefaultKimiFingerprintUserAgent,
+		Platform:      DefaultKimiFingerprintPlatform,
+		Version:       DefaultKimiFingerprintVersion,
+		CustomHeaders: map[string]string{},
+	}
+}
+
+// NormalizeKimiIdentityFingerprint trims user input and applies the default enablement.
+func NormalizeKimiIdentityFingerprint(in KimiIdentityFingerprintConfig) KimiIdentityFingerprintConfig {
+	return defaultKimiIdentityFingerprintEnabled(CleanKimiIdentityFingerprint(in))
+}
+
+// CleanKimiIdentityFingerprint trims explicit overrides while preserving empty fields.
+func CleanKimiIdentityFingerprint(in KimiIdentityFingerprintConfig) KimiIdentityFingerprintConfig {
+	out := in
+	out.UserAgent = strings.TrimSpace(out.UserAgent)
+	out.Platform = strings.TrimSpace(out.Platform)
+	out.Version = strings.TrimSpace(out.Version)
+	out.DeviceName = strings.TrimSpace(out.DeviceName)
+	out.DeviceModel = strings.TrimSpace(out.DeviceModel)
+	out.CustomHeaders = cleanIdentityFingerprintHeaders(out.CustomHeaders)
+	return out
+}
+
+// WithKimiHeaderDefaults folds the legacy kimi-header-defaults block into the
+// fingerprint preset layer.
+//
+// Both settings describe the same three headers. Deployments configured before
+// the fingerprint existed must keep their values, so the legacy block acts as a
+// preset the fingerprint's own preset can still override, and both stay below a
+// learned observation.
+func WithKimiHeaderDefaults(fp KimiIdentityFingerprintConfig, legacy KimiHeaderDefaults) KimiIdentityFingerprintConfig {
+	out := CleanKimiIdentityFingerprint(fp)
+	if out.UserAgent == "" {
+		out.UserAgent = strings.TrimSpace(legacy.UserAgent)
+	}
+	if out.Platform == "" {
+		out.Platform = strings.TrimSpace(legacy.Platform)
+	}
+	if out.Version == "" {
+		out.Version = strings.TrimSpace(legacy.Version)
+	}
+	return out
+}
+
+func defaultKimiIdentityFingerprintEnabled(in KimiIdentityFingerprintConfig) KimiIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func kimiLegacyDefaultDisabled(fp KimiIdentityFingerprintConfig) bool {
+	if fp.Enabled || len(fp.CustomHeaders) > 0 ||
+		strings.TrimSpace(fp.DeviceName) != "" || strings.TrimSpace(fp.DeviceModel) != "" {
+		return false
+	}
+	defaults := DefaultKimiIdentityFingerprint()
+	return emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.Platform, defaults.Platform) &&
+		emptyOrEqual(fp.Version, defaults.Version)
+}
+
+func (fp *KimiIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias KimiIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = KimiIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *KimiIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias KimiIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = KimiIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}

--- a/internal/identityfingerprint/extract.go
+++ b/internal/identityfingerprint/extract.go
@@ -25,6 +25,11 @@ const (
 	FieldXAIGrokConversationID  = "x-grok-conv-id"
 	FieldXAIClientIdentifier    = "x-grok-client-identifier"
 	FieldXAIClientVersion       = "x-grok-client-version"
+	FieldKimiPlatform           = "x-msh-platform"
+	FieldKimiVersion            = "x-msh-version"
+	FieldKimiDeviceName         = "x-msh-device-name"
+	FieldKimiDeviceModel        = "x-msh-device-model"
+	FieldKimiDeviceID           = "x-msh-device-id"
 )
 
 var (
@@ -33,6 +38,7 @@ var (
 	tokenVerRe       = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*codex[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
 	geminiUARe       = regexp.MustCompile(`(?i)^google-api-nodejs-client/([0-9]+(?:\.[0-9]+){0,3})`)
 	xaiTokenVerRe    = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*(?:grok|xai)[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
+	kimiTokenVerRe   = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*kimi[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
 )
 
 func ExtractObservation(input LearnInput) (Observation, bool) {
@@ -50,6 +56,8 @@ func ExtractObservation(input LearnInput) (Observation, bool) {
 		return extractGeminiObservation(input, headers, observedAt)
 	case ProviderXAI:
 		return extractXAIObservation(input, headers, observedAt)
+	case ProviderKimi:
+		return extractKimiObservation(input, headers, observedAt)
 	default:
 		return Observation{}, false
 	}
@@ -222,6 +230,59 @@ func extractXAIObservation(input LearnInput, headers http.Header, observedAt tim
 	}, true
 }
 
+// extractKimiObservation learns the identity a real kimi-cli presents.
+//
+// The device fields are part of the observation on purpose. Without them every
+// account on a host goes out with that host's name and, when the credential
+// carries no device id of its own, the literal fallback string the proxy uses —
+// so accounts that share nothing else still look like one machine to Moonshot.
+func extractKimiObservation(input LearnInput, headers http.Header, observedAt time.Time) (Observation, bool) {
+	ua := strings.TrimSpace(headers.Get("User-Agent"))
+	platform := strings.TrimSpace(headers.Get("X-Msh-Platform"))
+	version := strings.TrimSpace(headers.Get("X-Msh-Version"))
+	product, uaVersion := kimiProductVersion(ua)
+	if product == "" && platform != "" {
+		product = platform
+	}
+	if version == "" {
+		version = uaVersion
+	}
+	// A caller that presents neither a kimi User-Agent nor the platform header is
+	// not the kimi client, and recording it would pin the account to a made-up
+	// identity.
+	if product == "" {
+		return Observation{}, false
+	}
+	fields := map[string]string{}
+	if ua != "" {
+		fields[FieldUserAgent] = ua
+	}
+	if platform != "" {
+		fields[FieldKimiPlatform] = platform
+	}
+	if version != "" {
+		fields[FieldKimiVersion] = version
+	}
+	addHeaderField(fields, headers, "X-Msh-Device-Name", FieldKimiDeviceName)
+	addHeaderField(fields, headers, "X-Msh-Device-Model", FieldKimiDeviceModel)
+	addHeaderField(fields, headers, "X-Msh-Device-Id", FieldKimiDeviceID)
+	if len(fields) == 0 {
+		return Observation{}, false
+	}
+	return Observation{
+		Provider:        ProviderKimi,
+		AccountKey:      strings.TrimSpace(input.AccountKey),
+		ProfileKey:      ProfileKeyDefault,
+		AuthSubjectID:   strings.TrimSpace(input.AuthSubjectID),
+		ClientProduct:   product,
+		ClientVariant:   "cli",
+		Version:         version,
+		Fields:          fields,
+		ObservedHeaders: observedHeaders(headers, []string{"User-Agent", "X-Msh-Platform", "X-Msh-Version", "X-Msh-Device-Name", "X-Msh-Device-Model", "X-Msh-Device-Id"}),
+		ObservedAt:      observedAt.UTC(),
+	}, true
+}
+
 func MergeObservation(existing *LearnedRecord, obs Observation) MergeResult {
 	if strings.TrimSpace(obs.AccountKey) == "" {
 		return MergeResult{Reason: "missing_account_key"}
@@ -365,6 +426,20 @@ func xaiProductVersion(ua string) (string, string) {
 	}
 	if strings.Contains(lower, "xai") {
 		return "xai-cli", ""
+	}
+	return "", ""
+}
+
+func kimiProductVersion(ua string) (string, string) {
+	ua = strings.TrimSpace(ua)
+	if ua == "" {
+		return "", ""
+	}
+	if matches := kimiTokenVerRe.FindStringSubmatch(ua); len(matches) > 0 {
+		return strings.ToLower(matches[1]), matches[2]
+	}
+	if strings.Contains(strings.ToLower(ua), "kimi") {
+		return "kimi-cli", ""
 	}
 	return "", ""
 }

--- a/internal/identityfingerprint/kimi_test.go
+++ b/internal/identityfingerprint/kimi_test.go
@@ -1,0 +1,164 @@
+package identityfingerprint
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func kimiClientHeaders() http.Header {
+	headers := http.Header{}
+	headers.Set("User-Agent", "KimiCLI/1.12.0")
+	headers.Set("X-Msh-Platform", "kimi_cli")
+	headers.Set("X-Msh-Version", "1.12.0")
+	headers.Set("X-Msh-Device-Name", "starship")
+	headers.Set("X-Msh-Device-Model", "darwin arm64")
+	headers.Set("X-Msh-Device-Id", "device-from-client")
+	return headers
+}
+
+func TestExtractKimiObservationFromRealClientHeaders(t *testing.T) {
+	obs, ok := ExtractObservation(LearnInput{
+		Provider:   ProviderKimi,
+		AccountKey: "acct",
+		Headers:    kimiClientHeaders(),
+		ObservedAt: time.Date(2026, 8, 27, 1, 2, 3, 0, time.UTC),
+	})
+	if !ok {
+		t.Fatal("ExtractObservation returned false for a real kimi-cli request")
+	}
+	if obs.ClientProduct != "kimicli" || obs.Version != "1.12.0" {
+		t.Fatalf("product/version = %s/%s, want kimicli/1.12.0", obs.ClientProduct, obs.Version)
+	}
+	if obs.ProfileKey != ProfileKeyDefault {
+		t.Fatalf("profile key = %q, want the single default profile", obs.ProfileKey)
+	}
+	for field, want := range map[string]string{
+		FieldUserAgent:       "KimiCLI/1.12.0",
+		FieldKimiPlatform:    "kimi_cli",
+		FieldKimiVersion:     "1.12.0",
+		FieldKimiDeviceName:  "starship",
+		FieldKimiDeviceModel: "darwin arm64",
+		// Without the device id every credential that has none of its own goes out
+		// with the same host fallback string, which is the cross-account collision
+		// this observation exists to remove.
+		FieldKimiDeviceID: "device-from-client",
+	} {
+		if got := obs.Fields[field]; got != want {
+			t.Fatalf("field %s = %q, want %q", field, got, want)
+		}
+	}
+}
+
+func TestExtractKimiObservationFallsBackToPlatformHeader(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Msh-Platform", "kimi_cli")
+	headers.Set("X-Msh-Version", "1.9.2")
+
+	obs, ok := ExtractObservation(LearnInput{Provider: ProviderKimi, AccountKey: "acct", Headers: headers})
+	if !ok {
+		t.Fatal("a request identified only by X-Msh-Platform should still be learnable")
+	}
+	if obs.ClientProduct != "kimi_cli" || obs.Version != "1.9.2" {
+		t.Fatalf("product/version = %s/%s, want kimi_cli/1.9.2", obs.ClientProduct, obs.Version)
+	}
+}
+
+func TestExtractKimiObservationRejectsForeignClients(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("User-Agent", "curl/8.7.1")
+
+	if _, ok := ExtractObservation(LearnInput{Provider: ProviderKimi, AccountKey: "acct", Headers: headers}); ok {
+		t.Fatal("a caller that is not the kimi client must not pin the account to its identity")
+	}
+}
+
+func TestResolveKimiPrefersLearnedOverPresetOverDefault(t *testing.T) {
+	learned := &LearnedRecord{
+		Provider:   ProviderKimi,
+		AccountKey: "acct",
+		ProfileKey: ProfileKeyDefault,
+		Fields: map[string]string{
+			FieldUserAgent:      "KimiCLI/1.12.0",
+			FieldKimiVersion:    "1.12.0",
+			FieldKimiDeviceName: "starship",
+			FieldKimiDeviceID:   "device-from-client",
+		},
+	}
+	preset := config.KimiIdentityFingerprintConfig{
+		Enabled:   true,
+		UserAgent: "KimiCLI/1.11.0",
+		Platform:  "kimi_cli_custom",
+	}
+
+	resolved, effective := ResolveKimi(preset, learned)
+
+	if resolved.UserAgent != "KimiCLI/1.12.0" {
+		t.Fatalf("user agent = %q, want the learned value", resolved.UserAgent)
+	}
+	if resolved.Platform != "kimi_cli_custom" {
+		t.Fatalf("platform = %q, want the operator preset when nothing was learned", resolved.Platform)
+	}
+	if resolved.DeviceModel != "" {
+		t.Fatalf("device model = %q, want empty so the runtime keeps its host fallback", resolved.DeviceModel)
+	}
+	if effective.Fields[FieldUserAgent].Source != FieldSourceLearned {
+		t.Fatalf("user agent source = %q, want learned", effective.Fields[FieldUserAgent].Source)
+	}
+	if effective.Fields[FieldKimiPlatform].Source != FieldSourcePreset {
+		t.Fatalf("platform source = %q, want preset", effective.Fields[FieldKimiPlatform].Source)
+	}
+	if effective.Version != "1.12.0" {
+		t.Fatalf("effective version = %q, want the learned client version", effective.Version)
+	}
+	if got := KimiLearnedDeviceID(learned); got != "device-from-client" {
+		t.Fatalf("learned device id = %q, want the observed value", got)
+	}
+}
+
+func TestResolveKimiWithoutLearnedKeepsPreviousHardcodedIdentity(t *testing.T) {
+	resolved, effective := ResolveKimi(config.KimiIdentityFingerprintConfig{Enabled: true}, nil)
+
+	if resolved.UserAgent != config.DefaultKimiFingerprintUserAgent ||
+		resolved.Platform != config.DefaultKimiFingerprintPlatform ||
+		resolved.Version != config.DefaultKimiFingerprintVersion {
+		t.Fatalf("resolved = %+v, want the builtin kimi-cli template", resolved)
+	}
+	if effective.Fields[FieldUserAgent].Source != FieldSourceBuiltinDefault {
+		t.Fatalf("user agent source = %q, want builtin_default", effective.Fields[FieldUserAgent].Source)
+	}
+	if _, ok := effective.Fields[FieldKimiDeviceID]; ok {
+		t.Fatal("device id must only appear once it has been observed")
+	}
+}
+
+// The legacy kimi-header-defaults block predates the fingerprint and configures
+// the same three headers, so an existing deployment must not have its values
+// replaced by the builtin template.
+func TestWithKimiHeaderDefaultsKeepsLegacyOverrides(t *testing.T) {
+	legacy := config.KimiHeaderDefaults{UserAgent: "KimiCLI/1.8.0", Platform: "kimi_cli", Version: "1.8.0"}
+
+	merged := config.WithKimiHeaderDefaults(config.KimiIdentityFingerprintConfig{Enabled: true}, legacy)
+	resolved, _ := ResolveKimi(merged, nil)
+	if resolved.UserAgent != "KimiCLI/1.8.0" || resolved.Version != "1.8.0" {
+		t.Fatalf("resolved = %+v, want the legacy header defaults", resolved)
+	}
+
+	explicit := config.KimiIdentityFingerprintConfig{Enabled: true, UserAgent: "KimiCLI/1.13.0"}
+	resolved, _ = ResolveKimi(config.WithKimiHeaderDefaults(explicit, legacy), nil)
+	if resolved.UserAgent != "KimiCLI/1.13.0" {
+		t.Fatalf("user agent = %q, want the fingerprint preset to win over the legacy block", resolved.UserAgent)
+	}
+	if resolved.Version != "1.8.0" {
+		t.Fatalf("version = %q, want the legacy block to still fill unset fields", resolved.Version)
+	}
+}
+
+func TestNormalizeKimiIdentityFingerprintDefaultsToEnabled(t *testing.T) {
+	out := config.NormalizeKimiIdentityFingerprint(config.KimiIdentityFingerprintConfig{})
+	if !out.Enabled {
+		t.Fatal("kimi fingerprint must default to enabled like every other provider")
+	}
+}

--- a/internal/identityfingerprint/resolve.go
+++ b/internal/identityfingerprint/resolve.go
@@ -194,6 +194,50 @@ func ResolveXAI(cfg config.XAIIdentityFingerprintConfig, learned *LearnedRecord)
 	return resolved, effective
 }
 
+// ResolveKimi merges the operator preset, the learned kimi-cli observation and
+// the builtin template into the identity sent to the Kimi coding gateway.
+//
+// Device name, model and id have no builtin fallback: an empty result means the
+// executor keeps its host-derived value, which is the pre-fingerprint behaviour.
+// The device id is learned but deliberately not presettable — one id configured
+// globally would make every account look like the same machine, which is the
+// opposite of what the learned value achieves.
+func ResolveKimi(cfg config.KimiIdentityFingerprintConfig, learned *LearnedRecord) (config.KimiIdentityFingerprintConfig, EffectiveFingerprint) {
+	clean := config.CleanKimiIdentityFingerprint(cfg)
+	defaults := config.DefaultKimiIdentityFingerprint()
+	fields := make(map[string]FieldValue)
+	pick := func(field, preset, learnedValue, defaultValue string) string {
+		value, source := pickField(preset, learnedValue, defaultValue)
+		fields[field] = FieldValue{Value: value, Source: source}
+		return value
+	}
+
+	resolved := config.KimiIdentityFingerprintConfig{
+		Enabled:       clean.Enabled,
+		UserAgent:     pick(FieldUserAgent, clean.UserAgent, learnedField(learned, FieldUserAgent), defaults.UserAgent),
+		Platform:      pick(FieldKimiPlatform, clean.Platform, learnedField(learned, FieldKimiPlatform), defaults.Platform),
+		Version:       pick(FieldKimiVersion, clean.Version, learnedFieldOrVersion(learned, FieldKimiVersion), defaults.Version),
+		DeviceName:    pick(FieldKimiDeviceName, clean.DeviceName, learnedField(learned, FieldKimiDeviceName), ""),
+		DeviceModel:   pick(FieldKimiDeviceModel, clean.DeviceModel, learnedField(learned, FieldKimiDeviceModel), ""),
+		CustomHeaders: clean.CustomHeaders,
+	}
+	if deviceID := learnedField(learned, FieldKimiDeviceID); deviceID != "" {
+		fields[FieldKimiDeviceID] = FieldValue{Value: deviceID, Source: FieldSourceLearned}
+	}
+	effective := effective(ProviderKimi, clean.Enabled, learned, fields)
+	if value := strings.TrimSpace(resolved.Version); value != "" {
+		effective.Version = value
+	}
+	return resolved, effective
+}
+
+// KimiLearnedDeviceID returns the device id observed from a real kimi-cli, or an
+// empty string. It is not part of the resolved config because it never comes from
+// operator presets or builtin defaults.
+func KimiLearnedDeviceID(learned *LearnedRecord) string {
+	return learnedField(learned, FieldKimiDeviceID)
+}
+
 func pickField(preset, learned, fallback string) (string, FieldSource) {
 	if value := strings.TrimSpace(learned); value != "" {
 		return value, FieldSourceLearned

--- a/internal/identityfingerprint/types.go
+++ b/internal/identityfingerprint/types.go
@@ -9,6 +9,7 @@ const (
 	ProviderCodex  Provider = "codex"
 	ProviderGemini Provider = "gemini"
 	ProviderXAI    Provider = "xai"
+	ProviderKimi   Provider = "kimi"
 )
 
 type FieldSource string

--- a/internal/management/settings/runtimeconfig/spec.go
+++ b/internal/management/settings/runtimeconfig/spec.go
@@ -473,6 +473,7 @@ type identityFingerprintRuntimePayload struct {
 	Claude                config.ClaudeIdentityFingerprintConfig `json:"claude,omitempty"`
 	Gemini                config.GeminiIdentityFingerprintConfig `json:"gemini,omitempty"`
 	XAI                   config.XAIIdentityFingerprintConfig    `json:"xai,omitempty"`
+	Kimi                  config.KimiIdentityFingerprintConfig   `json:"kimi,omitempty"`
 }
 
 func IdentityFingerprintRuntimeSettingValue(value config.IdentityFingerprintConfig) any {
@@ -483,6 +484,7 @@ func IdentityFingerprintRuntimeSettingValue(value config.IdentityFingerprintConf
 		Claude:                normalized.Claude,
 		Gemini:                normalized.Gemini,
 		XAI:                   normalized.XAI,
+		Kimi:                  normalized.Kimi,
 	}
 }
 
@@ -496,6 +498,10 @@ func identityFingerprintRuntimeSettingConfig(raw json.RawMessage) (config.Identi
 		Claude: payload.Claude,
 		Gemini: payload.Gemini,
 		XAI:    payload.XAI,
+		// Payloads written before kimi joined carry no kimi block, so it stays a
+		// zero value and normalization enables it with the builtin template — which
+		// is byte-identical to what the executor hardcoded before.
+		Kimi: payload.Kimi,
 	}
 	if payload.RuntimeSettingVersion >= identityFingerprintRuntimeSettingVersion {
 		return config.NormalizeIdentityFingerprintConfig(value), nil

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -14,6 +14,7 @@ import (
 
 	kimiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
@@ -561,7 +562,16 @@ func resolveKimiDeviceID(auth *cliproxyauth.Auth) string {
 func applyKimiHeadersWithAuth(r *http.Request, token string, stream bool, auth *cliproxyauth.Auth, cfg *config.Config) {
 	applyKimiHeaders(r, token, stream, cfg)
 
-	if deviceID := resolveKimiDeviceID(auth); deviceID != "" {
+	// The identity fingerprint replaces the host-derived client identity with the
+	// one this account's real kimi-cli presents; anything it cannot resolve keeps
+	// the values applyKimiHeaders just set.
+	var learned *identityfingerprint.LearnedRecord
+	if fp, record, ok := kimiIdentityFingerprint(cfg, auth, r.Context()); ok {
+		applyKimiIdentityFingerprintHeaders(r.Header, fp)
+		learned = record
+	}
+
+	if deviceID := resolveKimiOutboundDeviceID(auth, learned); deviceID != "" {
 		r.Header.Set("X-Msh-Device-Id", deviceID)
 	}
 }

--- a/internal/runtime/executor/kimi_identity_fingerprint.go
+++ b/internal/runtime/executor/kimi_identity_fingerprint.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// kimiIdentityFingerprint resolves the outbound kimi-cli identity for an account
+// and returns the learned record alongside it, because the device id is carried
+// only by the observation (see ResolveKimi).
+//
+// Scope note: this covers the OpenAI-compatible path. A Claude-format request to
+// a Kimi credential is served by ClaudeExecutor against the same gateway, where
+// the caller really is a Claude client, so it keeps the Claude fingerprint.
+func kimiIdentityFingerprint(cfg *config.Config, auth *cliproxyauth.Auth, ctx context.Context) (config.KimiIdentityFingerprintConfig, *identityfingerprint.LearnedRecord, bool) {
+	if cfg == nil || !cfg.IdentityFingerprint.Kimi.Enabled {
+		return config.KimiIdentityFingerprintConfig{}, nil, false
+	}
+	learned := observeRuntimeIdentityFingerprint(identityfingerprint.ProviderKimi, auth, ctx)
+	preset := config.WithKimiHeaderDefaults(cfg.IdentityFingerprint.Kimi, cfg.KimiHeaderDefaults)
+	resolved, _ := identityfingerprint.ResolveKimi(preset, learned)
+	return resolved, learned, true
+}
+
+// applyKimiIdentityFingerprintHeaders overwrites the host-derived defaults with
+// the resolved identity. Empty fields are left alone so the caller's fallback
+// (hostname, GOOS/GOARCH) survives when nothing has been learned or configured.
+func applyKimiIdentityFingerprintHeaders(headers http.Header, fp config.KimiIdentityFingerprintConfig) {
+	if headers == nil {
+		return
+	}
+	for header, value := range map[string]string{
+		"User-Agent":         fp.UserAgent,
+		"X-Msh-Platform":     fp.Platform,
+		"X-Msh-Version":      fp.Version,
+		"X-Msh-Device-Name":  fp.DeviceName,
+		"X-Msh-Device-Model": fp.DeviceModel,
+	} {
+		if value = strings.TrimSpace(value); value != "" {
+			headers.Set(header, value)
+		}
+	}
+	for key, value := range fp.CustomHeaders {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || isKimiFingerprintRuntimeBlockedHeader(key) {
+			continue
+		}
+		headers.Set(key, value)
+	}
+}
+
+// resolveKimiOutboundDeviceID picks the device id sent upstream.
+//
+// The credential's own id wins: it is the device Moonshot associated with the
+// account at login, and replacing it would present a known account from an
+// unknown machine. A learned id is next — it is the real client's device and is
+// scoped to this account, unlike the host fallback that every credential without
+// an id would otherwise share.
+func resolveKimiOutboundDeviceID(auth *cliproxyauth.Auth, learned *identityfingerprint.LearnedRecord) string {
+	if deviceID := resolveKimiDeviceID(auth); deviceID != "" {
+		return deviceID
+	}
+	return identityfingerprint.KimiLearnedDeviceID(learned)
+}
+
+func isKimiFingerprintRuntimeBlockedHeader(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "authorization", "content-type", "accept", "connection", "user-agent",
+		"x-msh-platform", "x-msh-version", "x-msh-device-name", "x-msh-device-model",
+		"x-msh-device-id":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/executor/kimi_identity_fingerprint_test.go
+++ b/internal/runtime/executor/kimi_identity_fingerprint_test.go
@@ -1,0 +1,163 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func kimiFingerprintRequest(t *testing.T, inbound map[string]string) *http.Request {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	for key, value := range inbound {
+		ginCtx.Request.Header.Set(key, value)
+	}
+	req := httptest.NewRequest(http.MethodPost, "https://api.kimi.com/coding/v1/chat/completions", nil)
+	return req.WithContext(context.WithValue(req.Context(), util.ContextKeyGin, ginCtx))
+}
+
+func kimiFingerprintConfig() *config.Config {
+	return &config.Config{
+		IdentityFingerprint: config.IdentityFingerprintConfig{
+			Kimi: config.NormalizeKimiIdentityFingerprint(config.KimiIdentityFingerprintConfig{}),
+		},
+	}
+}
+
+func TestApplyKimiHeadersAdoptsLearnedClientIdentity(t *testing.T) {
+	req := kimiFingerprintRequest(t, map[string]string{
+		"User-Agent":         "KimiCLI/1.12.0",
+		"X-Msh-Platform":     "kimi_cli",
+		"X-Msh-Version":      "1.12.0",
+		"X-Msh-Device-Name":  "starship",
+		"X-Msh-Device-Model": "darwin arm64",
+		"X-Msh-Device-Id":    "device-from-client",
+	})
+	auth := &cliproxyauth.Auth{ID: "kimi-learned-account", Provider: "kimi"}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, kimiFingerprintConfig())
+
+	for header, want := range map[string]string{
+		"User-Agent":         "KimiCLI/1.12.0",
+		"X-Msh-Platform":     "kimi_cli",
+		"X-Msh-Version":      "1.12.0",
+		"X-Msh-Device-Name":  "starship",
+		"X-Msh-Device-Model": "darwin arm64",
+		// No credential-scoped id exists, so the client's own device is used rather
+		// than the host fallback every such credential would otherwise share.
+		"X-Msh-Device-Id": "device-from-client",
+	} {
+		if got := req.Header.Get(header); got != want {
+			t.Fatalf("%s = %q, want %q", header, got, want)
+		}
+	}
+}
+
+func TestApplyKimiHeadersKeepsCredentialDeviceIDOverLearnedOne(t *testing.T) {
+	req := kimiFingerprintRequest(t, map[string]string{
+		"User-Agent":      "KimiCLI/1.12.0",
+		"X-Msh-Platform":  "kimi_cli",
+		"X-Msh-Device-Id": "device-from-client",
+	})
+	auth := &cliproxyauth.Auth{
+		ID:       "kimi-bound-device-account",
+		Provider: "kimi",
+		Metadata: map[string]any{"device_id": "device-from-login"},
+	}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, kimiFingerprintConfig())
+
+	// The login-time device is the one Moonshot associated with the account.
+	if got := req.Header.Get("X-Msh-Device-Id"); got != "device-from-login" {
+		t.Fatalf("X-Msh-Device-Id = %q, want the credential's own device id", got)
+	}
+	if got := req.Header.Get("User-Agent"); got != "KimiCLI/1.12.0" {
+		t.Fatalf("User-Agent = %q, want the learned client version", got)
+	}
+}
+
+func TestApplyKimiHeadersIgnoresForeignClientIdentity(t *testing.T) {
+	req := kimiFingerprintRequest(t, map[string]string{
+		"User-Agent":      "curl/8.7.1",
+		"X-Msh-Device-Id": "not-a-kimi-device",
+	})
+	auth := &cliproxyauth.Auth{ID: "kimi-foreign-client-account", Provider: "kimi"}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, kimiFingerprintConfig())
+
+	if got := req.Header.Get("User-Agent"); got != config.DefaultKimiFingerprintUserAgent {
+		t.Fatalf("User-Agent = %q, want the builtin kimi-cli identity", got)
+	}
+	if got := req.Header.Get("X-Msh-Device-Id"); got == "not-a-kimi-device" {
+		t.Fatal("a non-kimi caller must not set the account's outbound device id")
+	}
+	// The host fallback still applies, matching the pre-fingerprint behaviour.
+	if got := req.Header.Get("X-Msh-Device-Name"); got != getKimiHostname() {
+		t.Fatalf("X-Msh-Device-Name = %q, want the host fallback", got)
+	}
+}
+
+func TestApplyKimiHeadersWithFingerprintDisabledKeepsLegacyDefaults(t *testing.T) {
+	req := kimiFingerprintRequest(t, map[string]string{
+		"User-Agent":     "KimiCLI/1.12.0",
+		"X-Msh-Platform": "kimi_cli",
+	})
+	cfg := &config.Config{
+		KimiHeaderDefaults: config.KimiHeaderDefaults{UserAgent: "KimiCLI/1.8.0", Version: "1.8.0"},
+	}
+	auth := &cliproxyauth.Auth{ID: "kimi-fingerprint-off-account", Provider: "kimi"}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, cfg)
+
+	if got := req.Header.Get("User-Agent"); got != "KimiCLI/1.8.0" {
+		t.Fatalf("User-Agent = %q, want the configured header defaults when the fingerprint is off", got)
+	}
+	if got := req.Header.Get("X-Msh-Version"); got != "1.8.0" {
+		t.Fatalf("X-Msh-Version = %q, want the configured header defaults", got)
+	}
+}
+
+func TestApplyKimiHeadersFingerprintKeepsLegacyHeaderDefaultsAsPreset(t *testing.T) {
+	req := kimiFingerprintRequest(t, nil)
+	cfg := kimiFingerprintConfig()
+	cfg.KimiHeaderDefaults = config.KimiHeaderDefaults{UserAgent: "KimiCLI/1.8.0", Version: "1.8.0"}
+	auth := &cliproxyauth.Auth{ID: "kimi-legacy-preset-account", Provider: "kimi"}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, cfg)
+
+	// Enabling the fingerprint must not silently replace an operator's existing
+	// kimi-header-defaults with the builtin template.
+	if got := req.Header.Get("User-Agent"); got != "KimiCLI/1.8.0" {
+		t.Fatalf("User-Agent = %q, want the legacy header defaults to survive", got)
+	}
+	if got := req.Header.Get("X-Msh-Platform"); got != config.DefaultKimiFingerprintPlatform {
+		t.Fatalf("X-Msh-Platform = %q, want the builtin value for the field legacy config left unset", got)
+	}
+}
+
+func TestKimiFingerprintCustomHeadersCannotOverrideManagedHeaders(t *testing.T) {
+	headers := http.Header{}
+	applyKimiIdentityFingerprintHeaders(headers, config.KimiIdentityFingerprintConfig{
+		Enabled:   true,
+		UserAgent: "KimiCLI/1.12.0",
+		CustomHeaders: map[string]string{
+			"X-Msh-Device-Id": "spoofed",
+			"X-Msh-Trace":     "kept",
+		},
+	})
+
+	if got := headers.Get("X-Msh-Device-Id"); got != "" {
+		t.Fatalf("X-Msh-Device-Id = %q, want the managed header left untouched", got)
+	}
+	if got := headers.Get("X-Msh-Trace"); got != "kept" {
+		t.Fatalf("X-Msh-Trace = %q, want unmanaged custom headers applied", got)
+	}
+}


### PR DESCRIPTION
## 问题

kimi 是唯一没有接入身份指纹系统的 OAuth 供应商。它出站时用的是一套写死的身份：

| 头 | 改动前的来源 |
|---|---|
| `User-Agent` | 硬编码 `KimiCLI/1.10.6`（或 `kimi-header-defaults`） |
| `X-Msh-Platform` | 硬编码 `kimi_cli` |
| `X-Msh-Version` | 硬编码 `1.10.6` |
| `X-Msh-Device-Name` | **代理服务器的 hostname** |
| `X-Msh-Device-Model` | 服务器的 `GOOS GOARCH` |
| `X-Msh-Device-Id` | 凭据自带的 device_id，否则**所有账号共用同一个兜底字符串** |

结果是同一台机器上互不相关的 kimi 账号，在 Moonshot 侧看起来是同一台设备跑的同一个客户端——正是 claude / codex / xai 已经用身份指纹解决掉的问题。

## 改动

kimi 以**单档案** provider 的形式接入（对齐 claude/xai，而不是 codex 的多档案选择器）：kimi-cli 目前是唯一的客户端形态，多档案列表只会有一条、策略也没有备选对象。

- `internal/identityfingerprint`：新增 `ProviderKimi`，从入站请求学习 `User-Agent` / `X-Msh-Platform` / `X-Msh-Version` / `X-Msh-Device-Name` / `X-Msh-Device-Model` / `X-Msh-Device-Id`，按账号存储；`ResolveKimi` 按 learned → preset → builtin 的既有优先级合成出站身份。
- `internal/config`：新增 `identity-fingerprint.kimi`（独立文件 `identity_fingerprint_kimi.go`，不撑大既有配置文件）。
- `internal/runtime/executor`：`applyKimiHeadersWithAuth` 应用解析结果；解析不出的字段保持原有的主机兜底值。
- 管理端：`/v0/management/identity-fingerprint` 的读写、校验、状态、账号详情、learned 记录清理全部覆盖 kimi。

### 两个刻意的设计决定

**device id 只学不配。** 它是账号绑定的设备标识，全局配一个值会让所有账号又变回同一台机器。优先级是：凭据自身的登录期 device_id > 学习到的真实客户端 device id > 主机兜底。

**device name / model 没有 builtin 默认值。** 代理唯一能编出来的值就是自己的 hostname，既不真实又在同主机上完全一致。留空表示「保持运行时的主机兜底」，也就是改动前的行为。

### 向后兼容

- 没有学习记录的账号：builtin 模板与改动前硬编码的值逐字节一致，出站身份不变。
- 配过 `kimi-header-defaults` 的部署：该块在 `SanitizeIdentityFingerprint` 时折叠进指纹的 preset 层（fingerprint preset > legacy > builtin），值不丢，且管理端读到的就是实际生效的那一份，不会出现「面板显示一套、上游收到另一套」。
- runtime settings 旧 payload 没有 kimi 块 → 归一化后按默认启用，行为等价于改动前。

## 影响面

- 目录：`CliRelay/`。前端配套（指纹页 kimi tab 从旧的三字段静态表单升级为真正的指纹面板）随后单独提 PR；后端先合，学习与复用不依赖 UI。
- 无数据迁移。新增配置项 `identity-fingerprint.kimi`，默认启用。

## 已执行的验证

在 `CliRelay-wt-kimi-fingerprint` worktree 内执行 `./scripts/ci-pr.sh`，完整通过（exit 0）：结构扫描、`gofmt`、secret scan、`go vet ./...`、`go test ./...`、updater 子模块 vet/test/build、`golangci-lint run`、`go build ./cmd/server`。

新增测试：
- `internal/identityfingerprint/kimi_test.go`：真实 kimi-cli 头的提取（含 device 字段）、仅凭 `X-Msh-Platform` 也可学习、非 kimi 客户端（curl）不得污染账号身份、learned/preset/builtin 三层优先级、无学习记录时与旧硬编码逐项一致、legacy `kimi-header-defaults` 兼容、默认启用。
- `internal/runtime/executor/kimi_identity_fingerprint_test.go`：出站头采用学习到的客户端身份、凭据自身 device id 优先于学习值、非 kimi 调用方不改写出站身份且保留主机兜底、指纹关闭时沿用 legacy 配置、custom-headers 不得覆盖受管头。