### PR TITLE
fix(end-users): clear profile-owned scopes when a permission profile is unbound

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -14,7 +14,7 @@
       },
       {
         "path": "internal/enduser/service.go",
-        "max_lines": 1169
+        "max_lines": 1168
       },
       {
         "path": "internal/identity/service.go",

--- a/internal/enduser/profile_unbind.go
+++ b/internal/enduser/profile_unbind.go
@@ -1,0 +1,48 @@
+package enduser
+
+import "strings"
+
+// appendPermissionProfileSets writes the permission-profile change, and clears
+// what the profile owned when it is being unbound.
+//
+// Binding a profile copies its allowed-models / allowed-channels /
+// allowed-channel-groups / system-prompt onto the account row. Unbinding used to
+// reset only the quota fields and leave those four behind. The console renders
+// them only while a profile is attached, so the account then read "unrestricted"
+// while a stale channel-group whitelist was still in force — invisible in the
+// UI, unreachable from it, and unnamed by the request error.
+//
+// The cleanup fires only on set → empty: switching between profiles is a rebind,
+// not an unbind. An explicit value in the same patch still wins, so this only
+// fills fields the caller left alone.
+func appendPermissionProfileSets(
+	sets []string,
+	args []interface{},
+	currentProfileID string,
+	patch *QuotaPatch,
+) ([]string, []interface{}) {
+	nextProfileID := strings.TrimSpace(*patch.PermissionProfileID)
+	sets = append(sets, "permission_profile_id = ?")
+	args = append(args, nextProfileID)
+
+	if nextProfileID != "" || strings.TrimSpace(currentProfileID) == "" {
+		return sets, args
+	}
+	if patch.AllowedModels == nil {
+		sets = append(sets, "allowed_models = ?")
+		args = append(args, encodeJSONStringList(nil))
+	}
+	if patch.AllowedChannels == nil {
+		sets = append(sets, "allowed_channels = ?")
+		args = append(args, encodeJSONStringList(nil))
+	}
+	if patch.AllowedChannelGroups == nil {
+		sets = append(sets, "allowed_channel_groups = ?")
+		args = append(args, encodeJSONStringList(nil))
+	}
+	if patch.SystemPrompt == nil {
+		sets = append(sets, "system_prompt = ?")
+		args = append(args, "")
+	}
+	return sets, args
+}

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -639,8 +639,36 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 	}
 	if accountQuotaPatch != nil {
 		if accountQuotaPatch.PermissionProfileID != nil {
+			nextProfileID := strings.TrimSpace(*accountQuotaPatch.PermissionProfileID)
 			sets = append(sets, "permission_profile_id = ?")
-			args = append(args, strings.TrimSpace(*accountQuotaPatch.PermissionProfileID))
+			args = append(args, nextProfileID)
+			// Unbinding a profile has to drop what the profile put on the account.
+			// Binding copies the profile's model/channel scopes onto the row, and the
+			// console only renders those scopes while a profile is attached — so a
+			// leftover whitelist became invisible: the account read "unrestricted"
+			// while a stale channel-group list kept every other credential out of
+			// reach, with nowhere in the UI to see or clear it.
+			//
+			// An explicit value in the same patch still wins; this only fills the
+			// fields the caller left alone.
+			if nextProfileID == "" && strings.TrimSpace(currentProfileID) != "" {
+				if accountQuotaPatch.AllowedModels == nil {
+					sets = append(sets, "allowed_models = ?")
+					args = append(args, encodeJSONStringList(nil))
+				}
+				if accountQuotaPatch.AllowedChannels == nil {
+					sets = append(sets, "allowed_channels = ?")
+					args = append(args, encodeJSONStringList(nil))
+				}
+				if accountQuotaPatch.AllowedChannelGroups == nil {
+					sets = append(sets, "allowed_channel_groups = ?")
+					args = append(args, encodeJSONStringList(nil))
+				}
+				if accountQuotaPatch.SystemPrompt == nil {
+					sets = append(sets, "system_prompt = ?")
+					args = append(args, "")
+				}
+			}
 		}
 		if accountQuotaPatch.DailyLimit != nil {
 			sets = append(sets, "daily_limit = ?")

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -639,36 +639,7 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 	}
 	if accountQuotaPatch != nil {
 		if accountQuotaPatch.PermissionProfileID != nil {
-			nextProfileID := strings.TrimSpace(*accountQuotaPatch.PermissionProfileID)
-			sets = append(sets, "permission_profile_id = ?")
-			args = append(args, nextProfileID)
-			// Unbinding a profile has to drop what the profile put on the account.
-			// Binding copies the profile's model/channel scopes onto the row, and the
-			// console only renders those scopes while a profile is attached — so a
-			// leftover whitelist became invisible: the account read "unrestricted"
-			// while a stale channel-group list kept every other credential out of
-			// reach, with nowhere in the UI to see or clear it.
-			//
-			// An explicit value in the same patch still wins; this only fills the
-			// fields the caller left alone.
-			if nextProfileID == "" && strings.TrimSpace(currentProfileID) != "" {
-				if accountQuotaPatch.AllowedModels == nil {
-					sets = append(sets, "allowed_models = ?")
-					args = append(args, encodeJSONStringList(nil))
-				}
-				if accountQuotaPatch.AllowedChannels == nil {
-					sets = append(sets, "allowed_channels = ?")
-					args = append(args, encodeJSONStringList(nil))
-				}
-				if accountQuotaPatch.AllowedChannelGroups == nil {
-					sets = append(sets, "allowed_channel_groups = ?")
-					args = append(args, encodeJSONStringList(nil))
-				}
-				if accountQuotaPatch.SystemPrompt == nil {
-					sets = append(sets, "system_prompt = ?")
-					args = append(args, "")
-				}
-			}
+			sets, args = appendPermissionProfileSets(sets, args, currentProfileID, accountQuotaPatch)
 		}
 		if accountQuotaPatch.DailyLimit != nil {
 			sets = append(sets, "daily_limit = ?")

--- a/internal/enduser/service_sqlite_test.go
+++ b/internal/enduser/service_sqlite_test.go
@@ -23,6 +23,7 @@ func openEndUserTestDB(t *testing.T) *sql.DB {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	sqlapikey.InitTable(db)
+	sqlapikey.InitPermissionProfilesTable(db)
 	if _, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS end_users (
 			id TEXT PRIMARY KEY,
@@ -203,5 +204,108 @@ func TestUpdateUserAutoCapsOwnedKeyPeriodLimits(t *testing.T) {
 	}
 	if stored != 100 {
 		t.Fatalf("stored day = %v, want 100", stored)
+	}
+}
+
+// Unbinding a permission profile used to leave the profile's model/channel
+// scopes on the account. The console renders those scopes only while a profile
+// is attached, so the account read "unrestricted" while a stale channel-group
+// whitelist kept every credential outside that group unreachable — with nowhere
+// in the UI to see it, and no error message that named it.
+func TestUnbindingPermissionProfileClearsInheritedScopes(t *testing.T) {
+	db := openEndUserTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	userID := uuid.NewString()
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status,
+			permission_profile_id, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
+		VALUES (?, ?, 'scoped', 'scoped', 'Scoped', 'x', 'active',
+			'profile-1', '["grok-4.5"]', '["Grok Account"]', '["group"]', 'be brief', ?, ?)
+	`, userID, tenantID, now, now); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	actor := identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}, Permissions: map[string]bool{"end_users.write": true}}
+	empty := ""
+	if _, err := svc.UpdateUser(ctx, actor, tenantID, userID, nil, nil, nil, nil, &QuotaPatch{PermissionProfileID: &empty}); err != nil {
+		t.Fatalf("UpdateUser: %v", err)
+	}
+
+	var profileID, models, channels, groups, prompt string
+	if err := db.QueryRow(`SELECT permission_profile_id, allowed_models, allowed_channels, allowed_channel_groups, system_prompt
+		FROM end_users WHERE id = ?`, userID).Scan(&profileID, &models, &channels, &groups, &prompt); err != nil {
+		t.Fatalf("query user: %v", err)
+	}
+	if profileID != "" {
+		t.Fatalf("permission_profile_id = %q, want cleared", profileID)
+	}
+	for name, got := range map[string]string{
+		"allowed_models":         models,
+		"allowed_channels":       channels,
+		"allowed_channel_groups": groups,
+	} {
+		if got != "[]" {
+			t.Errorf("%s = %q, want an empty list after unbinding", name, got)
+		}
+	}
+	if prompt != "" {
+		t.Errorf("system_prompt = %q, want cleared after unbinding", prompt)
+	}
+}
+
+// Switching between profiles must not trip the unbind cleanup, and an explicit
+// scope in the same patch still wins over it.
+func TestProfileScopesSurviveWhenNotUnbinding(t *testing.T) {
+	db := openEndUserTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	actor := identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}, Permissions: map[string]bool{"end_users.write": true}}
+	now := time.Now().UTC()
+
+	rebind := uuid.NewString()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status,
+			permission_profile_id, allowed_channel_groups, created_at, updated_at)
+		VALUES (?, ?, 'rebind', 'rebind', 'Rebind', 'x', 'active', 'profile-1', '["group"]', ?, ?)
+	`, rebind, tenantID, now, now); err != nil {
+		t.Fatalf("insert rebind user: %v", err)
+	}
+	other := "profile-2"
+	if _, err := svc.UpdateUser(ctx, actor, tenantID, rebind, nil, nil, nil, nil, &QuotaPatch{PermissionProfileID: &other}); err != nil {
+		t.Fatalf("UpdateUser rebind: %v", err)
+	}
+	var groups string
+	if err := db.QueryRow(`SELECT allowed_channel_groups FROM end_users WHERE id = ?`, rebind).Scan(&groups); err != nil {
+		t.Fatalf("query rebind: %v", err)
+	}
+	if groups != `["group"]` {
+		t.Fatalf("allowed_channel_groups = %q, want untouched when switching profiles", groups)
+	}
+
+	explicit := uuid.NewString()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status,
+			permission_profile_id, allowed_channel_groups, created_at, updated_at)
+		VALUES (?, ?, 'explicit', 'explicit', 'Explicit', 'x', 'active', 'profile-1', '["group"]', ?, ?)
+	`, explicit, tenantID, now, now); err != nil {
+		t.Fatalf("insert explicit user: %v", err)
+	}
+	empty := ""
+	kept := []string{"default"}
+	if _, err := svc.UpdateUser(ctx, actor, tenantID, explicit, nil, nil, nil, nil, &QuotaPatch{
+		PermissionProfileID:  &empty,
+		AllowedChannelGroups: &kept,
+	}); err != nil {
+		t.Fatalf("UpdateUser explicit: %v", err)
+	}
+	if err := db.QueryRow(`SELECT allowed_channel_groups FROM end_users WHERE id = ?`, explicit).Scan(&groups); err != nil {
+		t.Fatalf("query explicit: %v", err)
+	}
+	if groups != `["default"]` {
+		t.Fatalf("allowed_channel_groups = %q, want the explicit value in the same patch", groups)
 	}
 }

--- a/internal/storage/postgres/ip_access_migrations.go
+++ b/internal/storage/postgres/ip_access_migrations.go
@@ -9,8 +9,45 @@ func laterRuntimeMigrations() []Migration {
 		// Operator-managed IP allow/deny list, authentication attempt log, and
 		// source address on audit rows.
 		{Version: "202608100001_ip_access_control", SQL: ipAccessControlSQL},
+		// Drop model/channel scopes stranded on end users by an unbound permission
+		// profile. See endUserUnboundProfileScopeCleanupSQL.
+		{Version: "202608270001_end_user_unbound_profile_scope_cleanup", SQL: endUserUnboundProfileScopeCleanupSQL},
 	}
 }
+
+// endUserUnboundProfileScopeCleanupSQL clears model/channel scopes left on end
+// users that have no permission profile.
+//
+// Binding a profile copied its allowed-models / allowed-channels /
+// allowed-channel-groups onto the account row; unbinding cleared the quota
+// fields and left those three behind. The console renders them only while a
+// profile is attached, so the account showed "unrestricted" while a stale
+// channel-group whitelist kept every credential outside that group unreachable
+// — invisible in the UI, and with no way to clear it from there either.
+//
+// The unbind path now clears them, but that only helps the next unbind: an
+// account already in this state can no longer reach the code that would fix it.
+// Hence this one-off pass.
+//
+// Scope is deliberately narrow: only rows with no profile, and only the fields
+// a profile owns. A tenant that set these through the API without a profile is
+// outside what the console can express, and would have been equally invisible
+// there; the trade is a visible empty list over a silent unreachable one.
+const endUserUnboundProfileScopeCleanupSQL = `
+UPDATE end_users
+SET allowed_models         = '[]',
+    allowed_channels       = '[]',
+    allowed_channel_groups = '[]',
+    system_prompt          = '',
+    updated_at             = CURRENT_TIMESTAMP
+WHERE COALESCE(TRIM(permission_profile_id), '') = ''
+  AND (
+        COALESCE(allowed_models, '[]')         NOT IN ('[]', '')
+     OR COALESCE(allowed_channels, '[]')       NOT IN ('[]', '')
+     OR COALESCE(allowed_channel_groups, '[]') NOT IN ('[]', '')
+     OR COALESCE(system_prompt, '')            <> ''
+      );
+`
 
 // ipAccessControlSQL adds the operator-managed IP allow/deny list, the
 // authentication attempt log that makes an attack source identifiable, and the

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,14 +11,27 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 28 {
-		t.Fatalf("RuntimeMigrations len = %d, want 28", len(migrations))
+	if len(migrations) != 29 {
+		t.Fatalf("RuntimeMigrations len = %d, want 29", len(migrations))
 	}
-	// Latest: the IP allow/deny list, authentication attempt log, and source
-	// address on audit rows. Appended from laterRuntimeMigrations() because
-	// migrations.go sits at its structure-gate size ceiling.
+	// Appended from laterRuntimeMigrations() because migrations.go sits at its
+	// structure-gate size ceiling.
 	if migrations[27].Version != "202608100001_ip_access_control" {
-		t.Fatalf("latest migration version = %q", migrations[27].Version)
+		t.Fatalf("ip access migration version = %q", migrations[27].Version)
+	}
+	// Latest: clears model/channel scopes stranded on end users whose permission
+	// profile was unbound without them.
+	if migrations[28].Version != "202608270001_end_user_unbound_profile_scope_cleanup" {
+		t.Fatalf("latest migration version = %q", migrations[28].Version)
+	}
+	for _, fragment := range []string{
+		"UPDATE end_users",
+		"allowed_channel_groups = '[]'",
+		"COALESCE(TRIM(permission_profile_id), '') = ''",
+	} {
+		if !strings.Contains(migrations[28].SQL, fragment) {
+			t.Fatalf("scope cleanup migration missing %q", fragment)
+		}
 	}
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS ip_access_rules",


### PR DESCRIPTION
## 问题

终端用户的「账户权限模板」显示为「默认：不限制」，但账号上实际带着一条看不见、也删不掉的渠道组白名单。

线上表现：kimi 账号健康（`status=active`，8 个模型已注册），同一个 API key 打 `grok-4.6` 返回 200，打 `kimi-k3` / `kimi-k2.6` / `kimi-for-coding` 全部 `auth_not_found`。该 key 绑定的终端用户 `kittors` 在 UI 上是「默认：不限制」，但 `/v0/management/end-users` 返回的 `allowed-channel-groups` 是 `["group"]`。运营者已在 `default` 组的 allowed-models 里加了 `kimi-k3`——毫无作用，因为整个 `default` 组都不在这个终端用户的可见范围内。

## 根因

绑定权限模板时，模板的 `allowed-models` / `allowed-channels` / `allowed-channel-groups` / `system-prompt` 会被**拷贝到账号行**上（`EndUsersPage.tsx` 的保存逻辑）。解绑时只重置了配额类字段，这四个原样留下。

后端 `EffectiveEndUserQuotaWithProfiles` 在 `PermissionProfileID` 为空时直接返回账号自身的值，于是残留的白名单继续生效。而控制台仅在绑定了模板时渲染这些白名单，所以它既不可见、也无从清除——错误信息里也没有任何东西指向它（这一半已由 kittors/CliRelay#943、#945 修复）。

## 改动

**1. 解绑时清理（防止再发生）**

`internal/enduser/service.go`：`permission_profile_id` 由非空变为空时，一并清空这四个由模板拥有的字段。

- 同一个 patch 里显式给了值时以显式值为准
- 模板之间切换不受影响：清理只在「从有到无」时触发
- 放在服务层而不是前端，任何写入口（控制台、API）行为一致

**2. 一次性数据修复（清理存量）**

新增迁移 `202608270001_end_user_unbound_profile_scope_cleanup`。修好的解绑路径救不了已经处于该状态的账号——它们已经没有模板了，永远不会再走到那段代码。

清理范围刻意收窄：只针对**没有模板**的行，只清**模板拥有的那四个字段**。不带模板而通过 API 直接设置这些字段，是控制台无法表达的配置，在控制台里同样是不可见的；这里的取舍是「一个可见的空列表」优于「一条静默生效的不可达限制」。

## 影响面

- 目录：`CliRelay/`（`internal/enduser`、`internal/storage/postgres`）。
- **有数据迁移**，会修改既有 `end_users` 行。上面已说明范围与取舍。
- 前端无需改动：控制台解绑时已经会发 `permission-profile-id: ""`，由服务层完成清理。

## 已执行的验证

在 `CliRelay-wt-profileunbind` worktree 内执行 `./scripts/ci-pr.sh`，完整通过（exit 0），日志无 FAIL：结构扫描、`gofmt`、secret scan、`go vet ./...`、`go test ./...`、updater 子模块 vet/test/build、`golangci-lint run`、`go build ./cmd/server`。

新增测试：
- `internal/enduser/service_sqlite_test.go`：解绑后四个字段全部清空；模板间切换不清理；同一 patch 内的显式值优先于清理。
- `internal/storage/postgres/runtime_test.go`：迁移已注册且 SQL 含关键约束（只针对无模板行）。