### PR TITLE
fix(routing): name the channel group that serves the model, not just the allowed set

### DIFF
--- a/sdk/cliproxy/auth/selection_diagnostics.go
+++ b/sdk/cliproxy/auth/selection_diagnostics.go
@@ -38,6 +38,11 @@ type selectionRejection struct {
 	// servingBlockedByGroups records that a serving credential was excluded by
 	// the caller's allowed-channel-groups restriction.
 	servingBlockedByGroups bool
+	// servingGroups holds the channel groups the excluded serving credentials
+	// actually belong to. Naming the allowed set alone left the operator guessing
+	// which group to add: the model list they had already edited lived in a group
+	// they could not reach.
+	servingGroups map[string]struct{}
 }
 
 // diagnoseEmptyCandidates inspects the credentials the scope considered and
@@ -53,7 +58,10 @@ func (s selectorService) diagnoseEmptyCandidates(
 		return nil
 	}
 
-	rejection := selectionRejection{modelBlockedByGroups: map[string]struct{}{}}
+	rejection := selectionRejection{
+		modelBlockedByGroups: map[string]struct{}{},
+		servingGroups:        map[string]struct{}{},
+	}
 	for _, candidate := range s.manager.auths {
 		if candidate == nil || candidate.Disabled || candidate.Status == StatusDisabled {
 			continue
@@ -83,6 +91,9 @@ func (s selectorService) diagnoseEmptyCandidates(
 		}
 		if !authAllowedByGroups(scope.cfg, candidate, scope.allowedGroups) {
 			rejection.servingBlockedByGroups = true
+			for group := range authGroups(scope.cfg, candidate) {
+				rejection.servingGroups[group] = struct{}{}
+			}
 			continue
 		}
 
@@ -109,8 +120,8 @@ func (s selectorService) diagnoseEmptyCandidates(
 			return &Error{
 				Code: "model_outside_allowed_channel_groups",
 				Message: fmt.Sprintf(
-					"model %q is served only by credentials outside the channel groups this credential may use (%s); add a serving account to one of those groups, or widen the allowed channel groups",
-					scope.modelKey, describeScopeNames(scope.allowedGroups),
+					"model %q is served by credentials in channel group %s, which this credential may not use (allowed: %s); add a serving group to the allowed channel groups, or move a serving account into an allowed one",
+					scope.modelKey, describeScopeNames(rejection.servingGroups), describeScopeNames(scope.allowedGroups),
 				),
 			}
 		}

--- a/sdk/cliproxy/auth/selection_diagnostics_test.go
+++ b/sdk/cliproxy/auth/selection_diagnostics_test.go
@@ -237,6 +237,11 @@ func TestModelOutsideAllowedChannelGroupsIsNamed(t *testing.T) {
 	if !strings.Contains(selectionErr.Message, "group") {
 		t.Errorf("message does not name the allowed channel group: %q", selectionErr.Message)
 	}
+	// Naming only the allowed set left the operator guessing which group to add:
+	// they had already edited the model list of a group they could not reach.
+	if !strings.Contains(selectionErr.Message, "default") {
+		t.Errorf("message does not name the group that actually serves the model: %q", selectionErr.Message)
+	}
 }
 
 // TestReachableModelStillSelectableUnderChannelGroupScope pins that the diagnosis


### PR DESCRIPTION
## 问题

kittors/CliRelay#943 之后，够不着的模型会报：

```
model "kimi-k3" is served only by credentials outside the channel groups this
credential may use ("group"); add a serving account to one of those groups, or
widen the allowed channel groups
```

信息量还是不够。实际现场是：运营者已经在 `default` 组的 allowed-models 里加了 `kimi-k3`，但他的终端用户被限制在 `group` 组——消息只说了「你能用 group」，没说「这个模型在 default 里」，所以他看着自己刚加过的模型列表，仍然不知道该动哪一处。

## 改动

诊断在被 `allowed-channel-groups` 拦下时，记录被拦候选**实际所属的组**，消息同时点出两边：

```
model "kimi-k3" is served by credentials in channel group "default", which this
credential may not use (allowed: "group"); add a serving group to the allowed
channel groups, or move a serving account into an allowed one
```

一眼就知道是把 `default` 加进允许组，还是把账号挪进 `group`。

## 影响面

- 目录：`CliRelay/`（`sdk/cliproxy/auth/selection_diagnostics.go`），仅失败路径的消息文案与一个新增字段。
- error code 不变（`model_outside_allowed_channel_groups`），路由行为不变。

## 已执行的验证

在 `CliRelay-wt-diag2` worktree 内执行 `./scripts/ci-pr.sh`，完整通过（exit 0）。

`TestModelOutsideAllowedChannelGroupsIsNamed` 增加断言：消息必须点名真正服务该模型的组（`default`），而不只是允许集合。