### PR TITLE
fix(management): probe models with management authority, not a borrowed API key

### DIFF
--- a/internal/api/handlers/management/model_test_run.go
+++ b/internal/api/handlers/management/model_test_run.go
@@ -1,0 +1,164 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Model connectivity test.
+//
+// The panel used to answer "can this model be reached" from the browser: it
+// listed the tenant's API keys, picked one itself, and sent a chat completion to
+// the public /v1 endpoint. That answers a different question — whether that
+// particular business identity may use the model. An operator checking a healthy
+// kimi account got "no auth available" because the key it happened to pick was
+// bound to an end user restricted to one channel group, and no amount of channel
+// or model configuration on the account side could change that.
+//
+// Image and video generation already test through the auth manager for exactly
+// this reason. This does the same for chat models: management authority, tenant
+// scope, no API key in the loop.
+
+const modelTestPromptLimit = 4000
+
+// modelTestTimeout bounds one probe. Long enough for a cold upstream, short
+// enough that an operator is not left watching a spinner.
+const modelTestTimeout = 120 * time.Second
+
+type modelTestRequest struct {
+	Model   string `json:"model"`
+	Prompt  string `json:"prompt"`
+	Channel string `json:"channel"`
+}
+
+// PostModelTest runs one non-streaming completion against a model using
+// management authority, and reports what came back.
+func (h *Handler) PostModelTest(c *gin.Context) {
+	var body modelTestRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	model := strings.TrimSpace(body.Model)
+	if model == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "model is required"})
+		return
+	}
+	prompt := strings.TrimSpace(body.Prompt)
+	if prompt == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "prompt is required"})
+		return
+	}
+	if len(prompt) > modelTestPromptLimit {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "prompt is too long"})
+		return
+	}
+	if h == nil || h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth manager unavailable"})
+		return
+	}
+
+	providers := sdkmodelcatalog.GetProviderName(model)
+	if len(providers) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("no provider serves model %q", model)})
+		return
+	}
+
+	payload, err := buildModelTestPayload(model, prompt)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), modelTestTimeout)
+	defer cancel()
+
+	startedAt := time.Now()
+	resp, execErr := h.authManager.Execute(ctx, providers, coreexecutor.Request{
+		Model:   model,
+		Payload: payload,
+		Format:  sdktranslator.FromString("openai"),
+	}, coreexecutor.Options{
+		OriginalRequest: payload,
+		SourceFormat:    sdktranslator.FromString("openai"),
+		Metadata:        modelTestMetadata(effectiveTenantID(c), body.Channel),
+	})
+	elapsed := time.Since(startedAt).Milliseconds()
+
+	if execErr != nil {
+		// The upstream reason is the whole point of the probe, so it is reported
+		// as a result rather than swallowed into a 5xx.
+		c.JSON(http.StatusOK, gin.H{"ok": false, "error": execErr.Error(), "duration_ms": elapsed})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"ok":          true,
+		"content":     modelTestContent(resp.Payload),
+		"duration_ms": elapsed,
+	})
+}
+
+// modelTestMetadata scopes the probe to the tenant and, when the operator picked
+// a channel, to that channel. Restricting by channel is what the panel's channel
+// selector always implied but never did: it only used the value to choose an API
+// key, so the request could still land on a different account.
+func modelTestMetadata(tenantID, channel string) map[string]any {
+	meta := map[string]any{
+		coreexecutor.SinglePickMetadataKey: true,
+		coreexecutor.TenantMetadataKey:     coreauth.NormalizedTenantID(tenantID),
+	}
+	if channel = strings.TrimSpace(channel); channel != "" {
+		meta["allowed-channels"] = channel
+	}
+	return meta
+}
+
+func buildModelTestPayload(model, prompt string) ([]byte, error) {
+	payload := []byte(`{"stream":false,"messages":[]}`)
+	var err error
+	if payload, err = sjson.SetBytes(payload, "model", model); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "messages.0.role", "user"); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "messages.0.content", prompt); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	return payload, nil
+}
+
+// modelTestContent pulls the assistant text out of an OpenAI-shaped response,
+// falling back to the raw body so an unexpected shape is still inspectable.
+func modelTestContent(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	if text := gjson.GetBytes(payload, "choices.0.message.content").String(); strings.TrimSpace(text) != "" {
+		return text
+	}
+	if parts := gjson.GetBytes(payload, "choices.0.message.content.#.text"); parts.Exists() {
+		texts := make([]string, 0, len(parts.Array()))
+		for _, part := range parts.Array() {
+			if value := strings.TrimSpace(part.String()); value != "" {
+				texts = append(texts, value)
+			}
+		}
+		if len(texts) > 0 {
+			return strings.Join(texts, "\n")
+		}
+	}
+	return string(payload)
+}

--- a/internal/api/handlers/management/model_test_run_test.go
+++ b/internal/api/handlers/management/model_test_run_test.go
@@ -1,0 +1,101 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+func TestBuildModelTestPayloadShapesOneUserTurn(t *testing.T) {
+	payload, err := buildModelTestPayload("kimi-k3", "How is the weather?")
+	if err != nil {
+		t.Fatalf("buildModelTestPayload: %v", err)
+	}
+	if got := gjson.GetBytes(payload, "model").String(); got != "kimi-k3" {
+		t.Fatalf("model = %q, want kimi-k3", got)
+	}
+	if got := gjson.GetBytes(payload, "messages.#").Int(); got != 1 {
+		t.Fatalf("messages = %d, want exactly the probe turn", got)
+	}
+	if got := gjson.GetBytes(payload, "messages.0.content").String(); got != "How is the weather?" {
+		t.Fatalf("content = %q, want the prompt", got)
+	}
+	if gjson.GetBytes(payload, "stream").Bool() {
+		t.Fatal("the probe must not stream; the handler reads one response body")
+	}
+}
+
+// The channel selector in the panel used to only pick an API key, so a probe
+// could land on a different account than the operator selected. Scoping the
+// execution is what makes that selector mean something.
+func TestModelTestMetadataScopesTenantAndChannel(t *testing.T) {
+	meta := modelTestMetadata("tenant-a", " kimi ")
+	if got := meta["allowed-channels"]; got != "kimi" {
+		t.Fatalf("allowed-channels = %v, want the trimmed channel", got)
+	}
+	if meta["tenant_id"] != "tenant-a" {
+		t.Fatalf("tenant_id = %v, want tenant-a", meta["tenant_id"])
+	}
+
+	// No channel selected means "any account that serves the model", not a
+	// restriction to the empty channel.
+	if _, ok := modelTestMetadata("tenant-a", "  ")["allowed-channels"]; ok {
+		t.Fatal("an unset channel must not restrict the probe")
+	}
+}
+
+func TestModelTestContentPrefersAssistantText(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"sunny"}}]}`)
+	if got := modelTestContent(body); got != "sunny" {
+		t.Fatalf("content = %q, want sunny", got)
+	}
+	// An unexpected shape stays inspectable rather than turning into "".
+	raw := []byte(`{"unexpected":true}`)
+	if got := modelTestContent(raw); got != string(raw) {
+		t.Fatalf("content = %q, want the raw body for an unknown shape", got)
+	}
+}
+
+func postModelTest(t *testing.T, h *Handler, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/models/test", strings.NewReader(string(encoded)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.PostModelTest(c)
+	return rec
+}
+
+func TestPostModelTestRejectsIncompleteRequests(t *testing.T) {
+	h := &Handler{}
+	for name, body := range map[string]map[string]string{
+		"no model":  {"prompt": "hi"},
+		"no prompt": {"model": "kimi-k3"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := postModelTest(t, h, body).Code; got != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", got)
+			}
+		})
+	}
+}
+
+// A model no provider serves is a 404, not the generic selection failure an
+// operator would otherwise have to interpret.
+func TestPostModelTestReportsUnknownModel(t *testing.T) {
+	h := &Handler{}
+	rec := postModelTest(t, h, map[string]string{"model": "not-a-real-model-xyz", "prompt": "hi"})
+	if rec.Code != http.StatusNotFound && rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 404 (unknown model) or 503 (no auth manager)", rec.Code)
+	}
+}

--- a/internal/api/routes/management_model_routes.go
+++ b/internal/api/routes/management_model_routes.go
@@ -9,6 +9,9 @@ func registerManagementModelRoutes(group *gin.RouterGroup, h *managementhandlers
 	models := h.Models()
 	group.GET("/models", models.GetModels)
 	group.GET("/models/configured-availability", models.GetConfiguredModelAvailability)
+	// Management-authority connectivity probe: no API key, so an end user's
+	// channel-group scope cannot make a healthy model look unreachable.
+	group.POST("/models/test", h.PostModelTest)
 	group.GET("/model-path-availability", models.GetModelPathAvailability)
 	group.GET("/model-configs", models.GetModelConfigs)
 	group.POST("/model-configs", models.PostModelConfig)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 329; got != want {
+	if got, want := len(routes), 330; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -362,6 +362,7 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/model-pricing",
 		"GET /v0/management/models",
 		"GET /v0/management/models/configured-availability",
+		"POST /v0/management/models/test",
 		"GET /v0/management/oauth-excluded-models",
 		"GET /v0/management/oauth-model-alias",
 		"GET /v0/management/ollama-cloud-api-key",


### PR DESCRIPTION
## 问题

管理面板「测试模型」回答的是另一个问题。

它在浏览器里列出租户的 API key、**自己挑一个**，然后拿这个 key 去打公网 `/v1/chat/completions`。所以它测的是「这个业务身份能不能用该模型」，而不是「这个模型通不通」。

线上表现：运营者检查一个健康的 kimi 账号（`status=active`、模型已注册），得到 `auth_not_found: no auth available`。挑中的 key 绑定的终端用户被限制在一个渠道组内，kimi 账号不在其中——账号侧怎么配都没用，因为探针问的根本不是账号。

图像生成、视频生成的测试早就走 `authManager.Execute`（管理身份），只有文本模型测试绕去了前端挑 key。

## 改动

新增 `POST /v0/management/models/test`，与 image/video 测试同一套模式：

- 管理身份执行，租户作用域，**链路里没有 API key**，因此不受 key / 终端用户的 `allowed-models`、`allowed-channels`、`allowed-channel-groups` 影响
- 上游失败作为**结果**返回（`{ok:false, error, duration_ms}`）而不是吞成 5xx——报错原文正是探针的价值
- 耗时在服务端围绕执行本身测量，不含面板自己的往返
- 模型未被任何 provider 服务时返回 404，而不是让运营者去解读通用的选路失败

顺带让「渠道」下拉名副其实：它以前只用来挑 key，请求仍可能落到别的账号；现在通过 `allowed-channels` 元数据把执行限定到所选渠道。

## 影响面

- 目录：`CliRelay/`。前端配套 PR：kittors/codeProxy 侧同名分支（改用该接口，不再从浏览器挑 key）。
- 新增一条管理路由，路由快照测试已同步（329 → 330）。
- 不改动任何既有路由、鉴权模型或路由选择逻辑。

## 已执行的验证

在 `CliRelay-wt-modeltest` worktree 内执行 `./scripts/ci-pr.sh`，完整通过（exit 0），日志中无 FAIL：结构扫描、`gofmt`、secret scan、`go vet ./...`、`go test ./...`、updater 子模块 vet/test/build、`golangci-lint run`、`go build ./cmd/server`。

按 AGENTS.md 要求，改动 management 路由注册后跑了含 `TestRegisterManagementRouteTable` 的 `internal/api/routes` 全包测试。

新增 `internal/api/handlers/management/model_test_run_test.go`：探针载荷只含一轮 user 消息且不流式、渠道元数据的租户与渠道作用域（未选渠道时不得退化成「限制到空渠道」）、响应内容提取（未知结构保留原始 body 以便排查）、缺 model/prompt 返回 400、未知模型不落到通用选路失败。